### PR TITLE
Fix Kanban Codex channel nudge delivery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -435,6 +435,7 @@ EClaw/
    |-----|----------|---------|--------|
    | Interview start fails with owner_device_not_found | `GET /api/rental/debug/interview-start-fail?deviceId=X&deviceSecret=Y` | 2026-04-12 | Active |
    | Chat first render delayed by cross-device label resolution | `GET /api/debug/chat-render-load-order?deviceId=X&deviceSecret=Y` | 2026-05-01 | Active |
+   | Kanban nudges ignored by Codex channel bridge | `GET /api/mission/debug/kanban-codex-nudge?deviceId=X&deviceSecret=Y` | 2026-05-01 | Active |
 
 6. **Demand Elegance (Balanced)** — 在保持 minimal change 的前提下，追求可讀、一致的程式風格；不為了「漂亮」而過度重構，但也不容忍明顯的 code smell 在新增的程式碼中出現。
 
@@ -1176,6 +1177,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | Cross-Speak Rendering | `tests/jest/cross-speak-chat-rendering.test.js` | Cross-device message direction rendering in chat.html |
 | Transform Cross-Route | `tests/jest/transform-cross-route.test.js` | Transform auto-route bot replies to sender device |
 | Mission Skill/Rule Dedup | `tests/jest/mission-skill-rule-dedup.test.js` | Skill/add and rule/add deduplication on concurrent multi-entity notify |
+| Kanban Chat Card Ref | `tests/jest/kanban-chat-card-ref.test.js` | Kanban notification chat deep-link plus Codex channel nudge payload contract (`expectsReply:true`) |
 | AI Chat Widget Guard | `tests/jest/ai-chat-widget-guard.test.js` | AI chat widget visibility guard in WebView contexts |
 | Discord Integration | `tests/jest/discord-integration.test.js` | Discord slash command integration, signature verification |
 | Note Pages | `tests/jest/note-pages.test.js` | Note page CRUD, public/private toggle, visitor analytics |

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -315,7 +315,7 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
                         from: 'kanban',
                         text: message + descBlock,
                         eclaw_context: {
-                            expectsReply: false,
+                            expectsReply: true,
                             silentToken: '[SILENT]',
                             missionHints: kanbanHints,
                         }
@@ -352,6 +352,100 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
             }
         }
     }
