### PR TITLE
feat(publisher): Qiita vault-first multi-tenant (4/10 platforms)

### DIFF
--- a/backend/article-publisher.js
+++ b/backend/article-publisher.js
@@ -99,6 +99,11 @@ let telegraphAccessToken = process.env.TELEGRAPH_ACCESS_TOKEN || null;
 // Qiita
 const QIITA_ACCESS_TOKEN = process.env.QIITA_ACCESS_TOKEN;
 const QIITA_API_BASE = 'https://qiita.com/api/v2';
+const QIITA_CRED_KEYS = ['QIITA_ACCESS_TOKEN'];
+const QIITA_CREDS_MISSING = {
+    error: 'Qiita credentials not set for this device',
+    setup_url: '/portal/publisher-setup.html'
+};
 
 // WeChat Official Account
 const WECHAT_APP_ID = process.env.WECHAT_APP_ID;
@@ -1413,16 +1418,23 @@ router.get('/telegraph/page/:path/views', async (req, res) => {
 // Rate limit: 1000 req/hr (authenticated)
 // ============================================
 
-function requireQiita(res) {
-    if (!QIITA_ACCESS_TOKEN) { res.status(501).json({ error: 'Qiita not configured (QIITA_ACCESS_TOKEN missing)' }); return false; }
-    return true;
+// Resolve the Qiita bearer token (vault-first, env fallback).
+async function resolveQiitaCreds(deviceId) {
+    if (deviceId && typeof _getDeviceVar === 'function') {
+        try {
+            const v = await _getDeviceVar(deviceId, QIITA_CRED_KEYS[0]);
+            if (typeof v === 'string' && v.length > 0) return { token: v, source: 'vault' };
+        } catch (_) { /* fall through to env */ }
+    }
+    if (QIITA_ACCESS_TOKEN) return { token: QIITA_ACCESS_TOKEN, source: 'env' };
+    return { token: null, source: 'missing' };
 }
 
-async function qiitaRequest(method, path, body = null) {
+async function qiitaRequest(method, path, body = null, token = QIITA_ACCESS_TOKEN) {
     const options = {
         method,
         headers: {
-            Authorization: `Bearer ${QIITA_ACCESS_TOKEN}`,
+            Authorization: `Bearer ${token}`,
             'Content-Type': 'application/json'
         }
     };
@@ -1444,10 +1456,12 @@ async function qiitaRequest(method, path, body = null) {
 
 // GET /api/publisher/qiita/me
 router.get('/qiita/me', async (req, res) => {
-    if (!requireQiita(res)) return;
     try {
-        const data = await qiitaRequest('GET', '/authenticated_user');
-        res.json({ success: true, user: { id: data.id, name: data.name, items_count: data.items_count, followers_count: data.followers_count } });
+        const deviceId = req.query?.deviceId || null;
+        const { token, source } = await resolveQiitaCreds(deviceId);
+        if (!token) return res.status(400).json(QIITA_CREDS_MISSING);
+        const data = await qiitaRequest('GET', '/authenticated_user', null, token);
+        res.json({ success: true, user: { id: data.id, name: data.name, items_count: data.items_count, followers_count: data.followers_count }, _credSource: source });
     } catch (err) {
         res.status(err.status || 500).json({ error: err.message });
     }
@@ -1455,13 +1469,15 @@ router.get('/qiita/me', async (req, res) => {
 
 // POST /api/publisher/qiita/publish
 router.post('/qiita/publish', express.json(), async (req, res) => {
-    if (!requireQiita(res)) return;
     const rateLimitMsg = checkPublishRateLimit('qiita');
     if (rateLimitMsg) return res.status(429).json({ error: rateLimitMsg });
-    const { title, body, tags, private: isPrivate, tweet, includeReferralCTA } = req.body;
+    const { title, body, tags, private: isPrivate, tweet, includeReferralCTA, deviceId } = req.body;
     if (!title || !body) return res.status(400).json({ error: 'title, body required' });
 
     try {
+        const { token, source } = await resolveQiitaCreds(deviceId || null);
+        if (!token) return res.status(400).json(QIITA_CREDS_MISSING);
+
         const finalBody = appendReferralCTA(body, { format: 'md', skip: includeReferralCTA === false });
         const item = {
             title,
@@ -1472,9 +1488,9 @@ router.post('/qiita/publish', express.json(), async (req, res) => {
         };
         if (item.tags.length === 0) item.tags = [{ name: 'EClaw', versions: [] }];
 
-        const data = await qiitaRequest('POST', '/items', item);
+        const data = await qiitaRequest('POST', '/items', item, token);
         recordPublish('qiita');
-        console.log(`[Publisher] Qiita article created: ${data.id} "${title}"`);
+        console.log(`[Publisher] Qiita article created: ${data.id} "${title}" (creds: ${source})`);
         res.json({ success: true, platform: 'qiita', postId: data.id, url: data.url, title: data.title });
     } catch (err) {
         console.error('[Publisher] Qiita publish error:', err);
@@ -1484,18 +1500,20 @@ router.post('/qiita/publish', express.json(), async (req, res) => {
 
 // PUT /api/publisher/qiita/post/:postId
 router.put('/qiita/post/:postId', express.json(), async (req, res) => {
-    if (!requireQiita(res)) return;
     const { postId } = req.params;
-    const { title, body, tags, private: isPrivate } = req.body;
+    const { title, body, tags, private: isPrivate, deviceId } = req.body;
 
     try {
+        const { token } = await resolveQiitaCreds(deviceId || null);
+        if (!token) return res.status(400).json(QIITA_CREDS_MISSING);
+
         const item = {};
         if (title !== undefined) item.title = title;
         if (body !== undefined) item.body = body;
         if (isPrivate !== undefined) item.private = isPrivate;
         if (tags !== undefined) item.tags = tags.map(t => typeof t === 'string' ? { name: t, versions: [] } : t);
 
-        const data = await qiitaRequest('PATCH', `/items/${postId}`, item);
+        const data = await qiitaRequest('PATCH', `/items/${postId}`, item, token);
         console.log(`[Publisher] Qiita article updated: ${postId}`);
         res.json({ success: true, platform: 'qiita', postId: data.id, url: data.url, title: data.title });
     } catch (err) {
@@ -1505,11 +1523,13 @@ router.put('/qiita/post/:postId', express.json(), async (req, res) => {
 });
 
 // DELETE /api/publisher/qiita/post/:postId
-router.delete('/qiita/post/:postId', async (req, res) => {
-    if (!requireQiita(res)) return;
+router.delete('/qiita/post/:postId', express.json(), async (req, res) => {
     const { postId } = req.params;
+    const deviceId = req.body?.deviceId || req.query?.deviceId || null;
     try {
-        await qiitaRequest('DELETE', `/items/${postId}`);
+        const { token } = await resolveQiitaCreds(deviceId);
+        if (!token) return res.status(400).json(QIITA_CREDS_MISSING);
+        await qiitaRequest('DELETE', `/items/${postId}`, null, token);
         console.log(`[Publisher] Qiita article deleted: ${postId}`);
         res.json({ success: true, platform: 'qiita', deleted: postId });
     } catch (err) {

--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -3679,14 +3679,14 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                     <div class="guide-panel" id="guide-publisher">
                         <header>
                             <h1 data-i18n="guide_pub_title">多平台發布 Publisher</h1>
-                            <p class="meta" data-i18n="guide_pub_meta">10 個內容平台 · 多租戶金鑰 roadmap · X / Hashnode / DEV.to 已上線、其餘 env-only</p>
+                            <p class="meta" data-i18n="guide_pub_meta">10 個內容平台 · 多租戶金鑰 roadmap · X / Hashnode / DEV.to / Qiita 已上線、其餘 env-only</p>
                         </header>
 
                         <h2 data-i18n="guide_pub_overview_h">總覽</h2>
                         <p data-i18n="guide_pub_overview_desc">
                             <code>backend/article-publisher.js</code> 把 10 個內容平台統一在 <code>/api/publisher/&lt;platform&gt;/*</code> 之下。
                             「多租戶」指的是<strong>每個 device 用自己金鑰庫裡的金鑰</strong>呼叫對應平台，而非全站共用 owner 一把 env 金鑰。
-                            目前 X、Hashnode、DEV.to 走完整的 vault-first 流程（<code>resolveXCreds()</code> / <code>resolveHashnodeCreds()</code> / <code>resolveDevtoCreds()</code>），其餘平台仍是 env-only single-tenant。
+                            目前 X、Hashnode、DEV.to、Qiita 走完整的 vault-first 流程（<code>resolveXCreds()</code> / <code>resolveHashnodeCreds()</code> / <code>resolveDevtoCreds()</code> / <code>resolveQiitaCreds()</code>），其餘平台仍是 env-only single-tenant。
                         </p>
 
                         <h2 data-i18n="guide_pub_status_h">平台狀態總表</h2>
@@ -3746,7 +3746,7 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                                     <td>ja</td>
                                     <td>Bearer</td>
                                     <td><code>QIITA_ACCESS_TOKEN</code></td>
-                                    <td><span class="pub-badge pub-badge-env">⚙️ env-only</span></td>
+                                    <td><span class="pub-badge pub-badge-vault">🔓 vault-first</span></td>
                                 </tr>
                                 <tr>
                                     <td><strong>WeChat 公眾號</strong></td>
@@ -3793,7 +3793,7 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                             </tbody>
                         </table>
 
-                        <h2 data-i18n="guide_pub_roadmap_h">Roadmap：把剩下 7 個平台搬上 vault-first</h2>
+                        <h2 data-i18n="guide_pub_roadmap_h">Roadmap：把剩下 6 個平台搬上 vault-first</h2>
                         <p data-i18n="guide_pub_roadmap_desc">每一個平台只要照 X 的樣板做：先在 publisher router 頂部加一個 <code>resolve&lt;Platform&gt;Creds(deviceId)</code>，先讀 <code>_getDeviceVar()</code>、若缺則 fallback 到 <code>process.env</code>，然後在每個 endpoint 把 <code>process.env.XXX</code> 換成 <code>(await resolve())</code> 結果。</p>
                         <ol>
                             <li data-i18n="guide_pub_roadmap_step1">複製 <code>resolveXCreds()</code> 為 <code>resolveTumblrCreds()</code>、<code>resolveRedditCreds()</code> ... 共 9 份。</li>


### PR DESCRIPTION
## Summary
- Adds vault-first Qiita credential resolution mirroring the DEV.to pattern (PR #2146)
- All 4 Qiita publisher routes now read per-device bearer token from vault first, env fallback
- info.html Qiita badge flips to vault-first; roadmap counter 7→6

## What changed
- `resolveQiitaCreds(deviceId)` returns `{ token, source: 'vault'|'env'|'missing' }`
- `qiitaRequest(method, path, body, token)` — token defaults to env to keep internal callers working
- Routes touched: `GET /qiita/me`, `POST /qiita/publish`, `PUT /qiita/post/:id`, `DELETE /qiita/post/:id`
- `DELETE` route now uses `express.json()` so deviceId can come from body
- `info.html`: meta tagline + overview paragraph + Qiita badge + roadmap header

## Test plan
- [x] `node -c backend/article-publisher.js` syntax passes
- [x] Diff matches DEV.to pattern (PR #2146) byte-for-byte (1-key 結構同等)
- [ ] CI green
- [ ] After deploy: `/api/publisher/platforms` still shows `qiita: configured=true` (env fallback works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)