### PR TITLE
feat(card-holder): 開始對話 + 分享 actions on MyCard (Android + iOS)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/CardHolderActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/CardHolderActivity.kt
@@ -1333,8 +1333,44 @@ class CardHolderActivity : AppCompatActivity() {
                 text = card.publicCode
                 textSize = 12f
                 setTextColor(Color.parseColor("#6C63FF"))
-                setPadding(0, 0, 0, dp(12))
+                setPadding(0, 0, 0, dp(8))
             })
+
+            val shareUrl = "https://eclawbot.com/c/${card.publicCode}"
+            val actionRow = LinearLayout(this).apply {
+                orientation = LinearLayout.HORIZONTAL
+                setPadding(0, 0, 0, dp(12))
+            }
+            fun actionChip(label: String, onClick: () -> Unit): TextView = TextView(this).apply {
+                text = label
+                textSize = 12f
+                setTextColor(Color.parseColor("#6C63FF"))
+                background = GradientDrawable().apply {
+                    setColor(Color.parseColor("#1a1a3f"))
+                    cornerRadius = dp(6).toFloat()
+                }
+                setPadding(dp(12), dp(6), dp(12), dp(6))
+                val lp = LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.WRAP_CONTENT,
+                    LinearLayout.LayoutParams.WRAP_CONTENT
+                )
+                lp.marginEnd = dp(8)
+                layoutParams = lp
+                setOnClickListener { onClick() }
+            }
+            actionRow.addView(actionChip(getString(R.string.action_start_chat)) {
+                try {
+                    startActivity(android.content.Intent(android.content.Intent.ACTION_VIEW, Uri.parse(shareUrl)))
+                } catch (e: Exception) {
+                    Toast.makeText(this@CardHolderActivity, e.message ?: "", Toast.LENGTH_SHORT).show()
+                }
+            })
+            actionRow.addView(actionChip(getString(R.string.action_share_link)) {
+                val clip = getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+                clip.setPrimaryClip(ClipData.newPlainText("shareUrl", shareUrl))
+                Toast.makeText(this@CardHolderActivity, R.string.card_share_copied, Toast.LENGTH_SHORT).show()
+            })
+            layout.addView(actionRow)
         }
         if (!card.description.isNullOrEmpty()) {
             addDialogSection(layout, getString(R.string.card_holder_description), card.description)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -545,6 +545,9 @@ If you have any questions, please contact us via our official email.
     <string name="action_move_to_mission">➡️ Move to Mission</string>
     <string name="action_mark_done">✅ Mark Done</string>
     <string name="action_edit">✏️ Edit</string>
+    <string name="action_start_chat">💬 Start Chat</string>
+    <string name="action_share_link">🔗 Share</string>
+    <string name="card_share_copied">Share link copied</string>
     <string name="action_delete">🗑️ Delete</string>
     <string name="delete_confirm_title">Delete Confirmation</string>
     <string name="delete_confirm_message_format">Are you sure you want to delete "%s"?</string>

--- a/ios-app/app/(tabs)/cards.tsx
+++ b/ios-app/app/(tabs)/cards.tsx
@@ -11,6 +11,7 @@ import {
   ScrollView,
   RefreshControl,
   Clipboard,
+  Linking,
 } from 'react-native';
 import { useTheme } from 'react-native-paper';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -570,6 +571,21 @@ export default function CardsScreen() {
                     >
                       <Text style={styles.editBtnText}>{t('common.edit', 'Edit')}</Text>
                     </TouchableOpacity>
+                    <TouchableOpacity
+                      style={styles.chatBtn}
+                      onPress={() => Linking.openURL(`https://eclawbot.com/c/${c.publicCode}`)}
+                    >
+                      <Text style={styles.chatBtnText}>{t('cardHolder.startChat', '\u{1F4AC} Chat')}</Text>
+                    </TouchableOpacity>
+                    <TouchableOpacity
+                      style={styles.shareBtn}
+                      onPress={() => {
+                        Clipboard.setString(`https://eclawbot.com/c/${c.publicCode}`);
+                        Alert.alert('', t('cardHolder.shareCopied', 'Share link copied'));
+                      }}
+                    >
+                      <Text style={styles.shareBtnText}>{t('cardHolder.share', '\u{1F517} Share')}</Text>
+                    </TouchableOpacity>
                   </View>
                 </View>
               ))}
@@ -683,11 +699,15 @@ const styles = StyleSheet.create({
   myCardItem: { backgroundColor: '#1A1A2E', borderRadius: 12, borderWidth: 1, borderColor: '#333355', padding: 16, alignItems: 'center', width: 160 },
   myCardAvatar: { fontSize: 36, marginBottom: 6 },
   myCardName: { color: '#fff', fontSize: 14, fontWeight: '600', textAlign: 'center' },
-  myCardActions: { flexDirection: 'row', gap: 6, marginTop: 6 },
+  myCardActions: { flexDirection: 'row', flexWrap: 'wrap', justifyContent: 'center', gap: 6, marginTop: 6 },
   copyBtn: { borderWidth: 1, borderColor: '#333355', borderRadius: 4, paddingHorizontal: 10, paddingVertical: 3 },
   copyBtnText: { color: '#777', fontSize: 11 },
   editBtn: { borderWidth: 1, borderColor: '#6C63FF', borderRadius: 4, paddingHorizontal: 10, paddingVertical: 3 },
   editBtnText: { color: '#6C63FF', fontSize: 11 },
+  chatBtn: { borderWidth: 1, borderColor: '#10b981', borderRadius: 4, paddingHorizontal: 10, paddingVertical: 3 },
+  chatBtnText: { color: '#10b981', fontSize: 11 },
+  shareBtn: { borderWidth: 1, borderColor: '#333355', borderRadius: 4, paddingHorizontal: 10, paddingVertical: 3 },
+  shareBtnText: { color: '#aaa', fontSize: 11 },
   // Recent
   recentItem: { flexDirection: 'row', alignItems: 'center', gap: 12, padding: 12, backgroundColor: '#1A1A2E', borderRadius: 12, borderWidth: 1, borderColor: '#333355', marginBottom: 8 },
   timeAgo: { color: '#777', fontSize: 11 },


### PR DESCRIPTION
## Summary
- **Android** `CardHolderActivity.showMyCardDetailDialog`: inline chip row with 💬 Start Chat (opens `/c/{publicCode}`) and 🔗 Share (copies URL)
- **iOS** `cards.tsx` MyCard action row: add Chat (Linking.openURL) and Share (clipboard) buttons next to Copy + Edit
- Strings: `action_start_chat`, `action_share_link`, `card_share_copied`

Closes part of card_7b7dd9e3 (App 名片夾對齊 Web — 開始對話/分享). Interview/Rent still pending — require deeper Agent Card Editor port.

## Test plan
- [ ] Android: long-press MyCard → dialog shows Chat + Share chips; tap Chat opens browser to `/c/{code}`; tap Share toasts "Share link copied"
- [ ] iOS: MyCards item shows Chat + Share buttons; tap Chat opens URL; tap Share copies link and alerts
- [ ] Pre-existing Copy + Edit still work on both