### PR TITLE
fix(kanban): 接通 push 通知 — 狀態變更通知到 Bot

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1061,7 +1061,7 @@ app.use('/api/mission', missionModule.router);
 // Kanban Board (Mission v2) — mounted on same /api/mission path
 let kanbanModule;
 try {
-    kanbanModule = require('./kanban')(devices, { awardEntityXP, serverLog });
+    kanbanModule = require('./kanban')(devices, { awardEntityXP, serverLog, pushToChannelCallback: (...args) => channelModule.pushToChannelCallback(...args) });
     app.use('/api/mission', kanbanModule.router);
     console.log('[Kanban] Module loaded successfully');
 } catch (err) {

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -101,7 +101,7 @@ async function initKanbanDatabase() {
 /**
  * Factory: receives in-memory devices object from index.js
  */
-module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity } = {}) {
+module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pushToChannelCallback } = {}) {
     const router = express.Router();
 
     // Health check
@@ -171,14 +171,39 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity } =
         );
     }
 
-    // ── Helper: push notification to entity (non-blocking) ──
+    // ── Helper: push notification to entity via channel callback + save to chat ──
     async function notifyEntities(deviceId, entityIds, message) {
-        if (!pushToEntity) return;
+        if (!pushToChannelCallback && !pushToEntity) {
+            console.warn('[Kanban] No push callback available — notifications will not be delivered');
+            return;
+        }
         for (const eid of entityIds) {
             try {
-                await pushToEntity(deviceId, eid, message);
+                const device = devices[deviceId];
+                const entity = device?.entities?.[eid];
+                if (!entity) {
+                    console.warn(`[Kanban] Entity ${eid} not found on device ${deviceId}`);
+                    continue;
+                }
+
+                // Push via channel callback (same as client/speak)
+                if (entity.bindingType === 'channel' && pushToChannelCallback) {
+                    const result = await pushToChannelCallback(deviceId, eid, {
+                        event: 'kanban_notification',
+                        from: 'kanban',
+                        text: message,
+                        eclaw_context: {
+                            silentToken: '[SILENT]',
+                            missionHints: `\n[AVAILABLE TOOLS — Kanban Board]\nRead board: exec: curl -s "https://eclawbot.com/api/mission/cards?deviceId=${deviceId}&botSecret=${entity.botSecret}&entityId=${eid}"\nMove card: exec: curl -s -X POST "https://eclawbot.com/api/mission/card/CARD_ID/move" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","botSecret":"${entity.botSecret}","entityId":${eid},"newStatus":"STATUS","assignedBots":[BOT_IDS]}'\nAdd comment: exec: curl -s -X POST "https://eclawbot.com/api/mission/card/CARD_ID/comment" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","botSecret":"${entity.botSecret}","entityId":${eid},"text":"YOUR_COMMENT"}'\n`
+                        }
+                    }, entity.channelAccountId);
+                    console.log(`[Kanban] Push to entity ${eid}: ${result.pushed ? 'OK' : result.reason}`);
+                } else if (pushToEntity) {
+                    await pushToEntity(deviceId, eid, message);
+                    console.log(`[Kanban] Legacy push to entity ${eid}`);
+                }
             } catch (e) {
-                console.warn(`[Kanban] Failed to push to entity ${eid}:`, e.message);
+                console.error(`[Kanban] Failed to push to entity ${eid}:`, e.message);
             }
         }
     }


### PR DESCRIPTION
問題：kanban 初始化沒傳 pushToChannelCallback → notifyEntities 靜默失敗 → Bot 收不到通知

修復：
1. index.js 傳 pushToChannelCallback 給 kanban
2. notifyEntities 用 channel callback push（同 client/speak）
3. 附帶 kanban API hints 讓 Bot 知道怎麼操作看板
4. debug logging