### PR TITLE
fix(chat): schedule-popup contrast — undefined --accent fallback

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -1810,8 +1810,8 @@
         }
 
         .schedule-tab-btn.active {
-            color: var(--accent);
-            border-bottom-color: var(--accent);
+            color: var(--primary, #6C63FF);
+            border-bottom-color: var(--primary, #6C63FF);
         }
 
         .schedule-section {
@@ -1847,7 +1847,7 @@
             font-size: 14px;
             white-space: pre-wrap;
             word-break: break-word;
-            color: var(--text-primary);
+            color: var(--text, #fff);
         }
 
         .sched-message-echo.empty {
@@ -1883,9 +1883,9 @@
         }
 
         .sched-target-chip.checked {
-            background: var(--accent);
-            color: var(--bg);
-            border-color: var(--accent);
+            background: var(--primary, #6C63FF);
+            color: #fff;
+            border-color: var(--primary, #6C63FF);
         }
 
         .sched-mode-toggle {
@@ -1902,13 +1902,13 @@
             font-size: 13px;
             font-weight: 600;
             cursor: pointer;
-            color: var(--text-primary);
+            color: var(--text, #fff);
         }
 
         .sched-mode-btn.active {
-            background: var(--accent);
-            color: var(--bg);
-            border-color: var(--accent);
+            background: var(--primary, #6C63FF);
+            color: #fff;
+            border-color: var(--primary, #6C63FF);
         }
 
         .sched-mode-pane {
@@ -1972,7 +1972,7 @@
         .sched-queue-countdown {
             font-family: ui-monospace, "SF Mono", Menlo, monospace;
             font-weight: 600;
-            color: var(--accent);
+            color: var(--primary, #6C63FF);
         }
 
         .sched-queue-countdown.late {
@@ -2000,7 +2000,7 @@
 
         .sched-queue-edit-form {
             background: var(--card);
-            border: 1px solid var(--accent);
+            border: 1px solid var(--primary, #6C63FF);
             border-radius: 8px;
             padding: 10px;
             margin-top: 6px;


### PR DESCRIPTION
## Summary
- Replaces `var(--accent)` (undefined in dark theme → transparent) with `var(--primary, #6C63FF)` at 8 schedule-popup CSS sites in `chat.html`
- Fixes `var(--text-primary)` (also undefined) → `var(--text, #fff)` for the message-echo and mode-button text
- Visible result: active mode button, checked target chip, active tab, queue countdown, and edit-form border now render in the brand purple instead of invisible

## Why
Hank flagged 「字看不清楚」on card_aa55c721 during screenshot review of PR #2082. Root cause: dark theme defines `--primary` (#6C63FF) but never `--accent`, so every CSS rule using `var(--accent)` collapsed to transparent, and the "active" mode button looked less prominent than the inactive one.

## Test plan
- [ ] Wait for Railway redeploy
- [ ] Long-press send → popup; verify Fixed/Countdown active button is purple, not invisible
- [ ] Tick a target chip; verify checked chip turns purple with white text
- [ ] Switch to Queue tab; verify countdown text is purple
- [ ] Click Edit on a queue item; verify edit form border is purple
- [ ] Full screenshot review attached to card_aa55c721

🤖 Generated with [Claude Code](https://claude.com/claude-code)