### PR TITLE
feat(kanban-deps): PR-DCC — race-window hardening (device-scoped advisory lock)

### DIFF
--- a/backend/api_kanban_dependencies.js
+++ b/backend/api_kanban_dependencies.js
@@ -21,6 +21,11 @@ const { detectDependencyCycle } = require('./kanban-dependencies');
 
 const VALID_DEPENDENCY_TYPES = new Set(['blocks', 'requires', 'related']);
 
+// PR-DCC: device-scoped advisory lock namespace. Mac_F sign-off 2026-05-07 β′
+// — namespace + hashtext(deviceId) serializes dep-edge writes per device so
+// the cycle-check ↔ INSERT window is closed (transitive cycles included).
+const DEP_LOCK_NAMESPACE = 0x44434843; // 'DCHC' — Dep-Chain Cycle
+
 module.exports = function (devices, options = {}) {
     const router = express.Router();
     const pool = options.pool || new Pool({
@@ -68,8 +73,9 @@ module.exports = function (devices, options = {}) {
         return null;
     }
 
-    async function cardExistsInDevice(cardId, deviceId) {
-        const { rows } = await pool.query(
+    async function cardExistsInDevice(cardId, deviceId, queryable) {
+        const q = queryable || pool;
+        const { rows } = await q.query(
             'SELECT id FROM kanban_cards WHERE id = $1 AND device_id = $2 LIMIT 1',
             [cardId, deviceId]
         );
@@ -94,15 +100,26 @@ module.exports = function (devices, options = {}) {
             return res.status(400).json({ success: false, error: 'A card cannot depend on itself' });
         }
 
+        const client = await pool.connect();
         try {
-            if (!(await cardExistsInDevice(cardId, deviceId))) {
+            await client.query('BEGIN');
+            // Acquire device-scoped lock first; releases automatically on COMMIT/ROLLBACK.
+            await client.query(
+                'SELECT pg_advisory_xact_lock($1::int, hashtext($2)::int)',
+                [DEP_LOCK_NAMESPACE, deviceId]
+            );
+
+            if (!(await cardExistsInDevice(cardId, deviceId, client))) {
+                await client.query('ROLLBACK');
                 return res.status(404).json({ success: false, error: 'Card not found' });
             }
-            if (!(await cardExistsInDevice(dependsOnCardId, deviceId))) {
+            if (!(await cardExistsInDevice(dependsOnCardId, deviceId, client))) {
+                await client.query('ROLLBACK');
                 return res.status(404).json({ success: false, error: 'Dependency card not found' });
             }
 
-            if (await detectDependencyCycle(pool, deviceId, cardId, dependsOnCardId)) {
+            if (await detectDependencyCycle(client, deviceId, cardId, dependsOnCardId)) {
+                await client.query('ROLLBACK');
                 return res.status(400).json({
                     success: false,
                     error: 'Adding this dependency would create a cycle',
@@ -110,7 +127,7 @@ module.exports = function (devices, options = {}) {
                 });
             }
 
-            const existing = await pool.query(
+            const existing = await client.query(
                 `SELECT id FROM kanban_card_dependencies
                  WHERE device_id = $1 AND card_id = $2 AND depends_on_card_id = $3
                  LIMIT 1`,
@@ -118,10 +135,11 @@ module.exports = function (devices, options = {}) {
             );
 
             if (existing.rows.length > 0) {
+                await client.query('COMMIT');
                 return res.json({ success: true, created: false, cardId, dependsOnCardId, dependencyType });
             }
 
-            await pool.query(
+            await client.query(
                 `INSERT INTO kanban_card_dependencies
                     (device_id, card_id, depends_on_card_id, dependency_type, created_by)
                  VALUES ($1, $2, $3, $4, $5)
@@ -129,10 +147,14 @@ module.exports = function (devices, options = {}) {
                 [deviceId, cardId, dependsOnCardId, dependencyType, entityId || 0]
             );
 
+            await client.query('COMMIT');
             res.json({ success: true, created: true, cardId, dependsOnCardId, dependencyType });
         } catch (err) {
+            try { await client.query('ROLLBACK'); } catch (_) { /* best-effort */ }
             console.error('[KanbanDeps] POST dependency error:', err);
             res.status(500).json({ success: false, error: 'Internal server error' });
+        } finally {
+            client.release();
         }
     });
 

--- a/backend/tests/jest/__fixtures__/kanban-dep-schema.js
+++ b/backend/tests/jest/__fixtures__/kanban-dep-schema.js
@@ -12,7 +12,7 @@
  * dep-chain code actually exercises.
  */
 
-const { newDb } = require('pg-mem');
+const { newDb, DataType } = require('pg-mem');
 
 const MINIMAL_SCHEMA = `
     CREATE TABLE kanban_cards (
@@ -42,6 +42,30 @@ const MINIMAL_SCHEMA = `
 
 async function bootstrap() {
     const db = newDb({ autoCreateForeignKeyIndices: true });
+    // PR-DCC: pg-mem does not ship `pg_advisory_xact_lock`. Register as a no-op
+    // so the locked POST path executes; real mutual-exclusion proof lives in
+    // tests gated behind RUN_PG_INTEGRATION=1 (real PG only).
+    db.public.registerFunction({
+        name: 'pg_advisory_xact_lock',
+        args: [DataType.integer, DataType.integer],
+        returns: DataType.text,
+        implementation: () => null,
+    });
+    // hashtext(text)::int — pg-mem lacks it; deterministic 32-bit FNV-1a is
+    // close enough for tests that only need stable per-deviceId integers.
+    db.public.registerFunction({
+        name: 'hashtext',
+        args: [DataType.text],
+        returns: DataType.integer,
+        implementation: (s) => {
+            let h = 0x811c9dc5;
+            for (let i = 0; i < (s || '').length; i++) {
+                h ^= s.charCodeAt(i);
+                h = Math.imul(h, 0x01000193);
+            }
+            return h | 0;
+        },
+    });
     const { Pool } = db.adapters.createPg();
     const pool = new Pool();
     await pool.query(MINIMAL_SCHEMA);

--- a/backend/tests/jest/api-kanban-dependencies-race.test.js
+++ b/backend/tests/jest/api-kanban-dependencies-race.test.js
@@ -1,0 +1,155 @@
+'use strict';
+
+/**
+ * api_kanban_dependencies POST race-window hardening (PR-DCC).
+ *
+ * Mac_F sign-off 2026-05-07 β′:
+ *   - device-scoped pg_advisory_xact_lock(namespace, hashtext(deviceId))
+ *     wraps the exists/cycle/INSERT block
+ *   - lock acquired BEFORE BFS so concurrent inserts on the same device
+ *     serialize through the same key (closes the transitive-cycle hole that
+ *     pair-scoped β had: A→B exists; concurrent B→C and C→A)
+ *
+ * pg-mem CANNOT prove concurrency (no real PG locking semantics). Under
+ * pg-mem we verify SQL ordering (BEGIN → lock → … → COMMIT/ROLLBACK) via a
+ * client-query spy. Real-PG concurrency proof is gated behind
+ * RUN_PG_INTEGRATION=1 and is intentionally a follow-up; the lock SQL itself
+ * is a 1-liner whose semantics are documented in PostgreSQL.
+ */
+
+const express = require('express');
+const request = require('supertest');
+const { bootstrap, insertCard, reset } = require('./__fixtures__/kanban-dep-schema');
+
+const DEVICE = 'dev-a';
+const ENTITY_ID = 7;
+const BOT_SECRET = 'b';
+const auth = { deviceId: DEVICE, entityId: ENTITY_ID, botSecret: BOT_SECRET };
+
+describe('api_kanban_dependencies POST race hardening (PR-DCC)', () => {
+    let pool;
+    let app;
+    let queryLog;
+
+    beforeAll(async () => {
+        ({ pool } = await bootstrap());
+        const origConnect = pool.connect.bind(pool);
+        pool.connect = async (...args) => {
+            const client = await origConnect(...args);
+            const origQuery = client.query.bind(client);
+            client.query = (sql, params) => {
+                const head = typeof sql === 'string'
+                    ? sql.split('\n')[0].trim()
+                    : (sql && sql.text ? sql.text.split('\n')[0].trim() : String(sql));
+                queryLog.push(head);
+                return origQuery(sql, params);
+            };
+            return client;
+        };
+
+        const factory = require('../../api_kanban_dependencies');
+        const devices = {
+            [DEVICE]: {
+                deviceSecret: 's',
+                entities: { [ENTITY_ID]: { botSecret: BOT_SECRET } },
+            },
+        };
+        const { router } = factory(devices, { pool });
+        app = express();
+        app.use(express.json());
+        app.use('/api/mission', router);
+    });
+
+    beforeEach(async () => {
+        await reset(pool);
+        for (const id of ['A', 'B', 'C']) await insertCard(pool, id, DEVICE);
+        queryLog = [];
+    });
+
+    test('happy POST runs BEGIN → lock → INSERT → COMMIT in order', async () => {
+        const res = await request(app)
+            .post('/api/mission/card/A/dependency')
+            .send({ ...auth, dependsOnCardId: 'B' });
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({ success: true, created: true });
+
+        const ix = (re) => queryLog.findIndex((s) => re.test(s));
+        const beginIdx = ix(/^BEGIN/i);
+        const lockIdx = ix(/pg_advisory_xact_lock/);
+        const insertIdx = ix(/^INSERT INTO kanban_card_dependencies/);
+        const commitIdx = ix(/^COMMIT/i);
+
+        expect(beginIdx).toBeGreaterThanOrEqual(0);
+        expect(lockIdx).toBeGreaterThan(beginIdx);
+        expect(insertIdx).toBeGreaterThan(lockIdx);
+        expect(commitIdx).toBeGreaterThan(insertIdx);
+    });
+
+    test('cycle rejection ROLLBACKs the transaction (no commit)', async () => {
+        await pool.query(
+            `INSERT INTO kanban_card_dependencies (device_id, card_id, depends_on_card_id) VALUES ($1, $2, $3)`,
+            [DEVICE, 'A', 'B']
+        );
+        queryLog = [];
+        const res = await request(app)
+            .post('/api/mission/card/B/dependency')
+            .send({ ...auth, dependsOnCardId: 'A' });
+        expect(res.status).toBe(400);
+        expect(res.body.cycleDetected).toBe(true);
+
+        const hasLock = queryLog.some((s) => /pg_advisory_xact_lock/.test(s));
+        const hasRollback = queryLog.some((s) => /^ROLLBACK/i.test(s));
+        const hasCommit = queryLog.some((s) => /^COMMIT/i.test(s));
+        expect(hasLock).toBe(true);
+        expect(hasRollback).toBe(true);
+        expect(hasCommit).toBe(false);
+    });
+
+    test('source-card 404 ROLLBACKs after lock acquired (no inserts)', async () => {
+        const res = await request(app)
+            .post('/api/mission/card/NOPE/dependency')
+            .send({ ...auth, dependsOnCardId: 'B' });
+        expect(res.status).toBe(404);
+        const hasLock = queryLog.some((s) => /pg_advisory_xact_lock/.test(s));
+        const hasInsert = queryLog.some((s) => /^INSERT INTO kanban_card_dependencies/.test(s));
+        const hasRollback = queryLog.some((s) => /^ROLLBACK/i.test(s));
+        expect(hasLock).toBe(true);
+        expect(hasInsert).toBe(false);
+        expect(hasRollback).toBe(true);
+    });
+
+    test('idempotent re-POST (existing edge) still COMMITs the no-op tx', async () => {
+        await pool.query(
+            `INSERT INTO kanban_card_dependencies (device_id, card_id, depends_on_card_id) VALUES ($1, $2, $3)`,
+            [DEVICE, 'A', 'B']
+        );
+        queryLog = [];
+        const res = await request(app)
+            .post('/api/mission/card/A/dependency')
+            .send({ ...auth, dependsOnCardId: 'B' });
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({ success: true, created: false });
+        const hasLock = queryLog.some((s) => /pg_advisory_xact_lock/.test(s));
+        const hasCommit = queryLog.some((s) => /^COMMIT/i.test(s));
+        expect(hasLock).toBe(true);
+        expect(hasCommit).toBe(true);
+    });
+});
+
+// Real-PG concurrency proof — only runs against a real PG instance because
+// pg-mem cannot model `pg_advisory_xact_lock` blocking semantics. Set
+// RUN_PG_INTEGRATION=1 and DATABASE_URL to enable. Intentionally a placeholder
+// scaffold; full harness lives in a follow-up.
+const REAL_PG = process.env.RUN_PG_INTEGRATION === '1';
+const describeReal = REAL_PG ? describe : describe.skip;
+
+describeReal('api_kanban_dependencies POST concurrent race (real PG only)', () => {
+    test.skip('two parallel POSTs creating a transitive cycle: only one wins', () => {
+        // Scaffold for follow-up. Expected shape:
+        //   1. seed cards A,B,C and edge A→B
+        //   2. fire POST B→C and POST C→A in parallel
+        //   3. assert exactly one POST returns 200, the other returns
+        //      400 cycleDetected, and the final graph contains exactly two edges
+        //      (no C→A→B→C cycle).
+    });
+});


### PR DESCRIPTION
## Summary

PR-DCC closes the cycle-check ↔ INSERT race in `POST /api/mission/card/:cardId/dependency`. Follow-up to PR-DCA (helper) + PR-DCB (router/idempotency).

**Vulnerability** (caught by Mac_F #1 sign-off review on my pair-scoped β proposal): cycle-check reads then INSERT happens on a fresh pool query. Two concurrent POSTs can both pass `detectDependencyCycle()`, then both insert, creating a cycle. A pair-scoped lock keyed on `{cardId, dependsOnCardId}` does not fix transitive cases — `A→B` exists; concurrent `B→C` and `C→A` use disjoint sorted-pair keys, both pass BFS, graph becomes `C→A→B→C`.

**Fix** (Mac_F sign-off 2026-05-07 β′): device-scoped `pg_advisory_xact_lock(namespace, hashtext(deviceId))` acquired BEFORE any read. All dep-edge writes for the same device serialize through the same lock key.

## What changed

- `backend/api_kanban_dependencies.js`: POST handler now wraps exists/cycle/INSERT in `BEGIN; SELECT pg_advisory_xact_lock(...); ...; COMMIT|ROLLBACK` on a single pooled client. Idempotent re-POST still returns `created:false` (no double-insert). Self-edge / dependencyType / 404 short-circuits remain *before* the connect (no client leak).
- `backend/tests/jest/__fixtures__/kanban-dep-schema.js`: register `pg_advisory_xact_lock` and `hashtext` as pg-mem no-ops (deterministic FNV-1a for `hashtext`) so DCB tests still pass under pg-mem.
- `backend/tests/jest/api-kanban-dependencies-race.test.js` (new): verifies SQL ordering under pg-mem (BEGIN → lock → … → COMMIT/ROLLBACK), cycle-rejection rollback, 404 rollback after lock, idempotent re-POST commit.

## pg-mem limitation (intentional)

pg-mem **cannot** prove mutual exclusion — its no-op `pg_advisory_xact_lock` does not block. Under pg-mem we only verify the lock SQL fires in the right place. Real-PG concurrency proof is gated behind `RUN_PG_INTEGRATION=1` and scaffolded as a `test.skip` placeholder; full harness lives in a follow-up. Mac_F's sign-off explicitly approved this split (do not fake a green pg-mem race test).

## Test plan
- [x] `jest backend/tests/jest/api-kanban-dependencies.test.js backend/tests/jest/kanban-dependencies-cycle.test.js backend/tests/jest/api-kanban-dependencies-race.test.js` → 30 pass, 1 skip
- [x] `node --check` on all 3 modified files
- [ ] (follow-up) wire real-PG harness behind `RUN_PG_INTEGRATION=1` to prove parallel POST gives exactly one winner
- [ ] (post-merge) prod smoke: POST a happy edge, POST a cycle, verify no 500s in Railway logs

## Card

card_6ad2eeee3fb57b577bbbb7cc → in_progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)