### PR TITLE
fix(i18n): fix SyntaxError in i18n.js causing all portal pages to crash

### DIFF
--- a/backend/public/portal/compare.html
+++ b/backend/public/portal/compare.html
@@ -204,7 +204,7 @@
 
     </main>
 
-    <script src="shared/i18n.js"></script>
+    <script src="../shared/i18n.js"></script>
     <script src="shared/auth.js"></script>
     <script src="shared/footer.js"></script>
 </body>

--- a/backend/public/portal/index.html
+++ b/backend/public/portal/index.html
@@ -395,7 +395,7 @@
 
     <!-- Language selector for login page -->
     <div style="position:fixed; top:20px; right:20px;">
-        <select onchange="i18n.setLanguage(this.value)"
+        <select onchange="if(typeof i18n!=='undefined')i18n.setLanguage(this.value)"
             style="background:#1a1a2e;border:1px solid #333;color:#aaa;cursor:pointer;padding:4px 8px;border-radius:6px;font-size:13px;">
             <option value="en">EN</option>
             <option value="zh">繁中</option>

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -40589,7 +40589,39 @@ const TRANSLATIONS = {
         "guide_wp_style_abstract": "Abstrait",
         "guide_wp_style_cartoon": "Dessin Animé",
         "guide_wp_style_realistic": "Réaliste",
-        "guide_wp_title": "🖼️ Wallpaper Bot — Personnalisez le Wallpaper avec l'IA",    },
+        "guide_wp_title": "🖼️ Wallpaper Bot — Personnalisez le Wallpaper avec l'IA",
+        "arena_title": "EClawbot Agent Benchmark",
+        "arena_subtitle": "Cadre d'évaluation standardisé pour les agents IA. 12 critères couvrant la perception, l'interaction, le raisonnement, la génération de code et la résilience en sécurité — noté en temps réel.",
+        "arena_generate": "🎯 Générer un Examen Factice",
+        "arena_view_lb": "🏆 Voir le Classement",
+        "arena_tests_title": "🧪 Catégories d'Épreuves",
+        "arena_lb_title": "🏆 Classement",
+        "arena_lb_name": "Nom",
+        "arena_lb_model": "Modèle",
+        "arena_lb_score": "Score",
+        "arena_lb_loading": "Chargement...",
+        "arena_exam_title": "Arena d'Entretien — Examen",
+        "arena_waiting": "En attente que le Bot rejoigne...",
+        "arena_copy_label": "📋 Copiez ces instructions et envoyez-les à votre Bot :",
+        "arena_copy_btn": "📋 Copier les Instructions",
+        "arena_report_title": "📊 Rapport d'Examen",
+        "arena_name_prompt": "Entrez votre nom pour le classement",
+        "arena_submit_name": "Soumettre",
+        "arena_fb_title": "💬 Donnez-nous votre avis",
+        "arena_fb_caps_q": "Quelles capacités voulez-vous que votre Agent ait ? (Sélectionnez toutes les réponses applicables)",
+        "arena_fb_credibility": "Crédibilité des résultats :",
+        "arena_fb_comment_ph": "Suggestions ou commentaires pour EClawbot...",
+        "arena_fb_submit": "Envoyer les Commentaires",
+        "arena_comments_title": "💬 Tableau de Discussion",
+        "arena_comments_hint": "Complétez un examen et soumettez-le au classement pour laisser un commentaire.",
+        "arena_comments_text_ph": "Laissez un commentaire...",
+        "arena_comments_post": "Publier",
+        "arena_comments_loading": "Chargement des commentaires...",
+        "arena_badge": "Agent Benchmark",
+        "arena_cooldown_prefix": "Prochaine évaluation disponible dans",
+        "arena_lb_time": "Temps",
+        "guide_nav_arena": "⛳ Arena d'Entretien"
+    },
     es: {
         "mc_title": "EClawbot Centro de Misiones",
         "mc_auth_title": "Centro de Misiones",
@@ -50025,38 +50057,6 @@ const TRANSLATIONS = {
         "arena_lb_time": "Tiempo",
         "guide_nav_arena": "🏌️ Arena de Entrevistas"
     },
-        "arena_title": "EClawbot Agent Benchmark",
-        "arena_subtitle": "Cadre d'évaluation standardisé pour les agents IA. 12 critères couvrant la perception, l'interaction, le raisonnement, la génération de code et la résilience en sécurité — noté en temps réel.",
-        "arena_generate": "🎯 Générer un Examen Factice",
-        "arena_view_lb": "🏆 Voir le Classement",
-        "arena_tests_title": "🧪 Catégories d'Épreuves",
-        "arena_lb_title": "🏆 Classement",
-        "arena_lb_name": "Nom",
-        "arena_lb_model": "Modèle",
-        "arena_lb_score": "Score",
-        "arena_lb_loading": "Chargement...",
-        "arena_exam_title": "Arena d'Entretien — Examen",
-        "arena_waiting": "En attente que le Bot rejoigne...",
-        "arena_copy_label": "📋 Copiez ces instructions et envoyez-les à votre Bot :",
-        "arena_copy_btn": "📋 Copier les Instructions",
-        "arena_report_title": "📊 Rapport d'Examen",
-        "arena_name_prompt": "Entrez votre nom pour le classement",
-        "arena_submit_name": "Soumettre",
-        "arena_fb_title": "💬 Donnez-nous votre avis",
-        "arena_fb_caps_q": "Quelles capacités voulez-vous que votre Agent ait ? (Sélectionnez toutes les réponses applicables)",
-        "arena_fb_credibility": "Crédibilité des résultats :",
-        "arena_fb_comment_ph": "Suggestions ou commentaires pour EClawbot...",
-        "arena_fb_submit": "Envoyer les Commentaires",
-        "arena_comments_title": "💬 Tableau de Discussion",
-        "arena_comments_hint": "Complétez un examen et soumettez-le au classement pour laisser un commentaire.",
-        "arena_comments_text_ph": "Laissez un commentaire...",
-        "arena_comments_post": "Publier",
-        "arena_comments_loading": "Chargement des commentaires...",
-        "arena_badge": "Agent Benchmark",
-        "arena_cooldown_prefix": "Prochaine évaluation disponible dans",
-        "arena_lb_time": "Temps",
-        "guide_nav_arena": "⛳ Arena d'Entretien"
-
     de: {
         // General / Common
         "general_title": "Allgemein",
@@ -84421,8 +84421,8 @@ class I18n {
     }
 }
 
-// Global instance
-const i18n = new I18n();
+// Global instance (use var so window.i18n is set for cross-script access)
+var i18n = new I18n();
 
 // Auto-apply on load
 document.addEventListener('DOMContentLoaded', () => {

--- a/backend/tests/jest/i18n-syntax.test.js
+++ b/backend/tests/jest/i18n-syntax.test.js
@@ -1,0 +1,106 @@
+/**
+ * i18n.js syntax and structure regression tests
+ *
+ * Ensures the i18n translation file parses correctly and all language
+ * sections are properly structured. Catches misplaced translations
+ * and missing commas between language blocks.
+ *
+ * Regression: orphaned French arena translations between es/de sections
+ * caused a SyntaxError preventing the entire i18n.js from loading,
+ * crashing all portal pages.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const I18N_PATH = path.join(__dirname, '../../public/shared/i18n.js');
+
+describe('i18n.js syntax and structure', () => {
+    let content;
+
+    beforeAll(() => {
+        content = fs.readFileSync(I18N_PATH, 'utf8');
+    });
+
+    test('file parses without syntax errors', () => {
+        expect(() => {
+            new vm.Script(content, { filename: 'i18n.js' });
+        }).not.toThrow();
+    });
+
+    test('TRANSLATIONS object is valid and contains expected languages', () => {
+        const sandbox = {
+            localStorage: { getItem: () => null, setItem: () => {} },
+            navigator: { language: 'en' },
+            document: {
+                addEventListener: () => {},
+                querySelectorAll: () => [],
+                documentElement: { lang: '' }
+            },
+            fetch: () => Promise.resolve(),
+            console,
+            _result: {}
+        };
+        vm.createContext(sandbox);
+        vm.runInContext(content + '\n_result.TRANSLATIONS = TRANSLATIONS; _result.i18n = i18n;', sandbox);
+
+        const { TRANSLATIONS, i18n } = sandbox._result;
+
+        const requiredLangs = ['en', 'zh', 'ja', 'ko', 'fr', 'es', 'de'];
+        for (const lang of requiredLangs) {
+            expect(TRANSLATIONS).toHaveProperty(lang);
+            expect(typeof TRANSLATIONS[lang]).toBe('object');
+        }
+
+        expect(i18n).toBeDefined();
+        expect(typeof i18n.t).toBe('function');
+        expect(typeof i18n.setLanguage).toBe('function');
+    });
+
+    test('i18n.t() returns translations, not raw keys', () => {
+        const sandbox = {
+            localStorage: { getItem: () => null, setItem: () => {} },
+            navigator: { language: 'en' },
+            document: {
+                addEventListener: () => {},
+                querySelectorAll: () => [],
+                documentElement: { lang: '' }
+            },
+            fetch: () => Promise.resolve(),
+            console,
+            _result: {}
+        };
+        vm.createContext(sandbox);
+        vm.runInContext(content + '\n_result.i18n = i18n;', sandbox);
+
+        const { i18n } = sandbox._result;
+        // Should return a translated string, not the key itself
+        const result = i18n.t('mc_title');
+        expect(result).not.toBe('mc_title');
+        expect(result).toBe('EClawbot Mission Control');
+    });
+
+    test('French (fr) section contains arena translations', () => {
+        const sandbox = {
+            localStorage: { getItem: () => null, setItem: () => {} },
+            navigator: { language: 'en' },
+            document: {
+                addEventListener: () => {},
+                querySelectorAll: () => [],
+                documentElement: { lang: '' }
+            },
+            fetch: () => Promise.resolve(),
+            console,
+            _result: {}
+        };
+        vm.createContext(sandbox);
+        vm.runInContext(content + '\n_result.TRANSLATIONS = TRANSLATIONS;', sandbox);
+
+        const fr = sandbox._result.TRANSLATIONS.fr;
+        expect(fr).toBeDefined();
+        expect(fr['arena_title']).toBeDefined();
+        expect(fr['arena_subtitle']).toBeDefined();
+        expect(fr['arena_generate']).toBeDefined();
+    });
+});


### PR DESCRIPTION
## Summary
- Fix orphaned French arena translations (31 lines) placed between `es` and `de` sections outside any language block, causing a `SyntaxError` that prevented `i18n` from being created — all portal pages crashed
- Fix `compare.html` wrong i18n.js path (`shared/i18n.js` → `../shared/i18n.js`)
- Guard `index.html` language selector `onchange` against i18n load race condition
- Change `const i18n` to `var i18n` for robust `window` property access

## Test plan
- [x] `node --check backend/public/shared/i18n.js` passes (no syntax errors)
- [x] New `i18n-syntax.test.js` regression test (4 cases) all pass
- [x] ESLint passes (0 errors)
- [x] Full Jest suite passes (1292/1293, pre-existing channel-api failure)

https://claude.ai/code/session_01MoKZ4WAxDAS5SPdkX4CU9R