### PR TITLE
fix(portal): keep Mission sub-tabs visible in split-view embed mode

### DIFF
--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -802,12 +802,12 @@
 
         // ── Init ──
         window.addEventListener('DOMContentLoaded', async () => {
-            // Detect embed mode (workspace split view)
+            // Detect embed mode (workspace split view). Keep sub-tabs visible so
+            // users can still navigate between Mission sub-pages (mind / kanban /
+            // env-vars / remote-control / publisher) from inside a split pane.
             const _isEmbed = new URLSearchParams(window.location.search).get('embed') === '1';
             if (_isEmbed) {
                 document.body.classList.add('embed-mode');
-                const subTabs = document.querySelector('.sub-tabs');
-                if (subTabs) subTabs.style.display = 'none';
             }
             renderNav('mission');
             if (typeof renderFooter === 'function') renderFooter();

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -1080,12 +1080,13 @@
 
         window.addEventListener('DOMContentLoaded', async () => {
             try {
-            // Detect embed mode (workspace split view)
+            // Detect embed mode (workspace split view). Keep sub-tabs visible so
+            // users can still reach env-vars / remote-control / publisher — those
+            // are sub-pages of Mission and are not reachable from the workspace
+            // top-level nav.
             const _isEmbed = new URLSearchParams(window.location.search).get('embed') === '1';
             if (_isEmbed) {
                 document.body.classList.add('embed-mode');
-                const subTabs = document.querySelector('.sub-tabs');
-                if (subTabs) subTabs.style.display = 'none';
             }
             renderNav('mission');
             if (typeof renderFooter === 'function') renderFooter();


### PR DESCRIPTION
## Summary
- Hank 2026-04-24: "web 在分割視窗時 任務頁面中的 tab 遺失了 用戶無法點擊 看板等 tab"
- `mission.html` and `kanban.html` were forcing `.sub-tabs { display: none }` on any URL with `?embed=1`. Since `workspace.html` (split view) renders each pane as an iframe with `?embed=1`, the 5-tab Mission sub-nav (Mind / Kanban / Env / Remote / Publisher) became unreachable.
- Workspace's top-level nav only knows about `mission` + `kanban`; `env-vars`, `screen-control`, `publisher` are only reachable through the sub-tabs.

## Fix
Drop the `display:none` override in both files' embed-mode branch. The `.sub-tabs` row already has `overflow-x: auto` + `flex-shrink: 0` on each tab, so at narrow widths it horizontally scrolls instead of disappearing.

## Repro
Before: open `/portal/mission.html?embed=1` at 600px width → no sub-tabs.
After: 5 tabs visible and horizontally scrollable when the pane gets narrow.

## Test plan
- [x] Playwright 600px `?embed=1` screenshot shows tabs (after merge + deploy)
- [ ] Verify in workspace.html split-view panes
- [ ] Verify on Android/iOS WebView (portal uses WebView for mission/kanban)

Closes `card_16ffeb45941492dfc7d4fc1c` (P1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)