### PR TITLE
fix(kanban-i18n): add 'blocked' status label to EN + zh-TW (P1.3 baseline)

### DIFF
--- a/backend/i18n/kanban-notifications.js
+++ b/backend/i18n/kanban-notifications.js
@@ -4,7 +4,7 @@
 
 const TRANSLATIONS = {
     en: {
-        statusLabels: { backlog: 'Backlog', todo: 'TODO', in_progress: 'In Progress', review: 'Review', done: 'Done' },
+        statusLabels: { backlog: 'Backlog', todo: 'TODO', in_progress: 'In Progress', review: 'Review', done: 'Done', blocked: 'Blocked' },
         cardCreated: '📋 New task assigned: {priorityIcon} [{priority}] {title}\nStatus: {status}',
         statusChanged: '{direction} Task status changed: [{title}]\n{from} → {to}',
         staleNudge: '⏰ Task nudge: [{title}]\nStuck in "{status}" for {hours}h, please continue',
@@ -16,7 +16,7 @@ const TRANSLATIONS = {
         reviewerNoReply: '(no reply content)'
     },
     zh: {
-        statusLabels: { backlog: '待辦池', todo: '待辦', in_progress: '進行中', review: '審查', done: '完成' },
+        statusLabels: { backlog: '待辦池', todo: '待辦', in_progress: '進行中', review: '審查', done: '完成', blocked: '已封鎖' },
         cardCreated: '📋 新任務指派：{priorityIcon} [{priority}] {title}\n狀態: {status}',
         statusChanged: '{direction} 任務狀態變更：[{title}]\n{from} → {to}',
         staleNudge: '⏰ 任務催促：[{title}]\n已在「{status}」停留 {hours} 小時，請繼續推進',


### PR DESCRIPTION
## Summary
EN baseline now includes `statusLabels.blocked: 'Blocked'` so the existing fallback in `statusLabel()` returns the correct word for the 11 untranslated locales until Hermes ships proper translations. zh-TW added too.

## Why
P1.1 + P1.2 made `blocked` a first-class kanban status. Push notifications still emit literal `blocked` for non-EN/zh-TW users because the per-locale `statusLabels` maps don't have the key.

## Follow-ups
Delegated to Hermes in a separate PR: zh-CN, ja, ko, th, vi, id, hi, es, fr, ms, ar, de.

Refs: card_42526620af35fb0b27edb2a2 (umbrella P1.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)