### PR TITLE
fix(portal): align cross-device code display with spec S4.1.3

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3955,7 +3955,7 @@
             xdeviceCodesWithMessages.forEach(code => {
                 const existing = group.querySelector(`[data-filter="xdevice-${code}"]`);
                 if (existing) return;
-                const shortCode = code.length > 12 ? code.slice(0, 8) : code;
+                const shortCode = code.length > 12 ? code.slice(0, 6) : code;
                 const label = xdeviceLabelCache[code] || `\u{1F310} ${shortCode}`;
                 const chip = document.createElement('button');
                 chip.className = `filter-chip filter-chip-entity filter-chip-contact${currentFilter === 'xdevice-' + code ? ' active' : ''}`;
@@ -4186,7 +4186,7 @@
             if (myPublicCodeMap[code]) return myPublicCodeMap[code].label;
             if (xdeviceLabelCache[code]) return xdeviceLabelCache[code];
             // Shorten UUID-style device IDs to first 8 chars for readability
-            const display = code && code.length > 12 ? code.slice(0, 8) : code;
+            const display = code && code.length > 12 ? code.slice(0, 6) : code;
             return `&#x1F310; ${escapeHtml(display)}`;
         }
 


### PR DESCRIPTION
## Summary
- Fix publicCode display truncation: spec S4.1.3 requires first 6 chars, code used 8
- Affects filter chip labels and source labels in chat

## Test plan
- [x] Visual: cross-device messages show shorter code prefix

## Self-Review Checklist
### Part A
| # | Item | Status |
|---|------|--------|
| 1 | Logic trace | ✅ Simple string truncation change |
| 2 | Test coverage | ⚠️ NO-OP (visual only) |
| 3 | Return shape | ⚠️ NO-OP |
| 4 | What this does NOT fix | ✅ Android/iOS need separate update |
| 5 | Security | ⚠️ NO-OP |
### Part B
| # | Item | Status |
|---|------|--------|
| 6-10 | All | ⚠️ NO-OP |

🤖 Generated with [Claude Code](https://claude.com/claude-code)