### PR TITLE
Pass deviceSecret in all client/speak calls for Gatekeeper exemption

### DIFF
--- a/app/src/main/java/com/hank/clawlive/ChatActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/ChatActivity.kt
@@ -909,6 +909,7 @@ class ChatActivity : AppCompatActivity() {
                 val entityIdValue: Any = if (targetIds.size == 1) targetIds.first() else targetIds
                 val request = mapOf<String, Any>(
                     "deviceId" to deviceManager.deviceId,
+                    "deviceSecret" to deviceManager.deviceSecret,
                     "entityId" to entityIdValue,
                     "text" to text,
                     "source" to "android_chat",
@@ -1212,6 +1213,7 @@ class ChatActivity : AppCompatActivity() {
 
                     val request = mutableMapOf<String, Any>(
                         "deviceId" to deviceManager.deviceId,
+                        "deviceSecret" to deviceManager.deviceSecret,
                         "entityId" to entityIdValue,
                         "text" to text,
                         "source" to "android_chat"

--- a/app/src/main/java/com/hank/clawlive/MessageActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/MessageActivity.kt
@@ -191,6 +191,7 @@ class MessageActivity : AppCompatActivity() {
 
                 val request = mapOf<String, Any>(
                     "deviceId" to deviceManager.deviceId,
+                    "deviceSecret" to deviceManager.deviceSecret,
                     "entityId" to entityIdValue,
                     "text" to text,
                     "source" to "android_widget"

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -2180,6 +2180,7 @@
                             const msgText = (i === 0 && text) ? text : (f.type === 'photo' ? '[Photo]' : f.type === 'video' ? '[Video]' : `[File] ${f.fileName}`);
                             await apiCall('POST', '/api/client/speak', {
                                 deviceId: currentUser.deviceId,
+                                deviceSecret: currentUser.deviceSecret,
                                 entityId: entityId,
                                 text: msgText,
                                 source: 'web_chat',
@@ -2190,6 +2191,7 @@
                     } else {
                         const speakBody = {
                             deviceId: currentUser.deviceId,
+                            deviceSecret: currentUser.deviceSecret,
                             entityId: entityId,
                             text: text,
                             source: 'web_chat'
@@ -2587,6 +2589,7 @@
                 const entityId = targets.length === 1 ? targets[0] : targets;
                 await apiCall('POST', '/api/client/speak', {
                     deviceId: currentUser.deviceId,
+                    deviceSecret: currentUser.deviceSecret,
                     entityId: entityId,
                     text: `[Voice ${durationSec}s]`,
                     source: 'web_chat',


### PR DESCRIPTION
Web portal (chat.html) and Android (ChatActivity, MessageActivity) now include deviceSecret in client/speak requests. Backend uses this to identify admin devices and skip Gatekeeper First Lock for developers.

https://claude.ai/code/session_01QhUB387CNCzSmPiYVyVMA2