### PR TITLE
Fix rental contract id generation

### DIFF
--- a/backend/rental.js
+++ b/backend/rental.js
@@ -29,6 +29,7 @@ const fs = require('fs');
 const path = require('path');
 const { runInterview, getProbeList } = require('./bot-interview');
 const safeEqual = require('./safe-equal');
+const { newContractId } = require('./entity-id');
 
 const pool = new Pool({
     connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
@@ -146,6 +147,11 @@ async function initRentalDatabase() {
         try {
             await pool.query(`ALTER TABLE bot_listings ADD COLUMN IF NOT EXISTS avatar_url TEXT`);
         } catch (_) { /* column may already exist */ }
+        try {
+            await pool.query(`ALTER TABLE rental_contracts ALTER COLUMN id SET DEFAULT ('contract_' || encode(gen_random_bytes(12), 'hex'))`);
+        } catch (err) {
+            console.warn('[Rental] Schema warning: rental_contracts.id default:', err.message);
+        }
 
         // Startup cleanup: revert any listings stuck in 'interview' (server crashed mid-run)
         await pool.query(
@@ -701,14 +707,15 @@ async function startRental({
 
         // 5. Create the contract row. Computed ends_at lets the cron find
         //    expiring contracts without recomputing.
+        const contractId = newContractId();
         const contractRes = await client.query(
             `INSERT INTO rental_contracts
-                (listing_id, owner_user_id, renter_user_id, renter_device_id,
+                (id, listing_id, owner_user_id, renter_user_id, renter_device_id,
                  rate_mli_per_ktoken_snapshot, deposit_mli,
                  planned_duration_min, started_at, ends_at, status)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW() + make_interval(mins => $7), 'active')
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW() + make_interval(mins => $8), 'active')
              RETURNING id, status, started_at, ends_at, deposit_mli`,
-            [listingId, listing.owner_user_id, renterUserId, renterDeviceId,
+            [contractId, listingId, listing.owner_user_id, renterUserId, renterDeviceId,
              rateSnapshot, depositMli, durationMinutes]
         );
         const contract = contractRes.rows[0];
@@ -1513,15 +1520,16 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
                 }
             });
 
+            const contractId = newContractId();
             const contract = await step('insert_contract', async () => {
                 const contractRes = await client.query(
                     `INSERT INTO rental_contracts
-                        (listing_id, owner_user_id, renter_user_id, renter_device_id,
+                        (id, listing_id, owner_user_id, renter_user_id, renter_device_id,
                          rate_mli_per_ktoken_snapshot, deposit_mli,
                          planned_duration_min, started_at, ends_at, status)
-                     VALUES ($1, $2, $3, $4, $5, $6, $7, NOW(), NOW() + make_interval(mins => $7), 'active')
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW() + make_interval(mins => $8), 'active')
                      RETURNING id, status, started_at, ends_at, deposit_mli`,
-                    [listingId, listing.owner_user_id, renterUserId, renterDeviceId,
+                    [contractId, listingId, listing.owner_user_id, renterUserId, renterDeviceId,
                      rateSnapshot, depositMli, durationMinutes]
                 );
                 return contractRes.rows[0];

--- a/backend/tests/jest/rental-contract.test.js
+++ b/backend/tests/jest/rental-contract.test.js
@@ -112,9 +112,9 @@ jest.mock('pg', () => {
 
         // INSERT rental_contracts
         if (/^INSERT INTO rental_contracts/i.test(norm)) {
-            const id = `contract-${state.nextContractId++}`;
-            const [listingId, ownerUserId, renterUserId, renterDeviceId,
+            const [id, listingId, ownerUserId, renterUserId, renterDeviceId,
                    rateSnapshot, depositMli, durationMin] = params;
+            state.nextContractId++;
             const startedAt = new Date();
             const endsAt = new Date(Date.now() + durationMin * 60 * 1000);
             const row = {
@@ -349,7 +349,7 @@ describe('rental: startRental happy path', () => {
             durationMinutes: 60,
         }, walletApi);
 
-        expect(contract.id).toMatch(/^contract-/);
+        expect(contract.id).toMatch(/^contract_[a-f0-9]{24}$/);
         expect(contract.status).toBe('active');
         // Deposit = rate × 20 = 5000 × 20 = 100_000
         expect(String(contract.deposit_mli)).toBe('100000');

--- a/backend/tests/jest/rental-debug-contract-start.test.js
+++ b/backend/tests/jest/rental-debug-contract-start.test.js
@@ -65,11 +65,11 @@ jest.mock('pg', () => {
         if (/^INSERT INTO rental_contracts/i.test(norm)) {
             return {
                 rows: [{
-                    id: 'contract-dry-run',
+                    id: params[0],
                     status: 'active',
                     started_at: new Date('2026-05-01T00:00:00Z'),
                     ends_at: new Date('2026-05-01T00:30:00Z'),
-                    deposit_mli: params[5],
+                    deposit_mli: params[6],
                 }],
                 rowCount: 1,
             };
@@ -245,8 +245,8 @@ describe('rental debug endpoints', () => {
         ]);
         expect(res.body.diagnostics.dryRunStart).toMatchObject({
             ok: true,
-            contractIdPreview: 'contract-dry-run',
         });
+        expect(res.body.diagnostics.dryRunStart.contractIdPreview).toMatch(/^contract_[a-f0-9]{24}$/);
     });
 
     test('contract-start-fail predicts insufficient rental balance', async () => {

--- a/backend/tests/jest/rental-wallet-integration.test.js
+++ b/backend/tests/jest/rental-wallet-integration.test.js
@@ -80,8 +80,8 @@ jest.mock('pg', () => {
 
         // INSERT rental_contracts
         if (/^INSERT INTO rental_contracts/i.test(norm)) {
-            const id = `contract-${state.nextContractId++}`;
-            const [listingId, ownerUserId, renterUserId, renterDeviceId, rateSnapshot, depositMli, durationMin] = params;
+            const [id, listingId, ownerUserId, renterUserId, renterDeviceId, rateSnapshot, depositMli, durationMin] = params;
+            state.nextContractId++;
             const startedAt = new Date();
             const endsAt = new Date(Date.now() + durationMin * 60 * 1000);
             state.contracts.push({


### PR DESCRIPTION
## Summary
- Generate `contract_...` ids in application code before inserting rental contracts
- Repair the `rental_contracts.id` database default during rental schema init for existing production databases
- Update rental lifecycle, dry-run debug, and wallet integration tests for explicit contract ids

## Root Cause
Production `rental_contracts.id` had no effective default. `POST /api/rental/contract` inserted without an id, so Postgres rejected the row with `23502 null value in column id`, which collapsed to `internal_error`.

## Verification
- `node --check backend/rental.js`
- `cd backend && npx jest tests/jest/rental-contract.test.js tests/jest/rental-debug-contract-start.test.js tests/jest/rental-wallet-integration.test.js`

## Issue
Fixes #2283.
