### PR TITLE
i18n: Android ja/ko/th/vi/in fill 25 missing translation keys

### DIFF
--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -317,6 +317,65 @@
     <string name="file_broadcast">Siaran</string>
     <string name="file_btn_delete">Hapus</string>
     <string name="file_btn_download">Unduh</string>
+    <string name="bind_button">Ikatan</string>
+    <string name="card_holder">Pemegang Kartu</string>
+    <string name="chat">Obrolan</string>
+    <string name="choose_plan_title">Pilih Paket</string>
+    <string name="confirm">Konfirmasi</string>
+    <string name="enter_binding_code">Masukkan kode ikatan</string>
+    <string name="error_occurred">Terjadi kesalahan</string>
+    <string name="info">Info</string>
+    <string name="invite_title">Undang</string>
+    <string name="language">Bahasa</string>
+    <string name="loading">Memuat…</string>
+    <string name="microphone_permission_denied">Izin mikrofon ditolak</string>
+    <string name="my_rentals_title">Sewa Saya</string>
+    <string name="privacy_policy_content">
+
+<b>1. Komitmen Privasi Utama</b>
+
+Tim E-claw memahami pentingnya privasi bagi Anda. Kami dengan ini menyatakan dengan tegas：<b>Kami tidak akan pernah menjual, membocorkan, atau menyalahgunakan data pribadi Anda.</b>
+
+<b>2. Data Apa yang Kami Kumpulkan？</b>
+
+Untuk menyediakan layanan, kami hanya mengumpulkan data minimum yang diperlukan untuk operasi：
+- ID Perangkat：Digunakan untuk membedakan perangkat berbeda
+- Versi Aplikasi：Digunakan untuk pemeriksaan kompatibilitas
+- Data Pengikatan：Nama dan status agen
+- Lokasi GPS（opsional）：Hanya diperoleh ketika agen AI Anda secara aktif memintanya. Hanya disimpan di memori, tidak secara permanen
+- Pesan Suara（opsional）：Hanya ketika Anda menekan tombol rekam di obrolan. Diunggah sebagai bagian dari riwayat obrolan
+
+<b>Kami TIDAK mengumpulkan：</b>
+- Nama, nomor telepon, atau email Anda
+- Data kamera Anda
+- Informasi aplikasi lain di ponsel Anda
+
+<b>3. Protokol OpenClaw</b>
+Kami adalah pendukung tegas ekosistem OpenClaw. Kami tidak akan membangun "Taman Tertutup" dan berjanji untuk mempertahankan interoperabilitas.
+
+<b>4. Privasi Percakapan AI</b>
+Pesan dikirim melalui HTTPS terenkripsi ke agen AI yang terikat. Aliran data dikendalikan oleh Anda.
+
+<b>5. GPS dan Mikrofon</b>
+GPS：Hanya sesuai permintaan, tidak ada pelacakan latar belakang, data hilang setelah restart server
+Mikrofon：Hanya aktif saat merekam, tidak ada penyadapan latar belakang
+Keduanya tidak akan dibagikan ke pihak ketiga
+
+<b>6. Hubungi Kami</b>
+Jika ada pertanyaan, silakan hubungi kami melalui email resmi kami.
+    
+    </string>
+    <string name="recording">Merekam…</string>
+    <string name="schedule">Jadwal</string>
+    <string name="settings">Pengaturan</string>
+    <string name="topup_ecoin">Isi Ulang E-Coin</string>
+    <string name="topup_ecoin_title">Isi Ulang E-Coin</string>
+    <string name="topup_failed">Isi ulang gagal</string>
+    <string name="topup_success">Isi ulang berhasil</string>
+    <string name="unbind_button">Lepas Ikatan</string>
+    <string name="upgrade_plan">Upgrade Paket</string>
+    <string name="voice_message">Pesan Suara</string>
+    <string name="wallet_title">Dompet</string>
     <string name="file_btn_share">Bagikan</string>
     <string name="file_delete_confirm">Apakah Anda yakin ingin menghapus file ini?</string>
     <string name="file_delete_title">Hapus File</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -317,6 +317,65 @@
     <string name="file_broadcast">ブロードキャスト</string>
     <string name="file_btn_delete">削除</string>
     <string name="file_btn_download">ダウンロード</string>
