### PR TITLE
fix(share-chat): prevent message leakage in share-history

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -979,7 +979,11 @@ authModule.setOnEmailVerified(async (deviceId) => {
             await saveChatMessage(target.deviceId, target.entityId, msg.text, sourceTag, true, false, msg.media_type || null, msg.media_url || null);
             // Also save sender's copy (same as /api/client/cross-speak)
             if (deviceId !== target.deviceId) {
-                await saveChatMessage(deviceId, 0, msg.text, sourceTag, true, false, msg.media_type || null, msg.media_url || null);
+                const senderMsgId = await saveChatMessage(deviceId, 0, msg.text, sourceTag, true, false, msg.media_type || null, msg.media_url || null);
+                if (!senderMsgId) {
+                    console.warn(`[PendingFlush] Sender copy save returned null for device ${deviceId}, retrying...`);
+                    await saveChatMessage(deviceId, 0, msg.text, sourceTag, true, false, msg.media_type || null, msg.media_url || null);
+                }
             }
             // Auto-collect target card for sender so it appears in chat.html "Send to" bar
             autoCollectCard(deviceId, msg.target_code, toEntity, 'auto_speak');
@@ -11759,7 +11763,10 @@ app.get('/api/chat/history-by-code', async (req, res) => {
 /**
  * GET /api/chat/share-history — Get cross-speak conversation for shareable chat link
  * Returns messages between the authenticated sender and the target entity (by publicCode).
- * Queries the TARGET device's chat history for cross-device messages involving this sender.
+ * Queries TWO sources:
+ *   1. Target device: sender's cross-device messages (source contains sender deviceId)
+ *   2. Sender device: auto-routed bot replies (source contains target publicCode)
+ * This avoids leaking unrelated bot messages from the target device.
  * Auth: JWT cookie (eclaw_session) required.
  * Query: ?code=ABC123&limit=50&since=TIMESTAMP_MS
  */
@@ -11783,33 +11790,39 @@ app.get('/api/chat/share-history', async (req, res) => {
     const senderDeviceId = req.user.deviceId;
 
     try {
-        // Bot replies via /api/transform don't carry sender correlation, so we constrain
-        // them to only those after this sender's first message to avoid leaking other conversations
+        // Query two sources to build the full conversation:
+        // 1. Target device: sender's messages (source contains sender's deviceId)
+        // 2. Sender device: auto-routed bot replies (source contains target publicCode like "xdevice:CODE:...")
         const senderPattern = `%${senderDeviceId}%`;
+        const targetCodePattern = `%${code}%`;
         let query, params;
         if (since) {
             const sinceTs = new Date(parseInt(since));
-            query = `SELECT id, text, source, is_from_user, is_from_bot, media_type, media_url, created_at, is_delivered
-                     FROM chat_messages
-                     WHERE device_id = $1 AND entity_id = $2
-                     AND (source ILIKE $3 OR is_from_bot = true)
-                     AND created_at > $5
-                     ORDER BY created_at ASC LIMIT $4`;
-            params = [target.deviceId, target.entityId, senderPattern, maxLimit, sinceTs];
+            query = `(SELECT id, text, source, is_from_user, is_from_bot, media_type, media_url, created_at, is_delivered
+                      FROM chat_messages
+                      WHERE device_id = $1 AND entity_id = $2
+                      AND source ILIKE $3
+                      AND created_at > $6)
+                     UNION ALL
+                     (SELECT id, text, source, is_from_user, is_from_bot, media_type, media_url, created_at, is_delivered
+                      FROM chat_messages
+                      WHERE device_id = $5 AND is_from_bot = true
+                      AND source ILIKE $4
+                      AND created_at > $6)
+                     ORDER BY created_at ASC LIMIT $7`;
+            params = [target.deviceId, target.entityId, senderPattern, targetCodePattern, senderDeviceId, sinceTs, maxLimit];
         } else {
-            query = `SELECT id, text, source, is_from_user, is_from_bot, media_type, media_url, created_at, is_delivered
-                     FROM chat_messages
-                     WHERE device_id = $1 AND entity_id = $2
-                     AND (
-                         source ILIKE $3
-                         OR (is_from_bot = true AND created_at >= (
-                             SELECT COALESCE(MIN(created_at), NOW())
-                             FROM chat_messages
-                             WHERE device_id = $1 AND entity_id = $2 AND source ILIKE $3
-                         ))
-                     )
-                     ORDER BY created_at ASC LIMIT $4`;
-            params = [target.deviceId, target.entityId, senderPattern, maxLimit];
+            query = `(SELECT id, text, source, is_from_user, is_from_bot, media_type, media_url, created_at, is_delivered
+                      FROM chat_messages
+                      WHERE device_id = $1 AND entity_id = $2
+                      AND source ILIKE $3)
+                     UNION ALL
+                     (SELECT id, text, source, is_from_user, is_from_bot, media_type, media_url, created_at, is_delivered
+                      FROM chat_messages
+                      WHERE device_id = $5 AND is_from_bot = true
+                      AND source ILIKE $4)
+                     ORDER BY created_at ASC LIMIT $6`;
+            params = [target.deviceId, target.entityId, senderPattern, targetCodePattern, senderDeviceId, maxLimit];
         }
 
         const result = await chatPool.query(query, params);

--- a/backend/tests/jest/share-chat.test.js
+++ b/backend/tests/jest/share-chat.test.js
@@ -341,3 +341,74 @@ describe('share-chat registration flow (static analysis)', () => {
         }
     });
 });
+
+// ════════════════════════════════════════════════════════════════
+// GET /api/chat/share-history — Regression: no data leakage
+// ════════════════════════════════════════════════════════════════
+describe('GET /api/chat/share-history', () => {
+    it('rejects unauthenticated requests', async () => {
+        const res = await request(app).get('/api/chat/share-history?code=abc123');
+        expect(res.status).toBe(401);
+    });
+
+    it('rejects missing code parameter (with invalid auth)', async () => {
+        const res = await request(app)
+            .get('/api/chat/share-history')
+            .set('Cookie', 'eclaw_session=invalid');
+        // 401 (invalid cookie) or 400 (missing code) — both acceptable
+        expect([400, 401]).toContain(res.status);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// Regression: share-history must NOT use broad is_from_bot filter
+// ════════════════════════════════════════════════════════════════
+describe('share-history query isolation (static analysis)', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const indexSource = fs.readFileSync(
+        path.join(__dirname, '../../index.js'), 'utf8'
+    );
+
+    // Extract the share-history route handler
+    const routeMatch = indexSource.match(
+        /app\.get\('\/api\/chat\/share-history'[\s\S]*?\n\}\);/
+    );
+    const routeBody = routeMatch ? routeMatch[0] : '';
+
+    it('share-history handler exists', () => {
+        expect(routeBody.length).toBeGreaterThan(100);
+    });
+
+    it('queries BOTH target device and sender device via UNION', () => {
+        // The fix uses UNION ALL to merge target-device sender messages
+        // and sender-device auto-routed bot replies
+        expect(routeBody).toContain('UNION ALL');
+    });
+
+    it('does NOT use broad is_from_bot on target device', () => {
+        // The old buggy query had: WHERE device_id = $1 ... AND (source ILIKE $3 OR is_from_bot = true)
+        // This leaked ALL bot messages. After fix, is_from_bot should only appear
+        // in the sender-device subquery, not in the target-device subquery.
+        // Split the UNION: first subquery should NOT contain is_from_bot
+        const parts = routeBody.split('UNION ALL');
+        if (parts.length >= 2) {
+            // First subquery (target device): must NOT have is_from_bot = true
+            // It should only filter by source ILIKE (sender's messages)
+            const firstSubquery = parts[0];
+            // The first SELECT should use entity_id and source ILIKE, not is_from_bot
+            expect(firstSubquery).toContain('source ILIKE');
+            // Ensure no standalone "is_from_bot = true" in first subquery
+            // (it can appear in the SELECT column list, but not in WHERE)
+            const firstWhere = firstSubquery.split('WHERE').slice(1).join('WHERE');
+            expect(firstWhere).not.toMatch(/is_from_bot\s*=\s*true/);
+        }
+    });
+
+    it('sender device query filters by target publicCode pattern', () => {
+        // The second subquery should search sender's device for auto-routed
+        // replies containing the target publicCode
+        expect(routeBody).toContain('targetCodePattern');
+        expect(routeBody).toContain('senderDeviceId');
+    });
+});


### PR DESCRIPTION
## Summary
- Fix share-history endpoint leaking ALL bot messages from target device to any authenticated visitor
- Replace broad `is_from_bot = true` filter with UNION query that only returns sender's messages + auto-routed replies
- Add retry + logging for pending flush sender copy save failure

## Root Cause
The `GET /api/chat/share-history` query returned 70+ unrelated bot messages (skill discoveries, channel responses, etc.) because it used `is_from_bot = true` without correlating to the specific sender. User A at `/c/akdsv7` would see entity messages meant for User B.

## Test plan
- [x] All 832 Jest tests pass (48 suites)
- [x] ESLint: 0 errors
- [x] New regression tests verify UNION query structure and no broad is_from_bot in target-device subquery

https://claude.ai/code/session_011Sd1C6x3g6UY8dkvymzMtj