### PR TITLE
fix: render image avatars in chat bubble labels

### DIFF
--- a/backend/public/portal/shared/entity-utils.js
+++ b/backend/public/portal/shared/entity-utils.js
@@ -83,9 +83,5 @@ function getEntityLabel(entityId) {
     const escapeFn = typeof escapeHtml === 'function' ? escapeHtml
         : typeof esc === 'function' ? esc
         : (s) => s;
-    // For image URL avatars, skip the emoji prefix in text-only contexts
-    if (isAvatarUrl(avatar)) {
-        return `${escapeFn(name)} (#${entityId})`;
-    }
-    return `${avatar} ${escapeFn(name)} (#${entityId})`;
+    return `${renderAvatarHtml(avatar, 20)} ${escapeFn(name)} (#${entityId})`;
 }


### PR DESCRIPTION
## Summary
- Fix `getEntityLabel()` in `entity-utils.js` to render image avatars (Flickr URLs) in chat bubble labels
- Previously, URL-based avatars were skipped entirely — only emoji avatars were shown
- Now uses `renderAvatarHtml(avatar, 20)` to consistently render both emoji and `<img>` avatars

## Test plan
- [x] All 508 Jest tests pass
- [ ] Verify entity #0's Flickr avatar appears in chat bubble sender labels
- [ ] Verify avatars still display correctly in filter chips, bottom checkboxes, and other pages

https://claude.ai/code/session_01CG9BzJusXEGJoLYJQUgPrD