### PR TITLE
fix(mockup-chat): prevent product-card / note-preview collapse to 2px

### DIFF
--- a/backend/public/assets/mockup-chat.html
+++ b/backend/public/assets/mockup-chat.html
@@ -23,7 +23,7 @@ body { background:#1a1a2e; color:#e0e0e0; font-family:-apple-system,BlinkMacSyst
 .msg-time { font-size:9px; color:#666; margin-top:4px; }
 
 /* Product card */
-.product-card { background:#1e293b; border:1px solid #334155; border-radius:10px; overflow:hidden; max-width:280px; align-self:flex-start; }
+.product-card { background:#1e293b; border:1px solid #334155; border-radius:10px; overflow:hidden; max-width:280px; align-self:flex-start; flex-shrink:0; }
 .product-img { height:100px; background:linear-gradient(135deg,#7c83ff,#ff6b9d); display:flex; align-items:center; justify-content:center; font-size:40px; }
 .product-info { padding:10px; }
 .product-name { font-weight:600; font-size:13px; margin-bottom:4px; }
@@ -31,7 +31,7 @@ body { background:#1a1a2e; color:#e0e0e0; font-family:-apple-system,BlinkMacSyst
 .product-btn { background:#7c83ff; color:white; border:none; padding:6px 16px; border-radius:6px; font-size:11px; cursor:pointer; margin-top:6px; width:100%; }
 
 /* Note preview iframe */
-.note-preview { background:#0d1117; border:1px solid #334155; border-radius:8px; overflow:hidden; max-width:300px; align-self:flex-start; }
+.note-preview { background:#0d1117; border:1px solid #334155; border-radius:8px; overflow:hidden; max-width:300px; align-self:flex-start; flex-shrink:0; }
 .note-preview-header { background:#161b22; padding:6px 10px; font-size:10px; color:#8b949e; display:flex; align-items:center; gap:6px; }
 .note-preview-body { padding:10px; font-size:12px; color:#c9d1d9; line-height:1.5; }
 .note-link { color:#58a6ff; font-size:11px; text-decoration:none; }


### PR DESCRIPTION
## Summary
- E2E drill 2026-05-04 found `.product-card` and `.note-preview` rendering at 2px height inside `.messages` flex container
- Root cause: children without `flex-shrink:0` plus `overflow:hidden` silently collapse when column overflows
- Fix: add `flex-shrink:0` to both rules

## Test plan
- [x] DevTools getBoundingClientRect: card now reports content-driven height (~93px / ~92px) instead of 2px
- [x] Visual: product card and note preview render full content
- [x] Scope: cosmetic only, no JS/script changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)