### PR TITLE
fix: persist rental status to DB, reconcile on restart

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -128,6 +128,10 @@ async function createTables() {
 
         // Bot Identity Layer: unified identity JSONB (role, instructions, boundaries, public profile)
         await client.query(`ALTER TABLE entities ADD COLUMN IF NOT EXISTS identity JSONB`);
+
+        // Rental status persistence: track leased_in/leased_out and contract reference
+        await client.query(`ALTER TABLE entities ADD COLUMN IF NOT EXISTS rental_status TEXT`);
+        await client.query(`ALTER TABLE entities ADD COLUMN IF NOT EXISTS rental_contract_id TEXT`);
         // Migrate existing agent_card data into identity.public
         await client.query(`
             UPDATE entities SET identity = jsonb_build_object('public', agent_card)
@@ -560,15 +564,17 @@ async function saveDeviceData(deviceId, deviceData) {
                     entity.channelAccountId || null,
                     entity.agentCard ? JSON.stringify(entity.agentCard) : null,
                     entity.encryptionStatus || null,
-                    entity.identity ? JSON.stringify(entity.identity) : null
+                    entity.identity ? JSON.stringify(entity.identity) : null,
+                    entity.rental_status || null,
+                    entity.rental_contract_id || null
                 ];
                 const entitySql = `INSERT INTO entities (
                         device_id, entity_id, bot_secret, is_bound, name,
                         character, state, message, parts,
                         last_updated, message_queue, webhook, app_version,
                         xp, level, avatar, public_code, binding_type, channel_account_id, agent_card,
-                        encryption_status, identity
-                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22)
+                        encryption_status, identity, rental_status, rental_contract_id
+                    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24)
                     ON CONFLICT (device_id, entity_id)
                     DO UPDATE SET
                         bot_secret = $3,
@@ -590,7 +596,9 @@ async function saveDeviceData(deviceId, deviceData) {
                         channel_account_id = $19,
                         agent_card = $20,
                         encryption_status = $21,
-                        identity = $22`;
+                        identity = $22,
+                        rental_status = $23,
+                        rental_contract_id = $24`;
 
                 await client.query(`SAVEPOINT entity_${i}`);
                 try {
@@ -722,7 +730,9 @@ async function loadAllDevices() {
                 encryptionStatus: row.encryption_status || null,
                 identity: row.identity ? (typeof row.identity === 'string' ? JSON.parse(row.identity) : row.identity) : null,
                 isPublic: !!row.is_public,
-                publishedAt: row.published_at ? new Date(row.published_at).getTime() : null
+                publishedAt: row.published_at ? new Date(row.published_at).getTime() : null,
+                rental_status: row.rental_status || null,
+                rental_contract_id: row.rental_contract_id || null
             };
         }
 

--- a/backend/rental.js
+++ b/backend/rental.js
@@ -1128,34 +1128,42 @@ async function reconcileRentalEntities(devices, helpers) {
                     }
                 }
 
-                const device = devices[row.renter_device_id];
-                // Check if any entity already has this contract ID
-                const alreadyExists = Object.values(device.entities).some(
-                    e => e && e.rental_contract_id === row.id && e.isBound
-                );
-                if (alreadyExists) continue;
-
-                // Entity handover was lost — re-create it
                 const listing = await getListing(row.listing_id);
                 if (!listing) {
                     result.errors.push(`listing_missing:${row.listing_id}`);
                     continue;
                 }
 
-                insertRentalEntity(devices, {
-                    renterDeviceId: row.renter_device_id,
-                    contractId: row.id,
-                    listing,
-                    rateMliPerKtoken: Number(row.rate_mli_per_ktoken_snapshot),
-                }, helpers);
+                // Reconcile renter entity
+                const device = devices[row.renter_device_id];
+                // Check if any entity already has this contract ID
+                const alreadyExists = Object.values(device.entities).some(
+                    e => e && e.rental_contract_id === row.id && e.isBound
+                );
+                if (!alreadyExists) {
+                    // Entity handover was lost — re-create it
+                    insertRentalEntity(devices, {
+                        renterDeviceId: row.renter_device_id,
+                        contractId: row.id,
+                        listing,
+                        rateMliPerKtoken: Number(row.rate_mli_per_ktoken_snapshot),
+                    }, helpers);
 
-                // Persist reconciled entity to DB
-                if (helpers?.saveDeviceData && devices[row.renter_device_id]) {
-                    await helpers.saveDeviceData(row.renter_device_id, devices[row.renter_device_id]);
+                    // Persist reconciled entity to DB
+                    if (helpers?.saveDeviceData && devices[row.renter_device_id]) {
+                        await helpers.saveDeviceData(row.renter_device_id, devices[row.renter_device_id]);
+                    }
+
+                    result.reconciled++;
+                    console.log(`[Rental] Reconciled renter entity for contract ${row.id} on device ${row.renter_device_id}`);
                 }
 
-                result.reconciled++;
-                console.log(`[Rental] Reconciled entity for contract ${row.id} on device ${row.renter_device_id}`);
+                // Reconcile owner entity leased_out status (lost on server restart)
+                markOwnerEntityLeasedOut(devices, {
+                    ownerDeviceId: listing.owner_device_id,
+                    ownerEntityId: listing.owner_entity_id,
+                    contractId: row.id,
+                });
             } catch (err) {
                 result.errors.push(`contract_${row.id}:${err.message}`);
             }


### PR DESCRIPTION
## Summary
- Add `rental_status` and `rental_contract_id` columns to `entities` table (auto-migrate)
- Persist both fields in `saveDeviceData` / `loadAllDevices`
- `reconcileRentalEntities` now re-marks owner entity as `leased_out` for active contracts

## Root cause
`rental_status` was only stored in memory — lost on every server restart. This caused:
1. Owner's chat showing rental bot responses (leased_out check failed)
2. Rental mirror not triggering (same check)

## Test plan
- [ ] Deploy → server restarts → owner entities retain `leased_out` status
- [ ] Renter bot responses only appear in renter's chat
- [ ] Owner's chat no longer shows rental conversation
- [ ] Existing non-rental entities unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)