### PR TITLE
fix(arena): generate exam id in code — prod DB DEFAULT is missing

### DIFF
--- a/backend/arena-pool-validator.js
+++ b/backend/arena-pool-validator.js
@@ -506,17 +506,20 @@ async function validateRuntimeSelfTest({ arenaModule, dbPool, log }) {
     }
 
     // 1. Create a scratch exam directly in DB (skip 5-min IP cooldown).
+    // Generate id explicitly — the column DEFAULT can be missing/broken on
+    // production (PR #1813 migration didn't always re-set the new DEFAULT).
+    // Mirrors the live POST /api/arena/exam path so this test catches the
+    // same NOT-NULL violation real users would hit.
+    const { newExamId } = require('./entity-id');
+    const examId = newExamId();
     const examToken = 'selftest-' + Date.now().toString(36) + Math.random().toString(36).slice(2, 8);
     const expiresAt = new Date(Date.now() + 30 * 60_000);
-    let examId;
     try {
-        const res = await dbPool.query(
-            `INSERT INTO arena_exams (exam_token, status, max_score, expires_at)
-             VALUES ($1, 'waiting', $2, $3)
-             RETURNING id`,
-            [examToken, arenaModule.MAX_TOTAL_SCORE || 147, expiresAt]
+        await dbPool.query(
+            `INSERT INTO arena_exams (id, exam_token, status, max_score, expires_at)
+             VALUES ($1, $2, 'waiting', $3, $4)`,
+            [examId, examToken, arenaModule.MAX_TOTAL_SCORE || 147, expiresAt]
         );
-        examId = res.rows[0].id;
     } catch (err) {
         out.issues.push(`insert arena_exams failed: ${err.message}`);
         out.stage = 'create_exam';

--- a/backend/index.js
+++ b/backend/index.js
@@ -1880,7 +1880,8 @@ app.get('/arena/test/:examId', async (req, res) => {
         });
     } catch (err) {
         console.error('[Arena] test entry error:', err);
-        res.status(500).json({ error: 'internal_error' });
+        serverLog('error', 'arena', `GET /arena/test/${req.params.examId} failed: ${err.message}\n${err.stack || ''}`);
+        res.status(500).json({ error: 'internal_error', detail: err.message });
     }
 });
 if (process.env.NODE_ENV !== 'test') {

--- a/backend/interview-arena.js
+++ b/backend/interview-arena.js
@@ -1215,7 +1215,13 @@ module.exports = function arenaFactory({ serverLog, io } = {}) {
             }
         } catch (err) {
             console.error('[Arena] create exam error:', err);
-            res.status(500).json({ success: false, error: 'internal_error' });
+            audit('error', 'arena', `POST /exam failed: ${err.message}\n${err.stack || ''}`);
+            res.status(500).json({
+                success: false,
+                error: 'internal_error',
+                detail: err.message,
+                stage: 'create_exam',
+            });
         }
     });
 

--- a/backend/interview-arena.js
+++ b/backend/interview-arena.js
@@ -19,6 +19,7 @@ const crypto = require('crypto');
 const { Pool } = require('pg');
 const fs = require('fs');
 const path = require('path');
