### PR TITLE
fix(kanban): generate card id app-side (unblock prod)

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -38,6 +38,7 @@ const _crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
 const safeEqual = require('./safe-equal');
+const { newCardId } = require('./entity-id');
 const { tKanban, statusLabel } = require('./i18n/kanban-notifications');
 
 // Cache device→language to avoid repeated lookups
@@ -438,12 +439,12 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
 
         try {
             const result = await pool.query(
-                `INSERT INTO kanban_cards (device_id, title, description, priority, status, assigned_bots, created_by, reviewer_entity_id, status_changed_at,
+                `INSERT INTO kanban_cards (id, device_id, title, description, priority, status, assigned_bots, created_by, reviewer_entity_id, status_changed_at,
                     is_automation, schedule_enabled, schedule_type, schedule_cron, schedule_run_at, schedule_timezone, schedule_next_run_at)
-                 VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8, NOW(),
-                    $9, $10, $11, $12, $13, $14, $15)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, NOW(),
+                    $10, $11, $12, $13, $14, $15, $16)
                  RETURNING *`,
-                [deviceId, title.trim(), description || '', cardPriority, cardStatus, JSON.stringify(bots), createdBy, reviewer,
+                [newCardId(), deviceId, title.trim(), description || '', cardPriority, cardStatus, JSON.stringify(bots), createdBy, reviewer,
                     finalAutomation, schedEnabled, schedType, schedCron, schedRunAt, schedTz, schedNextRunAt]
             );
 
@@ -1747,11 +1748,11 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
 
                     // Create child card (inherit reviewerEntityId from parent)
                     const childResult = await pool.query(
-                        `INSERT INTO kanban_cards (device_id, title, description, priority, status, assigned_bots, created_by,
+                        `INSERT INTO kanban_cards (id, device_id, title, description, priority, status, assigned_bots, created_by,
                             status_changed_at, stale_threshold_ms, done_retention_ms, parent_card_id, is_auto_generated, reviewer_entity_id)
-                         VALUES ($1, $2, $3, $4, 'todo', $5::jsonb, $6, NOW(), $7, $8, $9, true, $10)
+                         VALUES ($1, $2, $3, $4, $5, 'todo', $6::jsonb, $7, NOW(), $8, $9, $10, true, $11)
                          RETURNING *`,
-                        [card.device_id, childTitle, card.description || '', card.priority,
+                        [newCardId(), card.device_id, childTitle, card.description || '', card.priority,
                          JSON.stringify(bots), card.created_by,
                          card.stale_threshold_ms, card.done_retention_ms, card.id,
                          card.reviewer_entity_id || null]

--- a/backend/tests/jest/kanban-card.test.js
+++ b/backend/tests/jest/kanban-card.test.js
@@ -188,7 +188,7 @@ describe('POST /card — inline automation + schedule', () => {
         expect(res.status).toBe(200);
         // finalAutomation should be true due to recurring schedule
         const insertParams = mockQuery.mock.calls[0][1];
-        expect(insertParams[8]).toBe(true); // finalAutomation param
+        expect(insertParams[9]).toBe(true); // finalAutomation param (index shifted by +1 after adding id as $1)
     });
 
     it('rejects recurring schedule with missing cron', async () => {


### PR DESCRIPTION
## Summary
- PR #1812/#1813 schema migration silently left kanban_cards.id with no DEFAULT on prod. Every POST /api/mission/card returns \`null value in column id violates not-null constraint\`.
- Hotfix: use the existing \`newCardId()\` factory from entity-id.js to generate the prefixed id app-side, pass it explicitly in the INSERT.
- Defense-in-depth regardless of DB default state. Also a diagnostic — if insert now errors with \"invalid input syntax for type uuid\", we know the column is still UUID and the ALTER TYPE migration needs more work.

## Files
- backend/kanban.js — import newCardId; include id in both POST /card INSERT and automation child-spawner INSERT

## Test plan
- [x] CI green
- [ ] After Railway deploy: \`POST /api/mission/card\` succeeds and returns id matching \`card_[a-f0-9]{24}\`
- [ ] If it fails with a UUID-cast error, open another PR to fix the schema type

🤖 Generated with [Claude Code](https://claude.com/claude-code)