### PR TITLE
fix: resolve AI chat message loss and freeze on reopen (#248)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
@@ -761,7 +761,8 @@ data class AiChatPollResponse(
     val busy: Boolean = false,
     val retry_after: Int? = null,
     val error: String? = null,
-    val latency_ms: Long? = null
+    val latency_ms: Long? = null,
+    val progress: Map<String, Any?>? = null
 )
 
 // ============ Version Check ============

--- a/app/src/main/java/com/hank/clawlive/ui/AiChatBottomSheet.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/AiChatBottomSheet.kt
@@ -95,6 +95,8 @@ class AiChatBottomSheet : BottomSheetDialogFragment() {
         setupListeners()
         observeState()
 
+        viewModel.ensureActiveState()
+
         if (pageName.isNotEmpty()) {
             tvContextTag.text = "\uD83D\uDCCD $pageName"
             tvContextTag.visibility = View.VISIBLE

--- a/app/src/main/java/com/hank/clawlive/ui/AiChatViewModel.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/AiChatViewModel.kt
@@ -93,6 +93,20 @@ class AiChatViewModel(application: Application) : AndroidViewModel(application) 
         savePendingRequestId(null)
     }
 
+    fun ensureActiveState() {
+        if (!_uiState.value.isLoading) return
+        val pollingActive = pollingJob?.isActive == true
+        val statusActive = statusJob?.isActive == true
+        if (!pollingActive && !statusActive) {
+            val pendingId = loadPendingRequestId()
+            if (pendingId != null) {
+                resumePendingIfNeeded()
+            } else {
+                _uiState.update { it.copy(isLoading = false, typingText = null) }
+            }
+        }
+    }
+
     // ── Submit + Poll ────────────────────
 
     private suspend fun submitAndPoll(body: MutableMap<String, Any>, busyAttempt: Int) {
@@ -139,13 +153,20 @@ class AiChatViewModel(application: Application) : AndroidViewModel(application) 
                             deviceManager.deviceId,
                             deviceManager.deviceSecret
                         )
+                        // Update typing text from server progress
+                        val progressText = progressToText(poll.progress)
+                        if (progressText != null) {
+                            statusJob?.cancel()
+                            _uiState.update { it.copy(typingText = progressText) }
+                        }
                         when (poll.status) {
                             "completed", "failed", "expired" -> {
                                 pollResult = poll
                                 break
                             }
                         }
-                    } catch (_: Exception) {
+                    } catch (e: Exception) {
+                        if (e is kotlinx.coroutines.CancellationException) throw e
                         // Transient network error — keep polling
                     }
                 }
@@ -286,7 +307,9 @@ class AiChatViewModel(application: Application) : AndroidViewModel(application) 
                         when (poll.status) {
                             "completed", "failed", "expired" -> { pollResult = poll; break }
                         }
-                    } catch (_: Exception) {}
+                    } catch (e: Exception) {
+                        if (e is kotlinx.coroutines.CancellationException) throw e
+                    }
                 }
 
                 when {
@@ -317,6 +340,32 @@ class AiChatViewModel(application: Application) : AndroidViewModel(application) 
             } finally {
                 savePendingRequestId(null)
             }
+        }
+    }
+
+    // ── Progress Text ─────────────────────
+
+    private fun progressToText(progress: Map<String, Any?>?): String? {
+        if (progress == null) return null
+        val turn = (progress["turn"] as? Number)?.toInt() ?: 0
+        val suffix = if (turn > 0) " (Step $turn/15)" else ""
+        return when (progress["event"]) {
+            "tool_use" -> {
+                val tool = progress["tool"] as? String ?: "Processing"
+                val label = when (tool) {
+                    "Read" -> "Reading file"
+                    "Grep" -> "Searching code"
+                    "Glob" -> "Finding files"
+                    "Bash" -> "Running analysis"
+                    "Edit" -> "Editing file"
+                    "Write" -> "Writing file"
+                    else -> tool
+                }
+                "$label…$suffix"
+            }
+            "thinking" -> "Analyzing…$suffix"
+            "tool_result" -> "Processing result…$suffix"
+            else -> null
         }
     }
 

