### PR TITLE
fix: arena admin auth reads deviceSecret + timing-safe compare

### DIFF
--- a/backend/interview-arena.js
+++ b/backend/interview-arena.js
@@ -1704,30 +1704,27 @@ module.exports = function arenaFactory({ serverLog, io, devices } = {}) {
     // Path 1 unchanged. Paths 2–3 let ops admin without a separate env —
     // possession of deviceSecret / botSecret is already proof of ownership.
     // When multi-tenant launches, gate 2–3 on a specific ADMIN_DEVICE_ID env.
+    const safeEqual = require('./safe-equal');
+
     function checkAdminAuth(req) {
-        const crypto = require('crypto');
         const body = req.body || {};
 
         // Path 1: ADMIN_SECRET token
         const token    = req.headers['x-admin-token'] || body.adminToken;
         const expected = process.env.ADMIN_SECRET;
-        if (expected && token) {
-            const a = Buffer.from(String(token));
-            const b = Buffer.from(expected);
-            if (a.length === b.length && crypto.timingSafeEqual(a, b)) return true;
-        }
+        if (expected && token && safeEqual(token, expected)) return true;
 
         // Paths 2 / 3: device credentials
         const deviceId = body.deviceId || req.headers['x-device-id'];
         const device   = deviceId && deviceRegistry[deviceId];
         if (device) {
             const deviceSecret = body.deviceSecret || req.headers['x-device-secret'];
-            if (deviceSecret && device.secret && deviceSecret === device.secret) return true;
+            if (safeEqual(deviceSecret, device.deviceSecret)) return true;
 
             const botSecret = body.botSecret || req.headers['x-bot-secret'];
-            const entityId  = body.entityId != null ? parseInt(body.entityId) : NaN;
+            const entityId  = body.entityId != null ? parseInt(body.entityId, 10) : NaN;
             const entity    = Number.isFinite(entityId) && (device.entities || {})[entityId];
-            if (entity && botSecret && entity.botSecret === botSecret) return true;
+            if (entity && safeEqual(botSecret, entity.botSecret)) return true;
         }
 
         // Localhost fallback only when no secret configured at all

--- a/backend/tests/jest/interview-arena.test.js
+++ b/backend/tests/jest/interview-arena.test.js
@@ -327,9 +327,12 @@ describe('interview-arena: API endpoints', () => {
     const request = require('supertest');
     const express = require('express');
     const arenaFactory = require('../../interview-arena');
+    // Shape must match production device registry (index.js getOrCreateDevice):
+    // { deviceId, deviceSecret, entities: { [id]: { botSecret, ... } } }
     const fakeDevices = {
         'dev-alpha': {
-            secret: 'device-secret-alpha',
+            deviceId: 'dev-alpha',
+            deviceSecret: 'device-secret-alpha',
             entities: {
                 2: { botSecret: 'bot-secret-commander' },
                 5: { botSecret: 'bot-secret-helper' },
@@ -502,6 +505,36 @@ describe('interview-arena: API endpoints', () => {
                 expect(globalThis.__arenaState.exams).toHaveLength(1);
                 expect(globalThis.__arenaState.sessions).toHaveLength(1);
                 expect(globalThis.__arenaState.feedback).toHaveLength(1);
+            } finally {
+                if (prev === undefined) delete process.env.ADMIN_SECRET;
+                else process.env.ADMIN_SECRET = prev;
+            }
+        });
+
+        test('rejects empty-string deviceSecret (safeEqual falsy guard)', async () => {
+            const prev = process.env.ADMIN_SECRET;
+            process.env.ADMIN_SECRET = 'unused';
+            try {
+                const res = await request(app)
+                    .post('/api/arena/admin/reset-leaderboard')
+                    .send({ deviceId: 'dev-alpha', deviceSecret: '' });
+                expect(res.status).toBe(403);
+                expect(res.body.error).toBe('forbidden');
+            } finally {
+                if (prev === undefined) delete process.env.ADMIN_SECRET;
+                else process.env.ADMIN_SECRET = prev;
+            }
+        });
+
+        test('rejects localhost when ADMIN_SECRET is configured (no implicit bypass)', async () => {
+            const prev = process.env.ADMIN_SECRET;
+            process.env.ADMIN_SECRET = 'test-admin-secret';
+            try {
+                // supertest defaults to 127.0.0.1, but ADMIN_SECRET is set so
+                // the "no secret configured" localhost fallback must NOT fire.
+                const res = await request(app).post('/api/arena/admin/reset-leaderboard');
+                expect(res.status).toBe(403);
+                expect(res.body.error).toBe('forbidden');
             } finally {
                 if (prev === undefined) delete process.env.ADMIN_SECRET;
                 else process.env.ADMIN_SECRET = prev;


### PR DESCRIPTION
## Summary

Hotfix for PR #1892. The new `POST /api/arena/admin/reset-leaderboard` endpoint had two production bugs that the original test suite missed because the fixture mirrored the code instead of the real registry.

### What was broken
- `checkAdminAuth` read `device.secret`, but the production device registry (`index.js:3630 getOrCreateDevice`) stores the secret under **`device.deviceSecret`**. Result: Path 2 (device-owner auth) always failed in prod.
- `parseInt(entityId)` had no radix.
- Inline `timingSafeEqual` with a buffer-length check ran three times; one of them missed the deviceSecret path's falsy guard.

### What this PR changes
- `backend/interview-arena.js`: route all three comparisons through the existing `safe-equal.js` helper. Read `device.deviceSecret`. Add radix `10` to `parseInt`.
- `backend/tests/jest/interview-arena.test.js`:
  - Fixture rewritten to match prod shape: `{ deviceId, deviceSecret, entities: { [id]: { botSecret } } }`.
  - +2 edge tests:
    - Empty-string deviceSecret rejected (safeEqual falsy regression).
    - Localhost request rejected when `ADMIN_SECRET` is set (no implicit bypass).

## Test plan
- [x] `npx jest tests/jest/interview-arena.test.js` — 47/47 green (was 45, +2 new)
- [ ] Post-merge: `curl` reset-leaderboard with real `deviceId + botSecret + entityId` against prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)