### PR TITLE
feat: add MiniGame admin analytics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1087,7 +1087,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | gRPC Transport | `node backend/tests/test-grpc-transport.js` | None (local) | Proto loading, gRPC server, HealthService |
 | ENV Vars Merge | `node backend/tests/test-vars-merge.js` | Device ID + Secret | Cross-platform merge, conflict splitting |
 | Channel API | `node backend/tests/test-channel-api.js` | Device ID + Secret | OpenClaw channel integration |
-| MiniGame Admin Submissions | `cd backend && npx jest tests/jest/minigame-admin-submissions.test.js tests/jest/admin-auth.test.js --runInBand` | None | Regression: admin-only MiniGame submissions API matches feedback source/category/tags/body and admin page endpoint remains auth-gated |
+| MiniGame Admin Submissions + Analytics | `cd backend && npx jest tests/jest/minigame-admin-submissions.test.js tests/jest/admin-auth.test.js --runInBand` | None | Regression: admin-only MiniGame submissions API matches feedback source/category/tags/body, MiniGame error/play analytics aggregate server_logs + device_telemetry, and admin endpoints remain auth-gated |
 | Kanban auto-review busy-state guard | `cd backend && npx jest tests/jest/kanban-autoreview-busy-state-guard.test.js --runInBand` | None | Regression: BUSY/PROCESSING/WORKING progress heartbeats must not auto-close kanban child cards before work completes |
 | Portal static IDs | `cd backend && npx jest tests/jest/portal-static-ids.test.js --runInBand` | None | Regression #2468: dashboard invite banners must have unique IDs and onboarding JS must target the onboarding banner |
 | Skill Templates | `node backend/tests/test-skill-templates.js` | None | Skill template CRUD, requiredVars format validation (Gson compat), contribute endpoint input guard |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1066,7 +1066,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | gRPC Transport | `node backend/tests/test-grpc-transport.js` | None (local) | Proto loading, gRPC server, HealthService |
 | ENV Vars Merge | `node backend/tests/test-vars-merge.js` | Device ID + Secret | Cross-platform merge, conflict splitting |
 | Channel API | `node backend/tests/test-channel-api.js` | Device ID + Secret | OpenClaw channel integration |
-| MiniGame Admin Submissions | `cd backend && npx jest tests/jest/minigame-admin-submissions.test.js tests/jest/admin-auth.test.js --runInBand` | None | Regression: admin-only MiniGame submissions API matches feedback source/category/tags/body and admin page endpoint remains auth-gated |
+| MiniGame Admin Submissions + Analytics | `cd backend && npx jest tests/jest/minigame-admin-submissions.test.js tests/jest/admin-auth.test.js --runInBand` | None | Regression: admin-only MiniGame submissions API matches feedback source/category/tags/body, MiniGame error/play analytics aggregate server_logs + device_telemetry, and admin endpoints remain auth-gated |
 | Skill Templates | `node backend/tests/test-skill-templates.js` | None | Skill template CRUD, requiredVars format validation (Gson compat), contribute endpoint input guard |
 | WebSocket Auth | `node backend/tests/test-ws-auth.js` | Device ID + Secret | Socket.IO authentication |
 | AI Chat Image | `node backend/tests/test-ai-chat-image.js` | Device ID + Secret | AI chat with image support |

--- a/backend/device-feedback.js
+++ b/backend/device-feedback.js
@@ -551,6 +551,295 @@ async function getMiniGameSubmissions(pool, { limit = 50, offset = 0 } = {}) {
     }
 }
 
