### PR TITLE
fix(transform): tolerant speakTo formats + clean fallback chatSource

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -6196,19 +6196,43 @@ app.get('/api/status', (req, res) => {
 
 /**
  * Resolve a speakTo target code to { deviceId, entityId }.
- * Supports both publicCode (cross-device) and numeric entityId string (same-device fallback).
- * @param {string} code - publicCode or entityId string
+ *
+ * Accepted forms (PR #2291 — defensive against LLM misuse):
+ *   - "abc123"     6-char publicCode (cross-device)
+ *   - "5"          numeric entityId  (same-device)
+ *   - "#5"         hash + numeric    (same-device — Claude/LLM often confuses
+ *                                     the @-mention routing token with speakTo)
+ *   - "@#5"        @-prefixed         (same as above with @)
+ *   - "<#5>"       bracketed numeric  (legacy form mentioned in older docs)
+ *   - "@abc123"    @-prefixed pubCode (same as above with @)
+ *   - "<@abc123>"  bracketed pubCode  (mention-parser's <@xxxxxx> form)
+ *
+ * @param {string} code
  * @param {string} senderDeviceId - sender's device for same-device entityId fallback
  * @returns {{ deviceId, entityId } | null}
  */
 function resolveSpeakToTarget(code, senderDeviceId) {
-    // Try publicCode first
-    const byCode = publicCodeIndex[code];
+    if (typeof code !== 'string' || code.length === 0) return null;
+
+    // Strip routing-token prefixes/suffixes that Claude/LLMs sometimes paste
+    // into speakTo when they confuse the in-text @-mention syntax with the
+    // speakTo array contract. We never strip any character that could be part
+    // of a real publicCode (publicCodes are exactly 6 chars of [a-z0-9]).
+    let normalized = code.trim();
+    if (normalized.startsWith('<') && normalized.endsWith('>')) {
+        normalized = normalized.slice(1, -1);
+    }
+    if (normalized.startsWith('@')) normalized = normalized.slice(1);
+    if (normalized.startsWith('#')) normalized = normalized.slice(1);
+
+    // Try publicCode first (both raw and normalized — a real publicCode never
+    // starts with @/#/< so the normalized form just unwraps decorator syntax).
+    const byCode = publicCodeIndex[normalized] || publicCodeIndex[code];
     if (byCode) return byCode;
 
     // Fallback: pure numeric string → same-device entityId
-    if (/^\d+$/.test(code)) {
-        const eid = parseInt(code);
+    if (/^\d+$/.test(normalized)) {
+        const eid = parseInt(normalized);
         const device = devices[senderDeviceId];
         if (device && device.entities[eid]) {
             return { deviceId: senderDeviceId, entityId: eid };
@@ -7185,14 +7209,20 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
     // this, the sender's own chat row never gets written — message disappears.
     // Save to sender so the author at least sees their own words, and surface
     // a warning so the caller knows no delivery happened.
+    //
+    // PR #2291 — chatSource here MUST NOT use the `pendingA2A` arrow form.
+    // When the requested delivery failed (e.g. Claude/LLM passes
+    // `speakTo: ["#6"]` and the resolver doesn't recognise the form), the
+    // user-visible result is the message rendered as if it were sent to
+    // pendingA2A's fromEntityId — because the source string is
+    // `entity:N:CHAR->X`. That's a misleading routing trail in chat history
+    // ("looks like sent to #X but never delivered to anyone"). Use the plain
+    // entity name so chat UI clearly renders this as a sender-only row.
     const hasDeliveryRequested = (broadcast || (speakTo && Array.isArray(speakTo) && speakTo.length > 0));
     if (hasDeliveryRequested && !deliverySaved && finalMessage && !isSilentMessage) {
         const isLeasedOut = entity.rental_status === 'leased_out';
         if (!isLeasedOut) {
-            const pendingA2A = entity.messageQueue && entity.messageQueue.find(m => m.from && m.from.startsWith('entity:'));
-            const chatSource = pendingA2A
-                ? `entity:${eId}:${entity.character}->${pendingA2A.fromEntityId}`
-                : entity.name || `Entity ${eId}`;
+            const chatSource = entity.name || `Entity ${eId}`;
             const reasons = deliveryResults && deliveryResults.results ? deliveryResults.results.map(r => r.reason || 'ok').join(',') : 'none';
             serverLog('warn', 'chat_save', `[CHAT_FALLBACK_TRANSFORM] all targets failed for entity ${eId}; saving sender copy. reasons=[${reasons}] speakTo=${JSON.stringify(speakTo || null)} broadcast=${!!broadcast}`, { deviceId, entityId: eId, metadata: { path: 'fallback_transform', reasons, hadSpeakTo: !!speakTo, hadBroadcast: !!broadcast } });
             await saveChatMessage(deviceId, eId, finalMessage, chatSource, false, true, null, null, null, null, null, null, validatedCard, validatedAttachments);

--- a/backend/tests/jest/transform-speakto-tolerant-formats.test.js
+++ b/backend/tests/jest/transform-speakto-tolerant-formats.test.js
@@ -1,0 +1,208 @@
+/**
+ * /api/transform speakTo tolerant formats + fallback-anchor regression
+ * (PR #2291)
+ *
+ * Two related fixes:
+ *
+ * 1. resolveSpeakToTarget now accepts decorated forms like `#6`, `@#6`,
+ *    `<#6>`, `@abc123`, `<@abc123>` in the speakTo array — strips the
+ *    decorator and falls back to publicCode / numeric-entityId lookup.
+ *    Claude / LLM bots routinely confuse the in-text @-mention syntax
+ *    with the speakTo array contract, sending `speakTo: ["#6"]` when
+ *    they mean "deliver to entity 6". Server now does the right thing.
+ *
+ * 2. When delivery requested but every target fails to resolve, the
+ *    fallback save no longer borrows `pendingA2A.fromEntityId` as a
+ *    chatSource arrow. That produced misleading rows like
+ *    `entity:2:LOBSTER->3 delivered=false` for a message that was
+ *    never sent to entity 3. We now save with `entity.name` so chat
+ *    UI clearly renders it as a sender-only row.
+ */
+
+require('./helpers/mock-setup');
+
+const request = require('supertest');
+const pg = require('pg');
+let app;
+
+const post = (path) => request(app).post(path).set('Host', 'localhost');
+
+let chatInserts = [];
+
+beforeAll(() => {
+    const originalPool = pg.Pool;
+    pg.Pool = jest.fn().mockImplementation(() => ({
+        query: jest.fn().mockImplementation(async (sql, params) => {
+            const sqlStr = typeof sql === 'string' ? sql : (sql && sql.text) || '';
+            if (/^\s*INSERT INTO chat_messages/i.test(sqlStr)) {
+                chatInserts.push({
+                    deviceId: params?.[0],
+                    entityId: params?.[1],
+                    text: params?.[2],
+                    source: params?.[3],
+                });
+                return { rows: [{ id: `mock-${chatInserts.length}` }], rowCount: 1 };
+            }
+            return { rows: [], rowCount: 0 };
+        }),
+        connect: jest.fn().mockResolvedValue({ query: jest.fn().mockResolvedValue({ rows: [] }), release: jest.fn() }),
+        end: jest.fn().mockResolvedValue(undefined),
+    }));
+    app = require('../../index');
+    pg.Pool = originalPool;
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+});
+
+beforeEach(() => { chatInserts = []; });
+
+async function registerDevice(id) {
+    const secret = `secret-${id}`;
+    await post('/api/device/register').send({ deviceId: id, deviceSecret: secret, entityId: 0 });
+    return secret;
+}
+
+async function bindEntity(deviceId, deviceSecret, entityId = 0) {
+    const regRes = await post('/api/device/register').send({ deviceId, deviceSecret, entityId });
+    const code = regRes.body.bindingCode;
+    if (!code) return undefined;
+    const bindRes = await post('/api/bind').send({ code });
+    return bindRes.body.botSecret;
+}
+
+function rowsForProbe(tag) {
+    return chatInserts.filter(r => (r.text || '').includes(tag));
+}
+
+describe('POST /api/transform — speakTo tolerant formats (#2291)', () => {
+    let deviceId, deviceSecret, botSecret2, entity1Code;
+
+    beforeAll(async () => {
+        deviceId = 'speakto-tolerant';
+        deviceSecret = await registerDevice(deviceId);
+        await bindEntity(deviceId, deviceSecret, 0);
+        await post('/api/device/add-entity').send({ deviceId, deviceSecret });
+        await bindEntity(deviceId, deviceSecret, 1);
+        await post('/api/device/add-entity').send({ deviceId, deviceSecret });
+        botSecret2 = await bindEntity(deviceId, deviceSecret, 2);
+
+        const { devices } = require('../../index');
+        entity1Code = devices[deviceId].entities[1].publicCode;
+
+        // pendingA2A entry from entity 0 — pre-fix, the fallback would have
+        // anchored chatSource to ->0 even though delivery target was #1.
+        devices[deviceId].entities[2].messageQueue.push({
+            text: 'priming',
+            from: 'entity:0:LOBSTER',
+            fromEntityId: 0,
+            timestamp: Date.now(),
+            crossDevice: false,
+        });
+    });
+
+    test.each([
+        ['#1',           'hash + numeric'],
+        ['@#1',          '@-prefixed hash'],
+        ['<#1>',         'bracketed hash'],
+    ])('speakTo: ["%s"] → resolves to entity 1 (%s)', async (speakToCode) => {
+        const tag = `TOL-${speakToCode}-${Date.now()}`;
+        const res = await post('/api/transform').send({
+            deviceId,
+            entityId: 2,
+            botSecret: botSecret2,
+            state: 'IDLE',
+            message: tag,
+            speakTo: [speakToCode],
+        });
+
+        expect(res.status).toBe(200);
+        // Resolved: delivery routed to entity 1 (not "not_found")
+        expect(res.body.delivery?.results?.[0]?.success).toBe(true);
+        expect(res.body.delivery?.results?.[0]?.entityId).toBe(1);
+
+        const rows = rowsForProbe(tag);
+        // Single delivery row, source pointing to ->1 (the real target)
+        expect(rows.some(r => r.source && r.source.endsWith('->1'))).toBe(true);
+        // No misleading ->0 phantom from the pendingA2A anchor
+        expect(rows.some(r => r.source && /->0$/.test(r.source))).toBe(false);
+    });
+
+    test('speakTo: ["@<publicCode>"] strips @ and resolves', async () => {
+        const tag = `TOL-AT-PUB-${Date.now()}`;
+        const res = await post('/api/transform').send({
+            deviceId,
+            entityId: 2,
+            botSecret: botSecret2,
+            state: 'IDLE',
+            message: tag,
+            speakTo: [`@${entity1Code}`],
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.delivery?.results?.[0]?.success).toBe(true);
+        expect(res.body.delivery?.results?.[0]?.entityId).toBe(1);
+    });
+
+    test('speakTo: ["<@publicCode>"] strips < > and @ and resolves', async () => {
+        const tag = `TOL-LT-PUB-${Date.now()}`;
+        const res = await post('/api/transform').send({
+            deviceId,
+            entityId: 2,
+            botSecret: botSecret2,
+            state: 'IDLE',
+            message: tag,
+            speakTo: [`<@${entity1Code}>`],
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.delivery?.results?.[0]?.success).toBe(true);
+        expect(res.body.delivery?.results?.[0]?.entityId).toBe(1);
+    });
+
+    test('speakTo: ["nonexistent"] still returns not_found (regression)', async () => {
+        const tag = `TOL-NF-${Date.now()}`;
+        const res = await post('/api/transform').send({
+            deviceId,
+            entityId: 2,
+            botSecret: botSecret2,
+            state: 'IDLE',
+            message: tag,
+            speakTo: ['notreal'],
+        });
+
+        expect(res.status).toBe(200);
+        const result = res.body.delivery?.results?.[0];
+        expect(result?.success).toBe(false);
+        expect(result?.reason).toBe('not_found');
+
+        // Fallback save still creates ONE sender-side row.
+        const rows = rowsForProbe(tag);
+        expect(rows).toHaveLength(1);
+        // Critical: NO misleading routing arrow that pretends a target was reached.
+        // pendingA2A is from entity 0 — pre-fix this row would be `->0`.
+        expect(/->\d+$/.test(rows[0].source)).toBe(false);
+    });
+
+    test('speakTo: ["#999"] (numeric but invalid entity) → not_found, no phantom anchor', async () => {
+        const tag = `TOL-INV-NUM-${Date.now()}`;
+        const res = await post('/api/transform').send({
+            deviceId,
+            entityId: 2,
+            botSecret: botSecret2,
+            state: 'IDLE',
+            message: tag,
+            speakTo: ['#999'],
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.delivery?.results?.[0]?.success).toBe(false);
+
+        const rows = rowsForProbe(tag);
+        expect(rows).toHaveLength(1);
+        // No misleading routing arrow
+        expect(/->\d+$/.test(rows[0].source)).toBe(false);
+    });
+});


### PR DESCRIPTION
Follow-up to #2290 — fixes two related production observations.

## Production case (his_e5ea1549-...)

Claude (#2) sent:
```json
{ "message": "@#6 收到 21:04 i18n drift 報告...",
  "speakTo": ["#6"] }
```

Result in chat history (misleading): `entity:2:LOBSTER->3 delivered=false`. The chat UI rendered it as "Sent to Mac_E (#3)" — but Claude never intended #3, and #6 never received it either.

```
[CHAT_FALLBACK_TRANSFORM] all targets failed for entity 2;
reasons=[not_found] speakTo=["#6"] broadcast=false
```

## Two root causes

1. **`resolveSpeakToTarget` was strict**. Accepted only bare `publicCode` (`abc123`) or numeric `entityId` (`6`). LLMs routinely paste the in-text @-mention syntax (`#6`, `@#6`, `<#6>`) into speakTo because the routing-policy text uses those forms as routing tokens — server should be tolerant of common LLM mistakes here, the cost of accepting them is zero.

2. **Fallback save anchored on `pendingA2A.fromEntityId`**. When delivery requested + every target failed, the fallback save wrote `entity:N:CHAR->X` where X was whoever last A2Ad the sender — completely unrelated to the requested target. Chat history then looks like delivery to X happened (it didnt).

## Fix

- `resolveSpeakToTarget` strips `@`, `#`, and surrounding `<...>` before lookup. Real publicCodes are exactly 6 chars `[a-z0-9]`, so none of the stripped chars could be part of one. New accepted forms: `abc123`, `6`, `#6`, `@#6`, `<#6>`, `@abc123`, `<@abc123>`.
- Fallback save uses `entity.name || "Entity N"` as chatSource. Failed delivery does not pretend a target was reached.

## Test plan

- [x] `tests/jest/transform-speakto-tolerant-formats.test.js` — 7 new cases: 5 decorated forms + 2 failed-delivery chatSource cases
- [x] All 8 transform-related test files (92 cases): green
- [x] `npm run lint`: 0 errors

Refs #2282

🤖 Generated with [Claude Code](https://claude.com/claude-code)