+    <string name="bind_button">バインド</string>
+    <string name="card_holder">名刺ホルダー</string>
+    <string name="chat">チャット</string>
+    <string name="choose_plan_title">プランを選択</string>
+    <string name="confirm">確認</string>
+    <string name="enter_binding_code">バインディングコードを入力</string>
+    <string name="error_occurred">エラーが発生しました</string>
+    <string name="info">情報</string>
+    <string name="invite_title">招待</string>
+    <string name="language">言語</string>
+    <string name="loading">読み込み中…</string>
+    <string name="microphone_permission_denied">マイクの許可が拒否されました</string>
+    <string name="my_rentals_title">私のレンタル</string>
+    <string name="privacy_policy_content">
+
+<b>1. プライバシー最優先の約束</b>
+
+E-claw チームは一切個人のデータを販売、流用、乱用しないことをここに明記します。
+
+<b>2. 収集するデータ</b>
+
+本サービスの運営に必要な最小限のデータのみを収集します：
+- デバイスID：デバイスの識別用
+- アプリバージョン：互換性チェック用
+- バインディングデータ：エージェント名とステータス
+- GPS位置（任意）：AIエージェントが能動的に要求した場合のみ取得。メモリにのみ保存され、永続化されません。
+- 音声メッセージ（任意）：チャット内で録音ボタンを押した場合のみ。チャット履歴の一部としてアップロードされます。
+
+<b>収集しないもの：</b>
+- 氏名、電話番号、メール
+- カメラデータ
+- スマートフォン上の他のアプリ情報
+
+<b>3. OpenClawプロトコル</b>
+我々はOpenClawエコシステムの坚定的支持者です。閉鎖的な「垣根の庭」を構築せず、相互運用性を維持することを約束します。
+
+<b>4. AI会話のプライバシー</b>
+メッセージは暗号化されたHTTPSを通じてバインドされたAIエージェントに送信されます。データフローはあなたが制御します。
+
+<b>5. GPSとマイク</b>
+GPS：オンデマンドのみ、バックグラウンド追跡なし、サーバー再起動後にデータは消失します。
+マイク：録音中のみアクティブ、バックグラウンド監視なし。
+両方も第三者とは共有されません。
+
+<b>6. お問い合わせ</b>
+ご質問がございましたら、公式メールでお問い合わせください。
+    
+    </string>
+    <string name="recording">録音中…</string>
+    <string name="schedule">スケジュール</string>
+    <string name="settings">設定</string>
+    <string name="topup_ecoin">E-Coinをチャージ</string>
+    <string name="topup_ecoin_title">E-Coinをチャージ</string>
+    <string name="topup_failed">チャージに失敗しました</string>
+    <string name="topup_success">チャージに成功しました</string>
+    <string name="unbind_button">バインド解除</string>
+    <string name="upgrade_plan">プランをアップグレード</string>
+    <string name="voice_message">音声メッセージ</string>
+    <string name="wallet_title">ウォレット</string>
     <string name="file_btn_share">共有</string>
     <string name="file_delete_confirm">このファイルを削除してもよろしいですか？</string>
     <string name="file_delete_title">ファイルを削除</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -317,6 +317,65 @@
     <string name="file_broadcast">브로드캐스트</string>
     <string name="file_btn_delete">삭제</string>
     <string name="file_btn_download">다운로드</string>
