### PR TITLE
feat: Publisher X BYO credentials (multi-tenant Phase 1)

### DIFF
--- a/backend/article-publisher.js
+++ b/backend/article-publisher.js
@@ -603,17 +603,69 @@ router.delete('/hashnode/post/:postId', async (req, res) => {
 // ============================================
 // X (TWITTER) PUBLISH / REPLY / DELETE
 // Uses OAuth 1.0a (HMAC-SHA1) for Twitter API v2
-// Tokens stored in env: X_CONSUMER_KEY, X_CONSUMER_SECRET, X_ACCESS_TOKEN, X_ACCESS_TOKEN_SECRET
+// Tokens resolved in priority order:
+//   1. device-vars vault (per deviceId, BYO credentials) — multi-tenant
+//   2. process.env.X_CONSUMER_KEY / X_CONSUMER_SECRET / X_ACCESS_TOKEN / X_ACCESS_TOKEN_SECRET — fallback (Hank's single-tenant prod)
+//   3. Structured error { error, setup_url } — no creds found
+// The 4 keys are atomic: partial vault (e.g. 3 of 4) is treated as not-set and falls through to env.
 // ============================================
 
 const X_API_BASE = 'https://api.x.com/2';
+const X_CRED_KEYS = ['X_CONSUMER_KEY', 'X_CONSUMER_SECRET', 'X_ACCESS_TOKEN', 'X_ACCESS_TOKEN_SECRET'];
 
-function getXOAuth() {
+// Injected by index.js at mount time; signature: async (deviceId, varName) => string|null
+// Keeps this module decoupled from the encryption/DB layer (same pattern as embedding-client).
+let _getDeviceVar = null;
+function setDeviceVarResolver(fn) {
+    _getDeviceVar = (typeof fn === 'function') ? fn : null;
+}
+
+/**
+ * Resolve the 4 X OAuth 1.0a keys for a given deviceId.
+ * Returns { creds: {consumer_key, consumer_secret, access_token, access_token_secret}, source: 'vault'|'env'|'missing' }
+ * When source === 'missing', caller should return a 400 with setup_url.
+ */
+async function resolveXCreds(deviceId) {
+    // 1. Try vault (all 4 keys must be present — atomic)
+    if (deviceId && typeof _getDeviceVar === 'function') {
+        try {
+            const vaultVals = await Promise.all(X_CRED_KEYS.map(k => _getDeviceVar(deviceId, k)));
+            const allPresent = vaultVals.every(v => typeof v === 'string' && v.length > 0);
+            if (allPresent) {
+                return {
+                    creds: {
+                        consumer_key: vaultVals[0],
+                        consumer_secret: vaultVals[1],
+                        access_token: vaultVals[2],
+                        access_token_secret: vaultVals[3]
+                    },
+                    source: 'vault'
+                };
+            }
+        } catch (_) { /* fall through to env */ }
+    }
+
+    // 2. Env fallback (backward-compat for Hank's single-tenant prod)
+    const envVals = X_CRED_KEYS.map(k => process.env[k]);
+    if (envVals.every(v => typeof v === 'string' && v.length > 0)) {
+        return {
+            creds: {
+                consumer_key: envVals[0],
+                consumer_secret: envVals[1],
+                access_token: envVals[2],
+                access_token_secret: envVals[3]
+            },
+            source: 'env'
+        };
+    }
+
+    // 3. Nothing configured
+    return { creds: null, source: 'missing' };
+}
+
+function buildXOAuth(consumerKey, consumerSecret) {
     return OAuth({
-        consumer: {
-            key: process.env.X_CONSUMER_KEY,
-            secret: process.env.X_CONSUMER_SECRET
-        },
+        consumer: { key: consumerKey, secret: consumerSecret },
         signature_method: 'HMAC-SHA1',
         hash_function(base_string, key) {
             return crypto.createHmac('sha1', key).update(base_string).digest('base64');
@@ -621,17 +673,38 @@ function getXOAuth() {
     });
 }
 
-function getXToken() {
+// Legacy helpers retained for backward compatibility; no longer used on the
+// resolved-cred path (they only read env). Kept so external callers / tests
+// that import them do not break.
+function _getXOAuth() {
+    return buildXOAuth(process.env.X_CONSUMER_KEY, process.env.X_CONSUMER_SECRET);
+}
+
+function _getXToken() {
     return {
         key: process.env.X_ACCESS_TOKEN,
         secret: process.env.X_ACCESS_TOKEN_SECRET
     };
 }
 
-async function xApiRequest(method, path, body = null) {
+// Structured error body for the "no creds configured" case
+const X_CREDS_MISSING = {
+    error: 'X credentials not set for this device',
+    setup_url: '/portal/publisher-setup.html'
+};
+
+async function xApiRequest(method, path, body = null, creds = null) {
     const url = `${X_API_BASE}${path}`;
-    const oauth = getXOAuth();
-    const token = getXToken();
+    // When creds are provided (new multi-tenant path) use them; otherwise fall
+    // back to env (legacy callers that predate resolver injection).
+    const c = creds || {
+        consumer_key: process.env.X_CONSUMER_KEY,
+        consumer_secret: process.env.X_CONSUMER_SECRET,
+        access_token: process.env.X_ACCESS_TOKEN,
+        access_token_secret: process.env.X_ACCESS_TOKEN_SECRET
+    };
+    const oauth = buildXOAuth(c.consumer_key, c.consumer_secret);
+    const token = { key: c.access_token, secret: c.access_token_secret };
     const authHeader = oauth.toHeader(oauth.authorize({ url, method }, token));
 
     const options = {
@@ -669,9 +742,17 @@ async function xApiRequest(method, path, body = null) {
 router.post('/x/media/upload', upload.single('media'), async (req, res) => {
     if (!req.file) return res.status(400).json({ error: 'media file required (multipart field: media)' });
 
+    // Resolve creds (vault → env → missing). deviceId may be in body or query.
+    const deviceId = req.body?.deviceId || req.query?.deviceId || null;
+    const { creds, source } = await resolveXCreds(deviceId);
+    console.log(`[Publisher] X creds resolved from: ${source}${deviceId ? ` (deviceId=${deviceId})` : ''}`);
+    if (!creds) {
+        return res.status(400).json(X_CREDS_MISSING);
+    }
+
     try {
-        const oauth = getXOAuth();
-        const token = getXToken();
+        const oauth = buildXOAuth(creds.consumer_key, creds.consumer_secret);
+        const token = { key: creds.access_token, secret: creds.access_token_secret };
         const uploadUrl = 'https://upload.twitter.com/1.1/media/upload.json';
 
         // Build multipart form-data with base64-encoded media
@@ -703,8 +784,15 @@ router.post('/x/media/upload', upload.single('media'), async (req, res) => {
 
 // POST /api/publisher/x/tweet — Create a tweet (or reply if reply_to is set)
 router.post('/x/tweet', express.json(), async (req, res) => {
-    const { text, reply_to, media_ids } = req.body;
+    const { text, reply_to, media_ids, deviceId } = req.body;
     if (!text) return res.status(400).json({ error: 'text required' });
+
+    // Resolve creds: vault (per deviceId) → env → structured error
+    const { creds, source } = await resolveXCreds(deviceId);
+    console.log(`[Publisher] X creds resolved from: ${source}${deviceId ? ` (deviceId=${deviceId})` : ''}`);
+    if (!creds) {
+        return res.status(400).json(X_CREDS_MISSING);
+    }
 
     try {
         const { text: finalText, truncated, originalWeighted } = truncateTweet(text);
@@ -718,7 +806,7 @@ router.post('/x/tweet', express.json(), async (req, res) => {
             body.media = { media_ids };
         }
 
-        const data = await xApiRequest('POST', '/tweets', body);
+        const data = await xApiRequest('POST', '/tweets', body, creds);
         console.log(`[Publisher] X tweet created: ${data.data?.id} ${reply_to ? '(reply to ' + reply_to + ')' : ''}`);
         res.json({
             success: true,
@@ -738,8 +826,14 @@ router.post('/x/tweet', express.json(), async (req, res) => {
 // DELETE /api/publisher/x/tweet/:tweetId — Delete a tweet
 router.delete('/x/tweet/:tweetId', async (req, res) => {
     const { tweetId } = req.params;
+    const deviceId = req.body?.deviceId || req.query?.deviceId || null;
+    const { creds, source } = await resolveXCreds(deviceId);
+    console.log(`[Publisher] X creds resolved from: ${source}${deviceId ? ` (deviceId=${deviceId})` : ''}`);
+    if (!creds) {
+        return res.status(400).json(X_CREDS_MISSING);
+    }
     try {
-        await xApiRequest('DELETE', `/tweets/${tweetId}`);
+        await xApiRequest('DELETE', `/tweets/${tweetId}`, null, creds);
         console.log(`[Publisher] X tweet deleted: ${tweetId}`);
         res.json({ success: true, platform: 'x', deleted: tweetId });
     } catch (err) {
@@ -750,8 +844,14 @@ router.delete('/x/tweet/:tweetId', async (req, res) => {
 
 // GET /api/publisher/x/me — Get authenticated user info
 router.get('/x/me', async (req, res) => {
+    const deviceId = req.query?.deviceId || null;
+    const { creds, source } = await resolveXCreds(deviceId);
+    console.log(`[Publisher] X creds resolved from: ${source}${deviceId ? ` (deviceId=${deviceId})` : ''}`);
+    if (!creds) {
+        return res.status(400).json(X_CREDS_MISSING);
+    }
     try {
-        const data = await xApiRequest('GET', '/users/me');
+        const data = await xApiRequest('GET', '/users/me', null, creds);
         res.json({ success: true, user: data.data });
     } catch (err) {
         res.status(500).json({ error: err.message });
@@ -2113,4 +2213,17 @@ router.get('/health', async (req, res) => {
     });
 });
 
-module.exports = { router, initPublisherTable, truncateTweet, X_TWEET_WEIGHTED_LIMIT, appendReferralCTA, buildReferralCTA, REFERRAL_CTA_URL, getPlatformsStatus };
+module.exports = {
+    router,
+    initPublisherTable,
+    truncateTweet,
+    X_TWEET_WEIGHTED_LIMIT,
+    appendReferralCTA,
+    buildReferralCTA,
+    REFERRAL_CTA_URL,
+    getPlatformsStatus,
+    // Phase 1 multi-tenant exports (X BYO credentials)
+    setDeviceVarResolver,
+    resolveXCreds,
+    X_CREDS_MISSING
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -14115,6 +14115,10 @@ orgChartModule.initTable(chatPool);
 crossDeviceSettings.initTable(chatPool);
 chatIntegrity.initIntegrityTable(chatPool);
 articlePublisher.initPublisherTable(chatPool);
+// Wire per-device vault resolver for BYO credentials (Phase 1: X/Twitter)
+// Reuses the same helper used by the chat-embedding BYO path (getDeviceVarForEmbedding).
+// Function declaration is hoisted, so it's safe to reference here.
+articlePublisher.setDeviceVarResolver(getDeviceVarForEmbedding);
 
 // Auto-migrate: add delivery tracking + media columns
 chatPool.query(`

--- a/backend/public/portal/publisher-setup.html
+++ b/backend/public/portal/publisher-setup.html
@@ -1,0 +1,311 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow">
+    <title>EClawbot - Publisher X Setup / X 發布設定</title>
+    <meta name="description" content="Save your X (Twitter) OAuth 1.0a credentials to the EClaw device vault.">
+    <link rel="icon" type="image/png" href="assets/favicon-32.png">
+    <link rel="stylesheet" href="shared/style.css">
+    <link rel="canonical" href="https://eclawbot.com/portal/publisher-setup.html">
+    <style>
+        /* Phase-1 publisher BYO setup — minimal, portal-aesthetic shell.
+           No i18n wiring yet; bilingual strings are hardcoded inline so this
+           page ships in a single PR. A dedicated i18n card will migrate
+           these to proper i18n keys later. */
+        main { padding: 24px 16px; }
+        .container { max-width: 640px; margin: 0 auto; }
+
+        .page-title {
+            font-size: 20px; font-weight: 700; color: var(--text);
+            margin: 0 0 4px;
+        }
+        .page-subtitle {
+            font-size: 13px; color: var(--text-secondary);
+            margin: 0 0 20px; line-height: 1.5;
+        }
+
+        .card {
+            background: var(--card);
+            border: 1px solid var(--card-border);
+            border-radius: var(--radius);
+            padding: 20px;
+            margin-bottom: 16px;
+        }
+
+        .section-title {
+            font-size: 13px; font-weight: 600; color: var(--text-secondary);
+            text-transform: uppercase; letter-spacing: 0.5px;
+            margin: 0 0 12px;
+        }
+
+        .field { margin-bottom: 14px; }
+        .field label {
+            display: block; font-size: 13px; font-weight: 500;
+            color: var(--text); margin-bottom: 6px;
+        }
+        .field-hint {
+            font-size: 11px; color: var(--text-muted);
+            margin-top: 4px; line-height: 1.4;
+        }
+
+        .pw-row {
+            display: flex; gap: 6px; align-items: center;
+        }
+        .pw-row input[type="password"],
+        .pw-row input[type="text"] {
+            flex: 1;
+            padding: 10px 12px;
+            background: var(--input-bg);
+            border: 1px solid var(--card-border);
+            border-radius: var(--radius-sm);
+            color: var(--text);
+            font-size: 13px;
+            font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+            outline: none;
+            transition: border-color 0.15s;
+            box-sizing: border-box;
+        }
+        .pw-row input:focus { border-color: var(--primary); }
+        .pw-toggle {
+            background: transparent;
+            border: 1px solid var(--card-border);
+            border-radius: var(--radius-sm);
+            color: var(--text-secondary);
+            cursor: pointer;
+            padding: 9px 10px;
+            font-size: 14px;
+        }
+        .pw-toggle:hover { border-color: var(--primary); color: var(--text); }
+
+        .actions {
+            display: flex; gap: 8px; justify-content: flex-end;
+            margin-top: 16px; flex-wrap: wrap;
+        }
+        .btn {
+            padding: 10px 20px;
+            border-radius: var(--radius-sm);
+            border: 1px solid transparent;
+            font-size: 14px; font-weight: 600;
+            cursor: pointer; font-family: inherit;
+            transition: opacity 0.15s, border-color 0.15s;
+        }
+        .btn:hover { opacity: 0.88; }
+        .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+        .btn-primary { background: var(--primary); color: #fff; }
+        .btn-outline {
+            background: transparent; color: var(--text);
+            border-color: var(--card-border);
+        }
+
+        .result {
+            margin-top: 12px; padding: 10px 12px;
+            border-radius: var(--radius-sm); font-size: 13px;
+            display: none;
+        }
+        .result.success {
+            background: rgba(76,175,80,0.12);
+            border: 1px solid rgba(76,175,80,0.35);
+            color: var(--success, #4caf50);
+        }
+        .result.error {
+            background: rgba(211,47,47,0.1);
+            border: 1px solid rgba(211,47,47,0.35);
+            color: var(--danger, #f44336);
+        }
+
+        .help {
+            font-size: 12px; color: var(--text-muted);
+            line-height: 1.6; margin-top: 4px;
+        }
+        .help a { color: var(--primary); }
+
+        #loadingState { padding: 40px 0; text-align: center; color: var(--text-secondary); }
+    </style>
+</head>
+
+<body>
+    <main>
+        <div class="container">
+
+            <div id="loadingState">Loading… / 載入中…</div>
+
+            <div id="pageContent" style="display:none;">
+                <h1 class="page-title">X (Twitter) Publisher Setup / X 發布設定</h1>
+                <p class="page-subtitle">
+                    Save your 4 X OAuth 1.0a keys to the device vault. Your bot will use these
+                    credentials when publishing tweets — no one else can read them.<br>
+                    將你的 4 組 X OAuth 1.0a 金鑰儲存至裝置保管庫。機器人發推時會使用這些憑證，其他人無法讀取。
+                </p>
+
+                <div class="card">
+                    <div class="section-title">Credentials / 憑證</div>
+
+                    <div class="field">
+                        <label for="xConsumerKey">Consumer Key / 消費者金鑰</label>
+                        <div class="pw-row">
+                            <input type="password" id="xConsumerKey" autocomplete="off" spellcheck="false">
+                            <button type="button" class="pw-toggle" onclick="togglePw('xConsumerKey', this)">👁</button>
+                        </div>
+                        <div class="field-hint">From X Developer Portal → App → Keys and tokens → API Key.</div>
+                    </div>
+
+                    <div class="field">
+                        <label for="xConsumerSecret">Consumer Secret / 消費者密鑰</label>
+                        <div class="pw-row">
+                            <input type="password" id="xConsumerSecret" autocomplete="off" spellcheck="false">
+                            <button type="button" class="pw-toggle" onclick="togglePw('xConsumerSecret', this)">👁</button>
+                        </div>
+                        <div class="field-hint">Paired with the Consumer Key. AKA "API Key Secret".</div>
+                    </div>
+
+                    <div class="field">
+                        <label for="xAccessToken">Access Token / 存取權杖</label>
+                        <div class="pw-row">
+                            <input type="password" id="xAccessToken" autocomplete="off" spellcheck="false">
+                            <button type="button" class="pw-toggle" onclick="togglePw('xAccessToken', this)">👁</button>
+                        </div>
+                        <div class="field-hint">Generated in X Developer Portal under your App → Keys and tokens → Access Token.</div>
+                    </div>
+
+                    <div class="field">
+                        <label for="xAccessTokenSecret">Access Token Secret / 存取權杖密鑰</label>
+                        <div class="pw-row">
+                            <input type="password" id="xAccessTokenSecret" autocomplete="off" spellcheck="false">
+                            <button type="button" class="pw-toggle" onclick="togglePw('xAccessTokenSecret', this)">👁</button>
+                        </div>
+                        <div class="field-hint">Paired with the Access Token.</div>
+                    </div>
+
+                    <p class="help">
+                        All 4 keys are required (atomic). Values are AES-256-GCM encrypted server-side
+                        with your device's seal key before storage.<br>
+                        4 組金鑰皆為必填（原子性）。伺服器以 AES-256-GCM 加密後儲存，使用你裝置專屬的密封金鑰。
+                    </p>
+
+                    <div class="actions">
+                        <button type="button" class="btn btn-outline" onclick="clearForm()">Clear / 清空</button>
+                        <button type="button" class="btn btn-primary" id="saveBtn" onclick="saveToVault()">
+                            Save to vault / 儲存至保管庫
+                        </button>
+                    </div>
+
+                    <div id="result" class="result"></div>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <script src="shared/auth.js"></script>
+    <script src="shared/api.js"></script>
+    <script>
+        // Phase-1 publisher BYO setup script.
+        // Matches the embed-context bootstrap used by env-vars.html: we rely on
+        // checkAuth() to resolve currentUser (which includes deviceId + deviceSecret),
+        // whether the page is loaded standalone, via ?embed=1 in the mobile WebView,
+        // or via the iOS/Android URL-param auth fallback.
+
+        const X_KEYS = [
+            ['xConsumerKey',       'X_CONSUMER_KEY'],
+            ['xConsumerSecret',    'X_CONSUMER_SECRET'],
+            ['xAccessToken',       'X_ACCESS_TOKEN'],
+            ['xAccessTokenSecret', 'X_ACCESS_TOKEN_SECRET']
+        ];
+
+        function togglePw(id, btn) {
+            const el = document.getElementById(id);
+            if (!el) return;
+            el.type = el.type === 'password' ? 'text' : 'password';
+            btn.textContent = el.type === 'password' ? '👁' : '🙈';
+        }
+
+        function clearForm() {
+            for (const [id] of X_KEYS) {
+                const el = document.getElementById(id);
+                if (el) el.value = '';
+            }
+            hideResult();
+        }
+
+        function showResult(msg, kind) {
+            const el = document.getElementById('result');
+            el.textContent = msg;
+            el.className = 'result ' + (kind === 'success' ? 'success' : 'error');
+            el.style.display = 'block';
+        }
+
+        function hideResult() {
+            const el = document.getElementById('result');
+            el.style.display = 'none';
+            el.textContent = '';
+        }
+
+        async function saveToVault() {
+            hideResult();
+            if (!window.currentUser || !window.currentUser.deviceId || !window.currentUser.deviceSecret) {
+                showResult('Not authenticated. / 尚未登入。', 'error');
+                return;
+            }
+
+            // Collect values; all 4 are required (atomic)
+            const vars = {};
+            const missing = [];
+            for (const [id, keyName] of X_KEYS) {
+                const v = (document.getElementById(id).value || '').trim();
+                if (!v) { missing.push(keyName); continue; }
+                vars[keyName] = v;
+            }
+            if (missing.length > 0) {
+                showResult('All 4 keys are required (missing: ' + missing.join(', ') + ') / 4 組金鑰皆為必填', 'error');
+                return;
+            }
+
+            const btn = document.getElementById('saveBtn');
+            btn.disabled = true;
+            btn.textContent = 'Saving… / 儲存中…';
+
+            try {
+                // POST /api/device-vars with source=web performs a merge that preserves
+                // existing keys from other sources (APP) while updating our 4 X keys.
+                const result = await apiCall('POST', '/api/device-vars', {
+                    deviceId: window.currentUser.deviceId,
+                    deviceSecret: window.currentUser.deviceSecret,
+                    vars,
+                    source: 'web'
+                });
+
+                if (result && result.success) {
+                    showResult(
+                        'Saved. Your bot can now publish to X using these credentials. / '
+                        + '已儲存。機器人現在可以使用這些憑證發布至 X。',
+                        'success'
+                    );
+                } else {
+                    showResult(
+                        'Save failed: ' + ((result && result.error) || 'unknown error'),
+                        'error'
+                    );
+                }
+            } catch (e) {
+                showResult('Save failed: ' + (e.message || e) + ' / 儲存失敗', 'error');
+            } finally {
+                btn.disabled = false;
+                btn.textContent = 'Save to vault / 儲存至保管庫';
+            }
+        }
+
+        window.addEventListener('DOMContentLoaded', async () => {
+            try {
+                const user = await checkAuth();
+                if (!user) return; // checkAuth redirects on failure
+                document.getElementById('loadingState').style.display = 'none';
+                document.getElementById('pageContent').style.display = 'block';
+            } catch (e) {
+                document.getElementById('loadingState').textContent =
+                    'Auth error: ' + (e.message || e);
+            }
+        });
+    </script>
+</body>
+</html>

--- a/backend/tests/jest/card-holder.test.js
+++ b/backend/tests/jest/card-holder.test.js
@@ -181,6 +181,7 @@ jest.mock('../../article-publisher', () => {
     return {
         router: express.Router(),
         initPublisherTable: jest.fn().mockResolvedValue(undefined),
+        setDeviceVarResolver: jest.fn(),
     };
 });
 

--- a/backend/tests/jest/entity-trash.test.js
+++ b/backend/tests/jest/entity-trash.test.js
@@ -188,6 +188,7 @@ jest.mock('../../article-publisher', () => {
     return {
         router: express.Router(),
         initPublisherTable: jest.fn().mockResolvedValue(undefined),
+        setDeviceVarResolver: jest.fn(),
     };
 });
 

--- a/backend/tests/jest/friend-system.test.js
+++ b/backend/tests/jest/friend-system.test.js
@@ -216,6 +216,7 @@ jest.mock('../../article-publisher', () => {
     return {
         router: express.Router(),
         initPublisherTable: jest.fn().mockResolvedValue(undefined),
+        setDeviceVarResolver: jest.fn(),
     };
 });
 

--- a/backend/tests/jest/helpers/mock-setup.js
+++ b/backend/tests/jest/helpers/mock-setup.js
@@ -208,6 +208,7 @@ jest.mock('../../../article-publisher', () => {
     return {
         router: express.Router(),
         initPublisherTable: jest.fn().mockResolvedValue(undefined),
+        setDeviceVarResolver: jest.fn(),
     };
 });
 

--- a/backend/tests/jest/publisher-x-multitenant.test.js
+++ b/backend/tests/jest/publisher-x-multitenant.test.js
@@ -1,0 +1,263 @@
+/**
+ * Phase-1 multi-tenant X publisher tests.
+ *
+ * Covers the credential-resolution order for POST /api/publisher/x/tweet:
+ *   A. Vault returns all 4 keys  → publish uses vault creds (OAuth header signed with vault Consumer Key)
+ *   B. Vault returns nothing     → falls back to process.env.X_*
+ *   C. Vault returns 3 of 4 keys → atomic: treated as not-set → returns
+ *                                  { error: 'X credentials not set for this device', setup_url: '/portal/publisher-setup.html' }
+ *
+ * We exercise `resolveXCreds` directly (unit) for deterministic assertions,
+ * then drive the HTTP route with a stubbed global fetch to prove the creds
+ * flow all the way through to the outbound OAuth header.
+ */
+
+const articlePublisher = require('../../article-publisher');
+const { resolveXCreds, setDeviceVarResolver, X_CREDS_MISSING } = articlePublisher;
+
+const CONSUMER_KEY_VAULT   = 'vault-ck';
+const CONSUMER_SECRET_VAULT = 'vault-cs';
+const ACCESS_TOKEN_VAULT   = 'vault-at';
+const ACCESS_SECRET_VAULT  = 'vault-ats';
+
+const CONSUMER_KEY_ENV     = 'env-ck';
+const CONSUMER_SECRET_ENV  = 'env-cs';
+const ACCESS_TOKEN_ENV     = 'env-at';
+const ACCESS_SECRET_ENV    = 'env-ats';
+
+const ALL_VAULT = {
+    X_CONSUMER_KEY:        CONSUMER_KEY_VAULT,
+    X_CONSUMER_SECRET:     CONSUMER_SECRET_VAULT,
+    X_ACCESS_TOKEN:        ACCESS_TOKEN_VAULT,
+    X_ACCESS_TOKEN_SECRET: ACCESS_SECRET_VAULT,
+};
+
+const PARTIAL_VAULT = {
+    X_CONSUMER_KEY:        CONSUMER_KEY_VAULT,
+    X_CONSUMER_SECRET:     CONSUMER_SECRET_VAULT,
+    X_ACCESS_TOKEN:        ACCESS_TOKEN_VAULT,
+    // X_ACCESS_TOKEN_SECRET deliberately missing → atomic "not-set"
+};
+
+function makeResolver(store) {
+    return async (deviceId, varName) => {
+        if (!store) return null;
+        return Object.prototype.hasOwnProperty.call(store, varName) ? store[varName] : null;
+    };
+}
+
+// ─────────────────────────────────────────────────────────────
+// resolveXCreds — unit tests (deterministic, no HTTP)
+// ─────────────────────────────────────────────────────────────
+
+describe('resolveXCreds — credential resolution order (Phase 1)', () => {
+    const savedEnv = {};
+    beforeEach(() => {
+        for (const k of ['X_CONSUMER_KEY', 'X_CONSUMER_SECRET', 'X_ACCESS_TOKEN', 'X_ACCESS_TOKEN_SECRET']) {
+            savedEnv[k] = process.env[k];
+            delete process.env[k];
+        }
+        setDeviceVarResolver(null);
+    });
+    afterEach(() => {
+        for (const [k, v] of Object.entries(savedEnv)) {
+            if (v === undefined) delete process.env[k]; else process.env[k] = v;
+        }
+        setDeviceVarResolver(null);
+    });
+
+    it('Case A: vault has all 4 keys → resolves from vault (env ignored even if set)', async () => {
+        // Set env to different values — vault must win, never leak into result.
+        process.env.X_CONSUMER_KEY        = CONSUMER_KEY_ENV;
+        process.env.X_CONSUMER_SECRET     = CONSUMER_SECRET_ENV;
+        process.env.X_ACCESS_TOKEN        = ACCESS_TOKEN_ENV;
+        process.env.X_ACCESS_TOKEN_SECRET = ACCESS_SECRET_ENV;
+
+        setDeviceVarResolver(makeResolver(ALL_VAULT));
+        const out = await resolveXCreds('dev-1');
+        expect(out.source).toBe('vault');
+        expect(out.creds).toEqual({
+            consumer_key:        CONSUMER_KEY_VAULT,
+            consumer_secret:     CONSUMER_SECRET_VAULT,
+            access_token:        ACCESS_TOKEN_VAULT,
+            access_token_secret: ACCESS_SECRET_VAULT,
+        });
+    });
+
+    it('Case B: vault returns empty → falls back to process.env.X_*', async () => {
+        process.env.X_CONSUMER_KEY        = CONSUMER_KEY_ENV;
+        process.env.X_CONSUMER_SECRET     = CONSUMER_SECRET_ENV;
+        process.env.X_ACCESS_TOKEN        = ACCESS_TOKEN_ENV;
+        process.env.X_ACCESS_TOKEN_SECRET = ACCESS_SECRET_ENV;
+
+        setDeviceVarResolver(makeResolver({}));
+        const out = await resolveXCreds('dev-1');
+        expect(out.source).toBe('env');
+        expect(out.creds).toEqual({
+            consumer_key:        CONSUMER_KEY_ENV,
+            consumer_secret:     CONSUMER_SECRET_ENV,
+            access_token:        ACCESS_TOKEN_ENV,
+            access_token_secret: ACCESS_SECRET_ENV,
+        });
+    });
+
+    it('Case B-no-deviceId: no deviceId supplied → skips vault, uses env', async () => {
+        process.env.X_CONSUMER_KEY        = CONSUMER_KEY_ENV;
+        process.env.X_CONSUMER_SECRET     = CONSUMER_SECRET_ENV;
+        process.env.X_ACCESS_TOKEN        = ACCESS_TOKEN_ENV;
+        process.env.X_ACCESS_TOKEN_SECRET = ACCESS_SECRET_ENV;
+
+        // Vault resolver set but deviceId=null → resolver must not be consulted
+        const spy = jest.fn().mockResolvedValue(null);
+        setDeviceVarResolver(spy);
+
+        const out = await resolveXCreds(null);
+        expect(out.source).toBe('env');
+        expect(spy).not.toHaveBeenCalled();
+    });
+
+    it('Case C: vault returns 3 of 4 keys → partial treated as not-set, falls through (atomic)', async () => {
+        // No env configured → partial vault triggers the structured "missing" response
+        setDeviceVarResolver(makeResolver(PARTIAL_VAULT));
+        const out = await resolveXCreds('dev-1');
+        expect(out.source).toBe('missing');
+        expect(out.creds).toBeNull();
+    });
+
+    it('Case C-partial-with-env: 3-of-4 vault still falls through to env if env is configured', async () => {
+        // Regression guard: partial vault must NOT poison the env fallback.
+        process.env.X_CONSUMER_KEY        = CONSUMER_KEY_ENV;
+        process.env.X_CONSUMER_SECRET     = CONSUMER_SECRET_ENV;
+        process.env.X_ACCESS_TOKEN        = ACCESS_TOKEN_ENV;
+        process.env.X_ACCESS_TOKEN_SECRET = ACCESS_SECRET_ENV;
+
+        setDeviceVarResolver(makeResolver(PARTIAL_VAULT));
+        const out = await resolveXCreds('dev-1');
+        expect(out.source).toBe('env');
+        expect(out.creds.consumer_key).toBe(CONSUMER_KEY_ENV);
+    });
+
+    it('Case D: neither vault nor env → returns missing sentinel', async () => {
+        setDeviceVarResolver(makeResolver({}));
+        const out = await resolveXCreds('dev-1');
+        expect(out.source).toBe('missing');
+        expect(out.creds).toBeNull();
+    });
+
+    it('X_CREDS_MISSING payload shape includes setup_url', () => {
+        expect(X_CREDS_MISSING).toEqual({
+            error: 'X credentials not set for this device',
+            setup_url: '/portal/publisher-setup.html'
+        });
+    });
+});
+
+// ─────────────────────────────────────────────────────────────
+// POST /api/publisher/x/tweet — integration: creds flow into OAuth
+// ─────────────────────────────────────────────────────────────
+//
+// We mount only the publisher router (not full index.js) to keep the test
+// fast and avoid the chain of module mocks. Outbound fetch is stubbed so we
+// can inspect the OAuth Authorization header and assert the Consumer Key that
+// actually got signed into the request.
+
+describe('POST /api/publisher/x/tweet — credential flow (integration)', () => {
+    let app, request, originalFetch;
+    let savedEnv = {};
+
+    beforeAll(() => {
+        const express = require('express');
+        request = require('supertest');
+        app = express();
+        app.use('/api/publisher', articlePublisher.router);
+        originalFetch = global.fetch;
+    });
+
+    afterAll(() => {
+        global.fetch = originalFetch;
+    });
+
+    beforeEach(() => {
+        for (const k of ['X_CONSUMER_KEY', 'X_CONSUMER_SECRET', 'X_ACCESS_TOKEN', 'X_ACCESS_TOKEN_SECRET']) {
+            savedEnv[k] = process.env[k];
+            delete process.env[k];
+        }
+        setDeviceVarResolver(null);
+        // Stub fetch: always return a successful tweet payload
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: true,
+            status: 200,
+            headers: { get: () => null },
+            text: async () => JSON.stringify({ data: { id: '1234567890', text: 'hi' } })
+        });
+    });
+
+    afterEach(() => {
+        for (const [k, v] of Object.entries(savedEnv)) {
+            if (v === undefined) delete process.env[k]; else process.env[k] = v;
+        }
+        setDeviceVarResolver(null);
+    });
+
+    it('Case A (vault wins): OAuth header contains the vault Consumer Key', async () => {
+        // env intentionally set to the "wrong" key to prove vault takes priority
+        process.env.X_CONSUMER_KEY        = CONSUMER_KEY_ENV;
+        process.env.X_CONSUMER_SECRET     = CONSUMER_SECRET_ENV;
+        process.env.X_ACCESS_TOKEN        = ACCESS_TOKEN_ENV;
+        process.env.X_ACCESS_TOKEN_SECRET = ACCESS_SECRET_ENV;
+
+        setDeviceVarResolver(makeResolver(ALL_VAULT));
+
+        const res = await request(app)
+            .post('/api/publisher/x/tweet')
+            .send({ text: 'hello from vault', deviceId: 'dev-1' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        const [url, opts] = global.fetch.mock.calls[0];
+        expect(url).toBe('https://api.x.com/2/tweets');
+        const authHeader = opts.headers.Authorization || opts.headers.authorization;
+        expect(authHeader).toBeTruthy();
+        // Vault key must be in the OAuth header; env key must not.
+        expect(authHeader).toContain(`oauth_consumer_key="${CONSUMER_KEY_VAULT}"`);
+        expect(authHeader).not.toContain(CONSUMER_KEY_ENV);
+        // And the oauth_token uses the vault access token, not env.
+        expect(authHeader).toContain(`oauth_token="${ACCESS_TOKEN_VAULT}"`);
+    });
+
+    it('Case B (env fallback): no vault match → OAuth header uses env Consumer Key', async () => {
+        process.env.X_CONSUMER_KEY        = CONSUMER_KEY_ENV;
+        process.env.X_CONSUMER_SECRET     = CONSUMER_SECRET_ENV;
+        process.env.X_ACCESS_TOKEN        = ACCESS_TOKEN_ENV;
+        process.env.X_ACCESS_TOKEN_SECRET = ACCESS_SECRET_ENV;
+
+        setDeviceVarResolver(makeResolver({})); // empty vault
+
+        const res = await request(app)
+            .post('/api/publisher/x/tweet')
+            .send({ text: 'hello from env', deviceId: 'dev-1' });
+
+        expect(res.status).toBe(200);
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        const authHeader = global.fetch.mock.calls[0][1].headers.Authorization
+            || global.fetch.mock.calls[0][1].headers.authorization;
+        expect(authHeader).toContain(`oauth_consumer_key="${CONSUMER_KEY_ENV}"`);
+        expect(authHeader).toContain(`oauth_token="${ACCESS_TOKEN_ENV}"`);
+    });
+
+    it('Case C (partial vault, no env): returns structured error with setup_url and does NOT call X', async () => {
+        setDeviceVarResolver(makeResolver(PARTIAL_VAULT));
+
+        const res = await request(app)
+            .post('/api/publisher/x/tweet')
+            .send({ text: 'should not send', deviceId: 'dev-1' });
+
+        expect(res.status).toBe(400);
+        expect(res.body).toEqual({
+            error: 'X credentials not set for this device',
+            setup_url: '/portal/publisher-setup.html'
+        });
+        expect(global.fetch).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Scope (Phase 1)

Lets individual EClaw users publish to X/Twitter using *their own* 4 OAuth 1.0a keys stored in the device-vars vault (BYO credentials). Hank's existing single-tenant prod (keys in `process.env.X_*`) is preserved as the fallback path so nothing breaks.

### Credential resolution order (X path only)
1. **Vault** — `device-vars` lookup per `deviceId`, atomic for all 4 keys (`X_CONSUMER_KEY`, `X_CONSUMER_SECRET`, `X_ACCESS_TOKEN`, `X_ACCESS_TOKEN_SECRET`). Partial (e.g. 3 of 4) → treated as not-set.
2. **Env fallback** — `process.env.X_*` (backward-compat for Hank's prod).
3. **Structured error** — `{ error: "X credentials not set for this device", setup_url: "/portal/publisher-setup.html" }`.

Log emits `[Publisher] X creds resolved from: vault | env | missing` — secrets themselves are never logged.

### Files

| Path | Change |
|---|---|
| `backend/article-publisher.js` | `setDeviceVarResolver` injector, `resolveXCreds` helper, `X_CREDS_MISSING` sentinel; `/x/tweet`, `/x/media/upload`, `/x/tweet/:id` (DELETE), `/x/me` now resolve creds via helper |
| `backend/index.js` | wires `getDeviceVarForEmbedding` (existing helper) as the resolver right after `initPublisherTable` |
| `backend/public/portal/publisher-setup.html` (new) | 4-field password form, POSTs to `/api/device-vars` with `source: "web"`; bilingual EN/zh strings hardcoded (no i18n wiring — see out-of-scope) |
| `backend/tests/jest/publisher-x-multitenant.test.js` (new) | 10 tests — resolveXCreds unit coverage + integration tests hitting `/x/tweet` with stubbed `fetch` to assert the OAuth header contains the correct `oauth_consumer_key` depending on vault/env state |
| `backend/tests/jest/{card-holder,entity-trash,friend-system}.test.js` + `helpers/mock-setup.js` | add `setDeviceVarResolver: jest.fn()` to the `article-publisher` mock so `index.js` init doesn't crash (required because `index.js` now calls that method on the real module) |

## Out of scope (explicitly deferred)

- i18n translation files for the setup page — will go to a dedicated i18n card per user rule (i18n bot).
- Other publishers (WordPress, Mastodon — retired; Blogger/Hashnode/DEV.to/etc. still env-only in this phase).
- Schema migrations — `device_vars` table already exists; no change needed.
- Onboarding wizard integration — Phase 2.

## E2E verification (local)

Stood up a fresh Postgres in Docker + booted the backend at `:18787` with `SEAL_KEY` + `JWT_SECRET`.

### 1) device-vars round-trip (save 4 fake X keys, read back via botSecret)

```
$ curl -s -X POST http://localhost:18787/api/device-vars \
    -H 'Content-Type: application/json' \
    -d '{"deviceId":"phase1-test-...","deviceSecret":"...","source":"web",
         "vars":{"X_CONSUMER_KEY":"fake_ck_phase1","X_CONSUMER_SECRET":"fake_cs_phase1",
                 "X_ACCESS_TOKEN":"fake_at_phase1","X_ACCESS_TOKEN_SECRET":"fake_ats_phase1"}}'
{"success":true,"count":4,"mergedVars":{"X_CONSUMER_KEY":"fake_ck_phase1",...},...}

$ curl -s "http://localhost:18787/api/device-vars?deviceId=...&botSecret=..."
{"success":true,"vars":{"X_CONSUMER_KEY":"fake_ck_phase1","X_CONSUMER_SECRET":"fake_cs_phase1",
                         "X_ACCESS_TOKEN":"fake_at_phase1","X_ACCESS_TOKEN_SECRET":"fake_ats_phase1"}}
```

### 2) publisher-setup.html served

```
$ curl -s http://localhost:18787/portal/publisher-setup.html | head -n 12
<!DOCTYPE html>
<html lang="en">
<head>
    <meta charset="UTF-8">
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
    <meta name="robots" content="noindex, nofollow">
    <title>EClawbot - Publisher X Setup / X 發布設定</title>
    <meta name="description" content="Save your X (Twitter) OAuth 1.0a credentials to the EClaw device vault.">
    <link rel="icon" type="image/png" href="assets/favicon-32.png">
    <link rel="stylesheet" href="shared/style.css">
    <link rel="canonical" href="https://eclawbot.com/portal/publisher-setup.html">
    <style>
```

### 3) `/api/publisher/x/tweet` resolves from vault vs missing

```
# With deviceId (vault has 4 fake keys) → reaches X API, gets 401 (fake creds, as expected)
$ curl -s -X POST http://localhost:18787/api/publisher/x/tweet \
    -H 'Content-Type: application/json' \
    -d '{"text":"phase1-e2e-test","deviceId":"phase1-test-..."}'
{"error":"Unauthorized","xResponse":{"title":"Unauthorized","type":"about:blank","status":401,...}}

# No deviceId, no env → structured error with setup_url
$ curl -s -X POST http://localhost:18787/api/publisher/x/tweet \
    -H 'Content-Type: application/json' \
    -d '{"text":"no-device-no-env"}'
{"error":"X credentials not set for this device","setup_url":"/portal/publisher-setup.html"}

# Backend log confirms resolver paths:
[Publisher] X creds resolved from: vault (deviceId=phase1-test-...)
[Publisher] X creds resolved from: missing
```

### 4) Jest

```
$ npx jest --testPathPattern=publisher-x-multitenant
PASS tests/jest/publisher-x-multitenant.test.js
  resolveXCreds — credential resolution order (Phase 1)
    ✓ Case A: vault has all 4 keys → resolves from vault (env ignored even if set)
    ✓ Case B: vault returns empty → falls back to process.env.X_*
    ✓ Case B-no-deviceId: no deviceId supplied → skips vault, uses env
    ✓ Case C: vault returns 3 of 4 keys → partial treated as not-set, falls through (atomic)
    ✓ Case C-partial-with-env: 3-of-4 vault still falls through to env if env is configured
    ✓ Case D: neither vault nor env → returns missing sentinel
    ✓ X_CREDS_MISSING payload shape includes setup_url
  POST /api/publisher/x/tweet — credential flow (integration)
    ✓ Case A (vault wins): OAuth header contains the vault Consumer Key
    ✓ Case B (env fallback): no vault match → OAuth header uses env Consumer Key
    ✓ Case C (partial vault, no env): returns structured error with setup_url and does NOT call X

Tests:       10 passed, 10 total

$ npx jest --testPathPattern='publisher|x-tweet-truncate'
Test Suites: 6 passed, 6 total
Tests:       111 passed, 111 total
```

## Next step (Phase 2)

Dogfood migration: Hank is user#1 — commander drives the Railway `X_*` env → vault paste manually post-merge via the `/portal/publisher-setup.html` page (or direct `POST /api/device-vars`). Once Hank's prod deviceId has all 4 vault keys, the env vars can be stripped from Railway.

Card: `card_20288d766a3ee1c094e2a5f2`