### PR TITLE
feat(chat): auto-approve Codex input requests

### DIFF
--- a/backend/device-preferences.js
+++ b/backend/device-preferences.js
@@ -8,6 +8,8 @@ const KanbanStatus = require('./public/shared/kanban-status.js');
 const DEFAULTS = {
     broadcast_recipient_info: true,
     remote_control_enabled: false,
+    // Codex channel: entity-specific auto-approve toggle for "requests input"
+    codex_auto_approve_targets: {},
     // Kanban nudge (stale-card reminder) — applies uniformly to all entities
     kanban_nudge_batch_size: 1,
     kanban_nudge_priority_mode: 'priority_first',  // 'priority_first' | 'column_first' | 'column_level'
@@ -45,6 +47,17 @@ function coerceValue(key, raw) {
         const filtered = raw.filter(s => NUDGE_STATUS_OPTIONS.has(s));
         // Must nudge at least one column, else fall back to default.
         return filtered.length ? filtered : [...def];
+    }
+    if (key === 'codex_auto_approve_targets') {
+        if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {};
+        const out = {};
+        for (const [entityId, enabled] of Object.entries(raw)) {
+            const n = Number(entityId);
+            if (Number.isFinite(n) && n >= 0) {
+                out[String(n)] = !!enabled;
+            }
+        }
+        return out;
     }
     return def;
 }

--- a/backend/index.js
+++ b/backend/index.js
@@ -826,7 +826,7 @@ const DEFAULT_INITIAL_SLOTS = 1; // new devices start with 1 slot (entity #0)
 // ============================================
 // PLATFORM SLASH COMMANDS
 // ============================================
-const PLATFORM_COMMANDS = new Set(['help', 'status', 'reset']);
+const PLATFORM_COMMANDS = new Set(['help', 'status', 'reset', 'auto_approve']);
 
 function parsePlatformCommand(text) {
     if (!text || !text.startsWith('/')) return null;
@@ -900,6 +900,36 @@ async function handlePlatformCommand(command, deviceId, device, targetIds, confi
             }
             return {
                 text: 'Conversation Reset:\n' + results.join('\n'),
+                needsConfirmation: false
+            };
+        }
+
+        case 'auto_approve': {
+            const prefs = await devicePrefs.getPrefs(deviceId);
+            const currentTargets = {
+                ...(prefs.codex_auto_approve_targets || {})
+            };
+            const toggled = [];
+
+            for (const eId of targetIds) {
+                const key = String(eId);
+                const next = !currentTargets[key];
+                currentTargets[key] = next;
+                toggled.push({ entityId: eId, enabled: next });
+            }
+
+            await devicePrefs.updatePrefs(deviceId, {
+                codex_auto_approve_targets: currentTargets
+            });
+
+            const enabledCount = toggled.filter(t => t.enabled).length;
+            const disabledCount = toggled.length - enabledCount;
+            const statusText = toggled.length === 1
+                ? `Auto-approve ${toggled[0].enabled ? 'enabled' : 'disabled'} for #${toggled[0].entityId}.`
+                : `Auto-approve updated for ${toggled.length} entities (${enabledCount} enabled, ${disabledCount} disabled).`;
+
+            return {
+                text: `${statusText} Future "requests input" prompts will auto-answer yes for the enabled entities.`,
                 needsConfirmation: false
             };
         }

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3841,6 +3841,8 @@
                     renderMessages(prevCount < allMessages.length);
                     refreshXDeviceLabelsInBackground(allMessages);
                     ChatIntegrityValidator.validateDataLayer(data.messages);
