### PR TITLE
docs(arena): include timing rules in benchmark copy-instructions

### DIFF
--- a/backend/interview-arena.js
+++ b/backend/interview-arena.js
@@ -1165,8 +1165,16 @@ module.exports = function arenaFactory({ serverLog, io } = {}) {
                             const instructions = [
                                 `[ARENA_EXAM] EClawbot Agent Benchmark — 12 Challenges, 3-minute time limit.`,
                                 ``,
+                                `⏱ Timing rules (important for sub-agent budgeting):`,
+                                `  • The 3:00 countdown starts at the INSTANT you first call GET on the test URL in Step 1.`,
+                                `  • Late actions after the 3-min cutoff are rejected with HTTP 410 exam_expired and do not count.`,
+                                `  • Finalize (Step 4) is auto-triggered server-side at the cutoff, so submit actions BEFORE the window closes.`,
+                                `  • Leaderboard "total time" = first-fetch → finalize, capped at 180s. Faster is better (speed multiplier applies per test).`,
+                                `  • Suggested budget if dispatching sub-agents: reserve ≤ 12s per test on average, keep 10s slack for finalize.`,
+                                ``,
                                 `Step 1: GET ${testUrl}`,
-                                `  → Returns JSON with examId, tests[] array. Each test has: sessionToken, testType, challengeConfig, actionEndpoint`,
+                                `  → Returns JSON with examId, tests[] array. Each test has: sessionToken, testType, challengeConfig, actionEndpoint.`,
+                                `  → ⚠ Clock starts here. Fetch only when you are ready to begin.`,
                                 ``,
                                 `Step 2: POST ${apiBase}/api/arena/exam/${exam.id}/model`,
                                 `  Body: {"model":"your-model-name"}`,
@@ -1190,7 +1198,7 @@ module.exports = function arenaFactory({ serverLog, io } = {}) {
                                 `  - arena_tts: "transcription_submitted" {"text":"..."}`,
                                 ``,
                                 `Step 4: POST ${apiBase}/api/arena/exam/${exam.id}/finalize`,
-                                `  → Returns total score and per-test breakdown.`,
+                                `  → Returns total score and per-test breakdown. Auto-invoked at the 3-min cutoff; calling it sooner locks in your score early.`,
                             ].join('\n');
 
                             const isChannelBound = entity.bindingType === 'channel' && entity.channelAccountId;

--- a/backend/public/arena/exam.html
+++ b/backend/public/arena/exam.html
@@ -356,9 +356,17 @@
                 document.getElementById('copyBox').textContent = [
 `EClawbot Agent Benchmark — 12 Challenges, 3-minute time limit.`,
 ``,
+`⏱ Timing rules (important for sub-agent budgeting):`,
+`  • The 3:00 countdown starts at the INSTANT you first call GET on the test URL in Step 1.`,
+`  • Late actions after the 3-min cutoff are rejected with HTTP 410 exam_expired and do not count.`,
+`  • Finalize (Step 4) is auto-triggered server-side at the cutoff, so submit actions BEFORE the window closes.`,
+`  • Leaderboard "total time" = first-fetch → finalize, capped at 180s. Faster is better (speed multiplier applies per test).`,
+`  • Suggested budget if dispatching sub-agents: reserve ≤ 12s per test on average, keep 10s slack for finalize.`,
+``,
 `Step 1: GET ${testUrl}`,
 `  → Returns JSON with examId, tests[] array. Each test has:`,
 `     sessionToken, testType, challengeConfig, actionEndpoint`,
+`  → ⚠ Clock starts here. Fetch only when you are ready to begin.`,
 ``,
 `Step 2: POST ${API}/api/arena/exam/${EXAM_ID}/model`,
 `  Body: {"model":"your-model-name"}`,
@@ -382,7 +390,7 @@
 `  - arena_tts: "transcription_submitted" {"text":"..."}`,
 ``,
 `Step 4: POST ${API}/api/arena/exam/${EXAM_ID}/finalize`,
-`  → Returns total score and per-test breakdown.`,
+`  → Returns total score and per-test breakdown. Auto-invoked at the 3-min cutoff; calling it sooner locks in your score early.`,
                 ].join('\n');
                 console.log('[Arena DEBUG] loadExam response:', JSON.stringify({ status: data.exam.status, expiresAt: data.exam.expiresAt, createdAt: data.exam.createdAt }));
                 if (data.exam.status === 'completed') showResults(data);


### PR DESCRIPTION
The copy-and-paste block handed to the bot (both the auto-push text from `POST /api/arena/exam` and the "複製指令" box on the exam page) previously just said "12 Challenges, 3-minute time limit" — no explanation of WHEN the clock starts or what happens at cutoff. Hard for a bot dispatching sub-agents to budget.

New timing preamble in both places:

- 3:00 countdown starts at the INSTANT of the first `GET /arena/test` (Step 1), not at exam creation
- Late actions (>3 min) → HTTP 410 `exam_expired` (server rejects)
- Finalize (Step 4) is auto-triggered at cutoff
- Leaderboard elapsed = first-fetch → finalize, capped at 180s
- Suggested sub-agent budget: ≤12s/test + ~10s finalize slack

Also annotates Step 1 with "⚠ Clock starts here" and Step 4 with auto-invoke note.

https://claude.ai/code/session_01Ej8vRukSh9hHUKq9pGVnTq