### PR TITLE
feat: enhance feedback with log snapshot capture + AI diagnostic prompt

### DIFF
--- a/backend/device-feedback.js
+++ b/backend/device-feedback.js
@@ -1,0 +1,561 @@
+/**
+ * Device Feedback Module
+ *
+ * Integrates user feedback with log/telemetry snapshots to create
+ * AI-debuggable bug reports.
+ *
+ * Flow:
+ *   1. User submits feedback (POST /api/feedback)
+ *   2. Backend auto-captures: telemetry entries + server logs + device state
+ *   3. Auto-triages based on error patterns in captured logs
+ *   4. GET /api/feedback/:id/ai-prompt returns a structured diagnostic prompt
+ *   5. POST /api/feedback/:id/create-issue creates a GitHub issue
+ */
+
+const LOG_WINDOW_MS = 5 * 60 * 1000; // capture last 5 minutes of logs
+
+// ============================================
+// DB SETUP
+// ============================================
+
+async function initFeedbackTable(pool) {
+    if (!pool) return;
+    try {
+        // Add new columns to existing feedback table (safe migration)
+        await pool.query(`ALTER TABLE feedback ADD COLUMN IF NOT EXISTS category VARCHAR(32) DEFAULT 'bug'`);
+        await pool.query(`ALTER TABLE feedback ADD COLUMN IF NOT EXISTS severity VARCHAR(16) DEFAULT 'medium'`);
+        await pool.query(`ALTER TABLE feedback ADD COLUMN IF NOT EXISTS log_snapshot JSONB`);
+        await pool.query(`ALTER TABLE feedback ADD COLUMN IF NOT EXISTS device_state JSONB`);
+        await pool.query(`ALTER TABLE feedback ADD COLUMN IF NOT EXISTS status VARCHAR(32) DEFAULT 'open'`);
+        await pool.query(`ALTER TABLE feedback ADD COLUMN IF NOT EXISTS tags TEXT[] DEFAULT '{}'`);
+        await pool.query(`ALTER TABLE feedback ADD COLUMN IF NOT EXISTS ai_diagnosis TEXT`);
+        await pool.query(`ALTER TABLE feedback ADD COLUMN IF NOT EXISTS resolution TEXT`);
+        await pool.query(`ALTER TABLE feedback ADD COLUMN IF NOT EXISTS github_issue_url TEXT`);
+        await pool.query(`ALTER TABLE feedback ADD COLUMN IF NOT EXISTS mark_ts BIGINT`);
+        await pool.query(`ALTER TABLE feedback ADD COLUMN IF NOT EXISTS device_secret TEXT`);
+        await pool.query(`CREATE INDEX IF NOT EXISTS idx_feedback_device ON feedback(device_id)`);
+        await pool.query(`CREATE INDEX IF NOT EXISTS idx_feedback_status ON feedback(status)`);
+        console.log('[Feedback] Table migration complete');
+    } catch (err) {
+        console.error('[Feedback] Migration error:', err.message);
+    }
+}
+
+// ============================================
+// LOG SNAPSHOT CAPTURE
+// ============================================
+
+/**
+ * Capture telemetry entries + server logs for a device within a time window.
+ * @param {Pool} chatPool - PostgreSQL pool (for server_logs + device_telemetry)
+ * @param {string} deviceId
+ * @param {number} [sinceMs] - Start of capture window (default: now - 5 min)
+ * @returns {object} { telemetry: [], serverLogs: [], capturedAt, windowMs }
+ */
+async function captureLogSnapshot(chatPool, deviceId, sinceMs) {
+    const since = sinceMs || (Date.now() - LOG_WINDOW_MS);
+    const snapshot = {
+        telemetry: [],
+        serverLogs: [],
+        capturedAt: Date.now(),
+        windowMs: Date.now() - since
+    };
+
+    if (!chatPool) return snapshot;
+
+    try {
+        // Capture device telemetry entries
+        const telResult = await chatPool.query(
+            `SELECT ts, type, action, page, input, output, duration, meta
+             FROM device_telemetry
+             WHERE device_id = $1 AND ts >= $2
+             ORDER BY ts DESC
+             LIMIT 200`,
+            [deviceId, since]
+        );
+        snapshot.telemetry = telResult.rows.map(r => ({
+            ts: parseInt(r.ts),
+            type: r.type,
+            action: r.action,
+            page: r.page,
+            input: r.input,
+            output: r.output,
+            duration: r.duration ? parseInt(r.duration) : null,
+            meta: r.meta
+        }));
+    } catch (err) {
+        snapshot.telemetryError = err.message;
+    }
+
+    try {
+        // Capture server logs (filter by this device)
+        const logResult = await chatPool.query(
+            `SELECT level, category, message, device_id, entity_id, metadata, created_at
+             FROM server_logs
+             WHERE (device_id = $1 OR device_id IS NULL)
+             AND created_at > $2
+             ORDER BY created_at DESC
+             LIMIT 100`,
+            [deviceId, new Date(since)]
+        );
+        snapshot.serverLogs = logResult.rows.map(r => ({
+            level: r.level,
+            category: r.category,
+            message: r.message,
+            entityId: r.entity_id,
+            metadata: r.metadata,
+            createdAt: r.created_at
+        }));
+    } catch (err) {
+        snapshot.serverLogsError = err.message;
+    }
+
+    return snapshot;
+}
+
+/**
+ * Capture current device/entity state snapshot.
+ * @param {object} devices - In-memory devices map
+ * @param {string} deviceId
+ * @returns {object|null}
+ */
+function captureDeviceState(devices, deviceId) {
+    const device = devices[deviceId];
+    if (!device) return null;
+
+    const entities = [];
+    for (let i = 0; i < 4; i++) {
+        const e = device.entities[i];
+        if (!e) continue;
+        entities.push({
+            entityId: i,
+            isBound: e.isBound,
+            name: e.name || null,
+            character: e.character,
+            state: e.state,
+            message: e.message ? e.message.substring(0, 200) : null,
+            lastUpdated: e.lastUpdated,
+            hasWebhook: !!e.webhook,
+            webhookMode: e.webhook ? 'push' : 'polling',
+            appVersion: e.appVersion || null
+        });
+    }
+
+    return {
+        deviceId,
+        entityCount: entities.length,
+        boundCount: entities.filter(e => e.isBound).length,
+        entities,
+        capturedAt: Date.now()
+    };
+}
+
+// ============================================
+// AUTO-TRIAGE
+// ============================================
+
+/**
+ * Analyze log snapshot and auto-assign severity, tags, and preliminary diagnosis.
+ * @param {object} logSnapshot
+ * @returns {{ severity: string, tags: string[], diagnosis: string }}
+ */
+function autoTriage(logSnapshot) {
+    const tags = [];
+    let severity = 'low';
+    const issues = [];
+
+    if (!logSnapshot) return { severity, tags, diagnosis: '' };
+
+    const telemetry = logSnapshot.telemetry || [];
+    const serverLogs = logSnapshot.serverLogs || [];
+
+    // Scan telemetry for HTTP error patterns
+    const errorCalls = [];
+    for (const entry of telemetry) {
+        if (entry.type !== 'api_req') continue;
+        const status = entry.output?.status || entry.output?.statusCode;
+        if (status >= 400) {
+            errorCalls.push({ action: entry.action, status, output: entry.output });
+        }
+    }
+
+    // Categorize errors
+    const has403 = errorCalls.some(e => e.status === 403);
+    const has429 = errorCalls.some(e => e.status === 429);
+    const has500 = errorCalls.some(e => e.status >= 500);
+    const hasTimeout = telemetry.some(e => e.duration && e.duration > 10000);
+
+    if (has500) {
+        tags.push('server_error');
+        severity = 'critical';
+        issues.push(`Server 500 errors detected in ${errorCalls.filter(e => e.status >= 500).length} API call(s)`);
+    }
+    if (has403) {
+        tags.push('auth_issue');
+        if (severity !== 'critical') severity = 'high';
+        issues.push('Authentication failures (403) detected — botSecret may be invalid or expired');
+    }
+    if (has429) {
+        tags.push('rate_limited');
+        if (severity === 'low') severity = 'medium';
+        issues.push('Rate limiting (429) triggered — user may have hit daily message limit');
+    }
+    if (hasTimeout) {
+        tags.push('performance');
+        if (severity === 'low') severity = 'medium';
+        issues.push('Slow API calls detected (>10s) — possible performance issue');
+    }
+
+    // Scan server logs for error-level entries
+    const errorLogs = serverLogs.filter(l => l.level === 'error');
+    if (errorLogs.length > 0) {
+        tags.push('backend_error');
+        if (severity === 'low') severity = 'medium';
+        issues.push(`${errorLogs.length} server-side error(s) in logs`);
+    }
+
+    // Scan for specific categories
+    const logCategories = [...new Set(serverLogs.map(l => l.category))];
+    if (logCategories.includes('broadcast_push') || logCategories.includes('speakto_push')) {
+        tags.push('push_related');
+    }
+    if (logCategories.includes('bind') || logCategories.includes('unbind')) {
+        tags.push('binding_related');
+    }
+
+    // Telemetry error entries (client-side errors)
+    const clientErrors = telemetry.filter(e => e.type === 'error');
+    if (clientErrors.length > 0) {
+        tags.push('client_error');
+        issues.push(`${clientErrors.length} client-side error(s) captured`);
+    }
+
+    // Tag affected endpoints
+    const affectedEndpoints = [...new Set(errorCalls.map(e => e.action))];
+    if (affectedEndpoints.length > 0) {
+        tags.push(...affectedEndpoints.map(a => `endpoint:${a}`));
+    }
+
+    if (tags.length === 0) {
+        tags.push('ux_issue');
+    }
+
+    const diagnosis = issues.length > 0
+        ? 'Auto-detected issues:\n' + issues.map(i => `- ${i}`).join('\n')
+        : 'No obvious errors detected in recent logs. This may be a UX/behavior issue.';
+
+    return { severity, tags, diagnosis };
+}
+
+// ============================================
+// AI PROMPT GENERATION
+// ============================================
+
+/**
+ * Generate a structured AI diagnostic prompt from a feedback record.
+ * @param {object} feedback - Full feedback row from DB
+ * @returns {string}
+ */
+function generateAiPrompt(feedback) {
+    const lines = [];
+
+    lines.push(`## Bug Report #${feedback.id}`);
+    lines.push('');
+    lines.push(`**Description:** ${feedback.message}`);
+    lines.push(`**Category:** ${feedback.category || 'bug'}`);
+    lines.push(`**Severity:** ${feedback.severity || 'unknown'}`);
+    lines.push(`**Status:** ${feedback.status || 'open'}`);
+    lines.push(`**Device:** ${feedback.device_id}`);
+    lines.push(`**App Version:** ${feedback.app_version || 'unknown'}`);
+    lines.push(`**Reported:** ${new Date(parseInt(feedback.created_at)).toISOString()}`);
+
+    if (feedback.tags && feedback.tags.length > 0) {
+        lines.push(`**Tags:** ${feedback.tags.join(', ')}`);
+    }
+
+    const snapshot = feedback.log_snapshot;
+    if (snapshot) {
+        const windowMin = Math.round((snapshot.windowMs || 0) / 60000);
+
+        // Recent API Calls
+        const apiCalls = (snapshot.telemetry || []).filter(e => e.type === 'api_req');
+        if (apiCalls.length > 0) {
+            lines.push('');
+            lines.push(`### Recent API Calls (last ${windowMin} min) — ${apiCalls.length} total`);
+            lines.push('');
+            lines.push('| Time | Endpoint | Status | Duration |');
+            lines.push('|------|----------|--------|----------|');
+            for (const call of apiCalls.slice(0, 30)) {
+                const time = new Date(call.ts).toISOString().split('T')[1].split('.')[0];
+                const status = call.output?.status || call.output?.statusCode || '?';
+                const dur = call.duration ? `${call.duration}ms` : '-';
+                const flag = status >= 400 ? ' **FAILED**' : '';
+                lines.push(`| ${time} | ${call.action || '-'} | ${status}${flag} | ${dur} |`);
+            }
+        }
+
+        // Client-side errors
+        const clientErrors = (snapshot.telemetry || []).filter(e => e.type === 'error');
+        if (clientErrors.length > 0) {
+            lines.push('');
+            lines.push(`### Client-Side Errors — ${clientErrors.length} total`);
+            for (const err of clientErrors.slice(0, 10)) {
+                const time = new Date(err.ts).toISOString().split('T')[1].split('.')[0];
+                lines.push(`- [${time}] ${err.action || 'unknown'}: ${JSON.stringify(err.meta || {})}`);
+            }
+        }
+
+        // Server Logs
+        if (snapshot.serverLogs && snapshot.serverLogs.length > 0) {
+            lines.push('');
+            lines.push(`### Server Logs — ${snapshot.serverLogs.length} entries`);
+            lines.push('');
+            for (const log of snapshot.serverLogs.slice(0, 20)) {
+                const level = log.level === 'error' ? '**ERROR**' : log.level === 'warn' ? 'WARN' : 'info';
+                const time = log.createdAt ? new Date(log.createdAt).toISOString().split('T')[1].split('.')[0] : '?';
+                lines.push(`- [${time}][${level}] ${log.category}: ${log.message}`);
+            }
+        }
+    }
+
+    // Device State
+    const state = feedback.device_state;
+    if (state) {
+        lines.push('');
+        lines.push(`### Device State (${state.boundCount}/${state.entityCount} entities bound)`);
+        lines.push('');
+        for (const e of (state.entities || [])) {
+            const bound = e.isBound ? 'BOUND' : 'unbound';
+            const msg = e.message ? `"${e.message.substring(0, 60)}"` : '-';
+            lines.push(`- Entity ${e.entityId}: ${e.character} [${bound}] state=${e.state} mode=${e.webhookMode} msg=${msg}`);
+        }
+    }
+
+    // Auto-diagnosis
+    if (feedback.ai_diagnosis) {
+        lines.push('');
+        lines.push('### Auto-Triage Diagnosis');
+        lines.push('');
+        lines.push(feedback.ai_diagnosis);
+    }
+
+    lines.push('');
+    lines.push('---');
+    lines.push('');
+    lines.push('**Instructions for AI:** Analyze the above bug report, API call history, server logs, and device state. ');
+    lines.push('Identify the root cause, the affected code path in the backend (backend/index.js), and suggest a fix. ');
+    lines.push('If the issue is client-side (Android app), indicate which Activity/Repository is involved.');
+
+    return lines.join('\n');
+}
+
+// ============================================
+// FEEDBACK DB OPERATIONS
+// ============================================
+
+/**
+ * Save enhanced feedback with log snapshot.
+ */
+async function saveFeedback(pool, { deviceId, deviceSecret, message, category, appVersion, logSnapshot, deviceState, markTs }) {
+    if (!pool) return null;
+
+    const triage = autoTriage(logSnapshot);
+
+    try {
+        const result = await pool.query(
+            `INSERT INTO feedback
+             (device_id, device_secret, message, category, app_version, log_snapshot, device_state,
+              severity, status, tags, ai_diagnosis, mark_ts, created_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'open', $9, $10, $11, $12)
+             RETURNING id, severity, tags, ai_diagnosis`,
+            [
+                deviceId,
+                deviceSecret || null,
+                message,
+                category || 'bug',
+                appVersion || '',
+                JSON.stringify(logSnapshot),
+                JSON.stringify(deviceState),
+                triage.severity,
+                triage.tags,
+                triage.diagnosis,
+                markTs || null,
+                Date.now()
+            ]
+        );
+        return result.rows[0];
+    } catch (err) {
+        console.error('[Feedback] Save error:', err.message);
+        return null;
+    }
+}
+
+/**
+ * Get feedback list with filters.
+ */
+async function getFeedbackList(pool, { deviceId, status, severity, limit = 50, offset = 0 }) {
+    if (!pool) return [];
+
+    let query = 'SELECT id, device_id, message, category, severity, status, tags, app_version, github_issue_url, created_at FROM feedback WHERE 1=1';
+    const params = [];
+
+    if (deviceId) {
+        params.push(deviceId);
+        query += ` AND device_id = $${params.length}`;
+    }
+    if (status) {
+        params.push(status);
+        query += ` AND status = $${params.length}`;
+    }
+    if (severity) {
+        params.push(severity);
+        query += ` AND severity = $${params.length}`;
+    }
+
+    query += ' ORDER BY created_at DESC';
+    params.push(Math.min(parseInt(limit) || 50, 200));
+    query += ` LIMIT $${params.length}`;
+    params.push(parseInt(offset) || 0);
+    query += ` OFFSET $${params.length}`;
+
+    try {
+        const result = await pool.query(query, params);
+        return result.rows;
+    } catch (err) {
+        console.error('[Feedback] List error:', err.message);
+        return [];
+    }
+}
+
+/**
+ * Get single feedback by ID (full record with log_snapshot).
+ */
+async function getFeedbackById(pool, id) {
+    if (!pool) return null;
+    try {
+        const result = await pool.query('SELECT * FROM feedback WHERE id = $1', [id]);
+        return result.rows[0] || null;
+    } catch (err) {
+        console.error('[Feedback] Get error:', err.message);
+        return null;
+    }
+}
+
+/**
+ * Update feedback status/resolution.
+ */
+async function updateFeedback(pool, id, updates) {
+    if (!pool) return false;
+    const allowed = ['status', 'resolution', 'github_issue_url', 'ai_diagnosis', 'severity'];
+    const sets = [];
+    const params = [];
+
+    for (const [key, value] of Object.entries(updates)) {
+        if (allowed.includes(key)) {
+            params.push(value);
+            sets.push(`${key} = $${params.length}`);
+        }
+    }
+    if (sets.length === 0) return false;
+
+    params.push(id);
+    try {
+        await pool.query(`UPDATE feedback SET ${sets.join(', ')} WHERE id = $${params.length}`, params);
+        return true;
+    } catch (err) {
+        console.error('[Feedback] Update error:', err.message);
+        return false;
+    }
+}
+
+// ============================================
+// GITHUB ISSUE CREATION
+// ============================================
+
+/**
+ * Create a GitHub issue from feedback.
+ * Requires GITHUB_TOKEN and GITHUB_REPO in env.
+ * @returns {{ url: string, number: number } | null}
+ */
+async function createGithubIssue(feedback) {
+    const token = process.env.GITHUB_TOKEN;
+    const repo = process.env.GITHUB_REPO; // e.g. "HankHuang0516/realbot"
+    if (!token || !repo) return null;
+
+    const prompt = generateAiPrompt(feedback);
+    const severityLabel = `severity:${feedback.severity || 'medium'}`;
+    const labels = ['bug', 'ai-feedback', severityLabel];
+    if (feedback.tags) {
+        for (const tag of feedback.tags) {
+            if (!tag.startsWith('endpoint:')) labels.push(tag);
+        }
+    }
+
+    const title = `[Feedback #${feedback.id}] ${(feedback.message || '').substring(0, 80)}`;
+    const body = prompt;
+
+    try {
+        const res = await fetch(`https://api.github.com/repos/${repo}/issues`, {
+            method: 'POST',
+            headers: {
+                'Authorization': `token ${token}`,
+                'Accept': 'application/vnd.github.v3+json',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({ title, body, labels })
+        });
+
+        if (!res.ok) {
+            const err = await res.text();
+            console.error(`[Feedback] GitHub issue creation failed (${res.status}):`, err);
+            return null;
+        }
+
+        const data = await res.json();
+        return { url: data.html_url, number: data.number };
+    } catch (err) {
+        console.error('[Feedback] GitHub API error:', err.message);
+        return null;
+    }
+}
+
+// ============================================
+// MARK TIMESTAMP (for "mark now, report later")
+// ============================================
+
+// In-memory mark timestamps: deviceId → timestamp
+const markTimestamps = {};
+
+function setMark(deviceId) {
+    markTimestamps[deviceId] = Date.now();
+    return markTimestamps[deviceId];
+}
+
+function getMark(deviceId) {
+    return markTimestamps[deviceId] || null;
+}
+
+function clearMark(deviceId) {
+    delete markTimestamps[deviceId];
+}
+
+// ============================================
+// EXPORTS
+// ============================================
+
+module.exports = {
+    initFeedbackTable,
+    captureLogSnapshot,
+    captureDeviceState,
+    autoTriage,
+    generateAiPrompt,
+    saveFeedback,
+    getFeedbackList,
+    getFeedbackById,
+    updateFeedback,
+    createGithubIssue,
+    setMark,
+    getMark,
+    clearMark,
+    LOG_WINDOW_MS
+};

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -310,11 +310,20 @@
         </div>
 
         <!-- Feedback Card -->
-        <div class="card" onclick="showFeedbackDialog()" style="cursor:pointer; margin-bottom: 20px;">
-            <div class="card-title" data-i18n="settings_feedback_title">Feedback</div>
-            <div style="font-size:14px;color:var(--text-secondary);margin-top:4px;" data-i18n="settings_feedback_desc">
-                Found a bug or have a suggestion? Let us know!
+        <div class="card" style="margin-bottom: 20px;">
+            <div style="display:flex;justify-content:space-between;align-items:center;">
+                <div onclick="showFeedbackDialog()" style="cursor:pointer;flex:1;">
+                    <div class="card-title" data-i18n="settings_feedback_title">Feedback</div>
+                    <div style="font-size:14px;color:var(--text-secondary);margin-top:4px;" data-i18n="settings_feedback_desc">
+                        Found a bug or have a suggestion? Let us know!
+                    </div>
+                </div>
+                <button onclick="markBugMoment()" id="btnMark"
+                    style="margin-left:12px;padding:8px 14px;border-radius:8px;border:1px solid var(--border-color);background:var(--bg-secondary);color:var(--text-primary);cursor:pointer;font-size:13px;white-space:nowrap;">
+                    Mark
+                </button>
             </div>
+            <div id="markStatus" style="font-size:12px;color:var(--accent);margin-top:6px;display:none;"></div>
         </div>
 
         <!-- Logout -->
@@ -365,11 +374,27 @@
     <div class="dialog-overlay" id="feedbackDialog" style="display:none">
         <div class="dialog">
             <div class="dialog-title" data-i18n="settings_feedback_title">Feedback</div>
-            <p data-i18n="settings_feedback_desc" style="margin-bottom:10px;">Found a bug or have a suggestion? Let us
-                know!</p>
-            <textarea id="feedbackText" class="form-input" rows="5" data-i18n="settings_feedback_hint"
-                placeholder="Enter your feedback here..."
+            <p style="margin-bottom:10px;font-size:14px;color:var(--text-secondary);">
+                Logs from the last 5 minutes will be automatically captured to help diagnose the issue.
+            </p>
+            <div style="display:flex;gap:8px;margin-bottom:12px;">
+                <button class="feedback-cat-btn active" data-cat="bug" onclick="setFeedbackCategory('bug')">Bug</button>
+                <button class="feedback-cat-btn" data-cat="feature" onclick="setFeedbackCategory('feature')">Feature</button>
+                <button class="feedback-cat-btn" data-cat="question" onclick="setFeedbackCategory('question')">Question</button>
+            </div>
+            <style>
+                .feedback-cat-btn {
+                    padding: 6px 16px; border-radius: 20px; border: 1px solid var(--border-color);
+                    background: var(--bg-secondary); color: var(--text-secondary); cursor: pointer; font-size: 13px;
+                }
+                .feedback-cat-btn.active {
+                    background: var(--accent); color: #fff; border-color: var(--accent);
+                }
+            </style>
+            <textarea id="feedbackText" class="form-input" rows="5"
+                placeholder="Describe the issue or suggestion..."
                 style="width: 100%; resize: vertical; margin-bottom: 1rem; padding: 10px; border-radius: 8px; border: 1px solid var(--border-color); background: var(--bg-secondary); color: var(--text-primary);"></textarea>
+            <div id="feedbackResult" style="display:none;margin-bottom:12px;padding:10px;border-radius:8px;background:var(--bg-secondary);font-size:13px;"></div>
             <div class="dialog-actions">
                 <button class="btn btn-outline" onclick="closeFeedbackDialog()"
                     data-i18n="settings_feedback_cancel">Cancel</button>
@@ -699,16 +724,43 @@
         }
 
         // ============================================
