### PR TITLE
fix: add User-Agent fallback for WebView AI widget detection

### DIFF
--- a/backend/public/portal/shared/ai-chat.js
+++ b/backend/public/portal/shared/ai-chat.js
@@ -745,13 +745,19 @@
     }
 
     // ── Init ──────────────────────────────────
+    function isAndroidWebView() {
+        return typeof AndroidBridge !== 'undefined' ||
+            /EClawAndroid/i.test(navigator.userAgent);
+    }
+
     function init() {
         // Skip AI chat widget in Android WebView — the app has its own AI chat
-        if (typeof AndroidBridge !== 'undefined') return;
+        if (isAndroidWebView()) return;
 
         const check = setInterval(() => {
             if (window.currentUser) {
                 clearInterval(check);
+                if (isAndroidWebView()) return; // re-check after wait
                 loadHistory();
                 createWidget();
                 resumePendingRequest();


### PR DESCRIPTION
## Summary
- Follow-up to #410 — AI chat widget still appeared in Android WebView
- Added `navigator.userAgent` check for `EClawAndroid` as fallback (set by `ChatWebViewManager.kt:54`)
- Added re-check inside the 200ms polling interval before `createWidget()` is called
- Dual detection: `AndroidBridge` JS bridge + User-Agent string

## Test plan
- [x] All 835 Jest tests pass
- [ ] Open chat page in Android app — verify AI support FAB does NOT appear
- [ ] Open chat page in desktop browser — verify AI support FAB still works

https://claude.ai/code/session_01YYwPCFFW98fQWZRzWwbcGd