### PR TITLE
fix(chat): render Card/Skill/Rule/Listing/Exam/Contract chips when ID is in backticks

### DIFF
--- a/backend/public/portal/shared/entity-link-render.js
+++ b/backend/public/portal/shared/entity-link-render.js
@@ -38,6 +38,16 @@
         '\\b(' + TYPE_NAMES + ')\\s*[:：]?\\s*([0-9a-f]{8})\\b', 'gi'
     );
 
+    // Markdown renders `backtick-wrapped` IDs as <code>ID</code>, and the code-segment
+    // skip in renderEntityLinks() hides them from the patterns above. Match
+    // "<type> <code>ID</code>" explicitly before the split.
+    const CODE_FULL_RE = new RegExp(
+        '\\b(' + TYPE_NAMES + ')\\s*[:：]?\\s*<code[^>]*>\\s*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\s*</code>', 'gi'
+    );
+    const CODE_SHORT_RE = new RegExp(
+        '\\b(' + TYPE_NAMES + ')\\s*[:：]?\\s*<code[^>]*>\\s*([0-9a-f]{8})\\s*</code>', 'gi'
+    );
+
     // Placeholder system (same approach as note-link-render)
     const pendingChips = [];
 
@@ -71,6 +81,16 @@
      */
     function renderEntityLinks(escapedHtml) {
         if (!escapedHtml) return escapedHtml;
+
+        // Phase 0: "<type> <code>fullUUID</code>" → chip placeholder (consumes the <code> wrapper)
+        escapedHtml = escapedHtml.replace(CODE_FULL_RE, (match, type, uuid) => {
+            const short = uuid.substring(0, 8);
+            return queueChip(type.toLowerCase(), uuid, short);
+        });
+        // Phase 0b: "<type> <code>shortId</code>" → chip placeholder
+        escapedHtml = escapedHtml.replace(CODE_SHORT_RE, (match, type, shortId) => {
+            return queueChip(type.toLowerCase(), shortId, shortId);
+        });
 
         // Split by code/pre to skip code blocks
         const parts = escapedHtml.split(/(<code[\s>][\s\S]*?<\/code>|<pre[\s>][\s\S]*?<\/pre>)/gi);


### PR DESCRIPTION
## Summary
- Mirrors PR #1799 Phase 0 pattern for the 6 entity types handled by `shared/entity-link-render.js` (card, skill, rule, listing, exam, contract)
- Previously: `` `card 01ccb36a` `` → Markdown rendered `<code>01ccb36a</code>` → skipped by the code-segment filter → no chip
- Now: `CODE_FULL_RE` + `CODE_SHORT_RE` run before the split, consuming the `<code>...</code>` wrapper into a placeholder so Phase 1/2 can't double-match

## Test plan
- [ ] Send `` Card `01ccb36a` `` in chat → blue Card chip renders
- [ ] Send `` Skill: `a51136e1` `` in chat → purple Skill chip renders
- [ ] Send `` Rule：`01ccb36a-...-f9b2d0731b5a` `` (Chinese colon, full UUID) → red Rule chip renders
- [ ] Plain `Card 01ccb36a` (no backticks) still renders via Phase 1/2 (regression check)
- [ ] Triple-backtick code block with `card 01ccb36a` inside → NOT rendered as chip (code fence still wins)
- [ ] Mixed-case `CARD <code>01ccb36a</code>` → chip renders (case-insensitive flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)