### PR TITLE
fix: resolve admin nav link race condition for admin users

### DIFF
--- a/backend/public/portal/shared/auth.js
+++ b/backend/public/portal/shared/auth.js
@@ -23,6 +23,10 @@ async function checkAuth() {
         const emailEl = document.getElementById('navEmail');
         if (emailEl) emailEl.textContent = currentUser.email;
 
+        // Ensure admin link is added after user data is available
+        // (the 600ms timeout in nav.js may fire before this API call completes)
+        if (typeof window._addAdminLink === 'function') window._addAdminLink();
+
         return currentUser;
     } catch (e) {
         window.location.href = 'index.html';

--- a/backend/public/portal/shared/nav.js
+++ b/backend/public/portal/shared/nav.js
@@ -26,7 +26,8 @@ function renderNav(activePage) {
             }
         }
     };
-    setTimeout(window._addAdminLink, 600);
+    // _addAdminLink is called by checkAuth() after user data is available,
+    // or manually by pages with custom auth flows (e.g., info.html).
 
     const t = (key, fallback) => typeof i18n !== 'undefined' ? i18n.t(key) : fallback;
 

--- a/backend/tests/test-ux-static-audit.js
+++ b/backend/tests/test-ux-static-audit.js
@@ -511,6 +511,24 @@ function auditScriptOrder(html, page) {
     return passed;
 }
 
+/**
+ * 10. Admin Link After Auth
+ * shared/auth.js must call _addAdminLink() after setting window.currentUser
+ * to avoid race condition with the 600ms setTimeout in nav.js.
+ */
+function auditAdminLinkAfterAuth() {
+    const authPath = path.join(PORTAL_DIR, 'shared', 'auth.js');
+    if (!fs.existsSync(authPath)) {
+        check('admin link after auth', false, 'shared/auth.js not found');
+        return false;
+    }
+    const src = fs.readFileSync(authPath, 'utf8');
+    const hasCall = /_addAdminLink/.test(src);
+    check('admin link after auth', hasCall,
+        hasCall ? 'checkAuth() calls _addAdminLink()' : 'checkAuth() missing _addAdminLink() — admin nav link may not appear on slow networks');
+    return hasCall;
+}
+
 // ── Main ────────────────────────────────────────────────────
 
 console.log('\n\u{1F50D} UX Static Audit \u2014 Layer 1\n');
@@ -518,6 +536,10 @@ console.log('\n\u{1F50D} UX Static Audit \u2014 Layer 1\n');
 let totalChecks = 0;
 let totalPassed = 0;
 let totalFailed = 0;
+
+// Global checks (not per-page)
+console.log('\u2500\u2500 Global Checks \u2500\u2500');
+auditAdminLinkAfterAuth();
 
 for (const page of PAGES) {
     const filePath = path.join(PORTAL_DIR, page);


### PR DESCRIPTION
## Summary
- Fixed race condition where admin nav link disappeared when `/api/auth/me` took >600ms
- `checkAuth()` now calls `_addAdminLink()` directly after user data is available
- Removed redundant 600ms setTimeout fallback in nav.js
- Added regression check in `test-ux-static-audit.js`

## Root Cause
`nav.js` used `setTimeout(_addAdminLink, 600)` which raced against the async `checkAuth()` API call. On slow networks, the timeout fired before `window.currentUser` was set, so the admin link was never added.

## Test plan
- [x] `node backend/tests/test-ux-static-audit.js` passes with new admin link check
- [x] All 508 Jest tests pass (`npm test`)
- [ ] Verify admin nav link appears for bbb880008@gmail.com after deploy

https://claude.ai/code/session_01Gt7JEYcc5zBYkS8i3q3N4u