### PR TITLE
feat(recovery): rebuild P0 CTA register intent + portal beacons (PR #2496)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 # Ensure Unix line endings for shell scripts
 gradlew text eol=lf
 *.sh text eol=lf
+*.js text eol=lf

--- a/backend/index.js
+++ b/backend/index.js
@@ -16561,6 +16561,31 @@ sitePageviews.initPageviewsTable(chatPool);
 if (mindmapModule && typeof mindmapModule.initMindmapTables === 'function') {
     mindmapModule.initMindmapTables(chatPool);
 }
+
+// Anonymous portal beacons table (for growth funnel tracking)
+(async () => {
+    try {
+        await chatPool.query(`
+            CREATE TABLE IF NOT EXISTS portal_beacons (
+                id          BIGSERIAL   PRIMARY KEY,
+                action      TEXT        NOT NULL,
+                ip_hash     TEXT,
+                ua          TEXT,
+                meta        JSONB,
+                created_at  TIMESTAMPTZ DEFAULT NOW()
+            )
+        `);
+        await chatPool.query(`CREATE INDEX IF NOT EXISTS idx_pb_action_ts ON portal_beacons (action, created_at DESC)`);
+        await chatPool.query(`CREATE INDEX IF NOT EXISTS idx_pb_ts         ON portal_beacons (created_at DESC)`);
+        await chatPool.query(`CREATE INDEX IF NOT EXISTS idx_pb_meta       ON portal_beacons USING GIN (meta)`);
+        console.log('[PortalBeacons] Table ready');
+    } catch (err) {
+        console.error('[PortalBeacons] Table init error:', err.message);
+    }
+})();
+
+    mindmapModule.initMindmapTables(chatPool);
+}
 feedbackModule.initFeedbackTable(chatPool);
 feedbackModule.initFeedbackPhotosTable(chatPool);
 notifModule.initNotificationTables(chatPool);
@@ -18134,6 +18159,66 @@ app.post('/api/device-telemetry', async (req, res) => {
         bufferUsed: result.bufferUsed,
         maxBuffer: telemetry.MAX_BUFFER_BYTES
     });
+});
+
+// Anonymous portal beacon endpoint — no device auth required.
+// Accepts pre-login events (portal_open, register_tab_open, register_submit,
+// register_success, register_error) and stores them for funnel analysis.
+// All entries must be non-PII (no email, phone, IP raw — use hashes only).
+
+// POST /api/portal/beacons — no device auth required.
+// Rate-limited: 60 events/min per IP. Explicit 64kb body cap.
+const beaconLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: 60,
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: () => rateLimitDisabled(),
+    keyGenerator: (req) => req.ip || 'unknown',
+    message: { success: false, error: 'Too many beacon events — try again shortly' },
+});
+app.post('/api/portal/beacons', express.json({ limit: '64kb' }), beaconLimiter, async (req, res) => {
+    const { entries } = req.body;
+    if (!Array.isArray(entries) || entries.length === 0) {
+        return res.status(400).json({ success: false, error: 'entries array required' });
+    }
+    const VALID_ACTIONS = new Set([
+        'portal_open', 'register_tab_open', 'register_submit',
+        'register_success', 'register_error'
+    ]);
+    const clientIp = (req.headers['x-forwarded-for'] || '').split(',')[0].trim()
+        || (req.socket && req.socket.remoteAddress) || '';
+    const ua = (req.headers['user-agent'] || '').substring(0, 512) || null;
+    let stored = 0;
+    for (const entry of entries.slice(0, 50)) {
+        const action = String(entry.action || '').substring(0, 128);
+        if (!VALID_ACTIONS.has(action)) continue;
+        const meta = entry.meta ? (() => {
+            const m = {};
+            // Only allow whitelisted non-PII fields
+            const ALLOWED = ['source','channel','utm_source','utm_medium','utm_campaign','utm_content','utm_term','email_hash','error_type'];
+            for (const k of ALLOWED) {
+                if (entry.meta[k] !== undefined) m[k] = String(entry.meta[k]).substring(0, 256);
+            }
+            return Object.keys(m).length > 0 ? JSON.stringify(m) : null;
+        })() : null;
+        try {
+            await chatPool.query(
+                `INSERT INTO portal_beacons (action, ip_hash, ua, meta, created_at)
+                 VALUES ($1,$2,$3,$4,NOW())`,
+                [
+                    action,
+                    clientIp ? require('crypto').createHash('sha256').update(clientIp).digest('hex').substring(0, 16) : null,
+                    ua,
+                    meta
+                ]
+            );
+            stored++;
+        } catch (err) {
+            console.error('[PortalBeacons] Insert error:', err.message);
+        }
+    }
+    res.json({ success: true, stored });
 });
 
 // GET /api/device-telemetry — Read telemetry for debugging

--- a/backend/index.js
+++ b/backend/index.js
@@ -16584,8 +16584,6 @@ if (mindmapModule && typeof mindmapModule.initMindmapTables === 'function') {
     }
 })();
 
