### PR TITLE
fix(mindmap): re-render Subsystems popover on open

### DIFF
--- a/backend/public/portal/mindmap.html
+++ b/backend/public/portal/mindmap.html
@@ -527,6 +527,9 @@
             const pop = document.getElementById('subsystemsPop');
             const btn = document.getElementById('btnSubsystems');
             if (!pop || !btn) return;
+            // Re-render on open so the list always reflects live cy state
+            // (covers empty-graph load where renderGraph never ran).
+            if (open) renderSubsystemsPop();
             pop.classList.toggle('active', !!open);
             btn.setAttribute('aria-expanded', open ? 'true' : 'false');
         }


### PR DESCRIPTION
## Summary
- 3-line follow-up to PR #2142.
- The popover was first rendered when the user clicked the toggle, but on empty-graph startup `renderGraph` never runs — so `setSubsystemsPopOpen(true)` toggled an empty `<div>` on, and the empty-state hint was never shown.
- Fix: call `renderSubsystemsPop()` inside `setSubsystemsPopOpen(true)` so the list is regenerated from live cy state every time the menu opens.

## Test plan
- [x] Empty graph → click "Subsystems ▾" → see "No subsystems — mark a node as 'Subgraph root' to add one." (verified locally; before fix the popover was visually empty)
- [x] Populated graph → click toggle → 4 alphabetized subsystems appear (`mindmap-subsystems-popover-open.png`)
- [x] Click an item → camera pans + zooms to that node, focus mode + active highlight (`mindmap-after-jump-vector-memory.png`)
- [x] Mobile 390×844 → popover responsive override fires (`mindmap-subsystems-mobile.png`)

card_048b2c01

🤖 Generated with [Claude Code](https://claude.com/claude-code)