### PR TITLE
fix: resolve 7 open issues — race condition, NPE, file delete, auto-save

### DIFF
--- a/app/src/main/java/com/hank/clawlive/FileManagerActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/FileManagerActivity.kt
@@ -395,6 +395,23 @@ class FileManagerActivity : AppCompatActivity() {
         }
         btnRow.addView(btnShare)
 
+        // Delete button
+        val btnDelete = MaterialButton(this, null, com.google.android.material.R.attr.materialButtonOutlinedStyle).apply {
+            text = getString(R.string.file_btn_delete)
+            setTextColor(getColor(com.google.android.material.R.color.design_default_color_error))
+            val lp = LinearLayout.LayoutParams(
+                ViewGroup.LayoutParams.WRAP_CONTENT,
+                ViewGroup.LayoutParams.WRAP_CONTENT
+            )
+            lp.marginStart = 16
+            layoutParams = lp
+            setOnClickListener {
+                dialog.dismiss()
+                confirmDeleteFile(file)
+            }
+        }
+        btnRow.addView(btnDelete)
+
         layout.addView(btnRow)
 
         dialog.setContentView(layout)
@@ -443,6 +460,41 @@ class FileManagerActivity : AppCompatActivity() {
             putExtra(Intent.EXTRA_SUBJECT, "E-Claw ${if (file.type == "photo") "Photo" else "Voice"}")
         }
         startActivity(Intent.createChooser(shareIntent, getString(R.string.file_btn_share)))