+
+    // Debug: kanban-codex-nudge (#2273) — keep until user confirms Codex channel nudges are reliable.
+    router.get('/debug/kanban-codex-nudge', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const { deviceId } = { ...req.query, ...req.body };
+        const cardId = req.query.cardId ? String(req.query.cardId) : null;
+        const entityId = req.query.entityId !== undefined ? Number(req.query.entityId) : null;
+
+        try {
+            const prefs = await devicePrefs.getPrefs(deviceId).catch(() => ({}));
+            const cardParams = [deviceId];
+            let cardWhere = `device_id = $1 AND archived = false`;
+            if (cardId) {
+                cardParams.push(cardId);
+                cardWhere += ` AND id = $${cardParams.length}`;
+            } else {
+                cardWhere += `
+                  AND status IN ('backlog', 'todo', 'in_progress', 'review')
+                  AND EXTRACT(EPOCH FROM (NOW() - status_changed_at)) * 1000 > stale_threshold_ms`;
+            }
+            const cardsRes = await pool.query(
+                `SELECT id, title, status, priority, assigned_bots, stale_threshold_ms,
+                        status_changed_at, last_stale_nudge_at
+                   FROM kanban_cards
+                  WHERE ${cardWhere}
+                  ORDER BY updated_at DESC NULLS LAST
+                  LIMIT 20`,
+                cardParams
+            );
+
+            const device = devices[deviceId] || null;
+            const entityRows = [];
+            const ids = new Set();
+            for (const card of cardsRes.rows) {
+                for (const bid of (card.assigned_bots || [])) ids.add(Number(bid));
+            }
+            if (Number.isFinite(entityId)) ids.add(entityId);
+
+            for (const id of ids) {
+                const ent = device?.entities?.[id] || null;
+                entityRows.push({
+                    entityId: id,
+                    exists: !!ent,
+                    isBound: !!ent?.isBound,
+                    bindingType: ent?.bindingType || null,
+                    hasChannelAccountId: !!ent?.channelAccountId,
+                    hasWebhook: !!ent?.webhook,
+                    channelPushPossible: !!(ent && ent.bindingType === 'channel' && ent.channelAccountId && pushToChannelCallback),
+                    codexBridgeWouldIgnoreOldPayload: true,
+                    fixedPayloadExpectsReply: true,
+                });
+            }
+
+            res.json({
+                success: true,
+                bug: 'kanban-codex-nudge',
+                diagnostics: {
+                    deviceInMemory: !!device,
+                    hasPushToChannelCallback: !!pushToChannelCallback,
+                    prefs: {
+                        kanban_nudge_interval_minutes: prefs.kanban_nudge_interval_minutes || null,
+                        kanban_nudge_batch_size: prefs.kanban_nudge_batch_size || null,
+                        kanban_nudge_priority_mode: prefs.kanban_nudge_priority_mode || null,
+                        kanban_nudge_per_entity_throttle: prefs.kanban_nudge_per_entity_throttle !== false,
+                        kanban_nudge_statuses: prefs.kanban_nudge_statuses || KanbanStatus.NUDGE_DEFAULT_STATUSES,
+                    },
+                    cards: cardsRes.rows.map((card) => ({
+                        id: card.id,
+                        title: card.title,
+                        status: card.status,
+                        priority: card.priority,
+                        assigned_bots: card.assigned_bots || [],
+                        stale_threshold_ms: card.stale_threshold_ms,
+                        status_changed_at: card.status_changed_at,
+                        last_stale_nudge_at: card.last_stale_nudge_at,
+                    })),
+                    assignedEntities: entityRows,
+                    expectedChannelPayload: {
+                        event: 'kanban_notification',
+                        from: 'kanban',
+                        eclaw_context: {
+                            expectsReply: true,
+                            silentToken: '[SILENT]',
+                            missionHints: 'present_when_getMissionApiHints_is_configured',
+                        },
+                    },
+                },
+                timestamp: new Date().toISOString(),
+            });
+        } catch (err) {
+            console.error('[Kanban] debug kanban-codex-nudge error:', err.message);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
 
     // ── Helper: compute next cron run time ──
     function computeNextRun(cronExpression, timezone) {

--- a/backend/tests/jest/kanban-chat-card-ref.test.js
+++ b/backend/tests/jest/kanban-chat-card-ref.test.js
@@ -25,6 +25,7 @@ const request = require('supertest');
 
 let app;
 let saveChatSpy;
+let channelPushSpy;
 
 beforeAll(() => {
     app = express();
@@ -40,10 +41,12 @@ beforeAll(() => {
     };
 
     saveChatSpy = jest.fn().mockResolvedValue('chat-msg-uuid');
+    channelPushSpy = jest.fn().mockResolvedValue({ pushed: true });
 
     const kanbanModule = require('../../kanban')(mockDevices, {
         saveChatMessage: saveChatSpy,
-        pushToChannelCallback: jest.fn().mockResolvedValue({ pushed: true }),
+        pushToChannelCallback: channelPushSpy,
+        getMissionApiHints: () => '[AVAILABLE TOOLS - Kanban Board]',
     });
     app.use('/api/mission', kanbanModule.router);
 });
@@ -52,6 +55,7 @@ beforeEach(() => {
     mockQuery.mockReset();
     mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
     saveChatSpy.mockClear();
+    channelPushSpy.mockClear();
 });
 
 const AUTH = { deviceId: 'dev-1', deviceSecret: 'secret-1' };
@@ -86,6 +90,14 @@ describe('notifyEntities → saveChatMessage kanban_ref card arg', () => {
         //                             backupUrl, mentions, card, attachments)
         const cardArg = args[12];
         expect(cardArg).toEqual({ kind: 'kanban_ref', id: 'card_abc' });
+        expect(channelPushSpy).toHaveBeenCalledWith('dev-1', 0, expect.objectContaining({
+            event: 'kanban_notification',
+            from: 'kanban',
+            eclaw_context: expect.objectContaining({
+                expectsReply: true,
+                silentToken: '[SILENT]',
+            }),
+        }), 'ch-0');
     });
 
     it('forwards the moved card id on status change (todo → in_progress)', async () => {
@@ -114,5 +126,41 @@ describe('notifyEntities → saveChatMessage kanban_ref card arg', () => {
         expect(saveChatSpy).toHaveBeenCalled();
         const cardArg = saveChatSpy.mock.calls[0][12];
         expect(cardArg).toEqual({ kind: 'kanban_ref', id: 'card_xyz' });
+    });
+
+    it('debug endpoint reports the fixed Codex-channel nudge payload contract', async () => {
+        const staleCard = {
+            ...createdCardRow,
+            id: 'card_stale',
+            assigned_bots: [0],
+            stale_threshold_ms: 1000,
+            status_changed_at: new Date(Date.now() - 3600_000),
+            last_stale_nudge_at: null,
+        };
+        mockQuery.mockResolvedValueOnce({ rows: [staleCard], rowCount: 1 });
+
+        const res = await request(app)
+            .get('/api/mission/debug/kanban-codex-nudge')
+            .query(AUTH)
+            .expect(200);
+
+        expect(res.body.success).toBe(true);
+        expect(res.body.bug).toBe('kanban-codex-nudge');
+        expect(res.body.diagnostics.expectedChannelPayload).toMatchObject({
+            event: 'kanban_notification',
+            from: 'kanban',
+            eclaw_context: {
+                expectsReply: true,
+                silentToken: '[SILENT]',
+            },
+        });
+        expect(res.body.diagnostics.assignedEntities).toEqual([
+            expect.objectContaining({
+                entityId: 0,
+                bindingType: 'channel',
+                channelPushPossible: true,
+                fixedPayloadExpectsReply: true,
+            }),
+        ]);
     });
 });


### PR DESCRIPTION
## Summary
- Fixes Kanban channel notifications so Codex-channel bots receive actionable nudges with `eclaw_context.expectsReply: true`.
- Adds `/api/mission/debug/kanban-codex-nudge` to inspect stale-card candidates, assigned entity channel readiness, and the expected fixed payload contract.
- Extends the Kanban chat/card regression test to assert channel callbacks use `event: kanban_notification` with `expectsReply: true`.

## Diagnosis
Codex bridge intentionally ignores `kanban_notification` callbacks unless `eclaw_context.expectsReply === true`. EClaw was sending Kanban notifications with `expectsReply: false`, so Codex-channel nudges could arrive at the bridge and still be dropped as `kanban_notification_no_reply`.

## Verification
- `node --check backend/kanban.js`
- `cd backend && npx jest tests/jest/kanban-chat-card-ref.test.js`
- `git diff --check`

## Follow-up
After merge/deploy, run production debug endpoint and live Codex-channel E2E to confirm a Kanban nudge reaches Codex and starts an actionable turn.

Closes #2273
