### PR TITLE
Show MiniGame submissions in admin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1087,6 +1087,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | gRPC Transport | `node backend/tests/test-grpc-transport.js` | None (local) | Proto loading, gRPC server, HealthService |
 | ENV Vars Merge | `node backend/tests/test-vars-merge.js` | Device ID + Secret | Cross-platform merge, conflict splitting |
 | Channel API | `node backend/tests/test-channel-api.js` | Device ID + Secret | OpenClaw channel integration |
+| MiniGame Admin Submissions | `cd backend && npx jest tests/jest/minigame-admin-submissions.test.js tests/jest/admin-auth.test.js --runInBand` | None | Regression: admin-only MiniGame submissions API matches feedback source/category/tags/body and admin page endpoint remains auth-gated |
 | Kanban auto-review busy-state guard | `cd backend && npx jest tests/jest/kanban-autoreview-busy-state-guard.test.js --runInBand` | None | Regression: BUSY/PROCESSING/WORKING progress heartbeats must not auto-close kanban child cards before work completes |
 | Portal static IDs | `cd backend && npx jest tests/jest/portal-static-ids.test.js --runInBand` | None | Regression #2468: dashboard invite banners must have unique IDs and onboarding JS must target the onboarding banner |
 | Skill Templates | `node backend/tests/test-skill-templates.js` | None | Skill template CRUD, requiredVars format validation (Gson compat), contribute endpoint input guard |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1066,6 +1066,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | gRPC Transport | `node backend/tests/test-grpc-transport.js` | None (local) | Proto loading, gRPC server, HealthService |
 | ENV Vars Merge | `node backend/tests/test-vars-merge.js` | Device ID + Secret | Cross-platform merge, conflict splitting |
 | Channel API | `node backend/tests/test-channel-api.js` | Device ID + Secret | OpenClaw channel integration |
+| MiniGame Admin Submissions | `cd backend && npx jest tests/jest/minigame-admin-submissions.test.js tests/jest/admin-auth.test.js --runInBand` | None | Regression: admin-only MiniGame submissions API matches feedback source/category/tags/body and admin page endpoint remains auth-gated |
 | Skill Templates | `node backend/tests/test-skill-templates.js` | None | Skill template CRUD, requiredVars format validation (Gson compat), contribute endpoint input guard |
 | WebSocket Auth | `node backend/tests/test-ws-auth.js` | Device ID + Secret | Socket.IO authentication |
 | AI Chat Image | `node backend/tests/test-ai-chat-image.js` | Device ID + Secret | AI chat with image support |

