### PR TITLE
chore: scheduled audit — CLAUDE.md update, fix test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,8 +198,8 @@ EClaw/
 │   ├── go/                        # Go SDK
 │   └── rust/                      # Rust SDK
 ├── docs/
-│   ├── plans/                     # Design documents (23 files)
-│   ├── reports/                   # Test & analysis reports (8 files)
+│   ├── plans/                     # Design documents (42 files)
+│   ├── reports/                   # Test & analysis reports (20 files)
 │   └── issues/                    # Issue documentation (4 files)
 ├── .github/workflows/
 │   ├── backend-ci.yml             # Backend lint + Jest tests
@@ -1000,6 +1000,12 @@ curl "https://eclawbot.com/api/device-telemetry?deviceId=ID&deviceSecret=SECRET&
 - **i18n Cron-Notify Fix (v1.1117)**: EN labels for cron-notify keys no longer leak CJK 母卡
 - **Telegram Adapter PoC (v1.1121, reverted)**: Long-poll Telegram adapter attempted then reverted
 - **App Version**: Updated to 1.0.79 (versionCode 85)
+
+### Recent Features (v1.1122.x – v1.1123.x)
+
+- **Mindmap Empty-State for Fresh Devices (v1.1123)**: Ripped `MOCK_NODES`/`MOCK_EDGES` seed data; mindmap now renders an empty-state UI for fresh devices instead of mock content (#2246)
+- **Kanban Cron-Spawn Child Inheritance (v1.1122)**: Cron-spawned child cards inherit `requires_screenshot_review` flag from parent; mom card edit toggle for screenshot review setting (#2245)
+- **Mindmap Phase 4 Read-Side (v1.1122)**: `/api/mission/mindmap` honors `chat_anchor_coord` for read-side rendering, connecting mindmap nodes to chat anchor positions (#2244)
 
 ---
 

--- a/backend/tests/jest/transform-delivery.test.js
+++ b/backend/tests/jest/transform-delivery.test.js
@@ -25,7 +25,7 @@ let app;
 // INSERT assertions can still scan them after clearMocks runs.
 const pgPoolSnapshot = [];
 
-const post = (path) => request(app).post(path).set('Host', 'localhost');
+const post = (path) => request(app).post(path).set('Host', 'localhost').set('Accept-Encoding', 'identity');
 
 /** Register + bind entity, return botSecret */
 async function bindEntity(deviceId, deviceSecret, entityId = 0) {
@@ -45,7 +45,8 @@ async function bindEntity(deviceId, deviceSecret, entityId = 0) {
 async function getPublicCode(deviceId, deviceSecret, entityId) {
     const res = await request(app).get('/api/entities')
         .query({ deviceId, deviceSecret })
-        .set('Host', 'localhost');
+        .set('Host', 'localhost')
+        .set('Accept-Encoding', 'identity');
     const entity = (res.body.entities || []).find(e => e.entityId === entityId);
     return entity ? entity.publicCode : null;
 }


### PR DESCRIPTION
## Summary
- Update stale doc counts in CLAUDE.md (plans: 23→42, reports: 8→20)
- Add Recent Features section for v1.1122.x–v1.1123.x
- Fix intermittent `Parse Error` in `transform-delivery.test.js` by setting `Accept-Encoding: identity`

## Test plan
- [x] All 146 Jest suites pass (2412/2412 tests)
- [x] No new test failures introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)