### PR TITLE
fix: cross-device chat rendering bugs (5 issues)

### DIFF
--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -597,8 +597,15 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             entity.lastUpdated = Date.now();
 
             // Save to chat history
+            // Check for pending cross-device context first, so local copy also shows routing direction
+            const pendingCross = message ? (entity.messageQueue && entity.messageQueue.findLast(m => m.crossDevice)) : null;
+            const hasCrossRoute = !!(pendingCross && pendingCross.fromDeviceId);
             if (message) {
-                saveChatMessage(deviceId, eId, message, 'bot', false, true, mediaType || null, mediaUrl || null);
+                // If replying to a cross-device message, tag local copy with routing info
+                const localSource = hasCrossRoute
+                    ? `xdevice:${entity.publicCode}:${entity.character}->${pendingCross.fromPublicCode || pendingCross.fromDeviceId}`
+                    : 'bot';
+                saveChatMessage(deviceId, eId, message, localSource, false, true, mediaType || null, mediaUrl || null);
 
                 // XP: Award for channel bot reply (same logic as /api/transform)
                 if (awardEntityXP && XP_AMOUNTS) {
@@ -612,27 +619,24 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             }
 
             // [CROSS-DEVICE AUTO-ROUTE] — if pending message was cross-device, save reply to sender device
-            if (message) {
-                const pendingCross = entity.messageQueue && entity.messageQueue.findLast(m => m.crossDevice);
-                if (pendingCross && pendingCross.fromDeviceId) {
-                    const replySource = `xdevice:${entity.publicCode}:${entity.character}->${pendingCross.fromPublicCode || pendingCross.fromDeviceId}`;
-                    const senderEntityId = pendingCross.fromEntityId >= 0 ? pendingCross.fromEntityId : 0;
-                    saveChatMessage(pendingCross.fromDeviceId, senderEntityId, message, replySource, false, true);
-                    serverLog('info', 'cross_speak_push', `[CROSS_ROUTE] Channel auto-routed reply to sender ${pendingCross.fromDeviceId}:${senderEntityId}`, {
-                        deviceId, entityId: eId,
-                        metadata: { senderDeviceId: pendingCross.fromDeviceId, senderEntityId, fromPublicCode: pendingCross.fromPublicCode }
-                    });
+            if (hasCrossRoute) {
+                const replySource = `xdevice:${entity.publicCode}:${entity.character}->${pendingCross.fromPublicCode || pendingCross.fromDeviceId}`;
+                const senderEntityId = pendingCross.fromEntityId >= 0 ? pendingCross.fromEntityId : 0;
+                saveChatMessage(pendingCross.fromDeviceId, senderEntityId, message, replySource, false, true);
+                serverLog('info', 'cross_speak_push', `[CROSS_ROUTE] Channel auto-routed reply to sender ${pendingCross.fromDeviceId}:${senderEntityId}`, {
+                    deviceId, entityId: eId,
+                    metadata: { senderDeviceId: pendingCross.fromDeviceId, senderEntityId, fromPublicCode: pendingCross.fromPublicCode }
+                });
 
-                    // Notify sender device about the reply
-                    if (notifyDevice) {
-                        notifyDevice(pendingCross.fromDeviceId, {
-                            type: 'chat', category: 'cross_speak',
-                            title: `${entity.name || entity.publicCode || `Entity ${eId}`} replied`,
-                            body: (message || '').slice(0, 100),
-                            link: 'chat.html',
-                            metadata: { fromPublicCode: entity.publicCode, entityId: senderEntityId }
-                        }).catch(() => {});
-                    }
+                // Notify sender device about the reply
+                if (notifyDevice) {
+                    notifyDevice(pendingCross.fromDeviceId, {
+                        type: 'chat', category: 'cross_speak',
+                        title: `${entity.name || entity.publicCode || `Entity ${eId}`} replied`,
+                        body: (message || '').slice(0, 100),
+                        link: 'chat.html',
+                        metadata: { fromPublicCode: entity.publicCode, entityId: senderEntityId }
+                    }).catch(() => {});
                 }
             }
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -6197,10 +6197,13 @@ app.post('/api/client/cross-speak', async (req, res) => {
     };
     toEntity.messageQueue.push(messageObj);
 
-    // Save chat message
-    const chatMsgId = await saveChatMessage(target.deviceId, target.entityId, text, `${sourceLabel}->${targetCode}`, true, false, mediaType || null, mediaUrl || null);
-    if (!isOwnerMode) {
-        await saveChatMessage(deviceId, fromId, text, `${sourceLabel}->${targetCode}`, true, false, mediaType || null, mediaUrl || null);
+    // Save chat message — always save to both sender and target devices
+    const sourceTag = `${sourceLabel}->${targetCode}`;
+    const chatMsgId = await saveChatMessage(target.deviceId, target.entityId, text, sourceTag, true, false, mediaType || null, mediaUrl || null);
+    // Also save sender's copy: in owner mode use entity 0; in entity mode use fromId
+    const senderEntityId = isOwnerMode ? 0 : fromId;
+    if (deviceId !== target.deviceId || senderEntityId !== target.entityId) {
+        await saveChatMessage(deviceId, senderEntityId, text, sourceTag, true, false, mediaType || null, mediaUrl || null);
     }
 
     toEntity.message = isOwnerMode ? `xdevice:owner: ${text}` : `xdevice:${fromEntity.publicCode}:${fromEntity.character}: ${text}`;
@@ -6237,6 +6240,7 @@ app.post('/api/client/cross-speak', async (req, res) => {
             backupUrl: mediaType === 'photo' ? getBackupUrl(mediaUrl) : null,
             fromEntityId: isOwnerMode ? -1 : fromId,
             fromPublicCode: isOwnerMode ? null : fromEntity.publicCode,
+            fromDeviceId: deviceId,
             isOwnerMode,
             eclaw_context: {
                 missionHints: getMissionApiHints('https://eclawbot.com', target.deviceId, target.entityId, toEntity.botSecret),
@@ -6271,8 +6275,8 @@ app.post('/api/client/cross-speak', async (req, res) => {
             pushMsg += `[DEVICE OWNER INSTRUCTION]\n${xdSettingsClient.pre_inject}\n\n`;
         }
         pushMsg += isOwnerMode
-            ? `[MESSAGE from Device Owner] ${senderName}\nContent: ${text}`
-            : `[CROSS-DEVICE MESSAGE from Human User] From: ${fromEntity.name || 'User'} (code: ${fromEntity.publicCode})\nContent: ${text}`;
+            ? `[MESSAGE from Device Owner] ${senderName} (device: ${deviceId})\nContent: ${text}`
+            : `[CROSS-DEVICE MESSAGE from Human User] From: ${fromEntity.name || 'User'} (code: ${fromEntity.publicCode}, device: ${deviceId})\nContent: ${text}`;
         if (mediaType === 'photo') {
             pushMsg += `\n[Attachment: Photo]\nmedia_type: photo\nmedia_url: ${mediaUrl}`;
             const bkUrl = getBackupUrl(mediaUrl);

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -1354,6 +1354,10 @@
                         myPublicCodeMap[e.publicCode] = { entityId: e.entityId, label: getEntityLabel(e.entityId) };
                     }
                 });
+                // Also register device ID so owner-mode cross-device messages are recognized as "self"
+                if (currentUser.deviceId) {
+                    myPublicCodeMap[currentUser.deviceId] = { entityId: -1, label: 'You' };
+                }
                 renderTargetBar();
                 loadContacts();
             } catch (e) {
@@ -1722,7 +1726,8 @@
             xdeviceCodesWithMessages.forEach(code => {
                 const existing = group.querySelector(`[data-filter="xdevice-${code}"]`);
                 if (existing) return;
-                const label = xdeviceLabelCache[code] || `\u{1F310} ${code}`;
+                const shortCode = code.length > 12 ? code.slice(0, 8) : code;
+                const label = xdeviceLabelCache[code] || `\u{1F310} ${shortCode}`;
                 const chip = document.createElement('span');
                 chip.className = `filter-chip filter-chip-entity filter-chip-contact${currentFilter === 'xdevice-' + code ? ' active' : ''}`;
                 chip.dataset.filter = `xdevice-${code}`;
@@ -1824,7 +1829,9 @@
         function getXDeviceLabel(code) {
             if (myPublicCodeMap[code]) return myPublicCodeMap[code].label;
             if (xdeviceLabelCache[code]) return xdeviceLabelCache[code];
-            return `&#x1F310; ${escapeHtml(code)}`;
+            // Shorten UUID-style device IDs to first 8 chars for readability
+            const display = code && code.length > 12 ? code.slice(0, 8) : code;
+            return `&#x1F310; ${escapeHtml(display)}`;
         }
 
         async function resolveXDeviceCodes(messages) {
@@ -1838,7 +1845,9 @@
                     if (!myPublicCodeMap[t] && !xdeviceLabelCache[t]) unknownCodes.add(t);
                 }
             }
-            const lookups = Array.from(unknownCodes).map(async code => {
+            const lookups = Array.from(unknownCodes)
+                .filter(code => !code.includes('-')) // Skip UUID-style device IDs (owner mode); they aren't public codes
+                .map(async code => {
                 try {
                     const data = await apiCall('GET', `/api/entity/lookup?code=${encodeURIComponent(code)}`);
                     if (data.success && data.entity) {
@@ -2011,8 +2020,8 @@
             if (!source) return null;
             if (_sourceParseCache.has(source)) return _sourceParseCache.get(source);
             let result = null;
-            // Cross-device: xdevice:code:CHARACTER->targetCode
-            const xmatch = source.match(/^xdevice:([a-z0-9]+):([^:]+)->(.+)$/);
+            // Cross-device: xdevice:code:CHARACTER->targetCode  (code may be UUID with hyphens)
+            const xmatch = source.match(/^xdevice:([a-z0-9-]+):([^:]+)->(.+)$/);
             if (xmatch) {
                 result = {
                     fromPublicCode: xmatch[1],


### PR DESCRIPTION
## Summary
- **Bug1**: Save sender copy of cross-device message in owner mode (message now visible to sender)
- **Bug2/4/5**: Fix regex `[a-z0-9]+` → `[a-z0-9-]+` to match UUID device IDs; register device ID in `myPublicCodeMap`; shorten UUID display
- **Bug3**: Include sender device ID in channel/webhook push payload
- **Bug5**: Tag local bot reply with cross-device source when auto-routing reply

## Test plan
- [x] All 782 Jest tests pass (46 suites)
- [x] ESLint: 0 errors
- [ ] Manual: User A sends cross-device msg in owner mode → message appears on User A's chat
- [ ] Manual: User B sees incoming msg on left side with cross-device label
- [ ] Manual: Bot reply shows direction label on both User A and User B screens

https://claude.ai/code/session_013okLMUMPAniYFQhhsV6MpP