### PR TITLE
feat(publisher): Hashnode vault-first multi-tenant (2/10)

### DIFF
--- a/backend/article-publisher.js
+++ b/backend/article-publisher.js
@@ -66,6 +66,11 @@ const BLOGGER_REDIRECT_URI = process.env.BLOGGER_REDIRECT_URI || 'https://eclawb
 const BLOGGER_SCOPE = 'https://www.googleapis.com/auth/blogger';
 const HASHNODE_API_TOKEN = process.env.HASHNODE_API_TOKEN;
 const HASHNODE_GQL_ENDPOINT = 'https://gql.hashnode.com';
+const HASHNODE_CRED_KEYS = ['HASHNODE_API_TOKEN'];
+const HASHNODE_CREDS_MISSING = {
+    error: 'Hashnode credentials not set for this device',
+    setup_url: '/portal/publisher-setup.html'
+};
 
 // DEV.to (Forem API)
 const DEVTO_API_KEY = process.env.DEVTO_API_KEY;
@@ -526,12 +531,25 @@ router.delete('/blogger/post/:postId', async (req, res) => {
 // HASHNODE PUBLISH / DELETE
 // ============================================
 
-async function hashnodeGQL(query, variables = {}) {
+// Resolve the Hashnode API token (vault-first, env fallback). Returns
+// { token, source: 'vault'|'env'|'missing' }. Caller passes token into hashnodeGQL.
+async function resolveHashnodeCreds(deviceId) {
+    if (deviceId && typeof _getDeviceVar === 'function') {
+        try {
+            const v = await _getDeviceVar(deviceId, HASHNODE_CRED_KEYS[0]);
+            if (typeof v === 'string' && v.length > 0) return { token: v, source: 'vault' };
+        } catch (_) { /* fall through to env */ }
+    }
+    if (HASHNODE_API_TOKEN) return { token: HASHNODE_API_TOKEN, source: 'env' };
+    return { token: null, source: 'missing' };
+}
+
+async function hashnodeGQL(query, variables = {}, token = HASHNODE_API_TOKEN) {
     const res = await fetch(HASHNODE_GQL_ENDPOINT, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/json',
-            Authorization: HASHNODE_API_TOKEN
+            Authorization: token
         },
         body: JSON.stringify({ query, variables })
     });
@@ -543,20 +561,26 @@ async function hashnodeGQL(query, variables = {}) {
 // Get current user's publications
 router.get('/hashnode/me', async (req, res) => {
     try {
-        const data = await hashnodeGQL(`query { me { id username publications(first: 10) { edges { node { id title url } } } } }`);
-        res.json({ success: true, user: data.me });
+        const deviceId = req.query?.deviceId || null;
+        const { token, source } = await resolveHashnodeCreds(deviceId);
+        if (!token) return res.status(400).json(HASHNODE_CREDS_MISSING);
+        const data = await hashnodeGQL(`query { me { id username publications(first: 10) { edges { node { id title url } } } } }`, {}, token);
+        res.json({ success: true, user: data.me, _credSource: source });
     } catch (err) {
         res.status(500).json({ error: err.message });
     }
 });
 
 router.post('/hashnode/publish', express.json(), async (req, res) => {
-    const { publicationId, title, contentMarkdown, tags, slug, includeReferralCTA } = req.body;
+    const { publicationId, title, contentMarkdown, tags, slug, includeReferralCTA, deviceId } = req.body;
     if (!publicationId || !title || !contentMarkdown) {
         return res.status(400).json({ error: 'publicationId, title, contentMarkdown required' });
     }
 
     try {
+        const { token, source } = await resolveHashnodeCreds(deviceId || null);
+        if (!token) return res.status(400).json(HASHNODE_CREDS_MISSING);
+
         const finalMarkdown = appendReferralCTA(contentMarkdown, { format: 'md', locale: 'en', skip: includeReferralCTA === false });
 
         const data = await hashnodeGQL(`
@@ -573,9 +597,9 @@ router.post('/hashnode/publish', express.json(), async (req, res) => {
                 slug: slug || title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, ''),
                 tags: tags ? tags.map(t => typeof t === 'string' ? { slug: t, name: t } : t) : []
             }
-        });
+        }, token);
         const post = data.publishPost.post;
-        console.log(`[Publisher] Hashnode post created: ${post.id} "${title}"`);
+        console.log(`[Publisher] Hashnode post created: ${post.id} "${title}" (creds: ${source})`);
         res.json({ success: true, platform: 'hashnode', postId: post.id, url: post.url, slug: post.slug });
     } catch (err) {
         console.error('[Publisher] Hashnode publish error:', err);
@@ -583,16 +607,19 @@ router.post('/hashnode/publish', express.json(), async (req, res) => {
     }
 });
 
-router.delete('/hashnode/post/:postId', async (req, res) => {
+router.delete('/hashnode/post/:postId', express.json(), async (req, res) => {
     const { postId } = req.params;
+    const deviceId = req.body?.deviceId || req.query?.deviceId || null;
     try {
+        const { token } = await resolveHashnodeCreds(deviceId);
+        if (!token) return res.status(400).json(HASHNODE_CREDS_MISSING);
         await hashnodeGQL(`
             mutation RemovePost($id: ID!) {
                 removePost(input: { id: $id }) {
                     post { id }
                 }
             }
-        `, { id: postId });
+        `, { id: postId }, token);
         console.log(`[Publisher] Hashnode post deleted: ${postId}`);
         res.json({ success: true, platform: 'hashnode', deleted: postId });
     } catch (err) {

--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -3679,14 +3679,14 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                     <div class="guide-panel" id="guide-publisher">
                         <header>
                             <h1 data-i18n="guide_pub_title">多平台發布 Publisher</h1>
-                            <p class="meta" data-i18n="guide_pub_meta">10 個內容平台 · 多租戶金鑰 roadmap · X 已上線、其餘 env-only</p>
+                            <p class="meta" data-i18n="guide_pub_meta">10 個內容平台 · 多租戶金鑰 roadmap · X / Hashnode 已上線、其餘 env-only</p>
                         </header>
 
                         <h2 data-i18n="guide_pub_overview_h">總覽</h2>
                         <p data-i18n="guide_pub_overview_desc">
                             <code>backend/article-publisher.js</code> 把 10 個內容平台統一在 <code>/api/publisher/&lt;platform&gt;/*</code> 之下。
                             「多租戶」指的是<strong>每個 device 用自己金鑰庫裡的金鑰</strong>呼叫對應平台，而非全站共用 owner 一把 env 金鑰。
-                            目前只有 X 走完整的 vault-first 流程（<code>resolveXCreds(deviceId)</code>），其餘平台仍是 env-only single-tenant。
+                            目前 X 與 Hashnode 走完整的 vault-first 流程（<code>resolveXCreds()</code> / <code>resolveHashnodeCreds()</code>），其餘平台仍是 env-only single-tenant。
                         </p>
 
                         <h2 data-i18n="guide_pub_status_h">平台狀態總表</h2>
@@ -3725,7 +3725,7 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                                     <td>global</td>
                                     <td>API Key</td>
                                     <td><code>HASHNODE_API_TOKEN</code></td>
-                                    <td><span class="pub-badge pub-badge-env">⚙️ env-only</span></td>
+                                    <td><span class="pub-badge pub-badge-vault">🔓 vault-first</span></td>
                                 </tr>
                                 <tr>
                                     <td><strong>DEV.to</strong></td>
@@ -3793,7 +3793,7 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                             </tbody>
                         </table>
 
-                        <h2 data-i18n="guide_pub_roadmap_h">Roadmap：把另外 9 個平台搬上 vault-first</h2>
+                        <h2 data-i18n="guide_pub_roadmap_h">Roadmap：把剩下 8 個平台搬上 vault-first</h2>
                         <p data-i18n="guide_pub_roadmap_desc">每一個平台只要照 X 的樣板做：先在 publisher router 頂部加一個 <code>resolve&lt;Platform&gt;Creds(deviceId)</code>，先讀 <code>_getDeviceVar()</code>、若缺則 fallback 到 <code>process.env</code>，然後在每個 endpoint 把 <code>process.env.XXX</code> 換成 <code>(await resolve())</code> 結果。</p>
                         <ol>
                             <li data-i18n="guide_pub_roadmap_step1">複製 <code>resolveXCreds()</code> 為 <code>resolveTumblrCreds()</code>、<code>resolveRedditCreds()</code> ... 共 9 份。</li>


### PR DESCRIPTION
## Summary
- Hashnode is now the **2nd of 10** content platforms with multi-tenant vault key support (after X).
- Each device can store its own \`HASHNODE_API_TOKEN\` in the encrypted vault; falls back to \`process.env.HASHNODE_API_TOKEN\` so Hank's single-tenant prod stays alive.
- \`info.html\` publisher table flipped: Hashnode badge env-only → 🔓 vault-first.

## Changes
- \`backend/article-publisher.js\`:
  - \`HASHNODE_CRED_KEYS\` + \`HASHNODE_CREDS_MISSING\` constants
  - \`resolveHashnodeCreds(deviceId)\` → \`{ token, source: 'vault' | 'env' | 'missing' }\`
  - \`hashnodeGQL(query, vars, token = HASHNODE_API_TOKEN)\` — token argument added with env default for back-compat
  - GET \`/hashnode/me\` (deviceId from query), POST \`/hashnode/publish\` (deviceId from body), DELETE \`/hashnode/post/:postId\` (deviceId from body|query) all call \`resolveHashnodeCreds\` and return \`HASHNODE_CREDS_MISSING\` (400 + setup_url) when neither vault nor env has a token
- \`backend/public/portal/info.html\`:
  - Hashnode row badge: env-only → vault-first
  - Meta tagline now reads "X / Hashnode 已上線、其餘 env-only"
  - Roadmap header: 9 platforms → 8 platforms

## Test plan
- [x] \`node -c backend/article-publisher.js\` — syntax clean
- [ ] Curl \`/api/publisher/hashnode/me?deviceId=...\` against Railway (post-deploy) — expects either user payload (if vault/env present) or HASHNODE_CREDS_MISSING 400
- [ ] Visit \`/portal/info.html#guide-publisher\` — Hashnode row shows green vault-first badge

## Related
- Card \`card_92caa644\` — multi-tenant migration tracker (Hashnode = step 2/10 after X)
- Continues from PR #2144 (publisher status panel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)