### PR TITLE
fix(android): use View.generateViewId() in FileManagerActivity

### DIFF
--- a/app/src/main/java/com/hank/clawlive/FileManagerActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/FileManagerActivity.kt
@@ -576,7 +576,7 @@ class FileManagerActivity : AppCompatActivity() {
                 isCheckable = true
                 isCloseIconVisible = true
                 setOnCloseIconClickListener { showDeleteFolderDialog(folder) }
-                chipGroupFolder.generateViewId().also { id = it }
+                View.generateViewId().also { id = it }
             }
             chipGroupFolder.addView(chip)
         }


### PR DESCRIPTION
## Summary
- Fix `generateViewId()` unresolved reference: it's a static method on `View`, not on `ChipGroup`
- Fixes Android CI compilation failure from #417

https://claude.ai/code/session_01JgEaki2zVSKYREdgoVxK4z