### PR TITLE
fix(device-vars): guard DELETE endpoint with explicit confirm

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -15613,9 +15613,12 @@ app.delete('/api/device-vars/:key', async (req, res) => {
 });
 
 // DELETE /api/device-vars — client clears all vars
-// Auth: deviceSecret
+// Auth: deviceSecret + explicit confirm flag (2026-04-23 hardening: require
+// confirm:"YES_DELETE_ALL_VAULT" so a stray curl / misfired cron can't wipe
+// the vault without intent). Every attempt is server-logged with the
+// existing key count so we can trace who wiped what.
 app.delete('/api/device-vars', async (req, res) => {
-    const { deviceId, deviceSecret } = req.body;
+    const { deviceId, deviceSecret, confirm } = req.body;
     if (!deviceId || !deviceSecret) {
         return res.status(400).json({ success: false, error: 'deviceId and deviceSecret required' });
     }
@@ -15623,8 +15626,22 @@ app.delete('/api/device-vars', async (req, res) => {
     if (!device || !safeEqual(device.deviceSecret, deviceSecret)) {
         return res.status(403).json({ success: false, error: 'Invalid credentials' });
     }
+
+    const existing = await db.getDeviceVars(deviceId);
+    const existingKeyCount = existing && Array.isArray(existing.var_keys) ? existing.var_keys.length : 0;
+
+    if (existingKeyCount > 0 && confirm !== 'YES_DELETE_ALL_VAULT') {
+        serverLog('warn', 'device_vars', `[Vars] refused DELETE for ${deviceId}: ${existingKeyCount} keys present, no confirm`, { deviceId, metadata: { existingKeyCount, ip: req.ip, userAgent: req.get('user-agent') } });
+        return res.status(400).json({
+            success: false,
+            error: 'refuse_delete_without_confirm',
+            message: `Refusing to delete ${existingKeyCount} existing keys without explicit confirmation. Pass confirm:"YES_DELETE_ALL_VAULT" to proceed.`,
+        });
+    }
+
+    serverLog('info', 'device_vars', `[Vars] DELETE ${deviceId}: wiping ${existingKeyCount} keys`, { deviceId, metadata: { existingKeyCount, ip: req.ip, userAgent: req.get('user-agent') } });
     await db.deleteDeviceVars(deviceId);
-    res.json({ success: true });
+    res.json({ success: true, deletedKeyCount: existingKeyCount });
 });
 
 // GET /api/logs — Query server logs for debugging

--- a/backend/tests/jest/device-vars.test.js
+++ b/backend/tests/jest/device-vars.test.js
@@ -287,6 +287,80 @@ describe('DELETE /api/device-vars', () => {
     });
 });
 
+describe('DELETE /api/device-vars — confirm-guard for non-empty vault', () => {
+    // 2026-04-23 follow-up to legacy-wipe incident: DELETE endpoint is the
+    // other vector that can wipe the vault in one call. Refuse unless caller
+    // passes confirm:"YES_DELETE_ALL_VAULT" when existing keys are present.
+    const db = require('../../db');
+
+    afterEach(() => {
+        db.getDeviceVars.mockResolvedValue(null);
+    });
+
+    it('refuses DELETE when vault has keys and no confirm is passed', async () => {
+        const devId = `vars-del-guard-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        db.getDeviceVars.mockResolvedValueOnce({
+            vars: { EXISTING: 'value' },
+            var_keys: ['EXISTING'],
+        });
+        const res = await del('/api/device-vars').send({
+            deviceId: devId,
+            deviceSecret: secret,
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+        expect(res.body.error).toBe('refuse_delete_without_confirm');
+        expect(res.body.message).toMatch(/Refusing to delete 1 existing keys/);
+    });
+
+    it('allows DELETE on non-empty vault with confirm:"YES_DELETE_ALL_VAULT"', async () => {
+        const devId = `vars-del-confirm-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        db.getDeviceVars.mockResolvedValueOnce({
+            vars: { A: '1', B: '2', C: '3' },
+            var_keys: ['A', 'B', 'C'],
+        });
+        const res = await del('/api/device-vars').send({
+            deviceId: devId,
+            deviceSecret: secret,
+            confirm: 'YES_DELETE_ALL_VAULT',
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.deletedKeyCount).toBe(3);
+    });
+
+    it('allows DELETE on empty vault without confirm (nothing to lose)', async () => {
+        const devId = `vars-del-emptyvault-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        // Default mock returns null → existingKeyCount = 0 → bypass guard
+        const res = await del('/api/device-vars').send({
+            deviceId: devId,
+            deviceSecret: secret,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.deletedKeyCount).toBe(0);
+    });
+
+    it('rejects an incorrect confirm string', async () => {
+        const devId = `vars-del-wrongconfirm-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        db.getDeviceVars.mockResolvedValueOnce({
+            vars: { EXISTING: 'value' },
+            var_keys: ['EXISTING'],
+        });
+        const res = await del('/api/device-vars').send({
+            deviceId: devId,
+            deviceSecret: secret,
+            confirm: 'yes_delete_all_vault', // wrong case
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('refuse_delete_without_confirm');
+    });
+});
+
 describe('DELETE /api/device-vars/:key', () => {
     it('returns 400 when deviceId is missing', async () => {
         const res = await del('/api/device-vars/MY_KEY').send({ deviceSecret: 'x' });


### PR DESCRIPTION
## Summary
- Follow-up to PR #1995 (legacy empty-wipe guard). The POST legacy-mode vector is now defused, but `DELETE /api/device-vars` was still a one-call wipe with no log trail.
- Require `confirm:"YES_DELETE_ALL_VAULT"` when the vault has existing keys. Empty-vault deletes remain free.
- Every attempt (refuse + success) is now `serverLog`'d with key count, IP, user-agent — we can trace any future wipe to its caller.
- Return `deletedKeyCount` in the success payload so callers know what they wiped.

## Why
2026-04-23 second wipe event: vault had 17 live keys at 13:14 TW → empty at ~13:25 TW, post-PR #1995 deploy. The legacy-mode POST path was blocked by #1995, so the most likely remaining vector was an unguarded `DELETE /api/device-vars` call (no log, no confirm). This PR closes that vector and wires observability so a third incident wouldn't be invisible.

## Test plan
- [x] `npx jest tests/jest/device-vars.test.js` — 29/29 green, including 4 new DELETE-guard cases:
  - refuse on non-empty vault with no confirm
  - allow on non-empty vault with `confirm:"YES_DELETE_ALL_VAULT"`
  - allow on empty vault without confirm
  - reject wrong-cased confirm string (`yes_delete_all_vault`)
- [ ] CI green on push
- [ ] Post-merge: confirm `POST /api/logs` shows the `[Vars] DELETE` / `refused DELETE` lines when exercised

🤖 Generated with [Claude Code](https://claude.com/claude-code)