### PR TITLE
fix(chat): strip raw R2 presigned URLs from message text + shorten TTL

### DIFF
--- a/backend/files.js
+++ b/backend/files.js
@@ -5,7 +5,7 @@
  *
  * Endpoints:
  * POST /upload              - Upload a file (multipart/form-data)
- * GET  /:fileId             - Get signed download URL (15-day TTL, 1h signed URL)
+ * GET  /:fileId             - Get signed download URL (15-day TTL, 10-min signed URL)
  * DELETE /:fileId           - Delete a file
  * GET  /list                - List files for a device (with usage stats)
  *
@@ -42,7 +42,7 @@ const BUCKET = process.env.R2_BUCKET_NAME || 'eclaw-files';
 const FILE_TTL_DAYS = 15;
 const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20MB per file
 const QUOTA_SOFT_BYTES = 500 * 1024 * 1024; // 500MB per device (soft cap)
-const SIGNED_URL_EXPIRES = 3600; // 1 hour
+const SIGNED_URL_EXPIRES = 600; // 10 minutes — shorter window reduces leak blast radius if URL ends up in a log or screenshot before chat.html's R2LinkRender strips it.
 const MAX_EDIT_SIZE = 512 * 1024; // 512KB cap for online text editing
 
 // File extensions allowed for online text editing (Monaco). Server is the

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -1497,6 +1497,39 @@
             display: block; cursor: pointer; object-fit: cover;
         }
 
+        /* ── Inline R2 attachment card (URL-stripped replacement) ── */
+        .r2-attachment-card {
+            display: inline-flex; align-items: center; gap: 6px;
+            padding: 4px 8px; margin: 2px 0;
+            border-radius: 10px;
+            background: rgba(255,255,255,0.08);
+            border: 1px solid rgba(255,255,255,0.12);
+            font-size: 13px; max-width: 100%;
+            vertical-align: middle;
+        }
+        .chat-msg.received .r2-attachment-card {
+            background: var(--card); border-color: var(--card-border);
+        }
+        .r2-attachment-card .r2-attachment-icon { font-size: 16px; flex-shrink: 0; cursor: pointer; }
+        .r2-attachment-card .r2-attachment-name {
+            font-weight: 500; word-break: break-all; cursor: pointer;
+            overflow: hidden; text-overflow: ellipsis; max-width: 220px;
+            white-space: nowrap;
+        }
+        .r2-attachment-card .r2-attachment-btn {
+            flex-shrink: 0; font-size: 12px; padding: 3px 8px;
+            border-radius: 6px; background: var(--primary); color: #fff;
+            border: none; cursor: pointer; white-space: nowrap;
+        }
+        .r2-attachment-card.r2-inert { cursor: default; opacity: 0.85; }
+        .r2-legacy-chip {
+            display: inline-flex; align-items: center; gap: 4px;
+            padding: 2px 6px; border-radius: 8px; font-size: 11px;
+            background: rgba(255,255,255,0.05);
+            color: var(--text-muted);
+        }
+        .r2-legacy-chip .r2-legacy-link { color: var(--text-muted); text-decoration: underline; }
+
         /* ── Scroll Navigator (side drag) ── */
         .scroll-nav {
             position: absolute;
@@ -2468,6 +2501,7 @@
     <script src="shared/note-link-render.js"></script>
     <script src="shared/entity-link-render.js"></script>
     <script src="shared/his-link-render.js"></script>
+    <script src="shared/r2-link-render.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
     <script src="/socket.io/socket.io.js"></script>
@@ -3849,12 +3883,20 @@
                     if (window.HisLinkRender) {
                         textHtml = HisLinkRender.renderHisLinks(textHtml);
                     }
+                    // Strip raw R2 presigned URLs — replace with attachment cards so
+                    // that access-key IDs and 10-minute bearer tokens never reach the DOM.
+                    if (window.R2LinkRender) {
+                        textHtml = R2LinkRender.replaceR2Links(textHtml);
+                    }
                 }
