### PR TITLE
feat: add prompt policy orchestration

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -212,6 +212,11 @@ async function createTables() {
             ALTER TABLE devices ADD COLUMN IF NOT EXISTS paid_borrow_slots INTEGER DEFAULT 0
         `);
 
+        // Prompt Policy: device-level system prompt orchestration, merged with entity identity/policy at runtime
+        await client.query(`
+            ALTER TABLE devices ADD COLUMN IF NOT EXISTS prompt_policy JSONB
+        `);
+
         // Dynamic entity system: per-device counter for unique entity ID assignment
         await client.query(`
             ALTER TABLE devices ADD COLUMN IF NOT EXISTS next_entity_id INTEGER DEFAULT 1
@@ -620,11 +625,18 @@ async function saveDeviceData(deviceId, deviceData) {
 
             // Upsert device
             await client.query(
-                `INSERT INTO devices (device_id, device_secret, created_at, updated_at, next_entity_id)
-                 VALUES ($1, $2, $3, $4, $5)
+                `INSERT INTO devices (device_id, device_secret, created_at, updated_at, next_entity_id, prompt_policy)
+                 VALUES ($1, $2, $3, $4, $5, $6)
                  ON CONFLICT (device_id)
-                 DO UPDATE SET updated_at = $4, next_entity_id = $5`,
-                [deviceId, deviceData.deviceSecret, deviceData.createdAt, Date.now(), deviceData.nextEntityId || 1]
+                 DO UPDATE SET updated_at = $4, next_entity_id = $5, prompt_policy = $6`,
+                [
+                    deviceId,
+                    deviceData.deviceSecret,
+                    deviceData.createdAt,
+                    Date.now(),
+                    deviceData.nextEntityId || 1,
+                    deviceData.promptPolicy ? JSON.stringify(deviceData.promptPolicy) : null
+                ]
             );
 
             // Clear all public_code for this device first to avoid unique constraint
@@ -789,6 +801,9 @@ async function loadAllDevices() {
                 deviceSecret: row.device_secret,
                 createdAt: parseInt(row.created_at),
                 nextEntityId: parseInt(row.next_entity_id) || 1,
+                promptPolicy: row.prompt_policy
+                    ? (typeof row.prompt_policy === 'string' ? JSON.parse(row.prompt_policy) : row.prompt_policy)
+                    : null,
                 fcmToken: row.fcm_token || null,
                 apnsToken: row.apns_token || null,
                 entities: {}

--- a/backend/index.js
+++ b/backend/index.js
@@ -4338,6 +4338,7 @@ function getOrCreateDevice(deviceId, deviceSecret = null, opts = {}) {
             createdAt: Date.now(),
             isTestDevice: opts.isTestDevice || false,
             nextEntityId: DEFAULT_INITIAL_SLOTS, // = 1
+            promptPolicy: null,
             entities: {}
         };
         // Initialize only 1 slot (entity #0)
@@ -10113,6 +10114,194 @@ function validateIdentity(identity) {
     return { valid: true, identity: cleaned };
 }
 
+const PROMPT_POLICY_VERSION = 1;
+const PROMPT_POLICY_MAX_ITEMS = 20;
+const PROMPT_POLICY_MAX_TEXT = 1000;
+const PROMPT_POLICY_MAX_CHANNELS = 12;
+const PROMPT_POLICY_MIN_HEARTBEAT_MS = 60 * 1000;
+const PROMPT_POLICY_MAX_HEARTBEAT_MS = 30 * 60 * 1000;
+
+const DEFAULT_PROMPT_POLICY_TASK_PROTOCOL = {
+    requireTestPlan: true,
+    requireMilestoneUpdates: true,
+    statusHeartbeatMs: 180000
+};
+
+const PLATFORM_PROMPT_POLICY_SECTION = [
+    'Follow EClaw channel routing, auth, and safety rules.',
+    'Never reveal device secrets, bot secrets, API keys, database URLs, or tokens.',
+    'For long-running work, keep the user updated with concrete progress and blockers.'
+].join('\n');
+
+function asPromptPolicyLines(value, fieldName, maxItems = PROMPT_POLICY_MAX_ITEMS) {
+    if (value === undefined) return { lines: undefined };
+    const rawLines = Array.isArray(value)
+        ? value
+        : String(value).split('\n');
+    if (rawLines.length > maxItems) {
+        return { error: `${fieldName} supports at most ${maxItems} lines` };
+    }
+    const lines = rawLines
+        .map(line => String(line || '').trim())
+        .filter(Boolean)
+        .map(line => line.substring(0, PROMPT_POLICY_MAX_TEXT));
+    const secretLine = lines.find(containsLikelyPromptSecret);
+    if (secretLine) {
+        return { error: `${fieldName} appears to contain a secret; store secrets in device vars instead` };
+    }
+    return { lines };
+}
+
+function containsLikelyPromptSecret(text) {
+    if (!text) return false;
+    return [
+        /\bsk-[A-Za-z0-9_-]{20,}/,
+        /\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|password|secret)\s*[:=]\s*\S{8,}/i,
+        /BEGIN (?:RSA |EC |OPENSSH |)?PRIVATE KEY/i,
+        /\bpostgres(?:ql)?:\/\/[^/\s:]+:[^@\s]+@/i
+    ].some(re => re.test(text));
+}
+
+function sanitizePromptTaskProtocol(input) {
+    const protocol = { ...DEFAULT_PROMPT_POLICY_TASK_PROTOCOL };
+    if (!input || typeof input !== 'object') return protocol;
+    if (input.requireTestPlan !== undefined) protocol.requireTestPlan = !!input.requireTestPlan;
+    if (input.requireMilestoneUpdates !== undefined) protocol.requireMilestoneUpdates = !!input.requireMilestoneUpdates;
+    if (input.statusHeartbeatMs !== undefined) {
+        const ms = parseInt(input.statusHeartbeatMs);
+        if (!Number.isFinite(ms)) return { error: 'taskProtocol.statusHeartbeatMs must be a number' };
+        protocol.statusHeartbeatMs = Math.max(PROMPT_POLICY_MIN_HEARTBEAT_MS, Math.min(PROMPT_POLICY_MAX_HEARTBEAT_MS, ms));
+    }
+    return protocol;
+}
+
+function sanitizePromptChannelOverrides(overrides) {
+    if (overrides === undefined) return { overrides: undefined };
+    if (!overrides || typeof overrides !== 'object' || Array.isArray(overrides)) {
+        return { error: 'channelOverrides must be an object' };
+    }
+    const entries = Object.entries(overrides).slice(0, PROMPT_POLICY_MAX_CHANNELS);
+    const cleaned = {};
+    for (const [rawChannel, rawOverride] of entries) {
+        const channel = String(rawChannel || '').trim().substring(0, 40).toLowerCase();
+        if (!/^[a-z0-9_-]+$/.test(channel)) return { error: `Invalid channel override key: ${rawChannel}` };
+        if (!rawOverride || typeof rawOverride !== 'object' || Array.isArray(rawOverride)) {
+            return { error: `channelOverrides.${channel} must be an object` };
+        }
+        const lines = asPromptPolicyLines(rawOverride.instructions, `channelOverrides.${channel}.instructions`);
+        if (lines.error) return { error: lines.error };
+        cleaned[channel] = {
+            enabled: rawOverride.enabled !== false,
+            instructions: lines.lines || []
+        };
+    }
+    return { overrides: cleaned };
+}
+
+function validatePromptPolicy(policy) {
+    if (!policy || typeof policy !== 'object' || Array.isArray(policy)) {
+        return { valid: false, error: 'promptPolicy must be an object' };
+    }
+
+    const instructions = asPromptPolicyLines(policy.instructions, 'instructions');
+    if (instructions.error) return { valid: false, error: instructions.error };
+
+    const taskProtocol = sanitizePromptTaskProtocol(policy.taskProtocol);
+    if (taskProtocol.error) return { valid: false, error: taskProtocol.error };
+
+    const channelOverrides = sanitizePromptChannelOverrides(policy.channelOverrides);
+    if (channelOverrides.error) return { valid: false, error: channelOverrides.error };
+
+    return {
+        valid: true,
+        promptPolicy: {
+            version: PROMPT_POLICY_VERSION,
+            enabled: policy.enabled !== false,
+            instructions: instructions.lines || [],
+            taskProtocol,
+            channelOverrides: channelOverrides.overrides || {},
+            updatedAt: new Date().toISOString()
+        }
+    };
+}
+
+function getEntityPromptPolicy(entity) {
+    return entity?.identity?.promptPolicy || null;
+}
+
+function setEntityPromptPolicy(entity, promptPolicy) {
+    if (!entity.identity) entity.identity = {};
+    entity.identity.promptPolicy = promptPolicy;
+    entity.lastUpdated = Date.now();
+}
+
+function appendPromptPolicySection(sections, scope, title, lines) {
+    const content = Array.isArray(lines) ? lines.filter(Boolean).join('\n') : String(lines || '').trim();
+    if (!content) return;
+    sections.push({ scope, title, content });
+}
+
+function buildPromptPolicySections(device, entity, channel = 'generic') {
+    const normalizedChannel = String(channel || 'generic').trim().toLowerCase();
+    const sections = [];
+    const devicePolicy = device?.promptPolicy?.enabled === false ? null : (device?.promptPolicy || null);
+    const identity = entity?.identity || {};
+    const entityPolicy = getEntityPromptPolicy(entity)?.enabled === false ? null : getEntityPromptPolicy(entity);
+
+    appendPromptPolicySection(sections, 'platform', 'EClaw Platform Policy', PLATFORM_PROMPT_POLICY_SECTION);
+
+    appendPromptPolicySection(sections, 'device', 'Device Instructions', devicePolicy?.instructions || []);
+
+    const identityLines = [];
+    if (identity.role) identityLines.push(`Role: ${identity.role}`);
+    if (identity.description) identityLines.push(`Description: ${identity.description}`);
+    if (identity.tone) identityLines.push(`Tone: ${identity.tone}`);
+    if (identity.language) identityLines.push(`Language: ${identity.language}`);
+    if (Array.isArray(identity.instructions) && identity.instructions.length) {
+        identityLines.push('Identity instructions:', ...identity.instructions.map(item => `- ${item}`));
+    }
+    if (Array.isArray(identity.boundaries) && identity.boundaries.length) {
+        identityLines.push('Boundaries:', ...identity.boundaries.map(item => `- ${item}`));
+    }
+    appendPromptPolicySection(sections, 'identity', 'Entity Identity', identityLines);
+
+    appendPromptPolicySection(sections, 'entity', 'Entity Prompt Policy', entityPolicy?.instructions || []);
+
+    const protocol = {
+        ...DEFAULT_PROMPT_POLICY_TASK_PROTOCOL,
+        ...(devicePolicy?.taskProtocol || {}),
+        ...(entityPolicy?.taskProtocol || {})
+    };
+    appendPromptPolicySection(sections, 'taskProtocol', 'Task Protocol', [
+        protocol.requireTestPlan ? 'Start long tasks with a concise test plan before implementation.' : '',
+        protocol.requireMilestoneUpdates ? 'Report progress after meaningful milestones and include blockers explicitly.' : '',
+        `Preferred autonomous status heartbeat interval: ${protocol.statusHeartbeatMs}ms.`
+    ]);
+
+    const deviceOverride = devicePolicy?.channelOverrides?.[normalizedChannel];
+    if (deviceOverride?.enabled !== false) {
+        appendPromptPolicySection(sections, 'channel', `Device ${normalizedChannel} Override`, deviceOverride?.instructions || []);
+    }
+    const entityOverride = entityPolicy?.channelOverrides?.[normalizedChannel];
+    if (entityOverride?.enabled !== false) {
+        appendPromptPolicySection(sections, 'channel', `Entity ${normalizedChannel} Override`, entityOverride?.instructions || []);
+    }
+
+    return {
+        version: PROMPT_POLICY_VERSION,
+        channel: normalizedChannel,
+        taskProtocol: protocol,
+        sections,
+        compiledPrompt: sections.map(section => `## ${section.title}\n${section.content}`).join('\n\n')
+    };
+}
+
+function requireDeviceOwner(device, deviceSecret) {
+    if (!deviceSecret) return { error: 'deviceSecret required', status: 400 };
+    if (!safeEqual(device.deviceSecret, deviceSecret)) return { error: 'Invalid deviceSecret', status: 403 };
+    return {};
+}
+
 /**
  * PUT /api/entity/identity — Create or update bot identity (partial merge)
  * Auth: deviceSecret (owner) OR botSecret (bot self-update)
@@ -10218,6 +10407,114 @@ app.delete('/api/entity/identity', async (req, res) => {
     io.to(deviceId).emit('entity:identity-updated', { entityId: parseInt(entityId), identity: null });
     serverLog('info', 'identity', `Entity ${entityId} identity cleared`, { deviceId, entityId: parseInt(entityId) });
     res.json({ success: true });
+});
+
+/**
+ * GET /api/device/prompt-policy — Read device-level prompt policy
+ * Auth: deviceSecret (owner)
+ */
+app.get('/api/device/prompt-policy', (req, res) => {
+    const { deviceId, deviceSecret } = req.query;
+    if (!deviceId) return res.status(400).json({ success: false, error: 'deviceId required' });
+    const device = devices[deviceId];
+    if (!device) return res.status(404).json({ success: false, error: 'Device not found' });
+    const auth = requireDeviceOwner(device, deviceSecret);
+    if (auth.error) return res.status(auth.status).json({ success: false, error: auth.error });
+    res.json({ success: true, promptPolicy: device.promptPolicy || null });
+});
+
+/**
+ * PUT /api/device/prompt-policy — Set device-level prompt policy
+ * Auth: deviceSecret (owner)
+ */
+app.put('/api/device/prompt-policy', async (req, res) => {
+    const { deviceId, deviceSecret, promptPolicy } = req.body || {};
+    if (!deviceId) return res.status(400).json({ success: false, error: 'deviceId required' });
+    const device = devices[deviceId];
+    if (!device) return res.status(404).json({ success: false, error: 'Device not found' });
+    const auth = requireDeviceOwner(device, deviceSecret);
+    if (auth.error) return res.status(auth.status).json({ success: false, error: auth.error });
+
+    const { valid, promptPolicy: cleaned, error } = validatePromptPolicy(promptPolicy);
+    if (!valid) return res.status(400).json({ success: false, error });
+
+    device.promptPolicy = cleaned;
+    if (typeof db.saveDeviceData === 'function') {
+        db.saveDeviceData(deviceId, device).catch(err => console.error('[PromptPolicy] Device save error:', err.message));
+    }
+    io.to(deviceId).emit('prompt-policy:updated', { scope: 'device', promptPolicy: cleaned });
+    serverLog('info', 'prompt-policy', 'Device prompt policy updated', { deviceId });
+    res.json({ success: true, promptPolicy: cleaned });
+});
+
+/**
+ * GET /api/entity/:entityId/prompt-policy — Read entity-level prompt policy
+ * Auth: deviceSecret (owner)
+ */
+app.get('/api/entity/:entityId/prompt-policy', (req, res) => {
+    const { deviceId, deviceSecret } = req.query;
+    const { entityId } = req.params;
+    if (!deviceId || entityId === undefined) return res.status(400).json({ success: false, error: 'deviceId, entityId required' });
+    const device = devices[deviceId];
+    if (!device) return res.status(404).json({ success: false, error: 'Device not found' });
+    const owner = requireDeviceOwner(device, deviceSecret);
+    if (owner.error) return res.status(owner.status).json({ success: false, error: owner.error });
+    const entity = device.entities[parseInt(entityId)];
+    if (!entity) return res.status(404).json({ success: false, error: 'Entity not found' });
+    res.json({ success: true, promptPolicy: getEntityPromptPolicy(entity) });
+});
+
+/**
+ * PUT /api/entity/:entityId/prompt-policy — Set entity-level prompt policy
+ * Auth: deviceSecret (owner)
+ */
+app.put('/api/entity/:entityId/prompt-policy', async (req, res) => {
+    const { deviceId, deviceSecret, promptPolicy } = req.body || {};
+    const { entityId } = req.params;
+    if (!deviceId || entityId === undefined) return res.status(400).json({ success: false, error: 'deviceId, entityId required' });
+    const device = devices[deviceId];
+    if (!device) return res.status(404).json({ success: false, error: 'Device not found' });
+    const owner = requireDeviceOwner(device, deviceSecret);
+    if (owner.error) return res.status(owner.status).json({ success: false, error: owner.error });
+    const entity = device.entities[parseInt(entityId)];
+    if (!entity) return res.status(404).json({ success: false, error: 'Entity not found' });
+
+    const { valid, promptPolicy: cleaned, error } = validatePromptPolicy(promptPolicy);
+    if (!valid) return res.status(400).json({ success: false, error });
+
+    setEntityPromptPolicy(entity, cleaned);
+    if (typeof db.saveDeviceData === 'function') {
+        db.saveDeviceData(deviceId, device).catch(err => console.error('[PromptPolicy] Entity save error:', err.message));
+    }
+    io.to(deviceId).emit('prompt-policy:updated', { scope: 'entity', entityId: parseInt(entityId), promptPolicy: cleaned });
+    serverLog('info', 'prompt-policy', `Entity ${entityId} prompt policy updated`, { deviceId, entityId: parseInt(entityId) });
+    res.json({ success: true, promptPolicy: cleaned });
+});
+
+/**
+ * GET /api/channel/prompt-policy — Read composed prompt policy for channel bridges
+ * Auth: deviceSecret (owner preview) OR botSecret (bound channel runtime)
+ */
+app.get('/api/channel/prompt-policy', (req, res) => {
+    const { deviceId, deviceSecret, botSecret, entityId, channel } = req.query;
+    if (!deviceId || entityId === undefined) {
+        return res.status(400).json({ success: false, error: 'deviceId, entityId required' });
+    }
+    if (!deviceSecret && !botSecret) {
+        return res.status(400).json({ success: false, error: 'deviceSecret or botSecret required' });
+    }
+    const device = devices[deviceId];
+    if (!device) return res.status(404).json({ success: false, error: 'Device not found' });
+    const auth = authEntityAccess(device, deviceSecret, botSecret, entityId);
+    if (auth.error) return res.status(auth.status).json({ success: false, error: auth.error });
+
+    const policy = buildPromptPolicySections(device, auth.entity, channel || 'generic');
+    res.json({
+        success: true,
+        policy,
+        devicePolicy: device.promptPolicy || null,
+        entityPolicy: getEntityPromptPolicy(auth.entity)
+    });
 });
 
 // ── Agent Card Holder (replaces Cross-Device Contacts — no upper limit) ──

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -196,6 +196,36 @@
             display: flex;
         }
 
+        .policy-grid {
+            display: grid;
+            gap: 12px;
+        }
+
+        .policy-textarea {
+            width: 100%;
+            min-height: 92px;
+            resize: vertical;
+            padding: 10px 12px;
+            border: 1px solid var(--card-border);
+            border-radius: var(--radius-sm);
+            background: var(--input-bg);
+            color: var(--text);
+            font: 13px/1.5 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        }
+
+        .policy-preview {
+            display: none;
+            white-space: pre-wrap;
+            max-height: 260px;
+            overflow: auto;
+            padding: 12px;
+            border: 1px solid var(--card-border);
+            border-radius: var(--radius-sm);
+            background: var(--bg);
+            color: var(--text-secondary);
+            font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+        }
+
         /* ── Cancel section ── */
         .cancel-section {
             margin-top: 12px;
@@ -866,6 +896,68 @@
                         </label>
                     </div>
                 </div>
+
+                <!-- Agent Policy -->
+                <div style="margin-top:18px;padding-top:16px;border-top:1px solid var(--card-border);">
+                    <div class="card-title" style="font-size:14px;margin-bottom:6px;">
+                        <span>🧭 Agent Policy</span>
+                    </div>
+                    <p class="section-desc">Centrally injects device-level system prompt policy into Codex, Claude, and future channel bridges.</p>
+                    <div class="policy-grid">
+                        <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;">
+                            <input type="checkbox" id="promptPolicyEnabled">
+                            <span>Enable device prompt policy</span>
+                        </label>
+
+                        <label style="display:block;">
+                            <span class="setting-row-label">Device instructions</span>
+                            <textarea id="promptPolicyInstructions" class="policy-textarea" placeholder="One instruction per line"></textarea>
+                        </label>
+
+                        <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:10px;">
+                            <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;">
+                                <input type="checkbox" id="promptPolicyRequirePlan">
+                                <span>Require test plan</span>
+                            </label>
+                            <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;">
+                                <input type="checkbox" id="promptPolicyRequireMilestones">
+                                <span>Require milestone updates</span>
+                            </label>
+                            <label style="display:flex;align-items:center;gap:8px;font-size:13px;">
+                                <span>Heartbeat min</span>
+                                <input type="number" id="promptPolicyHeartbeatMinutes" min="1" max="30" step="1"
+                                       style="width:70px;padding:6px 8px;border:1px solid var(--card-border);border-radius:6px;background:var(--bg);color:var(--text);text-align:right;">
+                            </label>
+                        </div>
+
+                        <label style="display:block;">
+                            <span class="setting-row-label">Codex override</span>
+                            <textarea id="promptPolicyCodexOverride" class="policy-textarea" placeholder="Codex-only instructions"></textarea>
+                        </label>
+
+                        <label style="display:block;">
+                            <span class="setting-row-label">Claude Code override</span>
+                            <textarea id="promptPolicyClaudeOverride" class="policy-textarea" placeholder="Claude Code-only instructions"></textarea>
+                        </label>
+
+                        <div style="display:flex;flex-wrap:wrap;gap:8px;align-items:center;">
+                            <button class="btn btn-primary btn-sm" onclick="savePromptPolicy()" id="promptPolicySaveBtn">Save Policy</button>
+                            <button class="btn btn-outline btn-sm" onclick="loadPromptPolicy()">Refresh</button>
+                            <span style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--text-secondary);">
+                                Preview entity #
+                                <input type="number" id="promptPolicyPreviewEntity" min="0" step="1" value="0"
+                                       style="width:64px;padding:6px 8px;border:1px solid var(--card-border);border-radius:6px;background:var(--bg);color:var(--text);text-align:right;">
+                            </span>
+                            <select id="promptPolicyPreviewChannel" style="padding:6px 8px;border:1px solid var(--card-border);border-radius:6px;background:var(--bg);color:var(--text);">
+                                <option value="codex">codex</option>
+                                <option value="claude_code">claude_code</option>
+                            </select>
+                            <button class="btn btn-outline btn-sm" onclick="previewPromptPolicy()">Preview</button>
+                        </div>
+                        <div id="promptPolicyStatus" class="section-desc" style="margin:0;"></div>
+                        <pre id="promptPolicyPreview" class="policy-preview"></pre>
+                    </div>
+                </div>
             </div>
         </div>
 
@@ -1216,6 +1308,7 @@
             loadViewModePreference();
             loadNotifPreferences();
             loadDevicePreferences();
+            loadPromptPolicy(user);
             initKanbanNudgeCollapse();
             updatePushToggle();
 
@@ -2072,6 +2165,105 @@
                 await apiCall('PUT', '/api/device-preferences', { prefs });
             } catch (e) {
                 showToast(i18n.t('toast_preference_update_failed'), 'error');
+            }
+        }
+
+        // ── Agent prompt policy ──
+        function getPromptPolicyLines(id) {
+            const el = document.getElementById(id);
+            if (!el) return [];
+            return String(el.value || '')
+                .split('\n')
+                .map(line => line.trim())
+                .filter(Boolean);
+        }
+
+        function setPromptPolicyLines(id, lines) {
+            const el = document.getElementById(id);
+            if (el) el.value = Array.isArray(lines) ? lines.join('\n') : '';
+        }
+
+        function setPromptPolicyStatus(message, isError = false) {
+            const el = document.getElementById('promptPolicyStatus');
+            if (!el) return;
+            el.textContent = message || '';
+            el.style.color = isError ? 'var(--danger)' : 'var(--text-secondary)';
+        }
+
+        async function loadPromptPolicy(user = currentUser) {
+            if (!user?.deviceId || !user?.deviceSecret) return;
+            try {
+                const path = `/api/device/prompt-policy?deviceId=${encodeURIComponent(user.deviceId)}&deviceSecret=${encodeURIComponent(user.deviceSecret)}`;
+                const data = await apiCall('GET', path);
+                const policy = data.promptPolicy || {};
+                document.getElementById('promptPolicyEnabled').checked = policy.enabled !== false;
+                setPromptPolicyLines('promptPolicyInstructions', policy.instructions || []);
+                document.getElementById('promptPolicyRequirePlan').checked = policy.taskProtocol?.requireTestPlan !== false;
+                document.getElementById('promptPolicyRequireMilestones').checked = policy.taskProtocol?.requireMilestoneUpdates !== false;
+                document.getElementById('promptPolicyHeartbeatMinutes').value = Math.round((policy.taskProtocol?.statusHeartbeatMs || 180000) / 60000);
+                setPromptPolicyLines('promptPolicyCodexOverride', policy.channelOverrides?.codex?.instructions || []);
+                setPromptPolicyLines('promptPolicyClaudeOverride', policy.channelOverrides?.claude_code?.instructions || []);
+                setPromptPolicyStatus(policy.updatedAt ? `Loaded policy updated ${policy.updatedAt}` : 'No saved policy yet.');
+            } catch (e) {
+                setPromptPolicyStatus('Failed to load prompt policy', true);
+            }
+        }
+
+        async function savePromptPolicy(user = currentUser) {
+            if (!user?.deviceId || !user?.deviceSecret) return;
+            const btn = document.getElementById('promptPolicySaveBtn');
+            if (btn) btn.disabled = true;
+            try {
+                const heartbeatMinutes = Math.max(1, Math.min(30, parseInt(document.getElementById('promptPolicyHeartbeatMinutes').value) || 3));
+                const policy = {
+                    enabled: document.getElementById('promptPolicyEnabled').checked,
+                    instructions: getPromptPolicyLines('promptPolicyInstructions'),
+                    taskProtocol: {
+                        requireTestPlan: document.getElementById('promptPolicyRequirePlan').checked,
+                        requireMilestoneUpdates: document.getElementById('promptPolicyRequireMilestones').checked,
+                        statusHeartbeatMs: heartbeatMinutes * 60000
+                    },
+                    channelOverrides: {
+                        codex: {
+                            enabled: true,
+                            instructions: getPromptPolicyLines('promptPolicyCodexOverride')
+                        },
+                        claude_code: {
+                            enabled: true,
+                            instructions: getPromptPolicyLines('promptPolicyClaudeOverride')
+                        }
+                    }
+                };
+                await apiCall('PUT', '/api/device/prompt-policy', {
+                    deviceId: user.deviceId,
+                    deviceSecret: user.deviceSecret,
+                    promptPolicy: policy
+                });
+                setPromptPolicyStatus('Policy saved.');
+                showToast('Prompt policy saved');
+            } catch (e) {
+                setPromptPolicyStatus(e.message || 'Failed to save prompt policy', true);
+                showToast(e.message || 'Failed to save prompt policy', 'error');
+            } finally {
+                if (btn) btn.disabled = false;
+            }
+        }
+
+        async function previewPromptPolicy(user = currentUser) {
+            if (!user?.deviceId || !user?.deviceSecret) return;
+            const preview = document.getElementById('promptPolicyPreview');
+            const entityId = Math.max(0, parseInt(document.getElementById('promptPolicyPreviewEntity').value) || 0);
+            const channel = document.getElementById('promptPolicyPreviewChannel').value || 'codex';
+            if (preview) {
+                preview.style.display = 'block';
+                preview.textContent = 'Loading...';
+            }
+            try {
+                const path = `/api/channel/prompt-policy?deviceId=${encodeURIComponent(user.deviceId)}&deviceSecret=${encodeURIComponent(user.deviceSecret)}&entityId=${entityId}&channel=${encodeURIComponent(channel)}`;
+                const data = await apiCall('GET', path);
+                if (preview) preview.textContent = data.policy?.compiledPrompt || '(empty policy)';
+            } catch (e) {
+                if (preview) preview.textContent = e.message || 'Preview failed';
             }
         }
 

