### PR TITLE
feat(wallet): verify Google Play purchases via androidpublisher v3

### DIFF
--- a/backend/tests/jest/wallet-topup-google.test.js
+++ b/backend/tests/jest/wallet-topup-google.test.js
@@ -1,0 +1,515 @@
+/**
+ * Google Play androidpublisher v3 verification tests.
+ *
+ * Covers the 8 cases from the spec:
+ *   1. Happy path: purchaseState=0 → verifyGooglePurchase returns
+ *      { valid:true, orderId }; endpoint credits the ledger using
+ *      Google's orderId (NOT the raw purchaseToken) as external_txn_id.
+ *   2. purchaseState=1 (canceled) → 402 purchase_not_verified.
+ *   3. purchaseState=2 (pending)  → 402 purchase_not_verified.
+ *   4. Token exchange HTTP 401   → 500 google_auth_failed (detail masked).
+ *   5. GOOGLE_PLAY_SERVICE_ACCOUNT unset → FAIL-CLOSED 500 google_auth_failed.
+ *      (We chose fail-closed over fallback-to-trust; see PR body.)
+ *   6. Access-token cache: two successive verifications → only ONE POST
+ *      to oauth2.googleapis.com/token.
+ *   7. Dedup: same purchaseToken credited twice → second call is deduped
+ *      (same orderId in response; wallet balance unchanged).
+ *   8. Acknowledge is fire-and-forget: mock ack to reject → endpoint
+ *      still returns 200 and ledger is still credited.
+ *
+ * Strategy: reuse the wallet.test.js pg simulator (same jest.mock shape),
+ * mock `global.fetch` per test, and drive the route via supertest.
+ */
+
+// ── In-memory pg simulator (mirrors wallet.test.js) ─────────────────────
+jest.mock('pg', () => {
+    const state = {
+        wallets: new Map(),
+        ledger: [],
+        nextLedgerId: 1,
+        topupOrders: [],
+        nextOrderId: 1,
+        userAccounts: new Map(),
+    };
+    globalThis.__walletFakeState = state;
+
+    function ensureWallet(userId) {
+        if (!state.wallets.has(userId)) {
+            state.wallets.set(userId, {
+                balance_mli: 0n,
+                held_mli: 0n,
+                lifetime_earned_mli: 0n,
+                lifetime_spent_mli: 0n,
+            });
+        }
+    }
+
+    function runQuery(sql, params = []) {
+        const norm = sql.replace(/\s+/g, ' ').trim();
+        if (/^(BEGIN|COMMIT|ROLLBACK)$/i.test(norm)) return { rows: [], rowCount: 0 };
+        if (/^CREATE (TABLE|INDEX|UNIQUE INDEX)/i.test(norm)) return { rows: [], rowCount: 0 };
+        if (/^INSERT INTO wallets \(user_id\) VALUES/i.test(norm)) {
+            ensureWallet(params[0]);
+            return { rows: [], rowCount: 1 };
+        }
+        if (/^SELECT .* FROM wallet_ledger WHERE idempotency_key = \$1$/i.test(norm)) {
+            const match = state.ledger.find(r => r.idempotency_key === params[0]);
+            return { rows: match ? [match] : [], rowCount: match ? 1 : 0 };
+        }
+        if (/^SELECT balance_mli, held_mli FROM wallets WHERE user_id = \$1 FOR UPDATE$/i.test(norm)) {
+            const w = state.wallets.get(params[0]);
+            if (!w) return { rows: [], rowCount: 0 };
+            return {
+                rows: [{ balance_mli: w.balance_mli.toString(), held_mli: w.held_mli.toString() }],
+                rowCount: 1,
+            };
+        }
+        if (/^UPDATE wallets SET balance_mli = \$1, held_mli = \$2/i.test(norm)) {
+            const [bal, held, earnedInc, spentInc, userId] = params;
+            const w = state.wallets.get(userId);
+            if (!w) return { rows: [], rowCount: 0 };
+            w.balance_mli = BigInt(bal);
+            w.held_mli = BigInt(held);
+            w.lifetime_earned_mli += BigInt(earnedInc);
+            w.lifetime_spent_mli += BigInt(spentInc);
+            return { rows: [], rowCount: 1 };
+        }
+        if (/^INSERT INTO wallet_ledger/i.test(norm)) {
+            const [userId, deltaMli, heldDeltaMli, balanceAfter, heldAfter,
+                   type, refType, refId, counterparty, note, idemKey] = params;
+            if (state.ledger.some(r => r.idempotency_key === idemKey)) {
+                throw new Error('duplicate key value violates unique constraint "wallet_ledger_idempotency_key_key"');
+            }
+            const row = {
+                id: state.nextLedgerId++,
+                user_id: userId,
+                delta_mli: String(deltaMli),
+                held_delta_mli: String(heldDeltaMli),
+                balance_after_mli: String(balanceAfter),
+                held_after_mli: String(heldAfter),
+                type, ref_type: refType, ref_id: refId,
+                counterparty_user_id: counterparty,
+                note, idempotency_key: idemKey,
+                created_at: new Date(),
+            };
+            state.ledger.push(row);
+            return { rows: [{ id: row.id, created_at: row.created_at }], rowCount: 1 };
+        }
+        if (/^SELECT balance_mli, held_mli, lifetime_earned_mli, lifetime_spent_mli FROM wallets/i.test(norm)) {
+            const w = state.wallets.get(params[0]);
+            if (!w) return { rows: [], rowCount: 0 };
+            return {
+                rows: [{
+                    balance_mli: w.balance_mli.toString(),
+                    held_mli: w.held_mli.toString(),
+                    lifetime_earned_mli: w.lifetime_earned_mli.toString(),
+                    lifetime_spent_mli: w.lifetime_spent_mli.toString(),
+                }],
+                rowCount: 1,
+            };
+        }
+        if (/^SELECT id, status, ecoin_total_mli FROM topup_orders WHERE channel = \$1 AND external_txn_id = \$2$/i.test(norm)) {
+            const [channel, txnId] = params;
+            const match = state.topupOrders.find(o => o.channel === channel && o.external_txn_id === txnId);
+            return {
+                rows: match ? [{ id: match.id, status: match.status, ecoin_total_mli: String(match.ecoin_total_mli) }] : [],
+                rowCount: match ? 1 : 0,
+            };
+        }
+        if (/^INSERT INTO topup_orders/i.test(norm)) {
+            const [userId, channel, amountTwd, baseMli, bonusMli, totalMli, externalTxnId, externalRaw] = params;
+            const id = `order-${state.nextOrderId++}`;
+            const row = {
+                id, user_id: userId, channel, amount_twd: amountTwd,
+                ecoin_base_mli: baseMli, ecoin_bonus_mli: bonusMli, ecoin_total_mli: totalMli,
+                status: 'pending', external_txn_id: externalTxnId, external_raw: externalRaw,
+                created_at: new Date(), paid_at: null,
+            };
+            state.topupOrders.push(row);
+            return { rows: [{ id, status: 'pending', ecoin_total_mli: String(totalMli) }], rowCount: 1 };
+        }
+        if (/^SELECT id, status FROM topup_orders WHERE id = \$1 FOR UPDATE$/i.test(norm)) {
+            const order = state.topupOrders.find(o => o.id === params[0]);
+            if (!order) return { rows: [], rowCount: 0 };
+            return { rows: [{ id: order.id, status: order.status }], rowCount: 1 };
+        }
+        if (/^UPDATE topup_orders SET status = 'paid', paid_at = NOW\(\) WHERE id = \$1$/i.test(norm)) {
+            const order = state.topupOrders.find(o => o.id === params[0]);
+            if (!order) return { rows: [], rowCount: 0 };
+            order.status = 'paid';
+            order.paid_at = new Date();
+            return { rows: [], rowCount: 1 };
+        }
+        throw new Error(`[fake-pg] Unhandled SQL: ${norm}`);
+    }
+
+    class FakeClient {
+        async query(sql, params) { return runQuery(sql, params); }
+        release() { /* noop */ }
+    }
+    class FakePool {
+        async connect() { return new FakeClient(); }
+        async query(sql, params) { return runQuery(sql, params); }
+    }
+    return { Pool: jest.fn().mockImplementation(() => new FakePool()) };
+});
+
+jest.mock('fs', () => {
+    const real = jest.requireActual('fs');
+    return {
+        ...real,
+        readFileSync: jest.fn((p, enc) => {
+            if (typeof p === 'string' && p.endsWith('wallet_schema.sql')) return '';
+            return real.readFileSync(p, enc);
+        }),
+    };
+});
+
+const fake = { get state() { return globalThis.__walletFakeState; } };
+
+// ── Test-only RSA keypair for GSA (never used outside this file) ────────
+const { generateKeyPairSync } = require('crypto');
+const { privateKey: _testPrivateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+const TEST_PRIVATE_KEY_PEM = _testPrivateKey.export({ type: 'pkcs8', format: 'pem' });
+
+const FAKE_GSA = {
+    type: 'service_account',
+    project_id: 'eclaw-play-billing',
+    private_key_id: 'test-kid',
+    private_key: TEST_PRIVATE_KEY_PEM,
+    client_email: 'eclaw-play-billing-verifier@eclaw-play-billing.iam.gserviceaccount.com',
+    client_id: '1234567890',
+    auth_uri: 'https://accounts.google.com/o/oauth2/auth',
+    token_uri: 'https://oauth2.googleapis.com/token',
+};
+
+const ALICE = '11111111-1111-1111-1111-111111111111';
+
+// ── Test harness ────────────────────────────────────────────────────────
+const express = require('express');
+const supertest = require('supertest');
+const wallet = require('../../wallet');
+
+function resetState() {
+    fake.state.wallets.clear();
+    fake.state.ledger.length = 0;
+    fake.state.nextLedgerId = 1;
+    fake.state.topupOrders.length = 0;
+    fake.state.nextOrderId = 1;
+    fake.state.userAccounts.clear();
+}
+
+function buildApp({ user = { userId: ALICE }, serverLog } = {}) {
+    const app = express();
+    app.use(express.json());
+    const fakeAuth = (req, _res, next) => { if (user) req.user = user; next(); };
+    const w = wallet({ authMiddleware: fakeAuth, serverLog: serverLog || (() => {}) });
+    app.use('/api/wallet', w.router);
+    return { app, walletApi: w };
+}
+
+/**
+ * Build a single-shot fetch mock that dispatches based on URL. Each call
+ * increments a counter so tests can assert token-cache behavior.
+ */
+function makeFetchMock({ onToken, onProductsGet, onAck, tokenResponder } = {}) {
+    const calls = { token: 0, productsGet: 0, ack: 0, urls: [] };
+    global.fetch = jest.fn().mockImplementation(async (url, opts = {}) => {
+        calls.urls.push(url);
+        if (typeof url === 'string' && url.includes('oauth2.googleapis.com/token')) {
+            calls.token += 1;
+            if (tokenResponder) return tokenResponder(url, opts, calls);
+            if (onToken) return onToken(url, opts, calls);
+            return {
+                ok: true, status: 200,
+                json: async () => ({ access_token: `at-${calls.token}`, expires_in: 3600, token_type: 'Bearer' }),
+            };
+        }
+        if (typeof url === 'string' && url.endsWith(':acknowledge')) {
+            calls.ack += 1;
+            if (onAck) return onAck(url, opts, calls);
+            return { ok: true, status: 204, json: async () => ({}) };
+        }
+        if (typeof url === 'string' && url.includes('/purchases/products/')) {
+            calls.productsGet += 1;
+            if (onProductsGet) return onProductsGet(url, opts, calls);
+            return { ok: true, status: 200, json: async () => ({ purchaseState: 0, orderId: 'GPA.0000-0000-0000-0001' }) };
+        }
+        throw new Error(`[fetch-mock] unexpected URL: ${url}`);
+    });
+    return calls;
+}
+
+beforeEach(() => {
+    resetState();
+    process.env.GOOGLE_PLAY_SERVICE_ACCOUNT = JSON.stringify(FAKE_GSA);
+    delete process.env.GOOGLE_PLAY_ALLOW_UNVERIFIED;
+    if (wallet._resetGoogleCache) wallet._resetGoogleCache();
+});
+
+afterEach(() => {
+    delete process.env.GOOGLE_PLAY_SERVICE_ACCOUNT;
+    delete process.env.GOOGLE_PLAY_ALLOW_UNVERIFIED;
+    if (global.fetch && global.fetch.mockRestore) global.fetch.mockRestore();
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe('wallet: verifyGooglePurchase helper', () => {
+    test('case 1: happy path — purchaseState=0 returns { valid:true, orderId }', async () => {
+        makeFetchMock({
+            onProductsGet: () => ({
+                ok: true, status: 200,
+                json: async () => ({
+                    purchaseState: 0,
+                    consumptionState: 0,
+                    acknowledgementState: 0,
+                    orderId: 'GPA.3311-0000-0000-0001',
+                    purchaseTimeMillis: String(Date.now()),
+                }),
+            }),
+        });
+        const result = await wallet.verifyGooglePurchase(
+            wallet.GOOGLE_PACKAGE_NAME,
+            'ec.topup.starter',
+            'fake-purchase-token-happy'
+        );
+        expect(result.valid).toBe(true);
+        expect(result.orderId).toBe('GPA.3311-0000-0000-0001');
+        expect(result.purchaseState).toBe(0);
+    });
+
+    test('case 2: purchaseState=1 (canceled) throws google_token_canceled', async () => {
+        makeFetchMock({
+            onProductsGet: () => ({
+                ok: true, status: 200,
+                json: async () => ({ purchaseState: 1, orderId: 'GPA.canceled' }),
+            }),
+        });
+        await expect(wallet.verifyGooglePurchase(
+            wallet.GOOGLE_PACKAGE_NAME, 'ec.topup.starter', 'token-canceled'
+        )).rejects.toThrow('google_token_canceled');
+    });
+
+    test('case 3: purchaseState=2 (pending) throws google_token_pending', async () => {
+        makeFetchMock({
+            onProductsGet: () => ({
+                ok: true, status: 200,
+                json: async () => ({ purchaseState: 2, orderId: 'GPA.pending' }),
+            }),
+        });
+        await expect(wallet.verifyGooglePurchase(
+            wallet.GOOGLE_PACKAGE_NAME, 'ec.topup.starter', 'token-pending'
+        )).rejects.toThrow('google_token_pending');
+    });
+
+    test('case 4: token exchange HTTP 401 throws google_auth_failed', async () => {
+        makeFetchMock({
+            tokenResponder: () => ({ ok: false, status: 401, json: async () => ({ error: 'invalid_grant' }) }),
+        });
+        await expect(wallet.verifyGooglePurchase(
+            wallet.GOOGLE_PACKAGE_NAME, 'ec.topup.starter', 'token-bad-jwt'
+        )).rejects.toThrow('google_auth_failed');
+    });
+
+    test('case 6: access-token cache — two verifications → one POST to oauth2/token', async () => {
+        const calls = makeFetchMock();  // default: both GETs succeed with purchaseState=0
+        await wallet.verifyGooglePurchase(
+            wallet.GOOGLE_PACKAGE_NAME, 'ec.topup.starter', 'tok-cache-a'
+        );
+        await wallet.verifyGooglePurchase(
+            wallet.GOOGLE_PACKAGE_NAME, 'ec.topup.starter', 'tok-cache-b'
+        );
+        expect(calls.token).toBe(1);       // only one token exchange
+        expect(calls.productsGet).toBe(2); // two product lookups
+    });
+});
+
+describe('wallet: POST /topup/verify-google (integration)', () => {
+    test('case 1: happy path → credits wallet and uses Google orderId as external_txn_id', async () => {
+        makeFetchMock({
+            onProductsGet: () => ({
+                ok: true, status: 200,
+                json: async () => ({
+                    purchaseState: 0,
+                    consumptionState: 0,
+                    acknowledgementState: 0,
+                    orderId: 'GPA.REAL-ORDER-0001',
+                }),
+            }),
+        });
+        const { app } = buildApp();
+        const res = await supertest(app).post('/api/wallet/topup/verify-google')
+            .send({ productId: 'ec.topup.starter', purchaseToken: 'user-facing-token-0001' })
+            .expect(200);
+
+        expect(res.body.success).toBe(true);
+        expect(res.body.order.status).toBe('paid');
+        expect(res.body.order.ecoinTotal).toBe(9450);  // 9000 + 5% bonus (450)
+        expect(res.body.order.deduped).toBe(false);
+
+        // Order MUST be keyed by Google's orderId, not the raw purchaseToken.
+        const orderRow = fake.state.topupOrders[0];
+        expect(orderRow.external_txn_id).toBe('GPA.REAL-ORDER-0001');
+        expect(orderRow.external_txn_id).not.toBe('user-facing-token-0001');
+    });
+
+    test('case 2: canceled purchase → 402 purchase_not_verified', async () => {
+        makeFetchMock({
+            onProductsGet: () => ({
+                ok: true, status: 200,
+                json: async () => ({ purchaseState: 1, orderId: 'GPA.cancel' }),
+            }),
+        });
+        const { app } = buildApp();
+        const res = await supertest(app).post('/api/wallet/topup/verify-google')
+            .send({ productId: 'ec.topup.starter', purchaseToken: 'token-cancel-0002' })
+            .expect(402);
+        expect(res.body.error).toBe('purchase_not_verified');
+        expect(res.body.details.code).toBe('google_token_canceled');
+        // No ledger row written, no order created.
+        expect(fake.state.ledger).toHaveLength(0);
+        expect(fake.state.topupOrders).toHaveLength(0);
+    });
+
+    test('case 3: pending purchase → 402 purchase_not_verified', async () => {
+        makeFetchMock({
+            onProductsGet: () => ({
+                ok: true, status: 200,
+                json: async () => ({ purchaseState: 2 }),
+            }),
+        });
+        const { app } = buildApp();
+        const res = await supertest(app).post('/api/wallet/topup/verify-google')
+            .send({ productId: 'ec.topup.starter', purchaseToken: 'token-pending-0003' })
+            .expect(402);
+        expect(res.body.error).toBe('purchase_not_verified');
+        expect(res.body.details.code).toBe('google_token_pending');
+        expect(fake.state.ledger).toHaveLength(0);
+    });
+
+    test('case 4: bad JWT / 401 from Google → 500 google_auth_failed (detail masked)', async () => {
+        makeFetchMock({
+            tokenResponder: () => ({ ok: false, status: 401, json: async () => ({ error: 'invalid_grant' }) }),
+        });
+        const { app } = buildApp();
+        const res = await supertest(app).post('/api/wallet/topup/verify-google')
+            .send({ productId: 'ec.topup.starter', purchaseToken: 'token-auth-fail' })
+            .expect(500);
+        expect(res.body.error).toBe('google_auth_failed');
+        // The upstream "invalid_grant" reason is NOT leaked to the client.
+        expect(JSON.stringify(res.body)).not.toMatch(/invalid_grant/);
+        expect(fake.state.ledger).toHaveLength(0);
+    });
+
+    test('case 5: GOOGLE_PLAY_SERVICE_ACCOUNT unset → FAIL-CLOSED (500 google_auth_failed)', async () => {
+        delete process.env.GOOGLE_PLAY_SERVICE_ACCOUNT;
+        if (wallet._resetGoogleCache) wallet._resetGoogleCache();
+        makeFetchMock();  // won't be called
+        const { app } = buildApp();
+        const res = await supertest(app).post('/api/wallet/topup/verify-google')
+            .send({ productId: 'ec.topup.starter', purchaseToken: 'token-no-gsa' })
+            .expect(500);
+        expect(res.body.error).toBe('google_auth_failed');
+        expect(fake.state.ledger).toHaveLength(0);
+        expect(fake.state.topupOrders).toHaveLength(0);
+    });
+
+    test('case 5b: GOOGLE_PLAY_ALLOW_UNVERIFIED=1 + no GSA → legacy trust path (audited fallback)', async () => {
+        delete process.env.GOOGLE_PLAY_SERVICE_ACCOUNT;
+        process.env.GOOGLE_PLAY_ALLOW_UNVERIFIED = '1';
+        if (wallet._resetGoogleCache) wallet._resetGoogleCache();
+        makeFetchMock();  // won't be called
+        const audited = [];
+        const { app } = buildApp({ serverLog: (lvl, tag, msg, meta) => audited.push({ lvl, tag, msg, meta }) });
+        const res = await supertest(app).post('/api/wallet/topup/verify-google')
+            .send({ productId: 'ec.topup.starter', purchaseToken: 'token-rollback-path' })
+            .expect(200);
+        expect(res.body.success).toBe(true);
+        const warn = audited.find(a => a.lvl === 'warn' && /skipped/.test(a.msg));
+        expect(warn).toBeDefined();
+    });
+
+    test('case 6: same-session cache — two verifications hit token endpoint once', async () => {
+        const calls = makeFetchMock({
+            onProductsGet: (url) => ({
+                ok: true, status: 200,
+                json: async () => {
+                    // Distinct orderIds so dedup doesn't hide the second call.
+                    const orderSuffix = url.includes('token-cache-2') ? '2' : '1';
+                    return { purchaseState: 0, orderId: `GPA.CACHE-${orderSuffix}` };
+                },
+            }),
+        });
+        const { app } = buildApp();
+        await supertest(app).post('/api/wallet/topup/verify-google')
+            .send({ productId: 'ec.topup.starter', purchaseToken: 'token-cache-1' })
+            .expect(200);
+        await supertest(app).post('/api/wallet/topup/verify-google')
+            .send({ productId: 'ec.topup.starter', purchaseToken: 'token-cache-2' })
+            .expect(200);
+        expect(calls.token).toBe(1);       // token exchange happened exactly once
+        expect(calls.productsGet).toBe(2); // two separate purchase lookups
+    });
+
+    test('case 7: dedup — same purchaseToken → second call returns deduped, no double credit', async () => {
+        makeFetchMock({
+            onProductsGet: () => ({
+                ok: true, status: 200,
+                json: async () => ({
+                    purchaseState: 0,
+                    orderId: 'GPA.DEDUP-0001',   // same orderId both times
+                }),
+            }),
+        });
+        const { app, walletApi } = buildApp();
+        const first = await supertest(app).post('/api/wallet/topup/verify-google')
+            .send({ productId: 'ec.topup.starter', purchaseToken: 'token-dedup' })
+            .expect(200);
+        expect(first.body.order.deduped).toBe(false);
+
+        const second = await supertest(app).post('/api/wallet/topup/verify-google')
+            .send({ productId: 'ec.topup.starter', purchaseToken: 'token-dedup' })
+            .expect(200);
+        expect(second.body.order.deduped).toBe(true);
+
+        // Wallet balance is credited exactly once (9450 e幣 = 9,450,000 mli).
+        const bal = await walletApi.getBalance(ALICE);
+        expect(bal.balance_ecoin).toBe(9450);
+        expect(fake.state.ledger).toHaveLength(1);
+    });
+
+    test('case 8: acknowledge is fire-and-forget — ack failure does NOT break the 200 response', async () => {
+        const calls = makeFetchMock({
+            onProductsGet: () => ({
+                ok: true, status: 200,
+                json: async () => ({ purchaseState: 0, orderId: 'GPA.ACK-FAIL-0001' }),
+            }),
+            onAck: () => ({ ok: false, status: 500, json: async () => ({ error: { code: 500 } }) }),
+        });
+        const { app } = buildApp();
+        const res = await supertest(app).post('/api/wallet/topup/verify-google')
+            .send({ productId: 'ec.topup.starter', purchaseToken: 'token-ack-fail' })
+            .expect(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.order.ecoinTotal).toBe(9450);
+
+        // Give the fire-and-forget ack a tick to reach the mock.
+        await new Promise((r) => setImmediate(r));
+        expect(calls.ack).toBe(1);
+        // Ledger still credited even though ack returned 500.
+        expect(fake.state.ledger).toHaveLength(1);
+    });
+
+    test('rejects missing/invalid inputs with 400', async () => {
+        makeFetchMock();
+        const { app } = buildApp();
+        await supertest(app).post('/api/wallet/topup/verify-google').send({}).expect(400);
+        await supertest(app).post('/api/wallet/topup/verify-google')
+            .send({ productId: 'ec.topup.starter' }).expect(400);
+        await supertest(app).post('/api/wallet/topup/verify-google')
+            .send({ productId: 'ec.topup.starter', purchaseToken: 'short' }).expect(400);
+        await supertest(app).post('/api/wallet/topup/verify-google')
+            .send({ productId: 'fake_tier', purchaseToken: 'long-enough-token' }).expect(400);
+    });
+});

--- a/backend/tests/jest/wallet.test.js
+++ b/backend/tests/jest/wallet.test.js
@@ -705,24 +705,41 @@ describe('wallet: HTTP routes', () => {
     });
 
     test('POST /topup/verify-google credits wallet end-to-end', async () => {
-        const app = buildApp({ user: { userId: ALICE } });
-        const res = await supertest(app).post('/api/wallet/topup/verify-google')
-            .send({ productId: 'ec.topup.starter', purchaseToken: 'gp-real-token-12345' })
-            .expect(200);
-        expect(res.body.success).toBe(true);
-        expect(res.body.order.status).toBe('paid');
-        // 9000 + 450 bonus = 9450 e幣
-        expect(res.body.order.ecoinTotal).toBe(9450);
-        expect(res.body.order.deduped).toBe(false);
+        // The full androidpublisher verification path is covered by
+        // wallet-topup-google.test.js (mocks global.fetch for the Google API).
+        // This legacy case exercises the rollback fallback (explicit
+        // GOOGLE_PLAY_ALLOW_UNVERIFIED=1) so it doesn't require real creds.
+        const prevGsa = process.env.GOOGLE_PLAY_SERVICE_ACCOUNT;
+        const prevAllow = process.env.GOOGLE_PLAY_ALLOW_UNVERIFIED;
+        delete process.env.GOOGLE_PLAY_SERVICE_ACCOUNT;
+        process.env.GOOGLE_PLAY_ALLOW_UNVERIFIED = '1';
+        if (wallet._resetGoogleCache) wallet._resetGoogleCache();
+        try {
+            const app = buildApp({ user: { userId: ALICE } });
+            const res = await supertest(app).post('/api/wallet/topup/verify-google')
+                .send({ productId: 'ec.topup.starter', purchaseToken: 'gp-real-token-12345' })
+                .expect(200);
+            expect(res.body.success).toBe(true);
+            expect(res.body.order.status).toBe('paid');
+            // 9000 + 450 bonus = 9450 e幣
+            expect(res.body.order.ecoinTotal).toBe(9450);
+            expect(res.body.order.deduped).toBe(false);
 
-        // Replaying the same token should dedupe (no double credit).
-        const replay = await supertest(app).post('/api/wallet/topup/verify-google')
-            .send({ productId: 'ec.topup.starter', purchaseToken: 'gp-real-token-12345' })
-            .expect(200);
-        expect(replay.body.order.deduped).toBe(true);
+            // Replaying the same token should dedupe (no double credit).
+            const replay = await supertest(app).post('/api/wallet/topup/verify-google')
+                .send({ productId: 'ec.topup.starter', purchaseToken: 'gp-real-token-12345' })
+                .expect(200);
+            expect(replay.body.order.deduped).toBe(true);
 
-        const bal = await walletApi.getBalance(ALICE);
-        expect(bal.balance_ecoin).toBe(9450);
+            const bal = await walletApi.getBalance(ALICE);
+            expect(bal.balance_ecoin).toBe(9450);
+        } finally {
+            if (prevGsa === undefined) delete process.env.GOOGLE_PLAY_SERVICE_ACCOUNT;
+            else process.env.GOOGLE_PLAY_SERVICE_ACCOUNT = prevGsa;
+            if (prevAllow === undefined) delete process.env.GOOGLE_PLAY_ALLOW_UNVERIFIED;
+            else process.env.GOOGLE_PLAY_ALLOW_UNVERIFIED = prevAllow;
+            if (wallet._resetGoogleCache) wallet._resetGoogleCache();
+        }
     });
 
     // ── Apple IAP verification ──────────────────────────────────────

--- a/backend/wallet.js
+++ b/backend/wallet.js
@@ -21,6 +21,8 @@ const express = require('express');
 const { Pool } = require('pg');
 const fs = require('fs');
 const path = require('path');
+const crypto = require('crypto');
+const jwt = require('jsonwebtoken');
 
 const pool = new Pool({
     connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
@@ -45,6 +47,17 @@ const INSURANCE_POOL_BPS = 200;
 /** Well-known virtual user UUIDs for platform-owned wallets. */
 const PLATFORM_WALLET_USER_ID = '00000000-0000-0000-0000-000000000001';
 const INSURANCE_POOL_USER_ID  = '00000000-0000-0000-0000-000000000002';
+
+/** Google Play package name (must match the Android app's applicationId). */
+const GOOGLE_PACKAGE_NAME = 'com.eclawbot.app';
+/** OAuth access-token cache TTL (conservative under Google's 3600s lifetime). */
+const GOOGLE_TOKEN_CACHE_MS = 55 * 60 * 1000;
+/** Google Play API scope — read + acknowledge purchases. */
+const GOOGLE_ANDROIDPUBLISHER_SCOPE = 'https://www.googleapis.com/auth/androidpublisher';
+/** OAuth token exchange endpoint. */
+const GOOGLE_OAUTH_TOKEN_URL = 'https://oauth2.googleapis.com/token';
+/** androidpublisher v3 REST API base. */
+const GOOGLE_ANDROIDPUBLISHER_BASE = 'https://androidpublisher.googleapis.com/androidpublisher/v3';
 
 /**
  * All ledger type values. Keep in sync with wallet_schema.sql comment.
@@ -729,6 +742,262 @@ async function getLedger(userId, { limit = 50, offset = 0, type = null } = {}) {
 }
 
 // ============================================
+// Google Play purchase verification (androidpublisher v3)
+// ============================================
+//
+// Security posture: FAIL-CLOSED. If GOOGLE_PLAY_SERVICE_ACCOUNT is missing
+// or unparseable, /topup/verify-google rejects with purchase_not_verified
+// instead of falling back to the legacy trust-token path. Rationale: this
+// route credits real money into wallets; an env-misconfiguration should
+// NOT open the door to forged purchaseTokens. To intentionally disable
+// verification (e.g. during a rollback), set env
+// `GOOGLE_PLAY_ALLOW_UNVERIFIED=1` — the flip is explicit + audited.
+//
+// No GSA field (private_key, private_key_id, full JSON) is ever logged.
+// Only `client_email` and `project_id` may appear in audit records.
+
+/**
+ * Singleton GSA env parser. Returns the parsed service account object
+ * on first call and caches it. Returns null if env is missing OR malformed.
+ * Never throws — caller decides how to handle missing creds.
+ */
+let _gsaCache = undefined;  // undefined = not parsed yet; null = parsed but absent/invalid
+function _getServiceAccount() {
+    if (_gsaCache !== undefined) return _gsaCache;
+    const raw = process.env.GOOGLE_PLAY_SERVICE_ACCOUNT;
+    if (!raw || typeof raw !== 'string') {
+        _gsaCache = null;
+        return _gsaCache;
+    }
+    try {
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object') {
+            _gsaCache = null;
+            return _gsaCache;
+        }
+        // Required fields: client_email + private_key. Do NOT log the key.
+        if (typeof parsed.client_email !== 'string' || typeof parsed.private_key !== 'string') {
+            _gsaCache = null;
+            return _gsaCache;
+        }
+        _gsaCache = parsed;
+        return _gsaCache;
+    } catch (_err) {
+        // JSON parse failed — treat as missing. Don't log the raw value
+        // (may contain the private key even if malformed).
+        _gsaCache = null;
+        return _gsaCache;
+    }
+}
+
+/** Reset the GSA + access-token caches. For tests only. */
+function _resetGoogleCache() {
+    _gsaCache = undefined;
+    _accessTokenCache = { token: null, expiresAt: 0, inflight: null };
+}
+
+/**
+ * Single-flight OAuth access-token cache.
+ * - `expiresAt`: epoch-ms at which the cached token becomes stale.
+ * - `inflight`: if a fetch is already in progress, concurrent callers await
+ *   the same promise instead of re-signing a JWT + hammering the token endpoint.
+ */
+let _accessTokenCache = { token: null, expiresAt: 0, inflight: null };
+
+/** Build and sign a service-account JWT assertion for the token exchange. */
+function _signServiceAccountJwt(sa, now = Math.floor(Date.now() / 1000)) {
+    const header = { alg: 'RS256', typ: 'JWT', kid: sa.private_key_id || undefined };
+    const payload = {
+        iss: sa.client_email,
+        sub: sa.client_email,
+        aud: GOOGLE_OAUTH_TOKEN_URL,
+        scope: GOOGLE_ANDROIDPUBLISHER_SCOPE,
+        iat: now,
+        exp: now + 3600,
+    };
+    return jwt.sign(payload, sa.private_key, { algorithm: 'RS256', header });
+}
+
+/**
+ * Acquire an OAuth access token for the androidpublisher scope.
+ * Returns the cached token if still fresh (within GOOGLE_TOKEN_CACHE_MS).
+ * Throws google_auth_failed on any upstream failure.
+ */
+async function _getGoogleAccessToken({ fetchImpl = fetch, now = Date.now() } = {}) {
+    const sa = _getServiceAccount();
+    if (!sa) {
+        const e = new Error('google_auth_failed');
+        e.reason = 'gsa_missing_or_invalid';
+        throw e;
+    }
+
+    if (_accessTokenCache.token && _accessTokenCache.expiresAt > now) {
+        return _accessTokenCache.token;
+    }
+    if (_accessTokenCache.inflight) {
+        return _accessTokenCache.inflight;
+    }
+
+    _accessTokenCache.inflight = (async () => {
+        try {
+            const assertion = _signServiceAccountJwt(sa);
+            const body = new URLSearchParams({
+                grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+                assertion,
+            });
+            const resp = await fetchImpl(GOOGLE_OAUTH_TOKEN_URL, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                body: body.toString(),
+            });
+            if (!resp.ok) {
+                const e = new Error('google_auth_failed');
+                e.reason = `token_exchange_http_${resp.status}`;
+                throw e;
+            }
+            const data = await resp.json();
+            if (!data || typeof data.access_token !== 'string') {
+                const e = new Error('google_auth_failed');
+                e.reason = 'token_exchange_malformed';
+                throw e;
+            }
+            _accessTokenCache.token = data.access_token;
+            _accessTokenCache.expiresAt = now + GOOGLE_TOKEN_CACHE_MS;
+            return data.access_token;
+        } finally {
+            _accessTokenCache.inflight = null;
+        }
+    })();
+    return _accessTokenCache.inflight;
+}
+
+/**
+ * Verify a Google Play purchase token via androidpublisher v3.
+ *
+ * Returns on success:
+ *   { valid: true, orderId, purchaseState, consumptionState,
+ *     acknowledgementState, rawResponse }
+ *
+ * Throws with a typed `.code`:
+ *   - google_auth_failed   — JWT sign / token exchange failed (500 to client)
+ *   - google_token_invalid — HTTP 400/404 from Google (402 to client)
+ *   - google_token_canceled — purchaseState=1 (402 to client)
+ *   - google_token_pending  — purchaseState=2 (402 to client)
+ *
+ * `orderId` is Google's authoritative per-transaction ID — prefer this over
+ * the raw purchaseToken when computing external_txn_id.
+ */
+async function verifyGooglePurchase(
+    packageName,
+    productId,
+    purchaseToken,
+    { fetchImpl = fetch } = {}
+) {
+    if (!packageName || typeof packageName !== 'string') throw new Error('package_name_invalid');
+    if (!productId || typeof productId !== 'string') throw new Error('product_id_invalid');
+    if (!purchaseToken || typeof purchaseToken !== 'string') throw new Error('purchase_token_invalid');
+
+    const accessToken = await _getGoogleAccessToken({ fetchImpl });
+    const url = `${GOOGLE_ANDROIDPUBLISHER_BASE}/applications/${encodeURIComponent(packageName)}`
+              + `/purchases/products/${encodeURIComponent(productId)}`
+              + `/tokens/${encodeURIComponent(purchaseToken)}`;
+
+    const resp = await fetchImpl(url, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${accessToken}` },
+    });
+
+    if (resp.status === 401 || resp.status === 403) {
+        // Most commonly: service account lacks Play Console access.
+        const e = new Error('google_auth_failed');
+        e.reason = `api_http_${resp.status}`;
+        throw e;
+    }
+    if (resp.status === 400 || resp.status === 404 || resp.status === 410) {
+        // Token does not identify a known purchase.
+        const e = new Error('google_token_invalid');
+        e.reason = `api_http_${resp.status}`;
+        throw e;
+    }
+    if (!resp.ok) {
+        const e = new Error('google_auth_failed');
+        e.reason = `api_http_${resp.status}`;
+        throw e;
+    }
+
+    let data;
+    try {
+        data = await resp.json();
+    } catch (_err) {
+        const e = new Error('google_auth_failed');
+        e.reason = 'api_malformed_json';
+        throw e;
+    }
+
+    // purchaseState: 0=purchased, 1=canceled, 2=pending
+    if (data.purchaseState === 1) {
+        const e = new Error('google_token_canceled');
+        e.purchaseState = 1;
+        throw e;
+    }
+    if (data.purchaseState === 2) {
+        const e = new Error('google_token_pending');
+        e.purchaseState = 2;
+        throw e;
+    }
+    if (data.purchaseState !== 0) {
+        const e = new Error('google_token_invalid');
+        e.purchaseState = data.purchaseState;
+        throw e;
+    }
+
+    return {
+        valid: true,
+        orderId: data.orderId || null,
+        purchaseState: data.purchaseState,
+        consumptionState: data.consumptionState,
+        acknowledgementState: data.acknowledgementState,
+        rawResponse: data,
+    };
+}
+
+/**
+ * Acknowledge a purchase. Must be called within 3 days of purchase or
+ * Google auto-refunds. Fire-and-forget from the caller's perspective:
+ * the wallet has already been credited, so an ack failure is logged + left
+ * for a retry cron — we never revoke credited ecoins on ack failure.
+ *
+ * Never throws (errors are returned as { ok: false, error }).
+ */
+async function acknowledgeGooglePurchase(
+    packageName,
+    productId,
+    purchaseToken,
+    { fetchImpl = fetch } = {}
+) {
+    try {
+        const accessToken = await _getGoogleAccessToken({ fetchImpl });
+        const url = `${GOOGLE_ANDROIDPUBLISHER_BASE}/applications/${encodeURIComponent(packageName)}`
+                  + `/purchases/products/${encodeURIComponent(productId)}`
+                  + `/tokens/${encodeURIComponent(purchaseToken)}:acknowledge`;
+        const resp = await fetchImpl(url, {
+            method: 'POST',
+            headers: {
+                Authorization: `Bearer ${accessToken}`,
+                'Content-Type': 'application/json',
+            },
+            body: '{}',
+        });
+        if (!resp.ok && resp.status !== 204) {
+            return { ok: false, error: `ack_http_${resp.status}` };
+        }
+        return { ok: true };
+    } catch (err) {
+        return { ok: false, error: err.message || 'ack_failed' };
+    }
+}
+
+// ============================================
 // Express factory
 // ============================================
 
@@ -791,9 +1060,10 @@ module.exports = function walletFactory({ authMiddleware, adminMiddleware, serve
     //   — Device auth (Android app): { deviceId, deviceSecret } in body
     //   — JWT auth (portal): cookie/Authorization header
     //
-    // TODO: validate purchaseToken via Google androidpublisher API once
-    // GOOGLE_PLAY_SERVICE_ACCOUNT is provisioned. Until then we trust the
-    // token and rely on UNIQUE(channel, external_txn_id) for dedupe.
+    // Verifies purchaseToken against Google androidpublisher v3 before
+    // crediting the wallet. Fail-closed: if GOOGLE_PLAY_SERVICE_ACCOUNT is
+    // missing/invalid the request is rejected (purchase_not_verified) so
+    // an env misconfiguration can't open the door to forged tokens.
     router.post('/topup/verify-google', async (req, res) => {
         try {
             const { productId, purchaseToken, deviceId, deviceSecret: devSecret } = req.body || {};
@@ -842,14 +1112,65 @@ module.exports = function walletFactory({ authMiddleware, adminMiddleware, serve
                 return res.status(400).json({ success: false, error: 'unknown_product' });
             }
 
+            // --- Verify with Google androidpublisher ---
+            // Fail-closed by default. `GOOGLE_PLAY_ALLOW_UNVERIFIED=1` is an
+            // explicit, audited escape hatch for emergency rollback.
+            const allowUnverified = process.env.GOOGLE_PLAY_ALLOW_UNVERIFIED === '1';
+            let googleOrderId = null;
+            let skippedVerification = false;
+
+            if (allowUnverified && !_getServiceAccount()) {
+                // Emergency rollback path — audited so Hank sees it.
+                skippedVerification = true;
+                audit('warn', 'wallet', `google verification skipped (GOOGLE_PLAY_ALLOW_UNVERIFIED=1) user=${userId} product=${productId}`, {
+                    userId, action: 'topup_verify', result: 'unverified_fallback',
+                });
+            } else {
+                try {
+                    const verified = await verifyGooglePurchase(
+                        GOOGLE_PACKAGE_NAME, productId, purchaseToken
+                    );
+                    googleOrderId = verified.orderId;
+                } catch (vErr) {
+                    if (vErr.message === 'google_auth_failed') {
+                        // Server-side problem (bad GSA, Google 5xx). Mask the
+                        // internal reason from the client; log for ops.
+                        audit('error', 'wallet', `google_auth_failed user=${userId} reason=${vErr.reason || 'unknown'}`, {
+                            userId, action: 'topup_verify', result: 'google_auth_failed',
+                        });
+                        return res.status(500).json({ success: false, error: 'google_auth_failed' });
+                    }
+                    // google_token_invalid / canceled / pending → 402 + safe error code
+                    const code = vErr.message;  // safe: one of the enumerated strings
+                    audit('warn', 'wallet', `purchase_not_verified user=${userId} product=${productId} code=${code}`, {
+                        userId, action: 'topup_verify', result: code,
+                    });
+                    return res.status(402).json({
+                        success: false,
+                        error: 'purchase_not_verified',
+                        details: { code },
+                    });
+                }
+            }
+
+            // Google orderId (stable per-transaction) is preferred over the
+            // raw purchaseToken as the external_txn_id. Fall back to the token
+            // only when Google omitted orderId (rare) or we skipped verification.
+            const externalTxnId = googleOrderId || purchaseToken;
+
             const order = await createTopupOrder({
                 userId,
                 channel: 'google_play',
                 priceUsd: tier.priceUsd,
                 baseMli: tier.baseMli,
                 bonusMli: tier.bonusMli,
-                externalTxnId: purchaseToken,
-                externalRaw: { productId, source: 'verify-google' },
+                externalTxnId,
+                externalRaw: {
+                    productId,
+                    source: 'verify-google',
+                    orderId: googleOrderId,
+                    verified: !skippedVerification,
+                },
             });
 
             const ledger = await markTopupPaid({
@@ -862,6 +1183,27 @@ module.exports = function walletFactory({ authMiddleware, adminMiddleware, serve
             audit('info', 'wallet', `topup verified user=${userId} product=${productId} order=${order.id}`, {
                 userId, action: 'topup_verify', resource: order.id, result: 'success',
             });
+
+            // Fire-and-forget acknowledge AFTER ledger credit succeeded.
+            // If ack fails, the user keeps their ecoins; a retry cron can
+            // reconcile. Never block the response on this.
+            if (!skippedVerification) {
+                Promise.resolve()
+                    .then(() => acknowledgeGooglePurchase(GOOGLE_PACKAGE_NAME, productId, purchaseToken))
+                    .then((ackRes) => {
+                        if (!ackRes.ok) {
+                            audit('warn', 'wallet', `google ack failed user=${userId} order=${order.id} err=${ackRes.error}`, {
+                                userId, action: 'topup_ack', resource: order.id, result: 'ack_failed',
+                            });
+                        }
+                    })
+                    .catch((ackErr) => {
+                        audit('warn', 'wallet', `google ack threw user=${userId} order=${order.id}`, {
+                            userId, action: 'topup_ack', resource: order.id, result: 'ack_threw',
+                            metadata: { message: ackErr && ackErr.message },
+                        });
+                    });
+            }
 
             res.json({
                 success: true,
@@ -1083,8 +1425,12 @@ module.exports = function walletFactory({ authMiddleware, adminMiddleware, serve
         usdToMli,
         ecoinToMli,
         mliToEcoin,
+        // Google Play verification (exposed for tests + callers)
+        verifyGooglePurchase,
+        acknowledgeGooglePurchase,
+        GOOGLE_PACKAGE_NAME,
         // Internals exposed for testing
-        _internals: { applyLedgerEntry, withTransaction, pool },
+        _internals: { applyLedgerEntry, withTransaction, pool, _resetGoogleCache, _getServiceAccount },
     };
 };
 
@@ -1101,3 +1447,7 @@ module.exports.ecoinToMli = ecoinToMli;
 module.exports.mliToEcoin = mliToEcoin;
 module.exports.TOPUP_TIERS = TOPUP_TIERS;
 module.exports.getTopupTier = getTopupTier;
+module.exports.GOOGLE_PACKAGE_NAME = GOOGLE_PACKAGE_NAME;
+module.exports.verifyGooglePurchase = verifyGooglePurchase;
+module.exports.acknowledgeGooglePurchase = acknowledgeGooglePurchase;
+module.exports._resetGoogleCache = _resetGoogleCache;


### PR DESCRIPTION
## Summary

Wires `/api/wallet/topup/verify-google` to Google Play's androidpublisher v3 REST API before crediting the wallet. Replaces the `TODO: validate purchaseToken` trust-token path at `backend/wallet.js:794` with a fully verified pipeline.

- `verifyGooglePurchase(packageName, productId, purchaseToken)` — service-account JWT → OAuth token → GET purchase-token resource. Typed errors: `google_auth_failed`, `google_token_invalid`, `google_token_canceled`, `google_token_pending`.
- `acknowledgeGooglePurchase()` — fire-and-forget `:acknowledge` call after the ledger credit succeeds. Ack failures log a warn audit but never revoke credited ecoins (a retry cron can reconcile; within Google's 3-day ack window).
- Route uses Google's **stable `orderId`** as `external_txn_id`, not the raw purchaseToken — `UNIQUE(channel, external_txn_id)` still dedupes across the full lifecycle.
- Singleton GSA env parser + 55-minute access-token cache (conservative under Google's 60-min TTL) with single-flight `inflight` tracking to avoid thundering-herd re-signs on first use.

## Security posture — FAIL-CLOSED

Missing / unparseable `GOOGLE_PLAY_SERVICE_ACCOUNT` now rejects requests with `500 google_auth_failed` instead of the legacy trust-token fallback. Rationale: this endpoint credits real money; an env misconfiguration should not open the door to forged purchaseTokens.

If Hank wants the fallback behavior for a production rollback, set `GOOGLE_PLAY_ALLOW_UNVERIFIED=1` on Railway — the flip is explicit, audited (warn-level), and temporary. Unset it to re-enable verification.

Other guardrails:
- **No GSA leakage:** private key / full JSON never logged. Audit records only include `client_email` / `project_id`.
- **Constant-time checks:** existing `safeEqual` preserved for device auth; no new cmp paths added.
- **Input masking:** upstream auth failure reasons (e.g. `invalid_grant`) are kept in server audit logs only, never surfaced to the client response body.

## Changes

- `backend/wallet.js`
  - New constants `GOOGLE_PACKAGE_NAME`, `GOOGLE_TOKEN_CACHE_MS`, OAuth / androidpublisher URL literals.
  - New helpers (above the Express factory): `_getServiceAccount()` singleton, `_signServiceAccountJwt()`, `_getGoogleAccessToken()` with single-flight cache, `verifyGooglePurchase()`, `acknowledgeGooglePurchase()`, `_resetGoogleCache()` (test-only).
  - Route updated to call `verifyGooglePurchase` → map typed errors to `402 purchase_not_verified` (client-facing) or `500 google_auth_failed` (server-side). Fire-and-forget ack post-credit.
  - Uses `Google orderId` for `external_txn_id`; `externalRaw` now stamps `{ productId, source, orderId, verified }` for forensic.
  - Factory + module-level exports: `verifyGooglePurchase`, `acknowledgeGooglePurchase`, `GOOGLE_PACKAGE_NAME`, `_resetGoogleCache`.

- `backend/tests/jest/wallet-topup-google.test.js` (new)
  - Generates a throwaway RSA keypair in-memory so the JWT signer runs for real (never a checked-in secret).
  - Mocks `global.fetch` with URL-dispatched responders (token / products GET / ack) and asserts call counts.
  - 15 test cases covering all 8 spec scenarios plus input validation:
    1. Happy path → `{valid:true, orderId}` and credit keyed by orderId
    2. `purchaseState=1` canceled → 402
    3. `purchaseState=2` pending → 402
    4. Token HTTP 401 → 500 (detail masked)
    5. Unset GSA → 500 fail-closed
    5b. `GOOGLE_PLAY_ALLOW_UNVERIFIED=1` → audited rollback path
    6. Token cache single-flight (1 token POST for 2 verifies)
    7. Dedup via orderId (second call `deduped:true`, balance credited once)
    8. Ack rejects → endpoint still 200, ledger still credited

- `backend/tests/jest/wallet.test.js`
  - Existing `POST /topup/verify-google credits wallet end-to-end` test now uses the `GOOGLE_PLAY_ALLOW_UNVERIFIED=1` rollback so it doesn't need Google creds. Full Google-API path coverage lives in the new file.

## Tradeoffs

- **Fail-closed over fallback-to-trust:** spec allowed either; I picked fail-closed because the endpoint credits money and env misconfigurations should never be silently turned into forged-token acceptance. Escape hatch: `GOOGLE_PLAY_ALLOW_UNVERIFIED=1`.
- **No new deps:** uses `jsonwebtoken` (already in `backend/package.json`) and native `fetch` (Node 18+).
- **Ack is best-effort:** never blocks the response and never throws. If Google's ack endpoint flaps, users keep their ecoins — a retry cron is the correct compensation path (ack is required within 3 days; we have a large window).
- **Token cache race:** single-flight via `_accessTokenCache.inflight` — concurrent callers on cold-start await the same promise instead of re-signing.

## Test plan

- [x] `npx jest tests/jest/wallet-topup-google.test.js` → 15/15 pass
- [x] `npx jest tests/jest/wallet.test.js` → 55/55 pass (existing case updated to exercise rollback)
- [x] Full `npx jest` backend suite → 1673/1673 pass across 96 suites
- [ ] Live smoke post-merge: fake token → 402; real TWD 30 tier token → credits 3000 e幣 exactly once (dedup check)
- [ ] Verify Railway env `GOOGLE_PLAY_SERVICE_ACCOUNT` is set + parseable before the first real user attempt (fail-closed will reject otherwise)

🤖 Generated with [Claude Code](https://claude.com/claude-code)