### PR TITLE
chore(arena): surface real 500 error message for diagnosis

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1880,7 +1880,8 @@ app.get('/arena/test/:examId', async (req, res) => {
         });
     } catch (err) {
         console.error('[Arena] test entry error:', err);
-        res.status(500).json({ error: 'internal_error' });
+        serverLog('error', 'arena', `GET /arena/test/${req.params.examId} failed: ${err.message}\n${err.stack || ''}`);
+        res.status(500).json({ error: 'internal_error', detail: err.message });
     }
 });
 if (process.env.NODE_ENV !== 'test') {

--- a/backend/interview-arena.js
+++ b/backend/interview-arena.js
@@ -1215,7 +1215,13 @@ module.exports = function arenaFactory({ serverLog, io } = {}) {
             }
         } catch (err) {
             console.error('[Arena] create exam error:', err);
-            res.status(500).json({ success: false, error: 'internal_error' });
+            audit('error', 'arena', `POST /exam failed: ${err.message}\n${err.stack || ''}`);
+            res.status(500).json({
+                success: false,
+                error: 'internal_error',
+                detail: err.message,
+                stage: 'create_exam',
+            });
         }
     });
 


### PR DESCRIPTION
## Summary

Diagnostic patch — `POST /api/arena/exam` and `GET /arena/test/:examId` are still returning 500 in production after PR #1836 (which fixed the `stripSecretsForBot` factory-export bug). The real failure is hidden behind a generic `{error:"internal_error"}`. This patch attaches `err.message` + stack to `/api/logs` and includes `err.message` in the JSON response so the next click on "🧪 Run Interview" reveals the actual cause.

Temporary — will revert or keep based on what we find.

## Test plan

- [ ] After merge: hit `POST /api/arena/exam` once, read `detail` field
- [ ] Read `/api/logs?category=arena&level=error` for full stack
- [ ] Identify and patch root cause

https://claude.ai/code/session_01Ej8vRukSh9hHUKq9pGVnTq