### PR TITLE
wire(kanban): data-i18n on sort dropdown options

### DIFF
--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -429,10 +429,10 @@
                     <button class="kb-chip" data-filter="mine" data-i18n="kb_filter_mine" onclick="filterCards('mine')">My Cards</button>
                 </div>
                 <select class="kb-sort-select" onchange="sortCards(this.value)">
-                    <option value="default">Default Order</option>
-                    <option value="created_desc">Newest First</option>
-                    <option value="created_asc">Oldest First</option>
-                    <option value="priority_asc">High Priority First</option>
+                    <option value="default" data-i18n="kb_sort_default">Default Order</option>
+                    <option value="created_desc" data-i18n="kb_sort_newest">Newest First</option>
+                    <option value="created_asc" data-i18n="kb_sort_oldest">Oldest First</option>
+                    <option value="priority_asc" data-i18n="kb_sort_priority">High Priority First</option>
                 </select>
                 <button class="btn btn-primary" data-i18n="kb_new_card_btn" onclick="openNewCard()">+ New Card</button>
             </div>


### PR DESCRIPTION
## Summary
Wire the 4 `<option>` tags in the kanban sort dropdown to the `kb_sort_*` i18n keys shipped in PR #1927 (EN) and PR #1928 (zh-TW).

## Changes
- `backend/public/portal/kanban.html` (line 432-435): add `data-i18n="kb_sort_default|newest|oldest|priority"` to the 4 options.

## Depends on
- PR #1924 (sort dropdown base) — merged
- PR #1927 (EN keys) — merged
- PR #1928 (zh-TW keys) — merged
- PR #1929/#1930/#1931 (ja/ko/de keys) — CHANGES REQUESTED (English copy-paste), not blocking this wiring PR because i18n resolver falls back to literal text until keys are in.

## Not in scope
No locale file edits (those are on Mac_E per 1-locale-per-PR rule).

## Test plan
- [ ] Visit kanban portal in EN → dropdown shows "Default Order" / "Newest First" / "Oldest First" / "High Priority First"
- [ ] Switch lang → zh-TW → dropdown shows "預設順序" / "最新建立" / "最舊建立" / "高優先級優先"
- [ ] Switch lang → ja/ko/de → falls back to English literal (expected until #1929/#1930/#1931 corrected + merged)