### PR TITLE
fix: [SILENT] 訊息不應出現在聊天頁面

### DIFF
--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -602,7 +602,9 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             // Check for pending cross-device context first, so local copy also shows routing direction
             const pendingCross = message ? (entity.messageQueue && entity.messageQueue.findLast(m => m.crossDevice)) : null;
             const hasCrossRoute = !!(pendingCross && pendingCross.fromDeviceId);
-            if (message) {
+            // Skip silent tokens — internal signals should not appear in chat
+            const isSilentMsg = message && /^\[SILENT\]$/i.test(message.trim());
+            if (message && !isSilentMsg) {
                 // If replying to a cross-device message, tag local copy with routing info
                 const localSource = hasCrossRoute
                     ? `xdevice:${entity.publicCode}:${entity.character}->${pendingCross.fromPublicCode || pendingCross.fromDeviceId}`

--- a/backend/index.js
+++ b/backend/index.js
@@ -3973,7 +3973,9 @@ app.post('/api/transform', (req, res) => {
     entity.lastUpdated = Date.now();
 
     // Save bot message to chat history so it appears in Chat page
-    if (finalMessage) {
+    // Skip silent tokens — these are internal signals that should not appear in chat
+    const isSilentMessage = finalMessage && /^\[SILENT\]$/i.test(finalMessage.trim());
+    if (finalMessage && !isSilentMessage) {
         saveChatMessage(deviceId, eId, finalMessage, entity.name || `Entity ${eId}`, false, true);
         markMessagesAsRead(deviceId, eId);
 


### PR DESCRIPTION
Bot 回覆 [SILENT] 是內部信號，不應存入聊天記錄。

修復：在 /api/transform 和 channel-api 的 saveChatMessage 前過濾 [SILENT]。