### PR TITLE
feat: add avatar photo upload to Flickr for all platforms

### DIFF
--- a/app/src/main/java/com/hank/clawlive/MainActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/MainActivity.kt
@@ -45,6 +45,7 @@ import com.hank.clawlive.data.local.EntityAvatarManager
 import com.hank.clawlive.fcm.ClawFcmService
 import com.hank.clawlive.data.local.LayoutPreferences
 import com.hank.clawlive.data.local.UsageManager
+import com.hank.clawlive.data.model.AvatarUploadResponse
 import com.hank.clawlive.data.model.EntityStatus
 import com.hank.clawlive.data.model.UpdateAvatarRequest
 import com.hank.clawlive.data.remote.NetworkModule
@@ -84,6 +85,18 @@ class MainActivity : AppCompatActivity() {
         ActivityResultContracts.RequestPermission()
     ) { granted ->
         Timber.d("[FCM] POST_NOTIFICATIONS permission granted=$granted")
+    }
+
+    // Avatar photo picker state
+    private var avatarPickerEntityId: Int = -1
+    private var avatarPickerIconView: TextView? = null
+
+    private val avatarPhotoLauncher = registerForActivityResult(
+        ActivityResultContracts.GetContent()
+    ) { uri ->
+        if (uri != null && avatarPickerEntityId >= 0) {
+            uploadAvatarPhoto(uri, avatarPickerEntityId, avatarPickerIconView)
+        }
     }
 
     // UI elements