-        // Feedback
+        // Feedback (Enhanced with log snapshot + AI triage)
         // ============================================
+        let feedbackCategory = 'bug';
+
+        function setFeedbackCategory(cat) {
+            feedbackCategory = cat;
+            document.querySelectorAll('.feedback-cat-btn').forEach(b => {
+                b.classList.toggle('active', b.dataset.cat === cat);
+            });
+        }
+
         function showFeedbackDialog() {
             document.getElementById('feedbackDialog').style.display = '';
             document.getElementById('feedbackText').value = '';
+            document.getElementById('feedbackResult').style.display = 'none';
+            setFeedbackCategory('bug');
             setTimeout(() => document.getElementById('feedbackText').focus(), 100);
         }
 
         function closeFeedbackDialog() {
             document.getElementById('feedbackDialog').style.display = 'none';
+        }
+
+        async function markBugMoment() {
+            try {
+                const user = await checkAuth();
+                await apiCall('POST', '/api/feedback/mark', {
+                    deviceId: user?.deviceId || 'web-portal'
+                });
+                const el = document.getElementById('markStatus');
+                el.style.display = '';
+                el.textContent = 'Marked at ' + new Date().toLocaleTimeString() + ' — logs from this point will be captured when you submit feedback.';
+                document.getElementById('btnMark').textContent = 'Marked';
+                setTimeout(() => { document.getElementById('btnMark').textContent = 'Mark'; }, 5000);
+            } catch (e) {
+                showToast('Mark failed: ' + e.message, 'error');
+            }
         }
 
         async function sendFeedback() {
@@ -725,14 +777,35 @@
 
             try {
                 const user = await checkAuth();
-                await apiCall('POST', '/api/feedback', {
+                const result = await apiCall('POST', '/api/feedback', {
                     deviceId: user?.deviceId || 'web-portal',
+                    deviceSecret: user?.deviceSecret || '',
                     message: message,
+                    category: feedbackCategory,
                     appVersion: 'Portal v' + PORTAL_VERSION
                 });
 
+                // Show triage result
+                const resultEl = document.getElementById('feedbackResult');
+                const logs = result.logsCaptured || {};
+                let html = `<strong>Feedback #${result.feedbackId || '?'}</strong> received<br>`;
+                html += `Severity: <strong>${result.severity || '?'}</strong> | `;
+                html += `Logs captured: ${logs.telemetry || 0} API calls, ${logs.serverLogs || 0} server logs<br>`;
+                if (result.tags && result.tags.length > 0) {
+                    html += `Tags: ${result.tags.map(t => '<code>' + t + '</code>').join(' ')}<br>`;
+                }
+                if (result.diagnosis) {
+                    html += `<div style="margin-top:6px;font-size:12px;color:var(--text-secondary);">${result.diagnosis.replace(/\n/g, '<br>')}</div>`;
+                }
+                if (result.githubIssue) {
+                    html += `<div style="margin-top:6px;"><a href="${result.githubIssue.url}" target="_blank">GitHub Issue #${result.githubIssue.number}</a></div>`;
+                }
+                resultEl.innerHTML = html;
+                resultEl.style.display = '';
+
                 showToast(i18n.t('settings_feedback_sent'), 'success');
-                closeFeedbackDialog();
+                // Hide mark status
+                document.getElementById('markStatus').style.display = 'none';
             } catch (e) {
                 showToast(e.message, 'error');
             } finally {

--- a/backend/tests/test_feedback.js
+++ b/backend/tests/test_feedback.js
@@ -1,0 +1,352 @@
+/**
+ * Feedback + Log Snapshot Integration Test
+ *
+ * Tests the enhanced feedback flow:
+ *   1. Register device + bind entity → generate some API activity
+ *   2. POST /api/feedback/mark → set mark timestamp
+ *   3. Generate more API activity (to appear in log snapshot)
+ *   4. POST /api/feedback → submit with auto log capture
+ *   5. Verify feedback response contains triage info + log counts
+ *   6. GET /api/feedback → list feedback
+ *   7. GET /api/feedback/:id → get full record with log_snapshot
+ *   8. GET /api/feedback/:id/ai-prompt → verify AI prompt generation
+ *   9. PATCH /api/feedback/:id → update status
+ */
+
+const API_BASE = process.env.API_BASE || 'https://eclaw.up.railway.app';
+
+const TEST_DEVICE_ID = `test-feedback-${Date.now()}`;
+const TEST_DEVICE_SECRET = `secret-${Date.now()}`;
+
+let passed = 0;
+let failed = 0;
+let feedbackId = null;
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+async function api(method, path, body = null, retries = 2) {
+    for (let attempt = 0; attempt <= retries; attempt++) {
+        try {
+            const options = { method, headers: { 'Content-Type': 'application/json' } };
+            if (body) options.body = JSON.stringify(body);
+            const res = await fetch(`${API_BASE}${path}`, options);
+            const text = await res.text();
+            await sleep(150);
+            try {
+                return { status: res.status, data: JSON.parse(text) };
+            } catch {
+                return { status: res.status, data: text };
+            }
+        } catch (e) {
+            if (attempt < retries) {
+                await sleep(1000 * (attempt + 1));
+                continue;
+            }
+            return { status: 0, data: { error: e.message } };
+        }
+    }
+}
+
+function assert(label, condition, detail) {
+    if (condition) {
+        console.log(`  OK ${label}`);
+        passed++;
+    } else {
+        console.log(`  FAIL ${label}${detail ? ': ' + JSON.stringify(detail) : ''}`);
+        failed++;
+    }
+}
+
+// ==============================
+// Setup: Create device + API activity
+// ==============================
+
+async function setup() {
+    console.log('--- Setup: Create device with bound entity ---\n');
+
+    const reg = await api('POST', '/api/device/register', {
+        deviceId: TEST_DEVICE_ID,
+        deviceSecret: TEST_DEVICE_SECRET,
+        entityId: 0,
+        appVersion: 'test-feedback',
+        isTestDevice: true
+    });
+    assert('Register device', reg.data.success, reg.data);
+
+    const bind = await api('POST', '/api/bind', { code: reg.data.bindingCode });
+    assert('Bind entity 0', bind.data.success, bind.data);
+
+    // Generate some API activity
+    await api('POST', '/api/client/speak', {
+        deviceId: TEST_DEVICE_ID, entityId: 0, text: 'Pre-feedback message', source: 'test'
+    });
+    await api('GET', `/api/status?deviceId=${TEST_DEVICE_ID}&entityId=0`);
+
+    console.log('  API activity generated\n');
+}
+
+// ==============================
+// Test: Mark timestamp
+// ==============================
+
+async function testMark() {
+    console.log('--- Test: Mark bug moment ---\n');
+
+    const { status, data } = await api('POST', '/api/feedback/mark', {
+        deviceId: TEST_DEVICE_ID
+    });
+    assert('Mark returns 200', status === 200, { status });
+    assert('Mark returns success', data.success === true, data);
+    assert('Mark returns timestamp', typeof data.markTs === 'number', { markTs: data.markTs });
+
+    // Generate more activity AFTER the mark
+    await sleep(500);
+    await api('POST', '/api/client/speak', {
+        deviceId: TEST_DEVICE_ID, entityId: 0, text: 'Post-mark message 1', source: 'test'
+    });
+    await api('POST', '/api/client/speak', {
+        deviceId: TEST_DEVICE_ID, entityId: 0, text: 'Post-mark message 2', source: 'test'
+    });
+    // Intentionally trigger a 404 error for triage to detect
+    await api('POST', '/api/entity/speak-to', {
+        deviceId: TEST_DEVICE_ID, fromEntityId: 0, toEntityId: 99, botSecret: 'wrong', text: 'bad'
+    });
+
+    console.log('  Post-mark API activity generated\n');
+}
+
+// ==============================
+// Test: Submit feedback
+// ==============================
+
+async function testSubmitFeedback() {
+    console.log('--- Test: Submit feedback with auto log capture ---\n');
+
+    const { status, data } = await api('POST', '/api/feedback', {
+        deviceId: TEST_DEVICE_ID,
+        deviceSecret: TEST_DEVICE_SECRET,
+        message: 'Test bug: entity message not delivered after binding',
+        category: 'bug',
+        appVersion: 'test-feedback-1.0'
+    });
+
+    assert('Feedback returns 200', status === 200, { status });
+    assert('Feedback returns success', data.success === true, data);
+    assert('Feedback returns feedbackId', typeof data.feedbackId === 'number', { feedbackId: data.feedbackId });
+    assert('Feedback returns severity', typeof data.severity === 'string', { severity: data.severity });
+    assert('Feedback returns tags array', Array.isArray(data.tags), { tags: data.tags });
+
+    // Log capture verification
+    assert('Logs captured: telemetry > 0', data.logsCaptured?.telemetry > 0, data.logsCaptured);
+    assert('Logs captured: windowMs > 0', data.logsCaptured?.windowMs > 0, data.logsCaptured);
+
+    feedbackId = data.feedbackId;
+    console.log(`  Feedback #${feedbackId}: severity=${data.severity} tags=[${data.tags}]\n`);
+}
+
+// ==============================
+// Test: List feedback
+// ==============================
+
+async function testListFeedback() {
+    console.log('--- Test: List feedback ---\n');
+
+    const { status, data } = await api('GET',
+        `/api/feedback?deviceId=${TEST_DEVICE_ID}&deviceSecret=${TEST_DEVICE_SECRET}`
+    );
+    assert('List returns 200', status === 200, { status });
+    assert('List returns success', data.success === true, data);
+    assert('List contains feedback', data.count > 0, { count: data.count });
+
+    const found = data.feedback?.find(f => f.id === feedbackId);
+    assert('Our feedback found in list', !!found, { feedbackId });
+    if (found) {
+        assert('Feedback has severity', !!found.severity, { severity: found.severity });
+        assert('Feedback has status=open', found.status === 'open', { status: found.status });
+    }
+}
+
+// ==============================
+// Test: Get single feedback (full record)
+// ==============================
+
+async function testGetFeedback() {
+    console.log('--- Test: Get single feedback with log snapshot ---\n');
+
+    if (!feedbackId) { console.log('  SKIP: no feedbackId'); return; }
+
+    const { status, data } = await api('GET',
+        `/api/feedback/${feedbackId}?deviceId=${TEST_DEVICE_ID}&deviceSecret=${TEST_DEVICE_SECRET}`
+    );
+    assert('Get returns 200', status === 200, { status });
+    assert('Get returns success', data.success === true, data);
+
+    const fb = data.feedback;
+    assert('Feedback has log_snapshot', fb.log_snapshot != null, { hasSnapshot: !!fb.log_snapshot });
+    assert('Feedback has device_state', fb.device_state != null, { hasState: !!fb.device_state });
+    assert('Feedback has ai_diagnosis', typeof fb.ai_diagnosis === 'string', { diagnosis: fb.ai_diagnosis?.substring(0, 80) });
+
+    if (fb.log_snapshot) {
+        const snap = typeof fb.log_snapshot === 'string' ? JSON.parse(fb.log_snapshot) : fb.log_snapshot;
+        assert('Snapshot has telemetry entries', Array.isArray(snap.telemetry) && snap.telemetry.length > 0, { count: snap.telemetry?.length });
+        assert('Snapshot has capturedAt', typeof snap.capturedAt === 'number', { capturedAt: snap.capturedAt });
+    }
+
+    if (fb.device_state) {
+        const state = typeof fb.device_state === 'string' ? JSON.parse(fb.device_state) : fb.device_state;
+        assert('Device state has entities', Array.isArray(state.entities) && state.entities.length > 0, { count: state.entities?.length });
+    }
+}
+
+// ==============================
+// Test: AI prompt generation
+// ==============================
+
+async function testAiPrompt() {
+    console.log('--- Test: AI prompt generation ---\n');
+
+    if (!feedbackId) { console.log('  SKIP: no feedbackId'); return; }
+
+    const { status, data } = await api('GET',
+        `/api/feedback/${feedbackId}/ai-prompt?deviceId=${TEST_DEVICE_ID}&deviceSecret=${TEST_DEVICE_SECRET}`
+    );
+    assert('AI prompt returns 200', status === 200, { status });
+    assert('AI prompt returns success', data.success === true, data);
+    assert('Prompt is a string', typeof data.prompt === 'string', { length: data.prompt?.length });
+    assert('Prompt contains bug description', data.prompt?.includes('entity message not delivered'), { preview: data.prompt?.substring(0, 100) });
+    assert('Prompt contains API calls section', data.prompt?.includes('Recent API Calls'), { found: data.prompt?.includes('Recent API Calls') });
+    assert('Prompt contains Device State section', data.prompt?.includes('Device State'), { found: data.prompt?.includes('Device State') });
+    assert('Prompt contains Instructions for AI', data.prompt?.includes('Instructions for AI'), { found: data.prompt?.includes('Instructions for AI') });
+
+    console.log(`  Prompt length: ${data.prompt?.length || 0} chars\n`);
+}
+
+// ==============================
+// Test: Update feedback status
+// ==============================
+
+async function testUpdateFeedback() {
+    console.log('--- Test: Update feedback status ---\n');
+
+    if (!feedbackId) { console.log('  SKIP: no feedbackId'); return; }
+
+    const { status, data } = await api('PATCH', `/api/feedback/${feedbackId}`, {
+        deviceId: TEST_DEVICE_ID,
+        deviceSecret: TEST_DEVICE_SECRET,
+        status: 'diagnosed',
+        resolution: 'Auto-test: verified feedback flow works correctly'
+    });
+    assert('Update returns 200', status === 200, { status });
+    assert('Update success', data.success === true, data);
+
+    // Verify the update
+    const verify = await api('GET',
+        `/api/feedback/${feedbackId}?deviceId=${TEST_DEVICE_ID}&deviceSecret=${TEST_DEVICE_SECRET}`
+    );
+    assert('Status updated to diagnosed', verify.data.feedback?.status === 'diagnosed', { status: verify.data.feedback?.status });
+    assert('Resolution saved', verify.data.feedback?.resolution?.includes('Auto-test'), { resolution: verify.data.feedback?.resolution });
+}
+
+// ==============================
+// Test: Error cases
+// ==============================
+
+async function testErrorCases() {
+    console.log('--- Test: Error handling ---\n');
+
+    // Empty message
+    const { status: s1 } = await api('POST', '/api/feedback', {
+        deviceId: TEST_DEVICE_ID, message: ''
+    });
+    assert('Empty message returns 400', s1 === 400, { status: s1 });
+
+    // Missing credentials for list
+    const { status: s2 } = await api('GET', '/api/feedback');
+    assert('List without creds returns 400', s2 === 400, { status: s2 });
+
+    // Invalid credentials
+    const { status: s3 } = await api('GET',
+        `/api/feedback?deviceId=${TEST_DEVICE_ID}&deviceSecret=wrong`
+    );
+    assert('Wrong secret returns 401', s3 === 401, { status: s3 });
+
+    // Non-existent feedback
+    const { status: s4 } = await api('GET',
+        `/api/feedback/999999?deviceId=${TEST_DEVICE_ID}&deviceSecret=${TEST_DEVICE_SECRET}`
+    );
+    assert('Non-existent feedback returns 404', s4 === 404, { status: s4 });
+
+    // Mark without deviceId
+    const { status: s5 } = await api('POST', '/api/feedback/mark', {});
+    assert('Mark without deviceId returns 400', s5 === 400, { status: s5 });
+}
+
+// ==============================
+// Test: Log / Telemetry API Verification
+// ==============================
+
+async function testLogApiVerification() {
+    console.log('--- Log / Telemetry API Verification ---\n');
+
+    const telRes = await api('GET',
+        `/api/device-telemetry?deviceId=${TEST_DEVICE_ID}&deviceSecret=${TEST_DEVICE_SECRET}&type=api_req`
+    );
+    if (telRes.status === 200 && telRes.data.entries) {
+        const actions = telRes.data.entries.map(e => e.action);
+        assert('Telemetry captured API calls', telRes.data.entries.length > 0, { count: telRes.data.entries.length });
+        assert('Telemetry logged POST /api/device/register', actions.some(a => a.includes('/api/device/register')));
+        assert('Telemetry logged POST /api/client/speak', actions.some(a => a.includes('/api/client/speak')));
+        assert('Telemetry logged POST /api/feedback', actions.some(a => a.includes('/api/feedback')));
+        const withDuration = telRes.data.entries.filter(e => e.duration != null && e.duration > 0);
+        assert('Telemetry entries include duration', withDuration.length > 0, { count: withDuration.length });
+    }
+
+    const logRes = await api('GET',
+        `/api/logs?deviceId=${TEST_DEVICE_ID}&deviceSecret=${TEST_DEVICE_SECRET}&limit=50`
+    );
+    assert('Server log API accessible', logRes.status === 200 && logRes.data.success, { status: logRes.status });
+}
+
+// ==============================
+// Main
+// ==============================
+
+async function main() {
+    console.log('='.repeat(60));
+    console.log('FEEDBACK + LOG SNAPSHOT INTEGRATION TEST');
+    console.log('='.repeat(60));
+    console.log(`API Base: ${API_BASE}`);
+    console.log(`Test Device: ${TEST_DEVICE_ID}\n`);
+
+    try {
+        await setup();
+        await testMark();
+        await testSubmitFeedback();
+        await testListFeedback();
+        await testGetFeedback();
+        await testAiPrompt();
+        await testUpdateFeedback();
+        await testErrorCases();
+        await testLogApiVerification();
+    } catch (e) {
+        console.error('\nFATAL:', e.message);
+        console.error(e.stack);
+    }
+
+    console.log(`\n${'='.repeat(60)}`);
+    console.log(`FEEDBACK TEST SUMMARY: ${passed} passed, ${failed} failed`);
+    console.log('='.repeat(60));
+
+    if (failed > 0) {
+        console.log(`\n${failed} assertion(s) FAILED`);
+        process.exit(1);
+    } else {
+        console.log('\nAll feedback integration tests passed');
+        process.exit(0);
+    }
+}
+
+main().catch(e => {
+    console.error('FATAL:', e);
+    process.exit(1);
+});


### PR DESCRIPTION
Integrates user feedback with the log/telemetry API to create AI-debuggable bug reports.

New module: backend/device-feedback.js
- captureLogSnapshot(): auto-captures last 5 min of telemetry + server logs
- captureDeviceState(): snapshots current device/entity state
- autoTriage(): scans logs for error patterns (403/429/500/timeout), auto-assigns severity and tags
- generateAiPrompt(): produces structured markdown prompt with API call history, server logs, device state, and fix instructions
- createGithubIssue(): auto-creates GitHub issue via API (when configured)
- Mark system: "mark now, report later" for intermittent bugs

Enhanced endpoints:
- POST /api/feedback (upgraded): auto log capture + triage + optional GitHub issue
- POST /api/feedback/mark: bookmark current moment for later feedback
- GET /api/feedback: list feedback with status/severity filters
- GET /api/feedback/:id: full record including log_snapshot
- GET /api/feedback/:id/ai-prompt: structured AI diagnostic prompt
- POST /api/feedback/:id/create-issue: manual GitHub issue creation
- PATCH /api/feedback/:id: update status/resolution

DB migration: adds category, severity, log_snapshot, device_state, status, tags, ai_diagnosis, resolution, github_issue_url, mark_ts columns to existing feedback table.

Portal: settings.html feedback dialog now shows category selector (Bug/Feature/Question), Mark button, and triage results after submit.

Test: test_feedback.js covers the full flow including mark → submit → list → get → ai-prompt → update → error cases.

https://claude.ai/code/session_012WGV3Y2ocztVGZV1vPkML3