### PR TITLE
fix(publisher): allow browser navigation on OAuth start/callback routes

### DIFF
--- a/backend/article-publisher.js
+++ b/backend/article-publisher.js
@@ -37,6 +37,14 @@ const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: 15 
 function requirePublisherAuth(req, res, next) {
     // GET /platforms is always public (read-only discovery)
     if (req.method === 'GET' && req.path === '/platforms') return next();
+    // OAuth start/callback routes are browser-navigated redirects — the
+    // browser cannot attach custom headers when the user hits the URL or
+    // when the provider (Google/WordPress.com) bounces back to /callback.
+    // These routes have their own `state` anti-CSRF token, so they're
+    // designed to be public. Without this bypass, the WordPress renew
+    // flow (surfaced in /wordpress/oauth/status → renewUrl) 401s when the
+    // user clicks it.
+    if (req.method === 'GET' && /^\/[a-z]+\/oauth\/(start|callback)$/.test(req.path)) return next();
     // Read at request time so env changes take effect without restart
     const apiKey = process.env.PUBLISHER_API_KEY;
     // If PUBLISHER_API_KEY not set, skip auth (backward-compatible)

--- a/backend/tests/jest/publisher.test.js
+++ b/backend/tests/jest/publisher.test.js
@@ -213,6 +213,39 @@ describe('Publisher API auth (X-Publisher-Key)', () => {
         expect(res.status).toBe(200);
         expect(res.body.success).toBe(true);
     });
+
+    it('GET /*/oauth/start is public even when PUBLISHER_API_KEY is set (browser navigation)', async () => {
+        // Regression guard: browsers can't attach X-Publisher-Key when
+        // navigating to an OAuth-start redirect, so these routes must
+        // bypass the key gate (they have their own `state` CSRF token).
+        // Before the bypass, clicking the renew URL from
+        // /wordpress/oauth/status would 401 with "Invalid or missing
+        // X-Publisher-Key header".
+        process.env.PUBLISHER_API_KEY = 'test-secret-key';
+        // WordPress OAuth start — 501 when client creds unset (expected in
+        // test env), but crucially NOT 401.
+        const wp = await request(app).get('/api/publisher/wordpress/oauth/start');
+        expect(wp.status).not.toBe(401);
+        // Blogger OAuth start — same shape.
+        const bl = await request(app).get('/api/publisher/blogger/oauth/start');
+        expect(bl.status).not.toBe(401);
+    });
+
+    it('GET /*/oauth/callback is public (provider bounces the user back to us)', async () => {
+        process.env.PUBLISHER_API_KEY = 'test-secret-key';
+        // No `code` → 400, not 401 (auth middleware must let it through).
+        const res = await request(app).get('/api/publisher/wordpress/oauth/callback');
+        expect(res.status).not.toBe(401);
+    });
+
+    it('still gates non-OAuth GETs under the publisher key', async () => {
+        // Regression guard: the bypass regex is scoped to /*/oauth/(start|callback)
+        // — other publisher GETs (e.g. /wordpress/oauth/status, /blogger/status)
+        // must still require the key when one is set.
+        process.env.PUBLISHER_API_KEY = 'test-secret-key';
+        const res = await request(app).get('/api/publisher/wordpress/oauth/status');
+        expect(res.status).toBe(401);
+    });
 });
 
 // ════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- `requirePublisherAuth` rejected every publisher GET except `/platforms`, so browser-navigated OAuth start/callback URLs 401'd with `Invalid or missing X-Publisher-Key header`.
- Whitelist `GET /*/oauth/(start|callback)` — these are by-design public (provider redirects back to `/callback`; user types `/start` in the URL bar). Each flow already has its own `state` CSRF token.
- `/oauth/status` and the POST `/publish` routes still require the key.

## Test plan
- [x] `npx jest tests/jest/publisher.test.js -t 'Publisher API auth'` — 8/8 pass (3 new regression guards for OAuth start/callback public + status-still-gated)
- [ ] After merge + Railway deploy: hit `https://eclawbot.com/api/publisher/wordpress/oauth/start` from a fresh browser tab; expect a redirect to `public-api.wordpress.com/oauth2/authorize`, not a 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)