### PR TITLE
fix(invite): resolve route conflict causing 500 on /api/invite/my-code (#1676)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1746,12 +1746,14 @@ setTimeout(() => trustModule.initTrustDatabase(), 3000);
 // ============================================
 // INVITE / REFERRAL SYSTEM (P5)
 // ============================================
+// invite.js (Phase 5 JWT-based) router removed — conflicts with device-auth
+// invite routes below (line ~3662). Schema init kept for table idempotency.
 const inviteModule = require('./invite')({
     authMiddleware: authModule.authMiddleware,
     walletModule,
     serverLog,
 });
-app.use('/api/invite', inviteModule.router);
+// NOTE: router NOT mounted — device-auth routes in index.js handle /api/invite/*
 setTimeout(() => inviteModule.initInviteDatabase(), 3500);
 
 // ============================================
@@ -3657,14 +3659,37 @@ function generateInviteCode() {
     return code;
 }
 
-// GET /api/invite/my-code — get (or auto-generate) the caller's invite code
-// Auth: deviceId + deviceSecret
-app.get('/api/invite/my-code', async (req, res) => {
-    const { deviceId, deviceSecret } = req.query;
-    if (!deviceId || !deviceSecret) return res.status(400).json({ success: false, error: 'deviceId and deviceSecret required' });
-    if (!devices[deviceId] || !safeEqual(devices[deviceId].deviceSecret, deviceSecret)) {
-        return res.status(403).json({ success: false, error: 'Invalid credentials' });
+// Helper: extract authenticated deviceId from device-auth params OR JWT cookie
+function resolveInviteAuth(req) {
+    // 1) Device auth via query/body params
+    const qDeviceId = req.query.deviceId || (req.body && req.body.deviceId);
+    const qDeviceSecret = req.query.deviceSecret || (req.body && req.body.deviceSecret);
+    if (qDeviceId && qDeviceSecret) {
+        if (!devices[qDeviceId] || !safeEqual(devices[qDeviceId].deviceSecret, qDeviceSecret)) {
+            return { error: 'Invalid credentials', status: 403 };
+        }
+        return { deviceId: qDeviceId };
     }
+    // 2) JWT cookie auth (for invite.html which uses apiCall with credentials:'include')
+    const token = req.cookies && req.cookies.eclaw_session;
+    if (token) {
+        try {
+            const jwt = require('jsonwebtoken');
+            const decoded = jwt.verify(token, JWT_SECRET_FALLBACK);
+            if (decoded && decoded.deviceId && devices[decoded.deviceId]) {
+                return { deviceId: decoded.deviceId };
+            }
+        } catch (_) { /* invalid token — fall through */ }
+    }
+    return { error: 'deviceId and deviceSecret required, or valid session cookie', status: 401 };
+}
+
+// GET /api/invite/my-code — get (or auto-generate) the caller's invite code
+// Auth: deviceId+deviceSecret OR JWT cookie
+app.get('/api/invite/my-code', async (req, res) => {
+    const auth = resolveInviteAuth(req);
+    if (auth.error) return res.status(auth.status).json({ success: false, error: auth.error });
+    const deviceId = auth.deviceId;
 
     const pg = authModule.pool;
     try {
@@ -3697,15 +3722,15 @@ app.get('/api/invite/my-code', async (req, res) => {
 });
 
 // POST /api/invite/redeem — redeem an invite code
-// Body: { deviceId, deviceSecret, code }
+// Body: { deviceId, deviceSecret, code } OR JWT cookie + { code }
 // Reward: invitee +300 bonus, inviter +50 bonus
 app.post('/api/invite/redeem', async (req, res) => {
-    const { deviceId, deviceSecret, code } = req.body;
-    if (!deviceId || !deviceSecret || !code) {
-        return res.status(400).json({ success: false, error: 'deviceId, deviceSecret, and code required' });
-    }
-    if (!devices[deviceId] || !safeEqual(devices[deviceId].deviceSecret, deviceSecret)) {
-        return res.status(403).json({ success: false, error: 'Invalid credentials' });
+    const { code } = req.body;
+    const auth = resolveInviteAuth(req);
+    if (auth.error) return res.status(auth.status).json({ success: false, error: auth.error });
+    const deviceId = auth.deviceId;
+    if (!code) {
+        return res.status(400).json({ success: false, error: 'code required' });
     }
 
     const pg = authModule.pool;
@@ -3756,13 +3781,11 @@ app.post('/api/invite/redeem', async (req, res) => {
 });
 
 // GET /api/invite/stats — get invite stats and remaining bonus
-// Auth: deviceId + deviceSecret
+// Auth: deviceId+deviceSecret OR JWT cookie
 app.get('/api/invite/stats', async (req, res) => {
-    const { deviceId, deviceSecret } = req.query;
-    if (!deviceId || !deviceSecret) return res.status(400).json({ success: false, error: 'deviceId and deviceSecret required' });
-    if (!devices[deviceId] || !safeEqual(devices[deviceId].deviceSecret, deviceSecret)) {
-        return res.status(403).json({ success: false, error: 'Invalid credentials' });
-    }
+    const auth = resolveInviteAuth(req);
+    if (auth.error) return res.status(auth.status).json({ success: false, error: auth.error });
+    const deviceId = auth.deviceId;
 
     const pg = authModule.pool;
     try {

--- a/backend/run_all_tests.js
+++ b/backend/run_all_tests.js
@@ -110,6 +110,7 @@ const TEST_FILES = [
     'test-entity-trash.js',         // Entity trash: soft-delete recovery, 7-day retention
     'test-channel-push-text.js',    // Channel push text format verification
     'test-note-pages.js',           // Note page CRUD, public/private toggle, visitor analytics
+    'test-invite-auth.js',          // Invite auth: device+cookie dual auth, route conflict fix (#1676)
 ];
 
 // Manual UI tests (run on device, not automated):

--- a/backend/tests/test-invite-auth.js
+++ b/backend/tests/test-invite-auth.js
@@ -1,0 +1,100 @@
+/**
+ * Regression test: Issue #1676 — /api/invite/my-code returns 500
+ *
+ * Root cause: invite.js JWT-auth router was mounted before index.js device-auth
+ * routes, intercepting device-auth requests and returning 401/500.
+ *
+ * Fix: removed invite.js router mount; index.js routes now support both
+ * device-auth (query params) and JWT cookie auth.
+ *
+ * Run: node backend/tests/test-invite-auth.js
+ * Credentials: BROADCAST_TEST_DEVICE_ID + BROADCAST_TEST_DEVICE_SECRET
+ */
+require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') });
+
+const BASE = process.env.TEST_BASE_URL || 'https://eclawbot.com';
+const DEVICE_ID = process.env.BROADCAST_TEST_DEVICE_ID;
+const DEVICE_SECRET = process.env.BROADCAST_TEST_DEVICE_SECRET;
+
+if (!DEVICE_ID || !DEVICE_SECRET) {
+    console.error('Missing BROADCAST_TEST_DEVICE_ID or BROADCAST_TEST_DEVICE_SECRET');
+    process.exit(1);
+}
+
+let passed = 0, failed = 0;
+
+function assert(condition, label) {
+    if (condition) { console.log(`  ✅ ${label}`); passed++; }
+    else { console.error(`  ❌ ${label}`); failed++; }
+}
+
+async function run() {
+    console.log('=== Issue #1676: Invite Auth Regression Test ===\n');
+
+    // Test 1: GET /api/invite/my-code with device auth (settings.html pattern)
+    console.log('Test 1: GET /api/invite/my-code with device auth');
+    {
+        const url = `${BASE}/api/invite/my-code?deviceId=${encodeURIComponent(DEVICE_ID)}&deviceSecret=${encodeURIComponent(DEVICE_SECRET)}`;
+        const res = await fetch(url);
+        const data = await res.json();
+        assert(res.status === 200, `status 200 (got ${res.status})`);
+        assert(data.success === true, 'success: true');
+        assert(typeof data.code === 'string' && data.code.length >= 4, `code is string (got: ${data.code})`);
+        assert(typeof data.bonus_messages === 'number' || data.bonus_messages !== undefined, 'bonus_messages present');
+        assert(typeof data.total_invited === 'number' || data.total_invited !== undefined, 'total_invited present');
+    }
+
+    // Test 2: GET /api/invite/my-code without any auth → should return 401 not 500
+    console.log('\nTest 2: GET /api/invite/my-code without auth');
+    {
+        const res = await fetch(`${BASE}/api/invite/my-code`);
+        assert(res.status === 401, `status 401 (got ${res.status})`);
+        assert(res.status !== 500, 'NOT 500 (was the original bug)');
+    }
+
+    // Test 3: GET /api/invite/my-code with wrong secret → 403
+    console.log('\nTest 3: GET /api/invite/my-code with wrong secret');
+    {
+        const url = `${BASE}/api/invite/my-code?deviceId=${encodeURIComponent(DEVICE_ID)}&deviceSecret=wrong_secret`;
+        const res = await fetch(url);
+        assert(res.status === 403, `status 403 (got ${res.status})`);
+    }
+
+    // Test 4: GET /api/invite/stats with device auth
+    console.log('\nTest 4: GET /api/invite/stats with device auth');
+    {
+        const url = `${BASE}/api/invite/stats?deviceId=${encodeURIComponent(DEVICE_ID)}&deviceSecret=${encodeURIComponent(DEVICE_SECRET)}`;
+        const res = await fetch(url);
+        const data = await res.json();
+        assert(res.status === 200, `status 200 (got ${res.status})`);
+        assert(data.success === true, 'success: true');
+    }
+
+    // Test 5: POST /api/invite/redeem with no code → 400
+    console.log('\nTest 5: POST /api/invite/redeem with no code');
+    {
+        const res = await fetch(`${BASE}/api/invite/redeem`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET }),
+        });
+        assert(res.status === 400, `status 400 (got ${res.status})`);
+    }
+
+    // Test 6: POST /api/invite/redeem with invalid code → 404
+    console.log('\nTest 6: POST /api/invite/redeem with invalid code');
+    {
+        const res = await fetch(`${BASE}/api/invite/redeem`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET, code: 'ZZZZZZZZ' }),
+        });
+        const data = await res.json();
+        assert(res.status === 404 || res.status === 400, `status 404/400 (got ${res.status})`);
+    }
+
+    console.log(`\n=== Results: ${passed} passed, ${failed} failed ===`);
+    process.exit(failed > 0 ? 1 : 0);
+}
+
+run().catch(err => { console.error('Test runner error:', err); process.exit(1); });


### PR DESCRIPTION
## Summary
- Remove invite.js JWT-auth router mount that intercepted device-auth requests, causing 401/500 on settings.html
- Add `resolveInviteAuth()` helper supporting both device-auth (query params) and JWT cookie auth
- Add regression test `test-invite-auth.js` with 6 test cases covering auth paths and error handling

Closes #1676

## Test plan
- [x] Jest tests pass (72/74 suites, 2 pre-existing failures unrelated)
- [x] ESLint passes (0 errors)
- [ ] Run `node backend/tests/test-invite-auth.js` against production after deploy
- [ ] Verify settings.html invite card loads correctly
- [ ] Verify invite.html page works with JWT cookie auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)