+function clampAnalyticsWindowHours(value, fallback = 24, max = 24 * 30) {
+    const parsed = parseInt(value, 10);
+    if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+    return Math.min(parsed, max);
+}
+
+const MINIGAME_SERVER_LOG_SIGNAL_SQL = `(
+    category ILIKE '%minigame%'
+    OR message ILIKE '%minigame%'
+    OR message ILIKE '%mini game%'
+    OR message ILIKE '%game factory%'
+    OR message ~* 'GAME-[0-9]+'
+    OR COALESCE(metadata::text, '') ILIKE '%minigame%'
+    OR COALESCE(metadata::text, '') ILIKE '%mini game%'
+    OR COALESCE(metadata::text, '') ILIKE '%game factory%'
+    OR COALESCE(metadata::text, '') ~* 'GAME-[0-9]+'
+)`;
+
+const MINIGAME_TELEMETRY_SIGNAL_SQL = `(
+    COALESCE(page, '') ILIKE '%minigame%'
+    OR COALESCE(page, '') ~* 'GAME-[0-9]+'
+    OR COALESCE(action, '') ILIKE '%minigame%'
+    OR COALESCE(action, '') ILIKE '%mini game%'
+    OR COALESCE(action, '') ILIKE '%game factory%'
+    OR COALESCE(action, '') ~* 'GAME-[0-9]+'
+    OR COALESCE(input::text, '') ILIKE '%minigame%'
+    OR COALESCE(output::text, '') ILIKE '%minigame%'
+    OR COALESCE(meta::text, '') ILIKE '%minigame%'
+    OR COALESCE(input::text, '') ~* 'GAME-[0-9]+'
+    OR COALESCE(output::text, '') ~* 'GAME-[0-9]+'
+    OR COALESCE(meta::text, '') ~* 'GAME-[0-9]+'
+)`;
+
+function normalizeMiniGameAnalyticsRows(rows = []) {
+    return rows.map(row => ({
+        ...row,
+        count: parseInt(row.count, 10) || 0,
+        events: parseInt(row.events, 10) || 0,
+        totalEvents: parseInt(row.total_events, 10) || parseInt(row.totalEvents, 10) || 0,
+        pageViews: parseInt(row.page_views, 10) || parseInt(row.pageViews, 10) || 0,
+        playActions: parseInt(row.play_actions, 10) || parseInt(row.playActions, 10) || 0,
+        errors: parseInt(row.errors, 10) || 0,
+        serverErrors: parseInt(row.server_errors, 10) || parseInt(row.serverErrors, 10) || 0,
+        telemetryErrors: parseInt(row.telemetry_errors, 10) || parseInt(row.telemetryErrors, 10) || 0,
+        uniqueDevices: parseInt(row.unique_devices, 10) || parseInt(row.uniqueDevices, 10) || 0,
+        avgDurationMs: row.avg_duration_ms == null && row.avgDurationMs == null
+            ? null
+            : Math.round(parseFloat(row.avg_duration_ms ?? row.avgDurationMs) || 0),
+        gameId: row.game_id || row.gameId || 'unknown',
+        errorSignature: row.error_signature || row.errorSignature || null,
+        firstSeenAt: row.first_seen_at || row.firstSeenAt || null,
+        lastSeenAt: row.last_seen_at || row.lastSeenAt || null,
+        createdAt: row.created_at || row.createdAt || null
+    }));
+}
+
+/**
+ * Admin-facing MiniGame telemetry/error analytics.
+ *
+ * Data sources are production tables, not ad-hoc CSV exports:
+ * - server_logs: backend/runtime error signatures mentioning MiniGame or GAME-###.
+ * - device_telemetry: page views, user actions, play starts, and client errors.
+ *
+ * This intentionally aggregates/limits results so the admin dashboard can show
+ * patterns without leaking full logs or secrets.
+ */
+async function getMiniGameAnalytics(pool, { hours = 24, limit = 25 } = {}) {
+    const safeHours = clampAnalyticsWindowHours(hours);
+    const safeLimit = clampFeedbackPage(limit, 25, 100);
+    const empty = {
+        windowHours: safeHours,
+        summary: {
+            errorEvents: 0,
+            serverErrorEvents: 0,
+            telemetryErrorEvents: 0,
+            totalEvents: 0,
+            pageViews: 0,
+            playActions: 0,
+            uniqueDevices: 0,
+            affectedGames: 0
+        },
+        errorStats: [],
+        gameStats: [],
+        recentErrors: []
+    };
+    if (!pool) return empty;
+
+    const params = [safeHours, safeLimit];
+    try {
+        const summaryResult = await pool.query(
+            `WITH telemetry AS (
+                SELECT
+                    COALESCE(
+                        substring(COALESCE(page, '') from '(GAME-[0-9]{3,})'),
+                        substring(COALESCE(action, '') from '(GAME-[0-9]{3,})'),
+                        substring(COALESCE(input::text, '') from '(GAME-[0-9]{3,})'),
+                        substring(COALESCE(output::text, '') from '(GAME-[0-9]{3,})'),
+                        substring(COALESCE(meta::text, '') from '(GAME-[0-9]{3,})')
+                    ) AS game_id,
+                    device_id,
+                    type,
+                    action
+                FROM device_telemetry
+                WHERE created_at >= NOW() - ($1::int * INTERVAL '1 hour')
+                  AND ${MINIGAME_TELEMETRY_SIGNAL_SQL}
+            ),
+            server_errors AS (
+                SELECT
+                    COALESCE(
+                        substring(message from '(GAME-[0-9]{3,})'),
+                        substring(COALESCE(metadata::text, '') from '(GAME-[0-9]{3,})')
+                    ) AS game_id,
+                    device_id
+                FROM server_logs
+                WHERE created_at >= NOW() - ($1::int * INTERVAL '1 hour')
+                  AND level IN ('error', 'warn')
+                  AND ${MINIGAME_SERVER_LOG_SIGNAL_SQL}
+            )
+            SELECT
+                CAST((SELECT COUNT(*) FROM telemetry) AS int) AS total_events,
+                CAST((SELECT COUNT(*) FROM telemetry WHERE type = 'page_view') AS int) AS page_views,
+                CAST((SELECT COUNT(*) FROM telemetry WHERE action ILIKE '%play%' OR action ILIKE '%start%' OR action ILIKE '%game_start%') AS int) AS play_actions,
+                CAST((SELECT COUNT(*) FROM telemetry WHERE type = 'error') AS int) AS telemetry_error_events,
+                CAST((SELECT COUNT(*) FROM server_errors) AS int) AS server_error_events,
+                CAST((SELECT COUNT(DISTINCT device_id) FROM telemetry WHERE device_id IS NOT NULL) AS int) AS unique_devices,
+                CAST((SELECT COUNT(DISTINCT game_id) FROM (
+                    SELECT game_id FROM telemetry WHERE game_id IS NOT NULL
+                    UNION ALL
+                    SELECT game_id FROM server_errors WHERE game_id IS NOT NULL
+                ) games) AS int) AS affected_games`,
+            [safeHours]
+        );
+
+        const errorStatsResult = await pool.query(
+            `WITH errors AS (
+                SELECT
+                    'server_log' AS source,
+                    COALESCE(
+                        substring(message from '(GAME-[0-9]{3,})'),
+                        substring(COALESCE(metadata::text, '') from '(GAME-[0-9]{3,})'),
+                        'unknown'
+                    ) AS game_id,
+                    regexp_replace(left(message, 240), '\\s+', ' ', 'g') AS error_signature,
+                    device_id,
+                    created_at
+                FROM server_logs
+                WHERE created_at >= NOW() - ($1::int * INTERVAL '1 hour')
+                  AND level IN ('error', 'warn')
+                  AND ${MINIGAME_SERVER_LOG_SIGNAL_SQL}
+                UNION ALL
+                SELECT
+                    'telemetry' AS source,
+                    COALESCE(
+                        substring(COALESCE(page, '') from '(GAME-[0-9]{3,})'),
+                        substring(COALESCE(action, '') from '(GAME-[0-9]{3,})'),
+                        substring(COALESCE(input::text, '') from '(GAME-[0-9]{3,})'),
+                        substring(COALESCE(output::text, '') from '(GAME-[0-9]{3,})'),
+                        substring(COALESCE(meta::text, '') from '(GAME-[0-9]{3,})'),
+                        'unknown'
+                    ) AS game_id,
+                    regexp_replace(left(COALESCE(output->>'message', meta->>'message', input->>'message', action, 'client error'), 240), '\\s+', ' ', 'g') AS error_signature,
+                    device_id,
+                    created_at
+                FROM device_telemetry
+                WHERE created_at >= NOW() - ($1::int * INTERVAL '1 hour')
+                  AND type = 'error'
+                  AND ${MINIGAME_TELEMETRY_SIGNAL_SQL}
+            )
+            SELECT
+                game_id,
+                error_signature,
+                CAST(COUNT(*) AS int) AS count,
+                CAST(COUNT(*) FILTER (WHERE source = 'server_log') AS int) AS server_errors,
+                CAST(COUNT(*) FILTER (WHERE source = 'telemetry') AS int) AS telemetry_errors,
+                CAST(COUNT(DISTINCT device_id) AS int) AS unique_devices,
+                MIN(created_at) AS first_seen_at,
+                MAX(created_at) AS last_seen_at
+            FROM errors
+            GROUP BY game_id, error_signature
+            ORDER BY count DESC, last_seen_at DESC
+            LIMIT $2`,
+            params
+        );
+
+        const gameStatsResult = await pool.query(
+            `WITH telemetry AS (
+                SELECT
+                    COALESCE(
+                        substring(COALESCE(page, '') from '(GAME-[0-9]{3,})'),
+                        substring(COALESCE(action, '') from '(GAME-[0-9]{3,})'),
+                        substring(COALESCE(input::text, '') from '(GAME-[0-9]{3,})'),
+                        substring(COALESCE(output::text, '') from '(GAME-[0-9]{3,})'),
+                        substring(COALESCE(meta::text, '') from '(GAME-[0-9]{3,})'),
+                        'unknown'
+                    ) AS game_id,
+                    device_id,
+                    type,
+                    action,
+                    duration,
+                    created_at
+                FROM device_telemetry
+                WHERE created_at >= NOW() - ($1::int * INTERVAL '1 hour')
+                  AND ${MINIGAME_TELEMETRY_SIGNAL_SQL}
+            )
+            SELECT
+                game_id,
+                CAST(COUNT(*) AS int) AS total_events,
+                CAST(COUNT(*) FILTER (WHERE type = 'page_view') AS int) AS page_views,
+                CAST(COUNT(*) FILTER (WHERE action ILIKE '%play%' OR action ILIKE '%start%' OR action ILIKE '%game_start%') AS int) AS play_actions,
+                CAST(COUNT(*) FILTER (WHERE type = 'error') AS int) AS errors,
+                CAST(COUNT(DISTINCT device_id) AS int) AS unique_devices,
+                ROUND(AVG(duration)) AS avg_duration_ms,
+                MAX(created_at) AS last_seen_at
+            FROM telemetry
+            GROUP BY game_id
+            ORDER BY total_events DESC, errors DESC, last_seen_at DESC
+            LIMIT $2`,
+            params
+        );
+
+        const recentErrorsResult = await pool.query(
+            `WITH recent AS (
+                SELECT
+                    'server_log' AS source,
+                    COALESCE(
+                        substring(message from '(GAME-[0-9]{3,})'),
+                        substring(COALESCE(metadata::text, '') from '(GAME-[0-9]{3,})'),
+                        'unknown'
+                    ) AS game_id,
+                    level,
+                    regexp_replace(left(message, 360), '\\s+', ' ', 'g') AS message,
+                    device_id,
+                    created_at
+                FROM server_logs
+                WHERE created_at >= NOW() - ($1::int * INTERVAL '1 hour')
+                  AND level IN ('error', 'warn')
+                  AND ${MINIGAME_SERVER_LOG_SIGNAL_SQL}
+                UNION ALL
+                SELECT
+                    'telemetry' AS source,
+                    COALESCE(
+                        substring(COALESCE(page, '') from '(GAME-[0-9]{3,})'),
+                        substring(COALESCE(action, '') from '(GAME-[0-9]{3,})'),
+                        substring(COALESCE(input::text, '') from '(GAME-[0-9]{3,})'),
+                        substring(COALESCE(output::text, '') from '(GAME-[0-9]{3,})'),
+                        substring(COALESCE(meta::text, '') from '(GAME-[0-9]{3,})'),
+                        'unknown'
+                    ) AS game_id,
+                    'error' AS level,
+                    regexp_replace(left(COALESCE(output->>'message', meta->>'message', input->>'message', action, 'client error'), 360), '\\s+', ' ', 'g') AS message,
+                    device_id,
+                    created_at
+                FROM device_telemetry
+                WHERE created_at >= NOW() - ($1::int * INTERVAL '1 hour')
+                  AND type = 'error'
+                  AND ${MINIGAME_TELEMETRY_SIGNAL_SQL}
+            )
+            SELECT source, game_id, level, message, device_id, created_at
+            FROM recent
+            ORDER BY created_at DESC
+            LIMIT $2`,
+            params
+        );
+
+        const summaryRow = summaryResult.rows[0] || {};
+        const serverErrorEvents = parseInt(summaryRow.server_error_events, 10) || 0;
+        const telemetryErrorEvents = parseInt(summaryRow.telemetry_error_events, 10) || 0;
+        return {
+            windowHours: safeHours,
+            summary: {
+                errorEvents: serverErrorEvents + telemetryErrorEvents,
+                serverErrorEvents,
+                telemetryErrorEvents,
+                totalEvents: parseInt(summaryRow.total_events, 10) || 0,
+                pageViews: parseInt(summaryRow.page_views, 10) || 0,
+                playActions: parseInt(summaryRow.play_actions, 10) || 0,
+                uniqueDevices: parseInt(summaryRow.unique_devices, 10) || 0,
+                affectedGames: parseInt(summaryRow.affected_games, 10) || 0
+            },
+            errorStats: normalizeMiniGameAnalyticsRows(errorStatsResult.rows),
+            gameStats: normalizeMiniGameAnalyticsRows(gameStatsResult.rows),
+            recentErrors: normalizeMiniGameAnalyticsRows(recentErrorsResult.rows)
+        };
+    } catch (err) {
+        console.error('[Feedback] MiniGame analytics error:', err.message);
+        return empty;
+    }
+}
+
 /**
  * Get single feedback by ID (full record with log_snapshot).
  */
