### PR TITLE
feat(card-holder): Run Interview entry on MyCard detail (Android + iOS)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/CardHolderActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/CardHolderActivity.kt
@@ -1403,6 +1403,14 @@ class CardHolderActivity : AppCompatActivity() {
                 }
             }
             actionRow.addView(plazaChip)
+            actionRow.addView(actionChip(getString(R.string.action_run_interview)) {
+                try {
+                    val url = "https://eclawbot.com/portal/card-holder.html"
+                    startActivity(android.content.Intent(android.content.Intent.ACTION_VIEW, Uri.parse(url)))
+                } catch (e: Exception) {
+                    Toast.makeText(this@CardHolderActivity, e.message ?: "", Toast.LENGTH_SHORT).show()
+                }
+            })
             layout.addView(actionRow)
         }
         if (!card.description.isNullOrEmpty()) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -552,6 +552,7 @@ If you have any questions, please contact us via our official email.
     <string name="action_plaza_off">🏗 Bot Plaza: OFF</string>
     <string name="plaza_published">Published to Bot Plaza</string>
     <string name="plaza_unpublished">Removed from Bot Plaza</string>
+    <string name="action_run_interview">🧪 Run Interview</string>
     <string name="action_delete">🗑️ Delete</string>
     <string name="delete_confirm_title">Delete Confirmation</string>
     <string name="delete_confirm_message_format">Are you sure you want to delete "%s"?</string>

--- a/ios-app/app/(tabs)/cards.tsx
+++ b/ios-app/app/(tabs)/cards.tsx
@@ -616,6 +616,14 @@ export default function CardsScreen() {
                           : t('cardHolder.plazaOff', '\u{1F3D7} Plaza: OFF')}
                       </Text>
                     </TouchableOpacity>
+                    <TouchableOpacity
+                      style={styles.interviewBtn}
+                      onPress={() => {
+                        Linking.openURL('https://eclawbot.com/portal/card-holder.html').catch(() => {});
+                      }}
+                    >
+                      <Text style={styles.interviewBtnText}>{t('cardHolder.runInterview', '\u{1F9EA} Interview')}</Text>
+                    </TouchableOpacity>
                   </View>
                 </View>
               ))}
@@ -742,6 +750,8 @@ const styles = StyleSheet.create({
   plazaBtnTextOn: { color: '#FFD700', fontSize: 11 },
   plazaBtnOff: { borderWidth: 1, borderColor: '#333355', borderRadius: 4, paddingHorizontal: 10, paddingVertical: 3 },
   plazaBtnTextOff: { color: '#777', fontSize: 11 },
+  interviewBtn: { borderWidth: 1, borderColor: '#10b981', backgroundColor: 'rgba(16,185,129,0.12)', borderRadius: 4, paddingHorizontal: 10, paddingVertical: 3 },
+  interviewBtnText: { color: '#10b981', fontSize: 11 },
   // Recent
   recentItem: { flexDirection: 'row', alignItems: 'center', gap: 12, padding: 12, backgroundColor: '#1A1A2E', borderRadius: 12, borderWidth: 1, borderColor: '#333355', marginBottom: 8 },
   timeAgo: { color: '#777', fontSize: 11 },


### PR DESCRIPTION
## Summary
- Adds 🧪 Run Interview chip to MyCard detail on both Android and iOS.
- Tapping it opens \`portal/card-holder.html\` where the existing AgentCardEditor drives the full 8-probe interview → Arena exam → capability sync flow.

## Why
Kanban card_7b7dd9e3 acceptance says "從名片夾... 能走完 編輯/開始對話/面試/出租 全流程". The first three and 出租 were shipped in PRs #1824–#1827, but 面試 was split out to card_d3cdda14 as P2 because a native port of the 8-probe engine was believed to be heavy.

Scoping showed a shorter path: the chat/mission/org-chart tabs of both apps already embed WebView-backed web UIs (\`portal/chat.html\`, \`portal/mission.html\`, \`dashboard.html?view=orgchart\`). Routing 面試 to \`portal/card-holder.html\` keeps that pattern and reuses \`shared/agent-card-editor.js\` — no engine port needed, and the web flow stays the single source of truth for interview logic.

## What changed
- \`app/src/main/java/com/hank/clawlive/CardHolderActivity.kt\` — one extra \`actionChip\` in \`showMyCardDetailDialog\`, \`ACTION_VIEW\` intent to the web page.
- \`app/src/main/res/values/strings.xml\` — \`action_run_interview\` string.
- \`ios-app/app/(tabs)/cards.tsx\` — one extra \`TouchableOpacity\` using the already-imported \`Linking\`, plus matching green accent style.

## Test plan
- [ ] Android: tap a card in My Cards → detail dialog shows chips row with 💬 Chat / 🔗 Share / 🏗 Plaza / 🧪 Run Interview; tapping 🧪 opens the web card-holder page.
- [ ] iOS: same flow via Linking.openURL.
- [ ] Existing chips still work (chat intent, share clipboard, plaza toggle).
- [ ] \`./gradlew assembleDebug\` passes (Kotlin compile green).
- [ ] Android Lint passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)