### PR TITLE
feat(hermes): delivery-stuck heartbeat detection (Phase H1.2)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -3910,12 +3910,18 @@ async function backfillPublicCodes() {
 const MESSAGE_QUEUE_CAP = 200;
 const DEAD_LETTER_CAP = 50;
 
+// Phase H1.2: delivery-stuck detection. Bot daemons drain via POST /api/bot/pending-messages.
+// If mqLen > 0 AND now-lastDrainedAt exceeds this threshold, the entity is presumed stuck
+// (Hermes typically polls every ~5s, so 90s = 18 missed polls = clearly dead).
+const HEARTBEAT_STUCK_MS = 90_000;
+
 function enqueueMessage(toEntity, messageObj, ctx) {
     if (!toEntity) return;
     if (!Array.isArray(toEntity.messageQueue)) toEntity.messageQueue = [];
     if (!Array.isArray(toEntity.deadLetterQueue)) toEntity.deadLetterQueue = [];
 
     toEntity.messageQueue.push(messageObj);
+    toEntity.lastEnqueuedAt = Date.now();
 
     while (toEntity.messageQueue.length > MESSAGE_QUEUE_CAP) {
         const dropped = toEntity.messageQueue.shift();
@@ -3960,6 +3966,38 @@ function clampQueuesOnLoad() {
     }
 }
 
+// Phase H1.2: Scan all bound bot entities for stuck delivery (mq > 0 + lastDrainedAt stale).
+// Returns a list of stuck-entity descriptors for /api/health and admin tooling.
+function findStuckEntities(nowMs) {
+    const now = nowMs || Date.now();
+    const stuck = [];
+    for (const [deviceId, dev] of Object.entries(devices || {})) {
+        const ents = dev && dev.entities;
+        if (!ents) continue;
+        for (const ent of Object.values(ents)) {
+            if (!ent || !ent.isBound) continue;
+            const mqLen = (ent.messageQueue && ent.messageQueue.length) || 0;
+            if (mqLen === 0) continue;
+            // If a bot has never drained but has messages waiting, the time-since-enqueue is the
+            // best lower-bound for "how long has this been pending"
+            const referenceAt = ent.lastDrainedAt || ent.lastEnqueuedAt || ent.lastUpdated || 0;
+            const idleMs = now - referenceAt;
+            if (idleMs > HEARTBEAT_STUCK_MS) {
+                stuck.push({
+                    deviceId,
+                    entityId: ent.entityId,
+                    character: ent.character || null,
+                    mqLen,
+                    lastDrainedAt: ent.lastDrainedAt || null,
+                    lastEnqueuedAt: ent.lastEnqueuedAt || null,
+                    idleMs,
+                });
+            }
+        }
+    }
+    return stuck;
+}
+
 // Helper: Create default entity
 function createDefaultEntity(entityId) {
     return {
@@ -3974,6 +4012,8 @@ function createDefaultEntity(entityId) {
         lastUpdated: Date.now(),
         messageQueue: [],
         deadLetterQueue: [], // Phase H1.1: capped overflow buffer for forensics
+        lastEnqueuedAt: null, // Phase H1.2: when server last appended to messageQueue
+        lastDrainedAt: null, // Phase H1.2: when bot daemon last consumed messageQueue (heartbeat)
         webhook: null,
         appVersion: null, // Device app version (e.g., "1.0.3")
         avatar: null, // User-chosen emoji avatar (synced across devices)
@@ -4688,6 +4728,14 @@ app.get('/api/health', (req, res) => {
             }
         }
     } catch (_) { /* best-effort */ }
+
+    // Phase H1.2: stuck-delivery snapshot. Empty array under normal traffic.
+    let stuckList = [];
+    try { stuckList = findStuckEntities(); } catch (_) { /* best-effort */ }
+    const stuckPreview = stuckList
+        .sort((a, b) => b.idleMs - a.idleMs)
+        .slice(0, 5);
+
     res.status(200).json({
         status: 'ok',
         timestamp: Date.now(),
@@ -4701,6 +4749,11 @@ app.get('/api/health', (req, res) => {
             maxDlqLen: maxDlq,
             totalDlq,
             entities: entitiesScanned,
+        },
+        delivery: {
+            stuckThresholdMs: HEARTBEAT_STUCK_MS,
+            stuckCount: stuckList.length,
+            stuck: stuckPreview,
         },
     });
 });
@@ -13392,8 +13445,12 @@ app.post('/api/bot/pending-messages', async (req, res) => {
     // Clear messageQueue after delivery (bot acknowledges receipt)
     entity.messageQueue = [];
 
-    // Update entity status
-    entity.lastUpdated = Date.now();
+    // Phase H1.2: every poll is a heartbeat — record even when queue is empty.
+    // Stuck-detection uses lastDrainedAt to decide if Hermes is alive but starved
+    // (mq>0 + recent drain = backlog) vs dead (mq>0 + stale drain = no daemon).
+    const now = Date.now();
+    entity.lastDrainedAt = now;
+    entity.lastUpdated = now;
 
     res.json({
         success: true,
@@ -18077,3 +18134,5 @@ module.exports._enqueueMessage = enqueueMessage;
 module.exports._MESSAGE_QUEUE_CAP = MESSAGE_QUEUE_CAP;
 module.exports._DEAD_LETTER_CAP = DEAD_LETTER_CAP;
 module.exports._clampQueuesOnLoad = clampQueuesOnLoad;
+module.exports._findStuckEntities = findStuckEntities;
+module.exports._HEARTBEAT_STUCK_MS = HEARTBEAT_STUCK_MS;

--- a/backend/tests/jest/heartbeat-stuck.test.js
+++ b/backend/tests/jest/heartbeat-stuck.test.js
@@ -1,0 +1,153 @@
+/**
+ * Phase H1.2 — heartbeat / delivery-stuck detection.
+ *
+ * Hermes [回應超時] recurred 2026-04-28 because there was no server-side signal
+ * for "queue has items but daemon hasn't drained recently" — the only alert was
+ * a sibling bot complaining downstream. This locks in the threshold and the
+ * findStuckEntities() shape so /api/health can't quietly drift.
+ */
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+        connect: jest.fn().mockResolvedValue({
+            query: jest.fn().mockResolvedValue({ rows: [] }),
+            release: jest.fn(),
+        }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+jest.mock('../../db', () => ({
+    initDatabase: jest.fn().mockResolvedValue(true),
+    saveDeviceData: jest.fn().mockResolvedValue(true),
+    saveAllDevices: jest.fn().mockResolvedValue(true),
+    loadAllDevices: jest.fn().mockResolvedValue({}),
+    deleteDevice: jest.fn().mockResolvedValue(true),
+    getStats: jest.fn().mockResolvedValue({}),
+    closeDatabase: jest.fn().mockResolvedValue(undefined),
+    saveOfficialBot: jest.fn().mockResolvedValue(true),
+    loadOfficialBots: jest.fn().mockResolvedValue({}),
+    deleteOfficialBot: jest.fn().mockResolvedValue(true),
+    loadSubscriptions: jest.fn().mockResolvedValue({}),
+    saveSubscription: jest.fn().mockResolvedValue(true),
+    pool: { query: jest.fn().mockResolvedValue({ rows: [] }) },
+}));
+
+const app = require('../../index');
+const findStuck = app._findStuckEntities;
+const STUCK_MS = app._HEARTBEAT_STUCK_MS;
+const enqueue = app._enqueueMessage;
+const devices = app.devices;
+
+function clearDevices() {
+    for (const k of Object.keys(devices)) delete devices[k];
+}
+
+describe('Phase H1.2 — findStuckEntities', () => {
+    afterEach(clearDevices);
+
+    test('exposes the documented threshold (90s)', () => {
+        expect(STUCK_MS).toBe(90_000);
+    });
+
+    test('empty devices map → no stuck entities', () => {
+        clearDevices();
+        expect(findStuck()).toEqual([]);
+    });
+
+    test('bound bot with mq>0 + recent drain → NOT stuck', () => {
+        clearDevices();
+        const now = Date.now();
+        const bot = {
+            entityId: 5, isBound: true, character: 'HERMES',
+            messageQueue: [{ text: 'pending' }],
+            lastDrainedAt: now - 10_000, // drained 10s ago — alive
+        };
+        devices['dev-1'] = { entities: { 5: bot } };
+        expect(findStuck(now)).toEqual([]);
+    });
+
+    test('bound bot with mq>0 + stale drain → STUCK', () => {
+        clearDevices();
+        const now = Date.now();
+        const bot = {
+            entityId: 5, isBound: true, character: 'HERMES',
+            messageQueue: [{ text: 'queued-1' }, { text: 'queued-2' }],
+            lastEnqueuedAt: now - 120_000,
+            lastDrainedAt: now - 120_000, // 120s > 90s threshold
+        };
+        devices['dev-2'] = { entities: { 5: bot } };
+        const stuck = findStuck(now);
+        expect(stuck).toHaveLength(1);
+        expect(stuck[0]).toMatchObject({
+            deviceId: 'dev-2',
+            entityId: 5,
+            character: 'HERMES',
+            mqLen: 2,
+        });
+        expect(stuck[0].idleMs).toBeGreaterThanOrEqual(STUCK_MS);
+    });
+
+    test('unbound entity is ignored even if mq stale', () => {
+        clearDevices();
+        const now = Date.now();
+        const ghost = {
+            entityId: 9, isBound: false,
+            messageQueue: [{ text: 'orphan' }],
+            lastDrainedAt: now - 600_000,
+        };
+        devices['dev-3'] = { entities: { 9: ghost } };
+        expect(findStuck(now)).toEqual([]);
+    });
+
+    test('bot that has never drained falls back to lastEnqueuedAt for staleness', () => {
+        clearDevices();
+        const now = Date.now();
+        const newbie = {
+            entityId: 7, isBound: true, character: 'NEWBOT',
+            messageQueue: [{ text: 'first' }],
+            lastDrainedAt: null,
+            lastEnqueuedAt: now - 200_000,
+        };
+        devices['dev-4'] = { entities: { 7: newbie } };
+        const stuck = findStuck(now);
+        expect(stuck).toHaveLength(1);
+        expect(stuck[0].lastDrainedAt).toBeNull();
+        expect(stuck[0].idleMs).toBeGreaterThanOrEqual(STUCK_MS);
+    });
+
+    test('enqueueMessage stamps lastEnqueuedAt', () => {
+        const ent = { entityId: 5, isBound: true, messageQueue: [], deadLetterQueue: [] };
+        const before = Date.now();
+        enqueue(ent, { text: 'hello' }, 'unit_test');
+        expect(ent.lastEnqueuedAt).toBeGreaterThanOrEqual(before);
+    });
+
+    test('multiple stuck bots all surface', () => {
+        clearDevices();
+        const now = Date.now();
+        devices['dev-5'] = {
+            entities: {
+                5: {
+                    entityId: 5, isBound: true, character: 'HERMES',
+                    messageQueue: [{}, {}, {}],
+                    lastDrainedAt: now - 95_000,
+                },
+                6: {
+                    entityId: 6, isBound: true, character: 'OPENBOT',
+                    messageQueue: [{}],
+                    lastDrainedAt: now - 91_000,
+                },
+                7: {
+                    entityId: 7, isBound: true, character: 'ALIVE',
+                    messageQueue: [{}],
+                    lastDrainedAt: now - 5_000, // healthy
+                },
+            },
+        };
+        const stuck = findStuck(now);
+        const ids = stuck.map(s => s.entityId).sort();
+        expect(ids).toEqual([5, 6]);
+    });
+});


### PR DESCRIPTION
## Summary
- Tracks `lastEnqueuedAt` + `lastDrainedAt` per entity (every `/api/bot/pending-messages` poll is a heartbeat, even on empty queue).
- Adds `findStuckEntities()` returning bound bots with `mqLen>0` AND `now-lastDrainedAt > 90s`.
- Surfaces `delivery: { stuckThresholdMs, stuckCount, stuck: [top 5] }` block in `/api/health` so external monitors catch Hermes-style death within ~90s instead of waiting 5 min for sibling-bot complaint.

## Why
Phase H1.1 capped the queue but didn't tell us *when* a bot stopped consuming. The 2026-04-28 Hermes recurrence was first reported by LOBSTER 5 minutes after delivery — too slow. H1.2 makes server-side death detectable on every `/api/health` poll.

## Test plan
- [x] 8 jest cases in `tests/jest/heartbeat-stuck.test.js` (15/15 across both H1.1 + H1.2 suites)
- [ ] post-merge: curl `/api/health` → `delivery.stuckThresholdMs=90000`, `stuckCount` reasonable
- [ ] Manual: stop Hermes daemon, enqueue message, confirm `delivery.stuck[0]` shows entityId 5 within 90s

🤖 Generated with [Claude Code](https://claude.com/claude-code)