### PR TITLE
feat(chat): quote-reply reachable on mobile WebView

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -407,6 +407,11 @@
         .chat-msg:hover .chat-reply-btn { opacity: 1; }
         .chat-reply-btn:hover { color: var(--primary); border-color: var(--primary); }
         .chat-msg.sent .chat-reply-btn { right: auto; left: -30px; }
+        /* Touch devices: hover never fires, so make the reply button persistently visible */
+        @media (hover: none) {
+            .chat-reply-btn { opacity: 0.75; width: 30px; height: 30px; font-size: 15px; }
+            .chat-reply-btn:active { opacity: 1; color: var(--primary); border-color: var(--primary); }
+        }
 
         /* ── Reply preview bar above input ── */
         .reply-preview-bar {
@@ -2547,6 +2552,49 @@
             const btn = e.target.closest('.code-copy-btn');
             if (btn) copyCodeBlock(btn);
         });
+
+        // Long-press on a message bubble triggers the quote-reply flow.
+        // Needed for mobile WebView where :hover-revealed reply button is hard to tap.
+        (function installLongPressQuote() {
+            const container = document.getElementById('chatMessages');
+            let timer = null;
+            let startX = 0;
+            let startY = 0;
+            const LONG_PRESS_MS = 450;
+            const MOVE_CANCEL_PX = 10;
+
+            const clear = () => { if (timer) { clearTimeout(timer); timer = null; } };
+
+            container.addEventListener('touchstart', (e) => {
+                const msg = e.target.closest('.chat-msg');
+                if (!msg) return;
+                // Don't intercept taps on interactive children (reply btn, links, images).
+                if (e.target.closest('a, button, .chat-reply-btn, .link-preview-slot, .chat-img, video')) return;
+                const btn = msg.querySelector('.chat-reply-btn');
+                if (!btn) return;
+                const touch = e.touches[0];
+                startX = touch.clientX;
+                startY = touch.clientY;
+                clear();
+                timer = setTimeout(() => {
+                    timer = null;
+                    if (navigator.vibrate) { try { navigator.vibrate(15); } catch (_) {} }
+                    handleReplyBtn(btn);
+                }, LONG_PRESS_MS);
+            }, { passive: true });
+
+            container.addEventListener('touchmove', (e) => {
+                if (!timer) return;
+                const touch = e.touches[0];
+                if (Math.abs(touch.clientX - startX) > MOVE_CANCEL_PX ||
+                    Math.abs(touch.clientY - startY) > MOVE_CANCEL_PX) {
+                    clear();
+                }
+            }, { passive: true });
+
+            container.addEventListener('touchend', clear, { passive: true });
+            container.addEventListener('touchcancel', clear, { passive: true });
+        })();
 
         // ── Init ──
         window.addEventListener('DOMContentLoaded', async () => {


### PR DESCRIPTION
## Summary
- Reply button now visible on touch devices (was hover-only — effectively invisible in Android/iOS WebView).
- Added long-press gesture on message bubbles that triggers the existing quote-reply flow (with haptic nudge on supported devices).
- No native port required — both apps already embed `portal/chat.html`.

## Why
`card_d3cdda1455152e3caee8d4ac` calls for "Quote-to-Chat — 長按 context menu". Scoping showed both mobile chat screens are WebViews loading the portal chat, and the reply/quote backend (`handleReplyBtn` → `setReplyContext`) already exists. The only gap was discoverability on touch: `:hover` doesn't fire reliably, so the `.chat-reply-btn` never surfaced. This PR closes that gap with a CSS `@media (hover: none)` override plus a touch long-press that reuses `handleReplyBtn()` — zero new JS surface, no new state.

## Test plan
- [ ] Open chat in Android app → long-press a bubble → reply preview bar shows with that message.
- [ ] Open chat in iOS app → long-press a bubble → reply preview bar shows.
- [ ] Desktop hover behavior unchanged (button fades in on hover as before).
- [ ] Tap a link inside a bubble → still opens the link (long-press filter excludes `<a>`, `.chat-img`, `.chat-reply-btn`).
- [ ] Scrolling through messages does not trigger the long-press (touchmove > 10px cancels the timer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)