### PR TITLE
fix(kanban): regen R2 signed URL on every card-file read

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -1447,8 +1447,10 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
             filename = filename || r2row.rows[0].filename;
             mimeType = mimeType || r2row.rows[0].mime_type;
             fileSize = fileSize || parseInt(r2row.rows[0].size);
-            // Stored url is just a legacy cache; GET regenerates from fileId.
-            url = url || `r2:${fileId}`;
+            // Stored url is always the opaque cache when file_id is set — any
+            // `url` the caller passed (possibly a raw R2 signed URL that would
+            // leak) is discarded. GET regenerates from fileId on every read.
+            url = `r2:${fileId}`;
         }
 
         if (!filename || !url) {

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -37,6 +37,8 @@ const { Pool } = require('pg');
 const _crypto = require('crypto');
 const fs = require('fs');
 const path = require('path');
+const { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3');
+const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
 const safeEqual = require('./safe-equal');
 const { newCardId } = require('./entity-id');
 const { tKanban, statusLabel } = require('./i18n/kanban-notifications');
@@ -72,6 +74,55 @@ try {
 const pool = new Pool({
     connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
 });
+
+// R2 client (shared config with files.js) — used to regenerate fresh signed URLs
+// for card attachments on every read, so UI never shows an expired link.
+const r2 = new S3Client({
+    region: 'auto',
+    endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+    credentials: {
+        accessKeyId: process.env.R2_ACCESS_KEY_ID || '',
+        secretAccessKey: process.env.R2_SECRET_ACCESS_KEY || '',
+    },
+});
+const R2_BUCKET = process.env.R2_BUCKET_NAME || 'eclaw-files';
+const R2_URL_TTL_SECONDS = 600; // 10 min — fresh on every GET, short blast radius.
+
+async function signCardFileUrl(fileId, deviceId, filename) {
+    const result = await pool.query(
+        'SELECT r2_key, filename, mime_type FROM r2_files WHERE file_id = $1 AND device_id = $2 AND expires_at > NOW()',
+        [fileId, deviceId]
+    );
+    if (!result.rows.length) return null;
+    const row = result.rows[0];
+    const cmdParams = { Bucket: R2_BUCKET, Key: row.r2_key };
+    if (filename) {
+        cmdParams.ResponseContentDisposition = `inline; filename="${encodeURIComponent(row.filename)}"`;
+    }
+    return await getSignedUrl(r2, new GetObjectCommand(cmdParams), { expiresIn: R2_URL_TTL_SECONDS });
+}
+
+async function mapCardFileRow(r) {
+    let url = r.url;
+    if (r.file_id) {
+        try {
+            const fresh = await signCardFileUrl(r.file_id, r.device_id, r.filename);
+            if (fresh) url = fresh;
+        } catch (err) {
+            console.warn('[Kanban] signCardFileUrl failed, falling back to stored url:', err.message);
+        }
+    }
+    return {
+        id: r.id,
+        fileId: r.file_id || null,
+        filename: r.filename,
+        url,
+        mimeType: r.mime_type,
+        fileSize: r.file_size ? parseInt(r.file_size) : null,
+        uploadedBy: r.uploaded_by,
+        createdAt: new Date(r.created_at).getTime(),
+    };
+}
 
 // Valid statuses in order
 const STATUSES = ['backlog', 'todo', 'in_progress', 'review', 'done', 'blocked'];
@@ -871,20 +922,13 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
                 updatedAt: new Date(r.updated_at).getTime()
             }));
 
-            // Fetch files
+            // Fetch files — regenerate fresh R2 signed URLs for rows that were
+            // stored as fileId refs (stored url in DB is just a legacy cache).
             const filesResult = await pool.query(
                 `SELECT * FROM kanban_files WHERE card_id = $1 ORDER BY created_at DESC`,
                 [cardId]
             );
-            card.files = filesResult.rows.map(r => ({
-                id: r.id,
-                filename: r.filename,
-                url: r.url,
-                mimeType: r.mime_type,
-                fileSize: r.file_size ? parseInt(r.file_size) : null,
-                uploadedBy: r.uploaded_by,
-                createdAt: new Date(r.created_at).getTime()
-            }));
+            card.files = await Promise.all(filesResult.rows.map(mapCardFileRow));
 
             res.json({ success: true, card });
         } catch (err) {
@@ -1369,15 +1413,7 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
                 [cardId]
             );
 
