### PR TITLE
feat(chip): Smart Chip B — reference-preview popover (card + requote)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -2093,6 +2093,60 @@
             border-color: rgba(168, 85, 247, 0.35);
         }
 
+        /* ── 引用預覽卡 popover (Chip B) ── */
+        .autolink-chip-popover {
+            background: #1e1e28;
+            border: 1px solid rgba(168, 85, 247, 0.45);
+            border-radius: 10px;
+            box-shadow: 0 12px 32px rgba(0, 0, 0, 0.55);
+            color: #eee;
+            font-size: 13px;
+            overflow: hidden;
+        }
+        .autolink-chip-popover .chip-popover-header {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            padding: 8px 10px;
+            background: rgba(168, 85, 247, 0.10);
+            border-bottom: 1px solid rgba(255,255,255,0.06);
+        }
+        .autolink-chip-popover .chip-popover-title {
+            flex: 1;
+            font-weight: 600;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+        }
+        .autolink-chip-popover .chip-popover-status {
+            font-size: 11px;
+            padding: 1px 6px;
+            border-radius: 4px;
+            background: rgba(255,255,255,0.08);
+            text-transform: uppercase;
+        }
+        .autolink-chip-popover .chip-status--done { background: rgba(34,197,94,0.2); color: #4ade80; }
+        .autolink-chip-popover .chip-status--in_progress { background: rgba(59,130,246,0.2); color: #60a5fa; }
+        .autolink-chip-popover .chip-status--todo { background: rgba(250,204,21,0.2); color: #facc15; }
+        .autolink-chip-popover .chip-status--blocked { background: rgba(239,68,68,0.2); color: #f87171; }
+        .autolink-chip-popover .chip-popover-btn {
+            background: transparent;
+            border: none;
+            color: #aaa;
+            cursor: pointer;
+            font-size: 14px;
+            padding: 2px 4px;
+            border-radius: 4px;
+        }
+        .autolink-chip-popover .chip-popover-btn:hover { background: rgba(255,255,255,0.08); color: #fff; }
+        .autolink-chip-popover .chip-popover-body { padding: 8px 10px; max-height: 180px; overflow-y: auto; }
+        .autolink-chip-popover .chip-popover-desc { color: #ccc; line-height: 1.45; margin-bottom: 6px; white-space: pre-wrap; }
+        .autolink-chip-popover .chip-popover-comment { font-size: 12px; color: #aaa; margin-top: 4px; padding-left: 4px; border-left: 2px solid rgba(168,85,247,0.3); }
+        .autolink-chip-popover .chip-popover-footer { padding: 6px 10px; border-top: 1px solid rgba(255,255,255,0.06); text-align: right; }
+        .autolink-chip-popover .chip-popover-open { color: #c084fc; font-size: 12px; text-decoration: none; }
+        .autolink-chip-popover .chip-popover-open:hover { text-decoration: underline; }
+        .autolink-chip-popover .chip-popover-loading, .autolink-chip-popover .chip-popover-error { padding: 16px; text-align: center; color: #888; font-size: 12px; }
+
         /* ── Entity Preview Modal ── */
         #entityPreviewModal .modal-box {
             max-width: 600px;
@@ -2528,6 +2582,7 @@
     <script src="shared/entity-link-render.js"></script>
     <script src="shared/his-link-render.js"></script>
     <script src="shared/autolink-chip.js"></script>
+    <script src="shared/autolink-chip-preview.js"></script>
     <script src="shared/r2-link-render.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -125,6 +125,25 @@
         .autolink-chip--review { background:rgba(250,204,21,0.18); color:#facc15; border-color:rgba(250,204,21,0.35); }
         .autolink-chip--src { background:rgba(168,85,247,0.18); color:#c084fc; border-color:rgba(168,85,247,0.35); }
 
+        /* 引用預覽卡 popover (Chip B) */
+        .autolink-chip-popover { background:#1e1e28; border:1px solid rgba(168,85,247,0.45); border-radius:10px; box-shadow:0 12px 32px rgba(0,0,0,.55); color:#eee; font-size:13px; overflow:hidden; }
+        .autolink-chip-popover .chip-popover-header { display:flex; align-items:center; gap:6px; padding:8px 10px; background:rgba(168,85,247,.10); border-bottom:1px solid rgba(255,255,255,.06); }
+        .autolink-chip-popover .chip-popover-title { flex:1; font-weight:600; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+        .autolink-chip-popover .chip-popover-status { font-size:11px; padding:1px 6px; border-radius:4px; background:rgba(255,255,255,.08); text-transform:uppercase; }
+        .autolink-chip-popover .chip-status--done { background:rgba(34,197,94,.2); color:#4ade80; }
+        .autolink-chip-popover .chip-status--in_progress { background:rgba(59,130,246,.2); color:#60a5fa; }
+        .autolink-chip-popover .chip-status--todo { background:rgba(250,204,21,.2); color:#facc15; }
+        .autolink-chip-popover .chip-status--blocked { background:rgba(239,68,68,.2); color:#f87171; }
+        .autolink-chip-popover .chip-popover-btn { background:transparent; border:none; color:#aaa; cursor:pointer; font-size:14px; padding:2px 4px; border-radius:4px; }
+        .autolink-chip-popover .chip-popover-btn:hover { background:rgba(255,255,255,.08); color:#fff; }
+        .autolink-chip-popover .chip-popover-body { padding:8px 10px; max-height:180px; overflow-y:auto; }
+        .autolink-chip-popover .chip-popover-desc { color:#ccc; line-height:1.45; margin-bottom:6px; white-space:pre-wrap; }
+        .autolink-chip-popover .chip-popover-comment { font-size:12px; color:#aaa; margin-top:4px; padding-left:4px; border-left:2px solid rgba(168,85,247,.3); }
+        .autolink-chip-popover .chip-popover-footer { padding:6px 10px; border-top:1px solid rgba(255,255,255,.06); text-align:right; }
+        .autolink-chip-popover .chip-popover-open { color:#c084fc; font-size:12px; text-decoration:none; }
+        .autolink-chip-popover .chip-popover-open:hover { text-decoration:underline; }
+        .autolink-chip-popover .chip-popover-loading, .autolink-chip-popover .chip-popover-error { padding:16px; text-align:center; color:#888; font-size:12px; }
+
         /* Modal tabs */
         .kb-modal-tabs { display:flex; gap:0; padding:0 24px; border-bottom:1px solid var(--card-border); }
         .kb-modal-tab { padding:10px 16px; font-size:13px; font-weight:600; color:var(--text-secondary); background:none; border:none; border-bottom:2px solid transparent; cursor:pointer; }
@@ -764,6 +783,7 @@
     <script src="shared/entity-link-render.js"></script>
     <script src="shared/note-link-render.js"></script>
     <script src="shared/autolink-chip.js"></script>
+    <script src="shared/autolink-chip-preview.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
     <script src="/socket.io/socket.io.js"></script>

--- a/backend/public/portal/shared/autolink-chip-preview.js
+++ b/backend/public/portal/shared/autolink-chip-preview.js
@@ -1,0 +1,209 @@
+/**
+ * AutolinkChipPreview — Smart-quote Chip B.
+ *
+ * Registers window.AutolinkChipPreview so AutolinkChip.onChipClick opens a
+ * popover instead of deep-linking. Popover shows the referenced entity's
+ * title / status / first 200 chars / last 1–2 comments, with a requote (📌)
+ * button that inserts a fresh [引用 <id>] token into the active chat input.
+ *
+ * Only one popover at a time. ESC / outside-click closes it.
+ *
+ * Supported ref types (Phase 1):
+ *   - src://kanban/card/<id>  → GET /api/mission/card/:id
+ *
+ * Unsupported types render a graceful "尚未支援" popover (later cards will
+ * add note/review endpoints + rendering).
+ */
+(function (global) {
+    'use strict';
+
+    let currentPopover = null;
+    let currentAnchor = null;
+
+    function t(key, fallback) {
+        try { return (global.i18n && typeof global.i18n.t === 'function') ? (global.i18n.t(key) || fallback) : fallback; }
+        catch (_) { return fallback; }
+    }
+
+    function escapeHtml(s) {
+        const d = document.createElement('div');
+        d.textContent = s == null ? '' : String(s);
+        return d.innerHTML;
+    }
+
+    function closePopover() {
+        if (!currentPopover) return;
+        currentPopover.remove();
+        currentPopover = null;
+        currentAnchor = null;
+    }
+
+    function positionPopover(pop, anchorEl) {
+        const rect = anchorEl.getBoundingClientRect();
+        const width = 320;
+        const viewportW = window.innerWidth;
+        const gap = 6;
+        let left = rect.left + window.scrollX;
+        if (left + width > window.scrollX + viewportW - 8) {
+            left = window.scrollX + viewportW - width - 8;
+        }
+        if (left < window.scrollX + 8) left = window.scrollX + 8;
+        pop.style.position = 'absolute';
+        pop.style.top = (rect.bottom + window.scrollY + gap) + 'px';
+        pop.style.left = left + 'px';
+        pop.style.width = width + 'px';
+        pop.style.zIndex = '9999';
+    }
+
+    function openPreview(refType, refId, anchorEl) {
+        closePopover();
+        const pop = document.createElement('div');
+        pop.className = 'autolink-chip-popover';
+        pop.setAttribute('data-ref-type', refType);
+        pop.setAttribute('data-ref-id', refId);
+        pop._refType = refType;
+        pop._refId = refId;
+        pop._data = null;
+        pop.innerHTML = buildLoadingHtml();
+        document.body.appendChild(pop);
+        positionPopover(pop, anchorEl);
+        currentPopover = pop;
+        currentAnchor = anchorEl;
+        bindPopoverActions(pop);
+
+        resolveRef(refType, refId).then(data => {
+            if (currentPopover !== pop) return;
+            pop._data = data;
+            pop.innerHTML = buildContentHtml(data, refType, refId);
+        }).catch(err => {
+            if (currentPopover !== pop) return;
+            pop._data = null;
+            pop.innerHTML = buildErrorHtml(err, refType, refId);
+        });
+    }
+
+    function resolveRef(refType, refId) {
+        if (refType === 'src') {
+            const m = /^src:\/\/([a-z]+)\/([a-z]+)\/([a-f0-9]{8,})(#.+)?$/i.exec(refId);
+            if (!m) return Promise.reject(new Error('bad src token'));
+            const kind = m[1], type = m[2], id = m[3], anchor = m[4] || null;
+            if (kind === 'kanban' && type === 'card') {
+                const deviceId = (global.currentUser && global.currentUser.deviceId) || '';
+                const url = '/api/mission/card/card_' + id + (deviceId ? '?deviceId=' + encodeURIComponent(deviceId) : '');
+                return fetch(url, { credentials: 'include' })
+                    .then(r => r.json())
+                    .then(j => {
+                        if (j && j.success === false) throw new Error(j.error || 'fetch failed');
+                        const card = j.card || j;
+                        if (!card || !card.id) throw new Error('card not found');
+                        return { kind: 'card', data: card, anchor, refType, refId };
+                    });
+            }
+            return Promise.reject(new Error('ref_not_supported:' + kind + '/' + type));
+        }
+        if (refType === 'review') {
+            return Promise.reject(new Error('ref_not_supported:review'));
+        }
+        return Promise.reject(new Error('ref_not_supported:' + refType));
+    }
+
+    function buildLoadingHtml() {
+        return `<div class="chip-popover-loading">${escapeHtml(t('chip_popover_loading', '載入中…'))}</div>`;
+    }
+
+    function buildErrorHtml(err, refType, refId) {
+        const msg = (err && err.message && err.message.startsWith('ref_not_supported:'))
+            ? t('chip_popover_not_supported', '此引用類型尚未支援預覽')
+            : t('chip_popover_load_error', '載入失敗') + (err && err.message ? ' (' + escapeHtml(err.message.slice(0, 60)) + ')' : '');
+        return `
+            <div class="chip-popover-header">
+                <span class="chip-popover-title">${escapeHtml(refId || '')}</span>
+                <button class="chip-popover-btn chip-popover-close" title="${escapeHtml(t('common_close', '關閉'))}" data-action="close">✖</button>
+            </div>
+            <div class="chip-popover-body"><div class="chip-popover-error">${escapeHtml(msg)}</div></div>
+        `;
+    }
+
+    function buildContentHtml(d, refType, refId) {
+        if (d.kind !== 'card') return buildErrorHtml(new Error('ref_not_supported:kind'), refType, refId);
+        const c = d.data;
+        const status = c.status || 'todo';
+        const desc = (c.description || '').slice(0, 200);
+        const hasMoreDesc = (c.description || '').length > 200;
+        const comments = (Array.isArray(c.comments) ? c.comments.slice(-2) : []).map(cmt => {
+            const text = (cmt.text || '').slice(0, 120);
+            return '<div class="chip-popover-comment">💬 ' + escapeHtml(text) + (cmt.text && cmt.text.length > 120 ? '…' : '') + '</div>';
+        }).join('');
+        const hashId = c.id.indexOf('card_') === 0 ? c.id : ('card_' + c.id);
+        const fullUrl = '/portal/kanban.html#' + hashId;
+        const requoteTitle = t('chip_popover_requote', '再引用到聊天');
+        const closeTitle = t('common_close', '關閉');
+        const openFullLabel = t('chip_popover_open_full', '打開完整頁面 →');
+        return `
+            <div class="chip-popover-header">
+                <span class="chip-popover-title" title="${escapeHtml(c.title || '')}">${escapeHtml(c.title || '')}</span>
+                <span class="chip-popover-status chip-status--${escapeHtml(status)}">${escapeHtml(status)}</span>
+                <button class="chip-popover-btn chip-popover-quote" title="${escapeHtml(requoteTitle)}" data-action="requote">📌</button>
+                <button class="chip-popover-btn chip-popover-close" title="${escapeHtml(closeTitle)}" data-action="close">✖</button>
+            </div>
+            <div class="chip-popover-body">
+                ${desc ? '<div class="chip-popover-desc">' + escapeHtml(desc) + (hasMoreDesc ? '…' : '') + '</div>' : ''}
+                ${comments}
+            </div>
+            <div class="chip-popover-footer">
+                <a href="${escapeHtml(fullUrl)}" class="chip-popover-open">${escapeHtml(openFullLabel)}</a>
+            </div>
+        `;
+    }
+
+    function bindPopoverActions(pop) {
+        pop.addEventListener('click', (e) => {
+            const btn = e.target.closest('[data-action]');
+            if (!btn) return;
+            e.stopPropagation();
+            const action = btn.getAttribute('data-action');
+            if (action === 'close') { closePopover(); return; }
+            if (action === 'requote') { insertRequoteToken(pop._data, pop._refType, pop._refId); closePopover(); return; }
+        });
+    }
+
+    function insertRequoteToken(data, refType, refId) {
+        const token = tokenFor(data, refType, refId);
+        const input = document.getElementById('messageInput') || document.querySelector('textarea, [contenteditable="true"]');
+        if (!input) return;
+        if (input.tagName === 'TEXTAREA' || input.tagName === 'INPUT') {
+            const cur = input.value || '';
+            const pos = input.selectionStart != null ? input.selectionStart : cur.length;
+            const before = cur.slice(0, pos), after = cur.slice(pos);
+            const insert = (before && !before.endsWith(' ') ? ' ' : '') + token + ' ';
+            input.value = before + insert + after;
+            input.focus();
+            const caret = before.length + insert.length;
+            try { input.setSelectionRange(caret, caret); } catch (_) {}
+            input.dispatchEvent(new Event('input', { bubbles: true }));
+        } else {
+            input.focus();
+            document.execCommand && document.execCommand('insertText', false, token + ' ');
+        }
+    }
+
+    function tokenFor(data, refType, refId) {
+        if (data && data.kind === 'card' && data.data && data.data.id) {
+            return data.data.id; // already `card_<hex>`; EntityLinkRender will re-chip it on render
+        }
+        return refId;
+    }
+
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape' && currentPopover) { closePopover(); }
+    });
+    document.addEventListener('click', (e) => {
+        if (!currentPopover) return;
+        if (e.target.closest('.autolink-chip-popover') || e.target === currentAnchor || e.target.closest('.autolink-chip')) return;
+        closePopover();
+    });
+
+    global.AutolinkChipPreview = openPreview;
+    global.AutolinkChipPreview._close = closePopover;
+    global.AutolinkChipPreview._current = () => currentPopover;
+})(window);

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -3035,6 +3035,13 @@ const TRANSLATIONS = {
         "files_multi_select_attach": "Attach to chat",
         "files_multi_select_cancel": "Cancel",
 
+        // 智慧引用 Chip B — preview popover
+        "chip_popover_loading": "Loading…",
+        "chip_popover_load_error": "Load failed",
+        "chip_popover_not_supported": "Preview not yet supported for this reference type",
+        "chip_popover_requote": "Quote to chat again",
+        "chip_popover_open_full": "Open full page →",
+
         // Compare Channels (compare-channels.html)
         "cmp_title": "EClawbot vs Telegram - Channel Comparison",
         "cmp_eclaw_name": "EClawbot",
@@ -7649,6 +7656,11 @@ const TRANSLATIONS = {
         "files_multi_select_count": "已選",
         "files_multi_select_attach": "夾帶到聊天",
         "files_multi_select_cancel": "取消",
+        "chip_popover_loading": "載入中…",
+        "chip_popover_load_error": "載入失敗",
+        "chip_popover_not_supported": "此引用類型尚未支援預覽",
+        "chip_popover_requote": "再引用到聊天",
+        "chip_popover_open_full": "打開完整頁面 →",
         "cmp_title": "EClawbot vs Telegram — 頻道比較",
         "cmp_eclaw_name": "EClawbot",
         "cmp_telegram_name": "Telegram",


### PR DESCRIPTION
## Summary
- Click an autolink chip → inline **preview popover** with title / status / desc / last 2 comments (no full-page nav).
- Header 📌 button inserts a fresh `card_<id>` token at the chat input caret — closes the quote→edit→re-quote loop.
- ✖ / **ESC** / outside-click all close cleanly; only one popover at a time.
- Phase 1 scope: `src://kanban/card/<id>` only. Other ref types (`review_*`, notes, …) render a graceful zh-Hant *尚未支援預覽* message so they're safe to drop in right now — future cards add handlers without touching call-sites.

Plugs into the existing `window.AutolinkChipPreview` extension point that Chip A already wired, so `chat.html` + `kanban.html` just get the `<script>` include + a CSS block.

## Files
- **new** `backend/public/portal/shared/autolink-chip-preview.js` — popover module (~200 lines, no deps)
- `backend/public/portal/chat.html` — script tag + popover CSS
- `backend/public/portal/kanban.html` — script tag + popover CSS
- `backend/public/shared/i18n.js` — 5 new keys × EN / zh-Hant

## Test plan
E2E via local harness with stubbed `/api/mission/card/:id` — all green:
- [x] card `done` → green DONE badge
- [x] card `in_progress` → blue IN_PROGRESS badge
- [x] desc trimmed to 200 chars with ellipsis
- [x] last 2 comments only, each truncated at 120 chars
- [x] 📌 requote → exactly one clean `card_<hex>` token inserted (fixed double-listener bug found mid-drill)
- [x] ✖ close, ESC close, outside-click close
- [x] review chip → graceful *此引用類型尚未支援預覽* fallback
- [x] zero JS errors in console
- [x] `node --check` clean, ESLint 0 errors, i18n-check all referenced keys resolve in EN

Screenshots: `pr_chipb-01` (done popover), `pr_chipb-02` (requote inserted), `pr_chipb-03` (in_progress), `pr_chipb-04` (review unsupported).

Closes `card_8088ace696bbb81d01a0c601` (Smart Chip B popover).

🤖 Generated with [Claude Code](https://claude.com/claude-code)