### PR TITLE
fix(AiChat): move 5 hardcoded strings to strings.xml + i18n

### DIFF
--- a/app/src/main/java/com/hank/clawlive/ui/AiChatViewModel.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/AiChatViewModel.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.hank.clawlive.data.local.DeviceManager
+import com.hank.clawlive.R
 import com.hank.clawlive.data.remote.AiChatPollResponse
 import com.hank.clawlive.data.remote.NetworkModule
 import kotlinx.coroutines.Job
@@ -120,12 +121,12 @@ class AiChatViewModel(application: Application) : AndroidViewModel(application) 
             }
 
             if (!submitResponse.success) {
-                finishWithError(submitResponse.message ?: submitResponse.error ?: "Failed to send message.")
+                finishWithError(submitResponse.message ?: submitResponse.error ?: context.getString(R.string.chat_failed_to_send))
                 return
             }
 
             val requestId = submitResponse.requestId ?: run {
-                finishWithError("Failed to send message.")
+                finishWithError(context.getString(R.string.chat_failed_to_send_v2))
                 return
             }
             savePendingRequestId(requestId)
@@ -134,7 +135,7 @@ class AiChatViewModel(application: Application) : AndroidViewModel(application) 
             statusJob?.cancel()
             statusJob = viewModelScope.launch {
                 delay(5000)
-                _uiState.update { it.copy(typingText = "AI is analyzing your message…") }
+                _uiState.update { it.copy(typingText = context.getString(R.string.chat_ai_analyzing)) }
                 delay(10000)
                 _uiState.update { it.copy(typingText = "Still working on it…") }
                 delay(45000)
@@ -386,7 +387,7 @@ class AiChatViewModel(application: Application) : AndroidViewModel(application) 
                 is java.net.SocketTimeoutException -> "Response timed out. Trying again…"
                 is java.net.UnknownHostException -> "No internet connection. Please check your network."
                 is java.io.IOException -> "Connection error. Please try again."
-                else -> "Network error. Please try again."
+                else -> context.getString(R.string.chat_network_error)
             }
         }
         val errorBody = try { e.response()?.errorBody()?.string() } catch (_: Exception) { null }
@@ -396,7 +397,7 @@ class AiChatViewModel(application: Application) : AndroidViewModel(application) 
             401 -> json.optString("message", "").ifEmpty {
                 "Device not registered. Please restart the app."
             }
