### PR TITLE
fix(i18n): 實用案例頁面空白修復 — 保留原始 HTML 內容

### DIFF
--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -18948,12 +18948,16 @@ class I18n {
         document.querySelectorAll('[data-i18n]').forEach(el => {
             const key = el.getAttribute('data-i18n');
             if (key) {
+                const translated = this.t(key);
+                // Skip if translation returns the key itself (no translation found)
+                // This preserves the original HTML content as fallback
+                if (translated === key) return;
                 if (el.tagName === 'INPUT' || el.tagName === 'TEXTAREA') {
                     if (el.hasAttribute('placeholder')) {
-                        el.placeholder = this.t(key);
+                        el.placeholder = translated;
                     }
                 } else {
-                    el.innerHTML = this.t(key);
+                    el.innerHTML = translated;
                 }
             }
         });


### PR DESCRIPTION
問題：guide panel 有 737 個 data-i18n key 但 en/zh 都沒翻譯 → t(key) 返回 key 名稱 → innerHTML 被覆蓋成 key 字串 → 頁面看起來空白

修復：如果 t(key) 返回 key 本身（無翻譯），跳過 innerHTML 覆蓋，保留原本的中文 HTML 內容