### PR TITLE
fix(kanban): notes tab reads camelCase to match API response

### DIFF
--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -1878,7 +1878,7 @@
                     <div class="kb-note">
                         <div class="kb-note-title">${escapeHtml(n.title)}</div>
                         <div class="kb-note-content">${escapeHtml(n.content)}</div>
-                        <div class="kb-note-meta">#${n.from_entity_id ?? '?'} · ${formatTime(n.created_at)}</div>
+                        <div class="kb-note-meta">#${n.fromEntityId ?? n.from_entity_id ?? '?'} · ${formatTime(n.createdAt ?? n.created_at)}</div>
                     </div>
                 `).join('') : '<div class="kb-empty" data-i18n="kb_empty_no_notes">' + t('kb_empty_no_notes', 'No notes yet') + '</div>';
             } catch(e) { panel.innerHTML = '<div class="kb-empty">Failed to load notes</div>'; }


### PR DESCRIPTION
## Summary
- Bug: kanban card notes tab showed `#? · ` for every note's meta line.
- Root cause: API maps DB columns to camelCase (`fromEntityId` / `createdAt` in `kanban.js:1334-1335`), but frontend was reading `n.from_entity_id` / `n.created_at` (`kanban.html:1881`).
- Fix: read camelCase first, fall back to snake_case for tolerance.

## Test plan
- [ ] Open any card with at least one note, click 筆記 tab
- [ ] Confirm meta line now shows `#<entityId> · <time>` instead of `#? · `