### PR TITLE
fix(invite): add /invite/:code route + click telemetry — shared URLs were 404ing

### DIFF
--- a/backend/auth_schema.sql
+++ b/backend/auth_schema.sql
@@ -191,3 +191,21 @@ CREATE TABLE IF NOT EXISTS invite_rewards (
 -- bit0=bronze (3 invites), bit1=silver (10), bit2=gold (30), bit3=diamond (100).
 -- Thresholds + bonuses live in index.js INVITE_TIERS.
 ALTER TABLE invite_rewards ADD COLUMN IF NOT EXISTS milestones_claimed INTEGER NOT NULL DEFAULT 0;
+
+-- invite_clicks: funnel step 1 telemetry. Logged when anyone hits
+-- /invite/:code (the share URL shown on invite.html + QR codes). Exists
+-- because prior to this table the /invite/:code route didn't exist at all
+-- — shared links 404'd, so conversion showed 0/N and we had no visibility
+-- into whether it was a click problem or a redeem problem.
+-- IP is hashed (sha256 truncated to 16 hex) to keep PII footprint low
+-- while still allowing unique-visitor heuristics.
+CREATE TABLE IF NOT EXISTS invite_clicks (
+    id BIGSERIAL PRIMARY KEY,
+    code VARCHAR(12) NOT NULL,
+    clicked_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    ip_hash VARCHAR(16),
+    user_agent TEXT,
+    referer TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_invite_clicks_code ON invite_clicks(code);
+CREATE INDEX IF NOT EXISTS idx_invite_clicks_clicked_at ON invite_clicks(clicked_at);

--- a/backend/db.js
+++ b/backend/db.js
@@ -2218,6 +2218,49 @@ async function getCommunityStats(poolArg) {
     }
 }
 
+async function logInviteClick({ code, ipHash, userAgent, referer }, poolArg) {
+    const p = poolArg || pool;
+    if (!p) return false;
+    try {
+        await p.query(
+            `INSERT INTO invite_clicks (code, ip_hash, user_agent, referer)
+             VALUES ($1, $2, $3, $4)`,
+            [code, ipHash || null, userAgent || null, referer || null]
+        );
+        return true;
+    } catch (err) {
+        console.error('[DB] logInviteClick error:', err.message);
+        return false;
+    }
+}
+
+async function getInviteClickStats(poolArg) {
+    const p = poolArg || pool;
+    try {
+        const r = await p.query(
+            `SELECT c.code,
+                    COUNT(*)::int AS clicks,
+                    COUNT(DISTINCT c.ip_hash)::int AS unique_clicks,
+                    MAX(c.clicked_at) AS last_clicked_at,
+                    (SELECT used_by_device_id FROM invite_codes WHERE code = c.code) IS NOT NULL AS redeemed
+             FROM invite_clicks c
+             GROUP BY c.code
+             ORDER BY last_clicked_at DESC
+             LIMIT 100`
+        );
+        return r.rows.map(row => ({
+            code: row.code,
+            clicks: row.clicks,
+            unique_clicks: row.unique_clicks,
+            last_clicked_at: row.last_clicked_at,
+            redeemed: row.redeemed === true,
+        }));
+    } catch (err) {
+        console.error('[DB] getInviteClickStats error:', err.message);
+        return [];
+    }
+}
+
 async function upsertCommunityRating(publicCode, deviceId, stars) {
     try {
         await pool.query(
@@ -2351,4 +2394,6 @@ module.exports = {
     addCommunityMessage,
     upsertCommunityRating,
     getCommunityStats,
+    logInviteClick,
+    getInviteClickStats,
 };

--- a/backend/index.js
+++ b/backend/index.js
@@ -625,7 +625,7 @@ app.get('/invite/:code', async (req, res) => {
     try {
         const ipRaw = (req.headers['x-forwarded-for'] || '').split(',')[0].trim() || req.ip || '';
         const ipHash = ipRaw
-            ? require('crypto').createHash('sha256').update(ipRaw).digest('hex').slice(0, 16)
+            ? crypto.createHash('sha256').update(ipRaw).digest('hex').slice(0, 16)
             : null;
         const userAgent = String(req.headers['user-agent'] || '').slice(0, 500) || null;
         const referer = String(req.headers.referer || req.headers.referrer || '').slice(0, 500) || null;

--- a/backend/index.js
+++ b/backend/index.js
@@ -608,6 +608,34 @@ app.get('/c/:code', (req, res) => {
     res.sendFile(_SHARE_CHAT_HTML_PATH);
 });
 
+// Public invite link landing. The shared URL format shown in invite.html +
+// QR codes is `https://eclawbot.com/invite/{CODE}`. Before this route existed
+// those links 404'd — which explained 0/N invite conversion: nobody made it
+// past the click. This route logs the click (step-1 funnel telemetry) and
+// 302-redirects to the portal page with the code pre-filled.
+// IP hashed (sha256 truncated to 16) to keep PII minimal while still allowing
+// unique-click estimates. Logging is best-effort — a DB failure must NEVER
+// block the redirect (we'd just be replacing a 404 with a 500).
+app.get('/invite/:code', async (req, res) => {
+    const raw = String(req.params.code || '').toUpperCase();
+    const code = /^[A-Z0-9]{4,12}$/.test(raw) ? raw : null;
+    if (!code) {
+        return res.redirect(302, '/portal/invite.html');
+    }
+    try {
+        const ipRaw = (req.headers['x-forwarded-for'] || '').split(',')[0].trim() || req.ip || '';
+        const ipHash = ipRaw
+            ? require('crypto').createHash('sha256').update(ipRaw).digest('hex').slice(0, 16)
+            : null;
+        const userAgent = String(req.headers['user-agent'] || '').slice(0, 500) || null;
+        const referer = String(req.headers.referer || req.headers.referrer || '').slice(0, 500) || null;
+        await db.logInviteClick({ code, ipHash, userAgent, referer });
+    } catch (err) {
+        console.warn(`[/invite/:code] click log failed for ${code}: ${err.message}`);
+    }
+    return res.redirect(302, `/portal/invite.html?redeem=${encodeURIComponent(code)}`);
+});
+
 // Legacy: rental-monitor moved to /portal/admin/rental-monitor.html in PR B
 // (admin-only gate). Redirect so old bookmarks still land somewhere sensible —
 // non-admins will bounce back to /portal/ from the admin hub's gate check.

--- a/backend/public/portal/invite.html
+++ b/backend/public/portal/invite.html
@@ -399,8 +399,15 @@
         }
 
         window.addEventListener('DOMContentLoaded', async () => {
-            const _isEmbed = new URLSearchParams(window.location.search).get('embed') === '1' || window.self !== window.top;
+            const _params = new URLSearchParams(window.location.search);
+            const _isEmbed = _params.get('embed') === '1' || window.self !== window.top;
             if (_isEmbed) document.body.classList.add('embed-mode');
+            // Pre-fill redeem box when arriving via /invite/:code share link.
+            const _redeemParam = (_params.get('redeem') || '').toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 12);
+            if (_redeemParam) {
+                const _input = document.getElementById('redeemInput');
+                if (_input) _input.value = _redeemParam;
+            }
             renderNav('settings');
             if (typeof renderFooter === 'function') renderFooter();
             if (typeof i18n !== 'undefined') i18n.apply();

--- a/backend/tests/jest/invite-clicks.test.js
+++ b/backend/tests/jest/invite-clicks.test.js
@@ -1,0 +1,106 @@
+/**
+ * Invite click-tracking tests.
+ *
+ * Covers db.logInviteClick + db.getInviteClickStats contract. These back
+ * the /invite/:code share-link route which (a) fixes the prior 404 and
+ * (b) logs step-1 funnel telemetry for the invite conversion metric.
+ *
+ * pg Pool is mocked because db.js's module-scoped pool is null until
+ * initDatabase() runs (requires DATABASE_URL — not in unit-test env).
+ * Helpers accept a poolArg override for exactly this reason.
+ */
+
+let mockQuery;
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: jest.fn(),
+        connect: jest.fn(),
+        end: jest.fn(),
+    })),
+}));
+
+let db;
+
+beforeEach(() => {
+    jest.resetModules();
+    mockQuery = jest.fn();
+    db = require('../../db');
+});
+
+const fakePool = () => ({ query: (...a) => mockQuery(...a) });
+
+describe('db.logInviteClick', () => {
+    it('inserts a row with all fields when pg is available', async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+        const ok = await db.logInviteClick(
+            { code: 'ABC123', ipHash: 'deadbeef12345678', userAgent: 'UA/1.0', referer: 'https://x.example/p' },
+            fakePool()
+        );
+        expect(ok).toBe(true);
+        expect(mockQuery).toHaveBeenCalledTimes(1);
+        const [sql, params] = mockQuery.mock.calls[0];
+        expect(sql).toMatch(/INSERT INTO invite_clicks/);
+        expect(params).toEqual(['ABC123', 'deadbeef12345678', 'UA/1.0', 'https://x.example/p']);
+    });
+
+    it('coerces missing metadata to NULL instead of undefined', async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+        const ok = await db.logInviteClick({ code: 'XY99' }, fakePool());
+        expect(ok).toBe(true);
+        const [, params] = mockQuery.mock.calls[0];
+        expect(params).toEqual(['XY99', null, null, null]);
+    });
+
+    it('returns false (no throw) on DB error — redirect path must not break', async () => {
+        mockQuery.mockRejectedValueOnce(new Error('connection refused'));
+        const ok = await db.logInviteClick({ code: 'FAIL' }, fakePool());
+        expect(ok).toBe(false);
+    });
+
+    it('returns false when pool is unavailable (no module pool, no override)', async () => {
+        // Call with no poolArg and the module-scoped pool is null in unit env.
+        const ok = await db.logInviteClick({ code: 'NOPG' });
+        expect(ok).toBe(false);
+    });
+});
+
+describe('db.getInviteClickStats', () => {
+    it('returns per-code aggregate with clicks + unique_clicks + redeemed flag', async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [
+            { code: 'AAA1', clicks: 5, unique_clicks: 3, last_clicked_at: new Date('2026-04-24T01:00:00Z'), redeemed: true },
+            { code: 'BBB2', clicks: 2, unique_clicks: 2, last_clicked_at: new Date('2026-04-23T18:00:00Z'), redeemed: false },
+        ]});
+        const stats = await db.getInviteClickStats(fakePool());
+        expect(stats).toHaveLength(2);
+        expect(stats[0].code).toBe('AAA1');
+        expect(stats[0].clicks).toBe(5);
+        expect(stats[0].unique_clicks).toBe(3);
+        expect(stats[0].redeemed).toBe(true);
+        expect(stats[1].redeemed).toBe(false);
+    });
+
+    it('groups by code and joins to invite_codes for redeemed flag', async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [] });
+        await db.getInviteClickStats(fakePool());
+        const sql = mockQuery.mock.calls[0][0];
+        expect(sql).toMatch(/GROUP BY c\.code/);
+        expect(sql).toMatch(/FROM invite_codes WHERE code = c\.code/);
+        expect(sql).toMatch(/COUNT\(DISTINCT c\.ip_hash\)/);
+        expect(sql).toMatch(/LIMIT 100/);
+    });
+
+    it('returns [] (not throws) on DB error', async () => {
+        mockQuery.mockRejectedValueOnce(new Error('bad sql'));
+        const stats = await db.getInviteClickStats(fakePool());
+        expect(stats).toEqual([]);
+    });
+
+    it('coerces redeemed to strict boolean (not nullable)', async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [
+            { code: 'CCC3', clicks: 1, unique_clicks: 1, last_clicked_at: new Date(), redeemed: null },
+        ]});
+        const stats = await db.getInviteClickStats(fakePool());
+        expect(stats[0].redeemed).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- Share URL `https://eclawbot.com/invite/{CODE}` (referenced in `invite.html` L230 + QR generator L91) had **no matching server-side route** — every click returned HTTP 404 before reaching the redeem page. That's the real root cause of `/api/growth/daily` reporting `invite_conversion: 0/8`: funnel died at step 1 (click), not step 2 (redeem).
- New `GET /invite/:code` route: validates the code (regex `/^[A-Z0-9]{4,12}$/`), logs a row to `invite_clicks` (code + sha256-truncated IP + UA + referer), 302-redirects to `/portal/invite.html?redeem=CODE`.
- Click logging is **best-effort** — a DB error must not demote a 302 back to a 500/404. Verified by unit test.
- Tiny frontend change in `invite.html`: reads `?redeem=` and prefills the redeem box so users land on a working page.

