### PR TITLE
feat(android): add GPS location support — listen, fetch, report

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -113,6 +113,7 @@ dependencies {
 
     // Facebook Login
     implementation(libs.facebook.login)
+    implementation(libs.play.services.location)
 
     // Unit test dependencies
     testImplementation("junit:junit:4.13.2")

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,8 @@
     <uses-permission android:name="android.permission.CAMERA" />
     <!-- Push notifications (required for Android 13+ / API 33+) -->
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
     <uses-feature android:name="android.hardware.camera" android:required="false" />
     <uses-feature android:name="android.hardware.microphone" android:required="false" />
 

--- a/app/src/main/java/com/hank/clawlive/MainActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/MainActivity.kt
@@ -145,6 +145,9 @@ class MainActivity : AppCompatActivity() {
         // Connect Socket.IO for real-time updates
         com.hank.clawlive.data.remote.SocketManager.connect(this)
 
+        // Listen for location requests from server (Bot requesting device GPS)
+        observeLocationRequests()
+
         // FCM: Create notification channels + request permission (Android 13+)
         ClawFcmService.createChannels(this)
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
@@ -180,6 +183,18 @@ class MainActivity : AppCompatActivity() {
     override fun onPause() {
         super.onPause()
         RecordingIndicatorHelper.detach()
+    }
+
+    private fun observeLocationRequests() {
+        lifecycleScope.launch {
+            com.hank.clawlive.data.remote.SocketManager.locationRequestFlow.collect { json ->
+                val requestId = json.optString("requestId", null)
+                timber.log.Timber.d("[Location] Socket location_request, requestId=$requestId")
+                com.hank.clawlive.location.LocationHelper.fetchAndReportAsync(
+                    applicationContext, requestId
+                )
+            }
+        }
     }
 
     private fun startEntityPolling() {

--- a/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
@@ -515,6 +515,11 @@ interface ClawApiService {
     @GET("api/rule-templates")
     suspend fun getRuleTemplates(): SkillTemplatesResponse
 
+    // ============ Device GPS Location ============
+
+    @POST("api/device/location")
+    suspend fun reportDeviceLocation(@Body body: Map<String, @JvmSuppressWildcards Any>): LocationReportResponse
+
     // ============ Local Variables (device-only vault) ============
 
     @POST("api/device-vars")
@@ -868,4 +873,23 @@ data class CrossDeviceSettingsResponse(
     val success: Boolean,
     val settings: CrossDeviceSettings? = null,
     val message: String? = null
+)
+
+// ============ Device Location Models ============
+
+data class LocationReportResponse(
+    val success: Boolean,
+    val location: DeviceLocation? = null,
+    val error: String? = null
+)
+
+data class DeviceLocation(
+    val latitude: Double,
+    val longitude: Double,
+    val accuracy: Double? = null,
+    val altitude: Double? = null,
+    val speed: Double? = null,
+    val bearing: Double? = null,
+    val provider: String? = null,
+    val updatedAt: Long = 0
 )

--- a/app/src/main/java/com/hank/clawlive/data/remote/SocketManager.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/SocketManager.kt
@@ -38,6 +38,9 @@ object SocketManager {
     private val _controlCommandFlow = MutableSharedFlow<JSONObject>(extraBufferCapacity = 16)
     val controlCommandFlow: SharedFlow<JSONObject> = _controlCommandFlow
 
+    private val _locationRequestFlow = MutableSharedFlow<JSONObject>(extraBufferCapacity = 4)
+    val locationRequestFlow: SharedFlow<JSONObject> = _locationRequestFlow
+
     fun connect(context: Context) {
         if (isInitialized) return
 
@@ -104,6 +107,12 @@ object SocketManager {
                     val json = args.firstOrNull() as? JSONObject ?: return@on
                     Timber.d("[Socket] device:control-command: $json")
                     _controlCommandFlow.tryEmit(json)
+                }
+
+                on("location_request") { args ->
+                    val json = args.firstOrNull() as? JSONObject ?: JSONObject()
+                    Timber.d("[Socket] location_request received: $json")
+                    _locationRequestFlow.tryEmit(json)
                 }
 
                 connect()

--- a/app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt
+++ b/app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt
@@ -16,6 +16,7 @@ import com.hank.clawlive.MainActivity
 import com.hank.clawlive.R
 import com.hank.clawlive.data.local.DeviceManager
 import com.hank.clawlive.data.remote.NetworkModule
+import com.hank.clawlive.location.LocationHelper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -63,6 +64,17 @@ class ClawFcmService : FirebaseMessagingService() {
 
     override fun onMessageReceived(message: RemoteMessage) {
         val data = message.data
+
+        // Handle location request silently — no notification, just fetch and report GPS
+        if (data["type"] == "location_request" || data["category"] == "location_request") {
+            val requestId = try {
+                org.json.JSONObject(data["metadata"] ?: "{}").optString("requestId", null)
+            } catch (_: Exception) { null }
+            Timber.d("[FCM] Location request received, requestId=$requestId")
+            LocationHelper.fetchAndReportAsync(applicationContext, requestId)
+            return
+        }
+
         val title = data["title"] ?: message.notification?.title ?: "E-Claw"
         val body = data["body"] ?: message.notification?.body ?: ""
         val category = data["category"] ?: "system"

--- a/app/src/main/java/com/hank/clawlive/location/LocationHelper.kt
+++ b/app/src/main/java/com/hank/clawlive/location/LocationHelper.kt
@@ -1,0 +1,158 @@
+package com.hank.clawlive.location
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Looper
+import androidx.core.content.ContextCompat
+import com.google.android.gms.location.*
+import com.hank.clawlive.data.local.DeviceManager
+import com.hank.clawlive.data.remote.NetworkModule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withTimeoutOrNull
+import timber.log.Timber
+import kotlin.coroutines.resume
+
+/**
+ * Helper to fetch GPS location and report it to the EClaw backend.
+ *
+ * Flow:
+ *   1. Server sends Socket.IO "location_request" or FCM push
+ *   2. App calls LocationHelper.fetchAndReport(context, requestId)
+ *   3. Helper gets GPS via FusedLocationProvider
+ *   4. POSTs coordinates to /api/device/location
+ */
+object LocationHelper {
+
+    private const val TIMEOUT_MS = 15_000L
+
+    /**
+     * Check if location permission is granted.
+     */
+    fun hasLocationPermission(context: Context): Boolean {
+        return ContextCompat.checkSelfPermission(
+            context, Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED ||
+        ContextCompat.checkSelfPermission(
+            context, Manifest.permission.ACCESS_COARSE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+
+    /**
+     * Fetch current GPS location and POST to backend.
+     * Call from coroutine scope (e.g. Dispatchers.IO).
+     * Returns true if successfully reported.
+     */
+    suspend fun fetchAndReport(context: Context, requestId: String? = null): Boolean {
+        if (!hasLocationPermission(context)) {
+            Timber.w("[Location] No location permission")
+            return false
+        }
+
+        val location = getCurrentLocation(context)
+        if (location == null) {
+            Timber.w("[Location] Failed to get location within timeout")
+            return false
+        }
+
+        return reportLocation(context, location, requestId)
+    }
+
+    /**
+     * Get current location using FusedLocationProviderClient.
+     * Tries last known location first, falls back to fresh request.
+     */
+    @Suppress("MissingPermission")
+    private suspend fun getCurrentLocation(context: Context): android.location.Location? {
+        val client = LocationServices.getFusedLocationProviderClient(context)
+
+        // Try last known location first (fast)
+        val lastKnown = try {
+            suspendCancellableCoroutine<android.location.Location?> { cont ->
+                client.lastLocation
+                    .addOnSuccessListener { loc -> cont.resume(loc) }
+                    .addOnFailureListener { cont.resume(null) }
+            }
+        } catch (e: Exception) {
+            null
+        }
+
+        // If last known is recent enough (< 2 minutes), use it
+        if (lastKnown != null) {
+            val ageMs = System.currentTimeMillis() - lastKnown.time
+            if (ageMs < 120_000) {
+                Timber.d("[Location] Using last known: ${lastKnown.latitude}, ${lastKnown.longitude} (age: ${ageMs/1000}s)")
+                return lastKnown
+            }
+        }
+
+        // Request fresh location
+        return withTimeoutOrNull(TIMEOUT_MS) {
+            suspendCancellableCoroutine<android.location.Location?> { cont ->
+                val request = LocationRequest.Builder(Priority.PRIORITY_HIGH_ACCURACY, 1000)
+                    .setWaitForAccurateLocation(false)
+                    .setMaxUpdates(1)
+                    .setMaxUpdateDelayMillis(5000)
+                    .build()
+
+                val callback = object : LocationCallback() {
+                    override fun onLocationResult(result: LocationResult) {
+                        client.removeLocationUpdates(this)
+                        val loc = result.lastLocation
+                        Timber.d("[Location] Fresh location: ${loc?.latitude}, ${loc?.longitude}")
+                        if (cont.isActive) cont.resume(loc)
+                    }
+                }
+
+                client.requestLocationUpdates(request, callback, Looper.getMainLooper())
+                cont.invokeOnCancellation {
+                    client.removeLocationUpdates(callback)
+                }
+            }
+        }
+    }
+
+    /**
+     * POST location to /api/device/location
+     */
+    private suspend fun reportLocation(
+        context: Context,
+        location: android.location.Location,
+        requestId: String?
+    ): Boolean {
+        val dm = DeviceManager.getInstance(context)
+        val body = mutableMapOf<String, Any>(
+            "deviceId" to dm.deviceId,
+            "deviceSecret" to dm.deviceSecret,
+            "latitude" to location.latitude,
+            "longitude" to location.longitude
+        )
+        if (location.hasAccuracy()) body["accuracy"] = location.accuracy.toDouble()
+        if (location.hasAltitude()) body["altitude"] = location.altitude
+        if (location.hasSpeed()) body["speed"] = location.speed.toDouble()
+        if (location.hasBearing()) body["bearing"] = location.bearing.toDouble()
+        body["provider"] = location.provider ?: "fused"
+        if (requestId != null) body["requestId"] = requestId
+
+        return try {
+            val response = NetworkModule.api.reportDeviceLocation(body)
+            Timber.d("[Location] Reported: ${location.latitude}, ${location.longitude} → ${response.success}")
+            response.success
+        } catch (e: Exception) {
+            Timber.e(e, "[Location] Failed to report location")
+            false
+        }
+    }
+
+    /**
+     * Fire-and-forget: fetch and report in background.
+     */
+    fun fetchAndReportAsync(context: Context, requestId: String? = null) {
+        CoroutineScope(Dispatchers.IO).launch {
+            fetchAndReport(context, requestId)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ googleServices = "4.4.2"
 credentialManager = "1.5.0-beta01"
 googleId = "1.1.1"
 facebookSdk = "17.0.0"
+playServicesLocation = "21.3.0"
 
 [libraries]
 billing = { group = "com.android.billingclient", name = "billing-ktx", version.ref = "billing" }
@@ -67,6 +68,9 @@ google-id = { group = "com.google.android.libraries.identity.googleid", name = "
 
 # Facebook Login
 facebook-login = { group = "com.facebook.android", name = "facebook-login", version.ref = "facebookSdk" }
+
+# Google Play Services Location
+play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Android GPS 定位功能

搭配 PR #477 的 Server API，實作 Android 端 GPS 接收與回報。

### 改動摘要

| 檔案 | 改動 |
|------|------|
| `libs.versions.toml` | 加 play-services-location 21.3.0 |
| `build.gradle.kts` | 加 location 依賴 |
| `AndroidManifest.xml` | 加 FINE/COARSE_LOCATION 權限 |
| `LocationHelper.kt` | **新增** — FusedLocation 取 GPS + 回報 API |
| `SocketManager.kt` | 加 `location_request` 事件監聯 + Flow |
| `MainActivity.kt` | collect locationRequestFlow → 觸發 GPS |
| `ClawFcmService.kt` | 攔截 location_request FCM（靜默處理）|
| `ClawApiService.kt` | 加 `reportDeviceLocation()` + response models |

### 流程
```
Bot POST /api/device/location/request
  → Server 推 Socket.IO location_request + FCM
    → App 收到 → LocationHelper 取 GPS
      → POST /api/device/location 回報
        → Bot GET /api/device/location 讀取
```

### LocationHelper 策略
- 先嘗試 lastKnownLocation（< 2 分鐘有效）
- 否則 FusedLocationProvider 請求新定位（HIGH_ACCURACY）
- 15 秒超時
- 回報 lat/lng/accuracy/altitude/speed/bearing/provider

### 注意
- App 第一次使用需要用戶授權位置權限
- FCM location_request 是靜默處理，不會彈通知