### PR TITLE
feat(mindmap): live kanban data feed for portal mind-map (PR-C)

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -805,6 +805,153 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
     });
 
     // ============================================
+    // GET /mindmap — Live data feed for mission.html mind-map
+    // ============================================
+    // Projects active kanban cards into the {id,label,sys,tier,status,summary}
+    // shape consumed by public/portal/shared/mission-mindmap.js. Edges come
+    // from parent_card_id. The 8-system frame (invite/device/i18n/kanban/chat/
+    // payment/broadcast/bridge) is preserved as virtual hub nodes so the
+    // sys-rail UI keeps working even when zero cards classify into a system.
+    //
+    // The frontend (mission.html) calls this and falls back to the in-file
+    // MOCK_NODES when totalCards < 5 or when this endpoint errors.
+    const SYS_KEYWORDS = [
+        ['i18n',      /(i18n|locale|翻譯|翻译|hermes|cc_warn)/i],
+        ['chat',      /(聊天|chat|引用|chip|popover|embed=1|message|心智圖|mindmap|mind-map)/i],
+        ['kanban',    /(看板|kanban|卡片|card|screenshot|note|筆記|comment)/i],
+        ['invite',    /(邀請|invite|redeem|tier|funnel|leaderboard|qr)/i],
+        ['device',    /(裝置|device|secret|vault|rental|health|switch)/i],
+        ['payment',   /(支付|wallet|payment|iap|topup|top-up|storekit|訂閱)/i],
+        ['broadcast', /(廣播|broadcast|publisher|twitter|mastodon|wordpress|wp\.com|社群|x \(twitter\))/i],
+        ['bridge',    /(橋接|bridge|osascript|u\d{2}|ssh|terminal-bridge|hermes-bridge)/i],
+    ];
+    function classifySys(title) {
+        const t = String(title || '');
+        for (const [sys, rx] of SYS_KEYWORDS) {
+            if (rx.test(t)) return sys;
+        }
+        return 'kanban';
+    }
+    function tierFor(priority, isAutomation) {
+        if (isAutomation) return 'leaf';
+        if (priority === 'P0' || priority === 'P1') return 'topic';
+        return 'leaf';
+    }
+    function statusFor(kanbanStatus) {
+        if (kanbanStatus === 'done') return 'done';
+        if (kanbanStatus === 'backlog') return 'blocked';
+        return 'active';
+    }
+    router.get('/mindmap', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const { deviceId } = { ...req.query, ...req.body };
+        const includeAutomation = req.query.includeAutomation === 'true';
+        try {
+            const cardsResult = await pool.query(
+                `SELECT id, title, description, priority, status, parent_card_id, is_automation, assigned_bots
+                 FROM kanban_cards
+                 WHERE device_id = $1 AND archived = false
+                   ${includeAutomation ? '' : 'AND (is_automation = false OR is_automation IS NULL)'}
+                 ORDER BY
+                    CASE priority WHEN 'P0' THEN 0 WHEN 'P1' THEN 1 WHEN 'P2' THEN 2 WHEN 'P3' THEN 3 END,
+                    updated_at DESC NULLS LAST
+                 LIMIT 80`,
+                [deviceId]
+            );
+
+            const sysHubs = {
+                invite:    { id: 'sys:invite',    label: '邀請',     sys: 'invite',    tier: 'domain', status: 'active', summary: '' },
+                device:    { id: 'sys:device',    label: '裝置',     sys: 'device',    tier: 'domain', status: 'active', summary: '' },
+                i18n:      { id: 'sys:i18n',      label: 'i18n',     sys: 'i18n',      tier: 'domain', status: 'active', summary: '' },
+                kanban:    { id: 'sys:kanban',    label: '看板',     sys: 'kanban',    tier: 'domain', status: 'active', summary: '' },
+                chat:      { id: 'sys:chat',      label: '聊天',     sys: 'chat',      tier: 'domain', status: 'active', summary: '' },
+                payment:   { id: 'sys:payment',   label: '支付',     sys: 'payment',   tier: 'domain', status: 'active', summary: '' },
+                broadcast: { id: 'sys:broadcast', label: '廣播',     sys: 'broadcast', tier: 'domain', status: 'active', summary: '' },
+                bridge:    { id: 'sys:bridge',    label: '橋接',     sys: 'bridge',    tier: 'domain', status: 'active', summary: '' },
+            };
+
+            const nodes = [];
+            const edges = [];
+            const cardIds = new Set();
+            const sysCount = {};
+
+            for (const c of cardsResult.rows) {
+                const sys = classifySys(c.title);
+                sysCount[sys] = (sysCount[sys] || 0) + 1;
+                const summary = (c.description || '').replace(/\s+/g, ' ').trim().slice(0, 120);
+                nodes.push({
+                    id: c.id,
+                    label: (c.title || '').slice(0, 40),
+                    sys,
+                    tier: tierFor(c.priority, c.is_automation),
+                    status: statusFor(c.status),
+                    summary,
+                    priority: c.priority,
+                    cardStatus: c.status,
+                });
+                cardIds.add(c.id);
+            }
+
+            // Hub nodes: include hubs that own ≥1 card (keeps the rail tidy)
+            for (const sys of Object.keys(sysHubs)) {
+                if (sysCount[sys]) {
+                    const hub = { ...sysHubs[sys], summary: `${sysCount[sys]} 張卡片` };
+                    nodes.unshift(hub);
+                    // Connect each card in this sys to its hub when no parent_card edge exists yet
+                    for (const c of cardsResult.rows) {
+                        if (classifySys(c.title) === sys && !c.parent_card_id) {
+                            edges.push([hub.id, c.id]);
+                        }
+                    }
+                }
+            }
+
+            // Parent → child edges (only when both endpoints are in the result set)
+            for (const c of cardsResult.rows) {
+                if (c.parent_card_id && cardIds.has(c.parent_card_id)) {
+                    edges.push([c.parent_card_id, c.id]);
+                }
+            }
+
+            // Chat embedding telemetry — surface as a hub-level annotation.
+            // chat_messages has no card_id link, so we can only report the
+            // device-wide count here; per-card linkage will land in a follow-up.
+            let messagesWithEmbedding = 0;
+            try {
+                const embedResult = await pool.query(
+                    `SELECT COUNT(*)::int AS n FROM chat_messages
+                     WHERE device_id = $1 AND embedding IS NOT NULL`,
+                    [deviceId]
+                );
+                messagesWithEmbedding = embedResult.rows[0]?.n || 0;
+                if (messagesWithEmbedding > 0) {
+                    const chatHub = nodes.find(n => n.id === 'sys:chat');
+                    if (chatHub) {
+                        chatHub.summary = `${sysCount.chat || 0} 張卡片 · ${messagesWithEmbedding} 則訊息已嵌入`;
+                    }
+                }
+            } catch (e) {
+                // pgvector not installed or column missing — skip silently
+            }
+
+            res.json({
+                success: true,
+                live: true,
+                nodes,
+                edges,
+                stats: {
+                    totalCards: cardsResult.rows.length,
+                    messagesWithEmbedding,
+                    sysCount,
+                },
+            });
+        } catch (err) {
+            console.error('[Kanban] Mindmap error:', err.message);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
+    // ============================================
     // GET /cards/archived — Archived cards (paginated)
     // ============================================
     router.get('/cards/archived', async (req, res) => {

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -957,7 +957,24 @@
             if (mmExpanded && !mmInitialized && window.MissionMindmap) {
                 mmInitialized = true;
                 try {
-                    await window.MissionMindmap.init({ rootEl: container });
+                    let liveData = null;
+                    try {
+                        const resp = await fetch(
+                            `/api/mission/mindmap?deviceId=${encodeURIComponent(currentUser.deviceId)}&deviceSecret=${encodeURIComponent(currentUser.deviceSecret)}`
+                        );
+                        if (resp.ok) {
+                            const j = await resp.json();
+                            // Need at least 5 nodes for a mind-map to be useful;
+                            // below that, fall back to the curated demo so the
+                            // UX doesn't look empty for fresh devices.
+                            if (j.success && Array.isArray(j.nodes) && j.nodes.length >= 5) {
+                                liveData = { nodes: j.nodes, edges: j.edges || [] };
+                            }
+                        }
+                    } catch (fetchErr) {
+                        console.warn('mindmap live fetch failed, falling back to mock:', fetchErr);
+                    }
+                    await window.MissionMindmap.init({ rootEl: container, data: liveData });
                 } catch (err) {
                     console.error('mindmap init failed:', err);
                     container.innerHTML = '<div style="padding:14px;color:var(--text-secondary);font-size:12px;">載入失敗：' + (err.message || err) + '</div>';

--- a/backend/tests/jest/kanban-mindmap.test.js
+++ b/backend/tests/jest/kanban-mindmap.test.js
@@ -1,0 +1,176 @@
+/**
+ * GET /api/mission/mindmap — Live data feed for portal/mission.html mind-map.
+ *
+ * Verifies the projection of kanban_cards into the {nodes, edges} shape
+ * consumed by public/portal/shared/mission-mindmap.js (PR-C, card_90e2ec3).
+ */
+
+const mockQuery = jest.fn();
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: (...args) => mockQuery(...args),
+        connect: jest.fn().mockResolvedValue({
+            query: jest.fn().mockResolvedValue({ rows: [] }),
+            release: jest.fn(),
+        }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+jest.mock('../../safe-equal', () => (a, b) => a === b);
+
+const express = require('express');
+const request = require('supertest');
+
+let app;
+
+beforeAll(() => {
+    app = express();
+    app.use(express.json());
+
+    const mockDevices = {
+        'dev-1': {
+            deviceSecret: 'sec-1',
+            entities: {
+                2: { isBound: true, botSecret: 'bot-2', character: 'Bot2' },
+            },
+        },
+    };
+
+    const kanbanModule = require('../../kanban')(mockDevices, {});
+    app.use('/api/mission', kanbanModule.router);
+});
+
+beforeEach(() => {
+    mockQuery.mockReset();
+});
+
+const AUTH = '?deviceId=dev-1&deviceSecret=sec-1';
+
+describe('GET /api/mission/mindmap', () => {
+    it('rejects unauthenticated requests', async () => {
+        const res = await request(app).get('/api/mission/mindmap?deviceId=dev-1');
+        expect(res.status).toBe(400);
+    });
+
+    it('returns empty graph when no cards exist', async () => {
+        mockQuery
+            .mockResolvedValueOnce({ rows: [] }) // cards
+            .mockResolvedValueOnce({ rows: [{ n: 0 }] }); // chat embedding count
+
+        const res = await request(app).get('/api/mission/mindmap' + AUTH);
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.live).toBe(true);
+        expect(res.body.nodes).toEqual([]);
+        expect(res.body.edges).toEqual([]);
+        expect(res.body.stats.totalCards).toBe(0);
+    });
+
+    it('classifies cards by sys-keyword and emits hub→card edges', async () => {
+        mockQuery
+            .mockResolvedValueOnce({
+                rows: [
+                    { id: 'card_a', title: 'i18n ko cc_warn 修正', description: 'fix korean', priority: 'P0', status: 'in_progress', parent_card_id: null, is_automation: false, assigned_bots: [5] },
+                    { id: 'card_b', title: '看板深層連結 anchor', description: 'kanban deeplink', priority: 'P1', status: 'todo', parent_card_id: null, is_automation: false, assigned_bots: [2] },
+                    { id: 'card_c', title: '聊天引用晶片 popover', description: 'chat chip popover', priority: 'P0', status: 'review', parent_card_id: null, is_automation: false, assigned_bots: [2] },
+                    { id: 'card_d', title: 'Random thing nobody knows', description: 'fallback', priority: 'P2', status: 'todo', parent_card_id: null, is_automation: false, assigned_bots: [2] },
+                ],
+            })
+            .mockResolvedValueOnce({ rows: [{ n: 42 }] });
+
+        const res = await request(app).get('/api/mission/mindmap' + AUTH);
+        expect(res.status).toBe(200);
+        const sysOf = id => res.body.nodes.find(n => n.id === id)?.sys;
+        expect(sysOf('card_a')).toBe('i18n');
+        expect(sysOf('card_b')).toBe('kanban');
+        expect(sysOf('card_c')).toBe('chat');
+        expect(sysOf('card_d')).toBe('kanban'); // fallback
+
+        // Hubs emitted only for active sys
+        const hubIds = res.body.nodes.filter(n => n.id.startsWith('sys:')).map(n => n.id).sort();
+        expect(hubIds).toEqual(['sys:chat', 'sys:i18n', 'sys:kanban']);
+
+        // Hub→card edges exist for every parentless card
+        const edgeSet = new Set(res.body.edges.map(([s, t]) => `${s}→${t}`));
+        expect(edgeSet.has('sys:i18n→card_a')).toBe(true);
+        expect(edgeSet.has('sys:kanban→card_b')).toBe(true);
+        expect(edgeSet.has('sys:chat→card_c')).toBe(true);
+        expect(edgeSet.has('sys:kanban→card_d')).toBe(true);
+
+        // Chat embedding telemetry surfaced on hub
+        const chatHub = res.body.nodes.find(n => n.id === 'sys:chat');
+        expect(chatHub.summary).toContain('42 則訊息已嵌入');
+    });
+
+    it('emits parent→child edges when both endpoints are in the result set', async () => {
+        mockQuery
+            .mockResolvedValueOnce({
+                rows: [
+                    { id: 'card_p', title: '父卡 i18n', description: '', priority: 'P1', status: 'in_progress', parent_card_id: null, is_automation: false, assigned_bots: [5] },
+                    { id: 'card_c', title: '子卡 i18n locale', description: '', priority: 'P2', status: 'todo', parent_card_id: 'card_p', is_automation: false, assigned_bots: [5] },
+                ],
+            })
+            .mockResolvedValueOnce({ rows: [{ n: 0 }] });
+
+        const res = await request(app).get('/api/mission/mindmap' + AUTH);
+        const edgeSet = new Set(res.body.edges.map(([s, t]) => `${s}→${t}`));
+        expect(edgeSet.has('card_p→card_c')).toBe(true);
+        // Parent has hub edge; child does NOT (it has parent_card_id)
+        expect(edgeSet.has('sys:i18n→card_p')).toBe(true);
+        expect(edgeSet.has('sys:i18n→card_c')).toBe(false);
+    });
+
+    it('maps kanban status to mind-map status (done/blocked/active)', async () => {
+        mockQuery
+            .mockResolvedValueOnce({
+                rows: [
+                    { id: 'card_done',    title: 'kanban thing',  description: '', priority: 'P2', status: 'done',     parent_card_id: null, is_automation: false, assigned_bots: [2] },
+                    { id: 'card_back',    title: 'kanban backlog',description: '', priority: 'P2', status: 'backlog',  parent_card_id: null, is_automation: false, assigned_bots: [2] },
+                    { id: 'card_inprog',  title: 'kanban active', description: '', priority: 'P2', status: 'in_progress', parent_card_id: null, is_automation: false, assigned_bots: [2] },
+                ],
+            })
+            .mockResolvedValueOnce({ rows: [{ n: 0 }] });
+
+        const res = await request(app).get('/api/mission/mindmap' + AUTH);
+        const byId = Object.fromEntries(res.body.nodes.map(n => [n.id, n]));
+        expect(byId.card_done.status).toBe('done');
+        expect(byId.card_back.status).toBe('blocked');
+        expect(byId.card_inprog.status).toBe('active');
+    });
+
+    it('excludes automation cards by default; ?includeAutomation=true opts in', async () => {
+        mockQuery
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [{ n: 0 }] });
+
+        await request(app).get('/api/mission/mindmap' + AUTH);
+        const sql1 = mockQuery.mock.calls[0][0];
+        expect(sql1).toMatch(/is_automation = false OR is_automation IS NULL/);
+
+        mockQuery.mockReset();
+        mockQuery
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [{ n: 0 }] });
+
+        await request(app).get('/api/mission/mindmap' + AUTH + '&includeAutomation=true');
+        const sql2 = mockQuery.mock.calls[0][0];
+        expect(sql2).not.toMatch(/is_automation = false OR is_automation IS NULL/);
+    });
+
+    it('survives chat_messages.embedding column missing (pgvector not installed)', async () => {
+        mockQuery
+            .mockResolvedValueOnce({
+                rows: [
+                    { id: 'card_x', title: '聊天 chip', description: '', priority: 'P2', status: 'todo', parent_card_id: null, is_automation: false, assigned_bots: [2] },
+                ],
+            })
+            .mockRejectedValueOnce(new Error('column "embedding" does not exist'));
+
+        const res = await request(app).get('/api/mission/mindmap' + AUTH);
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.stats.messagesWithEmbedding).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary

- New `GET /api/mission/mindmap` projects active kanban_cards into the `{nodes, edges}` shape consumed by `mission-mindmap.js` so the portal mind-map shows real project state instead of the curated mock.
- `mission.html` now fetches the live feed on first expand and falls back to MOCK when fewer than 5 nodes are returned or fetch fails — fresh devices and offline reloads still see a useful demo.
- Hub-then-leaf layout preserves the 8-system frame (邀請/裝置/i18n/看板/聊天/支付/廣播/橋接); each card's `sys` is derived by a title-keyword classifier (regex order: i18n → chat → kanban → invite → device → payment → broadcast → bridge → fallback `kanban`).
- `parent_card_id` becomes a card→card edge; `chat_messages` with non-null embedding surface as device-wide telemetry on the chat hub (per-card linkage deferred — `chat_messages` has no `card_id` column today).

## Why now

Closes the data-wiring leg of the mind-map PR series (PR-A static / PR-B chip popover + 📌 tray / **PR-C live data**). Card: `card_90e2ec3adaf8b096d3990b54`.

## Test plan

- [x] `backend/tests/jest/kanban-mindmap.test.js` — 7 tests pass: auth, empty graph, sys-classifier, hub→card edges, parent→child edges, status mapping (done/blocked/active), automation default-exclude, `pgvector` column-missing graceful fallback.
- [x] `node -c` syntax check on `kanban.js`.
- [ ] Post-merge: hit `https://eclawbot.com/portal/mission.html` in a fresh tab, expand 🧠 心智圖, verify (a) live nodes render with correct sys-grouping, (b) chip popover + 📌 pin tray still work from PR-B, (c) mobile portrait (390x844) bottom-sheet popover still anchors correctly. Capture console for any errors.
- [ ] Post-merge: confirm fresh devices (no cards) gracefully fall back to MOCK without console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)