### PR TITLE
fix: prevent CDN cache mismatch from breaking entity loading on web portal

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -149,7 +149,14 @@ app.get('/landing', (req, res) => {
 });
 
 app.use('/mission', express.static(path.join(__dirname, 'public')));
-app.use('/portal', express.static(path.join(__dirname, 'public/portal')));
+app.use('/portal', express.static(path.join(__dirname, 'public/portal'), {
+    setHeaders: (res, filePath) => {
+        // Prevent CDN from serving stale JS after deploys (fixes entity-utils.js cache mismatch)
+        if (filePath.endsWith('.js')) {
+            res.set('Cache-Control', 'no-cache');
+        }
+    }
+}));
 app.use('/shared', express.static(path.join(__dirname, 'public/shared'), {
     setHeaders: (res, filePath) => {
         if (filePath.endsWith('i18n.js')) {

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -1082,6 +1082,7 @@
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
     <script src="shared/ai-chat.js"></script>
+    <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script>
         // ── State ──
         let allMessages = [];

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -1303,6 +1303,7 @@
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
     <script src="shared/ai-chat.js"></script>
+    <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script>
         // --- Constants ---
         // ENTITY_CHARS_DEFAULT, getAvatarForEntity, getEntityDisplayName, getEntityLabel

--- a/backend/public/portal/files.html
+++ b/backend/public/portal/files.html
@@ -511,6 +511,7 @@
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
     <script src="shared/ai-chat.js"></script>
+    <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script>
         // ENTITY_CHARS_DEFAULT, getAvatarForEntity, getEntityDisplayName, getEntityLabel
         // are provided by shared/entity-utils.js

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -567,6 +567,7 @@
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
     <script src="shared/ai-chat.js"></script>
+    <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script>
         // --- State ---
         let dashboard = { todoList: [], missionList: [], doneList: [], notes: [], rules: [], skills: [], souls: [] };

--- a/backend/public/portal/schedule.html
+++ b/backend/public/portal/schedule.html
@@ -457,6 +457,7 @@
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
     <script src="shared/ai-chat.js"></script>
+    <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script>
         // ── State ──
         let allSchedules = [];

--- a/backend/tests/jest/health.test.js
+++ b/backend/tests/jest/health.test.js
@@ -218,3 +218,18 @@ describe('GET /', () => {
         expect(res.text).toContain('EClawbot');
     });
 });
+
+describe('Portal static JS cache headers', () => {
+    it('sets Cache-Control: no-cache on portal JS files', async () => {
+        const res = await request(app).get('/portal/shared/entity-utils.js');
+        expect(res.status).toBe(200);
+        expect(res.headers['cache-control']).toBe('no-cache');
+    });
+
+    it('does not set no-cache on portal HTML files', async () => {
+        const res = await request(app).get('/portal/index.html');
+        expect(res.status).toBe(200);
+        // HTML should not have no-cache (only JS gets it)
+        expect(res.headers['cache-control']).not.toBe('no-cache');
+    });
+});


### PR DESCRIPTION
## Summary
- Cloudflare CDN could serve stale `entity-utils.js` (missing `renderAvatarHtml`) alongside newer portal pages that call it, causing `ReferenceError` caught as "Failed to load entities" / "chat_load_failed"
- Set `Cache-Control: no-cache` on all portal JS files so CDN revalidates on every request
- Add inline `renderAvatarHtml`/`isAvatarUrl` fallback stubs in 5 portal pages as defense-in-depth
- Add Jest tests for cache-control headers

## Test plan
- [x] Jest: 355 tests pass (20 suites)
- [x] ESLint: 0 errors
- [x] New cache-control header tests pass

https://claude.ai/code/session_01CmmyaTrWo2nC42Fwraoouc