### PR TITLE
feat(onboarding): Track 4 product tour — Claude channel binding

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -4423,6 +4423,43 @@
 
             setTimeout(() => ProductTour.goTo('track3', 0), 600);
         })();
+
+        /* ══════ Onboarding Tour (Track 4) — Step 5: Verify Claude binding ══════ */
+        (function initTourTrack4Step5() {
+            const params = new URLSearchParams(location.search);
+            if (params.get('tour') !== 'track4') return;
+            if (typeof ProductTour === 'undefined') return;
+            if (ProductTour.isDone('track4')) return;
+
+            function callMarkComplete() {
+                try {
+                    fetch('/api/user/onboarding/mark-complete', {
+                        method: 'POST',
+                        credentials: 'include',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ track: 'track4', dismissed: false, completedAt: new Date().toISOString() })
+                    }).catch(() => {});
+                } catch (_) { /* best-effort */ }
+                try { localStorage.setItem('eclaw_onboarding_last_seen', new Date().toISOString()); }
+                catch (_) {}
+            }
+
+            ProductTour.register('track4', [
+                {
+                    target: () => document.getElementById('entityGrid') || document.body,
+                    i18nKey: 'onboarding_tour_track4_step5',
+                    fallback: "You're all set — open any bot here and send a message. The first reply confirms Claude is wired up.",
+                    stepNumber: 5,
+                    timeout: 8000,
+                    onNext: callMarkComplete
+                }
+            ], {
+                totalSteps: 5,
+                onDismiss: callMarkComplete
+            });
+
+            setTimeout(() => ProductTour.goTo('track4', 0), 600);
+        })();
     </script>
     </main>
 </body>

--- a/backend/public/portal/env-vars.html
+++ b/backend/public/portal/env-vars.html
@@ -335,6 +335,7 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
+    <script src="shared/product-tour.js"></script>
     <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid|EClawIOS/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
     <script src="shared/ai-chat.js"></script>
     <script>
@@ -577,7 +578,49 @@
             renderAll();
             renderBotHint();
             syncVarsToServer(); // sync on page load
+            initTourTrack4();
         });
+
+        /* ══════ Onboarding Tour (Track 4) — Steps 1-4: Claude channel binding ══════ */
+        function initTourTrack4() {
+            const params = new URLSearchParams(location.search);
+            if (params.get('tour') !== 'track4') return;
+            if (typeof ProductTour === 'undefined') return;
+            if (ProductTour.isDone('track4')) return;
+
+            const DASHBOARD_URL = '/portal/dashboard.html?tour=track4&step=5';
+
+            ProductTour.register('track4', [
+                {
+                    target: () => document.getElementById('varsContent') || document.body,
+                    i18nKey: 'onboarding_tour_track4_step1',
+                    fallback: "Claude channel binding lives in device env vars. You'll paste your Anthropic API key here so bots answer via Claude directly.",
+                    timeout: 10000
+                },
+                {
+                    target: '#addVarBtn',
+                    i18nKey: 'onboarding_tour_track4_step2',
+                    fallback: "First grab a key from console.anthropic.com/settings/keys — then press + Add to create a new env var.",
+                    timeout: 10000
+                },
+                {
+                    target: '#addVarBtn',
+                    i18nKey: 'onboarding_tour_track4_step3',
+                    fallback: "Name the var ANTHROPIC_API_KEY (uppercase) and paste your sk-ant-... secret. It will be AES-encrypted server-side.",
+                    timeout: 10000
+                },
+                {
+                    target: '#addVarBtn',
+                    i18nKey: 'onboarding_tour_track4_step4',
+                    fallback: "Optional extras via the same + Add dialog: ANTHROPIC_MODEL (claude-opus-4-7 / -sonnet-4-6 / -haiku-4-5) and ANTHROPIC_MAX_TOKENS to cap usage.",
+                    timeout: 10000,
+                    onNext: () => { window.location.href = DASHBOARD_URL; }
+                }
+            ], { totalSteps: 5 });
+
+            const resumeAt = Math.max(0, Math.min(parseInt(params.get('step') || '1', 10) - 1, 3));
+            setTimeout(() => ProductTour.goTo('track4', resumeAt), 500);
+        }
     </script>
     </main>
 </body>

--- a/backend/public/portal/onboarding.html
+++ b/backend/public/portal/onboarding.html
@@ -256,7 +256,7 @@
                 '1': '/portal/plaza.html?tour=track1',
                 '2': '/portal/community.html?tour=track2#rental',
                 '3': '/portal/settings.html?tour=track3#channelApiCard',
-                '4': null,
+                '4': '/portal/env-vars.html?tour=track4',
                 '5': '/portal/onboarding/hermes-coming-soon.html',
                 '6': '/arena/?tour=track6'
             };

--- a/backend/tests/jest/onboarding-tour.test.js
+++ b/backend/tests/jest/onboarding-tour.test.js
@@ -49,6 +49,10 @@ describe('Scope 0 wizard routes to plaza with tour param', () => {
         expect(html).toMatch(/'3':\s*'\/portal\/settings\.html\?tour=track3[^']*'/);
     });
 
