### PR TITLE
fix: preserve scroll position when switching bottom nav tabs

### DIFF
--- a/app/src/main/java/com/hank/clawlive/ui/BottomNavHelper.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/BottomNavHelper.kt
@@ -50,8 +50,7 @@ object BottomNavHelper {
             navView?.setOnClickListener {
                 if (navItem != currentItem) {
                     val intent = Intent(activity, targetClass)
-                    intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP or
-                            Intent.FLAG_ACTIVITY_SINGLE_TOP
+                    intent.flags = Intent.FLAG_ACTIVITY_REORDER_TO_FRONT
                     activity.startActivity(intent)
                     @Suppress("DEPRECATION")
                     activity.overridePendingTransition(0, 0)


### PR DESCRIPTION
## Summary
- Changed `FLAG_ACTIVITY_CLEAR_TOP | FLAG_ACTIVITY_SINGLE_TOP` to `FLAG_ACTIVITY_REORDER_TO_FRONT` in `BottomNavHelper.kt`
- This preserves Activity instances (and their scroll positions) when switching between bottom nav tabs
- Previously, `CLEAR_TOP` destroyed Activities above the target, causing scroll position loss on every tab switch

## Test plan
- [ ] Navigate to Cards tab, scroll down, switch to Home, switch back to Cards — scroll position should be preserved
- [ ] Verify all 5 tabs switch correctly with no duplicate Activities
- [ ] Verify bottom nav highlight stays correct on each tab

https://claude.ai/code/session_01EWpU25sCmYmpNjKgRgbAWS