### PR TITLE
chore: remove AI chat debug instrumentation (#419)

### DIFF
--- a/backend/public/portal/admin.html
+++ b/backend/public/portal/admin.html
@@ -852,18 +852,8 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script>
-    // Block AI chat widget in Android WebView (native app has its own AI chat)
-    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
-        window.__blockAiChatWidget = true;
-        new MutationObserver(function(m, obs) {
-            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
-            if (f) f.remove(); if (p) p.remove();
-            if (f || p) obs.disconnect();
-        }).observe(document.documentElement, { childList: true, subtree: true });
-    }
-    </script>
-    <script src="shared/ai-chat.js?v=419"></script>
+    <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
+    <script src="shared/ai-chat.js"></script>
     <script>
         let statsData = null;
         let bindingsData = null;

--- a/backend/public/portal/card-holder.html
+++ b/backend/public/portal/card-holder.html
@@ -614,18 +614,8 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script>
-    // Block AI chat widget in Android WebView (native app has its own AI chat)
-    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
-        window.__blockAiChatWidget = true;
-        new MutationObserver(function(m, obs) {
-            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
-            if (f) f.remove(); if (p) p.remove();
-            if (f || p) obs.disconnect();
-        }).observe(document.documentElement, { childList: true, subtree: true });
-    }
-    </script>
-    <script src="shared/ai-chat.js?v=419"></script>
+    <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
+    <script src="shared/ai-chat.js"></script>
     <script>
         // ── State ──
         let myCards = [];

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -1081,18 +1081,8 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script>
-    // Block AI chat widget in Android WebView (native app has its own AI chat)
-    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
-        window.__blockAiChatWidget = true;
-        new MutationObserver(function(m, obs) {
-            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
-            if (f) f.remove(); if (p) p.remove();
-            if (f || p) obs.disconnect();
-        }).observe(document.documentElement, { childList: true, subtree: true });
-    }
-    </script>
-    <script src="shared/ai-chat.js?v=419"></script>
+    <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
+    <script src="shared/ai-chat.js"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script>
         // ── State ──

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -1302,18 +1302,8 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script>
-    // Block AI chat widget in Android WebView (native app has its own AI chat)
-    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
-        window.__blockAiChatWidget = true;
-        new MutationObserver(function(m, obs) {
-            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
-            if (f) f.remove(); if (p) p.remove();
-            if (f || p) obs.disconnect();
-        }).observe(document.documentElement, { childList: true, subtree: true });
-    }
-    </script>
-    <script src="shared/ai-chat.js?v=419"></script>
+    <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
+    <script src="shared/ai-chat.js"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script>
         // --- Constants ---

--- a/backend/public/portal/env-vars.html
+++ b/backend/public/portal/env-vars.html
@@ -312,18 +312,8 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script>
-    // Block AI chat widget in Android WebView (native app has its own AI chat)
-    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
-        window.__blockAiChatWidget = true;
-        new MutationObserver(function(m, obs) {
-            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
-            if (f) f.remove(); if (p) p.remove();
-            if (f || p) obs.disconnect();
-        }).observe(document.documentElement, { childList: true, subtree: true });
-    }
-    </script>
-    <script src="shared/ai-chat.js?v=419"></script>
+    <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
+    <script src="shared/ai-chat.js"></script>
     <script>
         function esc(s) {
             const d = document.createElement('div');

--- a/backend/public/portal/feedback.html
+++ b/backend/public/portal/feedback.html
@@ -770,18 +770,8 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script>
-    // Block AI chat widget in Android WebView (native app has its own AI chat)
-    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
-        window.__blockAiChatWidget = true;
-        new MutationObserver(function(m, obs) {
-            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
-            if (f) f.remove(); if (p) p.remove();
-            if (f || p) obs.disconnect();
-        }).observe(document.documentElement, { childList: true, subtree: true });
-    }
-    </script>
-    <script src="shared/ai-chat.js?v=419"></script>
+    <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
+    <script src="shared/ai-chat.js"></script>
 
     <script>
         let allFeedback = [];

