### PR TITLE
release: v1.0.70 — Dashboard + Org Chart parity on Android & iOS

### DIFF
--- a/RELEASE_HISTORY.md
+++ b/RELEASE_HISTORY.md
@@ -5,9 +5,10 @@ Track git commits for each release to enable changelog generation via `git diff`
 ---
 
 ## Latest
-v1.0.69 | 57b5250b | 2026-04-16 | versionCode 75 | Internal ✅ + Production ✅ (submitted for review 2026-04-17 09:33 TW)
+v1.0.70 | 9a3a1c52 | 2026-04-17 | versionCode 76 | Dashboard + Org Chart parity on Android & iOS (WebView → portal/dashboard.html)
 
 ## Recent
+v1.0.69 | 57b5250b | 2026-04-16 | versionCode 75 | Internal ✅ + Production ✅ (submitted for review 2026-04-17 09:33 TW)
 v1.0.68 | 606b04ca | 2026-04-16
 v1.0.67 | ecbe48e0 | 2026-04-16
 v1.0.65 | c3769436 | 2026-04-16

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 75
-        versionName = "1.0.69"
+        versionCode = 76
+        versionName = "1.0.70"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
## Summary

Release bump v1.0.70 / versionCode 76. Ships the work merged via #1795 and #1796.

## What's in v1.0.70

**Dashboard + Org Chart parity**
- Android: `DashboardActivity` loads `portal/dashboard.html` via WebView. Launched from a new top-bar `btnDashboard` icon on `MainActivity` (next to `btnEditMode`). Mirrors `MissionControlActivity` for lifecycle/insets/auth injection.
- iOS: new Dashboard tab between Home and Chat. Uses the shared `WebViewScreen` component (same pattern as `mission.tsx`).
- Full 4-mode Org Chart (none / low / recommended / strict) with drag/drop reparent, persisted via `PUT /api/device/org-chart`.
- Playwright iPhone 13 viewport smoke test confirmed drag/drop works on mobile (both mouse + TouchEvent dispatch), mode radio toggles persist, reset restores hierarchy.

**i18n coverage**
- Android: `dashboard_entry_title` / `_subtitle` / `_content_description` in all 14 locales (en/zh-TW/zh-CN plus ar/de/es/fr/hi/in/ja/ko/ms/th/vi).
- iOS: `tabs.dashboard` in all 16 locales.

**iOS Home/Cards/Settings alignment** (bundled via #1795 merge)
- Entity card redesign aligned with Android `item_agent_card.xml`
- `card-holder.tsx` + `entity-manager.tsx` removed (duplicate surfaces)
- Settings "Manage Entities" entry dropped

**Docs**
- `docs/specs/android-app-spec.md`: `DashboardActivity` added to inventory
- `docs/specs/ios-app-spec.md`: Dashboard tab row added; Org Chart parity flipped ⚠️ → ✅

## Upload plan

1. Merge this PR
2. Build AAB: `./gradlew.bat bundleRelease` (signed with upload keystore)
3. Upload to internal testing track: `node scripts/upload_to_play.js`
4. Mark v1.0.70 as "Internal ✅" in RELEASE_HISTORY.md after upload

## Test plan

- [x] Android Lint green (on #1795 and #1796)
- [x] Kotlin Unit Tests green
- [x] Assemble Debug APK green
- [x] iOS tsc passes for touched files
- [ ] Manual: tap top-bar dashboard icon on Android, verify org chart loads with session
- [ ] Manual: tap Dashboard tab on iOS, verify org chart loads with session
- [ ] Manual: drag entity to new parent, reload app, verify hierarchy persisted

🤖 Generated with [Claude Code](https://claude.com/claude-code)