### PR TITLE
feat(chip): smart-chip cross-pane requote (closes card_f60efb51)

### DIFF
--- a/backend/public/portal/shared/autolink-chip-preview.js
+++ b/backend/public/portal/shared/autolink-chip-preview.js
@@ -99,6 +99,7 @@
         pop._refId = refId;
         pop._data = null;
         pop._depth = stack.length;
+        pop._anchorEl = anchorEl;
         pop.innerHTML = buildLoadingHtml();
         document.body.appendChild(pop);
         positionPopover(pop, anchorEl);
@@ -226,7 +227,7 @@
                 if (idx >= 0) closeFromIndex(idx);
                 return;
             }
-            if (action === 'requote') { insertRequoteToken(pop._data, pop._refType, pop._refId); closeAll(); return; }
+            if (action === 'requote') { insertRequoteToken(pop._data, pop._refType, pop._refId, pop._anchorEl || rootAnchor); closeAll(); return; }
         });
     }
 
@@ -244,10 +245,7 @@
         setTimeout(() => { tip.remove(); }, 1800);
     }
 
-    function insertRequoteToken(data, refType, refId) {
-        const token = tokenFor(data, refType, refId);
-        const input = document.getElementById('messageInput') || document.querySelector('textarea, [contenteditable="true"]');
-        if (!input) return;
+    function insertRequoteTokenIntoInput(input, token) {
         if (input.tagName === 'TEXTAREA' || input.tagName === 'INPUT') {
             const cur = input.value || '';
             const pos = input.selectionStart != null ? input.selectionStart : cur.length;
@@ -263,6 +261,37 @@
             document.execCommand && document.execCommand('insertText', false, token + ' ');
         }
     }
+
+    function insertRequoteToken(data, refType, refId, anchorEl) {
+        const token = tokenFor(data, refType, refId);
+        const input = document.getElementById('messageInput') || document.querySelector('textarea, [contenteditable="true"]');
+        if (input) {
+            insertRequoteTokenIntoInput(input, token);
+            return;
+        }
+        // No local chat input — try cross-pane relay (workspace split-view).
+        // Source page posts to its parent; workspace forwards to the chat iframe.
+        if (window.parent && window.parent !== window) {
+            try {
+                window.parent.postMessage(
+                    { type: 'eclaw_requote', token, refType, refId },
+                    window.location.origin
+                );
+                showToast(anchorEl, t('chip_popover_requoted', '已引用'));
+            } catch (_) {}
+        }
+    }
+
+    // Receive cross-pane requote (chat iframe side). Workspace forwards
+    // 'eclaw_requote' here; insert into messageInput if present.
+    window.addEventListener('message', (e) => {
+        if (e.origin !== window.location.origin) return;
+        if (!e.data || e.data.type !== 'eclaw_requote') return;
+        const input = document.getElementById('messageInput');
+        if (input && typeof e.data.token === 'string') {
+            insertRequoteTokenIntoInput(input, e.data.token);
+        }
+    });
 
     function tokenFor(data, refType, refId) {
         if (data && data.kind === 'card' && data.data && data.data.id) {

--- a/backend/public/portal/workspace.html
+++ b/backend/public/portal/workspace.html
@@ -396,13 +396,22 @@
 
     window.addEventListener('message', (e) => {
         if (e.origin !== window.location.origin) return;
-        if (!e.data || e.data.type !== 'eclaw_quote') return;
-        const chatPane = _getChatPane();
-        if (chatPane) {
-            chatPane.contentWindow.postMessage(e.data, window.location.origin);
-        } else {
-            // Fallback: chat pane not open — persist so it picks up on next open
-            localStorage.setItem('eclaw_pending_quote', JSON.stringify({ ...e.data, ts: Date.now() }));
+        if (!e.data) return;
+        if (e.data.type === 'eclaw_quote') {
+            const chatPane = _getChatPane();
+            if (chatPane) {
+                chatPane.contentWindow.postMessage(e.data, window.location.origin);
+            } else {
+                // Fallback: chat pane not open — persist so it picks up on next open
+                localStorage.setItem('eclaw_pending_quote', JSON.stringify({ ...e.data, ts: Date.now() }));
+            }
+            return;
+        }
+        if (e.data.type === 'eclaw_requote') {
+            // Smart-chip 📌 from a non-chat pane — forward to chat pane if open.
+            const chatPane = _getChatPane();
+            if (chatPane) chatPane.contentWindow.postMessage(e.data, window.location.origin);
+            return;
         }
     });
 

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -3198,6 +3198,7 @@ const TRANSLATIONS = {
         "chip_popover_open_full": "Open full page →",
         "chip_popover_cycle": "Already in the reference stack",
         "chip_popover_too_deep": "Too deep — open the full page instead",
+        "chip_popover_requoted": "Quoted into chat",
 
         // Compare Channels (compare-channels.html)
         "cmp_title": "EClawbot vs Telegram - Channel Comparison",
@@ -7991,6 +7992,7 @@ const TRANSLATIONS = {
         "chip_popover_open_full": "打開完整頁面 →",
         "chip_popover_cycle": "已在引用堆疊上",
         "chip_popover_too_deep": "太深，請直接跳頁",
+        "chip_popover_requoted": "已引用至聊天",
         "cmp_title": "EClawbot vs Telegram — 頻道比較",
         "cmp_eclaw_name": "EClawbot",
         "cmp_telegram_name": "Telegram",


### PR DESCRIPTION
## Summary
- 📌 in autolink-chip popover used to fail silently from non-chat panes (no `#messageInput` on source page).
- Now: `insertRequoteToken` postMessages `eclaw_requote` to `window.parent` when no local input.
- workspace.html relay forwards to the chat iframe pane, mirroring the existing `eclaw_quote` pattern.
- Source page shows a transient "已引用 / Quoted into chat" toast.
- Standalone (non-workspace) pages unchanged.

## Files
- `backend/public/portal/shared/autolink-chip-preview.js` — extract `insertRequoteTokenIntoInput`, add cross-pane fallback, add chat-side `eclaw_requote` listener, store `pop._anchorEl` for toast positioning.
- `backend/public/portal/workspace.html` — relay forwards `eclaw_requote` to chat iframe alongside `eclaw_quote`.
- `backend/public/shared/i18n.js` — `chip_popover_requoted` key for en + zh-TW (other 11 locales pending Hermes batch).

## Tests
- `backend/tests/jest/autolink-chip.test.js` — 11/11 pass (no signature change to public API).
- Manual verification: TODO via Playwright on workspace split-view in next loop tick.

## Closes
- card_f60efb51 [功能增強] 智慧引用：分割畫面已開聊天時改塞子畫面 + 來源頁浮動 toast

## Follow-up
- File i18n card for `chip_popover_requoted` × 11 remaining locales (Hermes batch when daemon recovers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)