### PR TITLE
fix(publisher): truncate X tweets exceeding 280 weighted chars

### DIFF
--- a/backend/article-publisher.js
+++ b/backend/article-publisher.js
@@ -5,7 +5,30 @@ const express = require('express');
 const crypto = require('crypto');
 const OAuth = require('oauth-1.0a');
 const multer = require('multer');
+const twitterText = require('twitter-text');
 const router = express.Router();
+
+const X_TWEET_WEIGHTED_LIMIT = 280;
+
+function truncateTweet(text) {
+    const parsed = twitterText.parseTweet(text);
+    if (parsed.valid && parsed.weightedLength <= X_TWEET_WEIGHTED_LIMIT) {
+        return { text, truncated: false, originalWeighted: parsed.weightedLength };
+    }
+    const ellipsis = '…';
+    let lo = 0;
+    let hi = text.length;
+    while (lo < hi) {
+        const mid = Math.ceil((lo + hi) / 2);
+        const candidate = text.slice(0, mid) + ellipsis;
+        if (twitterText.parseTweet(candidate).weightedLength <= X_TWEET_WEIGHTED_LIMIT) {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    return { text: text.slice(0, lo) + ellipsis, truncated: true, originalWeighted: parsed.weightedLength };
+}
 const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 15 * 1024 * 1024 } }); // 15 MB limit
 
 // ============================================
@@ -610,7 +633,12 @@ router.post('/x/tweet', express.json(), async (req, res) => {
     if (!text) return res.status(400).json({ error: 'text required' });
 
     try {
-        const body = { text };
+        const { text: finalText, truncated, originalWeighted } = truncateTweet(text);
+        if (truncated) {
+            console.warn(`[Publisher] X tweet truncated from weighted ${originalWeighted} to ${X_TWEET_WEIGHTED_LIMIT}`);
+        }
+
+        const body = { text: finalText };
         if (reply_to) body.reply = { in_reply_to_tweet_id: reply_to };
         if (media_ids && Array.isArray(media_ids) && media_ids.length > 0) {
             body.media = { media_ids };
@@ -623,7 +651,9 @@ router.post('/x/tweet', express.json(), async (req, res) => {
             platform: 'x',
             tweetId: data.data?.id,
             text: data.data?.text,
-            isReply: !!reply_to
+            isReply: !!reply_to,
+            truncated,
+            originalWeightedLength: originalWeighted
         });
     } catch (err) {
         console.error('[Publisher] X tweet error:', err);
@@ -2049,4 +2079,4 @@ router.get('/health', async (req, res) => {
     });
 });
 
-module.exports = { router, initPublisherTable };
+module.exports = { router, initPublisherTable, truncateTweet, X_TWEET_WEIGHTED_LIMIT };

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -32,6 +32,7 @@
         "sanitize-html": "^2.17.2",
         "socket.io": "^4.8.3",
         "swagger-ui-express": "^5.0.1",
+        "twitter-text": "^3.1.0",
         "undici": "^7.24.4",
         "web-push": "^3.6.7",
         "ws": "^8.19.0",
@@ -1417,6 +1418,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -4540,6 +4550,14 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.12.tgz",
+      "integrity": "sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==",
+      "deprecated": "core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.",
+      "hasInstallScript": true,
       "license": "MIT"
     },
     "node_modules/core-util-is": {
@@ -10044,6 +10062,29 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/twemoji-parser": {
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/twemoji-parser/-/twemoji-parser-11.0.2.tgz",
+      "integrity": "sha512-5kO2XCcpAql6zjdLwRwJjYvAZyDy3+Uj7v1ipBzLthQmDL7Ce19bEqHr3ImSNeoSW2OA8u02XmARbXHaNO8GhA==",
+      "license": "MIT"
+    },
+    "node_modules/twitter-text": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/twitter-text/-/twitter-text-3.1.0.tgz",
+      "integrity": "sha512-nulfUi3FN6z0LUjYipJid+eiwXvOLb8Ass7Jy/6zsXmZK3URte043m8fL3FyDzrK+WLpyqhHuR/TcARTN/iuGQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.3.1",
+        "core-js": "^2.5.0",
+        "punycode": "1.4.1",
+        "twemoji-parser": "^11.0.2"
+      }
+    },
+    "node_modules/twitter-text/node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "license": "MIT"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -46,6 +46,7 @@
     "sanitize-html": "^2.17.2",
     "socket.io": "^4.8.3",
     "swagger-ui-express": "^5.0.1",
+    "twitter-text": "^3.1.0",
     "undici": "^7.24.4",
     "web-push": "^3.6.7",
     "ws": "^8.19.0",