## Why this PR is infra-shipped-without-asking
Per memory `feedback_ship_infra_fixes_without_asking.md`: backend route + new DB table + 5 lines of JS prefill, no new UI surface, no basic-function change. The 5-line prefill is directly tied to the route fix (the redirect passes `?redeem=`) so bundling avoids a follow-up PR for zero gain.

## Follow-ups
- `GET /api/invite/clicks` admin endpoint using `db.getInviteClickStats` (for Growth Metrics dashboard). Helper exists, endpoint not yet wired — small next PR.
- `/api/growth/daily` `invite_conversion` currently uses `invite_redemptions` count; consider adding `clicks_today` + `click_to_redeem_pct` once we have real data.

## Test plan
- [x] `npx jest tests/jest/invite-clicks.test.js` — 8/8 new tests green (logInviteClick valid shape / null coercion / DB-fail non-throw / no-pool; getInviteClickStats shape / SQL grouping / error path / strict boolean)
- [x] Full suite: 118/118 suites, 2121/2121 tests (+8 new)
- [ ] Post-deploy: `curl -sS -o /dev/null -w "%{http_code} → %{redirect_url}\n" https://eclawbot.com/invite/TESTCODE` should return `302 → /portal/invite.html?redeem=TESTCODE` (was `404`)
- [ ] Post-deploy: Playwright web + mobile screenshot of landing via invite link — prefill visible in redeem input
- [ ] Post-deploy: confirm `invite_clicks` rows appear after clicking a real code

🤖 Generated with [Claude Code](https://claude.com/claude-code)