### PR TITLE
[P0-1] Bot 訊息 Markdown 渲染

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -192,6 +192,87 @@
             border-bottom-left-radius: 4px;
         }
 
+        /* Markdown rendered content inside bot bubbles */
+        .chat-bubble.md-rendered {
+            white-space: normal;
+        }
+        .chat-bubble.md-rendered h1,
+        .chat-bubble.md-rendered h2,
+        .chat-bubble.md-rendered h3 {
+            margin: 0.4em 0 0.2em;
+            line-height: 1.3;
+        }
+        .chat-bubble.md-rendered h1 { font-size: 1.3em; }
+        .chat-bubble.md-rendered h2 { font-size: 1.15em; }
+        .chat-bubble.md-rendered h3 { font-size: 1.05em; }
+        .chat-bubble.md-rendered p {
+            margin: 0.3em 0;
+        }
+        .chat-bubble.md-rendered ul,
+        .chat-bubble.md-rendered ol {
+            margin: 0.3em 0;
+            padding-left: 1.5em;
+        }
+        .chat-bubble.md-rendered li {
+            margin: 0.15em 0;
+        }
+        .chat-bubble.md-rendered code {
+            background: rgba(255,255,255,0.1);
+            padding: 0.15em 0.4em;
+            border-radius: 4px;
+            font-size: 0.9em;
+            font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, monospace;
+        }
+        .chat-bubble.md-rendered pre {
+            background: rgba(0,0,0,0.3);
+            padding: 0.6em 0.8em;
+            border-radius: 6px;
+            overflow-x: auto;
+            margin: 0.4em 0;
+        }
+        .chat-bubble.md-rendered pre code {
+            background: none;
+            padding: 0;
+        }
+        .chat-bubble.md-rendered table {
+            border-collapse: collapse;
+            margin: 0.4em 0;
+            width: 100%;
+            font-size: 0.9em;
+        }
+        .chat-bubble.md-rendered th,
+        .chat-bubble.md-rendered td {
+            border: 1px solid var(--card-border, rgba(255,255,255,0.2));
+            padding: 0.3em 0.6em;
+            text-align: left;
+        }
+        .chat-bubble.md-rendered th {
+            background: rgba(255,255,255,0.05);
+        }
+        .chat-bubble.md-rendered blockquote {
+            border-left: 3px solid var(--primary, #7c3aed);
+            margin: 0.4em 0;
+            padding: 0.2em 0.8em;
+            opacity: 0.85;
+        }
+        .chat-bubble.md-rendered a {
+            color: inherit;
+            text-decoration: underline;
+            text-underline-offset: 2px;
+        }
+        .chat-bubble.md-rendered > *:first-child {
+            margin-top: 0;
+        }
+        .chat-bubble.md-rendered > *:last-child {
+            margin-bottom: 0;
+        }
+        .chat-msg.sent .chat-bubble.md-rendered code {
+            background: rgba(255,255,255,0.15);
+        }
+        .chat-msg.sent .chat-bubble.md-rendered pre {
+            background: rgba(0,0,0,0.25);
+        }
+
         .chat-msg.platform {
             align-self: center;
             align-items: center;
@@ -1182,6 +1263,8 @@
         }
     </style>
     <link rel="canonical" href="https://eclawbot.com/portal/chat.html">
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
 </head>
 
 <body>
@@ -2352,10 +2435,21 @@
                 const isPlaceholder = (rawText === '[Photo]' || rawText === '[Video]' || rawText === '[Voice message]' || rawText.startsWith('[File]'));
                 let textHtml = '';
                 let firstUrl = '';
+                let isMdRendered = false;
                 if (!isPlaceholder && rawText) {
-                    const linkified = linkifyText(escapeHtml(rawText));
-                    textHtml = linkified.html;
-                    firstUrl = linkified.urls[0] || '';
+                    if (msg.is_from_bot && typeof marked !== 'undefined' && typeof DOMPurify !== 'undefined') {
+                        // Bot messages: render Markdown
+                        textHtml = DOMPurify.sanitize(marked.parse(rawText));
+                        isMdRendered = true;
+                        // Extract first URL for link preview
+                        const urlMatch = rawText.match(/https?:\/\/[^\s<>\])"']+/);
+                        firstUrl = urlMatch ? urlMatch[0] : '';
+                    } else {
+                        // User messages: plain text with linkify
+                        const linkified = linkifyText(escapeHtml(rawText));
+                        textHtml = linkified.html;
+                        firstUrl = linkified.urls[0] || '';
+                    }
                 }
                 const firstUrlIsImage = firstUrl && isImageUrl(firstUrl);
                 const inlineImgHtml = firstUrlIsImage
@@ -2423,7 +2517,7 @@
                 return `
                     <div class="chat-msg ${msgClass}">
                         <div class="chat-source">${sourceLabel}</div>
-                        <div class="chat-bubble">${textHtml}${mediaHtml}${inlineImgHtml}</div>
+                        <div class="chat-bubble${isMdRendered ? ' md-rendered' : ''}">${textHtml}${mediaHtml}${inlineImgHtml}</div>
                         ${previewId ? `<div class="link-preview-slot" id="${previewId}" data-url="${escapeHtml(firstUrl)}"></div>` : ''}
                         ${reactionsHtml}
                         <div class="chat-meta">${time}</div>


### PR DESCRIPTION
## 變更內容

### chat.html — Bot 訊息改用 Markdown 渲染

**新增 CDN：**
- `marked.js` — Markdown parser
- `DOMPurify` — HTML sanitizer

**邏輯變更（renderMessages 約 L2356）：**
- `is_from_bot=true` → `marked.parse(rawText)` + `DOMPurify.sanitize()`
- 用戶訊息不變，維持 `linkifyText(escapeHtml(rawText))`
- Bot 訊息的 `.chat-bubble` 加上 `.md-rendered` class
- 從 rawText 用 regex 提取第一個 URL 給 link preview（避免 linkify 重複處理）

**新增 CSS（.chat-bubble.md-rendered）：**
- `white-space: normal`（覆蓋 `pre-wrap`）
- h1-h3 字級 + margin
- ul/ol 縮排
- `code` 背景 + 圓角 + monospace
- `pre` 深色背景 + overflow-x
- `table` border-collapse + th/td border
- `blockquote` 左邊紫線
- 第一/最後元素 margin 歸零
- sent 泡泡的 code/pre 針對白字調色

**+98 行 / -4 行**

## 測試項目
- [ ] 粗體 `**bold**`
- [ ] 列表 `- item` / `1. item`
- [ ] Code block `` ` `` 和 ``` ``` ```
- [ ] 連結自動可點
- [ ] 表格
- [ ] 用戶訊息不受影響（純文字）
- [ ] marked/DOMPurify CDN 載入失敗時 fallback（走原本 linkify 路徑）