### PR TITLE
fix(rental): persist rental entity to DB after in-memory insert

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -12508,7 +12508,7 @@ missionModule.setPushToBot(pushToBot);
 
 // Wire pushToBot + devices into rental module for interview probe dispatch
 if (typeof rentalModule.setInterviewDeps === 'function') {
-    rentalModule.setInterviewDeps({ pushToBot, devices, arenaModule, setInterviewCapabilities, generateBotSecret, generatePublicCode, publicCodeIndex, ensureOneEmptySlot, getOrCreateDevice, get pushToChannelCallback() { return channelModule?.pushToChannelCallback?.bind(channelModule); } });
+    rentalModule.setInterviewDeps({ pushToBot, devices, arenaModule, setInterviewCapabilities, generateBotSecret, generatePublicCode, publicCodeIndex, ensureOneEmptySlot, getOrCreateDevice, saveDeviceData: db.saveDeviceData, get pushToChannelCallback() { return channelModule?.pushToChannelCallback?.bind(channelModule); } });
 }
 
 // Reconcile rental entities that may have been lost during server restart (#1713).
@@ -12516,7 +12516,7 @@ if (typeof rentalModule.setInterviewDeps === 'function') {
 if (persistenceReady && typeof rentalModule.reconcileRentalEntities === 'function') {
     rentalModule.reconcileRentalEntities(devices, {
         generateBotSecret, generatePublicCode, publicCodeIndex,
-        ensureOneEmptySlot, getOrCreateDevice,
+        ensureOneEmptySlot, getOrCreateDevice, saveDeviceData: db.saveDeviceData,
     }).then(result => {
         if (result.reconciled > 0 || result.errors.length > 0) {
             console.log(`[Rental] Reconciled ${result.reconciled} rental entities` +

--- a/backend/rental.js
+++ b/backend/rental.js
@@ -1015,6 +1015,11 @@ async function reconcileRentalEntities(devices, helpers) {
                     rateMliPerKtoken: Number(row.rate_mli_per_ktoken_snapshot),
                 }, helpers);
 
+                // Persist reconciled entity to DB
+                if (helpers?.saveDeviceData && devices[row.renter_device_id]) {
+                    await helpers.saveDeviceData(row.renter_device_id, devices[row.renter_device_id]);
+                }
+
                 result.reconciled++;
                 console.log(`[Rental] Reconciled entity for contract ${row.id} on device ${row.renter_device_id}`);
             } catch (err) {
@@ -1167,6 +1172,12 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
                     audit('info', 'rental', `entity handover: slot ${slot} on ${renterDeviceId}`, {
                         userId: req.user.userId, action: 'rental_entity_insert', resource: contract.id,
                     });
+
+                    // Persist to DB so entity poll reads the updated state
+                    if (_interviewDeps.saveDeviceData) {
+                        await _interviewDeps.saveDeviceData(renterDeviceId, _interviewDeps.devices[renterDeviceId]);
+                        await _interviewDeps.saveDeviceData(listing.owner_device_id, _interviewDeps.devices[listing.owner_device_id]);
+                    }
                 }
             } catch (handoverErr) {
                 // Log but don't fail the contract — the DB contract is the source of truth.
@@ -1220,6 +1231,14 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
                     audit('info', 'rental', `entity handover cleanup: ${info.renter_device_id}`, {
                         userId: req.user.userId, action: 'rental_entity_remove', resource: contract.id,
                     });
+
+                    // Persist cleanup to DB
+                    if (_interviewDeps.saveDeviceData && _interviewDeps.devices[info.renter_device_id]) {
+                        await _interviewDeps.saveDeviceData(info.renter_device_id, _interviewDeps.devices[info.renter_device_id]);
+                    }
+                    if (_interviewDeps.saveDeviceData && _interviewDeps.devices[info.owner_device_id]) {
+                        await _interviewDeps.saveDeviceData(info.owner_device_id, _interviewDeps.devices[info.owner_device_id]);
+                    }
                 }
             } catch (cleanupErr) {
                 console.error('[Rental] entity handover cleanup failed:', cleanupErr.message);


### PR DESCRIPTION
## Summary
- Root cause: insertRentalEntity only modified in-memory devices map, never called db.saveDeviceData()
- Entity poll reads from DB → overwrites in-memory isBound:true with DB isBound:false
- Fix: call saveDeviceData after insert/remove/reconcile

Fixes #1713

🤖 Generated with [Claude Code](https://claude.com/claude-code)