### PR TITLE
fix(auth): WebView device-mismatch guard for stale session cookies

### DIFF
--- a/backend/public/portal/shared/auth.js
+++ b/backend/public/portal/shared/auth.js
@@ -18,6 +18,16 @@ async function checkAuth() {
         }
     } catch (_) { /* ignore */ }
 
+    // Collect any URL-param device credentials up-front so we can detect a
+    // session-vs-URL device mismatch after /me succeeds.
+    let urlDeviceId = null;
+    let urlDeviceSecret = null;
+    try {
+        const params = new URLSearchParams(window.location.search);
+        urlDeviceId = params.get('deviceId');
+        urlDeviceSecret = params.get('deviceSecret');
+    } catch (_) { /* ignore */ }
+
     try {
         // Suppress api.js's built-in 401->index redirect so the WebView / URL-param
         // fallbacks below get a chance to device-login. Without this, the redirect
@@ -27,6 +37,31 @@ async function checkAuth() {
         const data = await apiCall('GET', '/api/auth/me', null, { skip401Redirect: true });
         currentUser = data.user;
         window.currentUser = currentUser;
+
+        // WebView stale-session guard: if the host passed deviceId+deviceSecret
+        // in the URL but /me returned a DIFFERENT device (e.g. leftover session
+        // cookie from a prior account or test device), the URL-param device is
+        // authoritative for this launch. Re-login so env-vars and other pages
+        // hit the device the shell intended, not whoever the stale cookie
+        // happens to belong to. Without this, pages like env-vars.html render
+        // empty because they query the wrong device_vars row.
+        if (urlDeviceId && urlDeviceSecret && currentUser.deviceId && urlDeviceId !== currentUser.deviceId) {
+            try {
+                const relogin = await apiCall('POST', '/api/auth/device-login', {
+                    deviceId: urlDeviceId,
+                    deviceSecret: urlDeviceSecret
+                });
+                if (relogin && relogin.success && relogin.user) {
+                    currentUser = relogin.user;
+                    if (!currentUser.deviceSecret) currentUser.deviceSecret = urlDeviceSecret;
+                    if (!currentUser.deviceId) currentUser.deviceId = urlDeviceId;
+                    window.currentUser = currentUser;
+                    console.log('[Auth] WebView device mismatch → re-logged into URL-param device');
+                }
+            } catch (reloginErr) {
+                console.warn('[Auth] WebView device mismatch but re-login failed, staying on session user:', reloginErr);
+            }
+        }
 
         // Restore language preference from server if not set locally
         if (currentUser.language && typeof i18n !== 'undefined') {

--- a/backend/tests/jest/portal-auth-race.test.js
+++ b/backend/tests/jest/portal-auth-race.test.js
@@ -149,4 +149,14 @@ describe('auth.js wiring (static analysis)', () => {
         // itself (api.js no longer does it for the /me probe).
         expect(source).toMatch(/window\.location\.href\s*=\s*['"]index\.html['"]/);
     });
+
+    test('WebView device-mismatch guard re-logs into URL-param device', () => {
+        // Incident 2026-04-24 card_f0d95b8d: mission.html's env-vars sub-tab
+        // rendered blank in the iOS WebView because a stale session cookie
+        // belonged to a different device than the URL params. The guard
+        // detects mismatch between URL deviceId and /me's returned deviceId,
+        // then calls /api/auth/device-login with the URL-param credentials.
+        expect(source).toMatch(/urlDeviceId\s*!==\s*currentUser\.deviceId/);
+        expect(source).toMatch(/apiCall\(\s*['"]POST['"]\s*,\s*['"]\/api\/auth\/device-login['"]/);
+    });
 });


### PR DESCRIPTION
## Summary

- Root cause of [card_f0d95b8d](https://eclawbot.com) "App 任務頁金鑰庫 tab 空白 — web 同一帳號顯示 17 支完好": iOS WebView's checkAuth trusts a stale `/api/auth/me` session over the URL-param device credentials the native shell just handed it. Downstream pages query the wrong device and render empty.
- Fix: when `/me` returns a user whose `deviceId` differs from the URL-param `deviceId`, force `/api/auth/device-login` with URL-param credentials. The shell-injected device is authoritative for the launch.
- Silent fallback to the existing session if re-login fails, so we don't downgrade working sessions on a flaky network.

## Repro (captured earlier this session via Playwright)

```
URL:  https://eclawbot.com/portal/env-vars.html?deviceId=480def4c…&deviceSecret=…
currentUser.deviceId:  2a0ad04d…    ← from leftover session cookie
visible text:          "尚無變數"
server vars count for URL-param device:  17
```

After the fix, checkAuth detects the mismatch and re-logs into the URL-param device before any downstream page reads `currentUser.deviceSecret`.

## Test plan

- [x] `jest backend/tests/jest/portal-auth-race.test.js` → 8/8 green (existing 7 + new static-analysis guard)
- [ ] Prod E2E after deploy: reopen app → mission → 金鑰庫 tab → 17 keys render (Hank to confirm on actual device; Playwright-simulated repro will be rerun post-deploy in commander session)

## Notes

- Does not affect fresh WebView installs (no stale cookie, goes straight through 401 → iOS fallback path, no mismatch to detect).
- Complements the previous hydrate fix (#2047) by ensuring the hydrate uses the *right* device's credentials.

🤖 Generated with [Claude Code](https://claude.com/claude-code)