### PR TITLE
Hermes file edit: broadcast-from-entity-2-lobster

### DIFF
--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -616,7 +616,7 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
     // ============================================
     router.post('/message', async (req, res) => {
         try {
-            const { channel_api_key, deviceId, entityId, botSecret, message, state, mediaType, mediaUrl, targetDeviceId, card, senderHint } = req.body;
+            const { channel_api_key, deviceId, entityId, botSecret, message, state, mediaType, mediaUrl, targetDeviceId, card, senderHint, aboutCardId } = req.body;
             let { speakTo, broadcast } = req.body;
 
             if (process.env.DEBUG === 'true') serverLog('info', 'client_push', `[PUSH] /channel/message called, state=${state}, hasMsg=${!!message}`, { deviceId, entityId: entityId !== undefined ? parseInt(entityId) : 'auto' });
@@ -897,7 +897,7 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             const kanbanBusyStates = new Set(['BUSY', 'PROCESSING', 'WORKING', 'IN_PROGRESS', 'IN-PROGRESS']);
             const isKanbanBusyState = kanbanBusyStates.has(String(state || '').trim().toUpperCase());
             if (!isKanbanBusyState && message && kanbanAutoReview) {
-                kanbanAutoReview(deviceId, eId, message).catch(err => {
+                kanbanAutoReview(deviceId, eId, message, aboutCardId).catch(err => {
                     console.error(`[Channel] autoReviewOnTransform failed:`, err.message);
                 });
             }

--- a/backend/tests/jest/kanban-autoreview-cardid-guard.test.js
+++ b/backend/tests/jest/kanban-autoreview-cardid-guard.test.js
@@ -6,6 +6,7 @@ const path = require('path');
 const ROOT = path.join(__dirname, '..', '..');
 const kanbanSrc = fs.readFileSync(path.join(ROOT, 'kanban.js'), 'utf8');
 const indexSrc = fs.readFileSync(path.join(ROOT, 'index.js'), 'utf8');
+const channelApiSrc = fs.readFileSync(path.join(ROOT, 'channel-api.js'), 'utf8');
 
 function extractFunctionBody(src, signature) {
     const start = src.indexOf(signature);
@@ -60,5 +61,18 @@ describe('transform handler — wires aboutCardId through to autoReviewOnTransfo
 
     test('autoReviewOnTransform call passes aboutCardId as 4th argument', () => {
         expect(indexSrc).toMatch(/autoReviewOnTransform\(deviceId,\s*eId,\s*finalMessage,\s*aboutCardId\)/);
+    });
+});
+
+describe('channel-api — wires aboutCardId through to kanbanAutoReview', () => {
+    test('POST /channel/message destructure includes aboutCardId from req.body', () => {
+        // Match the destructuring line in the /channel/message handler
+        expect(channelApiSrc).toMatch(/const\s*\{[^}]*\baboutCardId\b[^}]*\}\s*=\s*req\.body/);
+    });
+
+    test('kanbanAutoReview call in channel transform passes aboutCardId as 4th argument', () => {
+        // The kanbanAutoReview call inside the channel transform handler
+        // (after kanbanBusyStates check) should pass aboutCardId
+        expect(channelApiSrc).toMatch(/kanbanAutoReview\(deviceId,\s*eId,\s*message,\s*aboutCardId\)/);
     });
 });


### PR DESCRIPTION
Automated Hermes PR-only file-edit flow.

- Source: hermes-daemon PR-only clone workspace
- Branch created by daemon; review/merge handled by LOBSTER/Hank policy
- Token values are never printed in logs

Hermes reply:
完成。以下是變更摘要：
修改了 2 個檔案：
backend/channel-api.js
Line 619 — 在 /channel/message handler 的 request body 解構式中加入
aboutCardId：
js
// 改前
const { channelapikey, deviceId, entityId, botSecret, message, state,
... } = req.body;
// 改後
const { channelapikey, deviceId, entityId, botSecret, message, state,
..., aboutCardId } = req.body;
Line 900 — 將 aboutCardId 傳給 kanbanAutoReview（與 /api/transform
行為一致）：
js
// 改前
kanbanAutoReview(deviceId, eId, message).catch(...)
// 改後
kanbanAutoReview(deviceId, eId, message, aboutCardId).catch(...)
backend/tests/jest/kanban-autoreview-cardid-guard.test.js
新增 2 個測試，確保 channel-api.js 正確將 aboutCardId 傳遞給
kanbanAutoReview。
受影響範圍：
當 entity（包含 Hermes entity5）的 auto-cron 發送完工 IDLE transform
時：
- 舊行為：channel path 完全忽略 aboutCardId，可能誤觸 legacy
邏輯導致錯誤關卡
- 新行為：channel path 與 /api/transform 一致，精確關閉 aboutCardId
指定的卡
廣播要求 Hank 整合回報：✅ 已經修復 channel-api.js 的 aboutCardId
傳遞問題。實體的 scheduled/cron tasks 無需修改 server 端，只要在
transform body 裡帶 aboutCardId:"card<id>" 就會精確關卡。