### PR TITLE
fix(fcm): self-heal token registration on every app launch (v1.0.72)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 77
-        versionName = "1.0.71"
+        versionCode = 78
+        versionName = "1.0.72"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/hank/clawlive/ClawApplication.kt
+++ b/app/src/main/java/com/hank/clawlive/ClawApplication.kt
@@ -2,10 +2,15 @@ package com.hank.clawlive
 
 import android.app.Application
 import android.content.Context
+import com.google.firebase.messaging.FirebaseMessaging
 import com.hank.clawlive.data.local.DeviceManager
+import com.hank.clawlive.data.remote.NetworkModule
 import com.hank.clawlive.data.remote.TelemetryHelper
 import com.hank.clawlive.debug.CrashLogManager
 import com.hank.clawlive.debug.FileTimberTree
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import timber.log.Timber
 import java.io.OutputStreamWriter
 import java.io.PrintWriter
@@ -48,7 +53,43 @@ class ClawApplication : Application() {
         // 5. Upload any pending crash logs from previous session
         uploadPendingCrashLogs()
 
+        // 6. Self-heal FCM token registration on every launch.
+        // onNewToken() only fires when the token changes (install / clear-data / reinstall).
+        // If the very first registration failed (e.g. before deviceSecret was provisioned),
+        // the device would stay unregistered forever. Pulling the current token at startup
+        // and POSTing it unconditionally fixes that class of silent failures.
+        refreshAndRegisterFcmToken()
+
         Timber.i("ClawApplication initialized")
+    }
+
+    private fun refreshAndRegisterFcmToken() {
+        val dm = DeviceManager.getInstance(this)
+        if (dm.deviceId.isBlank() || dm.deviceSecret.isBlank()) {
+            Timber.d("[FCM] Skipping startup token registration — device not provisioned yet")
+            return
+        }
+        FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
+            if (!task.isSuccessful) {
+                Timber.w(task.exception, "[FCM] Failed to fetch token at startup")
+                return@addOnCompleteListener
+            }
+            val token = task.result ?: return@addOnCompleteListener
+            CoroutineScope(Dispatchers.IO).launch {
+                try {
+                    NetworkModule.api.registerFcmToken(
+                        mapOf(
+                            "deviceId" to dm.deviceId,
+                            "deviceSecret" to dm.deviceSecret,
+                            "fcmToken" to token
+                        )
+                    )
+                    Timber.d("[FCM] Startup token registered: ${token.take(20)}...")
+                } catch (e: Exception) {
+                    Timber.e(e, "[FCM] Startup token register failed")
+                }
+            }
+        }
     }
 
     /**

--- a/backend/index.js
+++ b/backend/index.js
@@ -633,7 +633,7 @@ function ensureOneEmptySlot(device) {
 
 // Latest app version - update this with each release
 // Bot will warn users if their app version is older than this
-const LATEST_APP_VERSION = "1.0.71";
+const LATEST_APP_VERSION = "1.0.72";
 const FORCE_UPDATE_BELOW = null; // Set to version string (e.g. "1.0.30") to force-update anything below
 const APP_RELEASE_NOTES = process.env.APP_RELEASE_NOTES || null;
 


### PR DESCRIPTION
## Summary
- Backend diagnostic logs from PR #1805 revealed that Hank's device had \`device.fcmToken = NULL\` — hence \"app closed, no FCM notification\" symptom on v1.0.71.
- Root cause: Android \`ClawFcmService\` only registered the FCM token inside \`onNewToken()\`, which fires exclusively on token change. If the first invocation raced the device provisioning flow and failed silently, the device would stay un-registered forever.
- Fix: in \`ClawApplication.onCreate()\`, fetch the current token via \`FirebaseMessaging.getInstance().token\` and POST it to \`/api/device/fcm-token\` on every app launch. Idempotent (backend just \`UPDATE\`s the row), safe to call repeatedly, self-heals any prior missed registration.
- Bumps versionCode 77→78, versionName 1.0.71→1.0.72, and \`LATEST_APP_VERSION\` so existing v1.0.71 users see the update banner pointing at the fixed release.

## Why
Without this, users who hit the first-install race have NO way to recover from in-app (would need to clear data or reinstall, which loses their device credentials).

## Test plan
- [ ] After build, install v1.0.72 on Hank's device (or any device with token currently missing)
- [ ] Watch Railway logs for \`[FCM] sent OK\` on next bot message/speakTo, instead of \`[FCM] skip: no fcmToken\`
- [ ] Verify phone receives FCM notification while app is force-closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)