### PR TITLE
fix: community search finds 0 — saveDeviceData before setEntityPublic

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -1727,11 +1727,21 @@ async function cleanupExpiredPendingMessages(cutoffTimestamp) {
 async function setEntityPublic(deviceId, entityId, isPublic) {
     try {
         const now = isPublic ? new Date().toISOString() : null;
-        await chatPool.query(
+        const result = await chatPool.query(
             `UPDATE entities SET is_public = $1, published_at = CASE WHEN $1 THEN COALESCE(published_at, $2::timestamptz) ELSE published_at END
              WHERE device_id = $3 AND entity_id = $4`,
             [isPublic, now, deviceId, entityId]
         );
+        // If entity row doesn't exist yet, INSERT it (saveDeviceData may not have run)
+        if (result.rowCount === 0) {
+            console.warn(`[DB] setEntityPublic: entity ${deviceId}:${entityId} not in DB yet, inserting`);
+            await chatPool.query(
+                `INSERT INTO entities (device_id, entity_id, is_public, published_at, is_bound)
+                 VALUES ($1, $2, $3, $4, true)
+                 ON CONFLICT (device_id, entity_id) DO UPDATE SET is_public = $3, published_at = COALESCE(EXCLUDED.published_at, entities.published_at)`,
+                [deviceId, entityId, isPublic, now]
+            );
+        }
         return true;
     } catch (err) {
         console.error('[DB] setEntityPublic error:', err.message);

--- a/backend/index.js
+++ b/backend/index.js
@@ -6485,16 +6485,16 @@ app.put('/api/entity/agent-card', (req, res) => {
     if (isPublic !== undefined) {
         entity.isPublic = !!isPublic;
         entity.publishedAt = isPublic ? (entity.publishedAt || Date.now()) : null;
-        // Persist is_public to DB (separate column, not part of saveDeviceData)
-        db.setEntityPublic(deviceId, parseInt(entityId), !!isPublic).catch(err =>
-            console.error('[AgentCard] setEntityPublic error:', err.message)
-        );
         serverLog('info', 'bot_plaza', `Entity ${entityId} visibility: ${isPublic ? 'PUBLIC' : 'PRIVATE'}`, { deviceId, entityId });
     }
 
-    // Persist to DB
+    // Persist to DB — saveDeviceData FIRST (ensures entity row exists), then setEntityPublic
     if (typeof db.saveDeviceData === 'function') {
-        db.saveDeviceData(deviceId, device).catch(err => console.error('[AgentCard] DB save error:', err.message));
+        db.saveDeviceData(deviceId, device).then(() => {
+            if (isPublic !== undefined) {
+                return db.setEntityPublic(deviceId, parseInt(entityId), !!isPublic);
+            }
+        }).catch(err => console.error('[AgentCard] DB save error:', err.message));
     }
     res.json({ success: true, agentCard: card, isPublic: !!entity.isPublic });
 });


### PR DESCRIPTION
## Root Cause
`setEntityPublic` 跑 UPDATE 但 entity row 不在 DB 裡（`saveDeviceData` 還沒被呼叫），UPDATE hits 0 rows。

## Fix
1. **index.js**: `saveDeviceData().then(setEntityPublic())` — 確保 entity row 先存在
2. **db.js**: `setEntityPublic` 加 fallback INSERT ON CONFLICT — 雙重保險

Merge 後再 PUT agent-card 一次 public:true，community search 就能找到了。