### PR TITLE
fix: resolve 7 rental UIUX bugs (M1/M3/M8/D1/D2/D3/D4)

### DIFF
--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -779,7 +779,7 @@
                     rentalBots = (data.listings || []).map(l => {
                         const caps = l.capabilities ? Object.keys(l.capabilities).filter(k => l.capabilities[k]?.supported) : [];
                         return {
-                            publicCode: l.id, name: l.title || 'Rental Bot', avatar: '🤖',
+                            publicCode: l.id, name: l.title || 'Rental Bot', avatar: l.avatar_url || '🤖',
                             desc: l.description || (l.model_detected || ''),
                             tags: caps, caps: caps, _capsObj: l.capabilities || {},
                             stars: l.avg_rating || 0, reviews: l.total_rentals || 0,
@@ -863,7 +863,7 @@
         return `<div class="${isRented ? 'bot-card rented' : 'bot-card'}" onclick="${isRented ? '' : "openRentalDetail('" + bot.listingId + "')"}" style="border-left:3px solid ${borderColor};">
             <span class="bot-card-level" style="background:${borderColor};color:#fff;">${isRented ? tt('mp_status_rented','\u5df2\u51fa\u79df') : tt('community_filter_rental','\u51fa\u79df')}</span>
             <div class="bot-card-header">
-                <div class="bot-card-avatar">\ud83e\udd16</div>
+                <div class="bot-card-avatar">${bot.avatar && bot.avatar.startsWith('http') ? '<img src="' + esc(bot.avatar) + '" style="width:40px;height:40px;border-radius:50%;object-fit:cover;">' : (bot.avatar || '\ud83e\udd16')}</div>
                 <div class="bot-card-info">
                     <div class="bot-card-name">${esc(bot.name)}</div>
                     ${bot.modelDetected ? `<div style="font-size:11px;color:var(--text-secondary);">\ud83e\udd16 ${esc(bot.modelDetected)}</div>` : ''}
@@ -1056,7 +1056,7 @@
             content.innerHTML = `
                 <button class="modal-close" onclick="closeDetail()">\u2715</button>
                 <div class="detail-header">
-                    <div class="detail-avatar">\ud83e\udd16</div>
+                    <div class="detail-avatar">${l.avatar_url && l.avatar_url.startsWith('http') ? '<img src="' + esc(l.avatar_url) + '" style="width:60px;height:60px;border-radius:50%;object-fit:cover;">' : (l.avatar_url || '\ud83e\udd16')}</div>
                     <div class="detail-name">${esc(l.title)}</div>
                     ${l.model_detected ? `<div style="font-size:12px;color:var(--text-secondary);margin-top:2px;">\ud83e\udd16 ${esc(l.model_detected)}</div>` : ''}
                     <div class="detail-level-xp"><span style="color:#f59e0b;">${stars} (${l.total_rentals || 0} ${ttt('mp_d_rentals','rentals')})</span></div>

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -1896,6 +1896,8 @@
                     '<span class="badge ' + stateBadgeClass + '">' + escapeHtml(state) + '</span>' +
                     (entity.bindingType === 'channel' ? '<span class="badge-channel">⚡ Channel</span>' : '') +
                     (entity.encryptionStatus === 'e2ee' ? '<span class="badge-e2ee">🔒 E2EE</span>' : '') +
+                    (entity.rental_status === 'leased_in' ? '<span class="badge-rental" style="background:rgba(156,39,176,0.15);color:#9C27B0;font-size:10px;padding:2px 6px;border-radius:4px;margin-left:4px;">🤖 Rented</span>' : '') +
+                    (entity.rental_status === 'leased_out' ? '<span class="badge-leased-out" style="background:rgba(255,152,0,0.15);color:#FF9800;font-size:10px;padding:2px 6px;border-radius:4px;margin-left:4px;">📤 Leased Out</span>' : '') +
                     '</div>' +
                     (function() {
                         var xd = getXpDisplay(entity);

--- a/backend/rental.js
+++ b/backend/rental.js
@@ -141,10 +141,32 @@ async function initRentalDatabase() {
                 }
             }
         }
+        // Add avatar_url column if missing (BUG-M1: display real bot avatar)
+        try {
+            await pool.query(`ALTER TABLE bot_listings ADD COLUMN IF NOT EXISTS avatar_url TEXT`);
+        } catch (_) { /* column may already exist */ }
+
         // Startup cleanup: revert any listings stuck in 'interview' (server crashed mid-run)
         await pool.query(
             `UPDATE bot_listings SET status = 'draft', updated_at = NOW() WHERE status = 'interview'`
         );
+
+        // BUG-M1: Backfill avatar_url from in-memory entity data for existing listings
+        if (_interviewDeps.devices) {
+            try {
+                const nullAvatars = await pool.query(
+                    `SELECT id, owner_device_id, owner_entity_id FROM bot_listings WHERE avatar_url IS NULL`
+                );
+                for (const row of nullAvatars.rows) {
+                    const dev = _interviewDeps.devices[row.owner_device_id];
+                    const ent = dev?.entities?.[row.owner_entity_id];
+                    if (ent?.avatar) {
+                        await pool.query(`UPDATE bot_listings SET avatar_url = $1 WHERE id = $2`, [ent.avatar, row.id]);
+                    }
+                }
+                if (nullAvatars.rowCount > 0) console.log(`[Rental] Backfilled avatar_url for ${nullAvatars.rowCount} listing(s)`);
+            } catch (e) { console.warn('[Rental] Avatar backfill warning:', e.message); }
+        }
 
         console.log('[Rental] Database initialized');
     } catch (error) {
@@ -161,6 +183,7 @@ async function createListing({
     title, description = null, rateMliPerKtoken,
     minRentalMinutes = MIN_RENTAL_MINUTES,
     maxRentalMinutes = MAX_RENTAL_MINUTES,
+    avatarUrl = null,
 }) {
     assertString('owner_user_id', ownerUserId, { max: 64 });
     assertString('owner_device_id', ownerDeviceId, { max: 64 });
@@ -191,11 +214,11 @@ async function createListing({
     const res = await pool.query(
         `INSERT INTO bot_listings
             (owner_user_id, owner_device_id, owner_entity_id, title, description,
-             rate_mli_per_ktoken, min_rental_minutes, max_rental_minutes, status)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'draft')
+             rate_mli_per_ktoken, min_rental_minutes, max_rental_minutes, avatar_url, status)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'draft')
          RETURNING id, status, created_at`,
         [ownerUserId, ownerDeviceId, ownerEntityId, title, description,
-         rateMliPerKtoken, minRentalMinutes, maxRentalMinutes]
+         rateMliPerKtoken, minRentalMinutes, maxRentalMinutes, avatarUrl || null]
     );
     return res.rows[0];
 }
@@ -353,10 +376,13 @@ async function searchMarketplace({
                 bl.model_detected, bl.capabilities, bl.benchmark_score,
                 bl.avg_rating, bl.total_rentals, bl.uptime_pct,
                 bl.owner_device_id, bl.owner_entity_id,
+                bl.avatar_url,
                 bl.created_at AS bl_created_at,
                 EXISTS (
                     SELECT 1 FROM rental_contracts ac
-                    WHERE ac.listing_id = bl.id
+                    JOIN bot_listings sib ON sib.id = ac.listing_id
+                    WHERE sib.owner_device_id = bl.owner_device_id
+                      AND sib.owner_entity_id = bl.owner_entity_id
                       AND ac.status IN ('reserved', 'active', 'suspended_insufficient_funds')
                 ) AS has_active_contract
             FROM bot_listings bl
@@ -894,6 +920,8 @@ function insertRentalEntity(devices, {
     entity.publicCode = publicCode;
     entity.character = listing.title || 'Rental Bot';
     entity.name = listing.title || 'Rental Bot';
+    // BUG-D1: Copy the owner's avatar so rental entity displays correctly on dashboard
+    entity.avatar = listing.avatar_url || null;
     entity.state = 'IDLE';
     entity.message = `Rented from marketplace (${rateMliPerKtoken / 1000} e幣/1K)`;
     entity.lastUpdated = Date.now();
@@ -961,6 +989,42 @@ function clearOwnerEntityLeasedOut(devices, { ownerDeviceId, ownerEntityId }) {
 
     entity.rental_status = null;
     entity.rental_contract_id = null;
+}
+
+/**
+ * BUG-D3: Reconcile rental entities — remove orphaned rental entities
+ * whose contracts have ended but weren't cleaned up (e.g. server crash,
+ * deployed before removeRentalEntity was implemented).
+ */
+async function reconcileRentalEntities(devices, helpers) {
+    let reconciled = 0;
+    const errors = [];
+    for (const [deviceId, device] of Object.entries(devices)) {
+        if (!device?.entities) continue;
+        for (const [slotId, entity] of Object.entries(device.entities)) {
+            if (entity.rental_status !== 'leased_in' || !entity.rental_contract_id) continue;
+            // Check if the contract is still active
+            try {
+                const res = await pool.query(
+                    `SELECT status FROM rental_contracts WHERE id = $1`,
+                    [entity.rental_contract_id]
+                );
+                const status = res.rows[0]?.status;
+                if (!status || !['reserved', 'active', 'suspended_insufficient_funds'].includes(status)) {
+                    // Contract ended or missing — remove ghost entity
+                    if (entity.publicCode && helpers?.publicCodeIndex) {
+                        delete helpers.publicCodeIndex[entity.publicCode];
+                    }
+                    delete device.entities[slotId];
+                    reconciled++;
+                    if (helpers?.saveDeviceData) {
+                        await helpers.saveDeviceData(deviceId, device);
+                    }
+                }
+            } catch (e) { errors.push(`${deviceId}/${slotId}: ${e.message}`); }
+        }
+    }
+    return { reconciled, errors };
 }
 
 /** Minimal entity stub for a new rental slot. */
@@ -1103,10 +1167,19 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
     router.post('/listing', authMiddleware, rentalRoute(async (req, res) => {
         const { ownerDeviceId, ownerEntityId, title, description,
                 rateMliPerKtoken, minRentalMinutes, maxRentalMinutes } = req.body || {};
+        // BUG-M1: capture entity avatar for marketplace display
+        let avatarUrl = null;
+        if (_interviewDeps.devices && ownerDeviceId) {
+            const dev = _interviewDeps.devices[ownerDeviceId];
+            const ent = dev?.entities?.[ownerEntityId];
+            if (ent?.avatar && (ent.avatar.startsWith('http') || ent.avatar.length <= 4)) {
+                avatarUrl = ent.avatar;
+            }
+        }
         const listing = await createListing({
             ownerUserId: req.user.userId,
             ownerDeviceId, ownerEntityId, title, description, rateMliPerKtoken,
-            minRentalMinutes, maxRentalMinutes,
+            minRentalMinutes, maxRentalMinutes, avatarUrl,
         });
         audit('info', 'rental', `listing created ${listing.id} by ${req.user.userId}`, {
             userId: req.user.userId, action: 'listing_create', resource: listing.id,
@@ -1672,6 +1745,7 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
         markOwnerEntityLeasedOut,
         removeRentalEntity,
         clearOwnerEntityLeasedOut,
+        reconcileRentalEntities,
         reconcileRentalEntities,
         // Interview dispatch (late-bound)
         setInterviewDeps: (deps) => { _interviewDeps = deps; },


### PR DESCRIPTION
## Summary
- **BUG-M3 (P1)**: Fix marketplace availability — EXISTS subquery checks sibling listings
- **BUG-M1/D1 (P2)**: Real bot avatars in marketplace + rental entities (avatar_url column + backfill)
- **BUG-D2/D4 (P2)**: Rental status badges on dashboard (🤖 Rented / 📤 Leased Out)
- **BUG-D3 (P1)**: Ghost entity reconciliation on startup
- **BUG-M8 (P2)**: Self-rental detection verified correct

## Test plan
- [ ] i18n-syntax test passes
- [ ] Pure UI Playwright verification of all 7 bugs
- [ ] Marketplace shows correct availability badges
- [ ] Dashboard shows rental badges
- [ ] Ghost entity #0 removed after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)