### PR TITLE
Add broadcast deduplication and increase bot file size limits

### DIFF
--- a/backend/public/portal/feedback.html
+++ b/backend/public/portal/feedback.html
@@ -723,7 +723,7 @@
         let allFeedback = [];
         let currentFilter = 'all';
         let feedbackCategory = 'bug';
-        let currentUser = null;
+        // currentUser is declared in shared/auth.js
         let selectedPhotos = []; // File objects selected for upload
 
         window.addEventListener('DOMContentLoaded', async () => {


### PR DESCRIPTION
## Summary
This PR implements broadcast message deduplication to prevent bots from re-broadcasting recently received content, increases the maximum bot file size limit from 64KB to 15MB, and improves bot-to-bot loop prevention messaging.

## Key Changes

- **Broadcast Deduplication**: Added a `recentBroadcasts` cache that tracks recently broadcast messages per device within a 60-second window. When a bot attempts to broadcast content that matches a recent broadcast from another entity, the broadcast is suppressed and returns a success response with `deduplicated: true` flag.

- **Bot-to-Bot Counter Reset**: Modified `resetBotToBotCounter()` to also clear the broadcast dedup cache for a device when human intervention resets the counter, allowing fresh broadcasts after human messages.

- **Enhanced Bot Instructions**: Updated the bot-to-bot broadcast notification message to explicitly instruct bots NOT to re-broadcast similar content and to prefer using speak-to for direct replies instead.

- **File Size Limit Increase**: Increased `BOT_FILE_MAX_SIZE` from 64KB to 15MB per file to support larger bot-managed files. Updated the `/api/bot/file` endpoint to use `express.json({ limit: '20mb' })` middleware to handle larger request payloads.

- **Code Cleanup**: Removed redundant `currentUser` variable declaration in feedback.html (now sourced from shared/auth.js).

## Implementation Details

- Broadcast deduplication normalizes text by trimming and limiting to 200 characters to catch similar content variations
- The dedup window is 60 seconds, allowing time for human intervention while preventing rapid bot-to-bot message loops
- Deduplication is device-scoped to prevent cross-device interference
- File upload limit increased to 20MB to accommodate the new 15MB per-file limit with overhead

https://claude.ai/code/session_01Q3FAi2U7xRZP8J7YUoQecj