### PR TITLE
feat(publisher): Tumblr vault-first multi-tenant (#7/10)

### DIFF
--- a/backend/article-publisher.js
+++ b/backend/article-publisher.js
@@ -117,6 +117,11 @@ const TUMBLR_CONSUMER_SECRET = process.env.TUMBLR_CONSUMER_SECRET;
 const TUMBLR_ACCESS_TOKEN = process.env.TUMBLR_ACCESS_TOKEN;
 const TUMBLR_ACCESS_TOKEN_SECRET = process.env.TUMBLR_ACCESS_TOKEN_SECRET;
 const TUMBLR_API_BASE = 'https://api.tumblr.com/v2';
+const TUMBLR_CRED_KEYS = ['TUMBLR_CONSUMER_KEY', 'TUMBLR_CONSUMER_SECRET', 'TUMBLR_ACCESS_TOKEN', 'TUMBLR_ACCESS_TOKEN_SECRET'];
+const TUMBLR_CREDS_MISSING = {
+    error: 'Tumblr credentials not set for this device',
+    setup_url: '/portal/publisher-setup.html'
+};
 
 // Reddit (OAuth2 password grant — script app)
 const REDDIT_CLIENT_ID = process.env.REDDIT_CLIENT_ID;
@@ -1707,17 +1712,37 @@ router.delete('/wechat/draft/:mediaId', async (req, res) => {
 // Auth: OAuth 1.0a | Content: NPF (Neue Post Format) / HTML
 // ============================================
 
-function requireTumblr(res) {
-    if (!TUMBLR_CONSUMER_KEY || !TUMBLR_ACCESS_TOKEN) {
-        res.status(501).json({ error: 'Tumblr not configured (TUMBLR_CONSUMER_KEY, TUMBLR_ACCESS_TOKEN missing)' });
-        return false;
+// Resolve Tumblr OAuth1.0a credentials (vault-first, env fallback). All 4 keys atomic.
+async function resolveTumblrCreds(deviceId) {
+    if (deviceId && typeof _getDeviceVar === 'function') {
+        try {
+            const ck = await _getDeviceVar(deviceId, 'TUMBLR_CONSUMER_KEY');
+            const cs = await _getDeviceVar(deviceId, 'TUMBLR_CONSUMER_SECRET');
+            const at = await _getDeviceVar(deviceId, 'TUMBLR_ACCESS_TOKEN');
+            const ats = await _getDeviceVar(deviceId, 'TUMBLR_ACCESS_TOKEN_SECRET');
+            if (typeof ck === 'string' && ck.length > 0
+                && typeof cs === 'string' && cs.length > 0
+                && typeof at === 'string' && at.length > 0
+                && typeof ats === 'string' && ats.length > 0) {
+                return { consumerKey: ck, consumerSecret: cs, accessToken: at, accessTokenSecret: ats, source: 'vault' };
+            }
+        } catch (_) { /* fall through to env */ }
     }
-    return true;
+    if (TUMBLR_CONSUMER_KEY && TUMBLR_CONSUMER_SECRET && TUMBLR_ACCESS_TOKEN && TUMBLR_ACCESS_TOKEN_SECRET) {
+        return {
+            consumerKey: TUMBLR_CONSUMER_KEY,
+            consumerSecret: TUMBLR_CONSUMER_SECRET,
+            accessToken: TUMBLR_ACCESS_TOKEN,
+            accessTokenSecret: TUMBLR_ACCESS_TOKEN_SECRET,
+            source: 'env'
+        };
+    }
+    return { consumerKey: null, consumerSecret: null, accessToken: null, accessTokenSecret: null, source: 'missing' };
 }
 
-function getTumblrOAuth() {
+function getTumblrOAuth(creds) {
     return OAuth({
-        consumer: { key: TUMBLR_CONSUMER_KEY, secret: TUMBLR_CONSUMER_SECRET },
+        consumer: { key: creds.consumerKey, secret: creds.consumerSecret },
         signature_method: 'HMAC-SHA1',
         hash_function(base_string, key) {
             return crypto.createHmac('sha1', key).update(base_string).digest('base64');
@@ -1725,10 +1750,16 @@ function getTumblrOAuth() {
     });
 }
 
-async function tumblrRequest(method, path, body = null) {
+async function tumblrRequest(method, path, body = null, creds = null) {
+    const effectiveCreds = creds || {
+        consumerKey: TUMBLR_CONSUMER_KEY,
+        consumerSecret: TUMBLR_CONSUMER_SECRET,
+        accessToken: TUMBLR_ACCESS_TOKEN,
+        accessTokenSecret: TUMBLR_ACCESS_TOKEN_SECRET
+    };
     const url = `${TUMBLR_API_BASE}${path}`;
-    const oauth = getTumblrOAuth();
-    const token = { key: TUMBLR_ACCESS_TOKEN, secret: TUMBLR_ACCESS_TOKEN_SECRET };
+    const oauth = getTumblrOAuth(effectiveCreds);
+    const token = { key: effectiveCreds.accessToken, secret: effectiveCreds.accessTokenSecret };
     const authHeader = oauth.toHeader(oauth.authorize({ url, method }, token));
 
     const options = {
@@ -1749,9 +1780,11 @@ async function tumblrRequest(method, path, body = null) {
 
 // GET /api/publisher/tumblr/me — Get user info + blogs
 router.get('/tumblr/me', async (req, res) => {
-    if (!requireTumblr(res)) return;
+    const deviceId = req.query.deviceId;
+    const creds = await resolveTumblrCreds(deviceId);
+    if (creds.source === 'missing') return res.status(501).json(TUMBLR_CREDS_MISSING);
     try {
-        const data = await tumblrRequest('GET', '/user/info');
+        const data = await tumblrRequest('GET', '/user/info', null, creds);
         const user = data.user;
         res.json({
             success: true,
@@ -1764,7 +1797,9 @@ router.get('/tumblr/me', async (req, res) => {
 
 // POST /api/publisher/tumblr/publish
 router.post('/tumblr/publish', express.json(), async (req, res) => {
-    if (!requireTumblr(res)) return;
+    const deviceId = req.body.deviceId;
+    const creds = await resolveTumblrCreds(deviceId);
+    if (creds.source === 'missing') return res.status(501).json(TUMBLR_CREDS_MISSING);
     const { blogName, title, content, tags, state, includeReferralCTA } = req.body;
     if (!blogName || !content) return res.status(400).json({ error: 'blogName, content required' });
 
@@ -1781,7 +1816,7 @@ router.post('/tumblr/publish', express.json(), async (req, res) => {
             postBody.content.unshift({ type: 'text', subtype: 'heading1', text: title });
         }
 
-        const data = await tumblrRequest('POST', `/blog/${blogName}/posts`, postBody);
+        const data = await tumblrRequest('POST', `/blog/${blogName}/posts`, postBody, creds);
         console.log(`[Publisher] Tumblr post created: ${data.id} on ${blogName}`);
         res.json({
             success: true, platform: 'tumblr', postId: String(data.id),
@@ -1795,13 +1830,15 @@ router.post('/tumblr/publish', express.json(), async (req, res) => {
 
 // DELETE /api/publisher/tumblr/post/:postId
 router.delete('/tumblr/post/:postId', async (req, res) => {
-    if (!requireTumblr(res)) return;
+    const deviceId = req.query.deviceId;
+    const creds = await resolveTumblrCreds(deviceId);
+    if (creds.source === 'missing') return res.status(501).json(TUMBLR_CREDS_MISSING);
     const { postId } = req.params;
     const { blogName } = req.query;
     if (!blogName) return res.status(400).json({ error: 'blogName query param required' });
 
     try {
-        await tumblrRequest('POST', `/blog/${blogName}/post/delete`, { id: postId });
+        await tumblrRequest('POST', `/blog/${blogName}/post/delete`, { id: postId }, creds);
         console.log(`[Publisher] Tumblr post deleted: ${postId}`);
         res.json({ success: true, platform: 'tumblr', deleted: postId });
     } catch (err) {

--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -3679,14 +3679,14 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                     <div class="guide-panel" id="guide-publisher">
                         <header>
                             <h1 data-i18n="guide_pub_title">多平台發布 Publisher</h1>
-                            <p class="meta" data-i18n="guide_pub_meta">10 個內容平台 · 多租戶金鑰 roadmap · X / Hashnode / DEV.to / Qiita / LinkedIn / Reddit 已上線、其餘 env-only</p>
+                            <p class="meta" data-i18n="guide_pub_meta">10 個內容平台 · 多租戶金鑰 roadmap · X / Hashnode / DEV.to / Qiita / LinkedIn / Reddit / Tumblr 已上線、其餘 env-only</p>
                         </header>
 
                         <h2 data-i18n="guide_pub_overview_h">總覽</h2>
                         <p data-i18n="guide_pub_overview_desc">
                             <code>backend/article-publisher.js</code> 把 10 個內容平台統一在 <code>/api/publisher/&lt;platform&gt;/*</code> 之下。
                             「多租戶」指的是<strong>每個 device 用自己金鑰庫裡的金鑰</strong>呼叫對應平台，而非全站共用 owner 一把 env 金鑰。
-                            目前 X、Hashnode、DEV.to、Qiita、LinkedIn、Reddit 走完整的 vault-first 流程（<code>resolveXCreds()</code> / <code>resolveHashnodeCreds()</code> / <code>resolveDevtoCreds()</code> / <code>resolveQiitaCreds()</code> / <code>resolveLinkedinCreds()</code> / <code>resolveRedditCreds()</code>），其餘平台仍是 env-only single-tenant。
+                            目前 X、Hashnode、DEV.to、Qiita、LinkedIn、Reddit、Tumblr 走完整的 vault-first 流程（<code>resolveXCreds()</code> / <code>resolveHashnodeCreds()</code> / <code>resolveDevtoCreds()</code> / <code>resolveQiitaCreds()</code> / <code>resolveLinkedinCreds()</code> / <code>resolveRedditCreds()</code> / <code>resolveTumblrCreds()</code>），其餘平台仍是 env-only single-tenant。
                         </p>
 
                         <h2 data-i18n="guide_pub_status_h">平台狀態總表</h2>
@@ -3760,7 +3760,7 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                                     <td>global</td>
                                     <td>OAuth1a</td>
                                     <td><code>TUMBLR_CONSUMER_KEY</code> · <code>TUMBLR_CONSUMER_SECRET</code> · <code>TUMBLR_ACCESS_TOKEN</code> · <code>TUMBLR_ACCESS_TOKEN_SECRET</code></td>
-                                    <td><span class="pub-badge pub-badge-env">⚙️ env-only</span></td>
+                                    <td><span class="pub-badge pub-badge-vault">🔓 vault-first</span></td>
                                 </tr>
                                 <tr>
                                     <td><strong>Reddit</strong></td>
@@ -3793,7 +3793,7 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                             </tbody>
                         </table>
 
-                        <h2 data-i18n="guide_pub_roadmap_h">Roadmap：把剩下 4 個平台搬上 vault-first</h2>
+                        <h2 data-i18n="guide_pub_roadmap_h">Roadmap：把剩下 3 個平台搬上 vault-first</h2>
                         <p data-i18n="guide_pub_roadmap_desc">每一個平台只要照 X 的樣板做：先在 publisher router 頂部加一個 <code>resolve&lt;Platform&gt;Creds(deviceId)</code>，先讀 <code>_getDeviceVar()</code>、若缺則 fallback 到 <code>process.env</code>，然後在每個 endpoint 把 <code>process.env.XXX</code> 換成 <code>(await resolve())</code> 結果。</p>
                         <ol>
                             <li data-i18n="guide_pub_roadmap_step1">複製 <code>resolveXCreds()</code> 為 <code>resolveTumblrCreds()</code>、<code>resolveRedditCreds()</code> ... 共 9 份。</li>


### PR DESCRIPTION
## Summary
- 7th platform in vault-first multi-tenant migration (X / Hashnode / DEV.to / Qiita / LinkedIn / Reddit done; Tumblr now)
- 4 OAuth1.0a keys (consumer key+secret, access token+secret) atomic — partial vault forces full env fallback
- All 3 routes extract deviceId; OAuth signing helper now takes creds parameter (no more module-level capture)
- info.html: Tumblr badge → vault-first, roadmap counter 4→3, meta tagline updated

## Notes
OAuth1.0a signs each request fresh, so no token cache to per-tenant-ize (unlike Reddit OAuth2 which had a module-level cache leak fix in #2149). Pattern is the simplest 4-key migration so far — straight `getXOAuth(creds) + xRequest(...creds)` plumbing.

Backwards-compat: env-only Hank deploy unchanged (creds object built from env when deviceId not provided).

## Test plan
- [ ] CI 4/4 (eslint / i18n / jest / Railway preview)
- [ ] Self-review via PR comment (commander as reviewer)
- [ ] Squash-merge to main
- [ ] Card card_52559d75d4bce861c643ca49 → done with screenshot evidence