### PR TITLE
feat(onboarding): Track 3 product tour — OpenClaw channel binding

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -4386,6 +4386,43 @@
 
             setTimeout(() => ProductTour.goTo('track1', 0), 600);
         })();
+
+        /* ══════ Onboarding Tour (Track 3) — Step 5: Channel entity visible ══════ */
+        (function initTourTrack3Step5() {
+            const params = new URLSearchParams(location.search);
+            if (params.get('tour') !== 'track3') return;
+            if (typeof ProductTour === 'undefined') return;
+            if (ProductTour.isDone('track3')) return;
+
+            function callMarkComplete() {
+                try {
+                    fetch('/api/user/onboarding/mark-complete', {
+                        method: 'POST',
+                        credentials: 'include',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ track: 'track3', dismissed: false, completedAt: new Date().toISOString() })
+                    }).catch(() => {});
+                } catch (_) { /* best-effort */ }
+                try { localStorage.setItem('eclaw_onboarding_last_seen', new Date().toISOString()); }
+                catch (_) {}
+            }
+
+            ProductTour.register('track3', [
+                {
+                    target: () => document.getElementById('entityGrid') || document.body,
+                    i18nKey: 'onboarding_tour_track3_step5',
+                    fallback: "You're all set — once OpenClaw registers, the channel entity shows up here with a ⚡Channel badge.",
+                    stepNumber: 5,
+                    timeout: 8000,
+                    onNext: callMarkComplete
+                }
+            ], {
+                totalSteps: 5,
+                onDismiss: callMarkComplete
+            });
+
+            setTimeout(() => ProductTour.goTo('track3', 0), 600);
+        })();
     </script>
     </main>
 </body>

--- a/backend/public/portal/onboarding.html
+++ b/backend/public/portal/onboarding.html
@@ -255,7 +255,7 @@
             const trackRoutes = {
                 '1': '/portal/plaza.html?tour=track1',
                 '2': '/portal/community.html?tour=track2#rental',
-                '3': null,
+                '3': '/portal/settings.html?tour=track3#channelApiCard',
                 '4': null,
                 '5': '/portal/onboarding/hermes-coming-soon.html',
                 '6': null

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -2023,6 +2023,52 @@
 
             setTimeout(() => ProductTour.goTo('track1', 0), 500);
         })();