-                const firstUrlIsImage = firstUrl && isImageUrl(firstUrl);
+                // Suppress inline image + link preview when firstUrl is an R2 presigned URL;
+                // the attachment card rendered above is the safe surface for that file.
+                const firstUrlIsR2 = firstUrl && window.R2LinkRender && R2LinkRender.isR2Url(firstUrl);
+                const firstUrlIsImage = firstUrl && !firstUrlIsR2 && isImageUrl(firstUrl);
                 const inlineImgHtml = firstUrlIsImage
                     ? `<img class="chat-inline-img" src="${escapeHtml(firstUrl)}" alt="" loading="lazy" onclick="openLightbox('${escapeHtml(firstUrl)}')" onerror="this.style.display='none'">`
                     : '';
-                const previewId = firstUrl && !firstUrlIsImage ? `lp-${msg.id || Math.random().toString(36).slice(2)}` : '';
+                const previewId = firstUrl && !firstUrlIsImage && !firstUrlIsR2 ? `lp-${msg.id || Math.random().toString(36).slice(2)}` : '';
 
                 // Read receipt for sent messages
                 let receipt = '';

--- a/backend/public/portal/share-chat.html
+++ b/backend/public/portal/share-chat.html
@@ -94,6 +94,13 @@
 
         .empty-msg { text-align: center; color: var(--text-muted); padding: 40px 20px; font-size: 14px; }
 
+        /* ── Inert R2 attachment card (share-chat is read-only) ── */
+        .r2-attachment-card { display: inline-flex; align-items: center; gap: 6px; padding: 4px 8px; margin: 2px 0; border-radius: 10px; background: rgba(255,255,255,0.08); border: 1px solid rgba(255,255,255,0.12); font-size: 13px; vertical-align: middle; opacity: 0.85; }
+        .r2-attachment-card .r2-attachment-icon { font-size: 16px; flex-shrink: 0; }
+        .r2-attachment-card .r2-attachment-name { font-weight: 500; word-break: break-all; overflow: hidden; text-overflow: ellipsis; max-width: 220px; white-space: nowrap; }
+        .r2-legacy-chip { display: inline-flex; align-items: center; gap: 4px; padding: 2px 6px; border-radius: 8px; font-size: 11px; background: rgba(255,255,255,0.05); color: var(--text-muted); }
+        .r2-legacy-chip .r2-legacy-link { color: var(--text-muted); text-decoration: underline; }
+
         /* ── Debug panel ── */
         .debug-panel { position: fixed; bottom: 0; left: 0; right: 0; max-height: 200px; overflow-y: auto; background: #111827; color: #10b981; font-family: monospace; font-size: 11px; padding: 8px; z-index: 200; border-top: 2px solid #10b981; display: none; }
         .debug-panel.visible { display: block; }
@@ -348,6 +355,7 @@
     <button class="debug-toggle" id="debugToggle" onclick="toggleDebug()">DEBUG</button>
 
     <script src="/portal/shared/entity-utils.js"></script>
+    <script src="/portal/shared/r2-link-render.js"></script>
     <script src="/shared/i18n.js"></script>
     <script src="/shared/telemetry.js"></script>
     <script>
@@ -719,6 +727,11 @@
                 textSpan.className = 'md-content';
             } else {
                 textSpan.innerHTML = renderMessageContent(escapeHtml(cleanText));
+            }
+            // Share-chat is public — strip R2 presigned URLs so screenshots/forwards
+            // never leak access-key IDs. Inert mode renders filename only, no buttons.
+            if (window.R2LinkRender) {
+                textSpan.innerHTML = R2LinkRender.replaceR2Links(textSpan.innerHTML, { interactive: false });
             }
             div.appendChild(textSpan);
         }

