### PR TITLE
fix(kanban): assigned avatar chips show correct entity

### DIFF
--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -433,7 +433,10 @@
             // Load entities for assignee picker
             try {
                 const data = await apiCall('GET', `/api/entities?deviceId=${encodeURIComponent(currentUser.deviceId)}&deviceSecret=${encodeURIComponent(currentUser.deviceSecret)}`);
-                if (data.entities) boundEntities = data.entities;
+                if (data.entities) {
+                    boundEntities = data.entities;
+                    if (typeof updateEntityMaps === 'function') updateEntityMaps(boundEntities);
+                }
             } catch(e) {}
 
             await loadCards();


### PR DESCRIPTION
## Summary
- Call `updateEntityMaps(boundEntities)` after loading entities so `getAvatarForEntity()` and `getEntityDisplayName()` resolve actual entity data instead of defaults
- Fixes kanban card chips showing wrong emoji/name for assigned entities

## Test plan
- [ ] Open kanban board with entities that have custom avatars/names
- [ ] Verify assigned avatar chips on cards show the correct entity avatar and name

🤖 Generated with [Claude Code](https://claude.com/claude-code)