### PR TITLE
fix(growth): honor date=YYYY-MM-DD param in /api/growth/daily

### DIFF
--- a/backend/growth.js
+++ b/backend/growth.js
@@ -57,36 +57,48 @@ async function isOwnerAdmin(deviceId) {
 }
 
 const TZ = 'Asia/Taipei';
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
 
-async function fetchTodaySignups() {
+function taipeiTodayISO() {
+    // Asia/Taipei is UTC+8 with no DST — shift and slice.
+    return new Date(Date.now() + 8 * 3600 * 1000).toISOString().slice(0, 10);
+}
+
+function isValidDateStr(s) {
+    if (typeof s !== 'string' || !DATE_RE.test(s)) return false;
+    const d = new Date(s + 'T00:00:00Z');
+    return !Number.isNaN(d.getTime()) && d.toISOString().slice(0, 10) === s;
+}
+
+async function fetchSignupsForDate(dateStr) {
     const r = await pool.query(
         `SELECT COUNT(*)::int AS c FROM user_accounts
-         WHERE created_at >= date_trunc('day', NOW() AT TIME ZONE $1) AT TIME ZONE $1
-           AND created_at <  (date_trunc('day', NOW() AT TIME ZONE $1) + INTERVAL '1 day') AT TIME ZONE $1`,
-        [TZ]
+         WHERE created_at >= ($2::date::timestamp) AT TIME ZONE $1
+           AND created_at <  (($2::date + INTERVAL '1 day')::timestamp) AT TIME ZONE $1`,
+        [TZ, dateStr]
     );
     return r.rows[0].c;
 }
 
-async function fetchRetention7d() {
+async function fetchRetention7dForDate(dateStr) {
     const r = await pool.query(
-        `WITH today_start AS (
-           SELECT date_trunc('day', NOW() AT TIME ZONE $1) AS d
+        `WITH anchor AS (
+           SELECT $2::date AS d
          ),
          cohort AS (
-           SELECT id FROM user_accounts, today_start
-           WHERE created_at >= (d - INTERVAL '7 days') AT TIME ZONE $1
-             AND created_at <  (d - INTERVAL '6 days') AT TIME ZONE $1
+           SELECT id FROM user_accounts, anchor
+           WHERE created_at >= ((d - INTERVAL '7 days')::timestamp) AT TIME ZONE $1
+             AND created_at <  ((d - INTERVAL '6 days')::timestamp) AT TIME ZONE $1
          ),
          active AS (
            SELECT c.id FROM cohort c
-           JOIN user_accounts u ON u.id = c.id, today_start
-           WHERE u.last_login_at >= d AT TIME ZONE $1
-             AND u.last_login_at <  (d + INTERVAL '1 day') AT TIME ZONE $1
+           JOIN user_accounts u ON u.id = c.id, anchor
+           WHERE u.last_login_at >= (d::timestamp) AT TIME ZONE $1
+             AND u.last_login_at <  ((d + INTERVAL '1 day')::timestamp) AT TIME ZONE $1
          )
          SELECT (SELECT COUNT(*) FROM cohort)::int AS cohort_size,
                 (SELECT COUNT(*) FROM active)::int AS active_size`,
-        [TZ]
+        [TZ, dateStr]
     );
     const { cohort_size, active_size } = r.rows[0];
     if (cohort_size === 0) return { cohort_size: 0, active_size: 0, pct: null };
@@ -97,13 +109,13 @@ async function fetchRetention7d() {
     };
 }
 
-async function fetchPlazaNewListed() {
+async function fetchPlazaNewListedForDate(dateStr) {
     const r = await pool.query(
         `SELECT COUNT(*)::int AS c FROM bot_listings
          WHERE status = 'listed'
-           AND created_at >= date_trunc('day', NOW() AT TIME ZONE $1) AT TIME ZONE $1
-           AND created_at <  (date_trunc('day', NOW() AT TIME ZONE $1) + INTERVAL '1 day') AT TIME ZONE $1`,
-        [TZ]
+           AND created_at >= ($2::date::timestamp) AT TIME ZONE $1
+           AND created_at <  (($2::date + INTERVAL '1 day')::timestamp) AT TIME ZONE $1`,
+        [TZ, dateStr]
     );
     return r.rows[0].c;
 }
@@ -131,10 +143,19 @@ module.exports = function(devices) {
     const router = express.Router();
 
     router.get('/daily', async (req, res) => {
-        const { deviceId, botSecret, entityId } = req.query;
+        const { deviceId, botSecret, entityId, date } = req.query;
 
         if (!deviceId || !botSecret || !entityId) {
             return res.status(400).json({ success: false, error: 'Missing deviceId, botSecret, or entityId' });
+        }
+
+        let anchorDate;
+        if (date === undefined || date === '') {
+            anchorDate = taipeiTodayISO();
+        } else if (isValidDateStr(date)) {
+            anchorDate = date;
+        } else {
+            return res.status(400).json({ success: false, error: 'Invalid date — expected YYYY-MM-DD' });
         }
 
         const entity = findEntity(devices, deviceId, parseInt(entityId), botSecret);
@@ -159,14 +180,14 @@ module.exports = function(devices) {
 
         try {
             const [today_signups, retention_7d, plaza_new_listed_today, invite_conversion] = await Promise.all([
-                fetchTodaySignups(),
-                fetchRetention7d(),
-                fetchPlazaNewListed(),
+                fetchSignupsForDate(anchorDate),
+                fetchRetention7dForDate(anchorDate),
+                fetchPlazaNewListedForDate(anchorDate),
                 fetchInviteConversion()
             ]);
             return res.json({
                 success: true,
-                date: new Date().toISOString().slice(0, 10),
+                date: anchorDate,
                 today_signups,
                 retention_7d,
                 plaza_new_listed_today,
@@ -174,7 +195,8 @@ module.exports = function(devices) {
                 follow_ups: [
                     'source_channel: schema lacks signup_source column',
                     'visitor_to_signup_conversion: page_views has no FK to user_accounts',
-                    'plaza_new_listed_today: counts created_at not status_changed_at (bot_listings has no listed_at column)'
+                    'plaza_new_listed_today: counts created_at not status_changed_at (bot_listings has no listed_at column)',
+                    'invite_conversion is cumulative-to-now (not date-scoped); needs invite_redemptions.redeemed_at filter for historical k-value by day'
                 ]
             });
         } catch (err) {
@@ -185,6 +207,6 @@ module.exports = function(devices) {
 
     return {
         router,
-        _internal: { checkRate, findEntity, isOwnerAdmin, fetchTodaySignups, fetchRetention7d, fetchPlazaNewListed, rateBuckets }
+        _internal: { checkRate, findEntity, isOwnerAdmin, fetchSignupsForDate, fetchRetention7dForDate, fetchPlazaNewListedForDate, fetchInviteConversion, isValidDateStr, taipeiTodayISO, rateBuckets }
     };
 };

--- a/backend/index.js
+++ b/backend/index.js
@@ -1255,7 +1255,8 @@ app.get('/api/help', (req, res) => {
         search:     ['搜尋','search','fetch','網頁','web','query','検索','ウェブ','スクレイピング','검색','웹','스크래핑','ค้นหา','เว็บ','ดึงข้อมูล','tìm kiếm','cạo dữ liệu','pencarian','pengikisan','recherche','extraction web','búsqueda','raspado web','carian'],
         files:      ['file','檔案','upload','download','上傳','下載','ファイル','アップロード','保存','파일','업로드','저장','ไฟล์','อัปโหลด','บันทึก','tệp','tải lên','lưu','unggah','simpan','fichier','téléchargement','enregistrer','archivo','subir','guardar','fail','muat naik'],
         entities:   ['entity','實體','bind','綁定','status','lookup','查詢實體','エンティティ','バインディング','엔티티','연결','바인딩','เอนทิตี','การผูกมัด','thực thể','liên kết','kết nối','entitas','pengikatan','koneksi','entité','liaison','entidad','enlace','vínculo','entiti','sambungan'],
-        vault:      ['vault','device-vars','devicevars','secret','api key','apikey','金鑰','密鑰','秘密','保險箱','audit','審計','variables','環境變數','환경 변수','보관소','감사','シークレット','金庫','監査','bí mật','kho','giám sát','rahasia','brankas','audit log']
+        vault:      ['vault','device-vars','devicevars','secret','api key','apikey','金鑰','密鑰','秘密','保險箱','audit','審計','variables','環境變數','환경 변수','보관소','감사','シークレット','金庫','監査','bí mật','kho','giám sát','rahasia','brankas','audit log'],
+        analytics:  ['analytics','growth','metrics','signup','retention','kpi','viral','k-value','成長','指標','留存','分析','회귀','분석','지표','メトリクス','分析','指標']
     };
 
     const matched = Object.entries(INTENT_MAP).find(([, kws]) =>
@@ -1320,6 +1321,10 @@ app.get('/api/help', (req, res) => {
             { title: 'Full API documentation', curl: `curl -s "${apiBase}/api/skill-doc?format=text"` },
             { title: 'Read mission dashboard', curl: `curl -s "${apiBase}/api/mission/dashboard?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}"` },
             { title: 'Read kanban board', curl: `curl -s "${apiBase}/api/mission/cards?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}"` }
+        ],
+        analytics: [
+            { title: 'Daily growth snapshot (today, owner-admin only)', curl: `curl -s "${apiBase}/api/growth/daily?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}"` },
+            { title: 'Daily growth snapshot for a specific date (YYYY-MM-DD)', curl: `curl -s "${apiBase}/api/growth/daily?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}&date=2026-04-17"` }
         ]
     };
 

--- a/backend/tests/jest/growth.test.js
+++ b/backend/tests/jest/growth.test.js
@@ -113,7 +113,8 @@ describe('Growth /daily aggregation contract', () => {
         expect(res.body.invite_conversion).toEqual({ total_codes: 50, redeemed_codes: 11, pct: 22 });
         expect(res.body.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
         expect(Array.isArray(res.body.follow_ups)).toBe(true);
-        expect(res.body.follow_ups.length).toBe(3);
+        expect(res.body.follow_ups.length).toBe(4);
+        expect(res.body.follow_ups.some(s => /invite_conversion.*cumulative/i.test(s))).toBe(true);
     });
 
     it('reports invite_conversion pct as null when no codes issued', async () => {
@@ -170,6 +171,65 @@ describe('Growth /daily aggregation contract', () => {
         mockQuery.mockRejectedValueOnce(new Error('admin check failed'));
         const res = await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2');
         expect(res.status).toBe(500);
+    });
+});
+
+describe('Growth /daily date param (historical snapshots)', () => {
+    it('accepts date=YYYY-MM-DD and echoes it back in response', async () => {
+        setupAdminQueries({ signups: 3, cohort: 10, active: 2, plaza: 1, total_codes: 20, redeemed_codes: 4 });
+        const res = await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2&date=2026-04-17');
+        expect(res.status).toBe(200);
+        expect(res.body.date).toBe('2026-04-17');
+    });
+
+    it('passes the supplied date into the signups SQL (not NOW())', async () => {
+        setupAdminQueries({ signups: 9 });
+        await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2&date=2026-04-17');
+        // Find the signups query (first metric after is_admin). Params[1] should be the anchor date.
+        const signupsCall = mockQuery.mock.calls.find(c => /FROM user_accounts\s+WHERE created_at/.test(c[0]) && Array.isArray(c[1]));
+        expect(signupsCall).toBeDefined();
+        expect(signupsCall[1]).toEqual(['Asia/Taipei', '2026-04-17']);
+    });
+
+    it('two requests with different dates query DB with different anchor params', async () => {
+        setupAdminQueries({ signups: 5 });
+        await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2&date=2026-04-17');
+        const firstCalls = mockQuery.mock.calls.slice();
+        mockQuery.mockReset();
+        setupAdminQueries({ signups: 12 });
+        await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2&date=2026-04-18');
+        const secondCalls = mockQuery.mock.calls.slice();
+
+        const firstAnchors = firstCalls.map(c => (c[1] || [])[1]).filter(Boolean);
+        const secondAnchors = secondCalls.map(c => (c[1] || [])[1]).filter(Boolean);
+        expect(firstAnchors).toContain('2026-04-17');
+        expect(secondAnchors).toContain('2026-04-18');
+        expect(firstAnchors).not.toContain('2026-04-18');
+        expect(secondAnchors).not.toContain('2026-04-17');
+    });
+
+    it('rejects malformed date with 400', async () => {
+        const res = await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2&date=2026/04/17');
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/date/i);
+    });
+
+    it('rejects impossible date (Feb 30) with 400', async () => {
+        const res = await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2&date=2026-02-30');
+        expect(res.status).toBe(400);
+    });
+
+    it('defaults to today in Taipei TZ when date omitted', async () => {
+        setupAdminQueries({ signups: 2 });
+        const res = await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2');
+        expect(res.status).toBe(200);
+        const expected = new Date(Date.now() + 8 * 3600 * 1000).toISOString().slice(0, 10);
+        expect(res.body.date).toBe(expected);
+    });
+
+    it('validates date before auth/rate — bad date 400 even without valid creds', async () => {
+        const res = await get('?deviceId=admin-dev&botSecret=wrong&entityId=2&date=garbage');
+        expect(res.status).toBe(400);
     });
 });
 


### PR DESCRIPTION
## Summary
- `/api/growth/daily` handler used `NOW()` for all queries, so `date=<past>` was silently ignored and every request returned today's snapshot. This blocked k-value / WoW analytics and left the Friday viral-loop cron flying blind on history.
- Parse optional `date=YYYY-MM-DD` query param, validate format + calendar validity (rejects `2026-02-30`, slashes, garbage), then route it as the anchor into signups / retention_7d / plaza queries (all Taipei-TZ aligned).
- Bad date → 400 **before** auth + rate-check so callers don't burn quota on probe mistakes.
- When omitted, default anchor = today in Taipei TZ (UTC+8, no DST).
- Added 7 tests covering: echo-back, SQL anchor param, two-date divergence, malformed date, impossible date, default behavior, validation-before-auth ordering. All 23 growth tests + full 2108-test suite green.

Closes card_ae74befb6b186648d3ddaa64

## Known scope not addressed (follow-up in response body)
- `invite_conversion` is still cumulative-to-now. Turning it into per-day k-value needs `invite_redemptions.redeemed_at` filter + likely an `invite_codes.issued_at` anchor. Documented as a new follow_up in response body; will file a companion card for the class-of-bug hunt (other `/api/*` that accept `date|from|to` silently).

## Test plan
- [x] `npx jest tests/jest/growth.test.js` — 23/23 pass
- [x] `npx jest` full suite — 2108/2108 pass
- [ ] After Railway deploy: curl `/api/growth/daily?date=2026-04-17` vs `?date=2026-04-18` and confirm `date` echo differs + numbers diverge when signups exist
- [ ] Invalid date 400: `?date=garbage`, `?date=2026-02-30`, `?date=2026/04/17`
- [ ] Default-today: omit date → response.date == Taipei today

## Code Review Checklist
Self-review comment will be added below per /Users/hank/Desktop/Project/EClaw/docs/code-review-checklist.md before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)