### PR TITLE
Fix rental contract start diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,6 +434,7 @@ EClaw/
    | Bug | Endpoint | Created | Status |
    |-----|----------|---------|--------|
    | Interview start fails with owner_device_not_found | `GET /api/rental/debug/interview-start-fail?deviceId=X&deviceSecret=Y` | 2026-04-12 | Active |
+   | Rental contract start returns internal_error during rent/borrow E2E | `GET /api/rental/debug/contract-start-fail?deviceId=X&deviceSecret=Y&listingId=Y&renterDeviceId=Z&durationMinutes=30` | 2026-05-01 | Active |
 
 6. **Demand Elegance (Balanced)** — 在保持 minimal change 的前提下，追求可讀、一致的程式風格；不為了「漂亮」而過度重構，但也不容忍明顯的 code smell 在新增的程式碼中出現。
 
@@ -1113,6 +1114,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | Channel XP | `node backend/tests/test-channel-xp.js` | Device ID + Secret | Channel XP tracking and propagation |
 | Customer Service API | `node backend/tests/test-customer-service-api.js` | Device ID + Secret | Customer service AI tool handlers |
 | Entity Trash | `node backend/tests/test-entity-trash.js` | Device ID + Secret | Entity soft-delete, restore, 7-day retention |
+| Rental Debug Contract Start | `cd backend && npx jest tests/jest/rental-debug-contract-start.test.js` | None | Regression #2263: rental debug endpoints authenticate safely and report contract-start economics/predicted blockers |
 | Note Pages | `node backend/tests/test-note-pages.js` | Device ID + Secret | Note page public/private toggle, visitor analytics, custom domain |
 | AI Chat WebView Guard | `node backend/tests/test-ai-chat-webview-guard.js` | Device ID + Secret | AI chat widget hidden in Android WebView contexts |
 | Org Chart | `node backend/tests/test-org-chart.js` | Device ID + Secret | Org chart CRUD lifecycle, cycle detection, partial update, auth validation |

--- a/backend/rental.js
+++ b/backend/rental.js
@@ -28,7 +28,7 @@ const { Pool } = require('pg');
 const fs = require('fs');
 const path = require('path');
 const { runInterview, getProbeList } = require('./bot-interview');
-const { safeEqual } = require('./safe-equal');
+const safeEqual = require('./safe-equal');
 
 const pool = new Pool({
     connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
@@ -1816,6 +1816,187 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
         const result = await pool.query(`DELETE FROM rental_cooldowns WHERE user_id = $1`, [userId]);
         res.json({ success: true, cleared: result.rowCount });
     } catch (e) { res.status(500).json({ success: false, error: e.message }); } });
