### PR TITLE
fix(security): remove allowVulnerableTags XSS risk in sanitizer (#1840)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1409,10 +1409,24 @@ app.get('/p/:code/:noteId', async (req, res) => {
 
 function sanitizePublicHtml(html) {
     if (!html) return '';
-    // Sanitize HTML (strips <script> by default)
-    const sanitized = sanitizeHtml(html, {
-        allowVulnerableTags: true,
-        allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img', 'h1', 'h2', 'span', 'details', 'summary', 'mark', 'del', 'ins', 'sub', 'sup', 'style']),
+
+    // Extract <style> blocks before sanitization (sanitize-html strips them without allowVulnerableTags)
+    const extractedStyles = [];
+    const htmlWithoutStyles = html.replace(/<style[^>]*>([\s\S]*?)<\/style>/gi, (_match, css) => {
+        // Strip dangerous CSS: @import, url(), expression(), behavior, -moz-binding
+        const safeCss = css
+            .replace(/@import\b[^;]*/gi, '/* @import removed */')
+            .replace(/expression\s*\([^)]*\)/gi, '/* expression removed */')
+            .replace(/behavior\s*:[^;]*/gi, '/* behavior removed */')
+            .replace(/-moz-binding\s*:[^;]*/gi, '/* -moz-binding removed */')
+            .replace(/url\s*\(\s*["']?(?!data:image\/)[^)]*\)/gi, '/* url() removed */');
+        if (safeCss.trim()) extractedStyles.push(safeCss);
+        return '';
+    });
+
+    // Sanitize HTML without allowVulnerableTags (no <style>/<script> in allowedTags)
+    const sanitized = sanitizeHtml(htmlWithoutStyles, {
+        allowedTags: sanitizeHtml.defaults.allowedTags.concat(['img', 'h1', 'h2', 'span', 'details', 'summary', 'mark', 'del', 'ins', 'sub', 'sup']),
         allowedAttributes: {
             ...sanitizeHtml.defaults.allowedAttributes,
             img: ['src', 'alt', 'width', 'height', 'loading'],
@@ -1433,9 +1447,14 @@ function sanitizePublicHtml(html) {
         } }
     });
 
+    // Re-inject sanitized <style> blocks
+    const styleBlock = extractedStyles.length > 0
+        ? `<style>${extractedStyles.join('\n')}</style>`
+        : '';
+
     // If original HTML contains <script>, preserve them as blocked for consent-gated execution
     const hasScripts = /<script[\s>]/i.test(html);
-    if (!hasScripts) return sanitized;
+    if (!hasScripts) return styleBlock + sanitized;
 
     // Extract all <script> tags from original HTML, encode as data for deferred execution
     const scriptBlocks = [];
@@ -1443,11 +1462,11 @@ function sanitizePublicHtml(html) {
         const srcMatch = attrs.match(/src=["']([^"']+)["']/i);
         scriptBlocks.push(srcMatch ? { src: srcMatch[1] } : { inline: body });
     });
-    if (scriptBlocks.length === 0) return sanitized;
+    if (scriptBlocks.length === 0) return styleBlock + sanitized;
 
     // Embed blocked scripts as JSON data attribute for client-side consent activation
     const encoded = Buffer.from(JSON.stringify(scriptBlocks)).toString('base64');
-    return sanitized + `<div id="eclaw-blocked-scripts" data-scripts="${encoded}" style="display:none"></div>`;
+    return styleBlock + sanitized + `<div id="eclaw-blocked-scripts" data-scripts="${encoded}" style="display:none"></div>`;
 }
 
 /** Check if rendered content has blocked scripts that need consent */
@@ -16358,3 +16377,4 @@ module.exports.httpServer = httpServer;
 module.exports.io = io;
 module.exports.devices = devices;
 module.exports.safeEqual = safeEqual;
+module.exports._sanitizePublicHtml = sanitizePublicHtml;

--- a/backend/tests/jest/sanitize-public-html.test.js
+++ b/backend/tests/jest/sanitize-public-html.test.js
@@ -1,0 +1,116 @@
+/**
+ * Regression test for sanitizePublicHtml — #1840 XSS fix.
+ *
+ * Verifies that:
+ * 1. allowVulnerableTags is NOT used (no raw <style>/<script> passthrough)
+ * 2. CSS from <style> tags is extracted, sanitized, and re-injected
+ * 3. Dangerous CSS constructs (url(), @import, expression()) are stripped
+ * 4. Normal HTML and inline styles still work
+ * 5. <script> tags are blocked (consent-gated)
+ */
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+        connect: jest.fn().mockResolvedValue({
+            query: jest.fn().mockResolvedValue({ rows: [] }),
+            release: jest.fn(),
+        }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+const app = require('../../index');
+const sanitize = app._sanitizePublicHtml;
+
+describe('sanitizePublicHtml (XSS regression #1840)', () => {
+    test('strips <script> tags from output (consent-gated)', () => {
+        const html = '<p>Hello</p><script>alert("xss")</script>';
+        const result = sanitize(html);
+        expect(result).not.toContain('<script>');
+        // Script should be preserved as blocked data for consent
+        expect(result).toContain('eclaw-blocked-scripts');
+    });
+
+    test('preserves safe HTML tags', () => {
+        const html = '<h1>Title</h1><p>Text</p><ul><li>Item</li></ul>';
+        const result = sanitize(html);
+        expect(result).toContain('<h1>');
+        expect(result).toContain('<p>');
+        expect(result).toContain('<li>');
+    });
+
+    test('preserves inline style attributes', () => {
+        const html = '<p style="color: red; font-size: 14px;">Styled</p>';
+        const result = sanitize(html);
+        expect(result).toContain('color');
+    });
+
+    test('extracts <style> blocks and re-injects sanitized CSS', () => {
+        const html = '<style>.foo { color: blue; }</style><p class="foo">Blue text</p>';
+        const result = sanitize(html);
+        expect(result).toContain('<style>');
+        expect(result).toContain('color: blue');
+        expect(result).toContain('<p');
+    });
+
+    test('strips @import from <style> blocks', () => {
+        const html = '<style>@import url("https://evil.com/steal.css"); .ok { color: red; }</style><p>Text</p>';
+        const result = sanitize(html);
+        expect(result).toContain('/* @import removed */');
+        expect(result).not.toContain('evil.com');
+        expect(result).toContain('color: red');
+    });
+
+    test('strips expression() from <style> blocks', () => {
+        const html = '<style>.x { width: expression(document.body.clientWidth); }</style><p>T</p>';
+        const result = sanitize(html);
+        expect(result).not.toContain('expression(');
+        expect(result).toContain('/* expression removed */');
+    });
+
+    test('strips url() with non-data-image sources', () => {
+        const html = '<style>.bg { background: url("https://tracker.com/pixel.gif"); }</style><p>T</p>';
+        const result = sanitize(html);
+        expect(result).not.toContain('tracker.com');
+        expect(result).toContain('/* url() removed */');
+    });
+
+    test('preserves url() with data:image sources', () => {
+        const html = '<style>.bg { background: url(data:image/png;base64,abc123); }</style><p>T</p>';
+        const result = sanitize(html);
+        expect(result).toContain('data:image/png');
+    });
+
+    test('strips -moz-binding from <style> blocks', () => {
+        const html = '<style>.x { -moz-binding: url("https://evil.com/xbl"); }</style><p>T</p>';
+        const result = sanitize(html);
+        expect(result).not.toContain('-moz-binding:');
+        expect(result).not.toContain('evil.com');
+    });
+
+    test('returns empty string for null/empty input', () => {
+        expect(sanitize(null)).toBe('');
+        expect(sanitize('')).toBe('');
+        expect(sanitize(undefined)).toBe('');
+    });
+
+    test('strips <style> tag from allowedTags (no allowVulnerableTags)', () => {
+        // Without the fix, <style> would pass through directly
+        // With the fix, <style> is extracted, sanitized, and re-injected separately
+        const html = '<style>body { background: red; }</style><p>Safe</p>';
+        const result = sanitize(html);
+        // The output should still contain <style> (re-injected), but the content is sanitized
+        expect(result).toContain('<style>');
+        expect(result).toContain('background: red');
+    });
+
+    test('multiple <style> blocks are all sanitized', () => {
+        const html = '<style>.a { color: red; }</style><p>Hi</p><style>.b { font-size: 12px; } @import "evil";</style>';
+        const result = sanitize(html);
+        expect(result).toContain('color: red');
+        expect(result).toContain('font-size: 12px');
+        expect(result).toContain('/* @import removed */');
+        expect(result).not.toContain('"evil"');
+    });
+});


### PR DESCRIPTION
## Summary
- Remove `allowVulnerableTags: true` from note page HTML sanitizer to close XSS risk (#1840)
- Extract `<style>` blocks before sanitization, strip dangerous CSS constructs (@import, url(), expression(), behavior, -moz-binding), and re-inject safely
- Add 12 regression tests covering all XSS vectors

## Test plan
- [x] All 89 Jest suites pass (1577+ tests)
- [x] i18n-syntax test passes
- [x] 12 new sanitizer regression tests pass
- [ ] Verify note pages with custom CSS still render correctly post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)