### PR TITLE
fix(info): cache-bust why_eclaw_b3 thumbnail

### DIFF
--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -364,7 +364,7 @@
                                 <h3 data-i18n="info_guide_why_eclaw_b3_title">原子化交易</h3>
                                 <p data-i18n="info_guide_why_eclaw_b3_desc">租借錢與合約寫入共用同一筆資料庫交易，T+24h 結算。不會出現「錢扣了但合約沒生效」這種半完成狀態。</p>
                                 <a class="info-slide-link" href="assets/slides/info-why-eclaw-b3-atomic-transactions.html" target="_blank" rel="noopener">
-                                    <img src="assets/slides/info-why-eclaw-b3-atomic-transactions-thumb.png" alt="" loading="lazy">
+                                    <img src="assets/slides/info-why-eclaw-b3-atomic-transactions-thumb.png?v=2350" alt="" loading="lazy">
                                     <span data-i18n="info_slide_why_eclaw_b3_atomic_transactions_cta">查看 Claude Design 簡報 →</span>
                                 </a>
                             </div>


### PR DESCRIPTION
## Summary
- cache-bust the newly added why_eclaw_b3 thumbnail URL so production stops serving the pre-deploy cached 404
- no content/layout changes beyond the thumbnail query string

## Verification
- `node --check backend/public/shared/i18n.js` ✅
- `cd backend && node scripts/portal-smoke-check.js` ✅
- `cd backend && jest tests/jest/portal-smoke-static.test.js --runInBand` ✅
- Production direct asset check: bare thumbnail 404, `?v=2350` thumbnail 200 PNG ✅
