### PR TITLE
fix(socket): skip 401 redirect for /api/notifications/count

### DIFF
--- a/backend/public/portal/shared/socket.js
+++ b/backend/public/portal/shared/socket.js
@@ -96,7 +96,7 @@ function handleIncomingNotification(notif) {
 
 async function updateNotifBadge() {
     try {
-        const data = await apiCall('GET', '/api/notifications/count');
+        const data = await apiCall('GET', '/api/notifications/count', null, { skip401Redirect: true });
         unreadNotifCount = data.count || 0;
         renderNotifBadge(unreadNotifCount);
     } catch (e) {


### PR DESCRIPTION
## Summary
- Add `skip401Redirect: true` to `updateNotifBadge()`'s apiCall in `shared/socket.js:99`
- Companion to PR #2041 which fixed the same pattern in `nav.js` for `/api/wallet/balance`

## Why
Stale sessions (Playwright E2E, expired cookie) cause `updateNotifBadge` to fire before page-level re-auth, and `shared/api.js` redirects to `index.html` on 401 unless the call opts out.

Caught today while running kanban-nudge collapse E2E — `/settings.html` kept bouncing to `/dashboard.html` → `/index.html`. Same one-liner pattern as #2041.

## Test plan
- [ ] Deploy reaches prod (Railway auto)
- [ ] Playwright login → settings.html direct, no bounce
- [ ] No repeated 401 error spam in console
- [ ] Silent failure path still renders badge hidden (no UX regression)

## Related
- Card: card_b7667389c0d36d469fc62605
- Prior fix: #2041 (nav.js wallet-balance)

🤖 Generated with [Claude Code](https://claude.com/claude-code)