### PR TITLE
fix(db): retry DB init + startup gate to prevent entity wipe on deploy

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -10,38 +10,52 @@ let pool = null;
 
 // Initialize database connection
 async function initDatabase() {
-    try {
-        // Railway automatically provides DATABASE_URL environment variable
-        // when you add a PostgreSQL service
-        const connectionString = process.env.DATABASE_URL;
+    const connectionString = process.env.DATABASE_URL;
 
-        if (!connectionString) {
-            console.error('[DB] DATABASE_URL not found. PostgreSQL persistence disabled.');
-            console.error('[DB] To enable: Add PostgreSQL service in Railway dashboard');
-            return false;
-        }
-
-        // Create connection pool
-        pool = new Pool({
-            connectionString: connectionString,
-            ssl: process.env.NODE_ENV === 'production' ? {
-                rejectUnauthorized: false // Railway uses self-signed certificates
-            } : false
-        });
-
-        // Test connection
-        const client = await pool.connect();
-        console.log('[DB] PostgreSQL connection established');
-        client.release();
-
-        // Create tables if they don't exist
-        await createTables();
-
-        return true;
-    } catch (err) {
-        console.error('[DB] Failed to initialize database:', err.message);
+    if (!connectionString) {
+        console.error('[DB] DATABASE_URL not found. PostgreSQL persistence disabled.');
+        console.error('[DB] To enable: Add PostgreSQL service in Railway dashboard');
         return false;
     }
+
+    // Retry up to 5 times with exponential back-off (1s → 2s → 4s → 8s → 16s)
+    // Railway may restart PG and Node concurrently; the DB might not be ready
+    // on the first attempt, causing a silent fallback to file storage that
+    // wipes all in-memory entities (see 2026-04-20 incident).
+    const MAX_RETRIES = 5;
+    for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+        try {
+            // Create / recreate connection pool on each attempt
+            pool = new Pool({
+                connectionString: connectionString,
+                ssl: process.env.NODE_ENV === 'production' ? {
+                    rejectUnauthorized: false // Railway uses self-signed certificates
+                } : false
+            });
+
+            // Test connection
+            const client = await pool.connect();
+            console.log(`[DB] PostgreSQL connection established (attempt ${attempt}/${MAX_RETRIES})`);
+            client.release();
+
+            // Create tables if they don't exist
+            await createTables();
+
+            return true;
+        } catch (err) {
+            console.error(`[DB] Init attempt ${attempt}/${MAX_RETRIES} failed: ${err.message}`);
+            // Clean up the failed pool before retrying
+            if (pool) { try { await pool.end(); } catch (_) {} pool = null; }
+            if (attempt < MAX_RETRIES) {
+                const delay = Math.pow(2, attempt - 1) * 1000;
+                console.log(`[DB] Retrying in ${delay / 1000}s...`);
+                await new Promise(r => setTimeout(r, delay));
+            }
+        }
+    }
+
+    console.error('[DB] All connection attempts exhausted. PostgreSQL persistence disabled.');
+    return false;
 }
 
 // Create database tables

--- a/backend/index.js
+++ b/backend/index.js
@@ -558,6 +558,18 @@ app.get('/privacy-policy.html', (req, res) => {
     res.sendFile(path.join(__dirname, 'public/privacy-policy.html'));
 });
 
+// Startup gate: reject device-scoped API requests while persistence is loading.
+// Without this, getOrCreateDevice() creates a blank device that shadows the
+// real DB-loaded one, silently wiping all entities (2026-04-20 incident).
+if (process.env.NODE_ENV !== 'test') {
+    app.use('/api', (req, res, next) => {
+        if (persistenceReady) return next();
+        // Allow health/version probes even during startup
+        if (req.path === '/health' || req.path === '/version') return next();
+        res.status(503).json({ success: false, message: 'Server starting up — please retry in a few seconds' });
+    });
+}
+
 // Telemetry auto-capture middleware (pool linked lazily after chatPool init)
 let _telemetryPool = null;
 const telemetryPoolProxy = {


### PR DESCRIPTION
## Summary
- **db.initDatabase()** now retries up to 5 times with exponential back-off (1s→16s) to handle transient Railway PG connection failures
- **Startup 503 gate** middleware blocks `/api/*` requests until persistence is loaded, preventing `getOrCreateDevice()` from creating blank devices that shadow real DB entities

## Root Cause
After the 2026-04-20 deploy, `db.initDatabase()` silently failed → `usePostgreSQL=false` → file fallback with no `devices.json` → first API request created blank device → all 4 entities appeared lost (but were still intact in PostgreSQL).

## Test plan
- [x] 1688/1688 Jest tests pass (98 suites)
- [ ] Deploy and verify entities load from PostgreSQL
- [ ] Verify channel bots reconnect successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)