### PR TITLE
feat(mindmap): Route A mirror — auto-pair notes with mindmap leaves

### DIFF
--- a/backend/mindmap-mirror.js
+++ b/backend/mindmap-mirror.js
@@ -1,0 +1,220 @@
+/**
+ * Mindmap Mirror — Route A (Mirror mode) auto-pair between notes and mindmap.
+ *
+ * Every mission note gets a matching mindmap leaf node whose parent is a
+ * lazily-created domain node for the note's category. The leaf carries a
+ * `note` anchor pointing back to the note, and the domain carries a
+ * `note_category` anchor keyed on the normalised (lowercased, trimmed)
+ * category string so future lookups are O(1) regardless of title drift.
+ *
+ * Ownership: this module writes directly to the `mindmap_nodes` /
+ * `mindmap_edges` / `mindmap_node_anchors` tables via the shared pg pool.
+ * All writes are device-scoped; a bad deviceId can never leak rows across
+ * tenants because every query carries WHERE device_id = $1.
+ *
+ * Failure policy: every mirror call is called from mission.js AFTER the
+ * source-of-truth note write has already committed. If a mirror call throws,
+ * the caller logs + swallows — mindmap is a derived read model and must not
+ * block note CRUD. Backfill is idempotent so a dropped write can be healed.
+ */
+'use strict';
+
+const SUMMARY_CLAMP = 200;
+const DEFAULT_CATEGORY = 'general';
+const DEFAULT_TITLE = '(untitled note)';
+
+function clampStr(v, max) {
+    if (v === null || v === undefined) return null;
+    const s = String(v);
+    return s.length > max ? s.slice(0, max) : s;
+}
+
+function normCategory(cat) {
+    const c = (cat == null ? '' : String(cat)).trim();
+    return (c || DEFAULT_CATEGORY).toLowerCase();
+}
+
+function displayCategory(cat) {
+    const c = (cat == null ? '' : String(cat)).trim();
+    return c || DEFAULT_CATEGORY;
+}
+
+function displayTitle(title) {
+    const t = (title == null ? '' : String(title)).trim();
+    return t || DEFAULT_TITLE;
+}
+
+async function findNodeIdForNote(pool, deviceId, noteId) {
+    const r = await pool.query(
+        `SELECT node_id FROM mindmap_node_anchors
+         WHERE device_id = $1 AND anchor_type = 'note' AND anchor_ref = $2
+         LIMIT 1`,
+        [deviceId, String(noteId)]
+    );
+    return r.rowCount === 0 ? null : r.rows[0].node_id;
+}
+
+async function ensureCategoryDomainNode(pool, deviceId, entityId, category) {
+    const norm = normCategory(category);
+    const existing = await pool.query(
+        `SELECT n.id FROM mindmap_nodes n
+         JOIN mindmap_node_anchors a ON a.node_id = n.id
+         WHERE n.device_id = $1
+           AND n.node_type = 'domain'
+           AND a.anchor_type = 'note_category'
+           AND a.anchor_ref = $2
+         LIMIT 1`,
+        [deviceId, norm]
+    );
+    if (existing.rowCount > 0) return existing.rows[0].id;
+
+    const title = displayCategory(category);
+    const ins = await pool.query(
+        `INSERT INTO mindmap_nodes (device_id, entity_id, title, summary, node_type)
+         VALUES ($1, $2, $3, $4, 'domain') RETURNING id`,
+        [
+            deviceId,
+            entityId == null ? null : entityId,
+            title,
+            `Auto-generated category domain for "${title}" notes (mirror mode).`,
+        ]
+    );
+    const nodeId = ins.rows[0].id;
+    await pool.query(
+        `INSERT INTO mindmap_node_anchors (device_id, node_id, anchor_type, anchor_ref, display_label)
+         VALUES ($1, $2, 'note_category', $3, $4)`,
+        [deviceId, nodeId, norm, title]
+    );
+    return nodeId;
+}
+
+async function ensureParentOfEdge(pool, deviceId, childId, parentId) {
+    if (!childId || !parentId || childId === parentId) return null;
+    const existing = await pool.query(
+        `SELECT id FROM mindmap_edges
+         WHERE device_id = $1
+           AND source_node_id = $2
+           AND target_node_id = $3
+           AND edge_type = 'parent_of'
+         LIMIT 1`,
+        [deviceId, parentId, childId]
+    );
+    if (existing.rowCount > 0) return existing.rows[0].id;
+    const ins = await pool.query(
+        `INSERT INTO mindmap_edges (device_id, source_node_id, target_node_id, edge_type)
+         VALUES ($1, $2, $3, 'parent_of') RETURNING id`,
+        [deviceId, parentId, childId]
+    );
+    return ins.rows[0].id;
+}
+
+async function mirrorNoteCreate(pool, deviceId, entityId, note) {
+    if (!note || !note.id) throw new Error('note.id required');
+
+    const existing = await findNodeIdForNote(pool, deviceId, note.id);
+    if (existing) return { nodeId: existing, created: false };
+
+    const domainId = await ensureCategoryDomainNode(pool, deviceId, entityId, note.category);
+    const title = displayTitle(note.title);
+    const summary = clampStr(note.content, SUMMARY_CLAMP);
+
+    const nodeRes = await pool.query(
+        `INSERT INTO mindmap_nodes (device_id, entity_id, title, summary, node_type, parent_node_id)
+         VALUES ($1, $2, $3, $4, 'leaf', $5) RETURNING id`,
+        [deviceId, entityId == null ? null : entityId, title, summary, domainId]
+    );
+    const nodeId = nodeRes.rows[0].id;
+
+    await pool.query(
+        `INSERT INTO mindmap_node_anchors (device_id, node_id, anchor_type, anchor_ref, display_label)
+         VALUES ($1, $2, 'note', $3, $4)`,
+        [deviceId, nodeId, String(note.id), title]
+    );
+    await ensureParentOfEdge(pool, deviceId, nodeId, domainId);
+    return { nodeId, created: true, domainId };
+}
+
+async function mirrorNoteUpdate(pool, deviceId, entityId, note) {
+    if (!note || !note.id) return null;
+
+    const nodeId = await findNodeIdForNote(pool, deviceId, note.id);
+    if (!nodeId) return mirrorNoteCreate(pool, deviceId, entityId, note);
+
+    const title = displayTitle(note.title);
+    const summary = clampStr(note.content, SUMMARY_CLAMP);
+
+    await pool.query(
+        `UPDATE mindmap_nodes
+         SET title = $1, summary = $2, updated_at = NOW()
+         WHERE id = $3 AND device_id = $4`,
+        [title, summary, nodeId, deviceId]
+    );
+    await pool.query(
+        `UPDATE mindmap_node_anchors
+         SET display_label = $1
+         WHERE device_id = $2 AND node_id = $3 AND anchor_type = 'note'`,
+        [title, deviceId, nodeId]
+    );
+
+    if (note.category !== undefined) {
+        const newDomainId = await ensureCategoryDomainNode(pool, deviceId, entityId, note.category);
+        await pool.query(
+            `UPDATE mindmap_nodes SET parent_node_id = $1
+             WHERE id = $2 AND device_id = $3`,
+            [newDomainId, nodeId, deviceId]
+        );
+        await pool.query(
+            `DELETE FROM mindmap_edges
+             WHERE device_id = $1 AND target_node_id = $2 AND edge_type = 'parent_of'`,
+            [deviceId, nodeId]
+        );
+        await ensureParentOfEdge(pool, deviceId, nodeId, newDomainId);
+    }
+    return { nodeId, updated: true };
+}
+
+async function mirrorNoteDelete(pool, deviceId, noteId) {
+    if (!noteId) return null;
+    const nodeId = await findNodeIdForNote(pool, deviceId, noteId);
+    if (!nodeId) return null;
+    await pool.query(
+        `DELETE FROM mindmap_nodes WHERE id = $1 AND device_id = $2`,
+        [nodeId, deviceId]
+    );
+    return { nodeId, deleted: true };
+}
+
+async function mirrorBackfill(pool, deviceId, entityId, notes) {
+    const result = { total: 0, created: 0, skipped: 0, errors: 0 };
+    for (const note of (notes || [])) {
+        result.total++;
+        try {
+            const r = await mirrorNoteCreate(pool, deviceId, entityId, note);
+            if (r.created) result.created++;
+            else result.skipped++;
+        } catch (err) {
+            result.errors++;
+            console.error(`[MindmapMirror] backfill failed for note ${note && note.id}:`, err.message);
+        }
+    }
+    return result;
+}
+
+module.exports = {
+    mirrorNoteCreate,
+    mirrorNoteUpdate,
+    mirrorNoteDelete,
+    mirrorBackfill,
+    _internal: {
+        ensureCategoryDomainNode,
+        ensureParentOfEdge,
+        findNodeIdForNote,
+        normCategory,
+        displayCategory,
+        displayTitle,
+        clampStr,
+        SUMMARY_CLAMP,
+        DEFAULT_CATEGORY,
+        DEFAULT_TITLE,
+    },
+};

