### PR TITLE
fix(chat): vector-neighbor 404s when pgvector unavailable in prod

### DIFF
--- a/backend/chat-embedding.js
+++ b/backend/chat-embedding.js
@@ -145,17 +145,19 @@ async function countUnembeddedForDevice(deviceId) {
  */
 async function findMessage(deviceId, messageId) {
     if (!poolRef || !deviceId || !messageId) return null;
+    const hasEmbeddingExpr = vectorEnabled ? '(embedding IS NOT NULL)' : 'FALSE';
     try {
         const r = await poolRef.query(
             `SELECT id, entity_id, text, source, is_from_user, is_from_bot, created_at,
-                    (embedding IS NOT NULL) AS has_embedding
+                    ${hasEmbeddingExpr} AS has_embedding
              FROM chat_messages
              WHERE id = $1 AND device_id = $2
              LIMIT 1`,
             [messageId, deviceId]
         );
         return r.rows[0] || null;
-    } catch {
+    } catch (err) {
+        console.warn('[ChatEmbedding] findMessage failed:', err.message);
         return null;
     }
 }

--- a/backend/tests/jest/chat-related.test.js
+++ b/backend/tests/jest/chat-related.test.js
@@ -82,3 +82,63 @@ describe('chat-embedding module — related helpers no-op when disabled', () => 
         expect(await chatEmbedding.searchRelatedBySemantic('x', null)).toEqual([]);
     });
 });
+
+// Regression: when pgvector is unavailable in prod, the `embedding` column is
+// never added to chat_messages. findMessage() used to reference that column
+// unconditionally and returned null (silent catch) on every lookup, surfacing
+// as "Failed to load related messages" in the UI for every click.
+describe('chat-embedding findMessage — no-pgvector regression', () => {
+    // Isolated module instance so we control poolRef + vectorEnabled cleanly.
+    let chatEmbedding;
+    beforeEach(() => {
+        jest.isolateModules(() => {
+            chatEmbedding = require('../../chat-embedding');
+        });
+    });
+
+    it('builds SQL without `embedding IS NOT NULL` when vectorEnabled=false', async () => {
+        const captured = [];
+        const pool = {
+            query: (sql, params) => {
+                // Swallow initSchema's CREATE EXTENSION / ALTER calls as failures
+                // to keep vectorEnabled=false, but capture the findMessage call.
+                if (/CREATE EXTENSION|ALTER TABLE|CREATE INDEX/i.test(sql)) {
+                    return Promise.reject(new Error('not available'));
+                }
+                captured.push({ sql, params });
+                return Promise.resolve({
+                    rows: [{ id: 'msg1', entity_id: 1, text: 'hi', has_embedding: false }]
+                });
+            }
+        };
+        await chatEmbedding.initSchema(pool);
+        expect(chatEmbedding.isVectorEnabled()).toBe(false);
+
+        const result = await chatEmbedding.findMessage('dev1', 'msg1');
+        expect(result).toBeTruthy();
+        expect(result.id).toBe('msg1');
+        expect(captured.length).toBe(1);
+        expect(captured[0].sql).not.toMatch(/embedding\s+IS\s+NOT\s+NULL/i);
+        expect(captured[0].sql).toMatch(/FALSE\s+AS\s+has_embedding/i);
+    });
+
+    it('still uses embedding column when vectorEnabled=true', async () => {
+        const captured = [];
+        const pool = {
+            query: (sql, params) => {
+                captured.push({ sql, params });
+                return Promise.resolve({
+                    rows: sql.includes('WHERE id')
+                        ? [{ id: 'msg1', has_embedding: true }]
+                        : []
+                });
+            }
+        };
+        await chatEmbedding.initSchema(pool);
+        expect(chatEmbedding.isVectorEnabled()).toBe(true);
+
+        captured.length = 0;
+        await chatEmbedding.findMessage('dev1', 'msg1');
+        expect(captured[0].sql).toMatch(/\(embedding\s+IS\s+NOT\s+NULL\)\s+AS\s+has_embedding/i);
+    });
+});


### PR DESCRIPTION
## Summary

- `findMessage()` referenced `embedding` column unconditionally; when pgvector extension init failed in prod the column was never added, every lookup threw, bare `catch {}` silently returned `null` → `/api/chat/message/:id/related` returned **404 message_not_found** for *every real message*.
- UI surfaced this as **"Failed to load related messages"** on every click of the vector-neighbor icon.
- Fix: gate the `embedding` column reference on `vectorEnabled` (select `FALSE AS has_embedding` when off), log swallowed errors instead of returning null silently. ILIKE keyword fallback path in `/api/chat/message/:id/related` still runs, so users see related messages by text even without pgvector.

## Repro (prod)

```
$ curl -sS -X POST https://eclawbot.com/api/chat/message/8d847382-.../related -d '{...real creds...}'
→ HTTP/2 404 {"success":false,"error":"message_not_found"}
```

Message ID came from `/api/chat/history` — same `chat_messages` table — proving the message exists, the error was spurious.

Probe of `/api/chat/search` returned `mode: "keyword"` (not `semantic_empty_keyword_fallback`), confirming `isVectorEnabled() === false` in prod.

## Test plan

- [x] `npx jest tests/jest/chat-related.test.js` — 9/9 pass, including 2 new regression tests
  - `builds SQL without 'embedding IS NOT NULL' when vectorEnabled=false`
  - `still uses embedding column when vectorEnabled=true`
- [ ] Post-merge E2E: open portal/chat.html → click vector-neighbor icon → expect keyword-related results (not error toast) + clean `browser_console_messages`

🤖 Generated with [Claude Code](https://claude.com/claude-code)