### PR TITLE
fix: make /api/health dynamic for deploy detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -346,7 +346,7 @@ When implementing or modifying any feature on one platform, ensure the other pla
 - Changes to root files do NOT trigger deployment — must change files under `backend/`
 - Railway sits behind Cloudflare CDN — deploy can take 2-5 minutes
 - Use `/api/auth/oauth/providers` or `/api/audit-logs` as deploy canary endpoints
-- `/api/health` build string is hardcoded, not useful for detecting deploys — check uptime or new endpoint availability instead
+- `/api/health` returns dynamic `startedAt` ISO timestamp and `uptime` — compare `startedAt` to detect new deploys
 
 ---
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -25,6 +25,9 @@ const app = express();
 app.set('trust proxy', 1); // Railway reverse proxy — makes req.ip, req.protocol accurate
 const httpServer = http.createServer(app);
 const port = process.env.PORT || 3000;
+const SERVER_STARTED_AT = new Date();
+const SERVER_BUILD_TAG = `v5.6-${SERVER_STARTED_AT.toISOString().slice(0, 10).replace(/-/g, '')}`;
+
 
 // ============================================
 // SOCKET.IO SERVER
@@ -2299,7 +2302,7 @@ app.get('/', (req, res) => {
 
 // Health check endpoint for Railway
 app.get('/api/health', (req, res) => {
-    res.status(200).json({ status: 'ok', timestamp: Date.now(), build: 'v5.6-20260302', uptime: process.uptime() });
+    res.status(200).json({ status: 'ok', timestamp: Date.now(), build: SERVER_BUILD_TAG, uptime: process.uptime(), startedAt: SERVER_STARTED_AT.toISOString() });
 });
 
 

--- a/backend/tests/jest/health.test.js
+++ b/backend/tests/jest/health.test.js
@@ -183,6 +183,24 @@ describe('GET /api/health', () => {
         expect(res.body.timestamp).toBeGreaterThanOrEqual(before);
         expect(res.body.timestamp).toBeLessThanOrEqual(Date.now());
     });
+
+    it('includes a dynamic build tag with date', async () => {
+        const res = await request(app).get('/api/health');
+        expect(res.body.build).toMatch(/^v5\.6-\d{8}$/);
+    });
+
+    it('includes startedAt as a valid ISO timestamp', async () => {
+        const res = await request(app).get('/api/health');
+        expect(res.body.startedAt).toBeDefined();
+        const parsed = new Date(res.body.startedAt);
+        expect(parsed.getTime()).not.toBeNaN();
+    });
+
+    it('includes uptime as a positive number', async () => {
+        const res = await request(app).get('/api/health');
+        expect(typeof res.body.uptime).toBe('number');
+        expect(res.body.uptime).toBeGreaterThanOrEqual(0);
+    });
 });
 
 // ════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Replace hardcoded build string in `/api/health` with dynamic `SERVER_BUILD_TAG` and `startedAt` ISO timestamp
- `startedAt` changes on each deploy, making it reliable for detecting new deployments
- Add 3 Jest tests for the new health response fields
- Update CLAUDE.md deployment docs to reflect the improvement

## Test plan
- [x] Jest health tests pass (12/12 including 3 new)
- [x] ESLint passes (0 errors)
- [ ] Verify `/api/health` returns dynamic `startedAt` and `build` after deploy

https://claude.ai/code/session_01XkMiCnwxKsdbd71HykMGnQ