### PR TITLE
feat(card-holder): Bot Plaza publish toggle on MyCard (Android + iOS)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/CardHolderActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/CardHolderActivity.kt
@@ -1370,6 +1370,39 @@ class CardHolderActivity : AppCompatActivity() {
                 clip.setPrimaryClip(ClipData.newPlainText("shareUrl", shareUrl))
                 Toast.makeText(this@CardHolderActivity, R.string.card_share_copied, Toast.LENGTH_SHORT).show()
             })
+            var plazaState = card.isPublic
+            lateinit var plazaChip: TextView
+            plazaChip = actionChip(getString(if (plazaState) R.string.action_plaza_on else R.string.action_plaza_off)) {
+                val deviceId = deviceManager.deviceId
+                val deviceSecret = deviceManager.deviceSecret
+                val newValue = !plazaState
+                plazaChip.isEnabled = false
+                lifecycleScope.launch {
+                    try {
+                        val resp = NetworkModule.api.publishToPlaza(mapOf(
+                            "deviceId" to deviceId,
+                            "deviceSecret" to deviceSecret,
+                            "entityId" to card.entityId,
+                            "public" to newValue
+                        ))
+                        if (resp.success) {
+                            plazaState = newValue
+                            plazaChip.text = getString(if (plazaState) R.string.action_plaza_on else R.string.action_plaza_off)
+                            Toast.makeText(this@CardHolderActivity,
+                                if (plazaState) R.string.plaza_published else R.string.plaza_unpublished,
+                                Toast.LENGTH_SHORT).show()
+                            loadAllData()
+                        } else {
+                            Toast.makeText(this@CardHolderActivity, resp.message, Toast.LENGTH_SHORT).show()
+                        }
+                    } catch (e: Exception) {
+                        Toast.makeText(this@CardHolderActivity, e.message ?: "", Toast.LENGTH_SHORT).show()
+                    } finally {
+                        plazaChip.isEnabled = true
+                    }
+                }
+            }
+            actionRow.addView(plazaChip)
             layout.addView(actionRow)
         }
         if (!card.description.isNullOrEmpty()) {

--- a/app/src/main/java/com/hank/clawlive/data/model/ContactModels.kt
+++ b/app/src/main/java/com/hank/clawlive/data/model/ContactModels.kt
@@ -75,7 +75,8 @@ data class MyCardEntry(
     val description: String? = null,
     val contactEmail: String? = null,
     val website: String? = null,
-    val agentCard: AgentCard? = null
+    val agentCard: AgentCard? = null,
+    val isPublic: Boolean = false
 )
 
 data class MyCardsResponse(

--- a/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
@@ -221,6 +221,9 @@ interface ClawApiService {
     @GET("api/contacts/my-cards")
     suspend fun getMyCards(@Query("deviceId") deviceId: String, @Query("deviceSecret") deviceSecret: String): MyCardsResponse
 
+    @POST("api/community/publish")
+    suspend fun publishToPlaza(@Body body: Map<String, @JvmSuppressWildcards Any>): ApiResponse
+
     @GET("api/contacts/recent")
     suspend fun getRecentContacts(@Query("deviceId") deviceId: String, @Query("deviceSecret") deviceSecret: String, @Query("limit") limit: Int = 20): ContactListResponse
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -548,6 +548,10 @@ If you have any questions, please contact us via our official email.
     <string name="action_start_chat">💬 Start Chat</string>
     <string name="action_share_link">🔗 Share</string>
     <string name="card_share_copied">Share link copied</string>
+    <string name="action_plaza_on">🏗 Bot Plaza: ON</string>
+    <string name="action_plaza_off">🏗 Bot Plaza: OFF</string>
+    <string name="plaza_published">Published to Bot Plaza</string>
+    <string name="plaza_unpublished">Removed from Bot Plaza</string>
     <string name="action_delete">🗑️ Delete</string>
     <string name="delete_confirm_title">Delete Confirmation</string>
     <string name="delete_confirm_message_format">Are you sure you want to delete "%s"?</string>

--- a/ios-app/app/(tabs)/cards.tsx
+++ b/ios-app/app/(tabs)/cards.tsx
@@ -54,6 +54,7 @@ interface MyCard {
   entityId: number;
   name?: string;
   avatar?: string;
+  isPublic?: boolean;
 }
 
 interface ChatMessage {
@@ -271,6 +272,25 @@ export default function CardsScreen() {
         },
       ]
     );
+  };
+
+  const togglePlaza = async (card: MyCard) => {
+    const newValue = !card.isPublic;
+    try {
+      const resp = await contactsApi.publishPlaza(card.entityId, newValue);
+      if (resp.data?.success) {
+        setMyCards(prev => prev.map(c =>
+          c.publicCode === card.publicCode ? { ...c, isPublic: newValue } : c
+        ));
+        Alert.alert('', newValue
+          ? t('cardHolder.plazaPublished', 'Published to Bot Plaza')
+          : t('cardHolder.plazaUnpublished', 'Removed from Bot Plaza'));
+      } else {
+        Alert.alert('Error', resp.data?.error || 'Failed');
+      }
+    } catch (e: any) {
+      Alert.alert('Error', e.response?.data?.error || e.message);
+    }
   };
 
   const showAddDialog = () => {
@@ -586,6 +606,16 @@ export default function CardsScreen() {
                     >
                       <Text style={styles.shareBtnText}>{t('cardHolder.share', '\u{1F517} Share')}</Text>
                     </TouchableOpacity>
+                    <TouchableOpacity
+                      style={c.isPublic ? styles.plazaBtnOn : styles.plazaBtnOff}
+                      onPress={() => togglePlaza(c)}
+                    >
+                      <Text style={c.isPublic ? styles.plazaBtnTextOn : styles.plazaBtnTextOff}>
+                        {c.isPublic
+                          ? t('cardHolder.plazaOn', '\u{1F3D7} Plaza: ON')
+                          : t('cardHolder.plazaOff', '\u{1F3D7} Plaza: OFF')}
+                      </Text>
+                    </TouchableOpacity>
                   </View>
                 </View>
               ))}
