### PR TITLE
fix(kanban): CREATE TABLE 被 comment filter 跳過導致 503

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -67,10 +67,12 @@ async function initKanbanDatabase() {
     try {
         const schemaPath = path.join(__dirname, 'kanban_schema.sql');
         const schema = fs.readFileSync(schemaPath, 'utf8');
-        const statements = schema
+        // Remove SQL comments before splitting (-- line comments and block separators)
+        const cleaned = schema.replace(/--[^\n]*/g, '').replace(/\n\s*\n/g, '\n');
+        const statements = cleaned
             .split(';')
             .map(s => s.trim())
-            .filter(s => s && !s.startsWith('--'));
+            .filter(s => s.length > 5);
         for (const stmt of statements) {
             try {
                 await pool.query(stmt);


### PR DESCRIPTION
根因：initKanbanDatabase 的 SQL parser 用 startsWith("--") 過濾語句，但 CREATE TABLE 前面有 -- 註解行，導致整段被跳過。kanban_cards table 從未建立。

修復：先 strip 所有 SQL 註解再 split。