### PR TITLE
fix(i18n): 7 個 chat_ key 缺失 (unread_sep/date_today/date_yesterday 等)

### DIFF
--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -4557,6 +4557,15 @@ const TRANSLATIONS = {
         // Navigation
         "nav_env_vars": "環境變數",
         "nav_remote_control": "遠端控制",
+
+        // Chat missing keys
+        "chat_date_today": "今天",
+        "chat_date_yesterday": "昨天",
+        "chat_empty_hint": "傳送訊息開始聊天",
+        "chat_mic_denied": "麥克風權限被拒絕",
+        "chat_playback_failed": "播放失敗",
+        "chat_unread_sep": "── 新訊息 ──",
+        "chat_voice_upload_failed": "語音上傳失敗",
         // 看板 (kanban.html)
         "kanban_tab": "看板",
         "kanban_title": "看板",
@@ -6351,6 +6360,15 @@ const TRANSLATIONS = {
         "admin_chart_bot_activity": "各 Bot 活跃度（24h）",
         "admin_chart_users": "位用户",
         "nav_admin": "管理员",
+
+        // Chat missing keys
+        "chat_date_today": "今天",
+        "chat_date_yesterday": "昨天",
+        "chat_empty_hint": "发送消息开始聊天",
+        "chat_mic_denied": "麦克风权限被拒绝",
+        "chat_playback_failed": "播放失败",
+        "chat_unread_sep": "── 新消息 ──",
+        "chat_voice_upload_failed": "语音上传失败",
         "nav_schedule": "定时",
         "sched_title": "定时任务",
         "sched_btn_add": "+ 新增定时",


### PR DESCRIPTION
chat_unread_sep 等 7 個 key 在 i18n.js 完全沒定義，fallback 顯示英文。

新增：chat_date_today/yesterday, chat_empty_hint, chat_mic_denied, chat_playback_failed, chat_unread_sep, chat_voice_upload_failed

三語：en + zh-TW + zh-CN