### PR TITLE
fix(MainActivity): move 9 hardcoded Toast strings to strings.xml + i18n

### DIFF
--- a/app/src/main/java/com/hank/clawlive/MainActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/MainActivity.kt
@@ -53,6 +53,7 @@ import com.hank.clawlive.data.local.UsageManager
 import com.hank.clawlive.data.model.AvatarUploadResponse
 import com.hank.clawlive.data.model.EntityStatus
 import com.hank.clawlive.data.model.UpdateAvatarRequest
+import com.hank.clawlive.R
 import com.hank.clawlive.data.remote.NetworkModule
 import com.hank.clawlive.data.remote.TelemetryHelper
 import com.hank.clawlive.data.repository.StateRepository
@@ -1037,7 +1038,7 @@ class MainActivity : AppCompatActivity() {
                         Toast.makeText(this@MainActivity, getString(R.string.xd_saved), Toast.LENGTH_SHORT).show()
                         dialog.dismiss()
                     } else {
-                        Toast.makeText(this@MainActivity, resp.message ?: "Error", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(this@MainActivity, resp.message ?: getString(R.string.main_save_error), Toast.LENGTH_SHORT).show()
                     }
                 } catch (e: Exception) {
                     Timber.e(e, "Failed to save cross-device settings")
@@ -1060,7 +1061,7 @@ class MainActivity : AppCompatActivity() {
                         Toast.makeText(this@MainActivity, getString(R.string.xd_reset_done), Toast.LENGTH_SHORT).show()
                         dialog.dismiss()
                     } else {
-                        Toast.makeText(this@MainActivity, resp.message ?: "Error", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(this@MainActivity, resp.message ?: getString(R.string.main_save_error), Toast.LENGTH_SHORT).show()
                     }
                 } catch (e: Exception) {
                     Timber.e(e, "Failed to reset cross-device settings")
@@ -1139,7 +1140,7 @@ class MainActivity : AppCompatActivity() {
                 if (capsContainer.childCount < 10) {
                     capsContainer.addView(buildCapabilityRowForDialog("", "", capsContainer))
                 } else {
-                    Toast.makeText(this@MainActivity, "Maximum 10 capabilities", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@MainActivity, getString(R.string.main_max_capabilities), Toast.LENGTH_SHORT).show()
                 }
             }
         })
@@ -1318,7 +1319,7 @@ class MainActivity : AppCompatActivity() {
                     val v = input.text.toString().trim()
                     if (v.isEmpty()) return@setOnClickListener
                     if (chipContainer.childCount >= maxItems) {
-                        Toast.makeText(this@MainActivity, "Maximum $maxItems items", Toast.LENGTH_SHORT).show()
+                        Toast.makeText(this@MainActivity, getString(R.string.main_max_items, maxItems), Toast.LENGTH_SHORT).show()
                         return@setOnClickListener
                     }
                     chipContainer.addView(makeChipForDialog(v, chipContainer))
@@ -1357,7 +1358,7 @@ class MainActivity : AppCompatActivity() {
                               capabilities: List<Map<String, String>>, protocols: List<String>,
                               tags: List<String>, version: String, website: String, email: String) {
         if (description.isEmpty()) {
-            Toast.makeText(this, "Description is required", Toast.LENGTH_SHORT).show()
+            Toast.makeText(this, getString(R.string.main_description_required), Toast.LENGTH_SHORT).show()
             return
         }
 
@@ -1373,13 +1374,13 @@ class MainActivity : AppCompatActivity() {
                 )
                 val response = api.updateAgentCard(body)
                 if (response.success) {
-                    Toast.makeText(this@MainActivity, "Agent Card saved", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@MainActivity, getString(R.string.main_agent_card_saved), Toast.LENGTH_SHORT).show()
                 } else {
-                    Toast.makeText(this@MainActivity, response.message ?: "Save failed", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@MainActivity, response.message ?: getString(R.string.main_save_failed), Toast.LENGTH_SHORT).show()
                 }
             } catch (e: Exception) {
                 Timber.e(e, "Failed to save agent card")
-                Toast.makeText(this@MainActivity, "Save failed: ${e.message}", Toast.LENGTH_SHORT).show()
+                Toast.makeText(this@MainActivity, getString(R.string.main_save_failed_msg, e.message), Toast.LENGTH_SHORT).show()
             }
         }
     }
