### PR TITLE
feat: Bot Plaza P1 — community directory APIs

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -262,6 +262,44 @@ async function createTables() {
             ON CONFLICT (device_id, public_code) DO NOTHING
         `);
 
+        // ── Bot Plaza: Community tables ──
+        // Agent card visibility (public listing)
+        await client.query(`ALTER TABLE entities ADD COLUMN IF NOT EXISTS is_public BOOLEAN DEFAULT false`);
+        await client.query(`ALTER TABLE entities ADD COLUMN IF NOT EXISTS published_at TIMESTAMPTZ`);
+        await client.query(`ALTER TABLE entities ADD COLUMN IF NOT EXISTS avg_rating NUMERIC(2,1) DEFAULT 0`);
+        await client.query(`ALTER TABLE entities ADD COLUMN IF NOT EXISTS rating_count INTEGER DEFAULT 0`);
+        await client.query(`ALTER TABLE entities ADD COLUMN IF NOT EXISTS community_message_count INTEGER DEFAULT 0`);
+        await client.query(`CREATE INDEX IF NOT EXISTS idx_entities_public ON entities(is_public) WHERE is_public = true`);
+
+        // Community messages (comments on public agent cards)
+        await client.query(`
+            CREATE TABLE IF NOT EXISTS community_messages (
+                id              SERIAL PRIMARY KEY,
+                card_public_code VARCHAR(8) NOT NULL,
+                author_type     VARCHAR(10) NOT NULL CHECK (author_type IN ('bot', 'user')),
+                author_id       TEXT NOT NULL,
+                author_name     TEXT,
+                text            TEXT NOT NULL,
+                reply_to        INTEGER REFERENCES community_messages(id) ON DELETE SET NULL,
+                created_at      TIMESTAMPTZ DEFAULT NOW()
+            )
+        `);
+        await client.query(`CREATE INDEX IF NOT EXISTS idx_community_msg_card ON community_messages(card_public_code, created_at DESC)`);
+
+        // Community ratings (one per device per card)
+        await client.query(`
+            CREATE TABLE IF NOT EXISTS community_ratings (
+                id              SERIAL PRIMARY KEY,
+                card_public_code VARCHAR(8) NOT NULL,
+                device_id       TEXT NOT NULL,
+                stars           INTEGER NOT NULL CHECK (stars >= 1 AND stars <= 5),
+                created_at      TIMESTAMPTZ DEFAULT NOW(),
+                updated_at      TIMESTAMPTZ DEFAULT NOW(),
+                UNIQUE(card_public_code, device_id)
+            )
+        `);
+        await client.query(`CREATE INDEX IF NOT EXISTS idx_community_rating_card ON community_ratings(card_public_code)`);
+
         // Encrypted device variables (env vars vault)
         await client.query(`
             CREATE TABLE IF NOT EXISTS device_vars (
@@ -1684,6 +1722,179 @@ async function cleanupExpiredPendingMessages(cutoffTimestamp) {
     }
 }
 
+// ── Bot Plaza: Community functions ──
+
+async function setEntityPublic(deviceId, entityId, isPublic) {
+    try {
+        const now = isPublic ? new Date().toISOString() : null;
+        await chatPool.query(
+            `UPDATE entities SET is_public = $1, published_at = CASE WHEN $1 THEN COALESCE(published_at, $2::timestamptz) ELSE published_at END
+             WHERE device_id = $3 AND entity_id = $4`,
+            [isPublic, now, deviceId, entityId]
+        );
+        return true;
+    } catch (err) {
+        console.error('[DB] setEntityPublic error:', err.message);
+        return false;
+    }
+}
+
+async function searchPublicCards({ q, tag, capability, limit = 20, offset = 0, sort = 'newest' }) {
+    try {
+        const conditions = [`e.is_public = true`, `e.bot_secret IS NOT NULL`];
+        const params = [];
+        let paramIdx = 1;
+
+        if (q) {
+            conditions.push(`(e.name ILIKE $${paramIdx} OR e.agent_card->>'description' ILIKE $${paramIdx})`);
+            params.push(`%${q}%`);
+            paramIdx++;
+        }
+        if (tag) {
+            conditions.push(`e.agent_card->'tags' ? $${paramIdx}`);
+            params.push(tag);
+            paramIdx++;
+        }
+        if (capability) {
+            conditions.push(`EXISTS (SELECT 1 FROM jsonb_array_elements(e.agent_card->'capabilities') cap WHERE cap->>'id' ILIKE $${paramIdx} OR cap->>'name' ILIKE $${paramIdx})`);
+            params.push(`%${capability}%`);
+            paramIdx++;
+        }
+
+        const orderBy = sort === 'rating' ? 'e.avg_rating DESC, e.rating_count DESC' : 'e.published_at DESC NULLS LAST';
+        const safeLimit = Math.min(Math.max(parseInt(limit) || 20, 1), 50);
+        const safeOffset = Math.max(parseInt(offset) || 0, 0);
+
+        params.push(safeLimit, safeOffset);
+        const sql = `
+            SELECT e.public_code, e.name, e.character, e.avatar, e.agent_card,
+                   e.avg_rating, e.rating_count, e.community_message_count,
+                   e.published_at, e.level, e.xp
+            FROM entities e
+            WHERE ${conditions.join(' AND ')}
+            ORDER BY ${orderBy}
+            LIMIT $${paramIdx} OFFSET $${paramIdx + 1}
+        `;
+
+        const result = await chatPool.query(sql, params);
+        return result.rows.map(r => ({
+            publicCode: r.public_code,
+            name: r.name,
+            character: r.character,
+            avatar: r.avatar,
+            description: r.agent_card?.description || null,
+            capabilities: r.agent_card?.capabilities || [],
+            tags: r.agent_card?.tags || [],
+            avgRating: parseFloat(r.avg_rating) || 0,
+            ratingCount: parseInt(r.rating_count) || 0,
+            messageCount: parseInt(r.community_message_count) || 0,
+            publishedAt: r.published_at,
+            level: r.level || 1,
+            xp: r.xp || 0
+        }));
+    } catch (err) {
+        console.error('[DB] searchPublicCards error:', err.message);
+        return [];
+    }
+}
+
+async function getPublicCardDetail(publicCode) {
+    try {
+        const result = await chatPool.query(
+            `SELECT e.public_code, e.name, e.character, e.avatar, e.agent_card,
+                    e.avg_rating, e.rating_count, e.community_message_count,
+                    e.published_at, e.level, e.xp, e.state
+             FROM entities e
+             WHERE e.public_code = $1 AND e.is_public = true`,
+            [publicCode]
+        );
+        if (result.rows.length === 0) return null;
+        const r = result.rows[0];
+        return {
+            publicCode: r.public_code,
+            name: r.name,
+            character: r.character,
+            avatar: r.avatar,
+            agentCard: r.agent_card || null,
+            avgRating: parseFloat(r.avg_rating) || 0,
+            ratingCount: parseInt(r.rating_count) || 0,
+            messageCount: parseInt(r.community_message_count) || 0,
+            publishedAt: r.published_at,
+            level: r.level || 1,
+            xp: r.xp || 0,
+            state: r.state || 'IDLE'
+        };
+    } catch (err) {
+        console.error('[DB] getPublicCardDetail error:', err.message);
+        return null;
+    }
+}
+
+async function getCommunityMessages(publicCode, limit = 50, offset = 0) {
+    try {
+        const result = await chatPool.query(
+            `SELECT id, card_public_code, author_type, author_id, author_name, text, reply_to, created_at
+             FROM community_messages
+             WHERE card_public_code = $1
+             ORDER BY created_at DESC
+             LIMIT $2 OFFSET $3`,
+            [publicCode, Math.min(limit, 100), Math.max(offset, 0)]
+        );
+        return result.rows;
+    } catch (err) {
+        console.error('[DB] getCommunityMessages error:', err.message);
+        return [];
+    }
+}
+
+async function addCommunityMessage(publicCode, authorType, authorId, authorName, text, replyTo) {
+    try {
+        const result = await chatPool.query(
+            `INSERT INTO community_messages (card_public_code, author_type, author_id, author_name, text, reply_to)
+             VALUES ($1, $2, $3, $4, $5, $6) RETURNING *`,
+            [publicCode, authorType, authorId, authorName, text, replyTo || null]
+        );
+        // Increment message count on entity
+        await chatPool.query(
+            `UPDATE entities SET community_message_count = community_message_count + 1
+             WHERE public_code = $1`,
+            [publicCode]
+        );
+        return result.rows[0];
+    } catch (err) {
+        console.error('[DB] addCommunityMessage error:', err.message);
+        return null;
+    }
+}
+
+async function upsertCommunityRating(publicCode, deviceId, stars) {
+    try {
+        await chatPool.query(
+            `INSERT INTO community_ratings (card_public_code, device_id, stars)
+             VALUES ($1, $2, $3)
+             ON CONFLICT (card_public_code, device_id)
+             DO UPDATE SET stars = $3, updated_at = NOW()`,
+            [publicCode, deviceId, stars]
+        );
+        // Recalculate average
+        const result = await chatPool.query(
+            `SELECT AVG(stars)::numeric(2,1) AS avg, COUNT(*)::integer AS cnt
+             FROM community_ratings WHERE card_public_code = $1`,
+            [publicCode]
+        );
+        const avg = parseFloat(result.rows[0].avg) || 0;
+        const cnt = parseInt(result.rows[0].cnt) || 0;
+        await chatPool.query(
+            `UPDATE entities SET avg_rating = $1, rating_count = $2 WHERE public_code = $3`,
+            [avg, cnt, publicCode]
+        );
+        return { avgRating: avg, ratingCount: cnt };
+    } catch (err) {
+        console.error('[DB] upsertCommunityRating error:', err.message);
+        return null;
+    }
+}
+
 module.exports = {
     initDatabase,
     saveDeviceData,
@@ -1766,5 +1977,12 @@ module.exports = {
     savePendingCrossMessage,
     getPendingCrossMessages,
     deletePendingCrossMessages,
-    cleanupExpiredPendingMessages
+    cleanupExpiredPendingMessages,
+    // Bot Plaza: Community
+    setEntityPublic,
+    searchPublicCards,
+    getPublicCardDetail,
+    getCommunityMessages,
+    addCommunityMessage,
+    upsertCommunityRating
 };

--- a/backend/index.js
+++ b/backend/index.js
@@ -6361,6 +6361,188 @@ app.delete('/api/entity/agent-card', (req, res) => {
     res.json({ success: true });
 });
 
+// ============================================
+// BOT PLAZA: Community Directory
+// ============================================
+
+/**
+ * PATCH /api/entity/agent-card/visibility — Toggle public listing
+ * Auth: deviceSecret (owner only — bots cannot self-publish)
+ * Body: { deviceId, deviceSecret, entityId, public: true/false }
+ */
+app.patch('/api/entity/agent-card/visibility', async (req, res) => {
+    const { deviceId, deviceSecret, entityId } = req.body;
+    const isPublic = req.body.public;
+
+    if (!deviceId || entityId === undefined || typeof isPublic !== 'boolean') {
+        return res.status(400).json({ success: false, error: 'deviceId, deviceSecret, entityId, and public (boolean) required' });
+    }
+    if (!deviceSecret) {
+        return res.status(400).json({ success: false, error: 'deviceSecret required (owner only)' });
+    }
+
+    const device = devices[deviceId];
+    if (!device) return res.status(404).json({ success: false, error: 'Device not found' });
+    if (!safeEqual(device.deviceSecret, deviceSecret)) {
+        return res.status(403).json({ success: false, error: 'Invalid deviceSecret' });
+    }
+
+    const eId = parseInt(entityId);
+    const entity = device.entities[eId];
+    if (!entity || !entity.isBound) {
+        return res.status(404).json({ success: false, error: 'Entity not found or not bound' });
+    }
+
+    // Must have an agent card to publish
+    if (isPublic && !entity.agentCard) {
+        return res.status(400).json({ success: false, error: 'Entity must have an agent card before publishing' });
+    }
+
+    const ok = await db.setEntityPublic(deviceId, eId, isPublic);
+    if (!ok) return res.status(500).json({ success: false, error: 'Database error' });
+
+    serverLog('info', 'bot_plaza', `Entity ${eId} visibility: ${isPublic ? 'PUBLIC' : 'PRIVATE'}`, { deviceId, entityId: eId });
+
+    res.json({
+        success: true,
+        public: isPublic,
+        publicCode: entity.publicCode,
+        message: isPublic ? 'Agent card is now publicly listed' : 'Agent card removed from public listing'
+    });
+});
+
+/**
+ * GET /api/community/search — Search public agent cards
+ * No auth required (public directory)
+ * Query: ?q=keyword&tag=ecommerce&capability=translation&limit=20&offset=0&sort=newest|rating
+ */
+app.get('/api/community/search', async (req, res) => {
+    const { q, tag, capability, limit, offset, sort } = req.query;
+
+    const results = await db.searchPublicCards({
+        q, tag, capability,
+        limit: parseInt(limit) || 20,
+        offset: parseInt(offset) || 0,
+        sort: sort || 'newest'
+    });
+
+    res.json({
+        success: true,
+        count: results.length,
+        results
+    });
+});
+
+/**
+ * GET /api/community/card/:publicCode — Public card detail + messages
+ * No auth required
+ */
+app.get('/api/community/card/:publicCode', async (req, res) => {
+    const { publicCode } = req.params;
+    const card = await db.getPublicCardDetail(publicCode);
+    if (!card) return res.status(404).json({ success: false, error: 'Card not found or not public' });
+
+    const limit = Math.min(parseInt(req.query.messageLimit) || 50, 100);
+    const messages = await db.getCommunityMessages(publicCode, limit, 0);
+
+    res.json({
+        success: true,
+        card,
+        messages
+    });
+});
+
+/**
+ * POST /api/community/card/:publicCode/message — Leave a comment
+ * Auth: deviceSecret (user) OR botSecret (bot)
+ * Body: { text, replyTo?, deviceId, deviceSecret } or { text, replyTo?, deviceId, entityId, botSecret }
+ */
+app.post('/api/community/card/:publicCode/message', async (req, res) => {
+    const { publicCode } = req.params;
+    const { text, replyTo, deviceId, deviceSecret, botSecret, entityId } = req.body;
+
+    if (!text || typeof text !== 'string' || text.length < 1 || text.length > 500) {
+        return res.status(400).json({ success: false, error: 'text required (1-500 chars)' });
+    }
+    if (!deviceId) {
+        return res.status(400).json({ success: false, error: 'deviceId required' });
+    }
+
+    // Verify card exists and is public
+    const card = await db.getPublicCardDetail(publicCode);
+    if (!card) return res.status(404).json({ success: false, error: 'Card not found or not public' });
+
+    let authorType, authorId, authorName;
+
+    if (botSecret) {
+        // Bot auth
+        const eId = parseInt(entityId) || 0;
+        const device = devices[deviceId];
+        if (!device) return res.status(404).json({ success: false, error: 'Device not found' });
+        const entity = device.entities[eId];
+        if (!entity || !entity.isBound || !safeEqual(entity.botSecret, botSecret)) {
+            return res.status(403).json({ success: false, error: 'Invalid botSecret' });
+        }
+        authorType = 'bot';
+        authorId = `${deviceId}:${eId}`;
+        authorName = entity.name || `Entity ${eId}`;
+    } else if (deviceSecret) {
+        // User auth
+        const device = devices[deviceId];
+        if (!device) return res.status(404).json({ success: false, error: 'Device not found' });
+        if (!safeEqual(device.deviceSecret, deviceSecret)) {
+            return res.status(403).json({ success: false, error: 'Invalid deviceSecret' });
+        }
+        authorType = 'user';
+        authorId = deviceId;
+        authorName = 'Device Owner';
+    } else {
+        return res.status(400).json({ success: false, error: 'deviceSecret or botSecret required' });
+    }
+
+    const msg = await db.addCommunityMessage(publicCode, authorType, authorId, authorName, text, replyTo);
+    if (!msg) return res.status(500).json({ success: false, error: 'Failed to save message' });
+
+    res.json({ success: true, message: msg });
+});
+
+/**
+ * POST /api/community/card/:publicCode/rate — Rate a public card
+ * Auth: deviceSecret only (one rating per device per card)
+ * Body: { stars: 1-5, deviceId, deviceSecret }
+ */
+app.post('/api/community/card/:publicCode/rate', async (req, res) => {
+    const { publicCode } = req.params;
+    const { stars, deviceId, deviceSecret } = req.body;
+
+    if (!deviceId || !deviceSecret) {
+        return res.status(400).json({ success: false, error: 'deviceId and deviceSecret required' });
+    }
+    if (!Number.isInteger(stars) || stars < 1 || stars > 5) {
+        return res.status(400).json({ success: false, error: 'stars must be integer 1-5' });
+    }
+
+    const device = devices[deviceId];
+    if (!device) return res.status(404).json({ success: false, error: 'Device not found' });
+    if (!safeEqual(device.deviceSecret, deviceSecret)) {
+        return res.status(403).json({ success: false, error: 'Invalid deviceSecret' });
+    }
+
+    // Verify card exists and is public
+    const card = await db.getPublicCardDetail(publicCode);
+    if (!card) return res.status(404).json({ success: false, error: 'Card not found or not public' });
+
+    const result = await db.upsertCommunityRating(publicCode, deviceId, stars);
+    if (!result) return res.status(500).json({ success: false, error: 'Failed to save rating' });
+
+    res.json({
+        success: true,
+        stars,
+        avgRating: result.avgRating,
+        ratingCount: result.ratingCount
+    });
+});
+
 // ── Bot Identity Layer ──
 
 /**


### PR DESCRIPTION
## Bot Plaza Phase 1 — 後端 API

### 5 個 API endpoints

| # | Endpoint | Auth | 說明 |
|---|---------|------|------|
| 1 | `PATCH /api/entity/agent-card/visibility` | deviceSecret | 名片公開/取消公開開關 |
| 2 | `GET /api/community/search` | 無 | 搜尋公開名片（keyword, tag, capability, sort） |
| 3 | `GET /api/community/card/:publicCode` | 無 | 名片詳情 + 留言列表 |
| 4 | `POST /api/community/card/:publicCode/message` | deviceSecret/botSecret | 留言（支援回覆） |
| 5 | `POST /api/community/card/:publicCode/rate` | deviceSecret | 評分 1-5 星 |

### DB Schema
- entities: +is_public, +published_at, +avg_rating, +rating_count, +community_message_count
- 新 table: community_messages
- 新 table: community_ratings (unique per device+card)

### Testing
- ✅ 53/53 test suites, 893 tests passed