### PR TITLE
feat(onboarding): Track 2 product tour — paid e-coin bot rental

### DIFF
--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -1237,10 +1237,10 @@
     // Apply i18n translations to static data-i18n elements
     if (typeof i18n !== 'undefined') i18n.apply();
 
-    // Auto-switch to rental tab if URL hash is #rental OR tour=track1 is in URL
+    // Auto-switch to rental tab if URL hash is #rental OR a tour requests it
     const _tourParam = new URLSearchParams(location.search).get('tour');
     const _tourStep = parseInt(new URLSearchParams(location.search).get('step') || '0', 10);
-    if (location.hash === '#rental' || _tourParam === 'track1') {
+    if (location.hash === '#rental' || _tourParam === 'track1' || _tourParam === 'track2') {
         const rentalChip = document.querySelector('.plaza-chip[data-filter="rental"]');
         if (rentalChip) { setFilter('rental', rentalChip); } else { loadBots(); }
     } else {
@@ -1302,6 +1302,39 @@
                 }
             };
         }
+    })();
+
+    /* ══════ Onboarding Tour (Track 2: Paid e-coin Bot Rental) — steps 1-3 ══════ */
+    (function initTourTrack2() {
+        if (_tourParam !== 'track2') return;
+        if (typeof ProductTour === 'undefined') return;
+        if (ProductTour.isDone('track2')) return;
+
+        const WALLET_URL = '/portal/wallet.html?tour=track2&step=4#topup';
+
+        ProductTour.register('track2', [
+            {
+                target: '.plaza-chip[data-filter="rental"]',
+                i18nKey: 'onboarding_tour_track2_step1',
+                fallback: 'Paid and free bots both live here. Track 2 focuses on the paid side.'
+            },
+            {
+                target: () => document.querySelector('#botGrid .bot-card'),
+                i18nKey: 'onboarding_tour_track2_step2',
+                fallback: 'Each card shows the e-coin rate per 1K tokens — that is what you pay as the bot works.',
+                timeout: 12000
+            },
+            {
+                target: () => document.querySelector('#botGrid .bot-card'),
+                i18nKey: 'onboarding_tour_track2_step3',
+                fallback: 'Tap a card to open full terms. We will hop to the wallet next — no charge yet.',
+                timeout: 12000,
+                onNext: () => { window.location.href = WALLET_URL; }
+            }
+        ], { totalSteps: 5 });
+
+        const resumeAt = Math.max(0, Math.min(_tourStep, 2));
+        setTimeout(() => ProductTour.goTo('track2', resumeAt), 400);
     })();
     </script>
 </body>

--- a/backend/public/portal/my-rentals.html
+++ b/backend/public/portal/my-rentals.html
@@ -100,6 +100,7 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
+    <script src="shared/product-tour.js"></script>
     <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid|EClawIOS/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
     <script src="shared/ai-chat.js"></script>
 
@@ -475,7 +476,45 @@
             if (!user) return;
             initPortalSocket();
             loadTab();
+            initTourTrack2Step5();
         });
+
+        /* ══════ Onboarding Tour (Track 2) — Step 5: Rental management ══════ */
+        function initTourTrack2Step5() {
+            const params = new URLSearchParams(location.search);
+            if (params.get('tour') !== 'track2') return;
+            if (typeof ProductTour === 'undefined') return;
+            if (ProductTour.isDone('track2')) return;
+
+            function callMarkComplete() {
+                try {
+                    fetch('/api/user/onboarding/mark-complete', {
+                        method: 'POST',
+                        credentials: 'include',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ track: 'track2', dismissed: false, completedAt: new Date().toISOString() })
+                    }).catch(() => {});
+                } catch (_) { /* best-effort */ }
+                try { localStorage.setItem('eclaw_onboarding_last_seen', new Date().toISOString()); }
+                catch (_) {}
+            }
+
+            ProductTour.register('track2', [
+                {
+                    target: () => document.querySelector('.mr-tabs') || document.body,
+                    i18nKey: 'onboarding_tour_track2_step5',
+                    fallback: "You're all set — active rentals, leased-out bots, and disputes all live here.",
+                    stepNumber: 5,
+                    timeout: 8000,
+                    onNext: callMarkComplete
+                }
+            ], {
+                totalSteps: 5,
+                onDismiss: callMarkComplete
+            });
+
+            setTimeout(() => ProductTour.goTo('track2', 0), 600);
+        }
     </script>
 </body>
 </html>

