### PR TITLE
[codex] fix public auth console noise

### DIFF
--- a/backend/auth.js
+++ b/backend/auth.js
@@ -697,6 +697,77 @@ module.exports = function(devices, getOrCreateDevice, serverLog) {
     });
 
     // ============================================
+    // GET /session (optional auth; public-page safe)
+    // ============================================
+    router.get('/session', softAuthMiddleware, async (req, res) => {
+        try {
+            if (!req.user) {
+                return res.json({ success: true, authenticated: false, user: null });
+            }
+
+            // Device-only login (no user account)
+            if (!req.user.userId) {
+                const deviceId = req.user.deviceId;
+                const device = devices[deviceId];
+                const isPremium = device && device.isPremium;
+
+                return res.json({
+                    success: true,
+                    authenticated: true,
+                    user: {
+                        id: null,
+                        email: null,
+                        deviceId,
+                        deviceSecret: req.user.deviceSecret || null,
+                        subscriptionStatus: isPremium ? 'premium' : 'free',
+                        subscriptionExpiresAt: null,
+                        language: 'en',
+                        emailVerified: false,
+                        createdAt: null,
+                        isAdmin: false,
+                        displayName: null,
+                        avatarUrl: null,
+                    }
+                });
+            }
+
+            const result = await pool.query(
+                'SELECT id, email, device_id, device_secret, subscription_status, subscription_expires_at, language, email_verified, is_admin, created_at, display_name, avatar_url, google_id, facebook_id FROM user_accounts WHERE id = $1',
+                [req.user.userId]
+            );
+
+            if (result.rows.length === 0) {
+                return res.json({ success: true, authenticated: false, user: null });
+            }
+
+            const user = result.rows[0];
+            return res.json({
+                success: true,
+                authenticated: true,
+                user: {
+                    id: user.id,
+                    email: user.email,
+                    deviceId: user.device_id,
+                    deviceSecret: user.device_secret,
+                    subscriptionStatus: user.subscription_status,
+                    subscriptionExpiresAt: user.subscription_expires_at,
+                    language: user.language,
+                    emailVerified: user.email_verified,
+                    createdAt: user.created_at,
+                    isAdmin: user.is_admin || false,
+                    displayName: user.display_name || null,
+                    avatarUrl: user.avatar_url || null,
+                    googleLinked: !!user.google_id,
+                    facebookLinked: !!user.facebook_id,
+                }
+            });
+        } catch (error) {
+            console.error('[Auth] Get session error:', error);
+            res.status(500).json({ success: false, error: 'Failed to get session info' });
+        }
+    });
+
+    // ============================================
     // GET /me (requires auth)
     // ============================================
     router.get('/me', authMiddleware, async (req, res) => {

--- a/backend/index.js
+++ b/backend/index.js
@@ -2374,7 +2374,8 @@ app.get('/api/debug/info-public-pages', async (req, res) => {
                 },
                 roadmapPublicGate: {
                     fileExists: !!roadmapHtml,
-                    authProbeUsesSkip401Redirect: /apiCall\(\s*['"]GET['"]\s*,\s*['"]\/api\/auth\/me['"]\s*,\s*null\s*,\s*\{[^}]*skip401Redirect\s*:\s*true/.test(roadmapHtml),
+                    authProbeUsesOptionalSession: /apiCall\(\s*['"]GET['"]\s*,\s*['"]\/api\/auth\/session['"]/.test(roadmapHtml),
+                    avoidsNoisyAuthMeProbe: !/apiCall\(\s*['"]GET['"]\s*,\s*['"]\/api\/auth\/me['"]/.test(roadmapHtml),
                     includesAuthJs: /shared\/auth\.js/.test(roadmapHtml),
                 },
                 releaseNotesMarkdown: {

--- a/backend/public/portal/roadmap.html
+++ b/backend/public/portal/roadmap.html
@@ -484,8 +484,12 @@
     <script>
         window.addEventListener('DOMContentLoaded', async () => {
             try {
-                await apiCall('GET', '/api/auth/me', null, { skip401Redirect: true });
-                renderNav('info');
+                const data = await apiCall('GET', '/api/auth/session', null, { skip401Redirect: true });
+                if (data?.authenticated && data.user) {
+                    renderNav('info');
+                } else {
+                    renderPublicNav('info');
+                }
             } catch (e) {
                 renderPublicNav('info');
             }

--- a/backend/public/portal/shared/info.js
+++ b/backend/public/portal/shared/info.js
@@ -5,13 +5,17 @@ let currentUser = null;
 window.addEventListener('DOMContentLoaded', async () => {
     // Soft auth check: show authenticated nav if logged in, public nav otherwise
     try {
-        const data = await apiCall('GET', '/api/auth/me');
-        currentUser = data.user;
-        window.currentUser = currentUser;
-        renderNav('info');
-        if (window._addAdminLink) window._addAdminLink();
-        const emailEl = document.getElementById('navEmail');
-        if (emailEl) emailEl.textContent = currentUser.email;
+        const data = await apiCall('GET', '/api/auth/session', null, { skip401Redirect: true });
+        if (data?.authenticated && data.user) {
+            currentUser = data.user;
+            window.currentUser = currentUser;
+            renderNav('info');
+            if (window._addAdminLink) window._addAdminLink();
+            const emailEl = document.getElementById('navEmail');
+            if (emailEl) emailEl.textContent = currentUser.email;
+        } else {
+            renderPublicNav('info');
+        }
     } catch (e) {
         renderPublicNav('info');
     }
@@ -296,9 +300,9 @@ async function copyClaudeOpenclawExample() {
     let deviceSecret = i18n.t('guide_usecase_copy_device_secret_placeholder');
 
     try {
-        const data = await apiCall('GET', '/api/auth/me');
-        if (data?.user?.deviceId) deviceId = data.user.deviceId;
-        if (data?.user?.deviceSecret) deviceSecret = data.user.deviceSecret;
+        const data = await apiCall('GET', '/api/auth/session', null, { skip401Redirect: true });
+        if (data?.authenticated && data?.user?.deviceId) deviceId = data.user.deviceId;
+        if (data?.authenticated && data?.user?.deviceSecret) deviceSecret = data.user.deviceSecret;
     } catch (e) {
         // Not logged in, use placeholder
     }

--- a/backend/tests/jest/auth.test.js
+++ b/backend/tests/jest/auth.test.js
@@ -175,6 +175,14 @@ jest.mock('../../auth', () => {
         return res.json({ success: true, user: { id: 1, email: 'test@test.com' } });
     });
 
+    // GET /session — public-safe optional auth probe
+    router.get('/session', (req, res) => {
+        if (!req.cookies || !req.cookies.eclaw_session) {
+            return res.json({ success: true, authenticated: false, user: null });
+        }
+        return res.json({ success: true, authenticated: true, user: { id: 1, email: 'test@test.com' } });
+    });
+
     // GET /oauth/providers — public
     router.get('/oauth/providers', (_req, res) => {
         return res.json({ success: true, providers: [] });
@@ -318,6 +326,21 @@ describe('GET /api/auth/me', () => {
     it('returns 401 when not authenticated', async () => {
         const res = await get('/api/auth/me');
         expect(res.status).toBe(401);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// GET /api/auth/session
+// ════════════════════════════════════════════════════════════════
+describe('GET /api/auth/session', () => {
+    it('returns 200 anonymous session state when not authenticated', async () => {
+        const res = await get('/api/auth/session');
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({
+            success: true,
+            authenticated: false,
+            user: null,
+        });
     });
 });
 

--- a/backend/tests/jest/info-public-pages.test.js
+++ b/backend/tests/jest/info-public-pages.test.js
@@ -1,6 +1,6 @@
 /**
  * Regression coverage for public Info-page regressions reported 2026-05-04:
- * 1. /portal/roadmap.html must remain publicly viewable when /api/auth/me returns 401.
+ * 1. /portal/roadmap.html must remain publicly viewable without noisy /api/auth/me 401 probes.
  * 2. /portal/info.html release-note descriptions must render Markdown links safely.
  * 3. Temporary debug endpoint remains available while the production bug is verified.
  */
@@ -35,16 +35,22 @@ function freshMarkdownRenderer({ marked, DOMPurify } = {}) {
 }
 
 describe('roadmap public page auth gate', () => {
-    test('roadmap.html probes /api/auth/me without triggering api.js 401 redirect', () => {
+    test('roadmap.html uses the optional /api/auth/session probe instead of /api/auth/me', () => {
         const source = fs.readFileSync(ROADMAP_HTML, 'utf8');
-        const pattern = /apiCall\(\s*['"]GET['"]\s*,\s*['"]\/api\/auth\/me['"]\s*,\s*null\s*,\s*\{[^}]*skip401Redirect\s*:\s*true[^}]*\}\s*\)/;
-        expect(source).toMatch(pattern);
+        expect(source).toMatch(/apiCall\(\s*['"]GET['"]\s*,\s*['"]\/api\/auth\/session['"]/);
+        expect(source).not.toMatch(/apiCall\(\s*['"]GET['"]\s*,\s*['"]\/api\/auth\/me['"]/);
     });
 
     test('roadmap.html remains a public page with public nav available', () => {
         const source = fs.readFileSync(ROADMAP_HTML, 'utf8');
         expect(source).toMatch(/shared\/public-nav\.js/);
         expect(source).toMatch(/renderPublicNav/);
+    });
+
+    test('info.js uses the optional /api/auth/session probe for public nav detection', () => {
+        const source = fs.readFileSync(INFO_JS, 'utf8');
+        expect(source).toMatch(/\/api\/auth\/session/);
+        expect(source).not.toMatch(/apiCall\(\s*['"]GET['"]\s*,\s*['"]\/api\/auth\/me['"]/);
     });
 });
 
@@ -114,7 +120,8 @@ describe('info-public-pages debug endpoint registration', () => {
     test('backend exposes an authenticated temporary debug endpoint for the info public-page bugs', () => {
         const source = fs.readFileSync(INDEX_JS, 'utf8');
         expect(source).toMatch(/app\.get\(['"]\/api\/debug\/info-public-pages['"]/);
-        expect(source).toMatch(/authProbeUsesSkip401Redirect/);
+        expect(source).toMatch(/authProbeUsesOptionalSession/);
+        expect(source).toMatch(/avoidsNoisyAuthMeProbe/);
         expect(source).toMatch(/releaseRendererCallsMarkdownHelper/);
         expect(source).toMatch(/fallbackHandlesMarkdownLinks/);
     });


### PR DESCRIPTION
## Summary
Fixes QA/UIUX issue #2415 where public info/roadmap pages rendered correctly but logged expected `/api/auth/me` 401 errors for unauthenticated visitors.

- Adds `GET /api/auth/session` as a public-safe optional auth probe that returns HTTP 200 anonymous session state when logged out.
- Updates `/portal/info.html` shared logic and `/portal/roadmap.html` to use `/api/auth/session` instead of `/api/auth/me` for public nav detection.
- Updates the existing `/api/debug/info-public-pages` diagnostics for the new public auth probe contract.
- Adds regression coverage for anonymous `/api/auth/session` and public info/roadmap no-auth-me probes.

Fixes #2415.

## QA/UIUX scan context
Daily regression run before the fix:
- 39 public/portal routes returned HTTP 200 with no 404/5xx/unexpected public redirects.
- Headless desktop/mobile scan found no JS exceptions, broken images, missing hrefs, or external `_blank` rel issues.
- Only confirmed issue was noisy `/api/auth/me` 401 console output on public info/roadmap pages.

## Validation
- `cd backend && npx jest tests/jest/auth.test.js tests/jest/info-public-pages.test.js --runInBand` — 2 suites / 24 tests passing (existing Jest config warning about `runInBand`).
- `node --check backend/auth.js`
- `node --check backend/index.js`
- `node --check backend/public/portal/shared/info.js`
- `node --check backend/tests/jest/auth.test.js`
- `node --check backend/tests/jest/info-public-pages.test.js`
- `cd backend && npx eslint auth.js index.js tests/jest/auth.test.js tests/jest/info-public-pages.test.js` — 0 errors (existing ignored-test warnings).
- `git diff --check`
- Source verification: `info.js` and `roadmap.html` contain `/api/auth/session` and no `apiCall('GET', '/api/auth/me')`.
