### PR TITLE
feat: GET /api/growth/daily aggregate metrics endpoint

### DIFF
--- a/backend/growth.js
+++ b/backend/growth.js
@@ -1,0 +1,161 @@
+/**
+ * Growth Metrics API — public-read aggregate stats for owner-admin bots
+ *
+ * Mounted at: /api/growth
+ *
+ * Endpoints:
+ *   GET /daily — today's aggregate growth metrics
+ *
+ * Auth chain (all must pass):
+ *   1. botSecret matches devices[deviceId].entities[entityId].botSecret
+ *   2. user_accounts.is_admin = TRUE for the user owning that deviceId
+ *   3. Per-bot rate limit: 60 requests / hour
+ *
+ * Response is aggregate-only (no PII, no user IDs, no IPs). Even if a
+ * botSecret leaks, an attacker can only read site-wide totals already
+ * implied by the public landing page.
+ */
+
+const express = require('express');
+const { Pool } = require('pg');
+const safeEqual = require('./safe-equal');
+
+const pool = new Pool({
+    connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
+});
+
+const RATE_WINDOW_MS = 60 * 60 * 1000;
+const RATE_MAX = 60;
+const rateBuckets = new Map();
+
+function checkRate(botSecret) {
+    const now = Date.now();
+    const bucket = rateBuckets.get(botSecret) || { count: 0, resetAt: now + RATE_WINDOW_MS };
+    if (now > bucket.resetAt) {
+        bucket.count = 0;
+        bucket.resetAt = now + RATE_WINDOW_MS;
+    }
+    bucket.count += 1;
+    rateBuckets.set(botSecret, bucket);
+    return bucket.count <= RATE_MAX;
+}
+
+function findEntity(devices, deviceId, entityId, botSecret) {
+    const device = devices[deviceId];
+    if (!device) return null;
+    const entity = (device.entities || {})[entityId];
+    if (!entity || !safeEqual(entity.botSecret, botSecret)) return null;
+    return entity;
+}
+
+async function isOwnerAdmin(deviceId) {
+    const r = await pool.query(
+        'SELECT is_admin FROM user_accounts WHERE device_id = $1',
+        [deviceId]
+    );
+    return r.rows.length > 0 && r.rows[0].is_admin === true;
+}
+
+async function fetchTodaySignups() {
+    const r = await pool.query(
+        `SELECT COUNT(*)::int AS c FROM user_accounts
+         WHERE created_at >= date_trunc('day', NOW())
+           AND created_at <  date_trunc('day', NOW()) + INTERVAL '1 day'`
+    );
+    return r.rows[0].c;
+}
+
+async function fetchRetention7d() {
+    const r = await pool.query(
+        `WITH cohort AS (
+           SELECT id FROM user_accounts
+           WHERE created_at >= date_trunc('day', NOW() - INTERVAL '7 days')
+             AND created_at <  date_trunc('day', NOW() - INTERVAL '6 days')
+         ),
+         active AS (
+           SELECT id FROM cohort
+           WHERE id IN (
+             SELECT id FROM user_accounts
+             WHERE last_login_at >= NOW() - INTERVAL '24 hours'
+           )
+         )
+         SELECT (SELECT COUNT(*) FROM cohort)::int AS cohort_size,
+                (SELECT COUNT(*) FROM active)::int AS active_size`
+    );
+    const { cohort_size, active_size } = r.rows[0];
+    if (cohort_size === 0) return { cohort_size: 0, active_size: 0, pct: null };
+    return {
+        cohort_size,
+        active_size,
+        pct: Math.round((active_size / cohort_size) * 1000) / 10
+    };
+}
+
+async function fetchPlazaNewListed() {
+    const r = await pool.query(
+        `SELECT COUNT(*)::int AS c FROM bot_listings
+         WHERE status = 'listed'
+           AND created_at >= date_trunc('day', NOW())
+           AND created_at <  date_trunc('day', NOW()) + INTERVAL '1 day'`
+    );
+    return r.rows[0].c;
+}
+
+module.exports = function(devices) {
+    const router = express.Router();
+
+    router.get('/daily', async (req, res) => {
+        const { deviceId, botSecret, entityId } = req.query;
+
+        if (!deviceId || !botSecret || !entityId) {
+            return res.status(400).json({ success: false, error: 'Missing deviceId, botSecret, or entityId' });
+        }
+
+        const entity = findEntity(devices, deviceId, parseInt(entityId), botSecret);
+        if (!entity) {
+            return res.status(401).json({ success: false, error: 'Invalid credentials' });
+        }
+
+        let admin;
+        try {
+            admin = await isOwnerAdmin(deviceId);
+        } catch (err) {
+            console.error('[Growth] admin check error:', err);
+            return res.status(500).json({ success: false, error: 'Internal error' });
+        }
+        if (!admin) {
+            return res.status(403).json({ success: false, error: 'Owner is not admin' });
+        }
+
+        if (!checkRate(botSecret)) {
+            return res.status(429).json({ success: false, error: 'Rate limit exceeded (60/hour)' });
+        }
+
+        try {
+            const [today_signups, retention_7d, plaza_new_listed_today] = await Promise.all([
+                fetchTodaySignups(),
+                fetchRetention7d(),
+                fetchPlazaNewListed()
+            ]);
+            return res.json({
+                success: true,
+                date: new Date().toISOString().slice(0, 10),
+                today_signups,
+                retention_7d,
+                plaza_new_listed_today,
+                follow_ups: [
+                    'source_channel: schema lacks signup_source column',
+                    'visitor_to_signup_conversion: page_views has no FK to user_accounts'
+                ]
+            });
+        } catch (err) {
+            console.error('[Growth] query error:', err);
+            return res.status(500).json({ success: false, error: 'Query failed' });
+        }
+    });
+
+    return {
+        router,
+        _internal: { checkRate, findEntity, isOwnerAdmin, fetchTodaySignups, fetchRetention7d, fetchPlazaNewListed, rateBuckets }
+    };
+};

