### PR TITLE
feat(mindmap): AI traverse endpoint (Phase 4)

### DIFF
--- a/backend/anthropic-client.js
+++ b/backend/anthropic-client.js
@@ -506,4 +506,4 @@ async function analyzeWithClaude({ problemDescription, errorMessages, logs, hand
     };
 }
 
-module.exports = { chatWithClaude, analyzeWithClaude, formatDiagnostics, CUSTOMER_SERVICE_TOOLS };
+module.exports = { chatWithClaude, analyzeWithClaude, callAnthropic, formatDiagnostics, CUSTOMER_SERVICE_TOOLS };

--- a/backend/mindmap.js
+++ b/backend/mindmap.js
@@ -1,12 +1,12 @@
 /**
- * Mindmap MVP — Phase 1 (Schema + CRUD API)
+ * Mindmap MVP — Schema + CRUD + AI traverse
  *
  * Mounted at: /api/mindmap
  *
  * Card #19: 心智圖 MVP — 多層次 Zoom + Mini-map + 聚焦模式渲染架構.
- * Phase 1 ships the data layer only — nodes, edges, anchors, per-node
- * comments — plus the CRUD / traversal endpoints the UI (Phase 2) and
- * AI traverse (Phase 4) will sit on top of. No client changes in this PR.
+ * Phases 1-3 ship the data layer + portal UI; Phase 4 adds the AI traverse
+ * endpoint that reads a BFS subgraph anchored at a node and asks Claude to
+ * reason across it.
  *
  * Dual-auth (deviceSecret OR botSecret+entityId) on every endpoint.
  * All rows are scoped by `device_id` — never leak between devices.
@@ -24,14 +24,14 @@
  *   DELETE /anchor/:id                  Detach an anchor
  *   POST   /node/:id/comment            Leave a comment on a node
  *   GET    /node/:id/comments           List comments on a node
- *
- * Phase 4 (AI traverse) lands in a follow-up PR.
+ *   POST   /traverse                    AI reasoning over a BFS subgraph (Phase 4)
  */
 
 'use strict';
 
 const express = require('express');
 const safeEqual = require('./safe-equal');
+const { callAnthropic } = require('./anthropic-client');
 
 const NODE_TYPES = new Set(['domain', 'topic', 'leaf', 'concept']);
 const EDGE_TYPES = new Set(['relates_to', 'causes', 'extends', 'opposes', 'parent_of']);
