### PR TITLE
fix(publisher): Qiita locale defaults to ja (was zh-TW)

### DIFF
--- a/backend/article-publisher.js
+++ b/backend/article-publisher.js
@@ -220,6 +220,12 @@ const REFERRAL_CTA_COPY = {
         rewards: 'You get +100 e-coins / I get +500 / First top-up +500 bonus',
         cta: 'Claim your bonus',
         disclaimer: 'This link goes to the official EClaw invite page'
+    },
+    ja: {
+        header: '— この記事が気に入ったら、招待コードで EClaw を始めよう —',
+        rewards: '招待した人 +500 e-coin / 招待された人 +100 e-coin / 初回チャージで +500 ボーナス',
+        cta: '招待ページを開く',
+        disclaimer: 'このリンクは EClaw 公式の招待ページに移動します'
     }
 };
 
@@ -1539,7 +1545,7 @@ router.post('/qiita/publish', express.json(), async (req, res) => {
         const { token, source } = await resolveQiitaCreds(deviceId || null);
         if (!token) return res.status(400).json(QIITA_CREDS_MISSING);
 
-        const finalBody = appendReferralCTA(body, { format: 'md', skip: includeReferralCTA === false });
+        const finalBody = appendReferralCTA(body, { format: 'md', locale: 'ja', skip: includeReferralCTA === false });
         const item = {
             title,
             body: finalBody,


### PR DESCRIPTION
## Summary
- Hank flagged a live Qiita post with a **Chinese** referral CTA at the bottom — Qiita is Japanese.
- Root cause: `/qiita/publish` called `appendReferralCTA` without a `locale` arg → fell back to `'zh-TW'` default.
- Fix: add `ja` copy to `REFERRAL_CTA_COPY` + pin `locale: 'ja'` on the Qiita route.

## Test plan
- [x] Live re-publish of card_2a45e506 article confirms Qiita footer is now Japanese.
- [ ] Visual smoke: next Qiita publish reads `招待ページを開く` instead of `開啟邀請頁`.
- [ ] No regression on DEV.to / Hashnode (already pinned `en`).

Closes card_00f4c8899c3a27ac53dcba3d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)