### PR TITLE
feat(viral): instrument share-chat Proxy Window CTA for CTR analytics

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -16694,6 +16694,18 @@ app.get('/api/analytics/site-pageviews', async (req, res) => {
     }
 });
 
+// POST /api/analytics/cta-event — beacon endpoint for public pages (under
+// /portal/*) that the pageview middleware doesn't cover. The `name` must
+// match CTA_EVENT_ALLOWLIST so a spammer can't fabricate paths.
+app.post('/api/analytics/cta-event', express.json({ limit: '1kb' }), async (req, res) => {
+    const { name } = req.body || {};
+    if (!sitePageviews.isValidCtaEvent(name)) {
+        return res.status(400).json({ success: false, error: 'Invalid event name' });
+    }
+    await sitePageviews.recordCtaEvent(chatPool, req, name);
+    res.json({ success: true });
+});
+
 /**
  * PUT /api/bot/file - Create or update a file (upsert)
  */

--- a/backend/public/portal/share-chat.html
+++ b/backend/public/portal/share-chat.html
@@ -210,7 +210,7 @@
         <!-- Viral CTA: Create your own Bot -->
         <div class="proxy-cta">
             <div class="proxy-cta-text" data-i18n="sc_cta_create_bot">Like this bot? Create your own — it's free!</div>
-            <a class="proxy-cta-btn" href="#" onclick="showRegisterMode(); return false;" data-i18n="sc_cta_create_bot_btn">Create your own Bot</a>
+            <a class="proxy-cta-btn" href="#" onclick="beaconCta('share-chat-register-cta'); showRegisterMode(); return false;" data-i18n="sc_cta_create_bot_btn">Create your own Bot</a>
         </div>
 
         <div class="powered-by"><span data-i18n="sc_powered_by">Powered by</span> <a href="/" target="_blank">EClawbot</a></div>
@@ -952,6 +952,24 @@
     }
 
     // ── Registration ──
+    // Lightweight beacon into site_page_views (synthetic /_cta/<name> path).
+    // share-chat.html sits under /portal, which is excluded from the pageview
+    // middleware, so its CTR numbers are otherwise uncountable.
+    function beaconCta(name) {
+        try {
+            fetch('/api/analytics/cta-event', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ name }),
+                keepalive: true
+            }).catch(() => {});
+        } catch (_) { /* ignore */ }
+    }
+
+    // Fire once on first interactive frame so we count denominators (views)
+    // the same way we count numerators (CTA clicks).
+    window.addEventListener('DOMContentLoaded', () => beaconCta('share-chat-view'));
+
     function showRegisterMode() {
         document.getElementById('registerModal').classList.remove('hidden');
         document.getElementById('loginModal').classList.add('hidden');

--- a/backend/site-pageviews.js
+++ b/backend/site-pageviews.js
@@ -96,6 +96,50 @@ function pageviewMiddleware() {
     };
 }
 
