### PR TITLE
fix(chat): fix target bar overflow detection not working

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -918,7 +918,7 @@
             gap: 10px;
             flex-wrap: nowrap;
             overflow: hidden;
-            max-height: 34px;
+            min-height: 34px;
         }
 
         .target-bar-overflow {
@@ -1774,21 +1774,28 @@
                 allItems.push({ el: addBtn, type: 'add' });
             }
 
-            // Add all items to row first for measurement
+            // Step 1: measure with wrap enabled to detect overflow
+            row.style.flexWrap = 'wrap';
+            row.style.overflow = 'visible';
             allItems.forEach(item => row.appendChild(item.el));
 
-            // After layout, check which items overflow the first row
+            // Step 2: after layout, detect which items go beyond first row
             requestAnimationFrame(() => {
-                const rowRect = row.getBoundingClientRect();
-                const maxBottom = rowRect.top + 38; // ~one row height
+                const firstItemTop = allItems.length > 0 ? allItems[0].el.getBoundingClientRect().top : 0;
+                const ROW_TOLERANCE = 8; // px tolerance for alignment differences
                 const overflowItems = [];
 
-                allItems.forEach(item => {
-                    const elRect = item.el.getBoundingClientRect();
-                    if (elRect.top >= maxBottom) {
+                allItems.forEach((item, idx) => {
+                    if (idx === 0) return; // always keep first item (label)
+                    const rect = item.el.getBoundingClientRect();
+                    if (rect.top > firstItemTop + ROW_TOLERANCE) {
                         overflowItems.push(item);
                     }
                 });
+
+                // Step 3: restore single-row layout
+                row.style.flexWrap = 'nowrap';
+                row.style.overflow = 'hidden';
 
                 if (overflowItems.length > 0) {
                     // Move overflow items to the upward-expanding panel
@@ -1801,10 +1808,11 @@
                     const toggle = document.createElement('button');
                     toggle.className = 'target-bar-toggle';
                     toggle.textContent = `▲ +${overflowItems.length}`;
-                    toggle.setAttribute('data-i18n-title', 'chat_target_expand');
                     toggle.onclick = () => {
                         const isOpen = overflow.classList.toggle('open');
-                        toggle.textContent = isOpen ? '▼ ' + (i18n.t('chat_target_collapse') || 'Collapse') : `▲ +${overflowItems.length}`;
+                        toggle.textContent = isOpen
+                            ? '▼ ' + (i18n.t('chat_target_collapse') || 'Collapse')
+                            : `▲ +${overflowItems.length}`;
                     };
                     row.appendChild(toggle);
                 }


### PR DESCRIPTION
## Bug Fix

**問題：** 傳送給展開鈕無法顯示，老闆看不到展開按鈕。

**根本原因：** `.target-bar-row` 設了 `flex-wrap: nowrap` + `overflow: hidden`，所有元素強制單行，`offsetTop` 值永遠相同，溢出偵測邏輯永遠失效。

**修法：**
1. 量測階段先暫時設 `flex-wrap: wrap` + `overflow: visible`
2. 用第一個 item 的 `getBoundingClientRect().top` 作基準，超過 8px 的判為溢出
3. 量完立刻恢復 `nowrap` + `hidden`，確保視覺只顯示一行

Fixes: target bar toggle not visible