### PR TITLE
fix(transform,channel): save sender copy when all delivery targets fail

### DIFF
--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -814,6 +814,10 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             // ── speakTo / broadcast delivery ──
             const warnings = [];
             let deliveryResults = null;
+            // Mirror of the /api/transform fallback: set when delivery writes a
+            // chat row. If still false after the delivery block yet delivery was
+            // requested, we save the sender's copy so the message isn't lost.
+            let deliverySaved = false;
             if (entityIdCorrected) {
                 warnings.push(`entityId mismatch: auto-corrected to ${eId}.`);
             }
@@ -847,6 +851,7 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
                         } else {
                             const sourceLabel = `entity:${eId}:${entity.character}`;
                             const broadcastChatMsgId = await saveChatMessage(broadcastDeviceId, eId, deliveryText, `${sourceLabel}->${targetIds.join(',')}`, false, true, null, null, null, null, null, null, validatedCard);
+                            deliverySaved = true;
                             const bcastPrefs = devicePrefs ? await devicePrefs.getPrefs(broadcastDeviceId) : {};
                             const showRecipientInfo = bcastPrefs.broadcast_recipient_info !== false;
                             const results = await Promise.all(targetIds.map(toId =>
@@ -892,9 +897,22 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
                             card: validatedCard
                         });
                         results.push({ publicCode: code, success: true, ...result });
+                        deliverySaved = true;
                     }
                     deliveryResults = { speakTo: true, results };
                 }
