### PR TITLE
feat(mindmap): Phase 3 — zoom-tier rendering + focus-mode fog

### DIFF
--- a/backend/public/portal/mindmap.html
+++ b/backend/public/portal/mindmap.html
@@ -184,6 +184,34 @@
         }
         .mm-edge-mode-banner.active { display: block; }
 
+        .mm-focus-banner {
+            position: absolute;
+            top: 56px;
+            left: 50%;
+            transform: translateX(-50%);
+            background: rgba(80, 120, 200, 0.92);
+            color: #fff;
+            padding: 6px 12px;
+            border-radius: 6px;
+            font-size: 12px;
+            z-index: 14;
+            display: none;
+            box-shadow: 0 2px 8px rgba(0,0,0,0.25);
+        }
+        .mm-focus-banner.active { display: block; }
+
+        .mm-tier-badge {
+            background: var(--card-bg);
+            color: var(--text-secondary);
+            border: 1px solid var(--card-border);
+            border-radius: 6px;
+            padding: 7px 10px;
+            font-size: 11px;
+            font-variant-numeric: tabular-nums;
+            text-transform: uppercase;
+            letter-spacing: 0.4px;
+        }
+
         @media (max-width: 820px) {
             .mm-shell { grid-template-columns: 1fr; grid-template-rows: 60vh 1fr; }
             .mm-sidebar { border-left: none; border-top: 1px solid var(--card-border); }
@@ -212,9 +240,11 @@
                 <button class="mm-tool-btn" id="btnAddEdge" data-i18n="mindmap_connect_mode">Connect mode</button>
                 <button class="mm-tool-btn" id="btnFit" data-i18n="mindmap_fit">Fit</button>
                 <button class="mm-tool-btn" id="btnReload" data-i18n="mindmap_reload">Reload</button>
+                <div class="mm-tier-badge" id="zoomTierLabel" title="">L1</div>
                 <div class="mm-status" id="mmStatus" data-i18n="mindmap_loading">Loading…</div>
             </div>
             <div class="mm-edge-mode-banner" id="edgeBanner" data-i18n="mindmap_edge_mode_hint">Pick the source node, then the target. Esc to cancel.</div>
+            <div class="mm-focus-banner" id="focusBanner" data-i18n="mindmap_focus_mode_hint">Focus mode — click empty space or press Esc to exit</div>
             <div id="cy"></div>
             <div id="cyNav"></div>
         </div>
@@ -289,6 +319,18 @@
     <script src="../shared/i18n.js"></script>
     <script src="shared/footer.js"></script>
     <script>
+        // cytoscape-navigator registers itself against the global `cytoscape`
+        // via its UMD wrapper, but on some bundler paths the extension only
+        // exposes itself as `window.cytoscapeNavigator`. Try both so the
+        // mini-map works regardless of how the CDN ships the module.
+        if (typeof cytoscape !== 'undefined' && typeof cytoscape.use === 'function') {
+            try {
+                if (typeof window.cytoscapeNavigator === 'function') {
+                    cytoscape.use(window.cytoscapeNavigator);
+                }
+            } catch (_) { /* already registered or incompatible — fallback handles */ }
+        }
+
         let cy = null;
         let navigator = null;
         let selectedNodeId = null;
@@ -296,6 +338,75 @@
         let edgeMode = false;
         let edgeSourceId = null;
         let cachedNodeData = new Map();
+        let focusMode = false;
+        let focusNodeId = null;
+        let currentZoomTier = 'L1';
+
+        function getZoomTier(zoom) {
+            if (zoom < 0.5) return 'L0';
+            if (zoom < 1.5) return 'L1';
+            return 'L2';
+        }
+
+        function applyZoomTier() {
+            if (!cy) return;
+            const tier = getZoomTier(cy.zoom());
+            const el = document.getElementById('zoomTierLabel');
+            if (el) {
+                const labelKey = `mindmap_zoom_${tier.toLowerCase()}_label`;
+                const fallback = tier === 'L0' ? 'Overview' : tier === 'L1' ? 'Topics' : 'Detail';
+                el.textContent = `${tier} · ${i18n.t(labelKey, fallback)}`;
+            }
+            if (tier === currentZoomTier) return;
+            currentZoomTier = tier;
+            cy.batch(() => {
+                cy.elements().removeClass('tier-fade');
+                if (tier === 'L0') {
+                    // Only `domain` nodes visible; everything else plus cross-type edges fade.
+                    cy.nodes().forEach(n => {
+                        if (n.data('type') !== 'domain') n.addClass('tier-fade');
+                    });
+                    cy.edges().forEach(e => {
+                        const s = e.source().data('type');
+                        const t = e.target().data('type');
+                        if (s !== 'domain' || t !== 'domain') e.addClass('tier-fade');
+                    });
+                } else if (tier === 'L1') {
+                    // `domain` + `topic` full; `leaf` + `concept` fade.
+                    cy.nodes().forEach(n => {
+                        const ty = n.data('type');
+                        if (ty === 'leaf' || ty === 'concept') n.addClass('tier-fade');
+                    });
+                }
+                // L2: nothing faded.
+            });
+        }
+
+        function enterFocusMode(nodeId) {
+            if (!cy || !nodeId) return;
+            const focus = cy.getElementById(nodeId);
+            if (!focus || focus.empty()) return;
+            focusMode = true;
+            focusNodeId = nodeId;
+            const neighborhood = focus.closedNeighborhood();
+            cy.batch(() => {
+                cy.elements().addClass('fog');
+                neighborhood.removeClass('fog');
+            });
+            const banner = document.getElementById('focusBanner');
+            if (banner) banner.classList.add('active');
+        }
+
+        function exitFocusMode() {
+            if (!cy || !focusMode) return;
+            focusMode = false;
+            focusNodeId = null;
+            cy.batch(() => {
+                cy.elements().removeClass('fog');
+            });
+            const banner = document.getElementById('focusBanner');
+            if (banner) banner.classList.remove('active');
+        }
 
         function creds() {
             return `deviceId=${encodeURIComponent(currentUser.deviceId)}&deviceSecret=${encodeURIComponent(currentUser.deviceSecret)}`;
@@ -458,12 +569,16 @@
             ];
             cy.elements().remove();
             cy.add(elements);
+            // Re-render fog/tier classes against the freshly-added elements.
+            exitFocusMode();
+            currentZoomTier = null;
 
             const hasPositions = nodes.some(n => n.position && typeof n.position === 'object' && typeof n.position.x === 'number');
             if (!hasPositions && nodes.length > 1) {
                 cy.layout({ name: 'cose', animate: false, padding: 40, idealEdgeLength: 110 }).run();
             }
             cy.fit(null, 40);
+            applyZoomTier();
         }
 
         function initCytoscape() {
@@ -510,8 +625,14 @@
                         'text-background-padding': 2,
                     }},
                     { selector: '.dim', style: { 'opacity': 0.2 }},
