### PR TITLE
infra(rebind): auto-pause listings on entity rebind (P0 Phase 3)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1286,6 +1286,7 @@ setInterval(async () => {
                 device.entities[binding.entity_id].level = prev.level || 1;
                 device.entities[binding.entity_id].rebindCount = (prev.rebindCount || 0) + 1;
                 device.entities[binding.entity_id].lastRebindAt = Date.now();
+                await pauseRentalListingsOnRebind(binding.device_id, binding.entity_id);
             }
 
             delete officialBindingsCache[getBindingCacheKey(binding.device_id, binding.entity_id)];
@@ -2184,6 +2185,24 @@ const rentalModule = require('./rental')({
     serverLog,
 });
 app.use('/api/rental', rentalModule.router);
+
+// P0 Phase 3: when an entity slot is rebound, every active listing pointing
+// at it now references a different bot. Auto-pause the listings so the
+// marketplace stops booking the slot. Owner can manually re-publish or delist.
+// Errors are swallowed inside rentalModule.pauseListingsOnRebind — must not
+// abort the rebind itself.
+async function pauseRentalListingsOnRebind(deviceId, entityId) {
+    if (typeof rentalModule?.pauseListingsOnRebind !== 'function') return;
+    try {
+        const paused = await rentalModule.pauseListingsOnRebind(deviceId, entityId);
+        if (Array.isArray(paused) && paused.length > 0) {
+            serverLog('info', 'rental', `[Rebind cascade] auto-paused ${paused.length} listing(s)`,
+                { deviceId, entityId, listingIds: paused });
+        }
+    } catch (err) {
+        console.error('[Rebind cascade] pauseRentalListingsOnRebind error:', err.message);
+    }
+}
 // Defer schema init: rental_contracts has FKs to user_accounts and
 // bot_listings, so user_accounts must be created first.
 if (process.env.NODE_ENV !== 'test') {
@@ -6659,6 +6678,7 @@ app.delete('/api/entity', async (req, res) => {
     device.entities[eId].level = removedEntity?.level || 1;
     device.entities[eId].rebindCount = (removedEntity?.rebindCount || 0) + 1;
     device.entities[eId].lastRebindAt = Date.now();
+    await pauseRentalListingsOnRebind(deviceId, eId);
 
     console.log(`[Remove] Device ${deviceId} Entity ${eId} unbound`);
     serverLog('info', 'unbind', `Entity ${eId} unbound`, { deviceId, entityId: eId });
@@ -6779,6 +6799,7 @@ app.delete('/api/device/entity', async (req, res) => {
     device.entities[eId].level = removedEntity2?.level || 1;
     device.entities[eId].rebindCount = (removedEntity2?.rebindCount || 0) + 1;
     device.entities[eId].lastRebindAt = Date.now();
+    await pauseRentalListingsOnRebind(deviceId, eId);
 
     console.log(`[Device Remove] Device ${deviceId} Entity ${eId} unbound by device owner`);
 
@@ -11680,6 +11701,7 @@ async function autoUnbindEntity(deviceId, eId, device) {
     device.entities[eId].level = prevEntity?.level || 1;
     device.entities[eId].rebindCount = (prevEntity?.rebindCount || 0) + 1;
     device.entities[eId].lastRebindAt = Date.now();
+    await pauseRentalListingsOnRebind(deviceId, eId);
 }
 
 /**
@@ -11938,6 +11960,7 @@ app.post('/api/official-borrow/bind-free', async (req, res) => {
         }
     };
     publicCodeIndex[freePublicCode] = { deviceId, entityId: eId };
+    await pauseRentalListingsOnRebind(deviceId, eId);
 
     // Save binding record
     const binding = {
@@ -12100,6 +12123,7 @@ app.post('/api/official-borrow/bind-personal', async (req, res) => {
             setupPassword: personalBot.setup_password || null
         }
     };
+    await pauseRentalListingsOnRebind(deviceId, eId);
 
     // Mark personal bot as assigned
     personalBot.status = 'assigned';
@@ -12274,6 +12298,7 @@ app.post('/api/official-borrow/unbind', async (req, res) => {
     device.entities[eId].level = prevBorrow?.level || 1;
     device.entities[eId].rebindCount = (prevBorrow?.rebindCount || 0) + 1;
     device.entities[eId].lastRebindAt = Date.now();
+    await pauseRentalListingsOnRebind(deviceId, eId);
     await saveData();
 
     console.log(`[Borrow] Official binding removed: device ${deviceId} entity ${eId}`);
@@ -14434,6 +14459,7 @@ app.post('/api/admin/transfer-device', async (req, res) => {
             sourceDevice.entities[eId] = createDefaultEntity(eId);
             sourceDevice.entities[eId].rebindCount = (srcEntity.rebindCount || 0) + 1;
             sourceDevice.entities[eId].lastRebindAt = Date.now();
+            await pauseRentalListingsOnRebind(sourceDeviceId, eId);
             transferred.push({ entityId: eId, name: srcEntity.name, character: srcEntity.character });
         }
 

--- a/backend/rental.js
+++ b/backend/rental.js
@@ -320,6 +320,37 @@ async function delistListing(listingId, ownerUserId) {
     return res.rows[0];
 }
 
+/**
+ * P0 Phase 3: when an entity slot is rebound to a different bot, every active
+ * listing pointing at that slot is now stale. Auto-pause them so the
+ * marketplace stops booking the slot, while leaving the row in place so the
+ * owner can decide to re-list (after a fresh interview) or delist permanently.
+ *
+ * Statuses we touch: 'draft', 'interview', 'listed'.
+ * Statuses we leave alone: 'paused' (already safe), 'delisted' (terminal).
+ *
+ * Returns the affected listing IDs for caller logging. Errors are caught
+ * and logged — a DB hiccup must not abort the rebind itself.
+ */
+async function pauseListingsOnRebind(deviceId, entityId) {
+    if (!deviceId || !Number.isInteger(entityId)) return [];
+    try {
+        const res = await pool.query(
+            `UPDATE bot_listings
+                SET status = 'paused', updated_at = NOW()
+              WHERE owner_device_id = $1
+                AND owner_entity_id = $2
+                AND status IN ('draft', 'interview', 'listed')
+            RETURNING id, status`,
+            [deviceId, entityId]
+        );
+        return res.rows.map((r) => r.id);
+    } catch (err) {
+        console.error('[Rental] pauseListingsOnRebind error:', err.message);
+        return [];
+    }
+}
+
 async function getListing(listingId) {
     const res = await pool.query(
         `SELECT id, owner_user_id, owner_device_id, owner_entity_id,
@@ -1919,6 +1950,7 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
         publishListing,
         pauseListing,
         delistListing,
+        pauseListingsOnRebind,
         getListing,
         listMyListings,
         searchMarketplace,

--- a/backend/tests/jest/rental-listing.test.js
+++ b/backend/tests/jest/rental-listing.test.js
@@ -110,6 +110,20 @@ jest.mock('pg', () => {
             return { rows: [{ interview_passed: row.interview_passed }], rowCount: 1 };
         }
 
+        // P0 Phase 3 rebind cascade: UPDATE ... status='paused' WHERE owner_device_id AND owner_entity_id AND status IN (...)
+        if (/^UPDATE bot_listings SET status = 'paused', updated_at = NOW\(\) WHERE owner_device_id = \$1 AND owner_entity_id = \$2 AND status IN/i.test(norm)) {
+            const [deviceId, entityId] = params;
+            const affected = state.listings.filter(l =>
+                l.owner_device_id === deviceId &&
+                l.owner_entity_id === entityId &&
+                ['draft', 'interview', 'listed'].includes(l.status));
+            for (const row of affected) {
+                row.status = 'paused';
+                row.updated_at = new Date();
+            }
+            return { rows: affected.map(r => ({ id: r.id, status: r.status })), rowCount: affected.length };
+        }
+
         // Pause: UPDATE ... status='paused' WHERE id AND owner AND status='listed'
         if (/^UPDATE bot_listings SET status = 'paused'/i.test(norm)) {
             const [id, ownerUserId] = params;
@@ -566,6 +580,55 @@ describe('rental: filterDriftedListings (P0 Phase 2)', () => {
         const oldListings = [{ id: 'lo', owner_device_id: 'd1', owner_entity_id: 0 }];
         // d1.0 has rebindCount=0, listing has no bound_rebind_count → both 0 → keep
         expect(api.filterDriftedListings(oldListings, devices)).toHaveLength(1);
+    });
+});
+
+describe('rental: pauseListingsOnRebind (P0 Phase 3)', () => {
+    const DEV_A = 'dev-a';
+    const DEV_B = 'dev-b';
+
+    function seedListing({ id, deviceId, entityId, status = 'listed' }) {
+        const state = globalThis.__rentalFakeState;
+        state.listings.push({
+            id, owner_user_id: OWNER,
+            owner_device_id: deviceId, owner_entity_id: entityId,
+            title: id, description: '', rate_mli_per_ktoken: 1,
+            min_rental_minutes: 5, max_rental_minutes: 60,
+            interview_passed: true, status,
+            bound_rebind_count: 0,
+            created_at: new Date(), updated_at: new Date(),
+        });
+    }
+
+    test('flips draft/interview/listed → paused for matching device+entity', async () => {
+        seedListing({ id: 'p1', deviceId: DEV_A, entityId: 0, status: 'draft' });
+        seedListing({ id: 'p2', deviceId: DEV_A, entityId: 0, status: 'listed' });
+        seedListing({ id: 'p3', deviceId: DEV_A, entityId: 0, status: 'paused' });
+        seedListing({ id: 'p4', deviceId: DEV_A, entityId: 0, status: 'delisted' });
+        seedListing({ id: 'p5', deviceId: DEV_A, entityId: 1, status: 'listed' }); // different entity
+        seedListing({ id: 'p6', deviceId: DEV_B, entityId: 0, status: 'listed' }); // different device
+
+        const paused = await api.pauseListingsOnRebind(DEV_A, 0);
+        expect(paused.sort()).toEqual(['p1', 'p2']);
+
+        const state = globalThis.__rentalFakeState;
+        expect(state.listings.find(l => l.id === 'p1').status).toBe('paused');
+        expect(state.listings.find(l => l.id === 'p2').status).toBe('paused');
+        expect(state.listings.find(l => l.id === 'p3').status).toBe('paused'); // unchanged
+        expect(state.listings.find(l => l.id === 'p4').status).toBe('delisted'); // unchanged
+        expect(state.listings.find(l => l.id === 'p5').status).toBe('listed'); // entity 1 untouched
+        expect(state.listings.find(l => l.id === 'p6').status).toBe('listed'); // device B untouched
+    });
+
+    test('returns [] when no listings match', async () => {
+        const paused = await api.pauseListingsOnRebind('nope-device', 0);
+        expect(paused).toEqual([]);
+    });
+
+    test('rejects bad inputs without throwing', async () => {
+        await expect(api.pauseListingsOnRebind(null, 0)).resolves.toEqual([]);
+        await expect(api.pauseListingsOnRebind('dev', null)).resolves.toEqual([]);
+        await expect(api.pauseListingsOnRebind('dev', 'not-int')).resolves.toEqual([]);
     });
 });
 


### PR DESCRIPTION
## Summary
- Closes the listing-side cascade for the entity-rebind drift bug class.
- When an entity is rebound, every active listing for that `owner_device_id + owner_entity_id` flips to `paused` so renters cannot dispatch interviews or new contracts against the now-different bot.
- Phase 1 (`rebindCount` field + bot_listings snapshot) shipped in #2113.
- Phase 2 (marketplace drift filter) shipped in #2114.
- Phase 3 (this PR): server-side automatic pause on rebind.

## What changed
- `rental.js` — new `pauseListingsOnRebind(deviceId, entityId)` helper: `UPDATE bot_listings SET status='paused' WHERE owner_device_id=$1 AND owner_entity_id=$2 AND status IN ('draft','interview','listed') RETURNING id`. Exported from the factory.
- `index.js` — thin wrapper `pauseRentalListingsOnRebind` + `await` at all 8 entity-rebind callsites right after `rebindCount`/`lastRebindAt` bump. Errors are caught and logged; the rebind path is never blocked by a rental-side failure.
- `tests/jest/rental-listing.test.js` — 3 new jest cases (status-filter scope / no-match returns `[]` / bad input returns `[]`) + extended fake-pg matcher for the cascade UPDATE shape.

## Open question (not gated by this PR)
Active-contract policy on rebind is still pending — block / terminate+refund / silent drift. Whatever Hank picks slots into a follow-up Phase 4 that consults `bot_rentals` instead of `bot_listings`.

## Test plan
- [x] `npx jest tests/jest/rental-listing.test.js tests/jest/entity-rebind-counter.test.js` — 41/41 passing (38 prior + 3 new)
- [ ] CI green
- [ ] Spot-check on Railway after merge: rebind a listed bot → listing flips to paused; verify via `/api/rental/listings/mine`

🤖 Generated with [Claude Code](https://claude.com/claude-code)