### PR TITLE
docs: add botSecret vs deviceSecret authentication guide

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -7,6 +7,32 @@ info:
     collaboration, task dispatch, and automation. Each device supports multiple entity slots, each
     independently bindable to bots with their own identity, skills, and customer-facing Proxy Window.
     Communication flows: Client → Entity (speak), Entity → Entity (speak-to), Entity → All (broadcast).
+
+    ## Authentication: botSecret vs deviceSecret
+
+    EClaw uses two distinct credential types with different permission scopes:
+
+    | Credential | Format | Scope | Issued By | Used By |
+    |-----------|--------|-------|-----------|---------|
+    | **deviceSecret** | UUID-UUID (72 chars) | Full device access | /api/device/register | App, Portal, Owner |
+    | **botSecret** | 32-char hex | Single entity only | /api/bind | Bots, Agents |
+
+    ### deviceSecret (Device Owner)
+    - **What it is:** Root credential for the entire device
+    - **Permissions:** Manage ALL entities, change settings, read all chat, reorder/delete entities
+    - **Security:** Treat like a root password — never expose to bots or third parties
+    - **Where to find:** Returned by /api/device/register, stored in Android app's DeviceManager
+
+    ### botSecret (Bot/Agent)
+    - **What it is:** Per-entity credential for a single bot
+    - **Permissions:** Transform (update message/state), speak-to, read own dashboard, register webhook, use device features (TTS, GPS)
+    - **Cannot do:** Manage other entities, change device settings, access device-level data
+    - **Where to find:** Returned by /api/bind when a bot binds to an entity slot
+
+    ### Which one should I use?
+    - **Building an AI bot/agent?** → Use `botSecret` (you only need your own entity)
+    - **Building a device management tool?** → Use `deviceSecret`
+    - **Using the Web Portal?** → Uses `CookieAuth` (JWT session) instead
   version: 1.0.0
   contact:
     name: EClaw Support
@@ -50,12 +76,26 @@ components:
       type: apiKey
       in: query
       name: deviceSecret
-      description: Device owner credential (UUID-UUID format)
+      description: |
+        Device owner credential (UUID-UUID format).
+        Issued at device registration (/api/device/register).
+        Grants FULL device-level access: manage entities, change settings,
+        read all chat history, reorder/delete entities, access preferences.
+        Treat like a root password — never share with bots or third parties.
+        Used by: Android app, Web Portal, device owner scripts.
     BotSecret:
       type: apiKey
       in: query
       name: botSecret
-      description: Bot credential returned from /api/bind
+      description: |
+        Per-entity bot credential (32-char hex string).
+        Issued when a bot binds to an entity slot via /api/bind.
+        Grants ENTITY-SCOPED access only: transform (update status/message),
+        speak-to (message other entities), read own mission dashboard,
+        register webhook, and use device features (TTS, GPS, control).
+        Cannot manage other entities, change device settings, or access
+        device-level data. Each entity has its own unique botSecret.
+        Used by: OpenClaw bots, AI agents, external integrations.
     CookieAuth:
       type: apiKey
       in: cookie

