### PR TITLE
debug: add visible debug marker + telemetry for WebView AI widget detection

### DIFF
--- a/backend/public/portal/shared/ai-chat.js
+++ b/backend/public/portal/shared/ai-chat.js
@@ -6,12 +6,64 @@
 (function () {
     'use strict';
 
-    console.log('[AI Chat DEBUG] === ai-chat.js IIFE executing ===');
-    console.log('[AI Chat DEBUG] Time:', new Date().toISOString());
-    console.log('[AI Chat DEBUG] typeof AndroidBridge:', typeof AndroidBridge);
-    console.log('[AI Chat DEBUG] UA:', (navigator.userAgent || '').substring(0, 200));
-    console.log('[AI Chat DEBUG] Location:', window.location.href);
-    console.log('[AI Chat DEBUG] typeof window.currentUser:', typeof window.currentUser);
+    // ── Debug helper: logs to console + AndroidBridge.log + collects for API report ──
+    const _debugLogs = [];
+    function dbg(msg) {
+        const line = '[AI Chat DBG] ' + msg;
+        console.log(line);
+        _debugLogs.push({ t: Date.now(), m: msg });
+        try { if (typeof AndroidBridge !== 'undefined') AndroidBridge.log('DEBUG', line); } catch (_) {}
+    }
+    // Send collected debug logs to server as a telemetry entry + create GitHub issue
+    function flushDebugToServer() {
+        if (_debugLogs.length === 0) return;
+        const report = _debugLogs.map(l => '[' + new Date(l.t).toISOString() + '] ' + l.m).join('\n');
+        const payload = {
+            type: 'ai_chat_debug',
+            data: {
+                report: report,
+                userAgent: navigator.userAgent,
+                url: window.location.href,
+                hasBridge: typeof AndroidBridge !== 'undefined',
+                fabExists: !!document.getElementById('aiChatFab'),
+                panelExists: !!document.getElementById('aiChatPanel'),
+                timestamp: new Date().toISOString()
+            }
+        };
+        // Send via telemetry API (needs deviceId/deviceSecret from currentUser or AndroidBridge)
+        let deviceId, deviceSecret;
+        try {
+            if (typeof AndroidBridge !== 'undefined') {
+                deviceId = AndroidBridge.getDeviceId();
+                deviceSecret = AndroidBridge.getDeviceSecret();
+            } else if (window.currentUser) {
+                deviceId = window.currentUser.deviceId;
+                deviceSecret = window.currentUser.deviceSecret;
+            }
+        } catch (_) {}
+        if (deviceId && deviceSecret) {
+            fetch('/api/device-telemetry', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ deviceId, deviceSecret, entries: [payload] })
+            }).catch(() => {});
+        }
+        // Also show a visible marker on the page for quick identification
+        try {
+            const marker = document.createElement('div');
+            marker.id = 'aiChatDebugMarker';
+            marker.style.cssText = 'position:fixed;top:0;left:0;right:0;background:red;color:white;z-index:999999;padding:6px 12px;font-size:12px;font-family:monospace;max-height:40vh;overflow:auto;white-space:pre-wrap;';
+            marker.textContent = '🔴 AI-CHAT DEBUG REPORT (tap to dismiss)\n' + report;
+            marker.addEventListener('click', () => marker.remove());
+            document.body.appendChild(marker);
+        } catch (_) {}
+    }
+
+    dbg('=== ai-chat.js IIFE executing ===');
+    dbg('typeof AndroidBridge: ' + (typeof AndroidBridge));
+    dbg('UA: ' + (navigator.userAgent || '').substring(0, 250));
+    dbg('Location: ' + window.location.href);
+    dbg('typeof currentUser: ' + (typeof window.currentUser));
 
     const STORAGE_KEY = 'eclaw_ai_chat_history';
     const PENDING_KEY = 'eclaw_ai_chat_pending';
