### PR TITLE
refactor(notifications): atomic JSONB || merge in updatePrefs

### DIFF
--- a/backend/notifications.js
+++ b/backend/notifications.js
@@ -200,25 +200,16 @@ async function updatePrefs(deviceId, prefs) {
                 sanitized[key] = !!prefs[key];
             }
         }
-        // Merge with existing prefs so partial PUTs don't clobber other keys.
-        // The settings UI sends one toggle per request; without merge, each
-        // toggle erases all prior toggles back to DEFAULT_PREFS.
-        const existingRow = await pool.query(
-            'SELECT prefs FROM notification_preferences WHERE device_id = $1',
-            [deviceId]
-        );
-        let existing = {};
-        if (existingRow.rows.length > 0) {
-            const stored = existingRow.rows[0].prefs;
-            existing = typeof stored === 'string' ? JSON.parse(stored) : (stored || {});
-        }
-        const merged = { ...existing, ...sanitized };
+        // Atomic shallow-merge via PostgreSQL JSONB `||` so concurrent partial
+        // PUTs cannot interleave a stale read with a fresh write. Without the
+        // merge, each toggle would erase all prior toggles back to DEFAULT_PREFS.
         await pool.query(
             `INSERT INTO notification_preferences (device_id, prefs, updated_at)
-             VALUES ($1, $2, $3)
+             VALUES ($1, $2::jsonb, $3)
              ON CONFLICT (device_id)
-             DO UPDATE SET prefs = $2, updated_at = $3`,
-            [deviceId, JSON.stringify(merged), Date.now()]
+             DO UPDATE SET prefs = COALESCE(notification_preferences.prefs, '{}'::jsonb) || EXCLUDED.prefs,
+                           updated_at = EXCLUDED.updated_at`,
+            [deviceId, JSON.stringify(sanitized), Date.now()]
         );
         return true;
     } catch (err) {

--- a/backend/tests/jest/notification-prefs-merge.test.js
+++ b/backend/tests/jest/notification-prefs-merge.test.js
@@ -29,7 +29,15 @@ function makeMockPool() {
                 return { rows: [{ prefs: stored }] };
             }
             if (/INSERT INTO notification_preferences/i.test(sql)) {
-                stored = params[1]; // JSON string
+                // Emulate `prefs = COALESCE(prefs,'{}'::jsonb) || EXCLUDED.prefs`
+                // shallow-merge so the test exercises post-refactor behavior.
+                const incoming = typeof params[1] === 'string' ? JSON.parse(params[1]) : params[1];
+                if (stored === null) {
+                    stored = JSON.stringify(incoming);
+                } else {
+                    const existing = typeof stored === 'string' ? JSON.parse(stored) : (stored || {});
+                    stored = JSON.stringify({ ...existing, ...incoming });
+                }
                 return { rows: [], rowCount: 1 };
             }
             return { rows: [] };


### PR DESCRIPTION
## Summary
- Drop the SELECT round-trip in `updatePrefs` and let PostgreSQL do the shallow-merge atomically: `prefs = COALESCE(notification_preferences.prefs, '{}'::jsonb) || EXCLUDED.prefs`.
- Closes the small read/write race window left by PR #2322 (which fixed the overwrite bug at the application layer). Now a single statement reads + merges + writes; concurrent partial PUTs on the same device cannot interleave a stale read.
- Cast incoming `\$2` to `::jsonb` so the `||` operator resolves; carry timestamp via `EXCLUDED.updated_at` for symmetry with the merged value.

## Test plan
- [x] Updated Jest mock INSERT branch to emulate `||` shallow merge (parse existing + incoming, spread).
- [x] All 6 existing regression tests in `notification-prefs-merge.test.js` still pass:
  - first partial PUT writes only that key on top of defaults
  - second partial PUT does NOT erase the first key
  - rapid sequence of 6 single-key toggles all persist
  - toggling a key back to true preserves other false keys
  - full-blob PUT (all keys at once) still works
  - unknown keys in the PUT body are ignored, not persisted
- [x] No SQL changes besides the `DO UPDATE SET prefs = ...` clause; schema untouched.

Card: [refactor P3] updatePrefs JSONB || atomic merge (no app-level SELECT-then-UPDATE) — `card_7b0570ce1a4a3c56aa5e6887`

🤖 Generated with [Claude Code](https://claude.com/claude-code)