--- a/backend/tests/jest/x-tweet-truncate.test.js
+++ b/backend/tests/jest/x-tweet-truncate.test.js
@@ -1,0 +1,65 @@
+const { truncateTweet, X_TWEET_WEIGHTED_LIMIT } = require('../../article-publisher');
+const twitterText = require('twitter-text');
+
+function weighted(text) {
+    return twitterText.parseTweet(text).weightedLength;
+}
+
+describe('truncateTweet', () => {
+    it('passes short ASCII through unchanged', () => {
+        const r = truncateTweet('Hello world');
+        expect(r.truncated).toBe(false);
+        expect(r.text).toBe('Hello world');
+        expect(r.originalWeighted).toBe(11);
+    });
+
+    it('passes exactly-280 ASCII through unchanged', () => {
+        const input = 'a'.repeat(280);
+        const r = truncateTweet(input);
+        expect(r.truncated).toBe(false);
+        expect(r.text).toBe(input);
+    });
+
+    it('truncates 281 ASCII to fit weighted 280', () => {
+        const r = truncateTweet('a'.repeat(281));
+        expect(r.truncated).toBe(true);
+        expect(weighted(r.text)).toBeLessThanOrEqual(X_TWEET_WEIGHTED_LIMIT);
+        expect(r.text.endsWith('…')).toBe(true);
+    });
+
+    it('truncates long ASCII', () => {
+        const r = truncateTweet('a'.repeat(500));
+        expect(r.truncated).toBe(true);
+        expect(weighted(r.text)).toBeLessThanOrEqual(X_TWEET_WEIGHTED_LIMIT);
+    });
+
+    it('treats CJK chars as weight 2', () => {
+        const input = '測'.repeat(145);
+        expect(weighted(input)).toBe(290);
+        const r = truncateTweet(input);
+        expect(r.truncated).toBe(true);
+        expect(weighted(r.text)).toBeLessThanOrEqual(X_TWEET_WEIGHTED_LIMIT);
+        expect(r.text.endsWith('…')).toBe(true);
+    });
+
+    it('passes CJK text at exactly weighted 280 unchanged', () => {
+        const input = '測'.repeat(140);
+        expect(weighted(input)).toBe(280);
+        const r = truncateTweet(input);
+        expect(r.truncated).toBe(false);
+        expect(r.text).toBe(input);
+    });
+
+    it('keeps URL intact when truncating body around it', () => {
+        const input = 'Check this out https://example.com/path ' + 'x'.repeat(300);
+        const r = truncateTweet(input);
+        expect(r.truncated).toBe(true);
+        expect(weighted(r.text)).toBeLessThanOrEqual(X_TWEET_WEIGHTED_LIMIT);
+        expect(r.text.includes('https://example.com/path')).toBe(true);
+    });
+
+    it('reports originalWeighted reflecting pre-truncation length', () => {
+        const r = truncateTweet('a'.repeat(400));
+        expect(r.originalWeighted).toBe(400);
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `twitter-text` as the source-of-truth X length tokenizer (CJK weighted 2, URLs weighted 23 as `t.co`).
- `POST /api/publisher/x/tweet` now silently truncates oversized input via binary search + ellipsis, eliminating the 50% 403 rate on promo copy mixing URLs + CJK.
- Response body gains `truncated` + `originalWeightedLength` so callers can log/flag truncated posts.

## Motivation
Kanban card e62a4648. Current handler forwards raw `text` to X API; anything over weighted 280 → 403 with no guard. Naive character slice can't solve this because CJK counts 2× and URLs normalize to 23, so weighted length ≠ string length.

## Implementation notes
- Binary-search over `text.slice(0, n) + '…'` rather than pre-computing, so it naturally handles multi-byte codepoints and the URL-detection edge cases that `twitter-text` owns.
- Kept the function local + exported for tests; no new public API surface.
- +1 prod dep: `twitter-text@^3.1.0` (~50KB, authored by Twitter, last release v3.1.0).

## Test plan
- [x] New `tests/jest/x-tweet-truncate.test.js`: 8 cases (ASCII boundary, 281/500 overflow, CJK at/over/under 280 weighted, URL-preservation, originalWeighted report). All pass.
- [x] Regression: existing `publisher-extended` + `publisher-integration` (57 tests) all pass.
- [ ] Staging smoke: send a 300-char ASCII + a 150-CJK-char payload through `/api/publisher/x/tweet` and verify `truncated:true` in response + tweet lands within 280 weighted.

## Follow-ups
- Length-guard `/data/skill-templates.json` bodies that could exceed 240 chars (leave 40 for URL buffer).
- Emit a structured metric when `truncated:true` so template overflow is trendable.

Closes kanban e62a4648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)