--- a/backend/device-feedback.js
+++ b/backend/device-feedback.js
@@ -38,6 +38,8 @@ async function initFeedbackTable(pool) {
         await pool.query(`ALTER TABLE feedback ADD COLUMN IF NOT EXISTS source VARCHAR(16) DEFAULT 'unknown'`);
         await pool.query(`CREATE INDEX IF NOT EXISTS idx_feedback_device ON feedback(device_id)`);
         await pool.query(`CREATE INDEX IF NOT EXISTS idx_feedback_status ON feedback(status)`);
+        await pool.query(`CREATE INDEX IF NOT EXISTS idx_feedback_source ON feedback(source)`);
+        await pool.query(`CREATE INDEX IF NOT EXISTS idx_feedback_tags ON feedback USING GIN(tags)`);
         console.log('[Feedback] Table migration complete');
     } catch (err) {
         console.error('[Feedback] Migration error:', err.message);
@@ -460,6 +462,95 @@ async function getFeedbackList(pool, { deviceId, status, severity, limit = 50, o
     }
 }
 
+const MINIGAME_FEEDBACK_TERMS = Object.freeze([
+    'minigame',
+    'mini_game',
+    'mini-game',
+    'mini game',
+    'game_factory',
+    'game-factory',
+    'game factory'
+]);
+
+function clampFeedbackPage(value, fallback, max) {
+    const parsed = parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed < 0) return fallback;
+    return Math.min(parsed, max);
+}
+
+function miniGameFeedbackWhereClause(termParam = '$1') {
+    return `(
+        LOWER(COALESCE(source, '')) = ANY(${termParam}::text[])
+        OR LOWER(COALESCE(category, '')) = ANY(${termParam}::text[])
+        OR EXISTS (
+            SELECT 1
+            FROM unnest(COALESCE(tags, ARRAY[]::text[])) AS feedback_tag(tag)
+            WHERE LOWER(feedback_tag.tag) = ANY(${termParam}::text[])
+        )
+        OR message ILIKE '%minigame%'
+        OR message ILIKE '%mini game%'
+        OR message ILIKE '%game factory%'
+    )`;
+}
+
+/**
+ * Admin-facing MiniGame submission list.
+ *
+ * MiniGame submissions are stored in the shared feedback table. The public
+ * submitter can identify them through source/category/tags; the message
+ * fallback keeps older submissions visible if they only mentioned MiniGame in
+ * the text body.
+ */
+async function getMiniGameSubmissions(pool, { limit = 50, offset = 0 } = {}) {
+    const empty = {
+        summary: { total: 0, open: 0, bugReports: 0, highPriority: 0 },
+        submissions: []
+    };
+    if (!pool) return empty;
+
+    const safeLimit = clampFeedbackPage(limit, 50, 200);
+    const safeOffset = clampFeedbackPage(offset, 0, Number.MAX_SAFE_INTEGER);
+    const terms = Array.from(MINIGAME_FEEDBACK_TERMS);
+    const where = miniGameFeedbackWhereClause('$1');
+
+    try {
+        const summaryResult = await pool.query(
+            `SELECT
+                CAST(COUNT(*) AS int) AS total,
+                CAST(COUNT(*) FILTER (WHERE status = 'open') AS int) AS open,
+                CAST(COUNT(*) FILTER (WHERE category = 'bug') AS int) AS bug_reports,
+                CAST(COUNT(*) FILTER (WHERE severity IN ('critical', 'high')) AS int) AS high_priority
+             FROM feedback
+             WHERE ${where}`,
+            [terms]
+        );
+
+        const listResult = await pool.query(
+            `SELECT id, device_id, message, category, severity, status, tags, app_version,
+                    source, github_issue_url, created_at
+             FROM feedback
+             WHERE ${where}
+             ORDER BY created_at DESC
+             LIMIT $2 OFFSET $3`,
+            [terms, safeLimit, safeOffset]
+        );
+
+        const summaryRow = summaryResult.rows[0] || {};
+        return {
+            summary: {
+                total: parseInt(summaryRow.total, 10) || 0,
+                open: parseInt(summaryRow.open, 10) || 0,
+                bugReports: parseInt(summaryRow.bug_reports, 10) || 0,
+                highPriority: parseInt(summaryRow.high_priority, 10) || 0
+            },
+            submissions: listResult.rows
+        };
+    } catch (err) {
+        console.error('[Feedback] MiniGame submissions list error:', err.message);
+        return empty;
+    }
+}
+
 /**
  * Get single feedback by ID (full record with log_snapshot).
  */
