### PR TITLE
feat(mindmap): automation subsystem + dual-axis edges + unified cite

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -825,7 +825,12 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
         ['broadcast', /(廣播|broadcast|publisher|twitter|mastodon|wordpress|wp\.com|社群|x \(twitter\))/i],
         ['bridge',    /(橋接|bridge|osascript|u\d{2}|ssh|terminal-bridge|hermes-bridge)/i],
     ];
-    function classifySys(title) {
+    // Automation triggers (is_automation=true) anchor to a dedicated subsystem
+    // so the lineage (which cron spawned which real cards) becomes navigable.
+    // Spawned children keep their content classification — they get a
+    // sysHub edge for content + parent edge for lineage = dual-axis.
+    function classifySys(title, isAutomation) {
+        if (isAutomation) return 'automation';
         const t = String(title || '');
         for (const [sys, rx] of SYS_KEYWORDS) {
             if (rx.test(t)) return sys;
@@ -845,13 +850,11 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
     router.get('/mindmap', async (req, res) => {
         if (!authenticate(req, res)) return;
         const { deviceId } = { ...req.query, ...req.body };
-        const includeAutomation = req.query.includeAutomation === 'true';
         try {
             const cardsResult = await pool.query(
                 `SELECT id, title, description, priority, status, parent_card_id, is_automation, assigned_bots
                  FROM kanban_cards
                  WHERE device_id = $1 AND archived = false
-                   ${includeAutomation ? '' : 'AND (is_automation = false OR is_automation IS NULL)'}
                  ORDER BY
                     CASE priority WHEN 'P0' THEN 0 WHEN 'P1' THEN 1 WHEN 'P2' THEN 2 WHEN 'P3' THEN 3 END,
                     updated_at DESC NULLS LAST
@@ -860,14 +863,15 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
             );
 
             const sysHubs = {
-                invite:    { id: 'sys:invite',    label: '邀請',     sys: 'invite',    tier: 'domain', status: 'active', summary: '' },
-                device:    { id: 'sys:device',    label: '裝置',     sys: 'device',    tier: 'domain', status: 'active', summary: '' },
-                i18n:      { id: 'sys:i18n',      label: 'i18n',     sys: 'i18n',      tier: 'domain', status: 'active', summary: '' },
-                kanban:    { id: 'sys:kanban',    label: '看板',     sys: 'kanban',    tier: 'domain', status: 'active', summary: '' },
-                chat:      { id: 'sys:chat',      label: '聊天',     sys: 'chat',      tier: 'domain', status: 'active', summary: '' },
-                payment:   { id: 'sys:payment',   label: '支付',     sys: 'payment',   tier: 'domain', status: 'active', summary: '' },
-                broadcast: { id: 'sys:broadcast', label: '廣播',     sys: 'broadcast', tier: 'domain', status: 'active', summary: '' },
-                bridge:    { id: 'sys:bridge',    label: '橋接',     sys: 'bridge',    tier: 'domain', status: 'active', summary: '' },
+                invite:     { id: 'sys:invite',     label: '邀請',     sys: 'invite',     tier: 'domain', status: 'active', summary: '' },
+                device:     { id: 'sys:device',     label: '裝置',     sys: 'device',     tier: 'domain', status: 'active', summary: '' },
+                i18n:       { id: 'sys:i18n',       label: 'i18n',     sys: 'i18n',       tier: 'domain', status: 'active', summary: '' },
+                kanban:     { id: 'sys:kanban',     label: '看板',     sys: 'kanban',     tier: 'domain', status: 'active', summary: '' },
+                chat:       { id: 'sys:chat',       label: '聊天',     sys: 'chat',       tier: 'domain', status: 'active', summary: '' },
+                payment:    { id: 'sys:payment',    label: '支付',     sys: 'payment',    tier: 'domain', status: 'active', summary: '' },
+                broadcast:  { id: 'sys:broadcast',  label: '廣播',     sys: 'broadcast',  tier: 'domain', status: 'active', summary: '' },
+                bridge:     { id: 'sys:bridge',     label: '橋接',     sys: 'bridge',     tier: 'domain', status: 'active', summary: '' },
+                automation: { id: 'sys:automation', label: '自動化',   sys: 'automation', tier: 'domain', status: 'active', summary: '' },
             };
 
             const nodes = [];
@@ -876,7 +880,7 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
             const sysCount = {};
 
             for (const c of cardsResult.rows) {
-                const sys = classifySys(c.title);
+                const sys = classifySys(c.title, c.is_automation);
                 sysCount[sys] = (sysCount[sys] || 0) + 1;
                 const summary = (c.description || '').replace(/\s+/g, ' ').trim().slice(0, 120);
                 nodes.push({
@@ -888,18 +892,21 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
                     summary,
                     priority: c.priority,
                     cardStatus: c.status,
+                    isAutomation: !!c.is_automation,
                 });
                 cardIds.add(c.id);
             }
 
-            // Hub nodes: include hubs that own ≥1 card (keeps the rail tidy)
+            // Hub nodes: include hubs that own ≥1 card (keeps the rail tidy).
+            // Every card gets a hub edge — the parent_card_id edge is added
+            // separately below, so cards with parents end up dual-axis
+            // (lineage to parent + content/automation to hub).
             for (const sys of Object.keys(sysHubs)) {
                 if (sysCount[sys]) {
                     const hub = { ...sysHubs[sys], summary: `${sysCount[sys]} 張卡片` };
                     nodes.unshift(hub);
-                    // Connect each card in this sys to its hub when no parent_card edge exists yet
                     for (const c of cardsResult.rows) {
-                        if (classifySys(c.title) === sys && !c.parent_card_id) {
+                        if (classifySys(c.title, c.is_automation) === sys) {
                             edges.push([hub.id, c.id]);
                         }
                     }

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3194,9 +3194,22 @@
                 const pq = localStorage.getItem('eclaw_pending_quote');
                 if (pq) {
                     localStorage.removeItem('eclaw_pending_quote');
-                    const { source, title, excerpt, ts } = JSON.parse(pq);
+                    const { source, title, excerpt, prefillInput, ts } = JSON.parse(pq);
                     if (Date.now() - ts < 120000) { // within 2 minutes
                         quoteToChat(source, title, excerpt || '');
+                        // prefillInput: drop a chip token (or any text) directly
+                        // into the input so users can press send without typing.
+                        // Used by mindmap chip 📌 引用 — delivers mindmap_<uuid>
+                        // / card_<id> token, which autolink-chip then renders
+                        // as a chip preview in the sent message.
+                        if (prefillInput) {
+                            const inp = document.getElementById('messageInput');
+                            if (inp) {
+                                inp.value = prefillInput;
+                                inp.focus();
+                                try { inp.setSelectionRange(prefillInput.length, prefillInput.length); } catch(e2) {}
+                            }
+                        }
                     }
                 }
             } catch(e) {}
@@ -3232,8 +3245,16 @@
             window.addEventListener('message', (e) => {
                 if (e.origin !== window.location.origin) return;
                 if (!e.data || e.data.type !== 'eclaw_quote') return;
-                const { source, title, excerpt } = e.data;
+                const { source, title, excerpt, prefillInput } = e.data;
                 quoteToChat(source, title, excerpt || '');
+                if (prefillInput) {
+                    const inp = document.getElementById('messageInput');
+                    if (inp) {
+                        inp.value = String(prefillInput);
+                        inp.focus();
+                        try { inp.setSelectionRange(inp.value.length, inp.value.length); } catch(e2) {}
+                    }
+                }
             });
 
             // Mount @mention autocomplete on the message input.

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -1911,11 +1911,15 @@
             document.getElementById('dialogContainer').innerHTML = '';
         }
 
-        function quoteToChat(source, title, excerpt) {
+        function quoteToChat(source, title, excerpt, opts) {
+            // opts.prefillInput — optional string to pre-fill the message input
+            // on the chat page (used by mind-map chip cite to deliver a chip
+            // token straight into the input, so user just hits send).
+            const prefillInput = opts && opts.prefillInput ? String(opts.prefillInput) : '';
             if (window.self !== window.top) {
-                window.parent.postMessage({ type: 'eclaw_quote', source, title, excerpt: excerpt || '' }, window.location.origin);
+                window.parent.postMessage({ type: 'eclaw_quote', source, title, excerpt: excerpt || '', prefillInput }, window.location.origin);
             } else {
-                localStorage.setItem('eclaw_pending_quote', JSON.stringify({ source, title, excerpt: excerpt || '', ts: Date.now() }));
+                localStorage.setItem('eclaw_pending_quote', JSON.stringify({ source, title, excerpt: excerpt || '', prefillInput, ts: Date.now() }));
                 window.location.href = '/portal/chat.html';
             }
         }

--- a/backend/public/portal/shared/mission-mindmap.js
+++ b/backend/public/portal/shared/mission-mindmap.js
@@ -24,14 +24,15 @@
   const CDN = 'https://cdn.jsdelivr.net/npm/cytoscape@3.28.1/dist/cytoscape.min.js';
 
   const SYS = {
-    invite:    { color: '#f43f5e', label: '邀請成長' },
-    device:    { color: '#06b6d4', label: '裝置' },
-    i18n:      { color: '#a855f7', label: 'i18n' },
-    kanban:    { color: '#22c55e', label: '看板' },
-    chat:      { color: '#3b82f6', label: '聊天' },
-    payment:   { color: '#eab308', label: '支付' },
-    broadcast: { color: '#f97316', label: '廣播' },
-    bridge:    { color: '#ec4899', label: '橋接' },
+    invite:     { color: '#f43f5e', label: '邀請成長' },
+    device:     { color: '#06b6d4', label: '裝置' },
+    i18n:       { color: '#a855f7', label: 'i18n' },
+    kanban:     { color: '#22c55e', label: '看板' },
+    chat:       { color: '#3b82f6', label: '聊天' },
+    payment:    { color: '#eab308', label: '支付' },
+    broadcast:  { color: '#f97316', label: '廣播' },
+    bridge:     { color: '#ec4899', label: '橋接' },
+    automation: { color: '#64748b', label: '自動化' },
   };
 
   const MOCK_NODES = [
@@ -692,8 +693,11 @@
 
     function buildPopHtml(d, isPinned, related) {
       const sysMeta = SYS[d.sys];
-      const pinTitle = isPinned ? '取消釘選' : '釘選引用';
-      const pinIcon = isPinned ? '📍' : '📌';
+      // Pin = local bookmark to top-tray of this page (no deep-link, no API).
+      // Distinct from cite (📌, deep-links into chat) — different icons to
+      // avoid the 📌 collision now that cite uses the canonical 引用 emoji.
+      const pinTitle = isPinned ? '取消釘選' : '釘選到頂部列 (僅當前頁面)';
+      const pinIcon = isPinned ? '📍' : '🔖';
       const pinClass = isPinned ? 'pin-btn pinned' : 'pin-btn';
       // Citable IDs: real mindmap UUIDs (mindmap_xxxx) or kanban card prefix IDs
       // (card_xxxxxxxx). Virtual `sys:*` hubs are aggregations, not entities.
@@ -703,7 +707,7 @@
       const isVirtualHub = String(d.id).startsWith('sys:');
       const canCite = isUuid || isCardId;
       const citeTitle = canCite
-        ? '複製引用 token (聊天可貼上為 chip)'
+        ? '引用到聊天 — 跳到聊天頁,訊息框已預填 chip token,按送出即可'
         : isVirtualHub
           ? '子系統 hub 為彙總節點,無法引用'
           : '示範資料無法引用 — 需先在心智圖新增實際節點';
@@ -723,7 +727,7 @@
           <span class="swatch" style="background:${sysMeta.color}"></span>
           <span class="mm-chip-pop-title" title="${escapeHtml(d.label)}">${escapeHtml(d.label)}</span>
           <span class="mm-chip-pop-status ${escapeHtml(d.status)}">${escapeHtml(d.status)}</span>
-          <button class="mm-chip-pop-btn ${citeClass}" data-pop-act="cite" title="${escapeHtml(citeTitle)}">📋</button>
+          <button class="mm-chip-pop-btn ${citeClass}" data-pop-act="cite" title="${escapeHtml(citeTitle)}">📌</button>
           <button class="mm-chip-pop-btn ${pinClass}" data-pop-act="pin" title="${escapeHtml(pinTitle)}">${pinIcon}</button>
           <button class="mm-chip-pop-btn" data-pop-act="close" title="關閉">✖</button>
         </div>
@@ -827,12 +831,47 @@
           // the prefix and renders a card chip. UUID nodes use the legacy mindmap_ token.
           const isCard = /^card_[a-f0-9]{8}/i.test(nodeId);
           const token = isCard ? nodeId : 'mindmap_' + nodeId;
-          copyToClipboard(token).then(ok => {
-            const kind = isCard ? '卡片' : '心智圖節點';
-            showToast(ok
-              ? `已複製${kind}引用「${token.slice(0, 22)}…」— 切到聊天貼上即為 chip`
-              : `複製失敗,請手動複製: ${token}`);
-          });
+          const kind = isCard ? '卡片' : '心智圖節點';
+          // Unified 引用到聊天 UX — same path as card-holder/files/mission
+          // dialog 📌 buttons. Hands the token to chat as quote context +
+          // pre-fills the message input so the user just hits send. The
+          // chat onload reader (chat.html) consumes eclaw_pending_quote +
+          // optional prefillInput. Falls back to clipboard copy if neither
+          // postMessage nor localStorage path is available (offline / no
+          // chat page mounted).
+          const quoteSource = '心智圖';
+          const quoteTitle = d.label || token;
+          const quoteExcerpt = token;
+          try {
+            if (typeof global.quoteToChat === 'function') {
+              global.quoteToChat(quoteSource, quoteTitle, quoteExcerpt, { prefillInput: token });
+            } else if (global.self !== global.top) {
+              global.parent.postMessage({
+                type: 'eclaw_quote',
+                source: quoteSource,
+                title: quoteTitle,
+                excerpt: quoteExcerpt,
+                prefillInput: token,
+              }, global.location.origin);
+            } else {
+              global.localStorage.setItem('eclaw_pending_quote', JSON.stringify({
+                source: quoteSource,
+                title: quoteTitle,
+                excerpt: quoteExcerpt,
+                prefillInput: token,
+                ts: Date.now(),
+              }));
+              global.location.href = '/portal/chat.html';
+            }
+            showToast(`引用 ${kind}「${quoteTitle.slice(0, 18)}」到聊天 — 訊息框已預填,按送出即可`);
+          } catch (err) {
+            // Last resort — clipboard copy + manual paste hint
+            copyToClipboard(token).then(ok => {
+              showToast(ok
+                ? `引用直送失敗,已複製 token 請手動貼上聊天: ${token.slice(0, 22)}…`
+                : `引用失敗 (${err && err.message || 'unknown'}): ${token}`);
+            });
+          }
         }
       });
     }

--- a/backend/tests/jest/kanban-mindmap.test.js
+++ b/backend/tests/jest/kanban-mindmap.test.js
@@ -104,7 +104,7 @@ describe('GET /api/mission/mindmap', () => {
         expect(chatHub.summary).toContain('42 則訊息已嵌入');
     });
 
-    it('emits parent→child edges when both endpoints are in the result set', async () => {
+    it('emits parent→child edges AND hub edges for child (dual-axis)', async () => {
         mockQuery
             .mockResolvedValueOnce({
                 rows: [
@@ -117,9 +117,11 @@ describe('GET /api/mission/mindmap', () => {
         const res = await request(app).get('/api/mission/mindmap' + AUTH);
         const edgeSet = new Set(res.body.edges.map(([s, t]) => `${s}→${t}`));
         expect(edgeSet.has('card_p→card_c')).toBe(true);
-        // Parent has hub edge; child does NOT (it has parent_card_id)
+        // Both parent and child connect to their content sysHub — child's
+        // parent edge is no longer mutually exclusive with the hub edge,
+        // so the mindmap can navigate dual-axis (lineage + content).
         expect(edgeSet.has('sys:i18n→card_p')).toBe(true);
-        expect(edgeSet.has('sys:i18n→card_c')).toBe(false);
+        expect(edgeSet.has('sys:i18n→card_c')).toBe(true);
     });
 
     it('maps kanban status to mind-map status (done/blocked/active)', async () => {
@@ -140,21 +142,67 @@ describe('GET /api/mission/mindmap', () => {
         expect(byId.card_inprog.status).toBe('active');
     });
 
-    it('excludes automation cards by default; ?includeAutomation=true opts in', async () => {
+    it('automation cards: trigger goes to sys:automation hub; spawned children dual-axis', async () => {
+        // Trigger (is_automation=true) — title says "i18n cron" but classifier
+        // routes to automation regardless of content keywords. Child cards
+        // (is_automation=false) keep their content classification AND get
+        // both a hub edge + parent edge.
+        mockQuery
+            .mockResolvedValueOnce({
+                rows: [
+                    { id: 'card_cron',  title: 'i18n 巡檢 cron',         description: '',                    priority: 'P2', status: 'in_progress', parent_card_id: null,        is_automation: true,  assigned_bots: [5] },
+                    { id: 'card_kid1',  title: 'i18n 巡檢結果 04/26',     description: 'patrol output',       priority: 'P3', status: 'done',        parent_card_id: 'card_cron', is_automation: false, assigned_bots: [5] },
+                    { id: 'card_kid2',  title: '看板自動化發現 stale 卡', description: 'auto-found via cron', priority: 'P3', status: 'todo',        parent_card_id: 'card_cron', is_automation: false, assigned_bots: [2] },
+                ],
+            })
+            .mockResolvedValueOnce({ rows: [{ n: 0 }] });
+
+        const res = await request(app).get('/api/mission/mindmap' + AUTH);
+        expect(res.status).toBe(200);
+        const sysOf = id => res.body.nodes.find(n => n.id === id)?.sys;
+        expect(sysOf('card_cron')).toBe('automation');
+        expect(sysOf('card_kid1')).toBe('i18n');
+        expect(sysOf('card_kid2')).toBe('kanban');
+
+        // sys:automation hub now appears alongside content hubs
+        const hubIds = res.body.nodes.filter(n => n.id.startsWith('sys:')).map(n => n.id).sort();
+        expect(hubIds).toEqual(['sys:automation', 'sys:i18n', 'sys:kanban']);
+
+        const edgeSet = new Set(res.body.edges.map(([s, t]) => `${s}→${t}`));
+        // Trigger anchored to automation hub
+        expect(edgeSet.has('sys:automation→card_cron')).toBe(true);
+        // Children: lineage to parent + content hub edge (dual-axis)
+        expect(edgeSet.has('card_cron→card_kid1')).toBe(true);
+        expect(edgeSet.has('card_cron→card_kid2')).toBe(true);
+        expect(edgeSet.has('sys:i18n→card_kid1')).toBe(true);
+        expect(edgeSet.has('sys:kanban→card_kid2')).toBe(true);
+
+        // isAutomation flag surfaced on node payload for frontend styling
+        expect(res.body.nodes.find(n => n.id === 'card_cron').isAutomation).toBe(true);
+        expect(res.body.nodes.find(n => n.id === 'card_kid1').isAutomation).toBe(false);
+    });
+
+    it('automation no longer filtered by default; includeAutomation flag becomes a no-op', async () => {
         mockQuery
             .mockResolvedValueOnce({ rows: [] })
             .mockResolvedValueOnce({ rows: [{ n: 0 }] });
 
         await request(app).get('/api/mission/mindmap' + AUTH);
         const sql1 = mockQuery.mock.calls[0][0];
-        expect(sql1).toMatch(/is_automation = false OR is_automation IS NULL/);
+        // SQL no longer carries the is_automation filter — automation cards
+        // are first-class nodes anchored under sys:automation instead of
+        // hidden behind an opt-in flag.
+        expect(sql1).not.toMatch(/is_automation = false OR is_automation IS NULL/);
 
         mockQuery.mockReset();
         mockQuery
             .mockResolvedValueOnce({ rows: [] })
             .mockResolvedValueOnce({ rows: [{ n: 0 }] });
 
-        await request(app).get('/api/mission/mindmap' + AUTH + '&includeAutomation=true');
+        // Legacy callers passing ?includeAutomation=true still get a 200 —
+        // the flag is now a harmless no-op (kept for backwards compat).
+        const res = await request(app).get('/api/mission/mindmap' + AUTH + '&includeAutomation=true');
+        expect(res.status).toBe(200);
         const sql2 = mockQuery.mock.calls[0][0];
         expect(sql2).not.toMatch(/is_automation = false OR is_automation IS NULL/);
     });


### PR DESCRIPTION
## Summary

Three-item mindmap UX rework requested by Hank in chat (15:23 lock-in).
Card: card_2943e4b021432a452098aa3a.

1. **`sys:automation` as first-class subsystem.** Auto-cards used to be filtered out by default; spawned children leaked through and lost their parent edge → orphans at the bottom of the graph. Now auto triggers anchor under a new `sys:automation` hub, and the SQL filter is dropped entirely.
2. **Dual-axis edges (lineage + content).** Removed the `!c.parent_card_id` guard at the hub edge loop. Every card now gets *both* a sysHub edge (semantic) and a parent edge (lineage), so the mindmap is navigable from either axis. Auto-spawned children connect to their auto parent **and** their content subsystem.
3. **Mindmap chip 引用 unified to `quoteToChat()` deep-link.** Cite button used to be clipboard-only — inconsistent with the rest of the cite flow. Now it calls `quoteToChat(...)` with `prefillInput=token`, falling back through postMessage → localStorage → clipboard. `chat.html` consumes `prefillInput` on both the localStorage and postMessage paths. Pin button icons changed (`📌 → 🔖/📍`) so they no longer collide with the cite icon.

## Out of scope (Hank explicitly declined)

- Second clipboard-token button on chip (over-engineered)
- Default-collapse `sys:automation` (would become orphan once automation is first-class)

## Test plan

- [x] `npx jest tests/jest/kanban-mindmap.test.js` — 8/8 green (added 1, edited 2)
- [x] `npx eslint kanban.js public/portal/shared/mission-mindmap.js` — 0 errors
- [ ] Playwright web E2E: open mission.html, expand mindmap, click chip, click 📌, verify deep-link to chat with token pre-filled
- [ ] Playwright mobile viewport — same flow
- [ ] Screenshot evidence on card_2943e4b021432a452098aa3a

🤖 Generated with [Claude Code](https://claude.com/claude-code)