### PR TITLE
fix(wallet): mark zombie topup_orders 'failed' on first ack_sweep encounter

### DIFF
--- a/backend/ack-retry-sweep.js
+++ b/backend/ack-retry-sweep.js
@@ -101,11 +101,27 @@ async function runAckRetrySweep({
         const pkg = raw.packageName || packageName;
 
         // Rows created before this feature shipped won't have packageName /
-        // purchaseToken in external_raw. We can't retry those — flag as
-        // skipped so ops knows to ignore them (or backfill manually).
+        // purchaseToken in external_raw. We can't retry those (the token was
+        // never captured so Google can't be re-contacted) — mark 'failed'
+        // terminally in one shot. Otherwise the sweep scans them every cron
+        // tick and emits the same audit warn for up to REFUND_WINDOW_MS,
+        // flooding logs on a zombie row no action can save.
         if (!productId || !purchaseToken || !pkg) {
             stats.skipped += 1;
-            audit('warn', 'wallet', `ack_sweep skipped order=${row.id} — missing ack fields in external_raw`, {
+            try {
+                await pool.query(
+                    `UPDATE topup_orders
+                     SET ack_attempts = ack_attempts + 1,
+                         ack_state = CASE WHEN $2::boolean THEN 'failed' ELSE ack_state END
+                     WHERE id = $1 AND ack_state <> 'acked'`,
+                    [row.id, true]
+                );
+            } catch (err) {
+                audit('error', 'wallet', `ack_sweep zombie-fail update failed order=${row.id}: ${err.message}`, {
+                    action: 'ack_sweep', resource: row.id, result: 'state_update_failed',
+                });
+            }
+            audit('warn', 'wallet', `ack_sweep skipped order=${row.id} — missing ack fields in external_raw (marked failed, terminal)`, {
                 action: 'ack_sweep', resource: row.id, result: 'missing_fields',
                 metadata: {
                     hasProductId: !!productId,

--- a/backend/tests/jest/wallet-ack-retry-sweep.test.js
+++ b/backend/tests/jest/wallet-ack-retry-sweep.test.js
@@ -277,7 +277,13 @@ describe('ack-retry-sweep: runAckRetrySweep', () => {
         expect(orders[1].ack_state).toBe('acked');
     });
 
-    test('case 6: row missing purchaseToken in external_raw → skipped audit, ack never called', async () => {
+    test('case 6: zombie row (missing purchaseToken) → marked failed terminally, ack never called', async () => {
+        // Pre-migration zombie rows have external_raw without the purchaseToken
+        // that acknowledgeGooglePurchase needs. No retry can recover them, so
+        // the sweep must mark them 'failed' on the first encounter — otherwise
+        // the scan filter keeps re-picking them and emits a missing_fields
+        // warn every cron tick for up to 72h (see production incident
+        // 2026-04-20 where 2 orders looped 40+ retries before this fix).
         const orders = [makeOrder({
             id: 'o6',
             external_raw: { productId: 'ec.topup.starter' /* no purchaseToken, no packageName */ },
@@ -294,13 +300,45 @@ describe('ack-retry-sweep: runAckRetrySweep', () => {
 
         expect(stats).toMatchObject({ scanned: 1, skipped: 1, acked: 0 });
         expect(ackMock).not.toHaveBeenCalled();
-        expect(orders[0].ack_state).toBe('pending');
-        expect(orders[0].ack_attempts).toBe(0);
+        expect(orders[0].ack_state).toBe('failed');
+        expect(orders[0].ack_attempts).toBe(1);
 
         const skippedWarn = audit.entries.find(
             e => e.level === 'warn' && e.meta && e.meta.result === 'missing_fields'
         );
         expect(skippedWarn).toBeDefined();
+        expect(skippedWarn.msg).toMatch(/marked failed/);
+    });
+
+    test('case 6b: zombie row on second pass → not re-scanned (filter excludes failed)', async () => {
+        // Regression guard: after case 6 marks the zombie 'failed', the next
+        // sweep pass must NOT see it again (the SELECT already filters out
+        // ack_state = 'failed'). This lets the noise die for good.
+        const orders = [makeOrder({
+            id: 'o6b',
+            external_raw: { productId: 'ec.topup.starter' },
+        })];
+        const pool = makePool(orders);
+        const audit = makeAudit();
+        const ackMock = jest.fn().mockResolvedValue({ ok: true });
+
+        // First pass — marks it failed.
+        await runAckRetrySweep({
+            pool, audit,
+            acknowledgeGooglePurchase: ackMock,
+            packageName: DEFAULT_PKG,
+        });
+        expect(orders[0].ack_state).toBe('failed');
+
+        // Second pass — the filter should skip it entirely.
+        audit.entries.length = 0;
+        const stats2 = await runAckRetrySweep({
+            pool, audit,
+            acknowledgeGooglePurchase: ackMock,
+            packageName: DEFAULT_PKG,
+        });
+        expect(stats2).toMatchObject({ scanned: 0, skipped: 0 });
+        expect(audit.entries.filter(e => e.meta && e.meta.result === 'missing_fields')).toHaveLength(0);
     });
 
     test('case 7: ack throws (not rejects) → treated as failure, attempts bumped', async () => {


### PR DESCRIPTION
## Summary
- Pre-migration topup_orders (`external_raw` lacks `purchaseToken`) were looping in `ack-retry-sweep` forever. The SELECT kept re-picking them because the skip path didn't bump attempts or flip state.
- Patch the zombie-row path to mark `ack_state='failed'` in one shot. Scan filter (`ack_state <> 'failed'`) already excludes terminal rows, so the warn dies after one pass.
- Prod evidence (self-checked via `/api/logs?category=wallet`): orders `78099672…` + `77bea98b…` accumulated 40+ `missing ack fields` warns between 05:15 and 11:19 UTC today.

## Test plan
- [x] `npx jest tests/jest/wallet-ack-retry-sweep.test.js` — 14/14 pass including updated case 6 + new 6b (second-pass filter guard)
- [ ] After merge + Railway deploy: confirm `/api/logs?category=wallet` no longer emits `ack_sweep skipped` for the two known zombie orders (next hourly tick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)