### PR TITLE
docs(kanban): document cron-spawn notify gates + spec drift fix (card_dfe3b8df P0)

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -2440,6 +2440,7 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
                     // (default false: child card has just been born; let stale-scan
                     // pick it up later instead of pinging immediately, which Hank
                     // experienced as 5–6 nudges within an hour on 2026-04-28).
+                    // Spec: docs/mission-v2-kanban-spec.md §十一 "通知 gates（device preferences）".
                     const spawnPrefs = await devicePrefs.getPrefs(card.device_id).catch(() => ({}));
                     if (bots.length > 0 && spawnPrefs.kanban_cron_spawn_notify === true) {
                         const lang = await getDeviceLanguage(card.device_id);

--- a/docs/mission-v2-kanban-spec.md
+++ b/docs/mission-v2-kanban-spec.md
@@ -310,7 +310,7 @@ _老闆已確認所有問題，開始分拆任務開工。_
 自動建立臨時卡片（子卡）→ TODO
     │ assignedBots = 母卡的 assignedBots
     │ title = "[Auto] 母卡標題 (03/26 18:30)"
-    │ 自動 push 通知 assigned bots
+    │ push 通知 assigned bots（受 device pref kanban_cron_spawn_notify 控制；預設 false，見下節）
     ▼
 Bot 執行 → In Progress → Review → Done → 自動歸檔
     │
@@ -318,6 +318,19 @@ Bot 執行 → In Progress → Review → Done → 自動歸檔
     ▼
 母卡更新 lastRunAt + 留言板記錄執行結果
 ```
+
+### 通知 gates（device preferences）
+
+排程觸發的通知行為由兩個 device preference flag 控制（`backend/device-preferences.js` `DEFAULTS`，可透過 `PUT /api/device-preferences` 修改）：
+
+| Pref key | Default | 適用場景 | 行為 |
+|---|---|---|---|
+| `kanban_cron_spawn_notify` | `false` | 母卡 cron 生子卡（automation→child） | 預設關閉。子卡剛誕生先放著，由 stale-scan 過 `stale_threshold_ms` 後再督促，避免新卡片被立即推送一次、stale 又再推送一次的雙重通知。 |
+| `kanban_cron_recurring_notify` | `true` | 自身重複觸發母卡（recurring，無子卡） | 預設開啟。這類卡片觸發頻率低（每 cron tick 一次），使用者通常希望立刻知道。 |
+
+**手動建立子卡（`POST /api/mission/card`）不受此 gate 約束** — 只要 `status` 不是 `backlog`，仍會無條件 notify assigned bots（見 `backend/kanban.js` 的 `/card` POST handler）。Gate 僅針對 `backgroundTick` 跑出來的 cron 自動化路徑。
+
+**沿革：** 2026-04-28 觀察到自動 nudge 在 1 小時內噴出 5–6 次（自動化母卡每小時 fire 一次 × stale-scan 每 30 分鐘掃一次），導致頻道訊息洪災。`kanban_cron_spawn_notify` 預設改為 `false`，把通知時機交給 stale-scan 統一決定，避免 spawn + stale 雙計。Code anchor: `backend/kanban.js:2439-2451`、`backend/device-preferences.js:23-26`。
 
 ### 子卡特殊屬性
 


### PR DESCRIPTION
## Summary
Closes card_dfe3b8df (P0). Spec drift between docs/mission-v2-kanban-spec.md §十一 (says auto sub-cards push notify unconditionally) and backend/kanban.js:2439-2451 (notify gated behind \`kanban_cron_spawn_notify\`, default \`false\` since 2026-04-28 nudge-spam incident).

- spec line 313 trigger-flow box now reflects the gate
- new section **通知 gates (device preferences)** tabulates the two cron-related prefs (\`kanban_cron_spawn_notify\` / \`kanban_cron_recurring_notify\`) — defaults, scope, and historical reason
- explicit callout: manual \`POST /api/mission/card\` is NOT gated (unconditional notify when \`status !== backlog\`)
- backend/kanban.js cross-link comment to the spec section so future readers see the doc trail

Pure docs + 1 line code comment. No behavior change.

## Test plan
- [x] \`git diff --stat origin/main..HEAD\` clean: 2 files, +15/-1
- [x] Spec claim verified: backend/kanban.js:660 notify-on-create has no pref gate
- [x] Spec claim verified: backend/kanban.js:2444 notify-on-cron-child IS gated by \`kanban_cron_spawn_notify\`
- [ ] CI green (ESLint, jest, i18n syntax — all should pass on docs+comment-only change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)