### PR TITLE
fix(hermes): route remaining push sites + boot clamp (Phase H1.1b)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1130,6 +1130,9 @@ async function initPersistence() {
     // Load existing data
     await loadData();
 
+    // Phase H1.1b: clamp legacy queues that exceeded the cap before this code shipped.
+    clampQueuesOnLoad();
+
     // Load official bot pool
     if (usePostgreSQL) {
         const loadedBots = await db.loadOfficialBots();
@@ -3928,6 +3931,32 @@ function enqueueMessage(toEntity, messageObj, ctx) {
         try {
             console.warn(`[Queue] entity ${toEntity.entityId} mq overflow — dropped oldest to DLQ. mqLen=${toEntity.messageQueue.length} dlqLen=${toEntity.deadLetterQueue.length} ctx=${ctx || ''}`);
         } catch (_) {}
+    }
+}
+
+// Phase H1.1b: Boot-time clamp. Legacy persisted state may already exceed cap
+// (we observed mqLen=1564 on Hermes after the H1.1 deploy because the queue was
+// loaded from DB pre-fix). Trim once on load so /api/health reflects truth and
+// the next push doesn't immediately torch 1300+ messages into the 50-slot DLQ.
+function clampQueuesOnLoad() {
+    let trimmed = 0, entitiesScanned = 0;
+    for (const dev of Object.values(devices || {})) {
+        const ents = dev && dev.entities;
+        if (!ents) continue;
+        for (const ent of Object.values(ents)) {
+            entitiesScanned++;
+            if (Array.isArray(ent.messageQueue) && ent.messageQueue.length > MESSAGE_QUEUE_CAP) {
+                const overflow = ent.messageQueue.length - MESSAGE_QUEUE_CAP;
+                ent.messageQueue.splice(0, overflow); // drop oldest, no DLQ — these are pre-fix legacy
+                trimmed += overflow;
+            }
+            if (Array.isArray(ent.deadLetterQueue) && ent.deadLetterQueue.length > DEAD_LETTER_CAP) {
+                ent.deadLetterQueue.splice(0, ent.deadLetterQueue.length - DEAD_LETTER_CAP);
+            }
+        }
+    }
+    if (trimmed > 0) {
+        console.warn(`[Queue] boot clamp: trimmed ${trimmed} stale messages across ${entitiesScanned} entities (pre-cap legacy state)`);
     }
 }
 
@@ -8415,7 +8444,7 @@ app.post('/api/client/speak', async (req, res) => {
             mediaType: mediaType || null,
             mediaUrl: mediaUrl || null
         };
-        entity.messageQueue.push(messageObj);
+        enqueueMessage(entity, messageObj, 'incoming_chat');
         const chatBackupUrl = mediaType === 'photo' ? getBackupUrl(mediaUrl) : null;
         await saveChatMessage(deviceId, eId, text, source, true, false, mediaType || null, mediaUrl || null, null, null, chatBackupUrl, mentionsContext, null, validatedAttachments);
 
@@ -9117,7 +9146,7 @@ app.post('/api/entity/cross-speak', async (req, res) => {
         mediaUrl: mediaUrl || null,
         crossDevice: true
     };
-    toEntity.messageQueue.push(messageObj);
+    enqueueMessage(toEntity, messageObj, 'xdevice_publiccode');
 
     // Save chat message on BOTH devices
     const chatMsgId = await saveChatMessage(target.deviceId, target.entityId, crossText, `${sourceLabel}->${targetCode}`, false, true, mediaType || null, mediaUrl || null);
@@ -10759,7 +10788,7 @@ app.post('/api/client/cross-speak', async (req, res) => {
         mediaUrl: mediaUrl || null,
         crossDevice: !isOwnerMode || deviceId !== target.deviceId // false only when owner sends to own entity
     };
-    toEntity.messageQueue.push(messageObj);
+    enqueueMessage(toEntity, messageObj, isOwnerMode ? 'owner_speakto' : 'entity_speakto');
 
     // Save chat message — always save to both sender and target devices
     const sourceTag = `${sourceLabel}->${targetCode}`;
@@ -11102,7 +11131,7 @@ app.post('/api/entity/broadcast', async (req, res) => {
             mediaType: mediaType || null,
             mediaUrl: mediaUrl || null
         };
-        toEntity.messageQueue.push(messageObj);
+        enqueueMessage(toEntity, messageObj, 'broadcast');
         markMessagesAsRead(deviceId, toId);
 
         // Update entity.message so Android app can display it
@@ -17859,10 +17888,7 @@ app.post('/api/bot/sync-message', async (req, res) => {
     };
 
     // Add to entity's message queue
-    if (!entity.messageQueue) {
-        entity.messageQueue = [];
-    }
-    entity.messageQueue.push(messageObj);
+    enqueueMessage(entity, messageObj, 'bot_delivery');
     await saveChatMessage(deviceId, entityId, msgText, fromLabel || "bot", false, true, mediaType || null, mediaUrl || null);
     markMessagesAsRead(deviceId, entityId);
 
@@ -18050,3 +18076,4 @@ module.exports._createDefaultEntity = createDefaultEntity;
 module.exports._enqueueMessage = enqueueMessage;
 module.exports._MESSAGE_QUEUE_CAP = MESSAGE_QUEUE_CAP;
 module.exports._DEAD_LETTER_CAP = DEAD_LETTER_CAP;
+module.exports._clampQueuesOnLoad = clampQueuesOnLoad;

--- a/backend/tests/jest/message-queue-cap.test.js
+++ b/backend/tests/jest/message-queue-cap.test.js
@@ -38,6 +38,8 @@ const enqueue = app._enqueueMessage;
 const QUEUE_CAP = app._MESSAGE_QUEUE_CAP;
 const DLQ_CAP = app._DEAD_LETTER_CAP;
 const createDefaultEntity = app._createDefaultEntity;
+const clampQueuesOnLoad = app._clampQueuesOnLoad;
+const devices = app.devices;
 
 describe('Phase H1.1 — enqueueMessage cap + DLQ', () => {
     test('exposes the documented caps (200 / 50)', () => {
@@ -94,5 +96,35 @@ describe('Phase H1.1 — enqueueMessage cap + DLQ', () => {
         enqueue(ent, { text: 'first' }, 'legacy');
         expect(ent.messageQueue).toEqual([{ text: 'first' }]);
         expect(ent.deadLetterQueue).toEqual([]);
+    });
+
+    test('clampQueuesOnLoad trims pre-cap legacy state from devices map', () => {
+        // Stash + clear so we don't pollute prod-shape singleton between asserts.
+        const snapshot = { ...devices };
+        for (const k of Object.keys(devices)) delete devices[k];
+
+        const overflowEntity = { entityId: 42, messageQueue: [], deadLetterQueue: [] };
+        for (let i = 0; i < QUEUE_CAP + 500; i++) {
+            overflowEntity.messageQueue.push({ text: `legacy-${i}` });
+        }
+        const dlqOverflow = { entityId: 43, messageQueue: [], deadLetterQueue: [] };
+        for (let i = 0; i < DLQ_CAP + 20; i++) {
+            dlqOverflow.deadLetterQueue.push({ text: `dlq-${i}` });
+        }
+        devices['fake-device'] = { entities: { 42: overflowEntity, 43: dlqOverflow } };
+
+        clampQueuesOnLoad();
+
+        expect(overflowEntity.messageQueue.length).toBe(QUEUE_CAP);
+        // Oldest 500 are dropped wholesale (no DLQ promotion — they're pre-fix legacy)
+        expect(overflowEntity.messageQueue[0].text).toBe('legacy-500');
+        expect(overflowEntity.deadLetterQueue.length).toBe(0);
+
+        expect(dlqOverflow.deadLetterQueue.length).toBe(DLQ_CAP);
+        expect(dlqOverflow.deadLetterQueue[0].text).toBe('dlq-20');
+
+        // Restore
+        for (const k of Object.keys(devices)) delete devices[k];
+        Object.assign(devices, snapshot);
     });
 });


### PR DESCRIPTION
## Summary
- H1.1 only intercepted 3 of 8 `messageQueue.push` sites; this routes the remaining 5 (incoming_chat / xdevice_publiccode / owner_speakto / entity_speakto / broadcast / bot_delivery) through `enqueueMessage()`.
- Adds `clampQueuesOnLoad()` after `loadAllDevices()` — trims legacy mq>200 / dlq>50 wholesale (no DLQ promotion: those are pre-fix garbage, not real drops).
- Extends mq-cap test suite to 7 cases (clamp scenario verifies 700-entry legacy mq trimmed to 200, oldest 500 dropped).

## Why
v5.6 deploy showed `/api/health` `maxMqLen=1564` immediately after boot. That's persisted DB state that the H1.1 cap couldn't touch (only fires on push), and the un-routed sites would keep growing it.

## Test plan
- [x] `npx jest tests/jest/message-queue-cap.test.js` from `backend/` — 7/7 pass
- [ ] post-merge: curl `/api/health` → `maxMqLen <= 200`
- [ ] no overall test regression beyond pre-existing `chat-his-link-render` (card_398ac4c2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)