### PR TITLE
fix(topup): wire up WebView JS bridge + wallet tier click handler

### DIFF
--- a/app/src/main/java/com/hank/clawlive/WebViewActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/WebViewActivity.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.graphics.Color
 import android.net.Uri
 import android.os.Bundle
+import android.webkit.JavascriptInterface
 import android.webkit.WebChromeClient
 import android.webkit.WebResourceRequest
 import android.webkit.WebView
@@ -17,6 +18,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
+import com.hank.clawlive.billing.BillingManager
 import com.hank.clawlive.data.local.DeviceManager
 import com.hank.clawlive.data.remote.TelemetryHelper
 import com.hank.clawlive.ui.BottomNavHelper
@@ -29,6 +31,9 @@ import timber.log.Timber
  *
  * Launch via [WebViewActivity.launch] with a URL and title.
  * Credentials are injected via query params and localStorage.
+ *
+ * Exposes `window.AndroidBridge.launchTopupPurchase(productId)` so wallet.html
+ * can hand a tier tap back to the native Play Billing flow.
  */
 class WebViewActivity : AppCompatActivity() {
 
@@ -36,6 +41,7 @@ class WebViewActivity : AppCompatActivity() {
         const val EXTRA_URL = "extra_url"
         const val EXTRA_TITLE = "extra_title"
         const val EXTRA_NAV_ITEM = "extra_nav_item"
+        private const val BRIDGE_NAME = "AndroidBridge"
 
         fun launch(context: Context, url: String, title: String, navItem: NavItem = NavItem.SETTINGS) {
             context.startActivity(Intent(context, WebViewActivity::class.java).apply {
@@ -47,6 +53,7 @@ class WebViewActivity : AppCompatActivity() {
     }
 
     private val deviceManager: DeviceManager by lazy { DeviceManager.getInstance(this) }
+    private lateinit var billingManager: BillingManager
     private var webView: WebView? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -64,6 +71,14 @@ class WebViewActivity : AppCompatActivity() {
         findViewById<TextView>(R.id.tvWebviewTitle).text = title
         findViewById<ImageView>(R.id.btnWebviewBack).setOnClickListener { onBackPressedCompat() }
 
+        billingManager = BillingManager.getInstance(this)
+        billingManager.onTopupComplete = { productId, success ->
+            // Hand result back to wallet.html if it wired up a listener.
+            val js = "window.onTopupComplete && window.onTopupComplete(" +
+                "\"${productId.replace("\"", "\\\"")}\", $success);"
+            webView?.evaluateJavascript(js, null)
+        }
+
         setupWebView()
     }
 
@@ -72,6 +87,7 @@ class WebViewActivity : AppCompatActivity() {
         val title = intent.getStringExtra(EXTRA_TITLE) ?: "webview"
         TelemetryHelper.trackPageView(this, title.lowercase().replace(" ", "_"))
         RecordingIndicatorHelper.attach(this)
+        billingManager.refreshState()
     }
 
     override fun onPause() {
@@ -95,6 +111,8 @@ class WebViewActivity : AppCompatActivity() {
             settings.loadWithOverviewMode = false
             settings.useWideViewPort = false
             settings.userAgentString = settings.userAgentString + " EClawAndroid"
+
+            addJavascriptInterface(WebViewBridge(), BRIDGE_NAME)
 
             webViewClient = object : WebViewClient() {
                 override fun shouldOverrideUrlLoading(
@@ -172,8 +190,25 @@ class WebViewActivity : AppCompatActivity() {
     }
 
     override fun onDestroy() {
+        if (::billingManager.isInitialized) {
+            billingManager.onTopupComplete = null
+        }
         webView?.destroy()
         webView = null
         super.onDestroy()
+    }
+
+    /**
+     * JavaScript bridge exposed as `window.AndroidBridge`. Scope is intentionally
+     * narrow — only methods the portal pages hosted here need for native escape.
+     */
+    private inner class WebViewBridge {
+        @JavascriptInterface
+        fun launchTopupPurchase(productId: String) {
+            Timber.d("[WebView] launchTopupPurchase productId=$productId")
+            runOnUiThread {
+                billingManager.launchTopupPurchaseFlow(this@WebViewActivity, productId)
+            }
+        }
     }
 }

--- a/backend/public/portal/wallet.html
+++ b/backend/public/portal/wallet.html
@@ -86,7 +86,26 @@
             padding: 14px;
             background: var(--input-bg);
             position: relative;
+            cursor: pointer;
+            transition: border-color 0.15s, transform 0.1s;
         }
+        .tier-card:hover { border-color: var(--accent, #6366f1); }
+        .tier-card:active { transform: scale(0.97); }
+        .tier-card.is-pending { opacity: 0.6; pointer-events: none; }
+        .topup-toast {
+            position: fixed;
+            left: 50%;
+            bottom: 80px;
+            transform: translateX(-50%);
+            background: rgba(20, 20, 30, 0.92);
+            color: #fff;
+            padding: 10px 18px;
+            border-radius: 8px;
+            font-size: 14px;
+            z-index: 9999;
+            box-shadow: 0 2px 12px rgba(0,0,0,0.35);
+        }
+        .topup-toast.is-error { background: #b91c1c; }
         .tier-twd {
             font-size: 18px;
             font-weight: 700;
@@ -275,11 +294,58 @@
                         ${bonusLine}
                     `;
                     card.title = titleHint;
+                    card.dataset.productId = t.productId;
+                    card.addEventListener('click', () => tapTier(card, t.productId));
                     grid.appendChild(card);
                 }
             } catch (err) {
                 console.error('[wallet] tiers load failed', err);
             }
+        }
+
+        let pendingTierCard = null;
+
+        function tapTier(card, productId) {
+            if (pendingTierCard) return;
+            const bridge = window.AndroidBridge;
+            if (!bridge || typeof bridge.launchTopupPurchase !== 'function') {
+                showTopupToast(tt('wallet_topup_via_app', 'Please top up via the Android app'), true);
+                return;
+            }
+            pendingTierCard = card;
+            card.classList.add('is-pending');
+            try {
+                bridge.launchTopupPurchase(productId);
+            } catch (err) {
+                console.error('[wallet] launchTopupPurchase failed', err);
+                card.classList.remove('is-pending');
+                pendingTierCard = null;
+                showTopupToast(tt('wallet_topup_failed', 'Top-up failed. Please try again.'), true);
+            }
+        }
+
+        window.onTopupComplete = function(productId, success) {
+            if (pendingTierCard) {
+                pendingTierCard.classList.remove('is-pending');
+                pendingTierCard = null;
+            }
+            if (success) {
+                showTopupToast(tt('wallet_topup_success', 'Top-up successful!'));
+                loadBalance();
+                loadHistory();
+            } else {
+                showTopupToast(tt('wallet_topup_failed', 'Top-up failed. Please try again.'), true);
+            }
+        };
+
+        function showTopupToast(text, isError) {
+            const existing = document.querySelector('.topup-toast');
+            if (existing) existing.remove();
+            const el = document.createElement('div');
+            el.className = 'topup-toast' + (isError ? ' is-error' : '');
+            el.textContent = text;
+            document.body.appendChild(el);
+            setTimeout(() => { el.remove(); }, 3200);
         }
 
         async function loadHistory() {


### PR DESCRIPTION
## Summary
- Top-up Path B has been silently broken since commit `ddadca9e` (Apr 16), which moved the wallet UI from native Settings to `WebViewActivity`. The new host never called `addJavascriptInterface`, and the portal-side tier cards never had click handlers — so tapping any tier on `/portal/wallet.html` produced zero billing activity.
- `WebViewActivity` now exposes `window.AndroidBridge.launchTopupPurchase(productId)` backed by `BillingManager.launchTopupPurchaseFlow()`, with `onTopupComplete` forwarded to `window.onTopupComplete(productId, success)` for JS reloads. Bridge is cleared in `onDestroy`.
- `wallet.html` tier cards now get `cursor:pointer` + click handler that feature-detects the bridge, plus a toast-style status banner and a fallback message for non-WebView opens.

## Test plan
- [ ] CI green
- [ ] Deploy → open `/portal/wallet.html` in the Android app; tap any tier → Google Play sandbox sheet appears
- [ ] Complete sandbox purchase → wallet balance reloads + success toast shows
- [ ] Cancel sandbox purchase → failure toast shows, card returns to enabled
- [ ] Open `/portal/wallet.html` in desktop browser → fallback toast "Please top up via the Android app" shows on tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)