### PR TITLE
fix(#221,#220): AI chat forced convergence at step 14 + Android mission adapter NPE guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -532,6 +532,14 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | Schedule Channel | `node backend/tests/test-schedule-channel.js` | Device ID + Secret | Scheduler parity: channel-bound entities receive schedule push |
 | Schedule Cron Update | `node backend/tests/test-schedule-cron-update.js` | Device ID + Secret | Regression: cron schedule update NOT NULL violation on scheduled_at |
 
+### Jest Unit Tests (CI-run, `npm test`)
+
+*(In addition to the 10 core Jest files listed above)*
+
+| Test | File | Description |
+|------|------|-------------|
+| AI Chat Steps | `tests/jest/ai-chat-steps.test.js` | Issue #221: Agentic loop convergence at step 14, max step fallback, tool-use loop |
+
 ### Jest Unit Tests (CI-run, `npm test`, 10 files)
 
 | Test | File | Description |

--- a/app/src/main/java/com/hank/clawlive/ui/mission/MissionItemAdapter.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/mission/MissionItemAdapter.kt
@@ -45,7 +45,8 @@ class MissionItemAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(getItem(position))
+        val item = getItem(position) ?: return
+        holder.bind(item)
     }
 
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {

--- a/app/src/main/java/com/hank/clawlive/ui/mission/MissionNoteAdapter.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/mission/MissionNoteAdapter.kt
@@ -26,7 +26,8 @@ class MissionNoteAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(getItem(position))
+        val note = getItem(position) ?: return
+        holder.bind(note)
     }
 
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {

--- a/app/src/main/java/com/hank/clawlive/ui/mission/MissionRuleAdapter.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/mission/MissionRuleAdapter.kt
@@ -34,7 +34,8 @@ class MissionRuleAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(getItem(position))
+        val rule = getItem(position) ?: return
+        holder.bind(rule)
     }
 
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {

--- a/app/src/main/java/com/hank/clawlive/ui/mission/MissionSkillAdapter.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/mission/MissionSkillAdapter.kt
@@ -28,7 +28,8 @@ class MissionSkillAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(getItem(position))
+        val skill = getItem(position) ?: return
+        holder.bind(skill)
     }
 
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {

--- a/app/src/main/java/com/hank/clawlive/ui/mission/MissionSoulAdapter.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/mission/MissionSoulAdapter.kt
@@ -30,7 +30,8 @@ class MissionSoulAdapter(
     }
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        holder.bind(getItem(position))
+        val soul = getItem(position) ?: return
+        holder.bind(soul)
     }
 
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {

--- a/backend/ai-support.js
+++ b/backend/ai-support.js
@@ -686,7 +686,7 @@ module.exports = function (devices, chatPool, { serverLog, getWebhookFixInstruct
                     if (parsed.result_text) {
                         return parsed.result_text;
                     } else if (parsed.subtype === 'error_max_turns') {
-                        return 'Sorry, this question was too complex for me to fully analyze. Could you try asking a more specific question?';
+                        return 'This question required more analysis steps than allowed. Here is what I found so far — please try breaking your question into smaller, more specific parts for a complete answer.';
                     } else if (parsed.subtype === 'error_tool_execution') {
                         return 'I encountered an error while looking into your issue. Please try again.';
                     } else {

--- a/backend/anthropic-client.js
+++ b/backend/anthropic-client.js
@@ -9,6 +9,8 @@ const ANTHROPIC_MODEL = 'claude-sonnet-4-20250514';
 const ANTHROPIC_VERSION = '2023-06-01';
 const MAX_TOKENS = 2048;
 const TIMEOUT_MS = 120000; // 120s
+const MAX_TOOL_STEPS = 15; // Max agentic loop iterations
+const CONVERGENCE_STEP = 14; // Force conclusion at this step
 
 // ── System Prompts ──────────────────────────
 
@@ -327,8 +329,62 @@ async function chatWithClaude({ message, history, images, deviceContext, deviceD
     const userContent = buildUserContent(message, images);
     messages.push({ role: 'user', content: userContent });
 
-    const result = await callAnthropic(system, messages, GITHUB_TOOLS);
-    return parseResponse(result);
+    // Agentic tool-use loop: keep calling API until we get a final text response
+    let allActions = [];
+    for (let step = 1; step <= MAX_TOOL_STEPS; step++) {
+        // At convergence step, inject forced conclusion instruction
+        let stepSystem = system;
+        if (step >= CONVERGENCE_STEP) {
+            stepSystem += '\n\nIMPORTANT: You are running low on analysis steps. You MUST provide your final answer NOW. Summarize your findings and give a conclusion based on what you have so far. Do NOT call any more tools.';
+        }
+
+        const result = await callAnthropic(stepSystem, messages, step >= CONVERGENCE_STEP ? [] : GITHUB_TOOLS);
+        const parsed = parseResponse(result);
+
+        // Collect any tool actions
+        if (parsed.actions) {
+            allActions.push(...parsed.actions);
+        }
+
+        // If the model didn't request tool use, we're done
+        if (result.stop_reason !== 'tool_use') {
+            return {
+                response: parsed.response,
+                actions: allActions.length > 0 ? allActions : null
+            };
+        }
+
+        // Model requested tool use — append assistant response and tool results to messages
+        messages.push({ role: 'assistant', content: result.content });
+
+        // Build tool results for each tool_use block
+        const toolResults = [];
+        for (const block of (result.content || [])) {
+            if (block.type === 'tool_use') {
+                // We don't execute tools server-side in the loop — just acknowledge them.
+                // Actual execution (GitHub actions) happens after the loop via the actions array.
+                toolResults.push({
+                    type: 'tool_result',
+                    tool_use_id: block.id,
+                    content: 'Tool call acknowledged. The action will be executed after your response.'
+                });
+            }
+        }
+        if (toolResults.length > 0) {
+            messages.push({ role: 'user', content: toolResults });
+        }
+
+        console.log(`[Anthropic] Tool-use loop step ${step}/${MAX_TOOL_STEPS}, actions so far: ${allActions.length}`);
+    }
+
+    // Exceeded max steps — return whatever we have with a warning
+    console.warn(`[Anthropic] Reached max tool steps (${MAX_TOOL_STEPS}), forcing response`);
+    return {
+        response: allActions.length > 0
+            ? 'I\'ve completed the requested actions. Due to complexity limits, I may not have fully addressed all aspects of your question.'
+            : 'I apologize — your question required more analysis than I could complete. Here\'s what I gathered so far: please try asking a more specific question for better results.',
+        actions: allActions.length > 0 ? allActions : null
+    };
 }
 
 /**

--- a/backend/tests/jest/ai-chat-steps.test.js
+++ b/backend/tests/jest/ai-chat-steps.test.js
@@ -1,0 +1,158 @@
+/**
+ * Regression test for Issue #221:
+ * AI customer support should force a conclusion at step 14 (avoid exceeding step limit).
+ *
+ * Tests the anthropic-client module's agentic loop convergence logic.
+ */
+
+// Mock fetch before requiring the module
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+// Set required env
+process.env.ANTHROPIC_API_KEY = 'test-key-for-jest';
+
+const path = require('path');
+
+// We need to test the module's exported functions
+let chatWithClaude;
+
+beforeAll(() => {
+    // Clear module cache to pick up our mock
+    delete require.cache[require.resolve('../../anthropic-client')];
+    const client = require('../../anthropic-client');
+    chatWithClaude = client.chatWithClaude;
+});
+
+afterEach(() => {
+    mockFetch.mockReset();
+});
+
+describe('Issue #221: AI chat step limit and forced convergence', () => {
+    test('single-turn response returns immediately without looping', async () => {
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                content: [{ type: 'text', text: 'Hello! How can I help?' }],
+                stop_reason: 'end_turn'
+            })
+        });
+
+        const result = await chatWithClaude({
+            message: 'Hi',
+            history: []
+        });
+
+        expect(result.response).toBe('Hello! How can I help?');
+        expect(result.actions).toBeNull();
+        // Only 1 API call (no looping)
+        expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    test('tool_use triggers agentic loop and returns after tool acknowledgment', async () => {
+        // First call: model requests tool use
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                content: [
+                    { type: 'text', text: 'I\'ll create an issue for you.' },
+                    {
+                        type: 'tool_use',
+                        id: 'toolu_123',
+                        name: 'create_github_issue',
+                        input: { title: 'Bug report', body: 'Something is broken', labels: ['bug'] }
+                    }
+                ],
+                stop_reason: 'tool_use'
+            })
+        });
+
+        // Second call: model provides final text
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                content: [{ type: 'text', text: 'I\'ve created the issue for you.' }],
+                stop_reason: 'end_turn'
+            })
+        });
+
+        const result = await chatWithClaude({
+            message: 'Report a bug: app crashes on startup',
+            history: []
+        });
+
+        expect(result.response).toBe('I\'ve created the issue for you.');
+        expect(result.actions).toEqual([{
+            type: 'create_issue',
+            title: 'Bug report',
+            body: 'Something is broken',
+            labels: ['bug']
+        }]);
+        // 2 API calls: initial + after tool result
+        expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+
+    test('convergence instruction injected at step 14', async () => {
+        // Simulate a model that keeps requesting tool_use for 13 steps
+        for (let i = 0; i < 13; i++) {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    content: [
+                        { type: 'tool_use', id: `toolu_${i}`, name: 'create_github_issue',
+                          input: { title: `Issue ${i}`, body: 'test', labels: ['bug'] } }
+                    ],
+                    stop_reason: 'tool_use'
+                })
+            });
+        }
+
+        // Step 14 (convergence): model should get no tools and forced conclusion instruction
+        mockFetch.mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+                content: [{ type: 'text', text: 'Here is my summary based on analysis so far.' }],
+                stop_reason: 'end_turn'
+            })
+        });
+
+        const result = await chatWithClaude({
+            message: 'Complex analysis request',
+            history: []
+        });
+
+        expect(result.response).toBe('Here is my summary based on analysis so far.');
+
+        // Step 14 call should have no tools (forcing conclusion)
+        const step14Call = mockFetch.mock.calls[13];
+        const step14Body = JSON.parse(step14Call[1].body);
+        expect(step14Body.tools).toBeUndefined(); // empty tools array omitted by callAnthropic
+        expect(step14Body.system).toContain('You MUST provide your final answer NOW');
+    });
+
+    test('max steps exceeded returns fallback message', async () => {
+        // Simulate 15 consecutive tool_use responses (should not happen with convergence, but safety net)
+        for (let i = 0; i < 15; i++) {
+            mockFetch.mockResolvedValueOnce({
+                ok: true,
+                json: async () => ({
+                    content: [
+                        { type: 'tool_use', id: `toolu_${i}`, name: 'create_github_issue',
+                          input: { title: `Issue ${i}`, body: 'test', labels: ['bug'] } }
+                    ],
+                    stop_reason: 'tool_use'
+                })
+            });
+        }
+
+        const result = await chatWithClaude({
+            message: 'Very complex question',
+            history: []
+        });
+
+        // Should return a graceful fallback, not an error
+        expect(result.response).toContain('complexity limits');
+        expect(result.actions).not.toBeNull();
+        expect(result.actions.length).toBe(15);
+    });
+});


### PR DESCRIPTION
#221: Add agentic tool-use loop to chatWithClaude() with MAX_STEPS=15.
At step ≥14, injects forced conclusion instruction and removes tools
to ensure the AI always produces a useful response instead of hitting
the step limit silently. Improved error_max_turns message in sanitizer.

#220: Add null guard in onBindViewHolder() for all 5 mission adapters
(Note, Item, Skill, Rule, Soul) to prevent NullPointerException during
DiffUtil async processing after item deletion.

Closes #221, Closes #220

https://claude.ai/code/session_017vtzP9Pb8AJDGdHBbdqanZ