### PR TITLE
fix: remove duplicate let currentUser in card-holder.html

### DIFF
--- a/backend/public/portal/card-holder.html
+++ b/backend/public/portal/card-holder.html
@@ -675,7 +675,6 @@
     <script src="shared/footer.js"></script>
     <script src="shared/ai-chat.js"></script>
     <script>
-        let currentUser = null;
         let allCards = [];
         let myCards = [];
         let recentCards = [];

--- a/backend/run_all_tests.js
+++ b/backend/run_all_tests.js
@@ -66,6 +66,7 @@ const TEST_FILES = [
     'test-grpc-transport.js',       // gRPC: Proto loading, gRPC server, HealthService
     'test-skill-templates.js',      // Skill templates: CRUD, requiredVars format, Gson compat
     'test-ui-text-contrast.js',     // UI: input field text/bg contrast ratio
+    'test-portal-duplicate-vars.js', // Portal: no duplicate let/const vs shared scripts
     'test-ux-static-audit.js',      // UX Layer 1: static audit (i18n, form, error, loading, empty, auth, telemetry, a11y, script order)
     'test-ux-parity.js',            // UX Layer 2: cross-platform API-UI parity (Web/Android/iOS)
     'test-ux-live-validation.js',   // UX Layer 3: live endpoint validation (portal pages, auth, API smoke)

--- a/backend/tests/test-portal-duplicate-vars.js
+++ b/backend/tests/test-portal-duplicate-vars.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Portal Duplicate Variable Declaration — Static Analysis Test
+ *
+ * Scans portal HTML pages for `let`/`const` variable declarations that
+ * conflict with variables already declared in shared scripts (auth.js, etc.).
+ *
+ * In browsers, all <script> tags share the same global scope. A `let` or
+ * `const` redeclaration causes an uncaught SyntaxError that silently kills
+ * the entire inline <script> block.
+ *
+ * Regression for: card-holder.html "My Cards" blank page caused by
+ * duplicate `let currentUser` (also declared in shared/auth.js).
+ *
+ * No credentials needed.
+ *
+ * Usage:
+ *   node backend/tests/test-portal-duplicate-vars.js
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+// ── Test Result Tracking ────────────────────────────────────
+const results = [];
+function check(name, passed, detail = '') {
+    results.push({ name, passed, detail });
+    const icon = passed ? '✅' : '❌';
+    const suffix = detail ? ` — ${detail}` : '';
+    console.log(`  ${icon} ${name}${suffix}`);
+}
+
+console.log('\n🔍 Portal Duplicate Variable Declaration Test\n');
+
+// ── Shared scripts that declare global variables ────────────
+const PORTAL_DIR = path.resolve(__dirname, '../public/portal');
+const SHARED_DIR = path.join(PORTAL_DIR, 'shared');
+
+// Extract top-level let/const declarations from a JS file
+function extractGlobalDecls(jsContent) {
+    const decls = new Set();
+    // Match `let varName` or `const varName` at the start of a line (top-level)
+    const re = /^(?:let|const)\s+([a-zA-Z_$][a-zA-Z0-9_$]*)/gm;
+    let m;
+    while ((m = re.exec(jsContent)) !== null) {
+        decls.add(m[1]);
+    }
+    return decls;
+}
+
+// Build set of variables declared in shared scripts
+const sharedVars = new Map(); // varName → filename
+const sharedFiles = fs.readdirSync(SHARED_DIR).filter(f => f.endsWith('.js'));
+for (const file of sharedFiles) {
+    const content = fs.readFileSync(path.join(SHARED_DIR, file), 'utf8');
+    for (const v of extractGlobalDecls(content)) {
+        sharedVars.set(v, file);
+    }
+}
+
+console.log(`  Shared scripts: ${sharedFiles.length} files, ${sharedVars.size} global declarations`);
+
+// ── Scan each portal HTML page ──────────────────────────────
+const htmlFiles = fs.readdirSync(PORTAL_DIR).filter(f => f.endsWith('.html'));
+let totalDuplicates = 0;
+
+for (const htmlFile of htmlFiles) {
+    const content = fs.readFileSync(path.join(PORTAL_DIR, htmlFile), 'utf8');
+
+    // Check which shared scripts this page includes
+    const includedShared = new Set();
+    const scriptSrcRe = /src=["'](?:shared\/|\.\.\/shared\/)([^"']+)["']/g;
+    let sm;
+    while ((sm = scriptSrcRe.exec(content)) !== null) {
+        includedShared.add(sm[1]);
+    }
+
+    // Extract inline script variable declarations
+    const inlineScriptRe = /<script>([^]*?)<\/script>/g;
+    const inlineDecls = new Map(); // varName → lineNumber
+    let im;
+    while ((im = inlineScriptRe.exec(content)) !== null) {
+        const scriptContent = im[1];
+        const scriptStartOffset = im.index;
+        const linesBefore = content.substring(0, scriptStartOffset).split('\n').length;
+
+        const declRe = /^[ \t]*(?:let|const)\s+([a-zA-Z_$][a-zA-Z0-9_$]*)/gm;
+        let dm;
+        while ((dm = declRe.exec(scriptContent)) !== null) {
+            const lineInScript = scriptContent.substring(0, dm.index).split('\n').length;
+            inlineDecls.set(dm[1], linesBefore + lineInScript - 1);
+        }
+    }
+
+    // Check for conflicts
+    const duplicates = [];
+    for (const [varName, lineNum] of inlineDecls) {
+        if (sharedVars.has(varName)) {
+            const sharedFile = sharedVars.get(varName);
+            // Only flag if this page includes that shared script
+            if (includedShared.has(sharedFile)) {
+                duplicates.push({ varName, lineNum, sharedFile });
+            }
+        }
+    }
+
+    if (duplicates.length > 0) {
+        totalDuplicates += duplicates.length;
+        for (const d of duplicates) {
+            check(
+                `${htmlFile}:${d.lineNum} — no duplicate \`${d.varName}\``,
+                false,
+                `already declared in shared/${d.sharedFile}`
+            );
+        }
+    }
+}
+
+// Summary check
+check(
+    'No duplicate variable declarations across portal pages',
+    totalDuplicates === 0,
+    totalDuplicates > 0 ? `${totalDuplicates} duplicate(s) found` : `${htmlFiles.length} pages scanned`
+);
+
+// ── Summary ─────────────────────────────────────────────────
+console.log('\n' + '─'.repeat(55));
+const passed = results.filter(r => r.passed).length;
+const failed = results.filter(r => !r.passed).length;
+console.log(`  Total: ${results.length} checks — ${passed} passed, ${failed} failed`);
+if (failed > 0) {
+    console.log('  ⚠️  Fix duplicate declarations to prevent SyntaxError in browsers');
+    process.exit(1);
+}
+console.log('  ✅ All clear!\n');


### PR DESCRIPTION
## Summary
- Removed duplicate `let currentUser = null` declaration in `card-holder.html` that conflicted with `shared/auth.js`
- This caused an `Uncaught SyntaxError` that silently killed the entire inline `<script>` block, resulting in a blank "My Cards" tab
- Added static-analysis regression test (`test-portal-duplicate-vars.js`) scanning all portal pages for similar conflicts

## Test plan
- [x] `node backend/tests/test-portal-duplicate-vars.js` passes (0 duplicates found)
- [x] `npm test` — all 342 Jest tests pass
- [ ] Manual: open Card Holder page on Web Portal, verify "My Cards" tab shows bound entities

https://claude.ai/code/session_01QoSets1mLZ66FcW4S5ABcj