### PR TITLE
feat(idle-dispatch): PR-B wire onCardStatusChange → kanbanEvents.emit

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -43,6 +43,7 @@ const safeEqual = require('./safe-equal');
 const { newCardId } = require('./entity-id');
 const { tKanban, statusLabel } = require('./i18n/kanban-notifications');
 const devicePrefs = require('./device-preferences');
+const { emit: emitKanbanEvent } = require('./lib/kanban-events');
 
 // Cache device→language to avoid repeated lookups
 const deviceLangCache = new Map();
@@ -1553,6 +1554,19 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
             }
 
             await bumpVersion(deviceId);
+
+            // Idle-dispatch hook (PR-B). emit() is a no-op when
+            // IDLE_DISPATCH_HOOKS_ENABLED !== 'true'. Synchronous, never
+            // throws (wrapped internally), and runs after the DB write +
+            // notify so listeners see a durable transition.
+            emitKanbanEvent('card_status_changed', {
+                cardId,
+                fromStatus: oldStatus,
+                toStatus: newStatus,
+                deviceId,
+                entityId: req.body.entityId,
+                ts: new Date().toISOString()
+            });
 
             // Award XP for moving to done
             if (newStatus === 'done' && awardEntityXP) {

--- a/backend/tests/jest/idle-dispatch-pr-b-wire.test.js
+++ b/backend/tests/jest/idle-dispatch-pr-b-wire.test.js
@@ -1,0 +1,145 @@
+/**
+ * idle-dispatch-pr-b-wire.test.js — verifies the kanban POST /card/:id/move
+ * route fires kanbanEvents.emit('card_status_changed', ...) when the flag
+ * is ON, and stays silent when OFF (Mac_F sign-off req: "flag OFF 時不得
+ *改變現有行為").
+ *
+ * Uses the same in-process pg mock pattern as kanban-card.test.js so we
+ * exercise the real route handler — not just the emit primitive.
+ */
+
+const mockQuery = jest.fn();
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: mockQuery,
+        connect: jest.fn().mockResolvedValue({
+            query: jest.fn().mockResolvedValue({ rows: [] }),
+            release: jest.fn(),
+        }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+jest.mock('../../safe-equal', () => (a, b) => a === b);
+
+const express = require('express');
+const request = require('supertest');
+
+const AUTH = { deviceId: 'test-dev', deviceSecret: 'test-secret' };
+const MOCK_DEVICES = {
+    'test-dev': {
+        deviceSecret: 'test-secret',
+        entities: {
+            0: { isBound: true, botSecret: 'bot-sec', character: 'Bot0' },
+            1: { isBound: true, botSecret: 'bot-sec-1', character: 'Bot1' },
+        },
+    },
+};
+
+// Existing card row + UPDATE result row used by the happy path.
+const EXISTING_ROW = {
+    id: 'card_test_1',
+    device_id: 'test-dev',
+    status: 'todo',
+    assigned_bots: [0],
+    archived: false,
+    requires_screenshot_review: false,
+    title: 'Test card',
+    description: '',
+    is_auto_generated: false,
+    parent_card_id: null,
+};
+
+const UPDATED_ROW = {
+    ...EXISTING_ROW,
+    status: 'in_progress',
+    status_changed_at: new Date(),
+    updated_at: new Date(),
+    last_stale_nudge_at: null,
+};
+
+function primeHappyPath() {
+    // 1. SELECT existing card (line 1482)
+    mockQuery.mockResolvedValueOnce({ rows: [EXISTING_ROW] });
+    // 2. UPDATE kanban_cards (line 1526)
+    mockQuery.mockResolvedValueOnce({ rows: [UPDATED_ROW] });
+    // 3+. catch-all for addSystemComment / bumpVersion / etc.
+    mockQuery.mockResolvedValue({ rows: [] });
+}
+
+function freshApp() {
+    jest.resetModules();
+    mockQuery.mockReset();
+    mockQuery.mockResolvedValue({ rows: [] });
+    const app = express();
+    app.use(express.json());
+    const kanbanModule = require('../../kanban')(MOCK_DEVICES, {});
+    app.use('/api/mission', kanbanModule.router);
+    const { kanbanEvents } = require('../../lib/kanban-events');
+    return { app, kanbanEvents };
+}
+
+describe('idle-dispatch PR-B — /card/:id/move wires emit', () => {
+    const originalFlag = process.env.IDLE_DISPATCH_HOOKS_ENABLED;
+
+    afterAll(() => {
+        if (originalFlag !== undefined) process.env.IDLE_DISPATCH_HOOKS_ENABLED = originalFlag;
+        else delete process.env.IDLE_DISPATCH_HOOKS_ENABLED;
+    });
+
+    test('flag OFF: successful /move does NOT fire card_status_changed', async () => {
+        delete process.env.IDLE_DISPATCH_HOOKS_ENABLED;
+        const { app, kanbanEvents } = freshApp();
+        primeHappyPath();
+        const listener = jest.fn();
+        kanbanEvents.on('card_status_changed', listener);
+
+        const res = await request(app)
+            .post('/api/mission/card/card_test_1/move')
+            .send({ ...AUTH, entityId: 0, newStatus: 'in_progress', assignedBots: [0] });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(listener).not.toHaveBeenCalled();
+    });
+
+    test('flag ON: successful /move fires card_status_changed with full payload', async () => {
+        process.env.IDLE_DISPATCH_HOOKS_ENABLED = 'true';
+        const { app, kanbanEvents } = freshApp();
+        primeHappyPath();
+        const listener = jest.fn();
+        kanbanEvents.on('card_status_changed', listener);
+
+        const res = await request(app)
+            .post('/api/mission/card/card_test_1/move')
+            .send({ ...AUTH, entityId: 0, newStatus: 'in_progress', assignedBots: [0] });
+
+        expect(res.status).toBe(200);
+        expect(listener).toHaveBeenCalledTimes(1);
+        const evt = listener.mock.calls[0][0];
+        expect(evt.name).toBe('card_status_changed');
+        expect(evt.payload.cardId).toBe('card_test_1');
+        expect(evt.payload.fromStatus).toBe('todo');
+        expect(evt.payload.toStatus).toBe('in_progress');
+        expect(evt.payload.deviceId).toBe('test-dev');
+        expect(evt.payload.entityId).toBe(0);
+        expect(typeof evt.payload.ts).toBe('string');
+    });
+
+    test('flag ON: rejected move (validation) does NOT fire event', async () => {
+        process.env.IDLE_DISPATCH_HOOKS_ENABLED = 'true';
+        const { app, kanbanEvents } = freshApp();
+        // No primeHappyPath — first SELECT returns empty so the 404 fires.
+        mockQuery.mockResolvedValueOnce({ rows: [] });
+        const listener = jest.fn();
+        kanbanEvents.on('card_status_changed', listener);
+
+        const res = await request(app)
+            .post('/api/mission/card/missing_card/move')
+            .send({ ...AUTH, entityId: 0, newStatus: 'in_progress', assignedBots: [0] });
+
+        expect(res.status).toBe(404);
+        expect(listener).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

PR-A (\`d7526e26\`) added the idle-dispatch feature flag + EventEmitter wrapper but didn't wire any callsite. **PR-B** inserts \`emit('card_status_changed', ...)\` into \`POST /card/:id/move\` so listeners can observe durable status transitions.

## Mac_F (#1) sign-off compliance (2026-05-07 14:17 TPE)

- **Flag**: \`IDLE_DISPATCH_HOOKS_ENABLED\` env var (default OFF) — reused from PR-A, no rename
- **Placement**: emit fires AFTER \`UPDATE kanban_cards\` + \`bumpVersion\` succeed, BEFORE the XP award + queue-drain side-effects → listeners only see durable transitions
- **No-op when OFF**: \`emit()\` early-returns when flag unset — zero behavior change in production
- **Listener safety**: PR-A's \`emit()\` already wraps the synchronous \`kanbanEvents.emit()\` in try/catch and structured-logs failures, so a future async listener throw cannot 500 the user request
- **No secrets in payload**: \`{cardId, fromStatus, toStatus, deviceId, entityId, ts}\` — no \`botSecret\`/\`deviceSecret\`

## Test plan

New test file: \`backend/tests/jest/idle-dispatch-pr-b-wire.test.js\` — 3 cases via supertest against the real \`/api/mission/card/:id/move\` route:

- [x] **flag OFF + happy /move** → listener never called (Mac_F's required \"flag OFF 不得改變現有行為\" gate)
- [x] **flag ON + happy /move** → listener called once with full payload (cardId, fromStatus, toStatus, deviceId, entityId, ts)
- [x] **flag ON + 404 (validation rejected)** → listener never called

Regression checks (run locally):

- [x] \`idle-dispatch-hooks.test.js\` (PR-A): 5/5 pass
- [x] \`kanban-card.test.js\`: 33/33 pass — no regression in the move handler

## What's next

**PR-C** wires \`createAutoCronCard\` and lands after PR-B + a prod smoke with flag OFF (per Mac_F's gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)