### PR TITLE
docs(mockup): add notes.html 心智 tab static preview (#104)

### DIFF
--- a/backend/public/assets/mockup-mindmap-notes.html
+++ b/backend/public/assets/mockup-mindmap-notes.html
@@ -1,0 +1,369 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="robots" content="noindex, nofollow">
+<title>Mockup — notes.html 心智 tab</title>
+<style>
+:root {
+  --bg: #0d1117;
+  --card-bg: #161b22;
+  --card-border: #2a2f3a;
+  --text: #e6edf3;
+  --text-secondary: #8b949e;
+  --primary: #7c83ff;
+  --accent-kanban: #4ade80;
+  --accent-chat: #58a6ff;
+  --accent-note: #f0883e;
+  --accent-file: #c084fc;
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  background: var(--bg);
+  color: var(--text);
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  font-size: 14px;
+  min-height: 100vh;
+  padding: 20px;
+}
+.mockup-banner {
+  max-width: 1080px;
+  margin: 0 auto 16px;
+  padding: 10px 14px;
+  background: rgba(124, 131, 255, 0.12);
+  border: 1px solid var(--primary);
+  border-radius: 8px;
+  color: var(--text-secondary);
+  font-size: 12px;
+}
+.mockup-banner strong { color: var(--primary); }
+
+.page {
+  max-width: 1080px;
+  margin: 0 auto;
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 12px;
+  overflow: hidden;
+}
+
+/* Top tab bar */
+.tab-bar {
+  display: flex;
+  border-bottom: 1px solid var(--card-border);
+  background: rgba(0, 0, 0, 0.2);
+}
+.tab {
+  padding: 14px 22px;
+  font-size: 14px;
+  color: var(--text-secondary);
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  user-select: none;
+}
+.tab:hover { color: var(--text); }
+.tab.active {
+  color: var(--primary);
+  border-bottom-color: var(--primary);
+  font-weight: 600;
+}
+.tab-counter {
+  display: inline-block;
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text-secondary);
+  font-size: 11px;
+  padding: 2px 7px;
+  border-radius: 10px;
+  margin-left: 6px;
+}
+.tab.active .tab-counter { background: rgba(124, 131, 255, 0.25); color: var(--primary); }
+
+/* Mindmap tab content */
+.mm-tab {
+  padding: 20px 22px 28px;
+}
+.mm-toolbar {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 18px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.mm-toolbar .search {
+  flex: 1;
+  min-width: 200px;
+  background: var(--bg);
+  color: var(--text);
+  border: 1px solid var(--card-border);
+  border-radius: 6px;
+  padding: 8px 12px;
+  font-size: 13px;
+}
+.mm-btn {
+  background: var(--card-bg);
+  color: var(--text);
+  border: 1px solid var(--card-border);
+  border-radius: 6px;
+  padding: 7px 12px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.mm-btn.primary { background: var(--primary); color: #fff; border-color: var(--primary); }
+
+.mm-section-title {
+  font-size: 11px;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  margin: 18px 0 10px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.mm-section-title a { color: var(--primary); text-decoration: none; font-size: 11px; }
+.mm-section-title a:hover { text-decoration: underline; }
+
+/* Node card grid */
+.node-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 14px;
+}
+.node-card {
+  background: var(--bg);
+  border: 1px solid var(--card-border);
+  border-radius: 10px;
+  padding: 14px 16px;
+  transition: border-color 0.15s, transform 0.15s;
+  cursor: pointer;
+}
+.node-card:hover {
+  border-color: var(--primary);
+  transform: translateY(-2px);
+}
+.node-head {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+.node-type {
+  font-size: 10px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+  padding: 2px 7px;
+  border: 1px solid var(--card-border);
+  border-radius: 10px;
+}
+.node-type.domain { color: var(--primary); border-color: rgba(124, 131, 255, 0.4); }
+.node-type.topic { color: var(--accent-chat); border-color: rgba(88, 166, 255, 0.4); }
+.node-type.leaf { color: var(--accent-note); border-color: rgba(240, 136, 62, 0.4); }
+.node-title {
+  font-size: 15px;
+  font-weight: 600;
+  flex: 1;
+}
+.node-summary {
+  color: var(--text-secondary);
+  font-size: 12px;
+  line-height: 1.5;
+  margin-bottom: 10px;
+}
+
+/* Anchor chips */
+.anchor-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+.anchor-chip {
+  font-size: 11px;
+  padding: 3px 8px;
+  border-radius: 12px;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid var(--card-border);
+  color: var(--text-secondary);
+}
+.anchor-chip .dot { width: 6px; height: 6px; border-radius: 50%; flex: none; }
+.anchor-chip.kanban .dot { background: var(--accent-kanban); }
+.anchor-chip.chat .dot { background: var(--accent-chat); }
+.anchor-chip.note .dot { background: var(--accent-note); }
+.anchor-chip.file .dot { background: var(--accent-file); }
+
+.node-footer {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px dashed var(--card-border);
+  font-size: 11px;
+  color: var(--text-secondary);
+  display: flex;
+  justify-content: space-between;
+}
+
+/* Coming-soon stripe */
+.soon-stripe {
+  margin-top: 26px;
+  padding: 14px 16px;
+  border-radius: 8px;
+  background: linear-gradient(90deg, rgba(124, 131, 255, 0.12), rgba(88, 166, 255, 0.08));
+  border: 1px dashed var(--primary);
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+.soon-stripe strong { color: var(--primary); }
+</style>
+</head>
+<body>
+
+<div class="mockup-banner">
+  <strong>MOCKUP</strong> · <code>assets/mockup-mindmap-notes.html</code> ·
+  靜態預覽（無 API、無 auth）。目的：讓 Hank 預覽 notes.html 頂端 tab 長相，決定是否投入實作。
+</div>
+
+<div class="page">
+
+  <!-- Top tabs -->
+  <nav class="tab-bar">
+    <div class="tab">📄 文檔 <span class="tab-counter">12</span></div>
+    <div class="tab active">🧠 心智 <span class="tab-counter">47</span></div>
+    <div class="tab">🔍 向量 <span class="tab-counter">1.2k</span></div>
+    <div class="tab">📦 檔案 <span class="tab-counter">88</span></div>
+  </nav>
+
+  <!-- 心智 tab -->
+  <section class="mm-tab">
+
+    <div class="mm-toolbar">
+      <input class="search" placeholder="搜尋節點標題、摘要、anchor ref…">
+      <button class="mm-btn primary">＋ 新節點</button>
+      <button class="mm-btn">🗺 開啟完整 cytoscape</button>
+    </div>
+
+    <div class="mm-section-title">
+      <span>最近更新 · Recent nodes</span>
+      <a href="#">查看全部 47 →</a>
+    </div>
+
+    <div class="node-grid">
+
+      <article class="node-card">
+        <div class="node-head">
+          <span class="node-type domain">domain</span>
+          <span class="node-title">邀請系統</span>
+        </div>
+        <div class="node-summary">8 碼生碼、redeem flow、tier milestone、funnel telemetry。</div>
+        <div class="anchor-list">
+          <span class="anchor-chip kanban"><span class="dot"></span>看板 #102 邀請漏斗 0/8</span>
+          <span class="anchor-chip kanban"><span class="dot"></span>看板 f53a093a</span>
+          <span class="anchor-chip chat"><span class="dot"></span>聊天 2026-04-24 14:01</span>
+        </div>
+        <div class="node-footer">
+          <span>3 anchors · 2 留言</span>
+          <span>更新 2h ago</span>
+        </div>
+      </article>
+
+      <article class="node-card">
+        <div class="node-head">
+          <span class="node-type topic">topic</span>
+          <span class="node-title">Device Secret 輪替</span>
+        </div>
+        <div class="node-summary">安全性 P2 — POST /api/device/rotate-secret、UI dialog、一次性揭露。</div>
+        <div class="anchor-list">
+          <span class="anchor-chip kanban"><span class="dot"></span>看板 #103</span>
+          <span class="anchor-chip chat"><span class="dot"></span>聊天 rotate flow</span>
+          <span class="anchor-chip note"><span class="dot"></span>筆記 rotation runbook</span>
+        </div>
+        <div class="node-footer">
+          <span>3 anchors · 1 留言</span>
+          <span>更新 4h ago</span>
+        </div>
+      </article>
+
+      <article class="node-card">
+        <div class="node-head">
+          <span class="node-type leaf">leaf</span>
+          <span class="node-title">Kanban Nudge 收合</span>
+        </div>
+        <div class="node-summary">settings.html 折疊頭 + localStorage 狀態記憶 + aria-expanded。</div>
+        <div class="anchor-list">
+          <span class="anchor-chip kanban"><span class="dot"></span>看板 #105</span>
+          <span class="anchor-chip file"><span class="dot"></span>截圖 x4</span>
+        </div>
+        <div class="node-footer">
+          <span>2 anchors · 0 留言</span>
+          <span>更新 30m ago</span>
+        </div>
+      </article>
+
+      <article class="node-card">
+        <div class="node-head">
+          <span class="node-type topic">topic</span>
+          <span class="node-title">向量搜尋定位</span>
+        </div>
+        <div class="node-summary">三大賣點：跨 session 記憶、跨智能體共享、回憶能力。</div>
+        <div class="anchor-list">
+          <span class="anchor-chip chat"><span class="dot"></span>聊天 positioning</span>
+          <span class="anchor-chip note"><span class="dot"></span>筆記 roadmap</span>
+          <span class="anchor-chip note"><span class="dot"></span>筆記 selling-points</span>
+        </div>
+        <div class="node-footer">
+          <span>3 anchors · 4 留言</span>
+          <span>更新 1d ago</span>
+        </div>
+      </article>
+
+      <article class="node-card">
+        <div class="node-head">
+          <span class="node-type leaf">leaf</span>
+          <span class="node-title">Mac 風扇 runbook</span>
+        </div>
+        <div class="node-summary">HUP 閒置 tty login_pid、保留 console/tmux、U## 完工後關 tty。</div>
+        <div class="anchor-list">
+          <span class="anchor-chip note"><span class="dot"></span>筆記 fan-loud</span>
+          <span class="anchor-chip file"><span class="dot"></span>檔案 ps-aux.log</span>
+        </div>
+        <div class="node-footer">
+          <span>2 anchors · 0 留言</span>
+          <span>更新 2d ago</span>
+        </div>
+      </article>
+
+      <article class="node-card">
+        <div class="node-head">
+          <span class="node-type domain">domain</span>
+          <span class="node-title">Channel Plugin 架構</span>
+        </div>
+        <div class="node-summary">Claude Code / Hermes / OpenClaw — channel_api_key + botSecret，不吃 deviceSecret。</div>
+        <div class="anchor-list">
+          <span class="anchor-chip kanban"><span class="dot"></span>看板 deviceSecret audit</span>
+          <span class="anchor-chip chat"><span class="dot"></span>聊天 audit 回報</span>
+          <span class="anchor-chip file"><span class="dot"></span>檔案 eclaw_bridge.py</span>
+        </div>
+        <div class="node-footer">
+          <span>3 anchors · 0 留言</span>
+          <span>更新 3d ago</span>
+        </div>
+      </article>
+
+    </div>
+
+    <div class="soon-stripe">
+      <strong>下一步規劃</strong> · 筆記建立時自動 embed → 聚類為候選節點 → 手動確認後落到心智圖；
+      chat 每句話計算 embedding 座標，滑鼠 hover 節點時亮起同區聊天訊息；
+      kanban 子卡完成時自動 anchor 回上層 topic 節點。
+    </div>
+
+  </section>
+
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Static HTML mockup at `backend/public/assets/mockup-mindmap-notes.html` (Option C from direction survey).

- No portal nav entry, no API calls, no auth.
- Top tabs: 📄 文檔 / 🧠 心智 / 🔍 向量 / 📦 檔案.
- Mind-map tab shows node-card grid with anchor chips (kanban/chat/note/file) — the proposed UX for the notes+mindmap integration.
- "下一步規劃" stripe at bottom documents the data flow (notes → embed → cluster → nodes; chat embedding coords; kanban auto-anchor).

Purpose: give Hank a visual preview before committing to a full `notes.html` implementation. If he likes the direction, we replace `mockup-` with real and wire APIs.

## Test plan

- [x] File renders standalone (drag to browser)
- [x] Dark theme vars match portal (`--bg`, `--card-bg`, `--primary`)
- [x] Responsive grid (`auto-fill, minmax(300px, 1fr)`)
- [ ] Hank reviews direction and signals A/B/C

🤖 Generated with [Claude Code](https://claude.com/claude-code)