### PR TITLE
chore(gitattributes): restore gradlew + *.sh eol=lf rules

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
+# Force LF line endings for cross-platform tools that break on CRLF
 *.js text eol=lf
+gradlew text eol=lf
+*.sh text eol=lf


### PR DESCRIPTION
## Summary

- PR #2496 fast-fix replaced .gitattributes contents instead of appending — dropped pre-existing `gradlew text eol=lf` and `*.sh text eol=lf` rules
- This PR adds them back alongside the new `*.js text eol=lf` rule
- Avoids CRLF regression on shell scripts and Gradle wrapper for Windows checkouts

Follow-up flagged in the PR #2496 re-review per #1 Mac_F directive.
Card: card_46274a8ea71483cde9f291bf

## Test plan

- [x] git diff shows only the 3-line addition (gradlew/*.sh + comment header)
- [x] No code paths affected — pure repo metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)