@@ -609,6 +609,135 @@ function createMindmapModule(devices) {
             res.json({ success: true, comment: result.rows[0] });
         } catch (err) {
             console.error('[Mindmap] POST /node/:id/comment failed:', err.message);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
+    // ─── POST /traverse ─────────────────────────────────────────────────────
+    // Phase 4: AI reasoning over a BFS subgraph anchored at root_node_id.
+    // Fetches up to MAX_TRAVERSE_NODES nodes + their edges (depth clamped to
+    // MAX_TRAVERSE_DEPTH), serializes them into a compact outline, and asks
+    // Claude to answer the caller's question using only that subgraph.
+    router.post('/traverse', async (req, res) => {
+        const deviceId = authenticate(req, res);
+        if (!deviceId) return;
+        if (!requirePool(res)) return;
+
+        const { root_node_id, question } = req.body || {};
+        if (!isUuid(root_node_id)) {
+            return res.status(400).json({ success: false, error: 'Invalid root_node_id' });
+        }
+        if (!question || typeof question !== 'string' || !question.trim()) {
+            return res.status(400).json({ success: false, error: 'Missing question' });
+        }
+        if (!process.env.ANTHROPIC_API_KEY) {
+            return res.status(503).json({ success: false, error: 'AI unavailable (ANTHROPIC_API_KEY not set)' });
+        }
+        const depth = Math.min(MAX_TRAVERSE_DEPTH, Math.max(1, parseInt(req.body.depth, 10) || 2));
+
+        try {
+            const seed = await pool.query(
+                'SELECT id FROM mindmap_nodes WHERE id = $1 AND device_id = $2',
+                [root_node_id, deviceId]
+            );
+            if (seed.rowCount === 0) {
+                return res.status(404).json({ success: false, error: 'Root node not found' });
+            }
+
+            // Identical BFS to GET /subgraph — kept inline so the two routes
+            // can evolve independently (e.g. traverse may later weight edges).
+            const visited = new Set([root_node_id]);
+            let frontier = [root_node_id];
+            const allEdges = [];
+            for (let hop = 0; hop < depth && frontier.length > 0 && visited.size < MAX_TRAVERSE_NODES; hop++) {
+                const edges = await pool.query(
+                    `SELECT * FROM mindmap_edges
+                     WHERE device_id = $1
+                       AND (source_node_id = ANY($2::uuid[]) OR target_node_id = ANY($2::uuid[]))`,
+                    [deviceId, frontier]
+                );
+                const nextFrontier = [];
+                for (const e of edges.rows) {
+                    allEdges.push(e);
+                    for (const nid of [e.source_node_id, e.target_node_id]) {
+                        if (!visited.has(nid)) {
+                            visited.add(nid);
+                            nextFrontier.push(nid);
+                            if (visited.size >= MAX_TRAVERSE_NODES) break;
+                        }
+                    }
+                    if (visited.size >= MAX_TRAVERSE_NODES) break;
+                }
+                frontier = nextFrontier;
+            }
+
+            const uniqueEdges = Array.from(new Map(allEdges.map(e => [e.id, e])).values());
+            const nodeRows = await pool.query(
+                `SELECT id, title, summary, node_type FROM mindmap_nodes
+                 WHERE device_id = $1 AND id = ANY($2::uuid[])`,
+                [deviceId, [...visited]]
+            );
+
+            const nodesById = new Map(nodeRows.rows.map(n => [n.id, n]));
+            const rootRow = nodesById.get(root_node_id);
+            const shortId = (id) => id.slice(0, 8);
+
+            const nodeLines = nodeRows.rows.map(n => {
+                const typeTag = n.node_type ? `(${n.node_type})` : '(node)';
+                const marker = n.id === root_node_id ? ' [ROOT]' : '';
+                const summary = n.summary ? ` — ${clampStr(n.summary, 200)}` : '';
+                return `- [${shortId(n.id)}]${marker} "${n.title}" ${typeTag}${summary}`;
+            });
+            const edgeLines = uniqueEdges.map(e => {
+                const src = nodesById.get(e.source_node_id);
+                const tgt = nodesById.get(e.target_node_id);
+                if (!src || !tgt) return null;
+                const rel = e.edge_type || 'relates_to';
+                return `- [${shortId(e.source_node_id)}] "${src.title}" --(${rel})--> [${shortId(e.target_node_id)}] "${tgt.title}"`;
+            }).filter(Boolean);
+
+            const systemPrompt = [
+                'You are a reasoning engine over a mindmap subgraph.',
+                'Use ONLY the nodes and edges provided. Do not invent nodes.',
+                'When you reference a node, cite its short id in brackets like [a1b2c3d4].',
+                'Be concise: answer in 2-6 sentences plus an optional bulleted path of reasoning.',
+                'If the subgraph does not contain enough information, say so plainly.',
+            ].join('\n');
+
+            const userMessage = [
+                `Root node: [${shortId(root_node_id)}] "${rootRow?.title || '(unknown)'}"`,
+                `Depth: ${depth}, Nodes: ${nodeRows.rows.length}, Edges: ${uniqueEdges.length}`,
+                '',
+                'Nodes:',
+                nodeLines.join('\n') || '(none)',
+                '',
+                'Edges:',
+                edgeLines.join('\n') || '(none)',
+                '',
+                `Question: ${clampStr(question, 2000)}`,
+            ].join('\n');
+
+            const result = await callAnthropic(systemPrompt, [
+                { role: 'user', content: userMessage },
+            ]);
+            const answerText = (result.content || [])
+                .filter(b => b.type === 'text')
+                .map(b => b.text)
+                .join('\n')
+                .trim();
+
+            res.json({
+                success: true,
+                root: root_node_id,
+                depth,
+                truncated: visited.size >= MAX_TRAVERSE_NODES,
+                node_count: nodeRows.rows.length,
+                edge_count: uniqueEdges.length,
+                visited_node_ids: [...visited],
+                answer: answerText || '(no answer produced)',
+            });
+        } catch (err) {
+            console.error('[Mindmap] POST /traverse failed:', err.message);
             res.status(500).json({ success: false, error: err.message });
         }
     });

--- a/backend/tests/jest/mindmap.test.js
+++ b/backend/tests/jest/mindmap.test.js
@@ -1,0 +1,259 @@
+/**
+ * /api/mindmap/traverse — Phase 4 AI reasoning endpoint.
+ *
+ * Covers validation (missing creds, invalid UUIDs, empty question), the
+ * ANTHROPIC_API_KEY-absent 503 short-circuit, and a happy path driven by
+ * an isolated mindmap module instance with a stubbed pool + callAnthropic.
+ */
+
+require('./helpers/mock-setup');
+
+const request = require('supertest');
+let app;
+
+const post = (path) => request(app).post(path).set('Host', 'localhost');
+
+async function registerDevice(id) {
+    const secret = `secret-${id}`;
+    await request(app).post('/api/device/register').set('Host', 'localhost')
+        .send({ deviceId: id, deviceSecret: secret, entityId: 0 });
+    return secret;
+}
+
+const SAMPLE_UUID = '11111111-2222-3333-4444-555555555555';
+
+beforeAll(() => {
+    app = require('../../index');
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+    jest.resetModules();
+});
+
+describe('POST /api/mindmap/traverse — input validation', () => {
+    it('400 when deviceId missing', async () => {
+        const res = await post('/api/mindmap/traverse').send({
+            root_node_id: SAMPLE_UUID,
+            question: 'why?',
+        });
+        expect(res.status).toBe(400);
+    });
+
+    it('401 when deviceId has no matching device record', async () => {
+        // Dual-auth rejects unknown deviceId with 401 before the 400
+        // "missing secret" check — match the existing behavior of the
+        // authenticate() helper (same as other mindmap endpoints).
+        const res = await post('/api/mindmap/traverse').send({
+            deviceId: 'x',
+            root_node_id: SAMPLE_UUID,
+            question: 'why?',
+        });
+        expect(res.status).toBe(401);
+    });
+
+    it('401 for invalid device credentials', async () => {
+        const res = await post('/api/mindmap/traverse').send({
+            deviceId: 'mindmap-bogus-device',
+            deviceSecret: 'wrong',
+            root_node_id: SAMPLE_UUID,
+            question: 'why?',
+        });
+        expect(res.status).toBe(401);
+    });
+
+    it('400 for non-UUID root_node_id (after auth)', async () => {
+        const deviceSecret = await registerDevice('mindmap-traverse-invalid-uuid');
+        const res = await post('/api/mindmap/traverse').send({
+            deviceId: 'mindmap-traverse-invalid-uuid',
+            deviceSecret,
+            root_node_id: 'not-a-uuid',
+            question: 'why?',
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/root_node_id/);
+    });
+
+    it('400 when question is empty/whitespace', async () => {
+        const deviceSecret = await registerDevice('mindmap-traverse-empty-q');
+        const res = await post('/api/mindmap/traverse').send({
+            deviceId: 'mindmap-traverse-empty-q',
+            deviceSecret,
+            root_node_id: SAMPLE_UUID,
+            question: '   ',
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/question/i);
+    });
+});
+
+describe('POST /api/mindmap/traverse — AI availability gate', () => {
+    const savedKey = process.env.ANTHROPIC_API_KEY;
+
+    beforeAll(() => { delete process.env.ANTHROPIC_API_KEY; });
+    afterAll(() => {
+        if (savedKey === undefined) delete process.env.ANTHROPIC_API_KEY;
+        else process.env.ANTHROPIC_API_KEY = savedKey;
+    });
+
+    it('503 when ANTHROPIC_API_KEY is not set', async () => {
+        const deviceSecret = await registerDevice('mindmap-traverse-nokey');
+        const res = await post('/api/mindmap/traverse').send({
+            deviceId: 'mindmap-traverse-nokey',
+            deviceSecret,
+            root_node_id: SAMPLE_UUID,
+            question: 'why?',
+        });
+        expect(res.status).toBe(503);
+        expect(res.body.error).toMatch(/ANTHROPIC_API_KEY/);
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// Happy path: isolate the mindmap module so we can drive it with a custom
+// pool + mocked anthropic-client. This bypasses the top-level Express app
+// so the DB stubs in mock-setup don't interfere.
+// ─────────────────────────────────────────────────────────────────────────
+describe('mindmap /traverse — happy path (isolated module)', () => {
+    const ROOT_ID = '11111111-1111-4111-8111-111111111111';
+    const CHILD_ID = '22222222-2222-4222-8222-222222222222';
+    const EDGE_ID = '33333333-3333-4333-8333-333333333333';
+    const DEVICE_ID = 'happy-dev';
+    const DEVICE_SECRET = 'happy-secret';
+
+    let createMindmapModule;
+    let callAnthropicMock;
+    let poolQueryMock;
+    let router;
+    let express;
+    let supertest;
+    let testApp;
+
+    beforeEach(() => {
+        process.env.ANTHROPIC_API_KEY = 'test-key';
+
+        jest.isolateModules(() => {
+            callAnthropicMock = jest.fn().mockResolvedValue({
+                content: [{ type: 'text', text: 'The root explains the child via relates_to [22222222].' }],
+            });
+            jest.doMock('../../anthropic-client', () => ({
+                callAnthropic: callAnthropicMock,
+            }));
+            createMindmapModule = require('../../mindmap');
+            express = require('express');
+            supertest = require('supertest');
+        });
+
+        poolQueryMock = jest.fn(async (sql, params) => {
+            const norm = sql.replace(/\s+/g, ' ').trim();
+            // Auth seed check: SELECT id FROM mindmap_nodes WHERE id=$1 AND device_id=$2
+            if (/SELECT id FROM mindmap_nodes WHERE id = \$1 AND device_id = \$2/i.test(norm)) {
+                if (params[0] === ROOT_ID && params[1] === DEVICE_ID) {
+                    return { rowCount: 1, rows: [{ id: ROOT_ID }] };
+                }
+                return { rowCount: 0, rows: [] };
+            }
+            // BFS edge fetch
+            if (/FROM mindmap_edges\s+WHERE device_id = \$1\s+AND \(source_node_id/i.test(norm)) {
+                return {
+                    rowCount: 1,
+                    rows: [{
+                        id: EDGE_ID,
+                        device_id: DEVICE_ID,
+                        source_node_id: ROOT_ID,
+                        target_node_id: CHILD_ID,
+                        edge_type: 'relates_to',
+                        weight: 1.0,
+                    }],
+                };
+            }
+            // Node detail fetch (title/summary/node_type)
+            if (/SELECT id, title, summary, node_type FROM mindmap_nodes/i.test(norm)) {
+                return {
+                    rowCount: 2,
+                    rows: [
+                        { id: ROOT_ID, title: 'Root', summary: 'anchor', node_type: 'topic' },
+                        { id: CHILD_ID, title: 'Child', summary: 'leaf', node_type: 'leaf' },
+                    ],
+                };
+            }
+            return { rowCount: 0, rows: [] };
+        });
+
+        const devices = {
+            [DEVICE_ID]: { deviceSecret: DEVICE_SECRET, entities: {} },
+        };
+        const module = createMindmapModule(devices);
+        router = module.router;
+        module.initMindmapTables({ query: poolQueryMock });
+
+        testApp = express();
+        testApp.use(express.json());
+        testApp.use('/api/mindmap', router);
+    });
+
+    afterEach(() => {
+        jest.resetModules();
+        delete process.env.ANTHROPIC_API_KEY;
+    });
+
+    it('returns an AI answer referencing visited nodes', async () => {
+        const res = await supertest(testApp)
+            .post('/api/mindmap/traverse')
+            .send({
+                deviceId: DEVICE_ID,
+                deviceSecret: DEVICE_SECRET,
+                root_node_id: ROOT_ID,
+                question: 'How does the root relate to its child?',
+                depth: 1,
+            });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.root).toBe(ROOT_ID);
+        expect(res.body.depth).toBe(1);
+        expect(res.body.node_count).toBe(2);
+        expect(res.body.edge_count).toBe(1);
+        expect(res.body.visited_node_ids).toEqual(expect.arrayContaining([ROOT_ID, CHILD_ID]));
+        expect(res.body.answer).toContain('relates_to');
+
+        // Anthropic call payload sanity: the serialized subgraph must mention
+        // both node short-ids and the edge relation so the prompt actually
+        // contains the graph context.
+        expect(callAnthropicMock).toHaveBeenCalledTimes(1);
+        const [systemPrompt, messages] = callAnthropicMock.mock.calls[0];
+        expect(systemPrompt).toMatch(/mindmap subgraph/i);
+        expect(messages[0].role).toBe('user');
+        expect(messages[0].content).toContain('[11111111]');
+        expect(messages[0].content).toContain('[22222222]');
+        expect(messages[0].content).toContain('--(relates_to)-->');
+        expect(messages[0].content).toContain('How does the root relate');
+    });
+
+    it('404 when root node does not belong to device', async () => {
+        const res = await supertest(testApp)
+            .post('/api/mindmap/traverse')
+            .send({
+                deviceId: DEVICE_ID,
+                deviceSecret: DEVICE_SECRET,
+                root_node_id: '99999999-9999-4999-8999-999999999999',
+                question: 'ghost?',
+            });
+        expect(res.status).toBe(404);
+        expect(callAnthropicMock).not.toHaveBeenCalled();
+    });
+
+    it('clamps depth above MAX_TRAVERSE_DEPTH back to MAX', async () => {
+        const res = await supertest(testApp)
+            .post('/api/mindmap/traverse')
+            .send({
+                deviceId: DEVICE_ID,
+                deviceSecret: DEVICE_SECRET,
+                root_node_id: ROOT_ID,
+                question: 'why?',
+                depth: 99,
+            });
+        expect(res.status).toBe(200);
+        expect(res.body.depth).toBe(4); // MAX_TRAVERSE_DEPTH
+    });
+});


### PR DESCRIPTION
## Summary
- Ships `POST /api/mindmap/traverse` — the Phase 4 AI endpoint for card #19's mindmap MVP. Answers questions anchored at a root node using a BFS subgraph (depth ≤ 4, nodes ≤ 500) fed to Claude.
- Reuses the same dual-auth + device scoping as every other mindmap route. Validation runs before the `ANTHROPIC_API_KEY` check so clients get consistent 400s regardless of env state.
- Prompt serializes nodes (short-id + title + type + 200-char summary) and edges (`src --(rel)--> tgt`) into a compact outline — response returns `{answer, visited_node_ids, truncated, node_count, edge_count}`.

## Test plan
- [x] New `tests/jest/mindmap.test.js` — 9 cases: missing/invalid auth, 401 unknown device, 400 non-UUID root, 400 empty question, 503 when AI key missing, happy path (verifies prompt contains both node ids + `--(relates_to)-->` so subgraph context actually reaches Claude), 404 cross-device guard, depth clamp above MAX.
- [x] `npx jest` — 1975 passed, 1 pre-existing flaky mission.test:152 unrelated to this change (confirmed by running same command on `main`).
- [x] `npx eslint .` — clean on modified files (wallet.js warning is pre-existing).
- [ ] Post-deploy: smoke with a real device + 2-node subgraph to confirm Anthropic round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)