### PR TITLE
fix: seed virtual system users for platform/insurance wallets

### DIFF
--- a/backend/wallet.js
+++ b/backend/wallet.js
@@ -189,6 +189,41 @@ async function initWalletDatabase() {
                 }
             }
         }
+        // Seed virtual system users (platform + insurance) into user_accounts
+        // so the FK constraint on wallets.user_id is satisfied.
+        const virtualUsers = [
+            { id: PLATFORM_WALLET_USER_ID, email: 'system+platform@eclawbot.com', deviceId: 'system-platform-wallet' },
+            { id: INSURANCE_POOL_USER_ID,  email: 'system+insurance@eclawbot.com', deviceId: 'system-insurance-pool' },
+        ];
+        for (const vu of virtualUsers) {
+            try {
+                await pool.query(
+                    `INSERT INTO user_accounts (id, email, password_hash, device_id, device_secret)
+                     VALUES ($1, $2, 'SYSTEM_NO_LOGIN', $3, 'SYSTEM_NO_LOGIN')
+                     ON CONFLICT (id) DO NOTHING`,
+                    [vu.id, vu.email, vu.deviceId]
+                );
+            } catch (err) {
+                // Ignore duplicate key on email/device_id unique constraints
+                if (!err.message.includes('duplicate key') && !err.message.includes('already exists')) {
+                    console.warn(`[Wallet] Virtual user ${vu.id} seed warning:`, err.message);
+                }
+            }
+        }
+        // Ensure wallet rows exist for virtual users
+        for (const vu of virtualUsers) {
+            try {
+                await pool.query(
+                    `INSERT INTO wallets (user_id) VALUES ($1) ON CONFLICT (user_id) DO NOTHING`,
+                    [vu.id]
+                );
+            } catch (err) {
+                if (!err.message.includes('duplicate key') && !err.message.includes('already exists')) {
+                    console.warn(`[Wallet] Virtual wallet ${vu.id} seed warning:`, err.message);
+                }
+            }
+        }
+
         console.log('[Wallet] Database initialized');
     } catch (error) {
         console.error('[Wallet] Failed to init database:', error);


### PR DESCRIPTION
## Summary

- **Fixes #1706**: `POST /api/rental/contract/:id/end` with `endReason: ended_early_by_renter` returns HTTP 500
- Root cause: the forfeit split writes ledger entries to platform (`00000000-...0001`) and insurance (`00000000-...0002`) virtual wallet UUIDs, but these had no rows in `user_accounts`, causing a FK constraint violation when `ensureWalletRow` tries to insert into `wallets`
- Fix: seed virtual `user_accounts` + `wallets` rows for both system UUIDs during `initWalletDatabase()`, using `ON CONFLICT DO NOTHING` for idempotency

## Test plan

- [ ] Verify `initWalletDatabase()` creates the virtual user rows on server start
- [ ] Verify `POST /api/rental/contract/:id/end` with `ended_early_by_renter` no longer returns 500
- [ ] Verify `ended_violation` forfeit scenario also works
- [ ] Confirm idempotency: restarting server does not error on duplicate virtual users

🤖 Generated with [Claude Code](https://claude.com/claude-code)