### PR TITLE
fix(rental-ui): use correct deviceId field name from /api/auth/me

### DIFF
--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -927,7 +927,7 @@
             const duration = parseInt(document.getElementById('rentalDuration')?.value, 10) || 60;
             const data = await apiPost('/api/rental/contract', {
                 listingId,
-                renterDeviceId: user.user.device_id || 'web',
+                renterDeviceId: user.user.deviceId || user.user.device_id || 'web',
                 durationMinutes: duration,
             });
             if (data?.success) {


### PR DESCRIPTION
## Summary
- **Root cause**: `community.html` used `user.user.device_id` (snake_case) but `/api/auth/me` returns `deviceId` (camelCase)
- `renterDeviceId` fell back to `"web"` → `insertRentalEntity` wrote to phantom device
- Fix: `user.user.deviceId || user.user.device_id || "web"`

## This was the ACTUAL root cause of BUG-5
After 4 fix attempts (PR #1714, #1717, #1718), the real issue was a 1-character field name mismatch.

Fixes #1713

🤖 Generated with [Claude Code](https://claude.com/claude-code)