### PR TITLE
fix(schedule-popup): edit on legacy int ids; styled confirm shows i18n labels

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -5390,7 +5390,10 @@
         }
 
         function schedStartEdit(id) {
-            const it = _schedQueue.find(x => x.id === id);
+            // Legacy scheduled_messages.id is INT (SERIAL); rendered onclick passes
+            // a string. Coerce both sides to string before comparing — strict ===
+            // would silently no-op the Edit button on existing rows.
+            const it = _schedQueue.find(x => String(x.id) === String(id));
             if (!it) return;
             _schedEditingId = id;
             const node = document.querySelector('.sched-queue-item[data-sched-id="' + id + '"]');

--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -74,9 +74,19 @@ function showToast(message, type = 'info') {
  * @param {boolean} [opts.danger=false] - Red confirm button for destructive actions
  * @returns {Promise<boolean>}
  */
+// i18n helper that honours a fallback string. i18n.t(key, params) uses the
+// 2nd arg as substitution params, not as a fallback — so passing 'OK' was
+// silently ignored and the dialog rendered the raw key. Wrap to fall back
+// when the lookup returns the key itself.
+function _tFb(k, fb) {
+    if (typeof i18n === 'undefined' || !i18n.t) return fb || k;
+    const v = i18n.t(k);
+    return (v === k || !v) ? (fb || k) : v;
+}
+
 function showConfirm({ message, title, confirmText, cancelText, danger } = {}) {
     return new Promise((resolve) => {
-        const t = (typeof i18n !== 'undefined' && i18n.t) ? i18n.t.bind(i18n) : (k, fb) => fb || k;
+        const t = _tFb;
         const overlay = document.createElement('div');
         overlay.className = 'dialog-overlay eclaw-confirm-overlay';
         overlay.innerHTML = `<div class="dialog eclaw-confirm-dialog">
@@ -113,7 +123,7 @@ function showConfirm({ message, title, confirmText, cancelText, danger } = {}) {
  */
 function showPrompt({ message, title, defaultValue, placeholder, confirmText, cancelText } = {}) {
     return new Promise((resolve) => {
-        const t = (typeof i18n !== 'undefined' && i18n.t) ? i18n.t.bind(i18n) : (k, fb) => fb || k;
+        const t = _tFb;
         const overlay = document.createElement('div');
         overlay.className = 'dialog-overlay eclaw-confirm-overlay';
         overlay.innerHTML = `<div class="dialog eclaw-confirm-dialog">


### PR DESCRIPTION
## Summary
Two bugs surfaced during prod E2E of the schedule-popup (PR #2082, card_aa55c721):

1. **Edit button silent no-op.** `schedStartEdit(id)` strict-compared a string id (rendered onclick) to a number id (legacy SERIAL column) → `find()` returned undefined → no edit form. Coerce both sides to `String()`.
2. **Styled confirm/prompt render raw i18n keys.** `i18n.t(key, fb)` treats arg 2 as substitution params, not a fallback. So `t('dialog_ok','OK')` rendered the literal `dialog_ok` button label. Affects every `showConfirm`/`showPrompt` callsite portal-wide (36 of them). Replace with `_tFb()` helper that falls back when the lookup returns the key itself.

## Test plan
- [x] Static jest schedule-popup test still passes (9/9)
- [x] Prod-staging E2E with hotfix: long-press → popup → 30s countdown → submit → queue item appears → 5s poll fires the message into chat history (verified `[E2E] schedule-popup test ... hotfix-verify` arrived in `/api/chat/history`)
- [x] Edit click → inline form with current content + datetime renders
- [x] Delete → styled confirm renders "Cancel this scheduled message?" with proper "Cancel" / "OK" labels (was "dialog_cancel" / "dialog_ok") → confirm → item removed
- [ ] Re-verify post-Railway-redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)