-            413 -> "Images are too large. Please try with fewer or smaller images, or describe your issue in text."
+            413 -> context.getString(R.string.chat_images_too_large)
             429 -> {
                 val retryMs = json.optLong("retry_after_ms", 0)
                 if (retryMs > 0) "Message limit reached. Try again in ${retryMs / 1000}s."

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -333,6 +333,11 @@ Tus comentarios enviados aparecerán aquí.</string>
     <string name="file_broadcast">Broadcast</string>
     <string name="file_btn_delete">Eliminar</string>
     <string name="file_btn_download">Descargar</string>
+    <string name="chat_ai_analyzing">IA está analizando tu mensaje…</string>
+    <string name="chat_failed_to_send">Error al enviar el mensaje.</string>
+    <string name="chat_failed_to_send_v2">Error al enviar el mensaje.</string>
+    <string name="chat_images_too_large">Las imágenes son demasiado grandes. Intenta con menos imágenes o más pequeñas, o describe tu problema con texto.</string>
+    <string name="chat_network_error">Error de red. Inténtalo de nuevo.</string>
     <string name="invite_title">Invitar Amigos</string>
     <string name="my_rentals_title">Mis Alquileres</string>
     <string name="wallet_title">Billetera</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -317,6 +317,11 @@
     <string name="file_broadcast">Siaran</string>
     <string name="file_btn_delete">Hapus</string>
     <string name="file_btn_download">Unduh</string>
+    <string name="chat_ai_analyzing">AI sedang menganalisis pesan Anda…</string>
+    <string name="chat_failed_to_send">Gagal mengirim pesan.</string>
+    <string name="chat_failed_to_send_v2">Gagal mengirim pesan.</string>
+    <string name="chat_images_too_large">Gambar terlalu besar. Coba gunakan lebih sedikit atau gambar yang lebih kecil, atau jelaskan masalah Anda dalam teks.</string>
+    <string name="chat_network_error">Kesalahan jaringan. Silakan coba lagi.</string>
     <string name="bind_button">Ikatan</string>
     <string name="card_holder">Pemegang Kartu</string>
     <string name="chat">Obrolan</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -317,6 +317,11 @@
     <string name="file_broadcast">ブロードキャスト</string>
     <string name="file_btn_delete">削除</string>
     <string name="file_btn_download">ダウンロード</string>
+    <string name="chat_ai_analyzing">AIがメッセージを分析中…</string>
+    <string name="chat_failed_to_send">メッセージの送信に失敗しました。</string>
+    <string name="chat_failed_to_send_v2">メッセージの送信に失敗しました。</string>
+    <string name="chat_images_too_large">画像が大きすぎます。画像を減らすか、小さな画像を使用するか、テキストで問題を説明してください。</string>
+    <string name="chat_network_error">ネットワークエラー。再試行してください。</string>
     <string name="bind_button">バインド</string>
     <string name="card_holder">名刺ホルダー</string>
     <string name="chat">チャット</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -317,6 +317,11 @@
     <string name="file_broadcast">브로드캐스트</string>
     <string name="file_btn_delete">삭제</string>
     <string name="file_btn_download">다운로드</string>
+    <string name="chat_ai_analyzing">AI가 메시지 분석 중…</string>
+    <string name="chat_failed_to_send">메시지 전송에 실패했습니다.</string>
+    <string name="chat_failed_to_send_v2">메시지 전송에 실패했습니다.</string>
+    <string name="chat_images_too_large">이미지가 너무 큽니다. 이미지를 줄이거나 작은 이미지를 사용하거나 텍스트로 문제를 설명해 주세요.</string>
+    <string name="chat_network_error">네트워크 오류. 다시 시도해 주세요.</string>
     <string name="bind_button">바인드</string>
     <string name="card_holder">명함함</string>
     <string name="chat">채팅</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -317,6 +317,11 @@
     <string name="file_broadcast">ส่งถึงทุกคน</string>
     <string name="file_btn_delete">ลบ</string>
     <string name="file_btn_download">ดาวน์โหลด</string>
+    <string name="chat_ai_analyzing">AI กำลังวิเคราะห์ข้อความของคุณ…</string>
+    <string name="chat_failed_to_send">ส่งข้อความไม่สำเร็จ</string>
+    <string name="chat_failed_to_send_v2">ส่งข้อความไม่สำเร็จ</string>
+    <string name="chat_images_too_large">รูปภาพใหญ่เกินไป กรุณาลองใช้รูปภาพน้อยลงหรือขนาดเล็กลง หรืออธิบายปัญหาของคุณเป็นข้อความ</string>
+    <string name="chat_network_error">ข้อผิดพลาดเครือข่าย กรุณาลองอีกครั้ง</string>
     <string name="bind_button">ผูก</string>
     <string name="card_holder">ที่ใส่นามบัตร</string>
     <string name="chat">แชท</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -317,6 +317,11 @@
     <string name="file_broadcast">Phát chung</string>
     <string name="file_btn_delete">Xóa</string>
     <string name="file_btn_download">Tải xuống</string>
+    <string name="chat_ai_analyzing">AI đang phân tích tin nhắn của bạn…</string>
+    <string name="chat_failed_to_send">Gửi tin nhắn thất bại.</string>
+    <string name="chat_failed_to_send_v2">Gửi tin nhắn thất bại.</string>
+    <string name="chat_images_too_large">Hình ảnh quá lớn. Vui lòng thử ít hơn hoặc hình ảnh nhỏ hơn, hoặc mô tả vấn đề của bạn bằng văn bản.</string>
+    <string name="chat_network_error">Lỗi mạng. Vui lòng thử lại.</string>
     <string name="bind_button">Liên kết</string>
     <string name="card_holder">Người giữ thẻ</string>
     <string name="chat">Trò chuyện</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -320,6 +320,11 @@
     <string name="file_broadcast">广播</string>
     <string name="file_btn_delete">删除</string>
     <string name="file_btn_download">下载</string>
+    <string name="chat_ai_analyzing">AI 正在分析您的消息…</string>
+    <string name="chat_failed_to_send">发送消息失败。</string>
+    <string name="chat_failed_to_send_v2">发送消息失败。</string>
+    <string name="chat_images_too_large">图片太大，请减少图片数量或使用较小的图片，或以文字描述您的问题。</string>
+    <string name="chat_network_error">网络错误，请重试。</string>
     <string name="bind_button">绑定</string>
     <string name="card_holder">名片夹</string>
     <string name="chat">聊天</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -320,6 +320,11 @@
     <string name="file_broadcast">廣播</string>
     <string name="file_btn_delete">刪除</string>
     <string name="file_btn_download">下載</string>
+    <string name="chat_ai_analyzing">AI 正在分析您的訊息…</string>
+    <string name="chat_failed_to_send">發送訊息失敗。</string>
+    <string name="chat_failed_to_send_v2">發送訊息失敗。</string>
+    <string name="chat_images_too_large">圖片太大，請減少圖片數量或使用較小的圖片，或以文字描述您的問題。</string>
+    <string name="chat_network_error">網路錯誤，請重試。</string>
     <string name="bind_button">綁定</string>
     <string name="card_holder">名片夾</string>
     <string name="chat">聊天</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -554,6 +554,11 @@ If you have any questions, please contact us via our official email.
     <string name="file_type_photo">Photo</string>
     <string name="file_type_voice">Voice</string>
     <string name="file_btn_download">Download</string>
+    <string name="chat_ai_analyzing">AI is analyzing your message…</string>
+    <string name="chat_failed_to_send">Failed to send message.</string>
+    <string name="chat_failed_to_send_v2">Failed to send message.</string>
+    <string name="chat_images_too_large">Images are too large. Please try with fewer or smaller images, or describe your issue in text.</string>
+    <string name="chat_network_error">Network error. Please try again.</string>
     <string name="file_btn_share">Share</string>
     <string name="file_btn_delete">Delete</string>
     <string name="file_delete_title">Delete File</string>


### PR DESCRIPTION
## Summary
移除 AiChatViewModel.kt 硬編碼英文字串，移入 strings.xml 並補上 8 語系翻譯。

### 5 個字串
- `chat_failed_to_send`: Failed to send message.
- `chat_failed_to_send_v2`: Failed to send message.
- `chat_ai_analyzing`: AI is analyzing your message…
- `chat_network_error`: Network error. Please try again.
- `chat_images_too_large`: Images are too large...

### 修改檔案
- `AiChatViewModel.kt`: `context.getString(R.string.xxx)` 替換 5 處
- `values/strings.xml`: +5 keys（英文）
- 8 locale 檔案：+5 keys 翻譯（zh-TW, zh-CN, ja, ko, th, vi, in, es）

### 翻譯覆蓋
| 語系 | chat_failed_to_send | chat_ai_analyzing | chat_network_error |
|------|------|------|------|
| zh-TW | 發送訊息失敗。 | AI 正在分析您的訊息… | 網路錯誤，請重試。|
| zh-CN | 发送消息失败。 | AI 正在分析您的消息… | 网络错误，请重试。|
| ja | メッセージの送信に失敗しました。 | AIがメッセージを分析中… | ネットワークエラー。|
| ko | 메시지 전송에 실패했습니다. | AI가 메시지 분석 중… | 네트워크 오류。|
| es | Error al enviar el mensaje. | IA está analizando tu mensaje… | Error de red。|

10 files changed, 51 insertions(+), 5 deletions(-)