### PR TITLE
fix(rental): dedup listings, fix contract status, clean up ended entities

### DIFF
--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -730,12 +730,12 @@
 
     /* ══════ API ══════ */
     async function apiFetch(path) {
-        const r = await fetch(location.origin + path);
+        const r = await fetch(location.origin + path, { credentials: 'include' });
         if (!r.ok) throw new Error('HTTP ' + r.status);
         return r.json();
     }
     async function apiPost(path, body) {
-        const r = await fetch(location.origin + path, { method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify(body) });
+        const r = await fetch(location.origin + path, { method:'POST', headers:{'Content-Type':'application/json'}, credentials: 'include', body:JSON.stringify(body) });
         return r.json();
     }
 
@@ -1037,10 +1037,11 @@
             const maxH = (l.max_rental_minutes / 60).toFixed(1);
             const defaultH = Math.max(parseFloat(minH), 1);
             const isRented = !!l.has_active_contract;
+            const isSelfOwned = !!(meData?.user && l.owner_user_id && l.owner_user_id === meData.user.userId);
             _rentalWalletBalance = null;
-            if (meData?.user) {
+            if (meData?.user && !isSelfOwned) {
                 apiFetch('/api/wallet/balance?deviceId=' + encodeURIComponent(meData.user.deviceId || meData.user.device_id))
-                    .then(wb => { _rentalWalletBalance = parseInt(wb.balance_mli, 10) || 0; updateRentalEstimate(rateMli, depositEcoin); })
+                    .then(wb => { const w = wb.wallet || wb; _rentalWalletBalance = parseInt(w.balance_mli, 10) || 0; updateRentalEstimate(rateMli, depositEcoin); })
                     .catch(() => {});
             }
             let interviewHtml = '';
@@ -1070,7 +1071,7 @@
                     <div style="display:flex;justify-content:space-between;padding:6px 0;font-size:13px;"><span style="color:var(--text-secondary);">${ttt('mp_d_rating','Rating')}</span><span style="color:#f59e0b;">${stars} (${l.total_rentals || 0} ${ttt('mp_d_rentals','rentals')})</span></div>
                     <div style="display:flex;justify-content:space-between;padding:6px 0;font-size:13px;"><span style="color:var(--text-secondary);">${ttt('mp_d_uptime','Uptime')}</span><span>${l.uptime_pct || 100}%</span></div>
                 </div>
-                <div style="margin:0 20px;">
+                ${isSelfOwned ? '' : `<div style="margin:0 20px;">
                     <label style="font-size:12px;color:var(--text-secondary);font-weight:600;">\u23f1\ufe0f ${ttt('mp_d_rent_duration_hours','Duration (hours)')}</label>
                     <input type="number" id="rentalDurationHours" value="${defaultH}" min="${minH}" max="${maxH}" step="0.5" style="width:100%;margin-top:4px;padding:10px;border:1px solid var(--card-border);border-radius:var(--radius-sm);background:var(--input-bg);color:var(--text);font-size:14px;" oninput="updateRentalEstimate(${rateMli},${depositEcoin})">
                     <div class="rental-cost-box" id="rentalCostBox"></div>
@@ -1079,9 +1080,11 @@
                 <div class="privacy-check-row" style="margin:12px 20px 0;">
                     <input type="checkbox" id="privacyConsent" onchange="checkRentalBtnState()">
                     <label for="privacyConsent">${ttt('mp_privacy_warning','Your conversation will be processed through the lessor server.')} <strong>${ttt('mp_privacy_agree','I understand and agree')}</strong></label>
-                </div>
+                </div>`}
                 <div style="margin:12px 20px 20px;">
-                    ${isRented
+                    ${isSelfOwned
+                        ? `<button class="detail-btn primary" style="width:100%;padding:12px;font-size:14px;opacity:0.5;cursor:not-allowed;" disabled>\ud83d\udeab ${ttt('rental_error_self_rent','Cannot rent your own bot')}</button>`
+                        : isRented
                         ? `<button class="detail-btn primary" style="width:100%;padding:12px;font-size:14px;opacity:0.5;cursor:not-allowed;" disabled>\ud83d\udd34 ${ttt('mp_status_rented','Rented')}</button>`
                         : `<button class="detail-btn primary" style="width:100%;padding:12px;font-size:14px;" id="rentalConfirmBtn" disabled onclick="doRentalFromPlaza('${l.id}',${rateMli})">\ud83d\udd12 ${ttt('mp_rent_now','Rent Now')}</button>`}
                 </div>`;

--- a/backend/rental.js
+++ b/backend/rental.js
@@ -172,6 +172,22 @@ async function createListing({
     if (maxRentalMinutes > MAX_RENTAL_MINUTES) throw new Error('max_rental_minutes_invalid');
     if (minRentalMinutes > maxRentalMinutes) throw new Error('rental_duration_range_invalid');
 
+    // BUG-M2: Prevent duplicate listings for the same owner+entity combination.
+    // Only one active (draft/listed/paused/interview) listing allowed per entity.
+    const existingRes = await pool.query(
+        `SELECT id, status FROM bot_listings
+         WHERE owner_device_id = $1 AND owner_entity_id = $2
+           AND status IN ('draft', 'listed', 'paused', 'interview')
+         ORDER BY created_at DESC LIMIT 1`,
+        [ownerDeviceId, ownerEntityId]
+    );
+    if (existingRes.rowCount > 0) {
+        const err = new Error('duplicate_listing');
+        err.existingListingId = existingRes.rows[0].id;
+        err.existingStatus = existingRes.rows[0].status;
+        throw err;
+    }
+
     const res = await pool.query(
         `INSERT INTO bot_listings
             (owner_user_id, owner_device_id, owner_entity_id, title, description,
@@ -316,25 +332,37 @@ async function searchMarketplace({
 
     let orderBy;
     switch (sort) {
-        case 'rate_asc':  orderBy = 'bl.rate_mli_per_ktoken ASC'; break;
-        case 'rate_desc': orderBy = 'bl.rate_mli_per_ktoken DESC'; break;
-        case 'newest':    orderBy = 'bl.created_at DESC'; break;
+        case 'rate_asc':  orderBy = 'rate_mli_per_ktoken ASC'; break;
+        case 'rate_desc': orderBy = 'rate_mli_per_ktoken DESC'; break;
+        case 'newest':    orderBy = 'bl_created_at DESC'; break;
         case 'rating':
-        default:          orderBy = 'bl.avg_rating DESC, bl.total_rentals DESC'; break;
+        default:          orderBy = 'avg_rating DESC, total_rentals DESC'; break;
     }
 
     params.push(safeLimit);
     params.push(safeOffset);
+    // BUG-M3: Check ANY active contract (reserved/active/suspended), not just
+    // the current user's. Use EXISTS subquery to avoid duplicate rows.
+    // BUG-M2: Deduplicate by owner+entity — only show the most recent listing
+    // per owner_device_id + owner_entity_id combination using DISTINCT ON.
     const res = await pool.query(
-        `SELECT bl.id, bl.title, bl.description, bl.rate_mli_per_ktoken,
+        `SELECT * FROM (
+            SELECT DISTINCT ON (bl.owner_device_id, bl.owner_entity_id)
+                bl.id, bl.title, bl.description, bl.rate_mli_per_ktoken,
                 bl.min_rental_minutes, bl.max_rental_minutes,
                 bl.model_detected, bl.capabilities, bl.benchmark_score,
                 bl.avg_rating, bl.total_rentals, bl.uptime_pct,
-                CASE WHEN ac.id IS NOT NULL THEN TRUE ELSE FALSE END AS has_active_contract
-         FROM bot_listings bl
-         LEFT JOIN rental_contracts ac
-           ON ac.listing_id = bl.id AND ac.status LIKE 'active%'
-         WHERE ${where.join(' AND ')}
+                bl.owner_device_id, bl.owner_entity_id,
+                bl.created_at AS bl_created_at,
+                EXISTS (
+                    SELECT 1 FROM rental_contracts ac
+                    WHERE ac.listing_id = bl.id
+                      AND ac.status IN ('reserved', 'active', 'suspended_insufficient_funds')
+                ) AS has_active_contract
+            FROM bot_listings bl
+            WHERE ${where.join(' AND ')}
+            ORDER BY bl.owner_device_id, bl.owner_entity_id, bl.created_at DESC
+         ) deduped
          ORDER BY ${orderBy}
          LIMIT $${params.length - 1} OFFSET $${params.length}`,
         params
@@ -907,23 +935,16 @@ function removeRentalEntity(devices, { renterDeviceId, contractId }, helpers) {
     const device = devices[renterDeviceId];
     if (!device) return;
 
-    for (const [, entity] of Object.entries(device.entities)) {
+    for (const [slotId, entity] of Object.entries(device.entities)) {
         if (entity.rental_contract_id === contractId) {
-            // Clean up publicCode from global index before resetting
+            // Clean up publicCode from global index before deleting
             if (entity.publicCode && helpers?.publicCodeIndex) {
                 delete helpers.publicCodeIndex[entity.publicCode];
             }
-            // Reset to unbound default
-            entity.isBound = false;
-            entity.botSecret = null;
-            entity.publicCode = null;
-            entity.character = '🤖';
-            entity.name = null;
-            entity.state = 'IDLE';
-            entity.message = '';
-            entity.webhook = null;
-            entity.rental_contract_id = null;
-            entity.rental_status = null;
+            // BUG-D3: Delete the rental entity slot entirely instead of
+            // resetting to unbound defaults. Resetting left a ghost entity
+            // visible on the renter's dashboard after contract end.
+            delete device.entities[slotId];
             break;
         }
     }
@@ -1051,7 +1072,7 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
     const router = express.Router();
     const audit = serverLog || (() => {});
 
-    const INPUT_ERROR_RE = /^(?:[a-z][a-z0-9_]*_(?:invalid|required|forbidden|not_found)|publish_failed|interview_not_passed|no_fields_to_update|duration_too_(?:short|long)|duration_(?:below|above)_listing_(?:min|max)|listing_not_available|listing_already_rented|self_rental_forbidden|insufficient_balance_for_rental|contract_already_ended|contract_end_forbidden|interview_rate_limited|interview_already_running|owner_device_not_found|owner_entity_not_bound|owner_entity_no_webhook|listing_status_invalid_for_interview|cooldown_active)$/;
+    const INPUT_ERROR_RE = /^(?:[a-z][a-z0-9_]*_(?:invalid|required|forbidden|not_found)|publish_failed|interview_not_passed|no_fields_to_update|duration_too_(?:short|long)|duration_(?:below|above)_listing_(?:min|max)|listing_not_available|listing_already_rented|self_rental_forbidden|insufficient_balance_for_rental|contract_already_ended|contract_end_forbidden|interview_rate_limited|interview_already_running|owner_device_not_found|owner_entity_not_bound|owner_entity_no_webhook|listing_status_invalid_for_interview|cooldown_active|duplicate_listing)$/;
 
     function rentalRoute(fn) {
         return async (req, res) => {
@@ -1065,7 +1086,12 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
                     const code = /forbidden/.test(err.message) ? 403
                                : /not_found/.test(err.message) ? 404
                                : 400;
-                    return res.status(code).json({ success: false, error: err.message });
+                    const body = { success: false, error: err.message };
+                    if (err.existingListingId) body.existing_listing_id = err.existingListingId;
+                    if (err.existingStatus) body.existing_status = err.existingStatus;
+                    if (err.cooldownUntil) body.cooldown_until = err.cooldownUntil;
+                    if (err.details) body.details = err.details;
+                    return res.status(code).json(body);
                 }
                 console.error('[Rental] handler error:', err);
                 res.status(500).json({ success: false, error: 'internal_error' });

--- a/backend/tests/jest/rental-entity-visibility.test.js
+++ b/backend/tests/jest/rental-entity-visibility.test.js
@@ -218,11 +218,9 @@ describe('Rental entity dashboard visibility (#1712)', () => {
 
         // publicCode should be removed from index
         expect(publicCodeIndex[code]).toBeUndefined();
-        // Entity should be unbound and cleared
+        // BUG-D3: Entity slot should be fully deleted (not just reset)
         const entity = devices['renter-device-1'].entities[result.slot];
-        expect(entity.isBound).toBe(false);
-        expect(entity.botSecret).toBeNull();
-        expect(entity.publicCode).toBeNull();
+        expect(entity).toBeUndefined();
     });
 
     test('insertRentalEntity works without helpers (fallback)', () => {

--- a/backend/tests/jest/rental-guardrails.test.js
+++ b/backend/tests/jest/rental-guardrails.test.js
@@ -314,7 +314,7 @@ describe('P2-F: markOwnerEntityLeasedOut + clearOwnerEntityLeasedOut', () => {
 });
 
 describe('P2-F: removeRentalEntity', () => {
-    test('resets the rental entity to unbound default', () => {
+    test('deletes the rental entity slot entirely on contract end', () => {
         const devices = {
             'renter-dev': {
                 entities: {
@@ -324,11 +324,10 @@ describe('P2-F: removeRentalEntity', () => {
             },
         };
         rentalApi.removeRentalEntity(devices, { renterDeviceId: 'renter-dev', contractId: 'c-4' });
-        const entity = devices['renter-dev'].entities[1];
-        expect(entity.isBound).toBe(false);
-        expect(entity.rental_contract_id).toBeNull();
-        expect(entity.rental_status).toBeNull();
-        expect(entity.character).toBe('🤖');
+        // BUG-D3: Entity slot should be fully deleted, not just reset
+        expect(devices['renter-dev'].entities[1]).toBeUndefined();
+        // Other entities should not be affected
+        expect(devices['renter-dev'].entities[0]).toBeDefined();
     });
 
     test('does nothing if contract not found', () => {

--- a/backend/tests/jest/rental-listing.test.js
+++ b/backend/tests/jest/rental-listing.test.js
@@ -23,6 +23,20 @@ jest.mock('pg', () => {
         if (/^(BEGIN|COMMIT|ROLLBACK)$/i.test(norm)) return { rows: [], rowCount: 0 };
         if (/^CREATE (TABLE|INDEX|UNIQUE INDEX)/i.test(norm)) return { rows: [], rowCount: 0 };
 
+        // BUG-M2: Duplicate listing check (SELECT before INSERT)
+        if (/^SELECT id, status FROM bot_listings WHERE owner_device_id/i.test(norm)) {
+            const [ownerDeviceId, ownerEntityId] = params;
+            const existing = state.listings.find(l =>
+                l.owner_device_id === ownerDeviceId &&
+                l.owner_entity_id === ownerEntityId &&
+                ['draft', 'listed', 'paused', 'interview'].includes(l.status)
+            );
+            if (existing) {
+                return { rows: [{ id: existing.id, status: existing.status }], rowCount: 1 };
+            }
+            return { rows: [], rowCount: 0 };
+        }
+
         // INSERT new listing
         if (/^INSERT INTO bot_listings/i.test(norm)) {
             const [ownerUserId, ownerDeviceId, ownerEntityId, title, description,


### PR DESCRIPTION
## Summary
- **BUG-M2**: Prevent duplicate marketplace listings per entity — `createListing()` now rejects if an active listing already exists for the same `owner_device_id + owner_entity_id`. `searchMarketplace()` uses `DISTINCT ON` to show only the most recent listing per entity.
- **BUG-M3**: Fix "Available" shown for rented listings — `has_active_contract` now uses `EXISTS` subquery checking all contract statuses (reserved/active/suspended) instead of a LEFT JOIN that could miss contracts.
- **BUG-D3**: Fix ghost rental entities on renter dashboard after contract end — `removeRentalEntity()` now deletes the entity slot entirely instead of resetting to unbound defaults.

## Test plan
- [x] `rental-listing.test.js` — updated fake PG to handle duplicate check query; all 23 tests pass
- [x] `rental-guardrails.test.js` — updated `removeRentalEntity` test to expect slot deletion; all 40 tests pass
- [x] `rental-entity-visibility.test.js` — updated cleanup assertion; all 10 tests pass
- [x] i18n syntax tests pass (7/7)
- [ ] Manual: create two listings for same entity — second should fail with `duplicate_listing`
- [ ] Manual: verify rented listing shows red "Rented" badge in marketplace
- [ ] Manual: end a contract and confirm rental entity disappears from renter dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)