### PR TITLE
fix(portal): restore workspace telemetry page view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1090,6 +1090,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | MiniGame Admin Submissions + Analytics | `cd backend && npx jest tests/jest/minigame-admin-submissions.test.js tests/jest/admin-auth.test.js --runInBand` | None | Regression: admin-only MiniGame submissions API matches feedback source/category/tags/body, MiniGame error/play analytics aggregate server_logs + device_telemetry, and admin endpoints remain auth-gated |
 | Kanban auto-review busy-state guard | `cd backend && npx jest tests/jest/kanban-autoreview-busy-state-guard.test.js --runInBand` | None | Regression: BUSY/PROCESSING/WORKING progress heartbeats must not auto-close kanban child cards before work completes |
 | Portal static IDs | `cd backend && npx jest tests/jest/portal-static-ids.test.js --runInBand` | None | Regression #2468: dashboard invite banners must have unique IDs and onboarding JS must target the onboarding banner |
+| Portal workspace telemetry | `cd backend && npx jest tests/jest/portal-workspace-telemetry.test.js --runInBand` | None | Regression #2485: workspace page must not call a missing telemetry API during page initialization |
 | Skill Templates | `node backend/tests/test-skill-templates.js` | None | Skill template CRUD, requiredVars format validation (Gson compat), contribute endpoint input guard |
 | WebSocket Auth | `node backend/tests/test-ws-auth.js` | Device ID + Secret | Socket.IO authentication |
 | AI Chat Image | `node backend/tests/test-ai-chat-image.js` | Device ID + Secret | AI chat with image support |

--- a/backend/public/shared/telemetry.js
+++ b/backend/public/shared/telemetry.js
@@ -7,6 +7,7 @@
  *   - Errors (window.onerror + unhandledrejection)
  *
  * Manual tracking:
+ *   - telemetry.trackPageView(page, meta)
  *   - telemetry.trackAction(action, meta)
  *   - telemetry.trackError(error, meta)
  *   - telemetry.trackLifecycle(action, meta)
@@ -175,6 +176,13 @@ const _telemetry = (() => {
     // ---- public API ----
 
     return {
+        /** Track a page view explicitly (for pages that initialize after dynamic layout setup) */
+        trackPageView(page = null, meta = null) {
+            const detectedPage = page || _detectPage();
+            _page = detectedPage;
+            _push({ type: 'page_view', action: detectedPage, meta });
+        },
+
         /** Track a user action (button click, dialog open, etc.) */
         trackAction(action, meta = null) {
             _push({ type: 'user_action', action, meta });

--- a/backend/tests/jest/portal-workspace-telemetry.test.js
+++ b/backend/tests/jest/portal-workspace-telemetry.test.js
@@ -1,0 +1,18 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+describe('portal workspace telemetry integration', () => {
+    test('shared telemetry SDK exposes trackPageView used by workspace page', () => {
+        const telemetryPath = path.join(__dirname, '../../public/shared/telemetry.js');
+        const workspacePath = path.join(__dirname, '../../public/portal/workspace.html');
+
+        const telemetryJs = fs.readFileSync(telemetryPath, 'utf8');
+        const workspaceHtml = fs.readFileSync(workspacePath, 'utf8');
+
+        expect(workspaceHtml).toContain("telemetry.trackPageView('workspace')");
+        expect(telemetryJs).toMatch(/trackPageView\s*\(/);
+        expect(telemetryJs).toContain("type: 'page_view'");
+    });
+});


### PR DESCRIPTION
## Summary
- Restores `telemetry.trackPageView(page, meta)` in the shared portal telemetry SDK.
- Fixes `/portal/workspace.html` runtime error from calling a missing telemetry API during initialization.
- Adds a static Jest regression test and registers it in `AGENTS.md`.

## QA / Verification
- `cd backend && npx jest tests/jest/portal-workspace-telemetry.test.js tests/jest/portal-smoke-static.test.js --runInBand`
- `cd backend && npx eslint public/shared/telemetry.js tests/jest/portal-workspace-telemetry.test.js` (files are ignored by current eslint config; no errors)

## Notes
- Found during daily QA/UIUX audit, tracked in #2485.
- Does not touch main/production; ready for #2 review and CI gates.