-            const files = result.rows.map(r => ({
-                id: r.id,
-                filename: r.filename,
-                url: r.url,
-                mimeType: r.mime_type,
-                fileSize: r.file_size ? parseInt(r.file_size) : null,
-                uploadedBy: r.uploaded_by,
-                createdAt: new Date(r.created_at).getTime()
-            }));
+            const files = await Promise.all(result.rows.map(mapCardFileRow));
 
             res.json({ success: true, files });
         } catch (err) {
@@ -1391,13 +1427,32 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
     // ============================================
     router.post('/card/:id/file', async (req, res) => {
         if (!authenticate(req, res)) return;
-        const _p = { ...req.query, ...req.body }; console.log('[Kanban] POST /card/:id/file called', { deviceId: _p.deviceId, entityId: _p.entityId, cardId: req.params?.id });
-        const { deviceId, filename, url, mimeType, fileSize, entityId } = req.body;
+        const _p = { ...req.query, ...req.body }; console.log('[Kanban] POST /card/:id/file called', { deviceId: _p.deviceId, entityId: _p.entityId, cardId: req.params?.id, fileId: _p.fileId });
+        const { deviceId, entityId } = req.body;
+        let { fileId, filename, url, mimeType, fileSize } = req.body;
         const cardId = req.params.id;
         const uploadedBy = parseInt(entityId || 0);
 
+        // Preferred path: caller passes fileId from /api/files/upload. Server
+        // hydrates filename/mime/size from r2_files so the attachment always
+        // resolves via a freshly-signed URL on every read, never an expired one.
+        if (fileId) {
+            const r2row = await pool.query(
+                'SELECT filename, mime_type, size FROM r2_files WHERE file_id = $1 AND device_id = $2 AND expires_at > NOW()',
+                [fileId, deviceId]
+            );
+            if (!r2row.rows.length) {
+                return res.status(404).json({ success: false, error: 'fileId not found in r2_files or expired' });
+            }
+            filename = filename || r2row.rows[0].filename;
+            mimeType = mimeType || r2row.rows[0].mime_type;
+            fileSize = fileSize || parseInt(r2row.rows[0].size);
+            // Stored url is just a legacy cache; GET regenerates from fileId.
+            url = url || `r2:${fileId}`;
+        }
+
         if (!filename || !url) {
-            return res.status(400).json({ success: false, error: 'Missing filename or url' });
+            return res.status(400).json({ success: false, error: 'Missing filename or url (or fileId)' });
         }
 
         try {
@@ -1410,10 +1465,10 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
             }
 
             const result = await pool.query(
-                `INSERT INTO kanban_files (card_id, device_id, filename, url, mime_type, file_size, uploaded_by)
-                 VALUES ($1, $2, $3, $4, $5, $6, $7)
+                `INSERT INTO kanban_files (card_id, device_id, filename, url, mime_type, file_size, uploaded_by, file_id)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
                  RETURNING *`,
-                [cardId, deviceId, filename, url, mimeType || null, fileSize || null, uploadedBy]
+                [cardId, deviceId, filename, url, mimeType || null, fileSize || null, uploadedBy, fileId || null]
             );
 
             // Bump card updated_at so "Recently Updated" sort surfaces the card.
@@ -1422,15 +1477,7 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
                 [cardId, deviceId]
             );
 
-            const file = {
-                id: result.rows[0].id,
-                filename: result.rows[0].filename,
-                url: result.rows[0].url,
-                mimeType: result.rows[0].mime_type,
-                fileSize: result.rows[0].file_size ? parseInt(result.rows[0].file_size) : null,
-                uploadedBy: result.rows[0].uploaded_by,
-                createdAt: new Date(result.rows[0].created_at).getTime()
-            };
+            const file = await mapCardFileRow(result.rows[0]);
 
             await bumpVersion(deviceId);
             res.json({ success: true, file });

--- a/backend/kanban_schema.sql
+++ b/backend/kanban_schema.sql
@@ -122,6 +122,11 @@ CREATE TABLE IF NOT EXISTS kanban_files (
 
 CREATE INDEX IF NOT EXISTS idx_kanban_files_card ON kanban_files(card_id);
 
+-- Link to r2_files.file_id so GET can regenerate a fresh signed URL on demand.
+-- Nullable for backward-compat with rows that only stored a raw URL.
+ALTER TABLE kanban_files ADD COLUMN IF NOT EXISTS file_id TEXT;
+CREATE INDEX IF NOT EXISTS idx_kanban_files_file_id ON kanban_files(file_id);
+
 -- ============================================
 -- ID prefix migration (idempotent; no-ops after first run)
 -- Widen kanban_cards.id UUID → VARCHAR(48) so Stripe-style prefixed IDs

--- a/backend/tests/jest/kanban-file-regen-url.test.js
+++ b/backend/tests/jest/kanban-file-regen-url.test.js
@@ -1,0 +1,240 @@
+/**
+ * Kanban card file — regenerate R2 signed URL on every read.
+ *
+ * Contract pinned by these tests:
+ *   1. POST /card/:id/file with {fileId} hydrates metadata from r2_files
+ *      and persists file_id (stored url is opaque `r2:<fileId>` cache).
+ *   2. POST with {fileId} that doesn't exist → 404.
+ *   3. Legacy POST with {url, filename} (no fileId) still works unchanged.
+ *   4. GET /card/:id/files returns a freshly-signed URL for rows that have
+ *      file_id; rows with only a stored url return it as-is.
+ */
+
+const mockQuery = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: mockQuery,
+        connect: jest.fn().mockResolvedValue({
+            query: jest.fn().mockResolvedValue({ rows: [] }),
+            release: jest.fn(),
+        }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+jest.mock('../../safe-equal', () => (a, b) => a === b);
+
+// Deterministic signed-URL stub so tests can assert regeneration without
+// hitting AWS. Each call appends a monotonically increasing counter so we can
+// prove the URL is freshly computed on every read.
+jest.mock('@aws-sdk/s3-request-presigner', () => {
+    let _count = 0;
+    return {
+        __getSignCallCount: () => _count,
+        __resetSignCallCount: () => { _count = 0; },
+        getSignedUrl: jest.fn(async () => {
+            _count += 1;
+            return `https://r2.example.test/fresh?sig=${_count}`;
+        }),
+    };
+});
+const presigner = require('@aws-sdk/s3-request-presigner');
+const signCallCount = () => presigner.__getSignCallCount();
+
+const express = require('express');
+const request = require('supertest');
+
+let app;
+
+beforeAll(() => {
+    app = express();
+    app.use(express.json());
+
+    const mockDevices = {
+        'test-dev': {
+            deviceSecret: 'test-secret',
+            entities: {
+                2: { isBound: true, botSecret: 'bot-sec-2', character: 'Bot2' },
+            },
+        },
+    };
+
+    const kanbanModule = require('../../kanban')(mockDevices, {});
+    app.use('/api/mission', kanbanModule.router);
+});
+
+beforeEach(() => {
+    mockQuery.mockReset();
+    presigner.__resetSignCallCount();
+});
+
+const AUTH = { deviceId: 'test-dev', deviceSecret: 'test-secret', entityId: 2 };
+const post = (p) => request(app).post(p);
+const get = (p) => request(app).get(p);
+
+// ════════════════════════════════════════════════════════════════
+// POST /card/:id/file — fileId path
+// ════════════════════════════════════════════════════════════════
+describe('POST /card/:id/file with fileId', () => {
+    it('hydrates metadata from r2_files and persists file_id', async () => {
+        // 1) r2_files lookup
+        mockQuery.mockResolvedValueOnce({
+            rows: [{ filename: 'before.png', mime_type: 'image/png', size: 12345 }],
+        });
+        // 2) card existence check
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: 'card_abc' }] });
+        // 3) INSERT INTO kanban_files
+        mockQuery.mockResolvedValueOnce({
+            rows: [{
+                id: 'f1',
+                file_id: 'file-xyz',
+                filename: 'before.png',
+                url: 'r2:file-xyz',
+                mime_type: 'image/png',
+                file_size: 12345,
+                uploaded_by: 2,
+                device_id: 'test-dev',
+                created_at: new Date(),
+            }],
+        });
+        // 4) bump card updated_at
+        mockQuery.mockResolvedValueOnce({ rows: [] });
+        // 5) mapCardFileRow → signCardFileUrl → r2_files lookup for fresh URL
+        mockQuery.mockResolvedValueOnce({
+            rows: [{ r2_key: 'files/test-dev/file-xyz/before.png', filename: 'before.png', mime_type: 'image/png' }],
+        });
+
+        const res = await post('/api/mission/card/card_abc/file')
+            .send({ ...AUTH, fileId: 'file-xyz' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.file.fileId).toBe('file-xyz');
+        expect(res.body.file.filename).toBe('before.png');
+        expect(res.body.file.mimeType).toBe('image/png');
+        expect(res.body.file.fileSize).toBe(12345);
+        // URL is the freshly-signed one, not the opaque `r2:<fileId>` cache.
+        expect(res.body.file.url).toMatch(/^https:\/\/r2\.example\.test\/fresh\?sig=/);
+        expect(res.body.file.url).not.toContain('r2:');
+
+        // INSERT received file_id as the 8th param.
+        const insertCall = mockQuery.mock.calls.find(c => /INSERT INTO kanban_files/.test(c[0]));
+        expect(insertCall[1][7]).toBe('file-xyz');
+    });
+
+    it('rejects fileId that is not in r2_files (404)', async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [] }); // no r2_files row
+
+        const res = await post('/api/mission/card/card_abc/file')
+            .send({ ...AUTH, fileId: 'missing-id' });
+
+        expect(res.status).toBe(404);
+        expect(res.body.error).toMatch(/fileId/i);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// Legacy path — POST with only {url, filename} still accepted
+// ════════════════════════════════════════════════════════════════
+describe('POST /card/:id/file legacy path', () => {
+    it('accepts a raw url without fileId and stores file_id NULL', async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: 'card_abc' }] });
+        mockQuery.mockResolvedValueOnce({
+            rows: [{
+                id: 'f2',
+                file_id: null,
+                filename: 'legacy.png',
+                url: 'https://external.example/legacy.png',
+                mime_type: 'image/png',
+                file_size: null,
+                uploaded_by: 2,
+                device_id: 'test-dev',
+                created_at: new Date(),
+            }],
+        });
+        mockQuery.mockResolvedValueOnce({ rows: [] });
+
+        const res = await post('/api/mission/card/card_abc/file')
+            .send({ ...AUTH, filename: 'legacy.png', url: 'https://external.example/legacy.png', mimeType: 'image/png' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.file.fileId).toBeNull();
+        // Legacy row: URL passes through unchanged, never re-signed.
+        expect(res.body.file.url).toBe('https://external.example/legacy.png');
+        expect(signCallCount()).toBe(0);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// GET /card/:id/files — fresh URL per read
+// ════════════════════════════════════════════════════════════════
+describe('GET /card/:id/files regeneration', () => {
+    it('regenerates signed URL for rows with file_id; passes through for legacy rows', async () => {
+        // card existence
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: 'card_abc' }] });
+        // kanban_files rows
+        mockQuery.mockResolvedValueOnce({
+            rows: [
+                {
+                    id: 'f1', file_id: 'file-xyz', filename: 'a.png',
+                    url: 'r2:file-xyz', mime_type: 'image/png',
+                    file_size: 1, uploaded_by: 2, device_id: 'test-dev',
+                    created_at: new Date(),
+                },
+                {
+                    id: 'f2', file_id: null, filename: 'legacy.png',
+                    url: 'https://external.example/legacy.png',
+                    mime_type: 'image/png', file_size: 2, uploaded_by: 2,
+                    device_id: 'test-dev', created_at: new Date(),
+                },
+            ],
+        });
+        // r2_files lookup for f1 fresh URL
+        mockQuery.mockResolvedValueOnce({
+            rows: [{ r2_key: 'files/test-dev/file-xyz/a.png', filename: 'a.png', mime_type: 'image/png' }],
+        });
+
+        const res = await get('/api/mission/card/card_abc/files')
+            .query(AUTH);
+
+        expect(res.status).toBe(200);
+        expect(res.body.files).toHaveLength(2);
+        // file_id row → freshly signed URL
+        expect(res.body.files[0].fileId).toBe('file-xyz');
+        expect(res.body.files[0].url).toMatch(/^https:\/\/r2\.example\.test\/fresh\?sig=/);
+        // legacy row → url passes through
+        expect(res.body.files[1].fileId).toBeNull();
+        expect(res.body.files[1].url).toBe('https://external.example/legacy.png');
+        // Only one sign call — not wasted on legacy row.
+        expect(signCallCount()).toBe(1);
+    });
+
+    it('two reads of the same card produce two distinct fresh URLs', async () => {
+        const cardRow = { rows: [{ id: 'card_abc' }] };
+        const filesRow = {
+            rows: [{
+                id: 'f1', file_id: 'file-xyz', filename: 'a.png',
+                url: 'r2:file-xyz', mime_type: 'image/png',
+                file_size: 1, uploaded_by: 2, device_id: 'test-dev',
+                created_at: new Date(),
+            }],
+        };
+        const r2Row = {
+            rows: [{ r2_key: 'files/test-dev/file-xyz/a.png', filename: 'a.png', mime_type: 'image/png' }],
+        };
+
+        // First GET
+        mockQuery.mockResolvedValueOnce(cardRow);
+        mockQuery.mockResolvedValueOnce(filesRow);
+        mockQuery.mockResolvedValueOnce(r2Row);
+        const res1 = await get('/api/mission/card/card_abc/files').query(AUTH);
+
+        // Second GET
+        mockQuery.mockResolvedValueOnce(cardRow);
+        mockQuery.mockResolvedValueOnce(filesRow);
+        mockQuery.mockResolvedValueOnce(r2Row);
+        const res2 = await get('/api/mission/card/card_abc/files').query(AUTH);
+
+        expect(res1.body.files[0].url).not.toBe(res2.body.files[0].url);
+    });
+});


