### PR TITLE
fix(invite): preserve ?redeem= across signup/login flow

### DIFF
--- a/backend/public/portal/index.html
+++ b/backend/public/portal/index.html
@@ -424,6 +424,17 @@
         let resetToken = null;
         let termsAccepted = false;
 
+        function redirectAfterAuth() {
+            let pendingCode = null;
+            try { pendingCode = localStorage.getItem('pendingInviteCode'); } catch (_) {}
+            if (pendingCode) {
+                try { localStorage.removeItem('pendingInviteCode'); } catch (_) {}
+                window.location.href = 'invite.html?redeem=' + encodeURIComponent(pendingCode);
+                return;
+            }
+            window.location.href = 'dashboard.html';
+        }
+
         // Check URL params
         window.addEventListener('DOMContentLoaded', async () => {
             if (typeof renderFooter === 'function') renderFooter();
@@ -447,7 +458,7 @@
             try {
                 const data = await apiCall('GET', '/api/auth/me');
                 if (data.success) {
-                    window.location.href = 'dashboard.html';
+                    redirectAfterAuth();
                 }
             } catch (e) { }
         });
@@ -543,7 +554,7 @@
             try {
                 const data = await apiCall('POST', '/api/auth/login', { email, password });
                 applyServerLanguage(data);
-                window.location.href = 'dashboard.html';
+                redirectAfterAuth();
             } catch (e) {
                 showMsg('loginError', e.message);
                 if (e.message.includes('not verified')) {
@@ -648,7 +659,7 @@
             try {
                 const data = await apiCall('POST', '/api/auth/device-login', { deviceId, deviceSecret });
                 applyServerLanguage(data);
-                window.location.href = 'dashboard.html';
+                redirectAfterAuth();
             } catch (e) {
                 showMsg('deviceError', e.message);
             } finally {
@@ -728,7 +739,7 @@
                                 accessToken: resp.access_token
                             });
                             applyServerLanguage(data);
-                            window.location.href = 'dashboard.html';
+                            redirectAfterAuth();
                         } catch (e) {
                             showMsg('loginError', e.message || 'Google login failed');
                         }
@@ -750,7 +761,7 @@
                         accessToken: response.authResponse.accessToken
                     }).then(function (data) {
                         applyServerLanguage(data);
-                        window.location.href = 'dashboard.html';
+                        redirectAfterAuth();
                     }).catch(function (e) {
                         showMsg('loginError', e.message || 'Facebook login failed');
                     });

--- a/backend/public/portal/invite.html
+++ b/backend/public/portal/invite.html
@@ -476,6 +476,7 @@
             // Pre-fill redeem box when arriving via /invite/:code share link.
             const _redeemParam = (_params.get('redeem') || '').toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 12);
             if (_redeemParam) {
+                try { localStorage.setItem('pendingInviteCode', _redeemParam); } catch (_) {}
                 const _input = document.getElementById('redeemInput');
                 if (_input) _input.value = _redeemParam;
             }


### PR DESCRIPTION
## Summary
- Invite share-link clicks (`/invite/:code` → `invite.html?redeem=CODE`) lose the redeem param when `checkAuth()` redirects unauth visitors to `index.html`. After signup/login the user lands on `dashboard.html` with no memory of the invite.
- **Phase 1 fix** (this PR): stash `?redeem=` to `localStorage.pendingInviteCode` on invite.html load, consume it on post-auth redirect via new `redirectAfterAuth()` helper in index.html (replaces 5 sites: auto-login, email login, device login, Google OAuth, Facebook OAuth).
- User still clicks the Redeem button manually on landing — no silent autoredeem.

## Why now
Closes viral-loop track PR #3 (parent `card_7657c36`). Tuesday cron flagged invite 0% redeem rate; root cause is this funnel break.

## Out of scope (Phase 2)
- Server-side cookie stash on `/invite/:code` click (helps users who arrive on a fresh device with no localStorage).
- Soft-prompt on landing ("看到您是 Alice 邀請來的，要不要 redeem？").
- Real `hreflang` once `i18n.js` parses URL `?lang=` (separate track).

## Test plan
- [x] Local: Playwright signed-out invite.html?redeem=ABC123 → `localStorage.pendingInviteCode` set + input prefilled
- [x] Local: signed-in user post-login with stash → redirected to invite.html?redeem=ABC123 (not dashboard)
- [x] Local: signed-in user without stash → still redirected to dashboard.html (no regression)
- [ ] CI: Jest + ESLint + i18n syntax + Railway preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)