### PR TITLE
feat(seo): add robots.txt, sitemap.xml, meta tags, JSON-LD, and hrefl…

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -130,6 +130,15 @@ app.use(cors({ origin: true, credentials: true }));
 app.use('/api/ai-support/chat', express.json({ limit: '10mb' }));
 app.use(express.json());
 app.use(cookieParser());
+
+// SEO: serve robots.txt and sitemap.xml at root
+app.get('/robots.txt', (req, res) => {
+    res.type('text/plain').sendFile(path.join(__dirname, 'public/robots.txt'));
+});
+app.get('/sitemap.xml', (req, res) => {
+    res.type('application/xml').sendFile(path.join(__dirname, 'public/sitemap.xml'));
+});
+
 app.use('/mission', express.static(path.join(__dirname, 'public')));
 app.use('/portal', express.static(path.join(__dirname, 'public/portal')));
 app.use('/shared', express.static(path.join(__dirname, 'public/shared'), {

--- a/backend/public/portal/admin.html
+++ b/backend/public/portal/admin.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title data-i18n="admin_title">E-Claw - Admin Dashboard</title>
+    <meta name="robots" content="noindex, nofollow">
+    <title data-i18n="admin_title">EClaw - Admin Dashboard</title>
+    <meta name="description" content="EClaw admin panel — server management and audit logs.">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦞</text></svg>">
     <link rel="stylesheet" href="shared/style.css">
     <style>

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title data-i18n="chat_title">E-Claw - Chat</title>
+    <meta name="robots" content="noindex, nofollow">
+    <title data-i18n="chat_title">EClaw - Chat</title>
+    <meta name="description" content="Real-time chat with your EClaw AI entities.">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦞</text></svg>">
     <link rel="stylesheet" href="shared/style.css">
     <style>

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -4,7 +4,10 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title data-i18n="dash_title">E-Claw - Dashboard</title>
+    <meta name="robots" content="noindex, nofollow">
+    <title data-i18n="dash_title">EClaw - Dashboard</title>
+    <meta name="description" content="EClaw device dashboard — manage entities, monitor status, and control your claw machines.">
+    <link rel="preconnect" href="https://js.tappaysdk.com">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦞</text></svg>">
     <link rel="stylesheet" href="shared/style.css">
     <style>
@@ -1277,8 +1280,8 @@
         </div>
     </div>
 
-    <!-- TapPay SDK -->
-    <script src="https://js.tappaysdk.com/sdk/tpdirect/v5.17.0"></script>
+    <!-- TapPay SDK (async — only needed for billing interactions) -->
+    <script src="https://js.tappaysdk.com/sdk/tpdirect/v5.17.0" async></script>
 
     <script src="shared/api.js"></script>
     <script src="shared/nav.js"></script>

--- a/backend/public/portal/delete-account.html
+++ b/backend/public/portal/delete-account.html
@@ -3,7 +3,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>E-Claw — Delete Account</title>
+    <meta name="robots" content="noindex, nofollow">
+    <title>EClaw — Delete Account</title>
+    <meta name="description" content="Delete your EClaw account and associated data.">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦞</text></svg>">
     <link rel="stylesheet" href="shared/style.css">
     <style>

--- a/backend/public/portal/env-vars.html
+++ b/backend/public/portal/env-vars.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>E-Claw - Env Variables</title>
+    <meta name="robots" content="noindex, nofollow">
+    <title>EClaw - Env Variables</title>
+    <meta name="description" content="EClaw environment variable editor for device configuration.">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦞</text></svg>">
     <link rel="stylesheet" href="shared/style.css">
     <style>

--- a/backend/public/portal/feedback.html
+++ b/backend/public/portal/feedback.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title data-i18n="feedback_title">E-Claw - My Feedback</title>
+    <meta name="robots" content="noindex, nofollow">
+    <title data-i18n="feedback_title">EClaw - My Feedback</title>
+    <meta name="description" content="Submit and track feedback and bug reports for EClaw.">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦞</text></svg>">
     <link rel="stylesheet" href="shared/style.css">
     <style>

--- a/backend/public/portal/files.html
+++ b/backend/public/portal/files.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title data-i18n="files_title">E-Claw - Files</title>
+    <meta name="robots" content="noindex, nofollow">
+    <title data-i18n="files_title">EClaw - Files</title>
+    <meta name="description" content="EClaw file manager for device storage.">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦞</text></svg>">
     <link rel="stylesheet" href="shared/style.css">
     <style>

--- a/backend/public/portal/index.html
+++ b/backend/public/portal/index.html
@@ -4,7 +4,32 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title data-i18n="portal_login_title">E-Claw - Login</title>
+    <title data-i18n="portal_login_title">EClaw - IoT Claw Machine Management Platform</title>
+    <meta name="description" content="EClaw connects physical claw machines to AI-powered agents. Manage devices, entities, and missions from a unified web portal.">
+    <link rel="canonical" href="https://eclawbot.com/portal/">
+    <!-- Open Graph -->
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="EClaw - IoT Claw Machine Management Platform">
+    <meta property="og:description" content="EClaw connects physical claw machines to AI-powered agents. Manage devices, entities, and missions from a unified web portal.">
+    <meta property="og:url" content="https://eclawbot.com/portal/">
+    <meta property="og:site_name" content="EClaw">
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="EClaw - IoT Claw Machine Management Platform">
+    <meta name="twitter:description" content="EClaw connects physical claw machines to AI-powered agents. Manage devices, entities, and missions from a unified web portal.">
+    <!-- Preconnect to external origins -->
+    <link rel="preconnect" href="https://accounts.google.com" crossorigin>
+    <link rel="dns-prefetch" href="https://connect.facebook.net">
+    <!-- hreflang for multi-language -->
+    <link rel="alternate" hreflang="en" href="https://eclawbot.com/portal/">
+    <link rel="alternate" hreflang="zh-Hant" href="https://eclawbot.com/portal/">
+    <link rel="alternate" hreflang="zh-Hans" href="https://eclawbot.com/portal/">
+    <link rel="alternate" hreflang="ja" href="https://eclawbot.com/portal/">
+    <link rel="alternate" hreflang="ko" href="https://eclawbot.com/portal/">
+    <link rel="alternate" hreflang="th" href="https://eclawbot.com/portal/">
+    <link rel="alternate" hreflang="vi" href="https://eclawbot.com/portal/">
+    <link rel="alternate" hreflang="id" href="https://eclawbot.com/portal/">
+    <link rel="alternate" hreflang="x-default" href="https://eclawbot.com/portal/">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦞</text></svg>">
     <link rel="stylesheet" href="shared/style.css">
     <style>
@@ -123,9 +148,32 @@
             .terms-footer { padding: 12px 16px; flex-direction: column; }
         }
     </style>
+    <!-- JSON-LD Organization schema -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "SoftwareApplication",
+        "name": "EClaw",
+        "url": "https://eclawbot.com",
+        "applicationCategory": "BusinessApplication",
+        "operatingSystem": "Web, Android, iOS",
+        "description": "IoT claw machine management platform with AI-powered agent ecosystem. Connect physical claw machines to AI entities for remote management and automation.",
+        "offers": {
+            "@type": "Offer",
+            "price": "0",
+            "priceCurrency": "USD"
+        },
+        "publisher": {
+            "@type": "Organization",
+            "name": "EClaw",
+            "url": "https://eclawbot.com"
+        }
+    }
+    </script>
 </head>
 
 <body>
+    <main>
     <!-- Terms & Privacy Dialog -->
     <div id="termsOverlay" class="terms-overlay" style="display:none">
         <div class="terms-dialog">
@@ -186,7 +234,7 @@
 
     <div class="auth-container">
         <div class="auth-logo">
-            <h1 data-i18n="portal_app_title">E-Claw</h1>
+            <h1 data-i18n="portal_app_title">EClaw</h1>
         </div>
 
         <!-- Tabs -->
@@ -671,6 +719,7 @@
         loadOAuthConfig();
     </script>
     <script src="https://accounts.google.com/gsi/client" async defer></script>
+    </main>
 </body>
 
 </html>

--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title data-i18n="info_title">E-Claw - Info Hub</title>
+    <meta name="robots" content="noindex, nofollow">
+    <title data-i18n="info_title">EClaw - Info Hub</title>
+    <meta name="description" content="EClaw information hub — documentation and device guides.">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦞</text></svg>">
     <link rel="stylesheet" href="shared/style.css">
     <style>

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title data-i18n="mc_title">E-Claw Mission Control</title>
+    <meta name="robots" content="noindex, nofollow">
+    <title data-i18n="mc_title">EClaw - Mission Control</title>
+    <meta name="description" content="EClaw mission control — manage todos, missions, notes, and rules for your AI agents.">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦞</text></svg>">
     <link rel="stylesheet" href="shared/style.css">
     <style>

--- a/backend/public/portal/schedule.html
+++ b/backend/public/portal/schedule.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title data-i18n="sched_title">E-Claw - Schedule</title>
+    <meta name="robots" content="noindex, nofollow">
+    <title data-i18n="sched_title">EClaw - Schedule</title>
+    <meta name="description" content="EClaw task scheduler — create and manage cron-based schedules for your entities.">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦞</text></svg>">
     <link rel="stylesheet" href="shared/style.css">
     <style>

--- a/backend/public/portal/screen-control.html
+++ b/backend/public/portal/screen-control.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>E-Claw - Remote Control</title>
+    <meta name="robots" content="noindex, nofollow">
+    <title>EClaw - Remote Control</title>
+    <meta name="description" content="EClaw remote screen capture and control.">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦞</text></svg>">
     <link rel="stylesheet" href="shared/style.css">
     <style>

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -4,7 +4,9 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title data-i18n="settings_title">E-Claw - Settings</title>
+    <meta name="robots" content="noindex, nofollow">
+    <title data-i18n="settings_title">EClaw - Settings</title>
+    <meta name="description" content="EClaw device and account settings.">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦞</text></svg>">
     <link rel="stylesheet" href="shared/style.css">
     <style>

--- a/backend/public/robots.txt
+++ b/backend/public/robots.txt
@@ -1,0 +1,32 @@
+# EClaw - robots.txt
+# https://eclawbot.com
+
+User-agent: *
+
+# Public pages
+Allow: /portal/$
+Allow: /portal/index.html
+Allow: /api/docs
+
+# Authenticated portal pages — not useful to crawlers
+Disallow: /portal/dashboard.html
+Disallow: /portal/chat.html
+Disallow: /portal/mission.html
+Disallow: /portal/settings.html
+Disallow: /portal/schedule.html
+Disallow: /portal/env-vars.html
+Disallow: /portal/files.html
+Disallow: /portal/feedback.html
+Disallow: /portal/admin.html
+Disallow: /portal/info.html
+Disallow: /portal/screen-control.html
+Disallow: /portal/delete-account.html
+
+# API endpoints
+Disallow: /api/
+
+# Allow health and version for monitoring tools
+Allow: /api/health
+Allow: /api/version
+
+Sitemap: https://eclawbot.com/sitemap.xml

--- a/backend/public/sitemap.xml
+++ b/backend/public/sitemap.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://eclawbot.com/portal/</loc>
+    <changefreq>monthly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://eclawbot.com/api/docs</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>


### PR DESCRIPTION
…ang to web portal

- Add robots.txt (allow public pages, disallow auth-walled pages and API)
- Add sitemap.xml with 2 public URLs (portal index + API docs)
- Add Express routes for /robots.txt and /sitemap.xml with correct MIME types
- Add meta description to all 13 portal HTML pages
- Add noindex/nofollow to 12 authenticated pages
- Add OG tags, Twitter Card, canonical URL, JSON-LD SoftwareApplication schema to index.html
- Add hreflang tags for 9 languages (en, zh-Hant, zh-Hans, ja, ko, th, vi, id, x-default)
- Add preconnect hints for Google, Facebook, TapPay
- Add <main> semantic wrapper to index.html
- Make TapPay SDK load async on dashboard
- Unify brand name from "E-Claw" to "EClaw" across all page titles