+    <string name="bind_button">바인드</string>
+    <string name="card_holder">명함함</string>
+    <string name="chat">채팅</string>
+    <string name="choose_plan_title">요금제 선택</string>
+    <string name="confirm">확인</string>
+    <string name="enter_binding_code">바인딩 코드 입력</string>
+    <string name="error_occurred">오류가 발생했습니다</string>
+    <string name="info">정보</string>
+    <string name="invite_title">초대</string>
+    <string name="language">언어</string>
+    <string name="loading">로딩 중…</string>
+    <string name="microphone_permission_denied">마이크 권한이 거부되었습니다</string>
+    <string name="my_rentals_title">내 대여</string>
+    <string name="privacy_policy_content">
+
+<b>1. 개인정보 보호 최우선 약속</b>
+
+E-claw 팀은 개인 데이터를 판매, 유출 또는 오용하지 않을 것을 엄숙히 선언합니다.
+
+<b>2. 수집하는 데이터</b>
+
+서비스를 제공하기 위해 필요한 최소한의 데이터만 수집합니다：
+- 기기 ID: 기기 구분용
+- 앱 버전: 호환성 검사용
+- 바인딩 데이터: 에이전트 이름과 상태
+- GPS 위치(선택): AI 에이전트가 능동적으로 요청할 때만 가져옴. 메모리에만 저장되며 영구 보관되지 않음
+- 음성 메시지(선택): 채팅에서 녹음 버튼을 누를 때만. 채팅 기록의 일부로 업로드됨
+
+<b>수집하지 않음：</b>
+- 성명, 전화번호 또는 이메일
+- 카메라 데이터
+- 스마트폰의 다른 앱 정보
+
+<b>3. OpenClaw 프로토콜</b>
+저희는 OpenClaw 생태계의 확고한 지지자입니다. 폐쇄적인 "방파장 정원"을 구축하지 않으며 상호운용성을 유지할 것을 약속합니다.
+
+<b>4. AI 대화 프라이버시</b>
+메시지는 암호화된 HTTPS를 통해 바인딩된 AI 에이전트에 전송됩니다. 데이터 흐름은 귀하가 제어합니다.
+
+<b>5. GPS와 마이크</b>
+GPS: 온디맨드만, 백그라운드 추적 없음, 서버 재시작 시 데이터 소멸
+마이크: 녹음 중에만 활성화, 백그라운드 감청 없음
+둘 다 제3자와 공유되지 않습니다.
+
+<b>6. 연락처</b>
+문의사항이 있으시면 공식 이메일을 통해 연락 주세요.
+    
+    </string>
+    <string name="recording">녹음 중…</string>
+    <string name="schedule">일정</string>
+    <string name="settings">설정</string>
+    <string name="topup_ecoin">E-Coin 충전</string>
+    <string name="topup_ecoin_title">E-Coin 충전</string>
+    <string name="topup_failed">충전 실패</string>
+    <string name="topup_success">충전 성공</string>
+    <string name="unbind_button">바인드 해제</string>
+    <string name="upgrade_plan">요금제 업그레이드</string>
+    <string name="voice_message">음성 메시지</string>
+    <string name="wallet_title">지갑</string>
     <string name="file_btn_share">공유</string>
     <string name="file_delete_confirm">이 파일을 삭제하시겠습니까?</string>
     <string name="file_delete_title">파일 삭제</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -317,6 +317,65 @@
     <string name="file_broadcast">ส่งถึงทุกคน</string>
     <string name="file_btn_delete">ลบ</string>
     <string name="file_btn_download">ดาวน์โหลด</string>
