### PR TITLE
fix(kanban): guard auto-review during progress heartbeats

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1082,6 +1082,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | gRPC Transport | `node backend/tests/test-grpc-transport.js` | None (local) | Proto loading, gRPC server, HealthService |
 | ENV Vars Merge | `node backend/tests/test-vars-merge.js` | Device ID + Secret | Cross-platform merge, conflict splitting |
 | Channel API | `node backend/tests/test-channel-api.js` | Device ID + Secret | OpenClaw channel integration |
+| Kanban auto-review busy-state guard | `cd backend && npx jest tests/jest/kanban-autoreview-busy-state-guard.test.js --runInBand` | None | Regression: BUSY/PROCESSING/WORKING progress heartbeats must not auto-close kanban child cards before work completes |
 | Skill Templates | `node backend/tests/test-skill-templates.js` | None | Skill template CRUD, requiredVars format validation (Gson compat), contribute endpoint input guard |
 | WebSocket Auth | `node backend/tests/test-ws-auth.js` | Device ID + Secret | Socket.IO authentication |
 | AI Chat Image | `node backend/tests/test-ai-chat-image.js` | Device ID + Secret | AI chat with image support |

--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -892,8 +892,11 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
 
             serverLog('info', 'transform', `${state || entity.state}: ${(message || '').slice(0, 100)}`, { deviceId, entityId: eId, metadata: { state: state || entity.state, via: 'channel' } });
 
-            // Auto-move kanban child cards to done (same as /api/transform)
-            if (state !== 'BUSY' && message && kanbanAutoReview) {
+            // Auto-move kanban child cards to done (same as /api/transform).
+            // START/progress heartbeats must use BUSY/PROCESSING/WORKING without closing cards.
+            const kanbanBusyStates = new Set(['BUSY', 'PROCESSING', 'WORKING', 'IN_PROGRESS', 'IN-PROGRESS']);
+            const isKanbanBusyState = kanbanBusyStates.has(String(state || '').trim().toUpperCase());
+            if (!isKanbanBusyState && message && kanbanAutoReview) {
                 kanbanAutoReview(deviceId, eId, message).catch(err => {
                     console.error(`[Channel] autoReviewOnTransform failed:`, err.message);
                 });

--- a/backend/index.js
+++ b/backend/index.js
@@ -7067,10 +7067,14 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
         }
     }
 
-    // Auto-move child cards to review when bot replies (any non-BUSY state with a message)
-    // Previously required state === 'IDLE', but some bots don't send state explicitly
-    // Skip for leased_out entities — rental bot responses belong to the renter's context
-    if (state !== 'BUSY' && finalMessage && entity.rental_status !== 'leased_out' && kanbanModule && kanbanModule.autoReviewOnTransform) {
+    // Auto-move child cards to review only when bot replies from a completion/non-busy state.
+    // START/progress heartbeats must use BUSY/PROCESSING/WORKING without closing cards.
+    // Previously this checked only state !== 'BUSY', so PROCESSING/WORKING heartbeats could
+    // silently false-close cron child cards before the audit actually ran (card_8e5d242...).
+    // Skip for leased_out entities — rental bot responses belong to the renter's context.
+    const kanbanBusyStates = new Set(['BUSY', 'PROCESSING', 'WORKING', 'IN_PROGRESS', 'IN-PROGRESS']);
+    const isKanbanBusyState = kanbanBusyStates.has(String(state || '').trim().toUpperCase());
+    if (!isKanbanBusyState && finalMessage && entity.rental_status !== 'leased_out' && kanbanModule && kanbanModule.autoReviewOnTransform) {
         kanbanModule.autoReviewOnTransform(deviceId, eId, finalMessage, aboutCardId).catch(err => {
             console.error(`[Transform] autoReviewOnTransform failed:`, err.message);
         });

--- a/backend/tests/jest/kanban-autoreview-busy-state-guard.test.js
+++ b/backend/tests/jest/kanban-autoreview-busy-state-guard.test.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const indexSrc = fs.readFileSync(path.join(ROOT, 'index.js'), 'utf8');
+const channelSrc = fs.readFileSync(path.join(ROOT, 'channel-api.js'), 'utf8');
+
+function expectBusyGuard(src) {
+    expect(src).toMatch(/kanbanBusyStates\s*=\s*new Set\(\[([^\]]+)/);
+    expect(src).toMatch(/'BUSY'/);
+    expect(src).toMatch(/'PROCESSING'/);
+    expect(src).toMatch(/'WORKING'/);
+    expect(src).toMatch(/String\(state \|\| ''\)\.trim\(\)\.toUpperCase\(\)/);
+    expect(src).toMatch(/!isKanbanBusyState[\s\S]*autoReviewOnTransform|!isKanbanBusyState[\s\S]*kanbanAutoReview/);
+}
+
+describe('kanban auto-review busy-state guard', () => {
+    test('/api/transform does not auto-close cards for BUSY/PROCESSING/WORKING progress heartbeats', () => {
+        expectBusyGuard(indexSrc);
+        expect(indexSrc).not.toMatch(/state !== 'BUSY' && finalMessage[\s\S]*autoReviewOnTransform/);
+    });
+
+    test('channel transform mirrors the same busy-state guard', () => {
+        expectBusyGuard(channelSrc);
+        expect(channelSrc).not.toMatch(/state !== 'BUSY' && message[\s\S]*kanbanAutoReview/);
+    });
+});


### PR DESCRIPTION
## Summary
- Prevent kanban auto-review false-close on START/progress heartbeats by treating `BUSY`, `PROCESSING`, `WORKING`, `IN_PROGRESS`, and `IN-PROGRESS` as active states.
- Apply the same guard to `/api/transform` and channel transform flows.
- Add Jest regression coverage and register it in `AGENTS.md`.

## Linked cards
- Fix card: `card_0c682946bc741cbf9b050089`
- False-closed audit card: `card_8e5d24232a067d8194d2047f`
- Placeholder audit trail: `card_26ab61f166713e23a12bfb1b`

## Backfill
- Backfilled the missed 2026-05-04 14:28 PR Auto-Review on `card_8e5d24232a067d8194d2047f`.
- Detected PR #2401 (`627ab309`) in the intended window.
- Backend changes had corresponding Jest coverage (`backend/tests/jest/transform-channel-key-auth.test.js`).
- CI ESLint/Jest for #2401 were green; no test coverage comment needed.

## Verification
- `node --check backend/index.js`
- `node --check backend/channel-api.js`
- `cd backend && npx jest tests/jest/kanban-autoreview-busy-state-guard.test.js tests/jest/kanban-autoreview-cardid-guard.test.js --runInBand`

Note: I also attempted `transform-channel-key-auth.test.js` locally for backfill context, but this worktree lacks local `pg`; #2401 GitHub CI already passed that test/check set.
