### PR TITLE
feat: 智慧引用 Card A — render review_ / src:// as 引用晶片

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -2067,6 +2067,32 @@
             filter: brightness(1.3);
         }
 
+        /* ── 引用晶片 / Autolink Chip (review_, src://) ── */
+        .autolink-chip {
+            display: inline-block;
+            padding: 1px 8px;
+            border-radius: 10px;
+            font-weight: 600;
+            font-size: 0.92em;
+            cursor: pointer;
+            transition: filter 0.15s, transform 0.1s;
+            font-family: 'SF Mono', 'Fira Code', monospace;
+            user-select: none;
+            border: 1px solid transparent;
+        }
+        .autolink-chip:hover { filter: brightness(1.3); transform: translateY(-1px); }
+        .autolink-chip:active { transform: translateY(0); }
+        .autolink-chip--review {
+            background: rgba(250, 204, 21, 0.18);
+            color: #facc15;
+            border-color: rgba(250, 204, 21, 0.35);
+        }
+        .autolink-chip--src {
+            background: rgba(168, 85, 247, 0.18);
+            color: #c084fc;
+            border-color: rgba(168, 85, 247, 0.35);
+        }
+
         /* ── Entity Preview Modal ── */
         #entityPreviewModal .modal-box {
             max-width: 600px;
@@ -2501,6 +2527,7 @@
     <script src="shared/note-link-render.js"></script>
     <script src="shared/entity-link-render.js"></script>
     <script src="shared/his-link-render.js"></script>
+    <script src="shared/autolink-chip.js"></script>
     <script src="shared/r2-link-render.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
@@ -3882,6 +3909,10 @@
                     // Render his_<id> history tokens as clickable chips
                     if (window.HisLinkRender) {
                         textHtml = HisLinkRender.renderHisLinks(textHtml);
+                    }
+                    // 智慧引用：detect review_ / src:// tokens → 引用晶片 (autolink-chip)
+                    if (window.AutolinkChip) {
+                        textHtml = AutolinkChip.render(textHtml);
                     }
                     // Strip raw R2 presigned URLs — replace with attachment cards so
                     // that access-key IDs and 10-minute bearer tokens never reach the DOM.

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -114,6 +114,17 @@
         .kb-modal-meta .meta-item { display:flex; align-items:center; gap:4px; }
         .kb-detail-desc { width:100%; font-size:13px; color:var(--text-secondary); margin-top:8px; white-space:pre-wrap; word-break:break-word; max-height:30vh; overflow-y:auto; overscroll-behavior:contain; padding-right:4px; }
 
