### PR TITLE
fix(mission): accept content/category aliases on /note/update + fix /api/help

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1142,7 +1142,7 @@ app.get('/api/help', (req, res) => {
         notes: [
             { title: 'Read mission dashboard (notes/rules/skills)', curl: `curl -s "${apiBase}/api/mission/dashboard?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}"` },
             { title: 'Add note', curl: `curl -s -X POST "${apiBase}/api/mission/note/add" -H "Content-Type: application/json" -d ${d},"title":"TITLE","content":"CONTENT"}'` },
-            { title: 'Update note', curl: `curl -s -X POST "${apiBase}/api/mission/note/update" -H "Content-Type: application/json" -d ${d},"title":"TITLE","content":"NEW_CONTENT"}'` }
+            { title: 'Update note', curl: `curl -s -X POST "${apiBase}/api/mission/note/update" -H "Content-Type: application/json" -d ${d},"title":"TITLE","newContent":"NEW_CONTENT"}'` }
         ],
         search: [
             { title: 'Web search (DuckDuckGo)', curl: `curl -s "${apiBase}/api/bot/web-search?q=QUERY&deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}"` },

--- a/backend/mission.js
+++ b/backend/mission.js
@@ -737,7 +737,11 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
     // ============================================
     router.post('/note/update', async (req, res) => {
         if (!authenticate(req, res)) return;
-        const { deviceId, title, newTitle, newContent, newCategory } = req.body;
+        const { deviceId, title } = req.body;
+        // Accept content/category as aliases for newContent/newCategory (#1888)
+        const newTitle = req.body.newTitle;
+        const newContent = req.body.newContent !== undefined ? req.body.newContent : req.body.content;
+        const newCategory = req.body.newCategory !== undefined ? req.body.newCategory : req.body.category;
 
         if (!title) {
             return res.status(400).json({ success: false, error: 'Missing title' });

--- a/backend/tests/jest/mission.test.js
+++ b/backend/tests/jest/mission.test.js
@@ -212,6 +212,18 @@ describe('Category support in update endpoints', () => {
         expect([200, 404, 500].includes(res.status)).toBe(true);
     });
 
+    it('note/update accepts content as alias for newContent (docs-bot compat)', async () => {
+        const res = await post('/api/mission/note/update')
+            .send({ ...auth, title: 'Some Note', content: 'Aliased body' });
+        expect([200, 404, 500].includes(res.status)).toBe(true);
+    });
+
+    it('note/update accepts category as alias for newCategory', async () => {
+        const res = await post('/api/mission/note/update')
+            .send({ ...auth, title: 'Some Note', category: 'Aliased' });
+        expect([200, 404, 500].includes(res.status)).toBe(true);
+    });
+
     it('rule/update accepts newCategory field', async () => {
         const res = await post('/api/mission/rule/update')
             .send({ ...auth, name: 'Some Rule', newCategory: 'Workflow' });


### PR DESCRIPTION
## Summary
- `/api/help` curl_example for `/note/update` showed `"title":"TITLE","content":"NEW_CONTENT"` but the handler only read `newContent`/`newCategory` → silent no-op for any bot following the docs.
- Fix docs (`index.js:1145`) to use `newContent`.
- Add handler aliasing (`mission.js`) so `content`/`category` work as aliases for `newContent`/`newCategory` (backward compat for any bot already wired to the old docs).
- 2 new alias tests; existing 24 mission tests still pass.

## Why it matters
Discovered 2026-04-20 during rental-health SOP Step 3 — first snapshot append came back `success:true` but canonical note `note_d2229b778f995db9e325ff04` didn't change until I re-read `mission.js:740` and retried with `newContent`. Any bot following `/api/help` today would hit the same silent-success trap.

Tracking card: `card_6fa66142631194c1a8cdcfb4`.

## Test plan
- [x] `npx jest tests/jest/mission.test.js` → 26/26 passing (includes the 2 new alias cases + existing `newCategory` regression)
- [ ] Post-deploy: re-run the SOP step with `"content"` (not `"newContent"`) against live `/note/update` and confirm persistence via `dashboard` read

🤖 Generated with [Claude Code](https://claude.com/claude-code)