### PR TITLE
test: bump fetch-with-timeout assertion 400→1500ms (CI jitter)

### DIFF
--- a/backend/tests/jest/fetch-with-timeout.test.js
+++ b/backend/tests/jest/fetch-with-timeout.test.js
@@ -68,7 +68,7 @@ describe('fetch-with-timeout helper', () => {
         await expect(
             fetchWithTimeout('https://eclawbot.com/slow', { method: 'GET' }, { timeoutMs: 30 })
         ).rejects.toBeInstanceOf(TimeoutError);
-        expect(Date.now() - start).toBeLessThan(400);
+        expect(Date.now() - start).toBeLessThan(1500);
         expect(global.fetch).toHaveBeenCalledTimes(1);
         expect(global.fetch.mock.calls[0][1].signal).toBeDefined();
     });


### PR DESCRIPTION
## Summary
Bump fetch-with-timeout jest assertion from `toBeLessThan(400)` to `toBeLessThan(1500)`.

## Motivation
Slow GitHub Actions runners observed 549ms to abort a 30ms-timeout fetch — triggered a flaky CI failure on PR #1862 that forced an --admin merge. The test intent is "aborts much faster than the 5000ms slow upstream call", not sub-400ms precision. 1500ms keeps the signal strong while absorbing scheduler jitter.

## Test plan
- [x] npx jest --testPathPattern=tests/jest/fetch-with-timeout green