### PR TITLE
fix(chat-save): observability hardening for lost messages

### DIFF
--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -911,6 +911,8 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
                 const localSource = hasCrossRoute
                     ? `xdevice:${entity.publicCode}:${entity.character}->${pendingCross.fromPublicCode || pendingCross.fromDeviceId}`
                     : (entity.name || `Entity ${eId}`);
+                const reasons = deliveryResults && deliveryResults.results ? deliveryResults.results.map(r => r.reason || 'ok').join(',') : 'none';
+                serverLog('warn', 'chat_save', `[CHAT_FALLBACK_CHANNEL] all targets failed for entity ${eId}; saving sender copy. reasons=[${reasons}] speakTo=${JSON.stringify(speakTo || null)} broadcast=${!!broadcast}`, { deviceId, entityId: eId, metadata: { path: 'fallback_channel', reasons, hadSpeakTo: !!speakTo, hadBroadcast: !!broadcast } });
                 await saveChatMessage(deviceId, eId, message, localSource, false, true, mediaType || null, mediaUrl || null, null, null, null, null, validatedCard);
                 warnings.push('All delivery targets failed; message saved to sender chat only.');
             }

--- a/backend/index.js
+++ b/backend/index.js
@@ -5934,6 +5934,8 @@ app.post('/api/transform', async (req, res) => {
             const chatSource = pendingA2A
                 ? `entity:${eId}:${entity.character}->${pendingA2A.fromEntityId}`
                 : entity.name || `Entity ${eId}`;
+            const reasons = deliveryResults && deliveryResults.results ? deliveryResults.results.map(r => r.reason || 'ok').join(',') : 'none';
+            serverLog('warn', 'chat_save', `[CHAT_FALLBACK_TRANSFORM] all targets failed for entity ${eId}; saving sender copy. reasons=[${reasons}] speakTo=${JSON.stringify(speakTo || null)} broadcast=${!!broadcast}`, { deviceId, entityId: eId, metadata: { path: 'fallback_transform', reasons, hadSpeakTo: !!speakTo, hadBroadcast: !!broadcast } });
             await saveChatMessage(deviceId, eId, finalMessage, chatSource, false, true, null, null, null, null, null, null, validatedCard, validatedAttachments);
             warnings.push('All delivery targets failed; message saved to sender chat only.');
         }
@@ -14981,7 +14983,11 @@ async function getDeviceVarForEmbedding(deviceId, varName) {
 
 // Save chat message to database, returns row ID (UUID) or null
 // Deduplication: bot messages with identical text for the same entity within 10s are skipped
+// Data-loss hardening (2026-04-23): one retry on INSERT failure, structured
+// log on every catch, dead-letter line to /tmp/chat_dead_letter.jsonl so we
+// can replay or grep for lost messages even when pg blips.
 async function saveChatMessage(deviceId, entityId, text, source, isFromUser, isFromBot, mediaType = null, mediaUrl = null, scheduleId = null, scheduleLabel = null, backupUrl = null, mentions = null, card = null, attachments = null) {
+    const textPreview = text == null ? null : String(text).slice(0, 120);
     try {
         // Dedup: skip if the same BOT message was already saved recently
         // Bot dedup: prevents echo when bot calls multiple endpoints (broadcast + sync-message + transform)
@@ -14997,17 +15003,31 @@ async function saveChatMessage(deviceId, entityId, text, source, isFromUser, isF
                 [deviceId, entityId, text, isFromUser || false, isFromBot || false, source || null]
             );
             if (dedup.rows.length > 0) {
-                console.log(`[Chat] Dedup: skipping duplicate ${isFromBot ? 'bot' : 'user'} message for entity ${entityId} (existing id=${dedup.rows[0].id}, source="${source}")`);
+                serverLog('info', 'chat_save', `[CHAT_DEDUP] returning existing id=${dedup.rows[0].id} entity_id=${entityId} source="${source}" preview="${textPreview}"`, { deviceId, entityId, metadata: { path: 'dedup', existingId: dedup.rows[0].id, source } });
                 return dedup.rows[0].id;
             }
         }
 
-        const result = await chatPool.query(
-            `INSERT INTO chat_messages (device_id, entity_id, text, source, is_from_user, is_from_bot, media_type, media_url, schedule_id, schedule_label, backup_url, mentions, card, attachments)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14) RETURNING id`,
-            [deviceId, entityId, text, source, isFromUser || false, isFromBot || false, mediaType, mediaUrl, scheduleId, scheduleLabel, backupUrl, mentions ? JSON.stringify(mentions) : null, card ? JSON.stringify(card) : null, attachments ? JSON.stringify(attachments) : null]
-        );
+        const insertParams = [deviceId, entityId, text, source, isFromUser || false, isFromBot || false, mediaType, mediaUrl, scheduleId, scheduleLabel, backupUrl, mentions ? JSON.stringify(mentions) : null, card ? JSON.stringify(card) : null, attachments ? JSON.stringify(attachments) : null];
+        const insertSQL = `INSERT INTO chat_messages (device_id, entity_id, text, source, is_from_user, is_from_bot, media_type, media_url, schedule_id, schedule_label, backup_url, mentions, card, attachments)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14) RETURNING id`;
+
+        let result;
+        try {
+            result = await chatPool.query(insertSQL, insertParams);
+        } catch (firstErr) {
+            serverLog('warn', 'chat_save', `[CHAT_SAVE_RETRY] first INSERT failed: ${firstErr.message}; retrying once`, { deviceId, entityId, metadata: { path: 'retry', source, errCode: firstErr.code } });
+            await new Promise(r => setTimeout(r, 400));
+            result = await chatPool.query(insertSQL, insertParams);
+        }
         const msgId = result.rows[0]?.id || null;
+        if (!msgId) {
+            // INSERT returned no row — should be impossible with RETURNING id, but
+            // fail loud so we see it in logs instead of silently dropping.
+            serverLog('error', 'chat_save', `[CHAT_SAVE_EMPTY] INSERT returned no row entity_id=${entityId} source="${source}" preview="${textPreview}"`, { deviceId, entityId, metadata: { path: 'empty_insert', source } });
+        } else {
+            serverLog('info', 'chat_save', `[CHAT_SAVE_OK] id=${msgId} entity_id=${entityId} source="${source}" preview="${textPreview}"`, { deviceId, entityId, metadata: { path: 'insert', source, chatMsgId: msgId } });
+        }
 
         // Fire-and-forget: generate semantic embedding for vector search (Phase 2)
         if (msgId && text) {
@@ -15042,10 +15062,11 @@ async function saveChatMessage(deviceId, entityId, text, source, isFromUser, isF
 
         return msgId;
     } catch (err) {
-        // Silently fail - chat history is non-critical
-        if (!err.message.includes('does not exist')) {
-            console.warn('[Chat] Failed to save message:', err.message);
-        }
+        serverLog('error', 'chat_save', `[CHAT_SAVE_FAIL] entity_id=${entityId} source="${source}" err="${err.message}" preview="${textPreview}"`, { deviceId, entityId, metadata: { path: 'catch', source, errCode: err.code, errName: err.name } });
+        try {
+            const line = JSON.stringify({ t: new Date().toISOString(), deviceId, entityId, source, isFromUser: !!isFromUser, isFromBot: !!isFromBot, textPreview, err: err.message, errCode: err.code }) + '\n';
+            require('fs').appendFileSync('/tmp/chat_dead_letter.jsonl', line);
+        } catch (_) { /* best-effort */ }
         return null;
     }
 }


### PR DESCRIPTION
## Summary
- Replace silent catch in `saveChatMessage` with structured `serverLog` calls (`[CHAT_SAVE_OK]`, `[CHAT_SAVE_RETRY]`, `[CHAT_SAVE_EMPTY]`, `[CHAT_SAVE_FAIL]`, `[CHAT_DEDUP]`).
- Retry failed INSERTs once after 400ms (pg blips) before giving up.
- Append a dead-letter line to `/tmp/chat_dead_letter.jsonl` on total failure so messages are recoverable even when DB is wedged.
- Log `[CHAT_FALLBACK_TRANSFORM]` and `[CHAT_FALLBACK_CHANNEL]` with the per-target `reason` list so we can see when delivery collapses to sender-only save.

## Motivation
`his_5897536e-8077-4b93-a8b5-915e7bf43351` was a fakechat bridge reply that never surfaced in `chat_messages` — and the legacy silent catch swallowed the evidence (`err.message.includes('does not exist')` was the only logged case, everything else went to console.warn or straight to /dev/null). This PR makes every save path emit a correlatable line so the next occurrence is debuggable.

No behavior change on the happy path; dedup / INSERT / embedding / socket emit are all unchanged.

## Test plan
- [ ] Deploy to Railway, watch `/api/logs` for `[CHAT_SAVE_OK]` on any bot reply
- [ ] Ask Mac_E (#3) to reproduce the his_ scenario, confirm `[CHAT_FALLBACK_CHANNEL]` (or `[CHAT_SAVE_FAIL]`) lights up with a real reason
- [ ] Verify `/tmp/chat_dead_letter.jsonl` stays empty in steady state

🤖 Generated with [Claude Code](https://claude.com/claude-code)