--- a/backend/public/portal/onboarding.html
+++ b/backend/public/portal/onboarding.html
@@ -254,7 +254,7 @@
 
             const trackRoutes = {
                 '1': '/portal/plaza.html?tour=track1',
-                '2': null,
+                '2': '/portal/community.html?tour=track2#rental',
                 '3': null,
                 '4': null,
                 '5': '/portal/onboarding/hermes-coming-soon.html',

--- a/backend/public/portal/wallet.html
+++ b/backend/public/portal/wallet.html
@@ -226,6 +226,7 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
+    <script src="shared/product-tour.js"></script>
     <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid|EClawIOS/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
     <script src="shared/ai-chat.js"></script>
 
@@ -403,7 +404,33 @@
             initPortalSocket();
 
             await Promise.all([loadBalance(), loadTiers(), loadHistory()]);
+            initTourTrack2Step4();
         });
+
+        /* ══════ Onboarding Tour (Track 2) — Step 4: Top-up ══════ */
+        function initTourTrack2Step4() {
+            const params = new URLSearchParams(location.search);
+            if (params.get('tour') !== 'track2') return;
+            if (typeof ProductTour === 'undefined') return;
+            if (ProductTour.isDone('track2')) return;
+
+            ProductTour.register('track2', [
+                {
+                    target: '#tierGrid',
+                    i18nKey: 'onboarding_tour_track2_step4',
+                    fallback: 'Top up e-coin here whenever your balance runs low. Currently Android-only.',
+                    stepNumber: 4,
+                    timeout: 10000,
+                    onNext: () => {
+                        window.location.href = '/portal/my-rentals.html?tour=track2&step=5';
+                    }
+                }
+            ], { totalSteps: 5 });
+
+            const grid = document.getElementById('tierGrid');
+            if (grid && grid.scrollIntoView) grid.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            setTimeout(() => ProductTour.goTo('track2', 0), 500);
+        }
     </script>
 </body>
 </html>

