### PR TITLE
fix(portal): kanban schedule enable silent-fail + note chip ellipsis + 📌 undefined

### DIFF
--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -1209,7 +1209,7 @@
             const reviewerName = card.reviewerEntityId != null ? getEntityDisplayName(card.reviewerEntityId) : '';
             meta.innerHTML = `
                 <span class="meta-item"><span class="kb-card-priority" data-p="${card.priority}">${card.priority}</span></span>
-                <span class="meta-item">📌 ${STATUS_LABELS[card.status]}</span>
+                <span class="meta-item">📌 ${STATUS_LABELS[card.status] || card.status || '—'}</span>
                 <span class="meta-item">👤 ${(card.assignedBots||[]).map(id=>{ const e=boundEntities.find(x=>x.entityId===id); return e?(e.name||e.character||'#'+id):'#'+id; }).join(', ')}</span>
                 ${reviewerName ? `<span class="meta-item">🔍 ${escapeHtml(reviewerName)}</span>` : ''}
                 <span class="meta-item">🕐 ${formatTime(card.createdAt || card.created_at)}</span>
@@ -1320,7 +1320,20 @@
 
         async function toggleAutoSchedule(cardId, enable) {
             const card = findCard(cardId);
-            if (!card) return;
+            if (!card) {
+                showToast(t('kb_auto_card_missing', 'Card not loaded — refresh the board'), true);
+                return;
+            }
+            if (enable) {
+                const schedType = card.schedule?.type || 'recurring';
+                const needsCron = schedType === 'recurring' && !card.schedule?.cronExpression;
+                const needsRunAt = schedType === 'once' && !card.schedule?.runAt;
+                if (needsCron || needsRunAt) {
+                    showToast(t('kb_auto_need_config', 'Schedule config missing — opening editor'), true);
+                    editAutoSchedule(cardId);
+                    return;
+                }
+            }
             const btn = document.querySelector('.kb-auto-action-btn.pause,.kb-auto-action-btn.resume');
             const body = { deviceId: currentUser.deviceId, deviceSecret: currentUser.deviceSecret, enabled: enable, type: card.schedule?.type || 'recurring' };
             if (card.schedule?.cronExpression) body.cronExpression = card.schedule.cronExpression;

--- a/backend/public/portal/shared/note-link-render.js
+++ b/backend/public/portal/shared/note-link-render.js
@@ -23,19 +23,20 @@
     // Matches: "Note a51136e1-...", "note: a51136e1-...", "Note：a51136e1-...", "筆記 a51136e1-..."
     const UUID_NOTE_RE = new RegExp(NOTE_KW + '\\s*[:：#＃]?\\s*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\b', 'gi');
 
-    // Keyword + short 8-char hex ID
-    // Matches: "Note a51136e1", "note:a51136e1", "筆記 a51136e1"
-    const SHORT_NOTE_RE = new RegExp(NOTE_KW + '\\s*[:：#＃]?\\s*([0-9a-f]{8})\\b', 'gi');
+    // Keyword + short 8-char hex ID — trailing "...", "…", or bare word-boundary all accepted
+    // Matches: "Note a51136e1", "note:a51136e1", "筆記 a51136e1", "note a51136e1..."
+    const SHORT_NOTE_RE = new RegExp(NOTE_KW + '\\s*[:：#＃]?\\s*([0-9a-f]{8})(?:\\.{3}|…)?\\b', 'gi');
 
     // Markdown renders `backtick-wrapped` IDs as <code>ID</code>, and the code-segment
     // skip in renderNoteLinks() hides them from the patterns above. Match
     // "<keyword> <code>ID</code>" explicitly before the split.
-    const CODE_UUID_NOTE_RE = new RegExp(NOTE_KW + '\\s*[:：#＃]?\\s*<code[^>]*>\\s*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})\\s*</code>', 'gi');
-    const CODE_SHORT_NOTE_RE = new RegExp(NOTE_KW + '\\s*[:：#＃]?\\s*<code[^>]*>\\s*([0-9a-f]{8})\\s*</code>', 'gi');
+    const CODE_UUID_NOTE_RE = new RegExp(NOTE_KW + '\\s*[:：#＃]?\\s*<code[^>]*>\\s*([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?:\\.{3}|…)?\\s*</code>', 'gi');
+    const CODE_SHORT_NOTE_RE = new RegExp(NOTE_KW + '\\s*[:：#＃]?\\s*<code[^>]*>\\s*([0-9a-f]{8})(?:\\.{3}|…)?\\s*</code>', 'gi');
 
     // Prefixed note IDs like "note_b7dd9e3a4c2..." — self-identifying, no keyword needed.
-    const PREFIXED_NOTE_RE = /\bnote_([a-f0-9]{24})\b/gi;
-    const CODE_PREFIXED_NOTE_RE = /<code[^>]*>\s*note_([a-f0-9]{24})\s*<\/code>/gi;
+    // Trailing "..." or "…" after the 24-hex body is tolerated (user-written ellipsis).
+    const PREFIXED_NOTE_RE = /\bnote_([a-f0-9]{24})(?:\.{3}|…)?\b/gi;
+    const CODE_PREFIXED_NOTE_RE = /<code[^>]*>\s*note_([a-f0-9]{24})(?:\.{3}|…)?\s*<\/code>/gi;
 
     // Cache: short prefix → full noteId (populated on successful API fetches)
     const resolvedIds = {};


### PR DESCRIPTION
## Context
Hank shared a screenshot of `⚙️ [自動化] EClaw Portal UIUX 巡檢（每4小時）` card that could not be enabled. Meta row rendered `📌 undefined` and clicking the `▶ Resume` button appeared to do nothing. Separately, Hank reported `note <backtick>d0f95750...<backtick>` chips in chat not clickable.

## Root causes (3 bugs)

### 1. `📌 undefined` — kanban.html:1212
`${STATUS_LABELS[card.status]}` returned `undefined` for archived / legacy / null statuses (STATUS_LABELS only covers the 5 board columns). Fix: fall back to raw status string or `—`.

### 2. Schedule-enable silent fail — kanban.html:1321 `toggleAutoSchedule`
The quick-button directly POSTed to `/schedule` with `type:'recurring'` but no `cronExpression` when the card's schedule config was missing (e.g. legacy card, never fully configured). Backend returns 400 `"Missing cronExpression for recurring schedule"` — UI showed a toast but nothing else. Fix:
- If `findCard()` returns null: toast "Card not loaded — refresh"
- If enabling but schedule config is incomplete: toast + open the edit dialog so user can fill it in, instead of hitting a dead API

### 3. Note chip regex misses trailing `...` / `…` — note-link-render.js
`note <backtick>d0f95750...<backtick>` → markdown → `note <code>d0f95750...</code>` → regex `\s*</code>` required whitespace-only between 8-hex and `</code>`. `...` broke the match. Fixed across all 5 patterns (short/UUID/prefixed × bare/in-code).

## Verification (Playwright, 420×844 + 1280×800)
- [x] All new regex cases match; all prior cases still match (bare 8-hex, bare UUID, bare prefixed, Chinese keyword variants)
- [x] STATUS_LABELS fallback renders correctly for: 5 known statuses, `archived`, `legacy_foo`, null, undefined, empty string
- [x] `toggleAutoSchedule` with null card → toast path; with card but no cron → opens edit dialog

## Self-review checklist
- [x] mobile viewport screenshot attached (`.playwright-mcp/kanban-fix-verification-mobile.png`)
- [x] desktop viewport not required (pure logic + small CSS-agnostic text change)
- [x] overlays: edit-schedule dialog opens correctly (dialog pre-existed, only invocation flow changed)
- [x] i18n keys added: `kb_auto_card_missing`, `kb_auto_need_config` (EN fallback provided; will follow up with ja/zh-CN/etc. translations via i18n delegate)
- [x] no help-page changes needed (internal logic)
- [x] no debug-flag endpoint changes needed