### PR TITLE
fix(fcm): include title/body in android.notification so killed-app push isn't blank

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -14377,23 +14377,30 @@ async function sendFcm(deviceId, notif) {
         return;
     }
     const tokenPrefix = token.slice(0, 12);
+    // Silent categories handled by the app's FCM service (start TtsService,
+    // fetch GPS, etc). Sending an android.notification for these would make
+    // the OS display a visible tray notification when the app is killed.
+    const silent = notif.category === 'tts' || notif.category === 'location_request';
+    const fcmMessage = {
+        token,
+        data: {
+            title: notif.title || '',
+            body: notif.body || '',
+            category: notif.category || '',
+            link: notif.link || ''
+        },
+        android: { priority: 'high' }
+    };
+    if (!silent) {
+        fcmMessage.android.notification = {
+            title: notif.title || '',
+            body: notif.body || '',
+            channelId: 'eclaw_chat',
+            sound: 'default'
+        };
+    }
     try {
-        const resp = await firebaseAdmin.messaging().send({
-            token,
-            data: {
-                title: notif.title || '',
-                body: notif.body || '',
-                category: notif.category || '',
-                link: notif.link || ''
-            },
-            android: {
-                priority: 'high',
-                notification: {
-                    channelId: 'eclaw_chat',
-                    sound: 'default'
-                }
-            }
-        });
+        const resp = await firebaseAdmin.messaging().send(fcmMessage);
         console.log('[FCM] sent OK', { deviceId, tokenPrefix, category: notif?.category, messageId: resp });
     } catch (e) {
         if (e.code === 'messaging/registration-token-not-registered') {


### PR DESCRIPTION
## Summary
- Root cause of blank FCM notification when APP is force-closed: `sendFcm()` built a hybrid message (data + android.notification) with `channelId` and `sound` but **no title/body**. When the APP is killed, Android displays `android.notification` directly (bypassing `onMessageReceived()`), producing an empty tray notification.
- Fix: for visible categories, copy `title`/`body` into `android.notification` so the OS can render a usable notification in the killed-app case.
- Silent categories (`tts`, `location_request`) stay data-only so `ClawFcmService` can start services without a spurious visible notification.

## Repro / Evidence
- Device: 480def4c-2183-4d8e-afd0-b131ae89adcc on v1.0.72 (after the self-heal from PR #1806).
- Railway showed `[FCM] sent OK` ; phone received the notification (big win vs previous `skip: no fcmToken`), but the tray card's title/body were blank.

## Test plan
- [ ] After Railway deploy, fire a speakTo when the target APP is force-closed → notification should now show sender/title + body.
- [ ] With APP in foreground, same speakTo should still show custom in-app notification via `onMessageReceived()` (unchanged path — it reads `data.title`/`data.body`).
- [ ] Silent categories (`tts`, `location_request`) should **not** display a notification when APP is force-closed (data-only, no android.notification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)