### PR TITLE
fix: copy CHANGELOG.md to backend/ in nixpacks + visibility accepts X-Bot-Secret header

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -3094,12 +3094,11 @@ app.get('/api/whoami', (req, res) => {
  */
 app.get('/api/release-notes', (req, res) => {
     try {
-        // Try multiple paths — Railway cwd may differ from __dirname parent
+        // Railway deploys backend/ as /app, so CHANGELOG.md is copied there by nixpacks
         const candidates = [
-            path.join(__dirname, '..', 'CHANGELOG.md'),
+            path.join(__dirname, 'CHANGELOG.md'),          // /app/CHANGELOG.md (Railway)
+            path.join(__dirname, '..', 'CHANGELOG.md'),    // local dev (repo root)
             path.join(process.cwd(), 'CHANGELOG.md'),
-            path.join(process.cwd(), '..', 'CHANGELOG.md'),
-            '/app/CHANGELOG.md'  // Railway default app root
         ];
         const changelogPath = candidates.find(p => fs.existsSync(p));
         if (!changelogPath) {
@@ -6518,8 +6517,13 @@ app.delete('/api/entity/agent-card', (req, res) => {
  */
 // Two routes: original path + alias to avoid Cloudflare WAF blocking "agent-card/visibility"
 async function handleVisibility(req, res) {
-    const { deviceId, deviceSecret, botSecret, entityId } = req.body;
-    const isPublic = req.body.public;
+    // Accept params from body, query, or headers (Cloudflare WAF blocks secrets in body/query)
+    const src = { ...req.query, ...req.body };
+    const deviceId = src.deviceId || req.headers['x-device-id'];
+    const deviceSecret = src.deviceSecret || req.headers['x-device-secret'];
+    const botSecret = src.botSecret || req.headers['x-bot-secret'];
+    const entityId = src.entityId;
+    const isPublic = typeof src.public === 'boolean' ? src.public : src.public === 'true';
 
     if (!deviceId || typeof isPublic !== 'boolean') {
         return res.status(400).json({ success: false, error: 'deviceId and public (boolean) required' });

--- a/nixpacks.toml
+++ b/nixpacks.toml
@@ -3,7 +3,7 @@ nixPkgs = ["nodejs_20"]
 
 [phases.install]
 dependsOn = ["setup"]
-cmds = ["cd backend && npm install"]
+cmds = ["cp CHANGELOG.md backend/ 2>/dev/null || true", "cd backend && npm install"]
 
 [start]
 cmd = "cd backend && node index.js"


### PR DESCRIPTION
## 根因找到了

### 1. CHANGELOG.md not found
`/api/debug/paths` 顯示 Railway 的 __dirname=/app, cwd=/app，目錄裡只有 backend/ 的內容。
**CHANGELOG.md 在 repo root，沒被 deploy 進去。**

修復：nixpacks.toml install phase 加 `cp CHANGELOG.md backend/`

### 2. Visibility 503
測試發現：
- 空 request → 通過 ✅
- deviceId only → 通過 ✅
- deviceId + botSecret(abc123) → 通過 ✅
- deviceId + botSecret(700a5ad1...) → **503** ❌

**Cloudflare WAF 檢測到 32-char hex string 像 API key，擋掉了。**

修復：支援 `X-Bot-Secret` / `X-Device-Id` HTTP headers 傳認證，繞過 body/query 檢測。

### 用法
```bash
curl -X POST https://eclawbot.com/api/community/publish \
  -H "X-Device-Id: xxx" \
  -H "X-Bot-Secret: yyy" \
  -H "Content-Type: application/json" \
  -d '{"public": true}'
```