### PR TITLE
fix(arena): surface model + unblock result chip clicks behind name modal

### DIFF
--- a/backend/public/arena/exam.html
+++ b/backend/public/arena/exam.html
@@ -485,6 +485,7 @@
 
             let detailRows = '';
             const REFS = ['OSWorld','WebArena','WebVoyager','OSWorld','WebArena','WorkArena','ST-WebAgentBench','HumanEval Pro','—','Context-Bench','—','Web Speech API'];
+            const examModel = data?.exam?.model || '—';
             NAMES.forEach((name, i) => {
                 const s = data.sessions ? data.sessions.find(x => x.test_index === i) : null;
                 const sc = s ? (s.score || 0) : (scores[i] || 0);
@@ -514,6 +515,7 @@
                     <div class="report-detail" style="display:none;padding:10px 12px;background:var(--bg-secondary);font-size:12px;color:var(--text-secondary);line-height:1.7;">
                         <div style="margin-bottom:6px;color:var(--text);font-size:13px;">${comment}</div>
                         <div><strong>Score:</strong> ${sc} / ${mx} (${scPct}%)</div>
+                        <div><strong>Model:</strong> ${examModel}</div>
                         ${speedInfo ? `<div><strong>Speed:</strong> ${speedInfo}</div>` : ''}
                         ${raw.score !== undefined && raw.maxScore !== undefined ? `<div><strong>Base accuracy:</strong> ${raw.score} / ${raw.maxScore}</div>` : ''}
                         <div><strong>Status:</strong> ${s ? s.status : (sc > 0 ? 'completed' : 'no data')}</div>
@@ -526,6 +528,7 @@
                 <div style="text-align:center;padding:16px 0 20px;">
                     <div style="font-size:48px;font-weight:900;color:${gradeColor};margin-bottom:4px;">Grade: ${grade}</div>
                     <div style="font-size:14px;color:var(--text-secondary);">${total} / ${maxS} (${pct}%) &mdash; ${passed} passed, ${failed} failed</div>
+                    <div style="font-size:12px;color:var(--accent-cyan);margin-top:6px;font-weight:600;">Model: ${examModel}</div>
                     <div style="font-size:13px;color:var(--text-muted);margin-top:8px;">${commentary}</div>
                 </div>
                 <div style="text-align:center;margin:16px 0 24px;"><canvas id="radarChart" width="300" height="300" style="max-width:100%;"></canvas></div>
@@ -1069,7 +1072,7 @@
     </div>
 
     <canvas id="confettiCanvas"></canvas>
-    <div class="modal-overlay" id="nameModal">
+    <div class="modal-overlay" id="nameModal" onclick="if(event.target===this)dismissModal()">
         <div class="modal-card">
             <div class="modal-title" data-i18n="arena_name_prompt">Submit to Leaderboard</div>
             <div class="modal-subtitle" data-i18n="arena_name_subtitle">Enter a name to claim your score</div>


### PR DESCRIPTION
## Summary
老闆回報 `exam_a2578b9fe98b1fe026f81d54` 結果頁面的 chip 看起來可按但按下去沒反應，也看不到模型資訊。

## 兩個根因

1. **Name modal 擋住 chip 點擊**
   Chip 本體的 `addEventListener('click', ...)` 其實是有接 (exam.html L540)。但 `showResults()` 結束後 0.5–3 秒會自動 pop 出 `nameModal`，z-index:100 + blur backdrop 蓋滿整個視口 — 使用者看得到後面的 chip 卻點不到，modal 把 click event 全吃掉了。
   **Fix:** name modal 的 overlay 加 `onclick="if(event.target===this)dismissModal()"`，點空白處即可關閉。和已經存在的 `agentPopup` overlay 是同一個 pattern。

2. **模型資訊從未出現**
   Chip 展開後只列 score / speed / base accuracy，沒有任何地方寫出哪個模型跑的。`infoBar` 的 `#modelBadge` 對 completed exam 是 `display:none`，model 資訊等於消失。
   **Fix:** `showResults()` 從 `data.exam.model` 抓出模型名稱 (null fallback `—`)，寫在 (a) 報告標題 Grade 下方一行 cyan 高亮，(b) 每個 chip 展開後 detail panel 多一行 `Model: <name>`。

## E2E 重現
- Prod `exam_a2578b9fe98b1fe026f81d54` — 導航後等 4.5s：
  - `modalVisible: true`
  - `modelShownInInfoBar: ""`
  - `detailPanelHasModel: false`
  - 手動 JS click chip → detail toggle 從 `none` → `block`，證實 handler 有接，只是被 modal 擋住。

## Test plan
- [ ] Prod deploy 後開任意 completed exam → 點空白處 → name modal 消失 → chip 可點開 detail
- [ ] Detail panel 顯示 `Model: <模型名>`；無模型時顯示 `Model: —`
- [ ] 報告標題 Grade 下方顯示 Model 這行
- [ ] ESC / Submit 流程原路不變

🤖 Generated with [Claude Code](https://claude.com/claude-code)