+    test("trackRoutes['4'] points to env-vars.html?tour=track4", () => {
+        expect(html).toMatch(/'4':\s*'\/portal\/env-vars\.html\?tour=track4[^']*'/);
+    });
+
     test("trackRoutes['6'] points to /arena/?tour=track6", () => {
         expect(html).toMatch(/'6':\s*'\/arena\/\?tour=track6'/);
     });
@@ -68,7 +72,7 @@ describe('plaza.html redirects to community.html preserving query', () => {
 });
 
 describe('Product tour script is loaded on tour pages', () => {
-    const pages = ['community.html', 'settings.html', 'dashboard.html', 'wallet.html', 'my-rentals.html'];
+    const pages = ['community.html', 'settings.html', 'dashboard.html', 'wallet.html', 'my-rentals.html', 'env-vars.html'];
     test.each(pages)('%s loads shared/product-tour.js', (page) => {
         const html = read(`public/portal/${page}`);
         expect(html).toMatch(/<script\s+src=["'][^"']*product-tour\.js["']/);
@@ -132,6 +136,11 @@ describe('i18n keys for tour callouts are defined in en and zh', () => {
         'onboarding_tour_track3_step3',
         'onboarding_tour_track3_step4',
         'onboarding_tour_track3_step5',
+        'onboarding_tour_track4_step1',
+        'onboarding_tour_track4_step2',
+        'onboarding_tour_track4_step3',
+        'onboarding_tour_track4_step4',
+        'onboarding_tour_track4_step5',
         'onboarding_tour_track6_step1',
         'onboarding_tour_track6_step2',
         'onboarding_tour_track6_step3',
@@ -216,6 +225,22 @@ describe('Tour calls site integration', () => {
         expect(html).toMatch(/onboarding_tour_track2_step5/);
         expect(html).toMatch(/\/api\/user\/onboarding\/mark-complete/);
         expect(html).toMatch(/track:\s*['"]track2['"]/);
+    });
+
+    test('env-vars.html registers track4 tour with 4 steps and navigates to dashboard step 5', () => {
+        const html = read('public/portal/env-vars.html');
+        expect(html).toMatch(/ProductTour\.register\(\s*['"]track4['"]/);
+        expect(html).toMatch(/onboarding_tour_track4_step1/);
+        expect(html).toMatch(/onboarding_tour_track4_step2/);
+        expect(html).toMatch(/onboarding_tour_track4_step3/);
+        expect(html).toMatch(/onboarding_tour_track4_step4/);
+        expect(html).toMatch(/\/portal\/dashboard\.html\?tour=track4&step=5/);
+    });
+
+    test('dashboard.html hosts track4 step 5 and calls mark-complete with track:"track4"', () => {
+        const html = read('public/portal/dashboard.html');
+        expect(html).toMatch(/onboarding_tour_track4_step5/);
+        expect(html).toMatch(/track:\s*['"]track4['"]/);
     });
 
     test('settings.html registers track3 tour with 4 steps and navigates to dashboard step 5', () => {


### PR DESCRIPTION
## Summary
- Scope 0 wizard Track 4 walks users through binding their own Anthropic API key so bots can be powered by Claude directly
- Reuses existing `product-tour.js` library; no new tour lib
- Cross-page flow: `env-vars.html` (steps 1-4: intro → + Add → name `ANTHROPIC_API_KEY` → optional model/max-tokens) → `dashboard.html` (step 5: verify via test message) → `POST /api/user/onboarding/mark-complete`
- **No dedicated Claude UI exists** — binding is env-var based. Tour teaches the env-var path and links to `console.anthropic.com/settings/keys` via callout text. No in-portal "Test Connection" button (verification is implicit on first bot message round-trip).
- Independent `localStorage` keys (`eclaw_tour_track4_{step,done}`) keep tours decoupled
- 5 i18n keys added (en + zh); other 10 locales fall back to English

## Changed
- `onboarding.html` — `trackRoutes['4']` → `/portal/env-vars.html?tour=track4`
- `env-vars.html` — loads `product-tour.js`, new `initTourTrack4()` function registered with 4 steps spotlighting `#varsContent` + `#addVarBtn`; final step navigates to `dashboard.html?tour=track4&step=5`
- `dashboard.html` — new `initTourTrack4Step5()` IIFE; onNext/onDismiss posts mark-complete with `track:'track4'`
- `shared/i18n.js` — 5 new en + 5 new zh keys (`onboarding_tour_track4_step1..step5`)
- `tests/jest/onboarding-tour.test.js` — extends static audit with track4 wizard route, page register, cross-page URL, i18n key presence

## Test plan
- [x] Jest `onboarding-tour.test.js` + `i18n-syntax.test.js` — 1838/1838 local
- [x] ESLint clean on new code
- [ ] Manual E2E on prod after deploy: open `/portal/env-vars.html?tour=track4` and walk 5 steps
- [ ] Verify `POST /api/user/onboarding/mark-complete` with `track:'track4'` returns 200

## Curl smoke (mark-complete endpoint already shipped in #1911)
```
$ curl -sL -X POST https://eclawbot.com/api/user/onboarding/mark-complete \
    -H 'Content-Type: application/json' \
    -d '{"track":"track4","dismissed":false}'
{"success":true,"authenticated":false,"onboarding":{"track":"track4",...}}
```
(Backend endpoint accepts any track slug; only the frontend hook is new.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)