### PR TITLE
fix(kanban): L2/L3 escalation also notifies assigned_bots

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -1990,19 +1990,34 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
         }
     }
 
-    async function fireBlockEscalation(card) {
-        const elapsedHrs = Math.round((Date.now() - new Date(card.status_changed_at).getTime()) / 3600000 * 10) / 10;
+    function buildEscalationRecipients(card) {
         const config = card.config || {};
         const esc = config.escalationPolicy || {};
         const notifyEntityId = esc.notifyEntityId || card.reviewer_entity_id;
+        const bots = Array.isArray(card.assigned_bots) ? card.assigned_bots : [];
+        const seen = new Set();
+        const out = [];
+        for (const id of [notifyEntityId, ...bots]) {
+            if (id == null) continue;
+            const key = String(id);
+            if (seen.has(key)) continue;
+            seen.add(key);
+            out.push(id);
+        }
+        return out;
+    }
+
+    async function fireBlockEscalation(card) {
+        const elapsedHrs = Math.round((Date.now() - new Date(card.status_changed_at).getTime()) / 3600000 * 10) / 10;
+        const recipients = buildEscalationRecipients(card);
         await pool.query(
             `UPDATE kanban_cards SET status = 'blocked', status_changed_at = NOW(), last_stale_nudge_at = NOW(), updated_at = NOW() WHERE id = $1`,
             [card.id]
         );
         await addSystemComment(card.id, card.device_id,
             `🚫 自動封鎖：此卡片已停滯 ${elapsedHrs} 小時，已自動移至「blocked」，請人工介入`);
-        if (notifyEntityId != null) {
-            notifyEntities(card.device_id, [notifyEntityId],
+        if (recipients.length > 0) {
+            notifyEntities(card.device_id, recipients,
                 `🚫 卡片「${card.title}」已停滯 ${elapsedHrs}h，自動 blocked，需人工介入`,
                 { cardId: card.id });
         }
@@ -2011,9 +2026,7 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
 
     async function fireLevelTwoEscalation(card) {
         const elapsedHrs = Math.round((Date.now() - new Date(card.status_changed_at).getTime()) / 3600000 * 10) / 10;
-        const config = card.config || {};
-        const esc = config.escalationPolicy || {};
-        const notifyEntityId = esc.notifyEntityId || card.reviewer_entity_id;
+        const recipients = buildEscalationRecipients(card);
         const PRIORITY_UPGRADE = { P3: 'P2', P2: 'P1', P1: 'P0', P0: 'P0' };
         const newPriority = PRIORITY_UPGRADE[card.priority] || card.priority;
         if (newPriority === card.priority) return false;
@@ -2023,8 +2036,8 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
         );
         await addSystemComment(card.id, card.device_id,
             `⬆️ 自動升級：停滯 ${elapsedHrs} 小時，優先級 ${card.priority} → ${newPriority}`);
-        if (notifyEntityId != null) {
-            notifyEntities(card.device_id, [notifyEntityId],
+        if (recipients.length > 0) {
+            notifyEntities(card.device_id, recipients,
                 `⬆️ 卡片「${card.title}」停滯 ${elapsedHrs}h，已自動升級至 ${newPriority}`,
                 { cardId: card.id });
         }


### PR DESCRIPTION
## Summary
- Extract escalation recipients into `buildEscalationRecipients(card)`: merges `notifyEntityId` + `assigned_bots`, dedupes
- `fireBlockEscalation` + `fireLevelTwoEscalation` now ping bots actually working on the card, not only the escalation contact

## Why
Quirk #3 from `feedback_kanban_nudge_quirks` — when stale escalation fires, the assigned bots don't get the message, so a delegated bot can remain idle through both nudge cycles and never know their card went blocked or got priority-upgraded. They look idle when they're actually starved of signal.

L1 nudge already targets `assigned_bots`. This patch makes L2/L3 consistent.

## Test plan
- [ ] Unit: card with `notifyEntityId=4`, `assigned_bots=[5,4]` → recipients = `[4,5]` (4 first, deduped)
- [ ] Unit: card with no `notifyEntityId`, `assigned_bots=[5]` → recipients = `[5]`
- [ ] Unit: card with `notifyEntityId=4`, no bots → recipients = `[4]`
- [ ] Unit: card with neither → recipients = `[]` (no notify call fired)
- [ ] Integration (manual): force a card past stale-block window → confirm `kanban_notify` row arrives at every assigned bot inbox + escalation contact

🤖 Generated with [Claude Code](https://claude.com/claude-code)