### PR TITLE
feat(publisher): vault-first Blogger creds (multi-tenant 8/10)

### DIFF
--- a/backend/article-publisher.js
+++ b/backend/article-publisher.js
@@ -64,6 +64,11 @@ const BLOGGER_CLIENT_ID = process.env.BLOGGER_CLIENT_ID;
 const BLOGGER_CLIENT_SECRET = process.env.BLOGGER_CLIENT_SECRET;
 const BLOGGER_REDIRECT_URI = process.env.BLOGGER_REDIRECT_URI || 'https://eclawbot.com/api/publisher/blogger/oauth/callback';
 const BLOGGER_SCOPE = 'https://www.googleapis.com/auth/blogger';
+const BLOGGER_CRED_KEYS = ['BLOGGER_CLIENT_ID', 'BLOGGER_CLIENT_SECRET'];
+const BLOGGER_CREDS_MISSING = {
+    error: 'Blogger credentials not set for this device',
+    setup_url: '/portal/publisher-setup.html'
+};
 const HASHNODE_API_TOKEN = process.env.HASHNODE_API_TOKEN;
 const HASHNODE_GQL_ENDPOINT = 'https://gql.hashnode.com';
 const HASHNODE_CRED_KEYS = ['HASHNODE_API_TOKEN'];
