### PR TITLE
fix: Backend CI Jest tests pass (HTTPS redirect 127.0.0.1)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -104,7 +104,7 @@ app.use((req, res, next) => {
 // HTTPS redirect (Railway terminates TLS, forwards X-Forwarded-Proto)
 // Skip for health check path — Railway probes containers internally over HTTP
 app.use((req, res, next) => {
-    if (req.protocol === 'http' && req.hostname !== 'localhost' && req.path !== '/api/health') {
+    if (req.protocol === 'http' && req.hostname !== 'localhost' && req.hostname !== '127.0.0.1' && req.path !== '/api/health') {
         return res.redirect(301, `https://${req.hostname}${req.originalUrl}`);
     }
     next();


### PR DESCRIPTION
## Summary
- HTTPS redirect middleware only exempted `localhost` but supertest uses `127.0.0.1`
- All 14 Jest tests were returning 301 instead of expected status codes
- Added `127.0.0.1` to the exemption check

## Test plan
- [x] 14/14 Jest tests pass locally
- [x] ESLint: 0 errors