### PR TITLE
fix(kanban): mobile toolbar + dark-mode history drawer

### DIFF
--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -18,8 +18,10 @@
         /* ══════════════ Toolbar ══════════════ */
         .kb-toolbar { display:flex; justify-content:space-between; align-items:center; margin-bottom:16px; flex-wrap:wrap; gap:10px; }
         .kb-toolbar h2 { font-size:20px; font-weight:700; }
-        .kb-toolbar-actions { display:flex; gap:8px; align-items:center; }
-        .kb-filter-chips { display:flex; gap:6px; flex-wrap:wrap; }
+        .kb-toolbar-actions { display:flex; gap:8px 6px; align-items:center; flex-wrap:wrap; }
+        .kb-toolbar-actions .btn { white-space:nowrap; flex-shrink:0; }
+        .kb-filter-chips { display:flex; gap:6px; flex-wrap:wrap; flex-shrink:0; }
+        .kb-chip { white-space:nowrap; }
         .kb-chip { padding:4px 12px; border-radius:var(--radius-pill); font-size:12px; font-weight:500; cursor:pointer; border:1px solid var(--card-border); background:none; color:var(--text-secondary); transition:all 0.2s; }
         .kb-chip.active { background:var(--primary); color:#fff; border-color:var(--primary); }
         .kb-chip:hover:not(.active) { border-color:var(--text-muted); color:var(--text); }
@@ -355,9 +357,49 @@
         body.app-webview .kb-auto-grid { flex-wrap:nowrap; }
         body.app-webview .kb-auto-card { flex:0 0 180px; }
 
+        /* History drawer: theme-aware so dark-mode text (color:var(--text)=white)
+           is not rendered on the hardcoded inline background:#fff of the drawer. */
+        #kbHistoryOverlay > div {
+            background: var(--card, #fff) !important;
+            color: var(--text, #111) !important;
+        }
+        #kbHistoryOverlay h3,
+        #kbHistoryOverlay h3 span { color: var(--text) !important; }
+        #kbHistoryOverlay #kbHistoryTotal { color: var(--text-muted, #888) !important; }
+        #kbHistoryList > div { border-color: var(--card-border, #e0e0e0) !important; }
+        #kbHistoryList > div > div > div:first-child { color: var(--text) !important; }
+        #kbHistoryList > div > div > div:nth-child(2) { color: var(--text-muted, #888) !important; }
+        #kbHistoryPager > span { color: var(--text-secondary, #666) !important; }
+
         /* ══════════════ Responsive ══════════════ */
         @media (max-width: 640px) {
             .sub-tab { padding:8px 12px; font-size:13px; }
+
+            /* Ghost buttons in toolbar: icon-only at narrow viewport */
+            .kb-toolbar-actions .btn.btn-ghost [data-i18n="kb_funnel_label"],
+            .kb-toolbar-actions .btn.btn-ghost [data-i18n="kb_history_label"] { display:none; }
+
+            /* Funnel: per-label wrap so date inputs don't overlap */
+            .kb-funnel > label { flex-shrink:0; white-space:nowrap; display:inline-flex; align-items:center; gap:4px; }
+            .kb-funnel > label > input[type="date"] { max-width:130px; }
+
+            /* Sort select: smaller on mobile */
+            .kb-sort-select { min-width:110px; margin-left:0; }
+
+            /* Card avatar badge: widen name so short entity names don't ellipsize */
+            .kb-card-avatars { max-width:100%; overflow:hidden; }
+            .kb-card-avatar-name { max-width:120px; }
+
+            /* History drawer: tighter padding + let card titles wrap on mobile */
+            #kbHistoryOverlay > div { padding: 16px !important; }
+            #kbHistoryList > div { flex-wrap: wrap !important; }
+            #kbHistoryList > div > div:first-child { flex: 1 1 100% !important; min-width: 0 !important; }
+            #kbHistoryList > div > div:first-child > div:first-child {
+                white-space: normal !important;
+                overflow: visible !important;
+                text-overflow: clip !important;
+                word-break: break-word;
+            }
         }
         @media (max-width: 768px) {
             .kb-board { display:none; }


### PR DESCRIPTION
## Summary
- Toolbar at narrow viewport no longer overflows (Funnel / History / +New-Card were pushed off-screen because `.kb-toolbar-actions` had no `flex-wrap`)
- History drawer text is readable in dark mode (was white-on-white: inline `background:#fff` + inherited `color: var(--text)=white`)
- History card titles wrap on mobile instead of being ellipsized

## Scope
Single file: `backend/public/portal/kanban.html` (+44 / −2, CSS only)

## Verification (personal, not delegated)
Ran Playwright on live prod with local CSS diff injected via `<style>` tag. Captured before/after at **420×844 mobile** and **1280×800 desktop** for both the toolbar and the history drawer. Files live on my workstation:
- `kanban-mobile-BEFORE.png` — +新增卡片 clipped off right edge
- `kanban-mobile-AFTER.png` — buttons wrap cleanly, chips inline
- `kanban-history-mobile-BEFORE.png` — title row blank (white h3 on white bg), card titles truncated
- `kanban-history-mobile-AFTER.png` — 📦 已归档卡片 (58 total) visible; titles wrap full-width
- `kanban-desktop-toolbar-AFTER.png` — no regression
- `kanban-desktop-history-AFTER.png` — drawer readable, same layout as before

## Bugs fixed
1. `.kb-toolbar-actions` missing `flex-wrap: wrap` → action buttons overflowed the viewport and the `+ 新增卡片` button was offscreen on mobile
2. History drawer uses hardcoded inline `background:#fff`, but inherited text color resolves to `var(--text)` which is `#fff` in dark mode → invisible header + metadata. Fixed via `#kbHistoryOverlay > div { color: var(--text) !important }` + theme-aware bg
3. History-item JS renders title with `white-space:nowrap; overflow:hidden; text-overflow:ellipsis` — at 420px wide minus Restore button, titles like `[Auto] Daily 每日社群互動監控 · 2026-04-23 超長標題測試_abc` were cut off after ~25 chars. Fixed via mobile-only override allowing wrap

## Test plan
- [x] Mobile viewport (420×844) toolbar: all buttons visible, chips inline, sort dropdown present
- [x] Mobile viewport history drawer: title visible, cards wrap, Restore button visible
- [x] Desktop viewport (1280×800): no regression on toolbar or drawer
- [x] Dark mode: drawer readable

## Related
- Tracking card: `card_ffb76de19a889fce59e8a1b0` (P1 frontend bug: Kanban mobile WebView 工具列崩壞)
- Workflow memory saved: `feedback_personal_screenshot_review.md` — all UI PRs from now on require personal playwright web+mobile screenshots before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)