+                    await syncCodexAutoApproveTargetsFromServer();
+                    await maybeAutoApproveRequests(allMessages);
                 }
             } catch (e) {
                 console.error('[CHAT_DEBUG] loadMessages FAILED:', e.message || e);
@@ -4925,6 +4927,103 @@
 
         // ── Slash Command Confirmation State ──
         let pendingConfirmCommand = null;
+        let codexAutoApproveSyncAt = 0;
+        const CODEX_AUTO_APPROVE_PREF_KEY = 'eclaw_codex_auto_approve_targets';
+        const CODEX_AUTO_APPROVE_REPLIED_KEY = 'eclaw_codex_auto_approve_replied_messages';
+        const CODEX_AUTO_APPROVE_REFRESH_MS = 60 * 1000;
+
+        function readJsonStorage(key, fallback) {
+            try {
+                const raw = localStorage.getItem(key);
+                if (!raw) return fallback;
+                const parsed = JSON.parse(raw);
+                return parsed && typeof parsed === 'object' ? parsed : fallback;
+            } catch (_) {
+                return fallback;
+            }
+        }
+
+        function writeJsonStorage(key, value) {
+            try { localStorage.setItem(key, JSON.stringify(value || {})); } catch (_) {}
+        }
+
+        function getCodexAutoApproveTargets() {
+            return readJsonStorage(CODEX_AUTO_APPROVE_PREF_KEY, {});
+        }
+
+        function setCodexAutoApproveTargets(targets) {
+            writeJsonStorage(CODEX_AUTO_APPROVE_PREF_KEY, targets);
+        }
+
+        function getCodexAutoApproveReplied() {
+            return readJsonStorage(CODEX_AUTO_APPROVE_REPLIED_KEY, {});
+        }
+
+        function markCodexAutoApproveReplied(messageId) {
+            const replied = getCodexAutoApproveReplied();
+            replied[String(messageId)] = true;
+            writeJsonStorage(CODEX_AUTO_APPROVE_REPLIED_KEY, replied);
+        }
+
+        function isAutoApproveEnabledForEntity(entityId) {
+            const targets = getCodexAutoApproveTargets();
+            return !!targets[String(entityId)];
+        }
+
+        async function syncCodexAutoApproveTargetsFromServer(force = false) {
+            const now = Date.now();
+            if (!force && codexAutoApproveSyncAt && now - codexAutoApproveSyncAt < CODEX_AUTO_APPROVE_REFRESH_MS) {
+                return getCodexAutoApproveTargets();
+            }
+            if (!currentUser?.deviceId || !currentUser?.deviceSecret) {
+                return getCodexAutoApproveTargets();
+            }
+            try {
+                const data = await apiCall('GET', `/api/device-preferences?deviceId=${encodeURIComponent(currentUser.deviceId)}&deviceSecret=${encodeURIComponent(currentUser.deviceSecret)}`);
+                const targets = data?.prefs?.codex_auto_approve_targets || {};
+                setCodexAutoApproveTargets(targets);
+                codexAutoApproveSyncAt = now;
+                return targets;
+            } catch (_) {
+                return getCodexAutoApproveTargets();
+            }
+        }
+
+        async function maybeAutoApproveRequests(messages) {
+            if (!Array.isArray(messages) || !messages.length) return;
+            const replied = getCodexAutoApproveReplied();
+            const latestByEntity = new Map();
+
+            for (const msg of messages) {
+                if (!msg || !msg.is_from_bot) continue;
+                const entityId = Number(msg.entity_id);
+                if (!Number.isFinite(entityId) || !isAutoApproveEnabledForEntity(entityId)) continue;
+                const text = String(msg.text || '');
+                if (!/codex requests input/i.test(text)) continue;
+                if (replied[msg.id]) continue;
+
+                const ts = Date.parse(msg.created_at || msg.createdAt || 0) || 0;
+                const prev = latestByEntity.get(entityId);
+                if (!prev || ts > prev.ts) {
+                    latestByEntity.set(entityId, { msg, ts });
+                }
+            }
+
+            for (const { msg } of latestByEntity.values()) {
+                try {
+                    await apiCall('POST', '/api/client/speak', {
+                        deviceId: currentUser.deviceId,
+                        deviceSecret: currentUser.deviceSecret,
+                        entityId: msg.entity_id,
+                        text: 'yes',
+                        source: 'web_chat'
+                    });
+                    markCodexAutoApproveReplied(msg.id);
+                } catch (err) {
+                    console.warn('[CHAT] auto-approve failed:', err.message || err);
+                }
+            }
+        }
 
         // ── Quote Reply State ──
         let replyContext = null;
@@ -5112,6 +5211,10 @@
                         // Track confirmation state from platform commands
                         if (speakResp && speakResp.needsConfirmation && speakResp.confirmCommand) {
                             pendingConfirmCommand = speakResp.confirmCommand;
+                        }
+                        if (speakResp && speakResp.command === 'auto_approve') {
+                            await syncCodexAutoApproveTargetsFromServer(true);
+                            await maybeAutoApproveRequests(allMessages);
                         }
                         if (hasNoWebhookWarning(speakResp)) {
                             showWebhookTroubleModal();

--- a/backend/tests/jest/chat.test.js
+++ b/backend/tests/jest/chat.test.js
@@ -7,8 +7,13 @@
 
 require('./helpers/mock-setup');
 
+const fs = require('fs');
+const path = require('path');
 const request = require('supertest');
 let app;
+const ROOT = path.join(__dirname, '..', '..');
+const chatHtml = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'chat.html'), 'utf8');
+const backendIndex = fs.readFileSync(path.join(ROOT, 'index.js'), 'utf8');
 
 const get = (path) => request(app).get(path).set('Host', 'localhost');
 const post = (path) => request(app).post(path).set('Host', 'localhost');
