### PR TITLE
i18n: Android zh-CN + zh-TW fill 25 missing translation keys

### DIFF
--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -320,6 +320,30 @@
     <string name="file_broadcast">广播</string>
     <string name="file_btn_delete">删除</string>
     <string name="file_btn_download">下载</string>
+    <string name="bind_button">绑定</string>
+    <string name="card_holder">名片夹</string>
+    <string name="chat">聊天</string>
+    <string name="choose_plan_title">选择方案</string>
+    <string name="confirm">确认</string>
+    <string name="enter_binding_code">输入绑定码</string>
+    <string name="error_occurred">发生错误</string>
+    <string name="info">信息</string>
+    <string name="invite_title">邀请</string>
+    <string name="language">语言</string>
+    <string name="loading">加载中…</string>
+    <string name="microphone_permission_denied">麦克风权限被拒绝</string>
+    <string name="my_rentals_title">我的租赁</string>
+    <string name="recording">录音中…</string>
+    <string name="schedule">定时任务</string>
+    <string name="settings">设置</string>
+    <string name="topup_ecoin">充值 E-Coin</string>
+    <string name="topup_ecoin_title">充值 E-Coin</string>
+    <string name="topup_failed">充值失败</string>
+    <string name="topup_success">充值成功</string>
+    <string name="unbind_button">解除绑定</string>
+    <string name="upgrade_plan">升级方案</string>
+    <string name="voice_message">语音消息</string>
+    <string name="wallet_title">钱包</string>
     <string name="file_btn_share">分享</string>
     <string name="file_delete_confirm">确定删除文件？</string>
     <string name="file_delete_title">删除文件</string>
@@ -485,6 +509,43 @@
     <string name="premium_badge">高级版</string>
     <string name="priority">优先级</string>
     <string name="privacy_policy_title">隐私政策</string>
+    <string name="privacy_policy_content">
+<b>1. 隐私至上的承诺</b>
+
+E-claw 团队深知隐私对您的重要性。我们在此郑重声明：<b>我们绝不会出售、泄露或滥用您的任何个人数据。</b>
+
+
+<b>2. 我们收集哪些数据？</b>
+
+为提供服务，我们仅收集运营所需的最少数据：
+- 设备 ID：用于区分不同设备。
+- 应用版本：用于兼容性检查。
+- 绑定数据：智能体名称和状态。
+- GPS 位置（可选）：仅当您的 AI 智能体主动请求时获取。仅存于内存，不持久化存储。
+- 语音消息（可选）：仅当您在聊天中按下录音按钮时。作为聊天记录的一部分上传。
+
+<b>我们不会收集：</b>
+- 您的姓名、电话号码或邮箱。
+- 您的相机数据。
+- 您手机上其他应用的信息。
+
+
+<b>3. OpenClaw 协议</b>
+我们是 OpenClaw 生态系统的坚定支持者。我们不会构建封闭的"围墙花园"，并承诺保持互操作性。
+
+<b>4. AI 对话隐私</b>
+消息通过加密的 HTTPS 发送至您绑定的 AI 智能体。数据流向由您掌控。
+
+<b>5. GPS 与麦克风</b>
+GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
+麦克风：仅在录音时启用，不会后台监听。
+两者均不会分享给第三方。
+
+
+<b>6. 联系我们</b>
+如有任何疑问，请通过官方邮箱与我们联系。
+    
+    </string>
     <string name="processing_payment">正在处理付款…</string>
     <string name="public_code_label">Public Code · 点击复制</string>
     <string name="publish_notification">发布通知</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -320,6 +320,30 @@
     <string name="file_broadcast">廣播</string>
     <string name="file_btn_delete">刪除</string>
     <string name="file_btn_download">下載</string>
