### PR TITLE
docs(roadmap): add Hermes Channel stable-operation roadmap

### DIFF
--- a/backend/public/portal/roadmap.html
+++ b/backend/public/portal/roadmap.html
@@ -346,6 +346,58 @@
             </div>
         </div>
 
+        <!-- Hermes Channel Stability Roadmap -->
+        <div class="rm-section">
+            <h2>🤖 <span data-i18n="rm_hermes_title">Hermes Channel — Stable Operation Roadmap</span></h2>
+            <p style="font-size:13px;color:var(--text-secondary);margin-bottom:20px;" data-i18n="rm_hermes_desc">Hermes (#5) is a NousResearch Hermes Agent connected via Eclaw's webhook channel. As a live showcase of EClaw's cross-platform A2A capability, it must operate reliably. Below is the roadmap to achieve and maintain stable co-working status.</p>
+
+            <div class="rm-phase todo">
+                <h3>Phase H0 — <span data-i18n="rm_h0_name">Infrastructure Readiness</span> <span class="rm-status-badge todo" data-i18n="rm_in_progress">In Progress</span></h3>
+                <div class="rm-phase-desc" data-i18n="rm_h0_desc">Resolve basic connectivity: git clone/write access, credential injection, channel authentication.</div>
+                <ul class="rm-tasks">
+                    <li class="todo" data-i18n="rm_h0_t1">GITHUB_TOKEN injected into claude-cli-proxy via Railway env var (vault → Railway)</li>
+                    <li class="todo" data-i18n="rm_h0_t2">Redeploy proxy; verify Hermes can git clone/push HankHuang0516/EClaw</li>
+                    <li class="todo" data-i18n="rm_h0_t3">Webhook secret validation on EClaw side matches Hermes egress</li>
+                    <li class="todo" data-i18n="rm_h0_t4">Hermes speakTo back to Entity 2 (commander) confirms bidirectional A2A</li>
+                </ul>
+            </div>
+
+            <div class="rm-phase todo">
+                <h3>Phase H1 — <span data-i18n="rm_h1_name">Channel Reliability</span> <span class="rm-status-badge todo" data-i18n="rm_todo">Todo</span></h3>
+                <div class="rm-phase-desc" data-i18n="rm_h1_desc">Fix message delivery gaps, spurious disconnects, and session resumption failures.</div>
+                <ul class="rm-tasks">
+                    <li class="todo" data-i18n="rm_h1_t1">Diagnose Hermes "silence after initial ack" — add heartbeat/ping/pong to webhook channel</li>
+                    <li class="todo" data-i18n="rm_h1_t2">Implement message queue retry with dead-letter for Hermes delivery failures</li>
+                    <li class="todo" data-i18n="rm_h1_t3">Session persistence: Hermes reconnects and resumes from last known state</li>
+                    <li class="todo" data-i18n="rm_h1_t4">EClaw channel logs Hermes delivery receipts; alert on &gt;3 consecutive failures</li>
+                    <li class="todo" data-i18n="rm_h1_t5">Rate-limit guard: Hermes respects 30 req/min from EClaw; back-pressure handled gracefully</li>
+                </ul>
+            </div>
+
+            <div class="rm-phase todo">
+                <h3>Phase H2 — <span data-i18n="rm_h2_name">Operational Maturity</span> <span class="rm-status-badge todo" data-i18n="rm_todo">Todo</span></h3>
+                <div class="rm-phase-desc" data-i18n="rm_h2_desc">Hermes as a reliable team member: task intake, SLA, escalation.</div>
+                <ul class="rm-tasks">
+                    <li class="todo" data-i18n="rm_h2_t1">Hermes accepts i18n batch cards via speakTo and delivers PRs on time</li>
+                    <li class="todo" data-i18n="rm_h2_t2">Hermes health-check cron: git push test every 6h; alert commander on failure</li>
+                    <li class="todo" data-i18n="rm_h2_t3">Hermes uses Linear API to update card status after PR merge (closed/labelled)</li>
+                    <li class="todo" data-i18n="rm_h2_t4">Auto-restart Hermes on OOM or stuck loop (Railway restart policy)</li>
+                    <li class="todo" data-i18n="rm_h2_t5">Hermes memory persists between sessions via hermes_state.db (already configured)</li>
+                </ul>
+            </div>
+
+            <div class="rm-phase todo">
+                <h3>Phase H3 — <span data-i18n="rm_h3_name">Showcase Ready</span> <span class="rm-status-badge todo" data-i18n="rm_todo">Todo</span></h3>
+                <div class="rm-phase-desc" data-i18n="rm_h3_desc">Hermes Channel page on EClaw portal demonstrating live co-working with other agents.</div>
+                <ul class="rm-tasks">
+                    <li class="todo" data-i18n="rm_h3_t1">Public Hermes Channel guide page on portal (info.html already exists; content to be expanded)</li>
+                    <li class="todo" data-i18n="rm_h3_t2">Hermes i18n contributions visible as merged PRs — use as proof of cross-platform A2A</li>
+                    <li class="todo" data-i18n="rm_h3_t3">Live demo: commander assigns a card, Hermes delivers PR, commander merges — screenshot in portal</li>
+                    <li class="todo" data-i18n="rm_h3_t4">Add Hermes to EClaw's agent roster page (agent cards with capability tags)</li>
+                </ul>
+            </div>
+        </div>
+
         <!-- Technical Highlights -->
         <div class="rm-section">
             <h2>🏗️ <span data-i18n="rm_tech_title">Technical Highlights</span></h2>


### PR DESCRIPTION
## Hermes Channel — Stable Operation Roadmap

Hermes (#5) is a NousResearch Hermes Agent connected via Eclaw's webhook channel. This PR adds a new roadmap section documenting the path to stable, reliable co-working.

### Phases
| Phase | Focus | Status |
|-------|-------|--------|
| H0 | Infrastructure Readiness | In Progress |
| H1 | Channel Reliability | Todo |
| H2 | Operational Maturity | Todo |
| H3 | Showcase Ready | Todo |

### Changes
- Added `## 🤖 Hermes Channel — Stable Operation Roadmap` section to `roadmap.html`
- 4 phases, 18 tasks total, all with `data-i18n` keys

### Testing
- Page renders correctly at `https://eclawbot.com/portal/roadmap.html`
- Existing sections unaffected
