### PR TITLE
fix(arena): form_fill country select defaults to expectedValue

### DIFF
--- a/backend/arena-test-pages.js
+++ b/backend/arena-test-pages.js
@@ -178,7 +178,15 @@ function renderFormFill(session, config, sessionToken, apiBase) {
             <div class="hint">expected: ${escHtml(expectedShown)}</div></div>`;
         }
         if (f.type === 'select' && Array.isArray(f.options)) {
-            const opts = f.options.map(o =>
+            // Defensive: if the generator's expectedValue isn't in the options
+            // list, prepend it so the rendered form still defaults to the right
+            // answer. card_f0d0a2eb: a buggy generator can otherwise leave the
+            // select on options[0] and a bot reading the DOM (not the hint)
+            // submits the wrong value.
+            const optsList = f.options.includes(expected)
+                ? f.options
+                : (expected != null ? [expected, ...f.options] : f.options);
+            const opts = optsList.map(o =>
                 `<option value="${escAttr(o)}"${o === expected ? ' selected' : ''}>${escHtml(o)}</option>`
             ).join('');
             return `<div class="field"><label>${label}</label>

--- a/backend/interview-arena.js
+++ b/backend/interview-arena.js
@@ -206,12 +206,16 @@ const FORM_MESSAGES = ['Hello World','Please process my order','Testing the form
 
 function generateFormFillChallenge() {
     const nameIdx = Math.floor(Math.random() * FORM_NAMES.length);
-    const countryIdx = Math.floor(Math.random() * FORM_COUNTRIES.length);
+    // Pick country FROM the shuffled subset (not from the full pool) so
+    // expectedValue is guaranteed to exist in options. card_f0d0a2eb:
+    // previously expectedValue could be a country that wasn't in the
+    // 5-item options subset, which broke the <select selected> default.
+    const countryOptions = shuffle([...FORM_COUNTRIES]).slice(0, 5);
+    const country = countryOptions[Math.floor(Math.random() * countryOptions.length)];
     const fields = [
         { name: 'fullName', type: 'text', label: 'Full Name', expectedValue: FORM_NAMES[nameIdx] },
         { name: 'email', type: 'email', label: 'Email', expectedValue: FORM_EMAILS[nameIdx % FORM_EMAILS.length] },
-        { name: 'country', type: 'select', label: 'Country', expectedValue: FORM_COUNTRIES[countryIdx],
-          options: shuffle([...FORM_COUNTRIES]).slice(0, 5) },
+        { name: 'country', type: 'select', label: 'Country', expectedValue: country, options: countryOptions },
         { name: 'agreeTerms', type: 'checkbox', label: 'Agree to Terms', expectedValue: true },
     ];
     const extras = [


### PR DESCRIPTION
## Summary
- Fixes [card_f0d0a2eb](https://eclawbot.com): in \`form_fill\`, the Country dropdown defaulted to options[0] instead of the expected answer because the generator picked \`expectedValue\` from the full \`FORM_COUNTRIES\` pool while the options were a 5-item shuffled subset — so the expected country was often missing from the dropdown entirely.
- Two-layer fix: data fix in the generator (guaranteed expected ∈ options) + defensive fallback in the renderer (prepend missing-expected as a synthetic option) so future generators with the same bug class don't silently break the dropdown default.

## Test plan
- [x] Local smoke: renderer prepends + selects expected when not in options
- [x] ESLint clean
- [x] Jest backend suite passes
- [ ] CI green
- [ ] Post-merge: spawn fresh form_fill session, confirm Country select now reads as expected on first paint

🤖 Generated with [Claude Code](https://claude.com/claude-code)