### PR TITLE
[codex] fix info integration slide claims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -440,6 +440,7 @@ EClaw/
    | Info public pages: roadmap redirects unauthenticated visitors + release notes show raw Markdown links | `GET /api/debug/info-public-pages?deviceId=X&deviceSecret=Y` | 2026-05-04 | Active |
    | Info slide uses invented Interview Arena leaderboard bot names | `GET /api/debug/info-leaderboard-slide?deviceId=X&deviceSecret=Y` | 2026-05-04 | Active |
    | Info Pricing Advisor slide claims unavailable GPT-5 tier and unsourced computed scores | `GET /api/debug/info-pricing-slide?deviceId=X&deviceSecret=Y` | 2026-05-04 | Active |
+   | Info Integration slide lists unsupported integrations and fake platform/SLA stats | `GET /api/debug/info-integration-slide?deviceId=X&deviceSecret=Y` | 2026-05-05 | Active |
 
 6. **Demand Elegance (Balanced)** — 在保持 minimal change 的前提下，追求可讀、一致的程式風格；不為了「漂亮」而過度重構，但也不容忍明顯的 code smell 在新增的程式碼中出現。
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -2464,6 +2464,81 @@ app.get('/api/debug/info-leaderboard-slide', async (req, res) => {
     }
 });
 
+// Temporary diagnostic endpoint for Integration slide accuracy:
+// the marketing slide must only list integrations that are actually supported
+// or wired today, and must not claim invented platform counts/SLA metrics.
+// Authenticated with device credentials; returns only static code diagnostics.
+app.get('/api/debug/info-integration-slide', async (req, res) => {
+    const { deviceId, deviceSecret } = req.query || {};
+    const timestamp = new Date().toISOString();
+    try {
+        if (!deviceId || !deviceSecret) {
+            return res.status(401).json({ success: false, bug: 'info-integration-slide', error: 'deviceId and deviceSecret required', timestamp });
+        }
+
+        const memDevice = devices[deviceId];
+        const pool = db._getPool ? db._getPool() : authModule.pool;
+        const dbDevice = pool
+            ? await pool.query('SELECT device_secret FROM devices WHERE device_id = $1', [deviceId])
+            : { rows: [] };
+        const dbDeviceRow = dbDevice.rows[0] || null;
+        const memSecretOk = !!(memDevice && memDevice.deviceSecret && safeEqual(memDevice.deviceSecret, deviceSecret));
+        const dbSecretOk = !!(dbDeviceRow && dbDeviceRow.device_secret && safeEqual(dbDeviceRow.device_secret, deviceSecret));
+        if (!memSecretOk && !dbSecretOk) {
+            return res.status(403).json({ success: false, bug: 'info-integration-slide', error: 'Invalid credentials', timestamp });
+        }
+
+        const slideDir = path.join(__dirname, 'public', 'portal', 'assets', 'slides');
+        const slidePath = path.join(slideDir, 'info-integration.html');
+        const slideHtml = fs.existsSync(slidePath) ? fs.readFileSync(slidePath, 'utf8') : '';
+        const supported = ['Telegram', 'Railway', 'GitHub', 'MiniMax', 'Anthropic', 'OpenAI', 'Voyage'];
+        const unsupported = [
+            'Discord', 'Slack', 'Teams', 'LINE', 'WhatsApp',
+            'GitLab', 'VS Code', 'JetBrains', 'Docker', 'Kubernetes',
+            'AWS', 'Azure', 'GCP', 'Vercel', 'DigitalOcean',
+        ];
+
+        res.json({
+            success: true,
+            bug: 'info-integration-slide',
+            diagnostics: {
+                server: {
+                    build: SERVER_BUILD_TAG,
+                    startedAt: SERVER_STARTED_AT.toISOString(),
+                    uptimeSec: Math.round(process.uptime()),
+                },
+                auth: {
+                    memSecretOk,
+                    dbSecretOk,
+                    requestUserDeviceId: req.user?.deviceId || null,
+                    requestUserId: req.user?.userId || null,
+                },
+                slide: {
+                    fileExists: !!slideHtml,
+                    supportedIntegrationsPresent: supported.filter(name => slideHtml.includes(name)),
+                    unsupportedClaimsPresent: unsupported.filter(name => slideHtml.includes(name)),
+                    hasFakeScaleStats: /50\+|99\.9%|24\/7/.test(slideHtml),
+                    hasActualStats: /已上線 \/ 已接線整合/.test(slideHtml)
+                        && /公開 channel plugin/.test(slideHtml)
+                        && /2026-05/.test(slideHtml),
+                    hasAvailabilityDisclaimer: /僅列出已上線或已接線的整合能力/.test(slideHtml)
+                        && /未上線\/未實作項目不列為正式支援/.test(slideHtml),
+                    hasDeadCompleteListCta: /查看完整整合列表/.test(slideHtml) || /href=["']#["']/.test(slideHtml),
+                },
+                screenshots: {
+                    webAssetExists: fs.existsSync(path.join(slideDir, 'info-integration-web.png')),
+                    mobileAssetExists: fs.existsSync(path.join(slideDir, 'info-integration-mobile.png')),
+                    thumbAssetExists: fs.existsSync(path.join(slideDir, 'info-integration-thumb.png')),
+                },
+            },
+            timestamp,
+        });
+    } catch (err) {
+        console.error('[Debug info-integration-slide] failed:', err);
+        res.status(500).json({ success: false, bug: 'info-integration-slide', error: err.message, timestamp });
+    }
+});
+
 // Temporary diagnostic endpoint for Pricing Advisor slide accuracy:
 // the marketing slide must not present unavailable model tiers or computed
 // pricing scores as real system output before Pricing Advisor is live.

--- a/backend/public/portal/assets/slides/info-integration.html
+++ b/backend/public/portal/assets/slides/info-integration.html
@@ -2,7 +2,7 @@
 <html lang="zh-TW">
 <head>
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=1280, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>EClaw - 🔗 跨平台整合生態系統</title>
     <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet">
     <style>
@@ -317,6 +317,12 @@
             transition: all 0.3s ease;
         }
 