--- a/backend/public/shared/r2-link-render.js
+++ b/backend/public/shared/r2-link-render.js
@@ -1,0 +1,136 @@
+/**
+ * R2 Link Render — strip raw Cloudflare R2 presigned URLs out of chat message
+ * HTML and replace them with safer attachment cards.
+ *
+ * Why: R2 presigned URLs are bearer tokens valid for the full expiry window
+ * (default 10 min). If one ends up in a chat bubble as plain text or as a
+ * clickable link, anyone who can see the message (screenshot, forward,
+ * cross-device sync) can exfiltrate the file for the rest of that window —
+ * and the access key ID embedded in the query string is visible too.
+ *
+ * This helper is applied AFTER markdown/linkify post-processing and it:
+ *   1. Finds <a href="…r2.cloudflarestorage.com…">…</a> and replaces them
+ *      with an attachment card (📎 filename + 📥 download button) whose
+ *      click handlers re-fetch a fresh signed URL from /api/files/:id.
+ *   2. Finds <img src="…r2.cloudflarestorage.com…"> (rare — e.g. markdown
+ *      `![alt](r2url)` from a bot) and collapses them to the same card so
+ *      the src attribute stops leaking the URL.
+ *   3. Legacy / unparseable R2 URLs (no fileId in path) fall back to a
+ *      muted "legacy file" chip that still opens the raw link — otherwise
+ *      historical messages would become un-openable.
+ *
+ * The expected path shape from backend/files.js line 199 is
+ *   /{bucket}/files/{deviceId}/{fileId}/{filename}
+ * where fileId is a uuidv4 — we validate that before rendering the card
+ * so random R2 URLs that don't match our upload layout fall through.
+ *
+ * Consumers must provide previewAttachment(fileId) and
+ * downloadAttachment(fileId, filename) globals (chat.html does).
+ * For read-only surfaces (share-chat.html), pass { interactive: false }
+ * and the card renders as an inert chip — no click handlers.
+ */
+(function (global) {
+    'use strict';
+
+    const R2_HOST_RE = /\.r2\.cloudflarestorage\.com$/i;
+    const FILE_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+    function isR2Url(url) {
+        if (!url || typeof url !== 'string') return false;
+        try {
+            const u = new URL(url);
+            return R2_HOST_RE.test(u.hostname);
+        } catch (_) { return false; }
+    }
+
+    function parseR2Url(url) {
+        if (!isR2Url(url)) return null;
+        try {
+            const u = new URL(url);
+            const parts = u.pathname.split('/').filter(Boolean);
+            const idx = parts.indexOf('files');
+            if (idx < 0 || parts.length < idx + 4) return null;
+            const fileId = parts[idx + 2];
+            if (!FILE_ID_RE.test(fileId)) return null;
+            let filename;
+            try {
+                filename = decodeURIComponent(parts.slice(idx + 3).join('/'));
+            } catch (_) {
+                filename = parts.slice(idx + 3).join('/');
+            }
+            return { fileId, filename: filename || 'file' };
+        } catch (_) { return null; }
+    }
+
+    function escapeAttr(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+    }
+
+    function labelFor(key, fallback) {
+        if (global.i18n && typeof global.i18n.t === 'function') {
+            const v = global.i18n.t(key);
+            if (v && v !== key) return v;
+        }
+        return fallback;
+    }
+
+    function buildCard(parsed, opts) {
+        const fileId = escapeAttr(parsed.fileId);
+        const filename = escapeAttr(parsed.filename);
+        const interactive = !opts || opts.interactive !== false;
+        const dlLabel = escapeAttr(labelFor('chat_file_download', 'Download'));
+
+        if (!interactive) {
+            return '<span class="r2-attachment-card r2-inert" title="' + filename + '">' +
+                   '<span class="r2-attachment-icon">📎</span>' +
+                   '<span class="r2-attachment-name">' + filename + '</span>' +
+                   '</span>';
+        }
+
+        return '<span class="r2-attachment-card" data-file-id="' + fileId + '">' +
+               '<span class="r2-attachment-icon" onclick="if(typeof previewAttachment===\'function\')previewAttachment(\'' + fileId + '\')">📎</span>' +
+               '<span class="r2-attachment-name" onclick="if(typeof previewAttachment===\'function\')previewAttachment(\'' + fileId + '\')">' + filename + '</span>' +
+               '<button type="button" class="r2-attachment-btn" onclick="event.preventDefault();event.stopPropagation();if(typeof downloadAttachment===\'function\')downloadAttachment(\'' + fileId + '\',\'' + filename + '\')">📥 ' + dlLabel + '</button>' +
+               '</span>';
+    }
+
+    function buildLegacyChip(url) {
+        const esc = escapeAttr(url);
+        const label = escapeAttr(labelFor('chat_legacy_file', 'legacy file'));
+        return '<span class="r2-legacy-chip" title="Legacy file link">📎 ' +
+               '<a href="' + esc + '" target="_blank" rel="noopener" class="r2-legacy-link">' + label + '</a>' +
+               '</span>';
+    }
+
+    function replaceR2Links(html, opts) {
+        if (!html || typeof html !== 'string') return html;
+        let out = html;
+
+        // <a href="…r2…">INNER</a>  → card (or legacy chip if unparseable)
+        const anchorRe = /<a\b[^>]*?href=["']([^"']*r2\.cloudflarestorage\.com[^"']*)["'][^>]*>[\s\S]*?<\/a>/gi;
+        out = out.replace(anchorRe, (match, href) => {
+            const parsed = parseR2Url(href);
+            return parsed ? buildCard(parsed, opts) : buildLegacyChip(href);
+        });
+
+        // <img src="…r2…" …>  → card (or legacy chip)
+        const imgRe = /<img\b[^>]*?src=["']([^"']*r2\.cloudflarestorage\.com[^"']*)["'][^>]*?>/gi;
+        out = out.replace(imgRe, (match, src) => {
+            const parsed = parseR2Url(src);
+            return parsed ? buildCard(parsed, opts) : buildLegacyChip(src);
+        });
+
+        return out;
+    }
+
+    const api = { isR2Url, parseR2Url, replaceR2Links };
+    global.R2LinkRender = api;
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/backend/tests/jest/r2-link-render.test.js
+++ b/backend/tests/jest/r2-link-render.test.js
@@ -1,0 +1,130 @@
+/**
+ * R2 Link Render — unit tests for the client-side helper that strips raw
+ * Cloudflare R2 presigned URLs out of chat message HTML.
+ *
+ * Covers the security contract (card_5c03553f1a0c56b9672dc7e6):
+ *  - raw R2 anchors and img tags are replaced by attachment cards
+ *  - access-key IDs and bearer tokens never appear in the output HTML
+ *  - legacy/unparseable R2 URLs fall back to a muted chip (still usable)
+ *  - non-R2 URLs pass through untouched
+ */
+
+const path = require('path');
+
+describe('R2LinkRender', () => {
+    let R2LinkRender;
+
+    beforeAll(() => {
+        // Module assigns to globalThis (no window in Node), so read it back.
+        require(path.join(__dirname, '..', '..', 'public', 'shared', 'r2-link-render.js'));
+        R2LinkRender = global.R2LinkRender;
+    });
+
+    const SAMPLE_URL = 'https://abc123.r2.cloudflarestorage.com/eclaw-files/files/dev-1/11111111-2222-3333-4444-555555555555/report.pdf' +
+        '?X-Amz-Algorithm=AWS4-HMAC-SHA256' +
+        '&X-Amz-Credential=SECRET_ACCESS_KEY_ID%2F20260424%2Fauto%2Fs3%2Faws4_request' +
+        '&X-Amz-Signature=deadbeef';
+
+    describe('isR2Url', () => {
+        test('matches r2.cloudflarestorage.com host', () => {
+            expect(R2LinkRender.isR2Url(SAMPLE_URL)).toBe(true);
+        });
+        test('rejects non-R2 hosts', () => {
+            expect(R2LinkRender.isR2Url('https://example.com/file.pdf')).toBe(false);
+            expect(R2LinkRender.isR2Url('https://r2.cloudflarestorage.com.evil.com/x')).toBe(false);
+        });
+        test('rejects malformed input', () => {
+            expect(R2LinkRender.isR2Url(null)).toBe(false);
+            expect(R2LinkRender.isR2Url('')).toBe(false);
+            expect(R2LinkRender.isR2Url('not a url')).toBe(false);
+        });
+    });
+
+    describe('parseR2Url', () => {
+        test('extracts fileId and filename', () => {
+            const parsed = R2LinkRender.parseR2Url(SAMPLE_URL);
+            expect(parsed).toEqual({
+                fileId: '11111111-2222-3333-4444-555555555555',
+                filename: 'report.pdf',
+            });
+        });
+        test('decodes URL-encoded filenames', () => {
+            const url = 'https://x.r2.cloudflarestorage.com/b/files/d/11111111-2222-3333-4444-555555555555/%E6%A8%99%E6%9C%AC.pdf?sig=1';
+            const parsed = R2LinkRender.parseR2Url(url);
+            expect(parsed.filename).toBe('標本.pdf');
+        });
+        test('rejects paths without fileId uuid', () => {
+            const url = 'https://x.r2.cloudflarestorage.com/b/random/path/foo.pdf?sig=1';
+            expect(R2LinkRender.parseR2Url(url)).toBe(null);
+        });
+        test('rejects non-r2 hosts', () => {
+            expect(R2LinkRender.parseR2Url('https://example.com/files/d/11111111-2222-3333-4444-555555555555/f.pdf')).toBe(null);
+        });
+    });
+
+    describe('replaceR2Links — security contract', () => {
+        test('strips the entire query string (access key + signature) from anchor output', () => {
+            const input = `<a href="${SAMPLE_URL}" target="_blank">${SAMPLE_URL}</a>`;
+            const output = R2LinkRender.replaceR2Links(input);
+            expect(output).not.toMatch(/X-Amz-Signature/);
+            expect(output).not.toMatch(/X-Amz-Credential/);
+            expect(output).not.toMatch(/SECRET_ACCESS_KEY_ID/);
+            expect(output).not.toMatch(/r2\.cloudflarestorage\.com/);
+        });
+
+        test('replaces anchor with attachment card carrying fileId + filename', () => {
+            const input = `<p>See this: <a href="${SAMPLE_URL}">file</a></p>`;
+            const output = R2LinkRender.replaceR2Links(input);
+            expect(output).toContain('r2-attachment-card');
+            expect(output).toContain('data-file-id="11111111-2222-3333-4444-555555555555"');
+            expect(output).toContain('report.pdf');
+        });
+
+        test('replaces img tag too (markdown image from bot)', () => {
+            const imgUrl = SAMPLE_URL.replace('report.pdf', 'photo.jpg');
+            const input = `<img src="${imgUrl}" alt="photo">`;
+            const output = R2LinkRender.replaceR2Links(input);
+            expect(output).toContain('r2-attachment-card');
+            expect(output).toContain('photo.jpg');
+            expect(output).not.toMatch(/cloudflarestorage\.com/);
+            expect(output).not.toContain('<img');
+        });
+
+        test('inert mode renders card without click handlers (share-chat surface)', () => {
+            const input = `<a href="${SAMPLE_URL}">x</a>`;
+            const output = R2LinkRender.replaceR2Links(input, { interactive: false });
+            expect(output).toContain('r2-inert');
+            expect(output).not.toContain('previewAttachment');
+            expect(output).not.toContain('downloadAttachment');
+            expect(output).not.toMatch(/cloudflarestorage\.com/);
+        });
+
+        test('legacy R2 URL (no fileId) falls back to muted chip — still openable', () => {
+            const legacy = 'https://x.r2.cloudflarestorage.com/bucket/random/foo.pdf?sig=abc';
+            const input = `<a href="${legacy}">file</a>`;
+            const output = R2LinkRender.replaceR2Links(input);
+            expect(output).toContain('r2-legacy-chip');
+            expect(output).toContain(legacy.replace(/&/g, '&amp;'));
+        });
+
+        test('non-R2 links pass through untouched', () => {
+            const input = '<a href="https://example.com/report.pdf">report</a> and <p>text</p>';
+            const output = R2LinkRender.replaceR2Links(input);
+            expect(output).toBe(input);
+        });
+
+        test('handles null / empty / non-string input gracefully', () => {
+            expect(R2LinkRender.replaceR2Links('')).toBe('');
+            expect(R2LinkRender.replaceR2Links(null)).toBe(null);
+            expect(R2LinkRender.replaceR2Links(undefined)).toBe(undefined);
+        });
+
+        test('card onclick handlers do not leak the original URL', () => {
+            const input = `<a href="${SAMPLE_URL}">file</a>`;
+            const output = R2LinkRender.replaceR2Links(input);
+            expect(output).toContain('previewAttachment');
+            expect(output).toContain('downloadAttachment');
+            expect(output).not.toMatch(/X-Amz/);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Defense-in-depth against R2 presigned URL leakage in chat message bubbles.

- New shared client module `backend/public/shared/r2-link-render.js` parses any `<a href=...r2...>` or `<img src=...r2...>` in rendered chat HTML and replaces it with a safe attachment card (📎 filename + 📥 Download). Download fetches a fresh short-lived signed URL via `/api/files/:id` on demand — the original URL never reaches the DOM.
- Wired into `chat.html` (post-processor after Mention / Note / Entity / His renderers) and `share-chat.html` (inert mode, no auth-less download for the public surface).
- `SIGNED_URL_EXPIRES` 3600s → 600s. Smaller blast radius if a URL still slips through logs/cross-device sync.
- Legacy R2 URLs with no parseable fileId fall back to a muted "legacy file" chip so old messages stay openable (does not completely hide them — matches task requirement).
- 15 Jest unit tests (`tests/jest/r2-link-render.test.js`) pin the security contract: access-key ID, X-Amz-Signature, X-Amz-Credential, and the hostname are all absent from the output HTML.

Complements merged #2045 which covers structured file-message UI; this PR covers the "message text happens to contain an R2 URL" case (bot markdown, user paste, etc.).

## Playwright E2E screenshots

Desktop (1280×800):
| Before | After |
|--------|-------|
| ![before-desktop](https://eclaw-files.a9ea84990ec49fdfd03e23197f2c6857.r2.cloudflarestorage.com/files/2a0ad04d-9107-4250-b8be-ecd565983fb2/230e1e5b-3942-4d88-bae8-30da59c798fb/before-desktop.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=57f969c0ce692bdd5d45e71bd7b5bec2%2F20260424%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260424T151006Z&X-Amz-Expires=3600&X-Amz-Signature=724431208b14154c9b553235ac96cc680ef1305fa70c4aeda333739c43dc0d88&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject) | ![after-desktop](https://eclaw-files.a9ea84990ec49fdfd03e23197f2c6857.r2.cloudflarestorage.com/files/2a0ad04d-9107-4250-b8be-ecd565983fb2/e9ad34ab-7481-4f16-8775-8b16bbfa9ccd/after-desktop.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=57f969c0ce692bdd5d45e71bd7b5bec2%2F20260424%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260424T151007Z&X-Amz-Expires=3600&X-Amz-Signature=c0d71377ae65ffeaf715562c0d90c7320242a377e5695e4b60063f46e2ec07e9&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject) |

Mobile (375×812 iPhone viewport):
| Before | After |
|--------|-------|
| ![before-mobile](https://eclaw-files.a9ea84990ec49fdfd03e23197f2c6857.r2.cloudflarestorage.com/files/2a0ad04d-9107-4250-b8be-ecd565983fb2/1eae5656-1919-4fd1-8860-bd55851d2ee3/before-mobile.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=57f969c0ce692bdd5d45e71bd7b5bec2%2F20260424%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260424T151007Z&X-Amz-Expires=3600&X-Amz-Signature=55d86c2b8c82f0ab87760a2be11494e1ca73a01d859f379e727a3a1a069515c7&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject) | ![after-mobile](https://eclaw-files.a9ea84990ec49fdfd03e23197f2c6857.r2.cloudflarestorage.com/files/2a0ad04d-9107-4250-b8be-ecd565983fb2/deed483f-d115-4b19-a32d-213f1f05695d/after-mobile.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=57f969c0ce692bdd5d45e71bd7b5bec2%2F20260424%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260424T151008Z&X-Amz-Expires=3600&X-Amz-Signature=9a4cf56b1349c9353be71b3d5379cd828a12c0c913df7622e879ed6ebee323af&X-Amz-SignedHeaders=host&x-amz-checksum-mode=ENABLED&x-id=GetObject) |

Fresh signed URLs (TTL 1h); screenshots also attached to `card_5c03553f1a0c56b9672dc7e6`.

## Test plan

- [x] `npx jest tests/jest/r2-link-render.test.js` — 15/15 passing
- [x] `npx jest tests/jest/i18n-syntax.test.js` — 11/11 passing (no i18n changes on my files)
- [x] Playwright desktop + mobile before/after screenshots — bearer token + access-key ID absent from DOM in AFTER shots
- [ ] Reviewer verifies firstUrl-image path no longer eagerly fetches R2 presigned URLs
- [ ] Reviewer verifies share-chat renders inert card (no click handler, no fetch) on public surface
- [ ] Post-merge: confirm Railway deploy & spot-check production chat for a bot message that embeds an R2 URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)