+// Events we accept from unauthenticated public pages. Keeping a closed
+// allowlist here stops a spammer from writing arbitrary paths into
+// site_page_views, which would poison the analytics dashboards.
+const CTA_EVENT_ALLOWLIST = new Set([
+    'share-chat-view',         // share-chat.html pageview (not covered by
+                               // pageviewMiddleware because /portal is excluded)
+    'share-chat-register-cta', // "Create your own Bot" button click
+]);
+
+function isValidCtaEvent(name) {
+    return typeof name === 'string' && CTA_EVENT_ALLOWLIST.has(name);
+}
+
+/**
+ * Record a CTA / beacon event from a public page that the pageview
+ * middleware can't otherwise see (e.g. anything under /portal). Writes
+ * into the same `site_page_views` table with a synthetic `/_cta/<name>`
+ * path so the existing aggregation endpoint can report it via `path=_cta/*`.
+ *
+ * Fire-and-forget like the middleware — never throws, never blocks callers.
+ */
+async function recordCtaEvent(pool, req, name) {
+    if (!pool || !isValidCtaEvent(name)) return;
+    const q = req.query || {};
+    const params = [
+        '/_cta/' + name,
+        clientIp(req).substring(0, 64) || null,
+        (req.headers['user-agent'] || '').substring(0, 512) || null,
+        (req.headers['referer'] || req.headers['referrer'] || '').substring(0, 512) || null,
+        q.utm_source ? String(q.utm_source).substring(0, 128) : null,
+        q.utm_medium ? String(q.utm_medium).substring(0, 128) : null,
+        q.utm_campaign ? String(q.utm_campaign).substring(0, 128) : null,
+    ];
+    try {
+        await pool.query(
+            `INSERT INTO site_page_views (path, ip, ua, referer, utm_source, utm_medium, utm_campaign)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+            params
+        );
+    } catch {
+        // swallow — CTA tracking must not break user flow
+    }
+}
+
 /**
  * Convert a shell-style glob (with `*`) into a Postgres LIKE pattern.
  * `*` → `%`, other chars are escaped. Returns null if input is empty.
@@ -178,6 +222,9 @@ module.exports = {
     shouldTrack, // exported for unit tests
     globToLike,  // exported for unit tests
     queryPageviews,
+    recordCtaEvent,
+    isValidCtaEvent,
+    CTA_EVENT_ALLOWLIST,
     EXCLUDE_PREFIXES,
     MARKETING_PREFIXES,
 };

--- a/backend/tests/jest/site-pageviews-cta.test.js
+++ b/backend/tests/jest/site-pageviews-cta.test.js
@@ -1,0 +1,47 @@
+/**
+ * Covers the closed-allowlist CTA beacon: public pages under /portal
+ * can't use pageviewMiddleware (excluded prefix), so they POST to
+ * /api/analytics/cta-event which calls recordCtaEvent. An unbounded
+ * `name` would let a spammer write arbitrary paths into site_page_views
+ * and poison analytics — so the allowlist is load-bearing.
+ */
+const sp = require('../../site-pageviews');
+
+describe('site-pageviews CTA beacon', () => {
+    test('allowlist contains share-chat events', () => {
+        expect(sp.isValidCtaEvent('share-chat-view')).toBe(true);
+        expect(sp.isValidCtaEvent('share-chat-register-cta')).toBe(true);
+    });
+
+    test('rejects anything outside the allowlist', () => {
+        for (const bad of [null, undefined, '', 'attack', '../../etc/passwd', '_cta/foo', 42, {}]) {
+            expect(sp.isValidCtaEvent(bad)).toBe(false);
+        }
+    });
+
+    test('recordCtaEvent is a silent no-op when pool is missing', async () => {
+        await expect(sp.recordCtaEvent(null, { headers: {}, query: {} }, 'share-chat-view')).resolves.toBeUndefined();
+    });
+
+    test('recordCtaEvent writes /_cta/<name> when allowed', async () => {
+        const captured = [];
+        const fakePool = { query: (sql, params) => { captured.push({ sql, params }); return Promise.resolve(); } };
+        const req = {
+            headers: { 'user-agent': 'ua', referer: 'r' },
+            query: { utm_source: 's' },
+            socket: { remoteAddress: '1.2.3.4' },
+        };
+        await sp.recordCtaEvent(fakePool, req, 'share-chat-register-cta');
+        expect(captured).toHaveLength(1);
+        expect(captured[0].params[0]).toBe('/_cta/share-chat-register-cta');
+        expect(captured[0].params[1]).toBe('1.2.3.4');
+        expect(captured[0].params[4]).toBe('s');
+    });
+
+    test('recordCtaEvent silently drops non-allowlisted names', async () => {
+        const fakePool = { query: () => { throw new Error('should not be called'); } };
+        await expect(
+            sp.recordCtaEvent(fakePool, { headers: {}, query: {} }, 'nope')
+        ).resolves.toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary

From today's viral-loop auto-trigger: the 週二 rotation asks \"Proxy Window bottom CTA 點擊率 < 5% 嗎?\" — but the metric was impossible to answer. share-chat.html sits under \`/portal/*\`, which \`pageviewMiddleware\` excludes, and there was no CTA click tracking anywhere. Both the numerator and denominator were dark.

This PR ships the instrumentation:

- \`POST /api/analytics/cta-event\` — public beacon that writes into \`site_page_views\` with synthetic path \`/_cta/<name>\`. \`name\` is constrained to a closed allowlist (\`share-chat-view\`, \`share-chat-register-cta\`) so random internet traffic can't poison the analytics dashboard with fabricated paths.
- share-chat.html — fires \`share-chat-view\` on DOMContentLoaded and \`share-chat-register-cta\` on the \"Create your own Bot\" button click. Login-modal \"Register\" link and auto-prompt from empty-handed \`handleSend\` are **not** counted — only the explicit CTA click is the numerator we want.

Once this lands, CTR is queryable via the existing aggregation endpoint:

\`\`\`
GET /api/analytics/site-pageviews?path=_cta/share-chat-register-cta
GET /api/analytics/site-pageviews?path=_cta/share-chat-view
\`\`\`

## Test plan

- [x] \`npx jest tests/jest/site-pageviews-cta.test.js\` — ✅ 5/5 (allowlist, pool-missing no-op, happy path, rejection path)
- [x] Full \`npx jest\` — 1992/1992 pass
- [ ] After merge: visit \`/portal/share-chat.html?code=<any>\`, click CTA, then query \`GET /api/analytics/site-pageviews?path=_cta/*\` and confirm two rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)