### PR TITLE
docs(specs): seed backend spec anchors — INDEX + rental + rebind-cascade

### DIFF
--- a/backend/docs/specs/INDEX.md
+++ b/backend/docs/specs/INDEX.md
@@ -1,0 +1,49 @@
+# Backend Subsystem Specs — Index
+
+Per Hank 2026-04-25 1on1 Q2: 用 grep 理解 code 架構容易撞名 — 規範書當錨點。
+心智圖第一層的每個節點需要對應的 spec doc。
+
+**Legend:** ✅ has dedicated spec · △ partial / scattered design+impl notes · ❌ no spec yet
+
+| # | Subsystem | Source files | Spec status | Location |
+|---|-----------|--------------|-------------|----------|
+| 1 | rental | `backend/rental.js`, `backend/rental_schema.sql`, `backend/rental-proxy.js` | ✅ | [`backend/docs/specs/rental.md`](rental.md) (this audit's sample) |
+| 2 | rental — rebind cascade Phase 1-4 | `backend/rental.js` (pause/terminate helpers), `backend/index.js` (8 callsites) | ✅ | [`backend/docs/specs/rental-rebind-cascade.md`](rental-rebind-cascade.md) (Phase 4 follow-through) |
+| 3 | wallet | `backend/wallet.js`, `backend/wallet_schema.sql` | ❌ | constants live in code (`LEDGER_TYPES`, `applyLedgerEntry`) — needs extraction |
+| 4 | kanban (mission v2) | `backend/kanban.js`, `backend/mission.js` | △ | repo-root [`docs/mission-v2-kanban-spec.md`](../../../docs/mission-v2-kanban-spec.md) — written before screenshot-review gate / cron 子卡; needs supplement |
+| 5 | vault — device_vars + encryptVars | `backend/index.js` (encryptVars / decryptVars), `backend/auth.js` | △ | repo-root [`docs/plans/2026-03-03-env-vars-encrypted-persistence-design.md`](../../../docs/plans/2026-03-03-env-vars-encrypted-persistence-design.md) — design only, no current-state spec; missing the "vault NEVER auto-injects, no allowed_vars whitelist" rule |
+| 6 | official-bind / public-code | `backend/index.js` (officialBindingsCache, public_code_index), `backend/auth.js` | ❌ | borrow flow + free vs personal binding only documented in code paths |
+| 7 | channel-bridge (fakechat / web_chat) | `backend/index.js` (`/api/client/speak`, `/api/transform`, `/api/chat/history`), `bridge.ts` | ❌ | `bridge.ts` has inline comments; AVAILABLE TOOLS dashboard format only encoded in mission notify code |
+| 8 | mission-dashboard / notes / chat-history | `backend/mission.js`, `backend/index.js` (`/api/mission/dashboard`, `/api/chat/history`) | ❌ | endpoint shapes only in code |
+| 9 | publisher (X/Mastodon retired/Discord) | `backend/publisher*.js`, `backend/x-tweet*.js`, `backend/discord*.js` | △ | scattered; news-publishing-api 2026-03-15 doc covers only one path |
+| 10 | arena (browser interview / E2E test) | `backend/arena.js`, `backend/interview-arena.js` | ❌ | arena page_loaded protocol only in [memory](../../../docs/specs/) reference, not yet a backend spec |
+| 11 | gatekeeper (intent classifier) | `backend/gatekeeper.js`, `backend/gatekeeper-router.js` | △ | repo-root [`docs/issues/gatekeeper-*.md`](../../../docs/issues/) bug post-mortems exist; no positive spec |
+| 12 | bot identity layer (device + entity slot) | `backend/index.js` (entity rebind, createDefaultEntity), `backend/auth.js` | △ | repo-root [`docs/bot-identity-layer.md`](../../../docs/bot-identity-layer.md) exists — coverage TBD |
+
+## Gap list (priority order)
+
+**P0 / blocks mind-map first layer:**
+1. **wallet.md** — ledger type matrix + balance/held invariants + idempotency contract. Cited by every rental + topup card; absence makes "why does endRental return refund_mli + forfeit_mli but NOT credit owner directly" impossible to grep without reading source.
+2. **vault.md** — codify `feedback_no_whitelist_vault.md` rule into the repo. Encryption boundary, botSecret authority, what is NEVER auto-decrypted. Today only lives in my agent memory.
+3. **channel-bridge.md** — fakechat ↔ web_chat ↔ AVAILABLE TOOLS dashboard contract. Drives every bot's runtime behavior; absence is why Hermes shipped broken i18n on 2026-04-25 (he didn't have a doc to cite).
+
+**P1 / fills mind-map second layer:**
+4. **official-bind.md** — borrow vs personal vs free; unbind cascade (now Phase 1-4 documented separately); public-code allocator constraints.
+5. **kanban-supplement.md** — screenshot-review gate, cron 子卡 lifecycle, archived/restore, status enum (`backlog, todo, in_progress, review, done, blocked`).
+6. **mission-dashboard.md** — endpoint shapes, AVAILABLE TOOLS format, dashboard refresh cadence.
+
+**P2 / nice to have:**
+7. publisher.md (post-Mastodon-retirement, post-wp.com-retirement)
+8. arena.md (page_loaded → navigateUrl protocol)
+9. gatekeeper.md (positive spec, not just bug post-mortems)
+
+## Out of scope for this audit
+
+This card delivers: **(a) this INDEX**, **(b) the gap list above**, and **(c) one sample spec — `rental.md`**. It does NOT fill in the gaps. Each P0/P1/P2 doc above should become its own card (or be batched into themed cards) when prioritized.
+
+## Convention going forward
+
+- Every new subsystem must ship a `backend/docs/specs/<subsystem>.md` alongside the implementation PR.
+- Specs cite **constants by name + value** (e.g. `INTERVIEW_PASS_SCORE = 60`) so a grep against the doc finds the rule, and a grep against the code finds the implementation — both lead to the same line.
+- Specs document **invariants and boundaries**, not API shape (that lives in `/api/help` + JSDoc on the route handlers).
+- When a constant changes, the spec changes in the same PR (CI does not enforce this yet — file a follow-up if drift becomes a problem).

