### PR TITLE
fix(kanban): require aboutCardId for auto-close (IDLE-content false-close fix)

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -2626,39 +2626,29 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
      */
     async function autoReviewOnTransform(deviceId, entityId, transformMessage, aboutCardId) {
         try {
-            // Find active cards assigned to this entity that are in todo/in_progress
-            // Supports both auto-generated child cards AND manually created cards with reviewer
-            let result;
-            if (aboutCardId) {
-                result = await pool.query(
-                    `SELECT c.id, c.title, c.status, c.parent_card_id, c.assigned_bots, c.reviewer_entity_id, c.requires_screenshot_review
-                     FROM kanban_cards c
-                     WHERE c.id = $1
-                       AND c.device_id = $2
-                       AND (c.is_auto_generated = true OR c.reviewer_entity_id IS NOT NULL)
-                       AND c.archived = false
-                       AND c.status IN ('todo', 'in_progress')
-                       AND c.assigned_bots::jsonb @> $3::jsonb`,
-                    [aboutCardId, deviceId, JSON.stringify([entityId])]
-                );
-            } else {
-                result = await pool.query(
-                    `SELECT c.id, c.title, c.status, c.parent_card_id, c.assigned_bots, c.reviewer_entity_id, c.requires_screenshot_review
-                     FROM kanban_cards c
-                     WHERE c.device_id = $1
-                       AND (c.is_auto_generated = true OR c.reviewer_entity_id IS NOT NULL)
-                       AND c.archived = false
-                       AND c.status IN ('todo', 'in_progress')
-                       AND c.assigned_bots::jsonb @> $2::jsonb`,
-                    [deviceId, JSON.stringify([entityId])]
-                );
-                // Without an explicit aboutCardId, refuse to batch-close: only proceed
-                // when exactly one card is eligible (the unambiguous in-flight target).
-                if (result.rows.length > 1) {
-                    console.warn(`[Kanban] autoReviewOnTransform skipped: ${result.rows.length} eligible cards for entity ${entityId} but no aboutCardId in transform body — pass {aboutCardId:"card_..."} to auto-close a specific card`);
-                    return;
-                }
+            // aboutCardId is now required. Without it, we skip entirely — the
+            // previous "exactly one eligible card" fallback would close cards
+            // whose title had nothing to do with the IDLE message content
+            // (e.g. a bot reporting completion of task X while only task Y was
+            // eligible for auto-close on its board would close Y by mistake).
+            // See card_393752f8 / card_819d50f1 RCA for a real instance.
+            if (!aboutCardId) {
+                console.warn(`[Kanban] autoReviewOnTransform skipped: no aboutCardId provided by entity ${entityId} — pass {aboutCardId:"card_..."} in transform body to auto-close a specific card`);
+                return;
             }
+            // Find active card assigned to this entity that is in todo/in_progress.
+            // Supports both auto-generated child cards AND manually created cards with reviewer.
+            const result = await pool.query(
+                `SELECT c.id, c.title, c.status, c.parent_card_id, c.assigned_bots, c.reviewer_entity_id, c.requires_screenshot_review
+                 FROM kanban_cards c
+                 WHERE c.id = $1
+                   AND c.device_id = $2
+                   AND (c.is_auto_generated = true OR c.reviewer_entity_id IS NOT NULL)
+                   AND c.archived = false
+                   AND c.status IN ('todo', 'in_progress')
+                   AND c.assigned_bots::jsonb @> $3::jsonb`,
+                [aboutCardId, deviceId, JSON.stringify([entityId])]
+            );
 
             if (result.rows.length === 0) return;
 

--- a/backend/tests/jest/kanban-autoreview-cardid-guard.test.js
+++ b/backend/tests/jest/kanban-autoreview-cardid-guard.test.js
@@ -28,32 +28,26 @@ describe('autoReviewOnTransform — cardId guard against false batch-close', () 
         expect(kanbanSrc).toContain(sig);
     });
 
-    test('targeted branch filters SELECT by c.id when aboutCardId is provided', () => {
-        expect(body).toMatch(/if\s*\(\s*aboutCardId\s*\)\s*{[\s\S]*?WHERE c\.id = \$1[\s\S]*?AND c\.device_id = \$2[\s\S]*?AND c\.assigned_bots::jsonb @> \$3::jsonb/);
+    test('SELECT filters by c.id and ties query to aboutCardId', () => {
+        expect(body).toMatch(/WHERE c\.id = \$1[\s\S]*?AND c\.device_id = \$2[\s\S]*?AND c\.assigned_bots::jsonb @> \$3::jsonb/);
     });
 
-    test('untargeted branch refuses to batch-close when more than one card matches', () => {
-        expect(body).toMatch(/result\.rows\.length\s*>\s*1[\s\S]*?return/);
-        expect(body).toMatch(/autoReviewOnTransform skipped/);
+    test('skips entirely when aboutCardId is missing — no IDLE-content fallback close', () => {
+        expect(body).toMatch(/if\s*\(\s*!\s*aboutCardId\s*\)\s*{[\s\S]*?autoReviewOnTransform skipped[\s\S]*?return/);
     });
 
-    test('untargeted branch still proceeds when exactly one card matches', () => {
-        expect(body).toMatch(/if\s*\(\s*result\.rows\.length === 0\s*\)\s*return/);
+    test('does not contain the legacy "exactly one eligible card" untargeted branch', () => {
+        expect(body).not.toMatch(/result\.rows\.length\s*>\s*1/);
+        expect(body).not.toMatch(/}\s*else\s*{[\s\S]*?WHERE c\.device_id = \$1/);
     });
 
-    test('eligibility filter (auto-generated OR reviewer-tagged + active status) is preserved on both branches', () => {
-        const targeted = body.match(/if\s*\(\s*aboutCardId\s*\)\s*{[\s\S]*?\)\s*;/);
-        const fallback = body.match(/}\s*else\s*{[\s\S]*?if\s*\(\s*result\.rows\.length\s*>\s*1\s*\)/);
-        expect(targeted).not.toBeNull();
-        expect(fallback).not.toBeNull();
-        for (const slice of [targeted[0], fallback[0]]) {
-            expect(slice).toMatch(/is_auto_generated = true OR .*reviewer_entity_id IS NOT NULL/);
-            expect(slice).toMatch(/status IN \('todo', 'in_progress'\)/);
-            expect(slice).toMatch(/archived = false/);
-        }
+    test('eligibility filter (auto-generated OR reviewer-tagged + active status) is intact', () => {
+        expect(body).toMatch(/is_auto_generated = true OR .*reviewer_entity_id IS NOT NULL/);
+        expect(body).toMatch(/status IN \('todo', 'in_progress'\)/);
+        expect(body).toMatch(/archived = false/);
     });
 
-    test('screenshot-review gate at line ~2557 is still in place after refactor', () => {
+    test('screenshot-review gate is still in place after refactor', () => {
         expect(body).toMatch(/requires_screenshot_review !== false/);
         expect(body).toMatch(/Auto-close blocked by screenshot gate/);
     });


### PR DESCRIPTION
## Summary
- IDLE chat from a bot was closing one of that bot's eligible in_progress cards even when the chat content was about something else entirely. Real instance: card_819d50f1 (47 sub-item slides, 0 PRs / 0 commits) was closed because its owner #6 sent an unrelated IDLE status update.
- Fix: in \`autoReviewOnTransform\`, require \`aboutCardId\`. If absent, log and skip.
- Related: PR #2403 took the same closed-by-default approach for the BUSY heartbeat path.

## Why the previous "exactly one eligible" guard wasn't enough
- The earlier fix (post-card_5b6654e6) refused to close when more than one card was eligible. That stops batch-close, not single-card mistakes.
- If the bot has exactly one eligible in_progress card and sends an IDLE chat about anything (a consultation, a report on another card, a status update), that one card still closes.

## Sender-side context
- Codex (#6) already committed (in card_393752f8 comments) to binding \`aboutCardId\` on every auto-cron message.
- Mac_F (#1) endorsed Option A (strict required-field) over heuristic content matching after I consulted him.

## Risk
- Bots that don't pass \`aboutCardId\` lose implicit auto-close; they'll need to call \`/move\` themselves or pass the card id. This is the intended behaviour.
- All trained LOBSTER-ecosystem bots are already prompted to send \`aboutCardId\`. Hermes daemon is the one I haven't verified — I'll broadcast post-merge.

## Test plan
- [x] \`npx jest tests/jest/kanban-autoreview-cardid-guard.test.js\` — 8 passing (updated assertions: skip when no aboutCardId, no legacy untargeted branch)
- [x] Full backend jest suite: 171 suites / 2588 tests passing
- [ ] Post-merge: monitor for one week, confirm no false-closes; broadcast to member entities to confirm their auto-cron jobs pass \`aboutCardId\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)