### PR TITLE
fix(i18n): zh-TW / zh-CN fall back to canonical zh dict before en

### DIFF
--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -61815,7 +61815,18 @@ class I18n {
 
     t(key, params = {}) {
         const dict = TRANSLATIONS[this.lang] || TRANSLATIONS['en'];
-        let str = dict[key] || TRANSLATIONS['en'][key] || key;
+        let str = dict[key];
+        if (str === undefined) {
+            // zh-TW / zh-CN fall back to `zh` (Traditional Chinese canonical
+            // dict) before en. Without this, browsers reporting `zh-TW` exact-
+            // match the 8-key publisher-guide stub and see English for the
+            // other ~4875 keys.
+            if ((this.lang === 'zh-TW' || this.lang === 'zh-CN') && TRANSLATIONS['zh']) {
+                str = TRANSLATIONS['zh'][key];
+            }
+            if (str === undefined) str = TRANSLATIONS['en'][key];
+            if (str === undefined) str = key;
+        }
 
         // Simple parameter replacement {name}
         Object.keys(params).forEach(k => {

--- a/backend/tests/jest/i18n-fallback-chain.test.js
+++ b/backend/tests/jest/i18n-fallback-chain.test.js
@@ -1,0 +1,140 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const I18N_FILE = path.join(__dirname, '..', '..', 'public', 'shared', 'i18n.js');
+
+function loadI18n() {
+    const src = fs.readFileSync(I18N_FILE, 'utf8');
+    const noop = () => {};
+    const sandbox = {
+        _result: null,
+        _I18nClass: null,
+        localStorage: { getItem: () => null, setItem: noop },
+        navigator: { language: 'en' },
+        document: { querySelectorAll: () => [], documentElement: { lang: 'en' }, addEventListener: noop, getElementById: () => null },
+        window: { location: { search: '' } },
+        setTimeout: noop,
+        console: { log: noop, warn: noop, error: noop }
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(src + '\n_result = TRANSLATIONS;\n_I18nClass = I18n;', sandbox, { timeout: 5000 });
+    return { TRANSLATIONS: sandbox._result, I18n: sandbox._I18nClass };
+}
+
+describe('i18n.t() — zh-TW / zh-CN → zh fallback chain', () => {
+    let TRANSLATIONS, I18n;
+    beforeAll(() => {
+        ({ TRANSLATIONS, I18n } = loadI18n());
+    });
+
+    test('TRANSLATIONS.zh exists and is the canonical Traditional Chinese dict', () => {
+        expect(TRANSLATIONS.zh).toBeDefined();
+        expect(typeof TRANSLATIONS.zh).toBe('object');
+        expect(Object.keys(TRANSLATIONS.zh).length).toBeGreaterThan(1000);
+    });
+
+    test('TRANSLATIONS["zh-TW"] is a small override stub (publisher-guide-only)', () => {
+        expect(TRANSLATIONS['zh-TW']).toBeDefined();
+        const zhTwKeys = Object.keys(TRANSLATIONS['zh-TW']);
+        // Stub by design — small handful of publisher-guide overrides.
+        expect(zhTwKeys.length).toBeLessThan(50);
+        expect(zhTwKeys.length).toBeGreaterThan(0);
+    });
+
+    test('zh-TW lang resolves a key present in zh (not present in zh-TW stub)', () => {
+        // Pick a key that exists in zh but NOT in the zh-TW stub.
+        const zhKeys = Object.keys(TRANSLATIONS.zh);
+        const zhTwSet = new Set(Object.keys(TRANSLATIONS['zh-TW']));
+        // Require zh value to actually differ from en — many brand-name keys
+        // are intentionally identical (e.g. "EClawbot Mission Control"); those
+        // can't prove the fallback path was taken.
+        const fallbackKey = zhKeys.find(k => !zhTwSet.has(k) && TRANSLATIONS.zh[k] && TRANSLATIONS.en[k] && TRANSLATIONS.zh[k] !== TRANSLATIONS.en[k]);
+        expect(fallbackKey).toBeDefined();
+
+        const i18n = new I18n();
+        i18n.lang = 'zh-TW';
+        const out = i18n.t(fallbackKey);
+        expect(out).toBe(TRANSLATIONS.zh[fallbackKey]);
+        expect(out).not.toBe(TRANSLATIONS.en[fallbackKey]);
+    });
+
+    test('zh-TW lang STILL prefers stub override when key exists in stub', () => {
+        const stubKeys = Object.keys(TRANSLATIONS['zh-TW']);
+        expect(stubKeys.length).toBeGreaterThan(0);
+        const k = stubKeys[0];
+
+        const i18n = new I18n();
+        i18n.lang = 'zh-TW';
+        const out = i18n.t(k);
+        expect(out).toBe(TRANSLATIONS['zh-TW'][k]);
+    });
+
+    test('zh-CN lang falls back through zh before en', () => {
+        // Find a key absent from zh-CN but present in zh and en.
+        const zhCnSet = new Set(Object.keys(TRANSLATIONS['zh-CN']));
+        const zhKeys = Object.keys(TRANSLATIONS.zh);
+        const fallbackKey = zhKeys.find(k => !zhCnSet.has(k) && TRANSLATIONS.zh[k] && TRANSLATIONS.en[k] && TRANSLATIONS.zh[k] !== TRANSLATIONS.en[k]);
+        if (!fallbackKey) {
+            // No such key in this snapshot — skip rather than fail (zh-CN may have grown to fully cover zh).
+            return;
+        }
+
+        const i18n = new I18n();
+        i18n.lang = 'zh-CN';
+        const out = i18n.t(fallbackKey);
+        expect(out).toBe(TRANSLATIONS.zh[fallbackKey]);
+    });
+
+    test('keys absent from both zh-TW stub AND zh fall through to en', () => {
+        // Find a key in en but not in zh and not in zh-TW.
+        const enKeys = Object.keys(TRANSLATIONS.en);
+        const zhSet = new Set(Object.keys(TRANSLATIONS.zh));
+        const zhTwSet = new Set(Object.keys(TRANSLATIONS['zh-TW']));
+        const enOnly = enKeys.find(k => !zhSet.has(k) && !zhTwSet.has(k));
+        if (!enOnly) return;
+
+        const i18n = new I18n();
+        i18n.lang = 'zh-TW';
+        const out = i18n.t(enOnly);
+        expect(out).toBe(TRANSLATIONS.en[enOnly]);
+    });
+
+    test('non-Chinese locales unaffected by the zh fallback (e.g. ja key missing → en, NOT zh)', () => {
+        const enKeys = Object.keys(TRANSLATIONS.en);
+        const jaSet = new Set(Object.keys(TRANSLATIONS.ja || {}));
+        const zhSet = new Set(Object.keys(TRANSLATIONS.zh));
+        const k = enKeys.find(x => !jaSet.has(x) && zhSet.has(x) && TRANSLATIONS.zh[x] !== TRANSLATIONS.en[x]);
+        if (!k) return;
+
+        const i18n = new I18n();
+        i18n.lang = 'ja';
+        const out = i18n.t(k);
+        expect(out).toBe(TRANSLATIONS.en[k]);
+        expect(out).not.toBe(TRANSLATIONS.zh[k]);
+    });
+
+    test('unknown key returns the key itself (last-resort fallback preserved)', () => {
+        const i18n = new I18n();
+        i18n.lang = 'zh-TW';
+        const bogus = '__no_such_key_zzz_' + Date.now();
+        expect(i18n.t(bogus)).toBe(bogus);
+    });
+
+    test('parameter replacement still works through the fallback path', () => {
+        // Find a zh key with {param} placeholder that's not in zh-TW stub.
+        const zhKeys = Object.keys(TRANSLATIONS.zh);
+        const zhTwSet = new Set(Object.keys(TRANSLATIONS['zh-TW']));
+        const paramKey = zhKeys.find(k => !zhTwSet.has(k) && /\{[a-zA-Z_]+\}/.test(TRANSLATIONS.zh[k] || ''));
+        if (!paramKey) return;
+
+        const placeholder = TRANSLATIONS.zh[paramKey].match(/\{([a-zA-Z_]+)\}/)[1];
+        const i18n = new I18n();
+        i18n.lang = 'zh-TW';
+        const out = i18n.t(paramKey, { [placeholder]: 'XYZ' });
+        expect(out).toContain('XYZ');
+        expect(out).not.toContain(`{${placeholder}}`);
+    });
+});


### PR DESCRIPTION
## Summary
- Browsers reporting `navigator.language === \"zh-TW\"` were exact-matching the 8-key publisher-guide stub in `TRANSLATIONS[\"zh-TW\"]`, then falling straight through to `en` for the ~4485 keys not in that stub. Result: Traditional Chinese users saw English for ~99.8% of keys.
- Add a single-step fallback in `i18n.t()`: when lang is `zh-TW` or `zh-CN` and the key is missing, look in `TRANSLATIONS.zh` (the canonical ~4493-key Traditional Chinese dict) before falling to `en`.
- Override semantics preserved: keys present in the zh-TW stub still win.
- Non-Chinese locales unaffected (ja → en, NOT zh).

## Why this approach (Option B, not delete-the-stub)
Mac_F (#1) consultation endorsed Option B over Option A (delete the 8-key stub):
- minimal change vs. potentially-intentional publisher-guide overrides
- preserves override semantics for any future zh-TW-specific copy
- localStorage safety net — users who pinned `zh-TW` keep getting Traditional Chinese without a one-time wipe

## Test plan
- [x] New jest suite `tests/jest/i18n-fallback-chain.test.js` — 9 cases, 9/9 passing
  - TRANSLATIONS.zh exists / zh-TW is small stub
  - zh-TW lang resolves a zh-only key (filtered to keys where `zh != en` so brand-name identity can't false-pass)
  - zh-TW STILL prefers stub override
  - zh-CN falls back through zh before en
  - keys absent from both → en
  - non-Chinese locales unaffected (ja missing key → en, NOT zh)
  - unknown key returns key (last-resort fallback preserved)
  - parameter replacement still works through the fallback
- [x] All other i18n jest suites still green (27/27)
- [x] Full suite: 170/172 (the 2 failures — auth.test.js / friend-system.test.js — are pre-existing flaky port-collision in full-suite runs; both pass when re-run isolated, on this branch and on main)
- [ ] Post-merge: visit eclawbot.com from a `zh-TW` browser and confirm UI renders Traditional Chinese end-to-end

## Notes
- Filed as card_2611ada58 on the kanban board.
- Worktree-built per `feedback_shared_worktree_branch_contamination` (branched from `origin/main`, not local HEAD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)