### PR TITLE
infra(rebind): hide drifted listings from marketplace (P0 Phase 2)

### DIFF
--- a/backend/rental.js
+++ b/backend/rental.js
@@ -398,6 +398,7 @@ async function searchMarketplace({
                 bl.avg_rating, bl.total_rentals, bl.uptime_pct,
                 bl.owner_device_id, bl.owner_entity_id,
                 bl.avatar_url,
+                bl.bound_rebind_count,
                 bl.created_at AS bl_created_at,
                 EXISTS (
                     SELECT 1 FROM rental_contracts ac
@@ -415,6 +416,32 @@ async function searchMarketplace({
         params
     );
     return res.rows;
+}
+
+/**
+ * P0 Phase 2: drop listings whose live entity rebindCount has drifted past
+ * bound_rebind_count (snapshot at listing creation). A drifted listing
+ * silently points at a different bot than the renter expects, so we hide it
+ * from public search but leave it in the DB — owner sees it in /my-rentals
+ * and can either re-publish (resnap) or delist.
+ *
+ * Fail-open semantics: if the in-memory devices map is unavailable (early
+ * boot, test harness), skip the filter and return all listings unchanged.
+ * The DB-level snapshot still records bound_rebind_count, so retroactive
+ * filtering works once the map is wired in.
+ */
+function filterDriftedListings(listings, devicesMap) {
+    if (!Array.isArray(listings)) return listings;
+    if (!devicesMap || typeof devicesMap !== 'object') return listings;
+    return listings.filter((l) => {
+        const dev = devicesMap[l.owner_device_id];
+        const ent = dev?.entities?.[l.owner_entity_id];
+        if (!ent) return false; // entity slot vanished → definitely drifted
+        const liveCount = Number.isInteger(ent.rebindCount) ? ent.rebindCount : 0;
+        const boundCount = Number.isFinite(Number(l.bound_rebind_count))
+            ? Number(l.bound_rebind_count) : 0;
+        return liveCount === boundCount;
+    });
 }
 
 // ============================================
@@ -1498,7 +1525,11 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
                 limit: req.query.limit,
                 offset: req.query.offset,
             });
-            res.json({ success: true, listings });
+            // P0 Phase 2: hide listings whose entity slot has been rebound since
+            // the listing was created (silent identity drift). Owner still sees
+            // them in /my-rentals so they can re-publish or delist explicitly.
+            const filtered = filterDriftedListings(listings, _interviewDeps?.devices);
+            res.json({ success: true, listings: filtered });
         } catch (err) {
             console.error('[Rental] /marketplace error:', err);
             res.status(500).json({ success: false, error: 'internal_error' });
@@ -1891,6 +1922,7 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
         getListing,
         listMyListings,
         searchMarketplace,
+        filterDriftedListings,
         startRental,
         endRental,
         getMyContracts,

--- a/backend/tests/jest/rental-listing.test.js
+++ b/backend/tests/jest/rental-listing.test.js
@@ -525,6 +525,50 @@ describe('rental: searchMarketplace', () => {
     });
 });
 
+describe('rental: filterDriftedListings (P0 Phase 2)', () => {
+    const listings = [
+        { id: 'l1', title: 'Match', owner_device_id: 'd1', owner_entity_id: 0, bound_rebind_count: 0 },
+        { id: 'l2', title: 'Drifted', owner_device_id: 'd1', owner_entity_id: 1, bound_rebind_count: 0 },
+        { id: 'l3', title: 'Match-rebound', owner_device_id: 'd2', owner_entity_id: 0, bound_rebind_count: 3 },
+        { id: 'l4', title: 'Slot-gone',  owner_device_id: 'd3', owner_entity_id: 0, bound_rebind_count: 0 },
+    ];
+    const devices = {
+        d1: { entities: { 0: { rebindCount: 0 }, 1: { rebindCount: 5 } } },
+        d2: { entities: { 0: { rebindCount: 3 } } },
+        // d3 is missing → l4 hidden
+    };
+
+    test('returns input unchanged if devicesMap is missing', () => {
+        expect(api.filterDriftedListings(listings, null)).toEqual(listings);
+        expect(api.filterDriftedListings(listings, undefined)).toEqual(listings);
+    });
+
+    test('keeps listings whose live rebindCount matches the snapshot', () => {
+        const out = api.filterDriftedListings(listings, devices);
+        const ids = out.map(l => l.id).sort();
+        expect(ids).toEqual(['l1', 'l3']);
+    });
+
+    test('drops listings with no matching device or entity slot', () => {
+        const out = api.filterDriftedListings(listings, devices);
+        expect(out.find(l => l.id === 'l4')).toBeUndefined();
+    });
+
+    test('treats missing rebindCount on entity as 0 (legacy entities)', () => {
+        const legacyDevices = {
+            d1: { entities: { 0: { /* no rebindCount */ } } },
+        };
+        const matchedLegacy = [{ id: 'lz', owner_device_id: 'd1', owner_entity_id: 0, bound_rebind_count: 0 }];
+        expect(api.filterDriftedListings(matchedLegacy, legacyDevices)).toHaveLength(1);
+    });
+
+    test('treats missing bound_rebind_count on listing as 0', () => {
+        const oldListings = [{ id: 'lo', owner_device_id: 'd1', owner_entity_id: 0 }];
+        // d1.0 has rebindCount=0, listing has no bound_rebind_count → both 0 → keep
+        expect(api.filterDriftedListings(oldListings, devices)).toHaveLength(1);
+    });
+});
+
 describe('rental: factory hard-fail', () => {
     test('throws when authMiddleware is missing', () => {
         expect(() => rental({ walletModule: stubWallet })).toThrow(/authMiddleware/);


### PR DESCRIPTION
## Summary

Phase 2 of the entity-rebind cascade fix (card_b0d150cfc6ab20c52640d4b7) — closes the actual user-visible silent identity-drift hole.

Phase 1 (#2113) added the snapshot. This PR uses it.

**Behavior:** if a listing's `bound_rebind_count` no longer matches the live entity's `rebindCount`, the listing is filtered out of `/api/rental/marketplace`. The listing stays in the DB so the owner can see it in `/my-rentals` and either re-publish (resnap) or delist.

## Changes

1. `searchMarketplace` SQL now selects `bl.bound_rebind_count`.
2. New helper `filterDriftedListings(listings, devicesMap)`:
   - Drops if `dev.entities[entity_id]` is missing.
   - Drops if `liveCount !== boundCount`.
   - Fail-open: returns input unchanged if `devicesMap` is null/undefined (early boot / test harness).
3. `/marketplace` route applies the filter via late-bound `_interviewDeps.devices`.
4. Helper exported from rental factory for unit testing + future reuse.

## Known limitations (deferred to Phase 3)

- SQL `LIMIT` is applied before JS-side filter, so a page may return fewer than `limit` results when drift exists. Acceptable — drift is rare; Phase 3 cascade auto-pause normalizes this on rebind.
- Owner-side `/my-rentals` does NOT yet flag drifted listings visually. P1 (delist UI) card will add the indicator.

## Test plan

- [x] 5 new jest tests for `filterDriftedListings`: null map fail-open, match keep, missing slot drop, legacy entity (missing rebindCount), legacy listing (missing bound_rebind_count). All pass.
- [x] Existing rental-listing suite (29 tests) unaffected.
- [x] ESLint clean.
- [ ] Verify on Railway that real `_interviewDeps.devices` is wired before /marketplace serves a request (rental.js depends on `setInterviewDeps` being called during init).

🤖 Generated with [Claude Code](https://claude.com/claude-code)