### PR TITLE
feat(arena): admin endpoint to reset public leaderboard

### DIFF
--- a/backend/interview-arena.js
+++ b/backend/interview-arena.js
@@ -1739,6 +1739,26 @@ module.exports = function arenaFactory({ serverLog, io } = {}) {
             .catch(err => console.error('[Arena] refresh-pool error:', err.message));
     });
 
+    // POST /api/arena/admin/reset-leaderboard — wipe public ranking only.
+    // Destructive + irreversible. Preserves arena_exams / arena_sessions /
+    // arena_feedback / arena_comments so exam history and user feedback
+    // survive. Useful when the scoring rubric changes and old rankings
+    // become incomparable but the raw test data is still worth keeping.
+    router.post('/admin/reset-leaderboard', async (req, res) => {
+        if (!checkAdminAuth(req)) return res.status(403).json({ success: false, error: 'forbidden' });
+        try {
+            const before = await pool.query('SELECT COUNT(*)::int AS n FROM arena_leaderboard');
+            const deletedCount = before.rows[0]?.n ?? 0;
+            await pool.query('TRUNCATE TABLE arena_leaderboard');
+            audit('info', 'arena_admin', `leaderboard reset (${deletedCount} rows removed)`);
+            res.json({ success: true, deletedCount, table: 'arena_leaderboard' });
+        } catch (err) {
+            console.error('[Arena] reset-leaderboard error:', err);
+            audit('error', 'arena_admin', `reset-leaderboard failed: ${err.message}`);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
     // POST /api/arena/admin/self-test — on-demand runtime self-test.
     // The routine bot (or any admin) can call this anytime to verify the
     // full scoring pipeline is healthy: creates a scratch exam, runs every

--- a/backend/tests/jest/interview-arena.test.js
+++ b/backend/tests/jest/interview-arena.test.js
@@ -70,6 +70,15 @@ jest.mock('pg', () => {
             state.leaderboard.push({ name: params[1], score: params[3] });
             return { rows: [], rowCount: 1 };
         }
+        // COUNT leaderboard (used by reset-leaderboard)
+        if (/SELECT COUNT.*FROM arena_leaderboard/i.test(norm)) {
+            return { rows: [{ n: state.leaderboard.length }], rowCount: 1 };
+        }
+        // TRUNCATE leaderboard (reset-leaderboard)
+        if (/TRUNCATE TABLE arena_leaderboard/i.test(norm)) {
+            state.leaderboard.length = 0;
+            return { rows: [], rowCount: 0 };
+        }
         // SELECT leaderboard
         if (/FROM arena_leaderboard/i.test(norm)) {
             return { rows: state.leaderboard, rowCount: state.leaderboard.length };
@@ -355,6 +364,82 @@ describe('interview-arena: API endpoints', () => {
         const res = await request(app).get('/api/arena/leaderboard');
         expect(res.status).toBe(200);
         expect(Array.isArray(res.body.leaderboard)).toBe(true);
+    });
+
+    describe('POST /api/arena/admin/reset-leaderboard', () => {
+        test('rejects request without admin token', async () => {
+            const prev = process.env.ADMIN_SECRET;
+            process.env.ADMIN_SECRET = 'test-admin-secret';
+            try {
+                const res = await request(app).post('/api/arena/admin/reset-leaderboard');
+                expect(res.status).toBe(403);
+                expect(res.body.error).toBe('forbidden');
+            } finally {
+                if (prev === undefined) delete process.env.ADMIN_SECRET;
+                else process.env.ADMIN_SECRET = prev;
+            }
+        });
+
+        test('wipes leaderboard and returns deleted count', async () => {
+            const prev = process.env.ADMIN_SECRET;
+            process.env.ADMIN_SECRET = 'test-admin-secret';
+            try {
+                globalThis.__arenaState.leaderboard.push(
+                    { name: 'Alice', score: 120 },
+                    { name: 'Bob',   score: 95  },
+                    { name: 'Carol', score: 80  },
+                );
+                const res = await request(app)
+                    .post('/api/arena/admin/reset-leaderboard')
+                    .set('x-admin-token', 'test-admin-secret');
+                expect(res.status).toBe(200);
+                expect(res.body.success).toBe(true);
+                expect(res.body.deletedCount).toBe(3);
+                expect(res.body.table).toBe('arena_leaderboard');
+                expect(globalThis.__arenaState.leaderboard).toHaveLength(0);
+            } finally {
+                if (prev === undefined) delete process.env.ADMIN_SECRET;
+                else process.env.ADMIN_SECRET = prev;
+            }
+        });
+
+        test('returns zero deletedCount on already-empty leaderboard', async () => {
+            const prev = process.env.ADMIN_SECRET;
+            process.env.ADMIN_SECRET = 'test-admin-secret';
+            try {
+                const res = await request(app)
+                    .post('/api/arena/admin/reset-leaderboard')
+                    .set('x-admin-token', 'test-admin-secret');
+                expect(res.status).toBe(200);
+                expect(res.body.deletedCount).toBe(0);
+            } finally {
+                if (prev === undefined) delete process.env.ADMIN_SECRET;
+                else process.env.ADMIN_SECRET = prev;
+            }
+        });
+
+        test('does not touch exams/sessions/feedback', async () => {
+            const prev = process.env.ADMIN_SECRET;
+            process.env.ADMIN_SECRET = 'test-admin-secret';
+            try {
+                globalThis.__arenaState.exams.push({ id: 'exam-keep', status: 'completed' });
+                globalThis.__arenaState.sessions.push({ id: 'sess-keep', exam_id: 'exam-keep' });
+                globalThis.__arenaState.feedback.push({ exam_id: 'exam-keep' });
+                globalThis.__arenaState.leaderboard.push({ name: 'X', score: 1 });
+
+                const res = await request(app)
+                    .post('/api/arena/admin/reset-leaderboard')
+                    .set('x-admin-token', 'test-admin-secret');
+                expect(res.status).toBe(200);
+                expect(globalThis.__arenaState.leaderboard).toHaveLength(0);
+                expect(globalThis.__arenaState.exams).toHaveLength(1);
+                expect(globalThis.__arenaState.sessions).toHaveLength(1);
+                expect(globalThis.__arenaState.feedback).toHaveLength(1);
+            } finally {
+                if (prev === undefined) delete process.env.ADMIN_SECRET;
+                else process.env.ADMIN_SECRET = prev;
+            }
+        });
     });
 });
 


### PR DESCRIPTION
## Summary
- New endpoint `POST /api/arena/admin/reset-leaderboard` — TRUNCATEs `arena_leaderboard` only
- Guarded by existing `checkAdminAuth` (x-admin-token header or body.adminToken vs ADMIN_SECRET env, localhost fallback)
- Preserves `arena_exams` / `arena_sessions` / `arena_feedback` / `arena_comments` so exam history and user feedback survive
- Returns `{ success, deletedCount, table }` for ops visibility

## Why
Hank requested "Arena 排行榜重置歸零" and picked Scope 1 (leaderboard only). Use case: scoring rubric changes and old rankings become incomparable, but the raw exam/session data is still worth keeping for analysis.

## Test plan
- [x] 4 Jest tests: 403 without admin token, success wipe with count, empty-table no-op, isolation (exams/sessions/feedback untouched)
- [x] 41/41 arena tests green locally
- [ ] After merge: Hank triggers via `curl -X POST -H "x-admin-token: $ADMIN_SECRET" https://eclawbot.com/api/arena/admin/reset-leaderboard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)