+        .platform-tag.supported {
+            background: rgba(46, 134, 193, 0.10);
+            border-color: rgba(46, 134, 193, 0.28);
+            color: #1F5F8B;
+        }
+
         .platform-tag:hover {
             background: #2E86C1;
             color: #FFFFFF;
@@ -363,6 +369,14 @@
             opacity: 0.92;
         }
 
+        .stats-note {
+            margin-top: 16px;
+            font-family: 'Noto Sans TC', sans-serif;
+            font-size: 13px;
+            line-height: 1.55;
+            opacity: 0.88;
+        }
+
         /* CTA */
         .cta-section {
             text-align: center;
@@ -390,14 +404,41 @@
             transform: scale(1.02);
             box-shadow: 0 8px 24px rgba(63, 81, 181, 0.4);
         }
+
+        @media (max-width: 768px) {
+            body { align-items: flex-start; }
+            .content-wrapper { padding: 32px 20px; }
+            .emoji-icon { font-size: 44px; }
+            .headline { font-size: 28px; overflow-wrap: anywhere; }
+            .subline { font-size: 15px; }
+            .central-hub { width: 100%; max-width: 320px; height: 132px; margin-bottom: 32px; }
+            .hub-connectors,
+            .integration-node { display: none; }
+            .hub-core { width: 104px; height: 104px; }
+            .hub-core::after { width: 120px; height: 120px; }
+            .integration-grid { grid-template-columns: 1fr; gap: 16px; }
+            .stats-content { grid-template-columns: 1fr; gap: 18px; }
+            .header-section,
+            .emoji-icon,
+            .ecosystem-container,
+            .integration-category,
+            .stats-banner,
+            .stat-number { animation: none !important; opacity: 1; transform: none; }
+        }
+
+        @media (max-width: 430px) {
+            .content-wrapper { padding: 28px 16px; }
+            .headline { font-size: 20px; }
+            .central-hub { max-width: 300px; height: 124px; }
+        }
     </style>
 </head>
 <body>
     <div class="content-wrapper">
         <section class="header-section">
             <span class="emoji-icon">🔗</span>
-            <h1 class="headline">Cross-platform Integration Ecosystem<br>跨平台整合生態系統</h1>
-            <p class="subline">無縫連接各大平台，打造全方位AI服務體驗</p>
+            <h1 class="headline">Integrations<br>已上線整合</h1>
+            <p class="subline">僅列出已上線或已接線能力</p>
         </section>
 
         <section class="ecosystem-container">
@@ -420,51 +461,40 @@
 
                 <div class="hub-core">EClaw<br>Hub</div>
 
