### PR TITLE
fix(notif): FCM logs to serverLog + /api/device/fcm-status diagnostic

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -16697,16 +16697,38 @@ app.post('/api/device/fcm-token', (req, res) => {
         device.apnsToken = resolvedToken;
         chatPool.query('ALTER TABLE devices ADD COLUMN IF NOT EXISTS apns_token TEXT').catch(() => {});
         chatPool.query('UPDATE devices SET apns_token = $1 WHERE device_id = $2', [resolvedToken, deviceId]).catch(() => {});
-        console.log(`[PUSH] APNs token registered`, { deviceId, prevPrefix, newPrefix, changed });
+        serverLog('info', 'fcm_token', `APNs token registered`, { deviceId, metadata: { prevPrefix, newPrefix, changed, platform: 'apns' } });
     } else {
         // Android FCM token (default)
         device.fcmToken = resolvedToken;
         chatPool.query('ALTER TABLE devices ADD COLUMN IF NOT EXISTS fcm_token TEXT').catch(() => {});
         chatPool.query('UPDATE devices SET fcm_token = $1 WHERE device_id = $2', [resolvedToken, deviceId]).catch(() => {});
-        console.log(`[PUSH] FCM token registered`, { deviceId, prevPrefix, newPrefix, changed });
+        serverLog('info', 'fcm_token', `FCM token registered`, { deviceId, metadata: { prevPrefix, newPrefix, changed, platform: 'fcm' } });
     }
 
     res.json({ success: true, platform: resolvedPlatform });
+});
+
+// Read-only FCM/APNs registration status. Diagnostic for "no notifications
+// despite enabled" — lets the device owner check whether the token even made
+// it to the backend without exposing the token itself.
+app.get('/api/device/fcm-status', (req, res) => {
+    const { deviceId, deviceSecret } = req.query;
+    if (!deviceId || !deviceSecret) {
+        return res.status(400).json({ success: false, error: 'deviceId and deviceSecret required' });
+    }
+    const device = devices[deviceId];
+    if (!device || !safeEqual(device.deviceSecret, deviceSecret)) {
+        return res.status(401).json({ success: false, error: 'Invalid credentials' });
+    }
+    const fcm = device.fcmToken || null;
+    const apns = device.apnsToken || null;
+    res.json({
+        success: true,
+        firebaseAdminInitialized: !!firebaseAdmin,
+        fcm: { registered: !!fcm, prefix: fcm ? fcm.slice(0, 12) : null },
+        apns: { registered: !!apns, prefix: apns ? apns.slice(0, 12) : null }
+    });
 });
 
 // Send FCM push notification (enabled when FIREBASE_SERVICE_ACCOUNT is set)
@@ -16717,21 +16739,21 @@ try {
         firebaseAdmin.initializeApp({
             credential: firebaseAdmin.credential.cert(JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT))
         });
-        console.log('[FCM] Firebase Admin initialized');
+        serverLog('info', 'fcm_init', 'Firebase Admin initialized');
     }
 } catch (e) {
-    console.warn('[FCM] Firebase Admin init skipped:', e.message);
+    serverLog('warn', 'fcm_init', `Firebase Admin init skipped: ${e.message}`);
 }
 
 async function sendFcm(deviceId, notif) {
     if (!firebaseAdmin) {
-        console.log('[FCM] skip: firebaseAdmin not initialized', { deviceId });
+        serverLog('warn', 'fcm_send', 'skip: firebaseAdmin not initialized', { deviceId, metadata: { category: notif?.category } });
         return;
     }
     const device = devices[deviceId];
     const token = device?.fcmToken;
     if (!token) {
-        console.log('[FCM] skip: no fcmToken for device', { deviceId, deviceExists: !!device, category: notif?.category });
+        serverLog('warn', 'fcm_send', 'skip: no fcmToken for device', { deviceId, metadata: { deviceExists: !!device, category: notif?.category } });
         return;
     }
     const tokenPrefix = token.slice(0, 12);
@@ -16759,13 +16781,13 @@ async function sendFcm(deviceId, notif) {
     }
     try {
         const resp = await firebaseAdmin.messaging().send(fcmMessage);
-        console.log('[FCM] sent OK', { deviceId, tokenPrefix, category: notif?.category, messageId: resp });
+        serverLog('info', 'fcm_send', 'sent OK', { deviceId, metadata: { tokenPrefix, category: notif?.category, messageId: resp } });
     } catch (e) {
         if (e.code === 'messaging/registration-token-not-registered') {
             delete devices[deviceId]?.fcmToken;
             chatPool.query('UPDATE devices SET fcm_token = NULL WHERE device_id = $1', [deviceId]).catch(() => {});
         }
-        console.warn('[FCM] Send failed:', { deviceId, tokenPrefix, code: e.code, message: e.message });
+        serverLog('error', 'fcm_send', `send failed: ${e.message}`, { deviceId, metadata: { tokenPrefix, code: e.code } });
     }
 }
 

