### PR TITLE
fix(tests): add deviceSecret to integration tests hitting /api/entities

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@
 - **Repository**: `HankHuang0516/realbot` (GitHub repo ID: `1150444936`)
 - **Production URL**: `https://eclawbot.com`
 - **Package name**: `realbot-backend` (historical name; brand is "EClaw")
-- **Current version**: 1.1045.x+ (via semantic-release; `package.json` stays 1.0.0 placeholder)
+- **Current version**: 1.1054.x+ (via semantic-release; `package.json` stays 1.0.0 placeholder)
 - **Android app version**: 1.0.76 (versionCode 82); `LATEST_APP_VERSION` constant in `backend/index.js`
 - **Brand name**: "EClawbot" (rebranded from "EClaw" in v1.105.0; domain `eclawbot.com`)
 
@@ -865,11 +865,23 @@ curl "https://eclawbot.com/api/device-telemetry?deviceId=ID&deviceSecret=SECRET&
 - **Chat Reply + Photo Fix**: Reply quote and photo attachment conflict resolved
 - **Marketing Hero Image**: Vector-memory hero image v1 (1200×630 OG) for social sharing
 
+### Recent Features (v1.1046.x – v1.1054.x)
+
+- **Onboarding Wizard (v1.1046–v1.1048)**: Scope 0 intent-based 3-question wizard router; 6 product tour tracks (free bot, paid bot, OpenClaw channel, Claude channel, Hermes channel, agent evaluation); dismiss flag persistence
+- **Chat History Token `his_<id>` (v1.1052–v1.1054)**: Parse `his_<id>` tokens into clickable history chips in chat; quote-reply auto-injects `his_<id>` prefix; bots taught the token via A2A skill update; UUID message ID support
+- **Mind Map Phase 3–4 (v1.1050–v1.1054)**: Zoom-tier rendering + focus-mode fog (Phase 3); AI traverse endpoint over BFS subgraph (Phase 4); rate-limit `/traverse` + clamp node titles; Route A mirror — auto-pair notes with mindmap leaves
+- **Share-Chat Proxy Window CTA (v1.1049)**: Viral CTA + pageview beacons wired on share-chat Proxy Window
+- **Hermes Channel Plugin Guide (v1.1054)**: Added to info.html for channel plugin documentation
+- **Transform Sender Copy Fix (v1.1054)**: Save sender copy even when all delivery targets fail
+- **i18n Hardening**: Analytics keys spliced into 7 locale blocks; orphan key detection at outer TRANSLATIONS scope; hi/ar deduplication; HankHuang0516/realbot → EClaw repo rename in portal
+- **Auth Race Fix (v1.1049)**: Prevent api.js 401 redirect from racing auth.js fallbacks
+- **Billing Retry (v1.1047)**: Retry stuck INAPP top-up purchases on Android app startup; WebView JS bridge wired for wallet tier clicks
+
 ---
 
 ## Test Coverage Summary
 
-**~440 total API routes** across all modules (390 excluding Article Publisher), **~75% covered** by Jest + integration tests (~1800 test cases across 108 Jest files + 78 integration tests).
+**~440 total API routes** across all modules (390 excluding Article Publisher), **~75% covered** by Jest + integration tests (~2017 test cases across 113 Jest files + 78 integration tests).
 
 | Module | Coverage | Notes |
 |--------|----------|-------|
@@ -1024,7 +1036,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 ### Running All Tests
 ```bash
 node backend/run_all_tests.js          # Run all tests sequentially
-cd backend && npm test                  # Jest unit tests (97 files)
+cd backend && npm test                  # Jest unit tests (113 files)
 cd backend && npm run lint              # ESLint
 ```
 

