### PR TITLE
fix(api): include avatar in GET /api/status so polling clients sync

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1128,6 +1128,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | Auth Extended | `tests/jest/auth-extended.test.js` | device-login, verify-email, forgot-password, reset-password, bind-email, app-login, OAuth (Google/Facebook/OIDC), account deletion, RBAC roles |
 | Subscription | `tests/jest/subscription.test.js` | Subscription status, TapPay payment, cancellation, Google Play verification, usage limits |
 | Usage Limit Removed | `tests/jest/usage-limit-removed.test.js` | Regression: `enforceUsageLimit()` is a no-op; never queries `usage_tracking` / `invite_rewards`; always returns `allowed:true, limit:null` |
+| Status Avatar Sync | `tests/jest/status-avatar-sync.test.js` | Regression: `GET /api/status` MUST include `avatar` field so polling clients (Android live wallpaper / widget / iOS) keep entity avatars in sync; locks parity with `/api/entities` |
 | Official Borrow | `tests/jest/official-borrow.test.js` | Official bot borrowing lifecycle (bind-free, bind-personal, add-paid-slot, unbind, verify-subscription) |
 | Device Preferences | `tests/jest/device-preferences.test.js` | Device preference GET/PUT, auth validation |
 | Publisher Extended | `tests/jest/publisher-extended.test.js` | Blogger, Hashnode, X/Twitter, Tumblr, Reddit, LinkedIn, Mastodon publish/delete/me validation |

