### PR TITLE
feat(kanban): PR-DCB — dep-chain HTTP API + jest supertest

### DIFF
--- a/backend/api_kanban_dependencies.js
+++ b/backend/api_kanban_dependencies.js
@@ -1,318 +1,280 @@
+'use strict';
+
 /**
- * Kanban Card Dependencies API
- * Task #42: Bidirectional dependency chain system
+ * Kanban card dependency-chain HTTP API (PR-DCB).
+ *
+ * Mounted under /api/mission. Auth model matches kanban.js — botSecret OR
+ * deviceSecret per device. All routes are strictly device-scoped: cards in
+ * other devices behave as 404 (no leak), per Mac_F sign-off 2026-05-07.
+ *
+ * Uses the iterative-BFS detectDependencyCycle() helper from PR-DCA — no
+ * PL/pgSQL `detect_dependency_cycle()` function call (that path was dropped
+ * in PR-DCA because the schema-init `;`-splitter cannot host function bodies).
+ *
+ * Pool is injectable via options.pool so jest can drive it under pg-mem.
  */
 
 const express = require('express');
 const { Pool } = require('pg');
-const router = express.Router();
+const safeEqual = require('./safe-equal');
+const { detectDependencyCycle } = require('./kanban-dependencies');
 
-const pool = new Pool({
-    connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
-});
+const VALID_DEPENDENCY_TYPES = new Set(['blocks', 'requires', 'related']);
 
