### PR TITLE
fix: block duplicate AI chat widget in Android WebView (#419)

### DIFF
--- a/backend/public/portal/admin.html
+++ b/backend/public/portal/admin.html
@@ -852,7 +852,18 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script src="shared/ai-chat.js"></script>
+    <script>
+    // Block AI chat widget in Android WebView (native app has its own AI chat)
+    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
+        window.__blockAiChatWidget = true;
+        new MutationObserver(function(m, obs) {
+            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
+            if (f) f.remove(); if (p) p.remove();
+            if (f || p) obs.disconnect();
+        }).observe(document.documentElement, { childList: true, subtree: true });
+    }
+    </script>
+    <script src="shared/ai-chat.js?v=419"></script>
     <script>
         let statsData = null;
         let bindingsData = null;

--- a/backend/public/portal/card-holder.html
+++ b/backend/public/portal/card-holder.html
@@ -614,7 +614,18 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script src="shared/ai-chat.js"></script>
+    <script>
+    // Block AI chat widget in Android WebView (native app has its own AI chat)
+    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
+        window.__blockAiChatWidget = true;
+        new MutationObserver(function(m, obs) {
+            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
+            if (f) f.remove(); if (p) p.remove();
+            if (f || p) obs.disconnect();
+        }).observe(document.documentElement, { childList: true, subtree: true });
+    }
+    </script>
+    <script src="shared/ai-chat.js?v=419"></script>
     <script>
         // ── State ──
         let myCards = [];

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -1081,7 +1081,18 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script src="shared/ai-chat.js"></script>
+    <script>
+    // Block AI chat widget in Android WebView (native app has its own AI chat)
+    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
+        window.__blockAiChatWidget = true;
+        new MutationObserver(function(m, obs) {
+            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
+            if (f) f.remove(); if (p) p.remove();
+            if (f || p) obs.disconnect();
+        }).observe(document.documentElement, { childList: true, subtree: true });
+    }
+    </script>
+    <script src="shared/ai-chat.js?v=419"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script>
         // ── State ──

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -1302,7 +1302,18 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script src="shared/ai-chat.js"></script>
+    <script>
+    // Block AI chat widget in Android WebView (native app has its own AI chat)
+    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
+        window.__blockAiChatWidget = true;
+        new MutationObserver(function(m, obs) {
+            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
+            if (f) f.remove(); if (p) p.remove();
+            if (f || p) obs.disconnect();
+        }).observe(document.documentElement, { childList: true, subtree: true });
+    }
+    </script>
+    <script src="shared/ai-chat.js?v=419"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script>
         // --- Constants ---

--- a/backend/public/portal/env-vars.html
+++ b/backend/public/portal/env-vars.html
@@ -312,7 +312,18 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script src="shared/ai-chat.js"></script>
+    <script>
+    // Block AI chat widget in Android WebView (native app has its own AI chat)
+    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
+        window.__blockAiChatWidget = true;
+        new MutationObserver(function(m, obs) {
+            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
+            if (f) f.remove(); if (p) p.remove();
+            if (f || p) obs.disconnect();
+        }).observe(document.documentElement, { childList: true, subtree: true });
+    }
+    </script>
+    <script src="shared/ai-chat.js?v=419"></script>
     <script>
         function esc(s) {
             const d = document.createElement('div');

--- a/backend/public/portal/feedback.html
+++ b/backend/public/portal/feedback.html
@@ -770,7 +770,18 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script src="shared/ai-chat.js"></script>
+    <script>
+    // Block AI chat widget in Android WebView (native app has its own AI chat)
+    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
+        window.__blockAiChatWidget = true;
+        new MutationObserver(function(m, obs) {
+            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
+            if (f) f.remove(); if (p) p.remove();
+            if (f || p) obs.disconnect();
+        }).observe(document.documentElement, { childList: true, subtree: true });
+    }
+    </script>
+    <script src="shared/ai-chat.js?v=419"></script>
 
     <script>
         let allFeedback = [];

