### PR TITLE
fix(wallet): ack sweep skips terminal failed rows

### DIFF
--- a/backend/ack-retry-sweep.js
+++ b/backend/ack-retry-sweep.js
@@ -11,10 +11,10 @@
  *     ack_attempts=0 on insert; on ack success → 'acked'; on ack failure
  *     → bump attempts (see wallet.js verify-google route).
  *   - This sweep runs hourly, retries every google_play row where
- *     ack_state != 'acked' AND created_at within last 72h (Google's auto-
- *     refund window). On success → mark 'acked'. On 3 consecutive failures
- *     → mark 'failed' and emit an audit warn so ops can investigate before
- *     the refund lands.
+ *     ack_state NOT IN ('acked','failed') AND created_at within last 72h
+ *     (Google's auto-refund window). On success → mark 'acked'. On 3
+ *     consecutive failures → mark 'failed' (terminal: no further retries)
+ *     and emit an audit warn so ops can investigate before the refund lands.
  *
  * The sweep is idempotent: :acknowledge on an already-acked purchase is a
  * no-op on Google's side (they return 200 or 'already acknowledged' — both
@@ -76,6 +76,7 @@ async function runAckRetrySweep({
              FROM topup_orders
              WHERE channel = 'google_play'
                AND ack_state <> 'acked'
+               AND ack_state <> 'failed'
                AND status = 'paid'
                AND created_at >= $1
              ORDER BY created_at ASC

--- a/backend/tests/jest/wallet-ack-retry-sweep.test.js
+++ b/backend/tests/jest/wallet-ack-retry-sweep.test.js
@@ -49,7 +49,7 @@ function makeOrder(overrides = {}) {
 /**
  * Minimal fake pg pool backed by an in-memory array. Supports just the
  * SQL shapes the sweep issues:
- *   - SELECT ... FROM topup_orders WHERE channel='google_play' AND ack_state <> 'acked' AND status='paid' AND created_at >= $1 ORDER BY created_at ASC LIMIT $2
+ *   - SELECT ... FROM topup_orders WHERE channel='google_play' AND ack_state <> 'acked' AND ack_state <> 'failed' AND status='paid' AND created_at >= $1 ORDER BY created_at ASC LIMIT $2
  *   - UPDATE topup_orders SET ack_state='acked', ack_at=NOW(), ack_attempts=ack_attempts+1 WHERE id=$1 AND ack_state <> 'acked'
  *   - UPDATE topup_orders SET ack_attempts=ack_attempts+1, ack_state = CASE WHEN $2::boolean THEN 'failed' ELSE ack_state END WHERE id=$1 AND ack_state <> 'acked'
  */
@@ -64,6 +64,7 @@ function makePool(orders) {
                 const matched = orders
                     .filter(o => o.channel === 'google_play'
                               && o.ack_state !== 'acked'
+                              && o.ack_state !== 'failed'
                               && o.status === 'paid'
                               && new Date(o.created_at) >= new Date(windowStart))
                     .sort((a, b) => new Date(a.created_at) - new Date(b.created_at))
@@ -211,11 +212,8 @@ describe('ack-retry-sweep: runAckRetrySweep', () => {
     test('case 4: no pending rows → no-op (all stats zero, ack never called)', async () => {
         const orders = [
             makeOrder({ id: 'o4a', ack_state: 'acked' }),  // excluded by filter
-            makeOrder({ id: 'o4b', ack_state: 'failed' }), // excluded (wait — failed IS != acked, so this ISN'T excluded)
+            makeOrder({ id: 'o4b', ack_state: 'failed' }), // excluded — 'failed' is terminal
         ];
-        // The sweep does re-pick 'failed' rows (ack_state <> 'acked'). For a
-        // true no-op we need all acked:
-        orders[1].ack_state = 'acked';
 
         const pool = makePool(orders);
         const audit = makeAudit();
@@ -229,6 +227,31 @@ describe('ack-retry-sweep: runAckRetrySweep', () => {
 
         expect(stats).toMatchObject({ scanned: 0, acked: 0, failed: 0, exhausted: 0, skipped: 0 });
         expect(ackMock).not.toHaveBeenCalled();
+    });
+
+    test('case 4b: row already marked ack_state=failed → skipped (terminal, not re-queried)', async () => {
+        // Regression guard: PR #1881 originally selected ack_state <> 'acked',
+        // which re-picked 'failed' rows every hour → wasted Google call +
+        // duplicate exhausted audit warn each tick until the 72h window
+        // closed. 'failed' must be terminal.
+        const orders = [
+            makeOrder({ id: 'already-failed', ack_state: 'failed', ack_attempts: 3 }),
+        ];
+        const pool = makePool(orders);
+        const audit = makeAudit();
+        const ackMock = jest.fn().mockResolvedValue({ ok: true });
+
+        const stats = await runAckRetrySweep({
+            pool, audit,
+            acknowledgeGooglePurchase: ackMock,
+            packageName: DEFAULT_PKG,
+        });
+
+        expect(stats).toMatchObject({ scanned: 0, acked: 0, failed: 0, exhausted: 0, skipped: 0 });
+        expect(ackMock).not.toHaveBeenCalled();
+        // Row is untouched: attempts stay at 3, state stays 'failed'.
+        expect(orders[0].ack_state).toBe('failed');
+        expect(orders[0].ack_attempts).toBe(3);
     });
 
     test('case 5: row older than 72h window → skipped entirely (not scanned)', async () => {

--- a/backend/wallet_schema.sql
+++ b/backend/wallet_schema.sql
@@ -130,6 +130,8 @@ ALTER TABLE topup_orders
 
 -- Only google_play rows need ack; partial index keeps it cheap. The sweep
 -- runs hourly and filters by (channel, ack_state, created_at window).
+-- 'failed' is terminal (3 retries exhausted) so exclude it too — matching
+-- the sweep's SELECT predicate keeps this partial index useful.
 CREATE INDEX IF NOT EXISTS idx_topup_ack_pending
     ON topup_orders(channel, ack_state, created_at)
-    WHERE channel = 'google_play' AND ack_state <> 'acked';
+    WHERE channel = 'google_play' AND ack_state <> 'acked' AND ack_state <> 'failed';


### PR DESCRIPTION
## Summary

Follow-up to #1881. The sweep's SELECT predicate was `ack_state <> 'acked'`, which still re-queried rows already marked `'failed'` after three strikes. Result: every hour the sweep wasted a Google `:acknowledge` call on the dead row, bumped `ack_attempts` past 3, and emitted a duplicate `exhausted` audit warn — repeating until the row aged out of the 72h refund window (~72 duplicate warns per dead row).

- Tighten `SELECT` in `backend/ack-retry-sweep.js` to also exclude `ack_state <> 'failed'` so `'failed'` is truly terminal
- Match the partial index `idx_topup_ack_pending` predicate in `backend/wallet_schema.sql` so the index stays usable for the sweep's query plan
- Add regression test `case 4b` in `wallet-ack-retry-sweep.test.js`: a row with `ack_state='failed', ack_attempts=3` inside the 72h window must NOT be scanned and `acknowledgeGooglePurchase` must NOT be called

## Test plan

- [x] `cd backend && npx jest tests/jest/wallet-ack-retry-sweep.test.js` — 13/13 passing (including new case 4b)
- [x] Full jest suite still green (1686/1686)
- [ ] Post-merge: watch Railway logs next sweep tick — `[AckSweep] scanned=N` should no longer include known-failed orders

Out of scope: credit path, cron registration, other sweeps.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>