### PR TITLE
fix(chat): loading hint stuck on screen in target bar

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -1648,13 +1648,13 @@
 
         // ── Entities ──
         async function loadBoundEntities() {
-            const bar = document.getElementById('targetBar');
-            if (bar && boundEntities.length === 0) {
+            const row = document.getElementById('targetBarRow');
+            if (row && boundEntities.length === 0) {
                 const hint = document.createElement('span');
                 hint.className = 'target-loading-hint';
                 hint.style.cssText = 'color:var(--text-muted);font-size:12px;';
                 hint.textContent = i18n.t('chat_loading_entities');
-                bar.appendChild(hint);
+                row.appendChild(hint);
             }
             try {
                 const data = await apiCall('GET', `/api/entities?deviceId=${currentUser.deviceId}`);


### PR DESCRIPTION
## Bug Fix

**問題：** 「載入實體中」文字永遠不消失

**根因：** `loadBoundEntities()` 把 loading hint 加到 `#targetBar`（父層），但 `renderTargetBar()` 只清 `#targetBarRow`（子層）的 `.target-loading-hint`，導致 hint 永遠留在畫面上。

**修法：** 把 hint 加到 `#targetBarRow`，這樣 `renderTargetBar()` 開頭的清除邏輯就能正確移除。

3 行改動。