### PR TITLE
debug: add SKILL_TPL_DEBUG logs for skill templates 0 issue

### DIFF
--- a/app/src/main/java/com/hank/clawlive/MissionControlActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/MissionControlActivity.kt
@@ -28,6 +28,7 @@ import com.hank.clawlive.data.local.DeviceManager
 import com.hank.clawlive.data.local.EntityAvatarManager
 import com.hank.clawlive.data.local.LocalVarsManager
 import com.hank.clawlive.data.remote.SkillTemplate
+import com.hank.clawlive.data.remote.SkillTemplatesResponse
 import com.hank.clawlive.data.remote.SyncLocalVarsRequest
 import com.hank.clawlive.data.model.*
 import com.hank.clawlive.data.remote.NetworkModule
@@ -109,14 +110,44 @@ class MissionControlActivity : AppCompatActivity() {
     }
 
     private fun loadSkillTemplates() {
+        Timber.d("SKILL_TPL_DEBUG loadSkillTemplates() called")
         lifecycleScope.launch {
+            // --- Raw HTTP debug: fetch body as string first ---
             try {
-                val response = api.getSkillTemplates()
-                if (response.success) {
-                    skillTemplates = response.templates
+                kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+                    val rawUrl = "https://eclawbot.com/api/skill-templates"
+                    Timber.d("SKILL_TPL_DEBUG fetching raw URL: $rawUrl")
+                    val rawReq = okhttp3.Request.Builder().url(rawUrl).get().build()
+                    val rawResp = okhttp3.OkHttpClient().newCall(rawReq).execute()
+                    val rawBody = rawResp.body?.string() ?: "(null body)"
+                    Timber.d("SKILL_TPL_DEBUG raw HTTP status=${rawResp.code}, bodyLen=${rawBody.length}")
+                    Timber.d("SKILL_TPL_DEBUG raw body first 500 chars: ${rawBody.take(500)}")
+                    // Try manual parse to see if Gson works
+                    val manualParsed = com.google.gson.Gson().fromJson(rawBody, SkillTemplatesResponse::class.java)
+                    Timber.d("SKILL_TPL_DEBUG manual Gson parse: success=${manualParsed.success}, templates.size=${manualParsed.templates.size}")
+                    rawResp.close()
                 }
             } catch (e: Exception) {
-                Timber.w(e, "Failed to load skill templates")
+                Timber.e(e, "SKILL_TPL_DEBUG RAW fetch exception: ${e::class.simpleName}: ${e.message}")
+            }
+
+            // --- Normal Retrofit call ---
+            try {
+                Timber.d("SKILL_TPL_DEBUG calling api.getSkillTemplates() via Retrofit...")
+                val response = api.getSkillTemplates()
+                Timber.d("SKILL_TPL_DEBUG Retrofit response: success=${response.success}, templates.size=${response.templates.size}, error=${response.error}")
+                if (response.success) {
+                    skillTemplates = response.templates
+                    Timber.d("SKILL_TPL_DEBUG assigned skillTemplates, size=${skillTemplates.size}")
+                    if (skillTemplates.isNotEmpty()) {
+                        val first = skillTemplates.first()
+                        Timber.d("SKILL_TPL_DEBUG first template: id=${first.id}, label=${first.label}, title=${first.title}")
+                    }
+                } else {
+                    Timber.w("SKILL_TPL_DEBUG Retrofit response.success=false, error=${response.error}")
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "SKILL_TPL_DEBUG EXCEPTION in Retrofit getSkillTemplates: ${e::class.simpleName}: ${e.message}")
             }
         }
     }
