### PR TITLE
feat(android): add category folder structure to Mission Control

### DIFF
--- a/app/src/main/java/com/hank/clawlive/MissionControlActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/MissionControlActivity.kt
@@ -1,12 +1,15 @@
 package com.hank.clawlive
 
+import android.content.Context
 import android.content.Intent
+import android.content.SharedPreferences
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.widget.ArrayAdapter
 import android.widget.CheckBox
 import android.widget.EditText
+import android.widget.ImageButton
 import android.widget.LinearLayout
 import android.widget.Spinner
 import android.widget.TextView
@@ -82,6 +85,20 @@ class MissionControlActivity : AppCompatActivity() {
         SoulTemplate("adventurer",   "⚔️"),
         SoulTemplate("poet",         "🌸")
     )
+
+    /** Category expand/collapse state stored in SharedPreferences. */
+    private val categoryStatePrefs: SharedPreferences by lazy {
+        getSharedPreferences("mission_cat_state_${deviceManager.deviceId}", Context.MODE_PRIVATE)
+    }
+
+    private fun isCategoryExpanded(section: String, category: String): Boolean {
+        return categoryStatePrefs.getBoolean("$section:$category", true)
+    }
+
+    private fun toggleCategoryExpanded(section: String, category: String) {
+        val current = isCategoryExpanded(section, category)
+        categoryStatePrefs.edit().putBoolean("$section:$category", !current).apply()
+    }
 
     private fun getTemplateDisplayName(tpl: SoulTemplate): String {
         val resId = resources.getIdentifier("soul_name_${tpl.id}", "string", packageName)
@@ -272,6 +289,15 @@ class MissionControlActivity : AppCompatActivity() {
         findViewById<MaterialButton>(R.id.btnAddRule).setOnClickListener { showAddRuleDialog() }
         findViewById<MaterialButton>(R.id.btnAddVar).setOnClickListener { showVarDialog(null) }
         findViewById<MaterialButton>(R.id.btnSyncVars).setOnClickListener { syncVarsToServer() }
+
+        // Category add buttons
+        findViewById<MaterialButton>(R.id.btnAddCatTodo).setOnClickListener { showAddCategoryDialog("todo") }
+        findViewById<MaterialButton>(R.id.btnAddCatMission).setOnClickListener { showAddCategoryDialog("mission") }
+        findViewById<MaterialButton>(R.id.btnAddCatDone).setOnClickListener { showAddCategoryDialog("done") }
+        findViewById<MaterialButton>(R.id.btnAddCatNotes).setOnClickListener { showAddCategoryDialog("notes") }
+        findViewById<MaterialButton>(R.id.btnAddCatSkills).setOnClickListener { showAddCategoryDialog("skills") }
+        findViewById<MaterialButton>(R.id.btnAddCatSouls).setOnClickListener { showAddCategoryDialog("souls") }
+        findViewById<MaterialButton>(R.id.btnAddCatRules).setOnClickListener { showAddCategoryDialog("rules") }
     }
 
     private fun observeState() {
@@ -292,14 +318,24 @@ class MissionControlActivity : AppCompatActivity() {
         btnUpload.isEnabled = !state.isSyncing
         btnUpload.text = getString(R.string.publish_notification)
 
-        // Lists
-        todoAdapter.submitList(state.todoList)
-        missionAdapter.submitList(state.missionList)
-        doneAdapter.submitList(state.doneList)
-        noteAdapter.submitList(state.notes)
-        skillAdapter.submitList(state.skills)
-        soulAdapter.submitList(state.souls)
-        ruleAdapter.submitList(state.rules)
+        // Lists — render categorized items into containers, uncategorized into RecyclerViews
+        renderCategorizedItems("todo", state.todoList, state.categoryOrder,
+            findViewById(R.id.containerTodo), todoAdapter,
+            { it.category }, { showEditItemDialog(it, ListMode.TODO) }, { showItemActionMenu(it, ListMode.TODO) })
+        renderCategorizedItems("mission", state.missionList, state.categoryOrder,
+            findViewById(R.id.containerMission), missionAdapter,
+            { it.category }, { showEditItemDialog(it, ListMode.MISSION) }, { showItemActionMenu(it, ListMode.MISSION) })
+        renderCategorizedItems("done", state.doneList, state.categoryOrder,
+            findViewById(R.id.containerDone), doneAdapter,
+            { it.category }, { showEditItemDialog(it, ListMode.DONE) }, { })
+        renderCategorizedNotes("notes", state.notes, state.categoryOrder,
+            findViewById(R.id.containerNotes), noteAdapter)
+        renderCategorizedSkills("skills", state.skills, state.categoryOrder,
+            findViewById(R.id.containerSkills), skillAdapter)
+        renderCategorizedSouls("souls", state.souls, state.categoryOrder,
+            findViewById(R.id.containerSouls), soulAdapter)
+        renderCategorizedRules("rules", state.rules, state.categoryOrder,
+            findViewById(R.id.containerRules), ruleAdapter)
 
         // Empty states
         findViewById<View>(R.id.tvTodoEmpty).visibility =
@@ -342,6 +378,7 @@ class MissionControlActivity : AppCompatActivity() {
         val etTitle = view.findViewById<EditText>(R.id.etTitle)
         val etDescription = view.findViewById<EditText>(R.id.etDescription)
         val spinnerPriority = view.findViewById<Spinner>(R.id.spinnerPriority)
+        val spinnerCategory = view.findViewById<Spinner>(R.id.spinnerCategory)
         val container = view.findViewById<LinearLayout>(R.id.entityCheckboxContainer)
 
         val priorities = Priority.values()
@@ -350,6 +387,7 @@ class MissionControlActivity : AppCompatActivity() {
             priorities.map { it.label })
         spinnerPriority.setSelection(1) // MEDIUM
 
+        buildCategorySpinner(spinnerCategory, "todo")
         val checkboxes = buildEntityCheckboxes(container, emptyList())
 
         MaterialAlertDialogBuilder(this)
@@ -363,7 +401,8 @@ class MissionControlActivity : AppCompatActivity() {
                         title = title,
                         description = etDescription.text.toString().trim(),
                         priority = priorities[spinnerPriority.selectedItemPosition],
-                        assignedBot = selectedEntities.joinToString(",").ifEmpty { null }
+                        assignedBot = selectedEntities.joinToString(",").ifEmpty { null },
+                        category = getSelectedCategory(spinnerCategory)
                     )
                 }
             }
@@ -376,6 +415,7 @@ class MissionControlActivity : AppCompatActivity() {
         val etTitle = view.findViewById<EditText>(R.id.etTitle)
         val etDescription = view.findViewById<EditText>(R.id.etDescription)
         val spinnerPriority = view.findViewById<Spinner>(R.id.spinnerPriority)
+        val spinnerCategory = view.findViewById<Spinner>(R.id.spinnerCategory)
         val container = view.findViewById<LinearLayout>(R.id.entityCheckboxContainer)
 
         val priorities = Priority.values()
@@ -386,6 +426,13 @@ class MissionControlActivity : AppCompatActivity() {
         etTitle.setText(item.title)
         etDescription.setText(item.description ?: "")
         spinnerPriority.setSelection(priorities.indexOf(item.priority ?: Priority.MEDIUM))
+
+        val section = when (mode) {
+            ListMode.TODO -> "todo"
+            ListMode.MISSION -> "mission"
+            ListMode.DONE -> "done"
+        }
+        buildCategorySpinner(spinnerCategory, section, item.category)
 
         val selectedEntities = item.assignedBot?.split(",")?.map { it.trim() } ?: emptyList()
         val checkboxes = buildEntityCheckboxes(container, selectedEntities)
@@ -402,7 +449,8 @@ class MissionControlActivity : AppCompatActivity() {
                         title = title,
                         description = etDescription.text.toString().trim(),
                         priority = priorities[spinnerPriority.selectedItemPosition],
-                        assignedBot = selected.joinToString(",").ifEmpty { null }
+                        assignedBot = selected.joinToString(",").ifEmpty { null },
+                        category = getSelectedCategory(spinnerCategory)
                     )
                 }
             }
@@ -445,7 +493,9 @@ class MissionControlActivity : AppCompatActivity() {
         val view = LayoutInflater.from(this).inflate(R.layout.dialog_mission_note, null)
         val etTitle = view.findViewById<EditText>(R.id.etTitle)
         val etContent = view.findViewById<EditText>(R.id.etContent)
-        val etCategory = view.findViewById<EditText>(R.id.etCategory)
+        val spinnerCategory = view.findViewById<Spinner>(R.id.spinnerCategory)
+
+        buildCategorySpinner(spinnerCategory, "notes")
 
         MaterialAlertDialogBuilder(this)
             .setTitle(getString(R.string.add_note))
@@ -457,7 +507,7 @@ class MissionControlActivity : AppCompatActivity() {
                     viewModel.addNote(
                         title = title,
                         content = content,
-                        category = etCategory.text.toString().trim().ifEmpty { "general" }
+                        category = getSelectedCategory(spinnerCategory) ?: "general"
                     )
                 }
             }
@@ -469,11 +519,11 @@ class MissionControlActivity : AppCompatActivity() {
         val view = LayoutInflater.from(this).inflate(R.layout.dialog_mission_note, null)
         val etTitle = view.findViewById<EditText>(R.id.etTitle)
         val etContent = view.findViewById<EditText>(R.id.etContent)
-        val etCategory = view.findViewById<EditText>(R.id.etCategory)
+        val spinnerCategory = view.findViewById<Spinner>(R.id.spinnerCategory)
 
         etTitle.setText(note.title)
         etContent.setText(note.content)
-        etCategory.setText(note.category ?: "")
+        buildCategorySpinner(spinnerCategory, "notes", note.category)
 
         val dialog = MaterialAlertDialogBuilder(this)
             .setTitle(getString(R.string.edit))
@@ -485,7 +535,7 @@ class MissionControlActivity : AppCompatActivity() {
                         noteId = note.id,
                         title = title,
                         content = etContent.text.toString().trim(),
-                        category = etCategory.text.toString().trim().ifEmpty { "general" }
+                        category = getSelectedCategory(spinnerCategory) ?: "general"
                     )
                 }
             }
@@ -507,12 +557,14 @@ class MissionControlActivity : AppCompatActivity() {
         val etName = view.findViewById<EditText>(R.id.etName)
         val etDescription = view.findViewById<EditText>(R.id.etDescription)
         val spinnerType = view.findViewById<Spinner>(R.id.spinnerRuleType)
+        val spinnerCategory = view.findViewById<Spinner>(R.id.spinnerCategory)
         val container = view.findViewById<LinearLayout>(R.id.entityCheckboxContainer)
 
         val types = RuleType.values()
         spinnerType.adapter = ArrayAdapter(this,
             android.R.layout.simple_spinner_dropdown_item,
             types.map { it.name })
+        buildCategorySpinner(spinnerCategory, "rules")
 
         // Wire up server-side rule gallery button
         btnChooseRuleTemplate.setOnClickListener {
@@ -544,7 +596,8 @@ class MissionControlActivity : AppCompatActivity() {
                         name = name,
                         description = etDescription.text.toString().trim(),
                         ruleType = types[spinnerType.selectedItemPosition],
-                        assignedEntities = checkboxes.filter { it.second.isChecked }.map { it.first }
+                        assignedEntities = checkboxes.filter { it.second.isChecked }.map { it.first },
+                        category = getSelectedCategory(spinnerCategory)
                     )
                 }
             }
@@ -557,6 +610,7 @@ class MissionControlActivity : AppCompatActivity() {
         val etName = view.findViewById<EditText>(R.id.etName)
         val etDescription = view.findViewById<EditText>(R.id.etDescription)
         val spinnerType = view.findViewById<Spinner>(R.id.spinnerRuleType)
+        val spinnerCategory = view.findViewById<Spinner>(R.id.spinnerCategory)
         val container = view.findViewById<LinearLayout>(R.id.entityCheckboxContainer)
 
         val types = RuleType.values()
@@ -567,6 +621,7 @@ class MissionControlActivity : AppCompatActivity() {
         etName.setText(rule.name)
         etDescription.setText(rule.description)
         spinnerType.setSelection(types.indexOf(rule.ruleType))
+        buildCategorySpinner(spinnerCategory, "rules", rule.category)
 
         val checkboxes = buildEntityCheckboxes(container, rule.assignedEntities)
 
@@ -581,7 +636,8 @@ class MissionControlActivity : AppCompatActivity() {
                         name = name,
                         description = etDescription.text.toString().trim(),
                         ruleType = types[spinnerType.selectedItemPosition],
-                        assignedEntities = checkboxes.filter { it.second.isChecked }.map { it.first }
+                        assignedEntities = checkboxes.filter { it.second.isChecked }.map { it.first },
+                        category = getSelectedCategory(spinnerCategory)
                     )
                 }
             }
@@ -637,7 +693,9 @@ class MissionControlActivity : AppCompatActivity() {
         val etTitle = view.findViewById<EditText>(R.id.etTitle)
         val etUrl = view.findViewById<EditText>(R.id.etUrl)
         val etSteps = view.findViewById<EditText>(R.id.etSteps)
+        val spinnerCategory = view.findViewById<Spinner>(R.id.spinnerCategory)
         val container = view.findViewById<LinearLayout>(R.id.entityCheckboxContainer)
+        buildCategorySpinner(spinnerCategory, "skills", skill?.category)
         val layoutRequiredVarsWarning = view.findViewById<LinearLayout>(R.id.layoutRequiredVarsWarning)
         val tvRequiredVarsList = view.findViewById<TextView>(R.id.tvRequiredVarsList)
         val btnGoToEnvVars = view.findViewById<MaterialButton>(R.id.btnGoToEnvVars)
@@ -697,10 +755,11 @@ class MissionControlActivity : AppCompatActivity() {
                     val url = etUrl.text.toString().trim()
                     val steps = etSteps.text.toString().trim()
                     val selectedEntities = checkboxes.filter { it.second.isChecked }.map { it.first }
+                    val cat = getSelectedCategory(spinnerCategory)
                     if (skill != null) {
-                        viewModel.editSkill(skill.id, title, url, steps, selectedEntities)
+                        viewModel.editSkill(skill.id, title, url, steps, selectedEntities, cat)
                     } else {
-                        viewModel.addSkill(title, url, steps, selectedEntities)
+                        viewModel.addSkill(title, url, steps, selectedEntities, cat)
                     }
                 }
             }
@@ -863,7 +922,9 @@ class MissionControlActivity : AppCompatActivity() {
         val btnChooseSoulTemplate = view.findViewById<MaterialButton>(R.id.btnChooseSoulTemplate)
         val etName = view.findViewById<EditText>(R.id.etName)
         val etDescription = view.findViewById<EditText>(R.id.etDescription)
+        val spinnerCategory = view.findViewById<Spinner>(R.id.spinnerCategory)
         val container = view.findViewById<LinearLayout>(R.id.entityCheckboxContainer)
+        buildCategorySpinner(spinnerCategory, "souls", soul?.category)
 
         // Track currently selected template ID
         var selectedTemplateId: String? = soul?.templateId
@@ -921,10 +982,11 @@ class MissionControlActivity : AppCompatActivity() {
                 if (name.isNotEmpty()) {
                     val description = etDescription.text.toString().trim()
                     val selectedEntities = checkboxes.filter { it.second.isChecked }.map { it.first }
+                    val cat = getSelectedCategory(spinnerCategory)
                     if (soul != null) {
-                        viewModel.editSoul(soul.id, name, description, selectedTemplateId, selectedEntities)
+                        viewModel.editSoul(soul.id, name, description, selectedTemplateId, selectedEntities, cat)
                     } else {
-                        viewModel.addSoul(name, description, selectedTemplateId, selectedEntities)
+                        viewModel.addSoul(name, description, selectedTemplateId, selectedEntities, cat)
                     }
                 }
             }
@@ -1004,6 +1066,352 @@ class MissionControlActivity : AppCompatActivity() {
                 viewModel.updateNotifiedSnapshot()
             }
             .show()
+    }
+
+    // ============================================
+    // Category Rendering
+    // ============================================
+
+    /** Render a category header into a container, returning the body LinearLayout. */
+    private fun inflateCategoryHeader(
+        container: LinearLayout,
+        section: String,
+        category: String,
+        count: Int
+    ): LinearLayout {
+        val headerView = LayoutInflater.from(this).inflate(R.layout.item_category_header, container, false)
+        val expanded = isCategoryExpanded(section, category)
+
+        headerView.findViewById<TextView>(R.id.tvChevron).text = if (expanded) "▼" else "▶"
+        headerView.findViewById<TextView>(R.id.tvCategoryName).text = category
+        headerView.findViewById<TextView>(R.id.tvCategoryCount).text = "($count)"
+
+        val bodyLayout = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            visibility = if (expanded) View.VISIBLE else View.GONE
+            setPadding(16, 0, 0, 0)
+        }
+
+        headerView.findViewById<View>(R.id.categoryHeader).setOnClickListener {
+            toggleCategoryExpanded(section, category)
+            val nowExpanded = isCategoryExpanded(section, category)
+            headerView.findViewById<TextView>(R.id.tvChevron).text = if (nowExpanded) "▼" else "▶"
+            bodyLayout.visibility = if (nowExpanded) View.VISIBLE else View.GONE
+        }
+
+        headerView.findViewById<ImageButton>(R.id.btnRename).setOnClickListener {
+            showRenameCategoryDialog(section, category)
+        }
+        headerView.findViewById<ImageButton>(R.id.btnDelete).setOnClickListener {
+            showDeleteCategoryDialog(section, category)
+        }
+
+        container.addView(headerView)
+        container.addView(bodyLayout)
+        return bodyLayout
+    }
+
+    /** Generic category rendering for MissionItem lists (TODO, Mission, Done). */
+    private fun <T> renderCategorizedItems(
+        section: String,
+        items: List<T>,
+        categoryOrder: Map<String, List<String>>,
+        container: LinearLayout,
+        adapter: RecyclerView.Adapter<*>,
+        getCategory: (T) -> String?,
+        onClick: (T) -> Unit,
+        onLongClick: (T) -> Unit
+    ) {
+        container.removeAllViews()
+        val order = categoryOrder[section] ?: emptyList()
+        if (order.isEmpty()) {
+            // No categories — use adapter directly (backward compat)
+            @Suppress("UNCHECKED_CAST")
+            (adapter as? MissionItemAdapter)?.submitList(items as? List<MissionItem>)
+            return
+        }
+
+        val grouped = items.groupBy { getCategory(it) }
+        val categorizedIds = mutableSetOf<String>()
+
+        for (cat in order) {
+            val catItems = grouped[cat] ?: emptyList()
+            val body = inflateCategoryHeader(container, section, cat, catItems.size)
+            for (item in catItems) {
+                val itemView = createMissionItemView(item as MissionItem, onClick as (MissionItem) -> Unit, onLongClick as (MissionItem) -> Unit)
+                body.addView(itemView)
+            }
+            catItems.forEach { categorizedIds.add((it as MissionItem).id) }
+        }
+
+        // Uncategorized items go to the RecyclerView adapter
+        val uncategorized = items.filterIsInstance<MissionItem>().filter { it.id !in categorizedIds && getCategory(it as T) == null }
+        @Suppress("UNCHECKED_CAST")
+        (adapter as? MissionItemAdapter)?.submitList(uncategorized)
+    }
+
+    private fun createMissionItemView(item: MissionItem, onClick: (MissionItem) -> Unit, onLongClick: (MissionItem) -> Unit): View {
+        val view = LayoutInflater.from(this).inflate(R.layout.item_mission, null)
+        view.findViewById<TextView>(R.id.tvPriority).text = (item.priority?.label ?: "🟡 中").take(2)
+        view.findViewById<TextView>(R.id.tvTitle).text = item.title
+        view.findViewById<TextView>(R.id.tvStatus).text = item.status?.label ?: "待處理"
+        val tvDesc = view.findViewById<TextView>(R.id.tvDescription)
+        if (!item.description.isNullOrBlank()) {
+            tvDesc.text = item.description
+            tvDesc.visibility = View.VISIBLE
+        } else {
+            tvDesc.visibility = View.GONE
+        }
+        view.findViewById<View>(R.id.detailsRow).visibility = View.GONE
+        view.findViewById<View>(R.id.tvCompletedAt).visibility = View.GONE
+        view.setOnClickListener { onClick(item) }
+        view.setOnLongClickListener { onLongClick(item); true }
+        val lp = LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+        lp.bottomMargin = 6
+        view.layoutParams = lp
+        return view
+    }
+
+    private fun renderCategorizedNotes(
+        section: String,
+        items: List<MissionNote>,
+        categoryOrder: Map<String, List<String>>,
+        container: LinearLayout,
+        adapter: MissionNoteAdapter
+    ) {
+        container.removeAllViews()
+        val order = categoryOrder[section] ?: emptyList()
+        if (order.isEmpty()) {
+            adapter.submitList(items)
+            return
+        }
+
+        val grouped = items.groupBy { it.category }
+        val categorizedIds = mutableSetOf<String>()
+
+        for (cat in order) {
+            val catItems = grouped[cat] ?: emptyList()
+            val body = inflateCategoryHeader(container, section, cat, catItems.size)
+            for (note in catItems) {
+                val view = createNoteItemView(note)
+                body.addView(view)
+            }
+            catItems.forEach { categorizedIds.add(it.id) }
+        }
+
+        adapter.submitList(items.filter { it.id !in categorizedIds && it.category == null })
+    }
+
+    private fun createNoteItemView(note: MissionNote): View {
+        val view = LayoutInflater.from(this).inflate(R.layout.item_mission_note, null)
+        view.findViewById<TextView>(R.id.tvTitle).text = note.title
+        view.findViewById<TextView>(R.id.tvContent).text = note.content
+        view.findViewById<TextView>(R.id.tvCategory).text = note.category ?: ""
+        view.setOnClickListener { showEditNoteDialog(note) }
+        val lp = LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+        lp.bottomMargin = 6
+        view.layoutParams = lp
+        return view
+    }
+
+    private fun renderCategorizedSkills(
+        section: String,
+        items: List<MissionSkill>,
+        categoryOrder: Map<String, List<String>>,
+        container: LinearLayout,
+        adapter: MissionSkillAdapter
+    ) {
+        container.removeAllViews()
+        val order = categoryOrder[section] ?: emptyList()
+        if (order.isEmpty()) {
+            adapter.submitList(items)
+            return
+        }
+
+        val grouped = items.groupBy { it.category }
+        val categorizedIds = mutableSetOf<String>()
+
+        for (cat in order) {
+            val catItems = grouped[cat] ?: emptyList()
+            val body = inflateCategoryHeader(container, section, cat, catItems.size)
+            for (skill in catItems) {
+                val view = createSkillItemView(skill)
+                body.addView(view)
+            }
+            catItems.forEach { categorizedIds.add(it.id) }
+        }
+
+        adapter.submitList(items.filter { it.id !in categorizedIds && it.category == null })
+    }
+
+    private fun createSkillItemView(skill: MissionSkill): View {
+        val view = LayoutInflater.from(this).inflate(R.layout.item_mission_skill, null)
+        view.findViewById<TextView>(R.id.tvTitle).text = if (skill.isSystem) "\uD83D\uDD12 ${skill.title}" else skill.title
+        val tvEntities = view.findViewById<TextView>(R.id.tvEntities)
+        if (skill.assignedEntities.isNotEmpty()) {
+            tvEntities.text = skill.assignedEntities.joinToString(", ")
+            tvEntities.visibility = View.VISIBLE
+        } else {
+            tvEntities.visibility = View.GONE
+        }
+        val tvUrl = view.findViewById<TextView>(R.id.tvUrl)
+        if (!skill.url.isNullOrBlank()) {
+            tvUrl.text = skill.url
+            tvUrl.visibility = View.VISIBLE
+        } else {
+            tvUrl.visibility = View.GONE
+        }
+        view.setOnClickListener { showEditSkillDialog(skill) }
+        val lp = LinearLayout.LayoutParams(LinearLayout.LayoutParams.MATCH_PARENT, LinearLayout.LayoutParams.WRAP_CONTENT)
+        lp.bottomMargin = 6
+        view.layoutParams = lp
+        return view
+    }
+
+    private fun renderCategorizedSouls(
+        section: String,
+        items: List<MissionSoul>,
+        categoryOrder: Map<String, List<String>>,
+        container: LinearLayout,
+        adapter: MissionSoulAdapter
+    ) {
+        container.removeAllViews()
+        val order = categoryOrder[section] ?: emptyList()
+        if (order.isEmpty()) {
+            adapter.submitList(items)
+            return
+        }
+
+        val grouped = items.groupBy { it.category }
+        val categorizedIds = mutableSetOf<String>()
+
+        for (cat in order) {
+            val catItems = grouped[cat] ?: emptyList()
+            val body = inflateCategoryHeader(container, section, cat, catItems.size)
+            for (soul in catItems) {
+                val tv = TextView(this).apply {
+                    text = "${soul.name}${if (soul.isActive) "" else " (inactive)"}"
+                    textSize = 14f
+                    setTextColor(0xFFFFFFFF.toInt())
+                    setPadding(8, 8, 8, 8)
+                    setOnClickListener { showEditSoulDialog(soul) }
+                }
+                body.addView(tv)
+            }
+            catItems.forEach { categorizedIds.add(it.id) }
+        }
+
+        adapter.submitList(items.filter { it.id !in categorizedIds && it.category == null })
+    }
+
+    private fun renderCategorizedRules(
+        section: String,
+        items: List<MissionRule>,
+        categoryOrder: Map<String, List<String>>,
+        container: LinearLayout,
+        adapter: MissionRuleAdapter
+    ) {
+        container.removeAllViews()
+        val order = categoryOrder[section] ?: emptyList()
+        if (order.isEmpty()) {
+            adapter.submitList(items)
+            return
+        }
+
+        val grouped = items.groupBy { it.category }
+        val categorizedIds = mutableSetOf<String>()
+
+        for (cat in order) {
+            val catItems = grouped[cat] ?: emptyList()
+            val body = inflateCategoryHeader(container, section, cat, catItems.size)
+            for (rule in catItems) {
+                val tv = TextView(this).apply {
+                    text = "${rule.name} [${rule.ruleType.name}]${if (rule.isEnabled) "" else " (disabled)"}"
+                    textSize = 14f
+                    setTextColor(0xFFFFFFFF.toInt())
+                    setPadding(8, 8, 8, 8)
+                    setOnClickListener { showEditRuleDialog(rule) }
+                }
+                body.addView(tv)
+            }
+            catItems.forEach { categorizedIds.add(it.id) }
+        }
+
+        adapter.submitList(items.filter { it.id !in categorizedIds && it.category == null })
+    }
+
+    // ============================================
+    // Category Dialogs
+    // ============================================
+
+    private fun showAddCategoryDialog(section: String) {
+        val input = EditText(this).apply {
+            hint = getString(R.string.category_name_hint)
+            setPadding(48, 24, 48, 8)
+        }
+        MaterialAlertDialogBuilder(this)
+            .setTitle(getString(R.string.category_add_title))
+            .setView(input)
+            .setPositiveButton(R.string.send) { _, _ ->
+                val name = input.text.toString().trim().take(50)
+                if (name.isNotEmpty()) {
+                    val existing = viewModel.getCategoryOrder(section)
+                    if (existing.contains(name)) {
+                        Toast.makeText(this, getString(R.string.category_already_exists, name), Toast.LENGTH_SHORT).show()
+                    } else {
+                        viewModel.addCategory(section, name)
+                    }
+                }
+            }
+            .setNegativeButton(R.string.cancel, null)
+            .show()
+    }
+
+    private fun showRenameCategoryDialog(section: String, oldName: String) {
+        val input = EditText(this).apply {
+            setText(oldName)
+            setPadding(48, 24, 48, 8)
+        }
+        MaterialAlertDialogBuilder(this)
+            .setTitle(getString(R.string.category_rename_title))
+            .setView(input)
+            .setPositiveButton(R.string.done) { _, _ ->
+                val newName = input.text.toString().trim().take(50)
+                if (newName.isNotEmpty() && newName != oldName) {
+                    viewModel.renameCategory(section, oldName, newName)
+                }
+            }
+            .setNegativeButton(R.string.cancel, null)
+            .show()
+    }
+
+    private fun showDeleteCategoryDialog(section: String, category: String) {
+        MaterialAlertDialogBuilder(this)
+            .setTitle(getString(R.string.category_delete_title))
+            .setMessage(getString(R.string.category_delete_confirm, category))
+            .setPositiveButton(R.string.delete) { _, _ ->
+                viewModel.deleteCategory(section, category)
+            }
+            .setNegativeButton(R.string.cancel, null)
+            .show()
+    }
+
+    /** Build a category Spinner for a dialog. Returns the Spinner. */
+    private fun buildCategorySpinner(spinner: Spinner, section: String, currentCategory: String? = null) {
+        val categories = viewModel.getCategoryOrder(section)
+        val options = mutableListOf(getString(R.string.category_none))
+        options.addAll(categories)
+        spinner.adapter = ArrayAdapter(this, android.R.layout.simple_spinner_dropdown_item, options)
+        if (currentCategory != null) {
+            val idx = categories.indexOf(currentCategory)
+            if (idx >= 0) spinner.setSelection(idx + 1) // +1 for "No category" option
+        }
+    }
+
+    /** Get the selected category from a Spinner (null if "No category" selected). */
+    private fun getSelectedCategory(spinner: Spinner): String? {
+        return if (spinner.selectedItemPosition == 0) null
+        else spinner.selectedItem?.toString()
     }
 
     private fun showDeleteConfirm(name: String, onConfirm: () -> Unit) {

--- a/app/src/main/java/com/hank/clawlive/data/model/MissionControl.kt
+++ b/app/src/main/java/com/hank/clawlive/data/model/MissionControl.kt
@@ -42,7 +42,8 @@ data class MissionItem(
     val createdAt: Long = System.currentTimeMillis(),
     val updatedAt: Long = System.currentTimeMillis(),
     val completedAt: Long? = null,
-    val createdBy: String? = null
+    val createdBy: String? = null,
+    val category: String? = null
 )
 
 /**
@@ -71,7 +72,8 @@ data class MissionRule(
     val config: Map<String, Any> = emptyMap(),
     val assignedEntities: List<String> = emptyList(),
     val createdAt: Long = System.currentTimeMillis(),
-    val updatedAt: Long = System.currentTimeMillis()
+    val updatedAt: Long = System.currentTimeMillis(),
+    val category: String? = null
 )
 
 enum class RuleType {
@@ -95,7 +97,8 @@ data class MissionSkill(
     val isSystem: Boolean = false,
     val createdAt: Long = System.currentTimeMillis(),
     val updatedAt: Long = System.currentTimeMillis(),
-    val createdBy: String? = null
+    val createdBy: String? = null,
+    val category: String? = null
 )
 
 /**
@@ -110,7 +113,8 @@ data class MissionSoul(
     val isActive: Boolean = true,
     val createdAt: Long = System.currentTimeMillis(),
     val updatedAt: Long = System.currentTimeMillis(),
-    val createdBy: String? = null
+    val createdBy: String? = null,
+    val category: String? = null
 )
 
 /**
@@ -124,6 +128,7 @@ data class MissionDashboardSnapshot(
     val rules: List<MissionRule>,
     val skills: List<MissionSkill> = emptyList(),
     val souls: List<MissionSoul> = emptyList(),
+    val categoryOrder: Map<String, List<String>> = emptyMap(),
     val version: Int = 1,
     val lastSyncedAt: Long = System.currentTimeMillis()
 )

--- a/app/src/main/java/com/hank/clawlive/ui/MissionViewModel.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/MissionViewModel.kt
@@ -28,6 +28,7 @@ data class MissionUiState(
     val rules: List<MissionRule> = emptyList(),
     val skills: List<MissionSkill> = emptyList(),
     val souls: List<MissionSoul> = emptyList(),
+    val categoryOrder: Map<String, List<String>> = emptyMap(),
     val version: Int = 1,
     val lastSyncedAt: Long? = null,
     val error: String? = null,
@@ -93,6 +94,7 @@ class MissionViewModel(application: Application) : AndroidViewModel(application)
                 rules = snapshot.rules ?: emptyList(),
                 skills = snapshot.skills ?: emptyList(),
                 souls = snapshot.souls ?: emptyList(),
+                categoryOrder = snapshot.categoryOrder ?: emptyMap(),
                 version = snapshot.version,
                 lastSyncedAt = snapshot.lastSyncedAt
             )
@@ -122,6 +124,7 @@ class MissionViewModel(application: Application) : AndroidViewModel(application)
                             rules = d.rules ?: emptyList(),
                             skills = d.skills ?: emptyList(),
                             souls = d.souls ?: emptyList(),
+                            categoryOrder = d.categoryOrder ?: emptyMap(),
                             version = d.version,
                             lastSyncedAt = d.lastSyncedAt,
                             hasLocalChanges = false
@@ -136,6 +139,7 @@ class MissionViewModel(application: Application) : AndroidViewModel(application)
                         rules = d.rules ?: emptyList(),
                         skills = d.skills ?: emptyList(),
                         souls = d.souls ?: emptyList(),
+                        categoryOrder = d.categoryOrder ?: emptyMap(),
                         version = d.version,
                         lastSyncedAt = d.lastSyncedAt ?: System.currentTimeMillis()
                     )
@@ -169,7 +173,8 @@ class MissionViewModel(application: Application) : AndroidViewModel(application)
                         "notes" to state.notes,
                         "rules" to state.rules,
                         "skills" to state.skills,
-                        "souls" to state.souls
+                        "souls" to state.souls,
+                        "categoryOrder" to state.categoryOrder
                     )
                 )
                 val response = api.uploadMissionDashboard(body)
@@ -217,6 +222,7 @@ class MissionViewModel(application: Application) : AndroidViewModel(application)
                 rules = state.rules,
                 skills = state.skills,
                 souls = state.souls,
+                categoryOrder = state.categoryOrder,
                 version = state.version,
                 lastSyncedAt = state.lastSyncedAt ?: System.currentTimeMillis()
             )
@@ -251,6 +257,7 @@ class MissionViewModel(application: Application) : AndroidViewModel(application)
             rules = s.rules.map { it.copy() },
             skills = s.skills.map { it.copy() },
             souls = s.souls.map { it.copy() },
+            categoryOrder = s.categoryOrder.toMap(),
             version = s.version,
             lastSyncedAt = s.lastSyncedAt ?: System.currentTimeMillis()
         )
@@ -260,12 +267,13 @@ class MissionViewModel(application: Application) : AndroidViewModel(application)
     // TODO List CRUD
     // ============================================
 
-    fun addTodoItem(title: String, description: String = "", priority: Priority = Priority.MEDIUM, assignedBot: String? = null) {
+    fun addTodoItem(title: String, description: String = "", priority: Priority = Priority.MEDIUM, assignedBot: String? = null, category: String? = null) {
         val item = MissionItem(
             title = title,
             description = description,
             priority = priority,
-            assignedBot = assignedBot
+            assignedBot = assignedBot,
+            category = category
         )
         _uiState.update {
             it.copy(
@@ -276,14 +284,14 @@ class MissionViewModel(application: Application) : AndroidViewModel(application)
         saveToLocal()
     }
 
-    fun editItem(itemId: String, title: String, description: String, priority: Priority, assignedBot: String? = null) {
+    fun editItem(itemId: String, title: String, description: String, priority: Priority, assignedBot: String? = null, category: String? = null) {
         _uiState.update { state ->
             state.copy(
                 todoList = state.todoList.map {
-                    if (it.id == itemId) it.copy(title = title, description = description, priority = priority, assignedBot = assignedBot, updatedAt = System.currentTimeMillis()) else it
+                    if (it.id == itemId) it.copy(title = title, description = description, priority = priority, assignedBot = assignedBot, category = category, updatedAt = System.currentTimeMillis()) else it
                 },
                 missionList = state.missionList.map {
-                    if (it.id == itemId) it.copy(title = title, description = description, priority = priority, assignedBot = assignedBot, updatedAt = System.currentTimeMillis()) else it
+                    if (it.id == itemId) it.copy(title = title, description = description, priority = priority, assignedBot = assignedBot, category = category, updatedAt = System.currentTimeMillis()) else it
                 },
                 hasLocalChanges = true
             )
@@ -378,19 +386,19 @@ class MissionViewModel(application: Application) : AndroidViewModel(application)
     // Rules CRUD
     // ============================================
 
-    fun addRule(name: String, description: String, ruleType: RuleType, assignedEntities: List<String> = emptyList()) {
-        val rule = MissionRule(name = name, description = description, ruleType = ruleType, assignedEntities = assignedEntities)
+    fun addRule(name: String, description: String, ruleType: RuleType, assignedEntities: List<String> = emptyList(), category: String? = null) {
+        val rule = MissionRule(name = name, description = description, ruleType = ruleType, assignedEntities = assignedEntities, category = category)
         _uiState.update {
             it.copy(rules = it.rules + rule, hasLocalChanges = true)
         }
         saveToLocal()
     }
 
-    fun editRule(ruleId: String, name: String, description: String, ruleType: RuleType, assignedEntities: List<String> = emptyList()) {
+    fun editRule(ruleId: String, name: String, description: String, ruleType: RuleType, assignedEntities: List<String> = emptyList(), category: String? = null) {
         _uiState.update { state ->
             state.copy(
                 rules = state.rules.map {
-                    if (it.id == ruleId) it.copy(name = name, description = description, ruleType = ruleType, assignedEntities = assignedEntities, updatedAt = System.currentTimeMillis()) else it
+                    if (it.id == ruleId) it.copy(name = name, description = description, ruleType = ruleType, assignedEntities = assignedEntities, category = category, updatedAt = System.currentTimeMillis()) else it
                 },
                 hasLocalChanges = true
             )
@@ -424,19 +432,19 @@ class MissionViewModel(application: Application) : AndroidViewModel(application)
     // Skills CRUD
     // ============================================
 
-    fun addSkill(title: String, url: String = "", steps: String = "", assignedEntities: List<String> = emptyList()) {
-        val skill = MissionSkill(title = title, url = url, steps = steps, assignedEntities = assignedEntities)
+    fun addSkill(title: String, url: String = "", steps: String = "", assignedEntities: List<String> = emptyList(), category: String? = null) {
+        val skill = MissionSkill(title = title, url = url, steps = steps, assignedEntities = assignedEntities, category = category)
         _uiState.update {
             it.copy(skills = it.skills + skill, hasLocalChanges = true)
         }
         saveToLocal()
     }
 
-    fun editSkill(skillId: String, title: String, url: String, steps: String, assignedEntities: List<String>) {
+    fun editSkill(skillId: String, title: String, url: String, steps: String, assignedEntities: List<String>, category: String? = null) {
         _uiState.update { state ->
             state.copy(
                 skills = state.skills.map {
-                    if (it.id == skillId) it.copy(title = title, url = url, steps = steps, assignedEntities = assignedEntities, updatedAt = System.currentTimeMillis()) else it
+                    if (it.id == skillId) it.copy(title = title, url = url, steps = steps, assignedEntities = assignedEntities, category = category, updatedAt = System.currentTimeMillis()) else it
                 },
                 hasLocalChanges = true
             )
@@ -458,19 +466,19 @@ class MissionViewModel(application: Application) : AndroidViewModel(application)
     // Souls CRUD
     // ============================================
 
-    fun addSoul(name: String, description: String = "", templateId: String? = null, assignedEntities: List<String> = emptyList()) {
-        val soul = MissionSoul(name = name, description = description, templateId = templateId, assignedEntities = assignedEntities)
+    fun addSoul(name: String, description: String = "", templateId: String? = null, assignedEntities: List<String> = emptyList(), category: String? = null) {
+        val soul = MissionSoul(name = name, description = description, templateId = templateId, assignedEntities = assignedEntities, category = category)
         _uiState.update {
             it.copy(souls = it.souls + soul, hasLocalChanges = true)
         }
         saveToLocal()
     }
 
-    fun editSoul(soulId: String, name: String, description: String, templateId: String?, assignedEntities: List<String>) {
+    fun editSoul(soulId: String, name: String, description: String, templateId: String?, assignedEntities: List<String>, category: String? = null) {
         _uiState.update { state ->
             state.copy(
                 souls = state.souls.map {
-                    if (it.id == soulId) it.copy(name = name, description = description, templateId = templateId, assignedEntities = assignedEntities, updatedAt = System.currentTimeMillis()) else it
+                    if (it.id == soulId) it.copy(name = name, description = description, templateId = templateId, assignedEntities = assignedEntities, category = category, updatedAt = System.currentTimeMillis()) else it
                 },
                 hasLocalChanges = true
             )
@@ -515,6 +523,7 @@ class MissionViewModel(application: Application) : AndroidViewModel(application)
             rules = s.rules.map { it.copy() },
             skills = s.skills.map { it.copy() },
             souls = s.souls.map { it.copy() },
+            categoryOrder = s.categoryOrder.toMap(),
             version = s.version,
             lastSyncedAt = s.lastSyncedAt ?: System.currentTimeMillis()
         )
@@ -680,5 +689,114 @@ class MissionViewModel(application: Application) : AndroidViewModel(application)
                 Timber.w(e, "[MISSION] fetchRuleTemplates failed: ${e.message}")
             }
         }
+    }
+
+    // ============================================
+    // Category Management
+    // ============================================
+
+    fun getCategoryOrder(section: String): List<String> {
+        return _uiState.value.categoryOrder[section] ?: emptyList()
+    }
+
+    fun addCategory(section: String, name: String) {
+        _uiState.update { state ->
+            val order = state.categoryOrder.toMutableMap()
+            val list = (order[section] ?: emptyList()).toMutableList()
+            if (!list.contains(name)) {
+                list.add(name)
+                order[section] = list
+            }
+            state.copy(categoryOrder = order, hasLocalChanges = true)
+        }
+        saveToLocal()
+    }
+
+    fun renameCategory(section: String, oldName: String, newName: String) {
+        _uiState.update { state ->
+            val order = state.categoryOrder.toMutableMap()
+            val list = (order[section] ?: emptyList()).toMutableList()
+            val idx = list.indexOf(oldName)
+            if (idx >= 0) list[idx] = newName
+            order[section] = list
+
+            // Rename category in all items of this section
+            fun renameInItems(items: List<MissionItem>) = items.map {
+                if (it.category == oldName) it.copy(category = newName, updatedAt = System.currentTimeMillis()) else it
+            }
+            fun renameInNotes(items: List<MissionNote>) = items.map {
+                if (it.category == oldName) it.copy(category = newName, updatedAt = System.currentTimeMillis()) else it
+            }
+
+            when (section) {
+                "todo" -> state.copy(categoryOrder = order, todoList = renameInItems(state.todoList), hasLocalChanges = true)
+                "mission" -> state.copy(categoryOrder = order, missionList = renameInItems(state.missionList), hasLocalChanges = true)
+                "done" -> state.copy(categoryOrder = order, doneList = renameInItems(state.doneList), hasLocalChanges = true)
+                "notes" -> state.copy(categoryOrder = order, notes = renameInNotes(state.notes), hasLocalChanges = true)
+                "skills" -> state.copy(categoryOrder = order, skills = state.skills.map {
+                    if (it.category == oldName) it.copy(category = newName, updatedAt = System.currentTimeMillis()) else it
+                }, hasLocalChanges = true)
+                "souls" -> state.copy(categoryOrder = order, souls = state.souls.map {
+                    if (it.category == oldName) it.copy(category = newName, updatedAt = System.currentTimeMillis()) else it
+                }, hasLocalChanges = true)
+                "rules" -> state.copy(categoryOrder = order, rules = state.rules.map {
+                    if (it.category == oldName) it.copy(category = newName, updatedAt = System.currentTimeMillis()) else it
+                }, hasLocalChanges = true)
+                else -> state.copy(categoryOrder = order, hasLocalChanges = true)
+            }
+        }
+        saveToLocal()
+    }
+
+    fun deleteCategory(section: String, name: String) {
+        _uiState.update { state ->
+            val order = state.categoryOrder.toMutableMap()
+            val list = (order[section] ?: emptyList()).toMutableList()
+            list.remove(name)
+            order[section] = list
+
+            // Uncategorize items
+            fun uncatItems(items: List<MissionItem>) = items.map {
+                if (it.category == name) it.copy(category = null, updatedAt = System.currentTimeMillis()) else it
+            }
+            fun uncatNotes(items: List<MissionNote>) = items.map {
+                if (it.category == name) it.copy(category = null, updatedAt = System.currentTimeMillis()) else it
+            }
+
+            when (section) {
+                "todo" -> state.copy(categoryOrder = order, todoList = uncatItems(state.todoList), hasLocalChanges = true)
+                "mission" -> state.copy(categoryOrder = order, missionList = uncatItems(state.missionList), hasLocalChanges = true)
+                "done" -> state.copy(categoryOrder = order, doneList = uncatItems(state.doneList), hasLocalChanges = true)
+                "notes" -> state.copy(categoryOrder = order, notes = uncatNotes(state.notes), hasLocalChanges = true)
+                "skills" -> state.copy(categoryOrder = order, skills = state.skills.map {
+                    if (it.category == name) it.copy(category = null, updatedAt = System.currentTimeMillis()) else it
+                }, hasLocalChanges = true)
+                "souls" -> state.copy(categoryOrder = order, souls = state.souls.map {
+                    if (it.category == name) it.copy(category = null, updatedAt = System.currentTimeMillis()) else it
+                }, hasLocalChanges = true)
+                "rules" -> state.copy(categoryOrder = order, rules = state.rules.map {
+                    if (it.category == name) it.copy(category = null, updatedAt = System.currentTimeMillis()) else it
+                }, hasLocalChanges = true)
+                else -> state.copy(categoryOrder = order, hasLocalChanges = true)
+            }
+        }
+        saveToLocal()
+    }
+
+    fun clearCategory(section: String, name: String) {
+        _uiState.update { state ->
+            // Remove all items in this category (keep category in order)
+            when (section) {
+                "todo" -> state.copy(todoList = state.todoList.filter { it.category != name }, hasLocalChanges = true)
+                "mission" -> state.copy(missionList = state.missionList.filter { it.category != name }, hasLocalChanges = true)
+                "done" -> state.copy(doneList = state.doneList.filter { it.category != name }, hasLocalChanges = true)
+                "notes" -> state.copy(notes = state.notes.filter { it.category != name }, hasLocalChanges = true)
+                "skills" -> state.copy(skills = state.skills.filter { it.category != name }, hasLocalChanges = true)
+                "souls" -> state.copy(souls = state.souls.filter { it.category != name }, hasLocalChanges = true)
+                "rules" -> state.copy(rules = state.rules.filter { it.category != name }, hasLocalChanges = true)
+                else -> state
+            }
+        }
+        saveToLocal()
     }
 }

--- a/app/src/main/res/layout/activity_mission_control.xml
+++ b/app/src/main/res/layout/activity_mission_control.xml
@@ -124,14 +124,33 @@
                     android:orientation="vertical"
                     android:padding="12dp">
 
-                    <TextView
-                        android:layout_width="wrap_content"
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="@string/mission_tab_todo"
-                        android:textSize="16sp"
-                        android:textStyle="bold"
-                        android:textColor="@android:color/white"
-                        android:layout_marginBottom="8dp" />
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:layout_marginBottom="8dp">
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/mission_tab_todo"
+                            android:textSize="16sp"
+                            android:textStyle="bold"
+                            android:textColor="@android:color/white" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnAddCatTodo"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/category_add"
+                            android:textSize="11sp"
+                            android:minHeight="0dp"
+                            android:paddingVertical="4dp"
+                            style="@style/Widget.Material3.Button.TextButton" />
+
+                    </LinearLayout>
 
                     <TextView
                         android:id="@+id/tvTodoEmpty"
@@ -143,6 +162,12 @@
                         android:gravity="center"
                         android:padding="16dp"
                         android:visibility="gone" />
+
+                    <LinearLayout
+                        android:id="@+id/containerTodo"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical" />
 
                     <androidx.recyclerview.widget.RecyclerView
                         android:id="@+id/rvTodo"
@@ -178,14 +203,33 @@
                     android:orientation="vertical"
                     android:padding="12dp">
 
-                    <TextView
-                        android:layout_width="wrap_content"
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="@string/mission_tab_missions"
-                        android:textSize="16sp"
-                        android:textStyle="bold"
-                        android:textColor="@android:color/white"
-                        android:layout_marginBottom="8dp" />
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:layout_marginBottom="8dp">
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/mission_tab_missions"
+                            android:textSize="16sp"
+                            android:textStyle="bold"
+                            android:textColor="@android:color/white" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnAddCatMission"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/category_add"
+                            android:textSize="11sp"
+                            android:minHeight="0dp"
+                            android:paddingVertical="4dp"
+                            style="@style/Widget.Material3.Button.TextButton" />
+
+                    </LinearLayout>
 
                     <TextView
                         android:id="@+id/tvMissionEmpty"
@@ -197,6 +241,12 @@
                         android:gravity="center"
                         android:padding="16dp"
                         android:visibility="gone" />
+
+                    <LinearLayout
+                        android:id="@+id/containerMission"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical" />
 
                     <androidx.recyclerview.widget.RecyclerView
                         android:id="@+id/rvMission"
@@ -224,14 +274,33 @@
                     android:orientation="vertical"
                     android:padding="12dp">
 
-                    <TextView
-                        android:layout_width="wrap_content"
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="@string/mission_tab_done"
-                        android:textSize="16sp"
-                        android:textStyle="bold"
-                        android:textColor="@android:color/white"
-                        android:layout_marginBottom="8dp" />
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:layout_marginBottom="8dp">
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/mission_tab_done"
+                            android:textSize="16sp"
+                            android:textStyle="bold"
+                            android:textColor="@android:color/white" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnAddCatDone"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/category_add"
+                            android:textSize="11sp"
+                            android:minHeight="0dp"
+                            android:paddingVertical="4dp"
+                            style="@style/Widget.Material3.Button.TextButton" />
+
+                    </LinearLayout>
 
                     <TextView
                         android:id="@+id/tvDoneEmpty"
@@ -243,6 +312,12 @@
                         android:gravity="center"
                         android:padding="16dp"
                         android:visibility="gone" />
+
+                    <LinearLayout
+                        android:id="@+id/containerDone"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical" />
 
                     <androidx.recyclerview.widget.RecyclerView
                         android:id="@+id/rvDone"
@@ -270,14 +345,33 @@
                     android:orientation="vertical"
                     android:padding="12dp">
 
-                    <TextView
-                        android:layout_width="wrap_content"
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="@string/mission_tab_notes"
-                        android:textSize="16sp"
-                        android:textStyle="bold"
-                        android:textColor="@android:color/white"
-                        android:layout_marginBottom="8dp" />
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:layout_marginBottom="8dp">
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/mission_tab_notes"
+                            android:textSize="16sp"
+                            android:textStyle="bold"
+                            android:textColor="@android:color/white" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnAddCatNotes"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/category_add"
+                            android:textSize="11sp"
+                            android:minHeight="0dp"
+                            android:paddingVertical="4dp"
+                            style="@style/Widget.Material3.Button.TextButton" />
+
+                    </LinearLayout>
 
                     <TextView
                         android:id="@+id/tvNotesEmpty"
@@ -289,6 +383,12 @@
                         android:gravity="center"
                         android:padding="16dp"
                         android:visibility="gone" />
+
+                    <LinearLayout
+                        android:id="@+id/containerNotes"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical" />
 
                     <androidx.recyclerview.widget.RecyclerView
                         android:id="@+id/rvNotes"
@@ -324,14 +424,33 @@
                     android:orientation="vertical"
                     android:padding="12dp">
 
-                    <TextView
-                        android:layout_width="wrap_content"
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="@string/mission_tab_skills"
-                        android:textSize="16sp"
-                        android:textStyle="bold"
-                        android:textColor="@android:color/white"
-                        android:layout_marginBottom="8dp" />
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:layout_marginBottom="8dp">
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/mission_tab_skills"
+                            android:textSize="16sp"
+                            android:textStyle="bold"
+                            android:textColor="@android:color/white" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnAddCatSkills"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/category_add"
+                            android:textSize="11sp"
+                            android:minHeight="0dp"
+                            android:paddingVertical="4dp"
+                            style="@style/Widget.Material3.Button.TextButton" />
+
+                    </LinearLayout>
 
                     <TextView
                         android:id="@+id/tvSkillsEmpty"
@@ -343,6 +462,12 @@
                         android:gravity="center"
                         android:padding="16dp"
                         android:visibility="gone" />
+
+                    <LinearLayout
+                        android:id="@+id/containerSkills"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical" />
 
                     <androidx.recyclerview.widget.RecyclerView
                         android:id="@+id/rvSkills"
@@ -457,14 +582,33 @@
                     android:orientation="vertical"
                     android:padding="12dp">
 
-                    <TextView
-                        android:layout_width="wrap_content"
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="@string/mission_tab_souls"
-                        android:textSize="16sp"
-                        android:textStyle="bold"
-                        android:textColor="@android:color/white"
-                        android:layout_marginBottom="8dp" />
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:layout_marginBottom="8dp">
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/mission_tab_souls"
+                            android:textSize="16sp"
+                            android:textStyle="bold"
+                            android:textColor="@android:color/white" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnAddCatSouls"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/category_add"
+                            android:textSize="11sp"
+                            android:minHeight="0dp"
+                            android:paddingVertical="4dp"
+                            style="@style/Widget.Material3.Button.TextButton" />
+
+                    </LinearLayout>
 
                     <TextView
                         android:id="@+id/tvSoulsEmpty"
@@ -476,6 +620,12 @@
                         android:gravity="center"
                         android:padding="16dp"
                         android:visibility="gone" />
+
+                    <LinearLayout
+                        android:id="@+id/containerSouls"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical" />
 
                     <androidx.recyclerview.widget.RecyclerView
                         android:id="@+id/rvSouls"
@@ -511,14 +661,33 @@
                     android:orientation="vertical"
                     android:padding="12dp">
 
-                    <TextView
-                        android:layout_width="wrap_content"
+                    <LinearLayout
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:text="@string/mission_tab_rules"
-                        android:textSize="16sp"
-                        android:textStyle="bold"
-                        android:textColor="@android:color/white"
-                        android:layout_marginBottom="8dp" />
+                        android:orientation="horizontal"
+                        android:gravity="center_vertical"
+                        android:layout_marginBottom="8dp">
+
+                        <TextView
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_weight="1"
+                            android:text="@string/mission_tab_rules"
+                            android:textSize="16sp"
+                            android:textStyle="bold"
+                            android:textColor="@android:color/white" />
+
+                        <com.google.android.material.button.MaterialButton
+                            android:id="@+id/btnAddCatRules"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:text="@string/category_add"
+                            android:textSize="11sp"
+                            android:minHeight="0dp"
+                            android:paddingVertical="4dp"
+                            style="@style/Widget.Material3.Button.TextButton" />
+
+                    </LinearLayout>
 
                     <TextView
                         android:id="@+id/tvRulesEmpty"
@@ -530,6 +699,12 @@
                         android:gravity="center"
                         android:padding="16dp"
                         android:visibility="gone" />
+
+                    <LinearLayout
+                        android:id="@+id/containerRules"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="vertical" />
 
                     <androidx.recyclerview.widget.RecyclerView
                         android:id="@+id/rvRules"

--- a/app/src/main/res/layout/dialog_mission_item.xml
+++ b/app/src/main/res/layout/dialog_mission_item.xml
@@ -38,6 +38,19 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:text="@string/category_label"
+        android:textSize="12sp"
+        android:layout_marginBottom="4dp" />
+
+    <Spinner
+        android:id="@+id/spinnerCategory"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:text="@string/assign_entity"
         android:textSize="12sp"
         android:layout_marginBottom="4dp" />

--- a/app/src/main/res/layout/dialog_mission_note.xml
+++ b/app/src/main/res/layout/dialog_mission_note.xml
@@ -22,11 +22,16 @@
         android:minLines="4"
         android:layout_marginBottom="12dp" />
 
-    <EditText
-        android:id="@+id/etCategory"
-        android:layout_width="match_parent"
+    <TextView
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:hint="分類 (預設: general)"
-        android:inputType="text" />
+        android:text="@string/category_label"
+        android:textSize="12sp"
+        android:layout_marginBottom="4dp" />
+
+    <Spinner
+        android:id="@+id/spinnerCategory"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/dialog_mission_rule.xml
+++ b/app/src/main/res/layout/dialog_mission_rule.xml
@@ -46,6 +46,19 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:text="@string/category_label"
+        android:textSize="12sp"
+        android:layout_marginBottom="4dp" />
+
+    <Spinner
+        android:id="@+id/spinnerCategory"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:text="@string/assign_entity_multi"
         android:textSize="12sp"
         android:layout_marginBottom="4dp" />

--- a/app/src/main/res/layout/dialog_mission_skill.xml
+++ b/app/src/main/res/layout/dialog_mission_skill.xml
@@ -125,6 +125,19 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:text="@string/category_label"
+        android:textSize="12sp"
+        android:layout_marginBottom="4dp" />
+
+    <Spinner
+        android:id="@+id/spinnerCategory"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:text="@string/assign_entity_multi"
         android:textSize="12sp"
         android:layout_marginBottom="4dp" />

--- a/app/src/main/res/layout/dialog_mission_soul.xml
+++ b/app/src/main/res/layout/dialog_mission_soul.xml
@@ -34,6 +34,19 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:text="@string/category_label"
+        android:textSize="12sp"
+        android:layout_marginBottom="4dp" />
+
+    <Spinner
+        android:id="@+id/spinnerCategory"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp" />
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:text="@string/assign_entity_multi"
         android:textSize="12sp"
         android:layout_marginBottom="4dp" />

--- a/app/src/main/res/layout/item_category_header.xml
+++ b/app/src/main/res/layout/item_category_header.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical"
+    android:layout_marginTop="8dp"
+    android:layout_marginBottom="2dp">
+
+    <LinearLayout
+        android:id="@+id/categoryHeader"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:paddingVertical="6dp"
+        android:paddingHorizontal="4dp"
+        android:background="?attr/selectableItemBackground">
+
+        <TextView
+            android:id="@+id/tvChevron"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="12sp"
+            android:textColor="@color/text_secondary"
+            android:layout_marginEnd="6dp"
+            tools:text="▼" />
+
+        <TextView
+            android:id="@+id/tvCategoryName"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textColor="@color/text_secondary"
+            android:textSize="13sp"
+            android:textStyle="bold"
+            android:maxLines="1"
+            android:ellipsize="end"
+            tools:text="Work" />
+
+        <TextView
+            android:id="@+id/tvCategoryCount"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/text_disabled"
+            android:textSize="11sp"
+            android:layout_marginEnd="8dp"
+            tools:text="(3)" />
+
+        <ImageButton
+            android:id="@+id/btnRename"
+            android:layout_width="28dp"
+            android:layout_height="28dp"
+            android:src="@android:drawable/ic_menu_edit"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:scaleType="centerInside"
+            android:padding="4dp"
+            android:contentDescription="@string/category_rename" />
+
+        <ImageButton
+            android:id="@+id/btnDelete"
+            android:layout_width="28dp"
+            android:layout_height="28dp"
+            android:src="@android:drawable/ic_menu_close_clear_cancel"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:scaleType="centerInside"
+            android:padding="4dp"
+            android:contentDescription="@string/category_delete_title" />
+
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -679,6 +679,21 @@ If you have any questions, please contact us via our official email.
     <string name="mission_tab_souls">🧠 Souls</string>
     <string name="mission_tab_rules">📜 Rules (Workflow)</string>
 
+    <!-- Category Management -->
+    <string name="category_add">+ Category</string>
+    <string name="category_add_title">Add Category</string>
+    <string name="category_name_hint">Category name</string>
+    <string name="category_rename">Rename Category</string>
+    <string name="category_rename_title">Rename Category</string>
+    <string name="category_delete_title">Delete Category</string>
+    <string name="category_delete_confirm">Delete category \"%1$s\"? Items will become uncategorized.</string>
+    <string name="category_clear_title">Clear Category</string>
+    <string name="category_clear_confirm">Clear all items in \"%1$s\"?</string>
+    <string name="category_uncategorized">Uncategorized</string>
+    <string name="category_label">Category</string>
+    <string name="category_none">(No category)</string>
+    <string name="category_already_exists">Category \"%1$s\" already exists</string>
+
     <!-- Common Buttons -->
     <string name="common_add">+ Add</string>
     <string name="common_show">Show</string>


### PR DESCRIPTION
## Summary
- Add category folder grouping to all 7 mission sections (TODO, Mission, Done, Notes, Skills, Souls, Rules) in Android app, matching Web Portal's category system
- Category CRUD: add, rename, delete categories per section with collapsible folder UI
- Category Spinner in all item dialogs for assigning items to categories
- categoryOrder synced with server via dashboard upload/download for cross-platform parity

## Test plan
- [ ] Verify category add/rename/delete in each section
- [ ] Verify items assigned to categories render in collapsible folders
- [ ] Verify uncategorized items render in flat list below folders
- [ ] Verify categoryOrder persists across app restart and syncs with Web Portal
- [ ] Verify expand/collapse state persists via SharedPreferences

https://claude.ai/code/session_01Td4yQXDcnusJzBRNajojUu