### PR TITLE
feat(entities): bots can discover bindingType + channelProvider

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -4879,11 +4879,39 @@ app.post('/api/bind', async (req, res) => {
 // ============================================
 
 /**
+ * Classify a channel callback_url into one of the known provider buckets
+ * so bots can route dispatches differently (OpenClaw vs Claude Code vs
+ * Hermes vs a custom webhook). Heuristic-only — the plugin never tells
+ * us directly what it is, so we read the URL the plugin registered.
+ *
+ * Returns: 'openclaw' | 'claude' | 'hermes' | 'custom' | null
+ * null means the entity is channel-bound but /register hasn't happened
+ * yet (callback_url still NULL in channel_accounts).
+ */
+function deriveChannelProvider(callbackUrl) {
+    if (!callbackUrl) return null;
+    let host = '';
+    let path = '';
+    try {
+        const u = new URL(callbackUrl);
+        host = (u.hostname || '').toLowerCase();
+        path = (u.pathname || '').toLowerCase();
+    } catch {
+        return 'custom';
+    }
+    const hay = `${host}${path}`;
+    if (hay.includes('openclaw')) return 'openclaw';
+    if (hay.includes('hermes')) return 'hermes';
+    if (hay.includes('claude') || hay.includes('claude-code')) return 'claude';
+    return 'custom';
+}
+
+/**
  * GET /api/entities
  * Get bound entities for a specific device.
  * Auth: deviceId+deviceSecret OR JWT cookie (web portal)
  */
-app.get('/api/entities', (req, res) => {
+app.get('/api/entities', async (req, res) => {
     const filterDeviceId = req.query.deviceId;
     const deviceSecret = req.query.deviceSecret;
 
@@ -4902,6 +4930,19 @@ app.get('/api/entities', (req, res) => {
     }
     if (!authedDeviceId) {
         return res.status(403).json({ success: false, message: 'Invalid credentials' });
+    }
+
+    // One lookup so we can annotate each channel-bound entity with its
+    // derived provider (openclaw / claude / hermes / custom). Best-effort:
+    // DB failures leave channelProvider=null, never break /api/entities.
+    let providerByAccountId = new Map();
+    try {
+        const rows = await db.getChannelAccountsByDevice(authedDeviceId);
+        for (const row of rows || []) {
+            providerByAccountId.set(row.id, deriveChannelProvider(row.callback_url));
+        }
+    } catch (err) {
+        console.warn(`[/api/entities] channel_accounts lookup failed: ${err.message}`);
     }
 
     const entities = [];
@@ -4929,6 +4970,10 @@ app.get('/api/entities', (req, res) => {
                     level: entity.level || 1,
                     publicCode: entity.publicCode || null,
                     bindingType: entity.bindingType || null,
+                    channelAccountId: entity.channelAccountId || null,
+                    channelProvider: (entity.bindingType === 'channel' && entity.channelAccountId)
+                        ? (providerByAccountId.get(entity.channelAccountId) || null)
+                        : null,
                     encryptionStatus: entity.encryptionStatus || null,
                     isPublic: !!entity.isPublic,
                     rental_status: entity.rental_status || null,  // 'leased_in', 'leased_out', or null
@@ -4995,7 +5040,7 @@ app.get('/api/entities', (req, res) => {
  *
  * Returns rental status for each entity (leased_out, leased_in, null).
  */
-app.get('/api/entities/status', (req, res) => {
+app.get('/api/entities/status', async (req, res) => {
     const { deviceId, botSecret, entityId } = req.query;
 
     if (!deviceId) return res.status(400).json({ success: false, error: 'Missing deviceId' });
@@ -5011,16 +5056,39 @@ app.get('/api/entities/status', (req, res) => {
         return res.status(401).json({ success: false, error: 'Invalid credentials' });
     }
 
+    // One DB round-trip to get every channel_account for this device so we
+    // can derive provider per channel-bound entity without N+1 queries.
+    // Failures here must not break status — fall back to empty map and let
+    // the client see channelProvider=null.
+    let providerByAccountId = new Map();
+    try {
+        const rows = await db.getChannelAccountsByDevice(deviceId);
+        for (const row of rows || []) {
+            providerByAccountId.set(row.id, deriveChannelProvider(row.callback_url));
+        }
+    } catch (err) {
+        console.warn(`[/api/entities/status] channel_accounts lookup failed: ${err.message}`);
+    }
+
     const entityList = [];
     for (const id of Object.keys(device.entities).map(Number)) {
         const entity = device.entities[id];
         if (!entity) continue;
+        const bindingType = entity.bindingType || null;
+        const channelAccountId = entity.channelAccountId || null;
+        const channelProvider = (bindingType === 'channel' && channelAccountId)
+            ? (providerByAccountId.get(channelAccountId) || null)
+            : null;
         entityList.push({
             entityId: id,
             isBound: !!entity.isBound,
             character: entity.character || '',
             state: entity.state || 'IDLE',
-            rentalStatus: entity.rental_status || null, // 'leased_out', 'leased_in', or null
+            bindingType,            // 'channel' | 'webhook' | 'personal' | 'free' | null
+            channelAccountId,       // numeric id in channel_accounts (only when bindingType='channel')
+            channelProvider,        // 'openclaw' | 'claude' | 'hermes' | 'custom' | null
+            encryptionStatus: entity.encryptionStatus || null, // 'e2ee' | 'transport' | null
+            rentalStatus: entity.rental_status || null,
             rentalContractId: entity.rental_contract_id || null,
         });
     }
@@ -8533,6 +8601,11 @@ app.get('/api/entity/lookup', (req, res) => {
                 language: entity.identity.language || null,
                 public: entity.identity.public || null
             } : null,
+            // Coarse binding class so cross-device callers can tell how to
+            // reach this entity (via channel provider vs webhook vs direct app
+            // binding). Provider-level detail (openclaw/claude/hermes) is
+            // intentionally NOT exposed here to avoid fingerprinting.
+            bindingType: entity.bindingType || null,
             encryptionStatus: entity.encryptionStatus || null
         }
     });

--- a/backend/tests/jest/entities-binding-discovery.test.js
+++ b/backend/tests/jest/entities-binding-discovery.test.js
@@ -1,0 +1,112 @@
+/**
+ * Regression: bots must be able to discover how each entity is bound.
+ *
+ * /api/entities/status    (botSecret auth)   must return bindingType +
+ *                                            channelAccountId + channelProvider
+ *                                            per entity.
+ * /api/entities           (deviceSecret)     must also carry channelProvider.
+ * /api/entity/lookup      (public)           must carry bindingType but
+ *                                            NOT channelProvider.
+ *
+ * Static source-level assertions — no live DB required.
+ */
+
+const fs = require('fs');
+
+const src = fs.readFileSync(require.resolve('../../index'), 'utf8');
+
+function slice(anchor, span = 2000) {
+    const i = src.indexOf(anchor);
+    expect(i).toBeGreaterThan(-1);
+    return src.slice(i, i + span);
+}
+
+describe('deriveChannelProvider helper', () => {
+    it('is defined in index.js and covers the four known providers', () => {
+        const block = slice('function deriveChannelProvider', 800);
+        expect(block).toMatch(/'openclaw'/);
+        expect(block).toMatch(/'claude'/);
+        expect(block).toMatch(/'hermes'/);
+        expect(block).toMatch(/'custom'/);
+    });
+
+    it('short-circuits on null/missing callback_url', () => {
+        const block = slice('function deriveChannelProvider', 800);
+        expect(block).toMatch(/if\s*\(!callbackUrl\)\s*return\s+null/);
+    });
+
+    // Evaluate the helper in isolation (no express/pool) by extracting its
+    // body from source so we can drive real URLs through it.
+    function extractFn(name) {
+        const re = new RegExp(`function ${name}\\b([\\s\\S]*?)\\n\\}\\n`);
+        const m = src.match(re);
+        if (!m) throw new Error(`could not extract ${name}`);
+        // eslint-disable-next-line no-new-func
+        return new Function(`return function ${name}${m[1]}}`)();
+    }
+    const derive = extractFn('deriveChannelProvider');
+
+    it.each([
+        [null, null],
+        ['', null],
+        ['https://plugin.openclaw.dev/callback', 'openclaw'],
+        ['https://my.openclaw-host.com/hook', 'openclaw'],
+        ['https://example.com/claude-code/webhook', 'claude'],
+        ['https://claude.ai/relay', 'claude'],
+        ['https://hermes.example.com/hook', 'hermes'],
+        ['https://a.eclawbot.com/eclaw-webhook', 'custom'],
+        ['not a url', 'custom'],
+    ])('%s -> %s', (url, expected) => {
+        expect(derive(url)).toBe(expected);
+    });
+});
+
+describe('/api/entities/status response shape', () => {
+    const handler = slice("app.get('/api/entities/status'", 3000);
+
+    it('is async (needs to look up channel_accounts)', () => {
+        expect(handler).toMatch(/app\.get\('\/api\/entities\/status',\s*async\s*\(req,\s*res\)\s*=>/);
+    });
+
+    it('fetches channel_accounts once via db.getChannelAccountsByDevice', () => {
+        expect(handler).toContain('db.getChannelAccountsByDevice(deviceId)');
+    });
+
+    it('each entity carries bindingType, channelAccountId, channelProvider', () => {
+        expect(handler).toMatch(/bindingType,/);
+        expect(handler).toMatch(/channelAccountId,/);
+        expect(handler).toMatch(/channelProvider,/);
+    });
+
+    it('channelProvider only set when bindingType="channel" AND channelAccountId present', () => {
+        expect(handler).toMatch(/bindingType === 'channel' && channelAccountId/);
+    });
+});
+
+describe('/api/entities response shape', () => {
+    const handler = slice("app.get('/api/entities',", 5000);
+
+    it('is async (now does channel_accounts lookup)', () => {
+        expect(handler).toMatch(/app\.get\('\/api\/entities',\s*async\s*\(req,\s*res\)\s*=>/);
+    });
+
+    it('annotates each bound entity with channelProvider', () => {
+        expect(handler).toMatch(/channelProvider:/);
+    });
+
+    it('provider lookup is best-effort (logs warn, does not throw)', () => {
+        expect(handler).toMatch(/console\.warn\(`\[\/api\/entities\] channel_accounts lookup failed/);
+    });
+});
+
+describe('/api/entity/lookup response shape (public)', () => {
+    const handler = slice("app.get('/api/entity/lookup'", 2500);
+
+    it('exposes bindingType (coarse binding class)', () => {
+        expect(handler).toMatch(/bindingType:\s*entity\.bindingType/);
+    });
+
+    it('does NOT expose channelProvider (fingerprinting)', () => {
+        expect(handler).not.toMatch(/channelProvider:/);
+    });
+});


### PR DESCRIPTION
## Summary
- Card #54: let bots tell whether an entity is bound via 綁定碼 / OpenClaw channel / Claude Code channel / Hermes channel, without standing up a new endpoint.
- Existing bot-auth endpoint `/api/entities/status` gains: `bindingType`, `channelAccountId`, `channelProvider`, `encryptionStatus`.
- Owner endpoint `/api/entities` also picks up `channelAccountId` + `channelProvider` (bindingType was already there).
- Public endpoint `/api/entity/lookup` gets `bindingType` only — provider detail is withheld to avoid cross-device fingerprinting.

## How providers are derived
`deriveChannelProvider(callback_url)` inspects the hostname+path the plugin registered:
- contains `openclaw` → `openclaw`
- contains `hermes`   → `hermes`
- contains `claude` / `claude-code` → `claude`
- otherwise → `custom`
- null callback_url (plugin hasn't called `/register` yet) → `null`

No schema change — we reuse `channel_accounts.callback_url`. One DB round-trip per request, best-effort (warn-log on failure, never throws).

## Test plan
- [x] `npx jest tests/jest/entities-binding-discovery.test.js` → 20/20 pass (9 URL → provider cases + 11 response-shape assertions).
- [ ] After deploy, hit `/api/entities/status` with my bot credentials and confirm channel-bound entities show `channelProvider: 'openclaw'`.
- [ ] Confirm `/api/entity/lookup?code=...` does NOT leak `channelProvider`.
- [ ] Confirm personal/free-bound entities get `channelProvider: null` (guard: only set when `bindingType === 'channel' && channelAccountId`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)