### PR TITLE
refactor(chat,kanban): share text-chip pipeline via ChatMessageRender

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -2584,7 +2584,8 @@
     <script src="shared/his-link-render.js"></script>
     <script src="shared/autolink-chip.js"></script>
     <script src="shared/autolink-chip-preview.js"></script>
-    <script src="shared/r2-link-render.js"></script>
+    <script src="../shared/r2-link-render.js"></script>
+    <script src="../shared/chat-message-render.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
     <script src="/socket.io/socket.io.js"></script>
@@ -3977,30 +3978,12 @@
                         textHtml = linkified.html;
                         firstUrl = linkified.urls[0] || '';
                     }
-                    // Render @mention tokens as chips (applies to both bot and user messages)
-                    if (window.MentionRender) {
-                        textHtml = MentionRender.renderMentionTokens(textHtml, buildMentionEntityMap(msg));
-                    }
-                    // Render Note ID patterns as clickable chips
-                    if (window.NoteLinkRender) {
-                        textHtml = NoteLinkRender.renderNoteLinks(textHtml);
-                    }
-                    // Render entity references (Card, Skill, Rule, etc.) as clickable chips
-                    if (window.EntityLinkRender) {
-                        textHtml = EntityLinkRender.renderEntityLinks(textHtml);
-                    }
-                    // Render his_<id> history tokens as clickable chips
-                    if (window.HisLinkRender) {
-                        textHtml = HisLinkRender.renderHisLinks(textHtml);
-                    }
-                    // 智慧引用：detect review_ / src:// tokens → 引用晶片 (autolink-chip)
-                    if (window.AutolinkChip) {
-                        textHtml = AutolinkChip.render(textHtml);
-                    }
-                    // Strip raw R2 presigned URLs — replace with attachment cards so
-                    // that access-key IDs and 10-minute bearer tokens never reach the DOM.
-                    if (window.R2LinkRender) {
-                        textHtml = R2LinkRender.replaceR2Links(textHtml);
+                    // Run shared chip pipeline (mention → note → entity → his → autolink-chip → R2)
+                    if (window.ChatMessageRender) {
+                        textHtml = ChatMessageRender.renderTextChips(textHtml, {
+                            surface: 'chat',
+                            mentionEntityMap: buildMentionEntityMap(msg)
+                        });
                     }
                 }
                 // Suppress inline image + link preview when firstUrl is an R2 presigned URL;

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -783,8 +783,12 @@
     <script src="shared/entity-utils.js"></script>
     <script src="shared/entity-link-render.js"></script>
     <script src="shared/note-link-render.js"></script>
+    <script src="shared/mention-render.js"></script>
+    <script src="shared/his-link-render.js"></script>
     <script src="shared/autolink-chip.js"></script>
     <script src="shared/autolink-chip-preview.js"></script>
+    <script src="../shared/r2-link-render.js"></script>
+    <script src="../shared/chat-message-render.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
     <script src="/socket.io/socket.io.js"></script>
@@ -806,9 +810,14 @@
     <script src="shared/ai-chat.js"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'🦞'};window.isAvatarUrl=function(){return false}}</script>
     <script>
-        // 智慧引用 render chain — escape text then apply entity-link / note-link / autolink-chip
+        // 智慧引用 render chain — delegates to shared ChatMessageRender so chat
+        // and kanban surfaces always run the same chip pipeline. Falls back to
+        // the in-line chain if the shared module hasn't loaded yet.
         function renderSmartChips(rawText) {
             if (rawText == null) return '';
+            if (window.ChatMessageRender) {
+                return ChatMessageRender.renderTextChipsFromRaw(rawText, { surface: 'kanban' });
+            }
             let html = escapeHtml(String(rawText));
             if (window.EntityLinkRender) html = EntityLinkRender.renderEntityLinks(html);
             if (window.NoteLinkRender)   html = NoteLinkRender.renderNoteLinks(html);

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -810,6 +810,22 @@
     <script src="shared/ai-chat.js"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'🦞'};window.isAvatarUrl=function(){return false}}</script>
     <script>
+        // Mention chips and his_ chips rendered by shared MentionRender /
+        // HisLinkRender call openMentionProfile() / openHistoryMessage() which
+        // live in chat.html. Stub them here so kanban-side clicks don't throw —
+        // route the user to chat with the target pre-resolved.
+        if (typeof window.openMentionProfile !== 'function') {
+            window.openMentionProfile = function (code) {
+                if (!code) return;
+                window.location.href = '/portal/chat.html?mention=' + encodeURIComponent(code);
+            };
+        }
+        if (typeof window.openHistoryMessage !== 'function') {
+            window.openHistoryMessage = function (msgId) {
+                if (!msgId) return;
+                window.location.href = '/portal/chat.html?his=' + encodeURIComponent(msgId);
+            };
+        }
         // 智慧引用 render chain — delegates to shared ChatMessageRender so chat
         // and kanban surfaces always run the same chip pipeline. Falls back to
         // the in-line chain if the shared module hasn't loaded yet.

