### PR TITLE
fix: register endpoint sets session cookie so pending messages can be saved

### DIFF
--- a/backend/auth.js
+++ b/backend/auth.js
@@ -263,10 +263,27 @@ module.exports = function(devices, getOrCreateDevice, serverLog) {
 
             audit('info', 'auth', 'Account registered', { userId: user.id, deviceId, ipAddress: req.ip, action: 'register', resource: 'account', result: 'success' });
 
+            // Set session cookie so client can queue pending messages before verification
+            const token = signToken(user);
+            res.cookie('eclaw_session', token, {
+                httpOnly: true,
+                secure: process.env.NODE_ENV === 'production',
+                sameSite: 'lax',
+                maxAge: 7 * 24 * 60 * 60 * 1000,
+                path: '/'
+            });
+            console.log('[Auth] Register: session cookie set for unverified user', user.id);
+
             res.json({
                 success: true,
                 message: 'Account created. Please check your email to verify.',
-                userId: user.id
+                userId: user.id,
+                user: {
+                    id: user.id,
+                    email: user.email,
+                    deviceId: user.device_id,
+                    emailVerified: false
+                }
             });
         } catch (error) {
             console.error('[Auth] Register error:', error);

--- a/backend/public/portal/share-chat.html
+++ b/backend/public/portal/share-chat.html
@@ -865,21 +865,14 @@
                 return;
             }
 
-            // Auto-login after register
-            dbg('info', 'Calling POST /api/auth/login (auto-login after register)');
-            const loginResp = await fetch(`${API_BASE}/api/auth/login`, {
-                method: 'POST',
-                credentials: 'include',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ email, password: pw })
-            });
-            const loginData = await loginResp.json();
-            dbg('info', `Auto-login response: ${loginResp.status}`, { success: loginData.success, deviceId: loginData.user?.deviceId, emailVerified: loginData.user?.emailVerified });
-            if (loginResp.ok && loginData.success) {
-                currentUser = loginData.user;
+            // Register now sets session cookie directly — no separate login needed
+            if (data.user) {
+                currentUser = data.user;
                 emailVerified = false;
+                dbg('info', 'Session established from register response', { deviceId: currentUser.deviceId, email: currentUser.email });
             } else {
-                dbg('warn', 'Auto-login failed after register — no session cookie', loginData);
+                dbg('warn', 'Register succeeded but no user object in response — trying /api/auth/me');
+                await checkAuthSilent();
             }
 
             // Save pending message to DB so it survives page reload

--- a/backend/tests/jest/share-chat.test.js
+++ b/backend/tests/jest/share-chat.test.js
@@ -301,6 +301,13 @@ describe('share-chat registration flow (static analysis)', () => {
         expect(count).toBeGreaterThanOrEqual(langs.length);
     });
 
+    it('doRegister does NOT call /api/auth/login (session cookie set by register)', () => {
+        const match = html.match(/async function doRegister\(\)\s*\{([\s\S]*?)^\s{4}\}/m);
+        expect(match).toBeTruthy();
+        const body = match[1];
+        expect(body).not.toContain('/api/auth/login');
+    });
+
     it('doRegister saves pending message to DB via pending-cross-speak API', () => {
         const match = html.match(/async function doRegister\(\)\s*\{([\s\S]*?)^\s{4}\}/m);
         expect(match).toBeTruthy();


### PR DESCRIPTION
## Summary
- **Root cause**: `POST /api/auth/login` returns 403 for unverified users (no cookie). After register, auto-login always failed → no session → `pending-cross-speak` skipped → message never saved to DB
- Register endpoint now sets session cookie directly (no login needed)
- `doRegister()` uses register response user object instead of calling login
- Messages are now properly persisted via `pending-cross-speak` API

## Test plan
- [x] 810/810 Jest tests pass
- [x] ESLint clean
- [ ] Verify: register on `/c/akdsv7`, type message, refresh — message persists
- [ ] Verify: after email verification, messages auto-upgrade to sent

https://claude.ai/code/session_01ABbWnT2EJ2Ak24xrmJfEqM