### PR TITLE
chore(api-helper): scope note on /api/chat/history hint

### DIFF
--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -581,7 +581,7 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
                 '[AVAILABLE TOOLS — Mission Dashboard]',
                 `Read tasks/notes/rules/skills: exec: curl -s "${apiBase}/api/mission/dashboard?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}"`,
                 `Read notes: exec: curl -s "${apiBase}/api/mission/notes?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}"`,
-                `Read chat history: exec: curl -s "${apiBase}/api/chat/history?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}&limit=100"`,
+                `Read chat history (scope: msgs to/from your entityId only — NOT full device transcript): exec: curl -s "${apiBase}/api/chat/history?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}&limit=100"`,
                 `Create kanban card: exec: curl -s -X POST "${apiBase}/api/mission/card" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${eId},"botSecret":"${botSecret}","title":"TASK_TITLE","status":"todo"}'`,
                 `Add note: exec: curl -s -X POST "${apiBase}/api/mission/note/add" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${eId},"botSecret":"${botSecret}","title":"TITLE","content":"CONTENT"}'`,
                 `Update wallpaper: exec: curl -s -X POST "${apiBase}/api/transform" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${eId},"botSecret":"${botSecret}","state":"IDLE","message":"hello"}'`

--- a/backend/docs/specs/channel-bridge.md
+++ b/backend/docs/specs/channel-bridge.md
@@ -111,7 +111,7 @@ Every bot push gets a curl-recipe block appended so the receiving LLM always has
 Current Taiwan Time: YYYY-MM-DD HH:mm (UTC+8)
 Read tasks/notes/rules/skills: exec: curl -s "{apiBase}/api/mission/dashboard?deviceId={deviceId}&botSecret={botSecret}&entityId={entityId}"
 Read notes: exec: curl -s "{apiBase}/api/mission/notes?..."
-Read chat history: exec: curl -s "{apiBase}/api/chat/history?...&limit=100"
+Read chat history (scope: msgs to/from your entityId only — NOT full device transcript): exec: curl -s "{apiBase}/api/chat/history?...&limit=100"
 Create kanban card: exec: curl -s -X POST "{apiBase}/api/mission/card" -H "Content-Type: application/json" -d '{...,"title":"TASK_TITLE","status":"todo"}'
 Add note: exec: curl -s -X POST "{apiBase}/api/mission/note/add" -H "Content-Type: application/json" -d '{...,"title":"TITLE","content":"CONTENT"}'
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -13923,7 +13923,7 @@ function getMissionApiHints(apiBase, deviceId, entityId, botSecret) {
     hints += `Current Taiwan Time: ${twTime} (UTC+8)\n`;
     hints += `Read tasks/notes/rules/skills: exec: curl -s "${apiBase}/api/mission/dashboard?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${entityId}"\n`;
     hints += `Read notes: exec: curl -s "${apiBase}/api/mission/notes?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${entityId}"\n`;
-    hints += `Read chat history: exec: curl -s "${apiBase}/api/chat/history?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${entityId}&limit=100"\n`;
+    hints += `Read chat history (scope: msgs to/from your entityId only — NOT full device transcript): exec: curl -s "${apiBase}/api/chat/history?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${entityId}&limit=100"\n`;
     hints += `Create kanban card: exec: curl -s -X POST "${apiBase}/api/mission/card" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${entityId},"botSecret":"${botSecret}","title":"TASK_TITLE","status":"todo"}'\n`;
     hints += `Add note: exec: curl -s -X POST "${apiBase}/api/mission/note/add" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${entityId},"botSecret":"${botSecret}","title":"TITLE","content":"CONTENT"}'\n`;
     hints += `\n[AVAILABLE TOOLS — Kanban Board]\n`;


### PR DESCRIPTION
## Summary
- Append `(scope: msgs to/from your entityId only — NOT full device transcript)` to the `Read chat history:` line in the [AVAILABLE TOOLS] helper text pushed to bots.
- Three callers kept in sync: `channel-api.js:584` (ECLAW_READY), `index.js:13926` (every-push hints), `docs/specs/channel-bridge.md:114` (spec).
- No auth/endpoint change — helper text only. The auth boundary at `index.js:16605-16650` already enforces this scope; the hint just makes it explicit so bots don't misread the data.

## Why
Hank channel msg 2026-04-26 21:43: "hint已經塞太多資訊了 在API helper加上風險說明說明即可". Card `card_f7123c59c22f980f413fe4ce` originally scoped to coordinate-fields + auth audit; rescoped narrower per Hank.

## Test plan
- [x] `node -c backend/index.js` + `node -c backend/channel-api.js` clean
- [x] Diff stat = 3 files / 3+ 3-
- [ ] Post-deploy: trigger any bot push and grep next ECLAW_READY init for `(scope: msgs to/from your entityId only` to confirm hint reaches the bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)