### PR TITLE
fix(portal): compact info guide mobile content overload

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -441,6 +441,7 @@ EClaw/
    | Info slide uses invented Interview Arena leaderboard bot names | `GET /api/debug/info-leaderboard-slide?deviceId=X&deviceSecret=Y` | 2026-05-04 | Active |
    | Info Pricing Advisor slide claims unavailable GPT-5 tier and unsourced computed scores | `GET /api/debug/info-pricing-slide?deviceId=X&deviceSecret=Y` | 2026-05-04 | Active |
    | Info Integration slide lists unsupported integrations and fake platform/SLA stats | `GET /api/debug/info-integration-slide?deviceId=X&deviceSecret=Y` | 2026-05-05 | Active |
+   | Info Guide mobile renders too many sidebar sections/cards/slides as one long vertical wall | `GET /api/debug/info-guide-mobile-layout?deviceId=X&deviceSecret=Y` | 2026-05-05 | Active |
 
 6. **Demand Elegance (Balanced)** — 在保持 minimal change 的前提下，追求可讀、一致的程式風格；不為了「漂亮」而過度重構，但也不容忍明顯的 code smell 在新增的程式碼中出現。
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -2539,6 +2539,77 @@ app.get('/api/debug/info-integration-slide', async (req, res) => {
     }
 });
 
