### PR TITLE
feat(invite): Option B — per-code-once, many codes per device

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -4285,9 +4285,9 @@ app.post('/api/invite/redeem', async (req, res) => {
         if (used_by_device_id) return res.status(409).json({ success: false, error: 'Invite code already used' });
         if (owner_device_id === deviceId) return res.status(400).json({ success: false, error: 'Cannot redeem your own invite code' });
 
-        // Check if this device already redeemed any code
-        const alreadyRedeemed = await pg.query('SELECT 1 FROM invite_codes WHERE used_by_device_id = $1', [deviceId]);
-        if (alreadyRedeemed.rows.length > 0) return res.status(409).json({ success: false, error: 'You have already redeemed an invite code' });
+        // Note: Option B — a device can redeem multiple different codes (one per
+        // inviter). Per-code-once is enforced above via used_by_device_id. See
+        // docs/invite-redemption-policy.md.
 
         // Mark code as used
         await pg.query(

--- a/backend/tests/jest/invite-redemption-policy.test.js
+++ b/backend/tests/jest/invite-redemption-policy.test.js
@@ -1,0 +1,66 @@
+/**
+ * Source-grep guard for Option B (per-code-once, many codes per device).
+ *
+ * Spec: docs/specs/invite-redemption-policy.md
+ *
+ * We use grep-style assertions against the /api/invite/redeem handler
+ * because (a) it's schema-identical to the existing invite-tiers.test.js
+ * pattern in this repo, and (b) the regression risk here is specifically
+ * the reintroduction of the old per-device-lifetime check — a pattern
+ * easy to catch at the source level.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const INDEX_JS = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'index.js'),
+    'utf8'
+);
+
+describe('invite redemption policy — Option B (per-code-once)', () => {
+    test('per-code-once check remains at the top of the handler', () => {
+        // A code whose used_by_device_id is already set must 409.
+        expect(INDEX_JS).toMatch(
+            /if \(used_by_device_id\) return res\.status\(409\)\.json\(\{ success: false, error: 'Invite code already used' \}\)/
+        );
+    });
+
+    test('self-invite guard remains', () => {
+        expect(INDEX_JS).toMatch(
+            /if \(owner_device_id === deviceId\) return res\.status\(400\)/
+        );
+    });
+
+    test('per-device-lifetime guard is removed', () => {
+        // The prior "SELECT 1 FROM invite_codes WHERE used_by_device_id = $1"
+        // check inside the redeem handler is deleted; Option B allows one
+        // device to redeem many different codes (one per inviter).
+        //
+        // getInviteClickStatsForOwner still uses used_by_device_id = $1 for
+        // its own aggregate — that's fine. The regression we're guarding
+        // against is specifically a bare SELECT ... WHERE used_by_device_id
+        // with no JOIN to invite_clicks or other aggregate context, inside
+        // the redeem flow.
+        const redeemMatch = INDEX_JS.match(
+            /app\.post\('\/api\/invite\/redeem'[\s\S]*?\n\}\);/
+        );
+        expect(redeemMatch).toBeTruthy();
+        const redeemBody = redeemMatch[0];
+        expect(redeemBody).not.toMatch(
+            /SELECT 1 FROM invite_codes WHERE used_by_device_id/
+        );
+        expect(redeemBody).not.toMatch(/You have already redeemed an invite code/);
+    });
+
+    test('handler still credits invitee and inviter rewards', () => {
+        // Regression guard — removing the lifetime lock must not have taken
+        // the reward INSERTs with it.
+        const redeemMatch = INDEX_JS.match(
+            /app\.post\('\/api\/invite\/redeem'[\s\S]*?\n\}\);/
+        );
+        const redeemBody = redeemMatch[0];
+        expect(redeemBody).toMatch(/INSERT INTO invite_rewards/);
+        expect(redeemBody).toMatch(/bonus_messages/);
+    });
+});

--- a/docs/specs/invite-redemption-policy.md
+++ b/docs/specs/invite-redemption-policy.md
@@ -1,0 +1,48 @@
+# Invite Redemption Policy
+
+**Status:** Active (adopted 2026-04-24 with PR #2039)
+**Author:** Claude (entity #2), written at Hank's direction after confirming no prior spec existed.
+**Scope:** `/api/invite/redeem` (device-auth path in `backend/index.js`). Does NOT cover the user-account-based flow in `backend/invite.js`, which has its own `max_uses` / `use_count` semantics.
+
+## Summary (TL;DR)
+
+Each invite code is redeemable **once total** (by any single device). A device may redeem **many different codes** — one per inviter — but never the same code twice (trivially enforced, since a code becomes "used" after first redemption).
+
+This replaces the previous "one redemption per device, ever" rule which was not documented and never had a written rationale.
+
+## Rules
+
+| Rule | Enforced by |
+|---|---|
+| Code must exist | `SELECT ... WHERE code = $1` (404 if not found) |
+| Code must not already be consumed | `if (used_by_device_id) → 409 invite_code_already_used` |
+| Device cannot redeem its own code | `if (owner_device_id === deviceId) → 400 self_invite` |
+| Device may redeem any number of distinct codes from different inviters | Absence of prior per-device-lifetime guard |
+
+## Rewards (unchanged)
+
+- Invitee: +300 bonus messages
+- Inviter: +50 bonus messages per new redeemer, plus tier/milestone unlocks at 3 / 10 / 30 / 100 unique invitees.
+
+Because each code pays out at most once, the total reward pool is O(unique codes issued), not O(device × code). Reward inflation is bounded by how many codes exist system-wide, not by how many devices redeem.
+
+## Why Option B over "one-per-device lifetime"
+
+Weighed on 2026-04-24 after week-one viral loop audit showed redemption = 0 / 8 issued codes. The prior lifetime-lock had two structural problems:
+
+1. **It silently blocks second-degree network effects.** In a mutual-invite social app, the 2nd, 3rd, 4th friend who wants to invite an already-onboarded user is simply wasted. Their code gets shared, clicked, and rejected with `you_have_already_redeemed` — with no visible hint that it's a lifetime lock, not a code-level issue.
+2. **It doesn't actually gate fraud.** Anyone motivated to farm bonus messages will spin up new device IDs — the per-device lock doesn't meaningfully raise the attack cost. Per-code-once (already enforced separately) is the real anti-abuse bound: each code pays out at most once regardless of who redeems.
+
+The tradeoff accepted: a small mutual-invite ring of N real users could each redeem each other's code for a net of `N × (300 invitee + 50 inviter) − N` rewards. At N = 4, that's 1400 bonus messages for 4 real accounts — well within the noise floor of the current growth stage.
+
+## What to revisit
+
+- If reward fraud emerges at scale, tighten anti-abuse at the **account / identity** layer (shared phone, shared payment), not at the per-device-redemption layer.
+- If the redemption count per device needs a rate-limit for other reasons (e.g. onboarding flow confusion), add a time-window cap (e.g. "max 3 codes redeemed in 7 days"), not a lifetime cap.
+
+## References
+
+- Source: `backend/index.js` — `POST /api/invite/redeem` (~line 4269)
+- Prior behavior: `SELECT 1 FROM invite_codes WHERE used_by_device_id = $1` guard at old lines 4288-4290 (removed in PR #2039)
+- Related: `backend/invite.js` — parallel user-account flow using `invite_redemptions` table (not yet wired to an HTTP route)
+- Growth context: Week-of-2026-04-18 viral loop report (0/8 conversion) triggered this spec


### PR DESCRIPTION
## Summary
Adopts Option B per the newly-written redemption policy spec (`docs/specs/invite-redemption-policy.md`). A device can now redeem multiple different invite codes from different inviters. Per-code-once is retained (each code pays out at most once, regardless of who redeems).

**Why:** week-one viral loop audit showed 0/8 conversion; the prior per-device-lifetime lock was silently blocking second-degree network effects while not meaningfully gating fraud. Spec doc explains the tradeoff analysis in detail — this closes card_de0fcc2c after Hank delegated the A/B decision to me with "if no spec, write one and make the call."

## Change set
- `backend/index.js`: remove the 3-line `alreadyRedeemed` guard inside `POST /api/invite/redeem`; keep the per-code-once check (line 4285).
- `docs/specs/invite-redemption-policy.md`: new spec (was missing).
- `backend/tests/jest/invite-redemption-policy.test.js`: 4 source-grep regression guards.

## Test plan
- [ ] `npx jest backend/tests/jest/invite-redemption-policy.test.js` — 4/4 pass (verified locally).
- [ ] Post-deploy curl: device A redeems code X (created by device B) → 200; same device A then redeems code Y (created by device C) → 200 (this would have been 409 before).
- [ ] Same-code double-redeem still rejected: device A tries code X again → 409 `Invite code already used`.
- [ ] Self-invite still rejected → 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)