### PR TITLE
feat(settings): deep-link section filter (?focus=channel-api / kanban-nudge)

### DIFF
--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1159,6 +1159,7 @@
     <script src="shared/auth.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/settings-deep-link.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/entity-utils.js"></script>
     <script src="shared/socket.js"></script>
@@ -1197,6 +1198,8 @@
             loadDevicePreferences();
             initKanbanNudgeCollapse();
             updatePushToggle();
+
+            if (typeof applyDeepLinkFocus === 'function') applyDeepLinkFocus();
 
             document.getElementById('pageContent').style.display = '';
             initTapPay();

--- a/backend/public/shared/settings-deep-link.js
+++ b/backend/public/shared/settings-deep-link.js
@@ -1,0 +1,62 @@
+// Settings deep-link section filter.
+// Lets the APP open settings.html with ?focus=<key> and only render the
+// matching card so the user doesn't have to scroll past unrelated sections.
+// Falls back to full page if key is unknown or absent.
+
+(function () {
+    const FOCUS_MAP = {
+        'channel-api': {
+            cardId: 'channelApiCard',
+            expand: null,
+        },
+        'kanban-nudge': {
+            cardId: 'kanban-nudge-card',
+            expand: function () {
+                const content = document.getElementById('kanbanNudgeContent');
+                const arrow = document.getElementById('kanbanNudgeArrow');
+                const header = document.getElementById('kanbanNudgeHeader');
+                if (content) content.classList.add('visible');
+                if (arrow) arrow.classList.add('expanded');
+                if (header) header.setAttribute('aria-expanded', 'true');
+            },
+        },
+    };
+
+    function readFocusKey() {
+        try {
+            const params = new URLSearchParams(window.location.search);
+            const q = params.get('focus');
+            if (q) return q;
+        } catch (_) { }
+        const hash = (window.location.hash || '').replace(/^#/, '');
+        return hash || null;
+    }
+
+    function applyDeepLinkFocus() {
+        const key = readFocusKey();
+        if (!key) return false;
+        const target = FOCUS_MAP[key];
+        if (!target) return false;
+        const targetEl = document.getElementById(target.cardId);
+        if (!targetEl) return false;
+
+        const cards = document.querySelectorAll('.card');
+        cards.forEach(function (el) {
+            if (el !== targetEl) el.style.display = 'none';
+        });
+
+        if (typeof target.expand === 'function') {
+            try { target.expand(); } catch (_) { }
+        }
+
+        try {
+            targetEl.scrollIntoView({ block: 'start', behavior: 'auto' });
+        } catch (_) { }
+
+        document.body.setAttribute('data-deep-link-focus', key);
+        return true;
+    }
+
+    window.applyDeepLinkFocus = applyDeepLinkFocus;
+    window.SETTINGS_DEEP_LINK_KEYS = Object.keys(FOCUS_MAP);
+})();


### PR DESCRIPTION
## Summary

- Adds `?focus=<key>` deep-link to `portal/settings.html`. When the APP opens settings via the 「管理所有金鑰」button, it appends `?focus=channel-api` and the page renders **only** the Channel API card. Same for 「看板督促設定」→ `?focus=kanban-nudge`.
- Shared module `public/shared/settings-deep-link.js` with key→cardId map. Easy to add more keys later (subscription, display, invite, …) without touching settings.html.
- Falls back gracefully: unknown key → full page; no key → full page; missing target element → full page.
- For `kanban-nudge`, the deep-link also force-expands the collapsed inner content so the toggles are immediately usable (instead of showing just a header).

## Why

Hank: 「APP 的管理所有金鑰按鈕 按下之後須僅跳轉顯示 'Channel API 欄位' 而不是整個設定頁面」 + same for 看板督促設定. Two cards, one shared mechanism.

Closes:
- `card_ef6326474f8a42b26886e019` — 管理所有金鑰 → Channel API only
- `card_7cd56e3651a63cb62f790568` — 看板督促設定 → kanban-nudge only

## Test plan

- [x] `?focus=channel-api` → only `#channelApiCard` visible
- [x] `?focus=kanban-nudge` → only `#kanban-nudge-card` visible + inner collapsed content auto-expands
- [x] `?focus=unknown-section` → all cards visible (no-op fallback)
- [x] No focus param → all cards visible
- [x] Hash form `#channel-api` works on fresh navigation (DOMContentLoaded path)
- [x] `node --check` on settings-deep-link.js — no syntax errors
- [ ] APP-side: append `?focus=channel-api` / `?focus=kanban-nudge` to the two button URLs (next PR, ships in v1.0.80)

🤖 Generated with [Claude Code](https://claude.com/claude-code)