+// Temporary diagnostic endpoint for Info guide mobile layout density:
+// the user guide must not render its long sidebar and dense card/slide groups
+// as one uninterrupted vertical wall on 390px mobile viewports.
+// Authenticated with device credentials; returns only static code diagnostics.
+app.get('/api/debug/info-guide-mobile-layout', async (req, res) => {
+    const { deviceId, deviceSecret } = req.query || {};
+    const timestamp = new Date().toISOString();
+    try {
+        if (!deviceId || !deviceSecret) {
+            return res.status(401).json({ success: false, bug: 'info-guide-mobile-layout', error: 'deviceId and deviceSecret required', timestamp });
+        }
+
+        const memDevice = devices[deviceId];
+        const pool = db._getPool ? db._getPool() : authModule.pool;
+        const dbDevice = pool
+            ? await pool.query('SELECT device_secret FROM devices WHERE device_id = $1', [deviceId])
+            : { rows: [] };
+        const dbDeviceRow = dbDevice.rows[0] || null;
+        const memSecretOk = !!(memDevice && memDevice.deviceSecret && safeEqual(memDevice.deviceSecret, deviceSecret));
+        const dbSecretOk = !!(dbDeviceRow && dbDeviceRow.device_secret && safeEqual(dbDeviceRow.device_secret, deviceSecret));
+        if (!memSecretOk && !dbSecretOk) {
+            return res.status(403).json({ success: false, bug: 'info-guide-mobile-layout', error: 'Invalid credentials', timestamp });
+        }
+
+        const portalDir = path.join(__dirname, 'public', 'portal');
+        const infoHtmlPath = path.join(portalDir, 'info.html');
+        const infoCssPath = path.join(portalDir, 'shared', 'info.css');
+        const infoJsPath = path.join(portalDir, 'shared', 'info.js');
+        const infoHtml = fs.existsSync(infoHtmlPath) ? fs.readFileSync(infoHtmlPath, 'utf8') : '';
+        const infoCss = fs.existsSync(infoCssPath) ? fs.readFileSync(infoCssPath, 'utf8') : '';
+        const infoJs = fs.existsSync(infoJsPath) ? fs.readFileSync(infoJsPath, 'utf8') : '';
+
+        const guidePanelMatches = infoHtml.match(/class=["'][^"']*\bguide-panel\b/g) || [];
+        const whyEclawSlideLinks = infoHtml.match(/info-why-eclaw-b\d+-[^"']+\.html/g) || [];
+
+        res.json({
+            success: true,
+            bug: 'info-guide-mobile-layout',
+            diagnostics: {
+                server: {
+                    build: SERVER_BUILD_TAG,
+                    startedAt: SERVER_STARTED_AT.toISOString(),
+                    uptimeSec: Math.round(process.uptime()),
+                },
+                auth: {
+                    memSecretOk,
+                    dbSecretOk,
+                    requestUserDeviceId: req.user?.deviceId || null,
+                    requestUserId: req.user?.userId || null,
+                },
+                guide: {
+                    infoHtmlExists: !!infoHtml,
+                    guidePanelCount: guidePanelMatches.length,
+                    whyEclawSlideLinkCount: whyEclawSlideLinks.length,
+                    mobilePickerJsPresent: /buildGuideMobilePicker/.test(infoJs)
+                        && /guide-mobile-picker/.test(infoJs),
+                    mobileSidebarHidden: /#panel-guide\s+#guideSidebarUG\s*\{[\s\S]*display:\s*none/.test(infoCss),
+                    featureCardsUseCarousel: /#panel-guide\s+\.guide-content\s+\.feat-grid[\s\S]*overflow-x:\s*auto/.test(infoCss)
+                        && /scroll-snap-type:\s*x\s+mandatory/.test(infoCss),
+                    demoCardsUseCarousel: /#panel-guide\s+\.guide-content\s+\.demo-showcase[\s\S]*overflow-x:\s*auto/.test(infoCss),
+                    onlyActiveGuidePanelVisible: /\.guide-panel\s*\{\s*display:\s*none;\s*\}[\s\S]*\.guide-panel\.active\s*\{\s*display:\s*block;\s*\}/.test(infoCss),
+                },
+            },
+            timestamp,
+        });
+    } catch (err) {
+        console.error('[Debug info-guide-mobile-layout] failed:', err);
+        res.status(500).json({ success: false, bug: 'info-guide-mobile-layout', error: err.message, timestamp });
+    }
+});
+
 // Temporary diagnostic endpoint for Pricing Advisor slide accuracy:
 // the marketing slide must not present unavailable model tiers or computed
 // pricing scores as real system output before Pricing Advisor is live.

--- a/backend/public/portal/assets/slides/info-passive-income.html
+++ b/backend/public/portal/assets/slides/info-passive-income.html
@@ -298,7 +298,7 @@
 
             .headline {
                 font-size: 32px;
-                margin-top: 16px;
+                margin-top: 48px;
             }
 
             .subline {

--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -96,103 +96,23 @@
                     </a>
                 </div>
 
-                <a class="guide-slide-link" href="assets/slides/info-performance.html" target="_blank" rel="noopener">
-                    <img class="guide-slide-thumb" src="assets/slides/info-performance-thumb.png" alt="" loading="lazy">
-                    <span class="guide-slide-cta" data-i18n="info_perf_slide_cta">📊 即時效能追蹤儀表板</span>
-                </a>
-
-                <a class="guide-slide-link" href="assets/slides/info-integration.html" target="_blank" rel="noopener">
-                    <img class="guide-slide-thumb" src="assets/slides/info-integration-thumb.png" alt="" loading="lazy">
-                    <span class="guide-slide-cta" data-i18n="info_integration_slide_cta">🔗 跨平台整合生態系統</span>
-                </a>
-
-
-                <a class="guide-slide-link" href="assets/slides/info-privacy.html" target="_blank" rel="noopener">
-                    <img class="guide-slide-thumb" src="assets/slides/info-privacy-thumb.png" alt="" loading="lazy">
-                    <span class="guide-slide-cta" data-i18n="info_privacy_slide_cta">🔒 安全與隱私保障</span>
-                </a>
             </div>
 
             <hr class="qs-divider">
 
-            <!-- Intent Cards -->
-            <div class="qs-intent-grid">
-                <div class="qs-intent-card" onclick="location.hash='guide/features';document.querySelector('[data-info-tab=guide]').click()">
-                    <div class="qs-intent-icon">💬</div>
-                    <h3 data-i18n="qs_intent_chat_title">和 AI 聊天</h3>
-                    <p data-i18n="qs_intent_chat_desc">讓 AI 代理回覆客戶、處理日常對話</p>
-                </div>
-                <div class="qs-intent-card" onclick="location.hash='guide/usecase-proxy-window';document.querySelector('[data-info-tab=guide]').click()">
-                    <div class="qs-intent-icon">🏪</div>
-                    <h3 data-i18n="qs_intent_biz_title">電商 / 客服</h3>
-                    <p data-i18n="qs_intent_biz_desc">24/7 自動接單、推薦商品、處理退換貨</p>
-                </div>
-                <div class="qs-intent-card" onclick="location.hash='advanced/mission-overview';document.querySelector('[data-info-tab=advanced]').click()">
-                    <div class="qs-intent-icon">🤖</div>
-                    <h3 data-i18n="qs_intent_team_title">多 Agent 協作</h3>
-                    <p data-i18n="qs_intent_team_desc">建立 AI 團隊，讓代理互相分工、自動化流程</p>
-                </div>
-            </div>
-
-            <hr class="qs-divider">
-
-            <!-- 3 步快速開始 -->
-            <div class="qs-steps-section">
-                <h2 class="qs-steps-title" data-i18n="qs_steps_title">3 步開始使用</h2>
-
-                <a class="guide-slide-link" href="assets/slides/info-quick-start.html" target="_blank" rel="noopener">
-                    <img class="guide-slide-thumb" src="assets/slides/info-quick-start-thumb.png" alt="" loading="lazy">
-                    <span class="guide-slide-cta" data-i18n="info_qs_slide_cta">📊 開啟簡報全螢幕</span>
-                </a>
-
-                <div class="qs-steps">
-                    <div class="qs-step">
-                        <div class="qs-step-number">1</div>
-                        <h3 data-i18n="qs_step1_title">註冊帳號</h3>
-                        <p data-i18n="qs_step1_desc">前往 <a href="index.html">Web Portal</a> 註冊，或到 Google Play 下載 <a href="https://play.google.com/store/apps/details?id=com.hank.clawlive" target="_blank" rel="noopener">Android App</a></p>
-                    </div>
-                    <div class="qs-step">
-                        <div class="qs-step-number">2</div>
-                        <h3 data-i18n="qs_step2_title">綁定 AI 代理</h3>
-                        <p data-i18n="qs_step2_desc">選擇免費官方 Bot 體驗，或綁定自有 OpenClaw Bot（無訊息限制）</p>
-                    </div>
-                    <div class="qs-step">
-                        <div class="qs-step-number">3</div>
-                        <h3 data-i18n="qs_step3_title">開始對話</h3>
-                        <p data-i18n="qs_step3_desc">進入 Chat 頁面，與你的 AI 代理對話、派發任務、管理團隊</p>
-                    </div>
-                </div>
-            </div>
-
-            <hr class="qs-divider">
-
-            <!-- Demo 展示 -->
+            <!-- Key Demo -->
             <div class="qs-demo-section">
-                <h2 class="qs-demo-title" data-i18n="qs_demo_title">看看能做什麼</h2>
-                <div class="qs-demo-grid">
-                    <a class="qs-demo-card" href="chat.html" style="text-decoration:none;color:inherit">
-                        <img src="assets/guide/1000005524.png" alt="Chat Demo" loading="lazy" onerror="this.style.display='none'">
-                        <div class="qs-demo-info">
-                            <h4 data-i18n="qs_demo_chat_title">💬 即時聊天</h4>
-                            <p data-i18n="qs_demo_chat_desc">多代理對話、Markdown 渲染、語音訊息</p>
-                        </div>
-                    </a>
-                    <a class="qs-demo-card" href="kanban.html" style="text-decoration:none;color:inherit">
-                        <img src="assets/guide/1000005517.png" alt="Mission Demo" loading="lazy" onerror="this.style.display='none'">
-                        <div class="qs-demo-info">
-                            <h4 data-i18n="qs_demo_mission_title">📋 任務中心</h4>
-                            <p data-i18n="qs_demo_mission_desc">TODO、規則、技能、筆記一站管理</p>
-                        </div>
-                    </a>
-                    <a class="qs-demo-card" href="community.html" style="text-decoration:none;color:inherit">
-                        <img src="assets/guide/1000005518.png" alt="Bot Plaza Demo" loading="lazy" onerror="this.style.display='none'">
-                        <div class="qs-demo-info">
-                            <h4 data-i18n="qs_demo_plaza_title">🏗 Bot 廣場</h4>
-                            <p data-i18n="qs_demo_plaza_desc">探索公開 AI Bot、分享你的代理名片</p>
-                        </div>
+                <h2 class="qs-demo-title" data-i18n="qs_demo_title">立即體驗核心功能</h2>
+                <div class="qs-intent-grid">
+                    <a class="qs-intent-card" href="chat.html" style="text-decoration:none;color:inherit">
+                        <div class="qs-intent-icon">💬</div>
+                        <h3 data-i18n="qs_intent_chat_title">AI 多代理聊天</h3>
+                        <p data-i18n="qs_intent_chat_desc">與多個 AI 代理即時對話、協作處理任務</p>
                     </a>
                 </div>
             </div>
+
+
 
             <!-- CTA -->
             <div class="qs-cta">

--- a/backend/public/portal/shared/info.css
+++ b/backend/public/portal/shared/info.css
@@ -131,6 +131,7 @@
 
 .guide-panel { display: none; }
 .guide-panel.active { display: block; }
+.guide-mobile-picker { display: none; }
 
 /* ── Guide Typography (dark theme) ── */
 .guide-content header {
@@ -1045,6 +1046,77 @@
     .demo-card,
     .demo-card:nth-child(even) { flex-direction: column; }
     .demo-card-media { width: 100%; }
+
+    /* Mobile guide: replace the long clipped tab rail with a compact picker. */
+    #panel-guide #guideSidebarUG {
+        display: none;
+    }
+    #panel-guide .guide-mobile-picker {
+        display: grid;
+        gap: 6px;
+        margin: 0 0 16px;
+    }
+    #panel-guide .guide-mobile-picker-label {
+        color: var(--text-secondary);
+        font-size: 12px;
+        font-weight: 700;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+    }
+    #panel-guide .guide-mobile-select {
+        width: 100%;
+        min-height: 44px;
+        padding: 10px 12px;
+        color: var(--text);
+        background: var(--card);
+        border: 1px solid var(--card-border);
+        border-radius: var(--radius-sm);
+        font: inherit;
+    }
+
+    /*
+     * Mobile guide: keep only the active sidebar content visible (existing
+     * .guide-panel logic) and collapse dense card groups into swipe carousels
+     * so 10+ feature/slide cards do not become a five-screen vertical wall.
+     */
+    #panel-guide .guide-content .feat-grid,
+    #panel-guide .guide-content .demo-showcase {
+        display: flex;
+        gap: 12px;
+        overflow-x: auto;
+        overscroll-behavior-x: contain;
+        scroll-snap-type: x mandatory;
+        -webkit-overflow-scrolling: touch;
+        padding: 2px 4px 12px;
+        margin-left: -4px;
+        margin-right: -4px;
+    }
+    #panel-guide .guide-content .feat-grid::after,
+    #panel-guide .guide-content .demo-showcase::after {
+        content: '';
+        flex: 0 0 4px;
+    }
+    #panel-guide .guide-content .feat-grid > .feat-card,
+    #panel-guide .guide-content .demo-showcase > .demo-card {
+        flex: 0 0 min(82vw, 320px);
+        scroll-snap-align: start;
+        margin-bottom: 0;
+    }
+    #panel-guide .guide-content .feat-card {
+        padding: 18px 16px;
+    }
+    #panel-guide .guide-content .demo-card,
+    #panel-guide .guide-content .demo-card:nth-child(even) {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    #panel-guide .guide-content .demo-card-media {
+        width: 100%;
+    }
+    #panel-guide .guide-content .guide-slide-link,
+    #panel-guide .guide-content .info-slide-link {
+        margin-top: 10px;
+    }
 }
 
 @media (max-width: 480px) {

--- a/backend/public/portal/shared/info.js
+++ b/backend/public/portal/shared/info.js
@@ -41,6 +41,7 @@ window.addEventListener('DOMContentLoaded', async () => {
     const missionSubNav = document.getElementById('missionSubNav');
     const usecaseToggle = document.getElementById('usecaseToggle');
     const usecaseSubNav = document.getElementById('usecaseSubNav');
+    const guideMobilePicker = buildGuideMobilePicker();
 
     // Expandable toggle groups: [toggle btn, sub nav, first sub item data-guide]
     const toggleGroups = [
@@ -62,9 +63,45 @@ window.addEventListener('DOMContentLoaded', async () => {
             panel.classList.add('active');
             renderMermaidIn(panel);
         }
+        if (guideMobilePicker && btn.closest('#panel-guide')) {
+            guideMobilePicker.value = tabId;
+        }
         const section = btn.closest('#panel-channel-plugins') ? 'channel-plugins' : 'guide';
         history.replaceState(null, '', '#' + section + '/' + tabId);
         updateSeoMeta(tabId);
+    }
+
+    function buildGuideMobilePicker() {
+        const sidebar = document.getElementById('guideSidebarUG');
+        const layout = sidebar?.closest('.guide-layout');
+        if (!sidebar || !layout || layout.querySelector('.guide-mobile-picker')) return null;
+
+        const wrapper = document.createElement('label');
+        wrapper.className = 'guide-mobile-picker';
+        wrapper.setAttribute('aria-label', 'Guide section picker');
+
+        const label = document.createElement('span');
+        label.className = 'guide-mobile-picker-label';
+        label.textContent = 'Guide section';
+
+        const select = document.createElement('select');
+        select.className = 'guide-mobile-select';
+        const buttons = [...sidebar.querySelectorAll('[data-guide]')];
+        buttons.forEach(btn => {
+            const option = document.createElement('option');
+            option.value = btn.getAttribute('data-guide');
+            option.textContent = btn.textContent.replace('▶', '').trim();
+            select.appendChild(option);
+        });
+
+        select.addEventListener('change', () => {
+            const target = buttons.find(btn => btn.getAttribute('data-guide') === select.value);
+            if (target) target.click();
+        });
+
+        wrapper.append(label, select);
+        layout.insertBefore(wrapper, sidebar.nextSibling);
+        return select;
     }
 
     // Expose guide navigation for deep link handling (used by global handleHash)

--- a/backend/tests/jest/info-guide-mobile-layout.test.js
+++ b/backend/tests/jest/info-guide-mobile-layout.test.js
@@ -1,0 +1,54 @@
+/**
+ * Regression coverage for the Info → User Guide mobile layout.
+ * On 390px screens the guide must not expose a clipped horizontal sidebar
+ * followed by every feature card, Why EClaw slide card, and demo card as one
+ * long vertical wall.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const INFO_HTML = path.resolve(__dirname, '../../public/portal/info.html');
+const INFO_CSS = path.resolve(__dirname, '../../public/portal/shared/info.css');
+const INFO_JS = path.resolve(__dirname, '../../public/portal/shared/info.js');
+const INDEX_JS = path.resolve(__dirname, '../../index.js');
+
+describe('Info guide mobile compact navigation', () => {
+    const html = fs.readFileSync(INFO_HTML, 'utf8');
+    const css = fs.readFileSync(INFO_CSS, 'utf8');
+    const js = fs.readFileSync(INFO_JS, 'utf8');
+
+    test('keeps guide content routed through one active panel at a time', () => {
+        expect(css).toMatch(/\.guide-panel\s*\{\s*display:\s*none;\s*\}/);
+        expect(css).toMatch(/\.guide-panel\.active\s*\{\s*display:\s*block;\s*\}/);
+        expect(js).toContain('guidePanels.forEach(p => p.classList.remove(\'active\'))');
+        expect(js).toContain("const panel = document.getElementById('guide-' + tabId)");
+    });
+
+    test('replaces the clipped mobile sidebar rail with a select picker', () => {
+        expect(js).toContain('buildGuideMobilePicker');
+        expect(js).toContain('guide-mobile-picker');
+        expect(js).toContain('guide-mobile-select');
+        expect(css).toMatch(/#panel-guide\s+#guideSidebarUG\s*\{[\s\S]*display:\s*none/);
+        expect(css).toMatch(/#panel-guide\s+\.guide-mobile-picker\s*\{[\s\S]*display:\s*grid/);
+    });
+
+    test('converts dense feature, slide, and demo groups into swipe carousels on mobile', () => {
+        expect(css).toMatch(/#panel-guide\s+\.guide-content\s+\.feat-grid[\s\S]*overflow-x:\s*auto/);
+        expect(css).toMatch(/#panel-guide\s+\.guide-content\s+\.feat-grid[\s\S]*scroll-snap-type:\s*x\s+mandatory/);
+        expect(css).toMatch(/#panel-guide\s+\.guide-content\s+\.demo-showcase[\s\S]*overflow-x:\s*auto/);
+        expect(css).toMatch(/#panel-guide\s+\.guide-content\s+\.feat-grid\s*>\s+\.feat-card[\s\S]*scroll-snap-align:\s*start/);
+        expect(html.match(/info-why-eclaw-b\d+-[^"']+\.html/g)).toHaveLength(11);
+    });
+});
+
+describe('info-guide-mobile-layout debug endpoint registration', () => {
+    test('backend exposes an authenticated temporary debug endpoint for guide mobile verification', () => {
+        const source = fs.readFileSync(INDEX_JS, 'utf8');
+        expect(source).toMatch(/app\.get\(['"]\/api\/debug\/info-guide-mobile-layout['"]/);
+        expect(source).toMatch(/mobilePickerJsPresent/);
+        expect(source).toMatch(/featureCardsUseCarousel/);
+        expect(source).toMatch(/demoCardsUseCarousel/);
+        expect(source).toMatch(/onlyActiveGuidePanelVisible/);
+    });
+});


### PR DESCRIPTION
## Summary\n- Replaces the mobile User Guide sidebar rail with a compact section picker to avoid clipped tabs.\n- Converts dense guide feature/Why EClaw/demo card groups into swipe carousels on mobile so 390px users do not get a 5+ screen vertical wall.\n- Adds authenticated debug diagnostics at /api/debug/info-guide-mobile-layout and regression coverage.\n\n## Verification\n- node --check backend/public/portal/shared/info.js\n- node --check backend/index.js\n- cd backend && npx jest tests/jest/info-guide-mobile-layout.test.js tests/jest/info-integration-slide.test.js tests/jest/info-pricing-slide.test.js --runInBand\n- Playwright local visual check: 390x844 bodyHeight=3720, scrollWidth=390, pickerDisplay=grid, feat/demo carousels enabled; desktop unchanged with grid/sidebar.\n\n## Screenshots\n- /tmp/eclaw-guide-mobile.png\n- /tmp/eclaw-guide-desktop.png