--- a/backend/public/portal/files.html
+++ b/backend/public/portal/files.html
@@ -510,18 +510,8 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script>
-    // Block AI chat widget in Android WebView (native app has its own AI chat)
-    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
-        window.__blockAiChatWidget = true;
-        new MutationObserver(function(m, obs) {
-            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
-            if (f) f.remove(); if (p) p.remove();
-            if (f || p) obs.disconnect();
-        }).observe(document.documentElement, { childList: true, subtree: true });
-    }
-    </script>
-    <script src="shared/ai-chat.js?v=419"></script>
+    <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
+    <script src="shared/ai-chat.js"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script>
         // ENTITY_CHARS_DEFAULT, getAvatarForEntity, getEntityDisplayName, getEntityLabel

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -867,18 +867,8 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script>
-    // Block AI chat widget in Android WebView (native app has its own AI chat)
-    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
-        window.__blockAiChatWidget = true;
-        new MutationObserver(function(m, obs) {
-            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
-            if (f) f.remove(); if (p) p.remove();
-            if (f || p) obs.disconnect();
-        }).observe(document.documentElement, { childList: true, subtree: true });
-    }
-    </script>
-    <script src="shared/ai-chat.js?v=419"></script>
+    <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
+    <script src="shared/ai-chat.js"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script>
         // --- State ---

--- a/backend/public/portal/schedule.html
+++ b/backend/public/portal/schedule.html
@@ -456,18 +456,8 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script>
-    // Block AI chat widget in Android WebView (native app has its own AI chat)
-    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
-        window.__blockAiChatWidget = true;
-        new MutationObserver(function(m, obs) {
-            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
-            if (f) f.remove(); if (p) p.remove();
-            if (f || p) obs.disconnect();
-        }).observe(document.documentElement, { childList: true, subtree: true });
-    }
-    </script>
-    <script src="shared/ai-chat.js?v=419"></script>
+    <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
+    <script src="shared/ai-chat.js"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script>
         // ── State ──

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -911,18 +911,8 @@
     <script src="../shared/entity-utils.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
-    <script>
-    // Block AI chat widget in Android WebView (native app has its own AI chat)
-    if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) {
-        window.__blockAiChatWidget = true;
-        new MutationObserver(function(m, obs) {
-            var f = document.getElementById('aiChatFab'), p = document.getElementById('aiChatPanel');
-            if (f) f.remove(); if (p) p.remove();
-            if (f || p) obs.disconnect();
-        }).observe(document.documentElement, { childList: true, subtree: true });
-    }
-    </script>
-    <script src="shared/ai-chat.js?v=419"></script>
+    <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
+    <script src="shared/ai-chat.js"></script>
 
     <script>
         let tappayReady = false;

--- a/backend/public/portal/shared/ai-chat.js
+++ b/backend/public/portal/shared/ai-chat.js
@@ -6,72 +6,8 @@
 (function () {
     'use strict';
 
-    // ── Debug helper: logs to console + AndroidBridge.log + collects for API report ──
-    const _debugLogs = [];
-    function dbg(msg) {
-        const line = '[AI Chat DBG] ' + msg;
-        console.log(line);
-        _debugLogs.push({ t: Date.now(), m: msg });
-        try { if (typeof AndroidBridge !== 'undefined') AndroidBridge.log('DEBUG', line); } catch (_) {}
-    }
-    // Send collected debug logs silently to telemetry API (no visible UI)
-    function flushDebugToServer() {
-        if (_debugLogs.length === 0) return;
-        const report = _debugLogs.map(l => '[' + new Date(l.t).toISOString() + '] ' + l.m).join('\n');
-        // Collect comprehensive environment snapshot for remote diagnosis
-        var scriptTags = [];
-        try { document.querySelectorAll('script[src]').forEach(function(s) { scriptTags.push(s.src); }); } catch (_) {}
-        const payload = {
-            type: 'ai_chat_debug',
-            data: {
-                report: report,
-                userAgent: navigator.userAgent,
-                url: window.location.href,
-                referrer: document.referrer || '',
-                hasBridge: typeof AndroidBridge !== 'undefined',
-                hasBlockFlag: !!window.__blockAiChatWidget,
-                fabExists: !!document.getElementById('aiChatFab'),
-                panelExists: !!document.getElementById('aiChatPanel'),
-                debugMarkerExists: !!document.getElementById('aiChatDebugMarker'),
-                readyState: document.readyState,
-                scriptTags: scriptTags,
-                cookieLen: (document.cookie || '').length,
-                timestamp: new Date().toISOString()
-            }
-        };
-        // Send via telemetry API (needs deviceId/deviceSecret from currentUser or AndroidBridge)
-        let deviceId, deviceSecret;
-        try {
-            if (typeof AndroidBridge !== 'undefined') {
-                deviceId = AndroidBridge.getDeviceId();
-                deviceSecret = AndroidBridge.getDeviceSecret();
-            } else if (window.currentUser) {
-                deviceId = window.currentUser.deviceId;
-                deviceSecret = window.currentUser.deviceSecret;
-            }
-        } catch (_) {}
-        if (deviceId && deviceSecret) {
-            fetch('/api/device-telemetry', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ deviceId, deviceSecret, entries: [payload] })
-            }).catch(() => {});
-        }
-        // Silent debug — no visible UI elements (telemetry only)
-    }
-
-    // Early exit if inline guard already detected Android WebView
-    if (window.__blockAiChatWidget) {
-        dbg('=== ai-chat.js BLOCKED by inline guard ===');
-        flushDebugToServer();
-        return;
-    }
-
-    dbg('=== ai-chat.js IIFE executing ===');
-    dbg('typeof AndroidBridge: ' + (typeof AndroidBridge));
-    dbg('UA: ' + (navigator.userAgent || '').substring(0, 250));
-    dbg('Location: ' + window.location.href);
-    dbg('typeof currentUser: ' + (typeof window.currentUser));
+    // Skip if inline guard already blocked (Android WebView detected before this script loaded)
+    if (window.__blockAiChatWidget) return;
 
     const STORAGE_KEY = 'eclaw_ai_chat_history';
     const PENDING_KEY = 'eclaw_ai_chat_pending';
