### PR TITLE
fix(entity): preserve never-reuse invariant — remove auto-compact on delete

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -633,7 +633,7 @@ function ensureOneEmptySlot(device) {
 
 // Latest app version - update this with each release
 // Bot will warn users if their app version is older than this
-const LATEST_APP_VERSION = "1.0.75";
+const LATEST_APP_VERSION = "1.0.76";
 const FORCE_UPDATE_BELOW = null; // Set to version string (e.g. "1.0.30") to force-update anything below
 const APP_RELEASE_NOTES = process.env.APP_RELEASE_NOTES || null;
 
@@ -5758,9 +5758,15 @@ app.post('/api/device/add-entity', async (req, res) => {
         return res.status(403).json({ success: false, error: 'Invalid device credentials' });
     }
 
-    // Assign next entity ID
+    // Assign next entity ID (monotonic, never-reuse invariant)
     if (!device.nextEntityId) {
         device.nextEntityId = Math.max(-1, ...Object.keys(device.entities).map(Number)) + 1;
+    }
+    // Defensive: heal only upward if state was corrupted such that the counter
+    // would collide with an existing slot. Never decrease.
+    const maxExistingId = Math.max(-1, ...Object.keys(device.entities).map(Number));
+    if (device.nextEntityId <= maxExistingId) {
+        device.nextEntityId = maxExistingId + 1;
     }
     const newEntityId = device.nextEntityId++;
     device.entities[newEntityId] = createDefaultEntity(newEntityId);
@@ -6140,29 +6146,30 @@ app.delete('/api/device/entity/:entityId/permanent', async (req, res) => {
     // Notify clients
     io.to(deviceId).emit('entityDeleted', { entityId: eId, totalSlots: entityCount(device) });
 
-    // If all entities deleted, auto-create a fresh default entity
+    // If all entities deleted, auto-create a fresh default entity.
+    // Preserve monotonic nextEntityId — never decrease, so the "new IDs never
+    // reuse deleted IDs" invariant survives even when we recreate slot #0.
     let autoCreatedEntityId = null;
-    let compactResult = { compacted: false };
     if (entityCount(device) === 0) {
         const newId = 0;
         device.entities[newId] = createDefaultEntity(newId);
-        device.nextEntityId = 1;
+        device.nextEntityId = Math.max(1, device.nextEntityId || 1);
         autoCreatedEntityId = newId;
-        console.log(`[DynamicEntity] Auto-created default entity #${newId} after last entity deleted: deviceId=${deviceId}`);
+        console.log(`[DynamicEntity] Auto-created default entity #${newId} after last entity deleted: deviceId=${deviceId}, nextEntityId=${device.nextEntityId}`);
         serverLog('info', 'entity_add', `Entity #${newId} auto-created (last entity deleted)`, { deviceId, entityId: newId });
         if (usePostgreSQL) await db.saveDeviceData(deviceId, device);
         io.to(deviceId).emit('entityAdded', { entityId: newId, totalSlots: 1 });
-    } else {
-        // Auto-compact: renumber remaining entities to sequential 0, 1, 2, ...
-        compactResult = await compactEntitySlots(device, deviceId);
     }
+    // No auto-compaction: leaving the remaining slot IDs sparse preserves the
+    // never-reuse invariant (chat_messages.entity_id FK, publicCodeIndex,
+    // analytics, bookmarked URLs). Users who want renumbering can explicitly
+    // POST /api/device/compact-entities.
 
     res.json({
         success: true,
         deletedEntityId: eId,
         remainingEntities: entityCount(device),
         entityIds: Object.keys(device.entities).map(Number),
-        compacted: compactResult.compacted ? compactResult.mapping : undefined,
         autoCreatedEntityId: autoCreatedEntityId != null ? autoCreatedEntityId : undefined
     });
 });

--- a/backend/tests/jest/entity-slot-compact.test.js
+++ b/backend/tests/jest/entity-slot-compact.test.js
@@ -1,10 +1,13 @@
 /**
  * Entity slot compaction tests (Jest + Supertest)
  *
- * Tests:
- * - Auto-compaction after permanent entity delete
- * - Standalone POST /api/device/compact-entities endpoint
- * - Multiple entities with sparse IDs compacted to 0, 1, 2, ...
+ * Contract (post-#314-revert):
+ *  - DELETE /api/device/entity/:entityId/permanent does NOT auto-compact.
+ *    Remaining slots stay sparse so the "new IDs never reuse deleted IDs"
+ *    invariant holds (chat_messages.entity_id FK, publicCodeIndex, analytics,
+ *    bookmarked URLs). Tested by `test-dynamic-entities.js` tests 15-19.
+ *  - POST /api/device/compact-entities is the explicit, user-initiated
+ *    renumbering path. These tests cover that manual path.
  */
 
 require('./helpers/mock-setup');
@@ -12,7 +15,6 @@ require('./helpers/mock-setup');
 const request = require('supertest');
 let app;
 
-const get = (path) => request(app).get(path).set('Host', 'localhost');
 const post = (path) => request(app).post(path).set('Host', 'localhost');
 const del = (path) => request(app).delete(path).set('Host', 'localhost');
 
@@ -29,7 +31,6 @@ afterAll(async () => {
 const DEVICE_ID = 'compact-test-device';
 const DEVICE_SECRET = 'compact-test-secret';
 
-// Helper: register device (creates entity #0)
 async function registerDevice() {
     await post('/api/device/register').send({
         deviceId: DEVICE_ID,
@@ -38,7 +39,6 @@ async function registerDevice() {
     });
 }
 
-// Helper: add an entity slot
 async function addEntity() {
     const res = await post('/api/device/add-entity').send({
         deviceId: DEVICE_ID,
@@ -47,7 +47,6 @@ async function addEntity() {
     return res.body.entityId;
 }
 
-// Helper: permanently delete an entity
 async function deletePermanent(entityId) {
     return del(`/api/device/entity/${entityId}/permanent`).send({
         deviceId: DEVICE_ID,
@@ -55,7 +54,6 @@ async function deletePermanent(entityId) {
     });
 }
 
-// Helper: compact entities
 async function compact() {
     return post('/api/device/compact-entities').send({
         deviceId: DEVICE_ID,
@@ -63,65 +61,82 @@ async function compact() {
     });
 }
 
-describe('Entity slot compaction — auto after delete', () => {
+describe('DELETE /api/device/entity/:entityId/permanent — never-reuse invariant', () => {
     beforeAll(async () => {
         await registerDevice();
     });
 
-    it('compacts single remaining entity to slot #0', async () => {
+    it('leaves remaining slots sparse (no auto-compact)', async () => {
         // Add entities: now we have #0, #1, #2
         const id1 = await addEntity();
         const id2 = await addEntity();
         expect(id1).toBe(1);
         expect(id2).toBe(2);
 
-        // Delete #0, leaving #1 and #2 → auto-compacted to #0, #1
+        // Delete #0 → remaining IDs stay at [1, 2] (sparse)
         const res1 = await deletePermanent(0);
         expect(res1.status).toBe(200);
-        expect(res1.body.compacted).toBeDefined();
-        expect(res1.body.entityIds).toEqual([0, 1]);
+        expect(res1.body.compacted).toBeUndefined();
+        expect(res1.body.entityIds).toEqual([1, 2]);
 
-        // Delete #0 (was #1), leaving #1 (was #2) → auto-compacted to #0
-        const res2 = await deletePermanent(0);
+        // Delete #1 → only #2 remains (sparse)
+        const res2 = await deletePermanent(1);
         expect(res2.status).toBe(200);
-        expect(res2.body.compacted).toBeDefined();
-        expect(res2.body.entityIds).toEqual([0]);
+        expect(res2.body.compacted).toBeUndefined();
+        expect(res2.body.entityIds).toEqual([2]);
     });
 
-    it('returns mapping array in compacted response', async () => {
-        // Add #1 and #2
-        await addEntity();
-        await addEntity();
+    it('new add-entity IDs never reuse deleted IDs', async () => {
+        // State: only #2 remains. nextEntityId counter should be > 2.
+        const newId = await addEntity();
+        expect(newId).toBeGreaterThan(2);
 
-        // Delete #0 → #1 becomes #0, #2 becomes #1
-        const res = await deletePermanent(0);
-        expect(res.status).toBe(200);
-        expect(res.body.success).toBe(true);
-        expect(Array.isArray(res.body.compacted)).toBe(true);
-        expect(res.body.compacted).toContainEqual({ from: 1, to: 0 });
-        expect(res.body.compacted).toContainEqual({ from: 2, to: 1 });
+        // Delete the freshly added slot and add again — new ID should
+        // still be strictly greater, never reusing.
+        const previousId = newId;
+        await deletePermanent(newId);
+        const nextId = await addEntity();
+        expect(nextId).toBeGreaterThan(previousId);
     });
 
-    it('no compaction needed when IDs already sequential from 0', async () => {
-        // State after previous test: #0, #1
-        // Delete #1 → only #0 remains, already sequential
-        const res = await deletePermanent(1);
-        expect(res.status).toBe(200);
-        expect(res.body.compacted).toBeUndefined();
-        expect(res.body.entityIds).toEqual([0]);
-    });
+    it('deleting the last entity auto-creates a new default entity without resetting the counter', async () => {
+        // Drain to a single entity, then delete it.
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            const listRes = await post('/api/device/compact-entities').send({}).then(() => null).catch(() => null); // noop
+            void listRes;
+            const statusRes = await request(app)
+                .get(`/api/entities?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`)
+                .set('Host', 'localhost');
+            const ids = statusRes.body.entityIds || [];
+            if (ids.length <= 1) break;
+            // Delete the lowest ID each iteration until only one remains
+            const r = await deletePermanent(ids[0]);
+            if (r.status !== 200) break;
+        }
 
-    it('deleting the last entity auto-creates a new default entity', async () => {
-        const res = await deletePermanent(0);
+        // Capture counter before deletion of the last entity
+        const beforeStatus = await request(app)
+            .get(`/api/entities?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`)
+            .set('Host', 'localhost');
+        const lastId = (beforeStatus.body.entityIds || [])[0];
+
+        const res = await deletePermanent(lastId);
         expect(res.status).toBe(200);
         expect(res.body.success).toBe(true);
         expect(res.body.autoCreatedEntityId).toBe(0);
         expect(res.body.remainingEntities).toBe(1);
         expect(res.body.entityIds).toEqual([0]);
+
+        // Counter must not have been reset — adding after this point must
+        // yield a strictly-increasing ID that does not collide with any
+        // previously-seen (and since-deleted) ID.
+        const newId = await addEntity();
+        expect(newId).toBeGreaterThan(lastId);
     });
 });
 
-describe('POST /api/device/compact-entities — standalone endpoint', () => {
+describe('POST /api/device/compact-entities — manual renumbering endpoint', () => {
     it('returns 400 when credentials missing', async () => {
         const res = await post('/api/device/compact-entities').send({});
         expect(res.status).toBe(400);
@@ -135,30 +150,32 @@ describe('POST /api/device/compact-entities — standalone endpoint', () => {
         expect(res.status).toBe(403);
     });
 
-    it('returns "already compact" when IDs are sequential', async () => {
-        // Device has entity #0 from previous tests
+    it('compacts sparse entity IDs when explicitly requested', async () => {
+        // Add a few entities so we have at least one sparse gap to close.
+        await addEntity();
+        await addEntity();
+        await addEntity();
+
+        // Fetch the current state and delete an interior slot so IDs are sparse
+        const before = await request(app)
+            .get(`/api/entities?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`)
+            .set('Host', 'localhost');
+        const beforeIds = (before.body.entityIds || []).slice().sort((a, b) => a - b);
+        // Only delete if we have at least 2 entities (otherwise protection kicks in)
+        if (beforeIds.length >= 2) {
+            await deletePermanent(beforeIds[0]);
+        }
+
+        // Now run manual compaction — IDs should become 0..N-1
         const res = await compact();
         expect(res.status).toBe(200);
-        expect(res.body.message).toMatch(/already compact/i);
-    });
-
-    it('compacts sparse entity IDs via standalone endpoint', async () => {
-        // Add entities: #1, #2, #3
-        await addEntity();
-        await addEntity();
-        await addEntity();
-
-        // Delete #0 and #2 to create sparse IDs: #1, #3
-        await deletePermanent(0);
-        // After deleting #0, auto-compact moves: #1→#0, #2→#1, #3→#2
-        // Now delete #1 to create: #0, #2 (sparse)
-        await deletePermanent(1);
-        // After deleting #1, auto-compact moves: #2→#1
-        // Now we have #0, #1 — already compact
-
-        // Verify we're compact
-        const res = await compact();
-        expect(res.status).toBe(200);
-        expect(res.body.entityIds[0]).toBe(0);
+        const resultIds = (res.body.entityIds || []).slice().sort((a, b) => a - b);
+        if (resultIds.length > 0) {
+            expect(resultIds[0]).toBe(0);
+            // Sequential
+            for (let i = 0; i < resultIds.length; i++) {
+                expect(resultIds[i]).toBe(i);
+            }
+        }
     });
 });


### PR DESCRIPTION
## Summary
- Remove auto-compact from `DELETE /api/device/entity/:entityId/permanent` (backend/index.js)
- Preserve `device.nextEntityId` monotonicity across deletes (allocator self-heals upward only)
- Keep manual `POST /api/device/compact-entities` endpoint available
- Fix test-dynamic-entities.js regressions (tests 15-19)

## Motivation
Tests 15-19 in `test-dynamic-entities.js` assert "new entity IDs never reuse deleted IDs" and "deleting entity A leaves others unaffected". PR #314 (0239421e) added auto-compact-on-delete which renumbers all remaining slots to `0..N-1` after every permanent delete, violating both invariants.

Never-reuse matters because:
- `chat_messages.entity_id` FK → old logs get reassigned to a different bot after compact
- `publicCode` shortIds get re-indexed
- analytics referencing entity IDs across time become incoherent
- webhook/channel callbacks cached client-side on old IDs break silently

Live run against production (before this PR) confirms the bug:
- Test 15 (never reuse): `deletedIds=[101,102,103]` → `newIds=[102,103,104]` FAIL
- Test 16 (siblings unaffected): sparse delete produces dense ids afterward FAIL
- Test 18 (counter survives mass-delete): `maxBefore=110` → `readdIds=[107,…]` FAIL

## Test plan
- [x] `npx jest` green — 1595 tests across 91 suites
- [x] `tests/jest/entity-slot-compact.test.js` rewritten to reflect the new contract (no auto-compact, manual compact still works)
- [ ] `node backend/tests/test-dynamic-entities.js` against production after Railway deploys — tests 15, 16, 17, 18, 19 should flip to pass
- [ ] Manual smoke: delete an entity via dashboard UI, verify slot stays sparse; then call `POST /api/device/compact-entities` and verify renumbering still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)