### PR TITLE
fix(chat): 智慧過濾鎖定時不自動捲動到新訊息

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -2525,8 +2525,9 @@
                     </div>`;
             }).join('');
 
-            // Auto-scroll
-            if (isFirstLoad || hasNewMessages || wasAtBottom) {
+            // Auto-scroll — skip when smart filter is locked on a specific entity/contact
+            const isFilteredView = currentFilter !== 'all';
+            if (isFirstLoad || (hasNewMessages && !isFilteredView) || wasAtBottom) {
                 container.scrollTop = container.scrollHeight;
             }
 


### PR DESCRIPTION
## 問題
聊天頁面智慧過濾鎖定在某個單位時，新訊息進來會自動捲動畫面，導致用戶正在閱讀的位置被打斷。

## 修復
`renderMessages` 的 auto-scroll 加入 filter 判斷：
- `currentFilter !== "all"` → 新訊息不自動捲動
- 用戶已在底部（wasAtBottom）→ 仍然捲動
- 首次載入 → 仍然捲動
- 用戶自己發送訊息 → 仍然捲動（不受影響）

## 改動
- `chat.html` renderMessages 函數，1 行邏輯變更