### PR TITLE
fix(arena): timer doesn't start until page refresh after bot pickup

### DIFF
--- a/backend/interview-arena.js
+++ b/backend/interview-arena.js
@@ -1165,8 +1165,16 @@ module.exports = function arenaFactory({ serverLog, io } = {}) {
                             const instructions = [
                                 `[ARENA_EXAM] EClawbot Agent Benchmark — 12 Challenges, 3-minute time limit.`,
                                 ``,
+                                `⏱ Timing rules (important for sub-agent budgeting):`,
+                                `  • The 3:00 countdown starts at the INSTANT you first call GET on the test URL in Step 1.`,
+                                `  • Late actions after the 3-min cutoff are rejected with HTTP 410 exam_expired and do not count.`,
+                                `  • Finalize (Step 4) is auto-triggered server-side at the cutoff, so submit actions BEFORE the window closes.`,
+                                `  • Leaderboard "total time" = first-fetch → finalize, capped at 180s. Faster is better (speed multiplier applies per test).`,
+                                `  • Suggested budget if dispatching sub-agents: reserve ≤ 12s per test on average, keep 10s slack for finalize.`,
+                                ``,
                                 `Step 1: GET ${testUrl}`,
-                                `  → Returns JSON with examId, tests[] array. Each test has: sessionToken, testType, challengeConfig, actionEndpoint`,
+                                `  → Returns JSON with examId, tests[] array. Each test has: sessionToken, testType, challengeConfig, actionEndpoint.`,
+                                `  → ⚠ Clock starts here. Fetch only when you are ready to begin.`,
                                 ``,
                                 `Step 2: POST ${apiBase}/api/arena/exam/${exam.id}/model`,
                                 `  Body: {"model":"your-model-name"}`,
@@ -1190,7 +1198,7 @@ module.exports = function arenaFactory({ serverLog, io } = {}) {
                                 `  - arena_tts: "transcription_submitted" {"text":"..."}`,
                                 ``,
                                 `Step 4: POST ${apiBase}/api/arena/exam/${exam.id}/finalize`,
-                                `  → Returns total score and per-test breakdown.`,
+                                `  → Returns total score and per-test breakdown. Auto-invoked at the 3-min cutoff; calling it sooner locks in your score early.`,
                             ].join('\n');
 
                             const isChannelBound = entity.bindingType === 'channel' && entity.channelAccountId;

--- a/backend/public/arena/exam.html
+++ b/backend/public/arena/exam.html
@@ -392,22 +392,29 @@
 `Step 4: POST ${API}/api/arena/exam/${EXAM_ID}/finalize`,
 `  → Returns total score and per-test breakdown. Auto-invoked at the 3-min cutoff; calling it sooner locks in your score early.`,
                 ].join('\n');
-                console.log('[Arena DEBUG] loadExam response:', JSON.stringify({ status: data.exam.status, expiresAt: data.exam.expiresAt, createdAt: data.exam.createdAt }));
-                if (data.exam.status === 'completed') showResults(data);
-                else if (data.exam.status === 'active') {
+                console.log('[Arena DEBUG] loadExam response:', JSON.stringify({ status: data.exam.status, expiresAt: data.exam.expiresAt, firstFetchedAt: data.exam.firstFetchedAt, createdAt: data.exam.createdAt }));
+                if (data.exam.status === 'completed') {
+                    showResults(data);
+                } else if (data.exam.firstFetchedAt) {
+                    // Bot has already fetched the test → the 3-min clock is
+                    // running. Drive the timer off expiresAt regardless of
+                    // whether status is still 'waiting' (no actions yet) or
+                    // already 'active' (first action received). Without this
+                    // the timer sat at "--:--" until the page was reloaded.
                     document.getElementById('statusText').textContent = 'Evaluation in progress...';
                     document.getElementById('scoreWrap').style.display = 'block';
                     if (data.exam.model) showModel(data.exam.model);
-                    // Calculate actual remaining time from expiresAt
                     let remainingSec = 180;
                     if (data.exam.expiresAt) {
                         const diff = Math.floor((new Date(data.exam.expiresAt).getTime() - Date.now()) / 1000);
                         remainingSec = Math.max(0, Math.min(180, diff));
-                        console.log('[Arena DEBUG] timer: expiresAt=' + data.exam.expiresAt + ' diff=' + diff + 's remaining=' + remainingSec + 's');
-                    } else {
-                        console.warn('[Arena DEBUG] no expiresAt in response, falling back to 180s');
                     }
                     startExamTimer(remainingSec);
+                } else {
+                    // Bot hasn't fetched yet — clock genuinely hasn't started.
+                    // Leave the timer at "--:--"; the socket "timer_started"
+                    // event will start it the moment the bot picks up.
+                    document.getElementById('statusText').textContent = 'Waiting for bot to fetch the test…';
                 }
             } catch (e) { console.error(e); }
         }

