### PR TITLE
fix(mission): harden update handlers + mirror aliases across rule/skill/soul

### DIFF
--- a/backend/mission.js
+++ b/backend/mission.js
@@ -770,8 +770,8 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
             }
 
             if (newTitle) note.title = newTitle.trim();
-            if (newContent !== undefined) note.content = newContent.trim();
-            if (newCategory !== undefined) note.category = newCategory.trim();
+            if (newContent !== undefined) note.content = (newContent ?? '').trim();
+            if (newCategory !== undefined) note.category = newCategory ? newCategory.trim() : null;
             note.updatedAt = Date.now();
 
             const updateResult = await client.query(
@@ -1819,7 +1819,10 @@ async function submitPayment() {
     // ============================================
     router.post('/rule/update', async (req, res) => {
         if (!authenticate(req, res)) return;
-        const { deviceId, name, newName, newDescription, newRuleType, newAssignedEntities, newIsEnabled, newCategory } = req.body;
+        const { deviceId, name, newName, newRuleType, newAssignedEntities, newIsEnabled } = req.body;
+        // Accept description/category as aliases for newDescription/newCategory (docs-bot compat)
+        const newDescription = req.body.newDescription !== undefined ? req.body.newDescription : req.body.description;
+        const newCategory = req.body.newCategory !== undefined ? req.body.newCategory : req.body.category;
 
         if (!name) {
             return res.status(400).json({ success: false, error: 'Missing name' });
@@ -1848,7 +1851,7 @@ async function submitPayment() {
             }
 
             if (newName) rule.name = newName.trim();
-            if (newDescription !== undefined) rule.description = newDescription.trim();
+            if (newDescription !== undefined) rule.description = (newDescription ?? '').trim();
             if (newRuleType) rule.ruleType = newRuleType;
             if (newAssignedEntities !== undefined) rule.assignedEntities = newAssignedEntities;
             if (newIsEnabled !== undefined) rule.isEnabled = newIsEnabled;
@@ -2068,7 +2071,10 @@ async function submitPayment() {
     // ============================================
     router.post('/skill/update', async (req, res) => {
         if (!authenticate(req, res)) return;
-        const { deviceId, title, newTitle, newUrl, newAssignedEntities, newCategory } = req.body;
+        const { deviceId, title, newTitle, newAssignedEntities } = req.body;
+        // Accept url/category as aliases for newUrl/newCategory (docs-bot compat)
+        const newUrl = req.body.newUrl !== undefined ? req.body.newUrl : req.body.url;
+        const newCategory = req.body.newCategory !== undefined ? req.body.newCategory : req.body.category;
 
         if (!title) {
             return res.status(400).json({ success: false, error: 'Missing title' });
@@ -2210,7 +2216,10 @@ async function submitPayment() {
     // ============================================
     router.post('/soul/update', async (req, res) => {
         if (!authenticate(req, res)) return;
-        const { deviceId, name, newName, newDescription, newTemplateId, newAssignedEntities, newIsActive, newCategory } = req.body;
+        const { deviceId, name, newName, newTemplateId, newAssignedEntities, newIsActive } = req.body;
+        // Accept description/category as aliases for newDescription/newCategory (docs-bot compat)
+        const newDescription = req.body.newDescription !== undefined ? req.body.newDescription : req.body.description;
+        const newCategory = req.body.newCategory !== undefined ? req.body.newCategory : req.body.category;
 
         if (!name) {
             return res.status(400).json({ success: false, error: 'Missing name' });
@@ -2239,7 +2248,7 @@ async function submitPayment() {
             }
 
             if (newName) soul.name = newName.trim();
-            if (newDescription !== undefined) soul.description = newDescription.trim();
+            if (newDescription !== undefined) soul.description = (newDescription ?? '').trim();
             if (newTemplateId !== undefined) soul.templateId = newTemplateId;
             if (newAssignedEntities !== undefined) soul.assignedEntities = newAssignedEntities;
             if (newIsActive !== undefined) soul.isActive = newIsActive;

--- a/backend/tests/jest/mission.test.js
+++ b/backend/tests/jest/mission.test.js
@@ -224,6 +224,64 @@ describe('Category support in update endpoints', () => {
         expect([200, 404, 500].includes(res.status)).toBe(true);
     });
 
+    it('note/update handles content:null without throwing', async () => {
+        const res = await post('/api/mission/note/update')
+            .send({ ...auth, title: 'Some Note', content: null });
+        // Must not throw TypeError on null.trim → 500 from undefined handler is the bug we're fixing
+        expect([200, 404, 500].includes(res.status)).toBe(true);
+        if (res.status === 500) expect(res.body.error || '').not.toMatch(/trim/i);
+    });
+
+    it('rule/update accepts description as alias for newDescription', async () => {
+        const res = await post('/api/mission/rule/update')
+            .send({ ...auth, name: 'Some Rule', description: 'Aliased body' });
+        expect([200, 404, 500].includes(res.status)).toBe(true);
+    });
+
+    it('rule/update accepts category as alias for newCategory', async () => {
+        const res = await post('/api/mission/rule/update')
+            .send({ ...auth, name: 'Some Rule', category: 'Aliased' });
+        expect([200, 404, 500].includes(res.status)).toBe(true);
+    });
+
+    it('rule/update handles description:null without throwing', async () => {
+        const res = await post('/api/mission/rule/update')
+            .send({ ...auth, name: 'Some Rule', description: null });
+        expect([200, 404, 500].includes(res.status)).toBe(true);
+        if (res.status === 500) expect(res.body.error || '').not.toMatch(/trim/i);
+    });
+
+    it('skill/update accepts url as alias for newUrl', async () => {
+        const res = await post('/api/mission/skill/update')
+            .send({ ...auth, title: 'Some Skill', url: 'https://aliased.example/x' });
+        expect([200, 404, 500].includes(res.status)).toBe(true);
+    });
+
+    it('skill/update accepts category as alias for newCategory', async () => {
+        const res = await post('/api/mission/skill/update')
+            .send({ ...auth, title: 'Some Skill', category: 'Aliased' });
+        expect([200, 404, 500].includes(res.status)).toBe(true);
+    });
+
+    it('soul/update accepts description as alias for newDescription', async () => {
+        const res = await post('/api/mission/soul/update')
+            .send({ ...auth, name: 'Some Soul', description: 'Aliased body' });
+        expect([200, 404, 500].includes(res.status)).toBe(true);
+    });
+
+    it('soul/update accepts category as alias for newCategory', async () => {
+        const res = await post('/api/mission/soul/update')
+            .send({ ...auth, name: 'Some Soul', category: 'Aliased' });
+        expect([200, 404, 500].includes(res.status)).toBe(true);
+    });
+
+    it('soul/update handles description:null without throwing', async () => {
+        const res = await post('/api/mission/soul/update')
+            .send({ ...auth, name: 'Some Soul', description: null });
+        expect([200, 404, 500].includes(res.status)).toBe(true);
+        if (res.status === 500) expect(res.body.error || '').not.toMatch(/trim/i);
+    });
+
     it('rule/update accepts newCategory field', async () => {
         const res = await post('/api/mission/rule/update')
             .send({ ...auth, name: 'Some Rule', newCategory: 'Workflow' });


### PR DESCRIPTION
## Summary
Follow-up to #1888. Bundles two reviewer-flagged cards into one PR:
- Null-safe trim on update handlers (`content: null` no longer crashes with TypeError)
- DX alias parity: `rule/update`, `skill/update`, `soul/update` now accept the same field names as their `/add` counterparts

## Behavior changes
- `note/update`, `rule/update`, `soul/update` — `newContent`/`newDescription: null` now means "clear the field" (stores `''`) instead of throwing a TypeError.
- `note/update` `newCategory: null` now clears to `null` (consistent with `rule/update`'s existing pattern).
- `rule/update` — accepts `description` / `category` (aliases `newDescription` / `newCategory`).
- `skill/update` — accepts `url` / `category` (aliases `newUrl` / `newCategory`).
- `soul/update` — accepts `description` / `category` (aliases `newDescription` / `newCategory`).
- `newX` fields still take precedence when both a canonical and alias are supplied.

## Closes
- `card_e50862243e5f09fa8c812950` (null.trim hardening)
- `card_de94f3a74b5401d17f7689cd` (sister-endpoint alias mirror)

## Test plan
- [x] `npx jest tests/jest/mission.test.js` → 35/35 passing (9 new tests)
- [ ] Post-deploy: send `POST /note/update` with `content: null` → 200/404, no 500 TypeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)