### PR TITLE
fix: portal screen-control uses deviceSecret instead of botSecret

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -534,6 +534,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | Schedule Cron Update | `node backend/tests/test-schedule-cron-update.js` | Device ID + Secret | Regression: cron schedule update NOT NULL violation on scheduled_at |
 | Card Holder | `node backend/tests/test-card-holder.js` | Device ID + Secret | Card Holder CRUD lifecycle, search, refresh, pin, category, notes |
 | UI Text Contrast | `node backend/tests/test-ui-text-contrast.js` | None | Static analysis: input field text/bg contrast ratio, chat input regression |
+| Screen Control Auth | `node backend/tests/test-screen-control-auth.js` | Device ID + Secret | Regression: portal screen-capture/control uses deviceSecret not botSecret |
 
 ### Jest Unit Tests (CI-run, `npm test`, 11 files)
 

--- a/backend/public/portal/screen-control.html
+++ b/backend/public/portal/screen-control.html
@@ -310,13 +310,11 @@
             btn.textContent = 'Capturing...';
             document.getElementById('screenMeta').textContent = '';
 
-            // Use entity 0 and deviceSecret as botSecret for portal testing
-            // NOTE: For actual bot use, the bot uses its own botSecret
             try {
                 const data = await apiCall('POST', '/api/device/screen-capture', {
                     deviceId: currentUser.deviceId,
                     entityId: 0,
-                    botSecret: currentUser.deviceSecret  // portal uses deviceSecret for testing
+                    deviceSecret: currentUser.deviceSecret
                 });
 
                 if (data.success) {
@@ -410,7 +408,7 @@
                 const data = await apiCall('POST', '/api/device/control', {
                     deviceId: currentUser.deviceId,
                     entityId: 0,
-                    botSecret: currentUser.deviceSecret,
+                    deviceSecret: currentUser.deviceSecret,
                     command: cmd,
                     params
                 });

--- a/backend/run_all_tests.js
+++ b/backend/run_all_tests.js
@@ -65,6 +65,7 @@ const TEST_FILES = [
     'test-agent-card-ui.js',        // Agent Card CRUD lifecycle, field validation
     'test-publisher-platforms.js',  // Publisher platforms listing + input validation (8 platforms)
     'test-card-holder.js',          // Card Holder CRUD lifecycle, search, refresh, pin, category, notes
+    'test-screen-control-auth.js',  // Screen control portal auth: deviceSecret instead of botSecret
 ];
 
 // Manual UI tests (run on device, not automated):

--- a/backend/tests/test-screen-control-auth.js
+++ b/backend/tests/test-screen-control-auth.js
@@ -1,0 +1,132 @@
+/**
+ * Screen Control Auth — Regression Test
+ *
+ * Verifies that the screen-capture and control endpoints accept
+ * deviceSecret (portal/owner auth) WITHOUT requiring botSecret.
+ *
+ * Bug: Web Portal was sending botSecret=deviceSecret which fails
+ * because botSecret is checked against entity.botSecret (different value).
+ * Fix: Portal now sends deviceSecret directly.
+ *
+ * Test Scenarios:
+ *  1. POST /api/device/screen-capture with deviceSecret → should NOT return "Invalid botSecret"
+ *  2. POST /api/device/control with deviceSecret → should NOT return "Invalid botSecret"
+ *  3. Missing both botSecret and deviceSecret → 400
+ *  4. Wrong deviceSecret → should NOT authenticate as owner (falls through to bot auth)
+ *
+ * Usage:
+ *   node test-screen-control-auth.js
+ *   node test-screen-control-auth.js --local
+ *
+ * Credentials from backend/.env:
+ *   BROADCAST_TEST_DEVICE_ID, BROADCAST_TEST_DEVICE_SECRET
+ */
+
+const path = require('path');
+const fs   = require('fs');
+
+const args    = process.argv.slice(2);
+const isLocal = args.includes('--local');
+const API_BASE = isLocal ? 'http://localhost:3000' : 'https://eclawbot.com';
+
+// ── Load .env ────────────────────────────────────────────────────────────────
+const envPath = path.join(__dirname, '..', '.env');
+if (fs.existsSync(envPath)) {
+    for (const line of fs.readFileSync(envPath, 'utf8').split('\n')) {
+        const m = line.match(/^\s*([^#=]+?)\s*=\s*(.*?)\s*$/);
+        if (m && !process.env[m[1]]) process.env[m[1]] = m[2];
+    }
+}
+
+const DEVICE_ID     = process.env.BROADCAST_TEST_DEVICE_ID;
+const DEVICE_SECRET = process.env.BROADCAST_TEST_DEVICE_SECRET;
+
+if (!DEVICE_ID || !DEVICE_SECRET) {
+    console.error('Missing BROADCAST_TEST_DEVICE_ID / BROADCAST_TEST_DEVICE_SECRET in .env');
+    process.exit(1);
+}
+
+let passed = 0, failed = 0;
+
+function ok(label) { passed++; console.log(`  ✅ ${label}`); }
+function fail(label, detail) { failed++; console.error(`  ❌ ${label} — ${detail}`); }
+
+async function post(endpoint, body) {
+    const res = await fetch(`${API_BASE}${endpoint}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    });
+    const json = await res.json();
+    return { status: res.status, json };
+}
+
+async function run() {
+    console.log(`\n🖥️  Screen Control Auth Tests — ${API_BASE}\n`);
+
+    // Test 1: screen-capture with deviceSecret should NOT get "Invalid botSecret"
+    {
+        const { status, json } = await post('/api/device/screen-capture', {
+            deviceId: DEVICE_ID,
+            entityId: 0,
+            deviceSecret: DEVICE_SECRET,
+        });
+        if (json.error === 'Invalid botSecret') {
+            fail('screen-capture deviceSecret auth', `Got "Invalid botSecret" — owner auth not working`);
+        } else {
+            // Acceptable responses: device_offline (503), remote_control_disabled (403), or success
+            // The key thing is we did NOT get "Invalid botSecret"
+            ok(`screen-capture deviceSecret auth (status=${status}, result=${json.error || 'success'})`);
+        }
+    }
+
+    // Test 2: control with deviceSecret should NOT get "Invalid botSecret"
+    {
+        const { status, json } = await post('/api/device/control', {
+            deviceId: DEVICE_ID,
+            entityId: 0,
+            deviceSecret: DEVICE_SECRET,
+            command: 'back',
+        });
+        if (json.error === 'Invalid botSecret') {
+            fail('control deviceSecret auth', `Got "Invalid botSecret" — owner auth not working`);
+        } else {
+            ok(`control deviceSecret auth (status=${status}, result=${json.error || 'success'})`);
+        }
+    }
+
+    // Test 3: missing both secrets → 400
+    {
+        const { status } = await post('/api/device/screen-capture', {
+            deviceId: DEVICE_ID,
+            entityId: 0,
+        });
+        status === 400
+            ? ok('screen-capture missing secrets → 400')
+            : fail('screen-capture missing secrets', `expected 400, got ${status}`);
+    }
+
+    // Test 4: wrong deviceSecret should not authenticate as owner
+    {
+        const { status, json } = await post('/api/device/screen-capture', {
+            deviceId: DEVICE_ID,
+            entityId: 0,
+            deviceSecret: 'wrong-secret-value',
+        });
+        // Should fall through to bot auth and fail (no botSecret provided)
+        // or get "Entity not bound" / "Invalid botSecret" — either way, not 2xx
+        if (status >= 200 && status < 300) {
+            fail('wrong deviceSecret rejected', `expected auth failure, got ${status}`);
+        } else {
+            ok(`wrong deviceSecret rejected (status=${status})`);
+        }
+    }
+
+    // Summary
+    console.log(`\n${'─'.repeat(50)}`);
+    console.log(`  Results: ${passed} passed, ${failed} failed`);
+    console.log('─'.repeat(50) + '\n');
+    process.exit(failed > 0 ? 1 : 0);
+}
+
+run().catch(err => { console.error('Fatal:', err); process.exit(1); });


### PR DESCRIPTION
## Summary
- Portal screen-control.html was sending `botSecret: deviceSecret` which fails because backend checks it against `entity.botSecret` (a different value)
- Changed both `screen-capture` and `control` API calls to send `deviceSecret` instead, using the existing owner auth path
- Added regression test `test-screen-control-auth.js`

## Test plan
- [ ] Verify screen-capture no longer shows "Invalid botSecret" on Web Portal
- [ ] Verify control commands work from Web Portal
- [ ] Run `node backend/tests/test-screen-control-auth.js` against production

https://claude.ai/code/session_01EmA4WZMxeNLfdd7Mh9mVzA