### PR TITLE
test: add fetch timeout + per-test hard cap to release gate

### DIFF
--- a/backend/run_all_tests.js
+++ b/backend/run_all_tests.js
@@ -119,7 +119,24 @@ const TEST_FILES = [
 // - test_entity_communication.js - Manual device UI testing
 // - test_name_feature.js         - Manual device UI testing
 
-const TEST_TIMEOUT = 600000; // 600 seconds per test (stress tests need more time when running in full suite)
+// Per-test hard cap. Default 120s — enough for every current suite under a
+// healthy backend; trips fast when Railway is unreachable instead of hanging
+// the release gate for 10 minutes.
+//
+// Override via env TEST_HARD_CAP_MS (e.g. 600000 for slow stress reruns).
+// Per-suite overrides live in TEST_TIMEOUT_OVERRIDES below.
+const DEFAULT_TEST_TIMEOUT_MS = 120_000;
+const TEST_TIMEOUT = Number.isFinite(Number(process.env.TEST_HARD_CAP_MS)) && Number(process.env.TEST_HARD_CAP_MS) > 0
+    ? Number(process.env.TEST_HARD_CAP_MS)
+    : DEFAULT_TEST_TIMEOUT_MS;
+
+// Stress tests that legitimately need more than the default cap.
+const TEST_TIMEOUT_OVERRIDES = {
+    'test_entity_delete.js':       600_000, // 40-entity stress
+    'test-dynamic-entities.js':    300_000, // 20-entity extreme + sparse delete cycles
+    'test-entity-trash.js':        300_000, // soft-delete + 7-day retention
+    'test_ux_coverage.js':         300_000, // coverage aggregation
+};
 
 /**
  * Clean up test environment before/after tests
@@ -189,15 +206,18 @@ async function runTest(testFile) {
         let output = '';
         let resolved = false;
 
-        // Timeout handler
+        // Per-test hard cap. If a test hangs (e.g. bare fetch() against a slow
+        // Railway instance) kill the child and emit a clear failure line so the
+        // release gate fails in minutes instead of hours.
+        const perTestTimeout = TEST_TIMEOUT_OVERRIDES[testFile] || TEST_TIMEOUT;
         const timeout = setTimeout(() => {
             if (!resolved) {
                 resolved = true;
-                child.kill();
-                console.log(`\n⏱️ TIMEOUT: ${testFile} (${TEST_TIMEOUT / 1000}s)`);
-                resolve({ file: testFile, passed: false, timeout: true });
+                try { child.kill('SIGKILL'); } catch { /* noop */ }
+                console.log(`\n⏱️  TEST TIMED OUT: ${testFile} (exceeded ${perTestTimeout / 1000}s hard cap)`);
+                resolve({ file: testFile, passed: false, timeout: true, timeoutMs: perTestTimeout });
             }
