### PR TITLE
fix(mindmap): hide top nav when ?view-mode=full

### DIFF
--- a/backend/public/portal/mindmap.html
+++ b/backend/public/portal/mindmap.html
@@ -18,6 +18,7 @@
             height: calc(100vh - var(--nav-height, 60px));
             min-height: 400px;
         }
+        body.mm-display-mode > nav.nav { display: none; }
         body.mm-display-mode #navContainer { display: none; }
         body.mm-display-mode .mm-shell { height: 100vh; grid-template-columns: 1fr; }
         body.mm-display-mode .mm-sidebar { display: none; }


### PR DESCRIPTION
## Summary
Fixes the display-mode CSS in PR #2222 — nav.js renders the top bar as `<nav class=\"nav\">` injected at body's firstChild, but the original rule targeted the unrelated `#navContainer` placeholder div. E2E found the nav still visible at `?view-mode=full`. One-line CSS addition.

## Test plan
- [ ] /portal/mindmap.html → top nav still visible (regression check)
- [ ] /portal/mindmap.html?view-mode=full → top nav hidden, canvas fills viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)