### PR TITLE
fix: cache-busting for i18n.js in info.html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# [1.102.0](https://github.com/HankHuang0516/EClaw/compare/v1.101.0...v1.102.0) (2026-03-16)
+
+
+### Features
+
+* **i18n:** internationalize hard-coded Chinese in OpenClaw usecase examples ([#231](https://github.com/HankHuang0516/EClaw/issues/231)) ([099ac68](https://github.com/HankHuang0516/EClaw/commit/099ac68fcc75f1b7d1e8effca08cf9ce1479306f))
+
 # [1.101.0](https://github.com/HankHuang0516/EClaw/compare/v1.100.0...v1.101.0) (2026-03-16)
 
 

--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -2151,7 +2151,7 @@ Claude 主動查詢執行結果
     <script src="shared/nav.js"></script>
     <script src="shared/public-nav.js"></script>
     <script src="../shared/telemetry.js"></script>
-    <script src="../shared/i18n.js"></script>
+    <script src="../shared/i18n.js?v=1.2.1"></script>
     <script src="shared/footer.js"></script>
     <script>
         let currentUser = null;


### PR DESCRIPTION
## Summary
- Add `?v=1.2.1` cache-busting query to i18n.js script tag in info.html
- Fixes raw i18n keys (e.g. `guide_usecase_code_arch`) showing on page due to Cloudflare CDN serving stale i18n.js

https://claude.ai/code/session_01RhwQEHyFwL3zgrYpXFkRJW