### PR TITLE
feat(channel-api): /api/channel/message accepts senderHint (Phase 3a of #2285)

### DIFF
--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -614,9 +614,27 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
     // ============================================
     router.post('/message', async (req, res) => {
         try {
-            const { channel_api_key, deviceId, entityId, botSecret, message, state, mediaType, mediaUrl, targetDeviceId, speakTo, broadcast, card } = req.body;
+            const { channel_api_key, deviceId, entityId, botSecret, message, state, mediaType, mediaUrl, targetDeviceId, card, senderHint } = req.body;
+            let { speakTo, broadcast } = req.body;
 
             if (process.env.DEBUG === 'true') serverLog('info', 'client_push', `[PUSH] /channel/message called, state=${state}, hasMsg=${!!message}`, { deviceId, entityId: entityId !== undefined ? parseInt(entityId) : 'auto' });
+
+            // Validate optional senderHint — bridges pass this so the server resolves
+            // routing centrally instead of each bridge implementing its own logic.
+            // Same shape and precedence as /api/transform (issue #2285): explicit
+            // speakTo/broadcast win, senderHint is the lowest-precedence fallback.
+            if (senderHint !== undefined && senderHint !== null) {
+                if (typeof senderHint !== 'object' || Array.isArray(senderHint)) {
+                    return res.status(400).json({ success: false, message: 'senderHint must be an object' });
+                }
+                const allowedKinds = new Set(['entity', 'user', 'broadcast', 'unknown']);
+                if (senderHint.kind && !allowedKinds.has(senderHint.kind)) {
+                    return res.status(400).json({
+                        success: false,
+                        message: `senderHint.kind must be one of: ${[...allowedKinds].join(', ')}`
+                    });
+                }
+            }
 
             if (!channel_api_key || !deviceId || !botSecret) {
                 if (process.env.DEBUG === 'true') serverLog('warn', 'client_push', `[PUSH] /channel/message missing required fields`, { deviceId });
@@ -708,6 +726,52 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             if (state) entity.state = state;
             if (message) entity.message = message;
             entity.lastUpdated = Date.now();
+
+            // ── senderHint resolution (channel-bridge centralization, issue #2285) ──
+            // Lowest precedence — only fills speakTo/broadcast when neither was
+            // explicitly set on the request body. Channel bridges pass senderHint
+            // derived from the inbound payload's "from*" fields so the server
+            // (not the bridge) decides where the bot's reply routes.
+            let senderHintResolution = null;
+            const noTargetYet = !broadcast && !(speakTo && Array.isArray(speakTo) && speakTo.length > 0);
+            if (senderHint && noTargetYet && message) {
+                const kind = senderHint.kind || 'unknown';
+                if (kind === 'broadcast') {
+                    broadcast = true;
+                    senderHintResolution = { kind, applied: 'broadcast' };
+                } else if (kind === 'entity') {
+                    let resolvedCode = null;
+                    if (senderHint.publicCode && typeof senderHint.publicCode === 'string') {
+                        const code = senderHint.publicCode.trim();
+                        if (publicCodeIndex && publicCodeIndex[code]) {
+                            resolvedCode = code;
+                        } else {
+                            for (const i of Object.keys(device.entities).map(Number)) {
+                                if (device.entities[i]?.publicCode === code) { resolvedCode = code; break; }
+                            }
+                        }
+                    }
+                    if (!resolvedCode && Number.isFinite(Number(senderHint.entityId))) {
+                        const hintId = Number(senderHint.entityId);
+                        const target = device.entities[hintId];
+                        if (target && target.publicCode) resolvedCode = target.publicCode;
+                    }
+                    if (resolvedCode) {
+                        speakTo = [resolvedCode];
+                        senderHintResolution = { kind, applied: 'speakTo', publicCode: resolvedCode };
+                    } else {
+                        senderHintResolution = { kind, applied: 'none', reason: 'unresolved_sender' };
+                    }
+                } else {
+                    senderHintResolution = { kind, applied: 'none' };
+                }
+            } else if (senderHint) {
+                senderHintResolution = {
+                    kind: senderHint.kind || 'unknown',
+                    applied: 'none',
+                    reason: noTargetYet ? 'no_message' : 'explicit_won'
+                };
+            }
 
             // Save to chat history
             // Check for pending cross-device context first, so local copy also shows routing direction
@@ -932,6 +996,7 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             };
             if (deliveryResults) response.delivery = deliveryResults;
             if (warnings.length > 0) response.warnings = warnings;
+            if (senderHintResolution) response.senderHintResolution = senderHintResolution;
             res.json(response);
         } catch (err) {
             console.error('[Channel] Message error:', err.message);

--- a/backend/tests/jest/channel-message-sender-hint.test.js
+++ b/backend/tests/jest/channel-message-sender-hint.test.js
@@ -1,0 +1,181 @@
+/**
+ * /api/channel/message — senderHint resolution (Phase 3a of issue #2285)
+ *
+ * Mirrors the senderHint contract from /api/transform onto the channel-bridge
+ * endpoint so codex / hermes / openclaw bridges can delegate routing to the
+ * server without each one reimplementing decideReplyRouting.
+ */
+
+require('./helpers/mock-setup');
+
+const db = require('../../db');
+const apiKey = 'eck_sender_hint_test';
+const account = { id: 1, channel_api_key: apiKey, channel_api_secret: 'ecs_test', deviceId: null, entityId: null };
+db.getChannelAccountByKey = jest.fn().mockImplementation(async (key) => key === apiKey ? account : null);
+db.getChannelAccountsByDevice = jest.fn().mockResolvedValue([]);
+db.createChannelAccount = jest.fn().mockResolvedValue(account);
+db.getChannelAccountById = jest.fn().mockResolvedValue(null);
+db.deleteChannelAccount = jest.fn().mockResolvedValue(true);
+db.updateChannelCallback = jest.fn().mockResolvedValue(true);
+db.updateChannelE2eeCapable = jest.fn().mockResolvedValue(true);
+db.clearChannelCallback = jest.fn().mockResolvedValue(true);
+db.getChannelAccountByDevice = jest.fn().mockResolvedValue(null);
+
+const request = require('supertest');
+let app;
+
+const post = (path) => request(app).post(path).set('Host', 'localhost');
+
+async function registerDevice(id) {
+    const secret = `secret-${id}`;
+    await post('/api/device/register').send({ deviceId: id, deviceSecret: secret, entityId: 0 });
+    return secret;
+}
+
+async function bindEntity(deviceId, deviceSecret, entityId = 0) {
+    const regRes = await post('/api/device/register').send({ deviceId, deviceSecret, entityId });
+    const code = regRes.body.bindingCode;
+    if (!code) return undefined;
+    const bindRes = await post('/api/bind').send({ code });
+    return bindRes.body.botSecret;
+}
+
+beforeAll(() => {
+    app = require('../../index');
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+});
+
+describe('POST /api/channel/message — senderHint', () => {
+    let deviceId, deviceSecret, botSecret1, entity0Code;
+
+    beforeAll(async () => {
+        deviceId = 'chmsg-sh-device';
+        deviceSecret = await registerDevice(deviceId);
+        await bindEntity(deviceId, deviceSecret, 0);
+        await post('/api/device/add-entity').send({ deviceId, deviceSecret });
+        botSecret1 = await bindEntity(deviceId, deviceSecret, 1);
+
+        const { devices } = require('../../index');
+        entity0Code = devices[deviceId].entities[0].publicCode;
+        expect(botSecret1).toBeTruthy();
+        expect(entity0Code).toBeTruthy();
+    });
+
+    it('resolves senderHint kind=entity with publicCode → fills speakTo', async () => {
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 1, botSecret: botSecret1,
+            state: 'IDLE',
+            message: 'reply via channel',
+            senderHint: { kind: 'entity', entityId: 0, publicCode: entity0Code }
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.senderHintResolution).toEqual({
+            kind: 'entity',
+            applied: 'speakTo',
+            publicCode: entity0Code
+        });
+    });
+
+    it('resolves senderHint kind=entity with entityId only → fills speakTo via local lookup', async () => {
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 1, botSecret: botSecret1,
+            state: 'IDLE',
+            message: 'reply',
+            senderHint: { kind: 'entity', entityId: 0 }
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.senderHintResolution.applied).toBe('speakTo');
+        expect(res.body.senderHintResolution.publicCode).toBe(entity0Code);
+    });
+
+    it('senderHint kind=broadcast → sets broadcast=true', async () => {
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 1, botSecret: botSecret1,
+            state: 'IDLE',
+            message: 'announcement',
+            senderHint: { kind: 'broadcast' }
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.senderHintResolution.applied).toBe('broadcast');
+    });
+
+    it('senderHint kind=user → no routing (status update)', async () => {
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 1, botSecret: botSecret1,
+            state: 'IDLE',
+            message: 'thanks!',
+            senderHint: { kind: 'user' }
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.senderHintResolution.applied).toBe('none');
+    });
+
+    it('explicit speakTo wins over senderHint', async () => {
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 1, botSecret: botSecret1,
+            state: 'IDLE',
+            message: 'reply',
+            speakTo: [entity0Code],
+            senderHint: { kind: 'broadcast' }
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.senderHintResolution.applied).toBe('none');
+        expect(res.body.senderHintResolution.reason).toBe('explicit_won');
+    });
+
+    it('senderHint with unresolvable publicCode → applied:none with reason', async () => {
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 1, botSecret: botSecret1,
+            state: 'IDLE',
+            message: 'reply',
+            senderHint: { kind: 'entity', publicCode: 'doesnotexist', entityId: 999 }
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.senderHintResolution.applied).toBe('none');
+        expect(res.body.senderHintResolution.reason).toBe('unresolved_sender');
+    });
+
+    it('rejects malformed senderHint (non-object)', async () => {
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 1, botSecret: botSecret1,
+            state: 'IDLE', message: 'x',
+            senderHint: 'entity'
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.message).toMatch(/senderHint/);
+    });
+
+    it('rejects unknown senderHint.kind', async () => {
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 1, botSecret: botSecret1,
+            state: 'IDLE', message: 'x',
+            senderHint: { kind: 'invalid_kind' }
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.message).toMatch(/senderHint\.kind/);
+    });
+
+    it('omitted senderHint → no senderHintResolution in response (backward compat)', async () => {
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 1, botSecret: botSecret1,
+            state: 'IDLE',
+            message: 'no hint'
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.senderHintResolution).toBeUndefined();
+    });
+});


### PR DESCRIPTION
Brings the `senderHint` contract from `/api/transform` (PR #2287) onto the channel-bridge endpoint so codex / hermes / openclaw bridges can delegate routing to the server with a single optional field.

## Why

Unlike `/api/transform`, `/api/channel/message` does **not** run the `@`-mention auto-router today. So bridges that post here (codex, hermes) have no centralized routing path at all — replies just become status updates unless the bridge guesses a `speakTo` itself. Adding `senderHint` here closes that gap with the smallest possible diff.

## Contract

Same shape, same precedence rules as `/api/transform`:

```js
{ senderHint: { kind: "entity"|"user"|"broadcast"|"unknown", entityId?, publicCode? } }
```

- explicit `speakTo` / `broadcast` win over `senderHint`
- `senderHint` only fires when `noTargetYet && message`
- response surfaces `senderHintResolution { kind, applied, publicCode?, reason? }`

## Test plan

- [x] `tests/jest/channel-message-sender-hint.test.js` — 9 new cases, all pass
- [x] `tests/jest/channel-api.test.js` — 26 pre-existing cases, all pass
- [x] `npm run lint` — 0 errors

Refs #2285

🤖 Generated with [Claude Code](https://claude.com/claude-code)