### PR TITLE
fix(billing): retry stuck INAPP top-up purchases on app startup

### DIFF
--- a/app/src/main/java/com/hank/clawlive/billing/BillingManager.kt
+++ b/app/src/main/java/com/hank/clawlive/billing/BillingManager.kt
@@ -105,6 +105,7 @@ class BillingManager(private val context: Context) : PurchasesUpdatedListener {
                     querySubscriptionStatus()
                     queryProductDetails()
                     queryTopupProductDetails()
+                    queryStuckTopupPurchases()
                 } else {
                     Timber.tag(TAG).e("Billing setup failed: ${billingResult.debugMessage}")
                 }
@@ -210,6 +211,38 @@ class BillingManager(private val context: Context) : PurchasesUpdatedListener {
                         businessPrice = getSubPrice(subBusinessDetails)
                     )
                     Timber.tag(TAG).d("Subscription details loaded")
+                }
+            }
+        }
+    }
+
+    /**
+     * Retry any INAPP top-up purchases that were never consumed — typically because
+     * a prior verify-google call failed and the fail-safe left the token alive on
+     * Google Play. Without this sweep, the user hits itemAlreadyOwned on next buy
+     * until Google auto-refunds after ~3 days.
+     */
+    private fun queryStuckTopupPurchases() {
+        scope.launch {
+            val params = QueryPurchasesParams.newBuilder()
+                .setProductType(BillingClient.ProductType.INAPP)
+                .build()
+
+            billingClient.queryPurchasesAsync(params) { billingResult, purchases ->
+                if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
+                    Timber.tag(TAG).w("Stuck top-up query failed: ${billingResult.debugMessage}")
+                    return@queryPurchasesAsync
+                }
+                val stuck = purchases.filter { purchase ->
+                    purchase.purchaseState == Purchase.PurchaseState.PURCHASED &&
+                        purchase.products.any { it in TOPUP_PRODUCT_IDS }
+                }
+                if (stuck.isEmpty()) return@queryPurchasesAsync
+                Timber.tag(TAG).d("Found ${stuck.size} stuck top-up purchase(s) — retrying verify+consume")
+                stuck.forEach { purchase ->
+                    val productId = purchase.products.firstOrNull { it in TOPUP_PRODUCT_IDS }
+                        ?: return@forEach
+                    consumeAndVerifyTopup(purchase, productId)
                 }
             }
         }


### PR DESCRIPTION
## Summary

- If `verify-google` fails after a top-up purchase, the Play Billing token is intentionally not consumed (fail-safe keeps e-coins recoverable). Until now there was no retry path — the user hit `itemAlreadyOwned` on the next buy and had to wait ~3 days for Google's auto-refund.
- On `onBillingSetupFinished`, also query INAPP purchases and, for any PURCHASED top-up whose productId is in `TOPUP_PRODUCT_IDS`, re-run `consumeAndVerifyTopup`.
- Backend `markTopupPaid` is idempotent via `orderId`, so concurrent or repeat verifies cannot double-credit.

Companion to PR #1905 (WebViewActivity AndroidBridge wiring). Card: `[companion-bug] Android 客戶端 INAPP 未消費 token 啟動時重試`.

## Test plan

- [ ] Smoke: clean app launch → logcat shows `queryStuckTopupPurchases` runs with zero stuck items.
- [ ] Repro: force `verify-google` 500 (e.g. temporary airplane-mode right after dialog) → buy $1 → verify onTopupComplete(success=false) fires → restart app → logcat shows `Found 1 stuck top-up purchase(s) — retrying verify+consume` → backend `verify-google` 200 → token consumed → wallet balance credited.
- [ ] Idempotency: repeat the stuck-retry twice → second attempt backend returns `deduped:true`, no second credit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)