--- a/backend/tests/jest/push-notifications.test.js
+++ b/backend/tests/jest/push-notifications.test.js
@@ -132,3 +132,53 @@ describe('POST /api/device/fcm-token', () => {
         expect(res.status).toBeGreaterThanOrEqual(400);
     });
 });
+
+// ════════════════════════════════════════════════════════════════
+// GET /api/device/fcm-status — diagnostic read endpoint
+// Reports whether the backend has an FCM/APNs token registered for the
+// device, without exposing the token itself. Added to investigate "no
+// notifications despite enabled" (card_5385cfeacade16ce86b56378).
+// ════════════════════════════════════════════════════════════════
+describe('GET /api/device/fcm-status', () => {
+    it('returns 400 when deviceId is missing', async () => {
+        const res = await get('/api/device/fcm-status');
+        expect(res.status).toBe(400);
+    });
+
+    it('returns 401 with wrong deviceSecret', async () => {
+        await registerDevice('test-fcm-status-401');
+        const res = await get('/api/device/fcm-status?deviceId=test-fcm-status-401&deviceSecret=wrong');
+        expect(res.status).toBe(401);
+    });
+
+    it('reports unregistered when no token has been sent', async () => {
+        const deviceSecret = await registerDevice('test-fcm-status-empty');
+        const res = await get(`/api/device/fcm-status?deviceId=test-fcm-status-empty&deviceSecret=${deviceSecret}`);
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.fcm.registered).toBe(false);
+        expect(res.body.fcm.prefix).toBeNull();
+        expect(res.body.apns.registered).toBe(false);
+    });
+
+    it('reports registered + prefix after fcm-token POST', async () => {
+        const deviceSecret = await registerDevice('test-fcm-status-set');
+        await post('/api/device/fcm-token')
+            .send({ deviceId: 'test-fcm-status-set', deviceSecret, token: 'fcmToken-abcdef-123456' });
+
+        const res = await get(`/api/device/fcm-status?deviceId=test-fcm-status-set&deviceSecret=${deviceSecret}`);
+        expect(res.status).toBe(200);
+        expect(res.body.fcm.registered).toBe(true);
+        expect(res.body.fcm.prefix).toBe('fcmToken-abc');
+        // Sanity: never leak the full token
+        const body = JSON.stringify(res.body);
+        expect(body).not.toContain('fcmToken-abcdef-123456');
+    });
+
+    it('exposes firebaseAdminInitialized boolean', async () => {
+        const deviceSecret = await registerDevice('test-fcm-status-fb');
+        const res = await get(`/api/device/fcm-status?deviceId=test-fcm-status-fb&deviceSecret=${deviceSecret}`);
+        expect(res.status).toBe(200);
+        expect(typeof res.body.firebaseAdminInitialized).toBe('boolean');
+    });
+});


### PR DESCRIPTION
## Summary
Companion to PR #2320 (cross_speak alias). Two observability gaps surfaced while triaging the "no notifications despite enabled" symptom on card_5385cfeacade16ce86b56378:

1. **FCM hot-path logs were invisible to /api/logs.** sendFcm() used console.log/console.warn, so we could not remotely diagnose whether pushes were skipped (no fcmToken / firebaseAdmin uninit) or actually firing. Convert to serverLog with categories \`fcm_send\` / \`fcm_init\` / \`fcm_token\`.
2. **No read endpoint for FCM registration state.** Added \`GET /api/device/fcm-status\` (deviceSecret-gated) returning \`{ firebaseAdminInitialized, fcm.{registered, prefix}, apns.{registered, prefix} }\`. 12-char prefix only — never exposes the actual token.

## Why
Without these, symptom 2 root-causing requires asking Hank to ferry Railway dashboard logs by hand. With these, a single curl call tells us whether the user's device even registered, and \`/api/logs?category=fcm_send\` reveals which skip branch is firing.

## Test plan
- [x] \`npx jest backend/tests/jest/push-notifications.test.js\` — 25/25 pass (20 existing + 5 new fcm-status)
- [ ] CI green
- [ ] Post-deploy: \`curl /api/device/fcm-status\` for Hank's device returns \`{ fcm.registered: true, firebaseAdminInitialized: true }\` → narrows symptom 2 to NotificationChannel / battery optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)