### PR TITLE
feat(backend): [Mission v2] Kanban Card CRUD API

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1058,6 +1058,10 @@ document.getElementById('content').innerHTML = marked.parse(${JSON.stringify(mdC
 const missionModule = require('./mission')(devices, { awardEntityXP, serverLog });
 app.use('/api/mission', missionModule.router);
 
+// Kanban Board (Mission v2) — mounted on same /api/mission path
+const kanbanModule = require('./kanban')(devices, { awardEntityXP, serverLog });
+app.use('/api/mission', kanbanModule.router);
+
 // ============================================
 // PAGE VIEW TRACKING (fire-and-forget)
 // ============================================
@@ -1343,6 +1347,7 @@ app.use('/api/docs', apiDocs.router);
 const botTools = require('./bot-tools');
 app.use('/api/bot', botTools.router);
 missionModule.initMissionDatabase();
+kanbanModule.initKanbanDatabase();
 // Wire notification callback (notifyDevice defined later, uses closure)
 missionModule.setNotifyCallback((deviceId, notif) => notifyDevice(deviceId, notif));
 

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -1,0 +1,897 @@
+/**
+ * Mission Center v2 — Kanban Board API
+ *
+ * Mounted at: /api/mission  (alongside existing mission.js routes)
+ *
+ * Cards CRUD:
+ *   POST   /card          — Create card
+ *   GET    /cards          — List cards (filter by status, archived)
+ *   GET    /card/:id       — Get card detail (with comments, notes, files)
+ *   PUT    /card/:id       — Update card fields
+ *   DELETE /card/:id       — Archive card
+ *
+ * Status transition:
+ *   POST   /card/:id/move  — Move card to new status + reassign
+ *
+ * Comments (留言板):
+ *   GET    /card/:id/comments
+ *   POST   /card/:id/comment
+ *
+ * Notes (筆記區):
+ *   GET    /card/:id/notes
+ *   POST   /card/:id/note
+ *
+ * Files (檔案區):
+ *   POST   /card/:id/file       (URL-based, not multipart for now)
+ *   GET    /card/:id/files
+ *
+ * Config:
+ *   PUT    /card/:id/config     — Update staleThresholdMs / doneRetentionMs
+ *
+ * Archived:
+ *   GET    /cards/archived      — List archived cards (paginated)
+ */
+
+const express = require('express');
+const { Pool } = require('pg');
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const safeEqual = require('./safe-equal');
+
+const pool = new Pool({
+    connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
+});
+
+// Valid statuses in order
+const STATUSES = ['backlog', 'todo', 'in_progress', 'review', 'done'];
+const PRIORITIES = ['P0', 'P1', 'P2', 'P3'];
+const STATUS_LABELS = {
+    backlog: 'Backlog',
+    todo: 'TODO',
+    in_progress: 'In Progress',
+    review: 'Review',
+    done: 'Done'
+};
+const PRIORITY_COLORS = { P0: '🔴', P1: '🟠', P2: '🔵', P3: '⚪' };
+
+// ── Schema init ──
+async function initKanbanDatabase() {
+    try {
+        const schemaPath = path.join(__dirname, 'kanban_schema.sql');
+        const schema = fs.readFileSync(schemaPath, 'utf8');
+        const statements = schema
+            .split(';')
+            .map(s => s.trim())
+            .filter(s => s && !s.startsWith('--'));
+        for (const stmt of statements) {
+            try {
+                await pool.query(stmt);
+            } catch (err) {
+                if (!err.message.includes('already exists') &&
+                    !err.message.includes('duplicate key')) {
+                    console.warn('[Kanban] Schema warning:', err.message);
+                }
+            }
+        }
+        console.log('[Kanban] Database initialized');
+    } catch (error) {
+        console.error('[Kanban] Failed to init database:', error);
+    }
+}
+
+/**
+ * Factory: receives in-memory devices object from index.js
+ */
+module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity } = {}) {
+    const router = express.Router();
+
+    // ── Auth helpers (same as mission.js) ──
+    function findEntityByCredentials(deviceId, entityId, botSecret) {
+        const device = devices[deviceId];
+        if (!device) return null;
+        const entity = (device.entities || {})[entityId];
+        if (!entity || !safeEqual(entity.botSecret, botSecret)) return null;
+        return entity;
+    }
+
+    function findDeviceByCredentials(deviceId, deviceSecret) {
+        const device = devices[deviceId];
+        if (!device || !safeEqual(device.deviceSecret, deviceSecret)) return null;
+        return device;
+    }
+
+    function authenticate(req, res) {
+        const params = { ...req.query, ...req.body };
+        const { deviceId, deviceSecret, botSecret, entityId } = params;
+
+        if (!deviceId) {
+            res.status(400).json({ success: false, error: 'Missing deviceId' });
+            return false;
+        }
+
+        if (deviceSecret) {
+            const device = findDeviceByCredentials(deviceId, deviceSecret);
+            if (device) return true;
+        }
+
+        if (botSecret) {
+            const entity = findEntityByCredentials(deviceId, parseInt(entityId || 0), botSecret);
+            if (entity) return true;
+        }
+
+        if (!deviceSecret && !botSecret) {
+            res.status(400).json({ success: false, error: 'Missing deviceSecret or botSecret' });
+        } else {
+            res.status(401).json({ success: false, error: 'Invalid credentials' });
+        }
+        return false;
+    }
+
+    // ── Helper: bump dashboard version (to trigger frontend refresh) ──
+    async function bumpVersion(deviceId) {
+        try {
+            await pool.query(
+                `UPDATE mission_dashboard SET updated_at = NOW() WHERE device_id = $1`,
+                [deviceId]
+            );
+        } catch (e) {
+            console.warn('[Kanban] Failed to bump version:', e.message);
+        }
+    }
+
+    // ── Helper: add system comment to card ──
+    async function addSystemComment(cardId, deviceId, text) {
+        await pool.query(
+            `INSERT INTO kanban_comments (card_id, device_id, from_entity_id, text, is_system)
+             VALUES ($1, $2, -1, $3, true)`,
+            [cardId, deviceId, text]
+        );
+    }
+
+    // ── Helper: push notification to entity (non-blocking) ──
+    async function notifyEntities(deviceId, entityIds, message) {
+        if (!pushToEntity) return;
+        for (const eid of entityIds) {
+            try {
+                await pushToEntity(deviceId, eid, message);
+            } catch (e) {
+                console.warn(`[Kanban] Failed to push to entity ${eid}:`, e.message);
+            }
+        }
+    }
+
+    // ── Helper: serialize card row to API response ──
+    function serializeCard(row) {
+        return {
+            id: row.id,
+            title: row.title,
+            description: row.description || '',
+            priority: row.priority,
+            status: row.status,
+            assignedBots: row.assigned_bots || [],
+            createdBy: row.created_by,
+            statusChangedAt: row.status_changed_at ? new Date(row.status_changed_at).getTime() : null,
+            staleThresholdMs: parseInt(row.stale_threshold_ms) || 10800000,
+            doneRetentionMs: parseInt(row.done_retention_ms) || 86400000,
+            archived: row.archived || false,
+            createdAt: row.created_at ? new Date(row.created_at).getTime() : null,
+            updatedAt: row.updated_at ? new Date(row.updated_at).getTime() : null,
+            // Aggregated counts (if present from JOIN)
+            commentCount: parseInt(row.comment_count) || 0,
+            noteCount: parseInt(row.note_count) || 0,
+            fileCount: parseInt(row.file_count) || 0,
+        };
+    }
+
+    // ============================================
+    // POST /card — Create card
+    // ============================================
+    router.post('/card', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const { deviceId, title, description, priority, status, assignedBots, entityId } = req.body;
+
+        if (!title || !title.trim()) {
+            return res.status(400).json({ success: false, error: 'Missing title' });
+        }
+
+        const cardPriority = PRIORITIES.includes(priority) ? priority : 'P2';
+        const cardStatus = STATUSES.includes(status) ? status : 'backlog';
+        const bots = Array.isArray(assignedBots) ? assignedBots.map(Number) : [];
+        const createdBy = parseInt(entityId || 0);
+
+        try {
+            const result = await pool.query(
+                `INSERT INTO kanban_cards (device_id, title, description, priority, status, assigned_bots, created_by, status_changed_at)
+                 VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, NOW())
+                 RETURNING *`,
+                [deviceId, title.trim(), description || '', cardPriority, cardStatus, JSON.stringify(bots), createdBy]
+            );
+
+            const card = serializeCard(result.rows[0]);
+            await bumpVersion(deviceId);
+
+            // System comment
+            await addSystemComment(card.id, deviceId, `📋 卡片建立 — 狀態: ${STATUS_LABELS[cardStatus]}，指派給: ${bots.map(b => `#${b}`).join(', ') || '未指派'}`);
+
+            // Push notify assigned bots if status != backlog
+            if (cardStatus !== 'backlog' && bots.length > 0) {
+                const msg = `📋 新任務指派：${PRIORITY_COLORS[cardPriority]} [${cardPriority}] ${title.trim()}\n狀態: ${STATUS_LABELS[cardStatus]}`;
+                notifyEntities(deviceId, bots, msg);
+            }
+
+            if (awardEntityXP) {
+                try { await awardEntityXP(deviceId, createdBy, 10); } catch (e) { /* ignore */ }
+            }
+
+            res.json({ success: true, card });
+        } catch (err) {
+            console.error('[Kanban] Create card error:', err);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
+    // ============================================
+    // GET /cards — List cards
+    // ============================================
+    router.get('/cards', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const { deviceId } = { ...req.query, ...req.body };
+        const { status: filterStatus, assignedBot, priority: filterPriority } = req.query;
+
+        try {
+            let query = `
+                SELECT c.*,
+                    COALESCE(cm.cnt, 0) AS comment_count,
+                    COALESCE(n.cnt, 0) AS note_count,
+                    COALESCE(f.cnt, 0) AS file_count
+                FROM kanban_cards c
+                LEFT JOIN (SELECT card_id, COUNT(*) AS cnt FROM kanban_comments GROUP BY card_id) cm ON cm.card_id = c.id
+                LEFT JOIN (SELECT card_id, COUNT(*) AS cnt FROM kanban_notes GROUP BY card_id) n ON n.card_id = c.id
+                LEFT JOIN (SELECT card_id, COUNT(*) AS cnt FROM kanban_files GROUP BY card_id) f ON f.card_id = c.id
+                WHERE c.device_id = $1 AND c.archived = false
+            `;
+            const params = [deviceId];
+            let paramIdx = 2;
+
+            if (filterStatus && STATUSES.includes(filterStatus)) {
+                query += ` AND c.status = $${paramIdx++}`;
+                params.push(filterStatus);
+            }
+
+            if (assignedBot !== undefined) {
+                query += ` AND c.assigned_bots @> $${paramIdx++}::jsonb`;
+                params.push(JSON.stringify([parseInt(assignedBot)]));
+            }
+
+            if (filterPriority && PRIORITIES.includes(filterPriority)) {
+                query += ` AND c.priority = $${paramIdx++}`;
+                params.push(filterPriority);
+            }
+
+            // Order: P0 first, then by status position, then newest first
+            query += ` ORDER BY 
+                CASE c.priority WHEN 'P0' THEN 0 WHEN 'P1' THEN 1 WHEN 'P2' THEN 2 WHEN 'P3' THEN 3 END,
+                CASE c.status WHEN 'in_progress' THEN 0 WHEN 'review' THEN 1 WHEN 'todo' THEN 2 WHEN 'backlog' THEN 3 WHEN 'done' THEN 4 END,
+                c.created_at DESC`;
+
+            const result = await pool.query(query, params);
+            const cards = result.rows.map(serializeCard);
+
+            // Group by status for kanban view
+            const board = {};
+            for (const s of STATUSES) board[s] = [];
+            for (const card of cards) {
+                if (board[card.status]) board[card.status].push(card);
+            }
+
+            res.json({ success: true, cards, board, total: cards.length });
+        } catch (err) {
+            console.error('[Kanban] List cards error:', err);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
+    // ============================================
+    // GET /cards/archived — Archived cards (paginated)
+    // ============================================
+    router.get('/cards/archived', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const { deviceId } = { ...req.query, ...req.body };
+        const page = Math.max(1, parseInt(req.query.page) || 1);
+        const limit = Math.min(50, Math.max(1, parseInt(req.query.limit) || 20));
+        const offset = (page - 1) * limit;
+
+        try {
+            const countResult = await pool.query(
+                `SELECT COUNT(*) FROM kanban_cards WHERE device_id = $1 AND archived = true`,
+                [deviceId]
+            );
+            const total = parseInt(countResult.rows[0].count);
+
+            const result = await pool.query(
+                `SELECT c.*,
+                    COALESCE(cm.cnt, 0) AS comment_count,
+                    COALESCE(n.cnt, 0) AS note_count,
+                    COALESCE(f.cnt, 0) AS file_count
+                FROM kanban_cards c
+                LEFT JOIN (SELECT card_id, COUNT(*) AS cnt FROM kanban_comments GROUP BY card_id) cm ON cm.card_id = c.id
+                LEFT JOIN (SELECT card_id, COUNT(*) AS cnt FROM kanban_notes GROUP BY card_id) n ON n.card_id = c.id
+                LEFT JOIN (SELECT card_id, COUNT(*) AS cnt FROM kanban_files GROUP BY card_id) f ON f.card_id = c.id
+                WHERE c.device_id = $1 AND c.archived = true
+                ORDER BY c.archived_at DESC NULLS LAST
+                LIMIT $2 OFFSET $3`,
+                [deviceId, limit, offset]
+            );
+
+            res.json({
+                success: true,
+                cards: result.rows.map(serializeCard),
+                total,
+                page,
+                pages: Math.ceil(total / limit)
+            });
+        } catch (err) {
+            console.error('[Kanban] Archived cards error:', err);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
+    // ============================================
+    // GET /card/:id — Card detail
+    // ============================================
+    router.get('/card/:id', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const { deviceId } = { ...req.query, ...req.body };
+        const cardId = req.params.id;
+
+        try {
+            const cardResult = await pool.query(
+                `SELECT c.*,
+                    COALESCE(cm.cnt, 0) AS comment_count,
+                    COALESCE(n.cnt, 0) AS note_count,
+                    COALESCE(f.cnt, 0) AS file_count
+                FROM kanban_cards c
+                LEFT JOIN (SELECT card_id, COUNT(*) AS cnt FROM kanban_comments GROUP BY card_id) cm ON cm.card_id = c.id
+                LEFT JOIN (SELECT card_id, COUNT(*) AS cnt FROM kanban_notes GROUP BY card_id) n ON n.card_id = c.id
+                LEFT JOIN (SELECT card_id, COUNT(*) AS cnt FROM kanban_files GROUP BY card_id) f ON f.card_id = c.id
+                WHERE c.id = $1 AND c.device_id = $2`,
+                [cardId, deviceId]
+            );
+
+            if (cardResult.rows.length === 0) {
+                return res.status(404).json({ success: false, error: 'Card not found' });
+            }
+
+            const card = serializeCard(cardResult.rows[0]);
+
+            // Fetch comments (latest 50)
+            const commentsResult = await pool.query(
+                `SELECT * FROM kanban_comments WHERE card_id = $1 ORDER BY created_at ASC LIMIT 50`,
+                [cardId]
+            );
+            card.comments = commentsResult.rows.map(r => ({
+                id: r.id,
+                fromEntityId: r.from_entity_id,
+                text: r.text,
+                isSystem: r.is_system,
+                createdAt: new Date(r.created_at).getTime()
+            }));
+
+            // Fetch notes
+            const notesResult = await pool.query(
+                `SELECT * FROM kanban_notes WHERE card_id = $1 ORDER BY created_at DESC`,
+                [cardId]
+            );
+            card.notes = notesResult.rows.map(r => ({
+                id: r.id,
+                title: r.title,
+                content: r.content,
+                fromEntityId: r.from_entity_id,
+                createdAt: new Date(r.created_at).getTime(),
+                updatedAt: new Date(r.updated_at).getTime()
+            }));
+
+            // Fetch files
+            const filesResult = await pool.query(
+                `SELECT * FROM kanban_files WHERE card_id = $1 ORDER BY created_at DESC`,
+                [cardId]
+            );
+            card.files = filesResult.rows.map(r => ({
+                id: r.id,
+                filename: r.filename,
+                url: r.url,
+                mimeType: r.mime_type,
+                fileSize: r.file_size ? parseInt(r.file_size) : null,
+                uploadedBy: r.uploaded_by,
+                createdAt: new Date(r.created_at).getTime()
+            }));
+
+            res.json({ success: true, card });
+        } catch (err) {
+            console.error('[Kanban] Get card error:', err);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
+    // ============================================
+    // PUT /card/:id — Update card fields
+    // ============================================
+    router.put('/card/:id', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const { deviceId, title, description, priority, assignedBots } = req.body;
+        const cardId = req.params.id;
+
+        try {
+            // Check card exists and belongs to device
+            const existing = await pool.query(
+                `SELECT * FROM kanban_cards WHERE id = $1 AND device_id = $2`,
+                [cardId, deviceId]
+            );
+            if (existing.rows.length === 0) {
+                return res.status(404).json({ success: false, error: 'Card not found' });
+            }
+
+            const updates = [];
+            const params = [];
+            let paramIdx = 1;
+
+            if (title !== undefined) {
+                updates.push(`title = $${paramIdx++}`);
+                params.push(title.trim());
+            }
+            if (description !== undefined) {
+                updates.push(`description = $${paramIdx++}`);
+                params.push(description);
+            }
+            if (priority !== undefined && PRIORITIES.includes(priority)) {
+                updates.push(`priority = $${paramIdx++}`);
+                params.push(priority);
+            }
+            if (assignedBots !== undefined && Array.isArray(assignedBots)) {
+                updates.push(`assigned_bots = $${paramIdx++}::jsonb`);
+                params.push(JSON.stringify(assignedBots.map(Number)));
+            }
+
+            if (updates.length === 0) {
+                return res.status(400).json({ success: false, error: 'Nothing to update' });
+            }
+
+            updates.push(`updated_at = NOW()`);
+            params.push(cardId);
+            params.push(deviceId);
+
+            const result = await pool.query(
+                `UPDATE kanban_cards SET ${updates.join(', ')}
+                 WHERE id = $${paramIdx++} AND device_id = $${paramIdx++}
+                 RETURNING *`,
+                params
+            );
+
+            await bumpVersion(deviceId);
+            res.json({ success: true, card: serializeCard(result.rows[0]) });
+        } catch (err) {
+            console.error('[Kanban] Update card error:', err);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
+    // ============================================
+    // DELETE /card/:id — Archive card
+    // ============================================
+    router.delete('/card/:id', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const { deviceId } = { ...req.query, ...req.body };
+        const cardId = req.params.id;
+
+        try {
+            const result = await pool.query(
+                `UPDATE kanban_cards SET archived = true, archived_at = NOW(), updated_at = NOW()
+                 WHERE id = $1 AND device_id = $2
+                 RETURNING *`,
+                [cardId, deviceId]
+            );
+
+            if (result.rows.length === 0) {
+                return res.status(404).json({ success: false, error: 'Card not found' });
+            }
+
+            await addSystemComment(cardId, deviceId, '🗄️ 卡片已歸檔');
+            await bumpVersion(deviceId);
+
+            res.json({ success: true, message: 'Card archived' });
+        } catch (err) {
+            console.error('[Kanban] Archive card error:', err);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
+    // ============================================
+    // POST /card/:id/move — Move card status
+    // ============================================
+    router.post('/card/:id/move', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const { deviceId, newStatus, assignedBots } = req.body;
+        const cardId = req.params.id;
+
+        if (!newStatus || !STATUSES.includes(newStatus)) {
+            return res.status(400).json({ success: false, error: `Invalid status. Must be one of: ${STATUSES.join(', ')}` });
+        }
+
+        try {
+            const existing = await pool.query(
+                `SELECT * FROM kanban_cards WHERE id = $1 AND device_id = $2 AND archived = false`,
+                [cardId, deviceId]
+            );
+            if (existing.rows.length === 0) {
+                return res.status(404).json({ success: false, error: 'Card not found or archived' });
+            }
+
+            const card = existing.rows[0];
+            const oldStatus = card.status;
+
+            // Done cards cannot be moved back
+            if (oldStatus === 'done') {
+                return res.status(400).json({ success: false, error: 'Done cards cannot be moved. Create a new card instead.' });
+            }
+
+            // Same status = no-op
+            if (oldStatus === newStatus) {
+                return res.status(400).json({ success: false, error: 'Card is already in this status' });
+            }
+
+            const bots = Array.isArray(assignedBots) ? assignedBots.map(Number) : (card.assigned_bots || []);
+
+            const result = await pool.query(
+                `UPDATE kanban_cards 
+                 SET status = $1, assigned_bots = $2::jsonb, status_changed_at = NOW(), 
+                     last_stale_nudge_at = NULL, updated_at = NOW()
+                 WHERE id = $3 AND device_id = $4
+                 RETURNING *`,
+                [newStatus, JSON.stringify(bots), cardId, deviceId]
+            );
+
+            const updatedCard = serializeCard(result.rows[0]);
+
+            // System comment
+            const botLabel = bots.map(b => `#${b}`).join(', ') || '未指派';
+            await addSystemComment(cardId, deviceId,
+                `📌 狀態更新：${STATUS_LABELS[oldStatus]} → ${STATUS_LABELS[newStatus]}，指派給: ${botLabel}`);
+
+            // Push notify new assigned bots
+            if (bots.length > 0) {
+                const direction = STATUSES.indexOf(newStatus) > STATUSES.indexOf(oldStatus) ? '➡️' : '⬅️';
+                const msg = `${direction} 任務狀態變更：[${card.title}]\n${STATUS_LABELS[oldStatus]} → ${STATUS_LABELS[newStatus]}`;
+                notifyEntities(deviceId, bots, msg);
+            }
+
+            await bumpVersion(deviceId);
+
+            // Award XP for moving to done
+            if (newStatus === 'done' && awardEntityXP) {
+                for (const bot of bots) {
+                    try { await awardEntityXP(deviceId, bot, 25); } catch (e) { /* ignore */ }
+                }
+            }
+
+            res.json({ success: true, card: updatedCard, transition: { from: oldStatus, to: newStatus } });
+        } catch (err) {
+            console.error('[Kanban] Move card error:', err);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
+    // ============================================
+    // GET /card/:id/comments — List comments
+    // ============================================
+    router.get('/card/:id/comments', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const { deviceId } = { ...req.query, ...req.body };
+        const cardId = req.params.id;
+        const limit = Math.min(100, Math.max(1, parseInt(req.query.limit) || 50));
+        const offset = Math.max(0, parseInt(req.query.offset) || 0);
+
+        try {
+            // Verify card belongs to device
+            const cardCheck = await pool.query(
+                `SELECT id FROM kanban_cards WHERE id = $1 AND device_id = $2`,
+                [cardId, deviceId]
+            );
+            if (cardCheck.rows.length === 0) {
+                return res.status(404).json({ success: false, error: 'Card not found' });
+            }
+
+            const result = await pool.query(
+                `SELECT * FROM kanban_comments WHERE card_id = $1 ORDER BY created_at ASC LIMIT $2 OFFSET $3`,
+                [cardId, limit, offset]
+            );
+
+            const comments = result.rows.map(r => ({
+                id: r.id,
+                fromEntityId: r.from_entity_id,
+                text: r.text,
+                isSystem: r.is_system,
+                createdAt: new Date(r.created_at).getTime()
+            }));
+
+            res.json({ success: true, comments, total: comments.length });
+        } catch (err) {
+            console.error('[Kanban] List comments error:', err);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
+    // ============================================
+    // POST /card/:id/comment — Add comment
+    // ============================================
+    router.post('/card/:id/comment', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const { deviceId, text, entityId, fromEntityId } = req.body;
+        const cardId = req.params.id;
+        const eId = parseInt(fromEntityId ?? entityId ?? 0);
+
+        if (!text || !text.trim()) {
+            return res.status(400).json({ success: false, error: 'Missing text' });
+        }
+
+        try {
+            const cardCheck = await pool.query(
+                `SELECT id, assigned_bots FROM kanban_cards WHERE id = $1 AND device_id = $2`,
+                [cardId, deviceId]
+            );
+            if (cardCheck.rows.length === 0) {
+                return res.status(404).json({ success: false, error: 'Card not found' });
+            }
+
+            const result = await pool.query(
+                `INSERT INTO kanban_comments (card_id, device_id, from_entity_id, text, is_system)
+                 VALUES ($1, $2, $3, $4, false)
+                 RETURNING *`,
+                [cardId, deviceId, eId, text.trim()]
+            );
+
+            const comment = {
+                id: result.rows[0].id,
+                fromEntityId: result.rows[0].from_entity_id,
+                text: result.rows[0].text,
+                isSystem: false,
+                createdAt: new Date(result.rows[0].created_at).getTime()
+            };
+
+            await bumpVersion(deviceId);
+
+            res.json({ success: true, comment });
+        } catch (err) {
+            console.error('[Kanban] Add comment error:', err);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
+    // ============================================
+    // GET /card/:id/notes — List notes
+    // ============================================
+    router.get('/card/:id/notes', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const { deviceId } = { ...req.query, ...req.body };
+        const cardId = req.params.id;
+
+        try {
+            const cardCheck = await pool.query(
+                `SELECT id FROM kanban_cards WHERE id = $1 AND device_id = $2`,
+                [cardId, deviceId]
+            );
+            if (cardCheck.rows.length === 0) {
+                return res.status(404).json({ success: false, error: 'Card not found' });
+            }
+
+            const result = await pool.query(
+                `SELECT * FROM kanban_notes WHERE card_id = $1 ORDER BY created_at DESC`,
+                [cardId]
+            );
+
+            const notes = result.rows.map(r => ({
+                id: r.id,
+                title: r.title,
+                content: r.content,
+                fromEntityId: r.from_entity_id,
+                createdAt: new Date(r.created_at).getTime(),
+                updatedAt: new Date(r.updated_at).getTime()
+            }));
+
+            res.json({ success: true, notes });
+        } catch (err) {
+            console.error('[Kanban] List notes error:', err);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
+    // ============================================
+    // POST /card/:id/note — Add note
+    // ============================================
+    router.post('/card/:id/note', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const { deviceId, title, content, entityId, fromEntityId } = req.body;
+        const cardId = req.params.id;
+        const eId = parseInt(fromEntityId ?? entityId ?? 0);
+
+        if (!content || !content.trim()) {
+            return res.status(400).json({ success: false, error: 'Missing content' });
+        }
+
+        try {
+            const cardCheck = await pool.query(
+                `SELECT id FROM kanban_cards WHERE id = $1 AND device_id = $2`,
+                [cardId, deviceId]
+            );
+            if (cardCheck.rows.length === 0) {
+                return res.status(404).json({ success: false, error: 'Card not found' });
+            }
+
+            const result = await pool.query(
+                `INSERT INTO kanban_notes (card_id, device_id, title, content, from_entity_id)
+                 VALUES ($1, $2, $3, $4, $5)
+                 RETURNING *`,
+                [cardId, deviceId, (title || '').trim(), content.trim(), eId]
+            );
+
+            const note = {
+                id: result.rows[0].id,
+                title: result.rows[0].title,
+                content: result.rows[0].content,
+                fromEntityId: result.rows[0].from_entity_id,
+                createdAt: new Date(result.rows[0].created_at).getTime(),
+                updatedAt: new Date(result.rows[0].updated_at).getTime()
+            };
+
+            await bumpVersion(deviceId);
+            res.json({ success: true, note });
+        } catch (err) {
+            console.error('[Kanban] Add note error:', err);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
+    // ============================================
+    // GET /card/:id/files — List files
+    // ============================================
+    router.get('/card/:id/files', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const { deviceId } = { ...req.query, ...req.body };
+        const cardId = req.params.id;
+
+        try {
+            const cardCheck = await pool.query(
+                `SELECT id FROM kanban_cards WHERE id = $1 AND device_id = $2`,
+                [cardId, deviceId]
+            );
+            if (cardCheck.rows.length === 0) {
+                return res.status(404).json({ success: false, error: 'Card not found' });
+            }
+
+            const result = await pool.query(
+                `SELECT * FROM kanban_files WHERE card_id = $1 ORDER BY created_at DESC`,
+                [cardId]
+            );
+
+            const files = result.rows.map(r => ({
+                id: r.id,
+                filename: r.filename,
+                url: r.url,
+                mimeType: r.mime_type,
+                fileSize: r.file_size ? parseInt(r.file_size) : null,
+                uploadedBy: r.uploaded_by,
+                createdAt: new Date(r.created_at).getTime()
+            }));
+
+            res.json({ success: true, files });
+        } catch (err) {
+            console.error('[Kanban] List files error:', err);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
+    // ============================================
+    // POST /card/:id/file — Add file (URL-based)
+    // ============================================
+    router.post('/card/:id/file', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const { deviceId, filename, url, mimeType, fileSize, entityId } = req.body;
+        const cardId = req.params.id;
+        const uploadedBy = parseInt(entityId || 0);
+
+        if (!filename || !url) {
+            return res.status(400).json({ success: false, error: 'Missing filename or url' });
+        }
+
+        try {
+            const cardCheck = await pool.query(
+                `SELECT id FROM kanban_cards WHERE id = $1 AND device_id = $2`,
+                [cardId, deviceId]
+            );
+            if (cardCheck.rows.length === 0) {
+                return res.status(404).json({ success: false, error: 'Card not found' });
+            }
+
+            const result = await pool.query(
+                `INSERT INTO kanban_files (card_id, device_id, filename, url, mime_type, file_size, uploaded_by)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7)
+                 RETURNING *`,
+                [cardId, deviceId, filename, url, mimeType || null, fileSize || null, uploadedBy]
+            );
+
+            const file = {
+                id: result.rows[0].id,
+                filename: result.rows[0].filename,
+                url: result.rows[0].url,
+                mimeType: result.rows[0].mime_type,
+                fileSize: result.rows[0].file_size ? parseInt(result.rows[0].file_size) : null,
+                uploadedBy: result.rows[0].uploaded_by,
+                createdAt: new Date(result.rows[0].created_at).getTime()
+            };
+
+            await bumpVersion(deviceId);
+            res.json({ success: true, file });
+        } catch (err) {
+            console.error('[Kanban] Add file error:', err);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
+    // ============================================
+    // PUT /card/:id/config — Update thresholds
+    // ============================================
+    router.put('/card/:id/config', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const { deviceId, staleThresholdMs, doneRetentionMs } = req.body;
+        const cardId = req.params.id;
+
+        try {
+            const updates = [];
+            const params = [];
+            let paramIdx = 1;
+
+            if (staleThresholdMs !== undefined) {
+                const val = parseInt(staleThresholdMs);
+                if (isNaN(val) || val < 600000) { // min 10 minutes
+                    return res.status(400).json({ success: false, error: 'staleThresholdMs must be >= 600000 (10 min)' });
+                }
+                updates.push(`stale_threshold_ms = $${paramIdx++}`);
+                params.push(val);
+            }
+            if (doneRetentionMs !== undefined) {
+                const val = parseInt(doneRetentionMs);
+                if (isNaN(val) || val < 3600000) { // min 1 hour
+                    return res.status(400).json({ success: false, error: 'doneRetentionMs must be >= 3600000 (1 hr)' });
+                }
+                updates.push(`done_retention_ms = $${paramIdx++}`);
+                params.push(val);
+            }
+
+            if (updates.length === 0) {
+                return res.status(400).json({ success: false, error: 'Nothing to update' });
+            }
+
+            updates.push(`updated_at = NOW()`);
+            params.push(cardId);
+            params.push(deviceId);
+
+            const result = await pool.query(
+                `UPDATE kanban_cards SET ${updates.join(', ')}
+                 WHERE id = $${paramIdx++} AND device_id = $${paramIdx++}
+                 RETURNING *`,
+                params
+            );
+
+            if (result.rows.length === 0) {
+                return res.status(404).json({ success: false, error: 'Card not found' });
+            }
+
+            res.json({ success: true, card: serializeCard(result.rows[0]) });
+        } catch (err) {
+            console.error('[Kanban] Config card error:', err);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
+    return { router, initKanbanDatabase };
+};

--- a/backend/kanban_schema.sql
+++ b/backend/kanban_schema.sql
@@ -1,0 +1,76 @@
+-- Kanban Board Schema (Mission Center v2)
+-- PostgreSQL
+
+-- ============================================
+-- Kanban Cards Table
+-- ============================================
+CREATE TABLE IF NOT EXISTS kanban_cards (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    device_id VARCHAR(64) NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    description TEXT DEFAULT '',
+    priority VARCHAR(8) NOT NULL DEFAULT 'P2',           -- P0, P1, P2, P3
+    status VARCHAR(16) NOT NULL DEFAULT 'backlog',       -- backlog, todo, in_progress, review, done
+    assigned_bots JSONB DEFAULT '[]'::jsonb,             -- array of entity IDs e.g. [2, 4]
+    created_by INTEGER NOT NULL DEFAULT 0,               -- entity ID of creator
+    status_changed_at TIMESTAMPTZ DEFAULT NOW(),         -- for stale detection
+    stale_threshold_ms BIGINT DEFAULT 10800000,          -- 3 hours
+    done_retention_ms BIGINT DEFAULT 86400000,           -- 24 hours
+    last_stale_nudge_at TIMESTAMPTZ DEFAULT NULL,        -- last nudge timestamp (min 1hr gap)
+    archived BOOLEAN DEFAULT FALSE,
+    archived_at TIMESTAMPTZ DEFAULT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_kanban_cards_device ON kanban_cards(device_id);
+CREATE INDEX IF NOT EXISTS idx_kanban_cards_status ON kanban_cards(device_id, status);
+CREATE INDEX IF NOT EXISTS idx_kanban_cards_archived ON kanban_cards(device_id, archived);
+
+-- ============================================
+-- Kanban Comments Table (留言板)
+-- ============================================
+CREATE TABLE IF NOT EXISTS kanban_comments (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    card_id UUID NOT NULL REFERENCES kanban_cards(id) ON DELETE CASCADE,
+    device_id VARCHAR(64) NOT NULL,
+    from_entity_id INTEGER NOT NULL,
+    text TEXT NOT NULL,
+    is_system BOOLEAN DEFAULT FALSE,                     -- system messages (status changes, nudges)
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_kanban_comments_card ON kanban_comments(card_id, created_at);
+
+-- ============================================
+-- Kanban Notes Table (筆記區)
+-- ============================================
+CREATE TABLE IF NOT EXISTS kanban_notes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    card_id UUID NOT NULL REFERENCES kanban_cards(id) ON DELETE CASCADE,
+    device_id VARCHAR(64) NOT NULL,
+    title VARCHAR(255) NOT NULL DEFAULT '',
+    content TEXT NOT NULL DEFAULT '',
+    from_entity_id INTEGER NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_kanban_notes_card ON kanban_notes(card_id);
+
+-- ============================================
+-- Kanban Files Table (檔案區)
+-- ============================================
+CREATE TABLE IF NOT EXISTS kanban_files (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    card_id UUID NOT NULL REFERENCES kanban_cards(id) ON DELETE CASCADE,
+    device_id VARCHAR(64) NOT NULL,
+    filename VARCHAR(255) NOT NULL,
+    url TEXT NOT NULL,                                   -- link to file (S3, external URL, etc.)
+    mime_type VARCHAR(128) DEFAULT NULL,
+    file_size BIGINT DEFAULT NULL,
+    uploaded_by INTEGER NOT NULL,
+    created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_kanban_files_card ON kanban_files(card_id);


### PR DESCRIPTION
## Mission Center v2 — Kanban 看板系統後端 API

根據 `docs/mission-v2-kanban-spec.md` 規格實作第一階段：Card CRUD。

### 新增檔案
- `backend/kanban.js` — 完整 API 模組（~580 行）
- `backend/kanban_schema.sql` — PostgreSQL schema（4 tables）

### API 端點（14 個）

| Method | Path | 說明 |
|--------|------|------|
| POST | /api/mission/card | 建立卡片 |
| GET | /api/mission/cards | 列出卡片（支援 status/assignedBot/priority 過濾）|
| GET | /api/mission/cards/archived | 歸檔卡片（分頁）|
| GET | /api/mission/card/:id | 卡片詳情（含留言/筆記/檔案）|
| PUT | /api/mission/card/:id | 更新卡片 |
| DELETE | /api/mission/card/:id | 歸檔卡片 |
| POST | /api/mission/card/:id/move | 狀態推進/倒退 |
| GET | /api/mission/card/:id/comments | 留言列表 |
| POST | /api/mission/card/:id/comment | 新增留言 |
| GET | /api/mission/card/:id/notes | 筆記列表 |
| POST | /api/mission/card/:id/note | 新增筆記 |
| GET | /api/mission/card/:id/files | 檔案列表 |
| POST | /api/mission/card/:id/file | 新增檔案 |
| PUT | /api/mission/card/:id/config | 配置閾值 |

### 規格符合度
- ✅ 五欄看板（backlog/todo/in_progress/review/done）
- ✅ 卡片可前進也可倒退（Done 除外）
- ✅ assignedBots 陣列（多 bot）
- ✅ staleThresholdMs / doneRetentionMs 可配置
- ✅ 狀態變更自動系統留言
- ✅ 建立/推進時 push 通知 assigned bots
- ✅ 歸檔系統（soft delete + 分頁查詢）
- ✅ 雙重認證（deviceSecret / botSecret）
- ⏳ 自動催促 + 自動清除（TODO #2 任務）

### DB Schema
- `kanban_cards` — 主卡片表
- `kanban_comments` — 留言板
- `kanban_notes` — 筆記區
- `kanban_files` — 檔案附件