### PR TITLE
chore(mindmap): rip MOCK_NODES seed; render empty-state for fresh devices

### DIFF
--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -843,13 +843,13 @@
             <!-- Mind-map (PR-A: static mockup; PR-B will wire to /api/mission/cards) -->
             <div class="card mm-card">
                 <div class="card-header">
-                    <h2>🧠 <span data-i18n="mm_card_title">心智圖</span> <span style="font-size:11px;color:var(--text-secondary);font-weight:500;margin-left:6px;" data-i18n="mm_card_beta">(beta · 模擬資料)</span></h2>
+                    <h2>🧠 <span data-i18n="mm_card_title">心智圖</span> <span style="font-size:11px;color:var(--text-secondary);font-weight:500;margin-left:6px;" data-i18n="mm_card_beta">(beta)</span></h2>
                     <div class="section-header-actions">
                         <button class="btn btn-outline btn-sm" id="mmToggleBtn" onclick="toggleMindmap()" data-i18n="mm_card_expand">展開</button>
                     </div>
                 </div>
                 <div id="mmContainer" style="display:none;"></div>
-                <div id="mmHint" style="font-size:12px;color:var(--text-secondary);padding:4px 2px;" data-i18n="mm_card_hint">52 個節點 · 8 子系統 · 76 條連線（含跨系統依賴）。展開可互動探索。</div>
+                <div id="mmHint" style="font-size:12px;color:var(--text-secondary);padding:4px 2px;" data-i18n="mm_card_hint">把看板卡片連成圖：任務、子卡與聊天錨點互相關聯。展開可互動探索。</div>
             </div>
 
             <!-- Notes -->
