### PR TITLE
chore(app): v1.0.80 — wire SettingsActivity buttons to settings.html?focus=

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 85
-        versionName = "1.0.79"
+        versionCode = 86
+        versionName = "1.0.80"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
@@ -302,7 +302,7 @@ class SettingsActivity : AppCompatActivity() {
 
         findViewById<MaterialButton>(R.id.btnKanbanNudge).setOnClickListener {
             TelemetryHelper.trackAction("settings_kanban_nudge")
-            WebViewActivity.launch(this, "https://eclawbot.com/portal/settings.html#kanban-nudge-card", getString(R.string.kanban_nudge_settings_title))
+            WebViewActivity.launch(this, "https://eclawbot.com/portal/settings.html?focus=kanban-nudge", getString(R.string.kanban_nudge_settings_title))
         }
 
         findViewById<MaterialButton>(R.id.btnWallet).setOnClickListener {
@@ -1424,7 +1424,7 @@ class SettingsActivity : AppCompatActivity() {
 
         findViewById<com.google.android.material.button.MaterialButton>(R.id.btnChannelApiManage).setOnClickListener {
             TelemetryHelper.trackAction("channel_api_manage_all")
-            WebViewActivity.launch(this, "https://eclawbot.com/portal/settings.html", getString(R.string.channel_api_card_title))
+            WebViewActivity.launch(this, "https://eclawbot.com/portal/settings.html?focus=channel-api", getString(R.string.channel_api_card_title))
         }
     }
 


### PR DESCRIPTION
## Summary
- The deep-link section filter shipped in PR #2229 (\`backend/public/shared/settings-deep-link.js\`) reads \`?focus=<key>\` to collapse the rest of the page to that single card.
- APP entry buttons were still launching bare URLs (channel-api) or a hash that the filter doesn't read (\`#kanban-nudge-card\`), so users still landed on the full page and had to scroll past unrelated sections.
- Bump versionCode 85 → 86, versionName 1.0.79 → 1.0.80.

## Changes
- \`btnKanbanNudge\` → \`settings.html?focus=kanban-nudge\`
- \`btnChannelApiManage\` → \`settings.html?focus=channel-api\`

## Test plan
- [ ] Build internal-test APK, install, tap 看板督促 in Settings — only nudge card visible.
- [ ] Tap 管理所有金鑰 — only Channel API card visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)