### PR TITLE
fix: hide AI chat widget in Android WebView to prevent duplicate AI service

### DIFF
--- a/backend/public/portal/shared/ai-chat.js
+++ b/backend/public/portal/shared/ai-chat.js
@@ -746,6 +746,9 @@
 
     // ── Init ──────────────────────────────────
     function init() {
+        // Skip AI chat widget in Android WebView — the app has its own AI chat
+        if (typeof AndroidBridge !== 'undefined') return;
+
         const check = setInterval(() => {
             if (window.currentUser) {
                 clearInterval(check);


### PR DESCRIPTION
## Summary
- When `chat.html` loads inside the Android app's WebView, the web portal's AI support floating button appeared alongside the app's native AI chat feature, causing two AI services to show on the same page
- Added an `AndroidBridge` detection check in `ai-chat.js` `init()` to skip widget creation when running inside the Android WebView
- Uses the existing `AndroidBridge` JS bridge object that the app already injects

## Test plan
- [x] All 835 Jest tests pass
- [ ] Open chat page in Android app WebView — verify AI support FAB does not appear
- [ ] Open chat page in desktop browser — verify AI support FAB still appears normally

https://claude.ai/code/session_01YYwPCFFW98fQWZRzWwbcGd