+    <string name="bind_button">綁定</string>
+    <string name="card_holder">名片夾</string>
+    <string name="chat">聊天</string>
+    <string name="choose_plan_title">選擇方案</string>
+    <string name="confirm">確認</string>
+    <string name="enter_binding_code">輸入綁定碼</string>
+    <string name="error_occurred">發生錯誤</string>
+    <string name="info">資訊</string>
+    <string name="invite_title">邀請</string>
+    <string name="language">語言</string>
+    <string name="loading">載入中…</string>
+    <string name="microphone_permission_denied">麥克風權限被拒絕</string>
+    <string name="my_rentals_title">我的租用</string>
+    <string name="recording">錄音中…</string>
+    <string name="schedule">排程</string>
+    <string name="settings">設定</string>
+    <string name="topup_ecoin">儲值 E-Coin</string>
+    <string name="topup_ecoin_title">儲值 E-Coin</string>
+    <string name="topup_failed">儲值失敗</string>
+    <string name="topup_success">儲值成功</string>
+    <string name="unbind_button">解除綁定</string>
+    <string name="upgrade_plan">升級方案</string>
+    <string name="voice_message">語音訊息</string>
+    <string name="wallet_title">錢包</string>
     <string name="file_btn_share">分享</string>
     <string name="file_delete_confirm">確定刪除檔案？</string>
     <string name="file_delete_title">刪除檔案</string>
@@ -485,6 +509,42 @@
     <string name="premium_badge">尊爵會員</string>
     <string name="priority">優先權</string>
     <string name="privacy_policy_title">隱私權政策</string>
+    <string name="privacy_policy_content">
+<b>1. 隱私權至上承諾</b>
+
+E-claw (電子蝦) 團隊深知隱私對您的重要性。我們在此鄭重聲明：<b>我們絕不會販賣、洩露或濫用您的任何個人資料。</b>
+
+<b>2. 我們收集什麼資料？</b>
+
+為了提供服務，我們僅收集運作所需的最少資料：
+- 裝置 ID：用於區分不同裝置。
+- App 版本：用於相容性檢查。
+- 綁定資料：Agent 名稱與狀態。
+- GPS 位置（選擇性）：僅在您的 AI Agent 主動請求時取得。僅存於記憶體，不永久儲存。
+- 語音訊息（選擇性）：僅在您按下聊天中的錄音按鈕時。作為聊天記錄的一部分上傳。
+
+<b>我們「不」收集：</b>
+- 您的姓名、電話或 Email。
+- 您的相機資料。
+- 您手機上的其他應用程式資訊。
+
+
+<b>3. OpenClaw 協議</b>
+我們是 OpenClaw 生態系統的堅定支持者。我們不會建立封閉的「圍牆花園」，並承諾保持互通性。
+
+
+<b>4. AI 對話隱私</b>
+訊息透過加密 HTTPS 傳送至您綁定的 AI Agent。資料流向由您掌控。
+
+<b>5. GPS 與麥克風</b>
+GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
+麥克風：僅在錄音時啟用，不會背景監聽。
+兩者均不會分享給第三方。
+
+<b>6. 聯絡我們</b>
+如有任何疑問，請透過我們的官方 Email 聯繫。
+    
+    </string>
     <string name="processing_payment">付款處理中…</string>
     <string name="public_code_label">Public Code · 點擊複製</string>
     <string name="publish_notification">發布通知</string>


### PR DESCRIPTION
## Summary
补齐 25 个缺少的翻譯 key（bind_button, card_holder, chat, choose_plan_title, confirm, enter_binding_code, error_occurred, info, invite_title, language, loading, microphone_permission_denied, my_rentals_title, privacy_policy_content, recording, schedule, settings, topup_ecoin, topup_ecoin_title, topup_failed, topup_success, unbind_button, upgrade_plan, voice_message, wallet_title）。

- privacy_policy_content (長文 ~1400 chars) 完整翻譯 for both zh-CN and zh-TW
- 121 lines added across 2 files

## Changes
- `app/src/main/res/values-zh-rCN/strings.xml`: +25 keys (simplified Chinese)
- `app/src/main/res/values-zh-rTW/strings.xml`: +25 keys (traditional chinese)

- Note: values/strings.xml already had all 25 keys (from previous Spanish PR branch)

## Verification
All 25 keys present in all 3 locale files confirmed via grep check.