### PR TITLE
fix(i18n): make dup-key lint script string-aware + accept all locale headers

### DIFF
--- a/backend/scripts/i18n-lint-dup-keys.js
+++ b/backend/scripts/i18n-lint-dup-keys.js
@@ -13,30 +13,55 @@ const fs = require('fs');
 
 const I18N_PATH = process.argv[2] || path.join(__dirname, '../public/shared/i18n.js');
 
-function findLocaleBlocks(content, lines) {
+// Match `xx:` or `xx-XX:` locale headers, with optional surrounding quotes.
+const LOCALE_HEADER_RE = /^"?([a-z]{2}(?:[-_][A-Z]{2})?)"?:\s*\{/;
+
+// Count `{` and `}` outside string literals. Honors `\"` escapes within "..." strings.
+function countBracesOutsideStrings(line, startInString) {
+  let opens = 0;
+  let closes = 0;
+  let inString = startInString;
+  let escape = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (escape) { escape = false; continue; }
+    if (inString) {
+      if (ch === '\\') { escape = true; continue; }
+      if (ch === '"') { inString = false; continue; }
+      continue;
+    }
+    if (ch === '"') { inString = true; continue; }
+    if (ch === '{') opens++;
+    else if (ch === '}') closes++;
+  }
+  return { opens, closes, inString };
+}
+
+function findLocaleBlocks(lines) {
   const blocks = {};
   let braceDepth = 0;
   let inTranslations = false;
+  let inString = false;
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
     const trimmed = line.trimStart();
     const indent = line.length - trimmed.length;
 
-    // Check locale header BEFORE updating brace depth for this line
-    const m = trimmed.match(/^([a-z]{2}(?:[-_][A-Z]{2})?):\s*\{/);
-    if (m && indent === 4 && braceDepth === 1 && inTranslations) {
-      blocks[m[1]] = i + 1; // 1-indexed
+    // Locale header check uses brace depth at *start* of this line.
+    // Accept indent up to 4 (some locales like "zh-CN": have indent 0).
+    if (!inString && braceDepth === 1 && inTranslations && indent <= 4) {
+      const m = trimmed.match(LOCALE_HEADER_RE);
+      if (m) blocks[m[1]] = i + 1;
     }
 
-    // Update brace depth AFTER the check (depth at start of this line)
-    if (!inTranslations) {
-      if (line.includes('TRANSLATIONS') && line.includes('=')) {
-        inTranslations = true;
-      }
+    if (!inTranslations && line.includes('TRANSLATIONS') && line.includes('=')) {
+      inTranslations = true;
     }
-    braceDepth += (line.match(/\{/g) || []).length;
-    braceDepth -= (line.match(/\}/g) || []).length;
+
+    const counts = countBracesOutsideStrings(line, inString);
+    braceDepth += counts.opens - counts.closes;
+    inString = counts.inString;
   }
 
   return blocks;
@@ -45,7 +70,8 @@ function findLocaleBlocks(content, lines) {
 function findDuplicateKeys(lines, startLine, endLine) {
   const keyPositions = {};
   const dups = [];
-  const keyRe = /^\s+"([a-zA-Z_]+)":/;
+  // Match indented `"key":` at any depth within the locale block.
+  const keyRe = /^\s+"([a-zA-Z0-9_-]+)":/;
 
   for (let i = startLine - 1; i < Math.min(endLine - 1, lines.length); i++) {
     const m = lines[i].match(keyRe);
@@ -72,7 +98,7 @@ function main() {
   }
 
   const lines = content.split('\n');
-  const blocks = findLocaleBlocks(content, lines);
+  const blocks = findLocaleBlocks(lines);
 
   if (Object.keys(blocks).length === 0) {
     console.error('Error: No locale blocks found. Is this the i18n.js file?');
@@ -86,11 +112,13 @@ function main() {
     localeEnds[sorted[i][0]] = i + 1 < sorted.length ? sorted[i + 1][1] - 1 : lines.length + 1;
   }
 
+  const dupsByLocale = {};
   let hasErrors = false;
 
   for (const [locale, startLine] of sorted) {
     const endLine = localeEnds[locale];
     const dups = findDuplicateKeys(lines, startLine, endLine);
+    dupsByLocale[locale] = dups;
 
     if (dups.length > 0) {
       hasErrors = true;
@@ -108,8 +136,8 @@ function main() {
 
   console.error('\n=== SUMMARY ===');
   if (hasErrors) {
-    const totalDups = sorted.reduce((sum, [l]) => sum + findDuplicateKeys(lines, blocks[l], localeEnds[l]).length, 0);
-    const failCount = sorted.filter(([l]) => findDuplicateKeys(lines, blocks[l], localeEnds[l]).length > 0).length;
+    const totalDups = sorted.reduce((sum, [l]) => sum + dupsByLocale[l].length, 0);
+    const failCount = sorted.filter(([l]) => dupsByLocale[l].length > 0).length;
     console.error(`Total: ${totalDups} duplicate key(s) across ${failCount} locale(s)`);
     process.exit(1);
   } else {

--- a/backend/tests/jest/i18n-lint-dup-keys.test.js
+++ b/backend/tests/jest/i18n-lint-dup-keys.test.js
@@ -1,0 +1,148 @@
+/**
+ * Tests for scripts/i18n-lint-dup-keys.js parser correctness.
+ * Covers: string-aware brace counting, indent tolerance, quoted-key acceptance.
+ */
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/i18n-lint-dup-keys.js');
+
+function runLint(source) {
+  const tmp = path.join(os.tmpdir(), `i18n-lint-fixture-${Date.now()}-${Math.random().toString(36).slice(2)}.js`);
+  fs.writeFileSync(tmp, source, 'utf8');
+  try {
+    const out = execFileSync('node', [SCRIPT, tmp], { encoding: 'utf8' });
+    return { code: 0, stdout: out, stderr: '' };
+  } catch (err) {
+    return { code: err.status, stdout: err.stdout || '', stderr: err.stderr || '' };
+  } finally {
+    fs.unlinkSync(tmp);
+  }
+}
+
+describe('i18n-lint-dup-keys parser', () => {
+  test('counts brace depth correctly when locale strings contain { and }', () => {
+    const src = [
+      'const TRANSLATIONS = {',
+      '    en: {',
+      '        "greet_user": "Hello {name}, you have (#{count}) items.",',
+      '        "msg_orphan_open": "Found unclosed { in raw text",',
+      '    },',
+      '    de: {',
+      '        "greet_user": "Hallo {name}",',
+      '    },',
+      '};',
+      '',
+    ].join('\n');
+    const res = runLint(src);
+    expect(res.stdout).toContain('PASS: en');
+    expect(res.stdout).toContain('PASS: de');
+    expect(res.code).toBe(0);
+  });
+
+  test('detects locale headers with quoted compound keys (e.g. "zh-CN":)', () => {
+    const src = [
+      'const TRANSLATIONS = {',
+      '    en: {',
+      '        "hello": "Hello",',
+      '    },',
+      '"zh-CN": {',
+      '        "hello": "你好",',
+      '    },',
+      '    ja: {',
+      '        "hello": "こんにちは",',
+      '    },',
+      '};',
+      '',
+    ].join('\n');
+    const res = runLint(src);
+    expect(res.stdout).toContain('PASS: en');
+    expect(res.stdout).toContain('PASS: zh-CN');
+    expect(res.stdout).toContain('PASS: ja');
+    expect(res.code).toBe(0);
+  });
+
+  test('reports real duplicates within a single locale block', () => {
+    const src = [
+      'const TRANSLATIONS = {',
+      '    en: {',
+      '        "key_a": "first",',
+      '        "key_b": "second",',
+      '        "key_a": "duplicate",',
+      '    },',
+      '    de: {',
+      '        "key_a": "Erste",',
+      '    },',
+      '};',
+      '',
+    ].join('\n');
+    const res = runLint(src);
+    expect(res.stderr).toContain('FAIL: en');
+    expect(res.stderr).toContain('"key_a"');
+    expect(res.stdout).toContain('PASS: de');
+    expect(res.code).toBe(1);
+  });
+
+  test('does NOT flag same key across different locales as duplicate', () => {
+    const src = [
+      'const TRANSLATIONS = {',
+      '    en: {',
+      '        "shared": "English",',
+      '    },',
+      '    de: {',
+      '        "shared": "Deutsch",',
+      '    },',
+      '    ja: {',
+      '        "shared": "日本語",',
+      '    },',
+      '};',
+      '',
+    ].join('\n');
+    const res = runLint(src);
+    expect(res.stdout).toContain('PASS: en');
+    expect(res.stdout).toContain('PASS: de');
+    expect(res.stdout).toContain('PASS: ja');
+    expect(res.code).toBe(0);
+  });
+
+  test('handles escaped quotes inside translation strings', () => {
+    const src = [
+      'const TRANSLATIONS = {',
+      '    en: {',
+      '        "quoted": "He said \\"hello {name}\\" to her",',
+      '    },',
+      '    de: {',
+      '        "quoted": "Er sagte",',
+      '    },',
+      '};',
+      '',
+    ].join('\n');
+    const res = runLint(src);
+    expect(res.stdout).toContain('PASS: en');
+    expect(res.stdout).toContain('PASS: de');
+    expect(res.code).toBe(0);
+  });
+
+  test('regression: real i18n.js detects all 14 locales (no false-positive es absorption)', () => {
+    const realPath = path.resolve(__dirname, '../../public/shared/i18n.js');
+    if (!fs.existsSync(realPath)) {
+      return;
+    }
+    let stdout = '', stderr = '', code = 0;
+    try {
+      stdout = execFileSync('node', [SCRIPT, realPath], { encoding: 'utf8' });
+    } catch (err) {
+      stdout = err.stdout || '';
+      stderr = err.stderr || '';
+      code = err.status;
+    }
+    const allOutput = stdout + stderr;
+    for (const locale of ['en', 'zh', 'zh-CN', 'ja', 'ko', 'th', 'vi', 'id', 'fr', 'es', 'de', 'ms', 'hi', 'ar']) {
+      expect(allOutput).toMatch(new RegExp(`(PASS|FAIL): ${locale.replace('-', '\\-')} `));
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes three parser bugs in `scripts/i18n-lint-dup-keys.js` (added in PR #2195) that were causing 14131 false-positive duplicate-key reports against `i18n.js`.

The lint was lumping de / ms / hi / ar / zh-CN into a fake oversized `es` block and reporting their keys as "duplicates inside es". Verified via `node eval(TRANSLATIONS)` that the real file parses cleanly with 14 locales — the structural "es boundary bug" never existed; it was a lint artifact.

### Three parser bugs

1. **Brace counter wasn't string-aware.** Translation values like `"...{name}..."` had their `{` and `}` counted into `braceDepth`. One truncated Spanish string at L40123 (`(#{i...`) had an unmatched `{` that pushed `braceDepth` permanently off-by-one for the rest of the file.

2. **`indent === 4` was too strict.** L9453 has `"zh-CN": {` at indent=0, silently skipped.

3. **Locale-header regex didn't accept quoted keys.** `"zh-CN":` form was rejected.

### Fix

- `countBracesOutsideStrings()`: char-level scanner that respects `"..."` and `\"` escapes; only counts braces in code, not in strings.
- `LOCALE_HEADER_RE`: accepts optional surrounding quotes.
- Indent check relaxed to `indent <= 4`.

### Before / after on real `i18n.js`

| | Before | After |
|---|---|---|
| Locales detected | 9 (en, zh, ja, ko, th, vi, id, fr, es) | 14 (+ zh-CN, de, ms, hi, ar) |
| Reported dups | 17079 (mostly fake) | 2635 (all real existing tech debt) |
| `es` reported size | L38571–L63828 (bogus 25K lines) | L38571–L42616 (real 4K lines) |

### Out of scope

The newly visible real-duplicate findings (`ms`: 635, `hi`: 1993) are pre-existing tech debt that the buggy lint had been hiding. Will file a separate cleanup card. Not in scope here.

L40123 truncated translation (`(#{i...`) is a translator TODO, not a lint bug — also out of scope, follow-up Hermes task.

## Test plan

- [x] `npm run lint:i18n-dups` — all 14 locales detected, real dups correctly attributed
- [x] `node_modules/.bin/jest tests/jest/i18n-lint-dup-keys.test.js` — 6/6 pass
  - string-aware brace counting
  - quoted compound locale keys (`"zh-CN":`)
  - real intra-locale duplicates flagged
  - same key across different locales NOT flagged
  - escaped quotes inside strings
  - regression: real `i18n.js` enumerates all 14 locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)