### PR TITLE
feat(kanban): PR-DCA — dep-chain schema + cycle detection

### DIFF
--- a/backend/kanban-dependencies.js
+++ b/backend/kanban-dependencies.js
@@ -1,0 +1,51 @@
+/**
+ * Kanban card dependency-chain helpers (PR-DCA).
+ *
+ * Restored after PR #2481 → PR #2494 cleanup, per Mac_F (#1) sign-off 2026-05-07
+ * card_92363a55c53eef7b672024e9. PR-DCA scope: schema + cycle detection only.
+ * Router mount lives in PR-DCB (api_kanban_dependencies.js).
+ *
+ * Cycle detection runs as an iterative BFS over the dependency graph rather
+ * than a PL/pgSQL recursive CTE: keeps the migration compatible with the
+ * `;`-splitter in initKanbanDatabase() and stays testable under pg-mem,
+ * which has spotty `WITH RECURSIVE` support across versions.
+ */
+
+'use strict';
+
+/**
+ * Returns true if inserting (cardId → dependsOnCardId) would close a cycle.
+ *
+ * Walk semantics: starting at dependsOnCardId, follow `card_id → depends_on_card_id`
+ * edges. If we ever land on cardId, the proposed edge would create a cycle.
+ *
+ * Self-reference (cardId === dependsOnCardId) is rejected up front.
+ */
+async function detectDependencyCycle(pool, deviceId, cardId, dependsOnCardId) {
+    if (!pool || !deviceId || !cardId || !dependsOnCardId) {
+        throw new Error('detectDependencyCycle: pool, deviceId, cardId, dependsOnCardId all required');
+    }
+    if (cardId === dependsOnCardId) return true;
+
+    const visited = new Set([dependsOnCardId]);
+    const queue = [dependsOnCardId];
+
+    while (queue.length > 0) {
+        const node = queue.shift();
+        const { rows } = await pool.query(
+            'SELECT depends_on_card_id FROM kanban_card_dependencies WHERE device_id = $1 AND card_id = $2',
+            [deviceId, node]
+        );
+        for (const row of rows) {
+            const next = row.depends_on_card_id;
+            if (next === cardId) return true;
+            if (!visited.has(next)) {
+                visited.add(next);
+                queue.push(next);
+            }
+        }
+    }
+    return false;
+}
+
+module.exports = { detectDependencyCycle };

--- a/backend/kanban_schema.sql
+++ b/backend/kanban_schema.sql
@@ -189,3 +189,28 @@ ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS pending_dispatch BOOLEAN DEFAU
 
 CREATE INDEX IF NOT EXISTS idx_kanban_cards_pending_dispatch ON kanban_cards(device_id, pending_dispatch, dispatch_mode)
     WHERE pending_dispatch = TRUE;
+
+-- ============================================
+-- Migration: Card dependency chain (PR-DCA)
+-- Restored from PR #2481 (cleaned in #2494) per Mac_F sign-off 2026-05-07.
+-- Cycle detection lives in backend/kanban-dependencies.js (BFS in JS); no
+-- PL/pgSQL function is registered, so this section stays compatible with
+-- the kanban_schema.sql `;`-splitter in initKanbanDatabase().
+-- ============================================
+CREATE TABLE IF NOT EXISTS kanban_card_dependencies (
+    id BIGSERIAL PRIMARY KEY,
+    device_id VARCHAR(64) NOT NULL,
+    card_id VARCHAR(48) NOT NULL REFERENCES kanban_cards(id) ON DELETE CASCADE,
+    depends_on_card_id VARCHAR(48) NOT NULL REFERENCES kanban_cards(id) ON DELETE CASCADE,
+    dependency_type VARCHAR(16) DEFAULT 'blocks',
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    created_by INTEGER NOT NULL DEFAULT 0,
+    UNIQUE(device_id, card_id, depends_on_card_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_kanban_dependencies_card ON kanban_card_dependencies(device_id, card_id);
+CREATE INDEX IF NOT EXISTS idx_kanban_dependencies_depends_on ON kanban_card_dependencies(device_id, depends_on_card_id);
+CREATE INDEX IF NOT EXISTS idx_kanban_dependencies_type ON kanban_card_dependencies(device_id, dependency_type);
+
+ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS has_dependencies BOOLEAN DEFAULT FALSE;
+ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS dependency_status VARCHAR(16) DEFAULT 'ready';

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -45,6 +45,7 @@
         "eslint": "^9.28.0",
         "jest": "^29.7.0",
         "nodemon": "^3.1.0",
+        "pg-mem": "^3.0.14",
         "supertest": "^7.2.2"
       },
       "engines": {
@@ -4187,6 +4188,25 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -4416,6 +4436,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/component-emitter": {
       "version": "1.3.1",
@@ -4682,6 +4709,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
@@ -4740,6 +4785,13 @@
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
+    },
+    "node_modules/discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -5885,8 +5937,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
-      "license": "MIT",
-      "optional": true
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/gaxios": {
       "version": "6.7.1",
@@ -6182,6 +6234,19 @@
         "node": ">=4"
       }
     },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/has-symbols": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
