### PR TITLE
fix(mindmap): rate-limit /traverse + clamp node titles in prompt

### DIFF
--- a/backend/mindmap.js
+++ b/backend/mindmap.js
@@ -59,6 +59,49 @@ function createMindmapModule(devices) {
 
     const router = express.Router();
 
+    // POST /traverse wraps an Anthropic call. Without this bucket a
+    // botSecret holder could loop the endpoint and drain credits. Keyed by
+    // deviceId+entityId (owner caller falls into an 'owner' bucket).
+    const TRAVERSE_WINDOW_MS = 3600000; // 1 hour
+    const TRAVERSE_MAX_PER_HOUR = 15;   // lower than chat (20/hr) — traverse
+                                        // is heavier and less interactive
+    const traverseRateLimit = {};
+
+    function traverseRateKey(deviceId, entityId) {
+        return `${deviceId}:${entityId == null ? 'owner' : entityId}`;
+    }
+
+    function checkTraverseRateLimit(deviceId, entityId) {
+        const key = traverseRateKey(deviceId, entityId);
+        const now = Date.now();
+        const entry = traverseRateLimit[key];
+        if (!entry || now - entry.windowStart > TRAVERSE_WINDOW_MS) {
+            traverseRateLimit[key] = { count: 1, windowStart: now };
+            return { allowed: true, remaining: TRAVERSE_MAX_PER_HOUR - 1 };
+        }
+        if (entry.count >= TRAVERSE_MAX_PER_HOUR) {
+            return {
+                allowed: false,
+                retryAfterMs: TRAVERSE_WINDOW_MS - (now - entry.windowStart),
+                remaining: 0,
+            };
+        }
+        entry.count++;
+        return { allowed: true, remaining: TRAVERSE_MAX_PER_HOUR - entry.count };
+    }
+
+    // Same GC cadence as ai-support.js — prune keys whose windows lapsed
+    // more than one full window ago so the map can't grow unbounded.
+    const traverseGcHandle = setInterval(() => {
+        const now = Date.now();
+        for (const key of Object.keys(traverseRateLimit)) {
+            if (now - traverseRateLimit[key].windowStart > TRAVERSE_WINDOW_MS * 2) {
+                delete traverseRateLimit[key];
+            }
+        }
+    }, 1800000);
+    if (traverseGcHandle.unref) traverseGcHandle.unref();
+
     async function initMindmapTables(p) {
         if (!p) return;
         pool = p;
@@ -623,7 +666,19 @@ function createMindmapModule(devices) {
         if (!deviceId) return;
         if (!requirePool(res)) return;
 
-        const { root_node_id, question } = req.body || {};
+        const { root_node_id, question, entityId } = req.body || {};
+        const gate = checkTraverseRateLimit(deviceId, entityId);
+        if (!gate.allowed) {
+            res.set('Retry-After', Math.ceil(gate.retryAfterMs / 1000));
+            return res.status(429).json({
+                success: false,
+                error: 'Rate limit exceeded',
+                retryAfterMs: gate.retryAfterMs,
+                limit: TRAVERSE_MAX_PER_HOUR,
+                windowMs: TRAVERSE_WINDOW_MS,
+            });
+        }
+
         if (!isUuid(root_node_id)) {
             return res.status(400).json({ success: false, error: 'Invalid root_node_id' });
         }
@@ -682,18 +737,21 @@ function createMindmapModule(devices) {
             const rootRow = nodesById.get(root_node_id);
             const shortId = (id) => id.slice(0, 8);
 
+            // Titles clamped to 120 alongside the existing summary/200 clamp.
+            // A 500-node subgraph × long titles would blow a multi-KB prompt
+            // otherwise; 120 is enough for any real human-written node title.
             const nodeLines = nodeRows.rows.map(n => {
                 const typeTag = n.node_type ? `(${n.node_type})` : '(node)';
                 const marker = n.id === root_node_id ? ' [ROOT]' : '';
                 const summary = n.summary ? ` — ${clampStr(n.summary, 200)}` : '';
-                return `- [${shortId(n.id)}]${marker} "${n.title}" ${typeTag}${summary}`;
+                return `- [${shortId(n.id)}]${marker} "${clampStr(n.title, 120)}" ${typeTag}${summary}`;
             });
             const edgeLines = uniqueEdges.map(e => {
                 const src = nodesById.get(e.source_node_id);
                 const tgt = nodesById.get(e.target_node_id);
                 if (!src || !tgt) return null;
                 const rel = e.edge_type || 'relates_to';
-                return `- [${shortId(e.source_node_id)}] "${src.title}" --(${rel})--> [${shortId(e.target_node_id)}] "${tgt.title}"`;
+                return `- [${shortId(e.source_node_id)}] "${clampStr(src.title, 120)}" --(${rel})--> [${shortId(e.target_node_id)}] "${clampStr(tgt.title, 120)}"`;
             }).filter(Boolean);
 
             const systemPrompt = [
@@ -705,7 +763,7 @@ function createMindmapModule(devices) {
             ].join('\n');
 
             const userMessage = [
-                `Root node: [${shortId(root_node_id)}] "${rootRow?.title || '(unknown)'}"`,
+                `Root node: [${shortId(root_node_id)}] "${clampStr(rootRow?.title, 120) || '(unknown)'}"`,
                 `Depth: ${depth}, Nodes: ${nodeRows.rows.length}, Edges: ${uniqueEdges.length}`,
                 '',
                 'Nodes:',

--- a/backend/tests/jest/mindmap.test.js
+++ b/backend/tests/jest/mindmap.test.js
@@ -256,4 +256,71 @@ describe('mindmap /traverse — happy path (isolated module)', () => {
         expect(res.status).toBe(200);
         expect(res.body.depth).toBe(4); // MAX_TRAVERSE_DEPTH
     });
+
+    // The traverse prompt previously clamped summary to 200 but left title
+    // unclamped, so 500 long-titled nodes could explode the Anthropic prompt.
+    it('clamps node titles to 120 chars in the Anthropic prompt', async () => {
+        const longTitle = 'X'.repeat(300);
+        // Override the node fetch so both rows return the long title. Edges
+        // query still returns the same edge so src.title / tgt.title are
+        // exercised in the edgeLines builder too.
+        poolQueryMock.mockImplementation(async (sql, params) => {
+            const norm = sql.replace(/\s+/g, ' ').trim();
+            if (/SELECT id FROM mindmap_nodes WHERE id = \$1 AND device_id = \$2/i.test(norm)) {
+                return { rowCount: 1, rows: [{ id: ROOT_ID }] };
+            }
+            if (/FROM mindmap_edges/i.test(norm)) {
+                return { rowCount: 1, rows: [{
+                    id: EDGE_ID, device_id: DEVICE_ID,
+                    source_node_id: ROOT_ID, target_node_id: CHILD_ID,
+                    edge_type: 'relates_to', weight: 1.0,
+                }] };
+            }
+            if (/SELECT id, title, summary, node_type FROM mindmap_nodes/i.test(norm)) {
+                return { rowCount: 2, rows: [
+                    { id: ROOT_ID, title: longTitle, summary: 'anchor', node_type: 'topic' },
+                    { id: CHILD_ID, title: longTitle, summary: 'leaf', node_type: 'leaf' },
+                ] };
+            }
+            return { rowCount: 0, rows: [] };
+        });
+
+        const res = await supertest(testApp).post('/api/mindmap/traverse').send({
+            deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET,
+            root_node_id: ROOT_ID, question: 'why?',
+        });
+        expect(res.status).toBe(200);
+        const prompt = callAnthropicMock.mock.calls[0][1][0].content;
+        // No raw 300-char run of "X" should survive anywhere in the prompt
+        expect(prompt).not.toMatch(/X{121,}/);
+        // And the clamped 120-char run must actually appear (root + nodeLines + edgeLines)
+        expect(prompt).toMatch(/X{120}/);
+    });
+
+    // Per-device+entity bucket protects Anthropic credits from bot-secret holders
+    // looping the endpoint. Hits above TRAVERSE_MAX_PER_HOUR return 429 with
+    // Retry-After; separate entity ids get separate buckets.
+    it('returns 429 when per-device+entity rate limit is exceeded', async () => {
+        const TRAVERSE_MAX = 15; // must match mindmap.js constant
+        const ownerBody = {
+            deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET,
+            root_node_id: ROOT_ID, question: 'why?',
+        };
+        // Burn through the entity=owner bucket
+        for (let i = 0; i < TRAVERSE_MAX; i++) {
+            const ok = await supertest(testApp).post('/api/mindmap/traverse').send(ownerBody);
+            expect(ok.status).toBe(200);
+        }
+        const blocked = await supertest(testApp).post('/api/mindmap/traverse').send(ownerBody);
+        expect(blocked.status).toBe(429);
+        expect(blocked.body.error).toMatch(/Rate limit/i);
+        expect(blocked.body.retryAfterMs).toBeGreaterThan(0);
+        expect(blocked.headers['retry-after']).toBeDefined();
+
+        // A call with an explicit entityId should fall into a different bucket.
+        const otherEntity = await supertest(testApp).post('/api/mindmap/traverse').send({
+            ...ownerBody, entityId: 7,
+        });
+        expect(otherEntity.status).toBe(200);
+    });
 });


### PR DESCRIPTION
## Summary

Two follow-up kanban cards from PR #1969, same endpoint (\`POST /api/mindmap/traverse\`), bundled so the review only pays the round-trip cost once.

**Rate limit** — Traverse wraps an Anthropic API call. Without a bucket, a botSecret holder can loop the endpoint and burn credits. Added an in-process bucket keyed by \`deviceId:entityId\` (owner caller falls into an \`owner\` bucket), cap \`TRAVERSE_MAX_PER_HOUR = 15\`. Returns 429 with \`Retry-After\` + \`retryAfterMs\` when hit. Map gets GC'd on the same 30-min cadence \`ai-support.js\` uses; handle is \`.unref()\`'d so it never holds the event loop open.

**Title clamp** — Summary was already clamped to 200 chars in \`nodeLines\`, but title was unclamped in both \`nodeLines\` and \`edgeLines\` (and in the root-header line). A 500-node subgraph with long titles could inflate the prompt into multi-KB territory. \`clampStr(title, 120)\` is enough for any real human-written node title.

## Test plan

- [x] \`npx jest tests/jest/mindmap.test.js\` — ✅ 11/11 (added title-clamp prompt-inspection + 429-on-overflow + separate-entity-bucket tests)
- [x] Full \`npx jest\` — 1994/1994 pass
- [ ] Post-merge: curl /traverse 16× with same deviceId+entityId, confirm 16th returns 429 with Retry-After header

🤖 Generated with [Claude Code](https://claude.com/claude-code)