### PR TITLE
fix(ui): swap dashboard grid icon → org-chart tree icon

### DIFF
--- a/app/src/main/res/drawable/ic_dashboard.xml
+++ b/app/src/main/res/drawable/ic_dashboard.xml
@@ -5,5 +5,5 @@
     android:viewportHeight="24">
     <path
         android:fillColor="#FFFFFF"
-        android:pathData="M3,13h8V3H3v10zM3,21h8v-6H3v6zM13,21h8V11h-8v10zM13,3v6h8V3h-8z"/>
+        android:pathData="M22,11V3h-7v3H9V3H2v8h7V8h2v10h4v3h7v-8h-7v3h-2V8h2v3z"/>
 </vector>


### PR DESCRIPTION
The btnDashboard (activity_main.xml) opens the org chart bottom sheet, but the icon was a 4-square dashboard grid — misleading.

Swapped to Material `account_tree` pathData (parent → children nodes). No layout/code changes.

**Note:** This is an Android drawable — requires APK rebuild to ship. Server-side cannot push this change.