--- a/backend/docs/specs/rental-rebind-cascade.md
+++ b/backend/docs/specs/rental-rebind-cascade.md
@@ -1,0 +1,230 @@
+# rental — entity rebind cascade (Phases 1-4)
+
+**Source:**
+- `backend/rental.js` (helpers: `filterDriftedListings`, `pauseListingsOnRebind`, `terminateActiveContractsOnRebind`)
+- `backend/index.js` (8 rebind callsites; `pauseRentalListingsOnRebind` / `terminateRentalContractsOnRebind` wrappers at lines 2195 / 2213)
+- `backend/rental_schema.sql` (`bot_listings.bound_rebind_count`)
+
+**Policy anchor:** Hank 2026-04-25 1on1 Q1 — "B 重綁屬於 owner 問題 所以虧要 owner 吃". A renter contracts bot **X** at the slot. After the owner rebinds the slot to bot **Y**, the renter's lost rental window is on the **owner**, not the renter or platform.
+
+---
+
+## 1. The drift problem
+
+Listings and contracts are pinned to a **slot identity** —
+`(owner_device_id, owner_entity_id)` — not to the bot's content. When the slot
+is rebound to a different bot, the row keeps pointing at `(device, entity)`,
+but the bot serving that slot has changed underneath it. Without intervention:
+
+- Marketplace search would still surface the now-stale listing.
+- Active contracts would silently stream traffic to a different bot than the
+  renter agreed to.
+- The renter has no signal that anything changed.
+
+The cascade closes that gap with four phases, each landing in its own PR so
+behavior could be vetted incrementally.
+
+---
+
+## 2. Cascade phases
+
+| Phase | PR | Helper / signal | Effect |
+|-------|----|-----------------|--------|
+| 1 | #2113 | `entities[id].rebindCount++`, `lastRebindAt = Date.now()` | every rebind increments a counter on the in-memory entity record (also stamped onto `last_rebind_at` for persistence) |
+| 2 | #2114 | `filterDriftedListings(listings, devicesMap)` (`rental.js:593-605`) | marketplace search hides any listing where `rebindCount > bound_rebind_count` (the snapshot taken when the listing was published) |
+| 3 | #2115 | `pauseListingsOnRebind(deviceId, entityId)` (`rental.js:335-352`) | drifted listings auto-transition `draft / interview / listed → paused`; `paused` and `delisted` are left alone |
+| 4 | #2118 | `terminateActiveContractsOnRebind(deviceId, entityId, walletApi)` (`rental.js:375-481`) | every `reserved / active / suspended_insufficient_funds` contract on the slot ends as `ended_admin` (renter gets 100% deposit back), then **owner** pays a pro-rata penalty to the renter |
+
+Phase 1 is the *signal*. Phases 2-3 are the *passive* (search hide) + *active*
+(state mutation) reactions on the listing side. Phase 4 is the contract-side
+reaction.
+
+---
+
+## 3. Wiring (`backend/index.js`)
+
+Two thin wrappers (`pauseRentalListingsOnRebind` at line 2195,
+`terminateRentalContractsOnRebind` at line 2213) wrap the rental-module
+helpers, swallow errors, and emit info / warn logs. Both are awaited
+**immediately after** every rebindCount bump:
+
+| Line | Callsite |
+|------|----------|
+| 1289 / 1290 | borrow expiration cleanup |
+| 6707 / 6708 | rebind via API (path A) |
+| 6829 / 6830 | rebind via API (path B) |
+| 11732 / 11733 | personal binding rebind |
+| 11992 / 11993 | free public-code allocation |
+| 12156 / 12157 | generic rebind handler |
+| 12332 / 12333 | rebind w/ saveData |
+| 14494 / 14495 | cross-device transfer |
+
+**Invariant:** every site that bumps `entity.rebindCount` calls **both**
+`pauseRentalListingsOnRebind` **and** `terminateRentalContractsOnRebind`,
+in that order. New rebind paths added in the future must follow the same
+pattern — drop a rebindCount bump without the cascade and you re-open the
+drift hole.
+
+---
+
+## 4. Phase 4 detail — termination + owner penalty
+
+### 4.1 Selection query (`rental.js:381-391`)
+
+```sql
+SELECT c.id, c.listing_id, c.owner_user_id, c.renter_user_id,
+       c.deposit_mli, c.planned_duration_min, c.started_at, c.ends_at,
+       c.status
+  FROM rental_contracts c
+  JOIN bot_listings l ON l.id = c.listing_id
+ WHERE l.owner_device_id = $1
+   AND l.owner_entity_id = $2
+   AND c.status IN ('reserved', 'active', 'suspended_insufficient_funds')
+```
+
+Note the **JOIN through bot_listings**. Contracts don't carry the slot key
+directly; they carry `listing_id`. Slot equality is enforced via the listing.
+
+### 4.2 Pro-rata penalty math (`rental.js:402-413`)
+
+```
+plannedMs = planned_duration_min × 60_000
+remainingMs = max(0, ends_at − Date.now())
+ratio = min(1, remainingMs / plannedMs)
+penaltyMli = floor(deposit_mli × ratio)
+```
+
+**Reserved contracts** (never started — `status === 'reserved' || !started_at || !ends_at`)
+get `penaltyMli = depositMli` directly. The rationale: the renter committed a
+deposit and got 0 rental time before the rebind; full deposit's worth of
+penalty is owed.
+
+### 4.3 Two-step settlement
+
+**Step 1** — `endRental({ contractId, endReason: 'ended_admin', requesterUserId: owner_user_id }, walletApi)`.
+This is the existing rental termination path and runs through the normal
+disposition matrix (`rental.md` §3): `ended_admin` returns 100% of the
+renter's remaining `held_mli` to their balance. `requesterUserId = owner` so
+the auth check inside `endRental` passes; the cascade itself is admin-initiated
+upstream.
+
+**Step 2** — owner-pays-renter pro-rata transfer, in its own
+`walletApi.withTransaction`:
+
+```
+SELECT balance_mli, held_mli FROM wallets WHERE user_id = $owner FOR UPDATE
+actualPenaltyMli = min(penaltyMli, ownerBalance)
+shortfallMli = penaltyMli - actualPenaltyMli
+
+if actualPenaltyMli > 0:
+    applyLedgerEntry(owner,  -actualPenaltyMli, type=REFUND, idempotencyKey=`rebind-refund-debit:<contractId>`)
+    applyLedgerEntry(renter, +actualPenaltyMli, type=REFUND, idempotencyKey=`rebind-refund-credit:<contractId>`)
+```
+
+### 4.4 Negative-balance clamp
+
+`applyLedgerEntry` rejects negative `balance_mli`. If owner cannot cover the
+full `penaltyMli`, the helper clamps to `min(penalty, available)` and writes
+the residual as `shortfallMli` to a `serverLog` warn entry. Behaviour is
+intentionally simple:
+
+- Owner balance is **never** driven negative.
+- Shortfall is **not** pursued — no debt collection, no async retry, no lien.
+- The shortfall log is for audit only.
+
+### 4.5 Idempotency
+
+Each contract emits ledger entries with stable keys:
+
+- `rebind-refund-debit:<contractId>` (owner debit leg)
+- `rebind-refund-credit:<contractId>` (renter credit leg)
+
+Plus the `endRental` keys (`rental-release:<contractId>` etc., see
+`rental.md` §3). A second cascade pass over the same slot is a no-op:
+
+1. The selection query no longer matches — contracts are now `ended_admin`.
+2. Even if it did, the idempotency keys collide and `applyLedgerEntry` rejects
+   the dupe before mutating wallets.
+
+This is exercised by the `rental-rebind-cascade.test.js` "idempotency on
+second run" case.
+
+### 4.6 Per-contract error isolation
+
+The for-loop in `terminateActiveContractsOnRebind` wraps each contract in its
+own try/catch (`rental.js:399-479`). One bad row (corrupt deposit, stale
+foreign key, transaction conflict) records an `{ contractId, error }` outcome
+and lets the cascade continue. Rebind itself MUST NOT be blocked by rental
+state — the slot has already changed identity in memory, so rolling back the
+rebind on a contract failure would leave a worse inconsistency.
+
+---
+
+## 5. Test coverage
+
+`backend/tests/jest/rental-rebind-cascade.test.js` (9 cases, all pass):
+
+1. Empty slot returns `[]` (no contracts → no work).
+2. Active contract → renter refund (100% held) + owner pro-rata penalty.
+3. Reserved contract → `penaltyMli = depositMli` (full deposit).
+4. Owner balance below penalty → clamp to balance, record `shortfallMli`.
+5. Slot isolation — contracts on a different `(device, entity)` pair are
+   untouched.
+6. Already-ended contracts (`ended_normal` etc.) are skipped by the SELECT.
+7. Idempotency on second run — second call is a no-op (no ledger dupes).
+8. Missing `walletApi` → safe early return `[]`.
+9. Invalid args (`null` deviceId, non-int entityId) → safe early return `[]`.
+
+Plus the broader rental + wallet suites:
+
+- `backend/tests/jest/rental*` — 271/271 pass (contract / listing /
+  wallet-integration / proxy / marketplace / security)
+- `backend/tests/jest/wallet*` — 84/84 pass (ledger / topup / ack-retry)
+
+---
+
+## 6. Why the design picks what it picks
+
+**Why owner pays, not platform.** Hank's policy ruling. The owner is the
+party who voluntarily rebound the slot. Platform-pays would convert every
+owner mistake into a platform liability and incentivise no-cost owner churn.
+
+**Why pro-rata, not flat.** A reserved contract that hasn't started yet
+disrupts the renter more (relative to time committed) than a contract
+3 minutes from natural end. Pro-rata captures that intuition without needing
+a separate policy table.
+
+**Why `ended_admin` not `ended_violation`.** `ended_admin` returns 100% of
+remaining held to the renter (`rental.md` §3). `ended_violation` would forfeit
+30% — but the renter did nothing wrong here. The pro-rata penalty is a
+*separate* punitive transfer from owner; the renter's own deposit comes
+back whole.
+
+**Why error-swallow at the cascade boundary.** Rebind is the upstream truth
+(slot identity already changed in `devices` map and DB). A failure in the
+listing-pause or contract-terminate step cannot un-rebind. Best we can do is
+log + continue — the alternative is a half-rebound slot that's much worse.
+
+**Why JOIN through `bot_listings` not `rental_contracts.owner_*`.** Even
+though `rental_contracts` carries `owner_user_id`, the *slot* identity lives
+on `bot_listings`. A user can own multiple slots; the cascade must terminate
+**only** contracts on the rebound slot, not all of the user's contracts.
+
+---
+
+## 7. Future hooks
+
+Not yet implemented; track here so callers know what's coming:
+
+- **Renter notification** — currently the renter learns of the termination
+  by observing their balance and the ended contract row. A push to chat /
+  fakechat ("您租用的 bot 因 owner 重綁已終止 — 押金已退還 + 補償 X e幣")
+  would close the loop. Owner-side notification likewise.
+- **Soft warning before rebind** — show owner the count of active contracts
+  that would be terminated and the pro-rata penalty they'd owe before they
+  confirm the rebind. Strictly preventive; the cascade itself stays the
+  source of truth.
+- **CI drift check** — every `entity.rebindCount = ...` site must be
+  followed by `pauseRentalListingsOnRebind` + `terminateRentalContractsOnRebind`.
+  A grep-based lint in CI would catch a future contributor adding a 9th
+  rebind path that forgets the cascade.

