### PR TITLE
fix: change visibility endpoint from PATCH to POST

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -6393,7 +6393,7 @@ app.delete('/api/entity/agent-card', (req, res) => {
  * Auth: deviceSecret (owner only — bots cannot self-publish)
  * Body: { deviceId, deviceSecret, entityId, public: true/false }
  */
-app.patch('/api/entity/agent-card/visibility', async (req, res) => {
+app.post('/api/entity/agent-card/visibility', async (req, res) => {
     const { deviceId, deviceSecret, entityId } = req.body;
     const isPublic = req.body.public;
 


### PR DESCRIPTION
Railway proxy 擋 PATCH method 回 503。改成 POST。

`app.patch → app.post` for `/api/entity/agent-card/visibility`