### PR TITLE
fix(android): resolve CI failures — missing API method + i18n format strings

### DIFF
--- a/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
@@ -190,6 +190,9 @@ interface ClawApiService {
     // SUBSCRIPTION
     // ============================================
 
+    @POST("api/wallet/topup/verify-google")
+    suspend fun verifyGoogleTopup(@Body body: Map<String, @JvmSuppressWildcards Any>): ApiResponse
+
     @POST("api/subscription/verify-google")
     suspend fun verifyGoogleSubscription(@Body body: Map<String, @JvmSuppressWildcards Any>): ApiResponse
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -319,7 +319,7 @@ Tus comentarios enviados aparecerán aquí.</string>
     <string name="feedback_photo_uploaded">%d foto(s) subida(s)</string>
     <string name="feedback_photo_uploading">Subiendo fotos…</string>
     <string name="feedback_result_issue">Ver Issue de GitHub #%d</string>
-    <string name="feedback_result_logs">Capturados: %d llamadas API, %d registros del servidor</string>
+    <string name="feedback_result_logs">Capturados: %1$d llamadas API, %2$d registros del servidor</string>
     <string name="feedback_result_severity">Severidad: %s</string>
     <string name="feedback_result_title">Comentarios #%d recibidos</string>
     <string name="feedback_sending">Enviando…</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -303,7 +303,7 @@
     <string name="feedback_photo_uploaded">%d foto diunggah</string>
     <string name="feedback_photo_uploading">Mengunggah foto…</string>
     <string name="feedback_result_issue">Lihat GitHub Issue #%d</string>
-    <string name="feedback_result_logs">Diambil: %d panggilan API, %d log server</string>
+    <string name="feedback_result_logs">Diambil: %1$d panggilan API, %2$d log server</string>
     <string name="feedback_result_severity">Tingkat keparahan: %s</string>
     <string name="feedback_result_title">Umpan balik #%d diterima</string>
     <string name="feedback_sending">Mengirim…</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -303,7 +303,7 @@
     <string name="feedback_photo_uploaded">%d枚の写真をアップロードしました</string>
     <string name="feedback_photo_uploading">写真をアップロード中…</string>
     <string name="feedback_result_issue">GitHub Issue #%d を表示</string>
-    <string name="feedback_result_logs">キャプチャ: APIコール %d件、サーバーログ %d件</string>
+    <string name="feedback_result_logs">キャプチャ: APIコール %1$d件、サーバーログ %2$d件</string>
     <string name="feedback_result_severity">重要度: %s</string>
     <string name="feedback_result_title">フィードバック #%d を受信しました</string>
     <string name="feedback_sending">送信中…</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -303,7 +303,7 @@
     <string name="feedback_photo_uploaded">%d장의 사진이 업로드되었습니다</string>
     <string name="feedback_photo_uploading">사진 업로드 중…</string>
     <string name="feedback_result_issue">GitHub 이슈 #%d 보기</string>
-    <string name="feedback_result_logs">캡처됨: API 호출 %d건, 서버 로그 %d건</string>
+    <string name="feedback_result_logs">캡처됨: API 호출 %1$d건, 서버 로그 %2$d건</string>
     <string name="feedback_result_severity">심각도: %s</string>
     <string name="feedback_result_title">피드백 #%d이(가) 접수되었습니다</string>
     <string name="feedback_sending">전송 중…</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -303,7 +303,7 @@
     <string name="feedback_photo_uploaded">อัปโหลด %d รูปแล้ว</string>
     <string name="feedback_photo_uploading">กำลังอัปโหลดรูปภาพ…</string>
     <string name="feedback_result_issue">ดู GitHub Issue #%d</string>
-    <string name="feedback_result_logs">บันทึกที่จับได้: %d การเรียก API, %d บันทึกเซิร์ฟเวอร์</string>
+    <string name="feedback_result_logs">บันทึกที่จับได้: %1$d การเรียก API, %2$d บันทึกเซิร์ฟเวอร์</string>
     <string name="feedback_result_severity">ความรุนแรง: %s</string>
     <string name="feedback_result_title">ได้รับความคิดเห็น #%d แล้ว</string>
     <string name="feedback_sending">กำลังส่ง…</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -303,7 +303,7 @@
     <string name="feedback_photo_uploaded">Đã tải lên %d ảnh</string>
     <string name="feedback_photo_uploading">Đang tải ảnh lên…</string>
     <string name="feedback_result_issue">Xem GitHub Issue #%d</string>
-    <string name="feedback_result_logs">Đã thu thập: %d lệnh gọi API, %d nhật ký máy chủ</string>
+    <string name="feedback_result_logs">Đã thu thập: %1$d lệnh gọi API, %2$d nhật ký máy chủ</string>
     <string name="feedback_result_severity">Mức độ: %s</string>
     <string name="feedback_result_title">Đã nhận phản hồi #%d</string>
     <string name="feedback_sending">Đang gửi…</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -306,7 +306,7 @@
     <string name="feedback_photo_uploaded">已上传 %d 张照片</string>
     <string name="feedback_photo_uploading">正在上传照片…</string>
     <string name="feedback_result_issue">查看 GitHub Issue #%d</string>
-    <string name="feedback_result_logs">已捕获：%d 个 API 调用，%d 条服务器日志</string>
+    <string name="feedback_result_logs">已捕获：%1$d 个 API 调用，%2$d 条服务器日志</string>
     <string name="feedback_result_severity">严重程度：%s</string>
     <string name="feedback_result_title">反馈 #%d 已收到</string>
     <string name="feedback_sending">发送中…</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -306,7 +306,7 @@
     <string name="feedback_photo_uploaded">已上傳 %d 張照片</string>
     <string name="feedback_photo_uploading">照片上傳中…</string>
     <string name="feedback_result_issue">查看 GitHub Issue #%d</string>
-    <string name="feedback_result_logs">已擷取：%d 個 API 請求、%d 筆伺服器紀錄</string>
+    <string name="feedback_result_logs">已擷取：%1$d 個 API 請求、%2$d 筆伺服器紀錄</string>
     <string name="feedback_result_severity">嚴重程度：%s</string>
     <string name="feedback_result_title">意見 #%d 已收到</string>
     <string name="feedback_sending">傳送中…</string>


### PR DESCRIPTION
## Summary
- **BillingManager.kt:457** — `verifyGoogleTopup` was called but never defined in `ClawApiService`. Added the missing Retrofit method pointing to `POST /api/wallet/topup/verify-google`.
- **feedback_result_logs** — 8 language files used non-positional `%d` instead of `%1$d`/`%2$d`, causing `mergeDebugResources` failure. Fixed all 8 files (es, ja, ko, th, vi, in, zh-CN, zh-TW).

These two issues were blocking all Android CI runs on main and on PRs #1721/#1722.

## Test plan
- [ ] Android CI passes (compileDebugKotlin + mergeDebugResources)
- [ ] Existing i18n PRs #1721 and #1722 can be rebased and merged after this

🤖 Generated with [Claude Code](https://claude.com/claude-code)