### PR TITLE
fix(chat-save): await all saveChatMessage bot-reply calls (#60)

### DIFF
--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -721,7 +721,7 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
                     const localSource = hasCrossRoute
                         ? `xdevice:${entity.publicCode}:${entity.character}->${pendingCross.fromPublicCode || pendingCross.fromDeviceId}`
                         : (entity.name || `Entity ${eId}`);
-                    saveChatMessage(deviceId, eId, message, localSource, false, true, mediaType || null, mediaUrl || null, null, null, null, null, validatedCard);
+                    await saveChatMessage(deviceId, eId, message, localSource, false, true, mediaType || null, mediaUrl || null, null, null, null, null, validatedCard);
                 }
 
                 // XP: Award for channel bot reply (same logic as /api/transform)
@@ -741,7 +741,7 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
                 const targetDev = devices[targetDeviceId];
                 if (targetDev) {
                     const replySource = `xdevice:${entity.publicCode}:${entity.character}->${targetDeviceId}`;
-                    saveChatMessage(targetDeviceId, 0, message, replySource, false, true);
+                    await saveChatMessage(targetDeviceId, 0, message, replySource, false, true);
                     serverLog('info', 'cross_speak_push', `[EXPLICIT_ROUTE] Channel routed reply to ${targetDeviceId}`, {
                         deviceId, entityId: eId,
                         metadata: { targetDeviceId, fromPublicCode: entity.publicCode }
@@ -761,7 +761,7 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             } else if (hasCrossRoute) {
                 const replySource = `xdevice:${entity.publicCode}:${entity.character}->${pendingCross.fromPublicCode || pendingCross.fromDeviceId}`;
                 const senderEntityId = pendingCross.fromEntityId >= 0 ? pendingCross.fromEntityId : 0;
-                saveChatMessage(pendingCross.fromDeviceId, senderEntityId, message, replySource, false, true);
+                await saveChatMessage(pendingCross.fromDeviceId, senderEntityId, message, replySource, false, true);
                 serverLog('info', 'cross_speak_push', `[CROSS_ROUTE] Channel auto-routed reply to sender ${pendingCross.fromDeviceId}:${senderEntityId}`, {
                     deviceId, entityId: eId,
                     metadata: { senderDeviceId: pendingCross.fromDeviceId, senderEntityId, fromPublicCode: pendingCross.fromPublicCode }

--- a/backend/index.js
+++ b/backend/index.js
@@ -5686,7 +5686,7 @@ app.post('/api/transform', async (req, res) => {
         // Skip saving to owner's chat when entity is leased_out — rental mirror handles renter's copy
         const isLeasedOut = entity.rental_status === 'leased_out';
         if (!hasDelivery && !isLeasedOut) {
-            saveChatMessage(deviceId, eId, finalMessage, chatSource, false, true, null, null, null, null, null, null, validatedCard, validatedAttachments);
+            await saveChatMessage(deviceId, eId, finalMessage, chatSource, false, true, null, null, null, null, null, null, validatedCard, validatedAttachments);
         }
         if (!isLeasedOut) markMessagesAsRead(deviceId, eId);
         if (pendingA2A) {
@@ -5703,7 +5703,7 @@ app.post('/api/transform', async (req, res) => {
             const targetDev = devices[targetDeviceId];
             if (targetDev) {
                 const replySource = `xdevice:${entity.publicCode}:${entity.character}->${targetDeviceId}`;
-                saveChatMessage(targetDeviceId, 0, finalMessage, replySource, false, true);
+                await saveChatMessage(targetDeviceId, 0, finalMessage, replySource, false, true);
                 serverLog('info', 'cross_speak_push', `[EXPLICIT_ROUTE] Transform routed reply to ${targetDeviceId}`, {
                     deviceId, entityId: eId,
                     metadata: { targetDeviceId, fromPublicCode: entity.publicCode }
@@ -5724,7 +5724,7 @@ app.post('/api/transform', async (req, res) => {
             if (pendingCross && pendingCross.fromDeviceId) {
                 const replySource = `xdevice:${entity.publicCode}:${entity.character}->${pendingCross.fromPublicCode || pendingCross.fromDeviceId}`;
                 const senderEntityId = pendingCross.fromEntityId >= 0 ? pendingCross.fromEntityId : 0;
-                saveChatMessage(pendingCross.fromDeviceId, senderEntityId, finalMessage, replySource, false, true);
+                await saveChatMessage(pendingCross.fromDeviceId, senderEntityId, finalMessage, replySource, false, true);
                 serverLog('info', 'cross_speak_push', `[CROSS_ROUTE] Transform auto-routed reply to sender ${pendingCross.fromDeviceId}:${senderEntityId}`, {
                     deviceId, entityId: eId,
                     metadata: { senderDeviceId: pendingCross.fromDeviceId, senderEntityId, fromPublicCode: pendingCross.fromPublicCode }
@@ -5793,7 +5793,7 @@ app.post('/api/transform', async (req, res) => {
                             rentalEntity.message = finalMessage;
                             rentalEntity.lastUpdated = Date.now();
                             // Save to renter's chat history
-                            saveChatMessage(cRow.rows[0].renter_device_id, parseInt(slotId), finalMessage,
+                            await saveChatMessage(cRow.rows[0].renter_device_id, parseInt(slotId), finalMessage,
                                 rentalEntity.name || `Rental Bot`, false, true);
                             // Notify renter via Socket.IO
                             if (io) {
@@ -7752,7 +7752,7 @@ app.post('/api/client/speak', async (req, res) => {
     if (parsedCmd) {
         // Save user's command as a user message for each target
         for (const eId of targetIds) {
-            saveChatMessage(deviceId, eId, text, source, true, false);
+            await saveChatMessage(deviceId, eId, text, source, true, false);
         }
 
         const confirmed = req.body.confirmed === true;
@@ -7820,7 +7820,7 @@ app.post('/api/client/speak', async (req, res) => {
         };
         entity.messageQueue.push(messageObj);
         const chatBackupUrl = mediaType === 'photo' ? getBackupUrl(mediaUrl) : null;
-        saveChatMessage(deviceId, eId, text, source, true, false, mediaType || null, mediaUrl || null, null, null, chatBackupUrl, mentionsContext);
+        await saveChatMessage(deviceId, eId, text, source, true, false, mediaType || null, mediaUrl || null, null, null, chatBackupUrl, mentionsContext);
 
         // Reset bot-to-bot counter: human message breaks the loop
         resetBotToBotCounter(deviceId);
@@ -17150,7 +17150,7 @@ app.post('/api/bot/sync-message', async (req, res) => {
         entity.messageQueue = [];
     }
     entity.messageQueue.push(messageObj);
-    saveChatMessage(deviceId, entityId, msgText, fromLabel || "bot", false, true, mediaType || null, mediaUrl || null);
+    await saveChatMessage(deviceId, entityId, msgText, fromLabel || "bot", false, true, mediaType || null, mediaUrl || null);
     markMessagesAsRead(deviceId, entityId);
 
     // Also update entity.message for immediate display


### PR DESCRIPTION
## Summary

Ten `saveChatMessage` call-sites in the bot-reply paths were fire-and-forget, creating a narrow silent-loss window that matches the `his_5897536e` symptom (message rendered client-side via socket.io but absent from DB).

- **channel-api.js** — vanilla save (724), explicit cross-route (744), auto cross-route (764)
- **index.js** — /api/transform vanilla save (5689), explicit cross-route (5706), auto cross-route (5727), rental mirror (5796); /api/client/speak slash-command user save (7755), broadcast user save (7823); /api/bot/sync-message (17153)

PR #1988 already instrumented `saveChatMessage` with `[CHAT_SAVE_FAIL]` + `/tmp/chat_dead_letter.jsonl`, but an unawaited promise can still be dropped if the Node process exits or the HTTP handler returns before the INSERT resolves. `await`ing closes that window: the route cannot respond until the insert is observed (and any pg error still follows the existing FAIL + dead-letter path).

## Why not a semantic change

Routes are already `async`. The only observable difference is that `res.json(...)` now cannot beat the INSERT to the wire. All existing tests pass (49/49 in chat.test.js, chat-dedup-speakto.test.js, cross-speak-chat-rendering.test.js).

## Test plan

- [x] `jest chat.test.js chat-dedup-speakto.test.js cross-speak-chat-rendering.test.js` — all pass
- [x] `node --check` on both edited files
- [ ] Post-deploy: monitor `[CHAT_SAVE_OK]` rate + verify zero `[CHAT_SAVE_FAIL]` / `[CHAT_FALLBACK_*]` over 24h
- [ ] If any future `his_<uuid>` orphan is reported, we now have tight observability to pinpoint the surviving leak path

## Related

- Task #60 (fakechat bridge reply not persisted)
- Follow-up to PR #1988 (observability) and PR-for-task-#50 (speakTo/broadcast data-loss fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)