### PR TITLE
i18n(android): strings.xml zh-rCN — 16 missing keys

### DIFF
--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -841,4 +841,21 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="schedule_error_generic">Error: %s</string>
     <string name="schedule_failed_to_load">Failed to load: %s</string>
     <string name="schedule_operation_failed">Operation failed</string>
+    <string name="close">关闭</string>
+    <string name="developer_section_title">开发者</string>
+    <string name="ecoin_unit">e币</string>
+    <string name="org_chart_sheet_title">组织图</string>
+    <string name="settings_delete_account">删除账户</string>
+    <string name="settings_invite">邀请好友</string>
+    <string name="settings_my_rentals">我的租借</string>
+    <string name="settings_wallet">钱包</string>
+    <string name="topup_bonus_format"> (+%d%% 加赠)</string>
+    <string name="topup_tier_advanced">进阶</string>
+    <string name="topup_tier_format">%1$s — %2$s
+%3$s %4$s%5$s</string>
+    <string name="topup_tier_premium">尊享</string>
+    <string name="topup_tier_small">小额</string>
+    <string name="topup_tier_standard">标准</string>
+    <string name="topup_tier_starter">入门</string>
+    <string name="channel_api_manage_all">管理所有密钥 →</string>
 </resources>


### PR DESCRIPTION
## i18n(android): strings.xml zh-rCN — 16 missing keys

Added 16 missing strings for zh-rCN locale:

- channel_api_manage_all
- close
- developer_section_title
- ecoin_unit
- org_chart_sheet_title
- settings_delete_account
- settings_invite
- settings_my_rentals
- settings_wallet
- topup_bonus_format
- topup_tier_advanced
- topup_tier_format
- topup_tier_premium
- topup_tier_small
- topup_tier_standard
- topup_tier_starter

Translations sourced from zh-rTW baseline + simplified Chinese conventions.

Please ensure CI passes (Lint + Kotlin Unit Tests + Assemble Debug APK) before merge.