+            }
+
+            // Fallback: delivery was requested but no target resolved — save
+            // sender's copy so chat UI still shows the message. Mirror of the
+            // same logic in /api/transform.
+            const hasDeliveryRequested = (broadcast || (speakTo && Array.isArray(speakTo) && speakTo.length > 0));
+            if (hasDeliveryRequested && !deliverySaved && message && !isSilentMsg) {
+                const localSource = hasCrossRoute
+                    ? `xdevice:${entity.publicCode}:${entity.character}->${pendingCross.fromPublicCode || pendingCross.fromDeviceId}`
+                    : (entity.name || `Entity ${eId}`);
+                await saveChatMessage(deviceId, eId, message, localSource, false, true, mediaType || null, mediaUrl || null, null, null, null, null, validatedCard);
+                warnings.push('All delivery targets failed; message saved to sender chat only.');
             }
 
             const response = {

--- a/backend/index.js
+++ b/backend/index.js
@@ -5730,6 +5730,13 @@ app.post('/api/transform', async (req, res) => {
         ? [`entityId mismatch: you provided ${parseInt(entityId) || 0} but your botSecret belongs to entity ${eId}. Auto-corrected to ${eId}.`]
         : [];
     let deliveryResults = null;
+    // Tracks whether the delivery path actually persisted a chat row. If
+    // hasDelivery was true but every target fell through (all speakTo codes
+    // unresolved, broadcast dedup/rate-limit/no-targets/device-missing), the
+    // original code left the message in no chat_messages row at all — silent
+    // data loss. We flip this flag only when a save happens, then use it below
+    // to run a sender-side fallback save.
+    let deliverySaved = false;
 
     if ((speakTo || broadcast) && finalMessage) {
         // If both provided, broadcast takes priority
@@ -5781,6 +5788,7 @@ app.post('/api/transform', async (req, res) => {
                         } else {
                             const sourceLabel = `entity:${eId}:${entity.character}`;
                             const broadcastChatMsgId = await saveChatMessage(broadcastDeviceId, eId, deliveryText, `${sourceLabel}->${targetIds.join(',')}`, false, true, null, null, null, null, null, null, validatedCard, validatedAttachments);
+                            deliverySaved = true;
 
                             // Check recipient info preference
                             const bcastPrefs = await devicePrefs.getPrefs(broadcastDeviceId);
@@ -5906,9 +5914,28 @@ app.post('/api/transform', async (req, res) => {
 
                 console.log(`[Transform+SpeakTo] ${deviceId}:${eId} -> ${target.deviceId}:${target.entityId} (${code})`);
                 results.push({ publicCode: code, success: true, ...result });
+                deliverySaved = true;
             }
 
             deliveryResults = { speakTo: true, results };
+        }
+    }
+
+    // Fallback: delivery was requested but every target fell through (dedup,
+    // rate-limit, no-targets, device-missing, all codes unresolved). Without
+    // this, the sender's own chat row never gets written — message disappears.
+    // Save to sender so the author at least sees their own words, and surface
+    // a warning so the caller knows no delivery happened.
+    const hasDeliveryRequested = (broadcast || (speakTo && Array.isArray(speakTo) && speakTo.length > 0));
+    if (hasDeliveryRequested && !deliverySaved && finalMessage && !isSilentMessage) {
+        const isLeasedOut = entity.rental_status === 'leased_out';
+        if (!isLeasedOut) {
+            const pendingA2A = entity.messageQueue && entity.messageQueue.find(m => m.from && m.from.startsWith('entity:'));
+            const chatSource = pendingA2A
+                ? `entity:${eId}:${entity.character}->${pendingA2A.fromEntityId}`
+                : entity.name || `Entity ${eId}`;
+            await saveChatMessage(deviceId, eId, finalMessage, chatSource, false, true, null, null, null, null, null, null, validatedCard, validatedAttachments);
+            warnings.push('All delivery targets failed; message saved to sender chat only.');
         }
     }
 

--- a/backend/tests/jest/transform-delivery.test.js
+++ b/backend/tests/jest/transform-delivery.test.js
@@ -16,7 +16,14 @@
 require('./helpers/mock-setup');
 
 const request = require('supertest');
+const pg = require('pg');
 let app;
+
+// jest.config has clearMocks:true which wipes pg.Pool.mock.results before
+// every test. We need to snapshot Pool instances at require-time (when
+// chatPool/auth pool/etc. are created) and hold direct references so our
+// INSERT assertions can still scan them after clearMocks runs.
+const pgPoolSnapshot = [];
 
 const post = (path) => request(app).post(path).set('Host', 'localhost');
 
@@ -45,6 +52,11 @@ async function getPublicCode(deviceId, deviceSecret, entityId) {
 
 beforeAll(() => {
     app = require('../../index');
+    // Snapshot all Pool instances constructed during module load (before the
+    // first test fires jest.clearAllMocks and empties pg.Pool.mock.results).
+    for (const r of pg.Pool.mock.results) {
+        if (r.value && !pgPoolSnapshot.includes(r.value)) pgPoolSnapshot.push(r.value);
+    }
 });
 
 afterAll(async () => {
@@ -448,5 +460,147 @@ describe('POST /api/channel/message + speakTo', () => {
             });
         // 403 (invalid key) or 500 (mock DB lacks getChannelAccountByKey) — but NOT a field parsing error
         expect([403, 500].includes(res.status)).toBe(true);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// 11. Fallback save when delivery requested but every target fails
+//     Regression for silent data loss: speakTo-all-fail, broadcast dead
+//     paths (dedup / rate-limit / no-targets / device-missing) used to
+//     leave zero chat rows. After the fix: sender-side row + warning.
+// ════════════════════════════════════════════════════════════════
+describe('Transform fallback save on delivery failure', () => {
+    const deviceId = 'transform-fallback-test';
+    const deviceSecret = `secret-${deviceId}`;
+    let botSecret0, code1;
+
+    beforeAll(async () => {
+        botSecret0 = await bindEntity(deviceId, deviceSecret, 0);
+        await bindEntity(deviceId, deviceSecret, 1);
+        code1 = await getPublicCode(deviceId, deviceSecret, 1);
+    });
+
+    function clearPoolQueries() {
+        for (const p of pgPoolSnapshot) p.query.mockClear();
+    }
+
+    // saveChatMessage uses chatPool; multiple modules create their own Pool
+    // instances, so we have to scan every Pool's query.mock.calls rather than
+    // guessing which one holds chat_messages.
+    function findChatInserts(text) {
+        const matches = [];
+        for (const p of pgPoolSnapshot) {
+            for (const call of p.query.mock.calls) {
+                if (typeof call[0] === 'string'
+                    && call[0].includes('INSERT INTO chat_messages')
+                    && Array.isArray(call[1])
+                    && call[1][2] === text) {
+                    matches.push(call);
+                }
+            }
+        }
+        return matches;
+    }
+
+    it('speakTo with only-unresolved codes → sender row saved + warning', async () => {
+        clearPoolQueries();
+
+        const msg = 'fallback-all-fail-' + Date.now();
+        const res = await post('/api/transform')
+            .send({
+                deviceId,
+                entityId: 0,
+                botSecret: botSecret0,
+                message: msg,
+                state: 'IDLE',
+                speakTo: ['nonexistent-code-xyz']
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body.delivery.results[0].success).toBe(false);
+        expect(res.body.warnings).toBeDefined();
+        expect(res.body.warnings.some(w => w.includes('saved to sender chat only'))).toBe(true);
+
+        // Sender-side row present: is_from_bot=true (index 5), deviceId matches, entity=0
+        const inserts = findChatInserts(msg);
+        expect(inserts.length).toBeGreaterThan(0);
+        const params = inserts[0][1];
+        expect(params[0]).toBe(deviceId);
+        expect(params[1]).toBe(0);
+        expect(params[2]).toBe(msg);
+        expect(params[4]).toBe(false); // is_from_user
+        expect(params[5]).toBe(true);  // is_from_bot
+    });
+
+    it('successful speakTo does not fire fallback (no duplicate save, no warning)', async () => {
+        clearPoolQueries();
+
+        const msg = 'fallback-success-path-' + Date.now();
+        const res = await post('/api/transform')
+            .send({
+                deviceId,
+                entityId: 0,
+                botSecret: botSecret0,
+                message: msg,
+                state: 'IDLE',
+                speakTo: [code1]
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body.delivery.results[0].success).toBe(true);
+        // No fallback warning
+        const fallbackWarn = (res.body.warnings || []).some(w => w.includes('saved to sender chat only'));
+        expect(fallbackWarn).toBe(false);
+        // Exactly one sender-side row (the normal speakTo save), not two
+        const inserts = findChatInserts(msg);
+        expect(inserts.length).toBe(1);
+    });
+
+    it('broadcast with no other bound entities → sender row saved + warning', async () => {
+        // Fresh single-entity device so broadcast has zero targets
+        const devId = 'transform-fallback-solo';
+        const devSecret = `secret-${devId}`;
+        const bs = await bindEntity(devId, devSecret, 0);
+
+        clearPoolQueries();
+
+        const msg = 'fallback-broadcast-solo-' + Date.now();
+        const res = await post('/api/transform')
+            .send({
+                deviceId: devId,
+                entityId: 0,
+                botSecret: bs,
+                message: msg,
+                state: 'IDLE',
+                broadcast: true
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body.warnings).toBeDefined();
+        expect(res.body.warnings.some(w => w.includes('saved to sender chat only'))).toBe(true);
+
+        const inserts = findChatInserts(msg);
+        expect(inserts.length).toBeGreaterThan(0);
+    });
+
+    it('[SILENT] sentinel message skips fallback save (no warning, no sender row)', async () => {
+        clearPoolQueries();
+
+        // [SILENT] is the explicit sentinel that suppresses sender-side saving
+        const msg = '[SILENT]';
+        const res = await post('/api/transform')
+            .send({
+                deviceId,
+                entityId: 0,
+                botSecret: botSecret0,
+                message: msg,
+                state: 'IDLE',
+                speakTo: ['nonexistent-code-xyz']
+            });
+
+        expect(res.status).toBe(200);
+        const fallbackWarn = (res.body.warnings || []).some(w => w.includes('saved to sender chat only'));
+        expect(fallbackWarn).toBe(false);
+        expect(findChatInserts(msg).length).toBe(0);
     });
 });


### PR DESCRIPTION
## Summary
- `/api/transform` and `/api/channel/message` used to drop the sender's own chat row whenever `speakTo` or `broadcast:true` was requested but every target failed (all codes unresolved, broadcast dedup/rate-limit/no-peers/device-missing).
- Now: track `deliverySaved` across the delivery block; on 0 saves, write a sender-side copy and return a warning. `[SILENT]` sentinel + leased_out entities still opt out.
- Added 4 jest regression tests covering speakTo-all-fail, successful-speakTo-no-duplicate, broadcast-solo, and `[SILENT]`.

## Why this bug existed
Prod probe 2026-04-22 confirmed: my own onboarding message (sent with `speakTo:["Eclaw_Office","Hermes"]` — entity names instead of the 6-char publicCodes) resolved 0 targets and produced 0 rows in `chat_messages`. Silent data loss.

## Test plan
- [x] `npx jest tests/jest/transform-delivery.test.js` — 20/20 pass
- [x] `npx jest` full suite — 2004/2004 pass
- [ ] Post-merge: prod probe with invalid `speakTo` code → confirm warning + sender row visible in chat UI