@@ -260,6 +265,23 @@ describe('client/speak structured attachments', () => {
         // No fileId → validator filters out → treat as plain text message, no error
         expect(res.status).toBe(200);
         expect(res.body.success).toBe(true);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// Codex channel auto-approve wiring
+// ════════════════════════════════════════════════════════════════
+describe('Codex channel auto-approve wiring', () => {
+    it('chat UI includes /auto_approve handling and request auto-yes helper', () => {
+        expect(chatHtml).toContain("'/auto_approve'");
+        expect(chatHtml).toContain('maybeAutoApproveRequests');
+        expect(chatHtml).toContain('codex_auto_approve_targets');
+        expect(chatHtml.toLowerCase()).toContain('codex requests input');
+    });
+
+    it('backend platform command includes auto_approve', () => {
+        expect(backendIndex).toContain("new Set(['help', 'status', 'reset', 'auto_approve'])");
+        expect(backendIndex).toContain("case 'auto_approve'");
     });
 });
 

--- a/backend/tests/jest/device-preferences.test.js
+++ b/backend/tests/jest/device-preferences.test.js
@@ -6,6 +6,8 @@
  * - PUT /api/device-preferences
  */
 
+const devicePrefsModule = require('../../device-preferences');
+
 // ── Mock all modules with side-effects before requiring index.js ──
 
 jest.mock('pg', () => ({
@@ -223,5 +225,12 @@ describe('PUT /api/device-preferences', () => {
             .send({ deviceId: 'dev-1', deviceSecret: 'sec', prefs: 'not-an-object' });
         // Returns 400 (invalid prefs) or 401 (auth fail)
         expect(res.status).toBeGreaterThanOrEqual(400);
+    });
+});
+
+describe('codex auto-approve preference', () => {
+    it('includes codex_auto_approve_targets in defaults', () => {
+        expect(devicePrefsModule.DEFAULTS).toHaveProperty('codex_auto_approve_targets');
+        expect(devicePrefsModule.DEFAULTS.codex_auto_approve_targets).toEqual({});
     });
 });


### PR DESCRIPTION
## Summary
- Add `/auto_approve` as a platform slash command
- Persist entity-specific Codex auto-approve targets in device preferences
- Auto-reply `yes` when the chat sees a `Codex requests input` prompt for enabled entities
- Add regression coverage for the backend preference and chat wiring

## Verification
- `npx jest --runInBand --forceExit --runTestsByPath backend/tests/jest/device-preferences.test.js backend/tests/jest/chat.test.js`
