### PR TITLE
feat(workspace): unlimited panes with draggable tab reorder

### DIFF
--- a/backend/public/portal/workspace.html
+++ b/backend/public/portal/workspace.html
@@ -14,12 +14,10 @@
         .workspace-pane {
             border: none;
             height: 100%;
-            min-width: 200px;
+            min-width: 180px;
             background: var(--bg);
+            flex-shrink: 0;
         }
-        .workspace-container.single-pane .workspace-pane.left { width: 100%; }
-        .workspace-container.single-pane .workspace-pane.right { display: none; }
-        .workspace-container.single-pane .workspace-divider { display: none; }
 
         /* Draggable divider */
         .workspace-divider {
@@ -32,17 +30,13 @@
             z-index: 10;
         }
         .workspace-divider:hover,
-        .workspace-divider.dragging {
-            background: var(--accent, #7c6aef);
-        }
+        .workspace-divider.dragging { background: var(--accent, #7c6aef); }
         .workspace-divider::after {
             content: '';
             position: absolute;
-            top: 50%;
-            left: 50%;
+            top: 50%; left: 50%;
             transform: translate(-50%, -50%);
-            width: 2px;
-            height: 32px;
+            width: 2px; height: 32px;
             border-radius: 1px;
             background: var(--text-muted, #666);
             opacity: 0.5;
@@ -50,7 +44,7 @@
         .workspace-divider:hover::after,
         .workspace-divider.dragging::after { opacity: 1; background: #fff; }
 
-        /* Overlay to capture mouse events over iframes during drag */
+        /* Overlay to capture mouse during divider drag */
         .drag-overlay {
             display: none;
             position: fixed;
@@ -62,65 +56,52 @@
         /* Pane label tabs */
         .pane-labels {
             display: flex;
-            height: 32px;
+            height: 34px;
             background: var(--card-bg, #1a1a2e);
             border-bottom: 1px solid var(--card-border, #2a2a3e);
             align-items: center;
-            padding: 0 8px;
-            gap: 4px;
+            padding: 0 6px;
+            gap: 2px;
             font-size: 12px;
+            overflow-x: auto;
         }
         .pane-label {
-            padding: 4px 12px;
-            border-radius: 6px;
+            padding: 5px 10px;
+            border-radius: 6px 6px 0 0;
             color: var(--text-muted, #888);
-            cursor: default;
+            cursor: grab;
             display: flex;
             align-items: center;
-            gap: 6px;
+            gap: 5px;
+            white-space: nowrap;
+            user-select: none;
+            border: 1px solid transparent;
+            border-bottom: none;
+            transition: background 0.15s, border-color 0.15s;
         }
-        .pane-label.active {
-            background: var(--accent, #7c6aef);
-            color: #fff;
+        .pane-label:hover { background: rgba(255,255,255,0.05); }
+        .pane-label.active { background: var(--accent, #7c6aef); color: #fff; }
+        .pane-label.drag-over {
+            border-color: var(--accent, #7c6aef);
+            background: rgba(124,106,239,0.15);
         }
         .pane-label .pane-close {
             cursor: pointer;
-            opacity: 0.6;
+            opacity: 0.5;
             font-size: 14px;
             line-height: 1;
+            margin-left: 2px;
         }
         .pane-label .pane-close:hover { opacity: 1; }
 
         /* Active tab highlights in nav */
-        .nav-link.active-left { border-bottom: 2px solid var(--accent, #7c6aef); }
-        .nav-link.active-right { border-bottom: 2px solid #4CAF50; }
-
-        /* Narrow screen notice */
-        .narrow-notice {
-            display: none;
-            position: fixed;
-            bottom: 16px;
-            left: 50%;
-            transform: translateX(-50%);
-            background: var(--card-bg, #1a1a2e);
-            border: 1px solid var(--card-border, #2a2a3e);
-            padding: 8px 16px;
-            border-radius: 8px;
-            font-size: 13px;
-            color: var(--text-muted, #888);
-            z-index: 200;
-        }
+        .nav-link.active-pane { border-bottom: 2px solid var(--accent, #7c6aef); }
     </style>
 </head>
 <body>
     <div class="pane-labels" id="paneLabels"></div>
-    <div class="workspace-container single-pane" id="workspaceContainer">
-        <iframe class="workspace-pane left" id="paneLeft"></iframe>
-        <div class="workspace-divider" id="divider"></div>
-        <iframe class="workspace-pane right" id="paneRight"></iframe>
-    </div>
+    <div class="workspace-container" id="workspaceContainer"></div>
     <div class="drag-overlay" id="dragOverlay"></div>
-    <div class="narrow-notice" id="narrowNotice" data-i18n="workspace_narrow_notice">Split view requires a wider screen</div>
 
     <script src="../shared/i18n.js"></script>
     <script src="shared/api.js"></script>
@@ -129,257 +110,274 @@
     <script src="shared/footer.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script>
-    // ── Page definitions ──
     const PAGES = {
-        'dashboard': { href: 'dashboard.html', icon: '📊', label: 'Dashboard', i18nKey: 'nav_dashboard' },
-        'chat':      { href: 'chat.html',      icon: '💬', label: 'Chat',      i18nKey: 'nav_chat' },
-        'mission':   { href: 'mission.html',    icon: '🚀', label: 'Mission',   i18nKey: 'nav_mission' },
-        'card-holder': { href: 'card-holder.html', icon: '🗂️', label: 'Cards', i18nKey: 'nav_card_holder' },
-        'community': { href: 'community.html',  icon: '🏪', label: 'Community', i18nKey: 'nav_community' },
-        'settings':  { href: 'settings.html',   icon: '⚙️', label: 'Settings', i18nKey: 'nav_settings' },
-        'info':      { href: 'info.html',       icon: '📖', label: 'Info',      i18nKey: 'nav_info' },
-        'admin':     { href: 'admin.html',      icon: '🔒', label: 'Admin',     i18nKey: 'nav_admin' }
+        'dashboard':   { href: 'dashboard.html',   icon: '📊', label: 'Dashboard',  i18nKey: 'nav_dashboard' },
+        'chat':        { href: 'chat.html',         icon: '💬', label: 'Chat',       i18nKey: 'nav_chat' },
+        'mission':     { href: 'mission.html',      icon: '🚀', label: 'Mission',    i18nKey: 'nav_mission' },
+        'card-holder': { href: 'card-holder.html',  icon: '🗂️', label: 'Cards',     i18nKey: 'nav_card_holder' },
+        'community':   { href: 'community.html',    icon: '🏪', label: 'Community',  i18nKey: 'nav_community' },
+        'settings':    { href: 'settings.html',     icon: '⚙️', label: 'Settings',  i18nKey: 'nav_settings' },
+        'info':        { href: 'info.html',         icon: '📖', label: 'Info',       i18nKey: 'nav_info' },
+        'admin':       { href: 'admin.html',        icon: '🔒', label: 'Admin',      i18nKey: 'nav_admin' }
     };
 
-    // ── State ──
-    let state = { left: null, right: null };
-    let splitRatio = 0.5; // 0..1, left pane width ratio
+    const COLORS = ['#7c6aef','#4CAF50','#FF9800','#E91E63','#00BCD4','#9C27B0','#CDDC39','#FF5722'];
+
+    // ── State: ordered array of panes ──
+    let panes = [];   // [{ id: 'chat', width: 0.5 }, ...]
+
+    function t(key, fb) { return typeof i18n !== 'undefined' ? i18n.t(key) : fb; }
 
     function pageIdFromHref(href) {
-        for (const [id, p] of Object.entries(PAGES)) {
-            if (p.href === href) return id;
-        }
+        for (const [id, p] of Object.entries(PAGES)) { if (p.href === href) return id; }
         return href.replace('.html', '');
     }
 
-    function t(key, fallback) {
-        return typeof i18n !== 'undefined' ? i18n.t(key) : fallback;
-    }
-
-    // ── Initialize ──
+    // ── Init ──
     function initWorkspace() {
         renderNav('workspace');
 
-        // Read initial state from URL params
         const params = new URLSearchParams(window.location.search);
-        const leftPage = params.get('left') || 'dashboard';
-        const rightPage = params.get('right') || null;
+        const paneParam = params.get('panes'); // e.g. "chat,mission,dashboard"
+        const leftParam = params.get('left');  // backwards compat
 
-        state.left = leftPage;
-        state.right = rightPage;
+        if (paneParam) {
+            const ids = paneParam.split(',').filter(id => PAGES[id]);
+            const w = 1 / (ids.length || 1);
+            panes = ids.map(id => ({ id, width: w }));
+        } else if (leftParam) {
+            panes = [{ id: leftParam, width: 1 }];
+            const rightParam = params.get('right');
+            if (rightParam && PAGES[rightParam]) {
+                panes = [{ id: leftParam, width: 0.5 }, { id: rightParam, width: 0.5 }];
+            }
+        }
 
-        // Restore split ratio from localStorage
-        const savedRatio = parseFloat(localStorage.getItem('eclaw-split-ratio'));
-        if (!isNaN(savedRatio) && savedRatio > 0.15 && savedRatio < 0.85) splitRatio = savedRatio;
+        if (panes.length === 0) panes = [{ id: 'dashboard', width: 1 }];
+
+        // Restore widths from localStorage
+        try {
+            const saved = JSON.parse(localStorage.getItem('eclaw-workspace-widths') || 'null');
+            if (saved && saved.length === panes.length) {
+                panes.forEach((p, i) => { p.width = saved[i]; });
+            }
+        } catch (e) {}
 
         // Intercept nav link clicks
         document.querySelectorAll('.nav-link').forEach(link => {
             link.addEventListener('click', (e) => {
                 e.preventDefault();
-                const href = link.getAttribute('href');
-                const pageId = pageIdFromHref(href);
-                handlePaneNavigation(pageId);
+                handleNavClick(pageIdFromHref(link.getAttribute('href')));
             });
         });
 
-        applyState();
-        setupDividerDrag();
-        setupWidthGuard();
+        render();
 
-        if (typeof telemetry !== 'undefined') {
-            telemetry.trackPageView('workspace');
-        }
+        if (typeof telemetry !== 'undefined') telemetry.trackPageView('workspace');
     }
 
-    // ── Navigation state machine ──
-    function handlePaneNavigation(pageId) {
+    // ── Nav click logic ──
+    function handleNavClick(pageId) {
         if (!PAGES[pageId]) return;
-
-        if (state.right) {
-            // Dual-pane mode
-            if (pageId === state.left) {
-                state = { left: state.right, right: null };
-            } else if (pageId === state.right) {
-                state = { left: state.left, right: null };
-            } else {
-                state = { left: pageId, right: state.left };
-            }
+        const idx = panes.findIndex(p => p.id === pageId);
+        if (idx >= 0) {
+            // Already open — close it (unless it's the only one)
+            if (panes.length <= 1) return;
+            panes.splice(idx, 1);
+            normalizeWidths();
         } else {
-            // Single-pane mode
-            if (pageId === state.left) return;
-            state = { left: pageId, right: state.left };
+            // Add new pane at the left
+            panes.unshift({ id: pageId, width: 0 });
+            normalizeWidths();
         }
-
-        applyState();
+        render();
     }
 
-    // ── Apply state to DOM ──
-    function applyState() {
+    function normalizeWidths() {
+        const w = 1 / panes.length;
+        panes.forEach(p => { p.width = w; });
+    }
+
+    // ── Render everything ──
+    function render() {
+        renderContainer();
+        renderLabels();
+        updateNavHighlights();
+        updateUrl();
+        saveState();
+    }
+
+    function renderContainer() {
         const container = document.getElementById('workspaceContainer');
-        const leftIframe = document.getElementById('paneLeft');
-        const rightIframe = document.getElementById('paneRight');
-        const isDual = !!state.right;
+        container.innerHTML = '';
 
-        container.className = 'workspace-container ' + (isDual ? 'dual-pane' : 'single-pane');
+        panes.forEach((pane, i) => {
+            // Iframe
+            const iframe = document.createElement('iframe');
+            iframe.className = 'workspace-pane';
+            iframe.id = 'pane-' + i;
+            iframe.style.width = (pane.width * 100).toFixed(2) + '%';
+            const pageInfo = PAGES[pane.id];
+            if (pageInfo) iframe.src = pageInfo.href + '?embed=1';
+            container.appendChild(iframe);
 
-        // Set pane widths based on split ratio
-        if (isDual) {
-            const leftPct = (splitRatio * 100).toFixed(1);
-            const rightPct = ((1 - splitRatio) * 100).toFixed(1);
-            leftIframe.style.width = leftPct + '%';
-            leftIframe.style.flex = 'none';
-            rightIframe.style.width = rightPct + '%';
-            rightIframe.style.flex = 'none';
-        } else {
-            leftIframe.style.width = '100%';
-            leftIframe.style.flex = '';
-            rightIframe.style.width = '';
-            rightIframe.style.flex = '';
-        }
+            // Divider between panes
+            if (i < panes.length - 1) {
+                const div = document.createElement('div');
+                div.className = 'workspace-divider';
+                div.setAttribute('data-index', i);
+                div.addEventListener('mousedown', startDividerDrag);
+                container.appendChild(div);
+            }
+        });
+    }
 
-        // Load iframes (only change src if different to avoid reload)
-        const leftSrc = state.left ? PAGES[state.left]?.href + '?embed=1' : '';
-        const rightSrc = state.right ? PAGES[state.right]?.href + '?embed=1' : '';
+    // ── Divider drag ──
+    let dragIndex = -1;
 
-        if (leftIframe.getAttribute('data-page') !== state.left) {
-            leftIframe.src = leftSrc;
-            leftIframe.setAttribute('data-page', state.left || '');
-        }
-        if (isDual && rightIframe.getAttribute('data-page') !== state.right) {
-            rightIframe.src = rightSrc;
-            rightIframe.setAttribute('data-page', state.right || '');
-        }
-        if (!isDual) {
-            rightIframe.src = 'about:blank';
-            rightIframe.setAttribute('data-page', '');
-        }
+    function startDividerDrag(e) {
+        e.preventDefault();
+        dragIndex = parseInt(e.target.getAttribute('data-index'));
+        e.target.classList.add('dragging');
+        document.getElementById('dragOverlay').style.display = 'block';
 
-        // Update nav highlights
+        const onMove = (ev) => {
+            if (dragIndex < 0) return;
+            const container = document.getElementById('workspaceContainer');
+            const rect = container.getBoundingClientRect();
+            const totalW = rect.width - (panes.length - 1) * 6; // subtract divider widths
+
+            // Calculate mouse position relative to the start of pane[dragIndex]
+            let offsetBefore = 0;
+            for (let j = 0; j < dragIndex; j++) {
+                offsetBefore += panes[j].width * totalW + 6;
+            }
+            const combinedW = (panes[dragIndex].width + panes[dragIndex + 1].width) * totalW;
+            const mouseInCombined = (ev.clientX - rect.left) - offsetBefore;
+            const ratio = Math.max(0.1, Math.min(0.9, mouseInCombined / combinedW));
+
+            const totalShare = panes[dragIndex].width + panes[dragIndex + 1].width;
+            panes[dragIndex].width = totalShare * ratio;
+            panes[dragIndex + 1].width = totalShare * (1 - ratio);
+
+            // Update widths directly (no full re-render to avoid iframe reload)
+            panes.forEach((p, i) => {
+                const el = document.getElementById('pane-' + i);
+                if (el) el.style.width = (p.width * 100).toFixed(2) + '%';
+            });
+        };
+
+        const onUp = () => {
+            document.querySelectorAll('.workspace-divider.dragging').forEach(d => d.classList.remove('dragging'));
+            document.getElementById('dragOverlay').style.display = 'none';
+            dragIndex = -1;
+            document.removeEventListener('mousemove', onMove);
+            document.removeEventListener('mouseup', onUp);
+            saveState();
+        };
+
+        document.addEventListener('mousemove', onMove);
+        document.addEventListener('mouseup', onUp);
+    }
+
+    // ── Pane label tabs (draggable to reorder) ──
+    let dragLabelIdx = -1;
+
+    function renderLabels() {
+        const bar = document.getElementById('paneLabels');
+        bar.innerHTML = '';
+
+        panes.forEach((pane, i) => {
+            const span = document.createElement('span');
+            span.className = 'pane-label' + (i === 0 ? ' active' : '');
+            span.style.borderBottomColor = COLORS[i % COLORS.length];
+            span.style.borderBottom = '2px solid ' + COLORS[i % COLORS.length];
+            span.setAttribute('draggable', 'true');
+            span.setAttribute('data-idx', i);
+
+            const p = PAGES[pane.id];
+            const icon = p ? p.icon : '';
+            const label = p ? t(p.i18nKey, p.label) : pane.id;
+            span.innerHTML = `${icon} ${label}`;
+
+            // Close button (only if more than 1 pane)
+            if (panes.length > 1) {
+                const close = document.createElement('span');
+                close.className = 'pane-close';
+                close.textContent = '×';
+                close.title = t('workspace_close_pane', 'Close Pane');
+                close.addEventListener('click', (e) => { e.stopPropagation(); removePane(i); });
+                span.appendChild(close);
+            }
+
+            // Drag to reorder
+            span.addEventListener('dragstart', (e) => {
+                dragLabelIdx = i;
+                e.dataTransfer.effectAllowed = 'move';
+                span.style.opacity = '0.5';
+            });
+            span.addEventListener('dragend', () => {
+                span.style.opacity = '';
+                dragLabelIdx = -1;
+                bar.querySelectorAll('.pane-label').forEach(el => el.classList.remove('drag-over'));
+            });
+            span.addEventListener('dragover', (e) => {
+                e.preventDefault();
+                e.dataTransfer.dropEffect = 'move';
+                span.classList.add('drag-over');
+            });
+            span.addEventListener('dragleave', () => { span.classList.remove('drag-over'); });
+            span.addEventListener('drop', (e) => {
+                e.preventDefault();
+                span.classList.remove('drag-over');
+                if (dragLabelIdx < 0 || dragLabelIdx === i) return;
+                // Swap panes
+                const moved = panes.splice(dragLabelIdx, 1)[0];
+                panes.splice(i, 0, moved);
+                render();
+            });
+
+            bar.appendChild(span);
+        });
+    }
+
+    function removePane(idx) {
+        if (panes.length <= 1) return;
+        panes.splice(idx, 1);
+        normalizeWidths();
+        render();
+    }
+
+    // ── Nav highlights ──
+    function updateNavHighlights() {
+        const openIds = new Set(panes.map(p => p.id));
         document.querySelectorAll('.nav-link').forEach(link => {
             const href = link.getAttribute('href');
             if (!href) return;
             const pid = pageIdFromHref(href);
-            link.classList.remove('active', 'active-left', 'active-right');
-            if (pid === state.left) link.classList.add('active', 'active-left');
-            if (pid === state.right) link.classList.add('active-right');
-        });
-
-        renderPaneLabels();
-
-        // Update URL
-        const urlParams = new URLSearchParams();
-        if (state.left) urlParams.set('left', state.left);
-        if (state.right) urlParams.set('right', state.right);
-        history.replaceState(null, '', 'workspace.html?' + urlParams.toString());
-
-        localStorage.setItem('eclaw-workspace-state', JSON.stringify(state));
-    }
-
-    // ── Draggable divider ──
-    function setupDividerDrag() {
-        const divider = document.getElementById('divider');
-        const overlay = document.getElementById('dragOverlay');
-        const container = document.getElementById('workspaceContainer');
-        let isDragging = false;
-
-        divider.addEventListener('mousedown', (e) => {
-            e.preventDefault();
-            isDragging = true;
-            divider.classList.add('dragging');
-            overlay.style.display = 'block';
-        });
-
-        document.addEventListener('mousemove', (e) => {
-            if (!isDragging) return;
-            const rect = container.getBoundingClientRect();
-            const x = e.clientX - rect.left;
-            const dividerWidth = 6;
-            let ratio = (x - dividerWidth / 2) / (rect.width - dividerWidth);
-            ratio = Math.max(0.15, Math.min(0.85, ratio));
-            splitRatio = ratio;
-
-            const leftIframe = document.getElementById('paneLeft');
-            const rightIframe = document.getElementById('paneRight');
-            leftIframe.style.width = (ratio * 100).toFixed(1) + '%';
-            rightIframe.style.width = ((1 - ratio) * 100).toFixed(1) + '%';
-        });
-
-        document.addEventListener('mouseup', () => {
-            if (!isDragging) return;
-            isDragging = false;
-            divider.classList.remove('dragging');
-            overlay.style.display = 'none';
-            localStorage.setItem('eclaw-split-ratio', splitRatio.toFixed(3));
+            link.classList.toggle('active-pane', openIds.has(pid));
+            link.classList.toggle('active', openIds.has(pid));
         });
     }
 
-    // ── Pane label bar ──
-    function renderPaneLabels() {
-        const container = document.getElementById('paneLabels');
-        const isDual = !!state.right;
-        let html = '';
-
-        if (state.left) {
-            const p = PAGES[state.left];
-            const label = p ? (t(p.i18nKey, p.label)) : state.left;
-            const icon = p ? p.icon : '';
-            html += `<span class="pane-label active">${icon} ${label}`;
-            if (isDual) html += ` <span class="pane-close" onclick="closePane('left')" title="${t('workspace_close_pane', 'Close Pane')}">&times;</span>`;
-            html += `</span>`;
-        }
-        if (state.right) {
-            const p = PAGES[state.right];
-            const label = p ? (t(p.i18nKey, p.label)) : state.right;
-            const icon = p ? p.icon : '';
-            html += `<span class="pane-label" style="background:#2a3a2a;color:#4CAF50;">${icon} ${label}`;
-            html += ` <span class="pane-close" onclick="closePane('right')" title="${t('workspace_close_pane', 'Close Pane')}">&times;</span>`;
-            html += `</span>`;
-        }
-
-        container.innerHTML = html;
-        container.style.display = isDual ? 'flex' : 'none';
+    // ── URL & persistence ──
+    function updateUrl() {
+        const ids = panes.map(p => p.id).join(',');
+        history.replaceState(null, '', 'workspace.html?panes=' + encodeURIComponent(ids));
     }
 
-    function closePane(side) {
-        if (side === 'left') {
-            state = { left: state.right, right: null };
-        } else {
-            state = { left: state.left, right: null };
-        }
-        applyState();
+    function saveState() {
+        localStorage.setItem('eclaw-workspace-widths', JSON.stringify(panes.map(p => p.width)));
+        localStorage.setItem('eclaw-workspace-panes', panes.map(p => p.id).join(','));
     }
 
-    // ── Width guard: auto-collapse on narrow screens ──
-    function setupWidthGuard() {
-        const mq = window.matchMedia('(min-width: 1200px)');
-        let savedRight = null;
-
-        function handleWidth(e) {
-            const notice = document.getElementById('narrowNotice');
-            if (!e.matches && state.right) {
-                savedRight = state.right;
-                state.right = null;
-                applyState();
-                if (notice) { notice.style.display = 'block'; setTimeout(() => notice.style.display = 'none', 3000); }
-            } else if (e.matches && savedRight && !state.right) {
-                state.right = savedRight;
-                savedRight = null;
-                applyState();
-            }
-        }
-
-        mq.addEventListener('change', handleWidth);
-        if (!mq.matches && state.right) handleWidth(mq);
-    }
-
-    // ── Listen for view mode change from settings iframe ──
+    // ── Listen for view mode change ──
     window.addEventListener('storage', (e) => {
         if (e.key === 'eclaw-view-mode' && e.newValue === 'single') {
-            window.location.href = (state.left || 'dashboard') + '.html';
+            window.location.href = (panes[0]?.id || 'dashboard') + '.html';
         }
     });
 
-    // ── Boot ──
     document.addEventListener('DOMContentLoaded', initWorkspace);
     </script>
 </body>


### PR DESCRIPTION
## Summary
- 不再限制雙頁面，可以無限疊加分割畫面
- 頂部浮動 tab 可以按住拖曳交換左右位置
- 所有分隔線都可以拖曳調整寬度
- 每個 tab 有關閉按鈕（僅剩一個時隱藏）
- 色彩標記區分不同 tab
- 寬度比例和順序存 localStorage
- URL 格式：`workspace.html?panes=chat,mission,dashboard`

## Test plan
- [ ] 點 nav tab 新增 pane → 畫面分割
- [ ] 再點 → 再分割（3個、4個...）
- [ ] 拖曳分隔線 → 調整寬度
- [ ] 拖曳頂部 tab → 交換位置
- [ ] 點已開啟的 tab → 關閉該 pane
- [ ] 點 × 關閉 → pane 移除

🤖 Generated with [Claude Code](https://claude.com/claude-code)