### PR TITLE
fix(ui): define .btn-ghost so kanban header icons stop rendering as white-on-white

### DIFF
--- a/backend/public/portal/shared/style.css
+++ b/backend/public/portal/shared/style.css
@@ -420,6 +420,12 @@ a:hover { text-decoration: underline; }
     color: var(--text-secondary);
 }
 .btn-outline:hover { border-color: var(--primary); color: var(--primary); }
+.btn-ghost {
+    background: transparent;
+    border: 1px solid var(--card-border);
+    color: var(--text);
+}
+.btn-ghost:hover { background: var(--card-border); color: var(--text); }
 .btn-sm { padding: 6px 12px; font-size: 12px; }
 .btn-block { width: 100%; justify-content: center; }
 .btn:disabled { opacity: 0.5; cursor: not-allowed; pointer-events: none; background: var(--card-border); }


### PR DESCRIPTION
## Summary
- `.btn-ghost` was referenced in `kanban.html` (Filter / History icon buttons) and `onboarding/wizard.html` but had **no CSS rule** — buttons fell back to the user-agent default grey background, which against the dark theme produced near-invisible white-on-white boxes.
- On mobile where labels are hidden (`body.app-webview .kb-toolbar-actions .btn.btn-ghost [data-i18n="kb_funnel_label"] { display:none }`), this rendered two blank squares in the kanban toolbar with no affordance whatsoever.
- Fix mirrors the existing `.btn-outline` convention: transparent background, card-border outline, inherits `--text` for the glyph, subtle hover fill.

## Root cause
`.btn-outline`, `.btn-primary`, `.btn-danger`, `.btn-warning`, `.btn-success` are all defined in `shared/style.css` — `.btn-ghost` was simply never added. Silent regression because the bare `.btn` rule only sets `color`, leaving background to the UA default (`rgb(239 239 239)`).

## Evidence
See attached before/after screenshots (mobile 390×844 + desktop 1280×720). Before the fix the two buttons were rendered as opaque white squares. After the fix they render as transparent buttons with subtle borders, matching the rest of the dark theme and making the ▽ / 📦 glyphs legible.

## Test plan
- [x] Mobile before/after (390×844) shows ▽ filter and 📦 history buttons go from invisible white boxes to visible transparent buttons
- [x] Desktop before/after (1280×720) shows the same on labeled variant
- [x] No change to `.btn-primary` (+ New Card) — purple background was never broken
- [x] No new CSS vars introduced; purely uses existing `--card-border` and `--text`

Fixes `card_05e798644f6bd41aae8feada` (Hank 2026-04-25 02:31 pre-sleep report).

🤖 Generated with [Claude Code](https://claude.com/claude-code)