### PR TITLE
fix: add proper mocks to file-delete Jest test for CI

### DIFF
--- a/backend/tests/jest/file-delete.test.js
+++ b/backend/tests/jest/file-delete.test.js
@@ -2,16 +2,164 @@
  * Jest test: DELETE /api/device/files/:fileId
  * Validates file delete endpoint input validation and auth
  */
+
+// ── Same mocks as health.test.js ──
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+        connect: jest.fn().mockResolvedValue({
+            query: jest.fn().mockResolvedValue({ rows: [] }),
+            release: jest.fn(),
+        }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+jest.mock('../../db', () => ({
+    initDatabase: jest.fn().mockResolvedValue(false),
+    saveDeviceData: jest.fn().mockResolvedValue(true),
+    saveAllDevices: jest.fn().mockResolvedValue(true),
+    loadAllDevices: jest.fn().mockResolvedValue({}),
+    deleteDevice: jest.fn().mockResolvedValue(true),
+    getStats: jest.fn().mockResolvedValue({}),
+    closeDatabase: jest.fn().mockResolvedValue(undefined),
+    saveOfficialBot: jest.fn().mockResolvedValue(true),
+    loadOfficialBots: jest.fn().mockResolvedValue({}),
+    deleteOfficialBot: jest.fn().mockResolvedValue(true),
+    saveOfficialBinding: jest.fn().mockResolvedValue(true),
+    removeOfficialBinding: jest.fn().mockResolvedValue(true),
+    getOfficialBinding: jest.fn().mockResolvedValue(null),
+    getDeviceOfficialBindings: jest.fn().mockResolvedValue([]),
+    updateSubscriptionVerified: jest.fn().mockResolvedValue(true),
+    loadAllOfficialBindings: jest.fn().mockResolvedValue([]),
+    getExpiredPersonalBindings: jest.fn().mockResolvedValue([]),
+    getPaidBorrowSlots: jest.fn().mockResolvedValue(0),
+    incrementPaidBorrowSlots: jest.fn().mockResolvedValue(true),
+    saveFeedback: jest.fn().mockResolvedValue({ id: 1 }),
+}));
+
+jest.mock('../../flickr', () => ({
+    initFlickr: jest.fn(),
+    uploadPhoto: jest.fn().mockResolvedValue(null),
+    isAvailable: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('../../scheduler', () => ({
+    init: jest.fn(),
+    createSchedule: jest.fn().mockResolvedValue({ id: 1 }),
+    updateSchedule: jest.fn().mockResolvedValue(true),
+    deleteSchedule: jest.fn().mockResolvedValue(true),
+    getSchedules: jest.fn().mockResolvedValue([]),
+    getSchedule: jest.fn().mockResolvedValue(null),
+    getSchedulesForBot: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../../device-telemetry', () => ({
+    initTelemetryTable: jest.fn().mockResolvedValue(undefined),
+    appendEntries: jest.fn().mockResolvedValue(undefined),
+    captureApiCall: jest.fn().mockResolvedValue(undefined),
+    getEntries: jest.fn().mockResolvedValue([]),
+    getSummary: jest.fn().mockResolvedValue({}),
+    clearEntries: jest.fn().mockResolvedValue(undefined),
+    createMiddleware: jest.fn().mockReturnValue((_req, _res, next) => next()),
+    sanitize: jest.fn().mockImplementation((v) => v),
+    MAX_BUFFER_BYTES: 1024 * 1024,
+    MAX_ENTRIES: 500,
+}));
+
+jest.mock('../../device-feedback', () => ({
+    initFeedbackTable: jest.fn().mockResolvedValue(undefined),
+    initFeedbackPhotosTable: jest.fn().mockResolvedValue(undefined),
+    captureLogSnapshot: jest.fn().mockResolvedValue([]),
+    captureDeviceState: jest.fn().mockResolvedValue({}),
+    autoTriage: jest.fn().mockResolvedValue('low'),
+    generateAiPrompt: jest.fn().mockReturnValue(''),
+    saveFeedback: jest.fn().mockResolvedValue({ id: 1 }),
+    getFeedbackList: jest.fn().mockResolvedValue([]),
+    getFeedbackById: jest.fn().mockResolvedValue(null),
+    updateFeedback: jest.fn().mockResolvedValue(true),
+    createGithubIssue: jest.fn().mockResolvedValue(null),
+    getPendingDebugFeedback: jest.fn().mockResolvedValue([]),
+    saveDebugResult: jest.fn().mockResolvedValue(true),
+    setMark: jest.fn().mockResolvedValue(undefined),
+    getMark: jest.fn().mockResolvedValue(null),
+    clearMark: jest.fn().mockResolvedValue(undefined),
+    LOG_WINDOW_MS: 60000,
+    MAX_PHOTOS_PER_FEEDBACK: 10,
+    MAX_PHOTO_SIZE: 5 * 1024 * 1024,
+    saveFeedbackPhoto: jest.fn().mockResolvedValue({ id: 1 }),
+    getFeedbackPhotos: jest.fn().mockResolvedValue([]),
+    getFeedbackPhoto: jest.fn().mockResolvedValue(null),
+    deleteFeedbackPhotos: jest.fn().mockResolvedValue(undefined),
+    cleanupResolvedFeedbackPhotos: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../gatekeeper', () => ({
+    detectMaliciousMessage: jest.fn().mockReturnValue({ isMalicious: false }),
+    detectAndMaskLeaks: jest.fn().mockImplementation((text) => text),
+    initGatekeeperTable: jest.fn().mockResolvedValue(undefined),
+    loadBlockedDevices: jest.fn().mockResolvedValue(undefined),
+    recordViolation: jest.fn().mockResolvedValue(undefined),
+    isDeviceBlocked: jest.fn().mockReturnValue(false),
+    getStrikeInfo: jest.fn().mockResolvedValue({ strikes: 0, blocked: false }),
+    getFreeBotTOS: jest.fn().mockResolvedValue(null),
+    hasAgreedToTOS: jest.fn().mockResolvedValue(false),
+    recordTOSAgreement: jest.fn().mockResolvedValue(undefined),
+    setServerLog: jest.fn(),
+    MAX_STRIKES: 3,
+    FREE_BOT_TOS_VERSION: '1.0',
+}));
+
+jest.mock('../../mission', () => {
+    const express = jest.requireActual('express');
+    return jest.fn().mockReturnValue({
+        router: express.Router(),
+        initMissionDatabase: jest.fn().mockResolvedValue(undefined),
+        setNotifyCallback: jest.fn(),
+        setPushToBot: jest.fn(),
+        setPushToChannelCallback: jest.fn(),
+    });
+});
+
+jest.mock('../../auth', () => {
+    const express = jest.requireActual('express');
+    const noop = (_req, _res, next) => next();
+    return jest.fn().mockReturnValue({
+        router: express.Router(),
+        authMiddleware: noop,
+        softAuthMiddleware: noop,
+        adminMiddleware: noop,
+        initAuthDatabase: jest.fn().mockResolvedValue(undefined),
+        pool: {
+            query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+        },
+    });
+});
+
+jest.mock('../../subscription', () => {
+    const express = jest.requireActual('express');
+    return jest.fn().mockReturnValue({
+        router: express.Router(),
+        loadPremiumStatus: jest.fn().mockResolvedValue(undefined),
+    });
+});
+
+// ── Load app after mocks are established ──
 const request = require('supertest');
-const app = require('../../index');
+let app;
+
+beforeAll(() => {
+    app = require('../../index');
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+    jest.resetModules();
+});
 
 describe('DELETE /api/device/files/:fileId', () => {
     const FAKE_FILE_ID = '00000000-0000-0000-0000-000000000000';
-
-    // Warm up the app (wait for init to settle)
-    beforeAll(async () => {
-        await request(app).get('/api/health');
-    });
 
     it('returns 400 when credentials are missing', async () => {
         const res = await request(app).delete(`/api/device/files/${FAKE_FILE_ID}`);


### PR DESCRIPTION
Adds the standard mock setup to file-delete.test.js that was missing, causing CI failure.

https://claude.ai/code/session_01LGdHdfY4HEAr4kJ46zCDWK