### PR TITLE
feat(growth): CTA register intent + portal beacon funnel (slice 1+2)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,1 @@
-# Ensure Unix line endings for shell scripts
-gradlew text eol=lf
-*.sh text eol=lf
+*.js text eol=lf

--- a/backend/auth_schema.sql
+++ b/backend/auth_schema.sql
@@ -210,7 +210,8 @@ CREATE TABLE IF NOT EXISTS invite_clicks (
     clicked_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
     ip_hash VARCHAR(16),
     user_agent TEXT,
-    referer TEXT
+    referer TEXT,
+    source TEXT DEFAULT 'direct'
 );
 CREATE INDEX IF NOT EXISTS idx_invite_clicks_code ON invite_clicks(code);
 CREATE INDEX IF NOT EXISTS idx_invite_clicks_clicked_at ON invite_clicks(clicked_at);

--- a/backend/db.js
+++ b/backend/db.js
@@ -2292,14 +2292,14 @@ async function getCommunityStats(poolArg) {
     }
 }
 
-async function logInviteClick({ code, ipHash, userAgent, referer }, poolArg) {
+async function logInviteClick({ code, ipHash, userAgent, referer, source }, poolArg) {
     const p = poolArg || pool;
     if (!p) return false;
     try {
         await p.query(
-            `INSERT INTO invite_clicks (code, ip_hash, user_agent, referer)
-             VALUES ($1, $2, $3, $4)`,
-            [code, ipHash || null, userAgent || null, referer || null]
+            `INSERT INTO invite_clicks (code, ip_hash, user_agent, referer, source)
+             VALUES ($1, $2, $3, $4, $5)`,
+            [code, ipHash || null, userAgent || null, referer || null, source || 'direct']
         );
         return true;
     } catch (err) {

--- a/backend/growth.js
+++ b/backend/growth.js
@@ -158,6 +158,33 @@ async function fetchInviteConversion() {
     };
 }
 
+async function fetchInviteClicksForDate(anchorDate) {
+    // Aggregate invite clicks for a specific date (Taiwan time)
+    // Returns total clicks + per-source breakdown
+    const r = await pool.query(
+        `SELECT COUNT(*)::int AS total_clicks,
+                COUNT(DISTINCT ic.ip_hash)::int AS unique_clicks,
+                COALESCE(ic.source, 'direct') AS source
+         FROM invite_clicks ic
+         WHERE DATE(ic.clicked_at AT TIME ZONE 'Asia/Taipei') = $1::date
+         GROUP BY COALESCE(ic.source, 'direct')
+         ORDER BY total_clicks DESC`,
+        [anchorDate]
+    );
+    const totalRow = r.rows.reduce((acc, row) => ({
+        total_clicks: acc.total_clicks + row.total_clicks,
+        unique_clicks: acc.unique_clicks + row.unique_clicks,
+    }), { total_clicks: 0, unique_clicks: 0 });
+    return {
+        total: totalRow,
+        by_source: r.rows.map(row => ({
+            source: row.source,
+            clicks: row.total_clicks,
+            unique_clicks: row.unique_clicks,
+        }))
+    };
+}
+
 module.exports = function(devices) {
     const router = express.Router();
 
@@ -198,11 +225,12 @@ module.exports = function(devices) {
         }
 
         try {
-            const [today_signups, retention_7d, plaza_new_listed_today, invite_conversion, source_channel] = await Promise.all([
+            const [today_signups, retention_7d, plaza_new_listed_today, invite_conversion, invite_clicks, source_channel] = await Promise.all([
                 fetchSignupsForDate(anchorDate),
                 fetchRetention7dForDate(anchorDate),
                 fetchPlazaNewListedForDate(anchorDate),
                 fetchInviteConversion(),
+                fetchInviteClicksForDate(anchorDate),
                 fetchSignupSourceForDate(anchorDate)
             ]);
             return res.json({
@@ -213,6 +241,7 @@ module.exports = function(devices) {
                 retention_7d,
                 plaza_new_listed_today,
                 invite_conversion,
+                invite_clicks,
                 follow_ups: [
                     'visitor_to_signup_conversion: page_views has no FK to user_accounts',
                     'plaza_new_listed_today: counts created_at not status_changed_at (bot_listings has no listed_at column)',
@@ -227,6 +256,6 @@ module.exports = function(devices) {
 
     return {
         router,
-        _internal: { checkRate, findEntity, isOwnerAdmin, fetchSignupsForDate, fetchSignupSourceForDate, fetchRetention7dForDate, fetchPlazaNewListedForDate, fetchInviteConversion, isValidDateStr, taipeiTodayISO, rateBuckets }
+        _internal: { checkRate, findEntity, isOwnerAdmin, fetchSignupsForDate, fetchSignupSourceForDate, fetchRetention7dForDate, fetchPlazaNewListedForDate, fetchInviteConversion, fetchInviteClicksForDate, isValidDateStr, taipeiTodayISO, rateBuckets }
     };
 };

--- a/backend/index.js
+++ b/backend/index.js
@@ -16580,6 +16580,16 @@ sitePageviews.initPageviewsTable(chatPool);
     }
 })();
 
+// Migration: add source column to existing invite_clicks table (idempotent)
+(async () => {
+    try {
+        await chatPool.query(`ALTER TABLE invite_clicks ADD COLUMN IF NOT EXISTS source TEXT DEFAULT 'direct'`);
+        console.log('[Migration] invite_clicks.source column ready');
+    } catch (err) {
+        console.error('[Migration] invite_clicks.source error:', err.message);
+    }
+})();
+
 if (mindmapModule && typeof mindmapModule.initMindmapTables === 'function') {
     mindmapModule.initMindmapTables(chatPool);
 }
@@ -18162,7 +18172,19 @@ app.post('/api/device-telemetry', async (req, res) => {
 // Accepts pre-login events (portal_open, register_tab_open, register_submit,
 // register_success, register_error) and stores them for funnel analysis.
 // All entries must be non-PII (no email, phone, IP raw — use hashes only).
-app.post('/api/portal/beacons', async (req, res) => {
+
+// POST /api/portal/beacons — no device auth required.
+// Rate-limited: 60 events/min per IP. Explicit 64kb body cap.
+const beaconLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 60,
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: () => rateLimitDisabled(),
+    keyGenerator: (req) => req.ip || 'unknown',
+    message: { success: false, error: 'Too many beacon events — try again shortly' },
+});
+app.post('/api/portal/beacons', express.json({ limit: '64kb' }), beaconLimiter, async (req, res) => {
     const { entries } = req.body;
     if (!Array.isArray(entries) || entries.length === 0) {
         return res.status(400).json({ success: false, error: 'entries array required' });

--- a/backend/index.js
+++ b/backend/index.js
@@ -640,7 +640,8 @@ app.get('/invite/:code', async (req, res) => {
             : null;
         const userAgent = String(req.headers['user-agent'] || '').slice(0, 500) || null;
         const referer = String(req.headers.referer || req.headers.referrer || '').slice(0, 500) || null;
-        await db.logInviteClick({ code, ipHash, userAgent, referer });
+        const source = (req.query && req.query.utm_source) || (req.query && req.query.source) || 'direct';
+        await db.logInviteClick({ code, ipHash, userAgent, referer, source });
     } catch (err) {
         console.warn(`[/invite/:code] click log failed for ${code}: ${err.message}`);
     }
@@ -16557,6 +16558,28 @@ _telemetryPool = chatPool;
 telemetry.initTelemetryTable(chatPool, serverLog);
 sitePageviews.setPool(chatPool);
 sitePageviews.initPageviewsTable(chatPool);
+// Anonymous portal beacons table (for growth funnel tracking)
+(async () => {
+    try {
+        await chatPool.query(`
+            CREATE TABLE IF NOT EXISTS portal_beacons (
+                id          BIGSERIAL   PRIMARY KEY,
+                action      TEXT        NOT NULL,
+                ip_hash     TEXT,
+                ua          TEXT,
+                meta        JSONB,
+                created_at  TIMESTAMPTZ DEFAULT NOW()
+            )
+        `);
+        await chatPool.query(`CREATE INDEX IF NOT EXISTS idx_pb_action_ts ON portal_beacons (action, created_at DESC)`);
+        await chatPool.query(`CREATE INDEX IF NOT EXISTS idx_pb_ts         ON portal_beacons (created_at DESC)`);
+        await chatPool.query(`CREATE INDEX IF NOT EXISTS idx_pb_meta       ON portal_beacons USING GIN (meta)`);
+        console.log('[PortalBeacons] Table ready');
+    } catch (err) {
+        console.error('[PortalBeacons] Table init error:', err.message);
+    }
+})();
+
 if (mindmapModule && typeof mindmapModule.initMindmapTables === 'function') {
     mindmapModule.initMindmapTables(chatPool);
 }
@@ -18133,6 +18156,54 @@ app.post('/api/device-telemetry', async (req, res) => {
         bufferUsed: result.bufferUsed,
         maxBuffer: telemetry.MAX_BUFFER_BYTES
     });
+});
+
+// Anonymous portal beacon endpoint — no device auth required.
+// Accepts pre-login events (portal_open, register_tab_open, register_submit,
+// register_success, register_error) and stores them for funnel analysis.
+// All entries must be non-PII (no email, phone, IP raw — use hashes only).
+app.post('/api/portal/beacons', async (req, res) => {
+    const { entries } = req.body;
+    if (!Array.isArray(entries) || entries.length === 0) {
+        return res.status(400).json({ success: false, error: 'entries array required' });
+    }
+    const VALID_ACTIONS = new Set([
+        'portal_open', 'register_tab_open', 'register_submit',
+        'register_success', 'register_error'
+    ]);
+    const clientIp = (req.headers['x-forwarded-for'] || '').split(',')[0].trim()
+        || (req.socket && req.socket.remoteAddress) || '';
+    const ua = (req.headers['user-agent'] || '').substring(0, 512) || null;
+    let stored = 0;
+    for (const entry of entries.slice(0, 50)) {
+        const action = String(entry.action || '').substring(0, 128);
+        if (!VALID_ACTIONS.has(action)) continue;
+        const meta = entry.meta ? (() => {
+            const m = {};
+            // Only allow whitelisted non-PII fields
+            const ALLOWED = ['source','channel','utm_source','utm_medium','utm_campaign','utm_content','utm_term','email_hash','error_type'];
+            for (const k of ALLOWED) {
+                if (entry.meta[k] !== undefined) m[k] = String(entry.meta[k]).substring(0, 256);
+            }
+            return Object.keys(m).length > 0 ? JSON.stringify(m) : null;
+        })() : null;
+        try {
+            await chatPool.query(
+                `INSERT INTO portal_beacons (action, ip_hash, ua, meta, created_at)
+                 VALUES ($1,$2,$3,$4,NOW())`,
+                [
+                    action,
+                    clientIp ? require('crypto').createHash('sha256').update(clientIp).digest('hex').substring(0, 16) : null,
+                    ua,
+                    meta
+                ]
+            );
+            stored++;
+        } catch (err) {
+            console.error('[PortalBeacons] Insert error:', err.message);
+        }
+    }
+    res.json({ success: true, stored });
 });
 
 // GET /api/device-telemetry — Read telemetry for debugging

--- a/backend/public/js/growth-tracking.js
+++ b/backend/public/js/growth-tracking.js
@@ -49,8 +49,23 @@
         return normalizeSource(fallback, 'web_portal');
     }
 
+
+    function getUtmParams() {
+        const params = getParams();
+        return {
+            utm_source: params.get('utm_source') || params.get('utmSource') || null,
+            utm_medium: params.get('utm_medium') || params.get('utmMedium') || null,
+            utm_campaign: params.get('utm_campaign') || params.get('utmCampaign') || null,
+            utm_content: params.get('utm_content') || params.get('utmContent') || null,
+            utm_term: params.get('utm_term') || params.get('utmTerm') || null,
+            source: params.get('source') || null,
+            channel: params.get('channel') || null,
+        };
+    }
+
     return {
         collectSignupSource,
-        normalizeSource
+        normalizeSource,
+        getUtmParams
     };
 }));

--- a/backend/public/portal/compare.html
+++ b/backend/public/portal/compare.html
@@ -231,7 +231,7 @@
          <div class="cmp-cta">
             <div class="cmp-cta-text" data-i18n="cmp_cta_text">EClawbot delivers the most complete AI Agent collaboration experience. Why settle for just chat?</div>
             <div class="cmp-cta-buttons">
-                <a href="index.html" class="btn btn-primary" data-i18n="cmp_cta_eclaw">Get Started with EClawbot</a>
+                <a href="index.html?tab=register&source=compare_cta" class="btn btn-primary" data-i18n="cmp_cta_eclaw">Get Started with EClawbot</a>
             </div>
         </div>
 

--- a/backend/public/portal/index.html
+++ b/backend/public/portal/index.html
@@ -441,6 +441,21 @@
             if (typeof renderFooter === 'function') renderFooter();
             const params = new URLSearchParams(window.location.search);
 
+            // Capture UTM params for beacon tracking (no PII)
+            if (window.EClawGrowthTracking && window.EClawGrowthTracking.getUtmParams) {
+                window._growthUtm = window.EClawGrowthTracking.getUtmParams();
+                // Propagate UTM to beacon meta for portal_open
+                if (typeof telemetry !== 'undefined' && telemetry.trackAction) {
+                    telemetry.trackAction('portal_open', {
+                        source: window._growthUtm.source,
+                        channel: window._growthUtm.channel,
+                        utm_source: window._growthUtm.utm_source,
+                        utm_medium: window._growthUtm.utm_medium,
+                        utm_campaign: window._growthUtm.utm_campaign
+                    });
+                }
+            }
+
             if (params.get('verified') === 'true') {
                 showTab('login');
                 showMsg('loginError', i18n.t('login_msg_email_verified'), 'success');
@@ -465,6 +480,20 @@
         });
 
         function showTab(tab) {
+            // Track register tab open beacon
+            if (tab === 'register') {
+                const utm = window._growthUtm || {};
+                const meta = {
+                    source: utm.source || utm.utm_source || new URLSearchParams(window.location.search).get('source') || 'direct',
+                    channel: utm.channel || null,
+                    utm_source: utm.utm_source || null,
+                    utm_medium: utm.utm_medium || null,
+                    utm_campaign: utm.utm_campaign || null
+                };
+                if (typeof telemetry !== 'undefined' && telemetry.trackAction) {
+                    telemetry.trackAction('register_tab_open', meta);
+                }
+            }
             // If switching to register and terms not yet accepted, show terms dialog first
             if (tab === 'register' && !termsAccepted) {
                 showTermsDialog();
@@ -597,13 +626,33 @@
             btn.disabled = true;
             btn.textContent = i18n.t('login_btn_creating');
 
+            // Build signup source with UTM attribution
+            const signupSource = collectSignupSource();
+            const utm = window._growthUtm || {};
+            const regMeta = {
+                source: utm.source || utm.utm_source || signupSource,
+                channel: utm.channel || null,
+                utm_source: utm.utm_source || null,
+                utm_medium: utm.utm_medium || null,
+                utm_campaign: utm.utm_campaign || null
+            };
+
             try {
-                await apiCall('POST', '/api/auth/register', { email, password, signupSource: collectSignupSource() });
+                if (typeof telemetry !== 'undefined' && telemetry.trackAction) {
+                    telemetry.trackAction('register_submit', regMeta);
+                }
+                await apiCall('POST', '/api/auth/register', { email, password, signupSource });
+                if (typeof telemetry !== 'undefined' && telemetry.trackAction) {
+                    telemetry.trackAction('register_success', { ...regMeta, email_hash: 'REDACTED' });
+                }
                 showMsg('regSuccess', i18n.t('sc_register_success_verify'), 'success');
                 document.getElementById('regEmail').value = '';
                 document.getElementById('regPassword').value = '';
                 document.getElementById('regPasswordConfirm').value = '';
             } catch (e) {
+                if (typeof telemetry !== 'undefined' && telemetry.trackAction) {
+                    telemetry.trackAction('register_error', { ...regMeta, error_type: e.status || 'unknown' });
+                }
                 showMsg('regError', e.message);
             } finally {
                 btn.disabled = false;

--- a/backend/public/shared/telemetry.js
+++ b/backend/public/shared/telemetry.js
@@ -44,25 +44,41 @@ const _telemetry = (() => {
     async function _flush() {
         if (_buffer.length === 0) return;
         const creds = _getDeviceCredentials();
-        if (!creds) return; // not authenticated yet
-
         const batch = _buffer.splice(0, MAX_BATCH);
-        try {
-            await fetch(`${API_BASE}/api/device-telemetry`, {
-                method: 'POST',
-                credentials: 'include',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    deviceId: creds.deviceId,
-                    deviceSecret: creds.deviceSecret,
-                    platform: 'web',
-                    entries: batch
-                })
-            });
-        } catch {
-            // Re-queue on failure (drop if buffer is huge to avoid memory leak)
-            if (_buffer.length < 200) {
-                _buffer.unshift(...batch);
+
+        if (creds) {
+            // Authenticated: send to device-telemetry
+            try {
+                await fetch(`${API_BASE}/api/device-telemetry`, {
+                    method: 'POST',
+                    credentials: 'include',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        deviceId: creds.deviceId,
+                        deviceSecret: creds.deviceSecret,
+                        platform: 'web',
+                        entries: batch
+                    })
+                });
+            } catch {
+                if (_buffer.length < 200) _buffer.unshift(...batch);
+            }
+        } else {
+            // Anonymous (pre-login): send public beacon events to /api/portal/beacons
+            // Filter to only valid public beacon actions
+            const beaconEntries = batch.filter(e =>
+                ['portal_open','register_tab_open','register_submit','register_success','register_error'].includes(e.action)
+            );
+            if (beaconEntries.length > 0) {
+                try {
+                    await fetch(`${API_BASE}/api/portal/beacons`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ entries: beaconEntries })
+                    });
+                } catch {
+                    // Drop anonymous beacons on failure — no re-queue to avoid PII accumulation
+                }
             }
         }
     }

--- a/backend/public/shared/telemetry.js
+++ b/backend/public/shared/telemetry.js
@@ -76,8 +76,8 @@ const _telemetry = (() => {
                         headers: { 'Content-Type': 'application/json' },
                         body: JSON.stringify({ entries: beaconEntries })
                     });
-                } catch {
-                    // Drop anonymous beacons on failure — no re-queue to avoid PII accumulation
+                } catch (err) {
+                    console.warn('[telemetry] anonymous beacon flush failed', err);
                 }
             }
         }


### PR DESCRIPTION
## Slice 1+2 of Growth-P0 (per Mac_F #1 planning verdict 2026-05-07)

Author: Mac_E #3 (committed under agent-6 identity in error — work itself matches dispatch).
Opened by: LOBSTER #2 because branch was pushed but PR never filed.

## Scope

**Slice 1 — CTA register intent attribution**
- `info.html` primary CTA → `?tab=register&source=info_cta`
- `info.html` FAQ CTA → `?tab=register&source=info_faq`
- `compare.html` CTA → `?tab=register&source=compare_cta`

**Slice 2 — Public funnel beacons (anonymous, no PII)**
- `portal_open` on DOMContentLoaded with UTM/source capture
- `register_tab_open` when register tab shown
- `register_submit` on form submission
- `register_success` on success — `email_hash: 'REDACTED'`
- `register_error` on failure — `error_type` only, no raw message

## Files changed

- `backend/index.js` — new `portal_beacons` table (BIGSERIAL/JSONB/GIN), POST `/api/portal/beacons` endpoint (no device auth)
- `backend/public/shared/telemetry.js` — anonymous flush bridge: pre-auth events route to `/api/portal/beacons` with action allowlist
- `backend/public/js/growth-tracking.js` — adds `getUtmParams()` UMD export
- `backend/public/portal/index.html` — 5 beacon trigger sites + `window._growthUtm` UTM propagation
- `backend/public/portal/compare.html` — CTA href updated

## PII safeguards (verified by review)

- IP stored as SHA256 truncated to 16 hex chars
- UA truncated to 512 chars
- Per-field cap 256 chars
- `email_hash` hardcoded as `'REDACTED'` literal at call site (no actual hashing on client)
- `error_type` from `e.status`, never error message body
- Backend meta-key allowlist: `[source, channel, utm_source, utm_medium, utm_campaign, utm_content, utm_term, email_hash, error_type]` — arbitrary keys silently dropped
- Client action allowlist mirrored on server: `[portal_open, register_tab_open, register_submit, register_success, register_error]`

## Workflow

- #2 LOBSTER review → see comment thread
- #6 Codex telemetry deep-dive → card_d86649d4414fa8457df5fb3e (dispatching now)
- #1 Mac_F → final merge gate

## Test plan

- [ ] #6 verifies anonymous flush actually fires when `currentUser` is null at flush time (race with auth.js)
- [ ] #6 verifies compare.html CTA still routes via existing showTab parsing
- [ ] Post-merge: confirm beacons firing on prod via SQL count of `portal_beacons` rows, sliced by `meta->>'source'`
- [ ] Hold community content publish until 24-48h funnel review per Mac_F gate

🤖 Opened by Claude (LOBSTER #2) on behalf of Mac_E #3