@@ -142,8 +194,7 @@
 
     // ── Build DOM ─────────────────────────────
     function createWidget() {
-        console.log('[AI Chat DEBUG] createWidget() called');
-        console.log('[AI Chat DEBUG] Stack trace:', new Error().stack);
+        dbg('createWidget() called');
         // FAB
         const fab = document.createElement('button');
         fab.id = 'aiChatFab';
@@ -758,59 +809,54 @@
         const hasBridge = typeof AndroidBridge !== 'undefined';
         const ua = navigator.userAgent || '';
         const hasUaTag = /EClawAndroid/i.test(ua);
-        // Additional heuristics: Android WebView typically includes 'wv' in UA
         const hasWv = /\bwv\b/.test(ua);
         const hasAndroid = /Android/i.test(ua);
         const result = hasBridge || hasUaTag;
-        console.log('[AI Chat DEBUG] isAndroidWebView():', result,
-            '| hasBridge:', hasBridge,
-            '| hasUaTag:', hasUaTag,
-            '| hasWv:', hasWv,
-            '| hasAndroid:', hasAndroid,
-            '| UA:', ua.substring(0, 200));
+        dbg('isAndroidWebView()=' + result + ' | bridge=' + hasBridge + ' uaTag=' + hasUaTag + ' wv=' + hasWv + ' android=' + hasAndroid);
         return result;
     }
 
     function init() {
-        console.log('[AI Chat DEBUG] init() called at', new Date().toISOString());
-        console.log('[AI Chat DEBUG] document.readyState:', document.readyState);
-        console.log('[AI Chat DEBUG] window.AndroidBridge type:', typeof AndroidBridge);
-        console.log('[AI Chat DEBUG] navigator.userAgent:', navigator.userAgent);
+        dbg('init() called readyState=' + document.readyState);
+        dbg('typeof AndroidBridge=' + (typeof AndroidBridge));
 
         // Skip AI chat widget in Android WebView — the app has its own AI chat
         if (isAndroidWebView()) {
-            console.log('[AI Chat DEBUG] ✅ BLOCKED at init() — Android WebView detected, widget will NOT load');
+            dbg('BLOCKED at init() — WebView detected');
+            flushDebugToServer();
             return;
         }
-        console.log('[AI Chat DEBUG] ❌ NOT blocked at init() — proceeding to wait for currentUser');
+        dbg('NOT blocked at init() — waiting for currentUser');
 
         let checkCount = 0;
         const check = setInterval(() => {
             checkCount++;
             if (window.currentUser) {
                 clearInterval(check);
-                console.log('[AI Chat DEBUG] currentUser found after', checkCount, 'checks (' + (checkCount * 200) + 'ms)');
-                console.log('[AI Chat DEBUG] Re-checking isAndroidWebView before createWidget...');
+                dbg('currentUser found after ' + checkCount + ' checks (' + (checkCount * 200) + 'ms)');
+                dbg('Re-checking isAndroidWebView...');
                 if (isAndroidWebView()) {
-                    console.log('[AI Chat DEBUG] ✅ BLOCKED at currentUser check — Android WebView detected late');
+                    dbg('BLOCKED at currentUser check — late WebView detect');
+                    flushDebugToServer();
                     return;
                 }
-                console.log('[AI Chat DEBUG] ❌ NOT blocked at currentUser check — creating widget NOW');
-                console.log('[AI Chat DEBUG] Existing #aiChatFab:', !!document.getElementById('aiChatFab'));
-                console.log('[AI Chat DEBUG] Existing #aiChatPanel:', !!document.getElementById('aiChatPanel'));
+                dbg('NOT blocked — creating widget. Existing fab=' + !!document.getElementById('aiChatFab'));
                 loadHistory();
                 createWidget();
-                console.log('[AI Chat DEBUG] Widget created. #aiChatFab:', !!document.getElementById('aiChatFab'));
+                dbg('Widget created. fab=' + !!document.getElementById('aiChatFab'));
+                // Flush debug report so we can see it even when widget IS created (the problem case)
+                flushDebugToServer();
                 resumePendingRequest();
             }
             if (checkCount % 25 === 0) {
-                console.log('[AI Chat DEBUG] Still waiting for currentUser... check #' + checkCount);
+                dbg('Still waiting for currentUser... check #' + checkCount);
             }
         }, 200);
         setTimeout(() => {
             clearInterval(check);
             if (checkCount > 0 && !window.currentUser) {
-                console.log('[AI Chat DEBUG] Gave up waiting for currentUser after 10s (' + checkCount + ' checks)');
+                dbg('Gave up waiting for currentUser after 10s');
+                flushDebugToServer();
             }
         }, 10000);
     }


### PR DESCRIPTION
## Summary
- Adds multi-channel debug logging to `ai-chat.js` to diagnose why AI chat widget still appears in Android WebView
- Debug outputs to: red on-screen banner, `/api/device-telemetry` API, `AndroidBridge.log()` for Logcat
- Logs every decision point: IIFE load, `isAndroidWebView()` checks, `init()`, `createWidget()`

## Test plan
- [ ] Open portal page in Android WebView, check for red debug banner
- [ ] Query telemetry API for `ai_chat_debug` entries

https://claude.ai/code/session_01YYwPCFFW98fQWZRzWwbcGd