--- a/backend/public/shared/chat-message-render.js
+++ b/backend/public/shared/chat-message-render.js
@@ -1,0 +1,83 @@
+/**
+ * ChatMessageRender — shared text-chip pipeline used by both chat.html and
+ * kanban card comments / descriptions. Centralises the chip render order so
+ * the two surfaces can never silently diverge again.
+ *
+ * Input is already-escaped HTML (post escapeHtml or post linkifyText). The
+ * chain runs in the order each downstream module expects:
+ *
+ *   MentionRender → NoteLinkRender → EntityLinkRender → HisLinkRender
+ *     → AutolinkChip → R2LinkRender
+ *
+ * Surface flags let kanban skip features that don't belong on a card-comment
+ * surface (e.g. R2 attachment cards belong to chat messages, not card
+ * comments — kanban shows attachments separately via its own attachment list).
+ *
+ * Each helper module is feature-detected; missing modules degrade gracefully
+ * to "no chip" pass-through, so this file does not require import order
+ * changes in the host page.
+ */
+(function (global) {
+    'use strict';
+
+    /**
+     * @param {string} escapedHtml  Already-escaped HTML (do NOT pass raw text)
+     * @param {Object} [opts]
+     * @param {'chat'|'kanban'} [opts.surface='chat']
+     * @param {Object} [opts.mentionEntityMap]  publicCode → { name, isCrossDevice }
+     * @param {boolean} [opts.skipR2=false]  Force-skip R2 link replacement (chat
+     *        passes `false`; kanban passes `false` too — both want R2 cards.
+     *        Reserved for special surfaces like email export that need raw URLs.)
+     * @returns {string} HTML with chips applied
+     */
+    function renderTextChips(escapedHtml, opts) {
+        if (escapedHtml == null) return '';
+        let html = String(escapedHtml);
+        const o = opts || {};
+        const surface = o.surface || 'chat';
+        const mentionMap = o.mentionEntityMap || {};
+
+        if (global.MentionRender && typeof global.MentionRender.renderMentionTokens === 'function') {
+            html = global.MentionRender.renderMentionTokens(html, mentionMap);
+        }
+        if (global.NoteLinkRender && typeof global.NoteLinkRender.renderNoteLinks === 'function') {
+            html = global.NoteLinkRender.renderNoteLinks(html);
+        }
+        if (global.EntityLinkRender && typeof global.EntityLinkRender.renderEntityLinks === 'function') {
+            html = global.EntityLinkRender.renderEntityLinks(html);
+        }
+        if (global.HisLinkRender && typeof global.HisLinkRender.renderHisLinks === 'function') {
+            html = global.HisLinkRender.renderHisLinks(html);
+        }
+        if (global.AutolinkChip && typeof global.AutolinkChip.render === 'function') {
+            html = global.AutolinkChip.render(html);
+        }
+        if (!o.skipR2 && global.R2LinkRender && typeof global.R2LinkRender.replaceR2Links === 'function') {
+            html = global.R2LinkRender.replaceR2Links(html);
+        }
+
+        // Surface hook reserved for future per-surface trims (e.g. strip
+        // reactions/attachments from kanban). Currently no-op — both surfaces
+        // share the full chip set.
+        void surface;
+
+        return html;
+    }
+
+    /**
+     * Convenience: escape raw text first, then run the chip pipeline. Use
+     * this from kanban where the input is plain text rather than already
+     * escaped HTML. Chat keeps its own escapeHtml + linkifyText path because
+     * it needs the URL list for inline image / link preview rendering.
+     */
+    function renderTextChipsFromRaw(rawText, opts) {
+        const div = document.createElement('div');
+        div.textContent = rawText == null ? '' : String(rawText);
+        return renderTextChips(div.innerHTML, opts);
+    }
+
+    global.ChatMessageRender = {
+        renderTextChips,
+        renderTextChipsFromRaw
+    };
+})(window);

--- a/backend/tests/jest/chat-his-link-render.test.js
+++ b/backend/tests/jest/chat-his-link-render.test.js
@@ -15,6 +15,7 @@ const ROOT = path.join(__dirname, '..', '..');
 const chatHtml = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'chat.html'), 'utf8');
 const i18nJs = fs.readFileSync(path.join(ROOT, 'public', 'shared', 'i18n.js'), 'utf8');
 const hisRenderPath = path.join(ROOT, 'public', 'portal', 'shared', 'his-link-render.js');
+const sharedRenderJs = fs.readFileSync(path.join(ROOT, 'public', 'shared', 'chat-message-render.js'), 'utf8');
 
 const SAMPLE_UUID = '7c424d88-9007-4d9b-9363-d811755847b1';
 const SAMPLE_UUID_2 = '015181ca-52a7-439a-8971-34e2523f4adb';
@@ -28,8 +29,13 @@ describe('his_<uuid> chip — static wiring', () => {
         expect(chatHtml).toContain('shared/his-link-render.js');
     });
 
