### PR TITLE
fix(portal): lazy-render mermaid only when sub-panel visible

### DIFF
--- a/backend/public/portal/shared/info.js
+++ b/backend/public/portal/shared/info.js
@@ -54,7 +54,10 @@ window.addEventListener('DOMContentLoaded', async () => {
         clearGuideActive();
         btn.classList.add('active');
         const panel = document.getElementById('guide-' + tabId);
-        if (panel) panel.classList.add('active');
+        if (panel) {
+            panel.classList.add('active');
+            renderMermaidIn(panel);
+        }
         history.replaceState(null, '', '#guide/' + tabId);
     }
 
@@ -125,6 +128,13 @@ window.addEventListener('DOMContentLoaded', async () => {
     window.addEventListener('hashchange', handleHash);
 });
 
+function renderMermaidIn(root) {
+    if (!root || typeof mermaid === 'undefined') return;
+    const nodes = [...root.querySelectorAll('pre.mermaid:not([data-processed])')]
+        .filter(n => n.offsetParent !== null && n.getBoundingClientRect().width > 0);
+    if (nodes.length) mermaid.run({ nodes });
+}
+
 function switchInfoTab(target) {
     const infoTabs = document.querySelectorAll('.info-tab');
     const infoPanels = document.querySelectorAll('.info-panel');
@@ -135,11 +145,7 @@ function switchInfoTab(target) {
     if (tab) tab.classList.add('active');
     if (panel) {
         panel.classList.add('active');
-        // Render Mermaid diagrams deferred until panel is visible (avoids translate(NaN) errors)
-        const unrendered = panel.querySelectorAll('pre.mermaid:not([data-processed])');
-        if (unrendered.length && typeof mermaid !== 'undefined') {
-            mermaid.run({ nodes: unrendered });
-        }
+        renderMermaidIn(panel);
     }
     history.replaceState(null, '', '#' + target);
     window.scrollTo({ top: 0, behavior: 'smooth' });


### PR DESCRIPTION
## Summary
- Render mermaid diagrams only for nodes whose container is actually visible (offsetParent + non-zero width) — deferring hidden sub-panels until activated
- Wire `activateGuide` to run mermaid when a guide-panel becomes active, so intent-api-injection / usecase-minigame / etc. render on first click

## Bug
Fixes card_ecfa0759c0c92d8bf2b8fb57 — 16× `<g> attribute transform: Expected number, translate(undefined, NaN)` in console when switching to 使用指南 / 進階 tabs. Root cause: `mermaid.run` was called with ALL unrendered `pre.mermaid` nodes inside the info-panel, including ones in sub-panels where `display:none` made `width=0`, triggering div/0 in the transform math.

## Test plan
- [x] Local server + playwright: navigate → click 使用指南 / 進階 / 動態 API 注入 → 0 mermaid NaN errors (only benign /api/auth/me 404)
- [ ] Post-deploy console check on https://eclawbot.com/portal/info.html#guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)