### PR TITLE
fix(arena): harden navigation + coding + exam clock scoring

### DIFF
--- a/backend/arena-pool-validator.js
+++ b/backend/arena-pool-validator.js
@@ -69,9 +69,13 @@ const PERFECT_ACTIONS = {
                   payload: { dropX: t.x + Math.floor(t.w / 2), dropY: t.y + Math.floor(t.h / 2) },
                   timestamp: PERFECT_TIMESTAMP }];
     },
-    arena_navigation: () => [
+    arena_navigation: (c) => [
         { actionType: 'page_navigated', payload: { depth: 4 }, timestamp: PERFECT_TIMESTAMP },
-        { actionType: 'target_found', payload: {}, timestamp: PERFECT_TIMESTAMP + 1 },
+        // Post-anti-cheat-hardening: scorer requires the serial in payload.
+        // A bare empty {} no longer scores full marks (intentional — self-
+        // report exploit fix). Feed the real targetInfo so the synthetic
+        // "perfect" trial still exercises the happy path.
+        { actionType: 'target_found', payload: { targetInfo: c.targetInfo }, timestamp: PERFECT_TIMESTAMP + 1 },
     ],
     arena_table_extract: (c) => [
         { actionType: 'page_loaded', payload: {}, timestamp: PERFECT_TIMESTAMP },
@@ -240,6 +244,11 @@ function runOneTrial(testType, previousConfigs) {
         }
 
         // 6. Scoring with perfect synthetic actions — must score > 0
+        //    EXCEPTION: arena_coding currently degrades to score=0 by design
+        //    (anti-cheat: self-reported testResults are not trusted until a
+        //    real sandboxed executor lands). For coding we just verify the
+        //    scorer surfaces the server_side_execution_pending:true flag
+        //    and an expected shape — no "> 0" assertion.
         const perfectBuilder = PERFECT_ACTIONS[testType];
         if (perfectBuilder) {
             try {
@@ -247,6 +256,10 @@ function runOneTrial(testType, previousConfigs) {
                 const result = scorer(configWithWeight, actions);
                 if (!result || typeof result.score !== 'number') {
                     issues.push(`${testType}: scorer(perfect) returned invalid result: ${JSON.stringify(result)}`);
+                } else if (testType === 'arena_coding') {
+                    if (result.score !== 0 || result.server_side_execution_pending !== true) {
+                        issues.push(`arena_coding: expected degraded {score:0, server_side_execution_pending:true} shape, got ${summarize(result)}`);
+                    }
                 } else if (result.score === 0) {
                     issues.push(`${testType}: perfect action sequence scored 0 — scorer or config mismatch (config=${summarize(config)})`);
                 } else if (result.score > result.maxScore) {
@@ -594,6 +607,18 @@ async function validateRuntimeSelfTest({ arenaModule, dbPool, log }) {
                 const result  = scorer({ ...config, weight: s.max_score }, actions);
                 if (!result || typeof result.score !== 'number') {
                     out.issues.push(`${s.test_type}: scorer returned invalid result`);
+                    continue;
+                }
+                // arena_coding intentionally scores 0 until server-side
+                // sandboxed execution lands (anti-cheat: self-reported
+                // testResults are not trusted). Skip the "score > 0" gate
+                // for this one test type and instead verify the degraded
+                // shape carries the pending flag.
+                if (s.test_type === 'arena_coding') {
+                    if (result.server_side_execution_pending !== true) {
+                        out.issues.push(`arena_coding: expected server_side_execution_pending:true flag, got ${JSON.stringify(result)}`);
+                    }
+                    perTest.push({ testType: s.test_type, score: result.score, maxScore: result.maxScore, pending: true });
                     continue;
                 }
                 if (result.score <= 0) {

--- a/backend/interview-arena.js
+++ b/backend/interview-arena.js
@@ -611,8 +611,33 @@ function scoreNavigation(config, actionsLog) {
             deepest = Math.max(deepest, nav.payload.depth);
         }
     }
-    const reached = findAction(actionsLog, 'target_found') != null;
-    if (reached) return { score: config.weight, maxScore: config.weight };
+    // Full marks ONLY if the bot's `target_found` payload actually contains
+    // the serial string it was told to hunt for. A bare `{actionType:"target_found"}`
+    // with no payload used to net all 13 points — that was a self-report
+    // exploit. Normalize both sides (trim + lowercase + strip optional
+    // "Serial:" prefix) and require exact match OR strict substring so bots
+    // can echo "The serial is 8af0c1b3" without us false-negatives.
+    const found = findAction(actionsLog, 'target_found');
+    if (found) {
+        const norm = (v) => String(v == null ? '' : v)
+            .trim()
+            .toLowerCase()
+            .replace(/^serial\s*:\s*/i, '')
+            .trim();
+        const expected = norm(config.targetInfo);
+        const payload = found.payload || {};
+        const claimed = norm(
+            payload.targetInfo != null ? payload.targetInfo :
+            payload.serial != null ? payload.serial :
+            payload.value != null ? payload.value :
+            payload.text != null ? payload.text : ''
+        );
+        if (expected && claimed && (claimed === expected || claimed.includes(expected))) {
+            return { score: config.weight, maxScore: config.weight };
+        }
+        // target_found fired but payload empty/wrong → treat as not reached;
+        // fall through to depth-based partial credit rather than award full.
+    }
     const ratio = deepest / maxDepth;
     return { score: Math.round(config.weight * ratio * 0.75), maxScore: config.weight };
 }
@@ -655,17 +680,34 @@ function scoreDistraction(config, actionsLog) {
 }
 
 function scoreCoding(config, actionsLog) {
+    // Self-reported `testResults:[true,true,...]` used to net full marks
+    // without any actual code execution. Until a real sandboxed executor
+    // lands (vm2 / worker_thread with timeout + memory limit — see TODO),
+    // accept the submission metadata but award 0 and surface a machine-
+    // readable flag so downstream reporting can explain the gap.
+    //
+    // TODO(arena): replace this degraded scorer with a real sandboxed
+    // runner. Shape: spin up a worker_thread (or vm2 context) with
+    // resourceLimits.maxYoungGenerationSizeMb ~= 16, cpuTime timeout
+    // ~= 1000ms, no network/fs/require, feed each testCase.input via
+    // postMessage, compare stdout/return vs testCase.expected, then
+    // score ratio * weight with the existing speed bonus pipeline.
     const submit = findAction(actionsLog, 'code_submitted');
-    if (!submit || !submit.payload) return { score: 0, maxScore: config.weight };
-    const testResults = submit.payload.testResults || [];
+    if (!submit || !submit.payload) {
+        return { score: 0, maxScore: config.weight, server_side_execution_pending: true };
+    }
+    const claimedResults = Array.isArray(submit.payload.testResults) ? submit.payload.testResults
+        : Array.isArray(submit.payload.claimedResults) ? submit.payload.claimedResults
+        : [];
     const totalTests = (config.testCases || []).length;
-    if (totalTests === 0) return { score: 0, maxScore: config.weight };
-    const passed = testResults.filter(r => r === true || r === 'pass').length;
-    const ratio = passed / totalTests;
-    let score = Math.round(config.weight * 0.8 * ratio);
-    // Conciseness bonus (simplified: if code submitted and tests pass)
-    if (ratio >= 1.0) score = config.weight;
-    return { score, maxScore: config.weight };
+    return {
+        score: 0,
+        maxScore: config.weight,
+        server_side_execution_pending: true,
+        claimedPassed: claimedResults.filter(r => r === true || r === 'pass').length,
+        totalTests,
+        note: 'Self-reported testResults are not trusted. Awaiting server-side sandboxed execution.',
+    };
 }
 
 function scoreResponseTime(config, actionsLog) {
@@ -1087,15 +1129,20 @@ module.exports = function arenaFactory({ serverLog, io, devices } = {}) {
             // — INSERTs without an explicit id violate the NOT NULL constraint.
             const examId = newExamId();
             const examToken = generateToken(12);
-            const expiresAt = new Date(Date.now() + EXAM_TTL_MS);
-
-            // Optional: link this exam to a rental listing for interview qualification
+            // Clock-start fix: leave expires_at NULL at creation. The 3-min
+            // TTL budget is still EXAM_TTL_MS but the timer itself is armed
+            // atomically on the bot's first GET /arena/test/:id (see
+            // backend/index.js — first_fetched_at bump). Channel delivery
+            // latency (30-60s) no longer eats the bot's solving window,
+            // and exams that are never fetched simply never expire from
+            // the action endpoint's point of view (they're still garbage-
+            // collected by the daily pool updater).
             const listingId = req.body?.listingId || null;
             const examRes = await pool.query(
                 `INSERT INTO arena_exams (id, exam_token, listing_id, status, max_score, expires_at)
-                 VALUES ($1, $2, $3, $4, $5, $6)
+                 VALUES ($1, $2, $3, $4, $5, NULL)
                  RETURNING id, exam_token, listing_id, status, created_at, expires_at`,
-                [examId, examToken, listingId, EXAM_STATUS.WAITING, MAX_TOTAL_SCORE, expiresAt]
+                [examId, examToken, listingId, EXAM_STATUS.WAITING, MAX_TOTAL_SCORE]
             );
             const exam = examRes.rows[0];
 
@@ -1275,8 +1322,12 @@ module.exports = function arenaFactory({ serverLog, io, devices } = {}) {
             if (sessRes.rowCount === 0) return res.status(404).json({ success: false, error: 'session_not_found' });
             const session = sessRes.rows[0];
 
-            // Check expiry
-            if (new Date(session.expires_at) < new Date()) {
+            // Check expiry — NULL expires_at means the clock has not yet
+            // been armed (bot has not fetched GET /arena/test/:id). In that
+            // case the exam simply has not started, so the action is not
+            // "expired" — let it through. Normal case: timer was armed on
+            // first fetch and we compare normally.
+            if (session.expires_at != null && new Date(session.expires_at) < new Date()) {
                 return res.status(410).json({ success: false, error: 'exam_expired' });
             }
             if (session.status === 'completed') {

--- a/backend/interview_arena_schema.sql
+++ b/backend/interview_arena_schema.sql
@@ -123,3 +123,9 @@ ALTER TABLE arena_exams ADD COLUMN IF NOT EXISTS first_fetched_at TIMESTAMP WITH
 -- elapsed time for the leaderboard that isn't polluted by the user
 -- typing their display name after finalize.
 ALTER TABLE arena_exams ADD COLUMN IF NOT EXISTS completed_at TIMESTAMP WITH TIME ZONE;
+
+-- Allow expires_at to be NULL at exam creation. The 3-min TTL is armed
+-- atomically by GET /arena/test/:id (see backend/index.js), so the
+-- countdown measures from the bot's first fetch rather than from the
+-- channel-delivery-delayed INSERT. NULL = "clock not yet armed".
+ALTER TABLE arena_exams ALTER COLUMN expires_at DROP NOT NULL;

--- a/backend/tests/jest/interview-arena.test.js
+++ b/backend/tests/jest/interview-arena.test.js
@@ -274,10 +274,65 @@ describe('interview-arena: scoring engines', () => {
         expect(result.score).toBeLessThan(10);
     });
 
-    test('coding: all tests pass = full score', () => {
+    test('coding: self-reported testResults are untrusted → 0 + pending flag', () => {
+        // Anti-cheat: bots used to POST {testResults:[true,true,...]} and
+        // collect full marks. Until a real sandboxed executor lands we
+        // award 0 and surface server_side_execution_pending:true so
+        // downstream reporting can explain why.
         const config = { weight: 15, testCases: [{}, {}, {}] };
         const actions = [{ actionType: 'code_submitted', payload: { testResults: [true, true, true] } }];
-        expect(SCORING_ENGINES.arena_coding(config, actions).score).toBe(15);
+        const r = SCORING_ENGINES.arena_coding(config, actions);
+        expect(r.score).toBe(0);
+        expect(r.maxScore).toBe(15);
+        expect(r.server_side_execution_pending).toBe(true);
+        expect(r.claimedPassed).toBe(3);
+        expect(r.totalTests).toBe(3);
+    });
+
+    test('coding: empty submission = 0 + pending flag', () => {
+        const config = { weight: 15, testCases: [{}, {}, {}] };
+        const r = SCORING_ENGINES.arena_coding(config, []);
+        expect(r.score).toBe(0);
+        expect(r.server_side_execution_pending).toBe(true);
+    });
+
+    test('navigation: target_found with matching serial = full score', () => {
+        const config = { weight: 13, depth: 4, targetInfo: 'Serial: 8AF0C1B3' };
+        const actions = [
+            { actionType: 'page_navigated', payload: { depth: 4 } },
+            { actionType: 'target_found', payload: { targetInfo: '8af0c1b3' } },
+        ];
+        expect(SCORING_ENGINES.arena_navigation(config, actions).score).toBe(13);
+    });
+
+    test('navigation: target_found with exact "Serial: X" string = full score', () => {
+        const config = { weight: 13, depth: 4, targetInfo: 'Serial: 8AF0C1B3' };
+        const actions = [
+            { actionType: 'target_found', payload: { targetInfo: 'Serial: 8AF0C1B3' } },
+        ];
+        expect(SCORING_ENGINES.arena_navigation(config, actions).score).toBe(13);
+    });
+
+    test('navigation: target_found with bare empty payload = 0 (no depth)', () => {
+        const config = { weight: 13, depth: 4, targetInfo: 'Serial: 8AF0C1B3' };
+        const actions = [{ actionType: 'target_found', payload: {} }];
+        expect(SCORING_ENGINES.arena_navigation(config, actions).score).toBe(0);
+    });
+
+    test('navigation: target_found with WRONG serial = 0 (no depth)', () => {
+        const config = { weight: 13, depth: 4, targetInfo: 'Serial: 8AF0C1B3' };
+        const actions = [{ actionType: 'target_found', payload: { targetInfo: 'DEADBEEF' } }];
+        expect(SCORING_ENGINES.arena_navigation(config, actions).score).toBe(0);
+    });
+
+    test('navigation: partial depth credit when target not found', () => {
+        const config = { weight: 13, depth: 4, targetInfo: 'Serial: 8AF0C1B3' };
+        const actions = [
+            { actionType: 'page_navigated', payload: { depth: 2 } },
+        ];
+        const r = SCORING_ENGINES.arena_navigation(config, actions);
+        expect(r.score).toBeGreaterThan(0);
+        expect(r.score).toBeLessThan(13);
     });
 
     test('response_time: correct + fast = full score', () => {


### PR DESCRIPTION
## Summary

Three anti-cheat fixes for `backend/interview-arena.js` that previously let a bot score up to ~43 free points (13 + 15 + extra time) via self-reported action payloads and a prematurely-armed exam timer.

**Kanban bugs:** `card_4d40597babc1c36f929ceac4` (nav), `card_a691c7bdf2e023053c0b2d49` (coding), `card_2fbcd73739938fd4854f44ec` (clock). Left in_progress — commander moves them to review after this PR link is verified.

## Bug 1 — scoreNavigation: serial verification (13 pt)

**Before:** any `{actionType:"target_found"}` with empty payload → full weight.
**After:** require payload to include the serial string. Normalize both sides (trim + lowercase + strip optional `Serial:` prefix), accept exact match or strict substring (so `"The serial is 8af0c1b3"` works). Empty / wrong payload falls through to the depth-based partial credit path.

Accepts payload under any of `targetInfo`, `serial`, `value`, or `text` for bot compatibility.

## Bug 2 — scoreCoding: trust-free short-term degrade (15 pt)

**Before:** trusted `submit.payload.testResults`; bot sends `[true,true,...]` and collects 15 pt with zero code execution.

**After (short-term):** rename the accepted field concept to `claimedResults` in parsing, treat as untrusted, award `score: 0` with a machine-readable `server_side_execution_pending: true` flag plus `claimedPassed` / `totalTests` so downstream reporting can explain the gap. `// TODO(arena)` comment left inline pointing to the full sandboxed-executor follow-up (vm2 / worker_thread with cpu + memory limits).

## Bug 3 — Exam clock starts on first GET, not at CREATE (180 s window)

**Before:** `expires_at` was `new Date(Date.now() + EXAM_TTL_MS)` at INSERT time, so 30–60 s of channel delivery ate the bot's solving budget.

**After:**
- `arena_exams.expires_at` INSERT is now `NULL` (schema dropped `NOT NULL` via `ALTER TABLE arena_exams ALTER COLUMN expires_at DROP NOT NULL`).
- The atomic arm already exists in `backend/index.js` `GET /arena/test/:examId` — `UPDATE ... SET first_fetched_at = NOW(), expires_at = NOW() + INTERVAL '3 minutes' WHERE id = $1 AND first_fetched_at IS NULL`. Idempotent: subsequent reads do not reset it.
- The action endpoint's expiry check (`backend/interview-arena.js` L1330) now treats `expires_at = NULL` as "clock not yet armed" and allows the action through. An exam that is never fetched simply never expires from the action endpoint's point of view.
- L1178 comment ("Clock starts here") is now accurate without modification.

## Out of scope

- `stripSecretsForBot()` (L937–1047) was not touched — it's the intentional decoy layer.
- Real sandboxed code execution for `arena_coding` — follow-up card.

## Files changed

- `backend/interview-arena.js` — all 3 scoring/clock fixes
- `backend/interview_arena_schema.sql` — drop `NOT NULL` on `expires_at`
- `backend/arena-pool-validator.js` — update `PERFECT_ACTIONS.arena_navigation` to feed real `targetInfo`; special-case `arena_coding` in `validateStatic` + `validateRuntimeSelfTest` to verify the degraded shape instead of `score > 0`
- `backend/tests/jest/interview-arena.test.js` — replaced old coding test, added 5 navigation scoring tests + 1 empty-submission coding test

## Test plan

- [x] `npx jest --testPathPattern=tests/jest` — **2093 / 2093 pass** (116 suites)
- [x] New unit coverage:
  - scoreNavigation: empty payload → 0, correct serial (both bare and `Serial: X` form) → 13, wrong serial → 0, depth-only partial
  - scoreCoding: self-reported testResults → `{score:0, server_side_execution_pending:true, claimedPassed:3, totalTests:3}`; empty submission → `{score:0, server_side_execution_pending:true}`
- [x] `arena-pool-validator` static + runtime self-test suites all green after perfect-action builder update
- [ ] Smoke test in staging after merge: create exam → confirm row has `expires_at=NULL` → first GET → `expires_at ≈ now+180s` and `first_fetched_at` set → second GET within 1s → `expires_at` unchanged → POST navigation action with correct serial → full 13 → POST coding action with any testResults → 0 + `server_side_execution_pending:true` in the finalize report

## Surprises during implementation

- The clock-arming logic already existed in `backend/index.js:2113-2128` (PR #earlier shipped the GET-side half). Only the CREATE-side INSERT and the action-endpoint null guard were missing, so this fix completes a half-landed feature rather than writing new plumbing.
- The test mock in `interview-arena.test.js` still reads `params[1]` as `expires_at`, which is a preexisting fake — it happens to work because the mock falls back to a future date when the stored value is null. No mock change needed.

**Do not merge** — review only.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>