### PR TITLE
fix(ios): move hardcoded ✓ prefix into i18n values (#1779)

### DIFF
--- a/ios-app/app/official-borrow.tsx
+++ b/ios-app/app/official-borrow.tsx
@@ -88,7 +88,7 @@ export default function OfficialBorrowScreen() {
     try {
       await officialBorrowApi.bindFree(entityId, selectedBotId ?? undefined);
       await loadStatus();
-      setSnack('✓ ' + t('official_borrow.webhook_success'));
+      setSnack(t('official_borrow.webhook_success'));
     } catch {
       setSnack(t('errors.server'));
     } finally {

--- a/ios-app/i18n/de.json
+++ b/ios-app/i18n/de.json
@@ -350,7 +350,7 @@
     "slots_available": "{{count}} Slots verfügbar",
     "sold_out": "Ausverkauft",
     "webhook_testing": "Verbindung wird getestet...",
-    "webhook_success": "Verbindung erfolgreich",
+    "webhook_success": "✓ Verbindung erfolgreich",
     "iap_coming_soon": "Apple IAP-Abonnement bald verfügbar",
     "select_bot": "Wählen Sie einen Bot:",
     "active_users": "Aktive Benutzer"

--- a/ios-app/i18n/en.json
+++ b/ios-app/i18n/en.json
@@ -350,7 +350,7 @@
     "slots_available": "{{count}} slots available",
     "sold_out": "Sold Out",
     "webhook_testing": "Testing connection...",
-    "webhook_success": "Connection successful",
+    "webhook_success": "✓ Connection successful",
     "iap_coming_soon": "Apple IAP subscription coming soon",
     "select_bot": "Select a bot:",
     "active_users": "Active users"

--- a/ios-app/i18n/es.json
+++ b/ios-app/i18n/es.json
@@ -350,7 +350,7 @@
     "slots_available": "{{count}} ranuras disponibles",
     "sold_out": "Agotado",
     "webhook_testing": "Probando conexión...",
-    "webhook_success": "Conexión exitosa",
+    "webhook_success": "✓ Conexión exitosa",
     "iap_coming_soon": "Suscripción Apple IAP próximamente",
     "select_bot": "Seleccione un bot:",
     "active_users": "Usuarios activos"

--- a/ios-app/i18n/fr.json
+++ b/ios-app/i18n/fr.json
@@ -350,7 +350,7 @@
     "slots_available": "{{count}} emplacements disponibles",
     "sold_out": "Épuisé",
     "webhook_testing": "Test de connexion...",
-    "webhook_success": "Connexion réussie",
+    "webhook_success": "✓ Connexion réussie",
     "iap_coming_soon": "Abonnement Apple IAP bientôt disponible",
     "select_bot": "Sélectionnez un bot:",
     "active_users": "Utilisateurs actifs"

--- a/ios-app/i18n/id.json
+++ b/ios-app/i18n/id.json
@@ -350,7 +350,7 @@
     "slots_available": "{{count}} slot tersedia",
     "sold_out": "Habis Terjual",
     "webhook_testing": "Menguji koneksi...",
-    "webhook_success": "Koneksi berhasil",
+    "webhook_success": "✓ Koneksi berhasil",
     "iap_coming_soon": "Apple IAP akan segera hadir",
     "select_bot": "Pilih bot:",
     "active_users": "Pengguna aktif"

--- a/ios-app/i18n/it.json
+++ b/ios-app/i18n/it.json
@@ -288,7 +288,7 @@
     "slots_available": "{{count}} slot disponibili",
     "sold_out": "Esaurito",
     "webhook_testing": "Test connessione...",
-    "webhook_success": "Connessione riuscita",
+    "webhook_success": "✓ Connessione riuscita",
     "iap_coming_soon": "Abbonamento Apple IAP prossimamente",
     "select_bot": "Seleziona un bot:",
     "active_users": "Utenti attivi"

--- a/ios-app/i18n/ja.json
+++ b/ios-app/i18n/ja.json
@@ -350,7 +350,7 @@
     "slots_available": "残り {{count}} スロット",
     "sold_out": "売り切れ",
     "webhook_testing": "接続テスト中...",
-    "webhook_success": "接続成功",
+    "webhook_success": "✓ 接続成功",
     "iap_coming_soon": "Apple IAP 決済は近日公開予定",
     "select_bot": "Botを選択：",
     "active_users": "利用中ユーザー数"

--- a/ios-app/i18n/ko.json
+++ b/ios-app/i18n/ko.json
@@ -350,7 +350,7 @@
     "slots_available": "슬롯 {{count}}개 남음",
     "sold_out": "매진",
     "webhook_testing": "연결 테스트 중...",
-    "webhook_success": "연결 성공",
+    "webhook_success": "✓ 연결 성공",
     "iap_coming_soon": "Apple IAP 결제 곧 출시 예정",
     "select_bot": "봇 선택:",
     "active_users": "사용 중인 사용자"

--- a/ios-app/i18n/nl.json
+++ b/ios-app/i18n/nl.json
@@ -288,7 +288,7 @@
     "slots_available": "{{count}} slots beschikbaar",
     "sold_out": "Uitverkocht",
     "webhook_testing": "Verbinding testen...",
-    "webhook_success": "Verbinding succesvol",
+    "webhook_success": "✓ Verbinding succesvol",
     "iap_coming_soon": "Apple IAP-abonnement binnenkort beschikbaar",
     "select_bot": "Selecteer een bot:",
     "active_users": "Actieve gebruikers"

--- a/ios-app/i18n/pl.json
+++ b/ios-app/i18n/pl.json
@@ -288,7 +288,7 @@
     "slots_available": "{{count}} gniazd dostępne",
     "sold_out": "Wyprzedane",
     "webhook_testing": "Testowanie połączenia...",
-    "webhook_success": "Połączenie udane",
+    "webhook_success": "✓ Połączenie udane",
     "iap_coming_soon": "Subskrypcja Apple IAP już wkrótce",
     "select_bot": "Wybierz bota:",
     "active_users": "Aktywni użytkownicy"

--- a/ios-app/i18n/pt.json
+++ b/ios-app/i18n/pt.json
@@ -288,7 +288,7 @@
     "slots_available": "{{count}} slots disponíveis",
     "sold_out": "Esgotado",
     "webhook_testing": "Testando conexão...",
-    "webhook_success": "Conexão bem-sucedida",
+    "webhook_success": "✓ Conexão bem-sucedida",
     "iap_coming_soon": "Assinatura Apple IAP em breve",
     "select_bot": "Selecione um bot:",
     "active_users": "Usuários ativos"

--- a/ios-app/i18n/ru.json
+++ b/ios-app/i18n/ru.json
@@ -288,7 +288,7 @@
     "slots_available": "Доступно слотов: {{count}}",
     "sold_out": "Распродано",
     "webhook_testing": "Проверка подключения...",
-    "webhook_success": "Подключение успешно",
+    "webhook_success": "✓ Подключение успешно",
     "iap_coming_soon": "Подписка Apple IAP скоро появится",
     "select_bot": "Выберите бота:",
     "active_users": "Активные пользователи"

--- a/ios-app/i18n/th.json
+++ b/ios-app/i18n/th.json
@@ -350,7 +350,7 @@
     "slots_available": "เหลือ {{count}} สล็อต",
     "sold_out": "หมดแล้ว",
     "webhook_testing": "กำลังทดสอบการเชื่อมต่อ...",
-    "webhook_success": "เชื่อมต่อสำเร็จ",
+    "webhook_success": "✓ เชื่อมต่อสำเร็จ",
     "iap_coming_soon": "Apple IAP จะเปิดให้บริการเร็วๆ นี้",
     "select_bot": "เลือกบอท:",
     "active_users": "ผู้ใช้งานอยู่"

--- a/ios-app/i18n/vi.json
+++ b/ios-app/i18n/vi.json
@@ -350,7 +350,7 @@
     "slots_available": "Còn {{count}} khe",
     "sold_out": "Hết hàng",
     "webhook_testing": "Đang kiểm tra kết nối...",
-    "webhook_success": "Kết nối thành công",
+    "webhook_success": "✓ Kết nối thành công",
     "iap_coming_soon": "Apple IAP sẽ sớm ra mắt",
     "select_bot": "Chọn bot:",
     "active_users": "Người dùng đang hoạt động"

--- a/ios-app/i18n/zh-CN.json
+++ b/ios-app/i18n/zh-CN.json
@@ -350,7 +350,7 @@
     "slots_available": "剩余 {{count}} 个槽位",
     "sold_out": "已售完",
     "webhook_testing": "测试连接中...",
-    "webhook_success": "连接成功",
+    "webhook_success": "✓ 连接成功",
     "iap_coming_soon": "Apple IAP 订阅即将推出",
     "select_bot": "选择机器人：",
     "active_users": "使用中人数"

--- a/ios-app/i18n/zh-TW.json
+++ b/ios-app/i18n/zh-TW.json
@@ -349,7 +349,7 @@
     "slots_available": "剩餘 {{count}} 個槽位",
     "sold_out": "已售完",
     "webhook_testing": "測試連線中...",
-    "webhook_success": "連線成功",
+    "webhook_success": "✓ 連線成功",
     "iap_coming_soon": "Apple IAP 訂閱即將推出",
     "select_bot": "選擇機器人：",
     "active_users": "使用中人數"


### PR DESCRIPTION
## Summary
- Removed `'✓ ' + t(...)` string concatenation in `app/official-borrow.tsx:91` — the ✓ is now part of each locale's `official_borrow.webhook_success` value, so translators can localize or replace the glyph.
- Applied the prefix to all 16 locales (de/en/es/fr/id/it/ja/ko/nl/pl/pt/ru/th/vi/zh-CN/zh-TW).

## Why not a `<CheckIcon />`
`Snackbar` message is rendered as a string in this screen; swapping to a React node would require reshaping the component. The i18n-owned prefix is the smallest fix that stops the code from hardcoding UX chrome.

## Test plan
- [x] `npx tsc --noEmit` shows no new errors in touched files.
- [ ] Manual: swap device locale to zh-CN / ja / ko and trigger bind-free success — snack should show `✓ 连接成功` / `✓ 接続成功` / `✓ 연결 성공`.

Closes #1779

🤖 Generated with [Claude Code](https://claude.com/claude-code)