### PR TITLE
feat(kanban): chat-anchor schema — pin chat msg + mind-map coord (Phase 1)

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -408,6 +408,11 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
         if (row.last_run_result) card.lastRunResult = row.last_run_result;
         if (row.active_child_id) card.activeChildId = row.active_child_id;
 
+        // Chat-anchor (provenance back to chat message + mind-map coord);
+        // null on auto-generated cards (renders as N/A in UI).
+        card.chatAnchorMessageId = row.chat_anchor_message_id || null;
+        card.chatAnchorCoord = row.chat_anchor_coord || null;
+
         return card;
     }
 
@@ -417,7 +422,7 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
     router.post('/card', async (req, res) => {
         if (!authenticate(req, res)) return;
         const _p = { ...req.query, ...req.body }; console.log('[Kanban] POST /card called', { deviceId: _p.deviceId, entityId: _p.entityId, cardId: req.params?.id });
-        const { deviceId, title, description, priority, status, assignedBots, entityId, reviewerEntityId, isAutomation, schedule, requiresScreenshotReview } = req.body;
+        const { deviceId, title, description, priority, status, assignedBots, entityId, reviewerEntityId, isAutomation, schedule, requiresScreenshotReview, chatAnchorMessageId, chatAnchorCoord } = req.body;
 
         if (!title || !title.trim()) {
             return res.status(400).json({ success: false, error: 'Missing title' });
@@ -511,15 +516,33 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
             ? !isTextOnlyTitle
             : requiresScreenshotReview !== false;
 
+        // Chat-anchor: pin originating chat message + mind-map coord (Phase 1 — persist
+        // only; UI picker + validator enforcement land in follow-up PRs). Auto-cards leave
+        // both NULL so the UI renders N/A.
+        const anchorMsgId = (typeof chatAnchorMessageId === 'string' && chatAnchorMessageId.trim())
+            ? chatAnchorMessageId.trim().slice(0, 128)
+            : null;
+        let anchorCoord = null;
+        if (chatAnchorCoord && typeof chatAnchorCoord === 'object') {
+            const x = Number(chatAnchorCoord.x);
+            const y = Number(chatAnchorCoord.y);
+            if (Number.isFinite(x) && Number.isFinite(y)) {
+                anchorCoord = { x, y };
+            }
+        }
+
         try {
             const result = await pool.query(
                 `INSERT INTO kanban_cards (id, device_id, title, description, priority, status, assigned_bots, created_by, reviewer_entity_id, status_changed_at,
-                    is_automation, schedule_enabled, schedule_type, schedule_cron, schedule_run_at, schedule_timezone, schedule_next_run_at, requires_screenshot_review)
+                    is_automation, schedule_enabled, schedule_type, schedule_cron, schedule_run_at, schedule_timezone, schedule_next_run_at, requires_screenshot_review,
+                    chat_anchor_message_id, chat_anchor_coord)
                  VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8, $9, NOW(),
-                    $10, $11, $12, $13, $14, $15, $16, $17)
+                    $10, $11, $12, $13, $14, $15, $16, $17,
+                    $18, $19::jsonb)
                  RETURNING *`,
                 [newCardId(), deviceId, title.trim(), description || '', cardPriority, cardStatus, JSON.stringify(bots), createdBy, reviewer,
-                    finalAutomation, schedEnabled, schedType, schedCron, schedRunAt, schedTz, schedNextRunAt, finalRequiresScreenshot]
+                    finalAutomation, schedEnabled, schedType, schedCron, schedRunAt, schedTz, schedNextRunAt, finalRequiresScreenshot,
+                    anchorMsgId, anchorCoord ? JSON.stringify(anchorCoord) : null]
             );
 
             const card = serializeCard(result.rows[0]);

--- a/backend/kanban_schema.sql
+++ b/backend/kanban_schema.sql
@@ -56,6 +56,12 @@ ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS reviewer_entity_id INTEGER DEF
 -- without at least one image/* file attached via POST /api/mission/card/:id/file.
 ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS requires_screenshot_review BOOLEAN DEFAULT TRUE;
 
+-- Chat-anchor (2026-04-28): every human-filed card should pin the originating
+-- chat message + mind-map coord so the card has provenance back into 心智 / 對話.
+-- Auto-cards leave both NULL (rendered as N/A in UI).
+ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS chat_anchor_message_id TEXT DEFAULT NULL;
+ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS chat_anchor_coord JSONB DEFAULT NULL;
+
 CREATE INDEX IF NOT EXISTS idx_kanban_cards_automation ON kanban_cards(device_id, is_automation)
     WHERE is_automation = true;
 CREATE INDEX IF NOT EXISTS idx_kanban_cards_parent ON kanban_cards(parent_card_id)


### PR DESCRIPTION
## Summary

Phase 1 of card_cb5e6083ebcbc8486fcff8e0 — schema migration + backend persistence
for the **chat-anchor** field. Pins every human-filed kanban card back to (a) the
originating chat message and (b) the (x, y) coord on the mind-map canvas where
the card "lives". Auto-cards leave both fields NULL (UI will render **N/A**).

UI picker (kanban.html) + validator enforcement land in follow-up PRs — Phase 1
is intentionally additive only, no behavior change.

## Changes

**`backend/kanban_schema.sql`**
```sql
ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS chat_anchor_message_id TEXT DEFAULT NULL;
ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS chat_anchor_coord JSONB DEFAULT NULL;
```

**`backend/kanban.js`** (POST `/card` + `serializeCard`)
- Destructure `chatAnchorMessageId` + `chatAnchorCoord` from `req.body`
- Sanitize: trim + 128-char cap on msg id; coerce coord to `{ x:Number, y:Number }`
- Extended INSERT 17 → 19 columns
- `serializeCard` exposes both fields on returned card object

## Test plan

- [x] `node -e \"require('./backend/kanban.js')\"` — module loads cleanly
- [ ] After merge: Railway pulls migration on next deploy → both columns appear
- [ ] curl POST /api/mission/card with `chatAnchorMessageId` + `chatAnchorCoord` → echoed back via GET /api/mission/cards
- [ ] Existing cards (rows without these columns) → fall back to NULL → UI renders N/A

## Follow-up PRs (not in this one)

1. UI picker in kanban.html — pick anchor message from chat history + drop coord on mind-map
2. Validator enforcement — `requireChatAnchor` flag on POST /card for non-auto cards
3. mission.html mind-map → render kanban cards as colored dots at their `chat_anchor_coord`

card_cb5e6083ebcbc8486fcff8e0