+    <string name="bind_button">ผูก</string>
+    <string name="card_holder">ที่ใส่นามบัตร</string>
+    <string name="chat">แชท</string>
+    <string name="choose_plan_title">เลือกแผน</string>
+    <string name="confirm">ยืนยัน</string>
+    <string name="enter_binding_code">ใส่รหัสผูก</string>
+    <string name="error_occurred">เกิดข้อผิดพลาด</string>
+    <string name="info">ข้อมูล</string>
+    <string name="invite_title">เชิญ</string>
+    <string name="language">ภาษา</string>
+    <string name="loading">กำลังโหลด…</string>
+    <string name="microphone_permission_denied">สิทธิ์ไมโครโฟนถูกปฏิเสธ</string>
+    <string name="my_rentals_title">การเช่าของฉัน</string>
+    <string name="privacy_policy_content">
+
+<b>1. คำมั่นสัญญาด้านความเป็นส่วนตัวตอนแรก</b>
+
+ทีมงาน E-claw ตระหนักถึงความสำคัญของความเป็นส่วนตัวของคุณ เราขอประกาศอย่างเป็นทางการว่า：<b>เราจะไม่ขาย เปิดเผย หรือใช้ข้อมูลส่วนบุคคลของคุณในทางที่ผิดโดยเด็ดขาด</b>
+
+<b>2. เราเก็บข้อมูลอะไรบ้าง？</b>
+
+เพื่อให้บริการ เราเก็บเฉพาะข้อมูลที่จำเป็นสำหรับการดำเนินงาน：
+- รหัสอุปกรณ์：ใช้แยกความแตกต่างของอุปกรณ์ต่างๆ
+- เวอร์ชันแอป：ใช้ตรวจสอบความเข้ากันได้
+- ข้อมูลการผูก：ชื่อและสถานะของเอเจนต์
+- ตำแหน่ง GPS（ตัวเลือก）：รับเฉพาะเมื่อเอไอเอเจนต์ของคุณร้องขออย่างกระตือรือร้น เก็บในหน่วยความจำเท่านั้น ไม่เก็บถาวร
+- ข้อความเสียง（ตัวเลือก）：เฉพาะเมื่อคุณกดปุ่มบันทึกในแชท อัปโหลดเป็นส่วนหนึ่งของประวัติแชท
+
+<b>เราไม่เก็บ：</b>
+- ชื่อ เบอร์โทร หรืออีเมลของคุณ
+- ข้อมูลกล้องของคุณ
+- ข้อมูลแอปอื่นๆ บนโทรศัพท์ของคุณ
+
+<b>3. ข้อตกลง OpenClaw</b>
+เราเป็นผู้สนับสนุนที่มั่นคงของระบบนิเวศ OpenClaw เราจะไม่สร้าง "สวนกำแพง" ที่ปิดกั้น และสัญญาว่าจะรักษาความสามารถในการทำงานร่วมกัน
+
+<b>4. ความเป็นส่วนตัวของการสนทนา AI</b>
+ข้อความถูกส่งผ่าน HTTPS ที่เข้ารหัสไปยังเอไอเอเจนต์ที่ผูกไว้ การไหลของข้อมูลอยู่ภายใต้การควบคุมของคุณ
+
+<b>5. GPS และไมโครโฟน</b>
+GPS：รับตามความต้องการเท่านั้น ไม่ติดตามเบื้องหลัง ข้อมูลจะหายเมื่อรีสตาร์ทเซิร์ฟเวอร์
+ไมโครโฟน：ทำงานเฉพาะตอนบันทึกเท่านั้น ไม่ฟังเบื้องหลัง
+ทั้งสองไม่แชร์กับบุคคลที่สาม
+
+<b>6. ติดต่อเรา</b>
+หากมีคำถามใดๆ โปรดติดต่อเราผ่านอีเมลทางการ
+    
+    </string>
+    <string name="recording">กำลังบันทึก…</string>
+    <string name="schedule">กำหนดการ</string>
+    <string name="settings">ตั้งค่า</string>
+    <string name="topup_ecoin">เติม E-Coin</string>
+    <string name="topup_ecoin_title">เติม E-Coin</string>
+    <string name="topup_failed">เติมเงินล้มเหลว</string>
+    <string name="topup_success">เติมเงินสำเร็จ</string>
+    <string name="unbind_button">ยกเลิกการผูก</string>
+    <string name="upgrade_plan">อัพเกรดแผน</string>
+    <string name="voice_message">ข้อความเสียง</string>
+    <string name="wallet_title">กระเป๋าเงิน</string>
     <string name="file_btn_share">แชร์</string>
     <string name="file_delete_confirm">คุณแน่ใจหรือไม่ว่าต้องการลบไฟล์นี้?</string>
     <string name="file_delete_title">ลบไฟล์</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -317,6 +317,65 @@
     <string name="file_broadcast">Phát chung</string>
     <string name="file_btn_delete">Xóa</string>
     <string name="file_btn_download">Tải xuống</string>
