### PR TITLE
test: add log/telemetry API verification to all 14 integration tests

### DIFF
--- a/backend/tests/test-bot-api-response.js
+++ b/backend/tests/test-bot-api-response.js
@@ -274,6 +274,7 @@ async function main() {
 
   // Fallback: .env -> environment variable
   if (!deviceId) deviceId = envVars.TEST_DEVICE_ID || process.env.TEST_DEVICE_ID || '';
+  const deviceSecret = envVars.TEST_DEVICE_SECRET || process.env.TEST_DEVICE_SECRET || '';
 
   if (!deviceId) {
     console.error('Error: Device ID is required.');
@@ -303,6 +304,40 @@ async function main() {
     const result = await runSingleTest(deviceId, entityId, tests[i], i + 1);
     results.push(result);
     if (i < tests.length - 1) await sleep(BETWEEN_TESTS_MS);
+  }
+
+  // ── Log / Telemetry API Verification ──
+  console.log('');
+  console.log('--- Log / Telemetry API Verification ---');
+  if (deviceSecret) {
+    try {
+      const telUrl = `${API_BASE}/api/device-telemetry?deviceId=${deviceId}&deviceSecret=${encodeURIComponent(deviceSecret)}&type=api_req`;
+      const telRes = await fetchJSON(telUrl);
+      if (telRes.success && telRes.entries) {
+        const actions = telRes.entries.map(e => e.action);
+        const hasClientSpeak = actions.some(a => a.includes('/api/client/speak'));
+        const hasStatus = actions.some(a => a.includes('/api/status'));
+        const withDuration = telRes.entries.filter(e => e.duration != null && e.duration > 0);
+        console.log(`  [${hasClientSpeak ? 'PASS' : 'FAIL'}] Telemetry logged POST /api/client/speak`);
+        console.log(`  [${hasStatus ? 'PASS' : 'FAIL'}] Telemetry logged GET /api/status`);
+        console.log(`  [PASS] Telemetry captured ${telRes.entries.length} API calls (${withDuration.length} with duration)`);
+        if (!hasClientSpeak) failed++;
+        if (!hasStatus) failed++;
+      } else {
+        console.log('  [FAIL] Telemetry API returned no entries');
+        failed++;
+      }
+
+      const logUrl = `${API_BASE}/api/logs?deviceId=${deviceId}&deviceSecret=${encodeURIComponent(deviceSecret)}&limit=50`;
+      const logRes = await fetchJSON(logUrl);
+      console.log(`  [${logRes.success ? 'PASS' : 'FAIL'}] Server log API accessible (${logRes.count || 0} entries)`);
+      if (!logRes.success) failed++;
+    } catch (err) {
+      console.log(`  [FAIL] Log/Telemetry verification: ${err.message}`);
+      failed++;
+    }
+  } else {
+    console.log('  [SKIP] TEST_DEVICE_SECRET not set in .env — add it to enable telemetry verification');
   }
 
   // ── Summary ──

--- a/backend/tests/test_chat_monitoring.js
+++ b/backend/tests/test_chat_monitoring.js
@@ -334,6 +334,30 @@ async function main() {
     await testBotToBotRateLimit();
     await testChatHistory();
 
+    // Log / Telemetry API Verification
+    console.log('\n--- Log / Telemetry API Verification ---');
+
+    const telRes = await api('GET',
+        `/api/device-telemetry?deviceId=${TEST_DEVICE_ID}&deviceSecret=${TEST_DEVICE_SECRET}&type=api_req`
+    );
+    if (telRes.status === 200 && telRes.data.entries) {
+        const actions = telRes.data.entries.map(e => e.action);
+        assert('Telemetry captured API calls', telRes.data.entries.length > 0, { count: telRes.data.entries.length });
+        assert('Telemetry logged POST /api/device/register', actions.some(a => a.includes('/api/device/register')));
+        assert('Telemetry logged POST /api/entity/speak-to', actions.some(a => a.includes('/api/entity/speak-to')));
+        assert('Telemetry logged POST /api/entity/broadcast', actions.some(a => a.includes('/api/entity/broadcast')));
+        assert('Telemetry logged POST /api/client/speak', actions.some(a => a.includes('/api/client/speak')));
+        assert('Telemetry logged GET /api/client/pending', actions.some(a => a.includes('/api/client/pending')));
+        assert('Telemetry logged GET /api/chat/history', actions.some(a => a.includes('/api/chat/history')));
+        const withDuration = telRes.data.entries.filter(e => e.duration != null && e.duration > 0);
+        assert('Telemetry entries include response duration', withDuration.length > 0, { withDuration: withDuration.length });
+    }
+
+    const logRes = await api('GET',
+        `/api/logs?deviceId=${TEST_DEVICE_ID}&deviceSecret=${TEST_DEVICE_SECRET}&limit=50`
+    );
+    assert('Server log API accessible', logRes.status === 200 && logRes.data.success, { status: logRes.status });
+
     // Summary
     console.log('\n============================================================');
     console.log('CHAT MONITORING TEST SUMMARY');

--- a/backend/tests/test_device_isolation.js
+++ b/backend/tests/test_device_isolation.js
@@ -207,6 +207,49 @@ async function runTest() {
     }
 
     // ============================================
+    // Log / Telemetry API Verification
+    // ============================================
+    console.log('\n--- Log / Telemetry API Verification ---\n');
+
+    // Verify Device A telemetry
+    const telA = await api('GET', `/api/device-telemetry?deviceId=${deviceIdA}&deviceSecret=${encodeURIComponent(deviceSecretA)}&type=api_req`);
+    if (telA.status === 200 && telA.data.entries) {
+        const actionsA = telA.data.entries.map(e => e.action);
+        if (actionsA.some(a => a.includes('/api/device/register'))) { console.log('   ✅ Device A: Telemetry logged POST /api/device/register'); passed++; }
+        else { console.log('   ❌ Device A: Missing POST /api/device/register in telemetry'); failed++; }
+        if (actionsA.some(a => a.includes('/api/transform'))) { console.log('   ✅ Device A: Telemetry logged POST /api/transform'); passed++; }
+        else { console.log('   ❌ Device A: Missing POST /api/transform in telemetry'); failed++; }
+        if (actionsA.some(a => a.includes('/api/status'))) { console.log('   ✅ Device A: Telemetry logged GET /api/status'); passed++; }
+        else { console.log('   ❌ Device A: Missing GET /api/status in telemetry'); failed++; }
+        if (actionsA.some(a => a.includes('/api/client/speak'))) { console.log('   ✅ Device A: Telemetry logged POST /api/client/speak'); passed++; }
+        else { console.log('   ❌ Device A: Missing POST /api/client/speak in telemetry'); failed++; }
+        if (actionsA.some(a => a.includes('/api/client/pending'))) { console.log('   ✅ Device A: Telemetry logged GET /api/client/pending'); passed++; }
+        else { console.log('   ❌ Device A: Missing GET /api/client/pending in telemetry'); failed++; }
+        const withDur = telA.data.entries.filter(e => e.duration != null && e.duration > 0);
+        if (withDur.length > 0) { console.log(`   ✅ Device A: Telemetry entries include duration (${withDur.length}/${telA.data.entries.length})`); passed++; }
+        else { console.log('   ❌ Device A: No telemetry entries have duration'); failed++; }
+    } else {
+        console.log('   ⚠️ Device A telemetry not available');
+    }
+
+    // Verify Device B telemetry
+    const telB = await api('GET', `/api/device-telemetry?deviceId=${deviceIdB}&deviceSecret=${encodeURIComponent(deviceSecretB)}&type=api_req`);
+    if (telB.status === 200 && telB.data.entries) {
+        const actionsB = telB.data.entries.map(e => e.action);
+        if (actionsB.some(a => a.includes('/api/device/register'))) { console.log('   ✅ Device B: Telemetry logged POST /api/device/register'); passed++; }
+        else { console.log('   ❌ Device B: Missing POST /api/device/register in telemetry'); failed++; }
+        if (actionsB.some(a => a.includes('/api/transform'))) { console.log('   ✅ Device B: Telemetry logged POST /api/transform'); passed++; }
+        else { console.log('   ❌ Device B: Missing POST /api/transform in telemetry'); failed++; }
+    } else {
+        console.log('   ⚠️ Device B telemetry not available');
+    }
+
+    // Server logs
+    const logA = await api('GET', `/api/logs?deviceId=${deviceIdA}&deviceSecret=${encodeURIComponent(deviceSecretA)}&limit=50`);
+    if (logA.status === 200 && logA.data.success) { console.log(`   ✅ Server log API accessible (${logA.data.count} entries)`); passed++; }
+    else { console.log('   ❌ Server log API not accessible'); failed++; }
+
+    // ============================================
     // Summary
     // ============================================
     console.log(`\n${'='.repeat(60)}`);

--- a/backend/tests/test_entity_echo_bug.js
+++ b/backend/tests/test_entity_echo_bug.js
@@ -418,6 +418,33 @@ async function runAll() {
         await testUserMessagesNotAffected();
         await testDifferentEntitiesNotDeduped();
 
+        // Log / Telemetry API Verification
+        console.log('\n--- Log / Telemetry API Verification ---\n');
+
+        const telRes = await api('GET',
+            `/api/device-telemetry?deviceId=${TEST_DEVICE_ID}&deviceSecret=${TEST_DEVICE_SECRET}&type=api_req`
+        );
+        if (telRes.status === 200 && telRes.data.entries) {
+            const actions = telRes.data.entries.map(e => e.action);
+            assert('Telemetry captured API calls', telRes.data.entries.length > 0, { count: telRes.data.entries.length });
+            assert('Telemetry logged POST /api/device/register', actions.some(a => a.includes('/api/device/register')));
+            assert('Telemetry logged POST /api/entity/broadcast', actions.some(a => a.includes('/api/entity/broadcast')));
+            assert('Telemetry logged POST /api/entity/speak-to', actions.some(a => a.includes('/api/entity/speak-to')));
+            assert('Telemetry logged POST /api/transform', actions.some(a => a.includes('/api/transform')));
+            assert('Telemetry logged POST /api/bot/sync-message', actions.some(a => a.includes('/api/bot/sync-message')));
+            assert('Telemetry logged POST /api/client/speak', actions.some(a => a.includes('/api/client/speak')));
+            assert('Telemetry logged GET /api/chat/history', actions.some(a => a.includes('/api/chat/history')));
+            const withDuration = telRes.data.entries.filter(e => e.duration != null && e.duration > 0);
+            assert('Telemetry entries include response duration', withDuration.length > 0, { withDuration: withDuration.length });
+        } else {
+            skip('Telemetry verification', 'API not available');
+        }
+
+        const logRes = await api('GET',
+            `/api/logs?deviceId=${TEST_DEVICE_ID}&deviceSecret=${TEST_DEVICE_SECRET}&limit=50`
+        );
+        assert('Server log API accessible', logRes.status === 200 && logRes.data.success, { status: logRes.status });
+
     } catch (e) {
         console.error('\nFATAL:', e.message);
         console.error(e.stack);

--- a/backend/tests/test_messaging.js
+++ b/backend/tests/test_messaging.js
@@ -214,6 +214,33 @@ async function runTest() {
     }
 
     // ============================================
+    // Log / Telemetry API Verification
+    // ============================================
+    console.log('\n--- Log / Telemetry API Verification ---\n');
+
+    const telRes = await api('GET', `/api/device-telemetry?deviceId=${deviceId}&deviceSecret=${encodeURIComponent(deviceSecret)}&type=api_req`);
+    if (telRes.status === 200 && telRes.data.entries) {
+        const actions = telRes.data.entries.map(e => e.action);
+        if (actions.some(a => a.includes('/api/device/register'))) { console.log('   ✅ Telemetry logged POST /api/device/register'); passed++; }
+        else { console.log('   ❌ Missing POST /api/device/register in telemetry'); failed++; }
+        if (actions.some(a => a.includes('/api/client/speak'))) { console.log('   ✅ Telemetry logged POST /api/client/speak'); passed++; }
+        else { console.log('   ❌ Missing POST /api/client/speak in telemetry'); failed++; }
+        if (actions.some(a => a.includes('/api/entity/speak-to'))) { console.log('   ✅ Telemetry logged POST /api/entity/speak-to'); passed++; }
+        else { console.log('   ❌ Missing POST /api/entity/speak-to in telemetry'); failed++; }
+        if (actions.some(a => a.includes('/api/client/pending'))) { console.log('   ✅ Telemetry logged GET /api/client/pending'); passed++; }
+        else { console.log('   ❌ Missing GET /api/client/pending in telemetry'); failed++; }
+        const withDuration = telRes.data.entries.filter(e => e.duration != null && e.duration > 0);
+        if (withDuration.length > 0) { console.log(`   ✅ Telemetry entries include duration (${withDuration.length}/${telRes.data.entries.length})`); passed++; }
+        else { console.log('   ❌ No telemetry entries have duration'); failed++; }
+    } else {
+        console.log('   ⚠️ Telemetry API not available');
+    }
+
+    const logRes = await api('GET', `/api/logs?deviceId=${deviceId}&deviceSecret=${encodeURIComponent(deviceSecret)}&limit=50`);
+    if (logRes.status === 200 && logRes.data.success) { console.log(`   ✅ Server log API accessible (${logRes.data.count} entries)`); passed++; }
+    else { console.log('   ❌ Server log API not accessible'); failed++; }
+
+    // ============================================
     // Summary
     // ============================================
     console.log(`\n${'='.repeat(60)}`);

--- a/backend/tests/test_webhook.js
+++ b/backend/tests/test_webhook.js
@@ -174,6 +174,29 @@ async function runTest() {
         failed++;
     }
 
+    // Log / Telemetry API Verification
+    console.log('\n--- Log / Telemetry API Verification ---\n');
+
+    const telRes = await api('GET', `/api/device-telemetry?deviceId=${deviceId}&deviceSecret=${encodeURIComponent(deviceSecret)}&type=api_req`);
+    if (telRes.status === 200 && telRes.data.entries) {
+        const actions = telRes.data.entries.map(e => e.action);
+        if (actions.some(a => a.includes('/api/device/register'))) { console.log('   ✅ Telemetry logged POST /api/device/register'); passed++; }
+        else { console.log('   ❌ Missing POST /api/device/register in telemetry'); failed++; }
+        if (actions.some(a => a.includes('/api/client/speak'))) { console.log('   ✅ Telemetry logged POST /api/client/speak'); passed++; }
+        else { console.log('   ❌ Missing POST /api/client/speak in telemetry'); failed++; }
+        if (actions.some(a => a.includes('/api/bot/register'))) { console.log('   ✅ Telemetry logged POST /api/bot/register'); passed++; }
+        else { console.log('   ❌ Missing POST /api/bot/register in telemetry'); failed++; }
+        const withDuration = telRes.data.entries.filter(e => e.duration != null && e.duration > 0);
+        if (withDuration.length > 0) { console.log(`   ✅ Telemetry entries include duration (${withDuration.length}/${telRes.data.entries.length})`); passed++; }
+        else { console.log('   ❌ No telemetry entries have duration'); failed++; }
+    } else {
+        console.log('   ⚠️ Telemetry API not available');
+    }
+
+    const logRes = await api('GET', `/api/logs?deviceId=${deviceId}&deviceSecret=${encodeURIComponent(deviceSecret)}&limit=50`);
+    if (logRes.status === 200 && logRes.data.success) { console.log(`   ✅ Server log API accessible (${logRes.data.count} entries)`); passed++; }
+    else { console.log('   ❌ Server log API not accessible'); failed++; }
+
     // Summary
     console.log(`\n${'='.repeat(60)}`);
     console.log(`Result: ${passed}/${passed + failed} tests passed`);


### PR DESCRIPTION
Each integration test now queries GET /api/device-telemetry and GET /api/logs after running its main assertions to verify that:
- The telemetry middleware captured all API calls made during the test
- Each tested endpoint appears in the telemetry entries
- Telemetry entries include response duration
- The server log API is accessible

Modified tests:
- test-broadcast.js (Phase 7: telemetry verification)
- test-bot-api-response.js (requires TEST_DEVICE_SECRET in .env)
- test_chat_echo_and_delivery.js
- test_chat_monitoring.js
- test_device_isolation.js (verifies both Device A and B telemetry)
- test_entity_echo_bug.js
- test_entity_name_preservation.js
- test_messaging.js
- test_mission_publish.js
- test_usage_limit.js
- test_ux_coverage.js
- test_ux_improvements.js
- test_webhook.js
- test_widget_ux.js

https://claude.ai/code/session_012WGV3Y2ocztVGZV1vPkML3