### PR TITLE
fix(kanban): surface dispatch mode controls

### DIFF
--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -1887,6 +1887,7 @@
             const isOnce = sc.type === 'once';
             const cron = sc.cronExpression || sc.cron || '';
             const isEnabled = sc.enabled !== false;
+            const currentDispatchMode = card.dispatchMode === 'idle_only' ? 'idle_only' : 'immediate';
 
             const priorityOpts = ['P0','P1','P2','P3'].map(p =>
                 `<option value="${p}"${card.priority===p?' selected':''}>${p}</option>`
@@ -1939,6 +1940,14 @@
                     </label>
                 </div>
                 <div class="kb-form-group">
+                    <label class="kb-form-label">🚦 Dispatch Mode</label>
+                    <select class="kb-form-select" id="sp-dispatch-mode">
+                        <option value="immediate"${currentDispatchMode === 'immediate' ? ' selected' : ''}>Immediate</option>
+                        <option value="idle_only"${currentDispatchMode === 'idle_only' ? ' selected' : ''}>Idle only</option>
+                    </select>
+                    <div style="font-size:12px;color:var(--text-secondary);margin-top:6px">Idle only queues the next child card until one assigned bot is idle.</div>
+                </div>
+                <div class="kb-form-group">
                     <label class="kb-form-label">${t('kb_label_sched_type','Schedule Type')}</label>
                     <select class="kb-form-select" id="sp-type" onchange="spToggleSchedFields()">
                         <option value="recurring"${!isOnce?' selected':''}>${t('kb_sched_recurring','Recurring (Cron)')}</option>
@@ -1989,6 +1998,7 @@
             const type = document.getElementById('sp-type')?.value;
             const timezone = document.getElementById('sp-tz')?.value;
             const enabled = document.getElementById('sp-enabled')?.checked !== false;
+            const dispatchMode = document.getElementById('sp-dispatch-mode')?.value === 'idle_only' ? 'idle_only' : 'immediate';
 
             if (!title) { showToast(t('kb_err_title','Title is required'), true); return; }
 
@@ -2012,7 +2022,7 @@
             try {
                 await apiCall('PUT', `/api/mission/card/${cardId}`, {
                     deviceId: currentUser.deviceId, deviceSecret: currentUser.deviceSecret,
-                    title, description: desc, priority, assignedBots,
+                    title, description: desc, priority, assignedBots, dispatchMode,
                 });
                 await apiCall('PUT', `/api/mission/card/${cardId}/schedule`, schedBody);
                 showToast(t('kb_auto_edit_saved','Schedule updated'));
@@ -2353,6 +2363,7 @@
                     </div>
                     ${pausedBadge}
                     <div class="kb-auto-card-cron">↻ ${escapeHtml(cronDesc)}</div>
+                    <div class="kb-auto-card-cron">🚦 ${c.dispatchMode === 'idle_only' ? 'idle_only' : 'immediate'}</div>
                     <div class="kb-auto-card-next" data-i18n="kb_auto_next">Next: ${escapeHtml(nextRun)}</div>
                     ${lastResult ? '<div class="kb-auto-card-result '+resultClass+'">'+escapeHtml(lastResult)+'</div>' : ''}
                     ${activeChild}
@@ -2422,9 +2433,10 @@
             const nowPct = toPct(now);
 
             function buildCardHtml(card, leftPct, extraCls, timeLabel) {
+                const dispatchMode = card.dispatchMode === 'idle_only' ? 'idle_only' : 'immediate';
                 return `<div class="kb-tl-card${extraCls}" style="left:${leftPct}%" onclick="openDetail('${card.id}')" title="${escapeHtml(card.title)}">` +
                     `<span class="kb-tl-card-title">⚡ ${escapeHtml(card.title)}</span>` +
-                    `<span class="kb-tl-card-time">${timeLabel}</span></div>`;
+                    `<span class="kb-tl-card-time">${timeLabel} · 🚦 ${dispatchMode}</span></div>`;
             }
 
             function buildLane(labelHtml, cards, isUnassigned) {

--- a/backend/tests/jest/kanban-dispatch-mode-ux.test.js
+++ b/backend/tests/jest/kanban-dispatch-mode-ux.test.js
@@ -22,4 +22,14 @@ describe('kanban automation dispatch mode UX', () => {
     test('card detail displays dispatch mode state', () => {
         expect(kanbanHtml).toContain('🚦 dispatch: <code>${dispatchLabel}</code>');
     });
+
+    test('schedule tab exposes dispatch mode control', () => {
+        expect(kanbanHtml).toContain('id="sp-dispatch-mode"');
+        expect(kanbanHtml).toMatch(/assignedBots, dispatchMode/);
+    });
+
+    test('automation list and timeline surface dispatch mode without opening edit form', () => {
+        expect(kanbanHtml).toContain('🚦 ${c.dispatchMode');
+        expect(kanbanHtml).toContain('🚦 ${dispatchMode}');
+    });
 });


### PR DESCRIPTION
## Summary
- Surface dispatch mode directly in automation grid and timeline cards so users can see current mode without opening the hidden edit form
- Add dispatch mode selector to the Schedule tab (`sp-dispatch-mode`) and persist it with existing schedule metadata saves
- Extend static UX regression coverage for the visible controls

## Root cause
PR #2482 deployed the API and functional UX, but the main editable control was hidden in the detail modal move bar / edit flow. Users looking at automation cards or the Schedule tab could miss it and report no visible button.

## Verification
- `npx jest tests/jest/kanban-dispatch-mode-ux.test.js tests/jest/kanban-card.test.js` ✅ 38/38
- `npm run lint` ✅ 0 errors, 7 existing warnings
- `node scripts/i18n-check.js` ✅ all referenced EN keys resolve

## Notes
- No production/main push performed; PR-first workflow preserved.
