### PR TITLE
fix(arena): poll-fallback bootstraps exam timer when WS timer_started is missed

### DIFF
--- a/backend/public/arena/exam.html
+++ b/backend/public/arena/exam.html
@@ -1018,6 +1018,16 @@
                         document.getElementById('scoreWrap').style.display = 'block';
                     }
                 }
+                // Timer bootstrap fallback: if bot has fetched (firstFetchedAt set) but
+                // WS timer_started was missed, start the countdown from expiresAt now.
+                if (exam.firstFetchedAt && !examTimerInterval && exam.status !== 'completed') {
+                    let remainingSec = 180;
+                    if (exam.expiresAt) {
+                        const diff = Math.floor((new Date(exam.expiresAt).getTime() - Date.now()) / 1000);
+                        remainingSec = Math.max(0, Math.min(180, diff));
+                    }
+                    startExamTimer(remainingSec);
+                }
                 // Update session scores from DB
                 if (data.sessions) {
                     let total = 0;


### PR DESCRIPTION
## Summary
- Bug 6 (Hank 反覆回報): arena 面試 UI 整場 180s 停在 `--:--`。
- Root cause: timer 只會由 Socket.IO `timer_started` 或頁面載入時 `firstFetchedAt` 已 set 的路徑啟動; 若 page 先打開、bot 晚 fetch、加上 WS 漏事件 → 5s poll 只更新 status/scores 不會呼叫 `startExamTimer` → 計時器永遠不啟動。
- Fix: 在 poll body 狀態更新後，若 `firstFetchedAt` 已 set、`examTimerInterval` 未啟動、exam 未 completed，用 `expiresAt` 算出剩餘秒數並 `startExamTimer(remainingSec)`。

## E2E verification
- 用 prod exam `exam_a2578b9fe98b1fe026f81d54` 於 playwright 重現 → 計時器 `--:--`。
- `browser_evaluate` 清掉 `examTimerInterval` 模擬 WS 漏訊 → 等 12s → poll tick 內未 bootstrap → confirmed bug。
- 用 `browser_evaluate` 執行本 PR patch 邏輯 → action `started timer with 104s`、`timerText: "1:44"`、`intervalRunning: true` → 修復生效。

## Test plan
- [ ] prod 部署後開 arena 面試 → 倒數器每秒從 ~180 遞減到 0
- [ ] 故意重整頁面 (讓 WS timer_started 漏掉) → 5s 內 poll fallback 應補啟動計時器
- [ ] completed 狀態不再觸發 startExamTimer

🤖 Generated with [Claude Code](https://claude.com/claude-code)