### PR TITLE
fix(note-page): preserve <style> tags in public page sanitizer

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1244,7 +1244,8 @@ app.get('/p/:code/:noteId', async (req, res) => {
 function sanitizePublicHtml(html) {
     if (!html) return '';
     return sanitizeHtml(html, {
-        allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img', 'h1', 'h2', 'span', 'details', 'summary', 'mark', 'del', 'ins', 'sub', 'sup']),
+        allowVulnerableTags: true,
+        allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img', 'h1', 'h2', 'span', 'details', 'summary', 'mark', 'del', 'ins', 'sub', 'sup', 'style']),
         allowedAttributes: {
             ...sanitizeHtml.defaults.allowedAttributes,
             img: ['src', 'alt', 'width', 'height', 'loading'],


### PR DESCRIPTION
## Summary
- 公開筆記頁面的 sanitizer 過濾掉了 `<style>` 標籤，導致所有 CSS class 定義消失
- 筆記 HTML 包含完整的 `<style>` 區塊定義排版樣式（.phone-frame, .chat-area, .bubble 等），被過濾後只剩 inline style
- 這就是公開 URL 和 Page Viewer 渲染不一致的根本原因
- 新增 `style` 到 allowedTags + `allowVulnerableTags: true`（內容由裝置擁有者創建，風險可接受）

## Test plan
- [ ] 開啟 https://eclawbot.com/p/akdsv7/0843defe-0def-468c-84ba-d5f346940cbb
- [ ] 確認 CSS class 樣式正確渲染（phone frame、chat bubbles、cards 等）
- [ ] 與 Page Viewer 內的渲染結果比對，應一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)