### PR TITLE
fix: remove local messages before history reload to prevent duplicates

### DIFF
--- a/backend/public/portal/share-chat.html
+++ b/backend/public/portal/share-chat.html
@@ -971,13 +971,11 @@
                     emailVerified = true;
                     currentUser = data.user;
 
-                    // Upgrade pending messages in DOM
-                    document.querySelectorAll('.msg.pending').forEach(el => {
-                        el.classList.remove('pending');
-                        el.classList.add('sent');
-                        const hint = el.querySelector('.verify-hint');
-                        if (hint) hint.remove();
-                        dbg('info', 'Upgraded pending message to sent');
+                    // Remove locally-added messages — onAuthReady→loadChatHistory
+                    // will re-render them from DB to avoid duplicates
+                    document.querySelectorAll('.msg.pending, .msg.sent').forEach(el => {
+                        el.remove();
+                        dbg('info', 'Removed local message before history reload');
                     });
 
                     onAuthReady();

--- a/backend/tests/jest/share-chat.test.js
+++ b/backend/tests/jest/share-chat.test.js
@@ -325,9 +325,9 @@ describe('share-chat registration flow (static analysis)', () => {
     it('startVerificationPolling function exists and polls /api/auth/me', () => {
         expect(html).toContain('function startVerificationPolling()');
         expect(html).toContain('/api/auth/me');
-        // Should upgrade pending messages when verified
-        expect(html).toContain("el.classList.remove('pending')");
-        expect(html).toContain("el.classList.add('sent')");
+        // Should remove local messages before history reload to avoid duplicates
+        expect(html).toContain('.msg.pending, .msg.sent');
+        expect(html).toContain('el.remove()');
     });
 
     it('i18n keys sc_email_verified, sc_message_queued, sc_queue_failed exist in all languages', () => {


### PR DESCRIPTION
## Summary
- After email verification, `onAuthReady()` → `loadChatHistory()` renders messages from DB
- DOM already had the same message from `addLocalMessage()` during registration → duplicate
- Fix: remove locally-added `.msg.pending/.msg.sent` elements before `onAuthReady()` so DB version is the single source of truth

## Test plan
- [x] 810/810 Jest tests pass
- [ ] Register on `/c/akdsv7`, type message, verify email — message appears once, not twice

https://claude.ai/code/session_01ABbWnT2EJ2Ak24xrmJfEqM