### PR TITLE
fix(notif): cross_speak/cross_speak_sent honor speak_to toggle

### DIFF
--- a/backend/notifications.js
+++ b/backend/notifications.js
@@ -214,9 +214,20 @@ async function updatePrefs(deviceId, prefs) {
     }
 }
 
+// Some dispatch sites use sub-categories that share a single user-facing toggle.
+// e.g. "speak_to" toggle in Settings governs bot-to-bot pushes regardless of
+// whether the dispatch is same-device (`speak_to`) or cross-device
+// (`cross_speak`, `cross_speak_sent`). Without this map, cross-device pushes
+// bypass the toggle because the unknown key falls through DEFAULT_PREFS.
+const CATEGORY_ALIASES = {
+    cross_speak: 'speak_to',
+    cross_speak_sent: 'speak_to'
+};
+
 function isCategoryEnabled(prefs, category) {
     if (!prefs || typeof prefs !== 'object') return true;
-    return prefs[category] !== false;
+    const effective = CATEGORY_ALIASES[category] || category;
+    return prefs[effective] !== false;
 }
 
 // ============================================

--- a/backend/tests/jest/notification-category-aliases.test.js
+++ b/backend/tests/jest/notification-category-aliases.test.js
@@ -1,0 +1,46 @@
+/**
+ * Unit test for isCategoryEnabled() category aliasing.
+ *
+ * Regression: cross_speak / cross_speak_sent dispatch sites bypassed the
+ * user's "speak_to" toggle because those sub-categories were not in
+ * DEFAULT_PREFS, so `prefs[category] !== false` returned true (undefined).
+ * Reported by Hank 2026-05-03 (card_5385cfeacade16ce86b56378).
+ */
+
+const { isCategoryEnabled } = require('../../notifications');
+
+describe('isCategoryEnabled — category aliases', () => {
+    test('cross_speak honors speak_to=false', () => {
+        expect(isCategoryEnabled({ speak_to: false }, 'cross_speak')).toBe(false);
+    });
+
+    test('cross_speak_sent honors speak_to=false', () => {
+        expect(isCategoryEnabled({ speak_to: false }, 'cross_speak_sent')).toBe(false);
+    });
+
+    test('cross_speak honors speak_to=true', () => {
+        expect(isCategoryEnabled({ speak_to: true }, 'cross_speak')).toBe(true);
+    });
+
+    test('speak_to itself remains gated by its own key', () => {
+        expect(isCategoryEnabled({ speak_to: false }, 'speak_to')).toBe(false);
+        expect(isCategoryEnabled({ speak_to: true }, 'speak_to')).toBe(true);
+    });
+
+    test('non-aliased category passes through unchanged', () => {
+        expect(isCategoryEnabled({ bot_reply: false }, 'bot_reply')).toBe(false);
+        expect(isCategoryEnabled({ bot_reply: true }, 'bot_reply')).toBe(true);
+    });
+
+    test('missing prefs object returns true (fail-open)', () => {
+        expect(isCategoryEnabled(null, 'cross_speak')).toBe(true);
+        expect(isCategoryEnabled(undefined, 'cross_speak')).toBe(true);
+    });
+
+    test('alias does not leak into the wrong key when speak_to absent but cross_speak set', () => {
+        // User who somehow got cross_speak=false stored: still respected via fallback.
+        // (We map cross_speak → speak_to first; if speak_to absent, undefined !== false → true.)
+        // This documents that the alias is one-way: cross_speak reads speak_to, not vice versa.
+        expect(isCategoryEnabled({ cross_speak: false }, 'speak_to')).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- Bot-to-bot speakTo across devices was bypassing the user's notification toggle entirely. The dispatch sites use `category: 'cross_speak'` / `'cross_speak_sent'`, neither of which lived in `DEFAULT_PREFS`. `isCategoryEnabled()` therefore evaluated `prefs[category] !== false` against `undefined`, returning `true` and always pushing.
- Add a small `CATEGORY_ALIASES` map so both sub-categories resolve to the existing `speak_to` toggle. UI label `notif_pref_speak_to` (\"Entity Messages / 實體對話\") already covers the broader semantic; no new toggle, no schema change, no migration.
- Includes 7 unit tests covering the alias, the original key, fail-open, and one-way-mapping invariants.

## Background
Reported by Hank 2026-05-03 on `card_5385cfeacade16ce86b56378`:
> Android APP 的通知功能異常 bot speak to的通知功能 disable了也 關不掉

Symptom 2 in that report (\"很多選項打開也從沒有通知過\") is a separate failure mode (likely fcmToken / firebase-admin / NotificationChannel) and will be tackled in a follow-up after U01 E2E.

## Test plan
- [x] `npx jest backend/tests/jest/notification-category-aliases.test.js` — 7/7 passed
- [ ] CI green on this PR
- [ ] Post-merge E2E on Android: toggle speak_to off → bot-to-bot speakTo from another entity → no push (was pushing before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)