### PR TITLE
fix: move 2 hardcoded strings to strings.xml + i18n

### DIFF
--- a/app/src/main/java/com/hank/clawlive/ui/AiChatBottomSheet.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/AiChatBottomSheet.kt
@@ -240,7 +240,7 @@ class AiChatBottomSheet : BottomSheetDialogFragment() {
             renderImagePreview()
             updateSendButton()
         } catch (e: Exception) {
-            Toast.makeText(requireContext(), "Failed to load image", Toast.LENGTH_SHORT).show()
+            Toast.makeText(requireContext(), getString(R.string.chat_load_image_failed), Toast.LENGTH_SHORT).show()
         }
     }
 

--- a/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
@@ -12,6 +12,7 @@ import android.view.MotionEvent
 import android.view.ScaleGestureDetector
 import android.view.View
 import com.hank.clawlive.data.local.LayoutPreferences
+import com.hank.clawlive.R
 import com.hank.clawlive.data.model.EntityStatus
 import timber.log.Timber
 
@@ -202,7 +203,7 @@ class WallpaperPreviewView @JvmOverloads constructor(
         if (entities.isEmpty()) {
             labelPaint.textSize = 36f
             labelPaint.color = Color.GRAY
-            canvas.drawText("No bound entities", width / 2f, height / 2f, labelPaint)
+            canvas.drawText(context.getString(R.string.wallpaper_no_bound_entities), width / 2f, height / 2f, labelPaint)
             return
         }
 

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -333,6 +333,8 @@ Tus comentarios enviados aparecerán aquí.</string>
     <string name="file_broadcast">Broadcast</string>
     <string name="file_btn_delete">Eliminar</string>
     <string name="file_btn_download">Descargar</string>
+    <string name="chat_load_image_failed">Error al cargar imagen</string>
+    <string name="wallpaper_no_bound_entities">Sin entidades vinculadas</string>
     <string name="main_agent_card_deleted">Agent Card eliminado</string>
     <string name="main_agent_card_saved">Agent Card guardado</string>
     <string name="main_delete_failed">Error al eliminar</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -317,6 +317,8 @@
     <string name="file_broadcast">Siaran</string>
     <string name="file_btn_delete">Hapus</string>
     <string name="file_btn_download">Unduh</string>
+    <string name="chat_load_image_failed">Gagal memuat gambar</string>
+    <string name="wallpaper_no_bound_entities">Tidak ada entitas yang terikat</string>
     <string name="main_agent_card_deleted">Agent Card dihapus</string>
     <string name="main_agent_card_saved">Agent Card disimpan</string>
     <string name="main_delete_failed">Penghapusan gagal</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -317,6 +317,8 @@
     <string name="file_broadcast">ブロードキャスト</string>
     <string name="file_btn_delete">削除</string>
     <string name="file_btn_download">ダウンロード</string>
+    <string name="chat_load_image_failed">画像の読み込みに失敗しました</string>
+    <string name="wallpaper_no_bound_entities">バインドされたエンティティがありません</string>
     <string name="main_agent_card_deleted">Agent Card を削除しました</string>
     <string name="main_agent_card_saved">Agent Card を保存しました</string>
     <string name="main_delete_failed">削除に失敗しました</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -317,6 +317,8 @@
     <string name="file_broadcast">브로드캐스트</string>
     <string name="file_btn_delete">삭제</string>
     <string name="file_btn_download">다운로드</string>
+    <string name="chat_load_image_failed">이미지 로드 실패</string>
+    <string name="wallpaper_no_bound_entities">바인드된 엔티티가 없습니다</string>
     <string name="main_agent_card_deleted">Agent Card 삭제됨</string>
     <string name="main_agent_card_saved">Agent Card 저장됨</string>
     <string name="main_delete_failed">삭제 실패</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -317,6 +317,8 @@
     <string name="file_broadcast">ส่งถึงทุกคน</string>
     <string name="file_btn_delete">ลบ</string>
     <string name="file_btn_download">ดาวน์โหลด</string>
+    <string name="chat_load_image_failed">โหลดรูปภาพไม่สำเร็จ</string>
+    <string name="wallpaper_no_bound_entities">ไม่มีเอนทิตีที่ถูกผูกไว้</string>
     <string name="main_agent_card_deleted">ลบ Agent Card แล้ว</string>
     <string name="main_agent_card_saved">บันทึก Agent Card แล้ว</string>
     <string name="main_delete_failed">ลบล้มเหลว</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -317,6 +317,8 @@
     <string name="file_broadcast">Phát chung</string>
     <string name="file_btn_delete">Xóa</string>
     <string name="file_btn_download">Tải xuống</string>
+    <string name="chat_load_image_failed">Tải hình ảnh thất bại</string>
+    <string name="wallpaper_no_bound_entities">Không có thực thể được liên kết</string>
     <string name="main_agent_card_deleted">Đã xóa Agent Card</string>
     <string name="main_agent_card_saved">Đã lưu Agent Card</string>
     <string name="main_delete_failed">Xóa thất bại</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -320,6 +320,8 @@
     <string name="file_broadcast">广播</string>
     <string name="file_btn_delete">删除</string>
     <string name="file_btn_download">下载</string>
+    <string name="chat_load_image_failed">载入图片失败</string>
+    <string name="wallpaper_no_bound_entities">无已绑定实体</string>
     <string name="main_agent_card_deleted">Agent Card 已删除</string>
     <string name="main_agent_card_saved">Agent Card 已储存</string>
     <string name="main_delete_failed">删除失败</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -320,6 +320,8 @@
     <string name="file_broadcast">廣播</string>
     <string name="file_btn_delete">刪除</string>
     <string name="file_btn_download">下載</string>
+    <string name="chat_load_image_failed">載入圖片失敗</string>
+    <string name="wallpaper_no_bound_entities">無已綁定實體</string>
     <string name="main_agent_card_deleted">Agent Card 已刪除</string>
     <string name="main_agent_card_saved">Agent Card 已儲存</string>
     <string name="main_delete_failed">刪除失敗</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -554,6 +554,8 @@ If you have any questions, please contact us via our official email.
     <string name="file_type_photo">Photo</string>
     <string name="file_type_voice">Voice</string>
     <string name="file_btn_download">Download</string>
+    <string name="chat_load_image_failed">Failed to load image</string>
+    <string name="wallpaper_no_bound_entities">No bound entities</string>
     <string name="main_agent_card_deleted">Agent Card deleted</string>
     <string name="main_agent_card_saved">Agent Card saved</string>
     <string name="main_delete_failed">Delete failed</string>


### PR DESCRIPTION
## Summary
移除 2 處硬編碼英文字串：

- `WallpaperPreviewView.kt:205`: "No bound entities" → getString(R.string.wallpaper_no_bound_entities)
- `AiChatBottomSheet.kt`: "Failed to load image" → getString(R.string.chat_load_image_failed)

11 files changed (2 Kotlin + 9 strings.xml).