### PR TITLE
chore(audit): telemetry gaps + security fixes + zh-CN i18n

### DIFF
--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -743,6 +743,7 @@
     <script src="shared/auth.js"></script>
     <script src="shared/footer.js"></script>
     <script src="shared/product-tour.js"></script>
+    <script src="../shared/telemetry.js"></script>
     <script>
     /* ══════════════════════════════════════
        Real API Integration

--- a/backend/public/portal/index.html
+++ b/backend/public/portal/index.html
@@ -419,6 +419,7 @@
     <!-- IMPORTANT: Check path for i18n.js relative to portal/index.html. it is in ../shared/i18n.js since index.html is in portal/ -->
     <script src="../shared/i18n.js"></script>
     <script src="shared/footer.js"></script>
+    <script src="../shared/telemetry.js"></script>
     <script>
         let resetToken = null;
         let termsAccepted = false;

--- a/backend/public/portal/onboarding.html
+++ b/backend/public/portal/onboarding.html
@@ -262,6 +262,7 @@
     </main>
 
     <script src="/shared/i18n.js"></script>
+    <script src="/shared/telemetry.js"></script>
     <script>
         (function () {
             'use strict';

--- a/backend/public/portal/share-chat.html
+++ b/backend/public/portal/share-chat.html
@@ -349,6 +349,7 @@
 
     <script src="/portal/shared/entity-utils.js"></script>
     <script src="/shared/i18n.js"></script>
+    <script src="/shared/telemetry.js"></script>
     <script>
     const API_BASE = window.location.origin;
 

--- a/backend/public/portal/shared/agent-card-editor.js
+++ b/backend/public/portal/shared/agent-card-editor.js
@@ -292,12 +292,12 @@ window.AgentCardEditor = (function() {
                     ' <a href="' + examUrl + '?returnUrl=' + returnUrl + '" target="_blank" style="color:var(--primary);">' +
                     t('dash_interview_view_results', 'View Results →') + '</a></span>';
             } else {
-                if (statusEl) statusEl.innerHTML = '<span style="color:#ef4444;">❌ ' + (examRes.error || 'Failed to create exam') + '</span>';
+                if (statusEl) { statusEl.textContent = ''; var _sp2 = document.createElement('span'); _sp2.style.color = '#ef4444'; _sp2.textContent = '\u274c ' + (examRes.error || 'Failed to create exam'); statusEl.appendChild(_sp2); }
             }
         } catch (err) {
             btn.disabled = false;
             btn.textContent = '🧪 ' + t('dash_run_interview', 'Run Interview');
-            if (statusEl) statusEl.innerHTML = '<span style="color:#ef4444;">❌ ' + (err.message || 'Error') + '</span>';
+            if (statusEl) { statusEl.textContent = ''; var _sp = document.createElement('span'); _sp.style.color = '#ef4444'; _sp.textContent = '\u274c ' + (err.message || 'Error'); statusEl.appendChild(_sp); }
         }
     };
 

--- a/backend/rental.js
+++ b/backend/rental.js
@@ -28,6 +28,7 @@ const { Pool } = require('pg');
 const fs = require('fs');
 const path = require('path');
 const { runInterview, getProbeList } = require('./bot-interview');
+const { safeEqual } = require('./safe-equal');
 
 const pool = new Pool({
     connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
@@ -1482,7 +1483,7 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
         const devRes = await pool.query(
             'SELECT device_id, device_secret FROM devices WHERE device_id = $1', [deviceId]
         );
-        if (!devRes.rows.length || devRes.rows[0].device_secret !== deviceSecret) {
+        if (!devRes.rows.length || !safeEqual(devRes.rows[0].device_secret, deviceSecret)) {
             return res.json({ success: false, error: 'auth_failed' });
         }
         // In-memory device state
@@ -1583,7 +1584,7 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
         const devRes = await pool.query(
             'SELECT device_id, device_secret FROM devices WHERE device_id = $1', [deviceId]
         );
-        if (!devRes.rows.length || devRes.rows[0].device_secret !== deviceSecret) {
+        if (!devRes.rows.length || !safeEqual(devRes.rows[0].device_secret, deviceSecret)) {
             return res.json({ success: false, error: 'auth_failed' });
         }
         const userRes = await pool.query(


### PR DESCRIPTION
## Summary
- Add missing `telemetry.js` to 4 portal pages (community, login, onboarding, share-chat)
- Add 17 zh-CN translations for kanban nudge settings
- Fix XSS in agent-card-editor.js (innerHTML → textContent/DOM API)
- Fix timing-unsafe deviceSecret comparison in rental.js debug endpoints

## Test plan
- [x] All 116 Jest suites pass (2093 tests)
- [x] i18n strict check passes
- [x] i18n-syntax Jest test passes
- [x] Core regression tests pass (TLS headers, API docs, OIDC, broadcast)

🤖 Generated with [Claude Code](https://claude.com/claude-code)