+
+    // ── Debug: contract-start-fail (#2263) (DO NOT REMOVE until user confirms fix) ──
+    router.get('/debug/contract-start-fail', async (req, res) => { try {
+        const { deviceId, deviceSecret, listingId, renterDeviceId } = req.query;
+        const durationMinutes = parseInt(req.query.durationMinutes || '30', 10);
+        if (!deviceId || !deviceSecret) {
+            return res.json({ success: false, error: 'deviceId and deviceSecret required' });
+        }
+        if (!listingId || !renterDeviceId) {
+            return res.json({ success: false, error: 'listingId and renterDeviceId required' });
+        }
+        const devRes = await pool.query(
+            'SELECT device_id, device_secret FROM devices WHERE device_id = $1',
+            [deviceId]
+        );
+        if (!devRes.rows.length || !safeEqual(devRes.rows[0].device_secret, deviceSecret)) {
+            return res.json({ success: false, error: 'auth_failed' });
+        }
+
+        const requesterUserRes = await pool.query(
+            'SELECT id, email, device_id FROM user_accounts WHERE device_id = $1',
+            [deviceId]
+        );
+        const renterUserRes = await pool.query(
+            'SELECT id, email, device_id FROM user_accounts WHERE device_id = $1',
+            [renterDeviceId]
+        );
+        const listingRes = await pool.query(
+            `SELECT id, owner_user_id, owner_device_id, owner_entity_id,
+                    title, status, interview_passed, rate_mli_per_ktoken,
+                    min_rental_minutes, max_rental_minutes, updated_at
+             FROM bot_listings WHERE id = $1`,
+            [listingId]
+        );
+
+        const listing = listingRes.rows[0] || null;
+        const renterUser = renterUserRes.rows[0] || null;
+        let cooldownRows = [];
+        let activeContractRows = [];
+        let walletRow = null;
+        let renterEntityRows = [];
+        let prediction = {
+            deposit_mli: null,
+            buffer_mli: null,
+            required_mli: null,
+            current_mli: null,
+            affordable: null,
+            predicted_error: null,
+        };
+
+        if (renterUser && listing) {
+            const cooldownRes = await pool.query(
+                `SELECT cooldown_until FROM rental_cooldowns
+                 WHERE user_id = $1 AND listing_id = $2 AND cooldown_until > NOW()`,
+                [renterUser.id, listingId]
+            );
+            cooldownRows = cooldownRes.rows;
+
+            const activeRes = await pool.query(
+                `SELECT id, status, started_at, ends_at
+                 FROM rental_contracts
+                 WHERE listing_id = $1
+                   AND status IN ('reserved', 'active', 'suspended_insufficient_funds')
+                 ORDER BY started_at DESC NULLS LAST LIMIT 10`,
+                [listingId]
+            );
+            activeContractRows = activeRes.rows;
+
+            const walletRes = await pool.query(
+                'SELECT balance_mli, held_mli FROM wallets WHERE user_id = $1',
+                [renterUser.id]
+            );
+            walletRow = walletRes.rows[0] || null;
+
+            const entitiesRes = await pool.query(
+                'SELECT entity_id, is_bound, character, webhook FROM entities WHERE device_id = $1 ORDER BY entity_id ASC',
+                [renterDeviceId]
+            );
+            renterEntityRows = entitiesRes.rows;
+
+            const rateSnapshot = Number(listing.rate_mli_per_ktoken || 0);
+            const depositMli = computeDepositMli(rateSnapshot);
+            const bufferMli = rateSnapshot * 60;
+            const requiredMli = depositMli + bufferMli;
+            const currentMli = BigInt(walletRow?.balance_mli || 0);
+            let predictedError = null;
+            if (listing.status !== 'listed') predictedError = 'listing_not_available';
+            else if (!listing.interview_passed) predictedError = 'interview_not_passed';
+            else if (listing.owner_user_id === renterUser.id) predictedError = 'self_rental_forbidden';
+            else if (!Number.isInteger(durationMinutes) || durationMinutes <= 0) predictedError = 'duration_minutes_invalid';
+            else if (durationMinutes < MIN_RENTAL_MINUTES) predictedError = 'duration_too_short';
+            else if (durationMinutes > MAX_RENTAL_MINUTES) predictedError = 'duration_too_long';
+            else if (durationMinutes < Number(listing.min_rental_minutes)) predictedError = 'duration_below_listing_min';
+            else if (durationMinutes > Number(listing.max_rental_minutes)) predictedError = 'duration_above_listing_max';
+            else if (cooldownRows.length > 0) predictedError = 'cooldown_active';
+            else if (activeContractRows.length > 0) predictedError = 'listing_already_rented';
+            else if (currentMli < BigInt(requiredMli)) predictedError = 'insufficient_balance_for_rental';
+
+            prediction = {
+                deposit_mli: String(depositMli),
+                buffer_mli: String(bufferMli),
+                required_mli: String(requiredMli),
+                current_mli: String(currentMli),
+                affordable: currentMli >= BigInt(requiredMli),
+                predicted_error: predictedError,
+            };
+        } else if (!listing) {
+            prediction.predicted_error = 'listing_not_found';
+        } else if (!renterUser) {
+            prediction.predicted_error = 'renter_user_not_found';
+        }
+
+        const ownerMemoryDevice = listing ? _interviewDeps.devices?.[listing.owner_device_id] : null;
+        const ownerMemoryEntity = ownerMemoryDevice && listing
+            ? ownerMemoryDevice.entities?.[listing.owner_entity_id]
+            : null;
+        const renterMemoryDevice = _interviewDeps.devices?.[renterDeviceId] || null;
+
+        res.json({
+            success: true,
+            bug: 'contract-start-fail',
+            diagnostics: {
+                requester: {
+                    device_id: requesterUserRes.rows[0]?.device_id || null,
+                    user_id: requesterUserRes.rows[0]?.id || null,
+                    email: requesterUserRes.rows[0]?.email || null,
+                },
+                renter: renterUser ? {
+                    device_id: renterUser.device_id,
+                    user_id: renterUser.id,
+                    email: renterUser.email,
+                } : null,
+                listing: listing ? {
+                    id: listing.id,
+                    owner_user_id: listing.owner_user_id,
+                    owner_device_id: listing.owner_device_id,
+                    owner_entity_id: listing.owner_entity_id,
+                    title: listing.title,
+                    status: listing.status,
+                    interview_passed: listing.interview_passed,
+                    rate_mli_per_ktoken: listing.rate_mli_per_ktoken,
+                    min_rental_minutes: listing.min_rental_minutes,
+                    max_rental_minutes: listing.max_rental_minutes,
+                    updated_at: listing.updated_at,
+                } : null,
+                requested: { listingId, renterDeviceId, durationMinutes },
+                economics: prediction,
+                cooldowns: cooldownRows,
+                activeContracts: activeContractRows,
+                renterWallet: walletRow ? {
+                    balance_mli: String(walletRow.balance_mli),
+                    held_mli: String(walletRow.held_mli),
+                } : null,
+                renterDbEntities: renterEntityRows.map(r => ({
+                    entity_id: r.entity_id,
+                    is_bound: r.is_bound,
+                    character: r.character,
+                    webhook: r.webhook ? 'set' : 'null',
+                })),
+                memory: {
+                    hasInterviewDeps: !!_interviewDeps.devices,
+                    ownerDeviceInMemory: !!ownerMemoryDevice,
+                    renterDeviceInMemory: !!renterMemoryDevice,
+                    ownerEntity: ownerMemoryEntity ? {
+                        isBound: !!ownerMemoryEntity.isBound,
+                        character: ownerMemoryEntity.character || null,
+                        name: ownerMemoryEntity.name || null,
+                        rental_status: ownerMemoryEntity.rental_status || null,
+                        rental_contract_id: ownerMemoryEntity.rental_contract_id || null,
+                        hasWebhook: !!ownerMemoryEntity.webhook,
+                        bindingType: ownerMemoryEntity.bindingType || 'webhook',
+                        channelAccountId: ownerMemoryEntity.channelAccountId || null,
+                    } : null,
+                },
+            },
+            timestamp: new Date().toISOString(),
+        });
+    } catch (err) {
+        console.error('[Rental] /debug/contract-start-fail error:', err);
+        res.status(500).json({ success: false, error: err.message });
+    } });
 
     // ── Debug: interview-start-fail (DO NOT REMOVE until user confirms fix) ──
     router.get('/debug/interview-start-fail', async (req, res) => { try {

--- a/backend/tests/jest/rental-debug-contract-start.test.js
+++ b/backend/tests/jest/rental-debug-contract-start.test.js
@@ -1,0 +1,227 @@
+/**
+ * Rental debug endpoints.
+ *
+ * Covers the production E2E failure mode where contract start returned
+ * internal_error and the existing debug endpoint also crashed before it could
+ * explain the state.
+ */
+
+jest.mock('pg', () => {
+    const state = {
+        devices: new Map(),
+        usersByDevice: new Map(),
+        listings: new Map(),
+        cooldowns: [],
+        contracts: [],
+        wallets: new Map(),
+        entitiesByDevice: new Map(),
+    };
+    globalThis.__rentalDebugState = state;
+
+    function runQuery(sql, params = []) {
+        const norm = sql.replace(/\s+/g, ' ').trim();
+
+        if (/^SELECT device_id, device_secret FROM devices WHERE device_id = \$1$/i.test(norm)) {
+            const row = state.devices.get(params[0]);
+            return { rows: row ? [{ ...row }] : [], rowCount: row ? 1 : 0 };
+        }
+
+        if (/^SELECT id, email, device_id FROM user_accounts WHERE device_id = \$1$/i.test(norm)) {
+            const row = state.usersByDevice.get(params[0]);
+            return { rows: row ? [{ ...row }] : [], rowCount: row ? 1 : 0 };
+        }
+
+        if (/^SELECT id, owner_user_id, owner_device_id, owner_entity_id,/i.test(norm)) {
+            const row = state.listings.get(params[0]);
+            return { rows: row ? [{ ...row }] : [], rowCount: row ? 1 : 0 };
+        }
+
+        if (/^SELECT cooldown_until FROM rental_cooldowns/i.test(norm)) {
+            const rows = state.cooldowns.filter(c => c.user_id === params[0] && c.listing_id === params[1]);
+            return { rows, rowCount: rows.length };
+        }
+
+        if (/^SELECT id, status, started_at, ends_at FROM rental_contracts/i.test(norm)) {
+            const rows = state.contracts.filter(c =>
+                c.listing_id === params[0] &&
+                ['reserved', 'active', 'suspended_insufficient_funds'].includes(c.status)
+            );
+            return { rows, rowCount: rows.length };
+        }
+
+        if (/^SELECT id, listing_id, status, started_at, ends_at, renter_device_id FROM rental_contracts/i.test(norm)) {
+            const rows = state.contracts.filter(c =>
+                c.renter_device_id === params[0] &&
+                ['reserved', 'active', 'suspended_insufficient_funds'].includes(c.status)
+            );
+            return { rows, rowCount: rows.length };
+        }
+
+        if (/^SELECT balance_mli, held_mli FROM wallets WHERE user_id = \$1$/i.test(norm)) {
+            const row = state.wallets.get(params[0]);
+            return { rows: row ? [{ ...row }] : [], rowCount: row ? 1 : 0 };
+        }
+
+        if (/^SELECT entity_id, is_bound, character, webhook FROM entities WHERE device_id = \$1/i.test(norm)) {
+            const rows = state.entitiesByDevice.get(params[0]) || [];
+            return { rows: rows.map(r => ({ ...r })), rowCount: rows.length };
+        }
+
+        throw new Error(`[rental-debug fake pg] Unhandled SQL: ${norm}`);
+    }
+
+    return {
+        Pool: jest.fn(() => ({
+            query: jest.fn((sql, params) => Promise.resolve(runQuery(sql, params))),
+        })),
+    };
+});
+
+const express = require('express');
+const request = require('supertest');
+const rentalFactory = require('../../rental');
+
+function buildApp() {
+    const app = express();
+    app.use(express.json());
+    const rental = rentalFactory({
+        authMiddleware: (req, _res, next) => {
+            req.user = { userId: 'requester-user', deviceId: 'owner-device' };
+            next();
+        },
+        walletModule: {
+            withTransaction: async (fn) => fn({ query: () => Promise.resolve({ rows: [], rowCount: 0 }) }),
+        },
+    });
+    rental.setInterviewDeps({
+        devices: {
+            'owner-device': {
+                entities: {
+                    1: {
+                        isBound: true,
+                        character: 'Mac_F',
+                        name: 'My Bot',
+                        webhook: { url: 'https://example.test/hook' },
+                    },
+                },
+            },
+            'renter-device': { entities: {} },
+        },
+    });
+    app.use('/api/rental', rental.router);
+    return app;
+}
+
+function seedHappyPath() {
+    const state = globalThis.__rentalDebugState;
+    state.devices.clear();
+    state.usersByDevice.clear();
+    state.listings.clear();
+    state.cooldowns = [];
+    state.contracts = [];
+    state.wallets.clear();
+    state.entitiesByDevice.clear();
+
+    state.devices.set('owner-device', {
+        device_id: 'owner-device',
+        device_secret: 'owner-secret',
+    });
+    state.usersByDevice.set('owner-device', {
+        id: 'owner-user',
+        email: 'owner@example.test',
+        device_id: 'owner-device',
+    });
+    state.usersByDevice.set('renter-device', {
+        id: 'renter-user',
+        email: 'renter@example.test',
+        device_id: 'renter-device',
+    });
+    state.listings.set('listing-1', {
+        id: 'listing-1',
+        owner_user_id: 'owner-user',
+        owner_device_id: 'owner-device',
+        owner_entity_id: 1,
+        title: 'My Bot',
+        status: 'listed',
+        interview_passed: true,
+        rate_mli_per_ktoken: 5000,
+        min_rental_minutes: 30,
+        max_rental_minutes: 10080,
+        updated_at: new Date('2026-05-01T00:00:00Z'),
+    });
+    state.wallets.set('renter-user', {
+        balance_mli: '480000',
+        held_mli: '0',
+    });
+    state.entitiesByDevice.set('renter-device', [
+        { entity_id: 15, is_bound: false, character: null, webhook: null },
+    ]);
+}
+
+describe('rental debug endpoints', () => {
+    beforeEach(seedHappyPath);
+
+    test('rental-entity-visibility authenticates with safeEqual import fixed', async () => {
+        const res = await request(buildApp())
+            .get('/api/rental/debug/rental-entity-visibility')
+            .query({ deviceId: 'owner-device', deviceSecret: 'owner-secret' })
+            .expect(200);
+
+        expect(res.body.success).toBe(true);
+        expect(res.body.bug).toBe('rental-entity-visibility');
+        expect(res.body.error).toBeUndefined();
+    });
+
+    test('contract-start-fail reports affordability and no predicted blocker', async () => {
+        const res = await request(buildApp())
+            .get('/api/rental/debug/contract-start-fail')
+            .query({
+                deviceId: 'owner-device',
+                deviceSecret: 'owner-secret',
+                listingId: 'listing-1',
+                renterDeviceId: 'renter-device',
+                durationMinutes: 30,
+            })
+            .expect(200);
+
+        expect(res.body.success).toBe(true);
+        expect(res.body.bug).toBe('contract-start-fail');
+        expect(res.body.diagnostics.economics).toMatchObject({
+            deposit_mli: '100000',
+            buffer_mli: '300000',
+            required_mli: '400000',
+            current_mli: '480000',
+            affordable: true,
+            predicted_error: null,
+        });
+        expect(res.body.diagnostics.memory.ownerDeviceInMemory).toBe(true);
+        expect(res.body.diagnostics.renterDbEntities).toEqual([
+            expect.objectContaining({ entity_id: 15, is_bound: false }),
+        ]);
+    });
+
+    test('contract-start-fail predicts insufficient rental balance', async () => {
+        globalThis.__rentalDebugState.wallets.set('renter-user', {
+            balance_mli: '399999',
+            held_mli: '0',
+        });
+
+        const res = await request(buildApp())
+            .get('/api/rental/debug/contract-start-fail')
+            .query({
+                deviceId: 'owner-device',
+                deviceSecret: 'owner-secret',
+                listingId: 'listing-1',
+                renterDeviceId: 'renter-device',
+                durationMinutes: 30,
+            })
+            .expect(200);
+
+        expect(res.body.diagnostics.economics).toMatchObject({
+            required_mli: '400000',
+            current_mli: '399999',
+            affordable: false,
+            predicted_error: 'insufficient_balance_for_rental',
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Fixes rental debug endpoints crashing because `safeEqual` was imported as a named export.
- Adds `GET /api/rental/debug/contract-start-fail` for issue #2263 so the rent/borrow E2E can inspect listing state, renter wallet affordability, cooldowns, active contracts, DB entities, and in-memory entity state without mutating e-coin.
- Registers the active debug endpoint and regression test in `AGENTS.md`.

## Verification
- `node --check backend/rental.js`
- `cd backend && npx jest tests/jest/rental-debug-contract-start.test.js`

## Notes
- Refs #2263.
- I intentionally did not retry the live rental after this patch because the debug endpoint must deploy first, and successful retry would mutate e-coin/contract state.
