### PR TITLE
fix: persist language preference to server for cross-device sync

### DIFF
--- a/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
@@ -355,6 +355,8 @@ class SettingsActivity : AppCompatActivity() {
                 val current = AppCompatDelegate.getApplicationLocales()
                 if (current.toLanguageTags() != localeList.toLanguageTags()) {
                     AppCompatDelegate.setApplicationLocales(localeList)
+                    // Sync language to server for cross-device persistence
+                    syncLanguageToServer(tag)
                 }
             }
         }
@@ -377,6 +379,29 @@ class SettingsActivity : AppCompatActivity() {
             tag.contains("vi") -> chipLangVi.isChecked = true
             tag.contains("in") || tag.contains("id") -> chipLangId.isChecked = true
             else -> chipLangEn.isChecked = true
+        }
+    }
+
+    private fun syncLanguageToServer(localeTag: String) {
+        val deviceId = DeviceManager.getDeviceId(this) ?: return
+        val deviceSecret = DeviceManager.getDeviceSecret(this) ?: return
+        // Map Android locale tags to server language codes
+        val serverLang = when (localeTag) {
+            "zh-TW" -> "zh"
+            "zh-CN" -> "zh-CN"
+            "in" -> "id"
+            else -> localeTag
+        }
+        lifecycleScope.launch {
+            try {
+                NetworkModule.api.updateLanguage(mapOf(
+                    "deviceId" to deviceId,
+                    "deviceSecret" to deviceSecret,
+                    "language" to serverLang
+                ))
+            } catch (e: Exception) {
+                Timber.w(e, "Failed to sync language to server")
+            }
         }
     }
 
