### PR TITLE
fix(dashboard): lock to orgchart via document.referrer from community.html

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -1702,7 +1702,8 @@
 
         // --- Init ---
         window.addEventListener('DOMContentLoaded', async () => {
-            const __embeddedOrg = new URLSearchParams(window.location.search).get('view') === 'orgchart';
+            const __fromCommunity = /\/portal\/community\.html(?:$|[?#])/.test(document.referrer || '');
+            const __embeddedOrg = new URLSearchParams(window.location.search).get('view') === 'orgchart' || __fromCommunity;
             if (__embeddedOrg) document.body.classList.add('embedded-orgchart');
             renderNav('dashboard');
             if (typeof renderFooter === 'function') renderFooter();


### PR DESCRIPTION
## Summary
- Server-side fallback: when `document.referrer` is `/portal/community.html`, force `body.embedded-orgchart` class regardless of query params.
- Complements PR #1815 — no APK rebuild needed. Deploys to Railway, Hank's existing Android APK picks it up on next reload.

## Why
PR #1815 fixes it in `CardHolderActivity.kt` (Android-side intercept) but only takes effect after a fresh APK build. Hank wanted an immediate fix without waiting for Gradle/EAS.

## Effect
- Android CardHolder → portal nav Dashboard: ✅ lands in orgchart-only (via referer)
- Android btnDashboard → BottomSheet: ✅ unchanged (already had `?view=orgchart`)
- Desktop: clicking Dashboard from community.html ALSO locks to orgchart (minor behavior change, acceptable since community.html is primarily the app-embedded surface)
- Desktop: typing `/portal/dashboard.html` directly or navigating from other pages: ✅ unchanged (both tabs visible)

## Test plan
- [ ] Railway deploys the change
- [ ] Hank reloads dashboard from 名片 tab → sees org chart only
- [ ] Open `/portal/dashboard.html` directly in browser → still sees both tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)