### PR TITLE
fix(dashboard): touch-action:none on org chart nodes for mobile drag

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -1186,6 +1186,7 @@
             position: relative;
             min-width: 80px;
             user-select: none;
+            touch-action: none;
         }
         .org-node.user-node {
             background: var(--card);
@@ -1218,7 +1219,7 @@
             text-overflow: ellipsis;
             white-space: nowrap;
         }
-        .org-node.dragging { opacity: 0.4; transform: scale(0.95); }
+        .org-node.dragging { opacity: 0.4; transform: scale(0.95); touch-action: none; }
         .org-node.org-drop-target {
             outline: 2px solid var(--primary);
             outline-offset: 4px;


### PR DESCRIPTION
## Problem

Org chart drag-drop has touchstart/touchmove/touchend handlers in JS, but the `.org-node` CSS class is missing `touch-action: none`. On Android/iOS WebViews this lets the browser's default scroll/zoom gestures intercept touches during drag, so dragging an entity onto another often scrolls the page instead of moving the node.

## Fix

One-line CSS addition:
- Added `touch-action: none;` to `.org-node`
- Also added it to `.org-node.dragging` so the actively dragged node is explicitly opted out during the drag

Total diff: +2 lines, -1 line in `backend/public/portal/dashboard.html`.

## Test plan

- [ ] Open Android WebView Dashboard -> tap 🏢 Org Chart tab
- [ ] Long-press + drag an entity node onto another node
- [ ] Page must NOT scroll during drag
- [ ] Drop target highlights correctly and parent change persists
- [ ] Repeat on iOS WebView
- [ ] Desktop behavior (mouse drag) unchanged