### PR TITLE
Add rental contract start dry-run diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -434,7 +434,7 @@ EClaw/
    | Bug | Endpoint | Created | Status |
    |-----|----------|---------|--------|
    | Interview start fails with owner_device_not_found | `GET /api/rental/debug/interview-start-fail?deviceId=X&deviceSecret=Y` | 2026-04-12 | Active |
-   | Rental contract start returns internal_error during rent/borrow E2E | `GET /api/rental/debug/contract-start-fail?deviceId=X&deviceSecret=Y&listingId=Y&renterDeviceId=Z&durationMinutes=30` | 2026-05-01 | Active |
+| Rental contract start returns internal_error during rent/borrow E2E (#2283) | `GET /api/rental/debug/contract-start-fail?deviceId=X&deviceSecret=Y&listingId=Y&renterDeviceId=Z&durationMinutes=30` | 2026-05-01 | Active |
    | Chat first render delayed by cross-device label resolution | `GET /api/debug/chat-render-load-order?deviceId=X&deviceSecret=Y` | 2026-05-01 | Active |
    | Kanban nudges ignored by Codex channel bridge | `GET /api/mission/debug/kanban-codex-nudge?deviceId=X&deviceSecret=Y` | 2026-05-01 | Active |
 
@@ -1116,7 +1116,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | Channel XP | `node backend/tests/test-channel-xp.js` | Device ID + Secret | Channel XP tracking and propagation |
 | Customer Service API | `node backend/tests/test-customer-service-api.js` | Device ID + Secret | Customer service AI tool handlers |
 | Entity Trash | `node backend/tests/test-entity-trash.js` | Device ID + Secret | Entity soft-delete, restore, 7-day retention |
-| Rental Debug Contract Start | `cd backend && npx jest tests/jest/rental-debug-contract-start.test.js` | None | Regression #2263: rental debug endpoints authenticate safely and report contract-start economics/predicted blockers |
+| Rental Debug Contract Start | `cd backend && npx jest tests/jest/rental-debug-contract-start.test.js` | None | Regression #2263/#2283: rental debug endpoints authenticate safely, report economics/predicted blockers, and dry-run contract start steps without mutating wallet/contract state |
 | Note Pages | `node backend/tests/test-note-pages.js` | Device ID + Secret | Note page public/private toggle, visitor analytics, custom domain |
 | AI Chat WebView Guard | `node backend/tests/test-ai-chat-webview-guard.js` | Device ID + Secret | AI chat widget hidden in Android WebView contexts |
 | Org Chart | `node backend/tests/test-org-chart.js` | Device ID + Secret | Org chart CRUD lifecycle, cycle detection, partial update, auth validation |

--- a/backend/rental.js
+++ b/backend/rental.js
@@ -1436,6 +1436,142 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
         };
     }
 
