### PR TITLE
[codex] Fix dashboard invite banner duplicate IDs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1088,6 +1088,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | ENV Vars Merge | `node backend/tests/test-vars-merge.js` | Device ID + Secret | Cross-platform merge, conflict splitting |
 | Channel API | `node backend/tests/test-channel-api.js` | Device ID + Secret | OpenClaw channel integration |
 | Kanban auto-review busy-state guard | `cd backend && npx jest tests/jest/kanban-autoreview-busy-state-guard.test.js --runInBand` | None | Regression: BUSY/PROCESSING/WORKING progress heartbeats must not auto-close kanban child cards before work completes |
+| Portal static IDs | `cd backend && npx jest tests/jest/portal-static-ids.test.js --runInBand` | None | Regression #2468: dashboard invite banners must have unique IDs and onboarding JS must target the onboarding banner |
 | Skill Templates | `node backend/tests/test-skill-templates.js` | None | Skill template CRUD, requiredVars format validation (Gson compat), contribute endpoint input guard |
 | WebSocket Auth | `node backend/tests/test-ws-auth.js` | Device ID + Secret | Socket.IO authentication |
 | AI Chat Image | `node backend/tests/test-ai-chat-image.js` | Device ID + Secret | AI chat with image support |

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -1564,7 +1564,7 @@
         </div>
 
         <!-- Invite Onboarding Banner (shown only when use_count=0 and not dismissed in last 7d) -->
-        <div id="inviteBanner" class="invite-banner" role="region" aria-label="Invite friends">
+        <div id="inviteOnboardingBanner" class="invite-banner" role="region" aria-label="Invite friends">
             <div class="invite-banner-icon">🎁</div>
             <div class="invite-banner-text">
                 <div class="invite-banner-title" data-i18n="invite_banner_title">Invite friends, earn e-coin together</div>
@@ -1686,7 +1686,7 @@
         </div>
 
         <!-- Invite Friends Banner (viral loop entry) -->
-        <a class="invite-banner" href="/portal/invite.html" id="inviteBanner">
+        <a class="invite-banner" href="/portal/invite.html" id="inviteFriendsBanner">
             <span class="invite-banner-icon" aria-hidden="true">🎁</span>
             <div class="invite-banner-text">
                 <div class="invite-banner-title" data-i18n="dash_invite_title">Invite friends, earn 500 e-coin per signup</div>
@@ -2038,7 +2038,7 @@
             if (useCount === 0) {
                 const dismissedAt = parseInt(localStorage.getItem(BANNER_KEY) || '0', 10);
                 if (!dismissedAt || (Date.now() - dismissedAt) > SEVEN_DAYS_MS) {
-                    const banner = document.getElementById('inviteBanner');
+                    const banner = document.getElementById('inviteOnboardingBanner');
                     const codeEl = document.getElementById('inviteBannerCode');
                     if (banner && codeEl) {
                         codeEl.textContent = code;
@@ -2050,7 +2050,7 @@
 
         function dismissInviteBanner() {
             try { localStorage.setItem('invite_banner_dismissed_at', String(Date.now())); } catch (e) {}
-            const banner = document.getElementById('inviteBanner');
+            const banner = document.getElementById('inviteOnboardingBanner');
             if (banner) banner.style.display = 'none';
         }
 

--- a/backend/tests/jest/portal-static-ids.test.js
+++ b/backend/tests/jest/portal-static-ids.test.js
@@ -1,0 +1,22 @@
+const fs = require('fs');
+const path = require('path');
+
+describe('portal static HTML IDs', () => {
+  test('dashboard invite banners have unique IDs and onboarding JS targets the onboarding banner', () => {
+    const dashboardPath = path.join(__dirname, '../../public/portal/dashboard.html');
+    const html = fs.readFileSync(dashboardPath, 'utf8');
+
+    const ids = [...html.matchAll(/\bid=["']([^"']+)["']/g)]
+      .map((match) => match[1])
+      // Ignore JavaScript template-string selectors embedded in inline scripts.
+      .filter((id) => !id.includes('${'));
+    const duplicates = ids.filter((id, index) => ids.indexOf(id) !== index);
+
+    expect(duplicates).not.toContain('inviteBanner');
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(html).toContain('id="inviteOnboardingBanner"');
+    expect(html).toContain('id="inviteFriendsBanner"');
+    expect(html).toContain("document.getElementById('inviteOnboardingBanner')");
+    expect(html).not.toContain("document.getElementById('inviteBanner')");
+  });
+});


### PR DESCRIPTION
## Summary
- Fix duplicate `inviteBanner` IDs in `backend/public/portal/dashboard.html`
- Point invite onboarding show/dismiss JS at `inviteOnboardingBanner`
- Add a Jest regression test for dashboard static IDs and invite banner selectors
- Register the new regression test in `AGENTS.md`

## Root cause
The dashboard rendered both the invite onboarding banner and the viral invite entry with `id="inviteBanner"`. The onboarding JS used `document.getElementById('inviteBanner')`, which depends on a unique DOM ID and can target the wrong/ambiguous element for future UI automation and accessibility tooling.

## Issue
Fixes #2468

## Validation
- `cd backend && npx jest tests/jest/portal-static-ids.test.js --runInBand` — PASS (existing Jest config warning about `runInBand` is non-blocking)
- `cd backend && npm run smoke:portal` — PASS
- `node --check` across 31 `backend/public/**/*.js` files — PASS, 0 syntax errors
- Static HTML duplicate-ID scan across 34 portal/public pages — PASS, 0 duplicate ID issues
