### PR TITLE
fix(community): correct i18n.js path (404)

### DIFF
--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -599,7 +599,7 @@
         </div>
     </div>
 
-    <script src="shared/i18n.js"></script>
+    <script src="../shared/i18n.js"></script>
     <script src="shared/auth.js"></script>
     <script src="shared/footer.js"></script>
     <script>


### PR DESCRIPTION
## Problem
community.html loads i18n.js from `shared/i18n.js` (relative to portal/) which resolves to `/portal/shared/i18n.js` → 404.

All other portal pages correctly use `../shared/i18n.js`.

## Fix
Change path from `shared/i18n.js` to `../shared/i18n.js`.

## Impact
Bot Plaza page had no translations loaded. This fix restores i18n for community.html.

Found by UIUX scheduled patrol 2026-03-27 14:30.