### PR TITLE
fix: match help api category intents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1165,7 +1165,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | Server Logs | `tests/jest/server-logs.test.js` | GET /api/logs and GET /api/audit-logs — auth, query filters, limit enforcement |
 | Channel API | `tests/jest/channel-api.test.js` | Channel provision, register, bind, message, test-sink — auth, CRUD lifecycle |
 | OAuth Server | `tests/jest/oauth-server.test.js` | OAuth client registration, token endpoint, revoke (RFC 7009), introspect (RFC 7662) |
-| Device Vars | `tests/jest/device-vars.test.js` | Environment variables POST/GET/DELETE — auth, encryption, bot access |
+| Device Vars + Help | `tests/jest/device-vars.test.js` | Environment variables POST/GET/DELETE — auth, encryption, bot access; `/api/help` category matching |
 | Cross-Speak | `tests/jest/cross-speak.test.js` | Cross-device entity messaging, client cross-speak, pending queue — auth, validation |
 | Cross-Speak Channel | `tests/jest/cross-speak-channel.test.js` | Cross-speak channel push parity — entity/client cross-speak channel-bound delivery |
 | Link Preview | `tests/jest/link-preview.test.js` | Link preview OG tag extraction, URL validation, SSRF protection, timeout handling |

--- a/backend/index.js
+++ b/backend/index.js
@@ -756,6 +756,7 @@ if (process.env.NODE_ENV !== 'test') {
 // Per-route limiters already exist in bot-tools.js, growth.js, channel-api.js;
 // the limits below are additive and not intended to override them.
 const rateLimit = require('express-rate-limit');
+const { ipKeyGenerator } = rateLimit;
 const rateLimitDisabled = () =>
     process.env.NODE_ENV === 'test' && process.env.ENABLE_RATE_LIMIT_IN_TEST !== '1';
 
@@ -795,7 +796,7 @@ const messageLimiter = rateLimit({
     // before it reaches route validation).
     keyGenerator: (req) => {
         const deviceId = (req.body && req.body.deviceId) || null;
-        return deviceId ? `dev:${deviceId}` : `ip:${req.ip}`;
+        return deviceId ? `dev:${deviceId}` : `ip:${ipKeyGenerator(req.ip)}`;
     },
     skip: () => rateLimitDisabled(),
     message: { success: false, error: 'Too many messages — slow down' },
@@ -1361,8 +1362,8 @@ app.get('/api/help', (req, res) => {
         analytics:  ['analytics','growth','metrics','signup','retention','kpi','viral','k-value','成長','指標','留存','分析','회귀','분석','지표','メトリクス','分析','指標']
     };
 
-    const matched = Object.entries(INTENT_MAP).find(([, kws]) =>
-        kws.some(kw => q.includes(kw))
+    const matched = Object.entries(INTENT_MAP).find(([category, kws]) =>
+        q === category || q.includes(category) || kws.some(kw => q.includes(kw))
     )?.[0] ?? 'general';
 
     const d = `'{"deviceId":"${deviceId}","botSecret":"${botSecret}","entityId":${eId}`; // shared body prefix

--- a/backend/tests/jest/device-vars.test.js
+++ b/backend/tests/jest/device-vars.test.js
@@ -679,5 +679,19 @@ describe('GET /api/help — vault category', () => {
         expect(res.body.curl_examples).toContain('/api/device-vars/audit');
         expect(res.body.curl_examples).toContain('YES_DELETE_ALL_VAULT');
     });
-});
 
+    it('matches exact category names such as messaging', async () => {
+        const devId = `help-category-${Date.now()}`;
+        const secret = await registerDevice(devId);
+
+        const regRes = await post('/api/device/register').send({ deviceId: devId, deviceSecret: secret, entityId: 0 });
+        const bindRes = await post('/api/bind').send({ code: regRes.body.bindingCode });
+        const botSecret = bindRes.body.botSecret;
+
+        const res = await get(`/api/help?deviceId=${devId}&botSecret=${botSecret}&entityId=0&intent=messaging`);
+        expect(res.status).toBe(200);
+        expect(res.body.matched_category).toBe('messaging');
+        expect(res.body.curl_examples).toContain('/api/transform');
+        expect(res.body.curl_examples).toContain('speakTo');
+    });
+});


### PR DESCRIPTION
## Summary
- Fix /api/help intent routing so exact category names like messaging, entities, files, notes, and vault match their own category instead of falling through to general.
- Use express-rate-limit's ipKeyGenerator for message limiter IP fallback to remove the IPv6 validation warning in tests.
- Add regression coverage for /api/help?intent=messaging and update the regression test index.

## Verification
- node --check backend/index.js
- cd backend && npx jest tests/jest/device-vars.test.js tests/jest/rate-limit.test.js tests/jest/channel-api.test.js --runInBand
- cd backend && npm run lint (passes with 7 existing warnings)