### PR TITLE
[codex] fix info page public roadmap and markdown links

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -437,6 +437,7 @@ EClaw/
 | Rental contract start returns internal_error during rent/borrow E2E (#2283) | `GET /api/rental/debug/contract-start-fail?deviceId=X&deviceSecret=Y&listingId=Y&renterDeviceId=Z&durationMinutes=30` | 2026-05-01 | Active |
    | Chat first render delayed by cross-device label resolution | `GET /api/debug/chat-render-load-order?deviceId=X&deviceSecret=Y` | 2026-05-01 | Active |
    | Kanban nudges ignored by Codex channel bridge | `GET /api/mission/debug/kanban-codex-nudge?deviceId=X&deviceSecret=Y` | 2026-05-01 | Active |
+   | Info public pages: roadmap redirects unauthenticated visitors + release notes show raw Markdown links | `GET /api/debug/info-public-pages?deviceId=X&deviceSecret=Y` | 2026-05-04 | Active |
 
 6. **Demand Elegance (Balanced)** — 在保持 minimal change 的前提下，追求可讀、一致的程式風格；不為了「漂亮」而過度重構，但也不容忍明顯的 code smell 在新增的程式碼中出現。
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -2321,6 +2321,79 @@ app.get('/api/debug/chat-render-load-order', async (req, res) => {
     }
 });
 
