### PR TITLE
fix(kanban): cap long card description height in detail modal

### DIFF
--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -112,6 +112,7 @@
         .kb-btn-quote-chat:hover { background:var(--primary,#3b82f6); color:#fff; }
         .kb-modal-meta { padding:12px 24px; display:flex; gap:12px; flex-wrap:wrap; font-size:12px; color:var(--text-secondary); border-bottom:1px solid var(--card-border); }
         .kb-modal-meta .meta-item { display:flex; align-items:center; gap:4px; }
+        .kb-detail-desc { width:100%; font-size:13px; color:var(--text-secondary); margin-top:8px; white-space:pre-wrap; word-break:break-word; max-height:30vh; overflow-y:auto; overscroll-behavior:contain; padding-right:4px; }
 
         /* Modal tabs */
         .kb-modal-tabs { display:flex; gap:0; padding:0 24px; border-bottom:1px solid var(--card-border); }
@@ -1239,7 +1240,7 @@
                 ${reviewerName ? `<span class="meta-item">🔍 ${escapeHtml(reviewerName)}</span>` : ''}
                 <span class="meta-item">🕐 ${formatTime(card.createdAt || card.created_at)}</span>
                 ${scheduleInfo}
-                ${card.description ? '<div style="width:100%;font-size:13px;color:var(--text-secondary);margin-top:8px;white-space:pre-wrap;word-break:break-word">'+escapeHtml(card.description)+'</div>' : ''}
+                ${card.description ? '<div class="kb-detail-desc">'+escapeHtml(card.description)+'</div>' : ''}
             `;
 
             // Move bar — shared assign + reviewer UI for all cards


### PR DESCRIPTION
## Summary
- Long kanban card descriptions (2000+ char) pushed comments tab + move bar off-screen in the detail modal (`.kb-modal` has `max-height:85vh; overflow-y:auto` but users couldn't find the scroll).
- Move description into `.kb-detail-desc` with `max-height:30vh; overflow-y:auto; overscroll-behavior:contain` so tabs/comments/move-bar stay visible on first open and description scrolls within its own region.

## Why
Card `card_72415aeb` (P2 UX): 看板卡片內容過長時留言區無法捲動到. Reproduced against the live `card_6ff59619` (2151-char description) in local Playwright harness — comments panel was entirely below the fold before; visible without any modal scroll after.

## Test plan
- [x] Playwright viewport 1280×800: before screenshot shows 15+ description lines filling modal, no comments visible; after screenshot shows description capped at ~30vh with its own scrollbar, comments tab + first 2 bubbles + input textarea all visible
- [ ] Prod smoke: open any card with >1500 char description → description scrolls independently, tabs reachable without scrolling modal
- [ ] Mobile (≤768px): description 30vh cap still works within `flex:1` panel layout

## Out of scope
- Smart Chip / autolink rendering of description text (separate card `card_1f038480`)
- Refactor of `#detailMeta.innerHTML` template into a component (separate card `card_e9cf8052`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)