### PR TITLE
fix(security): XSS escape + org-chart forward grouping

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3454,7 +3454,8 @@
                 const msgText = msg.text || '';
                 if (!msg.is_from_user
                     || (msg.source && (msg.source.startsWith('mission_notify') || msg.source === 'scheduled'))
-                    || msgText.startsWith('[TASK FWD') || msgText.startsWith('[FWD')
+                    || msgText.startsWith('[📋 TASK FWD') || msgText.startsWith('[📢 FWD')
+                    || (msg.source && msg.source.startsWith('xdevice:'))
                 ) {
                     grouped.push(msg);
                     continue;
@@ -5433,7 +5434,7 @@
                     bodyEl.querySelectorAll('pre code').forEach(block => hljs.highlightElement(block));
                 }
             } catch (err) {
-                bodyEl.innerHTML = `<div class="note-modal-error">Failed to load note: ${err.message || err}</div>`;
+                bodyEl.innerHTML = `<div class="note-modal-error">Failed to load note: ${escapeHtml(String(err.message || err))}</div>`;
             }
         }
 
@@ -5517,7 +5518,7 @@
                 // Async: fetch kanban tasks assigned to this entity
                 fetchEntityKanbanTasks(publicCode, bodyEl);
             } catch (err) {
-                bodyEl.innerHTML = `<div class="entity-modal-error">Failed to load: ${err.message || err}</div>`;
+                bodyEl.innerHTML = `<div class="entity-modal-error">Failed to load: ${escapeHtml(String(err.message || err))}</div>`;
             }
         }
 
@@ -5618,7 +5619,7 @@
                 idEl.textContent = (data.id || entityId).substring(0, 8);
                 bodyEl.innerHTML = data.html;
             } catch (err) {
-                bodyEl.innerHTML = `<div class="entity-modal-error">Failed to load: ${err.message || err}</div>`;
+                bodyEl.innerHTML = `<div class="entity-modal-error">Failed to load: ${escapeHtml(String(err.message || err))}</div>`;
             }
         }
 

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -1129,7 +1129,8 @@
                     <span style="padding:6px 0; color:#666; font-size:13px;">${historyPage} / ${totalPages}</span>
                     <button class="btn btn-ghost" ${historyPage >= totalPages ? 'disabled' : ''} onclick="historyPage++; loadHistoryPage()">›</button>`;
             } catch (err) {
-                list.innerHTML = '<div style="color:#c33;">' + (err.message || err) + '</div>';
+                const _esc = s => String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;');
+                list.innerHTML = '<div style="color:#c33;">' + _esc(err.message || err) + '</div>';
             }
         }
 


### PR DESCRIPTION
## Summary
- Escape `err.message` in `innerHTML` across `chat.html` (3 instances) and `kanban.html` (1 instance) to prevent potential XSS
- Fix broadcast grouping exclusion to match actual org-chart forward prefixes (`[📋 TASK FWD]` and `[📢 FWD]`) instead of wrong ASCII-only patterns
- Exclude cross-device messages (`source: xdevice:*`) from broadcast grouping per agent-message-rendering-spec

## Self-Review
- ✅ Logic: XSS escape via escapeHtml() / inline _esc()
- ✅ Security: Fixes unescaped innerHTML injection
- ⚠️ NO-OP: No new APIs / i18n / docs needed

## Test plan
- [x] Jest 116 suites / 2099 tests pass
- [x] i18n-check passes
- [x] ESLint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)