+// Temporary diagnostic endpoint for public Info-page regressions:
+// - roadmap.html must not redirect unauthenticated visitors to index.html
+// - release notes must render Markdown links instead of raw `(https://...)`
+// Authenticated with device credentials; returns only static code diagnostics.
+app.get('/api/debug/info-public-pages', async (req, res) => {
+    const { deviceId, deviceSecret } = req.query || {};
+    const timestamp = new Date().toISOString();
+    try {
+        if (!deviceId || !deviceSecret) {
+            return res.status(401).json({ success: false, bug: 'info-public-pages', error: 'deviceId and deviceSecret required', timestamp });
+        }
+
+        const memDevice = devices[deviceId];
+        const pool = db._getPool ? db._getPool() : authModule.pool;
+        const dbDevice = pool
+            ? await pool.query('SELECT device_secret FROM devices WHERE device_id = $1', [deviceId])
+            : { rows: [] };
+        const dbDeviceRow = dbDevice.rows[0] || null;
+        const memSecretOk = !!(memDevice && memDevice.deviceSecret && safeEqual(memDevice.deviceSecret, deviceSecret));
+        const dbSecretOk = !!(dbDeviceRow && dbDeviceRow.device_secret && safeEqual(dbDeviceRow.device_secret, deviceSecret));
+        if (!memSecretOk && !dbSecretOk) {
+            return res.status(403).json({ success: false, bug: 'info-public-pages', error: 'Invalid credentials', timestamp });
+        }
+
+        const portalDir = path.join(__dirname, 'public', 'portal');
+        const roadmapPath = path.join(portalDir, 'roadmap.html');
+        const infoPath = path.join(portalDir, 'info.html');
+        const infoJsPath = path.join(portalDir, 'shared', 'info.js');
+        const markdownRenderPath = path.join(portalDir, 'shared', 'markdown-render.js');
+
+        const read = (p) => fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : '';
+        const roadmapHtml = read(roadmapPath);
+        const infoHtml = read(infoPath);
+        const infoJs = read(infoJsPath);
+        const markdownRenderJs = read(markdownRenderPath);
+
+        res.json({
+            success: true,
+            bug: 'info-public-pages',
+            diagnostics: {
+                server: {
+                    build: SERVER_BUILD_TAG,
+                    startedAt: SERVER_STARTED_AT.toISOString(),
+                    uptimeSec: Math.round(process.uptime()),
+                },
+                auth: {
+                    memSecretOk,
+                    dbSecretOk,
+                    requestUserDeviceId: req.user?.deviceId || null,
+                    requestUserId: req.user?.userId || null,
+                },
+                roadmapPublicGate: {
+                    fileExists: !!roadmapHtml,
+                    authProbeUsesSkip401Redirect: /apiCall\(\s*['"]GET['"]\s*,\s*['"]\/api\/auth\/me['"]\s*,\s*null\s*,\s*\{[^}]*skip401Redirect\s*:\s*true/.test(roadmapHtml),
+                    includesAuthJs: /shared\/auth\.js/.test(roadmapHtml),
+                },
+                releaseNotesMarkdown: {
+                    infoIncludesMarked: /marked\.min\.js/.test(infoHtml),
+                    infoIncludesDOMPurify: /purify\.min\.js/.test(infoHtml),
+                    infoIncludesMarkdownRenderer: /shared\/markdown-render\.js/.test(infoHtml),
+                    releaseRendererCallsMarkdownHelper: /renderSafeMarkdownInline\(ch\.description\)/.test(infoJs),
+                    markdownRendererFileExists: !!markdownRenderJs,
+                    fallbackHandlesMarkdownLinks: markdownRenderJs.includes('fallbackMarkdownInline') && markdownRenderJs.includes('https?:\\/\\/'),
+                },
+            },
+            timestamp,
+        });
+    } catch (err) {
+        console.error('[Debug info-public-pages] failed:', err);
+        res.status(500).json({ success: false, bug: 'info-public-pages', error: err.message, timestamp });
+    }
+});
+
 // Wire up pending message flush on email verification
 authModule.setOnEmailVerified(async (deviceId) => {
     console.log(`[PendingFlush] onEmailVerified triggered for device ${deviceId}`);

--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -4821,6 +4821,9 @@ platforms:
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js?v=1.2.2"></script>
     <script src="shared/footer.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
+    <script src="shared/markdown-render.js"></script>
     <script src="shared/info.js"></script>
     <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid|EClawIOS/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
     <script src="shared/ai-chat.js"></script>

--- a/backend/public/portal/roadmap.html
+++ b/backend/public/portal/roadmap.html
@@ -484,7 +484,7 @@
     <script>
         window.addEventListener('DOMContentLoaded', async () => {
             try {
-                await apiCall('GET', '/api/auth/me');
+                await apiCall('GET', '/api/auth/me', null, { skip401Redirect: true });
                 renderNav('info');
             } catch (e) {
                 renderPublicNav('info');

--- a/backend/public/portal/shared/info.js
+++ b/backend/public/portal/shared/info.js
@@ -356,7 +356,10 @@ async function copyClaudeOpenclawExample() {
                 const tag = ch.type === 'Features' ? 'feat' : ch.type === 'Bug Fixes' ? 'fix' : 'chore';
                 const tagClass = tag === 'feat' ? 'rn-tag-feat' : tag === 'fix' ? 'rn-tag-fix' : 'rn-tag-chore';
                 const scope = ch.scope ? '<strong>' + ch.scope + ':</strong> ' : '';
-                return '<li><span class="rn-tag ' + tagClass + '">' + tag + '</span> ' + scope + escHtml(ch.description) + '</li>';
+                const descriptionHtml = typeof window.renderSafeMarkdownInline === 'function'
+                    ? window.renderSafeMarkdownInline(ch.description)
+                    : escHtml(ch.description);
+                return '<li><span class="rn-tag ' + tagClass + '">' + tag + '</span> ' + scope + descriptionHtml + '</li>';
             }).join('');
             const openAttr = isLatest ? 'open' : '';
             return '<details class="rn-entry' + (isLatest ? ' latest' : '') + '" ' + openAttr + '>' +

--- a/backend/public/portal/shared/markdown-render.js
+++ b/backend/public/portal/shared/markdown-render.js
@@ -1,0 +1,71 @@
+// Safe Markdown helpers for public portal surfaces.
+// Prefer marked.js + DOMPurify when present; keep a tiny safe fallback so
+// release notes never show raw Markdown URLs if the CDN script is unavailable.
+(function(root) {
+    'use strict';
+
+    function escapeHtml(value) {
+        return String(value || '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+    }
+
+    function escapeAttr(value) {
+        return escapeHtml(value).replace(/`/g, '&#96;');
+    }
+
+    function addSafeLinkAttrs(html) {
+        return String(html || '').replace(/<a\b([^>]*)>/g, (_match, attrs) => {
+            const hasTarget = /\starget\s*=/.test(attrs);
+            const hasRel = /\srel\s*=/.test(attrs);
+            return `<a${attrs}${hasTarget ? '' : ' target="_blank"'}${hasRel ? '' : ' rel="noopener noreferrer"'}>`;
+        });
+    }
+
+    function fallbackMarkdownInline(source) {
+        let html = escapeHtml(source);
+        html = html.replace(/\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)/g, (_m, label, url) => {
+            const safeUrl = escapeAttr(url);
+            return `<a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${label}</a>`;
+        });
+        html = html.replace(/(^|[\s(])(https?:\/\/[^\s)<]+)/g, (_m, prefix, url) => {
+            const safeUrl = escapeAttr(url);
+            return `${prefix}<a href="${safeUrl}" target="_blank" rel="noopener noreferrer">${url}</a>`;
+        });
+        return html;
+    }
+
+    function renderSafeMarkdownInline(source) {
+        const text = String(source || '');
+        let html = null;
+
+        if (root.marked) {
+            if (typeof root.marked.parseInline === 'function') {
+                html = root.marked.parseInline(text);
+            } else if (typeof root.marked.parse === 'function') {
+                html = root.marked.parse(text).replace(/^<p>|<\/p>\s*$/g, '');
+            }
+        }
+
+        if (html === null) html = fallbackMarkdownInline(text);
+
+        if (root.DOMPurify && typeof root.DOMPurify.sanitize === 'function') {
+            html = root.DOMPurify.sanitize(html, {
+                ALLOWED_TAGS: ['a', 'strong', 'em', 'code', 'span'],
+                ALLOWED_ATTR: ['href', 'target', 'rel', 'class'],
+                ADD_ATTR: ['target', 'rel'],
+            });
+        }
+
+        return addSafeLinkAttrs(html);
+    }
+
+    root.renderSafeMarkdownInline = renderSafeMarkdownInline;
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = { renderSafeMarkdownInline, fallbackMarkdownInline, escapeHtml };
+    }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/backend/tests/jest/info-public-pages.test.js
+++ b/backend/tests/jest/info-public-pages.test.js
@@ -1,0 +1,121 @@
+/**
+ * Regression coverage for public Info-page regressions reported 2026-05-04:
+ * 1. /portal/roadmap.html must remain publicly viewable when /api/auth/me returns 401.
+ * 2. /portal/info.html release-note descriptions must render Markdown links safely.
+ * 3. Temporary debug endpoint remains available while the production bug is verified.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PORTAL_DIR = path.resolve(__dirname, '../../public/portal');
+const ROADMAP_HTML = path.join(PORTAL_DIR, 'roadmap.html');
+const INFO_HTML = path.join(PORTAL_DIR, 'info.html');
+const INFO_JS = path.join(PORTAL_DIR, 'shared/info.js');
+const MARKDOWN_RENDER_JS = path.join(PORTAL_DIR, 'shared/markdown-render.js');
+const INDEX_JS = path.resolve(__dirname, '../../index.js');
+
+function freshMarkdownRenderer({ marked, DOMPurify } = {}) {
+    const previousMarked = global.marked;
+    const previousDOMPurify = global.DOMPurify;
+    delete require.cache[require.resolve(MARKDOWN_RENDER_JS)];
+    delete global.renderSafeMarkdownInline;
+
+    if (marked === undefined) delete global.marked;
+    else global.marked = marked;
+
+    if (DOMPurify === undefined) delete global.DOMPurify;
+    else global.DOMPurify = DOMPurify;
+
+    const mod = require(MARKDOWN_RENDER_JS);
+
+    global.marked = previousMarked;
+    global.DOMPurify = previousDOMPurify;
+    return mod;
+}
+
+describe('roadmap public page auth gate', () => {
+    test('roadmap.html probes /api/auth/me without triggering api.js 401 redirect', () => {
+        const source = fs.readFileSync(ROADMAP_HTML, 'utf8');
+        const pattern = /apiCall\(\s*['"]GET['"]\s*,\s*['"]\/api\/auth\/me['"]\s*,\s*null\s*,\s*\{[^}]*skip401Redirect\s*:\s*true[^}]*\}\s*\)/;
+        expect(source).toMatch(pattern);
+    });
+
+    test('roadmap.html remains a public page with public nav available', () => {
+        const source = fs.readFileSync(ROADMAP_HTML, 'utf8');
+        expect(source).toMatch(/shared\/public-nav\.js/);
+        expect(source).toMatch(/renderPublicNav/);
+    });
+});
+
+describe('release notes Markdown rendering', () => {
+    test('info.html loads marked, DOMPurify, then the local safe Markdown renderer before info.js', () => {
+        const source = fs.readFileSync(INFO_HTML, 'utf8');
+        const markedIdx = source.indexOf('marked/marked.min.js');
+        const purifyIdx = source.indexOf('dompurify/dist/purify.min.js');
+        const rendererIdx = source.indexOf('shared/markdown-render.js');
+        const infoIdx = source.indexOf('shared/info.js');
+
+        expect(markedIdx).toBeGreaterThan(-1);
+        expect(purifyIdx).toBeGreaterThan(markedIdx);
+        expect(rendererIdx).toBeGreaterThan(purifyIdx);
+        expect(infoIdx).toBeGreaterThan(rendererIdx);
+    });
+
+    test('release-note descriptions call renderSafeMarkdownInline instead of escHtml-only output', () => {
+        const source = fs.readFileSync(INFO_JS, 'utf8');
+        expect(source).toMatch(/renderSafeMarkdownInline\(ch\.description\)/);
+        expect(source).toMatch(/descriptionHtml/);
+        expect(source).not.toMatch(/<\/strong>\s*\$\{escHtml\(ch\.description\)\}/);
+    });
+
+    test('fallback renderer converts issue Markdown links into safe anchors', () => {
+        const { renderSafeMarkdownInline } = freshMarkdownRenderer();
+        const html = renderSafeMarkdownInline('Fixes [#504](https://github.com/HankHuang0516/EClaw/issues/504)');
+
+        expect(html).toContain('<a href="https://github.com/HankHuang0516/EClaw/issues/504"');
+        expect(html).toContain('target="_blank"');
+        expect(html).toContain('rel="noopener noreferrer"');
+        expect(html).not.toContain('[#504](');
+    });
+
+    test('fallback renderer converts bare parenthesized URLs into safe anchors', () => {
+        const { renderSafeMarkdownInline } = freshMarkdownRenderer();
+        const html = renderSafeMarkdownInline('(https://github.com/HankHuang0516/EClaw/issues/504)');
+
+        expect(html).toContain('(<a href="https://github.com/HankHuang0516/EClaw/issues/504"');
+        expect(html).not.toContain('(https://github.com/HankHuang0516/EClaw/issues/504)');
+    });
+
+    test('marked + DOMPurify path is used when CDN libraries are present', () => {
+        const marked = { parseInline: jest.fn(() => '<a href="https://example.com">link</a><script>x</script>') };
+        const DOMPurify = { sanitize: jest.fn((html) => html.replace(/<script>.*?<\/script>/g, '')) };
+        const { renderSafeMarkdownInline } = freshMarkdownRenderer();
+        const previousMarked = global.marked;
+        const previousDOMPurify = global.DOMPurify;
+        try {
+            global.marked = marked;
+            global.DOMPurify = DOMPurify;
+
+            const html = renderSafeMarkdownInline('[link](https://example.com)');
+
+            expect(marked.parseInline).toHaveBeenCalled();
+            expect(DOMPurify.sanitize).toHaveBeenCalled();
+            expect(html).toContain('<a href="https://example.com" target="_blank" rel="noopener noreferrer">link</a>');
+            expect(html).not.toContain('<script>');
+        } finally {
+            global.marked = previousMarked;
+            global.DOMPurify = previousDOMPurify;
+        }
+    });
+});
+
+describe('info-public-pages debug endpoint registration', () => {
+    test('backend exposes an authenticated temporary debug endpoint for the info public-page bugs', () => {
+        const source = fs.readFileSync(INDEX_JS, 'utf8');
+        expect(source).toMatch(/app\.get\(['"]\/api\/debug\/info-public-pages['"]/);
+        expect(source).toMatch(/authProbeUsesSkip401Redirect/);
+        expect(source).toMatch(/releaseRendererCallsMarkdownHelper/);
+        expect(source).toMatch(/fallbackHandlesMarkdownLinks/);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes two public Info-page regressions:

- `/portal/roadmap.html` no longer lets the soft `/api/auth/me` probe trigger the shared `api.js` 401 redirect for unauthenticated visitors.
- Release-note change descriptions are rendered through a small safe Markdown helper so issue links and bare URLs become anchors instead of raw Markdown text.
- Adds a temporary authenticated debug endpoint, `GET /api/debug/info-public-pages?deviceId=X&deviceSecret=Y`, for verification until the user confirms the production bugs are fixed.

## Root cause

- `roadmap.html` called `apiCall('GET', '/api/auth/me')` without `skip401Redirect`, so public visitors were sent to `index.html` before the page could fall back to public nav.
- `shared/info.js` escaped release-note descriptions as plain text, bypassing Markdown rendering for semantic-release issue links.

## Validation

- `node --check backend/index.js`
- `node --check backend/public/portal/shared/markdown-render.js`
- `node --check backend/public/portal/shared/info.js`
- `node --check backend/tests/jest/info-public-pages.test.js`
- `cd backend && npx jest tests/jest/info-public-pages.test.js` (8/8 passed; existing Jest config warning about `runInBand` appears before the test run)
- `cd backend && npx eslint index.js public/portal/shared/info.js public/portal/shared/markdown-render.js tests/jest/info-public-pages.test.js` (0 errors; portal/test files are currently ignored by existing ESLint config and reported as warnings)
- `git diff --check`
