### PR TITLE
feat(ui): unify 📌 quote icon across chat bubbles + kanban card comments

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -4032,7 +4032,7 @@
 
                 const replySnippet = stripReplyQuotePrefix(rawText || '').replace(/\n/g, ' ').slice(0, 120);
                 const replySenderName = isSent ? (i18n.t('chat_reply_you') || 'You') : isPlatform ? 'Platform' : (getEntityLabel(msg.entity_id) || '');
-                const replyBtnHtml = msg.id ? `<button class="chat-reply-btn" data-msg-id="${escapeHtml(msg.id)}" data-sender="${escapeHtml(replySenderName)}" data-text="${escapeHtml(replySnippet)}" onclick="handleReplyBtn(this);event.stopPropagation()" data-i18n-title="chat_reply_btn" title="Reply">↩</button>` : '';
+                const replyBtnHtml = msg.id ? `<button class="chat-reply-btn" data-msg-id="${escapeHtml(msg.id)}" data-sender="${escapeHtml(replySenderName)}" data-text="${escapeHtml(replySnippet)}" onclick="handleReplyBtn(this);event.stopPropagation()" data-i18n-title="chat_reply_btn" title="Quote">📌</button>` : '';
 
                 return `${dateSep}${unreadSep}
                     <div class="chat-msg ${msgClass}${isGrouped ? ' grouped' : ''}" data-message-id="${escapeHtml(msg.id || '')}" style="position:relative">

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -132,7 +132,11 @@
         .kb-comment.sent .kb-comment-bubble { background:var(--primary); color:#fff; border-bottom-right-radius:4px; }
         .kb-comment.received .kb-comment-bubble { background:var(--input-bg); border:1px solid var(--card-border); border-bottom-left-radius:4px; }
         .kb-comment.system-msg .kb-comment-bubble { background:none; color:var(--text-secondary); font-style:italic; font-size:12px; text-align:center; padding:4px 0; }
-        .kb-comment-time { font-size:10px; color:var(--text-muted); margin-top:2px; }
+        .kb-comment-time { font-size:10px; color:var(--text-muted); }
+        .kb-comment-row { display:flex; align-items:center; gap:6px; margin-top:2px; }
+        .kb-comment.sent .kb-comment-row { flex-direction:row-reverse; }
+        .kb-comment-pin { background:none; border:none; padding:0; margin:0; font-size:13px; cursor:pointer; opacity:0.5; transition:opacity 0.15s; line-height:1; }
+        .kb-comment-pin:hover { opacity:1; }
         .kb-comment-input { display:flex; gap:8px; margin-top:12px; }
         .kb-comment-input textarea { flex:1; background:var(--input-bg); border:1px solid var(--card-border); border-radius:var(--radius-sm); padding:8px 12px; color:var(--text); font-size:13px; resize:vertical; min-height:60px; font-family:inherit; }
         .kb-comment-input button { align-self:flex-end; }
@@ -1503,6 +1507,14 @@
             quoteToChat('看板卡片', title, meta);
         }
 
+        function quoteCommentToChat(payload) {
+            if (!payload) return;
+            const src = payload.src || '留言';
+            const sender = payload.sender || '';
+            const text = (payload.text || '').replace(/\s+/g, ' ').slice(0, 80);
+            quoteToChat(src, sender, text);
+        }
+
         // ── Inline Schedule Panel (detail modal tab) ──
         function renderSchedulePanel(cardId) {
             const card = findCard(cardId);
@@ -1684,10 +1696,16 @@
                     const avatar = typeof getAvatarForEntity === 'function' ? getAvatarForEntity(c.from_entity_id) : '🦞';
                     const name = typeof getEntityDisplayName === 'function' ? getEntityDisplayName(c.from_entity_id) : '#'+(c.from_entity_id??'?');
                     const avatarHtml = typeof renderAvatarHtml === 'function' ? renderAvatarHtml(avatar, 16) : avatar;
+                    const cardTitle = (findCard(openCardId) || {}).title || '';
+                    const pinPayload = JSON.stringify({ src: '留言 · ' + cardTitle, sender: name, text: c.text || '' })
+                        .replace(/'/g, '&#39;');
                     return `<div class="kb-comment ${isSent ? 'sent' : 'received'}">
                         <div class="kb-comment-source"><span class="comment-avatar">${avatarHtml}</span> ${escapeHtml(name)}</div>
                         <div class="kb-comment-bubble">${escapeHtml(c.text)}</div>
-                        <div class="kb-comment-time">${formatTime(c.created_at)}</div>
+                        <div class="kb-comment-row">
+                            <button class="kb-comment-pin" onclick='quoteCommentToChat(${pinPayload})' title="引用到聊天">📌</button>
+                            <span class="kb-comment-time">${formatTime(c.created_at)}</span>
+                        </div>
                     </div>`;
                 }).join('');
 


### PR DESCRIPTION
## Summary
- chat.html per-bubble reply button: `↩` → `📌` (same handler, same `his_<uuid>` token). Aligns visually with the 📌 button already present on mission/files/card-holder/community/kanban surfaces.
- kanban.html card-detail comments tab: new inline `📌` chip next to each comment's timestamp; click quotes the comment (source = card title, sender = commenter) through the existing `quoteToChat` cross-surface bridge (localStorage + postMessage → chat.html).

Closes card `card_c9baef2485043b568b511096` ([F] 📌 引用功能擴展到各視窗 chip).

## Why this scope
Minimal delivery that satisfies Hank's spec "每個 chip 長按或點擊 📌 都能產出引用 token" — the two gaps were chat bubbles (using `↩` not `📌`) and kanban comments (no quote button at all).

Hardcoded zh-TW `引用到聊天` tooltip on the kanban comment pin rather than adding a new i18n key; avoids a 15-locale backfill for a trivial hover label.

## Out of scope (→ Phase 2 card)
"Clickable source-back chip for non-chat quotes" — today a quote from a kanban comment or mission dialog lands in chat as a literal text prefix (`↩ 📌 <source>: "<excerpt>"`). Phase 2 would give it a recognizable source token that the receiver renders as a link-chip (same idea as `his_<uuid>` → HisLinkRender, or existing `card_<shortId>` auto-link). Filed as follow-up.

## Test plan
- [ ] chat.html: bubble shows 📌 (not ↩); clicking opens reply preview bar with sender + excerpt
- [ ] kanban.html: open any card's Comments tab — each non-system comment has a 📌 chip on the right (sent rows) or left (received rows); click bridges to chat.html with prefilled reply preview
- [ ] Playwright web viewport + mobile viewport screenshots captured
- [ ] CI green
- [ ] i18n-check passes (no new orphans — no new keys added)
- [ ] Jest 2221/2221 passing locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)