### PR TITLE
fix: add shared style.css to landing page for nav bar rendering

### DIFF
--- a/backend/public/landing.html
+++ b/backend/public/landing.html
@@ -99,6 +99,7 @@
         ]
     }]
     </script>
+    <link rel="stylesheet" href="portal/shared/style.css">
     <style>
         .sr-only { position: absolute; width: 1px; height: 1px; padding: 0; margin: -1px; overflow: hidden; clip: rect(0,0,0,0); white-space: nowrap; border: 0; }
         * { margin: 0; padding: 0; box-sizing: border-box; }


### PR DESCRIPTION
## Problem

`https://eclawbot.com/` (landing page) 左上角 nav bar 元素垂直堆疊、沒有樣式。

**根因：** `landing.html` 有引入 `public-nav.js` 來渲染 nav，但**沒有引入** `portal/shared/style.css`，所以 `.nav`, `.nav-brand`, `.nav-links` 等 CSS class 全部沒有定義，瀏覽器用預設樣式渲染。

`enterprise.html` 已經有 `<link rel="stylesheet" href="portal/shared/style.css">`，只有 landing page 漏了。

## Fix

在 `landing.html` 的 `<head>` 加入：
```html
<link rel="stylesheet" href="portal/shared/style.css">
```

## Verified
- enterprise.html 已有此 import，表現正常
- 修復後 nav bar 將正確水平排列，與 enterprise/info 頁面一致