### PR TITLE
feat: 智慧引用 Card D — backend expansion so bots truly understand refs

### DIFF
--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -22,6 +22,8 @@ const db = require('./db');
 const { URL } = require('url');
 const dnsLookup = require('util').promisify(require('dns').lookup);
 const { enrichContext, materializeChannelText } = require('./push-context');
+const { scanReferences, buildReferencesBlock } = require('./reference-parser');
+const { resolveReferences } = require('./reference-resolver');
 
 // ── SSRF protection: reject private/internal callback URLs ──
 function isPrivateIp(ip) {
@@ -1122,6 +1124,22 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             const targetEntity = targetDevice && targetDevice.entities
                 ? targetDevice.entities[entityId]
                 : null;
+
+            // 智慧引用 / Smart Chip expansion — scan the outgoing text for
+            // card_/review_/src:// references and append a [REFERENCES] block
+            // so the receiving bot truly understands what is being cited
+            // instead of guessing from the opaque ID. See backend/reference-*.js.
+            let referencesBlock = null;
+            try {
+                const parsedRefs = scanReferences(payload.text || '');
+                if (parsedRefs.length > 0 && chatPool) {
+                    const resolved = await resolveReferences(chatPool, deviceId, parsedRefs);
+                    referencesBlock = buildReferencesBlock(resolved);
+                }
+            } catch (refErr) {
+                serverLog('warn', 'channel', `reference expansion failed: ${refErr.message}`, { deviceId, entityId });
+            }
+
             const enrichedCtx = enrichContext(payload.eclaw_context, {
                 helpers: pushContextHelpers,
                 apiBase,
@@ -1131,6 +1149,7 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
                 targetEntityId: entityId,
                 broadcastRecipients: payload.broadcastRecipients,
             });
+            if (referencesBlock) enrichedCtx.referencesBlock = referencesBlock;
             const materializedText = materializeChannelText(payload, enrichedCtx);
 
             const bodyStr = JSON.stringify({

--- a/backend/push-context.js
+++ b/backend/push-context.js
@@ -167,6 +167,7 @@ function materializeChannelText(payload, ctx = {}) {
 
     // Trailer.
     if (ctx.mentionsBlock) sections.push(String(ctx.mentionsBlock).trim());
+    if (ctx.referencesBlock) sections.push(String(ctx.referencesBlock).trim());
     if (ctx.missionHints) sections.push(String(ctx.missionHints).trim());
     if (ctx.identityHint) sections.push(String(ctx.identityHint).trim());
 

--- a/backend/reference-parser.js
+++ b/backend/reference-parser.js
@@ -1,0 +1,128 @@
+'use strict';
+
+/**
+ * reference-parser.js — detect 智慧引用 prefixes in plain message text.
+ *
+ * Pure scanner: no DB / async. Callers (channel push, webhook push) feed the
+ * parsed refs into a lookup helper to build the context block the receiving
+ * bot sees, so the bot can TRULY understand what's being referenced instead
+ * of guessing from an opaque ID.
+ *
+ * Recognised prefixes (mirrors client-side frontend modules but scans plain
+ * text, not HTML):
+ *   card_<hex>       — kanban card (EntityLinkRender handles frontend)
+ *   review_<slug>    — agent review (AutolinkChip handles frontend)
+ *   src://<kind>/<type>/<id>[#anchor]  — source-anchor token (AutolinkChip)
+ *
+ * Intentionally NOT scanned here:
+ *   note_<hex>       — NoteLinkRender frontend; separate context hook planned
+ *   @mention / his_  — owned by mention-parser.js
+ */
+
+const CARD_RE   = /\bcard_([a-f0-9]{8}(?:[a-f0-9]{16}|-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12})?)\b/gi;
+const REVIEW_RE = /\breview_([a-zA-Z0-9_-]{6,})\b/g;
+const SRC_RE    = /\bsrc:\/\/([a-z]+)\/([a-z]+)\/([a-f0-9]{8,})(#[a-z0-9-]+)?\b/gi;
+
+/**
+ * Scan a plain message for reference tokens.
+ * @param {string} text
+ * @returns {Array<{refType:'card'|'review'|'src', refId:string, raw:string, anchor?:string, kind?:string, innerType?:string}>}
+ *   Deduplicated, preserves order of first occurrence.
+ */
+function scanReferences(text) {
+    if (!text || typeof text !== 'string') return [];
+    const seen = new Set();
+    const out = [];
+
+    const push = (ref) => {
+        const key = ref.refType + ':' + ref.refId;
+        if (seen.has(key)) return;
+        seen.add(key);
+        out.push(ref);
+    };
+
+    let m;
+    // card_xxx
+    CARD_RE.lastIndex = 0;
+    while ((m = CARD_RE.exec(text)) !== null) {
+        const id = 'card_' + m[1].toLowerCase();
+        push({ refType: 'card', refId: id, raw: m[0] });
+    }
+    // review_xxx
+    REVIEW_RE.lastIndex = 0;
+    while ((m = REVIEW_RE.exec(text)) !== null) {
+        const id = 'review_' + m[1];
+        push({ refType: 'review', refId: id, raw: m[0] });
+    }
+    // src://kind/type/id[#anchor]
+    SRC_RE.lastIndex = 0;
+    while ((m = SRC_RE.exec(text)) !== null) {
+        const kind = m[1].toLowerCase();
+        const innerType = m[2].toLowerCase();
+        const innerId = m[3].toLowerCase();
+        const anchor = m[4] || null;
+        const refId = `src://${kind}/${innerType}/${innerId}${anchor || ''}`;
+        push({
+            refType: 'src',
+            refId,
+            raw: m[0],
+            anchor,
+            kind,
+            innerType,
+            innerId,
+        });
+    }
+
+    return out;
+}
+
+/**
+ * Build the [REFERENCES — CONTEXT] block appended to the receiving bot's text.
+ *
+ * Takes a list of already-resolved refs (caller runs the DB lookup) and
+ * produces a text block telling the bot what each ID actually points to.
+ *
+ * Each resolved entry has:
+ *   { refType, refId, resolved: true|false, title?, status?, priority?,
+ *     lastComment?, anchor?, error? }
+ *
+ * Unresolved refs include `{ resolved:false, error:'not_found'|'unsupported' }`
+ * so the bot knows the ID was typed but couldn't be expanded, rather than
+ * silently dropping the reference.
+ */
+function buildReferencesBlock(resolvedRefs) {
+    if (!Array.isArray(resolvedRefs) || resolvedRefs.length === 0) return '';
+
+    const lines = resolvedRefs.map((r) => {
+        if (!r.resolved) {
+            const reason = r.error === 'not_found' ? 'not found'
+                : r.error === 'unsupported' ? 'type not indexed yet'
+                : 'lookup failed';
+            return `  • ${r.refId} — (${reason})`;
+        }
+        const parts = [];
+        if (r.title) parts.push(`"${r.title}"`);
+        if (r.status) parts.push(`status: ${r.status}`);
+        if (r.priority) parts.push(`priority: ${r.priority}`);
+        if (r.anchor) parts.push(`anchor: ${r.anchor}`);
+        const head = `  • ${r.refId} — ${parts.join(', ') || '(no metadata)'}`;
+        if (r.lastComment) {
+            const c = String(r.lastComment).replace(/\s+/g, ' ').slice(0, 140);
+            return `${head}\n      last comment: "${c}"`;
+        }
+        return head;
+    });
+
+    const countNoun = resolvedRefs.length === 1 ? 'reference' : 'references';
+    const header = `[REFERENCES — CONTEXT] The user's message cites ${resolvedRefs.length} ${countNoun}; expanded below so you can understand what they refer to without guessing:`;
+    return `${header}\n${lines.join('\n')}`;
+}
+
+module.exports = {
+    scanReferences,
+    buildReferencesBlock,
+    // Exposed for unit tests / debug
+    _CARD_RE: CARD_RE,
+    _REVIEW_RE: REVIEW_RE,
+    _SRC_RE: SRC_RE,
+};

--- a/backend/reference-resolver.js
+++ b/backend/reference-resolver.js
@@ -1,0 +1,99 @@
+'use strict';
+
+/**
+ * reference-resolver.js — async DB lookup layer for 智慧引用 references.
+ *
+ * Takes the output of reference-parser.js::scanReferences() and resolves each
+ * ref to a structured entry with `{ resolved:true, title, status, priority,
+ * lastComment }` (or `{ resolved:false, error:'not_found'|'unsupported' }`).
+ *
+ * Kept separate from reference-parser so the scanner stays a pure sync module
+ * (no DB import, easy to unit test).
+ */
+
+const CARD_HEX_ONLY_RE = /^[a-f0-9]+$/i;
+
+/**
+ * Resolve a single card_ ref against kanban_cards. Handles short-prefix IDs
+ * (8-12 hex) the same way GET /card/:id does: exact match first, then LIKE
+ * prefix; if 2+ rows share a short prefix, mark as not_found so the bot
+ * disambiguates instead of picking the wrong card.
+ */
+async function resolveCardRef(pool, deviceId, cardId) {
+    let finalId = cardId;
+    const body = cardId.startsWith('card_') ? cardId.slice(5) : cardId;
+    if (CARD_HEX_ONLY_RE.test(body) && body.length >= 6 && body.length <= 12) {
+        const match = await pool.query(
+            `SELECT id FROM kanban_cards
+             WHERE device_id = $1 AND (id = $2 OR id LIKE $3 OR id LIKE $4)
+             ORDER BY created_at DESC LIMIT 2`,
+            [deviceId, cardId, body + '%', 'card_' + body + '%']
+        );
+        if (match.rows.length === 1) finalId = match.rows[0].id;
+        // 2+ matches → fall through, exact-match query below will 404.
+    }
+
+    const result = await pool.query(
+        `SELECT id, title, status, priority FROM kanban_cards
+         WHERE id = $1 AND device_id = $2`,
+        [finalId, deviceId]
+    );
+    if (result.rows.length === 0) return { resolved: false, error: 'not_found' };
+
+    const row = result.rows[0];
+    let lastComment = null;
+    try {
+        const c = await pool.query(
+            `SELECT text FROM kanban_comments
+             WHERE card_id = $1 AND is_system = false
+             ORDER BY created_at DESC LIMIT 1`,
+            [row.id]
+        );
+        if (c.rows.length) lastComment = c.rows[0].text;
+    } catch (_) { /* best-effort */ }
+
+    return {
+        resolved: true,
+        title: row.title,
+        status: row.status,
+        priority: row.priority,
+        lastComment,
+        canonicalId: row.id,
+    };
+}
+
+/**
+ * Resolve a list of parsed references (from scanReferences()) against the DB
+ * for a specific device. Returns an array of resolved entries with the same
+ * shape reference-parser::buildReferencesBlock expects.
+ */
+async function resolveReferences(pool, deviceId, refs) {
+    if (!Array.isArray(refs) || refs.length === 0) return [];
+    if (!pool || !deviceId) return [];
+
+    return Promise.all(refs.map(async (ref) => {
+        const base = { refType: ref.refType, refId: ref.refId };
+        if (ref.anchor) base.anchor = ref.anchor;
+
+        try {
+            if (ref.refType === 'card') {
+                const r = await resolveCardRef(pool, deviceId, ref.refId);
+                return { ...base, ...r };
+            }
+            if (ref.refType === 'src' && ref.kind === 'kanban' && ref.innerType === 'card') {
+                // src://kanban/card/<id>[#anchor] — treat as card lookup
+                const r = await resolveCardRef(pool, deviceId, 'card_' + ref.innerId);
+                return { ...base, ...r };
+            }
+            // review_ and non-kanban src:// are not indexed yet
+            return { ...base, resolved: false, error: 'unsupported' };
+        } catch (err) {
+            return { ...base, resolved: false, error: 'lookup_failed', _errMsg: String(err && err.message || err) };
+        }
+    }));
+}
+
+module.exports = {
+    resolveReferences,
+    resolveCardRef,
+};

--- a/backend/tests/jest/push-context.test.js
+++ b/backend/tests/jest/push-context.test.js
@@ -311,6 +311,34 @@ describe('materializeChannelText — wire format', () => {
         expect(hintsIdx).toBeGreaterThan(bodyIdx);
     });
 
+    test('referencesBlock is appended after body and after mentionsBlock, before missionHints', () => {
+        const out = materializeChannelText(
+            { event: 'message', text: '看 card_f6321df2 這張' },
+            {
+                mentionsBlock: '[MENTIONS] fake mentions block',
+                referencesBlock: '[REFERENCES — CONTEXT] The user cites 1 reference;\n  • card_f6321df2 — "Fix UI"',
+                missionHints: '[AVAILABLE TOOLS — Mission Dashboard] curl ...',
+            }
+        );
+        const bodyIdx = out.indexOf('看 card_f6321df2');
+        const mentIdx = out.indexOf('[MENTIONS]');
+        const refIdx = out.indexOf('[REFERENCES — CONTEXT]');
+        const hintIdx = out.indexOf('[AVAILABLE TOOLS');
+        expect(bodyIdx).toBeGreaterThan(-1);
+        expect(mentIdx).toBeGreaterThan(bodyIdx);
+        expect(refIdx).toBeGreaterThan(mentIdx);
+        expect(hintIdx).toBeGreaterThan(refIdx);
+    });
+
+    test('referencesBlock alone (no mentions) still renders in trailer', () => {
+        const out = materializeChannelText(
+            { event: 'message', text: 'see src://kanban/card/abcdef12' },
+            { referencesBlock: '[REFERENCES — CONTEXT] ...\n  • src://kanban/card/abcdef12 — "Card B"' }
+        );
+        expect(out).toContain('[REFERENCES — CONTEXT]');
+        expect(out.indexOf('src://kanban')).toBeLessThan(out.indexOf('[REFERENCES'));
+    });
+
     test('media attachment label is appended to body, not the trailer', () => {
         const out = materializeChannelText(
             {

--- a/backend/tests/jest/reference-parser.test.js
+++ b/backend/tests/jest/reference-parser.test.js
@@ -1,0 +1,172 @@
+'use strict';
+
+/**
+ * reference-parser unit tests — verifies message-text scanner extracts
+ * card_/review_/src:// tokens, deduplicates, and that buildReferencesBlock
+ * formats both resolved and unresolved entries correctly.
+ */
+
+const { scanReferences, buildReferencesBlock } = require('../../reference-parser');
+
+describe('scanReferences', () => {
+    test('extracts single card_ short prefix', () => {
+        const refs = scanReferences('看 card_f6321df2 這張');
+        expect(refs).toEqual([{ refType: 'card', refId: 'card_f6321df2', raw: 'card_f6321df2' }]);
+    });
+
+    test('extracts card_ in 24-hex long form', () => {
+        const refs = scanReferences('card_d3cdda1455152e3caee8d4ac done');
+        expect(refs[0].refId).toBe('card_d3cdda1455152e3caee8d4ac');
+    });
+
+    test('extracts card_ in UUID form', () => {
+        const refs = scanReferences('card_7b7dd9e3-55e1-4074-b101-40c47161d8de ok');
+        expect(refs[0].refId).toBe('card_7b7dd9e3-55e1-4074-b101-40c47161d8de');
+    });
+
+    test('extracts review_ slug', () => {
+        const refs = scanReferences('review_perf_q2_2026 complete');
+        expect(refs).toEqual([{ refType: 'review', refId: 'review_perf_q2_2026', raw: 'review_perf_q2_2026' }]);
+    });
+
+    test('extracts src:// with anchor', () => {
+        const refs = scanReferences('see src://kanban/card/f6321df2aaa0#comment-abc plz');
+        expect(refs).toHaveLength(1);
+        expect(refs[0]).toMatchObject({
+            refType: 'src',
+            refId: 'src://kanban/card/f6321df2aaa0#comment-abc',
+            kind: 'kanban',
+            innerType: 'card',
+            innerId: 'f6321df2aaa0',
+            anchor: '#comment-abc',
+        });
+    });
+
+    test('extracts src:// without anchor', () => {
+        const refs = scanReferences('src://reviews/agent/1a2b3c4d5e6f pending');
+        expect(refs[0].anchor).toBeNull();
+        expect(refs[0].refId).toBe('src://reviews/agent/1a2b3c4d5e6f');
+    });
+
+    test('deduplicates repeated references', () => {
+        const refs = scanReferences('card_f6321df2 again card_f6321df2 and card_f6321df2');
+        expect(refs).toHaveLength(1);
+    });
+
+    test('dedup is case-insensitive for card_/src:// (normalised to lowercase)', () => {
+        const refs = scanReferences('CARD_F6321DF2 and card_f6321df2');
+        expect(refs).toHaveLength(1);
+        expect(refs[0].refId).toBe('card_f6321df2');
+    });
+
+    test('preserves order of first occurrence across types', () => {
+        const refs = scanReferences('check card_f6321df2 then review_abc123456 then src://kanban/card/abcdef12');
+        expect(refs.map(r => r.refType)).toEqual(['card', 'review', 'src']);
+    });
+
+    test('mixed message with all three types', () => {
+        const refs = scanReferences('這張 card_f6321df2 關聯 review_perf_q2_2026 還有 src://reviews/agent/1a2b3c4d5e6f');
+        expect(refs).toHaveLength(3);
+    });
+
+    test('empty / null / non-string input returns empty array', () => {
+        expect(scanReferences('')).toEqual([]);
+        expect(scanReferences(null)).toEqual([]);
+        expect(scanReferences(undefined)).toEqual([]);
+        expect(scanReferences(42)).toEqual([]);
+    });
+
+    test('does not match note_ prefix (owned by NoteLinkRender)', () => {
+        const refs = scanReferences('note_1234567890abcdef12345678 should be ignored');
+        expect(refs).toEqual([]);
+    });
+
+    test('does not match skill_/rule_/listing_ (EntityLinkRender owns them)', () => {
+        // Only card_ is in our scan scope — other entity types flow through mention-parser
+        // or entity-link-render upstream without needing backend context expansion here.
+        const refs = scanReferences('skill_f6321df2 rule_f6321df2 listing_f6321df2');
+        expect(refs).toEqual([]);
+    });
+
+    test('word boundary — card_xxx not matched inside a larger token', () => {
+        const refs = scanReferences('xcard_f6321df2'); // leading x means no \b at start
+        expect(refs).toEqual([]);
+    });
+});
+
+describe('buildReferencesBlock', () => {
+    test('returns empty string for no refs', () => {
+        expect(buildReferencesBlock([])).toBe('');
+        expect(buildReferencesBlock(null)).toBe('');
+    });
+
+    test('singular "reference" in header when count is 1', () => {
+        const block = buildReferencesBlock([
+            { refType: 'card', refId: 'card_f6321df2', resolved: true, title: 'Test Card' }
+        ]);
+        expect(block).toMatch(/cites 1 reference;/);
+    });
+
+    test('plural "references" when count > 1', () => {
+        const block = buildReferencesBlock([
+            { refType: 'card', refId: 'card_f6321df2', resolved: true, title: 'A' },
+            { refType: 'card', refId: 'card_abcdef12', resolved: true, title: 'B' },
+        ]);
+        expect(block).toMatch(/cites 2 references;/);
+    });
+
+    test('resolved card includes title + status + priority + last comment', () => {
+        const block = buildReferencesBlock([{
+            refType: 'card',
+            refId: 'card_f6321df2',
+            resolved: true,
+            title: '修按鈕顏色',
+            status: 'in_progress',
+            priority: 'P1',
+            lastComment: '改好了，等 review',
+        }]);
+        expect(block).toMatch(/"修按鈕顏色"/);
+        expect(block).toMatch(/status: in_progress/);
+        expect(block).toMatch(/priority: P1/);
+        expect(block).toMatch(/last comment: "改好了，等 review"/);
+    });
+
+    test('unresolved ref includes reason', () => {
+        const block = buildReferencesBlock([
+            { refType: 'card', refId: 'card_deadbeef', resolved: false, error: 'not_found' },
+        ]);
+        expect(block).toMatch(/card_deadbeef — \(not found\)/);
+    });
+
+    test('unsupported type surfaces as "type not indexed yet"', () => {
+        const block = buildReferencesBlock([
+            { refType: 'review', refId: 'review_xyz789', resolved: false, error: 'unsupported' },
+        ]);
+        expect(block).toMatch(/review_xyz789 — \(type not indexed yet\)/);
+    });
+
+    test('long last-comment truncated to 140 chars', () => {
+        const long = 'x'.repeat(500);
+        const block = buildReferencesBlock([{
+            refType: 'card',
+            refId: 'card_f6321df2',
+            resolved: true,
+            title: 'Test',
+            lastComment: long,
+        }]);
+        const m = block.match(/last comment: "(x+)"/);
+        expect(m).toBeTruthy();
+        expect(m[1].length).toBe(140);
+    });
+
+    test('anchor from src:// shows on its own line attr', () => {
+        const block = buildReferencesBlock([{
+            refType: 'src',
+            refId: 'src://kanban/card/abcdef12#comment-xyz',
+            resolved: true,
+            title: 'Parent card',
+            anchor: '#comment-xyz',
+        }]);
+        expect(block).toMatch(/anchor: #comment-xyz/);
+    });
+});

--- a/backend/tests/jest/reference-resolver.test.js
+++ b/backend/tests/jest/reference-resolver.test.js
@@ -1,0 +1,165 @@
+'use strict';
+
+/**
+ * reference-resolver unit tests — verifies resolveReferences() does the
+ * correct DB queries per ref type and formats the return shape.
+ *
+ * DB is mocked so this test does not require Postgres.
+ */
+
+const { resolveReferences, resolveCardRef } = require('../../reference-resolver');
+
+function mockPool(responses) {
+    const queries = [];
+    const pool = {
+        query: jest.fn(async (sql, args) => {
+            queries.push({ sql, args });
+            const handler = responses.shift();
+            if (typeof handler === 'function') return handler(sql, args);
+            if (handler instanceof Error) throw handler;
+            return handler;
+        }),
+        _queries: queries,
+    };
+    return pool;
+}
+
+describe('resolveCardRef', () => {
+    test('short prefix resolves to full id via LIKE lookup', async () => {
+        const pool = mockPool([
+            { rows: [{ id: 'card_f6321df2aaaa1111bbbb2222' }] }, // short-prefix SELECT
+            { rows: [{ id: 'card_f6321df2aaaa1111bbbb2222', title: 'Fix UI', status: 'in_progress', priority: 'P1' }] }, // main SELECT
+            { rows: [{ text: 'latest update' }] }, // last comment
+        ]);
+        const r = await resolveCardRef(pool, 'dev1', 'card_f6321df2');
+        expect(r.resolved).toBe(true);
+        expect(r.title).toBe('Fix UI');
+        expect(r.status).toBe('in_progress');
+        expect(r.priority).toBe('P1');
+        expect(r.lastComment).toBe('latest update');
+        expect(r.canonicalId).toBe('card_f6321df2aaaa1111bbbb2222');
+    });
+
+    test('exact 24-hex id skips the LIKE resolve step', async () => {
+        const pool = mockPool([
+            { rows: [{ id: 'card_d3cdda1455152e3caee8d4ac', title: 'Long', status: 'done', priority: 'P2' }] },
+            { rows: [] }, // no comments
+        ]);
+        const r = await resolveCardRef(pool, 'dev1', 'card_d3cdda1455152e3caee8d4ac');
+        expect(r.resolved).toBe(true);
+        expect(r.title).toBe('Long');
+        expect(r.lastComment).toBeNull();
+        // Only 2 queries (main + comment), no short-prefix query
+        expect(pool._queries).toHaveLength(2);
+    });
+
+    test('ambiguous short prefix (2 matches) returns not_found', async () => {
+        const pool = mockPool([
+            { rows: [{ id: 'card_f6321df2aaaa' }, { id: 'card_f6321df2bbbb' }] }, // 2 matches
+            { rows: [] }, // exact-match on the raw short id returns nothing
+        ]);
+        const r = await resolveCardRef(pool, 'dev1', 'card_f6321df2');
+        expect(r.resolved).toBe(false);
+        expect(r.error).toBe('not_found');
+    });
+
+    test('card not in device returns not_found', async () => {
+        const pool = mockPool([
+            { rows: [] }, // short-prefix: no hits
+            { rows: [] }, // main: no hits
+        ]);
+        const r = await resolveCardRef(pool, 'dev1', 'card_deadbeef');
+        expect(r.resolved).toBe(false);
+        expect(r.error).toBe('not_found');
+    });
+});
+
+describe('resolveReferences', () => {
+    test('mixed refs route to correct resolvers', async () => {
+        // Route by SQL pattern + arg so the mock is order-independent (resolveReferences
+        // uses Promise.all, so card lookups run concurrently and interleave).
+        const pool = {
+            query: jest.fn(async (sql, args) => {
+                // short-prefix resolver
+                if (/LIKE \$3/.test(sql) && /LIKE \$4/.test(sql)) {
+                    if (args[2] === 'f6321df2%') return { rows: [{ id: 'card_f6321df2aaaa' }] };
+                    if (args[2] === 'abcdef12%') return { rows: [{ id: 'card_abcdef12aaaa' }] };
+                    return { rows: [] };
+                }
+                // main SELECT title/status/priority
+                if (/SELECT id, title, status, priority/.test(sql)) {
+                    if (args[0] === 'card_f6321df2aaaa') {
+                        return { rows: [{ id: 'card_f6321df2aaaa', title: 'Card A', status: 'todo', priority: 'P1' }] };
+                    }
+                    if (args[0] === 'card_abcdef12aaaa') {
+                        return { rows: [{ id: 'card_abcdef12aaaa', title: 'Card B', status: 'done', priority: 'P2' }] };
+                    }
+                    return { rows: [] };
+                }
+                // last-comment query
+                if (/kanban_comments/.test(sql)) {
+                    if (args[0] === 'card_f6321df2aaaa') return { rows: [{ text: 'hi' }] };
+                    return { rows: [] };
+                }
+                return { rows: [] };
+            }),
+        };
+
+        const refs = [
+            { refType: 'card', refId: 'card_f6321df2' },
+            { refType: 'review', refId: 'review_xyz123456' }, // unsupported
+            { refType: 'src', refId: 'src://kanban/card/abcdef12', kind: 'kanban', innerType: 'card', innerId: 'abcdef12', anchor: null },
+            { refType: 'src', refId: 'src://wiki/page/abcdef12', kind: 'wiki', innerType: 'page', innerId: 'abcdef12', anchor: null },
+        ];
+        const out = await resolveReferences(pool, 'dev1', refs);
+
+        expect(out).toHaveLength(4);
+        expect(out[0]).toMatchObject({ refType: 'card', resolved: true, title: 'Card A' });
+        expect(out[1]).toMatchObject({ refType: 'review', resolved: false, error: 'unsupported' });
+        expect(out[2]).toMatchObject({ refType: 'src', resolved: true, title: 'Card B' });
+        expect(out[3]).toMatchObject({ refType: 'src', resolved: false, error: 'unsupported' });
+    });
+
+    test('DB error on one ref does not break others', async () => {
+        const pool = {
+            query: jest.fn()
+                // first card: throws on the short-prefix query
+                .mockRejectedValueOnce(new Error('conn dropped'))
+                // second card: normal resolve (exact 24-hex skips short-prefix, so 2 queries)
+                .mockResolvedValueOnce({ rows: [{ id: 'card_111111111111111111111111', title: 'OK', status: 'todo', priority: 'P2' }] })
+                .mockResolvedValueOnce({ rows: [] }),
+        };
+        const refs = [
+            { refType: 'card', refId: 'card_f6321df2' },
+            { refType: 'card', refId: 'card_111111111111111111111111' },
+        ];
+        const out = await resolveReferences(pool, 'dev1', refs);
+        expect(out[0]).toMatchObject({ resolved: false, error: 'lookup_failed' });
+        expect(out[1]).toMatchObject({ resolved: true, title: 'OK' });
+    });
+
+    test('empty / missing args return empty array', async () => {
+        expect(await resolveReferences(null, 'dev', [])).toEqual([]);
+        expect(await resolveReferences({ query: jest.fn() }, null, [{ refType: 'card', refId: 'card_x' }])).toEqual([]);
+        expect(await resolveReferences({ query: jest.fn() }, 'dev', [])).toEqual([]);
+    });
+
+    test('anchor is preserved on resolved src ref', async () => {
+        const pool = mockPool([
+            { rows: [{ id: 'card_abcdef12aaaa' }] },
+            { rows: [{ id: 'card_abcdef12aaaa', title: 'Parent', status: 'review', priority: 'P0' }] },
+            { rows: [] },
+        ]);
+        const refs = [{
+            refType: 'src',
+            refId: 'src://kanban/card/abcdef12#comment-xyz',
+            kind: 'kanban',
+            innerType: 'card',
+            innerId: 'abcdef12',
+            anchor: '#comment-xyz',
+        }];
+        const out = await resolveReferences(pool, 'dev1', refs);
+        expect(out[0].anchor).toBe('#comment-xyz');
+        expect(out[0].resolved).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

卡 D 後端展開：外部 bot 透過 channel callback 收到訊息時，系統會自動掃描文字中的 \`card_/review_/src://\` 引用，**查 DB 把真正內容填進去**，不再只丟 ID 讓 bot 自己猜。

### 範例：bot 收到的 text 會長這樣

Before（現狀）：
\`\`\`
看一下 card_f6321df2 這張有沒有搞定
\`\`\`

After（本 PR）：
\`\`\`
看一下 card_f6321df2 這張有沒有搞定

[REFERENCES — CONTEXT] The user's message cites 1 reference; expanded below so you can understand what they refer to without guessing:
  • card_f6321df2 — "Fix UI button colour on kanban", status: in_progress, priority: P1
      last comment: "改好了，等 review"
\`\`\`

## 改動範圍
- **backend/reference-parser.js**（新）— 純 sync 掃描器；無 DB；好測
- **backend/reference-resolver.js**（新）— async DB 層；用 chatPool 查 kanban_cards
- **backend/channel-api.js**（改）— pushToChannelCallback 前先掃 + 查 + 掛 ctx.referencesBlock
- **backend/push-context.js**（改）— materializeChannelText 在 trailer 把 referencesBlock 吐出來

## 尚未支援（下一張卡處理）
- \`review_\` 前綴：目前後端還沒有 reviews 表 → 回 \`(type not indexed yet)\`
- 非 kanban 的 src://（e.g. \`src://wiki/page/xxx\`）：一樣 unsupported
- note_ 前綴：由 NoteLinkRender 管，另有獨立 context hook 計畫

## 失敗行為
reference 擴展若丟錯，channel push 不會被擋住 — 只會記 warn log 後照舊送。

## Test plan
- [x] 32 支 Jest 新測 + 原 push-context 31 支全綠（63 共）
- [x] 全套 2264 支測試全綠（無 regression）
- [ ] Staging smoke：從 web_chat 送 \"看 card_<real-id>\" 給有 channel callback 的 bot，確認 webhook 收到的 text 底部有 [REFERENCES] 區塊含真實標題
- [ ] Staging 負面測試：送 \"看 card_deadbeef\" → 應收到 \`(not found)\`
- [ ] Staging 未實作類型：送 \"看 review_xyz\" → 應收到 \`(type not indexed yet)\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)