@@ -814,59 +750,25 @@
 
     // ── Init ──────────────────────────────────
     function isAndroidWebView() {
-        const hasBridge = typeof AndroidBridge !== 'undefined';
-        const ua = navigator.userAgent || '';
-        const hasUaTag = /EClawAndroid/i.test(ua);
-        const hasWv = /\bwv\b/.test(ua);
-        const hasAndroid = /Android/i.test(ua);
-        const result = hasBridge || hasUaTag;
-        dbg('isAndroidWebView()=' + result + ' | bridge=' + hasBridge + ' uaTag=' + hasUaTag + ' wv=' + hasWv + ' android=' + hasAndroid);
-        return result;
+        return typeof AndroidBridge !== 'undefined' || /EClawAndroid/i.test(navigator.userAgent || '');
     }
 
     function init() {
-        dbg('init() called readyState=' + document.readyState);
-        dbg('typeof AndroidBridge=' + (typeof AndroidBridge));
-
         // Skip AI chat widget in Android WebView — the app has its own AI chat
-        if (isAndroidWebView()) {
-            dbg('BLOCKED at init() — WebView detected');
-            flushDebugToServer();
-            return;
-        }
-        dbg('NOT blocked at init() — waiting for currentUser');
+        if (isAndroidWebView()) return;
 
         let checkCount = 0;
         const check = setInterval(() => {
             checkCount++;
             if (window.currentUser) {
                 clearInterval(check);
-                dbg('currentUser found after ' + checkCount + ' checks (' + (checkCount * 200) + 'ms)');
-                dbg('Re-checking isAndroidWebView...');
-                if (isAndroidWebView()) {
-                    dbg('BLOCKED at currentUser check — late WebView detect');
-                    flushDebugToServer();
-                    return;
-                }
-                dbg('NOT blocked — creating widget. Existing fab=' + !!document.getElementById('aiChatFab'));
+                if (isAndroidWebView()) return; // late-binding bridge check
                 loadHistory();
                 createWidget();
-                dbg('Widget created. fab=' + !!document.getElementById('aiChatFab'));
-                // Flush debug report so we can see it even when widget IS created (the problem case)
-                flushDebugToServer();
                 resumePendingRequest();
             }
-            if (checkCount % 25 === 0) {
-                dbg('Still waiting for currentUser... check #' + checkCount);
-            }
         }, 200);
-        setTimeout(() => {
-            clearInterval(check);
-            if (checkCount > 0 && !window.currentUser) {
-                dbg('Gave up waiting for currentUser after 10s');
-                flushDebugToServer();
-            }
-        }, 10000);
+        setTimeout(() => { clearInterval(check); }, 10000);
     }
 
     // ── Public API ────────────────────────────

--- a/backend/tests/jest/ai-chat-widget-guard.test.js
+++ b/backend/tests/jest/ai-chat-widget-guard.test.js
@@ -12,7 +12,6 @@ const path = require('path');
 const PORTAL_DIR = path.resolve(__dirname, '../../public/portal');
 const AI_CHAT_JS = path.resolve(__dirname, '../../public/portal/shared/ai-chat.js');
 
-// Pages that include ai-chat.js
 const PAGES_WITH_AI_CHAT = [
     'admin.html',
     'card-holder.html',
@@ -38,11 +37,10 @@ describe('AI Chat Widget WebView Guard (#419)', () => {
         }
     });
 
