### PR TITLE
fix: prevent template gallery buttons from opening multiple dialogs on spam-click

### DIFF
--- a/app/src/main/java/com/hank/clawlive/MissionControlActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/MissionControlActivity.kt
@@ -532,6 +532,8 @@ class MissionControlActivity : AppCompatActivity() {
 
         // Wire up server-side rule gallery button
         btnChooseRuleTemplate.setOnClickListener {
+            if (isGalleryOpen) return@setOnClickListener
+            isGalleryOpen = true
             viewModel.fetchRuleTemplates()
             lifecycleScope.launch {
                 val templates = viewModel.ruleTemplates.first { it.isNotEmpty() }
@@ -540,6 +542,8 @@ class MissionControlActivity : AppCompatActivity() {
                     etDescription.setText(desc)
                     val idx = types.indexOfFirst { it.name == ruleType }
                     if (idx >= 0) spinnerType.setSelection(idx)
+                }.apply {
+                    setOnDismissListener { isGalleryOpen = false }
                 }.show()
             }
         }
@@ -733,8 +737,13 @@ class MissionControlActivity : AppCompatActivity() {
         }
     }
 
+    /** Prevents duplicate gallery dialogs from spam-clicking. */
+    private var isGalleryOpen = false
+
     /** Opens a scrollable gallery dialog listing all official skill templates. */
     private fun showTemplateGalleryDialog(onSelect: (SkillTemplate) -> Unit) {
+        if (isGalleryOpen) return
+        isGalleryOpen = true
         if (skillTemplates.isEmpty()) {
             lifecycleScope.launch {
                 try {
@@ -849,6 +858,7 @@ class MissionControlActivity : AppCompatActivity() {
             .setTitle(title)
             .setView(outerLayout)
             .setNegativeButton(R.string.cancel, null)
+            .setOnDismissListener { isGalleryOpen = false }
             .show()
     }
 
@@ -886,6 +896,8 @@ class MissionControlActivity : AppCompatActivity() {
 
         // Single Gallery button — shows built-in + community templates unified
         btnChooseSoulTemplate.setOnClickListener {
+            if (isGalleryOpen) return@setOnClickListener
+            isGalleryOpen = true
             lifecycleScope.launch {
                 // If community templates aren't loaded yet, fetch and wait
                 if (viewModel.soulTemplates.value.isEmpty()) {
@@ -909,6 +921,8 @@ class MissionControlActivity : AppCompatActivity() {
                     etDescription.setText(desc)
                     selectedTemplateId = templateId
                     btnChooseSoulTemplate.text = "🎭 $name"
+                }.apply {
+                    setOnDismissListener { isGalleryOpen = false }
                 }.show()
             }
         }

--- a/app/src/main/java/com/hank/clawlive/ui/mission/RuleGalleryDialog.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/mission/RuleGalleryDialog.kt
@@ -20,12 +20,21 @@ class RuleGalleryDialog(
     private val templates: List<SkillTemplate>,
     private val onTemplateSelected: (name: String, description: String, ruleType: String) -> Unit
 ) {
+    private var onDismissListener: (() -> Unit)? = null
+
+    /** Set a listener to be invoked when the dialog is dismissed (by selection, cancel, or back). */
+    fun setOnDismissListener(listener: () -> Unit): RuleGalleryDialog {
+        onDismissListener = listener
+        return this
+    }
+
     fun show() {
         if (templates.isEmpty()) {
             MaterialAlertDialogBuilder(context)
                 .setTitle(context.getString(R.string.mission_rule_gallery_title))
                 .setMessage(context.getString(R.string.mission_template_empty))
                 .setPositiveButton(android.R.string.ok, null)
+                .setOnDismissListener { onDismissListener?.invoke() }
                 .show()
             return
         }
@@ -118,6 +127,7 @@ class RuleGalleryDialog(
             .setTitle(title)
             .setView(outerLayout)
             .setNegativeButton(android.R.string.cancel, null)
+            .setOnDismissListener { onDismissListener?.invoke() }
             .show()
     }
 }

--- a/app/src/main/java/com/hank/clawlive/ui/mission/SoulGalleryDialog.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/mission/SoulGalleryDialog.kt
@@ -22,6 +22,14 @@ class SoulGalleryDialog(
     private val communityTemplates: List<SkillTemplate>,
     private val onSelected: (name: String, description: String, templateId: String?) -> Unit
 ) {
+    private var onDismissListener: (() -> Unit)? = null
+
+    /** Set a listener to be invoked when the dialog is dismissed (by selection, cancel, or back). */
+    fun setOnDismissListener(listener: () -> Unit): SoulGalleryDialog {
+        onDismissListener = listener
+        return this
+    }
+
     data class BuiltinTemplate(
         val id: String,
         val icon: String,
@@ -138,6 +146,7 @@ class SoulGalleryDialog(
             .setTitle(title)
             .setView(outerLayout)
             .setNegativeButton(android.R.string.cancel, null)
+            .setOnDismissListener { onDismissListener?.invoke() }
             .show()
     }
 }

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -1447,6 +1447,8 @@
 
         // ========== Soul Gallery ==========
         function showSoulGallery() {
+            // Prevent duplicate overlays from spam-clicking
+            if (document.getElementById('soul_gallery_overlay')) return;
             // Section A: built-in SOUL_TEMPLATES
             const builtinCards = SOUL_TEMPLATES.map(t => {
                 const name = getSoulTemplateName(t);
@@ -1558,6 +1560,8 @@
         }
 
         function showRuleGallery() {
+            // Prevent duplicate overlays from spam-clicking
+            if (document.getElementById('rule_gallery_overlay')) return;
             const cards = ruleTemplates.map(t =>
                 `<div class="tpl-gallery-card" data-id="${esc(t.id)}" data-label="${esc(t.label)}" data-author="${esc(t.author || '')}" onclick="selectRuleTemplate('${esc(t.id)}')">
                     <div class="tpl-gallery-icon">${esc(t.icon) || '📋'}</div>


### PR DESCRIPTION
## Summary
- Web Portal: guard `showSoulGallery()` and `showRuleGallery()` with overlay existence check to prevent duplicate overlays from `insertAdjacentHTML`
- Android: add `isGalleryOpen` flag with `onDismissListener` reset for all 3 gallery types (skill, soul, rule)

## Test plan
- [ ] Open mission page, click "瀏覽官方模板" button rapidly — verify only one gallery opens
- [ ] Open soul dialog, click template button rapidly — verify only one gallery
- [ ] Open rule dialog, click template button rapidly — verify only one gallery
- [ ] After closing gallery, verify button works again normally

https://claude.ai/code/session_01PGFSZ5oFQj5B22aQ5jwe46