### PR TITLE
fix(i18n): add missing commas in es/ar sections causing CI failure

### DIFF
--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -50188,7 +50188,7 @@ const TRANSLATIONS = {
         "arena_cancel": "Cancelar",
         "arena_expand": "Expandir",
         "arena_name_subtitle": "Ingresa tu nombre para registrar tu puntuación",
-        "arena_time_remaining": "Tiempo restante: "
+        "arena_time_remaining": "Tiempo restante: ",
 
         "action_add": "acción agregar",
         "activity": "actividad",
@@ -87642,7 +87642,7 @@ const TRANSLATIONS = {
         "guide_kanban_usecase_li4": "🔧 <strong>DevOps Automation</strong>: CI failure auto-creates a card → Backend Bot fixes → advances to Done",
         "guide_kanban_usecase_li4_strong": "DevOps Automation",
         "rn_1036_title": "v1.0.36",
-        "rn_1038_title": "v1.0.38"
+        "rn_1038_title": "v1.0.38",
 
         "action_add": "action إضافة",
         "action_confirm": "action تأكيد",


### PR DESCRIPTION
## Summary
- Fixed 2 missing trailing commas in i18n.js that caused SyntaxError during JS evaluation
- Spanish (es) line 50191: arena_time_remaining missing comma
- Arabic (ar) line 87645: rn_1038_title missing comma

This was the root cause of both CI failures:
1. Jest i18n-syntax.test.js — file parse failed on the missing commas
2. channel-cross-route.test.js — flaky failure caused by i18n parse error corrupting shared test state

After fix: 75/75 test suites, 1315/1315 tests pass

## Test plan
- [x] npx jest tests/jest/i18n-syntax.test.js — 7/7 pass
- [x] Full npm test — 75/75 suites, 1315/1315 tests pass

 Generated with Claude Code