### PR TITLE
Add email binding and account login for device credential recovery

### DIFF
--- a/app/src/main/java/com/hank/clawlive/data/local/DeviceManager.kt
+++ b/app/src/main/java/com/hank/clawlive/data/local/DeviceManager.kt
@@ -105,6 +105,20 @@ class DeviceManager private constructor(context: Context) {
         set(value) = prefs.edit().putLong(KEY_BINDING_EXPIRY, value).apply()
 
     /**
+     * Overwrite device credentials with values recovered from account login.
+     * Used when user logs in with email/password to restore their old device.
+     */
+    fun setCredentials(newDeviceId: String, newDeviceSecret: String) {
+        prefs.edit()
+            .putString(KEY_DEVICE_ID, newDeviceId)
+            .putString(KEY_DEVICE_SECRET, newDeviceSecret)
+            .remove(KEY_IS_BOUND)
+            .remove(KEY_BINDING_CODE)
+            .remove(KEY_BINDING_EXPIRY)
+            .apply()
+    }
+
+    /**
      * Reset device credentials (for re-binding)
      */
     fun reset() {

--- a/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
@@ -229,6 +229,9 @@ interface ClawApiService {
         @Query("deviceSecret") deviceSecret: String
     ): BindEmailStatusResponse
 
+    @POST("api/auth/app-login")
+    suspend fun appLogin(@Body body: Map<String, String>): AppLoginResponse
+
     // ============================================
     // SCHEDULE
     // ============================================
@@ -373,5 +376,13 @@ data class BindEmailStatusResponse(
     val bound: Boolean = false,
     val email: String? = null,
     val emailVerified: Boolean = false,
+    val error: String? = null
+)
+
+data class AppLoginResponse(
+    val success: Boolean,
+    val deviceId: String? = null,
+    val deviceSecret: String? = null,
+    val email: String? = null,
     val error: String? = null
 )

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -310,9 +310,25 @@
                 android:text="@string/web_portal"
                 android:textColor="#CCFFFFFF"
                 app:backgroundTint="#1A1A1A"
-                android:layout_marginBottom="24dp"
+                android:layout_marginBottom="8dp"
                 app:cornerRadius="12dp"
                 app:icon="@android:drawable/ic_menu_share"
+                app:iconTint="#CCFFFFFF"
+                app:strokeColor="#333333"
+                app:strokeWidth="1dp"
+                style="@style/Widget.Material3.Button.TonalButton"/>
+
+            <!-- Account Login Button -->
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnAccountLogin"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/account_login"
+                android:textColor="#CCFFFFFF"
+                app:backgroundTint="#1A1A1A"
+                android:layout_marginBottom="24dp"
+                app:cornerRadius="12dp"
+                app:icon="@android:drawable/ic_lock_idle_lock"
                 app:iconTint="#CCFFFFFF"
                 app:strokeColor="#333333"
                 app:strokeWidth="1dp"

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -219,6 +219,15 @@
     <string name="bind_email_open_portal">開啟網頁入口</string>
     <string name="bind_email_copy_credentials">複製裝置憑證</string>
 
+    <!-- Account Login -->
+    <string name="account_login">帳號登入</string>
+    <string name="account_login_hint">使用已綁定的信箱登入，可在重新安裝後恢復裝置資料。</string>
+    <string name="account_login_btn">登入</string>
+    <string name="account_login_logging_in">登入中…</string>
+    <string name="account_login_success_title">登入成功</string>
+    <string name="account_login_success_msg">帳號已恢復：%s\nApp 將重新啟動以載入您的資料。</string>
+    <string name="account_login_restart">立即重啟</string>
+
     <!-- Privacy Policy -->
     <string name="privacy_policy_title">隱私權政策</string>
     <string name="web_portal">網頁入口</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -287,6 +287,15 @@
     <string name="bind_email_open_portal">Open Portal</string>
     <string name="bind_email_copy_credentials">Copy Credentials</string>
 
+    <!-- Account Login -->
+    <string name="account_login">Account Login</string>
+    <string name="account_login_hint">Log in with your bound email to restore your device data after reinstalling.</string>
+    <string name="account_login_btn">Login</string>
+    <string name="account_login_logging_in">Logging in…</string>
+    <string name="account_login_success_title">Login Successful</string>
+    <string name="account_login_success_msg">Account restored: %s\nThe app will restart to load your data.</string>
+    <string name="account_login_restart">Restart Now</string>
+
     <!-- Privacy Policy -->
     <string name="privacy_policy_title">Privacy Policy</string>
     <string name="web_portal">Web Portal</string>


### PR DESCRIPTION
## Summary
This PR adds email/password account binding functionality to the Android app and corresponding backend endpoints, allowing users to link their device to an email account and recover device credentials after reinstalling the app.

## Key Changes

### Backend (Node.js)
- **POST `/api/auth/bind-email`**: New endpoint for Android users to bind their device to an email/password account
  - Validates device credentials, email format, and password strength (min 6 chars with letters and numbers)
  - Prevents duplicate device bindings and email registrations
  - Sends verification email with 24-hour expiration token
  - Stores hashed password and device credentials in database

- **GET `/api/auth/bind-email/status`**: New endpoint to check if a device has a linked email account
  - Returns bound status, email, and verification state
  - Used by Android app to determine which dialog to show

- **POST `/api/auth/app-login`**: New endpoint for credential recovery via email/password login
  - Authenticates user and verifies email before returning device credentials
  - Updates last login timestamp
  - Ensures virtual device exists in memory

### Android App (Kotlin)
- **SettingsActivity**: 
  - Added new "Account Login" button to settings
  - Enhanced web portal dialog to check binding status and show appropriate UI:
    - Bound state: Shows linked email with verification status and login hint
    - Unbound state: Prompts user to bind email or use device credentials
  - New `showBindEmailDialog()`: Form to bind email/password with validation
    - Email format validation
    - Password strength validation (6+ chars, letters + numbers)
    - Password confirmation matching
    - Shows loading state during submission
    - Sends verification email on success

  - New `showAccountLoginDialog()`: Form to recover device credentials
    - Email/password login with validation
    - Overwrites local device credentials on success
    - Prompts app restart to load recovered data
    - Error handling with user-friendly messages

- **ClawApiService**: Added three new API endpoints
  - `bindEmail()`, `getBindEmailStatus()`, `appLogin()`
  - New response data classes: `BindEmailResponse`, `BindEmailStatusResponse`, `AppLoginResponse`

- **DeviceManager**: 
  - New `setCredentials()` method to overwrite device ID/secret from account login
  - Clears binding state when credentials are recovered

### Localization
- Added 32 new string resources in English and Traditional Chinese for:
  - Email binding UI (title, labels, hints, validation messages)
  - Account login UI (title, button text, success messages)

### UI Layout
- Added "Account Login" button to settings activity layout
- Positioned below "Web Portal" button with consistent styling

## Implementation Details
- Uses Material Design TextInputLayout with password toggle for secure input
- Implements proper error handling with Retrofit exception parsing
- Tracks user actions via TelemetryHelper for analytics
- Uses Timber for logging
- Graceful fallback to unbound dialog if binding status check fails
- App restart mechanism to reload credentials after account login

https://claude.ai/code/session_019muxM3sGym6NQbtnF518Ag