### PR TITLE
test: add regression test for entity message echo (7 scenarios, 19 as…

### DIFF
--- a/backend/tests/test_entity_echo_bug.js
+++ b/backend/tests/test_entity_echo_bug.js
@@ -1,298 +1,444 @@
 /**
- * Test: Entity Message Echo/Duplication Bug
+ * Regression Test: Entity Message Echo/Duplication Bug
  *
- * ROOT CAUSE ANALYSIS:
- * When a bot responds to a message, the same text gets saved to chat_messages
- * multiple times through different endpoints:
+ * ROOT CAUSE:
+ * When a bot responds, it calls multiple endpoints that each independently
+ * save the same message to chat_messages DB:
+ *   1. /api/entity/broadcast   -> saveChatMessage()
+ *   2. /api/entity/speak-to    -> saveChatMessage()
+ *   3. /api/bot/sync-message   -> saveChatMessage()
+ *   4. /api/transform (message) -> saveChatMessage()
  *
- * 1. /api/entity/broadcast  -> saveChatMessage(deviceId, fromId, text, "entity:X:CHAR->targets", false, true)
- *    OR /api/entity/speak-to -> saveChatMessage(deviceId, fromId, text, "entity:X:CHAR->Y", false, true)
+ * When Chat UI queries /api/chat/history, ALL records are returned,
+ * causing the same message to appear 2-3 times (echo).
  *
- * 2. /api/bot/sync-message  -> saveChatMessage(deviceId, entityId, text, "bot", false, true)
+ * FIX: saveChatMessage() deduplicates bot messages — if an identical
+ * (device_id, entity_id, text, is_from_bot) was saved within 10s, skip.
  *
- * 3. /api/transform (if message is set) -> saveChatMessage(deviceId, entityId, text, entityName, false, true)
- *
- * All three insert into chat_messages with the same entity_id and similar text.
- * When the Chat UI loads /api/chat/history, it gets ALL records, causing duplicates.
- *
- * REPRODUCTION:
- * 1. Setup device with 2 bound entities
- * 2. Entity 0 broadcasts a message (saves to chat_messages once)
- * 3. Entity 0 also calls sync-message with the same text (saves AGAIN)
- * 4. Query chat/history -> same message appears TWICE
+ * This test verifies NO echo occurs in any combination.
  */
 
-const BASE_URL = process.env.TEST_URL || 'https://eclaw.up.railway.app';
+const API_BASE = process.env.API_BASE || 'https://eclaw.up.railway.app';
 
-async function api(method, path, body = null) {
-    const options = {
-        method,
-        headers: { 'Content-Type': 'application/json' }
-    };
-    if (body) options.body = JSON.stringify(body);
-    const res = await fetch(`${BASE_URL}${path}`, options);
-    const text = await res.text();
-    try {
-        return { status: res.status, data: JSON.parse(text) };
-    } catch {
-        return { status: res.status, data: text };
+const TEST_DEVICE_ID = `echo-regression-${Date.now()}`;
+const TEST_DEVICE_SECRET = `secret-${Date.now()}`;
+
+let passed = 0;
+let failed = 0;
+let skipped = 0;
+let boundEntities = []; // { entityId, botSecret }
+
+// ==============================
+// Helpers
+// ==============================
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function api(method, path, body = null, retries = 2) {
+    for (let attempt = 0; attempt <= retries; attempt++) {
+        try {
+            const options = { method, headers: { 'Content-Type': 'application/json' } };
+            if (body) options.body = JSON.stringify(body);
+            const res = await fetch(`${API_BASE}${path}`, options);
+            const text = await res.text();
+            await sleep(150); // prevent rate limiting
+            try {
+                return { status: res.status, data: JSON.parse(text) };
+            } catch {
+                return { status: res.status, data: text };
+            }
+        } catch (e) {
+            if (attempt < retries) {
+                await sleep(1000 * (attempt + 1));
+                continue;
+            }
+            return { status: 0, data: { error: e.message } };
+        }
     }
 }
 
-function sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
-}
-
-async function runEchoBugTest() {
-    console.log('='.repeat(60));
-    console.log('Entity Message Echo/Duplication Bug Test');
-    console.log('='.repeat(60));
-    console.log(`Target: ${BASE_URL}\n`);
-
-    let passed = 0, failed = 0;
-
-    // ============================================
-    // Setup: Create device with 2 bound entities
-    // ============================================
-    console.log('--- Setup: Create device with 2 entities ---\n');
-
-    const deviceId = `echo-test-${Date.now()}`;
-    const deviceSecret = `secret-${Date.now()}`;
-
-    // Register and bind Entity 0
-    const reg0 = await api('POST', '/api/device/register', {
-        entityId: 0, deviceId, deviceSecret, isTestDevice: true
-    });
-    const bind0 = await api('POST', '/api/bind', { code: reg0.data.bindingCode });
-    const botSecret0 = bind0.data.botSecret;
-    console.log(`Entity 0 bound, botSecret: ${botSecret0.substring(0, 8)}...`);
-
-    // Register and bind Entity 1
-    const reg1 = await api('POST', '/api/device/register', {
-        entityId: 1, deviceId, deviceSecret, isTestDevice: true
-    });
-    const bind1 = await api('POST', '/api/bind', { code: reg1.data.bindingCode });
-    const botSecret1 = bind1.data.botSecret;
-    console.log(`Entity 1 bound, botSecret: ${botSecret1.substring(0, 8)}...`);
-
-    // ============================================
-    // Test 1: Broadcast + sync-message = DUPLICATE
-    // ============================================
-    console.log('\n--- Test 1: Broadcast + sync-message causes duplicate ---\n');
-
-    const broadcastText = `Echo test broadcast ${Date.now()}`;
-
-    // Step 1: Entity 0 broadcasts (this is what a bot does when it talks to other entities)
-    console.log('1a. Entity 0 broadcasts message...');
-    const bcast = await api('POST', '/api/entity/broadcast', {
-        deviceId, fromEntityId: 0, botSecret: botSecret0, text: broadcastText
-    });
-    console.log(`    Broadcast result: ${bcast.data.success ? 'OK' : 'FAILED'}`);
-
-    // Step 2: Entity 0 also calls sync-message (bot syncs its response to chat)
-    console.log('1b. Entity 0 calls sync-message with SAME text...');
-    const sync = await api('POST', '/api/bot/sync-message', {
-        deviceId, entityId: 0, botSecret: botSecret0, message: broadcastText
-    });
-    console.log(`    Sync result: ${sync.data.success ? 'OK' : 'FAILED'}`);
-
-    // Step 3: Check chat history for duplicates
-    await sleep(500); // Wait for DB writes
-    console.log('1c. Checking chat history for duplicates...');
-    const history1 = await api('GET',
-        `/api/chat/history?deviceId=${deviceId}&deviceSecret=${deviceSecret}&limit=50`
-    );
-
-    const matchingMsgs1 = (history1.data.messages || []).filter(m =>
-        m.text === broadcastText && m.entity_id === 0
-    );
-
-    console.log(`    Messages with same text under entity 0: ${matchingMsgs1.length}`);
-    matchingMsgs1.forEach((m, i) => {
-        console.log(`      [${i}] source="${m.source}", is_from_bot=${m.is_from_bot}, id=${m.id}`);
-    });
-
-    if (matchingMsgs1.length > 1) {
-        console.log('    BUG CONFIRMED: Same message saved multiple times!');
-        console.log('    -> broadcast saved: source="entity:0:LOBSTER->1"');
-        console.log('    -> sync-message saved: source="bot"');
-        failed++;
-    } else if (matchingMsgs1.length === 1) {
-        console.log('    PASS: Message appears only once (dedup working)');
+function assert(label, condition, detail) {
+    if (condition) {
+        console.log(`  OK ${label}`);
         passed++;
     } else {
-        console.log('    SKIP: No messages found (chat DB may not be available)');
-    }
-
-    // ============================================
-    // Test 2: speak-to + sync-message = DUPLICATE
-    // ============================================
-    console.log('\n--- Test 2: speak-to + sync-message causes duplicate ---\n');
-
-    const speakToText = `Echo test speak-to ${Date.now()}`;
-
-    // Step 1: Entity 0 speaks to Entity 1
-    console.log('2a. Entity 0 speaks to Entity 1...');
-    const speakTo = await api('POST', '/api/entity/speak-to', {
-        deviceId, fromEntityId: 0, toEntityId: 1, botSecret: botSecret0, text: speakToText
-    });
-    console.log(`    Speak-to result: ${speakTo.data.success ? 'OK' : 'FAILED'}`);
-
-    // Step 2: Entity 0 also syncs same message
-    console.log('2b. Entity 0 calls sync-message with SAME text...');
-    const sync2 = await api('POST', '/api/bot/sync-message', {
-        deviceId, entityId: 0, botSecret: botSecret0, message: speakToText
-    });
-    console.log(`    Sync result: ${sync2.data.success ? 'OK' : 'FAILED'}`);
-
-    // Step 3: Check for duplicates
-    await sleep(500);
-    console.log('2c. Checking chat history for duplicates...');
-    const history2 = await api('GET',
-        `/api/chat/history?deviceId=${deviceId}&deviceSecret=${deviceSecret}&limit=50`
-    );
-
-    const matchingMsgs2 = (history2.data.messages || []).filter(m =>
-        m.text === speakToText && m.entity_id === 0
-    );
-
-    console.log(`    Messages with same text under entity 0: ${matchingMsgs2.length}`);
-    matchingMsgs2.forEach((m, i) => {
-        console.log(`      [${i}] source="${m.source}", is_from_bot=${m.is_from_bot}, id=${m.id}`);
-    });
-
-    if (matchingMsgs2.length > 1) {
-        console.log('    BUG CONFIRMED: speak-to + sync-message = duplicate!');
+        console.log(`  FAIL ${label}${detail ? ': ' + JSON.stringify(detail) : ''}`);
         failed++;
-    } else if (matchingMsgs2.length === 1) {
-        console.log('    PASS: Message appears only once');
-        passed++;
     }
-
-    // ============================================
-    // Test 3: transform + sync-message = DUPLICATE
-    // ============================================
-    console.log('\n--- Test 3: transform (with message) + sync-message causes duplicate ---\n');
-
-    const transformText = `Echo test transform ${Date.now()}`;
-
-    // Step 1: Entity 0 updates via transform with a message
-    console.log('3a. Entity 0 calls transform with message...');
-    const transform = await api('POST', '/api/transform', {
-        deviceId, entityId: 0, botSecret: botSecret0,
-        state: 'IDLE', message: transformText
-    });
-    console.log(`    Transform result: ${transform.data.success ? 'OK' : 'FAILED'}`);
-
-    // Step 2: Entity 0 also syncs same message
-    console.log('3b. Entity 0 calls sync-message with SAME text...');
-    const sync3 = await api('POST', '/api/bot/sync-message', {
-        deviceId, entityId: 0, botSecret: botSecret0, message: transformText
-    });
-    console.log(`    Sync result: ${sync3.data.success ? 'OK' : 'FAILED'}`);
-
-    // Step 3: Check for duplicates
-    await sleep(500);
-    console.log('3c. Checking chat history for duplicates...');
-    const history3 = await api('GET',
-        `/api/chat/history?deviceId=${deviceId}&deviceSecret=${deviceSecret}&limit=50`
-    );
-
-    const matchingMsgs3 = (history3.data.messages || []).filter(m =>
-        m.text === transformText && m.entity_id === 0
-    );
-
-    console.log(`    Messages with same text under entity 0: ${matchingMsgs3.length}`);
-    matchingMsgs3.forEach((m, i) => {
-        console.log(`      [${i}] source="${m.source}", is_from_bot=${m.is_from_bot}, id=${m.id}`);
-    });
-
-    if (matchingMsgs3.length > 1) {
-        console.log('    BUG CONFIRMED: transform + sync-message = duplicate!');
-        failed++;
-    } else if (matchingMsgs3.length === 1) {
-        console.log('    PASS: Message appears only once');
-        passed++;
-    }
-
-    // ============================================
-    // Test 4: Triple duplicate (broadcast + transform + sync-message)
-    // ============================================
-    console.log('\n--- Test 4: Triple duplicate (broadcast + transform + sync-message) ---\n');
-
-    const tripleText = `Echo test triple ${Date.now()}`;
-
-    console.log('4a. Entity 0 broadcasts...');
-    await api('POST', '/api/entity/broadcast', {
-        deviceId, fromEntityId: 0, botSecret: botSecret0, text: tripleText
-    });
-
-    console.log('4b. Entity 0 calls transform...');
-    await api('POST', '/api/transform', {
-        deviceId, entityId: 0, botSecret: botSecret0,
-        state: 'IDLE', message: tripleText
-    });
-
-    console.log('4c. Entity 0 calls sync-message...');
-    await api('POST', '/api/bot/sync-message', {
-        deviceId, entityId: 0, botSecret: botSecret0, message: tripleText
-    });
-
-    await sleep(500);
-    console.log('4d. Checking chat history...');
-    const history4 = await api('GET',
-        `/api/chat/history?deviceId=${deviceId}&deviceSecret=${deviceSecret}&limit=50`
-    );
-
-    const matchingMsgs4 = (history4.data.messages || []).filter(m =>
-        m.text === tripleText && m.entity_id === 0
-    );
-
-    console.log(`    Messages with same text under entity 0: ${matchingMsgs4.length}`);
-    matchingMsgs4.forEach((m, i) => {
-        console.log(`      [${i}] source="${m.source}", is_from_bot=${m.is_from_bot}, id=${m.id}`);
-    });
-
-    if (matchingMsgs4.length >= 3) {
-        console.log('    BUG CONFIRMED: TRIPLE duplicate! broadcast + transform + sync-message all saved independently.');
-        failed++;
-    } else if (matchingMsgs4.length > 1) {
-        console.log(`    BUG CONFIRMED: ${matchingMsgs4.length}x duplicate`);
-        failed++;
-    } else if (matchingMsgs4.length === 1) {
-        console.log('    PASS: Message appears only once');
-        passed++;
-    }
-
-    // ============================================
-    // Summary
-    // ============================================
-    console.log(`\n${'='.repeat(60)}`);
-    console.log('ROOT CAUSE SUMMARY');
-    console.log('='.repeat(60));
-    console.log(`
-The echo bug occurs because the bot calls MULTIPLE endpoints
-that each independently save the same message to chat_messages DB:
-
-  1. /api/entity/broadcast   -> saveChatMessage() [line 1896]
-  2. /api/entity/speak-to    -> saveChatMessage() [line 1754]
-  3. /api/bot/sync-message   -> saveChatMessage() [line 3884]
-  4. /api/transform (message) -> saveChatMessage() [line 1240]
-
-When the Chat UI queries /api/chat/history, ALL records are returned,
-causing the same message to appear 2-3 times.
-
-FIX: Add deduplication in sync-message and transform endpoints -
-skip saving to chat_messages if a recent identical message
-(same entity_id, same text, is_from_bot=true) was already saved
-within the last few seconds.
-`);
-
-    console.log(`Result: ${passed}/${passed + failed} tests passed`);
-    if (failed > 0) {
-        console.log(`${failed} duplication bug(s) confirmed`);
-    }
-    console.log('='.repeat(60));
 }
 
-runEchoBugTest().catch(console.error);
+function skip(label, reason) {
+    console.log(`  SKIP ${label} (${reason})`);
+    skipped++;
+}
+
+/**
+ * Query chat history and count how many times a specific text appears for an entity.
+ */
+async function countMessageOccurrences(text, entityId) {
+    const history = await api('GET',
+        `/api/chat/history?deviceId=${TEST_DEVICE_ID}&deviceSecret=${TEST_DEVICE_SECRET}&limit=100`
+    );
+    if (!history.data.success || !history.data.messages) {
+        return { count: -1, messages: [] }; // DB not available
+    }
+    const matching = history.data.messages.filter(m =>
+        m.text === text && m.entity_id === entityId
+    );
+    return { count: matching.length, messages: matching };
+}
+
+// ==============================
+// Setup
+// ==============================
+
+async function setup() {
+    console.log('--- Setup: Create device with 2 bound entities ---\n');
+
+    for (const entityId of [0, 1]) {
+        const reg = await api('POST', '/api/device/register', {
+            entityId, deviceId: TEST_DEVICE_ID, deviceSecret: TEST_DEVICE_SECRET, isTestDevice: true
+        });
+        assert(`Entity ${entityId} registered`, reg.data.success, reg.data);
+
+        const bind = await api('POST', '/api/bind', { code: reg.data.bindingCode });
+        assert(`Entity ${entityId} bound`, bind.data.success, bind.data);
+
+        boundEntities.push({ entityId, botSecret: bind.data.botSecret });
+        console.log(`  Entity ${entityId} botSecret: ${bind.data.botSecret?.substring(0, 8)}...`);
+    }
+}
+
+// ==============================
+// Test Cases
+// ==============================
+
+/**
+ * Test 1: broadcast + sync-message must NOT produce duplicate
+ */
+async function testBroadcastPlusSyncNoEcho() {
+    console.log('\n--- Test: broadcast + sync-message must NOT echo ---\n');
+
+    const text = `no-echo-broadcast-${Date.now()}`;
+    const entity = boundEntities[0];
+
+    // Bot broadcasts to other entities
+    const bcast = await api('POST', '/api/entity/broadcast', {
+        deviceId: TEST_DEVICE_ID, fromEntityId: entity.entityId,
+        botSecret: entity.botSecret, text
+    });
+    assert('broadcast succeeds', bcast.data.success, bcast.data);
+
+    // Bot also calls sync-message with the SAME text (this caused the echo)
+    const sync = await api('POST', '/api/bot/sync-message', {
+        deviceId: TEST_DEVICE_ID, entityId: entity.entityId,
+        botSecret: entity.botSecret, message: text
+    });
+    assert('sync-message succeeds', sync.data.success, sync.data);
+
+    await sleep(500);
+
+    const { count, messages } = await countMessageOccurrences(text, entity.entityId);
+    if (count === -1) {
+        skip('broadcast+sync dedup check', 'chat DB not available');
+        return;
+    }
+
+    assert(
+        `broadcast + sync-message: message appears exactly 1 time (got ${count})`,
+        count === 1,
+        { count, sources: messages.map(m => m.source) }
+    );
+}
+
+/**
+ * Test 2: speak-to + sync-message must NOT produce duplicate
+ */
+async function testSpeakToPlusSyncNoEcho() {
+    console.log('\n--- Test: speak-to + sync-message must NOT echo ---\n');
+
+    const text = `no-echo-speakto-${Date.now()}`;
+    const sender = boundEntities[0];
+
+    // Bot sends entity-to-entity message
+    const speakTo = await api('POST', '/api/entity/speak-to', {
+        deviceId: TEST_DEVICE_ID, fromEntityId: sender.entityId,
+        toEntityId: 1, botSecret: sender.botSecret, text
+    });
+    assert('speak-to succeeds', speakTo.data.success, speakTo.data);
+
+    // Bot also calls sync-message
+    const sync = await api('POST', '/api/bot/sync-message', {
+        deviceId: TEST_DEVICE_ID, entityId: sender.entityId,
+        botSecret: sender.botSecret, message: text
+    });
+    assert('sync-message succeeds', sync.data.success, sync.data);
+
+    await sleep(500);
+
+    const { count, messages } = await countMessageOccurrences(text, sender.entityId);
+    if (count === -1) {
+        skip('speak-to+sync dedup check', 'chat DB not available');
+        return;
+    }
+
+    assert(
+        `speak-to + sync-message: message appears exactly 1 time (got ${count})`,
+        count === 1,
+        { count, sources: messages.map(m => m.source) }
+    );
+}
+
+/**
+ * Test 3: transform + sync-message must NOT produce duplicate
+ */
+async function testTransformPlusSyncNoEcho() {
+    console.log('\n--- Test: transform + sync-message must NOT echo ---\n');
+
+    const text = `no-echo-transform-${Date.now()}`;
+    const entity = boundEntities[0];
+
+    // Bot updates entity via transform (includes message)
+    const transform = await api('POST', '/api/transform', {
+        deviceId: TEST_DEVICE_ID, entityId: entity.entityId,
+        botSecret: entity.botSecret, state: 'IDLE', message: text
+    });
+    assert('transform succeeds', transform.data.success !== false, transform.data);
+
+    // Bot also calls sync-message
+    const sync = await api('POST', '/api/bot/sync-message', {
+        deviceId: TEST_DEVICE_ID, entityId: entity.entityId,
+        botSecret: entity.botSecret, message: text
+    });
+    assert('sync-message succeeds', sync.data.success, sync.data);
+
+    await sleep(500);
+
+    const { count, messages } = await countMessageOccurrences(text, entity.entityId);
+    if (count === -1) {
+        skip('transform+sync dedup check', 'chat DB not available');
+        return;
+    }
+
+    assert(
+        `transform + sync-message: message appears exactly 1 time (got ${count})`,
+        count === 1,
+        { count, sources: messages.map(m => m.source) }
+    );
+}
+
+/**
+ * Test 4: Triple call (broadcast + transform + sync-message) must NOT produce triple echo
+ */
+async function testTripleCallNoEcho() {
+    console.log('\n--- Test: broadcast + transform + sync-message must NOT echo ---\n');
+
+    const text = `no-echo-triple-${Date.now()}`;
+    const entity = boundEntities[0];
+
+    // Bot calls all three endpoints with same text
+    const bcast = await api('POST', '/api/entity/broadcast', {
+        deviceId: TEST_DEVICE_ID, fromEntityId: entity.entityId,
+        botSecret: entity.botSecret, text
+    });
+    assert('broadcast succeeds', bcast.data.success, bcast.data);
+
+    const transform = await api('POST', '/api/transform', {
+        deviceId: TEST_DEVICE_ID, entityId: entity.entityId,
+        botSecret: entity.botSecret, state: 'IDLE', message: text
+    });
+    assert('transform succeeds', transform.data.success !== false, transform.data);
+
+    const sync = await api('POST', '/api/bot/sync-message', {
+        deviceId: TEST_DEVICE_ID, entityId: entity.entityId,
+        botSecret: entity.botSecret, message: text
+    });
+    assert('sync-message succeeds', sync.data.success, sync.data);
+
+    await sleep(500);
+
+    const { count, messages } = await countMessageOccurrences(text, entity.entityId);
+    if (count === -1) {
+        skip('triple dedup check', 'chat DB not available');
+        return;
+    }
+
+    assert(
+        `triple call: message appears exactly 1 time (got ${count})`,
+        count === 1,
+        { count, sources: messages.map(m => m.source) }
+    );
+}
+
+/**
+ * Test 5: Different messages from same entity should still be saved individually
+ * (dedup must NOT suppress legitimately different messages)
+ */
+async function testDifferentMessagesNotSuppressed() {
+    console.log('\n--- Test: different messages must NOT be suppressed ---\n');
+
+    const entity = boundEntities[0];
+    const text1 = `different-msg-A-${Date.now()}`;
+    const text2 = `different-msg-B-${Date.now()}`;
+
+    await api('POST', '/api/bot/sync-message', {
+        deviceId: TEST_DEVICE_ID, entityId: entity.entityId,
+        botSecret: entity.botSecret, message: text1
+    });
+
+    await api('POST', '/api/bot/sync-message', {
+        deviceId: TEST_DEVICE_ID, entityId: entity.entityId,
+        botSecret: entity.botSecret, message: text2
+    });
+
+    await sleep(500);
+
+    const result1 = await countMessageOccurrences(text1, entity.entityId);
+    const result2 = await countMessageOccurrences(text2, entity.entityId);
+
+    if (result1.count === -1) {
+        skip('different messages check', 'chat DB not available');
+        return;
+    }
+
+    assert(
+        `message A saved exactly 1 time (got ${result1.count})`,
+        result1.count === 1,
+        { count: result1.count }
+    );
+    assert(
+        `message B saved exactly 1 time (got ${result2.count})`,
+        result2.count === 1,
+        { count: result2.count }
+    );
+}
+
+/**
+ * Test 6: User messages (is_from_user=true) must NOT be affected by dedup
+ */
+async function testUserMessagesNotAffected() {
+    console.log('\n--- Test: user messages must NOT be affected by dedup ---\n');
+
+    const text = `user-msg-nodedup-${Date.now()}`;
+
+    // Send same message from user twice (to same entity)
+    await api('POST', '/api/client/speak', {
+        deviceId: TEST_DEVICE_ID, entityId: 0, text, source: 'regression_test'
+    });
+    await api('POST', '/api/client/speak', {
+        deviceId: TEST_DEVICE_ID, entityId: 0, text, source: 'regression_test'
+    });
+
+    await sleep(500);
+
+    const history = await api('GET',
+        `/api/chat/history?deviceId=${TEST_DEVICE_ID}&deviceSecret=${TEST_DEVICE_SECRET}&limit=100`
+    );
+
+    if (!history.data.success) {
+        skip('user message dedup-exempt check', 'chat DB not available');
+        return;
+    }
+
+    const matching = (history.data.messages || []).filter(m =>
+        m.text === text && m.entity_id === 0 && m.is_from_user
+    );
+
+    assert(
+        `user messages NOT suppressed: both saved (got ${matching.length})`,
+        matching.length === 2,
+        { count: matching.length }
+    );
+}
+
+/**
+ * Test 7: Messages to different entities must NOT be deduped
+ */
+async function testDifferentEntitiesNotDeduped() {
+    console.log('\n--- Test: same text to different entities must NOT be deduped ---\n');
+
+    const text = `cross-entity-${Date.now()}`;
+    const e0 = boundEntities[0];
+    const e1 = boundEntities[1];
+
+    await api('POST', '/api/bot/sync-message', {
+        deviceId: TEST_DEVICE_ID, entityId: e0.entityId,
+        botSecret: e0.botSecret, message: text
+    });
+
+    await api('POST', '/api/bot/sync-message', {
+        deviceId: TEST_DEVICE_ID, entityId: e1.entityId,
+        botSecret: e1.botSecret, message: text
+    });
+
+    await sleep(500);
+
+    const r0 = await countMessageOccurrences(text, e0.entityId);
+    const r1 = await countMessageOccurrences(text, e1.entityId);
+
+    if (r0.count === -1) {
+        skip('cross-entity dedup check', 'chat DB not available');
+        return;
+    }
+
+    assert(
+        `entity 0 has exactly 1 copy (got ${r0.count})`,
+        r0.count === 1,
+        { count: r0.count }
+    );
+    assert(
+        `entity 1 has exactly 1 copy (got ${r1.count})`,
+        r1.count === 1,
+        { count: r1.count }
+    );
+}
+
+// ==============================
+// Runner
+// ==============================
+
+async function runAll() {
+    console.log('='.repeat(60));
+    console.log('Regression: Entity Message Echo/Duplication');
+    console.log('='.repeat(60));
+    console.log(`Target: ${API_BASE}`);
+    console.log(`Device: ${TEST_DEVICE_ID}\n`);
+
+    try {
+        await setup();
+
+        // Echo prevention tests (the bug)
+        await testBroadcastPlusSyncNoEcho();
+        await testSpeakToPlusSyncNoEcho();
+        await testTransformPlusSyncNoEcho();
+        await testTripleCallNoEcho();
+
+        // Correctness: dedup must NOT suppress legitimate messages
+        await testDifferentMessagesNotSuppressed();
+        await testUserMessagesNotAffected();
+        await testDifferentEntitiesNotDeduped();
+
+    } catch (e) {
+        console.error('\nFATAL:', e.message);
+        console.error(e.stack);
+        process.exit(1);
+    }
+
+    // Summary
+    console.log(`\n${'='.repeat(60)}`);
+    console.log(`Results: ${passed} passed, ${failed} failed, ${skipped} skipped`);
+    console.log('='.repeat(60));
+
+    if (failed > 0) {
+        console.log(`\n${failed} assertion(s) FAILED — echo bug may still exist`);
+        process.exit(1);
+    } else {
+        console.log('\nAll echo regression tests passed');
+        process.exit(0);
+    }
+}
+
+runAll().catch(e => {
+    console.error('FATAL:', e);
+    process.exit(1);
+});


### PR DESCRIPTION
…sertions)

Tests verify:
- broadcast + sync-message = NO echo
- speak-to + sync-message = NO echo
- transform + sync-message = NO echo
- triple call (all 3 endpoints) = NO echo
- different messages NOT suppressed by dedup
- user messages NOT affected by dedup
- same text to different entities NOT deduped

Exits with code 1 if any assertion fails (CI-ready).

https://claude.ai/code/session_012WGV3Y2ocztVGZV1vPkML3