### PR TITLE
docs(specs): add channel-bridge.md — final P0 spec anchor

### DIFF
--- a/backend/docs/specs/INDEX.md
+++ b/backend/docs/specs/INDEX.md
@@ -13,7 +13,7 @@ Per Hank 2026-04-25 1on1 Q2: 用 grep 理解 code 架構容易撞名 — 規範�
 | 4 | kanban (mission v2) | `backend/kanban.js`, `backend/mission.js` | △ | repo-root [`docs/mission-v2-kanban-spec.md`](../../../docs/mission-v2-kanban-spec.md) — written before screenshot-review gate / cron 子卡; needs supplement |
 | 5 | vault — device_vars + encryptVars | `backend/index.js` (encryptVars / decryptVars), `backend/mission.js` (decryptVarsLocal) | ✅ | [`backend/docs/specs/vault.md`](vault.md) (encryption boundary, dual-auth, no-rental-leak rule, audit trail) |
 | 6 | official-bind / public-code | `backend/index.js` (officialBindingsCache, public_code_index), `backend/auth.js` | ❌ | borrow flow + free vs personal binding only documented in code paths |
-| 7 | channel-bridge (fakechat / web_chat) | `backend/index.js` (`/api/client/speak`, `/api/transform`, `/api/chat/history`), `bridge.ts` | ❌ | `bridge.ts` has inline comments; AVAILABLE TOOLS dashboard format only encoded in mission notify code |
+| 7 | channel-bridge (fakechat / web_chat) | `backend/index.js` (`/api/client/speak`, `/api/transform`, `/api/chat/history`), `bridge.ts` | ✅ | [`backend/docs/specs/channel-bridge.md`](channel-bridge.md) (3 endpoints, AVAILABLE TOOLS format, `{{KEY}}` interpolation sites, Hermes vs OpenClaw push templates, bridge.ts daemon role) |
 | 8 | mission-dashboard / notes / chat-history | `backend/mission.js`, `backend/index.js` (`/api/mission/dashboard`, `/api/chat/history`) | ❌ | endpoint shapes only in code |
 | 9 | publisher (X/Mastodon retired/Discord) | `backend/publisher*.js`, `backend/x-tweet*.js`, `backend/discord*.js` | △ | scattered; news-publishing-api 2026-03-15 doc covers only one path |
 | 10 | arena (browser interview / E2E test) | `backend/arena.js`, `backend/interview-arena.js` | ❌ | arena page_loaded protocol only in [memory](../../../docs/specs/) reference, not yet a backend spec |
