### PR TITLE
Fix portal QA smoke guards and chat/kanban UX regressions

### DIFF
--- a/.github/workflows/portal-smoke-ci.yml
+++ b/.github/workflows/portal-smoke-ci.yml
@@ -1,0 +1,52 @@
+name: Portal Smoke CI
+
+on:
+  push:
+    branches: ['**']
+    paths:
+      - 'backend/public/portal/**'
+      - 'backend/public/shared/**'
+      - 'backend/scripts/portal-smoke-check.js'
+      - 'backend/tests/jest/chat-targets-static.test.js'
+      - 'backend/tests/jest/kanban-nav-static.test.js'
+      - 'backend/tests/jest/portal-smoke-static.test.js'
+      - 'backend/package.json'
+      - 'backend/package-lock.json'
+      - '.github/workflows/portal-smoke-ci.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'backend/public/portal/**'
+      - 'backend/public/shared/**'
+      - 'backend/scripts/portal-smoke-check.js'
+      - 'backend/tests/jest/chat-targets-static.test.js'
+      - 'backend/tests/jest/kanban-nav-static.test.js'
+      - 'backend/tests/jest/portal-smoke-static.test.js'
+      - 'backend/package.json'
+      - 'backend/package-lock.json'
+      - '.github/workflows/portal-smoke-ci.yml'
+
+jobs:
+  smoke:
+    name: Critical portal pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: backend
+
+      - name: Run portal smoke check
+        run: npm run smoke:portal
+        working-directory: backend
+
+      - name: Run portal smoke Jest guard
+        run: npx jest tests/jest/portal-smoke-static.test.js tests/jest/chat-targets-static.test.js tests/jest/kanban-nav-static.test.js --runInBand
+        working-directory: backend

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,6 +12,7 @@
     "test:production": "API_BASE=https://eclawbot.com node stress-test.js",
     "test:persistence": "node test-persistence.js",
     "test:persistence:check": "node test-persistence.js --check",
+    "smoke:portal": "node scripts/portal-smoke-check.js",
     "lint": "eslint .",
     "lint:i18n-dups": "node scripts/i18n-lint-dup-keys.js"
   },

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3538,10 +3538,6 @@
             document.querySelectorAll('.target-contact-check input[type="checkbox"]').forEach(cb => {
                 if (cb.checked) contactCodes.push(cb.dataset.contactCode);
             });
-            // Only fall back to all entities when no contacts are selected either
-            if (local.length === 0 && contactCodes.length === 0 && boundEntities.length > 0) {
-                boundEntities.forEach(e => local.push(e.entityId));
-            }
             return { local, contacts: contactCodes };
         }
 

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -961,7 +961,7 @@
             if (_isEmbed) {
                 document.body.classList.add('embed-mode');
             }
-            renderNav('mission');
+            renderNav('kanban');
             if (typeof renderFooter === 'function') renderFooter();
             const user = await checkAuth();
             if (!user) return;

--- a/backend/scripts/portal-smoke-check.js
+++ b/backend/scripts/portal-smoke-check.js
@@ -1,0 +1,113 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const ROOT = path.resolve(__dirname, '..');
+const PUBLIC = path.join(ROOT, 'public');
+
+const CRITICAL_PAGES = [
+    {
+        file: 'portal/dashboard.html',
+        anchors: ['id="entityGrid"', 'function loadEntities', 'entity_poll_empty_skipped', 'serverReady'],
+    },
+    {
+        file: 'portal/chat.html',
+        anchors: ['id="chatMessages"', 'id="targetBar"', 'id="messageInput"', 'async function sendMessage'],
+    },
+    {
+        file: 'portal/kanban.html',
+        anchors: ['id="kbBoard"', 'id="col-todo"', 'id="detailModal"', 'function postComment'],
+    },
+    {
+        file: 'portal/info.html',
+        anchors: ['id="panel-channel-plugins"', 'id="guide-codex-channel"', 'codex-eclaw-bridge'],
+    },
+];
+
+function fail(errors, file, message) {
+    errors.push(`${file}: ${message}`);
+}
+
+function isExternal(url) {
+    return /^(https?:)?\/\//i.test(url) || /^(mailto|tel):/i.test(url);
+}
+
+function cleanAssetUrl(raw) {
+    return raw.split('#')[0].split('?')[0];
+}
+
+function resolveAsset(pageFile, rawUrl) {
+    const url = cleanAssetUrl(rawUrl);
+    if (!url || isExternal(url)) return null;
+    if (url === '/socket.io/socket.io.js') return null;
+    if (url.startsWith('/')) return path.join(PUBLIC, url);
+    return path.join(path.dirname(path.join(PUBLIC, pageFile)), url);
+}
+
+function assertAssetsExist(pageFile, html, errors) {
+    const attrRe = /<(script|link)\b[^>]*(?:src|href)=["']([^"']+)["'][^>]*>/gi;
+    for (const match of html.matchAll(attrRe)) {
+        const tag = match[0];
+        const url = match[2];
+        if (tag.startsWith('<link') && !/\brel=["']?stylesheet["']?/i.test(tag)) continue;
+        const resolved = resolveAsset(pageFile, url);
+        if (resolved && !fs.existsSync(resolved)) {
+            fail(errors, pageFile, `missing asset ${url}`);
+        }
+    }
+}
+
+function assertInlineScriptsParse(pageFile, html, errors) {
+    let index = 0;
+    const inlineScriptRe = /<script\b(?![^>]*\bsrc=)([^>]*)>([\s\S]*?)<\/script>/gi;
+    for (const match of html.matchAll(inlineScriptRe)) {
+        index += 1;
+        const attrs = match[1] || '';
+        if (/\btype=["']application\/ld\+json["']/i.test(attrs)) continue;
+        const code = match[2].trim();
+        if (!code) continue;
+        try {
+            new vm.Script(code, { filename: `${pageFile}#inline-script-${index}.js` });
+        } catch (err) {
+            fail(errors, pageFile, `inline script ${index} syntax error: ${err.message}`);
+        }
+    }
+}
+
+function assertAnchors(page, html, errors) {
+    for (const anchor of page.anchors) {
+        if (!html.includes(anchor)) {
+            fail(errors, page.file, `missing critical anchor ${anchor}`);
+        }
+    }
+}
+
+function runPortalSmokeCheck() {
+    const errors = [];
+    for (const page of CRITICAL_PAGES) {
+        const abs = path.join(PUBLIC, page.file);
+        if (!fs.existsSync(abs)) {
+            fail(errors, page.file, 'page file missing');
+            continue;
+        }
+        const html = fs.readFileSync(abs, 'utf8');
+        assertAnchors(page, html, errors);
+        assertAssetsExist(page.file, html, errors);
+        assertInlineScriptsParse(page.file, html, errors);
+    }
+    return { ok: errors.length === 0, errors };
+}
+
+if (require.main === module) {
+    const result = runPortalSmokeCheck();
+    if (!result.ok) {
+        console.error('Portal smoke check failed:\n' + result.errors.map(e => `  - ${e}`).join('\n'));
+        process.exit(1);
+    }
+    console.log('Portal smoke check passed');
+}
+
+module.exports = { runPortalSmokeCheck };

--- a/backend/tests/jest/chat-targets-static.test.js
+++ b/backend/tests/jest/chat-targets-static.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const chatHtml = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'chat.html'), 'utf8');
+
+describe('chat target selection safety', () => {
+    test('getSelectedTargets does not silently fall back to all entities when every recipient is unchecked', () => {
+        const start = chatHtml.indexOf('function getSelectedTargets()');
+        expect(start).toBeGreaterThan(0);
+        const end = chatHtml.indexOf('// ── Contacts Management ──', start);
+        expect(end).toBeGreaterThan(start);
+        const body = chatHtml.slice(start, end);
+
+        expect(body).not.toMatch(/boundEntities\.forEach\(\s*e\s*=>\s*local\.push\(e\.entityId\)/);
+        expect(body).not.toMatch(/local\.length\s*===\s*0[\s\S]*contactCodes\.length\s*===\s*0[\s\S]*boundEntities/);
+    });
+
+    test('sendMessage surfaces the existing select-entity error when no targets are selected', () => {
+        const start = chatHtml.indexOf('async function sendMessage()');
+        expect(start).toBeGreaterThan(0);
+        const body = chatHtml.slice(start, start + 5000);
+
+        expect(body).toContain('const targets = getSelectedTargets();');
+        expect(body).toMatch(/targets\.local\.length\s*===\s*0\s*&&\s*targets\.contacts\.length\s*===\s*0/);
+        expect(body).toContain("showToast(i18n.t('chat_select_entity'), 'error')");
+    });
+});

--- a/backend/tests/jest/kanban-nav-static.test.js
+++ b/backend/tests/jest/kanban-nav-static.test.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const kanbanHtml = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'kanban.html'), 'utf8');
+const missionHtml = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'mission.html'), 'utf8');
+const navJs = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'shared', 'nav.js'), 'utf8');
+
+describe('portal top navigation active page mapping', () => {
+    test('shared nav exposes separate Mission and Kanban top-level entries', () => {
+        expect(navJs).toContain("id: 'mission'");
+        expect(navJs).toContain("href: 'mission.html'");
+        expect(navJs).toContain("id: 'kanban'");
+        expect(navJs).toContain("href: 'kanban.html'");
+    });
+
+    test('kanban.html highlights Kanban, not Mission', () => {
+        expect(kanbanHtml).toContain("renderNav('kanban')");
+        expect(kanbanHtml).not.toContain("renderNav('mission')");
+    });
+
+    test('mission.html still highlights Mission', () => {
+        expect(missionHtml).toContain("renderNav('mission')");
+    });
+});

--- a/backend/tests/jest/portal-smoke-static.test.js
+++ b/backend/tests/jest/portal-smoke-static.test.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const { runPortalSmokeCheck } = require('../../scripts/portal-smoke-check');
+
+describe('portal critical page smoke check', () => {
+    test('dashboard, chat, kanban, and Codex Channel docs keep critical assets and anchors intact', () => {
+        const result = runPortalSmokeCheck();
+        expect(result.errors).toEqual([]);
+        expect(result.ok).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- Fix chat target selection so unchecking every recipient no longer silently broadcasts to all bound entities.
- Fix Kanban top navigation so `/portal/kanban.html` highlights Kanban instead of Mission.
- Add a critical portal smoke check, targeted Jest regression guards, and a dedicated Portal Smoke CI workflow for dashboard/chat/kanban/Codex Channel docs.

Closes #2259
Closes #2260

## Verification
- `npm run smoke:portal`
- `npx jest tests/jest/chat-targets-static.test.js tests/jest/kanban-nav-static.test.js tests/jest/portal-smoke-static.test.js`
- `node --check scripts/portal-smoke-check.js && node --check public/portal/shared/nav.js`
- `npm run lint` (passes with 7 existing unused-variable warnings outside this change)
- `npm test -- --runInBand` (150 suites / 2424 tests passed; existing Jest config warning and console noise remain)

## QA Notes
- Production dashboard, chat, kanban, and Codex Channel docs were reviewed from the browser before this patch.
- The new CI is intentionally separate from the existing backend workflow to avoid broad workflow churn while still catching blank-page/static portal regressions early.
