### PR TITLE
fix: render avatar URL as image across all Card Holder pages (#296)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/CardHolderActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/CardHolderActivity.kt
@@ -995,16 +995,28 @@ class CardHolderActivity : AppCompatActivity() {
 
     private fun buildAvatar(avatar: String?, character: String?): View {
         val size = dp(64)
+        val resolvedAvatar = avatar ?: if (character == "PIG") "\uD83D\uDC37" else "\uD83E\uDD9E"
+        val ovalBg = GradientDrawable().apply {
+            shape = GradientDrawable.OVAL
+            setColor(Color.parseColor("#252540"))
+        }
+        if (resolvedAvatar.startsWith("https://")) {
+            return ImageView(this).apply {
+                layoutParams = LinearLayout.LayoutParams(size, size)
+                scaleType = ImageView.ScaleType.CENTER_CROP
+                background = ovalBg
+                com.bumptech.glide.Glide.with(this@CardHolderActivity)
+                    .load(resolvedAvatar)
+                    .circleCrop()
+                    .into(this)
+            }
+        }
         return TextView(this).apply {
-            val emoji = avatar ?: if (character == "PIG") "\uD83D\uDC37" else "\uD83E\uDD9E"
-            text = emoji
+            text = resolvedAvatar
             textSize = 28f
             gravity = Gravity.CENTER
             layoutParams = LinearLayout.LayoutParams(size, size)
-            background = GradientDrawable().apply {
-                shape = GradientDrawable.OVAL
-                setColor(Color.parseColor("#252540"))
-            }
+            background = ovalBg
         }
     }
 

--- a/backend/public/portal/card-holder.html
+++ b/backend/public/portal/card-holder.html
@@ -575,6 +575,8 @@
     <script src="shared/api.js"></script>
     <script src="shared/nav.js"></script>
     <script src="shared/auth.js"></script>
+    <script src="shared/entity-utils.js"></script>
+    <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
     <script src="/socket.io/socket.io.js"></script>
@@ -712,7 +714,7 @@
             const ac = c.agentCard || {};
             let html = `<div class="card-item" onclick="showMyCardDetail('${escapeAttr(c.publicCode)}')">
                 <div class="card-row">
-                    <span class="agent-avatar">${avatar}</span>
+                    <span class="agent-avatar">${renderAvatarHtml(avatar, 48)}</span>
                     <div class="agent-meta">
                         <div class="agent-name">${escapeHtml(c.name || c.publicCode)}</div>
                         <span class="agent-code" onclick="event.stopPropagation(); copyCode('${escapeAttr(c.publicCode)}')" title="Click to copy">${escapeHtml(c.publicCode)}</span>
@@ -739,7 +741,7 @@
             const snap = c.cardSnapshot || {};
             let html = `<div class="card-item" onclick="openDetail('${escapeAttr(c.publicCode)}')">
                 <div class="card-row">
-                    <span class="agent-avatar">${avatar}</span>
+                    <span class="agent-avatar">${renderAvatarHtml(avatar, 48)}</span>
                     <div class="agent-meta">
                         <div class="agent-name">${escapeHtml(c.name || c.publicCode)}</div>
                         <span class="agent-code" onclick="event.stopPropagation(); copyCode('${escapeAttr(c.publicCode)}')">${escapeHtml(c.publicCode)}</span>
@@ -765,7 +767,7 @@
             const snap = c.cardSnapshot || {};
             let html = `<div class="card-item ${c.pinned ? 'pinned' : ''} ${c.blocked ? 'blocked' : ''}" onclick="openDetail('${escapeAttr(c.publicCode)}')">
                 <div class="card-row">
-                    <span class="agent-avatar">${avatar}</span>
+                    <span class="agent-avatar">${renderAvatarHtml(avatar, 48)}</span>
                     <div class="agent-meta">
                         <div class="agent-name">${escapeHtml(c.name || c.publicCode)}</div>
                         <span class="agent-code" onclick="event.stopPropagation(); copyCode('${escapeAttr(c.publicCode)}')">${escapeHtml(c.publicCode)}</span>
@@ -824,7 +826,7 @@
                     const snap = c.agentCard || {};
                     return `<div class="card-item">
                         <div class="card-row">
-                            <span class="agent-avatar">${avatar}</span>
+                            <span class="agent-avatar">${renderAvatarHtml(avatar, 48)}</span>
                             <div class="agent-meta">
                                 <div class="agent-name">${escapeHtml(c.name || c.publicCode)}</div>
                                 <span class="agent-code">${escapeHtml(c.publicCode)}</span>
@@ -858,7 +860,7 @@
             const content = document.getElementById('detailContent');
             content.innerHTML = `
                 <div class="modal-header">
-                    <span class="agent-avatar">${avatar}</span>
+                    <span class="agent-avatar">${renderAvatarHtml(avatar, 48)}</span>
                     <div class="modal-header-info">
                         <h3>${escapeHtml(card.name || card.publicCode)}</h3>
                         <span class="agent-code" onclick="copyCode('${escapeAttr(card.publicCode)}')">${escapeHtml(card.publicCode)}</span>
@@ -998,7 +1000,7 @@
             const content = document.getElementById('detailContent');
             content.innerHTML = `
                 <div class="modal-header">
-                    <span class="agent-avatar">${avatar}</span>
+                    <span class="agent-avatar">${renderAvatarHtml(avatar, 48)}</span>
                     <div class="modal-header-info">
                         <h3>${escapeHtml(card.name || card.publicCode)}</h3>
                         <span class="agent-code" onclick="copyCode('${escapeAttr(card.publicCode)}')">${escapeHtml(card.publicCode)}</span>

--- a/ios-app/app/(tabs)/cards.tsx
+++ b/ios-app/app/(tabs)/cards.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import {
   View,
   Text,
+  Image,
   StyleSheet,
   FlatList,
   TouchableOpacity,
@@ -117,8 +118,16 @@ export default function CardsScreen() {
     setRefreshing(false);
   };
 
-  const getAvatar = (c: { avatar?: string; character?: string }) =>
+  const getAvatarValue = (c: { avatar?: string; character?: string }) =>
     c.avatar || (c.character === 'PIG' ? '\u{1F437}' : '\u{1F99E}');
+
+  const renderAvatar = (c: { avatar?: string; character?: string }, size: number = 48, fontSize: number = 28) => {
+    const val = getAvatarValue(c);
+    if (val.startsWith('https://')) {
+      return <Image source={{ uri: val }} style={{ width: size, height: size, borderRadius: size / 2 }} />;
+    }
+    return <Text style={{ fontSize }}>{val}</Text>;
+  };
 
   const formatTimeAgo = (ts: number) => {
     const diff = Date.now() - ts;
@@ -283,7 +292,7 @@ export default function CardsScreen() {
       <SafeAreaView style={styles.container} edges={['bottom']}>
         <ScrollView style={styles.detailScroll}>
           <View style={styles.detailHeader}>
-            <Text style={styles.detailAvatar}>{getAvatar(selectedCard)}</Text>
+            {renderAvatar(selectedCard, 56, 40)}
             <View style={{ flex: 1 }}>
               <Text style={styles.detailName}>{selectedCard.name || selectedCard.publicCode}</Text>
               <View style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
@@ -447,7 +456,7 @@ export default function CardsScreen() {
         {c.pinned && !c.blocked && <Text style={styles.pinBadge}>{'\u{1F4CC}'}</Text>}
         {c.blocked && <Text style={styles.blockedCardBadge}>{t('cardHolder.blockedLabel', 'Blocked')}</Text>}
         <View style={styles.cardHeader}>
-          <Text style={styles.avatar}>{getAvatar(c)}</Text>
+          {renderAvatar(c, 48, 28)}
           <View style={styles.cardMeta}>
             <Text style={styles.cardName} numberOfLines={1}>{c.name || c.publicCode}</Text>
             <Text style={styles.cardCode}>{c.publicCode}</Text>
@@ -508,7 +517,7 @@ export default function CardsScreen() {
             <View style={styles.myCardsRow}>
               {myCards.map(c => (
                 <View key={c.publicCode} style={styles.myCardItem}>
-                  <Text style={styles.myCardAvatar}>{c.avatar || '\u{1F99E}'}</Text>
+                  {renderAvatar(c, 56, 36)}
                   <Text style={styles.myCardName}>{c.name || c.publicCode}</Text>
                   <Text style={styles.cardCode}>{c.publicCode}</Text>
                   <TouchableOpacity
@@ -542,7 +551,7 @@ export default function CardsScreen() {
           ) : (
             recentCards.map(c => (
               <TouchableOpacity key={c.publicCode} style={styles.recentItem} onPress={() => openDetail(c)}>
-                <Text style={styles.avatar}>{getAvatar(c)}</Text>
+                {renderAvatar(c, 48, 28)}
                 <View style={{ flex: 1 }}>
                   <Text style={styles.cardName}>{c.name || c.publicCode}</Text>
                   <Text style={styles.cardCode}>{c.publicCode}</Text>

--- a/ios-app/app/card-holder.tsx
+++ b/ios-app/app/card-holder.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react';
 import {
   View,
   Text,
+  Image,
   StyleSheet,
   FlatList,
   TouchableOpacity,
@@ -93,8 +94,16 @@ export default function CardHolderScreen() {
       return (b.addedAt || 0) - (a.addedAt || 0);
     });
 
-  const getAvatar = (c: CardEntry) =>
+  const getAvatarValue = (c: CardEntry) =>
     c.avatar || (c.character === 'PIG' ? '\u{1F437}' : '\u{1F99E}');
+
+  const renderAvatar = (c: CardEntry, size: number = 48, fontSize: number = 28) => {
+    const val = getAvatarValue(c);
+    if (val.startsWith('https://')) {
+      return <Image source={{ uri: val }} style={{ width: size, height: size, borderRadius: size / 2 }} />;
+    }
+    return <Text style={{ fontSize }}>{val}</Text>;
+  };
 
   const showAddDialog = () => {
     Alert.prompt(
@@ -208,7 +217,7 @@ export default function CardHolderScreen() {
       >
         {c.pinned && <Text style={styles.pinBadge}>{'\u{1F4CC}'}</Text>}
         <View style={styles.cardHeader}>
-          <Text style={styles.avatar}>{getAvatar(c)}</Text>
+          {renderAvatar(c, 48, 28)}
           <View style={styles.cardMeta}>
             <Text style={styles.cardName} numberOfLines={1}>{c.name || c.publicCode}</Text>
             <Text style={styles.cardCode}>{c.publicCode}</Text>
@@ -245,7 +254,7 @@ export default function CardHolderScreen() {
       <SafeAreaView style={styles.container}>
         <ScrollView style={styles.detailScroll}>
           <View style={styles.detailHeader}>
-            <Text style={styles.detailAvatar}>{getAvatar(selectedCard)}</Text>
+            {renderAvatar(selectedCard, 56, 40)}
             <View style={{ flex: 1 }}>
               <Text style={styles.detailName}>{selectedCard.name || selectedCard.publicCode}</Text>
               <Text style={styles.cardCode}>{selectedCard.publicCode}</Text>


### PR DESCRIPTION
## Summary
- **Web Portal**: Added `entity-utils.js` import to `card-holder.html`, replaced 6 raw `${avatar}` outputs with `renderAvatarHtml(avatar, 48)`
- **Android**: Updated `CardHolderActivity.buildAvatar()` to detect URL avatars and load them via Glide with `circleCrop()`
- **iOS/React Native**: Added `renderAvatar()` helper in `card-holder.tsx` and `cards.tsx` to conditionally render `<Image>` for URLs vs `<Text>` for emojis (6 locations total)

Closes #296

## Test plan
- [x] ESLint: 0 errors
- [x] Jest: 508/509 passed (1 pre-existing Telegraph failure)
- [ ] Manual: Set entity avatar to Flickr URL, verify card-holder page renders `<img>` not raw URL text
- [ ] Verify Android Card Holder shows Glide-loaded circular image for URL avatars
- [ ] Verify iOS Card Holder shows `<Image>` for URL avatars

🤖 Generated with [Claude Code](https://claude.com/claude-code)