### PR TITLE
i18n: fill missing ja, ko, es keys in ios-app i18n

### DIFF
--- a/ios-app/i18n/es.json
+++ b/ios-app/i18n/es.json
@@ -93,7 +93,8 @@
     "entity_idle": "Inactivo",
     "unbind_title": "Desvincular entidad",
     "unbind_message": "¿Está seguro de que desea desvincular {{name}}?",
-    "unbind_success": "Entidad desvinculada"
+    "unbind_success": "Entidad desvinculada",
+    "channel_ai_agent_hint": "🤖 Se recomienda encarecidamente usar Claude Code u otros agentes de IA para la instalación asistida."
   },
   "chat": {
     "title": "Chat",
@@ -148,7 +149,9 @@
     "browse_templates": "Explorar plantillas",
     "no_api_key_needed": "No se necesita clave API",
     "all_vars_configured": "Todas las variables configuradas",
-    "needs_vars": "Necesita: {{vars}}"
+    "needs_vars": "Necesita: {{vars}}",
+    "deprecated_msg": "Por favor, use el tablero Kanban para agregar nuevos elementos. El tablero Kanban tiene un ecosistema completo — deje que los bots migren los elementos existentes allí gradualmente.",
+    "deprecated_title": "Función Obsoleta"
   },
   "settings": {
     "title": "Configuración",

--- a/ios-app/i18n/ja.json
+++ b/ios-app/i18n/ja.json
@@ -142,7 +142,16 @@
     "keep_local": "ローカルを保持",
     "use_remote": "リモートを使用",
     "sync_success": "同期しました",
-    "soul_templates": "キャラクターテンプレート"
+    "soul_templates": "キャラクターテンプレート",
+    "all_vars_configured": "すべての変数が設定されました",
+    "browse_templates": "テンプレートを参照",
+    "builtin": "組み込み",
+    "needs_vars": "必要: {{vars}}",
+    "no_api_key_needed": "APIキーが不要です",
+    "no_rules": "ルールテンプレートがありません",
+    "no_skills": "スキルテンプレートがありません",
+    "no_souls": "ソウルテンプレートがありません",
+    "search_placeholder": "検索…"
   },
   "settings": {
     "title": "設定",

--- a/ios-app/i18n/ko.json
+++ b/ios-app/i18n/ko.json
@@ -142,7 +142,16 @@
     "keep_local": "로컬 유지",
     "use_remote": "원격 사용",
     "sync_success": "동기화됨",
-    "soul_templates": "캐릭터 템플릿"
+    "soul_templates": "캐릭터 템플릿",
+    "all_vars_configured": "모든 변수가 구성되었습니다",
+    "browse_templates": "템플릿 찾아보기",
+    "builtin": "기본 제공",
+    "needs_vars": "필요: {{vars}}",
+    "no_api_key_needed": "API 키가 필요하지 않습니다",
+    "no_rules": "규칙 템플릿 없음",
+    "no_skills": "스킬 템플릿 없음",
+    "no_souls": "소울 템플릿 없음",
+    "search_placeholder": "검색…"
   },
   "settings": {
     "title": "설정",


### PR DESCRIPTION
Fill missing translation keys for ios-app:
- es: home.channel_ai_agent_hint, mission.deprecated_title, mission.deprecated_msg
- ja: 9 mission.* keys
- ko: 9 mission.* keys