### PR TITLE
feat(chat): group consecutive photos into grid bubble (LINE/WhatsApp style)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -917,6 +917,52 @@
 
         .chat-photo:hover { opacity: 0.9; }
 
+        /* Multi-image grid bubble (WhatsApp/LINE/Telegram style).
+           Caps bubble at ~280px so 3~9 images never stretch the chat feed vertically. */
+        .chat-photo-grid {
+            display: grid;
+            gap: 2px;
+            margin-top: 6px;
+            border-radius: 8px;
+            overflow: hidden;
+            max-width: 280px;
+        }
+        .chat-photo-grid.count-2 { grid-template-columns: 1fr 1fr; }
+        .chat-photo-grid.count-3 { grid-template-columns: 1fr 1fr 1fr; }
+        .chat-photo-grid.count-4 { grid-template-columns: 1fr 1fr; }
+        .chat-photo-grid.count-5,
+        .chat-photo-grid.count-6,
+        .chat-photo-grid.count-7,
+        .chat-photo-grid.count-8,
+        .chat-photo-grid.count-9 { grid-template-columns: 1fr 1fr 1fr; }
+        .chat-photo-grid-cell {
+            position: relative;
+            width: 100%;
+            aspect-ratio: 1 / 1;
+            overflow: hidden;
+            background: rgba(0,0,0,0.05);
+            cursor: pointer;
+        }
+        .chat-photo-grid-cell img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+            display: block;
+        }
+        .chat-photo-grid-cell:hover img { opacity: 0.9; }
+        .chat-photo-grid-more {
+            position: absolute;
+            inset: 0;
+            background: rgba(0,0,0,0.5);
+            color: #fff;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 20px;
+            font-weight: 600;
+            pointer-events: none;
+        }
+
         .chat-inline-img {
             max-width: 280px;
             max-height: 240px;
@@ -3361,6 +3407,51 @@
             return grouped;
         }
 
+        // Consecutive photo messages from the same sender within 60s are rendered
+        // as ONE grid bubble (LINE/WhatsApp style) so multi-image uploads don't
+        // stretch the feed vertically. The LAST message in the run keeps its
+        // metadata (timestamp / reactions / receipt); earlier ones are skipped.
+        // Only pure photo messages (no meaningful text) are grouped — if the user
+        // wrote a caption, it stays with its own photo so context isn't lost.
+        function groupPhotoRuns(messages) {
+            const PHOTO_RUN_WINDOW_MS = 60 * 1000;
+            const isGroupablePhoto = (m) => (
+                m && m.media_type === 'photo' && m.media_url
+                && (!m.text || m.text === '[Photo]' || m.text === '[照片]')
+            );
+            const senderSig = (m) => {
+                if (m.is_from_user) return 'u:' + (m._groupedEntityIds ? m._groupedEntityIds.slice().sort().join(',') : (m.entity_id ?? ''));
+                if (m.is_from_bot) return 'b:' + (m.entity_id ?? '') + ':' + (m.source || '');
+                return 'o:' + (m.source || '') + ':' + (m.entity_id ?? '');
+            };
+
+            for (let i = 0; i < messages.length; i++) {
+                if (!isGroupablePhoto(messages[i])) continue;
+
+                // Collect a run starting at i
+                const run = [messages[i]];
+                const sig = senderSig(messages[i]);
+                let lastTs = new Date(messages[i].created_at).getTime();
+                let j = i + 1;
+                while (j < messages.length && isGroupablePhoto(messages[j]) && senderSig(messages[j]) === sig) {
+                    const ts = new Date(messages[j].created_at).getTime();
+                    if (ts - lastTs > PHOTO_RUN_WINDOW_MS) break;
+                    run.push(messages[j]);
+                    lastTs = ts;
+                    j++;
+                }
+
+                if (run.length >= 2) {
+                    const urls = run.map(m => m.media_url);
+                    // Mark all but the last as skipped; attach grid to the last.
+                    for (let k = 0; k < run.length - 1; k++) run[k]._photoGroupSkip = true;
+                    run[run.length - 1]._photoGroupUrls = urls;
+                }
+                i = j - 1; // skip past the run
+            }
+            return messages;
+        }
+
         // ── Cross-Device Code Resolution ──
         function getXDeviceLabel(code) {
             if (myPublicCodeMap[code]) return myPublicCodeMap[code].label;
@@ -3438,7 +3529,7 @@
                 return;
             }
 
