### PR TITLE
fix: add missing fields to pending flush channel push payload

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -771,19 +771,23 @@ authModule.setOnEmailVerified(async (deviceId) => {
 
             if (toEntity.bindingType === 'channel') {
                 // Channel plugin: send structured JSON
+                const flushXdSettings = await crossDeviceSettings.getSettings(target.deviceId, target.entityId);
                 channelModule.pushToChannelCallback(target.deviceId, target.entityId, {
                     event: 'cross_device_message',
                     from: `New User (${deviceId})`,
                     text: msg.text,
                     mediaType: msg.media_type || null,
                     mediaUrl: msg.media_url || null,
+                    backupUrl: msg.media_type === 'photo' ? getBackupUrl(msg.media_url) : null,
                     fromEntityId: -1,
                     fromPublicCode: null,
+                    fromDeviceId: deviceId,
                     isOwnerMode: true,
                     eclaw_context: {
                         missionHints: getMissionApiHints('https://eclawbot.com', target.deviceId, target.entityId, toEntity.botSecret),
                         silentToken: '[SILENT]',
-                        identitySetupRequired: !toEntity.identity
+                        identitySetupRequired: !toEntity.identity,
+                        preInject: flushXdSettings.pre_inject || null
                     }
                 }, toEntity.channelAccountId).catch(() => {});
             } else if (toEntity.webhook) {


### PR DESCRIPTION
## Summary
- Added `fromDeviceId`, `backupUrl`, and `preInject` to the pending cross-message flush channel push payload
- These fields were present in the normal `client/cross-speak` path but missing from the pending flush path, causing bots to not identify source device or see owner pre-inject instructions

## Test plan
- [x] All 782 Jest tests pass (`npm test`)
- [x] Cross-speak channel tests pass

https://claude.ai/code/session_011SRvxW4cPUTsktNna8WjjR