### PR TITLE
fix(kanban): smart-queue gate uses queue-empty, not bot-active (Phase 2 hotfix)

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -353,19 +353,22 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
         }
     }
 
-    // ── Smart-queue notify helpers (card_dfe3b8df Phase 2) ──
+    // ── Smart-queue notify helpers (card_dfe3b8df Phase 2 + #2307 hotfix) ──
     // Replaces the deprecated kanban_cron_spawn_notify boolean gate. cron auto-spawn
-    // notifies are routed per-bot: fire immediately if the bot has no active work,
-    // else enqueue silently and drain one entry on each move-to-done.
-    async function botHasActiveCards(deviceId, botId) {
+    // notifies are routed per-bot: fire immediately if the bot has no pending notify
+    // queued; else enqueue silently and drain one entry on each move-to-done.
+    //
+    // Original Phase 2 used "bot has active todo/in_progress cards" as the gate —
+    // that buried EVERY new spawn for any bot with persistent work (the common
+    // case for active developer bots), because the queue only drained on
+    // move-to-done. The empty-queue gate preserves the rate-limit intent (one
+    // fresh ping at a time per bot) without silencing first pings.
+    async function botHasPendingNotify(deviceId, botId) {
         const r = await pool.query(
-            `SELECT 1 FROM kanban_cards
-              WHERE device_id = $1
-                AND archived = false
-                AND status IN ('todo', 'in_progress')
-                AND assigned_bots @> $2::jsonb
+            `SELECT 1 FROM kanban_pending_notify
+              WHERE device_id = $1 AND bot_entity_id = $2
               LIMIT 1`,
-            [deviceId, JSON.stringify([Number(botId)])]
+            [deviceId, Number(botId)]
         );
         return r.rows.length > 0;
     }
@@ -2513,13 +2516,13 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
                         const payload = { description: card.description, cardId: childCard.id };
                         for (const botId of bots) {
                             try {
-                                const active = await botHasActiveCards(card.device_id, botId);
-                                if (active) {
+                                const hasPending = await botHasPendingNotify(card.device_id, botId);
+                                if (hasPending) {
                                     await enqueuePendingNotify(card.device_id, botId, childCard.id, msg, payload);
-                                    console.log(`[Kanban] Smart-queue: enqueued notify for bot #${botId} card ${childCard.id} (bot has active work)`);
+                                    console.log(`[Kanban] Smart-queue: enqueued notify for bot #${botId} card ${childCard.id} (bot has pending notify)`);
                                 } else {
                                     await notifyEntities(card.device_id, [botId], msg, payload);
-                                    console.log(`[Kanban] Smart-queue: pushed immediate notify for bot #${botId} card ${childCard.id} (bot idle)`);
+                                    console.log(`[Kanban] Smart-queue: pushed immediate notify for bot #${botId} card ${childCard.id} (queue empty)`);
                                 }
                             } catch (notifyErr) {
                                 console.error(`[Kanban] Smart-queue notify failed for bot #${botId}:`, notifyErr.message);

--- a/backend/tests/jest/kanban-smart-notify-queue.test.js
+++ b/backend/tests/jest/kanban-smart-notify-queue.test.js
@@ -49,12 +49,19 @@ describe('kanban smart-queue notify — schema', () => {
 });
 
 describe('kanban smart-queue notify — helpers', () => {
-    test('botHasActiveCards is defined', () => {
-        expect(kanbanSrc).toMatch(/async function botHasActiveCards\(deviceId, botId\)/);
+    test('botHasPendingNotify is defined', () => {
+        // Phase 2 hotfix #2307: gate switched from "bot has active cards" →
+        // "bot has pending notify queued" to avoid burying every spawn for
+        // bots with persistent work.
+        expect(kanbanSrc).toMatch(/async function botHasPendingNotify\(deviceId, botId\)/);
     });
 
-    test('botHasActiveCards filters to todo/in_progress only', () => {
-        expect(kanbanSrc).toMatch(/status IN \('todo', 'in_progress'\)/);
+    test('botHasPendingNotify reads from kanban_pending_notify, not kanban_cards', () => {
+        // Match the helper body (starts with botHasPendingNotify, ends at next async function).
+        const helper = kanbanSrc.match(/async function botHasPendingNotify[\s\S]*?\n    \}/);
+        expect(helper).not.toBeNull();
+        expect(helper[0]).toMatch(/FROM kanban_pending_notify/);
+        expect(helper[0]).not.toMatch(/FROM kanban_cards/);
     });
 
     test('enqueuePendingNotify is defined and writes to kanban_pending_notify', () => {
@@ -80,9 +87,10 @@ describe('kanban smart-queue notify — helpers', () => {
 });
 
 describe('kanban smart-queue notify — cron-spawn integration', () => {
-    test('cron-spawn block enqueues when bot has active work, fires immediately when idle', () => {
-        // The smart-queue gate must check botHasActiveCards before deciding push vs enqueue.
-        expect(kanbanSrc).toMatch(/const active = await botHasActiveCards\(card\.device_id, botId\)/);
+    test('cron-spawn block enqueues when queue non-empty, fires when queue empty', () => {
+        // Hotfix #2307: gate must check botHasPendingNotify (not active-cards),
+        // so first ping always fires for bots with persistent work.
+        expect(kanbanSrc).toMatch(/const hasPending = await botHasPendingNotify\(card\.device_id, botId\)/);
         expect(kanbanSrc).toMatch(/await enqueuePendingNotify\(card\.device_id, botId, childCard\.id/);
     });
 
@@ -91,6 +99,12 @@ describe('kanban smart-queue notify — cron-spawn integration', () => {
         // it, this test fails so reviewers can challenge.
         expect(kanbanSrc).not.toMatch(/spawnPrefs\.kanban_cron_spawn_notify/);
         expect(kanbanSrc).not.toMatch(/kanban_cron_spawn_notify\s*===\s*true/);
+    });
+
+    test('cron-spawn block no longer uses the active-cards gate (Phase 2 buried-spawn bug)', () => {
+        // Regression-pin for #2307: the "active cards" gate buried every spawn
+        // for bots with persistent todo/in_progress work. Must not return.
+        expect(kanbanSrc).not.toMatch(/botHasActiveCards/);
     });
 });
 

--- a/docs/mission-v2-kanban-spec.md
+++ b/docs/mission-v2-kanban-spec.md
@@ -310,7 +310,7 @@ _老闆已確認所有問題，開始分拆任務開工。_
 自動建立臨時卡片（子卡）→ TODO
     │ assignedBots = 母卡的 assignedBots
     │ title = "[Auto] 母卡標題 (03/26 18:30)"
-    │ push 通知 assigned bots（走 smart per-bot queue：bot 沒有活躍卡才立即推；有活躍卡則 enqueue，等他 done 一張再放出，見下節）
+    │ push 通知 assigned bots（走 smart per-bot queue：queue 空才立即推；queue 已有 entry 則 enqueue，等他 done 一張再放出，見下節）
     ▼
 Bot 執行 → In Progress → Review → Done → 自動歸檔
     │
@@ -327,8 +327,8 @@ cron 觸發的通知走**每個 bot 各自一條 queue**，避免一個 bot 同�
 
 | 觸發來源 | Bot 狀態 | 行為 |
 |---|---|---|
-| cron 母卡 spawn 子卡（automation→child） | bot 沒有 todo/in_progress 卡 | 立即 push notify（保留原 wakeup chain） |
-| cron 母卡 spawn 子卡（automation→child） | bot 有 todo/in_progress 卡 | 寫入 `kanban_pending_notify` queue，**不**推送；等 bot 自己把現有的某張卡推到 done，drain 一筆出來 |
+| cron 母卡 spawn 子卡（automation→child） | bot 的 `kanban_pending_notify` queue 為空 | 立即 push notify（保留原 wakeup chain） |
+| cron 母卡 spawn 子卡（automation→child） | bot 的 `kanban_pending_notify` queue 已有 entry | 寫入 `kanban_pending_notify` queue，**不**推送；等 bot 自己把任一卡推到 done，drain 一筆出來 |
 | 自身重複觸發母卡（recurring，無子卡） | 任意 | 走 `kanban_cron_recurring_notify` device pref（預設 `true`，這類卡片觸發頻率低，使用者通常希望立刻知道） |
 | 手動建立子卡（`POST /api/mission/card`，status≠backlog） | 任意 | 不走 queue，直接 notify（手動行為由人控制節奏，不需要降噪） |
 
@@ -351,7 +351,7 @@ CREATE INDEX idx_kanban_pending_notify_bot ON kanban_pending_notify(device_id, b
 
 **目標：** 同時最多 1 通新任務通知 per bot，避免 5–6 通連環炸；但保留下一張卡的 wakeup chain（done 一張就放出下一張）。
 
-**沿革：** 2026-04-28 cron 自動化在 1 小時內噴 5–6 通，引入 `kanban_cron_spawn_notify` flag 預設關閉作緊急止血，但完全 silent 的代價是 stale-scan 過 3hr 才喚醒，反而造成積壓。2026-05-03 (card_dfe3b8df Phase 2) 換成 smart-queue：`kanban_cron_spawn_notify` flag 退役，改寫死 always-on smart 路由邏輯。Code anchor: `backend/kanban.js` `botHasActiveCards` / `enqueuePendingNotify` / `drainOnePendingNotify`、`backend/kanban_schema.sql` table `kanban_pending_notify`。
+**沿革：** 2026-04-28 cron 自動化在 1 小時內噴 5–6 通，引入 `kanban_cron_spawn_notify` flag 預設關閉作緊急止血，但完全 silent 的代價是 stale-scan 過 3hr 才喚醒，反而造成積壓。2026-05-03 (card_dfe3b8df Phase 2, PR #2303) 換成 smart-queue：`kanban_cron_spawn_notify` flag 退役，改寫死 always-on smart 路由邏輯。**2026-05-03 (PR #2307 hotfix)** Phase 2 原本以「bot 是否有 active todo/in_progress 卡」當 gate，但 active developer bot 永遠有活躍卡 → 每次 spawn 都被 silent enqueue、queue 從不 drain → 通知完全消失。Gate 改成「queue 是否已有 entry」：queue 空就立即推，queue 已堆才靜音 enqueue，仍由 done 事件 drain。Code anchor: `backend/kanban.js` `botHasPendingNotify` / `enqueuePendingNotify` / `drainOnePendingNotify`、`backend/kanban_schema.sql` table `kanban_pending_notify`。
 
 ### 子卡特殊屬性
 


### PR DESCRIPTION
## Summary

Hotfix for the smart-queue notify regression Hank just caught (`card_dfe3b8df` Phase 2 / PR #2303): every cron-spawned sub-card was silent-enqueued forever, no notify ever reached the bot.

- **Root cause**: Phase 2 gated `enqueue vs fire` on `botHasActiveCards` (todo/in_progress). For any active developer bot, that's always true → all spawns enqueued, drain only fires on move-to-done, queue grows unboundedly → notify completely silent.
- **Fix**: Switch gate to `botHasPendingNotify` (queue non-empty for that bot). Empty queue → fire immediately. Already-pending → enqueue silently; existing done-drain hook surfaces them FIFO. Preserves the one-fresh-ping-per-work-cycle intent without burying first pings.
- **Regression pin**: Updated jest test now asserts (a) `botHasPendingNotify` exists and reads `kanban_pending_notify`; (b) cron-spawn block uses `hasPending` gate; (c) `botHasActiveCards` is fully removed.

## Test plan

- [x] `npx jest backend/tests/jest/kanban-smart-notify-queue.test.js` — 14/14 pass
- [ ] Post-merge prod E2E: trigger a cron母卡, confirm assigned bot receives kanban notify within seconds (not buried)
- [ ] Confirm a second spawn fires (or enqueues if first hasn't been picked up) without losing wakeup chain
- [ ] Confirm move-to-done still drains the next queued entry as before

## 沿革 / Why the original logic was wrong

The Phase 2 spec said "smart per-bot queue: bot 沒有活躍卡才立即推; 有活躍卡則 enqueue". That heuristic assumed bots cycle through active cards quickly — true for first-time installs, but for any productive bot setup, the bot is always working on something, so the gate is always "active" → notify never fires. The drain hook on `done` only releases ONE entry, which means even when the bot finishes a card, the queue keeps growing if cron spawns faster than the bot finishes.

Queue-empty gate is the right invariant: empty = no buried pings, safe to fire; non-empty = bot already has a fresh ping waiting, no need to spam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)