### PR TITLE
feat(publisher): DEV.to vault-first multi-tenant (3/10 platforms)

### DIFF
--- a/backend/article-publisher.js
+++ b/backend/article-publisher.js
@@ -75,6 +75,11 @@ const HASHNODE_CREDS_MISSING = {
 // DEV.to (Forem API)
 const DEVTO_API_KEY = process.env.DEVTO_API_KEY;
 const DEVTO_API_BASE = 'https://dev.to/api';
+const DEVTO_CRED_KEYS = ['DEVTO_API_KEY'];
+const DEVTO_CREDS_MISSING = {
+    error: 'DEV.to credentials not set for this device',
+    setup_url: '/portal/publisher-setup.html'
+};
 
 // WordPress (supports OAuth2 with DB-backed tokens OR Application Password)
 const WORDPRESS_CLIENT_ID = process.env.WORDPRESS_CLIENT_ID;
@@ -891,16 +896,23 @@ router.get('/x/me', async (req, res) => {
 // Auth: api-key header | Content: Markdown
 // ============================================
 
-function requireDevto(res) {
-    if (!DEVTO_API_KEY) { res.status(501).json({ error: 'DEV.to not configured (DEVTO_API_KEY missing)' }); return false; }
-    return true;
+// Resolve the DEV.to api-key (vault-first, env fallback).
+async function resolveDevtoCreds(deviceId) {
+    if (deviceId && typeof _getDeviceVar === 'function') {
+        try {
+            const v = await _getDeviceVar(deviceId, DEVTO_CRED_KEYS[0]);
+            if (typeof v === 'string' && v.length > 0) return { apiKey: v, source: 'vault' };
+        } catch (_) { /* fall through to env */ }
+    }
+    if (DEVTO_API_KEY) return { apiKey: DEVTO_API_KEY, source: 'env' };
+    return { apiKey: null, source: 'missing' };
 }
 
-async function devtoRequest(method, path, body = null) {
+async function devtoRequest(method, path, body = null, apiKey = DEVTO_API_KEY) {
     const options = {
         method,
         headers: {
-            'api-key': DEVTO_API_KEY,
+            'api-key': apiKey,
             'Accept': 'application/vnd.forem.api-v1+json',
             'Content-Type': 'application/json'
         }
@@ -918,10 +930,12 @@ async function devtoRequest(method, path, body = null) {
 
 // GET /api/publisher/devto/me
 router.get('/devto/me', async (req, res) => {
-    if (!requireDevto(res)) return;
     try {
-        const data = await devtoRequest('GET', '/users/me');
-        res.json({ success: true, user: { id: data.id, username: data.username, name: data.name } });
+        const deviceId = req.query?.deviceId || null;
+        const { apiKey, source } = await resolveDevtoCreds(deviceId);
+        if (!apiKey) return res.status(400).json(DEVTO_CREDS_MISSING);
+        const data = await devtoRequest('GET', '/users/me', null, apiKey);
+        res.json({ success: true, user: { id: data.id, username: data.username, name: data.name }, _credSource: source });
     } catch (err) {
         res.status(err.status || 500).json({ error: err.message });
     }
@@ -929,19 +943,21 @@ router.get('/devto/me', async (req, res) => {
 
 // POST /api/publisher/devto/publish
 router.post('/devto/publish', express.json(), async (req, res) => {
-    if (!requireDevto(res)) return;
-    const { title, body_markdown, published, tags, series, canonical_url, includeReferralCTA } = req.body;
+    const { title, body_markdown, published, tags, series, canonical_url, includeReferralCTA, deviceId } = req.body;
     if (!title || !body_markdown) return res.status(400).json({ error: 'title, body_markdown required' });
 
     try {
+        const { apiKey, source } = await resolveDevtoCreds(deviceId || null);
+        if (!apiKey) return res.status(400).json(DEVTO_CREDS_MISSING);
+
         const finalBody = appendReferralCTA(body_markdown, { format: 'md', locale: 'en', skip: includeReferralCTA === false });
         const article = { title, body_markdown: finalBody, published: published !== false };
         if (tags) article.tags = tags;
         if (series) article.series = series;
         if (canonical_url) article.canonical_url = canonical_url;
 
-        const data = await devtoRequest('POST', '/articles', { article });
-        console.log(`[Publisher] DEV.to article created: ${data.id} "${title}"`);
+        const data = await devtoRequest('POST', '/articles', { article }, apiKey);
+        console.log(`[Publisher] DEV.to article created: ${data.id} "${title}" (creds: ${source})`);
         res.json({ success: true, platform: 'devto', postId: String(data.id), url: data.url, title: data.title, slug: data.slug });
     } catch (err) {
         console.error('[Publisher] DEV.to publish error:', err);
@@ -951,11 +967,13 @@ router.post('/devto/publish', express.json(), async (req, res) => {
 
 // PUT /api/publisher/devto/post/:postId
 router.put('/devto/post/:postId', express.json(), async (req, res) => {
-    if (!requireDevto(res)) return;
     const { postId } = req.params;
-    const { title, body_markdown, published, tags, series, canonical_url } = req.body;
+    const { title, body_markdown, published, tags, series, canonical_url, deviceId } = req.body;
 
     try {
+        const { apiKey } = await resolveDevtoCreds(deviceId || null);
+        if (!apiKey) return res.status(400).json(DEVTO_CREDS_MISSING);
+
         const article = {};
         if (title !== undefined) article.title = title;
         if (body_markdown !== undefined) article.body_markdown = body_markdown;
@@ -964,7 +982,7 @@ router.put('/devto/post/:postId', express.json(), async (req, res) => {
         if (series !== undefined) article.series = series;
         if (canonical_url !== undefined) article.canonical_url = canonical_url;
 
-        const data = await devtoRequest('PUT', `/articles/${postId}`, { article });
+        const data = await devtoRequest('PUT', `/articles/${postId}`, { article }, apiKey);
         console.log(`[Publisher] DEV.to article updated: ${postId}`);
         res.json({ success: true, platform: 'devto', postId: String(data.id), url: data.url, title: data.title });
     } catch (err) {
@@ -974,11 +992,13 @@ router.put('/devto/post/:postId', express.json(), async (req, res) => {
 });
 
 // DELETE /api/publisher/devto/post/:postId — unpublish (DEV.to doesn't support true delete via API)
-router.delete('/devto/post/:postId', async (req, res) => {
-    if (!requireDevto(res)) return;
+router.delete('/devto/post/:postId', express.json(), async (req, res) => {
     const { postId } = req.params;
+    const deviceId = req.body?.deviceId || req.query?.deviceId || null;
     try {
-        await devtoRequest('PUT', `/articles/${postId}`, { article: { published: false } });
+        const { apiKey } = await resolveDevtoCreds(deviceId);
+        if (!apiKey) return res.status(400).json(DEVTO_CREDS_MISSING);
+        await devtoRequest('PUT', `/articles/${postId}`, { article: { published: false } }, apiKey);
         console.log(`[Publisher] DEV.to article unpublished: ${postId}`);
         res.json({ success: true, platform: 'devto', unpublished: String(postId) });
     } catch (err) {

--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -3679,14 +3679,14 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                     <div class="guide-panel" id="guide-publisher">
                         <header>
                             <h1 data-i18n="guide_pub_title">多平台發布 Publisher</h1>
-                            <p class="meta" data-i18n="guide_pub_meta">10 個內容平台 · 多租戶金鑰 roadmap · X / Hashnode 已上線、其餘 env-only</p>
+                            <p class="meta" data-i18n="guide_pub_meta">10 個內容平台 · 多租戶金鑰 roadmap · X / Hashnode / DEV.to 已上線、其餘 env-only</p>
                         </header>
 
                         <h2 data-i18n="guide_pub_overview_h">總覽</h2>
                         <p data-i18n="guide_pub_overview_desc">
                             <code>backend/article-publisher.js</code> 把 10 個內容平台統一在 <code>/api/publisher/&lt;platform&gt;/*</code> 之下。
                             「多租戶」指的是<strong>每個 device 用自己金鑰庫裡的金鑰</strong>呼叫對應平台，而非全站共用 owner 一把 env 金鑰。
-                            目前 X 與 Hashnode 走完整的 vault-first 流程（<code>resolveXCreds()</code> / <code>resolveHashnodeCreds()</code>），其餘平台仍是 env-only single-tenant。
+                            目前 X、Hashnode、DEV.to 走完整的 vault-first 流程（<code>resolveXCreds()</code> / <code>resolveHashnodeCreds()</code> / <code>resolveDevtoCreds()</code>），其餘平台仍是 env-only single-tenant。
                         </p>
 
                         <h2 data-i18n="guide_pub_status_h">平台狀態總表</h2>
@@ -3732,7 +3732,7 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                                     <td>global</td>
                                     <td>API Key</td>
                                     <td><code>DEVTO_API_KEY</code></td>
-                                    <td><span class="pub-badge pub-badge-env">⚙️ env-only</span></td>
+                                    <td><span class="pub-badge pub-badge-vault">🔓 vault-first</span></td>
                                 </tr>
                                 <tr>
                                     <td><strong>Telegraph</strong></td>
@@ -3793,7 +3793,7 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                             </tbody>
                         </table>
 
-                        <h2 data-i18n="guide_pub_roadmap_h">Roadmap：把剩下 8 個平台搬上 vault-first</h2>
+                        <h2 data-i18n="guide_pub_roadmap_h">Roadmap：把剩下 7 個平台搬上 vault-first</h2>
                         <p data-i18n="guide_pub_roadmap_desc">每一個平台只要照 X 的樣板做：先在 publisher router 頂部加一個 <code>resolve&lt;Platform&gt;Creds(deviceId)</code>，先讀 <code>_getDeviceVar()</code>、若缺則 fallback 到 <code>process.env</code>，然後在每個 endpoint 把 <code>process.env.XXX</code> 換成 <code>(await resolve())</code> 結果。</p>
                         <ol>
                             <li data-i18n="guide_pub_roadmap_step1">複製 <code>resolveXCreds()</code> 為 <code>resolveTumblrCreds()</code>、<code>resolveRedditCreds()</code> ... 共 9 份。</li>


### PR DESCRIPTION
## Summary
- Adds vault-first DEV.to credential resolution mirroring the X/Hashnode pattern (PR #2145)
- All 4 DEV.to publisher routes now read per-device api-key from vault first, env fallback
- info.html DEV.to badge flips to vault-first; roadmap counter 8→7

## What changed
- `resolveDevtoCreds(deviceId)` returns `{ apiKey, source: 'vault'|'env'|'missing' }`
- `devtoRequest(method, path, body, apiKey)` — apiKey defaults to env to keep internal callers working
- Routes touched: `GET /devto/me`, `POST /devto/publish`, `PUT /devto/post/:id`, `DELETE /devto/post/:id`
- `DELETE` route now accepts `express.json()` so deviceId can come from body
- `info.html`: meta tagline + overview paragraph + DEV.to badge + roadmap header

## Test plan
- [x] `node -c backend/article-publisher.js` syntax passes
- [x] Diff matches Hashnode pattern (PR #2145) byte-for-byte where structurally equivalent
- [ ] CI green
- [ ] After deploy: `/api/publisher/platforms` still shows `devto: configured=true` (env fallback works)
- [ ] `/api/publisher/devto/me` with no deviceId still resolves via env (backwards compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)