--- a/backend/growth.js
+++ b/backend/growth.js
@@ -56,31 +56,37 @@ async function isOwnerAdmin(deviceId) {
     return r.rows.length > 0 && r.rows[0].is_admin === true;
 }
 
+const TZ = 'Asia/Taipei';
+
 async function fetchTodaySignups() {
     const r = await pool.query(
         `SELECT COUNT(*)::int AS c FROM user_accounts
-         WHERE created_at >= date_trunc('day', NOW())
-           AND created_at <  date_trunc('day', NOW()) + INTERVAL '1 day'`
+         WHERE created_at >= date_trunc('day', NOW() AT TIME ZONE $1) AT TIME ZONE $1
+           AND created_at <  (date_trunc('day', NOW() AT TIME ZONE $1) + INTERVAL '1 day') AT TIME ZONE $1`,
+        [TZ]
     );
     return r.rows[0].c;
 }
 
 async function fetchRetention7d() {
     const r = await pool.query(
-        `WITH cohort AS (
-           SELECT id FROM user_accounts
-           WHERE created_at >= date_trunc('day', NOW() - INTERVAL '7 days')
-             AND created_at <  date_trunc('day', NOW() - INTERVAL '6 days')
+        `WITH today_start AS (
+           SELECT date_trunc('day', NOW() AT TIME ZONE $1) AS d
+         ),
+         cohort AS (
+           SELECT id FROM user_accounts, today_start
+           WHERE created_at >= (d - INTERVAL '7 days') AT TIME ZONE $1
+             AND created_at <  (d - INTERVAL '6 days') AT TIME ZONE $1
          ),
          active AS (
-           SELECT id FROM cohort
-           WHERE id IN (
-             SELECT id FROM user_accounts
-             WHERE last_login_at >= NOW() - INTERVAL '24 hours'
-           )
+           SELECT c.id FROM cohort c
+           JOIN user_accounts u ON u.id = c.id, today_start
+           WHERE u.last_login_at >= d AT TIME ZONE $1
+             AND u.last_login_at <  (d + INTERVAL '1 day') AT TIME ZONE $1
          )
          SELECT (SELECT COUNT(*) FROM cohort)::int AS cohort_size,
-                (SELECT COUNT(*) FROM active)::int AS active_size`
+                (SELECT COUNT(*) FROM active)::int AS active_size`,
+        [TZ]
     );
     const { cohort_size, active_size } = r.rows[0];
     if (cohort_size === 0) return { cohort_size: 0, active_size: 0, pct: null };
@@ -95,8 +101,9 @@ async function fetchPlazaNewListed() {
     const r = await pool.query(
         `SELECT COUNT(*)::int AS c FROM bot_listings
          WHERE status = 'listed'
-           AND created_at >= date_trunc('day', NOW())
-           AND created_at <  date_trunc('day', NOW()) + INTERVAL '1 day'`
+           AND created_at >= date_trunc('day', NOW() AT TIME ZONE $1) AT TIME ZONE $1
+           AND created_at <  (date_trunc('day', NOW() AT TIME ZONE $1) + INTERVAL '1 day') AT TIME ZONE $1`,
+        [TZ]
     );
     return r.rows[0].c;
 }
@@ -116,6 +123,10 @@ module.exports = function(devices) {
             return res.status(401).json({ success: false, error: 'Invalid credentials' });
         }
 
+        if (!checkRate(botSecret)) {
+            return res.status(429).json({ success: false, error: 'Rate limit exceeded (60/hour)' });
+        }
+
         let admin;
         try {
             admin = await isOwnerAdmin(deviceId);
@@ -125,10 +136,6 @@ module.exports = function(devices) {
         }
         if (!admin) {
             return res.status(403).json({ success: false, error: 'Owner is not admin' });
-        }
-
-        if (!checkRate(botSecret)) {
-            return res.status(429).json({ success: false, error: 'Rate limit exceeded (60/hour)' });
         }
 
         try {
@@ -145,7 +152,8 @@ module.exports = function(devices) {
                 plaza_new_listed_today,
                 follow_ups: [
                     'source_channel: schema lacks signup_source column',
-                    'visitor_to_signup_conversion: page_views has no FK to user_accounts'
+                    'visitor_to_signup_conversion: page_views has no FK to user_accounts',
+                    'plaza_new_listed_today: counts created_at not status_changed_at (bot_listings has no listed_at column)'
                 ]
             });
         } catch (err) {

--- a/backend/index.js
+++ b/backend/index.js
@@ -1238,6 +1238,15 @@ try {
     kanbanModule = { initKanbanDatabase: () => {}, startBackgroundTimers: () => {} };
 }
 
+// Growth metrics — botSecret + admin-owner gated, aggregate-only
+try {
+    const growthModule = require('./growth')(devices);
+    app.use('/api/growth', growthModule.router);
+    console.log('[Growth] Module loaded successfully');
+} catch (err) {
+    console.error('[Growth] Failed to load module:', err.message);
+}
+
 // ============================================
 // PAGE VIEW TRACKING (fire-and-forget)
 // ============================================

--- a/backend/tests/jest/growth.test.js
+++ b/backend/tests/jest/growth.test.js
@@ -108,7 +108,22 @@ describe('Growth /daily aggregation contract', () => {
         expect(res.body.plaza_new_listed_today).toBe(3);
         expect(res.body.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
         expect(Array.isArray(res.body.follow_ups)).toBe(true);
-        expect(res.body.follow_ups.length).toBe(2);
+        expect(res.body.follow_ups.length).toBe(3);
+    });
+
+    it('never leaks PII fields (id/email/ip/device_id) in response', async () => {
+        setupAdminQueries({ signups: 1, cohort: 1, active: 1, plaza: 1 });
+        const res = await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2');
+        const body = JSON.stringify(res.body);
+        expect(body).not.toMatch(/\bid\b\s*:/i);
+        expect(body).not.toMatch(/email/i);
+        expect(body).not.toMatch(/ip_address|"ip"/i);
+        expect(body).not.toMatch(/device_id|deviceId/);
+    });
+
+    it('handles non-numeric entityId as 401 (NaN safe)', async () => {
+        const res = await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=abc');
+        expect(res.status).toBe(401);
     });
 
     it('reports retention pct as null when cohort empty', async () => {

--- a/backend/tests/jest/growth.test.js
+++ b/backend/tests/jest/growth.test.js
@@ -1,0 +1,168 @@
+/**
+ * Growth Metrics endpoint tests
+ *
+ * Covers GET /api/growth/daily auth chain + aggregation contract.
+ * pg Pool is mocked; queries are intercepted to return canned rows so we
+ * verify the route's handling of each branch (signups, retention, plaza).
+ */
+
+let mockQuery;
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: (...args) => mockQuery(...args),
+        connect: jest.fn(),
+        end: jest.fn(),
+    })),
+}));
+
+const express = require('express');
+const request = require('supertest');
+
+let app;
+let growthModule;
+
+beforeEach(() => {
+    jest.resetModules();
+    mockQuery = jest.fn();
+
+    app = express();
+    app.use(express.json());
+
+    const mockDevices = {
+        'admin-dev': {
+            deviceSecret: 'sec',
+            entities: {
+                2: { isBound: true, botSecret: 'admin-bot-sec', character: 'A' },
+            },
+        },
+        'user-dev': {
+            deviceSecret: 'sec2',
+            entities: {
+                2: { isBound: true, botSecret: 'user-bot-sec', character: 'U' },
+            },
+        },
+        'unknown-dev': {
+            deviceSecret: 'sec3',
+            entities: {
+                2: { isBound: true, botSecret: 'orphan-bot-sec', character: 'O' },
+            },
+        },
+    };
+
+    growthModule = require('../../growth')(mockDevices);
+    app.use('/api/growth', growthModule.router);
+
+    // clear rate buckets between tests
+    growthModule._internal.rateBuckets.clear();
+});
+
+const get = (qs) => request(app).get('/api/growth/daily' + qs);
+
+function setupAdminQueries({ signups = 5, cohort = 10, active = 4, plaza = 2 } = {}) {
+    // is_admin lookup → then 3 metric queries (parallel order: signups, retention, plaza)
+    mockQuery
+        .mockResolvedValueOnce({ rows: [{ is_admin: true }] })
+        .mockResolvedValueOnce({ rows: [{ c: signups }] })
+        .mockResolvedValueOnce({ rows: [{ cohort_size: cohort, active_size: active }] })
+        .mockResolvedValueOnce({ rows: [{ c: plaza }] });
+}
+
+describe('Growth /daily auth', () => {
+    it('rejects missing query params (400)', async () => {
+        const res = await get('?deviceId=admin-dev');
+        expect(res.status).toBe(400);
+    });
+
+    it('rejects invalid botSecret (401)', async () => {
+        const res = await get('?deviceId=admin-dev&botSecret=wrong&entityId=2');
+        expect(res.status).toBe(401);
+    });
+
+    it('rejects unknown deviceId (401)', async () => {
+        const res = await get('?deviceId=ghost&botSecret=admin-bot-sec&entityId=2');
+        expect(res.status).toBe(401);
+    });
+
+    it('rejects when owner is not admin (403)', async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [{ is_admin: false }] });
+        const res = await get('?deviceId=user-dev&botSecret=user-bot-sec&entityId=2');
+        expect(res.status).toBe(403);
+    });
+
+    it('rejects when no user_account row matches deviceId (403)', async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [] });
+        const res = await get('?deviceId=unknown-dev&botSecret=orphan-bot-sec&entityId=2');
+        expect(res.status).toBe(403);
+    });
+});
+
+describe('Growth /daily aggregation contract', () => {
+    it('returns the 3 metrics + date + follow-ups list', async () => {
+        setupAdminQueries({ signups: 7, cohort: 20, active: 8, plaza: 3 });
+        const res = await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2');
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.today_signups).toBe(7);
+        expect(res.body.retention_7d).toEqual({ cohort_size: 20, active_size: 8, pct: 40 });
+        expect(res.body.plaza_new_listed_today).toBe(3);
+        expect(res.body.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        expect(Array.isArray(res.body.follow_ups)).toBe(true);
+        expect(res.body.follow_ups.length).toBe(2);
+    });
+
+    it('reports retention pct as null when cohort empty', async () => {
+        setupAdminQueries({ cohort: 0, active: 0 });
+        const res = await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2');
+        expect(res.status).toBe(200);
+        expect(res.body.retention_7d.pct).toBeNull();
+        expect(res.body.retention_7d.cohort_size).toBe(0);
+    });
+
+    it('rounds retention pct to one decimal', async () => {
+        setupAdminQueries({ cohort: 7, active: 1 });
+        const res = await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2');
+        expect(res.body.retention_7d.pct).toBe(14.3);
+    });
+
+    it('returns 500 on db error in metric query', async () => {
+        mockQuery
+            .mockResolvedValueOnce({ rows: [{ is_admin: true }] })
+            .mockRejectedValueOnce(new Error('boom'));
+        const res = await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2');
+        expect(res.status).toBe(500);
+    });
+
+    it('returns 500 on db error in admin check', async () => {
+        mockQuery.mockRejectedValueOnce(new Error('admin check failed'));
+        const res = await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2');
+        expect(res.status).toBe(500);
+    });
+});
+
+describe('Growth /daily rate limit', () => {
+    it('allows up to 60 requests per botSecret per hour', async () => {
+        // Simulate 60 successful calls
+        for (let i = 0; i < 60; i++) {
+            setupAdminQueries();
+            const res = await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2');
+            expect(res.status).toBe(200);
+        }
+        // 61st should 429
+        mockQuery.mockResolvedValueOnce({ rows: [{ is_admin: true }] });
+        const res = await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2');
+        expect(res.status).toBe(429);
+    });
+
+    it('separates rate buckets per botSecret', async () => {
+        // exhaust admin-bot-sec
+        for (let i = 0; i < 60; i++) {
+            setupAdminQueries();
+            await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2');
+        }
+        // user-dev with its own secret should still work (assuming admin)
+        setupAdminQueries();
+        const res = await get('?deviceId=user-dev&botSecret=user-bot-sec&entityId=2');
+        expect(res.status).toBe(200);
+    });
+});


