### PR TITLE
fix(rental): use make_interval for contract ends_at SQL

### DIFF
--- a/backend/rental.js
+++ b/backend/rental.js
@@ -424,7 +424,7 @@ async function startRental({
                 (listing_id, owner_user_id, renter_user_id, renter_device_id,
                  rate_mli_per_ktoken_snapshot, deposit_mli,
                  planned_duration_min, started_at, ends_at, status)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW() + ($7 || ' minutes')::interval, 'active')
+             VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW() + make_interval(mins => $7), 'active')
              RETURNING id, status, started_at, ends_at, deposit_mli`,
             [listingId, listing.owner_user_id, renterUserId, renterDeviceId,
              rateSnapshot, depositMli, durationMinutes]


### PR DESCRIPTION
## Summary
- Fix `startRental` SQL error: `($7 || " minutes")::interval` fails because PG cannot concat integer + text
- Replace with `make_interval(mins => $7)` which correctly handles integer params

## Test plan
- [ ] Create a rental contract via API and verify it succeeds (previously 500)
- [ ] Verify `ends_at` is correctly calculated

🤖 Generated with [Claude Code](https://claude.com/claude-code)