--- a/backend/public/arena/exam.html
+++ b/backend/public/arena/exam.html
@@ -356,9 +356,17 @@
                 document.getElementById('copyBox').textContent = [
 `EClawbot Agent Benchmark — 12 Challenges, 3-minute time limit.`,
 ``,
+`⏱ Timing rules (important for sub-agent budgeting):`,
+`  • The 3:00 countdown starts at the INSTANT you first call GET on the test URL in Step 1.`,
+`  • Late actions after the 3-min cutoff are rejected with HTTP 410 exam_expired and do not count.`,
+`  • Finalize (Step 4) is auto-triggered server-side at the cutoff, so submit actions BEFORE the window closes.`,
+`  • Leaderboard "total time" = first-fetch → finalize, capped at 180s. Faster is better (speed multiplier applies per test).`,
+`  • Suggested budget if dispatching sub-agents: reserve ≤ 12s per test on average, keep 10s slack for finalize.`,
+``,
 `Step 1: GET ${testUrl}`,
 `  → Returns JSON with examId, tests[] array. Each test has:`,
 `     sessionToken, testType, challengeConfig, actionEndpoint`,
+`  → ⚠ Clock starts here. Fetch only when you are ready to begin.`,
 ``,
 `Step 2: POST ${API}/api/arena/exam/${EXAM_ID}/model`,
 `  Body: {"model":"your-model-name"}`,
@@ -382,7 +390,7 @@
 `  - arena_tts: "transcription_submitted" {"text":"..."}`,
 ``,
 `Step 4: POST ${API}/api/arena/exam/${EXAM_ID}/finalize`,
-`  → Returns total score and per-test breakdown.`,
+`  → Returns total score and per-test breakdown. Auto-invoked at the 3-min cutoff; calling it sooner locks in your score early.`,
                 ].join('\n');
                 console.log('[Arena DEBUG] loadExam response:', JSON.stringify({ status: data.exam.status, expiresAt: data.exam.expiresAt, createdAt: data.exam.createdAt }));
                 if (data.exam.status === 'completed') showResults(data);


### PR DESCRIPTION
**User report:** opening the exam page shows `剩餘時間 --:--` and only starts ticking after a manual page refresh.

**Root cause:** `loadExam()` only started the countdown when `status === 'active'`, but the server doesn't flip status to `'active'` until the bot's FIRST action arrives. There's a window between (a) bot calling `GET /arena/test` (which sets `first_fetched_at` + bumps `expires_at`, but leaves status as `'waiting'`) and (b) bot sending its first action. If the user opens the exam page during that window — or if the page loads after bot pickup but before the socket connects — neither branch in `loadExam()` runs and the timer sits at the `--:--` placeholder.

**Fix:** drive the timer off `exam.firstFetchedAt` instead of `status`. If `firstFetchedAt` is set, the 3-min clock is already running — compute remaining from `expiresAt` and start the timer regardless of whether the status is `'waiting'` or `'active'`.

Also adds an explicit `Waiting for bot to fetch the test…` status text when `firstFetchedAt` is null, so the page communicates state instead of looking broken.

## Test plan

- [x] ESLint passes
- [ ] After deploy: open exam page right after creating exam (before bot fetches) → status text says "Waiting for bot to fetch", timer shows `--:--`
- [ ] After deploy: bot fetches → page receives socket `timer_started` → countdown begins ticking without refresh
- [ ] After deploy: open exam page after bot has fetched but before first action → countdown starts immediately, no refresh needed

https://claude.ai/code/session_01Ej8vRukSh9hHUKq9pGVnTq