### PR TITLE
fix: prevent entity cards from disappearing + improve logging for #16

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ When investigating backend bugs (broadcast failure, push not delivered, etc.):
 1. **Query server logs FIRST** via `GET /api/logs`
    - Requires `deviceId` + `deviceSecret` (ask user if not available)
    - Filters: `category`, `level` (info/warn/error), `since` (timestamp ms), `filterDevice`, `limit`
-   - Categories: `bind`, `unbind`, `transform`, `broadcast`, `broadcast_push`, `speakto_push`, `client_push`
+   - Categories: `bind`, `unbind`, `transform`, `broadcast`, `broadcast_push`, `speakto_push`, `client_push`, `entity_poll`
    - Example: `curl -s "https://eclaw.up.railway.app/api/logs?deviceId=DEVICE_ID&deviceSecret=DEVICE_SECRET&category=broadcast_push&limit=50"`
 
 2. **Check credentials**: Look in `backend/.env` (local only, gitignored). If not available, ask user for a valid deviceId+deviceSecret pair.

--- a/backend/device-telemetry.js
+++ b/backend/device-telemetry.js
@@ -391,6 +391,14 @@ function createMiddleware(pool, deviceLookup) {
                     if ('error' in data)   outputSummary.error = typeof data.error === 'string' ? data.error.substring(0, 200) : data.error;
                     if ('message' in data)  outputSummary.message = typeof data.message === 'string' ? data.message.substring(0, 200) : data.message;
                     if ('count' in data)   outputSummary.count = data.count;
+                    // Capture counts from entity/list responses (fixes logging blind spot for #16)
+                    if ('activeCount' in data) outputSummary.activeCount = data.activeCount;
+                    // Capture array lengths for any response containing lists
+                    for (const [k, v] of Object.entries(data)) {
+                        if (Array.isArray(v)) {
+                            outputSummary[k + 'Count'] = v.length;
+                        }
+                    }
                 }
                 outputSummary.status = res.statusCode;
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -1176,6 +1176,15 @@ app.get('/api/entities', (req, res) => {
         }
     }
 
+    // Log when a device-filtered request returns no entities but the device exists
+    // This helps diagnose transient empty responses that cause client-side card disappearing (#16)
+    if (filterDeviceId && entities.length === 0 && devices[filterDeviceId]) {
+        serverLog('warn', 'entity_poll', `Device ${filterDeviceId} returned 0 bound entities (device exists in memory)`, {
+            deviceId: filterDeviceId,
+            metadata: { totalDeviceSlots: MAX_ENTITIES_PER_DEVICE }
+        });
+    }
+
     res.json({
         entities: entities,
         activeCount: entities.length,


### PR DESCRIPTION
Root cause: The previous fix (b6dfa4f) only guarded edit mode, but
transient empty API responses (e.g. during server restart) could still
wipe entity cards in normal operation.

Client fix: Skip empty entity responses when cards were previously
showing. Log the anomaly via telemetry for future debugging.

Logging fixes:
- Telemetry middleware now captures activeCount and array lengths
  (previously only logged {status:200} with no entity count)
- Server logs entity_poll warnings when a known device gets 0 results
- Client tracks card visibility state changes in telemetry

https://claude.ai/code/session_01S6wQuWbsXC5mNVuV4QFL4j