+    async function diagnoseStartRentalDryRun({ listingId, renterUserId, renterDeviceId, durationMinutes }) {
+        const steps = [];
+        const client = await pool.connect();
+        let failedStep = null;
+
+        const step = async (name, fn) => {
+            failedStep = name;
+            const value = await fn();
+            steps.push({ name, ok: true });
+            return value;
+        };
+
+        try {
+            await client.query('BEGIN');
+
+            const listing = await step('lock_listing', async () => {
+                const listingRes = await client.query(
+                    `SELECT id, owner_user_id, rate_mli_per_ktoken,
+                            min_rental_minutes, max_rental_minutes,
+                            status, interview_passed
+                       FROM bot_listings WHERE id = $1 FOR UPDATE`,
+                    [listingId]
+                );
+                if (listingRes.rowCount === 0) throw new Error('listing_not_found');
+                return listingRes.rows[0];
+            });
+
+            await step('validate_listing', async () => {
+                if (listing.status !== 'listed') throw new Error('listing_not_available');
+                if (!listing.interview_passed) throw new Error('interview_not_passed');
+                if (listing.owner_user_id === renterUserId) throw new Error('self_rental_forbidden');
+                if (durationMinutes < listing.min_rental_minutes) throw new Error('duration_below_listing_min');
+                if (durationMinutes > listing.max_rental_minutes) throw new Error('duration_above_listing_max');
+            });
+
+            await step('check_cooldown', async () => {
+                const cooldownRes = await client.query(
+                    `SELECT cooldown_until FROM rental_cooldowns
+                       WHERE user_id = $1 AND listing_id = $2 AND cooldown_until > NOW()`,
+                    [renterUserId, listingId]
+                );
+                if (cooldownRes.rowCount > 0) throw new Error('cooldown_active');
+            });
+
+            await step('check_active_contract', async () => {
+                const activeRes = await client.query(
+                    `SELECT id FROM rental_contracts
+                       WHERE listing_id = $1
+                         AND status IN ('reserved', 'active', 'suspended_insufficient_funds')`,
+                    [listingId]
+                );
+                if (activeRes.rowCount > 0) throw new Error('listing_already_rented');
+            });
+
+            const rateSnapshot = Number(listing.rate_mli_per_ktoken);
+            const depositMli = computeDepositMli(rateSnapshot);
+            const bufferMli = rateSnapshot * 60;
+            const requiredMli = depositMli + bufferMli;
+
+            await step('check_wallet_balance', async () => {
+                const balRes = await client.query(
+                    `SELECT balance_mli FROM wallets WHERE user_id = $1`,
+                    [renterUserId]
+                );
+                const currentBalance = balRes.rowCount > 0 ? BigInt(balRes.rows[0].balance_mli) : 0n;
+                if (currentBalance < BigInt(requiredMli)) {
+                    const err = new Error('insufficient_balance_for_rental');
+                    err.details = {
+                        required_mli: String(requiredMli),
+                        current_mli: String(currentBalance),
+                        deposit_mli: String(depositMli),
+                        buffer_mli: String(bufferMli),
+                    };
+                    throw err;
+                }
+            });
+
+            const contract = await step('insert_contract', async () => {
+                const contractRes = await client.query(
+                    `INSERT INTO rental_contracts
+                        (listing_id, owner_user_id, renter_user_id, renter_device_id,
+                         rate_mli_per_ktoken_snapshot, deposit_mli,
+                         planned_duration_min, started_at, ends_at, status)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW() + make_interval(mins => $7), 'active')
+                     RETURNING id, status, started_at, ends_at, deposit_mli`,
+                    [listingId, listing.owner_user_id, renterUserId, renterDeviceId,
+                     rateSnapshot, depositMli, durationMinutes]
+                );
+                return contractRes.rows[0];
+            });
+
+            await step('insert_snapshot', async () => {
+                await client.query(
+                    `INSERT INTO rental_snapshots
+                        (contract_id, identity, rules, skills, webhook_url, allowed_vars)
+                     VALUES ($1, $2, $3, $4, $5, $6)`,
+                    [contract.id, null, null, null, null, '[]']
+                );
+            });
+
+            await step('hold_deposit', async () => {
+                await walletModule.applyLedgerEntry(client, {
+                    userId: renterUserId,
+                    balanceDelta: -depositMli,
+                    heldDelta: depositMli,
+                    type: walletModule.LEDGER_TYPES.DEPOSIT_HOLD,
+                    refType: 'rental_contract',
+                    refId: contract.id,
+                    note: `dry-run rental deposit: ${listingId}`,
+                    idempotencyKey: `rental-dry-run:${contract.id}`,
+                });
+            });
+
+            await client.query('ROLLBACK');
+            return { ok: true, steps, contractIdPreview: contract.id };
+        } catch (err) {
+            try { await client.query('ROLLBACK'); } catch { /* ignore */ }
+            steps.push({
+                name: failedStep || 'unknown',
+                ok: false,
+                error: {
+                    message: err.message,
+                    code: err.code || null,
+                    detail: err.detail || null,
+                    constraint: err.constraint || null,
+                    table: err.table || null,
+                    column: err.column || null,
+                    details: err.details || null,
+                },
+            });
+            return { ok: false, failedStep: failedStep || 'unknown', steps };
+        } finally {
+            client.release();
+        }
+    }
+
     // POST /api/rental/listing — create a draft listing
     router.post('/listing', authMiddleware, rentalRoute(async (req, res) => {
         const { ownerDeviceId, ownerEntityId, title, description,
@@ -1933,6 +2069,14 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
             ? ownerMemoryDevice.entities?.[listing.owner_entity_id]
             : null;
         const renterMemoryDevice = _interviewDeps.devices?.[renterDeviceId] || null;
+        const dryRunStart = renterUser && listing
+            ? await diagnoseStartRentalDryRun({
+                listingId,
+                renterUserId: renterUser.id,
+                renterDeviceId,
+                durationMinutes,
+            })
+            : null;
 
         res.json({
             success: true,
@@ -1969,6 +2113,7 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
                     balance_mli: String(walletRow.balance_mli),
                     held_mli: String(walletRow.held_mli),
                 } : null,
+                dryRunStart,
                 renterDbEntities: renterEntityRows.map(r => ({
                     entity_id: r.entity_id,
                     is_bound: r.is_bound,

--- a/backend/tests/jest/rental-debug-contract-start.test.js
+++ b/backend/tests/jest/rental-debug-contract-start.test.js
@@ -36,6 +36,11 @@ jest.mock('pg', () => {
             return { rows: row ? [{ ...row }] : [], rowCount: row ? 1 : 0 };
         }
 
+        if (/^SELECT id, owner_user_id, rate_mli_per_ktoken,/i.test(norm)) {
+            const row = state.listings.get(params[0]);
+            return { rows: row ? [{ ...row }] : [], rowCount: row ? 1 : 0 };
+        }
+
         if (/^SELECT cooldown_until FROM rental_cooldowns/i.test(norm)) {
             const rows = state.cooldowns.filter(c => c.user_id === params[0] && c.listing_id === params[1]);
             return { rows, rowCount: rows.length };
@@ -47,6 +52,31 @@ jest.mock('pg', () => {
                 ['reserved', 'active', 'suspended_insufficient_funds'].includes(c.status)
             );
             return { rows, rowCount: rows.length };
+        }
+
+        if (/^SELECT id FROM rental_contracts/i.test(norm)) {
+            const rows = state.contracts.filter(c =>
+                c.listing_id === params[0] &&
+                ['reserved', 'active', 'suspended_insufficient_funds'].includes(c.status)
+            );
+            return { rows: rows.map(c => ({ id: c.id })), rowCount: rows.length };
+        }
+
+        if (/^INSERT INTO rental_contracts/i.test(norm)) {
+            return {
+                rows: [{
+                    id: 'contract-dry-run',
+                    status: 'active',
+                    started_at: new Date('2026-05-01T00:00:00Z'),
+                    ends_at: new Date('2026-05-01T00:30:00Z'),
+                    deposit_mli: params[5],
+                }],
+                rowCount: 1,
+            };
+        }
+
+        if (/^INSERT INTO rental_snapshots/i.test(norm)) {
+            return { rows: [], rowCount: 1 };
         }
 
         if (/^SELECT id, listing_id, status, started_at, ends_at, renter_device_id FROM rental_contracts/i.test(norm)) {
@@ -62,9 +92,18 @@ jest.mock('pg', () => {
             return { rows: row ? [{ ...row }] : [], rowCount: row ? 1 : 0 };
         }
 
+        if (/^SELECT balance_mli FROM wallets WHERE user_id = \$1$/i.test(norm)) {
+            const row = state.wallets.get(params[0]);
+            return { rows: row ? [{ balance_mli: row.balance_mli }] : [], rowCount: row ? 1 : 0 };
+        }
+
         if (/^SELECT entity_id, is_bound, character, webhook FROM entities WHERE device_id = \$1/i.test(norm)) {
             const rows = state.entitiesByDevice.get(params[0]) || [];
             return { rows: rows.map(r => ({ ...r })), rowCount: rows.length };
+        }
+
+        if (/^(BEGIN|ROLLBACK)$/i.test(norm)) {
+            return { rows: [], rowCount: 0 };
         }
 
         throw new Error(`[rental-debug fake pg] Unhandled SQL: ${norm}`);
@@ -73,6 +112,10 @@ jest.mock('pg', () => {
     return {
         Pool: jest.fn(() => ({
             query: jest.fn((sql, params) => Promise.resolve(runQuery(sql, params))),
+            connect: jest.fn(() => Promise.resolve({
+                query: jest.fn((sql, params) => Promise.resolve(runQuery(sql, params))),
+                release: jest.fn(),
+            })),
         })),
     };
 });
@@ -91,6 +134,8 @@ function buildApp() {
         },
         walletModule: {
             withTransaction: async (fn) => fn({ query: () => Promise.resolve({ rows: [], rowCount: 0 }) }),
+            applyLedgerEntry: jest.fn(() => Promise.resolve({})),
+            LEDGER_TYPES: { DEPOSIT_HOLD: 'deposit_hold' },
         },
     });
     rental.setInterviewDeps({
@@ -198,6 +243,10 @@ describe('rental debug endpoints', () => {
         expect(res.body.diagnostics.renterDbEntities).toEqual([
             expect.objectContaining({ entity_id: 15, is_bound: false }),
         ]);
+        expect(res.body.diagnostics.dryRunStart).toMatchObject({
+            ok: true,
+            contractIdPreview: 'contract-dry-run',
+        });
     });
 
     test('contract-start-fail predicts insufficient rental balance', async () => {


### PR DESCRIPTION
## Summary
- Extend /api/rental/debug/contract-start-fail with a transaction-scoped dry-run of startRental steps
- Return the exact failing step plus sanitized DB error fields while rolling back all contract/wallet mutations
- Update rental debug regression coverage and AGENTS tracking for #2283

## Verification
- node --check backend/rental.js
- cd backend && npx jest tests/jest/rental-debug-contract-start.test.js

## Issue
- Fixes diagnostic gap for #2283; production E2E will use this PR after deploy to locate the remaining internal_error root cause.