### PR TITLE
fix(chat): move R2 attachments to structured metadata, keep signed URL out of message.text

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -7942,10 +7942,29 @@ app.post('/api/device/entity/avatar/upload', avatarUpload.single('file'), async 
  * If bot has registered webhook, push notification is sent.
  */
 app.post('/api/client/speak', async (req, res) => {
-    const { deviceId, deviceSecret, entityId, text, source = "client", mediaType, mediaUrl } = req.body;
+    const { deviceId, deviceSecret, entityId, text, source = "client", mediaType, mediaUrl, attachments } = req.body;
 
     if (!deviceId) {
         return res.status(400).json({ success: false, message: "deviceId required" });
+    }
+
+    // Validate optional attachments[] — structured fileId-based payload so the
+    // raw R2 signed URL stays out of message.text (security: 1-hour presigned
+    // URL = bearer token; keeping it in text means it leaks via transcript
+    // copy, API export, cross-device sync, etc. Display layer resolves fresh
+    // URLs from fileId via /api/files/:id at render time).
+    let validatedAttachments = null;
+    if (Array.isArray(attachments) && attachments.length > 0) {
+        if (attachments.length > 10) {
+            return res.status(400).json({ success: false, message: "attachments max 10 items" });
+        }
+        validatedAttachments = attachments.map(a => ({
+            fileId: String(a.fileId || '').slice(0, 128),
+            filename: String(a.filename || '').slice(0, 255),
+            size: typeof a.size === 'number' ? a.size : 0,
+            mimeType: String(a.mimeType || 'application/octet-stream').slice(0, 128),
+        })).filter(a => a.fileId);
+        if (validatedAttachments.length === 0) validatedAttachments = null;
     }
 
     const device = devices[deviceId];
@@ -8102,6 +8121,18 @@ app.post('/api/client/speak', async (req, res) => {
     // gets stored in chat_messages so the frontend can re-render chips.
     let pushText = (mentionParse && mentionParse.displayText) || text;
 
+    // Surface structured attachments to the bot as filename-only hints so the
+    // receiving side knows files are attached without leaking the signed URL.
+    // Bots can call GET /api/files/:id to fetch a fresh presigned URL. The raw
+    // URL is intentionally kept out of both chat_messages.text and the push
+    // body; chat.html renders attachments from the structured JSONB column.
+    if (validatedAttachments && validatedAttachments.length > 0) {
+        const hints = validatedAttachments
+            .map(a => `[📎 ${a.filename || a.fileId}]`)
+            .join(' ');
+        pushText = pushText ? `${pushText}\n${hints}` : hints;
+    }
+
     // ── Vault variable interpolation: {{KEY_NAME}} → actual value ──
     // Resolve {{KEY_NAME}} tokens in pushText only (bot-facing).
     // Original text (with {{KEY_NAME}}) is stored in chat_messages for privacy.
@@ -8217,7 +8248,7 @@ app.post('/api/client/speak', async (req, res) => {
         };
         entity.messageQueue.push(messageObj);
         const chatBackupUrl = mediaType === 'photo' ? getBackupUrl(mediaUrl) : null;
-        await saveChatMessage(deviceId, eId, text, source, true, false, mediaType || null, mediaUrl || null, null, null, chatBackupUrl, mentionsContext);
+        await saveChatMessage(deviceId, eId, text, source, true, false, mediaType || null, mediaUrl || null, null, null, chatBackupUrl, mentionsContext, null, validatedAttachments);
 
         // Reset bot-to-bot counter: human message breaks the loop
         resetBotToBotCounter(deviceId);
@@ -10377,7 +10408,22 @@ app.delete('/api/contacts/:publicCode/unfriend', async (req, res) => {
  * Body: { deviceId, fromEntityId, targetCode, text, mediaType?, mediaUrl? }
  */
 app.post('/api/client/cross-speak', async (req, res) => {
-    let { deviceId, fromEntityId, targetCode, text, mediaType, mediaUrl } = req.body;
+    let { deviceId, fromEntityId, targetCode, text, mediaType, mediaUrl, attachments } = req.body;
+
+    // Validate optional attachments[] (same fileId-based schema as /api/client/speak)
+    let validatedAttachments = null;
+    if (Array.isArray(attachments) && attachments.length > 0) {
+        if (attachments.length > 10) {
+            return res.status(400).json({ success: false, message: "attachments max 10 items" });
+        }
+        validatedAttachments = attachments.map(a => ({
+            fileId: String(a.fileId || '').slice(0, 128),
+            filename: String(a.filename || '').slice(0, 255),
+            size: typeof a.size === 'number' ? a.size : 0,
+            mimeType: String(a.mimeType || 'application/octet-stream').slice(0, 128),
+        })).filter(a => a.fileId);
+        if (validatedAttachments.length === 0) validatedAttachments = null;
+    }
 
     console.log(`[ClientCrossSpeak:DEBUG] Received request: deviceId=${deviceId}, fromEntityId=${fromEntityId}, targetCode=${targetCode}, text="${(text||'').slice(0,30)}", hasUser=${!!req.user}, hasCookie=${!!(req.cookies && req.cookies.eclaw_session)}`);
 
@@ -10399,10 +10445,16 @@ app.post('/api/client/cross-speak', async (req, res) => {
         }
     }
 
-    if (!deviceId || fromEntityId === undefined || !targetCode || !text) {
-        console.log(`[ClientCrossSpeak:DEBUG] Validation failed: deviceId=${!!deviceId}, fromEntityId=${fromEntityId}, targetCode=${!!targetCode}, text=${!!text}`);
-        return res.status(400).json({ success: false, message: "deviceId, fromEntityId, targetCode, and text are required" });
+    // Message requires at least text OR a structured attachment — attachment-only
+    // sends are valid (user drops a file from cloud library with no typed text).
+    const hasAttachments = validatedAttachments && validatedAttachments.length > 0;
+    if (!deviceId || fromEntityId === undefined || !targetCode || (!text && !hasAttachments)) {
+        console.log(`[ClientCrossSpeak:DEBUG] Validation failed: deviceId=${!!deviceId}, fromEntityId=${fromEntityId}, targetCode=${!!targetCode}, text=${!!text}, attachments=${hasAttachments}`);
+        return res.status(400).json({ success: false, message: "deviceId, fromEntityId, targetCode, and text (or attachments) are required" });
     }
+    // Normalise text so downstream code that expects a string works whether
+    // caller sent "" or omitted the field.
+    if (!text) text = '';
 
     const fromId = parseInt(fromEntityId);
     if (isNaN(fromId) || fromId < -1) {
@@ -10499,6 +10551,14 @@ app.post('/api/client/cross-speak', async (req, res) => {
 
     // ── Vault variable interpolation for cross-speak ──
     let pushText = text;
+    // Surface structured attachments as filename-only hints (same rationale as
+    // /api/client/speak — keep signed URL out of push text / DB).
+    if (validatedAttachments && validatedAttachments.length > 0) {
+        const hints = validatedAttachments
+            .map(a => `[📎 ${a.filename || a.fileId}]`)
+            .join(' ');
+        pushText = pushText ? `${pushText}\n${hints}` : hints;
+    }
     const vaultTokenReXD = /\{\{(\w+)\}\}/g;
     if (vaultTokenReXD.test(text)) {
         try {
@@ -10534,11 +10594,11 @@ app.post('/api/client/cross-speak', async (req, res) => {
 
     // Save chat message — always save to both sender and target devices
     const sourceTag = `${sourceLabel}->${targetCode}`;
-    const chatMsgId = await saveChatMessage(target.deviceId, target.entityId, text, sourceTag, true, false, mediaType || null, mediaUrl || null);
+    const chatMsgId = await saveChatMessage(target.deviceId, target.entityId, text, sourceTag, true, false, mediaType || null, mediaUrl || null, null, null, null, null, null, validatedAttachments);
     // Also save sender's copy: in owner mode use entity 0; in entity mode use fromId
     const senderEntityId = isOwnerMode ? 0 : fromId;
     if (deviceId !== target.deviceId || senderEntityId !== target.entityId) {
-        await saveChatMessage(deviceId, senderEntityId, text, sourceTag, true, false, mediaType || null, mediaUrl || null);
+        await saveChatMessage(deviceId, senderEntityId, text, sourceTag, true, false, mediaType || null, mediaUrl || null, null, null, null, null, null, validatedAttachments);
     }
 
     toEntity.message = isOwnerMode ? `xdevice:owner: ${text}` : `xdevice:${fromEntity.publicCode}:${fromEntity.character}: ${text}`;

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -4512,8 +4512,10 @@
             const input = document.getElementById('messageInput');
             const text = input.value.trim();
             // Split ready entries: uploaded media vs Cloud Drive refs. Media goes
-            // through the mediaType/mediaUrl path; r2refs are appended as Markdown
-            // links [📎 filename](signed-url) to the message text.
+            // through the mediaType/mediaUrl path; r2refs are sent as structured
+            // `attachments:[{fileId,filename,size,mimeType}]` so the signed R2
+            // URL never enters message.text. The render path resolves fresh
+            // URLs from fileId via /api/files/:id on demand.
             const allReady = pendingFiles.filter(f => f.status === 'ready');
             const readyFiles = allReady.filter(f => f.type !== 'r2ref');
             const readyR2Refs = allReady.filter(f => f.type === 'r2ref');
@@ -4538,12 +4540,16 @@
                 finalText = text ? `${quotePrefix}\n\n${text}` : quotePrefix;
                 clearReplyContext();
             }
-            if (hasR2Refs) {
-                const refLinks = readyR2Refs
-                    .map(r => `[📎 ${r.fileName}](${r.mediaUrl})`)
-                    .join('\n');
-                finalText = finalText ? `${finalText}\n\n${refLinks}` : refLinks;
-            }
+            // Structured attachments (fileId-based) — the signed URL intentionally
+            // stays out of finalText. speakBody / crossSpeakSafe pick this up below.
+            const r2Attachments = hasR2Refs
+                ? readyR2Refs.map(r => ({
+                    fileId: r.fileId,
+                    filename: r.fileName,
+                    size: r.size || 0,
+                    mimeType: r.mimeType || 'application/octet-stream'
+                }))
+                : null;
 
             // Check if any files still uploading
             if (pendingFiles.some(f => f.status === 'uploading')) {
@@ -4613,6 +4619,7 @@
                             text: finalText,
                             source: 'web_chat'
                         };
+                        if (r2Attachments) speakBody.attachments = r2Attachments;
                         // Inject confirmation flag for slash command re-send
                         if (pendingConfirmCommand && text === `/${pendingConfirmCommand}`) {
                             speakBody.confirmed = true;
@@ -4630,7 +4637,7 @@
                 }
 
                 // ── Cross-device contacts ──
-                if (targets.contacts.length > 0 && (finalText || hasFiles)) {
+                if (targets.contacts.length > 0 && (finalText || hasFiles || r2Attachments)) {
                     const explicitLocal = targets.local.length > 0
                         ? boundEntities.find(e => e.entityId === targets.local[0])
                         : null;
@@ -4644,9 +4651,11 @@
                             ));
                         }
                     } else {
-                        await Promise.all(targets.contacts.map(code =>
-                            crossSpeakSafe({ deviceId: currentUser.deviceId, fromEntityId, targetCode: code, text: finalText, source: 'web_chat' })
-                        ));
+                        await Promise.all(targets.contacts.map(code => {
+                            const body = { deviceId: currentUser.deviceId, fromEntityId, targetCode: code, text: finalText, source: 'web_chat' };
+                            if (r2Attachments) body.attachments = r2Attachments;
+                            return crossSpeakSafe(body);
+                        }));
                     }
                 }
 

--- a/backend/tests/jest/chat.test.js
+++ b/backend/tests/jest/chat.test.js
@@ -195,6 +195,75 @@ describe('client/speak messageQueue structure (shadow bug regression)', () => {
 });
 
 // ════════════════════════════════════════════════════════════════
+// Structured attachments on /api/client/speak — signed R2 URL must
+// NEVER enter message.text or the push body. Bots see only a
+// [📎 filename] hint + fileId-based metadata.
+// ════════════════════════════════════════════════════════════════
+describe('client/speak structured attachments', () => {
+    it('accepts attachments[] and rejects > 10 items', async () => {
+        const deviceSecret = await registerDevice('test-att-limit');
+        await post('/api/bind').send({
+            deviceId: 'test-att-limit', entityId: 0,
+            name: 'TestBot', character: '🤖', webhook: ''
+        });
+
+        const tooMany = Array.from({ length: 11 }, (_, i) => ({
+            fileId: `file-${i}`, filename: `f${i}.txt`, size: 1, mimeType: 'text/plain',
+        }));
+
+        const res = await post('/api/client/speak').send({
+            deviceId: 'test-att-limit', deviceSecret,
+            entityId: 0, text: 'too many', source: 'web_chat',
+            attachments: tooMany,
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.message).toMatch(/attachments max 10/);
+    });
+
+    it('strips unknown attachment fields and preserves fileId/filename/size/mimeType', async () => {
+        const deviceSecret = await registerDevice('test-att-shape');
+        await post('/api/bind').send({
+            deviceId: 'test-att-shape', entityId: 0,
+            name: 'TestBot', character: '🤖', webhook: ''
+        });
+
+        const res = await post('/api/client/speak').send({
+            deviceId: 'test-att-shape', deviceSecret,
+            entityId: 0,
+            text: 'here you go',
+            source: 'web_chat',
+            attachments: [{
+                fileId: 'abcd1234',
+                filename: 'report.pdf',
+                size: 12345,
+                mimeType: 'application/pdf',
+                // A signed URL must be silently dropped by the validator.
+                url: 'https://r2.cloudflarestorage.com/evil-url?X-Amz-Signature=abc',
+            }],
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+
+    it('drops attachments without fileId', async () => {
+        const deviceSecret = await registerDevice('test-att-nofileid');
+        await post('/api/bind').send({
+            deviceId: 'test-att-nofileid', entityId: 0,
+            name: 'TestBot', character: '🤖', webhook: ''
+        });
+
+        const res = await post('/api/client/speak').send({
+            deviceId: 'test-att-nofileid', deviceSecret,
+            entityId: 0, text: 'with bad att', source: 'web_chat',
+            attachments: [{ filename: 'noid.pdf', size: 10, mimeType: 'application/pdf' }],
+        });
+        // No fileId → validator filters out → treat as plain text message, no error
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
 // POST /api/chat/upload-media
 // ════════════════════════════════════════════════════════════════
 describe('POST /api/chat/upload-media', () => {


### PR DESCRIPTION
## Summary

- **Root cause of `card_c24b56d55858a9323423d7e5`** — chat.html's sendMessage was serializing R2 refs as Markdown `[📎 filename](signed-url)` into `finalText`, baking the 1-hour signed URL into `chat_messages.text`, /api/chat/history, cross-device sync, and webhook pushes.
- Compose-path fix: send r2refs as **structured `attachments:[{fileId,filename,size,mimeType}]`** in `/api/client/speak` and `/api/client/cross-speak` bodies; drop the Markdown-link append. chat.html's render path at line 4017-4038 already handles `msg.attachments` with per-file preview/download cards.
- Endpoint fix: both `/api/client/speak` and `/api/client/cross-speak` now accept `attachments[]` (same validator shape as `/api/transform`), and the bot-facing `pushText` gets filename-only `[📎 filename]` hints so receiving bots still know files are attached without leaking the signed URL.
- Cross-device gate relaxed so attachment-only sends (no typed text) are accepted.

## Why display-layer fix (PR #2059) wasn't enough

PR #2059 stripped R2 URLs at render time via `r2-link-render.js`, but:
- URLs were still in `message.text` in DB → `/api/chat/history` still returned them
- Non-webview readers (bots, API exports, backups, cross-device sync) saw raw URLs unchanged
- Receiving bots got `[📎 filename](url)` inside the push body

Hank 2026-04-24 correction: fix compose-path so URL never enters `message.text` in the first place. The legacy `replaceR2Links()` fallback chip still renders old raw-URL messages correctly.

## Test plan
- [x] Jest: 3 new specs (`client/speak structured attachments`) — 10-item cap, extra-field stripping, fileId-required filter
- [x] Jest regression: 61 tests passing (chat + cross-speak + r2-link-render)
- [x] ESLint clean on edited files
- [ ] CI (awaiting)
- [ ] Prod E2E after merge+deploy: attach cloud-library file → send → verify message bubble shows filename card with Download button, `message.text` in /api/chat/history contains no signed URL, receiving bot sees `[📎 filename]` hint only

🤖 Generated with [Claude Code](https://claude.com/claude-code)