### PR TITLE
fix(mindmap): add fullscreen button to mission.html embed (the actual user path)

### DIFF
--- a/backend/public/portal/shared/mission-mindmap.js
+++ b/backend/public/portal/shared/mission-mindmap.js
@@ -170,6 +170,9 @@
       font-size: 13px; color: var(--mm-text);
       position: relative;
     }
+    .mm-root:fullscreen, .mm-root:-webkit-full-screen {
+      height: 100vh; width: 100vw; border-radius: 0; border: none;
+    }
     .mm-root .sys-rail {
       background: var(--mm-bg-elev);
       border-right: 1px solid var(--mm-border);
@@ -560,6 +563,7 @@
         <div class="mm-toolbar">
           <button data-act="fit" title="Fit">🎯</button>
           <button data-act="reset" title="重整">🔄</button>
+          <button data-act="fullscreen" title="全螢幕" aria-label="全螢幕">⛶</button>
         </div>
         <div class="mm-pin-tray" data-pin-tray></div>
         <div class="mm-tier">L1 · <strong>Topics</strong></div>
@@ -1006,10 +1010,41 @@
       });
     });
 
+    const fsTarget = rootEl;
+    const fsBtn = rootEl.querySelector('.mm-toolbar [data-act="fullscreen"]');
+    function isFsActive() {
+      const fsEl = document.fullscreenElement || document.webkitFullscreenElement;
+      return !!fsEl && (fsEl === fsTarget || fsEl.contains(fsTarget));
+    }
+    function updateFsBtn() {
+      if (!fsBtn) return;
+      const active = isFsActive();
+      fsBtn.title = active ? '退出全螢幕' : '全螢幕';
+      fsBtn.setAttribute('aria-label', fsBtn.title);
+      fsBtn.textContent = active ? '⛶✕' : '⛶';
+    }
+    function toggleFs() {
+      const req = fsTarget.requestFullscreen || fsTarget.webkitRequestFullscreen;
+      const exit = document.exitFullscreen || document.webkitExitFullscreen;
+      if (isFsActive()) {
+        exit && exit.call(document);
+      } else if (req) {
+        req.call(fsTarget).catch(err => console.warn('[Mindmap] Fullscreen rejected:', err));
+      }
+    }
+    ['fullscreenchange', 'webkitfullscreenchange'].forEach(evt => {
+      document.addEventListener(evt, () => {
+        updateFsBtn();
+        if (cy) setTimeout(() => { cy.resize(); cy.fit(undefined, 30); }, 80);
+      });
+    });
+    updateFsBtn();
+
     rootEl.querySelectorAll('.mm-toolbar button').forEach(btn => {
       btn.addEventListener('click', () => {
         const act = btn.dataset.act;
         if (act === 'fit') cy.fit(undefined, 30);
+        if (act === 'fullscreen') toggleFs();
         if (act === 'reset') {
           ctrl.closeActive();
           cy.elements().removeClass('faded').removeClass('highlighted').removeClass('pinned');


### PR DESCRIPTION
## Summary
- Hank 截圖反映：prod mobile 工具列只看到 fit / reset 兩顆按鈕，沒看到我之前在 PR #2222 加的全螢幕 ⛶
- 真因：PR #2222/#2223 只動了 `portal/mindmap.html`（獨立頁），但 Hank 實際使用路徑是 mission.html → 心智 tab → 透過 `shared/mission-mindmap.js` embed，那個 embed 用自己的 in-canvas mini-toolbar，從沒拿到全螢幕按鈕
- 這條 PR 在 embed 工具列加上 ⛶ 按鈕、用標準 Fullscreen API 對 `.mm-root` 進入全螢幕、轉場後重新 fit cytoscape

## Why this matters
Hank 直接點出：「資訊不對等」這是警訊。我交付 PR #2222 時自我截圖只跑 `/portal/mindmap.html` standalone，沒驗到 mission.html embed → 帶來假完工。記下教訓：UI 改動必須驗到使用者實際走的入口頁，不是 component-only。

## Test plan
- [ ] Railway deploy 完，prod 重新整理 mission.html
- [ ] Mobile 390×844 — 心智 tab 展開後，工具列看得到 ⛶ 按鈕（在 🎯 / 🔄 右側）
- [ ] Click ⛶ → mindmap 進入瀏覽器全螢幕；canvas 撐滿；按鈕變 ⛶✕
- [ ] 再 Click → 退出 fullscreen，按鈕還原 ⛶
- [ ] Standalone `/portal/mindmap.html` 不受影響（PR #2222 + #2223 的入口仍 OK）

🤖 Generated with [Claude Code](https://claude.com/claude-code)