### PR TITLE
fix: redirect /info to /portal/info.html for correct asset resolution

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -183,10 +183,9 @@ app.get('/enterprise', (req, res) => {
     res.set('Cache-Control', 'public, max-age=3600');
     res.sendFile(path.join(__dirname, 'public/enterprise.html'));
 });
-// Info Hub page
+// Info Hub page — redirect to /portal/info.html so relative asset paths resolve correctly
 app.get('/info', (req, res) => {
-    res.set('Cache-Control', 'public, max-age=3600');
-    res.sendFile(path.join(__dirname, 'public/portal/info.html'));
+    res.redirect(301, '/portal/info.html');
 });
 
 // ── Enterprise Demo Chat ─────────────────────────────────────


### PR DESCRIPTION
## Problem

`/info` route used `sendFile` to serve `public/portal/info.html` at the `/info` URL path. This caused all relative asset references in info.html (e.g. `shared/style.css`, `shared/public-nav.js`, `shared/i18n.js`) to resolve against `/` instead of `/portal/`, resulting in 404s for CSS, JS, and other assets.

## Fix

Changed `/info` to a `301 redirect` to `/portal/info.html`. This way:
- Browser navigates to `/portal/info.html`
- All relative paths resolve correctly against `/portal/`
- SEO preserved with permanent redirect
- Consistent with how `/portal/info.html` already works directly

## Verified
- `/portal/info.html` serves correctly with all assets loading
- `/enterprise` continues working (enterprise.html is at `public/` root, so relative paths already work)