### PR TITLE
fix(kanban): i18n cards default requires_screenshot_review=false

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -503,7 +503,13 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
 
         // recurring schedule → auto-promote to automation
         const finalAutomation = wantAutomation || (schedEnabled && schedType === 'recurring');
-        const finalRequiresScreenshot = requiresScreenshotReview !== false;
+        // Text-only work (i18n / translation) has no screenshot to attach — default the
+        // gate off when caller didn't pass requiresScreenshotReview explicitly. Caller can
+        // still force `true` to opt back in.
+        const isTextOnlyTitle = /i18n|translate|翻譯|locale/i.test(title);
+        const finalRequiresScreenshot = requiresScreenshotReview === undefined
+            ? !isTextOnlyTitle
+            : requiresScreenshotReview !== false;
 
         try {
             const result = await pool.query(


### PR DESCRIPTION
## Summary
- 翻譯/locale 卡片沒有截圖可附，但 screenshot-review gate 會把它們從 done 反彈回 blocked，造成 Hermes/純文字 bot 看起來「無視任務」的死循環
- 在 createCard 裡：當 title 符合 `/i18n|translate|翻譯|locale/i` 且 caller 沒明確帶 `requiresScreenshotReview` 時，預設 `false`
- 視覺卡片不受影響；caller 顯式傳 `true` 仍可開回 gate

## Why
Per `feedback_kanban_nudge_quirks` (memory) — quirk #2: screenshot-review gate creates a done-rejected loop for non-visual work. This PR is half of the fix Hank approved (+204) on 2026-04-28.

## Test plan
- [x] Default behavior preserved for visual cards (`requires_screenshot_review` still defaults `true`)
- [x] i18n title pattern check is case-insensitive, matches Chinese 「翻譯」
- [x] Explicit `requiresScreenshotReview: true` still overrides (force-on)
- [x] Explicit `requiresScreenshotReview: false` still works (force-off)
- [ ] Smoke test: file an i18n card via API, verify INSERT row has `requires_screenshot_review=false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)