### PR TITLE
feat(settings): Mind Map entry + delete-account verified (v1.0.1 prep)

### DIFF
--- a/ios-app/app/(tabs)/settings.tsx
+++ b/ios-app/app/(tabs)/settings.tsx
@@ -235,6 +235,12 @@ export default function SettingsScreen() {
             right={(props) => <List.Icon {...props} icon="open-in-new" />}
             onPress={() => Linking.openURL('https://eclawbot.com/portal/settings.html#kanban-nudge-card').catch(() => {})}
           />
+          <List.Item
+            title={t('settings.mindmap', '🧠 Mind Map')}
+            left={(props) => <List.Icon {...props} icon="graph-outline" />}
+            right={(props) => <List.Icon {...props} icon="open-in-new" />}
+            onPress={() => Linking.openURL('https://eclawbot.com/portal/mindmap.html').catch(() => {})}
+          />
         </List.Section>
 
         <Divider />


### PR DESCRIPTION
## Summary
v1.0.1 release prep — non-Hermes-blocking items from Card C:

1. **delete-account verified reachable** in `ios-app/app/(tabs)/settings.tsx`:
   - `handleDeleteAccount` (L105-126) — confirm dialog → `authApi.deleteAccount()` → `clearAll()` → redirect to login.
   - "Delete Account" Button (L276-284) — `mode="text"`, red `theme.colors.error`, destructive style, sits in `bottomActions`.
   - Apple Review Guideline 5.1.1(v) requirement satisfied. No code change needed.

2. **Mind Map app entry added** to Settings → Services section, matching the existing Kanban Nudge / Privacy Policy `Linking.openURL` pattern (per WebView-first preference). Opens `https://eclawbot.com/portal/mindmap.html`.

3. (Not in this PR) Native screenshot review of 21 screens — separate follow-up, will iterate via simulator + computer MCP.

4. (Not in this PR) i18n 11-locale 15msg-cap removal — completed earlier today, all merged via PRs #2181-2191. 13-locale sweep done.

## Test plan
- [x] Code compiles (TypeScript strict; new `<List.Item>` follows established interface)
- [ ] iOS simulator: tap Settings → 🧠 Mind Map → opens portal mindmap.html in WebView
- [ ] iOS simulator: tap Settings → Delete Account → confirm dialog → success path

i18n: `settings.mindmap` key uses inline fallback `'🧠 Mind Map'` (matches `settings.kanban_nudge` / `settings.invite_friends` pattern). Hermes can pick up translations as a follow-up if Hank wants localized labels.