### PR DESCRIPTION
## Summary

Permanently fixes the recurring "照片都是無法×看不到" complaint.

Kanban card file attachments (screenshots, review artifacts) stored the raw pre-signed R2 URL directly in `kanban_files.url`. Signed URLs expire (10 min / 1 h TTL), so **any screenshot attached more than a TTL ago renders as a broken image**. Hank hit this 3+ times this week (PR #2049 review card, card_5c03553f, P0 rental card). Every time my only recourse was to re-sign and re-attach manually.

This changes the contract so card files **self-heal**: store a `file_id` ref, regenerate the signed URL on every read.

## Changes

- **Schema** (`kanban_schema.sql`): idempotent `ALTER TABLE kanban_files ADD COLUMN IF NOT EXISTS file_id TEXT` + index. Nullable for legacy rows.
- **POST `/card/:id/file`**: now accepts `{fileId}` (preferred). Server looks up `r2_files`, hydrates filename/mime/size, persists `file_id`. Stored `url` becomes an opaque `r2:<fileId>` cache that never leaks to clients. 404 if `fileId` missing/expired. Legacy `{url, filename}` path still accepted.
- **GET `/card/:id`** + **GET `/card/:id/files`**: rows with `file_id` get a freshly-signed URL on every read (10 min TTL — always fresh, never stale). Legacy rows (`file_id IS NULL`) return their stored URL unchanged.
- **Tests**: 5 new Jest specs pinning the contract. All 28 existing kanban tests still pass.

## Backward compatibility

Legacy rows with only a stored URL continue to work — they don't self-heal, but they don't break either. Any *new* attachment that uses the `{fileId}` path (and any old row you re-attach) becomes regenerable going forward.

Bots already call `/api/files/upload` and get back a `fileId` in the response, so switching callers to pass `fileId` is a single-line change on the client side.

## Test plan

- [x] `npx jest tests/jest/kanban-file-regen-url.test.js` — 5/5 passing
- [x] `npx jest tests/jest/kanban-card.test.js tests/jest/kanban-chat-card-ref.test.js` — 28/28 still passing
- [x] `eslint backend/kanban.js` — 0 errors
- [ ] Post-merge: re-attach screenshots to `card_f6321df2` (P0 rental) and `card_c24b56d5` (R2 URL security) using the new `fileId` path; confirm they stay visible indefinitely.

Closes `card_cf9bc3bd456c10e0379e7bcf`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)