### PR TITLE
fix(android): org chart bottom sheet only showed ~80dp on open

### DIFF
--- a/app/src/main/java/com/hank/clawlive/ui/OrgChartBottomSheetFragment.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/OrgChartBottomSheetFragment.kt
@@ -31,11 +31,16 @@ class OrgChartBottomSheetFragment : BottomSheetDialogFragment() {
         dialog.setOnShowListener {
             val sheet = dialog.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
             sheet?.let {
-                val behavior = BottomSheetBehavior.from(it)
                 val screenHeight = resources.displayMetrics.heightPixels
-                behavior.peekHeight = (screenHeight * 0.9).toInt()
-                behavior.state = BottomSheetBehavior.STATE_EXPANDED
+                val targetHeight = (screenHeight * 0.9).toInt()
+                it.layoutParams = it.layoutParams.apply { height = targetHeight }
+                it.requestLayout()
+                val behavior = BottomSheetBehavior.from(it)
+                behavior.isFitToContents = false
+                behavior.expandedOffset = (screenHeight * 0.1).toInt()
                 behavior.skipCollapsed = true
+                behavior.peekHeight = targetHeight
+                behavior.state = BottomSheetBehavior.STATE_EXPANDED
             }
         }
         return dialog


### PR DESCRIPTION
## Summary
- Explicitly size the bottom sheet view (height = 90% screen) in `setOnShowListener`, so BottomSheetBehavior no longer falls back to `fitToContents` and the content's pre-layout intrinsic height.
- Turn off `isFitToContents` and set `expandedOffset = screen × 0.1` so EXPANDED state has a deterministic size, not "wrap whatever the child measured to (0 for the WebView container)".

## Why it broke
The WebView container is `layout_height="0dp" android:layout_weight="1"`. Before layout, that's **0dp**. `BottomSheetBehavior` defaults to `fitToContents=true`, so STATE_EXPANDED used content intrinsic height = handle + title row ≈ 80dp. Users saw a thin stub at the bottom and couldn't drag it up.

Regression was introduced in PR #1810 (commit `f9497a07`, "fix(dashboard): show org chart inline instead of routing to full dashboard").

## Test plan
- [ ] `./gradlew assembleDebug` green
- [ ] `./gradlew lint` green
- [ ] Manual smoke on emulator (Pixel 6, API 34): open dashboard → tap org chart → sheet opens at ~90% height with WebView filled, can still drag down to dismiss
- [ ] Manual smoke on smaller device (API 30, 360×640): sheet still usable, WebView scrollable

🤖 Generated with [Claude Code](https://claude.com/claude-code)