### PR TITLE
feat(quote): split-pane in-place delivery + source-page toast

### DIFF
--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -158,6 +158,10 @@
         .autolink-chip-popover .chip-popover-loading, .autolink-chip-popover .chip-popover-error { padding:16px; text-align:center; color:#888; font-size:12px; }
         .autolink-chip-toast { background:rgba(30,30,40,0.95); color:#facc15; border:1px solid rgba(250,204,21,0.4); border-radius:6px; padding:6px 10px; font-size:12px; box-shadow:0 4px 12px rgba(0,0,0,0.5); transition:opacity 0.4s; pointer-events:none; }
 
+        /* Floating page-level toast — confirms cross-pane smart-quote delivery */
+        .eclaw-float-toast { position:fixed; top:16px; right:16px; z-index:99999; background:rgba(30,30,40,0.96); color:#4ade80; border:1px solid rgba(74,222,128,0.5); border-radius:8px; padding:10px 16px; font-size:13px; font-weight:600; box-shadow:0 6px 20px rgba(0,0,0,0.55); transition:opacity 0.4s, transform 0.3s; pointer-events:none; transform:translateY(-4px); }
+        .eclaw-float-toast.visible { transform:translateY(0); }
+
         /* Modal tabs */
         .kb-modal-tabs { display:flex; gap:0; padding:0 24px; border-bottom:1px solid var(--card-border); }
         .kb-modal-tab { padding:10px 16px; font-size:13px; font-weight:600; color:var(--text-secondary); background:none; border:none; border-bottom:2px solid transparent; cursor:pointer; }
@@ -1787,10 +1791,25 @@
             openCardId = null;
         }
 
+        function eclawShowFloatToast(msg) {
+            const tip = document.createElement('div');
+            tip.className = 'eclaw-float-toast';
+            tip.textContent = msg;
+            document.body.appendChild(tip);
+            requestAnimationFrame(() => tip.classList.add('visible'));
+            setTimeout(() => { tip.style.opacity = '0'; }, 2200);
+            setTimeout(() => { tip.remove(); }, 2700);
+        }
+
         function quoteToChat(source, title, excerpt) {
+            const toastMsg = (window.i18n && typeof window.i18n.t === 'function' && window.i18n.t('chip_popover_requoted')) || '已引用 ✓';
             if (window.self !== window.top) {
+                // Workspace split-pane mode: deliver to chat sub-pane via parent relay,
+                // confirm with a source-page floating toast — no force jump.
                 window.parent.postMessage({ type: 'eclaw_quote', source, title, excerpt: excerpt || '' }, window.location.origin);
+                eclawShowFloatToast(toastMsg);
             } else {
+                // Standalone: no chat pane reachable → fall back to navigation as before.
                 localStorage.setItem('eclaw_pending_quote', JSON.stringify({ source, title, excerpt: excerpt || '', ts: Date.now() }));
                 window.location.href = '/portal/chat.html';
             }

--- a/backend/public/portal/shared/autolink-chip-preview.js
+++ b/backend/public/portal/shared/autolink-chip-preview.js
@@ -264,9 +264,10 @@
 
     function insertRequoteToken(data, refType, refId, anchorEl) {
         const token = tokenFor(data, refType, refId);
-        const input = document.getElementById('messageInput') || document.querySelector('textarea, [contenteditable="true"]');
-        if (input) {
-            insertRequoteTokenIntoInput(input, token);
+        const chatInput = document.getElementById('messageInput');
+        if (chatInput) {
+            insertRequoteTokenIntoInput(chatInput, token);
+            showToast(anchorEl, t('chip_popover_requoted', '已引用'));
             return;
         }
         // No local chat input — try cross-pane relay (workspace split-view).
@@ -278,8 +279,14 @@
                     window.location.origin
                 );
                 showToast(anchorEl, t('chip_popover_requoted', '已引用'));
+                return;
             } catch (_) {}
         }
+        // Last-resort fallback: any other writable surface on the page (e.g. a
+        // mindmap inline-note editor). Silent — caller doesn't know if landing
+        // target was actually chat-shaped.
+        const fallback = document.querySelector('textarea, [contenteditable="true"]');
+        if (fallback) insertRequoteTokenIntoInput(fallback, token);
     }
 
     // Receive cross-pane requote (chat iframe side). Workspace forwards


### PR DESCRIPTION
## Summary
- 智慧引用：在分割子畫面已開聊天時，把引用塞到子畫面，並在來源頁面彈一個 `已引用 ✓` 浮動 toast，不再強制跳轉到 `/portal/chat.html`
- Standalone（沒有 workspace 父框）保留原本 localStorage handoff + 跳轉行為
- Chip 📌 popover 跨 pane fallback：來源頁沒有 `#messageInput` 時，透過 `window.parent.postMessage` 把 requote token 送到 chat sub-pane（workspace 已有 relay 支援）

## Files
- `backend/public/portal/kanban.html` (+19) — `eclawShowFloatToast()` helper、`.eclaw-float-toast` CSS、`quoteToChat()` 改寫成 iframe-aware
- `backend/public/portal/shared/autolink-chip-preview.js` (+13/-3) — `insertRequoteToken()` 加上 cross-pane relay 路徑

## Self-review
- [x] i18n: 重用既有 `chip_popover_requoted` key + literal fallback，不需要 Hermes dispatch
- [x] Help / info page: 純 UX polish，現有 docs 不需動
- [x] Debug flag: 純前端 relay，沒有新 endpoint / flag
- [x] Diff-stat: 29+/3- only — minimum viable surface
- [x] Targeted Jest: `autolink-chip.test.js` 22/22 通過（whole-suite infra bust 與本 PR 無關）
- [x] Visual: Playwright harness 截圖確認 toast 樣式 + 文案

## Test plan
- [x] T1: `eclawShowFloatToast('已引用 ✓')` direct call — toast 渲染 + 3s 自動消失
- [x] T2: `quoteToChat()` 走標準/iframe 分支判斷
- [ ] Real workspace E2E（kanban + chat split-pane）— blocked by /portal auth gate；harness 已涵蓋 helper logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)