-                <div class="integration-node node-top">通訊<br>平台</div>
-                <div class="integration-node node-right">社群<br>媒體</div>
-                <div class="integration-node node-bottom-right">開發<br>工具</div>
-                <div class="integration-node node-bottom-left">商務<br>平台</div>
-                <div class="integration-node node-left">雲端<br>服務</div>
+                <div class="integration-node node-top">Channel<br>Plugin</div>
+                <div class="integration-node node-right">AI<br>Models</div>
+                <div class="integration-node node-bottom-right">GitHub<br>Workflow</div>
+                <div class="integration-node node-bottom-left">Embedding<br>Search</div>
+                <div class="integration-node node-left">Railway<br>Deploy</div>
             </div>
 
             <div class="integration-grid">
                 <div class="integration-category c1">
                     <span class="category-icon">💬</span>
-                    <h3 class="category-title">通訊整合</h3>
-                    <p class="category-description">連接各大通訊平台，讓AI機器人在用戶常用的平台上提供服務</p>
+                    <h3 class="category-title">Channel Plugin</h3>
+                    <p class="category-description">已上線的外部通訊入口，聚焦可實際接入的 bot channel</p>
                     <div class="platform-list">
-                        <span class="platform-tag">Discord</span>
-                        <span class="platform-tag">Telegram</span>
-                        <span class="platform-tag">Slack</span>
-                        <span class="platform-tag">Teams</span>
-                        <span class="platform-tag">LINE</span>
-                        <span class="platform-tag">WhatsApp</span>
+                        <span class="platform-tag supported">Telegram</span>
                     </div>
                 </div>
                 <div class="integration-category c2">
                     <span class="category-icon">🚀</span>
-                    <h3 class="category-title">開發生態</h3>
-                    <p class="category-description">與主流開發工具深度整合，提升開發者體驗和工作效率</p>
+                    <h3 class="category-title">開發與部署</h3>
+                    <p class="category-description">目前用於 EClawbot 開發、PR 審查與正式服務部署的實際工具鏈</p>
                     <div class="platform-list">
-                        <span class="platform-tag">GitHub</span>
-                        <span class="platform-tag">GitLab</span>
-                        <span class="platform-tag">VS Code</span>
-                        <span class="platform-tag">JetBrains</span>
-                        <span class="platform-tag">Docker</span>
-                        <span class="platform-tag">Kubernetes</span>
+                        <span class="platform-tag supported">GitHub</span>
+                        <span class="platform-tag supported">Railway</span>
                     </div>
                 </div>
                 <div class="integration-category c3">
-                    <span class="category-icon">☁️</span>
-                    <h3 class="category-title">雲端基建</h3>
-                    <p class="category-description">支援各大雲端平台部署，確保高可用性和全球化服務</p>
+                    <span class="category-icon">🧠</span>
+                    <h3 class="category-title">AI / Embedding Provider</h3>
+                    <p class="category-description">後端已接線的模型與向量搜尋供應商，依 device vault 設定啟用</p>
                     <div class="platform-list">
-                        <span class="platform-tag">AWS</span>
-                        <span class="platform-tag">Azure</span>
-                        <span class="platform-tag">GCP</span>
-                        <span class="platform-tag">Railway</span>
-                        <span class="platform-tag">Vercel</span>
-                        <span class="platform-tag">DigitalOcean</span>
+                        <span class="platform-tag supported">MiniMax</span>
+                        <span class="platform-tag supported">Anthropic</span>
+                        <span class="platform-tag supported">OpenAI</span>
+                        <span class="platform-tag supported">Voyage</span>
                     </div>
                 </div>
             </div>
@@ -472,26 +502,20 @@
             <div class="stats-banner">
                 <div class="stats-content">
                     <div class="stat-item">
-                        <div class="stat-number">50+</div>
-                        <div class="stat-label">支援平台</div>
+                        <div class="stat-number">7</div>
+                        <div class="stat-label">已上線 / 已接線整合</div>
                     </div>
                     <div class="stat-item">
-                        <div class="stat-number">99.9%</div>
-                        <div class="stat-label">整合成功率</div>
+                        <div class="stat-number">1</div>
+                        <div class="stat-label">公開 channel plugin</div>
                     </div>
                     <div class="stat-item">
-                        <div class="stat-number">24/7</div>
-                        <div class="stat-label">即時同步</div>
+                        <div class="stat-number">2026-05</div>
+                        <div class="stat-label">清單更新月份</div>
                     </div>
                 </div>
