### PR TITLE
fix(i18n): honor ?lang= URL param at portal page init

### DIFF
--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -4668,7 +4668,7 @@ platforms:
     <script src="shared/nav.js"></script>
     <script src="shared/public-nav.js"></script>
     <script src="../shared/telemetry.js"></script>
-    <script src="../shared/i18n.js?v=1.2.1"></script>
+    <script src="../shared/i18n.js?v=1.2.2"></script>
     <script src="shared/footer.js"></script>
     <script src="shared/info.js"></script>
     <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid|EClawIOS/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -61331,45 +61331,68 @@ const TRANSLATIONS = {
 
 };
 // Portal version for sync tracking
-const PORTAL_VERSION = '1.2.0';
+const PORTAL_VERSION = '1.2.1';
 
 class I18n {
     constructor() {
-        const saved = localStorage.getItem('eclaw-language');
-        if (saved && TRANSLATIONS[saved]) {
-            this.lang = saved;
-        } else {
-            // Auto-detect from browser/device language
-            const browserLang = (navigator.language || navigator.userLanguage || 'en').toLowerCase();
-            const langMap = [
-                [['zh-cn', 'zh-hans', 'zh-sg'], 'zh-CN'],
-                [['zh'], 'zh'],
-                [['ja'], 'ja'],
-                [['ko'], 'ko'],
-                [['th'], 'th'],
-                [['vi'], 'vi'],
-                [['id', 'in'], 'id'],
-                [['es'], 'es'],
-                [['fr'], 'fr'],
-                [['de'], 'de'],
-                [['pt'], 'pt'],
-                [['it'], 'it'],
-                [['ru'], 'ru'],
-                [['tr'], 'tr'],
-                [['ms', 'my'], 'ms'],
-                [['hi'], 'hi'],
-                [['ar'], 'ar'],
-                [['nl'], 'nl'],
-                [['pl'], 'pl'],
-            ];
-            let detected = 'en';
+        const langMap = [
+            [['zh-cn', 'zh-hans', 'zh-sg'], 'zh-CN'],
+            [['zh'], 'zh'],
+            [['ja'], 'ja'],
+            [['ko'], 'ko'],
+            [['th'], 'th'],
+            [['vi'], 'vi'],
+            [['id', 'in'], 'id'],
+            [['es'], 'es'],
+            [['fr'], 'fr'],
+            [['de'], 'de'],
+            [['pt'], 'pt'],
+            [['it'], 'it'],
+            [['ru'], 'ru'],
+            [['tr'], 'tr'],
+            [['ms', 'my'], 'ms'],
+            [['hi'], 'hi'],
+            [['ar'], 'ar'],
+            [['nl'], 'nl'],
+            [['pl'], 'pl'],
+        ];
+        const resolveLang = (raw) => {
+            if (!raw) return null;
+            const lower = String(raw).toLowerCase();
+            // Exact match against supported codes (handles zh-CN, zh-TW, etc.)
+            for (const code of Object.keys(TRANSLATIONS)) {
+                if (code.toLowerCase() === lower) return code;
+            }
+            // Prefix match against canonical map
             for (const [prefixes, lang] of langMap) {
-                if (prefixes.some(p => browserLang.startsWith(p)) && TRANSLATIONS[lang]) {
-                    detected = lang;
-                    break;
+                if (prefixes.some(p => lower.startsWith(p)) && TRANSLATIONS[lang]) {
+                    return lang;
                 }
             }
-            this.lang = detected;
+            return null;
+        };
+
+        // Priority 1: ?lang= URL param (explicit deep-link from social/email/cron i18n probes)
+        let urlLang = null;
+        try {
+            const sp = new URLSearchParams(location.search);
+            urlLang = resolveLang(sp.get('lang'));
+        } catch (_) { /* SSR / non-browser; ignore */ }
+
+        if (urlLang) {
+            this.lang = urlLang;
+            // Persist explicit URL choice so subsequent same-tab navigation keeps it.
+            try { localStorage.setItem('eclaw-language', urlLang); } catch (_) {}
+        } else {
+            // Priority 2: previously chosen language
+            const saved = localStorage.getItem('eclaw-language');
+            if (saved && TRANSLATIONS[saved]) {
+                this.lang = saved;
+            } else {
+                // Priority 3: navigator.language
+                const browserLang = (navigator.language || navigator.userLanguage || 'en').toLowerCase();
+                this.lang = resolveLang(browserLang) || 'en';
+            }
         }
         this.observers = [];
     }


### PR DESCRIPTION
## Summary
- portal pages (info.html, settings.html, kanban.html, … all 30+ pages that load `shared/i18n.js`) now honor `?lang=ms` / `?lang=zh-CN` / etc. at construct time
- explicit URL choice persists to `localStorage` so subsequent same-tab nav keeps the locale
- existing localStorage / navigator.language behavior is preserved (URL param is now priority 1, ahead of the existing two)
- code only modifies the `I18n` class constructor — `TRANSLATIONS` dict untouched (per card scope)

## Why
`?lang=ms` deep-links from social/email/cron i18n probes were silently rendering English. The constructor read `localStorage` then `navigator.language` and never consulted the URL. Hank reported this as the closure follow-up of card_c34417 (ms translation work).

## Resolution rules
- exact match against any TRANSLATIONS code (case-insensitive) — supports zh-CN, zh-TW, ja, etc.
- otherwise fall through the same prefix map used by navigator.language detection (`zh-cn → zh-CN`, `ms-MY → ms`, …)
- unsupported codes (`?lang=xx`) silently fall through to localStorage / navigator.language; never break init

## Local verification (vm-evaluated constructor with mocked browser globals)
| # | Setup | lang | persisted |
| - | - | - | - |
| 1 | `?lang=ms` | ms | ms |
| 2 | `?lang=zh-CN` | zh-CN | zh-CN |
| 3 | `?lang=zh-cn` (lowercase) | zh-CN | zh-CN |
| 4 | `?lang=ja`, navigator=en | ja | ja |
| 5 | `?lang=xx`, navigator=ko-KR | ko (fallback) | (not persisted — bad URL ignored) |
| 6 | localStorage=de, no URL | de | de |
| 7 | navigator=ms-MY, no URL/LS | ms | (not persisted — auto-detect) |
| 8 | navigator=zh-TW, no URL/LS | zh-TW | (not persisted) |
| 9 | `?lang=` empty + localStorage=ja | ja | ja |
| 10 | `?lang=MS` (uppercase) | ms | ms |

## Versions
- `PORTAL_VERSION` 1.2.0 → 1.2.1
- `info.html` cache-buster bumped `?v=1.2.1` → `?v=1.2.2` so the bug-report page picks up the fix without a hard refresh

## Test plan
- [ ] Prod: visit `https://eclawbot.com/portal/info.html?lang=ms` → hero renders Malay; `document.documentElement.lang=ms`
- [ ] Prod: visit `https://eclawbot.com/portal/info.html?lang=ja` → 日文
- [ ] Prod: same tab navigate to `/portal/community.html` → still 日文 (persisted)
- [ ] Prod: clear `eclaw-language` localStorage + open `/portal/info.html?lang=xx` (unsupported) → falls back to browser language

Closes card_939f4537475809c8f4c530d3.