### PR TITLE
feat(chip): Smart Chip C — nested popover stack (cycle + depth guards)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -2146,6 +2146,7 @@
         .autolink-chip-popover .chip-popover-open { color: #c084fc; font-size: 12px; text-decoration: none; }
         .autolink-chip-popover .chip-popover-open:hover { text-decoration: underline; }
         .autolink-chip-popover .chip-popover-loading, .autolink-chip-popover .chip-popover-error { padding: 16px; text-align: center; color: #888; font-size: 12px; }
+        .autolink-chip-toast { background: rgba(30, 30, 40, 0.95); color: #facc15; border: 1px solid rgba(250, 204, 21, 0.4); border-radius: 6px; padding: 6px 10px; font-size: 12px; box-shadow: 0 4px 12px rgba(0, 0, 0, 0.5); transition: opacity 0.4s; pointer-events: none; }
 
         /* ── Entity Preview Modal ── */
         #entityPreviewModal .modal-box {

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -143,6 +143,7 @@
         .autolink-chip-popover .chip-popover-open { color:#c084fc; font-size:12px; text-decoration:none; }
         .autolink-chip-popover .chip-popover-open:hover { text-decoration:underline; }
         .autolink-chip-popover .chip-popover-loading, .autolink-chip-popover .chip-popover-error { padding:16px; text-align:center; color:#888; font-size:12px; }
+        .autolink-chip-toast { background:rgba(30,30,40,0.95); color:#facc15; border:1px solid rgba(250,204,21,0.4); border-radius:6px; padding:6px 10px; font-size:12px; box-shadow:0 4px 12px rgba(0,0,0,0.5); transition:opacity 0.4s; pointer-events:none; }
 
         /* Modal tabs */
         .kb-modal-tabs { display:flex; gap:0; padding:0 24px; border-bottom:1px solid var(--card-border); }

--- a/backend/public/portal/shared/autolink-chip-preview.js
+++ b/backend/public/portal/shared/autolink-chip-preview.js
@@ -1,24 +1,26 @@
 /**
- * AutolinkChipPreview — Smart-quote Chip B.
+ * AutolinkChipPreview — Smart-quote Chip B + nested-recursion Chip C.
  *
- * Registers window.AutolinkChipPreview so AutolinkChip.onChipClick opens a
- * popover instead of deep-linking. Popover shows the referenced entity's
- * title / status / first 200 chars / last 1–2 comments, with a requote (📌)
- * button that inserts a fresh [引用 <id>] token into the active chat input.
+ * Click an autolink chip → popover with title/status/desc/last-2 comments and
+ * a 📌 requote button. Embedded refs inside the popover content (a card whose
+ * description mentions another card_/src:// token) re-render as nested chips;
+ * clicking one stacks a child popover on top, up to MAX_DEPTH layers.
  *
- * Only one popover at a time. ESC / outside-click closes it.
+ * Cycle guard: clicking a chip whose refId is already on the open stack shows
+ * a transient toast "已在引用堆疊上". Depth guard: stack at MAX_DEPTH shows
+ * "太深，請直接跳頁".
+ *
+ * ESC / outside-click closes the entire stack.
  *
  * Supported ref types (Phase 1):
  *   - src://kanban/card/<id>  → GET /api/mission/card/:id
- *
- * Unsupported types render a graceful "尚未支援" popover (later cards will
- * add note/review endpoints + rendering).
  */
 (function (global) {
     'use strict';
 
-    let currentPopover = null;
-    let currentAnchor = null;
+    const MAX_DEPTH = 5;
+    let stack = []; // pop elements; stack[0] = root, last = innermost
+    let rootAnchor = null;
 
     function t(key, fallback) {
         try { return (global.i18n && typeof global.i18n.t === 'function') ? (global.i18n.t(key) || fallback) : fallback; }
@@ -31,11 +33,21 @@
         return d.innerHTML;
     }
 
-    function closePopover() {
-        if (!currentPopover) return;
-        currentPopover.remove();
-        currentPopover = null;
-        currentAnchor = null;
+    function renderChips(escapedHtml) {
+        if (global.AutolinkChip && typeof global.AutolinkChip.render === 'function') {
+            try { return global.AutolinkChip.render(escapedHtml); } catch (_) {}
+        }
+        return escapedHtml;
+    }
+
+    function closeAll() {
+        while (stack.length) stack.pop().remove();
+        rootAnchor = null;
+    }
+
+    function closeFromIndex(idx) {
+        while (stack.length > idx) stack.pop().remove();
+        if (!stack.length) rootAnchor = null;
     }
 
     function positionPopover(pop, anchorEl) {
@@ -52,11 +64,33 @@
         pop.style.top = (rect.bottom + window.scrollY + gap) + 'px';
         pop.style.left = left + 'px';
         pop.style.width = width + 'px';
-        pop.style.zIndex = '9999';
+        pop.style.zIndex = String(9999 + stack.length);
+    }
+
+    function refKey(refType, refId) { return refType + '|' + refId; }
+
+    function isOnStack(refType, refId) {
+        const key = refKey(refType, refId);
+        return stack.some(p => refKey(p._refType, p._refId) === key);
     }
 
     function openPreview(refType, refId, anchorEl) {
-        closePopover();
+        // Top-level call (from a chip outside any popover) — close existing stack first
+        if (!anchorEl || !anchorEl.closest('.autolink-chip-popover')) {
+            closeAll();
+            rootAnchor = anchorEl;
+        }
+
+        // Cycle / depth guards
+        if (isOnStack(refType, refId)) {
+            showToast(anchorEl, t('chip_popover_cycle', '已在引用堆疊上'));
+            return;
+        }
+        if (stack.length >= MAX_DEPTH) {
+            showToast(anchorEl, t('chip_popover_too_deep', '太深，請直接跳頁'));
+            return;
+        }
+
         const pop = document.createElement('div');
         pop.className = 'autolink-chip-popover';
         pop.setAttribute('data-ref-type', refType);
@@ -64,19 +98,19 @@
         pop._refType = refType;
         pop._refId = refId;
         pop._data = null;
+        pop._depth = stack.length;
         pop.innerHTML = buildLoadingHtml();
         document.body.appendChild(pop);
         positionPopover(pop, anchorEl);
-        currentPopover = pop;
-        currentAnchor = anchorEl;
+        stack.push(pop);
         bindPopoverActions(pop);
 
         resolveRef(refType, refId).then(data => {
-            if (currentPopover !== pop) return;
+            if (!stack.includes(pop)) return;
             pop._data = data;
             pop.innerHTML = buildContentHtml(data, refType, refId);
         }).catch(err => {
-            if (currentPopover !== pop) return;
+            if (!stack.includes(pop)) return;
             pop._data = null;
             pop.innerHTML = buildErrorHtml(err, refType, refId);
         });
@@ -128,12 +162,15 @@
         if (d.kind !== 'card') return buildErrorHtml(new Error('ref_not_supported:kind'), refType, refId);
         const c = d.data;
         const status = c.status || 'todo';
-        const desc = (c.description || '').slice(0, 200);
+        const descRaw = (c.description || '').slice(0, 200);
         const hasMoreDesc = (c.description || '').length > 200;
+        const desc = renderChips(escapeHtml(descRaw)) + (hasMoreDesc ? '…' : '');
         const comments = (Array.isArray(c.comments) ? c.comments.slice(-2) : []).map(cmt => {
-            const text = (cmt.text || '').slice(0, 120);
-            return '<div class="chip-popover-comment">💬 ' + escapeHtml(text) + (cmt.text && cmt.text.length > 120 ? '…' : '') + '</div>';
+            const raw = (cmt.text || '').slice(0, 120);
+            const truncated = cmt.text && cmt.text.length > 120 ? '…' : '';
+            return '<div class="chip-popover-comment">💬 ' + renderChips(escapeHtml(raw)) + truncated + '</div>';
         }).join('');
+        const titleRendered = renderChips(escapeHtml(c.title || ''));
         const hashId = c.id.indexOf('card_') === 0 ? c.id : ('card_' + c.id);
         const fullUrl = '/portal/kanban.html#' + hashId;
         const requoteTitle = t('chip_popover_requote', '再引用到聊天');
@@ -141,13 +178,13 @@
         const openFullLabel = t('chip_popover_open_full', '打開完整頁面 →');
         return `
             <div class="chip-popover-header">
-                <span class="chip-popover-title" title="${escapeHtml(c.title || '')}">${escapeHtml(c.title || '')}</span>
+                <span class="chip-popover-title" title="${escapeHtml(c.title || '')}">${titleRendered}</span>
                 <span class="chip-popover-status chip-status--${escapeHtml(status)}">${escapeHtml(status)}</span>
                 <button class="chip-popover-btn chip-popover-quote" title="${escapeHtml(requoteTitle)}" data-action="requote">📌</button>
                 <button class="chip-popover-btn chip-popover-close" title="${escapeHtml(closeTitle)}" data-action="close">✖</button>
             </div>
             <div class="chip-popover-body">
-                ${desc ? '<div class="chip-popover-desc">' + escapeHtml(desc) + (hasMoreDesc ? '…' : '') + '</div>' : ''}
+                ${descRaw ? '<div class="chip-popover-desc">' + desc + '</div>' : ''}
                 ${comments}
             </div>
             <div class="chip-popover-footer">
@@ -158,13 +195,46 @@
 
     function bindPopoverActions(pop) {
         pop.addEventListener('click', (e) => {
+            // Nested chip click → recurse into openPreview
+            const chip = e.target.closest('.autolink-chip');
+            if (chip && pop.contains(chip)) {
+                e.stopPropagation();
+                e.preventDefault();
+                const refType = chip.getAttribute('data-ref-type');
+                const refId = chip.getAttribute('data-ref-id');
+                if (refType && refId) {
+                    // Truncate stack above this popover (close any deeper siblings) before opening
+                    const myIdx = stack.indexOf(pop);
+                    if (myIdx >= 0) closeFromIndex(myIdx + 1);
+                    openPreview(refType, refId, chip);
+                }
+                return;
+            }
             const btn = e.target.closest('[data-action]');
             if (!btn) return;
             e.stopPropagation();
             const action = btn.getAttribute('data-action');
-            if (action === 'close') { closePopover(); return; }
-            if (action === 'requote') { insertRequoteToken(pop._data, pop._refType, pop._refId); closePopover(); return; }
+            if (action === 'close') {
+                const idx = stack.indexOf(pop);
+                if (idx >= 0) closeFromIndex(idx);
+                return;
+            }
+            if (action === 'requote') { insertRequoteToken(pop._data, pop._refType, pop._refId); closeAll(); return; }
         });
+    }
+
+    function showToast(anchorEl, msg) {
+        const tip = document.createElement('div');
+        tip.className = 'autolink-chip-toast';
+        tip.textContent = msg;
+        const rect = (anchorEl && anchorEl.getBoundingClientRect) ? anchorEl.getBoundingClientRect() : { left: 100, top: 100, bottom: 120 };
+        tip.style.position = 'absolute';
+        tip.style.top = (rect.bottom + window.scrollY + 4) + 'px';
+        tip.style.left = (rect.left + window.scrollX) + 'px';
+        tip.style.zIndex = String(9999 + stack.length + 1);
+        document.body.appendChild(tip);
+        setTimeout(() => { tip.style.opacity = '0'; }, 1200);
+        setTimeout(() => { tip.remove(); }, 1800);
     }
 
     function insertRequoteToken(data, refType, refId) {
@@ -189,21 +259,25 @@
 
     function tokenFor(data, refType, refId) {
         if (data && data.kind === 'card' && data.data && data.data.id) {
-            return data.data.id; // already `card_<hex>`; EntityLinkRender will re-chip it on render
+            return data.data.id;
         }
         return refId;
     }
 
     document.addEventListener('keydown', (e) => {
-        if (e.key === 'Escape' && currentPopover) { closePopover(); }
+        if (e.key === 'Escape' && stack.length) { closeAll(); }
     });
     document.addEventListener('click', (e) => {
-        if (!currentPopover) return;
-        if (e.target.closest('.autolink-chip-popover') || e.target === currentAnchor || e.target.closest('.autolink-chip')) return;
-        closePopover();
+        if (!stack.length) return;
+        if (e.target.closest('.autolink-chip-popover')) return;
+        if (e.target.closest('.autolink-chip-toast')) return;
+        if (e.target === rootAnchor) return;
+        if (e.target.closest('.autolink-chip')) return;
+        closeAll();
     });
 
     global.AutolinkChipPreview = openPreview;
-    global.AutolinkChipPreview._close = closePopover;
-    global.AutolinkChipPreview._current = () => currentPopover;
+    global.AutolinkChipPreview._closeAll = closeAll;
+    global.AutolinkChipPreview._stack = () => stack.slice();
+    global.AutolinkChipPreview._MAX_DEPTH = MAX_DEPTH;
 })(window);

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -3041,6 +3041,8 @@ const TRANSLATIONS = {
         "chip_popover_not_supported": "Preview not yet supported for this reference type",
         "chip_popover_requote": "Quote to chat again",
         "chip_popover_open_full": "Open full page →",
+        "chip_popover_cycle": "Already in the reference stack",
+        "chip_popover_too_deep": "Too deep — open the full page instead",
 
         // Compare Channels (compare-channels.html)
         "cmp_title": "EClawbot vs Telegram - Channel Comparison",
@@ -7661,6 +7663,8 @@ const TRANSLATIONS = {
         "chip_popover_not_supported": "此引用類型尚未支援預覽",
         "chip_popover_requote": "再引用到聊天",
         "chip_popover_open_full": "打開完整頁面 →",
+        "chip_popover_cycle": "已在引用堆疊上",
+        "chip_popover_too_deep": "太深，請直接跳頁",
         "cmp_title": "EClawbot vs Telegram — 頻道比較",
         "cmp_eclaw_name": "EClawbot",
         "cmp_telegram_name": "Telegram",


### PR DESCRIPTION
## Summary
- Embedded refs inside Chip B's preview popover (title / description / comments) now re-render as **nested chips**. Click → child popover stacks on top.
- **Cycle guard**: clicking a chip whose refId is already on the open stack → transient toast "已在引用堆疊上", no new popover.
- **Depth guard**: stack at `MAX_DEPTH=5` → toast "太深，請直接跳頁".
- ESC / outside-click closes the entire stack at once. 📌 requote from any depth closes the stack and inserts that card's `card_<hex>` token.
- Clicking a chip in a non-top popover closes deeper siblings first (siblings semantically replace, not pile).

## Files
- `backend/public/portal/shared/autolink-chip-preview.js` — refactor `currentPopover` → `stack[]`; route nested clicks through `openPreview`; add cycle/depth guards + toast helper; wire `AutolinkChip.render` over title / description / comment content
- `backend/public/portal/chat.html` / `kanban.html` — `.autolink-chip-toast` style
- `backend/public/shared/i18n.js` — 2 new keys × EN / zh-Hant (`chip_popover_cycle`, `chip_popover_too_deep`)

## Test plan
E2E harness (X→Y→Z→X cycle + D1..D6 depth chain), all green:
- [x] X popover renders 2 nested chips (Y in desc, X self-ref in comment)
- [x] click Y → stack 2; click Z → stack 3
- [x] click X-cycle chip in Z → toast "已在引用堆疊上", stack stays at 3
- [x] D1→D2→D3→D4→D5 stack reaches 5 with `topTitle: D5`
- [x] click D6 chip → toast "太深，請直接跳頁", stack stays at 5
- [x] ESC closes the entire stack
- [x] 📌 from D5 closes stack + inserts `card_d5d5d5d500000000eeeeeeee `
- [x] 0 console errors
- [x] ESLint 0 errors / i18n-check all keys resolve

Screenshots: `pr_chipc-01` (X with nested chips), `pr_chipc-02` (3-deep cascade with cycle toast), `pr_chipc-03` (5-deep cascade D1→D5).

Closes `card_6cb1ecf2…` (Smart Chip C nested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)