### PR TITLE
feat(chat): remove generic File upload; keep Photo/Video + Cloud Drive

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -2256,10 +2256,6 @@
                                 <span class="menu-icon">&#x1F3AC;</span>
                                 <span data-i18n="chat_attach_video">Video</span>
                             </button>
-                            <button class="attach-menu-item" onclick="openFilePicker()">
-                                <span class="menu-icon">&#x1F4CE;</span>
-                                <span data-i18n="chat_attach_file">File</span>
-                            </button>
                             <button class="attach-menu-item" onclick="openR2FilesPanel()">
                                 <span class="menu-icon">&#x1F4C1;</span>
                                 <span data-i18n="chat_attach_my_files">Cloud Drive</span>
@@ -2284,7 +2280,6 @@
                 </div>
                 <input type="file" id="photoFileInput" accept="image/jpeg,image/png,image/webp" multiple style="display:none" onchange="handleFilesSelected(this, 'photo')">
                 <input type="file" id="videoFileInput" accept="video/mp4,video/webm,video/quicktime" multiple style="display:none" onchange="handleFilesSelected(this, 'video')">
-                <input type="file" id="fileFileInput" multiple style="display:none" onchange="handleFilesSelected(this, 'file')">
             </div>
         </div>
     </div>
@@ -4833,11 +4828,6 @@
         function openVideoPicker() {
             document.getElementById('attachMenu').classList.remove('active');
             document.getElementById('videoFileInput').click();
-        }
-
-        function openFilePicker() {
-            document.getElementById('attachMenu').classList.remove('active');
-            document.getElementById('fileFileInput').click();
         }
 
         function handleFilesSelected(input, type) {


### PR DESCRIPTION
## Summary

- Drop the generic **File** item from the chat attach menu
- Keep **Photo**, **Video** (in-chat uploads) and **Cloud Drive** (R2) paths
- Pure deletion: 10 lines removed, 0 added

Hank's scope on task #42:
> 只需要移除 檔案這個選項保留照片影片雲端庫上傳途徑

## Changes

- Remove \"File\" menu item (`chat_attach_file` button) from `attachMenu`
- Remove `<input id=\"fileFileInput\">` hidden input
- Remove `openFilePicker()` — no longer referenced

## Kept intact

- `photoFileInput` / `videoFileInput` and their menu items
- `openPhotoPicker()` / `openVideoPicker()`
- R2 Cloud Drive panel (`openR2FilesPanel`, `r2UploadInput`, `uploadToR2`)
- `handleFilesSelected` / `uploadPendingFile` / `renderFilePreviewBar` — still reached by photo/video entries
- `msg.media_type === 'file'` rendering — backend may still emit file-type messages from other clients or API; display path stays

## i18n

`chat_attach_file` key left in 13 locales. Removing would be 13-file churn for no user-facing benefit; the key is small and inert.

## Test plan

- [x] grep confirms no remaining references to `openFilePicker`, `fileFileInput` in chat.html
- [x] grep confirms no Android native code references removed identifiers
- [ ] Manual: open chat.html, click `+` attach — verify menu shows Photo / Video / Cloud Drive (no File)
- [ ] Manual: Photo upload still works end-to-end
- [ ] Manual: Cloud Drive upload still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)