--- a/backend/index.js
+++ b/backend/index.js
@@ -6156,6 +6156,10 @@ app.get('/api/status', (req, res) => {
         parts: entity.parts,
         lastUpdated: entity.lastUpdated,
         isBound: entity.isBound,
+        // Avatar must be returned so polling clients (Android live wallpaper,
+        // widget, iOS) keep entity avatars in sync with the dashboard.
+        // See backend/openapi.yaml `/api/status` and Entity schema.
+        avatar: entity.avatar || null,
         rental_status: entity.rental_status || null,  // 'leased_in', 'leased_out', or null
         rental_contract_id: entity.rental_contract_id || null,
         versionInfo: getVersionInfo(appVersion || entity.appVersion)

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -499,32 +499,50 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
 
-  /api/device/status:
-    post:
+  /api/status:
+    get:
       tags: [Device]
       summary: Poll entity status
-      operationId: getDeviceStatus
+      description: |
+        Returns the current state of a single entity. Auth accepts any of:
+        deviceId+deviceSecret, deviceId+botSecret+entityId, or JWT cookie.
+
+        Response schema MUST include `avatar` so polling clients (Android live
+        wallpaper, widget, iOS) keep entity avatars in sync with the dashboard.
+        See Entity schema for the full field list.
+      operationId: getEntityStatus
       security:
         - DeviceSecret: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              required: [deviceId, deviceSecret]
-              properties:
-                deviceId:
-                  type: string
-                deviceSecret:
-                  type: string
-                entityId:
-                  type: integer
-                appVersion:
-                  type: string
+        - CookieAuth: []
+      parameters:
+        - name: deviceId
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: deviceSecret
+          in: query
+          schema:
+            type: string
+          description: Required unless using botSecret+entityId or JWT cookie auth
+        - name: botSecret
+          in: query
+          schema:
+            type: string
+          description: Bot-side auth; must be paired with entityId of the same bot
+        - name: entityId
+          in: query
+          schema:
+            type: integer
+            default: 0
+        - name: appVersion
+          in: query
+          schema:
+            type: string
+          description: Client app version, recorded on entity for telemetry
       responses:
         '200':
-          description: Entity status
+          description: Entity status (subset of Entity schema, must include avatar)
           content:
             application/json:
               schema:

--- a/backend/tests/jest/status-avatar-sync.test.js
+++ b/backend/tests/jest/status-avatar-sync.test.js
@@ -1,0 +1,116 @@
+/**
+ * Regression test: GET /api/status must include the `avatar` field.
+ *
+ * Polling clients (Android live wallpaper, widget, iOS native screens) hit
+ * /api/status to refresh entity state. If the response omits `avatar`, those
+ * surfaces never see avatar updates made on the dashboard, even though the
+ * value is correctly persisted to PostgreSQL via PUT/POST entity/avatar.
+ *
+ * Sister endpoint /api/entities already returns `avatar` (index.js:5990).
+ * /api/status was missing it; this test locks the parity.
+ *
+ * Spec source of truth: backend/openapi.yaml `/api/status` → Entity schema.
+ */
+
+require('./helpers/mock-setup');
+
+const request = require('supertest');
+let app;
+
+const get = (path) => request(app).get(path).set('Host', 'localhost');
+const put = (path) => request(app).put(path).set('Host', 'localhost');
+const post = (path) => request(app).post(path).set('Host', 'localhost');
+
+async function registerDevice(deviceId) {
+    const deviceSecret = `secret-${deviceId}`;
+    await post('/api/device/register')
+        .send({ deviceId, deviceSecret, entityId: 0 });
+    return deviceSecret;
+}
+
+beforeAll(() => {
+    app = require('../../index');
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise((resolve) => httpServer.close(resolve));
+    jest.resetModules();
+});
+
+describe('GET /api/status — avatar sync regression', () => {
+    it('returns the avatar field (null) for a freshly registered entity', async () => {
+        const deviceId = 'status-avatar-test-fresh';
+        const deviceSecret = await registerDevice(deviceId);
+
+        const res = await get(
+            `/api/status?deviceId=${deviceId}&deviceSecret=${deviceSecret}&entityId=0`
+        );
+
+        expect(res.status).toBe(200);
+        // Regression lock: `avatar` MUST be in the response payload, even if null.
+        expect(res.body).toHaveProperty('avatar');
+        expect(res.body.avatar).toBeNull();
+    });
+
+    it('reflects an emoji avatar set via PUT /api/device/entity/avatar', async () => {
+        const deviceId = 'status-avatar-test-emoji';
+        const deviceSecret = await registerDevice(deviceId);
+
+        const putRes = await put('/api/device/entity/avatar').send({
+            deviceId,
+            deviceSecret,
+            entityId: 0,
+            avatar: '🦞',
+        });
+        expect(putRes.status).toBe(200);
+
+        const res = await get(
+            `/api/status?deviceId=${deviceId}&deviceSecret=${deviceSecret}&entityId=0`
+        );
+
+        expect(res.status).toBe(200);
+        expect(res.body.avatar).toBe('🦞');
+    });
+
+    it('reflects a Flickr-URL avatar set via PUT /api/device/entity/avatar', async () => {
+        const deviceId = 'status-avatar-test-url';
+        const deviceSecret = await registerDevice(deviceId);
+
+        const flickrUrl = 'https://live.staticflickr.com/65535/00000000000_xxxxx_z.jpg';
+        const putRes = await put('/api/device/entity/avatar').send({
+            deviceId,
+            deviceSecret,
+            entityId: 0,
+            avatar: flickrUrl,
+        });
+        expect(putRes.status).toBe(200);
+
+        const res = await get(
+            `/api/status?deviceId=${deviceId}&deviceSecret=${deviceSecret}&entityId=0`
+        );
+
+        expect(res.status).toBe(200);
+        expect(res.body.avatar).toBe(flickrUrl);
+    });
+
+    it('keeps avatar in the response shape across the existing field set', async () => {
+        // Schema-style assertion: any client (Android wallpaper / iOS / widget)
+        // that destructures `avatar` from /api/status must keep working.
+        const deviceId = 'status-avatar-test-shape';
+        const deviceSecret = await registerDevice(deviceId);
+
+        const res = await get(
+            `/api/status?deviceId=${deviceId}&deviceSecret=${deviceSecret}&entityId=0`
+        );
+
+        expect(res.status).toBe(200);
+        // Pre-existing fields stay in place
+        expect(res.body).toHaveProperty('deviceId');
+        expect(res.body).toHaveProperty('entityId');
+        expect(res.body).toHaveProperty('state');
+        expect(res.body).toHaveProperty('isBound');
+        // New required field
+        expect(res.body).toHaveProperty('avatar');
+    });
+});


### PR DESCRIPTION
## Summary
- `/api/status` was missing the `avatar` field, so polling clients (Android live wallpaper / widget / iOS status refresh) never observed avatar changes made on the dashboard — even though `/api/entities` returns it correctly and the value is correctly persisted to PostgreSQL.
- Add `avatar: entity.avatar || null` to the `/api/status` response (`backend/index.js`).
- Fix `backend/openapi.yaml` — replace incorrect `POST /api/device/status` entry with the actual `GET /api/status` (query-param auth). Response continues to reference the `Entity` schema, which already declares `avatar`.
- New Jest regression `tests/jest/status-avatar-sync.test.js` (4 cases) locks the parity with `/api/entities`.
- `CLAUDE.md` registers the new regression test.

## Root cause clarification
Write path was already correct — `entity.avatar` is persisted via `saveData()` -> `db.saveAllDevices()` -> `entities.avatar` column on every PUT/POST avatar endpoint. The bug was a read-side schema gap on `/api/status`, not a DB persistence gap.

## Test plan
- [x] `npx jest tests/jest/status-avatar-sync.test.js` — 4 cases pass
- [x] `npx jest health validation mutations i18n-syntax` — 54 cases pass
- [x] `node scripts/i18n-check.js` — all keys resolve
- [x] `npx eslint backend/index.js` — no errors
- [ ] Backend CI green
- [ ] After merge: hit prod `GET /api/status?deviceId=...&deviceSecret=...&entityId=0` and confirm `avatar` is in the response body

## Self-review (per docs/code-review-checklist.md)
Part A (core)
1. Logic trace ✅ — single-line addition; the field is read from the same in-memory entity already used to populate other fields.
2. Test coverage ✅ — 4 cases (null / emoji / Flickr-URL / shape parity).
3. Return shape ✅ — additive only; existing fields untouched.
4. What this does NOT fix ⚠️ NO-OP — `/api/status` still omits `xp/level/publicCode/encryptionStatus/isPublic` that `/api/entities` returns; intentionally out-of-scope to keep the change minimal. Can be a follow-up if needed.
5. Security ✅ — no new auth surface; reuses existing deviceSecret / botSecret / JWT validation.

Part B (extended)
6. `/api/help` update ⚠️ NO-OP — no `/api/help` entry references this field today.
7. Related docs ✅ — `backend/openapi.yaml` updated to reflect the actual GET path + Entity schema (which has `avatar`).
8. i18n audit ⚠️ NO-OP — backend-only change, no UI strings.
9. Info page ⚠️ NO-OP — internal API contract fix, not user-visible feature.
10. Debug endpoint ⚠️ NO-OP — not a user-reported bug with active investigation; trivial single-field addition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)