### PR TITLE
fix: security + SEO + i18n audit fixes

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1125,7 +1125,7 @@ app.get('/p/:code/:noteId', async (req, res) => {
         const pageTitle = row.title || 'EClaw Page';
         const hasMarkdown = !!row.markdown_content;
         const htmlContent = hasMarkdown
-            ? `<div id="md-content"></div><script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"><\/script><script>document.getElementById('md-content').innerHTML=marked.parse(${JSON.stringify(row.markdown_content)});<\/script>`
+            ? `<div id="md-content"></div><script src="https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.2.4/purify.min.js"><\/script><script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"><\/script><script>document.getElementById('md-content').innerHTML=DOMPurify.sanitize(marked.parse(${JSON.stringify(row.markdown_content)}));<\/script>`
             : sanitizePublicHtml(row.html_content || '');
 
         const device = devices[target.deviceId];
@@ -2078,11 +2078,10 @@ app.post('/api/gatekeeper/appeal', async (req, res) => {
 });
 
 // GET /api/admin/gatekeeper/debug - Debug developer device cache
-app.get('/api/admin/gatekeeper/debug', async (req, res) => {
-    const { deviceId, deviceSecret } = req.query;
-    if (!deviceId || !deviceSecret) return res.status(400).json({ error: 'deviceId and deviceSecret required' });
+app.get('/api/admin/gatekeeper/debug', adminAuth, adminCheck, async (req, res) => {
+    const { deviceId } = req.query;
+    if (!deviceId) return res.status(400).json({ error: 'deviceId required' });
     const device = devices[deviceId];
-    if (!device || !safeEqual(device.deviceSecret, deviceSecret)) return res.status(403).json({ error: 'Invalid credentials' });
     // Query DB for is_admin
     let dbAdmin = null;
     try {

--- a/backend/public/enterprise.html
+++ b/backend/public/enterprise.html
@@ -22,6 +22,12 @@
     <meta name="twitter:image" content="https://eclawbot.com/assets/og-image.png">
     <!-- hreflang -->
     <link rel="alternate" hreflang="en" href="https://eclawbot.com/enterprise">
+    <link rel="alternate" hreflang="zh" href="https://eclawbot.com/enterprise">
+    <link rel="alternate" hreflang="ja" href="https://eclawbot.com/enterprise">
+    <link rel="alternate" hreflang="ko" href="https://eclawbot.com/enterprise">
+    <link rel="alternate" hreflang="th" href="https://eclawbot.com/enterprise">
+    <link rel="alternate" hreflang="vi" href="https://eclawbot.com/enterprise">
+    <link rel="alternate" hreflang="id" href="https://eclawbot.com/enterprise">
     <link rel="alternate" hreflang="x-default" href="https://eclawbot.com/enterprise">
     <link rel="icon" type="image/png" href="/portal/assets/favicon-32.png">
     <!-- JSON-LD -->

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -17814,6 +17814,14 @@ class I18n {
             }
         });
 
+        // Translate placeholder attributes
+        document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+            const key = el.getAttribute('data-i18n-placeholder');
+            if (key) {
+                el.placeholder = this.t(key);
+            }
+        });
+
         // Update html lang attribute
         const langMap = { 'zh': 'zh-TW', 'zh-CN': 'zh-CN', 'ja': 'ja', 'ko': 'ko', 'th': 'th', 'vi': 'vi', 'id': 'id' };
         document.documentElement.lang = langMap[this.lang] || 'en';


### PR DESCRIPTION
## Summary
- **P0 Security**: Add `adminAuth, adminCheck` middleware to `/api/admin/gatekeeper/debug` — was accessible to any device owner
- **P0 Security**: Add DOMPurify sanitization to `marked.parse()` output on public note pages (`/p/:code/:noteId`) — prevents stored XSS
- **P0 UI/UX**: Add `data-i18n-placeholder` processing to `i18n.apply()` — fixes 7 elements across 4 pages with non-translatable placeholders
- **SEO**: Add missing hreflang tags (zh/ja/ko/th/vi/id) to enterprise.html

## Test plan
- [x] Jest tests pass (893/893)
- [ ] Verify admin debug endpoint rejects non-admin requests
- [ ] Verify public note page renders markdown safely (no XSS)
- [ ] Verify placeholder translations work on share-chat, card-holder, feedback, settings pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)