### PR TITLE
feat(onboarding): Track 5 Hermes channel — Coming Soon placeholder

### DIFF
--- a/backend/public/portal/onboarding.html
+++ b/backend/public/portal/onboarding.html
@@ -218,7 +218,7 @@
                     <div class="ob-card-desc" data-i18n="onboarding_track4_desc">Use your own Anthropic API key so bots answer via Claude.</div>
                 </a>
 
-                <a class="ob-card" href="#track-5" data-track="5" data-disabled="true">
+                <a class="ob-card" href="/portal/onboarding/hermes-coming-soon.html" data-track="5">
                     <div class="ob-card-icon">✨</div>
                     <div class="ob-card-title" data-i18n="onboarding_track5_title">Bind Hermes channel</div>
                     <div class="ob-card-desc" data-i18n="onboarding_track5_desc">Join the waitlist and we'll notify you at launch.</div>
@@ -257,7 +257,7 @@
                 '2': null,
                 '3': null,
                 '4': null,
-                '5': null,
+                '5': '/portal/onboarding/hermes-coming-soon.html',
                 '6': null
             };
 

--- a/backend/public/portal/onboarding/hermes-coming-soon.html
+++ b/backend/public/portal/onboarding/hermes-coming-soon.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow">
+    <title data-i18n="hermes_coming_soon_title">Hermes channel — Coming Soon</title>
+    <meta name="description" content="Hermes channel integration is coming soon to EClawbot.">
+    <link rel="icon" type="image/png" href="/portal/assets/favicon-32.png">
+    <link rel="stylesheet" href="/portal/shared/style.css">
+    <link rel="canonical" href="https://eclawbot.com/portal/onboarding/hermes-coming-soon.html">
+    <style>
+        .hcs-container {
+            max-width: 560px;
+            margin: 0 auto;
+            padding: 56px 20px 80px;
+            text-align: center;
+        }
+
+        .hcs-icon {
+            font-size: 64px;
+            line-height: 1;
+            margin-bottom: 20px;
+        }
+
+        .hcs-title {
+            font-size: 28px;
+            font-weight: 700;
+            margin: 0 0 14px;
+        }
+
+        .hcs-subtitle {
+            display: inline-block;
+            font-size: 12px;
+            font-weight: 600;
+            padding: 4px 12px;
+            border-radius: 12px;
+            background: var(--input-bg);
+            color: var(--text-secondary);
+            border: 1px solid var(--card-border);
+            letter-spacing: 0.4px;
+            margin-bottom: 24px;
+        }
+
+        .hcs-desc {
+            font-size: 15px;
+            color: var(--text-secondary);
+            line-height: 1.6;
+            margin: 0 0 32px;
+        }
+
+        .hcs-actions {
+            display: flex;
+            flex-direction: column;
+            gap: 12px;
+            align-items: center;
+            margin-bottom: 28px;
+        }
+
+        .hcs-btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 240px;
+            padding: 12px 22px;
+            font-size: 14px;
+            font-weight: 500;
+            border-radius: var(--radius-sm, 8px);
+            border: 1px solid var(--card-border);
+            background: transparent;
+            color: inherit;
+            text-decoration: none;
+            cursor: pointer;
+            transition: background 0.15s, border-color 0.15s, transform 0.12s;
+        }
+
+        .hcs-btn:hover {
+            border-color: var(--accent, #7c3aed);
+            background: var(--input-bg);
+        }
+
+        .hcs-btn-primary {
+            background: var(--accent, #7c3aed);
+            color: #fff;
+            border-color: var(--accent, #7c3aed);
+        }
+
+        .hcs-btn-primary:hover {
+            background: #6d28d9;
+            border-color: #6d28d9;
+            color: #fff;
+        }
+
+        .hcs-back {
+            display: inline-block;
+            margin-top: 8px;
+            font-size: 13px;
+            color: var(--text-secondary);
+            text-decoration: none;
+        }
+
+        .hcs-back:hover {
+            color: var(--accent, #7c3aed);
+            text-decoration: underline;
+        }
+
+        @media (max-width: 480px) {
+            .hcs-container {
+                padding: 40px 16px 60px;
+            }
+
+            .hcs-title {
+                font-size: 22px;
+            }
+
+            .hcs-btn {
+                min-width: 100%;
+            }
+        }
+    </style>
+</head>
+
+<body>
+    <main>
+        <div class="hcs-container">
+            <div class="hcs-icon" aria-hidden="true">✨</div>
+            <h1 class="hcs-title" data-i18n="hermes_coming_soon_title">Hermes channel — Coming Soon</h1>
+            <div class="hcs-subtitle" data-i18n="hermes_coming_soon_badge">Coming Soon</div>
+            <p class="hcs-desc" data-i18n="hermes_coming_soon_desc">Hermes is an upcoming EClaw channel integration. We're working on it — stay tuned!</p>
+
+            <div class="hcs-actions">
+                <a class="hcs-btn hcs-btn-primary"
+                    href="mailto:support@eclawbot.com?subject=Hermes%20channel%20waitlist&body=Please%20notify%20me%20when%20Hermes%20channel%20launches."
+                    data-i18n="hermes_coming_soon_notify_btn">Notify me at launch</a>
+                <a class="hcs-btn" href="/portal/onboarding.html" id="hcs-back-wizard"
+                    data-i18n="hermes_coming_soon_back_wizard">Back to wizard</a>
+            </div>
+
+            <a class="hcs-back" href="/portal/dashboard.html"
+                data-i18n="hermes_coming_soon_explore">Just explore for now →</a>
+        </div>
+    </main>
+
+    <script src="/shared/i18n.js"></script>
+    <script>
+        (function () {
+            'use strict';
+            var SEEN_KEY = 'eclaw_tour_track5_seen';
+            try { localStorage.setItem(SEEN_KEY, '1'); } catch (_) { /* storage blocked — ignore */ }
+        })();
+    </script>
+</body>
+
+</html>

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -4224,6 +4224,21 @@ const TRANSLATIONS = {
         "onboarding_tour_next": "Next",
         "onboarding_tour_finish": "Finish",
         "onboarding_tour_skip": "Skip",
+
+        // Scope 0 → Track 2: Paid e-coin Bot Rental tour (product-tour.js)
+        "onboarding_tour_track2_step1": "Paid and free bots share this rental plaza. Track 2 focuses on the paid side — keep an eye on the e-coin rate.",
+        "onboarding_tour_track2_step2": "Every card shows the e-coin rate per 1K tokens. That's what you'll be charged as the bot works.",
+        "onboarding_tour_track2_step3": "Tap any card to open the full rental terms. We'll hop over to your wallet next — no charge yet.",
+        "onboarding_tour_track2_step4": "Top up e-coin here whenever your balance runs low. Currently Android-only via Google Play.",
+        "onboarding_tour_track2_step5": "You're all set — active rentals, leased-out bots, and any disputes all live on this page.",
+
+        // Scope 0 → Track 5: Hermes channel (coming soon)
+        "hermes_coming_soon_title": "Hermes channel — Coming Soon",
+        "hermes_coming_soon_badge": "Coming Soon",
+        "hermes_coming_soon_desc": "Hermes is an upcoming EClaw channel integration. We're working on it — stay tuned!",
+        "hermes_coming_soon_notify_btn": "Notify me at launch",
+        "hermes_coming_soon_back_wizard": "Back to wizard",
+        "hermes_coming_soon_explore": "Just explore for now →",
     },
 
     zh: {
@@ -8220,6 +8235,21 @@ const TRANSLATIONS = {
         "onboarding_tour_next": "下一步",
         "onboarding_tour_finish": "完成",
         "onboarding_tour_skip": "跳過",
+
+        // Scope 0 → Track 2: Paid e-coin Bot Rental tour (product-tour.js)
+        "onboarding_tour_track2_step1": "付費與免費 bot 都在「出租」分類裡 — Track 2 會帶你認識付費這一塊，注意 e幣 費率。",
+        "onboarding_tour_track2_step2": "每張卡片都會顯示 e幣/1K tokens 的費率，這就是 bot 工作時會扣掉的金額。",
+        "onboarding_tour_track2_step3": "點卡片看完整租借條件。我們下一步會帶你到錢包，這個 tour 不會實際扣款。",
+        "onboarding_tour_track2_step4": "e幣 不夠時就在這裡儲值（目前只能從 Android App 內 Google Play 購買）。",
+        "onboarding_tour_track2_step5": "完成啦！你的租約、出租 bot、爭議都會出現在這一頁。",
+
+        // Scope 0 → Track 5: Hermes channel (coming soon)
+        "hermes_coming_soon_title": "Hermes channel — 即將推出",
+        "hermes_coming_soon_badge": "即將推出",
+        "hermes_coming_soon_desc": "Hermes 是 EClaw 即將推出的 channel 整合，我們正在努力打造中，敬請期待！",
+        "hermes_coming_soon_notify_btn": "上線時通知我",
+        "hermes_coming_soon_back_wizard": "回到指引",
+        "hermes_coming_soon_explore": "先自己逛逛 →",
     },
 
     "zh-CN": {

--- a/backend/tests/jest/onboarding-track5-hermes.test.js
+++ b/backend/tests/jest/onboarding-track5-hermes.test.js
@@ -1,0 +1,115 @@
+/**
+ * Onboarding Track 5 — Hermes channel Coming Soon placeholder — static audit tests
+ *
+ * Verifies the Track 5 placeholder is wired:
+ *   - /portal/onboarding/hermes-coming-soon.html exists and loads i18n.js
+ *   - onboarding.html routes Track 5 to the placeholder page (no longer disabled)
+ *   - Placeholder sets the `eclaw_tour_track5_seen` localStorage flag
+ *   - Required i18n keys exist in en + zh
+ *
+ * Regression protection: static audit so the placeholder doesn't silently regress
+ * before the real Hermes integration ships.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const PUBLIC_DIR = path.join(__dirname, '../../public');
+const PORTAL_DIR = path.join(PUBLIC_DIR, 'portal');
+const BACKEND_DIR = path.join(__dirname, '../..');
+
+function read(relPath) {
+    return fs.readFileSync(path.join(BACKEND_DIR, relPath), 'utf8');
+}
+
+describe('Track 5 Hermes placeholder file exists', () => {
+    test('hermes-coming-soon.html exists under /portal/onboarding/', () => {
+        const p = path.join(PORTAL_DIR, 'onboarding/hermes-coming-soon.html');
+        expect(fs.existsSync(p)).toBe(true);
+    });
+});
+
+describe('hermes-coming-soon.html structure', () => {
+    const html = read('public/portal/onboarding/hermes-coming-soon.html');
+
+    test('has i18n title tag', () => {
+        expect(html).toMatch(/data-i18n="hermes_coming_soon_title"/);
+    });
+
+    test('loads i18n.js', () => {
+        expect(html).toMatch(/<script\s+src=["'][^"']*i18n\.js["']/);
+    });
+
+    test('sets eclaw_tour_track5_seen localStorage flag', () => {
+        expect(html).toMatch(/eclaw_tour_track5_seen/);
+        expect(html).toMatch(/localStorage\.setItem\(\s*SEEN_KEY\s*,\s*['"]1['"]/);
+    });
+
+    test('has back-to-wizard link', () => {
+        expect(html).toMatch(/href="\/portal\/onboarding\.html"/);
+    });
+
+    test('has notify-me button (mailto placeholder)', () => {
+        expect(html).toMatch(/href="mailto:[^"]*"/);
+        expect(html).toMatch(/data-i18n="hermes_coming_soon_notify_btn"/);
+    });
+});
+
+describe('onboarding.html wires Track 5 to placeholder page', () => {
+    const html = read('public/portal/onboarding.html');
+
+    test('Track 5 card links to hermes-coming-soon.html', () => {
+        expect(html).toMatch(/href="\/portal\/onboarding\/hermes-coming-soon\.html"\s+data-track="5"/);
+    });
+
+    test('Track 5 card is no longer data-disabled', () => {
+        expect(html).not.toMatch(/data-track="5"\s+data-disabled="true"/);
+    });
+
+    test("trackRoutes['5'] points to hermes-coming-soon.html", () => {
+        expect(html).toMatch(/'5':\s*'\/portal\/onboarding\/hermes-coming-soon\.html'/);
+    });
+});
+
+describe('Track 5 i18n keys defined in en + zh', () => {
+    const i18nSrc = read('public/shared/i18n.js');
+    const sandbox = {
+        localStorage: { getItem: () => null, setItem: () => {} },
+        navigator: { language: 'en' },
+        document: { addEventListener: () => {}, querySelectorAll: () => [], documentElement: { lang: '' } },
+        fetch: () => Promise.resolve(),
+        console,
+        _result: {}
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(i18nSrc + '\n_result.TRANSLATIONS = TRANSLATIONS;', sandbox);
+    const T = sandbox._result.TRANSLATIONS;
+
+    const requiredKeys = [
+        'hermes_coming_soon_title',
+        'hermes_coming_soon_badge',
+        'hermes_coming_soon_desc',
+        'hermes_coming_soon_notify_btn',
+        'hermes_coming_soon_back_wizard',
+        'hermes_coming_soon_explore'
+    ];
+
+    test.each(requiredKeys)('en has %s', (key) => {
+        expect(T.en[key]).toBeDefined();
+        expect(T.en[key]).toEqual(expect.any(String));
+        expect(T.en[key].length).toBeGreaterThan(0);
+    });
+
+    test.each(requiredKeys)('zh has %s', (key) => {
+        expect(T.zh[key]).toBeDefined();
+        expect(T.zh[key]).toEqual(expect.any(String));
+        expect(T.zh[key].length).toBeGreaterThan(0);
+    });
+
+    test('zh translations differ from en (real translation, not copy)', () => {
+        for (const key of requiredKeys) {
+            expect(T.zh[key]).not.toBe(T.en[key]);
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Adds the Track 5 option in the onboarding wizard with a dedicated Coming Soon page (`/portal/onboarding/hermes-coming-soon.html`)
- Wires the existing Track 5 card in `onboarding.html` to the new placeholder (no longer `data-disabled`) and adds `trackRoutes['5']` entry
- Sets `eclaw_tour_track5_seen` localStorage flag on view so repeat sessions know it was seen
- Full i18n for **en + zh** (6 new keys); the 10 other locales fall back to English as per task spec
- Static audit Jest test at `tests/jest/onboarding-track5-hermes.test.js` covers page existence, wizard routing, localStorage flag, notify button (mailto), and all required i18n keys in en+zh

## Files changed
- `backend/public/portal/onboarding/hermes-coming-soon.html` (new — Coming Soon placeholder page)
- `backend/public/portal/onboarding.html` (Track 5 card route + `trackRoutes['5']`)
- `backend/public/shared/i18n.js` (6 Hermes keys × en/zh)
- `backend/tests/jest/onboarding-track5-hermes.test.js` (new — regression test)

## Dependencies
Parent card `card_bf73d1b3a231a397efe7c13a` (Onboarding wizard) already ships the Track 5 card as a disabled placeholder — this PR unlocks the card and points it at a dedicated Coming Soon page. No further parent-card dependency.

## Test plan
- [x] `cd backend && npm test -- --testPathPattern=onboarding-track5-hermes` (22 new tests pass)
- [x] `cd backend && npm test -- --testPathPattern=i18n-syntax` (mandatory per CLAUDE.md — passes)
- [x] `cd backend && npm run lint` (no new warnings)
- [x] Full Jest suite `npm test` — 1795/1795 pass (pre-existing flaky `transform-cross-route` passed this run)
- [ ] Post-deploy: `curl -I https://eclawbot.com/portal/onboarding/hermes-coming-soon.html` → 200
- [ ] Post-deploy: manual check that wizard Track 5 card routes to the new page

## Notes
No backend route added — `/portal/*` static middleware already serves the subdirectory. Pure frontend change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)