### PR TITLE
fix(wallet): env-drive Google Play package name (default com.hank.clawlive)

### DIFF
--- a/backend/wallet.js
+++ b/backend/wallet.js
@@ -49,7 +49,7 @@ const PLATFORM_WALLET_USER_ID = '00000000-0000-0000-0000-000000000001';
 const INSURANCE_POOL_USER_ID  = '00000000-0000-0000-0000-000000000002';
 
 /** Google Play package name (must match the Android app's applicationId). */
-const GOOGLE_PACKAGE_NAME = 'com.eclawbot.app';
+const GOOGLE_PACKAGE_NAME = process.env.GOOGLE_PLAY_PACKAGE || 'com.hank.clawlive';
 /** OAuth access-token cache TTL (conservative under Google's 3600s lifetime). */
 const GOOGLE_TOKEN_CACHE_MS = 55 * 60 * 1000;
 /** Google Play API scope — read + acknowledge purchases. */


### PR DESCRIPTION
## Bug

PR #1879 (262c3548) introduced Google Play purchase verification via androidpublisher v3, but hardcoded the package name at `backend/wallet.js:52`:

```js
const GOOGLE_PACKAGE_NAME = 'com.eclawbot.app';
```

The real Android app's `applicationId` is **`com.hank.clawlive`** — confirmed via:
- `app/build.gradle.kts` (`applicationId = "com.hank.clawlive"`)
- Live emulator: `adb shell pm list packages | grep clawlive` → `package:com.hank.clawlive` (v1.0.75)

androidpublisher v3 requires the package segment of the URL to match the Play Console listing exactly. With the wrong name, every `purchases.products.get` call would 404 and `/topup/verify-google` would fail-closed in production.

## Fix

Switch to an env-driven constant with the correct default:

```js
const GOOGLE_PACKAGE_NAME = process.env.GOOGLE_PLAY_PACKAGE || 'com.hank.clawlive';
```

This lets Railway override via `GOOGLE_PLAY_PACKAGE` if the Play Console listing ever changes, without another code deploy.

## Scope

Android-only. Deliberately **not** touching:
- iOS `APPLE_BUNDLE_ID` / `expectedBundleId` (wallet.js:1303) — independent identifier.
- `com.eclawbot` marketing links in `public/shared/i18n.js` — Play Store marketing URLs, different concern.

## Tests

`cd backend && npx jest tests/jest/wallet-topup-google.test.js tests/jest/wallet.test.js`
→ **70/70 passing** (2 suites). Full jest run: **1673/1673 passing** (96 suites).

Test file already imports `wallet.GOOGLE_PACKAGE_NAME` (exported const), so changing the default value flows through automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)