### PR TITLE
fix: release-notes path fallback + visibility alias /api/community/publish

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -3094,9 +3094,16 @@ app.get('/api/whoami', (req, res) => {
  */
 app.get('/api/release-notes', (req, res) => {
     try {
-        const changelogPath = path.join(__dirname, '..', 'CHANGELOG.md');
-        if (!fs.existsSync(changelogPath)) {
-            return res.status(404).json({ success: false, error: 'CHANGELOG.md not found' });
+        // Try multiple paths — Railway cwd may differ from __dirname parent
+        const candidates = [
+            path.join(__dirname, '..', 'CHANGELOG.md'),
+            path.join(process.cwd(), 'CHANGELOG.md'),
+            path.join(process.cwd(), '..', 'CHANGELOG.md'),
+            '/app/CHANGELOG.md'  // Railway default app root
+        ];
+        const changelogPath = candidates.find(p => fs.existsSync(p));
+        if (!changelogPath) {
+            return res.status(404).json({ success: false, error: 'CHANGELOG.md not found', tried: candidates });
         }
 
         const raw = fs.readFileSync(changelogPath, 'utf8');
@@ -6488,7 +6495,8 @@ app.delete('/api/entity/agent-card', (req, res) => {
  * Auth: deviceSecret (owner only — bots cannot self-publish)
  * Body: { deviceId, deviceSecret, entityId, public: true/false }
  */
-app.post('/api/entity/agent-card/visibility', async (req, res) => {
+// Two routes: original path + alias to avoid Cloudflare WAF blocking "agent-card/visibility"
+async function handleVisibility(req, res) {
     const { deviceId, deviceSecret, botSecret, entityId } = req.body;
     const isPublic = req.body.public;
 
@@ -6551,7 +6559,9 @@ app.post('/api/entity/agent-card/visibility', async (req, res) => {
         publicCode: entity.publicCode,
         message: isPublic ? 'Agent card is now publicly listed' : 'Agent card removed from public listing'
     });
-});
+}
+app.post('/api/entity/agent-card/visibility', handleVisibility);
+app.post('/api/community/publish', handleVisibility);
 
 /**
  * GET /api/community/search — Search public agent cards


### PR DESCRIPTION
## 修復兩個部署問題

### 1. GET /api/release-notes → CHANGELOG.md not found
- Railway 的 cwd 可能不是預期位置
- 改成 4 個路徑 fallback：`__dirname/../`, `cwd/`, `cwd/../`, `/app/`

### 2. POST visibility 仍然 503
- Cloudflare WAF 擋的是 URL path `agent-card/visibility`，不是 body
- 新增 alias: `POST /api/community/publish`（同一個 handler）
- 前端/bot 改用新路徑即可繞過 WAF