### PR TITLE
fix(kanban): wire screenshot review toggle in schedule panel

### DIFF
--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -1858,6 +1858,11 @@
                     <textarea class="kb-form-textarea" id="sp-desc">${escapeHtml(card.description||'')}</textarea>
                 </div>
                 <div class="kb-form-group">
+                    <div class="kb-auto-toggle-row">
+                        <label class="kb-auto-toggle-label"><input type="checkbox" id="sp-requires-screenshot"${card.requiresScreenshotReview !== false ? ' checked' : ''}> 📸 <span>${t('kb_label_requires_screenshot','需截圖審查（完成時附截圖才可推進 review/done）')}</span></label>
+                    </div>
+                </div>
+                <div class="kb-form-group">
                     <label class="kb-form-label">${t('kb_label_priority','Priority')}</label>
                     <select class="kb-form-select" id="sp-priority">${priorityOpts}</select>
                 </div>
@@ -1922,6 +1927,7 @@
             const type = document.getElementById('sp-type')?.value;
             const timezone = document.getElementById('sp-tz')?.value;
             const enabled = document.getElementById('sp-enabled')?.checked !== false;
+            const requiresScreenshotReview = document.getElementById('sp-requires-screenshot')?.checked !== false;
 
             if (!title) { showToast(t('kb_err_title','Title is required'), true); return; }
 
