### PR TITLE
fix: replace non-existent onAuth() with checkAuth() in card-holder.html

### DIFF
--- a/backend/public/portal/card-holder.html
+++ b/backend/public/portal/card-holder.html
@@ -683,9 +683,11 @@
         let searchDebounce = null;
         let categories = new Set();
 
-        onAuth(user => {
-            currentUser = user;
+        window.addEventListener('DOMContentLoaded', async () => {
             renderNav('card-holder');
+            if (typeof renderFooter === 'function') renderFooter();
+            const user = await checkAuth();
+            if (!user) return;
             document.getElementById('navEmail').textContent = user.email || '';
             if (typeof initAiChat === 'function') initAiChat(user);
             loadAllData();


### PR DESCRIPTION
## Summary
- `card-holder.html` called `onAuth(callback)` which doesn't exist — all other portal pages use `await checkAuth()` from `shared/auth.js`
- This caused `Uncaught ReferenceError: onAuth is not defined`, preventing page initialization
- Replaced with the standard `DOMContentLoaded` + `checkAuth()` pattern used by all other portal pages

## Test plan
- [x] `node backend/tests/test-portal-duplicate-vars.js` passes
- [x] `npm test` — same 342 tests, no new failures
- [ ] Manual: open Card Holder page, verify My Cards tab shows bound entities

https://claude.ai/code/session_01QoSets1mLZ66FcW4S5ABcj