### PR TITLE
fix(transform): self-save chatSource no longer leaks pendingA2A

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -6807,10 +6807,19 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
         // [A2A_BOT_REPLY] — detect if this transform is in response to an A2A speak-to
         const pendingA2A = entity.messageQueue && entity.messageQueue.find(m => m.from && m.from.startsWith('entity:'));
 
-        // Build source: if replying to a speak-to, include routing info so chat renders "Entity A → Entity B"
-        const chatSource = pendingA2A
-            ? `entity:${eId}:${entity.character}->${pendingA2A.fromEntityId}`
-            : entity.name || `Entity ${eId}`;
+        // PR #2292 — chatSource used to be `entity:N:CHAR->X` when pendingA2A
+        // existed (X = whoever last A2A'd this entity). Intent was "show that
+        // this status was in response to X". In practice the chat UI renders
+        // the same arrow as a real delivery ("Sent to Entity X"), which is
+        // misleading because:
+        //   - is_delivered is still false / delivered_to is null
+        //   - the bot didn't actually route the reply anywhere
+        //   - X is whoever sat at the head of messageQueue, often unrelated
+        //     to the message body
+        // The audit-trail value of "this followed an A2A from X" is preserved
+        // by the [A2A_BOT_REPLY] server log below; the chat row should be a
+        // plain sender-only row.
+        const chatSource = entity.name || `Entity ${eId}`;
 
         // Only save self chat message if NOT doing speakTo/broadcast delivery (avoid duplicate)
         // Skip saving to owner's chat when entity is leased_out — rental mirror handles renter's copy