@@ -923,6 +1212,7 @@ module.exports = {
     saveFeedback,
     getFeedbackList,
     getMiniGameSubmissions,
+    getMiniGameAnalytics,
     miniGameFeedbackWhereClause,
     MINIGAME_FEEDBACK_TERMS,
     getFeedbackById,

--- a/backend/index.js
+++ b/backend/index.js
@@ -3755,6 +3755,30 @@ app.get('/api/admin/minigame-submissions', adminAuth, adminCheck, async (req, re
 });
 
 /**
+ * GET /api/admin/minigame-analytics
+ * Admin: aggregated MiniGame runtime error and play telemetry dashboard.
+ *
+ * Uses production telemetry/log tables so admins can see the same kind of
+ * GAME-### error patterns previously analyzed from ad-hoc CSV exports, plus
+ * page-view/play-action analytics for the related games.
+ */
+app.get('/api/admin/minigame-analytics', adminAuth, adminCheck, async (req, res) => {
+    try {
+        const result = await feedbackModule.getMiniGameAnalytics(chatPool, {
+            hours: req.query.hours,
+            limit: req.query.limit
+        });
+        res.json({
+            success: true,
+            ...result
+        });
+    } catch (err) {
+        console.error('[Admin] MiniGame analytics error:', err);
+        res.status(500).json({ success: false, error: 'Failed to load MiniGame analytics' });
+    }
+});
+
+/**
  * GET /api/skill-templates/contributions
  * Admin: view full contribution history (all statuses).
  */

--- a/backend/public/portal/admin.html
+++ b/backend/public/portal/admin.html
@@ -1281,11 +1281,18 @@
             html += '<div id="miniGameSubmissionsContent" style="color:var(--text-secondary);">Loading...</div>';
             html += '</div>';
 
+            // MiniGame runtime analytics section
+            html += '<div class="section-card">';
+            html += '<div class="section-title">🎮 MiniGame Error & Play Analytics</div>';
+            html += '<div id="miniGameAnalyticsContent" style="color:var(--text-secondary);">Loading...</div>';
+            html += '</div>';
+
             content.innerHTML = html;
 
             // Load optional feedback sections asynchronously
             loadArenaFeedback();
             loadMiniGameSubmissions();
+            loadMiniGameAnalytics();
         }
 
         async function loadArenaFeedback() {
@@ -1360,6 +1367,95 @@
                 }
                 fbHtml += '</tbody></table></div>';
                 el.innerHTML = fbHtml;
