### PR TITLE
feat(publisher): retire wordpress from public surface

### DIFF
--- a/backend/article-publisher.js
+++ b/backend/article-publisher.js
@@ -122,7 +122,7 @@ const MASTODON_INSTANCE_URL = process.env.MASTODON_INSTANCE_URL || 'https://mast
 // ============================================
 const publishRateLimits = {
     qiita: { maxPerDay: 2, label: 'Qiita' },
-    wordpress: { maxPerDay: 4, label: 'WordPress' },  // 2 sites × 2 posts
+    // wordpress removed 2026-04-20 — platform retired
 };
 const publishCounters = new Map(); // key: "platform:YYYY-MM-DD" -> count
 
@@ -1987,12 +1987,10 @@ function getPlatformsStatus() {
           configured: !!(process.env.X_CONSUMER_KEY && process.env.X_ACCESS_TOKEN) },
         { id: 'devto', name: 'DEV.to', region: 'global', authType: 'api_key', contentFormat: 'markdown',
           configured: !!DEVTO_API_KEY },
-        { id: 'wordpress', name: 'WordPress', region: 'global',
-          authType: WP_USE_APP_PASSWORD ? 'basic' : 'bearer',
-          authMode: WP_USE_APP_PASSWORD ? 'app_password' : (wordpressTokens.has('default') ? 'oauth2_db' : 'oauth2'),
-          contentFormat: 'html',
-          configured: WP_USE_APP_PASSWORD || !!getWordpressToken().token,
-          ...wpExpiryWarning(), ...rateLimitInfo('wordpress') },
+        // WordPress retired 2026-04-20 — owner's wp.com site was suspended
+        // (0 sites accessible). Routes + wordpress_tokens table kept so a
+        // future restore is a one-PR change; retire from the public surface
+        // only (platforms list / dashboard / health probes).
         { id: 'telegraph', name: 'Telegraph', region: 'global', authType: 'auto', contentFormat: 'html',
           configured: true },
         { id: 'qiita', name: 'Qiita', region: 'ja', authType: 'bearer', contentFormat: 'markdown',
@@ -2059,48 +2057,7 @@ router.get('/health', async (req, res) => {
             const d = await r.json();
             return { user: d.username };
         }),
-        // WordPress
-        probe('wordpress', 'WordPress', async () => {
-            if (WP_USE_APP_PASSWORD) {
-                const credentials = Buffer.from(`${WORDPRESS_USERNAME}:${WORDPRESS_APP_PASSWORD}`).toString('base64');
-                const r = await fetch(`${WORDPRESS_SITE_URL}/wp-json/wp/v2/users/me`, {
-                    headers: { Authorization: `Basic ${credentials}` }
-                });
-                if (!r.ok) throw Object.assign(new Error(`HTTP ${r.status}`), { status: r.status });
-                return { authMode: 'app_password' };
-            }
-            const wp = getWordpressToken();
-            if (!wp.token) return { skip: true, reason: wp.expired ? 'OAuth token expired' : 'Not configured' };
-            // Test read endpoint
-            const r = await fetch(`${WORDPRESS_API_BASE}/rest/v1.1/me`, {
-                headers: { Authorization: `Bearer ${wp.token}` }
-            });
-            if (!r.ok) throw Object.assign(new Error(`HTTP ${r.status}`), { status: r.status });
-            // Test write endpoint
-            const wr = await fetch(`${WORDPRESS_API_BASE}/rest/v1.1/sites/253401752/posts/new`, {
-                method: 'POST',
-                headers: { Authorization: `Bearer ${wp.token}`, 'Content-Type': 'application/json' },
-                body: JSON.stringify({ title: '__health_check__', content: 'test', status: 'draft' })
-            });
-            if (!wr.ok) {
-                const wd = await wr.json().catch(() => ({}));
-                const msg = wd.message || wd.error || `HTTP ${wr.status}`;
-                if (msg.includes('disabled')) {
-                    return { authMode: 'oauth2', readOk: true, writeOk: false,
-                        issue: 'WordPress.com has disabled the posts API for this site — free plan limitation. Upgrade to a paid plan or use self-hosted WordPress with Application Password auth.',
-                        fix: 'Set WORDPRESS_SITE_URL + WORDPRESS_USERNAME + WORDPRESS_APP_PASSWORD env vars to use a self-hosted WordPress instead.' };
-                }
-                throw Object.assign(new Error(msg), { status: wr.status });
-            }
-            // If draft was created, delete it
-            const wd = await wr.json();
-            if (wd.ID) {
-                await fetch(`${WORDPRESS_API_BASE}/rest/v1.1/sites/253401752/posts/${wd.ID}/delete`, {
-                    method: 'POST', headers: { Authorization: `Bearer ${wp.token}` }
-                }).catch(() => {});
-            }
-            return { authMode: 'oauth2', readOk: true, writeOk: true };
-        }),
+        // WordPress probe removed 2026-04-20 — platform retired.
         // Qiita
         probe('qiita', 'Qiita', async () => {
             if (!QIITA_ACCESS_TOKEN) return { skip: true, reason: 'QIITA_ACCESS_TOKEN not set' };

--- a/backend/index.js
+++ b/backend/index.js
@@ -4208,11 +4208,6 @@ function classifyPublisher(p) {
         if (p.expiresAt && Number(p.expiresAt) < Date.now()) return 'disconnected';
         return 'connected';
     }
-    // WordPress: if CLIENT_ID+SECRET set but no token, OAuth flow is pending
-    // — treat as disconnected (admin needs to finish auth).
-    if (p.id === 'wordpress' && process.env.WORDPRESS_CLIENT_ID && process.env.WORDPRESS_CLIENT_SECRET) {
-        return 'disconnected';
-    }
     return 'unconfigured';
 }
 

--- a/backend/public/portal/publisher.html
+++ b/backend/public/portal/publisher.html
@@ -431,24 +431,6 @@
                 }),
                 path: '/api/publisher/blogger/publish'
             },
