### PR TITLE
Fix Agent Policy editor deep links

### DIFF
--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1363,9 +1363,8 @@
             initKanbanNudgeCollapse();
             updatePushToggle();
 
-            if (typeof applyDeepLinkFocus === 'function') applyDeepLinkFocus();
-
             document.getElementById('pageContent').style.display = '';
+            if (typeof applyDeepLinkFocus === 'function') applyDeepLinkFocus();
             initTapPay();
 
             setInterval(loadSubscriptionStatus, 15000);
@@ -2345,7 +2344,9 @@
 
             onPromptPolicyScopeChange();
             loadPromptPolicy(user);
-            setTimeout(() => document.getElementById('agentPolicySection')?.scrollIntoView({ behavior: 'smooth', block: 'start' }), 0);
+            requestAnimationFrame(() => {
+                document.getElementById('agentPolicySection')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            });
         }
 
         function applyDeepLinkFocus() {

--- a/backend/tests/jest/settings-prompt-policy-dashboard.test.js
+++ b/backend/tests/jest/settings-prompt-policy-dashboard.test.js
@@ -56,5 +56,14 @@ describe('Settings Agent Policy dashboard editor', () => {
         expect(html).toContain("params.get('scope') === 'entity'");
         expect(html).toContain("window.location.hash === '#agent-policy'");
         expect(html).toContain("loadPromptPolicy(user)");
+        expect(html).toContain("requestAnimationFrame(() =>");
+    });
+
+    test('applies Agent Policy deep links after settings content is visible', () => {
+        const showContentIndex = html.indexOf("document.getElementById('pageContent').style.display = '';");
+        const deepLinkIndex = html.indexOf("if (typeof applyDeepLinkFocus === 'function') applyDeepLinkFocus();");
+        expect(showContentIndex).toBeGreaterThan(-1);
+        expect(deepLinkIndex).toBeGreaterThan(-1);
+        expect(showContentIndex).toBeLessThan(deepLinkIndex);
     });
 });


### PR DESCRIPTION
## Summary
- Apply Agent Policy deep links after Settings content is visible
- Use requestAnimationFrame before scrolling to the Agent Policy editor
- Add static coverage for the deep-link timing

## Verification
- `npm test -- --runTestsByPath tests/jest/settings-prompt-policy-dashboard.test.js tests/jest/dashboard-agent-policy-card.test.js`
- `npm run lint` (passes with existing warnings in article-publisher/interview-arena/wallet)