@@ -6426,6 +6491,13 @@
       "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/immutable": {
+      "version": "4.3.8",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
+      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/import-fresh": {
       "version": "3.3.1",
@@ -7429,10 +7501,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-stable-stringify": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz",
+      "integrity": "sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-stable-stringify/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
     },
@@ -7447,6 +7546,16 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jsonify": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "dev": true,
+      "license": "Public Domain",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/jsonwebtoken": {
@@ -7897,6 +8006,23 @@
         "mkdirp": "bin/cmd.js"
       }
     },
+    "node_modules/moment": {
+      "version": "2.30.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
+      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moo": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.3.tgz",
+      "integrity": "sha512-m2fmM2dDm7GZQsY7KK2cme8agi+AAljILjQnof7p1ZMDe6dQ4bdnSMx0cPppudoeNv5hEFQirN6u+O4fDE0IWA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -7946,6 +8072,29 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nearley": {
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
+      "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6"
+      },
+      "bin": {
+        "nearley-railroad": "bin/nearley-railroad.js",
+        "nearley-test": "bin/nearley-test.js",
+        "nearley-unparse": "bin/nearley-unparse.js",
+        "nearleyc": "bin/nearleyc.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://nearley.js.org/#give-to-nearley"
+      }
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -8172,6 +8321,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/on-finished": {
@@ -8460,6 +8619,95 @@
         "node": ">=4.0.0"
       }
     },
+    "node_modules/pg-mem": {
+      "version": "3.0.14",
+      "resolved": "https://registry.npmjs.org/pg-mem/-/pg-mem-3.0.14.tgz",
+      "integrity": "sha512-G9m8OD0A+YS083smidSUJddTX2dEDPT8mRMG3sQGNiGfS/mkvAgd9Kf1/onD5633bFN7HcQK/Tn2x7qjBMFRUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "functional-red-black-tree": "^1.0.1",
+        "immutable": "^4.3.4",
+        "json-stable-stringify": "^1.0.1",
+        "lru-cache": "^6.0.0",
+        "moment": "^2.27.0",
+        "object-hash": "^2.0.3",
+        "pgsql-ast-parser": "^12.0.2"
+      },
+      "peerDependencies": {
+        "@mikro-orm/core": ">=4.5.3",
+        "@mikro-orm/postgresql": ">=4.5.3",
+        "knex": ">=0.20",
+        "kysely": ">=0.26",
+        "pg-promise": ">=10.8.7",
+        "pg-server": "^0.1.5",
+        "postgres": "^3.4.4",
+        "slonik": ">=23.0.1",
+        "typeorm": ">=0.2.29"
+      },
+      "peerDependenciesMeta": {
+        "@mikro-orm/core": {
+          "optional": true
+        },
+        "@mikro-orm/postgresql": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mikro-orm": {
+          "optional": true
+        },
+        "pg-promise": {
+          "optional": true
+        },
+        "pg-server": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "slonik": {
+          "optional": true
+        },
+        "typeorm": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-mem/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pg-mem/node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pg-mem/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/pg-pool": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.11.0.tgz",
@@ -8498,6 +8746,17 @@
       "license": "MIT",
       "dependencies": {
         "split2": "^4.1.0"
+      }
+    },
+    "node_modules/pgsql-ast-parser": {
+      "version": "12.0.2",
+      "resolved": "https://registry.npmjs.org/pgsql-ast-parser/-/pgsql-ast-parser-12.0.2.tgz",
+      "integrity": "sha512-1WWa96Sw6h4uv9GLw98EzH/+xoBTC8j2TwV/AMW3E+Ir/fHOu/jLLbj6kPiz3y2bGISTKNYvKWwHoqvQ5FLuAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "moo": "^0.5.1",
+        "nearley": "^2.19.5"
       }
     },
     "node_modules/picocolors": {
@@ -8828,6 +9087,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      },
+      "engines": {
+        "node": ">=0.12"
+      }
+    },
     "node_modules/range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