-    mindmapModule.initMindmapTables(chatPool);
-}
 feedbackModule.initFeedbackTable(chatPool);
 feedbackModule.initFeedbackPhotosTable(chatPool);
 notifModule.initNotificationTables(chatPool);

--- a/backend/public/landing.html
+++ b/backend/public/landing.html
@@ -249,7 +249,7 @@
             <h1 data-i18n="landing_hero_title">EClawbot</h1>
             <p data-i18n="landing_hero_subtitle">Agent-to-Agent (A2A) Communication Platform — Your Personal Enterprise AI Assistant. Build, manage, and deploy AI agents for inter-agent collaboration, task automation, and customer-facing services. Powered by OpenClaw.</p>
             <div class="hero-cta">
-                <a href="/portal/" class="btn-primary" data-i18n="landing_get_started">Get Started</a>
+                <a href="/portal/?tab=register" class="btn-primary" data-i18n="landing_get_started">Get Started</a>
                 <a href="/portal/community.html" class="btn-outline" data-i18n="landing_browse_bots">Browse Bots</a>
                 <a href="/enterprise" class="btn-outline" data-i18n="landing_enterprise">Enterprise</a>
                 <a href="/api/docs" class="btn-outline" data-i18n="landing_api_docs">API Documentation</a>

--- a/backend/public/shared/telemetry.js
+++ b/backend/public/shared/telemetry.js
@@ -7,6 +7,7 @@
  *   - Errors (window.onerror + unhandledrejection)
  *
  * Manual tracking:
+ *   - telemetry.trackPageView(page, meta)
  *   - telemetry.trackAction(action, meta)
  *   - telemetry.trackError(error, meta)
  *   - telemetry.trackLifecycle(action, meta)
@@ -43,25 +44,41 @@ const _telemetry = (() => {
     async function _flush() {
         if (_buffer.length === 0) return;
         const creds = _getDeviceCredentials();
-        if (!creds) return; // not authenticated yet
-
         const batch = _buffer.splice(0, MAX_BATCH);
-        try {
-            await fetch(`${API_BASE}/api/device-telemetry`, {
-                method: 'POST',
-                credentials: 'include',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    deviceId: creds.deviceId,
-                    deviceSecret: creds.deviceSecret,
-                    platform: 'web',
-                    entries: batch
-                })
-            });
-        } catch {
-            // Re-queue on failure (drop if buffer is huge to avoid memory leak)
-            if (_buffer.length < 200) {
-                _buffer.unshift(...batch);
+
+        if (creds) {
+            // Authenticated: send to device-telemetry
+            try {
+                await fetch(`${API_BASE}/api/device-telemetry`, {
+                    method: 'POST',
+                    credentials: 'include',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        deviceId: creds.deviceId,
+                        deviceSecret: creds.deviceSecret,
+                        platform: 'web',
+                        entries: batch
+                    })
+                });
+            } catch {
+                if (_buffer.length < 200) _buffer.unshift(...batch);
+            }
+        } else {
+            // Anonymous (pre-login): send public beacon events to /api/portal/beacons
+            // Filter to only valid public beacon actions
+            const beaconEntries = batch.filter(e =>
+                ['portal_open','register_tab_open','register_submit','register_success','register_error'].includes(e.action)
+            );
+            if (beaconEntries.length > 0) {
+                try {
+                    await fetch(`${API_BASE}/api/portal/beacons`, {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ entries: beaconEntries })
+                    });
+                } catch (err) {
+                    console.warn('[telemetry] anonymous beacon flush failed', err);
+                }
             }
         }
     }
@@ -175,6 +192,13 @@ const _telemetry = (() => {
     // ---- public API ----
 
     return {
+        /** Track a page view explicitly (for pages that initialize after dynamic layout setup) */
+        trackPageView(page = null, meta = null) {
+            const detectedPage = page || _detectPage();
+            _page = detectedPage;
+            _push({ type: 'page_view', action: detectedPage, meta });
+        },
+
         /** Track a user action (button click, dialog open, etc.) */
         trackAction(action, meta = null) {
             _push({ type: 'user_action', action, meta });


### PR DESCRIPTION
Cherry-pick reconstruction of lost P0 from PR #2496 (mergeCommit 4cc86758).

## Scope
- CTA register intent: landing.html - Get Started → /portal/?tab=register
- POST /api/portal/beacons (anonymous, 60/min rate limit, 64kb body cap)
  - portal_beacons table CREATE IF NOT EXISTS at boot
  - VALID_ACTIONS: portal_open, register_tab_open, register_submit, register_success, register_error
  - Meta whitelist (anti-PII): source, channel, utm_* fields, email_hash, error_type
  - ip_hash = sha256-16
- telemetry.js: anonymous beacon flush to /api/portal/beacons
- .gitattributes: *.js text eol=lf

## Reference Commits
- ff15affd: CTA register intent (P0 slice 1)
- 689b5d60: beacons endpoint + rate limit + body cap (P0 slice 2)
- 4cc86758: original merged commit (lost)


## Already recovered separately (NOT in this PR)
- e965a72a: invite_clicks + funnel (PR #2500)

Closes card_a3e9a5d1bce1b5466443037a