### PR TITLE
feat: hide dashboard agent policy until edit mode

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -1433,8 +1433,12 @@
         }
 
         .agent-policy-card {
+            display: none;
             margin-bottom: 16px;
             padding: 16px 18px;
+        }
+        .agent-policy-card.is-visible {
+            display: block;
         }
         .agent-policy-header {
             display: flex;
@@ -1563,7 +1567,7 @@
             <button type="button" class="invite-banner-close" onclick="dismissInviteBanner()" aria-label="Dismiss" title="Hide for 7 days">×</button>
         </div>
 
-        <section class="card agent-policy-card" id="dashboardAgentPolicyCard" aria-labelledby="dashboardAgentPolicyTitle">
+        <section class="card agent-policy-card" id="dashboardAgentPolicyCard" aria-labelledby="dashboardAgentPolicyTitle" aria-hidden="true">
             <div class="agent-policy-header">
                 <div>
                     <div class="agent-policy-title" id="dashboardAgentPolicyTitle">
@@ -1985,7 +1989,6 @@
             renderSlotSelector();
 
             await loadEntities();
-            loadDashboardPromptPolicy().catch(err => console.warn('[AgentPolicy] dashboard load failed', err));
 
             if (__embeddedOrg) switchDashTab('orgchart');
 
@@ -2059,6 +2062,22 @@
             if (!input || input.dataset.userTouched === '1') return;
             const entityId = findPreferredPolicyEntityId();
             input.value = entityId ? String(entityId) : '0';
+        }
+
+        function setDashboardAgentPolicyCardVisible(visible) {
+            const card = document.getElementById('dashboardAgentPolicyCard');
+            if (!card) return;
+            card.classList.toggle('is-visible', visible);
+            card.setAttribute('aria-hidden', visible ? 'false' : 'true');
+            if (visible) {
+                loadDashboardPromptPolicy().catch(err => console.warn('[AgentPolicy] dashboard load failed', err));
+            } else {
+                const preview = document.getElementById('dashboardAgentPolicyPreview');
+                if (preview) {
+                    preview.style.display = 'none';
+                    preview.textContent = '';
+                }
+            }
         }
 
         function getDashboardOverrideLabels(policy = {}) {
@@ -2498,6 +2517,7 @@
                 var orderChanged = JSON.stringify(currentOrder) !== JSON.stringify(originalEntityOrder);
                 isEditMode = false;
                 document.getElementById('btnEditMode').classList.remove('active');
+                setDashboardAgentPolicyCardVisible(false);
                 renderEntities();
                 if (orderChanged) {
                     persistReorder(currentOrder);
@@ -2510,6 +2530,7 @@
                 originalEntityOrder = entities.map(function(e) { return e.entityId; });
                 isEditMode = true;
                 document.getElementById('btnEditMode').classList.add('active');
+                setDashboardAgentPolicyCardVisible(true);
                 renderEntities();
             }
             if (window.telemetry) {

--- a/backend/tests/jest/dashboard-agent-policy-card.test.js
+++ b/backend/tests/jest/dashboard-agent-policy-card.test.js
@@ -16,9 +16,22 @@ describe('Dashboard Agent Policy card', () => {
 
     test('renders a dashboard Agent Policy status card', () => {
         expect(html).toContain('id="dashboardAgentPolicyCard"');
+        expect(html).toContain('id="dashboardAgentPolicyCard" aria-labelledby="dashboardAgentPolicyTitle" aria-hidden="true"');
+        expect(html).toContain('.agent-policy-card {');
+        expect(html).toContain('display: none;');
+        expect(html).toContain('.agent-policy-card.is-visible');
         expect(html).toContain('id="dashboardAgentPolicyStatus"');
         expect(html).toContain('id="dashboardAgentPolicyEnabledBadge"');
         expect(html).toContain('id="dashboardAgentPolicyDetails"');
+    });
+
+    test('only shows the Agent Policy card while dashboard edit mode is active', () => {
+        expect(html).not.toContain('loadDashboardPromptPolicy().catch(err => console.warn(\'[AgentPolicy] dashboard load failed\', err));\n\n            if (__embeddedOrg)');
+        expect(html).toContain('function setDashboardAgentPolicyCardVisible(visible)');
+        expect(html).toContain("card.classList.toggle('is-visible', visible);");
+        expect(html).toContain("card.setAttribute('aria-hidden', visible ? 'false' : 'true');");
+        expect(html).toContain('setDashboardAgentPolicyCardVisible(false);');
+        expect(html).toContain('setDashboardAgentPolicyCardVisible(true);');
     });
 
     test('supports entity/channel preview controls from the dashboard', () => {


### PR DESCRIPTION
## Summary
- Hide the Dashboard Agent Policy card by default.
- Show it only while Dashboard edit mode is active, then load policy data lazily.
- Clear/hide the compiled prompt preview when leaving edit mode.

## Verification
- npm test -- --runTestsByPath tests/jest/dashboard-agent-policy-card.test.js
- npm run lint (passes with existing warnings only)
- git diff --check