+        /* 智慧引用 / Smart-chip base + autolink-chip variants */
+        .entity-link, .note-link, .autolink-chip {
+            display:inline-block; padding:1px 8px; border-radius:10px; font-weight:600; font-size:0.92em;
+            cursor:pointer; font-family:'SF Mono','Fira Code',monospace; user-select:none;
+            border:1px solid transparent; transition:filter .15s, transform .1s;
+        }
+        .entity-link:hover, .note-link:hover, .autolink-chip:hover { filter:brightness(1.3); transform:translateY(-1px); }
+        .note-link { background:rgba(52,211,153,0.18); color:#34d399; border-color:rgba(52,211,153,0.35); }
+        .autolink-chip--review { background:rgba(250,204,21,0.18); color:#facc15; border-color:rgba(250,204,21,0.35); }
+        .autolink-chip--src { background:rgba(168,85,247,0.18); color:#c084fc; border-color:rgba(168,85,247,0.35); }
+
         /* Modal tabs */
         .kb-modal-tabs { display:flex; gap:0; padding:0 24px; border-bottom:1px solid var(--card-border); }
         .kb-modal-tab { padding:10px 16px; font-size:13px; font-weight:600; color:var(--text-secondary); background:none; border:none; border-bottom:2px solid transparent; cursor:pointer; }
@@ -750,6 +761,9 @@
     <script src="shared/nav.js"></script>
     <script src="shared/auth.js"></script>
     <script src="shared/entity-utils.js"></script>
+    <script src="shared/entity-link-render.js"></script>
+    <script src="shared/note-link-render.js"></script>
+    <script src="shared/autolink-chip.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
     <script src="/socket.io/socket.io.js"></script>
@@ -771,6 +785,15 @@
     <script src="shared/ai-chat.js"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'🦞'};window.isAvatarUrl=function(){return false}}</script>
     <script>
+        // 智慧引用 render chain — escape text then apply entity-link / note-link / autolink-chip
+        function renderSmartChips(rawText) {
+            if (rawText == null) return '';
+            let html = escapeHtml(String(rawText));
+            if (window.EntityLinkRender) html = EntityLinkRender.renderEntityLinks(html);
+            if (window.NoteLinkRender)   html = NoteLinkRender.renderNoteLinks(html);
+            if (window.AutolinkChip)     html = AutolinkChip.render(html);
+            return html;
+        }
         const STATUSES = ['backlog','todo','in_progress','review','done'];
         const STATUS_LABELS = {backlog:'Backlog',todo:'TODO',in_progress:'In Progress',review:'Review',done:'Done'};
         const STATUS_I18N = {backlog:'kb_col_backlog',todo:'kb_col_todo',in_progress:'kb_col_in_progress',review:'kb_col_review',done:'kb_col_done'};
@@ -1004,7 +1027,7 @@
                     <span class="kb-card-assigned">${renderAssignedAvatars(card.assignedBots)}</span>
                 </div>
                 <div class="kb-card-title">${escapeHtml(card.title)}</div>
-                ${card.description ? '<div class="kb-card-desc">'+escapeHtml(card.description)+'</div>' : ''}
+                ${card.description ? '<div class="kb-card-desc">'+renderSmartChips(card.description)+'</div>' : ''}
                 <div class="kb-card-footer">
                     ${commentCount ? '<span>💬 '+commentCount+'</span>' : ''}
                     ${noteCount ? '<span>📝 '+noteCount+'</span>' : ''}
@@ -1240,7 +1263,7 @@
                 ${reviewerName ? `<span class="meta-item">🔍 ${escapeHtml(reviewerName)}</span>` : ''}
                 <span class="meta-item">🕐 ${formatTime(card.createdAt || card.created_at)}</span>
                 ${scheduleInfo}
-                ${card.description ? '<div class="kb-detail-desc">'+escapeHtml(card.description)+'</div>' : ''}
+                ${card.description ? '<div class="kb-detail-desc">'+renderSmartChips(card.description)+'</div>' : ''}
             `;
 
             // Move bar — shared assign + reviewer UI for all cards
@@ -1689,7 +1712,7 @@
                 const commentsHtml = comments.map(c => {
                     if (c.is_system) {
                         return `<div class="kb-comment system-msg">
-                            <div class="kb-comment-bubble">${escapeHtml(c.text)}</div>
+                            <div class="kb-comment-bubble">${renderSmartChips(c.text)}</div>
                             <div class="kb-comment-time">${formatTime(c.created_at)}</div>
                         </div>`;
                     }
@@ -1702,7 +1725,7 @@
                         .replace(/'/g, '&#39;');
                     return `<div class="kb-comment ${isSent ? 'sent' : 'received'}">
                         <div class="kb-comment-source"><span class="comment-avatar">${avatarHtml}</span> ${escapeHtml(name)}</div>
-                        <div class="kb-comment-bubble">${escapeHtml(c.text)}</div>
+                        <div class="kb-comment-bubble">${renderSmartChips(c.text)}</div>
                         <div class="kb-comment-row">
                             <button class="kb-comment-pin" onclick='quoteCommentToChat(${pinPayload})' title="引用到聊天">📌</button>
                             <span class="kb-comment-time">${formatTime(c.created_at)}</span>

--- a/backend/public/portal/shared/autolink-chip.js
+++ b/backend/public/portal/shared/autolink-chip.js
@@ -1,0 +1,168 @@
+/**
+ * AutolinkChip — detect NEW reference prefixes in already-escaped HTML and
+ * render them as clickable 引用晶片 (reference chips).
+ *
+ * Recognised prefixes (this module owns):
+ *   1. review_<6+ alnum>     — agent review
+ *   2. src://<kind>/<type>/<id>[#anchor]  — source-anchor token
+ *
+ * NOT handled here (existing modules already own these):
+ *   - card_<hex>      → EntityLinkRender (entity-link-render.js)
+ *   - skill_/rule_/listing_/exam_/contract_ → EntityLinkRender
+ *   - note_<24hex>    → NoteLinkRender
+ *   - @mention        → MentionRender
+ *   - his_<uuid>      → HisLinkRender
+ *
+ * Must run AFTER EntityLinkRender / NoteLinkRender / HisLinkRender in the
+ * render pipeline so their spans' inner text ("card_abc123") isn't re-matched.
+ *
+ * All inputs are expected to be already-escaped HTML (post-DOMPurify or
+ * post-escapeHtml), consistent with the other render modules.
+ *
+ * Subsequent cards (B: preview popover, C: recursive, D: backend expansion)
+ * extend this module — do not rename public surface.
+ */
+(function (global) {
+    'use strict';
+
+    const REVIEW_RE      = /\breview_([a-zA-Z0-9_-]{6,})\b/g;
+    const CODE_REVIEW_RE = /<code[^>]*>\s*review_([a-zA-Z0-9_-]{6,})\s*<\/code>/g;
+    const SRC_RE         = /\bsrc:\/\/([a-z]+)\/([a-z]+)\/([a-f0-9]{8,})(#[a-z0-9-]+)?\b/gi;
+    const CODE_SRC_RE    = /<code[^>]*>\s*src:\/\/([a-z]+)\/([a-z]+)\/([a-f0-9]{8,})(#[a-z0-9-]+)?\s*<\/code>/gi;
+
+    const PLACEHOLDER_PREFIX = '\x00AUTOCHIP[';
+    const PLACEHOLDER_SUFFIX = ']\x00';
+    const pending = [];
+
+    function queue(refType, refId, label, extra) {
+        const idx = pending.length;
+        pending.push({ refType, refId, label, extra: extra || null });
+        return `${PLACEHOLDER_PREFIX}${idx}${PLACEHOLDER_SUFFIX}`;
+    }
+
+    function flush(html) {
+        const out = html.replace(/\x00AUTOCHIP\[(\d+)\]\x00/g, (_m, idx) => {
+            const c = pending[parseInt(idx, 10)];
+            return buildChipHtml(c.refType, c.refId, c.label, c.extra);
+        });
+        pending.length = 0;
+        return out;
+    }
+
+    function buildChipHtml(refType, refId, label, extra) {
+        const dataset = [
+            `data-ref-type="${escapeAttr(refType)}"`,
+            `data-ref-id="${escapeAttr(refId)}"`,
+            `data-ref-label="${escapeAttr(label)}"`,
+            extra && extra.anchor ? `data-ref-anchor="${escapeAttr(extra.anchor)}"` : ''
+        ].filter(Boolean).join(' ');
+        const icon = refType === 'review' ? '⭐'
+                    : refType === 'src' ? '📍'
+                    : '🔗';
+        return `<span class="autolink-chip autolink-chip--${escapeAttr(refType)}" ${dataset} onclick="AutolinkChip.onChipClick(this, event)" title="${escapeAttr(refType)}:${escapeAttr(refId)}">${icon} ${escapeAttr(label)}</span>`;
+    }
+
+    function escapeAttr(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;')
+            .replace(/"/g, '&quot;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;');
+    }
+
+    /**
+     * Replace review_ and src:// references in already-escaped HTML with
+     * autolink-chip spans. Safe against <code>/<pre> blocks and any spans
+     * already produced by upstream renderers (entity-link / note-link / his-link).
+     */
+    function render(escapedHtml) {
+        if (!escapedHtml || typeof escapedHtml !== 'string') return escapedHtml;
+        let html = escapedHtml;
+
+        // Phase -1: <code>review_xxx</code> / <code>src://...</code> → chip (consumes the code wrapper)
+        html = html.replace(CODE_REVIEW_RE, (_m, slug) => {
+            const id = 'review_' + slug;
+            return queue('review', id, shortLabel(id));
+        });
+        html = html.replace(CODE_SRC_RE, (_m, kind, type, id, anchor) => {
+            const full = `src://${kind}/${type}/${id}${anchor || ''}`;
+            return queue('src', full, shortLabel(full), { anchor: anchor || null });
+        });
+
+        // Split out <code>/<pre> blocks AND existing chip spans so bare patterns
+        // don't touch already-rendered chips or literal code.
+        const SPLIT_RE = /(<code[\s>][\s\S]*?<\/code>|<pre[\s>][\s\S]*?<\/pre>|<span\s+class="(?:entity-link|note-link|his-link|mention-chip)[^"]*"[\s\S]*?<\/span>)/gi;
+        const parts = html.split(SPLIT_RE);
+        for (let i = 0; i < parts.length; i++) {
+            if (i % 2 === 1) continue; // skipped block
+            let p = parts[i];
+            p = p.replace(REVIEW_RE, (_m, slug) => {
+                const id = 'review_' + slug;
+                return queue('review', id, shortLabel(id));
+            });
+            p = p.replace(SRC_RE, (_m, kind, type, id, anchor) => {
+                const full = `src://${kind}/${type}/${id}${anchor || ''}`;
+                return queue('src', full, shortLabel(full), { anchor: anchor || null });
+            });
+            parts[i] = p;
+        }
+
+        return flush(parts.join(''));
+    }
+
+    function shortLabel(fullId) {
+        const r = /^review_(.{1,12})/.exec(fullId);
+        if (r) return 'review_' + r[1] + (fullId.length > r[0].length ? '…' : '');
+        if (fullId.startsWith('src://')) {
+            // src://kanban/card/<24hex>#comment-<uuid> → src://kanban/card_<8hex>…
+            const s = /^src:\/\/([a-z]+)\/([a-z]+)\/([a-f0-9]{8})/.exec(fullId);
+            if (s) return `src://${s[1]}/${s[2]}_${s[3].slice(0, 4)}…`;
+        }
+        return fullId.length > 18 ? fullId.slice(0, 16) + '…' : fullId;
+    }
+
+    /**
+     * Default click handler — delegates to preview opener if registered
+     * (Card B), otherwise deep-links to the target surface.
+     */
+    function onChipClick(el, ev) {
+        if (ev && ev.stopPropagation) ev.stopPropagation();
+        const refType = el.getAttribute('data-ref-type');
+        const refId = el.getAttribute('data-ref-id');
+        if (!refType || !refId) return;
+
+        // Preview handler wins if installed (Card B will register this)
+        if (typeof global.AutolinkChipPreview === 'function') {
+            try {
+                global.AutolinkChipPreview(refType, refId, el);
+                return;
+            } catch (e) { /* fall through to deep-link */ }
+        }
+
+        // Fallback deep-link (Card A default behaviour — simple navigation)
+        const url = deepLinkUrl(refType, refId, el.getAttribute('data-ref-anchor'));
+        if (url) window.location.href = url;
+    }
+
+    function deepLinkUrl(refType, refId, anchor) {
+        if (refType === 'review') return `/portal/reviews.html#${refId}`;
+        if (refType === 'src') {
+            // src://kanban/card/<id>#anchor → /portal/kanban.html#card_<id>[anchor]
+            const m = /^src:\/\/([a-z]+)\/([a-z]+)\/([a-f0-9]{8,})(#.+)?$/i.exec(refId);
+            if (m) {
+                const surface = m[1] === 'kanban' ? 'kanban.html' : `${m[1]}.html`;
+                return `/portal/${surface}#${m[2]}_${m[3]}${m[4] || ''}`;
+            }
+        }
+        return null;
+    }
+
+    global.AutolinkChip = {
+        render,
+        onChipClick,
+        deepLinkUrl,
+        // internal — exposed for unit testing only
+        _escapeAttr: escapeAttr,
+        _shortLabel: shortLabel
+    };
+})(window);

--- a/backend/tests/jest/autolink-chip.test.js
+++ b/backend/tests/jest/autolink-chip.test.js
@@ -1,0 +1,111 @@
+/**
+ * AutolinkChip unit tests — verifies review_ and src:// prefix detection in
+ * already-escaped HTML produces 引用晶片 (autolink-chip) spans.
+ *
+ * Loads the browser module into a stubbed global so we can exercise its
+ * public API (render / onChipClick / deepLinkUrl) without a DOM.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadAutolinkChip() {
+    const src = fs.readFileSync(
+        path.join(__dirname, '../../public/portal/shared/autolink-chip.js'),
+        'utf8'
+    );
+    const sandbox = { window: {}, global: {} };
+    sandbox.window.AutolinkChipPreview = undefined;
+    // The module IIFE uses `(function(global){...})(window)` — point global at sandbox.window
+    vm.createContext(sandbox);
+    vm.runInContext(src, sandbox);
+    return sandbox.window.AutolinkChip;
+}
+
+describe('AutolinkChip.render', () => {
+    const AutolinkChip = loadAutolinkChip();
+
+    test('review_ prefix becomes an autolink-chip--review span', () => {
+        const out = AutolinkChip.render('See review_abc123456 for details');
+        expect(out).toMatch(/<span class="autolink-chip autolink-chip--review"/);
+        expect(out).toMatch(/data-ref-type="review"/);
+        expect(out).toMatch(/data-ref-id="review_abc123456"/);
+    });
+
+    test('src:// token becomes an autolink-chip--src span with anchor attr', () => {
+        const out = AutolinkChip.render(
+            'see src://kanban/card/f6321df2aaa0#comment-xyz plz'
+        );
+        expect(out).toMatch(/autolink-chip--src/);
+        expect(out).toMatch(/data-ref-id="src:\/\/kanban\/card\/f6321df2aaa0#comment-xyz"/);
+        expect(out).toMatch(/data-ref-anchor="#comment-xyz"/);
+    });
+
+    test('card_ prefix is NOT handled (EntityLinkRender owns it)', () => {
+        const out = AutolinkChip.render('touching card_f6321df2 today');
+        expect(out).not.toMatch(/autolink-chip--card/);
+        // bare text preserved so EntityLinkRender can act on it upstream
+        expect(out).toMatch(/card_f6321df2/);
+    });
+
+    test('<code>review_xxx</code> is consumed into chip (code wrapper stripped)', () => {
+        const out = AutolinkChip.render('done <code>review_hotfix_apr25</code> ok');
+        expect(out).toMatch(/autolink-chip--review/);
+        // The <code> wrapper should be gone
+        expect(out).not.toMatch(/<code>review_hotfix/);
+    });
+
+    test('tokens inside <code>/<pre> blocks are preserved as literal text', () => {
+        const out = AutolinkChip.render(
+            'example: <code>SOURCE: src://kanban/card/abcdef12</code>'
+        );
+        // The src:// inside code must NOT be chipped
+        expect(out).toMatch(/<code>SOURCE: src:\/\/kanban\/card\/abcdef12<\/code>/);
+        expect(out).not.toMatch(/autolink-chip--src/);
+    });
+
+    test('existing entity-link spans are not double-wrapped', () => {
+        // Simulate output after EntityLinkRender has already acted on card_xxx
+        const upstream =
+            'link <span class="entity-link entity-link-card" data-entity-id="card_f6321df2">card_f6321df2</span> and review_abc12345';
+        const out = AutolinkChip.render(upstream);
+        // Only the review_ should become a chip; the card span stays intact
+        expect(out).toMatch(/<span class="entity-link entity-link-card"[^>]*>card_f6321df2<\/span>/);
+        expect(out).toMatch(/autolink-chip--review/);
+    });
+
+    test('empty / non-string input passes through', () => {
+        expect(AutolinkChip.render('')).toBe('');
+        expect(AutolinkChip.render(null)).toBeNull();
+        expect(AutolinkChip.render(undefined)).toBeUndefined();
+    });
+
+    test('shortLabel truncates long src:// ids', () => {
+        const out = AutolinkChip.render('src://kanban/card/d3cdda1455152e3caee8d4ac#comment-alpha');
+        expect(out).toMatch(/src:\/\/kanban\/card_d3cd…/);
+    });
+});
+
+describe('AutolinkChip.deepLinkUrl', () => {
+    const AutolinkChip = loadAutolinkChip();
+
+    test('review_ → /portal/reviews.html#<id>', () => {
+        expect(AutolinkChip.deepLinkUrl('review', 'review_abc12345', null))
+            .toBe('/portal/reviews.html#review_abc12345');
+    });
+
+    test('src://kanban/card/<id>#anchor → /portal/kanban.html#card_<id>#anchor', () => {
+        const url = AutolinkChip.deepLinkUrl(
+            'src',
+            'src://kanban/card/f6321df2aaa0#comment-xyz',
+            '#comment-xyz'
+        );
+        expect(url).toBe('/portal/kanban.html#card_f6321df2aaa0#comment-xyz');
+    });
+
+    test('unknown ref type returns null', () => {
+        expect(AutolinkChip.deepLinkUrl('wat', 'anything', null)).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary
- 首張卡，智慧引用功能啟動：聊天 & 看板訊息裡的 \`review_xxx\` 和 \`src://kanban/card/...#anchor\` 自動變成可點擊的彩色小方塊（引用晶片）。
- 點擊會預先呼叫 window.AutolinkChipPreview（下一張卡 B 會接上預覽浮窗），沒預覽時直接跳轉。
- 卡 B、C、D、E 會疊上來；這張先把 chip 的骨架和測試補齊。

## 不涵蓋（刻意不動）
- \`card_\`、\`skill_\`、\`rule_\` 等原本已經由 entity-link-render.js 處理 → 不重複處理，避免雙層 chip。
- \`note_\` / \`@mention\` / \`his_\` 仍由原有 render 模組負責。

## 視覺驗證
見 \`/tmp/autolink-test/harness.html\` Playwright 快照 — review_ 黃晶片 ⭐、src:// 紫晶片 📍 正確渲染；\`<code>\` 與 \`<pre>\` 區塊裡的 token 不會被處理。

## Test plan
- [x] 新增 11 支 Jest 單測（review_、src://、code-wrapper 吞噬、code-block 內不處理、不與 entity-link span 雙層包覆、長 id 截斷、deepLinkUrl 路由）全綠。
- [x] 靜態 harness.html 在 Playwright 驗證 5 種訊息形態都正確渲染。
- [ ] Staging smoke：聊天送一條 \`review_demo_apr25\` 和 \`src://kanban/card/<real-id>\`，確認可點、hover 有色變。
- [ ] 看板開啟任何有 src:// reference 的卡，確認說明與留言中的 token 變晶片。

🤖 Generated with [Claude Code](https://claude.com/claude-code)