### PR TITLE
fix(test): chat-his-link-render expected locale count 15 → 14

### DIFF
--- a/backend/tests/jest/chat-his-link-render.test.js
+++ b/backend/tests/jest/chat-his-link-render.test.js
@@ -130,10 +130,10 @@ describe('his_<uuid> chip — i18n keys', () => {
         }
     });
 
-    test('key appears in every locale block (15 occurrences each)', () => {
+    test('key appears in every locale block (14 occurrences each)', () => {
         for (const key of REQUIRED_KEYS) {
             const count = (i18nJs.match(new RegExp(`"${key}":`, 'g')) || []).length;
-            expect(count).toBe(15);
+            expect(count).toBe(14);
         }
     });
 });


### PR DESCRIPTION
## Summary
- Backend CI red on main for 3+ commits — \`chat-his-link-render.test.js\` asserts 15 locale blocks but \`shared/i18n.js\` has 14
- Flip expected count to 14 to match codebase (en/zh-TW/zh-CN/ja/ko/th/vi/id/fr/es/de/ms/hi/ar)
- Closes card_398ac4c2 (P2/todo)
- Promised follow-up to PR #2218 admin-merge

## Test plan
- [x] \`npx jest tests/jest/chat-his-link-render.test.js\` → 15/15 green locally
- [ ] Backend CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)