### PR TITLE
fix(hermes): exclude pre-H1.2 ghost entities from severe trigger (Phase H1.5 hotfix)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -3923,17 +3923,31 @@ const SEVERE_STUCK_MS = 300_000;
 // crashloop where DB-loaded stale mq + cold daemon trips immediate 503 → kill → repeat.
 // 3 min gives a fresh Hermes plenty of time to start polling and reset lastDrainedAt.
 const HEALTH_BOOT_GRACE_MS = 180_000;
+// Severe requires at least this many "previously alive, now stopped" entities. Single-bot
+// orphans must NOT trigger restart. Pre-H1.2 historical state (lastDrainedAt=null forever)
+// must NOT trigger restart. Only a daemon-wide failure — multiple bots that USED to drain
+// suddenly stopping — warrants a process kill.
+const SEVERE_STUCK_MIN_COUNT = 5;
 
 function evaluateDeliveryHealth(stuckList, uptimeMs) {
     const oldestIdleMs = stuckList.length
         ? stuckList.reduce((m, s) => (s.idleMs > m ? s.idleMs : m), 0)
         : 0;
-    const severe = oldestIdleMs > SEVERE_STUCK_MS && uptimeMs > HEALTH_BOOT_GRACE_MS;
+    // Severe only counts entities that USED to drain (lastDrainedAt set) and stopped.
+    // Excludes ghost entities (never-drained, pre-H1.2 historical state) from triggering
+    // restarts — those are stale data, not a live-daemon failure.
+    const severeStuckCount = stuckList.filter(
+        s => s.lastDrainedAt && s.idleMs > SEVERE_STUCK_MS
+    ).length;
+    const severe = severeStuckCount >= SEVERE_STUCK_MIN_COUNT
+        && uptimeMs > HEALTH_BOOT_GRACE_MS;
     return {
         stuckThresholdMs: HEARTBEAT_STUCK_MS,
         severeThresholdMs: SEVERE_STUCK_MS,
+        severeMinCount: SEVERE_STUCK_MIN_COUNT,
         bootGraceMs: HEALTH_BOOT_GRACE_MS,
         stuckCount: stuckList.length,
+        severeStuckCount,
         oldestIdleMs,
         severe,
     };
@@ -18168,4 +18182,5 @@ module.exports._findStuckEntities = findStuckEntities;
 module.exports._HEARTBEAT_STUCK_MS = HEARTBEAT_STUCK_MS;
 module.exports._SEVERE_STUCK_MS = SEVERE_STUCK_MS;
 module.exports._HEALTH_BOOT_GRACE_MS = HEALTH_BOOT_GRACE_MS;
+module.exports._SEVERE_STUCK_MIN_COUNT = SEVERE_STUCK_MIN_COUNT;
 module.exports._evaluateDeliveryHealth = evaluateDeliveryHealth;

--- a/backend/tests/jest/health-503-severe.test.js
+++ b/backend/tests/jest/health-503-severe.test.js
@@ -39,11 +39,22 @@ const evaluate = app._evaluateDeliveryHealth;
 const SEVERE_MS = app._SEVERE_STUCK_MS;
 const GRACE_MS = app._HEALTH_BOOT_GRACE_MS;
 const HEARTBEAT_MS = app._HEARTBEAT_STUCK_MS;
+const SEVERE_MIN = app._SEVERE_STUCK_MIN_COUNT;
+
+// Helper: synth a stuck entity that USED to drain (lastDrainedAt non-null).
+// These count toward severe. Pre-H1.2 ghost entries (lastDrainedAt=null) do NOT.
+function alive(entityId, idleMs) {
+    return { entityId, idleMs, lastDrainedAt: Date.now() - idleMs };
+}
+function ghost(entityId, idleMs) {
+    return { entityId, idleMs, lastDrainedAt: null };
+}
 
 describe('Phase H1.5 — evaluateDeliveryHealth severity gate', () => {
-    test('exposes documented thresholds (severe=300s, grace=180s)', () => {
+    test('exposes documented thresholds (severe=300s, grace=180s, minCount=5)', () => {
         expect(SEVERE_MS).toBe(300_000);
         expect(GRACE_MS).toBe(180_000);
+        expect(SEVERE_MIN).toBe(5);
         // Severe must be strictly greater than the H1.2 alert threshold,
         // otherwise we'd 503 on every alert and thrash.
         expect(SEVERE_MS).toBeGreaterThan(HEARTBEAT_MS);
@@ -53,72 +64,106 @@ describe('Phase H1.5 — evaluateDeliveryHealth severity gate', () => {
         const r = evaluate([], 999_999_999);
         expect(r.severe).toBe(false);
         expect(r.stuckCount).toBe(0);
+        expect(r.severeStuckCount).toBe(0);
         expect(r.oldestIdleMs).toBe(0);
     });
 
-    test('single mildly-stuck entity (idle > 90s, ≤ 5min) → NOT severe', () => {
-        const r = evaluate(
-            [{ entityId: 5, idleMs: 120_000 }],
-            10 * 60 * 1000, // 10 min uptime — well past grace
-        );
-        expect(r.severe).toBe(false);
-        expect(r.oldestIdleMs).toBe(120_000);
-        expect(r.stuckCount).toBe(1);
-    });
-
-    test('severely stuck entity but uptime within grace → NOT severe', () => {
-        const r = evaluate(
-            [{ entityId: 5, idleMs: 600_000 }], // 10min idle
-            60_000, // only 60s uptime — still warming up
-        );
-        expect(r.severe).toBe(false);
-    });
-
-    test('severely stuck entity past grace → severe (triggers 503)', () => {
-        const r = evaluate(
-            [{ entityId: 5, idleMs: 6 * 60 * 1000 }], // 6 min idle
-            10 * 60 * 1000, // 10 min uptime
-        );
+    test('5+ alive bots stopped past grace → severe (triggers 503)', () => {
+        const list = [1, 2, 3, 4, 5].map(id => alive(id, 6 * 60 * 1000));
+        const r = evaluate(list, 10 * 60 * 1000);
+        expect(r.severeStuckCount).toBe(5);
         expect(r.severe).toBe(true);
-        expect(r.oldestIdleMs).toBe(6 * 60 * 1000);
+    });
+
+    test('4 alive bots stopped past grace → NOT severe (under min count)', () => {
+        const list = [1, 2, 3, 4].map(id => alive(id, 6 * 60 * 1000));
+        const r = evaluate(list, 10 * 60 * 1000);
+        expect(r.severeStuckCount).toBe(4);
+        expect(r.severe).toBe(false);
+    });
+
+    test('one alive bot stopped past grace → NOT severe (one orphan ≠ daemon dead)', () => {
+        const r = evaluate([alive(5, 6 * 60 * 1000)], 10 * 60 * 1000);
+        expect(r.severe).toBe(false);
+    });
+
+    test('mildly stuck (idle 90s–5min) → NOT severe even with many entries', () => {
+        const list = [1, 2, 3, 4, 5, 6].map(id => alive(id, 120_000));
+        const r = evaluate(list, 10 * 60 * 1000);
+        expect(r.severeStuckCount).toBe(0);
+        expect(r.severe).toBe(false);
+        expect(r.stuckCount).toBe(6);
+    });
+
+    test('severe-eligible state but uptime within grace → NOT severe', () => {
+        const list = [1, 2, 3, 4, 5, 6].map(id => alive(id, 6 * 60 * 1000));
+        const r = evaluate(list, 60_000);
+        expect(r.severe).toBe(false);
+    });
+
+    test('1000 ghost bots (lastDrainedAt=null) past grace → NOT severe', () => {
+        // The exact prod scenario that triggered this hotfix: pre-H1.2 historical
+        // queues with no drain stamps. Must never auto-restart on these.
+        const list = Array.from({ length: 1000 }, (_, i) => ghost(i, 6 * 60 * 1000));
+        const r = evaluate(list, 10 * 60 * 1000);
+        expect(r.severeStuckCount).toBe(0);
+        expect(r.severe).toBe(false);
+        expect(r.stuckCount).toBe(1000);
+    });
+
+    test('mixed: 4 alive stopped + 100 ghosts → still NOT severe (alive < min)', () => {
+        const list = [
+            ...[1, 2, 3, 4].map(id => alive(id, 6 * 60 * 1000)),
+            ...Array.from({ length: 100 }, (_, i) => ghost(100 + i, 6 * 60 * 1000)),
+        ];
+        const r = evaluate(list, 10 * 60 * 1000);
+        expect(r.severeStuckCount).toBe(4);
+        expect(r.severe).toBe(false);
+    });
+
+    test('mixed: 5 alive stopped + 100 ghosts → severe (alive crosses min)', () => {
+        const list = [
+            ...[1, 2, 3, 4, 5].map(id => alive(id, 6 * 60 * 1000)),
+            ...Array.from({ length: 100 }, (_, i) => ghost(100 + i, 6 * 60 * 1000)),
+        ];
+        const r = evaluate(list, 10 * 60 * 1000);
+        expect(r.severeStuckCount).toBe(5);
+        expect(r.severe).toBe(true);
     });
 
     test('idleMs == SEVERE_STUCK_MS → not severe (strict >)', () => {
-        const r = evaluate(
-            [{ entityId: 5, idleMs: SEVERE_MS }],
-            10 * 60 * 1000,
-        );
+        const list = Array.from({ length: 10 }, (_, i) => alive(i, SEVERE_MS));
+        const r = evaluate(list, 10 * 60 * 1000);
+        expect(r.severeStuckCount).toBe(0);
         expect(r.severe).toBe(false);
     });
 
-    test('idleMs == SEVERE_STUCK_MS + 1 → severe', () => {
-        const r = evaluate(
-            [{ entityId: 5, idleMs: SEVERE_MS + 1 }],
-            10 * 60 * 1000,
-        );
+    test('idleMs == SEVERE_STUCK_MS + 1 with 5+ alive → severe', () => {
+        const list = Array.from({ length: 5 }, (_, i) => alive(i, SEVERE_MS + 1));
+        const r = evaluate(list, 10 * 60 * 1000);
+        expect(r.severeStuckCount).toBe(5);
         expect(r.severe).toBe(true);
     });
 
     test('uptimeMs == HEALTH_BOOT_GRACE_MS → not severe yet (strict >)', () => {
-        const r = evaluate(
-            [{ entityId: 5, idleMs: 6 * 60 * 1000 }],
-            GRACE_MS,
-        );
+        const list = Array.from({ length: 5 }, (_, i) => alive(i, 6 * 60 * 1000));
+        const r = evaluate(list, GRACE_MS);
         expect(r.severe).toBe(false);
     });
 
-    test('returns oldestIdleMs of the worst stuck entity, not first', () => {
+    test('returns oldestIdleMs of the worst entity (alive OR ghost)', () => {
         const r = evaluate(
             [
-                { entityId: 5, idleMs: 100_000 },
-                { entityId: 6, idleMs: 700_000 }, // worst — should win
-                { entityId: 7, idleMs: 200_000 },
+                alive(5, 100_000),
+                ghost(6, 700_000), // worst — ghost still counted for oldestIdleMs (observability)
+                alive(7, 200_000),
             ],
             10 * 60 * 1000,
         );
         expect(r.oldestIdleMs).toBe(700_000);
-        expect(r.severe).toBe(true);
         expect(r.stuckCount).toBe(3);
+        expect(r.severeStuckCount).toBe(0); // none alive past 5min
+        expect(r.severe).toBe(false);
     });
 
     test('response shape includes all documented threshold fields', () => {
@@ -126,8 +171,10 @@ describe('Phase H1.5 — evaluateDeliveryHealth severity gate', () => {
         expect(r).toEqual(expect.objectContaining({
             stuckThresholdMs: HEARTBEAT_MS,
             severeThresholdMs: SEVERE_MS,
+            severeMinCount: SEVERE_MIN,
             bootGraceMs: GRACE_MS,
             stuckCount: 0,
+            severeStuckCount: 0,
             oldestIdleMs: 0,
             severe: false,
         }));


### PR DESCRIPTION
## Summary
Hotfix for #2216. Production `/api/health` after H1.5 deploy showed 215 stuck entities, all with `lastDrainedAt: null` — pre-H1.2 historical orphans, NOT a daemon-dead signal. Without this fix, after the 180s boot grace expired, severity would flip `true` → `503` → Railway restart → repeat (crashloop on stale data).

## What changed
- `backend/index.js`
  - New constant `SEVERE_STUCK_MIN_COUNT = 5`
  - `evaluateDeliveryHealth` now computes `severeStuckCount`: filter to `s.lastDrainedAt && s.idleMs > SEVERE_STUCK_MS` (excludes ghosts)
  - `severe = severeStuckCount >= SEVERE_STUCK_MIN_COUNT && uptimeMs > HEALTH_BOOT_GRACE_MS`
  - Response shape adds `severeStuckCount` + `severeMinCount` (ghost count = `stuckCount - severeStuckCount`)
- `backend/tests/jest/health-503-severe.test.js` — 13 cases (was 11):
  - `1000 ghosts past grace → NOT severe`
  - `4 alive + 100 ghosts → NOT severe (under min)`
  - `5 alive + 100 ghosts → severe`
  - `single orphan past grace → NOT severe`
  - all old "severe-eligible" cases updated to use 5+ alive entities

## Why two safeguards
| Guard | Reason |
|---|---|
| `lastDrainedAt` required | Ghost entries (never alive) must never trigger restart — they're stale, not failing |
| `severeStuckCount ≥ 5` | One legit-orphan bot ≠ daemon dead. Only broad failure warrants kill |

## Test plan
- [x] `jest tests/jest/health-503-severe.test.js tests/jest/heartbeat-stuck.test.js tests/jest/message-queue-cap.test.js` → 31/31 pass
- [ ] Post-merge: `curl https://eclawbot.com/api/health | jq '.delivery'` shows `severeStuckCount: 0, severe: false` even with `stuckCount: 215`
- [ ] Wait until uptime > 180s and confirm `severe` stays `false` (no crashloop)

## Production impact
The 215 ghost bots remain visible for observability (`stuckCount: 215`, `oldestIdleMs` keeps climbing). Cleanup of those orphan device records is a separate card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)