### PR TITLE
feat(idle-dispatch): PR-C wire createAutoCronCard → kanbanEvents.emit

### DIFF
--- a/backend/docs/idle-dispatch.md
+++ b/backend/docs/idle-dispatch.md
@@ -1,11 +1,12 @@
-# Idle Dispatch Hooks - PR-A Instrumentation
+# Idle Dispatch Hooks
 
-> Status: PR-A - instrumentation only (no listener logic)
+> Status: PR-A foundation + PR-B/PR-C call-sites — emit-only, no listeners
 
 ## Overview
 
-PR-A adds instrumentation hooks for kanban card lifecycle events.
-It is purely observational. Default OFF - production behavior changes zero.
+Instrumentation hooks for kanban card lifecycle events. Purely
+observational at this stage. Default OFF — production behavior changes
+zero until a listener is registered AND the env flag is set.
 
 ## Architecture
 
@@ -30,22 +31,28 @@ backend/
 
 ## Events
 
-| Event | Payload |
-|---|---|
-| card_status_changed | `{cardId, fromStatus, toStatus, deviceId, entityId, ts}` |
+| Event | Emitted from | Payload |
+|---|---|---|
+| card_status_changed | `kanban.js` POST /card/:id/move (PR-B) | `{cardId, fromStatus, toStatus, deviceId, entityId, ts}` |
+| auto_cron_card_created | `idle_dispatch_integration.js` createAutoCronCard (PR-C) | `{cardId, parentCardId, deviceId, assignedBots, ts}` |
+
+Both events fire AFTER the durable DB write completes, so listeners
+never see a transition that gets rolled back.
 
 ## Structured Logs
 
 ```json
-{"ev":"idle_dispatch.card_status_changed","name":"card_status_changed","payload":{...},"ts":"..."}
-{"ev":"idle_dispatch.emit_error","name":"card_status_changed","error":"...","ts":"..."}
+{"ev":"idle_dispatch.card_status_changed","name":"<event>","payload":{...},"ts":"..."}
+{"ev":"idle_dispatch.emit_error","name":"<event>","error":"...","ts":"..."}
 ```
 
 No secrets logged (botSecret/deviceSecret excluded from emit() payload by design).
 
-## PR-B (Future)
+## Future work
 
-PR-B will add listeners for: queue depth, drain attempt, drain result, latency.
+A listener subsystem (queue-depth metrics, dispatch-latency tracking,
+drain attempts) is out of scope for the current PR series. Adding one
+only requires `kanbanEvents.on('<event>', handler)` somewhere in startup.
 
 ## Rollback
 

--- a/backend/idle_dispatch_integration.js
+++ b/backend/idle_dispatch_integration.js
@@ -5,6 +5,7 @@
 
 const { Pool } = require('pg');
 const { smartDispatch, drainBotQueue } = require('./idle_dispatch_handler');
