### PR TITLE
feat(growth): track signup source attribution

### DIFF
--- a/backend/auth.js
+++ b/backend/auth.js
@@ -62,6 +62,32 @@ function generateDeviceCredentials() {
     return { deviceId, deviceSecret };
 }
 
+function normalizeSignupSource(value, fallback = 'unknown') {
+    const raw = (typeof value === 'string' ? value : '').trim().toLowerCase();
+    const normalized = raw
+        .replace(/\s+/g, '_')
+        .replace(/[^a-z0-9._:-]/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^[-_.:]+|[-_.:]+$/g, '')
+        .slice(0, 64);
+    return normalized || fallback;
+}
+
+function getSignupSource(req, fallback = 'unknown') {
+    const body = req?.body || {};
+    const query = req?.query || {};
+    const explicit = body.signup_source || body.signupSource || body.source
+        || query.signup_source || query.signupSource || query.source
+        || req?.get?.('x-signup-source') || req?.get?.('x-client-source');
+    const utmSource = body.utm_source || body.utmSource || query.utm_source || query.utmSource;
+    const inviteCode = body.invite_code || body.inviteCode || query.invite_code || query.inviteCode;
+
+    if (explicit) return normalizeSignupSource(explicit, fallback);
+    if (utmSource) return normalizeSignupSource(`utm:${utmSource}`, fallback);
+    if (inviteCode) return normalizeSignupSource('invite', fallback);
+    return normalizeSignupSource(fallback, 'unknown');
+}
+
 // Initialize database tables from schema file
 async function initAuthDatabase() {
     try {
@@ -208,6 +234,7 @@ module.exports = function(devices, getOrCreateDevice, serverLog) {
     router.post('/register', authRateLimit, async (req, res) => {
         try {
             const { email, password } = req.body;
+            const signupSource = getSignupSource(req, 'web_email');
 
             if (!email || !password) {
                 return res.status(400).json({ success: false, error: 'Email and password required' });
@@ -243,10 +270,10 @@ module.exports = function(devices, getOrCreateDevice, serverLog) {
 
             // Insert user
             const result = await pool.query(
-                `INSERT INTO user_accounts (email, password_hash, device_id, device_secret, verify_token, verify_token_expires)
-                 VALUES ($1, $2, $3, $4, $5, $6)
+                `INSERT INTO user_accounts (email, password_hash, device_id, device_secret, verify_token, verify_token_expires, signup_source)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7)
                  RETURNING id, email, device_id, device_secret`,
-                [emailLower, passwordHash, deviceId, deviceSecret, verifyToken, verifyExpires]
+                [emailLower, passwordHash, deviceId, deviceSecret, verifyToken, verifyExpires, signupSource]
             );
 
             const user = result.rows[0];
@@ -1003,6 +1030,7 @@ module.exports = function(devices, getOrCreateDevice, serverLog) {
     router.post('/bind-email', async (req, res) => {
         try {
             const { deviceId, deviceSecret, email, password } = req.body;
+            const signupSource = getSignupSource(req, 'device_bind_email');
 
             if (!deviceId || !deviceSecret || !email || !password) {
                 return res.status(400).json({ success: false, error: 'deviceId, deviceSecret, email, and password are required' });
@@ -1056,10 +1084,10 @@ module.exports = function(devices, getOrCreateDevice, serverLog) {
 
             // Create user account linked to existing device
             const result = await pool.query(
-                `INSERT INTO user_accounts (email, password_hash, device_id, device_secret, verify_token, verify_token_expires)
-                 VALUES ($1, $2, $3, $4, $5, $6)
+                `INSERT INTO user_accounts (email, password_hash, device_id, device_secret, verify_token, verify_token_expires, signup_source)
+                 VALUES ($1, $2, $3, $4, $5, $6, $7)
                  RETURNING id, email, device_id`,
-                [emailLower, passwordHash, deviceId, deviceSecret, verifyTokenValue, verifyExpires]
+                [emailLower, passwordHash, deviceId, deviceSecret, verifyTokenValue, verifyExpires, signupSource]
             );
 
             const user = result.rows[0];
@@ -1386,12 +1414,13 @@ module.exports = function(devices, getOrCreateDevice, serverLog) {
         const creds = (deviceId && deviceSecret && devices[deviceId] && safeEqual(devices[deviceId].deviceSecret, deviceSecret))
             ? { deviceId, deviceSecret }
             : generateDeviceCredentials();
+        const signupSource = getSignupSource(req, `${provider}_oauth`);
 
         const insertResult = await pool.query(
-            `INSERT INTO user_accounts (email, ${providerCol}, display_name, avatar_url, email_verified, auth_provider, device_id, device_secret)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+            `INSERT INTO user_accounts (email, ${providerCol}, display_name, avatar_url, email_verified, auth_provider, device_id, device_secret, signup_source)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
              RETURNING *`,
-            [email ? email.toLowerCase() : null, providerId, displayName, avatarUrl, !!email, provider, creds.deviceId, creds.deviceSecret]
+            [email ? email.toLowerCase() : null, providerId, displayName, avatarUrl, !!email, provider, creds.deviceId, creds.deviceSecret, signupSource]
         );
 
         const newUser = insertResult.rows[0];
@@ -1865,11 +1894,12 @@ module.exports = function(devices, getOrCreateDevice, serverLog) {
             if (!user) {
                 // Create new account
                 const { deviceId: newDeviceId, deviceSecret: newDeviceSecret } = generateDeviceCredentials();
+                const signupSource = getSignupSource(req, `oidc:${providerName.toLowerCase()}`);
                 const result = await pool.query(
-                    `INSERT INTO user_accounts (email, oidc_provider, oidc_subject, display_name, avatar_url, auth_provider, device_id, device_secret, email_verified)
-                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, TRUE)
+                    `INSERT INTO user_accounts (email, oidc_provider, oidc_subject, display_name, avatar_url, auth_provider, device_id, device_secret, email_verified, signup_source)
+                     VALUES ($1, $2, $3, $4, $5, $6, $7, $8, TRUE, $9)
                      RETURNING *`,
-                    [email, providerName.toLowerCase(), sub, displayName, avatarUrl, `oidc:${providerName.toLowerCase()}`, newDeviceId, newDeviceSecret]
+                    [email, providerName.toLowerCase(), sub, displayName, avatarUrl, `oidc:${providerName.toLowerCase()}`, newDeviceId, newDeviceSecret, signupSource]
                 );
                 user = result.rows[0];
                 isNewAccount = true;

--- a/backend/auth_schema.sql
+++ b/backend/auth_schema.sql
@@ -21,6 +21,8 @@ CREATE TABLE IF NOT EXISTS user_accounts (
     tappay_card_token TEXT,
     -- Admin
     is_admin BOOLEAN DEFAULT FALSE,
+    -- Growth attribution (aggregate-only source channel, never stores UTM params with PII)
+    signup_source VARCHAR(64) DEFAULT 'unknown',
     -- Preferences
     language VARCHAR(10) DEFAULT 'en',
     -- Metadata
@@ -33,6 +35,7 @@ CREATE INDEX IF NOT EXISTS idx_user_accounts_email ON user_accounts(email);
 CREATE INDEX IF NOT EXISTS idx_user_accounts_device_id ON user_accounts(device_id);
 CREATE INDEX IF NOT EXISTS idx_user_accounts_verify_token ON user_accounts(verify_token);
 CREATE INDEX IF NOT EXISTS idx_user_accounts_reset_token ON user_accounts(reset_token);
+CREATE INDEX IF NOT EXISTS idx_user_accounts_signup_source ON user_accounts(signup_source);
 
 -- ============================================
 -- Server-side Usage Tracking
@@ -89,6 +92,8 @@ ALTER TABLE chat_messages ADD COLUMN IF NOT EXISTS delivered_to TEXT DEFAULT NUL
 
 -- Migration: add is_admin column to existing user_accounts tables
 ALTER TABLE user_accounts ADD COLUMN IF NOT EXISTS is_admin BOOLEAN DEFAULT FALSE;
+ALTER TABLE user_accounts ADD COLUMN IF NOT EXISTS signup_source VARCHAR(64) DEFAULT 'unknown';
+CREATE INDEX IF NOT EXISTS idx_user_accounts_signup_source ON user_accounts(signup_source);
 
 -- Set admins
 UPDATE user_accounts SET is_admin = TRUE WHERE email IN ('hankhuang0516@gmail.com', 'bbb880008@gmail.com');

--- a/backend/growth.js
+++ b/backend/growth.js
@@ -80,6 +80,21 @@ async function fetchSignupsForDate(dateStr) {
     return r.rows[0].c;
 }
 
+async function fetchSignupSourceForDate(dateStr) {
+    const r = await pool.query(
+        `SELECT COALESCE(NULLIF(signup_source, ''), 'unknown') AS source,
+                COUNT(*)::int AS count
+         FROM user_accounts
+         WHERE created_at >= ($2::date::timestamp) AT TIME ZONE $1
+           AND created_at <  (($2::date + INTERVAL '1 day')::timestamp) AT TIME ZONE $1
+         GROUP BY 1
+         ORDER BY count DESC, source ASC
+         LIMIT 20`,
+        [TZ, dateStr]
+    );
+    return r.rows.map(row => ({ source: row.source || 'unknown', count: Number(row.count) || 0 }));
+}
+
 async function fetchRetention7dForDate(dateStr) {
     const r = await pool.query(
         `WITH anchor AS (
@@ -183,21 +198,22 @@ module.exports = function(devices) {
         }
 
         try {
-            const [today_signups, retention_7d, plaza_new_listed_today, invite_conversion] = await Promise.all([
+            const [today_signups, retention_7d, plaza_new_listed_today, invite_conversion, source_channel] = await Promise.all([
                 fetchSignupsForDate(anchorDate),
                 fetchRetention7dForDate(anchorDate),
                 fetchPlazaNewListedForDate(anchorDate),
-                fetchInviteConversion()
+                fetchInviteConversion(),
+                fetchSignupSourceForDate(anchorDate)
             ]);
             return res.json({
                 success: true,
                 date: anchorDate,
                 today_signups,
+                source_channel,
                 retention_7d,
                 plaza_new_listed_today,
                 invite_conversion,
                 follow_ups: [
-                    'source_channel: schema lacks signup_source column',
                     'visitor_to_signup_conversion: page_views has no FK to user_accounts',
                     'plaza_new_listed_today: counts created_at not status_changed_at (bot_listings has no listed_at column)',
                     'invite_conversion is cumulative-to-now (not date-scoped); needs invite_codes.used_at filter for historical k-value by day'
@@ -211,6 +227,6 @@ module.exports = function(devices) {
 
     return {
         router,
-        _internal: { checkRate, findEntity, isOwnerAdmin, fetchSignupsForDate, fetchRetention7dForDate, fetchPlazaNewListedForDate, fetchInviteConversion, isValidDateStr, taipeiTodayISO, rateBuckets }
+        _internal: { checkRate, findEntity, isOwnerAdmin, fetchSignupsForDate, fetchSignupSourceForDate, fetchRetention7dForDate, fetchPlazaNewListedForDate, fetchInviteConversion, isValidDateStr, taipeiTodayISO, rateBuckets }
     };
 };

--- a/backend/public/portal/index.html
+++ b/backend/public/portal/index.html
@@ -529,6 +529,17 @@
             return null;
         }
 
+        function collectSignupSource() {
+            const params = new URLSearchParams(window.location.search);
+            const explicit = params.get('signup_source') || params.get('signupSource') || params.get('source');
+            const utmSource = params.get('utm_source') || params.get('utmSource');
+            const inviteCode = params.get('code') || params.get('invite') || params.get('invite_code') || localStorage.getItem('pendingInviteCode');
+            if (explicit) return explicit;
+            if (utmSource) return `utm:${utmSource}`;
+            if (inviteCode) return 'invite';
+            return 'web_portal';
+        }
+
         function applyServerLanguage(data) {
             if (data && data.user && data.user.language) {
                 const lang = data.user.language;
@@ -590,7 +601,7 @@
             btn.textContent = i18n.t('login_btn_creating');
 
             try {
-                await apiCall('POST', '/api/auth/register', { email, password });
+                await apiCall('POST', '/api/auth/register', { email, password, signupSource: collectSignupSource() });
                 showMsg('regSuccess', i18n.t('sc_register_success_verify'), 'success');
                 document.getElementById('regEmail').value = '';
                 document.getElementById('regPassword').value = '';

--- a/backend/public/portal/share-chat.html
+++ b/backend/public/portal/share-chat.html
@@ -1054,7 +1054,7 @@
                 method: 'POST',
                 credentials: 'include',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ email, password: pw })
+                body: JSON.stringify({ email, password: pw, signupSource: 'share_chat' })
             });
             const data = await resp.json();
             dbg('info', `Register response: ${resp.status}`, data);
@@ -1132,7 +1132,7 @@
                 method: 'POST',
                 credentials: 'include',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ email, password: pw })
+                body: JSON.stringify({ email, password: pw, signupSource: 'share_chat' })
             });
             const data = await resp.json();
             if (!resp.ok || !data.success) {

--- a/backend/tests/jest/growth.test.js
+++ b/backend/tests/jest/growth.test.js
@@ -18,6 +18,8 @@ jest.mock('pg', () => ({
 
 const express = require('express');
 const request = require('supertest');
+const fs = require('fs');
+const path = require('path');
 
 let app;
 let growthModule;
@@ -62,14 +64,17 @@ const get = (qs) => request(app).get('/api/growth/daily' + qs);
 function setupAdminQueries({
     signups = 5, cohort = 10, active = 4, plaza = 2,
     total_codes = 0, redeemed_codes = 0,
+    sourceRows,
 } = {}) {
-    // is_admin lookup → 4 metric queries (parallel order: signups, retention, plaza, invite)
+    const finalSourceRows = sourceRows || [{ source: 'web_portal', count: signups }];
+    // is_admin lookup → 5 metric queries (parallel order: signups, retention, plaza, invite, source_channel)
     mockQuery
         .mockResolvedValueOnce({ rows: [{ is_admin: true }] })
         .mockResolvedValueOnce({ rows: [{ c: signups }] })
         .mockResolvedValueOnce({ rows: [{ cohort_size: cohort, active_size: active }] })
         .mockResolvedValueOnce({ rows: [{ c: plaza }] })
-        .mockResolvedValueOnce({ rows: [{ total_codes, redeemed_codes }] });
+        .mockResolvedValueOnce({ rows: [{ total_codes, redeemed_codes }] })
+        .mockResolvedValueOnce({ rows: finalSourceRows });
 }
 
 describe('Growth /daily auth', () => {
@@ -102,19 +107,39 @@ describe('Growth /daily auth', () => {
 });
 
 describe('Growth /daily aggregation contract', () => {
-    it('returns the 4 metrics + date + follow-ups list', async () => {
-        setupAdminQueries({ signups: 7, cohort: 20, active: 8, plaza: 3, total_codes: 50, redeemed_codes: 11 });
+    it('returns the 5 metrics + date + follow-ups list', async () => {
+        setupAdminQueries({
+            signups: 7, cohort: 20, active: 8, plaza: 3, total_codes: 50, redeemed_codes: 11,
+            sourceRows: [{ source: 'invite', count: 4 }, { source: 'web_portal', count: 3 }],
+        });
         const res = await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2');
         expect(res.status).toBe(200);
         expect(res.body.success).toBe(true);
         expect(res.body.today_signups).toBe(7);
+        expect(res.body.source_channel).toEqual([{ source: 'invite', count: 4 }, { source: 'web_portal', count: 3 }]);
         expect(res.body.retention_7d).toEqual({ cohort_size: 20, active_size: 8, pct: 40 });
         expect(res.body.plaza_new_listed_today).toBe(3);
         expect(res.body.invite_conversion).toEqual({ total_codes: 50, redeemed_codes: 11, pct: 22 });
         expect(res.body.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
         expect(Array.isArray(res.body.follow_ups)).toBe(true);
-        expect(res.body.follow_ups.length).toBe(4);
+        expect(res.body.follow_ups.length).toBe(3);
+        expect(res.body.follow_ups.some(s => /schema lacks signup_source/i.test(s))).toBe(false);
         expect(res.body.follow_ups.some(s => /invite_conversion.*cumulative/i.test(s))).toBe(true);
+    });
+
+    it('source_channel SQL groups by signup_source without leaking user rows', async () => {
+        setupAdminQueries({
+            signups: 6,
+            sourceRows: [{ source: 'utm:twitter', count: 4 }, { source: 'unknown', count: 2 }],
+        });
+        const res = await get('?deviceId=admin-dev&botSecret=admin-bot-sec&entityId=2&date=2026-04-17');
+        expect(res.status).toBe(200);
+        expect(res.body.source_channel).toEqual([{ source: 'utm:twitter', count: 4 }, { source: 'unknown', count: 2 }]);
+
+        const sourceCall = mockQuery.mock.calls.find(c => /signup_source/i.test(c[0]) && /GROUP BY 1/i.test(c[0]));
+        expect(sourceCall).toBeDefined();
+        expect(sourceCall[1]).toEqual(['Asia/Taipei', '2026-04-17']);
+        expect(sourceCall[0]).not.toMatch(/email|device_id|ip/i);
     });
 
     it('reports invite_conversion pct as null when no codes issued', async () => {
@@ -267,4 +292,24 @@ describe('Growth /daily rate limit', () => {
         const res = await get('?deviceId=user-dev&botSecret=user-bot-sec&entityId=2');
         expect(res.status).toBe(200);
     }, 30000);
+});
+
+describe('Growth signup_source schema contract', () => {
+    it('auth schema creates and migrates user_accounts.signup_source', () => {
+        const schema = fs.readFileSync(path.join(__dirname, '../../auth_schema.sql'), 'utf8');
+        expect(schema).toMatch(/signup_source\s+VARCHAR\(64\)/i);
+        expect(schema).toMatch(/ALTER TABLE user_accounts ADD COLUMN IF NOT EXISTS signup_source/i);
+        expect(schema).toMatch(/idx_user_accounts_signup_source/i);
+    });
+
+    it('portal registration surfaces send a signupSource field', () => {
+        const portalIndex = fs.readFileSync(path.join(__dirname, '../../public/portal/index.html'), 'utf8');
+        const shareChat = fs.readFileSync(path.join(__dirname, '../../public/portal/share-chat.html'), 'utf8');
+        const iosApi = fs.readFileSync(path.join(__dirname, '../../../ios-app/services/api.ts'), 'utf8');
+
+        expect(portalIndex).toMatch(/signupSource:\s*collectSignupSource\(\)/);
+        expect(portalIndex).toMatch(/utm:/);
+        expect(shareChat).toMatch(/signupSource:\s*'share_chat'/);
+        expect(iosApi).toMatch(/signupSource\s*=\s*'ios_app'/);
+    });
 });

--- a/ios-app/services/api.ts
+++ b/ios-app/services/api.ts
@@ -263,8 +263,8 @@ export const authApi = {
     apiClient.post('/api/auth/login', { email, password }),
 
   /** Register new account with email + password */
-  register: (email: string, password: string, displayName?: string) =>
-    apiClient.post('/api/auth/register', { email, password, displayName }),
+  register: (email: string, password: string, displayName?: string, signupSource = 'ios_app') =>
+    apiClient.post('/api/auth/register', { email, password, displayName, signupSource }),
 
   /** Login with device credentials (returns JWT) */
   deviceLogin: (deviceId: string, deviceSecret: string) =>


### PR DESCRIPTION
## Summary
- add `user_accounts.signup_source` schema + migration/index
- persist normalized signup source from email register, bind-email, OAuth/OIDC, web portal, share-chat, and iOS signup flows
- add `source_channel` aggregation to `/api/growth/daily` without exposing user rows/PII
- extend growth regression coverage for schema, aggregation, and client signup-source payloads

## Verification
- `git diff --check`
- `node -c backend/auth.js`
- `node -c backend/growth.js`
- `cd backend && npx jest tests/jest/growth.test.js --runInBand`

## Notes
- PR only; no production deploy or main push performed.
