### PR TITLE
feat(security): global rate limiting on /api/* (#1948)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -739,6 +739,69 @@ if (process.env.NODE_ENV !== 'test') {
     });
 }
 
+// ============================================
+// GLOBAL RATE LIMITING (issue #1948)
+// ============================================
+// Three tiers:
+//   1. Global /api/* — 100 req/min per IP
+//   2. Auth endpoints — 10 req/min per IP (login/register brute-force)
+//   3. Message endpoints — 30 req/min per device (transform / client/speak)
+//
+// Skipped when NODE_ENV === 'test' to keep existing Jest suites running
+// (unset or set to '1' via ENABLE_RATE_LIMIT_IN_TEST to exercise the
+// regression test below).
+// /api/health and /api/version are always skipped so Railway health probes
+// and external monitors never trip the limiter.
+//
+// Per-route limiters already exist in bot-tools.js, growth.js, channel-api.js;
+// the limits below are additive and not intended to override them.
+const rateLimit = require('express-rate-limit');
+const rateLimitDisabled = () =>
+    process.env.NODE_ENV === 'test' && process.env.ENABLE_RATE_LIMIT_IN_TEST !== '1';
+
+const globalApiLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 100,
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: (req) => {
+        if (rateLimitDisabled()) return true;
+        // Health + version probes are unconditionally exempt.
+        if (req.path === '/health' || req.path === '/version') return true;
+        return false;
+    },
+    message: { success: false, error: 'Too many requests — try again shortly' },
+});
+app.use('/api', globalApiLimiter);
+
+const authLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 10,
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: () => rateLimitDisabled(),
+    message: { success: false, error: 'Too many auth attempts — try again in a minute' },
+});
+// Mount auth limiter BEFORE the auth router (line ~1917) so it fires first.
+app.use(['/api/auth/login', '/api/auth/register'], authLimiter);
+
+const messageLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 30,
+    standardHeaders: true,
+    legacyHeaders: false,
+    // Key by deviceId (attacker-controlled IP rotation shouldn't help) with
+    // IP fallback when body is absent (e.g. malformed request hits limiter
+    // before it reaches route validation).
+    keyGenerator: (req) => {
+        const deviceId = (req.body && req.body.deviceId) || null;
+        return deviceId ? `dev:${deviceId}` : `ip:${req.ip}`;
+    },
+    skip: () => rateLimitDisabled(),
+    message: { success: false, error: 'Too many messages — slow down' },
+});
+app.use(['/api/transform', '/api/client/speak'], messageLimiter);
+
 // Telemetry auto-capture middleware (pool linked lazily after chatPool init)
 let _telemetryPool = null;
 const telemetryPoolProxy = {

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -20,6 +20,7 @@
         "cron-parser": "^5.5.0",
         "dotenv": "^16.4.5",
         "express": "^4.21.2",
+        "express-rate-limit": "^8.4.0",
         "firebase-admin": "^13.6.1",
         "flickr-sdk": "^6.3.0",
         "google-auth-library": "^9.0.0",
@@ -5414,6 +5415,24 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.4.0.tgz",
+      "integrity": "sha512-gDK8yiqKxrGta+3WtON59arrrw6GLmadA1qoFgYXzdcch8fmKDID2XqO8itsi3f1wufXYPT51387dN6cvVBS3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -6470,6 +6489,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
+      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,6 +34,7 @@
     "cron-parser": "^5.5.0",
     "dotenv": "^16.4.5",
     "express": "^4.21.2",
+    "express-rate-limit": "^8.4.0",
     "firebase-admin": "^13.6.1",
     "flickr-sdk": "^6.3.0",
     "google-auth-library": "^9.0.0",

--- a/backend/tests/jest/rate-limit.test.js
+++ b/backend/tests/jest/rate-limit.test.js
@@ -1,0 +1,217 @@
+/**
+ * Regression test for issue #1948 — global rate limiting.
+ *
+ * Verifies the three tiers configured in backend/index.js:
+ *   1. Global /api/*      — 100 req/min per IP
+ *   2. Auth endpoints     — 10 req/min per IP  (login / register)
+ *   3. Message endpoints  — 30 req/min per deviceId
+ * And that /api/health is never rate-limited.
+ *
+ * Rate limiting is normally disabled under NODE_ENV='test'; this suite sets
+ * ENABLE_RATE_LIMIT_IN_TEST=1 BEFORE requiring index.js so the limiters engage.
+ */
+
+process.env.ENABLE_RATE_LIMIT_IN_TEST = '1';
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+        connect: jest.fn().mockResolvedValue({
+            query: jest.fn().mockResolvedValue({ rows: [] }),
+            release: jest.fn(),
+        }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+jest.mock('../../db', () => ({
+    initDatabase: jest.fn().mockResolvedValue(true),
+    saveDeviceData: jest.fn().mockResolvedValue(true),
+    saveAllDevices: jest.fn().mockResolvedValue(true),
+    loadAllDevices: jest.fn().mockResolvedValue({}),
+    deleteDevice: jest.fn().mockResolvedValue(true),
+    getStats: jest.fn().mockResolvedValue({}),
+    closeDatabase: jest.fn().mockResolvedValue(undefined),
+    saveOfficialBot: jest.fn().mockResolvedValue(true),
+    loadOfficialBots: jest.fn().mockResolvedValue({}),
+    deleteOfficialBot: jest.fn().mockResolvedValue(true),
+    saveOfficialBinding: jest.fn().mockResolvedValue(true),
+    removeOfficialBinding: jest.fn().mockResolvedValue(true),
+    getOfficialBinding: jest.fn().mockResolvedValue(null),
+    getDeviceOfficialBindings: jest.fn().mockResolvedValue([]),
+    updateSubscriptionVerified: jest.fn().mockResolvedValue(true),
+    loadAllOfficialBindings: jest.fn().mockResolvedValue([]),
+    getExpiredPersonalBindings: jest.fn().mockResolvedValue([]),
+    getPaidBorrowSlots: jest.fn().mockResolvedValue(0),
+    incrementPaidBorrowSlots: jest.fn().mockResolvedValue(true),
+    saveFeedback: jest.fn().mockResolvedValue({ id: 1 }),
+}));
+
+jest.mock('../../flickr', () => ({
+    initFlickr: jest.fn(),
+    uploadPhoto: jest.fn().mockResolvedValue(null),
+    isAvailable: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('../../scheduler', () => ({
+    init: jest.fn(),
+    createSchedule: jest.fn().mockResolvedValue({ id: 1 }),
+    updateSchedule: jest.fn().mockResolvedValue(true),
+    deleteSchedule: jest.fn().mockResolvedValue(true),
+    getSchedules: jest.fn().mockResolvedValue([]),
+    getSchedule: jest.fn().mockResolvedValue(null),
+    getSchedulesForBot: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../../device-telemetry', () => ({
+    initTelemetryTable: jest.fn().mockResolvedValue(undefined),
+    appendEntries: jest.fn().mockResolvedValue(undefined),
+    captureApiCall: jest.fn().mockResolvedValue(undefined),
+    getEntries: jest.fn().mockResolvedValue([]),
+    getSummary: jest.fn().mockResolvedValue({}),
+    clearEntries: jest.fn().mockResolvedValue(undefined),
+    createMiddleware: jest.fn().mockReturnValue((_req, _res, next) => next()),
+    sanitize: jest.fn().mockImplementation((v) => v),
+    MAX_BUFFER_BYTES: 1024 * 1024,
+    MAX_ENTRIES: 500,
+}));
+
+jest.mock('../../device-feedback', () => ({
+    initFeedbackTable: jest.fn().mockResolvedValue(undefined),
+    initFeedbackPhotosTable: jest.fn().mockResolvedValue(undefined),
+    captureLogSnapshot: jest.fn().mockResolvedValue([]),
+    captureDeviceState: jest.fn().mockResolvedValue({}),
+    autoTriage: jest.fn().mockResolvedValue('low'),
+    generateAiPrompt: jest.fn().mockReturnValue(''),
+    saveFeedback: jest.fn().mockResolvedValue({ id: 1 }),
+    getFeedbackList: jest.fn().mockResolvedValue([]),
+    getFeedbackById: jest.fn().mockResolvedValue(null),
+    updateFeedback: jest.fn().mockResolvedValue(true),
+    createGithubIssue: jest.fn().mockResolvedValue(null),
+    getPendingDebugFeedback: jest.fn().mockResolvedValue([]),
+    saveDebugResult: jest.fn().mockResolvedValue(true),
+    setMark: jest.fn().mockResolvedValue(undefined),
+    getMark: jest.fn().mockResolvedValue(null),
+    clearMark: jest.fn().mockResolvedValue(undefined),
+    LOG_WINDOW_MS: 60000,
+    MAX_PHOTOS_PER_FEEDBACK: 10,
+    MAX_PHOTO_SIZE: 5 * 1024 * 1024,
+    saveFeedbackPhoto: jest.fn().mockResolvedValue({ id: 1 }),
+    getFeedbackPhotos: jest.fn().mockResolvedValue([]),
+    getFeedbackPhoto: jest.fn().mockResolvedValue(null),
+    deleteFeedbackPhotos: jest.fn().mockResolvedValue(undefined),
+    cleanupResolvedFeedbackPhotos: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../gatekeeper', () => ({
+    detectMaliciousMessage: jest.fn().mockReturnValue({ isMalicious: false }),
+    detectAndMaskLeaks: jest.fn().mockImplementation((text) => text),
+    initGatekeeperTable: jest.fn().mockResolvedValue(undefined),
+    loadBlockedDevices: jest.fn().mockResolvedValue(undefined),
+    recordViolation: jest.fn().mockResolvedValue(undefined),
+    isDeviceBlocked: jest.fn().mockReturnValue(false),
+    getStrikeInfo: jest.fn().mockResolvedValue({ strikes: 0, blocked: false }),
+    getFreeBotTOS: jest.fn().mockResolvedValue(null),
+    hasAgreedToTOS: jest.fn().mockResolvedValue(false),
+    recordTOSAgreement: jest.fn().mockResolvedValue(undefined),
+    setServerLog: jest.fn(),
+    MAX_STRIKES: 3,
+    FREE_BOT_TOS_VERSION: '1.0',
+}));
+
+jest.mock('../../mission', () => {
+    const express = jest.requireActual('express');
+    return jest.fn().mockReturnValue({
+        router: express.Router(),
+        initMissionDatabase: jest.fn().mockResolvedValue(undefined),
+        setNotifyCallback: jest.fn(),
+        setPushToBot: jest.fn(),
+        setPushToChannelCallback: jest.fn(),
+    });
+});
+
+jest.mock('../../auth', () => {
+    const express = jest.requireActual('express');
+    const router = express.Router();
+    // Tiny stub: POST /login always returns 401 so rate-limit can count
+    // refusals without exercising real auth code.
+    router.post('/login', (_req, res) => res.status(401).json({ success: false, error: 'stub' }));
+    router.post('/register', (_req, res) => res.status(400).json({ success: false, error: 'stub' }));
+    return jest.fn().mockReturnValue({
+        router,
+        authMiddleware: (_req, _res, next) => next(),
+        softAuthMiddleware: (_req, _res, next) => next(),
+        adminMiddleware: (_req, _res, next) => next(),
+        initAuthDatabase: jest.fn().mockResolvedValue(undefined),
+        setOnEmailVerified: jest.fn(),
+        pool: { query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }) },
+    });
+});
+
+jest.mock('../../subscription', () => {
+    const express = jest.requireActual('express');
+    return jest.fn().mockReturnValue({
+        router: express.Router(),
+        loadPremiumStatus: jest.fn().mockResolvedValue(undefined),
+    });
+});
+
+const request = require('supertest');
+let app;
+
+beforeAll(() => {
+    app = require('../../index');
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise((resolve) => httpServer.close(resolve));
+    jest.resetModules();
+    delete process.env.ENABLE_RATE_LIMIT_IN_TEST;
+});
+
+describe('Issue #1948 — auth endpoint rate limit (10/min per IP)', () => {
+    it('11th POST /api/auth/login from same IP within the window returns 429', async () => {
+        // First 10 must be allowed (401 stub from mocked auth router).
+        for (let i = 0; i < 10; i++) {
+            const res = await request(app)
+                .post('/api/auth/login')
+                .send({ email: `user${i}@test`, password: 'x' });
+            expect([401, 400]).toContain(res.status);
+        }
+        // 11th hits the limiter.
+        const blocked = await request(app)
+            .post('/api/auth/login')
+            .send({ email: 'user11@test', password: 'x' });
+        expect(blocked.status).toBe(429);
+        expect(blocked.body.success).toBe(false);
+    }, 30000);
+});
+
+describe('Issue #1948 — /api/health is not rate-limited', () => {
+    it('accepts > 100 requests in rapid succession', async () => {
+        // Sanity: health probes from Railway + monitors should never be blocked.
+        for (let i = 0; i < 150; i++) {
+            const res = await request(app).get('/api/health');
+            expect(res.status).toBe(200);
+        }
+    }, 30000);
+});
+
+describe('Issue #1948 — message endpoint rate limit (30/min per device)', () => {
+    it('31st POST /api/transform with same deviceId returns 429', async () => {
+        const deviceId = 'rl-test-device-' + Date.now();
+        // Requests will fail auth/validation (no real binding), but the
+        // limiter counts BEFORE the route runs. 30 non-429 responses, then 429.
+        for (let i = 0; i < 30; i++) {
+            const res = await request(app)
+                .post('/api/transform')
+                .send({ deviceId, entityId: 0, botSecret: 'x', message: 'hi', state: 'IDLE' });
+            expect(res.status).not.toBe(429);
+        }
+        const blocked = await request(app)
+            .post('/api/transform')
+            .send({ deviceId, entityId: 0, botSecret: 'x', message: 'hi', state: 'IDLE' });
+        expect(blocked.status).toBe(429);
+    }, 30000);
+});


### PR DESCRIPTION
## Summary
Three-tier rate limit on `/api/*` using `express-rate-limit`:

| Scope | Limit | Key |
| --- | --- | --- |
| Global `/api/*` | 100 req/min | IP |
| `/api/auth/login`, `/api/auth/register` | 10 req/min | IP |
| `/api/transform`, `/api/client/speak` | 30 req/min | `deviceId` (IP fallback) |

- `/api/health` + `/api/version` always exempt so Railway + external monitors never 429.
- Per-route limiters already in `bot-tools.js`, `growth.js`, `channel-api.js` are **additive**, not replaced.
- `trust proxy: 1` is already set — `req.ip` reflects the real client behind Cloudflare → Railway.
- Limiters skipped under `NODE_ENV=test` to keep the 2000+ existing suites running; the new regression test opts in via `ENABLE_RATE_LIMIT_IN_TEST=1`.
- Added `express-rate-limit@^8.4.0` to `backend/package.json`.

## Test plan
- [x] `backend && npx jest --testPathPattern=rate-limit` — 3/3 pass:
  - 11th login from same IP → 429
  - `/api/health` ×150 rapid → all 200
  - 31st `/api/transform` with same `deviceId` → 429
- [x] `backend && npx jest` — 121 suites / 2145 tests pass, zero regressions
- [x] `backend && npm run lint` — 0 errors

Closes #1948

---
U29 sub-agent (dispatched by commander). No MCP elicitation triggered for this PR.