### PR TITLE
fix(invite): funnel table headers use tt() so they pick up active locale

### DIFF
--- a/backend/public/portal/invite.html
+++ b/backend/public/portal/invite.html
@@ -417,10 +417,10 @@
                     <table class="inv-funnel-table">
                         <thead>
                             <tr>
-                                <th data-i18n="invite_per_code_col_code">Code</th>
-                                <th class="num" data-i18n="invite_per_code_col_clicks">Clicks</th>
-                                <th class="num" data-i18n="invite_per_code_col_unique">Unique</th>
-                                <th data-i18n="invite_per_code_col_status">Status</th>
+                                <th>${tt('invite_per_code_col_code', 'Code')}</th>
+                                <th class="num">${tt('invite_per_code_col_clicks', 'Clicks')}</th>
+                                <th class="num">${tt('invite_per_code_col_unique', 'Unique')}</th>
+                                <th>${tt('invite_per_code_col_status', 'Status')}</th>
                             </tr>
                         </thead>
                         <tbody>${rows.map(r => `


### PR DESCRIPTION
## Summary
Follow-up to PR #2037. Live prod Playwright verification showed summary chips + status badges rendered correctly in zh-CN, but the four table headers (Code / Clicks / Unique / Status) stayed as the hardcoded English fallback. Root cause: \`data-i18n\` attributes are scanned at page load only — dynamically-injected innerHTML never gets a second pass. Switched to \`tt()\` at string-build time (same pattern the summary chips already use).

## Test plan
- [ ] Post-deploy Playwright on prod with zh-CN Accept-Language — all four headers translate.
- [ ] EN fallback still shows Code / Clicks / Unique / Status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)