+
+        /* ══════ Onboarding Tour (Track 3) — Steps 1-4: OpenClaw channel binding ══════ */
+        (function initTourTrack3() {
+            const params = new URLSearchParams(location.search);
+            if (params.get('tour') !== 'track3') return;
+            if (typeof ProductTour === 'undefined') return;
+            if (ProductTour.isDone('track3')) return;
+
+            const DASHBOARD_URL = '/portal/dashboard.html?tour=track3&step=5';
+
+            ProductTour.register('track3', [
+                {
+                    target: '#channelApiCard',
+                    i18nKey: 'onboarding_tour_track3_step1',
+                    fallback: 'This is the Channel API hub. OpenClaw is a bot ecosystem you can self-host — binding a channel here lets its bots talk through EClaw.',
+                    timeout: 10000
+                },
+                {
+                    target: () => document.getElementById('btnGenChannel') || document.getElementById('channelApiCard'),
+                    i18nKey: 'onboarding_tour_track3_step2',
+                    fallback: 'Press "+ New Key" to generate a one-time API key + secret pair for your OpenClaw instance.',
+                    timeout: 10000
+                },
+                {
+                    target: '#channelApiCard',
+                    i18nKey: 'onboarding_tour_track3_step3',
+                    fallback: 'Copy the key and secret, then paste them into your local openclaw.config.yaml. The secret is shown only once.',
+                    timeout: 10000
+                },
+                {
+                    target: '#channelApiCard',
+                    i18nKey: 'onboarding_tour_track3_step4',
+                    fallback: 'Restart OpenClaw. The plugin auto-registers its webhook and the first bot message verifies the connection end-to-end.',
+                    timeout: 10000,
+                    onNext: () => { window.location.href = DASHBOARD_URL; }
+                }
+            ], { totalSteps: 5 });
+
+            const scrollTarget = document.getElementById('channelApiCard');
+            if (scrollTarget && scrollTarget.scrollIntoView) {
+                scrollTarget.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            }
+
+            const resumeAt = Math.max(0, Math.min(parseInt(params.get('step') || '1', 10) - 1, 3));
+            setTimeout(() => ProductTour.goTo('track3', resumeAt), 500);
+        })();
     </script>
     </main>
 </body>

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -4232,6 +4232,13 @@ const TRANSLATIONS = {
         "onboarding_tour_track2_step4": "Top up e-coin here whenever your balance runs low. Currently Android-only via Google Play.",
         "onboarding_tour_track2_step5": "You're all set — active rentals, leased-out bots, and any disputes all live on this page.",
 
+        // Scope 0 → Track 3: OpenClaw channel binding tour (product-tour.js)
+        "onboarding_tour_track3_step1": "This is the Channel API hub. OpenClaw is a bot ecosystem you can self-host — binding a channel lets its bots talk through EClaw.",
+        "onboarding_tour_track3_step2": "Press \"+ New Key\" to generate a one-time API key + secret pair for your OpenClaw instance.",
+        "onboarding_tour_track3_step3": "Copy the key and secret, then paste them into your local openclaw.config.yaml. The secret is shown only once.",
+        "onboarding_tour_track3_step4": "Restart OpenClaw. The plugin auto-registers its webhook and the first bot message verifies the connection end-to-end.",
+        "onboarding_tour_track3_step5": "You're all set — once OpenClaw registers, the channel entity shows up here with a ⚡Channel badge.",
+
         // Scope 0 → Track 5: Hermes channel (coming soon)
         "hermes_coming_soon_title": "Hermes channel — Coming Soon",
         "hermes_coming_soon_badge": "Coming Soon",
@@ -8242,6 +8249,13 @@ const TRANSLATIONS = {
         "onboarding_tour_track2_step3": "點卡片看完整租借條件。我們下一步會帶你到錢包，這個 tour 不會實際扣款。",
         "onboarding_tour_track2_step4": "e幣 不夠時就在這裡儲值（目前只能從 Android App 內 Google Play 購買）。",
         "onboarding_tour_track2_step5": "完成啦！你的租約、出租 bot、爭議都會出現在這一頁。",
+
+        // Scope 0 → Track 3: OpenClaw channel binding tour (product-tour.js)
+        "onboarding_tour_track3_step1": "這裡是 Channel API 管理中心。OpenClaw 是你可以自己架的 bot 生態系 — 綁定 channel 讓 OpenClaw 的 bot 透過 EClaw 收發訊息。",
+        "onboarding_tour_track3_step2": "點「+ New Key」產生一組一次性的 API key + secret，給你本地的 OpenClaw 使用。",
+        "onboarding_tour_track3_step3": "複製 key 與 secret，貼進你本地的 openclaw.config.yaml。Secret 只顯示一次，關掉就再也拿不回來。",
+        "onboarding_tour_track3_step4": "重啟 OpenClaw。Plugin 會自動註冊 webhook，第一則 bot 訊息會驗證連線是否打通。",
+        "onboarding_tour_track3_step5": "完成啦！OpenClaw 註冊成功後，channel entity 會顯示在這裡，標著 ⚡Channel 徽章。",
 
         // Scope 0 → Track 5: Hermes channel (coming soon)
         "hermes_coming_soon_title": "Hermes channel — 即將推出",

--- a/backend/tests/jest/onboarding-tour.test.js
+++ b/backend/tests/jest/onboarding-tour.test.js
@@ -44,6 +44,10 @@ describe('Scope 0 wizard routes to plaza with tour param', () => {
     test("trackRoutes['2'] points to community.html?tour=track2", () => {
         expect(html).toMatch(/'2':\s*'\/portal\/community\.html\?tour=track2[^']*'/);
     });
+
+    test("trackRoutes['3'] points to settings.html?tour=track3", () => {
+        expect(html).toMatch(/'3':\s*'\/portal\/settings\.html\?tour=track3[^']*'/);
+    });
 });
 
 describe('plaza.html redirects to community.html preserving query', () => {
@@ -119,6 +123,11 @@ describe('i18n keys for tour callouts are defined in en and zh', () => {
         'onboarding_tour_track2_step3',
         'onboarding_tour_track2_step4',
         'onboarding_tour_track2_step5',
+        'onboarding_tour_track3_step1',
+        'onboarding_tour_track3_step2',
+        'onboarding_tour_track3_step3',
+        'onboarding_tour_track3_step4',
+        'onboarding_tour_track3_step5',
         'onboarding_tour_next',
         'onboarding_tour_finish',
         'onboarding_tour_skip'
@@ -198,5 +207,21 @@ describe('Tour calls site integration', () => {
         expect(html).toMatch(/onboarding_tour_track2_step5/);
         expect(html).toMatch(/\/api\/user\/onboarding\/mark-complete/);
         expect(html).toMatch(/track:\s*['"]track2['"]/);
+    });
+
+    test('settings.html registers track3 tour with 4 steps and navigates to dashboard step 5', () => {
+        const html = read('public/portal/settings.html');
+        expect(html).toMatch(/ProductTour\.register\(\s*['"]track3['"]/);
+        expect(html).toMatch(/onboarding_tour_track3_step1/);
+        expect(html).toMatch(/onboarding_tour_track3_step2/);
+        expect(html).toMatch(/onboarding_tour_track3_step3/);
+        expect(html).toMatch(/onboarding_tour_track3_step4/);
+        expect(html).toMatch(/\/portal\/dashboard\.html\?tour=track3&step=5/);
+    });
+
+    test('dashboard.html hosts track3 step 5 and calls mark-complete with track:"track3"', () => {
+        const html = read('public/portal/dashboard.html');
+        expect(html).toMatch(/onboarding_tour_track3_step5/);
+        expect(html).toMatch(/track:\s*['"]track3['"]/);
     });
 });


### PR DESCRIPTION
## Summary
- Scope 0 wizard Track 3 walks users through self-hosted OpenClaw channel binding
- Reuses existing `product-tour.js` library; no new tour lib
- Cross-page flow: `settings.html` (steps 1-4: Channel API card → + New Key → copy key → restart OpenClaw) → `dashboard.html` (step 5: ⚡Channel entity badge) → `POST /api/user/onboarding/mark-complete`
- No in-portal "Test Connection" button exists (verification is the first round-trip message). Tour teaches the out-of-portal config flow via callout text instead.
- Independent `localStorage` keys (`eclaw_tour_track3_{step,done}`) keep tours decoupled
- 5 i18n keys added (en + zh); other 10 locales fall back to English

## Changed
- `onboarding.html` — `trackRoutes['3']` → `/portal/settings.html?tour=track3#channelApiCard`
- `settings.html` — new `initTourTrack3()` IIFE with 4 steps, spotlights `#channelApiCard` and `#btnGenChannel`; final step navigates to `dashboard.html?tour=track3&step=5`
- `dashboard.html` — new `initTourTrack3Step5()` IIFE spotlights `#entityGrid`; onNext/onDismiss posts mark-complete with `track:'track3'`
- `shared/i18n.js` — 5 new en + 5 new zh keys (`onboarding_tour_track3_step1..step5`)
- `tests/jest/onboarding-tour.test.js` — extends static audit with track3 wizard route, page register, cross-page URL, i18n key presence

## Test plan
- [x] Jest `onboarding-tour.test.js` + `i18n-syntax.test.js` — 1824/1824 local
- [x] ESLint clean on new code
- [ ] Manual E2E on prod after deploy: open `/portal/settings.html?tour=track3#channelApiCard` and walk through 5 steps
- [ ] Verify `POST /api/user/onboarding/mark-complete` with `track:'track3'` returns 200 on prod

## Curl smoke (mark-complete endpoint already shipped in #1911)
```
$ curl -sL -X POST https://eclawbot.com/api/user/onboarding/mark-complete \
    -H 'Content-Type: application/json' \
    -d '{"track":"track3","dismissed":false}'
{"success":true,"authenticated":false,"onboarding":{"track":"track3",...}}
```
(Backend endpoint accepts any track slug; only the frontend hook is new.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)