--- a/backend/tests/jest/transform-self-save-no-pendingA2A.test.js
+++ b/backend/tests/jest/transform-self-save-no-pendingA2A.test.js
@@ -1,0 +1,142 @@
+/**
+ * /api/transform self-save chatSource regression — pendingA2A no longer
+ * leaks into the chat row's source field (PR #2292 / extends #2290).
+ *
+ * Before PR #2292: when a bot transformed without speakTo/broadcast/@-mention
+ * AND its messageQueue had a pending A2A entry from entity X, the self-save
+ * wrote `entity:N:CHAR->X delivered=false`. The chat UI then rendered this
+ * as "Sent to Entity X" — completely misleading because:
+ *   - the bot didn't actually route the reply anywhere
+ *   - X is whoever sat at the head of messageQueue (often unrelated)
+ *   - delivery never happened (delivered=false, delivered_to=null)
+ *
+ * Production case from his_873e8f44-... 2026-05-02 21:53:
+ *   sender: entity 2 (Claude)
+ *   message: "兩張審核的卡都收完了..." (no @-mention, no speakTo)
+ *   pendingA2A on #2's queue: from entity 3 (Mac_E)
+ *   Pre-fix row: source=entity:2:LOBSTER->3 (rendered "Sent to Mac_E (#3)")
+ *   Post-fix row: source=entity.name (rendered as own status, no fake target)
+ */
+
+require('./helpers/mock-setup');
+
+const request = require('supertest');
+const pg = require('pg');
+let app;
+
+const post = (path) => request(app).post(path).set('Host', 'localhost');
+
+let chatInserts = [];
+
+beforeAll(() => {
+    const originalPool = pg.Pool;
+    pg.Pool = jest.fn().mockImplementation(() => ({
+        query: jest.fn().mockImplementation(async (sql, params) => {
+            const sqlStr = typeof sql === 'string' ? sql : (sql && sql.text) || '';
+            if (/^\s*INSERT INTO chat_messages/i.test(sqlStr)) {
+                chatInserts.push({
+                    deviceId: params?.[0],
+                    entityId: params?.[1],
+                    text: params?.[2],
+                    source: params?.[3],
+                });
+                return { rows: [{ id: `mock-${chatInserts.length}` }], rowCount: 1 };
+            }
+            return { rows: [], rowCount: 0 };
+        }),
+        connect: jest.fn().mockResolvedValue({ query: jest.fn().mockResolvedValue({ rows: [] }), release: jest.fn() }),
+        end: jest.fn().mockResolvedValue(undefined),
+    }));
+    app = require('../../index');
+    pg.Pool = originalPool;
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+});
+
+beforeEach(() => { chatInserts = []; });
+
+async function registerDevice(id) {
+    const secret = `secret-${id}`;
+    await post('/api/device/register').send({ deviceId: id, deviceSecret: secret, entityId: 0 });
+    return secret;
+}
+
+async function bindEntity(deviceId, deviceSecret, entityId = 0) {
+    const regRes = await post('/api/device/register').send({ deviceId, deviceSecret, entityId });
+    const code = regRes.body.bindingCode;
+    if (!code) return undefined;
+    const bindRes = await post('/api/bind').send({ code });
+    return bindRes.body.botSecret;
+}
+
+function rowsForProbe(tag) {
+    return chatInserts.filter(r => (r.text || '').includes(tag));
+}
+
+describe('POST /api/transform — self-save chatSource never leaks pendingA2A (#2292)', () => {
+    let deviceId, deviceSecret, botSecret2;
+
+    beforeAll(async () => {
+        deviceId = 'self-save-clean';
+        deviceSecret = await registerDevice(deviceId);
+        await bindEntity(deviceId, deviceSecret, 0);
+        await post('/api/device/add-entity').send({ deviceId, deviceSecret });
+        await bindEntity(deviceId, deviceSecret, 1);
+        await post('/api/device/add-entity').send({ deviceId, deviceSecret });
+        botSecret2 = await bindEntity(deviceId, deviceSecret, 2);
+
+        // Inject pendingA2A from entity 0 onto entity 2's messageQueue. Pre-fix
+        // this would cause every subsequent transform from #2 (without speakTo
+        // / @-mention) to be saved as `entity:2:LOBSTER->0`.
+        const { devices } = require('../../index');
+        devices[deviceId].entities[2].messageQueue.push({
+            text: 'priming A2A from entity 0',
+            from: 'entity:0:LOBSTER',
+            fromEntityId: 0,
+            timestamp: Date.now(),
+            crossDevice: false,
+        });
+    });
+
+    it('plain status update with pendingA2A in queue → source has NO ->X arrow', async () => {
+        const tag = `STATUS-${Date.now()}`;
+        const res = await post('/api/transform').send({
+            deviceId,
+            entityId: 2,
+            botSecret: botSecret2,
+            state: 'IDLE',
+            message: `${tag} pure status, no @, no speakTo`,
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+
+        const rows = rowsForProbe(tag);
+        expect(rows).toHaveLength(1);
+        // Critical: chatSource must NOT pretend a target was reached.
+        expect(/->\d+$/.test(rows[0].source)).toBe(false);
+        // chatSource is the plain entity name (or fallback "Entity N")
+        expect(rows[0].source).toMatch(/^(.+|Entity \d+)$/);
+    });
+
+    it('multiple status updates leave NO trailing arrows', async () => {
+        const tag = `STATUS-MULTI-${Date.now()}`;
+        for (let i = 0; i < 3; i++) {
+            await post('/api/transform').send({
+                deviceId,
+                entityId: 2,
+                botSecret: botSecret2,
+                state: 'IDLE',
+                message: `${tag} round ${i}`,
+            });
+        }
+        const rows = rowsForProbe(tag);
+        expect(rows).toHaveLength(3);
+        for (const r of rows) {
+            expect(/->\d+$/.test(r.source)).toBe(false);
+        }
+    });
+});

--- a/backend/tests/jest/transform-self-save-phantom.test.js
+++ b/backend/tests/jest/transform-self-save-phantom.test.js
@@ -180,8 +180,10 @@ describe('POST /api/transform — self-save phantom-row regression (#2282)', () 
         const rows = rowsForProbe(tag);
         // No routing resolved → exactly one self-save row (no duplicate).
         expect(rows).toHaveLength(1);
-        // Source uses pendingA2A path: entity:2:CHAR->0
-        expect(rows[0].source).toMatch(/entity:2:[A-Z]+->0/);
+        // Post-PR-#2292: chatSource is plain entity name (no `->X` arrow).
+        // The pendingA2A presence is logged via [A2A_BOT_REPLY] but does not
+        // pollute the chat row's source field with a fake routing target.
+        expect(/->\d+$/.test(rows[0].source)).toBe(false);
     });
 
     it('@all in text → broadcast resolved before self-save → no phantom', async () => {


### PR DESCRIPTION
Extends [PR #2291](https://github.com/HankHuang0516/EClaw/pull/2291)`s fallback-anchor cleanup to the **self-save** block in `/api/transform`.

## Production case (his_873e8f44-... 2026-05-02 21:53)

  sender: entity 2 (Claude)
  message: "兩張審核的卡都收完了..." (no @-mention, no speakTo, no broadcast)
  pendingA2A on #2`s queue: entity 3 (Mac_E)
  Pre-fix row: `source=entity:2:LOBSTER->3 delivered=false to=null`

The chat UI rendered it as "Sent to Mac_E (#3)" even though the bot never routed anything anywhere.

## Why

When a bot transforms with **no** explicit speakTo/broadcast and **no** @-mention in text, the self-save block uses `pendingA2A.fromEntityId` as the chatSource arrow:

```js
const chatSource = pendingA2A
    ? `entity:${eId}:${entity.character}->${pendingA2A.fromEntityId}`  // ← misleading
    : entity.name || `Entity ${eId}`;
```

Intent was "show that this status was in response to X". In practice the chat UI renders the same arrow as a real delivery, so the user sees "Sent to Mac_E (#3)" for a message that was never delivered to #3 (or anyone).

## Fix

Use `entity.name` unconditionally — the audit-trail value of "this followed an A2A from X" is preserved by the `[A2A_BOT_REPLY]` server log already in place; the chat row should be a plain sender-only row.

## Test plan

- [x] `tests/jest/transform-self-save-no-pendingA2A.test.js` (NEW, 2 cases)
- [x] `tests/jest/transform-self-save-phantom.test.js` probe C updated
- [x] All 9 transform test files green
- [x] `npm run lint`: 0 errors

Refs #2282

🤖 Generated with [Claude Code](https://claude.com/claude-code)