### PR TITLE
fix: silent debug + no-store cache for Android WebView (#419)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -340,9 +340,10 @@ app.get('/c/:code', (req, res) => {
 app.use('/mission', express.static(path.join(__dirname, 'public')));
 app.use('/portal', express.static(path.join(__dirname, 'public/portal'), {
     setHeaders: (res, filePath) => {
-        // Prevent CDN from serving stale JS after deploys (fixes entity-utils.js cache mismatch)
-        if (filePath.endsWith('.js')) {
-            res.set('Cache-Control', 'no-cache');
+        // Prevent CDN/WebView from caching stale HTML or JS after deploys
+        // no-store: prohibits any cache (CDN + browser); fixes #419 duplicate AI widget
+        if (filePath.endsWith('.html') || filePath.endsWith('.js')) {
+            res.set('Cache-Control', 'no-store, no-cache, must-revalidate');
         }
     }
 }));

--- a/backend/public/portal/shared/ai-chat.js
+++ b/backend/public/portal/shared/ai-chat.js
@@ -14,19 +14,28 @@
         _debugLogs.push({ t: Date.now(), m: msg });
         try { if (typeof AndroidBridge !== 'undefined') AndroidBridge.log('DEBUG', line); } catch (_) {}
     }
-    // Send collected debug logs to server as a telemetry entry + create GitHub issue
+    // Send collected debug logs silently to telemetry API (no visible UI)
     function flushDebugToServer() {
         if (_debugLogs.length === 0) return;
         const report = _debugLogs.map(l => '[' + new Date(l.t).toISOString() + '] ' + l.m).join('\n');
+        // Collect comprehensive environment snapshot for remote diagnosis
+        var scriptTags = [];
+        try { document.querySelectorAll('script[src]').forEach(function(s) { scriptTags.push(s.src); }); } catch (_) {}
         const payload = {
             type: 'ai_chat_debug',
             data: {
                 report: report,
                 userAgent: navigator.userAgent,
                 url: window.location.href,
+                referrer: document.referrer || '',
                 hasBridge: typeof AndroidBridge !== 'undefined',
+                hasBlockFlag: !!window.__blockAiChatWidget,
                 fabExists: !!document.getElementById('aiChatFab'),
                 panelExists: !!document.getElementById('aiChatPanel'),
+                debugMarkerExists: !!document.getElementById('aiChatDebugMarker'),
+                readyState: document.readyState,
+                scriptTags: scriptTags,
+                cookieLen: (document.cookie || '').length,
                 timestamp: new Date().toISOString()
             }
         };
@@ -48,15 +57,7 @@
                 body: JSON.stringify({ deviceId, deviceSecret, entries: [payload] })
             }).catch(() => {});
         }
-        // Also show a visible marker on the page for quick identification
-        try {
-            const marker = document.createElement('div');
-            marker.id = 'aiChatDebugMarker';
-            marker.style.cssText = 'position:fixed;top:0;left:0;right:0;background:red;color:white;z-index:999999;padding:6px 12px;font-size:12px;font-family:monospace;max-height:40vh;overflow:auto;white-space:pre-wrap;';
-            marker.textContent = '🔴 AI-CHAT DEBUG REPORT (tap to dismiss)\n' + report;
-            marker.addEventListener('click', () => marker.remove());
-            document.body.appendChild(marker);
-        } catch (_) {}
+        // Silent debug — no visible UI elements (telemetry only)
     }
 
     // Early exit if inline guard already detected Android WebView

--- a/backend/tests/jest/ai-chat-widget-guard.test.js
+++ b/backend/tests/jest/ai-chat-widget-guard.test.js
@@ -99,4 +99,19 @@ describe('AI Chat Widget WebView Guard (#419)', () => {
         expect(aiChatCode).toMatch(/AndroidBridge/);
         expect(aiChatCode).toMatch(/EClawAndroid/);
     });
+
+    test('ai-chat.js does NOT have visible debug banner (silent telemetry only)', () => {
+        const aiChatCode = fs.readFileSync(AI_CHAT_JS, 'utf-8');
+        // No visible debug elements — all debugging via silent telemetry API
+        expect(aiChatCode).not.toMatch(/background:\s*red/);
+        expect(aiChatCode).not.toMatch(/AI-CHAT DEBUG REPORT/);
+        expect(aiChatCode).toMatch(/Silent debug/);
+    });
+
+    test('ai-chat.js sends comprehensive debug data via telemetry', () => {
+        const aiChatCode = fs.readFileSync(AI_CHAT_JS, 'utf-8');
+        expect(aiChatCode).toMatch(/hasBlockFlag/);
+        expect(aiChatCode).toMatch(/scriptTags/);
+        expect(aiChatCode).toMatch(/readyState/);
+    });
 });

--- a/backend/tests/jest/health.test.js
+++ b/backend/tests/jest/health.test.js
@@ -238,17 +238,17 @@ describe('GET /', () => {
     });
 });
 
-describe('Portal static JS cache headers', () => {
-    it('sets Cache-Control: no-cache on portal JS files', async () => {
+describe('Portal static cache headers', () => {
+    it('sets Cache-Control: no-store on portal JS files', async () => {
         const res = await request(app).get('/portal/shared/entity-utils.js');
         expect(res.status).toBe(200);
-        expect(res.headers['cache-control']).toBe('no-cache');
+        expect(res.headers['cache-control']).toMatch(/no-store/);
     });
 
-    it('does not set no-cache on portal HTML files', async () => {
+    it('sets Cache-Control: no-store on portal HTML files', async () => {
         const res = await request(app).get('/portal/index.html');
         expect(res.status).toBe(200);
-        // HTML should not have no-cache (only JS gets it)
-        expect(res.headers['cache-control']).not.toBe('no-cache');
+        // HTML also needs no-store to prevent Android WebView caching stale pages (#419)
+        expect(res.headers['cache-control']).toMatch(/no-store/);
     });
 });


### PR DESCRIPTION
## Summary
- Removes intrusive red debug banner — all diagnostics now sent silently via telemetry API
- Changes `Cache-Control` from `no-cache` to `no-store` for both HTML and JS under `/portal/` to defeat Cloudflare CDN + Android WebView caching of stale pages
- Expanded telemetry data: scriptTags, readyState, hasBlockFlag, referrer

## Root cause
Android WebView cached the HTML page itself (not just ai-chat.js), so the inline guard script was never loaded. `no-store` prevents all caching.

## Test plan
- [x] 865/865 Jest tests pass
- [x] ai-chat-widget-guard.test.js: 10 tests (added no-banner + telemetry checks)
- [x] health.test.js: updated cache header expectations
- [ ] Manual: Android app chat page — verify no web AI FAB

https://claude.ai/code/session_01YYwPCFFW98fQWZRzWwbcGd