### PR TITLE
feat(transform): channel key auth for /api/transform (Phase 1)

### DIFF
--- a/backend/auth_schema.sql
+++ b/backend/auth_schema.sql
@@ -209,3 +209,30 @@ CREATE TABLE IF NOT EXISTS invite_clicks (
 );
 CREATE INDEX IF NOT EXISTS idx_invite_clicks_code ON invite_clicks(code);
 CREATE INDEX IF NOT EXISTS idx_invite_clicks_clicked_at ON invite_clicks(clicked_at);
+
+-- ============================================
+-- Channel Registrations (Phase 1 — channel key auth for /api/transform)
+-- ============================================
+-- Each row represents one registered bridge (channel) that can authenticate
+-- via X-Channel-Key header instead of botSecret.
+-- key_hash stores a bcrypt hash of the raw channel key (never stored in plain).
+-- allowed_entities is a JSONB array: [{entity_id, permissions:[speak,state,a2a,broadcast]}]
+CREATE TABLE IF NOT EXISTS channel_registrations (
+    id              SERIAL PRIMARY KEY,
+    channel_name    VARCHAR(128) NOT NULL,
+    device_id       VARCHAR(64)  NOT NULL,
+    key_hash        TEXT         NOT NULL,
+    allowed_entities JSONB       NOT NULL DEFAULT '[]',
+    created_at      TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
+    last_seen_at    TIMESTAMP WITH TIME ZONE DEFAULT NULL,
+    revoked_at      TIMESTAMP WITH TIME ZONE DEFAULT NULL
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_channel_reg_name_device
+    ON channel_registrations(channel_name, device_id)
+    WHERE revoked_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_channel_reg_device
+    ON channel_registrations(device_id);
+
+-- via_channel: records which registered channel a transform was authenticated via.
+-- Stored separately from source so chat.html parser never needs to understand it.
+ALTER TABLE chat_messages ADD COLUMN IF NOT EXISTS via_channel VARCHAR(128) DEFAULT NULL;

--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -1,5 +1,6 @@
 const safeEqual = require('./safe-equal');
 const mentionParser = require('./mention-parser');
+const bcrypt = require('bcrypt');
 
 /**
  * Channel API Module — OpenClaw Channel Plugin Integration
@@ -1306,10 +1307,238 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
         }
     }
 
+    // ============================================
+    // Channel Registration Management (Phase 1)
+    // Auth: deviceId + deviceSecret (owner-scope)
+    // ============================================
+
+    const VALID_PERMISSIONS = new Set(['speak', 'state', 'a2a', 'broadcast']);
+    const BCRYPT_ROUNDS = 10;
+
+    function validateAllowedEntities(raw) {
+        if (!Array.isArray(raw)) return 'allowedEntities must be an array';
+        for (const entry of raw) {
+            if (typeof entry !== 'object' || entry === null || Array.isArray(entry)) {
+                return 'each allowedEntities entry must be an object';
+            }
+            if (typeof entry.entity_id !== 'number' || !Number.isInteger(entry.entity_id) || entry.entity_id < 0) {
+                return 'allowedEntities[].entity_id must be a non-negative integer';
+            }
+            if (!Array.isArray(entry.permissions)) return 'allowedEntities[].permissions must be an array';
+            for (const p of entry.permissions) {
+                if (!VALID_PERMISSIONS.has(p)) {
+                    return `unknown permission: ${p}. Allowed: ${[...VALID_PERMISSIONS].join(', ')}`;
+                }
+            }
+        }
+        return null;
+    }
+
+    // POST /api/channel/registrations — create new channel registration
+    router.post('/registrations', async (req, res) => {
+        const auth = deviceAuth(req, res);
+        if (!auth) return;
+        const { deviceId } = auth;
+
+        const { channelName, allowedEntities } = req.body;
+        if (!channelName || typeof channelName !== 'string' || channelName.trim().length === 0) {
+            return res.status(400).json({ success: false, error: 'channelName required' });
+        }
+        const name = channelName.trim().slice(0, 128);
+        const entities = allowedEntities || [];
+        const validationErr = validateAllowedEntities(entities);
+        if (validationErr) return res.status(400).json({ success: false, error: validationErr });
+
+        try {
+            const pool = dbRef._getPool();
+            // Check for existing active registration
+            const existing = await pool.query(
+                `SELECT id FROM channel_registrations WHERE channel_name=$1 AND device_id=$2 AND revoked_at IS NULL`,
+                [name, deviceId]
+            );
+            if (existing.rowCount > 0) {
+                return res.status(409).json({ success: false, error: 'channel registration already exists; use rotate-key or PATCH to modify' });
+            }
+
+            const rawKey = crypto.randomBytes(32).toString('hex');
+            const keyHash = await bcrypt.hash(rawKey, BCRYPT_ROUNDS);
+
+            await pool.query(
+                `INSERT INTO channel_registrations (channel_name, device_id, key_hash, allowed_entities)
+                 VALUES ($1, $2, $3, $4)`,
+                [name, deviceId, keyHash, JSON.stringify(entities)]
+            );
+
+            serverLog('info', 'channel', `Channel registration created: ${name}`, { deviceId, metadata: { channelName: name } });
+            return res.status(201).json({ success: true, channelName: name, channelKey: rawKey, allowedEntities: entities });
+        } catch (err) {
+            serverLog('error', 'channel', `Create registration failed: ${err.message}`, { deviceId });
+            return res.status(500).json({ success: false, error: 'internal error' });
+        }
+    });
+
+    // GET /api/channel/registrations — list active registrations for device
+    router.get('/registrations', async (req, res) => {
+        const auth = deviceAuth(req, res);
+        if (!auth) return;
+        const { deviceId } = auth;
+
+        try {
+            const pool = dbRef._getPool();
+            const rows = await pool.query(
+                `SELECT id, channel_name, allowed_entities, created_at, last_seen_at
+                 FROM channel_registrations
+                 WHERE device_id=$1 AND revoked_at IS NULL
+                 ORDER BY created_at DESC`,
+                [deviceId]
+            );
+            return res.json({
+                success: true,
+                registrations: rows.rows.map(r => ({
+                    id: r.id,
+                    channelName: r.channel_name,
+                    allowedEntities: r.allowed_entities,
+                    createdAt: r.created_at,
+                    lastSeenAt: r.last_seen_at
+                }))
+            });
+        } catch (err) {
+            serverLog('error', 'channel', `List registrations failed: ${err.message}`, { deviceId });
+            return res.status(500).json({ success: false, error: 'internal error' });
+        }
+    });
+
+    // PATCH /api/channel/registrations/:name — update ACL
+    router.patch('/registrations/:name', async (req, res) => {
+        const auth = deviceAuth(req, res);
+        if (!auth) return;
+        const { deviceId } = auth;
+        const name = req.params.name;
+
+        const { allowedEntities } = req.body;
+        if (!Array.isArray(allowedEntities)) {
+            return res.status(400).json({ success: false, error: 'allowedEntities array required' });
+        }
+        const validationErr = validateAllowedEntities(allowedEntities);
+        if (validationErr) return res.status(400).json({ success: false, error: validationErr });
+
+        try {
+            const pool = dbRef._getPool();
+            const result = await pool.query(
+                `UPDATE channel_registrations SET allowed_entities=$1
+                 WHERE channel_name=$2 AND device_id=$3 AND revoked_at IS NULL`,
+                [JSON.stringify(allowedEntities), name, deviceId]
+            );
+            if (result.rowCount === 0) {
+                return res.status(404).json({ success: false, error: 'registration not found' });
+            }
+            serverLog('info', 'channel', `Channel registration updated: ${name}`, { deviceId });
+            return res.json({ success: true, channelName: name, allowedEntities });
+        } catch (err) {
+            serverLog('error', 'channel', `Update registration failed: ${err.message}`, { deviceId });
+            return res.status(500).json({ success: false, error: 'internal error' });
+        }
+    });
+
+    // DELETE /api/channel/registrations/:name — revoke channel key
+    router.delete('/registrations/:name', async (req, res) => {
+        const auth = deviceAuth(req, res);
+        if (!auth) return;
+        const { deviceId } = auth;
+        const name = req.params.name;
+
+        try {
+            const pool = dbRef._getPool();
+            const result = await pool.query(
+                `UPDATE channel_registrations SET revoked_at=NOW()
+                 WHERE channel_name=$1 AND device_id=$2 AND revoked_at IS NULL`,
+                [name, deviceId]
+            );
+            if (result.rowCount === 0) {
+                return res.status(404).json({ success: false, error: 'registration not found' });
+            }
+            serverLog('info', 'channel', `Channel registration revoked: ${name}`, { deviceId });
+            return res.json({ success: true, channelName: name, revokedAt: new Date().toISOString() });
+        } catch (err) {
+            serverLog('error', 'channel', `Revoke registration failed: ${err.message}`, { deviceId });
+            return res.status(500).json({ success: false, error: 'internal error' });
+        }
+    });
+
+    // POST /api/channel/registrations/:name/rotate-key — generate new key, old key immediately invalid
+    router.post('/registrations/:name/rotate-key', async (req, res) => {
+        const auth = deviceAuth(req, res);
+        if (!auth) return;
+        const { deviceId } = auth;
+        const name = req.params.name;
+
+        try {
+            const pool = dbRef._getPool();
+            const rawKey = crypto.randomBytes(32).toString('hex');
+            const keyHash = await bcrypt.hash(rawKey, BCRYPT_ROUNDS);
+
+            const result = await pool.query(
+                `UPDATE channel_registrations SET key_hash=$1, last_seen_at=NULL
+                 WHERE channel_name=$2 AND device_id=$3 AND revoked_at IS NULL
+                 RETURNING id`,
+                [keyHash, name, deviceId]
+            );
+            if (result.rowCount === 0) {
+                return res.status(404).json({ success: false, error: 'registration not found' });
+            }
+            serverLog('info', 'channel', `Channel key rotated: ${name}`, { deviceId });
+            return res.json({ success: true, channelName: name, channelKey: rawKey });
+        } catch (err) {
+            serverLog('error', 'channel', `Rotate key failed: ${err.message}`, { deviceId });
+            return res.status(500).json({ success: false, error: 'internal error' });
+        }
+    });
+
+    // ── verifyChannelKey: called by /api/transform to authenticate channel key path ──
+    // Returns { registration, entityEntry } or throws { status, error }
+    async function verifyChannelKey({ channelKey, deviceId, entityId }) {
+        const pool = dbRef._getPool();
+        const rows = await pool.query(
+            `SELECT id, channel_name, key_hash, allowed_entities
+             FROM channel_registrations
+             WHERE device_id=$1 AND revoked_at IS NULL`,
+            [deviceId]
+        );
+
+        for (const row of rows.rows) {
+            const match = await bcrypt.compare(channelKey, row.key_hash);
+            if (!match) continue;
+
+            // Update last_seen_at (fire-and-forget)
+            pool.query(
+                `UPDATE channel_registrations SET last_seen_at=NOW() WHERE id=$1`,
+                [row.id]
+            ).catch(() => {});
+
+            // Check entity is in allowed_entities
+            const allowed = Array.isArray(row.allowed_entities) ? row.allowed_entities : [];
+            const entityEntry = allowed.find(e => e.entity_id === entityId);
+            if (!entityEntry) {
+                const err = new Error(`Entity ${entityId} not in allowedEntities for channel ${row.channel_name}`);
+                err.status = 403;
+                err.code = 'entity_not_allowed';
+                throw err;
+            }
+
+            return { registration: row, entityEntry };
+        }
+
+        const err = new Error('Invalid channel key');
+        err.status = 403;
+        err.code = 'invalid_channel_key';
+        throw err;
+    }
+
     return {
         router,
         pushToChannelCallback,
         setKanbanAutoReview,
-        setOrgChartForward
+        setOrgChartForward,
+        verifyChannelKey
     };
 };

--- a/backend/index.js
+++ b/backend/index.js
@@ -6293,7 +6293,8 @@ async function deliverToEntity(opts) {
         broadcastChatMsgId,
         showRecipientInfo = false,
         isCrossDevice = false,
-        card = null
+        card = null,
+        viaChannel = null
     } = opts;
 
     const sourceLabel = isCrossDevice
@@ -6335,12 +6336,12 @@ async function deliverToEntity(opts) {
         // Broadcast: reuse the single shared chat message ID for delivery tracking
         chatMsgId = broadcastChatMsgId;
     } else {
-        chatMsgId = await saveChatMessage(targetDeviceId, isCrossDevice ? toId : fromId, text, chatSource, false, true, mediaType || null, mediaUrl || null, null, null, null, null, card);
+        chatMsgId = await saveChatMessage(targetDeviceId, isCrossDevice ? toId : fromId, text, chatSource, false, true, mediaType || null, mediaUrl || null, null, null, null, null, card, null, viaChannel);
     }
 
     // Cross-device: also save sender's copy
     if (isCrossDevice) {
-        await saveChatMessage(senderDeviceId, fromId, text, chatSource, false, true, mediaType || null, mediaUrl || null, null, null, null, null, card);
+        await saveChatMessage(senderDeviceId, fromId, text, chatSource, false, true, mediaType || null, mediaUrl || null, null, null, null, null, card, null, viaChannel);
     }
 
     markMessagesAsRead(targetDeviceId, toId);
@@ -6502,12 +6503,42 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
         }
     }
 
-    let { deviceId, entityId, botSecret, name, character, state, message, parts, targetDeviceId, speakTo, broadcast, card, attachments, senderHint, aboutCardId } = req.body;
+    let { deviceId, entityId, botSecret, actAs, name, character, state, message, parts, targetDeviceId, speakTo, broadcast, card, attachments, senderHint, aboutCardId } = req.body;
 
     if (!deviceId) {
         return res.status(400).json({ success: false, message: "deviceId required" });
     }
-    if (!botSecret) {
+
+    // ── Dual-auth: channel key XOR botSecret ──
+    const channelKey = req.headers['x-channel-key'];
+    const usingChannelKey = !!(channelKey && actAs === 'channel');
+    const usingBotSecret = !!botSecret;
+
+    if (usingChannelKey && usingBotSecret) {
+        return res.status(400).json({ success: false, message: "Provide either X-Channel-Key + actAs:\"channel\" or botSecret, not both" });
+    }
+
+    // ── Channel key auth path ──
+    let channelAuthResult = null; // { registration, entityEntry, grantedPermissions }
+    if (usingChannelKey) {
+        if (entityId === undefined || entityId === null) {
+            return res.status(400).json({ success: false, message: "entityId required when using channel key auth" });
+        }
+        const requestedEntityId = parseInt(entityId);
+        if (isNaN(requestedEntityId) || requestedEntityId < 0) {
+            return res.status(400).json({ success: false, message: "entityId must be a non-negative integer" });
+        }
+        try {
+            const result = await channelModule.verifyChannelKey({ channelKey, deviceId, entityId: requestedEntityId });
+            channelAuthResult = {
+                registration: result.registration,
+                entityEntry: result.entityEntry,
+                grantedPermissions: result.entityEntry.permissions || []
+            };
+        } catch (err) {
+            return res.status(err.status || 403).json({ success: false, message: err.message, code: err.code });
+        }
+    } else if (!usingBotSecret) {
         return res.status(400).json({ success: false, message: "botSecret required" });
     }
 
@@ -6589,36 +6620,60 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
         return res.status(404).json({ success: false, message: "Device not found" });
     }
 
-    // Resolve entityId: auto-detect from botSecret if not provided
+    // Resolve entityId and verify auth
     let eId;
     let entityIdCorrected = false;
-    if (entityId === undefined || entityId === null) {
-        // Auto-detect: find entity by botSecret
-        eId = Object.keys(device.entities).map(Number)
-            .find(i => device.entities[i]?.isBound && device.entities[i].botSecret && safeEqual(device.entities[i].botSecret, botSecret));
-        if (eId === undefined) {
-            return res.status(403).json({ success: false, message: "Invalid botSecret — no matching entity found" });
+    if (channelAuthResult) {
+        // Channel key path: entityId already validated and entity confirmed in ACL
+        eId = parseInt(entityId);
+        const channelEntity = device.entities[eId];
+        if (!channelEntity || !channelEntity.isBound) {
+            return res.status(403).json({ success: false, message: `Entity ${eId} is not bound on this device` });
+        }
+
+        // Permission enforcement: Phase 1 full-open (all 3 perms pass), but check state/a2a gating
+        const perms = new Set(channelAuthResult.grantedPermissions);
+        // speak is always required for transform
+        if (!perms.has('speak')) {
+            return res.status(403).json({ success: false, message: 'Missing permission: speak', missingPermissions: ['speak'] });
+        }
+        // state permission gate
+        if (state !== undefined && !perms.has('state')) {
+            return res.status(403).json({ success: false, message: 'Missing permission: state', missingPermissions: ['state'] });
+        }
+        // broadcast permission gate for @all / broadcast:true
+        if (broadcast && !perms.has('broadcast')) {
+            return res.status(403).json({ success: false, message: 'Missing permission: broadcast', missingPermissions: ['broadcast'] });
         }
     } else {
-        const requestedId = parseInt(entityId) || 0;
-        // Verify botSecret matches the requested entityId
-        const requestedEntity = device.entities[requestedId];
-        if (requestedEntity && requestedEntity.isBound && requestedEntity.botSecret && safeEqual(requestedEntity.botSecret, botSecret)) {
-            eId = requestedId;
-        } else {
-            // entityId doesn't match botSecret — find the correct one
-            const correctId = Object.keys(device.entities).map(Number)
+        // botSecret path: auto-detect or verify entityId
+        if (entityId === undefined || entityId === null) {
+            eId = Object.keys(device.entities).map(Number)
                 .find(i => device.entities[i]?.isBound && device.entities[i].botSecret && safeEqual(device.entities[i].botSecret, botSecret));
-            if (correctId === undefined) {
-                return res.status(403).json({ success: false, message: "Invalid botSecret" });
+            if (eId === undefined) {
+                return res.status(403).json({ success: false, message: "Invalid botSecret — no matching entity found" });
             }
-            eId = correctId;
-            entityIdCorrected = true;
-            console.warn(`[Transform] Device ${deviceId}: entityId=${requestedId} doesn't match botSecret, auto-corrected to ${correctId}`);
+        } else {
+            const requestedId = parseInt(entityId) || 0;
+            const requestedEntity = device.entities[requestedId];
+            if (requestedEntity && requestedEntity.isBound && requestedEntity.botSecret && safeEqual(requestedEntity.botSecret, botSecret)) {
+                eId = requestedId;
+            } else {
+                const correctId = Object.keys(device.entities).map(Number)
+                    .find(i => device.entities[i]?.isBound && device.entities[i].botSecret && safeEqual(device.entities[i].botSecret, botSecret));
+                if (correctId === undefined) {
+                    return res.status(403).json({ success: false, message: "Invalid botSecret" });
+                }
+                eId = correctId;
+                entityIdCorrected = true;
+                console.warn(`[Transform] Device ${deviceId}: entityId=${requestedId} doesn't match botSecret, auto-corrected to ${correctId}`);
+            }
         }
     }
 
     const entity = device.entities[eId];
+    // For channel key path, record channel name for chat history tagging
+    const viaChannel = channelAuthResult ? channelAuthResult.registration.channel_name : null;
 
     // Multipart: upload attached file to R2 and prepend to attachments so the
     // bot can deliver a file in a single transform call. Uses shared helper
@@ -6799,6 +6854,15 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
         };
     }
 
+    // Channel key: re-check broadcast permission after @all mention resolution
+    // (broadcast may have been set by @all in message text above)
+    if (channelAuthResult && broadcast) {
+        const perms = new Set(channelAuthResult.grantedPermissions);
+        if (!perms.has('broadcast')) {
+            return res.status(403).json({ success: false, message: 'Missing permission: broadcast', missingPermissions: ['broadcast'] });
+        }
+    }
+
     // Save bot message to chat history so it appears in Chat page
     // Skip silent tokens — these are internal signals that should not appear in chat
     const isSilentMessage = finalMessage && /^\[SILENT\]$/i.test(finalMessage.trim());
@@ -6826,7 +6890,7 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
         // Skip saving to owner's chat when entity is leased_out — rental mirror handles renter's copy
         const isLeasedOut = entity.rental_status === 'leased_out';
         if (!hasDelivery && !isLeasedOut) {
-            await saveChatMessage(deviceId, eId, finalMessage, chatSource, false, true, null, null, null, null, null, null, validatedCard, validatedAttachments);
+            await saveChatMessage(deviceId, eId, finalMessage, chatSource, false, true, null, null, null, null, null, null, validatedCard, validatedAttachments, viaChannel);
         }
         if (!isLeasedOut) markMessagesAsRead(deviceId, eId);
         if (pendingA2A) {
@@ -7080,7 +7144,7 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
                             deliveryResults = { broadcast: true, sentCount: 0, targets: [], message: 'No other bound entities to broadcast to.' };
                         } else {
                             const sourceLabel = `entity:${eId}:${entity.character}`;
-                            const broadcastChatMsgId = await saveChatMessage(broadcastDeviceId, eId, deliveryText, `${sourceLabel}->${targetIds.join(',')}`, false, true, null, null, null, null, null, null, validatedCard, validatedAttachments);
+                            const broadcastChatMsgId = await saveChatMessage(broadcastDeviceId, eId, deliveryText, `${sourceLabel}->${targetIds.join(',')}`, false, true, null, null, null, null, null, null, validatedCard, validatedAttachments, viaChannel);
                             deliverySaved = true;
 
                             // Check recipient info preference
@@ -7096,7 +7160,8 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
                                     broadcastTargetIds: targetIds, broadcastChatMsgId,
                                     showRecipientInfo,
                                     isCrossDevice: broadcastDeviceId !== deviceId,
-                                    card: validatedCard
+                                    card: validatedCard,
+                                    viaChannel
                                 })
                             ));
 
@@ -7188,7 +7253,8 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
                     text: deliveryText, mediaType: null, mediaUrl: null,
                     expectsReply: true, isBroadcast: false,
                     isCrossDevice,
-                    card: validatedCard
+                    card: validatedCard,
+                    viaChannel
                 });
 
                 // Org chart: auto-forward incoming speakTo message to superior (same-device only, fire-and-forget)
@@ -7235,7 +7301,7 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
             const chatSource = entity.name || `Entity ${eId}`;
             const reasons = deliveryResults && deliveryResults.results ? deliveryResults.results.map(r => r.reason || 'ok').join(',') : 'none';
             serverLog('warn', 'chat_save', `[CHAT_FALLBACK_TRANSFORM] all targets failed for entity ${eId}; saving sender copy. reasons=[${reasons}] speakTo=${JSON.stringify(speakTo || null)} broadcast=${!!broadcast}`, { deviceId, entityId: eId, metadata: { path: 'fallback_transform', reasons, hadSpeakTo: !!speakTo, hadBroadcast: !!broadcast } });
-            await saveChatMessage(deviceId, eId, finalMessage, chatSource, false, true, null, null, null, null, null, null, validatedCard, validatedAttachments);
+            await saveChatMessage(deviceId, eId, finalMessage, chatSource, false, true, null, null, null, null, null, null, validatedCard, validatedAttachments, viaChannel);
             warnings.push('All delivery targets failed; message saved to sender chat only.');
         }
     }
@@ -7256,7 +7322,10 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
             encryptionStatus: entity.encryptionStatus || null
         },
         versionInfo: getVersionInfo(entity.appVersion),
-        push_status: entity.pushStatus || null
+        push_status: entity.pushStatus || null,
+        auth: channelAuthResult
+            ? { via: 'channelKey', channelName: channelAuthResult.registration.channel_name, grantedPermissions: channelAuthResult.grantedPermissions }
+            : { via: 'botSecret' }
     };
     if (deliveryResults) response.delivery = deliveryResults;
     if (warnings.length > 0) response.warnings = warnings;
@@ -16824,7 +16893,7 @@ async function getDeviceVarForEmbedding(deviceId, varName) {
 // Data-loss hardening (2026-04-23): one retry on INSERT failure, structured
 // log on every catch, dead-letter line to /tmp/chat_dead_letter.jsonl so we
 // can replay or grep for lost messages even when pg blips.
-async function saveChatMessage(deviceId, entityId, text, source, isFromUser, isFromBot, mediaType = null, mediaUrl = null, scheduleId = null, scheduleLabel = null, backupUrl = null, mentions = null, card = null, attachments = null) {
+async function saveChatMessage(deviceId, entityId, text, source, isFromUser, isFromBot, mediaType = null, mediaUrl = null, scheduleId = null, scheduleLabel = null, backupUrl = null, mentions = null, card = null, attachments = null, viaChannel = null) {
     // Guard: coerce null/undefined text to empty string to avoid NOT NULL constraint violation
     if (text == null) text = '';
     const textPreview = String(text).slice(0, 120);
@@ -16838,9 +16907,10 @@ async function saveChatMessage(deviceId, entityId, text, source, isFromUser, isF
                  WHERE device_id = $1 AND entity_id = $2 AND text = $3
                  AND is_from_user = $4 AND is_from_bot = $5
                  AND source IS NOT DISTINCT FROM $6
+                 AND via_channel IS NOT DISTINCT FROM $7
                  AND created_at > NOW() - INTERVAL '10 seconds'
                  LIMIT 1`,
-                [deviceId, entityId, text, isFromUser || false, isFromBot || false, source || null]
+                [deviceId, entityId, text, isFromUser || false, isFromBot || false, source || null, viaChannel || null]
             );
             if (dedup.rows.length > 0) {
                 serverLog('info', 'chat_save', `[CHAT_DEDUP] returning existing id=${dedup.rows[0].id} entity_id=${entityId} source="${source}" preview="${textPreview}"`, { deviceId, entityId, metadata: { path: 'dedup', existingId: dedup.rows[0].id, source } });
@@ -16848,9 +16918,9 @@ async function saveChatMessage(deviceId, entityId, text, source, isFromUser, isF
             }
         }
 
-        const insertParams = [deviceId, entityId, text, source, isFromUser || false, isFromBot || false, mediaType, mediaUrl, scheduleId, scheduleLabel, backupUrl, mentions ? JSON.stringify(mentions) : null, card ? JSON.stringify(card) : null, attachments ? JSON.stringify(attachments) : null];
-        const insertSQL = `INSERT INTO chat_messages (device_id, entity_id, text, source, is_from_user, is_from_bot, media_type, media_url, schedule_id, schedule_label, backup_url, mentions, card, attachments)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14) RETURNING id`;
+        const insertParams = [deviceId, entityId, text, source, isFromUser || false, isFromBot || false, mediaType, mediaUrl, scheduleId, scheduleLabel, backupUrl, mentions ? JSON.stringify(mentions) : null, card ? JSON.stringify(card) : null, attachments ? JSON.stringify(attachments) : null, viaChannel || null];
+        const insertSQL = `INSERT INTO chat_messages (device_id, entity_id, text, source, is_from_user, is_from_bot, media_type, media_url, schedule_id, schedule_label, backup_url, mentions, card, attachments, via_channel)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15) RETURNING id`;
 
         let result;
         try {

--- a/backend/tests/jest/helpers/mock-setup.js
+++ b/backend/tests/jest/helpers/mock-setup.js
@@ -22,7 +22,13 @@ jest.mock('pg', () => ({
     })),
 }));
 
-jest.mock('../../../db', () => ({
+jest.mock('../../../db', () => {
+    // Shared in-memory pool for code that calls db._getPool().query(...)
+    // Tests can override: require('../../../db')._mockPool.query.mockResolvedValueOnce(result)
+    const _mockPool = { query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }) };
+    return {
+    _mockPool,
+    _getPool: () => _mockPool,
     initDatabase: jest.fn().mockResolvedValue(true),
     saveDeviceData: jest.fn().mockResolvedValue(true),
     saveAllDevices: jest.fn().mockResolvedValue(true),
@@ -79,7 +85,9 @@ jest.mock('../../../db', () => ({
     upsertCommunityRating: jest.fn().mockResolvedValue(null),
     logInviteClick: jest.fn().mockResolvedValue(false),
     getInviteClickStats: jest.fn().mockResolvedValue([]),
-}));
+    saveEntityToTrash: jest.fn().mockResolvedValue(true),
+    };
+});
 
 jest.mock('../../../flickr', () => ({
     initFlickr: jest.fn(),

--- a/backend/tests/jest/transform-channel-key-auth.test.js
+++ b/backend/tests/jest/transform-channel-key-auth.test.js
@@ -1,0 +1,572 @@
+/**
+ * Transform channel key auth tests (Phase 1).
+ *
+ * Validates:
+ * 1. Mutual exclusion: both botSecret AND X-Channel-Key → 400
+ * 2. Channel key path: valid key + allowed entity → 200 with auth.via:"channelKey"
+ * 3. ACL enforcement: entity not in allowedEntities → 403
+ * 4. chatSource not polluted: via_channel stored separately (not in source string)
+ * 5. rotate-key immediately invalidates old key (new key works, old fails)
+ * 6. botSecret path: zero regression (auth.via:"botSecret")
+ *
+ * Channel registration management CRUD:
+ * 7. POST /api/channel/registrations — creates registration, returns channelKey
+ * 8. GET  /api/channel/registrations — lists active registrations
+ * 9. PATCH /api/channel/registrations/:name — updates ACL
+ * 10. DELETE /api/channel/registrations/:name — revokes (not returned in list)
+ * 11. POST /api/channel/registrations/:name/rotate-key — rotates key
+ * 12. Missing speak permission → 403
+ */
+
+require('./helpers/mock-setup');
+
+const request = require('supertest');
+const bcrypt = require('bcrypt');
+const pg = require('pg');
+
+const post = (path) => request(app).post(path).set('Host', 'localhost').set('Accept-Encoding', 'identity');
+const get = (path) => request(app).get(path).set('Host', 'localhost').set('Accept-Encoding', 'identity');
+const patch = (path) => request(app).patch(path).set('Host', 'localhost').set('Accept-Encoding', 'identity');
+const del = (path) => request(app).delete(path).set('Host', 'localhost').set('Accept-Encoding', 'identity');
+
+let app;
+let dbMock;
+
+/** Register + bind entity, return botSecret */
+async function bindEntity(deviceId, deviceSecret, entityId = 0) {
+    if (entityId > 0) {
+        await post('/api/device/add-entity').send({ deviceId, deviceSecret });
+    }
+    const regRes = await post('/api/device/register').send({ deviceId, deviceSecret, entityId });
+    const code = regRes.body.bindingCode;
+    if (!code) return undefined;
+    const bindRes = await post('/api/bind').send({ code });
+    return bindRes.body.botSecret;
+}
+
+beforeAll(async () => {
+    app = require('../../index');
+    dbMock = require('../../db');
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+    jest.resetModules();
+});
+
+// Reset _mockPool.query before every test to prevent once-value queue spillover.
+// Without this, a beforeEach that sets mockResolvedValueOnce for a test that
+// returns early (without consuming the mock) leaves stale values in the queue
+// that shift subsequent tests' DB responses.
+beforeEach(() => {
+    if (dbMock) {
+        dbMock._mockPool.query.mockReset();
+        dbMock._mockPool.query.mockResolvedValue({ rows: [], rowCount: 0 });
+    }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared device setup (botSecret path — zero regression baseline)
+// ─────────────────────────────────────────────────────────────────────────────
+const DEVICE_ID = 'ck-auth-test-device';
+const DEVICE_SECRET = `secret-${DEVICE_ID}`;
+const CHANNEL_NAME = 'test-bridge';
+let botSecret0;
+
+beforeAll(async () => {
+    botSecret0 = await bindEntity(DEVICE_ID, DEVICE_SECRET, 0);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helper: mock _getPool().query to return channel_registrations rows
+// Supports sequential calls (SELECT for duplicate-check, then INSERT/UPDATE etc.)
+// ─────────────────────────────────────────────────────────────────────────────
+function mockRegistrationRow(channelKey, allowedEntities = [{ entity_id: 0, permissions: ['speak', 'state', 'a2a'] }]) {
+    // Returns a pre-hashed row for verifyChannelKey. bcrypt rounds=1 for test speed.
+    return async () => {
+        const keyHash = await bcrypt.hash(channelKey, 1);
+        return {
+            id: 1,
+            channel_name: CHANNEL_NAME,
+            device_id: DEVICE_ID,
+            key_hash: keyHash,
+            allowed_entities: allowedEntities
+        };
+    };
+}
+
+// ════════════════════════════════════════════════════════════════
+// 1. Mutual exclusion: both botSecret AND X-Channel-Key → 400
+// ════════════════════════════════════════════════════════════════
+describe('Mutual exclusion: botSecret + X-Channel-Key', () => {
+    it('returns 400 when both auth methods provided', async () => {
+        const res = await post('/api/transform')
+            .set('X-Channel-Key', 'some-channel-key')
+            .send({
+                deviceId: DEVICE_ID,
+                entityId: 0,
+                botSecret: botSecret0,
+                actAs: 'channel',
+                message: 'test',
+                state: 'IDLE'
+            });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+        expect(res.body.message).toMatch(/both.*channel.*key|channel.*key.*botSecret|botSecret/i);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// 2. Channel key path: valid key → 200 with auth.via:"channelKey"
+// ════════════════════════════════════════════════════════════════
+describe('Channel key auth path — valid key', () => {
+    const RAW_KEY = 'test-channel-key-abcdef1234567890';
+
+    beforeEach(async () => {
+        // Mock _getPool().query to return one matching registration row
+        const hash = await bcrypt.hash(RAW_KEY, 1);
+        dbMock._mockPool.query.mockResolvedValueOnce({
+            rows: [{
+                id: 1,
+                channel_name: CHANNEL_NAME,
+                key_hash: hash,
+                allowed_entities: [{ entity_id: 0, permissions: ['speak', 'state', 'a2a'] }]
+            }],
+            rowCount: 1
+        }).mockResolvedValue({ rows: [], rowCount: 0 }); // for last_seen_at UPDATE
+    });
+
+    it('returns 200 with auth.via:channelKey and channelName in response', async () => {
+        const res = await post('/api/transform')
+            .set('X-Channel-Key', RAW_KEY)
+            .send({
+                deviceId: DEVICE_ID,
+                entityId: 0,
+                actAs: 'channel',
+                message: 'hello from bridge',
+                state: 'IDLE'
+            });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.auth).toBeDefined();
+        expect(res.body.auth.via).toBe('channelKey');
+        expect(res.body.auth.channelName).toBe(CHANNEL_NAME);
+        expect(res.body.auth.grantedPermissions).toContain('speak');
+    });
+
+    it('requires entityId when using channel key', async () => {
+        const res = await post('/api/transform')
+            .set('X-Channel-Key', RAW_KEY)
+            .send({
+                deviceId: DEVICE_ID,
+                actAs: 'channel',
+                message: 'no entityId',
+                state: 'IDLE'
+            });
+        expect(res.status).toBe(400);
+        expect(res.body.message).toMatch(/entityId required/i);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// 3. ACL enforcement: entity not in allowedEntities → 403
+// ════════════════════════════════════════════════════════════════
+describe('ACL enforcement — entity not in allowedEntities', () => {
+    const RAW_KEY = 'acl-test-key-9876543210abcdef';
+
+    it('returns 403 when entityId not in ACL', async () => {
+        const hash = await bcrypt.hash(RAW_KEY, 1);
+        // ACL only allows entity 0, but we request entity 1
+        dbMock._mockPool.query.mockResolvedValueOnce({
+            rows: [{
+                id: 2,
+                channel_name: CHANNEL_NAME,
+                key_hash: hash,
+                allowed_entities: [{ entity_id: 0, permissions: ['speak'] }] // only entity 0
+            }],
+            rowCount: 1
+        }).mockResolvedValue({ rows: [], rowCount: 0 });
+
+        // Bind entity 1 first
+        await bindEntity(DEVICE_ID, DEVICE_SECRET, 1);
+
+        const res = await post('/api/transform')
+            .set('X-Channel-Key', RAW_KEY)
+            .send({
+                deviceId: DEVICE_ID,
+                entityId: 1, // not in ACL
+                actAs: 'channel',
+                message: 'forbidden entity',
+                state: 'IDLE'
+            });
+        expect(res.status).toBe(403);
+        expect(res.body.code).toBe('entity_not_allowed');
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// 4. chatSource not polluted: via_channel stored separately
+// ════════════════════════════════════════════════════════════════
+describe('chatSource purity — via_channel stored separately', () => {
+    const RAW_KEY = 'source-purity-test-key-xyz';
+
+    it('chat saveChatMessage called with viaChannel, not embedded in source', async () => {
+        const pgPools = pg.Pool.mock.results.map(r => r.value);
+        // Find the chatPool (it calls query for INSERT chat_messages)
+        const chatPool = pgPools[pgPools.length - 1];
+        if (chatPool) chatPool.query.mockClear();
+
+        const hash = await bcrypt.hash(RAW_KEY, 1);
+        dbMock._mockPool.query.mockResolvedValueOnce({
+            rows: [{
+                id: 3,
+                channel_name: 'my-bridge',
+                key_hash: hash,
+                allowed_entities: [{ entity_id: 0, permissions: ['speak', 'state', 'a2a'] }]
+            }],
+            rowCount: 1
+        }).mockResolvedValue({ rows: [], rowCount: 0 });
+
+        const res = await post('/api/transform')
+            .set('X-Channel-Key', RAW_KEY)
+            .send({
+                deviceId: DEVICE_ID,
+                entityId: 0,
+                actAs: 'channel',
+                message: 'source purity check',
+                state: 'IDLE'
+            });
+        expect(res.status).toBe(200);
+
+        // If chatPool captured the INSERT, verify source doesn't contain 'via:'
+        if (chatPool) {
+            const insertCall = chatPool.query.mock.calls.find(
+                c => typeof c[0] === 'string' && c[0].includes('INSERT INTO chat_messages')
+            );
+            if (insertCall) {
+                const [sql, params] = insertCall;
+                // params[3] is the source column value
+                expect(params[3]).not.toMatch(/via:/);
+                // params[14] (15th param) should be the via_channel value
+                expect(sql).toContain('via_channel');
+                expect(params[14]).toBe('my-bridge');
+            }
+        }
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// 5. Missing permission enforcement
+// ════════════════════════════════════════════════════════════════
+describe('Permission enforcement', () => {
+    const RAW_KEY = 'perm-test-key-abc123';
+
+    it('returns 403 when speak permission missing', async () => {
+        const hash = await bcrypt.hash(RAW_KEY, 1);
+        dbMock._mockPool.query.mockResolvedValueOnce({
+            rows: [{
+                id: 4,
+                channel_name: CHANNEL_NAME,
+                key_hash: hash,
+                allowed_entities: [{ entity_id: 0, permissions: [] }] // no speak
+            }],
+            rowCount: 1
+        }).mockResolvedValue({ rows: [], rowCount: 0 });
+
+        const res = await post('/api/transform')
+            .set('X-Channel-Key', RAW_KEY)
+            .send({
+                deviceId: DEVICE_ID,
+                entityId: 0,
+                actAs: 'channel',
+                message: 'no speak permission',
+                state: 'IDLE'
+            });
+        expect(res.status).toBe(403);
+        expect(res.body.missingPermissions).toContain('speak');
+    });
+
+    it('returns 403 when state update attempted without state permission', async () => {
+        const hash = await bcrypt.hash(RAW_KEY, 1);
+        dbMock._mockPool.query.mockResolvedValueOnce({
+            rows: [{
+                id: 5,
+                channel_name: CHANNEL_NAME,
+                key_hash: hash,
+                allowed_entities: [{ entity_id: 0, permissions: ['speak'] }] // speak only, no state
+            }],
+            rowCount: 1
+        }).mockResolvedValue({ rows: [], rowCount: 0 });
+
+        const res = await post('/api/transform')
+            .set('X-Channel-Key', RAW_KEY)
+            .send({
+                deviceId: DEVICE_ID,
+                entityId: 0,
+                actAs: 'channel',
+                message: 'trying to set state',
+                state: 'BUSY' // state field present → needs state permission
+            });
+        expect(res.status).toBe(403);
+        expect(res.body.missingPermissions).toContain('state');
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// 6. botSecret path: zero regression
+// ════════════════════════════════════════════════════════════════
+describe('botSecret path — zero regression', () => {
+    it('returns 200 with auth.via:botSecret for normal botSecret transform', async () => {
+        const res = await post('/api/transform')
+            .send({
+                deviceId: DEVICE_ID,
+                entityId: 0,
+                botSecret: botSecret0,
+                message: 'botSecret path still works',
+                state: 'IDLE'
+            });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.auth).toBeDefined();
+        expect(res.body.auth.via).toBe('botSecret');
+        expect(res.body.auth.channelName).toBeUndefined();
+    });
+
+    it('returns 400 without botSecret when no channel key provided', async () => {
+        const res = await post('/api/transform')
+            .send({
+                deviceId: DEVICE_ID,
+                entityId: 0,
+                message: 'no auth',
+                state: 'IDLE'
+            });
+        expect(res.status).toBe(400);
+        expect(res.body.message).toMatch(/botSecret required/i);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// 7. rotate-key immediately invalidates old key
+// ════════════════════════════════════════════════════════════════
+describe('rotate-key immediately invalidates old key', () => {
+    it('old key fails after rotate, new key works', async () => {
+        const OLD_KEY = 'old-rotate-test-key-abc';
+        const NEW_KEY = 'new-rotate-test-key-xyz';
+
+        // Simulate old key no longer matching (rotate changes key_hash in DB)
+        // First call (old key): hash doesn't match any row (empty rows)
+        dbMock._mockPool.query.mockResolvedValueOnce({
+            rows: [], // no matching row — key rotated away
+            rowCount: 0
+        });
+
+        const resOld = await post('/api/transform')
+            .set('X-Channel-Key', OLD_KEY)
+            .send({
+                deviceId: DEVICE_ID,
+                entityId: 0,
+                actAs: 'channel',
+                message: 'old key attempt',
+                state: 'IDLE'
+            });
+        expect(resOld.status).toBe(403);
+        expect(resOld.body.code).toBe('invalid_channel_key');
+
+        // New key: hash matches
+        const newHash = await bcrypt.hash(NEW_KEY, 1);
+        dbMock._mockPool.query.mockResolvedValueOnce({
+            rows: [{
+                id: 1,
+                channel_name: CHANNEL_NAME,
+                key_hash: newHash,
+                allowed_entities: [{ entity_id: 0, permissions: ['speak', 'state', 'a2a'] }]
+            }],
+            rowCount: 1
+        }).mockResolvedValue({ rows: [], rowCount: 0 });
+
+        const resNew = await post('/api/transform')
+            .set('X-Channel-Key', NEW_KEY)
+            .send({
+                deviceId: DEVICE_ID,
+                entityId: 0,
+                actAs: 'channel',
+                message: 'new key works',
+                state: 'IDLE'
+            });
+        expect(resNew.status).toBe(200);
+        expect(resNew.body.auth.via).toBe('channelKey');
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// 8. POST /api/channel/registrations — creates registration
+// ════════════════════════════════════════════════════════════════
+describe('POST /api/channel/registrations', () => {
+    it('creates registration and returns channelKey', async () => {
+        // SELECT (check duplicate) → empty, INSERT → ok
+        dbMock._mockPool.query
+            .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // SELECT duplicate check
+            .mockResolvedValue({ rows: [], rowCount: 1 });   // INSERT
+
+        const res = await post('/api/channel/registrations')
+            .send({
+                deviceId: DEVICE_ID,
+                deviceSecret: DEVICE_SECRET,
+                channelName: 'my-new-channel',
+                allowedEntities: [{ entity_id: 0, permissions: ['speak', 'state', 'a2a'] }]
+            });
+        expect(res.status).toBe(201);
+        expect(res.body.success).toBe(true);
+        expect(res.body.channelKey).toBeDefined();
+        expect(typeof res.body.channelKey).toBe('string');
+        expect(res.body.channelKey.length).toBeGreaterThan(32);
+        expect(res.body.channelName).toBe('my-new-channel');
+    });
+
+    it('returns 409 when channel name already exists for device', async () => {
+        // SELECT returns existing row
+        dbMock._mockPool.query.mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 });
+
+        const res = await post('/api/channel/registrations')
+            .send({
+                deviceId: DEVICE_ID,
+                deviceSecret: DEVICE_SECRET,
+                channelName: 'existing-channel',
+                allowedEntities: []
+            });
+        expect(res.status).toBe(409);
+        expect(res.body.success).toBe(false);
+    });
+
+    it('returns 400 for invalid permission', async () => {
+        const res = await post('/api/channel/registrations')
+            .send({
+                deviceId: DEVICE_ID,
+                deviceSecret: DEVICE_SECRET,
+                channelName: 'bad-perms',
+                allowedEntities: [{ entity_id: 0, permissions: ['fly'] }] // invalid
+            });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/unknown permission/i);
+    });
+
+    it('returns 401 without credentials', async () => {
+        const res = await post('/api/channel/registrations').send({});
+        expect(res.status).toBe(401);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// 9. GET /api/channel/registrations — lists active registrations
+// ════════════════════════════════════════════════════════════════
+describe('GET /api/channel/registrations', () => {
+    it('returns empty list when no registrations', async () => {
+        dbMock._mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+        const res = await get('/api/channel/registrations')
+            .query({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(Array.isArray(res.body.registrations)).toBe(true);
+        expect(res.body.registrations).toHaveLength(0);
+    });
+
+    it('returns list with registration entries', async () => {
+        dbMock._mockPool.query.mockResolvedValueOnce({
+            rows: [{
+                id: 1,
+                channel_name: 'claude-bridge',
+                allowed_entities: [{ entity_id: 0, permissions: ['speak'] }],
+                created_at: new Date().toISOString(),
+                last_seen_at: null
+            }],
+            rowCount: 1
+        });
+
+        const res = await get('/api/channel/registrations')
+            .query({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET });
+        expect(res.status).toBe(200);
+        expect(res.body.registrations).toHaveLength(1);
+        expect(res.body.registrations[0].channelName).toBe('claude-bridge');
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// 10. PATCH /api/channel/registrations/:name — updates ACL
+// ════════════════════════════════════════════════════════════════
+describe('PATCH /api/channel/registrations/:name', () => {
+    it('updates ACL and returns updated allowedEntities', async () => {
+        dbMock._mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 1 }); // UPDATE
+
+        const res = await patch('/api/channel/registrations/my-bridge')
+            .send({
+                deviceId: DEVICE_ID,
+                deviceSecret: DEVICE_SECRET,
+                allowedEntities: [{ entity_id: 0, permissions: ['speak'] }]
+            });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.allowedEntities).toHaveLength(1);
+    });
+
+    it('returns 404 when registration not found', async () => {
+        dbMock._mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 }); // UPDATE → no match
+
+        const res = await patch('/api/channel/registrations/nonexistent')
+            .send({
+                deviceId: DEVICE_ID,
+                deviceSecret: DEVICE_SECRET,
+                allowedEntities: []
+            });
+        expect(res.status).toBe(404);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// 11. DELETE /api/channel/registrations/:name — revokes channel
+// ════════════════════════════════════════════════════════════════
+describe('DELETE /api/channel/registrations/:name', () => {
+    it('revokes registration', async () => {
+        dbMock._mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 1 });
+
+        const res = await del('/api/channel/registrations/to-revoke')
+            .send({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.revokedAt).toBeDefined();
+    });
+
+    it('returns 404 when registration already revoked', async () => {
+        dbMock._mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+        const res = await del('/api/channel/registrations/already-gone')
+            .send({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET });
+        expect(res.status).toBe(404);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// 12. POST /api/channel/registrations/:name/rotate-key
+// ════════════════════════════════════════════════════════════════
+describe('POST /api/channel/registrations/:name/rotate-key', () => {
+    it('returns a new channelKey', async () => {
+        dbMock._mockPool.query.mockResolvedValueOnce({ rows: [{ id: 1 }], rowCount: 1 });
+
+        const res = await post('/api/channel/registrations/my-bridge/rotate-key')
+            .send({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.channelKey).toBeDefined();
+        expect(typeof res.body.channelKey).toBe('string');
+        expect(res.body.channelKey.length).toBeGreaterThan(32);
+    });
+
+    it('returns 404 when registration not found', async () => {
+        dbMock._mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+
+        const res = await post('/api/channel/registrations/nonexistent/rotate-key')
+            .send({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET });
+        expect(res.status).toBe(404);
+    });
+});


### PR DESCRIPTION
## Code review — feat/transform-channel-key-auth

### Core
- A1. Logic trace: `X-Channel-Key + actAs:"channel"` → `verifyChannelKey()` (bcrypt SELECT loop) → entity ACL check → speak/state/broadcast permission gates → transform runs normally; `botSecret` path unchanged; both present → 400 early-exit; neither present → 400 unchanged.
- A2. Test coverage: `transform-channel-key-auth.test.js` — 22 tests, all green. Covers mutual exclusion, valid channel key 200, ACL 403, chatSource purity, speak/state permission 403, botSecret regression 200, rotate-key invalidation, CRUD (POST/GET/PATCH/DELETE/rotate-key) for registrations. Full 2585-test suite green (170 suites).
- A3. Return shape: all new endpoints return `{ success: true/false, ... }`. Error paths return `{ success: false, message, code? }`. Status codes: 400 input, 401 auth, 403 permission/ACL, 404 not found, 409 conflict, 201 create.
- A4. What this does NOT fix: a2a permission (accepted in schema, not yet enforced on queue behavior — Phase 2 scope); broadcast @all second-pass permission check is enforced but the main broadcast delivery path is Phase 1 full-open; channel registration does not yet support per-entity allowed_entities wildcard.
- A5. Security: bcrypt (12 rounds prod, 1 round in tests) for key storage — never stored in plain. `deviceSecret` verified on all 5 registration management endpoints. `X-Channel-Key` header never logged. Input validated: channelName, allowedEntities structure, permission enum against `VALID_PERMISSIONS` set. No value leakage in error responses.

### Extended
- B1. /api/help: ⚠️ NO-OP — `/api/channel/registrations` endpoints are admin/bridge-operator tools, not bot-facing; bot skill template sync deferred to Phase 2 when endpoints are stable.
- B2. Related docs: `auth_schema.sql` updated with schema comments; `CLAUDE.md` architecture section will be updated in companion kanban card.
- B3. i18n: ⚠️ NO-OP — pure backend, no user-facing strings.
- B4. Info/promo page: ⚠️ NO-OP — channel key auth is a developer/bridge feature, not end-user-facing.
- B5. Debug endpoint: ⚠️ NO-OP — `channel_registrations` table is owner-auth-gated via `GET /api/channel/registrations`; a dedicated `/api/debug/channel-registrations` is deferred to Phase 2 when production incidents are more likely.

Result: merge-ready