### PR TITLE
feat(card-holder): add Edit action in card detail dialog

### DIFF
--- a/app/src/main/java/com/hank/clawlive/CardHolderActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/CardHolderActivity.kt
@@ -70,6 +70,7 @@ class CardHolderActivity : AppCompatActivity() {
 
     // Edit mode
     private var editMode = false
+    private var editToolbarBtn: ImageView? = null
 
     // Tab views
     private lateinit var tabLayout: TabLayout
@@ -143,6 +144,7 @@ class CardHolderActivity : AppCompatActivity() {
                 rebuildContent()
             }
         }
+        editToolbarBtn = editBtn
         toolbar.addView(title)
         toolbar.addView(editBtn)
         mainColumn.addView(toolbar)
@@ -1367,6 +1369,13 @@ class CardHolderActivity : AppCompatActivity() {
         AlertDialog.Builder(this, com.google.android.material.R.style.ThemeOverlay_Material3_MaterialAlertDialog)
             .setView(scroll)
             .setPositiveButton(android.R.string.ok, null)
+            .setNeutralButton(getString(R.string.action_edit)) { _, _ ->
+                if (!editMode) {
+                    editMode = true
+                    editToolbarBtn?.setColorFilter(Color.parseColor("#6C63FF"))
+                    rebuildContent()
+                }
+            }
             .create()
             .show()
     }


### PR DESCRIPTION
## Problem
The card holder has a pencil icon in the toolbar that toggles edit mode, but users tapping a card to view details had no path from 'view' to 'edit' — they had to dismiss the dialog and find the toolbar pencil.

This is the first PR for kanban card [7b7dd9e3] App 名片夾功能對齊 Web.

## Change
In `showMyCardDetailDialog`, replace the single OK button with OK + Edit (neutral). Tapping Edit:
1. Sets `editMode = true`
2. Syncs the toolbar pencil's color filter so its state matches
3. Rebuilds the cards list so the inline edit fields render

`editToolbarBtn` promoted to a class field so the dialog can update it.

## Scope
P1 — edit flow only. Follow-up PRs for 開始對話 / 面試 / 出租 actions will come separately per Hank's acceptance criteria.

## Testing
- [ ] Tap a 'My Card' from the holder → Edit button visible
- [ ] Tap Edit → dialog dismisses, toolbar pencil turns purple, card shows inline edit fields
- [ ] Tap toolbar pencil → editMode toggles back off

## Note
Requires APK rebuild to ship.