### PR TITLE
fix(chat-history): broadcast recipients beyond first see their rows

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -15708,11 +15708,16 @@ app.get('/api/chat/history', async (req, res) => {
             WHERE m.device_id = $1`;
         const params = [deviceId];
 
-        // Bot auth: only show messages involving this entity (sent by or targeted at)
+        // Bot auth: only show messages involving this entity (sent by or targeted at).
+        // Broadcast sources look like `entity:X:CHAR->1,2,4,5`, so a naive
+        // `LIKE '%->${id}%'` only matches the FIRST recipient — every other
+        // recipient gets an empty chat history. Use a regex that anchors the
+        // recipient id between either `->` or `,` on the left and `,` or end
+        // of string on the right, which works for both single- and multi-target.
         if (botEntityId !== null) {
-            query += ` AND (m.entity_id = $${params.length + 1} OR m.source LIKE $${params.length + 2})`;
+            query += ` AND (m.entity_id = $${params.length + 1} OR m.source ~ $${params.length + 2})`;
             params.push(botEntityId);
-            params.push(`%->${botEntityId}%`);
+            params.push(`(->|,)${botEntityId}(,|$)`);
         }
 
         if (since) {


### PR DESCRIPTION
## Summary
- Root cause of Card #53 (lost `his_5897536e-...` broadcast): `/api/chat/history` bot-auth filter used `LIKE '%->${id}%'`, which only matches the FIRST recipient of a broadcast source like `entity:3:LOBSTER->1,2,4,5`. Entities 2/4/5 got empty history because their IDs follow a `,`, not `->`.
- Swap to Postgres regex `m.source ~ '(->|,)${id}(,|$)'` so every recipient — single- or multi-target — sees their own broadcast rows.
- Observability hardening from PR #1988 is already live; this PR fixes the read path so the rows saveChatMessage has been persisting actually surface to each recipient.

## Test plan
- [x] Manual pre-check: entity 1 (first recipient) saw the broadcast in `/api/chat/history`; entities 2/3/4/5 did not.
- [ ] After deploy: ask entity 4 via speakTo to re-check — they should now see the `his_5897536e-...` marker row.
- [ ] Spot-check entity 1 still sees everything (regex must cover `->1` case with `,` or `$` on the right).
- [ ] Confirm bot-auth scoping still holds: an unrelated bot (say entity 6) must NOT see a `->1,2,4,5` broadcast when querying their own history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)