### PR TITLE
fix(channel-api): @-mention auto-router parity with /api/transform

### DIFF
--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -1,4 +1,5 @@
 const safeEqual = require('./safe-equal');
+const mentionParser = require('./mention-parser');
 
 /**
  * Channel API Module — OpenClaw Channel Plugin Integration
@@ -727,6 +728,31 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             if (message) entity.message = message;
             entity.lastUpdated = Date.now();
 
+            // ── @-mention auto-fill (PR #2300, parity with /api/transform) ──
+            // /api/transform has had this since #1619 (2026-04-06). LLM channel
+            // bridges (claude / codex / hermes) embed routing intent in text
+            // (`@#6 hello`) but used to silently drop it here because this
+            // endpoint was originally designed as a "thin pipe" relaying state.
+            //
+            // Same precedence as /api/transform: explicit speakTo / broadcast
+            // wins, in-text @-mention fills next, senderHint is last.
+            let transformMentionContext = null;
+            if (message) {
+                const tParse = mentionParser.parseMentions(message, {
+                    senderDeviceId: deviceId,
+                    devices,
+                    publicCodeIndex
+                });
+                transformMentionContext = mentionParser.toContextPayload(tParse);
+                if (transformMentionContext) {
+                    if (tParse.hasAll && !broadcast && !(speakTo && speakTo.length > 0)) {
+                        broadcast = true;
+                    } else if (tParse.mentions.length > 0 && !broadcast && !(speakTo && speakTo.length > 0)) {
+                        speakTo = tParse.mentions.map(m => m.publicCode);
+                    }
+                }
+            }
+
             // ── senderHint resolution (channel-bridge centralization, issue #2285) ──
             // Lowest precedence — only fills speakTo/broadcast when neither was
             // explicitly set on the request body. Channel bridges pass senderHint
@@ -996,6 +1022,7 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             };
             if (deliveryResults) response.delivery = deliveryResults;
             if (warnings.length > 0) response.warnings = warnings;
+            if (transformMentionContext) response.mentions = transformMentionContext;
             if (senderHintResolution) response.senderHintResolution = senderHintResolution;
             res.json(response);
         } catch (err) {

--- a/backend/tests/jest/channel-message-mention-autorouter.test.js
+++ b/backend/tests/jest/channel-message-mention-autorouter.test.js
@@ -1,0 +1,200 @@
+/**
+ * /api/channel/message — @-mention auto-router parity (PR #2300)
+ *
+ * Brings the in-text @-mention auto-fill from /api/transform (added in
+ * #1619, 2026-04-06) onto the channel-bridge endpoint. Without this, LLM
+ * channel bridges (claude / codex / hermes) would silently drop routing
+ * intent embedded in their reply text.
+ *
+ * Repro of the production bug (his_6af72154-... 2026-05-03 08:38):
+ *   Claude bridge POST /api/channel/message
+ *     { message: "@#6 Codex 嗨, ..." }   ← no speakTo, no broadcast
+ *   Pre-fix: chat row source = entity.name, no routing happened
+ *   Post-fix: auto-router resolves @#6 → speakTo=[publicCode of #6]
+ *             → real delivery to entity 6
+ */
+
+require('./helpers/mock-setup');
+
+const db = require('../../db');
+const apiKey = 'eck_mention_autorouter_test';
+const account = { id: 1, channel_api_key: apiKey, channel_api_secret: 'ecs_test', deviceId: null, entityId: null };
+db.getChannelAccountByKey = jest.fn().mockImplementation(async (key) => key === apiKey ? account : null);
+db.getChannelAccountsByDevice = jest.fn().mockResolvedValue([]);
+db.createChannelAccount = jest.fn().mockResolvedValue(account);
+db.getChannelAccountById = jest.fn().mockResolvedValue(null);
+db.deleteChannelAccount = jest.fn().mockResolvedValue(true);
+db.updateChannelCallback = jest.fn().mockResolvedValue(true);
+db.updateChannelE2eeCapable = jest.fn().mockResolvedValue(true);
+db.clearChannelCallback = jest.fn().mockResolvedValue(true);
+db.getChannelAccountByDevice = jest.fn().mockResolvedValue(null);
+
+const request = require('supertest');
+const pg = require('pg');
+let app;
+
+const post = (path) => request(app).post(path).set('Host', 'localhost');
+
+let chatInserts = [];
+
+beforeAll(() => {
+    const originalPool = pg.Pool;
+    pg.Pool = jest.fn().mockImplementation(() => ({
+        query: jest.fn().mockImplementation(async (sql, params) => {
+            const sqlStr = typeof sql === 'string' ? sql : (sql && sql.text) || '';
+            if (/^\s*INSERT INTO chat_messages/i.test(sqlStr)) {
+                chatInserts.push({
+                    deviceId: params?.[0],
+                    entityId: params?.[1],
+                    text: params?.[2],
+                    source: params?.[3],
+                });
+                return { rows: [{ id: `mock-${chatInserts.length}` }], rowCount: 1 };
+            }
+            return { rows: [], rowCount: 0 };
+        }),
+        connect: jest.fn().mockResolvedValue({ query: jest.fn().mockResolvedValue({ rows: [] }), release: jest.fn() }),
+        end: jest.fn().mockResolvedValue(undefined),
+    }));
+    app = require('../../index');
+    pg.Pool = originalPool;
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+});
+
+beforeEach(() => { chatInserts = []; });
+
+async function registerDevice(id) {
+    const secret = `secret-${id}`;
+    await post('/api/device/register').send({ deviceId: id, deviceSecret: secret, entityId: 0 });
+    return secret;
+}
+
+async function bindEntity(deviceId, deviceSecret, entityId = 0) {
+    const regRes = await post('/api/device/register').send({ deviceId, deviceSecret, entityId });
+    const code = regRes.body.bindingCode;
+    if (!code) return undefined;
+    const bindRes = await post('/api/bind').send({ code });
+    return bindRes.body.botSecret;
+}
+
+function rowsForProbe(tag) {
+    return chatInserts.filter(r => (r.text || '').includes(tag));
+}
+
+describe('POST /api/channel/message — @-mention auto-router (#2300)', () => {
+    let deviceId, deviceSecret, botSecret2, entity1Code;
+
+    beforeAll(async () => {
+        deviceId = 'chmsg-mention';
+        deviceSecret = await registerDevice(deviceId);
+        await bindEntity(deviceId, deviceSecret, 0);
+        await post('/api/device/add-entity').send({ deviceId, deviceSecret });
+        await bindEntity(deviceId, deviceSecret, 1);
+        await post('/api/device/add-entity').send({ deviceId, deviceSecret });
+        botSecret2 = await bindEntity(deviceId, deviceSecret, 2);
+
+        const { devices } = require('../../index');
+        entity1Code = devices[deviceId].entities[1].publicCode;
+        expect(entity1Code).toBeTruthy();
+    });
+
+    it('@#N in text, no explicit speakTo → auto-fills speakTo and routes to N', async () => {
+        const tag = `CHMSG-AT-${Date.now()}`;
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 2, botSecret: botSecret2,
+            state: 'IDLE',
+            message: `${tag} @#1 hi entity 1`,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.delivery?.results?.[0]?.entityId).toBe(1);
+        expect(res.body.mentions?.mentions?.[0]?.entityId).toBe(1);
+
+        const rows = rowsForProbe(tag);
+        // Single delivery row, source pointing to ->1 (the real target).
+        // No phantom self-save, no `entity.name` fallback.
+        expect(rows).toHaveLength(1);
+        expect(rows[0].source).toMatch(/entity:2:[A-Z]+->1$/);
+    });
+
+    it('<@publicCode> token in text → auto-fills speakTo with publicCode', async () => {
+        const tag = `CHMSG-PC-${Date.now()}`;
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 2, botSecret: botSecret2,
+            state: 'IDLE',
+            message: `${tag} <@${entity1Code}> via publicCode form`,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.delivery?.results?.[0]?.entityId).toBe(1);
+        expect(res.body.delivery?.results?.[0]?.publicCode).toBe(entity1Code);
+    });
+
+    it('@all in text, no explicit broadcast → auto-sets broadcast=true', async () => {
+        const tag = `CHMSG-ALL-${Date.now()}`;
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 2, botSecret: botSecret2,
+            state: 'IDLE',
+            message: `${tag} @all heads up`,
+        });
+        expect(res.status).toBe(200);
+        // Broadcast was set; delivery shape is broadcast-style
+        expect(res.body.delivery?.broadcast).toBe(true);
+        expect(res.body.mentions?.hasAll).toBe(true);
+    });
+
+    it('explicit speakTo wins over in-text @-mention', async () => {
+        const tag = `CHMSG-EXPLICIT-${Date.now()}`;
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 2, botSecret: botSecret2,
+            state: 'IDLE',
+            message: `${tag} @#1 trying to redirect`,
+            speakTo: [entity1Code], // explicit, same target — but sets the precedence rule
+        });
+        expect(res.status).toBe(200);
+        // Auto-router observed mentions but did NOT fill speakTo because explicit was set
+        expect(res.body.delivery?.results?.[0]?.entityId).toBe(1);
+        expect(res.body.mentions?.mentions?.[0]?.entityId).toBe(1);
+    });
+
+    it('senderHint is lower precedence than in-text @-mention', async () => {
+        const tag = `CHMSG-PREC-${Date.now()}`;
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 2, botSecret: botSecret2,
+            state: 'IDLE',
+            message: `${tag} @#1 in-text wins`,
+            senderHint: { kind: 'broadcast' }, // would otherwise broadcast
+        });
+        expect(res.status).toBe(200);
+        // In-text @-mention won → delivery to entity 1, not broadcast
+        expect(res.body.delivery?.results?.[0]?.entityId).toBe(1);
+        // senderHint resolution reports it didn't fire
+        expect(res.body.senderHintResolution.applied).toBe('none');
+        expect(res.body.senderHintResolution.reason).toBe('explicit_won');
+    });
+
+    it('no @-mention, no speakTo, no senderHint → still saves a sender-only row (no fake routing arrow)', async () => {
+        const tag = `CHMSG-PLAIN-${Date.now()}`;
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 2, botSecret: botSecret2,
+            state: 'IDLE',
+            message: `${tag} pure status, no routing`,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.mentions).toBeUndefined();
+
+        const rows = rowsForProbe(tag);
+        expect(rows).toHaveLength(1);
+        // Source is plain entity name, NO `->X` arrow that would mislead the UI.
+        expect(/->\d+$/.test(rows[0].source)).toBe(false);
+    });
+});


