### PR TITLE
fix(chat): render Note chip when ID is wrapped in backticks

### DIFF
--- a/backend/public/portal/shared/note-link-render.js
+++ b/backend/public/portal/shared/note-link-render.js
@@ -23,6 +23,12 @@
     // Matches: "Note a51136e1", "note:a51136e1", "Note: a51136e1"
     const SHORT_NOTE_RE = /\b(note)\s*[:：]?\s*([0-9a-f]{8})\b/gi;
 
+    // Markdown renders `backtick-wrapped` IDs as <code>ID</code>, and the code-segment
+    // skip in renderNoteLinks() hides them from the patterns above. Match "note <code>ID</code>"
+    // explicitly before the split.
+    const CODE_UUID_NOTE_RE = /\b(note)\s*[:：]?\s*<code[^>]*>\s*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\s*<\/code>/gi;
+    const CODE_SHORT_NOTE_RE = /\b(note)\s*[:：]?\s*<code[^>]*>\s*([0-9a-f]{8})\s*<\/code>/gi;
+
     // Cache: short prefix → full noteId (populated on successful API fetches)
     const resolvedIds = {};
 
@@ -34,6 +40,18 @@
      */
     function renderNoteLinks(escapedHtml) {
         if (!escapedHtml) return escapedHtml;
+
+        // Phase 0: "note <code>fullUUID</code>" → chip placeholder (consumes the <code> wrapper)
+        escapedHtml = escapedHtml.replace(CODE_UUID_NOTE_RE, (match, noteWord, uuid) => {
+            const short = uuid.substring(0, 8);
+            resolvedIds[short] = uuid;
+            return queueChip(uuid, short);
+        });
+        // Phase 0b: "note <code>shortId</code>" → chip placeholder
+        escapedHtml = escapedHtml.replace(CODE_SHORT_NOTE_RE, (match, noteWord, shortId) => {
+            const fullId = resolvedIds[shortId] || shortId;
+            return queueChip(fullId, shortId);
+        });
 
         // Split HTML into code/non-code segments to avoid transforming inside <code>/<pre>
         const parts = escapedHtml.split(/(<code[\s>][\s\S]*?<\/code>|<pre[\s>][\s\S]*?<\/pre>)/gi);


### PR DESCRIPTION
## Problem
Hank sent a screenshot showing \`note \`01ccb36a\`\` rendered as plain monospace code, not as the tappable Note chip that \`NoteLinkRender\` is supposed to produce.

## Root cause
1. Bot message goes through \`marked.parse()\` + DOMPurify — backticks around the ID become \`<code>01ccb36a</code>\`.
2. \`renderNoteLinks()\` splits the HTML on \`<code>/<pre>\` tags and skips the inside segments to avoid corrupting real code snippets.
3. The existing patterns (\`note <id>\`) look for keyword + ID *adjacent*. After the split, "note " and "<code>01ccb36a</code>" sit on opposite sides of the boundary, so the regex never sees them as one unit → no chip.

## Fix
Add a **Phase 0** pass before the split that matches \`note <code>ID</code>\` explicitly (short 8-hex and full UUID variants). The whole sequence — keyword + code wrapper + ID — becomes a single chip placeholder. Phase 1/2 keep handling unwrapped IDs.

## Regex verified
Node test shows positive matches for \`note <code>...</code>\`, \`Note: <code>...</code>\`, \`note：<code>...</code>\`, and \`<code class=\"language-xxx\">\`. Negative tests confirm no false positives on \`<code>\` alone, \`not <code>...\`, \`anote <code>...\`, 7-hex IDs, or 9-hex IDs.

## Test plan
- [x] Offline regex verification — positive + negative cases pass
- [ ] Send a chat message containing \`see note \\\`01ccb36a\\\`\` on production and confirm chip renders with document icon + click opens note preview modal
- [ ] Regression: messages without backticks (\`see note 01ccb36a\`) still match via Phase 2

## Scope note
\`EntityLinkRender\` (card/skill/rule/etc.) has the same structural bug — cards in backticks also fail to chip. **Intentionally not included here** to keep the fix scoped to the user-reported issue. Follow-up PR will extract the pattern into a shared helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)