### PR TITLE
fix(kanban): expose schedule.lastRunAt after once-trigger

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -242,11 +242,11 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
             fileCount: parseInt(row.file_count) || 0,
         };
 
-        // Schedule fields
-        if (row.schedule_enabled) {
+        // Schedule fields — always include if schedule was ever configured
+        if (row.schedule_enabled || row.schedule_type || row.schedule_last_run_at) {
             card.schedule = {
-                enabled: row.schedule_enabled,
-                type: row.schedule_type,
+                enabled: !!row.schedule_enabled,
+                type: row.schedule_type || null,
                 cronExpression: row.schedule_cron || null,
                 runAt: row.schedule_run_at ? new Date(row.schedule_run_at).getTime() : null,
                 timezone: row.schedule_timezone || 'Asia/Taipei',


### PR DESCRIPTION
**Bug:** After a `once` schedule fires, `schedule_enabled` is set to `false`. The card serializer only built the `schedule` object when `enabled=true`, so `lastRunAt` always appeared as `null` in the API response.

**Fix:** Include the schedule block whenever `schedule_type` or `schedule_last_run_at` is present, regardless of enabled state.

Found by QA test 2026-03-27.