### PR TITLE
feat(publisher): Reddit vault-first multi-tenant support

### DIFF
--- a/backend/article-publisher.js
+++ b/backend/article-publisher.js
@@ -123,7 +123,13 @@ const REDDIT_CLIENT_ID = process.env.REDDIT_CLIENT_ID;
 const REDDIT_CLIENT_SECRET = process.env.REDDIT_CLIENT_SECRET;
 const REDDIT_USERNAME = process.env.REDDIT_USERNAME;
 const REDDIT_PASSWORD = process.env.REDDIT_PASSWORD;
-let redditTokenCache = { access_token: null, expires_at: 0 };
+const REDDIT_CRED_KEYS = ['REDDIT_CLIENT_ID', 'REDDIT_CLIENT_SECRET', 'REDDIT_USERNAME', 'REDDIT_PASSWORD'];
+const REDDIT_CREDS_MISSING = {
+    error: 'Reddit credentials not set for this device',
+    setup_url: '/portal/publisher-setup.html'
+};
+// Per-tenant token cache. Key = clientId+username (so device A's token cannot be served to device B).
+const redditTokenCacheByCreds = new Map();
 
 // LinkedIn (OAuth2 Bearer)
 const LINKEDIN_ACCESS_TOKEN = process.env.LINKEDIN_ACCESS_TOKEN;
