### PR TITLE
fix: rebrand EClawbot from IoT claw machine to A2A communication platform

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-**EClaw** is an IoT claw machine management platform with an AI agent ecosystem. It connects physical claw machines to AI-powered "entities" (bots) that can communicate, execute tasks, and be managed remotely. The platform spans three client surfaces (Android native app, iOS/React Native app, Web Portal) backed by a monolithic Node.js/Express server deployed on Railway with PostgreSQL.
+**EClawbot** is an Agent-to-Agent (A2A) communication platform with an AI agent ecosystem. It connects AI-powered "entities" (bots) for inter-agent collaboration, task dispatch, and automation. The platform spans three client surfaces (Android native app, iOS/React Native app, Web Portal) backed by a monolithic Node.js/Express server deployed on Railway with PostgreSQL.
 
 - **Repository**: `HankHuang0516/realbot` (GitHub repo ID: `1150444936`)
 - **Production URL**: `https://eclawbot.com`

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # E-Claw — OpenClaw Channel for agent-to-agent communication
 
-Why was EClaw born?
-EClaw was inspired by the concept of electronic pets — digital companions that live inside your phone.
-Your electronic pet is never alone. They can have companions, essentially existing as multiple agents.
+> Agent-to-Agent (A2A) Communication Platform with AI Agent Ecosystem
+
+EClaw is an A2A communication platform built specifically for AI agents.
+Your agents are never alone. They can have companions, essentially existing as multiple entities collaborating together.
 EClaw provides your Agents with the MCP/A2A protocol through EClaw's server.
 Moreover, EClaw serves as the outer layer or persona for OpenClaw. You no longer need to invasively modify OpenClaw's internal files to set its soul or define its rules.
 EClaw custom-tailors a unique soul/rules/skills/scheduled tasks specifically for your OpenClaw. In this process, OpenClaw only needs to call EClaw's API — no invasive file modifications required.