-            wordpress: {
-                fields: [
-                    { key: 'title', type: 'text', label: 'Title', required: true },
-                    { key: 'content', type: 'textarea', label: 'HTML content', required: true, tall: true },
-                    { key: 'tags', type: 'text', label: 'Tags (comma-separated)' },
-                    { key: 'categories', type: 'text', label: 'Categories (comma-separated)' },
-                    { key: 'siteId', type: 'text', label: 'Site ID (required for WordPress.com OAuth2; leave empty if using Application Password)',
-                        hint: 'For OAuth2 mode backend returns 400 without siteId. App-Password mode ignores this field.' }
-                ],
-                toBody: s => ({
-                    title: s.title,
-                    content: s.content,
-                    tags: splitTags(s.tags),
-                    categories: splitTags(s.categories),
-                    siteId: s.siteId || undefined
-                }),
-                path: '/api/publisher/wordpress/publish'
-            },
             tumblr: {
                 fields: [
                     { key: 'blogName', type: 'text', label: 'Blog name (slug, e.g. your-blog)', required: true },

--- a/backend/tests/jest/monitoring.test.js
+++ b/backend/tests/jest/monitoring.test.js
@@ -284,31 +284,9 @@ describe('classifyPublisher (threshold math)', () => {
         expect(classify({ id: 'reddit', configured: false })).toBe('unconfigured');
     });
 
-    it('wordpress unconfigured but CLIENT_ID+SECRET set → disconnected (pending OAuth)', () => {
-        const prev = [process.env.WORDPRESS_CLIENT_ID, process.env.WORDPRESS_CLIENT_SECRET];
-        process.env.WORDPRESS_CLIENT_ID = 'x';
-        process.env.WORDPRESS_CLIENT_SECRET = 'y';
-        try {
-            expect(classify({ id: 'wordpress', configured: false })).toBe('disconnected');
-        } finally {
-            process.env.WORDPRESS_CLIENT_ID = prev[0] || '';
-            process.env.WORDPRESS_CLIENT_SECRET = prev[1] || '';
-            if (!prev[0]) delete process.env.WORDPRESS_CLIENT_ID;
-            if (!prev[1]) delete process.env.WORDPRESS_CLIENT_SECRET;
-        }
-    });
-
-    it('wordpress unconfigured + no CLIENT_ID → unconfigured', () => {
-        const prev = [process.env.WORDPRESS_CLIENT_ID, process.env.WORDPRESS_CLIENT_SECRET];
-        delete process.env.WORDPRESS_CLIENT_ID;
-        delete process.env.WORDPRESS_CLIENT_SECRET;
-        try {
-            expect(classify({ id: 'wordpress', configured: false })).toBe('unconfigured');
-        } finally {
-            if (prev[0]) process.env.WORDPRESS_CLIENT_ID = prev[0];
-            if (prev[1]) process.env.WORDPRESS_CLIENT_SECRET = prev[1];
-        }
-    });
+    // WordPress-specific classify branches removed 2026-04-20 along with
+    // the platform itself. Special-case `classifyPublisher` no longer has a
+    // wordpress branch; generic configured/unconfigured rules above cover it.
 });
 
 describe('GET /api/monitoring/rental-health threshold math (status)', () => {
@@ -316,21 +294,21 @@ describe('GET /api/monitoring/rental-health threshold math (status)', () => {
     const fetchHealth = () => request(app).get('/api/monitoring/rental-health?key=test-monitoring-key-1234');
 
     it('1 disconnected → yellow (was red, intentionally de-escalated)', async () => {
-        // Simulate by forcing WP disconnected via CLIENT_ID env (and no token).
-        const prev = [process.env.WORDPRESS_CLIENT_ID, process.env.WORDPRESS_CLIENT_SECRET];
-        process.env.WORDPRESS_CLIENT_ID = 'x';
-        process.env.WORDPRESS_CLIENT_SECRET = 'y';
+        // Mock one disconnected platform via getPlatformsStatus (matches the
+        // pattern used by the 2-/3-disconnected tests below).
+        const articlePublisher = require('../../article-publisher');
+        const origFn = articlePublisher.getPlatformsStatus;
+        articlePublisher.getPlatformsStatus = () => ([
+            { id: 'blogger', name: 'Blogger', region: 'global', configured: true, error: 'token expired' },
+            { id: 'telegraph', name: 'Telegraph', region: 'global', configured: true },
+        ]);
         try {
             const res = await fetchHealth();
             expect(res.status).toBe(200);
-            // WP is disconnected; all others unconfigured. DB is up. Status should be yellow.
-            expect(res.body.thresholds.publisherCounts.disconnected).toBeGreaterThanOrEqual(1);
+            expect(res.body.thresholds.publisherCounts.disconnected).toBe(1);
             expect(res.body.thresholds.status).toBe('yellow');
         } finally {
-            process.env.WORDPRESS_CLIENT_ID = prev[0] || '';
-            process.env.WORDPRESS_CLIENT_SECRET = prev[1] || '';
-            if (!prev[0]) delete process.env.WORDPRESS_CLIENT_ID;
-            if (!prev[1]) delete process.env.WORDPRESS_CLIENT_SECRET;
+            articlePublisher.getPlatformsStatus = origFn;
         }
     });
 
@@ -443,12 +421,13 @@ describe('GET /api/monitoring/rental-health happy path', () => {
         expect(res.body.db.entityTrash.oldestRowAgeSeconds).toBe(3600);
     });
 
-    it('publishers list contains 11 platforms (mastodon retired 2026-04-15)', async () => {
+    it('publishers list contains 10 platforms (mastodon retired 2026-04-15, wordpress retired 2026-04-20)', async () => {
         const res = await request(app)
             .get('/api/monitoring/rental-health?key=test-monitoring-key-1234');
-        expect(res.body.publishers.length).toBe(11);
+        expect(res.body.publishers.length).toBe(10);
         const ids = res.body.publishers.map(p => p.id);
         expect(ids).not.toContain('mastodon');
+        expect(ids).not.toContain('wordpress');
         expect(res.body.publishers[0]).toMatchObject({
             id: expect.any(String),
             name: expect.any(String),

--- a/backend/tests/jest/publisher-integration.test.js
+++ b/backend/tests/jest/publisher-integration.test.js
@@ -34,16 +34,18 @@ const post = (path) => request(publisherApp).post(path);
 const del = (path) => request(publisherApp).delete(path);
 
 // ════════════════════════════════════════════════════════════════
-// GET /api/publisher/platforms — list all 11 platforms (mastodon retired 2026-04-15)
+// GET /api/publisher/platforms — post-retirement list (10 platforms;
+// mastodon retired 2026-04-15, wordpress retired 2026-04-20)
 // ════════════════════════════════════════════════════════════════
 describe('GET /api/publisher/platforms', () => {
     it('returns list of all supported platforms', async () => {
         const res = await get('/api/publisher/platforms');
         expect(res.status).toBe(200);
         expect(Array.isArray(res.body.platforms)).toBe(true);
-        expect(res.body.platforms.length).toBeGreaterThanOrEqual(11);
+        expect(res.body.platforms.length).toBeGreaterThanOrEqual(10);
         const ids = res.body.platforms.map(p => p.id);
         expect(ids).not.toContain('mastodon');
+        expect(ids).not.toContain('wordpress');
     });
 
     it('each platform has required fields', async () => {

--- a/backend/tests/jest/publisher.test.js
+++ b/backend/tests/jest/publisher.test.js
@@ -252,23 +252,25 @@ describe('Publisher API auth (X-Publisher-Key)', () => {
 // GET /api/publisher/platforms
 // ════════════════════════════════════════════════════════════════
 describe('GET /api/publisher/platforms', () => {
-    it('returns 200 with all 8 platforms', async () => {
+    it('returns 200 with the post-retirement platform list (10, excl. mastodon + wordpress)', async () => {
         const res = await request(app).get('/api/publisher/platforms');
         expect(res.status).toBe(200);
         expect(res.body.success).toBe(true);
-        expect(res.body.platforms).toHaveLength(11);
+        expect(res.body.platforms).toHaveLength(10);
     });
 
     it('includes all expected platform IDs', async () => {
         const res = await request(app).get('/api/publisher/platforms');
         const ids = res.body.platforms.map(p => p.id);
         expect(ids).toEqual(expect.arrayContaining([
-            'blogger', 'hashnode', 'x', 'devto', 'wordpress', 'telegraph', 'qiita', 'wechat',
+            'blogger', 'hashnode', 'x', 'devto', 'telegraph', 'qiita', 'wechat',
             'tumblr', 'reddit', 'linkedin'
         ]));
-        // mastodon retired 2026-04-20; routes still exist for token recovery
-        // but platform is no longer in the public list.
+        // mastodon retired 2026-04-15; wordpress retired 2026-04-20 (owner's
+        // wp.com site suspended). Routes still exist for token recovery but
+        // platforms are no longer in the public list.
         expect(ids).not.toContain('mastodon');
+        expect(ids).not.toContain('wordpress');
     });
 
     it('each platform has required fields', async () => {


### PR DESCRIPTION
## Summary

- Retires WordPress from the publisher public surface because the owner's wp.com account has a suspended site — reauth succeeded but `/me/sites` returns 0, so publishing is unusable until the support dispute resolves.
- Mirrors the mastodon retirement pattern (#1892 + #1895): remove from `getPlatformsStatus`, `/api/publisher/health` probe, rate limit registry, `publisher.html` dashboard tile, and the `classifyPublisher` wordpress branch in `index.js`.
- Keeps `/api/publisher/wordpress/oauth/*`, `/api/publisher/wordpress/publish`, and the `wordpress_tokens` table intact so a restore is a one-PR revert once wp.com unsuspends.

## What breaks user-visible (intended)

- `/api/publisher/platforms` no longer includes `wordpress` (11 → 10 platforms)
- `/api/monitoring/rental-health` no longer lists wordpress among publishers; no more `publisher_disconnected:wordpress` yellow alerts
- Portal publisher dashboard tile gone
- `/api/publisher/health` probe no longer runs the wp check

## Test plan

- [x] `jest publisher.test.js` — 21/21 green (count updated to 10, retired id guard added)
- [x] `jest publisher-integration.test.js` — list-of-platforms test updated
- [x] `jest monitoring.test.js` — publishers-list count 11→10, 1-disconnected test rewritten to use the `getPlatformsStatus` mock pattern (existing wordpress-classify tests deleted alongside the removed classify branch)
- [x] Full suite: 73/73 on affected files. Full run prior to changes showed 1740/1743 with the same 3 wordpress-assumption failures now resolved.
- [ ] Post-merge: curl `/api/publisher/platforms` and `/api/monitoring/rental-health` to confirm wordpress absence on prod
- [ ] Rental-health next cron should stay green (no chronic yellow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)