### PR TITLE
fix: rental entity dashboard visibility (#1712)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -12508,7 +12508,7 @@ missionModule.setPushToBot(pushToBot);
 
 // Wire pushToBot + devices into rental module for interview probe dispatch
 if (typeof rentalModule.setInterviewDeps === 'function') {
-    rentalModule.setInterviewDeps({ pushToBot, devices, arenaModule, setInterviewCapabilities, get pushToChannelCallback() { return channelModule?.pushToChannelCallback?.bind(channelModule); } });
+    rentalModule.setInterviewDeps({ pushToBot, devices, arenaModule, setInterviewCapabilities, generateBotSecret, generatePublicCode, publicCodeIndex, ensureOneEmptySlot, get pushToChannelCallback() { return channelModule?.pushToChannelCallback?.bind(channelModule); } });
 }
 
 // NOTE: arenaModule.setAutoPushDeps is called AFTER channelModule init (see below ~line 13180+)

--- a/backend/rental.js
+++ b/backend/rental.js
@@ -23,6 +23,7 @@
  * If this module is updated, also update the roadmap page status and the design doc §10 delivery tracker. */
 
 const express = require('express');
+const crypto = require('crypto');
 const { Pool } = require('pg');
 const fs = require('fs');
 const path = require('path');
@@ -824,7 +825,7 @@ setInterval(() => {
  */
 function insertRentalEntity(devices, {
     renterDeviceId, contractId, listing, rateMliPerKtoken,
-}) {
+}, helpers) {
     const device = devices[renterDeviceId];
     if (!device) throw new Error('renter_device_not_found');
 
@@ -840,12 +841,24 @@ function insertRentalEntity(devices, {
         // Auto-expand: find max existing + 1
         const maxId = Math.max(-1, ...Object.keys(device.entities).map(Number));
         slot = maxId + 1;
-        device.entities[slot] = createDefaultRentalEntity();
+        device.entities[slot] = createDefaultRentalEntity(slot);
     }
+
+    // Generate botSecret and publicCode for the rental entity so it is
+    // fully functional (visible on dashboard, usable for chat/kanban/etc.)
+    const botSecret = helpers?.generateBotSecret
+        ? helpers.generateBotSecret()
+        : crypto.randomBytes(16).toString('hex');
+    const publicCode = helpers?.generatePublicCode
+        ? helpers.generatePublicCode()
+        : null;
 
     // Populate the rental entity
     const entity = device.entities[slot];
+    entity.entityId = slot;
     entity.isBound = true;
+    entity.botSecret = botSecret;
+    entity.publicCode = publicCode;
     entity.character = listing.title || 'Rental Bot';
     entity.name = listing.title || 'Rental Bot';
     entity.state = 'IDLE';
@@ -856,7 +869,17 @@ function insertRentalEntity(devices, {
     // Webhook points to a proxy URL — real webhook is in rental_snapshots
     entity.webhook = { url: `__rental_proxy__:${contractId}`, type: 'rental_proxy' };
 
-    return { slot };
+    // Register publicCode in the global index for cross-device messaging
+    if (publicCode && helpers?.publicCodeIndex) {
+        helpers.publicCodeIndex[publicCode] = { deviceId: renterDeviceId, entityId: slot };
+    }
+
+    // Ensure at least one empty slot remains after rental insertion
+    if (helpers?.ensureOneEmptySlot) {
+        helpers.ensureOneEmptySlot(device);
+    }
+
+    return { slot, botSecret, publicCode };
 }
 
 /**
@@ -875,14 +898,20 @@ function markOwnerEntityLeasedOut(devices, { ownerDeviceId, ownerEntityId, contr
 /**
  * Remove a rental entity from the renter's device (contract end).
  */
-function removeRentalEntity(devices, { renterDeviceId, contractId }) {
+function removeRentalEntity(devices, { renterDeviceId, contractId }, helpers) {
     const device = devices[renterDeviceId];
     if (!device) return;
 
     for (const [, entity] of Object.entries(device.entities)) {
         if (entity.rental_contract_id === contractId) {
+            // Clean up publicCode from global index before resetting
+            if (entity.publicCode && helpers?.publicCodeIndex) {
+                delete helpers.publicCodeIndex[entity.publicCode];
+            }
             // Reset to unbound default
             entity.isBound = false;
+            entity.botSecret = null;
+            entity.publicCode = null;
             entity.character = '🤖';
             entity.name = null;
             entity.state = 'IDLE';
@@ -909,8 +938,10 @@ function clearOwnerEntityLeasedOut(devices, { ownerDeviceId, ownerEntityId }) {
 }
 
 /** Minimal entity stub for a new rental slot. */
-function createDefaultRentalEntity() {
+function createDefaultRentalEntity(entityId) {
     return {
+        entityId: entityId,
+        botSecret: null,
         character: '🤖',
         state: 'IDLE',
         message: '',
@@ -924,6 +955,7 @@ function createDefaultRentalEntity() {
         level: 1,
         avatar: null,
         publicCode: null,
+        bindingType: null,
         rental_contract_id: null,
         rental_status: null,
     };
@@ -1045,6 +1077,11 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
                         contractId: contract.id,
                         listing,
                         rateMliPerKtoken: Number(listing.rate_mli_per_ktoken),
+                    }, {
+                        generateBotSecret: _interviewDeps.generateBotSecret,
+                        generatePublicCode: _interviewDeps.generatePublicCode,
+                        publicCodeIndex: _interviewDeps.publicCodeIndex,
+                        ensureOneEmptySlot: _interviewDeps.ensureOneEmptySlot,
                     });
                     markOwnerEntityLeasedOut(_interviewDeps.devices, {
                         ownerDeviceId: listing.owner_device_id,
@@ -1097,6 +1134,8 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
                     removeRentalEntity(_interviewDeps.devices, {
                         renterDeviceId: info.renter_device_id,
                         contractId: contract.id,
+                    }, {
+                        publicCodeIndex: _interviewDeps.publicCodeIndex,
                     });
                     clearOwnerEntityLeasedOut(_interviewDeps.devices, {
                         ownerDeviceId: info.owner_device_id,

--- a/backend/tests/jest/rental-entity-visibility.test.js
+++ b/backend/tests/jest/rental-entity-visibility.test.js
@@ -1,0 +1,243 @@
+/**
+ * Regression test: Rental entity dashboard visibility (#1712)
+ *
+ * Verifies that insertRentalEntity() creates entities with all required
+ * fields (entityId, botSecret, publicCode) so they appear on the
+ * renter's dashboard via GET /api/entities.
+ */
+
+const { insertRentalEntity, removeRentalEntity, createDefaultRentalEntity } = (() => {
+    // We need to extract the pure functions from rental.js.
+    // Since rental.js exports a factory, we access the named exports it attaches.
+    const mod = require('../../rental');
+    // The factory returns an object with these helpers
+    const instance = mod({
+        authMiddleware: (req, res, next) => next(),
+        adminMiddleware: (req, res, next) => next(),
+        walletModule: { withTransaction: async (fn) => fn({}) },
+        serverLog: () => {},
+    });
+    return instance;
+})();
+
+describe('Rental entity dashboard visibility (#1712)', () => {
+    let devices;
+    let publicCodeIndex;
+    const helpers = {
+        generateBotSecret: () => 'test_bot_secret_32charhex1234567',
+        generatePublicCode: () => 'abc123',
+        publicCodeIndex: {},
+        ensureOneEmptySlot: () => null,
+    };
+
+    beforeEach(() => {
+        publicCodeIndex = {};
+        helpers.publicCodeIndex = publicCodeIndex;
+        devices = {
+            'renter-device-1': {
+                deviceId: 'renter-device-1',
+                deviceSecret: 'secret',
+                nextEntityId: 2,
+                entities: {
+                    0: {
+                        entityId: 0,
+                        botSecret: 'existing-secret',
+                        isBound: true,
+                        character: 'existing',
+                        name: 'Existing Bot',
+                        state: 'IDLE',
+                        message: '',
+                        parts: {},
+                        lastUpdated: Date.now(),
+                        messageQueue: [],
+                        webhook: { url: 'https://example.com' },
+                        xp: 0,
+                        level: 1,
+                        avatar: null,
+                        publicCode: 'exist1',
+                    },
+                    1: {
+                        entityId: 1,
+                        isBound: false,
+                        character: 'LOBSTER',
+                        state: 'IDLE',
+                        message: '',
+                        parts: {},
+                        lastUpdated: Date.now(),
+                        messageQueue: [],
+                        webhook: null,
+                        xp: 0,
+                        level: 1,
+                        avatar: null,
+                        publicCode: null,
+                    },
+                },
+            },
+        };
+    });
+
+    test('insertRentalEntity sets entityId on the entity', () => {
+        const result = insertRentalEntity(devices, {
+            renterDeviceId: 'renter-device-1',
+            contractId: 'contract-1',
+            listing: { title: 'Test Rental Bot' },
+            rateMliPerKtoken: 5000,
+        }, helpers);
+
+        expect(result.slot).toBe(1); // reuses unbound slot 1
+        const entity = devices['renter-device-1'].entities[1];
+        expect(entity.entityId).toBe(1);
+        expect(entity.isBound).toBe(true);
+    });
+
+    test('insertRentalEntity generates botSecret', () => {
+        const result = insertRentalEntity(devices, {
+            renterDeviceId: 'renter-device-1',
+            contractId: 'contract-1',
+            listing: { title: 'Test Rental Bot' },
+            rateMliPerKtoken: 5000,
+        }, helpers);
+
+        const entity = devices['renter-device-1'].entities[result.slot];
+        expect(entity.botSecret).toBeTruthy();
+        expect(typeof entity.botSecret).toBe('string');
+        expect(entity.botSecret.length).toBeGreaterThan(0);
+        expect(result.botSecret).toBe(entity.botSecret);
+    });
+
+    test('insertRentalEntity generates publicCode and registers in index', () => {
+        const result = insertRentalEntity(devices, {
+            renterDeviceId: 'renter-device-1',
+            contractId: 'contract-1',
+            listing: { title: 'Test Rental Bot' },
+            rateMliPerKtoken: 5000,
+        }, helpers);
+
+        const entity = devices['renter-device-1'].entities[result.slot];
+        expect(entity.publicCode).toBeTruthy();
+        expect(result.publicCode).toBe(entity.publicCode);
+        // Should be registered in the public code index
+        expect(publicCodeIndex[entity.publicCode]).toEqual({
+            deviceId: 'renter-device-1',
+            entityId: result.slot,
+        });
+    });
+
+    test('insertRentalEntity sets name and character from listing title', () => {
+        insertRentalEntity(devices, {
+            renterDeviceId: 'renter-device-1',
+            contractId: 'contract-1',
+            listing: { title: 'My Cool Bot' },
+            rateMliPerKtoken: 3000,
+        }, helpers);
+
+        const entity = devices['renter-device-1'].entities[1];
+        expect(entity.name).toBe('My Cool Bot');
+        expect(entity.character).toBe('My Cool Bot');
+    });
+
+    test('rental entity would be returned by /api/entities filter (isBound check)', () => {
+        insertRentalEntity(devices, {
+            renterDeviceId: 'renter-device-1',
+            contractId: 'contract-1',
+            listing: { title: 'Rental Bot' },
+            rateMliPerKtoken: 5000,
+        }, helpers);
+
+        // Simulate what /api/entities does: iterate and filter isBound
+        const entities = [];
+        const device = devices['renter-device-1'];
+        for (const i of Object.keys(device.entities).map(Number)) {
+            const entity = device.entities[i];
+            if (!entity) continue;
+            if (entity.isBound) {
+                entities.push({
+                    entityId: entity.entityId,
+                    name: entity.name,
+                    character: entity.character,
+                    isBound: true,
+                    publicCode: entity.publicCode || null,
+                    botSecret: entity.botSecret,
+                });
+            }
+        }
+
+        // Should have 2 entities: the existing one + the rental
+        expect(entities.length).toBe(2);
+        const rental = entities.find(e => e.name === 'Rental Bot');
+        expect(rental).toBeDefined();
+        expect(rental.entityId).toBe(1);
+        expect(rental.publicCode).toBeTruthy();
+        expect(rental.botSecret).toBeTruthy();
+    });
+
+    test('insertRentalEntity auto-expands when all slots are bound', () => {
+        // Make slot 1 also bound
+        devices['renter-device-1'].entities[1].isBound = true;
+
+        let ensureCalled = false;
+        const helpersWithExpand = {
+            ...helpers,
+            ensureOneEmptySlot: () => { ensureCalled = true; return null; },
+        };
+
+        const result = insertRentalEntity(devices, {
+            renterDeviceId: 'renter-device-1',
+            contractId: 'contract-1',
+            listing: { title: 'Expanded Bot' },
+            rateMliPerKtoken: 1000,
+        }, helpersWithExpand);
+
+        // Should have created slot 2
+        expect(result.slot).toBe(2);
+        const entity = devices['renter-device-1'].entities[2];
+        expect(entity.entityId).toBe(2);
+        expect(entity.isBound).toBe(true);
+        expect(entity.botSecret).toBeTruthy();
+        expect(ensureCalled).toBe(true);
+    });
+
+    test('removeRentalEntity cleans up publicCode from index', () => {
+        const result = insertRentalEntity(devices, {
+            renterDeviceId: 'renter-device-1',
+            contractId: 'contract-1',
+            listing: { title: 'Temp Bot' },
+            rateMliPerKtoken: 2000,
+        }, helpers);
+
+        const code = result.publicCode;
+        expect(publicCodeIndex[code]).toBeDefined();
+
+        removeRentalEntity(devices, {
+            renterDeviceId: 'renter-device-1',
+            contractId: 'contract-1',
+        }, { publicCodeIndex });
+
+        // publicCode should be removed from index
+        expect(publicCodeIndex[code]).toBeUndefined();
+        // Entity should be unbound and cleared
+        const entity = devices['renter-device-1'].entities[result.slot];
+        expect(entity.isBound).toBe(false);
+        expect(entity.botSecret).toBeNull();
+        expect(entity.publicCode).toBeNull();
+    });
+
+    test('insertRentalEntity works without helpers (fallback)', () => {
+        // When no helpers are passed, should still generate a botSecret via crypto
+        const result = insertRentalEntity(devices, {
+            renterDeviceId: 'renter-device-1',
+            contractId: 'contract-1',
+            listing: { title: 'Fallback Bot' },
+            rateMliPerKtoken: 1000,
+        });
+
+        const entity = devices['renter-device-1'].entities[result.slot];
+        expect(entity.entityId).toBe(1);
+        expect(entity.isBound).toBe(true);
+        // botSecret generated via crypto fallback
+        expect(entity.botSecret).toBeTruthy();
+        expect(entity.botSecret.length).toBe(32);
+        // publicCode null without helper
+        expect(entity.publicCode).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- **Bug**: After renting a bot, renter dashboard showed 0 entities bound despite active contract
- **Root cause**: `insertRentalEntity()` created entities without `entityId`, `botSecret`, or `publicCode`
- **Fix**: Generate all required fields, register publicCode in global index, clean up on contract end

## Test plan
- [x] New Jest test `rental-entity-visibility.test.js` (8 cases passing)
- [ ] Verify renter dashboard shows rental entity after contract start
- [ ] Verify rental entity has working publicCode
- [ ] Verify cleanup on contract end

Fixes #1712