+const { newExamId } = require('./entity-id');
 
 const pool = new Pool({
     connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot',
@@ -1085,11 +1086,16 @@ module.exports = function arenaFactory({ serverLog, io } = {}) {
             // Optional: link this exam to a rental listing for interview qualification
             const listingId = req.body?.listingId || null;
 
+            // Generate id in code rather than relying on the column DEFAULT.
+            // The PR #1813 migration set the column DEFAULT to gen_random_bytes()
+            // (pgcrypto), but on production that DEFAULT is missing/non-functional
+            // — INSERTs without an explicit id violate the NOT NULL constraint.
+            const examId = newExamId();
             const examRes = await pool.query(
-                `INSERT INTO arena_exams (exam_token, listing_id, status, max_score, expires_at)
-                 VALUES ($1, $2, $3, $4, $5)
+                `INSERT INTO arena_exams (id, exam_token, listing_id, status, max_score, expires_at)
+                 VALUES ($1, $2, $3, $4, $5, $6)
                  RETURNING id, exam_token, listing_id, status, created_at, expires_at`,
-                [examToken, listingId, EXAM_STATUS.WAITING, MAX_TOTAL_SCORE, expiresAt]
+                [examId, examToken, listingId, EXAM_STATUS.WAITING, MAX_TOTAL_SCORE, expiresAt]
             );
             const exam = examRes.rows[0];
 

--- a/backend/tests/jest/arena-pool-validator.test.js
+++ b/backend/tests/jest/arena-pool-validator.test.js
@@ -135,8 +135,10 @@ describe('validateRuntimeSelfTest — in-process scoring-flow check', () => {
             async query(sql, params = []) {
                 const s = sql.replace(/\s+/g, ' ').trim();
                 if (/INSERT INTO arena_exams/i.test(s)) {
-                    const id = 'exam-' + (store.exams.size + 1);
-                    store.exams.set(id, { id, exam_token: params[0] });
+                    // Validator now passes id explicitly to mirror the production fix —
+                    // production's column DEFAULT was missing so we generate id in code.
+                    const id = params[0];
+                    store.exams.set(id, { id, exam_token: params[1] });
                     return { rows: [{ id }], rowCount: 1 };
                 }
                 if (/INSERT INTO arena_sessions/i.test(s)) {
@@ -198,6 +200,50 @@ describe('validateRuntimeSelfTest — in-process scoring-flow check', () => {
         const report = await validator.validateRuntimeSelfTest({ arenaModule, dbPool: null });
         expect(report.ok).toBe(false);
         expect(report.issues[0]).toMatch(/dbPool/);
+    });
+
+    test('regression: passing id explicitly avoids prod-style NOT NULL violation', async () => {
+        // Simulate production's broken state: column DEFAULT for arena_exams.id
+        // is missing/non-functional, so any INSERT that omits id violates NOT NULL.
+        const arenaModule = require('../../interview-arena');
+        const store = { exams: new Map(), sessions: [] };
+        const dbPool = {
+            async query(sql, params = []) {
+                const s = sql.replace(/\s+/g, ' ').trim();
+                if (/INSERT INTO arena_exams/i.test(s)) {
+                    // First positional param MUST be a non-null id (production fix)
+                    if (!params[0]) {
+                        const err = new Error('null value in column "id" of relation "arena_exams" violates not-null constraint');
+                        throw err;
+                    }
+                    const id = params[0];
+                    store.exams.set(id, { id, exam_token: params[1] });
+                    return { rows: [{ id }], rowCount: 1 };
+                }
+                if (/INSERT INTO arena_sessions/i.test(s)) {
+                    store.sessions.push({
+                        exam_id: params[0], session_token: params[1],
+                        test_type: params[2], test_index: params[3],
+                        challenge_config: params[4], max_score: params[5],
+                    });
+                    return { rows: [{}], rowCount: 1 };
+                }
+                if (/SELECT session_token.*FROM arena_sessions WHERE exam_id/i.test(s)) {
+                    const rows = store.sessions
+                        .filter(x => x.exam_id === params[0])
+                        .sort((a, b) => a.test_index - b.test_index);
+                    return { rows, rowCount: rows.length };
+                }
+                if (/DELETE FROM arena_exams/i.test(s)) {
+                    store.exams.delete(params[0]);
+                    return { rows: [], rowCount: 1 };
+                }
+                return { rows: [], rowCount: 0 };
+            },
+        };
+        const report = await validator.validateRuntimeSelfTest({ arenaModule, dbPool });
+        expect(report.ok).toBe(true);
+        expect(report.totalScore).toBeGreaterThan(0);
     });
 
     test('cleans up scratch exam even when a session insert fails', async () => {


### PR DESCRIPTION
## Summary

`POST /api/arena/exam` (clicking 🧪 Run Interview) was returning 500 with the actual error (now visible thanks to PR #1837):

```
null value in column "id" of relation "arena_exams" violates not-null constraint
```

PR #1813's schema migration dropped the UUID default, converted `id` to `VARCHAR(48)`, and tried to `SET DEFAULT ('exam_' || encode(gen_random_bytes(12), 'hex'))`. On production that SET DEFAULT never took effect — every INSERT without an explicit `id` violated NOT NULL.

Fix: generate the id in code via `newExamId()` from the existing entity-id factory and pass it explicitly. Same fix applied to `validateRuntimeSelfTest` so the routine self-test mirrors the live path.

## Test plan

- [x] 53/53 Jest tests pass (`arena-pool-validator.test.js` + `interview-arena.test.js`)
- [x] New regression test: stub throws the exact prod NOT NULL error if id is omitted; passes only because we now pass id explicitly
- [x] ESLint: 0 errors
- [ ] After merge: re-run live `POST /api/arena/exam` — must return 200 with exam.id
- [ ] After merge: click 🧪 Run Interview in card-holder — must open new tab, no "invalid" error

https://claude.ai/code/session_01Ej8vRukSh9hHUKq9pGVnTq