### PR TITLE
i18n(android): round 2 — 8 common keys + 9 low-translation locales 15 old keys

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -943,4 +943,28 @@ GPS: عند الطلب فقط، بلا تتبع في الخلفية، تُفقد
     <string name="card_chat_history_failed">فشل تحميل سجل الدردشة</string>
     <string name="feedback_photo_upload_failed">فشل رفع الصورة: %s</string>
     <string name="wallpaper_load_entities_failed">فشل تحميل الكيانات: %s</string>
+    <string name="action_plaza_on">🏗 بلازا البوت: تشغيل</string>
+    <string name="action_plaza_off">🏗 بلازا البوت: إيقاف</string>
+    <string name="action_run_interview">🧪 تشغيل المقابلة</string>
+    <string name="action_share_link">🔗 مشاركة</string>
+    <string name="action_start_chat">💬 بدء المحادثة</string>
+    <string name="card_share_copied">تم نسخ رابط المشاركة</string>
+    <string name="plaza_published">تم النشر في بلازا البوت</string>
+    <string name="plaza_unpublished">تمت الإزالة من بلازا البوت</string>
+    <string name="close">إغلاق</string>
+    <string name="developer_section_title">المطور</string>
+    <string name="ecoin_unit">عملات e</string>
+    <string name="org_chart_sheet_title">الهيكل التنظيمي</string>
+    <string name="settings_delete_account">حذف الحساب</string>
+    <string name="settings_invite">دعوة الأصدقاء</string>
+    <string name="settings_my_rentals">إيجاراتي</string>
+    <string name="settings_wallet">المحفظة</string>
+    <string name="topup_bonus_format"> (+%d%% مكافأة)</string>
+    <string name="topup_tier_advanced">متقدم</string>
+    <string name="topup_tier_format">%1$s — %2$s
+%3$s %4$s%5$s</string>
+    <string name="topup_tier_premium">متميز</string>
+    <string name="topup_tier_small">صغير</string>
+    <string name="topup_tier_standard">قياسي</string>
+    <string name="topup_tier_starter">مبتدئ</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -943,4 +943,28 @@ Bei Fragen kontaktieren Sie uns über unsere offizielle E-Mail.
     <string name="card_chat_history_failed">Chatverlauf konnte nicht geladen werden</string>
     <string name="feedback_photo_upload_failed">Foto-Upload fehlgeschlagen: %s</string>
     <string name="wallpaper_load_entities_failed">Entitäten konnten nicht geladen werden: %s</string>