+    <string name="bind_button">Liên kết</string>
+    <string name="card_holder">Người giữ thẻ</string>
+    <string name="chat">Trò chuyện</string>
+    <string name="choose_plan_title">Chọn gói</string>
+    <string name="confirm">Xác nhận</string>
+    <string name="enter_binding_code">Nhập mã liên kết</string>
+    <string name="error_occurred">Đã xảy ra lỗi</string>
+    <string name="info">Thông tin</string>
+    <string name="invite_title">Mời</string>
+    <string name="language">Ngôn ngữ</string>
+    <string name="loading">Đang tải…</string>
+    <string name="microphone_permission_denied">Quyền microphone bị từ chối</string>
+    <string name="my_rentals_title">Cho thuê của tôi</string>
+    <string name="privacy_policy_content">
+
+<b>1. Cam kết bảo mật quyền riêng tư</b>
+
+Đội ngũ E-claw hiểu rõ tầm quan trọng của quyền riêng tư đối với bạn. Chúng tôi nghiêm túc tuyên bố：<b>Chúng tôi sẽ không bao giờ bán, tiết lộ hoặc lạm dụng bất kỳ dữ liệu cá nhân nào của bạn.</b>
+
+<b>2. Chúng tôi thu thập dữ liệu gì？</b>
+
+Để cung cấp dịch vụ, chúng tôi chỉ thu thập dữ liệu tối thiểu cần thiết cho hoạt động：
+- ID thiết bị：Dùng để phân biệt các thiết bị khác nhau
+- Phiên bản ứng dụng：Dùng để kiểm tra tính tương thích
+- Dữ liệu liên kết：Tên và trạng thái của tác nhân
+- Vị trí GPS（tùy chọn）：Chỉ lấy khi tác nhân AI chủ động yêu cầu. Chỉ lưu trong bộ nhớ, không lưu trữ vĩnh viễn
+- Tin nhắn thoại（tùy chọn）：Chỉ khi bạn nhấn nút ghi âm trong trò chuyện. Được tải lên như một phần của lịch sử trò chuyện
+
+<b>Chúng tôi KHÔNG thu thập：</b>
+- Tên, số điện thoại hoặc email của bạn
+- Dữ liệu camera của bạn
+- Thông tin về các ứng dụng khác trên điện thoại của bạn
+
+<b>3. Giao thức OpenClaw</b>
+Chúng tôi là người ủng hộ kiên định của hệ sinh thái OpenClaw. Chúng tôi sẽ không xây dựng "vườn có tường bao" đóng kín và cam kết duy trì khả năng tương tác
+
+<b>4. Quyền riêng tư trò chuyện AI</b>
+Tin nhắn được gửi qua HTTPS được mã hóa đến tác nhân AI được liên kết. Luồng dữ liệu do bạn kiểm soát
+
+<b>5. GPS và Microphone</b>
+GPS：Chỉ theo yêu cầu, không theo dõi nền, dữ liệu biến mất khi khởi động lại máy chủ
+Microphone：Chỉ kích hoạt khi ghi âm, không nghe lén nền
+Cả hai đều không được chia sẻ với bên thứ ba
+
+<b>6. Liên hệ với chúng tôi</b>
+Nếu có bất kỳ câu hỏi nào, vui lòng liên hệ với chúng tôi qua email chính thức
+    
+    </string>
+    <string name="recording">Đang ghi âm…</string>
+    <string name="schedule">Lịch trình</string>
+    <string name="settings">Cài đặt</string>
+    <string name="topup_ecoin">Nạp E-Coin</string>
+    <string name="topup_ecoin_title">Nạp E-Coin</string>
+    <string name="topup_failed">Nạp tiền thất bại</string>
+    <string name="topup_success">Nạp tiền thành công</string>
+    <string name="unbind_button">Hủy liên kết</string>
+    <string name="upgrade_plan">Nâng cấp gói</string>
+    <string name="voice_message">Tin nhắn thoại</string>
+    <string name="wallet_title">Ví</string>
     <string name="file_btn_share">Chia sẻ</string>
     <string name="file_delete_confirm">Bạn có chắc muốn xóa tệp này không?</string>
     <string name="file_delete_title">Xóa tệp</string>


### PR DESCRIPTION
## Summary
- Fill 25 missing translatable keys for ja, ko, th, vi, in (Indonesian)
- Keys include: bind_button, card_holder, chat, choose_plan_title, confirm, etc.
- privacy_policy_content fully translated for each language

## Test plan
- [ ] Android lint passes
- [ ] All XML files valid (no content after </resources>)

🤖 Generated with [Claude Code](https://claude.com/claude-code)