### PR TITLE
feat(portal): add invite CTA to main nav

### DIFF
--- a/backend/public/portal/shared/nav.js
+++ b/backend/public/portal/shared/nav.js
@@ -12,6 +12,7 @@ function renderNav(activePage) {
         { id: 'mission', i18nKey: 'nav_mission', label: 'Mission', href: 'mission.html', icon: '🚀' },
         { id: 'kanban', i18nKey: 'nav_kanban', label: 'Kanban', href: 'kanban.html', icon: '📋' },
         { id: 'card-holder', i18nKey: 'nav_card_holder', label: 'Cards', href: 'card-holder.html', icon: '🗂️' },
+        { id: 'invite', i18nKey: 'nav_invite', label: 'Invite Friends', href: 'invite.html', icon: '🎁' },
         { id: 'community', i18nKey: 'nav_community', label: 'Community', href: 'community.html', icon: '🏪' },
         { id: 'settings', i18nKey: 'nav_settings', label: 'Settings', href: 'settings.html', icon: '⚙️' },
         { id: 'info', i18nKey: 'nav_info', label: 'Info', href: 'info.html', icon: '📖' }


### PR DESCRIPTION
## Summary
- Surfaces invite/referral at the top-level nav (between Cards and Community)
- Uses existing `nav_invite` i18n key (en/zh-TW/ar native, others English fallback)
- One-line change to `backend/public/portal/shared/nav.js`

## Why
Promo card `card_492dfafb9303078c589d0516` UX audit (2026-04-20) found:
- Invite was only reachable via Settings mid-page card or direct `/invite.html` link
- Result: 4 codes issued, 0 redeemed — pure visibility problem
- No main-nav entry, no onboarding, no dashboard CTA

This PR addresses the **lowest-risk third** of the remediation plan (nav visibility). Companion cards `card_e2e71c8f0eda85732752aee6` (toast + banner onboarding) and `card_50cf10c0e012ad593cb98b19` (tier milestones) will follow.

## Risk
- 🟢 Pure UI — no DB, no API, no state change
- Icon 🎁 keeps it visually distinct from neighbors (🗂️ Cards, 🏪 Community)
- Iframe/embed rendering already short-circuited by existing `embed=1` + `window.self !== window.top` guards

## Test plan
- [x] Desktop: nav shows 🎁 Invite Friends between Cards and Community
- [x] Mobile: hamburger menu includes the entry
- [x] Click routes to `/invite.html`
- [x] i18n: en/zh-TW render native; others use English fallback (acceptable — key exists, no crash)
- [ ] Production smoke after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)