### PR TITLE
fix(env-vars): hydrate localStorage from server on page load

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -15814,40 +15814,60 @@ app.post('/api/device-vars', async (req, res) => {
     }
 });
 
-// GET /api/device-vars — bot reads vars (botSecret auth)
-// Auth: botSecret (entity must be bound to the device)
+// GET /api/device-vars — read vault. Dual-auth:
+//   - botSecret  → entity-side read, subject to the owner's lock flag
+//   - deviceSecret → owner-side read (read-only, bypasses lock because
+//                    the owner can toggle it anyway). This is the owner-side
+//                    "hydrate empty local cache from server" path used by the
+//                    env-vars.html page-load to avoid the 2026-04-24 incident
+//                    where a fresh Android WebView with empty localStorage
+//                    rendered blank while the web (with cached localStorage)
+//                    showed 17 keys.
 app.get('/api/device-vars', async (req, res) => {
-    const { deviceId, botSecret } = req.query;
-    if (!deviceId || !botSecret) {
-        return res.status(400).json({ success: false, error: 'deviceId and botSecret required' });
+    const { deviceId, botSecret, deviceSecret } = req.query;
+    if (!deviceId || (!botSecret && !deviceSecret)) {
+        return res.status(400).json({ success: false, error: 'deviceId and (botSecret or deviceSecret) required' });
     }
     const device = devices[deviceId];
     if (!device) {
         return res.status(404).json({ success: false, error: 'Device not found' });
     }
 
-    // Authenticate bot
-    const allEntities = Object.values(device.entities || {});
-    const botEntity = allEntities.find(e => e.isBound && safeEqual(e.botSecret, botSecret));
-    if (!botEntity) {
-        return res.status(403).json({ success: false, error: 'Invalid botSecret' });
+    let authMode; // 'owner' | 'bot'
+    if (deviceSecret) {
+        if (!safeEqual(device.deviceSecret, deviceSecret)) {
+            return res.status(403).json({ success: false, error: 'Invalid deviceSecret' });
+        }
+        authMode = 'owner';
+    } else {
+        const allEntities = Object.values(device.entities || {});
+        const botEntity = allEntities.find(e => e.isBound && safeEqual(e.botSecret, botSecret));
+        if (!botEntity) {
+            return res.status(403).json({ success: false, error: 'Invalid botSecret' });
+        }
+        authMode = 'bot';
     }
 
-    // Check if vars exist in DB
     const row = await db.getDeviceVars(deviceId);
     if (!row) {
-        return res.json({ success: true, vars: {}, hint: 'No vars saved — owner has not configured any variables' });
+        const base = { success: true, vars: {}, hint: 'No vars saved — owner has not configured any variables' };
+        if (authMode === 'owner') base.sources = {};
+        return res.json(base);
     }
 
-    // Check lock
-    if (row.is_locked) {
+    // Bots are blocked by the owner's lock flag; owner always bypasses.
+    if (authMode === 'bot' && row.is_locked) {
         return res.status(403).json({ success: false, error: 'locked', message: 'Variables are locked by owner' });
     }
 
-    // Decrypt and return
     try {
         const vars = decryptVars(row.encrypted_vars, row.iv, row.auth_tag);
-        return res.json({ success: true, vars });
+        const out = { success: true, vars };
+        if (authMode === 'owner') {
+            out.sources = row.var_sources || {};
+            out.locked = !!row.is_locked;
+        }
+        return res.json(out);
     } catch (err) {
         console.error(`[Vars] Decrypt failed for ${deviceId}:`, err.message);
         return res.status(500).json({ success: false, error: 'Decryption failed' });

--- a/backend/public/portal/env-vars.html
+++ b/backend/public/portal/env-vars.html
@@ -565,6 +565,30 @@
             }
         }
 
+        // Read-only server-side hydrate. Fixes the symmetric bug of the
+        // "empty-POST wipe": on a fresh WebView with empty localStorage, the
+        // page used to render blank forever because there was no GET path.
+        // Now we always GET first, populate localStorage from the server, and
+        // render. POST is still gated to avoid the original wipe footgun.
+        async function hydrateFromServer() {
+            if (!currentUser) return;
+            try {
+                const qs = new URLSearchParams({
+                    deviceId: currentUser.deviceId,
+                    deviceSecret: currentUser.deviceSecret
+                }).toString();
+                const result = await apiCall('GET', `/api/device-vars?${qs}`);
+                if (result && result.vars && typeof result.vars === 'object') {
+                    localStorage.setItem(varsKey(), JSON.stringify(result.vars));
+                }
+                if (typeof result?.locked === 'boolean') {
+                    localStorage.setItem(lockKey(), String(result.locked));
+                }
+            } catch (e) {
+                // Best-effort — offline or auth drift shouldn't crash the page.
+            }
+        }
+
         // ── Init ──
         window.addEventListener('DOMContentLoaded', async () => {
             renderNav('mission');
@@ -575,12 +599,17 @@
             document.getElementById('loadingState').style.display = 'none';
             document.getElementById('varsContent').style.display = '';
 
+            // Hydrate localStorage from server BEFORE first render so fresh
+            // WebView partitions (incident 2026-04-24: Android app empty, web
+            // 17 keys) don't render an empty list.
+            await hydrateFromServer();
             renderAll();
             renderBotHint();
-            // Page-load sync only when local has entries to push. An empty local
-            // here would otherwise POST {vars:{},source:'web'} and, in merge mode,
-            // silently drop every existing same-source key on the server.
-            // Incident 2026-04-24: Android WebView fresh storage partition → wipe.
+            // Page-load POST sync only when local has entries to push. An empty
+            // local here would otherwise POST {vars:{},source:'web'} and, in
+            // merge mode, silently drop every existing same-source key on the
+            // server. Server now also refuses empty merges without confirm, but
+            // we gate client-side too so the refused POST doesn't flood logs.
             if (Object.keys(loadLocalVars()).length > 0) {
                 syncVarsToServer();
             }


### PR DESCRIPTION
## Summary
- Fixes app-side 金鑰庫 tab rendering empty while web shows 17 keys (same account, same device, same server)
- Root cause: env-vars.html only ever read from localStorage; the page-load POST sync was gated off when local was empty (correct — an empty-vars POST would wipe the server per the 2026-04-24 incident); there was no GET path → fresh WebView = blank forever
- Fix: add owner-side GET (with \`deviceSecret\`) for read-only hydration, and call it on page load before first render

## Reported
2026-04-24 21:29 TW via fakechat: "我App打開任務頁面切到金鑰庫 還是空的 但是！我的web 打開任務頁面切到金鑰庫 卻是17個完好無缺 why??? 開卡深入調查"

Kanban: \`card_f0d95b8d067baca2eb07cb2b\`

## Test plan
- [x] \`node -c backend/index.js\` passes
- [ ] After Railway deploy:
  - curl GET with \`deviceSecret\` → 17 keys + sources + locked
  - curl GET with \`botSecret\` → 17 keys (unchanged, no sources)
  - curl GET with neither → 400
  - curl GET with bad deviceSecret → 403
  - Playwright: clear localStorage → reload env-vars.html → 17 keys render without user interaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)