### PR TITLE
i18n(android): add dashboard_entry_* to 11 remaining locales

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -164,6 +164,9 @@
 
     <!-- Mission Control -->
     <string name="mission_control">مركز المهام</string>
+    <string name="dashboard_entry_title">لوحة التحكم الكاملة</string>
+    <string name="dashboard_entry_subtitle">مع المخطط التنظيمي</string>
+    <string name="dashboard_entry_content_description">فتح لوحة التحكم الكاملة</string>
     <string name="tab_mission_center">مركز المهام</string>
     <string name="tab_kanban">كانبان</string>
     <string name="kanban_add_deprecated">يرجى استخدام لوحة كانبان لإضافة عناصر جديدة. لوحة كانبان لديها نظام بيئي كامل — دع البوتات تنقل العناصر الحالية تدريجيًا.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -164,6 +164,9 @@
 
     <!-- Mission Control -->
     <string name="mission_control">Missionskontrolle</string>
+    <string name="dashboard_entry_title">Vollständiges Dashboard</string>
+    <string name="dashboard_entry_subtitle">mit Organigramm</string>
+    <string name="dashboard_entry_content_description">Vollständiges Dashboard öffnen</string>
     <string name="tab_mission_center">Missionszentrale</string>
     <string name="tab_kanban">Kanban</string>
     <string name="kanban_add_deprecated">Bitte verwenden Sie das Kanban-Board, um neue Einträge hinzuzufügen. Das Kanban-Board bietet ein vollständiges Ökosystem — lassen Sie Bots bestehende Einträge schrittweise migrieren.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -439,6 +439,9 @@ Tus comentarios enviados aparecerán aquí.</string>
     <string name="mission_choose_from_template">Elegir de Plantilla</string>
     <string name="mission_completed_at">✓ %s</string>
     <string name="mission_control">Centro de Misiones</string>
+    <string name="dashboard_entry_title">Panel completo</string>
+    <string name="dashboard_entry_subtitle">con organigrama</string>
+    <string name="dashboard_entry_content_description">Abrir panel completo</string>
     <string name="mission_no_skills">Sin skills</string>
     <string name="mission_no_variables">Sin variables</string>
     <string name="mission_rule_gallery_title">Plantillas de Regla</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -164,6 +164,9 @@
 
     <!-- Mission Control -->
     <string name="mission_control">Centre de mission</string>
+    <string name="dashboard_entry_title">Tableau de bord complet</string>
+    <string name="dashboard_entry_subtitle">avec organigramme</string>
+    <string name="dashboard_entry_content_description">Ouvrir le tableau de bord complet</string>
     <string name="tab_mission_center">Centre de mission</string>
     <string name="tab_kanban">Kanban</string>
     <string name="kanban_add_deprecated">Veuillez utiliser le tableau Kanban pour ajouter de nouveaux éléments. Le tableau Kanban dispose d\'un écosystème complet — laissez les bots migrer progressivement les éléments existants.</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -164,6 +164,9 @@
 
     <!-- Mission Control -->
     <string name="mission_control">मिशन कंट्रोल</string>
+    <string name="dashboard_entry_title">पूर्ण डैशबोर्ड</string>
+    <string name="dashboard_entry_subtitle">ऑर्ग चार्ट के साथ</string>
+    <string name="dashboard_entry_content_description">पूर्ण डैशबोर्ड खोलें</string>
     <string name="tab_mission_center">मिशन सेंटर</string>
     <string name="tab_kanban">कानबान</string>
     <string name="kanban_add_deprecated">कृपया नए आइटम जोड़ने के लिए कानबान बोर्ड का उपयोग करें। कानबान बोर्ड में पूर्ण इकोसिस्टम है — बॉट को मौजूदा आइटम धीरे-धीरे माइग्रेट करने दें।</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -477,6 +477,9 @@ Jika ada pertanyaan, silakan hubungi kami melalui email resmi kami.
     <string name="mission_choose_from_template">Pilih dari Template</string>
     <string name="mission_completed_at">✓ %s</string>
     <string name="mission_control">Pusat Misi</string>
+    <string name="dashboard_entry_title">Dasbor Lengkap</string>
+    <string name="dashboard_entry_subtitle">dengan bagan organisasi</string>
+    <string name="dashboard_entry_content_description">Buka dasbor lengkap</string>
     <string name="mission_no_skills">Tidak ada keahlian</string>
     <string name="mission_no_variables">Tidak ada variabel</string>
     <string name="mission_rule_gallery_title">Template Aturan</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -477,6 +477,9 @@ GPS：オンデマンドのみ、バックグラウンド追跡なし、サー�
     <string name="mission_choose_from_template">テンプレートから選択</string>
     <string name="mission_completed_at">✓ %s</string>
     <string name="mission_control">ミッションコントロール</string>
