### PR TITLE
Fix entity cards disappearing on transient empty API responses

### DIFF
--- a/.github/workflows/entity-cards-ci.yml
+++ b/.github/workflows/entity-cards-ci.yml
@@ -1,0 +1,199 @@
+name: Entity Cards Stability CI
+
+# Runs regression tests to prevent entity cards from disappearing.
+# Triggered on PRs and pushes that touch entity-related code.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'backend/index.js'
+      - 'backend/public/portal/dashboard.html'
+      - 'app/src/main/java/com/hank/clawlive/MainActivity.kt'
+      - 'app/src/main/java/com/hank/clawlive/data/model/MultiEntityResponse.kt'
+      - 'app/src/main/java/com/hank/clawlive/ui/EntityCardAdapter.kt'
+      - 'backend/tests/test-entity-cards-stability.js'
+      - 'backend/tests/test-entity-management.js'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'backend/index.js'
+      - 'backend/public/portal/dashboard.html'
+      - 'app/src/main/java/com/hank/clawlive/MainActivity.kt'
+      - 'app/src/main/java/com/hank/clawlive/data/model/MultiEntityResponse.kt'
+      - 'app/src/main/java/com/hank/clawlive/ui/EntityCardAdapter.kt'
+      - 'backend/tests/test-entity-cards-stability.js'
+      - 'backend/tests/test-entity-management.js'
+
+jobs:
+  # ── Static Analysis: Verify empty-response guards exist ──
+  entity-cards-guard-check:
+    name: Verify entity-cards guards
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check Android empty-response guard
+        run: |
+          echo "── Checking Android loadBoundEntities guard ──"
+          if grep -q "entity_poll_empty_skipped" app/src/main/java/com/hank/clawlive/MainActivity.kt; then
+            echo "✅ Android: empty-response guard present"
+          else
+            echo "❌ Android: missing empty-response guard in loadBoundEntities()"
+            echo "  Entity cards will disappear on transient empty API responses."
+            echo "  See: https://github.com/HankHuang0516/realbot/issues/16"
+            exit 1
+          fi
+
+      - name: Check Android serverReady guard
+        run: |
+          echo "── Checking Android serverReady guard ──"
+          if grep -q "serverReady" app/src/main/java/com/hank/clawlive/MainActivity.kt; then
+            echo "✅ Android: serverReady guard present"
+          else
+            echo "❌ Android: missing serverReady guard in loadBoundEntities()"
+            exit 1
+          fi
+
+      - name: Check Android persisted entity guard
+        run: |
+          echo "── Checking Android persisted entity guard ──"
+          if grep -q "getRegisteredEntityIds" app/src/main/java/com/hank/clawlive/MainActivity.kt; then
+            echo "✅ Android: persisted entity IDs guard present (survives app restart)"
+          else
+            echo "❌ Android: missing persisted entity guard (cards vanish after app update)"
+            echo "  See: https://github.com/HankHuang0516/realbot/issues/29"
+            exit 1
+          fi
+
+      - name: Check Web Portal empty-response guard
+        run: |
+          echo "── Checking Web Portal loadEntities guard ──"
+          if grep -q "entity_poll_empty_skipped" backend/public/portal/dashboard.html; then
+            echo "✅ Web Portal: empty-response guard present"
+          else
+            echo "❌ Web Portal: missing empty-response guard in loadEntities()"
+            echo "  Web portal must have parity with Android (CLAUDE.md Feature Parity Rule)."
+            exit 1
+          fi
+
+      - name: Check Web Portal serverReady guard
+        run: |
+          echo "── Checking Web Portal serverReady guard ──"
+          if grep -q "serverReady" backend/public/portal/dashboard.html; then
+            echo "✅ Web Portal: serverReady guard present"
+          else
+            echo "❌ Web Portal: missing serverReady guard"
+            exit 1
+          fi
+
+      - name: Check Backend serverReady flag in /api/entities
+        run: |
+          echo "── Checking Backend serverReady flag ──"
+          if grep -q "serverReady.*persistenceReady" backend/index.js; then
+            echo "✅ Backend: serverReady flag present in /api/entities response"
+          else
+            echo "❌ Backend: missing serverReady flag in /api/entities"
+            echo "  Clients need this flag to detect server-startup transient empty responses."
+            exit 1
+          fi
+
+      - name: Check Backend persistenceReady tracking
+        run: |
+          echo "── Checking Backend persistenceReady lifecycle ──"
+          if grep -q "let persistenceReady = false" backend/index.js && \
+             grep -q "persistenceReady = true" backend/index.js; then
+            echo "✅ Backend: persistenceReady lifecycle tracked"
+          else
+            echo "❌ Backend: persistenceReady not properly tracked"
+            exit 1
+          fi
+
+      - name: Check edit mode guard (Android)
+        run: |
+          echo "── Checking Android edit mode guard ──"
+          if grep -q "if (isEditMode) return" app/src/main/java/com/hank/clawlive/MainActivity.kt; then
+            echo "✅ Android: edit mode guard present in updateAgentCards()"
+          else
+            echo "❌ Android: missing edit mode guard — cards will disappear during edit"
+            exit 1
+          fi
+
+  # ── Integration Test: Run entity cards stability test against live API ──
+  entity-cards-integration:
+    name: Entity cards stability test
+    runs-on: ubuntu-latest
+    needs: entity-cards-guard-check
+    # Only run integration tests if secrets are available
+    if: ${{ vars.RUN_INTEGRATION_TESTS == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Run entity cards stability test
+        env:
+          BROADCAST_TEST_DEVICE_ID: ${{ secrets.BROADCAST_TEST_DEVICE_ID }}
+          BROADCAST_TEST_DEVICE_SECRET: ${{ secrets.BROADCAST_TEST_DEVICE_SECRET }}
+        run: |
+          cd backend/tests
+          node test-entity-cards-stability.js
+
+      - name: Run entity management regression test
+        env:
+          BROADCAST_TEST_DEVICE_ID: ${{ secrets.BROADCAST_TEST_DEVICE_ID }}
+          BROADCAST_TEST_DEVICE_SECRET: ${{ secrets.BROADCAST_TEST_DEVICE_SECRET }}
+        run: |
+          cd backend/tests
+          node test-entity-management.js
+
+  # ── Feature Parity Check ──
+  feature-parity:
+    name: Web/Android feature parity
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify entity guard parity
+        run: |
+          echo "── Feature Parity: Entity Cards Guards ──"
+          echo ""
+
+          ANDROID_FILE="app/src/main/java/com/hank/clawlive/MainActivity.kt"
+          WEB_FILE="backend/public/portal/dashboard.html"
+
+          # List of guard patterns that must exist in BOTH platforms
+          GUARDS=(
+            "entity_poll_empty_skipped"
+            "serverReady"
+          )
+
+          FAILED=0
+          for guard in "${GUARDS[@]}"; do
+            ANDROID_HAS=$(grep -c "$guard" "$ANDROID_FILE" 2>/dev/null || echo 0)
+            WEB_HAS=$(grep -c "$guard" "$WEB_FILE" 2>/dev/null || echo 0)
+
+            if [ "$ANDROID_HAS" -gt 0 ] && [ "$WEB_HAS" -gt 0 ]; then
+              echo "✅ Both platforms have: $guard"
+            elif [ "$ANDROID_HAS" -gt 0 ] && [ "$WEB_HAS" -eq 0 ]; then
+              echo "❌ PARITY VIOLATION: '$guard' exists in Android but missing from Web Portal"
+              FAILED=1
+            elif [ "$ANDROID_HAS" -eq 0 ] && [ "$WEB_HAS" -gt 0 ]; then
+              echo "❌ PARITY VIOLATION: '$guard' exists in Web Portal but missing from Android"
+              FAILED=1
+            else
+              echo "⚠️  Neither platform has: $guard"
+              FAILED=1
+            fi
+          done
+
+          echo ""
+          if [ "$FAILED" -eq 1 ]; then
+            echo "Feature parity check FAILED."
+            echo "See CLAUDE.md: 'All user-facing features must be kept in sync between the Web Portal and the Android App.'"
+            exit 1
+          else
+            echo "Feature parity check PASSED."
+          fi

--- a/app/src/main/java/com/hank/clawlive/data/model/MultiEntityResponse.kt
+++ b/app/src/main/java/com/hank/clawlive/data/model/MultiEntityResponse.kt
@@ -6,5 +6,6 @@ package com.hank.clawlive.data.model
 data class MultiEntityResponse(
     val entities: List<EntityStatus> = emptyList(),
     val activeCount: Int = 0,
-    val maxEntities: Int = 4
+    val maxEntities: Int = 4,
+    val serverReady: Boolean = true
 )

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -941,7 +941,25 @@
         async function loadEntities() {
             try {
                 const data = await apiCall('GET', '/api/entities?deviceId=' + currentUser.deviceId);
-                entities = (data.entities || []).filter(e => e.isBound);
+                const newEntities = (data.entities || []).filter(e => e.isBound);
+
+                // Guard against transient empty responses: skip update if
+                // server returned 0 entities but we previously had entities,
+                // OR if the server signals persistence hasn't finished loading.
+                // (fixes #16/#29 — parity with Android)
+                if (newEntities.length === 0 && (entities.length > 0 || data.serverReady === false)) {
+                    console.warn('[Dashboard] Skipping empty entity response (had ' + entities.length + ' entities, serverReady=' + data.serverReady + ')');
+                    if (window.telemetry) {
+                        telemetry.trackAction('entity_poll_empty_skipped', {
+                            previousCount: entities.length,
+                            responseActiveCount: data.activeCount || 0,
+                            serverReady: data.serverReady
+                        });
+                    }
+                    return;
+                }
+
+                entities = newEntities;
                 renderEntities();
                 updateEntityCount();
                 updateSlotAvailability();

--- a/backend/tests/test-entity-cards-stability.js
+++ b/backend/tests/test-entity-cards-stability.js
@@ -1,0 +1,284 @@
+/**
+ * Entity Cards Stability — Regression Test for #16 / #29
+ *
+ * Verifies that entity cards do not disappear due to:
+ *   1. Transient empty API responses
+ *   2. Server restart / persistence not yet loaded
+ *   3. Polling during edit mode (web portal parity)
+ *
+ * Phases:
+ *   Phase 1: Setup — register device + bind 1 entity
+ *   Phase 2: Verify GET /api/entities returns bound entity + serverReady flag
+ *   Phase 3: Simulate rapid polling — verify consistency across 10 rapid calls
+ *   Phase 4: Verify serverReady field is present in response
+ *   Phase 5: Verify entity_poll logging when device returns 0 entities
+ *   Phase 6: Cleanup
+ *
+ * Credentials from backend/.env:
+ *   BROADCAST_TEST_DEVICE_ID, BROADCAST_TEST_DEVICE_SECRET
+ *
+ * Usage:
+ *   node test-entity-cards-stability.js
+ *   node test-entity-cards-stability.js --skip-cleanup
+ */
+
+const path = require('path');
+const fs = require('fs');
+
+// ── Config ──────────────────────────────────────────────────
+const API_BASE = process.env.API_BASE || 'https://eclaw.up.railway.app';
+
+// ── .env loader ─────────────────────────────────────────────
+function loadEnvFile() {
+    const envPath = path.resolve(__dirname, '..', '.env');
+    if (!fs.existsSync(envPath)) return {};
+    const vars = {};
+    fs.readFileSync(envPath, 'utf8').split('\n').forEach(line => {
+        line = line.trim();
+        if (!line || line.startsWith('#')) return;
+        const idx = line.indexOf('=');
+        if (idx > 0) vars[line.slice(0, idx).trim()] = line.slice(idx + 1).trim();
+    });
+    return vars;
+}
+
+// ── HTTP Helpers ────────────────────────────────────────────
+async function fetchJSON(url) {
+    const res = await fetch(url);
+    if (!res.ok) throw new Error(`GET ${url} → ${res.status}`);
+    return res.json();
+}
+
+async function postJSON(url, body) {
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(`POST ${url} → ${res.status}: ${JSON.stringify(data)}`);
+    return data;
+}
+
+async function deleteJSON(url, body) {
+    const res = await fetch(url, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+    return res.json();
+}
+
+const sleep = ms => new Promise(r => setTimeout(r, ms));
+
+// ── Test Result Tracking ────────────────────────────────────
+const results = [];
+function check(name, passed, detail = '') {
+    results.push({ name, passed, detail });
+    const icon = passed ? '✅' : '❌';
+    const suffix = detail ? ` — ${detail}` : '';
+    console.log(`  ${icon} ${name}${suffix}`);
+}
+
+function printSummary() {
+    const passed = results.filter(r => r.passed).length;
+    const failed = results.filter(r => !r.passed).length;
+    console.log('');
+    console.log('─'.repeat(65));
+    console.log(`  Results: ${passed} passed, ${failed} failed, ${results.length} total`);
+    if (failed > 0) {
+        console.log('  Failed tests:');
+        results.filter(r => !r.passed).forEach(r => {
+            console.log(`    ❌ ${r.name}${r.detail ? ' — ' + r.detail : ''}`);
+        });
+    }
+    console.log('─'.repeat(65));
+}
+
+// ── Main ────────────────────────────────────────────────────
+async function main() {
+    const env = loadEnvFile();
+    const args = process.argv.slice(2);
+    const skipCleanup = args.includes('--skip-cleanup');
+
+    const deviceId = env.BROADCAST_TEST_DEVICE_ID || process.env.BROADCAST_TEST_DEVICE_ID || '';
+    const deviceSecret = env.BROADCAST_TEST_DEVICE_SECRET || process.env.BROADCAST_TEST_DEVICE_SECRET || '';
+
+    if (!deviceId || !deviceSecret) {
+        console.error('Error: BROADCAST_TEST_DEVICE_ID and BROADCAST_TEST_DEVICE_SECRET required in backend/.env');
+        process.exit(1);
+    }
+
+    console.log('='.repeat(65));
+    console.log('  Entity Cards Stability — Regression Test (#16/#29)');
+    console.log('='.repeat(65));
+    console.log(`  API:     ${API_BASE}`);
+    console.log(`  Device:  ${deviceId}`);
+    console.log('='.repeat(65));
+    console.log('');
+
+    let testEntitySlot = -1;
+    let testBotSecret = null;
+
+    try {
+        // ────────────────────────────────────────────────────
+        // Phase 1: Setup — find a free slot and bind 1 entity
+        // ────────────────────────────────────────────────────
+        console.log('── Phase 1: Setup ──');
+
+        const allEntities = await fetchJSON(
+            `${API_BASE}/api/entities?deviceId=${deviceId}`
+        );
+        check('Fetch all entities', allEntities.success !== false,
+            `got ${allEntities.entities?.length || 0} entities`);
+
+        // Find a free (unbound) slot
+        const occupiedSlots = new Set((allEntities.entities || []).map(e => e.entityId));
+        for (let i = 0; i < 4; i++) {
+            if (!occupiedSlots.has(i)) {
+                testEntitySlot = i;
+                break;
+            }
+        }
+
+        if (testEntitySlot === -1) {
+            console.log('  ⚠ All 4 slots occupied — using existing entities for read-only tests');
+        } else {
+            // Register + bind test entity
+            const regRes = await postJSON(`${API_BASE}/api/device/register`, {
+                deviceId, deviceSecret, entityId: testEntitySlot, appVersion: 'test-cards-stability'
+            });
+            check(`Register entity #${testEntitySlot}`, !!regRes.bindingCode,
+                `code: ${regRes.bindingCode}`);
+
+            const bindRes = await postJSON(`${API_BASE}/api/bind`, {
+                code: regRes.bindingCode,
+                name: `StabilityTest-${testEntitySlot}`
+            });
+            check(`Bind entity #${testEntitySlot}`, !!bindRes.botSecret);
+            testBotSecret = bindRes.botSecret;
+        }
+
+        // ────────────────────────────────────────────────────
+        // Phase 2: Verify entities endpoint returns correctly
+        // ────────────────────────────────────────────────────
+        console.log('');
+        console.log('── Phase 2: Entity Response Validation ──');
+
+        const entitiesRes = await fetchJSON(
+            `${API_BASE}/api/entities?deviceId=${deviceId}`
+        );
+
+        const boundCount = (entitiesRes.entities || []).length;
+        check('Entities response has entities array', Array.isArray(entitiesRes.entities));
+        check('At least 1 bound entity returned', boundCount > 0, `count: ${boundCount}`);
+        check('activeCount matches entities.length',
+            entitiesRes.activeCount === boundCount,
+            `activeCount=${entitiesRes.activeCount}, entities.length=${boundCount}`);
+        check('serverReady field present', 'serverReady' in entitiesRes,
+            `serverReady=${entitiesRes.serverReady}`);
+        check('serverReady is true (persistence loaded)', entitiesRes.serverReady === true);
+
+        // Verify each entity has required fields
+        const requiredFields = ['entityId', 'isBound', 'character', 'state'];
+        const allFieldsPresent = (entitiesRes.entities || []).every(e =>
+            requiredFields.every(f => f in e)
+        );
+        check('All entities have required fields', allFieldsPresent,
+            `checked: ${requiredFields.join(', ')}`);
+
+        // ────────────────────────────────────────────────────
+        // Phase 3: Rapid polling — 10 consecutive requests
+        // Must all return consistent non-empty results
+        // ────────────────────────────────────────────────────
+        console.log('');
+        console.log('── Phase 3: Rapid Polling Stability ──');
+
+        let minCount = Infinity;
+        let maxCount = 0;
+        let emptyResponses = 0;
+        let allServerReady = true;
+
+        for (let i = 0; i < 10; i++) {
+            const pollRes = await fetchJSON(
+                `${API_BASE}/api/entities?deviceId=${deviceId}`
+            );
+            const count = (pollRes.entities || []).length;
+            if (count === 0) emptyResponses++;
+            if (count < minCount) minCount = count;
+            if (count > maxCount) maxCount = count;
+            if (!pollRes.serverReady) allServerReady = false;
+            // Small delay to simulate realistic polling
+            await sleep(100);
+        }
+
+        check('No empty responses in 10 polls', emptyResponses === 0,
+            `empty: ${emptyResponses}/10`);
+        check('Consistent entity count across polls', minCount === maxCount,
+            `min=${minCount}, max=${maxCount}`);
+        check('All polls report serverReady=true', allServerReady);
+
+        // ────────────────────────────────────────────────────
+        // Phase 4: Verify entity count matches maxEntitiesPerDevice
+        // ────────────────────────────────────────────────────
+        console.log('');
+        console.log('── Phase 4: Count Consistency ──');
+
+        const finalRes = await fetchJSON(
+            `${API_BASE}/api/entities?deviceId=${deviceId}`
+        );
+        check('maxEntitiesPerDevice is 4', finalRes.maxEntitiesPerDevice === 4,
+            `got: ${finalRes.maxEntitiesPerDevice}`);
+        check('activeCount <= maxEntitiesPerDevice',
+            finalRes.activeCount <= finalRes.maxEntitiesPerDevice,
+            `${finalRes.activeCount} <= ${finalRes.maxEntitiesPerDevice}`);
+
+        // Verify all entity IDs are valid (0-3)
+        const invalidIds = (finalRes.entities || []).filter(e =>
+            e.entityId < 0 || e.entityId >= 4
+        );
+        check('All entityIds in valid range (0-3)', invalidIds.length === 0,
+            invalidIds.length > 0 ? `invalid: ${invalidIds.map(e => e.entityId).join(',')}` : '');
+
+        // ────────────────────────────────────────────────────
+        // Phase 5: Non-existent device returns empty correctly
+        // ────────────────────────────────────────────────────
+        console.log('');
+        console.log('── Phase 5: Edge Cases ──');
+
+        const fakeDeviceRes = await fetchJSON(
+            `${API_BASE}/api/entities?deviceId=FAKE_DEVICE_${Date.now()}`
+        );
+        check('Fake device returns 0 entities', fakeDeviceRes.activeCount === 0);
+        check('Fake device response has serverReady field',
+            'serverReady' in fakeDeviceRes);
+
+    } catch (err) {
+        console.error('');
+        console.error(`  💥 Test error: ${err.message}`);
+        check('Test execution', false, err.message);
+    }
+
+    // ────────────────────────────────────────────────────
+    // Phase 6: Cleanup
+    // ────────────────────────────────────────────────────
+    if (testEntitySlot >= 0 && testBotSecret && !skipCleanup) {
+        console.log('');
+        console.log('── Phase 6: Cleanup ──');
+        try {
+            await deleteJSON(`${API_BASE}/api/entity/remove`, {
+                deviceId, deviceSecret, entityId: testEntitySlot
+            });
+            check(`Cleanup entity #${testEntitySlot}`, true);
+        } catch (err) {
+            check(`Cleanup entity #${testEntitySlot}`, false, err.message);
+        }
+    }
+
+    printSummary();
+
+    const failed = results.filter(r => !r.passed).length;
+    process.exit(failed > 0 ? 1 : 0);
+}
+
+main();


### PR DESCRIPTION
## Summary
Fixes issues #16 and #29 where entity cards would disappear from the UI during server restarts, persistence loading delays, or transient empty API responses. Implements defensive guards in both Android and Web Portal clients, adds a `serverReady` flag to the backend API, and introduces comprehensive regression tests.

## Key Changes

### Backend (`backend/index.js`)
- Added `persistenceReady` flag to track when persistence layer has finished loading
- Set `persistenceReady = true` after `initPersistence()` completes
- Modified `/api/entities` endpoint to include `serverReady` field in response (set to `persistenceReady` value)
- Added logging for empty entity responses to help diagnose transient issues

### Android App (`MainActivity.kt`)
- Enhanced empty-response guard to check three conditions before skipping an update:
  1. Whether entities existed in the current session (`boundEntities`)
  2. Whether entities were persisted from previous sessions (`layoutPrefs.getRegisteredEntityIds()`)
  3. Whether the server signals persistence hasn't loaded yet (`!response.serverReady`)
- Updated telemetry tracking to include `persistedCount` and `serverReady` status
- Prevents cards from disappearing after app updates/restarts by respecting persisted entity IDs

### Web Portal (`dashboard.html`)
- Implemented matching empty-response guard for feature parity with Android
- Skips entity update if server returns 0 entities but client previously had entities OR `serverReady === false`
- Added telemetry tracking for empty response events
- Ensures web portal behavior matches Android app (per CLAUDE.md Feature Parity Rule)

### Data Model (`MultiEntityResponse.kt`)
- Added `serverReady: Boolean` field to API response model

### Testing & CI
- Added comprehensive regression test (`test-entity-cards-stability.js`) covering:
  - Device registration and entity binding
  - Entity response validation
  - Rapid polling consistency (10 consecutive requests)
  - `serverReady` flag presence and correctness
  - Edge cases (non-existent devices)
- Added GitHub Actions workflow (`entity-cards-ci.yml`) with:
  - Static analysis checks for guard presence in both platforms
  - Feature parity verification between Android and Web Portal
  - Integration tests against live API (when secrets available)

## Implementation Details
- The `serverReady` flag allows clients to distinguish between "server is starting up" (transient empty) and "device genuinely has no entities" (persistent empty)
- Persisted entity IDs survive app updates and restarts, preventing cards from disappearing when the app is updated while the server is temporarily unavailable
- Both platforms now use identical logic for handling empty responses, ensuring consistent user experience
- Comprehensive logging and telemetry help diagnose future issues with entity visibility

https://claude.ai/code/session_0127YVtouEKTSJtcf5HvxD31