+                <p class="stats-note">僅展示目前可用或已接線能力；未上線/未實作項目不列為正式支援，規劃中的整合會待完成後再加入清單。</p>
             </div>
-        </section>
-
-        <section class="cta-section">
-            <a class="cta-button" href="#">
-                查看完整整合列表
-                <span>→</span>
-            </a>
         </section>
     </div>
 </body>

--- a/backend/tests/jest/info-integration-slide.test.js
+++ b/backend/tests/jest/info-integration-slide.test.js
@@ -1,0 +1,74 @@
+/**
+ * Regression coverage for the Cross-platform Integration Ecosystem info slide.
+ * The marketing slide must only present integrations that are actually
+ * supported or wired today, and must not show invented platform counts/SLA.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const SLIDE = path.resolve(__dirname, '../../public/portal/assets/slides/info-integration.html');
+const INDEX_JS = path.resolve(__dirname, '../../index.js');
+
+const UNSUPPORTED_VISIBLE_CLAIMS = [
+    'Discord',
+    'Slack',
+    'Teams',
+    'LINE',
+    'WhatsApp',
+    'GitLab',
+    'VS Code',
+    'JetBrains',
+    'Docker',
+    'Kubernetes',
+    'AWS',
+    'Azure',
+    'GCP',
+    'Vercel',
+    'DigitalOcean',
+];
+
+describe('Integration ecosystem slide copy', () => {
+    const source = fs.readFileSync(SLIDE, 'utf8');
+
+    test('only lists currently supported or wired integrations', () => {
+        for (const name of ['Telegram', 'Railway', 'GitHub', 'MiniMax', 'Anthropic', 'OpenAI', 'Voyage']) {
+            expect(source).toContain(name);
+        }
+        for (const name of UNSUPPORTED_VISIBLE_CLAIMS) {
+            expect(source).not.toContain(name);
+        }
+    });
+
+    test('removes invented scale, success-rate, and SLA stats', () => {
+        expect(source).not.toContain('50+');
+        expect(source).not.toContain('99.9%');
+        expect(source).not.toContain('24/7');
+        expect(source).toContain('7');
+        expect(source).toContain('已上線 / 已接線整合');
+        expect(source).toContain('1');
+        expect(source).toContain('公開 channel plugin');
+        expect(source).toContain('2026-05');
+    });
+
+    test('does not keep a dead complete-integration-list CTA', () => {
+        expect(source).not.toContain('查看完整整合列表');
+        expect(source).not.toMatch(/href=["']#["']/);
+    });
+
+    test('clearly states that only available or wired capabilities are shown', () => {
+        expect(source).toContain('僅列出已上線或已接線能力');
+        expect(source).toContain('未上線/未實作項目不列為正式支援');
+    });
+});
+
+describe('info-integration-slide debug endpoint registration', () => {
+    test('backend exposes an authenticated temporary debug endpoint for slide verification', () => {
+        const source = fs.readFileSync(INDEX_JS, 'utf8');
+        expect(source).toMatch(/app\.get\(['"]\/api\/debug\/info-integration-slide['"]/);
+        expect(source).toMatch(/unsupportedClaimsPresent/);
+        expect(source).toMatch(/supportedIntegrationsPresent/);
+        expect(source).toMatch(/hasActualStats/);
+        expect(source).toMatch(/hasDeadCompleteListCta/);
+    });
+});


### PR DESCRIPTION
## Summary
- Update `info-integration.html` to only list currently supported or wired integrations: Telegram, Railway, GitHub, MiniMax, Anthropic, OpenAI, and Voyage.
- Remove unsupported platform claims and the dead `查看完整整合列表` CTA.
- Replace invented `50+`, `99.9%`, and `24/7` stats with dated, concrete availability counts.
- Add mobile responsive rules for the slide and a temporary authenticated debug endpoint.
- Add regression coverage for the slide claims.

## Root cause
The marketing slide presented planned/unsupported integrations and unsourced availability/SLA metrics as if they were production-supported capabilities.

## Validation
- `node --check backend/index.js`
- `cd backend && npx jest tests/jest/info-integration-slide.test.js tests/jest/info-pricing-slide.test.js tests/jest/info-leaderboard-slide.test.js --runInBand`
- `git diff --check`
- Local Chrome screenshots generated for desktop `1440x900` and mobile `390x844`; mobile layout no longer cuts the integration hub/cards horizontally.
