### PR TITLE
fix: save pending messages to DB and poll for email verification on share-chat

### DIFF
--- a/backend/auth.js
+++ b/backend/auth.js
@@ -442,7 +442,8 @@ module.exports = function(devices, getOrCreateDevice, serverLog) {
     // ============================================
     router.get('/verify-email', async (req, res) => {
         try {
-            const { token } = req.query;
+            const { token, returnTo } = req.query;
+            console.log('[Auth] verify-email called', { hasToken: !!token, returnTo: returnTo || null });
             if (!token) {
                 return res.status(400).send('Missing verification token');
             }
@@ -453,12 +454,15 @@ module.exports = function(devices, getOrCreateDevice, serverLog) {
             );
 
             if (result.rows.length === 0) {
+                console.log('[Auth] verify-email: invalid token (no matching user)');
                 return res.status(400).send('Invalid verification token');
             }
 
             const user = result.rows[0];
+            console.log('[Auth] verify-email: found user', { userId: user.id, email: user.email, deviceId: user.device_id });
 
             if (user.verify_token_expires && user.verify_token_expires < Date.now()) {
+                console.log('[Auth] verify-email: token expired', { expires: user.verify_token_expires, now: Date.now() });
                 return res.status(400).send('Verification token expired. Please register again.');
             }
 
@@ -466,18 +470,28 @@ module.exports = function(devices, getOrCreateDevice, serverLog) {
                 'UPDATE user_accounts SET email_verified = TRUE, verify_token = NULL, verify_token_expires = NULL WHERE id = $1',
                 [user.id]
             );
+            console.log('[Auth] verify-email: email_verified set to TRUE for user', user.id);
 
             // Flush pending cross-device messages (queued before verification)
             if (_onEmailVerified && user.device_id) {
                 try {
+                    console.log('[Auth] verify-email: calling _onEmailVerified for device', user.device_id);
                     await _onEmailVerified(user.device_id);
+                    console.log('[Auth] verify-email: _onEmailVerified completed');
                 } catch (flushErr) {
                     console.error('[Auth] Pending message flush error:', flushErr.message);
                 }
+            } else {
+                console.log('[Auth] verify-email: no _onEmailVerified callback or no device_id', { hasCallback: !!_onEmailVerified, deviceId: user.device_id });
             }
 
-            // Redirect to portal login page
-            res.redirect(`${BASE_URL}/portal/index.html?verified=true`);
+            // Redirect back to share-chat page if returnTo is provided, otherwise portal login
+            if (returnTo && returnTo.startsWith('/c/')) {
+                console.log('[Auth] verify-email: redirecting to share-chat returnTo', returnTo);
+                res.redirect(`${BASE_URL}${returnTo}?verified=true`);
+            } else {
+                res.redirect(`${BASE_URL}/portal/index.html?verified=true`);
+            }
         } catch (error) {
             console.error('[Auth] Verify email error:', error);
             res.status(500).send('Verification failed');

--- a/backend/index.js
+++ b/backend/index.js
@@ -752,7 +752,9 @@ authModule.initAuthDatabase();
 
 // Wire up pending message flush on email verification
 authModule.setOnEmailVerified(async (deviceId) => {
+    console.log(`[PendingFlush] onEmailVerified triggered for device ${deviceId}`);
     const pending = await db.getPendingCrossMessages(deviceId);
+    console.log(`[PendingFlush] Found ${pending.length} pending cross-speak messages for device ${deviceId}`);
     if (pending.length === 0) return;
     console.log(`[PendingFlush] Flushing ${pending.length} pending cross-speak messages for device ${deviceId}`);
 

--- a/backend/public/portal/share-chat.html
+++ b/backend/public/portal/share-chat.html
@@ -435,12 +435,18 @@
     }
 
     function onAuthReady() {
+        dbg('info', 'onAuthReady called', { emailVerified, hasUser: !!currentUser, deviceId: currentUser?.deviceId });
         // Show sender selector only for verified users
         if (emailVerified) {
+            dbg('info', 'Email verified — loading entities, chat history, starting poll');
             loadEntities();
             document.getElementById('senderBar').style.display = 'flex';
             // Load existing conversation and start polling for replies
             loadChatHistory().then(() => startPolling());
+        } else {
+            dbg('warn', 'onAuthReady: email NOT verified — sender bar hidden, no chat history loaded');
+            // Start verification polling if logged in but unverified
+            if (currentUser) startVerificationPolling();
         }
     }
 
@@ -482,9 +488,10 @@
 
         // Logged in but unverified -> queue as pending
         if (!emailVerified) {
-            dbg('warn', 'Email not verified — queuing as pending');
+            dbg('warn', 'Email not verified — queuing as pending', { deviceId: currentUser.deviceId, targetCode, textLen: text.length });
             addLocalMessage(text, 'pending');
             try {
+                dbg('info', 'Saving to pending-cross-speak API', { targetCode, text: text.slice(0, 50) });
                 const pendResp = await fetch(`${API_BASE}/api/chat/pending-cross-speak`, {
                     method: 'POST',
                     credentials: 'include',
@@ -493,11 +500,18 @@
                 });
                 const pendData = await pendResp.json().catch(() => ({}));
                 dbg('info', `Pending queue response: ${pendResp.status}`, pendData);
-                showToast('Message queued (email verification required)', 'warn');
+                if (pendResp.ok) {
+                    showToast(t('sc_message_queued', 'Message queued (email verification required)'), 'warn');
+                } else {
+                    dbg('error', 'Pending queue failed', pendData);
+                    showToast(t('sc_queue_failed', 'Failed to queue message'), 'error');
+                }
             } catch (e) {
                 dbg('error', `Failed to queue pending: ${e.message}`);
-                showToast('Failed to queue message', 'error');
+                showToast(t('sc_queue_failed', 'Failed to queue message'), 'error');
             }
+            // Ensure verification polling is running
+            if (!verifyPollTimer) startVerificationPolling();
             return;
         }
 
@@ -828,7 +842,7 @@
     }
 
     async function doRegister() {
-        dbg('info', 'doRegister called');
+        dbg('info', 'doRegister called', { pendingText: pendingText ? pendingText.slice(0, 50) : null });
         const email = document.getElementById('regEmail').value.trim();
         const pw = document.getElementById('regPassword').value;
         const errEl = document.getElementById('regError');
@@ -836,6 +850,7 @@
         const btn = document.getElementById('regSubmitBtn');
         btn.disabled = true;
         try {
+            dbg('info', 'Calling POST /api/auth/register', { email });
             const resp = await fetch(`${API_BASE}/api/auth/register`, {
                 method: 'POST',
                 credentials: 'include',
@@ -843,6 +858,7 @@
                 body: JSON.stringify({ email, password: pw })
             });
             const data = await resp.json();
+            dbg('info', `Register response: ${resp.status}`, data);
             if (!resp.ok || !data.success) {
                 errEl.textContent = data.error || t('sc_registration_failed', 'Registration failed');
                 btn.disabled = false;
@@ -850,6 +866,7 @@
             }
 
             // Auto-login after register
+            dbg('info', 'Calling POST /api/auth/login (auto-login after register)');
             const loginResp = await fetch(`${API_BASE}/api/auth/login`, {
                 method: 'POST',
                 credentials: 'include',
@@ -857,19 +874,51 @@
                 body: JSON.stringify({ email, password: pw })
             });
             const loginData = await loginResp.json();
+            dbg('info', `Auto-login response: ${loginResp.status}`, { success: loginData.success, deviceId: loginData.user?.deviceId, emailVerified: loginData.user?.emailVerified });
             if (loginResp.ok && loginData.success) {
                 currentUser = loginData.user;
                 emailVerified = false;
             } else {
-                dbg('warn', 'Auto-login failed after register (email not verified), staying on page');
+                dbg('warn', 'Auto-login failed after register — no session cookie', loginData);
             }
 
-            // Stay on share-chat page — email verification required before redirect
+            // Save pending message to DB so it survives page reload
             const saved = pendingText;
+            dbg('info', 'Post-register state', { saved: saved ? saved.slice(0, 50) : null, hasCurrentUser: !!currentUser, targetCode });
             closeModal();
-            if (saved) addLocalMessage(saved, 'pending');
+
+            if (saved && currentUser) {
+                dbg('info', 'Saving pending message to DB via pending-cross-speak API');
+                addLocalMessage(saved, 'pending');
+                try {
+                    const pendResp = await fetch(`${API_BASE}/api/chat/pending-cross-speak`, {
+                        method: 'POST',
+                        credentials: 'include',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ targetCode, text: saved })
+                    });
+                    const pendData = await pendResp.json().catch(() => ({}));
+                    dbg('info', `Pending-cross-speak response: ${pendResp.status}`, pendData);
+                    if (!pendResp.ok) {
+                        dbg('error', 'Failed to save pending message to DB', pendData);
+                    }
+                } catch (e) {
+                    dbg('error', `Pending-cross-speak network error: ${e.message}`);
+                }
+            } else if (saved) {
+                dbg('warn', 'Has pending text but no currentUser — message NOT saved to DB');
+                addLocalMessage(saved, 'pending');
+            }
+
             showToast(t('sc_register_success_verify', 'Account created! Check your email to verify.'), 'success');
+
+            // Start polling for email verification status
+            if (currentUser && !emailVerified) {
+                dbg('info', 'Starting email verification polling');
+                startVerificationPolling();
+            }
         } catch (e) {
+            dbg('error', `doRegister error: ${e.message}`);
             errEl.textContent = t('sc_network_error', 'Network error');
             btn.disabled = false;
         }
@@ -908,6 +957,43 @@
             errEl.textContent = t('sc_network_error', 'Network error');
             btn.disabled = false;
         }
+    }
+
+    // ── Email verification polling ──
+    let verifyPollTimer = null;
+    function startVerificationPolling() {
+        if (verifyPollTimer) return;
+        dbg('info', 'Verification polling started (5s interval)');
+        verifyPollTimer = setInterval(async () => {
+            try {
+                dbg('info', 'Verification poll: checking /api/auth/me');
+                const resp = await fetch(`${API_BASE}/api/auth/me`, { credentials: 'include' });
+                if (!resp.ok) { dbg('warn', `Verification poll: /me returned ${resp.status}`); return; }
+                const data = await resp.json();
+                dbg('info', 'Verification poll result', { emailVerified: data.user?.emailVerified, email: data.user?.email });
+                if (data.success && data.user && data.user.emailVerified) {
+                    dbg('info', 'Email verified! Upgrading session state');
+                    clearInterval(verifyPollTimer);
+                    verifyPollTimer = null;
+                    emailVerified = true;
+                    currentUser = data.user;
+
+                    // Upgrade pending messages in DOM
+                    document.querySelectorAll('.msg.pending').forEach(el => {
+                        el.classList.remove('pending');
+                        el.classList.add('sent');
+                        const hint = el.querySelector('.verify-hint');
+                        if (hint) hint.remove();
+                        dbg('info', 'Upgraded pending message to sent');
+                    });
+
+                    onAuthReady();
+                    showToast(t('sc_email_verified', 'Email verified! You can now chat.'), 'success');
+                }
+            } catch (e) {
+                dbg('error', `Verification poll error: ${e.message}`);
+            }
+        }, 5000);
     }
 
     function escapeHtml(s) {

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -1477,6 +1477,9 @@ const TRANSLATIONS = {
         "sc_registration_failed": "Registration failed",
         "sc_register_success_verify": "Account created! Check your email to verify.",
         "sc_login_failed": "Login failed",
+        "sc_email_verified": "Email verified! You can now chat.",
+        "sc_message_queued": "Message queued (email verification required)",
+        "sc_queue_failed": "Failed to queue message",
         "sc_qr_loading": "QR loading...",
         "sc_qr_failed": "QR failed to load",
 
@@ -3187,6 +3190,9 @@ const TRANSLATIONS = {
         "sc_registration_failed": "註冊失敗",
         "sc_register_success_verify": "帳號已建立！請至信箱驗證後即可開始聊天。",
         "sc_login_failed": "登入失敗",
+        "sc_email_verified": "郵件已驗證！現在可以開始聊天了。",
+        "sc_message_queued": "訊息已排入佇列（需先驗證電子郵件）",
+        "sc_queue_failed": "訊息排入佇列失敗",
         "sc_qr_loading": "QR 載入中...",
         "sc_qr_failed": "QR 載入失敗",
 
@@ -4935,6 +4941,9 @@ const TRANSLATIONS = {
         "sc_registration_failed": "注册失败",
         "sc_register_success_verify": "账号已创建！请查收邮件完成验证。",
         "sc_login_failed": "登录失败",
+        "sc_email_verified": "邮箱已验证！现在可以开始聊天了。",
+        "sc_message_queued": "消息已排队（需先验证邮箱）",
+        "sc_queue_failed": "消息排队失败",
         "sc_qr_loading": "QR 加载中...",
         "sc_qr_failed": "QR 加载失败",
 
@@ -6494,6 +6503,9 @@ const TRANSLATIONS = {
         "sc_registration_failed": "登録に失敗しました",
         "sc_register_success_verify": "アカウントが作成されました！メールを確認して認証してください。",
         "sc_login_failed": "ログインに失敗しました",
+        "sc_email_verified": "メール認証完了！チャットを開始できます。",
+        "sc_message_queued": "メッセージがキューに追加されました（メール認証が必要です）",
+        "sc_queue_failed": "メッセージのキュー追加に失敗しました",
         "sc_qr_loading": "QR 読み込み中...",
         "sc_qr_failed": "QR の読み込みに失敗しました",
 
@@ -8176,6 +8188,9 @@ const TRANSLATIONS = {
         "sc_registration_failed": "회원가입 실패",
         "sc_register_success_verify": "계정이 생성되었습니다! 이메일을 확인하여 인증해 주세요.",
         "sc_login_failed": "로그인 실패",
+        "sc_email_verified": "이메일 인증 완료! 이제 채팅할 수 있습니다.",
+        "sc_message_queued": "메시지가 대기열에 추가됨 (이메일 인증 필요)",
+        "sc_queue_failed": "메시지 대기열 추가 실패",
         "sc_qr_loading": "QR 로딩 중...",
         "sc_qr_failed": "QR 로드 실패",
 
@@ -9864,6 +9879,9 @@ const TRANSLATIONS = {
         "sc_registration_failed": "ลงทะเบียนไม่สำเร็จ",
         "sc_register_success_verify": "สร้างบัญชีสำเร็จ! กรุณาตรวจสอบอีเมลเพื่อยืนยัน",
         "sc_login_failed": "เข้าสู่ระบบไม่สำเร็จ",
+        "sc_email_verified": "ยืนยันอีเมลสำเร็จ! คุณสามารถแชทได้แล้ว",
+        "sc_message_queued": "ข้อความอยู่ในคิว (ต้องยืนยันอีเมลก่อน)",
+        "sc_queue_failed": "ไม่สามารถเพิ่มข้อความในคิวได้",
         "sc_qr_loading": "กำลังโหลด QR...",
         "sc_qr_failed": "โหลด QR ไม่สำเร็จ",
 
@@ -11546,6 +11564,9 @@ const TRANSLATIONS = {
         "sc_registration_failed": "Đăng ký thất bại",
         "sc_register_success_verify": "Tài khoản đã được tạo! Vui lòng kiểm tra email để xác minh.",
         "sc_login_failed": "Đăng nhập thất bại",
+        "sc_email_verified": "Email đã xác minh! Bạn có thể trò chuyện ngay.",
+        "sc_message_queued": "Tin nhắn đã xếp hàng (cần xác minh email)",
+        "sc_queue_failed": "Không thể xếp hàng tin nhắn",
         "sc_qr_loading": "Đang tải QR...",
         "sc_qr_failed": "Tải QR thất bại",
 
@@ -13228,6 +13249,9 @@ const TRANSLATIONS = {
         "sc_registration_failed": "Pendaftaran gagal",
         "sc_register_success_verify": "Akun berhasil dibuat! Silakan periksa email untuk verifikasi.",
         "sc_login_failed": "Login gagal",
+        "sc_email_verified": "Email terverifikasi! Anda sekarang bisa mengobrol.",
+        "sc_message_queued": "Pesan diantrekan (perlu verifikasi email)",
+        "sc_queue_failed": "Gagal mengantrikan pesan",
         "sc_qr_loading": "Memuat QR...",
         "sc_qr_failed": "Gagal memuat QR",
 

--- a/backend/tests/jest/share-chat.test.js
+++ b/backend/tests/jest/share-chat.test.js
@@ -300,4 +300,37 @@ describe('share-chat registration flow (static analysis)', () => {
         const count = (i18nContent.match(/sc_register_success_verify/g) || []).length;
         expect(count).toBeGreaterThanOrEqual(langs.length);
     });
+
+    it('doRegister saves pending message to DB via pending-cross-speak API', () => {
+        const match = html.match(/async function doRegister\(\)\s*\{([\s\S]*?)^\s{4}\}/m);
+        expect(match).toBeTruthy();
+        const body = match[1];
+        expect(body).toContain('pending-cross-speak');
+    });
+
+    it('doRegister starts verification polling after register', () => {
+        const match = html.match(/async function doRegister\(\)\s*\{([\s\S]*?)^\s{4}\}/m);
+        expect(match).toBeTruthy();
+        const body = match[1];
+        expect(body).toContain('startVerificationPolling');
+    });
+
+    it('startVerificationPolling function exists and polls /api/auth/me', () => {
+        expect(html).toContain('function startVerificationPolling()');
+        expect(html).toContain('/api/auth/me');
+        // Should upgrade pending messages when verified
+        expect(html).toContain("el.classList.remove('pending')");
+        expect(html).toContain("el.classList.add('sent')");
+    });
+
+    it('i18n keys sc_email_verified, sc_message_queued, sc_queue_failed exist in all languages', () => {
+        const i18nContent = fs.readFileSync(
+            path.join(__dirname, '../../public/shared/i18n.js'), 'utf8'
+        );
+        const langs = ['en', 'zh-TW', 'zh-CN', 'ja', 'ko', 'th', 'vi', 'id'];
+        for (const key of ['sc_email_verified', 'sc_message_queued', 'sc_queue_failed']) {
+            const count = (i18nContent.match(new RegExp(key, 'g')) || []).length;
+            expect(count).toBeGreaterThanOrEqual(langs.length);
+        }
+    });
 });


### PR DESCRIPTION
## Summary
- Fix message loss after email verification on share-chat page
- `doRegister()` now persists pending messages to DB via `pending-cross-speak` API
- Added verification polling (5s) to auto-detect email verification and upgrade pending messages
- Backend `verify-email` supports `returnTo` param for share-chat redirect
- Added debug logging throughout the registration/verification flow
- 3 new i18n keys in 8 languages, 4 new regression tests

## Test plan
- [x] Jest share-chat tests pass (13/13)
- [x] Full test suite passes (809/809)
- [x] ESLint clean (0 errors)
- [ ] Verify: register on `/c/:code`, message persists after page reload
- [ ] Verify: after email verification, pending messages auto-upgrade to sent

https://claude.ai/code/session_01ABbWnT2EJ2Ak24xrmJfEqM