### PR TITLE
fix(seo): add Express route for /promo-meta.html (#2515)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -290,6 +290,11 @@ app.get(['/promo', '/promo.html'], (req, res) => {
     res.set('Cache-Control', 'public, max-age=3600');
     res.sendFile(path.join(__dirname, 'public/promo.html'));
 });
+// Promo meta page (SEO structured data for promo)
+app.get('/promo-meta.html', (req, res) => {
+    res.set('Cache-Control', 'public, max-age=3600');
+    res.sendFile(path.join(__dirname, 'public/promo-meta.html'));
+});
 // Info Hub page — redirect to /portal/info.html so relative asset paths resolve correctly
 app.get('/info', (req, res) => {
     res.redirect(301, '/portal/info.html');


### PR DESCRIPTION
## Summary
- Add missing Express route for `/promo-meta.html` so the page is accessible at the root URL
- File exists in `backend/public/promo-meta.html` and is listed in sitemap but had no Express route
- Fixes #2515

## Test plan
- [ ] Verify `curl -I https://eclawbot.com/promo-meta.html` returns 200 after deploy
- [ ] Verify sitemap entry matches accessible URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)