### PR TITLE
fix(dashboard): harden orgchart embed lock — DOM remove + UA detect + guard

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -1703,8 +1703,12 @@
         // --- Init ---
         window.addEventListener('DOMContentLoaded', async () => {
             const __fromCommunity = /\/portal\/community\.html(?:$|[?#])/.test(document.referrer || '');
-            const __embeddedOrg = new URLSearchParams(window.location.search).get('view') === 'orgchart' || __fromCommunity;
-            if (__embeddedOrg) document.body.classList.add('embedded-orgchart');
+            const __isAndroidApp = /EClawAndroid/.test(navigator.userAgent || '');
+            const __embeddedOrg = new URLSearchParams(window.location.search).get('view') === 'orgchart' || __fromCommunity || __isAndroidApp;
+            if (__embeddedOrg) {
+                document.body.classList.add('embedded-orgchart');
+                document.getElementById('dashTabs')?.remove();
+            }
             renderNav('dashboard');
             if (typeof renderFooter === 'function') renderFooter();
             const user = await checkAuth();
@@ -2854,6 +2858,7 @@
         let orgSaveTimer = null;
 
         function switchDashTab(tab) {
+            if (document.body.classList.contains('embedded-orgchart') && tab !== 'orgchart') return;
             document.querySelectorAll('.dash-tab').forEach(t => t.classList.toggle('active', t.dataset.tab === tab));
             // Toggle entity grid + empty state
             const entityGrid = document.getElementById('entityGrid');


### PR DESCRIPTION
Follow-up to #1819 which Hank reported still shows both tabs in the Android WebView.

## Root cause
CSS `body.embedded-orgchart .dash-tabs { display: none !important }` relies on WebView receiving the updated HTML. WebView cache can serve pre-fix HTML indefinitely.

## Three-layer hard lock

1. **DOM removal**: `document.getElementById('dashTabs')?.remove()` — the tab bar is deleted, not hidden. No CSS dependency.
2. **UA detection**: If `navigator.userAgent` contains `EClawAndroid` (set by OrgChartBottomSheetFragment), treat as embedded even without query params.
3. **switchDashTab guard**: Early-returns when `.embedded-orgchart` is present and target !== `orgchart`. Catches any leftover event handlers.

## Why UA is the key fallback
The Android WebView already appends `EClawAndroid` in `OrgChartBottomSheetFragment.kt:65`. No APK rebuild needed — server-only deploy via Railway.

Closes the tab-leak reported in <!-- #kanban card_05cfc13a71676fc224240897 -->