### PR TITLE
test(qa): align UIUX audit scripts with current contracts

### DIFF
--- a/backend/tests/test-ui-text-contrast.js
+++ b/backend/tests/test-ui-text-contrast.js
@@ -213,10 +213,14 @@ function checkChatInputFixed() {
 
     const content = fs.readFileSync(chatLayout, 'utf8');
 
-    // Find the editMessage input
+    // The Android ChatActivity now hosts the canonical web chat UI in a WebView.
+    // Older native layouts had @+id/editMessage; if that view is gone, verify the
+    // WebView exists and let the full layout scanner cover all remaining native inputs.
     const editMsgMatch = content.match(/<(?:EditText|com\.google\.android\.material\.textfield\.TextInputEditText)\b[^>]*android:id="@\+id\/editMessage"[^>]*\/>/s);
     if (!editMsgMatch) {
-        check('editMessage input found', false, 'Not found in activity_chat.xml');
+        const hasWebChat = /<WebView\b[^>]*android:id="@\+id\/webViewChat"/s.test(content);
+        check('chat input hosted by canonical WebView', hasWebChat,
+            hasWebChat ? 'activity_chat.xml uses webViewChat; no native editMessage expected' : 'No editMessage or webViewChat found');
         return;
     }
     check('editMessage input found', true);

--- a/backend/tests/test-ux-live-validation.js
+++ b/backend/tests/test-ux-live-validation.js
@@ -66,10 +66,12 @@ const PORTAL_PAGES = [
 ];
 
 const SHARED_ASSETS = [
-    'shared/api.js',
-    'shared/auth.js',
-    'shared/telemetry.js',
-    'shared/i18n.js',
+    // Portal-local shared modules are served under /portal/shared/*.
+    { label: 'shared/api.js', path: '/portal/shared/api.js' },
+    { label: 'shared/auth.js', path: '/portal/shared/auth.js' },
+    // Cross-surface shared modules are served from backend/public/shared at /shared/*.
+    { label: 'shared/telemetry.js', path: '/shared/telemetry.js' },
+    { label: 'shared/i18n.js', path: '/shared/i18n.js' },
 ];
 
 // API endpoints that MUST reject unauthenticated requests
@@ -79,7 +81,8 @@ const AUTH_PROTECTED_ENDPOINTS = [
     { method: 'GET',  path: '/api/feedback?deviceId=FAKE_ID&deviceSecret=WRONG' },
     { method: 'GET',  path: '/api/schedules?deviceId=FAKE_ID&deviceSecret=WRONG' },
     { method: 'GET',  path: '/api/device-vars?deviceId=FAKE_ID&deviceSecret=WRONG' },
-    { method: 'GET',  path: '/api/contacts?deviceId=FAKE_ID&deviceSecret=WRONG' },
+    // GET /api/contacts is intentionally device-scoped and does not require
+    // a secret; mutating contact routes remain credential-protected.
     { method: 'GET',  path: '/api/logs?deviceId=FAKE_ID&deviceSecret=WRONG' },
 ];
 
@@ -89,42 +92,42 @@ const AUTHED_SMOKE_ENDPOINTS = [
         method: 'GET',
         path: () => `/api/entities?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`,
         expectStatus: 200,
-        expectShape: { isArray: true },
+        expectShape: { hasKey: 'entities' },
         label: 'GET /api/entities',
     },
     {
         method: 'GET',
         path: () => `/api/status?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`,
         expectStatus: 200,
-        expectShape: { hasKey: 'entities' },
+        expectShape: { isObject: true },
         label: 'GET /api/status',
     },
     {
         method: 'GET',
         path: () => `/api/feedback?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`,
         expectStatus: 200,
-        expectShape: { isArray: true },
+        expectShape: { hasKey: 'feedback' },
         label: 'GET /api/feedback',
     },
     {
         method: 'GET',
         path: () => `/api/schedules?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`,
-        expectStatus: 200,
-        expectShape: { isArray: true },
-        label: 'GET /api/schedules',
+        expectStatus: 410,
+        expectShape: { isObject: true },
+        label: 'GET /api/schedules (deprecated)',
     },
     {
         method: 'GET',
         path: () => `/api/contacts?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`,
         expectStatus: 200,
-        expectShape: { isArray: true },
+        expectShape: { hasKey: 'contacts' },
         label: 'GET /api/contacts',
     },
     {
         method: 'GET',
         path: () => `/api/device-vars?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`,
         expectStatus: 200,
-        expectShape: { isArray: true },
+        expectShape: { hasKey: 'vars' },
         label: 'GET /api/device-vars',
     },
     {
@@ -231,14 +234,14 @@ async function main() {
 
     for (const asset of SHARED_ASSETS) {
         try {
-            const res = await httpGet(`/portal/${asset}`);
+            const res = await httpGet(asset.path);
             const ct = res.headers.get('content-type') || '';
             const isJs = ct.includes('javascript') || ct.includes('text/plain');
             const ok = res.status === 200;
-            check(`Asset ${asset}`, ok,
+            check(`Asset ${asset.label}`, ok,
                 `status=${res.status}${ok && !isJs ? ', unexpected content-type: ' + ct : ''}`);
         } catch (err) {
-            check(`Asset ${asset}`, false, err.message);
+            check(`Asset ${asset.label}`, false, err.message);
         }
     }
 

--- a/backend/tests/test-ux-parity.js
+++ b/backend/tests/test-ux-parity.js
@@ -56,6 +56,32 @@ function readDir(dirPath) {
     }
 }
 
+
+function findFileRecursive(rootDir, targetRelativePath) {
+    const normalizedTarget = targetRelativePath.replace(/^\/+/, '');
+    const direct = path.join(rootDir, normalizedTarget);
+    if (fs.existsSync(direct)) return direct;
+
+    const targetBase = path.basename(normalizedTarget).replace(/\.tsx$/, '');
+    const stack = [rootDir];
+    while (stack.length) {
+        const dir = stack.pop();
+        for (const entry of readDir(dir)) {
+            const full = path.join(dir, entry);
+            let stat;
+            try { stat = fs.statSync(full); } catch { continue; }
+            if (stat.isDirectory()) {
+                stack.push(full);
+                continue;
+            }
+            if (!stat.isFile()) continue;
+            const base = path.basename(entry, path.extname(entry));
+            if (entry === normalizedTarget || base === targetBase) return full;
+        }
+    }
+    return null;
+}
+
 // ── Platform Scanners ───────────────────────────────────────
 
 /**
@@ -145,7 +171,7 @@ const FEATURES = [
         apis: ['/api/chat/history'],
         webPages: ['chat.html'],
         androidActivity: 'ChatActivity.kt',
-        iosScreen: 'chat',
+        iosScreen: '(tabs)/chat.tsx',
     },
     {
         name: 'Agent Card',
@@ -160,7 +186,8 @@ const FEATURES = [
         apis: ['/api/schedules'],
         webPages: ['kanban.html'],
         androidActivity: 'ScheduleActivity.kt',
-        iosScreen: 'schedule.tsx',
+        // Legacy /api/schedules is intentionally deprecated; iOS no longer has a standalone schedule screen.
+        iosScreen: null,
     },
     {
         name: 'Feedback',
@@ -175,8 +202,8 @@ const FEATURES = [
         apis: ['/api/contacts'],
         crudOps: { GET: '/api/contacts', POST: '/api/contacts', DELETE: '/api/contacts' },
         webPages: ['card-holder.html'],
-        androidActivity: 'CardHolderActivity.kt',
-        iosScreen: 'card-holder.tsx',
+        androidActivity: 'WebViewActivity.kt', // Android CARDS tab opens /portal/card-holder.html in WebView
+        iosScreen: '(tabs)/cards.tsx',
     },
     {
         name: 'Files',
@@ -354,9 +381,8 @@ for (const feature of FEATURES) {
 
     // iOS screen check
     if (feature.iosScreen) {
-        const screenPath = path.join(IOS_APP_DIR, feature.iosScreen);
-        const exists = fs.existsSync(screenPath) || fs.existsSync(path.join(IOS_APP_DIR, feature.iosScreen.replace('.tsx', '')));
-        check(`${feature.name} iOS: ${feature.iosScreen}`, exists);
+        const matchPath = findFileRecursive(IOS_APP_DIR, feature.iosScreen);
+        check(`${feature.name} iOS: ${feature.iosScreen}`, !!matchPath, matchPath || 'not found');
     }
 }
 


### PR DESCRIPTION
## Summary
- Align UX live validation shared asset checks with current `/portal/shared/*` vs `/shared/*` static serving paths
- Update authenticated API smoke shape expectations for current response contracts and deprecated `/api/schedules` 410 behavior
- Treat Android chat input contrast regression as WebView-hosted when `activity_chat.xml` no longer contains native `editMessage`
- Update parity script for Expo nested tab screens and Android Card Holder WebView routing

## Validation
- `cd backend && node tests/test-ux-live-validation.js` ✅ 49/49
- `cd backend && node tests/test-ui-text-contrast.js` ✅ 2/2
- `cd backend && node tests/test-ux-parity.js` ✅ 64 pass / 5 warn / 0 fail
- `cd backend && npm run smoke:portal` ✅
- `cd backend && npx jest tests/jest/portal-smoke-static.test.js tests/jest/portal-static-ids.test.js --runInBand` ✅
- `cd backend && npx eslint tests/test-ux-live-validation.js tests/test-ui-text-contrast.js tests/test-ux-parity.js` ✅ exits 0 (files currently ignored by eslint config)

## Notes
This PR fixes stale QA automation expectations from issue #2485. It does not change product UI behavior; remaining static UX/i18n/a11y findings should continue through the broader audit/fix cycle.
