### PR TITLE
fix(hermes): messageQueue cap 200 + dead-letter buffer (Phase H1.1)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -887,6 +887,7 @@ async function handlePlatformCommand(command, deviceId, device, targetIds, confi
                         [deviceId, eId]
                     );
                     entity.messageQueue = [];
+                    entity.deadLetterQueue = [];
                     const name = entity.name || `Entity ${eId}`;
                     results.push(`#${eId} ${name}: history cleared`);
                 } catch (err) {
@@ -2041,7 +2042,7 @@ authModule.setOnEmailVerified(async (deviceId) => {
                 mediaUrl: msg.media_url || null,
                 crossDevice: true
             };
-            toEntity.messageQueue.push(messageObj);
+            enqueueMessage(toEntity, messageObj, 'pending_flush');
 
             const sourceTag = `${sourceLabel}->${msg.target_code}`;
             await saveChatMessage(target.deviceId, target.entityId, msg.text, sourceTag, true, false, msg.media_type || null, msg.media_url || null);
@@ -3899,6 +3900,37 @@ async function backfillPublicCodes() {
     }
 }
 
+// Phase H1.1: bounded messageQueue + dead-letter buffer.
+// Hermes [回應超時] recurred 2026-04-28 because the per-entity messageQueue could grow
+// unbounded — daemon refactor (PR #2201) didn't actually cap it. Hard cap at 200; older
+// entries spill to a small deadLetterQueue (50) for forensics + Phase H1.2 alerting.
+const MESSAGE_QUEUE_CAP = 200;
+const DEAD_LETTER_CAP = 50;
+
+function enqueueMessage(toEntity, messageObj, ctx) {
+    if (!toEntity) return;
+    if (!Array.isArray(toEntity.messageQueue)) toEntity.messageQueue = [];
+    if (!Array.isArray(toEntity.deadLetterQueue)) toEntity.deadLetterQueue = [];
+
+    toEntity.messageQueue.push(messageObj);
+
+    while (toEntity.messageQueue.length > MESSAGE_QUEUE_CAP) {
+        const dropped = toEntity.messageQueue.shift();
+        toEntity.deadLetterQueue.push({
+            ...dropped,
+            droppedAt: Date.now(),
+            droppedReason: 'queue_overflow',
+            droppedCtx: ctx || null,
+        });
+        while (toEntity.deadLetterQueue.length > DEAD_LETTER_CAP) {
+            toEntity.deadLetterQueue.shift();
+        }
+        try {
+            console.warn(`[Queue] entity ${toEntity.entityId} mq overflow — dropped oldest to DLQ. mqLen=${toEntity.messageQueue.length} dlqLen=${toEntity.deadLetterQueue.length} ctx=${ctx || ''}`);
+        } catch (_) {}
+    }
+}
+
 // Helper: Create default entity
 function createDefaultEntity(entityId) {
     return {
@@ -3912,6 +3944,7 @@ function createDefaultEntity(entityId) {
         parts: {},
         lastUpdated: Date.now(),
         messageQueue: [],
+        deadLetterQueue: [], // Phase H1.1: capped overflow buffer for forensics
         webhook: null,
         appVersion: null, // Device app version (e.g., "1.0.3")
         avatar: null, // User-chosen emoji avatar (synced across devices)
@@ -4606,7 +4639,41 @@ app.get('/api/invite/clicks', async (req, res) => {
 });
 
 app.get('/api/health', (req, res) => {
-    res.status(200).json({ status: 'ok', timestamp: Date.now(), build: SERVER_BUILD_TAG, uptime: process.uptime(), startedAt: SERVER_STARTED_AT.toISOString() });
+    // Phase H1.1: surface worst-case mq/dlq depth so ops can spot Hermes-style fan-out
+    // before [回應超時] hits. Cheap O(entities) pass — devices is the in-memory map.
+    let maxMq = 0;
+    let maxDlq = 0;
+    let totalDlq = 0;
+    let entitiesScanned = 0;
+    try {
+        for (const dev of Object.values(devices || {})) {
+            const ents = dev && dev.entities;
+            if (!ents) continue;
+            for (const ent of Object.values(ents)) {
+                entitiesScanned++;
+                const m = (ent.messageQueue && ent.messageQueue.length) || 0;
+                const d = (ent.deadLetterQueue && ent.deadLetterQueue.length) || 0;
+                if (m > maxMq) maxMq = m;
+                if (d > maxDlq) maxDlq = d;
+                totalDlq += d;
+            }
+        }
+    } catch (_) { /* best-effort */ }
+    res.status(200).json({
+        status: 'ok',
+        timestamp: Date.now(),
+        build: SERVER_BUILD_TAG,
+        uptime: process.uptime(),
+        startedAt: SERVER_STARTED_AT.toISOString(),
+        queue: {
+            cap: MESSAGE_QUEUE_CAP,
+            dlqCap: DEAD_LETTER_CAP,
+            maxMqLen: maxMq,
+            maxDlqLen: maxDlq,
+            totalDlq,
+            entities: entitiesScanned,
+        },
+    });
 });
 
 // ============================================
@@ -5782,7 +5849,7 @@ async function deliverToEntity(opts) {
         messageObj.fromDeviceId = senderDeviceId;
         messageObj.crossDevice = true;
     }
-    toEntity.messageQueue.push(messageObj);
+    enqueueMessage(toEntity, messageObj, isCrossDevice ? 'speakto_xdevice' : (isBroadcast ? 'speakto_broadcast' : 'speakto'));
 
     // Save chat message
     const chatSource = isCrossDevice
@@ -8650,7 +8717,7 @@ app.post('/api/entity/speak-to', async (req, res) => {
         mediaType: mediaType || null,
         mediaUrl: mediaUrl || null
     };
-    toEntity.messageQueue.push(messageObj);
+    enqueueMessage(toEntity, messageObj, 'a2a_speakto');
     serverLog('info', 'speakto_push', `[A2A_MQ_PUSH] Entity ${toId}.messageQueue += item from Entity ${fromId} | mqLen=${toEntity.messageQueue.length}`, {
         deviceId, entityId: toId,
         metadata: { tag: 'A2A_MQ_PUSH', fromEntityId: fromId, toEntityId: toId, mqLen: toEntity.messageQueue.length }
@@ -17980,3 +18047,6 @@ module.exports._classifyPublisher = classifyPublisher;
 module.exports._MONITORING_THRESHOLDS = MONITORING_THRESHOLDS;
 module.exports._requireAdmin = requireAdmin;
 module.exports._createDefaultEntity = createDefaultEntity;
+module.exports._enqueueMessage = enqueueMessage;
+module.exports._MESSAGE_QUEUE_CAP = MESSAGE_QUEUE_CAP;
+module.exports._DEAD_LETTER_CAP = DEAD_LETTER_CAP;

--- a/backend/tests/jest/message-queue-cap.test.js
+++ b/backend/tests/jest/message-queue-cap.test.js
@@ -1,0 +1,98 @@
+/**
+ * Phase H1.1 — messageQueue cap + dead-letter buffer.
+ *
+ * Hermes [回應超時] recurred 2026-04-28 (mqLen=1349 observed earlier) because
+ * per-entity messageQueue grew unbounded. This locks in the cap so the next
+ * fan-out can't silently stall the bridge.
+ */
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+        connect: jest.fn().mockResolvedValue({
+            query: jest.fn().mockResolvedValue({ rows: [] }),
+            release: jest.fn(),
+        }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+jest.mock('../../db', () => ({
+    initDatabase: jest.fn().mockResolvedValue(true),
+    saveDeviceData: jest.fn().mockResolvedValue(true),
+    saveAllDevices: jest.fn().mockResolvedValue(true),
+    loadAllDevices: jest.fn().mockResolvedValue({}),
+    deleteDevice: jest.fn().mockResolvedValue(true),
+    getStats: jest.fn().mockResolvedValue({}),
+    closeDatabase: jest.fn().mockResolvedValue(undefined),
+    saveOfficialBot: jest.fn().mockResolvedValue(true),
+    loadOfficialBots: jest.fn().mockResolvedValue({}),
+    deleteOfficialBot: jest.fn().mockResolvedValue(true),
+    loadSubscriptions: jest.fn().mockResolvedValue({}),
+    saveSubscription: jest.fn().mockResolvedValue(true),
+    pool: { query: jest.fn().mockResolvedValue({ rows: [] }) },
+}));
+
+const app = require('../../index');
+const enqueue = app._enqueueMessage;
+const QUEUE_CAP = app._MESSAGE_QUEUE_CAP;
+const DLQ_CAP = app._DEAD_LETTER_CAP;
+const createDefaultEntity = app._createDefaultEntity;
+
+describe('Phase H1.1 — enqueueMessage cap + DLQ', () => {
+    test('exposes the documented caps (200 / 50)', () => {
+        expect(QUEUE_CAP).toBe(200);
+        expect(DLQ_CAP).toBe(50);
+    });
+
+    test('default entity factory initialises both queues empty', () => {
+        const ent = createDefaultEntity(7);
+        expect(ent.messageQueue).toEqual([]);
+        expect(ent.deadLetterQueue).toEqual([]);
+    });
+
+    test('queue stays clamped at cap; oldest spills to DLQ', () => {
+        const ent = createDefaultEntity(5);
+        for (let i = 0; i < QUEUE_CAP + 10; i++) {
+            enqueue(ent, { text: `msg-${i}`, timestamp: i }, 'unit_test');
+        }
+        expect(ent.messageQueue.length).toBe(QUEUE_CAP);
+        // Oldest 10 spilled into DLQ
+        expect(ent.deadLetterQueue.length).toBe(10);
+        // First DLQ entry is the very first message pushed
+        expect(ent.deadLetterQueue[0].text).toBe('msg-0');
+        expect(ent.deadLetterQueue[0].droppedReason).toBe('queue_overflow');
+        expect(ent.deadLetterQueue[0].droppedCtx).toBe('unit_test');
+        // mq head is the (QUEUE_CAP+1)th item we sent: msg-10
+        expect(ent.messageQueue[0].text).toBe('msg-10');
+    });
+
+    test('DLQ itself is bounded — only the most recent DEAD_LETTER_CAP overflows survive', () => {
+        const ent = createDefaultEntity(9);
+        const total = QUEUE_CAP + DLQ_CAP + 25;
+        for (let i = 0; i < total; i++) {
+            enqueue(ent, { text: `msg-${i}` }, 'flood');
+        }
+        expect(ent.messageQueue.length).toBe(QUEUE_CAP);
+        expect(ent.deadLetterQueue.length).toBe(DLQ_CAP);
+        // DLQ keeps the LATEST drops, not the earliest — earliest are dropped wholesale.
+        const firstDlq = ent.deadLetterQueue[0].text;
+        const lastDlq = ent.deadLetterQueue[DLQ_CAP - 1].text;
+        // First surviving DLQ entry index = total - QUEUE_CAP - DLQ_CAP
+        expect(firstDlq).toBe(`msg-${total - QUEUE_CAP - DLQ_CAP}`);
+        // Last DLQ entry index = total - QUEUE_CAP - 1
+        expect(lastDlq).toBe(`msg-${total - QUEUE_CAP - 1}`);
+    });
+
+    test('skips work safely if entity is missing', () => {
+        expect(() => enqueue(null, { text: 'x' }, 'noop')).not.toThrow();
+        expect(() => enqueue(undefined, { text: 'x' }, 'noop')).not.toThrow();
+    });
+
+    test('lazy-initialises queues if entity arrived without them (legacy data)', () => {
+        const ent = { entityId: 1 };
+        enqueue(ent, { text: 'first' }, 'legacy');
+        expect(ent.messageQueue).toEqual([{ text: 'first' }]);
+        expect(ent.deadLetterQueue).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary
- Per-entity \`messageQueue\` is now hard-capped at **200**; older entries spill into a 50-entry \`deadLetterQueue\` with drop metadata so we don't lose them silently.
- All three push sites (PendingFlush xdevice flush, \`deliverEntityToEntity\` speakto, A2A \`/transform\` speakTo) routed through new \`enqueueMessage(entity, msg, ctx)\`.
- \`/api/health\` surfaces \`maxMqLen\`, \`maxDlqLen\`, \`totalDlq\`, plus the configured caps — so the next time fan-out gets ugly we can see it from the dashboard before \`[回應超時]\` lands.

## Why
Hermes \`[回應超時]\` recurred 2026-04-28 10:45 even though PR #2201 marked the daemon refactor resolved on roadmap.html. The HTTP refactor moved the symptom but didn't actually bound the queue (Hermes' last incident hit \`mqLen=1349\` before recovery). Hank explicitly raised priority — fix is P0.

## Card
card_f1e7feeb28ba93ae36db7f39 — \[P0\] Hermes daemon refactor 失效復發

## Tests
- New \`tests/jest/message-queue-cap.test.js\` (6 cases) — caps verified, oldest-spills-to-DLQ verified, DLQ self-cap verified, legacy/missing-entity safety verified. All pass locally.

## Follow-ups (same card)
- Phase H1.2: heartbeat / ping-pong + delivery-receipt alert
- Phase H1.5: Docker health-check → Railway auto-restart

## Test plan
- [x] New unit tests pass
- [x] Existing chat / a2a tests still pass (no behavior change for in-cap traffic)
- [ ] Post-deploy: GET /api/health returns the new \`queue\` block

🤖 Generated with [Claude Code](https://claude.com/claude-code)