### PR TITLE
fix(portal): improve QA accessibility shims

### DIFF
--- a/backend/public/portal/marketplace.html
+++ b/backend/public/portal/marketplace.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Redirecting to Bot Plaza...</title>
     <script>window.location.replace('community.html#rental');</script>
 </head>

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -918,7 +918,7 @@
             <button id="wvClearBtn" style="display:none" onclick="clearDrawing()" data-i18n="mc_note_draw_clear">Clear</button>
             <button id="wvSaveDrawBtn" style="display:none" onclick="saveDrawing()" data-i18n="mc_note_draw_save">Save</button>
             <div class="wv-toolbar-sep"></div>
-            <button id="wvPublicToggle" onclick="togglePagePublic()" style="font-size:12px;"></button>
+            <button id="wvPublicToggle" onclick="togglePagePublic()" style="font-size:12px;" aria-label="Private">🔒 Private</button>
             <button id="wvCopyLinkBtn" onclick="copyNotePageLink()" style="display:none;font-size:12px;" data-i18n="mc_note_copy_link">Copy Link</button>
             <button id="wvEditHtmlBtn" onclick="editPageHtml()" data-i18n="mc_note_edit_page">Edit HTML</button>
             <button onclick="closePageViewer()" data-i18n="mc_note_page_close">Close</button>
@@ -2227,7 +2227,11 @@
             const btn = document.getElementById('wvPublicToggle');
             if (!btn) return;
             const isPublic = !!notePagePublic[noteId];
-            btn.textContent = isPublic ? '🌐 ' + (i18n.t('mc_note_public_label') || 'Public') : '🔒 ' + (i18n.t('mc_note_private_label') || 'Private');
+            const publicLabel = i18n.t('mc_note_public_label') || 'Public';
+            const privateLabel = i18n.t('mc_note_private_label') || 'Private';
+            const toggleLabel = isPublic ? publicLabel : privateLabel;
+            btn.textContent = (isPublic ? '🌐 ' : '🔒 ') + toggleLabel;
+            btn.setAttribute('aria-label', toggleLabel);
             btn.style.color = isPublic ? '#4CAF50' : '#9E9E9E';
             // Show/hide copy link button based on public status
             const copyBtn = document.getElementById('wvCopyLinkBtn');

--- a/backend/tests/jest/portal-static-ids.test.js
+++ b/backend/tests/jest/portal-static-ids.test.js
@@ -19,4 +19,26 @@ describe('portal static HTML IDs', () => {
     expect(html).toContain("document.getElementById('inviteOnboardingBanner')");
     expect(html).not.toContain("document.getElementById('inviteBanner')");
   });
+
+  test('mission note page public toggle has a stable accessible label before state hydration', () => {
+    const missionPath = path.join(__dirname, '../../public/portal/mission.html');
+    const html = fs.readFileSync(missionPath, 'utf8');
+
+    const buttonMatch = html.match(/<button\s+[^>]*id=["']wvPublicToggle["'][^>]*>([\s\S]*?)<\/button>/);
+    expect(buttonMatch).not.toBeNull();
+    const buttonMarkup = buttonMatch[0];
+    const initialText = buttonMatch[1].replace(/<[^>]*>/g, '').trim();
+
+    expect(buttonMarkup).toMatch(/aria-label=["'][^"']+["']/);
+    expect(initialText.length).toBeGreaterThan(0);
+    expect(html).toContain("btn.setAttribute('aria-label', toggleLabel)");
+  });
+
+  test('marketplace redirect shim keeps mobile viewport metadata', () => {
+    const marketplacePath = path.join(__dirname, '../../public/portal/marketplace.html');
+    const html = fs.readFileSync(marketplacePath, 'utf8');
+
+    expect(html).toMatch(/<meta\s+name=["']viewport["']\s+content=["']width=device-width,\s*initial-scale=1\.0["']>/);
+  });
+
 });


### PR DESCRIPTION
## Summary

Fix two confirmed QA/UIUX findings from the daily audit:

- Fixes #2518 by giving `mission.html#wvPublicToggle` a stable initial accessible label/text before dynamic state hydration, and keeping `aria-label` updated when state changes.
- Fixes #2519 by adding the standard mobile viewport meta tag to the `/portal/marketplace.html` redirect shim.

## Validation

- `/Users/hank/Desktop/Project/EClaw/backend/node_modules/.bin/jest --runTestsByPath tests/jest/portal-static-ids.test.js` from `/tmp/eclaw-qa-fix/backend` → PASS (3 tests)
- `npm run smoke:portal` from `/tmp/eclaw-qa-fix/backend` → PASS
- `node tests/test-ux-static-audit.js` from `/tmp/eclaw-qa-fix/backend` → completed; existing 24 static findings remain (tracked by #2485), no new regression from this patch

## Notes

- No direct push to main.
- #2515 intentionally untouched; LOBSTER owns that closeout.
- Worktree had unrelated CRLF working-copy noise after test execution; commit contains only the 3 intended files.
