### PR TITLE
fix(note-page): expand allowed CSS in public page sanitizer

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1252,7 +1252,17 @@ function sanitizePublicHtml(html) {
             '*': ['class', 'id', 'style']
         },
         allowedSchemes: ['http', 'https', 'mailto'],
-        allowedStyles: { '*': { 'color': [/.*/], 'text-align': [/.*/], 'font-size': [/.*/], 'background-color': [/.*/] } }
+        allowedStyles: { '*': {
+            'color': [/.*/], 'background': [/.*/], 'background-color': [/.*/],
+            'text-align': [/.*/], 'text-decoration': [/.*/],
+            'font-size': [/.*/], 'font-weight': [/.*/],
+            'margin': [/.*/], 'margin-top': [/.*/], 'margin-bottom': [/.*/], 'margin-left': [/.*/], 'margin-right': [/.*/],
+            'padding': [/.*/], 'padding-top': [/.*/], 'padding-bottom': [/.*/], 'padding-left': [/.*/], 'padding-right': [/.*/],
+            'border': [/.*/], 'border-radius': [/.*/],
+            'display': [/.*/], 'flex': [/.*/], 'flex-direction': [/.*/], 'gap': [/.*/], 'align-items': [/.*/], 'justify-content': [/.*/],
+            'max-width': [/.*/], 'min-width': [/.*/], 'width': [/.*/], 'height': [/.*/],
+            'line-height': [/.*/], 'white-space': [/.*/], 'overflow': [/.*/], 'opacity': [/.*/]
+        } }
     });
 }
 


### PR DESCRIPTION
## Summary
- 公開筆記頁面的 `sanitizePublicHtml()` 只允許 4 種 CSS 屬性，其他排版用的 style（padding, margin, border-radius, display, flex 等）全被過濾
- 導致公開頁面 (`/p/:code/:noteId`) 渲染結果與 Page Viewer 裡不一樣
- 擴充 allowedStyles 白名單，涵蓋常見排版、間距、flexbox 等 CSS 屬性

## Test plan
- [ ] 對比 Page Viewer 和公開 URL 的渲染結果，應一致
- [ ] 驗證 XSS 防護仍有效（不允許 `position: fixed` 覆蓋、`expression()` 等）

🤖 Generated with [Claude Code](https://claude.com/claude-code)