### PR TITLE
fix(chat): render note modal content as Markdown when html_content has no tags

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -5010,14 +5010,20 @@
 
                 idEl.textContent = (resp.noteId || resolvedId).substring(0, 8);
 
-                // Render content — support HTML or Markdown
+                // Render content — support HTML or Markdown.
+                // /note/add writes plain/markdown text into html_content, so if we detect
+                // no HTML tags in htmlContent, parse it as markdown too.
                 let html = '';
+                const renderAsMarkdown = (src) => typeof marked !== 'undefined'
+                    ? marked.parse(src)
+                    : src.replace(/\n/g, '<br>');
                 if (resp.htmlContent) {
-                    html = resp.htmlContent;
+                    // Require a proper tag (name followed by space/>//>) so that autolinks
+                    // like <https://example.com> aren't mis-detected as HTML.
+                    const hasHtmlTags = /<\/?[a-z][\w-]*(?:\s|>|\/>)/i.test(resp.htmlContent);
+                    html = hasHtmlTags ? resp.htmlContent : renderAsMarkdown(resp.htmlContent);
                 } else if (resp.markdownContent) {
-                    html = typeof marked !== 'undefined'
-                        ? marked.parse(resp.markdownContent)
-                        : resp.markdownContent.replace(/\n/g, '<br>');
+                    html = renderAsMarkdown(resp.markdownContent);
                 } else {
                     html = '<em>Empty note</em>';
                 }


### PR DESCRIPTION
## Problem
Hank opened a note via the chip and the body showed raw markdown (literal \`#\`, \`-\`, \`**\`) instead of rendered headings, bullets, and bold. \"純文字檔對於人類來說很難辨讀.\"

## Root cause
- \`POST /api/mission/note/add\` (used by bot-created notes) writes the user's content directly into the \`note_pages.html_content\` column — no conversion, no markdown parse (\`mission.js:716-720\`).
- \`GET /api/mission/note/page\` returns that column as \`htmlContent\`.
- \`openNoteModal\` in \`portal/chat.html\` branched \"if htmlContent, innerHTML it verbatim; else markdownContent → marked.parse()\". Since markdown notes are stored in \`html_content\`, they never took the markdown branch.

## Fix
Frontend-only, minimal diff in \`portal/chat.html\`:
- When \`htmlContent\` is present, sniff for an actual HTML tag (name followed by whitespace / \`>\` / \`/>\`).
- No tag → treat as markdown → marked.parse() → DOMPurify.
- Has a tag → keep the existing HTML path.

The tag shape is strict enough that markdown autolinks (\`<https://...>\`, \`<foo@bar.com>\`) and stray \`<\` characters (\"2 < 3\") don't false-positive as HTML.

## Why frontend, not backend
- Legacy notes already live in \`html_content\` with markdown; a backend-only fix wouldn't help them without a DB migration.
- The frontend heuristic fixes the legacy rows immediately. If we later normalize the write path too, this code keeps working.

## Verification
14-case Node regex test covers real tags (open/close/self-close/attrs), autolinks, markdown, plain text. All pass.

## Test plan
- [ ] Open a markdown-body note via chip → see rendered headings/lists/bold (primary case)
- [ ] Open a truly-HTML-saved note (edited via \`PUT /note/page\` with \`htmlContent\`) → still renders as HTML
- [ ] Open a note whose body contains \`<https://example.com>\` autolink → renders as a link, not as raw angle brackets
- [ ] Empty note → shows \"Empty note\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)