### PR TITLE
fix(channel): suppress operational A2A loop messages

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -437,6 +437,7 @@ EClaw/
 | Rental contract start returns internal_error during rent/borrow E2E (#2283) | `GET /api/rental/debug/contract-start-fail?deviceId=X&deviceSecret=Y&listingId=Y&renterDeviceId=Z&durationMinutes=30` | 2026-05-01 | Active |
    | Chat first render delayed by cross-device label resolution | `GET /api/debug/chat-render-load-order?deviceId=X&deviceSecret=Y` | 2026-05-01 | Active |
    | Kanban nudges ignored by Codex channel bridge | `GET /api/mission/debug/kanban-codex-nudge?deviceId=X&deviceSecret=Y` | 2026-05-01 | Active |
+   | Codex channel A2A loop from operational bridge errors | `GET /api/debug/a2a-loop-guard?deviceId=X&deviceSecret=Y` | 2026-05-02 | Active |
 
 6. **Demand Elegance (Balanced)** — 在保持 minimal change 的前提下，追求可讀、一致的程式風格；不為了「漂亮」而過度重構，但也不容忍明顯的 code smell 在新增的程式碼中出現。
 
@@ -1175,7 +1176,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | Cross-Speak Channel | `tests/jest/cross-speak-channel.test.js` | Cross-speak channel push parity — entity/client cross-speak channel-bound delivery |
 | Link Preview | `tests/jest/link-preview.test.js` | Link preview OG tag extraction, URL validation, SSRF protection, timeout handling |
 | Account Deletion | `tests/jest/account-deletion.test.js` | DELETE /api/auth/account cleanup of all related tables, FK constraint handling |
-| Channel Cross-Route | `tests/jest/channel-cross-route.test.js` | Channel message cross-device routing, auto-route consumption |
+| Channel Cross-Route | `tests/jest/channel-cross-route.test.js` | Channel message cross-device routing, auto-route consumption, and suppression of Codex operational bridge errors |
 | Cross-Speak Rendering | `tests/jest/cross-speak-chat-rendering.test.js` | Cross-device message direction rendering in chat.html |
 | Transform Cross-Route | `tests/jest/transform-cross-route.test.js` | Transform auto-route bot replies to sender device |
 | Mission Skill/Rule Dedup | `tests/jest/mission-skill-rule-dedup.test.js` | Skill/add and rule/add deduplication on concurrent multi-entity notify |

--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -60,7 +60,46 @@ async function assertPublicCallbackUrl(callbackUrl) {
     if (isPrivateIp(address)) throw new Error('callback_url must not resolve to a private/internal IP');
 }
 
-module.exports = function (devices, { authMiddleware, serverLog, generateBotSecret, generatePublicCode, publicCodeIndex, saveChatMessage, io, saveData, createDefaultEntity, apiBase, awardEntityXP, XP_AMOUNTS, notifyDevice, deliverToEntity, gatekeeperCheckText, resolveSpeakToTarget, checkBotToBotRateLimit, checkCrossSpeakRateLimit, crossDeviceSettings, devicePrefs, recentBroadcasts: _recentBroadcasts, BOT2BOT_MAX_MESSAGES: _BOT2BOT_MAX_MESSAGES, db: dbRef, getMissionApiHints, buildIdentitySetupHint, buildBroadcastRecipientBlock, chatPool }) {
+function isTruthyFlag(value) {
+    if (value === true || value === 1) return true;
+    if (typeof value !== 'string') return false;
+    return ['true', '1', 'yes', 'on'].includes(value.trim().toLowerCase());
+}
+
+function isOperationalChannelMessage(message) {
+    if (!message || typeof message !== 'string') return false;
+    const text = message.trim();
+    return [
+        /^Codex bridge error\b/i,
+        /^Codex status heartbeat\b/i,
+        /^Codex watchdog\b/i,
+        /^Codex bridge status\b/i,
+        /^Codex bridge thread reset\./i,
+        /^Codex turn interrupted\./i,
+        /^No active Codex turn\./i,
+        /^Codex is working\.\.\./i,
+        /^Codex model set to\b/i,
+        /^Codex intelligence set to\b/i,
+        /^Invalid Codex model name\./i,
+        /^Invalid Codex intelligence value\./i,
+        /^Unknown Codex model option:/i,
+        /^Unknown Codex intelligence option:/i,
+        /^Choose the Codex model\b/i,
+        /^選擇 Codex 智慧功能等級/i,
+        /^EClaw progress update\b/i,
+        /^\[SYSTEM:/i,
+    ].some(pattern => pattern.test(text));
+}
+
+function shouldSuppressA2A(reqBody, message) {
+    return isTruthyFlag(reqBody.suppressA2A)
+        || isTruthyFlag(reqBody.suppress_a2a)
+        || isTruthyFlag(reqBody.noA2A)
+        || isTruthyFlag(reqBody.no_a2a)
+        || isOperationalChannelMessage(message);
+}
+
+function channelApiModule(devices, { authMiddleware, serverLog, generateBotSecret, generatePublicCode, publicCodeIndex, saveChatMessage, io, saveData, createDefaultEntity, apiBase, awardEntityXP, XP_AMOUNTS, notifyDevice, deliverToEntity, gatekeeperCheckText, resolveSpeakToTarget, checkBotToBotRateLimit, checkCrossSpeakRateLimit, crossDeviceSettings, devicePrefs, recentBroadcasts: _recentBroadcasts, BOT2BOT_MAX_MESSAGES: _BOT2BOT_MAX_MESSAGES, db: dbRef, getMissionApiHints, buildIdentitySetupHint, buildBroadcastRecipientBlock, chatPool }) {
     const pushContextHelpers = { getMissionApiHints, buildIdentitySetupHint, buildBroadcastRecipientBlock };
     // Late-bound kanban auto-review hook (set after kanbanModule init)
     let kanbanAutoReview = null;
@@ -615,6 +654,7 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
     router.post('/message', async (req, res) => {
         try {
             const { channel_api_key, deviceId, entityId, botSecret, message, state, mediaType, mediaUrl, targetDeviceId, speakTo, broadcast, card } = req.body;
+            const suppressA2AForward = shouldSuppressA2A(req.body || {}, message);
 
             if (process.env.DEBUG === 'true') serverLog('info', 'client_push', `[PUSH] /channel/message called, state=${state}, hasMsg=${!!message}`, { deviceId, entityId: entityId !== undefined ? parseInt(entityId) : 'auto' });
 
@@ -716,7 +756,7 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             // Skip silent tokens — internal signals should not appear in chat
             const isSilentMsg = message && /^\[SILENT\]$/i.test(message.trim());
             // Skip self chat save when speakTo/broadcast is present — deliverToEntity will save with routing source
-            const hasDelivery = (broadcast || (speakTo && Array.isArray(speakTo) && speakTo.length > 0));
+            const hasDelivery = !suppressA2AForward && (broadcast || (speakTo && Array.isArray(speakTo) && speakTo.length > 0));
             if (message && !isSilentMsg) {
                 if (!hasDelivery) {
                     // If replying to a cross-device message, tag local copy with routing info
@@ -738,7 +778,7 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             }
 
             // [CROSS-DEVICE ROUTING] — explicit targetDeviceId OR auto-route from pending cross-device message
-            if (targetDeviceId && message) {
+            if (!suppressA2AForward && targetDeviceId && message) {
                 // Explicit routing — bot specifies which device to route reply to
                 const targetDev = devices[targetDeviceId];
                 if (targetDev) {
@@ -760,7 +800,7 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
                 } else {
                     serverLog('warn', 'cross_speak_push', `[EXPLICIT_ROUTE] targetDeviceId ${targetDeviceId} not found`, { deviceId, entityId: eId });
                 }
-            } else if (hasCrossRoute) {
+            } else if (!suppressA2AForward && hasCrossRoute) {
                 const replySource = `xdevice:${entity.publicCode}:${entity.character}->${pendingCross.fromPublicCode || pendingCross.fromDeviceId}`;
                 const senderEntityId = pendingCross.fromEntityId >= 0 ? pendingCross.fromEntityId : 0;
                 await saveChatMessage(pendingCross.fromDeviceId, senderEntityId, message, replySource, false, true);
@@ -802,14 +842,14 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             serverLog('info', 'transform', `${state || entity.state}: ${(message || '').slice(0, 100)}`, { deviceId, entityId: eId, metadata: { state: state || entity.state, via: 'channel' } });
 
             // Auto-move kanban child cards to done (same as /api/transform)
-            if (state !== 'BUSY' && message && kanbanAutoReview) {
+            if (!suppressA2AForward && state !== 'BUSY' && message && kanbanAutoReview) {
                 kanbanAutoReview(deviceId, eId, message).catch(err => {
                     console.error(`[Channel] autoReviewOnTransform failed:`, err.message);
                 });
             }
 
             // Org chart: auto-forward channel bot response to superior entity (fire-and-forget)
-            if (finalMessage && entity && orgChartForwardFn) {
+            if (!suppressA2AForward && finalMessage && entity && orgChartForwardFn) {
                 orgChartForwardFn(entity, deviceId, finalMessage).catch(() => {});
             }
 
@@ -823,8 +863,11 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             if (entityIdCorrected) {
                 warnings.push(`entityId mismatch: auto-corrected to ${eId}.`);
             }
+            if (suppressA2AForward) {
+                warnings.push('A2A routing suppressed for operational channel message.');
+            }
 
-            if ((speakTo || broadcast) && message && !isSilentMsg && deliverToEntity && resolveSpeakToTarget) {
+            if (!suppressA2AForward && (speakTo || broadcast) && message && !isSilentMsg && deliverToEntity && resolveSpeakToTarget) {
                 if (speakTo && broadcast) {
                     warnings.push('Both speakTo and broadcast provided — broadcast takes priority, speakTo ignored.');
                 }
@@ -908,7 +951,7 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             // Fallback: delivery was requested but no target resolved — save
             // sender's copy so chat UI still shows the message. Mirror of the
             // same logic in /api/transform.
-            const hasDeliveryRequested = (broadcast || (speakTo && Array.isArray(speakTo) && speakTo.length > 0));
+            const hasDeliveryRequested = !suppressA2AForward && (broadcast || (speakTo && Array.isArray(speakTo) && speakTo.length > 0));
             if (hasDeliveryRequested && !deliverySaved && message && !isSilentMsg) {
                 const localSource = hasCrossRoute
                     ? `xdevice:${entity.publicCode}:${entity.character}->${pendingCross.fromPublicCode || pendingCross.fromDeviceId}`
@@ -931,6 +974,7 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
                 }
             };
             if (deliveryResults) response.delivery = deliveryResults;
+            if (suppressA2AForward) response.suppressedA2A = true;
             if (warnings.length > 0) response.warnings = warnings;
             res.json(response);
         } catch (err) {
@@ -1220,4 +1264,9 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
         setKanbanAutoReview,
         setOrgChartForward
     };
-};
+}
+
+channelApiModule.isOperationalChannelMessage = isOperationalChannelMessage;
+channelApiModule.shouldSuppressA2A = shouldSuppressA2A;
+
+module.exports = channelApiModule;

--- a/backend/index.js
+++ b/backend/index.js
@@ -2321,6 +2321,223 @@ app.get('/api/debug/chat-render-load-order', async (req, res) => {
     }
 });
 
+// Temporary diagnostic endpoint for Codex channel A2A loop suppression.
+// It reports message classes, route-source shapes, and guard config only; no raw
+// chat text, secrets, tokens, webhook URLs, or callback payloads are returned.
+app.get('/api/debug/a2a-loop-guard', async (req, res) => {
+    const { deviceId, deviceSecret } = req.query || {};
+    const timestamp = new Date().toISOString();
+    const classifyMessage = (message) => {
+        if (!message || typeof message !== 'string') return 'empty';
+        const text = message.trim();
+        if (/^Codex bridge error\b/i.test(text)) return 'codex_bridge_error';
+        if (/^Codex status heartbeat\b/i.test(text)) return 'codex_status_heartbeat';
+        if (/^Codex watchdog\b/i.test(text)) return 'codex_watchdog';
+        if (/^Codex bridge status\b/i.test(text)) return 'codex_bridge_status';
+        if (/^EClaw progress update\b/i.test(text)) return 'eclaw_progress_update';
+        if (/^\[SYSTEM:/i.test(text)) return 'system_control';
+        return 'ordinary';
+    };
+    const classifySource = (source) => {
+        if (!source) return '(empty)';
+        if (source.startsWith('xdevice:')) return 'xdevice';
+        if (source.startsWith('entity:')) return 'entity-route';
+        return 'local-or-channel';
+    };
+
+    try {
+        if (!deviceId || !deviceSecret) {
+            return res.status(401).json({ success: false, bug: 'a2a-loop-guard', error: 'deviceId and deviceSecret required', timestamp });
+        }
+
+        const memDevice = devices[deviceId];
+        const pool = db._getPool ? db._getPool() : authModule.pool;
+        const dbDevice = pool
+            ? await pool.query('SELECT device_secret FROM devices WHERE device_id = $1', [deviceId])
+            : { rows: [] };
+        const dbDeviceRow = dbDevice.rows[0] || null;
+        const memSecretOk = !!(memDevice && memDevice.deviceSecret && safeEqual(memDevice.deviceSecret, deviceSecret));
+        const dbSecretOk = !!(dbDeviceRow && dbDeviceRow.device_secret && safeEqual(dbDeviceRow.device_secret, deviceSecret));
+        if (!memSecretOk && !dbSecretOk) {
+            return res.status(403).json({ success: false, bug: 'a2a-loop-guard', error: 'Invalid credentials', timestamp });
+        }
+
+        const [chatRows, logRows, channelRows] = pool ? await Promise.all([
+            pool.query(
+                `SELECT id, entity_id, source, is_from_bot, is_from_user, LENGTH(COALESCE(text, '')) AS text_length,
+                        CASE
+                            WHEN text ~* '^Codex bridge error' THEN 'codex_bridge_error'
+                            WHEN text ~* '^Codex status heartbeat' THEN 'codex_status_heartbeat'
+                            WHEN text ~* '^Codex watchdog' THEN 'codex_watchdog'
+                            WHEN text ~* '^Codex bridge status' THEN 'codex_bridge_status'
+                            WHEN text ~* '^EClaw progress update' THEN 'eclaw_progress_update'
+                            WHEN text ~* '^\\[SYSTEM:' THEN 'system_control'
+                            ELSE 'ordinary'
+                        END AS message_class,
+                        created_at
+                 FROM chat_messages
+                 WHERE device_id = $1
+                   AND (
+                        source LIKE 'entity:%->%'
+                        OR source LIKE 'xdevice:%->%'
+                        OR text ~* '^(Codex bridge error|Codex status heartbeat|Codex watchdog|Codex bridge status|EClaw progress update|\\[SYSTEM:)'
+                   )
+                 ORDER BY created_at DESC
+                 LIMIT 100`,
+                [deviceId]
+            ).catch(err => ({ rows: [], error: err.message })),
+            pool.query(
+                `SELECT level, category, entity_id,
+                        CASE
+                            WHEN message ~* '^Codex bridge error' THEN 'codex_bridge_error'
+                            WHEN message ~* '^Codex status heartbeat' THEN 'codex_status_heartbeat'
+                            WHEN message ~* '^Codex watchdog' THEN 'codex_watchdog'
+                            WHEN message ~* '^Codex bridge status' THEN 'codex_bridge_status'
+                            WHEN message ~* '^EClaw progress update' THEN 'eclaw_progress_update'
+                            WHEN message ~* '^\\[SYSTEM:' THEN 'system_control'
+                            ELSE 'ordinary'
+                        END AS message_class,
+                        created_at
+                 FROM server_logs
+                 WHERE device_id = $1
+                   AND (
+                        category IN ('cross_speak_push', 'transform', 'chat_save', 'channel')
+                        OR message ~* '^(Codex bridge error|Codex status heartbeat|Codex watchdog|Codex bridge status|EClaw progress update|\\[SYSTEM:)'
+                   )
+                 ORDER BY created_at DESC
+                 LIMIT 100`,
+                [deviceId]
+            ).catch(err => ({ rows: [], error: err.message })),
+            pool.query(
+                `SELECT id, status, callback_url, updated_at
+                 FROM channel_accounts
+                 WHERE device_id = $1
+                 ORDER BY updated_at DESC NULLS LAST, id ASC`,
+                [deviceId]
+            ).catch(err => ({ rows: [], error: err.message })),
+        ]) : [{ rows: [] }, { rows: [] }, { rows: [] }];
+
+        const memEntities = memDevice?.entities || {};
+        const memoryEntities = Object.keys(memEntities).map(Number).sort((a, b) => a - b).map(id => {
+            const entity = memEntities[id] || {};
+            const queue = Array.isArray(entity.messageQueue) ? entity.messageQueue : [];
+            const crossQueue = queue.filter(m => m && m.crossDevice);
+            const queuedMessageClasses = queue.reduce((acc, item) => {
+                const cls = classifyMessage(item?.text || item?.message || '');
+                acc[cls] = (acc[cls] || 0) + 1;
+                return acc;
+            }, {});
+            return {
+                entityId: id,
+                isBound: !!entity.isBound,
+                state: entity.state || null,
+                bindingType: entity.bindingType || null,
+                publicCodePresent: !!entity.publicCode,
+                queueLength: queue.length,
+                crossQueueLength: crossQueue.length,
+                latestCrossFromShape: crossQueue.length ? classifySource(crossQueue[crossQueue.length - 1]?.from || '') : null,
+                queuedMessageClasses,
+            };
+        });
+
+        const chatByClass = {};
+        const chatBySourceShape = {};
+        for (const row of chatRows.rows) {
+            const cls = row.message_class || 'unknown';
+            chatByClass[cls] = (chatByClass[cls] || 0) + 1;
+            const shape = classifySource(row.source || '');
+            chatBySourceShape[shape] = (chatBySourceShape[shape] || 0) + 1;
+        }
+
+        const logsByClass = {};
+        const logsByCategory = {};
+        for (const row of logRows.rows) {
+            const cls = row.message_class || 'unknown';
+            logsByClass[cls] = (logsByClass[cls] || 0) + 1;
+            const category = row.category || '(empty)';
+            logsByCategory[category] = (logsByCategory[category] || 0) + 1;
+        }
+
+        res.json({
+            success: true,
+            bug: 'a2a-loop-guard',
+            diagnostics: {
+                server: {
+                    build: SERVER_BUILD_TAG,
+                    startedAt: SERVER_STARTED_AT.toISOString(),
+                    uptimeSec: Math.round(process.uptime()),
+                },
+                auth: {
+                    memSecretOk,
+                    dbSecretOk,
+                    requestUserDeviceId: req.user?.deviceId || null,
+                    requestUserId: req.user?.userId || null,
+                },
+                guardConfig: {
+                    acceptsSuppressFlags: ['suppressA2A', 'suppress_a2a', 'noA2A', 'no_a2a'],
+                    operationalClasses: [
+                        'codex_bridge_error',
+                        'codex_status_heartbeat',
+                        'codex_watchdog',
+                        'codex_bridge_status',
+                        'eclaw_progress_update',
+                        'system_control',
+                    ],
+                    suppressesCrossDeviceRoute: true,
+                    suppressesSpeakToBroadcast: true,
+                    suppressesOrgForward: true,
+                    suppressesKanbanAutoReview: true,
+                },
+                memoryEntities,
+                recentChat: {
+                    returned: chatRows.rows.length,
+                    queryError: chatRows.error || null,
+                    byClass: chatByClass,
+                    bySourceShape: chatBySourceShape,
+                    rows: chatRows.rows.map(row => ({
+                        id: row.id,
+                        entityId: row.entity_id,
+                        sourceShape: classifySource(row.source || ''),
+                        messageClass: row.message_class,
+                        messageLength: Number(row.text_length || 0),
+                        isFromBot: !!row.is_from_bot,
+                        isFromUser: !!row.is_from_user,
+                        createdAt: row.created_at,
+                    })),
+                },
+                recentServerLogs: {
+                    returned: logRows.rows.length,
+                    queryError: logRows.error || null,
+                    byClass: logsByClass,
+                    byCategory: logsByCategory,
+                    rows: logRows.rows.map(row => ({
+                        level: row.level,
+                        category: row.category,
+                        entityId: row.entity_id,
+                        messageClass: row.message_class,
+                        createdAt: row.created_at,
+                    })),
+                },
+                channelAccounts: {
+                    returned: channelRows.rows.length,
+                    queryError: channelRows.error || null,
+                    rows: channelRows.rows.map(row => ({
+                        id: row.id,
+                        status: row.status,
+                        hasCallback: !!row.callback_url,
+                        callbackHost: row.callback_url ? (() => { try { return new URL(row.callback_url).host; } catch (_) { return 'invalid-url'; } })() : null,
+                        updatedAt: row.updated_at,
+                    })),
+                },
+            },
+            timestamp,
+        });
+    } catch (err) {
+        console.error('[Debug a2a-loop-guard] failed:', err);
+        res.status(500).json({ success: false, bug: 'a2a-loop-guard', error: err.message, timestamp });
+    }
+});
+
 // Wire up pending message flush on email verification
 authModule.setOnEmailVerified(async (deviceId) => {
     console.log(`[PendingFlush] onEmailVerified triggered for device ${deviceId}`);

--- a/backend/tests/jest/channel-cross-route.test.js
+++ b/backend/tests/jest/channel-cross-route.test.js
@@ -214,6 +214,29 @@ describe('POST /api/channel/message — cross-device routing', () => {
         expect(crossRemaining.length).toBe(1);
     });
 
+    it('suppresses Codex bridge operational errors from A2A routing', async () => {
+        const { devices } = require('../../index');
+        const entity = devices[DEVICE_A].entities[0];
+        injectCrossDeviceMessage(entity, DEVICE_B, 'B_CODE');
+
+        const res = await post('/api/channel/message').send({
+            channel_api_key: CHANNEL_API_KEY,
+            deviceId: DEVICE_A,
+            entityId: 0,
+            botSecret: botSecretA,
+            message: [
+                'Codex bridge error',
+                '- Reason: Codex is still processing the previous message.'
+            ].join('\n')
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.suppressedA2A).toBe(true);
+        expect(res.body.warnings).toContain('A2A routing suppressed for operational channel message.');
+        expect(entity.messageQueue.filter(m => m.crossDevice).length).toBe(1);
+    });
+
     it('handles owner-mode cross-device message (fromEntityId=-1)', async () => {
         const { devices } = require('../../index');
         const entity = devices[DEVICE_A].entities[0];

--- a/backend/tests/jest/chat-render-load-order.test.js
+++ b/backend/tests/jest/chat-render-load-order.test.js
@@ -41,7 +41,7 @@ describe('chat.html initial render order', () => {
     test('debug endpoint reports render-load diagnostics without chat message text', () => {
         const start = indexJs.indexOf("app.get('/api/debug/chat-render-load-order'");
         expect(start).toBeGreaterThan(0);
-        const end = indexJs.indexOf('// Wire up pending message flush on email verification', start);
+        const end = indexJs.indexOf('// Temporary diagnostic endpoint for Codex channel A2A loop suppression.', start);
         expect(end).toBeGreaterThan(start);
         const body = indexJs.slice(start, end);
 


### PR DESCRIPTION
## Summary
- add channel-message A2A suppression flags and operational Codex message detection
- prevent suppressed operational messages from cross-device auto-route, speakTo/broadcast, org-forward, and kanban auto-review paths
- add a temporary diagnostics endpoint at GET /api/debug/a2a-loop-guard and register the regression test in AGENTS.md
- scope the existing chat-render debug static test so it does not inspect the new A2A diagnostics endpoint

## Verification
- node -c backend/channel-api.js && node -c backend/index.js
- npm run lint -- index.js channel-api.js tests/jest/chat-render-load-order.test.js tests/jest/channel-cross-route.test.js (0 errors; existing warnings only)
- npx jest tests/jest/chat-render-load-order.test.js tests/jest/channel-api.test.js tests/jest/channel-cross-route.test.js tests/jest/transform-rich-card.test.js (58 passed)
- npm test (157 suites / 2475 tests passed)