@@ -297,6 +328,7 @@ class MissionControlActivity : AppCompatActivity() {
         btnUpload.text = getString(R.string.publish_notification)
 
         // Lists
+        Timber.d("SKILL_TPL_DEBUG updateUI: skills.size=${state.skills.size}, todoList.size=${state.todoList.size}, notes.size=${state.notes.size}, souls.size=${state.souls.size}")
         todoAdapter.submitList(state.todoList)
         missionAdapter.submitList(state.missionList)
         doneAdapter.submitList(state.doneList)
@@ -723,25 +755,35 @@ class MissionControlActivity : AppCompatActivity() {
 
     /** Opens a scrollable gallery dialog listing all official skill templates. */
     private fun showTemplateGalleryDialog(onSelect: (SkillTemplate) -> Unit) {
+        Timber.d("SKILL_TPL_DEBUG showTemplateGalleryDialog() called, current skillTemplates.size=${skillTemplates.size}")
         if (skillTemplates.isEmpty()) {
+            Timber.d("SKILL_TPL_DEBUG skillTemplates is empty, re-fetching from API...")
             lifecycleScope.launch {
                 try {
                     val response = api.getSkillTemplates()
+                    Timber.d("SKILL_TPL_DEBUG gallery re-fetch: success=${response.success}, templates.size=${response.templates.size}, error=${response.error}")
                     if (response.success) {
                         skillTemplates = response.templates
+                        Timber.d("SKILL_TPL_DEBUG gallery re-fetch assigned, size=${skillTemplates.size}")
+                    } else {
+                        Timber.w("SKILL_TPL_DEBUG gallery re-fetch success=false")
                     }
                 } catch (e: Exception) {
-                    Timber.w(e, "Failed to reload skill templates")
+                    Timber.e(e, "SKILL_TPL_DEBUG EXCEPTION in gallery re-fetch: ${e::class.simpleName}: ${e.message}")
                 }
+                Timber.d("SKILL_TPL_DEBUG opening gallery internal with ${skillTemplates.size} templates")
                 showTemplateGalleryDialogInternal(onSelect)
             }
             return
         }
+        Timber.d("SKILL_TPL_DEBUG opening gallery internal (cached) with ${skillTemplates.size} templates")
         showTemplateGalleryDialogInternal(onSelect)
     }
 
     private fun showTemplateGalleryDialogInternal(onSelect: (SkillTemplate) -> Unit) {
+        Timber.d("SKILL_TPL_DEBUG showTemplateGalleryDialogInternal() skillTemplates.size=${skillTemplates.size}")
         val localVars = LocalVarsManager.getInstance(this).getAll()
+        Timber.d("SKILL_TPL_DEBUG localVars.size=${localVars.size}")
 
         // Outer container: search bar + scrollable list
         val outerLayout = LinearLayout(this).apply {

--- a/app/src/main/java/com/hank/clawlive/ui/MissionViewModel.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/MissionViewModel.kt
@@ -110,8 +110,13 @@ class MissionViewModel(application: Application) : AndroidViewModel(application)
                     deviceId = deviceManager.deviceId,
                     deviceSecret = deviceManager.deviceSecret
                 )
+                Timber.d("SKILL_TPL_DEBUG downloadDashboard response: success=${response.success}, dashboard=${response.dashboard != null}")
                 if (response.success && response.dashboard != null) {
                     val d = response.dashboard
+                    Timber.d("SKILL_TPL_DEBUG dashboard.skills=${d.skills?.size ?: "null"}, dashboard.souls=${d.souls?.size ?: "null"}")
+                    if (d.skills != null && d.skills.isNotEmpty()) {
+                        Timber.d("SKILL_TPL_DEBUG first dashboard skill: id=${d.skills.first().id}, title=${d.skills.first().title}")
+                    }
                     _uiState.update {
                         it.copy(
                             isLoading = false,


### PR DESCRIPTION
## Summary
- Added comprehensive debug logging to diagnose Android skill templates showing 0 items
- Covers raw HTTP fetch, Gson deserialization, Retrofit response, dashboard download, and UI update
- Filter keyword in Logcat: `SKILL_TPL_DEBUG`

## Test plan
- [ ] Build and run Android app
- [ ] Open Mission Control page
- [ ] Filter Logcat by `SKILL_TPL_DEBUG`
- [ ] Check which step fails (network / parse / Retrofit / UI)
- [ ] Open "Browse Templates" gallery and check gallery-specific logs

?? Generated with [Claude Code](https://claude.com/claude-code)