### PR TITLE
fix: sync Google Play subscription with server to lift usage limits

### DIFF
--- a/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
@@ -96,6 +96,13 @@ interface ClawApiService {
     suspend fun verifyBorrowSubscription(@Body body: Map<String, @JvmSuppressWildcards Any>): ApiResponse
 
     // ============================================
+    // SUBSCRIPTION
+    // ============================================
+
+    @POST("api/subscription/verify-google")
+    suspend fun verifyGoogleSubscription(@Body body: Map<String, @JvmSuppressWildcards Any>): ApiResponse
+
+    // ============================================
     // CHAT HISTORY (Backend PostgreSQL)
     // ============================================
 


### PR DESCRIPTION
BillingManager only updated the client-side isPremium flag after a
Google Play purchase but never called the server's verify-google
endpoint. This meant the server still treated the user as free-tier
and returned HTTP 429 even after subscribing.

Added syncPremiumWithServer() to BillingManager that calls
/api/subscription/verify-google after purchase and on subscription
status queries (handles server restarts). Added the corresponding
Retrofit endpoint to ClawApiService.

https://claude.ai/code/session_012WGV3Y2ocztVGZV1vPkML3