### PR TITLE
fix(chat): reply quote + photo attachment conflict

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -4342,6 +4342,25 @@
             setReplyContext(null, senderLabel, previewText);
         }
 
+        function fileMsgText(index, file, text) {
+            if (index === 0 && text) return text;
+            if (file.type === 'photo') return '[Photo]';
+            if (file.type === 'video') return '[Video]';
+            return `[File] ${file.fileName}`;
+        }
+
+        async function crossSpeakSafe(body) {
+            try {
+                await apiCall('POST', '/api/client/cross-speak', body);
+            } catch (err) {
+                if (err.status === 404) {
+                    showToast(i18n.t('chat_contacts_offline_send'), 'error');
+                } else {
+                    throw err;
+                }
+            }
+        }
+
         // ── Send Message ──
         async function sendMessage() {
             const input = document.getElementById('messageInput');
@@ -4352,13 +4371,11 @@
             // Must have text or pending files
             if (!text && !hasFiles) return;
 
-            // Prepend reply quote if active
             let finalText = text;
-            if (replyContext && text) {
+            if (replyContext) {
                 const excerpt = replyContext.text.length > 80 ? replyContext.text.slice(0, 80) + '…' : replyContext.text;
-                finalText = `↩ ${replyContext.senderName}: "${excerpt}"\n\n${text}`;
-                clearReplyContext();
-            } else if (replyContext) {
+                const quotePrefix = `↩ ${replyContext.senderName}: "${excerpt}"`;
+                finalText = text ? `${quotePrefix}\n\n${text}` : quotePrefix;
                 clearReplyContext();
             }
 
@@ -4407,7 +4424,7 @@
                     if (hasFiles) {
                         for (let i = 0; i < readyFiles.length; i++) {
                             const f = readyFiles[i];
-                            const msgText = (i === 0 && finalText) ? finalText : (f.type === 'photo' ? '[Photo]' : f.type === 'video' ? '[Video]' : `[File] ${f.fileName}`);
+                            const msgText = fileMsgText(i, f, finalText);
                             const fileResp = await apiCall('POST', '/api/client/speak', {
                                 deviceId: currentUser.deviceId,
                                 deviceSecret: currentUser.deviceSecret,
@@ -4447,30 +4464,24 @@
                 }
 
                 // ── Cross-device contacts ──
-                if (targets.contacts.length > 0 && finalText) {
-                    // If user explicitly selected a local entity, use it as sender; otherwise owner mode (-1)
+                if (targets.contacts.length > 0 && (finalText || hasFiles)) {
                     const explicitLocal = targets.local.length > 0
                         ? boundEntities.find(e => e.entityId === targets.local[0])
                         : null;
                     const fromEntityId = explicitLocal ? explicitLocal.entityId : -1;
-                    const crossSpeakPromises = targets.contacts.map(async (code) => {
-                        try {
-                            await apiCall('POST', '/api/client/cross-speak', {
-                                deviceId: currentUser.deviceId,
-                                fromEntityId: fromEntityId,
-                                targetCode: code,
-                                text: finalText,
-                                source: 'web_chat'
-                            });
-                        } catch (err) {
-                            if (err.status === 404) {
-                                showToast(i18n.t('chat_contacts_offline_send'), 'error');
-                            } else {
-                                throw err;
-                            }
+                    if (hasFiles) {
+                        for (let i = 0; i < readyFiles.length; i++) {
+                            const f = readyFiles[i];
+                            const msgText = fileMsgText(i, f, finalText);
+                            await Promise.all(targets.contacts.map(code =>
+                                crossSpeakSafe({ deviceId: currentUser.deviceId, fromEntityId, targetCode: code, text: msgText, source: 'web_chat', mediaType: f.type, mediaUrl: f.mediaUrl })
+                            ));
                         }
-                    });
-                    await Promise.all(crossSpeakPromises);
+                    } else {
+                        await Promise.all(targets.contacts.map(code =>
+                            crossSpeakSafe({ deviceId: currentUser.deviceId, fromEntityId, targetCode: code, text: finalText, source: 'web_chat' })
+                        ));
+                    }
                 }
 
                 // Save selected targets

--- a/backend/tests/jest/chat-quote-photo.test.js
+++ b/backend/tests/jest/chat-quote-photo.test.js
@@ -1,0 +1,116 @@
+/**
+ * Regression: chat quote (reply) + photo attachment conflict
+ *
+ * Bug 1: reply context + photo-only (no text) → quote silently dropped
+ * Bug 3: cross-device contacts cannot send photos via /api/client/cross-speak
+ */
+
+require('./helpers/mock-setup');
+
+const request = require('supertest');
+let app;
+
+const get = (path) => request(app).get(path).set('Host', 'localhost');
+const post = (path) => request(app).post(path).set('Host', 'localhost');
+
+async function registerDevice(id) {
+    const secret = `secret-${id}`;
+    await post('/api/device/register')
+        .send({ deviceId: id, deviceSecret: secret, entityId: 0 });
+    return secret;
+}
+
+beforeAll(() => {
+    app = require('../../index');
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+    jest.resetModules();
+});
+
+// ════════════════════════════════════════════════════════════════
+// client/speak accepts mediaType + mediaUrl alongside text (quote caption)
+// ════════════════════════════════════════════════════════════════
+describe('client/speak with media + quote text', () => {
+    it('accepts photo with quote-prefix text (no user body text)', async () => {
+        const deviceSecret = await registerDevice('test-quote-photo-1');
+        await post('/api/bind').send({
+            deviceId: 'test-quote-photo-1', entityId: 0,
+            name: 'QuoteBot', character: '📎', webhook: ''
+        });
+
+        const quotePrefix = '↩ 📌 Kanban: Task title';
+        const res = await post('/api/client/speak').send({
+            deviceId: 'test-quote-photo-1',
+            deviceSecret,
+            entityId: 0,
+            text: quotePrefix,
+            source: 'web_chat',
+            mediaType: 'photo',
+            mediaUrl: 'https://example.com/photo.jpg'
+        });
+
+        expect([200, 201].includes(res.status)).toBe(true);
+        if (res.body.success !== undefined) {
+            expect(res.body.success).toBe(true);
+        }
+    });
+
+    it('accepts photo with empty text (fallback label)', async () => {
+        const deviceSecret = await registerDevice('test-quote-photo-2');
+        await post('/api/bind').send({
+            deviceId: 'test-quote-photo-2', entityId: 0,
+            name: 'PhotoBot', character: '📷', webhook: ''
+        });
+
+        const res = await post('/api/client/speak').send({
+            deviceId: 'test-quote-photo-2',
+            deviceSecret,
+            entityId: 0,
+            text: '[Photo]',
+            source: 'web_chat',
+            mediaType: 'photo',
+            mediaUrl: 'https://example.com/img.png'
+        });
+
+        expect([200, 201].includes(res.status)).toBe(true);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// client/cross-speak accepts mediaType + mediaUrl
+// ════════════════════════════════════════════════════════════════
+describe('client/cross-speak with media', () => {
+    it('accepts mediaType and mediaUrl fields (owner mode)', async () => {
+        await registerDevice('test-cross-media-1');
+
+        const res = await post('/api/client/cross-speak').send({
+            deviceId: 'test-cross-media-1',
+            fromEntityId: -1,
+            targetCode: 'NONEXIST',
+            text: '↩ 📌 Note: summary',
+            source: 'web_chat',
+            mediaType: 'photo',
+            mediaUrl: 'https://example.com/cross-photo.jpg'
+        });
+
+        // 404 = target not found (expected); NOT 400 (field rejection)
+        expect(res.status).toBe(404);
+    });
+
+    it('sends text-only cross-speak without media fields (owner mode)', async () => {
+        await registerDevice('test-cross-media-2');
+
+        const res = await post('/api/client/cross-speak').send({
+            deviceId: 'test-cross-media-2',
+            fromEntityId: -1,
+            targetCode: 'NONEXIST',
+            text: 'Hello cross device',
+            source: 'web_chat'
+        });
+
+        expect(res.status).toBe(404);
+    });
+});


### PR DESCRIPTION
## Summary
- **Bug 1 fix**: Reply/quote context was silently dropped when user sent only a photo (no typed text). Now the quote prefix is always applied to `finalText` regardless of whether the user typed additional text.
- **Bug 3 fix**: Cross-device contacts could not receive photos — the cross-speak path only sent text. Now sends `mediaType` + `mediaUrl` via `/api/client/cross-speak` which already supports these fields.
- **Code quality**: Extracted `fileMsgText()` and `crossSpeakSafe()` helpers to deduplicate identical logic between local and cross-device send paths.

## Test plan
- [x] New Jest test `chat-quote-photo.test.js` — 4 cases (quote+photo speak, photo-only speak, cross-speak with media, cross-speak text-only)
- [x] Existing `chat.test.js` — all 17 tests pass
- [x] Existing `cross-speak.test.js` — all 26 tests pass
- [x] `simplify` skill review completed (reuse, quality, efficiency)

https://claude.ai/code/session_01MeRFTjGcCKpSvRwMbdnFyX