### PR TITLE
fix(auth): remove JWT_SECRET hardcoded fallback (#391)

### DIFF
--- a/backend/auth.js
+++ b/backend/auth.js
@@ -36,7 +36,8 @@ const googleClient = GOOGLE_CLIENT_ID ? new OAuth2Client(GOOGLE_CLIENT_ID) : nul
 const FACEBOOK_APP_ID = process.env.FACEBOOK_APP_ID;
 const FACEBOOK_APP_SECRET = process.env.FACEBOOK_APP_SECRET;
 
-const JWT_SECRET = process.env.JWT_SECRET || 'dev-secret-change-in-production';
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) throw new Error('JWT_SECRET environment variable is required');
 const JWT_EXPIRY = '7d';
 const BCRYPT_ROUNDS = 12;
 const BASE_URL = process.env.BASE_URL || 'https://eclawbot.com';

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,6 +1,8 @@
 /** @type {import('jest').Config} */
 module.exports = {
     testEnvironment: 'node',
+    // Set required env vars before any test module loads
+    setupFiles: ['./tests/jest/helpers/env-setup.js'],
     testMatch: ['**/tests/jest/**/*.test.js'],
     testTimeout: 15000,
     // Prevent open handles from keeping Jest alive

--- a/backend/tests/jest/helpers/env-setup.js
+++ b/backend/tests/jest/helpers/env-setup.js
@@ -1,0 +1,5 @@
+/**
+ * Jest global env setup — runs before each test file.
+ * Sets required environment variables that would otherwise cause fail-fast errors.
+ */
+if (!process.env.JWT_SECRET) process.env.JWT_SECRET = 'test-jwt-secret-for-jest';

--- a/backend/tests/jest/helpers/mock-setup.js
+++ b/backend/tests/jest/helpers/mock-setup.js
@@ -8,6 +8,9 @@
  * without real DB, Flickr, scheduler, etc.
  */
 
+// Ensure JWT_SECRET is set for auth module (fail-fast guard)
+if (!process.env.JWT_SECRET) process.env.JWT_SECRET = 'test-jwt-secret-for-jest';
+
 jest.mock('pg', () => ({
     Pool: jest.fn().mockImplementation(() => ({
         query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),


### PR DESCRIPTION
## Summary
- Remove hardcoded `'dev-secret-change-in-production'` fallback from JWT_SECRET
- Server now throws on startup if `JWT_SECRET` env var is missing
- Add Jest `env-setup.js` to provide JWT_SECRET during test runs

## Test plan
- [x] 816/816 Jest tests pass
- [x] Railway has JWT_SECRET configured

Closes #391

https://claude.ai/code/session_01CR1o8Ev8xp8WhPP3ZLDDnu