@@ -747,6 +760,25 @@ class MainActivity : AppCompatActivity() {
 
         val currentAvatar = avatarManager.getAvatar(entityId)
 
+        // Show current image avatar preview if applicable
+        val imgPreview = dialogView.findViewById<ImageView>(R.id.imgCurrentAvatar)
+        if (avatarManager.isImageUrl(currentAvatar)) {
+            imgPreview.visibility = android.view.View.VISIBLE
+            com.bumptech.glide.Glide.with(this)
+                .load(currentAvatar)
+                .circleCrop()
+                .into(imgPreview)
+        }
+
+        // Upload photo button
+        val uploadBtn = dialogView.findViewById<com.google.android.material.button.MaterialButton>(R.id.btnUploadAvatar)
+        uploadBtn.setOnClickListener {
+            avatarPickerEntityId = entityId
+            avatarPickerIconView = iconView
+            dialog.dismiss()
+            avatarPhotoLauncher.launch("image/*")
+        }
+
         EntityAvatarManager.AVATAR_OPTIONS.forEach { avatar ->
             val tv = TextView(this).apply {
                 text = avatar
@@ -784,6 +816,40 @@ class MainActivity : AppCompatActivity() {
         }
 
         dialog.show()
+    }
+
+    private fun uploadAvatarPhoto(uri: android.net.Uri, entityId: Int, iconView: TextView?) {
+        lifecycleScope.launch {
+            try {
+                val inputStream = contentResolver.openInputStream(uri) ?: return@launch
+                val bytes = inputStream.readBytes()
+                inputStream.close()
+
+                val requestFile = okhttp3.RequestBody.create(
+                    okhttp3.MediaType.parse("image/jpeg"), bytes
+                )
+                val filePart = okhttp3.MultipartBody.Part.createFormData("file", "avatar.jpg", requestFile)
+                val deviceIdPart = okhttp3.RequestBody.create(okhttp3.MediaType.parse("text/plain"), deviceManager.deviceId)
+                val secretPart = okhttp3.RequestBody.create(okhttp3.MediaType.parse("text/plain"), deviceManager.deviceSecret)
+                val entityIdPart = okhttp3.RequestBody.create(okhttp3.MediaType.parse("text/plain"), entityId.toString())
+
+                val response = withContext(Dispatchers.IO) {
+                    api.uploadEntityAvatar(filePart, deviceIdPart, secretPart, entityIdPart)
+                }
+
+                if (response.success && response.avatar != null) {
+                    avatarManager.setAvatar(entityId, response.avatar)
+                    android.widget.Toast.makeText(this@MainActivity, R.string.avatar_upload_success, android.widget.Toast.LENGTH_SHORT).show()
+                    // Refresh UI
+                    viewModel.loadEntities(deviceManager.deviceId, deviceManager.deviceSecret)
+                } else {
+                    android.widget.Toast.makeText(this@MainActivity, R.string.avatar_upload_failed, android.widget.Toast.LENGTH_SHORT).show()
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "[Avatar] Upload failed")
+                android.widget.Toast.makeText(this@MainActivity, R.string.avatar_upload_failed, android.widget.Toast.LENGTH_SHORT).show()
+            }
+        }
     }
 
     private fun showRenameDialog(entity: EntityStatus) {

--- a/app/src/main/java/com/hank/clawlive/data/local/EntityAvatarManager.kt
+++ b/app/src/main/java/com/hank/clawlive/data/local/EntityAvatarManager.kt
@@ -58,4 +58,7 @@ class EntityAvatarManager private constructor(context: Context) {
     fun setAvatar(entityId: Int, avatar: String) {
         prefs.edit().putString("emoji_$entityId", avatar).apply()
     }
+
+    /** Check if an avatar value is an image URL (not an emoji). */
+    fun isImageUrl(avatar: String): Boolean = avatar.startsWith("https://")
 }

--- a/app/src/main/java/com/hank/clawlive/data/model/ApiModels.kt
+++ b/app/src/main/java/com/hank/clawlive/data/model/ApiModels.kt
@@ -68,6 +68,14 @@ data class GenericResponse(
     @SerializedName("message") val message: String? = null
 )
 
+// Avatar upload response (includes Flickr URL)
+data class AvatarUploadResponse(
+    @SerializedName("success") val success: Boolean = false,
+    @SerializedName("avatar") val avatar: String? = null,
+    @SerializedName("entityId") val entityId: Int = -1,
+    @SerializedName("message") val message: String? = null
+)
+
 // Agent Card models
 data class AgentCardCapability(
     @SerializedName("id") val id: String = "",

--- a/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
@@ -79,6 +79,16 @@ interface ClawApiService {
     @PUT("api/device/entity/avatar")
     suspend fun updateEntityAvatar(@Body request: UpdateAvatarRequest): GenericResponse
 
+    // Upload photo as entity avatar (stored on Flickr)
+    @Multipart
+    @POST("api/device/entity/avatar/upload")
+    suspend fun uploadEntityAvatar(
+        @Part file: MultipartBody.Part,
+        @Part("deviceId") deviceId: RequestBody,
+        @Part("deviceSecret") deviceSecret: RequestBody,
+        @Part("entityId") entityId: RequestBody
+    ): AvatarUploadResponse
+
     // Agent Card CRUD
     @GET("api/entity/agent-card")
     suspend fun getAgentCard(

--- a/app/src/main/java/com/hank/clawlive/ui/EntityCardAdapter.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/EntityCardAdapter.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.LinearLayout
 import android.widget.PopupMenu
@@ -111,10 +112,25 @@ class EntityCardAdapter(
 
         private val timeFormat = SimpleDateFormat("HH:mm", Locale.getDefault())
 
+        private val imgEntityAvatar: ImageView = itemView.findViewById(R.id.imgEntityAvatar)
+        private val avatarContainer: FrameLayout = itemView.findViewById(R.id.avatarContainer)
+
         fun bind(entity: EntityStatus) {
-            // Avatar
-            tvEntityIcon.text = getAvatar(entity.entityId)
-            tvEntityIcon.setOnClickListener { onAvatarClick(entity, tvEntityIcon) }
+            // Avatar — image URL or emoji
+            val avatarValue = getAvatar(entity.entityId)
+            if (avatarValue.startsWith("https://")) {
+                tvEntityIcon.visibility = android.view.View.GONE
+                imgEntityAvatar.visibility = android.view.View.VISIBLE
+                com.bumptech.glide.Glide.with(itemView.context)
+                    .load(avatarValue)
+                    .circleCrop()
+                    .into(imgEntityAvatar)
+            } else {
+                tvEntityIcon.visibility = android.view.View.VISIBLE
+                imgEntityAvatar.visibility = android.view.View.GONE
+                tvEntityIcon.text = avatarValue
+            }
+            avatarContainer.setOnClickListener { onAvatarClick(entity, tvEntityIcon) }
 
             // Name
             tvEntityName.text = getEntityLabel(entity)

--- a/app/src/main/java/com/hank/clawlive/ui/chat/ChatAdapter.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/chat/ChatAdapter.kt
@@ -342,6 +342,7 @@ class ChatAdapter : ListAdapter<ChatMessage, RecyclerView.ViewHolder>(ChatDiffCa
         private val btnPlay: ImageButton = itemView.findViewById(R.id.btnPlay)
         private val progressVoice: ProgressBar = itemView.findViewById(R.id.progressVoice)
         private val tvDuration: TextView = itemView.findViewById(R.id.tvDuration)
+        private val imgAvatar: ImageView? = itemView.findViewById(R.id.imgAvatar)
         private val layoutLinkPreview: LinearLayout = itemView.findViewById(R.id.layoutLinkPreview)
         private val ivLinkPreview: ImageView = itemView.findViewById(R.id.ivLinkPreview)
         private val tvLinkTitle: TextView = itemView.findViewById(R.id.tvLinkTitle)
@@ -377,7 +378,19 @@ class ChatAdapter : ListAdapter<ChatMessage, RecyclerView.ViewHolder>(ChatDiffCa
                 tvEntityName.text = adapter.getXDeviceLabel(message.fromPublicCode)
             } else {
                 val entityId = message.fromEntityId ?: 0
-                tvAvatar.text = avatarManager.getAvatar(entityId)
+                val avatarValue = avatarManager.getAvatar(entityId)
+                if (avatarValue.startsWith("https://") && imgAvatar != null) {
+                    tvAvatar.visibility = android.view.View.GONE
+                    imgAvatar.visibility = android.view.View.VISIBLE
+                    com.bumptech.glide.Glide.with(itemView.context)
+                        .load(avatarValue)
+                        .circleCrop()
+                        .into(imgAvatar)
+                } else {
+                    tvAvatar.visibility = android.view.View.VISIBLE
+                    imgAvatar?.visibility = android.view.View.GONE
+                    tvAvatar.text = avatarValue
+                }
                 tvEntityName.text = adapter.getEntityDisplayName(entityId)
             }
 

--- a/app/src/main/res/layout/dialog_avatar_picker.xml
+++ b/app/src/main/res/layout/dialog_avatar_picker.xml
@@ -27,6 +27,27 @@
         android:textColor="?android:attr/textColorSecondary"
         android:layout_marginBottom="20dp" />
 
+    <!-- Upload Photo Button -->
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnUploadAvatar"
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        android:text="@string/avatar_upload_photo"
+        app:icon="@android:drawable/ic_menu_camera"
+        app:iconGravity="textStart" />
+
+    <!-- Current image avatar preview (hidden by default) -->
+    <ImageView
+        android:id="@+id/imgCurrentAvatar"
+        android:layout_width="64dp"
+        android:layout_height="64dp"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginBottom="12dp"
+        android:visibility="gone"
+        android:scaleType="centerCrop" />
+
     <!-- Avatar Grid -->
     <GridLayout
         android:id="@+id/avatarGrid"

--- a/app/src/main/res/layout/item_agent_card.xml
+++ b/app/src/main/res/layout/item_agent_card.xml
@@ -35,16 +35,29 @@
                 app:tint="@color/text_disabled"/>
 
             <!-- Entity Avatar (tap to change) -->
-            <TextView
-                android:id="@+id/tvEntityIcon"
+            <FrameLayout
                 android:layout_width="48dp"
                 android:layout_height="48dp"
-                android:text="🦞"
-                android:textSize="32sp"
-                android:gravity="center"
                 android:clickable="true"
                 android:focusable="true"
-                android:background="?attr/selectableItemBackgroundBorderless" />
+                android:id="@+id/avatarContainer">
+
+                <TextView
+                    android:id="@+id/tvEntityIcon"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:text="🦞"
+                    android:textSize="32sp"
+                    android:gravity="center"
+                    android:background="?attr/selectableItemBackgroundBorderless" />
+
+                <ImageView
+                    android:id="@+id/imgEntityAvatar"
+                    android:layout_width="48dp"
+                    android:layout_height="48dp"
+                    android:scaleType="centerCrop"
+                    android:visibility="gone" />
+            </FrameLayout>
 
             <!-- Name + ID -->
             <LinearLayout

--- a/app/src/main/res/layout/item_message_received.xml
+++ b/app/src/main/res/layout/item_message_received.xml
@@ -10,15 +10,27 @@
     android:paddingVertical="4dp">
 
     <!-- Entity Avatar -->
-    <TextView
-        android:id="@+id/tvAvatar"
+    <FrameLayout
         android:layout_width="36dp"
         android:layout_height="36dp"
-        android:layout_marginEnd="8dp"
-        android:background="@drawable/bubble_received"
-        android:gravity="center"
-        android:text="🦞"
-        android:textSize="20sp" />
+        android:layout_marginEnd="8dp">
+
+        <TextView
+            android:id="@+id/tvAvatar"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:background="@drawable/bubble_received"
+            android:gravity="center"
+            android:text="🦞"
+            android:textSize="20sp" />
+
+        <ImageView
+            android:id="@+id/imgAvatar"
+            android:layout_width="36dp"
+            android:layout_height="36dp"
+            android:scaleType="centerCrop"
+            android:visibility="gone" />
+    </FrameLayout>
 
     <LinearLayout
         android:layout_width="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -227,6 +227,10 @@
     <!-- Bot Avatar -->
     <string name="bot_avatar">Bot Avatar</string>
     <string name="avatar_subtitle">Entity %d</string>
+    <string name="avatar_upload_photo">Upload Photo</string>
+    <string name="avatar_uploading">Uploading…</string>
+    <string name="avatar_upload_failed">Upload failed</string>
+    <string name="avatar_upload_success">Avatar updated!</string>
 
     <!-- Entity Management -->
     <string name="remove_entity">Remove</string>

--- a/backend/index.js
+++ b/backend/index.js
@@ -3707,9 +3707,16 @@ app.put('/api/device/entity/avatar', async (req, res) => {
         return res.status(400).json({ success: false, message: "Invalid entityId" });
     }
 
-    // Validate avatar: must be a short emoji string (1-8 chars to support compound emojis)
-    if (!avatar || typeof avatar !== 'string' || avatar.length > 8) {
-        return res.status(400).json({ success: false, message: "Invalid avatar (must be 1-8 chars)" });
+    // Validate avatar: emoji (1-8 chars) or image URL (https://)
+    if (!avatar || typeof avatar !== 'string') {
+        return res.status(400).json({ success: false, message: "Invalid avatar" });
+    }
+    const isAvatarUrl = avatar.startsWith('https://');
+    if (!isAvatarUrl && avatar.length > 8) {
+        return res.status(400).json({ success: false, message: "Invalid avatar (emoji must be 1-8 chars)" });
+    }
+    if (isAvatarUrl && avatar.length > 500) {
+        return res.status(400).json({ success: false, message: "Avatar URL too long" });
     }
 
     const device = devices[deviceId];
@@ -3732,6 +3739,88 @@ app.put('/api/device/entity/avatar', async (req, res) => {
     await saveData();
 
     res.json({ success: true, avatar, entityId: eId });
+});
+
+/**
+ * POST /api/device/entity/avatar/upload
+ * Upload a photo to Flickr and set it as the entity's avatar.
+ * Body (multipart): file (image), deviceId, deviceSecret, entityId
+ * Max file size: 5MB
+ */
+const avatarUpload = multer({
+    storage: multer.memoryStorage(),
+    limits: { fileSize: 5 * 1024 * 1024 }, // 5MB max
+    fileFilter: (req, file, cb) => {
+        const allowed = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
+        if (!allowed.includes(file.mimetype)) {
+            cb(new Error('Unsupported image type: ' + file.mimetype));
+        } else {
+            cb(null, true);
+        }
+    }
+});
+
+app.post('/api/device/entity/avatar/upload', avatarUpload.single('file'), async (req, res) => {
+    let { deviceId, deviceSecret, entityId } = req.body || {};
+
+    // Fallback: use cookie-based auth (web portal)
+    if ((!deviceId || !deviceSecret) && req.cookies && req.cookies.eclaw_session) {
+        try {
+            const jwt = require('jsonwebtoken');
+            const decoded = jwt.verify(req.cookies.eclaw_session, process.env.JWT_SECRET || 'dev-secret-change-in-production');
+            if (decoded && decoded.deviceId && decoded.deviceSecret) {
+                deviceId = decoded.deviceId;
+                deviceSecret = decoded.deviceSecret;
+            }
+        } catch (e) { /* invalid token, fall through */ }
+    }
+
+    if (!deviceId || !deviceSecret) {
+        return res.status(400).json({ success: false, message: "deviceId and deviceSecret required" });
+    }
+
+    const eId = parseInt(entityId);
+    if (isNaN(eId) || eId < 0) {
+        return res.status(400).json({ success: false, message: "Invalid entityId" });
+    }
+
+    if (!req.file) {
+        return res.status(400).json({ success: false, message: "No image file uploaded" });
+    }
+
+    const device = devices[deviceId];
+    if (!device) {
+        return res.status(404).json({ success: false, message: "Device not found" });
+    }
+
+    if (device.deviceSecret !== deviceSecret) {
+        return res.status(403).json({ success: false, message: "Invalid deviceSecret" });
+    }
+
+    const entity = device.entities[eId];
+    if (!entity) {
+        return res.status(400).json({ success: false, message: `Entity ${eId} not found` });
+    }
+
+    if (!flickr.isAvailable()) {
+        return res.status(503).json({ success: false, message: "Photo upload service unavailable" });
+    }
+
+    try {
+        const result = await flickr.uploadPhoto(req.file.buffer, req.file.originalname || 'avatar.jpg');
+        if (!result.success) {
+            return res.status(500).json({ success: false, message: "Flickr upload failed: " + result.error });
+        }
+
+        entity.avatar = result.url;
+        entity.lastUpdated = Date.now();
+        await saveData();
+
+        res.json({ success: true, avatar: result.url, entityId: eId });
+    } catch (err) {
+        console.error('[Avatar Upload] Error:', err);
+        res.status(500).json({ success: false, message: "Upload failed: " + err.message });
+    }
 });
 
 // ============================================

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -1410,7 +1410,7 @@
                 label.className = 'target-check target-entity-check';
                 const e2eeBadge = e.encryptionStatus === 'e2ee' ? ' 🔒' : '';
                 label.innerHTML = `<input type="checkbox" data-entity="${e.entityId}" ${isChecked ? 'checked' : ''} onchange="updateTargetAll()">
-                    <span>${avatar} ${escapeHtml(name)} (#${e.entityId})${e2eeBadge}</span>`;
+                    <span>${renderAvatarHtml(avatar, 20)} ${escapeHtml(name)} (#${e.entityId})${e2eeBadge}</span>`;
                 bar.appendChild(label);
             });
 
@@ -1658,7 +1658,7 @@
                 const avatar = getAvatarForEntity(id);
                 const existing = group.querySelector(`[data-filter="entity-${id}"]`);
                 if (existing) {
-                    existing.textContent = `${avatar} ${getEntityDisplayName(id)} (#${id})`;
+                    existing.innerHTML = `${renderAvatarHtml(avatar, 18)} ${getEntityDisplayName(id)} (#${id})`;
                     return;
                 }
 
@@ -1666,7 +1666,7 @@
                 chip.className = `filter-chip filter-chip-entity${currentFilter === 'entity-' + id ? ' active' : ''}`;
                 chip.dataset.filter = `entity-${id}`;
                 chip.onclick = () => setFilter(`entity-${id}`);
-                chip.textContent = `${avatar} ${getEntityDisplayName(id)} (#${id})`;
+                chip.innerHTML = `${renderAvatarHtml(avatar, 18)} ${getEntityDisplayName(id)} (#${id})`;
                 group.insertBefore(chip, myChip);
             });
 

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -1550,7 +1550,7 @@
                 return '<div class="entity-card card" data-entity-id="' + entity.entityId + '"' + (isEditMode ? ' draggable="true"' : '') + '>' +
                     '<div class="entity-card-body">' +
                     '<div class="drag-handle" title="' + i18n.t('dash_drag_to_reorder') + '">&#9776;</div>' +
-                    '<div class="entity-avatar" onclick="openAvatarPicker(' + entity.entityId + ')">' + avatar + '</div>' +
+                    '<div class="entity-avatar" onclick="openAvatarPicker(' + entity.entityId + ')">' + renderAvatarHtml(avatar) + '</div>' +
                     '<div class="entity-info">' +
                     '<div class="entity-name" onclick="openRenamePicker(' + entity.entityId + ', \'' + escapedName + '\')" title="' + i18n.t('dash_rename_title') + '">' + escapeHtml(displayName) + '</div>' +
                     '<div class="entity-badges">' +
@@ -2184,10 +2184,23 @@
                 gridHtml += '<div class="avatar-option' + selectedClass + '" data-emoji="' + emoji + '">' + emoji + '</div>';
             }
 
+            // Show current image avatar preview if applicable
+            var currentPreview = '';
+            if (isAvatarUrl(currentAvatar)) {
+                currentPreview = '<div style="text-align:center;margin-bottom:12px;">' +
+                    '<img src="' + currentAvatar + '" style="width:64px;height:64px;border-radius:50%;object-fit:cover;border:2px solid var(--primary);">' +
+                    '</div>';
+            }
+
             overlay.innerHTML =
                 '<div class="avatar-picker">' +
                 '<div class="avatar-picker-title" data-i18n="dash_avatar_title">' + i18n.t('dash_avatar_title') + '</div>' +
                 '<div class="avatar-picker-desc" data-i18n="dash_avatar_desc">' + i18n.t('dash_avatar_desc') + '</div>' +
+                currentPreview +
+                '<div class="avatar-upload-btn" id="avatarUploadBtn">' +
+                '&#x1F4F7; ' + (i18n.t('dash_avatar_upload') || 'Upload Photo') +
+                '</div>' +
+                '<input type="file" id="avatarFileInput" accept="image/jpeg,image/png,image/webp,image/gif" style="display:none">' +
                 '<div class="avatar-grid">' + gridHtml + '</div>' +
                 '<div class="avatar-picker-actions">' +
                 '<button class="btn btn-outline btn-sm" data-i18n="mc_dlg_cancel">' + i18n.t('mc_dlg_cancel') + '</button>' +
@@ -2195,6 +2208,46 @@
                 '</div>';
 
             document.body.appendChild(overlay);
+
+            // Handle photo upload
+            var uploadBtn = overlay.querySelector('#avatarUploadBtn');
+            var fileInput = overlay.querySelector('#avatarFileInput');
+            uploadBtn.addEventListener('click', function() { fileInput.click(); });
+            fileInput.addEventListener('change', async function() {
+                var file = fileInput.files[0];
+                if (!file) return;
+                if (file.size > 5 * 1024 * 1024) {
+                    showToast(i18n.t('dash_avatar_too_large') || 'Image must be under 5MB', 'error');
+                    return;
+                }
+                uploadBtn.classList.add('uploading');
+                uploadBtn.innerHTML = '&#x23F3; ' + (i18n.t('dash_avatar_uploading') || 'Uploading...');
+                try {
+                    var formData = new FormData();
+                    formData.append('file', file);
+                    formData.append('entityId', entityId);
+                    var resp = await fetch('/api/device/entity/avatar/upload', {
+                        method: 'POST',
+                        credentials: 'include',
+                        body: formData
+                    });
+                    var data = await resp.json();
+                    if (data.success && data.avatar) {
+                        saveAvatarForEntity(entityId, data.avatar);
+                        overlay.remove();
+                        renderEntities();
+                        showToast(i18n.t('dash_avatar_uploaded') || 'Avatar updated!', 'success');
+                    } else {
+                        showToast(data.message || 'Upload failed', 'error');
+                        uploadBtn.classList.remove('uploading');
+                        uploadBtn.innerHTML = '&#x1F4F7; ' + (i18n.t('dash_avatar_upload') || 'Upload Photo');
+                    }
+                } catch (err) {
+                    showToast(err.message || 'Upload error', 'error');
+                    uploadBtn.classList.remove('uploading');
+                    uploadBtn.innerHTML = '&#x1F4F7; ' + (i18n.t('dash_avatar_upload') || 'Upload Photo');
+                }
+            });
 
             // Handle emoji selection
             overlay.querySelectorAll('.avatar-option').forEach(opt => {
@@ -2729,7 +2782,7 @@
 
                 return '<div class="binding-item">' +
                     '<div class="binding-info">' +
-                    '<span class="binding-emoji">' + avatar + '</span>' +
+                    '<span class="binding-emoji">' + renderAvatarHtml(avatar, 32) + '</span>' +
                     '<div class="binding-details">' +
                     '<span class="binding-entity-name">Entity ' + b.entityId + '</span>' +
                     '<span class="binding-type"><span class="badge ' + typeBadgeClass + '">' + typeText + '</span></span>' +

--- a/backend/public/portal/files.html
+++ b/backend/public/portal/files.html
@@ -576,7 +576,7 @@
                 const name = e.name || (getEntityDisplayName(e.entityId) + ' #' + e.entityId);
                 const isActive = currentEntityFilter === e.entityId;
                 return '<div class="filter-chip' + (isActive ? ' active' : '') + '" data-entity="' + e.entityId + '" onclick="setEntityFilter(' + e.entityId + ')">' +
-                    avatar + ' ' + escapeHtml(name) +
+                    renderAvatarHtml(avatar, 20) + ' ' + escapeHtml(name) +
                     '</div>';
             }).join('');
         }
@@ -700,7 +700,7 @@
             let badges = '<div class="entity-badges">';
             eIds.forEach(eid => {
                 const avatar = getAvatarForEntity(eid);
-                badges += '<span class="entity-badge">' + avatar + '</span>';
+                badges += '<span class="entity-badge">' + renderAvatarHtml(avatar, 20) + '</span>';
             });
             badges += '</div>';
 
@@ -715,7 +715,7 @@
             const eIds = file.entityIds || [file.entityId];
             return eIds.map(eid => {
                 const avatar = getAvatarForEntity(eid);
-                return avatar + ' ' + escapeHtml(getEntityName(eid));
+                return renderAvatarHtml(avatar, 18) + ' ' + escapeHtml(getEntityName(eid));
             }).join(', ');
         }
 

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -673,7 +673,7 @@
             boundEntities.forEach(e => {
                 const avatar = getAvatarForEntity(e.entityId);
                 const name = getEntityDisplayName(e.entityId);
-                opts.push({ value: String(e.entityId), label: `${avatar} ${name} (#${e.entityId})` });
+                opts.push({ value: String(e.entityId), label: `${renderAvatarHtml(avatar, 18)} ${name} (#${e.entityId})` });
             });
             return opts;
         }
@@ -1701,7 +1701,7 @@
                 const checked = isEdit && (skill.assignedEntities || []).includes(String(e.entityId)) ? 'checked' : '';
                 return `<label>
                     <input type="checkbox" class="skill-entity-cb" value="${e.entityId}" ${checked}>
-                    ${avatar} ${esc(name)} (#${e.entityId})
+                    ${renderAvatarHtml(avatar, 18)} ${esc(name)} (#${e.entityId})
                 </label>`;
             }).join('');
 
@@ -1821,7 +1821,7 @@
                 const checked = isEdit && (rule.assignedEntities || []).includes(String(e.entityId)) ? 'checked' : '';
                 return `<label>
                     <input type="checkbox" class="rule-entity-cb" value="${e.entityId}" ${checked}>
-                    ${avatar} ${esc(name)} (#${e.entityId})
+                    ${renderAvatarHtml(avatar, 18)} ${esc(name)} (#${e.entityId})
                 </label>`;
             }).join('');
 