--- a/backend/tests/test-broadcast.js
+++ b/backend/tests/test-broadcast.js
@@ -103,7 +103,7 @@ async function main() {
   if (numExtras === 0) numExtras = Math.floor(Math.random() * 3) + 1;
 
   // Pre-check: discover existing bound entities so we can ensure at least 2 total
-  const preCheckRes = await fetchJSON(`${API_BASE}/api/entities?deviceId=${deviceId}`);
+  const preCheckRes = await fetchJSON(`${API_BASE}/api/entities?deviceId=${deviceId}&deviceSecret=${deviceSecret}`);
   const preBoundCount = (preCheckRes.entities || []).length;
   const minNeeded = Math.max(numExtras, 2 - preBoundCount);
   if (minNeeded > numExtras) {
@@ -128,7 +128,7 @@ async function main() {
   // ────────────────────────────────────────────────────
   console.log('--- Phase 1: Discover existing entities ---');
 
-  const entitiesRes = await fetchJSON(`${API_BASE}/api/entities?deviceId=${deviceId}`);
+  const entitiesRes = await fetchJSON(`${API_BASE}/api/entities?deviceId=${deviceId}&deviceSecret=${deviceSecret}`);
   const existingBound = entitiesRes.entities || [];
   const existingIds = new Set(existingBound.map(e => e.entityId));
 
@@ -194,7 +194,7 @@ async function main() {
   }
 
   // Refresh bound entities list
-  const afterBindRes = await fetchJSON(`${API_BASE}/api/entities?deviceId=${deviceId}`);
+  const afterBindRes = await fetchJSON(`${API_BASE}/api/entities?deviceId=${deviceId}&deviceSecret=${deviceSecret}`);
   const allBound = afterBindRes.entities || [];
   const allBoundIds = allBound.map(e => e.entityId);
   console.log(`\n  All bound entities now: [${allBoundIds.join(', ')}] (${allBound.length} total)`);
@@ -234,7 +234,7 @@ async function main() {
   // Record baseline for each target
   const baselines = {};
   for (const tid of expectedTargets) {
-    const st = await fetchJSON(`${API_BASE}/api/status?deviceId=${deviceId}&entityId=${tid}`);
+    const st = await fetchJSON(`${API_BASE}/api/status?deviceId=${deviceId}&deviceSecret=${deviceSecret}&entityId=${tid}`);
     baselines[tid] = { message: st.message, lastUpdated: st.lastUpdated };
   }
 
@@ -291,7 +291,7 @@ async function main() {
   await sleep(2000);
 
   for (const tid of expectedTargets) {
-    const st = await fetchJSON(`${API_BASE}/api/status?deviceId=${deviceId}&entityId=${tid}`);
+    const st = await fetchJSON(`${API_BASE}/api/status?deviceId=${deviceId}&deviceSecret=${deviceSecret}&entityId=${tid}`);
     const baseline = baselines[tid];
 
     // Check if message was updated
@@ -325,7 +325,7 @@ async function main() {
   }
 
   for (const tid of expectedTargets) {
-    const st = await fetchJSON(`${API_BASE}/api/status?deviceId=${deviceId}&entityId=${tid}`);
+    const st = await fetchJSON(`${API_BASE}/api/status?deviceId=${deviceId}&deviceSecret=${deviceSecret}&entityId=${tid}`);
     console.log(`  Entity ${tid}: state=${st.state}, message="${st.message?.slice(0, 60)}"`);
   }
   console.log('');
@@ -447,7 +447,7 @@ async function main() {
 
       // Verify target entity message updated
       await sleep(2000);
-      const targetSt = await fetchJSON(`${API_BASE}/api/status?deviceId=${deviceId}&entityId=${replyTarget}`);
+      const targetSt = await fetchJSON(`${API_BASE}/api/status?deviceId=${deviceId}&deviceSecret=${deviceSecret}&entityId=${replyTarget}`);
       const hasReply = targetSt.message && targetSt.message.includes(replyText);
       check('Target entity received speak-to message', hasReply,
         `message="${targetSt.message?.slice(0, 60)}"`

--- a/backend/tests/test-edit-mode-public-code.js
+++ b/backend/tests/test-edit-mode-public-code.js
@@ -135,7 +135,7 @@ async function main() {
         console.log('── Phase 1: Setup ──');
 
         const allEntities = await fetchJSON(
-            `${API_BASE}/api/entities?deviceId=${deviceId}`
+            `${API_BASE}/api/entities?deviceId=${deviceId}&deviceSecret=${deviceSecret}`
         );
         check('Fetch all entities', allEntities.success !== false,
             `got ${allEntities.entities?.length || 0} entities`);
@@ -183,7 +183,7 @@ async function main() {
         // Fetch entities again to get publicCodes
         await sleep(500);
         const withCodes = await fetchJSON(
-            `${API_BASE}/api/entities?deviceId=${deviceId}`
+            `${API_BASE}/api/entities?deviceId=${deviceId}&deviceSecret=${deviceSecret}`
         );
 
         for (const te of testEntities) {
@@ -220,7 +220,7 @@ async function main() {
         console.log(`  Swapping slot ${slotA} (code: ${codeA}) ↔ slot ${slotB} (code: ${codeB})`);
 
         // Build reorder permutation: fetch current entity IDs, swap only slotA and slotB
-        const preReorder = await fetchJSON(`${API_BASE}/api/entities?deviceId=${deviceId}`);
+        const preReorder = await fetchJSON(`${API_BASE}/api/entities?deviceId=${deviceId}&deviceSecret=${deviceSecret}`);
         const currentIds = preReorder.entityIds || [];
         const order = [...currentIds];
         const idxA = order.indexOf(slotA);
@@ -246,7 +246,7 @@ async function main() {
 
         await sleep(1000);
         const afterSwap = await fetchJSON(
-            `${API_BASE}/api/entities?deviceId=${deviceId}`
+            `${API_BASE}/api/entities?deviceId=${deviceId}&deviceSecret=${deviceSecret}`
         );
         check('Post-swap fetch succeeds', afterSwap.success !== false);
 
@@ -302,7 +302,7 @@ async function main() {
 
         await sleep(1000);
         const afterSwapBack = await fetchJSON(
-            `${API_BASE}/api/entities?deviceId=${deviceId}`
+            `${API_BASE}/api/entities?deviceId=${deviceId}&deviceSecret=${deviceSecret}`
         );
 
         const entityBackA = afterSwapBack.entities?.find(e => e.entityId === slotA);
@@ -360,7 +360,7 @@ async function main() {
         try {
             // Re-fetch current state (positions may have changed)
             const currentEntities = await fetchJSON(
-                `${API_BASE}/api/entities?deviceId=${deviceId}`
+                `${API_BASE}/api/entities?deviceId=${deviceId}&deviceSecret=${deviceSecret}`
             );
             const boundEntities = currentEntities.entities || [];
 

--- a/backend/tests/test-entity-cards-stability.js
+++ b/backend/tests/test-entity-cards-stability.js
@@ -127,7 +127,7 @@ async function main() {
         console.log('── Phase 1: Setup ──');
 
         const allEntities = await fetchJSON(
-            `${API_BASE}/api/entities?deviceId=${deviceId}`
+            `${API_BASE}/api/entities?deviceId=${deviceId}&deviceSecret=${deviceSecret}`
         );
         check('Fetch all entities', allEntities.success !== false,
             `got ${allEntities.entities?.length || 0} entities`);
@@ -166,7 +166,7 @@ async function main() {
         console.log('── Phase 2: Entity Response Validation ──');
 
         const entitiesRes = await fetchJSON(
-            `${API_BASE}/api/entities?deviceId=${deviceId}`
+            `${API_BASE}/api/entities?deviceId=${deviceId}&deviceSecret=${deviceSecret}`
         );
 
         const boundCount = (entitiesRes.entities || []).length;
@@ -201,7 +201,7 @@ async function main() {
 
         for (let i = 0; i < 10; i++) {
             const pollRes = await fetchJSON(
-                `${API_BASE}/api/entities?deviceId=${deviceId}`
+                `${API_BASE}/api/entities?deviceId=${deviceId}&deviceSecret=${deviceSecret}`
             );
             const count = (pollRes.entities || []).length;
             if (count === 0) emptyResponses++;
@@ -225,7 +225,7 @@ async function main() {
         console.log('── Phase 4: Count Consistency ──');
 
         const finalRes = await fetchJSON(
-            `${API_BASE}/api/entities?deviceId=${deviceId}`
+            `${API_BASE}/api/entities?deviceId=${deviceId}&deviceSecret=${deviceSecret}`
         );
         check('maxEntitiesPerDevice is 4', finalRes.maxEntitiesPerDevice === 4,
             `got: ${finalRes.maxEntitiesPerDevice}`);

--- a/backend/tests/test-entity-management.js
+++ b/backend/tests/test-entity-management.js
@@ -123,7 +123,7 @@ async function main() {
         console.log('── Phase 1: Setup ──');
 
         const allEntities = await fetchJSON(
-            `${API_BASE}/api/entities?deviceId=${deviceId}`
+            `${API_BASE}/api/entities?deviceId=${deviceId}&deviceSecret=${deviceSecret}`
         );
         check('Fetch all entities', allEntities.success !== false, `got ${allEntities.entities?.length || 0} entities`);
 
@@ -285,7 +285,7 @@ async function main() {
         console.log('── Phase 7: Post-reorder state verification ──');
 
         await sleep(1000); // let server save
-        const afterEntities = await fetchJSON(`${API_BASE}/api/entities?deviceId=${deviceId}`);
+        const afterEntities = await fetchJSON(`${API_BASE}/api/entities?deviceId=${deviceId}&deviceSecret=${deviceSecret}`);
         check('Post-reorder fetch succeeds', afterEntities.success !== false);
 
         // After swap: entity at slotA should have marker from slotB, and vice versa
@@ -460,7 +460,7 @@ async function main() {
         // After reorder, botSecrets may have swapped slots.
         // We need to use the CURRENT entity state to find which botSecret is at which slot.
         try {
-            const currentEntities = await fetchJSON(`${API_BASE}/api/entities?deviceId=${deviceId}`);
+            const currentEntities = await fetchJSON(`${API_BASE}/api/entities?deviceId=${deviceId}&deviceSecret=${deviceSecret}`);
             const currentBound = currentEntities.entities?.filter(e => e.isBound) || [];
 
             // Delete entities that we created (identified by name pattern TestBot-*)


### PR DESCRIPTION
## Summary
- Fix 4 integration tests that were failing with 403 due to missing `deviceSecret` in `/api/entities` and `/api/status` API calls
- Update CLAUDE.md with recent features (v1.1046–v1.1054) and correct Jest test count (113 suites, 2017 tests)

## Test plan
- [x] All 113 Jest suites pass (2017 tests)
- [x] `test-broadcast.js` — 52/52 pass
- [x] `test-edit-mode-public-code.js` — 25/25 pass
- [x] `test-cross-device-settings.js` — 47/47 pass
- [x] i18n-check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)