@@ -1809,49 +1815,69 @@ router.delete('/tumblr/post/:postId', async (req, res) => {
 // Auth: OAuth2 password grant | Content: text/link
 // ============================================
 
-function requireReddit(res) {
-    if (!REDDIT_CLIENT_ID || !REDDIT_CLIENT_SECRET || !REDDIT_USERNAME || !REDDIT_PASSWORD) {
-        res.status(501).json({ error: 'Reddit not configured (REDDIT_CLIENT_ID, REDDIT_CLIENT_SECRET, REDDIT_USERNAME, REDDIT_PASSWORD missing)' });
-        return false;
+// Resolve Reddit credentials (vault-first, env fallback). All 4 keys atomic.
+async function resolveRedditCreds(deviceId) {
+    if (deviceId && typeof _getDeviceVar === 'function') {
+        try {
+            const cid = await _getDeviceVar(deviceId, 'REDDIT_CLIENT_ID');
+            const csec = await _getDeviceVar(deviceId, 'REDDIT_CLIENT_SECRET');
+            const usr = await _getDeviceVar(deviceId, 'REDDIT_USERNAME');
+            const pwd = await _getDeviceVar(deviceId, 'REDDIT_PASSWORD');
+            if ([cid, csec, usr, pwd].every(v => typeof v === 'string' && v.length > 0)) {
+                return { clientId: cid, clientSecret: csec, username: usr, password: pwd, source: 'vault' };
+            }
+        } catch (_) { /* fall through to env */ }
     }
-    return true;
+    if (REDDIT_CLIENT_ID && REDDIT_CLIENT_SECRET && REDDIT_USERNAME && REDDIT_PASSWORD) {
+        return {
+            clientId: REDDIT_CLIENT_ID, clientSecret: REDDIT_CLIENT_SECRET,
+            username: REDDIT_USERNAME, password: REDDIT_PASSWORD, source: 'env'
+        };
+    }
+    return { clientId: null, clientSecret: null, username: null, password: null, source: 'missing' };
 }
 
-async function getRedditToken() {
-    if (redditTokenCache.access_token && redditTokenCache.expires_at > Date.now() + 60000) {
-        return redditTokenCache.access_token;
+async function getRedditToken(creds) {
+    const cacheKey = `${creds.clientId}:${creds.username}`;
+    const cached = redditTokenCacheByCreds.get(cacheKey);
+    if (cached && cached.access_token && cached.expires_at > Date.now() + 60000) {
+        return cached.access_token;
     }
-    const auth = Buffer.from(`${REDDIT_CLIENT_ID}:${REDDIT_CLIENT_SECRET}`).toString('base64');
+    const auth = Buffer.from(`${creds.clientId}:${creds.clientSecret}`).toString('base64');
     const res = await fetch('https://www.reddit.com/api/v1/access_token', {
         method: 'POST',
         headers: {
             Authorization: `Basic ${auth}`,
             'Content-Type': 'application/x-www-form-urlencoded',
-            'User-Agent': 'EClaw:v1.0 (by /u/' + REDDIT_USERNAME + ')'
+            'User-Agent': 'EClaw:v1.0 (by /u/' + creds.username + ')'
         },
         body: new URLSearchParams({
             grant_type: 'password',
-            username: REDDIT_USERNAME,
-            password: REDDIT_PASSWORD
+            username: creds.username,
+            password: creds.password
         })
     });
     const data = await res.json();
     if (data.error) throw new Error(`Reddit auth: ${data.error}`);
-    redditTokenCache = {
+    redditTokenCacheByCreds.set(cacheKey, {
         access_token: data.access_token,
         expires_at: Date.now() + (data.expires_in * 1000)
-    };
+    });
     return data.access_token;
 }
 
-async function redditRequest(method, path, body = null) {
-    const token = await getRedditToken();
+async function redditRequest(method, path, body = null, creds = null) {
+    const effectiveCreds = creds || {
+        clientId: REDDIT_CLIENT_ID, clientSecret: REDDIT_CLIENT_SECRET,
+        username: REDDIT_USERNAME, password: REDDIT_PASSWORD
+    };
+    const token = await getRedditToken(effectiveCreds);
     const options = {
         method,
         headers: {
             Authorization: `Bearer ${token}`,
             'Content-Type': 'application/x-www-form-urlencoded',
-            'User-Agent': 'EClaw:v1.0 (by /u/' + REDDIT_USERNAME + ')'
+            'User-Agent': 'EClaw:v1.0 (by /u/' + effectiveCreds.username + ')'
         }
     };
     if (body) options.body = new URLSearchParams(body);
@@ -1867,17 +1893,19 @@ async function redditRequest(method, path, body = null) {
 
 // GET /api/publisher/reddit/me
 router.get('/reddit/me', async (req, res) => {
-    if (!requireReddit(res)) return;
     try {
-        const token = await getRedditToken();
+        const deviceId = req.query?.deviceId || null;
+        const creds = await resolveRedditCreds(deviceId);
+        if (!creds.clientId) return res.status(400).json(REDDIT_CREDS_MISSING);
+        const token = await getRedditToken(creds);
         const meRes = await fetch('https://oauth.reddit.com/api/v1/me', {
             headers: {
                 Authorization: `Bearer ${token}`,
-                'User-Agent': 'EClaw:v1.0 (by /u/' + REDDIT_USERNAME + ')'
+                'User-Agent': 'EClaw:v1.0 (by /u/' + creds.username + ')'
             }
         });
         const data = await meRes.json();
-        res.json({ success: true, user: { name: data.name, id: data.id, link_karma: data.link_karma, comment_karma: data.comment_karma } });
+        res.json({ success: true, user: { name: data.name, id: data.id, link_karma: data.link_karma, comment_karma: data.comment_karma }, _credSource: creds.source });
     } catch (err) {
         res.status(err.status || 500).json({ error: err.message });
     }
@@ -1885,11 +1913,13 @@ router.get('/reddit/me', async (req, res) => {
 
 // POST /api/publisher/reddit/submit — Submit a text or link post
 router.post('/reddit/submit', express.json(), async (req, res) => {
-    if (!requireReddit(res)) return;
-    const { subreddit, title, text, url: linkUrl, kind } = req.body;
+    const { subreddit, title, text, url: linkUrl, kind, deviceId } = req.body;
     if (!subreddit || !title) return res.status(400).json({ error: 'subreddit, title required' });
 
     try {
+        const creds = await resolveRedditCreds(deviceId || null);
+        if (!creds.clientId) return res.status(400).json(REDDIT_CREDS_MISSING);
+
         const postBody = {
             sr: subreddit,
             title,
@@ -1899,12 +1929,12 @@ router.post('/reddit/submit', express.json(), async (req, res) => {
         if (linkUrl) postBody.url = linkUrl;
         if (text) postBody.text = text;
 
-        const data = await redditRequest('POST', '/api/submit', postBody);
+        const data = await redditRequest('POST', '/api/submit', postBody, creds);
         const result = data.json?.data;
         if (data.json?.errors?.length > 0) {
             return res.status(400).json({ error: data.json.errors.map(e => e.join(': ')).join('; ') });
         }
-        console.log(`[Publisher] Reddit post submitted to r/${subreddit}: ${result?.id}`);
+        console.log(`[Publisher] Reddit post submitted to r/${subreddit}: ${result?.id} (creds: ${creds.source})`);
         res.json({
             success: true, platform: 'reddit', postId: result?.id,
             url: result?.url, subreddit, title
@@ -1916,12 +1946,14 @@ router.post('/reddit/submit', express.json(), async (req, res) => {
 });
 
 // DELETE /api/publisher/reddit/post/:postId — Delete (requires fullname t3_id)
-router.delete('/reddit/post/:postId', async (req, res) => {
-    if (!requireReddit(res)) return;
+router.delete('/reddit/post/:postId', express.json(), async (req, res) => {
     const { postId } = req.params;
+    const deviceId = req.body?.deviceId || req.query?.deviceId || null;
     try {
+        const creds = await resolveRedditCreds(deviceId);
+        if (!creds.clientId) return res.status(400).json(REDDIT_CREDS_MISSING);
         const fullname = postId.startsWith('t3_') ? postId : `t3_${postId}`;
-        await redditRequest('POST', '/api/del', { id: fullname });
+        await redditRequest('POST', '/api/del', { id: fullname }, creds);
         console.log(`[Publisher] Reddit post deleted: ${postId}`);
         res.json({ success: true, platform: 'reddit', deleted: postId });
     } catch (err) {

--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -3679,14 +3679,14 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                     <div class="guide-panel" id="guide-publisher">
                         <header>
                             <h1 data-i18n="guide_pub_title">多平台發布 Publisher</h1>
-                            <p class="meta" data-i18n="guide_pub_meta">10 個內容平台 · 多租戶金鑰 roadmap · X / Hashnode / DEV.to / Qiita / LinkedIn 已上線、其餘 env-only</p>
+                            <p class="meta" data-i18n="guide_pub_meta">10 個內容平台 · 多租戶金鑰 roadmap · X / Hashnode / DEV.to / Qiita / LinkedIn / Reddit 已上線、其餘 env-only</p>
                         </header>
 
                         <h2 data-i18n="guide_pub_overview_h">總覽</h2>
                         <p data-i18n="guide_pub_overview_desc">
                             <code>backend/article-publisher.js</code> 把 10 個內容平台統一在 <code>/api/publisher/&lt;platform&gt;/*</code> 之下。
                             「多租戶」指的是<strong>每個 device 用自己金鑰庫裡的金鑰</strong>呼叫對應平台，而非全站共用 owner 一把 env 金鑰。
-                            目前 X、Hashnode、DEV.to、Qiita、LinkedIn 走完整的 vault-first 流程（<code>resolveXCreds()</code> / <code>resolveHashnodeCreds()</code> / <code>resolveDevtoCreds()</code> / <code>resolveQiitaCreds()</code> / <code>resolveLinkedinCreds()</code>），其餘平台仍是 env-only single-tenant。
+                            目前 X、Hashnode、DEV.to、Qiita、LinkedIn、Reddit 走完整的 vault-first 流程（<code>resolveXCreds()</code> / <code>resolveHashnodeCreds()</code> / <code>resolveDevtoCreds()</code> / <code>resolveQiitaCreds()</code> / <code>resolveLinkedinCreds()</code> / <code>resolveRedditCreds()</code>），其餘平台仍是 env-only single-tenant。
                         </p>
 
                         <h2 data-i18n="guide_pub_status_h">平台狀態總表</h2>
@@ -3767,7 +3767,7 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                                     <td>global</td>
                                     <td>OAuth2 password</td>
                                     <td><code>REDDIT_CLIENT_ID</code> · <code>REDDIT_CLIENT_SECRET</code> · <code>REDDIT_USERNAME</code> · <code>REDDIT_PASSWORD</code></td>
-                                    <td><span class="pub-badge pub-badge-env">⚙️ env-only</span></td>
+                                    <td><span class="pub-badge pub-badge-vault">🔓 vault-first</span></td>
                                 </tr>
                                 <tr>
                                     <td><strong>LinkedIn</strong></td>
@@ -3793,7 +3793,7 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                             </tbody>
                         </table>
 
-                        <h2 data-i18n="guide_pub_roadmap_h">Roadmap：把剩下 5 個平台搬上 vault-first</h2>
+                        <h2 data-i18n="guide_pub_roadmap_h">Roadmap：把剩下 4 個平台搬上 vault-first</h2>
                         <p data-i18n="guide_pub_roadmap_desc">每一個平台只要照 X 的樣板做：先在 publisher router 頂部加一個 <code>resolve&lt;Platform&gt;Creds(deviceId)</code>，先讀 <code>_getDeviceVar()</code>、若缺則 fallback 到 <code>process.env</code>，然後在每個 endpoint 把 <code>process.env.XXX</code> 換成 <code>(await resolve())</code> 結果。</p>
                         <ol>
                             <li data-i18n="guide_pub_roadmap_step1">複製 <code>resolveXCreds()</code> 為 <code>resolveTumblrCreds()</code>、<code>resolveRedditCreds()</code> ... 共 9 份。</li>


### PR DESCRIPTION
## Summary
- 6th of 10 platforms; mirrors LinkedIn PR #2148 + adds **per-tenant token cache** (the genuinely novel piece)
- `resolveRedditCreds(deviceId)`: vault-first; 4-key atomic check (CLIENT_ID/CLIENT_SECRET/USERNAME/PASSWORD); falls back to env as a unit
- **Token cache changed from `let redditTokenCache = {...}` to `Map<clientId:username, {token, expiresAt}>`** — fixes a cross-tenant leak that would surface as soon as a 2nd device started using the vault path
- `getRedditToken(creds)` + `redditRequest(method, path, body, creds=null)` both accept creds; `redditRequest` defaults to env creds for symmetry
- 3 routes plumb deviceId from req; DELETE got `express.json()`
- info.html: Reddit row → vault-first badge, meta + overview lists `resolveRedditCreds()`, roadmap 5→4

## Card
- card_a679d498e452e68ec2157edc (multi-tenant migration #6/10)

## Test plan
- [ ] CI green (ESLint / i18n / Jest / Railway preview)
- [ ] Self-review (commander as reviewer)
- [ ] Squash-merge into main
- [ ] Prod verify deploy lands (Reddit env not set on prod, so will stay configured=false — no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)