-/**
- * Add dependency relationship between cards
- * POST /api/mission/card/:cardId/dependency
- */
-router.post('/card/:cardId/dependency', async (req, res) => {
-    try {
-        const { cardId } = req.params;
-        const { deviceId, entityId, botSecret, dependsOnCardId, dependencyType = 'blocks' } = req.body;
+module.exports = function (devices, options = {}) {
+    const router = express.Router();
+    const pool = options.pool || new Pool({
+        connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
+    });
 
-        // Validate auth (simplified for prototype)
-        if (!deviceId || !entityId || !botSecret) {
-            return res.status(401).json({ success: false, error: 'Authentication required' });
-        }
-
-        // Validate cards exist
-        const cardsExist = await pool.query(`
-            SELECT id FROM kanban_cards
-            WHERE device_id = $1 AND id IN ($2, $3)
-        `, [deviceId, cardId, dependsOnCardId]);
-
-        if (cardsExist.rows.length !== 2) {
-            return res.status(404).json({ success: false, error: 'One or both cards not found' });
-        }
-
-        // Check for cycle before adding dependency
-        const cycleCheck = await pool.query(`
-            SELECT detect_dependency_cycle($1, $2, $3) as has_cycle
-        `, [deviceId, cardId, dependsOnCardId]);
-
-        if (cycleCheck.rows[0].has_cycle) {
-            return res.status(400).json({
-                success: false,
-                error: 'Adding this dependency would create a cycle',
-                cycleDetected: true
-            });
-        }
-
-        // Add dependency relationship
-        const result = await pool.query(`
-            INSERT INTO kanban_card_dependencies
-            (device_id, card_id, depends_on_card_id, dependency_type, created_by)
-            VALUES ($1, $2, $3, $4, $5)
-            ON CONFLICT (device_id, card_id, depends_on_card_id)
-            DO UPDATE SET dependency_type = EXCLUDED.dependency_type
-            RETURNING *
-        `, [deviceId, cardId, dependsOnCardId, dependencyType, entityId]);
-
-        res.json({
-            success: true,
-            dependency: result.rows[0],
-            message: `Dependency added: Card ${cardId} depends on Card ${dependsOnCardId}`
-        });
-
-    } catch (err) {
-        console.error('Add dependency error:', err);
-        res.status(500).json({ success: false, error: 'Internal server error' });
+    function findEntityByCredentials(deviceId, entityId, botSecret) {
+        const device = devices[deviceId];
+        if (!device) return null;
+        const entity = (device.entities || {})[entityId];
+        if (!entity || !safeEqual(entity.botSecret, botSecret)) return null;
+        return entity;
     }
-});
 
-/**
- * Remove dependency relationship
- * DELETE /api/mission/card/:cardId/dependency/:dependsOnCardId
- */
-router.delete('/card/:cardId/dependency/:dependsOnCardId', async (req, res) => {
-    try {
-        const { cardId, dependsOnCardId } = req.params;
-        const { deviceId, entityId, botSecret } = req.body;
-
-        // Validate auth
-        if (!deviceId || !entityId || !botSecret) {
-            return res.status(401).json({ success: false, error: 'Authentication required' });
-        }
-
-        // Remove dependency
-        const result = await pool.query(`
-            DELETE FROM kanban_card_dependencies
-            WHERE device_id = $1 AND card_id = $2 AND depends_on_card_id = $3
-            RETURNING *
-        `, [deviceId, cardId, dependsOnCardId]);
-
-        if (result.rows.length === 0) {
-            return res.status(404).json({ success: false, error: 'Dependency not found' });
-        }
-
-        res.json({
-            success: true,
-            removed: result.rows[0],
-            message: `Dependency removed: Card ${cardId} no longer depends on Card ${dependsOnCardId}`
-        });
-
-    } catch (err) {
-        console.error('Remove dependency error:', err);
-        res.status(500).json({ success: false, error: 'Internal server error' });
+    function findDeviceByCredentials(deviceId, deviceSecret) {
+        const device = devices[deviceId];
+        if (!device || !safeEqual(device.deviceSecret, deviceSecret)) return null;
+        return device;
     }
-});
 
-/**
- * Get all dependencies for a card
- * GET /api/mission/card/:cardId/dependencies
- */
-router.get('/card/:cardId/dependencies', async (req, res) => {
-    try {
-        const { cardId } = req.params;
-        const { deviceId, entityId, botSecret } = req.query;
+    function authenticate(req, res) {
+        const params = { ...req.query, ...req.body };
+        const { deviceId, deviceSecret, botSecret, entityId } = params;
 
-        // Validate auth
-        if (!deviceId || !entityId || !botSecret) {
-            return res.status(401).json({ success: false, error: 'Authentication required' });
+        if (!deviceId) {
+            res.status(400).json({ success: false, error: 'Missing deviceId' });
+            return null;
         }
 
-        // Get dependencies this card depends on
-        const dependsOn = await pool.query(`
-            SELECT d.*, c.title as depends_on_title, c.status as depends_on_status
-            FROM kanban_card_dependencies d
-            JOIN kanban_cards c ON d.depends_on_card_id = c.id
-            WHERE d.device_id = $1 AND d.card_id = $2
-            ORDER BY d.created_at
-        `, [deviceId, cardId]);
-
-        // Get dependencies that depend on this card
-        const dependents = await pool.query(`
-            SELECT d.*, c.title as dependent_title, c.status as dependent_status
-            FROM kanban_card_dependencies d
-            JOIN kanban_cards c ON d.card_id = c.id
-            WHERE d.device_id = $1 AND d.depends_on_card_id = $2
-            ORDER BY d.created_at
-        `, [deviceId, cardId]);
-
-        // Get dependency status summary
-        const statusSummary = await pool.query(`
-            SELECT dependency_status, has_dependencies
-            FROM kanban_cards
-            WHERE device_id = $1 AND id = $2
-        `, [deviceId, cardId]);
-
-        res.json({
-            success: true,
-            cardId,
-            dependsOn: dependsOn.rows,
-            dependents: dependents.rows,
-            status: statusSummary.rows[0] || { dependency_status: 'ready', has_dependencies: false },
-            summary: {
-                dependsOnCount: dependsOn.rows.length,
-                dependentsCount: dependents.rows.length,
-                blockedByCount: dependsOn.rows.filter(d => d.depends_on_status !== 'done').length
-            }
-        });
-
-    } catch (err) {
-        console.error('Get dependencies error:', err);
-        res.status(500).json({ success: false, error: 'Internal server error' });
-    }
-});
-
-/**
- * Get dependency chain visualization data
- * GET /api/mission/dependencies/graph
- */
-router.get('/dependencies/graph', async (req, res) => {
-    try {
-        const { deviceId, entityId, botSecret, rootCardId } = req.query;
-
-        // Validate auth
-        if (!deviceId || !entityId || !botSecret) {
-            return res.status(401).json({ success: false, error: 'Authentication required' });
+        if (deviceSecret) {
+            const device = findDeviceByCredentials(deviceId, deviceSecret);
+            if (device) return { deviceId, entityId: entityId ? parseInt(entityId, 10) : null };
         }
 
-        // Get all dependencies for the device or specific root card
-        let query, params;
-        if (rootCardId) {
-            // Get dependency subgraph starting from root card
-            query = `
-                WITH RECURSIVE dependency_tree AS (
-                    -- Start from root card
-                    SELECT
-                        id, title, status, dependency_status,
-                        ARRAY[id] as path,
-                        0 as depth
-                    FROM kanban_cards
-                    WHERE device_id = $1 AND id = $2
+        if (botSecret) {
+            const entity = findEntityByCredentials(deviceId, parseInt(entityId || 0, 10), botSecret);
+            if (entity) return { deviceId, entityId: parseInt(entityId, 10) };
+        }
 
-                    UNION
-
-                    -- Find all cards that depend on cards in current tree
-                    SELECT
-                        c.id, c.title, c.status, c.dependency_status,
-                        dt.path || c.id as path,
-                        dt.depth + 1 as depth
-                    FROM dependency_tree dt
-                    JOIN kanban_card_dependencies d ON dt.id = d.depends_on_card_id
-                    JOIN kanban_cards c ON d.card_id = c.id
-                    WHERE c.device_id = $1
-                    AND NOT c.id = ANY(dt.path) -- Prevent infinite recursion
-                    AND dt.depth < 10 -- Limit depth
-                )
-                SELECT DISTINCT * FROM dependency_tree ORDER BY depth, title
-            `;
-            params = [deviceId, rootCardId];
+        if (!deviceSecret && !botSecret) {
+            res.status(400).json({ success: false, error: 'Missing deviceSecret or botSecret' });
         } else {
-            // Get all cards with dependencies
-            query = `
-                SELECT DISTINCT
-                    c.id, c.title, c.status, c.dependency_status, c.has_dependencies
-                FROM kanban_cards c
-                LEFT JOIN kanban_card_dependencies d1 ON c.id = d1.card_id
-                LEFT JOIN kanban_card_dependencies d2 ON c.id = d2.depends_on_card_id
-                WHERE c.device_id = $1
-                AND (c.has_dependencies = TRUE OR d2.id IS NOT NULL)
-                AND c.archived = FALSE
-                ORDER BY c.title
-            `;
-            params = [deviceId];
+            res.status(401).json({ success: false, error: 'Invalid credentials' });
         }
-
-        const cards = await pool.query(query, params);
-
-        // Get all dependency relationships
-        const dependencies = await pool.query(`
-            SELECT
-                d.*,
-                c1.title as card_title,
-                c2.title as depends_on_title
-            FROM kanban_card_dependencies d
-            JOIN kanban_cards c1 ON d.card_id = c1.id
-            JOIN kanban_cards c2 ON d.depends_on_card_id = c2.id
-            WHERE d.device_id = $1
-            ORDER BY d.created_at
-        `, [deviceId]);
-
-        // Build graph structure
-        const nodes = cards.rows.map(card => ({
-            id: card.id,
-            title: card.title,
-            status: card.status,
-            dependencyStatus: card.dependency_status,
-            hasDependencies: card.has_dependencies,
-            depth: card.depth || 0
-        }));
-
-        const edges = dependencies.rows.map(dep => ({
-            from: dep.depends_on_card_id,
-            to: dep.card_id,
-            type: dep.dependency_type,
-            id: dep.id
-        }));
-
-        res.json({
-            success: true,
-            graph: {
-                nodes,
-                edges,
-                metadata: {
-                    totalCards: nodes.length,
-                    totalDependencies: edges.length,
-                    rootCardId: rootCardId || null
-                }
-            }
-        });
-
-    } catch (err) {
-        console.error('Get dependency graph error:', err);
-        res.status(500).json({ success: false, error: 'Internal server error' });
+        return null;
     }
-});
 
-/**
- * Validate dependency chain for cycles
- * POST /api/mission/dependencies/validate
- */
-router.post('/dependencies/validate', async (req, res) => {
-    try {
-        const { deviceId, entityId, botSecret, cardId, dependsOnCardId } = req.body;
+    async function cardExistsInDevice(cardId, deviceId) {
+        const { rows } = await pool.query(
+            'SELECT id FROM kanban_cards WHERE id = $1 AND device_id = $2 LIMIT 1',
+            [cardId, deviceId]
+        );
+        return rows.length > 0;
+    }
 
-        // Validate auth
-        if (!deviceId || !entityId || !botSecret) {
-            return res.status(401).json({ success: false, error: 'Authentication required' });
+    // POST /card/:cardId/dependency
+    router.post('/card/:cardId/dependency', async (req, res) => {
+        const auth = authenticate(req, res);
+        if (!auth) return;
+        const { deviceId, entityId } = auth;
+        const { cardId } = req.params;
+        const { dependsOnCardId, dependencyType = 'blocks' } = req.body || {};
+
+        if (!dependsOnCardId) {
+            return res.status(400).json({ success: false, error: 'Missing dependsOnCardId' });
+        }
+        if (!VALID_DEPENDENCY_TYPES.has(dependencyType)) {
+            return res.status(400).json({ success: false, error: `Invalid dependencyType (allowed: ${[...VALID_DEPENDENCY_TYPES].join(', ')})` });
+        }
+        if (cardId === dependsOnCardId) {
+            return res.status(400).json({ success: false, error: 'A card cannot depend on itself' });
         }
 
-        // Check for cycle
-        const cycleCheck = await pool.query(`
-            SELECT detect_dependency_cycle($1, $2, $3) as has_cycle
-        `, [deviceId, cardId, dependsOnCardId]);
+        try {
+            if (!(await cardExistsInDevice(cardId, deviceId))) {
+                return res.status(404).json({ success: false, error: 'Card not found' });
+            }
+            if (!(await cardExistsInDevice(dependsOnCardId, deviceId))) {
+                return res.status(404).json({ success: false, error: 'Dependency card not found' });
+            }
 
-        const hasCycle = cycleCheck.rows[0].has_cycle;
+            if (await detectDependencyCycle(pool, deviceId, cardId, dependsOnCardId)) {
+                return res.status(400).json({
+                    success: false,
+                    error: 'Adding this dependency would create a cycle',
+                    cycleDetected: true
+                });
+            }
 
-        res.json({
-            success: true,
-            validation: {
+            const existing = await pool.query(
+                `SELECT id FROM kanban_card_dependencies
+                 WHERE device_id = $1 AND card_id = $2 AND depends_on_card_id = $3
+                 LIMIT 1`,
+                [deviceId, cardId, dependsOnCardId]
+            );
+
+            if (existing.rows.length > 0) {
+                return res.json({ success: true, created: false, cardId, dependsOnCardId, dependencyType });
+            }
+
+            await pool.query(
+                `INSERT INTO kanban_card_dependencies
+                    (device_id, card_id, depends_on_card_id, dependency_type, created_by)
+                 VALUES ($1, $2, $3, $4, $5)
+                 ON CONFLICT (device_id, card_id, depends_on_card_id) DO NOTHING`,
+                [deviceId, cardId, dependsOnCardId, dependencyType, entityId || 0]
+            );
+
+            res.json({ success: true, created: true, cardId, dependsOnCardId, dependencyType });
+        } catch (err) {
+            console.error('[KanbanDeps] POST dependency error:', err);
+            res.status(500).json({ success: false, error: 'Internal server error' });
+        }
+    });
+
+    // DELETE /card/:cardId/dependency/:dependsOnCardId
+    router.delete('/card/:cardId/dependency/:dependsOnCardId', async (req, res) => {
+        const auth = authenticate(req, res);
+        if (!auth) return;
+        const { deviceId } = auth;
+        const { cardId, dependsOnCardId } = req.params;
+
+        try {
+            const result = await pool.query(
+                `DELETE FROM kanban_card_dependencies
+                 WHERE device_id = $1 AND card_id = $2 AND depends_on_card_id = $3`,
+                [deviceId, cardId, dependsOnCardId]
+            );
+            res.json({ success: true, deleted: result.rowCount, cardId, dependsOnCardId });
+        } catch (err) {
+            console.error('[KanbanDeps] DELETE dependency error:', err);
+            res.status(500).json({ success: false, error: 'Internal server error' });
+        }
+    });
+
+    // GET /card/:cardId/dependencies — what this card depends on
+    router.get('/card/:cardId/dependencies', async (req, res) => {
+        const auth = authenticate(req, res);
+        if (!auth) return;
+        const { deviceId } = auth;
+        const { cardId } = req.params;
+
+        try {
+            if (!(await cardExistsInDevice(cardId, deviceId))) {
+                return res.status(404).json({ success: false, error: 'Card not found' });
+            }
+            const { rows } = await pool.query(
+                `SELECT d.depends_on_card_id, d.dependency_type, d.created_at,
+                        c.title, c.status
+                 FROM kanban_card_dependencies d
+                 JOIN kanban_cards c
+                     ON c.id = d.depends_on_card_id AND c.device_id = d.device_id
+                 WHERE d.device_id = $1 AND d.card_id = $2
+                 ORDER BY d.created_at`,
+                [deviceId, cardId]
+            );
+            res.json({
+                success: true,
                 cardId,
-                dependsOnCardId,
-                hasCycle,
-                isValid: !hasCycle,
-                message: hasCycle
-                    ? 'This dependency would create a cycle and is not allowed'
-                    : 'This dependency is valid and can be added'
+                dependencies: rows.map(r => ({
+                    cardId: r.depends_on_card_id,
+                    title: r.title,
+                    status: r.status,
+                    type: r.dependency_type,
+                    createdAt: r.created_at
+                }))
+            });
+        } catch (err) {
+            console.error('[KanbanDeps] GET dependencies error:', err);
+            res.status(500).json({ success: false, error: 'Internal server error' });
+        }
+    });
+
+    // GET /card/:cardId/dependents — what depends on this card
+    router.get('/card/:cardId/dependents', async (req, res) => {
+        const auth = authenticate(req, res);
+        if (!auth) return;
+        const { deviceId } = auth;
+        const { cardId } = req.params;
+
+        try {
+            if (!(await cardExistsInDevice(cardId, deviceId))) {
+                return res.status(404).json({ success: false, error: 'Card not found' });
             }
-        });
+            const { rows } = await pool.query(
+                `SELECT d.card_id, d.dependency_type, d.created_at,
+                        c.title, c.status
+                 FROM kanban_card_dependencies d
+                 JOIN kanban_cards c
+                     ON c.id = d.card_id AND c.device_id = d.device_id
+                 WHERE d.device_id = $1 AND d.depends_on_card_id = $2
+                 ORDER BY d.created_at`,
+                [deviceId, cardId]
+            );
+            res.json({
+                success: true,
+                cardId,
+                dependents: rows.map(r => ({
+                    cardId: r.card_id,
+                    title: r.title,
+                    status: r.status,
+                    type: r.dependency_type,
+                    createdAt: r.created_at
+                }))
+            });
+        } catch (err) {
+            console.error('[KanbanDeps] GET dependents error:', err);
+            res.status(500).json({ success: false, error: 'Internal server error' });
+        }
+    });
 
-    } catch (err) {
-        console.error('Validate dependency error:', err);
-        res.status(500).json({ success: false, error: 'Internal server error' });
-    }
-});
+    // GET /dependencies/graph — device-scoped node+edge dump
+    router.get('/dependencies/graph', async (req, res) => {
+        const auth = authenticate(req, res);
+        if (!auth) return;
+        const { deviceId } = auth;
 
-module.exports = router;
+        try {
+            const nodesQ = await pool.query(
+                `SELECT DISTINCT c.id, c.title, c.status
+                 FROM kanban_cards c
+                 WHERE c.device_id = $1
+                   AND c.id IN (
+                     SELECT card_id FROM kanban_card_dependencies WHERE device_id = $1
+                     UNION
+                     SELECT depends_on_card_id FROM kanban_card_dependencies WHERE device_id = $1
+                   )
+                 ORDER BY c.id`,
+                [deviceId]
+            );
+            const edgesQ = await pool.query(
+                `SELECT card_id, depends_on_card_id, dependency_type, created_at
+                 FROM kanban_card_dependencies
+                 WHERE device_id = $1
+                 ORDER BY created_at`,
+                [deviceId]
+            );
+            res.json({
+                success: true,
+                graph: {
+                    nodes: nodesQ.rows.map(n => ({ id: n.id, title: n.title, status: n.status })),
+                    edges: edgesQ.rows.map(e => ({
+                        from: e.card_id,
+                        to: e.depends_on_card_id,
+                        type: e.dependency_type,
+                        createdAt: e.created_at
+                    }))
+                }
+            });
+        } catch (err) {
+            console.error('[KanbanDeps] GET graph error:', err);
+            res.status(500).json({ success: false, error: 'Internal server error' });
+        }
+    });
+
+    return { router };
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -1632,6 +1632,15 @@ try {
     kanbanModule = { initKanbanDatabase: () => {}, startBackgroundTimers: () => {} };
 }
 
+// Kanban dep-chain HTTP API (PR-DCB) — mounted on same /api/mission path
+try {
+    const kanbanDepsModule = require('./api_kanban_dependencies')(devices);
+    app.use('/api/mission', kanbanDepsModule.router);
+    console.log('[KanbanDeps] Module loaded successfully');
+} catch (err) {
+    console.error('[KanbanDeps] Failed to load module:', err.message);
+}
+
 // Idle Dispatch System — smart bot availability-based card dispatch
 try {
     const idleDispatchRouter = require('./api_idle_dispatch');

--- a/backend/tests/jest/__fixtures__/kanban-dep-schema.js
+++ b/backend/tests/jest/__fixtures__/kanban-dep-schema.js
@@ -1,0 +1,73 @@
+'use strict';
+
+/**
+ * Shared pg-mem fixture for kanban dep-chain tests (PR-DCA + PR-DCB).
+ *
+ * Mac_F sign-off 2026-05-07: extract MINIMAL_SCHEMA so DCA and DCB don't drift.
+ * Narrow scope — schema setup only, no broader test framework abstraction.
+ *
+ * The full backend/kanban_schema.sql cannot be loaded under pg-mem (computed
+ * `DEFAULT (encode(gen_random_bytes…))`, `ALTER COLUMN TYPE … USING`,
+ * partial-index `WHERE`); this fixture mirrors only the table shapes the
+ * dep-chain code actually exercises.
+ */
+
+const { newDb } = require('pg-mem');
+
+const MINIMAL_SCHEMA = `
+    CREATE TABLE kanban_cards (
+        id VARCHAR(48) PRIMARY KEY,
+        device_id VARCHAR(64) NOT NULL,
+        title VARCHAR(255) NOT NULL,
+        has_dependencies BOOLEAN DEFAULT FALSE,
+        dependency_status VARCHAR(16) DEFAULT 'ready',
+        status VARCHAR(16) DEFAULT 'todo'
+    );
+
+    CREATE TABLE kanban_card_dependencies (
+        id BIGSERIAL PRIMARY KEY,
+        device_id VARCHAR(64) NOT NULL,
+        card_id VARCHAR(48) NOT NULL REFERENCES kanban_cards(id) ON DELETE CASCADE,
+        depends_on_card_id VARCHAR(48) NOT NULL REFERENCES kanban_cards(id) ON DELETE CASCADE,
+        dependency_type VARCHAR(16) DEFAULT 'blocks',
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        created_by INTEGER NOT NULL DEFAULT 0,
+        UNIQUE(device_id, card_id, depends_on_card_id)
+    );
+
+    CREATE INDEX idx_kanban_dependencies_card ON kanban_card_dependencies(device_id, card_id);
+    CREATE INDEX idx_kanban_dependencies_depends_on ON kanban_card_dependencies(device_id, depends_on_card_id);
+    CREATE INDEX idx_kanban_dependencies_type ON kanban_card_dependencies(device_id, dependency_type);
+`;
+
+async function bootstrap() {
+    const db = newDb({ autoCreateForeignKeyIndices: true });
+    const { Pool } = db.adapters.createPg();
+    const pool = new Pool();
+    await pool.query(MINIMAL_SCHEMA);
+    return { pool, db };
+}
+
+async function insertCard(pool, id, deviceId, title) {
+    await pool.query(
+        `INSERT INTO kanban_cards (id, device_id, title) VALUES ($1, $2, $3)
+         ON CONFLICT (id) DO NOTHING`,
+        [id, deviceId, title || `card ${id}`]
+    );
+}
+
+async function insertEdge(pool, deviceId, from, to) {
+    await pool.query(
+        `INSERT INTO kanban_card_dependencies (device_id, card_id, depends_on_card_id)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (device_id, card_id, depends_on_card_id) DO NOTHING`,
+        [deviceId, from, to]
+    );
+}
+
+async function reset(pool) {
+    await pool.query('DELETE FROM kanban_card_dependencies');
+    await pool.query('DELETE FROM kanban_cards');
+}
+
+module.exports = { MINIMAL_SCHEMA, bootstrap, insertCard, insertEdge, reset };

--- a/backend/tests/jest/api-kanban-dependencies.test.js
+++ b/backend/tests/jest/api-kanban-dependencies.test.js
@@ -1,0 +1,242 @@
+'use strict';
+
+/**
+ * api_kanban_dependencies router tests (PR-DCB).
+ *
+ * Mounts the real router against a pg-mem-backed pool (shared MINIMAL_SCHEMA
+ * fixture from kanban-dep-schema.js) and a stub `devices` map. No HTTP-level
+ * mocks of pg — the SQL is executed.
+ *
+ * Mac_F sign-off 2026-05-07 hard gates:
+ *   1. auth gate: missing creds → 400/401, never 200
+ *   2. cross-device: cards in another device behave as 404 (no leak)
+ *   3. self-edge → 400, never reaches INSERT
+ *   4. cycle rejection: returns 400 + cycleDetected:true (PR-DCA helper)
+ *   5. happy POST + idempotent re-POST: created:true → created:false
+ *   6. DELETE returns {deleted:rowCount}
+ *   7. graph endpoint device-scoped (cross-device returns empty)
+ */
+
+const express = require('express');
+const request = require('supertest');
+const { bootstrap, insertCard, insertEdge, reset } = require('./__fixtures__/kanban-dep-schema');
+
+const DEVICE_A = 'dev-a';
+const DEVICE_B = 'dev-b';
+const ENTITY_ID = 7;
+const BOT_SECRET = 'test-bot-secret';
+const DEVICE_SECRET = 'test-device-secret';
+
+function buildApp(pool) {
+    const devices = {
+        [DEVICE_A]: {
+            deviceSecret: DEVICE_SECRET,
+            entities: { [ENTITY_ID]: { botSecret: BOT_SECRET } },
+        },
+        [DEVICE_B]: {
+            deviceSecret: 'other-device-secret',
+            entities: { [ENTITY_ID]: { botSecret: 'other-bot-secret' } },
+        },
+    };
+    const factory = require('../../api_kanban_dependencies');
+    const { router } = factory(devices, { pool });
+    const app = express();
+    app.use(express.json());
+    app.use('/api/mission', router);
+    return app;
+}
+
+const auth = { deviceId: DEVICE_A, entityId: ENTITY_ID, botSecret: BOT_SECRET };
+const authQS = `deviceId=${DEVICE_A}&entityId=${ENTITY_ID}&botSecret=${BOT_SECRET}`;
+
+describe('api_kanban_dependencies router (PR-DCB)', () => {
+    let pool;
+    let app;
+
+    beforeAll(async () => {
+        ({ pool } = await bootstrap());
+        app = buildApp(pool);
+    });
+
+    beforeEach(async () => {
+        await reset(pool);
+        for (const id of ['A', 'B', 'C', 'D']) {
+            await insertCard(pool, id, DEVICE_A);
+        }
+        // device B has its own card 'A' to verify isolation
+        await insertCard(pool, 'A', DEVICE_B, 'B-side card A');
+        await insertCard(pool, 'X', DEVICE_B, 'B-side card X');
+    });
+
+    describe('auth gate', () => {
+        test('POST without creds → 400 missing deviceId', async () => {
+            const res = await request(app).post('/api/mission/card/A/dependency').send({});
+            expect(res.status).toBe(400);
+            expect(res.body.error).toMatch(/deviceId/i);
+        });
+
+        test('POST with deviceId only → 400 missing secrets', async () => {
+            const res = await request(app)
+                .post('/api/mission/card/A/dependency')
+                .send({ deviceId: DEVICE_A });
+            expect(res.status).toBe(400);
+            expect(res.body.error).toMatch(/Secret/i);
+        });
+
+        test('POST with wrong botSecret → 401', async () => {
+            const res = await request(app)
+                .post('/api/mission/card/A/dependency')
+                .send({ ...auth, botSecret: 'wrong', dependsOnCardId: 'B' });
+            expect(res.status).toBe(401);
+        });
+
+        test('GET without creds → 400', async () => {
+            const res = await request(app).get('/api/mission/card/A/dependencies');
+            expect(res.status).toBe(400);
+        });
+    });
+
+    describe('POST /card/:cardId/dependency', () => {
+        test('happy path → success:true, created:true', async () => {
+            const res = await request(app)
+                .post('/api/mission/card/A/dependency')
+                .send({ ...auth, dependsOnCardId: 'B' });
+            expect(res.status).toBe(200);
+            expect(res.body).toMatchObject({ success: true, created: true, cardId: 'A', dependsOnCardId: 'B', dependencyType: 'blocks' });
+        });
+
+        test('idempotent re-POST → created:false (no double-insert)', async () => {
+            await request(app)
+                .post('/api/mission/card/A/dependency')
+                .send({ ...auth, dependsOnCardId: 'B' });
+            const res = await request(app)
+                .post('/api/mission/card/A/dependency')
+                .send({ ...auth, dependsOnCardId: 'B' });
+            expect(res.status).toBe(200);
+            expect(res.body).toMatchObject({ success: true, created: false });
+        });
+
+        test('self-edge (A→A) → 400, never reaches INSERT', async () => {
+            const res = await request(app)
+                .post('/api/mission/card/A/dependency')
+                .send({ ...auth, dependsOnCardId: 'A' });
+            expect(res.status).toBe(400);
+            expect(res.body.error).toMatch(/itself/i);
+        });
+
+        test('missing source card → 404', async () => {
+            const res = await request(app)
+                .post('/api/mission/card/NOPE/dependency')
+                .send({ ...auth, dependsOnCardId: 'B' });
+            expect(res.status).toBe(404);
+            expect(res.body.error).toMatch(/Card not found/i);
+        });
+
+        test('missing dependency card → 404', async () => {
+            const res = await request(app)
+                .post('/api/mission/card/A/dependency')
+                .send({ ...auth, dependsOnCardId: 'NOPE' });
+            expect(res.status).toBe(404);
+            expect(res.body.error).toMatch(/Dependency card not found/i);
+        });
+
+        test('cross-device: card in DEVICE_B is invisible to DEVICE_A → 404', async () => {
+            const res = await request(app)
+                .post('/api/mission/card/A/dependency')
+                .send({ ...auth, dependsOnCardId: 'X' });
+            expect(res.status).toBe(404);
+        });
+
+        test('cycle rejection (A→B exists; adding B→A) → 400 cycleDetected', async () => {
+            await insertEdge(pool, DEVICE_A, 'A', 'B');
+            const res = await request(app)
+                .post('/api/mission/card/B/dependency')
+                .send({ ...auth, dependsOnCardId: 'A' });
+            expect(res.status).toBe(400);
+            expect(res.body).toMatchObject({ success: false, cycleDetected: true });
+        });
+
+        test('invalid dependencyType → 400', async () => {
+            const res = await request(app)
+                .post('/api/mission/card/A/dependency')
+                .send({ ...auth, dependsOnCardId: 'B', dependencyType: 'pwns' });
+            expect(res.status).toBe(400);
+            expect(res.body.error).toMatch(/Invalid dependencyType/i);
+        });
+    });
+
+    describe('DELETE /card/:cardId/dependency/:dependsOnCardId', () => {
+        test('removes existing edge → success, deleted:1', async () => {
+            await insertEdge(pool, DEVICE_A, 'A', 'B');
+            const res = await request(app)
+                .delete('/api/mission/card/A/dependency/B')
+                .send(auth);
+            expect(res.status).toBe(200);
+            expect(res.body).toMatchObject({ success: true, deleted: 1 });
+        });
+
+        test('non-existent edge → success, deleted:0', async () => {
+            const res = await request(app)
+                .delete('/api/mission/card/A/dependency/B')
+                .send(auth);
+            expect(res.status).toBe(200);
+            expect(res.body).toMatchObject({ success: true, deleted: 0 });
+        });
+    });
+
+    describe('GET /card/:cardId/dependencies', () => {
+        test('returns dependsOn list with title + status JOINs', async () => {
+            await insertEdge(pool, DEVICE_A, 'A', 'B');
+            await insertEdge(pool, DEVICE_A, 'A', 'C');
+            const res = await request(app).get(`/api/mission/card/A/dependencies?${authQS}`);
+            expect(res.status).toBe(200);
+            expect(res.body.success).toBe(true);
+            expect(res.body.cardId).toBe('A');
+            const ids = res.body.dependencies.map(d => d.cardId).sort();
+            expect(ids).toEqual(['B', 'C']);
+            expect(res.body.dependencies[0]).toHaveProperty('title');
+            expect(res.body.dependencies[0]).toHaveProperty('status');
+            expect(res.body.dependencies[0]).toHaveProperty('type', 'blocks');
+        });
+
+        test('cross-device card → 404 (no leak)', async () => {
+            const res = await request(app).get(`/api/mission/card/X/dependencies?${authQS}`);
+            expect(res.status).toBe(404);
+        });
+    });
+
+    describe('GET /card/:cardId/dependents', () => {
+        test('returns reverse-direction list', async () => {
+            await insertEdge(pool, DEVICE_A, 'B', 'A');
+            await insertEdge(pool, DEVICE_A, 'C', 'A');
+            const res = await request(app).get(`/api/mission/card/A/dependents?${authQS}`);
+            expect(res.status).toBe(200);
+            const ids = res.body.dependents.map(d => d.cardId).sort();
+            expect(ids).toEqual(['B', 'C']);
+        });
+    });
+
+    describe('GET /dependencies/graph', () => {
+        test('device-scoped nodes + edges', async () => {
+            await insertEdge(pool, DEVICE_A, 'A', 'B');
+            await insertEdge(pool, DEVICE_A, 'B', 'C');
+            const res = await request(app).get(`/api/mission/dependencies/graph?${authQS}`);
+            expect(res.status).toBe(200);
+            expect(res.body.success).toBe(true);
+            const nodeIds = res.body.graph.nodes.map(n => n.id).sort();
+            expect(nodeIds).toEqual(['A', 'B', 'C']);
+            expect(res.body.graph.edges).toHaveLength(2);
+            expect(res.body.graph.edges[0]).toHaveProperty('from');
+            expect(res.body.graph.edges[0]).toHaveProperty('to');
+            expect(res.body.graph.edges[0]).toHaveProperty('type');
+        });
+
+        test('cross-device isolation: edges in DEVICE_B do not leak into DEVICE_A graph', async () => {
+            await insertEdge(pool, DEVICE_B, 'A', 'X');
+            const res = await request(app).get(`/api/mission/dependencies/graph?${authQS}`);
+            expect(res.status).toBe(200);
+            expect(res.body.graph.nodes).toEqual([]);
+            expect(res.body.graph.edges).toEqual([]);
+        });
+    });
+});

--- a/backend/tests/jest/kanban-dependencies-cycle.test.js
+++ b/backend/tests/jest/kanban-dependencies-cycle.test.js
@@ -1,79 +1,20 @@
 'use strict';
 
 /**
- * kanban-dependencies-cycle.test.js (PR-DCA)
+ * kanban-dependencies-cycle.test.js (PR-DCA — refactored in PR-DCB to use shared fixture)
  *
- * Real SQL execution via pg-mem against a hand-rolled minimal schema
- * mirroring the dep-chain DDL added to backend/kanban_schema.sql in this
- * PR. We do NOT load the full kanban_schema.sql here because pg-mem cannot
- * parse a few statements the live schema relies on (computed `DEFAULT
- * (encode(gen_random_bytes…))`, `ALTER COLUMN TYPE … USING`, partial-index
- * `WHERE`); those are tested elsewhere in CI. The dep-chain DDL itself is
- * plain ANSI-shape syntax and pg-mem runs it faithfully — sufficient for
- * Mac_F's hard-gate cycle-detection coverage.
+ * Real SQL execution via pg-mem against the shared MINIMAL_SCHEMA fixture
+ * in backend/tests/jest/__fixtures__/kanban-dep-schema.js.
  *
  * Mac_F sign-off 2026-05-07 explicitly allowed this fallback shape:
  *   "if pg-mem cannot faithfully run the recursive CTE/function, do not
  *    fake a green test … keep pg-mem for route/idempotency tests".
  */
 
-const { newDb } = require('pg-mem');
-
 const { detectDependencyCycle } = require('../../kanban-dependencies');
+const { bootstrap, insertCard, insertEdge, reset } = require('./__fixtures__/kanban-dep-schema');
 
 const DEVICE = 'test-dev';
-
-// Minimal schema covering only the dep-chain surface this PR introduces
-// plus the stub `kanban_cards` row table required for the FK constraint.
-const MINIMAL_SCHEMA = `
-    CREATE TABLE kanban_cards (
-        id VARCHAR(48) PRIMARY KEY,
-        device_id VARCHAR(64) NOT NULL,
-        title VARCHAR(255) NOT NULL,
-        has_dependencies BOOLEAN DEFAULT FALSE,
-        dependency_status VARCHAR(16) DEFAULT 'ready'
-    );
-
-    CREATE TABLE kanban_card_dependencies (
-        id BIGSERIAL PRIMARY KEY,
-        device_id VARCHAR(64) NOT NULL,
-        card_id VARCHAR(48) NOT NULL REFERENCES kanban_cards(id) ON DELETE CASCADE,
-        depends_on_card_id VARCHAR(48) NOT NULL REFERENCES kanban_cards(id) ON DELETE CASCADE,
-        dependency_type VARCHAR(16) DEFAULT 'blocks',
-        created_at TIMESTAMPTZ DEFAULT NOW(),
-        created_by INTEGER NOT NULL DEFAULT 0,
-        UNIQUE(device_id, card_id, depends_on_card_id)
-    );
-
-    CREATE INDEX idx_kanban_dependencies_card ON kanban_card_dependencies(device_id, card_id);
-    CREATE INDEX idx_kanban_dependencies_depends_on ON kanban_card_dependencies(device_id, depends_on_card_id);
-    CREATE INDEX idx_kanban_dependencies_type ON kanban_card_dependencies(device_id, dependency_type);
-`;
-
-async function bootstrap() {
-    const db = newDb({ autoCreateForeignKeyIndices: true });
-    const { Pool } = db.adapters.createPg();
-    const pool = new Pool();
-    await pool.query(MINIMAL_SCHEMA);
-    return { pool };
-}
-
-async function insertCard(pool, id) {
-    await pool.query(
-        `INSERT INTO kanban_cards (id, device_id, title) VALUES ($1, $2, $3)
-         ON CONFLICT (id) DO NOTHING`,
-        [id, DEVICE, `card ${id}`]
-    );
-}
-
-async function insertEdge(pool, from, to) {
-    await pool.query(
-        `INSERT INTO kanban_card_dependencies (device_id, card_id, depends_on_card_id)
-         VALUES ($1, $2, $3)
-         ON CONFLICT (device_id, card_id, depends_on_card_id) DO NOTHING`,
-        [DEVICE, from, to]
-    );
-}
 
 describe('detectDependencyCycle (PR-DCA)', () => {
     let pool;
@@ -83,10 +24,9 @@ describe('detectDependencyCycle (PR-DCA)', () => {
     });
 
     beforeEach(async () => {
-        await pool.query('DELETE FROM kanban_card_dependencies');
-        await pool.query('DELETE FROM kanban_cards');
+        await reset(pool);
         for (const id of ['A', 'B', 'C', 'D', 'E']) {
-            await insertCard(pool, id);
+            await insertCard(pool, id, DEVICE);
         }
     });
 
@@ -95,21 +35,21 @@ describe('detectDependencyCycle (PR-DCA)', () => {
     });
 
     test('direct: A→B exists; adding B→A is rejected', async () => {
-        await insertEdge(pool, 'A', 'B');
+        await insertEdge(pool, DEVICE, 'A', 'B');
         await expect(detectDependencyCycle(pool, DEVICE, 'B', 'A')).resolves.toBe(true);
     });
 
     test('transitive: A→B and B→C exist; adding C→A is rejected', async () => {
-        await insertEdge(pool, 'A', 'B');
-        await insertEdge(pool, 'B', 'C');
+        await insertEdge(pool, DEVICE, 'A', 'B');
+        await insertEdge(pool, DEVICE, 'B', 'C');
         await expect(detectDependencyCycle(pool, DEVICE, 'C', 'A')).resolves.toBe(true);
     });
 
     test('parallel chains (A→B, A→C, B→D, C→D): adding E→A is NOT a cycle', async () => {
-        await insertEdge(pool, 'A', 'B');
-        await insertEdge(pool, 'A', 'C');
-        await insertEdge(pool, 'B', 'D');
-        await insertEdge(pool, 'C', 'D');
+        await insertEdge(pool, DEVICE, 'A', 'B');
+        await insertEdge(pool, DEVICE, 'A', 'C');
+        await insertEdge(pool, DEVICE, 'B', 'D');
+        await insertEdge(pool, DEVICE, 'C', 'D');
         await expect(detectDependencyCycle(pool, DEVICE, 'E', 'A')).resolves.toBe(false);
     });
 
@@ -118,7 +58,7 @@ describe('detectDependencyCycle (PR-DCA)', () => {
     });
 
     test('cross-device isolation: edges in another device do not bleed across', async () => {
-        await insertEdge(pool, 'A', 'B');
+        await insertEdge(pool, DEVICE, 'A', 'B');
         await expect(detectDependencyCycle(pool, 'other-dev', 'B', 'A')).resolves.toBe(false);
     });
 


### PR DESCRIPTION
## Summary
- Mounts the kanban dep-chain HTTP API under `/api/mission` (POST/DELETE/GET endpoints + `/dependencies/graph`).
- Factory pattern matching `kanban.js`: shared auth helpers, injectable pool for tests.
- Strict device-scoping — cards in another device behave as 404 (no leak), per Mac_F sign-off 2026-05-07.
- Replaces the unmounted PR #2481 scaffold (own Pool, fake auth) wholesale.
- Extracts `MINIMAL_SCHEMA` to `tests/jest/__fixtures__/kanban-dep-schema.js` so PR-DCA + PR-DCB share one fixture (Mac_F Q3).

## Card / Sign-off
- Card: `card_92363a55c53eef7b672024e9`
- Mac_F (#1) sign-off 2026-05-07: 4 questions answered, 7 hard gates explicit.
- Builds on PR-DCA (#2506, mergeCommit `5c86b19c`).

## Mac_F hard gates → tests
| Gate | Test |
|------|------|
| Auth: 400/401 never 200 | `auth gate` (4 cases) |
| Self-edge → 400 | `self-edge (A→A) → 400, never reaches INSERT` |
| Cycle → 400 + cycleDetected | `cycle rejection (A→B exists; adding B→A) → 400 cycleDetected` |
| Idempotent POST | `created:true → created:false` |
| DELETE returns rowCount | `removes existing edge → success, deleted:1` + `deleted:0` |
| Cross-device → 404 | `cross-device: card in DEVICE_B is invisible to DEVICE_A → 404` |
| Graph device-scoped | `cross-device isolation: edges in DEVICE_B do not leak into DEVICE_A graph` |

## Test plan
- [x] `npx jest --testPathPattern="api-kanban-dependencies|kanban-dependencies-cycle" -i` → 26/26 passing locally
- [x] Existing PR-DCA cycle test refactored to shared fixture; still 7/7 green
- [x] `node -c backend/index.js` and module-load check → router mounts cleanly
- [ ] CI green
- [ ] Post-merge prod smoke: authenticated curl `/api/mission/dependencies/graph` returns JSON

## Out of scope (deferred to PR-DCC)
- Cycle-check + INSERT race window hardening (transaction + advisory lock or SERIALIZABLE retry) — explicitly carved out per Mac_F sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)