### PR TITLE
feat(scheduled-messages): Phase 1 backend — schema + 4 CRUD + poller

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1411,7 +1411,8 @@ app.get('/api/help', (req, res) => {
         general: [
             { title: 'Full API documentation', curl: `curl -s "${apiBase}/api/skill-doc?format=text"` },
             { title: 'Read mission dashboard', curl: `curl -s "${apiBase}/api/mission/dashboard?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}"` },
-            { title: 'Read kanban board', curl: `curl -s "${apiBase}/api/mission/cards?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}"` }
+            { title: 'Read kanban board', curl: `curl -s "${apiBase}/api/mission/cards?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}"` },
+            { title: 'Scheduled messages (user action, DEVICE_SECRET required)', curl: `curl -s "${apiBase}/api/scheduled-messages?deviceId=${deviceId}&deviceSecret=DEVICE_SECRET&chatEntityId=${eId}"` }
         ],
         analytics: [
             { title: 'Daily growth snapshot (today, owner-admin only)', curl: `curl -s "${apiBase}/api/growth/daily?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}"` },
@@ -1591,6 +1592,22 @@ try {
 } catch (err) {
     console.error('[Mindmap] Failed to load module:', err.message);
     mindmapModule = { initMindmapTables: () => {} };
+}
+
+// Scheduled Messages — user-scheduled chat messages (Phase 1: backend)
+let scheduledMessagesModule;
+try {
+    scheduledMessagesModule = require('./scheduled-messages')(devices, {
+        saveChatMessage,
+        pushToBot,
+        unifiedPush,
+        serverLog,
+    });
+    app.use('/api/scheduled-messages', scheduledMessagesModule.router);
+    console.log('[ScheduledMessages] Module loaded successfully');
+} catch (err) {
+    console.error('[ScheduledMessages] Failed to load module:', err.message);
+    scheduledMessagesModule = { initDatabase: () => {}, startPoller: () => {}, stopPoller: () => {} };
 }
 
 // ============================================
@@ -1969,6 +1986,12 @@ nodeCron.schedule('17 3 * * *', () => {
 missionModule.initMissionDatabase();
 kanbanModule.initKanbanDatabase();
 kanbanModule.startBackgroundTimers();
+if (scheduledMessagesModule && scheduledMessagesModule.initDatabase) {
+    scheduledMessagesModule.initDatabase();
+    if (process.env.NODE_ENV !== 'test' && scheduledMessagesModule.startPoller) {
+        scheduledMessagesModule.startPoller();
+    }
+}
 // Wire notification callback (notifyDevice defined later, uses closure)
 missionModule.setNotifyCallback((deviceId, notif) => notifyDevice(deviceId, notif));
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -6921,12 +6921,26 @@ async function compactEntitySlots(device, deviceId) {
                     [deviceId, affectedOldSlots]
                 );
 
-                // 3d: Migrate scheduled_messages entity_id
+                // 3d: Migrate scheduled_messages (Phase 1 schema uses user_entity_id /
+                // chat_entity_id / target_entity_ids JSONB, and tracks state via
+                // sent_at / cancelled_at — not status). Skip already-dispatched or
+                // cancelled rows; for live ones remap the two scalar slots and
+                // rebuild the JSONB target array element-by-element.
                 await client.query(
                     `UPDATE scheduled_messages
-                     SET entity_id = CASE entity_id ${caseClauses} ELSE entity_id END
-                     WHERE device_id = $1 AND entity_id = ANY($2) AND status IN ('pending', 'active')`,
-                    [deviceId, affectedOldSlots]
+                     SET user_entity_id = CASE user_entity_id ${caseClauses} ELSE user_entity_id END,
+                         chat_entity_id = CASE chat_entity_id ${caseClauses} ELSE chat_entity_id END,
+                         target_entity_ids = COALESCE(
+                             (SELECT jsonb_agg(
+                                 to_jsonb(CASE elem::int ${caseClauses} ELSE elem::int END)
+                                 ORDER BY ord
+                             ) FROM jsonb_array_elements_text(target_entity_ids) WITH ORDINALITY AS t(elem, ord)),
+                             target_entity_ids
+                         )
+                     WHERE device_id = $1
+                       AND sent_at IS NULL
+                       AND cancelled_at IS NULL`,
+                    [deviceId]
                 );
 
                 // 3d2: Migrate kanban_cards assigned_bots JSONB array
@@ -7535,12 +7549,26 @@ app.post('/api/device/reorder-entities', async (req, res) => {
                 [deviceId, affectedOldSlots]
             );
 
-            // 3c: Migrate scheduled_messages entity_id (active/pending only)
+            // 3c: Migrate scheduled_messages (Phase 1 schema uses user_entity_id /
+            // chat_entity_id / target_entity_ids JSONB, and tracks state via
+            // sent_at / cancelled_at — not status). Skip already-dispatched or
+            // cancelled rows; for live ones remap the two scalar slots and
+            // rebuild the JSONB target array element-by-element.
             await client.query(
                 `UPDATE scheduled_messages
-                 SET entity_id = CASE entity_id ${caseClauses} ELSE entity_id END
-                 WHERE device_id = $1 AND entity_id = ANY($2) AND status IN ('pending', 'active')`,
-                [deviceId, affectedOldSlots]
+                 SET user_entity_id = CASE user_entity_id ${caseClauses} ELSE user_entity_id END,
+                     chat_entity_id = CASE chat_entity_id ${caseClauses} ELSE chat_entity_id END,
+                     target_entity_ids = COALESCE(
+                         (SELECT jsonb_agg(
+                             to_jsonb(CASE elem::int ${caseClauses} ELSE elem::int END)
+                             ORDER BY ord
+                         ) FROM jsonb_array_elements_text(target_entity_ids) WITH ORDINALITY AS t(elem, ord)),
+                         target_entity_ids
+                     )
+                 WHERE device_id = $1
+                   AND sent_at IS NULL
+                   AND cancelled_at IS NULL`,
+                [deviceId]
             );
 
             // 3c2: Migrate kanban_cards assigned_bots + reviewer_entity_id

--- a/backend/scheduled-messages.js
+++ b/backend/scheduled-messages.js
@@ -1,0 +1,497 @@
+/**
+ * Scheduled Messages — user-scheduled chat messages dispatched at a future time.
+ *
+ * Mounted at: /api/scheduled-messages
+ *
+ * Endpoints (all deviceSecret-authenticated — this is a user action, never a bot action):
+ *   POST   /           — Create a scheduled message
+ *   GET    /           — List pending scheduled messages for a chat
+ *   PUT    /:id        — Update content / scheduledAt / targetEntityIds (pre-send only)
+ *   DELETE /:id        — Cancel (pre-send only; sets cancelled_at)
+ *
+ * Background poller (started at module load unless NODE_ENV=test):
+ *   Every 5s, atomically claim rows where scheduled_at <= NOW() and
+ *   dispatch them as user messages via the injected saveChatMessage /
+ *   pushToBot / unifiedPush callbacks.
+ *
+ * Dispatch is fire-once: sent_at is stamped inside the claim UPDATE, so a
+ * concurrent poller tick cannot double-send. Delivery failures are captured
+ * in last_error but do not un-set sent_at — the spec opts for observable-
+ * once semantics over infinite retry.
+ */
+
+const express = require('express');
+const { Pool } = require('pg');
+const fs = require('fs');
+const path = require('path');
+const safeEqual = require('./safe-equal');
+
+const pool = new Pool({
+    connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
+});
+
+const MAX_CONTENT_LEN = 10000;
+const MAX_SCHEDULE_AHEAD_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const POLLER_INTERVAL_MS = 5000;
+const POLLER_BATCH_SIZE = 50;
+
+// ── Schema init ──
+async function initScheduledMessagesDatabase() {
+    try {
+        const schemaPath = path.join(__dirname, 'scheduled_messages_schema.sql');
+        const schema = fs.readFileSync(schemaPath, 'utf8');
+        const cleaned = schema.replace(/--[^\n]*/g, '').replace(/\n\s*\n/g, '\n');
+        const statements = cleaned
+            .split(';')
+            .map(s => s.trim())
+            .filter(s => s.length > 5);
+        let ok = 0, skipped = 0, failed = 0;
+        for (const stmt of statements) {
+            try {
+                await pool.query(stmt);
+                ok++;
+            } catch (err) {
+                if (err.message.includes('already exists') || err.message.includes('duplicate key')) {
+                    skipped++;
+                } else {
+                    failed++;
+                    console.error('[ScheduledMessages] Schema failed:', err.message, '\n  stmt:', stmt.slice(0, 80));
+                }
+            }
+        }
+        console.log(`[ScheduledMessages] Database initialized: ${ok} OK, ${skipped} skipped, ${failed} failed`);
+    } catch (error) {
+        console.error('[ScheduledMessages] Failed to init database:', error.message);
+    }
+}
+
+// ── Helpers ──
+function parseTimestamp(input) {
+    if (input == null) return null;
+    if (typeof input === 'number') {
+        return Number.isFinite(input) ? new Date(input) : null;
+    }
+    if (typeof input === 'string') {
+        const d = new Date(input);
+        return Number.isNaN(d.getTime()) ? null : d;
+    }
+    if (input instanceof Date) {
+        return Number.isNaN(input.getTime()) ? null : input;
+    }
+    return null;
+}
+
+function validateTargetEntityIds(targetEntityIds, device) {
+    if (!Array.isArray(targetEntityIds) || targetEntityIds.length === 0) {
+        return { valid: false, error: 'targetEntityIds must be a non-empty array' };
+    }
+    const entities = (device && device.entities) || {};
+    const cleaned = [];
+    for (const raw of targetEntityIds) {
+        const id = parseInt(raw, 10);
+        if (!Number.isInteger(id) || id < 0) {
+            return { valid: false, error: `Invalid entity id: ${raw}` };
+        }
+        // id 0 is always the owner/default slot. For other ids, the slot must
+        // exist on the device (bound or not — user can schedule for a slot
+        // they intend to bind later, but the slot must at least be present).
+        if (id !== 0 && !entities.hasOwnProperty(id)) {
+            return { valid: false, error: `Entity ${id} not found on device` };
+        }
+        cleaned.push(id);
+    }
+    return { valid: true, ids: Array.from(new Set(cleaned)) };
+}
+
+function rowToApi(row) {
+    return {
+        id: row.id,
+        chatEntityId: row.chat_entity_id,
+        userEntityId: row.user_entity_id,
+        targetEntityIds: row.target_entity_ids,
+        content: row.content,
+        scheduledAt: new Date(row.scheduled_at).getTime(),
+        createdAt: new Date(row.created_at).getTime(),
+        sentAt: row.sent_at ? new Date(row.sent_at).getTime() : null,
+        cancelledAt: row.cancelled_at ? new Date(row.cancelled_at).getTime() : null,
+    };
+}
+
+/**
+ * Factory. Matches the kanban/mission module style so index.js wires it the same way.
+ */
+module.exports = function (devices, { saveChatMessage, pushToBot, unifiedPush, serverLog } = {}) {
+    const router = express.Router();
+
+    // ── Auth (deviceSecret only — scheduling is a user action) ──
+    function findDeviceByCredentials(deviceId, deviceSecret) {
+        const device = devices && devices[deviceId];
+        if (!device || !safeEqual(device.deviceSecret, deviceSecret)) return null;
+        return device;
+    }
+
+    function authenticate(req, res) {
+        const params = { ...req.query, ...req.body };
+        const { deviceId, deviceSecret } = params;
+        if (!deviceId) {
+            res.status(400).json({ success: false, error: 'Missing deviceId' });
+            return null;
+        }
+        if (!deviceSecret) {
+            res.status(400).json({ success: false, error: 'Missing deviceSecret' });
+            return null;
+        }
+        const device = findDeviceByCredentials(deviceId, deviceSecret);
+        if (!device) {
+            res.status(401).json({ success: false, error: 'Invalid credentials' });
+            return null;
+        }
+        return { device, deviceId };
+    }
+
+    function log(level, msg, meta) {
+        if (typeof serverLog === 'function') {
+            try { serverLog(level, 'scheduled_messages', msg, meta || {}); } catch (_) {}
+        }
+    }
+
+    // ════════════════════════════════════════
+    // POST / — create a scheduled message
+    // ════════════════════════════════════════
+    router.post('/', async (req, res) => {
+        const auth = authenticate(req, res);
+        if (!auth) return;
+        const { device, deviceId } = auth;
+        const { chatEntityId, userEntityId, targetEntityIds, content, scheduledAt } = req.body || {};
+
+        if (chatEntityId == null || !Number.isInteger(parseInt(chatEntityId, 10))) {
+            return res.status(400).json({ success: false, error: 'chatEntityId required (integer)' });
+        }
+        if (userEntityId == null || !Number.isInteger(parseInt(userEntityId, 10))) {
+            return res.status(400).json({ success: false, error: 'userEntityId required (integer)' });
+        }
+        if (typeof content !== 'string' || content.length < 1 || content.length > MAX_CONTENT_LEN) {
+            return res.status(400).json({
+                success: false,
+                error: `content must be a string of length 1..${MAX_CONTENT_LEN}`,
+            });
+        }
+        const when = parseTimestamp(scheduledAt);
+        if (!when) {
+            return res.status(400).json({ success: false, error: 'scheduledAt must be a valid timestamp (ms or ISO string)' });
+        }
+        const nowMs = Date.now();
+        if (when.getTime() <= nowMs) {
+            return res.status(400).json({ success: false, error: 'scheduledAt must be in the future' });
+        }
+        if (when.getTime() > nowMs + MAX_SCHEDULE_AHEAD_MS) {
+            return res.status(400).json({ success: false, error: 'scheduledAt cannot be more than 7 days ahead' });
+        }
+        const targetCheck = validateTargetEntityIds(targetEntityIds, device);
+        if (!targetCheck.valid) {
+            return res.status(400).json({ success: false, error: targetCheck.error });
+        }
+
+        try {
+            const result = await pool.query(
+                `INSERT INTO scheduled_messages
+                    (device_id, chat_entity_id, user_entity_id, target_entity_ids, content, scheduled_at)
+                 VALUES ($1, $2, $3, $4::jsonb, $5, $6)
+                 RETURNING id, scheduled_at`,
+                [
+                    deviceId,
+                    parseInt(chatEntityId, 10),
+                    parseInt(userEntityId, 10),
+                    JSON.stringify(targetCheck.ids),
+                    content,
+                    when.toISOString(),
+                ]
+            );
+            const row = result.rows[0];
+            log('info', `created id=${row.id} targets=${targetCheck.ids.join(',')} at=${when.toISOString()}`, { deviceId });
+            return res.json({
+                success: true,
+                id: row.id,
+                scheduledAt: new Date(row.scheduled_at).getTime(),
+            });
+        } catch (err) {
+            console.error('[ScheduledMessages] POST failed:', err.message);
+            log('error', `POST failed: ${err.message}`, { deviceId });
+            return res.status(500).json({ success: false, error: 'Internal error' });
+        }
+    });
+
+    // ════════════════════════════════════════
+    // GET / — list pending (unsent, uncancelled) messages for a chat
+    // ════════════════════════════════════════
+    router.get('/', async (req, res) => {
+        const auth = authenticate(req, res);
+        if (!auth) return;
+        const { deviceId } = auth;
+        const { chatEntityId } = req.query;
+
+        try {
+            let sql = `SELECT id, chat_entity_id, user_entity_id, target_entity_ids, content,
+                              scheduled_at, created_at, sent_at, cancelled_at
+                       FROM scheduled_messages
+                       WHERE device_id = $1
+                         AND sent_at IS NULL
+                         AND cancelled_at IS NULL`;
+            const params = [deviceId];
+            if (chatEntityId != null && chatEntityId !== '') {
+                params.push(parseInt(chatEntityId, 10));
+                sql += ` AND chat_entity_id = $${params.length}`;
+            }
+            sql += ' ORDER BY scheduled_at ASC LIMIT 500';
+            const result = await pool.query(sql, params);
+            return res.json({
+                success: true,
+                messages: result.rows.map(rowToApi),
+            });
+        } catch (err) {
+            console.error('[ScheduledMessages] GET failed:', err.message);
+            return res.status(500).json({ success: false, error: 'Internal error' });
+        }
+    });
+
+    // ════════════════════════════════════════
+    // PUT /:id — update content / scheduledAt / targetEntityIds (pre-send only)
+    // ════════════════════════════════════════
+    router.put('/:id', async (req, res) => {
+        const auth = authenticate(req, res);
+        if (!auth) return;
+        const { device, deviceId } = auth;
+        const { id } = req.params;
+        const { content, scheduledAt, targetEntityIds } = req.body || {};
+
+        const updates = [];
+        const params = [];
+
+        if (content !== undefined) {
+            if (typeof content !== 'string' || content.length < 1 || content.length > MAX_CONTENT_LEN) {
+                return res.status(400).json({
+                    success: false,
+                    error: `content must be a string of length 1..${MAX_CONTENT_LEN}`,
+                });
+            }
+            params.push(content);
+            updates.push(`content = $${params.length}`);
+        }
+
+        if (scheduledAt !== undefined) {
+            const when = parseTimestamp(scheduledAt);
+            if (!when) {
+                return res.status(400).json({ success: false, error: 'scheduledAt must be a valid timestamp' });
+            }
+            const nowMs = Date.now();
+            if (when.getTime() <= nowMs) {
+                return res.status(400).json({ success: false, error: 'scheduledAt must be in the future' });
+            }
+            if (when.getTime() > nowMs + MAX_SCHEDULE_AHEAD_MS) {
+                return res.status(400).json({ success: false, error: 'scheduledAt cannot be more than 7 days ahead' });
+            }
+            params.push(when.toISOString());
+            updates.push(`scheduled_at = $${params.length}`);
+        }
+
+        if (targetEntityIds !== undefined) {
+            const targetCheck = validateTargetEntityIds(targetEntityIds, device);
+            if (!targetCheck.valid) {
+                return res.status(400).json({ success: false, error: targetCheck.error });
+            }
+            params.push(JSON.stringify(targetCheck.ids));
+            updates.push(`target_entity_ids = $${params.length}::jsonb`);
+        }
+
+        if (updates.length === 0) {
+            return res.status(400).json({ success: false, error: 'No updatable fields provided' });
+        }
+
+        params.push(id, deviceId);
+        const idIdx = params.length - 1;
+        const devIdx = params.length;
+        try {
+            const result = await pool.query(
+                `UPDATE scheduled_messages
+                    SET ${updates.join(', ')}
+                  WHERE id = $${idIdx}
+                    AND device_id = $${devIdx}
+                    AND sent_at IS NULL
+                    AND cancelled_at IS NULL
+                RETURNING id, chat_entity_id, user_entity_id, target_entity_ids, content,
+                          scheduled_at, created_at, sent_at, cancelled_at`,
+                params
+            );
+            if (result.rows.length === 0) {
+                return res.status(404).json({ success: false, error: 'Not found or already sent/cancelled' });
+            }
+            return res.json({ success: true, message: rowToApi(result.rows[0]) });
+        } catch (err) {
+            console.error('[ScheduledMessages] PUT failed:', err.message);
+            return res.status(500).json({ success: false, error: 'Internal error' });
+        }
+    });
+
+    // ════════════════════════════════════════
+    // DELETE /:id — cancel (pre-send only)
+    // ════════════════════════════════════════
+    router.delete('/:id', async (req, res) => {
+        const auth = authenticate(req, res);
+        if (!auth) return;
+        const { deviceId } = auth;
+        const { id } = req.params;
+        try {
+            const result = await pool.query(
+                `UPDATE scheduled_messages
+                    SET cancelled_at = NOW()
+                  WHERE id = $1
+                    AND device_id = $2
+                    AND sent_at IS NULL
+                    AND cancelled_at IS NULL
+                RETURNING id, cancelled_at`,
+                [id, deviceId]
+            );
+            if (result.rows.length === 0) {
+                return res.status(404).json({ success: false, error: 'Not found or already sent/cancelled' });
+            }
+            log('info', `cancelled id=${id}`, { deviceId });
+            return res.json({
+                success: true,
+                id: result.rows[0].id,
+                cancelledAt: new Date(result.rows[0].cancelled_at).getTime(),
+            });
+        } catch (err) {
+            console.error('[ScheduledMessages] DELETE failed:', err.message);
+            return res.status(500).json({ success: false, error: 'Internal error' });
+        }
+    });
+
+    // ════════════════════════════════════════
+    // Dispatch a single claimed row → save chat + push to bots
+    // ════════════════════════════════════════
+    async function dispatchRow(row) {
+        const deviceId = row.device_id;
+        const device = devices && devices[deviceId];
+        if (!device) {
+            await pool.query(
+                `UPDATE scheduled_messages SET last_error = $1 WHERE id = $2`,
+                ['device_not_found', row.id]
+            );
+            return;
+        }
+        const targetIds = Array.isArray(row.target_entity_ids) ? row.target_entity_ids : [];
+        const errors = [];
+        for (const eId of targetIds) {
+            const entity = device.entities && device.entities[eId];
+            try {
+                if (typeof saveChatMessage === 'function') {
+                    await saveChatMessage(
+                        deviceId,
+                        eId,
+                        row.content,
+                        'scheduled',
+                        true,   // is_from_user: user-scheduled message counts as a user message
+                        false,  // is_from_bot
+                        null, null, null,
+                        'scheduled' // schedule_label
+                    );
+                }
+                if (!entity || !entity.isBound) continue;
+                if (entity.bindingType === 'channel' && typeof unifiedPush === 'function') {
+                    await unifiedPush(entity, deviceId, 'new_message', {
+                        message: row.content,
+                        from: 'scheduled',
+                    }, { event: 'message', from: 'scheduled' }).catch(err => {
+                        errors.push(`entity=${eId} channel_push_failed: ${err.message}`);
+                    });
+                } else if (entity.webhook && typeof pushToBot === 'function') {
+                    await pushToBot(entity, deviceId, 'new_message', {
+                        message: `[SCHEDULED MESSAGE]\n${row.content}`,
+                    }).catch(err => {
+                        errors.push(`entity=${eId} webhook_push_failed: ${err.message}`);
+                    });
+                }
+            } catch (err) {
+                errors.push(`entity=${eId}: ${err.message}`);
+            }
+        }
+        if (errors.length > 0) {
+            try {
+                await pool.query(
+                    `UPDATE scheduled_messages SET last_error = $1 WHERE id = $2`,
+                    [errors.join(' | ').slice(0, 2000), row.id]
+                );
+            } catch (_) {}
+            log('warn', `dispatch id=${row.id} errors: ${errors.join(' | ')}`, { deviceId });
+        } else {
+            log('info', `dispatch id=${row.id} ok targets=${targetIds.length}`, { deviceId });
+        }
+    }
+
+    // ════════════════════════════════════════
+    // Poller — atomically claim due rows and dispatch
+    // ════════════════════════════════════════
+    async function pollAndFire() {
+        let claimed;
+        try {
+            const result = await pool.query(
+                `UPDATE scheduled_messages
+                    SET sent_at = NOW()
+                  WHERE id IN (
+                      SELECT id FROM scheduled_messages
+                       WHERE sent_at IS NULL
+                         AND cancelled_at IS NULL
+                         AND scheduled_at <= NOW()
+                       ORDER BY scheduled_at ASC
+                       LIMIT ${POLLER_BATCH_SIZE}
+                       FOR UPDATE SKIP LOCKED
+                  )
+                RETURNING id, device_id, chat_entity_id, user_entity_id,
+                          target_entity_ids, content, scheduled_at, sent_at`
+            );
+            claimed = result.rows;
+        } catch (err) {
+            console.error('[ScheduledMessages] poller claim failed:', err.message);
+            return { claimed: 0, dispatched: 0 };
+        }
+        if (!claimed || claimed.length === 0) return { claimed: 0, dispatched: 0 };
+        let dispatched = 0;
+        for (const row of claimed) {
+            try {
+                await dispatchRow(row);
+                dispatched++;
+            } catch (err) {
+                console.error(`[ScheduledMessages] dispatch failed for ${row.id}:`, err.message);
+            }
+        }
+        return { claimed: claimed.length, dispatched };
+    }
+
+    let pollerTimer = null;
+    function startPoller() {
+        if (pollerTimer) return;
+        pollerTimer = setInterval(() => {
+            pollAndFire().catch(err => console.error('[ScheduledMessages] poller tick:', err.message));
+        }, POLLER_INTERVAL_MS);
+        if (pollerTimer.unref) pollerTimer.unref();
+        console.log(`[ScheduledMessages] Poller started (every ${POLLER_INTERVAL_MS}ms)`);
+    }
+    function stopPoller() {
+        if (pollerTimer) {
+            clearInterval(pollerTimer);
+            pollerTimer = null;
+        }
+    }
+
+    return {
+        router,
+        initDatabase: initScheduledMessagesDatabase,
+        pollAndFire,
+        startPoller,
+        stopPoller,
+        // exposed for tests
+        _pool: pool,
+    };
+};
+
+module.exports.initScheduledMessagesDatabase = initScheduledMessagesDatabase;

--- a/backend/scheduled_messages_schema.sql
+++ b/backend/scheduled_messages_schema.sql
@@ -1,0 +1,28 @@
+-- Scheduled Messages Schema (Phase 1 backend)
+-- PostgreSQL
+--
+-- Lets users queue a chat message to be dispatched at a future time
+-- by a server-side background poller. Dispatch is fire-once: sent_at
+-- is stamped atomically via UPDATE ... FOR UPDATE SKIP LOCKED.
+
+CREATE TABLE IF NOT EXISTS scheduled_messages (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    device_id TEXT NOT NULL,
+    chat_entity_id INTEGER NOT NULL,         -- chat room context (which chat the message was scheduled in)
+    user_entity_id INTEGER NOT NULL,         -- sender entity id (typically 0 = device owner)
+    target_entity_ids JSONB NOT NULL,        -- array of entity ids, e.g. [0, 3, 5]
+    content TEXT NOT NULL,
+    scheduled_at TIMESTAMPTZ NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    sent_at TIMESTAMPTZ,
+    cancelled_at TIMESTAMPTZ,
+    last_error TEXT,
+    CONSTRAINT scheduled_messages_content_len CHECK (char_length(content) BETWEEN 1 AND 10000)
+);
+
+CREATE INDEX IF NOT EXISTS idx_scheduled_messages_pending
+    ON scheduled_messages (scheduled_at)
+    WHERE sent_at IS NULL AND cancelled_at IS NULL;
+
+CREATE INDEX IF NOT EXISTS idx_scheduled_messages_device
+    ON scheduled_messages (device_id, chat_entity_id);

--- a/backend/tests/jest/scheduled-messages.test.js
+++ b/backend/tests/jest/scheduled-messages.test.js
@@ -1,0 +1,346 @@
+/**
+ * Scheduled Messages endpoint tests (Jest + Supertest)
+ *
+ * Covers the user-action scheduled messages API at /api/scheduled-messages/*:
+ *   POST   /        create
+ *   GET    /        list pending
+ *   PUT    /:id     update (pre-send)
+ *   DELETE /:id     cancel (pre-send)
+ *   pollAndFire()   background claim + dispatch
+ */
+
+// Mock pg so the module's Pool() call is captured. Default to empty-rows
+// responses; individual tests override via mockPoolQuery per-case.
+const mockPoolQuery = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: mockPoolQuery,
+        connect: jest.fn().mockResolvedValue({ query: mockPoolQuery, release: jest.fn() }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+const express = require('express');
+const request = require('supertest');
+
+let app;
+let smModule;
+let mockSaveChat;
+let mockPushToBot;
+let mockUnifiedPush;
+
+const deviceId = 'test-dev';
+const deviceSecret = 'test-secret';
+
+beforeAll(() => {
+    app = express();
+    app.use(express.json());
+
+    const devices = {
+        [deviceId]: {
+            deviceSecret,
+            entities: {
+                0: { isBound: true,  botSecret: 'bot-0', webhook: { url: 'https://example.com/hook' }, bindingType: 'webhook' },
+                1: { isBound: false, botSecret: null },
+                2: { isBound: true,  botSecret: 'bot-2', bindingType: 'channel' },
+            },
+        },
+    };
+
+    mockSaveChat = jest.fn().mockResolvedValue('msg-id');
+    mockPushToBot = jest.fn().mockResolvedValue({ pushed: true });
+    mockUnifiedPush = jest.fn().mockResolvedValue({ pushed: true });
+
+    smModule = require('../../scheduled-messages')(devices, {
+        saveChatMessage: mockSaveChat,
+        pushToBot: mockPushToBot,
+        unifiedPush: mockUnifiedPush,
+        serverLog: () => {},
+    });
+    app.use('/api/scheduled-messages', smModule.router);
+});
+
+afterEach(() => {
+    mockPoolQuery.mockClear();
+    mockSaveChat.mockClear();
+    mockPushToBot.mockClear();
+    mockUnifiedPush.mockClear();
+});
+
+afterAll(() => {
+    // Guard against leaked intervals even though startPoller was never called here.
+    if (smModule && smModule.stopPoller) smModule.stopPoller();
+});
+
+const post = (p) => request(app).post(p);
+const get = (p) => request(app).get(p);
+const put = (p) => request(app).put(p);
+const del = (p) => request(app).delete(p);
+
+const futureIso = (offsetMs) => new Date(Date.now() + offsetMs).toISOString();
+const futureMs = (offsetMs) => Date.now() + offsetMs;
+
+// ═══════════════════════════════════════════════════════════
+// Auth
+// ═══════════════════════════════════════════════════════════
+describe('Auth', () => {
+    it('POST without deviceId → 400', async () => {
+        const res = await post('/api/scheduled-messages').send({});
+        expect(res.status).toBe(400);
+    });
+
+    it('POST without deviceSecret → 400', async () => {
+        const res = await post('/api/scheduled-messages').send({ deviceId });
+        expect(res.status).toBe(400);
+    });
+
+    it('POST with wrong deviceSecret → 401', async () => {
+        const res = await post('/api/scheduled-messages')
+            .send({ deviceId, deviceSecret: 'WRONG', chatEntityId: 0, userEntityId: 0,
+                    targetEntityIds: [0], content: 'hi', scheduledAt: futureIso(60_000) });
+        expect(res.status).toBe(401);
+    });
+
+    it('GET with wrong deviceSecret → 401', async () => {
+        const res = await get(`/api/scheduled-messages?deviceId=${deviceId}&deviceSecret=WRONG`);
+        expect(res.status).toBe(401);
+    });
+});
+
+// ═══════════════════════════════════════════════════════════
+// POST /
+// ═══════════════════════════════════════════════════════════
+describe('POST /api/scheduled-messages', () => {
+    const validBody = () => ({
+        deviceId, deviceSecret,
+        chatEntityId: 0,
+        userEntityId: 0,
+        targetEntityIds: [0],
+        content: 'Hello future',
+        scheduledAt: futureIso(5 * 60_000), // 5 minutes ahead
+    });
+
+    it('creates when body is valid', async () => {
+        const scheduledIso = futureIso(60_000);
+        mockPoolQuery.mockResolvedValueOnce({
+            rows: [{ id: 'abc-123', scheduled_at: scheduledIso }],
+        });
+        const res = await post('/api/scheduled-messages').send(validBody());
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.id).toBe('abc-123');
+        expect(typeof res.body.scheduledAt).toBe('number');
+    });
+
+    it('rejects past scheduledAt with 400', async () => {
+        const res = await post('/api/scheduled-messages')
+            .send({ ...validBody(), scheduledAt: new Date(Date.now() - 60_000).toISOString() });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/future/i);
+    });
+
+    it('rejects scheduledAt more than 7 days ahead with 400', async () => {
+        const tooFar = Date.now() + 8 * 24 * 60 * 60 * 1000;
+        const res = await post('/api/scheduled-messages')
+            .send({ ...validBody(), scheduledAt: new Date(tooFar).toISOString() });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/7 days/i);
+    });
+
+    it('rejects content longer than 10000 chars with 400', async () => {
+        const res = await post('/api/scheduled-messages')
+            .send({ ...validBody(), content: 'x'.repeat(10001) });
+        expect(res.status).toBe(400);
+    });
+
+    it('rejects empty content with 400', async () => {
+        const res = await post('/api/scheduled-messages')
+            .send({ ...validBody(), content: '' });
+        expect(res.status).toBe(400);
+    });
+
+    it('rejects missing targetEntityIds with 400', async () => {
+        const res = await post('/api/scheduled-messages')
+            .send({ ...validBody(), targetEntityIds: [] });
+        expect(res.status).toBe(400);
+    });
+
+    it('rejects target entity that does not exist on device with 400', async () => {
+        const res = await post('/api/scheduled-messages')
+            .send({ ...validBody(), targetEntityIds: [999] });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/999/);
+    });
+
+    it('accepts numeric scheduledAt (ms)', async () => {
+        mockPoolQuery.mockResolvedValueOnce({
+            rows: [{ id: 'xyz', scheduled_at: new Date(futureMs(60_000)).toISOString() }],
+        });
+        const res = await post('/api/scheduled-messages')
+            .send({ ...validBody(), scheduledAt: futureMs(60_000) });
+        expect(res.status).toBe(200);
+    });
+});
+
+// ═══════════════════════════════════════════════════════════
+// GET /
+// ═══════════════════════════════════════════════════════════
+describe('GET /api/scheduled-messages', () => {
+    it('returns pending-only list', async () => {
+        const rows = [
+            {
+                id: 'a', chat_entity_id: 0, user_entity_id: 0,
+                target_entity_ids: [0], content: 'hi',
+                scheduled_at: futureIso(60_000),
+                created_at: new Date().toISOString(),
+                sent_at: null, cancelled_at: null,
+            },
+        ];
+        mockPoolQuery.mockResolvedValueOnce({ rows });
+        const res = await get(`/api/scheduled-messages?deviceId=${deviceId}&deviceSecret=${deviceSecret}&chatEntityId=0`);
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.messages).toHaveLength(1);
+        expect(res.body.messages[0].id).toBe('a');
+        // Assert the SQL only requests unsent + uncancelled rows
+        const sqlArg = mockPoolQuery.mock.calls[mockPoolQuery.mock.calls.length - 1][0];
+        expect(sqlArg).toMatch(/sent_at IS NULL/);
+        expect(sqlArg).toMatch(/cancelled_at IS NULL/);
+    });
+});
+
+// ═══════════════════════════════════════════════════════════
+// PUT /:id
+// ═══════════════════════════════════════════════════════════
+describe('PUT /api/scheduled-messages/:id', () => {
+    it('updates scheduledAt', async () => {
+        const newIso = futureIso(10 * 60_000);
+        mockPoolQuery.mockResolvedValueOnce({
+            rows: [{
+                id: 'abc', chat_entity_id: 0, user_entity_id: 0,
+                target_entity_ids: [0], content: 'hi',
+                scheduled_at: newIso, created_at: new Date().toISOString(),
+                sent_at: null, cancelled_at: null,
+            }],
+        });
+        const res = await put('/api/scheduled-messages/abc')
+            .send({ deviceId, deviceSecret, scheduledAt: newIso });
+        expect(res.status).toBe(200);
+        expect(res.body.message.id).toBe('abc');
+    });
+
+    it('rejects empty update payload with 400', async () => {
+        const res = await put('/api/scheduled-messages/abc')
+            .send({ deviceId, deviceSecret });
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 404 when row is already sent/cancelled', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [] }); // no row updated
+        const res = await put('/api/scheduled-messages/abc')
+            .send({ deviceId, deviceSecret, content: 'updated' });
+        expect(res.status).toBe(404);
+    });
+
+    it('rejects past scheduledAt with 400', async () => {
+        const res = await put('/api/scheduled-messages/abc')
+            .send({ deviceId, deviceSecret, scheduledAt: new Date(Date.now() - 60_000).toISOString() });
+        expect(res.status).toBe(400);
+    });
+});
+
+// ═══════════════════════════════════════════════════════════
+// DELETE /:id
+// ═══════════════════════════════════════════════════════════
+describe('DELETE /api/scheduled-messages/:id', () => {
+    it('cancels a pending message (sets cancelled_at)', async () => {
+        const cancelIso = new Date().toISOString();
+        mockPoolQuery.mockResolvedValueOnce({
+            rows: [{ id: 'abc', cancelled_at: cancelIso }],
+        });
+        const res = await del('/api/scheduled-messages/abc')
+            .send({ deviceId, deviceSecret });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.id).toBe('abc');
+        expect(typeof res.body.cancelledAt).toBe('number');
+        // UPDATE must guard against already-sent/cancelled rows
+        const sqlArg = mockPoolQuery.mock.calls[mockPoolQuery.mock.calls.length - 1][0];
+        expect(sqlArg).toMatch(/sent_at IS NULL/);
+        expect(sqlArg).toMatch(/cancelled_at IS NULL/);
+    });
+
+    it('returns 404 when row is already sent', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+        const res = await del('/api/scheduled-messages/abc')
+            .send({ deviceId, deviceSecret });
+        expect(res.status).toBe(404);
+    });
+});
+
+// ═══════════════════════════════════════════════════════════
+// pollAndFire() smoke
+// ═══════════════════════════════════════════════════════════
+describe('pollAndFire() background dispatch', () => {
+    it('claims due rows and dispatches via saveChatMessage + pushToBot', async () => {
+        // The poller runs a single UPDATE ... RETURNING query that claims
+        // all due rows and flips their sent_at in one atomic step.
+        mockPoolQuery.mockResolvedValueOnce({
+            rows: [{
+                id: 'claim-1',
+                device_id: deviceId,
+                chat_entity_id: 0,
+                user_entity_id: 0,
+                target_entity_ids: [0, 2],
+                content: 'scheduled hello',
+                scheduled_at: new Date(Date.now() - 1000).toISOString(),
+                sent_at: new Date().toISOString(),
+            }],
+        });
+
+        const result = await smModule.pollAndFire();
+        expect(result.claimed).toBe(1);
+        expect(result.dispatched).toBe(1);
+
+        // saveChatMessage called once per target entity (2 targets)
+        expect(mockSaveChat).toHaveBeenCalledTimes(2);
+        expect(mockSaveChat).toHaveBeenCalledWith(
+            deviceId, 0, 'scheduled hello', 'scheduled', true, false,
+            null, null, null, 'scheduled'
+        );
+
+        // Entity 0 has webhook → pushToBot called
+        expect(mockPushToBot).toHaveBeenCalledTimes(1);
+        // Entity 2 is channel-bound → unifiedPush called
+        expect(mockUnifiedPush).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns {claimed: 0} when no rows are due', async () => {
+        mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+        const result = await smModule.pollAndFire();
+        expect(result.claimed).toBe(0);
+        expect(result.dispatched).toBe(0);
+        expect(mockSaveChat).not.toHaveBeenCalled();
+    });
+
+    it('tolerates device not present (does not throw)', async () => {
+        mockPoolQuery.mockResolvedValueOnce({
+            rows: [{
+                id: 'claim-2',
+                device_id: 'ghost-device',
+                chat_entity_id: 0,
+                user_entity_id: 0,
+                target_entity_ids: [0],
+                content: 'for ghost',
+                scheduled_at: new Date().toISOString(),
+                sent_at: new Date().toISOString(),
+            }],
+        });
+        // The second call is the last_error UPDATE inside dispatchRow
+        mockPoolQuery.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+        const result = await smModule.pollAndFire();
+        expect(result.claimed).toBe(1);
+        expect(result.dispatched).toBe(1);
+        expect(mockSaveChat).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary
Phase 1 backend for user-scheduled messages (card_aa55c721b512c1d10288f1e9). Lets users queue a chat message to be dispatched at a future scheduled time by a server-side background poller. UI lands in Phase 2.

- `scheduled_messages_schema.sql` — new table with pending-index + 1..10000 char content check.
- `scheduled-messages.js` — factory module: 4 CRUD endpoints + atomic claim-and-dispatch poller.
- `index.js` — wires the module, starts the poller (guarded off in `NODE_ENV=test`), and surfaces the endpoint in `/api/help` general intent.
- Jest: 22 new cases covering auth, POST validation (past time / >7 day / length / unknown entity), GET filter, PUT/DELETE guards, and poller smoke.

## Endpoints (all `deviceSecret`-authed — user action)
| Method | Path | Purpose |
|---|---|---|
| POST | `/api/scheduled-messages` | Create (body: `deviceId, deviceSecret, chatEntityId, userEntityId, targetEntityIds[], content, scheduledAt`) |
| GET  | `/api/scheduled-messages?chatEntityId=` | List pending (unsent, uncancelled) |
| PUT  | `/api/scheduled-messages/:id` | Update `content` / `scheduledAt` / `targetEntityIds` (pre-send only) |
| DELETE | `/api/scheduled-messages/:id` | Cancel (sets `cancelled_at`, pre-send only) |

Validation: `scheduledAt` must be future + ≤7 days ahead; content 1..10000 chars; each `targetEntityIds` id must exist on the device (id 0 always allowed).

## Poller
Every 5s, a single atomic statement claims due rows and flips `sent_at` in one shot:
```sql
UPDATE scheduled_messages SET sent_at = NOW()
 WHERE id IN (
   SELECT id FROM scheduled_messages
    WHERE sent_at IS NULL AND cancelled_at IS NULL AND scheduled_at <= NOW()
    ORDER BY scheduled_at LIMIT 50 FOR UPDATE SKIP LOCKED
 )
RETURNING …
```
Each claimed row is dispatched via injected `saveChatMessage` (source `scheduled`, `is_from_user=true`) and — if the target entity is bound — `pushToBot` (webhook) or `unifiedPush` (channel). Dispatch failures are captured in `last_error` (no infinite retry; fire-once semantics).

## Local test run
```
$ npx jest tests/jest/scheduled-messages.test.js
Tests:       22 passed, 22 total
```

## E2E smoke (to run post-deploy)
Using `BROADCAST_TEST_DEVICE_ID` / `BROADCAST_TEST_DEVICE_SECRET` (live prod):
```bash
# 1. POST — create
curl -s -X POST "https://eclawbot.com/api/scheduled-messages" \
  -H "Content-Type: application/json" \
  -d "{\"deviceId\":\"$DEV_ID\",\"deviceSecret\":\"$DEV_SECRET\",\"chatEntityId\":0,\"userEntityId\":0,\"targetEntityIds\":[0],\"content\":\"smoke-test\",\"scheduledAt\":\"$(date -u -v+2M +%Y-%m-%dT%H:%M:%SZ)\"}"
# → {"success":true,"id":"<uuid>","scheduledAt":<ms>}

# 2. GET — list pending
curl -s "https://eclawbot.com/api/scheduled-messages?deviceId=$DEV_ID&deviceSecret=$DEV_SECRET&chatEntityId=0"
# → {"success":true,"messages":[{...}]}

# 3. PUT — reschedule
curl -s -X PUT "https://eclawbot.com/api/scheduled-messages/<uuid>" \
  -H "Content-Type: application/json" \
  -d "{\"deviceId\":\"$DEV_ID\",\"deviceSecret\":\"$DEV_SECRET\",\"content\":\"smoke-test-updated\"}"
# → {"success":true,"message":{...}}

# 4. DELETE — cancel
curl -s -X DELETE "https://eclawbot.com/api/scheduled-messages/<uuid>" \
  -H "Content-Type: application/json" \
  -d "{\"deviceId\":\"$DEV_ID\",\"deviceSecret\":\"$DEV_SECRET\"}"
# → {"success":true,"id":"<uuid>","cancelledAt":<ms>}
```
The commander will run these once Railway redeploys after merge and append the actual responses to card `card_aa55c721b512c1d10288f1e9`.

## Out of scope for this PR
- UI (modal / list / dialogs) — Phase 2 follow-up.
- Retry on delivery failure — spec opts for fire-once + `last_error` observability.
- Multi-tenant metering or subscription gating — not required for Phase 1.

## Test plan
- [x] `npx jest tests/jest/scheduled-messages.test.js` — 22 pass
- [x] `npm run lint` — no new errors
- [x] `node scripts/i18n-check.js` — no new i18n refs
- [ ] Post-merge: Railway deploy + 4 curl smoke run above
- [ ] Post-merge: verify poller log line `[ScheduledMessages] Poller started` appears in Railway logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)