### PR TITLE
[codex] fix info performance slide demo metrics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -440,6 +440,7 @@ EClaw/
    | Info public pages: roadmap redirects unauthenticated visitors + release notes show raw Markdown links | `GET /api/debug/info-public-pages?deviceId=X&deviceSecret=Y` | 2026-05-04 | Active |
    | Info slide uses invented Interview Arena leaderboard bot names | `GET /api/debug/info-leaderboard-slide?deviceId=X&deviceSecret=Y` | 2026-05-04 | Active |
    | Info Pricing Advisor slide claims unavailable GPT-5 tier and unsourced computed scores | `GET /api/debug/info-pricing-slide?deviceId=X&deviceSecret=Y` | 2026-05-04 | Active |
+   | Info Performance slide presents static mock metrics as LIVE production telemetry with Korean Won currency | `GET /api/debug/info-performance-slide?deviceId=X&deviceSecret=Y` | 2026-05-05 | Active |
 
 6. **Demand Elegance (Balanced)** — 在保持 minimal change 的前提下，追求可讀、一致的程式風格；不為了「漂亮」而過度重構，但也不容忍明顯的 code smell 在新增的程式碼中出現。
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -2464,6 +2464,76 @@ app.get('/api/debug/info-leaderboard-slide', async (req, res) => {
     }
 });
 
+// Temporary diagnostic endpoint for Performance Tracking slide accuracy:
+// the marketing slide must not present static mock metrics as live production
+// telemetry, unrelated currency, or precise production SLO/revenue claims.
+// Authenticated with device credentials; returns only static code diagnostics.
+app.get('/api/debug/info-performance-slide', async (req, res) => {
+    const { deviceId, deviceSecret } = req.query || {};
+    const timestamp = new Date().toISOString();
+    try {
+        if (!deviceId || !deviceSecret) {
+            return res.status(401).json({ success: false, bug: 'info-performance-slide', error: 'deviceId and deviceSecret required', timestamp });
+        }
+
+        const memDevice = devices[deviceId];
+        const pool = db._getPool ? db._getPool() : authModule.pool;
+        const dbDevice = pool
+            ? await pool.query('SELECT device_secret FROM devices WHERE device_id = $1', [deviceId])
+            : { rows: [] };
+        const dbDeviceRow = dbDevice.rows[0] || null;
+        const memSecretOk = !!(memDevice && memDevice.deviceSecret && safeEqual(memDevice.deviceSecret, deviceSecret));
+        const dbSecretOk = !!(dbDeviceRow && dbDeviceRow.device_secret && safeEqual(dbDeviceRow.device_secret, deviceSecret));
+        if (!memSecretOk && !dbSecretOk) {
+            return res.status(403).json({ success: false, bug: 'info-performance-slide', error: 'Invalid credentials', timestamp });
+        }
+
+        const slideDir = path.join(__dirname, 'public', 'portal', 'assets', 'slides');
+        const slidePath = path.join(slideDir, 'info-performance.html');
+        const slideHtml = fs.existsSync(slidePath) ? fs.readFileSync(slidePath, 'utf8') : '';
+
+        res.json({
+            success: true,
+            bug: 'info-performance-slide',
+            diagnostics: {
+                server: {
+                    build: SERVER_BUILD_TAG,
+                    startedAt: SERVER_STARTED_AT.toISOString(),
+                    uptimeSec: Math.round(process.uptime()),
+                },
+                auth: {
+                    memSecretOk,
+                    dbSecretOk,
+                    requestUserDeviceId: req.user?.deviceId || null,
+                    requestUserId: req.user?.userId || null,
+                },
+                slide: {
+                    fileExists: !!slideHtml,
+                    claimsLiveTelemetry: />LIVE</.test(slideHtml) || /class=["']live-indicator["']/.test(slideHtml),
+                    usesKoreanWonSymbol: /₩|₩847K/.test(slideHtml),
+                    hasDemoBadge: /DEMO/.test(slideHtml) && /示意資料/.test(slideHtml),
+                    avoidsPreciseMockClaims: !/98\.7%|156ms|₩847K/.test(slideHtml),
+                    usesTaiwanSampleCurrency: /NT\$76K/.test(slideHtml),
+                    hasDemoDisclaimer: /即時效能追蹤功能展示/.test(slideHtml)
+                        && /不代表目前 EClawbot 生產營收、SLO 或即時監控結果/.test(slideHtml),
+                    hasResponsiveViewport: /width=device-width/.test(slideHtml),
+                    hasMobileMediaQuery: /@media \(max-width: 768px\)/.test(slideHtml)
+                        && /@media \(max-width: 430px\)/.test(slideHtml),
+                },
+                screenshots: {
+                    webAssetExists: fs.existsSync(path.join(slideDir, 'info-performance-web.png')),
+                    mobileAssetExists: fs.existsSync(path.join(slideDir, 'info-performance-mobile.png')),
+                    thumbAssetExists: fs.existsSync(path.join(slideDir, 'info-performance-thumb.png')),
+                },
+            },
+            timestamp,
+        });
+    } catch (err) {
+        console.error('[Debug info-performance-slide] failed:', err);
+        res.status(500).json({ success: false, bug: 'info-performance-slide', error: err.message, timestamp });
+    }
+});
+
 // Temporary diagnostic endpoint for Pricing Advisor slide accuracy:
 // the marketing slide must not present unavailable model tiers or computed
 // pricing scores as real system output before Pricing Advisor is live.

--- a/backend/public/portal/assets/slides/info-performance.html
+++ b/backend/public/portal/assets/slides/info-performance.html
@@ -2,7 +2,7 @@
 <html lang="zh-TW">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=1280, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>EClaw - 📊 即時效能追蹤儀表板</title>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <style>
@@ -58,9 +58,9 @@
             from { opacity: 0; transform: translateY(20px); }
             to   { opacity: 1; transform: translateY(0); }
         }
