### PR TITLE
fix: kanban module crash resilience (cron-parser optional)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1059,8 +1059,15 @@ const missionModule = require('./mission')(devices, { awardEntityXP, serverLog }
 app.use('/api/mission', missionModule.router);
 
 // Kanban Board (Mission v2) — mounted on same /api/mission path
-const kanbanModule = require('./kanban')(devices, { awardEntityXP, serverLog });
-app.use('/api/mission', kanbanModule.router);
+let kanbanModule;
+try {
+    kanbanModule = require('./kanban')(devices, { awardEntityXP, serverLog });
+    app.use('/api/mission', kanbanModule.router);
+    console.log('[Kanban] Module loaded successfully');
+} catch (err) {
+    console.error('[Kanban] Failed to load module:', err.message);
+    kanbanModule = { initKanbanDatabase: () => {}, startBackgroundTimers: () => {} };
+}
 
 // ============================================
 // PAGE VIEW TRACKING (fire-and-forget)

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -38,7 +38,13 @@ const crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const safeEqual = require('./safe-equal');
-const { CronExpressionParser } = require('cron-parser');
+let CronExpressionParser;
+try {
+    ({ CronExpressionParser } = require('cron-parser'));
+} catch (e) {
+    console.warn('[Kanban] cron-parser not available — schedule features disabled');
+    CronExpressionParser = null;
+}
 
 const pool = new Pool({
     connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
@@ -165,6 +171,7 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity } =
     // ── Helper: compute next cron run time ──
     function computeNextRun(cronExpression, timezone) {
         try {
+            if (!CronExpressionParser) return null;
             const expr = CronExpressionParser.parse(cronExpression, { tz: timezone || 'Asia/Taipei' });
             return expr.next().toDate();
         } catch (e) {


### PR DESCRIPTION
Kanban routes returning 503 because cron-parser import crashes the module.

Fix:
1. index.js: try-catch around kanban require
2. kanban.js: optional cron-parser import