@@ -25,7 +25,7 @@ Per Hank 2026-04-25 1on1 Q2: 用 grep 理解 code 架構容易撞名 — 規範�
 **P0 / blocks mind-map first layer:**
 1. ~~**wallet.md**~~ — ✅ shipped (see row #3). Ledger type matrix, balance/held invariants, idempotency-key registry, platform/insurance pool UUIDs.
 2. ~~**vault.md**~~ — ✅ shipped (see row #5). Encryption boundary, dual-auth model, no-`allowed_vars` rule now anchored in the repo.
-3. **channel-bridge.md** — fakechat ↔ web_chat ↔ AVAILABLE TOOLS dashboard contract. Drives every bot's runtime behavior; absence is why Hermes shipped broken i18n on 2026-04-25 (he didn't have a doc to cite).
+3. ~~**channel-bridge.md**~~ — ✅ shipped (see row #7). 3 endpoints, AVAILABLE TOOLS format, `{{KEY}}` interpolation sites, Hermes vs OpenClaw push templates, `bridge.ts` daemon — all anchored.
 
 **P1 / fills mind-map second layer:**
 4. **official-bind.md** — borrow vs personal vs free; unbind cascade (now Phase 1-4 documented separately); public-code allocator constraints.

--- a/backend/docs/specs/INDEX.md
+++ b/backend/docs/specs/INDEX.md
@@ -9,7 +9,7 @@ Per Hank 2026-04-25 1on1 Q2: 用 grep 理解 code 架構容易撞名 — 規範�
 |---|-----------|--------------|-------------|----------|
 | 1 | rental | `backend/rental.js`, `backend/rental_schema.sql`, `backend/rental-proxy.js` | ✅ | [`backend/docs/specs/rental.md`](rental.md) (this audit's sample) |
 | 2 | rental — rebind cascade Phase 1-4 | `backend/rental.js` (pause/terminate helpers), `backend/index.js` (8 callsites) | ✅ | [`backend/docs/specs/rental-rebind-cascade.md`](rental-rebind-cascade.md) (Phase 4 follow-through) |
-| 3 | wallet | `backend/wallet.js`, `backend/wallet_schema.sql` | ❌ | constants live in code (`LEDGER_TYPES`, `applyLedgerEntry`) — needs extraction |
+| 3 | wallet | `backend/wallet.js`, `backend/wallet_schema.sql` | ✅ | [`backend/docs/specs/wallet.md`](wallet.md) (units, ledger type matrix, balance/held invariants, idempotency-key registry, special accounts) |
 | 4 | kanban (mission v2) | `backend/kanban.js`, `backend/mission.js` | △ | repo-root [`docs/mission-v2-kanban-spec.md`](../../../docs/mission-v2-kanban-spec.md) — written before screenshot-review gate / cron 子卡; needs supplement |
 | 5 | vault — device_vars + encryptVars | `backend/index.js` (encryptVars / decryptVars), `backend/mission.js` (decryptVarsLocal) | ✅ | [`backend/docs/specs/vault.md`](vault.md) (encryption boundary, dual-auth, no-rental-leak rule, audit trail) |
 | 6 | official-bind / public-code | `backend/index.js` (officialBindingsCache, public_code_index), `backend/auth.js` | ❌ | borrow flow + free vs personal binding only documented in code paths |
@@ -23,7 +23,7 @@ Per Hank 2026-04-25 1on1 Q2: 用 grep 理解 code 架構容易撞名 — 規範�
 ## Gap list (priority order)
 
 **P0 / blocks mind-map first layer:**
-1. **wallet.md** — ledger type matrix + balance/held invariants + idempotency contract. Cited by every rental + topup card; absence makes "why does endRental return refund_mli + forfeit_mli but NOT credit owner directly" impossible to grep without reading source.
+1. ~~**wallet.md**~~ — ✅ shipped (see row #3). Ledger type matrix, balance/held invariants, idempotency-key registry, platform/insurance pool UUIDs.
 2. ~~**vault.md**~~ — ✅ shipped (see row #5). Encryption boundary, dual-auth model, no-`allowed_vars` rule now anchored in the repo.
 3. **channel-bridge.md** — fakechat ↔ web_chat ↔ AVAILABLE TOOLS dashboard contract. Drives every bot's runtime behavior; absence is why Hermes shipped broken i18n on 2026-04-25 (he didn't have a doc to cite).
 

--- a/backend/docs/specs/channel-bridge.md
+++ b/backend/docs/specs/channel-bridge.md
@@ -1,0 +1,253 @@
+# channel-bridge — speak / transform / chat-history + AVAILABLE TOOLS contract
+
+**Source:** `backend/index.js` (`/api/client/speak`, `/api/transform`, `/api/chat/history`, `getMissionApiHints`), `backend/channel-api.js` (callback register/push), `backend/kanban.js` (kanban_notify path), `backend/push-context.js` (mention block helper), `bridge.ts` (Mac-side daemon, this repo)
+
+**Mounted at:** `/api/client/speak`, `/api/transform`, `/api/chat/history`, plus the channel-api router under `/api/channel/*`.
+
+The channel-bridge is the contract every bot's runtime depends on:
+- how an **owner-side message** lands in a bot's inbox (`/api/client/speak`),
+- how a **bot's reply** lands back in chat history and out to other entities (`/api/transform`),
+- how either side **reads** the conversation later (`/api/chat/history`),
+- and the **AVAILABLE TOOLS — Mission Dashboard / Kanban Board** block that's appended to every push so the receiving LLM always sees the curl recipes.
+
+This spec exists because the format was previously only encoded inside `getMissionApiHints` + scattered push paths — the 2026-04-25 Hermes broken-i18n incident traced back to him not having a single doc to cite. Constants and string templates are referenced **by name + line** so a grep against the doc and a grep against the code lead to the same place.
+
+---
+
+## 1. The three core endpoints
+
+### 1.1 `POST /api/client/speak` — owner / channel → bot
+
+Defined at `index.js:8043`. Body shape:
+
+| Field | Required | Notes |
+|-------|----------|-------|
+| `deviceId` | ✅ | the speaker's device |
+| `deviceSecret` | optional | when present + matches + device is in `developerDeviceIds` set → skips Gatekeeper First Lock (`index.js:8074-8078`) |
+| `entityId` | ✅ | `Number`, `Number[]`, or string `"all"` (broadcast to every bound entity) — see `index.js:8253-8275` |
+| `text` | ✅ | message body; `<@code>` / `@all` mentions are parsed by `mentionParser` (`index.js:8186`) |
+| `source` | default `"client"` | free-form label; ends up in `chat_messages.source` |
+| `mediaType` / `mediaUrl` | optional | `photo` / `voice` / `video` / `file` |
+| `attachments[]` | optional, max 10 | `{fileId, filename, size, mimeType}` — fileId-based, never raw R2 URLs (security: presigned URL = bearer token, must not leak via transcript — see `index.js:8050-8067`) |
+
+**Auth model:** none required for the typical channel push (channel plugin owns the device). `deviceSecret` only buys you the **developer exemption** from Gatekeeper First Lock; without it free-bot-targeted devices that are blocked or that send malicious tokens get a `403 GATEKEEPER_BLOCKED` / `GATEKEEPER_BLOCKED_MESSAGE` (`index.js:8117-8177`).
+
+**Daily limit:** `DAILY_LIMIT = 15` (`index.js:8082`) for non-premium devices. DB enforcement first, in-memory fallback if the DB is down (`index.js:8095-8113`).
+
+**Where the message lands:**
+1. `chat_messages` row via `saveChatMessage` per target entity (`index.js:8350`) — **stores raw `text` with `{{KEY}}` tokens unexpanded** (privacy + replay safety, see §4).
+2. Pushed to the bot via `unifiedPush` (channel binding) or `pushToBot` (webhook binding) at `index.js:8360-8442`. The push body is built from `pushText`, which **is** the expanded version.
+3. `entity.messageQueue` gets the same `messageObj` (`index.js:8348`) — this is the in-memory queue Hermes/OpenClaw bots drain on their next tick.
+
+**Idempotency:** none at this endpoint. Duplicate POSTs duplicate chat rows + duplicate pushes. Channel plugins (fakechat / web_chat) dedupe on their side.
+
+### 1.2 `POST /api/transform` — bot → owner / other entities
+
+Defined at `index.js:5918`. Accepts both JSON and `multipart/form-data` (the latter for inline file uploads to R2 — see `index.js:6038-6077`).
+
+**Required body:**
+- `deviceId`
+- `botSecret` — verified against `device.entities[entityId].botSecret` via `safeEqual`. If `entityId` is omitted, the server **auto-detects** the entity from the secret (`index.js:6004-6013`); if both are sent but mismatched, the server **auto-corrects** to the secret's entity and logs a warning (`index.js:6020-6030`).
+
+**Optional body:**
+
+| Field | Notes |
+|-------|-------|
+| `message` | the text body. `[SILENT]` (case-insensitive, exact line) is a sentinel — `index.js:8133` skips chat persistence so internal signals don't show up in chat. |
+| `name`, `character`, `state`, `parts` | mutate the entity record in-place (`index.js:6080-6116`) |
+| `speakTo` | `string[]` of `publicCode` or `entityId`. **Self-targets are stripped** at `index.js:6123-6129` so a bot accidentally self-targeting still saves to chat history. |
+| `broadcast` | boolean — push to every other bound entity |
+| `targetDeviceId` | cross-device speak (e.g. owner replying back to a renter device) |
+| `card` | rich `{ask_id, buttons[]}` payload, max 10 buttons, styles `primary`/`secondary`/`danger` (`index.js:5946-5982`) |
+| `attachments[]` | same shape as `/api/client/speak`; max 10 |
+
+**Auth model:** `botSecret` ↔ entity match via `safeEqual`. The endpoint is the **only** way a bot identifies itself to the server — there is no JWT path here. (Owner-driven cross-device speak uses a separate path at `index.js:10661+` with its own `vaultTokenReXD` interpolation.)
+
+**Gatekeeper Second Lock** (free bots only, `index.js:6090-6104`): scans `message` via `gatekeeper.detectAndMaskLeaks`; matched leaks are masked in-place before persistence and push.
+
+### 1.3 `GET /api/chat/history` — read
+
+Defined at `index.js:16570`. Query: `deviceId` + (`deviceSecret` **or** `botSecret`), plus optional `limit` (default 500), `before`, `since`.
+
+**Auth fan-out** (`index.js:16585-16615`):
+1. `deviceSecret` matches → owner mode, sees all entities' messages.
+2. `botSecret` matches a bound entity → **bot mode, scoped to that entity** via the regex predicate `m.source ~ '(->|,){eid}(,|$)' OR m.entity_id = {eid}` (`index.js:16630-16634`). The regex is the fix for the multi-recipient broadcast bug — naive `LIKE '%->{eid}%'` only matched the *first* recipient.
+3. JWT cookie fallback (`eclaw_session`, verified with `JWT_SECRET_FALLBACK`).
+
+**Always returned in chronological order** despite the underlying `ORDER BY created_at DESC LIMIT N` — the rows are reversed on the way out (`index.js:16652`).
+
+`/api/chat/history-by-code` (`index.js:16746`) and `/api/chat/search` (`index.js:16668`) are sibling endpoints — search is documented separately under the chat-embedding subsystem.
+
+---
+
+## 2. fakechat vs web_chat — channel sources
+
+EClaw treats every bot push as **transport-agnostic**: the same `unifiedPush` middleware runs whether the binding is `channel` (fakechat / Discord-via-channel-plugin / arbitrary plugin) or `webhook` (legacy direct URL).
+
+| Source | `bindingType` | Inbound path | Outbound path |
+|--------|---------------|--------------|---------------|
+| **fakechat** (this repo's `bridge.ts` daemon) | `channel` | bridge ↔ fakechat WS `ws://localhost:8787/ws` (`bridge.ts:25`) → `/api/client/speak` over HTTPS | bot calls `reply` MCP tool → fakechat WS → bridge intercepts → POST `/api/transform` |
+| **web_chat** (`chat.html` browser UI) | `channel` (most) or owner-direct | browser WS → backend `/api/client/speak` | server pushes via `pushToChannelCallback` → browser WS |
+| **kanban_notify** | n/a (server-internal) | `kanban.js:280-325` directly invokes `saveChatMessage` + `pushToChannelCallback` / `pushToBot` | bot replies via `/api/transform` like any other inbound message |
+
+**The MANDATORY reply contract** (channel-mode only, encoded in the fakechat MCP server instructions and reproduced verbatim here so `grep doc` finds it):
+
+> Messages from `<channel source="fakechat">` tags are from REAL END USERS on an external chat platform. They CANNOT see your transcript, terminal output, or any text you write directly. The ONLY way to communicate back is by calling the `reply` tool.
+
+This is **not** advisory. Without the `reply` call the user sees nothing — the transcript is invisible. The bridge enforces this with the **reply enforcer** (`bridge.ts:64`, `REPLY_TIMEOUT_S = 120`): if the bot is busy for >120 s after a human message and still hasn't called `reply`, the bridge injects a reminder. The **auto-wake** path (`bridge.ts:77-81`) handles the case where Claude Code's reactive-agent model leaves a forwarded message sitting idle — every `AUTO_WAKE_POLL_S = 5` it polls for true-idle, then `tmux send-keys` a nudge prompt.
+
+**i18n auto-detect:** the receiving bot detects the user's language from the message and replies in the same language. There is no server-side translation; this lives in the bot's prompt contract. The 2026-04-25 Hermes broken-i18n incident was Hermes shipping i18n across `backend/public/shared/i18n.js` without a doc to cite for which keys were canonical — that's now fixed via `feedback_i18n_dispatch_must_pin_path_and_keys.md` + Hermes-owned i18n PRs.
+
+---
+
+## 3. AVAILABLE TOOLS — Mission Dashboard / Kanban Board
+
+Every bot push gets a curl-recipe block appended so the receiving LLM always has the kanban + mission API signatures in context. The block is built by `getMissionApiHints(apiBase, deviceId, entityId, botSecret)` at **`index.js:13885-13902`**.
+
+**Exact format** (template literal with line breaks shown explicit):
+
+```
+[AVAILABLE TOOLS — Mission Dashboard]
+Current Taiwan Time: YYYY-MM-DD HH:mm (UTC+8)
+Read tasks/notes/rules/skills: exec: curl -s "{apiBase}/api/mission/dashboard?deviceId={deviceId}&botSecret={botSecret}&entityId={entityId}"
+Read notes: exec: curl -s "{apiBase}/api/mission/notes?..."
+Read chat history: exec: curl -s "{apiBase}/api/chat/history?...&limit=100"
+Create kanban card: exec: curl -s -X POST "{apiBase}/api/mission/card" -H "Content-Type: application/json" -d '{...,"title":"TASK_TITLE","status":"todo"}'
+Add note: exec: curl -s -X POST "{apiBase}/api/mission/note/add" -H "Content-Type: application/json" -d '{...,"title":"TITLE","content":"CONTENT"}'
+
+[AVAILABLE TOOLS — Kanban Board]
+Read board: exec: curl -s "{apiBase}/api/mission/cards?..."
+Move card: exec: curl -s -X POST "{apiBase}/api/mission/card/CARD_ID/move" ... '{"newStatus":"STATUS"}'
+Add comment: exec: curl -s -X POST "{apiBase}/api/mission/card/CARD_ID/comment" ... '{"text":"YOUR_COMMENT"}'
+Disable schedule: exec: curl -s -X PUT "{apiBase}/api/mission/card/CARD_ID/schedule" ... '{"enabled":false}'
+Enable schedule: exec: curl -s -X PUT "{apiBase}/api/mission/card/CARD_ID/schedule" ... '{"enabled":true,"type":"recurring","cronExpression":"*/20 * * * *","timezone":"Asia/Taipei"}'
+
+Discover more APIs: exec: curl -s "{apiBase}/api/help?intent=YOUR_INTENT&..."
+```
+
+The TW-time line is computed per push from `Asia/Taipei` so the bot has a clock without needing to call any other endpoint.
+
+**Where it's appended** (every push path that builds a webhook body — channel pushes get it via `unifiedPush` middleware too):
+
+| Callsite | Context |
+|----------|---------|
+| `index.js:2090`, `2077` | a2a / cross-device speak |
+| `index.js:5811`, `5855` | `/api/transform` outbound to other entities |
+| `index.js:8422` | `/api/client/speak` webhook path (the most common) |
+| `index.js:8700`, `8745` | `speakTo` per-target loop |
+| `index.js:9099`, `9139` | broadcast loop |
+| `index.js:10742`, `10786` | cross-device speak |
+| `index.js:11065`, `11116` | rental-bot push |
+| `kanban.js:306` (via injected dependency) | kanban_notify pushes (status changes, scheduled cron triggers) |
+
+The `[Local Variables available: ...]` block is a **separate** insert from `unifiedPush` middleware (`index.js:13947-13954`), appended only when:
+- `db.getDeviceVarsMeta(deviceId)` returns a row,
+- `is_locked === false`, and
+- `var_keys.length > 0`.
+
+It exposes the **list of vault keys** (not values), plus the curl recipe to fetch them via `/api/device-vars`. This is how a rental bot discovers it has access to `OPENAI_KEY` / `VOYAGE_KEY` / etc. without the server leaking them inline. The vault payload itself is **never** decrypted into the AVAILABLE TOOLS block — see `vault.md` §3.
+
+The `[IDENTITY_SETUP_REQUIRED]` block (`index.js:13909-13923`) is appended only when `entity.identity` is null, and **at most 3 times per session** (`entity._identityHintCount`).
+
+---
+
+## 4. `{{KEY}}` variable interpolation
+
+`{{KEY_NAME}}` placeholders are resolved at push time, never stored expanded. There are **four** interpolation sites — three in the channel-bridge path (the focus of this spec), one in mission dashboard rendering (already documented in `vault.md` §7).
+
+| Site | Path | Direction | What gets stored |
+|------|------|-----------|------------------|
+| `index.js:8238` (`vaultTokenRe`) | `/api/client/speak` push enrichment | owner → bot | `chat_messages.text` keeps the raw `{{KEY}}` form; only `pushText` (the bot's webhook body) is expanded |
+| `index.js:10661` (`vaultTokenReXD`) | cross-device speak | entity → entity | same: `text` raw, `pushText` expanded |
+| `index.js:15778` | `getDeviceVarForEmbedding` | server → embedding API (Voyage / OpenAI) | n/a — used only to fetch BYO embedding key, never stored |
+| `mission.js:83` (`applyVarSubstitution`) | `/api/mission/dashboard` render | server → bot | dashboard fields (`skills.steps`, `rules.description`, `souls.content`) — see `vault.md` §7 |
+
+Every site checks `varsRow.is_locked` before decrypting and silently leaves tokens unexpanded if the vault is locked or the key is missing (`index.js:8244-8246`, `10667-10669`). **The raw `{{KEY}}` form in `chat_messages.text` is the contract** — it lets owners replay/copy/forward messages without leaking secrets, and it lets the embedding pipeline index the placeholder rather than the value.
+
+**If you add a new server-side `{{KEY}}` interpolation site, update both this section and `vault.md` §7 in the same PR.**
+
+---
+
+## 5. Hermes engine vs OpenClaw engine
+
+Two transport models share the same channel-bridge:
+
+**OpenClaw engine** (`Mac_E` #3, `LOBSTER` #2, this assistant's #2): bot lives behind a webhook URL. EClaw pushes via `pushToBot` at `index.js:8400-8432`, body is the **instruction-first format** with a pre-filled curl template:
+
+```
+[ACTION REQUIRED] You MUST use exec tool with curl to call the API below.
+Your text reply is DISCARDED and the user will NEVER see it.
+Run this command to reply (replace YOUR_REPLY_HERE with your response):
+exec: curl -s -X POST "{apiBase}/api/transform" ... '{"message":"YOUR_REPLY_HERE"}'
+
+To BROADCAST to ALL other entities (use ONLY when user asks to broadcast):
+exec: curl -s -X POST "{apiBase}/api/transform" ... '{"broadcast":true}'
+
+[BROADCAST_RECIPIENTS] (only on multi-target)
+[MESSAGE] Device {deviceId} Entity {eId}
+From: {source}
+Content: {pushText}
+[Attachment: ...]   (optional)
+[AVAILABLE TOOLS — ...]  (always)
+[IDENTITY_SETUP_REQUIRED] (≤3× when no identity)
+[MENTIONS]              (when @-tags present)
+```
+
+The "your text reply is DISCARDED" line is intentional: OpenClaw bots are built on Claude Code, which would otherwise reply via terminal text the user can't see. Forcing the curl path is the contract.
+
+**Hermes engine** (`Hermes` #5): bot is a separate service with its own callback URL registered via `/api/channel/register` (`channel-api.js:329`). Outbound pushes go through `pushToChannelCallback` (`channel-api.js:1099`) which formats for Hermes's expected payload shape. Hermes's reply still routes back through `/api/transform` — the engine difference is **inbound formatting**, not the reply contract.
+
+**Discord** (legacy webhook): `index.js:8385-8398` short-circuits to a `**source**: text` format with embeds for media. Discord bots don't get the AVAILABLE TOOLS block (the bot is the Discord webhook target itself, not a Claude-driven LLM that needs API recipes).
+
+---
+
+## 6. `bridge.ts` — fakechat-side daemon
+
+This repo's `bridge.ts` is the bridge between the **EClaw webhook** and the **fakechat MCP plugin**. It runs as a long-lived `bun` process owned by the operator's Mac (this assistant's #2).
+
+| Constant | Default | Purpose |
+|----------|---------|---------|
+| `WEBHOOK_PORT` | `18800` | EClaw POSTs `/webhook` here on each push |
+| `FAKECHAT_WS` | `ws://localhost:8787/ws` | fakechat web UI WS the bridge subscribes to |
+| `API_BASE` | `https://eclawbot.com` | EClaw production base for outbound replies |
+| `WATCHDOG_TIMEOUT_S` | `30` | reply timeout for `/ask` PreToolUse hook |
+| `REPLY_TIMEOUT_S` | `120` | enforcer threshold — inject reminder if Claude busy >120 s without `reply` |
+| `AUTO_WAKE_DELAY_S` / `_POLL_S` / `_MAX_WAIT_S` / `_COOLDOWN_S` | `10` / `5` / `300` / `60` | auto-wake the reactive Claude Code session via `tmux send-keys` |
+| `SELF_CHECK_MIN` | `30` | re-POST `/api/channel/register` every 30 min — guards against silent callback-token expiry (2026-04-23 9-hour outage post-mortem) |
+| `FORWARD_KANBAN` | `true` | forward kanban_notify messages too (opt-out only; root-fix for 2026-04-21 was the context monitor + reply enforcer, not filtering) |
+
+**Inbound flow:**
+1. EClaw POST `/webhook` → bridge writes to fakechat upload endpoint → fakechat triggers MCP notification → Claude Code receives `<channel source="fakechat">` tag.
+2. Bridge tracks `lastDeviceId` / `lastEntityId` / `botSecret` from the inbound payload (`bridge.ts:30-32`) so reply routing knows where to forward.
+3. Bridge starts the auto-wake timer; if Claude doesn't `reply` within `REPLY_TIMEOUT_S`, the enforcer fires.
+
+**Outbound flow:**
+1. Claude calls `reply` MCP tool → fakechat WS broadcasts `{from: "assistant", text}` → bridge sees it on its WS subscription (`bridge.ts:183-208`).
+2. Bridge dedupes by fakechat message id (`forwardedMsgIds` map, 5 s TTL — `bridge.ts:136-146`).
+3. Bridge POSTs `/api/transform` with the cached `deviceId/entityId/botSecret`.
+4. On success, all watchdog state clears.
+
+**Out of scope for this spec:** the `stuck_prompt` recovery logic and `/auto_approve` toggle — those are documented in the bridge's own README + the 2026-04-25 fix commits (`067fc5b`, `7642016`).
+
+---
+
+## 7. What this doc deliberately does NOT cover
+
+- **Endpoint-level rate limits / quotas** beyond `DAILY_LIMIT = 15` — see `subscriptionModule.enforceUsageLimit` (`index.js:8083`) and the `subscription` subsystem when its spec ships.
+- **Mention parsing** internals (`<@code>`, `@all`, cross-device block check) — lives in `mentionParser` + `pushContext.buildMentionsBlock`. The channel-bridge consumes them but does not own the syntax.
+- **Gatekeeper detection rules** — `gatekeeper.detectMaliciousMessage` / `detectAndMaskLeaks` belong to that subsystem's spec (P1 gap, see `INDEX.md`).
+- **Vault encryption / `is_locked` semantics** — see `vault.md`. This spec only references the read interface.
+- **`/api/chat/search` semantic vs keyword fallback** — chat-embedding subsystem.
+- **R2 file upload / signed-URL TTL** — `files.js`. This spec only documents the `attachments[]` validation + the "no raw URLs in message text" rule.
+- **`bridge.ts` stuck_prompt recovery + auto-resolution** — bridge README + commit history.
+
+---
+
+## 8. Update discipline
+
+- New `getMissionApiHints` line → update §3 verbatim (the format is the contract).
+- New server-side `{{KEY}}` interpolation site → update §4 **and** `vault.md` §7 in the same PR.
+- New `bridge.ts` env var that affects the inbound/outbound contract → update §6 table.
+- New auth path on `/api/chat/history` (e.g. service-account token) → update §1.3 fan-out list.
+- New channel binding type beyond `channel` / `webhook` → update §2 source table + §5 engine list.
+- Changing the "your text reply is DISCARDED" sentence in the OpenClaw push template → update §5; this string is load-bearing for Claude-Code-based bots.

--- a/backend/docs/specs/wallet.md
+++ b/backend/docs/specs/wallet.md
@@ -1,0 +1,314 @@
+# wallet — e-coin balance, ledger, and top-up
+
+**Source:** `backend/wallet.js`, `backend/wallet_schema.sql`
+**Mounted at:** `/api/wallet`
+**Callers (cross-module):** `backend/rental.js`, `backend/rental-proxy.js`, `backend/invite.js`, `backend/subscription.js`
+
+The wallet is the e-coin spine: every monetary mutation in EClaw flows
+through `applyLedgerEntry` and lands in the append-only `wallet_ledger`
+table. This spec captures the unit system, the ledger type matrix, the
+balance/held invariants, the idempotency contract, and the special
+accounts. Constants are cited **by name + value** so a grep against this
+doc and a grep against the code lead to the same line.
+
+---
+
+## 1. Units & constants
+
+| Name | Value | Defined at | Meaning |
+|------|-------|------------|---------|
+| `ECOIN_TO_MLI` | `1000` | `wallet.js:39` | 1 e幣 = 1000 厘 (mli) |
+| `USD_TO_MLI` | `3_000_000` | `wallet.js:36` | 1 USD → 3,000 e幣 |
+| Exchange rate | 1 TWD = 100 e幣 = 100,000 厘 | `wallet_schema.sql:13` | hard-coded, no FX feed |
+| `PLATFORM_FEE_BPS` | `1500` | `wallet.js:42` | platform commission = 15% |
+| `INSURANCE_POOL_BPS` | `200` | `wallet.js:45` | of the 15% above, 2% goes to insurance |
+| `PLATFORM_WALLET_USER_ID` | `00000000-0000-0000-0000-000000000001` | `wallet.js:48` | virtual user receiving 13% net platform fee |
+| `INSURANCE_POOL_USER_ID` | `00000000-0000-0000-0000-000000000002` | `wallet.js:49` | virtual user receiving 2% insurance |
+| `GOOGLE_PACKAGE_NAME` | env `GOOGLE_PLAY_PACKAGE` or `'com.hank.clawlive'` | `wallet.js:52` | androidpublisher v3 package name |
+| `GOOGLE_TOKEN_CACHE_MS` | `55 × 60 × 1000` (55 min) | `wallet.js:54` | OAuth access-token cache TTL (under Google's 3600s) |
+
+**Mli, not e幣, is the canonical unit.** Every column, every API
+parameter, every ledger row is in mli. `mliToEcoin(mli)` is for display
+only — never store the converted value.
+
+There is **no `MIN_TOPUP`** and **no `MAX_BALANCE`** constant. The floor
+is implicit in the smallest topup tier (`ec.topup.small` = 1 USD = 3,000
+e幣). The ceiling is `BIGINT` overflow at the SQL layer; no application
+ceiling is enforced.
+
+---
+
+## 2. Top-up tier catalog (`TOPUP_TIERS`, `wallet.js:89-115`)
+
+`Object.freeze`'d at module load — pricing changes require a code change
++ deploy.
+
+| Product ID | Price (USD) | Base e幣 | Bonus | Total e幣 | Bonus % |
+|------------|------------:|--------:|------:|----------:|--------:|
+| `ec.topup.small` | 1 | 3,000 | 0 | 3,000 | 0% |
+| `ec.topup.starter` | 3 | 9,000 | 450 | 9,450 | +5% |
+| `ec.topup.standard` | 5 | 15,000 | 1,200 | 16,200 | +8% |
+| `ec.topup.advanced` | 10 | 30,000 | 3,600 | 33,600 | +12% |
+| `ec.topup.premium` | 20 | 60,000 | 9,000 | 69,000 | +15% |
+
+The same product IDs are wired to Google Play (Android Path B) and
+Apple IAP (iOS); the tier catalog is the single source of truth for
+both verifiers.
+
+---
+
+## 3. Ledger type matrix (`LEDGER_TYPES`, `wallet.js:66-80`)
+
+Every value here is one of the 13 enum strings stored in
+`wallet_ledger.type`. Schema mirror at `wallet_schema.sql:51-54`. **Adding
+a value requires touching both files in the same PR** + this matrix.
+
+| Ledger type | Const | Caller | balance Δ | held Δ | Idempotency-key prefix | Notes |
+|-------------|-------|--------|----------:|-------:|------------------------|-------|
+| `topup` | `TOPUP` | `wallet.js` `markTopupPaid` (`:622`), `creditTopup` (`:406`) | + | 0 | `topup:<orderId>` (`wallet.js:649`) | credited only after Google/Apple verify |
+| `subscription_grant` | `SUBSCRIPTION_GRANT` | `wallet.js` `grantSubscriptionEcoin` (`:426`) | + | 0 | `sub-grant:<userId>:<planId>:<YYYY-MM>` (`wallet.js:429`) | one grant per user per plan per month |
+| `signup_bonus` | `SIGNUP_BONUS` | (reserved — no current caller) | + | 0 | (caller-defined) | enum present for future use |
+| `referral_bonus` | `REFERRAL_BONUS` | `invite.js:178,186` (inviter + invitee legs) | + | 0 | `invite-inviter:<code>:<inviteeUserId>:<ts>`, `invite-invitee:<code>:<inviteeUserId>:<ts>` | two ledger rows per successful invite |
+| `deposit_hold` | `DEPOSIT_HOLD` | `wallet.js` `holdDeposit` (`:500`) — used by `rental.js:734` | − | + | `rental-hold:<contractId>` | renter freezes deposit on rental start |
+| `deposit_release` | `DEPOSIT_RELEASE` | `wallet.js` `releaseDeposit` (`:518`) — used by `rental.js:837` | + | − | `rental-release:<contractId>` | full or partial refund on rental end |
+| `deposit_forfeit` | `DEPOSIT_FORFEIT` | `wallet.js` `forfeitDeposit` (`:538`) — used by `rental.js:853` | 0 | − | `rental-forfeit:<contractId>` | held leaves renter; counterparty credits are separate ledger rows |
+| `rental_income` | `RENTAL_INCOME` | `rental-proxy.js:234` (token metering, post-fee net) | + | 0 | `<contractId>:<chunk>:income` (`rental-proxy.js:234`) | owner receives net of token charge; written to `pending_income_mli` (T+24h hold) |
+| `rental_spend` | `RENTAL_SPEND` | `rental-proxy.js:187` (token metering, renter side) | − | 0 | `<contractId>:<chunk>:spend`, `<...>:dep-deduct` for held leg | renter is debited per token chunk |
+| `platform_fee` | `PLATFORM_FEE` | `rental-proxy.js:246` (15% per token charge) + `rental.js:880` (forfeit-pfee) | + (to platform pool) | 0 | `<contractId>:<chunk>:pfee`, `rental-forfeit-pfee:<contractId>` | gross fee includes the 2% insurance share |
+| `refund` | `REFUND` | (reserved — used by tests + admin paths) | + | 0 | (caller-defined) | distinct from `deposit_release`; explicit refund of paid topups |
+| `admin_adjust` | `ADMIN_ADJUST` | `wallet.js` `adminAdjust` (`:556`) — `/api/wallet/admin/grant` | ± | 0 | `admin-grant:<adminId>:<ts>:<rand>` (`wallet.js:1472`) | always audited via `serverLog warn` |
+| `withdraw` | `WITHDRAW` | (reserved — no current caller) | − | 0 | (caller-defined) | bank/payment-processor withdraw, not yet wired |
+
+**Forfeit's three counterparty legs** (the rental-end "violation" path,
+`rental.js:856-895`) are written as separate ledger rows on the platform
++ insurance + owner-income wallets:
+
+| Counterparty | Ledger type | Idempotency-key | Driven by |
+|--------------|-------------|-----------------|-----------|
+| renter | `deposit_forfeit` | `rental-forfeit:<contractId>` | held −forfeit |
+| owner | `rental_income` | `rental-forfeit-income:<contractId>` | balance +85% × forfeit |
+| platform pool | `platform_fee` | `rental-forfeit-pfee:<contractId>` | balance +13% (net of insurance) |
+| insurance pool | `platform_fee` | `rental-forfeit-ins:<contractId>` | balance +2% |
+
+Five distinct idempotency keys per `endRental` call → one duplicate retry
+yields zero net mutation across all five rows.
+
+**Rebind cascade refund** (`rental.js:450-461`, Phase 4 of the rebind
+cascade — `rental-rebind-cascade.md`):
+
+| Leg | Ledger type | Idempotency-key |
+|-----|-------------|-----------------|
+| owner debit (pro-rata penalty) | `admin_adjust` | `rebind-refund-debit:<contractId>` |
+| renter credit (matching) | `admin_adjust` | `rebind-refund-credit:<contractId>` |
+
+---
+
+## 4. Balance / held invariants (`applyLedgerEntry`, `wallet.js:281-374`)
+
+Every successful ledger write upholds these invariants. They are enforced
+twice — application logic in `applyLedgerEntry`, and DB `CHECK`
+constraints (`wallet_schema.sql:32-33`) as defence-in-depth.
+
+1. **`balance_mli >= 0`** at all times. `applyLedgerEntry` throws
+   `insufficient_balance` (`wallet.js:328`) before writing; CHECK
+   constraint catches any code path that bypasses the helper.
+2. **`held_mli >= 0`** at all times. Throws `insufficient_held`
+   (`wallet.js:329`); CHECK constraint mirrors.
+3. **`held_mli` only mutates via `deposit_hold` / `deposit_release` /
+   `deposit_forfeit`** — every other ledger type passes `heldDelta: 0`.
+   Grep `held_mli` outside these three sites and you should find only
+   reads / reconciliation.
+4. **`pending_income_mli` is NOT in the ledger.** Rental income lives in
+   the dedicated column for T+24h settlement (`wallet_schema.sql:42-44`,
+   `rental-proxy.js:221`); the `income-release` daily cron sweeps it into
+   `balance_mli` via `applyLedgerEntry({ type: 'rental_income',
+   idempotencyKey: 'income-release:<userId>:<ts>' })` (`rental-proxy.js:425`).
+5. **Wallet row is locked `FOR UPDATE`** inside the same transaction
+   (`wallet.js:316-320`). All cross-module callers (`rental.js`,
+   `rental-proxy.js`) use `withTransaction` from this module so the lock
+   covers the whole business operation, not just the ledger insert.
+6. **Lifetime counters are monotonic.** `lifetime_earned_mli` increases
+   only on positive `balanceDelta`; `lifetime_spent_mli` increases only on
+   negative. They are never decreased (`wallet.js:332-333,339-340`).
+7. **No direct UPDATE to `wallets` outside `applyLedgerEntry`**, with one
+   sanctioned exception: `pending_income_mli` mutations in
+   `rental-proxy.js:221,413` (which are still bracketed by
+   `applyLedgerEntry` calls for the moves into and out of the bucket).
+   Adding any other direct write is a bug.
+
+`reconcileBalances` (`wallet.js:695-728`) verifies invariants 1-2 + 6 by
+re-summing the ledger and comparing to the cached aggregates. Empty
+discrepancy list = invariants hold. The admin endpoint
+`GET /api/wallet/admin/reconcile` runs this on demand; any drift logs
+`serverLog error wallet "reconcile FAIL"` (`wallet.js:1456`).
+
+---
+
+## 5. Idempotency contract
+
+The single load-bearing rule of the wallet:
+
+> **Every `applyLedgerEntry` call MUST supply an `idempotencyKey`.**
+> `wallet_ledger.idempotency_key` is `UNIQUE NOT NULL`
+> (`wallet_schema.sql:67`). A duplicate key returns the existing row
+> with `deduped: true` and **does not mutate** the wallet
+> (`wallet.js:301-311`).
+
+This means every caller can retry safely after a network blip, a
+container restart, or a duplicate webhook.
+
+### 5.1 Key length & shape
+
+`assertIdempotencyKey` (`wallet.js:158-162`) requires `4 ≤ length ≤ 128`.
+Convention: `<scope>:<id>[:<leg>]`, lower-snake, colon-separated.
+
+### 5.2 Prefix registry
+
+| Prefix | Owner | Shape | Notes |
+|--------|-------|-------|-------|
+| `topup:` | wallet.js | `topup:<orderId>` | one row per topup_order |
+| `sub-grant:` | wallet.js | `sub-grant:<userId>:<planId>:<YYYY-MM>` | one grant per user/plan/month |
+| `admin-grant:` | wallet.js | `admin-grant:<adminId>:<ts>:<rand>` | random suffix because admin can repeat-grant |
+| `rental-hold:` | rental.js | `rental-hold:<contractId>` | one hold per contract |
+| `rental-release:` | rental.js | `rental-release:<contractId>` | one release per contract |
+| `rental-forfeit:` | rental.js | `rental-forfeit:<contractId>` | renter held debit |
+| `rental-forfeit-income:` | rental.js | `rental-forfeit-income:<contractId>` | owner credit (85%) |
+| `rental-forfeit-pfee:` | rental.js | `rental-forfeit-pfee:<contractId>` | platform fee (13%) |
+| `rental-forfeit-ins:` | rental.js | `rental-forfeit-ins:<contractId>` | insurance pool (2%) |
+| `rebind-refund-debit:` | rental.js | `rebind-refund-debit:<contractId>` | owner debit (Phase 4) |
+| `rebind-refund-credit:` | rental.js | `rebind-refund-credit:<contractId>` | renter credit (Phase 4) |
+| `<contractId>:<chunk>:spend` | rental-proxy.js | per token charge | renter debit |
+| `<contractId>:<chunk>:dep-deduct` | rental-proxy.js | per token charge | held debit (when balance exhausts) |
+| `<contractId>:<chunk>:income` | rental-proxy.js | per token charge | owner pending_income credit |
+| `<contractId>:<chunk>:pfee` | rental-proxy.js | per token charge | platform fee leg |
+| `<contractId>:<chunk>:ins` | rental-proxy.js | per token charge | insurance pool leg |
+| `income-release:<userId>:<ts>` | rental-proxy.js | per sweep run | T+24h pending_income release |
+| `invite-inviter:<code>:<inviteeUserId>:<ts>` | invite.js | inviter bonus | |
+| `invite-invitee:<code>:<inviteeUserId>:<ts>` | invite.js | invitee bonus | |
+| `<base>:debit` / `<base>:credit` | wallet.js `transferEcoin` | derived from caller's `idempotencyKey` (`wallet.js:479,490`) | both legs share the caller's base key |
+
+When adding a new ledger writer, register its prefix here in the same PR.
+Picking a prefix that collides with an existing scope is a correctness
+bug (silent dedupe).
+
+---
+
+## 6. Topup-order lifecycle (`topup_orders` table)
+
+| Column | Type | Invariant | Notes |
+|--------|------|-----------|-------|
+| `id` | UUID | PK, `gen_random_uuid()` | distinct from external_txn_id |
+| `user_id` | UUID | FK `user_accounts ON DELETE CASCADE` | wallet credit lands here |
+| `channel` | VARCHAR(32) | one of `google_play`, `apple_iap`, `admin_grant`, `invite_bonus`, `signup_bonus` (`wallet_schema.sql:82`) | |
+| `amount_twd` | INTEGER | `>= 0` | misnamed (actually USD per `priceUsd` field); column kept for backward compat |
+| `ecoin_base_mli` | BIGINT | `>= 0` | tier base |
+| `ecoin_bonus_mli` | BIGINT | `>= 0`, default 0 | tier bonus |
+| `ecoin_total_mli` | BIGINT | `>= 0`, = base + bonus | what gets credited |
+| `status` | VARCHAR(32) | one of `pending`, `paid`, `failed`, `refunded` (`wallet_schema.sql:84`) | `paid` means ledger row exists |
+| `external_txn_id` | VARCHAR(255) | UNIQUE per `(channel, external_txn_id)` when not null (`wallet_schema.sql:105-107`) | Google `orderId` preferred over raw token |
+| `external_raw` | JSONB | full provider response | source of truth for ack-retry |
+| `ack_state` | VARCHAR(16) | `pending` / `acked` / `failed` (`wallet_schema.sql:118-121`) | google_play only |
+| `ack_attempts` | INTEGER | monotonic | 3 strikes → `failed` |
+| `ack_at` | TIMESTAMPTZ | NULL until acked | |
+
+### 6.1 Google Play verify-and-ack flow (`wallet.js:1114-1314`)
+
+1. `verify-google` resolves `userId` (device-secret OR JWT).
+2. Calls `verifyGooglePurchase` against androidpublisher v3.
+3. Inserts a `topup_orders` row via `createTopupOrder`
+   (deduped on `(channel, external_txn_id)`).
+4. Calls `markTopupPaid` → ledger row + `status='paid'`.
+5. Fire-and-forget `:acknowledge` → updates `ack_state`/`ack_attempts`.
+6. `ack-retry-sweep.js` (hourly cron) retries `ack_state='pending'`
+   rows up to 3 times before moving to `'failed'`.
+
+**Why fire-and-forget:** ack failure must NOT revoke the user's e-coin
+(`wallet.js:976-980`). Google auto-refunds after 72h of no-ack, which
+becomes a wallet drift the sweep is responsible for catching. Hank's
+explicit choice; do not "fix" by adding a synchronous ack.
+
+### 6.2 Fail-closed verification (`wallet.js:759-768`)
+
+Without `GOOGLE_PLAY_SERVICE_ACCOUNT` properly loaded, `/topup/verify-google`
+returns 500 `purchase_not_verified` rather than silently crediting
+unverified tokens. The escape hatch is `GOOGLE_PLAY_ALLOW_UNVERIFIED=1`,
+which is audited via `serverLog warn` (`wallet.js:1172`) — only intended
+for emergency rollback.
+
+### 6.3 Apple IAP verify (`wallet.js:1326-1442`)
+
+Mirrors Google's flow but uses Apple's `/verifyReceipt` (prod → sandbox
+21007 retry, `wallet.js:1346-1348`). Bundle-ID double-check against
+`APPLE_BUNDLE_ID` (default `com.eclawbot.app`). No ack call (Apple is
+ack-on-receipt-fetch).
+
+---
+
+## 7. Special accounts
+
+| Account | UUID | Purpose | Seeded at |
+|---------|------|---------|-----------|
+| Platform fee pool | `00000000-0000-0000-0000-000000000001` | receives 13% net of every rental token charge + every forfeit | `wallet.js:207-218` (auto-seed in `initWalletDatabase`) |
+| Insurance pool | `00000000-0000-0000-0000-000000000002` | receives 2% (of the 15% gross) for dispute / refund coverage | `wallet.js:209` |
+
+Both are seeded as virtual user_accounts rows with `password_hash =
+'SYSTEM_NO_LOGIN'` and `device_secret = 'SYSTEM_NO_LOGIN'` so the
+foreign key on `wallets.user_id` is satisfied without exposing a login
+path. **Never grant either account a real device_secret** — they must
+remain unauthenticatable.
+
+There is no "borrow shadow" wallet account in the current design; borrow
+flow ledger entries land on the borrower's own wallet (see
+official-bind spec, future).
+
+---
+
+## 8. Endpoint surface
+
+| Method | Path | Auth | Defined at | Purpose |
+|--------|------|------|------------|---------|
+| GET | `/api/wallet/balance` | JWT | `wallet.js:1044` | balance + held + lifetime |
+| GET | `/api/wallet/history` | JWT | `wallet.js:1050` | ledger rows, optional `?type=` filter |
+| GET | `/api/wallet/topup/tiers` | public | `wallet.js:1057` | tier catalog (no secrets) |
+| GET | `/api/wallet/topup/diag` | device-secret | `wallet.js:1074` | gated diagnostic for Path B; never exposes private_key |
+| POST | `/api/wallet/topup/verify-google` | device-secret OR JWT | `wallet.js:1114` | Path B verification + credit |
+| POST | `/api/wallet/topup/verify-apple` | JWT | `wallet.js:1363` | iOS IAP verification + credit |
+| GET | `/api/wallet/admin/reconcile` | JWT + admin | `wallet.js:1452` | run `reconcileBalances` |
+| POST | `/api/wallet/admin/grant` | JWT + admin | `wallet.js:1463` | manual e-coin grant; always audited |
+
+---
+
+## 9. What this doc deliberately does NOT cover
+
+- **Rental token metering math** — see `rental-proxy.js` and the future
+  `rental-proxy.md`; this spec only documents the ledger types it writes.
+- **Rental refund disposition matrix** — see `rental.md §3` (this spec
+  documents the ledger types, that spec documents the refund split).
+- **Subscription plan catalog** — see `backend/subscription.js`; this
+  spec only references the `subscription_grant` ledger type.
+- **Invite bonus amounts / cap** — see `backend/invite.js`; this spec
+  only documents the prefix `invite-inviter:` / `invite-invitee:`.
+- **Bot rental income tax / withdrawal flow** — `withdraw` enum is
+  reserved but no caller is wired yet. File a card before adding one.
+- **Currency conversion at top-up** — fixed 1 USD = 3,000,000 mli, no FX
+  feed. Adding tiered FX is a tier-catalog change, not a wallet change.
+
+---
+
+## 10. Update discipline
+
+- New `LEDGER_TYPES` value → update §3 matrix + `wallet_schema.sql:51-54`
+  comment + this file in the same PR.
+- New idempotency-key prefix → register in §5.2 in the same PR. Picking
+  a colliding prefix is a silent-dedupe correctness bug.
+- New endpoint under `/api/wallet` → update §8.
+- Tier catalog change → update §2 + the IAP product list in Play Console
+  / App Store Connect.
+- Schema column add/remove → update §6 (for `topup_orders`) or §4 (for
+  `wallets`).
+- New direct-write site to `wallets` outside `applyLedgerEntry` → STOP
+  and re-read invariant 7 in §4. The only sanctioned direct write is
+  `pending_income_mli`; anything else needs a policy doc here first.
+- `PLATFORM_WALLET_USER_ID` / `INSURANCE_POOL_USER_ID` rotation → no
+  rotation tooling exists; rotating either UUID would orphan every
+  ledger row referencing it. File a card before doing it.

--- a/backend/docs/specs/wallet.md
+++ b/backend/docs/specs/wallet.md
@@ -72,9 +72,9 @@ a value requires touching both files in the same PR** + this matrix.
 | `deposit_hold` | `DEPOSIT_HOLD` | `wallet.js` `holdDeposit` (`:500`) — used by `rental.js:734` | − | + | `rental-hold:<contractId>` | renter freezes deposit on rental start |
 | `deposit_release` | `DEPOSIT_RELEASE` | `wallet.js` `releaseDeposit` (`:518`) — used by `rental.js:837` | + | − | `rental-release:<contractId>` | full or partial refund on rental end |
 | `deposit_forfeit` | `DEPOSIT_FORFEIT` | `wallet.js` `forfeitDeposit` (`:538`) — used by `rental.js:853` | 0 | − | `rental-forfeit:<contractId>` | held leaves renter; counterparty credits are separate ledger rows |
-| `rental_income` | `RENTAL_INCOME` | `rental-proxy.js:234` (token metering, post-fee net) | + | 0 | `<contractId>:<chunk>:income` (`rental-proxy.js:234`) | owner receives net of token charge; written to `pending_income_mli` (T+24h hold) |
-| `rental_spend` | `RENTAL_SPEND` | `rental-proxy.js:187` (token metering, renter side) | − | 0 | `<contractId>:<chunk>:spend`, `<...>:dep-deduct` for held leg | renter is debited per token chunk |
-| `platform_fee` | `PLATFORM_FEE` | `rental-proxy.js:246` (15% per token charge) + `rental.js:880` (forfeit-pfee) | + (to platform pool) | 0 | `<contractId>:<chunk>:pfee`, `rental-forfeit-pfee:<contractId>` | gross fee includes the 2% insurance share |
+| `rental_income` | `RENTAL_INCOME` | `rental-proxy.js:234` (token metering, post-fee net) | + | 0 | `rental-usage:<contractId>:<msgId>:income` | owner receives net of token charge; written to `pending_income_mli` (T+24h hold) |
+| `rental_spend` | `RENTAL_SPEND` | `rental-proxy.js:187` (token metering, renter side) | − | 0 | `rental-usage:<contractId>:<msgId>:spend`, `:dep-deduct` for held leg | renter is debited per token chunk |
+| `platform_fee` | `PLATFORM_FEE` | `rental-proxy.js:246` (15% per token charge) + `rental.js:880` (forfeit-pfee) | + (to platform pool) | 0 | `rental-usage:<contractId>:<msgId>:pfee`, `rental-forfeit-pfee:<contractId>` | gross fee includes the 2% insurance share |
 | `refund` | `REFUND` | (reserved — used by tests + admin paths) | + | 0 | (caller-defined) | distinct from `deposit_release`; explicit refund of paid topups |
 | `admin_adjust` | `ADMIN_ADJUST` | `wallet.js` `adminAdjust` (`:556`) — `/api/wallet/admin/grant` | ± | 0 | `admin-grant:<adminId>:<ts>:<rand>` (`wallet.js:1472`) | always audited via `serverLog warn` |
 | `withdraw` | `WITHDRAW` | (reserved — no current caller) | − | 0 | (caller-defined) | bank/payment-processor withdraw, not yet wired |
@@ -177,11 +177,11 @@ Convention: `<scope>:<id>[:<leg>]`, lower-snake, colon-separated.
 | `rental-forfeit-ins:` | rental.js | `rental-forfeit-ins:<contractId>` | insurance pool (2%) |
 | `rebind-refund-debit:` | rental.js | `rebind-refund-debit:<contractId>` | owner debit (Phase 4) |
 | `rebind-refund-credit:` | rental.js | `rebind-refund-credit:<contractId>` | renter credit (Phase 4) |
-| `<contractId>:<chunk>:spend` | rental-proxy.js | per token charge | renter debit |
-| `<contractId>:<chunk>:dep-deduct` | rental-proxy.js | per token charge | held debit (when balance exhausts) |
-| `<contractId>:<chunk>:income` | rental-proxy.js | per token charge | owner pending_income credit |
-| `<contractId>:<chunk>:pfee` | rental-proxy.js | per token charge | platform fee leg |
-| `<contractId>:<chunk>:ins` | rental-proxy.js | per token charge | insurance pool leg |
+| `rental-usage:<contractId>:<msgId>:spend` | rental-proxy.js (`:153,:187`) | per token charge | renter debit; `<msgId>` = caller-supplied messageId or `Date.now()` |
+| `rental-usage:<contractId>:<msgId>:dep-deduct` | rental-proxy.js (`:210`) | per token charge | held debit (when balance exhausts) |
+| `rental-usage:<contractId>:<msgId>:income` | rental-proxy.js (`:234`) | per token charge | owner pending_income credit |
+| `rental-usage:<contractId>:<msgId>:pfee` | rental-proxy.js (`:246`) | per token charge | platform fee leg |
+| `rental-usage:<contractId>:<msgId>:ins` | rental-proxy.js (`:260`) | per token charge | insurance pool leg |
 | `income-release:<userId>:<ts>` | rental-proxy.js | per sweep run | T+24h pending_income release |
 | `invite-inviter:<code>:<inviteeUserId>:<ts>` | invite.js | inviter bonus | |
 | `invite-invitee:<code>:<inviteeUserId>:<ts>` | invite.js | invitee bonus | |


### PR DESCRIPTION
## Summary

- Adds `backend/docs/specs/channel-bridge.md` — the contract every bot's runtime depends on (3 endpoints + AVAILABLE TOOLS + `{{KEY}}` + Hermes vs OpenClaw + bridge.ts daemon).
- Updates `INDEX.md`: row 7 ❌ → ✅, gap list P0 #3 struck through. **P0 spec sweep complete** (rental ✅ vault ✅ wallet ✅ channel-bridge ✅).

## What it documents

| Section | Anchors |
|---------|---------|
| §1 three core endpoints | `/api/client/speak` (`index.js:8043`), `/api/transform` (`index.js:5918`), `/api/chat/history` (`index.js:16570`) — body shape, auth model, where messages land |
| §2 fakechat vs web_chat | channel source semantics, the MANDATORY `reply` tool contract, i18n auto-detect |
| §3 AVAILABLE TOOLS format | `getMissionApiHints` (`index.js:13885-13902`) verbatim template, all 14 callsites, Local Variables conditional block |
| §4 `{{KEY}}` interpolation | 4 sites (`index.js:8238`, `10661`, `15778`, `mission.js:83`), cross-linked with `vault.md` §7 |
| §5 Hermes vs OpenClaw engines | the "your text reply is DISCARDED" instruction-first format vs Hermes callback path |
| §6 bridge.ts | port 18800, 7 env-var constants, inbound/outbound flow, self-check rationale (2026-04-23 9-hour outage) |
| §7-8 explicit non-scope + update discipline | what to update where when contracts change |

## Why P0

Per `INDEX.md` gap list: *"Drives every bot's runtime behavior; absence is why Hermes shipped broken i18n on 2026-04-25 (he didn't have a doc to cite)."* Now anchored.

## Convention preserved

Every constant, line citation, and template literal uses cite-by-name+value so `grep doc` and `grep code` lead to the same place — same convention as `rental.md` / `vault.md` / `wallet.md`.

## Test plan

- [x] Pure docs change — no code paths touched
- [x] Cross-references to `vault.md` §7 still resolve
- [x] All cited line numbers verified against `backend/index.js`, `backend/kanban.js`, `bridge.ts` at HEAD
- [ ] Self-review checklist mirroring wallet.md / vault.md PRs
- [ ] CI green (lint / link check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)