### PR TITLE
fix(orgchart): lock embedded view — remove tab bar instead of hiding it

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -1703,7 +1703,11 @@
         // --- Init ---
         window.addEventListener('DOMContentLoaded', async () => {
             const __embeddedOrg = new URLSearchParams(window.location.search).get('view') === 'orgchart';
-            if (__embeddedOrg) document.body.classList.add('embedded-orgchart');
+            if (__embeddedOrg) {
+                document.body.classList.add('embedded-orgchart');
+                // Lock: remove tab bar entirely so it can't be re-enabled by JS
+                document.getElementById('dashTabs')?.remove();
+            }
             renderNav('dashboard');
             if (typeof renderFooter === 'function') renderFooter();
             const user = await checkAuth();
@@ -2853,6 +2857,8 @@
         let orgSaveTimer = null;
 
         function switchDashTab(tab) {
+            // Embedded orgchart mode: tab bar is removed, ignore any tab switch attempts
+            if (document.body.classList.contains('embedded-orgchart')) return;
             document.querySelectorAll('.dash-tab').forEach(t => t.classList.toggle('active', t.dataset.tab === tab));
             // Toggle entity grid + empty state
             const entityGrid = document.getElementById('entityGrid');


### PR DESCRIPTION
## fix(orgchart): lock embedded view — remove tab bar instead of hiding it

當 Android/iOS 用 WebView 開 ?view=orgchart 嵌入模式時，tab bar（Entities / Org Chart 切換鈕）原本只是 CSS display:none 隱藏，仍在 DOM 裡可被 JS 呼叫切換。

修正：
1. ?view=orgchart 時直接 `remove()` tab bar，徹底移除無法呼叫
2. `switchDashTab()` 加上 guard，embedded 模式下任何 tab 切換都被忽略

這樣 Android OrgChartBottomSheetFragment 嵌入 WebView 時，users 無法透過任何方式跳出 Org Chart 視圖。