+                    { selector: '.tier-fade', style: { 'opacity': 0.12, 'text-opacity': 0 }},
+                    { selector: '.fog', style: { 'opacity': 0.18, 'text-opacity': 0 }},
+                    { selector: 'edge.fog', style: { 'opacity': 0.08 }},
                 ],
             });
+
+            cy.on('zoom', applyZoomTier);
+            applyZoomTier();
 
             cy.on('tap', 'node', (evt) => {
                 const nodeId = evt.target.id();
@@ -526,11 +647,16 @@
                     return;
                 }
                 showEditor(nodeId);
+                // Focus re-anchors on every node tap so swapping selection
+                // immediately refreshes the fogged neighborhood.
+                exitFocusMode();
+                enterFocusMode(nodeId);
             });
 
             cy.on('tap', (evt) => {
                 if (evt.target === cy) {
                     if (edgeMode) setEdgeMode(false);
+                    exitFocusMode();
                     showEditor(null);
                 }
             });
@@ -552,6 +678,10 @@
                     viewLiveFramerate: 30,
                     thumbnailLiveFramerate: 10,
                 });
+            } else {
+                console.warn('[Mindmap] cytoscape-navigator not registered — mini-map disabled');
+                const nav = document.getElementById('cyNav');
+                if (nav) nav.style.display = 'none';
             }
         }
 
