### PR TITLE
fix: add rental_status fields to /api/entities and /api/status

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -4412,6 +4412,8 @@ app.get('/api/entities', (req, res) => {
                     bindingType: entity.bindingType || null,
                     encryptionStatus: entity.encryptionStatus || null,
                     isPublic: !!entity.isPublic,
+                    rental_status: entity.rental_status || null,  // 'leased_in', 'leased_out', or null
+                    rental_contract_id: entity.rental_contract_id || null,
                     messageQueue: (entity.messageQueue || []).map(m => ({
                         text: m.text,
                         from: m.from,
@@ -4567,6 +4569,8 @@ app.get('/api/status', (req, res) => {
         parts: entity.parts,
         lastUpdated: entity.lastUpdated,
         isBound: entity.isBound,
+        rental_status: entity.rental_status || null,  // 'leased_in', 'leased_out', or null
+        rental_contract_id: entity.rental_contract_id || null,
         versionInfo: getVersionInfo(appVersion || entity.appVersion)
     });
 });


### PR DESCRIPTION
## Summary
- Add `rental_status` and `rental_contract_id` fields to `GET /api/entities` response
- Add same fields to `GET /api/status` response
- `/api/entities/status` already had these fields; now all entity endpoints are consistent

## Test plan
- [ ] Verify `GET /api/entities` response includes `rental_status` and `rental_contract_id`
- [ ] Verify `GET /api/status` response includes both fields
- [ ] Confirm no regressions in existing entity polling

🤖 Generated with [Claude Code](https://claude.com/claude-code)