--- a/backend/tests/jest/onboarding-tour.test.js
+++ b/backend/tests/jest/onboarding-tour.test.js
@@ -40,6 +40,10 @@ describe('Scope 0 wizard routes to plaza with tour param', () => {
     test("trackRoutes['1'] points to plaza.html?tour=track1", () => {
         expect(html).toMatch(/'1':\s*'\/portal\/plaza\.html\?tour=track1'/);
     });
+
+    test("trackRoutes['2'] points to community.html?tour=track2", () => {
+        expect(html).toMatch(/'2':\s*'\/portal\/community\.html\?tour=track2[^']*'/);
+    });
 });
 
 describe('plaza.html redirects to community.html preserving query', () => {
@@ -56,7 +60,7 @@ describe('plaza.html redirects to community.html preserving query', () => {
 });
 
 describe('Product tour script is loaded on tour pages', () => {
-    const pages = ['community.html', 'settings.html', 'dashboard.html'];
+    const pages = ['community.html', 'settings.html', 'dashboard.html', 'wallet.html', 'my-rentals.html'];
     test.each(pages)('%s loads shared/product-tour.js', (page) => {
         const html = read(`public/portal/${page}`);
         expect(html).toMatch(/<script\s+src=["'][^"']*product-tour\.js["']/);
@@ -110,6 +114,11 @@ describe('i18n keys for tour callouts are defined in en and zh', () => {
         'onboarding_tour_track1_step3',
         'onboarding_tour_track1_step4',
         'onboarding_tour_track1_step5',
+        'onboarding_tour_track2_step1',
+        'onboarding_tour_track2_step2',
+        'onboarding_tour_track2_step3',
+        'onboarding_tour_track2_step4',
+        'onboarding_tour_track2_step5',
         'onboarding_tour_next',
         'onboarding_tour_finish',
         'onboarding_tour_skip'
@@ -167,5 +176,27 @@ describe('Tour calls site integration', () => {
         const html = read('public/portal/dashboard.html');
         expect(html).toMatch(/onboarding_tour_track1_step5/);
         expect(html).toMatch(/\/api\/user\/onboarding\/mark-complete/);
+    });
+
+    test('community.html registers track2 tour with 3 steps', () => {
+        const html = read('public/portal/community.html');
+        expect(html).toMatch(/ProductTour\.register\(\s*['"]track2['"]/);
+        expect(html).toMatch(/onboarding_tour_track2_step1/);
+        expect(html).toMatch(/onboarding_tour_track2_step2/);
+        expect(html).toMatch(/onboarding_tour_track2_step3/);
+        expect(html).toMatch(/\/portal\/wallet\.html\?tour=track2&step=4/);
+    });
+
+    test('wallet.html hosts track2 step 4 and navigates to my-rentals step 5', () => {
+        const html = read('public/portal/wallet.html');
+        expect(html).toMatch(/onboarding_tour_track2_step4/);
+        expect(html).toMatch(/\/portal\/my-rentals\.html\?tour=track2&step=5/);
+    });
+
+    test('my-rentals.html hosts track2 step 5 and calls mark-complete with track:"track2"', () => {
+        const html = read('public/portal/my-rentals.html');
+        expect(html).toMatch(/onboarding_tour_track2_step5/);
+        expect(html).toMatch(/\/api\/user\/onboarding\/mark-complete/);
+        expect(html).toMatch(/track:\s*['"]track2['"]/);
     });
 });


### PR DESCRIPTION
## Summary
- Scope 0 wizard Track 2 now walks users through paid bot rental end-to-end
- Reuses the existing `product-tour.js` library shipped in #1911; adds track2 steps alongside track1
- Cross-page flow: `community.html` (steps 1-3: rental filter → bot card → rate display) → `wallet.html` (step 4: top-up tier grid) → `my-rentals.html` (step 5: management hub + `POST /api/user/onboarding/mark-complete`)
- Independent `localStorage` keys (`eclaw_tour_track2_{step,done}`) keep tracks decoupled
- i18n keys for track2 already landed in #1912 (en + zh)

## Changed
- `onboarding.html` — `trackRoutes['2']` → `/portal/community.html?tour=track2#rental`
- `community.html` — new `initTourTrack2()` IIFE with 3 steps, shares `#rental` filter auto-apply with track1
- `wallet.html` — loads `product-tour.js`, step 4 spotlights `#tierGrid`, onNext navigates to my-rentals step 5
- `my-rentals.html` — loads `product-tour.js`, step 5 spotlights `.mr-tabs`, onNext/onDismiss posts mark-complete with `track:'track2'`
- `tests/jest/onboarding-tour.test.js` — extends static audit to cover track2 wizard route, page script loads, register call, cross-page URLs, i18n keys

## Test plan
- [x] Jest `onboarding-tour.test.js` + `i18n-syntax.test.js` — 1811/1811 local
- [x] ESLint clean on new code
- [ ] Manual E2E on prod after deploy: open `/portal/community.html?tour=track2#rental` and walk through 5 steps
- [ ] Verify `POST /api/user/onboarding/mark-complete` with `track:'track2'` returns 200 on prod

## Curl smoke (mark-complete endpoint already shipped in #1911)
```
$ curl -sL -X POST https://eclawbot.com/api/user/onboarding/mark-complete \
    -H 'Content-Type: application/json' \
    -d '{"track":"track2","dismissed":false}'
{"success":true,"authenticated":false,"onboarding":{"track":"track2","dismissed":false,"completedAt":"..."}}
```
(Backend endpoint already accepts any string track slug; only the frontend hook is new.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)