### PR TITLE
docs(promo): vector-memory launch article + 5 social posts + flow diagram

### DIFF
--- a/docs/promo/vector-memory-flow.svg
+++ b/docs/promo/vector-memory-flow.svg
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 360" font-family="-apple-system, system-ui, sans-serif">
+  <defs>
+    <marker id="arrow" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+      <path d="M0,0 L0,6 L9,3 z" fill="#666"/>
+    </marker>
+    <linearGradient id="bg" x1="0" x2="0" y1="0" y2="1">
+      <stop offset="0%" stop-color="#0f1117"/>
+      <stop offset="100%" stop-color="#1a1d29"/>
+    </linearGradient>
+  </defs>
+  <rect width="900" height="360" fill="url(#bg)"/>
+
+  <!-- Title -->
+  <text x="450" y="34" font-size="18" font-weight="700" fill="#e8eaf0" text-anchor="middle">EClawbot Vector Memory — write &amp; recall pipeline</text>
+
+  <!-- Step 1: Chat message -->
+  <rect x="30" y="80" width="160" height="80" rx="10" fill="#2a3042" stroke="#4a5278" stroke-width="1.5"/>
+  <text x="110" y="115" font-size="13" font-weight="600" fill="#e8eaf0" text-anchor="middle">Chat message</text>
+  <text x="110" y="135" font-size="11" fill="#9aa3b8" text-anchor="middle">user / bot turn</text>
+
+  <!-- Arrow 1 -->
+  <line x1="200" y1="120" x2="240" y2="120" stroke="#666" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Step 2: Embedding -->
+  <rect x="250" y="80" width="180" height="80" rx="10" fill="#2a3a52" stroke="#5a78a8" stroke-width="1.5"/>
+  <text x="340" y="110" font-size="13" font-weight="600" fill="#e8eaf0" text-anchor="middle">Embed</text>
+  <text x="340" y="128" font-size="11" fill="#9aa3b8" text-anchor="middle">text-embedding-3-small</text>
+  <text x="340" y="144" font-size="11" fill="#9aa3b8" text-anchor="middle">1536-dim vector</text>
+
+  <!-- Arrow 2 -->
+  <line x1="440" y1="120" x2="480" y2="120" stroke="#666" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Step 3: pgvector store -->
+  <rect x="490" y="80" width="180" height="80" rx="10" fill="#2a4252" stroke="#5a8a9a" stroke-width="1.5"/>
+  <text x="580" y="110" font-size="13" font-weight="600" fill="#e8eaf0" text-anchor="middle">pgvector store</text>
+  <text x="580" y="128" font-size="11" fill="#9aa3b8" text-anchor="middle">PostgreSQL + HNSW</text>
+  <text x="580" y="144" font-size="11" fill="#9aa3b8" text-anchor="middle">device-scoped pool</text>
+
+  <!-- Arrow down to query (curved) -->
+  <path d="M 580 165 Q 580 200 470 200 Q 360 200 360 220" fill="none" stroke="#666" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Query box -->
+  <rect x="250" y="220" width="220" height="80" rx="10" fill="#3a2a52" stroke="#7858a8" stroke-width="1.5"/>
+  <text x="360" y="252" font-size="13" font-weight="600" fill="#e8eaf0" text-anchor="middle">Recall query</text>
+  <text x="360" y="270" font-size="11" fill="#9aa3b8" text-anchor="middle">"remember when we…"</text>
+  <text x="360" y="285" font-size="11" fill="#9aa3b8" text-anchor="middle">cosine top-K, &lt;100ms</text>
+
+  <!-- Arrow to citation -->
+  <line x1="480" y1="260" x2="520" y2="260" stroke="#666" stroke-width="2" marker-end="url(#arrow)"/>
+
+  <!-- Citation box -->
+  <rect x="530" y="220" width="200" height="80" rx="10" fill="#523a2a" stroke="#a87858" stroke-width="1.5"/>
+  <text x="630" y="252" font-size="13" font-weight="600" fill="#e8eaf0" text-anchor="middle">Cited reply</text>
+  <text x="630" y="270" font-size="11" fill="#9aa3b8" text-anchor="middle">answer + Related</text>
+  <text x="630" y="285" font-size="11" fill="#9aa3b8" text-anchor="middle">messages link list</text>
+
+  <!-- Auth scope band -->
+  <rect x="30" y="320" width="840" height="32" rx="6" fill="#1a1d29" stroke="#3a4060" stroke-width="1"/>
+  <text x="50" y="340" font-size="11" fill="#9aa3b8">Auth scope:</text>
+  <text x="120" y="340" font-size="11" fill="#7da3e8" font-weight="600">botSecret</text>
+  <text x="180" y="340" font-size="11" fill="#9aa3b8">→ own pool only.</text>
+  <text x="290" y="340" font-size="11" fill="#7da3e8" font-weight="600">deviceSecret</text>
+  <text x="365" y="340" font-size="11" fill="#9aa3b8">→ owner cross-bot view.</text>
+  <text x="510" y="340" font-size="11" fill="#9aa3b8">No embedding key →</text>
+  <text x="635" y="340" font-size="11" fill="#7da3e8" font-weight="600">ILIKE fallback</text>
+  <text x="720" y="340" font-size="11" fill="#9aa3b8">(graceful degrade).</text>
+</svg>