+    <string name="action_plaza_on">🏗 Bot Plaza: AN</string>
+    <string name="action_plaza_off">🏗 Bot Plaza: AUS</string>
+    <string name="action_run_interview">🧪 Interview starten</string>
+    <string name="action_share_link">🔗 Teilen</string>
+    <string name="action_start_chat">💬 Chat starten</string>
+    <string name="card_share_copied">Freigabe-Link kopiert</string>
+    <string name="plaza_published">Auf Bot Plaza veröffentlicht</string>
+    <string name="plaza_unpublished">Von Bot Plaza entfernt</string>
+    <string name="close">Schließen</string>
+    <string name="developer_section_title">Entwickler</string>
+    <string name="ecoin_unit">e-Münzen</string>
+    <string name="org_chart_sheet_title">Organigramm</string>
+    <string name="settings_delete_account">Konto löschen</string>
+    <string name="settings_invite">Freunde einladen</string>
+    <string name="settings_my_rentals">Meine Vermietungen</string>
+    <string name="settings_wallet">Brieftasche</string>
+    <string name="topup_bonus_format"> (+%d%% Bonus)</string>
+    <string name="topup_tier_advanced">Fortgeschritten</string>
+    <string name="topup_tier_format">%1$s — %2$s
+%3$s %4$s%5$s</string>
+    <string name="topup_tier_premium">Premium</string>
+    <string name="topup_tier_small">Klein</string>
+    <string name="topup_tier_standard">Standard</string>
+    <string name="topup_tier_starter">Starter</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -868,4 +868,28 @@ Tu suscripción permanece activa y puedes reenlazar en cualquier momento (sujeto
     <string name="wallpaper_load_entities_failed">Error al cargar entidades: %s</string>
     <string name="billing_google_play_loading">Cargando Google Play...</string>
     <string name="dialog_unblock_message">¿Desbloquear %s?</string>
+    <string name="action_plaza_on">🏗 Bot Plaza: ENCENDIDO</string>
+    <string name="action_plaza_off">🏗 Bot Plaza: APAGADO</string>
+    <string name="action_run_interview">🧪 Ejecutar entrevista</string>
+    <string name="action_share_link">🔗 Compartir</string>
+    <string name="action_start_chat">💬 Iniciar chat</string>
+    <string name="card_share_copied">Enlace compartido copiado</string>
+    <string name="plaza_published">Publicado en Bot Plaza</string>
+    <string name="plaza_unpublished">Eliminado de Bot Plaza</string>
+    <string name="close">Cerrar</string>
+    <string name="developer_section_title">Desarrollador</string>
+    <string name="ecoin_unit">e-Monederos</string>
+    <string name="org_chart_sheet_title">Gráfico de organización</string>
+    <string name="settings_delete_account">Eliminar cuenta</string>
+    <string name="settings_invite">Invitar amigos</string>
+    <string name="settings_my_rentals">Mis alquileres</string>
+    <string name="settings_wallet">Cartera</string>
+    <string name="topup_bonus_format"> (+%d%% bono)</string>
+    <string name="topup_tier_advanced">Avanzado</string>
+    <string name="topup_tier_format">%1$s — %2$s
+%3$s %4$s%5$s</string>
+    <string name="topup_tier_premium">Premium</string>
+    <string name="topup_tier_small">Pequeño</string>
+    <string name="topup_tier_standard">Estándar</string>
+    <string name="topup_tier_starter">Inicio</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -943,4 +943,28 @@ Si vous avez des questions, contactez-nous via notre e-mail officiel.
     <string name="card_chat_history_failed">Échec du chargement de l\'historique de chat</string>
     <string name="feedback_photo_upload_failed">Échec du téléversement de la photo : %s</string>
     <string name="wallpaper_load_entities_failed">Échec du chargement des entités : %s</string>
+    <string name="action_plaza_on">🏗 Bot Plaza : ACTIVÉ</string>
+    <string name="action_plaza_off">🏗 Bot Plaza : DÉSACTIVÉ</string>
+    <string name="action_run_interview">🧪 Lancer l&apos;entretien</string>
+    <string name="action_share_link">🔗 Partager</string>
+    <string name="action_start_chat">💬 Démarrer le chat</string>
+    <string name="card_share_copied">Lien de partage copié</string>
+    <string name="plaza_published">Publié sur Bot Plaza</string>
+    <string name="plaza_unpublished">Retiré de Bot Plaza</string>
+    <string name="close">Fermer</string>
+    <string name="developer_section_title">Développeur</string>
+    <string name="ecoin_unit">e-Pièces</string>
+    <string name="org_chart_sheet_title">Organigramme</string>
+    <string name="settings_delete_account">Supprimer le compte</string>
+    <string name="settings_invite">Inviter des amis</string>
+    <string name="settings_my_rentals">Mes locations</string>
+    <string name="settings_wallet">Portefeuille</string>
+    <string name="topup_bonus_format"> (+%d%% bonus)</string>
+    <string name="topup_tier_advanced">Avancé</string>
+    <string name="topup_tier_format">%1$s — %2$s
+%3$s %4$s%5$s</string>
+    <string name="topup_tier_premium">Premium</string>
+    <string name="topup_tier_small">Petit</string>
+    <string name="topup_tier_standard">Standard</string>
+    <string name="topup_tier_starter">Débutant</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -943,4 +943,28 @@ GPS: केवल अनुरोध पर, कोई बैकग्राउ�
     <string name="card_chat_history_failed">चैट इतिहास लोड करने में विफल</string>
     <string name="feedback_photo_upload_failed">फोटो अपलोड विफल: %s</string>
     <string name="wallpaper_load_entities_failed">एंटिटी लोड करने में विफल: %s</string>
+    <string name="action_plaza_on">🏗 बॉट प्लाज़ा: चालू</string>
+    <string name="action_plaza_off">🏗 बॉट प्लाज़ा: बंद</string>
+    <string name="action_run_interview">🧪 इंटरव्यू चलाएं</string>
+    <string name="action_share_link">🔗 शेयर करें</string>
+    <string name="action_start_chat">💬 चैट शुरू करें</string>
+    <string name="card_share_copied">शेयर लिंक कॉपी किया गया</string>
+    <string name="plaza_published">Bot Plaza पर प्रकाशित</string>
+    <string name="plaza_unpublished">Bot Plaza से हटाया गया</string>
+    <string name="close">बंद करें</string>
+    <string name="developer_section_title">डेवलपर</string>
+    <string name="ecoin_unit">e-कोइन</string>
+    <string name="org_chart_sheet_title">संगठन चार्ट</string>
+    <string name="settings_delete_account">खाता हटाएं</string>
+    <string name="settings_invite">दोस्तों को आमंत्रित करें</string>
+    <string name="settings_my_rentals">मेरे किराये</string>
+    <string name="settings_wallet">वॉलेट</string>
+    <string name="topup_bonus_format"> (+%d%% बोनस)</string>
+    <string name="topup_tier_advanced">उन्नत</string>
+    <string name="topup_tier_format">%1$s — %2$s
+%3$s %4$s%5$s</string>
+    <string name="topup_tier_premium">प्रीमियम</string>
+    <string name="topup_tier_small">छोटा</string>
+    <string name="topup_tier_standard">मानक</string>
+    <string name="topup_tier_starter">स्टार्टर</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -839,4 +839,28 @@ Jika ada pertanyaan, silakan hubungi kami melalui email resmi kami.
     <string name="schedule_error_generic">Error: %s</string>
     <string name="schedule_failed_to_load">Failed to load: %s</string>
     <string name="schedule_operation_failed">Operation failed</string>
+    <string name="action_plaza_on">🏗 Bot Plaza: HIDUP</string>
+    <string name="action_plaza_off">🏗 Bot Plaza: MATI</string>
+    <string name="action_run_interview">🧪 Jalankan wawancara</string>
+    <string name="action_share_link">🔗 Bagikan</string>
+    <string name="action_start_chat">💬 Mulai obrolan</string>
+    <string name="card_share_copied">Tautan bagikan disalin</string>
+    <string name="plaza_published">Diterbitkan ke Bot Plaza</string>
+    <string name="plaza_unpublished">Dihapus dari Bot Plaza</string>
+    <string name="close">Tutup</string>
+    <string name="developer_section_title">Pengembang</string>
+    <string name="ecoin_unit">e-Koin</string>
+    <string name="org_chart_sheet_title">Bagan Organisasi</string>
+    <string name="settings_delete_account">Hapus akun</string>
+    <string name="settings_invite">Undang teman</string>
+    <string name="settings_my_rentals">Sewa saya</string>
+    <string name="settings_wallet">Dompet</string>
+    <string name="topup_bonus_format"> (+%d%% bonus)</string>
+    <string name="topup_tier_advanced">Lanjutan</string>
+    <string name="topup_tier_format">%1$s — %2$s
+%3$s %4$s%5$s</string>
+    <string name="topup_tier_premium">Premium</string>
+    <string name="topup_tier_small">Kecil</string>
+    <string name="topup_tier_standard">Standar</string>
+    <string name="topup_tier_starter">Pemula</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -856,4 +856,12 @@ GPS：オンデマンドのみ、バックグラウンド追跡なし、サー�
     <string name="topup_tier_standard">スタンダード</string>
     <string name="topup_tier_starter">スターター</string>
     <string name="channel_api_manage_all">すべてのキーを管理 →</string>
+    <string name="action_plaza_on">🏗 Bot Plaza：オン</string>
+    <string name="action_plaza_off">🏗 Bot Plaza：オフ</string>
+    <string name="action_run_interview">🧪 面接を実行</string>
+    <string name="action_share_link">🔗 シェア</string>
+    <string name="action_start_chat">💬 チャット開始</string>
+    <string name="card_share_copied">共有リンクをコピーしました</string>
+    <string name="plaza_published">Bot Plaza に公開しました</string>
+    <string name="plaza_unpublished">Bot Plaza から削除しました</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -856,4 +856,12 @@ GPS: 온디맨드만, 백그라운드 추적 없음, 서버 재시작 시 데이
     <string name="topup_tier_standard">표준</string>
     <string name="topup_tier_starter">스타터</string>
     <string name="channel_api_manage_all">모든 키 관리 →</string>
+    <string name="action_plaza_on">🏗 Bot Plaza：켜짐</string>
+    <string name="action_plaza_off">🏗 Bot Plaza：끄기</string>
+    <string name="action_run_interview">🧪 면접 실행</string>
+    <string name="action_share_link">🔗 공유</string>
+    <string name="action_start_chat">💬 채팅 시작</string>
+    <string name="card_share_copied">공유 링크가 복사되었습니다</string>
+    <string name="plaza_published">Bot Plaza에 게시됨</string>
+    <string name="plaza_unpublished">Bot Plaza에서 제거됨</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -943,4 +943,28 @@ Jika anda mempunyai sebarang soalan, sila hubungi kami melalui e-mel rasmi kami.
     <string name="card_chat_history_failed">Gagal memuat sejarah sembang</string>
     <string name="feedback_photo_upload_failed">Muat naik foto gagal: %s</string>
     <string name="wallpaper_load_entities_failed">Gagal memuat entiti: %s</string>
+    <string name="action_plaza_on">🏗 Bot Plaza: AKTIF</string>
+    <string name="action_plaza_off">🏗 Bot Plaza: MATI</string>
+    <string name="action_run_interview">🧪 Jalankan temu duga</string>
+    <string name="action_share_link">🔗 Kongsi</string>
+    <string name="action_start_chat">💬 Mula chat</string>
+    <string name="card_share_copied">Pautan kongsi disalin</string>
+    <string name="plaza_published">Diterbitkan ke Bot Plaza</string>
+    <string name="plaza_unpublished">Dibuang dari Bot Plaza</string>
+    <string name="close">Tutup</string>
+    <string name="developer_section_title">Pembangkit</string>
+    <string name="ecoin_unit">e-coin</string>
+    <string name="org_chart_sheet_title">Carta Organisasi</string>
+    <string name="settings_delete_account">Padam akaun</string>
+    <string name="settings_invite">Jemput rakan</string>
+    <string name="settings_my_rentals">Sewa saya</string>
+    <string name="settings_wallet">Dompet</string>
+    <string name="topup_bonus_format"> (+%d%% bonus)</string>
+    <string name="topup_tier_advanced">Lanjutan</string>
+    <string name="topup_tier_format">%1$s — %2$s
+%3$s %4$s%5$s</string>
+    <string name="topup_tier_premium">Premium</string>
+    <string name="topup_tier_small">Kecil</string>
+    <string name="topup_tier_standard">Standard</string>
+    <string name="topup_tier_starter">Pemula</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -839,4 +839,28 @@ GPS：รับตามความต้องการเท่านั้�
     <string name="schedule_error_generic">Error: %s</string>
     <string name="schedule_failed_to_load">Failed to load: %s</string>
     <string name="schedule_operation_failed">Operation failed</string>
+    <string name="action_plaza_on">🏗 บอทพลาซ่า: เปิด</string>
+    <string name="action_plaza_off">🏗 บอทพลาซ่า: ปิด</string>
+    <string name="action_run_interview">🧪 รันสัมภาษณ์</string>
+    <string name="action_share_link">🔗 แชร์</string>
+    <string name="action_start_chat">💬 เริ่มแชท</string>
+    <string name="card_share_copied">ลิงก์แชร์ถูกคัดลอกแล้ว</string>
+    <string name="plaza_published">เผยแพร่ไปยัง Bot Plaza แล้ว</string>
+    <string name="plaza_unpublished">ลบออกจาก Bot Plaza แล้ว</string>
+    <string name="close">ปิด</string>
+    <string name="developer_section_title">นักพัฒนา</string>
+    <string name="ecoin_unit">e-coin</string>
+    <string name="org_chart_sheet_title">แผนผังองค์กร</string>
+    <string name="settings_delete_account">ลบบัญชี</string>
+    <string name="settings_invite">เชิญเพื่อน</string>
+    <string name="settings_my_rentals">การเช่าของฉัน</string>
+    <string name="settings_wallet">กระเป๋าเงิน</string>
+    <string name="topup_bonus_format"> (+%d%% โบนัส)</string>
+    <string name="topup_tier_advanced">ขั้นสูง</string>
+    <string name="topup_tier_format">%1$s — %2$s
+%3$s %4$s%5$s</string>
+    <string name="topup_tier_premium">พรีเมียม</string>
+    <string name="topup_tier_small">เล็ก</string>
+    <string name="topup_tier_standard">มาตรฐาน</string>
+    <string name="topup_tier_starter">เริ่มต้น</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -839,4 +839,28 @@ Nếu có bất kỳ câu hỏi nào, vui lòng liên hệ với chúng tôi qua
     <string name="schedule_error_generic">Error: %s</string>
     <string name="schedule_failed_to_load">Failed to load: %s</string>
     <string name="schedule_operation_failed">Operation failed</string>
+    <string name="action_plaza_on">🏗 Bot Plaza: BẬT</string>
+    <string name="action_plaza_off">🏗 Bot Plaza: TẮT</string>
+    <string name="action_run_interview">🧪 Chạy phỏng vấn</string>
+    <string name="action_share_link">🔗 Chia sẻ</string>
+    <string name="action_start_chat">💬 Bắt đầu trò chuyện</string>
+    <string name="card_share_copied">Đã sao chép liên kết chia sẻ</string>
+    <string name="plaza_published">Đã xuất bản lên Bot Plaza</string>
+    <string name="plaza_unpublished">Đã gỡ khỏi Bot Plaza</string>
+    <string name="close">Đóng</string>
+    <string name="developer_section_title">Nhà phát triển</string>
+    <string name="ecoin_unit">e-Coins</string>
+    <string name="org_chart_sheet_title">Sơ đồ tổ chức</string>
+    <string name="settings_delete_account">Xóa tài khoản</string>
+    <string name="settings_invite">Mời bạn bè</string>
+    <string name="settings_my_rentals">Cho thuê của tôi</string>
+    <string name="settings_wallet">Ví</string>
+    <string name="topup_bonus_format"> (+%d%% thưởng)</string>
+    <string name="topup_tier_advanced">Nâng cao</string>
+    <string name="topup_tier_format">%1$s — %2$s
+%3$s %4$s%5$s</string>
+    <string name="topup_tier_premium">Cao cấp</string>
+    <string name="topup_tier_small">Nhỏ</string>
+    <string name="topup_tier_standard">Tiêu chuẩn</string>
+    <string name="topup_tier_starter">Khởi đầu</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -858,4 +858,12 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="topup_tier_standard">标准</string>
     <string name="topup_tier_starter">入门</string>
     <string name="channel_api_manage_all">管理所有密钥 →</string>
+    <string name="action_plaza_on">🏗 Bot Plaza：开</string>
+    <string name="action_plaza_off">🏗 Bot Plaza：关</string>
+    <string name="action_run_interview">🧪 执行面试</string>
+    <string name="action_share_link">🔗 分享</string>
+    <string name="action_start_chat">💬 开始聊天</string>
+    <string name="card_share_copied">分享链接已复制</string>
+    <string name="plaza_published">已发布至 Bot Plaza</string>
+    <string name="plaza_unpublished">已从 Bot Plaza 移除</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -856,4 +856,13 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="dialog_unblock_message">確定要解除封鎖 %s 嗎？</string>
     <string name="org_chart_sheet_title">組織圖</string>
     <string name="close">關閉</string>
+    <string name="action_plaza_on">🏗 Bot Plaza：開</string>
+    <string name="action_plaza_off">🏗 Bot Plaza：關</string>
+    <string name="action_run_interview">🧪 執行面試</string>
+    <string name="action_share_link">🔗 分享</string>
+    <string name="action_start_chat">💬 開始聊天</string>
+    <string name="card_share_copied">分享連結已複製</string>
+    <string name="plaza_published">已發布至 Bot Plaza</string>
+    <string name="plaza_unpublished">已從 Bot Plaza 移除</string>
+    <string name="channel_api_manage_all">管理所有金鑰 →</string>
 </resources>


### PR DESCRIPTION
## i18n(android): round 2 — fill 8 common + zh-rTW 1 + low-9 translation 15 old keys

### Changes
- **8 common keys** (all 13 locales): action_plaza_on, action_plaza_off, action_run_interview, action_share_link, action_start_chat, card_share_copied, plaza_published, plaza_unpublished
- **zh-rTW only**: channel_api_manage_all
- **9 low-translation locales** (ar/de/es/fr/hi/in/ms/th/vi): 15 old keys (close, developer_section_title, ecoin_unit, org_chart_sheet_title, settings_*, topup_tier_*)

### Key counts after patch
| locale | before | after | diff |
|--------|--------|-------|------|
| zh-rTW | 820 | 829 | +9 |
| zh-rCN/ja/ko | 821 | 829 | +8 |
| ar/de/es/fr/hi/in/ms/th/vi | 805 | 828 | +23 |

Note: 4 Facebook/Google keys (facebook_app_id etc) remain untranslated — these are translatable=false in source and intentionally excluded.

CI: Lint + Kotlin Unit Tests + Assemble Debug APK