### PR TITLE
fix(android): resolve compilation errors in MainViewModel and ScheduleAdapter

### DIFF
--- a/app/src/main/java/com/hank/clawlive/ui/MainViewModel.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/MainViewModel.kt
@@ -113,7 +113,7 @@ class MainViewModel(application: Application) : AndroidViewModel(application) {
                 } else {
                     _uiState.value = _uiState.value.copy(
                         isLoading = false,
-                        error = application.getString(R.string.error_occurred)
+                        error = getApplication<Application>().getString(R.string.error_occurred)
                     )
                 }
             } catch (e: retrofit2.HttpException) {

--- a/app/src/main/java/com/hank/clawlive/ui/schedule/ScheduleAdapter.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/schedule/ScheduleAdapter.kt
@@ -56,7 +56,7 @@ class ScheduleAdapter(
 
         // Entity — use real avatar from entityAvatars map, fall back to defaults
         val emoji = entityAvatars[item.entityId] ?: ENTITY_EMOJIS_DEFAULT[item.entityId] ?: "?"
-        val name = entityNames[item.entityId] ?: context.getString(R.string.entity_format, item.entityId)
+        val name = entityNames[item.entityId] ?: ctx.getString(R.string.entity_format, item.entityId)
         holder.tvEntity.text = "$emoji $name #${item.entityId}"
 
         // Repeat badge


### PR DESCRIPTION
## Summary
- **MainViewModel.kt:116**: `application` field is private in `AndroidViewModel` — replaced with `getApplication<Application>()`
- **ScheduleAdapter.kt:59**: `context` is undefined — replaced with local `ctx` variable (defined on line 52)

These two errors were introduced by the i18n hardcoded strings fix and cause Android CI to fail on `compileDebugKotlin`.

## Test plan
- [ ] Android CI lint/compile passes
- [ ] Verify MainViewModel binding code error message renders correctly
- [ ] Verify ScheduleAdapter entity name fallback works

🤖 Generated with [Claude Code](https://claude.com/claude-code)