### PR TITLE
fix(settings): focus mode hides logout/delete-account block

### DIFF
--- a/backend/public/shared/settings-deep-link.js
+++ b/backend/public/shared/settings-deep-link.js
@@ -45,6 +45,13 @@
             if (el !== targetEl) el.style.display = 'none';
         });
 
+        // Hide bottom actions (logout / delete-account) — they belong to the
+        // full settings page, not a focused single-card view. Leaving them
+        // visible turns the focused page into a small card on top of two
+        // dangerous red buttons that the user could mis-tap.
+        const actions = document.querySelectorAll('.actions-section');
+        actions.forEach(function (el) { el.style.display = 'none'; });
+
         if (typeof target.expand === 'function') {
             try { target.expand(); } catch (_) { }
         }


### PR DESCRIPTION
## Why

Hank 2026-04-28 21:47 web_chat after testing v1.0.80 deep-link:
> 進去頁面後底部是登出跟刪除帳號這兩個按鈕 會不會有點危險 容易誤按 因為跟頁面內容不相干

The deep-link landing page (`?focus=channel-api` / `?focus=kanban-nudge`)
hides all `.card` elements except the focused one — but `.actions-section`
(logout + delete-account) was outside that selector, so it stayed visible
right under the focused card. Looks like part of the focused card, invites
mis-taps.

## What

`applyDeepLinkFocus` now also hides every `.actions-section`. Logout and
delete-account remain reachable from the full settings page.

## Test plan

- [ ] Prod Playwright: load `/portal/settings.html?focus=kanban-nudge`,
      confirm `.actions-section` (Logout + Delete Account) is hidden
- [ ] Prod Playwright: load `/portal/settings.html?focus=channel-api`,
      confirm same
- [ ] Prod Playwright: load `/portal/settings.html` (no focus),
      confirm `.actions-section` IS visible
- [ ] Android emulator: launch APP, tap "看板督促" + "管理所有金鑰",
      confirm WebView lands on focused card with no logout/delete below

Closes card_33eb804a1f3f26cd78c6010a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)