### PR TITLE
feat(mindmap): Phase 4 read-side — render cards at chat_anchor_coord

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -908,7 +908,7 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
         const { deviceId } = { ...req.query, ...req.body };
         try {
             const cardsResult = await pool.query(
-                `SELECT id, title, description, priority, status, parent_card_id, is_automation, assigned_bots
+                `SELECT id, title, description, priority, status, parent_card_id, is_automation, assigned_bots, chat_anchor_coord
                  FROM kanban_cards
                  WHERE device_id = $1 AND archived = false
                  ORDER BY
@@ -939,7 +939,7 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
                 const sys = classifySys(c.title, c.is_automation);
                 sysCount[sys] = (sysCount[sys] || 0) + 1;
                 const summary = (c.description || '').replace(/\s+/g, ' ').trim().slice(0, 120);
-                nodes.push({
+                const node = {
                     id: c.id,
                     label: (c.title || '').slice(0, 40),
                     sys,
@@ -949,7 +949,12 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
                     priority: c.priority,
                     cardStatus: c.status,
                     isAutomation: !!c.is_automation,
-                });
+                };
+                const coord = c.chat_anchor_coord;
+                if (coord && Number.isFinite(coord.x) && Number.isFinite(coord.y)) {
+                    node.coord = { x: coord.x, y: coord.y };
+                }
+                nodes.push(node);
                 cardIds.add(c.id);
             }
 

--- a/backend/public/portal/shared/mission-mindmap.js
+++ b/backend/public/portal/shared/mission-mindmap.js
@@ -577,7 +577,13 @@
 
   function buildCy(canvasEl, nodes, edges) {
     const nodesById = Object.fromEntries(nodes.map(n => [n.id, n]));
-    const cyNodes = nodes.map(n => ({ data: { ...n, sysColor: SYS[n.sys].color } }));
+    const cyNodes = nodes.map(n => {
+      const sysColor = (SYS[n.sys] || SYS.kanban).color;
+      const cyNode = { data: { ...n, sysColor } };
+      const c = n.coord;
+      if (c && Number.isFinite(c.x) && Number.isFinite(c.y)) cyNode.position = { x: c.x, y: c.y };
+      return cyNode;
+    });
     const cyEdges = edges.map(([s, t, label]) => ({
       data: { id: `${s}__${t}`, source: s, target: t, label: label || '', cross: !!label }
     }));
@@ -586,7 +592,7 @@
       container: canvasEl,
       elements: [...cyNodes, ...cyEdges],
       layout: {
-        name: 'cose', padding: 30, animate: false, fit: true,
+        name: 'cose', padding: 30, animate: false, fit: true, randomize: false,
         idealEdgeLength: 95, nodeRepulsion: 8500, edgeElasticity: 100,
         nestingFactor: 1.2, gravity: 0.3, numIter: 1800, componentSpacing: 70,
       },


### PR DESCRIPTION
## Summary
- Phase 4 of mindmap roadmap: read-side honors `chat_anchor_coord` so notes saved with anchor positions render at their saved coordinates instead of cose layout randomizing them every load.
- Server (`backend/kanban.js`): adds `chat_anchor_coord` to mindmap SELECT + emits `coord` per node when present.
- Client (`backend/public/portal/shared/mission-mindmap.js`): `buildCy` honors `node.coord` if provided; layout `randomize: false` so anchored nodes stay put.

## Test plan
- [ ] Notes with no `chat_anchor_coord` still cose-layout normally (regression check)
- [ ] Notes saved with `chat_anchor_coord` render at saved x/y on reload
- [ ] Mindmap fullscreen + embed both pick up the new coord field