### PR TITLE
feat(hermes): /api/health 503 on severe stuck (Phase H1.5)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -3915,6 +3915,30 @@ const DEAD_LETTER_CAP = 50;
 // (Hermes typically polls every ~5s, so 90s = 18 missed polls = clearly dead).
 const HEARTBEAT_STUCK_MS = 90_000;
 
+// Phase H1.5: severe-stuck threshold for /api/health → 503 → Railway auto-restart.
+// 90s says "alert ops"; 5min says "the daemon is dead, kill the process". Set well above
+// the H1.2 alert window so transient blips don't cause restart thrash.
+const SEVERE_STUCK_MS = 300_000;
+// Boot-grace: process.uptime ≤ this skips the 503 even if state looks severe. Prevents
+// crashloop where DB-loaded stale mq + cold daemon trips immediate 503 → kill → repeat.
+// 3 min gives a fresh Hermes plenty of time to start polling and reset lastDrainedAt.
+const HEALTH_BOOT_GRACE_MS = 180_000;
+
+function evaluateDeliveryHealth(stuckList, uptimeMs) {
+    const oldestIdleMs = stuckList.length
+        ? stuckList.reduce((m, s) => (s.idleMs > m ? s.idleMs : m), 0)
+        : 0;
+    const severe = oldestIdleMs > SEVERE_STUCK_MS && uptimeMs > HEALTH_BOOT_GRACE_MS;
+    return {
+        stuckThresholdMs: HEARTBEAT_STUCK_MS,
+        severeThresholdMs: SEVERE_STUCK_MS,
+        bootGraceMs: HEALTH_BOOT_GRACE_MS,
+        stuckCount: stuckList.length,
+        oldestIdleMs,
+        severe,
+    };
+}
+
 function enqueueMessage(toEntity, messageObj, ctx) {
     if (!toEntity) return;
     if (!Array.isArray(toEntity.messageQueue)) toEntity.messageQueue = [];
@@ -4736,8 +4760,15 @@ app.get('/api/health', (req, res) => {
         .sort((a, b) => b.idleMs - a.idleMs)
         .slice(0, 5);
 
-    res.status(200).json({
-        status: 'ok',
+    // Phase H1.5: classify severity so Railway healthcheck (healthcheckPath=/api/health,
+    // restartPolicyType=ON_FAILURE) can auto-restart a wedged daemon. Returns 503 only
+    // when at least one bot is severely stuck AND we're past the boot grace.
+    const uptimeMs = process.uptime() * 1000;
+    const deliveryHealth = evaluateDeliveryHealth(stuckList, uptimeMs);
+    const httpStatus = deliveryHealth.severe ? 503 : 200;
+
+    res.status(httpStatus).json({
+        status: deliveryHealth.severe ? 'unhealthy' : 'ok',
         timestamp: Date.now(),
         build: SERVER_BUILD_TAG,
         uptime: process.uptime(),
@@ -4751,8 +4782,7 @@ app.get('/api/health', (req, res) => {
             entities: entitiesScanned,
         },
         delivery: {
-            stuckThresholdMs: HEARTBEAT_STUCK_MS,
-            stuckCount: stuckList.length,
+            ...deliveryHealth,
             stuck: stuckPreview,
         },
     });
@@ -18136,3 +18166,6 @@ module.exports._DEAD_LETTER_CAP = DEAD_LETTER_CAP;
 module.exports._clampQueuesOnLoad = clampQueuesOnLoad;
 module.exports._findStuckEntities = findStuckEntities;
 module.exports._HEARTBEAT_STUCK_MS = HEARTBEAT_STUCK_MS;
+module.exports._SEVERE_STUCK_MS = SEVERE_STUCK_MS;
+module.exports._HEALTH_BOOT_GRACE_MS = HEALTH_BOOT_GRACE_MS;
+module.exports._evaluateDeliveryHealth = evaluateDeliveryHealth;

--- a/backend/tests/jest/health-503-severe.test.js
+++ b/backend/tests/jest/health-503-severe.test.js
@@ -1,0 +1,151 @@
+/**
+ * Phase H1.5 — /api/health → 503 → Railway auto-restart on severe stuck.
+ *
+ * railway.json already has healthcheckPath=/api/health + restartPolicyType=ON_FAILURE.
+ * H1.5 makes the endpoint return 503 only when (a) at least one entity has been
+ * idle past SEVERE_STUCK_MS AND (b) we're past HEALTH_BOOT_GRACE_MS — to avoid
+ * a crashloop where DB-loaded stale state trips immediate 503 → kill → repeat.
+ */
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+        connect: jest.fn().mockResolvedValue({
+            query: jest.fn().mockResolvedValue({ rows: [] }),
+            release: jest.fn(),
+        }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+jest.mock('../../db', () => ({
+    initDatabase: jest.fn().mockResolvedValue(true),
+    saveDeviceData: jest.fn().mockResolvedValue(true),
+    saveAllDevices: jest.fn().mockResolvedValue(true),
+    loadAllDevices: jest.fn().mockResolvedValue({}),
+    deleteDevice: jest.fn().mockResolvedValue(true),
+    getStats: jest.fn().mockResolvedValue({}),
+    closeDatabase: jest.fn().mockResolvedValue(undefined),
+    saveOfficialBot: jest.fn().mockResolvedValue(true),
+    loadOfficialBots: jest.fn().mockResolvedValue({}),
+    deleteOfficialBot: jest.fn().mockResolvedValue(true),
+    loadSubscriptions: jest.fn().mockResolvedValue({}),
+    saveSubscription: jest.fn().mockResolvedValue(true),
+    pool: { query: jest.fn().mockResolvedValue({ rows: [] }) },
+}));
+
+const app = require('../../index');
+const evaluate = app._evaluateDeliveryHealth;
+const SEVERE_MS = app._SEVERE_STUCK_MS;
+const GRACE_MS = app._HEALTH_BOOT_GRACE_MS;
+const HEARTBEAT_MS = app._HEARTBEAT_STUCK_MS;
+
+describe('Phase H1.5 — evaluateDeliveryHealth severity gate', () => {
+    test('exposes documented thresholds (severe=300s, grace=180s)', () => {
+        expect(SEVERE_MS).toBe(300_000);
+        expect(GRACE_MS).toBe(180_000);
+        // Severe must be strictly greater than the H1.2 alert threshold,
+        // otherwise we'd 503 on every alert and thrash.
+        expect(SEVERE_MS).toBeGreaterThan(HEARTBEAT_MS);
+    });
+
+    test('empty stuck list → not severe regardless of uptime', () => {
+        const r = evaluate([], 999_999_999);
+        expect(r.severe).toBe(false);
+        expect(r.stuckCount).toBe(0);
+        expect(r.oldestIdleMs).toBe(0);
+    });
+
+    test('single mildly-stuck entity (idle > 90s, ≤ 5min) → NOT severe', () => {
+        const r = evaluate(
+            [{ entityId: 5, idleMs: 120_000 }],
+            10 * 60 * 1000, // 10 min uptime — well past grace
+        );
+        expect(r.severe).toBe(false);
+        expect(r.oldestIdleMs).toBe(120_000);
+        expect(r.stuckCount).toBe(1);
+    });
+
+    test('severely stuck entity but uptime within grace → NOT severe', () => {
+        const r = evaluate(
+            [{ entityId: 5, idleMs: 600_000 }], // 10min idle
+            60_000, // only 60s uptime — still warming up
+        );
+        expect(r.severe).toBe(false);
+    });
+
+    test('severely stuck entity past grace → severe (triggers 503)', () => {
+        const r = evaluate(
+            [{ entityId: 5, idleMs: 6 * 60 * 1000 }], // 6 min idle
+            10 * 60 * 1000, // 10 min uptime
+        );
+        expect(r.severe).toBe(true);
+        expect(r.oldestIdleMs).toBe(6 * 60 * 1000);
+    });
+
+    test('idleMs == SEVERE_STUCK_MS → not severe (strict >)', () => {
+        const r = evaluate(
+            [{ entityId: 5, idleMs: SEVERE_MS }],
+            10 * 60 * 1000,
+        );
+        expect(r.severe).toBe(false);
+    });
+
+    test('idleMs == SEVERE_STUCK_MS + 1 → severe', () => {
+        const r = evaluate(
+            [{ entityId: 5, idleMs: SEVERE_MS + 1 }],
+            10 * 60 * 1000,
+        );
+        expect(r.severe).toBe(true);
+    });
+
+    test('uptimeMs == HEALTH_BOOT_GRACE_MS → not severe yet (strict >)', () => {
+        const r = evaluate(
+            [{ entityId: 5, idleMs: 6 * 60 * 1000 }],
+            GRACE_MS,
+        );
+        expect(r.severe).toBe(false);
+    });
+
+    test('returns oldestIdleMs of the worst stuck entity, not first', () => {
+        const r = evaluate(
+            [
+                { entityId: 5, idleMs: 100_000 },
+                { entityId: 6, idleMs: 700_000 }, // worst — should win
+                { entityId: 7, idleMs: 200_000 },
+            ],
+            10 * 60 * 1000,
+        );
+        expect(r.oldestIdleMs).toBe(700_000);
+        expect(r.severe).toBe(true);
+        expect(r.stuckCount).toBe(3);
+    });
+
+    test('response shape includes all documented threshold fields', () => {
+        const r = evaluate([], 0);
+        expect(r).toEqual(expect.objectContaining({
+            stuckThresholdMs: HEARTBEAT_MS,
+            severeThresholdMs: SEVERE_MS,
+            bootGraceMs: GRACE_MS,
+            stuckCount: 0,
+            oldestIdleMs: 0,
+            severe: false,
+        }));
+    });
+});
+
+describe('Phase H1.5 — /api/health HTTP integration', () => {
+    let request;
+    beforeAll(() => {
+        request = require('supertest');
+    });
+
+    test('healthy state → 200 with delivery.severe === false', async () => {
+        const res = await request(app).get('/api/health');
+        expect(res.status).toBe(200);
+        expect(res.body.status).toBe('ok');
+        expect(res.body.delivery.severe).toBe(false);
+        expect(res.body.delivery.severeThresholdMs).toBe(SEVERE_MS);
+        expect(res.body.delivery.bootGraceMs).toBe(GRACE_MS);
+    });
+});


### PR DESCRIPTION
## Summary
- Closes the Hermes hardening loop: `/api/health` now returns **503** when any bot has been stuck > 5 min, triggering Railway's existing `restartPolicyType: ON_FAILURE` healthcheck policy.
- H1.2 = "alert ops" (90s); H1.5 = "kill the process" (5 min). Strictly above the alert threshold so observability never auto-restarts.
- Boot grace (180s) prevents crashloop when a freshly-rebooted daemon loads stale persisted mq before its first poll cycle.

## What changed
- `backend/index.js`
  - New constants: `SEVERE_STUCK_MS = 300_000`, `HEALTH_BOOT_GRACE_MS = 180_000`
  - New helper: `evaluateDeliveryHealth(stuckList, uptimeMs)` returns `{ stuckThresholdMs, severeThresholdMs, bootGraceMs, stuckCount, oldestIdleMs, severe }`
  - `/api/health` returns `503` + `status:'unhealthy'` when `severe===true`, else `200`/`'ok'` (unchanged)
  - Exports `_SEVERE_STUCK_MS`, `_HEALTH_BOOT_GRACE_MS`, `_evaluateDeliveryHealth`
- `backend/tests/jest/health-503-severe.test.js` (NEW) — 11 cases:
  - threshold values, empty list, mild stuck, severe within grace, severe past grace, boundary equality, oldestIdleMs aggregation, response shape
  - HTTP 200 integration via supertest

## Threshold rationale
| Constant | Value | Why |
|---|---|---|
| `HEARTBEAT_STUCK_MS` (H1.2) | 90 s | 18 missed Hermes polls — clearly dead; alert |
| `SEVERE_STUCK_MS` (H1.5) | 300 s | 5 min wedged ⇒ daemon-wide failure; restart |
| `HEALTH_BOOT_GRACE_MS` | 180 s | New process needs time to drain stale persisted mq |

## Test plan
- [x] `jest tests/jest/health-503-severe.test.js tests/jest/heartbeat-stuck.test.js tests/jest/message-queue-cap.test.js` → 26/26 pass
- [x] `jest tests/jest/health.test.js tests/jest/rate-limit.test.js tests/jest/gatekeeper.test.js` → 76/76 pass (no pre-existing /api/health regression)
- [ ] Post-merge: Railway redeploy → `curl -s https://eclawbot.com/api/health | jq '.delivery'` shows `severeThresholdMs: 300000, bootGraceMs: 180000, severe: false`
- [ ] Post-merge: simulate severe state in dev (manually stamp `lastDrainedAt = Date.now() - 6*60*1000` on a bound entity) → /api/health returns 503

🤖 Generated with [Claude Code](https://claude.com/claude-code)