### PR TITLE
fix(kanban): bump R2 signed URL TTL 10min → 3 days

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -86,7 +86,12 @@ const r2 = new S3Client({
     },
 });
 const R2_BUCKET = process.env.R2_BUCKET_NAME || 'eclaw-files';
-const R2_URL_TTL_SECONDS = 600; // 10 min — fresh on every GET, short blast radius.
+// 3 days. Files re-sign on every /card/:id/files GET (mapCardFileRow), but the
+// rendered <img src> in the user's browser stays fixed at the URL it received,
+// so the lifetime of a card screenshot in an opened tab is bounded by this TTL.
+// 10 min was too short — Hank reported screenshots vanishing after ~10 min on
+// done cards. R2 / SigV4 max is 7 days; 3 days is well inside that.
+const R2_URL_TTL_SECONDS = 3 * 24 * 60 * 60;
 
 async function signCardFileUrl(fileId, deviceId, filename) {
     const result = await pool.query(


### PR DESCRIPTION
## Summary
Card attachments (screenshots) on kanban cards become unviewable after ~10 min in an open browser tab, because the `<img src>` is frozen at whatever URL `/card/:id/files` returned, and that URL is signed for `expiresIn: 600`. Backend re-signs on every GET via `mapCardFileRow`, but the browser doesn't re-fetch — so the user sees a blank image after 10 min on a still-open page.

This PR bumps `R2_URL_TTL_SECONDS` from `600` to `3 * 24 * 60 * 60` (3 days), which Hank explicitly asked for (`維持至少３天`). R2/SigV4 hard cap is 7 days, so 3 days is well inside.

The re-sign-on-GET behavior is unchanged — every fresh page load still gets a fresh URL.

Closes card_a86d09d851c892aa7e4a646b. Side effect: card_51b5090219cceff703b1ea98 (Hank's CSS guardrail evidence) screenshot will be viewable again on next page load.

## Test plan
- [x] `npx jest tests/jest/kanban-file-regen-url.test.js` — all 5 pass
- [ ] Post-deploy: open card_51b5090219cceff703b1ea98 → screenshot loads
- [ ] Post-deploy: leave card open 30 min → screenshot still visible
- [ ] curl the new URL → confirm `X-Amz-Expires=259200`

🤖 Generated with [Claude Code](https://claude.com/claude-code)