### PR TITLE
feat(onboarding): Track 1 product tour — free/official bot rental

### DIFF
--- a/backend/device-preferences.js
+++ b/backend/device-preferences.js
@@ -55,4 +55,20 @@ async function updatePrefs(deviceId, prefs) {
     `, [deviceId, JSON.stringify(filtered), Date.now()]);
 }
 
-module.exports = { DEFAULTS, initTable, getPrefs, updatePrefs };
+async function setOnboarding(deviceId, payload) {
+    if (!pool || !deviceId) return;
+    const safe = {
+        track: typeof payload.track === 'string' ? payload.track.slice(0, 32) : null,
+        dismissed: !!payload.dismissed,
+        completedAt: payload.completedAt || new Date().toISOString()
+    };
+    await pool.query(`
+        INSERT INTO device_preferences (device_id, prefs, updated_at)
+        VALUES ($1, $2, $3)
+        ON CONFLICT (device_id) DO UPDATE
+        SET prefs = device_preferences.prefs || $2::jsonb,
+            updated_at = $3
+    `, [deviceId, JSON.stringify({ onboarding: safe }), Date.now()]);
+}
+
+module.exports = { DEFAULTS, initTable, getPrefs, updatePrefs, setOnboarding };

--- a/backend/index.js
+++ b/backend/index.js
@@ -14366,6 +14366,24 @@ app.put('/api/notification-preferences', async (req, res) => {
 });
 
 // ============================================
+// ONBOARDING (Scope 0 wizard completion)
+// ============================================
+app.post('/api/user/onboarding/mark-complete', async (req, res) => {
+    const deviceId = authDevice(req);
+    const body = req.body || {};
+    const payload = {
+        track: typeof body.track === 'string' ? body.track : null,
+        dismissed: !!body.dismissed,
+        completedAt: typeof body.completedAt === 'string' ? body.completedAt : new Date().toISOString()
+    };
+    if (deviceId) {
+        try { await devicePrefs.setOnboarding(deviceId, payload); }
+        catch (err) { console.error('[onboarding] setOnboarding failed:', err.message); }
+    }
+    res.json({ success: true, authenticated: !!deviceId, onboarding: payload });
+});
+
+// ============================================
 // DEVICE PREFERENCES (broadcast settings, etc.)
 // ============================================
 app.get('/api/device-preferences', async (req, res) => {

--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -742,6 +742,7 @@
     <script src="../shared/i18n.js"></script>
     <script src="shared/auth.js"></script>
     <script src="shared/footer.js"></script>
+    <script src="shared/product-tour.js"></script>
     <script>
     /* ══════════════════════════════════════
        Real API Integration
@@ -1236,13 +1237,72 @@
     // Apply i18n translations to static data-i18n elements
     if (typeof i18n !== 'undefined') i18n.apply();
 
-    // Auto-switch to rental tab if URL hash is #rental
-    if (location.hash === '#rental') {
+    // Auto-switch to rental tab if URL hash is #rental OR tour=track1 is in URL
+    const _tourParam = new URLSearchParams(location.search).get('tour');
+    const _tourStep = parseInt(new URLSearchParams(location.search).get('step') || '0', 10);
+    if (location.hash === '#rental' || _tourParam === 'track1') {
         const rentalChip = document.querySelector('.plaza-chip[data-filter="rental"]');
         if (rentalChip) { setFilter('rental', rentalChip); } else { loadBots(); }
     } else {
         loadBots();
     }
+
+    /* ══════ Onboarding Tour (Track 1: Free/Official Bot Rental) ══════ */
+    (function initTourTrack1() {
+        if (_tourParam !== 'track1') return;
+        if (typeof ProductTour === 'undefined') return;
+        if (ProductTour.isDone('track1')) return;
+
+        const SETTINGS_URL = '/portal/settings.html?tour=track1&step=4#channelApiCard';
+
+        ProductTour.register('track1', [
+            {
+                target: '.plaza-chip[data-filter="rental"]',
+                i18nKey: 'onboarding_tour_track1_step1',
+                fallback: 'Pick the category you want — free/official bots live under the rental filter.'
+            },
+            {
+                target: () => document.querySelector('#botGrid .bot-card'),
+                i18nKey: 'onboarding_tour_track1_step2',
+                fallback: 'Click a bot card to see the details.',
+                timeout: 12000
+            },
+            {
+                target: () => document.getElementById('rentalConfirmBtn'),
+                i18nKey: 'onboarding_tour_track1_step3',
+                fallback: 'Press here to start renting.',
+                timeout: 15000,
+                // If user clicks Next without completing the rental, skip to settings anyway —
+                // the rental success hook below handles the happy path.
+                onNext: () => { window.location.href = SETTINGS_URL; }
+            }
+        ], { totalSteps: 5 });
+
+        const resumeAt = Math.max(0, Math.min(_tourStep, 2));
+        setTimeout(() => ProductTour.goTo('track1', resumeAt), 400);
+
+        const _openRentalDetailOriginal = window.openRentalDetail;
+        if (typeof _openRentalDetailOriginal === 'function') {
+            window.openRentalDetail = async function () {
+                const result = await _openRentalDetailOriginal.apply(this, arguments);
+                const state = ProductTour.getState && ProductTour.getState();
+                if (state && state.id === 'track1' && state.stepIdx === 1) {
+                    setTimeout(() => ProductTour.goTo('track1', 2), 300);
+                }
+                return result;
+            };
+        }
+
+        const _doRentalOriginal = window.doRentalFromPlaza;
+        if (typeof _doRentalOriginal === 'function') {
+            window.doRentalFromPlaza = async function () {
+                await _doRentalOriginal.apply(this, arguments);
+                if (!document.getElementById('rentalConfirmBtn')) {
+                    setTimeout(() => { window.location.href = SETTINGS_URL; }, 1800);
+                }
+            };
+        }
+    })();
     </script>
 </body>
 

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -1780,6 +1780,7 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
+    <script src="shared/product-tour.js"></script>
     <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid|EClawIOS/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
     <script src="shared/agent-card-editor.js"></script>
     <script src="shared/ai-chat.js"></script>
@@ -4344,6 +4345,47 @@
             if (countdownInterval) clearInterval(countdownInterval);
             if (refreshInterval) clearInterval(refreshInterval);
         });
+
+        /* ══════ Onboarding Tour (Track 1) — Step 5: Completion ══════ */
+        (function initTourTrack1Step5() {
+            const params = new URLSearchParams(location.search);
+            if (params.get('tour') !== 'track1') return;
+            if (typeof ProductTour === 'undefined') return;
+            if (ProductTour.isDone('track1')) return;
+
+            function callMarkComplete() {
+                try {
+                    fetch('/api/user/onboarding/mark-complete', {
+                        method: 'POST',
+                        credentials: 'include',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ track: 'track1', dismissed: false, completedAt: new Date().toISOString() })
+                    }).catch(() => {});
+                } catch (_) { /* best-effort */ }
+                try {
+                    localStorage.setItem('eclaw_onboarding_last_seen', new Date().toISOString());
+                } catch (_) {}
+            }
+
+            ProductTour.register('track1', [
+                {
+                    target: () => document.getElementById('entityGrid') || document.body,
+                    i18nKey: 'onboarding_tour_track1_step5',
+                    fallback: "You're all set — your rented bot will appear here.",
+                    stepNumber: 5,
+                    timeout: 8000,
+                    onNext: function () {
+                        callMarkComplete();
+                    }
+                }
+            ], {
+                totalSteps: 5,
+                onComplete: () => { /* onNext already marked */ },
+                onDismiss: callMarkComplete
+            });
+
+            setTimeout(() => ProductTour.goTo('track1', 0), 600);
+        })();
     </script>
     </main>
 </body>

--- a/backend/public/portal/onboarding.html
+++ b/backend/public/portal/onboarding.html
@@ -253,7 +253,7 @@
             const LAST_SEEN_KEY = 'eclaw_onboarding_last_seen';
 
             const trackRoutes = {
-                '1': null,
+                '1': '/portal/plaza.html?tour=track1',
                 '2': null,
                 '3': null,
                 '4': null,

--- a/backend/public/portal/plaza.html
+++ b/backend/public/portal/plaza.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow">
+    <title>EClawbot - Bot Plaza</title>
+    <meta http-equiv="refresh" content="0; url=/portal/community.html">
+    <link rel="canonical" href="https://eclawbot.com/portal/community.html">
+    <style>
+        body { font-family: system-ui, -apple-system, sans-serif; padding: 40px; color: #444; }
+    </style>
+</head>
+
+<body>
+    <p>Redirecting to the Bot Plaza…</p>
+    <script>
+        (function () {
+            const src = new URL(window.location.href);
+            const dest = new URL('/portal/community.html', window.location.origin);
+            src.searchParams.forEach((v, k) => dest.searchParams.set(k, v));
+            if (src.hash) dest.hash = src.hash;
+            window.location.replace(dest.toString());
+        })();
+    </script>
+</body>
+
+</html>

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -985,6 +985,7 @@
     <script src="shared/entity-utils.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
+    <script src="shared/product-tour.js"></script>
     <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid|EClawIOS/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
     <script src="shared/ai-chat.js"></script>
 
@@ -1993,6 +1994,35 @@
                 e.target.style.display = 'none';
             }
         });
+
+        /* ══════ Onboarding Tour (Track 1) — Step 4: Channel binding ══════ */
+        (function initTourTrack1Step4() {
+            const params = new URLSearchParams(location.search);
+            if (params.get('tour') !== 'track1') return;
+            if (typeof ProductTour === 'undefined') return;
+            if (ProductTour.isDone('track1')) return;
+
+            ProductTour.register('track1', [
+                {
+                    target: '#channelApiCard',
+                    i18nKey: 'onboarding_tour_track1_step4',
+                    fallback: 'Bind a Channel API key here so your rented bot can actually respond.',
+                    stepNumber: 4,
+                    timeout: 10000,
+                    onNext: () => {
+                        window.location.href = '/portal/dashboard.html?tour=track1&step=5';
+                    }
+                }
+            ], { totalSteps: 5 });
+
+            // Auto-scroll channelApiCard into view so spotlight lands visibly
+            const scrollTarget = document.getElementById('channelApiCard');
+            if (scrollTarget && scrollTarget.scrollIntoView) {
+                scrollTarget.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            }
+
+            setTimeout(() => ProductTour.goTo('track1', 0), 500);
+        })();
     </script>
     </main>
 </body>

--- a/backend/public/portal/shared/product-tour.js
+++ b/backend/public/portal/shared/product-tour.js
@@ -1,0 +1,276 @@
+/**
+ * Product Tour — minimal spotlight + callout overlay for onboarding flows.
+ *
+ * Usage:
+ *   ProductTour.register('track1', [
+ *     { target: '#rental-chip', i18nKey: 'onboarding_tour_track1_step1', fallback: '...' },
+ *     { target: () => document.querySelector('.bot-card'), i18nKey: 'onboarding_tour_track1_step2' },
+ *     ...
+ *   ]);
+ *   ProductTour.start('track1');
+ *   ProductTour.goTo('track1', 3);  // resume at step (0-indexed)
+ *   ProductTour.isDone('track1');
+ *   ProductTour.markDone('track1');
+ *
+ * Cross-page: pages read URL param ?tour=<id>&step=<n> and resume via goTo.
+ * State persists in localStorage: eclaw_tour_<id>_step, eclaw_tour_<id>_done.
+ */
+(function (global) {
+    'use strict';
+
+    const STYLE_ID = 'product-tour-style';
+    const CSS = `
+        .pt-overlay {
+            position: fixed; inset: 0; z-index: 99998;
+            background: rgba(0,0,0,0.55);
+            pointer-events: auto;
+            transition: clip-path 0.22s ease;
+        }
+        .pt-spotlight {
+            position: fixed; z-index: 99999;
+            border-radius: 10px;
+            box-shadow: 0 0 0 4px rgba(124,58,237,0.7), 0 0 0 9999px rgba(0,0,0,0.55);
+            pointer-events: none;
+            transition: top 0.22s ease, left 0.22s ease, width 0.22s ease, height 0.22s ease;
+        }
+        .pt-callout {
+            position: fixed; z-index: 100000;
+            max-width: 320px; min-width: 220px;
+            background: #fff; color: #222;
+            border-radius: 12px;
+            padding: 14px 16px 12px;
+            box-shadow: 0 10px 30px rgba(0,0,0,0.35);
+            font-size: 14px; line-height: 1.5;
+        }
+        @media (prefers-color-scheme: dark) {
+            .pt-callout { background: #1f2937; color: #f3f4f6; }
+        }
+        .pt-callout-text { margin: 0 0 12px; }
+        .pt-callout-progress { font-size: 11px; color: #6b7280; margin-bottom: 6px; }
+        .pt-callout-actions { display: flex; justify-content: flex-end; gap: 8px; }
+        .pt-btn {
+            font: inherit;
+            border-radius: 8px;
+            padding: 6px 14px;
+            border: 1px solid transparent;
+            cursor: pointer;
+        }
+        .pt-btn-primary { background: #7c3aed; color: #fff; }
+        .pt-btn-primary:hover { background: #6d28d9; }
+        .pt-btn-ghost { background: transparent; color: inherit; border-color: rgba(0,0,0,0.15); }
+        .pt-callout .pt-close {
+            position: absolute; top: 6px; right: 8px;
+            background: transparent; border: 0; font-size: 16px;
+            cursor: pointer; color: inherit; opacity: 0.6;
+        }
+        .pt-callout .pt-close:hover { opacity: 1; }
+    `;
+
+    const tours = Object.create(null);
+    let active = null;  // { id, stepIdx, step, els: { overlay, spotlight, callout } }
+
+    function injectStyle() {
+        if (document.getElementById(STYLE_ID)) return;
+        const s = document.createElement('style');
+        s.id = STYLE_ID;
+        s.textContent = CSS;
+        document.head.appendChild(s);
+    }
+
+    function lsKey(id, suffix) { return `eclaw_tour_${id}_${suffix}`; }
+
+    function register(id, steps, opts) {
+        tours[id] = { steps, opts: opts || {} };
+    }
+
+    function isDone(id) { return localStorage.getItem(lsKey(id, 'done')) === '1'; }
+    function markDone(id) { localStorage.setItem(lsKey(id, 'done'), '1'); }
+    function savedStep(id) { return parseInt(localStorage.getItem(lsKey(id, 'step')) || '0', 10) || 0; }
+
+    function translate(step) {
+        const fb = step.fallback || '';
+        if (step.i18nKey && typeof global.i18n !== 'undefined' && global.i18n.t) {
+            const v = global.i18n.t(step.i18nKey);
+            if (v && v !== step.i18nKey) return v;
+        }
+        return fb;
+    }
+
+    function resolveTarget(step, cb) {
+        const deadline = Date.now() + (step.timeout || 8000);
+        const tryFind = () => {
+            let el = null;
+            try {
+                if (typeof step.target === 'function') el = step.target();
+                else if (typeof step.target === 'string') el = document.querySelector(step.target);
+            } catch (_) { el = null; }
+            if (el && el.offsetParent !== null) { cb(el); return; }
+            if (Date.now() > deadline) { cb(null); return; }
+            setTimeout(tryFind, 180);
+        };
+        tryFind();
+    }
+
+    function teardown() {
+        if (!active) return;
+        ['overlay', 'spotlight', 'callout'].forEach(k => {
+            if (active.els[k] && active.els[k].parentNode) active.els[k].parentNode.removeChild(active.els[k]);
+        });
+        document.removeEventListener('keydown', active.onKey, true);
+        window.removeEventListener('resize', active.onReposition);
+        window.removeEventListener('scroll', active.onReposition, true);
+        active = null;
+    }
+
+    function positionCallout(calloutEl, rect) {
+        const vw = window.innerWidth, vh = window.innerHeight;
+        const cw = calloutEl.offsetWidth || 280, ch = calloutEl.offsetHeight || 120;
+        const pad = 12;
+        let top = rect.bottom + pad;
+        let left = rect.left + (rect.width / 2) - (cw / 2);
+        if (top + ch + pad > vh) top = Math.max(pad, rect.top - ch - pad);
+        left = Math.max(pad, Math.min(left, vw - cw - pad));
+        calloutEl.style.top = top + 'px';
+        calloutEl.style.left = left + 'px';
+    }
+
+    function renderStep(targetEl) {
+        const { step, stepIdx, id } = active;
+        const tour = tours[id];
+        const total = (tour.opts && tour.opts.totalSteps) || tour.steps.length;
+        const displayNum = step.stepNumber || (stepIdx + 1);
+
+        const overlay = document.createElement('div');
+        overlay.className = 'pt-overlay';
+        overlay.addEventListener('click', (e) => { if (e.target === overlay) { /* click-outside is soft dismiss */ dismiss(); } });
+
+        const spotlight = document.createElement('div');
+        spotlight.className = 'pt-spotlight';
+
+        const callout = document.createElement('div');
+        callout.className = 'pt-callout';
+        const closeLabel = (typeof global.i18n !== 'undefined' && global.i18n.t('onboarding_tour_skip')) || 'Skip';
+        const nextLabel = stepIdx === total - 1
+            ? ((typeof global.i18n !== 'undefined' && global.i18n.t('onboarding_tour_finish')) || 'Finish')
+            : ((typeof global.i18n !== 'undefined' && global.i18n.t('onboarding_tour_next')) || 'Next');
+        const text = translate(step);
+        callout.innerHTML = `
+            <button class="pt-close" type="button" aria-label="Close">×</button>
+            <div class="pt-callout-progress">${displayNum} / ${total}</div>
+            <p class="pt-callout-text"></p>
+            <div class="pt-callout-actions">
+                <button class="pt-btn pt-btn-ghost" data-role="skip" type="button"></button>
+                <button class="pt-btn pt-btn-primary" data-role="next" type="button"></button>
+            </div>
+        `;
+        callout.querySelector('.pt-callout-text').textContent = text;
+        callout.querySelector('[data-role="skip"]').textContent = closeLabel;
+        callout.querySelector('[data-role="next"]').textContent = nextLabel;
+
+        document.body.appendChild(overlay);
+        document.body.appendChild(callout);
+        document.body.appendChild(spotlight);
+        active.els = { overlay, spotlight, callout };
+
+        const reposition = () => {
+            const rect = targetEl.getBoundingClientRect();
+            const pad = 6;
+            spotlight.style.top = (rect.top - pad) + 'px';
+            spotlight.style.left = (rect.left - pad) + 'px';
+            spotlight.style.width = (rect.width + pad * 2) + 'px';
+            spotlight.style.height = (rect.height + pad * 2) + 'px';
+            positionCallout(callout, rect);
+        };
+        reposition();
+        active.onReposition = reposition;
+        window.addEventListener('resize', reposition);
+        window.addEventListener('scroll', reposition, true);
+
+        const onKey = (e) => {
+            if (e.key === 'Escape') { e.preventDefault(); dismiss(); }
+            else if (e.key === 'Enter' || e.key === 'ArrowRight') { e.preventDefault(); next(); }
+        };
+        document.addEventListener('keydown', onKey, true);
+        active.onKey = onKey;
+
+        callout.querySelector('.pt-close').addEventListener('click', dismiss);
+        callout.querySelector('[data-role="skip"]').addEventListener('click', dismiss);
+        callout.querySelector('[data-role="next"]').addEventListener('click', next);
+
+        if (step.highlightClick !== false) {
+            // Allow user to still click through the spotlight
+            spotlight.style.pointerEvents = 'none';
+            overlay.style.pointerEvents = 'none';
+        }
+    }
+
+    function startAtIndex(id, stepIdx) {
+        const tour = tours[id];
+        if (!tour) { console.warn('[tour] not registered:', id); return; }
+        if (stepIdx < 0 || stepIdx >= tour.steps.length) { markDone(id); teardown(); return; }
+        const step = tour.steps[stepIdx];
+        teardown();
+        injectStyle();
+        active = { id, stepIdx, step, els: {} };
+        localStorage.setItem(lsKey(id, 'step'), String(stepIdx));
+        if (typeof step.onBeforeShow === 'function') {
+            try { step.onBeforeShow(); } catch (_) {}
+        }
+        resolveTarget(step, (el) => {
+            if (!active || active.stepIdx !== stepIdx) return;
+            if (!el) {
+                // Target not found — skip to next step silently so the tour doesn't wedge.
+                console.warn('[tour] target not found for step', stepIdx, step.target);
+                return startAtIndex(id, stepIdx + 1);
+            }
+            renderStep(el);
+        });
+    }
+
+    function start(id) {
+        if (isDone(id)) return;
+        const resumeAt = savedStep(id);
+        startAtIndex(id, resumeAt);
+    }
+
+    function goTo(id, stepIdx) {
+        if (isDone(id)) return;
+        startAtIndex(id, stepIdx);
+    }
+
+    function next() {
+        if (!active) return;
+        const { id, stepIdx, step } = active;
+        if (typeof step.onNext === 'function') {
+            try { step.onNext(); } catch (_) {}
+        }
+        const tour = tours[id];
+        if (stepIdx + 1 >= tour.steps.length) {
+            markDone(id);
+            teardown();
+            if (tour.opts && typeof tour.opts.onComplete === 'function') tour.opts.onComplete();
+            return;
+        }
+        startAtIndex(id, stepIdx + 1);
+    }
+
+    function dismiss() {
+        if (!active) return;
+        const { id } = active;
+        markDone(id);
+        teardown();
+        const tour = tours[id];
+        if (tour && tour.opts && typeof tour.opts.onDismiss === 'function') tour.opts.onDismiss();
+    }
+
+    function getState() {
+        if (!active) return null;
+        return { id: active.id, stepIdx: active.stepIdx };
+    }
+
+    global.ProductTour = {
+        register, start, goTo, next, dismiss,
+        isDone, markDone, getState
+    };
+
+})(typeof window !== 'undefined' ? window : this);

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -4214,6 +4214,16 @@ const TRANSLATIONS = {
         "onboarding_dont_show_again": "Don't show this again",
         "onboarding_skip_btn": "Just explore for now",
         "onboarding_dismiss_hint": "You can reopen this guide anytime from Settings.",
+
+        // Scope 0 → Track 1: Free/Official Bot Rental tour (product-tour.js)
+        "onboarding_tour_track1_step1": "Pick the category you want here — free and official bots live under the rental filter.",
+        "onboarding_tour_track1_step2": "Tap any bot card to see the full profile and rental terms.",
+        "onboarding_tour_track1_step3": "Press here to start renting. We'll walk you through binding next.",
+        "onboarding_tour_track1_step4": "Generate a Channel API key here so your rented bot can actually respond.",
+        "onboarding_tour_track1_step5": "You're all set — your rented bot will appear here on your dashboard.",
+        "onboarding_tour_next": "Next",
+        "onboarding_tour_finish": "Finish",
+        "onboarding_tour_skip": "Skip",
     },
 
     zh: {
@@ -8200,6 +8210,16 @@ const TRANSLATIONS = {
         "info_guide_credit_swap_cta_invite": "邀請朋友：<a href=\"settings.html\">設定 → 推薦碼</a>（雙方都拿獎勵）",
         "info_guide_credit_swap_cta_history": "查看你的任務記錄：<a href=\"kanban.html\">任務中心</a>",
         "roadmap_banner_user_view": "🎯 想看使用者視角的好處？前往 <a href=\"info.html#guide/passive-income\">使用指南 → 為什麼選擇 EClaw</a>",
+
+        // Scope 0 → Track 1: Free/Official Bot Rental tour (product-tour.js)
+        "onboarding_tour_track1_step1": "這裡勾選你要的類型 — 免費與官方 bot 都在「出租」分類裡。",
+        "onboarding_tour_track1_step2": "點這個看詳情 — 點任一張 bot 卡片查看完整資訊與租借條件。",
+        "onboarding_tour_track1_step3": "按這裡開始租 — 接下來我們會帶你完成綁定。",
+        "onboarding_tour_track1_step4": "綁好就能用 — 在這裡產生 Channel API Key，讓你租的 bot 真正能回話。",
+        "onboarding_tour_track1_step5": "完成啦！你租的 bot 會出現在儀表板上。",
+        "onboarding_tour_next": "下一步",
+        "onboarding_tour_finish": "完成",
+        "onboarding_tour_skip": "跳過",
     },
 
     "zh-CN": {
@@ -8511,6 +8531,16 @@ const TRANSLATIONS = {
         "onboarding_dont_show_again": "別再顯示此指引",
         "onboarding_skip_btn": "先自己逛逛",
         "onboarding_dismiss_hint": "你隨時可以從「設定」頁重新開啟這個指引。",
+
+        // Scope 0 → Track 1: Free/Official Bot Rental tour (product-tour.js)
+        "onboarding_tour_track1_step1": "這裡勾選你要的類型 — 免費與官方 bot 都在「出租」分類裡。",
+        "onboarding_tour_track1_step2": "點這個看詳情 — 點任一張 bot 卡片查看完整資訊與租借條件。",
+        "onboarding_tour_track1_step3": "按這裡開始租 — 接下來我們會帶你完成綁定。",
+        "onboarding_tour_track1_step4": "綁好就能用 — 在這裡產生 Channel API Key，讓你租的 bot 真正能回話。",
+        "onboarding_tour_track1_step5": "完成啦！你租的 bot 會出現在儀表板上。",
+        "onboarding_tour_next": "下一步",
+        "onboarding_tour_finish": "完成",
+        "onboarding_tour_skip": "跳過",
     },
 
     ja: {

--- a/backend/tests/jest/onboarding-tour.test.js
+++ b/backend/tests/jest/onboarding-tour.test.js
@@ -1,0 +1,171 @@
+/**
+ * Onboarding Tour (Track 1: Free/Official Bot Rental) — static audit tests
+ *
+ * Verifies the product tour infrastructure is wired across pages:
+ *   - Scope 0 wizard redirects Track 1 to /portal/plaza.html?tour=track1
+ *   - plaza.html stub redirects to community.html
+ *   - community.html, settings.html, dashboard.html all load product-tour.js
+ *   - product-tour.js parses and exposes ProductTour globals
+ *   - i18n.js defines the 5 callout keys + skip/next/finish in en + zh
+ *   - /api/user/onboarding/mark-complete endpoint handler exists in index.js
+ *
+ * Regression protection: ensures the tour never silently breaks across a refactor.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const PUBLIC_DIR = path.join(__dirname, '../../public');
+const PORTAL_DIR = path.join(PUBLIC_DIR, 'portal');
+const BACKEND_DIR = path.join(__dirname, '../..');
+
+function read(relPath) {
+    return fs.readFileSync(path.join(BACKEND_DIR, relPath), 'utf8');
+}
+
+describe('Onboarding Track 1 tour — files exist', () => {
+    test('product-tour.js exists', () => {
+        expect(fs.existsSync(path.join(PORTAL_DIR, 'shared/product-tour.js'))).toBe(true);
+    });
+
+    test('plaza.html stub exists', () => {
+        expect(fs.existsSync(path.join(PORTAL_DIR, 'plaza.html'))).toBe(true);
+    });
+});
+
+describe('Scope 0 wizard routes to plaza with tour param', () => {
+    const html = read('public/portal/onboarding.html');
+
+    test("trackRoutes['1'] points to plaza.html?tour=track1", () => {
+        expect(html).toMatch(/'1':\s*'\/portal\/plaza\.html\?tour=track1'/);
+    });
+});
+
+describe('plaza.html redirects to community.html preserving query', () => {
+    const html = read('public/portal/plaza.html');
+
+    test('has meta refresh to community.html', () => {
+        expect(html).toMatch(/http-equiv="refresh"[^>]*community\.html/);
+    });
+
+    test('JS redirect preserves search params', () => {
+        expect(html).toMatch(/community\.html/);
+        expect(html).toMatch(/searchParams\.forEach/);
+    });
+});
+
+describe('Product tour script is loaded on tour pages', () => {
+    const pages = ['community.html', 'settings.html', 'dashboard.html'];
+    test.each(pages)('%s loads shared/product-tour.js', (page) => {
+        const html = read(`public/portal/${page}`);
+        expect(html).toMatch(/<script\s+src=["'][^"']*product-tour\.js["']/);
+    });
+});
+
+describe('product-tour.js parses and exports ProductTour API', () => {
+    const src = read('public/portal/shared/product-tour.js');
+
+    test('parses without syntax errors', () => {
+        expect(() => new vm.Script(src, { filename: 'product-tour.js' })).not.toThrow();
+    });
+
+    test('exposes ProductTour globals (register/start/goTo/isDone/markDone)', () => {
+        const sandbox = {
+            window: {},
+            document: { createElement: () => ({ appendChild: () => {} }), head: { appendChild: () => {} }, body: { appendChild: () => {} } },
+            localStorage: { getItem: () => null, setItem: () => {} },
+            console,
+            setTimeout,
+            setInterval
+        };
+        sandbox.global = sandbox;
+        vm.createContext(sandbox);
+        vm.runInContext(src, sandbox);
+        const pt = sandbox.window.ProductTour;
+        expect(pt).toBeDefined();
+        ['register', 'start', 'goTo', 'next', 'dismiss', 'isDone', 'markDone', 'getState'].forEach(k => {
+            expect(typeof pt[k]).toBe('function');
+        });
+    });
+});
+
+describe('i18n keys for tour callouts are defined in en and zh', () => {
+    const i18nSrc = read('public/shared/i18n.js');
+    const sandbox = {
+        localStorage: { getItem: () => null, setItem: () => {} },
+        navigator: { language: 'en' },
+        document: { addEventListener: () => {}, querySelectorAll: () => [], documentElement: { lang: '' } },
+        fetch: () => Promise.resolve(),
+        console,
+        _result: {}
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(i18nSrc + '\n_result.TRANSLATIONS = TRANSLATIONS;', sandbox);
+    const T = sandbox._result.TRANSLATIONS;
+
+    const requiredKeys = [
+        'onboarding_tour_track1_step1',
+        'onboarding_tour_track1_step2',
+        'onboarding_tour_track1_step3',
+        'onboarding_tour_track1_step4',
+        'onboarding_tour_track1_step5',
+        'onboarding_tour_next',
+        'onboarding_tour_finish',
+        'onboarding_tour_skip'
+    ];
+
+    test.each(requiredKeys)('en has %s', (key) => {
+        expect(T.en[key]).toBeDefined();
+        expect(T.en[key]).toEqual(expect.any(String));
+        expect(T.en[key].length).toBeGreaterThan(0);
+    });
+
+    test.each(requiredKeys)('zh has %s', (key) => {
+        expect(T.zh[key]).toBeDefined();
+        expect(T.zh[key]).toEqual(expect.any(String));
+        expect(T.zh[key].length).toBeGreaterThan(0);
+    });
+
+    test('zh translations differ from en (real translation, not copy)', () => {
+        for (const key of requiredKeys) {
+            expect(T.zh[key]).not.toBe(T.en[key]);
+        }
+    });
+});
+
+describe('Backend /api/user/onboarding/mark-complete endpoint', () => {
+    const indexSrc = read('index.js');
+
+    test('index.js registers POST /api/user/onboarding/mark-complete', () => {
+        expect(indexSrc).toMatch(/app\.post\(\s*['"]\/api\/user\/onboarding\/mark-complete['"]/);
+    });
+
+    test('device-preferences.js exposes setOnboarding', () => {
+        const prefsSrc = read('device-preferences.js');
+        expect(prefsSrc).toMatch(/setOnboarding/);
+        expect(prefsSrc).toMatch(/module\.exports\s*=\s*\{[^}]*setOnboarding/);
+    });
+});
+
+describe('Tour calls site integration', () => {
+    test('community.html registers track1 tour with 3 steps', () => {
+        const html = read('public/portal/community.html');
+        expect(html).toMatch(/ProductTour\.register\(\s*['"]track1['"]/);
+        expect(html).toMatch(/onboarding_tour_track1_step1/);
+        expect(html).toMatch(/onboarding_tour_track1_step2/);
+        expect(html).toMatch(/onboarding_tour_track1_step3/);
+    });
+
+    test('settings.html hosts step 4 and navigates to dashboard step 5', () => {
+        const html = read('public/portal/settings.html');
+        expect(html).toMatch(/onboarding_tour_track1_step4/);
+        expect(html).toMatch(/\/portal\/dashboard\.html\?tour=track1&step=5/);
+    });
+
+    test('dashboard.html hosts step 5 and calls mark-complete API', () => {
+        const html = read('public/portal/dashboard.html');
+        expect(html).toMatch(/onboarding_tour_track1_step5/);
+        expect(html).toMatch(/\/api\/user\/onboarding\/mark-complete/);
+    });
+});


### PR DESCRIPTION
## Summary
- New 5-step product tour walks users from Scope 0 wizard → plaza → bot card → rent → channel binding → completion
- Vanilla JS tour lib (`shared/product-tour.js`) with cross-page state via localStorage and i18n-aware copy
- Semantic `plaza.html` redirect stub → `community.html` preserving query
- 8 i18n keys (en + zh) added to `shared/i18n.js` in both the Traditional `zh` and `zh-CN` sections
- Minimal `POST /api/user/onboarding/mark-complete` endpoint persists to `device_preferences.prefs.onboarding`

## Changed
- `onboarding.html` — wired `trackRoutes['1']` → `/portal/plaza.html?tour=track1`
- `community.html` — tour steps 1–3 (filter chip → bot card → rent button)
- `settings.html` — tour step 4 (`#channelApiCard`)
- `dashboard.html` — tour step 5 + `mark-complete` call
- `device-preferences.js` — new `setOnboarding()` helper
- `index.js` — `POST /api/user/onboarding/mark-complete` route

## Test plan
- [x] Jest `i18n-syntax` + new `onboarding-tour` static audit — 1773/1773 pass
- [x] ESLint clean on new files
- [ ] Manual E2E on prod after deploy: open `/portal/plaza.html?tour=track1` and walk all 5 steps
- [ ] Verify `POST /api/user/onboarding/mark-complete` returns 200 on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)