### PR TITLE
fix(android): force orgchart bottom sheet to 90% height

### DIFF
--- a/app/src/main/java/com/hank/clawlive/ui/OrgChartBottomSheetFragment.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/OrgChartBottomSheetFragment.kt
@@ -31,9 +31,16 @@ class OrgChartBottomSheetFragment : BottomSheetDialogFragment() {
         dialog.setOnShowListener {
             val sheet = dialog.findViewById<View>(com.google.android.material.R.id.design_bottom_sheet)
             sheet?.let {
-                val behavior = BottomSheetBehavior.from(it)
                 val screenHeight = resources.displayMetrics.heightPixels
-                behavior.peekHeight = (screenHeight * 0.9).toInt()
+                val targetHeight = (screenHeight * 0.9).toInt()
+                // BottomSheetDialog ignores match_parent on the sheet root and
+                // measures to children's wrap_content, which collapses the
+                // WebView (layout_weight=1 on a 0dp child) to ~20% of screen.
+                // Force the sheet's height explicitly so STATE_EXPANDED lands
+                // at the intended 90% height.
+                it.layoutParams = it.layoutParams.apply { height = targetHeight }
+                val behavior = BottomSheetBehavior.from(it)
+                behavior.peekHeight = targetHeight
                 behavior.state = BottomSheetBehavior.STATE_EXPANDED
                 behavior.skipCollapsed = true
             }


### PR DESCRIPTION
## Summary
- Force `layoutParams.height` on the design_bottom_sheet view in `OrgChartBottomSheetFragment` so `STATE_EXPANDED` actually lands at 90% of screen height
- Root cause: root `LinearLayout` uses `match_parent`, which `BottomSheetDialog` measures as `wrap_content`, collapsing the WebView (`0dp` + `weight=1`) and leaving the sheet stuck at ~20% / ~483 px on Pixel_9a
- `peekHeight` is now set to the same target, so early frames before `STATE_EXPANDED` takes effect aren't visibly tiny either

## Bug reference
- Parent card: `card_3d499e55d0dab8c4b17596ae` — [P2] Org chart issue persists
- Filed-by-drill card: "[P2] orgchart bottom sheet won't expand beyond peek — blocks reference drag/reset repro"
- Observed on com.hank.clawlive 1.0.75 / Pixel_9a emulator-5554
  - `design_bottom_sheet` = `[0,1941][1080,2424]` (~483 px tall)
  - inner WebView = `[0,2130][1080,2361]` (only 231 px; page content ≈ 1200 px)
- Swipe-up from handle dismissed the sheet instead of expanding (expected, since the sheet was already "expanded" in the wrong short height)

## Test plan
- [ ] Rebuild APK (next version bump); install on Pixel_9a emulator
- [ ] Launch EClaw → tap top-right grid icon ("Open full dashboard")
- [ ] Confirm sheet opens at ~90% of screen with full orgchart content visible (儀表板 header → 實體總覽 / 組織架構 tabs → tree → Reset + radio options)
- [ ] Swipe-down from handle still dismisses (no regression on close gesture)
- [ ] After sheet expansion confirmed, rerun drag / touch-drag / reset checks from the parent card to see which of the three original symptoms still reproduce

🤖 Generated with [Claude Code](https://claude.com/claude-code)