### PR TITLE
feat(landing): embed Day 0 promo video on hero

### DIFF
--- a/backend/public/landing.html
+++ b/backend/public/landing.html
@@ -171,6 +171,37 @@
         }
         .btn-outline:hover { border-color: #6C63FF; color: #fff; text-decoration: none; }
 
+        /* Hero video */
+        .hero-video {
+            max-width: 880px;
+            margin: 0 auto;
+            padding: 0 20px 40px;
+        }
+        .hero-video-frame {
+            position: relative;
+            width: 100%;
+            padding-bottom: 56.25%;
+            border-radius: 12px;
+            overflow: hidden;
+            background: #1A1A2E;
+            border: 1px solid #333355;
+            box-shadow: 0 12px 40px rgba(108, 99, 255, 0.18);
+        }
+        .hero-video-frame iframe {
+            position: absolute;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            border: 0;
+        }
+        .hero-video-caption {
+            text-align: center;
+            font-size: 0.9rem;
+            color: #888;
+            margin-top: 12px;
+        }
+
         /* Features */
         .features {
             max-width: 960px;
@@ -255,6 +286,19 @@
                 <a href="/api/docs" class="btn-outline" data-i18n="landing_api_docs">API Documentation</a>
                 <a href="/arena" class="btn-outline" data-i18n="landing_arena">Agent Benchmark</a>
             </div>
+        </section>
+
+        <section class="hero-video" aria-label="EClaw demo video">
+            <div class="hero-video-frame">
+                <iframe
+                    src="https://www.youtube-nocookie.com/embed/OkphZN8pRX8?rel=0"
+                    title="EClaw — AI Agent Interop Platform (Concept A)"
+                    loading="lazy"
+                    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                    allowfullscreen
+                    referrerpolicy="strict-origin-when-cross-origin"></iframe>
+            </div>
+            <p class="hero-video-caption">🎬 EClaw — AI Agent Interop Platform · Concept A</p>
         </section>
 
         <section class="features">


### PR DESCRIPTION
## Summary
- Embeds the Day 0 EClaw promo (Concept A — `https://youtu.be/OkphZN8pRX8`) directly under the landing-page hero so visitors see it before the feature grid.
- Uses `youtube-nocookie.com` for privacy + a 16:9 wrapper for responsive scaling.
- Pure HTML/CSS in `backend/public/landing.html`. No backend changes — existing CSP `frame-src https:` already allows the embed.

## Why now
Daily collaboration cron (`⚙️ Daily Eclaw 影片日常 — 09 素材 → 12 製作+YouTube → 16 內嵌`) Day 0 fallback: Hank verdict ✅ on zh-TW BGM-only, #6 uploaded to YouTube as Unlisted, this PR completes the 16:00 embed step.

Card: `card_a3afc09830c749e6da6bc137`

## Test plan
- [x] `git diff --stat` shows only `backend/public/landing.html` (+44 lines)
- [ ] Railway redeploy → eclawbot.com loads landing → iframe renders → player plays
- [ ] Mobile viewport: video frame stays inside hero block, no horizontal scroll

🤖 Generated with [Claude Code](https://claude.com/claude-code)