### PR TITLE
fix(test): delegate root test and remove invalid Jest option

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -7,8 +7,6 @@ module.exports = {
     testTimeout: 15000,
     // Prevent open handles from keeping Jest alive
     forceExit: true,
-    // Run tests in band (main process) to avoid worker exit code issues on Windows
-    runInBand: true,
     // Clear mocks between tests
     clearMocks: true,
     // Reset module registry between test files to avoid shared state

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "start": "cd backend && node server.js",
     "build": "cd backend && npm install",
     "postinstall": "cd backend && npm install",
-    "test": "jest --testPathPattern=backend/test"
+    "test": "cd backend && npm test"
   },
   "engines": {
     "node": ">=18.0.0"


### PR DESCRIPTION
## Summary
- delegate root npm test to the backend test script so it works from repo root
- remove unsupported runInBand from backend/jest.config.js to eliminate Jest validation warnings
- preserve backend's existing parallel test execution, because true in-band full-suite execution exposes an unrelated monitoring test order leak

## Verification
- npm test (repo root): 159 suites / 2487 tests passed, no Jest config validation warning
- npm run lint (backend): passed with existing 7 warnings