### PR TITLE
fix(portal): stop api.js 401 redirect racing auth.js WebView fallbacks

### DIFF
--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -2,7 +2,7 @@
 
 const API_BASE = window.location.origin;
 
-async function apiCall(method, path, body = null) {
+async function apiCall(method, path, body = null, opts = {}) {
     const options = {
         method: method,
         credentials: 'include', // Send cookies
@@ -26,9 +26,16 @@ async function apiCall(method, path, body = null) {
     const data = await response.json();
 
     if (response.status === 401) {
-        // Not authenticated - redirect to login (skip public pages, info page, and Android WebView)
+        // Not authenticated - redirect to login (skip public pages, info page, and Android WebView).
+        // Callers that handle 401 themselves (e.g. auth.js's /me probe that falls back to
+        // device-login) pass { skip401Redirect: true } so the redirect doesn't race against
+        // their fallback fetch — see the Portal auth race bug on iOS / Playwright.
         const isAndroidWebView = typeof AndroidBridge !== 'undefined';
-        if (!isAndroidWebView && !window.location.pathname.includes('index.html') && !window.location.pathname.endsWith('/portal/') && !window.location.pathname.includes('info.html')) {
+        if (!opts.skip401Redirect
+            && !isAndroidWebView
+            && !window.location.pathname.includes('index.html')
+            && !window.location.pathname.endsWith('/portal/')
+            && !window.location.pathname.includes('info.html')) {
             window.location.href = 'index.html';
         }
         throw new Error(data.error || 'Not authenticated');

--- a/backend/public/portal/shared/auth.js
+++ b/backend/public/portal/shared/auth.js
@@ -19,7 +19,12 @@ async function checkAuth() {
     } catch (_) { /* ignore */ }
 
     try {
-        const data = await apiCall('GET', '/api/auth/me');
+        // Suppress api.js's built-in 401->index redirect so the WebView / URL-param
+        // fallbacks below get a chance to device-login. Without this, the redirect
+        // starts before our fallback fetch completes and the browser aborts it
+        // with "TypeError: Failed to fetch". If every fallback fails, we redirect
+        // to index.html explicitly at the bottom of this function.
+        const data = await apiCall('GET', '/api/auth/me', null, { skip401Redirect: true });
         currentUser = data.user;
         window.currentUser = currentUser;
 

--- a/backend/tests/jest/portal-auth-race.test.js
+++ b/backend/tests/jest/portal-auth-race.test.js
@@ -1,0 +1,152 @@
+/**
+ * Portal auth race — WebView/iOS device-login should not lose to api.js's
+ * 401 → index.html redirect.
+ *
+ * Bug: on iOS WebView / Playwright, the first `/api/auth/me` call returns
+ * 401, api.js navigates to index.html immediately, and the still-in-flight
+ * device-login POST from auth.js is aborted mid-fetch ("TypeError: Failed
+ * to fetch"). The page never gets to device-login.
+ *
+ * Fix: api.js now accepts an `opts.skip401Redirect` flag; auth.js's /me
+ * probe passes `skip401Redirect: true` so its own fallback chain can
+ * complete. If every fallback fails, auth.js redirects explicitly.
+ *
+ * These tests load public/portal/shared/api.js into a vm sandbox so we
+ * can exercise apiCall directly with mocked fetch + window.location, plus
+ * a static-analysis guard so auth.js can't regress silently.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const API_JS = path.resolve(__dirname, '../../public/portal/shared/api.js');
+const AUTH_JS = path.resolve(__dirname, '../../public/portal/shared/auth.js');
+
+function makeSandbox({ status, body = {}, pathname = '/portal/dashboard.html' } = {}) {
+    const fakeResponse = {
+        status,
+        ok: status >= 200 && status < 300,
+        headers: { get: () => 'application/json' },
+        json: async () => body,
+        text: async () => JSON.stringify(body),
+    };
+    const hrefSetter = jest.fn();
+    const locationTarget = {
+        origin: 'http://localhost:8787',
+        pathname,
+        search: '',
+    };
+    const locationProxy = new Proxy(locationTarget, {
+        set(obj, prop, val) {
+            if (prop === 'href') hrefSetter(val);
+            obj[prop] = val;
+            return true;
+        },
+    });
+    const fetchMock = jest.fn().mockResolvedValue(fakeResponse);
+    const sandbox = {
+        window: { location: locationProxy },
+        document: { createElement: () => ({ appendChild: () => {}, remove: () => {}, addEventListener: () => {}, querySelector: () => ({ focus: () => {}, addEventListener: () => {}, select: () => {} }), querySelectorAll: () => [], textContent: '', innerHTML: '', style: {} }), body: { appendChild: () => {} } },
+        fetch: fetchMock,
+        console: { log: () => {}, warn: () => {}, error: () => {} },
+        setTimeout: (fn) => fn(),
+    };
+    sandbox.window.location = locationProxy;
+    sandbox.window.alert = () => {};
+    sandbox.window.confirm = () => {};
+    sandbox.window.prompt = () => {};
+    sandbox.location = locationProxy;
+    return { sandbox, hrefSetter, fetchMock };
+}
+
+function loadApiJs(sandbox) {
+    const src = fs.readFileSync(API_JS, 'utf8');
+    vm.createContext(sandbox);
+    vm.runInContext(src, sandbox);
+}
+
+describe('apiCall 401 behavior', () => {
+    test('401 on authenticated page redirects to index.html by default', async () => {
+        const { sandbox, hrefSetter } = makeSandbox({
+            status: 401,
+            body: { error: 'Not authenticated' },
+            pathname: '/portal/dashboard.html',
+        });
+        loadApiJs(sandbox);
+
+        await expect(sandbox.apiCall('GET', '/api/auth/me')).rejects.toThrow(/Not authenticated/);
+        expect(hrefSetter).toHaveBeenCalledWith('index.html');
+    });
+
+    test('401 with skip401Redirect=true does NOT navigate', async () => {
+        const { sandbox, hrefSetter } = makeSandbox({
+            status: 401,
+            body: { error: 'Not authenticated' },
+            pathname: '/portal/dashboard.html',
+        });
+        loadApiJs(sandbox);
+
+        await expect(
+            sandbox.apiCall('GET', '/api/auth/me', null, { skip401Redirect: true })
+        ).rejects.toThrow(/Not authenticated/);
+        expect(hrefSetter).not.toHaveBeenCalled();
+    });
+
+    test('401 with skip401Redirect=true still throws so caller can fallback', async () => {
+        const { sandbox } = makeSandbox({
+            status: 401,
+            body: { error: 'Not authenticated' },
+        });
+        loadApiJs(sandbox);
+
+        let threw = false;
+        try {
+            await sandbox.apiCall('GET', '/api/auth/me', null, { skip401Redirect: true });
+        } catch (_) {
+            threw = true;
+        }
+        expect(threw).toBe(true);
+    });
+
+    test('401 on index.html does not redirect (avoid loop)', async () => {
+        const { sandbox, hrefSetter } = makeSandbox({
+            status: 401,
+            body: { error: 'Not authenticated' },
+            pathname: '/portal/index.html',
+        });
+        loadApiJs(sandbox);
+
+        await expect(sandbox.apiCall('GET', '/api/auth/me')).rejects.toThrow();
+        expect(hrefSetter).not.toHaveBeenCalled();
+    });
+
+    test('200 on /me returns parsed body without touching window.location', async () => {
+        const { sandbox, hrefSetter } = makeSandbox({
+            status: 200,
+            body: { user: { deviceId: 'd1', email: 'a@b' } },
+        });
+        loadApiJs(sandbox);
+
+        const data = await sandbox.apiCall('GET', '/api/auth/me');
+        expect(data.user.deviceId).toBe('d1');
+        expect(hrefSetter).not.toHaveBeenCalled();
+    });
+});
+
+describe('auth.js wiring (static analysis)', () => {
+    const source = fs.readFileSync(AUTH_JS, 'utf8');
+
+    test('/me probe passes skip401Redirect so api.js does not race the fallback', () => {
+        // Look for an apiCall to /api/auth/me with a 4th arg containing skip401Redirect.
+        // Allow arbitrary whitespace/quoting.
+        const pattern = /apiCall\(\s*['"]GET['"]\s*,\s*['"]\/api\/auth\/me['"]\s*,[^,]*,\s*\{[^}]*skip401Redirect\s*:\s*true[^}]*\}\s*\)/;
+        expect(source).toMatch(pattern);
+    });
+
+    test('auth.js keeps an explicit final redirect when every fallback fails', () => {
+        // After iOS/Android fallbacks fail, auth.js must navigate to index.html
+        // itself (api.js no longer does it for the /me probe).
+        expect(source).toMatch(/window\.location\.href\s*=\s*['"]index\.html['"]/);
+    });
+});


### PR DESCRIPTION
## Summary
- Bug: iOS WebView / Playwright got stuck on a blank page because api.js navigated to `index.html` the moment `/api/auth/me` returned 401, aborting the device-login POST that auth.js was about to fire from its own catch.
- Fix: `apiCall(method, path, body, opts)` now supports `opts.skip401Redirect`. auth.js's `/me` probe passes it so its fallback chain (Android bridge → iOS URL params → localStorage) can complete. auth.js still redirects to `index.html` explicitly when every fallback fails, so nothing is silently swallowed.
- No behavior change for any other caller: default `opts = {}` keeps the existing redirect.

## Why Approach C (opt-in flag) over A / B
- A (URL allowlist in api.js): would keep knowledge about `/api/auth/me` inside the generic helper; any new caller that wants the same contract has to edit api.js.
- B (try device-login first, /me second): reorders the happy path and makes the cookie/session flow harder to reason about.
- C (this): one parameter, one caller, explicit opt-out. The race condition is a property of that caller, so the fix lives with that caller.

## Test plan
- [x] `npx jest tests/jest/portal-auth-race.test.js` — 7 new cases cover:
  - default 401 still redirects
  - `skip401Redirect: true` does NOT navigate
  - `skip401Redirect: true` still throws so caller can fallback
  - 401 on `index.html` never redirects (avoid loop)
  - 200 response untouched
  - auth.js wiring check (static): `/me` probe passes `skip401Redirect: true`
  - auth.js wiring check (static): explicit final `window.location.href = 'index.html'` still present
- [x] `npx jest auth* ai-chat-widget-guard portal-auth-race` — 81 passed
- [ ] Manual E2E on Android WebView + iOS WebView after merge (separate card)

Card: card_c7b10d42b9a1fbe8431e10ca

🤖 Generated with [Claude Code](https://claude.com/claude-code)