### PR TITLE
feat(mission): mind-map card on mission.html (PR-A static mockup)

### DIFF
--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -829,6 +829,18 @@
 
         <!-- Dashboard Content (hidden until loaded) -->
         <div id="dashboardContent" style="display:none;">
+            <!-- Mind-map (PR-A: static mockup; PR-B will wire to /api/mission/cards) -->
+            <div class="card">
+                <div class="card-header">
+                    <h2>🧠 <span data-i18n="mm_card_title">心智圖</span> <span style="font-size:11px;color:var(--text-secondary);font-weight:500;margin-left:6px;" data-i18n="mm_card_beta">(beta · 模擬資料)</span></h2>
+                    <div class="section-header-actions">
+                        <button class="btn btn-outline btn-sm" id="mmToggleBtn" onclick="toggleMindmap()" data-i18n="mm_card_expand">展開</button>
+                    </div>
+                </div>
+                <div id="mmContainer" style="display:none;"></div>
+                <div id="mmHint" style="font-size:12px;color:var(--text-secondary);padding:4px 2px;" data-i18n="mm_card_hint">52 個節點 · 8 子系統 · 76 條連線（含跨系統依賴）。展開可互動探索。</div>
+            </div>
+
             <!-- Notes -->
             <div class="card">
                 <div class="card-header">
@@ -918,6 +930,7 @@
     <script src="shared/entity-utils.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
+    <script src="shared/mission-mindmap.js" defer></script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
@@ -925,6 +938,31 @@
     <script src="shared/ai-chat.js"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script>
+        // --- Mind-map (PR-A: static mockup, lazy-init on first expand) ---
+        let mmInitialized = false;
+        let mmExpanded = false;
+        async function toggleMindmap() {
+            const container = document.getElementById('mmContainer');
+            const hint = document.getElementById('mmHint');
+            const btn = document.getElementById('mmToggleBtn');
+            if (!container || !btn) return;
+            mmExpanded = !mmExpanded;
+            container.style.display = mmExpanded ? 'block' : 'none';
+            if (hint) hint.style.display = mmExpanded ? 'none' : 'block';
+            btn.textContent = mmExpanded
+                ? (window.i18n && i18n.t('mm_card_collapse')) || '收起'
+                : (window.i18n && i18n.t('mm_card_expand')) || '展開';
+            if (mmExpanded && !mmInitialized && window.MissionMindmap) {
+                mmInitialized = true;
+                try {
+                    await window.MissionMindmap.init({ rootEl: container });
+                } catch (err) {
+                    console.error('mindmap init failed:', err);
+                    container.innerHTML = '<div style="padding:14px;color:var(--text-secondary);font-size:12px;">載入失敗：' + (err.message || err) + '</div>';
+                }
+            }
+        }
+
         // --- State ---
         let dashboard = { notes: [], rules: [], skills: [], souls: [], categoryOrder: {} };
         let lastSavedDashboard = null; // snapshot for auto-save conflict detection

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -947,8 +947,10 @@
             const btn = document.getElementById('mmToggleBtn');
             if (!container || !btn) return;
             mmExpanded = !mmExpanded;
-            container.style.display = mmExpanded ? 'block' : 'none';
-            if (hint) hint.style.display = mmExpanded ? 'none' : 'block';
+            // After init, the module sets .mm-root { display:grid } — so use
+            // '' (let CSS class win) when expanded, 'none' when collapsed.
+            container.style.display = mmExpanded ? '' : 'none';
+            if (hint) hint.style.display = mmExpanded ? 'none' : '';
             btn.textContent = mmExpanded
                 ? (window.i18n && i18n.t('mm_card_collapse')) || '收起'
                 : (window.i18n && i18n.t('mm_card_expand')) || '展開';

--- a/backend/public/portal/shared/mission-mindmap.js
+++ b/backend/public/portal/shared/mission-mindmap.js
@@ -616,6 +616,10 @@
 
     injectStyle();
     rootEl.classList.add('mm-root');
+    // Clear any inline display set by callers ("block"/"none" toggles) so the
+    // .mm-root grid rule wins. Callers should toggle visibility via a class
+    // (e.g. .mm-hidden { display: none }) or by replacing inline display with ''.
+    if (rootEl.style.display === 'block') rootEl.style.display = '';
     renderShell(rootEl, nodes, edges);
 
     await loadCytoscape();

