### PR TITLE
feat(monitoring): accept botSecret for rental-health endpoint

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -4012,19 +4012,30 @@ app.get('/api/health', (req, res) => {
 });
 
 // GET /api/monitoring/rental-health — aggregated rental fleet + DB + publisher status.
-// Auth: either MONITORING_KEY env var via ?key= / X-Monitoring-Key header,
-// OR a valid deviceId+deviceSecret pair (same pattern as /api/logs).
+// Auth: any of (a) MONITORING_KEY env via ?key= / X-Monitoring-Key header,
+// (b) deviceId+deviceSecret query (device-admin), (c) deviceId+entityId+botSecret query
+// (bot-scoped — used by the kanban cron probe).
 app.get('/api/monitoring/rental-health', async (req, res) => {
     const monitoringKey = process.env.MONITORING_KEY;
     const providedKey = req.query.key || req.headers['x-monitoring-key'];
     const keyOk = monitoringKey && providedKey && safeEqual(monitoringKey, String(providedKey));
     if (!keyOk) {
-        const { deviceId, deviceSecret } = req.query;
-        if (!deviceId || !deviceSecret) {
-            return res.status(401).json({ success: false, error: 'monitoring key or deviceId+deviceSecret required' });
+        const { deviceId, deviceSecret, botSecret, entityId } = req.query;
+        if (!deviceId || (!deviceSecret && !botSecret)) {
+            return res.status(401).json({ success: false, error: 'monitoring key, deviceId+deviceSecret, or deviceId+entityId+botSecret required' });
         }
         const device = devices[deviceId];
-        if (!device || !safeEqual(device.deviceSecret, deviceSecret)) {
+        if (!device) {
+            return res.status(401).json({ success: false, error: 'invalid credentials' });
+        }
+        let authed = false;
+        if (deviceSecret && safeEqual(device.deviceSecret, deviceSecret)) authed = true;
+        if (!authed && botSecret) {
+            const slot = parseInt(entityId);
+            const entity = device.entities && device.entities[slot];
+            if (entity && entity.botSecret && safeEqual(entity.botSecret, botSecret)) authed = true;
+        }
+        if (!authed) {
             return res.status(401).json({ success: false, error: 'invalid credentials' });
         }
     }

--- a/backend/tests/jest/monitoring.test.js
+++ b/backend/tests/jest/monitoring.test.js
@@ -213,6 +213,12 @@ describe('GET /api/monitoring/rental-health auth', () => {
             .set('X-Monitoring-Key', 'test-monitoring-key-1234');
         expect(res.status).toBe(200);
     });
+
+    it('rejects deviceId without any secret with 401', async () => {
+        const res = await request(app)
+            .get('/api/monitoring/rental-health?deviceId=does-not-exist');
+        expect(res.status).toBe(401);
+    });
 });
 
 describe('GET /api/monitoring/rental-health happy path', () => {


### PR DESCRIPTION
## Summary
- Adds third auth path to `GET /api/monitoring/rental-health`: `deviceId+entityId+botSecret`.
- Lets the kanban cron probe (commander entity #2) call the endpoint without putting `deviceSecret` in the card SOP.
- Existing `MONITORING_KEY` env path and `deviceSecret` path unchanged.

## Test plan
- [x] `monitoring.test.js` — 10 tests pass (added `rejects deviceId without any secret` case)
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)