+            } catch (e) {
+                el.innerHTML = '<p style="color:var(--danger);">Failed to load: ' + escapeHtml(e.message) + '</p>';
+            }
+        }
+
+        async function loadMiniGameAnalytics() {
+            const el = document.getElementById('miniGameAnalyticsContent');
+            if (!el) return;
+            try {
+                const data = await apiCall('GET', '/api/admin/minigame-analytics?hours=24&limit=25');
+                const summary = data.summary || {};
+                const errorStats = data.errorStats || [];
+                const gameStats = data.gameStats || [];
+                const recentErrors = data.recentErrors || [];
+
+                let html = '<p style="margin:0 0 12px;color:var(--text-secondary);">Last ' + escapeHtml(data.windowHours || 24) + 'h production telemetry/log aggregate. Data source: server_logs + device_telemetry.</p>';
+                html += '<div class="stats-grid" style="margin-bottom:16px;">';
+                html += statCard(summary.errorEvents || 0, 'Error events', summary.errorEvents ? 'danger' : 'success');
+                html += statCard(summary.affectedGames || 0, 'Affected games', summary.affectedGames ? 'warning' : 'success');
+                html += statCard(summary.pageViews || 0, 'Page views', '');
+                html += statCard(summary.playActions || 0, 'Play actions', '');
+                html += statCard(summary.uniqueDevices || 0, 'Unique devices', '');
+                html += statCard(summary.totalEvents || 0, 'Telemetry events', '');
+                html += '</div>';
+
+                html += '<h4 style="margin:12px 0 8px;">Top error signatures</h4>';
+                if (!errorStats.length) {
+                    html += '<p style="padding:12px;">No MiniGame errors in this window.</p>';
+                } else {
+                    html += '<div class="table-scroll"><table class="data-table"><thead><tr>';
+                    html += '<th>Game</th><th>Count</th><th>Server</th><th>Client</th><th>Devices</th><th>Last Seen</th><th>Error Signature</th>';
+                    html += '</tr></thead><tbody>';
+                    for (const row of errorStats) {
+                        html += '<tr>';
+                        html += '<td><code>' + escapeHtml(row.gameId || 'unknown') + '</code></td>';
+                        html += '<td>' + escapeHtml(row.count || 0) + '</td>';
+                        html += '<td>' + escapeHtml(row.serverErrors || 0) + '</td>';
+                        html += '<td>' + escapeHtml(row.telemetryErrors || 0) + '</td>';
+                        html += '<td>' + escapeHtml(row.uniqueDevices || 0) + '</td>';
+                        html += '<td>' + formatDate(row.lastSeenAt) + '</td>';
+                        html += '<td style="max-width:520px;white-space:normal;">' + escapeHtml(row.errorSignature || '-') + '</td>';
+                        html += '</tr>';
+                    }
+                    html += '</tbody></table></div>';
+                }
+
+                html += '<h4 style="margin:16px 0 8px;">Gameplay analytics by game</h4>';
+                if (!gameStats.length) {
+                    html += '<p style="padding:12px;">No MiniGame play telemetry in this window.</p>';
+                } else {
+                    html += '<div class="table-scroll"><table class="data-table"><thead><tr>';
+                    html += '<th>Game</th><th>Events</th><th>Page Views</th><th>Play Actions</th><th>Errors</th><th>Devices</th><th>Avg Duration</th><th>Last Seen</th>';
+                    html += '</tr></thead><tbody>';
+                    for (const row of gameStats) {
+                        html += '<tr>';
+                        html += '<td><code>' + escapeHtml(row.gameId || 'unknown') + '</code></td>';
+                        html += '<td>' + escapeHtml(row.totalEvents || 0) + '</td>';
+                        html += '<td>' + escapeHtml(row.pageViews || 0) + '</td>';
+                        html += '<td>' + escapeHtml(row.playActions || 0) + '</td>';
+                        html += '<td>' + escapeHtml(row.errors || 0) + '</td>';
+                        html += '<td>' + escapeHtml(row.uniqueDevices || 0) + '</td>';
+                        html += '<td>' + (row.avgDurationMs ? escapeHtml(row.avgDurationMs + 'ms') : '—') + '</td>';
+                        html += '<td>' + formatDate(row.lastSeenAt) + '</td>';
+                        html += '</tr>';
+                    }
+                    html += '</tbody></table></div>';
+                }
+
+                html += '<h4 style="margin:16px 0 8px;">Recent error samples</h4>';
+                if (!recentErrors.length) {
+                    html += '<p style="padding:12px;">No recent MiniGame error samples.</p>';
+                } else {
+                    html += '<div class="table-scroll"><table class="data-table"><thead><tr>';
+                    html += '<th>Time</th><th>Source</th><th>Game</th><th>Level</th><th>Device</th><th>Message</th>';
+                    html += '</tr></thead><tbody>';
+                    for (const row of recentErrors) {
+                        html += '<tr>';
+                        html += '<td>' + formatDate(row.createdAt) + '</td>';
+                        html += '<td>' + escapeHtml(row.source || '-') + '</td>';
+                        html += '<td><code>' + escapeHtml(row.gameId || 'unknown') + '</code></td>';
+                        html += '<td>' + escapeHtml(row.level || '-') + '</td>';
+                        html += '<td><code>' + escapeHtml(row.device_id || '-') + '</code></td>';
+                        html += '<td style="max-width:520px;white-space:normal;">' + escapeHtml(row.message || '-') + '</td>';
+                        html += '</tr>';
+                    }
+                    html += '</tbody></table></div>';
+                }
+
+                el.innerHTML = html;
             } catch (e) {
                 el.innerHTML = '<p style="color:var(--danger);">Failed to load: ' + escapeHtml(e.message) + '</p>';
             }

--- a/backend/tests/jest/admin-auth.test.js
+++ b/backend/tests/jest/admin-auth.test.js
@@ -78,6 +78,8 @@ jest.mock('../../device-feedback', () => ({
     generateAiPrompt: jest.fn().mockReturnValue(''),
     saveFeedback: jest.fn().mockResolvedValue({ id: 1 }),
     getFeedbackList: jest.fn().mockResolvedValue([]),
+    getMiniGameSubmissions: jest.fn().mockResolvedValue({ summary: {}, submissions: [] }),
+    getMiniGameAnalytics: jest.fn().mockResolvedValue({ summary: {}, errorStats: [], gameStats: [], recentErrors: [] }),
     getFeedbackById: jest.fn().mockResolvedValue(null),
     updateFeedback: jest.fn().mockResolvedValue(true),
     createGithubIssue: jest.fn().mockResolvedValue(null),
@@ -207,6 +209,11 @@ describe('Admin endpoints — unauthenticated access blocked', () => {
 
     it('GET /api/admin/minigame-submissions rejects without auth', async () => {
         const res = await get('/api/admin/minigame-submissions');
+        expect(res.status).toBe(401);
+    });
+
+    it('GET /api/admin/minigame-analytics rejects without auth', async () => {
+        const res = await get('/api/admin/minigame-analytics');
         expect(res.status).toBe(401);
     });
 

--- a/backend/tests/jest/minigame-admin-submissions.test.js
+++ b/backend/tests/jest/minigame-admin-submissions.test.js
@@ -59,4 +59,125 @@ describe('MiniGame admin submissions', () => {
             5
         ]);
     });
+
+    test('returns empty MiniGame analytics when pool is unavailable', async () => {
+        const result = await feedback.getMiniGameAnalytics(null);
+        expect(result).toEqual({
+            windowHours: 24,
+            summary: {
+                errorEvents: 0,
+                serverErrorEvents: 0,
+                telemetryErrorEvents: 0,
+                totalEvents: 0,
+                pageViews: 0,
+                playActions: 0,
+                uniqueDevices: 0,
+                affectedGames: 0
+            },
+            errorStats: [],
+            gameStats: [],
+            recentErrors: []
+        });
+    });
+
+    test('aggregates MiniGame error logs and play telemetry for admin analytics', async () => {
+        const calls = [];
+        const pool = {
+            query: jest.fn(async (sql, params) => {
+                calls.push({ sql, params });
+                if (/server_error_events/.test(sql)) {
+                    return {
+                        rows: [{
+                            total_events: '42',
+                            page_views: '12',
+                            play_actions: '8',
+                            telemetry_error_events: '3',
+                            server_error_events: '7',
+                            unique_devices: '5',
+                            affected_games: '2'
+                        }]
+                    };
+                }
+                if (/GROUP BY game_id, error_signature/.test(sql)) {
+                    return {
+                        rows: [{
+                            game_id: 'GAME-076',
+                            error_signature: 'Cannot set properties of null',
+                            count: '10',
+                            server_errors: '7',
+                            telemetry_errors: '3',
+                            unique_devices: '4',
+                            first_seen_at: '2026-05-06T01:00:00.000Z',
+                            last_seen_at: '2026-05-06T02:00:00.000Z'
+                        }]
+                    };
+                }
+                if (/GROUP BY game_id/.test(sql)) {
+                    return {
+                        rows: [{
+                            game_id: 'GAME-076',
+                            total_events: '30',
+                            page_views: '12',
+                            play_actions: '8',
+                            errors: '3',
+                            unique_devices: '5',
+                            avg_duration_ms: '1234',
+                            last_seen_at: '2026-05-06T02:10:00.000Z'
+                        }]
+                    };
+                }
+                return {
+                    rows: [{
+                        source: 'server_log',
+                        game_id: 'GAME-076',
+                        level: 'error',
+                        message: 'Cannot set properties of null',
+                        device_id: 'dev-1',
+                        created_at: '2026-05-06T02:11:00.000Z'
+                    }]
+                };
+            })
+        };
+
+        const result = await feedback.getMiniGameAnalytics(pool, { hours: 48, limit: 999 });
+
+        expect(result.windowHours).toBe(48);
+        expect(result.summary).toEqual({
+            errorEvents: 10,
+            serverErrorEvents: 7,
+            telemetryErrorEvents: 3,
+            totalEvents: 42,
+            pageViews: 12,
+            playActions: 8,
+            uniqueDevices: 5,
+            affectedGames: 2
+        });
+        expect(result.errorStats[0]).toMatchObject({
+            gameId: 'GAME-076',
+            errorSignature: 'Cannot set properties of null',
+            count: 10,
+            serverErrors: 7,
+            telemetryErrors: 3,
+            uniqueDevices: 4
+        });
+        expect(result.gameStats[0]).toMatchObject({
+            gameId: 'GAME-076',
+            totalEvents: 30,
+            pageViews: 12,
+            playActions: 8,
+            errors: 3,
+            avgDurationMs: 1234
+        });
+        expect(result.recentErrors[0]).toMatchObject({
+            gameId: 'GAME-076',
+            source: 'server_log',
+            message: 'Cannot set properties of null'
+        });
+        expect(calls).toHaveLength(4);
+        expect(calls[0].params).toEqual([48]);
+        expect(calls[1].params).toEqual([48, 100]);
+        expect(calls.map(c => c.sql.join?.('') || c.sql).join('\n')).toContain('device_telemetry');
+        expect(calls.map(c => c.sql.join?.('') || c.sql).join('\n')).toContain('server_logs');
+        expect(calls.map(c => c.sql.join?.('') || c.sql).join('\n')).toContain('GAME-[0-9]+');
+    });
 });


### PR DESCRIPTION
## Summary
- Add admin-only `GET /api/admin/minigame-analytics` for MiniGame runtime error and gameplay telemetry aggregates.
- Extend Admin → MiniGame section with error signature, gameplay-by-game, and recent error sample tables.
- Cover analytics aggregation + auth gating in Jest; update regression-test registry.

## Data sources
- `server_logs` for backend/runtime warning/error signatures containing `minigame`, `game factory`, or `GAME-###`.
- `device_telemetry` for MiniGame page views, play/start actions, client errors, unique devices, and average durations.
- Does not depend on temporary CSV exports.

## Verification
- `node -c backend/device-feedback.js`
- `node -c backend/index.js`
- `git diff --check`
- Admin HTML inline script syntax check with `node --check`
- `cd backend && npx eslint device-feedback.js index.js tests/jest/admin-auth.test.js tests/jest/minigame-admin-submissions.test.js` (0 errors; existing test ignore warnings)
- `cd backend && npx jest tests/jest/minigame-admin-submissions.test.js tests/jest/admin-auth.test.js --runInBand` (24/24 pass; existing Jest config warning for runInBand)
