### PR TITLE
fix(notif): merge partial prefs PUT to fix toggle leak

### DIFF
--- a/backend/notifications.js
+++ b/backend/notifications.js
@@ -200,12 +200,25 @@ async function updatePrefs(deviceId, prefs) {
                 sanitized[key] = !!prefs[key];
             }
         }
+        // Merge with existing prefs so partial PUTs don't clobber other keys.
+        // The settings UI sends one toggle per request; without merge, each
+        // toggle erases all prior toggles back to DEFAULT_PREFS.
+        const existingRow = await pool.query(
+            'SELECT prefs FROM notification_preferences WHERE device_id = $1',
+            [deviceId]
+        );
+        let existing = {};
+        if (existingRow.rows.length > 0) {
+            const stored = existingRow.rows[0].prefs;
+            existing = typeof stored === 'string' ? JSON.parse(stored) : (stored || {});
+        }
+        const merged = { ...existing, ...sanitized };
         await pool.query(
             `INSERT INTO notification_preferences (device_id, prefs, updated_at)
              VALUES ($1, $2, $3)
              ON CONFLICT (device_id)
              DO UPDATE SET prefs = $2, updated_at = $3`,
-            [deviceId, JSON.stringify(sanitized), Date.now()]
+            [deviceId, JSON.stringify(merged), Date.now()]
         );
         return true;
     } catch (err) {

--- a/backend/tests/jest/notification-prefs-merge.test.js
+++ b/backend/tests/jest/notification-prefs-merge.test.js
@@ -1,0 +1,105 @@
+/**
+ * Regression: updatePrefs() merges with stored prefs instead of overwriting.
+ *
+ * Symptom (Hank, 2026-05-03, card_166b2d64ececb06d1feefb8f): user toggled all
+ * 6 notification switches off in Settings, but server only persisted the last
+ * one — the rest reverted to DEFAULT_PREFS=true and FCM pushes kept arriving.
+ *
+ * Root cause: settings.html#toggleNotifPref sends one key per PUT. The old
+ * updatePrefs built a partial JSON from the request body and DO UPDATE SET
+ * prefs = $2 — so each call overwrote the entire JSONB column with the
+ * single-key payload.
+ *
+ * Fix: SELECT existing prefs, spread into the sanitized partial, then write.
+ */
+
+const { initNotificationTables, updatePrefs, getPrefs, DEFAULT_PREFS } = require('../../notifications');
+
+function makeMockPool() {
+    let stored = null; // null = no row yet
+    const calls = [];
+    return {
+        async query(sql, params) {
+            calls.push({ sql: sql.trim().slice(0, 60), params });
+            if (/CREATE TABLE|CREATE INDEX/i.test(sql)) {
+                return { rows: [] };
+            }
+            if (/^SELECT prefs FROM notification_preferences/i.test(sql.trim())) {
+                if (stored === null) return { rows: [] };
+                return { rows: [{ prefs: stored }] };
+            }
+            if (/INSERT INTO notification_preferences/i.test(sql)) {
+                stored = params[1]; // JSON string
+                return { rows: [], rowCount: 1 };
+            }
+            return { rows: [] };
+        },
+        _getStored() { return stored; },
+        _calls: calls
+    };
+}
+
+describe('updatePrefs — partial merge regression', () => {
+    let pool;
+
+    beforeEach(async () => {
+        pool = makeMockPool();
+        await initNotificationTables(pool);
+    });
+
+    test('first partial PUT writes only that key on top of defaults', async () => {
+        await updatePrefs('dev1', { bot_reply: false });
+        const prefs = await getPrefs('dev1');
+        expect(prefs.bot_reply).toBe(false);
+        expect(prefs.broadcast).toBe(true);
+        expect(prefs.speak_to).toBe(true);
+    });
+
+    test('second partial PUT does NOT erase the first key', async () => {
+        await updatePrefs('dev1', { bot_reply: false });
+        await updatePrefs('dev1', { broadcast: false });
+        const prefs = await getPrefs('dev1');
+        expect(prefs.bot_reply).toBe(false); // ← would be true under the old bug
+        expect(prefs.broadcast).toBe(false);
+        expect(prefs.speak_to).toBe(true);
+    });
+
+    test('rapid sequence of 6 single-key toggles all persist', async () => {
+        const keys = ['bot_reply', 'broadcast', 'speak_to', 'feedback_resolved', 'todo_done', 'scheduled'];
+        for (const k of keys) {
+            await updatePrefs('dev1', { [k]: false });
+        }
+        const prefs = await getPrefs('dev1');
+        for (const k of keys) {
+            expect(prefs[k]).toBe(false);
+        }
+        // platform_command was never touched → stays at default
+        expect(prefs.platform_command).toBe(true);
+    });
+
+    test('toggling a key back to true preserves other false keys', async () => {
+        await updatePrefs('dev1', { bot_reply: false });
+        await updatePrefs('dev1', { broadcast: false });
+        await updatePrefs('dev1', { bot_reply: true });
+        const prefs = await getPrefs('dev1');
+        expect(prefs.bot_reply).toBe(true);
+        expect(prefs.broadcast).toBe(false);
+    });
+
+    test('full-blob PUT (all keys at once) still works', async () => {
+        const allOff = {};
+        for (const k of Object.keys(DEFAULT_PREFS)) allOff[k] = false;
+        await updatePrefs('dev1', allOff);
+        const prefs = await getPrefs('dev1');
+        for (const k of Object.keys(DEFAULT_PREFS)) {
+            expect(prefs[k]).toBe(false);
+        }
+    });
+
+    test('unknown keys in the PUT body are ignored, not persisted', async () => {
+        await updatePrefs('dev1', { bot_reply: false, evil_key: true, __proto__: { polluted: true } });
+        const prefs = await getPrefs('dev1');
+        expect(prefs.bot_reply).toBe(false);
+        expect(prefs.evil_key).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Symptom
Hank reported (card_5385cfeacade16ce86b56378) that turning off all 6 notification toggles in the app's Settings page didn't actually stop pushes — bot-to-bot speak-to FCMs (e.g. `Codex → Mac_ClaudeAce 主管 / PING-AUTOPATROL`) kept arriving with every toggle visibly OFF.

PR #2320 (cross_speak alias) and #2321 (FCM observability) didn't help because the actual leak was upstream of `isCategoryEnabled`: **the prefs were never persisted as `false` in the first place.**

## Root cause
`backend/notifications.js#updatePrefs` built a `sanitized` object containing only the keys present in the PUT body, then `DO UPDATE SET prefs = $2` — replacing the entire JSONB column.

`backend/public/portal/settings.html#toggleNotifPref` sends **one toggle per request** (`prefs[key] = enabled`). Result: each PUT erased all prior toggles back to DEFAULT_PREFS=true; only the last click survived.

## Repro on prod (2026-05-03 22:14 TPE)
```
GET  → {scheduled:false, ... others true}
PUT  /api/notification-preferences  body={prefs:{bot_reply:false}}
GET  → {bot_reply:false, scheduled:TRUE ← overwritten back to default}
```
Hank's stored prefs: `scheduled:false` only — every other toggle had been clobbered, even though he visibly flipped 6 of them off in sequence.

## Fix
SELECT the row's existing prefs, spread the sanitized partial onto it, write the merged result. Application-level merge keeps the existing `INSERT … ON CONFLICT` shape and the `Object.keys(DEFAULT_PREFS)` whitelist; no schema change.

## Tests
New `backend/tests/jest/notification-prefs-merge.test.js` (6 cases):
- single partial PUT
- 2 sequential PUTs do not erase first key (← would fail under old code)
- rapid 6-key toggle-off sequence all persist
- toggling a key back to true preserves other false keys
- full-blob PUT still works
- unknown keys & `__proto__` ignored

13/13 pass alongside existing `notification-category-aliases` regression.

## Test plan
- [x] Jest passes
- [ ] Auto-deploy to Railway (~3 min)
- [ ] Toggle bot_reply off via UI/curl, leave it 5 min, send a bot-to-bot speakTo from #5 → no FCM
- [ ] Toggle back on → FCM arrives normally

## Related
- Closes card_166b2d64ececb06d1feefb8f
- Resolves the actual symptom in card_5385cfeacade16ce86b56378

🤖 Generated with [Claude Code](https://claude.com/claude-code)