### PR TITLE
fix(chat): cache-bust note-link-render.js to roll out PR #2019 chip fix

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -2390,7 +2390,7 @@
     <script src="shared/entity-utils.js"></script>
     <script src="shared/mention-autocomplete.js"></script>
     <script src="shared/mention-render.js"></script>
-    <script src="shared/note-link-render.js"></script>
+    <script src="shared/note-link-render.js?v=0e95a36c"></script>
     <script src="shared/entity-link-render.js"></script>
     <script src="shared/his-link-render.js"></script>
     <script src="../shared/telemetry.js"></script>


### PR DESCRIPTION
## Summary
- PR #2019 fixed the note-chip ellipsis regex, but `chat.html` loads `shared/note-link-render.js` with no version query so existing users still see the pre-fix bundle from browser disk cache
- Cloudflare page rule overrides our `max-age=60` to `max-age=14400` on prod (`cf-cache-status: HIT`, `age: 28` on first fetch + 4hr browser cache)
- Appending `?v=0e95a36c` (PR #2019 merge SHA) forces a fresh fetch for everyone and unblocks the rollout today

## Root cause (discovered during today's E2E drill)
`window.NoteLinkRender.renderNoteLinks('Check note \`d0f95750...\`')` on live prod returned the input unchanged even though:
- Origin JS is updated (7116 bytes, Last-Modified `Fri, 24 Apr 2026 01:24:06 GMT`, contains `(?:\\.{3}|…)?` ellipsis branches)
- `fetch('shared/note-link-render.js', {cache:'reload'})` returned the new bundle
- `<script src>` load returned 6870 bytes with `transferSize: 0` → browser served disk cache

## Class-of-bug follow-up
This is only the point fix. The broader issue — every `portal/shared/*.js` hotfix has the same invisible-rollout problem — needs deploy-time version injection in HTML + a Cloudflare page-rule review. Tracked internally.

## Test plan
- [x] Verified origin JS contains ellipsis branches before commit
- [ ] After merge + deploy: reload chat page, confirm `<script src="shared/note-link-render.js?v=0e95a36c">` in DOM
- [ ] Paste `Note \`d0f95750...\`` in chat → expect clickable chip (not plain text)
- [ ] Hard-reload no longer required for new users

🤖 Generated with [Claude Code](https://claude.com/claude-code)