### PR TITLE
HOTFIX: Remove false privacy/security certification claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -439,6 +439,7 @@ EClaw/
    | Kanban nudges ignored by Codex channel bridge | `GET /api/mission/debug/kanban-codex-nudge?deviceId=X&deviceSecret=Y` | 2026-05-01 | Active |
    | Info public pages: roadmap redirects unauthenticated visitors + release notes show raw Markdown links | `GET /api/debug/info-public-pages?deviceId=X&deviceSecret=Y` | 2026-05-04 | Active |
    | Info slide uses invented Interview Arena leaderboard bot names | `GET /api/debug/info-leaderboard-slide?deviceId=X&deviceSecret=Y` | 2026-05-04 | Active |
+   | Info privacy slide contains unverified certification/security claims | `GET /api/debug/info-privacy-claims?deviceId=X&deviceSecret=Y` | 2026-05-04 | Active |
 
 6. **Demand Elegance (Balanced)** — 在保持 minimal change 的前提下，追求可讀、一致的程式風格；不為了「漂亮」而過度重構，但也不容忍明顯的 code smell 在新增的程式碼中出現。
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -2463,6 +2463,105 @@ app.get('/api/debug/info-leaderboard-slide', async (req, res) => {
     }
 });
 
+// Temporary diagnostic endpoint for public Info-page privacy/security claims:
+// the privacy slide currently contains legal-risk certification/security claims and
+// must not be reachable from user-visible Info page entry points until rewritten.
+// Authenticated with device credentials; returns only static code diagnostics.
+app.get('/api/debug/info-privacy-claims', async (req, res) => {
+    const { deviceId, deviceSecret } = req.query || {};
+    const timestamp = new Date().toISOString();
+    try {
+        if (!deviceId || !deviceSecret) {
+            return res.status(401).json({ success: false, bug: 'info-privacy-claims', error: 'deviceId and deviceSecret required', timestamp });
+        }
+
+        const memDevice = devices[deviceId];
+        const pool = db._getPool ? db._getPool() : authModule.pool;
+        const dbDevice = pool
+            ? await pool.query('SELECT device_secret FROM devices WHERE device_id = $1', [deviceId])
+            : { rows: [] };
+        const dbDeviceRow = dbDevice.rows[0] || null;
+        const memSecretOk = !!(memDevice && memDevice.deviceSecret && safeEqual(memDevice.deviceSecret, deviceSecret));
+        const dbSecretOk = !!(dbDeviceRow && dbDeviceRow.device_secret && safeEqual(dbDeviceRow.device_secret, deviceSecret));
+        if (!memSecretOk && !dbSecretOk) {
+            return res.status(403).json({ success: false, bug: 'info-privacy-claims', error: 'Invalid credentials', timestamp });
+        }
+
+        const portalDir = path.join(__dirname, 'public', 'portal');
+        const infoPath = path.join(portalDir, 'info.html');
+        const slideDir = path.join(portalDir, 'assets', 'slides');
+        const privacySlidePath = path.join(slideDir, 'info-privacy.html');
+        const privacyMobilePath = path.join(slideDir, 'info-privacy-mobile.html');
+        const read = (p) => fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : '';
+        const infoHtml = read(infoPath);
+        const privacySlideHtml = read(privacySlidePath);
+        const privacyMobileHtml = read(privacyMobilePath);
+        const riskyClaimPatterns = [
+            /ISO\s*27001/i,
+            /GDPR/i,
+            /SOC\s*2/i,
+            /HIPAA/i,
+            /軍用級\s*AES-?256|military-grade\s*AES-?256/i,
+            /端到端加密傳輸|end-to-end encrypted transmission/i,
+            /資料庫加密存儲|encrypted database storage/i,
+            /99\.99%|0\s*資料外洩|24\/7\s*安全監控/i,
+        ];
+        const publicPortalReferences = [];
+        const walk = (dir) => {
+            if (!fs.existsSync(dir)) return;
+            for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+                const p = path.join(dir, entry.name);
+                if (entry.isDirectory()) {
+                    if (p === slideDir) continue;
+                    walk(p);
+                } else if (/\.(html|js|css)$/i.test(entry.name)) {
+                    const body = read(p);
+                    if (/info-privacy(?:-mobile)?\.html|info-privacy-thumb\.png/.test(body)) {
+                        publicPortalReferences.push(path.relative(portalDir, p));
+                    }
+                }
+            }
+        };
+        walk(portalDir);
+
+        res.json({
+            success: true,
+            bug: 'info-privacy-claims',
+            diagnostics: {
+                server: {
+                    build: SERVER_BUILD_TAG,
+                    startedAt: SERVER_STARTED_AT.toISOString(),
+                    uptimeSec: Math.round(process.uptime()),
+                },
+                auth: {
+                    memSecretOk,
+                    dbSecretOk,
+                    requestUserDeviceId: req.user?.deviceId || null,
+                    requestUserId: req.user?.userId || null,
+                },
+                infoPageExposure: {
+                    infoFileExists: !!infoHtml,
+                    linksPrivacySlide: /href=["']assets\/slides\/info-privacy\.html["']/.test(infoHtml),
+                    displaysPrivacyThumb: /src=["']assets\/slides\/info-privacy-thumb\.png["']/.test(infoHtml),
+                    usesPrivacyCtaKey: /data-i18n=["']info_privacy_slide_cta["']/.test(infoHtml),
+                    publicPortalReferences,
+                },
+                retainedSlideFiles: {
+                    privacySlideExists: !!privacySlideHtml,
+                    privacyMobileSlideExists: !!privacyMobileHtml,
+                    slideStillContainsRiskyClaims: riskyClaimPatterns.some(pattern => pattern.test(privacySlideHtml)),
+                    mobileSlideStillContainsRiskyClaims: riskyClaimPatterns.some(pattern => pattern.test(privacyMobileHtml)),
+                },
+            },
+            timestamp,
+        });
+    } catch (err) {
+        console.error('[Debug info-privacy-claims] failed:', err);
+        res.status(500).json({ success: false, bug: 'info-privacy-claims', error: err.message, timestamp });
+    }
+});
+
+
 // Wire up pending message flush on email verification
 authModule.setOnEmailVerified(async (deviceId) => {
     console.log(`[PendingFlush] onEmailVerified triggered for device ${deviceId}`);

--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -111,10 +111,6 @@
                     <span class="guide-slide-cta" data-i18n="info_enterprise_slide_cta">🏢 企業級解決方案</span>
                 </a>
 
-                <a class="guide-slide-link" href="assets/slides/info-privacy.html" target="_blank" rel="noopener">
-                    <img class="guide-slide-thumb" src="assets/slides/info-privacy-thumb.png" alt="" loading="lazy">
-                    <span class="guide-slide-cta" data-i18n="info_privacy_slide_cta">🔒 安全與隱私保障</span>
-                </a>
             </div>
 
             <hr class="qs-divider">

--- a/backend/tests/jest/info-privacy-claims.test.js
+++ b/backend/tests/jest/info-privacy-claims.test.js
@@ -1,0 +1,53 @@
+/**
+ * Regression coverage for the public Info privacy/security slide exposure.
+ * The retained slide file currently contains legal-risk claims and must not be
+ * linked or embedded from user-visible Info page entry points until rewritten.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const PORTAL_DIR = path.resolve(__dirname, '../../public/portal');
+const INFO_HTML = path.join(PORTAL_DIR, 'info.html');
+const INDEX_JS = path.resolve(__dirname, '../../index.js');
+
+function walkFiles(dir, out = []) {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            if (full === path.join(PORTAL_DIR, 'assets', 'slides')) continue;
+            walkFiles(full, out);
+        } else if (/\.(html|js|css)$/i.test(entry.name)) {
+            out.push(full);
+        }
+    }
+    return out;
+}
+
+describe('Info privacy/security slide exposure', () => {
+    test('info.html does not link or thumbnail the risky privacy slide', () => {
+        const source = fs.readFileSync(INFO_HTML, 'utf8');
+        expect(source).not.toMatch(/href=["']assets\/slides\/info-privacy\.html["']/);
+        expect(source).not.toMatch(/src=["']assets\/slides\/info-privacy-thumb\.png["']/);
+        expect(source).not.toMatch(/data-i18n=["']info_privacy_slide_cta["']/);
+    });
+
+    test('no public portal file outside the slide folder references the risky privacy slide', () => {
+        const offenders = walkFiles(PORTAL_DIR).filter((file) => {
+            const source = fs.readFileSync(file, 'utf8');
+            return /info-privacy(?:-mobile)?\.html|info-privacy-thumb\.png/.test(source);
+        }).map((file) => path.relative(PORTAL_DIR, file));
+
+        expect(offenders).toEqual([]);
+    });
+});
+
+describe('info-privacy-claims debug endpoint registration', () => {
+    test('backend exposes an authenticated temporary debug endpoint for exposure verification', () => {
+        const source = fs.readFileSync(INDEX_JS, 'utf8');
+        expect(source).toMatch(/app\.get\(['"]\/api\/debug\/info-privacy-claims['"]/);
+        expect(source).toMatch(/linksPrivacySlide/);
+        expect(source).toMatch(/publicPortalReferences/);
+        expect(source).toMatch(/slideStillContainsRiskyClaims/);
+    });
+});


### PR DESCRIPTION
## Critical Legal Fix

Immediately removes public exposure of the Info privacy/security slide that contains unverified certification and security claims.

### False claims no longer exposed from Info page
The retained slide files still contain claims such as:
- ISO 27001 / GDPR / SOC 2 / HIPAA certification/compliance claims
- Military-grade AES-256, E2EE transport, encrypted database storage claims
- MFA/biometric/SSO and 99.99%/0 breach/24/7 monitoring claims

This PR removes the user-visible Info page entry point while preserving the slide files for a later factual rewrite.

### What changed
1. Removed the `assets/slides/info-privacy.html` card/link/thumb from `backend/public/portal/info.html`.
2. Added authenticated diagnostic endpoint: `GET /api/debug/info-privacy-claims`.
3. Added static regression coverage: `backend/tests/jest/info-privacy-claims.test.js`.
4. Registered the temporary debug endpoint in `AGENTS.md` Active Debug Endpoints.

### Screenshot verification
Local browser screenshots were generated and checked:
- desktop `1440x900`: Quick Start slide row no longer shows the privacy/security card.
- mobile `390x844`: Quick Start entry list no longer exposes the privacy/security slide.

### Validation
- `node --check backend/index.js`
- `node --check backend/tests/jest/info-privacy-claims.test.js`
- `cd backend && node --check public/shared/i18n.js && node scripts/i18n-check.js`
- `cd backend && npx jest tests/jest/info-privacy-claims.test.js --runInBand` (3/3 passing)
- `cd backend && npx eslint index.js tests/jest/info-privacy-claims.test.js` (0 errors; existing ignore warning for targeted Jest file)
- `git diff --check`

Fixes: `card_61b299eb2ad8bf6d84fbd584`
