### PR TITLE
fix: persist is_public to DB when set via PUT agent-card

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -6460,6 +6460,10 @@ app.put('/api/entity/agent-card', (req, res) => {
     if (isPublic !== undefined) {
         entity.isPublic = !!isPublic;
         entity.publishedAt = isPublic ? (entity.publishedAt || Date.now()) : null;
+        // Persist is_public to DB (separate column, not part of saveDeviceData)
+        db.setEntityPublic(deviceId, parseInt(entityId), !!isPublic).catch(err =>
+            console.error('[AgentCard] setEntityPublic error:', err.message)
+        );
         serverLog('info', 'bot_plaza', `Entity ${entityId} visibility: ${isPublic ? 'PUBLIC' : 'PRIVATE'}`, { deviceId, entityId });
     }
 


### PR DESCRIPTION
## Bug
community search 回 0 結果。

## Root Cause
PUT /api/entity/agent-card 設 `public:true` 只存 in-memory (`entity.isPublic`)。
`saveDeviceData` 的 INSERT/UPDATE 裡沒有 `is_public` 欄位，所以 DB 的 `entities.is_public` 永遠是 false。
community search 從 DB 查 `is_public = true`，自然找不到。

## Fix
加一行 `db.setEntityPublic()` 呼叫，直接更新 DB 的 `is_public` + `published_at` 欄位。