### PR TITLE
feat(mindmap): align PR-B implementation with v3 dense mockup spec

### DIFF
--- a/backend/public/portal/shared/mission-mindmap.js
+++ b/backend/public/portal/shared/mission-mindmap.js
@@ -24,297 +24,247 @@
   };
 
   const MOCK_NODES = [
-    // 邀請 (7)
-    { id: 'inv-hub', label: '邀請系統', sys: 'invite', tier: 'domain', status: 'active', summary: '8 碼邀請、redeem、tier milestone、funnel telemetry。' },
-    { id: 'inv-code', label: '8 碼生碼', sys: 'invite', tier: 'topic', status: 'done' },
-    { id: 'inv-redeem', label: 'Redeem flow', sys: 'invite', tier: 'topic', status: 'active' },
-    { id: 'inv-tier', label: 'Tier milestone', sys: 'invite', tier: 'topic', status: 'active', summary: 'Tier 1 = 邀請 1 人解鎖 chip preview' },
-    { id: 'inv-leader', label: 'Leaderboard', sys: 'invite', tier: 'topic', status: 'blocked', summary: '需要先有 30+ 用戶才有意義' },
-    { id: 'inv-funnel', label: 'Funnel telemetry', sys: 'invite', tier: 'leaf', status: 'active' },
-    { id: 'inv-qr', label: 'QR 海報生成', sys: 'invite', tier: 'leaf', status: 'done' },
+  // 邀請 (7)
+  { id: 'inv-hub', label: '邀請系統', sys: 'invite', tier: 'domain', status: 'active', summary: '8 碼邀請、redeem、tier milestone、funnel telemetry。本週 0/9 兌換率 0%。' },
+  { id: 'inv-code', label: '8 碼生碼', sys: 'invite', tier: 'topic', status: 'done' },
+  { id: 'inv-redeem', label: 'Redeem flow', sys: 'invite', tier: 'topic', status: 'active' },
+  { id: 'inv-tier', label: 'Tier milestone', sys: 'invite', tier: 'topic', status: 'active', summary: 'Tier 1=邀請 1 人解鎖 chip preview' },
+  { id: 'inv-leader', label: 'Leaderboard', sys: 'invite', tier: 'topic', status: 'blocked', summary: '需要先有 30+ 用戶才有意義' },
+  { id: 'inv-funnel', label: 'Funnel telemetry', sys: 'invite', tier: 'leaf', status: 'active' },
+  { id: 'inv-qr', label: 'QR 海報生成', sys: 'invite', tier: 'leaf', status: 'done' },
 
-    // 裝置 (6)
-    { id: 'dev-hub', label: '裝置 / Device', sys: 'device', tier: 'domain', status: 'active', summary: 'deviceId + secret 認證、輪替、health probe。' },
-    { id: 'dev-rotate', label: 'Secret 輪替', sys: 'device', tier: 'topic', status: 'active', summary: 'POST /api/device/rotate-secret + 一次性 dialog' },
-    { id: 'dev-health', label: 'rental-health cron', sys: 'device', tier: 'topic', status: 'done' },
-    { id: 'dev-vars', label: 'device-vars vault', sys: 'device', tier: 'topic', status: 'done' },
-    { id: 'dev-switch', label: 'Switch Device', sys: 'device', tier: 'leaf', status: 'blocked', summary: '12.4h stale; 等 i18n' },
-    { id: 'dev-logs', label: '/api/logs', sys: 'device', tier: 'leaf', status: 'done' },
+  // 裝置 (6)
+  { id: 'dev-hub', label: '裝置 / Device', sys: 'device', tier: 'domain', status: 'active', summary: 'deviceId+secret 認證、輪替、health probe。' },
+  { id: 'dev-rotate', label: 'Secret 輪替', sys: 'device', tier: 'topic', status: 'active', summary: 'POST /api/device/rotate-secret + 一次性 dialog' },
+  { id: 'dev-health', label: 'rental-health cron', sys: 'device', tier: 'topic', status: 'done' },
+  { id: 'dev-vars', label: 'device-vars vault', sys: 'device', tier: 'topic', status: 'done' },
+  { id: 'dev-switch', label: 'Switch Device', sys: 'device', tier: 'leaf', status: 'blocked', summary: '12.4h stale; 等 i18n' },
+  { id: 'dev-logs', label: '/api/logs (DEVICE_SECRET)', sys: 'device', tier: 'leaf', status: 'done' },
 
-    // i18n (8)
-    { id: 'i18n-hub', label: 'i18n 13 locale', sys: 'i18n', tier: 'domain', status: 'active', summary: 'chip_popover_* 已補完 11 缺額 locale' },
-    { id: 'i18n-shared', label: 'shared/i18n.js (live)', sys: 'i18n', tier: 'topic', status: 'active', summary: '~61k lines, 唯一被 HTML import' },
-    { id: 'i18n-deadtop', label: '頂層 ./i18n.js (dead)', sys: 'i18n', tier: 'leaf', status: 'done', summary: '已 git rm + CI guard' },
-    { id: 'i18n-chip', label: 'chip_popover_*', sys: 'i18n', tier: 'topic', status: 'done', summary: 'PR #2095 merged' },
-    { id: 'i18n-kb', label: 'kb_/kanban_*', sys: 'i18n', tier: 'topic', status: 'blocked' },
-    { id: 'i18n-strict-ci', label: 'i18n-check.js (strict)', sys: 'i18n', tier: 'leaf', status: 'done' },
-    { id: 'i18n-key-audit', label: '558 stray }, audit', sys: 'i18n', tier: 'leaf', status: 'done' },
-    { id: 'i18n-translator', label: 'Mac_E i18n agent', sys: 'i18n', tier: 'leaf', status: 'blocked', summary: '錯檔路徑寫死，已 STOP' },
+  // i18n (8)
+  { id: 'i18n-hub', label: 'i18n 13 locale', sys: 'i18n', tier: 'domain', status: 'active', summary: 'en/zh/zh-TW/ja/ko/de/es/fr/pt/it/vi/th/id/ms/hi/ar — chip_popover 缺 10' },
+  { id: 'i18n-shared', label: 'shared/i18n.js (live)', sys: 'i18n', tier: 'topic', status: 'active', summary: '~61k lines, 唯一被 HTML import' },
+  { id: 'i18n-deadtop', label: '頂層 ./i18n.js (dead)', sys: 'i18n', tier: 'leaf', status: 'done', summary: '已 git rm + CI guard' },
+  { id: 'i18n-chip', label: 'chip_popover_*', sys: 'i18n', tier: 'topic', status: 'blocked', summary: 'Mac_E 兩次 wrong-file fail' },
+  { id: 'i18n-kb', label: 'kb_/kanban_*', sys: 'i18n', tier: 'topic', status: 'blocked' },
+  { id: 'i18n-strict-ci', label: 'i18n-check.js (strict)', sys: 'i18n', tier: 'leaf', status: 'done' },
+  { id: 'i18n-key-audit', label: '558 stray }, audit', sys: 'i18n', tier: 'leaf', status: 'done' },
+  { id: 'i18n-translator', label: 'Mac_E i18n agent', sys: 'i18n', tier: 'leaf', status: 'blocked', summary: '錯檔路徑寫死，已 STOP' },
 
-    // 看板 (7)
-    { id: 'kb-hub', label: '看板系統', sys: 'kanban', tier: 'domain', status: 'active' },
-    { id: 'kb-card', label: '/mission/card API', sys: 'kanban', tier: 'topic', status: 'done' },
-    { id: 'kb-screenshot-gate', label: 'screenshot 截圖閘', sys: 'kanban', tier: 'topic', status: 'active' },
-    { id: 'kb-r2-ttl', label: 'R2 TTL ≥3 days', sys: 'kanban', tier: 'leaf', status: 'done', summary: 'PR #2090 merged' },
-    { id: 'kb-deeplink', label: '深層連結 anchor scroll', sys: 'kanban', tier: 'leaf', status: 'done' },
-    { id: 'kb-notes-tab', label: '筆記 tab snake_case bug', sys: 'kanban', tier: 'leaf', status: 'active' },
-    { id: 'kb-mention', label: '@mention → entityId', sys: 'kanban', tier: 'topic', status: 'active' },
+  // 看板 (7)
+  { id: 'kb-hub', label: '看板系統', sys: 'kanban', tier: 'domain', status: 'active' },
+  { id: 'kb-card', label: '/mission/card API', sys: 'kanban', tier: 'topic', status: 'done' },
+  { id: 'kb-screenshot-gate', label: 'screenshot 截圖閘', sys: 'kanban', tier: 'topic', status: 'active' },
+  { id: 'kb-r2-ttl', label: 'R2 TTL ≥3 days', sys: 'kanban', tier: 'leaf', status: 'done', summary: 'PR #2090 merged' },
+  { id: 'kb-deeplink', label: '深層連結 anchor scroll', sys: 'kanban', tier: 'leaf', status: 'done' },
+  { id: 'kb-notes-tab', label: '筆記 tab snake_case bug', sys: 'kanban', tier: 'leaf', status: 'active' },
+  { id: 'kb-mention', label: '@mention → entityId', sys: 'kanban', tier: 'topic', status: 'active' },
 
-    // 聊天 (8)
-    { id: 'chat-hub', label: '聊天 / Chat', sys: 'chat', tier: 'domain', status: 'active' },
-    { id: 'chat-chip', label: '智慧引用晶片', sys: 'chat', tier: 'topic', status: 'active', summary: '@chip_popover_X 點擊預覽' },
-    { id: 'chat-chip-recursive', label: '預覽卡內遞迴 chip', sys: 'chat', tier: 'leaf', status: 'active' },
-    { id: 'chat-pin-btn', label: '📌 重新引用按鈕', sys: 'chat', tier: 'leaf', status: 'done', summary: 'PR #2089 merged' },
-    { id: 'chat-history-api', label: '/api/chat/history', sys: 'chat', tier: 'topic', status: 'done' },
-    { id: 'chat-schedule', label: '排程訊息 (long-press)', sys: 'chat', tier: 'topic', status: 'done' },
-    { id: 'chat-embed', label: 'embed=1 mode', sys: 'chat', tier: 'leaf', status: 'done' },
-    { id: 'chat-share', label: 'share-chat.html 公開', sys: 'chat', tier: 'leaf', status: 'active' },
+  // 聊天 (8)
+  { id: 'chat-hub', label: '聊天 / Chat', sys: 'chat', tier: 'domain', status: 'active' },
+  { id: 'chat-chip', label: '智慧引用晶片', sys: 'chat', tier: 'topic', status: 'active', summary: '@chip_popover_X 點擊預覽' },
+  { id: 'chat-chip-recursive', label: '預覽卡內遞迴 chip', sys: 'chat', tier: 'leaf', status: 'active' },
+  { id: 'chat-pin-btn', label: '📌 重新引用按鈕', sys: 'chat', tier: 'leaf', status: 'done', summary: 'PR #2089 merged' },
+  { id: 'chat-history-api', label: '/api/chat/history', sys: 'chat', tier: 'topic', status: 'done' },
+  { id: 'chat-schedule', label: '排程訊息 (long-press)', sys: 'chat', tier: 'topic', status: 'done' },
+  { id: 'chat-embed', label: 'embed=1 mode', sys: 'chat', tier: 'leaf', status: 'done' },
+  { id: 'chat-share', label: 'share-chat.html 公開', sys: 'chat', tier: 'leaf', status: 'active' },
 
-    // 支付 (5)
-    { id: 'pay-hub', label: '支付 / 訂閱', sys: 'payment', tier: 'domain', status: 'active' },
-    { id: 'pay-topup-b', label: 'Top-up Path B (sandbox)', sys: 'payment', tier: 'topic', status: 'active', summary: 'Android emu 已有 Play 帳號' },
-    { id: 'pay-iap-android', label: 'Android IAP', sys: 'payment', tier: 'topic', status: 'active' },
-    { id: 'pay-iap-ios', label: 'iOS StoreKit', sys: 'payment', tier: 'topic', status: 'blocked', summary: '等 Apple Connect 設定' },
-    { id: 'pay-wallet', label: 'wallet.html 餘額', sys: 'payment', tier: 'leaf', status: 'done' },
+  // 支付 (5)
+  { id: 'pay-hub', label: '支付 / 訂閱', sys: 'payment', tier: 'domain', status: 'active' },
+  { id: 'pay-topup-b', label: 'Top-up Path B (sandbox)', sys: 'payment', tier: 'topic', status: 'active', summary: 'Android emu 已有 Play 帳號' },
+  { id: 'pay-iap-android', label: 'Android IAP', sys: 'payment', tier: 'topic', status: 'active' },
+  { id: 'pay-iap-ios', label: 'iOS StoreKit', sys: 'payment', tier: 'topic', status: 'blocked', summary: '等 Apple Connect 設定' },
+  { id: 'pay-wallet', label: 'wallet.html 餘額', sys: 'payment', tier: 'leaf', status: 'done' },
 
-    // 廣播 (6)
-    { id: 'bcast-hub', label: '廣播 / Publisher', sys: 'broadcast', tier: 'domain', status: 'active' },
-    { id: 'bcast-x', label: 'X (Twitter)', sys: 'broadcast', tier: 'topic', status: 'active' },
-    { id: 'bcast-mastodon', label: 'Mastodon', sys: 'broadcast', tier: 'leaf', status: 'done', summary: '已棄用 2026-04-15' },
-    { id: 'bcast-wp', label: 'WordPress.com', sys: 'broadcast', tier: 'leaf', status: 'done', summary: '已退役 2026-04-20' },
-    { id: 'bcast-cron', label: 'Daily viral cron', sys: 'broadcast', tier: 'topic', status: 'active' },
-    { id: 'bcast-design', label: 'Claude Design 視覺', sys: 'broadcast', tier: 'leaf', status: 'active' },
+  // 廣播 (6)
+  { id: 'bcast-hub', label: '廣播 / Publisher', sys: 'broadcast', tier: 'domain', status: 'active' },
+  { id: 'bcast-x', label: 'X (Twitter)', sys: 'broadcast', tier: 'topic', status: 'active' },
+  { id: 'bcast-mastodon', label: 'Mastodon', sys: 'broadcast', tier: 'leaf', status: 'done', summary: '已棄用 2026-04-15' },
+  { id: 'bcast-wp', label: 'WordPress.com', sys: 'broadcast', tier: 'leaf', status: 'done', summary: '已退役 2026-04-20' },
+  { id: 'bcast-cron', label: 'Daily viral cron', sys: 'broadcast', tier: 'topic', status: 'active' },
+  { id: 'bcast-design', label: 'Claude Design 視覺', sys: 'broadcast', tier: 'leaf', status: 'active' },
 
-    // 橋接 (5)
-    { id: 'br-hub', label: '橋接 / Bridge', sys: 'bridge', tier: 'domain', status: 'active' },
-    { id: 'br-auth', label: 'bridge-auth (osascript)', sys: 'bridge', tier: 'topic', status: 'done' },
-    { id: 'br-eye', label: 'eye 螢幕全覽', sys: 'bridge', tier: 'leaf', status: 'done' },
-    { id: 'br-hermes-docker', label: 'hermes-bridge service', sys: 'bridge', tier: 'topic', status: 'done' },
-    { id: 'br-unit-u01', label: 'U01 = app E2E', sys: 'bridge', tier: 'leaf', status: 'active' },
-  ];
+  // 橋接 (5)
+  { id: 'br-hub', label: '橋接 / Bridge', sys: 'bridge', tier: 'domain', status: 'active' },
+  { id: 'br-auth', label: 'bridge-auth (osascript)', sys: 'bridge', tier: 'topic', status: 'done' },
+  { id: 'br-eye', label: 'eye 螢幕全覽', sys: 'bridge', tier: 'leaf', status: 'done' },
+  { id: 'br-hermes-docker', label: 'hermes-bridge service', sys: 'bridge', tier: 'topic', status: 'done', summary: 'card_7102c915 closed' },
+  { id: 'br-unit-u01', label: 'U01 = app E2E', sys: 'bridge', tier: 'leaf', status: 'active' },
+]
 
   const MOCK_EDGES = [
-    // 邀請 tree
-    ['inv-hub','inv-code'], ['inv-hub','inv-redeem'], ['inv-hub','inv-tier'],
-    ['inv-hub','inv-leader'], ['inv-redeem','inv-funnel'], ['inv-code','inv-qr'],
-    // 裝置 tree
-    ['dev-hub','dev-rotate'], ['dev-hub','dev-health'], ['dev-hub','dev-vars'],
-    ['dev-hub','dev-switch'], ['dev-hub','dev-logs'],
-    // i18n tree
-    ['i18n-hub','i18n-shared'], ['i18n-hub','i18n-chip'], ['i18n-hub','i18n-kb'],
-    ['i18n-shared','i18n-strict-ci'], ['i18n-shared','i18n-key-audit'],
-    ['i18n-shared','i18n-deadtop'], ['i18n-hub','i18n-translator'],
-    // 看板 tree
-    ['kb-hub','kb-card'], ['kb-hub','kb-screenshot-gate'], ['kb-screenshot-gate','kb-r2-ttl'],
-    ['kb-hub','kb-deeplink'], ['kb-hub','kb-notes-tab'], ['kb-hub','kb-mention'],
-    // 聊天 tree
-    ['chat-hub','chat-chip'], ['chat-chip','chat-chip-recursive'], ['chat-chip','chat-pin-btn'],
-    ['chat-hub','chat-history-api'], ['chat-hub','chat-schedule'], ['chat-hub','chat-embed'],
-    ['chat-hub','chat-share'],
-    // 支付 tree
-    ['pay-hub','pay-topup-b'], ['pay-hub','pay-iap-android'], ['pay-hub','pay-iap-ios'],
-    ['pay-hub','pay-wallet'], ['pay-iap-android','pay-topup-b'],
-    // 廣播 tree
-    ['bcast-hub','bcast-x'], ['bcast-hub','bcast-mastodon'], ['bcast-hub','bcast-wp'],
-    ['bcast-hub','bcast-cron'], ['bcast-cron','bcast-design'],
-    // 橋接 tree
-    ['br-hub','br-auth'], ['br-auth','br-eye'], ['br-hub','br-hermes-docker'], ['br-hub','br-unit-u01'],
+  // 邀請 tree
+  ['inv-hub','inv-code'],['inv-hub','inv-redeem'],['inv-hub','inv-tier'],
+  ['inv-hub','inv-leader'],['inv-redeem','inv-funnel'],['inv-code','inv-qr'],
+  // 裝置 tree
+  ['dev-hub','dev-rotate'],['dev-hub','dev-health'],['dev-hub','dev-vars'],
+  ['dev-hub','dev-switch'],['dev-hub','dev-logs'],
+  // i18n tree
+  ['i18n-hub','i18n-shared'],['i18n-hub','i18n-chip'],['i18n-hub','i18n-kb'],
+  ['i18n-shared','i18n-strict-ci'],['i18n-shared','i18n-key-audit'],
+  ['i18n-shared','i18n-deadtop'],['i18n-hub','i18n-translator'],
+  // 看板 tree
+  ['kb-hub','kb-card'],['kb-hub','kb-screenshot-gate'],['kb-screenshot-gate','kb-r2-ttl'],
+  ['kb-hub','kb-deeplink'],['kb-hub','kb-notes-tab'],['kb-hub','kb-mention'],
+  // 聊天 tree
+  ['chat-hub','chat-chip'],['chat-chip','chat-chip-recursive'],['chat-chip','chat-pin-btn'],
+  ['chat-hub','chat-history-api'],['chat-hub','chat-schedule'],['chat-hub','chat-embed'],
+  ['chat-hub','chat-share'],
+  // 支付 tree
+  ['pay-hub','pay-topup-b'],['pay-hub','pay-iap-android'],['pay-hub','pay-iap-ios'],
+  ['pay-hub','pay-wallet'],['pay-iap-android','pay-topup-b'],
+  // 廣播 tree
+  ['bcast-hub','bcast-x'],['bcast-hub','bcast-mastodon'],['bcast-hub','bcast-wp'],
+  ['bcast-hub','bcast-cron'],['bcast-cron','bcast-design'],
+  // 橋接 tree
+  ['br-hub','br-auth'],['br-auth','br-eye'],['br-hub','br-hermes-docker'],['br-hub','br-unit-u01'],
 
-    // ⛓ Cross-system dependencies (yellow dashed, labeled)
-    ['i18n-chip','chat-chip','depends'],
-    ['i18n-kb','kb-hub','depends'],
-    ['i18n-translator','br-auth','via'],
-    ['inv-redeem','dev-vars','via'],
-    ['inv-tier','chat-chip','unlocks'],
-    ['kb-screenshot-gate','bcast-cron','required'],
-    ['chat-schedule','kb-mention','reuses'],
-    ['br-hermes-docker','i18n-translator','runs'],
-    ['pay-topup-b','dev-health','telemetry'],
-    ['bcast-x','dev-vars','reads-key'],
-    ['bcast-design','br-auth','uses'],
-    ['kb-card','chat-history-api','share-DB'],
-    ['inv-funnel','bcast-cron','feeds'],
-    ['dev-switch','i18n-chip','blocked-by'],
-    ['chat-pin-btn','i18n-chip','i18n-key'],
-    ['kb-deeplink','chat-chip','same-anchor'],
-    ['br-unit-u01','kb-screenshot-gate','attaches'],
-    ['chat-share','bcast-x','outbound'],
-    ['inv-qr','bcast-design','asset'],
-  ];
+  // ⛓ Cross-system dependencies (different style)
+  ['i18n-chip','chat-chip','depends'],         // chip 引用要等 i18n
+  ['i18n-kb','kb-hub','depends'],
+  ['i18n-translator','br-auth','via'],         // i18n 派工經 bridge-auth
+  ['inv-redeem','dev-vars','via'],
+  ['inv-tier','chat-chip','unlocks'],
+  ['kb-screenshot-gate','bcast-cron','required'],
+  ['chat-schedule','kb-mention','reuses'],
+  ['br-hermes-docker','i18n-translator','runs'],
+  ['pay-topup-b','dev-health','telemetry'],
+  ['bcast-x','dev-vars','reads-key'],
+  ['bcast-design','br-auth','uses'],
+  ['kb-card','chat-history-api','share-DB'],
+  ['inv-funnel','bcast-cron','feeds'],
+  ['dev-switch','i18n-chip','blocked-by'],
+  ['chat-pin-btn','i18n-chip','i18n-key'],
+  ['kb-deeplink','chat-chip','same-anchor'],
+  ['br-unit-u01','kb-screenshot-gate','attaches'],
+  ['chat-share','bcast-x','outbound'],
+  ['inv-qr','bcast-design','asset'],
+]
 
   const STYLE_ID = 'mission-mindmap-style';
   const STYLE_CSS = `
+    :root {
+      --bg: #0d1117; --bg-elev: #161b22;
+      --card-border: #2a2f3a; --text: #e6edf3;
+      --text-secondary: #8b949e;
+    }
     .mm-root {
       display: grid;
-      grid-template-columns: 168px 1fr 256px;
+      grid-template-columns: 220px 1fr 320px;
       height: 540px;
       background: var(--bg, #0d1117);
       border: 1px solid var(--card-border, #2a2f3a);
-      border-radius: var(--radius-sm, 8px);
-      overflow: hidden;
-      font-size: 13px;
-      color: var(--text, #e6edf3);
+      border-radius: 8px; overflow: hidden;
+      font-size: 13px; color: var(--text, #e6edf3);
     }
-    @media (max-width: 860px) {
-      .mm-root { grid-template-columns: 1fr; height: auto; }
-      .mm-root .mm-rail { display: none; }
-      .mm-root .mm-side { display: none; }
-      .mm-root .mm-canvas-wrap { height: 480px; }
-    }
-    .mm-root .mm-rail {
+    .sys-rail {
       background: var(--bg-elev, #161b22);
       border-right: 1px solid var(--card-border, #2a2f3a);
-      padding: 12px 10px;
-      overflow-y: auto;
+      padding: 14px 12px; overflow-y: auto;
+      display: flex; flex-direction: column; gap: 10px;
     }
-    .mm-root .mm-rail h3 {
-      font-size: 10px;
-      text-transform: uppercase;
-      letter-spacing: 0.6px;
-      color: var(--text-secondary, #8b949e);
-      margin: 0 0 8px 4px;
-      font-weight: 600;
-    }
-    .mm-root .mm-sys-row {
-      display: flex; align-items: center; gap: 8px;
-      padding: 6px 8px;
-      border-radius: 5px;
-      font-size: 12px;
-      cursor: pointer;
-      user-select: none;
-      margin-bottom: 1px;
-    }
-    .mm-root .mm-sys-row:hover { background: rgba(255,255,255,0.05); }
-    .mm-root .mm-sys-row.active { background: rgba(124,131,255,0.16); }
-    .mm-root .mm-sys-row .mm-swatch {
-      width: 11px; height: 11px; border-radius: 3px; flex: none;
-      border: 1px solid rgba(255,255,255,0.2);
-    }
-    .mm-root .mm-sys-row .mm-name { flex: 1; }
-    .mm-root .mm-sys-row .mm-count {
-      font-size: 10px;
-      color: var(--text-secondary, #8b949e);
-      background: rgba(255,255,255,0.06);
-      padding: 1px 6px;
-      border-radius: 9px;
-    }
-    .mm-root .mm-legend {
-      margin-top: 12px;
-      padding-top: 10px;
-      border-top: 1px dashed var(--card-border, #2a2f3a);
-    }
-    .mm-root .mm-legend-row {
+    .sys-row {
       display: flex; align-items: center; gap: 7px;
-      font-size: 10px;
-      color: var(--text-secondary, #8b949e);
-      padding: 2px 4px;
+      padding: 5px 8px; border-radius: 5px; cursor: pointer;
+      font-size: 12px; transition: background 0.15s;
     }
-    .mm-root .mm-legend-row .mm-ring {
-      width: 11px; height: 11px; border-radius: 50%;
-      border: 2px solid #fde047; flex: none; background: transparent;
+    .sys-row:hover { background: rgba(255,255,255,0.06); }
+    .sys-row.active { background: rgba(255,255,255,0.10); }
+    .sys-row .swatch { width: 8px; height: 8px; border-radius: 2px; flex: none; }
+    .sys-row .name { flex: 1; color: var(--text, #e6edf3); }
+    .sys-row .count {
+      font-size: 10px; background: rgba(255,255,255,0.08);
+      padding: 1px 6px; border-radius: 8px; color: var(--text-secondary, #8b949e);
     }
-    .mm-root .mm-legend-row .mm-ring.blocked { border-color: #ef4444; }
-    .mm-root .mm-legend-row .mm-ring.done { border-color: #22c55e; border-style: dashed; }
-    .mm-root .mm-summary {
-      margin-top: 10px;
-      padding-top: 10px;
-      border-top: 1px dashed var(--card-border, #2a2f3a);
-      font-size: 10px;
-      color: var(--text-secondary, #8b949e);
-      line-height: 1.6;
+    .legend-block {
+      border-top: 1px solid var(--card-border, #2a2f3a);
+      padding-top: 10px; margin-top: auto;
     }
-    .mm-root .mm-summary .mm-num { color: var(--text, #e6edf3); font-weight: 600; }
-    .mm-root .mm-canvas-wrap {
-      position: relative;
-      background: var(--bg, #0d1117);
-      overflow: hidden;
+    .legend-block h4 {
+      font-size: 10px; text-transform: uppercase; letter-spacing: 0.5px;
+      color: var(--text-secondary, #8b949e); margin: 0 0 6px 0;
     }
-    .mm-root .mm-cy {
-      width: 100%;
-      height: 100%;
-      background:
-        radial-gradient(circle at 30% 30%, rgba(168,85,247,0.05), transparent 50%),
-        radial-gradient(circle at 70% 70%, rgba(34,197,94,0.04), transparent 50%),
-        var(--bg, #0d1117);
+    .legend-row {
+      display: flex; align-items: center; gap: 6px;
+      font-size: 11px; color: var(--text-secondary, #8b949e); margin-bottom: 3px;
     }
-    .mm-root .mm-toolbar {
-      position: absolute;
-      top: 8px; left: 8px;
-      z-index: 10;
-      display: flex; gap: 4px;
-      background: rgba(22,27,34,0.85);
-      backdrop-filter: blur(8px);
+    .status-ring {
+      width: 8px; height: 8px; border-radius: 50%; flex: none;
+    }
+    .status-ring.active { background: #fde047; }
+    .status-ring.blocked { background: #ef4444; }
+    .status-ring.done { background: #22c55e; }
+    .summary-block {
+      border-top: 1px solid var(--card-border, #2a2f3a);
+      padding-top: 8px; font-size: 11px;
+      color: var(--text-secondary, #8b949e); line-height: 1.6;
+    }
+    .summary-block .num { color: var(--text, #e6edf3); font-weight: 600; }
+    .mind-canvas-wrap {
+      position: relative; background: var(--bg, #0d1117); overflow: hidden;
+    }
+    .mm-toolbar {
+      position: absolute; top: 12px; left: 12px; z-index: 10;
+      display: flex; gap: 6px;
+      background: rgba(22,27,34,0.85); backdrop-filter: blur(8px);
       border: 1px solid var(--card-border, #2a2f3a);
-      border-radius: 6px;
-      padding: 4px;
+      border-radius: 8px; padding: 6px;
     }
-    .mm-root .mm-toolbar button {
-      background: transparent; color: var(--text, #e6edf3);
-      border: 1px solid transparent;
-      padding: 4px 8px; border-radius: 4px;
-      cursor: pointer; font-size: 11px;
+    .mm-toolbar button {
+      background: transparent; border: none; color: var(--text, #e6edf3);
+      padding: 5px 10px; border-radius: 5px; cursor: pointer; font-size: 12px;
     }
-    .mm-root .mm-toolbar button:hover { background: rgba(255,255,255,0.08); }
-    .mm-root .mm-tier {
-      position: absolute;
-      top: 8px; right: 8px;
-      z-index: 10;
-      background: rgba(22,27,34,0.85);
-      border: 1px solid var(--card-border, #2a2f3a);
-      border-radius: 5px;
-      padding: 4px 8px;
-      font-size: 10px;
-      color: var(--text-secondary, #8b949e);
+    .mm-toolbar button:hover { background: rgba(255,255,255,0.08); }
+    .mm-tier {
+      position: absolute; top: 14px; left: 50%; transform: translateX(-50%);
+      font-size: 10px; color: var(--text-secondary, #8b949e);
+      z-index: 5; pointer-events: none;
     }
-    .mm-root .mm-tier strong { color: var(--primary, #7c83ff); }
-    .mm-root .mm-side {
+    .mm-tier strong { color: var(--text, #e6edf3); }
+    .mm-cy { position: absolute; inset: 0; }
+    .mind-side {
       background: var(--bg-elev, #161b22);
       border-left: 1px solid var(--card-border, #2a2f3a);
-      overflow-y: auto;
+      display: flex; flex-direction: column; overflow-y: auto;
     }
-    .mm-root .mm-empty {
-      padding: 22px 14px;
-      text-align: center;
-      color: var(--text-secondary, #8b949e);
-      font-size: 12px;
-      line-height: 1.6;
+    .mm-empty {
+      display: flex; flex-direction: column; align-items: center;
+      justify-content: center; height: 100%; padding: 24px; text-align: center;
+      color: var(--text-secondary, #8b949e); font-size: 13px;
     }
-    .mm-root .mm-empty .mm-emoji { font-size: 26px; margin-bottom: 6px; }
-    .mm-root .mm-empty .mm-hint { margin-top: 8px; font-size: 10px; opacity: 0.7; }
-    .mm-root .mm-detail { padding: 14px; display: none; flex-direction: column; gap: 12px; }
-    .mm-root .mm-detail.visible { display: flex; }
-    .mm-root .mm-detail h4 {
-      font-size: 14px; margin: 0;
-      color: var(--text, #e6edf3);
+    .mm-empty .mm-emoji { font-size: 28px; margin-bottom: 8px; }
+    .mm-empty .mm-hint {
+      margin-top: 8px; font-size: 10px; opacity: 0.7; line-height: 1.6;
     }
-    .mm-root .mm-pills { display: flex; gap: 5px; flex-wrap: wrap; }
-    .mm-root .mm-pill {
+    .mm-detail {
+      padding: 14px; display: none; flex-direction: column; gap: 10px; overflow-y: auto;
+    }
+    .mm-detail.visible { display: flex; }
+    .mm-detail h4 { font-size: 14px; margin: 0; color: var(--text, #e6edf3); }
+    .mm-pills { display: flex; gap: 5px; flex-wrap: wrap; }
+    .mm-pill {
       font-size: 10px; padding: 2px 7px; border-radius: 10px;
       font-weight: 600; letter-spacing: 0.4px;
     }
-    .mm-root .mm-pill-status.active { background: rgba(253,224,71,0.15); color: #fde047; }
-    .mm-root .mm-pill-status.blocked { background: rgba(239,68,68,0.15); color: #ef4444; }
-    .mm-root .mm-pill-status.done { background: rgba(34,197,94,0.15); color: #22c55e; }
-    .mm-root .mm-detail .mm-summary-text {
-      color: var(--text-secondary, #8b949e);
-      font-size: 12px; line-height: 1.55;
+    .mm-pill-status.active { background: rgba(253,224,71,0.15); color: #fde047; }
+    .mm-pill-status.blocked { background: rgba(239,68,68,0.15); color: #ef4444; }
+    .mm-pill-status.done { background: rgba(34,197,94,0.15); color: #22c55e; }
+    .mm-summary-text {
+      color: var(--text-secondary, #8b949e); font-size: 12px; line-height: 1.55;
     }
-    .mm-root .mm-section h5 {
+    .mm-section h5 {
       font-size: 10px; text-transform: uppercase; letter-spacing: 0.6px;
-      color: var(--text-secondary, #8b949e);
-      margin: 0 0 6px 0; font-weight: 600;
+      color: var(--text-secondary, #8b949e); margin: 0 0 6px 0; font-weight: 600;
     }
-    .mm-root .mm-related { display: flex; flex-direction: column; gap: 3px; }
-    .mm-root .mm-related-row {
-      font-size: 11px;
-      padding: 5px 7px;
-      border-radius: 4px;
-      background: rgba(255,255,255,0.03);
-      cursor: pointer;
+    .mm-related { display: flex; flex-direction: column; gap: 3px; }
+    .mm-related-row {
+      font-size: 11px; padding: 5px 7px; border-radius: 4px;
+      background: rgba(255,255,255,0.03); cursor: pointer;
       display: flex; align-items: center; gap: 6px;
     }
-    .mm-root .mm-related-row:hover { background: rgba(255,255,255,0.07); }
-    .mm-root .mm-related-row .mm-swatch { width: 7px; height: 7px; border-radius: 2px; flex: none; }
+    .mm-related-row:hover { background: rgba(255,255,255,0.07); }
+    .mm-related-row .swatch { width: 7px; height: 7px; border-radius: 2px; flex: none; }
   `;
 
   function injectStyle() {
@@ -352,32 +302,32 @@
     const counts = countBySys(nodes);
     const railRows = Object.entries(SYS).map(([key, s]) => {
       const c = counts[key] || 0;
-      return `<div class="mm-sys-row" data-sys="${key}">
-        <span class="mm-swatch" style="background:${s.color}"></span>
-        <span class="mm-name">${s.label}</span>
-        <span class="mm-count">${c}</span>
+      return `<div class="sys-row" data-sys="${key}">
+        <span class="swatch" style="background:${s.color}"></span>
+        <span class="name">${s.label}</span>
+        <span class="count">${c}</span>
       </div>`;
     }).join('');
 
     const crossCount = edges.filter(e => e.length === 3).length;
 
     rootEl.innerHTML = `
-      <aside class="mm-rail">
+      <aside class="sys-rail">
         <h3>子系統</h3>
         ${railRows}
-        <div class="mm-legend">
+        <div class="legend-block">
           <h3>節點狀態</h3>
-          <div class="mm-legend-row"><span class="mm-ring"></span>進行中</div>
-          <div class="mm-legend-row"><span class="mm-ring blocked"></span>阻塞</div>
-          <div class="mm-legend-row"><span class="mm-ring done"></span>完成</div>
+          <div class="legend-row"><span class="status-ring"></span>進行中</div>
+          <div class="legend-row"><span class="mm-ring blocked"></span>阻塞</div>
+          <div class="legend-row"><span class="mm-ring done"></span>完成</div>
         </div>
-        <div class="mm-summary">
-          <span class="mm-num">${nodes.length}</span> 節點 ·
-          <span class="mm-num">${edges.length}</span> 連線<br>
-          <span class="mm-num">${crossCount}</span> 跨系統依賴
+        <div class="summary-block">
+          <span class="num">${nodes.length}</span> 節點 ·
+          <span class="num">${edges.length}</span> 連線<br>
+          <span class="num">${crossCount}</span> 跨系統依賴
         </div>
       </aside>
-      <div class="mm-canvas-wrap">
+      <div class="mind-canvas-wrap">
         <div class="mm-toolbar">
           <button data-act="fit">🎯 Fit</button>
           <button data-act="reset">🔄 重整</button>
@@ -385,7 +335,7 @@
         <div class="mm-tier">L1 · <strong>Topics</strong></div>
         <div class="mm-cy"></div>
       </div>
-      <aside class="mm-side">
+      <aside class="mind-side">
         <div class="mm-empty">
           <div class="mm-emoji">🧠</div>
           點任一節點查看相關依賴。
@@ -524,7 +474,7 @@
         row.className = 'mm-related-row';
         row.dataset.target = nb.id();
         row.innerHTML = `
-          <span class="mm-swatch" style="background:${SYS[nd.sys].color}"></span>
+          <span class="swatch" style="background:${SYS[nd.sys].color}"></span>
           <span>${nd.label}</span>
           <span style="color:var(--text-secondary,#8b949e);font-size:10px;margin-left:auto;">${SYS[nd.sys].label}</span>
         `;
@@ -573,11 +523,11 @@
       showSide(target);
     });
 
-    rootEl.querySelectorAll('.mm-sys-row').forEach(row => {
+    rootEl.querySelectorAll('.sys-row').forEach(row => {
       row.addEventListener('click', () => {
         const sys = row.dataset.sys;
         const wasActive = row.classList.contains('active');
-        rootEl.querySelectorAll('.mm-sys-row').forEach(r => r.classList.remove('active'));
+        rootEl.querySelectorAll('.sys-row').forEach(r => r.classList.remove('active'));
         cy.elements().removeClass('faded');
         if (wasActive) return;
         row.classList.add('active');
@@ -596,7 +546,7 @@
         if (act === 'fit') cy.fit(undefined, 30);
         if (act === 'reset') {
           cy.elements().removeClass('faded').removeClass('highlighted');
-          rootEl.querySelectorAll('.mm-sys-row').forEach(r => r.classList.remove('active'));
+          rootEl.querySelectorAll('.sys-row').forEach(r => r.classList.remove('active'));
           emptyEl.style.display = 'block';
           detailEl.classList.remove('visible');
           cy.fit(undefined, 30);

--- a/backend/public/portal/shared/mission-mindmap.js
+++ b/backend/public/portal/shared/mission-mindmap.js
@@ -317,9 +317,9 @@
         ${railRows}
         <div class="legend-block">
           <h3>節點狀態</h3>
-          <div class="legend-row"><span class="status-ring"></span>進行中</div>
-          <div class="legend-row"><span class="mm-ring blocked"></span>阻塞</div>
-          <div class="legend-row"><span class="mm-ring done"></span>完成</div>
+          <div class="legend-row"><span class="status-ring active"></span>進行中</div>
+          <div class="legend-row"><span class="status-ring blocked"></span>阻塞</div>
+          <div class="legend-row"><span class="status-ring done"></span>完成</div>
         </div>
         <div class="summary-block">
           <span class="num">${nodes.length}</span> 節點 ·


### PR DESCRIPTION
## feat(mindmap): align PR-B implementation with v3 dense mockup spec

### Changes
- Replace MOCK_NODES/MOCK_EDGES with v3 dense data (52 nodes, 76 edges, 8 subsystems)
- Update STYLE_CSS grid: `220px 1fr 320px` matching v3 dense layout
- Rename CSS classes to match v3 dense:
  - `.mm-rail` → `.sys-rail`
  - `.mm-canvas-wrap` → `.mind-canvas-wrap`
  - `.mm-side` → `.mind-side`
  - `.mm-sys-row` → `.sys-row`
  - `.mm-swatch` → `.swatch`
  - `.mm-name` → `.name`
  - `.mm-count` → `.count`
  - `.mm-legend` → `.legend-block`
  - `.mm-ring` → `.status-ring`
  - `.mm-summary` → `.summary-block`
- Update renderShell HTML template with v3 dense structure (legend-block, summary-block)
- Match v3 dense toolbar, empty state, detail panel structure
- Maintain hook points for future kanban/chat coordinate injection

### Screenshots

**v3 dense mockup (web):**
![v3 dense mockup](screenshot from browser)

### Verification
- `node --check backend/public/portal/shared/mission-mindmap.js` ✅
- i18n-check: ✅ (no i18n changes)
- i18n-check exit 0