### PR TITLE
Fix chat initial render delay from label resolution

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,6 +434,7 @@ EClaw/
    | Bug | Endpoint | Created | Status |
    |-----|----------|---------|--------|
    | Interview start fails with owner_device_not_found | `GET /api/rental/debug/interview-start-fail?deviceId=X&deviceSecret=Y` | 2026-04-12 | Active |
+   | Chat first render delayed by cross-device label resolution | `GET /api/debug/chat-render-load-order?deviceId=X&deviceSecret=Y` | 2026-05-01 | Active |
 
 6. **Demand Elegance (Balanced)** — 在保持 minimal change 的前提下，追求可讀、一致的程式風格；不為了「漂亮」而過度重構，但也不容忍明顯的 code smell 在新增的程式碼中出現。
 
@@ -1150,6 +1151,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | AI Support Extended | `tests/jest/ai-support-extended.test.js` | Extended AI support chat validation |
 | Bot Registration | `tests/jest/bot-registration.test.js` | Bot registration endpoint validation |
 | Chat | `tests/jest/chat.test.js` | Chat history, file upload, message reactions |
+| Chat Render Load Order | `tests/jest/chat-render-load-order.test.js` | Static regression: chat.html renders history before async cross-device label lookups; no credentials |
 | Customer Service Tools | `tests/jest/customer-service-tools.test.js` | Customer service AI tool handler validation |
 | Entity Management | `tests/jest/entity-management.test.js` | Entity CRUD, reorder, refresh validation |
 | Entity Slot Compact | `tests/jest/entity-slot-compact.test.js` | Slot compaction renumbering validation |

--- a/backend/index.js
+++ b/backend/index.js
@@ -2167,6 +2167,130 @@ app.get('/api/debug/dashboard-empty', async (req, res) => {
     }
 });
 