@@ -820,6 +845,18 @@ class SettingsActivity : AppCompatActivity() {
                     if (response.success && response.deviceId != null && response.deviceSecret != null) {
                         // Overwrite local credentials with recovered ones
                         deviceManager.setCredentials(response.deviceId, response.deviceSecret)
+                        // Restore language preference from server
+                        response.language?.let { lang ->
+                            val localeTag = when (lang) {
+                                "zh" -> "zh-TW"
+                                "zh-CN" -> "zh-CN"
+                                "id" -> "in"
+                                else -> lang
+                            }
+                            AppCompatDelegate.setApplicationLocales(
+                                LocaleListCompat.forLanguageTags(localeTag)
+                            )
+                        }
                         dialog.dismiss()
                         TelemetryHelper.trackAction("account_login_success")
 

--- a/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
@@ -272,6 +272,9 @@ interface ClawApiService {
     @POST("api/auth/app-login")
     suspend fun appLogin(@Body body: Map<String, String>): AppLoginResponse
 
+    @PATCH("api/auth/language")
+    suspend fun updateLanguage(@Body body: Map<String, String>): ApiResponse
+
     // ============================================
     // NOTIFICATIONS
     // ============================================
@@ -592,6 +595,7 @@ data class BindEmailStatusResponse(
     val googleLinked: Boolean = false,
     val facebookLinked: Boolean = false,
     val displayName: String? = null,
+    val language: String? = null,
     val channelApiKey: String? = null,
     val channelApiSecret: String? = null,
     val error: String? = null
@@ -602,6 +606,7 @@ data class AppLoginResponse(
     val deviceId: String? = null,
     val deviceSecret: String? = null,
     val email: String? = null,
+    val language: String? = null,
     val error: String? = null
 )
 

--- a/backend/auth.js
+++ b/backend/auth.js
@@ -386,6 +386,7 @@ module.exports = function(devices, getOrCreateDevice) {
                     id: user.id,
                     email: user.email,
                     deviceId: user.device_id,
+                    language: user.language,
                     subscriptionStatus: user.subscription_status
                 };
             } else {
@@ -395,6 +396,7 @@ module.exports = function(devices, getOrCreateDevice) {
                     id: null,
                     email: null,
                     deviceId: deviceId,
+                    language: 'en',
                     subscriptionStatus: 'free'
                 };
             }
@@ -679,6 +681,54 @@ module.exports = function(devices, getOrCreateDevice) {
     });
 
     // ============================================
+    // PATCH /language (update user language preference)
+    // ============================================
+    router.patch('/language', async (req, res) => {
+        try {
+            const { language, deviceId, deviceSecret } = req.body;
+            const validLangs = ['en', 'zh', 'zh-CN', 'ja', 'ko', 'th', 'vi', 'id'];
+            if (!language || !validLangs.includes(language)) {
+                return res.status(400).json({ success: false, error: 'Invalid language' });
+            }
+
+            // Support both cookie auth and deviceId/deviceSecret auth (for Android)
+            let userId = null;
+            if (deviceId && deviceSecret) {
+                const device = devices[deviceId];
+                if (!device || device.deviceSecret !== deviceSecret) {
+                    return res.status(401).json({ success: false, error: 'Invalid device credentials' });
+                }
+                const result = await pool.query(
+                    'SELECT id FROM user_accounts WHERE device_id = $1',
+                    [deviceId]
+                );
+                if (result.rows.length > 0) userId = result.rows[0].id;
+            } else {
+                // Try cookie auth
+                try {
+                    const token = req.cookies?.eclaw_session;
+                    if (token) {
+                        const decoded = jwt.verify(token, JWT_SECRET);
+                        userId = decoded.userId;
+                    }
+                } catch (_) { /* ignore */ }
+            }
+
+            if (userId) {
+                await pool.query(
+                    'UPDATE user_accounts SET language = $1 WHERE id = $2',
+                    [language, userId]
+                );
+            }
+
+            res.json({ success: true, language });
+        } catch (error) {
+            console.error('[Auth] Update language error:', error);
+            res.status(500).json({ success: false, error: 'Failed to update language' });
+        }
+    });
+
+    // ============================================
     // POST /resend-verification (requires email)
     // ============================================
     router.post('/resend-verification', async (req, res) => {
@@ -854,12 +904,12 @@ module.exports = function(devices, getOrCreateDevice) {
             }
 
             const result = await pool.query(
-                'SELECT email, email_verified, google_id, facebook_id, display_name FROM user_accounts WHERE device_id = $1',
+                'SELECT email, email_verified, google_id, facebook_id, display_name, language FROM user_accounts WHERE device_id = $1',
                 [deviceId]
             );
 
             if (result.rows.length === 0) {
-                return res.json({ success: true, bound: false, email: null, emailVerified: false, googleLinked: false, facebookLinked: false, displayName: null });
+                return res.json({ success: true, bound: false, email: null, emailVerified: false, googleLinked: false, facebookLinked: false, displayName: null, language: null });
             }
 
             const user = result.rows[0];
@@ -886,6 +936,7 @@ module.exports = function(devices, getOrCreateDevice) {
                 googleLinked: !!user.google_id,
                 facebookLinked: !!user.facebook_id,
                 displayName: user.display_name || null,
+                language: user.language || 'en',
                 channelApiKey,
                 channelApiSecret
             });
@@ -959,7 +1010,8 @@ module.exports = function(devices, getOrCreateDevice) {
                 success: true,
                 deviceId: user.device_id,
                 deviceSecret: user.device_secret,
-                email: user.email
+                email: user.email,
+                language: user.language || 'en'
             });
         } catch (error) {
             console.error('[Auth] App-login error:', error);

--- a/backend/public/portal/index.html
+++ b/backend/public/portal/index.html
@@ -447,6 +447,15 @@
             return null;
         }
 
+        function applyServerLanguage(data) {
+            if (data && data.user && data.user.language) {
+                const lang = data.user.language;
+                if (lang !== 'en' || localStorage.getItem('eclaw-language')) {
+                    localStorage.setItem('eclaw-language', lang);
+                }
+            }
+        }
+
         async function doLogin() {
             hideMsg('loginError');
             const email = document.getElementById('loginEmail').value.trim();
@@ -462,6 +471,7 @@
 
             try {
                 const data = await apiCall('POST', '/api/auth/login', { email, password });
+                applyServerLanguage(data);
                 window.location.href = 'dashboard.html';
             } catch (e) {
                 showMsg('loginError', e.message);
@@ -565,7 +575,8 @@
             btn.textContent = i18n.t('login_btn_logging_in');
 
             try {
-                await apiCall('POST', '/api/auth/device-login', { deviceId, deviceSecret });
+                const data = await apiCall('POST', '/api/auth/device-login', { deviceId, deviceSecret });
+                applyServerLanguage(data);
                 window.location.href = 'dashboard.html';
             } catch (e) {
                 showMsg('deviceError', e.message);
@@ -622,9 +633,10 @@
                     callback: async (resp) => {
                         if (resp.error) return showMsg('loginError', resp.error);
                         try {
-                            await apiCall('POST', '/api/auth/oauth/google', {
+                            const data = await apiCall('POST', '/api/auth/oauth/google', {
                                 accessToken: resp.access_token
                             });
+                            applyServerLanguage(data);
                             window.location.href = 'dashboard.html';
                         } catch (e) {
                             showMsg('loginError', e.message || 'Google login failed');
@@ -645,7 +657,8 @@
                 if (response.authResponse) {
                     apiCall('POST', '/api/auth/oauth/facebook', {
                         accessToken: response.authResponse.accessToken
-                    }).then(function () {
+                    }).then(function (data) {
+                        applyServerLanguage(data);
                         window.location.href = 'dashboard.html';
                     }).catch(function (e) {
                         showMsg('loginError', e.message || 'Facebook login failed');

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1371,6 +1371,8 @@
 
         function setLanguage(lang) {
             localStorage.setItem('eclaw-language', lang);
+            // Sync to server for cross-device persistence
+            apiCall('PATCH', '/api/auth/language', { language: lang }).catch(() => {});
             window.location.reload();
         }
 

--- a/backend/public/portal/shared/auth.js
+++ b/backend/public/portal/shared/auth.js
@@ -9,6 +9,16 @@ async function checkAuth() {
         currentUser = data.user;
         window.currentUser = currentUser;
 
+        // Restore language preference from server if not set locally
+        if (currentUser.language && typeof i18n !== 'undefined') {
+            const local = localStorage.getItem('eclaw-language');
+            if (!local && currentUser.language !== 'en') {
+                localStorage.setItem('eclaw-language', currentUser.language);
+                i18n.lang = currentUser.language;
+                i18n.apply();
+            }
+        }
+
         // Update nav email
         const emailEl = document.getElementById('navEmail');
         if (emailEl) emailEl.textContent = currentUser.email;


### PR DESCRIPTION
Language was only stored in localStorage (web) and AppCompatDelegate
(Android), lost when clearing browser data or switching devices.

- Add PATCH /api/auth/language endpoint (supports both cookie and
  deviceId/deviceSecret auth)
- Web: restore language from server on login and auth check
- Web: sync language changes to server from settings
- Android: sync language changes to server from SettingsActivity
- Android: restore language from server on app-login
- Include language field in device-login and bind-email/status responses

https://claude.ai/code/session_01PgnowNSLZVoV6pNY1yS5yV