### PR TITLE
fix(ios): icon-only bottom nav so CJK labels stop squeezing (#1769)

### DIFF
--- a/backend/tests/jest/ios-bottom-nav.test.js
+++ b/backend/tests/jest/ios-bottom-nav.test.js
@@ -1,0 +1,52 @@
+const fs = require('fs');
+const path = require('path');
+
+// Regression for Issue #1769 — bottom nav cramped in CJK locales.
+// The static guard below proves three invariants in
+// ios-app/app/(tabs)/_layout.tsx:
+//   1. A custom TabLabel component exists.
+//   2. The label returns null when !focused (so inactive tabs are icon-only,
+//      giving the 5 icons enough breathing room on iPhone 17 Pro width).
+//   3. The active label uses numberOfLines=1 + adjustsFontSizeToFit so the
+//      3-character CJK tab name ("任務", "名片夾") never truncates.
+
+describe('iOS bottom nav icon-only layout (#1769)', () => {
+    const layoutPath = path.join(
+        __dirname,
+        '..',
+        '..',
+        '..',
+        'ios-app',
+        'app',
+        '(tabs)',
+        '_layout.tsx'
+    );
+    let source = '';
+
+    beforeAll(() => {
+        source = fs.readFileSync(layoutPath, 'utf8');
+    });
+
+    test('(tabs)/_layout.tsx exists', () => {
+        expect(fs.existsSync(layoutPath)).toBe(true);
+    });
+
+    test('TabLabel component is declared', () => {
+        expect(source).toMatch(/function\s+TabLabel\s*\(/);
+    });
+
+    test('TabLabel returns null when !focused', () => {
+        // Matches `if (!focused) return null;` (whitespace-flexible).
+        expect(source).toMatch(/if\s*\(\s*!\s*focused\s*\)\s*return\s+null/);
+    });
+
+    test('active label has numberOfLines=1 and adjustsFontSizeToFit', () => {
+        expect(source).toMatch(/numberOfLines=\{1\}/);
+        expect(source).toMatch(/adjustsFontSizeToFit/);
+    });
+
+    test('all 5 tabs wire tabBarLabel through TabLabel', () => {
+        const matches = source.match(/tabBarLabel:\s*\(\s*\{[^}]*\}\s*\)\s*=>\s*\(\s*<TabLabel/g) || [];
+        expect(matches.length).toBe(5);
+    });
+});

--- a/ios-app/app/(tabs)/_layout.tsx
+++ b/ios-app/app/(tabs)/_layout.tsx
@@ -2,6 +2,7 @@ import { Tabs } from 'expo-router';
 import { useTranslation } from 'react-i18next';
 import { useTheme } from 'react-native-paper';
 import { MaterialCommunityIcons } from '@expo/vector-icons';
+import { Text } from 'react-native';
 
 type IconName = keyof typeof MaterialCommunityIcons.glyphMap;
 
@@ -13,6 +14,32 @@ function TabIcon({ name, focused }: { name: IconName; focused: boolean }) {
       size={24}
       color={focused ? theme.colors.primary : theme.colors.onSurfaceVariant}
     />
+  );
+}
+
+// Only the focused tab shows its label, so on narrow devices the 5 icons
+// always fit even in ja / ko where labels are wider. Inactive tabs render
+// nothing below the icon; the active label shrinks to a single line via
+// adjustsFontSizeToFit so 3-char CJK labels never truncate.
+function TabLabel({
+  color,
+  focused,
+  children,
+}: {
+  color: string;
+  focused: boolean;
+  children: React.ReactNode;
+}) {
+  if (!focused) return null;
+  return (
+    <Text
+      numberOfLines={1}
+      adjustsFontSizeToFit
+      minimumFontScale={0.7}
+      style={{ color, fontSize: 10, textAlign: 'center' }}
+    >
+      {children}
+    </Text>
   );
 }
 
@@ -39,6 +66,7 @@ export default function TabLayout() {
           fontSize: 10,
           marginTop: 0,
         },
+        tabBarLabelPosition: 'below-icon',
         headerStyle: { backgroundColor: theme.colors.surface },
         headerTintColor: theme.colors.onSurface,
         headerShown: true,
@@ -52,6 +80,9 @@ export default function TabLayout() {
           tabBarIcon: ({ focused }) => (
             <TabIcon name={focused ? 'home' : 'home-outline'} focused={focused} />
           ),
+          tabBarLabel: ({ color, focused }) => (
+            <TabLabel color={color} focused={focused}>{t('tabs.home')}</TabLabel>
+          ),
         }}
       />
       <Tabs.Screen
@@ -60,6 +91,9 @@ export default function TabLayout() {
           title: t('tabs.chat'),
           tabBarIcon: ({ focused }) => (
             <TabIcon name={focused ? 'chat' : 'chat-outline'} focused={focused} />
+          ),
+          tabBarLabel: ({ color, focused }) => (
+            <TabLabel color={color} focused={focused}>{t('tabs.chat')}</TabLabel>
           ),
         }}
       />
@@ -70,6 +104,9 @@ export default function TabLayout() {
           tabBarIcon: ({ focused }) => (
             <TabIcon name={focused ? 'target' : 'target'} focused={focused} />
           ),
+          tabBarLabel: ({ color, focused }) => (
+            <TabLabel color={color} focused={focused}>{t('tabs.mission')}</TabLabel>
+          ),
         }}
       />
       <Tabs.Screen
@@ -79,6 +116,9 @@ export default function TabLayout() {
           tabBarIcon: ({ focused }) => (
             <TabIcon name={focused ? 'card-account-details' : 'card-account-details-outline'} focused={focused} />
           ),
+          tabBarLabel: ({ color, focused }) => (
+            <TabLabel color={color} focused={focused}>{t('tabs.cards')}</TabLabel>
+          ),
         }}
       />
       <Tabs.Screen
@@ -87,6 +127,9 @@ export default function TabLayout() {
           title: t('tabs.settings'),
           tabBarIcon: ({ focused }) => (
             <TabIcon name={focused ? 'cog' : 'cog-outline'} focused={focused} />
+          ),
+          tabBarLabel: ({ color, focused }) => (
+            <TabLabel color={color} focused={focused}>{t('tabs.settings')}</TabLabel>
           ),
         }}
       />


### PR DESCRIPTION
## Summary
Going with **option B** (icon-only, text only on active tab) from the dispatch brief — lower risk than reshuffling information architecture.

- Added a `TabLabel` component in `app/(tabs)/_layout.tsx`:
  - Returns `null` when `!focused` → inactive tabs are icon-only, so 5 icons always fit on iPhone 17 Pro width (88pt per tab).
  - Active label has `numberOfLines={1}` + `adjustsFontSizeToFit` + `minimumFontScale={0.7}` so 3-character CJK labels (`任務` / `名片夾`) never truncate.
- Kept all 5 tabs — no info-architecture change; translators don't have to re-copy anything.

## Test plan
- [x] `npx jest tests/jest/ios-bottom-nav.test.js` passes (5/5 — TabLabel exists, returns null when !focused, uses `numberOfLines=1` + `adjustsFontSizeToFit`, all 5 tabs wired).
- [x] `npx tsc --noEmit` shows no new errors in touched file.
- [ ] Manual on iOS sim: switch locale to ja / ko / zh-CN, confirm no overlapping labels and active tab's label shrinks to a single line.

Closes #1769

🤖 Generated with [Claude Code](https://claude.com/claude-code)