### PR TITLE
fix: append media URL to message body for text-based agents

### DIFF
--- a/openclaw-channel-eclaw/src/webhook-handler.ts
+++ b/openclaw-channel-eclaw/src/webhook-handler.ts
@@ -61,7 +61,18 @@ export function createWebhookHandler(
         : undefined;
 
       // Build body — enrich with event context for bot-to-bot and broadcast
+      // Append media URL to body so text-based agents can see/analyze images
       let body = msg.text || '';
+      if (msg.mediaUrl && msg.mediaType) {
+        const mediaLabel = msg.mediaType === 'photo' ? 'Image'
+          : msg.mediaType === 'voice' ? 'Voice'
+          : msg.mediaType === 'video' ? 'Video'
+          : 'File';
+        const urlToAppend = msg.backupUrl || msg.mediaUrl;
+        body = body
+          ? `${body}\n[${mediaLabel}: ${urlToAppend}]`
+          : `[${mediaLabel}: ${urlToAppend}]`;
+      }
       if ((event === 'entity_message' || event === 'broadcast') && fromEntityId !== undefined) {
         const senderLabel = fromCharacter
           ? `Entity ${fromEntityId} (${fromCharacter})`


### PR DESCRIPTION
Channel plugin 收到圖片時只把 URL 放在 MediaUrl context metadata，text-based agent 看不到。

修改：在 body 後面 append `[Image: url]` 讓 agent 能直接收到圖片 URL 來分析。

優先使用 backupUrl（server cache）確保可靠性。