### PR TITLE
refactor(chat): merge photo + video picker into one Photo button

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -2252,10 +2252,6 @@
                                 <span class="menu-icon">&#x1F4F7;</span>
                                 <span data-i18n="chat_attach_photo">Photo</span>
                             </button>
-                            <button class="attach-menu-item" onclick="openVideoPicker()">
-                                <span class="menu-icon">&#x1F3AC;</span>
-                                <span data-i18n="chat_attach_video">Video</span>
-                            </button>
                             <button class="attach-menu-item" onclick="openR2FilesPanel()">
                                 <span class="menu-icon">&#x1F4C1;</span>
                                 <span data-i18n="chat_attach_my_files">Cloud Drive</span>
@@ -2278,8 +2274,7 @@
                     <button class="btn btn-primary btn-send" id="btnSend" onclick="sendMessage()"
                         data-i18n="chat_btn_send" title="Send">&#10148;</button>
                 </div>
-                <input type="file" id="photoFileInput" accept="image/jpeg,image/png,image/webp" multiple style="display:none" onchange="handleFilesSelected(this, 'photo')">
-                <input type="file" id="videoFileInput" accept="video/mp4,video/webm,video/quicktime" multiple style="display:none" onchange="handleFilesSelected(this, 'video')">
+                <input type="file" id="photoFileInput" accept="image/jpeg,image/png,image/webp,video/mp4,video/webm,video/quicktime" multiple style="display:none" onchange="handleFilesSelected(this, 'photo')">
             </div>
         </div>
     </div>
@@ -4827,11 +4822,6 @@
         function openPhotoPicker() {
             document.getElementById('attachMenu').classList.remove('active');
             document.getElementById('photoFileInput').click();
-        }
-
-        function openVideoPicker() {
-            document.getElementById('attachMenu').classList.remove('active');
-            document.getElementById('videoFileInput').click();
         }
 
         function handleFilesSelected(input, type) {


### PR DESCRIPTION
## Summary
- Two attach buttons (Photo / Video) shared the same `handleFilesSelected → uploadPendingFile → /api/chat/upload-media` pipeline; they only differed by `<input accept>`. `handleFilesSelected` already re-derives `photo/video` from file MIME.
- Hank asked to collapse them into one **📷 照片** button.

## Changes
- Remove Video menu item, `openVideoPicker()`, and `videoFileInput` element.
- Broaden `photoFileInput` `accept=` to `image/jpeg,image/png,image/webp,video/mp4,video/webm,video/quicktime`.
- `chat_attach_video` i18n key is now orphaned; leaving it for a separate i18n-cleanup PR to avoid churning ~30 locales here.

## Test plan
- [x] grep confirms no more refs to `openVideoPicker` / `videoFileInput`
- [x] MIME-based branching in `handleFilesSelected` still correctly tags `entry.type = photo | video`, so downstream rendering (image vs video thumbnail) stays intact
- [ ] Hank visual QA: tap 📷 → native picker shows both images and videos → select video → uploads + renders as video message

🤖 Generated with [Claude Code](https://claude.com/claude-code)