### PR TITLE
feat(app): sync Kanban Nudge settings to Android + iOS apps

### DIFF
--- a/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
@@ -300,6 +300,11 @@ class SettingsActivity : AppCompatActivity() {
             billingManager.launchPurchaseFlow(this)
         }
 
+        findViewById<MaterialButton>(R.id.btnKanbanNudge).setOnClickListener {
+            TelemetryHelper.trackAction("settings_kanban_nudge")
+            WebViewActivity.launch(this, "https://eclawbot.com/portal/settings.html#kanban-nudge-card", getString(R.string.kanban_nudge_settings_title))
+        }
+
         findViewById<MaterialButton>(R.id.btnWallet).setOnClickListener {
             TelemetryHelper.trackAction("settings_wallet")
             WebViewActivity.launch(this, "https://eclawbot.com/portal/wallet.html", getString(R.string.settings_wallet))

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -623,6 +623,22 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
+            <!-- Kanban Nudge Settings Button — opens WebView deep-linked to the Kanban Nudge card -->
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnKanbanNudge"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/kanban_nudge_settings_title"
+                android:textColor="@color/text_white_80"
+                app:backgroundTint="@color/surface_input"
+                android:layout_marginTop="16dp"
+                app:cornerRadius="12dp"
+                app:icon="@drawable/ic_open_in_new"
+                app:iconTint="@color/text_white_80"
+                app:strokeColor="@color/text_dark"
+                app:strokeWidth="1dp"
+                style="@style/Widget.Material3.Button.TonalButton"/>
+
             <!-- Wallet Button -->
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btnWallet"

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -145,6 +145,7 @@
     <string name="channel_api_no_key">暂无 API 密钥</string>
     <string name="channel_api_secret_label">API 密钥</string>
     <string name="channel_api_slots_active">已连接：%1$s</string>
+    <string name="kanban_nudge_settings_title">📋 看板督促设置</string>
     <string name="channel_bind_warning">2026-03 版本以上强烈建议使用 EClaw Channel 绑定，避免绑定失败。</string>
     <string name="channel_learn_more">了解更多 →</string>
     <string name="channel_promo">试试 EClaw Channel？更原生、更快速</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -145,6 +145,7 @@
     <string name="channel_api_no_key">尚無 API 金鑰</string>
     <string name="channel_api_secret_label">API 金鑰</string>
     <string name="channel_api_slots_active">已連線：%1$s</string>
+    <string name="kanban_nudge_settings_title">📋 看板督促設定</string>
     <string name="channel_bind_warning">2026-03 版本以上強烈建議使用 EClaw Channel 綁定，避免綁定失敗。</string>
     <string name="channel_learn_more">了解更多 →</string>
     <string name="channel_promo">試試 EClaw Channel？更原生、更快速</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -480,6 +480,9 @@
     <string name="channel_api_no_key">No API key yet. Open the Web Portal to generate one.</string>
     <string name="channel_api_slots_active">Connected: %1$s</string>
 
+    <!-- Kanban Nudge Settings -->
+    <string name="kanban_nudge_settings_title">📋 Kanban Nudge Settings</string>
+
     <!-- Account Status Card -->
     <string name="account_card_title">Account</string>
     <string name="account_status_loading">Checking account status\u2026</string>

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -852,7 +852,7 @@
         </div>
 
         <!-- Kanban Nudge Settings -->
-        <div class="card">
+        <div class="card" id="kanban-nudge-card">
             <div class="card-title">
                 <span>📋 <span data-i18n="kanban_nudge_title">Kanban Nudge</span></span>
             </div>

--- a/ios-app/app/(tabs)/settings.tsx
+++ b/ios-app/app/(tabs)/settings.tsx
@@ -229,6 +229,12 @@ export default function SettingsScreen() {
             right={(props) => <List.Icon {...props} icon="chevron-right" />}
             onPress={() => router.push('/invite')}
           />
+          <List.Item
+            title={t('settings.kanban_nudge', '📋 Kanban Nudge Settings')}
+            left={(props) => <List.Icon {...props} icon="clipboard-list" />}
+            right={(props) => <List.Icon {...props} icon="open-in-new" />}
+            onPress={() => Linking.openURL('https://eclawbot.com/portal/settings.html#kanban-nudge-card').catch(() => {})}
+          />
         </List.Section>
 
         <Divider />


### PR DESCRIPTION
## Summary

Adds a jump-off row in both Android and iOS native Settings that opens the portal's Kanban Nudge settings card directly via WebView / in-app browser. Keeps the actual settings UI single-sourced in `portal/settings.html`, so adding controls (batch / priority mode / statuses / interval) never requires another app release.

- `backend/public/portal/settings.html` — add `id="kanban-nudge-card"` anchor on the Nudge settings card for deep-linking
- `app/src/main/res/layout/activity_settings.xml` — new `@+id/btnKanbanNudge` MaterialButton inserted before btnWallet
- `app/src/main/java/com/hank/clawlive/SettingsActivity.kt` — click handler launches `WebViewActivity` at `https://eclawbot.com/portal/settings.html#kanban-nudge-card`
- `app/src/main/res/values/strings.xml` + `values-zh-rTW` + `values-zh-rCN` — title `📋 Kanban Nudge Settings` / `📋 看板督促設定` / `📋 看板督促设置`
- `ios-app/app/(tabs)/settings.tsx` — new `List.Item` under Services with `clipboard-list` icon, opens portal URL via `Linking.openURL`

## Why thin-native

- Follows existing Android pattern (Wallet / Rentals / Invite / DeleteAccount / ChannelAPI all launch WebView on portal pages)
- iOS already opens `privacy-policy.html` the same way
- Future nudge-feature additions (e.g. new priority modes, pause windows) ship via backend deploy, no App Store/Play review

## Test plan

- [ ] Android emu: open Settings → tap "📋 Kanban Nudge Settings" → WebView lands scrolled to nudge card
- [ ] iOS sim: open Settings → Services section shows new row → tap opens browser/WebView at same anchor
- [ ] zh-rTW locale: Android row label reads "📋 看板督促設定"
- [ ] zh-rCN locale: Android row label reads "📋 看板督促设置"
- [ ] Other Android locales fall back to EN default (acceptable; i18n follow-up card to be filed for bot #3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)