@@ -708,6 +738,10 @@ const styles = StyleSheet.create({
   chatBtnText: { color: '#10b981', fontSize: 11 },
   shareBtn: { borderWidth: 1, borderColor: '#333355', borderRadius: 4, paddingHorizontal: 10, paddingVertical: 3 },
   shareBtnText: { color: '#aaa', fontSize: 11 },
+  plazaBtnOn: { borderWidth: 1, borderColor: '#FFD700', backgroundColor: 'rgba(255,215,0,0.15)', borderRadius: 4, paddingHorizontal: 10, paddingVertical: 3 },
+  plazaBtnTextOn: { color: '#FFD700', fontSize: 11 },
+  plazaBtnOff: { borderWidth: 1, borderColor: '#333355', borderRadius: 4, paddingHorizontal: 10, paddingVertical: 3 },
+  plazaBtnTextOff: { color: '#777', fontSize: 11 },
   // Recent
   recentItem: { flexDirection: 'row', alignItems: 'center', gap: 12, padding: 12, backgroundColor: '#1A1A2E', borderRadius: 12, borderWidth: 1, borderColor: '#333355', marginBottom: 8 },
   timeAgo: { color: '#777', fontSize: 11 },

--- a/ios-app/services/api.ts
+++ b/ios-app/services/api.ts
@@ -401,6 +401,8 @@ export const contactsApi = {
     apiClient.post('/api/client/cross-speak', { toPublicCode, message }),
   myCards: () =>
     apiClient.get('/api/contacts/my-cards'),
+  publishPlaza: (entityId: number, isPublic: boolean) =>
+    apiClient.post('/api/community/publish', { entityId, public: isPublic }),
   recent: (limit = 20) =>
     apiClient.get('/api/contacts/recent', { params: { limit } }),
   chatHistoryByCode: (publicCode: string, limit = 30) =>


### PR DESCRIPTION
## Summary
- Android: MyCardEntry.isPublic + ClawApiService.publishToPlaza + plaza toggle chip in showMyCardDetailDialog
- iOS: MyCard.isPublic + contactsApi.publishPlaza + Plaza ON/OFF button in cards.tsx action row
- Both POST /api/community/publish (same endpoint web card-holder.html:1349 uses)

Closes 出租 sub-task of card_7b7dd9e3.

## Test plan
- [ ] Android: open MyCard dialog → tap Plaza chip → toggles ON/OFF, toast shows, list refreshes
- [ ] iOS: tap Plaza button on MyCard item → toggles, alert confirms, color switches to gold when ON
- [ ] Re-open app — state persists (from backend)