-        @keyframes livePulse {
-            0%, 100% { opacity: 1; transform: scale(1); }
-            50%      { opacity: 0.6; transform: scale(1.2); }
+        @keyframes sampleGlow {
+            0%, 100% { opacity: 1; }
+            50%      { opacity: 0.72; }
         }
         @keyframes chartGrow {
             from { transform: scaleY(0); }
@@ -159,7 +159,7 @@
             border-color: #2E86C1;
         }
 
-        .live-indicator {
+        .sample-indicator {
             position: absolute;
             top: 12px;
             right: 12px;
@@ -169,18 +169,18 @@
             font-family: 'Inter', sans-serif;
             font-weight: 600;
             font-size: 10px;
-            color: #27AE60;
-            background: rgba(39, 174, 96, 0.1);
+            color: #2E86C1;
+            background: rgba(46, 134, 193, 0.12);
             padding: 4px 8px;
             border-radius: 20px;
         }
 
-        .live-dot {
+        .sample-dot {
             width: 6px;
             height: 6px;
             border-radius: 50%;
-            background: #27AE60;
-            animation: livePulse 1.5s ease-in-out infinite;
+            background: #2E86C1;
+            animation: sampleGlow 1.8s ease-in-out infinite;
         }
 
         .metric-value {
@@ -453,9 +453,103 @@
             letter-spacing: 0.5px;
         }
 
+        .demo-note {
+            width: 100%;
+            max-width: 1080px;
+            margin-top: -12px;
+            margin-bottom: 22px;
+            padding: 12px 16px;
+            border-radius: 14px;
+            background: rgba(255, 255, 255, 0.82);
+            border: 1px solid rgba(46, 134, 193, 0.22);
+            color: #5D6D7E;
+            font-size: 13px;
+            line-height: 1.55;
+            text-align: center;
+        }
+
         .cta-button:hover {
             transform: scale(1.02);
             box-shadow: 0 8px 24px rgba(46, 134, 193, 0.4);
+        }
+
+        @media (max-width: 768px) {
+            body {
+                align-items: flex-start;
+            }
+
+            .content-wrapper {
+                padding: 32px 20px;
+            }
+
+            .emoji-icon {
+                font-size: 44px;
+            }
+
+            .headline {
+                font-size: 28px;
+                overflow-wrap: anywhere;
+            }
+
+            .subline {
+                font-size: 15px;
+            }
+
+            .metrics-grid {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+                gap: 14px;
+            }
+
+            .metric-card {
+                padding: 20px 12px 16px;
+            }
+
+            .metric-value {
+                font-size: 24px;
+            }
+
+            .chart-section,
+            .alert-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .dashboard-container,
+            .header-section,
+            .emoji-icon,
+            .alert-section,
+            .cta-section,
+            .activity-item,
+            .metric-value {
+                animation: none !important;
+                opacity: 1;
+                transform: none;
+            }
+        }
+
+        @media (max-width: 600px) {
+            .content-wrapper {
+                padding: 28px 16px;
+            }
+
+            .headline {
+                font-size: 21px;
+            }
+
+            .metrics-grid {
+                grid-template-columns: 1fr;
+                gap: 12px;
+            }
+
+            .sample-indicator {
+                top: 10px;
+                right: 10px;
+                font-size: 9px;
+                padding: 3px 7px;
+            }
+
+            .metric-value {
+                font-size: 22px;
+            }
         }
     </style>
 </head>
@@ -464,42 +558,42 @@
         <section class="header-section">
             <span class="emoji-icon">📊</span>
             <h1 class="headline">Real-time Performance Tracking<br>即時效能追蹤儀表板</h1>
-            <p class="subline">全方位監控機器人表現，數據驅動優化決策</p>
+            <p class="subline">以示意儀表板展示可追蹤的營運指標，實際數據以產品後台為準</p>
         </section>
 
         <section class="dashboard-container">
             <div class="metrics-grid">
                 <div class="metric-card m1">
-                    <div class="live-indicator"><span class="live-dot"></span>LIVE</div>
-                    <div class="metric-value">1,247</div>
-                    <div class="metric-label">今日任務完成</div>
-                    <span class="metric-trend positive">↗ +15.3%</span>
+                    <div class="sample-indicator"><span class="sample-dot"></span>DEMO</div>
+                    <div class="metric-value">最高 1.2K</div>
+                    <div class="metric-label">任務量示意</div>
+                    <span class="metric-trend positive">↗ 範例趨勢</span>
                 </div>
                 <div class="metric-card m2">
-                    <div class="live-indicator"><span class="live-dot"></span>LIVE</div>
-                    <div class="metric-value">98.7%</div>
-                    <div class="metric-label">系統可用率</div>
-                    <span class="metric-trend positive">↗ +0.2%</span>
+                    <div class="sample-indicator"><span class="sample-dot"></span>DEMO</div>
+                    <div class="metric-value">約 98%</div>
+                    <div class="metric-label">可用率目標範例</div>
+                    <span class="metric-trend positive">↗ 目標範圍</span>
                 </div>
                 <div class="metric-card m3">
-                    <div class="live-indicator"><span class="live-dot"></span>LIVE</div>
-                    <div class="metric-value">₩847K</div>
-                    <div class="metric-label">今日收益</div>
-                    <span class="metric-trend positive">↗ +22.1%</span>
+                    <div class="sample-indicator"><span class="sample-dot"></span>DEMO</div>
+                    <div class="metric-value">NT$76K</div>
+                    <div class="metric-label">收益示意</div>
+                    <span class="metric-trend positive">↗ 示例成長</span>
                 </div>
                 <div class="metric-card m4">
-                    <div class="live-indicator"><span class="live-dot"></span>LIVE</div>
-                    <div class="metric-value">156ms</div>
-                    <div class="metric-label">平均回應時間</div>
-                    <span class="metric-trend negative">↘ +12ms</span>
+                    <div class="sample-indicator"><span class="sample-dot"></span>DEMO</div>
+                    <div class="metric-value">&lt; 200ms</div>
+                    <div class="metric-label">典型回應時間</div>
+                    <span class="metric-trend positive">↘ 目標示意</span>
                 </div>
             </div>
 
             <div class="chart-section">
                 <div class="chart-container">
                     <div class="chart-header">
-                        <h3 class="chart-title">效能趨勢</h3>
-                        <span class="chart-period">過去24小時</span>
+                        <h3 class="chart-title">效能趨勢示意</h3>
+                        <span class="chart-period">範例 24h</span>
                     </div>
                     <div class="chart-visual">
                         <svg class="chart-svg" viewBox="0 0 400 120" preserveAspectRatio="none">
@@ -516,33 +610,33 @@
                 </div>
 
                 <div class="activity-feed">
-                    <h3 class="activity-header">即時動態</h3>
+                    <h3 class="activity-header">範例動態</h3>
                     <div class="activity-item a1">
                         <div class="activity-dot"></div>
                         <div class="activity-content">
-                            <div class="activity-text">機器人 #AI-247 完成翻譯任務</div>
-                            <div class="activity-time">2分鐘前</div>
+                            <div class="activity-text">Bot A 完成範例翻譯任務</div>
+                            <div class="activity-time">示意 2 分鐘前</div>
                         </div>
                     </div>
                     <div class="activity-item a2">
                         <div class="activity-dot"></div>
                         <div class="activity-content">
-                            <div class="activity-text">新訂單自動分派至最佳機器人</div>
-                            <div class="activity-time">5分鐘前</div>
+                            <div class="activity-text">範例任務自動分派至合適 bot</div>
+                            <div class="activity-time">示意 5 分鐘前</div>
                         </div>
                     </div>
                     <div class="activity-item a3">
                         <div class="activity-dot"></div>
                         <div class="activity-content">
-                            <div class="activity-text">系統效能優化完成</div>
-                            <div class="activity-time">12分鐘前</div>
+                            <div class="activity-text">範例效能優化完成</div>
+                            <div class="activity-time">示意 12 分鐘前</div>
                         </div>
                     </div>
                     <div class="activity-item a4">
                         <div class="activity-dot"></div>
                         <div class="activity-content">
-                            <div class="activity-text">收益達成今日目標</div>
-                            <div class="activity-time">15分鐘前</div>
+                            <div class="activity-text">收益示意達成目標</div>
+                            <div class="activity-time">示意 15 分鐘前</div>
                         </div>
                     </div>
                 </div>
@@ -553,24 +647,25 @@
                     <div class="alert-card success">
                         <div class="alert-header">
                             <span class="alert-icon">✅</span>
-                            <h4 class="alert-title">系統運作正常</h4>
+                            <h4 class="alert-title">示範狀態正常</h4>
                         </div>
-                        <p class="alert-description">所有機器人運作狀態良好，無異常警報</p>
+                        <p class="alert-description">此為儀表板功能示意，實際警報以系統後台為準</p>
                     </div>
                     <div class="alert-card warning">
                         <div class="alert-header">
                             <span class="alert-icon">⚠️</span>
-                            <h4 class="alert-title">建議優化</h4>
+                            <h4 class="alert-title">示範優化建議</h4>
                         </div>
-                        <p class="alert-description">檢測到回應時間略有增長，建議檢查伺服器負載</p>
+                        <p class="alert-description">此為範例提醒文案，不代表目前生產環境狀態</p>
                     </div>
                 </div>
             </div>
+            <p class="demo-note">DEMO / 示意資料：本頁為即時效能追蹤功能展示，不代表目前 EClawbot 生產營收、SLO 或即時監控結果；實際數值以產品後台與系統紀錄為準。</p>
         </section>
 
         <section class="cta-section">
             <a class="cta-button" href="#">
-                查看完整儀表板
+                查看儀表板功能
                 <span>→</span>
             </a>
         </section>

--- a/backend/tests/jest/info-performance-slide.test.js
+++ b/backend/tests/jest/info-performance-slide.test.js
@@ -1,0 +1,59 @@
+/**
+ * Regression coverage for the Performance Tracking info slide.
+ * The marketing slide must not present static mock metrics as live production
+ * telemetry or use an unrelated Korean Won currency symbol.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SLIDE = path.resolve(__dirname, '../../public/portal/assets/slides/info-performance.html');
+const INDEX_JS = path.resolve(__dirname, '../../index.js');
+
+describe('Performance Tracking slide copy', () => {
+    const source = fs.readFileSync(SLIDE, 'utf8');
+
+    test('does not show static mock metrics as LIVE production telemetry', () => {
+        expect(source).not.toMatch(/>LIVE</);
+        expect(source).not.toMatch(/class=["']live-indicator["']/);
+        expect(source).toContain('DEMO');
+        expect(source).toContain('示意資料');
+    });
+
+    test('uses a Taiwan-friendly sample currency instead of Korean Won', () => {
+        expect(source).not.toContain('₩');
+        expect(source).not.toContain('₩847K');
+        expect(source).toContain('NT$76K');
+    });
+
+    test('avoids precise absolute production claims for mock metrics', () => {
+        expect(source).not.toContain('98.7%');
+        expect(source).not.toContain('156ms');
+        expect(source).toContain('最高 1.2K');
+        expect(source).toContain('約 98%');
+        expect(source).toContain('&lt; 200ms');
+    });
+
+    test('adds a clear disclaimer that values are demo data, not production results', () => {
+        expect(source).toContain('本頁為即時效能追蹤功能展示');
+        expect(source).toContain('不代表目前 EClawbot 生產營收、SLO 或即時監控結果');
+        expect(source).toContain('實際數值以產品後台與系統紀錄為準');
+    });
+
+    test('uses a mobile-responsive viewport and media queries', () => {
+        expect(source).toMatch(/<meta name="viewport" content="width=device-width, initial-scale=1\.0">/);
+        expect(source).toMatch(/@media \(max-width: 768px\)/);
+        expect(source).toMatch(/@media \(max-width: 600px\)/);
+    });
+});
+
+describe('info-performance-slide debug endpoint registration', () => {
+    test('backend exposes an authenticated temporary debug endpoint for slide verification', () => {
+        const source = fs.readFileSync(INDEX_JS, 'utf8');
+        expect(source).toMatch(/app\.get\(['"]\/api\/debug\/info-performance-slide['"]/);
+        expect(source).toMatch(/claimsLiveTelemetry/);
+        expect(source).toMatch(/usesKoreanWonSymbol/);
+        expect(source).toMatch(/hasDemoDisclaimer/);
+        expect(source).toMatch(/hasResponsiveViewport/);
+    });
+});


### PR DESCRIPTION
## Summary
- Replace misleading `LIVE` badges on `info-performance.html` with DEMO/sample indicators.
- Replace the Korean Won mock revenue value with a Taiwan-friendly `NT$76K` sample and soften absolute mock metrics to sample/typical copy.
- Add a clear demo-data disclaimer and mobile responsive rules for the slide.
- Add an authenticated temporary debug endpoint for this production bug and regression tests covering the copy/viewport guard.

## Root cause
The public marketing slide used static mock dashboard metrics while labeling them as live production data, including an unrelated `₩847K` value and precise-looking SLO/latency values.

## Validation
- `node --check backend/index.js`
- `cd backend && npx jest tests/jest/info-performance-slide.test.js tests/jest/info-pricing-slide.test.js tests/jest/info-leaderboard-slide.test.js --runInBand`
- `git diff --check`
- Local Chrome screenshots generated for desktop `1440x900` and mobile `390x844` to confirm the mobile cards no longer overflow the viewport.
