### PR TITLE
fix(chat): quote-reply auto-injects his_<id> token

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -4360,7 +4360,11 @@
             let finalText = text;
             if (replyContext) {
                 const excerpt = replyContext.text.length > 80 ? replyContext.text.slice(0, 80) + '…' : replyContext.text;
-                const quotePrefix = `↩ ${replyContext.senderName}: "${excerpt}"`;
+                // Embed his_<id> token in the prefix so the referenced bubble
+                // renders as a clickable chip for everyone (sender + recipient
+                // bots see it inline and can scroll back).
+                const hisToken = replyContext.msgId ? ` his_${String(replyContext.msgId).replace(/[^0-9]/g, '')}` : '';
+                const quotePrefix = `↩ ${replyContext.senderName}:${hisToken} "${excerpt}"`;
                 finalText = text ? `${quotePrefix}\n\n${text}` : quotePrefix;
                 clearReplyContext();
             }

--- a/backend/tests/jest/chat-his-link-render.test.js
+++ b/backend/tests/jest/chat-his-link-render.test.js
@@ -37,6 +37,15 @@ describe('his_<id> chip — static wiring', () => {
         expect(chatHtml).toContain('.his-link');
         expect(chatHtml).toContain('his-flash');
     });
+
+    test('quote-reply composer auto-injects his_<id> into the outgoing prefix', () => {
+        // When replyContext is present, the send path must build a quotePrefix
+        // that contains his_<parent_id> so the referenced bubble renders as a
+        // chip for everyone. Regression guard: if someone removes the token,
+        // the feature silently regresses.
+        expect(chatHtml).toMatch(/const\s+hisToken\s*=\s*replyContext\.msgId/);
+        expect(chatHtml).toMatch(/his_\$\{String\(replyContext\.msgId\)/);
+    });
 });
 
 describe('his_<id> chip — module behaviour', () => {


### PR DESCRIPTION
## Summary
Close the user-side half of the historical-reference feature: quote-reply now auto-injects `his_<parent_id>` into the outgoing prefix so the referenced bubble shows as a blue chip for everyone and recipient bots see the reference inline.

## Gap this closes
PR #1978 shipped the chip renderer; #1979 told bots how to emit `his_<id>`. But user quote-reply only produced `↩ Name: "excerpt"` — no token. Hank caught this on the first end-to-end test (`測試引用/回覆會不會自動導入座標`).

## What changed
- `backend/public/portal/chat.html` — `sendMessage` builds `↩ Name: his_<msgId> "excerpt"` when `replyContext` is set. Pre-existing `stripReplyQuotePrefix` strips the whole `\n\n` block, so nested replies still clean up correctly.
- `backend/tests/jest/chat-his-link-render.test.js` — new regression assertion.

## Test plan
- [x] Jest: 14/14 passing locally.
- [ ] Manual: tap ↩ on a bubble → type reply → send → verify the outgoing bubble shows a blue `his_<id>` chip + the recipient bot sees the token in its push payload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)