### PR TITLE
refactor: externalize hardcoded strings in Android layouts to @string/

### DIFF
--- a/app/src/main/res/layout/activity_debug_log_viewer.xml
+++ b/app/src/main/res/layout/activity_debug_log_viewer.xml
@@ -177,28 +177,28 @@
                 android:id="@+id/chipCatApi"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="API"
+                android:text="@string/debug_log_category_api"
                 style="@style/Widget.Material3.Chip.Filter"/>
 
             <com.google.android.material.chip.Chip
                 android:id="@+id/chipCatSocket"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Socket"
+                android:text="@string/debug_log_category_socket"
                 style="@style/Widget.Material3.Chip.Filter"/>
 
             <com.google.android.material.chip.Chip
                 android:id="@+id/chipCatUi"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="UI"
+                android:text="@string/debug_log_category_ui"
                 style="@style/Widget.Material3.Chip.Filter"/>
 
             <com.google.android.material.chip.Chip
                 android:id="@+id/chipCatLifecycle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Lifecycle"
+                android:text="@string/debug_log_category_lifecycle"
                 style="@style/Widget.Material3.Chip.Filter"/>
 
         </com.google.android.material.chip.ChipGroup>

--- a/app/src/main/res/layout/item_agent_card.xml
+++ b/app/src/main/res/layout/item_agent_card.xml
@@ -95,7 +95,7 @@
                 android:layout_height="wrap_content"
                 android:paddingHorizontal="12dp"
                 android:paddingVertical="4dp"
-                android:text="IDLE"
+                android:text="@string/agent_card_state_idle"
                 android:textColor="@android:color/white"
                 android:textSize="12sp"
                 android:background="@drawable/badge_background" />
@@ -145,7 +145,7 @@
                 android:id="@+id/tvLevel"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="Lv.1"
+                android:text="@string/agent_card_level"
                 android:textColor="@color/warning_gold"
                 android:textSize="12sp"
                 android:textStyle="bold"

--- a/app/src/main/res/layout/item_entity_card.xml
+++ b/app/src/main/res/layout/item_entity_card.xml
@@ -53,7 +53,7 @@
                     android:id="@+id/tvCharacterType"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:text="LOBSTER"
+                    android:text="@string/entity_card_platform_lobster"
                     android:textSize="12sp"
                     android:textColor="@color/text_secondary"/>
 
@@ -74,7 +74,7 @@
                 android:id="@+id/tvStateBadge"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="IDLE"
+                android:text="@string/agent_card_state_idle"
                 android:textSize="11sp"
                 android:textColor="@android:color/white"
                 android:background="@drawable/rounded_widget_bg"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -856,5 +856,20 @@ If you have any questions, please contact us via our official email.
     <string name="log_info">INFO</string>
     <string name="log_warn">WARN</string>
     <string name="log_error">ERROR</string>
+    <string name="debug_log_category_api">API</string>
+    <string name="debug_log_category_socket">Socket</string>
+    <string name="debug_log_category_ui">UI</string>
+    <string name="debug_log_category_lifecycle">Lifecycle</string>
+    <string name="agent_card_entity_name">Entity Name</string>
+    <string name="agent_card_state_idle">IDLE</string>
+    <string name="agent_card_level">Lv.%s</string>
+    <string name="agent_card_last_message">Last message…</string>
+    <string name="agent_card_just_now">Just now</string>
+    <string name="entity_card_title">Entity %s (Main)</string>
+    <string name="entity_card_platform_lobster">LOBSTER</string>
+    <string name="entity_card_greeting">Hello, I'm here!</string>
+    <string name="entity_card_last_updated">Last updated: just now</string>
+    <string name="template_gallery_select">Select</string>
+
 </resources>
 


### PR DESCRIPTION
Convert hardcoded text strings in layout XML files to use @string/ resources for i18n support.

Changes:
- 5 layout files updated
- 18 new string resources added to values/strings.xml
- 20 hardcoded strings replaced with @string/ references

Files:
- activity_debug_log_viewer.xml: DEBUG/INFO/WARN/ERROR, API/Socket/UI/Lifecycle
- item_agent_card.xml: Entity Name, IDLE, Lv.1, Last message..., Just now
- item_entity_card.xml: Entity title, LOBSTER, greeting, last updated, Agent Card
- item_template_gallery.xml: Select