### PR TITLE
fix(arena): total-time stuck on --:-- when exam finishes fast

### DIFF
--- a/backend/public/arena/exam.html
+++ b/backend/public/arena/exam.html
@@ -419,15 +419,11 @@
             } catch (e) { console.error(e); }
         }
 
-        let resultsShown = false;
-        function showResults(data) {
-            if (resultsShown) return;
-            resultsShown = true;
-            document.getElementById('statusText').textContent = 'Evaluation Complete';
+        // Switch timer label to "Total time" and paint elapsedSec when we have it.
+        // Kept OUTSIDE the `resultsShown` guard so a later poll carrying elapsedSec
+        // can overwrite an earlier Socket.IO/autoFinalize call that lacked it.
+        function paintTotalTime(data) {
             if (examTimerInterval) { clearInterval(examTimerInterval); examTimerInterval = null; }
-            // Exam is done — swap the "Time remaining" label to "Total time"
-            // and show the actual time taken (first_fetched_at → completed_at,
-            // capped at 3:00). Falls back to "--:--" if the exam never started.
             const timerEl = document.getElementById('examTimer');
             const timerLabel = document.getElementById('examTimerLabel');
             if (timerLabel) {
@@ -442,11 +438,21 @@
                 if (secs != null) {
                     const m = Math.floor(secs / 60), s = secs % 60;
                     timerEl.textContent = m + ':' + String(s).padStart(2, '0');
-                } else {
-                    timerEl.textContent = '--:--';
                 }
+                // If secs is null, leave whatever was there ("--:--" or the last
+                // countdown value) and wait for a later call to overwrite.
                 timerEl.style.color = 'var(--text-muted)';
             }
+        }
+
+        let resultsShown = false;
+        function showResults(data) {
+            // Always refresh the timer — the 5s poll will catch up even if an
+            // earlier caller (Socket.IO, autoFinalize) arrived without elapsedSec.
+            paintTotalTime(data);
+            if (resultsShown) return;
+            resultsShown = true;
+            document.getElementById('statusText').textContent = 'Evaluation Complete';
             if (data?.exam?.model) showModel(data.exam.model);
             document.getElementById('scoreWrap').style.display = 'block';
             if (data.exam) { document.getElementById('totalScore').textContent = data.exam.totalScore || 0; document.getElementById('scoreFill').style.width = Math.round((data.exam.totalScore || 0) / 147 * 100) + '%'; }


### PR DESCRIPTION
## Summary
- `showResults()` is called from 3 places; Socket.IO `exam_complete` and autoFinalize send no `elapsedSec` but still set `resultsShown=true`, locking the timer UI at `--:--`.
- Split timer label/value update into `paintTotalTime()` that runs on every `showResults()` call (outside the guard).
- Guard still protects expensive work (report render, confetti, leaderboard modal) from running twice.

## Repro & verification
Confirmed via Playwright against production: API `/api/arena/exam/:id/results` returned `elapsedSec: 29` but UI stayed at `--:--`. Full trace and fix rationale in commit message.

## Test plan
- [ ] Deploy to Railway
- [ ] Open a fresh exam, dispatch to a bot, confirm `--:--` -> actual mm:ss after completion (both when a bot finalizes early and when the 3:00 countdown auto-finalizes)

Generated with Claude Code