-    test('all ai-chat pages have inline WebView guard script', () => {
+    test('all ai-chat pages have inline WebView guard', () => {
         for (const page of PAGES_WITH_AI_CHAT) {
             const content = pageContents[page];
             expect(content).toBeDefined();
-            // Guard must set __blockAiChatWidget before ai-chat.js loads
             expect(content).toMatch(/window\.__blockAiChatWidget\s*=\s*true/);
         }
     });
@@ -58,60 +56,31 @@ describe('AI Chat Widget WebView Guard (#419)', () => {
         }
     });
 
-    test('inline guard detects AndroidBridge', () => {
+    test('inline guard detects AndroidBridge and EClawAndroid UA', () => {
         for (const page of PAGES_WITH_AI_CHAT) {
             const content = pageContents[page];
             expect(content).toMatch(/typeof AndroidBridge/);
-        }
-    });
-
-    test('inline guard detects EClawAndroid user agent', () => {
-        for (const page of PAGES_WITH_AI_CHAT) {
-            const content = pageContents[page];
             expect(content).toMatch(/EClawAndroid/);
         }
     });
 
-    test('inline guard includes MutationObserver fallback for cached ai-chat.js', () => {
-        for (const page of PAGES_WITH_AI_CHAT) {
-            const content = pageContents[page];
-            expect(content).toMatch(/MutationObserver/);
-            expect(content).toMatch(/aiChatFab/);
-            expect(content).toMatch(/aiChatPanel/);
-        }
-    });
-
-    test('ai-chat.js has cache-busting query param', () => {
-        for (const page of PAGES_WITH_AI_CHAT) {
-            const content = pageContents[page];
-            expect(content).toMatch(/ai-chat\.js\?v=/);
-        }
-    });
-
     test('ai-chat.js checks __blockAiChatWidget flag', () => {
-        const aiChatCode = fs.readFileSync(AI_CHAT_JS, 'utf-8');
-        expect(aiChatCode).toMatch(/window\.__blockAiChatWidget/);
+        const code = fs.readFileSync(AI_CHAT_JS, 'utf-8');
+        expect(code).toMatch(/window\.__blockAiChatWidget/);
     });
 
     test('ai-chat.js has isAndroidWebView detection', () => {
-        const aiChatCode = fs.readFileSync(AI_CHAT_JS, 'utf-8');
-        expect(aiChatCode).toMatch(/function isAndroidWebView/);
-        expect(aiChatCode).toMatch(/AndroidBridge/);
-        expect(aiChatCode).toMatch(/EClawAndroid/);
+        const code = fs.readFileSync(AI_CHAT_JS, 'utf-8');
+        expect(code).toMatch(/function isAndroidWebView/);
+        expect(code).toMatch(/AndroidBridge/);
+        expect(code).toMatch(/EClawAndroid/);
     });
 
-    test('ai-chat.js does NOT have visible debug banner (silent telemetry only)', () => {
-        const aiChatCode = fs.readFileSync(AI_CHAT_JS, 'utf-8');
-        // No visible debug elements — all debugging via silent telemetry API
-        expect(aiChatCode).not.toMatch(/background:\s*red/);
-        expect(aiChatCode).not.toMatch(/AI-CHAT DEBUG REPORT/);
-        expect(aiChatCode).toMatch(/Silent debug/);
-    });
-
-    test('ai-chat.js sends comprehensive debug data via telemetry', () => {
-        const aiChatCode = fs.readFileSync(AI_CHAT_JS, 'utf-8');
-        expect(aiChatCode).toMatch(/hasBlockFlag/);
-        expect(aiChatCode).toMatch(/scriptTags/);
-        expect(aiChatCode).toMatch(/readyState/);
+    test('ai-chat.js has no debug instrumentation', () => {
+        const code = fs.readFileSync(AI_CHAT_JS, 'utf-8');
+        expect(code).not.toMatch(/AI Chat DBG/);
+        expect(code).not.toMatch(/flushDebugToServer/);
+        expect(code).not.toMatch(/background:\s*red/);
+        expect(code).not.toMatch(/_debugLogs/);
     });
 });


### PR DESCRIPTION
## Summary
- Remove all debug code from ai-chat.js (dbg, flushDebugToServer, _debugLogs, telemetry payload)
- Simplify inline guards to one-liners (remove MutationObserver fallback)
- Remove ?v=419 cache-busting param (no-store headers handle this now)
- Net: -229 lines of debug code removed

https://claude.ai/code/session_01YYwPCFFW98fQWZRzWwbcGd