@@ -693,7 +823,9 @@
                 document.getElementById('btnAddComment').addEventListener('click', postComment);
 
                 document.addEventListener('keydown', (e) => {
-                    if (e.key === 'Escape' && edgeMode) setEdgeMode(false);
+                    if (e.key !== 'Escape') return;
+                    if (edgeMode) setEdgeMode(false);
+                    if (focusMode) exitFocusMode();
                 });
 
                 window.addEventListener('beforeunload', () => {

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -4514,6 +4514,11 @@ const TRANSLATIONS = {
         "mindmap_err_anchor": "Anchor failed",
         "mindmap_err_detach": "Detach failed",
         "mindmap_err_comment": "Comment failed",
+        // Phase 3: zoom-tier rendering + focus-mode fog
+        "mindmap_focus_mode_hint": "Focus mode — click empty space or press Esc to exit",
+        "mindmap_zoom_l0_label": "Overview",
+        "mindmap_zoom_l1_label": "Topics",
+        "mindmap_zoom_l2_label": "Detail",
         // Site Analytics (analytics.html)
         "analytics_title": "Site Analytics",
         "analytics_subtitle": "Anonymous pageviews on public and marketing pages. Portal pages have their own device-scoped telemetry.",


### PR DESCRIPTION
## Summary

Phase 3 of the mind-map MVP (card `card_33bacd59a1be852f396d55b9`). Builds on Phase 1 (API, PR #1945) and Phase 2 (Cytoscape UI + mini-map scaffold, PR #1946).

- **Zoom-tier rendering**: three levels driven by `cy.zoom()`.
  - **L0** (zoom < 0.5): only `domain` nodes + domain-to-domain edges render; everything else fades to opacity 0.12.
  - **L1** (0.5 ≤ zoom < 1.5): `domain` + `topic` full; `leaf` + `concept` fade.
  - **L2** (zoom ≥ 1.5): all nodes and edges at full opacity.
  - A small tier badge in the toolbar reads `L0 · Overview`, `L1 · Topics`, or `L2 · Detail`.
- **Focus-mode fog**: tapping a node marks its closed 1-hop neighborhood full-opacity; every other element gets `.fog` (opacity 0.18 for nodes, 0.08 for edges). Click-background or Esc exits. Tapping a different node re-anchors the fog.
- **Mini-map**: register `cytoscape-navigator` via `cytoscape.use()` when the UMD exposes it as a named global; hide the mini-map container when the plugin is truly unavailable instead of leaving a dead empty box.
- **i18n**: 4 new EN keys (`mindmap_focus_mode_hint`, `mindmap_zoom_l{0,1,2}_label`). Non-EN locales fall back to EN until a follow-up delegation PR lands.

## Test plan

- [x] `node scripts/i18n-check.js` — EN coverage holds, no referenced keys missing.
- [x] JS parse-check on the inline `<script>` (`new Function(scriptSrc)` doesn't throw).
- [ ] Preview deploy: open mindmap.html, add 3+ nodes of different types, wheel-zoom through L0 → L1 → L2 and confirm tier badge + fade transitions.
- [ ] Click a node → fog engages, neighborhood stays lit.
- [ ] Esc / click empty canvas → fog clears.
- [ ] `browser_console_messages` clean (no warnings about missing i18n keys or cytoscape-navigator crashes).
- [ ] Mini-map (right-bottom) visible, viewport rectangle tracks pan/zoom.

Card stays `in_progress` — Phase 4 is `/api/mindmap/traverse` (AI walk along edges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)