### PR TITLE
fix: set bottom nav layout_gravity to BOTTOM in CardHolderActivity

### DIFF
--- a/app/src/main/java/com/hank/clawlive/CardHolderActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/CardHolderActivity.kt
@@ -197,6 +197,9 @@ class CardHolderActivity : AppCompatActivity() {
 
         // -- Bottom nav (inflate XML layout) --
         layoutInflater.inflate(R.layout.layout_bottom_nav, rootLayout)
+        rootLayout.findViewById<LinearLayout>(R.id.bottomNav)?.let {
+            (it.layoutParams as? FrameLayout.LayoutParams)?.gravity = Gravity.BOTTOM
+        }
 
         setContentView(rootLayout)
         BottomNavHelper.setup(this, NavItem.CARDS)


### PR DESCRIPTION
CardHolderActivity uses a FrameLayout as root, but the inflated
bottom nav had no layout_gravity set, causing it to render at the
top of the screen (FrameLayout default is TOP|START).

https://claude.ai/code/session_01YWZBXMr7xxDJRNBxMGbkS2