### PR TITLE
feat(chat): clickable card_<shortId> references in chat

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -759,9 +759,32 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
     router.get('/card/:id', async (req, res) => {
         if (!authenticate(req, res)) return;
         const { deviceId } = { ...req.query, ...req.body };
-        const cardId = req.params.id;
+        const rawId = req.params.id;
 
         try {
+            // Resolve short-ID prefixes to the full card ID, scoped to this device.
+            // Users commonly mention cards in chat with 8-hex shorthand (e.g. `card_7b7dd9e3`);
+            // fall back to a prefix match only when the raw id is an obvious shorthand
+            // (hex-only, ≤ 12 chars, optionally with a `card_` prefix).
+            let cardId = rawId;
+            const shortBody = /^card_([a-f0-9]{6,12})$/i.test(rawId)
+                ? rawId.slice(5)
+                : (/^[a-f0-9]{6,12}$/i.test(rawId) ? rawId : null);
+            if (shortBody) {
+                const match = await pool.query(
+                    `SELECT id FROM kanban_cards
+                     WHERE device_id = $1
+                       AND (id = $2 OR id LIKE $3 OR id LIKE $4)
+                     ORDER BY created_at DESC
+                     LIMIT 2`,
+                    [deviceId, rawId, shortBody + '%', 'card_' + shortBody + '%']
+                );
+                if (match.rows.length === 1) cardId = match.rows[0].id;
+                // If 2+ cards share this prefix we fall through to the exact-match
+                // query below, which will return 404 and force the caller to
+                // disambiguate with a longer id.
+            }
+
             const cardResult = await pool.query(
                 `SELECT c.*,
                     COALESCE(cm.cnt, 0) AS comment_count,

--- a/backend/public/portal/shared/entity-link-render.js
+++ b/backend/public/portal/shared/entity-link-render.js
@@ -79,9 +79,14 @@
 
     // Prefixed IDs like "card_7b7dd9e3a4c2..." — self-identifying, no keyword needed.
     // The prefix itself tells us the entity type, so the chip can route directly.
-    const PREFIXED_RE = new RegExp('\\b(card|skill|rule|listing|exam|contract)_([a-f0-9]{24})\\b', 'gi');
+    // Accepted hex forms after the prefix:
+    //   - 8 hex   (short prefix, resolved by backend LIKE lookup): card_7b7dd9e3
+    //   - 24 hex  (legacy full-suffix form):                      card_d3cdda1455152e3caee8d4ac
+    //   - UUID    (8-4-4-4-12):                                    card_7b7dd9e3-55e1-4074-b101-40c47161d8de
+    const PREFIXED_HEX = '[a-f0-9]{8}(?:[a-f0-9]{16}|-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})?';
+    const PREFIXED_RE = new RegExp('\\b(card|skill|rule|listing|exam|contract)_(' + PREFIXED_HEX + ')\\b', 'gi');
     // Code-wrapped variant: <code>card_xxx</code> (e.g. backtick-quoted in markdown).
-    const CODE_PREFIXED_RE = new RegExp('<code[^>]*>\\s*(card|skill|rule|listing|exam|contract)_([a-f0-9]{24})\\s*</code>', 'gi');
+    const CODE_PREFIXED_RE = new RegExp('<code[^>]*>\\s*(card|skill|rule|listing|exam|contract)_(' + PREFIXED_HEX + ')\\s*</code>', 'gi');
 
     // Placeholder system (same approach as note-link-render)
     const pendingChips = [];

--- a/backend/tests/jest/kanban-card.test.js
+++ b/backend/tests/jest/kanban-card.test.js
@@ -334,3 +334,89 @@ describe('GET /cards/projections', () => {
         expect(res.body.projections['card-bad']).toEqual([]);
     });
 });
+
+// ════════════════════════════════════════════════════════════════
+// GET /card/:id — Short-ID prefix resolution
+// ════════════════════════════════════════════════════════════════
+describe('GET /card/:id — short-ID prefix resolution', () => {
+    const fullCard = {
+        id: 'card_d3cdda1455152e3caee8d4ac',
+        device_id: 'test-dev',
+        title: 'Full card',
+        description: '',
+        priority: 'P2',
+        status: 'review',
+        assigned_bots: [0],
+        created_by: 0,
+        created_at: new Date(),
+        updated_at: new Date(),
+        status_changed_at: new Date(),
+        archived: false,
+        comment_count: 0,
+        note_count: 0,
+        file_count: 0,
+    };
+
+    it('resolves "card_<8hex>" shorthand to the full card id', async () => {
+        mockQuery
+            .mockResolvedValueOnce({ rows: [{ id: fullCard.id }] }) // prefix lookup
+            .mockResolvedValueOnce({ rows: [fullCard] })            // main query
+            .mockResolvedValueOnce({ rows: [] })                    // comments
+            .mockResolvedValueOnce({ rows: [] })                    // notes
+            .mockResolvedValueOnce({ rows: [] });                   // files
+
+        const res = await get('/api/mission/card/card_d3cdda14').query({ ...AUTH });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.card.id).toBe(fullCard.id);
+        // prefix lookup should run first with the stripped hex in both forms
+        const prefixParams = mockQuery.mock.calls[0][1];
+        expect(prefixParams).toContain('d3cdda14%');
+        expect(prefixParams).toContain('card_d3cdda14%');
+    });
+
+    it('resolves bare 8-hex UUID prefix (no card_ wrapper)', async () => {
+        const uuidCard = { ...fullCard, id: '7b7dd9e3-55e1-4074-b101-40c47161d8de' };
+        mockQuery
+            .mockResolvedValueOnce({ rows: [{ id: uuidCard.id }] })
+            .mockResolvedValueOnce({ rows: [uuidCard] })
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [] });
+
+        const res = await get('/api/mission/card/7b7dd9e3').query({ ...AUTH });
+
+        expect(res.status).toBe(200);
+        expect(res.body.card.id).toBe(uuidCard.id);
+    });
+
+    it('passes full ids through unchanged (no prefix query)', async () => {
+        mockQuery
+            .mockResolvedValueOnce({ rows: [fullCard] })
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [] });
+
+        const res = await get(`/api/mission/card/${fullCard.id}`).query({ ...AUTH });
+
+        expect(res.status).toBe(200);
+        // First call should be the main SELECT, not a prefix lookup
+        expect(mockQuery.mock.calls[0][0]).toMatch(/FROM kanban_cards c/);
+    });
+
+    it('returns 404 when the prefix is ambiguous (2+ matches)', async () => {
+        mockQuery
+            .mockResolvedValueOnce({
+                rows: [
+                    { id: 'card_d3cdda1400000000aaaaaaaa' },
+                    { id: 'card_d3cdda14ffffffffbbbbbbbb' },
+                ],
+            })
+            .mockResolvedValueOnce({ rows: [] }); // main lookup with raw id → miss
+
+        const res = await get('/api/mission/card/d3cdda14').query({ ...AUTH });
+
+        expect(res.status).toBe(404);
+    });
+});


### PR DESCRIPTION
## Summary
- Mentions like \`card_7b7dd9e3\` or \`card_d3cdda14\` in a chat message now render as clickable chips that open the card detail modal.
- Fix is on both layers (frontend regex + backend prefix lookup) so shorthand actually resolves.

## Why
User reported that card IDs written in chat bubbles look tappable but do nothing. Scoping:
1. \`EntityLinkRender.PREFIXED_RE\` required **24 hex** after \`card_\` — the 8-hex shorthand people naturally type never matched, so the chip was never injected.
2. Even if the regex matched, \`GET /api/mission/card/:id\` did an exact-match query on the raw id, so \`card_7b7dd9e3\` → 404 regardless.

## What changed
- **\`backend/public/portal/shared/entity-link-render.js\`** — \`PREFIXED_RE\` / \`CODE_PREFIXED_RE\` now accept 8-hex | 24-hex | UUID (8-4-4-4-12) after the \`card_\` / \`skill_\` / \`rule_\` / … prefix.
- **\`backend/kanban.js\` (GET /card/:id)** — when the incoming id is an obvious shorthand (\`^card_[a-f0-9]{6,12}$\` or \`^[a-f0-9]{6,12}$\`), a device-scoped prefix lookup resolves it to the full id before the main query runs. Ambiguous prefixes (2+ matches) fall through to 404 so callers must disambiguate.
- **\`backend/tests/jest/kanban-card.test.js\`** — 4 new unit tests covering: card_ prefix resolution, bare UUID prefix, full-id passthrough, and ambiguous-prefix 404.

## Test plan
- [ ] \`npx jest backend/tests/jest/kanban-card.test.js\` → 19 pass (was 15).
- [ ] In chat, message containing \`card_7b7dd9e3 → review\` shows a blue chip; tap → modal opens with the right card.
- [ ] Same for \`card_d3cdda14\`.
- [ ] Desktop hover / existing \`card 7b7dd9e3\` (space-separated) pattern unchanged.
- [ ] Lint: \`npx eslint backend/kanban.js\` → clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)