### PR TITLE
fix(security): remove hardcoded gateway/test creds (#2022)

### DIFF
--- a/backend/scripts/setup_broadcast_webhook.js
+++ b/backend/scripts/setup_broadcast_webhook.js
@@ -5,17 +5,28 @@
  */
 
 const WebSocket = require('ws');
+try { require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') }); } catch { /* optional */ }
 
-const WSS_URL = 'wss://clawdbot-railway-template-production-e663.up.railway.app';
-const HTTPS_URL = 'https://clawdbot-railway-template-production-e663.up.railway.app/tools/invoke';
-const GATEWAY_TOKEN = '1a712b828ffc1b3d3a94978b7e9805be1591b175f3ee11637840e4437e49d232';
-const SETUP_USERNAME = 'admin';
-const SETUP_PASSWORD = 'asasas123';
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`[FATAL] Missing env var ${name}. Set it in backend/.env or export it before running this script.`);
+    process.exit(2);
+  }
+  return v;
+}
 
-const BROADCAST_DEVICE_ID = '2a0ad04d-9107-4250-b8be-ecd565983fb2';
-const BROADCAST_DEVICE_SECRET = '77c91d51-7677-4c1f-aece-fe26fd651d6d-cfff4f91-6883-4450-b17d-1ae1cf4085b4';
-const ENTITY_ID = 2; // bind entity 2 as the webhook entity
-const ECLAW_API = 'https://eclawbot.com';
+// Credentials must come from env — never commit secrets to the repo (issue #2022).
+const WSS_URL = process.env.GATEWAY_WSS_URL || 'wss://clawdbot-railway-template-production-e663.up.railway.app';
+const HTTPS_URL = process.env.GATEWAY_HTTP_URL || 'https://clawdbot-railway-template-production-e663.up.railway.app/tools/invoke';
+const GATEWAY_TOKEN = requireEnv('GATEWAY_TOKEN');
+const SETUP_USERNAME = process.env.SETUP_USERNAME || 'admin';
+const SETUP_PASSWORD = requireEnv('SETUP_PASSWORD');
+
+const BROADCAST_DEVICE_ID = requireEnv('BROADCAST_TEST_DEVICE_ID');
+const BROADCAST_DEVICE_SECRET = requireEnv('BROADCAST_TEST_DEVICE_SECRET');
+const ENTITY_ID = parseInt(process.env.BROADCAST_TEST_ENTITY_ID || '2', 10);
+const ECLAW_API = process.env.ECLAW_API_URL || 'https://eclawbot.com';
 
 async function wsConnect(url, username, password, gatewayToken, setupPassword) {
   return new Promise((resolve, reject) => {

--- a/backend/scripts/setup_test_bot.js
+++ b/backend/scripts/setup_test_bot.js
@@ -5,18 +5,28 @@
  */
 
 const WebSocket = require('ws');
+try { require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') }); } catch { /* optional */ }
 
-// Bot 1 credentials (provided by user)
-const WSS_URL = 'wss://clawdbot-railway-template-production-e663.up.railway.app';
-const HTTPS_URL = 'https://clawdbot-railway-template-production-e663.up.railway.app/tools/invoke';
-const GATEWAY_TOKEN = '1a712b828ffc1b3d3a94978b7e9805be1591b175f3ee11637840e4437e49d232';
-const SETUP_USERNAME = 'admin';
-const SETUP_PASSWORD = 'asasas123';
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`[FATAL] Missing env var ${name}. Set it in backend/.env or export it before running this script.`);
+    process.exit(2);
+  }
+  return v;
+}
+
+// Credentials must come from env — never commit secrets to the repo (issue #2022).
+const WSS_URL = process.env.GATEWAY_WSS_URL || 'wss://clawdbot-railway-template-production-e663.up.railway.app';
+const HTTPS_URL = process.env.GATEWAY_HTTP_URL || 'https://clawdbot-railway-template-production-e663.up.railway.app/tools/invoke';
+const GATEWAY_TOKEN = requireEnv('GATEWAY_TOKEN');
+const SETUP_USERNAME = process.env.SETUP_USERNAME || 'admin';
+const SETUP_PASSWORD = requireEnv('SETUP_PASSWORD');
 
 // New test device
 const NEW_DEVICE_ID = 'test-bot-' + Date.now();
 const NEW_DEVICE_SECRET = 'secret-' + Date.now();
-const ECLAW_API = 'https://eclawbot.com';
+const ECLAW_API = process.env.ECLAW_API_URL || 'https://eclawbot.com';
 
 async function wsConnect(url, username, password, gatewayToken, setupPassword) {
   return new Promise((resolve, reject) => {

--- a/backend/tests/jest/hardcoded-creds-regression.test.js
+++ b/backend/tests/jest/hardcoded-creds-regression.test.js
@@ -1,0 +1,91 @@
+/**
+ * Regression test for issue #2022:
+ *
+ * Test + setup scripts previously inlined GATEWAY_TOKEN, SETUP_PASSWORD,
+ * BROADCAST_TEST_DEVICE_ID, and BROADCAST_TEST_DEVICE_SECRET as literals.
+ * The tokens are the real production gateway credentials for the Railway
+ * template bot and the broadcast test device — committing them to the repo
+ * leaks valid long-lived secrets to anyone with read access to git history.
+ *
+ * This test statically scans the affected files and fails if the known
+ * leaked literals reappear, OR if the `process.env.<NAME>` read for each
+ * required secret disappears. It also verifies the scripts exit non-zero
+ * (refuse to proceed) when a required env var is missing.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const REPO_ROOT = path.join(__dirname, '..', '..');
+
+// Literal values that previously shipped in the repo. Any reappearance =
+// regression. Kept here (not in .env) so the grep remains self-contained.
+const LEAKED_LITERALS = [
+    '1a712b828ffc1b3d3a94978b7e9805be1591b175f3ee11637840e4437e49d232', // GATEWAY_TOKEN
+    'asasas123',                                                          // SETUP_PASSWORD
+    '2a0ad04d-9107-4250-b8be-ecd565983fb2',                               // BROADCAST_TEST_DEVICE_ID
+    '77c91d51-7677-4c1f-aece-fe26fd651d6d-cfff4f91-6883-4450-b17d-1ae1cf4085b4', // BROADCAST_TEST_DEVICE_SECRET
+];
+
+const FILES_UNDER_TEST = [
+    'tests/test-ws-auth.js',
+    'scripts/setup_broadcast_webhook.js',
+    'scripts/setup_test_bot.js',
+];
+
+describe('Issue #2022 — no hardcoded credentials in test/setup scripts', () => {
+    test.each(FILES_UNDER_TEST)('%s contains none of the previously leaked literals', (rel) => {
+        const body = fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+        for (const lit of LEAKED_LITERALS) {
+            expect(body).not.toContain(lit);
+        }
+    });
+
+    test.each(FILES_UNDER_TEST)('%s reads GATEWAY_TOKEN and SETUP_PASSWORD from process.env', (rel) => {
+        const body = fs.readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+        expect(body).toMatch(/process\.env\.GATEWAY_TOKEN|process\.env\[['"]GATEWAY_TOKEN['"]\]|requireEnv\(['"]GATEWAY_TOKEN['"]\)/);
+        expect(body).toMatch(/process\.env\.SETUP_PASSWORD|process\.env\[['"]SETUP_PASSWORD['"]\]|requireEnv\(['"]SETUP_PASSWORD['"]\)/);
+    });
+
+    test('setup_broadcast_webhook.js reads BROADCAST_TEST_DEVICE_ID/SECRET from process.env', () => {
+        const body = fs.readFileSync(
+            path.join(REPO_ROOT, 'scripts/setup_broadcast_webhook.js'), 'utf8');
+        expect(body).toMatch(/BROADCAST_TEST_DEVICE_ID/);
+        expect(body).toMatch(/BROADCAST_TEST_DEVICE_SECRET/);
+        // Must be read through env, not inlined.
+        expect(body).toMatch(/requireEnv\(['"]BROADCAST_TEST_DEVICE_ID['"]\)|process\.env\.BROADCAST_TEST_DEVICE_ID/);
+        expect(body).toMatch(/requireEnv\(['"]BROADCAST_TEST_DEVICE_SECRET['"]\)|process\.env\.BROADCAST_TEST_DEVICE_SECRET/);
+    });
+});
+
+describe('Issue #2022 — scripts refuse to run without required env vars', () => {
+    // Each script should exit non-zero with a clear error, not silently proceed
+    // with undefined credentials or fall back to the removed hardcoded ones.
+    const scripts = [
+        'tests/test-ws-auth.js',
+        'scripts/setup_broadcast_webhook.js',
+        'scripts/setup_test_bot.js',
+    ];
+
+    test.each(scripts)('%s exits non-zero when GATEWAY_TOKEN/SETUP_PASSWORD missing', (rel) => {
+        const cleanEnv = { ...process.env };
+        delete cleanEnv.GATEWAY_TOKEN;
+        delete cleanEnv.SETUP_PASSWORD;
+        delete cleanEnv.BROADCAST_TEST_DEVICE_ID;
+        delete cleanEnv.BROADCAST_TEST_DEVICE_SECRET;
+        // Point dotenv at a path that doesn't exist so it can't rehydrate env.
+        cleanEnv.DOTENV_CONFIG_PATH = '/tmp/nonexistent-' + Date.now() + '.env';
+
+        const result = spawnSync('node', [path.join(REPO_ROOT, rel)], {
+            env: cleanEnv,
+            cwd: REPO_ROOT,
+            timeout: 10000,
+            encoding: 'utf8',
+        });
+
+        expect(result.status).not.toBe(0);
+        const combined = (result.stdout || '') + (result.stderr || '');
+        expect(combined).toMatch(/Missing env var/i);
+    }, 15000);
+});

--- a/backend/tests/test-ws-auth.js
+++ b/backend/tests/test-ws-auth.js
@@ -9,11 +9,23 @@ global.WebSocket = WebSocket;
 // Since index.js doesn't export them, we test the WebSocket protocol directly
 
 const crypto = require('crypto');
-const GATEWAY_URL = 'wss://clawdbot-railway-template-production-e663.up.railway.app';
-const HTTP_URL = 'https://clawdbot-railway-template-production-e663.up.railway.app/tools/invoke';
-const GATEWAY_TOKEN = '1a712b828ffc1b3d3a94978b7e9805be1591b175f3ee11637840e4437e49d232';
-const SETUP_PASSWORD = 'asasas123';
-const SETUP_USERNAME = 'admin';
+try { require('dotenv').config({ path: require('path').join(__dirname, '..', '.env') }); } catch { /* optional */ }
+
+function requireEnv(name) {
+  const v = process.env[name];
+  if (!v) {
+    console.error(`[FATAL] Missing env var ${name}. Set it in backend/.env or export it before running this test.`);
+    process.exit(2);
+  }
+  return v;
+}
+
+// Credentials must come from env — never commit secrets to the repo (issue #2022).
+const GATEWAY_URL = process.env.GATEWAY_WSS_URL || 'wss://clawdbot-railway-template-production-e663.up.railway.app';
+const HTTP_URL = process.env.GATEWAY_HTTP_URL || 'https://clawdbot-railway-template-production-e663.up.railway.app/tools/invoke';
+const GATEWAY_TOKEN = requireEnv('GATEWAY_TOKEN');
+const SETUP_PASSWORD = requireEnv('SETUP_PASSWORD');
+const SETUP_USERNAME = process.env.SETUP_USERNAME || 'admin';
 
 async function testWsFlow() {
   console.log('=== Testing WebSocket Gateway Transport ===\n');


### PR DESCRIPTION
## Summary
- Three files previously inlined live production credentials as literals:
  - `backend/tests/test-ws-auth.js` — `GATEWAY_TOKEN`, `SETUP_PASSWORD`, `SETUP_USERNAME`
  - `backend/scripts/setup_broadcast_webhook.js` — same plus real `BROADCAST_TEST_DEVICE_ID` / `_SECRET`
  - `backend/scripts/setup_test_bot.js` — `GATEWAY_TOKEN`, `SETUP_PASSWORD`
- All creds now read via `process.env.*` (optional `dotenv` for local dev). A `requireEnv()` helper makes each script exit non-zero with a clear message if a required var is missing — nothing silently proceeds with undefined tokens.
- New regression suite `hardcoded-creds-regression.test.js` statically scans the three files for the previously leaked literals and spawns each one with a stripped env to confirm it refuses to start.

## Out of scope (tracked separately by operator)
- Credential rotation of `GATEWAY_TOKEN`, `SETUP_PASSWORD`, `BROADCAST_TEST_DEVICE_SECRET`.
- Scrubbing prior git history (`git filter-repo`).

## Test plan
- [x] `backend && npx jest --testPathPattern=hardcoded-creds` — 10/10 pass
- [x] `backend && npx jest` — 121 suites / 2152 tests pass, zero regressions
- [x] `backend && npm run lint` — 0 errors

Closes #2022

---
U29 sub-agent (dispatched by commander). No MCP elicitation triggered for this PR.