@@ -831,6 +922,9 @@ module.exports = {
     generateAiPrompt,
     saveFeedback,
     getFeedbackList,
+    getMiniGameSubmissions,
+    miniGameFeedbackWhereClause,
+    MINIGAME_FEEDBACK_TERMS,
     getFeedbackById,
     updateFeedback,
     createGithubIssue,

--- a/backend/index.js
+++ b/backend/index.js
@@ -3731,6 +3731,30 @@ app.get('/api/admin/ping', (req, res) => {
 });
 
 /**
+ * GET /api/admin/minigame-submissions
+ * Admin: view MiniGame user submissions stored through the shared feedback
+ * intake. MiniGame can mark submissions with source/category/tags; older
+ * reports that only mention MiniGame in the body are also included.
+ */
+app.get('/api/admin/minigame-submissions', adminAuth, adminCheck, async (req, res) => {
+    try {
+        const result = await feedbackModule.getMiniGameSubmissions(chatPool, {
+            limit: req.query.limit,
+            offset: req.query.offset
+        });
+        res.json({
+            success: true,
+            count: result.submissions.length,
+            summary: result.summary,
+            submissions: result.submissions
+        });
+    } catch (err) {
+        console.error('[Admin] MiniGame submissions error:', err);
+        res.status(500).json({ success: false, error: 'Failed to load MiniGame submissions' });
+    }
+});
+
+/**
  * GET /api/skill-templates/contributions
  * Admin: view full contribution history (all statuses).
  */

--- a/backend/public/portal/admin.html
+++ b/backend/public/portal/admin.html
@@ -1275,10 +1275,17 @@
             html += '<div id="arenaFeedbackContent" style="color:var(--text-secondary);">Loading...</div>';
             html += '</div>';
 
+            // MiniGame submissions section
+            html += '<div class="section-card">';
+            html += '<div class="section-title">🎮 MiniGame Submissions</div>';
+            html += '<div id="miniGameSubmissionsContent" style="color:var(--text-secondary);">Loading...</div>';
+            html += '</div>';
+
             content.innerHTML = html;
 
-            // Load arena feedback asynchronously
+            // Load optional feedback sections asynchronously
             loadArenaFeedback();
+            loadMiniGameSubmissions();
         }
 
         async function loadArenaFeedback() {
@@ -1302,6 +1309,53 @@
                     fbHtml += '<td style="max-width:200px;overflow:hidden;text-overflow:ellipsis;">' + escapeHtml(caps) + '</td>';
                     fbHtml += '<td>' + (f.credibility_score != null ? f.credibility_score + '/10' : '-') + '</td>';
                     fbHtml += '<td style="max-width:200px;overflow:hidden;text-overflow:ellipsis;">' + escapeHtml(f.comment || '-') + '</td>';
+                    fbHtml += '</tr>';
+                }
+                fbHtml += '</tbody></table></div>';
+                el.innerHTML = fbHtml;
+            } catch (e) {
+                el.innerHTML = '<p style="color:var(--danger);">Failed to load: ' + escapeHtml(e.message) + '</p>';
+            }
+        }
+
+        async function loadMiniGameSubmissions() {
+            const el = document.getElementById('miniGameSubmissionsContent');
+            if (!el) return;
+            try {
+                const data = await apiCall('GET', '/api/admin/minigame-submissions?limit=50');
+                const submissions = data.submissions || [];
+                const summary = data.summary || {};
+                let fbHtml = '<div style="display:flex;gap:10px;flex-wrap:wrap;margin-bottom:12px;">';
+                fbHtml += '<span style="background:var(--bg-secondary);padding:6px 10px;border-radius:8px;">Total: ' + (summary.total || 0) + '</span>';
+                fbHtml += '<span style="background:var(--bg-secondary);padding:6px 10px;border-radius:8px;">Open: ' + (summary.open || 0) + '</span>';
+                fbHtml += '<span style="background:var(--bg-secondary);padding:6px 10px;border-radius:8px;">Bug reports: ' + (summary.bugReports || 0) + '</span>';
+                fbHtml += '<span style="background:var(--bg-secondary);padding:6px 10px;border-radius:8px;">High priority: ' + (summary.highPriority || 0) + '</span>';
+                fbHtml += '</div>';
+
+                if (submissions.length === 0) {
+                    el.innerHTML = fbHtml + '<p style="padding:12px;">No MiniGame submissions yet.</p>';
+                    return;
+                }
+
+                fbHtml += '<div class="table-scroll"><table class="data-table"><thead><tr>';
+                fbHtml += '<th>Time</th><th>Category</th><th>Severity</th><th>Status</th><th>Source</th><th>Tags</th><th>Message</th><th>Device</th><th>Issue</th>';
+                fbHtml += '</tr></thead><tbody>';
+                for (const f of submissions) {
+                    const tags = Array.isArray(f.tags) ? f.tags.join(', ') : '';
+                    const message = f.message || '-';
+                    const issue = f.github_issue_url
+                        ? '<a href="' + escapeHtml(f.github_issue_url) + '" target="_blank" rel="noopener noreferrer">Issue</a>'
+                        : '—';
+                    fbHtml += '<tr>';
+                    fbHtml += '<td>' + formatDate(f.created_at) + '</td>';
+                    fbHtml += '<td>' + escapeHtml(f.category || '-') + '</td>';
+                    fbHtml += '<td>' + escapeHtml(f.severity || '-') + '</td>';
+                    fbHtml += '<td>' + escapeHtml(f.status || '-') + '</td>';
+                    fbHtml += '<td>' + escapeHtml(f.source || '-') + '</td>';
+                    fbHtml += '<td style="max-width:160px;overflow:hidden;text-overflow:ellipsis;">' + escapeHtml(tags || '-') + '</td>';
+                    fbHtml += '<td style="max-width:360px;white-space:normal;">' + escapeHtml(message.length > 240 ? message.slice(0, 240) + '…' : message) + '</td>';
+                    fbHtml += '<td><code>' + escapeHtml(f.device_id || '-') + '</code></td>';
+                    fbHtml += '<td>' + issue + '</td>';
                     fbHtml += '</tr>';
                 }
                 fbHtml += '</tbody></table></div>';

--- a/backend/tests/jest/admin-auth.test.js
+++ b/backend/tests/jest/admin-auth.test.js
@@ -205,6 +205,11 @@ describe('Admin endpoints — unauthenticated access blocked', () => {
         expect(res.status).toBe(401);
     });
 
+    it('GET /api/admin/minigame-submissions rejects without auth', async () => {
+        const res = await get('/api/admin/minigame-submissions');
+        expect(res.status).toBe(401);
+    });
+
     it('POST /api/admin/gatekeeper/reset rejects without auth', async () => {
         const res = await post('/api/admin/gatekeeper/reset')
             .send({ deviceId: 'test' });

--- a/backend/tests/jest/minigame-admin-submissions.test.js
+++ b/backend/tests/jest/minigame-admin-submissions.test.js
@@ -1,0 +1,62 @@
+const feedback = require('../../device-feedback');
+
+describe('MiniGame admin submissions', () => {
+    test('builds a MiniGame matcher across source, category, tags, and legacy message text', () => {
+        const where = feedback.miniGameFeedbackWhereClause('$7');
+        expect(where).toContain("LOWER(COALESCE(source, '')) = ANY($7::text[])");
+        expect(where).toContain("LOWER(COALESCE(category, '')) = ANY($7::text[])");
+        expect(where).toContain('unnest(COALESCE(tags');
+        expect(where).toContain("message ILIKE '%minigame%'");
+        expect(where).toContain("message ILIKE '%game factory%'");
+    });
+
+    test('returns empty summary when pool is unavailable', async () => {
+        const result = await feedback.getMiniGameSubmissions(null);
+        expect(result).toEqual({
+            summary: { total: 0, open: 0, bugReports: 0, highPriority: 0 },
+            submissions: []
+        });
+    });
+
+    test('queries MiniGame feedback and caps admin page size', async () => {
+        const calls = [];
+        const pool = {
+            query: jest.fn(async (sql, params) => {
+                calls.push({ sql, params });
+                if (/CAST\(COUNT\(\*\) AS int\) AS total/.test(sql)) {
+                    return {
+                        rows: [{ total: '3', open: '2', bug_reports: '2', high_priority: '1' }]
+                    };
+                }
+                return {
+                    rows: [{
+                        id: 42,
+                        device_id: 'dev-1',
+                        message: 'MiniGame player got stuck',
+                        category: 'bug',
+                        severity: 'high',
+                        status: 'open',
+                        tags: ['minigame'],
+                        app_version: 'web-minigame',
+                        source: 'minigame',
+                        github_issue_url: null,
+                        created_at: 1710000000000
+                    }]
+                };
+            })
+        };
+
+        const result = await feedback.getMiniGameSubmissions(pool, { limit: 999, offset: 5 });
+
+        expect(result.summary).toEqual({ total: 3, open: 2, bugReports: 2, highPriority: 1 });
+        expect(result.submissions).toHaveLength(1);
+        expect(result.submissions[0].source).toBe('minigame');
+        expect(calls).toHaveLength(2);
+        expect(calls[0].params[0]).toEqual(expect.arrayContaining(['minigame', 'mini-game', 'game factory']));
+        expect(calls[1].params).toEqual([
+            expect.arrayContaining(['minigame', 'mini-game', 'game factory']),
+            200,
+            5
+        ]);
+    });
+});


### PR DESCRIPTION
## Summary
- Add an admin-only /api/admin/minigame-submissions endpoint for MiniGame-related feedback submissions.
- Surface MiniGame submissions in the admin portal with summary counts and a table.
- Add regression coverage for MiniGame feedback matching and admin auth-gating.

## Verification
- node -c backend/device-feedback.js && node -c backend/index.js
- cd backend && npx jest tests/jest/minigame-admin-submissions.test.js tests/jest/admin-auth.test.js --runInBand

Notes: Jest reports an existing validation warning for runInBand, but the targeted suites pass.