--- a/backend/public/docs/authentication.md
+++ b/backend/public/docs/authentication.md
@@ -1,0 +1,124 @@
+# EClaw Authentication Guide
+
+## Overview
+
+EClaw uses two distinct credential types. Choosing the right one depends on **who you are** and **what you need to do**.
+
+## Credential Comparison
+
+| | deviceSecret | botSecret |
+|---|---|---|
+| **Format** | UUID-UUID (72 chars) | 32-char hex string |
+| **Scope** | Full device (all entities) | Single entity only |
+| **Issued by** | `POST /api/device/register` | `POST /api/bind` |
+| **Used by** | Android App, Web Portal, device owner | Bots, AI agents, integrations |
+| **Security level** | 🔴 Root-level (never share) | 🟡 Entity-scoped (safe to give to a bot) |
+
+## deviceSecret — Device Owner Credential
+
+### What it is
+The master key for your entire device. Created when you first register a device.
+
+### Permissions
+- ✅ Manage ALL entity slots (add, delete, rename, reorder)
+- ✅ Change device settings and preferences
+- ✅ Read all chat history across all entities
+- ✅ Access device-level features (telemetry, logs)
+- ✅ Bind/unbind bots to entity slots
+
+### Security
+- 🔴 **Treat like a root password**
+- Never share with bots, agents, or third parties
+- Stored securely in the Android app's DeviceManager
+- If compromised, re-register the device
+
+### Where to find it
+```bash
+# Returned by device registration
+POST /api/device/register
+→ { "deviceId": "...", "deviceSecret": "..." }
+
+# On Android: DeviceManager.getInstance(context).deviceSecret
+```
+
+## botSecret — Bot/Agent Credential
+
+### What it is
+A per-entity credential that lets a bot control **one specific entity slot**. Created when a bot binds to an entity.
+
+### Permissions
+- ✅ Transform (update entity message, state, character)
+- ✅ Speak-to (message other entities on the same device)
+- ✅ Read own mission dashboard (todos, notes, skills, rules)
+- ✅ Register webhook for push notifications
+- ✅ Use device features: TTS, GPS location, screen control
+- ❌ Cannot manage other entities
+- ❌ Cannot change device settings
+- ❌ Cannot access device-level data
+
+### Security
+- 🟡 **Entity-scoped** — limited blast radius if compromised
+- Safe to provide to AI bots/agents
+- Each entity slot has its own unique botSecret
+- Invalidated if the entity is unbound
+
+### Where to find it
+```bash
+# Returned by bot binding
+POST /api/bind
+→ { "botSecret": "a1b2c3d4e5f6..." }
+
+# In OpenClaw channel plugin: stored in gateway memory
+# Via Mission Dashboard API:
+GET /api/mission/dashboard?deviceId=ID&botSecret=SECRET&entityId=N
+```
+
+## Which one should I use?
+
+| Scenario | Credential |
+|----------|-----------|
+| Building an AI bot/agent | `botSecret` |
+| OpenClaw integration | `botSecret` |
+| Device management tool | `deviceSecret` |
+| Web Portal (browser) | `CookieAuth` (JWT session) |
+| Admin operations | `deviceSecret` or `CookieAuth` |
+
+## Common Mistakes
+
+### ❌ Using deviceSecret in a bot
+Don't give bots more access than they need. Use `botSecret`.
+
+### ❌ Using botSecret on /api/status
+Some endpoints only accept `deviceSecret`. If you get "Invalid credentials", check the endpoint's auth requirements. Use `/api/mission/dashboard` to verify botSecret validity.
+
+### ❌ Hardcoding secrets in public repos
+Use environment variables or EClaw's Mission Notes (category: "secrets") to store credentials.
+
+## API Examples
+
+### Bot authentication (botSecret)
+```bash
+# Update entity status
+curl -X POST https://eclawbot.com/api/transform \
+  -H "Content-Type: application/json" \
+  -d '{"deviceId":"ID","entityId":0,"botSecret":"SECRET","state":"IDLE","message":"Hello!"}'
+
+# Send message to another entity
+curl -X POST https://eclawbot.com/api/entity/speak-to \
+  -H "Content-Type: application/json" \
+  -d '{"deviceId":"ID","fromEntityId":0,"botSecret":"SECRET","toEntityId":1,"text":"Hey!"}'
+```
+
+### Device owner authentication (deviceSecret)
+```bash
+# Get device status
+curl "https://eclawbot.com/api/device/status?deviceId=ID&deviceSecret=SECRET"
+
+# Rename entity
+curl -X POST https://eclawbot.com/api/device/entity/name \
+  -H "Content-Type: application/json" \
+  -d '{"deviceId":"ID","deviceSecret":"SECRET","entityId":0,"name":"MyBot"}'
+```
+
+---
+*Last updated: 2026-03-25*


### PR DESCRIPTION
## [HIGH] botSecret vs deviceSecret 說明文件改善

### Changes
1. **OpenAPI spec** — 擴充 securitySchemes 描述，加入權限說明
2. **OpenAPI spec** — API description 新增 Authentication 章節（比較表 + 使用指南）
3. **新文件** `backend/public/docs/authentication.md` — 獨立認證指南
   - 憑證比較表（格式、範圍、安全等級）
   - deviceSecret vs botSecret 權限矩陣
   - 常見錯誤（用錯憑證、硬編碼密鑰等）
   - API 範例

### 存取方式
- https://eclawbot.com/docs/authentication.md
- OpenAPI: https://eclawbot.com/api-docs (Swagger UI)