### PR TITLE
feat(community): add /api/community/stats + /list endpoints

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -2169,6 +2169,55 @@ async function addCommunityMessage(publicCode, authorType, authorId, authorName,
     }
 }
 
+async function getCommunityStats(poolArg) {
+    const p = poolArg || pool;
+    try {
+        const [totals, categories] = await Promise.all([
+            p.query(
+                `WITH public_set AS (
+                   SELECT public_code, published_at FROM entities
+                   WHERE is_public = true AND bot_secret IS NOT NULL
+                 )
+                 SELECT
+                   (SELECT COUNT(*)::int FROM public_set) AS total_bots,
+                   (SELECT COUNT(*)::int FROM public_set
+                    WHERE published_at >= ((NOW() AT TIME ZONE 'Asia/Taipei')::date::timestamp) AT TIME ZONE 'Asia/Taipei'
+                   ) AS new_today,
+                   (SELECT COUNT(DISTINCT p.public_code)::int FROM public_set p
+                    WHERE EXISTS (
+                      SELECT 1 FROM community_messages m
+                      WHERE m.card_public_code = p.public_code
+                        AND m.created_at >= NOW() - INTERVAL '7 days'
+                    ) OR EXISTS (
+                      SELECT 1 FROM community_ratings r
+                      WHERE r.card_public_code = p.public_code
+                        AND r.updated_at >= NOW() - INTERVAL '7 days'
+                    )
+                   ) AS active_7d`
+            ),
+            p.query(
+                `SELECT tag, COUNT(*)::int AS count
+                 FROM entities e,
+                      jsonb_array_elements_text(COALESCE(e.agent_card->'tags','[]'::jsonb)) AS tag
+                 WHERE e.is_public = true AND e.bot_secret IS NOT NULL
+                 GROUP BY tag
+                 ORDER BY count DESC
+                 LIMIT 5`
+            ),
+        ]);
+        const row = totals.rows[0] || {};
+        return {
+            total_bots: row.total_bots || 0,
+            new_today: row.new_today || 0,
+            active_7d: row.active_7d || 0,
+            top_categories: categories.rows.map(r => ({ tag: r.tag, count: r.count })),
+        };
+    } catch (err) {
+        console.error('[DB] getCommunityStats error:', err.message);
+        return { total_bots: 0, new_today: 0, active_7d: 0, top_categories: [], error: 'query_failed' };
+    }
+}
+
 async function upsertCommunityRating(publicCode, deviceId, stars) {
     try {
         await pool.query(
@@ -2300,5 +2349,6 @@ module.exports = {
     getPublicCardDetail,
     getCommunityMessages,
     addCommunityMessage,
-    upsertCommunityRating
+    upsertCommunityRating,
+    getCommunityStats,
 };

--- a/backend/index.js
+++ b/backend/index.js
@@ -8999,6 +8999,30 @@ app.get('/api/community/search', async (req, res) => {
 });
 
 /**
+ * GET /api/community/list — Plaza listing (alias of /search with sensible defaults)
+ * No auth required. Same query contract as /search.
+ */
+app.get('/api/community/list', async (req, res) => {
+    const { q, tag, capability, limit, offset, sort } = req.query;
+    const results = await db.searchPublicCards({
+        q, tag, capability,
+        limit: parseInt(limit) || 20,
+        offset: parseInt(offset) || 0,
+        sort: sort || 'newest'
+    });
+    res.json({ success: true, count: results.length, results });
+});
+
+/**
+ * GET /api/community/stats — Plaza aggregate stats (total_bots, new_today, active_7d, top_categories)
+ * No auth required (public numbers used by monitoring cron + landing page).
+ */
+app.get('/api/community/stats', async (req, res) => {
+    const stats = await db.getCommunityStats();
+    res.json({ success: true, ...stats });
+});
+
+/**
  * GET /api/community/card/:publicCode — Public card detail + messages
  * No auth required
  */

--- a/backend/tests/jest/community-stats.test.js
+++ b/backend/tests/jest/community-stats.test.js
@@ -1,0 +1,101 @@
+/**
+ * Community plaza stats endpoint contract test.
+ *
+ * Tests db.getCommunityStats shape + SQL param handling. Injects a fake
+ * pool because the module-scoped pool is created lazily via initDatabase()
+ * which requires DATABASE_URL — not available in unit-test env.
+ */
+
+let mockQuery;
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: jest.fn(),
+        connect: jest.fn(),
+        end: jest.fn(),
+    })),
+}));
+
+let db;
+
+beforeEach(() => {
+    jest.resetModules();
+    mockQuery = jest.fn();
+    db = require('../../db');
+});
+
+const fakePool = () => ({ query: (...a) => mockQuery(...a) });
+
+describe('db.getCommunityStats', () => {
+    it('returns the full shape with totals + top_categories', async () => {
+        mockQuery
+            .mockResolvedValueOnce({ rows: [{ total_bots: 42, new_today: 3, active_7d: 11 }] })
+            .mockResolvedValueOnce({ rows: [
+                { tag: 'customer-service', count: 18 },
+                { tag: 'translator', count: 12 },
+                { tag: 'coding', count: 7 },
+            ]});
+        const stats = await db.getCommunityStats(fakePool());
+        expect(stats).toEqual({
+            total_bots: 42,
+            new_today: 3,
+            active_7d: 11,
+            top_categories: [
+                { tag: 'customer-service', count: 18 },
+                { tag: 'translator', count: 12 },
+                { tag: 'coding', count: 7 },
+            ],
+        });
+    });
+
+    it('returns zeros + empty categories when no public bots exist', async () => {
+        mockQuery
+            .mockResolvedValueOnce({ rows: [{ total_bots: 0, new_today: 0, active_7d: 0 }] })
+            .mockResolvedValueOnce({ rows: [] });
+        const stats = await db.getCommunityStats(fakePool());
+        expect(stats).toEqual({
+            total_bots: 0,
+            new_today: 0,
+            active_7d: 0,
+            top_categories: [],
+        });
+    });
+
+    it('never throws — degrades to zeros + error flag on db failure', async () => {
+        mockQuery.mockRejectedValueOnce(new Error('connection refused'));
+        const stats = await db.getCommunityStats(fakePool());
+        expect(stats.total_bots).toBe(0);
+        expect(stats.new_today).toBe(0);
+        expect(stats.active_7d).toBe(0);
+        expect(stats.top_categories).toEqual([]);
+        expect(stats.error).toBe('query_failed');
+    });
+
+    it('fires exactly two queries in parallel — totals + categories', async () => {
+        mockQuery
+            .mockResolvedValueOnce({ rows: [{ total_bots: 1, new_today: 0, active_7d: 1 }] })
+            .mockResolvedValueOnce({ rows: [{ tag: 'test', count: 1 }] });
+        await db.getCommunityStats(fakePool());
+        expect(mockQuery).toHaveBeenCalledTimes(2);
+        const totalsSql = mockQuery.mock.calls[0][0];
+        expect(totalsSql).toMatch(/public_set/);
+        expect(totalsSql).toMatch(/INTERVAL '7 days'/);
+        expect(totalsSql).toMatch(/Asia\/Taipei/);
+        const catSql = mockQuery.mock.calls[1][0];
+        expect(catSql).toMatch(/jsonb_array_elements_text/);
+        expect(catSql).toMatch(/LIMIT 5/);
+    });
+
+    it('coerces missing totals row to zeros without crashing', async () => {
+        mockQuery
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [] });
+        const stats = await db.getCommunityStats(fakePool());
+        expect(stats).toEqual({
+            total_bots: 0,
+            new_today: 0,
+            active_7d: 0,
+            top_categories: [],
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- `GET /api/community/stats` — `{total_bots, new_today, active_7d, top_categories}` for Bot Plaza landing + monitoring cron
- `GET /api/community/list` — paginated plaza listing (thin alias of existing `/search` with defaults)
- Kills 404s blocking the daily 07:02 community engagement cron (buffered monitoring report had a permanent gap)

## Implementation

- `db.getCommunityStats(poolArg?)` — two parallel queries (totals CTE in Asia/Taipei + tag aggregation from `agent_card->'tags'`)
- `active_7d` = distinct public entities with a `community_messages.created_at` **or** `community_ratings.updated_at` within the last 7 days
- Optional `poolArg` lets Jest inject a fake pool without going through `initDatabase()` (which needs `DATABASE_URL`)
- Endpoint public like `/api/community/search` — aggregate numbers only, no PII

## Self-review (Part A — logic/tests/shape)

1. **SQL safe**: no user input reaches SQL; all constants
2. **Auth contract**: public read (matches `/api/community/search`); no PII exposed
3. **Shape stable**: explicit `|| 0` coercion for every numeric field; empty rows degrade silently
4. **Parallel fan-out**: totals + categories in single `Promise.all`
5. **Error never throws**: catches + returns `{error:'query_failed', ...zeros}` so monitoring cron sees valid-shape response
6. **Taipei TZ correct**: `(NOW() AT TIME ZONE 'Asia/Taipei')::date` anchors `new_today`
7. **Jest**: 5 tests cover full shape, empty, failure, parallel-fire, empty-row
8. **Full suite still green**: 117 / 2113 tests pass

## Self-review (Part B — docs/i18n/info/help)

- No help doc update needed — community endpoints have no keyword route in `/api/help`'s INTENT_MAP (follow-up: add `community/plaza/bot-market` mapping — tracked in card comment after merge)
- No i18n strings added (all JSON payload)
- No info-page update needed (aggregate numbers, not new user-facing feature)
- No debug endpoint (aggregate read is inherently debug-visible)

## Test plan

- [x] `npx jest tests/jest/community-stats.test.js` — 5/5 pass
- [x] Full `npx jest tests/jest/` — 2113/2113 pass
- [ ] Post-merge: `curl /api/community/stats` on prod returns 200 with non-null shape
- [ ] Post-merge: daily 07:02 monitoring cron next run includes real plaza numbers
- [ ] Post-merge: move card `card_6eb1cc6aab2211adc8616f58` todo→done with evidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)