@@ -968,22 +968,19 @@
             if (mmExpanded && !mmInitialized && window.MissionMindmap) {
                 mmInitialized = true;
                 try {
-                    let liveData = null;
+                    let liveData = { nodes: [], edges: [] };
                     try {
                         const resp = await fetch(
                             `/api/mission/mindmap?deviceId=${encodeURIComponent(currentUser.deviceId)}&deviceSecret=${encodeURIComponent(currentUser.deviceSecret)}`
                         );
                         if (resp.ok) {
                             const j = await resp.json();
-                            // Need at least 5 nodes for a mind-map to be useful;
-                            // below that, fall back to the curated demo so the
-                            // UX doesn't look empty for fresh devices.
-                            if (j.success && Array.isArray(j.nodes) && j.nodes.length >= 5) {
-                                liveData = { nodes: j.nodes, edges: j.edges || [] };
+                            if (j.success && Array.isArray(j.nodes)) {
+                                liveData = { nodes: j.nodes, edges: Array.isArray(j.edges) ? j.edges : [] };
                             }
                         }
                     } catch (fetchErr) {
-                        console.warn('mindmap live fetch failed, falling back to mock:', fetchErr);
+                        console.warn('mindmap live fetch failed:', fetchErr);
                     }
                     await window.MissionMindmap.init({ rootEl: container, data: liveData });
                 } catch (err) {

--- a/backend/public/portal/shared/mission-mindmap.js
+++ b/backend/public/portal/shared/mission-mindmap.js
@@ -1,7 +1,10 @@
 // mission-mindmap.js — PR-B v4 (chip+📌 + responsive)
 //
 // Lazy-loaded on first expand of the "🧠 心智圖" card in mission.html.
-// Same MOCK_NODES/MOCK_EDGES as PR-A (52 nodes / 76 edges / 8 subsystems).
+// Renders the user's own kanban cards as a graph; data is fetched from
+// /api/mission/mindmap by the embedding page and passed in via init({data}).
+// When the device has zero cards the module renders an empty-state hint —
+// no demo seed data is shipped (every device sees only its own work).
 //
 // Interaction model (rewritten 2026-04-25 after Hank rejected v3 dense):
 //   • Tap a node → spawn a floating 引用預覽卡 (chip popover) anchored near
@@ -23,6 +26,17 @@
 
   const CDN = 'https://cdn.jsdelivr.net/npm/cytoscape@3.28.1/dist/cytoscape.min.js';
 
+  // Subsystem registry — single source of truth for mindmap node styling.
+  // Each key matches the `sys` field that the kanban → mindmap mapper
+  // (backend/kanban.js → /api/mission/mindmap) emits per card. The color
+  // also drives sys-rail swatches and cytoscape edge tinting.
+  //
+  // Why a constant: subsystem palette is a design decision, not user data.
+  // Adding a subsystem requires three coordinated changes (this dict, the
+  // backend mapper, an i18n key for the label) so the cost is intentional.
+  // Source authority: Hank — palette locked 2026-04-25 with the chip+📌
+  // redesign; do not recolor without his approval (palette is reused in
+  // info.html and roadmap.html previews).
   const SYS = {
     invite:     { color: '#f43f5e', label: '邀請成長' },
     device:     { color: '#06b6d4', label: '裝置' },
@@ -35,124 +49,6 @@
     automation: { color: '#64748b', label: '自動化' },
   };
 
-  const MOCK_NODES = [
-  // 邀請 (7)
-  { id: 'inv-hub', label: '邀請系統', sys: 'invite', tier: 'domain', status: 'active', summary: '8 碼邀請、redeem、tier milestone、funnel telemetry。本週 0/9 兌換率 0%。' },
-  { id: 'inv-code', label: '8 碼生碼', sys: 'invite', tier: 'topic', status: 'done' },
-  { id: 'inv-redeem', label: 'Redeem flow', sys: 'invite', tier: 'topic', status: 'active' },
-  { id: 'inv-tier', label: 'Tier milestone', sys: 'invite', tier: 'topic', status: 'active', summary: 'Tier 1=邀請 1 人解鎖 chip preview' },
-  { id: 'inv-leader', label: 'Leaderboard', sys: 'invite', tier: 'topic', status: 'blocked', summary: '需要先有 30+ 用戶才有意義' },
-  { id: 'inv-funnel', label: 'Funnel telemetry', sys: 'invite', tier: 'leaf', status: 'active' },
-  { id: 'inv-qr', label: 'QR 海報生成', sys: 'invite', tier: 'leaf', status: 'done' },
-
-  // 裝置 (6)
-  { id: 'dev-hub', label: '裝置 / Device', sys: 'device', tier: 'domain', status: 'active', summary: 'deviceId+secret 認證、輪替、health probe。' },
-  { id: 'dev-rotate', label: 'Secret 輪替', sys: 'device', tier: 'topic', status: 'active', summary: 'POST /api/device/rotate-secret + 一次性 dialog' },
-  { id: 'dev-health', label: 'rental-health cron', sys: 'device', tier: 'topic', status: 'done' },
-  { id: 'dev-vars', label: 'device-vars vault', sys: 'device', tier: 'topic', status: 'done' },
-  { id: 'dev-switch', label: 'Switch Device', sys: 'device', tier: 'leaf', status: 'blocked', summary: '12.4h stale; 等 i18n' },
-  { id: 'dev-logs', label: '/api/logs (DEVICE_SECRET)', sys: 'device', tier: 'leaf', status: 'done' },
-
-  // i18n (8)
-  { id: 'i18n-hub', label: 'i18n 13 locale', sys: 'i18n', tier: 'domain', status: 'active', summary: 'en/zh/zh-TW/ja/ko/de/es/fr/pt/it/vi/th/id/ms/hi/ar — chip_popover 缺 10' },
-  { id: 'i18n-shared', label: 'shared/i18n.js (live)', sys: 'i18n', tier: 'topic', status: 'active', summary: '~61k lines, 唯一被 HTML import' },
-  { id: 'i18n-deadtop', label: '頂層 ./i18n.js (dead)', sys: 'i18n', tier: 'leaf', status: 'done', summary: '已 git rm + CI guard' },
-  { id: 'i18n-chip', label: 'chip_popover_*', sys: 'i18n', tier: 'topic', status: 'blocked', summary: 'Mac_E 兩次 wrong-file fail' },
-  { id: 'i18n-kb', label: 'kb_/kanban_*', sys: 'i18n', tier: 'topic', status: 'blocked' },
-  { id: 'i18n-strict-ci', label: 'i18n-check.js (strict)', sys: 'i18n', tier: 'leaf', status: 'done' },
-  { id: 'i18n-key-audit', label: '558 stray }, audit', sys: 'i18n', tier: 'leaf', status: 'done' },
-  { id: 'i18n-translator', label: 'Mac_E i18n agent', sys: 'i18n', tier: 'leaf', status: 'blocked', summary: '錯檔路徑寫死，已 STOP' },
-
-  // 看板 (7)
-  { id: 'kb-hub', label: '看板系統', sys: 'kanban', tier: 'domain', status: 'active' },
-  { id: 'kb-card', label: '/mission/card API', sys: 'kanban', tier: 'topic', status: 'done' },
-  { id: 'kb-screenshot-gate', label: 'screenshot 截圖閘', sys: 'kanban', tier: 'topic', status: 'active' },
-  { id: 'kb-r2-ttl', label: 'R2 TTL ≥3 days', sys: 'kanban', tier: 'leaf', status: 'done', summary: 'PR #2090 merged' },
-  { id: 'kb-deeplink', label: '深層連結 anchor scroll', sys: 'kanban', tier: 'leaf', status: 'done' },
-  { id: 'kb-notes-tab', label: '筆記 tab snake_case bug', sys: 'kanban', tier: 'leaf', status: 'active' },
-  { id: 'kb-mention', label: '@mention → entityId', sys: 'kanban', tier: 'topic', status: 'active' },
-
-  // 聊天 (8)
-  { id: 'chat-hub', label: '聊天 / Chat', sys: 'chat', tier: 'domain', status: 'active' },
-  { id: 'chat-chip', label: '智慧引用晶片', sys: 'chat', tier: 'topic', status: 'active', summary: '@chip_popover_X 點擊預覽' },
-  { id: 'chat-chip-recursive', label: '預覽卡內遞迴 chip', sys: 'chat', tier: 'leaf', status: 'active' },
-  { id: 'chat-pin-btn', label: '📌 重新引用按鈕', sys: 'chat', tier: 'leaf', status: 'done', summary: 'PR #2089 merged' },
-  { id: 'chat-history-api', label: '/api/chat/history', sys: 'chat', tier: 'topic', status: 'done' },
-  { id: 'chat-schedule', label: '排程訊息 (long-press)', sys: 'chat', tier: 'topic', status: 'done' },
-  { id: 'chat-embed', label: 'embed=1 mode', sys: 'chat', tier: 'leaf', status: 'done' },
-  { id: 'chat-share', label: 'share-chat.html 公開', sys: 'chat', tier: 'leaf', status: 'active' },
-
-  // 支付 (5)
-  { id: 'pay-hub', label: '支付 / 訂閱', sys: 'payment', tier: 'domain', status: 'active' },
-  { id: 'pay-topup-b', label: 'Top-up Path B (sandbox)', sys: 'payment', tier: 'topic', status: 'active', summary: 'Android emu 已有 Play 帳號' },
-  { id: 'pay-iap-android', label: 'Android IAP', sys: 'payment', tier: 'topic', status: 'active' },
-  { id: 'pay-iap-ios', label: 'iOS StoreKit', sys: 'payment', tier: 'topic', status: 'blocked', summary: '等 Apple Connect 設定' },
-  { id: 'pay-wallet', label: 'wallet.html 餘額', sys: 'payment', tier: 'leaf', status: 'done' },
-
-  // 廣播 (6)
-  { id: 'bcast-hub', label: '廣播 / Publisher', sys: 'broadcast', tier: 'domain', status: 'active' },
-  { id: 'bcast-x', label: 'X (Twitter)', sys: 'broadcast', tier: 'topic', status: 'active' },
-  { id: 'bcast-mastodon', label: 'Mastodon', sys: 'broadcast', tier: 'leaf', status: 'done', summary: '已棄用 2026-04-15' },
-  { id: 'bcast-wp', label: 'WordPress.com', sys: 'broadcast', tier: 'leaf', status: 'done', summary: '已退役 2026-04-20' },
-  { id: 'bcast-cron', label: 'Daily viral cron', sys: 'broadcast', tier: 'topic', status: 'active' },
-  { id: 'bcast-design', label: 'Claude Design 視覺', sys: 'broadcast', tier: 'leaf', status: 'active' },
-
-  // 橋接 (5)
-  { id: 'br-hub', label: '橋接 / Bridge', sys: 'bridge', tier: 'domain', status: 'active' },
-  { id: 'br-auth', label: 'bridge-auth (osascript)', sys: 'bridge', tier: 'topic', status: 'done' },
-  { id: 'br-eye', label: 'eye 螢幕全覽', sys: 'bridge', tier: 'leaf', status: 'done' },
-  { id: 'br-hermes-docker', label: 'hermes-bridge service', sys: 'bridge', tier: 'topic', status: 'done', summary: 'card_7102c915 closed' },
-  { id: 'br-unit-u01', label: 'U01 = app E2E', sys: 'bridge', tier: 'leaf', status: 'active' },
-];
-
-  const MOCK_EDGES = [
-  // 邀請 tree
-  ['inv-hub','inv-code'],['inv-hub','inv-redeem'],['inv-hub','inv-tier'],
-  ['inv-hub','inv-leader'],['inv-redeem','inv-funnel'],['inv-code','inv-qr'],
-  // 裝置 tree
-  ['dev-hub','dev-rotate'],['dev-hub','dev-health'],['dev-hub','dev-vars'],
-  ['dev-hub','dev-switch'],['dev-hub','dev-logs'],
-  // i18n tree
-  ['i18n-hub','i18n-shared'],['i18n-hub','i18n-chip'],['i18n-hub','i18n-kb'],
-  ['i18n-shared','i18n-strict-ci'],['i18n-shared','i18n-key-audit'],
-  ['i18n-shared','i18n-deadtop'],['i18n-hub','i18n-translator'],
-  // 看板 tree
-  ['kb-hub','kb-card'],['kb-hub','kb-screenshot-gate'],['kb-screenshot-gate','kb-r2-ttl'],
-  ['kb-hub','kb-deeplink'],['kb-hub','kb-notes-tab'],['kb-hub','kb-mention'],
-  // 聊天 tree
-  ['chat-hub','chat-chip'],['chat-chip','chat-chip-recursive'],['chat-chip','chat-pin-btn'],
-  ['chat-hub','chat-history-api'],['chat-hub','chat-schedule'],['chat-hub','chat-embed'],
-  ['chat-hub','chat-share'],
-  // 支付 tree
-  ['pay-hub','pay-topup-b'],['pay-hub','pay-iap-android'],['pay-hub','pay-iap-ios'],
-  ['pay-hub','pay-wallet'],['pay-iap-android','pay-topup-b'],
-  // 廣播 tree
-  ['bcast-hub','bcast-x'],['bcast-hub','bcast-mastodon'],['bcast-hub','bcast-wp'],
-  ['bcast-hub','bcast-cron'],['bcast-cron','bcast-design'],
-  // 橋接 tree
-  ['br-hub','br-auth'],['br-auth','br-eye'],['br-hub','br-hermes-docker'],['br-hub','br-unit-u01'],
-
-  // ⛓ Cross-system dependencies (different style)
-  ['i18n-chip','chat-chip','depends'],
-  ['i18n-kb','kb-hub','depends'],
-  ['i18n-translator','br-auth','via'],
-  ['inv-redeem','dev-vars','via'],
-  ['inv-tier','chat-chip','unlocks'],
-  ['kb-screenshot-gate','bcast-cron','required'],
-  ['chat-schedule','kb-mention','reuses'],
-  ['br-hermes-docker','i18n-translator','runs'],
-  ['pay-topup-b','dev-health','telemetry'],
-  ['bcast-x','dev-vars','reads-key'],
-  ['bcast-design','br-auth','uses'],
-  ['kb-card','chat-history-api','share-DB'],
-  ['inv-funnel','bcast-cron','feeds'],
-  ['dev-switch','i18n-chip','blocked-by'],
-  ['chat-pin-btn','i18n-chip','i18n-key'],
-  ['kb-deeplink','chat-chip','same-anchor'],
-  ['br-unit-u01','kb-screenshot-gate','attaches'],
-  ['chat-share','bcast-x','outbound'],
-  ['inv-qr','bcast-design','asset'],
-];
 
   const STYLE_ID = 'mission-mindmap-style';
   const STYLE_CSS = `
@@ -460,6 +356,27 @@
         top: 50px; font-size: 9px;
       }
     }
+    .mm-root.mm-empty {
+      display: flex; align-items: center; justify-content: center;
+      grid-template-columns: none;
+    }
+    .mm-empty-card {
+      max-width: 360px; padding: 28px 24px; text-align: center;
+      background: var(--mm-bg-elev); border: 1px solid var(--mm-border);
+      border-radius: 10px; color: var(--mm-text);
+    }
+    .mm-empty-emoji { font-size: 36px; margin-bottom: 10px; }
+    .mm-empty-title { font-size: 16px; margin: 0 0 8px 0; font-weight: 600; }
+    .mm-empty-hint {
+      font-size: 13px; margin: 0 0 16px 0; line-height: 1.5;
+      color: var(--mm-text-secondary);
+    }
+    .mm-empty-cta {
+      display: inline-block; padding: 8px 16px; font-size: 13px;
+      background: #22c55e; color: #0d1117; border-radius: 6px;
+      text-decoration: none; font-weight: 600;
+    }
+    .mm-empty-cta:hover { background: #16a34a; }
   `;
 
   function injectStyle() {
@@ -1168,12 +1085,36 @@
     return ctrl;
   }
 
+  function renderEmptyState(rootEl) {
+    injectStyle();
+    rootEl.classList.add('mm-root');
+    rootEl.classList.add('mm-empty');
+    if (rootEl.style.display === 'block') rootEl.style.display = '';
+    const t = (key, fallback) => (window.i18n && window.i18n.t && window.i18n.t(key)) || fallback;
+    const title = t('mm_empty_title', '心智圖還沒有節點');
+    const hint = t('mm_empty_hint', '建立看板卡片後，這裡會自動把任務、子卡與聊天錨點連成圖。');
+    const cta = t('mm_empty_cta', '前往看板新增第一張卡');
+    rootEl.innerHTML = `
+      <div class="mm-empty-card">
+        <div class="mm-empty-emoji">🧠</div>
+        <h3 class="mm-empty-title">${title}</h3>
+        <p class="mm-empty-hint">${hint}</p>
+        <a class="mm-empty-cta" href="kanban.html">${cta}</a>
+      </div>
+    `;
+  }
+
   async function init(opts) {
     const { rootEl, data } = opts || {};
     if (!rootEl) throw new Error('MissionMindmap.init: rootEl required');
 
-    const nodes = (data && data.nodes) || MOCK_NODES;
-    const edges = (data && data.edges) || MOCK_EDGES;
+    const nodes = (data && Array.isArray(data.nodes)) ? data.nodes : [];
+    const edges = (data && Array.isArray(data.edges)) ? data.edges : [];
+
+    if (nodes.length === 0) {
+      renderEmptyState(rootEl);
+      return { empty: true, nodes, edges };
+    }
 
     injectStyle();
     rootEl.classList.add('mm-root');
@@ -1189,5 +1130,5 @@
     return { cy, ...ctrl, nodes, edges };
   }
 
-  global.MissionMindmap = { init, SYS, MOCK_NODES, MOCK_EDGES };
+  global.MissionMindmap = { init, SYS };
 })(window);

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -24,10 +24,13 @@ const TRANSLATIONS = {
         "mc_done_title": "Done List",
         // 心智圖 (Mind-map card on mission.html)
         "mm_card_title": "Mind Map",
-        "mm_card_beta": "(beta · mock data)",
+        "mm_card_beta": "(beta)",
         "mm_card_expand": "Expand",
         "mm_card_collapse": "Collapse",
-        "mm_card_hint": "52 nodes · 8 subsystems · 76 edges (incl. cross-system). Expand to explore.",
+        "mm_card_hint": "Connects your kanban cards into a graph: tasks, sub-cards and chat anchors. Expand to explore.",
+        "mm_empty_title": "Mind map has no nodes yet",
+        "mm_empty_hint": "Once you create kanban cards, this view will connect tasks, sub-cards and chat anchors into a graph automatically.",
+        "mm_empty_cta": "Open kanban to create your first card",
 
         "mc_notes_title": "Notes",
         "mc_rules_title": "Rules (Workflow)",
@@ -5024,10 +5027,13 @@ const TRANSLATIONS = {
         "mc_done_title": "已完成",
         // 心智圖 (Mind-map card on mission.html)
         "mm_card_title": "心智图",
-        "mm_card_beta": "(beta · 模拟数据)",
+        "mm_card_beta": "(beta)",
         "mm_card_expand": "展开",
         "mm_card_collapse": "收起",
-        "mm_card_hint": "52 个节点 · 8 子系统 · 76 条连线（含跨系统依赖）。展开可互动探索。",
+        "mm_card_hint": "把看板卡片連成圖：任務、子卡與聊天錨點互相關聯。展開可互動探索。",
+        "mm_empty_title": "心智圖還沒有節點",
+        "mm_empty_hint": "建立看板卡片後，這裡會自動把任務、子卡與聊天錨點連成圖。",
+        "mm_empty_cta": "前往看板新增第一張卡",
 
         "mc_notes_title": "筆記",
         "mc_rules_title": "規則 (Workflow)",
@@ -14061,10 +14067,10 @@ const TRANSLATIONS = {
         "mc_done_title": "完了一覧",
         // 心智圖 (Mind-map card on mission.html)
         "mm_card_title": "マインドマップ",
-        "mm_card_beta": "(beta · モックデータ)",
+        "mm_card_beta": "(beta)",
         "mm_card_expand": "展開",
         "mm_card_collapse": "折りたたむ",
-        "mm_card_hint": "52 ノード · 8 サブシステム · 76 リンク（クロスシステム依存含む）。展開して操作。",
+        "mm_card_hint": "カンバンのカードを地図に：タスク、サブカード、チャットアンカーを連結。展開して操作してください。",
 
         "mc_notes_title": "ノート",
         "mc_rules_title": "ルール (ワークフロー)",
@@ -18203,10 +18209,10 @@ const TRANSLATIONS = {
         "mc_done_title": "완료 목록",
         // 心智圖 (Mind-map card on mission.html)
         "mm_card_title": "마인드맵",
-        "mm_card_beta": "(beta · 모의 데이터)",
+        "mm_card_beta": "(beta)",
         "mm_card_expand": "펼치기",
         "mm_card_collapse": "접기",
-        "mm_card_hint": "52 노드 · 8 서브시스템 · 76 연결(시스템 간 의존성 포함). 펼쳐서 탐색.",
+        "mm_card_hint": "칸반 카드를 지도로 연결: 작업, 서브카드, 채팅 앵커. 펼쳐서 탐색하세요.",
 
         "mc_notes_title": "노트",
         "mc_rules_title": "규칙 (워크플로)",
@@ -22310,10 +22316,10 @@ const TRANSLATIONS = {
         "mc_done_title": "รายการที่เสร็จแล้ว",
         // 心智圖 (Mind-map card on mission.html)
         "mm_card_title": "แผนที่ความคิด",
-        "mm_card_beta": "(beta · ข้อมูลจำลอง)",
+        "mm_card_beta": "(beta)",
         "mm_card_expand": "ขยาย",
         "mm_card_collapse": "ย่อ",
-        "mm_card_hint": "52 โหนด · 8 ระบบย่อย · 76 ลิงก์ (รวมข้ามระบบ) — ขยายเพื่อสำรวจ",
+        "mm_card_hint": "เชื่อมโยงการ์ดคันบังเป็นแผนที่: งาน, การ์ดย่อย, จุดเชื่อมแชต — ขยายเพื่อสำรวจ",
 
         "mc_notes_title": "โน้ต",
         "mc_rules_title": "กฎ (เวิร์คโฟลว์)",
@@ -26428,10 +26434,10 @@ const TRANSLATIONS = {
         "mc_done_title": "Danh sách Hoàn thành",
         // 心智圖 (Mind-map card on mission.html)
         "mm_card_title": "Bản đồ tư duy",
-        "mm_card_beta": "(beta · dữ liệu mô phỏng)",
+        "mm_card_beta": "(beta)",
         "mm_card_expand": "Mở rộng",
         "mm_card_collapse": "Thu gọn",
-        "mm_card_hint": "52 nút · 8 hệ thống con · 76 liên kết (bao gồm phụ thuộc liên hệ thống). Mở rộng để khám phá.",
+        "mm_card_hint": "Kết nối thẻ kanban thành đồ thị: nhiệm vụ, thẻ con, mỏ neo trò chuyện. Mở rộng để khám phá.",
 
         "mc_notes_title": "Ghi chú",
         "mc_rules_title": "Quy tắc (Luồng công việc)",
@@ -30520,10 +30526,10 @@ const TRANSLATIONS = {
         "mc_done_title": "Daftar Selesai",
         // 心智圖 (Mind-map card on mission.html)
         "mm_card_title": "Peta Pikiran",
-        "mm_card_beta": "(beta · data tiruan)",
+        "mm_card_beta": "(beta)",
         "mm_card_expand": "Perluas",
         "mm_card_collapse": "Tutup",
-        "mm_card_hint": "52 simpul · 8 subsistem · 76 koneksi (termasuk lintas sistem). Perluas untuk menjelajah.",
+        "mm_card_hint": "Menghubungkan kartu kanban menjadi peta: tugas, sub-kartu, dan jangkar obrolan. Perluas untuk menjelajah.",
 
         "mc_notes_title": "Catatan",
         "mc_rules_title": "Aturan (Alur Kerja)",
@@ -34609,10 +34615,10 @@ const TRANSLATIONS = {
         "mc_done_title": "Liste Terminée",
         // 心智圖 (Mind-map card on mission.html)
         "mm_card_title": "Carte mentale",
-        "mm_card_beta": "(beta · données fictives)",
+        "mm_card_beta": "(beta)",
         "mm_card_expand": "Déplier",
         "mm_card_collapse": "Replier",
-        "mm_card_hint": "52 nœuds · 8 sous-systèmes · 76 liens (dépendances intersystèmes incluses). Déplier pour explorer.",
+        "mm_card_hint": "Vos fiches kanban en graphe : tâches, sous-fiches et ancrages de chat reliés. Dépliez pour explorer.",
 
         "mc_notes_title": "Notes",
         "mc_rules_title": "Règles (Flux de Travail)",
@@ -38688,10 +38694,10 @@ const TRANSLATIONS = {
         "mc_done_title": "Lista Completada",
         // 心智圖 (Mind-map card on mission.html)
         "mm_card_title": "Mapa mental",
-        "mm_card_beta": "(beta · datos simulados)",
+        "mm_card_beta": "(beta)",
         "mm_card_expand": "Expandir",
         "mm_card_collapse": "Contraer",
-        "mm_card_hint": "52 nodos · 8 subsistemas · 76 conexiones (incl. dependencias entre sistemas). Expande para explorar.",
+        "mm_card_hint": "Conecta las tarjetas del kanban en un grafo: tareas, sub-tarjetas y anclas de chat. Expande para explorar.",
 
         "mc_notes_title": "Notas",
         "mc_rules_title": "Reglas (Flujos de Trabajo)",
@@ -42735,10 +42741,10 @@ const TRANSLATIONS = {
         "mc_done_title": "Erledigt",
         // 心智圖 (Mind-map card on mission.html)
         "mm_card_title": "Mindmap",
-        "mm_card_beta": "(beta · Mock-Daten)",
+        "mm_card_beta": "(beta)",
         "mm_card_expand": "Aufklappen",
         "mm_card_collapse": "Zuklappen",
-        "mm_card_hint": "52 Knoten · 8 Subsysteme · 76 Verbindungen (inkl. systemübergreifender Abhängigkeiten). Aufklappen zum Erkunden.",
+        "mm_card_hint": "Verknüpft Ihre Kanban-Karten zu einer Karte: Aufgaben, Unterkarten und Chat-Anker. Aufklappen zum Erkunden.",
 
         "mc_notes_title": "Notizen",
         "mc_rules_title": "Regeln",
@@ -46815,10 +46821,10 @@ const TRANSLATIONS = {
         "mc_done_title": "Senarai Selesai",
         // 心智圖 (Mind-map card on mission.html)
         "mm_card_title": "Peta Minda",
-        "mm_card_beta": "(beta · data tiruan)",
+        "mm_card_beta": "(beta)",
         "mm_card_expand": "Buka",
         "mm_card_collapse": "Tutup",
-        "mm_card_hint": "52 nod · 8 subsistem · 76 sambungan (termasuk silang sistem). Buka untuk meneroka.",
+        "mm_card_hint": "Menghubungkan kad kanban menjadi peta: tugas, sub-kad, dan jangkar sembang. Buka untuk meneroka.",
 
         "mc_notes_title": "Nota",
         "mc_rules_title": "Aturan (Alur Kerja)",
@@ -51983,10 +51989,10 @@ const TRANSLATIONS = {
         "mc_done_title": "पूर्ण सूची",
         // 心智圖 (Mind-map card on mission.html)
         "mm_card_title": "माइंड मैप",
-        "mm_card_beta": "(beta · नकली डेटा)",
+        "mm_card_beta": "(beta)",
         "mm_card_expand": "विस्तार करें",
         "mm_card_collapse": "समेटें",
-        "mm_card_hint": "52 नोड · 8 सबसिस्टम · 76 लिंक (क्रॉस-सिस्टम सहित)। एक्सप्लोर करने के लिए विस्तार करें।",
+        "mm_card_hint": "कानबन कार्ड्स का मैप: कार्य, उप-कार्ड और चैट एंकर जुड़े। एक्सप्लोर करने के लिए विस्तार करें।",
 
         "mc_notes_title": "नोट्स",
         "mc_rules_title": "नियम (वर्कफ़्लो)",
@@ -57132,10 +57138,10 @@ const TRANSLATIONS = {
         "mc_done_title": "قائمة المكتمل",
         // 心智圖 (Mind-map card on mission.html)
         "mm_card_title": "الخريطة الذهنية",
-        "mm_card_beta": "(beta · بيانات وهمية)",
+        "mm_card_beta": "(beta)",
         "mm_card_expand": "توسيع",
         "mm_card_collapse": "طي",
-        "mm_card_hint": "52 عقدة · 8 أنظمة فرعية · 76 رابطًا (تشمل التبعيات بين الأنظمة). وسّع للاستكشاف.",
+        "mm_card_hint": "يربط بطاقات كانبان كرسم بياني: المهام والبطاقات الفرعية ومرابط الدردشة. وسّع للاستكشاف.",
 
         "mc_notes_title": "ملاحظات",
         "mc_rules_title": "القواعد (سير العمل)",


### PR DESCRIPTION
## Summary
Other users with <5 kanban cards were seeing the same 52-node demo seed (邀請系統 / Mac_E i18n agent / Mastodon 已棄用 / Hank-personal node names) — none of which is their data. Strip the seed entirely; each device now sees only its own work.

## What changed
- **`mission-mindmap.js`**: delete `MOCK_NODES` (52 nodes) + `MOCK_EDGES` (76 edges). `init()` routes empty data to a new `renderEmptyState()` that shows a centered 🧠 hint card + deep-link to `kanban.html`. SYS palette comment now documents change-cost + source authority per Hank's coding rule (group constants + comment why constant + source of truth).
- **`mission.html`**: drop the `>=5` fallback gate; pass through whatever `/api/mission/mindmap` returns. Replace stale `(beta · 模擬資料)` tag and the `52 個節點 · 8 子系統 · 76 條連線` hint with truthful copy.
- **`shared/i18n.js`**: rewrite `mm_card_beta` (now `(beta)`) + `mm_card_hint` across **all 13 locales** to remove the false numeric prefix + "mock data" lie. Add `mm_empty_title` / `mm_empty_hint` / `mm_empty_cta` for en + zh baselines; other locales fall back to inline default strings until a Hermes follow-up dispatch fans them out.

## Why
Hank's question 2026-04-29: *「心智圖是不是有 hardcoding 沒清掉？」* + follow-up *「如果是其他用戶 他們的心智圖是不是也會出現這些 hardcoding 我希望以後避免 hardcoding 都要使用變數 如果變數必須使用常數則歸在一類 並且註解寫清楚」*. Confirmed yes — every device with <5 cards saw the same demo seed shipped in `mission-mindmap.js`. Demo data does not belong in a production module disguised as a fallback.

## i18n.js coding-rule alignment
- Variable-first: UI copy → i18n key (mm_empty_*).
- Where constants are required: SYS palette grouped at top of `mission-mindmap.js`, with a comment block explaining (a) why constant (b) change-cost (c) source authority — palette is locked by Hank, reused by `info.html` + `roadmap.html` previews.
- No more demo data masquerading as fallback.

## Test plan
- [x] `node -c` syntax-check on `mission-mindmap.js` + `i18n.js`
- [x] `node backend/scripts/i18n-check.js` green (no missing keys)
- [x] Local Playwright harness (desktop 1280×720): empty-state shows 🧠 + 心智圖還沒有節點 hint + 前往看板 CTA → kanban.html (`mindmap-empty-state-desktop.png`)
- [x] Local Playwright harness (mobile 390×844): empty-state stacks correctly (`mindmap-empty-state-mobile.png`)
- [x] Local Playwright harness (seeded 6-node dataset): regular cytoscape graph still renders with sys-rail counts + cross-system dashed edges (`mindmap-seeded-render-desktop.png`)
- [ ] Prod E2E after merge — verify a fresh device with 0 cards sees empty-state (no MOCK leak)

## Follow-up
- Dispatch Hermes (#5) to fan out `mm_empty_title` / `mm_empty_hint` / `mm_empty_cta` to the remaining 11 locales (ja/ko/th/vi/id/fr/es/de/ms/hi/ar + zh-CN). JS fallback covers them in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)