### PR TITLE
test: align publisher-count assertions with 11-platform reality

### DIFF
--- a/backend/tests/jest/monitoring.test.js
+++ b/backend/tests/jest/monitoring.test.js
@@ -443,10 +443,12 @@ describe('GET /api/monitoring/rental-health happy path', () => {
         expect(res.body.db.entityTrash.oldestRowAgeSeconds).toBe(3600);
     });
 
-    it('publishers list contains 12 platforms', async () => {
+    it('publishers list contains 11 platforms (mastodon retired 2026-04-15)', async () => {
         const res = await request(app)
             .get('/api/monitoring/rental-health?key=test-monitoring-key-1234');
-        expect(res.body.publishers.length).toBe(12);
+        expect(res.body.publishers.length).toBe(11);
+        const ids = res.body.publishers.map(p => p.id);
+        expect(ids).not.toContain('mastodon');
         expect(res.body.publishers[0]).toMatchObject({
             id: expect.any(String),
             name: expect.any(String),

--- a/backend/tests/jest/publisher-integration.test.js
+++ b/backend/tests/jest/publisher-integration.test.js
@@ -34,14 +34,16 @@ const post = (path) => request(publisherApp).post(path);
 const del = (path) => request(publisherApp).delete(path);
 
 // ════════════════════════════════════════════════════════════════
-// GET /api/publisher/platforms — list all 12 platforms
+// GET /api/publisher/platforms — list all 11 platforms (mastodon retired 2026-04-15)
 // ════════════════════════════════════════════════════════════════
 describe('GET /api/publisher/platforms', () => {
     it('returns list of all supported platforms', async () => {
         const res = await get('/api/publisher/platforms');
         expect(res.status).toBe(200);
         expect(Array.isArray(res.body.platforms)).toBe(true);
-        expect(res.body.platforms.length).toBeGreaterThanOrEqual(12);
+        expect(res.body.platforms.length).toBeGreaterThanOrEqual(11);
+        const ids = res.body.platforms.map(p => p.id);
+        expect(ids).not.toContain('mastodon');
     });
 
     it('each platform has required fields', async () => {


### PR DESCRIPTION
## Summary

Follow-up to PR #1892 (mastodon retirement). Two test files still asserted 12 platforms and failed on main:
- \`tests/jest/monitoring.test.js:449\`
- \`tests/jest/publisher-integration.test.js:44\`

Both now assert 11 and explicitly \`not.toContain('mastodon')\` so a future implicit re-add won't silently slip through. Full suite: 99/99 suites, 1727/1727 green.

## Test plan
- [x] \`npx jest tests/jest/monitoring.test.js tests/jest/publisher-integration.test.js\` — green
- [x] \`npx jest\` full suite — 99 passed, 0 failed (was 2 failing on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)