### PR TITLE
Allow all external execution permissions for Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,18 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash",
+      "Read",
+      "Edit",
+      "Write",
+      "WebFetch",
+      "Glob",
+      "Grep",
+      "Skill",
+      "Agent",
+      "NotebookEdit",
+      "WebSearch",
+      "TodoWrite"
+    ]
+  }
+}


### PR DESCRIPTION
Added .claude/settings.json with all tool permissions enabled,
so Claude Code can execute tools without per-action prompts.

https://claude.ai/code/session_01HSraQszExxe3MP8VoFdXgC