### PR TITLE
fix(device-vars): refuse legacy empty-wipe on non-empty vault

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -15376,7 +15376,7 @@ function logHandshakeFailure(opts) {
 // instead of replacing. Conflicting keys (same key, different value, different source)
 // are split into KEY_Web and KEY_APP to avoid data loss.
 app.post('/api/device-vars', async (req, res) => {
-    const { deviceId, deviceSecret, vars, locked, source } = req.body;
+    const { deviceId, deviceSecret, vars, locked, source, confirm } = req.body;
     if (!deviceId || !deviceSecret) {
         return res.status(400).json({ success: false, error: 'deviceId and deviceSecret required' });
     }
@@ -15485,7 +15485,23 @@ app.post('/api/device-vars', async (req, res) => {
                 }
             }
         } else {
-            // Legacy mode (no source): replace all, no merge
+            // Legacy mode (no source): replace all, no merge.
+            // Guard: an empty `incoming` in legacy mode wipes the vault —
+            // 2026-04-23 incident erased 17 live keys. Require an explicit
+            // confirm flag for empty replacements on a non-empty vault so
+            // accidental curls / buggy scripts can't silently zero it out.
+            if (Object.keys(incoming).length === 0) {
+                const existing = await db.getDeviceVars(deviceId);
+                const hadKeys = existing && Array.isArray(existing.var_keys) && existing.var_keys.length > 0;
+                if (hadKeys && confirm !== 'REPLACE_ALL_EMPTY') {
+                    serverLog('warn', 'device_vars', `[Vars] refused legacy empty wipe for ${deviceId}: ${existing.var_keys.length} keys present, no confirm`, { deviceId, metadata: { existingKeyCount: existing.var_keys.length } });
+                    return res.status(400).json({
+                        success: false,
+                        error: 'refuse_empty_legacy_wipe',
+                        message: `Refusing to replace ${existing.var_keys.length} existing keys with empty vault in legacy mode. Pass confirm:"REPLACE_ALL_EMPTY" or use source:"web"|"app" for merge-mode.`,
+                    });
+                }
+            }
             for (const k of Object.keys(incoming)) {
                 mergedSources[k] = null;
             }

--- a/backend/tests/jest/device-vars.test.js
+++ b/backend/tests/jest/device-vars.test.js
@@ -175,6 +175,82 @@ describe('GET /api/device-vars', () => {
     });
 });
 
+describe('POST /api/device-vars — legacy empty-wipe guard', () => {
+    // 2026-04-23 incident: legacy mode {vars:{}} with no `source` wiped 17
+    // live keys. Guard refuses empty legacy replacement against a non-empty
+    // vault unless caller passes confirm:"REPLACE_ALL_EMPTY".
+    const db = require('../../db');
+
+    afterEach(() => {
+        db.getDeviceVars.mockResolvedValue(null);
+    });
+
+    it('refuses legacy {vars:{}} when vault has existing keys (no confirm, no source)', async () => {
+        const devId = `vars-post-wipeguard-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        db.getDeviceVars.mockResolvedValueOnce({
+            vars: { EXISTING: 'value' },
+            var_keys: ['EXISTING'],
+        });
+        const res = await post('/api/device-vars').send({
+            deviceId: devId,
+            deviceSecret: secret,
+            vars: {},
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+        expect(res.body.error).toBe('refuse_empty_legacy_wipe');
+        expect(res.body.message).toMatch(/Refusing to replace 1 existing keys/);
+    });
+
+    it('allows legacy {vars:{}} on an empty vault (nothing to lose)', async () => {
+        const devId = `vars-post-emptyvault-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        // Default mock returns null (no row) → no existing keys
+        const res = await post('/api/device-vars').send({
+            deviceId: devId,
+            deviceSecret: secret,
+            vars: {},
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+
+    it('allows legacy {vars:{}} with confirm:"REPLACE_ALL_EMPTY" (explicit intent)', async () => {
+        const devId = `vars-post-confirm-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        db.getDeviceVars.mockResolvedValueOnce({
+            vars: { EXISTING: 'value' },
+            var_keys: ['EXISTING'],
+        });
+        const res = await post('/api/device-vars').send({
+            deviceId: devId,
+            deviceSecret: secret,
+            vars: {},
+            confirm: 'REPLACE_ALL_EMPTY',
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+
+    it('does NOT guard merge-mode source:"web" with empty vars (merge is safe)', async () => {
+        const devId = `vars-post-mergeempty-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        db.getDeviceVars.mockResolvedValueOnce({
+            vars: { EXISTING: 'value' },
+            var_keys: ['EXISTING'],
+        });
+        const res = await post('/api/device-vars').send({
+            deviceId: devId,
+            deviceSecret: secret,
+            vars: {},
+            source: 'web',
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+});
+
 describe('DELETE /api/device-vars', () => {
     it('returns 400 when deviceId is missing', async () => {
         const res = await del('/api/device-vars').send({ deviceSecret: 'x' });


### PR DESCRIPTION
## Summary
- Legacy `POST /api/device-vars` with `{vars:{}}` and no `source` silently erased a live vault on 2026-04-23 (17 keys → 0). The legacy "replace all, no merge" branch never validated that an empty replacement against a non-empty vault is almost never intentional.
- This PR adds a guard: **legacy mode + empty `incoming` + existing keys + no `confirm` flag → 400 `refuse_empty_legacy_wipe`**. Explicit resets still work via `confirm:"REPLACE_ALL_EMPTY"`.
- Merge-mode (`source:"web"` / `source:"app"`) is unaffected — merge of `{}` is already a safe no-op.

## What changed
- `backend/index.js`:15379 — accept optional `confirm` field.
- `backend/index.js`:15487–15505 — new guard in the legacy branch.
- `backend/tests/jest/device-vars.test.js` — 4 new tests (refuse on non-empty vault, allow on empty vault, allow with confirm, merge-mode unguarded).

## Why this is safe for existing callers
- Android `SyncLocalVarsRequest` defaults `source: "app"` → merge mode.
- Portal `env-vars.html` posts `source: "web"` → merge mode.
- iOS `deviceVarsApi` JIT pattern never sends empty legacy payloads.
- No first-party code path posts legacy `{vars:{}}` against an already-populated vault.

## Test plan
- [x] `npx jest tests/jest/device-vars.test.js` — 25/25 pass locally (21 existing + 4 new).
- [ ] CI green on push.
- [ ] Post-merge: next accidental curl with wrong payload returns 400 instead of wiping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)