### PR TITLE
fix(growth): count invite redemptions from invite_codes (live table)

### DIFF
--- a/backend/growth.js
+++ b/backend/growth.js
@@ -121,14 +121,18 @@ async function fetchPlazaNewListedForDate(dateStr) {
 }
 
 async function fetchInviteConversion() {
-    // Phase-5 viral-loop conversion: distinct codes with at least one redemption
-    // row in invite_redemptions, divided by total codes issued. Using the
-    // redemptions table (not invite_codes.used_at / use_count) because two
-    // competing invite_codes schemas exist in the repo — redemptions is the
-    // canonical Phase-5 source and is unambiguous.
+    // Viral-loop conversion: count from invite_codes directly because the live
+    // POST /api/invite/redeem endpoint (index.js) writes to
+    // invite_codes.used_by_device_id + used_at and never touches the Phase-5
+    // invite_redemptions table (whose router in backend/invite.js is not
+    // mounted as of 2026-04-20). Counting from invite_redemptions previously
+    // pinned this metric at 0 indefinitely. When the Phase-5 router lands
+    // and dual-writes to both tables, this query stays correct as long as
+    // used_by_device_id is also populated.
     const r = await pool.query(
-        `SELECT (SELECT COUNT(*)::int FROM invite_codes) AS total_codes,
-                (SELECT COUNT(DISTINCT code)::int FROM invite_redemptions) AS redeemed_codes`
+        `SELECT COUNT(*)::int AS total_codes,
+                COUNT(*) FILTER (WHERE used_by_device_id IS NOT NULL)::int AS redeemed_codes
+         FROM invite_codes`
     );
     const { total_codes, redeemed_codes } = r.rows[0];
     if (total_codes === 0) return { total_codes: 0, redeemed_codes: 0, pct: null };
@@ -196,7 +200,7 @@ module.exports = function(devices) {
                     'source_channel: schema lacks signup_source column',
                     'visitor_to_signup_conversion: page_views has no FK to user_accounts',
                     'plaza_new_listed_today: counts created_at not status_changed_at (bot_listings has no listed_at column)',
-                    'invite_conversion is cumulative-to-now (not date-scoped); needs invite_redemptions.redeemed_at filter for historical k-value by day'
+                    'invite_conversion is cumulative-to-now (not date-scoped); needs invite_codes.used_at filter for historical k-value by day'
                 ]
             });
         } catch (err) {

--- a/backend/tests/jest/growth.test.js
+++ b/backend/tests/jest/growth.test.js
@@ -130,6 +130,17 @@ describe('Growth /daily aggregation contract', () => {
         expect(res.body.invite_conversion.pct).toBe(33.3);
     });
 
+    it('invite_conversion SQL targets invite_codes (live table), not Phase-5 invite_redemptions', async () => {
+        setupAdminQueries({ total_codes: 5, redeemed_codes: 2 });
+        await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2');
+        const inviteCall = mockQuery.mock.calls.find(c => /total_codes/i.test(c[0]) && /redeemed_codes/i.test(c[0]));
+        expect(inviteCall).toBeDefined();
+        const sql = inviteCall[0];
+        expect(sql).toMatch(/FROM\s+invite_codes\b/i);
+        expect(sql).toMatch(/used_by_device_id/);
+        expect(sql).not.toMatch(/invite_redemptions/);
+    });
+
     it('never leaks PII fields (id/email/ip/device_id) in response', async () => {
         setupAdminQueries({ signups: 1, cohort: 1, active: 1, plaza: 1 });
         const res = await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2');


### PR DESCRIPTION
## Summary
- `GET /api/growth/daily` was reporting `invite_conversion = 0` indefinitely (e.g. 0/18) even after real redemptions on prod.
- Root cause: `fetchInviteConversion` counted from `invite_redemptions`, but the **live** `POST /api/invite/redeem` (backend/index.js) writes to `invite_codes.used_by_device_id + used_at` and never touches `invite_redemptions`. The Phase-5 router in `backend/invite.js` (which would populate `invite_redemptions`) is documented as **not mounted** as of 2026-04-20 — so that table is empty in prod.
- Fix: single `COUNT(*) FILTER (WHERE used_by_device_id IS NOT NULL) FROM invite_codes` scan. Forward-compatible with Phase-5 dual-write.

## Why two invite tables?
- `invite_codes` (auth_schema.sql) — device-auth flow, owned by index.js, **populated**
- `invite_redemptions` (Phase-5 user-auth flow, backend/invite.js router unmounted) — **empty**
- `growth.js` was reading the empty one. That's it.

## Risk
- Read-only analytics endpoint, mock-isolated tests still green (24/24).
- No schema change, no behaviour change for the `/redeem` write path.

## Test plan
- [x] `npx jest backend/tests/jest/growth.test.js` — 24 passing including new regression test
- [x] New test asserts SQL targets `invite_codes` + `used_by_device_id` and **does not** mention `invite_redemptions`
- [ ] Post-merge: hit `GET /api/growth/daily` on prod and confirm `invite_conversion.redeemed_codes > 0` (was stuck at 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)