### PR TITLE
fix(ios): swallow uncaught JS errors in production, not dev (#1766)

### DIFF
--- a/backend/tests/jest/ios-prod-error-overlay.test.js
+++ b/backend/tests/jest/ios-prod-error-overlay.test.js
@@ -1,0 +1,48 @@
+const fs = require('fs');
+const path = require('path');
+
+// Regression for Issue #1766 — production RN console error overlay.
+// The iOS app (Expo Router) has no jest runner, so this static scan
+// lives in the backend jest suite. It guards three invariants in
+// ios-app/app/_layout.tsx:
+//   1. LogBox.ignoreAllLogs() is called at module top-level.
+//   2. A global handler is installed via ErrorUtils.setGlobalHandler.
+//   3. The handler is gated behind `if (!__DEV__)` so dev keeps the
+//      native red-box but production swallows uncaught errors.
+
+describe('iOS production error overlay suppression (#1766)', () => {
+    const layoutPath = path.join(
+        __dirname,
+        '..',
+        '..',
+        '..',
+        'ios-app',
+        'app',
+        '_layout.tsx'
+    );
+    let source = '';
+
+    beforeAll(() => {
+        source = fs.readFileSync(layoutPath, 'utf8');
+    });
+
+    test('_layout.tsx exists', () => {
+        expect(fs.existsSync(layoutPath)).toBe(true);
+    });
+
+    test('LogBox.ignoreAllLogs is called', () => {
+        expect(source).toMatch(/LogBox\.ignoreAllLogs\s*\(\s*\)/);
+    });
+
+    test('global error handler is installed', () => {
+        expect(source).toMatch(/ErrorUtils/);
+        expect(source).toMatch(/setGlobalHandler/);
+    });
+
+    test('global handler is gated behind !__DEV__', () => {
+        // The `if (!__DEV__) { ... setGlobalHandler(...) }` block must
+        // appear in that order so the dev experience isn't altered.
+        const match = source.match(/if\s*\(\s*!\s*__DEV__\s*\)\s*{([\s\S]*?)setGlobalHandler/);
+        expect(match).not.toBeNull();
+    });
+});

--- a/ios-app/app/_layout.tsx
+++ b/ios-app/app/_layout.tsx
@@ -5,6 +5,20 @@ import { useColorScheme, View, ActivityIndicator, LogBox } from 'react-native';
 
 // Silence dev warnings overlay so it doesn't cover the tab bar.
 LogBox.ignoreAllLogs();
+
+// In production, swallow uncaught JS errors so the full-screen red-box
+// doesn't land on real users. Dev keeps the native handler so regressions
+// stay visible. Replace the console.log with a telemetry call once the
+// ios telemetry pipe lands — tracked in #1766.
+if (!__DEV__) {
+  const errorUtils = (global as unknown as { ErrorUtils?: { setGlobalHandler: (fn: (e: Error, isFatal?: boolean) => void) => void } }).ErrorUtils;
+  if (errorUtils?.setGlobalHandler) {
+    errorUtils.setGlobalHandler((e, isFatal) => {
+      // eslint-disable-next-line no-console
+      console.log('[prod-err]', isFatal ? 'fatal' : 'nonfatal', e?.message, e?.stack);
+    });
+  }
+}
 import { StatusBar } from 'expo-status-bar';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import '../i18n';


### PR DESCRIPTION
## Summary
- `app/_layout.tsx` now installs a global `ErrorUtils.setGlobalHandler` **only when `!__DEV__`**. In production the handler logs via `console.log('[prod-err]', ...)` instead of letting RN's red-box overlay block the UI. Dev keeps the native handler so regressions stay visible.
- `LogBox.ignoreAllLogs()` is kept (already present) so yellow-box warnings never cover the tab bar in either env.
- Static jest guard `backend/tests/jest/ios-prod-error-overlay.test.js` scans `_layout.tsx` for LogBox + `ErrorUtils.setGlobalHandler` gated behind `!__DEV__`. (iOS app has no jest runner of its own; keeping the check in backend jest keeps CI enforcement.)

## Not changed
- No `metro.config.js` / `app.config.ts` present in the repo — Expo's default metro pipeline already strips dev-only code paths behind `__DEV__` in production bundles, so adding a config purely for that would be cargo-cult. If we need custom minifier flags later, that's a follow-up.

## Test plan
- [x] `npx jest tests/jest/ios-prod-error-overlay.test.js` passes (4/4).
- [x] `npx tsc --noEmit` shows no new errors in `_layout.tsx`.
- [ ] Manual: build a TestFlight production bundle, force-throw in a handler, confirm no red-box and the `[prod-err]` log appears in Xcode console.

## Follow-up
Replace `console.log('[prod-err]', ...)` with a telemetry call once the iOS telemetry pipe lands — tagged in the code comment referencing #1766.

Closes #1766

🤖 Generated with [Claude Code](https://claude.com/claude-code)