### PR TITLE
feat(publisher): vault-first WeChat creds (multi-tenant 9/10)

### DIFF
--- a/backend/article-publisher.js
+++ b/backend/article-publisher.js
@@ -114,7 +114,15 @@ const QIITA_CREDS_MISSING = {
 const WECHAT_APP_ID = process.env.WECHAT_APP_ID;
 const WECHAT_APP_SECRET = process.env.WECHAT_APP_SECRET;
 const WECHAT_API_BASE = 'https://api.weixin.qq.com/cgi-bin';
-let wechatTokenCache = { access_token: null, expires_at: 0 };
+const WECHAT_CRED_KEYS = ['WECHAT_APP_ID', 'WECHAT_APP_SECRET'];
+const WECHAT_CREDS_MISSING = {
+    error: 'WeChat credentials not set for this device',
+    setup_url: '/portal/publisher-setup.html'
+};
+// Per-tenant token cache. Key = appId (so device A's token cannot be served
+// to device B). access_tokens have ~2h TTL and would leak across tenants if
+// stored globally.
+const wechatTokenCacheByCreds = new Map();
 
 // Tumblr (API v2, OAuth 1.0a — reuse oauth-1.0a lib)
 const TUMBLR_CONSUMER_KEY = process.env.TUMBLR_CONSUMER_KEY;
@@ -1597,46 +1605,69 @@ router.delete('/qiita/post/:postId', express.json(), async (req, res) => {
 // Note: Creates drafts only — manual publish required from WeChat admin
 // ============================================
 
-function requireWechat(res) {
-    if (!WECHAT_APP_ID || !WECHAT_APP_SECRET) { res.status(501).json({ error: 'WeChat not configured (WECHAT_APP_ID, WECHAT_APP_SECRET missing)' }); return false; }
-    return true;
+// Resolve WeChat AppID + AppSecret (vault-first, env fallback). 2-key atomic.
+async function resolveWechatCreds(deviceId) {
+    if (deviceId && typeof _getDeviceVar === 'function') {
+        try {
+            const ai = await _getDeviceVar(deviceId, 'WECHAT_APP_ID');
+            const as = await _getDeviceVar(deviceId, 'WECHAT_APP_SECRET');
+            if (typeof ai === 'string' && ai.length > 0
+                && typeof as === 'string' && as.length > 0) {
+                return { appId: ai, appSecret: as, source: 'vault' };
+            }
+        } catch (_) { /* fall through to env */ }
+    }
+    if (WECHAT_APP_ID && WECHAT_APP_SECRET) {
+        return { appId: WECHAT_APP_ID, appSecret: WECHAT_APP_SECRET, source: 'env' };
+    }
+    return { appId: null, appSecret: null, source: 'missing' };
 }
 
-async function getWechatToken() {
-    // Return cached token if still valid (with 5min buffer)
-    if (wechatTokenCache.access_token && wechatTokenCache.expires_at > Date.now() + 300000) {
-        return wechatTokenCache.access_token;
+// Get a valid access_token for the given creds. Cache is keyed by appId so
+// tokens don't leak between tenants. ~2h TTL with 5min buffer before refresh.
+async function getWechatToken(creds) {
+    const cacheKey = creds.appId;
+    const cached = wechatTokenCacheByCreds.get(cacheKey);
+    if (cached && cached.expires_at > Date.now() + 300000) {
+        return { token: cached.access_token, expires_at: cached.expires_at };
     }
     const res = await fetch(
-        `${WECHAT_API_BASE}/token?grant_type=client_credential&appid=${WECHAT_APP_ID}&secret=${WECHAT_APP_SECRET}`
+        `${WECHAT_API_BASE}/token?grant_type=client_credential&appid=${creds.appId}&secret=${creds.appSecret}`
     );
     const data = await res.json();
     if (data.errcode) throw new Error(`WeChat token error: ${data.errcode} ${data.errmsg}`);
-    wechatTokenCache = {
+    const entry = {
         access_token: data.access_token,
         expires_at: Date.now() + (data.expires_in * 1000)
     };
-    console.log('[Publisher] WeChat access_token refreshed');
-    return data.access_token;
+    wechatTokenCacheByCreds.set(cacheKey, entry);
+    console.log('[Publisher] WeChat access_token refreshed for appId=' + creds.appId.slice(0, 6) + '…');
+    return { token: entry.access_token, expires_at: entry.expires_at };
 }
 
 // GET /api/publisher/wechat/token — Get/refresh access_token status
 router.get('/wechat/token', async (req, res) => {
-    if (!requireWechat(res)) return;
+    const deviceId = req.query.deviceId;
+    const creds = await resolveWechatCreds(deviceId);
+    if (creds.source === 'missing') return res.status(501).json(WECHAT_CREDS_MISSING);
     try {
-        const token = await getWechatToken();
-        res.json({ success: true, platform: 'wechat', token_expires_at: wechatTokenCache.expires_at, has_token: !!token });
+        const t = await getWechatToken(creds);
+        res.json({ success: true, platform: 'wechat', token_expires_at: t.expires_at, has_token: !!t.token });
     } catch (err) {
         res.status(500).json({ error: err.message });
     }
 });
 
 // POST /api/publisher/wechat/upload-image — Upload cover image (permanent material)
+// deviceId via query param because route forwards raw multipart body to WeChat
+// (no JSON body parsing — would consume the multipart stream).
 router.post('/wechat/upload-image', async (req, res) => {
-    if (!requireWechat(res)) return;
+    const deviceId = req.query.deviceId;
+    const creds = await resolveWechatCreds(deviceId);
+    if (creds.source === 'missing') return res.status(501).json(WECHAT_CREDS_MISSING);
 
     try {
-        const token = await getWechatToken();
+        const t = await getWechatToken(creds);
         // Expect multipart/form-data with 'media' field
         // Forward the raw request body to WeChat
         const contentType = req.headers['content-type'];
@@ -1649,7 +1680,7 @@ router.post('/wechat/upload-image', async (req, res) => {
         const rawBody = Buffer.concat(chunks);
 
         const wxRes = await fetch(
-            `${WECHAT_API_BASE}/material/add_material?access_token=${token}&type=image`,
+            `${WECHAT_API_BASE}/material/add_material?access_token=${t.token}&type=image`,
             { method: 'POST', headers: { 'Content-Type': contentType }, body: rawBody }
         );
         const data = await wxRes.json();
@@ -1665,14 +1696,15 @@ router.post('/wechat/upload-image', async (req, res) => {
 
 // POST /api/publisher/wechat/draft — Create a draft article
 router.post('/wechat/draft', express.json(), async (req, res) => {
-    if (!requireWechat(res)) return;
-    const { title, content, thumb_media_id, author, digest } = req.body;
+    const { deviceId, title, content, thumb_media_id, author, digest } = req.body;
     if (!title || !content || !thumb_media_id) {
         return res.status(400).json({ error: 'title, content, thumb_media_id required' });
     }
+    const creds = await resolveWechatCreds(deviceId);
+    if (creds.source === 'missing') return res.status(501).json(WECHAT_CREDS_MISSING);
 
     try {
-        const token = await getWechatToken();
+        const t = await getWechatToken(creds);
         const article = {
             title,
             content,
@@ -1684,7 +1716,7 @@ router.post('/wechat/draft', express.json(), async (req, res) => {
             only_fans_can_comment: 0
         };
 
-        const wxRes = await fetch(`${WECHAT_API_BASE}/draft/add?access_token=${token}`, {
+        const wxRes = await fetch(`${WECHAT_API_BASE}/draft/add?access_token=${t.token}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ articles: [article] })
@@ -1702,13 +1734,15 @@ router.post('/wechat/draft', express.json(), async (req, res) => {
 
 // GET /api/publisher/wechat/drafts — List drafts
 router.get('/wechat/drafts', async (req, res) => {
-    if (!requireWechat(res)) return;
+    const deviceId = req.query.deviceId;
+    const creds = await resolveWechatCreds(deviceId);
+    if (creds.source === 'missing') return res.status(501).json(WECHAT_CREDS_MISSING);
     try {
-        const token = await getWechatToken();
+        const t = await getWechatToken(creds);
         const offset = parseInt(req.query.offset) || 0;
         const count = Math.min(parseInt(req.query.count) || 20, 20);
 
-        const wxRes = await fetch(`${WECHAT_API_BASE}/draft/batchget?access_token=${token}`, {
+        const wxRes = await fetch(`${WECHAT_API_BASE}/draft/batchget?access_token=${t.token}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ offset, count, no_content: 1 })
@@ -1724,11 +1758,13 @@ router.get('/wechat/drafts', async (req, res) => {
 
 // DELETE /api/publisher/wechat/draft/:mediaId
 router.delete('/wechat/draft/:mediaId', async (req, res) => {
-    if (!requireWechat(res)) return;
+    const deviceId = req.query.deviceId;
     const { mediaId } = req.params;
+    const creds = await resolveWechatCreds(deviceId);
+    if (creds.source === 'missing') return res.status(501).json(WECHAT_CREDS_MISSING);
     try {
-        const token = await getWechatToken();
-        const wxRes = await fetch(`${WECHAT_API_BASE}/draft/delete?access_token=${token}`, {
+        const t = await getWechatToken(creds);
+        const wxRes = await fetch(`${WECHAT_API_BASE}/draft/delete?access_token=${t.token}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ media_id: mediaId })

--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -3679,14 +3679,14 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                     <div class="guide-panel" id="guide-publisher">
                         <header>
                             <h1 data-i18n="guide_pub_title">多平台發布 Publisher</h1>
-                            <p class="meta" data-i18n="guide_pub_meta">10 個內容平台 · 多租戶金鑰 roadmap · X / Hashnode / DEV.to / Qiita / LinkedIn / Reddit / Tumblr / Blogger 已上線、其餘 env-only</p>
+                            <p class="meta" data-i18n="guide_pub_meta">10 個內容平台 · 多租戶金鑰 roadmap · X / Hashnode / DEV.to / Qiita / LinkedIn / Reddit / Tumblr / Blogger / WeChat 已上線、其餘 env-only</p>
                         </header>
 
                         <h2 data-i18n="guide_pub_overview_h">總覽</h2>
                         <p data-i18n="guide_pub_overview_desc">
                             <code>backend/article-publisher.js</code> 把 10 個內容平台統一在 <code>/api/publisher/&lt;platform&gt;/*</code> 之下。
                             「多租戶」指的是<strong>每個 device 用自己金鑰庫裡的金鑰</strong>呼叫對應平台，而非全站共用 owner 一把 env 金鑰。
-                            目前 X、Hashnode、DEV.to、Qiita、LinkedIn、Reddit、Tumblr、Blogger 走完整的 vault-first 流程（<code>resolveXCreds()</code> / <code>resolveHashnodeCreds()</code> / <code>resolveDevtoCreds()</code> / <code>resolveQiitaCreds()</code> / <code>resolveLinkedinCreds()</code> / <code>resolveRedditCreds()</code> / <code>resolveTumblrCreds()</code> / <code>resolveBloggerCreds()</code>），其餘平台仍是 env-only single-tenant。
+                            目前 X、Hashnode、DEV.to、Qiita、LinkedIn、Reddit、Tumblr、Blogger、WeChat 走完整的 vault-first 流程（<code>resolveXCreds()</code> / <code>resolveHashnodeCreds()</code> / <code>resolveDevtoCreds()</code> / <code>resolveQiitaCreds()</code> / <code>resolveLinkedinCreds()</code> / <code>resolveRedditCreds()</code> / <code>resolveTumblrCreds()</code> / <code>resolveBloggerCreds()</code> / <code>resolveWechatCreds()</code>），其餘平台仍是 env-only single-tenant。
                         </p>
 
                         <h2 data-i18n="guide_pub_status_h">平台狀態總表</h2>
@@ -3753,7 +3753,7 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                                     <td>zh-CN</td>
                                     <td>App credentials</td>
                                     <td><code>WECHAT_APP_ID</code> · <code>WECHAT_APP_SECRET</code> （drafts only）</td>
-                                    <td><span class="pub-badge pub-badge-env">⚙️ env-only</span></td>
+                                    <td><span class="pub-badge pub-badge-vault">🔓 vault-first</span></td>
                                 </tr>
                                 <tr>
                                     <td><strong>Tumblr</strong></td>
@@ -3793,7 +3793,7 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                             </tbody>
                         </table>
 
-                        <h2 data-i18n="guide_pub_roadmap_h">Roadmap：把剩下 2 個平台搬上 vault-first</h2>
+                        <h2 data-i18n="guide_pub_roadmap_h">Roadmap：剩下 1 個平台（Telegraph 是 auto-key 不需）</h2>
                         <p data-i18n="guide_pub_roadmap_desc">每一個平台只要照 X 的樣板做：先在 publisher router 頂部加一個 <code>resolve&lt;Platform&gt;Creds(deviceId)</code>，先讀 <code>_getDeviceVar()</code>、若缺則 fallback 到 <code>process.env</code>，然後在每個 endpoint 把 <code>process.env.XXX</code> 換成 <code>(await resolve())</code> 結果。</p>
                         <ol>
                             <li data-i18n="guide_pub_roadmap_step1">複製 <code>resolveXCreds()</code> 為 <code>resolveTumblrCreds()</code>、<code>resolveRedditCreds()</code> ... 共 9 份。</li>


### PR DESCRIPTION
## Summary

9th and final non-auto-key publisher platform migrated to vault-first multi-tenant. (Telegraph 10/10 is auto-key — no creds to migrate.)

- New `resolveWechatCreds(deviceId)` reads `WECHAT_APP_ID` + `WECHAT_APP_SECRET` from per-device vault first, env fallback (2-key atomic).
- Per-tenant token cache: global `wechatTokenCache` → `wechatTokenCacheByCreds` Map keyed by appId. Without this, device A's ~2h-TTL access_token would be served to device B.
- 5 routes threaded with deviceId:
  - `GET /wechat/token` (query)
  - `POST /wechat/upload-image` (query — raw multipart, body parsing would consume the stream)
  - `POST /wechat/draft` (body — `express.json` already wired)
  - `GET /wechat/drafts` (query)
  - `DELETE /wechat/draft/:mediaId` (query)
- Drop `requireWechat()` helper in favor of `creds.source === 'missing'` check (matches Reddit/Tumblr/Blogger pattern).
- info.html: WeChat row → 🔓 vault-first; meta + overview extended; roadmap heading 2→1.

## Backwards compatibility

Env-only deployment with `WECHAT_APP_ID`/`SECRET` set continues working unchanged when no vault entries exist. The cache Map is keyed by appId, so env-mode reuses one cache slot exactly like the old global cache.

## Test plan

- [x] ESLint passes (only pre-existing `*_CRED_KEYS` unused-var warnings — kept as documentation)
- [ ] CI green (jest / i18n / Railway preview)
- [ ] Self-review (commander as reviewer)
- [ ] Squash-merge to main

## After this lands

9/10 publisher platforms now vault-first (X / Hashnode / DEV.to / Qiita / LinkedIn / Reddit / Tumblr / Blogger / WeChat). Telegraph (10/10) is auto-key (anonymous account created on first call) — no migration needed. Roadmap section will retire after this PR.