### PR TITLE
fix(scheduled-messages): hotfix prod schema migration (Phase 1 was 500ing)

### DIFF
--- a/backend/scheduled-messages.js
+++ b/backend/scheduled-messages.js
@@ -36,6 +36,16 @@ const POLLER_INTERVAL_MS = 5000;
 const POLLER_BATCH_SIZE = 50;
 
 // ── Schema init ──
+// Columns the Phase 1 routes INSERT into. If a legacy prod table has any
+// other NOT NULL columns (predating Phase 1), our INSERTs will fail with
+// "null value in column X violates not-null constraint", so we relax those
+// at init time.
+const PHASE1_INSERT_COLUMNS = new Set([
+    'id', 'device_id', 'chat_entity_id', 'user_entity_id',
+    'target_entity_ids', 'content', 'scheduled_at', 'created_at',
+    'sent_at', 'cancelled_at', 'last_error',
+]);
+
 async function initScheduledMessagesDatabase() {
     try {
         const schemaPath = path.join(__dirname, 'scheduled_messages_schema.sql');
@@ -59,6 +69,32 @@ async function initScheduledMessagesDatabase() {
                 }
             }
         }
+
+        // Legacy NOT NULL columns predating Phase 1 would block our INSERTs,
+        // since the route handlers don't populate them. Drop NOT NULL on any
+        // unknown column.
+        try {
+            const colRes = await pool.query(
+                `SELECT column_name, is_nullable
+                   FROM information_schema.columns
+                  WHERE table_name = 'scheduled_messages' AND table_schema = 'public'`
+            );
+            for (const row of colRes.rows) {
+                if (row.is_nullable === 'NO' && !PHASE1_INSERT_COLUMNS.has(row.column_name)) {
+                    try {
+                        await pool.query(
+                            `ALTER TABLE scheduled_messages ALTER COLUMN "${row.column_name}" DROP NOT NULL`
+                        );
+                        console.log(`[ScheduledMessages] Relaxed legacy NOT NULL on column "${row.column_name}"`);
+                    } catch (e) {
+                        console.warn(`[ScheduledMessages] Could not relax NOT NULL on "${row.column_name}":`, e.message);
+                    }
+                }
+            }
+        } catch (e) {
+            console.warn('[ScheduledMessages] Legacy-column scan failed:', e.message);
+        }
+
         console.log(`[ScheduledMessages] Database initialized: ${ok} OK, ${skipped} skipped, ${failed} failed`);
     } catch (error) {
         console.error('[ScheduledMessages] Failed to init database:', error.message);

--- a/backend/scheduled_messages_schema.sql
+++ b/backend/scheduled_messages_schema.sql
@@ -20,6 +20,20 @@ CREATE TABLE IF NOT EXISTS scheduled_messages (
     CONSTRAINT scheduled_messages_content_len CHECK (char_length(content) BETWEEN 1 AND 10000)
 );
 
+-- Idempotent column adds for environments that already have a legacy
+-- scheduled_messages table predating Phase 1 (CREATE TABLE IF NOT EXISTS
+-- skips column adds when the table exists, leaving prod missing the new
+-- columns and causing 500s on POST/GET).
+ALTER TABLE scheduled_messages ADD COLUMN IF NOT EXISTS chat_entity_id INTEGER;
+ALTER TABLE scheduled_messages ADD COLUMN IF NOT EXISTS user_entity_id INTEGER;
+ALTER TABLE scheduled_messages ADD COLUMN IF NOT EXISTS target_entity_ids JSONB;
+ALTER TABLE scheduled_messages ADD COLUMN IF NOT EXISTS content TEXT;
+ALTER TABLE scheduled_messages ADD COLUMN IF NOT EXISTS scheduled_at TIMESTAMPTZ;
+ALTER TABLE scheduled_messages ADD COLUMN IF NOT EXISTS created_at TIMESTAMPTZ DEFAULT NOW();
+ALTER TABLE scheduled_messages ADD COLUMN IF NOT EXISTS sent_at TIMESTAMPTZ;
+ALTER TABLE scheduled_messages ADD COLUMN IF NOT EXISTS cancelled_at TIMESTAMPTZ;
+ALTER TABLE scheduled_messages ADD COLUMN IF NOT EXISTS last_error TEXT;
+
 CREATE INDEX IF NOT EXISTS idx_scheduled_messages_pending
     ON scheduled_messages (scheduled_at)
     WHERE sent_at IS NULL AND cancelled_at IS NULL;


### PR DESCRIPTION
## Why

Post-merge prod E2E for **PR #2082 (schedule-popup Phase 2 UI)** uncovered that Phase 1's backend (PR #2067) is currently **500ing on every POST/GET** in production:

```
column "chat_entity_id" of relation "scheduled_messages" does not exist
```

This means **the whole feature has been non-functional in prod since Phase 1 shipped**, and was never noticed because Phase 2 was the first time anything actually called these routes.

## Root cause

Phase 1's `scheduled_messages_schema.sql` uses `CREATE TABLE IF NOT EXISTS`. Prod has a pre-Phase-1 prototype `scheduled_messages` table with different column names — `IF NOT EXISTS` silently skipped the column creation, so the Phase 1 columns (`chat_entity_id`, `user_entity_id`, `target_entity_ids`, `sent_at`, `cancelled_at`) **never got added**.

Jest passed against a fresh test DB, so this only surfaced in prod.

## Fix

1. **`scheduled_messages_schema.sql`** — add `ALTER TABLE … ADD COLUMN IF NOT EXISTS` for every Phase 1 column, after the `CREATE TABLE IF NOT EXISTS`. Idempotent on both fresh DBs (no-op) and legacy DBs (adds the missing columns).

2. **`initScheduledMessagesDatabase`** — after applying the schema, scan `information_schema.columns` for any **legacy NOT NULL columns not in the Phase 1 INSERT set**, and run `ALTER COLUMN … DROP NOT NULL` on each. Without this step, INSERTs would still fail on a legacy table with extra `NOT NULL` columns the Phase 1 routes don't populate.

## Tests

- 22/22 existing Jest tests still pass (`tests/jest/scheduled-messages.test.js`)
- No new tests because the bug only reproduces against a real legacy table — the fresh test DB used in Jest never hits it. Post-merge prod E2E will verify (see schedule-popup card `card_aa55c721b512c1d10288f1e9`).

## Risk

- ALTER TABLE ADD COLUMN IF NOT EXISTS — no-op on fresh DBs.
- Legacy NOT NULL drop — only relaxes constraints we don't use, never tightens them. Existing data on legacy columns is preserved (untouched).

## Related

- Caught by E2E follow-through on PR #2082 (schedule-popup Phase 2 UI, merged earlier today)
- Tracked under kanban card `card_9705fbd342ecdc2332960ae0`