--- a/backend/public/portal/files.html
+++ b/backend/public/portal/files.html
@@ -510,7 +510,18 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script src="shared/ai-chat.js"></script>
+    <script>
+    // Block AI chat widget in Android WebView (native app has its own AI chat)
+    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
+        window.__blockAiChatWidget = true;
+        new MutationObserver(function(m, obs) {
+            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
+            if (f) f.remove(); if (p) p.remove();
+            if (f || p) obs.disconnect();
+        }).observe(document.documentElement, { childList: true, subtree: true });
+    }
+    </script>
+    <script src="shared/ai-chat.js?v=419"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script>
         // ENTITY_CHARS_DEFAULT, getAvatarForEntity, getEntityDisplayName, getEntityLabel

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -867,7 +867,18 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script src="shared/ai-chat.js"></script>
+    <script>
+    // Block AI chat widget in Android WebView (native app has its own AI chat)
+    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
+        window.__blockAiChatWidget = true;
+        new MutationObserver(function(m, obs) {
+            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
+            if (f) f.remove(); if (p) p.remove();
+            if (f || p) obs.disconnect();
+        }).observe(document.documentElement, { childList: true, subtree: true });
+    }
+    </script>
+    <script src="shared/ai-chat.js?v=419"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script>
         // --- State ---

--- a/backend/public/portal/schedule.html
+++ b/backend/public/portal/schedule.html
@@ -456,7 +456,18 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script src="shared/ai-chat.js"></script>
+    <script>
+    // Block AI chat widget in Android WebView (native app has its own AI chat)
+    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
+        window.__blockAiChatWidget = true;
+        new MutationObserver(function(m, obs) {
+            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
+            if (f) f.remove(); if (p) p.remove();
+            if (f || p) obs.disconnect();
+        }).observe(document.documentElement, { childList: true, subtree: true });
+    }
+    </script>
+    <script src="shared/ai-chat.js?v=419"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script>
         // ── State ──

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -911,7 +911,18 @@
     <script src="../shared/entity-utils.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script src="shared/ai-chat.js"></script>
+    <script>
+    // Block AI chat widget in Android WebView (native app has its own AI chat)
+    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
+        window.__blockAiChatWidget = true;
+        new MutationObserver(function(m, obs) {
+            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
+            if (f) f.remove(); if (p) p.remove();
+            if (f || p) obs.disconnect();
+        }).observe(document.documentElement, { childList: true, subtree: true });
+    }
+    </script>
+    <script src="shared/ai-chat.js?v=419"></script>
 
     <script>
         let tappayReady = false;

--- a/backend/public/portal/shared/ai-chat.js
+++ b/backend/public/portal/shared/ai-chat.js
@@ -59,6 +59,13 @@
         } catch (_) {}
     }
 
+    // Early exit if inline guard already detected Android WebView
+    if (window.__blockAiChatWidget) {
+        dbg('=== ai-chat.js BLOCKED by inline guard ===');
+        flushDebugToServer();
+        return;
+    }
+
     dbg('=== ai-chat.js IIFE executing ===');
     dbg('typeof AndroidBridge: ' + (typeof AndroidBridge));
     dbg('UA: ' + (navigator.userAgent || '').substring(0, 250));