@@ -376,14 +381,38 @@ function wpExpiryWarning() {
 // BLOGGER OAUTH FLOW
 // ============================================
 
+// Resolve Blogger OAuth-app credentials (vault-first, env fallback). 2-key
+// atomic: vault must have both CLIENT_ID and CLIENT_SECRET, or fall back to
+// env entirely. The per-user refresh_token is NOT a tenant credential — it's
+// stored per-device in blogger_tokens DB table after each OAuth callback.
+async function resolveBloggerCreds(deviceId) {
+    if (deviceId && typeof _getDeviceVar === 'function') {
+        try {
+            const ci = await _getDeviceVar(deviceId, 'BLOGGER_CLIENT_ID');
+            const cs = await _getDeviceVar(deviceId, 'BLOGGER_CLIENT_SECRET');
+            if (typeof ci === 'string' && ci.length > 0
+                && typeof cs === 'string' && cs.length > 0) {
+                return { clientId: ci, clientSecret: cs, source: 'vault' };
+            }
+        } catch (_) { /* fall through to env */ }
+    }
+    if (BLOGGER_CLIENT_ID && BLOGGER_CLIENT_SECRET) {
+        return { clientId: BLOGGER_CLIENT_ID, clientSecret: BLOGGER_CLIENT_SECRET, source: 'env' };
+    }
+    return { clientId: null, clientSecret: null, source: 'missing' };
+}
+
 // Step 1: Start OAuth — redirect user to Google consent
-router.get('/blogger/oauth/start', (req, res) => {
+router.get('/blogger/oauth/start', async (req, res) => {
     const { deviceId } = req.query;
     if (!deviceId) return res.status(400).json({ error: 'deviceId required' });
 
+    const creds = await resolveBloggerCreds(deviceId);
+    if (creds.source === 'missing') return res.status(501).json(BLOGGER_CREDS_MISSING);
+
     const state = crypto.randomBytes(16).toString('hex') + ':' + deviceId;
     const params = new URLSearchParams({
-        client_id: BLOGGER_CLIENT_ID,
+        client_id: creds.clientId,
         redirect_uri: BLOGGER_REDIRECT_URI,
         response_type: 'code',
         scope: BLOGGER_SCOPE,
@@ -403,14 +432,17 @@ router.get('/blogger/oauth/callback', async (req, res) => {
     const deviceId = state.split(':').slice(1).join(':');
 
     try {
+        const creds = await resolveBloggerCreds(deviceId);
+        if (creds.source === 'missing') return res.status(501).json(BLOGGER_CREDS_MISSING);
+
         // Exchange code for tokens
         const tokenRes = await fetch('https://oauth2.googleapis.com/token', {
             method: 'POST',
             headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
             body: new URLSearchParams({
                 code,
-                client_id: BLOGGER_CLIENT_ID,
-                client_secret: BLOGGER_CLIENT_SECRET,
+                client_id: creds.clientId,
+                client_secret: creds.clientSecret,
                 redirect_uri: BLOGGER_REDIRECT_URI,
                 grant_type: 'authorization_code'
             })
@@ -456,12 +488,17 @@ async function refreshBloggerToken(deviceId) {
     if (!entry?.refresh_token) throw new Error('No refresh token for device ' + deviceId);
     if (entry.expires_at > Date.now()) return entry.access_token; // still valid
 
+    const creds = await resolveBloggerCreds(deviceId);
+    if (creds.source === 'missing') {
+        throw new Error('Blogger OAuth-app credentials not set for device ' + deviceId);
+    }
+
     const res = await fetch('https://oauth2.googleapis.com/token', {
         method: 'POST',
         headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
         body: new URLSearchParams({
-            client_id: BLOGGER_CLIENT_ID,
-            client_secret: BLOGGER_CLIENT_SECRET,
+            client_id: creds.clientId,
+            client_secret: creds.clientSecret,
             refresh_token: entry.refresh_token,
             grant_type: 'refresh_token'
         })

--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -3679,14 +3679,14 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                     <div class="guide-panel" id="guide-publisher">
                         <header>
                             <h1 data-i18n="guide_pub_title">多平台發布 Publisher</h1>
-                            <p class="meta" data-i18n="guide_pub_meta">10 個內容平台 · 多租戶金鑰 roadmap · X / Hashnode / DEV.to / Qiita / LinkedIn / Reddit / Tumblr 已上線、其餘 env-only</p>
+                            <p class="meta" data-i18n="guide_pub_meta">10 個內容平台 · 多租戶金鑰 roadmap · X / Hashnode / DEV.to / Qiita / LinkedIn / Reddit / Tumblr / Blogger 已上線、其餘 env-only</p>
                         </header>
 
                         <h2 data-i18n="guide_pub_overview_h">總覽</h2>
                         <p data-i18n="guide_pub_overview_desc">
                             <code>backend/article-publisher.js</code> 把 10 個內容平台統一在 <code>/api/publisher/&lt;platform&gt;/*</code> 之下。
                             「多租戶」指的是<strong>每個 device 用自己金鑰庫裡的金鑰</strong>呼叫對應平台，而非全站共用 owner 一把 env 金鑰。
-                            目前 X、Hashnode、DEV.to、Qiita、LinkedIn、Reddit、Tumblr 走完整的 vault-first 流程（<code>resolveXCreds()</code> / <code>resolveHashnodeCreds()</code> / <code>resolveDevtoCreds()</code> / <code>resolveQiitaCreds()</code> / <code>resolveLinkedinCreds()</code> / <code>resolveRedditCreds()</code> / <code>resolveTumblrCreds()</code>），其餘平台仍是 env-only single-tenant。
+                            目前 X、Hashnode、DEV.to、Qiita、LinkedIn、Reddit、Tumblr、Blogger 走完整的 vault-first 流程（<code>resolveXCreds()</code> / <code>resolveHashnodeCreds()</code> / <code>resolveDevtoCreds()</code> / <code>resolveQiitaCreds()</code> / <code>resolveLinkedinCreds()</code> / <code>resolveRedditCreds()</code> / <code>resolveTumblrCreds()</code> / <code>resolveBloggerCreds()</code>），其餘平台仍是 env-only single-tenant。
                         </p>
 
                         <h2 data-i18n="guide_pub_status_h">平台狀態總表</h2>
@@ -3717,8 +3717,8 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                                     <td><strong>Blogger</strong></td>
                                     <td>global</td>
                                     <td>OAuth2</td>
-                                    <td><code>BLOGGER_CLIENT_ID</code> · <code>BLOGGER_CLIENT_SECRET</code> （+ DB token）</td>
-                                    <td><span class="pub-badge pub-badge-env">⚙️ env-only</span></td>
+                                    <td><code>BLOGGER_CLIENT_ID</code> · <code>BLOGGER_CLIENT_SECRET</code> （+ DB refresh_token）</td>
+                                    <td><span class="pub-badge pub-badge-vault">🔓 vault-first</span></td>
                                 </tr>
                                 <tr>
                                     <td><strong>Hashnode</strong></td>
@@ -3793,7 +3793,7 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                             </tbody>
                         </table>
 
-                        <h2 data-i18n="guide_pub_roadmap_h">Roadmap：把剩下 3 個平台搬上 vault-first</h2>
+                        <h2 data-i18n="guide_pub_roadmap_h">Roadmap：把剩下 2 個平台搬上 vault-first</h2>
                         <p data-i18n="guide_pub_roadmap_desc">每一個平台只要照 X 的樣板做：先在 publisher router 頂部加一個 <code>resolve&lt;Platform&gt;Creds(deviceId)</code>，先讀 <code>_getDeviceVar()</code>、若缺則 fallback 到 <code>process.env</code>，然後在每個 endpoint 把 <code>process.env.XXX</code> 換成 <code>(await resolve())</code> 結果。</p>
                         <ol>
                             <li data-i18n="guide_pub_roadmap_step1">複製 <code>resolveXCreds()</code> 為 <code>resolveTumblrCreds()</code>、<code>resolveRedditCreds()</code> ... 共 9 份。</li>


### PR DESCRIPTION
## Summary

8th of 10 publisher platforms migrated to vault-first multi-tenant credential pattern. Closes card_bb42c73c30f8753dae96aaf5.

- New `resolveBloggerCreds(deviceId)` reads `BLOGGER_CLIENT_ID` + `BLOGGER_CLIENT_SECRET` from per-device vault first, falls back to `process.env` (2-key atomic — no Frankenstein creds).
- 3 call sites threaded:
  - `/blogger/oauth/start` (consent URL `client_id`)
  - `/blogger/oauth/callback` (code→token exchange)
  - `refreshBloggerToken()` (refresh_token exchange)
- Per-user `refresh_token` is OAuth artifact, already stored per-device in `blogger_tokens` DB table — not migrated. Only the OAuth-app identity (CLIENT_ID/SECRET) is now per-tenant.
- info.html: Blogger row badge → 🔓 vault-first; meta tagline + overview function list extended; roadmap counter 3→2.

## Why simpler than Reddit

Blogger uses OAuth2 authorization-code flow, so per-user tokens flow through the consent UI and land in the existing `blogger_tokens` DB table keyed by `device_id`. No per-tenant Map cache needed beyond what already exists. Migration is just the OAuth-app identity.

## Backwards compatibility

When `deviceId` has no vault entry (or `_getDeviceVar` is unavailable), `resolveBloggerCreds()` falls through to `process.env` exactly as today. Single-tenant deployments require zero config changes.

## Test plan

- [x] ESLint passes (only pre-existing `*_CRED_KEYS` unused-var warnings, kept as documentation)
- [ ] CI green (jest / i18n / Railway preview)
- [ ] Self-review (commander as reviewer) posted as PR comment
- [ ] Squash-merge to main