### PR TITLE
fix: single source of truth for invite_codes schema

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1944,14 +1944,18 @@ setTimeout(() => trustModule.initTrustDatabase(), 3000);
 // ============================================
 // INVITE / REFERRAL SYSTEM (P5)
 // ============================================
-// invite.js (Phase 5 JWT-based) router removed — conflicts with device-auth
-// invite routes below (line ~3662). Schema init kept for table idempotency.
+// Phase-5 invite.js router is NOT mounted — the live /api/invite/*
+// endpoints are the device-auth legacy ones defined below (~line 3971)
+// against auth_schema.sql's invite_codes(owner_device_id, ...) table.
+// invite.js stays loaded so invite_redemptions (used by growth.js
+// conversion analytics) is created. The conflicting Phase-5
+// `invite_codes` CREATE has been removed from invite_schema.sql —
+// single source of truth is now auth_schema.sql.
 const inviteModule = require('./invite')({
     authMiddleware: authModule.authMiddleware,
     walletModule,
     serverLog,
 });
-// NOTE: router NOT mounted — device-auth routes in index.js handle /api/invite/*
 setTimeout(() => inviteModule.initInviteDatabase(), 3500);
 
 // ============================================

--- a/backend/invite.js
+++ b/backend/invite.js
@@ -1,7 +1,18 @@
 /**
  * Invite / Referral System — Phase 5 Growth Engine
  *
- * Mounted at: /api/invite
+ * Intended mount: /api/invite
+ *
+ * STATUS (2026-04-20): router NOT mounted. The live invite endpoints
+ * under /api/invite/* are the device-auth legacy ones defined in
+ * index.js:~3971 against the auth_schema.sql `invite_codes` table
+ * (owner_device_id / used_by_device_id). This file's user-auth code
+ * targets the Phase-5 shape (owner_user_id / max_uses / expires_at)
+ * and is kept for when the migration actually runs.
+ *
+ * Schema ownership: `invite_codes` → auth_schema.sql (device-based).
+ * `invite_redemptions` → invite_schema.sql (Phase-5 only; read by
+ * growth.js for conversion analytics even while this router is off).
  *
  * - Each user gets one invite code (auto-generated on first request)
  * - Redeemed by new users at signup or via /api/invite/redeem

--- a/backend/invite_schema.sql
+++ b/backend/invite_schema.sql
@@ -5,19 +5,18 @@
 -- ============================================
 -- Invite / Referral Schema (Phase 5)
 -- ============================================
-
-CREATE TABLE IF NOT EXISTS invite_codes (
-    code VARCHAR(8) PRIMARY KEY,
-    owner_user_id UUID NOT NULL,
-    max_uses INTEGER,
-    use_count INTEGER NOT NULL DEFAULT 0,
-    expires_at TIMESTAMP WITH TIME ZONE,
-    created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-    CONSTRAINT fk_invite_owner FOREIGN KEY (owner_user_id)
-        REFERENCES user_accounts(id) ON DELETE CASCADE
-);
-
-CREATE INDEX IF NOT EXISTS idx_invite_owner ON invite_codes(owner_user_id);
+--
+-- NOTE: The `invite_codes` table itself is owned by auth_schema.sql
+-- (device-based: owner_device_id / used_by_device_id / used_at).
+-- The Phase-5 migration to user-based codes is deferred — see
+-- backend/invite.js comment block + index.js:~1947 for the current
+-- "router not mounted" state. When the Phase-5 migration ships,
+-- re-introduce the invite_codes CREATE here (or migrate in place)
+-- and coordinate the cutover with auth_schema.sql.
+--
+-- This file only owns `invite_redemptions`, which is Phase-5-only
+-- and is read by growth.js for conversion analytics even while the
+-- Phase-5 router itself stays disabled.
 
 CREATE TABLE IF NOT EXISTS invite_redemptions (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/backend/tests/jest/invite-schema-conflict.test.js
+++ b/backend/tests/jest/invite-schema-conflict.test.js
@@ -1,0 +1,64 @@
+/**
+ * Regression: invite_codes schema conflict.
+ *
+ * Two files used to CREATE TABLE IF NOT EXISTS invite_codes with
+ * incompatible columns:
+ *   - auth_schema.sql:171 — legacy device-based (owner_device_id, ...)
+ *   - invite_schema.sql:9 — Phase-5 user-based (owner_user_id, ...)
+ * In prod, whichever ran first silently won (CREATE IF NOT EXISTS),
+ * leaving the loser's columns undefined. growth.js went around the
+ * problem via invite_redemptions.
+ *
+ * This test locks in the de-conflict fix: auth_schema.sql is the
+ * sole source of truth for invite_codes; invite_schema.sql only
+ * owns invite_redemptions.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const authSchema = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'auth_schema.sql'),
+    'utf8'
+);
+const inviteSchema = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'invite_schema.sql'),
+    'utf8'
+);
+
+describe('invite_codes schema has a single source of truth', () => {
+    test('auth_schema.sql creates invite_codes (legacy device-based)', () => {
+        expect(authSchema).toMatch(/CREATE TABLE IF NOT EXISTS invite_codes\b/);
+        // Sanity on legacy columns
+        expect(authSchema).toMatch(/owner_device_id\b/);
+        expect(authSchema).toMatch(/used_by_device_id\b/);
+    });
+
+    test('invite_schema.sql does NOT create invite_codes', () => {
+        expect(inviteSchema).not.toMatch(/CREATE TABLE IF NOT EXISTS invite_codes\b/);
+    });
+
+    test('invite_schema.sql does NOT create the Phase-5 idx_invite_owner index', () => {
+        // Was: CREATE INDEX IF NOT EXISTS idx_invite_owner ON invite_codes(owner_user_id)
+        // That index references a column that does not exist in the legacy table.
+        expect(inviteSchema).not.toMatch(/idx_invite_owner\b/);
+    });
+
+    test('invite_schema.sql still owns invite_redemptions (used by growth.js)', () => {
+        expect(inviteSchema).toMatch(/CREATE TABLE IF NOT EXISTS invite_redemptions\b/);
+        expect(inviteSchema).toMatch(/FOREIGN KEY \(code\)\s+REFERENCES invite_codes\(code\)/);
+    });
+
+    test('only one invite_codes CREATE in the whole backend/*.sql tree', () => {
+        const backendDir = path.join(__dirname, '..', '..');
+        const sqlFiles = fs.readdirSync(backendDir).filter(f => f.endsWith('.sql'));
+        const creators = [];
+        for (const f of sqlFiles) {
+            const src = fs.readFileSync(path.join(backendDir, f), 'utf8');
+            if (/CREATE TABLE IF NOT EXISTS invite_codes\b/.test(src)) {
+                creators.push(f);
+            }
+        }
+        expect(creators).toEqual(['auth_schema.sql']);
+    });
+});


### PR DESCRIPTION
## Summary
- `auth_schema.sql:171` and `invite_schema.sql:9` both had `CREATE TABLE IF NOT EXISTS invite_codes` with incompatible shapes (device-based legacy vs Phase-5 user-based). Whichever ran first silently won; in prod, auth init runs first so the legacy shape is what actually exists.
- Phase-5 `invite.js` router has been intentionally unmounted for a while (see comment at `index.js:~1947`), so the Phase-5 schema doesn't need to co-exist. Drop the duplicate `CREATE TABLE` and its `idx_invite_owner` index (which referenced a non-existent column in prod).
- `auth_schema.sql` is now the sole owner of `invite_codes`. `invite_schema.sql` keeps `invite_redemptions` (Phase-5 only, read by `growth.js` for conversion analytics).
- Added regression test `tests/jest/invite-schema-conflict.test.js` that greps every `backend/*.sql` and asserts only `auth_schema.sql` owns the table.

## Why this PR
Extracted from the 4h-nag follow-up card [follow-up] invite_codes schema 衝突清理 + 邀請碼推廣 — the schema half is pure tech debt and I can handle it autonomously. The promotion half still needs Hank's product call and stays on the original card.

## Test plan
- [x] `npx jest tests/jest/invite-schema-conflict` — 5 passing (new)
- [x] `npx jest tests/jest/invite.test.js` — unchanged, still 13 passing (Phase-5 logic unchanged)
- [x] Full jest run on main vs branch — only pre-existing JWT_SECRET env failures, no new regressions from this diff
- [ ] Post-deploy: confirm `/api/invite/my-code` still returns legacy device-based codes

🤖 Generated with [Claude Code](https://claude.com/claude-code)