+const { emit: emitKanbanEvent } = require('./lib/kanban-events');
 
 const pool = new Pool({
     connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
@@ -127,6 +128,19 @@ async function createAutoCronCard(parentCardId, deviceId, assignedBots) {
         `, [parentCardId, deviceId, autoCard.id]);
 
         console.log(`Auto cron card created: ${autoCard.id} for parent ${parentCardId}`);
+
+        // Idle-dispatch hook (PR-C). emit() is a no-op when
+        // IDLE_DISPATCH_HOOKS_ENABLED !== 'true'. Synchronous, never
+        // throws (wrapped internally), and runs after the spawn + parent-
+        // link UPDATE so listeners only see committed cron spawns.
+        emitKanbanEvent('auto_cron_card_created', {
+            cardId: autoCard.id,
+            parentCardId,
+            deviceId,
+            assignedBots,
+            ts: new Date().toISOString()
+        });
+
         return autoCard;
 
     } catch (error) {

--- a/backend/tests/jest/idle-dispatch-pr-c-wire.test.js
+++ b/backend/tests/jest/idle-dispatch-pr-c-wire.test.js
@@ -1,0 +1,117 @@
+/**
+ * idle-dispatch-pr-c-wire.test.js — verifies createAutoCronCard fires
+ * kanbanEvents.emit('auto_cron_card_created', ...) when the flag is ON,
+ * and stays silent when OFF (Mac_F sign-off req: "flag OFF 不得改變現有
+ * 行為").
+ *
+ * Mocks pg + idle_dispatch_handler so we exercise the real spawn path
+ * without touching a database.
+ */
+
+const mockQuery = jest.fn();
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: mockQuery,
+        connect: jest.fn().mockResolvedValue({
+            query: jest.fn().mockResolvedValue({ rows: [] }),
+            release: jest.fn(),
+        }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+jest.mock('../../idle_dispatch_handler', () => ({
+    smartDispatch: jest.fn().mockResolvedValue({ dispatched: true, reason: 'test' }),
+    drainBotQueue: jest.fn().mockResolvedValue({ drained: 0 }),
+}));
+
+const PARENT_ROW = {
+    title: 'Parent cron card',
+    description: 'parent desc',
+};
+
+function primeSpawn() {
+    // 1. SELECT parent
+    mockQuery.mockResolvedValueOnce({ rows: [PARENT_ROW] });
+    // 2. INSERT new card (createCardWithSmartDispatch)
+    mockQuery.mockResolvedValueOnce({ rows: [{
+        id: 'auto_card_xyz',
+        device_id: 'dev_1',
+        title: '[Auto] Parent cron card',
+        description: 'auto desc',
+        status: 'backlog',
+        assigned_bots: [3],
+        priority: 'P1',
+    }] });
+    // 3. UPDATE status='todo' after dispatch (smartDispatch returns dispatched:true)
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // 4. UPDATE is_auto_generated/parent_card_id link
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    // 5+: catch-all
+    mockQuery.mockResolvedValue({ rows: [] });
+}
+
+describe('idle-dispatch PR-C — createAutoCronCard wires emit', () => {
+    const originalFlag = process.env.IDLE_DISPATCH_HOOKS_ENABLED;
+
+    afterAll(() => {
+        if (originalFlag !== undefined) process.env.IDLE_DISPATCH_HOOKS_ENABLED = originalFlag;
+        else delete process.env.IDLE_DISPATCH_HOOKS_ENABLED;
+    });
+
+    beforeEach(() => {
+        jest.resetModules();
+        mockQuery.mockReset();
+        mockQuery.mockResolvedValue({ rows: [] });
+    });
+
+    test('flag OFF: createAutoCronCard does NOT fire auto_cron_card_created', async () => {
+        delete process.env.IDLE_DISPATCH_HOOKS_ENABLED;
+        const integ = require('../../idle_dispatch_integration');
+        const { kanbanEvents } = require('../../lib/kanban-events');
+        primeSpawn();
+        const listener = jest.fn();
+        kanbanEvents.on('auto_cron_card_created', listener);
+
+        const result = await integ.createAutoCronCard('parent_1', 'dev_1', [3]);
+
+        expect(result).toBeDefined();
+        expect(result.id).toBe('auto_card_xyz');
+        expect(listener).not.toHaveBeenCalled();
+    });
+
+    test('flag ON: createAutoCronCard fires auto_cron_card_created with full payload', async () => {
+        process.env.IDLE_DISPATCH_HOOKS_ENABLED = 'true';
+        const integ = require('../../idle_dispatch_integration');
+        const { kanbanEvents } = require('../../lib/kanban-events');
+        primeSpawn();
+        const listener = jest.fn();
+        kanbanEvents.on('auto_cron_card_created', listener);
+
+        await integ.createAutoCronCard('parent_1', 'dev_1', [3]);
+
+        expect(listener).toHaveBeenCalledTimes(1);
+        const evt = listener.mock.calls[0][0];
+        expect(evt.name).toBe('auto_cron_card_created');
+        expect(evt.payload.cardId).toBe('auto_card_xyz');
+        expect(evt.payload.parentCardId).toBe('parent_1');
+        expect(evt.payload.deviceId).toBe('dev_1');
+        expect(evt.payload.assignedBots).toEqual([3]);
+        expect(typeof evt.payload.ts).toBe('string');
+    });
+
+    test('flag ON: spawn failure (parent missing) does NOT fire event', async () => {
+        process.env.IDLE_DISPATCH_HOOKS_ENABLED = 'true';
+        const integ = require('../../idle_dispatch_integration');
+        const { kanbanEvents } = require('../../lib/kanban-events');
+        // Parent SELECT returns empty → throws before spawn completes
+        mockQuery.mockResolvedValueOnce({ rows: [] });
+        const listener = jest.fn();
+        kanbanEvents.on('auto_cron_card_created', listener);
+
+        await expect(integ.createAutoCronCard('missing_parent', 'dev_1', [3]))
+            .rejects.toThrow(/not found/);
+        expect(listener).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

Closes the idle-dispatch instrumentation series: PR-A (foundation) + PR-B (move handler) + **PR-C (cron spawn)**.

PR-C inserts \`emit('auto_cron_card_created', ...)\` at \`backend/idle_dispatch_integration.js:131\` (right after the \`Auto cron card created: ...\` log line, before \`return autoCard\`). Same flag, same fire-and-forget contract, same no-secrets-in-payload rule as PR-B.

## Mac_F gating compliance

- ✅ **Waited for PR-B merge** — PR #2504 mergeCommit \`7a71a31c\` landed first
- ✅ **Flag-OFF prod smoke passed** — build \`v5.6-20260507\` alive at 06:26:36Z; \`/api/mission/cards\` returns 893 cards; no 5xx after deploy
- ✅ **Same flag** (\`IDLE_DISPATCH_HOOKS_ENABLED\`) — no rename churn
- ✅ **emit() never blocks** — synchronous, internal try/catch, runs after the durable INSERT + UPDATE
- ✅ **Spawn failure suppresses event** — if the parent SELECT misses, the \`throw\` skips the emit (verified by the \"parent missing\" test case)

## Event signature

| Event | Payload |
|---|---|
| auto_cron_card_created | \`{cardId, parentCardId, deviceId, assignedBots, ts}\` |

## Test plan

\`backend/tests/jest/idle-dispatch-pr-c-wire.test.js\` — 3 cases:

- [x] **flag OFF + happy spawn** → listener never called (Mac_F's \"flag OFF 不得改變現有行為\" gate)
- [x] **flag ON + happy spawn** → listener called with full payload
- [x] **flag ON + parent missing** → throws, no event emitted

Regression checks:

- [x] \`idle-dispatch-pr-b-wire.test.js\`: 3/3 pass
- [x] \`idle-dispatch-hooks.test.js\`: 5/5 pass

## Doc

\`backend/docs/idle-dispatch.md\` updated:
- Status: \"PR-A foundation + PR-B/PR-C call-sites — emit-only, no listeners\"
- Events table: both \`card_status_changed\` and \`auto_cron_card_created\`
- Future-work note: listeners are out of scope for this PR series; adding one is just \`kanbanEvents.on(<event>, handler)\` at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)