-        }, TEST_TIMEOUT);
+        }, perTestTimeout);
 
         child.stdout.on('data', (data) => {
             const str = data.toString();
@@ -280,7 +300,8 @@ async function main() {
             console.log(`⏭️  SKIP: ${r.file}`);
             skipCount++;
         } else if (r.timeout) {
-            console.log(`⏱️  TIMEOUT: ${r.file}`);
+            const s = r.timeoutMs ? ` (${r.timeoutMs / 1000}s cap)` : '';
+            console.log(`⏱️  TEST TIMED OUT: ${r.file}${s}`);
             failCount++;
         } else if (r.passed) {
             console.log(`✅ PASS: ${r.file}`);

--- a/backend/tests/helpers/fetch-with-timeout.js
+++ b/backend/tests/helpers/fetch-with-timeout.js
@@ -1,0 +1,95 @@
+/**
+ * fetch-with-timeout — Shared helper for live-API regression tests
+ *
+ * Purpose: wrap global `fetch()` with an AbortController-based timeout so a
+ * slow or unreachable Railway instance fails fast instead of hanging the
+ * entire release gate (see 2026-04-19 v1.0.76 stall in test-dynamic-entities).
+ *
+ * Usage:
+ *   const { fetchWithTimeout, TimeoutError, getDefaultTimeoutMs } = require('./helpers/fetch-with-timeout');
+ *   const res = await fetchWithTimeout(url, { method: 'POST', body, headers });
+ *   // override per-call: fetchWithTimeout(url, opts, { timeoutMs: 5000 })
+ *
+ * Default timeout: 30_000 ms. Override globally via env TEST_FETCH_TIMEOUT_MS.
+ */
+
+const DEFAULT_TIMEOUT_MS = 30_000;
+
+function getDefaultTimeoutMs() {
+    const raw = process.env.TEST_FETCH_TIMEOUT_MS;
+    if (!raw) return DEFAULT_TIMEOUT_MS;
+    const n = Number(raw);
+    if (!Number.isFinite(n) || n <= 0) return DEFAULT_TIMEOUT_MS;
+    return n;
+}
+
+class TimeoutError extends Error {
+    constructor(message, { url, timeoutMs } = {}) {
+        super(message);
+        this.name = 'TimeoutError';
+        this.code = 'ETIMEOUT';
+        this.url = url;
+        this.timeoutMs = timeoutMs;
+    }
+}
+
+/**
+ * withTimeout — run an async function with an AbortController that auto-aborts
+ * after `ms` milliseconds. The inner function receives the AbortSignal as its
+ * sole argument so it can forward it to `fetch()` (or any abortable op).
+ *
+ * Throws TimeoutError if the timer fires before fn resolves.
+ */
+async function withTimeout(ms, fn, meta = {}) {
+    const ac = new AbortController();
+    let timedOut = false;
+    const t = setTimeout(() => {
+        timedOut = true;
+        ac.abort();
+    }, ms);
+    try {
+        return await fn(ac.signal);
+    } catch (err) {
+        if (timedOut || err?.name === 'AbortError') {
+            throw new TimeoutError(
+                `Request timed out after ${ms}ms${meta.url ? ` (${meta.url})` : ''}`,
+                { url: meta.url, timeoutMs: ms }
+            );
+        }
+        throw err;
+    } finally {
+        clearTimeout(t);
+    }
+}
+
+/**
+ * fetchWithTimeout — drop-in replacement for `fetch()` that enforces a timeout.
+ *
+ * @param {string|URL} url         target URL
+ * @param {object}     [init]      standard fetch init (method, headers, body, ...)
+ * @param {object}     [opts]      { timeoutMs?: number } per-call override
+ * @returns {Promise<Response>}
+ * @throws  {TimeoutError} when the timer fires before the server responds
+ */
+async function fetchWithTimeout(url, init = {}, opts = {}) {
+    const timeoutMs = Number.isFinite(opts.timeoutMs) && opts.timeoutMs > 0
+        ? opts.timeoutMs
+        : getDefaultTimeoutMs();
+    return withTimeout(
+        timeoutMs,
+        (signal) => {
+            // Caller-supplied signal takes precedence when present; otherwise wire ours.
+            const finalInit = init.signal ? init : { ...init, signal };
+            return fetch(url, finalInit);
+        },
+        { url: String(url) }
+    );
+}
+
+module.exports = {
+    fetchWithTimeout,
+    withTimeout,
+    TimeoutError,
+    getDefaultTimeoutMs,
+    DEFAULT_TIMEOUT_MS,
+};

--- a/backend/tests/jest/fetch-with-timeout.test.js
+++ b/backend/tests/jest/fetch-with-timeout.test.js
@@ -1,0 +1,129 @@
+/**
+ * Unit tests for backend/tests/helpers/fetch-with-timeout.js
+ *
+ * Protects the release-gate timeout contract: if global fetch() hangs, our
+ * wrapper MUST raise TimeoutError so the suite can fail fast instead of
+ * blocking release for 10+ minutes (see 2026-04-19 v1.0.76 stall).
+ */
+
+const {
+    fetchWithTimeout,
+    withTimeout,
+    TimeoutError,
+    getDefaultTimeoutMs,
+    DEFAULT_TIMEOUT_MS,
+} = require('../helpers/fetch-with-timeout');
+
+describe('fetch-with-timeout helper', () => {
+    const realFetch = global.fetch;
+    const realEnv = process.env.TEST_FETCH_TIMEOUT_MS;
+
+    afterEach(() => {
+        global.fetch = realFetch;
+        if (realEnv === undefined) delete process.env.TEST_FETCH_TIMEOUT_MS;
+        else process.env.TEST_FETCH_TIMEOUT_MS = realEnv;
+    });
+
+    test('withTimeout throws TimeoutError when signal fires', async () => {
+        const start = Date.now();
+        await expect(
+            withTimeout(40, (signal) => new Promise((_, reject) => {
+                signal.addEventListener('abort', () => {
+                    const err = new Error('aborted');
+                    err.name = 'AbortError';
+                    reject(err);
+                });
+            }))
+        ).rejects.toBeInstanceOf(TimeoutError);
+        const elapsed = Date.now() - start;
+        // Abort fired promptly (< 400ms) — proves we didn't hang.
+        expect(elapsed).toBeLessThan(400);
+    });
+
+    test('withTimeout resolves normally when fn finishes in time', async () => {
+        const result = await withTimeout(200, async () => 'ok');
+        expect(result).toBe('ok');
+    });
+
+    test('withTimeout re-throws non-timeout errors untouched', async () => {
+        const original = new Error('db down');
+        await expect(
+            withTimeout(200, async () => { throw original; })
+        ).rejects.toBe(original);
+    });
+
+    test('fetchWithTimeout propagates signal to fetch() and aborts slow call', async () => {
+        // Stub global fetch with a handler that never resolves unless aborted.
+        global.fetch = jest.fn((_url, init) => {
+            return new Promise((_, reject) => {
+                init.signal.addEventListener('abort', () => {
+                    const err = new Error('The operation was aborted');
+                    err.name = 'AbortError';
+                    reject(err);
+                });
+            });
+        });
+
+        const start = Date.now();
+        await expect(
+            fetchWithTimeout('https://eclawbot.com/slow', { method: 'GET' }, { timeoutMs: 30 })
+        ).rejects.toBeInstanceOf(TimeoutError);
+        expect(Date.now() - start).toBeLessThan(400);
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(global.fetch.mock.calls[0][1].signal).toBeDefined();
+    });
+
+    test('fetchWithTimeout returns Response when fetch resolves quickly', async () => {
+        const fakeResponse = { status: 200, ok: true };
+        global.fetch = jest.fn().mockResolvedValue(fakeResponse);
+        const res = await fetchWithTimeout('https://eclawbot.com/ok', {}, { timeoutMs: 200 });
+        expect(res).toBe(fakeResponse);
+    });
+
+    test('TimeoutError carries url + timeoutMs metadata', async () => {
+        global.fetch = jest.fn((_url, init) => new Promise((_, reject) => {
+            init.signal.addEventListener('abort', () => {
+                const err = new Error('aborted');
+                err.name = 'AbortError';
+                reject(err);
+            });
+        }));
+        try {
+            await fetchWithTimeout('https://eclawbot.com/foo', {}, { timeoutMs: 25 });
+            throw new Error('should have thrown');
+        } catch (err) {
+            expect(err).toBeInstanceOf(TimeoutError);
+            expect(err.name).toBe('TimeoutError');
+            expect(err.code).toBe('ETIMEOUT');
+            expect(err.timeoutMs).toBe(25);
+            expect(err.url).toBe('https://eclawbot.com/foo');
+        }
+    });
+
+    test('getDefaultTimeoutMs honors TEST_FETCH_TIMEOUT_MS env var', () => {
+        process.env.TEST_FETCH_TIMEOUT_MS = '2000';
+        expect(getDefaultTimeoutMs()).toBe(2000);
+
+        process.env.TEST_FETCH_TIMEOUT_MS = 'garbage';
+        expect(getDefaultTimeoutMs()).toBe(DEFAULT_TIMEOUT_MS);
+
+        process.env.TEST_FETCH_TIMEOUT_MS = '0';
+        expect(getDefaultTimeoutMs()).toBe(DEFAULT_TIMEOUT_MS);
+
+        delete process.env.TEST_FETCH_TIMEOUT_MS;
+        expect(getDefaultTimeoutMs()).toBe(DEFAULT_TIMEOUT_MS);
+    });
+
+    test('fetchWithTimeout respects caller-supplied signal when present', async () => {
+        let observedSignal;
+        global.fetch = jest.fn((_url, init) => {
+            observedSignal = init.signal;
+            return Promise.resolve({ status: 204 });
+        });
+
+        const externalAc = new AbortController();
+        await fetchWithTimeout('https://eclawbot.com/x', { signal: externalAc.signal }, { timeoutMs: 1000 });
+        // When caller passes their own signal, we do not overwrite it.
+        expect(observedSignal).toBe(externalAc.signal);
+    });
+});

--- a/backend/tests/test-dynamic-entities.js
+++ b/backend/tests/test-dynamic-entities.js
@@ -21,12 +21,15 @@
 
 const path = require('path');
 const fs = require('fs');
+const { fetchWithTimeout, getDefaultTimeoutMs, TimeoutError } = require('./helpers/fetch-with-timeout');
 
 const args = process.argv.slice(2);
 const API_BASE = args.includes('--local') ? 'http://localhost:3000' : 'https://eclawbot.com';
 const skipCleanup = args.includes('--skip-cleanup');
 
 const TAG = '[DynamicEntity Test]';
+const FETCH_TIMEOUT_MS = getDefaultTimeoutMs();
+console.log(`${TAG} fetch timeout = ${FETCH_TIMEOUT_MS}ms (override via TEST_FETCH_TIMEOUT_MS)`);
 
 // ── .env loader ─────────────────────────────────────────────
 function loadEnvFile() {
@@ -43,52 +46,82 @@ function loadEnvFile() {
 }
 
 // ── HTTP Helpers ────────────────────────────────────────────
+// All helpers run through fetchWithTimeout() so a stuck Railway / DNS / TCP
+// connect aborts after TEST_FETCH_TIMEOUT_MS instead of hanging the suite.
 async function fetchJSON(url) {
     console.log(`${TAG} GET ${url}`);
-    const res = await fetch(url);
-    let data;
-    try { data = await res.json(); } catch { data = null; }
-    console.log(`${TAG}   -> status=${res.status} body=${JSON.stringify(data).slice(0, 300)}`);
-    return { status: res.status, data };
+    try {
+        const res = await fetchWithTimeout(url);
+        let data;
+        try { data = await res.json(); } catch { data = null; }
+        console.log(`${TAG}   -> status=${res.status} body=${JSON.stringify(data).slice(0, 300)}`);
+        return { status: res.status, data };
+    } catch (err) {
+        if (err instanceof TimeoutError) {
+            console.log(`${TAG}   -> TIMEOUT after ${err.timeoutMs}ms: ${url}`);
+        }
+        throw err;
+    }
 }
 
 async function postJSON(url, body) {
     console.log(`${TAG} POST ${url} body=${JSON.stringify(body).slice(0, 200)}`);
-    const res = await fetch(url, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-    });
-    let data;
-    try { data = await res.json(); } catch { data = null; }
-    console.log(`${TAG}   -> status=${res.status} body=${JSON.stringify(data).slice(0, 300)}`);
-    return { status: res.status, data };
+    try {
+        const res = await fetchWithTimeout(url, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        let data;
+        try { data = await res.json(); } catch { data = null; }
+        console.log(`${TAG}   -> status=${res.status} body=${JSON.stringify(data).slice(0, 300)}`);
+        return { status: res.status, data };
+    } catch (err) {
+        if (err instanceof TimeoutError) {
+            console.log(`${TAG}   -> TIMEOUT after ${err.timeoutMs}ms: ${url}`);
+        }
+        throw err;
+    }
 }
 
 async function deleteJSON(url, body) {
     console.log(`${TAG} DELETE ${url} body=${JSON.stringify(body).slice(0, 200)}`);
-    const res = await fetch(url, {
-        method: 'DELETE',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-    });
-    let data;
-    try { data = await res.json(); } catch { data = null; }
-    console.log(`${TAG}   -> status=${res.status} body=${JSON.stringify(data).slice(0, 300)}`);
-    return { status: res.status, data };
+    try {
+        const res = await fetchWithTimeout(url, {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        let data;
+        try { data = await res.json(); } catch { data = null; }
+        console.log(`${TAG}   -> status=${res.status} body=${JSON.stringify(data).slice(0, 300)}`);
+        return { status: res.status, data };
+    } catch (err) {
+        if (err instanceof TimeoutError) {
+            console.log(`${TAG}   -> TIMEOUT after ${err.timeoutMs}ms: ${url}`);
+        }
+        throw err;
+    }
 }
 
 async function putJSON(url, body) {
     console.log(`${TAG} PUT ${url} body=${JSON.stringify(body).slice(0, 200)}`);
-    const res = await fetch(url, {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-    });
-    let data;
-    try { data = await res.json(); } catch { data = null; }
-    console.log(`${TAG}   -> status=${res.status} body=${JSON.stringify(data).slice(0, 300)}`);
-    return { status: res.status, data };
+    try {
+        const res = await fetchWithTimeout(url, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        let data;
+        try { data = await res.json(); } catch { data = null; }
+        console.log(`${TAG}   -> status=${res.status} body=${JSON.stringify(data).slice(0, 300)}`);
+        return { status: res.status, data };
+    } catch (err) {
+        if (err instanceof TimeoutError) {
+            console.log(`${TAG}   -> TIMEOUT after ${err.timeoutMs}ms: ${url}`);
+        }
+        throw err;
+    }
 }
 
 // ── Test Result Tracking ────────────────────────────────────

--- a/backend/tests/test-ux-live-validation.js
+++ b/backend/tests/test-ux-live-validation.js
@@ -19,6 +19,7 @@
 
 const path = require('path');
 const fs = require('fs');
+const { fetchWithTimeout, getDefaultTimeoutMs } = require('./helpers/fetch-with-timeout');
 
 // ── Load .env ────────────────────────────────────────────────
 const envPath = path.resolve(__dirname, '../.env');
@@ -169,23 +170,15 @@ function warn(name, detail = '') {
 }
 
 // ── HTTP Helper ─────────────────────────────────────────────
+// Default 15s here (portal pages), overridable via TEST_FETCH_TIMEOUT_MS.
+const HTTP_TIMEOUT_MS = Math.min(getDefaultTimeoutMs(), 15000);
 async function httpGet(urlPath, opts = {}) {
     const url = `${API_BASE}${urlPath}`;
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), 15000);
-    try {
-        const res = await fetch(url, {
-            method: opts.method || 'GET',
-            headers: opts.headers || {},
-            redirect: opts.redirect || 'follow',
-            signal: controller.signal,
-        });
-        clearTimeout(timeout);
-        return res;
-    } catch (err) {
-        clearTimeout(timeout);
-        throw err;
-    }
+    return fetchWithTimeout(url, {
+        method: opts.method || 'GET',
+        headers: opts.headers || {},
+        redirect: opts.redirect || 'follow',
+    }, { timeoutMs: HTTP_TIMEOUT_MS });
 }
 
 // ── Main ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- Wraps bare `fetch()` in AbortController timeout helper (default 30s, override via `TEST_FETCH_TIMEOUT_MS`) so live-API tests fail fast instead of hanging when Railway is slow/unreachable.
- Adds per-test hard cap in `run_all_tests.js` (default 120s, override via `TEST_HARD_CAP_MS`; per-suite overrides for legitimate stress tests) — kills child and logs `TEST TIMED OUT: <name>` instead of stalling the whole suite.
- 8 new Jest unit tests covering `TimeoutError`, signal abort propagation, env var parsing, caller-supplied signal precedence.

## Background
During 2026-04-19 v1.0.76 release prep, `node run_all_tests.js` stalled for 6+ minutes inside `backend/tests/test-dynamic-entities.js` because its helpers (`fetchJSON`, `postJSON`, `deleteJSON`, `putJSON`) use bare `fetch()` with no timeout. This PR adds the wrapper and applies it to `test-dynamic-entities.js` (root cause) and `test-ux-live-validation.js` (standardizes the existing manual AbortController there). Remaining sibling tests under `backend/tests/` are covered defensively by the new runner-level hard cap.

## Files
- `backend/tests/helpers/fetch-with-timeout.js` (new) — shared `fetchWithTimeout` / `withTimeout` / `TimeoutError`.
- `backend/tests/jest/fetch-with-timeout.test.js` (new) — 8 unit tests.
- `backend/tests/test-dynamic-entities.js` — routes all 4 helpers through `fetchWithTimeout`.
- `backend/tests/test-ux-live-validation.js` — uses shared helper.
- `backend/run_all_tests.js` — 120s default per-test cap, env override, per-suite overrides for `test_entity_delete.js` / `test-dynamic-entities.js` / `test-entity-trash.js` / `test_ux_coverage.js`.

## Test plan
- [x] `npx jest` — 91 suites / 1597 tests pass (0 regressions; 8 new tests pass)
- [x] Smoke: `fetchWithTimeout` aborts hung local server in 2006ms with `TEST_FETCH_TIMEOUT_MS=2000`
- [x] Smoke: `test-dynamic-entities.js` aborts with `TimeoutError` in 2s against hung endpoint instead of hanging
- [ ] Next release prep: verify `run_all_tests.js` survives a slow Railway window without 6+ minute stalls

## Notes
- Tests 15 & 16 in `test-dynamic-entities.js` still fail with the separate "ID reuse" regression being handled in the main session — **intentionally untouched**, out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)