### PR TITLE
infra(rebind): track entity rebindCount + bot_listings.bound_rebind_count (P0 Phase 1)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1284,6 +1284,8 @@ setInterval(async () => {
                 device.entities[binding.entity_id].name = prev.name || null;
                 device.entities[binding.entity_id].xp = prev.xp || 0;
                 device.entities[binding.entity_id].level = prev.level || 1;
+                device.entities[binding.entity_id].rebindCount = (prev.rebindCount || 0) + 1;
+                device.entities[binding.entity_id].lastRebindAt = Date.now();
             }
 
             delete officialBindingsCache[getBindingCacheKey(binding.device_id, binding.entity_id)];
@@ -3875,7 +3877,9 @@ function createDefaultEntity(entityId) {
         channelAccountId: null,
         agentCard: null, // derived from identity.public for backward compat
         identity: null, // Bot Identity Layer: unified role/instructions/boundaries + public profile
-        encryptionStatus: null // "e2ee" | "transport" | null (Issue #212)
+        encryptionStatus: null, // "e2ee" | "transport" | null (Issue #212)
+        rebindCount: 0, // Bumped each time the slot is rebound to a new bot; rental listings snapshot this to detect identity drift
+        lastRebindAt: null
     };
 }
 
@@ -6653,6 +6657,8 @@ app.delete('/api/entity', async (req, res) => {
     device.entities[eId].name = removedEntity?.name || null;
     device.entities[eId].xp = removedEntity?.xp || 0;
     device.entities[eId].level = removedEntity?.level || 1;
+    device.entities[eId].rebindCount = (removedEntity?.rebindCount || 0) + 1;
+    device.entities[eId].lastRebindAt = Date.now();
 
     console.log(`[Remove] Device ${deviceId} Entity ${eId} unbound`);
     serverLog('info', 'unbind', `Entity ${eId} unbound`, { deviceId, entityId: eId });
@@ -6771,6 +6777,8 @@ app.delete('/api/device/entity', async (req, res) => {
     device.entities[eId].name = removedEntity2?.name || null;
     device.entities[eId].xp = removedEntity2?.xp || 0;
     device.entities[eId].level = removedEntity2?.level || 1;
+    device.entities[eId].rebindCount = (removedEntity2?.rebindCount || 0) + 1;
+    device.entities[eId].lastRebindAt = Date.now();
 
     console.log(`[Device Remove] Device ${deviceId} Entity ${eId} unbound by device owner`);
 
@@ -11670,6 +11678,8 @@ async function autoUnbindEntity(deviceId, eId, device) {
     device.entities[eId].name = prevEntity?.name || null;
     device.entities[eId].xp = prevEntity?.xp || 0;
     device.entities[eId].level = prevEntity?.level || 1;
+    device.entities[eId].rebindCount = (prevEntity?.rebindCount || 0) + 1;
+    device.entities[eId].lastRebindAt = Date.now();
 }
 
 /**
@@ -11909,6 +11919,8 @@ app.post('/api/official-borrow/bind-free', async (req, res) => {
         ...createDefaultEntity(eId),
         xp: existingEntityFree?.xp || 0,
         level: existingEntityFree?.level || 1,
+        rebindCount: (existingEntityFree?.rebindCount || 0) + 1,
+        lastRebindAt: Date.now(),
         botSecret: botSecret,
         publicCode: freePublicCode,
         isBound: true,
@@ -12071,6 +12083,8 @@ app.post('/api/official-borrow/bind-personal', async (req, res) => {
         ...createDefaultEntity(eId),
         xp: existingEntityPersonal?.xp || 0,
         level: existingEntityPersonal?.level || 1,
+        rebindCount: (existingEntityPersonal?.rebindCount || 0) + 1,
+        lastRebindAt: Date.now(),
         botSecret: botSecret,
         isBound: true,
         name: existingEntityPersonal?.name || '月租版',
@@ -12258,6 +12272,8 @@ app.post('/api/official-borrow/unbind', async (req, res) => {
     device.entities[eId].name = prevBorrow?.name || null;
     device.entities[eId].xp = prevBorrow?.xp || 0;
     device.entities[eId].level = prevBorrow?.level || 1;
+    device.entities[eId].rebindCount = (prevBorrow?.rebindCount || 0) + 1;
+    device.entities[eId].lastRebindAt = Date.now();
     await saveData();
 
     console.log(`[Borrow] Official binding removed: device ${deviceId} entity ${eId}`);
@@ -14416,6 +14432,8 @@ app.post('/api/admin/transfer-device', async (req, res) => {
             }
 
             sourceDevice.entities[eId] = createDefaultEntity(eId);
+            sourceDevice.entities[eId].rebindCount = (srcEntity.rebindCount || 0) + 1;
+            sourceDevice.entities[eId].lastRebindAt = Date.now();
             transferred.push({ entityId: eId, name: srcEntity.name, character: srcEntity.character });
         }
 
@@ -17899,3 +17917,4 @@ module.exports._deletedPublicCodes = deletedPublicCodes;
 module.exports._classifyPublisher = classifyPublisher;
 module.exports._MONITORING_THRESHOLDS = MONITORING_THRESHOLDS;
 module.exports._requireAdmin = requireAdmin;
+module.exports._createDefaultEntity = createDefaultEntity;

--- a/backend/rental.js
+++ b/backend/rental.js
@@ -168,6 +168,7 @@ async function createListing({
     minRentalMinutes = MIN_RENTAL_MINUTES,
     maxRentalMinutes = MAX_RENTAL_MINUTES,
     avatarUrl = null,
+    boundRebindCount = 0,
 }) {
     assertString('owner_user_id', ownerUserId, { max: 64 });
     assertString('owner_device_id', ownerDeviceId, { max: 64 });
@@ -204,11 +205,13 @@ async function createListing({
     const res = await pool.query(
         `INSERT INTO bot_listings
             (owner_user_id, owner_device_id, owner_entity_id, title, description,
-             rate_mli_per_ktoken, min_rental_minutes, max_rental_minutes, avatar_url, status)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'draft')
-         RETURNING id, status, created_at`,
+             rate_mli_per_ktoken, min_rental_minutes, max_rental_minutes, avatar_url, status,
+             bound_rebind_count)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'draft', $10)
+         RETURNING id, status, created_at, bound_rebind_count`,
         [ownerUserId, ownerDeviceId, ownerEntityId, title, description,
-         rateMliPerKtoken, minRentalMinutes, maxRentalMinutes, avatarUrl || null]
+         rateMliPerKtoken, minRentalMinutes, maxRentalMinutes, avatarUrl || null,
+         Number.isInteger(boundRebindCount) && boundRebindCount >= 0 ? boundRebindCount : 0]
     );
     return res.rows[0];
 }
@@ -1252,17 +1255,22 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
                 rateMliPerKtoken, minRentalMinutes, maxRentalMinutes } = req.body || {};
         // BUG-M1: capture entity avatar for marketplace display
         let avatarUrl = null;
+        // P0: snapshot rebindCount so we can detect identity drift after a rebind
+        let boundRebindCount = 0;
         if (_interviewDeps?.devices && ownerDeviceId) {
             const dev = _interviewDeps.devices[ownerDeviceId];
             const ent = dev?.entities?.[ownerEntityId];
             if (ent?.avatar && (ent.avatar.startsWith('http') || ent.avatar.length <= 4)) {
                 avatarUrl = ent.avatar;
             }
+            if (ent && Number.isInteger(ent.rebindCount)) {
+                boundRebindCount = ent.rebindCount;
+            }
         }
         const listing = await createListing({
             ownerUserId: req.user.userId,
             ownerDeviceId, ownerEntityId, title, description, rateMliPerKtoken,
-            minRentalMinutes, maxRentalMinutes, avatarUrl,
+            minRentalMinutes, maxRentalMinutes, avatarUrl, boundRebindCount,
         });
         audit('info', 'rental', `listing created ${listing.id} by ${req.user.userId}`, {
             userId: req.user.userId, action: 'listing_create', resource: listing.id,

--- a/backend/rental_schema.sql
+++ b/backend/rental_schema.sql
@@ -43,6 +43,11 @@ CREATE TABLE IF NOT EXISTS bot_listings (
     uptime_pct NUMERIC(5,2) DEFAULT 100,
     -- Lifecycle
     status VARCHAR(32) NOT NULL DEFAULT 'draft',
+    -- Identity-drift detection (P0: silent rebind cascade)
+    -- Snapshot of entities[owner_entity_id].rebindCount at listing creation.
+    -- If the live entity rebindCount drifts past this value, the listing now
+    -- points at a different bot than was advertised; query layer must hide it.
+    bound_rebind_count INTEGER NOT NULL DEFAULT 0,
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     CONSTRAINT fk_listing_owner FOREIGN KEY (owner_user_id)
@@ -222,3 +227,9 @@ ALTER TABLE rental_usage_events ADD CONSTRAINT fk_usage_contract FOREIGN KEY (co
 ALTER TABLE bot_reviews ADD CONSTRAINT fk_review_contract FOREIGN KEY (contract_id) REFERENCES rental_contracts(id) ON DELETE CASCADE;
 ALTER TABLE bot_reviews ADD CONSTRAINT fk_review_listing FOREIGN KEY (listing_id) REFERENCES bot_listings(id) ON DELETE CASCADE;
 ALTER TABLE disputes ADD CONSTRAINT fk_dispute_contract FOREIGN KEY (contract_id) REFERENCES rental_contracts(id) ON DELETE CASCADE;
+
+-- ============================================
+-- Idempotent migration: add bound_rebind_count to existing deployments
+-- (P0 entity-rebind cascade — Phase 1)
+-- ============================================
+ALTER TABLE bot_listings ADD COLUMN IF NOT EXISTS bound_rebind_count INTEGER NOT NULL DEFAULT 0;

--- a/backend/tests/jest/entity-rebind-counter.test.js
+++ b/backend/tests/jest/entity-rebind-counter.test.js
@@ -1,0 +1,86 @@
+/**
+ * Entity rebind counter — P0 Phase 1 (silent identity-drift detection)
+ *
+ * Verifies createDefaultEntity returns rebindCount=0 / lastRebindAt=null
+ * and that the rebind pattern (snapshot → reset → bump) increments correctly.
+ *
+ * Card: card_b0d150cfc6ab20c52640d4b7
+ */
+
+require('./helpers/mock-setup');
+
+const { _createDefaultEntity: createDefaultEntity } = require('../../index');
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise((resolve) => httpServer.close(resolve));
+});
+
+describe('createDefaultEntity: rebind counter fields', () => {
+    test('a fresh entity has rebindCount=0 and lastRebindAt=null', () => {
+        const e = createDefaultEntity(0);
+        expect(e.entityId).toBe(0);
+        expect(e.rebindCount).toBe(0);
+        expect(e.lastRebindAt).toBeNull();
+    });
+
+    test('rebind pattern increments rebindCount and stamps lastRebindAt', () => {
+        // Simulate the pattern used at the 8 rebind callsites in index.js:
+        //   const prev = device.entities[eId];
+        //   device.entities[eId] = createDefaultEntity(eId);
+        //   device.entities[eId].rebindCount = (prev.rebindCount || 0) + 1;
+        //   device.entities[eId].lastRebindAt = Date.now();
+        const prev = { rebindCount: 4, name: 'OldBot', xp: 50, level: 3 };
+        const before = Date.now();
+
+        const next = createDefaultEntity(2);
+        next.name = prev.name || null;
+        next.xp = prev.xp || 0;
+        next.level = prev.level || 1;
+        next.rebindCount = (prev.rebindCount || 0) + 1;
+        next.lastRebindAt = Date.now();
+
+        expect(next.rebindCount).toBe(5);
+        expect(next.lastRebindAt).toBeGreaterThanOrEqual(before);
+        expect(next.name).toBe('OldBot');
+        expect(next.xp).toBe(50);
+        expect(next.level).toBe(3);
+        // Identity fields are reset
+        expect(next.botSecret).toBeNull();
+        expect(next.isBound).toBe(false);
+        expect(next.identity).toBeNull();
+    });
+
+    test('rebind from prev with no rebindCount field defaults to 1', () => {
+        // Backwards-compat: entities saved before this change have no rebindCount.
+        const prev = { name: 'Legacy' }; // rebindCount undefined
+        const next = createDefaultEntity(0);
+        next.rebindCount = (prev.rebindCount || 0) + 1;
+        expect(next.rebindCount).toBe(1);
+    });
+
+    test('spread-shape rebind (free/personal bind paths) preserves the increment', () => {
+        // Simulate the spread pattern at 11919 / 12082 callsites:
+        //   device.entities[eId] = {
+        //       ...createDefaultEntity(eId),
+        //       rebindCount: (existing?.rebindCount || 0) + 1,
+        //       lastRebindAt: Date.now(),
+        //       botSecret: ..., isBound: true, ...
+        //   };
+        const existing = { rebindCount: 2, xp: 10, level: 2 };
+        const next = {
+            ...createDefaultEntity(1),
+            xp: existing.xp,
+            level: existing.level,
+            rebindCount: (existing.rebindCount || 0) + 1,
+            lastRebindAt: Date.now(),
+            botSecret: 'new-secret',
+            isBound: true,
+        };
+        expect(next.rebindCount).toBe(3);
+        expect(next.lastRebindAt).not.toBeNull();
+        expect(next.isBound).toBe(true);
+        expect(next.botSecret).toBe('new-secret');
+        expect(next.entityId).toBe(1);
+    });
+});

--- a/backend/tests/jest/rental-listing.test.js
+++ b/backend/tests/jest/rental-listing.test.js
@@ -40,7 +40,7 @@ jest.mock('pg', () => {
         // INSERT new listing
         if (/^INSERT INTO bot_listings/i.test(norm)) {
             const [ownerUserId, ownerDeviceId, ownerEntityId, title, description,
-                   rate, minMin, maxMin /* 'draft' status is literal */] = params;
+                   rate, minMin, maxMin, avatarUrl, boundRebindCount /* 'draft' status is literal */] = params;
             const row = {
                 id: genId(),
                 owner_user_id: ownerUserId,
@@ -51,6 +51,7 @@ jest.mock('pg', () => {
                 rate_mli_per_ktoken: rate,
                 min_rental_minutes: minMin,
                 max_rental_minutes: maxMin,
+                avatar_url: avatarUrl,
                 availability_windows: [],
                 model_detected: null,
                 capabilities: {},
@@ -61,11 +62,15 @@ jest.mock('pg', () => {
                 total_rentals: 0,
                 uptime_pct: 100,
                 status: 'draft',
+                bound_rebind_count: boundRebindCount ?? 0,
                 created_at: new Date(),
                 updated_at: new Date(),
             };
             state.listings.push(row);
-            return { rows: [{ id: row.id, status: row.status, created_at: row.created_at }], rowCount: 1 };
+            return { rows: [{
+                id: row.id, status: row.status, created_at: row.created_at,
+                bound_rebind_count: row.bound_rebind_count,
+            }], rowCount: 1 };
         }
 
         // Specific status-transition handlers MUST come before the generic
@@ -291,6 +296,47 @@ describe('rental: createListing', () => {
             title: 'OK', rateMliPerKtoken: 5000,
             maxRentalMinutes: 999_999,
         })).rejects.toThrow('max_rental_minutes_invalid');
+    });
+
+    // P0 entity-rebind cascade — Phase 1
+    test('snapshots boundRebindCount=0 by default', async () => {
+        const listing = await api.createListing({
+            ownerUserId: OWNER,
+            ownerDeviceId: 'device-rb-default',
+            ownerEntityId: 0,
+            title: 'Default rebind',
+            rateMliPerKtoken: 0,
+        });
+        const row = globalThis.__rentalFakeState.listings.find(l => l.id === listing.id);
+        expect(row.bound_rebind_count).toBe(0);
+    });
+
+    test('snapshots boundRebindCount supplied at creation time', async () => {
+        const listing = await api.createListing({
+            ownerUserId: OWNER,
+            ownerDeviceId: 'device-rb-snap',
+            ownerEntityId: 1,
+            title: 'Snapshot rebind',
+            rateMliPerKtoken: 0,
+            boundRebindCount: 7,
+        });
+        const row = globalThis.__rentalFakeState.listings.find(l => l.id === listing.id);
+        expect(row.bound_rebind_count).toBe(7);
+    });
+
+    test('coerces negative or non-integer boundRebindCount to 0', async () => {
+        const a = await api.createListing({
+            ownerUserId: OWNER, ownerDeviceId: 'device-rb-neg', ownerEntityId: 0,
+            title: 'Neg', rateMliPerKtoken: 0, boundRebindCount: -3,
+        });
+        const b = await api.createListing({
+            ownerUserId: OWNER, ownerDeviceId: 'device-rb-str', ownerEntityId: 0,
+            title: 'Str', rateMliPerKtoken: 0, boundRebindCount: 'oops',
+        });
+        const rowA = globalThis.__rentalFakeState.listings.find(l => l.id === a.id);
+        const rowB = globalThis.__rentalFakeState.listings.find(l => l.id === b.id);
+        expect(rowA.bound_rebind_count).toBe(0);
+        expect(rowB.bound_rebind_count).toBe(0);
     });
 });
 


### PR DESCRIPTION
## Summary

P0 Phase 1 of the silent **entity-rebind cascade** fix (card_b0d150cfc6ab20c52640d4b7).

**The bug class:** rental listings reference `(owner_device_id, owner_entity_id)` only. When the entity slot is reset and rebound to a different bot, the listing silently resolves to the new bot — renters get served a different bot than they signed up for.

**This PR adds the detection primitive:**

1. `createDefaultEntity` gains `rebindCount: 0` + `lastRebindAt: null`.
2. All **8 rebind callsites** in `backend/index.js` snapshot `prev.rebindCount` and bump after reset:
   - `1283` borrow cleanup expire
   - `6654` unbind by user
   - `6772` device remove unbind
   - `11671` another unbind path
   - `11911` free version bind (spread shape)
   - `12073` personal/monthly bind (spread shape)
   - `12259` borrow remove
   - `14420` transfer source
3. Non-rebind callsites (initial creation, snapshot/backup) untouched.
4. `bot_listings.bound_rebind_count` column captures entity's `rebindCount` at listing creation; idempotent `ALTER TABLE … ADD COLUMN IF NOT EXISTS` migrates existing rows to default 0.
5. `createListing` route handler reads `entity.rebindCount` and threads it through.

## What this does NOT do (deferred to Phase 2/3)

- Phase 2: marketplace queries filter `bot_listings WHERE bound_rebind_count = current entity.rebindCount` to hide stale listings.
- Phase 3: rebind prompt warns owner about affected listings + auto-pause cascade.

## Test plan

- [x] Jest: `entity-rebind-counter.test.js` (4 tests covering fresh entity, increment pattern, undefined-prev fallback, spread-shape pattern) — all pass
- [x] Jest: `rental-listing.test.js` 3 new tests for `createListing` boundRebindCount snapshot/default/coercion — all pass
- [x] Existing rental + entity-management suites unaffected (84/84 pass)
- [x] ESLint clean
- [ ] Verify migration runs cleanly on Railway after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)