### PR TITLE
i18n(android): strings.xml ko — 16 missing keys

### DIFF
--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -839,4 +839,21 @@ GPS: 온디맨드만, 백그라운드 추적 없음, 서버 재시작 시 데이
     <string name="schedule_error_generic">Error: %s</string>
     <string name="schedule_failed_to_load">Failed to load: %s</string>
     <string name="schedule_operation_failed">Operation failed</string>
+    <string name="close">닫기</string>
+    <string name="developer_section_title">開発者</string>
+    <string name="ecoin_unit">e코인</string>
+    <string name="org_chart_sheet_title">조직도</string>
+    <string name="settings_delete_account">계정 삭제</string>
+    <string name="settings_invite">친구 초대</string>
+    <string name="settings_my_rentals">내 대여</string>
+    <string name="settings_wallet">지갑</string>
+    <string name="topup_bonus_format"> (+%d%% 보너스)</string>
+    <string name="topup_tier_advanced">고급</string>
+    <string name="topup_tier_format">%1$s — %2$s
+%3$s %4$s%5$s</string>
+    <string name="topup_tier_premium">프리미엄</string>
+    <string name="topup_tier_small">스몰</string>
+    <string name="topup_tier_standard">표준</string>
+    <string name="topup_tier_starter">스타터</string>
+    <string name="channel_api_manage_all">모든 키 관리 →</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -840,7 +840,7 @@ GPS: 온디맨드만, 백그라운드 추적 없음, 서버 재시작 시 데이
     <string name="schedule_failed_to_load">Failed to load: %s</string>
     <string name="schedule_operation_failed">Operation failed</string>
     <string name="close">닫기</string>
-    <string name="developer_section_title">開発者</string>
+    <string name="developer_section_title">개발자</string>
     <string name="ecoin_unit">e코인</string>
     <string name="org_chart_sheet_title">조직도</string>
     <string name="settings_delete_account">계정 삭제</string>


### PR DESCRIPTION
## i18n(android): strings.xml ko — 16 missing keys

Added 16 missing strings for Korean locale:

- channel_api_manage_all
- close
- developer_section_title
- ecoin_unit
- org_chart_sheet_title
- settings_delete_account
- settings_invite
- settings_my_rentals
- settings_wallet
- topup_bonus_format
- topup_tier_advanced
- topup_tier_format
- topup_tier_premium
- topup_tier_small
- topup_tier_standard
- topup_tier_starter

Translations reference: zh-rTW Chinese as tone baseline + Korean natural phrasing.

Please ensure CI passes (Lint + Kotlin Unit Tests + Assemble Debug APK) before merge.