### PR TITLE
feat(info): SEO meta swap for vector-memory + 4 marketing hook panels

### DIFF
--- a/backend/public/portal/shared/info.js
+++ b/backend/public/portal/shared/info.js
@@ -161,6 +161,12 @@ const SEO_META = {
     'usecase-claude-openclaw':     { title: 'Claude / OpenClaw Bot',   desc: 'Run Claude or OpenClaw-engine bots on EClawbot.' },
     'usecase-messaging-friends':   { title: 'Messaging Friends',       desc: 'Chat with other EClawbot users and their bots.' },
     'usecase-voice-tts':           { title: 'Voice / TTS',             desc: 'Voice and text-to-speech features for EClawbot agents.' },
+    // Marketing hooks
+    'vector-memory':               { title: 'Vector Memory',           desc: 'Semantic memory that breaks the context window, shares knowledge across bots, and cites its sources.' },
+    'passive-income':              { title: 'Idle Bot, Earn e-Coin',   desc: 'Rent out your idle EClawbot agents and earn e-coins while you sleep.' },
+    'rent-to-use':                 { title: 'Rent Big-Model Power',    desc: 'Rent powerful AI agents on EClawbot — no key, no setup, pay only for what you use.' },
+    'credit-swap':                 { title: 'Time Bank',               desc: 'Trade idle bot time for active bot time — the EClawbot time-banking system.' },
+    'arena-intro':                 { title: 'Interview Arena',         desc: 'Standardized 12-test, 147-point benchmark for AI agent capabilities — perception, interaction, reasoning, safety, memory, speed.' },
     // Mission sub-pages
     'mission-overview':            { title: 'Mission Overview',        desc: 'How EClawbot mission cards, kanban, and auto-crons fit together.' },
 };


### PR DESCRIPTION
## Summary
- Extends per-panel SEO swap (#2249) with five sidebar panels missing from `SEO_META`: `vector-memory`, `passive-income`, `rent-to-use`, `credit-swap`, `arena-intro`
- Hash deep-links to these panels now preview the right title/description on social shares (og:* + twitter:* + document.title)
- Closes card_f69b4cb73e4fe2124f6dcac5 — vector-memory archive panel was already shipped via #1967, refined by #2139, EN/zh/ja keys present in shared/i18n.js. ko + de delegated separately to Hermes.

## Test plan
- [x] Live verify: navigate to `#guide/vector-memory` → EN copy renders correctly (3 selling points + tech section + CTA)
- [x] After this PR: `document.title` becomes "Vector Memory · EClawbot" instead of generic "User Guide · EClawbot" when hash is `#guide/vector-memory`
- [x] Backwards compatible — keys absent from SEO_META are no-ops (same fallback as before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)