--- a/backend/docs/specs/rental.md
+++ b/backend/docs/specs/rental.md
@@ -1,0 +1,180 @@
+# rental — bot rental marketplace
+
+**Source:** `backend/rental.js`, `backend/rental_schema.sql`, `backend/rental-proxy.js`
+**Mounted at:** `/api/rental`
+**Wallet contract:** `backend/wallet.js` (held balance + ledger)
+
+This spec is the anchor doc for the rental subsystem. Every constant here is cited
+**by name + value** so a grep against this file finds the rule, and a grep against
+the source finds the implementation — both lead to the same line.
+
+---
+
+## 1. Constants
+
+| Name | Value | Defined at | Meaning |
+|------|-------|------------|---------|
+| `ECOIN_TO_MLI` | `1000` | `rental.js:41` | 1 e幣 = 1000 厘 (mirrors `wallet.js`) |
+| `DEPOSIT_TOKEN_MULTIPLIER` | `20` | `rental.js:44` | deposit = `rate_mli_per_ktoken × 20` (covers ~20k tokens of usage buffer) |
+| `MIN_RENTAL_MINUTES` | `30` | `rental.js:47` | reservation duration floor |
+| `MAX_RENTAL_MINUTES` | `7 × 24 × 60 = 10080` | `rental.js:48` | reservation duration ceiling (7 days) |
+| `INTERVIEW_PASS_SCORE` | `60` | `rental.js:51` | minimum interview score required to publish a listing |
+| `COOLDOWN_HOURS` | `24` | `rental.js:54` | same-renter / same-listing rental cooldown |
+| `INTERVIEW_RATE_LIMIT` | `3` | `rental.js:57` | interview attempts per listing per 7 days |
+
+Listings additionally store per-listing `min_rental_minutes` / `max_rental_minutes`
+that **must fall within** the global bounds; reservations are also validated against
+the listing-specific bounds (`rental.js:648-652`).
+
+---
+
+## 2. Status enums
+
+### 2.1 `LISTING_STATUSES` (`rental.js:59-65`)
+
+| Value | Meaning |
+|-------|---------|
+| `draft` | created, not yet interviewed |
+| `interview` | interview probe queued / in progress |
+| `listed` | passed interview (`score >= INTERVIEW_PASS_SCORE`), visible in marketplace |
+| `paused` | temporarily withdrawn by owner OR auto-paused on rebind (Phase 3) |
+| `delisted` | terminal; owner removed listing |
+
+### 2.2 `CONTRACT_STATUSES` (`rental.js:67-77`)
+
+| Value | Meaning |
+|-------|---------|
+| `reserved` | renter committed deposit; rental window not yet started |
+| `active` | rental in progress; usage charged from `held_mli` |
+| `suspended_insufficient_funds` | deposit emptied mid-window; renter can top up to resume |
+| `ended_normal` | terminal — full refund of remaining held |
+| `ended_early_by_renter` | terminal — 50% refund / 50% forfeit |
+| `ended_zero_balance` | terminal — deposit consumed; remainder (if any) returned |
+| `ended_disputed` | terminal — full refund pending dispute resolution |
+| `ended_violation` | terminal — 70% refund / 30% forfeit |
+| `ended_admin` | terminal — full refund (admin / cascade-driven termination) |
+
+Only the `reserved`, `active`, and `suspended_insufficient_funds` states allow
+`endRental` (`rental.js:775`); calling on terminal states throws
+`contract_already_ended`.
+
+---
+
+## 3. Deposit disposition matrix (`endRental`, `rental.js:752-895`)
+
+`actualHeldMli = min(wallets.held_mli, contract.deposit_mli)` — read inside the
+transaction so it reflects post-`chargeRentalUsage` reality, not the original
+deposit.
+
+| `endReason` | Refund (held → balance, renter) | Forfeit (split below) |
+|-------------|---------------------------------|------------------------|
+| `ended_normal` | `actualHeldMli` (100%) | 0 |
+| `ended_disputed` | `actualHeldMli` (100%) | 0 |
+| `ended_admin` | `actualHeldMli` (100%) | 0 |
+| `ended_early_by_renter` | `floor(actualHeldMli / 2)` (50%) | remainder (50%) |
+| `ended_violation` | `actualHeldMli − forfeit` (70%) | `floor(actualHeldMli × 0.3)` (30%) |
+| `ended_zero_balance` | `actualHeldMli` (whatever remains) | 0 |
+
+**Forfeit split** (`rental.js:856-859`, integer math; insurance fully inside
+platform's 15%):
+- `insuranceMli = floor(forfeit × 200 / 10000)` → **2%**
+- `platformGross = floor(forfeit × 1500 / 10000)` → **15%**
+- `platformNet = platformGross − insuranceMli` → **13%**
+- `ownerShare = forfeit − platformGross` → **85%**
+
+Insurance pool user id: `00000000-0000-0000-0000-000000000002`.
+Platform fee pool user id: `00000000-0000-0000-0000-000000000001`.
+
+**Idempotency keys** (one per contract per leg):
+- `rental-release:<contractId>`
+- `rental-forfeit:<contractId>`
+- `rental-forfeit-income:<contractId>`
+- `rental-forfeit-pfee:<contractId>`
+- `rental-forfeit-ins:<contractId>`
+
+A duplicate `endRental` call is therefore safe — `applyLedgerEntry` rejects
+idempotency-key collisions before mutating wallet rows.
+
+---
+
+## 4. Drift handling (rebind cascade)
+
+When a slot's entity is rebound to a different bot, all listings + active
+contracts attached to that slot become **drifted**: the row in
+`rental_contracts` / `bot_listings` still references the old `(device_id,
+entity_id)` pair, but the bot occupying that slot is now a different identity.
+
+The full cascade lives in `backend/docs/specs/rental-rebind-cascade.md` — this
+spec only covers the surface that callers grep for:
+
+| Phase | Helper | Behaviour |
+|-------|--------|-----------|
+| 1 | (none, schema-only) | every rebind bumps `entities.rebind_count` and stamps `last_rebind_at` |
+| 2 | `filterDriftedListings` (`rental.js:593-602`) | marketplace search hides any listing where `liveCount = entities.rebind_count > bound_rebind_count` (the snapshot taken when the listing was published) |
+| 3 | `pauseListingsOnRebind` | cascade: drifted listings auto-transition `listed → paused` so the marketplace search doesn't have to re-filter forever |
+| 4 | `terminateActiveContractsOnRebind` | cascade: every `reserved/active/suspended_insufficient_funds` contract on the slot ends as `ended_admin` (renter gets 100% deposit back), then the **owner** pays a pro-rata penalty `floor(deposit × remaining_ms / planned_ms)` to the renter, clamped to owner's available balance |
+
+**Why owner pays the pro-rata penalty:** Hank's 2026-04-25 1on1 Q1 ruling — "B 重綁屬於 owner 問題 所以虧要 owner 吃". The renter contracted bot X; the rebind replaces X with Y inside the slot, so the renter's lost rental window is on the owner.
+
+**Reserved-contract semantics:** `remainingMs / plannedMs = 1` because the rental
+hasn't started — full deposit's worth of pro-rata penalty applies (`rental.js:403-412`).
+
+**Shortfall behaviour:** `applyLedgerEntry` rejects negative balances. If the
+owner's balance is below the computed penalty, the helper clamps to
+`min(penalty, owner_balance)` and writes the residual as `shortfallMli` to a
+`serverLog` warn entry — it is **not** pursued further (no debt collection,
+no negative balance, no async retry).
+
+---
+
+## 5. Operations blocked on rental entities (`rental.js:966-1041`)
+
+When a bot is currently rented (any active contract on its `(device, entity)`
+slot), the renter — not the owner — is the de-facto operator. To prevent owner
+sabotage, the middleware blocks these operations at the API boundary:
+
+- entity rename / persona edit
+- vault key edit
+- entity delete
+- entity rebind (which would trigger Phase 4 cascade above; allowed only via admin path that consciously fires the cascade)
+- channel reconfiguration that would change the bot's identity
+
+Owner can still: pause listing, view dashboard, withdraw earnings.
+
+---
+
+## 6. Rate limiting
+
+- Interview attempts: `INTERVIEW_RATE_LIMIT = 3` per listing per rolling 7 days
+  (rental.js:57). Counted across all renters; an interview that ends in
+  `passed=false` still consumes a slot.
+- Same-renter cooldown: a renter cannot reserve the same listing again within
+  `COOLDOWN_HOURS = 24` of a previous contract end on that listing.
+
+---
+
+## 7. What this doc deliberately does NOT cover
+
+- **API shape** of the route handlers — see `/api/help` and JSDoc on the route
+  handlers in `rental.js`. This spec captures invariants and boundaries, not
+  request/response schemas.
+- **Wallet ledger types** — see `wallet.js` (and the future `wallet.md` spec
+  per the gap list in `INDEX.md`). This spec only references ledger types by
+  the names `endRental` actually writes: `DEPOSIT_RELEASE`, `DEPOSIT_FORFEIT`,
+  `RENTAL_INCOME`, `PLATFORM_FEE`.
+- **Bot interview probe set** — see `bot-interview.js` and `getProbeList`.
+- **Token metering during rentals** — see `rental-proxy.js` and
+  `chargeRentalUsage`.
+
+---
+
+## 8. Update discipline
+
+- When any constant value in §1 changes, update this file in the **same PR** as
+  the source change.
+- When a new contract status or listing status is added, update §2 and §3 (if
+  it has a refund disposition) in the same PR.
+- When the rebind cascade adds a new phase, update §4's table and link the
+  detailed spec.
+- CI does not yet enforce drift between code and spec — file a follow-up if
+  drift becomes a problem.


### PR DESCRIPTION
## Summary

Seeds the `backend/docs/specs/` directory with the first three anchor docs, addressing Hank's 2026-04-25 1on1 Q2 ("用 grep 理解 code 架構容易撞名，規範書當錨點"). No code changes — pure documentation.

- **`INDEX.md`** — 12-row subsystem coverage table + P0/P1/P2 gap list. Establishes the convention going forward: every new subsystem ships a `backend/docs/specs/<name>.md` alongside its implementation PR, citing constants by **name + value** so grep against doc and grep against code lead to the same line.
- **`rental.md`** — first sample spec. Captures invariants and boundaries (not API shape): all 7 numeric constants, both status enums, the full deposit disposition matrix from `endRental`, the 85/13/2 forfeit split, the drift surface, and the operations blocked on rental entities.
- **`rental-rebind-cascade.md`** — Phase 1-4 follow-through doc. Documents all 8 `index.js` wiring sites, the JOIN-through-`bot_listings` selection, pro-rata penalty math, owner-balance clamp + shortfall semantics, idempotency keys, per-contract error isolation, and the policy rationale (Hank's "B 重綁屬於 owner 問題 所以虧要 owner 吃").

## Why

Hank's pain point: searching code by symbol is unreliable when names collide across subsystems. A spec doc as anchor lets you start from the doc, find the rule, and grep the constant — both paths lead to the same line. INDEX.md also makes the gap list explicit so the next P0 cards (wallet / vault / channel-bridge) can be opened with clear scope.

## Test plan
- [x] `INDEX.md` references match real source files / paths
- [x] All constants cited in `rental.md` match `rental.js:41-57` exactly
- [x] Forfeit split math (85/13/2) verified against `rental.js:856-859`
- [x] All 8 cascade callsites listed in `rental-rebind-cascade.md` §3 match `grep terminateRentalContractsOnRebind backend/index.js`
- [x] Idempotency keys (`rebind-refund-debit:`, `rebind-refund-credit:`, `rental-release:`, etc.) match what `rental.js` actually writes
- [x] No code changes → no test runs needed; ESLint/Jest CI should pass on docs-only diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)