@@ -1945,7 +1951,7 @@
             try {
                 await apiCall('PUT', `/api/mission/card/${cardId}`, {
                     deviceId: currentUser.deviceId, deviceSecret: currentUser.deviceSecret,
-                    title, description: desc, priority, assignedBots,
+                    title, description: desc, priority, assignedBots, requiresScreenshotReview,
                 });
                 await apiCall('PUT', `/api/mission/card/${cardId}/schedule`, schedBody);
                 showToast(t('kb_auto_edit_saved','Schedule updated'));

--- a/backend/tests/jest/kanban-card.test.js
+++ b/backend/tests/jest/kanban-card.test.js
@@ -4,7 +4,11 @@
  * Tests that kanban cards require at least one assigned entity.
  */
 
+const fs = require('fs');
+const path = require('path');
 const mockQuery = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+const ROOT = path.join(__dirname, '..', '..');
+const kanbanHtml = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'kanban.html'), 'utf8');
 
 jest.mock('pg', () => ({
     Pool: jest.fn().mockImplementation(() => ({
@@ -175,6 +179,22 @@ describe('PUT /card/:id — assignedBots validation', () => {
             .send({ ...AUTH, assignedBots: [] });
         expect(res.status).toBe(400);
         expect(res.body.error).toMatch(/entity.*assigned/i);
+    });
+});
+
+describe('Kanban schedule panel — screenshot review toggle wiring', () => {
+    it('renders a screenshot review checkbox in the schedule panel', () => {
+        expect(kanbanHtml).toContain('id="sp-requires-screenshot"');
+        expect(kanbanHtml).toContain('kb_label_requires_screenshot');
+    });
+
+    it('submits requiresScreenshotReview when saving the schedule panel', () => {
+        const saveFn = kanbanHtml.slice(
+            kanbanHtml.indexOf('async function saveSchedulePanel'),
+            kanbanHtml.indexOf('async function saveSchedulePanel') + 2600
+        );
+        expect(saveFn).toContain('requiresScreenshotReview');
+        expect(saveFn).toContain("apiCall('PUT', `/api/mission/card/${cardId}`, {");
     });
 });
 


### PR DESCRIPTION
## Summary\n- Add the screenshot-review checkbox back into the kanban schedule panel\n- Persist  when saving schedule/card edits\n- Add a regression test to guard the wiring\n\n## Verification\n-   console.log
    [Kanban] POST /card called { deviceId: 'test-dev', entityId: undefined, cardId: undefined }

      at log (backend/kanban.js:425:59)

  console.log
    [Kanban] POST /card called { deviceId: 'test-dev', entityId: undefined, cardId: undefined }

      at log (backend/kanban.js:425:59)

  console.log
    [Kanban] POST /card called { deviceId: 'test-dev', entityId: undefined, cardId: undefined }

      at log (backend/kanban.js:425:59)

  console.log
    [Kanban] POST /card called { deviceId: 'test-dev', entityId: undefined, cardId: undefined }

      at log (backend/kanban.js:425:59)

  console.log
    [Kanban] POST /card called { deviceId: 'test-dev', entityId: 1, cardId: undefined }

      at log (backend/kanban.js:425:59)

  console.log
    [Kanban] POST /card called { deviceId: 'test-dev', entityId: undefined, cardId: undefined }

      at log (backend/kanban.js:425:59)

  console.log
    [Kanban] POST /card called { deviceId: 'test-dev', entityId: undefined, cardId: undefined }

      at log (backend/kanban.js:425:59)

  console.log
    [Kanban] PUT /card/:id called { deviceId: 'test-dev', entityId: undefined, cardId: '1' }

      at log (backend/kanban.js:1164:59)

  console.log
    [Kanban] POST /card/:id/move called { deviceId: 'test-dev', entityId: undefined, cardId: '1' }

      at log (backend/kanban.js:1312:59)

  console.log
    [Kanban] POST /card/:id/move called { deviceId: 'test-dev', entityId: undefined, cardId: '1' }

      at log (backend/kanban.js:1312:59)

  console.log
    [Kanban] POST /card called { deviceId: 'test-dev', entityId: undefined, cardId: undefined }

      at log (backend/kanban.js:425:59)

  console.log
    [Kanban] POST /card called { deviceId: 'test-dev', entityId: undefined, cardId: undefined }

      at log (backend/kanban.js:425:59)

  console.log
    [Kanban] POST /card called { deviceId: 'test-dev', entityId: undefined, cardId: undefined }

      at log (backend/kanban.js:425:59)

  console.log
    [Kanban] POST /card called { deviceId: 'test-dev', entityId: undefined, cardId: undefined }

      at log (backend/kanban.js:425:59)

  console.log
    [Kanban] PUT /card/:id/schedule called { deviceId: 'test-dev', entityId: undefined, cardId: 'uuid-1' }

      at log (backend/kanban.js:1778:59)

  console.log
    [Kanban] Auto-promoted card uuid-1 to automation (recurring schedule)

      at log (backend/kanban.js:1850:25)

  console.log
    [Kanban] PUT /card/:id/schedule called { deviceId: 'test-dev', entityId: undefined, cardId: 'uuid-2' }

      at log (backend/kanban.js:1778:59)

  console.warn
    [Kanban] Auth failed: {
      deviceId: 'bad',
      hasDeviceSecret: true,
      hasBotSecret: false,
      entityId: undefined
    }

      220 |             res.status(400).json({ success: false, error: 'Missing deviceSecret or botSecret' });
      221 |         } else {
    > 222 |             console.warn('[Kanban] Auth failed:', { deviceId, hasDeviceSecret: !!deviceSecret, hasBotSecret: !!botSecret, entityId });
          |                     ^
      223 |             res.status(401).json({ success: false, error: 'Invalid credentials' });
      224 |         }
      225 |         return false;

      at warn (backend/kanban.js:222:21)
      at authenticate (backend/kanban.js:728:14)
      at Layer.handle [as handle_request] (backend/node_modules/express/lib/router/layer.js:95:5)
      at next (backend/node_modules/express/lib/router/route.js:149:13)
      at Route.dispatch (backend/node_modules/express/lib/router/route.js:119:3)
      at Layer.handle [as handle_request] (backend/node_modules/express/lib/router/layer.js:95:5)
      at backend/node_modules/express/lib/router/index.js:284:15
      at router.process_params (backend/node_modules/express/lib/router/index.js:346:12)
      at next (backend/node_modules/express/lib/router/index.js:280:10)
      at router.handle (backend/node_modules/express/lib/router/index.js:175:3)
      at router (backend/node_modules/express/lib/router/index.js:47:12)
      at Layer.handle [as handle_request] (backend/node_modules/express/lib/router/layer.js:95:5)
      at trim_prefix (backend/node_modules/express/lib/router/index.js:328:13)
      at backend/node_modules/express/lib/router/index.js:286:9
      at router.process_params (backend/node_modules/express/lib/router/index.js:346:12)
      at next (backend/node_modules/express/lib/router/index.js:280:10)
      at jsonParser (backend/node_modules/body-parser/lib/types/json.js:113:7)
      at Layer.handle [as handle_request] (backend/node_modules/express/lib/router/layer.js:95:5)
      at trim_prefix (backend/node_modules/express/lib/router/index.js:328:13)
      at backend/node_modules/express/lib/router/index.js:286:9
      at router.process_params (backend/node_modules/express/lib/router/index.js:346:12)
      at next (backend/node_modules/express/lib/router/index.js:280:10)
      at expressInit (backend/node_modules/express/lib/middleware/init.js:40:5)
      at Layer.handle [as handle_request] (backend/node_modules/express/lib/router/layer.js:95:5)
      at trim_prefix (backend/node_modules/express/lib/router/index.js:328:13)
      at backend/node_modules/express/lib/router/index.js:286:9
      at router.process_params (backend/node_modules/express/lib/router/index.js:346:12)
      at next (backend/node_modules/express/lib/router/index.js:280:10)
      at query (backend/node_modules/express/lib/middleware/query.js:45:5)
      at Layer.handle [as handle_request] (backend/node_modules/express/lib/router/layer.js:95:5)
      at trim_prefix (backend/node_modules/express/lib/router/index.js:328:13)
      at backend/node_modules/express/lib/router/index.js:286:9
      at router.process_params (backend/node_modules/express/lib/router/index.js:346:12)
      at next (backend/node_modules/express/lib/router/index.js:280:10)
      at router.handle (backend/node_modules/express/lib/router/index.js:175:3)
      at app.handle (backend/node_modules/express/lib/application.js:181:10)
      at Server.app (backend/node_modules/express/lib/express.js:39:9)

  console.log
    [Kanban] POST /card/:id/comment called { deviceId: 'test-dev', entityId: 1, cardId: 'card_x' }

      at log (backend/kanban.js:1474:59)