@@ -2020,7 +2020,7 @@
                 const checked = isEdit && (soul.assignedEntities || []).includes(String(e.entityId)) ? 'checked' : '';
                 return `<label>
                     <input type="checkbox" class="soul-entity-cb" value="${e.entityId}" ${checked}>
-                    ${avatar} ${esc(name)} (#${e.entityId})
+                    ${renderAvatarHtml(avatar, 18)} ${esc(name)} (#${e.entityId})
                 </label>`;
             }).join('');
 

--- a/backend/public/portal/schedule.html
+++ b/backend/public/portal/schedule.html
@@ -591,7 +591,7 @@
             }
 
             el.innerHTML = items.map(s => {
-                const entityLabel = getAvatarForEntity(s.entityId) + ' ' + getEntityDisplayName(s.entityId) + ' #' + s.entityId;
+                const entityLabel = renderAvatarHtml(getAvatarForEntity(s.entityId), 20) + ' ' + getEntityDisplayName(s.entityId) + ' #' + s.entityId;
                 const timeStr = formatScheduleTime(s);
                 const statusClass = s.isPaused ? 'paused' : s.status;
                 const statusLabel = s.isPaused ? (i18n.t('sched_status_paused') || 'Paused') : getStatusLabel(s.status);
@@ -750,7 +750,7 @@
                 const name = getEntityDisplayName(e.entityId);
                 const activeClass = idx === 0 ? ' active' : '';
                 return '<div class="entity-chip' + activeClass + '" data-entity="' + e.entityId + '" onclick="selectEntity(' + e.entityId + ')">' +
-                    avatar + ' ' + esc(name) + ' (#' + e.entityId + ')' +
+                    renderAvatarHtml(avatar, 20) + ' ' + esc(name) + ' (#' + e.entityId + ')' +
                     '</div>';
             }).join('');
 