--- a/backend/tests/test-ai-chat-submit-poll.js
+++ b/backend/tests/test-ai-chat-submit-poll.js
@@ -194,15 +194,23 @@ async function testPollNonExistent() {
 }
 
 async function testPollCompletion(requestId) {
-    console.log('\n[7] Poll — wait for completion');
+    console.log('\n[7] Poll — wait for completion (with progress field check)');
 
     const POLL_INTERVAL = 3000;
     const MAX_ATTEMPTS = 50;
 
     let finalStatus = null;
+    let sawProgressField = false;
     for (let i = 1; i <= MAX_ATTEMPTS; i++) {
         await new Promise(r => setTimeout(r, POLL_INTERVAL));
         const r = await get(`/api/ai-support/chat/poll/${requestId}?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`);
+
+        // Verify progress field is always present (even if null) — regression for #248
+        if ('progress' in r.data) sawProgressField = true;
+        if (r.data.progress != null) {
+            console.log(`    (Progress event: ${JSON.stringify(r.data.progress)})`);
+        }
+
         if (r.data.status === 'completed' || r.data.status === 'failed' || r.data.status === 'expired') {
             finalStatus = r.data;
             console.log(`    (Completed after ${i} polls, ${i * POLL_INTERVAL / 1000}s)`);
@@ -214,12 +222,38 @@ async function testPollCompletion(requestId) {
     }
 
     ok(finalStatus !== null, 'Poll terminates within 150s');
+    ok(sawProgressField, 'Poll response includes progress field (Issue #248)');
     if (finalStatus) {
         ok(finalStatus.status === 'completed', `Final status: ${finalStatus.status}`);
         if (finalStatus.status === 'completed') {
             ok(typeof finalStatus.response === 'string' && finalStatus.response.length > 0, 'Response is non-empty string');
             ok(!finalStatus.busy, 'Not busy');
         }
+    }
+}
+
+async function testPollResponseSchema() {
+    console.log('\n[8] Poll — response schema validation (Issue #248)');
+
+    // Submit a request, then verify poll response has all expected fields
+    const requestId = randomUUID();
+    const r = await post('/api/ai-support/chat/submit', {
+        requestId,
+        deviceId: DEVICE_ID,
+        deviceSecret: DEVICE_SECRET,
+        message: 'Reply with: OK',
+        page: 'test_schema'
+    });
+    ok(r.status === 200, 'Submit for schema test → 200');
+
+    // Wait briefly then poll
+    await new Promise(r => setTimeout(r, 1000));
+    const poll = await get(`/api/ai-support/chat/poll/${requestId}?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`);
+    ok(poll.status === 200, 'Poll returns 200');
+
+    const expectedFields = ['success', 'status', 'response', 'busy', 'retry_after', 'error', 'latency_ms', 'progress'];
+    for (const field of expectedFields) {
+        ok(field in poll.data, `Poll response has '${field}' field`);
     }
 }
 
@@ -237,6 +271,7 @@ async function main() {
     await testPollAuth();
     await testPollNonExistent();
     await testPollCompletion(requestId);
+    await testPollResponseSchema();
 
     console.log(`\n${'='.repeat(50)}`);
     console.log(`Results: ${passed} passed, ${failed} failed out of ${passed + failed}`);


### PR DESCRIPTION
## Summary
- Fix CancellationException being swallowed in Android AiChatViewModel polling loops, which caused message loss when Activity was destroyed during active polling
- Add `ensureActiveState()` recovery mechanism to handle stale loading state when BottomSheet is reopened after coroutine cancellation
- Add `progress` field to AiChatPollResponse and implement real-time AI processing status display (matching web portal behavior)
- Extend regression test with progress field verification and poll response schema validation

## Test plan
- [x] All 342 Jest tests pass (`npm test`)
- [x] ESLint: 0 errors (57 pre-existing warnings)
- [ ] Run `node backend/tests/test-ai-chat-submit-poll.js` against production
- [ ] Verify Android build compiles with Kotlin changes
- [ ] Manual test: send AI chat message, dismiss BottomSheet, reopen — should show response

Closes #248

https://claude.ai/code/session_01KFY2YieyKgp37zSAYWeDG6