### PR TITLE
feat(seo): community.html og:locale + 13 og:locale:alternate

### DIFF
--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -16,6 +16,20 @@
     <meta property="og:image" content="https://eclawbot.com/assets/og-image.png">
     <meta property="og:image:width" content="512">
     <meta property="og:image:height" content="512">
+    <meta property="og:locale" content="en_US">
+    <meta property="og:locale:alternate" content="zh_TW">
+    <meta property="og:locale:alternate" content="zh_CN">
+    <meta property="og:locale:alternate" content="ja_JP">
+    <meta property="og:locale:alternate" content="ko_KR">
+    <meta property="og:locale:alternate" content="th_TH">
+    <meta property="og:locale:alternate" content="vi_VN">
+    <meta property="og:locale:alternate" content="id_ID">
+    <meta property="og:locale:alternate" content="fr_FR">
+    <meta property="og:locale:alternate" content="es_ES">
+    <meta property="og:locale:alternate" content="de_DE">
+    <meta property="og:locale:alternate" content="ms_MY">
+    <meta property="og:locale:alternate" content="hi_IN">
+    <meta property="og:locale:alternate" content="ar_AR">
     <meta name="twitter:card" content="summary">
     <meta name="twitter:title" content="EClawbot - Bot Plaza">
     <meta name="twitter:description" content="Discover and connect with AI bots on EClawbot Bot Plaza. Find AI agents, explore capabilities, and integrate them into your workflow.">


### PR DESCRIPTION
## Summary
- Add og:locale (en_US default) + 13 og:locale:alternate to community.html for the 14 supported locales (zh_TW / zh_CN / ja_JP / ko_KR / th_TH / vi_VN / id_ID / fr_FR / es_ES / de_DE / ms_MY / hi_IN / ar_AR)
- Helps Facebook / LinkedIn render correct preview language when Bot Plaza link is shared in different markets
- Viral-loop track PR #2 (parent card_7657c36 — Tue cron flagged Bot Plaza 0 views/30d)
- Closes card_79be495d

## Why no hreflang
i18n.js doesn't honor URL \`?lang=\` query param (only localStorage + browser auto-detect), so all locales share one URL. Adding hreflang now would mark the same URL as alternate — Google penalizes that as duplicate content. Phase 2 PR will add URL-param parsing to i18n.js + per-locale URLs + real hreflang.

## Test plan
- [x] grep -c og:locale = 14 ✓
- [ ] CI green
- [ ] visible in view-source after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)