### PR TITLE
fix: chat page auto-refresh on Android WebView foreground (#448)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -1331,6 +1331,19 @@
                 renderSlashSuggestions(savedDraft);
             }
 
+            // Reload messages when page becomes visible (Android WebView background→foreground)
+            let _lastHiddenAt = 0;
+            document.addEventListener('visibilitychange', () => {
+                if (document.visibilityState === 'hidden') {
+                    _lastHiddenAt = Date.now();
+                } else if (document.visibilityState === 'visible' && !isFirstLoad) {
+                    const hiddenMs = Date.now() - _lastHiddenAt;
+                    if (hiddenMs > 10000) { // only if hidden for >10s
+                        loadMessages().catch(() => {});
+                    }
+                }
+            });
+
             // Socket.IO real-time chat handler
             window.onSocketChatMessage = async function(msg) {
                 const exists = allMessages.some(m => m.id === msg.id);

--- a/backend/public/portal/shared/socket.js
+++ b/backend/public/portal/shared/socket.js
@@ -61,6 +61,14 @@ function initPortalSocket() {
     portalSocket.on('connect_error', (err) => {
         console.warn('[Socket] Connect error:', err.message);
     });
+
+    // Reconnect when page becomes visible again (Android WebView background→foreground)
+    document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible' && portalSocket && !portalSocket.connected) {
+            console.log('[Socket] Page visible — reconnecting...');
+            portalSocket.connect();
+        }
+    });
 }
 
 // ============================================


### PR DESCRIPTION
## Summary
- **#448**: Chat page loses Socket.IO connection when Android WebView is backgrounded — messages only visible after app restart

**Root cause**: Android pauses JS execution in background tabs; Socket.IO disconnects and does not recover visibly

**Fix**:
- `socket.js`: add `visibilitychange` listener — when page becomes visible and socket is disconnected, call `portalSocket.connect()`
- `chat.html`: add `visibilitychange` listener — when page becomes visible after >10s hidden, call `loadMessages()` to fetch any missed messages

## Test plan
- [ ] Open chat on Android, background app for 30s, return — new messages should appear without restart
- [ ] Disconnect network, reconnect, open chat — socket should reconnect automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)