### PR TITLE
fix: prevent usage counter inflation and sync client-server usage

### DIFF
--- a/app/src/main/java/com/hank/clawlive/ChatActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/ChatActivity.kt
@@ -496,6 +496,12 @@ class ChatActivity : AppCompatActivity() {
             } catch (e: Exception) {
                 Timber.e(e, "Failed to send media message")
                 if (e is retrofit2.HttpException && e.code() == 429) {
+                    try {
+                        val errorBody = e.response()?.errorBody()?.string()
+                        val json = org.json.JSONObject(errorBody ?: "{}")
+                        val serverUsed = json.optInt("used", -1)
+                        if (serverUsed >= 0) usageManager.syncFromServer(serverUsed)
+                    } catch (_: Exception) { }
                     showUsageLimitDialog()
                 } else {
                     Toast.makeText(this@ChatActivity, "Send failed: ${e.message}", Toast.LENGTH_SHORT).show()
@@ -753,6 +759,12 @@ class ChatActivity : AppCompatActivity() {
             } catch (e: Exception) {
                 Timber.e(e, "Failed to send message")
                 if (e is retrofit2.HttpException && e.code() == 429) {
+                    try {
+                        val errorBody = e.response()?.errorBody()?.string()
+                        val json = org.json.JSONObject(errorBody ?: "{}")
+                        val serverUsed = json.optInt("used", -1)
+                        if (serverUsed >= 0) usageManager.syncFromServer(serverUsed)
+                    } catch (_: Exception) { }
                     showUsageLimitDialog()
                 } else {
                     Toast.makeText(this@ChatActivity, "Send failed: ${e.message}", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/hank/clawlive/data/local/UsageManager.kt
+++ b/app/src/main/java/com/hank/clawlive/data/local/UsageManager.kt
@@ -140,6 +140,17 @@ class UsageManager private constructor(context: Context) {
     }
 
     /**
+     * Sync local usage count with server-reported value.
+     * Ensures client display matches actual server-side tracking.
+     */
+    fun syncFromServer(serverUsageCount: Int) {
+        prefs.edit()
+            .putInt(KEY_DAILY_COUNT, serverUsageCount)
+            .putString(KEY_LAST_RESET_DATE, getTodayString())
+            .apply()
+    }
+
+    /**
      * Reset usage (for testing only)
      */
     fun resetUsage() {

--- a/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
@@ -102,6 +102,9 @@ interface ClawApiService {
     @POST("api/subscription/verify-google")
     suspend fun verifyGoogleSubscription(@Body body: Map<String, @JvmSuppressWildcards Any>): ApiResponse
 
+    @POST("api/subscription/usage")
+    suspend fun getSubscriptionUsage(@Body body: Map<String, String>): SubscriptionUsageResponse
+
     // ============================================
     // CHAT HISTORY (Backend PostgreSQL)
     // ============================================
@@ -223,5 +226,13 @@ data class MediaUploadResponse(
     val success: Boolean,
     val mediaUrl: String? = null,
     val mediaType: String? = null,
+    val error: String? = null
+)
+
+data class SubscriptionUsageResponse(
+    val success: Boolean,
+    val isPremium: Boolean = false,
+    val usageToday: Int = 0,
+    val usageLimit: Int? = null,
     val error: String? = null
 )

--- a/backend/index.js
+++ b/backend/index.js
@@ -1551,7 +1551,8 @@ app.post('/api/client/speak', async (req, res) => {
                 message: "Daily message limit reached",
                 error: "USAGE_LIMIT_EXCEEDED",
                 remaining: 0,
-                limit: usage.limit
+                limit: usage.limit,
+                used: usage.used || 0
             });
         }
     } catch (usageErr) {


### PR DESCRIPTION
Two bugs fixed:

1. Server: enforceUsageLimit() incremented message_count on every call, including denied requests. After hitting 15/15, each retry inflated the counter (16, 17, 18...) making it impossible to recover even the next day if the inflated count persisted. Now checks count BEFORE incrementing and only increments for allowed messages.

2. Client-server desync: Client tracked usage locally in SharedPreferences independent of the server's usage_tracking table. After app updates, local counter reset to 0 while server retained the real count, showing "0/15" but blocking on send. Added:
   - POST /api/subscription/usage endpoint (device-auth) returning real count
   - BillingManager.syncUsageFromServer() called on refreshState()
   - UsageManager.syncFromServer() to update local state
   - ChatActivity syncs usage from 429 error responses

https://claude.ai/code/session_012WGV3Y2ocztVGZV1vPkML3