### PR TITLE
fix(telemetry): forward opts to wrapped apiCall (unbreaks skip401Redirect)

### DIFF
--- a/backend/public/shared/telemetry.js
+++ b/backend/public/shared/telemetry.js
@@ -70,11 +70,13 @@ const _telemetry = (() => {
 
     if (typeof apiCall === 'function') {
         const _origApiCall = apiCall;
-        // Replace global apiCall
-        window.apiCall = async function (method, path, body) {
+        // Replace global apiCall — forward opts (e.g. skip401Redirect) so the underlying
+        // 401 redirect guard still honors caller intent. Dropping the 4th arg here silently
+        // disabled skip401Redirect on every page and caused a settings→index→dashboard loop.
+        window.apiCall = async function (method, path, body, opts) {
             const start = Date.now();
             try {
-                const result = await _origApiCall(method, path, body);
+                const result = await _origApiCall(method, path, body, opts);
                 _push({
                     type: 'api_call',
                     action: `${method} ${path.split('?')[0]}`,


### PR DESCRIPTION
## Summary
- \`telemetry.js\` wraps \`apiCall\` to capture timing+errors but the wrapper's signature was \`(method, path, body)\` — the 4th \`opts\` arg was silently dropped.
- This defeated every caller that passed \`{ skip401Redirect: true }\`: nav.js wallet/balance, socket.js notifications/count, auth.js /me probe, etc.
- Net effect: PRs #2041 and #2042 were effectively inert on any page that included telemetry.js (i.e., all authed portal pages).
- Fix: add \`opts\` to wrapper signature + forward to \`_origApiCall\`. No behavior change for existing 3-arg callers.

## Repro (pre-fix)
1. Open \`/portal/settings.html\` on a trial device (no subscription → wallet/balance returns 401)
2. nav.js fires wallet/balance with \`skip401Redirect: true\` → telemetry drops opts → api.js default-redirects to index.html
3. index.html auto-logs-in → dashboard.html → wallet/balance 401 → index.html → loop

## Test plan
- [x] Direct-nav to settings.html stays on settings.html (no bounce)
- [x] Nav.js wallet/balance 401 no longer redirects (confirmed locally)
- [x] Existing 3-arg callers unaffected (same \`_origApiCall(method, path, body)\` call — \`opts=undefined\` defaults to \`{}\` in api.js)
- [ ] Railway auto-deploy + E2E confirm on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)