### PR TITLE
i18n: add 5 missing arena keys to fr section

### DIFF
--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -40735,7 +40735,12 @@ const TRANSLATIONS = {
         "arena_badge": "Agent Benchmark",
         "arena_cooldown_prefix": "Prochaine évaluation disponible dans",
         "arena_lb_time": "Temps",
-        "guide_nav_arena": "⛳ Arena d'Entretien"
+        "guide_nav_arena": "⛳ Arena d'Entretien",
+        "arena_back": "Retour au Benchmark",
+        "arena_cancel": "Annuler",
+        "arena_expand": "Développer",
+        "arena_name_subtitle": "Entrez votre nom pour enregistrer votre score",
+        "arena_time_remaining": "Temps restant : "
     },
     es: {
         "mc_title": "EClawbot Centro de Misiones",


### PR DESCRIPTION
Add missing arena translation keys (back, cancel, expand, name_subtitle, time_remaining). i18n-syntax test passes.
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>