### PR DESCRIPTION
## TL;DR

Production routing for Claude bridge has been broken since 2026-05-02 ~21:59. This PR mirrors the @-mention auto-router from `/api/transform` onto `/api/channel/message`. Phase 0 of the consolidated routing plan in `proposal_channel_key_on_transform.md`.

## Symptom

Reproduced live (his_6af72154-... 2026-05-03 08:38, device `480def4c-...`):

```json
// Claude bridge POST /api/channel/message
{ "message": "@#6 Codex 嗨, ..." }   // no speakTo, no broadcast
```

- Pre-fix: chat row source = `entity.name` (no `->X` arrow), no routing — Codex (#6) never received.
- Chat UI rendered "Sent to You" instead of "Sent to Codex (#6)".

## Root cause

**Long-standing parity gap, not a regression.**

The @-mention auto-router was added to `/api/transform` in PR #1619 (2026-04-06). It was never mirrored to `/api/channel/message` because the original design (`docs/plans/2026-03-07-channel-bot-context-parity-design.md`) treated channel/message as a "thin pipe" — bridges were assumed to express routing via explicit `speakTo` / `targetDeviceId` / dedicated `speak_to` callbacks, not via text.

In practice all four LLM bridges (claude / codex / hermes / openclaw) are entity-LLM runtimes that embed routing in text (`@#6 hello`). Until ~21:59 yesterday, Claude was calling `/api/transform` directly via curl (skill-template route). When the fakechat reply tool became reliable, Claude switched to it — and the reply tool goes through `bridge.ts forwardReplyToEClaw` → `/api/channel/message`. Routing has been broken since the switch.

## Fix

Mirror `/api/transform` line 6732-6749 (auto-fill block) into channel-api.js, placed BEFORE the existing senderHint resolution. Same precedence as `/api/transform`:

```
explicit speakTo / broadcast  >  in-text @-mention  >  senderHint
```

Response now also surfaces `mentions` field (parity with transform).

## Test plan

- [x] New: `tests/jest/channel-message-mention-autorouter.test.js` (6 cases)
  - `@#N` resolves and routes
  - `<@publicCode>` resolves
  - `@all` triggers broadcast
  - explicit speakTo wins over in-text mention
  - senderHint loses to in-text mention (precedence verified)
  - plain status update still saves clean sender row (no fake arrow)
- [x] All channel + transform test suites: 7 files / 64 cases green
- [x] `npm run lint`: 0 errors

## Out of scope (next phases)

This PR does not touch the architectural shift in `proposal_channel_key_on_transform.md`. That proposal still moves forward:

- Phase 1: backend `channel_registrations` + ACL + `/api/transform` dual-auth (channel key + actAs)
- Phase 2: bridge migration (claude → codex → hermes)
- Phase 3: monitor adoption metrics
- Phase 4: mark `/api/channel/message` legacy (keep functional for non-LLM bridges; this PRs auto-router is the safety net)

Refs proposal_channel_key_on_transform.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)