### PR TITLE
fix(ios): hide portal chrome + match deep-purple bg in WebView (#1770)

### DIFF
--- a/backend/tests/jest/ios-webview-chrome.test.js
+++ b/backend/tests/jest/ios-webview-chrome.test.js
@@ -1,0 +1,68 @@
+const fs = require('fs');
+const path = require('path');
+
+// Regression for Issue #1770 — WebView/native visual seam.
+// Short-term fix: WebView injects CSS + adds ?hideChrome=1 so portal pages
+// hosted inside the iOS WebView render against the same deep-purple
+// background and system font as the native container. Full native rewrite
+// is a separate roadmap item.
+
+describe('iOS WebView chrome hide (#1770)', () => {
+    const compPath = path.join(
+        __dirname,
+        '..',
+        '..',
+        '..',
+        'ios-app',
+        'components',
+        'WebViewScreen.tsx'
+    );
+    let source = '';
+
+    beforeAll(() => {
+        source = fs.readFileSync(compPath, 'utf8');
+    });
+
+    test('WebViewScreen.tsx exists', () => {
+        expect(fs.existsSync(compPath)).toBe(true);
+    });
+
+    test('query string includes hideChrome=1', () => {
+        // Loose: the literal must appear in the string list we compose.
+        expect(source).toMatch(/'hideChrome=1'/);
+    });
+
+    test('injected JS applies eclaw-ios-chrome class when ?hideChrome=1', () => {
+        expect(source).toMatch(/hideChrome.*===\s*'1'/);
+        expect(source).toMatch(/eclaw-ios-chrome/);
+        expect(source).toMatch(/classList\.add\(/);
+    });
+
+    test('chrome-hide CSS targets portal navbar and deep-purple bg', () => {
+        // Background must match the native container (#0D0D1A).
+        expect(source).toMatch(/#0D0D1A/);
+        // Must hide at least the portal .nav / .public-nav selectors.
+        expect(source).toMatch(/\.nav/);
+        expect(source).toMatch(/\.public-nav/);
+        // Must force system font (SF Pro / -apple-system).
+        expect(source).toMatch(/-apple-system/);
+    });
+
+    test('CSS is scoped to html.eclaw-ios-chrome so browser users are untouched', () => {
+        // Every rule in CHROME_HIDE_CSS should start with html.eclaw-ios-chrome,
+        // so a portal page loaded directly in Safari without the class is
+        // unaffected.
+        const cssMatch = source.match(/CHROME_HIDE_CSS\s*=\s*`([\s\S]*?)`/);
+        expect(cssMatch).not.toBeNull();
+        const css = cssMatch[1];
+        // Strip comments and whitespace-only lines, then check every selector
+        // block begins with the scope.
+        const rules = css
+            .split('}')
+            .map((r) => r.trim())
+            .filter((r) => r.length > 0 && r.includes('{'));
+        for (const rule of rules) {
+            expect(rule).toMatch(/html\.eclaw-ios-chrome/);
+        }
+    });
+});

--- a/ios-app/components/WebViewScreen.tsx
+++ b/ios-app/components/WebViewScreen.tsx
@@ -8,6 +8,34 @@ interface WebViewScreenProps {
   url: string;
 }
 
+// Short-term chrome-hide for #1770 — the full native rewrite is a separate
+// roadmap item. This CSS closes the most jarring seams (portal navbar,
+// light background, non-system fonts) when portal pages are hosted inside
+// the iOS WebView. Scoped via html.eclaw-ios-chrome so it cannot leak to
+// browser users.
+const CHROME_HIDE_CSS = `
+  html.eclaw-ios-chrome,
+  html.eclaw-ios-chrome body {
+    background-color: #0D0D1A !important;
+    color: #E5E5EA !important;
+    font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', 'SF Pro Display', 'Helvetica Neue', Arial, sans-serif !important;
+  }
+  html.eclaw-ios-chrome .nav,
+  html.eclaw-ios-chrome nav.nav,
+  html.eclaw-ios-chrome header.nav,
+  html.eclaw-ios-chrome .public-nav,
+  html.eclaw-ios-chrome .page-nav,
+  html.eclaw-ios-chrome .site-footer,
+  html.eclaw-ios-chrome footer.footer {
+    display: none !important;
+  }
+  html.eclaw-ios-chrome button,
+  html.eclaw-ios-chrome .btn,
+  html.eclaw-ios-chrome input[type="submit"] {
+    accent-color: #7C3AED;
+  }
+`;
+
 const INJECTED_JS = `
 (function() {
   try {
@@ -27,6 +55,17 @@ const INJECTED_JS = `
       try { localStorage.setItem('authToken', tok); } catch (_) {}
       try { document.cookie = 'eclaw_session=' + tok + '; path=/; SameSite=Lax; Secure'; } catch (_) {}
     }
+    // Chrome-hide — tag root + inject CSS so portal pages visually align
+    // with the native deep-purple container. Tracked in #1770.
+    if (params.get('hideChrome') === '1') {
+      try { document.documentElement.classList.add('eclaw-ios-chrome'); } catch (_) {}
+      try {
+        const style = document.createElement('style');
+        style.setAttribute('data-eclaw-ios-chrome', '1');
+        style.textContent = ${JSON.stringify(CHROME_HIDE_CSS)};
+        (document.head || document.documentElement).appendChild(style);
+      } catch (_) {}
+    }
   } catch(e) {
     if (window.ReactNativeWebView && window.ReactNativeWebView.postMessage) {
       window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'auth-diag-error', err: String(e) }));