@@ -1394,9 +1395,9 @@ class MainActivity : AppCompatActivity() {
                 )
                 val response = api.deleteAgentCard(body)
                 if (response.success) {
-                    Toast.makeText(this@MainActivity, "Agent Card deleted", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@MainActivity, getString(R.string.main_agent_card_deleted), Toast.LENGTH_SHORT).show()
                 } else {
-                    Toast.makeText(this@MainActivity, response.message ?: "Delete failed", Toast.LENGTH_SHORT).show()
+                    Toast.makeText(this@MainActivity, response.message ?: getString(R.string.main_delete_failed), Toast.LENGTH_SHORT).show()
                 }
             } catch (e: Exception) {
                 Timber.e(e, "Failed to delete agent card")

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -333,6 +333,15 @@ Tus comentarios enviados aparecerán aquí.</string>
     <string name="file_broadcast">Broadcast</string>
     <string name="file_btn_delete">Eliminar</string>
     <string name="file_btn_download">Descargar</string>
+    <string name="main_agent_card_deleted">Agent Card eliminado</string>
+    <string name="main_agent_card_saved">Agent Card guardado</string>
+    <string name="main_delete_failed">Error al eliminar</string>
+    <string name="main_description_required">La descripción es obligatoria</string>
+    <string name="main_max_capabilities">Máximo 10 capacidades</string>
+    <string name="main_max_items">Máximo %d elementos</string>
+    <string name="main_save_error">Se produjo un error</string>
+    <string name="main_save_failed">Error al guardar</string>
+    <string name="main_save_failed_msg">Error al guardar：%s</string>
     <string name="chat_ai_analyzing">IA está analizando tu mensaje…</string>
     <string name="chat_failed_to_send">Error al enviar el mensaje.</string>
     <string name="chat_failed_to_send_v2">Error al enviar el mensaje.</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -317,6 +317,15 @@
     <string name="file_broadcast">Siaran</string>
     <string name="file_btn_delete">Hapus</string>
     <string name="file_btn_download">Unduh</string>
+    <string name="main_agent_card_deleted">Agent Card dihapus</string>
+    <string name="main_agent_card_saved">Agent Card disimpan</string>
+    <string name="main_delete_failed">Penghapusan gagal</string>
+    <string name="main_description_required">Deskripsi wajib diisi</string>
+    <string name="main_max_capabilities">Maksimum 10 kapabilitas</string>
+    <string name="main_max_items">Maksimum %d item</string>
+    <string name="main_save_error">Terjadi kesalahan</string>
+    <string name="main_save_failed">Penyimpanan gagal</string>
+    <string name="main_save_failed_msg">Penyimpanan gagal：%s</string>
     <string name="chat_ai_analyzing">AI sedang menganalisis pesan Anda…</string>
     <string name="chat_failed_to_send">Gagal mengirim pesan.</string>
     <string name="chat_failed_to_send_v2">Gagal mengirim pesan.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -317,6 +317,15 @@
     <string name="file_broadcast">ブロードキャスト</string>
     <string name="file_btn_delete">削除</string>
     <string name="file_btn_download">ダウンロード</string>
+    <string name="main_agent_card_deleted">Agent Card を削除しました</string>
+    <string name="main_agent_card_saved">Agent Card を保存しました</string>
+    <string name="main_delete_failed">削除に失敗しました</string>
+    <string name="main_description_required">説明は必須です</string>
+    <string name="main_max_capabilities">キャパビリティは最大10個まで</string>
+    <string name="main_max_items">最大 %d 個のアイテム</string>
+    <string name="main_save_error">エラーが発生しました</string>
+    <string name="main_save_failed">保存に失敗しました</string>
+    <string name="main_save_failed_msg">保存に失敗しました：%s</string>
     <string name="chat_ai_analyzing">AIがメッセージを分析中…</string>
     <string name="chat_failed_to_send">メッセージの送信に失敗しました。</string>
     <string name="chat_failed_to_send_v2">メッセージの送信に失敗しました。</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -317,6 +317,15 @@
     <string name="file_broadcast">브로드캐스트</string>
     <string name="file_btn_delete">삭제</string>
     <string name="file_btn_download">다운로드</string>
+    <string name="main_agent_card_deleted">Agent Card 삭제됨</string>
+    <string name="main_agent_card_saved">Agent Card 저장됨</string>
+    <string name="main_delete_failed">삭제 실패</string>
+    <string name="main_description_required">설명은 필수입니다</string>
+    <string name="main_max_capabilities">최대 10개의 역량만 가능합니다</string>
+    <string name="main_max_items">최대 %d개 항목</string>
+    <string name="main_save_error">오류가 발생했습니다</string>
+    <string name="main_save_failed">저장 실패</string>
+    <string name="main_save_failed_msg">저장 실패：%s</string>
     <string name="chat_ai_analyzing">AI가 메시지 분석 중…</string>
     <string name="chat_failed_to_send">메시지 전송에 실패했습니다.</string>
     <string name="chat_failed_to_send_v2">메시지 전송에 실패했습니다.</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -317,6 +317,15 @@
     <string name="file_broadcast">ส่งถึงทุกคน</string>
     <string name="file_btn_delete">ลบ</string>
     <string name="file_btn_download">ดาวน์โหลด</string>
+    <string name="main_agent_card_deleted">ลบ Agent Card แล้ว</string>
+    <string name="main_agent_card_saved">บันทึก Agent Card แล้ว</string>
+    <string name="main_delete_failed">ลบล้มเหลว</string>
+    <string name="main_description_required">ต้องระบุคำอธิบาย</string>
+    <string name="main_max_capabilities">สูงสุด 10 ความสามารถ</string>
+    <string name="main_max_items">สูงสุด %d รายการ</string>
+    <string name="main_save_error">เกิดข้อผิดพลาด</string>
+    <string name="main_save_failed">บันทึกล้มเหลว</string>
+    <string name="main_save_failed_msg">บันทึกล้มเหลว：%s</string>
     <string name="chat_ai_analyzing">AI กำลังวิเคราะห์ข้อความของคุณ…</string>
     <string name="chat_failed_to_send">ส่งข้อความไม่สำเร็จ</string>
     <string name="chat_failed_to_send_v2">ส่งข้อความไม่สำเร็จ</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -317,6 +317,15 @@
     <string name="file_broadcast">Phát chung</string>
     <string name="file_btn_delete">Xóa</string>
     <string name="file_btn_download">Tải xuống</string>
+    <string name="main_agent_card_deleted">Đã xóa Agent Card</string>
+    <string name="main_agent_card_saved">Đã lưu Agent Card</string>
+    <string name="main_delete_failed">Xóa thất bại</string>
+    <string name="main_description_required">Mô tả là bắt buộc</string>
+    <string name="main_max_capabilities">Tối đa 10 khả năng</string>
+    <string name="main_max_items">Tối đa %d mục</string>
+    <string name="main_save_error">Đã xảy ra lỗi</string>
+    <string name="main_save_failed">Lưu thất bại</string>
+    <string name="main_save_failed_msg">Lưu thất bại：%s</string>
     <string name="chat_ai_analyzing">AI đang phân tích tin nhắn của bạn…</string>
     <string name="chat_failed_to_send">Gửi tin nhắn thất bại.</string>
     <string name="chat_failed_to_send_v2">Gửi tin nhắn thất bại.</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -320,6 +320,15 @@
     <string name="file_broadcast">广播</string>
     <string name="file_btn_delete">删除</string>
     <string name="file_btn_download">下载</string>
+    <string name="main_agent_card_deleted">Agent Card 已删除</string>
+    <string name="main_agent_card_saved">Agent Card 已储存</string>
+    <string name="main_delete_failed">删除失败</string>
+    <string name="main_description_required">描述为必填</string>
+    <string name="main_max_capabilities">最多 10 个能力</string>
+    <string name="main_max_items">最多 %d 个项目</string>
+    <string name="main_save_error">发生错误</string>
+    <string name="main_save_failed">储存失败</string>
+    <string name="main_save_failed_msg">储存失败：%s</string>
     <string name="chat_ai_analyzing">AI 正在分析您的消息…</string>
     <string name="chat_failed_to_send">发送消息失败。</string>
     <string name="chat_failed_to_send_v2">发送消息失败。</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -320,6 +320,15 @@
     <string name="file_broadcast">廣播</string>
     <string name="file_btn_delete">刪除</string>
     <string name="file_btn_download">下載</string>
+    <string name="main_agent_card_deleted">Agent Card 已刪除</string>
+    <string name="main_agent_card_saved">Agent Card 已儲存</string>
+    <string name="main_delete_failed">刪除失敗</string>
+    <string name="main_description_required">描述為必填</string>
+    <string name="main_max_capabilities">最多 10 個能力</string>
+    <string name="main_max_items">最多 %d 個項目</string>
+    <string name="main_save_error">發生錯誤</string>
+    <string name="main_save_failed">儲存失敗</string>
+    <string name="main_save_failed_msg">儲存失敗：%s</string>
     <string name="chat_ai_analyzing">AI 正在分析您的訊息…</string>
     <string name="chat_failed_to_send">發送訊息失敗。</string>
     <string name="chat_failed_to_send_v2">發送訊息失敗。</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -554,6 +554,15 @@ If you have any questions, please contact us via our official email.
     <string name="file_type_photo">Photo</string>
     <string name="file_type_voice">Voice</string>
     <string name="file_btn_download">Download</string>
+    <string name="main_agent_card_deleted">Agent Card deleted</string>
+    <string name="main_agent_card_saved">Agent Card saved</string>
+    <string name="main_delete_failed">Delete failed</string>
+    <string name="main_description_required">Description is required</string>
+    <string name="main_max_capabilities">Maximum 10 capabilities</string>
+    <string name="main_max_items">Maximum %d items</string>
+    <string name="main_save_error">Error</string>
+    <string name="main_save_failed">Save failed</string>
+    <string name="main_save_failed_msg">Save failed: %s</string>
     <string name="chat_ai_analyzing">AI is analyzing your message…</string>
     <string name="chat_failed_to_send">Failed to send message.</string>
     <string name="chat_failed_to_send_v2">Failed to send message.</string>


### PR DESCRIPTION
## Summary
移除 MainActivity.kt 9 處硬編碼 Toast 英文字串，移入 strings.xml 並補 8 語系翻譯。

### 9 個字串
- `main_save_error`: Error
- `main_max_capabilities`: Maximum 10 capabilities
- `main_max_items`: Maximum %d items（format）
- `main_description_required`: Description is required
- `main_agent_card_saved`: Agent Card saved
- `main_save_failed`: Save failed
- `main_save_failed_msg`: Save failed: %s（format）
- `main_agent_card_deleted`: Agent Card deleted
- `main_delete_failed`: Delete failed

### 修改檔案
- `MainActivity.kt`: `getString(R.string.xxx)` 替換 9 處
- `values/strings.xml`: +9 keys（英文）
- 8 locale 檔案：+9 keys 翻譯

10 files changed.