### PR TITLE
fix(db): hydrate fcm_token/apns_token from PG on boot

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -692,6 +692,8 @@ async function loadAllDevices() {
                 deviceSecret: row.device_secret,
                 createdAt: parseInt(row.created_at),
                 nextEntityId: parseInt(row.next_entity_id) || 1,
+                fcmToken: row.fcm_token || null,
+                apnsToken: row.apns_token || null,
                 entities: {}
             };
         }


### PR DESCRIPTION
## Summary
- `loadAllDevices()` in `backend/db.js` selected every column from the `devices` table but never mapped `fcm_token` / `apns_token` back into the in-memory device object.
- Every server restart (Railway auto-deploy included) silently wiped push tokens for every device until each app was re-opened and re-registered via the v1.0.72 startup self-heal. Any device that wasn't re-opened produced `[FCM] skip: no fcmToken` until its next launch.
- `saveDeviceData()` UPSERT never touches these columns on existing rows, so PG always held the correct value — only the boot-time hydration was missing.

## Repro / Evidence
- After PR #1808 Railway deploy, diag v8 speakTo to device `480def4c-...` logged `[FCM] skip: no fcmToken for device` even though the same device received a (blank) notification from diag v7 minutes earlier, proving the token had been registered and then lost on restart.

## Test plan
- [ ] After Railway deploy, fire diag v9 speakTo to the same device **without** reopening the app. Expect `[FCM] sent OK` (not `skip`) because boot-hydration now restores the token.
- [ ] Reopen the app → v1.0.72 self-heal still posts `/api/device/fcm-token` → `[PUSH] FCM token registered { changed: false }` since PG value matches.
- [ ] Force-stop app, fire another speakTo → phone notification shows title + body (PR #1808 confirmed; this PR ensures it keeps working after every deploy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)