### PR TITLE
fix: treat Railway as production for persistence

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -8,6 +8,10 @@ const { Pool } = require('pg');
 // Database connection pool
 let pool = null;
 
+function isProductionRuntime() {
+    return process.env.NODE_ENV === 'production' || Boolean(process.env.RAILWAY_ENVIRONMENT);
+}
+
 function shouldUseSsl(connectionString) {
     const sslMode = (process.env.PGSSLMODE || '').toLowerCase();
     if (sslMode === 'disable') return false;
@@ -24,7 +28,7 @@ function shouldUseSsl(connectionString) {
         // Fall through to the production default for non-URL connection strings.
     }
 
-    return process.env.NODE_ENV === 'production'
+    return isProductionRuntime()
         ? { rejectUnauthorized: false }
         : false;
 }

--- a/backend/index.js
+++ b/backend/index.js
@@ -661,6 +661,9 @@ const SCRIPT_VERSION = (
     String(Date.now())
 ).slice(0, 12);
 
+const isProductionRuntime = () =>
+    process.env.NODE_ENV === 'production' || Boolean(process.env.RAILWAY_ENVIRONMENT);
+
 const _PORTAL_HTML_DIR = path.join(__dirname, 'public/portal');
 const _SHARED_SRC_RE = /<script(\s[^>]*?)?\ssrc=(["'])((?:\.\.\/)?shared\/[^"']+?\.js)(\?[^"']*)?\2([^>]*)><\/script>/g;
 
@@ -1124,7 +1127,7 @@ async function initPersistence() {
     if (usePostgreSQL) {
         console.log('[Persistence] Using PostgreSQL (primary)');
     } else {
-        if (process.env.NODE_ENV === 'production' && process.env.DATABASE_URL) {
+        if (isProductionRuntime() && process.env.DATABASE_URL) {
             throw new Error('PostgreSQL persistence unavailable in production; refusing file-storage fallback');
         }
         console.log('[Persistence] Using file storage (fallback)');
@@ -4934,7 +4937,7 @@ app.get('/api/health', (req, res) => {
     const persistenceHealth = {
         mode: usePostgreSQL ? 'postgresql' : 'file',
         postgresql: usePostgreSQL,
-        productionRequiresPostgresql: Boolean(process.env.NODE_ENV === 'production' && process.env.DATABASE_URL),
+        productionRequiresPostgresql: Boolean(isProductionRuntime() && process.env.DATABASE_URL),
     };
     const persistenceSevere = persistenceHealth.productionRequiresPostgresql && !usePostgreSQL;
     const httpStatus = deliveryHealth.severe || persistenceSevere ? 503 : 200;

--- a/backend/tests/jest/db-ssl-mode.test.js
+++ b/backend/tests/jest/db-ssl-mode.test.js
@@ -28,6 +28,17 @@ describe('db SSL mode selection', () => {
         });
     });
 
+    test('treats Railway environment as production even without NODE_ENV', () => {
+        delete process.env.NODE_ENV;
+        process.env.RAILWAY_ENVIRONMENT = 'production';
+        delete process.env.PGSSLMODE;
+        const db = require('../../db');
+
+        expect(db._shouldUseSsl('postgresql://user:pass@example.com:5432/railway')).toEqual({
+            rejectUnauthorized: false,
+        });
+    });
+
     test('respects explicit PGSSLMODE disable', () => {
         process.env.NODE_ENV = 'production';
         process.env.PGSSLMODE = 'disable';

--- a/backend/tests/jest/health.test.js
+++ b/backend/tests/jest/health.test.js
@@ -152,8 +152,12 @@ jest.mock('../../subscription', () => {
 // ── Load app after mocks are established ──
 const request = require('supertest');
 let app;
+const originalRailwayEnvironment = process.env.RAILWAY_ENVIRONMENT;
+const originalDatabaseUrl = process.env.DATABASE_URL;
 
 beforeAll(() => {
+    process.env.RAILWAY_ENVIRONMENT = 'production';
+    process.env.DATABASE_URL = 'postgresql://user:pass@postgres-pgvector.railway.internal:5432/railway';
     // jest.mock calls above ensure mocked modules are used when index.js loads
     app = require('../../index');
 });
@@ -161,6 +165,16 @@ beforeAll(() => {
 afterAll(async () => {
     const { httpServer } = require('../../index');
     await new Promise(resolve => httpServer.close(resolve));
+    if (originalRailwayEnvironment === undefined) {
+        delete process.env.RAILWAY_ENVIRONMENT;
+    } else {
+        process.env.RAILWAY_ENVIRONMENT = originalRailwayEnvironment;
+    }
+    if (originalDatabaseUrl === undefined) {
+        delete process.env.DATABASE_URL;
+    } else {
+        process.env.DATABASE_URL = originalDatabaseUrl;
+    }
     jest.resetModules();
 });
 
@@ -201,6 +215,12 @@ describe('GET /api/health', () => {
         const res = await request(app).get('/api/health');
         expect(typeof res.body.uptime).toBe('number');
         expect(res.body.uptime).toBeGreaterThanOrEqual(0);
+    });
+
+    it('requires PostgreSQL persistence on Railway when DATABASE_URL is configured', async () => {
+        const res = await request(app).get('/api/health');
+        expect(res.body.persistence.productionRequiresPostgresql).toBe(true);
+        expect(res.body.persistence.mode).toBe('postgresql');
     });
 });
 


### PR DESCRIPTION
## Summary
- Use a shared production-runtime check that treats Railway deployments as production even when NODE_ENV is unset.
- Keep the PostgreSQL fallback refusal and /api/health persistence guard active on Railway when DATABASE_URL is configured.
- Apply the same runtime check to DB SSL defaults.
- Add regression coverage for Railway persistence health and DB SSL mode.

## Verification
- node --check backend/index.js && node --check backend/db.js
- cd backend && npx jest tests/jest/health.test.js tests/jest/db-ssl-mode.test.js tests/jest/device-vars.test.js tests/jest/rate-limit.test.js --runInBand
- cd backend && npm run lint (passes with 7 existing warnings)