### PR TITLE
fix: render contact checkboxes for zero-entity users in chat target bar

### DIFF
--- a/app/src/main/java/com/hank/clawlive/ChatActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/ChatActivity.kt
@@ -344,7 +344,8 @@ class ChatActivity : AppCompatActivity() {
                 }
                 boundEntityPublicCodes = publicCodeMap
 
-                if (boundIds.size <= 1 && contacts.isEmpty()) {
+                // When 0 entities, keep visible so contacts can appear after loadContacts()
+                if (boundIds.size == 1 && contacts.isEmpty()) {
                     chipGroupTargets.visibility = View.GONE
                 }
             } catch (e: Exception) {

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -1397,11 +1397,6 @@
             // Remove old dynamic elements
             bar.querySelectorAll('.target-entity-check, .target-loading-hint, .target-separator, .target-contact-check, .btn-add-contact, .contact-add-inline').forEach(el => el.remove());
 
-            if (boundEntities.length === 0) {
-                allLabel.style.display = 'none';
-                return;
-            }
-
             // Show "All" only if more than 1 entity
             allLabel.style.display = boundEntities.length > 1 ? '' : 'none';
 
@@ -1423,9 +1418,11 @@
 
             // ── Contacts section ──
             if (contacts.length > 0 || contactsLoaded) {
-                const sep = document.createElement('span');
-                sep.className = 'target-separator';
-                bar.appendChild(sep);
+                if (boundEntities.length > 0) {
+                    const sep = document.createElement('span');
+                    sep.className = 'target-separator';
+                    bar.appendChild(sep);
+                }
 
                 const savedContacts = localStorage.getItem('chat_last_contact_targets');
                 const savedContactSet = savedContacts ? new Set(savedContacts.split(',')) : new Set();

--- a/backend/tests/jest/cross-speak.test.js
+++ b/backend/tests/jest/cross-speak.test.js
@@ -251,3 +251,31 @@ describe('POST /api/chat/pending-cross-speak', () => {
         expect(res.body.success).toBe(false);
     });
 });
+
+// ════════════════════════════════════════════════════════════════
+// Regression: renderTargetBar must render contacts when entities=0
+// ════════════════════════════════════════════════════════════════
+describe('chat.html renderTargetBar regression', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const chatHtml = fs.readFileSync(
+        path.resolve(__dirname, '../../public/portal/chat.html'), 'utf8'
+    );
+
+    // Extract renderTargetBar body once for all tests
+    const fnMatch = chatHtml.match(/function renderTargetBar\(\)\s*\{([\s\S]*?)(?=\n {8}function\b)/);
+    const fnBody = fnMatch ? fnMatch[1] : '';
+
+    it('renderTargetBar does not early-return when boundEntities is empty', () => {
+        expect(fnMatch).toBeTruthy();
+        // Must NOT have early return when boundEntities.length === 0
+        const earlyReturnPattern = /if\s*\(\s*boundEntities\.length\s*===?\s*0\s*\)\s*\{[^}]*return;?\s*\}/;
+        expect(fnBody).not.toMatch(earlyReturnPattern);
+    });
+
+    it('contacts section is rendered regardless of boundEntities count', () => {
+        expect(fnMatch).toBeTruthy();
+        expect(fnBody).toMatch(/target-contact-check/);
+        expect(fnBody).toMatch(/Contacts section/);
+    });
+});


### PR DESCRIPTION
## Summary
- Fix renderTargetBar() early return that skipped contact checkbox rendering when boundEntities.length === 0
- Android: keep chipGroupTargets visible with 0 entities so contacts appear after loadContacts()
- Add regression test verifying no early return in renderTargetBar

## Test plan
- [x] Jest tests pass (801/801)
- [ ] Verify zero-entity user can send multiple cross-device messages
- [ ] Verify contact checkboxes render on chat page for zero-entity users

https://claude.ai/code/session_01XknwDMASrSgKJiLYC1H4bk