### PR TITLE
chore(fcm): add diagnostic logs to sendFcm silent paths

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -14361,13 +14361,19 @@ try {
 }
 
 async function sendFcm(deviceId, notif) {
-    if (!firebaseAdmin) return;
+    if (!firebaseAdmin) {
+        console.log('[FCM] skip: firebaseAdmin not initialized', { deviceId });
+        return;
+    }
+    const device = devices[deviceId];
+    const token = device?.fcmToken;
+    if (!token) {
+        console.log('[FCM] skip: no fcmToken for device', { deviceId, deviceExists: !!device, category: notif?.category });
+        return;
+    }
+    const tokenPrefix = token.slice(0, 12);
     try {
-        const device = devices[deviceId];
-        const token = device?.fcmToken;
-        if (!token) return;
-
-        await firebaseAdmin.messaging().send({
+        const resp = await firebaseAdmin.messaging().send({
             token,
             data: {
                 title: notif.title || '',
@@ -14383,12 +14389,13 @@ async function sendFcm(deviceId, notif) {
                 }
             }
         });
+        console.log('[FCM] sent OK', { deviceId, tokenPrefix, category: notif?.category, messageId: resp });
     } catch (e) {
         if (e.code === 'messaging/registration-token-not-registered') {
             delete devices[deviceId]?.fcmToken;
             chatPool.query('UPDATE devices SET fcm_token = NULL WHERE device_id = $1', [deviceId]).catch(() => {});
         }
-        console.warn('[FCM] Send failed:', e.message);
+        console.warn('[FCM] Send failed:', { deviceId, tokenPrefix, code: e.code, message: e.message });
     }
 }
 


### PR DESCRIPTION
## Summary
- Make both silent early-return paths in \`sendFcm()\` log the reason — currently they are 100% invisible from Railway logs, which blocks diagnosing the v1.0.71 \"app closed, no notification\" issue.
- Log successful sends with a token-prefix + messageId so we can confirm FCM actually hit Google's servers (previously success was also silent).
- Add \`code\` field to the failure log for easier grepping.

## Why
Diagnosing FCM delivery to Hank's phone: the only thing the prior sendFcm logged was caught exceptions. When fcmToken was null (possible post-reinstall / post-token-expiry), the function returned instantly with no trace at all — indistinguishable from \"never called\" from the log perspective. This change makes every code path visible.

## Test plan
- [ ] After Railway deploy, fire speakTo between entities on test device
- [ ] Verify Railway logs show either \`[FCM] sent OK\` or \`[FCM] skip: no fcmToken\` (not silence)
- [ ] Confirm existing successful-send path still works (no regression in notification delivery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)