### PR TITLE
feat(ios): Mind Map entry in Settings (v1.0.1 prep)

### DIFF
--- a/ios-app/app/(tabs)/settings.tsx
+++ b/ios-app/app/(tabs)/settings.tsx
@@ -235,6 +235,12 @@ export default function SettingsScreen() {
             right={(props) => <List.Icon {...props} icon="open-in-new" />}
             onPress={() => Linking.openURL('https://eclawbot.com/portal/settings.html#kanban-nudge-card').catch(() => {})}
           />
+          <List.Item
+            title={t('settings.mindmap', '🧠 Mind Map')}
+            left={(props) => <List.Icon {...props} icon="brain" />}
+            right={(props) => <List.Icon {...props} icon="open-in-new" />}
+            onPress={() => Linking.openURL('https://eclawbot.com/portal/mindmap.html').catch(() => {})}
+          />
         </List.Section>
 
         <Divider />


### PR DESCRIPTION
## Summary
- Adds Mind Map link to iOS Settings → Services section
- Mirrors existing kanban-nudge `Linking.openURL` pattern
- Targets `https://eclawbot.com/portal/mindmap.html`

## Why
v1.0.1 release-prep gap: `mindmap.html` shipped on web 2026-04-25 (心智圖 feature) but iOS app had zero entry point. Users on app couldn't reach the new feature.

## Test plan
- [ ] Build app, open Settings → Services, confirm "🧠 Mind Map" appears below Kanban Nudge
- [ ] Tap entry → opens mindmap.html in external browser
- [ ] i18n key `settings.mindmap` falls back to "🧠 Mind Map" if not yet translated (Hermes will catch in next i18n pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)