### PR TITLE
security: redact explicit token shapes (GitHub PAT, sk-, Slack) in A2A outbound + chat_messages

### DIFF
--- a/backend/gatekeeper.js
+++ b/backend/gatekeeper.js
@@ -241,7 +241,7 @@ const DEVICE_INFO_PATTERNS = [
 // Explicit token-shape patterns (GitHub PAT, Slack, OpenAI/Anthropic keys)
 const EXPLICIT_TOKEN_PATTERNS = [
     // GitHub Personal Access Token: ghp_ / gho_ / ghu_ / ghs_ / ghr_ + 36+ chars
-    /gh[pous]_[A-Za-z0-9]{36,}/g,
+    /gh[pousr]_[A-Za-z0-9]{36,}/g,
     // OpenAI / Anthropic / other sk- API keys: sk- + 30+ chars
     /sk-[A-Za-z0-9_-]{30,}/g,
     // Slack token: xoxb-/xoxa-/xoxp-/xoxr-/xoxs- + 20+ chars
@@ -307,7 +307,7 @@ function detectAndMaskLeaks(text, deviceId, botSecret, isOutbound) {
                 if (maskedText.includes(idCheck)) continue;
 
                 let kind;
-                if (match.startsWith('ghp') || match.startsWith('gho') || match.startsWith('ghu') || match.startsWith('ghs') || match.startsWith('ghr')) kind = 'github_pat';
+                if (/^gh[pousr]_/.test(match)) kind = 'github_pat';
                 else if (match.startsWith('sk-')) kind = 'api_key';
                 else if (match.startsWith('xox')) kind = 'slack_token';
                 else kind = 'token';

--- a/backend/gatekeeper.js
+++ b/backend/gatekeeper.js
@@ -25,6 +25,10 @@ try {
 const MAX_STRIKES = 3;
 const FREE_BOT_TOS_VERSION = '1.0';
 
+// Mask characters for secret redaction
+const REDACTED = '\u2736\u2736\u2736[REDACTED:'; // ✱✱✱[REDACTED:
+const REDACTED_SUFFIX = ']\u2736\u2736\u2736';   // ]✱✱✱
+
 // ============================================
 // FIRST LOCK: Malicious message detection
 // ============================================
@@ -234,6 +238,20 @@ const DEVICE_INFO_PATTERNS = [
     /https?:\/\/[^\s]+\/tools\/invoke[^\s]*/gi,
 ];
 
+// Explicit token-shape patterns (GitHub PAT, Slack, OpenAI/Anthropic keys)
+const EXPLICIT_TOKEN_PATTERNS = [
+    // GitHub Personal Access Token: ghp_ / gho_ / ghu_ / ghs_ / ghr_ + 36+ chars
+    /gh[pous]_[A-Za-z0-9]{36,}/g,
+    // OpenAI / Anthropic / other sk- API keys: sk- + 30+ chars
+    /sk-[A-Za-z0-9_-]{30,}/g,
+    // Slack token: xoxb-/xoxa-/xoxp-/xoxr-/xoxs- + 20+ chars
+    /xox[abprs]-[A-Za-z0-9-]{20,}/g,
+];
+
+// Admin notify cache to prevent duplicate notifies within 60 seconds per device+kind
+const notifyCache = {};
+const NOTIFY_COOLDOWN_MS = 60000;
+
 /**
  * Second Lock: Detect and mask token/info leaks in bot response
  * @param {string} text - The bot response text
@@ -241,11 +259,20 @@ const DEVICE_INFO_PATTERNS = [
  * @param {string} botSecret - Current entity's botSecret (to detect its leak)
  * @returns {{ leaked: boolean, maskedText: string, leakTypes: string[] }}
  */
-function detectAndMaskLeaks(text, deviceId, botSecret) {
+/**
+ * Second Lock: Detect and mask token/info leaks in bot response
+ * @param {string} text - The bot response text
+ * @param {string} deviceId - Current device ID (to avoid false positives on own deviceId)
+ * @param {string} botSecret - Current entity's botSecret (to detect its leak)
+ * @param {boolean} isOutbound - If true, this is an outbound A2A broadcast (log admin notify)
+ * @returns {{ leaked: boolean, maskedText: string, leakTypes: string[] }}
+ */
+function detectAndMaskLeaks(text, deviceId, botSecret, isOutbound) {
     if (!text || typeof text !== 'string') return { leaked: false, maskedText: text, leakTypes: [] };
 
     let maskedText = text;
     const leakTypes = [];
+    isOutbound = !!isOutbound;
 
     // Check if botSecret is exposed in clear text
     if (botSecret && maskedText.includes(botSecret)) {
@@ -258,7 +285,6 @@ function detectAndMaskLeaks(text, deviceId, botSecret) {
         const matches = maskedText.match(pattern);
         if (matches) {
             for (const match of matches) {
-                // Don't mask if it's the deviceId itself in a normal context (like API URLs we provide)
                 if (match.includes('/tools/invoke')) {
                     maskedText = maskedText.replace(match, '[REDACTED_WEBHOOK]');
                     leakTypes.push('webhook_leak');
@@ -270,49 +296,89 @@ function detectAndMaskLeaks(text, deviceId, botSecret) {
         }
     }
 
-    // Check for token-like patterns
-    for (const pattern of TOKEN_LEAK_PATTERNS) {
-        // Reset lastIndex for global patterns
+    // Check for explicit token patterns (GitHub PAT, Slack, OpenAI/Anthropic)
+    for (const pattern of EXPLICIT_TOKEN_PATTERNS) {
         pattern.lastIndex = 0;
         const matches = maskedText.match(pattern);
         if (matches) {
             for (const match of matches) {
-                // Skip if it's the deviceId itself (acceptable in normal responses)
                 if (match === deviceId) continue;
-                // Skip if it looks like a normal part of a URL we constructed
-                if (maskedText.includes(`"deviceId":"${match}"`)) continue;
+                const idCheck = String.fromCharCode(34) + 'deviceId' + String.fromCharCode(58,34) + match + String.fromCharCode(34);
+                if (maskedText.includes(idCheck)) continue;
 
-                // Classify the match
+                let kind;
+                if (match.startsWith('ghp') || match.startsWith('gho') || match.startsWith('ghu') || match.startsWith('ghs') || match.startsWith('ghr')) kind = 'github_pat';
+                else if (match.startsWith('sk-')) kind = 'api_key';
+                else if (match.startsWith('xox')) kind = 'slack_token';
+                else kind = 'token';
+
+                const replacement = REDACTED + kind + REDACTED_SUFFIX;
+                maskedText = maskedText.split(match).join(replacement);
+                if (!leakTypes.includes('explicit_token_leak')) leakTypes.push('explicit_token_leak');
+
+                if (isOutbound) scheduleAdminNotify(deviceId, 'explicit_token', kind, match.length);
+            }
+        }
+    }
+
+    // Check for generic token-like patterns (hex 32+, UUID, JWT, Bearer, etc.)
+    for (const pattern of TOKEN_LEAK_PATTERNS) {
+        pattern.lastIndex = 0;
+        const matches = maskedText.match(pattern);
+        if (matches) {
+            for (const match of matches) {
+                if (match === deviceId) continue;
+                const idCheck = String.fromCharCode(34) + 'deviceId' + String.fromCharCode(58,34) + match + String.fromCharCode(34);
+                if (maskedText.includes(idCheck)) continue;
+
                 const isPureHex = /^[0-9a-f]+$/i.test(match);
                 const isUUID = /^[0-9a-f]{8}-/.test(match);
                 const isJWT = match.startsWith('eyJ');
                 const isBearer = /^Bearer\s/i.test(match);
 
-                // For non-hex, non-special matches, require high entropy (avoids false positives on normal text)
                 if (!isPureHex && !isUUID && !isJWT && !isBearer) {
                     if (!looksLikeToken(match)) continue;
                 }
-                // For pure hex, still require minimum length
                 if (isPureHex && match.length < 32) continue;
 
-                // This looks like a leaked token/secret
-                const redacted = match.substring(0, 4) + '***' + match.substring(match.length - 4);
-                maskedText = maskedText.split(match).join(`[REDACTED:${redacted}]`);
-                if (!leakTypes.includes('token_pattern_leak')) {
-                    leakTypes.push('token_pattern_leak');
-                }
+                const replacement = REDACTED + 'hex_token' + REDACTED_SUFFIX;
+                maskedText = maskedText.split(match).join(replacement);
+                if (!leakTypes.includes('token_pattern_leak')) leakTypes.push('token_pattern_leak');
             }
         }
     }
 
-    return {
-        leaked: leakTypes.length > 0,
-        maskedText: maskedText,
-        leakTypes: leakTypes
-    };
+    return { leaked: leakTypes.length > 0, maskedText: maskedText, leakTypes: leakTypes };
 }
 
 // ============================================
+
+/**
+ * Fire-and-forget admin notify for secret-leak events (does not block the response).
+ * Cooldown cached per deviceId+kind to avoid spam.
+ */
+async function scheduleAdminNotify(deviceId, kind, tokenKind, byteLength) {
+    const cacheKey = deviceId + ':' + kind;
+    const now = Date.now();
+    if (notifyCache[cacheKey] && (now - notifyCache[cacheKey]) < NOTIFY_COOLDOWN_MS) return;
+    notifyCache[cacheKey] = now;
+
+    setImmediate(async () => {
+        try {
+            if (!pool) return;
+            const preview = REDACTED + tokenKind + REDACTED_SUFFIX;
+            const text = '\u26a0\ufe0f Secret leak blocked: ' + preview + ' (len=' + byteLength + ') device=' + deviceId.substring(0, 8) + '...';
+            await pool.query(
+                'INSERT INTO chat_messages (device_id, entity_id, text, source, is_from_user, is_from_bot)' +
+                ' VALUES ($1, NULL, $2, $3, false, true)',
+                [deviceId, text, 'admin_secret_notify']
+            );
+        } catch (err) {
+            console.warn('[Gatekeeper] admin notify failed:', err.message);
+        }
+    });
+}
+
 // STRIKE SYSTEM
 // ============================================
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -8507,7 +8507,7 @@ app.post('/api/entity/speak-to', async (req, res) => {
     const fromBindingST = officialBindingsCache[getBindingCacheKey(deviceId, fromId)];
     const isFreeBotSpeakTo = fromBindingST && officialBots[fromBindingST.bot_id] && officialBots[fromBindingST.bot_id].bot_type === 'free';
     if (isFreeBotSpeakTo && speakToText) {
-        const leakCheck = gatekeeper.detectAndMaskLeaks(speakToText, deviceId, fromEntity.botSecret);
+        const leakCheck = gatekeeper.detectAndMaskLeaks(speakToText, deviceId, fromEntity.botSecret, true);
         if (leakCheck.leaked) {
             speakToText = leakCheck.maskedText;
             console.warn(`[Gatekeeper] Second lock (speak-to): masked ${leakCheck.leakTypes.join(', ')} from device ${deviceId} entity ${fromId}`);
@@ -10833,7 +10833,7 @@ app.post('/api/entity/broadcast', async (req, res) => {
     const fromBinding = officialBindingsCache[getBindingCacheKey(deviceId, fromId)];
     const isFreeBotBroadcast = fromBinding && officialBots[fromBinding.bot_id] && officialBots[fromBinding.bot_id].bot_type === 'free';
     if (isFreeBotBroadcast && broadcastText) {
-        const leakCheck = gatekeeper.detectAndMaskLeaks(broadcastText, deviceId, fromEntity.botSecret);
+        const leakCheck = gatekeeper.detectAndMaskLeaks(broadcastText, deviceId, fromEntity.botSecret, true);
         if (leakCheck.leaked) {
             broadcastText = leakCheck.maskedText;
             console.warn(`[Gatekeeper] Second lock (broadcast): masked ${leakCheck.leakTypes.join(', ')} from device ${deviceId} entity ${fromId}`);

--- a/backend/tests/jest/gatekeeper.test.js
+++ b/backend/tests/jest/gatekeeper.test.js
@@ -382,3 +382,106 @@ describe('getFreeBotTOS', () => {
         expect(tos.sections[0].heading).toMatch(/服務/);
     });
 });
+
+
+    // ════════════════════════════════════════════════════════════════
+    // Explicit token-shape patterns (GitHub PAT, Slack, OpenAI/Anthropic)
+    // ════════════════════════════════════════════════════════════════
+    describe('Explicit token-shape redaction', () => {
+        const FAKE_GITHUB_PAT = 'ghp_FAKETESTXXXXXXXXXXXXXXXXXXXXXXXX';
+        const FAKE_OPENAI_KEY = 'sk-testtesttesttesttesttesttesttesttest';
+        const FAKE_SLACK_TOKEN = 'xoxb-12345678901234567890-abcd';
+
+        it('redacts GitHub PAT as ✱✱✱[REDACTED:github_pat]✱✱✱', () => {
+            const text = 'Token: ' + FAKE_GITHUB_PAT + ' is my key';
+            const r = detectAndMaskLeaks(text, DEVICE_ID, BOT_SECRET);
+            expect(r.leaked).toBe(true);
+            expect(r.maskedText).toContain('✶✶✶[REDACTED:github_pat]✶✶✶');
+            expect(r.maskedText).not.toContain('FAKETEST');
+        });
+
+        it('redacts GitHub PAT regardless of prefix variant (ghp/gho/ghu/ghs/ghr)', () => {
+            for (const prefix of ['ghp', 'gho', 'ghu', 'ghs', 'ghr']) {
+                const fake = prefix + '_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+                const r = detectAndMaskLeaks('Key: ' + fake, DEVICE_ID, BOT_SECRET);
+                expect(r.leaked).toBe(true);
+                expect(r.maskedText).toContain('[REDACTED:github_pat]');
+                expect(r.maskedText).not.toContain('XXXXXXXX');
+            }
+        });
+
+        it('redacts OpenAI/Anthropic sk- key as ✱✱✱[REDACTED:api_key]✱✱✱', () => {
+            const text = 'API key: ' + FAKE_OPENAI_KEY + ' is here';
+            const r = detectAndMaskLeaks(text, DEVICE_ID, BOT_SECRET);
+            expect(r.leaked).toBe(true);
+            expect(r.maskedText).toContain('✶✶✶[REDACTED:api_key]✶✶✶');
+            expect(r.maskedText).not.toContain('testtest');
+        });
+
+        it('redacts Slack xoxb- token as ✱✱✱[REDACTED:slack_token]✱✱✱', () => {
+            const text = 'Slack: ' + FAKE_SLACK_TOKEN + ' is here';
+            const r = detectAndMaskLeaks(text, DEVICE_ID, BOT_SECRET);
+            expect(r.leaked).toBe(true);
+            expect(r.maskedText).toContain('✶✶✶[REDACTED:slack_token]✶✶✶');
+        });
+
+        it('does NOT redact short prefixes (below minimum length)', () => {
+            const short = 'ghp_Short1';
+            const r = detectAndMaskLeaks('Token: ' + short, DEVICE_ID, BOT_SECRET);
+            expect(r.leaked).toBe(false);
+            expect(r.maskedText).toContain(short);
+        });
+
+        it('does NOT redact card_id-like strings (not real tokens)', () => {
+            const cardId = 'card_5c2e51dc9065998bc1b4cd49';
+            const r = detectAndMaskLeaks('Card: ' + cardId, DEVICE_ID, BOT_SECRET);
+            // card_ prefix is not in our patterns; should not be flagged
+            expect(r.maskedText).toContain(cardId);
+        });
+
+        it('does NOT redact normal English words', () => {
+            const r = detectAndMaskLeaks('The quick brown fox jumps over the lazy dog', DEVICE_ID, BOT_SECRET);
+            expect(r.leaked).toBe(false);
+            expect(r.maskedText).toBe('The quick brown fox jumps over the lazy dog');
+        });
+
+        it('does NOT redact normal English sentences (false-positive test)', () => {
+            const texts = [
+                'I need to transfer money from my bank account',
+                'Can you show me the access token for the API?',
+                'What is your password?',
+            ];
+            for (const text of texts) {
+                const r = detectAndMaskLeaks(text, DEVICE_ID, BOT_SECRET);
+                expect(r.leaked).toBe(false);
+            }
+        });
+
+        it('redacts multiple tokens in same message', () => {
+            const text = 'GitHub: ' + FAKE_GITHUB_PAT + ' and Slack: ' + FAKE_SLACK_TOKEN;
+            const r = detectAndMaskLeaks(text, DEVICE_ID, BOT_SECRET);
+            expect(r.leaked).toBe(true);
+            expect(r.maskedText).toContain('[REDACTED:github_pat]');
+            expect(r.maskedText).toContain('[REDACTED:slack_token]');
+            expect(r.maskedText).not.toContain('FAKETEST');
+            expect(r.maskedText).not.toContain('1234567890');
+        });
+
+        it('skips redaction when token appears inside a JSON "deviceId" field', () => {
+            const deviceIdToken = 'abc123def456abc123def456abc123de';
+            const json = '{"deviceId":"' + deviceIdToken + '"}';
+            const r = detectAndMaskLeaks(json, deviceIdToken, BOT_SECRET);
+            // The token IS the deviceId, so it should still be caught (our code skips if match === deviceId)
+            // But in a JSON field context it might be handled differently
+            expect(r.maskedText).not.toContain('abc123def456abc123def456abc123de');
+        });
+
+        it('isOutbound=true triggers admin notify path without crashing (fire-and-forget)', () => {
+            const text = 'Here is your token: ' + FAKE_GITHUB_PAT;
+            // Should not throw even if pool is mocked
+            const r = detectAndMaskLeaks(text, DEVICE_ID, BOT_SECRET, true);
+            expect(r.leaked).toBe(true);
+            expect(r.maskedText).toContain('[REDACTED:github_pat]');
+        });
+    });
+

--- a/backend/tests/jest/gatekeeper.test.js
+++ b/backend/tests/jest/gatekeeper.test.js
@@ -384,13 +384,15 @@ describe('getFreeBotTOS', () => {
 });
 
 
-    // ════════════════════════════════════════════════════════════════
-    // Explicit token-shape patterns (GitHub PAT, Slack, OpenAI/Anthropic)
-    // ════════════════════════════════════════════════════════════════
-    describe('Explicit token-shape redaction', () => {
-        const FAKE_GITHUB_PAT = 'ghp_FAKETESTXXXXXXXXXXXXXXXXXXXXXXXX';
-        const FAKE_OPENAI_KEY = 'sk-testtesttesttesttesttesttesttesttest';
-        const FAKE_SLACK_TOKEN = 'xoxb-12345678901234567890-abcd';
+// ════════════════════════════════════════════════════════════════
+// Explicit token-shape patterns (GitHub PAT, Slack, OpenAI/Anthropic)
+// ════════════════════════════════════════════════════════════════
+describe('Explicit token-shape redaction', () => {
+    const DEVICE_ID = 'test-device-001';
+    const BOT_SECRET = 'abc123SecretXYZ789verylongstring';
+    const FAKE_GITHUB_PAT = 'ghp_FAKETESTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+    const FAKE_OPENAI_KEY = 'sk-testtesttesttesttesttesttesttesttest';
+    const FAKE_SLACK_TOKEN = 'xoxb-12345678901234567890-abcd';
 
         it('redacts GitHub PAT as ✱✱✱[REDACTED:github_pat]✱✱✱', () => {
             const text = 'Token: ' + FAKE_GITHUB_PAT + ' is my key';
@@ -402,7 +404,7 @@ describe('getFreeBotTOS', () => {
 
         it('redacts GitHub PAT regardless of prefix variant (ghp/gho/ghu/ghs/ghr)', () => {
             for (const prefix of ['ghp', 'gho', 'ghu', 'ghs', 'ghr']) {
-                const fake = prefix + '_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
+                const fake = prefix + '_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX';
                 const r = detectAndMaskLeaks('Key: ' + fake, DEVICE_ID, BOT_SECRET);
                 expect(r.leaked).toBe(true);
                 expect(r.maskedText).toContain('[REDACTED:github_pat]');
@@ -467,13 +469,11 @@ describe('getFreeBotTOS', () => {
             expect(r.maskedText).not.toContain('1234567890');
         });
 
-        it('skips redaction when token appears inside a JSON "deviceId" field', () => {
+        it('skips redaction when token equals current deviceId', () => {
             const deviceIdToken = 'abc123def456abc123def456abc123de';
             const json = '{"deviceId":"' + deviceIdToken + '"}';
             const r = detectAndMaskLeaks(json, deviceIdToken, BOT_SECRET);
-            // The token IS the deviceId, so it should still be caught (our code skips if match === deviceId)
-            // But in a JSON field context it might be handled differently
-            expect(r.maskedText).not.toContain('abc123def456abc123def456abc123de');
+            expect(r.maskedText).toContain(deviceIdToken);
         });
 
         it('isOutbound=true triggers admin notify path without crashing (fire-and-forget)', () => {


### PR DESCRIPTION
## Summary

Adds explicit token-shape redaction (GitHub PAT, OpenAI/Anthropic `sk-`, Slack `xox*`) to gatekeeper second-lock, with admin-notify on outbound leakage.

- New `EXPLICIT_TOKEN_PATTERNS` (gh[pousr]_, sk-, xox[abprs]-) → `✶✶✶[REDACTED:<kind>]✶✶✶`
- `detectAndMaskLeaks()` adds `isOutbound` param; outbound leak triggers async `scheduleAdminNotify()` (60s cooldown per device+kind)
- `speakTo` and `broadcast` outbound paths in `index.js` pass `isOutbound=true`
- 61 jest cases (was 50, added 11 explicit-token cases)

This is a cherry-pick of #3's commit `e9b6b131` rebased onto current main (his branch was forked 8 commits behind and would have reverted #2093/#2095/#2096/#2097/#2099/#2100/#2092/#2094). Plus fixes: scope-hoisted test constants, lengthened PAT fixtures to match `{36,}` regex, added missing `r` to GitHub PAT prefix class (ghr_ refresh tokens).

Closes follow-up to card_5c2e51dc9065998bc1b4cd49 (P2 hygiene).

## Test plan

- [x] `cd backend && npx jest tests/jest/gatekeeper.test.js` → 61/61 pass
- [ ] Post-merge: send `ghp_FAKETESTXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX` in a free-bot speakTo and confirm `[REDACTED:github_pat]` appears in `/api/chat/history`
- [ ] Post-merge: confirm admin-notify row appears in chat_messages with `source=admin_secret_notify` (60s cooldown)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
