### PR TITLE
fix(chat): clear stale chat_draft when mindmap cite prefills

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3209,6 +3209,10 @@
                                 inp.focus();
                                 try { inp.setSelectionRange(prefillInput.length, prefillInput.length); } catch(e2) {}
                             }
+                            // The chat_draft restore below would otherwise
+                            // overwrite the prefill with a stale draft; the
+                            // deep-link explicitly asked for prefill, so it wins.
+                            localStorage.removeItem('chat_draft');
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

Companion fix discovered while E2E-ing PR #2173 (card_2943e4b021432a452098aa3a).

The mindmap chip 引用 (📌) deep-link writes a chip token to `messageInput` via the `eclaw_pending_quote → prefillInput` path. A few lines later the same chat.html init also restored `localStorage.chat_draft` into the same input, silently overwriting the prefill if the user had a stale draft sitting around.

Reproduced in E2E: cited `card_77733e63…` from the mindmap, but the chat input showed an unrelated `card_a82d…` left over from a prior session. The deep-link is an explicit user gesture, so it wins over draft restore.

## Test plan

- [x] Cleared chat_draft, fired prefillInput → input shows the cited token (verified pre-fix)
- [x] Repro: with stale chat_draft, prefillInput was overwritten — confirms the bug
- [ ] Re-run E2E after deploy: prefillInput should win regardless of draft state

🤖 Generated with [Claude Code](https://claude.com/claude-code)