--- a/backend/mindmap.js
+++ b/backend/mindmap.js
@@ -32,6 +32,7 @@
 const express = require('express');
 const safeEqual = require('./safe-equal');
 const { callAnthropic } = require('./anthropic-client');
+const mindmapMirror = require('./mindmap-mirror');
 
 const NODE_TYPES = new Set(['domain', 'topic', 'leaf', 'concept']);
 const EDGE_TYPES = new Set(['relates_to', 'causes', 'extends', 'opposes', 'parent_of']);
@@ -796,6 +797,29 @@ function createMindmapModule(devices) {
             });
         } catch (err) {
             console.error('[Mindmap] POST /traverse failed:', err.message);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
+    // ─── POST /mirror/backfill ───────────────────────────────────────────────
+    // Route A (Mirror mode) one-shot backfill: ensures every note in
+    // mission_dashboard.notes has a matching mindmap leaf node + note anchor.
+    // Idempotent — re-running only creates nodes for notes that still lack one.
+    router.post('/mirror/backfill', async (req, res) => {
+        const deviceId = authenticate(req, res);
+        if (!deviceId) return;
+        if (!requirePool(res)) return;
+        const entityId = getEntityId(req);
+        try {
+            const dash = await pool.query(
+                'SELECT notes FROM mission_dashboard WHERE device_id = $1',
+                [deviceId]
+            );
+            const notes = (dash.rows[0] && dash.rows[0].notes) || [];
+            const result = await mindmapMirror.mirrorBackfill(pool, deviceId, entityId, notes);
+            res.json({ success: true, ...result });
+        } catch (err) {
+            console.error('[Mindmap] POST /mirror/backfill failed:', err.message);
             res.status(500).json({ success: false, error: err.message });
         }
     });

--- a/backend/mission.js
+++ b/backend/mission.js
@@ -31,6 +31,18 @@ const fs = require('fs');
 const path = require('path');
 const safeEqual = require('./safe-equal');
 const { newNoteId, newSkillId, newRuleId } = require('./entity-id');
+const mindmapMirror = require('./mindmap-mirror');
+
+// Mirror a note-CRUD event into the mindmap, swallowing errors. The mindmap
+// is a derived read model — a mirror failure must never roll back the note
+// write that has already committed.
+function fireMirror(op, args) {
+    return Promise.resolve()
+        .then(() => op(...args))
+        .catch(err => {
+            console.error(`[MindmapMirror] ${op.name} failed:`, err.message);
+        });
+}
 
 const pool = new Pool({
     connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
@@ -721,6 +733,8 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
                 ON CONFLICT (device_id, note_id) DO NOTHING
             `, [deviceId, noteId, content || '']);
 
+            fireMirror(mindmapMirror.mirrorNoteCreate, [pool, deviceId, entityId, newNote]);
+
             if (serverLog) serverLog('info', 'mission', `[Mission] Note added: "${newNote.title}" by bot, device ${deviceId}`, { deviceId });
             res.json({ success: true, message: `Note "${newNote.title}" added`, item: newNote, noteId, version: updateResult.rows[0].version });
         } catch (error) {
@@ -738,7 +752,7 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
     // ============================================
     router.post('/note/update', async (req, res) => {
         if (!authenticate(req, res)) return;
-        const { deviceId, title } = req.body;
+        const { deviceId, title, entityId } = req.body;
         // Accept content/category as aliases for newContent/newCategory (#1888)
         const newTitle = req.body.newTitle;
         const newContent = req.body.newContent !== undefined ? req.body.newContent : req.body.content;
@@ -784,6 +798,15 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
 
             if (process.env.DEBUG === 'true') console.log(`[Mission] Note updated: "${note.title}", device ${deviceId}`);
             if (serverLog) serverLog('info', 'mission', `[Mission] Note updated: "${note.title}", device ${deviceId}`, { deviceId });
+
+            const mirrorNote = {
+                id: note.id,
+                title: note.title,
+                content: note.content,
+                ...(newCategory !== undefined ? { category: note.category } : {}),
+            };
+            fireMirror(mindmapMirror.mirrorNoteUpdate, [pool, deviceId, entityId, mirrorNote]);
+
             res.json({ success: true, message: `Note "${note.title}" updated`, item: note, version: updateResult.rows[0].version });
         } catch (error) {
             await client.query('ROLLBACK');
@@ -828,6 +851,7 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
                 return res.status(404).json({ success: false, error: `Note not found: "${title}"` });
             }
 
+            const deletedNote = notes[foundIdx];
             notes.splice(foundIdx, 1);
 
             const updateResult = await client.query(
@@ -839,6 +863,11 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
 
             if (process.env.DEBUG === 'true') console.log(`[Mission] Note deleted: "${title}", device ${deviceId}`);
             if (serverLog) serverLog('info', 'mission', `[Mission] Note deleted: "${title}", device ${deviceId}`, { deviceId });
+
+            if (deletedNote && deletedNote.id) {
+                fireMirror(mindmapMirror.mirrorNoteDelete, [pool, deviceId, deletedNote.id]);
+            }
+
             res.json({ success: true, message: `Note "${title}" deleted`, version: updateResult.rows[0].version });
         } catch (error) {
             await client.query('ROLLBACK');

--- a/backend/tests/jest/mindmap-mirror.test.js
+++ b/backend/tests/jest/mindmap-mirror.test.js
@@ -1,0 +1,355 @@
+/**
+ * Unit tests for mindmap-mirror (Route A — Mirror mode).
+ *
+ * Uses an in-memory fake pool that mimics the Postgres pool surface
+ * (`.query(sql, params)` returning `{ rowCount, rows }`) just enough to
+ * exercise the mirror helpers end-to-end without a live DB.
+ *
+ * The fake models three tables — mindmap_nodes, mindmap_edges,
+ * mindmap_node_anchors — and supports just the SQL shapes the mirror
+ * issues. It's deliberately narrow: the point is to verify the mirror's
+ * behaviour (idempotency, parent_of wiring, category domain reuse), not
+ * to reimplement Postgres.
+ */
+'use strict';
+
+const mirror = require('../../mindmap-mirror');
+
+function makeFakePool() {
+    let nodeSeq = 1;
+    let edgeSeq = 1;
+    let anchorSeq = 1;
+    const nodes = [];
+    const edges = [];
+    const anchors = [];
+
+    function uuid(prefix, n) {
+        const hex = n.toString(16).padStart(12, '0');
+        return `${prefix.padEnd(8, '0').slice(0, 8)}-0000-4000-8000-${hex}`;
+    }
+
+    async function query(sql, params) {
+        const norm = sql.replace(/\s+/g, ' ').trim();
+
+        // findNodeIdForNote
+        if (norm.startsWith("SELECT node_id FROM mindmap_node_anchors WHERE device_id = $1 AND anchor_type = 'note' AND anchor_ref = $2")) {
+            const [deviceId, noteId] = params;
+            const row = anchors.find(a =>
+                a.device_id === deviceId && a.anchor_type === 'note' && a.anchor_ref === String(noteId)
+            );
+            return row
+                ? { rowCount: 1, rows: [{ node_id: row.node_id }] }
+                : { rowCount: 0, rows: [] };
+        }
+
+        // ensureCategoryDomainNode lookup
+        if (norm.startsWith("SELECT n.id FROM mindmap_nodes n JOIN mindmap_node_anchors a ON a.node_id = n.id")) {
+            const [deviceId, normCat] = params;
+            const anchor = anchors.find(a =>
+                a.device_id === deviceId && a.anchor_type === 'note_category' && a.anchor_ref === normCat
+            );
+            if (!anchor) return { rowCount: 0, rows: [] };
+            const node = nodes.find(n => n.id === anchor.node_id && n.node_type === 'domain');
+            return node
+                ? { rowCount: 1, rows: [{ id: node.id }] }
+                : { rowCount: 0, rows: [] };
+        }
+
+        // ensureParentOfEdge lookup
+        if (norm.startsWith("SELECT id FROM mindmap_edges WHERE device_id = $1 AND source_node_id = $2 AND target_node_id = $3 AND edge_type = 'parent_of'")) {
+            const [deviceId, source, target] = params;
+            const edge = edges.find(e =>
+                e.device_id === deviceId && e.source_node_id === source && e.target_node_id === target && e.edge_type === 'parent_of'
+            );
+            return edge ? { rowCount: 1, rows: [{ id: edge.id }] } : { rowCount: 0, rows: [] };
+        }
+
+        // INSERT node (domain or leaf)
+        if (norm.startsWith('INSERT INTO mindmap_nodes')) {
+            const [deviceId, entityId, title, summary, ...rest] = params;
+            const isLeaf = norm.includes("'leaf'");
+            const node = {
+                id: uuid('node', nodeSeq++),
+                device_id: deviceId,
+                entity_id: entityId,
+                title,
+                summary,
+                node_type: isLeaf ? 'leaf' : 'domain',
+                parent_node_id: isLeaf ? rest[0] : null,
+            };
+            nodes.push(node);
+            return { rowCount: 1, rows: [{ id: node.id }] };
+        }
+
+        // INSERT anchor (note or note_category) — anchor_type is a SQL literal,
+        // not a placeholder, so it must be parsed from the VALUES clause.
+        if (norm.startsWith('INSERT INTO mindmap_node_anchors')) {
+            const [deviceId, nodeId, anchor_ref, display_label] = params;
+            const anchor_type = norm.includes("'note_category'") ? 'note_category' : 'note';
+            const row = {
+                id: uuid('anch', anchorSeq++),
+                device_id: deviceId,
+                node_id: nodeId,
+                anchor_type,
+                anchor_ref,
+                display_label,
+            };
+            anchors.push(row);
+            return { rowCount: 1, rows: [row] };
+        }
+
+        // INSERT edge (parent_of)
+        if (norm.startsWith('INSERT INTO mindmap_edges')) {
+            const [deviceId, source, target] = params;
+            const edge = {
+                id: uuid('edge', edgeSeq++),
+                device_id: deviceId,
+                source_node_id: source,
+                target_node_id: target,
+                edge_type: 'parent_of',
+            };
+            edges.push(edge);
+            return { rowCount: 1, rows: [{ id: edge.id }] };
+        }
+
+        // UPDATE node (title/summary)
+        if (norm.startsWith('UPDATE mindmap_nodes SET title = $1, summary = $2')) {
+            const [title, summary, nodeId, deviceId] = params;
+            const node = nodes.find(n => n.id === nodeId && n.device_id === deviceId);
+            if (!node) return { rowCount: 0, rows: [] };
+            node.title = title;
+            node.summary = summary;
+            return { rowCount: 1, rows: [node] };
+        }
+
+        // UPDATE anchor display_label
+        if (norm.startsWith('UPDATE mindmap_node_anchors SET display_label = $1')) {
+            const [label, deviceId, nodeId] = params;
+            let n = 0;
+            for (const a of anchors) {
+                if (a.device_id === deviceId && a.node_id === nodeId && a.anchor_type === 'note') {
+                    a.display_label = label;
+                    n++;
+                }
+            }
+            return { rowCount: n, rows: [] };
+        }
+
+        // UPDATE node parent_node_id
+        if (norm.startsWith('UPDATE mindmap_nodes SET parent_node_id = $1')) {
+            const [parentId, nodeId, deviceId] = params;
+            const node = nodes.find(n => n.id === nodeId && n.device_id === deviceId);
+            if (!node) return { rowCount: 0, rows: [] };
+            node.parent_node_id = parentId;
+            return { rowCount: 1, rows: [node] };
+        }
+
+        // DELETE parent_of edges targeting a node (before re-linking on category change)
+        if (norm.startsWith("DELETE FROM mindmap_edges WHERE device_id = $1 AND target_node_id = $2 AND edge_type = 'parent_of'")) {
+            const [deviceId, nodeId] = params;
+            const before = edges.length;
+            for (let i = edges.length - 1; i >= 0; i--) {
+                const e = edges[i];
+                if (e.device_id === deviceId && e.target_node_id === nodeId && e.edge_type === 'parent_of') {
+                    edges.splice(i, 1);
+                }
+            }
+            return { rowCount: before - edges.length, rows: [] };
+        }
+
+        // DELETE node (cascade simulated)
+        if (norm.startsWith('DELETE FROM mindmap_nodes WHERE id = $1 AND device_id = $2')) {
+            const [nodeId, deviceId] = params;
+            const idx = nodes.findIndex(n => n.id === nodeId && n.device_id === deviceId);
+            if (idx < 0) return { rowCount: 0, rows: [] };
+            nodes.splice(idx, 1);
+            for (let i = edges.length - 1; i >= 0; i--) {
+                if (edges[i].source_node_id === nodeId || edges[i].target_node_id === nodeId) edges.splice(i, 1);
+            }
+            for (let i = anchors.length - 1; i >= 0; i--) {
+                if (anchors[i].node_id === nodeId) anchors.splice(i, 1);
+            }
+            return { rowCount: 1, rows: [{ id: nodeId }] };
+        }
+
+        throw new Error(`Fake pool: unhandled SQL\n${norm}`);
+    }
+
+    return { query, _state: { nodes, edges, anchors } };
+}
+
+const DEVICE_ID = 'device-A';
+const ENTITY_ID = 2;
+
+describe('mindmap-mirror — Route A mirror mode', () => {
+    it('mirrorNoteCreate creates a leaf node + note anchor + parent_of edge to a domain node', async () => {
+        const pool = makeFakePool();
+        const note = { id: 'note-1', title: 'First note', content: 'hello world', category: 'ideas' };
+        const r = await mirror.mirrorNoteCreate(pool, DEVICE_ID, ENTITY_ID, note);
+        expect(r.created).toBe(true);
+
+        const { nodes, edges, anchors } = pool._state;
+        expect(nodes).toHaveLength(2);
+        const domain = nodes.find(n => n.node_type === 'domain');
+        const leaf = nodes.find(n => n.node_type === 'leaf');
+        expect(domain.title).toBe('ideas');
+        expect(leaf.title).toBe('First note');
+        expect(leaf.summary).toBe('hello world');
+        expect(leaf.parent_node_id).toBe(domain.id);
+
+        // Anchor points back to the note
+        const noteAnchor = anchors.find(a => a.anchor_type === 'note');
+        expect(noteAnchor.node_id).toBe(leaf.id);
+        expect(noteAnchor.anchor_ref).toBe('note-1');
+
+        // Category anchor on the domain for O(1) lookup next time
+        const catAnchor = anchors.find(a => a.anchor_type === 'note_category');
+        expect(catAnchor.node_id).toBe(domain.id);
+        expect(catAnchor.anchor_ref).toBe('ideas');
+
+        // parent_of edge from domain → leaf
+        const edge = edges.find(e => e.edge_type === 'parent_of');
+        expect(edge.source_node_id).toBe(domain.id);
+        expect(edge.target_node_id).toBe(leaf.id);
+    });
+
+    it('two notes with the same category reuse one domain node', async () => {
+        const pool = makeFakePool();
+        await mirror.mirrorNoteCreate(pool, DEVICE_ID, ENTITY_ID,
+            { id: 'n1', title: 'one', content: '', category: 'work' });
+        await mirror.mirrorNoteCreate(pool, DEVICE_ID, ENTITY_ID,
+            { id: 'n2', title: 'two', content: '', category: 'work' });
+
+        const { nodes, edges } = pool._state;
+        const domains = nodes.filter(n => n.node_type === 'domain');
+        const leaves = nodes.filter(n => n.node_type === 'leaf');
+        expect(domains).toHaveLength(1);
+        expect(leaves).toHaveLength(2);
+        expect(leaves.every(l => l.parent_node_id === domains[0].id)).toBe(true);
+        expect(edges.filter(e => e.edge_type === 'parent_of')).toHaveLength(2);
+    });
+
+    it('category is normalized — "Ideas" and "ideas" resolve to the same domain', async () => {
+        const pool = makeFakePool();
+        await mirror.mirrorNoteCreate(pool, DEVICE_ID, ENTITY_ID,
+            { id: 'n1', title: 'a', content: '', category: 'Ideas' });
+        await mirror.mirrorNoteCreate(pool, DEVICE_ID, ENTITY_ID,
+            { id: 'n2', title: 'b', content: '', category: 'ideas' });
+        const domains = pool._state.nodes.filter(n => n.node_type === 'domain');
+        expect(domains).toHaveLength(1);
+    });
+
+    it('missing/empty category falls back to DEFAULT_CATEGORY', async () => {
+        const pool = makeFakePool();
+        await mirror.mirrorNoteCreate(pool, DEVICE_ID, ENTITY_ID,
+            { id: 'n1', title: 'a', content: '' });
+        await mirror.mirrorNoteCreate(pool, DEVICE_ID, ENTITY_ID,
+            { id: 'n2', title: 'b', content: '', category: '' });
+        const domains = pool._state.nodes.filter(n => n.node_type === 'domain');
+        expect(domains).toHaveLength(1);
+        expect(domains[0].title).toBe('general');
+    });
+
+    it('content longer than SUMMARY_CLAMP is truncated to 200 chars', async () => {
+        const pool = makeFakePool();
+        const longContent = 'x'.repeat(500);
+        await mirror.mirrorNoteCreate(pool, DEVICE_ID, ENTITY_ID,
+            { id: 'n1', title: 'a', content: longContent, category: 'c' });
+        const leaf = pool._state.nodes.find(n => n.node_type === 'leaf');
+        expect(leaf.summary.length).toBe(200);
+    });
+
+    it('mirrorNoteCreate is idempotent — second call skips creation', async () => {
+        const pool = makeFakePool();
+        const note = { id: 'n1', title: 'a', content: '', category: 'c' };
+        const r1 = await mirror.mirrorNoteCreate(pool, DEVICE_ID, ENTITY_ID, note);
+        const r2 = await mirror.mirrorNoteCreate(pool, DEVICE_ID, ENTITY_ID, note);
+        expect(r1.created).toBe(true);
+        expect(r2.created).toBe(false);
+        expect(r2.nodeId).toBe(r1.nodeId);
+        expect(pool._state.nodes).toHaveLength(2);
+    });
+
+    it('mirrorNoteUpdate syncs title and summary on the existing leaf', async () => {
+        const pool = makeFakePool();
+        await mirror.mirrorNoteCreate(pool, DEVICE_ID, ENTITY_ID,
+            { id: 'n1', title: 'old', content: 'old body', category: 'c' });
+        await mirror.mirrorNoteUpdate(pool, DEVICE_ID, ENTITY_ID,
+            { id: 'n1', title: 'new title', content: 'new body' });
+        const leaf = pool._state.nodes.find(n => n.node_type === 'leaf');
+        expect(leaf.title).toBe('new title');
+        expect(leaf.summary).toBe('new body');
+        const anchor = pool._state.anchors.find(a => a.anchor_type === 'note');
+        expect(anchor.display_label).toBe('new title');
+    });
+
+    it('mirrorNoteUpdate with a new category repositions the leaf under a new domain', async () => {
+        const pool = makeFakePool();
+        await mirror.mirrorNoteCreate(pool, DEVICE_ID, ENTITY_ID,
+            { id: 'n1', title: 'a', content: '', category: 'old' });
+        const leafId = pool._state.nodes.find(n => n.node_type === 'leaf').id;
+        await mirror.mirrorNoteUpdate(pool, DEVICE_ID, ENTITY_ID,
+            { id: 'n1', title: 'a', content: '', category: 'new' });
+        const domains = pool._state.nodes.filter(n => n.node_type === 'domain');
+        expect(domains).toHaveLength(2);
+        const newDomain = domains.find(d => d.title === 'new');
+        const leaf = pool._state.nodes.find(n => n.id === leafId);
+        expect(leaf.parent_node_id).toBe(newDomain.id);
+        const parentEdges = pool._state.edges.filter(e => e.edge_type === 'parent_of' && e.target_node_id === leafId);
+        expect(parentEdges).toHaveLength(1);
+        expect(parentEdges[0].source_node_id).toBe(newDomain.id);
+    });
+
+    it('mirrorNoteUpdate creates a node if none existed yet (upsert behaviour)', async () => {
+        const pool = makeFakePool();
+        const r = await mirror.mirrorNoteUpdate(pool, DEVICE_ID, ENTITY_ID,
+            { id: 'n1', title: 'a', content: '', category: 'c' });
+        expect(r.created).toBe(true);
+        expect(pool._state.nodes.filter(n => n.node_type === 'leaf')).toHaveLength(1);
+    });
+
+    it('mirrorNoteDelete removes the leaf and cascades edges + anchors', async () => {
+        const pool = makeFakePool();
+        await mirror.mirrorNoteCreate(pool, DEVICE_ID, ENTITY_ID,
+            { id: 'n1', title: 'a', content: '', category: 'c' });
+        const { nodes, edges, anchors } = pool._state;
+        const leafId = nodes.find(n => n.node_type === 'leaf').id;
+        await mirror.mirrorNoteDelete(pool, DEVICE_ID, 'n1');
+        expect(nodes.find(n => n.id === leafId)).toBeUndefined();
+        expect(edges.filter(e => e.target_node_id === leafId)).toHaveLength(0);
+        expect(anchors.filter(a => a.node_id === leafId)).toHaveLength(0);
+        // Domain stays put for the (now-empty) category
+        expect(nodes.filter(n => n.node_type === 'domain')).toHaveLength(1);
+    });
+
+    it('mirrorNoteDelete is a no-op for a note that was never mirrored', async () => {
+        const pool = makeFakePool();
+        const r = await mirror.mirrorNoteDelete(pool, DEVICE_ID, 'never-mirrored');
+        expect(r).toBeNull();
+    });
+
+    it('mirrorBackfill processes a batch and is idempotent on re-run', async () => {
+        const pool = makeFakePool();
+        const notes = [
+            { id: 'n1', title: 'a', content: '', category: 'c' },
+            { id: 'n2', title: 'b', content: '', category: 'c' },
+            { id: 'n3', title: 'c', content: '', category: 'other' },
+        ];
+        const r1 = await mirror.mirrorBackfill(pool, DEVICE_ID, ENTITY_ID, notes);
+        expect(r1).toEqual({ total: 3, created: 3, skipped: 0, errors: 0 });
+
+        const r2 = await mirror.mirrorBackfill(pool, DEVICE_ID, ENTITY_ID, notes);
+        expect(r2).toEqual({ total: 3, created: 0, skipped: 3, errors: 0 });
+
+        expect(pool._state.nodes.filter(n => n.node_type === 'leaf')).toHaveLength(3);
+        expect(pool._state.nodes.filter(n => n.node_type === 'domain')).toHaveLength(2);
+    });
+
+    it('empty title / empty content still produce a valid node with default title', async () => {
+        const pool = makeFakePool();
+        await mirror.mirrorNoteCreate(pool, DEVICE_ID, ENTITY_ID,
+            { id: 'n1', title: '', content: '', category: 'c' });
+        const leaf = pool._state.nodes.find(n => n.node_type === 'leaf');
+        expect(leaf.title).toBe('(untitled note)');
+    });
+});


### PR DESCRIPTION
## Summary
- New `mindmap-mirror.js` module keeps every mission note paired with a mindmap leaf under a lazily-created domain node for the note's category.
- Note anchors (`note`) and category anchors (`note_category`, keyed on the normalised category) make create/update/delete O(1) and idempotent — safe to retry, safe to re-run as a backfill.
- Integrated into `mission.js` as fire-and-forget so a mirror failure never rolls back the note write that already committed; exposes `POST /mindmap/mirror/backfill` for one-shot healing of devices with pre-existing notes.

## Test plan
- [x] `npx jest tests/jest/mindmap-mirror.test.js` — 13/13 green (idempotency, category dedup + normalisation, title/summary sync, category-change re-parenting, delete cascade, backfill reruns)
- [x] Full jest suite 2013/2013 pass — no regressions elsewhere
- [ ] Post-merge on prod: create a note → confirm a leaf appears under the category domain; update the note's category → confirm re-parenting; delete the note → confirm leaf gone and domain stays

🤖 Generated with [Claude Code](https://claude.com/claude-code)