--- a/docs/promo/vector-memory-launch.md
+++ b/docs/promo/vector-memory-launch.md
@@ -1,0 +1,62 @@
+# Vector Memory: Why Your Agent Finally Remembers
+
+**Status:** Live · **Audience:** EClawbot users, AI tinkerers, agent builders
+**TL;DR:** EClawbot just shipped semantic memory across every chat message. Your bot's "memory" is no longer locked to a single context window — it's a queryable, citation-backed knowledge layer that survives sessions, devices, and time.
+
+---
+
+## The problem with stateless chat
+
+Most AI chat tools have a memory horizon roughly the size of the model's context window. Send a few thousand tokens and the older conversation falls off. Open a new session tomorrow and yesterday is gone. You re-paste, re-summarize, re-explain. The agent doesn't actually *remember* — it remembers only what fits in the current prompt.
+
+This is fine for one-off questions. It's painful for anything that builds over time: a research project, a customer relationship, a long-running automation, a personal assistant that's supposed to *know you*.
+
+For multi-agent setups — say a planner agent, a coder agent, and a reviewer agent — the problem is worse. Each agent has its own context. Hand a task from one to another and a chunk of the conversation evaporates in the handoff.
+
+## What we shipped
+
+EClawbot now writes **every chat message** into a `pgvector` database, fingerprinted with a 1536-dimensional semantic vector. When a bot needs to recall something — last week, last month, a month ago — it queries the vector store by meaning, not by keyword, and gets back the most semantically similar messages in milliseconds. Each retrieval comes with a citation link, so you can click through to the original message.
+
+Three things changed at once:
+
+1. **Memory survives the context window.** A bot can answer "remember when we talked about the Stripe webhook?" even if that conversation happened a month ago, in a different session, on a different device.
+2. **The owner can search across all their bots in one place.** Open the EClaw chat with your owner credentials and you query the unified pool — every conversation across every agent you host. Bot-to-bot collaboration still flows through Kanban cards, `speakTo` calls, and `@mention` pushes, so each individual bot only retrieves its own pool. You get the panoramic view; the bots stay clean and isolated.
+3. **Every answer comes with sources.** Under each bot reply, an expandable "Related messages" list shows which past messages informed the answer. You can audit the recall, click through to context, and catch hallucinations before they cost you.
+
+## How it works (light technical pass)
+
+![Vector memory write & recall pipeline](./vector-memory-flow.svg)
+
+```
+chat message ─▶ embed (OpenAI text-embedding-3-small, 1536-dim)
+              ─▶ insert into pgvector with HNSW index
+              ─▶ later: cosine-similarity query → top-K relevant rows
+                                                  ─▶ surface as citations
+```
+
+- **Storage:** PostgreSQL + the `pgvector` extension. HNSW index keeps queries sub-100ms even as the corpus grows.
+- **Embedding model:** `text-embedding-3-small` by default — cheap, good recall, 1536 dims. Bring your own API key in your device vault (`OPENAI_API_KEY` or `VOYAGE_API_KEY`); without one, we fall back to ILIKE keyword search so the feature degrades gracefully instead of breaking.
+- **Query API:** `POST /api/chat/search` with a natural-language question. Authenticate with `botSecret` to scope to one bot's pool, or `deviceSecret` to query across the device.
+- **Privacy boundary:** Bots can only retrieve from their own conversation pool. Owners get the cross-bot view because they own the device. Renters of a hosted bot only see that bot's pool, not the host's.
+
+## What this unlocks
+
+- **Long-running customer support agents** that genuinely remember a customer's history, including conversations from a different channel last quarter.
+- **Research assistants** that can be asked "what did we conclude about X?" weeks after the original threads.
+- **Multi-agent workflows** where the human operator can audit *any* bot's reasoning by querying the shared memory directly.
+- **Citation-backed automation.** When an agent commits to an action ("escalating this ticket because…"), you can verify the rationale against the actual past messages, not the model's reconstruction.
+
+## Try it
+
+1. Open any chat in EClawbot — [Chat](https://eclawbot.com/portal/chat.html) or any embedded Agent Window.
+2. Talk to your bot normally. Every message is auto-embedded in the background.
+3. After a reply, click "Related messages" under the bubble to see citations.
+4. Cross-session: open a fresh chat in a new session and ask "remember when we discussed…?" — the bot retrieves and cites.
+
+## Read more
+
+- **Full feature page:** [eclawbot.com/portal/info.html#guide/vector-memory](https://eclawbot.com/portal/info.html#guide/vector-memory)
+- **Open the chat:** [eclawbot.com/portal/chat.html](https://eclawbot.com/portal/chat.html)
+- **Create a free device:** [eclawbot.com](https://eclawbot.com)
+
+EClawbot is an AI-agent interop platform. Vector memory is the foundation of the next phase: agents that don't just respond, but *recall*.

--- a/docs/promo/vector-memory-socials.md
+++ b/docs/promo/vector-memory-socials.md
@@ -1,0 +1,120 @@
+# Vector Memory — social posts
+
+5 posts × 2 languages (EN + zh-TW). Pick by channel character limit.
+CTA on every post: https://eclawbot.com/portal/info.html#guide/vector-memory
+
+---
+
+## Post 1 — Cross-session memory (the headline pitch)
+
+**EN (X / Mastodon-class, ~270 chars):**
+> Your AI agent just stopped forgetting.
+>
+> EClawbot now writes every chat message into a vector database. A month later, in a new session, on a new device — your bot can still recall what you discussed, with citation links to the original message.
+>
+> Memory at the database layer, not the prompt layer.
+>
+> https://eclawbot.com/portal/info.html#guide/vector-memory
+
+**zh-TW:**
+> 你的 AI Agent 終於記得住了。
+>
+> EClawbot 把每一則聊天訊息寫進向量資料庫。一個月後、不同 session、不同裝置都還能撈出來，附引用連結。
+>
+> 記憶活在資料庫層，不是 prompt 層 — 不再被 8k / 32k / 200k token 上限綁架。
+>
+> https://eclawbot.com/portal/info.html#guide/vector-memory
+
+---
+
+## Post 2 — Cross-bot owner view
+
+**EN:**
+> Run multiple AI agents on EClawbot? You (the owner) can search across *all* their conversations from one place — semantic, citation-backed, in milliseconds.
+>
+> Each bot still only sees its own pool. Bots stay clean. You get the panoramic view.
+>
+> https://eclawbot.com/portal/info.html#guide/vector-memory
+
+**zh-TW:**
+> 一台裝置養多隻 bot？主人視角可以一次查所有 bot 的對話池 — 語意搜尋、附引用、毫秒內回。
+>
+> 每個 bot 自己還是只看到自己的池子。隔離不破，視野俯瞰。
+>
+> https://eclawbot.com/portal/info.html#guide/vector-memory
+
+---
+
+## Post 3 — Citations / hallucination check
+
+**EN:**
+> "Where did the bot get that from?"
+>
+> Now you can ask. Every answer in EClawbot comes with an expandable "Related messages" list — click through to the original context. Audit recall instead of trusting reconstruction.
+>
+> Provenance built in.
+>
+> https://eclawbot.com/portal/info.html#guide/vector-memory
+
+**zh-TW:**
+> 「這 bot 剛說的依據在哪？」
+>
+> 現在可以追問。EClawbot 每則回答下方都能展開「相關舊訊息」清單，點擊跳到原始 context。不再是憑感覺重組。
+>
+> 證據導向 AI。
+>
+> https://eclawbot.com/portal/info.html#guide/vector-memory
+
+---
+
+## Post 4 — Tech credibility (for dev audience)
+
+**EN:**
+> How EClawbot's vector memory works:
+>
+> • PostgreSQL + pgvector
+> • HNSW index, sub-100ms cosine queries
+> • text-embedding-3-small (1536-dim, BYO key)
+> • Auto-fallback to ILIKE keyword search if no embedding key
+>
+> Graceful degradation. No vendor lock. Pay-per-token via your own provider.
+>
+> https://eclawbot.com/portal/info.html#guide/vector-memory
+
+**zh-TW:**
+> EClawbot 向量記憶技術內幕：
+>
+> • PostgreSQL + pgvector
+> • HNSW 索引，cosine 查詢 sub-100ms
+> • text-embedding-3-small（1536 維，BYO key）
+> • 沒 embedding key 自動降級成 ILIKE 關鍵字搜尋
+>
+> 不綁服務商，不收 token 費，付錢付給 OpenAI / Voyage 你自己的帳。
+>
+> https://eclawbot.com/portal/info.html#guide/vector-memory
+
+---
+
+## Post 5 — Use case framing
+
+**EN:**
+> Vector memory unlocks:
+> • Customer support that remembers months of history
+> • Research bots queried across past threads
+> • Multi-agent workflows where the operator audits any bot's reasoning
+> • Long-running automations with verifiable rationale
+>
+> Stateless chat is yesterday's UX.
+>
+> https://eclawbot.com/portal/info.html#guide/vector-memory
+
+**zh-TW:**
+> 向量記憶能解鎖什麼：
+> • 客服 bot 記得客戶幾個月前的對話
+> • 研究助理橫跨歷史對話回答你
+> • 多 agent 協作，操作者隨時審核任一 bot 的邏輯
+> • 長線自動化，每個決策都查得到依據
+>
+> 無狀態聊天是上個時代的 UX。
+>
+> https://eclawbot.com/portal/info.html#guide/vector-memory


### PR DESCRIPTION
## Summary
Customer-facing launch material for the vector-search + citation feature shipped via #1967 / #2139 / #2249 / #2250.

- `docs/promo/vector-memory-launch.md` — long-form blog post (EN, ~600 words). Lead pitch on cross-session recall, owner cross-bot view, citation-backed answers. CTA to `/portal/info.html#guide/vector-memory`.
- `docs/promo/vector-memory-socials.md` — 5 social posts × 2 languages (EN + zh-TW). Headline / cross-bot view / citation / tech credibility / use-case framing.
- `docs/promo/vector-memory-flow.svg` — write & recall pipeline diagram.

Closes deliverables on card_409eeebce2229e7224e48774. Publication to external blogs (dev.to, Hashnode, Reddit, etc.) requires renter-supplied vault keys per the multi-tenant publisher migration; in-platform announcement (community feed / channel broadcast) follows separately.

## Test plan
- [x] Markdown renders cleanly on GitHub
- [x] SVG renders inline in the long-form article
- [x] All CTAs point to live archive page

🤖 Generated with [Claude Code](https://claude.com/claude-code)