### PR TITLE
feat(transform): support multipart/form-data for single-request file delivery

### DIFF
--- a/backend/files.js
+++ b/backend/files.js
@@ -474,6 +474,85 @@ module.exports = function filesModule(devices) {
     return { router };
 };
 
+// Shared helper used by POST /api/transform multipart path so file delivery
+// can be done in a single request. Throws Error with .httpStatus and .code.
+module.exports.uploadBufferToR2 = async function uploadBufferToR2({
+    deviceId, entityId, buffer, originalname, mimetype, size, testQuotaBytes,
+}) {
+    if (!deviceId) {
+        const e = new Error('deviceId required'); e.httpStatus = 400; e.code = 'bad_request'; throw e;
+    }
+    if (!buffer || !size) {
+        const e = new Error('No file provided'); e.httpStatus = 400; e.code = 'no_file'; throw e;
+    }
+    if (size > MAX_FILE_SIZE) {
+        const e = new Error(`File exceeds ${MAX_FILE_SIZE / 1024 / 1024}MB limit`);
+        e.httpStatus = 413; e.code = 'too_large'; throw e;
+    }
+
+    const usageResult = await pool.query(
+        'SELECT COALESCE(SUM(size), 0) AS total FROM r2_files WHERE device_id = $1 AND expires_at > NOW()',
+        [deviceId]
+    );
+    const currentUsage = parseInt(usageResult.rows[0].total);
+    const effectiveQuota = testQuotaBytes != null ? testQuotaBytes : QUOTA_SOFT_BYTES;
+
+    if (currentUsage + size > effectiveQuota) {
+        const oldestFiles = await pool.query(
+            `SELECT file_id, filename, size, created_at
+             FROM r2_files WHERE device_id = $1 AND expires_at > NOW()
+             ORDER BY created_at ASC LIMIT 5`,
+            [deviceId]
+        );
+        const e = new Error(`Storage quota exceeded (${Math.round(currentUsage / 1024 / 1024)}MB / ${Math.round(effectiveQuota / 1024 / 1024)}MB). Please remove some old files first.`);
+        e.httpStatus = 507;
+        e.code = 'quota_exceeded';
+        e.details = {
+            currentUsageMB: Math.round(currentUsage / 1024 / 1024),
+            quotaMB: Math.round(effectiveQuota / 1024 / 1024),
+            oldestFiles: oldestFiles.rows.map(f => ({
+                fileId: f.file_id,
+                filename: f.filename,
+                sizeMB: Math.round(f.size / 1024 / 1024 * 10) / 10,
+                createdAt: f.created_at,
+            })),
+        };
+        throw e;
+    }
+
+    const fileId = crypto.randomUUID();
+    const safeName = originalname.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 200);
+    const r2Key = `files/${deviceId}/${fileId}/${safeName}`;
+    const expiresAt = new Date(Date.now() + FILE_TTL_DAYS * 24 * 60 * 60 * 1000);
+
+    await r2.send(new PutObjectCommand({
+        Bucket: BUCKET,
+        Key: r2Key,
+        Body: buffer,
+        ContentType: mimetype,
+        ContentLength: size,
+        Metadata: {
+            deviceId,
+            entityId: entityId != null ? String(entityId) : '',
+            originalName: encodeURIComponent(originalname),
+        },
+    }));
+
+    await pool.query(
+        `INSERT INTO r2_files (file_id, device_id, entity_id, filename, size, mime_type, r2_key, expires_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+        [fileId, deviceId, entityId, originalname, size, mimetype, r2Key, expiresAt]
+    );
+
+    return {
+        fileId,
+        filename: originalname,
+        size,
+        mimeType: mimetype,
+        expiresAt: expiresAt.toISOString(),
+    };
+};
+
 // Export cleanup function for daily cron
 module.exports.cleanupExpiredFiles = async function () {
     const expired = await pool.query(

--- a/backend/index.js
+++ b/backend/index.js
@@ -5720,8 +5720,43 @@ async function deliverToEntity(opts) {
  * If both speakTo and broadcast are provided, broadcast takes priority + warning.
  *
  * REQUIRES botSecret for authentication!
+ *
+ * Supports both `application/json` and `multipart/form-data`. In the multipart
+ * form, a `file` field is uploaded to R2 inline and prepended to `attachments`
+ * so bots can deliver a file in one request instead of upload-then-attach.
+ * JSON fields (speakTo, attachments, card, parts, broadcast) are accepted as
+ * JSON-encoded strings when using multipart.
  */
-app.post('/api/transform', async (req, res) => {
+const transformUpload = multer({
+    storage: multer.memoryStorage(),
+    limits: { fileSize: 20 * 1024 * 1024 }, // 20MB — matches /api/files/upload
+});
+function transformMaybeMultipart(req, res, next) {
+    const ct = String(req.headers['content-type'] || '').toLowerCase();
+    if (ct.startsWith('multipart/form-data')) {
+        return transformUpload.single('file')(req, res, next);
+    }
+    return next();
+}
+app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
+    // Multipart sends text fields as strings; re-parse the JSON-shaped ones
+    // and coerce scalar types so downstream logic stays uniform with JSON mode.
+    if (req.file || String(req.headers['content-type'] || '').toLowerCase().startsWith('multipart/form-data')) {
+        for (const field of ['speakTo', 'parts', 'attachments', 'card']) {
+            const v = req.body[field];
+            if (typeof v === 'string' && v.length > 0) {
+                try { req.body[field] = JSON.parse(v); } catch (_) { /* leave as-is */ }
+            }
+        }
+        if (typeof req.body.entityId === 'string' && req.body.entityId !== '') {
+            const n = Number(req.body.entityId);
+            if (!Number.isNaN(n)) req.body.entityId = n;
+        }
+        if (typeof req.body.broadcast === 'string') {
+            req.body.broadcast = req.body.broadcast === 'true' || req.body.broadcast === '1';
+        }
+    }
+
     let { deviceId, entityId, botSecret, name, character, state, message, parts, targetDeviceId, speakTo, broadcast, card, attachments } = req.body;
 
     if (!deviceId) {
@@ -5819,6 +5854,50 @@ app.post('/api/transform', async (req, res) => {
     }
 
     const entity = device.entities[eId];
+
+    // Multipart: upload attached file to R2 and prepend to attachments so the
+    // bot can deliver a file in a single transform call. Uses shared helper
+    // from files.js; maps its structured errors back to HTTP status.
+    if (req.file) {
+        try {
+            // multer decodes filenames as latin-1; re-decode as UTF-8 to avoid
+            // mojibake for non-ASCII (CJK / accented) filenames.
+            const rawName = req.file.originalname || 'upload.bin';
+            const originalname = /[-ÿ]/.test(rawName)
+                ? Buffer.from(rawName, 'latin1').toString('utf8')
+                : rawName;
+
+            const uploaded = await require('./files').uploadBufferToR2({
+                deviceId,
+                entityId: eId,
+                buffer: req.file.buffer,
+                originalname,
+                mimetype: req.file.mimetype || 'application/octet-stream',
+                size: req.file.size,
+            });
+
+            const inline = {
+                fileId: uploaded.fileId,
+                filename: uploaded.filename,
+                size: uploaded.size,
+                mimeType: uploaded.mimeType,
+            };
+            validatedAttachments = validatedAttachments
+                ? [inline, ...validatedAttachments].slice(0, 10)
+                : [inline];
+        } catch (e) {
+            const status = e.httpStatus || 500;
+            const body = {
+                success: false,
+                error: e.code || 'upload_failed',
+                message: e.message || 'Upload failed',
+            };
+            if (e.code === 'quota_exceeded' && e.details) {
+                Object.assign(body, e.details);
+            }
+            return res.status(status).json(body);
+        }
+    }
 
     // Validate and update name if provided
     if (name !== undefined) {

--- a/backend/tests/jest/transform-multipart.test.js
+++ b/backend/tests/jest/transform-multipart.test.js
@@ -1,0 +1,160 @@
+/**
+ * POST /api/transform — multipart/form-data support (Issue #1781).
+ *
+ * Validates:
+ *   1. JSON requests still succeed unchanged (backward compat).
+ *   2. multipart requests upload the attached file and prepend it to attachments.
+ *   3. multipart requests parse JSON-string fields (speakTo, card, attachments).
+ *   4. Upload failures surface as transform-level errors.
+ */
+
+require('./helpers/mock-setup');
+
+// Mock the shared upload helper used by POST /api/transform multipart path.
+// The actual R2 client is never invoked in tests.
+jest.mock('../../files', () => {
+    const mock = (devices) => ({
+        router: require('express').Router(),
+    });
+    mock.uploadBufferToR2 = jest.fn(async ({ originalname, size, mimetype }) => ({
+        fileId: 'mock-file-id-123',
+        filename: originalname,
+        size,
+        mimeType: mimetype,
+        expiresAt: new Date(Date.now() + 15 * 24 * 60 * 60 * 1000).toISOString(),
+    }));
+    mock.cleanupExpiredFiles = jest.fn().mockResolvedValue(0);
+    return mock;
+});
+
+const request = require('supertest');
+let app;
+
+const post = (path) => request(app).post(path).set('Host', 'localhost');
+
+async function bindEntity(deviceId, deviceSecret, entityId = 0) {
+    if (entityId > 0) {
+        await post('/api/device/add-entity').send({ deviceId, deviceSecret });
+    }
+    const regRes = await post('/api/device/register').send({ deviceId, deviceSecret, entityId });
+    const code = regRes.body.bindingCode;
+    if (!code) return undefined;
+    const bindRes = await post('/api/bind').send({ code });
+    return bindRes.body.botSecret;
+}
+
+beforeAll(() => {
+    app = require('../../index');
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+    jest.resetModules();
+});
+
+describe('POST /api/transform — multipart', () => {
+    const deviceId = 'transform-multipart-test';
+    const deviceSecret = `secret-${deviceId}`;
+    let botSecret;
+
+    beforeAll(async () => {
+        botSecret = await bindEntity(deviceId, deviceSecret, 0);
+    });
+
+    beforeEach(() => {
+        const { uploadBufferToR2 } = require('../../files');
+        uploadBufferToR2.mockClear();
+    });
+
+    it('JSON path still works (backward compatible)', async () => {
+        const res = await post('/api/transform')
+            .send({ deviceId, entityId: 0, botSecret, message: 'plain json', state: 'IDLE' });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+
+        const { uploadBufferToR2 } = require('../../files');
+        expect(uploadBufferToR2).not.toHaveBeenCalled();
+    });
+
+    it('multipart: uploads file and auto-fills attachments[0]', async () => {
+        const fileBuffer = Buffer.from('hello world', 'utf8');
+        const res = await post('/api/transform')
+            .field('deviceId', deviceId)
+            .field('entityId', '0')
+            .field('botSecret', botSecret)
+            .field('message', 'here is your file')
+            .field('state', 'IDLE')
+            .attach('file', fileBuffer, { filename: 'report.txt', contentType: 'text/plain' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+
+        const { uploadBufferToR2 } = require('../../files');
+        expect(uploadBufferToR2).toHaveBeenCalledTimes(1);
+        const uploadArgs = uploadBufferToR2.mock.calls[0][0];
+        expect(uploadArgs.deviceId).toBe(deviceId);
+        expect(uploadArgs.entityId).toBe(0);
+        expect(uploadArgs.originalname).toBe('report.txt');
+        expect(uploadArgs.mimetype).toBe('text/plain');
+        expect(uploadArgs.size).toBe(fileBuffer.length);
+    });
+
+    it('multipart: parses JSON-string speakTo/card/attachments fields', async () => {
+        const fileBuffer = Buffer.from('x');
+        const res = await post('/api/transform')
+            .field('deviceId', deviceId)
+            .field('entityId', '0')
+            .field('botSecret', botSecret)
+            .field('message', 'with rich card')
+            .field('state', 'IDLE')
+            .field('card', JSON.stringify({
+                ask_id: 'test-ask-multipart',
+                buttons: [{ id: 'ok', label: 'OK', style: 'primary' }],
+            }))
+            .field('attachments', JSON.stringify([
+                { fileId: 'existing-file', filename: 'old.pdf', size: 100, mimeType: 'application/pdf' },
+            ]))
+            .attach('file', fileBuffer, { filename: 'note.md', contentType: 'text/markdown' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+
+    it('multipart: returns 507 when uploadBufferToR2 throws quota_exceeded', async () => {
+        const { uploadBufferToR2 } = require('../../files');
+        uploadBufferToR2.mockImplementationOnce(async () => {
+            const err = new Error('Storage quota exceeded (500MB / 500MB). Please remove some old files first.');
+            err.httpStatus = 507;
+            err.code = 'quota_exceeded';
+            err.details = { currentUsageMB: 500, quotaMB: 500, oldestFiles: [] };
+            throw err;
+        });
+
+        const fileBuffer = Buffer.from('x');
+        const res = await post('/api/transform')
+            .field('deviceId', deviceId)
+            .field('entityId', '0')
+            .field('botSecret', botSecret)
+            .field('message', 'quota test')
+            .field('state', 'IDLE')
+            .attach('file', fileBuffer, { filename: 'big.bin', contentType: 'application/octet-stream' });
+
+        expect(res.status).toBe(507);
+        expect(res.body.success).toBe(false);
+        expect(res.body.error).toBe('quota_exceeded');
+        expect(res.body.currentUsageMB).toBe(500);
+    });
+
+    it('multipart: missing botSecret returns 400', async () => {
+        const fileBuffer = Buffer.from('x');
+        const res = await post('/api/transform')
+            .field('deviceId', deviceId)
+            .field('entityId', '0')
+            .field('message', 'no auth')
+            .attach('file', fileBuffer, { filename: 'x.txt', contentType: 'text/plain' });
+
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- `POST /api/transform` now accepts `multipart/form-data`. A `file` field is uploaded to R2 via shared `uploadBufferToR2()` helper and auto-prepended to the `attachments` array.
- Bots can deliver a file in one request instead of upload-then-attach, reducing round-trips.
- Multipart string-shaped JSON fields (`speakTo`, `card`, `attachments`, `parts`) are parsed transparently; scalar coercion for `entityId`/`broadcast`.
- Backward compatible: JSON requests unchanged. The middleware only engages when `Content-Type` starts with `multipart/form-data`.
- Quota errors from the R2 helper map to HTTP 507 with `currentUsageMB` / `quotaMB` / `oldestFiles` diagnostics.

## Test plan
- [x] `npx jest --testPathPattern=transform-multipart` — 5/5 new tests pass
- [x] `npx jest --testPathPattern=transform` — all 56 transform-related tests pass (backward compat)
- [x] `npm run lint` — no new warnings/errors
- [ ] Manual multipart upload via curl against live deploy after merge

Closes #1781