-    test('chat.html calls HisLinkRender.renderHisLinks in the bubble pipeline', () => {
-        expect(chatHtml).toContain('HisLinkRender.renderHisLinks');
+    test('chat.html runs HisLinkRender via the shared ChatMessageRender pipeline', () => {
+        // The bubble pipeline now delegates the chip chain to ChatMessageRender
+        // (shared between chat.html and kanban.html). Verify chat.html invokes
+        // the shared module *and* the shared module wires HisLinkRender into
+        // the chain — together these still guarantee his_<uuid> rendering.
+        expect(chatHtml).toContain('ChatMessageRender.renderTextChips');
+        expect(sharedRenderJs).toContain('HisLinkRender.renderHisLinks');
     });
 
     test('chat.html defines openHistoryMessage function', () => {

--- a/backend/tests/jest/mention-ux-static.test.js
+++ b/backend/tests/jest/mention-ux-static.test.js
@@ -16,6 +16,7 @@ const ROOT = path.join(__dirname, '..', '..');
 const chatHtml = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'chat.html'), 'utf8');
 const i18nJs = fs.readFileSync(path.join(ROOT, 'public', 'shared', 'i18n.js'), 'utf8');
 const indexJs = fs.readFileSync(path.join(ROOT, 'index.js'), 'utf8');
+const sharedRenderJs = fs.readFileSync(path.join(ROOT, 'public', 'shared', 'chat-message-render.js'), 'utf8');
 
 describe('Mention feature — static wiring', () => {
     test('mention-autocomplete.js and mention-render.js are present in portal/shared', () => {
@@ -39,8 +40,13 @@ describe('Mention feature — static wiring', () => {
         expect(chatHtml).toMatch(/MentionAutocomplete\.attach\(\s*document\.getElementById\(['"]messageInput['"]\)/);
     });
 
-    test('chat.html calls MentionRender.renderMentionTokens in the bubble pipeline', () => {
-        expect(chatHtml).toContain('MentionRender.renderMentionTokens');
+    test('chat.html runs MentionRender via the shared ChatMessageRender pipeline', () => {
+        // The bubble pipeline now delegates the chip chain to ChatMessageRender
+        // (shared between chat.html and kanban.html). Verify chat.html invokes
+        // the shared module *and* the shared module wires MentionRender into
+        // the chain — together these still guarantee @mention chip rendering.
+        expect(chatHtml).toContain('ChatMessageRender.renderTextChips');
+        expect(sharedRenderJs).toContain('MentionRender.renderMentionTokens');
     });
 
     test('chat.html exposes buildMentionEntityMap helper', () => {


### PR DESCRIPTION
## Summary
- Card `card_e9cf8052a06fb34dbda8c693` (P1) — chat.html and kanban.html drifted on chip rendering. Kanban only ran 3 of the 6 chip modules; missing `MentionRender`, `HisLinkRender`, `R2LinkRender`. Adding a new chip type required two near-identical edits and was easy to forget.
- New shared module `backend/public/shared/chat-message-render.js` exposing `ChatMessageRender.renderTextChips(escapedHtml, opts)` + `renderTextChipsFromRaw(rawText, opts)`. Both surfaces call into the same pipeline.
- Surface flag (`'chat'` / `'kanban'`) is wired but currently no-op — both surfaces want the full chip set. Reserved for future per-surface trims (e.g. email export skipping R2 cards).
- **Side-fix**: `chat.html` was loading `<script src="shared/r2-link-render.js">` which 404'd in prod (the file lives at `backend/public/shared/`, served at `/shared/`, not `/portal/shared/`). R2 link rendering had been silently disabled on chat. Path corrected to `../shared/r2-link-render.js`.

## What changes for users
- **Kanban**: card descriptions / comments now render @mention chips, `his_<id>` history chips, and R2 presigned URLs strip into safe attachment cards — parity with chat.
- **Chat**: identical behaviour for non-R2 messages. Messages containing raw R2 presigned URLs now actually strip access-key IDs / 10-min bearer tokens (the intended behaviour that was silently broken).

## Test plan
- [ ] Visit /portal/chat.html: send a message containing `@somebody`, `card_<hex>`, `note_<24hex>`, `review_xxx`, `src://kanban/card/<id>`, `his_<id>` — all become chips. R2 presigned URLs strip into attachment cards (no `X-Amz-` token visible in DOM).
- [ ] Visit /portal/kanban.html: open a card whose description or comment contains those same tokens — same chip set renders. R2 presigned URLs become attachment cards (new behaviour).
- [ ] Smart Chip preview popover (Chip B/C from PR #2079, #2080) still opens / nests / cycles / depth-guards on both surfaces.
- [ ] Console: no `R2LinkRender is not defined`, `ChatMessageRender is not defined`, or undefined-fn errors on either surface.
- [ ] Mobile WebView: same as desktop above.

## Refs
- card_e9cf8052a06fb34dbda8c693 (P1)
- precedent: PR #2059 (`shared/r2-link-render.js` introduction)

🤖 Generated with [Claude Code](https://claude.com/claude-code)