@@ -965,7 +965,7 @@
                 const name = getEntityDisplayName(e.entityId);
                 const activeClass = e.entityId === schedule.entityId ? ' active' : '';
                 return '<div class="entity-chip' + activeClass + '" data-entity="' + e.entityId + '" onclick="selectEntity(' + e.entityId + ')">' +
-                    avatar + ' ' + esc(name) + ' (#' + e.entityId + ')' +
+                    renderAvatarHtml(avatar, 20) + ' ' + esc(name) + ' (#' + e.entityId + ')' +
                     '</div>';
             }).join('');
 

--- a/backend/public/portal/shared/entity-utils.js
+++ b/backend/public/portal/shared/entity-utils.js
@@ -52,6 +52,27 @@ function getEntityDisplayName(entityId) {
 }
 
 /**
+ * Check if an avatar value is an image URL (not an emoji).
+ */
+function isAvatarUrl(avatar) {
+    return avatar && typeof avatar === 'string' && avatar.startsWith('https://');
+}
+
+/**
+ * Render an avatar as HTML. Returns an <img> tag for URLs, or emoji text for emoji avatars.
+ * @param {string} avatar - emoji string or image URL
+ * @param {number} [size=48] - size in px (for image avatars)
+ */
+function renderAvatarHtml(avatar, size) {
+    size = size || 48;
+    if (isAvatarUrl(avatar)) {
+        return '<img src="' + avatar + '" class="entity-avatar-img" ' +
+            'style="width:' + size + 'px;height:' + size + 'px;" alt="avatar" loading="lazy">';
+    }
+    return avatar || '\u{1F99E}';
+}
+
+/**
  * Get a full label like "🦞 Lobster (#4)" for an entity.
  * Uses the page's local escapeHtml/esc function if available.
  */
