### PR TITLE
fix: chat photo display — Flickr fallback to backup URL + onerror handler

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -5461,7 +5461,8 @@ app.post('/api/client/speak', async (req, res) => {
             mediaUrl: mediaUrl || null
         };
         entity.messageQueue.push(messageObj);
-        saveChatMessage(deviceId, eId, text, source, true, false, mediaType || null, mediaUrl || null);
+        const chatBackupUrl = mediaType === 'photo' ? getBackupUrl(mediaUrl) : null;
+        saveChatMessage(deviceId, eId, text, source, true, false, mediaType || null, mediaUrl || null, null, null, chatBackupUrl);
 
         // Reset bot-to-bot counter: human message breaks the loop
         resetBotToBotCounter(deviceId);
@@ -10769,6 +10770,7 @@ chatPool.query(`
     ALTER TABLE chat_messages ADD COLUMN IF NOT EXISTS schedule_label TEXT DEFAULT NULL;
     ALTER TABLE chat_messages ADD COLUMN IF NOT EXISTS like_count INTEGER DEFAULT 0;
     ALTER TABLE chat_messages ADD COLUMN IF NOT EXISTS dislike_count INTEGER DEFAULT 0;
+    ALTER TABLE chat_messages ADD COLUMN IF NOT EXISTS backup_url TEXT DEFAULT NULL;
 `).catch(() => {});
 
 // Auto-migrate: create message_reactions table (message_id must be UUID to match chat_messages.id)
@@ -11832,7 +11834,7 @@ const A2A_SOURCE_RE = /^entity:\d+:[A-Z]+->/;
 
 // Save chat message to database, returns row ID (UUID) or null
 // Deduplication: bot messages with identical text for the same entity within 10s are skipped
-async function saveChatMessage(deviceId, entityId, text, source, isFromUser, isFromBot, mediaType = null, mediaUrl = null, scheduleId = null, scheduleLabel = null) {
+async function saveChatMessage(deviceId, entityId, text, source, isFromUser, isFromBot, mediaType = null, mediaUrl = null, scheduleId = null, scheduleLabel = null, backupUrl = null) {
     try {
         // Dedup: skip if the same BOT message was already saved recently
         // Bot dedup: prevents echo when bot calls multiple endpoints (broadcast + sync-message + transform)
@@ -11853,9 +11855,9 @@ async function saveChatMessage(deviceId, entityId, text, source, isFromUser, isF
         }
 
         const result = await chatPool.query(
-            `INSERT INTO chat_messages (device_id, entity_id, text, source, is_from_user, is_from_bot, media_type, media_url, schedule_id, schedule_label)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10) RETURNING id`,
-            [deviceId, entityId, text, source, isFromUser || false, isFromBot || false, mediaType, mediaUrl, scheduleId, scheduleLabel]
+            `INSERT INTO chat_messages (device_id, entity_id, text, source, is_from_user, is_from_bot, media_type, media_url, schedule_id, schedule_label, backup_url)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11) RETURNING id`,
+            [deviceId, entityId, text, source, isFromUser || false, isFromBot || false, mediaType, mediaUrl, scheduleId, scheduleLabel, backupUrl]
         );
         const msgId = result.rows[0]?.id || null;
 
@@ -11875,6 +11877,7 @@ async function saveChatMessage(deviceId, entityId, text, source, isFromUser, isF
                 is_from_bot: isFromBot || false,
                 media_type: mediaType,
                 media_url: mediaUrl,
+                backup_url: backupUrl,
                 schedule_id: scheduleId || null,
                 schedule_label: scheduleLabel || null,
                 created_at: Date.now()

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -2320,7 +2320,11 @@
                 // Build media content
                 let mediaHtml = '';
                 if (msg.media_type === 'photo' && msg.media_url) {
-                    mediaHtml = `<img class="chat-photo" src="${escapeHtml(msg.media_url)}" alt="Photo" onclick="openLightbox('${escapeHtml(msg.media_url)}')" loading="lazy">`;
+                    const backupSrc = msg.backup_url ? escapeHtml(msg.backup_url) : '';
+                    const onerrorFallback = backupSrc
+                        ? `onerror="if(!this.dataset.retried){this.dataset.retried='1';this.src='${backupSrc}'}else{this.style.display='none'}"`
+                        : `onerror="this.style.display='none'"`;
+                    mediaHtml = `<img class="chat-photo" src="${escapeHtml(msg.media_url)}" alt="Photo" onclick="openLightbox('${escapeHtml(msg.media_url)}')" loading="lazy" ${onerrorFallback}>`;
                 } else if (msg.media_type === 'video' && msg.media_url) {
                     mediaHtml = `<video class="chat-video" src="${escapeHtml(msg.media_url)}" controls preload="metadata"
                         onclick="event.stopPropagation();"


### PR DESCRIPTION
## Bug
聊天發送圖片功能失效 — Flickr 圖片 URL 失效時，照片直接破圖無 fallback。

## Root Cause
1. `<img class="chat-photo">` 沒有 `onerror` handler — Flickr 掛了就破圖
2. `backup_url`（server-cached 備份）沒存進 DB，也沒在前端渲染中使用

## Fixes
1. **chat.html** — chat-photo 加 onerror fallback：先嘗試 backup_url，都失敗才隱藏
2. **DB** — chat_messages 加 `backup_url` 欄位
3. **saveChatMessage** — 接受並存儲 backup_url
4. **Socket.IO emit** — 包含 backup_url
5. **client/speak** — photo 訊息自動計算並傳入 backup_url

## Testing
- ✅ 53/53 suites, 893 tests passed
- ✅ 後端上傳測試正常（Flickr + backup cache 都有效）