### PR TITLE
fix(mindmap): wrap toolbar on narrow viewports so status stays visible

### DIFF
--- a/backend/public/portal/mindmap.html
+++ b/backend/public/portal/mindmap.html
@@ -47,6 +47,7 @@
             left: 12px;
             right: 12px;
             display: flex;
+            flex-wrap: wrap;
             gap: 8px;
             z-index: 10;
             pointer-events: none;


### PR DESCRIPTION
## Summary
- Adds `flex-wrap: wrap` to `.mm-toolbar` so the six toolbar items wrap to a second row at iPhone-Pro width (390px)
- Restores visibility of `#mmStatus` (Loading… / Empty-graph prompt / N nodes · M edges / error text)

## Why
Companion to merged PR #2193. That fix made stale-rootNodeId fall back to the empty-graph state; this one makes the resulting "Empty graph — add your first node" feedback actually readable on iOS, where PR #2192 just shipped the Settings → Mind Map entry.

Card: `card_16097b2f6c49893cd21464f3` (sibling to closed `card_89ae6202`)

## Test plan
- [x] `git diff --stat` = 1 file, +1 / -0
- [ ] Post-merge: hit `portal/mindmap.html` at 390x844 and confirm status row visible (will use Playwright + screenshot evidence)

🤖 Generated with [Claude Code](https://claude.com/claude-code)