--- a/backend/tests/jest/ai-chat-widget-guard.test.js
+++ b/backend/tests/jest/ai-chat-widget-guard.test.js
@@ -1,0 +1,102 @@
+/**
+ * AI Chat Widget Guard — static analysis (Jest)
+ *
+ * Verifies that all portal pages including ai-chat.js have the inline
+ * Android WebView guard to prevent duplicate AI chat widgets.
+ * Issue: #419 (duplicate AI service in Android WebView)
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PORTAL_DIR = path.resolve(__dirname, '../../public/portal');
+const AI_CHAT_JS = path.resolve(__dirname, '../../public/portal/shared/ai-chat.js');
+
+// Pages that include ai-chat.js
+const PAGES_WITH_AI_CHAT = [
+    'admin.html',
+    'card-holder.html',
+    'chat.html',
+    'dashboard.html',
+    'env-vars.html',
+    'feedback.html',
+    'files.html',
+    'mission.html',
+    'schedule.html',
+    'settings.html',
+];
+
+describe('AI Chat Widget WebView Guard (#419)', () => {
+    const pageContents = {};
+
+    beforeAll(() => {
+        for (const page of PAGES_WITH_AI_CHAT) {
+            const filePath = path.join(PORTAL_DIR, page);
+            if (fs.existsSync(filePath)) {
+                pageContents[page] = fs.readFileSync(filePath, 'utf-8');
+            }
+        }
+    });
+
+    test('all ai-chat pages have inline WebView guard script', () => {
+        for (const page of PAGES_WITH_AI_CHAT) {
+            const content = pageContents[page];
+            expect(content).toBeDefined();
+            // Guard must set __blockAiChatWidget before ai-chat.js loads
+            expect(content).toMatch(/window\.__blockAiChatWidget\s*=\s*true/);
+        }
+    });
+
+    test('inline guard appears BEFORE ai-chat.js script tag', () => {
+        for (const page of PAGES_WITH_AI_CHAT) {
+            const content = pageContents[page];
+            const guardIdx = content.indexOf('__blockAiChatWidget');
+            const scriptIdx = content.indexOf('ai-chat.js');
+            expect(guardIdx).toBeGreaterThan(-1);
+            expect(scriptIdx).toBeGreaterThan(-1);
+            expect(guardIdx).toBeLessThan(scriptIdx);
+        }
+    });
+
+    test('inline guard detects AndroidBridge', () => {
+        for (const page of PAGES_WITH_AI_CHAT) {
+            const content = pageContents[page];
+            expect(content).toMatch(/typeof AndroidBridge/);
+        }
+    });
+
+    test('inline guard detects EClawAndroid user agent', () => {
+        for (const page of PAGES_WITH_AI_CHAT) {
+            const content = pageContents[page];
+            expect(content).toMatch(/EClawAndroid/);
+        }
+    });
+
+    test('inline guard includes MutationObserver fallback for cached ai-chat.js', () => {
+        for (const page of PAGES_WITH_AI_CHAT) {
+            const content = pageContents[page];
+            expect(content).toMatch(/MutationObserver/);
+            expect(content).toMatch(/aiChatFab/);
+            expect(content).toMatch(/aiChatPanel/);
+        }
+    });
+
+    test('ai-chat.js has cache-busting query param', () => {
+        for (const page of PAGES_WITH_AI_CHAT) {
+            const content = pageContents[page];
+            expect(content).toMatch(/ai-chat\.js\?v=/);
+        }
+    });
+
+    test('ai-chat.js checks __blockAiChatWidget flag', () => {
+        const aiChatCode = fs.readFileSync(AI_CHAT_JS, 'utf-8');
+        expect(aiChatCode).toMatch(/window\.__blockAiChatWidget/);
+    });
+
+    test('ai-chat.js has isAndroidWebView detection', () => {
+        const aiChatCode = fs.readFileSync(AI_CHAT_JS, 'utf-8');
+        expect(aiChatCode).toMatch(/function isAndroidWebView/);
+        expect(aiChatCode).toMatch(/AndroidBridge/);
+        expect(aiChatCode).toMatch(/EClawAndroid/);
+    });
+});


### PR DESCRIPTION
## Summary
- Fixes #419: AI chat widget appearing in Android WebView alongside native AI chat
- Root cause: Cloudflare CDN overrides `Cache-Control: no-cache` with `max-age=14400`, so Android WebView served old ai-chat.js without WebView detection
- Three-layer fix:
  1. **Inline guard script** on all 10 portal pages: sets `window.__blockAiChatWidget` flag + MutationObserver to remove widget even from cached JS
  2. **ai-chat.js early exit**: checks `__blockAiChatWidget` flag before any initialization
  3. **Cache-busting**: `?v=419` query param forces fresh fetch past CDN cache

## Test plan
- [x] New Jest test `ai-chat-widget-guard.test.js` (8 tests) verifying guard presence on all pages
- [x] All 863 Jest tests pass (51 suites)
- [x] ESLint: 0 errors
- [ ] Manual: open Android app chat → verify no web AI FAB appears

https://claude.ai/code/session_01YYwPCFFW98fQWZRzWwbcGd