+// Temporary diagnostic endpoint for the 2026-05-01 chat first-render delay.
+// Keep it content-safe: report counts, source shapes, and lookup pressure only;
+// never return chat text, secrets, tokens, or raw message payloads.
+app.get('/api/debug/chat-render-load-order', async (req, res) => {
+    const { deviceId, deviceSecret } = req.query || {};
+    const timestamp = new Date().toISOString();
+    try {
+        if (!deviceId || !deviceSecret) {
+            return res.status(401).json({ success: false, bug: 'chat-render-load-order', error: 'deviceId and deviceSecret required', timestamp });
+        }
+
+        const memDevice = devices[deviceId];
+        const pool = db._getPool ? db._getPool() : authModule.pool;
+        const dbDevice = pool
+            ? await pool.query('SELECT device_secret FROM devices WHERE device_id = $1', [deviceId])
+            : { rows: [] };
+        const dbDeviceRow = dbDevice.rows[0] || null;
+        const memSecretOk = !!(memDevice && memDevice.deviceSecret && safeEqual(memDevice.deviceSecret, deviceSecret));
+        const dbSecretOk = !!(dbDeviceRow && dbDeviceRow.device_secret && safeEqual(dbDeviceRow.device_secret, deviceSecret));
+        if (!memSecretOk && !dbSecretOk) {
+            return res.status(403).json({ success: false, bug: 'chat-render-load-order', error: 'Invalid credentials', timestamp });
+        }
+
+        const [historyRows, entityRows] = pool ? await Promise.all([
+            pool.query(
+                `SELECT id, source, entity_id, is_from_user, is_from_bot, created_at
+                 FROM chat_messages
+                 WHERE device_id = $1
+                 ORDER BY created_at DESC
+                 LIMIT 500`,
+                [deviceId]
+            ),
+            pool.query(
+                `SELECT entity_id, is_bound, public_code
+                 FROM entities
+                 WHERE device_id = $1
+                 ORDER BY entity_id ASC`,
+                [deviceId]
+            ),
+        ]) : [{ rows: [] }, { rows: [] }];
+
+        const xdeviceCodes = new Set();
+        let xdeviceMessageCount = 0;
+        let sameDeviceRouteCount = 0;
+        let uuidStyleCodeCount = 0;
+        const sourceShapes = {};
+
+        for (const row of historyRows.rows) {
+            const source = row.source || '';
+            const shape = source.startsWith('xdevice:')
+                ? 'xdevice'
+                : source.startsWith('entity:')
+                    ? 'entity-route'
+                    : source || '(empty)';
+            sourceShapes[shape] = (sourceShapes[shape] || 0) + 1;
+
+            const xmatch = source.match(/^xdevice:([a-z0-9-]+):([^:]+)->(.+)$/);
+            if (xmatch) {
+                xdeviceMessageCount += 1;
+                xdeviceCodes.add(xmatch[1]);
+                xdeviceCodes.add(xmatch[3]);
+                continue;
+            }
+            if (/^entity:\d+:[^:]+->/.test(source)) sameDeviceRouteCount += 1;
+        }
+
+        const ownPublicCodes = new Set(entityRows.rows.map(r => r.public_code).filter(Boolean));
+        const lookupEligibleCodes = [];
+        for (const code of xdeviceCodes) {
+            if (!code || ownPublicCodes.has(code)) continue;
+            if (code.includes('-')) {
+                uuidStyleCodeCount += 1;
+                continue;
+            }
+            lookupEligibleCodes.push(code);
+        }
+
+        res.json({
+            success: true,
+            bug: 'chat-render-load-order',
+            diagnostics: {
+                server: {
+                    build: SERVER_BUILD_TAG,
+                    startedAt: SERVER_STARTED_AT.toISOString(),
+                    uptimeSec: Math.round(process.uptime()),
+                },
+                auth: {
+                    memSecretOk,
+                    dbSecretOk,
+                    requestUserDeviceId: req.user?.deviceId || null,
+                    requestUserId: req.user?.userId || null,
+                },
+                historyWindow: {
+                    limit: 500,
+                    returned: historyRows.rows.length,
+                    oldestAt: historyRows.rows.length ? historyRows.rows[historyRows.rows.length - 1].created_at : null,
+                    newestAt: historyRows.rows.length ? historyRows.rows[0].created_at : null,
+                },
+                routeSources: {
+                    sourceShapes,
+                    xdeviceMessageCount,
+                    sameDeviceRouteCount,
+                    uniqueXdeviceCodeCount: xdeviceCodes.size,
+                    lookupEligibleCodeCount: lookupEligibleCodes.length,
+                    uuidStyleCodeCount,
+                },
+                entities: {
+                    total: entityRows.rows.length,
+                    bound: entityRows.rows.filter(r => r.is_bound).length,
+                    ownPublicCodeCount: ownPublicCodes.size,
+                },
+                clientFix: {
+                    firstRenderBeforeXdeviceLookup: true,
+                    lookupRunsInBackground: true,
+                },
+            },
+            timestamp,
+        });
+    } catch (err) {
+        console.error('[Debug chat-render-load-order] failed:', err);
+        res.status(500).json({ success: false, bug: 'chat-render-load-order', error: err.message, timestamp });
+    }
+});
+
 // Wire up pending message flush on email verification
 authModule.setOnEmailVerified(async (deviceId) => {
     console.log(`[PendingFlush] onEmailVerified triggered for device ${deviceId}`);

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -2888,8 +2888,11 @@
         let contacts = [];           // from /api/contacts
         let contactsLoaded = false;
         let _renderVersion = 0;
+        let _xdeviceResolutionSeq = 0;
         let myPublicCodeMap = {};   // publicCode -> { entityId, label }
         let xdeviceLabelCache = {}; // publicCode -> label (remote entities)
+        const xdeviceLookupInFlight = new Set();
+        const xdeviceLookupMissCache = new Set();
 
         // ── Chat Integrity Validator ──
         const ChatIntegrityValidator = (() => {
@@ -3715,9 +3718,9 @@
                     const prevCount = allMessages.length;
                     allMessages = data.messages;
                     _sourceParseCache.clear();
-                    await resolveXDeviceCodes(allMessages);
                     renderFilterChips();
                     renderMessages(prevCount < allMessages.length);
+                    refreshXDeviceLabelsInBackground(allMessages);
                     ChatIntegrityValidator.validateDataLayer(data.messages);
                 }
             } catch (e) {
@@ -4031,19 +4034,41 @@
                     if (!myPublicCodeMap[t] && !xdeviceLabelCache[t]) unknownCodes.add(t);
                 }
             }
-            const lookups = Array.from(unknownCodes)
+
+            const codesToLookup = Array.from(unknownCodes)
                 .filter(code => !code.includes('-')) // Skip UUID-style device IDs (owner mode); they aren't public codes
-                .map(async code => {
+                .filter(code => !xdeviceLookupInFlight.has(code) && !xdeviceLookupMissCache.has(code));
+
+            let resolvedAny = false;
+            const lookups = codesToLookup.map(async code => {
+                xdeviceLookupInFlight.add(code);
                 try {
                     const data = await apiCall('GET', `/api/entity/lookup?code=${encodeURIComponent(code)}`);
                     if (data.success && data.entity) {
                         const e = data.entity;
                         const avatar = e.avatar || (e.character === 'PIG' ? '\u{1F437}' : '\u{1F99E}');
                         xdeviceLabelCache[code] = `${renderAvatarHtml(avatar, 20)} ${escapeHtml(e.name || e.character)}`;
+                        resolvedAny = true;
+                    } else {
+                        xdeviceLookupMissCache.add(code);
                     }
-                } catch (_) { /* silent — will show raw code as fallback */ }
+                } catch (_) {
+                    xdeviceLookupMissCache.add(code);
+                } finally {
+                    xdeviceLookupInFlight.delete(code);
+                }
             });
             await Promise.all(lookups);
+            return resolvedAny;
+        }
+
+        function refreshXDeviceLabelsInBackground(messages) {
+            const seq = ++_xdeviceResolutionSeq;
+            resolveXDeviceCodes(messages).then(resolvedAny => {
+                if (!resolvedAny || seq !== _xdeviceResolutionSeq) return;
+                renderFilterChips();
+                renderMessages(false);
+            }).catch(() => {});
         }
 
         // ── Render Messages ──

--- a/backend/tests/jest/chat-render-load-order.test.js
+++ b/backend/tests/jest/chat-render-load-order.test.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const chatHtml = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'chat.html'), 'utf8');
+const indexJs = fs.readFileSync(path.join(ROOT, 'index.js'), 'utf8');
+
+describe('chat.html initial render order', () => {
+    test('loadMessages renders chat history before cross-device label lookups', () => {
+        const start = chatHtml.indexOf('async function loadMessages()');
+        expect(start).toBeGreaterThan(0);
+        const end = chatHtml.indexOf('// ── Filtering ──', start);
+        expect(end).toBeGreaterThan(start);
+        const body = chatHtml.slice(start, end);
+
+        expect(body).not.toMatch(/await\s+resolveXDeviceCodes\(/);
+        expect(body).not.toMatch(/await\s+refreshXDeviceLabelsInBackground\(/);
+
+        const renderIndex = body.indexOf('renderMessages(prevCount < allMessages.length);');
+        const backgroundIndex = body.indexOf('refreshXDeviceLabelsInBackground(allMessages);');
+        expect(renderIndex).toBeGreaterThan(0);
+        expect(backgroundIndex).toBeGreaterThan(renderIndex);
+    });
+
+    test('background cross-device label refresh updates the already-rendered chat safely', () => {
+        const start = chatHtml.indexOf('function refreshXDeviceLabelsInBackground(messages)');
+        expect(start).toBeGreaterThan(0);
+        const end = chatHtml.indexOf('// ── Render Messages ──', start);
+        expect(end).toBeGreaterThan(start);
+        const body = chatHtml.slice(start, end);
+
+        expect(body).toContain('resolveXDeviceCodes(messages).then(resolvedAny =>');
+        expect(body).toContain('if (!resolvedAny || seq !== _xdeviceResolutionSeq) return;');
+        expect(body).toContain('renderFilterChips();');
+        expect(body).toContain('renderMessages(false);');
+        expect(body).toContain('.catch(() => {});');
+    });
+
+    test('debug endpoint reports render-load diagnostics without chat message text', () => {
+        const start = indexJs.indexOf("app.get('/api/debug/chat-render-load-order'");
+        expect(start).toBeGreaterThan(0);
+        const end = indexJs.indexOf('// Wire up pending message flush on email verification', start);
+        expect(end).toBeGreaterThan(start);
+        const body = indexJs.slice(start, end);
+
+        expect(body).toContain('lookupEligibleCodeCount');
+        expect(body).toContain('firstRenderBeforeXdeviceLookup: true');
+        expect(body).toContain('lookupRunsInBackground: true');
+        expect(body).toMatch(/SELECT id, source, entity_id, is_from_user, is_from_bot, created_at/);
+        expect(body).not.toMatch(/SELECT[\s\S]*(text|message)[\s\S]*FROM chat_messages/);
+    });
+});


### PR DESCRIPTION
## Summary
- Render chat history immediately after `/api/chat/history` returns instead of blocking first paint on cross-device label lookup.
- Move cross-device label resolution into a guarded background refresh with in-flight and miss caches.
- Add a temporary authenticated debug endpoint for the chat render-delay incident that reports counts/source shapes only, without chat text.
- Register the new regression test and active debug endpoint in `AGENTS.md`.

## Verification
- Observed production `/portal/chat.html` for 5 minutes: page initially stayed on loading, then eventually rendered the 500-message window.
- `NODE_PATH=/Users/hank/Desktop/Project/EClaw/backend/node_modules PATH=/Users/hank/Desktop/Project/EClaw/backend/node_modules/.bin:$PATH npm test -- --runTestsByPath tests/jest/chat-render-load-order.test.js`
- `NODE_PATH=/Users/hank/Desktop/Project/EClaw/backend/node_modules PATH=/Users/hank/Desktop/Project/EClaw/backend/node_modules/.bin:$PATH npm run lint` (0 errors, 7 existing warnings)
- `NODE_PATH=/Users/hank/Desktop/Project/EClaw/backend/node_modules PATH=/Users/hank/Desktop/Project/EClaw/backend/node_modules/.bin:$PATH npm test` (151 suites / 2427 tests passed)

## Notes
- Debug endpoint: `GET /api/debug/chat-render-load-order?deviceId=X&deviceSecret=Y`
- The endpoint is intentionally content-safe: it queries only message IDs/source flags/timestamps and aggregate counts, not message text.