--- a/backend/tests/jest/identity.test.js
+++ b/backend/tests/jest/identity.test.js
@@ -281,3 +281,112 @@ describe('Agent Card backward compatibility', () => {
         expect(res.status).toBe(404); // device not found
     });
 });
+
+// ── Prompt Policy orchestration ──
+describe('Prompt Policy endpoints', () => {
+    beforeEach(() => {
+        for (const key of Object.keys(app.devices)) delete app.devices[key];
+        const entity = app._createDefaultEntity(6);
+        entity.isBound = true;
+        entity.botSecret = 'bot-secret';
+        entity.name = 'Codex';
+        entity.identity = {
+            role: 'QA reviewer',
+            instructions: ['Review UI and API regressions']
+        };
+        app.devices['prompt-device'] = {
+            deviceId: 'prompt-device',
+            deviceSecret: 'device-secret',
+            createdAt: Date.now(),
+            nextEntityId: 7,
+            promptPolicy: null,
+            entities: { 6: entity }
+        };
+    });
+
+    test('PUT /api/device/prompt-policy saves sanitized policy', async () => {
+        const res = await request(app)
+            .put('/api/device/prompt-policy')
+            .send({
+                deviceId: 'prompt-device',
+                deviceSecret: 'device-secret',
+                promptPolicy: {
+                    instructions: 'Use short status updates.\nAlways name blockers.',
+                    taskProtocol: { statusHeartbeatMs: 5000 },
+                    channelOverrides: {
+                        codex: { instructions: ['Prefer test-plan first replies.'] }
+                    }
+                }
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.promptPolicy.instructions).toEqual(['Use short status updates.', 'Always name blockers.']);
+        expect(res.body.promptPolicy.taskProtocol.statusHeartbeatMs).toBe(60000);
+        expect(app.devices['prompt-device'].promptPolicy.channelOverrides.codex.instructions).toEqual(['Prefer test-plan first replies.']);
+    });
+
+    test('PUT /api/entity/:entityId/prompt-policy stores policy under identity', async () => {
+        const res = await request(app)
+            .put('/api/entity/6/prompt-policy')
+            .send({
+                deviceId: 'prompt-device',
+                deviceSecret: 'device-secret',
+                promptPolicy: {
+                    instructions: ['When running QA, report page and command progress.'],
+                    channelOverrides: {
+                        claude_code: { instructions: ['Use concise wake-up diagnostics.'] }
+                    }
+                }
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body.promptPolicy.instructions).toEqual(['When running QA, report page and command progress.']);
+        expect(app.devices['prompt-device'].entities[6].identity.promptPolicy.instructions).toEqual([
+            'When running QA, report page and command progress.'
+        ]);
+    });
+
+    test('GET /api/channel/prompt-policy composes device, identity, entity, and channel policy', async () => {
+        app.devices['prompt-device'].promptPolicy = {
+            version: 1,
+            enabled: true,
+            instructions: ['Device-wide system prompt.'],
+            taskProtocol: { requireTestPlan: true, requireMilestoneUpdates: true, statusHeartbeatMs: 180000 },
+            channelOverrides: { codex: { enabled: true, instructions: ['Codex override.'] } }
+        };
+        app.devices['prompt-device'].entities[6].identity.promptPolicy = {
+            version: 1,
+            enabled: true,
+            instructions: ['Entity prompt policy.'],
+            taskProtocol: { requireTestPlan: true, requireMilestoneUpdates: true, statusHeartbeatMs: 120000 },
+            channelOverrides: {}
+        };
+
+        const res = await request(app)
+            .get('/api/channel/prompt-policy?deviceId=prompt-device&entityId=6&botSecret=bot-secret&channel=codex');
+
+        expect(res.status).toBe(200);
+        expect(res.body.policy.channel).toBe('codex');
+        expect(res.body.policy.taskProtocol.statusHeartbeatMs).toBe(120000);
+        expect(res.body.policy.compiledPrompt).toContain('Device-wide system prompt.');
+        expect(res.body.policy.compiledPrompt).toContain('Role: QA reviewer');
+        expect(res.body.policy.compiledPrompt).toContain('Entity prompt policy.');
+        expect(res.body.policy.compiledPrompt).toContain('Codex override.');
+    });
+
+    test('rejects likely secrets in prompt policy', async () => {
+        const res = await request(app)
+            .put('/api/device/prompt-policy')
+            .send({
+                deviceId: 'prompt-device',
+                deviceSecret: 'device-secret',
+                promptPolicy: {
+                    instructions: ['api_key=sk-thisShouldNotBeStoredInPromptPolicy1234567890']
+                }
+            });
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/secret/i);
+    });
+});


### PR DESCRIPTION
## Summary
- Add device-level prompt policy persistence with devices.prompt_policy and load/save support.
- Add prompt policy APIs for device policy, entity policy, and composed channel runtime policy.
- Add Settings > Developer > Agent Policy UI for editing device instructions, task protocol, Codex/Claude overrides, and previewing compiled policy.
- Add regression coverage for policy validation, entity storage, channel composition, and likely-secret rejection.

## Verification
- npx jest tests/jest/identity.test.js --runInBand
- Full backend Jest suite was also run accidentally through the package script and passed: 150 suites / 2428 tests.
- Static UI marker check for Settings Agent Policy controls.

## Notes
- Local portal server could not stay running without a local PostgreSQL service; backend endpoints are covered by Jest and the UI follows existing Settings API patterns.