### PR DESCRIPTION
## Summary

Adds a new public-read endpoint that returns today's growth metrics as aggregate counts only, gated to admin-owned bots via the existing botSecret auth pattern.

## Why

The kanban cron card '[成長] 每日增長指標追蹤' fires every morning expecting #2 channel-bot to record growth metrics, but `/api/admin/stats` requires a user JWT that bot entities don't have. Rather than handing admin tokens to a rental bot (which violates the rental trust boundary), this PR creates an aggregate-only endpoint that any admin-owned bot can poll safely.

## Auth chain

1. `botSecret` matches `devices[deviceId].entities[entityId].botSecret` (same as mission API)
2. `user_accounts.is_admin = TRUE` for the user owning that `device_id`
3. Per-bot in-memory rate limit: 60 req/hour

Even if a botSecret leaks, the response contains only site-wide counts already implied by the public landing page. No PII, no user IDs, no IPs.

## Endpoint

`GET /api/growth/daily?deviceId=X&botSecret=Y&entityId=Z`

Response:
\`\`\`json
{
  \"success\": true,
  \"date\": \"2026-04-15\",
  \"today_signups\": 7,
  \"retention_7d\": { \"cohort_size\": 20, \"active_size\": 8, \"pct\": 40.0 },
  \"plaza_new_listed_today\": 3,
  \"follow_ups\": [
    \"source_channel: schema lacks signup_source column\",
    \"visitor_to_signup_conversion: page_views has no FK to user_accounts\"
  ]
}
\`\`\`

## Deferred metrics

The original kanban card asked for 5 metrics. Schema reality:
- ✅ today_signups — `user_accounts.created_at`
- ❌ source_channel — no `signup_source` column (only `google_id`/`facebook_id`)
- ✅ retention_7d — `user_accounts.last_login_at`
- ✅ plaza_new_listed — `bot_listings.status='listed'`
- ❌ visitor→signup conversion — `page_views` has no FK to `user_accounts`

Both deferred metrics are surfaced in the response's `follow_ups` array so callers know the gap. They require schema changes that don't belong in this PR.

## Tests

\`tests/jest/growth.test.js\` — 12 cases:
- Auth (5): missing params, bad botSecret, unknown deviceId, non-admin owner, no user_account row
- Contract (5): metrics + date + follow_ups, empty cohort → null pct, decimal rounding, db error in metric, db error in admin check
- Rate limit (2): 60th req passes / 61st returns 429, separate buckets per botSecret

Mission + auth-extended regression suites: 79 tests green.

## Test plan

- [x] \`npx jest growth.test\` — 12/12 pass
- [x] \`npx jest mission auth-extended\` — 79/79 pass
- [ ] Manual smoke after deploy: \`curl -s \"$BASE/api/growth/daily?deviceId=...&botSecret=...&entityId=2\"\`