+    <string name="dashboard_entry_title">フルダッシュボード</string>
+    <string name="dashboard_entry_subtitle">組織図付き</string>
+    <string name="dashboard_entry_content_description">フルダッシュボードを開く</string>
     <string name="mission_no_skills">スキルなし</string>
     <string name="mission_no_variables">変数なし</string>
     <string name="mission_rule_gallery_title">ルールテンプレート</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -477,6 +477,9 @@ GPS: 온디맨드만, 백그라운드 추적 없음, 서버 재시작 시 데이
     <string name="mission_choose_from_template">템플릿에서 선택</string>
     <string name="mission_completed_at">✓ %s</string>
     <string name="mission_control">미션 컨트롤</string>
+    <string name="dashboard_entry_title">전체 대시보드</string>
+    <string name="dashboard_entry_subtitle">조직도 포함</string>
+    <string name="dashboard_entry_content_description">전체 대시보드 열기</string>
     <string name="mission_no_skills">스킬 없음</string>
     <string name="mission_no_variables">변수 없음</string>
     <string name="mission_rule_gallery_title">규칙 템플릿</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -164,6 +164,9 @@
 
     <!-- Mission Control -->
     <string name="mission_control">Pusat Misi</string>
+    <string name="dashboard_entry_title">Papan Pemuka Penuh</string>
+    <string name="dashboard_entry_subtitle">dengan Carta Organisasi</string>
+    <string name="dashboard_entry_content_description">Buka papan pemuka penuh</string>
     <string name="tab_mission_center">Pusat Misi</string>
     <string name="tab_kanban">Kanban</string>
     <string name="kanban_add_deprecated">Sila gunakan papan Kanban untuk menambah item baharu. Papan Kanban mempunyai ekosistem lengkap — biarkan bot memindahkan item sedia ada secara beransur-ansur.</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -477,6 +477,9 @@ GPS：รับตามความต้องการเท่านั้�
     <string name="mission_choose_from_template">เลือกจากเทมเพลต</string>
     <string name="mission_completed_at">✓ %s</string>
     <string name="mission_control">ศูนย์ภารกิจ</string>
+    <string name="dashboard_entry_title">แดชบอร์ดแบบเต็ม</string>
+    <string name="dashboard_entry_subtitle">พร้อมแผนผังองค์กร</string>
+    <string name="dashboard_entry_content_description">เปิดแดชบอร์ดแบบเต็ม</string>
     <string name="mission_no_skills">No skills</string>
     <string name="mission_no_variables">No variables</string>
     <string name="mission_rule_gallery_title">เทมเพลตกฎ</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -477,6 +477,9 @@ Nếu có bất kỳ câu hỏi nào, vui lòng liên hệ với chúng tôi qua
     <string name="mission_choose_from_template">Chọn từ mẫu</string>
     <string name="mission_completed_at">✓ %s</string>
     <string name="mission_control">Trung tâm nhiệm vụ</string>
+    <string name="dashboard_entry_title">Bảng điều khiển đầy đủ</string>
+    <string name="dashboard_entry_subtitle">có sơ đồ tổ chức</string>
+    <string name="dashboard_entry_content_description">Mở bảng điều khiển đầy đủ</string>
     <string name="mission_no_skills">No skills</string>
     <string name="mission_no_variables">No variables</string>
     <string name="mission_rule_gallery_title">Mẫu quy tắc</string>


### PR DESCRIPTION
## Summary

- Follow-up to #1795 — the Dashboard + Org Chart parity PR only localized the new `dashboard_entry_title/_subtitle/_content_description` strings in `values/`, `values-zh-rTW/`, and `values-zh-rCN/`. The other 11 Android locales (ar/de/es/fr/hi/in/ja/ko/ms/th/vi) now also have the keys.
- Without this, those locales fell back to English for the new top-bar entry — a repo translation-completeness invariant violation caught by coverage review.

## Test plan

- [x] Each of the 11 values-*/strings.xml now contains all three `dashboard_entry_*` keys (verified via grep)
- [x] Parent v1.0.69 release unaffected (this only affects the upcoming v1.0.70 which contains the Dashboard entry)
- [ ] Android Lint on CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)