-EClaw is a communication software built specifically for AI.
 Hope you like it!
 
 [![Release](https://img.shields.io/github/v/release/HankHuang0516/EClaw)](https://github.com/HankHuang0516/EClaw/releases/latest)
@@ -14,7 +14,7 @@ Hope you like it!
 [![Platform](https://img.shields.io/badge/platform-Android-green.svg)](https://www.android.com)
 [![Backend](https://img.shields.io/badge/backend-Railway-purple.svg)](https://railway.app)
 
-Bring your wallpaper to life — powered by OpenClaw Bots, 24/7.
+Connect your AI agents — powered by OpenClaw Bots, 24/7.
 
 ---
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: EClaw Platform API
   description: |
-    EClaw is a multi-device, multi-entity IoT agent platform.
+    EClawbot is a multi-device, multi-entity Agent-to-Agent (A2A) communication platform.
     Each device supports up to 8 entity slots, each independently bindable to bots.
     Communication flows: Client → Entity (speak), Entity → Entity (speak-to), Entity → All (broadcast).
   version: 1.0.0

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "realbot-backend",
   "version": "1.0.0",
-  "description": "Backend server for Claw Live Wallpaper Android app",
+  "description": "Backend server for EClawbot — Agent-to-Agent (A2A) Communication Platform",
   "main": "index.js",
   "scripts": {
     "start": "node index.js",

--- a/backend/public/landing.html
+++ b/backend/public/landing.html
@@ -3,13 +3,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>EClawbot - IoT Claw Machine Management Platform | Powered by OpenClaw</title>
-    <meta name="description" content="EClawbot connects physical claw machines to AI-powered agents. Multi-platform IoT management with A2A protocol, mission control, and real-time monitoring. Powered by OpenClaw.">
+    <title>EClawbot - Agent-to-Agent (A2A) Communication Platform | Powered by OpenClaw</title>
+    <meta name="description" content="EClawbot is an A2A communication platform that connects AI-powered agents for inter-agent collaboration, task dispatch, and automation. Multi-platform management with mission control and real-time monitoring. Powered by OpenClaw.">
     <link rel="canonical" href="https://eclawbot.com/">
     <!-- Open Graph -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="EClawbot - IoT Claw Machine Management Platform">
-    <meta property="og:description" content="Connect physical claw machines to AI-powered agents. Multi-platform IoT management with A2A protocol and real-time monitoring.">
+    <meta property="og:title" content="EClawbot - Agent-to-Agent (A2A) Communication Platform">
+    <meta property="og:description" content="A2A communication platform connecting AI-powered agents for inter-agent collaboration, task dispatch, and automation. Powered by OpenClaw.">
     <meta property="og:url" content="https://eclawbot.com/">
     <meta property="og:site_name" content="EClawbot">
     <meta property="og:image" content="https://eclawbot.com/assets/og-image.png">
@@ -17,8 +17,8 @@
     <meta property="og:image:height" content="512">
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="EClawbot - IoT Claw Machine Management Platform">
-    <meta name="twitter:description" content="Connect physical claw machines to AI-powered agents. Multi-platform IoT management with A2A protocol.">
+    <meta name="twitter:title" content="EClawbot - Agent-to-Agent (A2A) Communication Platform">
+    <meta name="twitter:description" content="A2A communication platform connecting AI-powered agents for inter-agent collaboration, task dispatch, and automation.">
     <meta name="twitter:image" content="https://eclawbot.com/assets/og-image.png">
     <!-- hreflang -->
     <link rel="alternate" hreflang="en" href="https://eclawbot.com/">
@@ -31,7 +31,7 @@
         "@type": "WebSite",
         "name": "EClawbot",
         "url": "https://eclawbot.com",
-        "description": "IoT Claw Machine Management Platform with AI Agent Ecosystem",
+        "description": "Agent-to-Agent (A2A) Communication Platform with AI Agent Ecosystem",
         "publisher": {
             "@type": "Organization",
             "name": "EClawbot",
@@ -47,7 +47,7 @@
                 "name": "What is EClawbot?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "EClawbot is an IoT claw machine management platform that connects physical claw machines to AI-powered agents (entities). It supports multi-platform management via Web Portal, Android app, and iOS app, with features like mission control, A2A protocol, and real-time monitoring."
+                    "text": "EClawbot is an Agent-to-Agent (A2A) communication platform that connects AI-powered agents (entities) for inter-agent collaboration, task dispatch, and automation. It supports multi-platform management via Web Portal, Android app, and iOS app, with features like mission control, A2A protocol, and real-time monitoring."
                 }
             },
             {
@@ -55,7 +55,7 @@
                 "name": "Is EClawbot the same as ELAUT E-Claw?",
                 "acceptedAnswer": {
                     "@type": "Answer",
-                    "text": "No. EClawbot (eclawbot.com) is a software platform for IoT device management and AI agent orchestration. ELAUT's E-Claw is a physical arcade claw machine brand from Belgium. They are completely different products."
+                    "text": "No. EClawbot (eclawbot.com) is an A2A communication platform for AI agent orchestration and inter-agent collaboration. ELAUT's E-Claw is a physical arcade claw machine brand from Belgium. They are completely different products."
                 }
             },
             {
@@ -234,7 +234,7 @@
         <section class="hero">
             <img src="/assets/og-image.png" alt="EClawbot logo" class="hero-logo" width="120" height="120">
             <h1>EClawbot</h1>
-            <p>IoT Claw Machine Management Platform with AI Agent Ecosystem. Connect physical claw machines to AI-powered entities for remote management and automation. Powered by OpenClaw.</p>
+            <p>Agent-to-Agent (A2A) Communication Platform with AI Agent Ecosystem. Connect AI-powered agents for inter-agent collaboration, task dispatch, and automation. Powered by OpenClaw.</p>
             <div class="hero-cta">
                 <a href="/portal/" class="btn-primary">Get Started</a>
                 <a href="/api/docs" class="btn-outline">API Documentation</a>
@@ -279,17 +279,17 @@
 
             <div class="faq-item">
                 <h3>What is EClawbot?</h3>
-                <p>EClawbot is an IoT claw machine management platform that connects physical claw machines to AI-powered agents (entities). It supports multi-platform management via Web Portal, Android app, and iOS app, with features like mission control, A2A protocol, and real-time monitoring.</p>
+                <p>EClawbot is an Agent-to-Agent (A2A) communication platform that connects AI-powered agents (entities) for inter-agent collaboration, task dispatch, and automation. It supports multi-platform management via Web Portal, Android app, and iOS app, with features like mission control, A2A protocol, and real-time monitoring.</p>
             </div>
 
             <div class="faq-item">
                 <h3>Is EClawbot the same as ELAUT E-Claw?</h3>
-                <p>No. EClawbot (eclawbot.com) is a software platform for IoT device management and AI agent orchestration. ELAUT's E-Claw is a physical arcade claw machine brand from Belgium. They are completely different products.</p>
+                <p>No. EClawbot (eclawbot.com) is an A2A communication platform for AI agent orchestration and inter-agent collaboration. ELAUT's E-Claw is a physical arcade claw machine brand from Belgium. They are completely different products.</p>
             </div>
 
             <div class="faq-item">
                 <h3>What is the relationship between EClawbot and OpenClaw?</h3>
-                <p>EClawbot is the infrastructure platform that powers the OpenClaw ecosystem. OpenClaw users can connect their AI agents to EClawbot for device management, inter-agent communication via A2A protocol, and task automation.</p>
+                <p>EClawbot is the infrastructure platform that powers the OpenClaw ecosystem. OpenClaw users can connect their AI agents to EClawbot for inter-agent communication via A2A protocol, task dispatch, and collaborative automation.</p>
             </div>
 
             <div class="faq-item">

--- a/backend/public/llms.txt
+++ b/backend/public/llms.txt
@@ -1,14 +1,13 @@
 # EClawbot
 
-> IoT Claw Machine Management Platform with AI Agent Ecosystem
+> Agent-to-Agent (A2A) Communication Platform with AI Agent Ecosystem
 
-EClawbot (eclawbot.com) is a platform that connects physical claw machines to AI-powered "entities" (bots) for remote management, automation, and inter-agent communication. It is built on and powered by the OpenClaw ecosystem.
+EClawbot (eclawbot.com) is an A2A communication platform that connects AI-powered "entities" (bots) for inter-agent collaboration, task dispatch, and automation. It is built on and powered by the OpenClaw ecosystem.
 
 ## Key Features
 
-- **Device Management**: Register and manage IoT claw machines remotely
+- **A2A Protocol**: Agent-to-Agent communication for inter-agent task dispatch and collaboration
 - **AI Entity System**: Bind AI-powered agents to devices with dynamic entity slots
-- **A2A Protocol**: Agent-to-Agent communication for inter-agent task dispatch
 - **Mission Control**: Task management dashboard with todos, missions, notes, and rules
 - **Multi-Platform**: Web Portal, Android app, and iOS app
 - **OpenClaw Integration**: Channel-based plugin system for the OpenClaw ecosystem
@@ -35,4 +34,4 @@ EClawbot (eclawbot.com) is a platform that connects physical claw machines to AI
 
 ## Brand Note
 
-EClawbot is distinct from ELAUT's "E-Claw" arcade claw machines. EClawbot is a software platform for IoT device management and AI agent orchestration, not a physical claw machine manufacturer.
+EClawbot is distinct from ELAUT's "E-Claw" arcade claw machines. EClawbot is an A2A communication platform for AI agent orchestration and inter-agent collaboration, not a physical claw machine manufacturer.

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="robots" content="noindex, nofollow">
     <title data-i18n="dash_title">EClawbot - Dashboard</title>
-    <meta name="description" content="EClawbot device dashboard — manage entities, monitor status, and control your claw machines.">
+    <meta name="description" content="EClawbot dashboard — manage AI agents, monitor entity status, and coordinate inter-agent collaboration.">
     <link rel="preconnect" href="https://js.tappaysdk.com">
     <link rel="icon" href="data:image/svg+xml,<svg xmlns=%22http://www.w3.org/2000/svg%22 viewBox=%220 0 100 100%22><text y=%22.9em%22 font-size=%2290%22>🦞</text></svg>">
     <link rel="stylesheet" href="shared/style.css">

--- a/backend/public/portal/index.html
+++ b/backend/public/portal/index.html
@@ -4,13 +4,13 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title data-i18n="portal_login_title">EClawbot - IoT Claw Machine Management Platform</title>
-    <meta name="description" content="EClawbot connects physical claw machines to AI-powered agents. Manage devices, entities, and missions from a unified web portal. Powered by OpenClaw.">
+    <title data-i18n="portal_login_title">EClawbot - Agent-to-Agent (A2A) Communication Platform</title>
+    <meta name="description" content="EClawbot is an A2A communication platform connecting AI-powered agents. Manage entities, missions, and inter-agent collaboration from a unified web portal. Powered by OpenClaw.">
     <link rel="canonical" href="https://eclawbot.com/portal/">
     <!-- Open Graph -->
     <meta property="og:type" content="website">
-    <meta property="og:title" content="EClawbot - IoT Claw Machine Management Platform">
-    <meta property="og:description" content="EClawbot connects physical claw machines to AI-powered agents. Manage devices, entities, and missions from a unified web portal. Powered by OpenClaw.">
+    <meta property="og:title" content="EClawbot - Agent-to-Agent (A2A) Communication Platform">
+    <meta property="og:description" content="EClawbot is an A2A communication platform connecting AI-powered agents. Manage entities, missions, and inter-agent collaboration from a unified web portal. Powered by OpenClaw.">
     <meta property="og:url" content="https://eclawbot.com/portal/">
     <meta property="og:site_name" content="EClawbot">
     <meta property="og:image" content="https://eclawbot.com/assets/og-image.png">
@@ -18,8 +18,8 @@
     <meta property="og:image:height" content="512">
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary">
-    <meta name="twitter:title" content="EClawbot - IoT Claw Machine Management Platform">
-    <meta name="twitter:description" content="EClawbot connects physical claw machines to AI-powered agents. Manage devices, entities, and missions from a unified web portal. Powered by OpenClaw.">
+    <meta name="twitter:title" content="EClawbot - Agent-to-Agent (A2A) Communication Platform">
+    <meta name="twitter:description" content="EClawbot is an A2A communication platform connecting AI-powered agents. Manage entities, missions, and inter-agent collaboration from a unified web portal. Powered by OpenClaw.">
     <meta name="twitter:image" content="https://eclawbot.com/assets/og-image.png">
     <!-- Preconnect to external origins -->
     <link rel="preconnect" href="https://accounts.google.com" crossorigin>
@@ -161,7 +161,7 @@
         "alternateName": ["EClaw", "E-Claw by OpenClaw"],
         "url": "https://eclawbot.com",
         "logo": "https://eclawbot.com/assets/og-image.png",
-        "description": "EClawbot is an IoT claw machine management platform with an AI agent ecosystem, powered by OpenClaw.",
+        "description": "EClawbot is an Agent-to-Agent (A2A) communication platform with an AI agent ecosystem, powered by OpenClaw.",
         "sameAs": [
             "https://github.com/HankHuang0516/realbot"
         ]
@@ -173,7 +173,7 @@
         "url": "https://eclawbot.com",
         "applicationCategory": "BusinessApplication",
         "operatingSystem": "Web, Android, iOS",
-        "description": "IoT claw machine management platform with AI-powered agent ecosystem. Connect physical claw machines to AI entities for remote management, automation, and A2A protocol communication.",
+        "description": "Agent-to-Agent (A2A) communication platform with AI-powered agent ecosystem. Connect AI agents for inter-agent collaboration, task dispatch, automation, and A2A protocol communication.",
         "image": "https://eclawbot.com/assets/og-image.png",
         "offers": {
             "@type": "Offer",

--- a/openclaw-channel-eclaw/README.md
+++ b/openclaw-channel-eclaw/README.md
@@ -1,6 +1,6 @@
 # @eclaw/openclaw-channel
 
-OpenClaw channel plugin for [E-Claw](https://eclawbot.com) — an AI chat platform for live wallpaper entities on Android.
+OpenClaw channel plugin for [EClawbot](https://eclawbot.com) — an Agent-to-Agent (A2A) communication platform for AI agents.
 
 This plugin enables OpenClaw bots to communicate with E-Claw users as a native channel, alongside Telegram, Discord, and Slack.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "realbot",
   "version": "1.0.0",
-  "description": "Realbot - Claw Live Wallpaper Backend",
+  "description": "EClawbot - Agent-to-Agent (A2A) Communication Platform",
   "main": "backend/server.js",
   "scripts": {
     "start": "cd backend && node server.js",


### PR DESCRIPTION
## Summary

- Remove all misleading descriptions that positioned EClawbot as a "claw machine management platform"
- Rebrand to correctly reflect EClawbot's true nature: **Agent-to-Agent (A2A) communication platform**
- Updated 10 files across SEO content, READMEs, package metadata, and documentation

## Files changed

| File | Changes |
|------|---------|
| `landing.html` | Meta tags, JSON-LD, hero section, FAQ (12 instances) |
| `llms.txt` | Full rewrite with A2A positioning |
| `portal/index.html` | Meta tags, JSON-LD (8 instances) |
| `portal/dashboard.html` | Meta description |
| `README.md` | Subtitle, description |
| `package.json` (root + backend) | Description fields |
| `openapi.yaml` | API description |
| `openclaw-channel-eclaw/README.md` | Plugin description |
| `CLAUDE.md` | Project overview |

## Test plan

- [x] ESLint: 0 errors
- [x] Jest: 581/581 passed
- [ ] Verify landing page renders correctly after deploy
- [ ] Verify Google Search Console picks up new meta descriptions

https://claude.ai/code/session_01TUXPXNgR71Whfjc1LZ2sfp