### PR TITLE
feat(publisher): LinkedIn vault-first multi-tenant support

### DIFF
--- a/backend/article-publisher.js
+++ b/backend/article-publisher.js
@@ -128,6 +128,11 @@ let redditTokenCache = { access_token: null, expires_at: 0 };
 // LinkedIn (OAuth2 Bearer)
 const LINKEDIN_ACCESS_TOKEN = process.env.LINKEDIN_ACCESS_TOKEN;
 const LINKEDIN_PERSON_URN = process.env.LINKEDIN_PERSON_URN; // e.g. "urn:li:person:abc123"
+const LINKEDIN_CRED_KEYS = ['LINKEDIN_ACCESS_TOKEN', 'LINKEDIN_PERSON_URN'];
+const LINKEDIN_CREDS_MISSING = {
+    error: 'LinkedIn credentials not set for this device',
+    setup_url: '/portal/publisher-setup.html'
+};
 
 // Mastodon (Bearer token, any instance)
 const MASTODON_ACCESS_TOKEN = process.env.MASTODON_ACCESS_TOKEN;
@@ -1930,19 +1935,28 @@ router.delete('/reddit/post/:postId', async (req, res) => {
 // Auth: Bearer token | Content: text/article
 // ============================================
 
-function requireLinkedin(res) {
-    if (!LINKEDIN_ACCESS_TOKEN || !LINKEDIN_PERSON_URN) {
-        res.status(501).json({ error: 'LinkedIn not configured (LINKEDIN_ACCESS_TOKEN, LINKEDIN_PERSON_URN missing)' });
-        return false;
+// Resolve LinkedIn credentials (vault-first, env fallback). Both access token AND person URN required.
+async function resolveLinkedinCreds(deviceId) {
+    if (deviceId && typeof _getDeviceVar === 'function') {
+        try {
+            const tok = await _getDeviceVar(deviceId, 'LINKEDIN_ACCESS_TOKEN');
+            const urn = await _getDeviceVar(deviceId, 'LINKEDIN_PERSON_URN');
+            if (typeof tok === 'string' && tok.length > 0 && typeof urn === 'string' && urn.length > 0) {
+                return { accessToken: tok, personUrn: urn, source: 'vault' };
+            }
+        } catch (_) { /* fall through to env */ }
     }
-    return true;
+    if (LINKEDIN_ACCESS_TOKEN && LINKEDIN_PERSON_URN) {
+        return { accessToken: LINKEDIN_ACCESS_TOKEN, personUrn: LINKEDIN_PERSON_URN, source: 'env' };
+    }
+    return { accessToken: null, personUrn: null, source: 'missing' };
 }
 
-async function linkedinRequest(method, path, body = null) {
+async function linkedinRequest(method, path, body = null, accessToken = LINKEDIN_ACCESS_TOKEN) {
     const options = {
         method,
         headers: {
-            Authorization: `Bearer ${LINKEDIN_ACCESS_TOKEN}`,
+            Authorization: `Bearer ${accessToken}`,
             'Content-Type': 'application/json',
             'X-Restli-Protocol-Version': '2.0.0',
             'LinkedIn-Version': '202501'
@@ -1962,10 +1976,12 @@ async function linkedinRequest(method, path, body = null) {
 
 // GET /api/publisher/linkedin/me
 router.get('/linkedin/me', async (req, res) => {
-    if (!requireLinkedin(res)) return;
     try {
-        const data = await linkedinRequest('GET', '/v2/userinfo');
-        res.json({ success: true, user: { sub: data.sub, name: data.name, email: data.email, picture: data.picture } });
+        const deviceId = req.query?.deviceId || null;
+        const { accessToken, source } = await resolveLinkedinCreds(deviceId);
+        if (!accessToken) return res.status(400).json(LINKEDIN_CREDS_MISSING);
+        const data = await linkedinRequest('GET', '/v2/userinfo', null, accessToken);
+        res.json({ success: true, user: { sub: data.sub, name: data.name, email: data.email, picture: data.picture }, _credSource: source });
     } catch (err) {
         res.status(err.status || 500).json({ error: err.message });
     }
@@ -1973,13 +1989,15 @@ router.get('/linkedin/me', async (req, res) => {
 
 // POST /api/publisher/linkedin/publish — Create a post (text or article)
 router.post('/linkedin/publish', express.json(), async (req, res) => {
-    if (!requireLinkedin(res)) return;
-    const { text, articleUrl, articleTitle, articleDescription, visibility } = req.body;
+    const { text, articleUrl, articleTitle, articleDescription, visibility, deviceId } = req.body;
     if (!text) return res.status(400).json({ error: 'text required' });
 
     try {
+        const { accessToken, personUrn, source } = await resolveLinkedinCreds(deviceId || null);
+        if (!accessToken) return res.status(400).json(LINKEDIN_CREDS_MISSING);
+
         const postBody = {
-            author: LINKEDIN_PERSON_URN,
+            author: personUrn,
             commentary: text,
             visibility: visibility || 'PUBLIC',
             distribution: { feedDistribution: 'MAIN_FEED', targetEntities: [], thirdPartyDistributionChannels: [] },
@@ -1997,9 +2015,9 @@ router.post('/linkedin/publish', express.json(), async (req, res) => {
             };
         }
 
-        const data = await linkedinRequest('POST', '/rest/posts', postBody);
+        const data = await linkedinRequest('POST', '/rest/posts', postBody, accessToken);
         // LinkedIn returns 201 with x-restli-id header for the post URN
-        console.log(`[Publisher] LinkedIn post created`);
+        console.log(`[Publisher] LinkedIn post created (creds: ${source})`);
         res.json({ success: true, platform: 'linkedin', postId: data?.id || 'created' });
     } catch (err) {
         console.error('[Publisher] LinkedIn publish error:', err);
@@ -2008,11 +2026,13 @@ router.post('/linkedin/publish', express.json(), async (req, res) => {
 });
 
 // DELETE /api/publisher/linkedin/post/:postUrn — Delete a post
-router.delete('/linkedin/post/:postUrn', async (req, res) => {
-    if (!requireLinkedin(res)) return;
+router.delete('/linkedin/post/:postUrn', express.json(), async (req, res) => {
     const { postUrn } = req.params;
+    const deviceId = req.body?.deviceId || req.query?.deviceId || null;
     try {
-        await linkedinRequest('DELETE', `/rest/posts/${encodeURIComponent(postUrn)}`);
+        const { accessToken } = await resolveLinkedinCreds(deviceId);
+        if (!accessToken) return res.status(400).json(LINKEDIN_CREDS_MISSING);
+        await linkedinRequest('DELETE', `/rest/posts/${encodeURIComponent(postUrn)}`, null, accessToken);
         console.log(`[Publisher] LinkedIn post deleted: ${postUrn}`);
         res.json({ success: true, platform: 'linkedin', deleted: postUrn });
     } catch (err) {

--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -3679,14 +3679,14 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                     <div class="guide-panel" id="guide-publisher">
                         <header>
                             <h1 data-i18n="guide_pub_title">多平台發布 Publisher</h1>
-                            <p class="meta" data-i18n="guide_pub_meta">10 個內容平台 · 多租戶金鑰 roadmap · X / Hashnode / DEV.to / Qiita 已上線、其餘 env-only</p>
+                            <p class="meta" data-i18n="guide_pub_meta">10 個內容平台 · 多租戶金鑰 roadmap · X / Hashnode / DEV.to / Qiita / LinkedIn 已上線、其餘 env-only</p>
                         </header>
 
                         <h2 data-i18n="guide_pub_overview_h">總覽</h2>
                         <p data-i18n="guide_pub_overview_desc">
                             <code>backend/article-publisher.js</code> 把 10 個內容平台統一在 <code>/api/publisher/&lt;platform&gt;/*</code> 之下。
                             「多租戶」指的是<strong>每個 device 用自己金鑰庫裡的金鑰</strong>呼叫對應平台，而非全站共用 owner 一把 env 金鑰。
-                            目前 X、Hashnode、DEV.to、Qiita 走完整的 vault-first 流程（<code>resolveXCreds()</code> / <code>resolveHashnodeCreds()</code> / <code>resolveDevtoCreds()</code> / <code>resolveQiitaCreds()</code>），其餘平台仍是 env-only single-tenant。
+                            目前 X、Hashnode、DEV.to、Qiita、LinkedIn 走完整的 vault-first 流程（<code>resolveXCreds()</code> / <code>resolveHashnodeCreds()</code> / <code>resolveDevtoCreds()</code> / <code>resolveQiitaCreds()</code> / <code>resolveLinkedinCreds()</code>），其餘平台仍是 env-only single-tenant。
                         </p>
 
                         <h2 data-i18n="guide_pub_status_h">平台狀態總表</h2>
@@ -3774,7 +3774,7 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                                     <td>global</td>
                                     <td>Bearer</td>
                                     <td><code>LINKEDIN_ACCESS_TOKEN</code> · <code>LINKEDIN_PERSON_URN</code></td>
-                                    <td><span class="pub-badge pub-badge-env">⚙️ env-only</span></td>
+                                    <td><span class="pub-badge pub-badge-vault">🔓 vault-first</span></td>
                                 </tr>
                                 <tr class="pub-row-retired">
                                     <td><s>WordPress.com</s></td>
@@ -3793,7 +3793,7 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                             </tbody>
                         </table>
 
-                        <h2 data-i18n="guide_pub_roadmap_h">Roadmap：把剩下 6 個平台搬上 vault-first</h2>
+                        <h2 data-i18n="guide_pub_roadmap_h">Roadmap：把剩下 5 個平台搬上 vault-first</h2>
                         <p data-i18n="guide_pub_roadmap_desc">每一個平台只要照 X 的樣板做：先在 publisher router 頂部加一個 <code>resolve&lt;Platform&gt;Creds(deviceId)</code>，先讀 <code>_getDeviceVar()</code>、若缺則 fallback 到 <code>process.env</code>，然後在每個 endpoint 把 <code>process.env.XXX</code> 換成 <code>(await resolve())</code> 結果。</p>
                         <ol>
                             <li data-i18n="guide_pub_roadmap_step1">複製 <code>resolveXCreds()</code> 為 <code>resolveTumblrCreds()</code>、<code>resolveRedditCreds()</code> ... 共 9 份。</li>


### PR DESCRIPTION
## Summary
- Mirrors Qiita PR #2147 pattern for LinkedIn (5th of 10 platforms)
- `resolveLinkedinCreds(deviceId)` reads `LINKEDIN_ACCESS_TOKEN` + `LINKEDIN_PERSON_URN` from device vault first; both must be present, else falls back to env
- `linkedinRequest` accepts `accessToken` parameter (defaults to env for backwards-compat)
- 3 routes plumb `deviceId` from req: `/me` (query), `/publish` + `/post/:postUrn` (body, DELETE got `express.json()`)
- info.html: LinkedIn row → vault-first badge, meta + overview lists `resolveLinkedinCreds()`, roadmap 6→5

## Card
- card_acaa6358eeba78cab45ceb1c (multi-tenant migration #5/10)
- Pattern alignment: same shape as X / Hashnode / DEV.to / Qiita

## Test plan
- [ ] CI green (ESLint / i18n / Jest / Railway preview)
- [ ] Self-review (commander as reviewer)
- [ ] Squash-merge into main
- [ ] Prod verify: `/api/publisher/platforms` shows `linkedin: configured=true` (env fallback intact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)