### PR TITLE
fix(mindmap): recover from stale rootNodeId 404 instead of dead-end

### DIFF
--- a/backend/public/portal/mindmap.html
+++ b/backend/public/portal/mindmap.html
@@ -726,7 +726,15 @@
                 renderGraph(data.nodes || [], data.edges || []);
                 setStatus(`${data.nodes.length} ${i18n.t('mindmap_nodes', 'nodes')} · ${data.edges.length} ${i18n.t('mindmap_edges', 'edges')}${data.truncated ? ' · ' + i18n.t('mindmap_truncated', 'truncated') : ''}`);
             } catch (e) {
-                setStatus(i18n.t('mindmap_err_load', 'Load failed') + ': ' + (e.message || e));
+                const msg = (e && e.message) || String(e);
+                if (/root.*not.*found|not.*found.*root|404/i.test(msg)) {
+                    try { localStorage.removeItem('mindmap:rootId'); } catch (_) {}
+                    rootNodeId = null;
+                    if (cy) cy.elements().remove();
+                    setStatus(i18n.t('mindmap_empty_graph', 'Empty graph — add your first node'));
+                    return;
+                }
+                setStatus(i18n.t('mindmap_err_load', 'Load failed') + ': ' + msg);
             }
         }
 


### PR DESCRIPTION
## Summary
- Detect 404 / root-not-found on `loadGraph` and fall back to empty-graph state instead of leaving the user staring at `Load failed: Root node not found`
- Clears `localStorage[mindmap:rootId]` + nulls in-memory `rootNodeId` so the recovery is sticky across reloads

## Why
Found during v1.0.1 screenshot sweep (subcard `card_e9abf25b`, parent `card_9353dffb`). Prod default visit shows `rootNodeId=3be77202-0580-483c-8343-89c53f45b17f` — a node that no longer exists. PR #2192 just added Settings → Mind Map entry into the iOS app, so any returning tester whose seed node was wiped (DB reset, sandbox swap) would hit this on first tap.

Card: `card_89ae6202d97c9f193c37d7bb`

## Test plan
- [x] Local: `git diff --stat` = 1 file, +9 / -1
- [ ] Manual: clear localStorage, set `mindmap:rootId` to a bogus UUID, reload → expect Empty-graph prompt rather than Load-failed error
- [ ] Post-merge: re-visit `portal/mindmap.html` on prod with the stale rootId → expect graceful empty-state recovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)