### PR TITLE
revert(ios): remove redundant Mind Map entry from Settings (#2178)

### DIFF
--- a/ios-app/app/(tabs)/settings.tsx
+++ b/ios-app/app/(tabs)/settings.tsx
@@ -235,12 +235,6 @@ export default function SettingsScreen() {
             right={(props) => <List.Icon {...props} icon="open-in-new" />}
             onPress={() => Linking.openURL('https://eclawbot.com/portal/settings.html#kanban-nudge-card').catch(() => {})}
           />
-          <List.Item
-            title={t('settings.mindmap', '🧠 Mind Map')}
-            left={(props) => <List.Icon {...props} icon="brain" />}
-            right={(props) => <List.Icon {...props} icon="open-in-new" />}
-            onPress={() => Linking.openURL('https://eclawbot.com/portal/mindmap.html').catch(() => {})}
-          />
         </List.Section>
 
         <Divider />


### PR DESCRIPTION
## Summary
Reverts PR #2178. Mind Map already reachable via the mission/task page — Settings → Services link was redundant.

## Why
Hank flagged 2026-04-27 22:00: 「mindmap entry 有入口呀 走任務頁面就可以了」 — I missed the existing mission-page entry when adding the redundant Settings link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)