### PR TITLE
fix(android): CardHolder dashboard link forces view=orgchart

### DIFF
--- a/app/src/main/java/com/hank/clawlive/CardHolderActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/CardHolderActivity.kt
@@ -314,9 +314,14 @@ class CardHolderActivity : AppCompatActivity() {
             webViewClient = object : WebViewClient() {
                 override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
                     val url = request?.url?.toString() ?: return false
-                    // Keep community.html navigation inside the WebView
-                    if (url.contains("eclawbot.com")) return false
-                    // Open external links in browser
+                    if (url.contains("eclawbot.com")) {
+                        if (url.contains("/portal/dashboard.html") && !url.contains("view=orgchart")) {
+                            val separator = if (url.contains("?")) "&" else "?"
+                            view?.loadUrl("$url${separator}embed=1&view=orgchart")
+                            return true
+                        }
+                        return false
+                    }
                     try {
                         startActivity(android.content.Intent(android.content.Intent.ACTION_VIEW, Uri.parse(url)))
                     } catch (e: Exception) {


### PR DESCRIPTION
## Summary
- Intercept `dashboard.html` navigation inside `CardHolderActivity`'s WebView and inject `embed=1&view=orgchart`.
- Before this fix, tapping the portal nav "Dashboard" link from within 名片 tab showed both 實體總覽 and 組織架構 sub-tabs instead of org-chart-only.
- Desktop web behavior is untouched (fix is Android-side only).

## Symptoms (reported by Hank)
Screenshot showed dashboard sub-tabs `實體總覽 | 組織架構` visible after tapping into dashboard from the 名片 tab — expected org-chart-only embedded view.

## Root cause
`backend/public/portal/shared/nav.js` links to plain `dashboard.html` (no query params). `dashboard.html:1705` only activates `body.embedded-orgchart` when `?view=orgchart` is present. The `OrgChartBottomSheetFragment` entry point already passes the param — but the CardHolder in-WebView nav link did not.

## Test plan
- [ ] Build v1.0.73 APK and open 名片 tab → tap Dashboard from portal nav → verify only 組織架構 tree shows
- [ ] Verify btnDashboard → OrgChartBottomSheet still renders org-chart-only (unchanged flow)
- [ ] Desktop browser: open `/portal/dashboard.html` via nav → both sub-tabs still visible (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)