@@ -8985,6 +9265,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/ret": {
+      "version": "0.1.15",
+      "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12"
       }
     },
     "node_modules/retry": {
@@ -9176,6 +9466,24 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/setprototypeof": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -61,6 +61,7 @@
     "eslint": "^9.28.0",
     "jest": "^29.7.0",
     "nodemon": "^3.1.0",
+    "pg-mem": "^3.0.14",
     "supertest": "^7.2.2"
   },
   "engines": {

--- a/backend/tests/jest/kanban-dependencies-cycle.test.js
+++ b/backend/tests/jest/kanban-dependencies-cycle.test.js
@@ -1,0 +1,129 @@
+'use strict';
+
+/**
+ * kanban-dependencies-cycle.test.js (PR-DCA)
+ *
+ * Real SQL execution via pg-mem against a hand-rolled minimal schema
+ * mirroring the dep-chain DDL added to backend/kanban_schema.sql in this
+ * PR. We do NOT load the full kanban_schema.sql here because pg-mem cannot
+ * parse a few statements the live schema relies on (computed `DEFAULT
+ * (encode(gen_random_bytes…))`, `ALTER COLUMN TYPE … USING`, partial-index
+ * `WHERE`); those are tested elsewhere in CI. The dep-chain DDL itself is
+ * plain ANSI-shape syntax and pg-mem runs it faithfully — sufficient for
+ * Mac_F's hard-gate cycle-detection coverage.
+ *
+ * Mac_F sign-off 2026-05-07 explicitly allowed this fallback shape:
+ *   "if pg-mem cannot faithfully run the recursive CTE/function, do not
+ *    fake a green test … keep pg-mem for route/idempotency tests".
+ */
+
+const { newDb } = require('pg-mem');
+
+const { detectDependencyCycle } = require('../../kanban-dependencies');
+
+const DEVICE = 'test-dev';
+
+// Minimal schema covering only the dep-chain surface this PR introduces
+// plus the stub `kanban_cards` row table required for the FK constraint.
+const MINIMAL_SCHEMA = `
+    CREATE TABLE kanban_cards (
+        id VARCHAR(48) PRIMARY KEY,
+        device_id VARCHAR(64) NOT NULL,
+        title VARCHAR(255) NOT NULL,
+        has_dependencies BOOLEAN DEFAULT FALSE,
+        dependency_status VARCHAR(16) DEFAULT 'ready'
+    );
+
+    CREATE TABLE kanban_card_dependencies (
+        id BIGSERIAL PRIMARY KEY,
+        device_id VARCHAR(64) NOT NULL,
+        card_id VARCHAR(48) NOT NULL REFERENCES kanban_cards(id) ON DELETE CASCADE,
+        depends_on_card_id VARCHAR(48) NOT NULL REFERENCES kanban_cards(id) ON DELETE CASCADE,
+        dependency_type VARCHAR(16) DEFAULT 'blocks',
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        created_by INTEGER NOT NULL DEFAULT 0,
+        UNIQUE(device_id, card_id, depends_on_card_id)
+    );
+
+    CREATE INDEX idx_kanban_dependencies_card ON kanban_card_dependencies(device_id, card_id);
+    CREATE INDEX idx_kanban_dependencies_depends_on ON kanban_card_dependencies(device_id, depends_on_card_id);
+    CREATE INDEX idx_kanban_dependencies_type ON kanban_card_dependencies(device_id, dependency_type);
+`;
+
+async function bootstrap() {
+    const db = newDb({ autoCreateForeignKeyIndices: true });
+    const { Pool } = db.adapters.createPg();
+    const pool = new Pool();
+    await pool.query(MINIMAL_SCHEMA);
+    return { pool };
+}
+
+async function insertCard(pool, id) {
+    await pool.query(
+        `INSERT INTO kanban_cards (id, device_id, title) VALUES ($1, $2, $3)
+         ON CONFLICT (id) DO NOTHING`,
+        [id, DEVICE, `card ${id}`]
+    );
+}
+
+async function insertEdge(pool, from, to) {
+    await pool.query(
+        `INSERT INTO kanban_card_dependencies (device_id, card_id, depends_on_card_id)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (device_id, card_id, depends_on_card_id) DO NOTHING`,
+        [DEVICE, from, to]
+    );
+}
+
+describe('detectDependencyCycle (PR-DCA)', () => {
+    let pool;
+
+    beforeAll(async () => {
+        ({ pool } = await bootstrap());
+    });
+
+    beforeEach(async () => {
+        await pool.query('DELETE FROM kanban_card_dependencies');
+        await pool.query('DELETE FROM kanban_cards');
+        for (const id of ['A', 'B', 'C', 'D', 'E']) {
+            await insertCard(pool, id);
+        }
+    });
+
+    test('self-reference (A→A) is always a cycle', async () => {
+        await expect(detectDependencyCycle(pool, DEVICE, 'A', 'A')).resolves.toBe(true);
+    });
+
+    test('direct: A→B exists; adding B→A is rejected', async () => {
+        await insertEdge(pool, 'A', 'B');
+        await expect(detectDependencyCycle(pool, DEVICE, 'B', 'A')).resolves.toBe(true);
+    });
+
+    test('transitive: A→B and B→C exist; adding C→A is rejected', async () => {
+        await insertEdge(pool, 'A', 'B');
+        await insertEdge(pool, 'B', 'C');
+        await expect(detectDependencyCycle(pool, DEVICE, 'C', 'A')).resolves.toBe(true);
+    });
+
+    test('parallel chains (A→B, A→C, B→D, C→D): adding E→A is NOT a cycle', async () => {
+        await insertEdge(pool, 'A', 'B');
+        await insertEdge(pool, 'A', 'C');
+        await insertEdge(pool, 'B', 'D');
+        await insertEdge(pool, 'C', 'D');
+        await expect(detectDependencyCycle(pool, DEVICE, 'E', 'A')).resolves.toBe(false);
+    });
+
+    test('happy path: empty graph, adding A→B is NOT a cycle', async () => {
+        await expect(detectDependencyCycle(pool, DEVICE, 'A', 'B')).resolves.toBe(false);
+    });
+
+    test('cross-device isolation: edges in another device do not bleed across', async () => {
+        await insertEdge(pool, 'A', 'B');
+        await expect(detectDependencyCycle(pool, 'other-dev', 'B', 'A')).resolves.toBe(false);
+    });
+
+    test('rejects missing required args', async () => {
+        await expect(detectDependencyCycle(pool, DEVICE, 'A', null)).rejects.toThrow(/required/);
+        await expect(detectDependencyCycle(null, DEVICE, 'A', 'B')).rejects.toThrow(/required/);
+    });
+});


### PR DESCRIPTION
## Summary
- Restores card dependency-chain support (PR #2481 → cleaned in PR #2494) per Mac_F (#1) sign-off 2026-05-07 14:38 TPE.
- **Scope: schema + cycle detection only.** Router mount is PR-DCB.
- Card: `card_92363a55c53eef7b672024e9`

## Architecture decisions (Mac_F Option α)
1. **JS-side BFS instead of PL/pgSQL recursive CTE** — keeps the migration compatible with the `;`-splitter in `initKanbanDatabase()` (function bodies with internal `;` would break splitting). Also testable under pg-mem, which has spotty `WITH RECURSIVE` support.
2. **Plain ANSI DDL appended to `kanban_schema.sql`** — uses `IF NOT EXISTS` everywhere, idempotent on re-run, matches the splitter's "skip already-exists errors" model.
3. **Hand-rolled MINIMAL_SCHEMA in tests** — full `kanban_schema.sql` has computed defaults (`encode(gen_random_bytes(…))`), `ALTER COLUMN TYPE … USING`, and partial-index `WHERE` clauses pg-mem can't parse. Mac_F sign-off explicitly allowed this fallback shape ("if pg-mem cannot faithfully run … keep pg-mem for route/idempotency tests").

## Files
- `backend/kanban_schema.sql` (+25): `kanban_card_dependencies` table + 3 indexes + `kanban_cards.has_dependencies` + `kanban_cards.dependency_status`
- `backend/kanban-dependencies.js` (NEW): `detectDependencyCycle(pool, deviceId, cardId, dependsOnCardId)` — iterative BFS over `card_id → depends_on_card_id` edges, scoped per device
- `backend/tests/jest/kanban-dependencies-cycle.test.js` (NEW): 7 cases — self-ref, direct, transitive, parallel chains, happy path, cross-device isolation, arg validation
- `backend/package.json` + `package-lock.json`: pg-mem ^3.0.14 added to devDependencies

## Test plan
- [x] `npx jest tests/jest/kanban-dependencies-cycle.test.js` → 7/7 green locally
- [ ] CI jest run green
- [ ] On merge: prod startup auto-applies the dep-chain DDL via `initKanbanDatabase()` (idempotent — safe re-run on existing tables)

## Mac_F hard gates (this PR)
- ✅ No PL/pgSQL function registered (splitter-safe)
- ✅ Cycle detection covered by real SQL execution (pg-mem), not mocks
- ✅ Cross-device isolation tested (`device_id` scoping in WHERE)
- ✅ Self-reference rejected up front
- ✅ Arg validation throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)