-            const displayMessages = groupBroadcastMessages(filtered);
+            const displayMessages = groupPhotoRuns(groupBroadcastMessages(filtered));
 
             // Helper: get sender key for grouping
             function senderKey(m) {
@@ -3472,7 +3563,14 @@
             }
 
             container.innerHTML = displayMessages.map((msg, idx) => {
-                const prev = idx > 0 ? displayMessages[idx - 1] : null;
+                // Skip earlier messages in a photo run — the last one renders the grid.
+                if (msg._photoGroupSkip) return '';
+                // Walk back over skipped photo-run entries so date separators
+                // and isGrouped detection compare against the previous *rendered* message.
+                let prev = null;
+                for (let p = idx - 1; p >= 0; p--) {
+                    if (!displayMessages[p]._photoGroupSkip) { prev = displayMessages[p]; break; }
+                }
                 const currTime = new Date(msg.created_at).getTime();
                 const prevTime = prev ? new Date(prev.created_at).getTime() : 0;
                 const gap = currTime - prevTime;
@@ -3496,7 +3594,21 @@
 
                 // Build media content
                 let mediaHtml = '';
-                if (msg.media_type === 'photo' && msg.media_url) {
+                if (Array.isArray(msg._photoGroupUrls) && msg._photoGroupUrls.length >= 2) {
+                    // Multi-image grid bubble
+                    const urls = msg._photoGroupUrls;
+                    const visibleCount = Math.min(urls.length, 9);
+                    const overflow = urls.length - visibleCount;
+                    const cells = urls.slice(0, visibleCount).map((url, i) => {
+                        const showMore = overflow > 0 && i === visibleCount - 1;
+                        const moreOverlay = showMore ? `<div class="chat-photo-grid-more">+${overflow}</div>` : '';
+                        return `<div class="chat-photo-grid-cell" onclick="openLightbox('${escapeHtml(url)}')">`
+                            + `<img class="chat-photo" src="${escapeHtml(url)}" alt="Photo" loading="lazy" onerror="this.style.display='none'">`
+                            + moreOverlay
+                            + `</div>`;
+                    }).join('');
+                    mediaHtml = `<div class="chat-photo-grid count-${visibleCount}">${cells}</div>`;
+                } else if (msg.media_type === 'photo' && msg.media_url) {
                     const backupSrc = msg.backup_url ? escapeHtml(msg.backup_url) : '';
                     const onerrorFallback = backupSrc
                         ? `onerror="if(!this.dataset.retried){this.dataset.retried='1';this.src='${backupSrc}'}else{this.style.display='none'}"`


### PR DESCRIPTION
## Summary
- Closes kanban card 389a90a5 (多圖上傳聊天 UI)
- Consecutive photo messages from the same sender within 60s now render as ONE bubble with a CSS grid of uniform thumbnails, instead of N separate 240x200 bubbles stacking vertically
- Max 9 visible; the 10th+ collapses into a "+N" overlay on the 9th cell
- Tap any cell → existing lightbox + swipe (no lightbox changes)

Scope: `portal/chat.html` only. Since Android + iOS chat are WebView-hosted (since v1.0.70 commit `0bbadbd4`), this one-file change ships across all three platforms simultaneously with no native code needed — the kanban description mentioning `ChatActivity ViewHolder + Glide` / `expo-image` is outdated.

## Implementation
- `groupPhotoRuns(messages)` after `groupBroadcastMessages`: walks the display list, clusters runs of photo-only messages from the same sender within a 60s rolling window, marks earlier ones with `_photoGroupSkip` and attaches `_photoGroupUrls` to the last.
- Captioned photos (user text present) stay with their image so meaningful context isn't lost. `[Photo]` / `[照片]` auto-captions are treated as empty.
- Render loop: skip `_photoGroupSkip`; walk back past skipped entries when computing `prev` so date separators + isGrouped detection remain correct for the grid-bearing message.
- CSS `.chat-photo-grid` with `grid-template-columns` based on count (2/3/4/9), aspect-ratio 1/1 cells, `+N` overlay on overflow.
- Each cell `<img>` keeps `class="chat-photo"` so the existing lightbox collector picks them up for swipe nav.

## Test plan
- [ ] Upload 2 photos at once → 2-column grid bubble, both tappable, lightbox shows `1/2` and `2/2`
- [ ] Upload 4 photos → 2x2 grid, all 4 tappable
- [ ] Upload 9 photos → 3x3 grid, no overflow overlay
- [ ] Upload 12 photos → 9 visible, 9th cell shows "+3" overlay; lightbox can't reach images 10-12 (expected, LINE-style)
- [ ] Upload 2 photos with a caption on the first → first photo stays solo with caption, subsequent photos group (if 2+)
- [ ] Upload 1 photo → single 240x200 bubble (no grid, regression check)
- [ ] Text reply between photo uploads → break the run cleanly, each side renders its own bubble
- [ ] Two different senders sending photos back-to-back → DO NOT merge across senders
- [ ] Photo group at end-of-day / midnight → date separator correctly attaches to first message of next day (not swallowed by skipped photos)
- [ ] On Android WebView (v1.0.71) and iOS WebView: grid width ≤ 280px, doesn't overflow chat bubble

🤖 Generated with [Claude Code](https://claude.com/claude-code)