### PR TITLE
feat(admin): GET /api/admin/invite/clicks — invite funnel step-1 visibility

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -3468,6 +3468,37 @@ app.get('/api/admin/bots', adminAuth, adminCheck, async (req, res) => {
     }
 });
 
+// GET /api/admin/invite/clicks — step-1 funnel telemetry for the invite
+// conversion metric. Pairs with /api/growth/daily which reports cumulative
+// redemptions; this endpoint shows per-code click counts + unique visitors
+// so we can see where drop-off happens (shared-but-not-clicked vs
+// clicked-but-not-redeemed). Admin-gated because the rows include IP hashes
+// and referrers — aggregate is public-safe, raw rows are not.
+app.get('/api/admin/invite/clicks', adminAuth, adminCheck, async (req, res) => {
+    try {
+        const rows = await db.getInviteClickStats();
+        const totalClicks = rows.reduce((s, r) => s + r.clicks, 0);
+        const totalUnique = rows.reduce((s, r) => s + r.unique_clicks, 0);
+        const redeemedCount = rows.filter(r => r.redeemed).length;
+        res.json({
+            success: true,
+            summary: {
+                codes_with_clicks: rows.length,
+                total_clicks: totalClicks,
+                total_unique_clicks: totalUnique,
+                redeemed: redeemedCount,
+                click_to_redeem_pct: rows.length > 0
+                    ? Math.round((redeemedCount / rows.length) * 1000) / 10
+                    : null,
+            },
+            rows,
+        });
+    } catch (err) {
+        console.error('[Admin] invite/clicks error:', err);
+        res.status(500).json({ success: false, error: 'Failed to load invite clicks' });
+    }
+});
+
 // POST /api/admin/push-update - Broadcast app update notification to all devices via FCM
 app.post('/api/admin/push-update', adminAuth, adminCheck, async (req, res) => {
     if (!firebaseAdmin) {

--- a/backend/tests/jest/admin-operations.test.js
+++ b/backend/tests/jest/admin-operations.test.js
@@ -108,6 +108,54 @@ describe('POST /api/admin/bots/create', () => {
 });
 
 // ════════════════════════════════════════════════════════════════
+// GET /api/admin/invite/clicks — invite funnel step-1 telemetry
+// ════════════════════════════════════════════════════════════════
+describe('GET /api/admin/invite/clicks', () => {
+    const db = require('../../db');
+
+    afterEach(() => {
+        if (db.getInviteClickStats.mockReset) db.getInviteClickStats.mockReset();
+    });
+
+    it('returns empty-but-shaped summary when no clicks logged', async () => {
+        db.getInviteClickStats.mockResolvedValueOnce([]);
+        const res = await get('/api/admin/invite/clicks');
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.summary).toEqual({
+            codes_with_clicks: 0,
+            total_clicks: 0,
+            total_unique_clicks: 0,
+            redeemed: 0,
+            click_to_redeem_pct: null,
+        });
+        expect(res.body.rows).toEqual([]);
+    });
+
+    it('aggregates totals + computes click_to_redeem_pct rounded to 1 decimal', async () => {
+        db.getInviteClickStats.mockResolvedValueOnce([
+            { code: 'AAA1', clicks: 6, unique_clicks: 4, last_clicked_at: new Date('2026-04-24T01:00:00Z'), redeemed: true },
+            { code: 'BBB2', clicks: 2, unique_clicks: 2, last_clicked_at: new Date('2026-04-23T18:00:00Z'), redeemed: false },
+            { code: 'CCC3', clicks: 1, unique_clicks: 1, last_clicked_at: new Date('2026-04-23T10:00:00Z'), redeemed: false },
+        ]);
+        const res = await get('/api/admin/invite/clicks');
+        expect(res.status).toBe(200);
+        expect(res.body.summary.codes_with_clicks).toBe(3);
+        expect(res.body.summary.total_clicks).toBe(9);
+        expect(res.body.summary.total_unique_clicks).toBe(7);
+        expect(res.body.summary.redeemed).toBe(1);
+        expect(res.body.summary.click_to_redeem_pct).toBe(33.3);
+        expect(res.body.rows).toHaveLength(3);
+    });
+
+    it('returns 500 when helper throws', async () => {
+        db.getInviteClickStats.mockRejectedValueOnce(new Error('boom'));
+        const res = await get('/api/admin/invite/clicks');
+        expect(res.status).toBe(500);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
 // PUT /api/admin/official-bot/:botId — update + sync bound entities
 // ════════════════════════════════════════════════════════════════
 describe('PUT /api/admin/official-bot/:botId', () => {

--- a/backend/tests/jest/helpers/mock-setup.js
+++ b/backend/tests/jest/helpers/mock-setup.js
@@ -74,6 +74,11 @@ jest.mock('../../../db', () => ({
     deleteDeviceVars: jest.fn().mockResolvedValue(true),
     logDeviceVarsAudit: jest.fn().mockResolvedValue(true),
     getDeviceVarsAudit: jest.fn().mockResolvedValue([]),
+    getCommunityStats: jest.fn().mockResolvedValue({ total_bots: 0, new_today: 0, active_7d: 0, top_categories: [] }),
+    searchPublicCards: jest.fn().mockResolvedValue([]),
+    upsertCommunityRating: jest.fn().mockResolvedValue(null),
+    logInviteClick: jest.fn().mockResolvedValue(false),
+    getInviteClickStats: jest.fn().mockResolvedValue([]),
 }));
 
 jest.mock('../../../flickr', () => ({


### PR DESCRIPTION
## Summary
- Follow-up to PR #2032 (which fixed the /invite/:code 404 and added the `invite_clicks` table). That PR added `db.getInviteClickStats` but left it un-wired — this PR exposes it as `GET /api/admin/invite/clicks`.
- Pairs with `/api/growth/daily` (cumulative redemptions) so we can see drop-off: **shared-but-not-clicked** vs **clicked-but-not-redeemed**.
- Admin-gated (`adminAuth` + `adminCheck`) because raw rows include IP hashes + referers. Summary is aggregate-only but the route returns both.

## Response shape
```json
{
  "success": true,
  "summary": {
    "codes_with_clicks": 3,
    "total_clicks": 9,
    "total_unique_clicks": 7,
    "redeemed": 1,
    "click_to_redeem_pct": 33.3
  },
  "rows": [{"code":"AAA1","clicks":6,"unique_clicks":4,"last_clicked_at":"...","redeemed":true}, ...]
}
```

## Why this PR is infra-shipped-without-asking
Per memory `feedback_ship_infra_fixes_without_asking.md`: admin-gated endpoint + small test additions, no UI touch, no basic-function change. I asked about this in a fakechat reply earlier instead of shipping — that was the wrong call; this corrects it.

## Test plan
- [x] `npx jest tests/jest/admin-operations.test.js` — 19/19 (3 new: empty shape / aggregation+rounding / 500 on helper throw)
- [x] Full suite: 118/118 suites, 2124/2124 tests (+3)
- [ ] Post-deploy: admin curl to `/api/admin/invite/clicks` should return `summary.codes_with_clicks: 0` on first call (no real clicks yet), non-zero after shared links get clicked

🤖 Generated with [Claude Code](https://claude.com/claude-code)