+    }
+
+    private fun confirmDeleteFile(file: DeviceFile) {
+        com.google.android.material.dialog.MaterialAlertDialogBuilder(this)
+            .setTitle(getString(R.string.file_delete_title))
+            .setMessage(getString(R.string.file_delete_confirm))
+            .setPositiveButton(getString(R.string.delete)) { _, _ -> performDeleteFile(file) }
+            .setNegativeButton(getString(R.string.cancel), null)
+            .show()
+    }
+
+    private fun performDeleteFile(file: DeviceFile) {
+        val deviceId = deviceManager.getDeviceId() ?: return
+        val deviceSecret = deviceManager.getDeviceSecret() ?: return
+        TelemetryHelper.trackAction("file_delete", mapOf("type" to file.type))
+
+        lifecycleScope.launch {
+            try {
+                val resp = api.deleteDeviceFile(file.id, deviceId, deviceSecret)
+                if (resp.success) {
+                    allFiles.removeAll { it.id == file.id }
+                    adapter.setFiles(allFiles)
+                    updateUI()
+                    Toast.makeText(this@FileManagerActivity,
+                        getString(R.string.file_deleted), Toast.LENGTH_SHORT).show()
+                } else {
+                    Toast.makeText(this@FileManagerActivity,
+                        getString(R.string.unknown_error), Toast.LENGTH_SHORT).show()
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Delete file failed")
+                Toast.makeText(this@FileManagerActivity,
+                    getString(R.string.unknown_error), Toast.LENGTH_SHORT).show()
+            }
+        }
     }
 
     private fun parseTimestamp(isoDate: String): Long? {

--- a/app/src/main/java/com/hank/clawlive/MissionControlActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/MissionControlActivity.kt
@@ -41,6 +41,7 @@ import com.hank.clawlive.ui.RecordingIndicatorHelper
 import com.hank.clawlive.ui.mission.*
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 import timber.log.Timber
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -106,6 +107,7 @@ class MissionControlActivity : AppCompatActivity() {
         observeState()
         loadEntityOptions()
         loadSkillTemplates()
+        viewModel.fetchSoulTemplates() // pre-fetch so data is warm when user opens dialog
     }
 
     private fun loadSkillTemplates() {
@@ -134,6 +136,32 @@ class MissionControlActivity : AppCompatActivity() {
     override fun onPause() {
         super.onPause()
         RecordingIndicatorHelper.detach()
+        // Auto-save and auto-notify on exit
+        autoSaveAndNotify()
+    }
+
+    private fun autoSaveAndNotify() {
+        if (!viewModel.uiState.value.hasLocalChanges && viewModel.getNotifiableItems().isEmpty()) return
+        viewModel.uploadDashboard(
+            onConflict = { _, _ -> /* Silent conflict — will resolve on next open */ },
+            onSuccess = {
+                // Auto-notify all changed items without prompt
+                val items = viewModel.getNotifiableItems()
+                if (items.isNotEmpty()) {
+                    val notifications = items.map { item ->
+                        mapOf<String, Any>(
+                            "type" to item.type,
+                            "title" to item.title,
+                            "priority" to item.priority,
+                            "entityIds" to item.entityIds,
+                            "url" to item.url
+                        )
+                    }
+                    viewModel.notifyEntities(notifications) { _, _ -> }
+                    viewModel.updateNotifiedSnapshot()
+                }
+            }
+        )
     }
 
     private fun loadEntityOptions() {
@@ -234,24 +262,8 @@ class MissionControlActivity : AppCompatActivity() {
             startActivity(Intent(this, ScheduleActivity::class.java))
         }
 
-        findViewById<MaterialButton>(R.id.btnUpload).setOnClickListener {
-            // Flush any pending auto-save first, then show notify prompt
-            viewModel.uploadDashboard(
-                onConflict = { yourVersion, serverVersion ->
-                    runOnUiThread {
-                        MaterialAlertDialogBuilder(this)
-                            .setTitle(getString(R.string.version_conflict_title))
-                            .setMessage(getString(R.string.version_conflict_message, yourVersion, serverVersion))
-                            .setPositiveButton(getString(R.string.download_latest)) { _, _ -> viewModel.downloadDashboard() }
-                            .setNegativeButton(R.string.cancel, null)
-                            .show()
-                    }
-                },
-                onSuccess = {
-                    runOnUiThread { showNotifyPrompt() }
-                }
-            )
-        }
+        // Hide the publish notification button — replaced by auto-save+notify on exit
+        findViewById<MaterialButton>(R.id.btnUpload).visibility = View.GONE
 
         findViewById<MaterialButton>(R.id.btnAddTodo).setOnClickListener { showAddItemDialog() }
         findViewById<MaterialButton>(R.id.btnAddSkill).setOnClickListener { showAddSkillDialog() }
@@ -388,7 +400,7 @@ class MissionControlActivity : AppCompatActivity() {
             priorities.map { it.label })
 
         etTitle.setText(item.title)
-        etDescription.setText(item.description)
+        etDescription.setText(item.description ?: "")
         spinnerPriority.setSelection(priorities.indexOf(item.priority ?: Priority.MEDIUM))
 
         val selectedEntities = item.assignedBot?.split(",")?.map { it.trim() } ?: emptyList()
@@ -477,7 +489,7 @@ class MissionControlActivity : AppCompatActivity() {
 
         etTitle.setText(note.title)
         etContent.setText(note.content)
-        etCategory.setText(note.category)
+        etCategory.setText(note.category ?: "")
 
         val dialog = MaterialAlertDialogBuilder(this)
             .setTitle(getString(R.string.edit))
@@ -677,8 +689,8 @@ class MissionControlActivity : AppCompatActivity() {
 
         if (skill != null) {
             etTitle.setText(skill.title)
-            etUrl.setText(skill.url)
-            etSteps.setText(skill.steps)
+            etUrl.setText(skill.url ?: "")
+            etSteps.setText(skill.steps ?: "")
             // System skills: lock title and URL
             if (skill.isSystem) {
                 etTitle.isEnabled = false
@@ -865,7 +877,7 @@ class MissionControlActivity : AppCompatActivity() {
         // Pre-fill fields and button label when editing existing soul
         if (soul != null) {
             etName.setText(soul.name)
-            etDescription.setText(soul.description)
+            etDescription.setText(soul.description ?: "")
             val existingTpl = soulTemplates.find { it.id == soul.templateId }
             if (existingTpl != null) {
                 btnChooseSoulTemplate.text = "🎭 ${getTemplateDisplayName(existingTpl)}"
@@ -874,22 +886,31 @@ class MissionControlActivity : AppCompatActivity() {
 
         // Single Gallery button — shows built-in + community templates unified
         btnChooseSoulTemplate.setOnClickListener {
-            viewModel.fetchSoulTemplates() // trigger background fetch (non-blocking)
-            val builtinList = soulTemplates.map { tpl ->
-                SoulGalleryDialog.BuiltinTemplate(
-                    id          = tpl.id,
-                    icon        = tpl.icon,
-                    name        = getTemplateDisplayName(tpl),
-                    description = getTemplateDescription(tpl)
-                )
+            lifecycleScope.launch {
+                // If community templates aren't loaded yet, fetch and wait
+                if (viewModel.soulTemplates.value.isEmpty()) {
+                    viewModel.fetchSoulTemplates()
+                    // Wait for data to arrive (up to 5s)
+                    withTimeoutOrNull(5000) {
+                        viewModel.soulTemplates.first { it.isNotEmpty() }
+                    }
+                }
+                val builtinList = soulTemplates.map { tpl ->
+                    SoulGalleryDialog.BuiltinTemplate(
+                        id          = tpl.id,
+                        icon        = tpl.icon,
+                        name        = getTemplateDisplayName(tpl),
+                        description = getTemplateDescription(tpl)
+                    )
+                }
+                val communityList = viewModel.soulTemplates.value
+                SoulGalleryDialog(this@MissionControlActivity, builtinList, communityList) { name, desc, templateId ->
+                    etName.setText(name)
+                    etDescription.setText(desc)
+                    selectedTemplateId = templateId
+                    btnChooseSoulTemplate.text = "🎭 $name"
+                }.show()
             }
-            val communityList = viewModel.soulTemplates.value
-            SoulGalleryDialog(this, builtinList, communityList) { name, desc, templateId ->
-                etName.setText(name)
-                etDescription.setText(desc)
-                selectedTemplateId = templateId
-                btnChooseSoulTemplate.text = "🎭 $name"
-            }.show()
         }
 
         val checkboxes = buildEntityCheckboxes(container, soul?.assignedEntities ?: emptyList())

--- a/app/src/main/java/com/hank/clawlive/data/model/MissionControl.kt
+++ b/app/src/main/java/com/hank/clawlive/data/model/MissionControl.kt
@@ -34,7 +34,7 @@ enum class MissionStatus(val label: String) {
 data class MissionItem(
     val id: String = UUID.randomUUID().toString(),
     val title: String,
-    val description: String = "",
+    val description: String? = null,
     val priority: Priority? = Priority.MEDIUM,
     val status: MissionStatus? = MissionStatus.PENDING,
     val assignedBot: String? = null,  // 負責的 bot ID
@@ -42,7 +42,7 @@ data class MissionItem(
     val createdAt: Long = System.currentTimeMillis(),
     val updatedAt: Long = System.currentTimeMillis(),
     val completedAt: Long? = null,
-    val createdBy: String = "user"
+    val createdBy: String? = null
 )
 
 /**
@@ -52,10 +52,10 @@ data class MissionNote(
     val id: String = UUID.randomUUID().toString(),
     val title: String,
     val content: String,
-    val category: String = "general",
+    val category: String? = null,
     val createdAt: Long = System.currentTimeMillis(),
     val updatedAt: Long = System.currentTimeMillis(),
-    val createdBy: String = "user"
+    val createdBy: String? = null
 )
 
 /**
@@ -89,13 +89,13 @@ enum class RuleType {
 data class MissionSkill(
     val id: String = UUID.randomUUID().toString(),
     val title: String,
-    val url: String = "",
-    val steps: String = "",
+    val url: String? = null,
+    val steps: String? = null,
     val assignedEntities: List<String> = emptyList(),
     val isSystem: Boolean = false,
     val createdAt: Long = System.currentTimeMillis(),
     val updatedAt: Long = System.currentTimeMillis(),
-    val createdBy: String = "user"
+    val createdBy: String? = null
 )
 
 /**
@@ -104,13 +104,13 @@ data class MissionSkill(
 data class MissionSoul(
     val id: String = UUID.randomUUID().toString(),
     val name: String,
-    val description: String = "",
+    val description: String? = null,
     val templateId: String? = null,
     val assignedEntities: List<String> = emptyList(),
     val isActive: Boolean = true,
     val createdAt: Long = System.currentTimeMillis(),
     val updatedAt: Long = System.currentTimeMillis(),
-    val createdBy: String = "user"
+    val createdBy: String? = null
 )
 
 /**

--- a/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
@@ -277,6 +277,13 @@ interface ClawApiService {
         @Query("since") since: Long? = null
     ): DeviceFilesResponse
 
+    @DELETE("api/device/files/{fileId}")
+    suspend fun deleteDeviceFile(
+        @Path("fileId") fileId: String,
+        @Query("deviceId") deviceId: String,
+        @Query("deviceSecret") deviceSecret: String
+    ): GenericResponse
+
     // ============================================
     // MISSION CONTROL DASHBOARD
     // Auth: deviceId + deviceSecret in query/body

--- a/app/src/main/java/com/hank/clawlive/ui/mission/MissionItemAdapter.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/mission/MissionItemAdapter.kt
@@ -64,7 +64,7 @@ class MissionItemAdapter(
             tvStatus.text = item.status?.label ?: "待處理"
 
             // Description (Markdown)
-            if (item.description.isNotBlank()) {
+            if (!item.description.isNullOrBlank()) {
                 markwon?.setMarkdown(tvDescription, item.description)
                 tvDescription.visibility = View.VISIBLE
             } else {

--- a/app/src/main/java/com/hank/clawlive/ui/mission/MissionNoteAdapter.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/mission/MissionNoteAdapter.kt
@@ -37,7 +37,7 @@ class MissionNoteAdapter(
         fun bind(note: MissionNote) {
             tvTitle.text = note.title
             markwon?.setMarkdown(tvContent, note.content) ?: run { tvContent.text = note.content }
-            tvCategory.text = note.category
+            tvCategory.text = note.category ?: ""
 
             itemView.setOnClickListener { onNoteClick(note) }
             itemView.setOnLongClickListener {

--- a/app/src/main/java/com/hank/clawlive/ui/mission/MissionSkillAdapter.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/mission/MissionSkillAdapter.kt
@@ -46,7 +46,7 @@ class MissionSkillAdapter(
                 tvEntities.visibility = View.GONE
             }
 
-            if (skill.url.isNotBlank()) {
+            if (!skill.url.isNullOrBlank()) {
                 tvUrl.text = skill.url
                 tvUrl.visibility = View.VISIBLE
             } else {

--- a/app/src/main/java/com/hank/clawlive/ui/mission/MissionSoulAdapter.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/mission/MissionSoulAdapter.kt
@@ -50,7 +50,7 @@ class MissionSoulAdapter(
                 tvEntities.visibility = View.GONE
             }
 
-            if (soul.description.isNotBlank()) {
+            if (!soul.description.isNullOrBlank()) {
                 tvDescription.text = soul.description.take(100)
                 tvDescription.visibility = View.VISIBLE
             } else {

--- a/app/src/main/java/com/hank/clawlive/ui/mission/SoulGalleryDialog.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/mission/SoulGalleryDialog.kt
@@ -107,16 +107,17 @@ class SoulGalleryDialog(
                     else ""
                 row.findViewById<TextView>(R.id.tvGalleryMeta).text = meta
                 row.findViewById<TextView>(R.id.tvGalleryStatus).apply {
-                    text = item.description.take(60) + if (item.description.length > 60) "…" else ""
+                    val desc = item.description ?: ""
+                    text = desc.take(60) + if (desc.length > 60) "…" else ""
                     setTextColor(android.graphics.Color.parseColor("#888888"))
                 }
                 row.setOnClickListener {
                     dialog?.dismiss()
-                    onSelected(item.name, item.description, item.templateId)
+                    onSelected(item.name, item.description ?: "", item.templateId)
                 }
                 row.findViewById<MaterialButton>(R.id.btnGallerySelect).setOnClickListener {
                     dialog?.dismiss()
-                    onSelected(item.name, item.description, item.templateId)
+                    onSelected(item.name, item.description ?: "", item.templateId)
                 }
                 listLayout.addView(row)
             }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -520,6 +520,10 @@ If you have any questions, please contact us via our official email.
     <string name="file_type_voice">Voice</string>
     <string name="file_btn_download">Download</string>
     <string name="file_btn_share">Share</string>
+    <string name="file_btn_delete">Delete</string>
+    <string name="file_delete_title">Delete File</string>
+    <string name="file_delete_confirm">Are you sure you want to delete this file?</string>
+    <string name="file_deleted">File deleted</string>
     <string name="file_load_more">Load More</string>
     <string name="file_playing_voice">Playing voice…</string>
     <string name="file_playback_done">Playback complete</string>

--- a/backend/index.js
+++ b/backend/index.js
@@ -491,7 +491,7 @@ async function initPersistence() {
     await backfillPublicCodes();
 
     // Load DB-approved skill contributions (supplements git-tracked skill-templates.json)
-    if (usePostgreSQL) loadApprovedContributions();
+    if (usePostgreSQL) await loadApprovedContributions();
 
     persistenceReady = true;
     console.log(`[Persistence] Ready — ${Object.keys(devices).length} devices loaded`);
@@ -10467,6 +10467,70 @@ app.get('/api/device/files', async (req, res) => {
     } catch (error) {
         console.error('[Files] List error:', error);
         res.status(500).json({ success: false, error: 'Failed to list files' });
+    }
+});
+
+// ============================================
+// DELETE DEVICE FILE (remove chat media record)
+// ============================================
+app.delete('/api/device/files/:fileId', async (req, res) => {
+    const { fileId } = req.params;
+    const deviceId = req.query.deviceId || req.body.deviceId;
+    const deviceSecret = req.query.deviceSecret || req.body.deviceSecret;
+
+    if (!deviceId || !deviceSecret) {
+        return res.status(400).json({ success: false, error: 'Missing credentials' });
+    }
+
+    const device = devices[deviceId];
+    if (!device || device.deviceSecret !== deviceSecret) {
+        const jwt = require('jsonwebtoken');
+        const token = req.cookies && req.cookies.eclaw_session;
+        if (token) {
+            try {
+                const decoded = jwt.verify(token, process.env.JWT_SECRET || 'dev-secret-change-in-production');
+                if (decoded.deviceId !== deviceId) {
+                    return res.status(401).json({ success: false, error: 'Invalid credentials' });
+                }
+            } catch {
+                return res.status(401).json({ success: false, error: 'Invalid credentials' });
+            }
+        } else {
+            return res.status(401).json({ success: false, error: 'Invalid credentials' });
+        }
+    }
+
+    try {
+        // Verify the file belongs to this device before deleting
+        const check = await chatPool.query(
+            'SELECT id, media_url FROM chat_messages WHERE id = $1 AND device_id = $2',
+            [fileId, deviceId]
+        );
+        if (check.rows.length === 0) {
+            return res.status(404).json({ success: false, error: 'File not found' });
+        }
+
+        // Delete the chat message record (and any broadcast duplicates with same media_url)
+        const mediaUrl = check.rows[0].media_url;
+        const deleted = await chatPool.query(
+            'DELETE FROM chat_messages WHERE device_id = $1 AND media_url = $2 RETURNING id',
+            [deviceId, mediaUrl]
+        );
+
+        // Also delete from chat_uploads if it was a DB-stored file
+        if (mediaUrl && mediaUrl.includes('/api/chat/file/')) {
+            const uploadIdMatch = mediaUrl.match(/\/api\/chat\/file\/(\d+)/);
+            if (uploadIdMatch) {
+                await chatPool.query('DELETE FROM chat_uploads WHERE id = $1 AND device_id = $2',
+                    [parseInt(uploadIdMatch[1]), deviceId]);
+            }
+        }
+
+        serverLog(deviceId, 'file_delete', `Deleted file ${fileId} (${deleted.rowCount} records)`);
+        res.json({ success: true, deletedCount: deleted.rowCount });
+    } catch (error) {
+        console.error('[Files] Delete error:', error);
+        res.status(500).json({ success: false, error: 'Failed to delete file' });
     }
 });
 

--- a/backend/public/portal/files.html
+++ b/backend/public/portal/files.html
@@ -175,6 +175,31 @@
             opacity: 0.5;
         }
 
+        /* Delete button on file card */
+        .file-delete-btn {
+            position: absolute;
+            top: 6px;
+            right: 6px;
+            width: 28px;
+            height: 28px;
+            border-radius: 50%;
+            background: rgba(0,0,0,0.55);
+            color: #fff;
+            border: none;
+            cursor: pointer;
+            font-size: 14px;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            z-index: 2;
+        }
+        .file-card:hover .file-delete-btn {
+            display: flex;
+        }
+        .file-delete-btn:hover {
+            background: var(--error, #e53e3e);
+        }
+
         /* Multi-entity badge overlay on thumbnail */
         .entity-badges {
             position: absolute;
@@ -718,8 +743,10 @@
                 const entityBadgesHtml = renderEntityBadges(file);
                 const entityNamesHtml = renderEntityNames(file);
 
+                const deleteBtn = '<button class="file-delete-btn" onclick="event.stopPropagation();deleteFile(' + idx + ')" title="Delete">&#x2715;</button>';
                 if (file.type === 'photo') {
                     return '<div class="file-card" onclick="previewFile(' + idx + ')">' +
+                        deleteBtn +
                         '<div class="file-thumb">' +
                         '<img src="' + escapeHtml(file.url) + '" alt="photo" loading="lazy" onerror="this.parentElement.innerHTML=\'<div class=file-thumb-icon>🖼️</div>\'">' +
                         entityBadgesHtml +
@@ -733,6 +760,7 @@
                         '</div></div>';
                 } else {
                     return '<div class="file-card" onclick="previewFile(' + idx + ')">' +
+                        deleteBtn +
                         '<div class="file-thumb">' +
                         '<div class="file-thumb-icon">🎙️</div>' +
                         entityBadgesHtml +
@@ -792,6 +820,7 @@
                 '<div class="preview-actions">' +
                 (file.type === 'photo' ? '<button class="btn btn-primary btn-sm" onclick="downloadFile(' + idx + ')">' + i18n.t('files_btn_download') + '</button>' : '') +
                 '<button class="btn btn-outline btn-sm" onclick="shareFile(' + idx + ')">' + i18n.t('files_btn_share') + '</button>' +
+                '<button class="btn btn-outline btn-sm" style="color:var(--error,#e53e3e);border-color:var(--error,#e53e3e)" onclick="deleteFile(' + idx + ')">' + i18n.t('files_btn_delete', 'Delete') + '</button>' +
                 '</div>';
 
             document.body.appendChild(overlay);
@@ -871,6 +900,30 @@
                     showToast(i18n.t('files_share_failed'), 'error');
                 }
                 document.body.removeChild(ta);
+            }
+        }
+
+        // --- Delete ---
+        async function deleteFile(idx) {
+            const file = allFiles[idx];
+            if (!file) return;
+            if (!confirm(i18n.t('files_delete_confirm', 'Are you sure you want to delete this file?'))) return;
+
+            try {
+                const resp = await apiCall('/api/device/files/' + file.id + '?deviceId=' + encodeURIComponent(deviceId) + '&deviceSecret=' + encodeURIComponent(deviceSecret), { method: 'DELETE' });
+                if (resp.success) {
+                    allFiles.splice(idx, 1);
+                    renderFiles();
+                    updateStats();
+                    // Close preview overlay if open
+                    const overlay = document.querySelector('.preview-overlay');
+                    if (overlay) overlay.remove();
+                    showToast(i18n.t('files_deleted', 'File deleted'), 'success');
+                } else {
+                    showToast(resp.error || 'Delete failed', 'error');
+                }
+            } catch (e) {
+                showToast(i18n.t('files_delete_failed', 'Failed to delete file'), 'error');
             }
         }
 

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -467,7 +467,6 @@
             <h1 class="page-title" data-i18n="nav_mission">Mission</h1>
             <div class="header-actions">
                 <button class="btn btn-outline" onclick="downloadDashboard()" data-i18n="mc_refresh">Refresh</button>
-                <button class="btn btn-primary" id="btnNotify" onclick="publishNotification()" data-i18n="mc_notify_btn">Publish Notification</button>
             </div>
         </div>
 
@@ -2135,13 +2134,65 @@
                 || JSON.stringify(soul.assignedEntities || []) !== JSON.stringify(prev.assignedEntities || []);
         }
 
-        // --- Cleanup ---
-        window.addEventListener('beforeunload', (e) => {
+        // --- Auto-save & auto-notify on exit ---
+        async function saveAndNotifyOnExit() {
             if (refreshTimer) clearInterval(refreshTimer);
-            // Warn if unsaved changes
-            if (hasChanges) {
-                e.preventDefault();
-                e.returnValue = '';
+
+            // Flush pending auto-save
+            if (autoSaveTimer) { clearTimeout(autoSaveTimer); autoSaveTimer = null; }
+
+            // Save if there are pending changes
+            if (hasChanges && !isSyncing) {
+                try {
+                    const data = await apiCall('POST', '/api/mission/dashboard', {
+                        deviceId: currentUser.deviceId,
+                        deviceSecret: currentUser.deviceSecret,
+                        version: version,
+                        dashboard: dashboard
+                    });
+                    if (data.success) {
+                        version = data.version || version + 1;
+                        hasChanges = false;
+                        lastSavedDashboard = JSON.parse(JSON.stringify(dashboard));
+                    }
+                } catch (e) {
+                    console.warn('Exit auto-save failed:', e.message);
+                }
+            }
+
+            // Auto-notify all changed items (no prompt)
+            const items = getNotifiableItems();
+            if (items.length > 0) {
+                const notifications = items.map(item => ({
+                    type: item.type,
+                    title: item.title,
+                    priority: item.priority,
+                    entityIds: item.entityIds,
+                    url: item.url || ''
+                }));
+                apiCall('POST', '/api/mission/notify', {
+                    deviceId: currentUser.deviceId,
+                    deviceSecret: currentUser.deviceSecret,
+                    notifications
+                }).catch(() => {});
+                updateNotifiedSnapshot();
+            }
+        }
+
+        // Use visibilitychange (reliable) + beforeunload (fallback)
+        let exitHandled = false;
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'hidden' && !exitHandled) {
+                exitHandled = true;
+                saveAndNotifyOnExit();
+                // Reset after a short delay in case user comes back
+                setTimeout(() => { exitHandled = false; }, 3000);
+            }
+        });
+        window.addEventListener('beforeunload', () => {
+            if (!exitHandled) {
+                exitHandled = true;
+                saveAndNotifyOnExit();
             }
         });
     </script>

--- a/backend/tests/jest/file-delete.test.js
+++ b/backend/tests/jest/file-delete.test.js
@@ -1,0 +1,29 @@
+/**
+ * Jest test: DELETE /api/device/files/:fileId
+ * Validates file delete endpoint input validation and auth
+ */
+const request = require('supertest');
+const app = require('../../index');
+
+describe('DELETE /api/device/files/:fileId', () => {
+    const FAKE_FILE_ID = '00000000-0000-0000-0000-000000000000';
+
+    // Warm up the app (wait for init to settle)
+    beforeAll(async () => {
+        await request(app).get('/api/health');
+    });
+
+    it('returns 400 when credentials are missing', async () => {
+        const res = await request(app).delete(`/api/device/files/${FAKE_FILE_ID}`);
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+        expect(res.body.error).toMatch(/Missing credentials/i);
+    });
+
+    it('returns 401 when deviceSecret is wrong', async () => {
+        const res = await request(app)
+            .delete(`/api/device/files/${FAKE_FILE_ID}?deviceId=nonexistent&deviceSecret=wrong`);
+        expect(res.status).toBe(401);
+        expect(res.body.success).toBe(false);
+    });
+});

--- a/ios-app/app/file-manager.tsx
+++ b/ios-app/app/file-manager.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useCallback } from 'react';
-import { View, FlatList, StyleSheet, Image, TouchableOpacity, Dimensions } from 'react-native';
+import { View, FlatList, StyleSheet, Image, TouchableOpacity, Dimensions, Alert } from 'react-native';
 import {
   Text,
   Chip,
@@ -90,8 +90,43 @@ export default function FileManagerScreen() {
     }
   };
 
+  const handleDelete = (file: MediaFile) => {
+    Alert.alert(
+      t('files.delete_title', 'Delete File'),
+      t('files.delete_confirm', 'Are you sure you want to delete this file?'),
+      [
+        { text: t('common.cancel', 'Cancel'), style: 'cancel' },
+        {
+          text: t('common.delete', 'Delete'),
+          style: 'destructive',
+          onPress: async () => {
+            try {
+              await fileApi.delete(file.id);
+              setFiles((prev) => prev.filter((f) => f.id !== file.id));
+              setSnack(t('files.deleted', 'File deleted'));
+            } catch {
+              setSnack(t('errors.server'));
+            }
+          },
+        },
+      ],
+    );
+  };
+
+  const handleLongPress = (file: MediaFile) => {
+    Alert.alert(
+      file.filename || (file.type === 'image' ? 'Photo' : 'Audio'),
+      undefined,
+      [
+        { text: t('files.share', 'Share'), onPress: () => handleShare(file) },
+        { text: t('files.delete', 'Delete'), style: 'destructive', onPress: () => handleDelete(file) },
+        { text: t('common.cancel', 'Cancel'), style: 'cancel' },
+      ],
+    );
+  };
+
   const renderItem = ({ item }: { item: MediaFile }) => (
-    <TouchableOpacity style={styles.gridItem} onLongPress={() => handleShare(item)}>
+    <TouchableOpacity style={styles.gridItem} onLongPress={() => handleLongPress(item)}>
       {item.type === 'image' ? (
         <Image source={{ uri: item.url }} style={styles.image} resizeMode="cover" />
       ) : (

--- a/ios-app/services/api.ts
+++ b/ios-app/services/api.ts
@@ -214,6 +214,8 @@ export const fileApi = {
     apiClient.get('/api/device/files', { params }),
   download: (fileId: string) =>
     apiClient.get(`/api/chat/file/${fileId}`, { responseType: 'blob' }),
+  delete: (fileId: string) =>
+    apiClient.delete(`/api/device/files/${fileId}`),
 };
 
 // ── Feedback APIs ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **#244-#247** (Soul template race condition): Added `await` to `loadApprovedContributions()` on backend; pre-fetch + coroutine wait on Android dialog
- **#242** (MissionSkill.steps NPE): Changed all `String = ""` fields to `String? = null` in mission data models, updated 13 null-safe call sites across 6 files
- **#249** (File delete): New `DELETE /api/device/files/:fileId` endpoint + delete UI on Web Portal, Android, iOS
- **#243** (Auto-save on exit): Removed Publish Notification button, auto-save + auto-notify on page exit via `visibilitychange`/`onPause()`
- **#248, #211**: Analysis comments added, left open for discussion

## Test plan

- [x] Backend Jest tests: 213/213 pass
- [x] ESLint: 0 errors
- [ ] Verify soul template dialog shows all 300+ templates on first open
- [ ] Verify file delete works on Web Portal
- [ ] Verify mission auto-save fires on page exit
- [ ] Android build verification

https://claude.ai/code/session_01LGdHdfY4HEAr4kJ46zCDWK