### PR TITLE
Fix environment variable isolation in publisher API tests

### DIFF
--- a/backend/tests/jest/publisher.test.js
+++ b/backend/tests/jest/publisher.test.js
@@ -150,12 +150,14 @@ jest.mock('../../subscription', () => {
 // ── Load app after mocks are established ──
 const request = require('supertest');
 let app;
+const savedPublisherKey = process.env.PUBLISHER_API_KEY;
 
 beforeAll(() => {
     app = require('../../index');
 });
 
 afterAll(async () => {
+    if (savedPublisherKey) process.env.PUBLISHER_API_KEY = savedPublisherKey;
     const { httpServer } = require('../../index');
     await new Promise(resolve => httpServer.close(resolve));
     jest.resetModules();
@@ -266,6 +268,9 @@ describe('GET /api/publisher/platforms', () => {
 // DEV.to input validation
 // ════════════════════════════════════════════════════════════════
 describe('POST /api/publisher/devto/publish', () => {
+    beforeAll(() => { delete process.env.PUBLISHER_API_KEY; });
+    afterAll(() => { if (savedPublisherKey) process.env.PUBLISHER_API_KEY = savedPublisherKey; });
+
     it('rejects missing body_markdown', async () => {
         const res = await request(app)
             .post('/api/publisher/devto/publish')
@@ -287,6 +292,9 @@ describe('POST /api/publisher/devto/publish', () => {
 // WordPress input validation
 // ════════════════════════════════════════════════════════════════
 describe('POST /api/publisher/wordpress/publish', () => {
+    beforeAll(() => { delete process.env.PUBLISHER_API_KEY; });
+    afterAll(() => { if (savedPublisherKey) process.env.PUBLISHER_API_KEY = savedPublisherKey; });
+
     it('rejects missing siteId', async () => {
         const res = await request(app)
             .post('/api/publisher/wordpress/publish')
@@ -299,6 +307,9 @@ describe('POST /api/publisher/wordpress/publish', () => {
 // Telegraph input validation
 // ════════════════════════════════════════════════════════════════
 describe('POST /api/publisher/telegraph/publish', () => {
+    beforeAll(() => { delete process.env.PUBLISHER_API_KEY; });
+    afterAll(() => { if (savedPublisherKey) process.env.PUBLISHER_API_KEY = savedPublisherKey; });
+
     it('rejects missing content', async () => {
         const res = await request(app)
             .post('/api/publisher/telegraph/publish')
@@ -319,6 +330,9 @@ describe('POST /api/publisher/telegraph/publish', () => {
 // Qiita input validation
 // ════════════════════════════════════════════════════════════════
 describe('POST /api/publisher/qiita/publish', () => {
+    beforeAll(() => { delete process.env.PUBLISHER_API_KEY; });
+    afterAll(() => { if (savedPublisherKey) process.env.PUBLISHER_API_KEY = savedPublisherKey; });
+
     it('rejects missing body', async () => {
         const res = await request(app)
             .post('/api/publisher/qiita/publish')
@@ -331,6 +345,9 @@ describe('POST /api/publisher/qiita/publish', () => {
 // WeChat input validation
 // ════════════════════════════════════════════════════════════════
 describe('POST /api/publisher/wechat/draft', () => {
+    beforeAll(() => { delete process.env.PUBLISHER_API_KEY; });
+    afterAll(() => { if (savedPublisherKey) process.env.PUBLISHER_API_KEY = savedPublisherKey; });
+
     it('rejects missing thumb_media_id', async () => {
         const res = await request(app)
             .post('/api/publisher/wechat/draft')


### PR DESCRIPTION
## Summary
This PR fixes environment variable isolation issues in the publisher API test suite by properly saving and restoring the `PUBLISHER_API_KEY` environment variable across test cases.

## Key Changes
- Save the original `PUBLISHER_API_KEY` value before any tests run
- Add `beforeAll` and `afterAll` hooks to each publisher endpoint test suite (devto, wordpress, telegraph, qiita, wechat) to isolate the environment variable state
- Each test suite now deletes `PUBLISHER_API_KEY` before running and restores it afterward
- Update the global `afterAll` hook to restore the saved value if it existed

## Implementation Details
The changes ensure that:
- Individual test suites can safely delete `PUBLISHER_API_KEY` without affecting other tests
- The original environment state is preserved after all tests complete
- Tests that validate API key requirements can run in isolation without interference from other test suites
- The solution handles both cases: when `PUBLISHER_API_KEY` was originally set and when it wasn't

https://claude.ai/code/session_014W5MpGMbq2NyWEyyu6Jw7W