### PR TITLE
feat(portal-seo): add OG/JSON-LD metadata + sitemap entries for arena, community, compare

### DIFF
--- a/backend/public/arena/index.html
+++ b/backend/public/arena/index.html
@@ -23,6 +23,7 @@
 
     <!-- JSON-LD Structured Data -->
     <script type="application/ld+json">
+    [
     {
         "@context": "https://schema.org",
         "@type": "WebApplication",
@@ -31,6 +32,7 @@
         "url": "https://eclawbot.com/arena/",
         "applicationCategory": "DeveloperApplication",
         "operatingSystem": "Web",
+        "keywords": "AI agent evaluation, agent benchmark, LLM evaluation, tool-use benchmark, agent leaderboard, Claude vs GPT, agent scoring",
         "offers": {
             "@type": "Offer",
             "price": "0",
@@ -41,7 +43,30 @@
             "name": "EClawbot",
             "url": "https://eclawbot.com"
         }
+    },
+    {
+        "@context": "https://schema.org",
+        "@type": "ItemList",
+        "name": "EClaw Arena — 12 Agent Evaluation Challenges",
+        "description": "Twelve standardized challenges covering vision, web interaction, coding, reasoning, and safety.",
+        "itemListOrder": "https://schema.org/ItemListUnordered",
+        "numberOfItems": 12,
+        "itemListElement": [
+            {"@type": "ListItem", "position": 1, "name": "Vision comprehension"},
+            {"@type": "ListItem", "position": 2, "name": "Document understanding"},
+            {"@type": "ListItem", "position": 3, "name": "Web navigation"},
+            {"@type": "ListItem", "position": 4, "name": "Form interaction"},
+            {"@type": "ListItem", "position": 5, "name": "Auth and redirect handling"},
+            {"@type": "ListItem", "position": 6, "name": "Code generation"},
+            {"@type": "ListItem", "position": 7, "name": "Code modification"},
+            {"@type": "ListItem", "position": 8, "name": "Multi-step planning"},
+            {"@type": "ListItem", "position": 9, "name": "Error recovery"},
+            {"@type": "ListItem", "position": 10, "name": "Constraint satisfaction"},
+            {"@type": "ListItem", "position": 11, "name": "Refusal accuracy"},
+            {"@type": "ListItem", "position": 12, "name": "Scope adherence"}
+        ]
     }
+    ]
     </script>
 
     <link rel="icon" type="image/png" href="/portal/assets/favicon-32.png">

--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -20,6 +20,25 @@
     <meta name="twitter:title" content="EClawbot - Bot Plaza">
     <meta name="twitter:description" content="Discover and connect with AI bots on EClawbot Bot Plaza. Find AI agents, explore capabilities, and integrate them into your workflow.">
     <meta name="twitter:image" content="https://eclawbot.com/assets/og-image.png">
+    <!-- JSON-LD Structured Data -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "CollectionPage",
+        "name": "EClawbot - Bot Plaza",
+        "description": "Discover and connect with AI bots on EClawbot Bot Plaza. Find AI agents, explore capabilities, and integrate them into your workflow.",
+        "url": "https://eclawbot.com/portal/community.html",
+        "isPartOf": {
+            "@type": "WebSite",
+            "name": "EClawbot",
+            "url": "https://eclawbot.com"
+        },
+        "about": {
+            "@type": "Thing",
+            "name": "AI Agents Marketplace"
+        }
+    }
+    </script>
     <link rel="stylesheet" href="shared/style.css">
     <style>
         /* Fallback dark theme variables (in case shared/style.css doesn't load) */

--- a/backend/public/portal/compare.html
+++ b/backend/public/portal/compare.html
@@ -8,6 +8,39 @@
     <link rel="icon" type="image/png" href="assets/favicon-32.png">
     <link rel="stylesheet" href="shared/style.css">
     <link rel="canonical" href="https://eclawbot.com/portal/compare.html">
+    <!-- Open Graph -->
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="EClawbot vs Telegram — Channel Comparison">
+    <meta property="og:description" content="Compare EClawbot and Telegram as OpenClaw bot channels. See capabilities, integration paths, and A2A features side by side.">
+    <meta property="og:url" content="https://eclawbot.com/portal/compare.html">
+    <meta property="og:site_name" content="EClawbot">
+    <meta property="og:image" content="https://eclawbot.com/assets/og-image.png">
+    <meta property="og:image:width" content="512">
+    <meta property="og:image:height" content="512">
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:title" content="EClawbot vs Telegram — Channel Comparison">
+    <meta name="twitter:description" content="Compare EClawbot and Telegram as OpenClaw bot channels. See capabilities, integration paths, and A2A features side by side.">
+    <meta name="twitter:image" content="https://eclawbot.com/assets/og-image.png">
+    <!-- JSON-LD Structured Data -->
+    <script type="application/ld+json">
+    {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": "EClawbot vs Telegram — Channel Comparison",
+        "description": "Compare EClawbot and Telegram as OpenClaw bot channels.",
+        "url": "https://eclawbot.com/portal/compare.html",
+        "isPartOf": {
+            "@type": "WebSite",
+            "name": "EClawbot",
+            "url": "https://eclawbot.com"
+        },
+        "about": [
+            {"@type": "SoftwareApplication", "name": "EClawbot", "applicationCategory": "CommunicationApplication"},
+            {"@type": "SoftwareApplication", "name": "Telegram", "applicationCategory": "CommunicationApplication"}
+        ]
+    }
+    </script>
     <style>
         /* Fallback dark theme */
         :root {

--- a/backend/public/sitemap.xml
+++ b/backend/public/sitemap.xml
@@ -42,4 +42,28 @@
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>
+  <url>
+    <loc>https://eclawbot.com/arena/</loc>
+    <lastmod>2026-04-15</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://eclawbot.com/portal/community.html</loc>
+    <lastmod>2026-04-15</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://eclawbot.com/portal/compare.html</loc>
+    <lastmod>2026-04-15</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://eclawbot.com/portal/roadmap.html</loc>
+    <lastmod>2026-04-15</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
+  </url>
 </urlset>


### PR DESCRIPTION
## Summary
- Extends arena/ JSON-LD with an ItemList of the 12 evaluation challenges + SEO keywords
- Adds OG, Twitter card, and WebPage JSON-LD to portal/compare.html (previously only title + canonical)
- Adds CollectionPage JSON-LD to portal/community.html (Bot Plaza) — OG/Twitter were already there
- Registers arena/, community, compare, roadmap in sitemap.xml so search engines can crawl them

## Why
Part of the #4 Portal SEO 優化 kanban card. These four pages are the public surface for organic discovery but had gaps in machine-readable schema. Adding them should help Google Rich Results and social-share cards.

## Test plan
- [ ] Verify sitemap.xml at https://eclawbot.com/sitemap.xml includes the new URLs after deploy
- [ ] Paste each new URL into Google Rich Results Test (https://search.google.com/test/rich-results) and confirm JSON-LD is detected
- [ ] Paste each URL into Twitter/X Card Validator and confirm card renders
- [ ] Submit updated sitemap via Google Search Console

🤖 Generated with [Claude Code](https://claude.com/claude-code)