### PR TITLE
fix(settings): unbreak channel-api + kanban-nudge APP deep links

### DIFF
--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1359,7 +1359,8 @@
             updatePushToggle();
 
             document.getElementById('pageContent').style.display = '';
-            if (typeof applyDeepLinkFocus === 'function') applyDeepLinkFocus();
+            if (typeof window.applyDeepLinkFocus === 'function') window.applyDeepLinkFocus();
+            applyAgentPolicyDeepLink(currentUser);
             initTapPay();
 
             setInterval(loadSubscriptionStatus, 15000);
@@ -2342,10 +2343,6 @@
             requestAnimationFrame(() => {
                 document.getElementById('agentPolicySection')?.scrollIntoView({ behavior: 'smooth', block: 'start' });
             });
-        }
-
-        function applyDeepLinkFocus() {
-            applyAgentPolicyDeepLink(currentUser);
         }
 
         async function loadPromptPolicy(user = currentUser) {

--- a/backend/tests/jest/settings-deep-link-focus.test.js
+++ b/backend/tests/jest/settings-deep-link-focus.test.js
@@ -1,0 +1,64 @@
+/**
+ * settings-deep-link.js — APP entry-button focus map.
+ *
+ * The Android/iOS APP opens settings.html with `?focus=<key>` (e.g.
+ * ?focus=channel-api or ?focus=kanban-nudge) so a single button jumps the
+ * user to the right card without scrolling past unrelated sections.
+ *
+ * Regression guard: PR #2294 / commit 7ac88746 introduced an inline
+ * `function applyDeepLinkFocus()` in settings.html that shadowed
+ * window.applyDeepLinkFocus from this file (function declarations hoist
+ * into local scope), silently breaking both APP entry buttons. The
+ * companion test in settings-prompt-policy-dashboard.test.js asserts the
+ * shadow is gone — this test pins the FOCUS_MAP keys themselves so a
+ * future rename on either end (APP query-string vs. settings-deep-link.js)
+ * still surfaces here.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const DEEP_LINK_JS = path.resolve(__dirname, '../../public/shared/settings-deep-link.js');
+
+function loadDeepLink(url) {
+    const src = fs.readFileSync(DEEP_LINK_JS, 'utf8');
+    const sandbox = {
+        window: { location: new URL(url) },
+        document: {
+            getElementById: () => null,
+            querySelectorAll: () => [],
+            body: { setAttribute: () => {} },
+        },
+    };
+    sandbox.window.document = sandbox.document;
+    vm.createContext(sandbox);
+    vm.runInContext(src, sandbox);
+    return sandbox.window;
+}
+
+describe('settings-deep-link FOCUS_MAP — APP entry buttons', () => {
+    test('exposes channel-api and kanban-nudge keys', () => {
+        const w = loadDeepLink('https://example.com/portal/settings.html');
+        expect(Array.isArray(w.SETTINGS_DEEP_LINK_KEYS)).toBe(true);
+        expect(w.SETTINGS_DEEP_LINK_KEYS).toEqual(
+            expect.arrayContaining(['channel-api', 'kanban-nudge'])
+        );
+    });
+
+    test('applyDeepLinkFocus is exported on window', () => {
+        const w = loadDeepLink('https://example.com/portal/settings.html');
+        expect(typeof w.applyDeepLinkFocus).toBe('function');
+    });
+
+    test('applyDeepLinkFocus returns false when key is missing', () => {
+        const w = loadDeepLink('https://example.com/portal/settings.html');
+        expect(w.applyDeepLinkFocus()).toBe(false);
+    });
+
+    test('applyDeepLinkFocus returns false for unknown key (graceful fallback)', () => {
+        const w = loadDeepLink('https://example.com/portal/settings.html?focus=does-not-exist');
+        expect(w.applyDeepLinkFocus()).toBe(false);
+    });
+});

--- a/backend/tests/jest/settings-prompt-policy-dashboard.test.js
+++ b/backend/tests/jest/settings-prompt-policy-dashboard.test.js
@@ -61,9 +61,20 @@ describe('Settings Agent Policy dashboard editor', () => {
 
     test('applies Agent Policy deep links after settings content is visible', () => {
         const showContentIndex = html.indexOf("document.getElementById('pageContent').style.display = '';");
-        const deepLinkIndex = html.indexOf("if (typeof applyDeepLinkFocus === 'function') applyDeepLinkFocus();");
+        const agentPolicyCallIndex = html.indexOf("applyAgentPolicyDeepLink(currentUser);");
         expect(showContentIndex).toBeGreaterThan(-1);
-        expect(deepLinkIndex).toBeGreaterThan(-1);
-        expect(showContentIndex).toBeLessThan(deepLinkIndex);
+        expect(agentPolicyCallIndex).toBeGreaterThan(-1);
+        expect(showContentIndex).toBeLessThan(agentPolicyCallIndex);
+    });
+
+    test('does not shadow window.applyDeepLinkFocus from settings-deep-link.js', () => {
+        // Regression guard: an inline `function applyDeepLinkFocus()` declaration here
+        // hoists into local scope and shadows window.applyDeepLinkFocus, breaking the
+        // ?focus=channel-api and ?focus=kanban-nudge entry points the APP relies on.
+        // The agent-policy deep link must call applyAgentPolicyDeepLink directly.
+        expect(html).not.toMatch(/function\s+applyDeepLinkFocus\s*\(/);
+        expect(html).toContain('settings-deep-link.js');
+        expect(html).toContain("if (typeof window.applyDeepLinkFocus === 'function') window.applyDeepLinkFocus();");
+        expect(html).toContain('applyAgentPolicyDeepLink(currentUser);');
     });
 });


### PR DESCRIPTION
## Summary

- 修復 APP 端兩個 entry 按鈕回退：API key 詳情 (`?focus=channel-api`) 與看板督促設定 (`?focus=kanban-nudge`)。
- Root cause：commit 7ac88746 在 settings.html inline 加了 `function applyDeepLinkFocus()`，因 hoisting 蓋掉了 settings-deep-link.js export 的 `window.applyDeepLinkFocus`，導致 FOCUS_MAP 完全沒被執行，只跑 agent-policy 分支。
- Fix：刪掉 inline shadow；init 時直接同時呼叫 `window.applyDeepLinkFocus()`（FOCUS_MAP 分支）+ `applyAgentPolicyDeepLink(currentUser)`（agent-policy 分支）。

## Regression guards

- `settings-prompt-policy-dashboard.test.js`：靜態 grep 拒絕 inline `function applyDeepLinkFocus(` 重新出現，並確認兩條 deep-link 路徑都在 init 時被串好。
- 新增 `settings-deep-link-focus.test.js`：vm-load `settings-deep-link.js`，pin `FOCUS_MAP` 必須包含 `channel-api` 與 `kanban-nudge`，以及未知 key 不會 throw。

## Test plan

- [x] `npx jest backend/tests/jest/settings-prompt-policy-dashboard.test.js backend/tests/jest/settings-deep-link-focus.test.js` — 15/15 passed
- [ ] Web 實機驗：merge 後在 Railway 上開 `https://eclawbot.com/portal/settings.html?focus=channel-api` → 應只剩 channel API card；`?focus=kanban-nudge` → 應自動展開 kanban nudge content。
- [ ] APP 實機驗 (next build)：點「看板督促設定」與「API key 詳情」按鈕跳到 settings.html 應顯示對應 card。

Closes card_6dad41fa757b79c0f39ba6fc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)