### PR TITLE
fix(kanban): render dep chips in card detail modal

### DIFF
--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -572,6 +572,8 @@
         /* ══════════════ Dependency Chain Chips ══════════════ */
         .kb-dep-chips-container { display:contents; }
         .kb-dep-chips { display:flex; gap:4px; flex-wrap:wrap; align-items:center; }
+        .kb-detail-dep-chips { display:block; width:100%; margin-top:8px; padding-top:8px; border-top:1px solid var(--card-border, rgba(255,255,255,0.06)); }
+        .kb-detail-dep-chips:empty { display:none; }
         .kb-dep-chip { display:inline-flex; align-items:center; gap:4px; padding:2px 8px; border-radius:12px; font-size:10px; font-weight:500; cursor:pointer; transition:all 0.2s; text-decoration:none; border:1px solid transparent; max-width:120px; overflow:hidden; }
         .kb-dep-chip:hover { transform:translateY(-1px); }
 
@@ -1847,7 +1849,14 @@
                 <span class="meta-item">🕐 ${formatTime(card.createdAt || card.created_at)}</span>
                 ${scheduleInfo}
                 ${card.description ? '<div class="kb-detail-desc">'+renderSmartChips(card.description)+'</div>' : ''}
+                <div class="kb-dep-chips-container kb-detail-dep-chips" data-card-id="${cardId}"></div>
             `;
+            const detailDepContainer = meta.querySelector('.kb-detail-dep-chips');
+            if (detailDepContainer) {
+                fetchCardDependencies(cardId).then(({ dependencies, dependents }) => {
+                    detailDepContainer.innerHTML = renderDependencyChips(dependencies, dependents);
+                });
+            }
 
             // Move bar — shared assign + reviewer UI for all cards
             const moveBar = document.getElementById('moveBar');


### PR DESCRIPTION
## Summary
- Detail modal opens a card via `openDetail(cardId)` but never rendered dependency chips because `meta.innerHTML` (kanban.html:1841-1849) had no `kb-dep-chips-container`. PR #2560's chip rendering was board-card-surface only.
- Adds a single `.kb-dep-chips-container.kb-detail-dep-chips` row right after the description, populated by the existing `fetchCardDependencies` + `renderDependencyChips` pair (cache shared with the card-surface load).
- Adds a `.kb-detail-dep-chips` rule so the row breaks full-width inside the flex `kb-modal-meta`, plus a `:empty` rule to suppress the divider when a card has no deps.

## Why
Hank's mobile screenshot of `[DEMO] 子卡 2 — 前端 UI（子卡 2)` detail modal showed zero chips even though the card has dependencies on its description. Root cause was the dep-chain UI never being wired into this surface. Closes the gap so opening any card shows ← / → chips inline.

## Test plan
- [x] Diff is +9 lines, no removals; reuses existing helpers.
- [ ] CI green (lint / Jest / portal pages).
- [ ] Post-merge: playwright on prod, mobile breakpoint, open a card with deps, capture chips visible in modal — attach screenshot to follow-up card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)