### PR TITLE
feat: add TTS (text-to-speech) API for bot voice commands

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <!-- Required for some devices to keep service alive properly if needed, usually BIND_WALLPAPER handles it -->
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <!-- Photo picker for custom wallpaper background -->
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
@@ -176,6 +177,11 @@
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>
         </service>
+
+        <service
+            android:name=".service.TtsService"
+            android:exported="false"
+            android:foregroundServiceType="mediaPlayback" />
 
         <service
             android:name=".service.ScreenControlService"

--- a/app/src/main/java/com/hank/clawlive/MainActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/MainActivity.kt
@@ -145,6 +145,14 @@ class MainActivity : AppCompatActivity() {
         // Connect Socket.IO for real-time updates
         com.hank.clawlive.data.remote.SocketManager.connect(this)
 
+        // Start TTS foreground service for bot voice commands
+        val ttsIntent = android.content.Intent(this, com.hank.clawlive.service.TtsService::class.java)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            startForegroundService(ttsIntent)
+        } else {
+            startService(ttsIntent)
+        }
+
         // Listen for location requests from server (Bot requesting device GPS)
         observeLocationRequests()
 

--- a/app/src/main/java/com/hank/clawlive/data/remote/SocketManager.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/SocketManager.kt
@@ -38,6 +38,9 @@ object SocketManager {
     private val _controlCommandFlow = MutableSharedFlow<JSONObject>(extraBufferCapacity = 16)
     val controlCommandFlow: SharedFlow<JSONObject> = _controlCommandFlow
 
+    private val _ttsFlow = MutableSharedFlow<JSONObject>(extraBufferCapacity = 8)
+    val ttsFlow: SharedFlow<JSONObject> = _ttsFlow
+
     private val _locationRequestFlow = MutableSharedFlow<JSONObject>(extraBufferCapacity = 4)
     val locationRequestFlow: SharedFlow<JSONObject> = _locationRequestFlow
 
@@ -107,6 +110,12 @@ object SocketManager {
                     val json = args.firstOrNull() as? JSONObject ?: return@on
                     Timber.d("[Socket] device:control-command: $json")
                     _controlCommandFlow.tryEmit(json)
+                }
+
+                on("device:tts") { args ->
+                    val json = args.firstOrNull() as? JSONObject ?: return@on
+                    Timber.d("[Socket] device:tts: $json")
+                    _ttsFlow.tryEmit(json)
                 }
 
                 on("location_request") { args ->

--- a/app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt
+++ b/app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt
@@ -79,6 +79,20 @@ class ClawFcmService : FirebaseMessagingService() {
         val body = data["body"] ?: message.notification?.body ?: ""
         val category = data["category"] ?: "system"
 
+        // TTS category: start TtsService to speak aloud instead of showing notification
+        if (category == "tts") {
+            val ttsIntent = Intent(this, com.hank.clawlive.service.TtsService::class.java).apply {
+                putExtra("tts_text", body)
+                putExtra("tts_entity_name", title)
+            }
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                startForegroundService(ttsIntent)
+            } else {
+                startService(ttsIntent)
+            }
+            return  // Don't show a notification for TTS
+        }
+
         val channelId = when (category) {
             "bot_reply", "broadcast", "speak_to" -> CHANNEL_CHAT
             "feedback_reply", "feedback_resolved" -> CHANNEL_FEEDBACK

--- a/app/src/main/java/com/hank/clawlive/service/TtsService.kt
+++ b/app/src/main/java/com/hank/clawlive/service/TtsService.kt
@@ -1,0 +1,194 @@
+package com.hank.clawlive.service
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.Service
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import android.speech.tts.TextToSpeech
+import android.speech.tts.UtteranceProgressListener
+import androidx.core.app.NotificationCompat
+import com.hank.clawlive.R
+import com.hank.clawlive.data.remote.SocketManager
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
+import timber.log.Timber
+import java.util.Locale
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Foreground service that listens to Socket.IO TTS events and speaks text aloud
+ * using Android's built-in TextToSpeech engine. Works even when the app is in background.
+ *
+ * Receives JSON via SocketManager.ttsFlow:
+ *   { "text": "...", "lang": "zh-TW", "speed": 1.0, "pitch": 1.0, "entityId": 0, "entityName": "Bot" }
+ */
+class TtsService : Service(), TextToSpeech.OnInitListener {
+
+    companion object {
+        private const val CHANNEL_ID = "eclaw_tts"
+        private const val NOTIFICATION_ID = 9001
+    }
+
+    private var tts: TextToSpeech? = null
+    private var ttsReady = false
+    private val serviceScope = CoroutineScope(Dispatchers.Main + SupervisorJob())
+    private val utteranceCounter = AtomicInteger(0)
+
+    override fun onCreate() {
+        super.onCreate()
+        Timber.d("[TTS] Service created")
+        createNotificationChannel()
+        startForeground(NOTIFICATION_ID, buildNotification("TTS 語音服務就緒"))
+        tts = TextToSpeech(this, this)
+        observeTtsFlow()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        // Handle FCM fallback: when the app receives an FCM with category=tts,
+        // it can start this service with extras
+        intent?.getStringExtra("tts_text")?.let { text ->
+            val lang = intent.getStringExtra("tts_lang") ?: "zh-TW"
+            val speed = intent.getFloatExtra("tts_speed", 1.0f)
+            val pitch = intent.getFloatExtra("tts_pitch", 1.0f)
+            val entityName = intent.getStringExtra("tts_entity_name") ?: "Bot"
+            speak(text, lang, speed, pitch, entityName)
+        }
+        return START_STICKY
+    }
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onInit(status: Int) {
+        if (status == TextToSpeech.SUCCESS) {
+            ttsReady = true
+            // Default to Traditional Chinese
+            val result = tts?.setLanguage(Locale.TRADITIONAL_CHINESE)
+            if (result == TextToSpeech.LANG_MISSING_DATA || result == TextToSpeech.LANG_NOT_SUPPORTED) {
+                Timber.w("[TTS] zh-TW not available, falling back to default")
+            }
+            tts?.setOnUtteranceProgressListener(object : UtteranceProgressListener() {
+                override fun onStart(utteranceId: String?) {
+                    Timber.d("[TTS] Speaking: $utteranceId")
+                }
+                override fun onDone(utteranceId: String?) {
+                    Timber.d("[TTS] Done: $utteranceId")
+                }
+                @Deprecated("Deprecated in Java")
+                override fun onError(utteranceId: String?) {
+                    Timber.e("[TTS] Error: $utteranceId")
+                }
+            })
+            Timber.d("[TTS] Engine initialized successfully")
+        } else {
+            Timber.e("[TTS] Engine initialization failed with status: $status")
+        }
+    }
+
+    private fun observeTtsFlow() {
+        serviceScope.launch {
+            SocketManager.ttsFlow.collect { json ->
+                val text = json.optString("text", "")
+                val lang = json.optString("lang", "zh-TW")
+                val speed = json.optDouble("speed", 1.0).toFloat()
+                val pitch = json.optDouble("pitch", 1.0).toFloat()
+                val entityName = json.optString("entityName", "Bot")
+                if (text.isNotEmpty()) {
+                    speak(text, lang, speed, pitch, entityName)
+                }
+            }
+        }
+    }
+
+    private fun speak(text: String, lang: String, speed: Float, pitch: Float, entityName: String) {
+        val engine = tts
+        if (engine == null || !ttsReady) {
+            Timber.w("[TTS] Engine not ready, dropping: $text")
+            return
+        }
+
+        // Set language
+        val locale = parseLocale(lang)
+        val langResult = engine.setLanguage(locale)
+        if (langResult == TextToSpeech.LANG_MISSING_DATA || langResult == TextToSpeech.LANG_NOT_SUPPORTED) {
+            Timber.w("[TTS] Language $lang not supported, using default")
+        }
+
+        // Set speed and pitch
+        engine.setSpeechRate(speed.coerceIn(0.5f, 2.0f))
+        engine.setPitch(pitch.coerceIn(0.5f, 2.0f))
+
+        // Update notification to show who's speaking
+        val nm = getSystemService(NotificationManager::class.java)
+        nm?.notify(NOTIFICATION_ID, buildNotification("🔊 $entityName 正在說話..."))
+
+        val utteranceId = "eclaw_tts_${utteranceCounter.incrementAndGet()}"
+        engine.speak(text, TextToSpeech.QUEUE_ADD, null, utteranceId)
+
+        Timber.d("[TTS] Queued: \"${text.take(80)}\" lang=$lang speed=$speed pitch=$pitch entity=$entityName")
+    }
+
+    /**
+     * Parse BCP-47 language tag into a Locale.
+     * Supports: zh-TW, zh-CN, en-US, ja-JP, ko-KR, etc.
+     */
+    private fun parseLocale(lang: String): Locale {
+        return when (lang.lowercase()) {
+            "zh-tw" -> Locale.TRADITIONAL_CHINESE
+            "zh-cn" -> Locale.SIMPLIFIED_CHINESE
+            "en-us" -> Locale.US
+            "en-gb" -> Locale.UK
+            "ja-jp", "ja" -> Locale.JAPANESE
+            "ko-kr", "ko" -> Locale.KOREAN
+            "en" -> Locale.ENGLISH
+            "zh" -> Locale.TRADITIONAL_CHINESE
+            else -> {
+                // Try to parse "xx-YY" format
+                val parts = lang.split("-", "_")
+                if (parts.size >= 2) Locale(parts[0], parts[1])
+                else Locale(parts[0])
+            }
+        }
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID,
+                "語音播放",
+                NotificationManager.IMPORTANCE_LOW
+            ).apply {
+                description = "Bot 語音指令播放通知"
+                setShowBadge(false)
+            }
+            val nm = getSystemService(NotificationManager::class.java)
+            nm?.createNotificationChannel(channel)
+        }
+    }
+
+    private fun buildNotification(contentText: String): Notification {
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setSmallIcon(R.drawable.ic_launcher_foreground)
+            .setContentTitle("E-Claw TTS")
+            .setContentText(contentText)
+            .setOngoing(true)
+            .setSilent(true)
+            .setPriority(NotificationCompat.PRIORITY_LOW)
+            .build()
+    }
+
+    override fun onDestroy() {
+        serviceScope.cancel()
+        tts?.stop()
+        tts?.shutdown()
+        tts = null
+        ttsReady = false
+        Timber.d("[TTS] Service destroyed")
+        super.onDestroy()
+    }
+}

--- a/backend/index.js
+++ b/backend/index.js
@@ -11093,6 +11093,94 @@ app.post('/api/device/control', async (req, res) => {
     res.json({ success: true, message: `Command "${command}" sent to device` });
 });
 
+/**
+ * POST /api/device/tts
+ * Bot sends a text-to-speech command. Relayed to App via Socket.IO.
+ * The Android app uses the built-in TextToSpeech engine to speak the text aloud,
+ * even when the app is in the background (via a foreground service).
+ *
+ * Body (bot auth):
+ *   { deviceId, entityId, botSecret, text, lang?, speed?, pitch? }
+ * Body (device owner auth):
+ *   { deviceId, entityId, deviceSecret, text, lang?, speed?, pitch? }
+ *
+ * Parameters:
+ *   text   - (required) The text to speak aloud (max 500 chars)
+ *   lang   - (optional) BCP-47 language tag, default "zh-TW"
+ *   speed  - (optional) Speech rate 0.5–2.0, default 1.0
+ *   pitch  - (optional) Speech pitch 0.5–2.0, default 1.0
+ */
+app.post('/api/device/tts', async (req, res) => {
+    const { deviceId, entityId, botSecret, deviceSecret, text, lang, speed, pitch } = req.body;
+
+    if (!deviceId || !text) {
+        return res.status(400).json({ success: false, error: 'deviceId and text are required' });
+    }
+
+    if (typeof text !== 'string' || text.length > 500) {
+        return res.status(400).json({ success: false, error: 'text must be a string of 500 characters or less' });
+    }
+
+    const eId = parseInt(entityId) || 0;
+    if (eId < 0) {
+        return res.status(400).json({ success: false, error: 'Invalid entityId' });
+    }
+
+    const device = devices[deviceId];
+    if (!device) return res.status(404).json({ success: false, error: 'Device not found' });
+
+    if (!isValidEntityId(device, eId)) {
+        return res.status(400).json({ success: false, error: 'Invalid entityId' });
+    }
+
+    // Auth: device owner (portal) OR bot
+    const isOwner = deviceSecret && device.deviceSecret && safeEqual(deviceSecret, device.deviceSecret);
+    if (!isOwner) {
+        const entity = device.entities[eId];
+        if (!entity || !entity.isBound) {
+            return res.status(400).json({ success: false, error: 'Entity not bound' });
+        }
+        if (!botSecret || !safeEqual(botSecret, entity.botSecret)) {
+            return res.status(403).json({ success: false, error: 'Invalid botSecret' });
+        }
+    }
+
+    // Validate optional params
+    const ttsLang = (typeof lang === 'string' && lang.length <= 10) ? lang : 'zh-TW';
+    const ttsSpeed = (typeof speed === 'number' && speed >= 0.5 && speed <= 2.0) ? speed : 1.0;
+    const ttsPitch = (typeof pitch === 'number' && pitch >= 0.5 && pitch <= 2.0) ? pitch : 1.0;
+
+    const ttsEntity = device.entities[eId];
+    const entityName = ttsEntity?.name || `Bot ${eId + 1}`;
+
+    serverLog('info', 'tts', `TTS command: "${text.slice(0, 80)}" lang=${ttsLang} speed=${ttsSpeed} pitch=${ttsPitch}`, {
+        deviceId, entityId: eId,
+        metadata: { lang: ttsLang, speed: ttsSpeed, pitch: ttsPitch, textLen: text.length }
+    });
+
+    // Emit via Socket.IO to the device
+    io.to(`device:${deviceId}`).emit('device:tts', {
+        text,
+        lang: ttsLang,
+        speed: ttsSpeed,
+        pitch: ttsPitch,
+        entityId: eId,
+        entityName
+    });
+
+    // Also send FCM data message as fallback (in case Socket.IO is disconnected)
+    if (typeof sendFcm === 'function') {
+        sendFcm(deviceId, {
+            title: entityName,
+            body: text,
+            category: 'tts',
+            link: ''
+        }).catch(() => {});
+    }
+
+    res.json({ success: true, message: `TTS command sent to device`, lang: ttsLang, speed: ttsSpeed, pitch: ttsPitch });
+});
+
 // Prune old notifications daily
 setInterval(() => notifModule.pruneOldNotifications(), 24 * 60 * 60 * 1000);
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -2880,3 +2880,81 @@ paths:
                     type: string
                   url:
                     type: string
+
+  /api/device/tts:
+    post:
+      summary: Send TTS (text-to-speech) command to device
+      description: |
+        Bot sends a text-to-speech command. The Android app speaks the text aloud
+        using the built-in TextToSpeech engine, even when the app is in the background.
+        Delivered via Socket.IO with FCM fallback.
+      tags:
+        - Device
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+                - deviceId
+                - text
+              properties:
+                deviceId:
+                  type: string
+                  description: Target device ID
+                entityId:
+                  type: integer
+                  description: Entity ID (default 0)
+                  default: 0
+                botSecret:
+                  type: string
+                  description: Bot secret for authentication
+                deviceSecret:
+                  type: string
+                  description: Device secret (alternative auth for portal)
+                text:
+                  type: string
+                  description: Text to speak aloud (max 500 chars)
+                  maxLength: 500
+                lang:
+                  type: string
+                  description: "BCP-47 language tag (default: zh-TW)"
+                  default: zh-TW
+                  example: zh-TW
+                speed:
+                  type: number
+                  description: "Speech rate 0.5-2.0 (default: 1.0)"
+                  minimum: 0.5
+                  maximum: 2.0
+                  default: 1.0
+                pitch:
+                  type: number
+                  description: "Speech pitch 0.5-2.0 (default: 1.0)"
+                  minimum: 0.5
+                  maximum: 2.0
+                  default: 1.0
+      responses:
+        '200':
+          description: TTS command sent successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  message:
+                    type: string
+                  lang:
+                    type: string
+                  speed:
+                    type: number
+                  pitch:
+                    type: number
+        '400':
+          description: Missing or invalid parameters
+        '403':
+          description: Invalid botSecret
+        '404':
+          description: Device not found


### PR DESCRIPTION
## Summary
Bot 可以透過 API 讓手機講話，使用 Android 內建 TextToSpeech 引擎，背景也能運作。

## Changes

### Backend
- `POST /api/device/tts` — Bot 認證後發送語音指令
- 透過 Socket.IO (`device:tts`) 推送到手機，FCM 作為備援
- 參數：`text`(必填), `lang`(預設 zh-TW), `speed`(0.5-2.0), `pitch`(0.5-2.0)

### Android
- **TtsService.kt** — 新增前台 Service，用內建 TTS 引擎講話，背景運作
- **SocketManager.kt** — 新增 `ttsFlow` 監聽 `device:tts` 事件
- **ClawFcmService.kt** — FCM 收到 `tts` category 時啟動 TtsService
- **MainActivity.kt** — App 啟動時自動啟動 TtsService
- **AndroidManifest.xml** — 註冊 TtsService + FOREGROUND_SERVICE_MEDIA_PLAYBACK 權限

### Docs
- OpenAPI spec 更新

## Usage
```bash
curl -X POST https://eclawbot.com/api/device/tts \
  -H "Content-Type: application/json" \
  -d '{"deviceId":"xxx","entityId":0,"botSecret":"xxx","text":"老闆好！"}'
```

## Testing
- ✅ Backend: 53 test suites / 885 tests all passed
- ✅ Kotlin compilation: BUILD SUCCESSFUL (zero errors, zero new warnings)