### PR TITLE
fix(enterprise): correct product catalog note page link

### DIFF
--- a/backend/public/enterprise.html
+++ b/backend/public/enterprise.html
@@ -495,8 +495,8 @@
                 </div>
                 <div>
                     <h3 style="font-size:1rem;margin-bottom:12px;color:var(--primary);" data-i18n="ent_ec_product_title">📦 Product Catalog</h3>
-                    <iframe src="/p/016t1c/9c761df9-d051-4abd-8d60-2afaf16349cf" style="width:100%;height:480px;border:1px solid var(--border);border-radius:12px;background:#0f1117;" loading="lazy"></iframe>
-                    <p style="font-size:12px;color:var(--text-muted);margin-top:8px;text-align:center;" id="ecProductNote"><span data-i18n="ent_ec_product_ai_note">AI-generated product page · </span><a href="/p/016t1c/9c761df9-d051-4abd-8d60-2afaf16349cf" target="_blank" style="color:var(--primary);" data-i18n="ent_ec_product_link">Open in new tab</a></p>
+                    <iframe src="/p/uwgm9y/9c761df9-d051-4abd-8d60-2afaf16349cf" style="width:100%;height:480px;border:1px solid var(--border);border-radius:12px;background:#0f1117;" loading="lazy"></iframe>
+                    <p style="font-size:12px;color:var(--text-muted);margin-top:8px;text-align:center;" id="ecProductNote"><span data-i18n="ent_ec_product_ai_note">AI-generated product page · </span><a href="/p/uwgm9y/9c761df9-d051-4abd-8d60-2afaf16349cf" target="_blank" style="color:var(--primary);" data-i18n="ent_ec_product_link">Open in new tab</a></p>
                 </div>
             </div>
             <div style="text-align:center;margin-top:24px;">


### PR DESCRIPTION
## Summary
- Enterprise page 的商品目錄 iframe 和連結指向不存在的 publicCode `016t1c`，導致 404
- 修正為正確的 publicCode `uwgm9y`（entity_1 的商品目錄筆記）

## Test plan
- [ ] Visit https://eclawbot.com/enterprise and verify 商品目錄 section loads correctly
- [ ] Click "Open in new tab" link and verify it opens the note page

🤖 Generated with [Claude Code](https://claude.com/claude-code)