### PR TITLE
fix: stale leased_out cleanup + socket message isolation

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -5146,14 +5146,25 @@ app.post('/api/transform', async (req, res) => {
     }
 
     // Emit entity:update via Socket.IO for real-time wallpaper/dashboard refresh
+    // For leased_out entities, only emit state (not message) to avoid chat content leaking to owner
     if (io) {
-        io.to(`device:${deviceId}`).emit('entity:update', {
-            deviceId, entityId: eId,
-            name: entity.name, character: entity.character,
-            state: entity.state, message: entity.message,
-            parts: entity.parts, lastUpdated: entity.lastUpdated,
-            xp: entity.xp || 0, level: entity.level || 1
-        });
+        if (entity.rental_status === 'leased_out') {
+            io.to(`device:${deviceId}`).emit('entity:update', {
+                deviceId, entityId: eId,
+                name: entity.name, character: entity.character,
+                state: entity.state,
+                parts: entity.parts, lastUpdated: entity.lastUpdated,
+                xp: entity.xp || 0, level: entity.level || 1
+            });
+        } else {
+            io.to(`device:${deviceId}`).emit('entity:update', {
+                deviceId, entityId: eId,
+                name: entity.name, character: entity.character,
+                state: entity.state, message: entity.message,
+                parts: entity.parts, lastUpdated: entity.lastUpdated,
+                xp: entity.xp || 0, level: entity.level || 1
+            });
+        }
     }
 
     // Notify device about bot reply (fire-and-forget)

--- a/backend/rental.js
+++ b/backend/rental.js
@@ -1068,6 +1068,29 @@ async function reconcileRentalEntities(devices, helpers) {
         }
     } catch (e) { errors.push(`phase2: ${e.message}`); }
 
+    // Phase 3: Clear stale leased_out on owner entities whose contracts have ended.
+    // Prevents permanent chat blackout if clearOwnerEntityLeasedOut failed (crash, etc.).
+    for (const [deviceId, device] of Object.entries(devices)) {
+        if (!device?.entities) continue;
+        for (const [slotId, entity] of Object.entries(device.entities)) {
+            if (entity.rental_status !== 'leased_out' || !entity.rental_contract_id) continue;
+            try {
+                const res = await pool.query(
+                    `SELECT status FROM rental_contracts WHERE id = $1`, [entity.rental_contract_id]
+                );
+                const status = res.rows[0]?.status;
+                const isActive = status && ['reserved', 'active', 'suspended_insufficient_funds'].includes(status);
+                if (!isActive) {
+                    entity.rental_status = null;
+                    entity.rental_contract_id = null;
+                    if (helpers?.saveDeviceData) await helpers.saveDeviceData(deviceId, device);
+                    reconciled++;
+                    console.log(`[Rental] Phase 3 cleared stale leased_out: ${deviceId}/${slotId} (contract status=${status || 'not_found'})`);
+                }
+            } catch (e) { errors.push(`phase3_${deviceId}/${slotId}: ${e.message}`); }
+        }
+    }
+
     return { reconciled, errors };
 }
 


### PR DESCRIPTION
## Summary
- **Phase 3 reconcile**: clear stale `leased_out` on owner entities whose contracts have ended — prevents permanent chat blackout
- **Socket isolation**: `entity:update` to owner omits `message` field for leased_out entities — prevents chat content leaking via typing indicator

## Test plan
- [ ] End a rental contract → owner entity `leased_out` cleared on next restart
- [ ] During active rental, owner chat sidebar shows entity state but not message content
- [ ] Non-rental entities unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)