### PR TITLE
fix: remove duplicate filter_all string resource

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -738,7 +738,6 @@ If you have any questions, please contact us via our official email.
     <string name="my_cards_section">My Cards</string>
     <string name="recent_interactions">Recent</string>
     <string name="collected_cards">Collected</string>
-    <string name="filter_all">All</string>
     <string name="filter_friends">Friends</string>
     <string name="filter_pinned">Pinned</string>
     <string name="add_friend_confirm">Add %1$s to friends?</string>


### PR DESCRIPTION
Fix Android CI build failure caused by duplicate `String/filter_all` entry in `strings.xml` (line 124 and 741).

https://claude.ai/code/session_01KFY2YieyKgp37zSAYWeDG6