@@ -62,5 +83,9 @@ function getEntityLabel(entityId) {
     const escapeFn = typeof escapeHtml === 'function' ? escapeHtml
         : typeof esc === 'function' ? esc
         : (s) => s;
+    // For image URL avatars, skip the emoji prefix in text-only contexts
+    if (isAvatarUrl(avatar)) {
+        return `${escapeFn(name)} (#${entityId})`;
+    }
     return `${avatar} ${escapeFn(name)} (#${entityId})`;
 }

--- a/backend/public/portal/shared/style.css
+++ b/backend/public/portal/shared/style.css
@@ -507,6 +507,38 @@ a:hover { text-decoration: underline; }
     box-shadow: 0 0 12px rgba(108, 99, 255, 0.3);
 }
 
+.entity-avatar-img {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    object-fit: cover;
+}
+
+.avatar-upload-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    width: 100%;
+    padding: 10px;
+    margin-bottom: 12px;
+    border: 2px dashed var(--border-color);
+    border-radius: 10px;
+    background: var(--input-bg);
+    color: var(--text-secondary);
+    font-size: 14px;
+    cursor: pointer;
+    transition: border-color 0.2s, color 0.2s;
+}
+.avatar-upload-btn:hover {
+    border-color: var(--primary);
+    color: var(--primary);
+}
+.avatar-upload-btn.uploading {
+    opacity: 0.6;
+    cursor: wait;
+}
+
 .entity-info { flex: 1; min-width: 0; }
 .entity-name { font-weight: 600; font-size: 15px; margin-bottom: 4px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .entity-message {

--- a/backend/tests/jest/avatar-upload.test.js
+++ b/backend/tests/jest/avatar-upload.test.js
@@ -1,0 +1,259 @@
+/**
+ * Jest test: Avatar upload and update endpoints
+ * Tests PUT /api/device/entity/avatar (relaxed validation)
+ * Tests POST /api/device/entity/avatar/upload (multipart upload)
+ */
+
+// ── Same mocks as health.test.js ──
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+        connect: jest.fn().mockResolvedValue({
+            query: jest.fn().mockResolvedValue({ rows: [] }),
+            release: jest.fn(),
+        }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+jest.mock('../../db', () => ({
+    initDatabase: jest.fn().mockResolvedValue(false),
+    saveDeviceData: jest.fn().mockResolvedValue(true),
+    saveAllDevices: jest.fn().mockResolvedValue(true),
+    loadAllDevices: jest.fn().mockResolvedValue({}),
+    deleteDevice: jest.fn().mockResolvedValue(true),
+    getStats: jest.fn().mockResolvedValue({}),
+    closeDatabase: jest.fn().mockResolvedValue(undefined),
+    saveOfficialBot: jest.fn().mockResolvedValue(true),
+    loadOfficialBots: jest.fn().mockResolvedValue({}),
+    deleteOfficialBot: jest.fn().mockResolvedValue(true),
+    saveOfficialBinding: jest.fn().mockResolvedValue(true),
+    removeOfficialBinding: jest.fn().mockResolvedValue(true),
+    getOfficialBinding: jest.fn().mockResolvedValue(null),
+    getDeviceOfficialBindings: jest.fn().mockResolvedValue([]),
+    updateSubscriptionVerified: jest.fn().mockResolvedValue(true),
+    loadAllOfficialBindings: jest.fn().mockResolvedValue([]),
+    getExpiredPersonalBindings: jest.fn().mockResolvedValue([]),
+    getPaidBorrowSlots: jest.fn().mockResolvedValue(0),
+    incrementPaidBorrowSlots: jest.fn().mockResolvedValue(true),
+    saveFeedback: jest.fn().mockResolvedValue({ id: 1 }),
+}));
+
+jest.mock('../../flickr', () => ({
+    initFlickr: jest.fn(),
+    uploadPhoto: jest.fn().mockResolvedValue({
+        success: true,
+        url: 'https://live.staticflickr.com/65535/12345_abc_b.jpg',
+        photoId: '12345',
+    }),
+    isAvailable: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock('../../scheduler', () => ({
+    init: jest.fn(),
+    createSchedule: jest.fn().mockResolvedValue({ id: 1 }),
+    updateSchedule: jest.fn().mockResolvedValue(true),
+    deleteSchedule: jest.fn().mockResolvedValue(true),
+    getSchedules: jest.fn().mockResolvedValue([]),
+    getSchedule: jest.fn().mockResolvedValue(null),
+    getSchedulesForBot: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../../device-telemetry', () => ({
+    initTelemetryTable: jest.fn().mockResolvedValue(undefined),
+    appendEntries: jest.fn().mockResolvedValue(undefined),
+    captureApiCall: jest.fn().mockResolvedValue(undefined),
+    getEntries: jest.fn().mockResolvedValue([]),
+    getSummary: jest.fn().mockResolvedValue({}),
+    clearEntries: jest.fn().mockResolvedValue(undefined),
+    createMiddleware: jest.fn().mockReturnValue((_req, _res, next) => next()),
+    sanitize: jest.fn().mockImplementation((v) => v),
+    MAX_BUFFER_BYTES: 1024 * 1024,
+    MAX_ENTRIES: 500,
+}));
+
+jest.mock('../../device-feedback', () => ({
+    initFeedbackTable: jest.fn().mockResolvedValue(undefined),
+    initFeedbackPhotosTable: jest.fn().mockResolvedValue(undefined),
+    captureLogSnapshot: jest.fn().mockResolvedValue([]),
+    captureDeviceState: jest.fn().mockResolvedValue({}),
+    autoTriage: jest.fn().mockResolvedValue('low'),
+    generateAiPrompt: jest.fn().mockReturnValue(''),
+    saveFeedback: jest.fn().mockResolvedValue({ id: 1 }),
+    getFeedbackList: jest.fn().mockResolvedValue([]),
+    getFeedbackById: jest.fn().mockResolvedValue(null),
+    updateFeedback: jest.fn().mockResolvedValue(true),
+    createGithubIssue: jest.fn().mockResolvedValue(null),
+    getPendingDebugFeedback: jest.fn().mockResolvedValue([]),
+    saveDebugResult: jest.fn().mockResolvedValue(true),
+    setMark: jest.fn().mockResolvedValue(undefined),
+    getMark: jest.fn().mockResolvedValue(null),
+    clearMark: jest.fn().mockResolvedValue(undefined),
+    LOG_WINDOW_MS: 60000,
+    MAX_PHOTOS_PER_FEEDBACK: 10,
+    MAX_PHOTO_SIZE: 5 * 1024 * 1024,
+    saveFeedbackPhoto: jest.fn().mockResolvedValue({ id: 1 }),
+    getFeedbackPhotos: jest.fn().mockResolvedValue([]),
+    getFeedbackPhoto: jest.fn().mockResolvedValue(null),
+    deleteFeedbackPhotos: jest.fn().mockResolvedValue(undefined),
+    cleanupResolvedFeedbackPhotos: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../gatekeeper', () => ({
+    detectMaliciousMessage: jest.fn().mockReturnValue({ isMalicious: false }),
+    detectAndMaskLeaks: jest.fn().mockImplementation((text) => text),
+    initGatekeeperTable: jest.fn().mockResolvedValue(undefined),
+    loadBlockedDevices: jest.fn().mockResolvedValue(undefined),
+    recordViolation: jest.fn().mockResolvedValue(undefined),
+    isDeviceBlocked: jest.fn().mockReturnValue(false),
+    getStrikeInfo: jest.fn().mockResolvedValue({ strikes: 0, blocked: false }),
+    getFreeBotTOS: jest.fn().mockResolvedValue(null),
+    hasAgreedToTOS: jest.fn().mockResolvedValue(false),
+    recordTOSAgreement: jest.fn().mockResolvedValue(undefined),
+    setServerLog: jest.fn(),
+    MAX_STRIKES: 3,
+    FREE_BOT_TOS_VERSION: '1.0',
+}));
+
+jest.mock('../../notifications', () => {
+    const express = jest.requireActual('express');
+    return {
+        init: jest.fn(),
+        router: express.Router(),
+        initNotificationTables: jest.fn().mockResolvedValue(undefined),
+    };
+});
+
+jest.mock('../../chat-integrity', () => ({
+    init: jest.fn().mockReturnValue({
+        verify: jest.fn().mockReturnValue({ valid: true }),
+        sign: jest.fn().mockReturnValue('sig'),
+    }),
+    initIntegrityTable: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../device-preferences', () => ({
+    init: jest.fn(),
+    initTable: jest.fn().mockResolvedValue(undefined),
+}));
+
+const request = require('supertest');
+const app = require('../../index');
+
+describe('PUT /api/device/entity/avatar', () => {
+    test('rejects missing credentials', async () => {
+        const res = await request(app)
+            .put('/api/device/entity/avatar')
+            .send({ entityId: 0, avatar: '🦞' });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+    });
+
+    test('rejects missing avatar', async () => {
+        const res = await request(app)
+            .put('/api/device/entity/avatar')
+            .send({ deviceId: 'test', deviceSecret: 'test', entityId: 0 });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+    });
+
+    test('rejects invalid entityId', async () => {
+        const res = await request(app)
+            .put('/api/device/entity/avatar')
+            .send({ deviceId: 'test', deviceSecret: 'test', entityId: -1, avatar: '🦞' });
+        expect(res.status).toBe(400);
+    });
+
+    test('rejects emoji longer than 8 chars', async () => {
+        const res = await request(app)
+            .put('/api/device/entity/avatar')
+            .send({ deviceId: 'test', deviceSecret: 'test', entityId: 0, avatar: '123456789' });
+        expect(res.status).toBe(400);
+        expect(res.body.message).toMatch(/emoji/i);
+    });
+
+    test('accepts valid https:// URL as avatar', async () => {
+        const res = await request(app)
+            .put('/api/device/entity/avatar')
+            .send({
+                deviceId: 'test', deviceSecret: 'test', entityId: 0,
+                avatar: 'https://live.staticflickr.com/65535/12345_abc_b.jpg'
+            });
+        // Will be 404 (device not found) but NOT 400 (validation passed)
+        expect(res.status).toBe(404);
+    });
+
+    test('rejects URL longer than 500 chars', async () => {
+        const longUrl = 'https://' + 'a'.repeat(500);
+        const res = await request(app)
+            .put('/api/device/entity/avatar')
+            .send({ deviceId: 'test', deviceSecret: 'test', entityId: 0, avatar: longUrl });
+        expect(res.status).toBe(400);
+        expect(res.body.message).toMatch(/too long/i);
+    });
+});
+
+describe('POST /api/device/entity/avatar/upload', () => {
+    test('rejects missing credentials', async () => {
+        const res = await request(app)
+            .post('/api/device/entity/avatar/upload')
+            .field('entityId', '0')
+            .attach('file', Buffer.from('fake-image'), {
+                filename: 'avatar.jpg',
+                contentType: 'image/jpeg',
+            });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+    });
+
+    test('rejects missing file', async () => {
+        const res = await request(app)
+            .post('/api/device/entity/avatar/upload')
+            .field('deviceId', 'test')
+            .field('deviceSecret', 'test')
+            .field('entityId', '0');
+        expect(res.status).toBe(400);
+        expect(res.body.message).toMatch(/no image/i);
+    });
+
+    test('rejects invalid entityId', async () => {
+        const res = await request(app)
+            .post('/api/device/entity/avatar/upload')
+            .field('deviceId', 'test')
+            .field('deviceSecret', 'test')
+            .field('entityId', '-1')
+            .attach('file', Buffer.from('fake-image'), {
+                filename: 'avatar.jpg',
+                contentType: 'image/jpeg',
+            });
+        expect(res.status).toBe(400);
+    });
+
+    test('rejects non-image file type', async () => {
+        const res = await request(app)
+            .post('/api/device/entity/avatar/upload')
+            .field('deviceId', 'test')
+            .field('deviceSecret', 'test')
+            .field('entityId', '0')
+            .attach('file', Buffer.from('not-an-image'), {
+                filename: 'test.txt',
+                contentType: 'text/plain',
+            });
+        // multer fileFilter rejects non-image types
+        expect([400, 404, 500]).toContain(res.status);
+        expect(res.body.success).not.toBe(true);
+    });
+
+    test('rejects unknown device', async () => {
+        const res = await request(app)
+            .post('/api/device/entity/avatar/upload')
+            .field('deviceId', 'nonexistent')
+            .field('deviceSecret', 'wrong')
+            .field('entityId', '0')
+            .attach('file', Buffer.from('fake-image'), {
+                filename: 'avatar.jpg',
+                contentType: 'image/jpeg',
+            });
+        expect(res.status).toBe(404);
+    });
+});

--- a/ios-app/app/entity-manager.tsx
+++ b/ios-app/app/entity-manager.tsx
@@ -71,15 +71,15 @@ export default function EntityManagerScreen() {
     const result = await ImagePicker.launchImageLibraryAsync({
       mediaTypes: ImagePicker.MediaTypeOptions.Images,
       quality: 0.5,
-      base64: true,
       allowsEditing: true,
       aspect: [1, 1],
     });
-    if (!result.canceled && result.assets[0].base64) {
-      const base64 = `data:image/jpeg;base64,${result.assets[0].base64}`;
+    if (!result.canceled && result.assets[0].uri) {
       try {
-        await deviceApi.updateAvatar(entity.entityId, base64);
-        updateEntity(entity.entityId, { avatarUrl: result.assets[0].uri });
+        const response = await deviceApi.uploadAvatar(entity.entityId, result.assets[0].uri);
+        if (response.data?.avatar) {
+          updateEntity(entity.entityId, { avatarUrl: response.data.avatar });
+        }
         setSnack(t('common.success'));
       } catch {
         setSnack(t('errors.server'));

--- a/ios-app/services/api.ts
+++ b/ios-app/services/api.ts
@@ -62,9 +62,23 @@ export const deviceApi = {
   renameEntity: (entityId: string, name: string) =>
     apiClient.put('/api/device/entity/name', { entityId, name }),
 
-  /** Update entity avatar (base64 image) */
-  updateAvatar: (entityId: string, avatarBase64: string) =>
-    apiClient.put('/api/device/entity/avatar', { entityId, avatar: avatarBase64 }),
+  /** Update entity avatar (emoji string or URL) */
+  updateAvatar: (entityId: string, avatar: string) =>
+    apiClient.put('/api/device/entity/avatar', { entityId, avatar }),
+
+  /** Upload photo as entity avatar (stored on Flickr) */
+  uploadAvatar: (entityId: string, imageUri: string) => {
+    const formData = new FormData();
+    formData.append('file', {
+      uri: imageUri,
+      type: 'image/jpeg',
+      name: 'avatar.jpg',
+    } as any);
+    formData.append('entityId', entityId);
+    return apiClient.post('/api/device/entity/avatar/upload', formData, {
+      headers: { 'Content-Type': 'multipart/form-data' },
+    });
+  },
 
   /** Remove/unbind an entity */
   removeEntity: (entityId: string) =>


### PR DESCRIPTION
Users can now upload custom photos as entity avatars. Photos are stored
on Flickr via the existing flickr.js integration. The avatar field
accepts both emoji strings (1-8 chars) and Flickr image URLs.

Backend:
- New POST /api/device/entity/avatar/upload multipart endpoint (5MB max)
- Relaxed PUT /api/device/entity/avatar validation to accept https:// URLs
- Added renderAvatarHtml() and isAvatarUrl() helpers to entity-utils.js
- Added .entity-avatar-img and .avatar-upload-btn CSS styles

Web Portal:
- Avatar picker now shows "Upload Photo" button above emoji grid
- Entity cards, chat, mission, schedule, files pages render image avatars

Android:
- Upload photo button in avatar picker dialog
- New uploadEntityAvatar multipart API in ClawApiService
- EntityCardAdapter and ChatAdapter render image avatars via Glide
- Added ImageView overlays in item_agent_card.xml and item_message_received.xml
- AvatarUploadResponse model for Flickr URL response

iOS:
- New uploadAvatar() multipart method in api.ts
- entity-manager.tsx uses multipart upload instead of base64

Tests:
- 11 new Jest tests for avatar upload validation (avatar-upload.test.js)

https://claude.ai/code/session_019NEwSrxGcnYGXYY6TG3YF8