### PR TITLE
feat(analytics): site_page_views table + pageview middleware (Analytics 1/3)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -13,6 +13,7 @@ const gatekeeper = require('./gatekeeper');
 const mentionParser = require('./mention-parser');
 const pushContext = require('./push-context');
 const telemetry = require('./device-telemetry');
+const sitePageviews = require('./site-pageviews');
 const feedbackModule = require('./device-feedback');
 const chatIntegrity = require('./chat-integrity');
 // JWT secret: fail-safe random per process if env var is missing (tokens signed in one process won't verify in another)
@@ -235,6 +236,11 @@ app.use(express.json({
     }
 }));
 app.use(cookieParser());
+
+// Site pageview tracker — anonymous GETs on marketing / public HTML pages.
+// Pool is wired lazily via setPool() once chatPool exists; tracking is
+// fire-and-forget and silently no-ops when the pool isn't ready.
+app.use(sitePageviews.pageviewMiddleware());
 
 // SEO: serve robots.txt, sitemap.xml, llms.txt at root
 app.get('/robots.txt', (req, res) => {
@@ -14107,6 +14113,8 @@ const chatPool = new Pool({
 // Link telemetry middleware to the real pool
 _telemetryPool = chatPool;
 telemetry.initTelemetryTable(chatPool, serverLog);
+sitePageviews.setPool(chatPool);
+sitePageviews.initPageviewsTable(chatPool);
 feedbackModule.initFeedbackTable(chatPool);
 feedbackModule.initFeedbackPhotosTable(chatPool);
 notifModule.initNotificationTables(chatPool);

--- a/backend/site-pageviews.js
+++ b/backend/site-pageviews.js
@@ -1,0 +1,106 @@
+/**
+ * Site Pageviews Module
+ *
+ * Tracks GET hits on marketing / public HTML pages (landing, enterprise,
+ * privacy, docs, arena, plus any *.html that isn't under portal/api/assets/shared).
+ * Portal pages already ship their own device-scoped telemetry via
+ * /shared/telemetry.js; this module is the anonymous "non-logged-in visitor"
+ * counterpart used by Card #21 (aggregated endpoint) + Card #22 (admin UI).
+ *
+ * Middleware is fire-and-forget: a failed INSERT must never block the user
+ * from getting the page.
+ */
+
+const EXCLUDE_PREFIXES = ['/portal', '/api', '/assets', '/shared'];
+
+// Marketing paths (prefix match, except '/' which is exact). Anything starting
+// with one of these is tracked even if it doesn't end in .html.
+const MARKETING_PREFIXES = ['/landing', '/enterprise', '/privacy-policy', '/docs', '/arena'];
+
+let _pool = null;
+
+function setPool(pool) {
+    _pool = pool;
+}
+
+async function initPageviewsTable(pool) {
+    if (!pool) return;
+    try {
+        await pool.query(`
+            CREATE TABLE IF NOT EXISTS site_page_views (
+                id           BIGSERIAL   PRIMARY KEY,
+                path         TEXT        NOT NULL,
+                ip           TEXT,
+                ua           TEXT,
+                referer      TEXT,
+                utm_source   TEXT,
+                utm_medium   TEXT,
+                utm_campaign TEXT,
+                created_at   TIMESTAMPTZ DEFAULT NOW()
+            )
+        `);
+        await pool.query(`CREATE INDEX IF NOT EXISTS idx_spv_path_ts  ON site_page_views (path, created_at DESC)`);
+        await pool.query(`CREATE INDEX IF NOT EXISTS idx_spv_ts       ON site_page_views (created_at DESC)`);
+        await pool.query(`CREATE INDEX IF NOT EXISTS idx_spv_campaign ON site_page_views (utm_campaign) WHERE utm_campaign IS NOT NULL`);
+        console.log('[Pageviews] Database table ready');
+    } catch (err) {
+        console.error('[Pageviews] Failed to create table:', err.message);
+    }
+}
+
+function shouldTrack(req) {
+    if (req.method !== 'GET') return false;
+    const p = req.path;
+    if (!p) return false;
+    for (const ex of EXCLUDE_PREFIXES) {
+        if (p === ex || p.startsWith(ex + '/')) return false;
+    }
+    if (p === '/') return true;
+    if (p.endsWith('.html')) return true;
+    for (const m of MARKETING_PREFIXES) {
+        if (p === m || p.startsWith(m + '/') || p === m + '.html') return true;
+    }
+    return false;
+}
+
+function clientIp(req) {
+    const xff = req.headers['x-forwarded-for'];
+    if (xff) return String(xff).split(',')[0].trim();
+    return (req.socket && req.socket.remoteAddress) || '';
+}
+
+function pageviewMiddleware() {
+    return (req, res, next) => {
+        try {
+            if (_pool && shouldTrack(req)) {
+                const q = req.query || {};
+                const params = [
+                    req.path,
+                    clientIp(req).substring(0, 64) || null,
+                    (req.headers['user-agent'] || '').substring(0, 512) || null,
+                    (req.headers['referer'] || req.headers['referrer'] || '').substring(0, 512) || null,
+                    q.utm_source ? String(q.utm_source).substring(0, 128) : null,
+                    q.utm_medium ? String(q.utm_medium).substring(0, 128) : null,
+                    q.utm_campaign ? String(q.utm_campaign).substring(0, 128) : null
+                ];
+                _pool.query(
+                    `INSERT INTO site_page_views (path, ip, ua, referer, utm_source, utm_medium, utm_campaign)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+                    params
+                ).catch(() => { /* swallow — tracking must not break user requests */ });
+            }
+        } catch {
+            // never throw from tracking middleware
+        }
+        next();
+    };
+}
+
+module.exports = {
+    initPageviewsTable,
+    pageviewMiddleware,
+    setPool,
+    shouldTrack, // exported for unit tests
+    EXCLUDE_PREFIXES,
+    MARKETING_PREFIXES,
+};


### PR DESCRIPTION
## Summary
Foundation for the 3-card analytics stack (#20 → #21 → #22). Anonymous-visitor pageview tracking for marketing / public HTML pages; portal pages keep their existing device-scoped telemetry (`/shared/telemetry.js`) unchanged.

## Changes
- **New module** `backend/site-pageviews.js`
  - `initPageviewsTable(pool)` — `site_page_views` table + 3 indexes (path+ts, ts, partial utm_campaign)
  - `pageviewMiddleware()` — express middleware; fire-and-forget INSERT; swallows failures so tracking cannot break user requests
  - `setPool(pool)` — lazy pool hand-off, called after `chatPool` exists
  - Captures `path, ip (x-forwarded-for first hop), ua (512B cap), referer, utm_source, utm_medium, utm_campaign, created_at`
- **`backend/index.js`**
  - `require('./site-pageviews')` near other module imports
  - `app.use(sitePageviews.pageviewMiddleware())` mounted right after `cookieParser()` and before any marketing route handlers
  - `sitePageviews.setPool(chatPool); sitePageviews.initPageviewsTable(chatPool);` next to the other `init*Table(chatPool)` calls

## Tracking rules
- **Include**: `GET *.html` not under excluded prefixes, plus marketing prefixes `/landing`, `/enterprise`, `/privacy-policy`, `/docs`, `/arena`, plus root `/`
- **Exclude**: `/portal/*` (has own telemetry), `/api/*`, `/assets/*`, `/shared/*`, non-GET
- `/robots.txt`, `/sitemap.xml`, `/llms.txt` naturally excluded (don't end in `.html`, not marketing prefixes)

## Test plan
- [x] Unit test `shouldTrack()` — 20/20 cases pass (marketing tracked; portal/api/assets/shared/robots/sitemap/llms excluded; POST/PUT skipped)
- [x] Middleware stub-pool test — 2 tracked / 2 skipped / `next()` fires 4/4, INSERT params include UTM + UA + referer + IP
- [x] `node -c index.js` — syntax OK
- [x] `node scripts/i18n-check.js` — strict i18n gate green (no new keys)
- [ ] Railway deploy: `site_page_views` table auto-created; hit `/landing?utm_source=twitter&utm_campaign=vector-launch`; `SELECT COUNT(*), utm_campaign FROM site_page_views GROUP BY utm_campaign` reflects the hit

## Follow-ups
- Card #21: `/api/analytics/site-pageviews` bot-auth endpoint (query by days / path glob / groupBy)
- Card #22: `/portal/analytics.html` admin view

🤖 Generated with [Claude Code](https://claude.com/claude-code)