### PR TITLE
fix(kanban): skip recurring automation parents in stale escalation

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -2051,11 +2051,16 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
             // Fetch stale candidates WITHOUT the global nudge-gap filter; we apply
             // per-device nudge interval + status filter (from device_preferences) below.
             // backlog (待排程) included here and filtered per-device — users can opt in.
+            // Skip recurring-schedule automation parents: their status_changed_at never
+            // moves (cron creates child cards instead), so they would always look stale
+            // and get escalated to P0 every staleThresholdMs window. Mirrors the same
+            // filter used in checkDoneAutoArchive below.
             const result = await pool.query(`
                 SELECT * FROM kanban_cards
                 WHERE archived = false
                   AND status IN ('backlog', 'todo', 'in_progress', 'review')
                   AND EXTRACT(EPOCH FROM (NOW() - status_changed_at)) * 1000 > stale_threshold_ms
+                  AND (schedule_enabled = false OR schedule_type != 'recurring' OR schedule_enabled IS NULL)
             `);
 
             if (result.rows.length === 0) return;

--- a/backend/tests/jest/kanban-stale-skip-recurring.test.js
+++ b/backend/tests/jest/kanban-stale-skip-recurring.test.js
@@ -1,0 +1,71 @@
+'use strict';
+
+/**
+ * Regression test — stale-escalation must skip recurring-schedule automation parents.
+ *
+ * Background: cron-driven parent cards never have their `status_changed_at`
+ * advance (cron creates child cards and resets the parent's `schedule_last_run_at`
+ * instead). Without a schedule-skip clause in `checkStaleCards()`, these parents
+ * get false-positive escalated to P0 every staleThresholdMs window — exactly
+ * what produced the 4× P0 escalations on PR Quality / PR Auto-Review /
+ * Golden-Path E2E / i18n Drift Scanner cron parents on 2026-05-02.
+ *
+ * The same skip filter already exists in `checkDoneAutoArchive()`; this test
+ * pins it in `checkStaleCards()` too so a future refactor cannot drop it
+ * silently.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const kanbanSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'kanban.js'),
+    'utf8'
+);
+
+function extractFunctionBody(src, signature) {
+    const start = src.indexOf(signature);
+    if (start === -1) throw new Error(`function not found: ${signature}`);
+    const open = src.indexOf('{', start);
+    let depth = 0;
+    for (let i = open; i < src.length; i++) {
+        const ch = src[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+            depth--;
+            if (depth === 0) return src.slice(open, i + 1);
+        }
+    }
+    throw new Error(`unterminated function: ${signature}`);
+}
+
+describe('checkStaleCards — recurring-schedule skip filter', () => {
+    const body = extractFunctionBody(kanbanSrc, 'async function checkStaleCards()');
+
+    test('SELECT excludes recurring-schedule automation parents', () => {
+        // Mirrors the canonical clause from checkDoneAutoArchive.
+        expect(body).toMatch(
+            /schedule_enabled\s*=\s*false\s+OR\s+schedule_type\s*!=\s*'recurring'\s+OR\s+schedule_enabled\s+IS\s+NULL/
+        );
+    });
+
+    test('SELECT still gates on stale_threshold_ms (no false-negative regression)', () => {
+        expect(body).toMatch(
+            /EXTRACT\(EPOCH FROM \(NOW\(\) - status_changed_at\)\) \* 1000 > stale_threshold_ms/
+        );
+    });
+
+    test('SELECT still scopes to active statuses', () => {
+        expect(body).toMatch(/status IN \('backlog', 'todo', 'in_progress', 'review'\)/);
+    });
+});
+
+describe('checkDoneAutoArchive — canonical skip filter still in place', () => {
+    const body = extractFunctionBody(kanbanSrc, 'async function checkDoneAutoArchive()');
+
+    test('keeps the same recurring-schedule skip clause used as the reference', () => {
+        expect(body).toMatch(
+            /schedule_enabled\s*=\s*false\s+OR\s+schedule_type\s*!=\s*'recurring'\s+OR\s+schedule_enabled\s+IS\s+NULL/
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- `checkStaleCards()` was missing the recurring-schedule skip clause that already exists in `checkDoneAutoArchive()`. Cron-driven parents (PR Quality / PR Auto-Review / Golden-Path E2E / i18n Drift Scanner / etc.) never have `status_changed_at` advance — cron creates child cards and updates `schedule_last_run_at` on the parent instead — so without the filter their clock looks frozen and the parent gets P0-escalated every `stale_threshold_ms` window.
- One-line SQL fix: append `AND (schedule_enabled = false OR schedule_type != 'recurring' OR schedule_enabled IS NULL)` to the SELECT, mirroring the canonical clause from `checkDoneAutoArchive()` 22 lines below.
- Adds `backend/tests/jest/kanban-stale-skip-recurring.test.js` as a static regression guard so a future refactor cannot drop the clause silently. Test parses the function body straight out of `kanban.js` and asserts the clause's presence; companion assertion guards `checkDoneAutoArchive()` too.

## Repro / motivation
On 2026-05-02 a single cron pass produced 4× P0 false-positive escalations on these recurring parents — Codex #6 cleared them, then handed off the upstream root-cause fix to me. Refs card_62daff7b51cff4edfd05689f.

## Test plan
- [x] `npx jest tests/jest/kanban-stale-skip-recurring.test.js` — 4/4 passing on patched code
- [x] Sanity-flip: stash the kanban.js patch and re-run — `SELECT excludes recurring-schedule automation parents` fails as expected (1 failed, 3 passed). Restored.
- [x] `node --check backend/kanban.js` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)