### PR TITLE
fix(device-vars): prevent empty-merge wipe (Android WebView incident)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -15495,6 +15495,24 @@ app.post('/api/device-vars', async (req, res) => {
                 }
             }
 
+            // Merge-mode empty guard (2026-04-24): same-source merge with an empty
+            // payload silently drops every key whose source matches `src`.
+            // Incident: Android WebView opened env-vars.html with empty localStorage
+            // and POSTed {vars:{},source:'web'}, wiping 17 keys. Refuse unless caller
+            // explicitly asks for REPLACE_ALL_EMPTY.
+            if (Object.keys(incoming).length === 0) {
+                const hadKeys = existing && Array.isArray(existing.var_keys) && existing.var_keys.length > 0;
+                if (hadKeys && confirm !== 'REPLACE_ALL_EMPTY') {
+                    serverLog('warn', 'device_vars', `[Vars] refused merge-mode empty wipe for ${deviceId}: ${existing.var_keys.length} keys present, src=${src}, no confirm`, { deviceId, metadata: { existingKeyCount: existing.var_keys.length, src, ip: _auditCtx.ip, ua: _auditCtx.ua } });
+                    db.logDeviceVarsAudit({ deviceId, action: 'refuse_wipe', source: src, callerIp: _auditCtx.ip, callerUa: _auditCtx.ua, beforeCount: existing.var_keys.length, afterCount: existing.var_keys.length });
+                    return res.status(400).json({
+                        success: false,
+                        error: 'refuse_empty_merge_wipe',
+                        message: `Refusing to merge empty vars into ${existing.var_keys.length} existing keys (src=${src}). Pass confirm:"REPLACE_ALL_EMPTY" to override.`,
+                    });
+                }
+            }
+
             merged = {};
             mergedSources = {};
 

--- a/backend/public/portal/env-vars.html
+++ b/backend/public/portal/env-vars.html
@@ -577,7 +577,13 @@
 
             renderAll();
             renderBotHint();
-            syncVarsToServer(); // sync on page load
+            // Page-load sync only when local has entries to push. An empty local
+            // here would otherwise POST {vars:{},source:'web'} and, in merge mode,
+            // silently drop every existing same-source key on the server.
+            // Incident 2026-04-24: Android WebView fresh storage partition → wipe.
+            if (Object.keys(loadLocalVars()).length > 0) {
+                syncVarsToServer();
+            }
             initTourTrack4();
         });
 

--- a/backend/tests/jest/device-vars.test.js
+++ b/backend/tests/jest/device-vars.test.js
@@ -233,7 +233,10 @@ describe('POST /api/device-vars — legacy empty-wipe guard', () => {
         expect(res.body.success).toBe(true);
     });
 
-    it('does NOT guard merge-mode source:"web" with empty vars (merge is safe)', async () => {
+    it('refuses merge-mode source:"web" with empty vars against non-empty vault (2026-04-24 incident)', async () => {
+        // Audit event #25 showed 17 keys → 0 via Android WebView POST
+        // {vars:{},source:'web'}. Merge branch now refuses empty incoming
+        // against a non-empty vault unless confirm:"REPLACE_ALL_EMPTY".
         const devId = `vars-post-mergeempty-${Date.now()}`;
         const secret = await registerDevice(devId);
         db.getDeviceVars.mockResolvedValueOnce({
@@ -245,6 +248,40 @@ describe('POST /api/device-vars — legacy empty-wipe guard', () => {
             deviceSecret: secret,
             vars: {},
             source: 'web',
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+        expect(res.body.error).toBe('refuse_empty_merge_wipe');
+        expect(res.body.message).toMatch(/Refusing to merge empty vars into 1 existing keys/);
+    });
+
+    it('allows merge-mode source:"web" with empty vars on empty vault (no-op, nothing to lose)', async () => {
+        const devId = `vars-post-mergeempty-empty-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        // Default mock returns null → no existing row
+        const res = await post('/api/device-vars').send({
+            deviceId: devId,
+            deviceSecret: secret,
+            vars: {},
+            source: 'web',
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+
+    it('allows merge-mode source:"web" with empty vars + confirm:"REPLACE_ALL_EMPTY" (explicit intent)', async () => {
+        const devId = `vars-post-mergeempty-confirm-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        db.getDeviceVars.mockResolvedValueOnce({
+            vars: { EXISTING: 'value' },
+            var_keys: ['EXISTING'],
+        });
+        const res = await post('/api/device-vars').send({
+            deviceId: devId,
+            deviceSecret: secret,
+            vars: {},
+            source: 'web',
+            confirm: 'REPLACE_ALL_EMPTY',
         });
         expect(res.status).toBe(200);
         expect(res.body.success).toBe(true);


### PR DESCRIPTION
## Summary
- **Bug A (backend)**: POST /api/device-vars in merge-mode with `vars={}` silently drops every key whose source matches. 2026-04-24 audit event #25 shows 17 → 0 keys, caller UA=EClawAndroid WebView, zero DELETE call involved. Legacy branch already had the empty-vars guard (2026-04-23 incident); merge branch never got one.
- **Bug B (frontend)**: env-vars.html calls `syncVarsToServer()` unconditionally on DOMContentLoaded. Android WebView fresh-install storage partition → `localStorage` empty → POSTs `{vars:{},source:'web'}` → wipes live vault.

## Fix
- `backend/index.js`: merge branch refuses `Object.keys(incoming).length===0` against a non-empty vault unless `confirm:"REPLACE_ALL_EMPTY"`. Writes `refuse_wipe` audit row with ip/ua for forensics.
- `backend/public/portal/env-vars.html`: guards the page-load sync so an empty local never becomes a write to server.

## Test plan
- [x] `node -c backend/index.js` parses
- [ ] Deployed: `curl -X POST /api/device-vars -d '{...vars:{},source:"web"}'` against a non-empty vault → 400 `refuse_empty_merge_wipe`
- [ ] Deployed: open env-vars.html with fresh localStorage → DevTools Network shows no POST /api/device-vars on page load
- [ ] audit log: after deploy + a day of traffic, no `before>0 after=0` merge events

## Related
- P0 incident card: `card_6ba085774a6bb69a257d0e50`
- Incident card: `card_dd7a86c1c19561a4167e4d7f` (P1 vault wipe 2026-04-23)

🤖 Generated with [Claude Code](https://claude.com/claude-code)