### PR TITLE
Refactor feedback section UI from card layout to button-based design

### DIFF
--- a/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
@@ -50,7 +50,7 @@ class SettingsActivity : AppCompatActivity() {
     private lateinit var tvEntityCount: TextView
     private lateinit var progressUsage: ProgressBar
     private lateinit var btnSubscribe: MaterialButton
-    private lateinit var btnFeedback: LinearLayout
+    private lateinit var btnFeedback: MaterialButton
     private lateinit var btnMarkBug: MaterialButton
     private lateinit var tvMarkStatus: TextView
     private lateinit var btnPrivacyPolicy: MaterialButton

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -197,95 +197,65 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
-            <!-- Feedback Card (dark theme matching app style) -->
-            <com.google.android.material.card.MaterialCardView
+            <!-- Feedback Button -->
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnFeedback"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="4dp"
-                app:cardCornerRadius="12dp"
-                app:cardElevation="2dp"
-                app:cardBackgroundColor="#1A1A1A"
+                android:text="@string/feedback"
+                android:textColor="#CCFFFFFF"
+                app:backgroundTint="#1A1A1A"
+                app:cornerRadius="12dp"
                 app:strokeColor="#333333"
-                app:strokeWidth="1dp">
+                app:strokeWidth="1dp"
+                style="@style/Widget.Material3.Button.TonalButton"/>
 
-                <LinearLayout
-                    android:layout_width="match_parent"
+            <!-- Feedback sub-actions row -->
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center_vertical"
+                android:paddingHorizontal="4dp"
+                android:layout_marginTop="-4dp"
+                android:layout_marginBottom="4dp">
+
+                <com.google.android.material.button.MaterialButton
+                    android:id="@+id/btnMarkBug"
+                    android:layout_width="wrap_content"
+                    android:layout_height="36dp"
+                    android:text="@string/feedback_mark"
+                    android:textSize="13sp"
+                    android:textColor="#CCFFFFFF"
+                    android:minWidth="0dp"
+                    android:paddingHorizontal="14dp"
+                    app:backgroundTint="#1A1A1A"
+                    app:cornerRadius="8dp"
+                    app:strokeColor="#333333"
+                    app:strokeWidth="1dp"
+                    style="@style/Widget.Material3.Button.TonalButton"/>
+
+                <TextView
+                    android:id="@+id/tvViewFeedbackHistory"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical"
-                    android:padding="16dp">
+                    android:text="@string/feedback_view_history"
+                    android:textSize="13sp"
+                    android:textColor="#FFD23F"
+                    android:layout_marginStart="8dp"
+                    android:paddingVertical="4dp"/>
 
-                    <LinearLayout
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:orientation="horizontal"
-                        android:gravity="center_vertical">
+                <TextView
+                    android:id="@+id/tvMarkStatus"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_weight="1"
+                    android:gravity="end"
+                    android:textSize="12sp"
+                    android:textColor="#FFD23F"
+                    android:visibility="gone"/>
 
-                        <LinearLayout
-                            android:id="@+id/btnFeedback"
-                            android:layout_width="0dp"
-                            android:layout_height="wrap_content"
-                            android:layout_weight="1"
-                            android:orientation="vertical">
-
-                            <TextView
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/feedback"
-                                android:textSize="16sp"
-                                android:textStyle="bold"
-                                android:textColor="@android:color/white"/>
-
-                            <TextView
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"
-                                android:text="@string/feedback_desc"
-                                android:textSize="13sp"
-                                android:textColor="#99FFFFFF"
-                                android:layout_marginTop="2dp"/>
-
-                        </LinearLayout>
-
-                        <com.google.android.material.button.MaterialButton
-                            android:id="@+id/btnMarkBug"
-                            android:layout_width="wrap_content"
-                            android:layout_height="36dp"
-                            android:text="@string/feedback_mark"
-                            android:textSize="13sp"
-                            android:textColor="@android:color/white"
-                            android:minWidth="0dp"
-                            android:paddingHorizontal="14dp"
-                            app:backgroundTint="#2A2A2A"
-                            app:cornerRadius="8dp"
-                            app:strokeColor="#444444"
-                            app:strokeWidth="1dp"
-                            style="@style/Widget.Material3.Button.TonalButton"/>
-
-                    </LinearLayout>
-
-                    <!-- Mark status text (shown after marking) -->
-                    <TextView
-                        android:id="@+id/tvMarkStatus"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:textSize="12sp"
-                        android:textColor="#FFD23F"
-                        android:visibility="gone"
-                        android:layout_marginTop="8dp"/>
-
-                    <!-- View History link -->
-                    <TextView
-                        android:id="@+id/tvViewFeedbackHistory"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:text="@string/feedback_view_history"
-                        android:textSize="13sp"
-                        android:textColor="#FFD23F"
-                        android:layout_marginTop="10dp"
-                        android:paddingVertical="4dp"/>
-
-                </LinearLayout>
-
-            </com.google.android.material.card.MaterialCardView>
+            </LinearLayout>
 
             <!-- Privacy Policy Button -->
             <com.google.android.material.button.MaterialButton


### PR DESCRIPTION
## Summary
Refactored the feedback section in the settings screen from a MaterialCardView-based layout to a cleaner button-based design with improved visual hierarchy and spacing.

## Key Changes
- **Replaced MaterialCardView with MaterialButton**: The main feedback container is now a MaterialButton instead of a card view, providing a more consistent interaction pattern
- **Simplified layout structure**: Removed nested LinearLayouts and consolidated the feedback UI into a more straightforward hierarchy
- **Reorganized sub-actions**: Moved the "Mark Bug" button and "View History" link into a horizontal LinearLayout below the main feedback button
- **Updated color scheme**: Adjusted background tint from `#2A2A2A` to `#1A1A1A` and stroke color from `#444444` to `#333333` for better visual consistency
- **Improved text styling**: Changed text color to `#CCFFFFFF` for better contrast and consistency with the new design
- **Updated Kotlin binding**: Changed `btnFeedback` from `LinearLayout` to `MaterialButton` type to match the new XML structure

## Implementation Details
- The feedback button now uses Material3's TonalButton style for consistency with other buttons in the settings screen
- The status message and history link are positioned in a horizontal layout with proper spacing and alignment
- The mark status TextView now uses `layout_weight="1"` with `gravity="end"` to align to the right side of the sub-actions row
- Negative margin (`layout_marginTop="-4dp"`) creates visual connection between the main button and sub-actions row

https://claude.ai/code/session_01BhAj9Lj4u7KbkR5TJYEMW5