### PR TITLE
fix(enterprise): replace stale product catalog demo link

### DIFF
--- a/backend/public/enterprise.html
+++ b/backend/public/enterprise.html
@@ -501,8 +501,8 @@
                 </div>
                 <div>
                     <h3 style="font-size:1rem;margin-bottom:12px;color:var(--primary);" data-i18n="ent_ec_product_title">📦 Product Catalog</h3>
-                    <iframe src="/p/uwgm9y/9c761df9-d051-4abd-8d60-2afaf16349cf" style="width:100%;height:480px;border:1px solid var(--border);border-radius:12px;background:#0f1117;" loading="lazy"></iframe>
-                    <p style="font-size:12px;color:var(--text-muted);margin-top:8px;text-align:center;" id="ecProductNote"><span data-i18n="ent_ec_product_ai_note">AI-generated product page · </span><a href="/p/uwgm9y/9c761df9-d051-4abd-8d60-2afaf16349cf" target="_blank" style="color:var(--primary);" data-i18n="ent_ec_product_link">Open in new tab</a></p>
+                    <iframe src="/assets/mockup-notepages.html" style="width:100%;height:480px;border:1px solid var(--border);border-radius:12px;background:#0f1117;" loading="lazy"></iframe>
+                    <p style="font-size:12px;color:var(--text-muted);margin-top:8px;text-align:center;" id="ecProductNote"><span data-i18n="ent_ec_product_ai_note">AI-generated product page · </span><a href="/assets/mockup-notepages.html" target="_blank" style="color:var(--primary);" data-i18n="ent_ec_product_link">Open in new tab</a></p>
                 </div>
             </div>
             <div style="text-align:center;margin-top:24px;">

--- a/backend/tests/jest/enterprise-demo-links.test.js
+++ b/backend/tests/jest/enterprise-demo-links.test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const publicDir = path.join(__dirname, '../../public');
+const enterpriseHtml = fs.readFileSync(path.join(publicDir, 'enterprise.html'), 'utf8');
+
+function getProductCatalogUrls() {
+    const sectionMatch = enterpriseHtml.match(/data-i18n="ent_ec_product_title"[\s\S]*?<iframe\s+src="([^"]+)"[\s\S]*?<p[^>]*id="ecProductNote"[\s\S]*?<a\s+href="([^"]+)"/);
+    if (!sectionMatch) return null;
+    return { iframeSrc: sectionMatch[1], openHref: sectionMatch[2] };
+}
+
+describe('enterprise product catalog demo links', () => {
+    test('uses a repo-owned mock page instead of a stale public note URL', () => {
+        const urls = getProductCatalogUrls();
+        expect(urls).toEqual({
+            iframeSrc: '/assets/mockup-notepages.html',
+            openHref: '/assets/mockup-notepages.html',
+        });
+        expect(urls.iframeSrc).not.toMatch(/^\/p\//);
+        expect(fs.existsSync(path.join(publicDir, urls.iframeSrc))).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- Replace the Enterprise Product Catalog demo iframe/open-link URL that returned 404 with the existing repo-owned `/assets/mockup-notepages.html` mock page.
- Add a regression test that keeps the Enterprise Product Catalog demo from pointing back to a stale `/p/...` public note URL.

Fixes #2324.

## QA / Verification
- `node backend/scripts/portal-smoke-check.js`
- `NODE_PATH=/Users/hank/Desktop/Project/EClaw/backend/node_modules /Users/hank/Desktop/Project/EClaw/backend/node_modules/.bin/jest tests/jest/enterprise-demo-links.test.js tests/jest/portal-smoke-static.test.js tests/jest/chat-targets-static.test.js tests/jest/kanban-nav-static.test.js --runInBand`
- Production audit evidence before fix: `/enterprise` returned 200, while `/p/uwgm9y/9c761df9-d051-4abd-8d60-2afaf16349cf` returned 404.

## Notes
- No production/main push.
- PR opened for review; do not merge until review/CI is green.
