### PR TITLE
fix(channel): add channel push to cross-speak + pending-flush

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -679,6 +679,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | OAuth Server | `tests/jest/oauth-server.test.js` | OAuth client registration, token endpoint, revoke (RFC 7009), introspect (RFC 7662) |
 | Device Vars | `tests/jest/device-vars.test.js` | Environment variables POST/GET/DELETE — auth, encryption, bot access |
 | Cross-Speak | `tests/jest/cross-speak.test.js` | Cross-device entity messaging, client cross-speak, pending queue — auth, validation |
+| Cross-Speak Channel | `tests/jest/cross-speak-channel.test.js` | Cross-speak channel push parity — entity/client cross-speak channel-bound delivery |
 | Link Preview | `tests/jest/link-preview.test.js` | Link preview OG tag extraction, URL validation, SSRF protection, timeout handling |
 
 ### Running All Tests

--- a/backend/index.js
+++ b/backend/index.js
@@ -764,7 +764,24 @@ authModule.setOnEmailVerified(async (deviceId) => {
             toEntity.message = `xdevice:owner: ${msg.text}`;
             toEntity.lastUpdated = Date.now();
 
-            if (toEntity.webhook) {
+            if (toEntity.bindingType === 'channel') {
+                // Channel plugin: send structured JSON
+                channelModule.pushToChannelCallback(target.deviceId, target.entityId, {
+                    event: 'cross_device_message',
+                    from: `New User (${deviceId})`,
+                    text: msg.text,
+                    mediaType: msg.media_type || null,
+                    mediaUrl: msg.media_url || null,
+                    fromEntityId: -1,
+                    fromPublicCode: null,
+                    isOwnerMode: true,
+                    eclaw_context: {
+                        missionHints: getMissionApiHints('https://eclawbot.com', target.deviceId, target.entityId, toEntity.botSecret),
+                        silentToken: '[SILENT]',
+                        identitySetupRequired: !toEntity.identity
+                    }
+                }, toEntity.channelAccountId).catch(() => {});
+            } else if (toEntity.webhook) {
                 const apiBase = 'https://eclawbot.com';
                 let pushMsg = `[ACTION REQUIRED] You MUST use exec tool with curl to call the API. Your text reply is DISCARDED.\n`;
                 pushMsg += `To update your wallpaper status:\n`;
@@ -5262,9 +5279,46 @@ app.post('/api/entity/cross-speak', async (req, res) => {
 
     console.log(`[CrossSpeak] ${deviceId}:${fromId} (${fromEntity.publicCode}) -> ${target.deviceId}:${target.entityId} (${targetCode}): "${crossText}"`);
 
-    // Push to target bot webhook
+    // Push to target bot — channel callback or traditional webhook
+    const isChannelBound = toEntity.bindingType === 'channel';
     const hasWebhook = !!toEntity.webhook;
-    if (hasWebhook) {
+    if (isChannelBound) {
+        // Channel plugin: send structured JSON
+        channelModule.pushToChannelCallback(target.deviceId, target.entityId, {
+            event: 'cross_device_message',
+            from: `${fromEntity.name || 'Entity'} (${fromEntity.publicCode})`,
+            text: crossText,
+            mediaType: mediaType || null,
+            mediaUrl: mediaUrl || null,
+            backupUrl: mediaType === 'photo' ? getBackupUrl(mediaUrl) : null,
+            fromEntityId: fromId,
+            fromPublicCode: fromEntity.publicCode,
+            fromCharacter: fromEntity.character,
+            eclaw_context: {
+                csRemaining: getCrossSpeakRemaining(target.deviceId, target.entityId),
+                csMax: CROSS_SPEAK_MAX_MESSAGES,
+                missionHints: getMissionApiHints('https://eclawbot.com', target.deviceId, target.entityId, toEntity.botSecret),
+                silentToken: '[SILENT]',
+                identitySetupRequired: !toEntity.identity,
+                preInject: xdSettings.pre_inject || null
+            }
+        }, toEntity.channelAccountId).then(pushResult => {
+            if (pushResult.pushed) {
+                messageObj.delivered = true;
+                markChatMessageDelivered(chatMsgId, String(target.entityId));
+                serverLog('info', 'cross_speak_push', `${fromEntity.publicCode} -> ${targetCode} channel push OK`, { deviceId, entityId: fromId, metadata: { targetCode, targetDeviceId: target.deviceId, mode: 'channel' } });
+                autoCollectCard(deviceId, targetCode, toEntity, 'auto_speak');
+                autoCollectCard(target.deviceId, fromEntity.publicCode, fromEntity, 'auto_speak');
+                db.upsertRecentInteraction(target.deviceId, fromEntity.publicCode, { name: fromEntity.name, character: fromEntity.character, avatar: fromEntity.avatar, cardSnapshot: fromEntity.agentCard }).catch(() => {});
+                db.upsertRecentInteraction(deviceId, targetCode, { name: toEntity.name, character: toEntity.character, avatar: toEntity.avatar, cardSnapshot: toEntity.agentCard }).catch(() => {});
+            } else {
+                serverLog('warn', 'cross_speak_push', `${fromEntity.publicCode} -> ${targetCode} channel not-pushed: ${pushResult.reason || 'unknown'}`, { deviceId, entityId: fromId });
+            }
+        }).catch(err => {
+            console.error(`[CrossSpeak] Channel push failed: ${err.message}`);
+            serverLog('error', 'cross_speak_push', `${fromEntity.publicCode} -> ${targetCode} channel FAILED: ${err.message}`, { deviceId, entityId: fromId });
+        });
+    } else if (hasWebhook) {
         const apiBase = 'https://eclawbot.com';
         const csRemaining = getCrossSpeakRemaining(target.deviceId, target.entityId);
         let pushMsg = `[ACTION REQUIRED] You MUST use exec tool with curl to call the API. Your text reply is DISCARDED.\n`;
@@ -5298,12 +5352,10 @@ app.post('/api/entity/cross-speak', async (req, res) => {
                 messageObj.delivered = true;
                 markChatMessageDelivered(chatMsgId, String(target.entityId));
                 serverLog('info', 'cross_speak_push', `${fromEntity.publicCode} -> ${targetCode} push OK`, { deviceId, entityId: fromId, metadata: { targetCode, targetDeviceId: target.deviceId } });
-                    // Auto-collect: sender collects target's card, target collects sender's card
-                    autoCollectCard(deviceId, targetCode, toEntity, 'auto_speak');
-                    autoCollectCard(target.deviceId, fromEntity.publicCode, fromEntity, 'auto_speak');
-                    // Record recent interaction on both sides
-                    db.upsertRecentInteraction(target.deviceId, fromEntity.publicCode, { name: fromEntity.name, character: fromEntity.character, avatar: fromEntity.avatar, cardSnapshot: fromEntity.agentCard }).catch(() => {});
-                    db.upsertRecentInteraction(deviceId, targetCode, { name: toEntity.name, character: toEntity.character, avatar: toEntity.avatar, cardSnapshot: toEntity.agentCard }).catch(() => {});
+                autoCollectCard(deviceId, targetCode, toEntity, 'auto_speak');
+                autoCollectCard(target.deviceId, fromEntity.publicCode, fromEntity, 'auto_speak');
+                db.upsertRecentInteraction(target.deviceId, fromEntity.publicCode, { name: fromEntity.name, character: fromEntity.character, avatar: fromEntity.avatar, cardSnapshot: fromEntity.agentCard }).catch(() => {});
+                db.upsertRecentInteraction(deviceId, targetCode, { name: toEntity.name, character: toEntity.character, avatar: toEntity.avatar, cardSnapshot: toEntity.agentCard }).catch(() => {});
             } else {
                 serverLog('warn', 'cross_speak_push', `${fromEntity.publicCode} -> ${targetCode} not-pushed: ${pushResult.reason || 'unknown'}`, { deviceId, entityId: fromId });
             }
@@ -5318,8 +5370,8 @@ app.post('/api/entity/cross-speak', async (req, res) => {
         message: `Cross-device message sent`,
         from: { publicCode: fromEntity.publicCode, character: fromEntity.character, entityId: fromId },
         to: { publicCode: targetCode, character: toEntity.character },
-        pushed: hasWebhook ? "pending" : false,
-        mode: hasWebhook ? "push" : "polling"
+        pushed: isChannelBound || hasWebhook ? "pending" : false,
+        mode: isChannelBound ? "channel" : (hasWebhook ? "push" : "polling")
     });
 });
 
@@ -6150,10 +6202,47 @@ app.post('/api/client/cross-speak', async (req, res) => {
     console.log(`[ClientCrossSpeak] ${deviceId}:${fromId} (${senderLabel}) -> ${target.deviceId}:${target.entityId} (${targetCode}): "${text}"`);
     serverLog('info', 'cross_speak', `[DEBUG] ClientCrossSpeak ${senderLabel} -> ${targetCode}: queued=${!!messageObj}, chatMsgId=${chatMsgId}`, { deviceId, entityId: fromId, metadata: { targetCode, targetDeviceId: target.deviceId, isOwnerMode, hasWebhook: !!toEntity.webhook } });
 
-    // Push to target bot
+    // Push to target bot — channel callback or traditional webhook
+    const isChannelBound = toEntity.bindingType === 'channel';
     const hasWebhook = !!toEntity.webhook;
-    console.log(`[ClientCrossSpeak:DEBUG] hasWebhook=${hasWebhook}, webhookUrl=${toEntity.webhook ? toEntity.webhook.slice(0, 40) + '...' : 'null'}`);
-    if (hasWebhook) {
+    console.log(`[ClientCrossSpeak:DEBUG] isChannelBound=${isChannelBound}, hasWebhook=${hasWebhook}, webhookUrl=${toEntity.webhook ? toEntity.webhook.slice(0, 40) + '...' : 'null'}`);
+    if (isChannelBound) {
+        // Channel plugin: send structured JSON
+        channelModule.pushToChannelCallback(target.deviceId, target.entityId, {
+            event: 'cross_device_message',
+            from: isOwnerMode ? `Device Owner (${senderName})` : `${fromEntity.name || 'User'} (${fromEntity.publicCode})`,
+            text,
+            mediaType: mediaType || null,
+            mediaUrl: mediaUrl || null,
+            backupUrl: mediaType === 'photo' ? getBackupUrl(mediaUrl) : null,
+            fromEntityId: isOwnerMode ? -1 : fromId,
+            fromPublicCode: isOwnerMode ? null : fromEntity.publicCode,
+            isOwnerMode,
+            eclaw_context: {
+                missionHints: getMissionApiHints('https://eclawbot.com', target.deviceId, target.entityId, toEntity.botSecret),
+                silentToken: '[SILENT]',
+                identitySetupRequired: !toEntity.identity,
+                preInject: xdSettingsClient.pre_inject || null
+            }
+        }, toEntity.channelAccountId).then(pushResult => {
+            if (pushResult.pushed) {
+                messageObj.delivered = true;
+                markChatMessageDelivered(chatMsgId, String(target.entityId));
+                serverLog('info', 'cross_speak_push', `Client ${senderLabel} -> ${targetCode} channel push OK`, { deviceId, entityId: fromId, metadata: { mode: 'channel' } });
+                if (!isOwnerMode) {
+                    autoCollectCard(deviceId, targetCode, toEntity, 'auto_speak');
+                    autoCollectCard(target.deviceId, fromEntity.publicCode, fromEntity, 'auto_speak');
+                    db.upsertRecentInteraction(target.deviceId, fromEntity.publicCode, { name: fromEntity.name, character: fromEntity.character, avatar: fromEntity.avatar, cardSnapshot: fromEntity.agentCard }).catch(() => {});
+                    db.upsertRecentInteraction(deviceId, targetCode, { name: toEntity.name, character: toEntity.character, avatar: toEntity.avatar, cardSnapshot: toEntity.agentCard }).catch(() => {});
+                }
+            } else {
+                serverLog('warn', 'cross_speak_push', `Client ${senderLabel} -> ${targetCode} channel not-pushed: ${pushResult.reason || 'unknown'}`, { deviceId, entityId: fromId });
+            }
+        }).catch(err => {
+            console.error(`[ClientCrossSpeak] Channel push failed: ${err.message}`);
+            serverLog('error', 'cross_speak_push', `ClientCrossSpeak ${senderLabel} -> ${targetCode} channel FAILED: ${err.message}`, { deviceId, entityId: fromId });
+        });
+    } else if (hasWebhook) {
         const apiBase = 'https://eclawbot.com';
         let pushMsg = `[ACTION REQUIRED] You MUST use exec tool with curl to call the API. Your text reply is DISCARDED.\n`;
         pushMsg += `To update your wallpaper status:\n`;
@@ -6186,17 +6275,15 @@ app.post('/api/client/cross-speak', async (req, res) => {
                 markChatMessageDelivered(chatMsgId, String(target.entityId));
                 serverLog('info', 'cross_speak_push', `Client ${senderLabel} -> ${targetCode} push OK`, { deviceId, entityId: fromId });
                 if (!isOwnerMode) {
-                    // Auto-collect: sender collects target's card, target collects sender's card
                     autoCollectCard(deviceId, targetCode, toEntity, 'auto_speak');
                     autoCollectCard(target.deviceId, fromEntity.publicCode, fromEntity, 'auto_speak');
-                    // Record recent interaction on both sides
                     db.upsertRecentInteraction(target.deviceId, fromEntity.publicCode, { name: fromEntity.name, character: fromEntity.character, avatar: fromEntity.avatar, cardSnapshot: fromEntity.agentCard }).catch(() => {});
                     db.upsertRecentInteraction(deviceId, targetCode, { name: toEntity.name, character: toEntity.character, avatar: toEntity.avatar, cardSnapshot: toEntity.agentCard }).catch(() => {});
                 }
             }
         }).catch(err => {
             console.error(`[ClientCrossSpeak] Push failed: ${err.message}`);
-            serverLog('error', 'push_error', `ClientCrossSpeak ${senderLabel} -> ${targetCode} FAILED: ${err.message}`, { deviceId, entityId: fromId });
+            serverLog('error', 'cross_speak_push', `ClientCrossSpeak ${senderLabel} -> ${targetCode} FAILED: ${err.message}`, { deviceId, entityId: fromId });
         });
     } else {
         console.log(`[ClientCrossSpeak:DEBUG] No webhook on target entity ${targetCode} — message queued but NOT pushed`);
@@ -6208,8 +6295,8 @@ app.post('/api/client/cross-speak', async (req, res) => {
         message: `Cross-device message sent`,
         from: isOwnerMode ? { owner: true } : { publicCode: fromEntity.publicCode, character: fromEntity.character },
         to: { publicCode: targetCode, character: toEntity.character },
-        pushed: hasWebhook ? "pending" : false,
-        _debug: { senderDeviceId: deviceId, targetDeviceId: target.deviceId, targetEntityId: target.entityId, isOwnerMode, hasWebhook, chatMsgId }
+        pushed: isChannelBound || hasWebhook ? "pending" : false,
+        _debug: { senderDeviceId: deviceId, targetDeviceId: target.deviceId, targetEntityId: target.entityId, isOwnerMode, isChannelBound, hasWebhook, chatMsgId }
     };
     console.log(`[ClientCrossSpeak:DEBUG] Response:`, JSON.stringify(responsePayload));
     res.json(responsePayload);
@@ -12207,3 +12294,4 @@ app.get('/api/bot/pending-messages', (req, res) => {
 module.exports = app;
 module.exports.httpServer = httpServer;
 module.exports.io = io;
+module.exports.devices = devices;

--- a/backend/tests/jest/cross-speak-channel.test.js
+++ b/backend/tests/jest/cross-speak-channel.test.js
@@ -1,0 +1,280 @@
+/**
+ * Cross-speak channel push parity regression tests (Jest + Supertest)
+ *
+ * Regression: entity/cross-speak, client/cross-speak, and PendingFlush callback
+ * previously only pushed via webhook (pushToBot), missing channel-bound entities
+ * (pushToChannelCallback). This test verifies the channel push path is now used
+ * when the target entity has bindingType === 'channel'.
+ *
+ * Tests:
+ *   POST /api/entity/cross-speak  → channel-bound target gets channel push
+ *   POST /api/client/cross-speak  → channel-bound target gets channel push
+ *   Response payload includes mode: "channel" for channel-bound targets
+ */
+
+require('./helpers/mock-setup');
+
+// Add cross-device-settings getSettings (not in shared mock-setup)
+const crossDeviceSettings = require('../../entity-cross-device-settings');
+crossDeviceSettings.getSettings = jest.fn().mockResolvedValue({
+    pre_inject: '',
+    forbidden_words: [],
+    rate_limit_seconds: 0,
+    blacklist: [],
+    whitelist_enabled: false,
+    whitelist: [],
+    reject_message: '',
+    allowed_media: ['text', 'photo', 'voice', 'video', 'file']
+});
+
+// Add channel-api db functions needed
+const db = require('../../db');
+db.getChannelAccountByKey = jest.fn().mockResolvedValue(null);
+db.getChannelAccountsByDevice = jest.fn().mockResolvedValue([]);
+db.createChannelAccount = jest.fn().mockResolvedValue({ id: 1, channel_api_key: 'eck_test', channel_api_secret: 'ecs_test' });
+db.getChannelAccountById = jest.fn().mockResolvedValue(null);
+db.deleteChannelAccount = jest.fn().mockResolvedValue(true);
+db.updateChannelCallback = jest.fn().mockResolvedValue(true);
+db.updateChannelE2eeCapable = jest.fn().mockResolvedValue(true);
+db.clearChannelCallback = jest.fn().mockResolvedValue(true);
+db.getChannelAccountByDevice = jest.fn().mockResolvedValue(null);
+
+const request = require('supertest');
+let app;
+
+const post = (path) => request(app).post(path).set('Host', 'localhost');
+
+/** Register a device and return its secret */
+async function registerDevice(id) {
+    const secret = `secret-${id}`;
+    await post('/api/device/register')
+        .send({ deviceId: id, deviceSecret: secret, entityId: 0 });
+    return secret;
+}
+
+/** Bind entity 0 and return botSecret */
+async function bindEntity(deviceId, deviceSecret) {
+    const regRes = await post('/api/device/register')
+        .send({ deviceId, deviceSecret, entityId: 0 });
+    const code = regRes.body.bindingCode;
+    if (!code) return undefined;
+    const bindRes = await post('/api/bind').send({ code });
+    return bindRes.body.botSecret;
+}
+
+/** Access in-memory devices map to set bindingType/channelAccountId on an entity */
+function getDevicesMap() {
+    const indexModule = require('../../index');
+    return indexModule.devices;
+}
+
+beforeAll(() => {
+    app = require('../../index');
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+    jest.resetModules();
+});
+
+// ════════════════════════════════════════════════════════════════
+// POST /api/entity/cross-speak — channel-bound target
+// ════════════════════════════════════════════════════════════════
+describe('POST /api/entity/cross-speak — channel push parity', () => {
+    let senderBotSecret;
+    let targetPublicCode;
+
+    beforeAll(async () => {
+        // Set up sender device + entity
+        const senderSecret = await registerDevice('chan-cs-sender');
+        senderBotSecret = await bindEntity('chan-cs-sender', senderSecret);
+
+        // Set up target device + entity
+        const targetSecret = await registerDevice('chan-cs-target');
+        await bindEntity('chan-cs-target', targetSecret);
+
+        // Get target entity's publicCode
+        const statusRes = await request(app)
+            .get('/api/entities?deviceId=chan-cs-target')
+            .set('Host', 'localhost');
+        const entities = statusRes.body.entities || statusRes.body;
+        const targetEntity = Array.isArray(entities)
+            ? entities.find(e => e.entityId === 0)
+            : entities[0] || entities['0'];
+        targetPublicCode = targetEntity?.publicCode;
+    });
+
+    afterEach(() => {
+        // Restore target entity state to prevent cross-test pollution
+        const devicesMap = getDevicesMap();
+        if (devicesMap && devicesMap['chan-cs-target']) {
+            const e = devicesMap['chan-cs-target'].entities[0];
+            e.bindingType = undefined;
+            e.channelAccountId = undefined;
+            e.webhook = null;
+        }
+    });
+
+    it('returns mode: "channel" when target is channel-bound', async () => {
+        const devicesMap = getDevicesMap();
+        if (!devicesMap || !devicesMap['chan-cs-target']) return;
+        const targetEntity = devicesMap['chan-cs-target'].entities[0];
+        targetEntity.bindingType = 'channel';
+        targetEntity.channelAccountId = 99;
+
+        const res = await post('/api/entity/cross-speak').send({
+            deviceId: 'chan-cs-sender',
+            fromEntityId: 0,
+            botSecret: senderBotSecret,
+            targetCode: targetPublicCode,
+            text: 'channel push test'
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.mode).toBe('channel');
+        expect(res.body.pushed).toBe('pending');
+    });
+
+    it('returns mode: "push" when target has webhook (not channel)', async () => {
+        const devicesMap = getDevicesMap();
+        if (!devicesMap || !devicesMap['chan-cs-target']) return;
+
+        devicesMap['chan-cs-target'].entities[0].webhook = { url: 'https://example.com/hook', type: 'openclaw' };
+
+        const res = await post('/api/entity/cross-speak').send({
+            deviceId: 'chan-cs-sender',
+            fromEntityId: 0,
+            botSecret: senderBotSecret,
+            targetCode: targetPublicCode,
+            text: 'webhook push test'
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.mode).toBe('push');
+        expect(res.body.pushed).toBe('pending');
+    });
+
+    it('returns mode: "polling" when target has no webhook and no channel', async () => {
+        const devicesMap = getDevicesMap();
+        if (!devicesMap || !devicesMap['chan-cs-target']) return;
+
+        const res = await post('/api/entity/cross-speak').send({
+            deviceId: 'chan-cs-sender',
+            fromEntityId: 0,
+            botSecret: senderBotSecret,
+            targetCode: targetPublicCode,
+            text: 'polling test'
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.mode).toBe('polling');
+        expect(res.body.pushed).toBe(false);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// POST /api/client/cross-speak — channel-bound target
+// ════════════════════════════════════════════════════════════════
+describe('POST /api/client/cross-speak — channel push parity', () => {
+    let senderBotSecret;
+    let targetPublicCode;
+
+    beforeAll(async () => {
+        // Set up sender device + entity
+        const senderSecret = await registerDevice('chan-cc-sender');
+        senderBotSecret = await bindEntity('chan-cc-sender', senderSecret);
+
+        // Set up target device + entity
+        const targetSecret = await registerDevice('chan-cc-target');
+        await bindEntity('chan-cc-target', targetSecret);
+
+        // Get target entity's publicCode
+        const statusRes = await request(app)
+            .get('/api/entities?deviceId=chan-cc-target')
+            .set('Host', 'localhost');
+        const entities = statusRes.body.entities || statusRes.body;
+        const targetEntity = Array.isArray(entities)
+            ? entities.find(e => e.entityId === 0)
+            : entities[0] || entities['0'];
+        targetPublicCode = targetEntity?.publicCode;
+    });
+
+    afterEach(() => {
+        const devicesMap = getDevicesMap();
+        if (devicesMap && devicesMap['chan-cc-target']) {
+            const e = devicesMap['chan-cc-target'].entities[0];
+            e.bindingType = undefined;
+            e.channelAccountId = undefined;
+            e.webhook = null;
+        }
+    });
+
+    it('returns channel mode when target is channel-bound', async () => {
+        const devicesMap = getDevicesMap();
+        if (!devicesMap || !devicesMap['chan-cc-target']) return;
+
+        const targetEntity = devicesMap['chan-cc-target'].entities[0];
+        targetEntity.bindingType = 'channel';
+        targetEntity.channelAccountId = 99;
+
+        const res = await post('/api/client/cross-speak').send({
+            deviceId: 'chan-cc-sender',
+            deviceSecret: 'secret-chan-cc-sender',
+            fromEntityId: 0,
+            targetCode: targetPublicCode,
+            text: 'channel push from client'
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.pushed).toBe('pending');
+        expect(res.body._debug).toBeDefined();
+        expect(res.body._debug.isChannelBound).toBe(true);
+    });
+
+    it('returns channel mode for owner mode (fromEntityId=-1) to channel-bound target', async () => {
+        const devicesMap = getDevicesMap();
+        if (!devicesMap || !devicesMap['chan-cc-target']) return;
+
+        const targetEntity = devicesMap['chan-cc-target'].entities[0];
+        targetEntity.bindingType = 'channel';
+        targetEntity.channelAccountId = 99;
+
+        const res = await post('/api/client/cross-speak').send({
+            deviceId: 'chan-cc-sender',
+            deviceSecret: 'secret-chan-cc-sender',
+            fromEntityId: -1,
+            targetCode: targetPublicCode,
+            text: 'owner channel push'
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.pushed).toBe('pending');
+        expect(res.body._debug.isChannelBound).toBe(true);
+        expect(res.body._debug.isOwnerMode).toBe(true);
+    });
+
+    it('returns polling mode when target has no webhook and no channel', async () => {
+        const devicesMap = getDevicesMap();
+        if (!devicesMap || !devicesMap['chan-cc-target']) return;
+
+        const res = await post('/api/client/cross-speak').send({
+            deviceId: 'chan-cc-sender',
+            deviceSecret: 'secret-chan-cc-sender',
+            fromEntityId: 0,
+            targetCode: targetPublicCode,
+            text: 'polling fallback test'
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.pushed).toBe(false);
+        expect(res.body._debug.isChannelBound).toBeFalsy();
+        expect(res.body._debug.hasWebhook).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- Add `bindingType === 'channel'` push path to `/api/entity/cross-speak`, `/api/client/cross-speak`, and PendingFlush callback
- These 3 endpoints previously only checked `entity.webhook` (pushToBot), missing channel-bound entities entirely
- Fix inconsistent log category `'push_error'` → `'cross_speak_push'` in client/cross-speak
- Add Jest regression tests verifying channel/webhook/polling delivery modes

## Test plan
- [x] New Jest tests: `cross-speak-channel.test.js` (6 tests, all pass)
- [x] Existing `cross-speak.test.js` (24 tests, all pass)
- [x] ESLint: 0 errors

https://claude.ai/code/session_013okLMUMPAniYFQhhsV6MpP