### PR TITLE
Exclude test devices from admin statistics and bindings

### DIFF
--- a/backend/public/portal/admin.html
+++ b/backend/public/portal/admin.html
@@ -579,21 +579,19 @@
             html += '<table class="data-table">';
             html += '<thead><tr><th>' + i18n.t('admin_col_source') + '</th><th>' + i18n.t('admin_col_email') + '</th><th>' + i18n.t('admin_col_verified') + '</th><th>' + i18n.t('admin_col_sub') + '</th><th>' + i18n.t('admin_col_role') + '</th><th>' + i18n.t('admin_col_device') + '</th><th>' + i18n.t('admin_col_registered') + '</th><th>' + i18n.t('admin_col_last_login') + '</th></tr></thead>';
             html += '<tbody>';
-            if (allUsers.length > 0) {
-                for (const u of allUsers) {
+            if (realUsers.length > 0) {
+                for (const u of realUsers) {
                     const subCls = u.subscriptionStatus === 'premium' ? 'type-premium' :
                         u.subscriptionStatus === 'expired' ? 'type-expired' : '';
                     const isApp = u.source === 'app_device';
-                    const testBadge = u.isTestDevice ? ' <span class="type-badge" style="background:rgba(255,152,0,0.2);color:#FF9800;font-size:10px;">TEST</span>' : '';
                     const sourceBadge = isApp
                         ? '<span class="type-badge" style="background:rgba(33,150,243,0.2);color:#2196F3;">APP</span>'
                         : '<span class="type-badge type-active">' + i18n.t('admin_source_web') + '</span>';
                     const emailDisplay = isApp
                         ? '<span style="color:var(--text-secondary);font-style:italic;">(' + i18n.t('admin_app_only') + ')</span>'
                         : escapeHtml(u.email);
-                    const rowStyle = u.isTestDevice ? ' style="opacity:0.5;"' : '';
-                    html += '<tr' + rowStyle + '>' +
-                        '<td>' + sourceBadge + testBadge + '</td>' +
+                    html += '<tr>' +
+                        '<td>' + sourceBadge + '</td>' +
                         '<td>' + emailDisplay + '</td>' +
                         '<td>' + (isApp ? '-' : (u.emailVerified ? '<span style="color:var(--success)">Yes</span>' : '<span style="color:var(--text-muted)">No</span>')) + '</td>' +
                         '<td><span class="type-badge ' + subCls + '">' + escapeHtml(u.subscriptionStatus) + '</span></td>' +


### PR DESCRIPTION
## Summary
This PR filters out test devices from admin dashboard statistics and bindings views to provide more accurate metrics of production usage.

## Key Changes
- **Admin Stats Endpoint**: Modified device counting logic to exclude test devices using `isTestDeviceCheck()` function
  - Changed from simple `Object.keys(devices).length` to iterating through devices and skipping test devices
  - Ensures device total, entity total, and bound entity counts only reflect production devices

- **Admin Bindings Endpoint**: Added filtering to exclude test device bindings from the response
  - Extracted binding transformation logic for reusability
  - Applied `isTestDeviceCheck()` filter to remove test device bindings before returning results

- **Admin Users Endpoint**: Simplified test device check logic
  - Removed unnecessary ternary operator that could return false when device is null
  - Now consistently calls `isTestDeviceCheck()` for all users

- **Admin Portal UI**: Removed test device indicators from user table
  - Removed "TEST" badge display for test devices
  - Removed row opacity styling that visually distinguished test devices
  - Changed from `allUsers` to `realUsers` variable (implying pre-filtered data)

## Implementation Details
The changes leverage the existing `isTestDeviceCheck()` function to consistently identify and exclude test devices across all admin views. This ensures that admin statistics accurately reflect production metrics without test/development device noise.

https://claude.ai/code/session_01RXm5DmuqpXY2nfdZMDeNCD