### PR TITLE
feat: expose /api/chat/history in [AVAILABLE TOOLS] channel prompt

### DIFF
--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -579,6 +579,7 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
                 '[AVAILABLE TOOLS — Mission Dashboard]',
                 `Read tasks/notes/rules/skills: exec: curl -s "${apiBase}/api/mission/dashboard?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}"`,
                 `Read notes: exec: curl -s "${apiBase}/api/mission/notes?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}"`,
+                `Read chat history: exec: curl -s "${apiBase}/api/chat/history?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}&limit=100"`,
                 `Create kanban card: exec: curl -s -X POST "${apiBase}/api/mission/card" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${eId},"botSecret":"${botSecret}","title":"TASK_TITLE","status":"todo"}'`,
                 `Add note: exec: curl -s -X POST "${apiBase}/api/mission/note/add" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${eId},"botSecret":"${botSecret}","title":"TITLE","content":"CONTENT"}'`,
                 `Update wallpaper: exec: curl -s -X POST "${apiBase}/api/transform" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${eId},"botSecret":"${botSecret}","state":"IDLE","message":"hello"}'`

--- a/backend/index.js
+++ b/backend/index.js
@@ -13043,6 +13043,7 @@ function getMissionApiHints(apiBase, deviceId, entityId, botSecret) {
     hints += `Current Taiwan Time: ${twTime} (UTC+8)\n`;
     hints += `Read tasks/notes/rules/skills: exec: curl -s "${apiBase}/api/mission/dashboard?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${entityId}"\n`;
     hints += `Read notes: exec: curl -s "${apiBase}/api/mission/notes?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${entityId}"\n`;
+    hints += `Read chat history: exec: curl -s "${apiBase}/api/chat/history?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${entityId}&limit=100"\n`;
     hints += `Create kanban card: exec: curl -s -X POST "${apiBase}/api/mission/card" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${entityId},"botSecret":"${botSecret}","title":"TASK_TITLE","status":"todo"}'\n`;
     hints += `Add note: exec: curl -s -X POST "${apiBase}/api/mission/note/add" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${entityId},"botSecret":"${botSecret}","title":"TITLE","content":"CONTENT"}'\n`;
     hints += `\n[AVAILABLE TOOLS — Kanban Board]\n`;


### PR DESCRIPTION
## Summary
- Add `Read chat history` curl hint in `[AVAILABLE TOOLS — Mission Dashboard]` block so channel-bound bots + kanban-nudged bots know they can pull recent chat context (supports `limit`, `before`).
- Updated in both emitters:
  - `getMissionApiHints()` in `backend/index.js` (kanban nudges + unified push middleware)
  - ECLAW_READY init push in `backend/channel-api.js` channel bind flow

## Why
`/api/chat/history` has existed for a while but was not advertised in the tool catalog bots receive. Without it, channel bots reacting to kanban/mission pushes have no way to fetch preceding chat turns unless the human hand-feeds the curl.

## Test plan
- [x] Pre-merge live E2E: `curl https://eclawbot.com/api/chat/history?deviceId=...&deviceSecret=...&limit=3` → HTTP 200, 3 messages.
- [x] `before` param filter verified (2 older messages returned when filtering before latest timestamp).
- [ ] Post-merge: trigger a kanban card nudge, confirm push text contains the new line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)