### PR TITLE
fix(audit): harden 12 silent try/catch schema-drift bombs (follow-up to #1950)

### DIFF
--- a/backend/ai-support.js
+++ b/backend/ai-support.js
@@ -58,6 +58,20 @@ module.exports = function (devices, chatPool, { serverLog, getWebhookFixInstruct
         return { allowed: true, remaining: max - entry.count };
     }
 
+    // Admin check — 5 routes below need this. Was duplicated as silent
+    // `try{...} catch (_) {}` blocks which hid schema drift on user_accounts
+    // (e.g. is_admin column rename would lock every admin out invisibly).
+    async function resolveIsAdmin(userId) {
+        if (!userId) return false;
+        try {
+            const r = await chatPool.query('SELECT is_admin FROM user_accounts WHERE id = $1', [userId]);
+            return r.rows[0]?.is_admin || false;
+        } catch (err) {
+            console.warn('[AI-Support] resolveIsAdmin failed for', userId, ':', err.message);
+            return false;
+        }
+    }
+
     // Clean up stale rate limit entries every 30 minutes
     setInterval(() => {
         const now = Date.now();
@@ -638,7 +652,9 @@ module.exports = function (devices, chatPool, { serverLog, getWebhookFixInstruct
                 [deviceId]
             );
             ctx.recentErrors = r.rows;
-        } catch (_) {}
+        } catch (err) {
+            console.warn('[AI-Support] buildDeviceContext.recentErrors failed:', err.message);
+        }
 
         // Recent important activity — bind/unbind/push/transform/broadcast, last 1h
         try {
@@ -652,7 +668,9 @@ module.exports = function (devices, chatPool, { serverLog, getWebhookFixInstruct
                 [deviceId]
             );
             ctx.recentActivity = r.rows;
-        } catch (_) {}
+        } catch (err) {
+            console.warn('[AI-Support] buildDeviceContext.recentActivity failed:', err.message);
+        }
 
         // Handshake failures — last 1h
         try {
@@ -664,7 +682,9 @@ module.exports = function (devices, chatPool, { serverLog, getWebhookFixInstruct
                 [deviceId]
             );
             ctx.handshakeFailures = r.rows;
-        } catch (_) {}
+        } catch (err) {
+            console.warn('[AI-Support] buildDeviceContext.handshakeFailures failed:', err.message);
+        }
 
         return ctx;
     }
@@ -983,11 +1003,7 @@ module.exports = function (devices, chatPool, { serverLog, getWebhookFixInstruct
         if (!req.user || !req.user.userId) {
             return res.status(401).json({ error: 'Not authenticated' });
         }
-        let isAdmin = false;
-        try {
-            const r = await chatPool.query('SELECT is_admin FROM user_accounts WHERE id = $1', [req.user.userId]);
-            isAdmin = r.rows[0]?.is_admin || false;
-        } catch (_) {}
+        const isAdmin = await resolveIsAdmin(req.user.userId);
         if (!isAdmin) {
             return res.status(403).json({ error: 'Admin access required' });
         }
@@ -1022,11 +1038,7 @@ module.exports = function (devices, chatPool, { serverLog, getWebhookFixInstruct
         if (!req.user || !req.user.userId) {
             return res.status(401).json({ error: 'Not authenticated' });
         }
-        let isAdmin = false;
-        try {
-            const r = await chatPool.query('SELECT is_admin FROM user_accounts WHERE id = $1', [req.user.userId]);
-            isAdmin = r.rows[0]?.is_admin || false;
-        } catch (_) {}
+        const isAdmin = await resolveIsAdmin(req.user.userId);
         if (!isAdmin) {
             return res.status(403).json({ error: 'Admin access required' });
         }
@@ -1162,11 +1174,7 @@ module.exports = function (devices, chatPool, { serverLog, getWebhookFixInstruct
         ).slice(0, 3);
 
         // Admin check via DB
-        let isAdmin = false;
-        try {
-            const r = await chatPool.query('SELECT is_admin FROM user_accounts WHERE id = $1', [req.user.userId]);
-            isAdmin = r.rows[0]?.is_admin || false;
-        } catch (_) {}
+        const isAdmin = await resolveIsAdmin(req.user.userId);
 
         // Rate limit
         const rateCheck = checkChatRateLimit(req.user.userId, isAdmin);
@@ -1346,11 +1354,7 @@ module.exports = function (devices, chatPool, { serverLog, getWebhookFixInstruct
         }
 
         // Admin check
-        let isAdmin = false;
-        try {
-            const r = await chatPool.query('SELECT is_admin FROM user_accounts WHERE id = $1', [req.user.userId]);
-            isAdmin = r.rows[0]?.is_admin || false;
-        } catch (_) {}
+        const isAdmin = await resolveIsAdmin(req.user.userId);
         if (!isAdmin) {
             return res.status(403).json({ success: false, error: 'Admin access required' });
         }
@@ -1623,11 +1627,7 @@ module.exports = function (devices, chatPool, { serverLog, getWebhookFixInstruct
         ).slice(0, 3);
 
         // Admin check
-        let isAdmin = false;
-        try {
-            const r = await chatPool.query('SELECT is_admin FROM user_accounts WHERE id = $1', [req.user.userId]);
-            isAdmin = r.rows[0]?.is_admin || false;
-        } catch (_) {}
+        const isAdmin = await resolveIsAdmin(req.user.userId);
 
         // Rate limit
         const rateCheck = checkChatRateLimit(req.user.userId, isAdmin);
@@ -1646,7 +1646,9 @@ module.exports = function (devices, chatPool, { serverLog, getWebhookFixInstruct
             if (existing.rows.length > 0) {
                 return res.json({ success: true, requestId, status: existing.rows[0].status });
             }
-        } catch (_) {}
+        } catch (err) {
+            console.warn('[AI-Support] idempotency lookup failed for', requestId, ':', err.message);
+        }
 
         // Insert pending request
         try {

--- a/backend/chat-embedding.js
+++ b/backend/chat-embedding.js
@@ -134,7 +134,8 @@ async function countUnembeddedForDevice(deviceId) {
             [deviceId]
         );
         return r.rows[0]?.n || 0;
-    } catch {
+    } catch (err) {
+        console.warn('[ChatEmbedding] countUnembeddedForDevice failed:', err.message);
         return 0;
     }
 }

--- a/backend/device-telemetry.js
+++ b/backend/device-telemetry.js
@@ -81,7 +81,10 @@ async function ensureSizeCache(pool, deviceId) {
             totalBytes: parseInt(r.rows[0].total) || 0,
             entryCount: parseInt(r.rows[0].cnt) || 0
         };
-    } catch {
+    } catch (err) {
+        // Don't throw — telemetry must never break callers — but at least log
+        // so schema drift on device_telemetry doesn't silently disable pruning.
+        console.warn('[DeviceTelemetry] ensureSizeCache failed for', deviceId, ':', err.message);
         sizeCache[deviceId] = { totalBytes: 0, entryCount: 0 };
     }
     return sizeCache[deviceId];

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -55,7 +55,8 @@ async function getDeviceLanguage(deviceId) {
         const lang = result.rows[0]?.language || 'en';
         deviceLangCache.set(deviceId, { lang, expires: Date.now() + DEVICE_LANG_TTL_MS });
         return lang;
-    } catch (_) {
+    } catch (err) {
+        console.warn('[Kanban] getDeviceLanguage failed for', deviceId, ':', err.message);
         return 'en';
     }
 }

--- a/backend/trust.js
+++ b/backend/trust.js
@@ -413,7 +413,8 @@ module.exports = function trustFactory({ authMiddleware, adminMiddleware, server
         try {
             const reviews = await getListingReviews(req.params.id, req.query);
             res.json({ success: true, reviews });
-        } catch {
+        } catch (err) {
+            console.warn('[trust] getListingReviews failed for', req.params.id, ':', err.message);
             res.status(500).json({ success: false, error: 'internal_error' });
         }
     });


### PR DESCRIPTION
## Summary

- Grep audit of `} catch {` / `catch (_) {}` across backend surfaced **12 silent catches** that queried DB columns/tables and swallowed schema errors behind graceful fallbacks. Any column rename in prod turns them into invisible misbehavior.
- Hardened each to still fall back gracefully but warn once with `err.message`, so future schema drift surfaces in logs instead of manifesting as mysterious "admin access denied / no data / English UI for everyone / unlimited storage use" bugs.
- Pure observability change — no behavior-of-happy-path shift. ESLint + full 1967-test Jest suite still green.

### Bombs defused

| File | Symptom on schema drift (before this PR) |
|---|---|
| `chat-embedding.js:countUnembeddedForDevice` | Always reports 0 unembedded messages |
| `trust.js` `/listing/:id/reviews` | 500 `internal_error` with no server-side diagnosis |
| `device-telemetry.js:ensureSizeCache` | Pruning silently disabled → unbounded growth |
| `kanban.js:getDeviceLanguage` | All users fall back to English permanently |
| `ai-support.js` admin check × 5 routes | Every admin locked out of admin-only routes |
| `ai-support.js:buildDeviceContext` × 3 | CS agent's prod-context silently incomplete |
| `ai-support.js` idempotency lookup | Duplicate inserts allowed silently |

### Not touched (reviewed but intentional)

- `URL.parse` / `JWT.verify` / `JSON.parse` catches — expected failure mode.
- Tracking middleware `never throw from tracking` — intentional decoupling.
- `interview-arena` pool file loader — hardcoded-default fallback is the design.

### Long-term follow-up (separate card)

Install pgvector in prod — that removes the original landmine condition entirely and upgrades vector-search from ILIKE 120-char probe to real semantic cosine.

Refs kanban card `card_e607083a0b282fd090939ab8`.

## Test plan

- [x] `npx eslint ai-support.js chat-embedding.js device-telemetry.js kanban.js trust.js` → exit 0
- [x] `npx jest --silent` → 1967/1967 passing (108 suites)
- [x] `npx jest tests/jest/chat-related.test.js` → 9/9 passing (covers countUnembeddedForDevice path)
- [ ] CI: ESLint, Jest, i18n-syntax (no i18n churn expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)