--- a/backend/public/portal/shared/mission-mindmap.js
+++ b/backend/public/portal/shared/mission-mindmap.js
@@ -1,0 +1,631 @@
+// mission-mindmap.js — Phase A static-mock integration (PR-A)
+//
+// Lazy-loaded on first expand of the "🧠 心智圖" card in mission.html.
+// PR-A ships the mockup verbatim (52 nodes / 76 edges / 8 subsystems) so
+// Hank can verify layout + interaction in production.
+// PR-B will replace MOCK_NODES/MOCK_EDGES by mapping /api/mission/cards
+// (assignedTo→sys, status→active|blocked|done) and chat embedding coords.
+(function (global) {
+  'use strict';
+
+  if (global.MissionMindmap) return;
+
+  const CDN = 'https://cdn.jsdelivr.net/npm/cytoscape@3.28.1/dist/cytoscape.min.js';
+
+  const SYS = {
+    invite:    { color: '#f43f5e', label: '邀請成長' },
+    device:    { color: '#06b6d4', label: '裝置' },
+    i18n:      { color: '#a855f7', label: 'i18n' },
+    kanban:    { color: '#22c55e', label: '看板' },
+    chat:      { color: '#3b82f6', label: '聊天' },
+    payment:   { color: '#eab308', label: '支付' },
+    broadcast: { color: '#f97316', label: '廣播' },
+    bridge:    { color: '#ec4899', label: '橋接' },
+  };
+
+  const MOCK_NODES = [
+    // 邀請 (7)
+    { id: 'inv-hub', label: '邀請系統', sys: 'invite', tier: 'domain', status: 'active', summary: '8 碼邀請、redeem、tier milestone、funnel telemetry。' },
+    { id: 'inv-code', label: '8 碼生碼', sys: 'invite', tier: 'topic', status: 'done' },
+    { id: 'inv-redeem', label: 'Redeem flow', sys: 'invite', tier: 'topic', status: 'active' },
+    { id: 'inv-tier', label: 'Tier milestone', sys: 'invite', tier: 'topic', status: 'active', summary: 'Tier 1 = 邀請 1 人解鎖 chip preview' },
+    { id: 'inv-leader', label: 'Leaderboard', sys: 'invite', tier: 'topic', status: 'blocked', summary: '需要先有 30+ 用戶才有意義' },
+    { id: 'inv-funnel', label: 'Funnel telemetry', sys: 'invite', tier: 'leaf', status: 'active' },
+    { id: 'inv-qr', label: 'QR 海報生成', sys: 'invite', tier: 'leaf', status: 'done' },
+
+    // 裝置 (6)
+    { id: 'dev-hub', label: '裝置 / Device', sys: 'device', tier: 'domain', status: 'active', summary: 'deviceId + secret 認證、輪替、health probe。' },
+    { id: 'dev-rotate', label: 'Secret 輪替', sys: 'device', tier: 'topic', status: 'active', summary: 'POST /api/device/rotate-secret + 一次性 dialog' },
+    { id: 'dev-health', label: 'rental-health cron', sys: 'device', tier: 'topic', status: 'done' },
+    { id: 'dev-vars', label: 'device-vars vault', sys: 'device', tier: 'topic', status: 'done' },
+    { id: 'dev-switch', label: 'Switch Device', sys: 'device', tier: 'leaf', status: 'blocked', summary: '12.4h stale; 等 i18n' },
+    { id: 'dev-logs', label: '/api/logs', sys: 'device', tier: 'leaf', status: 'done' },
+
+    // i18n (8)
+    { id: 'i18n-hub', label: 'i18n 13 locale', sys: 'i18n', tier: 'domain', status: 'active', summary: 'chip_popover_* 已補完 11 缺額 locale' },
+    { id: 'i18n-shared', label: 'shared/i18n.js (live)', sys: 'i18n', tier: 'topic', status: 'active', summary: '~61k lines, 唯一被 HTML import' },
+    { id: 'i18n-deadtop', label: '頂層 ./i18n.js (dead)', sys: 'i18n', tier: 'leaf', status: 'done', summary: '已 git rm + CI guard' },
+    { id: 'i18n-chip', label: 'chip_popover_*', sys: 'i18n', tier: 'topic', status: 'done', summary: 'PR #2095 merged' },
+    { id: 'i18n-kb', label: 'kb_/kanban_*', sys: 'i18n', tier: 'topic', status: 'blocked' },
+    { id: 'i18n-strict-ci', label: 'i18n-check.js (strict)', sys: 'i18n', tier: 'leaf', status: 'done' },
+    { id: 'i18n-key-audit', label: '558 stray }, audit', sys: 'i18n', tier: 'leaf', status: 'done' },
+    { id: 'i18n-translator', label: 'Mac_E i18n agent', sys: 'i18n', tier: 'leaf', status: 'blocked', summary: '錯檔路徑寫死，已 STOP' },
+
+    // 看板 (7)
+    { id: 'kb-hub', label: '看板系統', sys: 'kanban', tier: 'domain', status: 'active' },
+    { id: 'kb-card', label: '/mission/card API', sys: 'kanban', tier: 'topic', status: 'done' },
+    { id: 'kb-screenshot-gate', label: 'screenshot 截圖閘', sys: 'kanban', tier: 'topic', status: 'active' },
+    { id: 'kb-r2-ttl', label: 'R2 TTL ≥3 days', sys: 'kanban', tier: 'leaf', status: 'done', summary: 'PR #2090 merged' },
+    { id: 'kb-deeplink', label: '深層連結 anchor scroll', sys: 'kanban', tier: 'leaf', status: 'done' },
+    { id: 'kb-notes-tab', label: '筆記 tab snake_case bug', sys: 'kanban', tier: 'leaf', status: 'active' },
+    { id: 'kb-mention', label: '@mention → entityId', sys: 'kanban', tier: 'topic', status: 'active' },
+
+    // 聊天 (8)
+    { id: 'chat-hub', label: '聊天 / Chat', sys: 'chat', tier: 'domain', status: 'active' },
+    { id: 'chat-chip', label: '智慧引用晶片', sys: 'chat', tier: 'topic', status: 'active', summary: '@chip_popover_X 點擊預覽' },
+    { id: 'chat-chip-recursive', label: '預覽卡內遞迴 chip', sys: 'chat', tier: 'leaf', status: 'active' },
+    { id: 'chat-pin-btn', label: '📌 重新引用按鈕', sys: 'chat', tier: 'leaf', status: 'done', summary: 'PR #2089 merged' },
+    { id: 'chat-history-api', label: '/api/chat/history', sys: 'chat', tier: 'topic', status: 'done' },
+    { id: 'chat-schedule', label: '排程訊息 (long-press)', sys: 'chat', tier: 'topic', status: 'done' },
+    { id: 'chat-embed', label: 'embed=1 mode', sys: 'chat', tier: 'leaf', status: 'done' },
+    { id: 'chat-share', label: 'share-chat.html 公開', sys: 'chat', tier: 'leaf', status: 'active' },
+
+    // 支付 (5)
+    { id: 'pay-hub', label: '支付 / 訂閱', sys: 'payment', tier: 'domain', status: 'active' },
+    { id: 'pay-topup-b', label: 'Top-up Path B (sandbox)', sys: 'payment', tier: 'topic', status: 'active', summary: 'Android emu 已有 Play 帳號' },
+    { id: 'pay-iap-android', label: 'Android IAP', sys: 'payment', tier: 'topic', status: 'active' },
+    { id: 'pay-iap-ios', label: 'iOS StoreKit', sys: 'payment', tier: 'topic', status: 'blocked', summary: '等 Apple Connect 設定' },
+    { id: 'pay-wallet', label: 'wallet.html 餘額', sys: 'payment', tier: 'leaf', status: 'done' },
+
+    // 廣播 (6)
+    { id: 'bcast-hub', label: '廣播 / Publisher', sys: 'broadcast', tier: 'domain', status: 'active' },
+    { id: 'bcast-x', label: 'X (Twitter)', sys: 'broadcast', tier: 'topic', status: 'active' },
+    { id: 'bcast-mastodon', label: 'Mastodon', sys: 'broadcast', tier: 'leaf', status: 'done', summary: '已棄用 2026-04-15' },
+    { id: 'bcast-wp', label: 'WordPress.com', sys: 'broadcast', tier: 'leaf', status: 'done', summary: '已退役 2026-04-20' },
+    { id: 'bcast-cron', label: 'Daily viral cron', sys: 'broadcast', tier: 'topic', status: 'active' },
+    { id: 'bcast-design', label: 'Claude Design 視覺', sys: 'broadcast', tier: 'leaf', status: 'active' },
+
+    // 橋接 (5)
+    { id: 'br-hub', label: '橋接 / Bridge', sys: 'bridge', tier: 'domain', status: 'active' },
+    { id: 'br-auth', label: 'bridge-auth (osascript)', sys: 'bridge', tier: 'topic', status: 'done' },
+    { id: 'br-eye', label: 'eye 螢幕全覽', sys: 'bridge', tier: 'leaf', status: 'done' },
+    { id: 'br-hermes-docker', label: 'hermes-bridge service', sys: 'bridge', tier: 'topic', status: 'done' },
+    { id: 'br-unit-u01', label: 'U01 = app E2E', sys: 'bridge', tier: 'leaf', status: 'active' },
+  ];
+
+  const MOCK_EDGES = [
+    // 邀請 tree
+    ['inv-hub','inv-code'], ['inv-hub','inv-redeem'], ['inv-hub','inv-tier'],
+    ['inv-hub','inv-leader'], ['inv-redeem','inv-funnel'], ['inv-code','inv-qr'],
+    // 裝置 tree
+    ['dev-hub','dev-rotate'], ['dev-hub','dev-health'], ['dev-hub','dev-vars'],
+    ['dev-hub','dev-switch'], ['dev-hub','dev-logs'],
+    // i18n tree
+    ['i18n-hub','i18n-shared'], ['i18n-hub','i18n-chip'], ['i18n-hub','i18n-kb'],
+    ['i18n-shared','i18n-strict-ci'], ['i18n-shared','i18n-key-audit'],
+    ['i18n-shared','i18n-deadtop'], ['i18n-hub','i18n-translator'],
+    // 看板 tree
+    ['kb-hub','kb-card'], ['kb-hub','kb-screenshot-gate'], ['kb-screenshot-gate','kb-r2-ttl'],
+    ['kb-hub','kb-deeplink'], ['kb-hub','kb-notes-tab'], ['kb-hub','kb-mention'],
+    // 聊天 tree
+    ['chat-hub','chat-chip'], ['chat-chip','chat-chip-recursive'], ['chat-chip','chat-pin-btn'],
+    ['chat-hub','chat-history-api'], ['chat-hub','chat-schedule'], ['chat-hub','chat-embed'],
+    ['chat-hub','chat-share'],
+    // 支付 tree
+    ['pay-hub','pay-topup-b'], ['pay-hub','pay-iap-android'], ['pay-hub','pay-iap-ios'],
+    ['pay-hub','pay-wallet'], ['pay-iap-android','pay-topup-b'],
+    // 廣播 tree
+    ['bcast-hub','bcast-x'], ['bcast-hub','bcast-mastodon'], ['bcast-hub','bcast-wp'],
+    ['bcast-hub','bcast-cron'], ['bcast-cron','bcast-design'],
+    // 橋接 tree
+    ['br-hub','br-auth'], ['br-auth','br-eye'], ['br-hub','br-hermes-docker'], ['br-hub','br-unit-u01'],
+
+    // ⛓ Cross-system dependencies (yellow dashed, labeled)
+    ['i18n-chip','chat-chip','depends'],
+    ['i18n-kb','kb-hub','depends'],
+    ['i18n-translator','br-auth','via'],
+    ['inv-redeem','dev-vars','via'],
+    ['inv-tier','chat-chip','unlocks'],
+    ['kb-screenshot-gate','bcast-cron','required'],
+    ['chat-schedule','kb-mention','reuses'],
+    ['br-hermes-docker','i18n-translator','runs'],
+    ['pay-topup-b','dev-health','telemetry'],
+    ['bcast-x','dev-vars','reads-key'],
+    ['bcast-design','br-auth','uses'],
+    ['kb-card','chat-history-api','share-DB'],
+    ['inv-funnel','bcast-cron','feeds'],
+    ['dev-switch','i18n-chip','blocked-by'],
+    ['chat-pin-btn','i18n-chip','i18n-key'],
+    ['kb-deeplink','chat-chip','same-anchor'],
+    ['br-unit-u01','kb-screenshot-gate','attaches'],
+    ['chat-share','bcast-x','outbound'],
+    ['inv-qr','bcast-design','asset'],
+  ];
+
+  const STYLE_ID = 'mission-mindmap-style';
+  const STYLE_CSS = `
+    .mm-root {
+      display: grid;
+      grid-template-columns: 168px 1fr 256px;
+      height: 540px;
+      background: var(--bg, #0d1117);
+      border: 1px solid var(--card-border, #2a2f3a);
+      border-radius: var(--radius-sm, 8px);
+      overflow: hidden;
+      font-size: 13px;
+      color: var(--text, #e6edf3);
+    }
+    @media (max-width: 860px) {
+      .mm-root { grid-template-columns: 1fr; height: auto; }
+      .mm-root .mm-rail { display: none; }
+      .mm-root .mm-side { display: none; }
+      .mm-root .mm-canvas-wrap { height: 480px; }
+    }
+    .mm-root .mm-rail {
+      background: var(--bg-elev, #161b22);
+      border-right: 1px solid var(--card-border, #2a2f3a);
+      padding: 12px 10px;
+      overflow-y: auto;
+    }
+    .mm-root .mm-rail h3 {
+      font-size: 10px;
+      text-transform: uppercase;
+      letter-spacing: 0.6px;
+      color: var(--text-secondary, #8b949e);
+      margin: 0 0 8px 4px;
+      font-weight: 600;
+    }
+    .mm-root .mm-sys-row {
+      display: flex; align-items: center; gap: 8px;
+      padding: 6px 8px;
+      border-radius: 5px;
+      font-size: 12px;
+      cursor: pointer;
+      user-select: none;
+      margin-bottom: 1px;
+    }
+    .mm-root .mm-sys-row:hover { background: rgba(255,255,255,0.05); }
+    .mm-root .mm-sys-row.active { background: rgba(124,131,255,0.16); }
+    .mm-root .mm-sys-row .mm-swatch {
+      width: 11px; height: 11px; border-radius: 3px; flex: none;
+      border: 1px solid rgba(255,255,255,0.2);
+    }
+    .mm-root .mm-sys-row .mm-name { flex: 1; }
+    .mm-root .mm-sys-row .mm-count {
+      font-size: 10px;
+      color: var(--text-secondary, #8b949e);
+      background: rgba(255,255,255,0.06);
+      padding: 1px 6px;
+      border-radius: 9px;
+    }
+    .mm-root .mm-legend {
+      margin-top: 12px;
+      padding-top: 10px;
+      border-top: 1px dashed var(--card-border, #2a2f3a);
+    }
+    .mm-root .mm-legend-row {
+      display: flex; align-items: center; gap: 7px;
+      font-size: 10px;
+      color: var(--text-secondary, #8b949e);
+      padding: 2px 4px;
+    }
+    .mm-root .mm-legend-row .mm-ring {
+      width: 11px; height: 11px; border-radius: 50%;
+      border: 2px solid #fde047; flex: none; background: transparent;
+    }
+    .mm-root .mm-legend-row .mm-ring.blocked { border-color: #ef4444; }
+    .mm-root .mm-legend-row .mm-ring.done { border-color: #22c55e; border-style: dashed; }
+    .mm-root .mm-summary {
+      margin-top: 10px;
+      padding-top: 10px;
+      border-top: 1px dashed var(--card-border, #2a2f3a);
+      font-size: 10px;
+      color: var(--text-secondary, #8b949e);
+      line-height: 1.6;
+    }
+    .mm-root .mm-summary .mm-num { color: var(--text, #e6edf3); font-weight: 600; }
+    .mm-root .mm-canvas-wrap {
+      position: relative;
+      background: var(--bg, #0d1117);
+      overflow: hidden;
+    }
+    .mm-root .mm-cy {
+      width: 100%;
+      height: 100%;
+      background:
+        radial-gradient(circle at 30% 30%, rgba(168,85,247,0.05), transparent 50%),
+        radial-gradient(circle at 70% 70%, rgba(34,197,94,0.04), transparent 50%),
+        var(--bg, #0d1117);
+    }
+    .mm-root .mm-toolbar {
+      position: absolute;
+      top: 8px; left: 8px;
+      z-index: 10;
+      display: flex; gap: 4px;
+      background: rgba(22,27,34,0.85);
+      backdrop-filter: blur(8px);
+      border: 1px solid var(--card-border, #2a2f3a);
+      border-radius: 6px;
+      padding: 4px;
+    }
+    .mm-root .mm-toolbar button {
+      background: transparent; color: var(--text, #e6edf3);
+      border: 1px solid transparent;
+      padding: 4px 8px; border-radius: 4px;
+      cursor: pointer; font-size: 11px;
+    }
+    .mm-root .mm-toolbar button:hover { background: rgba(255,255,255,0.08); }
+    .mm-root .mm-tier {
+      position: absolute;
+      top: 8px; right: 8px;
+      z-index: 10;
+      background: rgba(22,27,34,0.85);
+      border: 1px solid var(--card-border, #2a2f3a);
+      border-radius: 5px;
+      padding: 4px 8px;
+      font-size: 10px;
+      color: var(--text-secondary, #8b949e);
+    }
+    .mm-root .mm-tier strong { color: var(--primary, #7c83ff); }
+    .mm-root .mm-side {
+      background: var(--bg-elev, #161b22);
+      border-left: 1px solid var(--card-border, #2a2f3a);
+      overflow-y: auto;
+    }
+    .mm-root .mm-empty {
+      padding: 22px 14px;
+      text-align: center;
+      color: var(--text-secondary, #8b949e);
+      font-size: 12px;
+      line-height: 1.6;
+    }
+    .mm-root .mm-empty .mm-emoji { font-size: 26px; margin-bottom: 6px; }
+    .mm-root .mm-empty .mm-hint { margin-top: 8px; font-size: 10px; opacity: 0.7; }
+    .mm-root .mm-detail { padding: 14px; display: none; flex-direction: column; gap: 12px; }
+    .mm-root .mm-detail.visible { display: flex; }
+    .mm-root .mm-detail h4 {
+      font-size: 14px; margin: 0;
+      color: var(--text, #e6edf3);
+    }
+    .mm-root .mm-pills { display: flex; gap: 5px; flex-wrap: wrap; }
+    .mm-root .mm-pill {
+      font-size: 10px; padding: 2px 7px; border-radius: 10px;
+      font-weight: 600; letter-spacing: 0.4px;
+    }
+    .mm-root .mm-pill-status.active { background: rgba(253,224,71,0.15); color: #fde047; }
+    .mm-root .mm-pill-status.blocked { background: rgba(239,68,68,0.15); color: #ef4444; }
+    .mm-root .mm-pill-status.done { background: rgba(34,197,94,0.15); color: #22c55e; }
+    .mm-root .mm-detail .mm-summary-text {
+      color: var(--text-secondary, #8b949e);
+      font-size: 12px; line-height: 1.55;
+    }
+    .mm-root .mm-section h5 {
+      font-size: 10px; text-transform: uppercase; letter-spacing: 0.6px;
+      color: var(--text-secondary, #8b949e);
+      margin: 0 0 6px 0; font-weight: 600;
+    }
+    .mm-root .mm-related { display: flex; flex-direction: column; gap: 3px; }
+    .mm-root .mm-related-row {
+      font-size: 11px;
+      padding: 5px 7px;
+      border-radius: 4px;
+      background: rgba(255,255,255,0.03);
+      cursor: pointer;
+      display: flex; align-items: center; gap: 6px;
+    }
+    .mm-root .mm-related-row:hover { background: rgba(255,255,255,0.07); }
+    .mm-root .mm-related-row .mm-swatch { width: 7px; height: 7px; border-radius: 2px; flex: none; }
+  `;
+
+  function injectStyle() {
+    if (document.getElementById(STYLE_ID)) return;
+    const s = document.createElement('style');
+    s.id = STYLE_ID;
+    s.textContent = STYLE_CSS;
+    document.head.appendChild(s);
+  }
+
+  function loadCytoscape() {
+    if (global.cytoscape) return Promise.resolve(global.cytoscape);
+    return new Promise((resolve, reject) => {
+      const existing = document.querySelector(`script[src="${CDN}"]`);
+      if (existing) {
+        existing.addEventListener('load', () => resolve(global.cytoscape));
+        existing.addEventListener('error', reject);
+        return;
+      }
+      const s = document.createElement('script');
+      s.src = CDN;
+      s.onload = () => resolve(global.cytoscape);
+      s.onerror = () => reject(new Error('cytoscape CDN failed'));
+      document.head.appendChild(s);
+    });
+  }
+
+  function countBySys(nodes) {
+    const counts = {};
+    for (const n of nodes) counts[n.sys] = (counts[n.sys] || 0) + 1;
+    return counts;
+  }
+
+  function renderShell(rootEl, nodes, edges) {
+    const counts = countBySys(nodes);
+    const railRows = Object.entries(SYS).map(([key, s]) => {
+      const c = counts[key] || 0;
+      return `<div class="mm-sys-row" data-sys="${key}">
+        <span class="mm-swatch" style="background:${s.color}"></span>
+        <span class="mm-name">${s.label}</span>
+        <span class="mm-count">${c}</span>
+      </div>`;
+    }).join('');
+
+    const crossCount = edges.filter(e => e.length === 3).length;
+
+    rootEl.innerHTML = `
+      <aside class="mm-rail">
+        <h3>子系統</h3>
+        ${railRows}
+        <div class="mm-legend">
+          <h3>節點狀態</h3>
+          <div class="mm-legend-row"><span class="mm-ring"></span>進行中</div>
+          <div class="mm-legend-row"><span class="mm-ring blocked"></span>阻塞</div>
+          <div class="mm-legend-row"><span class="mm-ring done"></span>完成</div>
+        </div>
+        <div class="mm-summary">
+          <span class="mm-num">${nodes.length}</span> 節點 ·
+          <span class="mm-num">${edges.length}</span> 連線<br>
+          <span class="mm-num">${crossCount}</span> 跨系統依賴
+        </div>
+      </aside>
+      <div class="mm-canvas-wrap">
+        <div class="mm-toolbar">
+          <button data-act="fit">🎯 Fit</button>
+          <button data-act="reset">🔄 重整</button>
+        </div>
+        <div class="mm-tier">L1 · <strong>Topics</strong></div>
+        <div class="mm-cy"></div>
+      </div>
+      <aside class="mm-side">
+        <div class="mm-empty">
+          <div class="mm-emoji">🧠</div>
+          點任一節點查看相關依賴。
+          <div class="mm-hint">滾輪 zoom · 拖曳 pan<br>左側點子系統可單獨高亮</div>
+        </div>
+        <div class="mm-detail">
+          <h4></h4>
+          <div class="mm-pills"></div>
+          <div class="mm-summary-text"></div>
+          <div class="mm-section">
+            <h5>跨系統相關節點</h5>
+            <div class="mm-related"></div>
+          </div>
+        </div>
+      </aside>
+    `;
+  }
+
+  function buildCy(canvasEl, nodes, edges) {
+    const nodesById = Object.fromEntries(nodes.map(n => [n.id, n]));
+    const cyNodes = nodes.map(n => ({ data: { ...n, sysColor: SYS[n.sys].color } }));
+    const cyEdges = edges.map(([s, t, label]) => ({
+      data: { id: `${s}__${t}`, source: s, target: t, label: label || '', cross: !!label }
+    }));
+
+    const cy = global.cytoscape({
+      container: canvasEl,
+      elements: [...cyNodes, ...cyEdges],
+      layout: {
+        name: 'cose', padding: 30, animate: false, fit: true,
+        idealEdgeLength: 95, nodeRepulsion: 8500, edgeElasticity: 100,
+        nestingFactor: 1.2, gravity: 0.3, numIter: 1800, componentSpacing: 70,
+      },
+      style: [
+        { selector: 'node', style: {
+          'label': 'data(label)',
+          'color': '#e6edf3',
+          'font-size': 10,
+          'font-weight': 600,
+          'text-valign': 'center',
+          'text-halign': 'center',
+          'text-wrap': 'wrap',
+          'text-max-width': 80,
+          'background-color': 'data(sysColor)',
+          'background-opacity': 0.18,
+          'border-width': 2,
+          'border-color': 'data(sysColor)',
+          'width': 54,
+          'height': 54,
+          'shape': 'round-rectangle',
+        }},
+        { selector: 'node[tier="domain"]', style: {
+          'width': 88, 'height': 88, 'font-size': 12,
+          'background-opacity': 0.28, 'border-width': 3,
+        }},
+        { selector: 'node[tier="topic"]', style: {
+          'width': 68, 'height': 68, 'font-size': 11, 'background-opacity': 0.2,
+        }},
+        { selector: 'node[tier="leaf"]', style: {
+          'width': 50, 'height': 50, 'font-size': 9, 'background-opacity': 0.13,
+        }},
+        { selector: 'node[status="active"]', style: { 'overlay-color': '#fde047', 'overlay-opacity': 0.06 }},
+        { selector: 'node[status="blocked"]', style: {
+          'border-color': '#ef4444', 'border-style': 'solid',
+          'overlay-color': '#ef4444', 'overlay-opacity': 0.08,
+        }},
+        { selector: 'node[status="done"]', style: { 'border-style': 'dashed', 'opacity': 0.6 }},
+        { selector: 'node:selected', style: {
+          'border-color': '#fde047', 'border-width': 4,
+          'overlay-color': '#fde047', 'overlay-opacity': 0.18,
+        }},
+        { selector: 'edge', style: {
+          'width': 1.1,
+          'line-color': '#2a2f3a',
+          'target-arrow-color': '#2a2f3a',
+          'target-arrow-shape': 'triangle',
+          'curve-style': 'bezier',
+          'opacity': 0.55,
+          'arrow-scale': 0.75,
+        }},
+        { selector: 'edge[cross="true"]', style: {
+          'line-color': '#fbbf24',
+          'target-arrow-color': '#fbbf24',
+          'line-style': 'dashed',
+          'opacity': 0.7,
+          'width': 1.3,
+          'label': 'data(label)',
+          'font-size': 8,
+          'color': '#fbbf24',
+          'text-background-color': '#0d1117',
+          'text-background-opacity': 0.85,
+          'text-background-padding': 2,
+        }},
+        { selector: 'edge:selected', style: {
+          'line-color': '#fde047', 'target-arrow-color': '#fde047',
+          'opacity': 1, 'width': 2.5,
+        }},
+        { selector: '.faded', style: { 'opacity': 0.12 }},
+        { selector: '.highlighted', style: { 'opacity': 1 }},
+      ],
+    });
+
+    return { cy, nodesById };
+  }
+
+  function bindEvents(rootEl, cy, nodesById) {
+    const emptyEl = rootEl.querySelector('.mm-empty');
+    const detailEl = rootEl.querySelector('.mm-detail');
+    const titleEl = detailEl.querySelector('h4');
+    const pillsEl = detailEl.querySelector('.mm-pills');
+    const summaryEl = detailEl.querySelector('.mm-summary-text');
+    const relatedEl = detailEl.querySelector('.mm-related');
+    const tierEl = rootEl.querySelector('.mm-tier');
+
+    function showSide(n) {
+      emptyEl.style.display = 'none';
+      detailEl.classList.add('visible');
+      const d = n.data();
+      titleEl.textContent = d.label;
+      const sysMeta = SYS[d.sys];
+      pillsEl.innerHTML = `
+        <span class="mm-pill" style="background:${sysMeta.color}26;color:${sysMeta.color};">${sysMeta.label}</span>
+        <span class="mm-pill mm-pill-status ${d.status}">${d.status}</span>
+      `;
+      summaryEl.textContent = d.summary || `(${sysMeta.label} 子系統 · ${d.tier})`;
+
+      relatedEl.innerHTML = '';
+      const seen = new Set();
+      n.neighborhood('node').forEach(nb => {
+        if (nb.id() === n.id()) return;
+        const nd = nb.data();
+        if (nd.sys === d.sys) return;
+        if (seen.has(nb.id())) return;
+        seen.add(nb.id());
+        const row = document.createElement('div');
+        row.className = 'mm-related-row';
+        row.dataset.target = nb.id();
+        row.innerHTML = `
+          <span class="mm-swatch" style="background:${SYS[nd.sys].color}"></span>
+          <span>${nd.label}</span>
+          <span style="color:var(--text-secondary,#8b949e);font-size:10px;margin-left:auto;">${SYS[nd.sys].label}</span>
+        `;
+        relatedEl.appendChild(row);
+      });
+      if (!relatedEl.children.length) {
+        relatedEl.innerHTML = '<div style="font-size:11px;color:var(--text-secondary,#8b949e);padding:5px;">沒有跨系統依賴</div>';
+      }
+    }
+
+    cy.on('tap', 'node', (evt) => {
+      const n = evt.target;
+      cy.elements().removeClass('faded').removeClass('highlighted');
+      cy.elements().addClass('faded');
+      n.removeClass('faded').addClass('highlighted');
+      n.neighborhood().removeClass('faded').addClass('highlighted');
+      showSide(n);
+    });
+
+    cy.on('tap', (evt) => {
+      if (evt.target === cy) {
+        cy.elements().removeClass('faded').removeClass('highlighted');
+        emptyEl.style.display = 'block';
+        detailEl.classList.remove('visible');
+      }
+    });
+
+    cy.on('zoom', () => {
+      const z = cy.zoom();
+      let tier = 'L1', label = 'Topics';
+      if (z < 0.55) { tier = 'L0'; label = 'Overview'; }
+      else if (z >= 1.4) { tier = 'L2'; label = 'Detail'; }
+      tierEl.innerHTML = `${tier} · <strong>${label}</strong>`;
+    });
+
+    relatedEl.addEventListener('click', (evt) => {
+      const row = evt.target.closest('.mm-related-row');
+      if (!row) return;
+      const target = cy.getElementById(row.dataset.target);
+      if (!target.length) return;
+      cy.elements().removeClass('faded').removeClass('highlighted');
+      cy.elements().addClass('faded');
+      target.removeClass('faded').addClass('highlighted');
+      target.neighborhood().removeClass('faded').addClass('highlighted');
+      cy.center(target);
+      showSide(target);
+    });
+
+    rootEl.querySelectorAll('.mm-sys-row').forEach(row => {
+      row.addEventListener('click', () => {
+        const sys = row.dataset.sys;
+        const wasActive = row.classList.contains('active');
+        rootEl.querySelectorAll('.mm-sys-row').forEach(r => r.classList.remove('active'));
+        cy.elements().removeClass('faded');
+        if (wasActive) return;
+        row.classList.add('active');
+        cy.nodes().forEach(n => { if (n.data('sys') !== sys) n.addClass('faded'); });
+        cy.edges().forEach(e => {
+          const sa = nodesById[e.data('source')]?.sys;
+          const ta = nodesById[e.data('target')]?.sys;
+          if (sa !== sys && ta !== sys) e.addClass('faded');
+        });
+      });
+    });
+
+    rootEl.querySelectorAll('.mm-toolbar button').forEach(btn => {
+      btn.addEventListener('click', () => {
+        const act = btn.dataset.act;
+        if (act === 'fit') cy.fit(undefined, 30);
+        if (act === 'reset') {
+          cy.elements().removeClass('faded').removeClass('highlighted');
+          rootEl.querySelectorAll('.mm-sys-row').forEach(r => r.classList.remove('active'));
+          emptyEl.style.display = 'block';
+          detailEl.classList.remove('visible');
+          cy.fit(undefined, 30);
+        }
+      });
+    });
+
+    return { showSide };
+  }
+
+  async function init(opts) {
+    const { rootEl, data } = opts || {};
+    if (!rootEl) throw new Error('MissionMindmap.init: rootEl required');
+
+    const nodes = (data && data.nodes) || MOCK_NODES;
+    const edges = (data && data.edges) || MOCK_EDGES;
+
+    injectStyle();
+    rootEl.classList.add('mm-root');
+    renderShell(rootEl, nodes, edges);
+
+    await loadCytoscape();
+
+    const canvasEl = rootEl.querySelector('.mm-cy');
+    const { cy, nodesById } = buildCy(canvasEl, nodes, edges);
+    const ctrl = bindEvents(rootEl, cy, nodesById);
+
+    return { cy, ...ctrl, nodes, edges };
+  }
+
+  global.MissionMindmap = { init, SYS, MOCK_NODES, MOCK_EDGES };
+})(window);

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -22,6 +22,13 @@ const TRANSLATIONS = {
         "mc_deprecated_add": "Please use the Kanban board instead. The Kanban board has a complete ecosystem — migrate existing items there gradually.",
         "mc_mission_title": "Mission List",
         "mc_done_title": "Done List",
+        // 心智圖 (Mind-map card on mission.html)
+        "mm_card_title": "Mind Map",
+        "mm_card_beta": "(beta · mock data)",
+        "mm_card_expand": "Expand",
+        "mm_card_collapse": "Collapse",
+        "mm_card_hint": "52 nodes · 8 subsystems · 76 edges (incl. cross-system). Expand to explore.",
+
         "mc_notes_title": "Notes",
         "mc_rules_title": "Rules (Workflow)",
         "mc_sync_unsaved": "* Unsaved changes",
@@ -4781,6 +4788,13 @@ const TRANSLATIONS = {
         "mc_deprecated_add": "請使用看板任務作為替代方案。看板任務頁面已有完整生態，請讓 bot 將現有任務逐步轉移到看板任務頁面。",
         "mc_mission_title": "任務列表",
         "mc_done_title": "已完成",
+        // 心智圖 (Mind-map card on mission.html)
+        "mm_card_title": "心智图",
+        "mm_card_beta": "(beta · 模拟数据)",
+        "mm_card_expand": "展开",
+        "mm_card_collapse": "收起",
+        "mm_card_hint": "52 个节点 · 8 子系统 · 76 条连线（含跨系统依赖）。展开可互动探索。",
+
         "mc_notes_title": "筆記",
         "mc_rules_title": "規則 (Workflow)",
         "mc_sync_unsaved": "* 未儲存的變更",
@@ -13566,6 +13580,13 @@ const TRANSLATIONS = {
         "mc_deprecated_add": "代わりにカンバンボードをご利用ください。カンバンボードには完全なエコシステムがあります。既存のタスクを徐々に移行してください。",
         "mc_mission_title": "ミッション一覧",
         "mc_done_title": "完了一覧",
+        // 心智圖 (Mind-map card on mission.html)
+        "mm_card_title": "マインドマップ",
+        "mm_card_beta": "(beta · モックデータ)",
+        "mm_card_expand": "展開",
+        "mm_card_collapse": "折りたたむ",
+        "mm_card_hint": "52 ノード · 8 サブシステム · 76 リンク（クロスシステム依存含む）。展開して操作。",
+
         "mc_notes_title": "ノート",
         "mc_rules_title": "ルール (ワークフロー)",
         "mc_sync_unsaved": "* 未保存の変更",
@@ -17560,6 +17581,13 @@ const TRANSLATIONS = {
         "mc_deprecated_add": "칸반 보드를 대신 사용해 주세요. 칸반 보드에는 완전한 생태계가 있습니다. 기존 작업을 점진적으로 이전해 주세요.",
         "mc_mission_title": "미션 목록",
         "mc_done_title": "완료 목록",
+        // 心智圖 (Mind-map card on mission.html)
+        "mm_card_title": "마인드맵",
+        "mm_card_beta": "(beta · 모의 데이터)",
+        "mm_card_expand": "펼치기",
+        "mm_card_collapse": "접기",
+        "mm_card_hint": "52 노드 · 8 서브시스템 · 76 연결(시스템 간 의존성 포함). 펼쳐서 탐색.",
+
         "mc_notes_title": "노트",
         "mc_rules_title": "규칙 (워크플로)",
         "mc_sync_unsaved": "* 저장되지 않은 변경 사항",
@@ -21544,6 +21572,13 @@ const TRANSLATIONS = {
         "mc_deprecated_add": "กรุณาใช้บอร์ดคัมบังแทน บอร์ดคัมบังมีระบบนิเวศที่สมบูรณ์ — ย้ายรายการที่มีอยู่ไปทีละน้อย",
         "mc_mission_title": "รายการภารกิจ",
         "mc_done_title": "รายการที่เสร็จแล้ว",
+        // 心智圖 (Mind-map card on mission.html)
+        "mm_card_title": "แผนที่ความคิด",
+        "mm_card_beta": "(beta · ข้อมูลจำลอง)",
+        "mm_card_expand": "ขยาย",
+        "mm_card_collapse": "ย่อ",
+        "mm_card_hint": "52 โหนด · 8 ระบบย่อย · 76 ลิงก์ (รวมข้ามระบบ) — ขยายเพื่อสำรวจ",
+
         "mc_notes_title": "โน้ต",
         "mc_rules_title": "กฎ (เวิร์คโฟลว์)",
         "mc_sync_unsaved": "* การเปลี่ยนแปลงที่ยังไม่ได้บันทึก",
@@ -25536,6 +25571,13 @@ const TRANSLATIONS = {
         "mc_deprecated_add": "Vui lòng sử dụng bảng Kanban thay thế. Bảng Kanban có hệ sinh thái hoàn chỉnh — hãy di chuyển các mục hiện tại dần dần.",
         "mc_mission_title": "Danh sách Nhiệm vụ",
         "mc_done_title": "Danh sách Hoàn thành",
+        // 心智圖 (Mind-map card on mission.html)
+        "mm_card_title": "Bản đồ tư duy",
+        "mm_card_beta": "(beta · dữ liệu mô phỏng)",
+        "mm_card_expand": "Mở rộng",
+        "mm_card_collapse": "Thu gọn",
+        "mm_card_hint": "52 nút · 8 hệ thống con · 76 liên kết (bao gồm phụ thuộc liên hệ thống). Mở rộng để khám phá.",
+
         "mc_notes_title": "Ghi chú",
         "mc_rules_title": "Quy tắc (Luồng công việc)",
         "mc_sync_unsaved": "* Thay đổi chưa lưu",
@@ -29502,6 +29544,13 @@ const TRANSLATIONS = {
         "mc_deprecated_add": "Silakan gunakan papan Kanban sebagai gantinya. Papan Kanban memiliki ekosistem lengkap — migrasikan item yang ada secara bertahap.",
         "mc_mission_title": "Daftar Misi",
         "mc_done_title": "Daftar Selesai",
+        // 心智圖 (Mind-map card on mission.html)
+        "mm_card_title": "Peta Pikiran",
+        "mm_card_beta": "(beta · data tiruan)",
+        "mm_card_expand": "Perluas",
+        "mm_card_collapse": "Tutup",
+        "mm_card_hint": "52 simpul · 8 subsistem · 76 koneksi (termasuk lintas sistem). Perluas untuk menjelajah.",
+
         "mc_notes_title": "Catatan",
         "mc_rules_title": "Aturan (Alur Kerja)",
         "mc_sync_unsaved": "* Perubahan belum disimpan",
@@ -33465,6 +33514,13 @@ const TRANSLATIONS = {
         "mc_deprecated_add": "Veuillez utiliser le tableau Kanban à la place. Le tableau Kanban dispose d'un écosystème complet — migrez progressivement les éléments existants.",
         "mc_mission_title": "Liste des Missions",
         "mc_done_title": "Liste Terminée",
+        // 心智圖 (Mind-map card on mission.html)
+        "mm_card_title": "Carte mentale",
+        "mm_card_beta": "(beta · données fictives)",
+        "mm_card_expand": "Déplier",
+        "mm_card_collapse": "Replier",
+        "mm_card_hint": "52 nœuds · 8 sous-systèmes · 76 liens (dépendances intersystèmes incluses). Déplier pour explorer.",
+
         "mc_notes_title": "Notes",
         "mc_rules_title": "Règles (Flux de Travail)",
         "mc_sync_unsaved": "* Modifications non enregistrées",
@@ -37418,6 +37474,13 @@ const TRANSLATIONS = {
         "mc_deprecated_add": "Por favor, utilice el tablero Kanban en su lugar. El tablero Kanban tiene un ecosistema completo — migre los elementos existentes gradualmente.",
         "mc_mission_title": "Lista de Misiones",
         "mc_done_title": "Lista Completada",
+        // 心智圖 (Mind-map card on mission.html)
+        "mm_card_title": "Mapa mental",
+        "mm_card_beta": "(beta · datos simulados)",
+        "mm_card_expand": "Expandir",
+        "mm_card_collapse": "Contraer",
+        "mm_card_hint": "52 nodos · 8 subsistemas · 76 conexiones (incl. dependencias entre sistemas). Expande para explorar.",
+
         "mc_notes_title": "Notas",
         "mc_rules_title": "Reglas (Flujos de Trabajo)",
         "mc_sync_unsaved": "* Cambios sin guardar",
@@ -41344,6 +41407,13 @@ const TRANSLATIONS = {
         "mc_deprecated_add": "Hinzufügen (alt)",
         "mc_mission_title": "Mission",
         "mc_done_title": "Erledigt",
+        // 心智圖 (Mind-map card on mission.html)
+        "mm_card_title": "Mindmap",
+        "mm_card_beta": "(beta · Mock-Daten)",
+        "mm_card_expand": "Aufklappen",
+        "mm_card_collapse": "Zuklappen",
+        "mm_card_hint": "52 Knoten · 8 Subsysteme · 76 Verbindungen (inkl. systemübergreifender Abhängigkeiten). Aufklappen zum Erkunden.",
+
         "mc_notes_title": "Notizen",
         "mc_rules_title": "Regeln",
         "mc_sync_unsaved": "Nicht gespeichert",
@@ -45302,6 +45372,13 @@ const TRANSLATIONS = {
         "mc_deprecated_add": "Sila gunakan papan Kanban sebagai ganti. Papan Kanban mempunyai ekosistem lengkap — pindahkan item sedia ada secara beransur-ansur.",
         "mc_mission_title": "Senarai Misi",
         "mc_done_title": "Senarai Selesai",
+        // 心智圖 (Mind-map card on mission.html)
+        "mm_card_title": "Peta Minda",
+        "mm_card_beta": "(beta · data tiruan)",
+        "mm_card_expand": "Buka",
+        "mm_card_collapse": "Tutup",
+        "mm_card_hint": "52 nod · 8 subsistem · 76 sambungan (termasuk silang sistem). Buka untuk meneroka.",
+
         "mc_notes_title": "Nota",
         "mc_rules_title": "Aturan (Alur Kerja)",
         "mc_sync_unsaved": "* Perubahan belum disimpan",
@@ -50984,6 +51061,13 @@ const TRANSLATIONS = {
         "mc_deprecated_add": "कृपया इसके बजाय कानबन बोर्ड का उपयोग करें। कानबन बोर्ड में पूर्ण पारिस्थितिकी तंत्र है — मौजूदा आइटम को धीरे-धीरे स्थानांतरित करें।",
         "mc_mission_title": "मिशन सूची",
         "mc_done_title": "पूर्ण सूची",
+        // 心智圖 (Mind-map card on mission.html)
+        "mm_card_title": "माइंड मैप",
+        "mm_card_beta": "(beta · नकली डेटा)",
+        "mm_card_expand": "विस्तार करें",
+        "mm_card_collapse": "समेटें",
+        "mm_card_hint": "52 नोड · 8 सबसिस्टम · 76 लिंक (क्रॉस-सिस्टम सहित)। एक्सप्लोर करने के लिए विस्तार करें।",
+
         "mc_notes_title": "नोट्स",
         "mc_rules_title": "नियम (वर्कफ़्लो)",
         "mc_sync_unsaved": "* सेव नहीं किए गए बदलाव",
@@ -58002,6 +58086,13 @@ const TRANSLATIONS = {
         "mc_deprecated_add": "يرجى استخدام لوحة كانبان بدلاً من ذلك. لوحة كانبان لديها نظام بيئي كامل — قم بنقل العناصر الحالية تدريجياً.",
         "mc_mission_title": "قائمة المهام",
         "mc_done_title": "قائمة المكتمل",
+        // 心智圖 (Mind-map card on mission.html)
+        "mm_card_title": "الخريطة الذهنية",
+        "mm_card_beta": "(beta · بيانات وهمية)",
+        "mm_card_expand": "توسيع",
+        "mm_card_collapse": "طي",
+        "mm_card_hint": "52 عقدة · 8 أنظمة فرعية · 76 رابطًا (تشمل التبعيات بين الأنظمة). وسّع للاستكشاف.",
+
         "mc_notes_title": "ملاحظات",
         "mc_rules_title": "القواعد (سير العمل)",
         "mc_sync_unsaved": "* تغييرات غير محفوظة",


### PR DESCRIPTION
## Summary
- Adds a collapsible "🧠 心智圖" card section above Notes on `mission.html`. Default collapsed; lazy-loads cytoscape@3.28.1 from CDN on first expand so cold page weight is unchanged.
- New module `backend/public/portal/shared/mission-mindmap.js` extracted from the v3 dense mockup (Hank-approved 2026-04-25). Exposes `window.MissionMindmap.init({ rootEl, data? })` and ships with 52-node / 64-edge mock data covering 8 subsystems (invite/device/i18n/kanban/chat/payment/broadcast/bridge), including 19 cross-system dashed-yellow dependency edges.
- 5 new i18n keys (`mm_card_title/beta/expand/collapse/hint`) across 13 locales.
- PR-B will swap `MOCK_NODES` for live `/api/mission/cards` (assignedTo→sys, status→active|blocked|done) and chat embedding coords.

## Why static-first
v3 mockup was approved at the asset URL with hand-curated structure. Shipping the same data verbatim into the live page lets Hank verify layout + interaction in production before we wire it to real card data — the wiring step has its own surface (auth, entity scoping, card→subsystem mapping heuristics) that deserves its own PR.

## Bug found + fixed pre-merge
Smoke test (file:// blocked, used local python http.server + Playwright) caught a layout collapse: callers toggling `container.style.display = 'block'` beat the module's `.mm-root { display:grid }` class via inline-style specificity. Patched in commit c73f4058 — module now strips inline display at init, mission.html toggle uses `''` instead of `'block'`. Verified 3-column grid renders, 52 nodes laid out via cose, side panel populates on node tap.

## Test plan
- [ ] Visit `/portal/mission.html`, confirm new "🧠 心智圖" card appears above Notes
- [ ] Click 展開 — cytoscape lazy-loads from CDN, mind-map renders 3-column (rail / canvas / side)
- [ ] Click any node — neighborhood highlights, side panel shows pills (subsystem + status) + summary + cross-system related list
- [ ] Click subsystem row in left rail — only that subsystem's nodes stay opaque
- [ ] Click 🎯 Fit / 🔄 重整 toolbar buttons
- [ ] At viewport ≤ 860px, confirm rail + side hide and canvas fills width (mobile fallback)
- [ ] Switch language; the i18n hint + button labels update
- [ ] CI: lint + i18n strict check + Jest all pass