@@ -42,7 +81,7 @@ export default function WebViewScreen({ url }: WebViewScreenProps) {
   const [loading, setLoading] = useState(true);
 
   const sep = url.includes('?') ? '&' : '?';
-  const qs: string[] = ['embed=1'];
+  const qs: string[] = ['embed=1', 'hideChrome=1'];
   if (deviceId) qs.push(`deviceId=${encodeURIComponent(deviceId)}`);
   if (deviceSecret) qs.push(`deviceSecret=${encodeURIComponent(deviceSecret)}`);
   if (authToken) qs.push(`authToken=${encodeURIComponent(authToken)}`);


### PR DESCRIPTION
## Summary
Short-term visual bridge while the full native rewrite of Mission / Wallet / Invite / Community is scoped as a separate roadmap item.

`components/WebViewScreen.tsx` now:
- Appends `?hideChrome=1` alongside the existing `?embed=1` on the portal URL.
- In `INJECTED_JS`, when `hideChrome=1` is present, tags `<html>` with class `eclaw-ios-chrome` **and** injects a `<style data-eclaw-ios-chrome="1">` with:
  - `background-color: #0D0D1A` (matches native container `StyleSheet.container.backgroundColor`)
  - `font-family: -apple-system, SF Pro Text / Display, …` (matches native UI)
  - `display: none` on `.nav`, `nav.nav`, `header.nav`, `.public-nav`, `.page-nav`, `.site-footer`
- Every rule is scoped `html.eclaw-ios-chrome …` so portal pages loaded directly in Safari remain unaffected.

## Not changed (deliberately)
- No portal-side CSS/JS changes — the scoped selectors keep blast radius zero for browser users. If we later want first-class embed styling on the backend, that's a follow-up.
- Did not port selectors for every portal page individually; the generic `.nav` / `.public-nav` selectors already hide the chrome on all WebView-hosted pages.

## Test plan
- [x] `npx jest tests/jest/ios-webview-chrome.test.js` passes (5/5 — hideChrome=1 in QS, class toggle, deep-purple bg + SF font + portal nav hidden, every CSS rule scoped to `html.eclaw-ios-chrome`).
- [x] `npx tsc --noEmit` shows no new errors in `components/WebViewScreen.tsx`.
- [ ] Manual on iOS sim: open Mission tab (WebView), confirm deep-purple background with no portal navbar or site footer; then open same URL in desktop Safari and confirm the portal still renders its navbar.

Closes #1770

🤖 Generated with [Claude Code](https://claude.com/claude-code)