### PR TITLE
chore(fcm): always log /api/device/fcm-token registration

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -14329,18 +14329,23 @@ app.post('/api/device/fcm-token', (req, res) => {
         return res.status(401).json({ success: false, error: 'Invalid credentials' });
     }
 
+    const prevToken = device.fcmToken || device.apnsToken;
+    const prevPrefix = prevToken ? prevToken.slice(0, 12) : 'none';
+    const newPrefix = resolvedToken.slice(0, 12);
+    const changed = prevToken !== resolvedToken;
+
     if (resolvedPlatform === 'apns') {
         // iOS APNs token
         device.apnsToken = resolvedToken;
         chatPool.query('ALTER TABLE devices ADD COLUMN IF NOT EXISTS apns_token TEXT').catch(() => {});
         chatPool.query('UPDATE devices SET apns_token = $1 WHERE device_id = $2', [resolvedToken, deviceId]).catch(() => {});
-        if (process.env.DEBUG === 'true') console.log(`[PUSH] APNs token registered for device ${deviceId}`);
+        console.log(`[PUSH] APNs token registered`, { deviceId, prevPrefix, newPrefix, changed });
     } else {
         // Android FCM token (default)
         device.fcmToken = resolvedToken;
         chatPool.query('ALTER TABLE devices ADD COLUMN IF NOT EXISTS fcm_token TEXT').catch(() => {});
         chatPool.query('UPDATE devices SET fcm_token = $1 WHERE device_id = $2', [resolvedToken, deviceId]).catch(() => {});
-        if (process.env.DEBUG === 'true') console.log(`[PUSH] FCM token registered for device ${deviceId}`);
+        console.log(`[PUSH] FCM token registered`, { deviceId, prevPrefix, newPrefix, changed });
     }
 
     res.json({ success: true, platform: resolvedPlatform });


### PR DESCRIPTION
## Summary
- Unconditionally log \`[PUSH] FCM/APNs token registered\` on every call to \`/api/device/fcm-token\` (previously DEBUG-gated, which hid the registration signal in prod)
- Emit prev/new token 12-char prefix + \`changed\` flag so we can verify whether a given app launch actually rotated the token

## Why
We need this to validate v1.0.72's startup self-heal lands token into DB. Without it, we only see the _consequences_ of registration (sendFcm succeeding), not the registration event itself — making it impossible to diagnose \"startup-register fired but backend rejected\" vs \"never fired at all\".

## Test plan
- [ ] Deploy, then watch Railway logs when a device with v1.0.72 opens: expect \`[PUSH] FCM token registered { deviceId, prevPrefix, newPrefix, changed: true/false }\`
- [ ] Confirm no perf impact (single log line per cold start, already trivially rate-limited by app launches)

🤖 Generated with [Claude Code](https://claude.com/claude-code)