### PR TITLE
fix: skip NAME_CHANGED notification when entity name is unchanged

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -5030,6 +5030,12 @@ app.put('/api/device/entity/name', async (req, res) => {
 
     const oldName = entity.name;
     const newName = (name && name.trim()) ? name.trim() : null;
+
+    // Skip if name didn't actually change
+    if (oldName === newName || ((!oldName && !newName))) {
+        return res.json({ success: true, name: newName, entityId: eId, changed: false });
+    }
+
     entity.name = newName;
     entity.lastUpdated = Date.now();
 


### PR DESCRIPTION
## Bug

`PUT /api/device/entity/name` 在名字沒變的情況下也會發送 `[SYSTEM:NAME_CHANGED]` 通知給 bot。

例如：Portal 儲存 entity 設定時觸發 rename API，即使名字完全一樣（BackendOps → BackendOps），bot 每次都會收到重複的改名通知。

## Fix

加入 `oldName === newName` 檢查，名字沒變時直接回傳 `{changed: false}` 不發通知。

## Testing
- ✅ 53/53 test suites, 893 tests passed