### PR TITLE
docs(petdx): UIUX + Backend API spec v0.2 — Android engine enhancement scope

### DIFF
--- a/docs/specs/petdx-backend-api-spec.md
+++ b/docs/specs/petdx-backend-api-spec.md
@@ -1,12 +1,12 @@
 # Petdx Backend API 設計規格
 
-> **狀態**: v0.1 (2026-05-10) · **作者**: LOBSTER #2 · **依賴卡**: `card_e8aeba8feedf22a714a33fc6`
+> **狀態**: v0.2 (2026-05-10) · **作者**: LOBSTER #2 · **依賴卡**: `card_e8aeba8feedf22a714a33fc6`
 >
-> **上游**: [Petdx UIUX 規格書 v0.1](./petdx-uiux-spec.md) §A 附錄
+> **上游**: [Petdx UIUX 規格書 v0.2](./petdx-uiux-spec.md)
 >
-> **下游**: 實作 `backend/petdx-api.js` + DB 遷移 + i18n keys
+> **下游**: 實作 `backend/companion-api.js` + DB 遷移 + i18n keys
 >
-> **Pending**: Mac_F #1 + Hank review of Petdx spec v0.1 §11 開放問題（影響本 API：Q1 主軸 / Q2 entity 視覺關係 / Q3 收益分潤）
+> **v0.1 → v0.2 變更**: 鎖定 Android 既有引擎增強 → 砍掉一半 endpoint（state-event / sync / states/:id）/ 新增 `/states/help` / e 幣分潤預設啟用 / avatar.png 在 publish 時自動生成 / state event log 表移除（改用既有 `audit_log`）。
 
 ---
 
@@ -19,17 +19,17 @@
 - 多租戶：每個 device 的 companion library 獨立（系統內建除外）
 - 透過 `device_vars` 持久化 per-entity 狀態（current companion / favorites）
 
+**v0.2 設計原則**：API 只做 CRUD + 狀態查詢；**不負責 state event 廣播**（既有 `/api/transform` 的 `state` 欄位已涵蓋）。
+
 ## 2. 端點總覽
 
 | Method | Path | 用途 | Auth |
 |---|---|---|---|
 | GET | `/api/companion/list` | 瀏覽伙伴（含過濾搜尋） | botSecret |
-| GET | `/api/companion/:id` | 單一伙伴詳情 | botSecret |
+| GET | `/api/companion/:id` | 單一伙伴詳情（CompanionDescriptor 全文） | botSecret |
+| GET | `/api/companion/:id/states/help` | **NEW**：查該伙伴 supportedStates | botSecret |
 | POST | `/api/companion/select` | 切換當前伙伴 | botSecret |
 | GET | `/api/companion/current` | 當前 entity 的伙伴 | botSecret |
-| GET | `/api/companion/states/:id` | 9 動畫狀態定義 | botSecret |
-| POST | `/api/companion/state-event` | 觸發狀態切換 | botSecret |
-| POST | `/api/companion/sync` | 主動同步 agent 大頭照 | botSecret |
 | POST | `/api/companion/favorite` | 收藏/取消收藏 | botSecret |
 | GET | `/api/companion/favorites` | 收藏清單 | botSecret |
 | POST | `/api/companion/rate` | 評分 | botSecret |
@@ -41,6 +41,12 @@
 | DELETE | `/api/companion/draft/:id` | 刪除草稿 | botSecret |
 | POST | `/api/companion/review/:id` | 審核（device owner only） | deviceSecret |
 | GET | `/api/companion/community` | 社群伙伴清單 | botSecret |
+| GET | `/api/companion/:id/earnings` | **NEW**：創作者收益（自己作品） | botSecret |
+
+**v0.1 移除的端點**：
+- ~~`GET /api/companion/states/:id`~~ — 合併入 `/states/help`
+- ~~`POST /api/companion/state-event`~~ — 改用既有 `/api/transform` `state` 欄位
+- ~~`POST /api/companion/sync`~~ — avatar.png 在 publish 時自動生成；client 端讀 vault `PETDX_AVATAR_<entityId>` 即可
 
 ---
 
@@ -54,16 +60,17 @@
 
 | 參數 | 型別 | 預設 | 說明 |
 |---|---|---|---|
-| `deviceId` | string | required |  |
-| `botSecret` | string | required |  |
-| `entityId` | int | required |  |
-| `category` | string | `''` (all) | `animal` / `human` / `robot` / `custom` |
+| `deviceId` | string | required | |
+| `botSecret` | string | required | |
+| `entityId` | int | required | |
+| `category` | string | `''` (all) | `animal` / `human` / `robot` / `mascot` / `custom` |
 | `mood` | string | `''` | `happy` / `busy` / `sleepy` / `playful` |
 | `color` | string | `''` | hex `#xxxxxx` 或 named bucket（red/orange/...） |
 | `q` | string | `''` | 關鍵字（name / description / tags / author） |
 | `tags` | string[] | `[]` | comma-separated, AND 比對 |
 | `sort` | string | `popular` | `popular` / `recent` / `rating` / `favorites` |
 | `scope` | string | `all` | `all` / `system` / `community` / `mine` |
+| `assetType` | string | `''` | `procedural` / `spritesheet` / `vector`（v0.2 新增）|
 | `page` | int | `1` | 1-indexed |
 | `limit` | int | `30` | max 100 |
 
@@ -79,11 +86,14 @@
     {
       "id": "petdx-orange-cat-001",
       "name": "橘貓菲比",
+      "avatarUrl": "/static/companions/petdx-orange-cat-001/avatar.png",
       "thumbnailUrl": "/static/companions/petdx-orange-cat-001/thumbnail.webp",
       "author": { "entityId": 12, "publicCode": "ab3xyz", "displayName": "Hank" },
       "tags": ["cat", "orange", "cute"],
       "mood": "happy",
       "color": "#ff8c42",
+      "assetType": "spritesheet",
+      "supportedStates": ["IDLE","BUSY","SLEEPING","EXCITED"],
       "stats": { "downloads": 1234, "favorites": 89, "rating": 4.7, "ratingCount": 32 },
       "isFavorited": true,
       "isCurrent": false,
@@ -98,11 +108,46 @@
 
 ### 3.2 GET `/api/companion/:id`
 
-單一伙伴完整 metadata（含 spritesheet URL 與 9 狀態定義）。
+單一伙伴完整 metadata（CompanionDescriptor 全文 + stats + isFavorited/isCurrent flags + asset URL）。
 
-**Response 200**: pet.json 全文 + stats + isFavorited/isCurrent flags。
+**Response 200**: 見 UIUX spec §2.1 CompanionDescriptor schema 全文，外加：
 
-### 3.3 POST `/api/companion/select`
+```json
+{
+  "...descriptor fields...": "...",
+  "stats": { "downloads": 1234, "favorites": 89, "rating": 4.7, "ratingCount": 32, "commentCount": 12 },
+  "isFavorited": true,
+  "isCurrent": false,
+  "publishedAt": 1778345000000
+}
+```
+
+### 3.3 GET `/api/companion/:id/states/help`（NEW v0.2）
+
+回傳該伙伴的 supportedStates + 每個 state 的 asset hint。Agent 在切換伙伴後主動呼叫，避免送出該伙伴不支援的 state。
+
+**Cache**: 1h immutable（與 `/api/companion/:id` 一致）。
+
+**Response 200**:
+
+```json
+{
+  "companionId": "petdx-lobster-default",
+  "supportedStates": ["IDLE","BUSY","EATING","SLEEPING","EXCITED"],
+  "stateAssets": {
+    "IDLE":     { "loop": true,  "fps": 4,  "hint": "default rest" },
+    "BUSY":     { "loop": true,  "fps": 6,  "hint": "working" },
+    "EATING":   { "loop": true,  "fps": 6,  "hint": "xp gain" },
+    "SLEEPING": { "loop": true,  "fps": 2,  "hint": "long idle" },
+    "EXCITED":  { "loop": false, "fps": 12, "hint": "card done / level up" }
+  },
+  "fallbackPolicy": "silent_to_idle"
+}
+```
+
+**用法**：Agent 收到不支援的 state event 時應 local fallback 到 IDLE，不需呼叫 backend；backend 也不會回 4xx。
+
+### 3.4 POST `/api/companion/select`
 
 切換當前伙伴。
 
@@ -112,16 +157,17 @@
   "deviceId": "...",
   "botSecret": "...",
   "entityId": 2,
-  "companionId": "petdx-orange-cat-001",
-  "syncAvatar": true
+  "companionId": "petdx-orange-cat-001"
 }
 ```
 
 **行為**:
 1. 寫入 `device_vars.PETDX_CURRENT_<entityId> = companionId`
-2. 若 `syncAvatar=true`（預設）→ 觸發 §3.7 sync flow
-3. 廣播 `companion-selected` event 到 WebSocket 所有 subscribed clients
-4. 寫入 `companion_events` audit log
+2. **自動寫入** `device_vars.PETDX_AVATAR_<entityId> = <avatar.png url>`（從 companions table 讀 avatar_url）
+3. 寫入 `entity_cards.icon_url = <avatar.png url>` for entity = entityId（保留 `icon_url_original` 作為 fallback）
+4. 廣播 `companion-selected` event 到 WebSocket subscribed clients
+5. 寫入 `companion_select_log`（rating gate + 收益計算用）
+6. **若 companion 為他人作品** → 觸發 §3.13 e 幣分潤入帳（per Q2）
 
 **Response 200**:
 ```json
@@ -129,90 +175,34 @@
   "success": true,
   "previous": "petdx-default-bot-001",
   "current": "petdx-orange-cat-001",
-  "avatarUrl": "data:image/webp;base64,..."
+  "avatarUrl": "/static/companions/petdx-orange-cat-001/avatar.png",
+  "earningsAwarded": { "creatorEntityId": 12, "amount": 1, "currency": "ecoin" }
 }
 ```
+
+`earningsAwarded` 為自己選自己作品時為 `null`。
 
 **Errors**: `404 companion_not_found`, `403 not_allowed`（社群伙伴未過審）
 
-### 3.4 GET `/api/companion/current`
+### 3.5 GET `/api/companion/current`
 
-讀取當前 entity 的伙伴（從 `device_vars.PETDX_CURRENT_<entityId>`）。若未設定 → 回傳系統預設。
+讀取當前 entity 的伙伴（從 `device_vars.PETDX_CURRENT_<entityId>`）。若未設定 → 回傳系統預設 `petdx-lobster-default`。
 
-### 3.5 GET `/api/companion/states/:id`
+**Response 200**: 同 §3.2 格式 + `selectedAt` timestamp。
 
-回傳 9 狀態定義（與 pet.json `states` 一致），用於 frontend 動畫渲染。Cache: 1h immutable。
-
-### 3.6 POST `/api/companion/state-event`
-
-通知 backend 一個 state-changing event 發生，由 backend 計算當前該播哪個 state。
-
-**Body**:
-```json
-{
-  "deviceId": "...",
-  "botSecret": "...",
-  "entityId": 2,
-  "event": "card-done",
-  "context": { "cardId": "card_xxx", "priority": "P0" }
-}
-```
-
-**Event types**: `state-change` / `card-status` / `push` / `click-pet` / `timeout` / `xp-gain` / `error`
-
-**Response 200**:
-```json
-{
-  "success": true,
-  "previousState": "working",
-  "newState": "celebrating",
-  "transitionMs": 200,
-  "expiresAt": 1778349000000
-}
-```
-
-celebrating/eating/alert 一次性 state 含 `expiresAt`，過期後 frontend 自動 fallback。
-
-### 3.7 POST `/api/companion/sync`
-
-主動觸發大頭照同步。Backend 從 spritesheet 抽 idle frame 0，寫入 `entity_card.iconUrl`，回傳 data URL。
-
-**Body**:
-```json
-{ "deviceId":"...", "botSecret":"...", "entityId": 2, "companionId": "..." }
-```
-
-**Response 200**:
-```json
-{
-  "success": true,
-  "avatarDataUrl": "data:image/webp;base64,...",
-  "cacheKey": "PETDX_AVATAR_CACHE_2",
-  "syncedTargets": ["entity_card", "chat_avatar", "kanban_avatar", "plaza_avatar", "mention_avatar"]
-}
-```
-
-**內部流程**:
-1. 從 `companions.spritesheet_url` 載入圖
-2. canvas drawImage(sheet, 0, idleRow*frameH, frameW, frameH, 0, 0, 256, 256)
-3. canvas.toDataURL('image/webp', 0.85) → base64 string
-4. 寫入 `entity_cards.icon_url` for entity = entityId
-5. 寫入 `device_vars.PETDX_AVATAR_CACHE_<entityId>`
-6. 同步 cache invalidation broadcast
-
-### 3.8 POST `/api/companion/favorite`
+### 3.6 POST `/api/companion/favorite`
 
 ```json
 { "deviceId":"...", "botSecret":"...", "entityId":2, "companionId":"...", "on":true }
 ```
 
-寫入 `companion_favorites` table。
+寫入 `companion_favorites` table；同時 increment/decrement `companions.favorite_count`（transaction）。
 
-### 3.9 GET `/api/companion/favorites`
+### 3.7 GET `/api/companion/favorites`
 
-回傳當前 entity 的收藏 companion 清單（簡略卡片格式）。
+回傳當前 entity 的收藏 companion 清單（簡略卡片格式，同 §3.1 item 結構）。
 
-### 3.10 POST `/api/companion/rate`
+### 3.8 POST `/api/companion/rate`
 
 ```json
 { "deviceId":"...", "botSecret":"...", "entityId":2, "companionId":"...", "stars": 5 }
@@ -220,42 +210,50 @@ celebrating/eating/alert 一次性 state 含 `expiresAt`，過期後 frontend �
 
 **驗證**:
 - stars: 1-5 整數
-- entity 必須**已切換為當前伙伴 ≥ 3 天**才可評（`companion_select_log` 查詢）
+- entity 必須**已切換為當前伙伴 ≥ 3 天**才可評（`companion_select_log` 查詢累積 duration_ms ≥ 259200000）
 - 同一 entity 對同一 companion 只能評 1 次（覆寫）
 
-### 3.11 POST `/api/companion/comment`
+### 3.9 POST `/api/companion/comment`
 
 ```json
 { "deviceId":"...", "botSecret":"...", "entityId":2, "companionId":"...", "text": "..." }
 ```
 
-**驗證**: text ≤ 500 chars, 非空, 通過 NSFW 自動過濾。
+**驗證**: text ≤ 500 chars, 非空, 通過 NSFW 自動過濾（既有 audit_log NSFW pipeline）。
 
-### 3.12 GET `/api/companion/comments/:id`
+### 3.10 GET `/api/companion/comments/:id`
 
 ```
 ?page=1&limit=20&sort=recent
 ```
 
-回傳留言列表（含創作者回覆）。
+回傳留言列表（含創作者一層回覆）。
 
-### 3.13 POST `/api/companion/submit`
+### 3.11 POST `/api/companion/submit`
 
 創作者提交伙伴到社群審核。
 
-**Multipart body**:
-- `petJson`: pet.json 內容（string）
-- `spritesheet`: webp 檔案
-- `spritesheetLite`: webp 檔案 (optional)
-- `spritesheetHires`: webp 檔案 (optional)
-- `thumbnail`: webp 縮圖（160x160）
+**Multipart body**（依 assetType 變化）：
+
+通用：
+- `descriptor`: CompanionDescriptor JSON（string）
+- `avatar`: PNG 256×256（optional override；缺則 backend 自動生成）
+
+assetType=`procedural`：
+- 不需另外檔案，描述參數寫在 descriptor.asset.params
+
+assetType=`spritesheet`：
+- `sheet`: webp 檔案 ≤ 600 KB
+
+assetType=`vector`：
+- v0.2 拒收，回 `400 unsupported_asset_type`
 
 **驗證**:
-- pet.json schema（§Petdx spec §2.4）
-- spritesheet ≤ 800 KB / lite ≤ 200 KB / hires ≤ 2 MB
-- pet.json `id` 全域唯一（含已存在草稿）
+- CompanionDescriptor schema（UIUX spec §2.4）
+- supportedStates 至少含 IDLE
 - author.entityId 必須等於 caller entityId
 - license 標記必填
+- 重複 hash 偵測（asset 檔案 SHA256）
 
 **處理**:
 1. 寫入 `/static/companions/<id>/`
@@ -272,11 +270,11 @@ celebrating/eating/alert 一次性 state 含 `expiresAt`，過期後 frontend �
 }
 ```
 
-### 3.14 POST `/api/companion/draft` / GET `/api/companion/drafts` / DELETE `/api/companion/draft/:id`
+### 3.12 POST `/api/companion/draft` / GET `/api/companion/drafts` / DELETE `/api/companion/draft/:id`
 
-草稿 CRUD。每 entity 最多 10 個草稿，存於 `device_vars.PETDX_DRAFT_<draftId>`。
+草稿 CRUD。每 entity 最多 10 個草稿，存於 `device_vars.PETDX_DRAFT_<draftId>`（不入 companions 表）。
 
-### 3.15 POST `/api/companion/review/:id`
+### 3.13 POST `/api/companion/review/:id`
 
 **Auth**: `deviceSecret`（device owner only），不接受 botSecret。
 
@@ -294,17 +292,44 @@ celebrating/eating/alert 一次性 state 含 `expiresAt`，過期後 frontend �
 **decision**: `approve` / `reject` / `request_changes`
 
 **處理**:
-- approve → status=`published`, 通知創作者
+- approve →
+  1. status=`published`
+  2. **若 descriptor.avatar.url 為空** → backend 跑 server-side render job 從 IDLE state 抽 1 frame → 寫 `/static/companions/<id>/avatar.png`，update `companions.avatar_url`
+  3. **同步生成 thumbnail.webp**（144×144，從 avatar.png down-scale）
+  4. 通知創作者 + 寫 audit log
 - reject → status=`rejected`, 30 天後自動清理
 - request_changes → status=`pending_changes`, 通知創作者修改
 
-### 3.16 GET `/api/companion/community`
+### 3.14 GET `/api/companion/community`
 
 ```
 ?author=<entityId>&page=1&limit=30&sort=popular
 ```
 
 社群已 published 伙伴清單，可依作者過濾。
+
+### 3.15 GET `/api/companion/:id/earnings`（NEW v0.2）
+
+創作者查自己作品的累積收益（per Q2 e 幣分潤）。
+
+**Auth**: botSecret + caller entityId 必須等於 companion.author_entity_id（不可看別人收益）
+
+**Query params**:
+- `since` / `until` — Unix ms，預設過去 30 天
+
+**Response 200**:
+```json
+{
+  "companionId": "petdx-orange-cat-001",
+  "totalEarnings": { "amount": 234, "currency": "ecoin" },
+  "selectCount": 234,
+  "uniqueSelectors": 87,
+  "byDay": [
+    { "date": "2026-05-09", "amount": 12, "selects": 12 },
+    { "date": "2026-05-08", "amount": 18, "selects": 18 }
+  ]
+}
+```
 
 ---
 
@@ -319,11 +344,12 @@ CREATE TABLE companions (
   version         TEXT NOT NULL DEFAULT '1.0.0',
   author_entity_id INTEGER,                              -- NULL = system built-in
   device_id       TEXT,                                  -- 創作者所屬 device
-  pet_json        TEXT NOT NULL,                         -- 完整 pet.json (JSON string)
-  spritesheet_url TEXT NOT NULL,
-  spritesheet_lite_url TEXT,
-  spritesheet_hires_url TEXT,
-  thumbnail_url   TEXT NOT NULL,
+  descriptor      TEXT NOT NULL,                         -- 完整 CompanionDescriptor (JSON string)
+  asset_type      TEXT NOT NULL,                         -- 'procedural' | 'spritesheet' | 'vector'
+  asset_url       TEXT,                                  -- spritesheet/vector 用；procedural 為 NULL
+  avatar_url      TEXT,                                  -- publish 時生成
+  thumbnail_url   TEXT,                                  -- publish 時生成
+  supported_states TEXT NOT NULL,                        -- JSON array, e.g. ["IDLE","BUSY","SLEEPING"]
   scope           TEXT NOT NULL DEFAULT 'community',    -- 'system' | 'community' | 'private'
   status          TEXT NOT NULL DEFAULT 'pending_review', -- 'pending_review' | 'published' | 'rejected' | 'hidden' | 'pending_changes'
   license         TEXT NOT NULL DEFAULT 'EClaw-default',
@@ -349,7 +375,15 @@ CREATE INDEX idx_companions_author ON companions(author_entity_id);
 CREATE INDEX idx_companions_scope_status ON companions(scope, status);
 CREATE INDEX idx_companions_popular ON companions(download_count DESC) WHERE status = 'published';
 CREATE INDEX idx_companions_recent ON companions(published_at DESC) WHERE status = 'published';
+CREATE INDEX idx_companions_asset_type ON companions(asset_type, status);
 ```
+
+**v0.1 → v0.2 schema 變更**：
+- `pet_json` → `descriptor`（命名一致化）
+- 新增 `asset_type`（取代 spritesheet_url/lite/hires 三欄）
+- `spritesheet_url/lite/hires` → 合併為單一 `asset_url`
+- 新增 `avatar_url`（publish 時生成）
+- 新增 `supported_states`（dynamic state list 索引用）
 
 ### 4.2 `companion_favorites`
 
@@ -400,7 +434,7 @@ CREATE INDEX idx_comments_companion ON companion_comments(companion_id, created_
 CREATE INDEX idx_comments_parent ON companion_comments(parent_id);
 ```
 
-### 4.5 `companion_select_log`（審計 + rating gate）
+### 4.5 `companion_select_log`（審計 + rating gate + 分潤計算）
 
 ```sql
 CREATE TABLE companion_select_log (
@@ -414,31 +448,36 @@ CREATE TABLE companion_select_log (
 
 CREATE INDEX idx_select_log_entity ON companion_select_log(entity_id, selected_at DESC);
 CREATE INDEX idx_select_log_companion ON companion_select_log(companion_id);
+CREATE INDEX idx_select_log_companion_date ON companion_select_log(companion_id, selected_at);
 ```
 
-### 4.6 `companion_state_events`（debug + state machine）
+### 4.6 `companion_earnings`（NEW v0.2）
 
 ```sql
-CREATE TABLE companion_state_events (
-  id            INTEGER PRIMARY KEY AUTOINCREMENT,
-  device_id     TEXT NOT NULL,
-  entity_id     INTEGER NOT NULL,
-  companion_id  TEXT NOT NULL,
-  event         TEXT NOT NULL,
-  previous_state TEXT,
-  new_state     TEXT NOT NULL,
-  context_json  TEXT,
-  created_at    INTEGER NOT NULL
+CREATE TABLE companion_earnings (
+  id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+  companion_id        TEXT NOT NULL REFERENCES companions(id) ON DELETE CASCADE,
+  creator_entity_id   INTEGER NOT NULL,                  -- companion 作者
+  selector_device_id  TEXT NOT NULL,                     -- 誰選了
+  selector_entity_id  INTEGER NOT NULL,
+  amount              INTEGER NOT NULL,                  -- e 幣量
+  currency            TEXT NOT NULL DEFAULT 'ecoin',
+  select_log_id       INTEGER REFERENCES companion_select_log(id),
+  awarded_at          INTEGER NOT NULL,
+  wallet_tx_id        TEXT                              -- Phase 4 wallet 對接時填
 );
 
-CREATE INDEX idx_state_events_entity ON companion_state_events(entity_id, created_at DESC);
+CREATE INDEX idx_earnings_creator ON companion_earnings(creator_entity_id, awarded_at DESC);
+CREATE INDEX idx_earnings_companion ON companion_earnings(companion_id, awarded_at DESC);
 ```
-
-僅保留 7 天，定期 cron purge。
 
 ### 4.7 `companion_drafts`
 
 不另建表，存於 `device_vars` 為 `PETDX_DRAFT_<draftId>`（隔離 per-device，不出現在社群索引）。
+
+### 4.8 ~~`companion_state_events`~~（v0.1 表，v0.2 移除）
+
+state event 不再持久化，需要 debug 時讀既有 `audit_log` 的 `companion.select` action 即可。
 
 ---
 
@@ -448,7 +487,8 @@ CREATE INDEX idx_state_events_entity ON companion_state_events(entity_id, create
 
 ```sql
 -- list with filters
-SELECT id, name, thumbnail_url, mood, color, tags,
+SELECT id, name, avatar_url, thumbnail_url, mood, color, tags,
+       asset_type, supported_states,
        download_count, favorite_count, rating_avg, rating_count,
        (SELECT 1 FROM companion_favorites WHERE device_id=? AND entity_id=? AND companion_id=companions.id) AS is_favorited
 FROM companions
@@ -457,6 +497,7 @@ WHERE status = 'published'
   AND (? = '' OR category = ?)
   AND (? = '' OR mood = ?)
   AND (? = '' OR color LIKE ?)
+  AND (? = '' OR asset_type = ?)
 ORDER BY download_count DESC
 LIMIT ? OFFSET ?;
 ```
@@ -484,12 +525,28 @@ CREATE VIRTUAL TABLE companions_fts USING fts5(
 
 複合 PK `(device_id, entity_id, companion_id)` 自動 unique。`companion_favorites` 寫入時 transaction 同時 increment `companions.favorite_count`。
 
-### 5.4 自動清理
+### 5.4 收益查詢
+
+`/api/companion/:id/earnings` 用 `idx_earnings_companion` partial index 命中：
+
+```sql
+SELECT date(awarded_at/1000, 'unixepoch') AS day,
+       SUM(amount) AS total,
+       COUNT(*) AS selects
+FROM companion_earnings
+WHERE companion_id = ?
+  AND awarded_at >= ?
+  AND awarded_at <= ?
+GROUP BY day
+ORDER BY day DESC;
+```
+
+### 5.5 自動清理
 
 cron 每日:
-- `companion_state_events` 保留 7 天
-- `companion_select_log` 保留 90 天
+- `companion_select_log` 保留 90 天（duration 計算用）
 - `status='rejected'` 滿 30 天的 companion 軟刪除
+- `companion_earnings` 永久保留（會計需求）
 
 ---
 
@@ -497,47 +554,52 @@ cron 每日:
 
 ### 6.1 `entity_cards.icon_url`
 
-POST `/api/companion/sync` 寫入 `entity_cards.icon_url`，但保留原有欄位 `icon_url_original` 作為 fallback。當伙伴被刪除時 restore original。
+POST `/api/companion/select` 寫入 `entity_cards.icon_url`，但保留原有欄位 `icon_url_original` 作為 fallback。當伙伴被刪除時 restore original。
 
 ### 6.2 WebSocket events
 
 新增 broadcast events:
 - `companion-selected` `{ deviceId, entityId, companionId, avatarUrl }`
-- `companion-state-changed` `{ deviceId, entityId, newState }`
 - `companion-published` `{ companionId, authorEntityId }`
 - `companion-rejected` `{ companionId, authorEntityId, reason }`
+
+**v0.1 移除**：~~`companion-state-changed`~~（state 改用既有 `/api/transform` 廣播）
 
 ### 6.3 `device_vars` keys
 
 | Key | 型別 | 用途 |
 |---|---|---|
 | `PETDX_CURRENT_<entityId>` | string (companionId) | 當前伙伴 |
-| `PETDX_AVATAR_CACHE_<entityId>` | string (data: URL) | 大頭照快取 |
+| `PETDX_AVATAR_<entityId>` | string (avatar.png url) | 大頭照 url（client 端快取） |
 | `PETDX_FAVORITES_<entityId>` | string (JSON array) | 收藏 mirror（DB 為主，這是 frontend cache） |
-| `PETDX_DRAFT_<draftId>` | string (pet.json) | 草稿 |
-| `PETDX_HIGH_QUALITY` | bool | 高品質模式 toggle |
+| `PETDX_DRAFT_<draftId>` | string (CompanionDescriptor) | 草稿 |
 | `PETDX_DISABLED` | bool | 完全停用伙伴系統 |
+| `PETDX_EARNINGS_RATE` | int | device-level e 幣率（device owner 可在 settings 改，預設 1） |
+
+**v0.1 移除**：~~`PETDX_AVATAR_CACHE_<entityId>`~~（base64 抽幀），~~`PETDX_HIGH_QUALITY`~~（Android 引擎自處理）。
 
 ### 6.4 i18n
 
 `/api/companion/list` response 不做 server-side i18n。Client 取 `i18n_data` JSON 後依 user locale 自選。
 
-新增 i18n keys 約 30 個，由 frontend 觸發在 portal/wallpaper-browser.html 與 portal/companion-creator.html。
+新增 i18n keys 約 25 個，由 frontend 觸發在設定頁伙伴瀏覽器與創作者工作台。
 
 ### 6.5 Rate limit
 
 | 端點 | 每 entity 每分鐘 |
 |---|---|
 | `/list` | 60 |
+| `/:id/states/help` | 60 |
 | `/select` | 30 |
-| `/state-event` | 600（高頻 OK） |
-| `/sync` | 30 |
 | `/submit` | 5 |
 | `/comment` | 10 |
 | `/rate` | 10 |
 | `/favorite` | 60 |
+| `/:id/earnings` | 30 |
 
 超出回 `429 rate_limit_exceeded`。
+
+**v0.1 移除**：~~`/state-event` 600/min~~（端點本身砍了），~~`/sync` 30/min~~（端點本身砍了）。
 
 ---
 
@@ -548,6 +610,7 @@ POST `/api/companion/sync` 寫入 `entity_cards.icon_url`，但保留原有欄�
 - 所有寫操作 `entity_id` 必須等於 caller entityId
 - 草稿 keys `PETDX_DRAFT_*` 跟著 device_vars 的多租戶隔離（per-bot 視野）
 - `submit` 強制 `author.entityId === entityId`（不可代提交）
+- `/:id/earnings` 強制 `caller entityId === companion.author_entity_id`
 
 ### 7.2 NSFW / 內容過濾
 
@@ -559,11 +622,12 @@ POST `/api/companion/sync` 寫入 `entity_cards.icon_url`，但保留原有欄�
 
 - submit per device 每天最多 5 個（防 spam）
 - comment per entity 每天最多 50 條
-- 同一 IP 不同 device 用相同 spritesheet hash → flag 重複偵測
+- 同一 IP 不同 device 用相同 asset hash → flag 重複偵測
+- **e 幣分潤防刷**：同一 selector entity 對同一 companion 24h 內只記 1 次（不論切換多少次）
 
 ### 7.4 License 與版權
 
-- pet.json `license` 欄位寫入 DB，published 時公開顯示
+- descriptor `license` 欄位寫入 DB，published 時公開顯示
 - DMCA take-down: device owner 介面 → `/api/companion/review/:id` decision=hide
 
 ---
@@ -573,21 +637,24 @@ POST `/api/companion/sync` 寫入 `entity_cards.icon_url`，但保留原有欄�
 ### 8.1 Metrics
 
 新增 Prometheus metrics：
-- `companion_select_total{device_id, scope}` counter
-- `companion_state_event_total{event, new_state}` counter
-- `companion_submit_total{status}` counter
+- `companion_select_total{device_id, scope, asset_type}` counter
+- `companion_submit_total{status, asset_type}` counter
 - `companion_active_unique` gauge（當下 5 分鐘內 select 過的 unique entity 數）
+- `companion_earnings_awarded_total{currency}` counter
+
+**v0.1 移除**：~~`companion_state_event_total`~~（端點砍了）
 
 ### 8.2 Logs
 
-每個 write 端點寫 audit log 到 `audit_log` table（既有），action_type 為 `companion.*`。
+每個 write 端點寫 audit log 到 `audit_log` table（既有），action_type 為 `companion.*`（包含 `companion.select` 取代 v0.1 state-event log）。
 
 ### 8.3 Dashboard
 
 新增 admin/dashboard.html 區塊：
 - 熱門 companion top 10
 - 當日 submit / approve / reject 數
-- spritesheet 總大小（用量警告）
+- asset 總大小（用量警告）
+- 當日 e 幣分潤總額
 
 ---
 
@@ -595,45 +662,50 @@ POST `/api/companion/sync` 寫入 `entity_cards.icon_url`，但保留原有欄�
 
 ```
 Phase 1 (本卡): Schema + DB migration + read endpoints
-  ├─ migrations/2026-05-XX-companion-schema.sql
-  ├─ backend/companion-api.js (list / get / current / states)
+  ├─ migrations/2026-05-XX-companion-schema-v0.2.sql
+  ├─ backend/companion-api.js (list / get / current / states/help)
   └─ unit tests
 
-Phase 2: Write endpoints
-  ├─ select / sync / state-event
-  ├─ favorite / rate / comment
-  └─ Frontend wallpaper-browser.html 串接
+Phase 2: Write endpoints + Android engine 串接
+  ├─ select / favorite / rate / comment
+  ├─ Android CompanionResolver + RenderRouter (UIUX spec §4.2)
+  └─ 設定頁伙伴瀏覽器串接
 
 Phase 3: 創作者工作台
-  ├─ submit / draft CRUD
-  └─ Frontend companion-creator.html
+  ├─ submit / draft CRUD / review
+  ├─ avatar.png 自動生成 server job
+  ├─ thumbnail.webp 自動生成
+  └─ Frontend creator UI（設定頁內）
 
-Phase 4: 社群與審核
-  ├─ review / community 端點
+Phase 4: 社群與審核 + 分潤
+  ├─ community 端點
   ├─ NSFW pipeline
-  └─ admin dashboard
-
-Phase 5: Wallet 對接（若 §11.Q3 啟用）
-  └─ 收益分潤接 wallet
+  ├─ companion_earnings 寫入 + earnings 查詢端點
+  ├─ admin dashboard
+  └─ Phase 4 wallet 對接（wallet_tx_id 填寫）
 ```
 
 每個 phase 對應一張 sub-card，本 spec 為 master design 文件。
 
 ---
 
-## 10. 開放問題（依賴 Petdx spec v0.1 §11）
+## 10. v0.2 變更摘要
 
-| # | 問題 | 對 API 的影響 |
-|---|---|---|
-| Q1 主軸取捨 | 若改為「大頭照同步為主」→ /sync 提升為主 endpoint，/state-event 退為配套 |
-| Q2 entity 視覺一致性 | 若強制一致 → /select 副作用包含 entity_card 直寫；可選一致 → 兩 path 並存 |
-| Q3 收益分潤 | 啟用 → 多 `companion_earnings` 表 + wallet 對接；關閉 → §3.13 submit 不寫入 earnings |
-| Q4 內建伙伴數量 | 影響 seed migration 大小，5 個或 10 個 |
-| Q5 9 狀態強制 | 強制 → schema 加 CHECK constraint；可選 → 由 client fallback |
-| Q7 審核強度 | 全自動 → 不需 /review；全人工 → /review 是必經 |
-| Q9 Live2D / Spine | 若加入 → schema 多 `format` 欄位（spritesheet/live2d/spine） |
+| 變更項 | v0.1 | v0.2 | 理由 |
+|---|---|---|---|
+| 端點數 | 18 | 14 (砍 4 加 2 新) | N3「沒用到的就砍」+ N4「help API」+ Q2「e 幣 earnings」 |
+| `state-event` 端點 | ✅ | ❌ | 既有 `/api/transform` `state` 欄位涵蓋 |
+| `sync` 端點 | ✅ | ❌ | avatar.png 在 publish 時自動生成 |
+| `states/:id` 端點 | ✅ (固定 9 state) | ❌ | 合併入 `/states/help`（dynamic） |
+| `states/help` 端點 | — | ✅ | N4 動態 state list |
+| `:id/earnings` 端點 | — | ✅ | Q2 e 幣分潤 |
+| asset_type 欄位 | spritesheet only | procedural / spritesheet / vector | UIUX §2.2 三種 asset path |
+| supportedStates 欄位 | hardcoded 9 | dynamic | Q5/N4 |
+| avatar 處理 | client-side 抽幀 + base64 cache | publish 時生成 PNG，client 讀 url | 簡化、減記憶體 |
+| companion_earnings 表 | 預留 | 必建 | Q2 預設啟用 |
+| companion_state_events 表 | ✅ | ❌ | 不再 persist event log |
 
-**v0.2 mapping**: Mac_F + Hank 確認後本 spec 升 v0.2，schema 與端點配套修。
+**v0.1 § 10 開放問題已封存**：所有 Q1-Q9 在 UIUX spec v0.2 §11 已解，本 spec schema 與端點配套修。
 
 ---
 
@@ -642,3 +714,4 @@ Phase 5: Wallet 對接（若 §11.Q3 啟用）
 | 版本 | 日期 | 作者 | 變更 |
 |---|---|---|---|
 | v0.1 | 2026-05-10 | LOBSTER #2 | 初版（依賴 Petdx UIUX spec v0.1，Mac_F silent 自繪）|
+| v0.2 | 2026-05-10 | LOBSTER #2 | 整合 UIUX v0.2 鎖定 Android 引擎增強：砍 4 端點 + 加 `/states/help` + `/earnings`、schema 改 dynamic state、avatar 改 publish-time PNG、新增 companion_earnings 表 |

--- a/docs/specs/petdx-uiux-spec.md
+++ b/docs/specs/petdx-uiux-spec.md
@@ -1,140 +1,137 @@
 # Petdx 伙伴系統 UIUX 規格書
 
-> **狀態**: v0.1 draft (2026-05-10) · **作者**: LOBSTER #2 · **依賴卡**: `card_060799205e328fde6d86d43b`
+> **狀態**: v0.2 (2026-05-10) · **作者**: LOBSTER #2 · **依賴卡**: `card_060799205e328fde6d86d43b`
 >
-> **Pending Mac_F #1 review**: 主軸取捨（動畫桌布 vs agent 大頭照同步）為 v0.1 假設，Mac_F 回覆後 v0.2 修訂。
+> **上一版**: v0.1 (2026-05-10) — Mac_F #1 silent fallback draft；本版整合 Hank 2026-05-10 web_chat Q-list 回應 (Q1/Q2/Q5 + N1–N5) 與 §1 線上編輯。
 >
-> **下游 gate**: 6 張 P2 impl 卡（Backend API / Frontend 動畫 / 瀏覽器 UI / E2E / 社群貢獻 / 創作者工作台）。
+> **範圍鎖定**: **Android App 既有動態桌布系統的增強**（沿用現有 `WallpaperService` + `ClawRenderer`），**不**重建 web portal 桌布頁面。Web portal 端僅保留「設定頁伙伴瀏覽器 + 創作者工作台」入口。
+>
+> **下游 gate**: 5 張 P2 impl 卡（v0.1 為 6 張，本版合併 Avatar 入 Frontend）。
 
 ---
 
 ## 1. 系統概覽
 
-Petdx 伙伴系統將 EClaw 的 entity（bot / user / agent）視覺化為「桌布伙伴」，每個伙伴是一張 spritesheet 動畫圖加上 metadata，可在三個位置同步呈現：
+Petdx 伙伴系統將 EClaw 的 entity（bot / user / agent）視覺化為「桌布伙伴」，每個伙伴是一組 CompanionDescriptor + 對應 asset，可在三個位置同步呈現：
 
-1. **動畫桌布**（主視覺）：portal 首頁背景與 chat 空白區，桌布伙伴依當前 entity 狀態播放動畫
-2. **agent 大頭照**：chat 對話列、kanban 卡片、entity card — 伙伴 idle frame 抽幀作為大頭照
-3. **伙伴瀏覽器**：portal/wallpaper-browser 頁面，使用者可瀏覽、搜尋、收藏、切換伙伴
+1. **動畫桌布**（主視覺）：使用現有 Android App 動態桌布系統
+2. **agent 大頭照**：chat 對話列、kanban 卡片、entity card — 伙伴 idle frame 固定大頭照
+3. **伙伴瀏覽器**：設定頁內入口，使用者可瀏覽、搜尋、收藏、切換伙伴（含社群貢獻），可預覽各狀態動作
 
-**主軸假設（待 Mac_F 確認）**: 「動畫桌布為主軸，大頭照同步是衍生」。理由：
-- 動畫桌布是新功能，亮點在 spritesheet + 9 狀態切換
-- 大頭照早已存在（entity card），同步只是把伙伴選擇 propagate 到既有 avatar slot
-- 創作者貢獻的價值在動畫質量（會動的伙伴）而非靜態頭像
-
-若 Mac_F 主張「大頭照同步為主軸」，§5 升至獨立模組，§4 退為配套。
+**主軸已鎖定**（Hank 2026-05-10）：「Android 桌布既有動畫的增強」。
+- §4 Android 引擎增強為 v0.2 主體
+- §5 大頭照同步是衍生（從伙伴 idle frame 取一張 PNG）
+- §3/§7 設定頁瀏覽器 + 創作者工作台是配套（瀏覽 / 搜尋 / 預覽 / 提交）
+- v0.1 假設的 web canvas 桌布 / 動畫管線 / WebView 渲染矩陣**全部下架**
 
 ### 1.1 名詞表
 
 | 名詞 | 定義 |
 |---|---|
-| 伙伴 / Companion | 一組 spritesheet + pet.json + metadata，代表一個視覺角色 |
-| spritesheet | 9 動畫狀態各 N 幀串成一張 webp |
-| 狀態 / state | 9 種角色行為（idle/working/sleeping/...）對應的動畫片段 |
-| 桌布伙伴 | 渲染在 portal 背景的伙伴實例 |
-| 同步大頭照 | 從當前伙伴 idle 狀態第一幀抽出的 avatar |
-| 創作者 | 上傳伙伴到社群的使用者 |
-| 社群伙伴 | 經審核公開的 community-contributed 伙伴 |
+| 伙伴 / Companion | 一組 CompanionDescriptor + asset，代表一個視覺角色 |
+| CompanionDescriptor | 描述伙伴 metadata + 支援的 state 列表 + 每 state 的 asset 路徑 |
+| asset | 伙伴的繪圖資源，依 `assetType` 分為 procedural / spritesheet / vector |
+| state | 角色行為（IDLE/BUSY/SLEEPING/...）對應的動畫片段，**每個伙伴自報支援哪些** |
+| 桌布伙伴 | Android `WallpaperService` 內渲染的伙伴實例 |
+| 同步大頭照 | 從當前伙伴 idle 狀態取一張固定 PNG 作為 avatar |
+| 創作者 | 透過設定頁工作台貢獻伙伴的使用者 |
+| 社群伙伴 | 經 device owner 審核公開的 community-contributed 伙伴 |
 
 ### 1.2 與既有系統的關係
 
 | 既有系統 | 關係 |
 |---|---|
-| Entity card (`/api/entity/agent-card`) | 大頭照欄位由伙伴 idle frame 覆寫 |
+| Android `WallpaperService` + `ClawRenderer` | **本 spec 主入口**；新增 CompanionDescriptor 解析層，既有 procedural 繪圖法是「Lobster 伙伴」的實作之一 |
+| Entity card (`/api/entity/agent-card`) | `iconUrl` 由伙伴 idle PNG snapshot 覆寫 |
 | Chat (`/api/chat/history`) | 對話列頭像同步當前伙伴 |
-| Kanban | 卡片 assignedBots 顯示伙伴頭像 |
-| Vault | 創作者收益（若啟用）寫入 device_vars |
-| Wallet (Phase 4 rebind) | 創作者收益分潤對接 wallet |
+| Kanban | 卡片 `assignedBots` 顯示伙伴頭像 |
+| Vault | 當前伙伴選擇 / avatar cache / 草稿存放 |
+| Wallet (Phase 4) | 創作者 e 幣分潤入帳 |
+
+### 1.3 不在 v0.2 範圍
+
+- Web portal 動畫桌布 canvas 渲染管線
+- iOS 原生 widget / WebView 桌布
+- Android home screen widget（另開 Phase 2 spec）
+- Live2D / Spine 動畫格式（asset type 預留欄位但 v0.2 不實作）
 
 ---
 
 ## 2. 伙伴資料模型
 
-### 2.1 pet.json schema
+### 2.1 CompanionDescriptor schema
 
 ```json
 {
-  "id": "petdx-orange-cat-001",
-  "name": "橘貓菲比",
+  "id": "petdx-lobster-default",
+  "name": "Lobster",
   "version": "1.0.0",
   "author": {
-    "entityId": 12,
-    "publicCode": "ab3xyz",
-    "displayName": "Hank"
+    "entityId": 0,
+    "publicCode": "system",
+    "displayName": "EClaw"
   },
-  "spritesheet": {
-    "url": "/static/companions/petdx-orange-cat-001/sheet.webp",
-    "frameWidth": 256,
-    "frameHeight": 256,
-    "rows": 9,
-    "stateLayout": ["idle", "working", "sleeping", "celebrating", "thinking", "eating", "playing", "sad", "alert"]
+  "assetType": "procedural",
+  "asset": {
+    "renderer": "lobster-procedural",
+    "params": {
+      "bodyColor": "#e63946",
+      "eyeStyle": "bead",
+      "antennaStyle": "double-curl"
+    }
   },
-  "states": {
-    "idle":        { "row": 0, "frames": 6,  "fps": 4,  "loop": true },
-    "working":     { "row": 1, "frames": 8,  "fps": 6,  "loop": true },
-    "sleeping":    { "row": 2, "frames": 4,  "fps": 2,  "loop": true },
-    "celebrating": { "row": 3, "frames": 12, "fps": 12, "loop": false },
-    "thinking":    { "row": 4, "frames": 6,  "fps": 4,  "loop": true },
-    "eating":      { "row": 5, "frames": 8,  "fps": 6,  "loop": true },
-    "playing":     { "row": 6, "frames": 10, "fps": 8,  "loop": true },
-    "sad":         { "row": 7, "frames": 6,  "fps": 3,  "loop": true },
-    "alert":       { "row": 8, "frames": 4,  "fps": 8,  "loop": true }
+  "supportedStates": ["IDLE", "BUSY", "EATING", "SLEEPING", "EXCITED"],
+  "stateAssets": {
+    "IDLE":     { "loop": true,  "fps": 4,  "hint": "default rest" },
+    "BUSY":     { "loop": true,  "fps": 6,  "hint": "working" },
+    "EATING":   { "loop": true,  "fps": 6,  "hint": "xp gain" },
+    "SLEEPING": { "loop": true,  "fps": 2,  "hint": "long idle" },
+    "EXCITED":  { "loop": false, "fps": 12, "hint": "card done / level up" }
+  },
+  "avatar": {
+    "url": "/static/companions/petdx-lobster-default/avatar.png",
+    "size": 256
   },
   "metadata": {
-    "tags": ["cat", "orange", "cute"],
-    "mood": "happy",
-    "color": "#ff8c42",
-    "category": "animal",
-    "description": "一隻每天賴床的橘貓",
+    "tags": ["mascot", "default"],
+    "color": "#e63946",
+    "category": "mascot",
+    "description": "EClaw 預設龍蝦伙伴",
     "createdAt": 1778345000000,
     "downloads": 0,
     "favorites": 0,
     "rating": null
   },
-  "license": "CC-BY-4.0",
+  "license": "EClaw-default",
   "i18n": {
-    "name": { "en": "Phoebe the Orange Cat", "zh-TW": "橘貓菲比", "ja": "ロボエの三毛ネコ" },
-    "description": { "en": "An orange cat that sleeps in every morning" }
+    "name": { "en": "Lobster", "zh-TW": "龍蝦", "ja": "ロブスター" },
+    "description": { "en": "Default lobster companion" }
   }
 }
 ```
 
-### 2.2 spritesheet.webp 規格
+### 2.2 assetType 三種路徑
 
-- **格式**: webp (lossy, q=85) · fallback png 8-bit
-- **解析度**: 每 frame 256×256（標準）/ 384×384（高品質）/ 128×128（行動裝置 lite）
-- **總尺寸上限**: 1024×9216 px (256×9 rows × 12 frames)
-- **檔案大小**: 標準版 ≤ 800 KB，lite ≤ 200 KB
-- **背景**: 透明 alpha channel
-- **frame 排列**: 由左至右、上至下，row 對應狀態，col 對應 frame index
+| assetType | 說明 | 引擎需要 |
+|---|---|---|
+| `procedural` | 引擎內建程序繪圖（既有 Lobster 屬於此類） | renderer key 對應 Android 內已寫好的 drawer 函式 |
+| `spritesheet` | webp/png 序列幀 | sheet url + 各 state 的 row/frame/fps |
+| `vector` | SVG + keyframe JSON（v0.2 預留，creator workshop MVP 不上） | svg url + keyframe url |
 
-範例 layout（256×256 frame，每 row 12 frames）:
+**v0.2 MVP** 只實作 `procedural` 與 `spritesheet`。`vector` 欄位 schema 預留但 backend reject。
 
-```
-row 0 (idle):        [f0][f1][f2][f3][f4][f5][--][--][--][--][--][--]   <- 6 frames used
-row 1 (working):     [f0][f1][f2][f3][f4][f5][f6][f7][--][--][--][--]   <- 8 frames
-row 2 (sleeping):    [f0][f1][f2][f3][--][--][--][--][--][--][--][--]   <- 4 frames
-... (rows 3-8)
-```
+### 2.3 動態 supportedStates（per N4 / Q5）
 
-### 2.3 9 狀態列舉與觸發規則
+伙伴**自報**支援哪些 state，沒有固定 9 個的限制。最低門檻：必須支援 `IDLE`。
 
-| state | 觸發條件 | 預設 fps | loop |
-|---|---|---|---|
-| `idle` | 預設、無事件 | 4 | yes |
-| `working` | entity state=ACTIVE / kanban card in_progress / chat 等待回應 | 6 | yes |
-| `sleeping` | entity 5min 無互動 / 凌晨時段 | 2 | yes |
-| `celebrating` | kanban card → done / PR merged / level up | 12 | no (一次性) |
-| `thinking` | entity state=PROCESSING / chat 訊息送出後 | 4 | yes |
-| `eating` | XP 增加 / earning 進帳 | 6 | yes |
-| `playing` | 使用者主動互動（點擊伙伴）| 8 | yes |
-| `sad` | error / 任務失敗 / wedge 偵測 | 3 | yes |
-| `alert` | nudge / push notification / mention | 8 | yes |
+| 場景 | supportedStates 範例 |
+|---|---|
+| Lobster 預設（既有引擎 5 state） | `["IDLE","BUSY","EATING","SLEEPING","EXCITED"]` |
+| 創作者極簡伙伴 | `["IDLE"]` |
+| 創作者豐富伙伴 | `["IDLE","BUSY","SLEEPING","EXCITED","SAD","ALERT","PLAYING","THINKING","CELEBRATING"]` |
+| 系統未來擴充 | 任意字串（PascalCase 或 SCREAMING_CASE） |
 
-**state 優先序**（同時觸發時取上層）:
-
-```
-celebrating > alert > sad > eating > playing > thinking > working > sleeping > idle
-```
+引擎收到 state 不在 `supportedStates` 時：靜默 fallback 到 `IDLE`，**不報錯**（per N4 「不要看起來不批配夥伴的樣貌就行」）。Agent 透過 §6.4 help API 主動查詢支援列表，避免送出無效 state。
 
 ### 2.4 必填 vs 選填
 
@@ -142,285 +139,327 @@ celebrating > alert > sad > eating > playing > thinking > working > sleeping > i
 |---|---|---|
 | id | ✅ | 唯一，kebab-case |
 | name | ✅ | i18n 預設 zh-TW |
-| spritesheet.url | ✅ | absolute or relative |
-| spritesheet.frameWidth/Height | ✅ |  |
-| states.idle | ✅ | 至少 idle 必填，其他狀態可省略並 fallback 到 idle |
-| metadata.tags | ⚪ | 至少 1 個 tag |
-| metadata.color | ⚪ | hex，影響瀏覽器分類過濾 |
-| author | ✅ | 系統內建伙伴 author.entityId=0 |
+| assetType | ✅ | `procedural` / `spritesheet` / `vector` |
+| asset | ✅ | schema 隨 assetType 變化 |
+| supportedStates | ✅ | 至少含 `IDLE` |
+| stateAssets.IDLE | ✅ | 其他 state 條件選填（in supportedStates 必填） |
+| avatar.url | ✅ | publish 時系統自動從 IDLE frame 生成；creator 也可上傳 override |
+| author | ✅ | 系統內建伙伴 `author.entityId=0` |
 | license | ⚪ | 預設 `EClaw-default` |
-| i18n | ⚪ |  |
+| i18n | ⚪ | |
 
 ---
 
-## 3. 伙伴瀏覽器 (Companion Browser)
+## 3. 伙伴瀏覽器（設定頁入口，per N2）
 
-進入點: `portal/wallpaper-browser.html`，從 settings 頁的「桌布伙伴」入口開啟。
+進入點：設定頁 → 「桌布伙伴」分組 → 「瀏覽伙伴」按鈕。
+**不再有 `portal/wallpaper-browser.html` 獨立頁**。
 
-### 3.1 佈局
+### 3.1 佈局（行動 / WebView 優先）
 
 ```
 ┌──────────────────────────────────────────────────────────┐
-│  [搜尋框........................]   [+ 創作我的伙伴]      │
+│  ← 返回設定        桌布伙伴瀏覽器        [+ 創作]         │
 ├──────────────────────────────────────────────────────────┤
-│  分類: [全部] [動物] [人物] [機器人] [自訂]               │
-│  心情: [全部] [開心] [忙碌] [愛睏] [淘氣]                 │
-│  顏色: [⚪][🔴][🟠][🟡][🟢][🔵][🟣]                       │
-│  排序: [熱門▼] [最新] [我的收藏]                          │
+│  [搜尋框........................]                         │
+│  分類: [全部] [動物] [人物] [機器人] [系統] [自訂]        │
+│  排序: [熱門▼] [最新] [我的收藏] [我的作品]               │
 ├──────────────────────────────────────────────────────────┤
-│  ┌─────┐ ┌─────┐ ┌─────┐ ┌─────┐ ┌─────┐ ┌─────┐         │
-│  │preview│ │preview│ │preview│ │preview│ │preview│ │preview│  <- 6 col grid
-│  │橘貓  │ │白兔  │ │機器人│ │獨角獸│ │柴犬  │ │企鵝  │         │
-│  │ 1.2k│ │ 856 │ │ 432 │ │ 312 │ │ 280 │ │ 210 │         │
-│  └─────┘ └─────┘ └─────┘ └─────┘ └─────┘ └─────┘         │
-│  ┌─────┐ ...                                              │
-│                                                            │
+│  ┌─────┐ ┌─────┐ ┌─────┐                                  │
+│  │preview│ │preview│ │preview│   <- 行動 3 col / 桌機 6 col │
+│  │橘貓  │ │白兔  │ │機器人│                                │
+│  │ 1.2k│ │ 856 │ │ 432 │                                  │
+│  └─────┘ └─────┘ └─────┘                                  │
+│  ...                                                       │
 │  [載入更多 ▼]                                              │
 └──────────────────────────────────────────────────────────┘
 ```
 
-### 3.2 grid item
+### 3.2 grid item 預覽動作
 
-每個 grid item 是 160×220 卡片：
+每個 grid item 是 144×200 卡片：
 
-- 上半部 160×160：**hover 時播放 idle 動畫**（4fps，~1.5s 循環），預設顯示 idle 第一幀
-- 下半部 160×60：name（粗體）、author 顯示名（小字灰色）、下載數 / 評分
-- **點擊 → 開啟詳情面板**，**雙擊 → 直接切換為當前伙伴**
-- 右上角 ❤ icon: 收藏狀態，點擊切換
+- 上半部 144×144：**靜態顯示 avatar.png**（idle frame snapshot）
+- 行動裝置長按 / 桌機 hover 1 秒 → **進入預覽模式**：在卡片內輪播該伙伴所有 supportedStates 各 1.5 秒
+- 下半部 144×56：name、author 顯示名、下載 / 評分
+- 點擊 → 詳情面板；長按詳情面板的「設為當前伙伴」 → 切換並退回設定頁
 
-### 3.3 詳情面板
+### 3.3 詳情面板（per N2 「預覽動作」）
 
-側邊抽屜（手機全螢幕、桌機 480 px 寬）:
+側邊抽屜（手機全螢幕、桌機 480 px 寬）：
 
-- 大預覽 320×320，**狀態切換器**（9 顆按鈕對應 9 狀態，點擊播放對應動畫）
+- 大預覽 320×320
+- **狀態切換器**：列出該伙伴的 `supportedStates`（動態，不是固定 9 顆按鈕；每顆按鈕點擊播放對應 state 動畫）
 - 名稱 / 作者 / 描述 / 標籤
-- 「設為桌布伙伴」（主按鈕）/「收藏」/「分享連結」
-- 統計：下載數、收藏數、評分（5 星）、留言數
+- 「設為當前伙伴」（主按鈕） / 「收藏」 / 「分享連結」
+- 統計：下載、收藏、評分（5 星）、留言
 - 留言區（前 3 條 + 載入更多）
 - 創作者其他作品（橫向 scroll，最多 6 個）
 
 ### 3.4 搜尋
 
-- **關鍵字**: 比對 name (i18n 全語系) + description + tags + author displayName
-- **debounce**: 300ms
-- **零結果**: 顯示「沒有相符伙伴 — 試試 [建議標籤 ×3]」
+- **關鍵字**：比對 name (i18n 全語系) + description + tags + author displayName
+- **debounce**: 300 ms
+- **零結果**：「沒有相符伙伴 — 試試 [建議標籤 ×3]」
 
 ### 3.5 響應式
 
 | 螢幕寬 | grid 欄數 | item 寬 | 篩選器 |
 |---|---|---|---|
-| ≥1280 | 6 | 160 | 全展開 |
-| 768–1279 | 4 | 160 | 全展開 |
-| 480–767 | 3 | 144 | 收合（icon 按鈕展開抽屜） |
-| <480 | 2 | 144 | 收合 |
+| ≥1280 (桌機) | 6 | 160 | 全展開 |
+| 768–1279 (平板) | 4 | 160 | 全展開 |
+| 480–767 (大手機) | 3 | 144 | 收合（icon 按鈕展開抽屜） |
+| <480 (小手機) | 2 | 144 | 收合 |
 
 ### 3.6 i18n 觸點
 
 - 所有 UI 字串透過 `data-i18n` + `backend/public/shared/i18n.js`
-- 伙伴 name/description 從 pet.json `i18n` 區塊讀取，fallback 到 default 值
-- 預期新增 i18n keys 約 30 個（瀏覽器 UI 25 + 詳情面板 5）
+- 伙伴 name/description 從 CompanionDescriptor `i18n` 區塊讀取，fallback 到 default
+- 預期新增 i18n keys 約 25 個
 
 ---
 
-## 4. 桌布伙伴渲染 (Wallpaper Companion)
+## 4. Android 動態桌布渲染（既有引擎增強）
 
-### 4.1 渲染目標
+**核心原則**：v0.2 是 enhancement，不是 rewrite。沿用 `app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt` + `engine/ClawRenderer.kt`，新增 CompanionDescriptor 解析層作為「素材路由」。
 
-桌布伙伴出現在以下位置（依優先序）:
-
-1. **portal 首頁背景**: 右下角浮動，z-index 5，不擋住主要內容
-2. **chat 空白區**: 對話歷史末尾右下角，z-index 10
-3. **kanban 看板背景**: 看板右下角，z-index 1（最淡）
-4. **行動裝置 home WebView**: 全螢幕背景，覆蓋整個視窗（解析度依裝置）
-
-### 4.2 尺寸與位置
-
-| 容器 | 預設尺寸 | 位置 | 偏移 |
-|---|---|---|---|
-| portal 首頁 | 192×192 | bottom-right | 32 px from edge |
-| chat 空白區 | 144×144 | bottom-right | 16 px |
-| kanban | 96×96 | bottom-right | 16 px (淡 30% 透明) |
-| 行動 home | 螢幕寬 × 螢幕寬（正方形） | center-bottom | safe-area + 24 px |
-
-### 4.3 渲染管線
+### 4.1 既有架構（保留）
 
 ```
-pet.json + spritesheet.webp
-         ↓
-   <canvas> drawImage(sheet, srcX, srcY, frameW, frameH, 0, 0, displayW, displayH)
-         ↓
-   每 1000/fps ms 切換到下一 frame
-         ↓
-   state 切換時：fade-out 200 ms → 換 row → fade-in 200 ms
+WallpaperService (ClawWallpaperService)
+    ↓ holds Engine
+WallpaperService.Engine (ClawEngine)
+    ↓ observes ClawStatusRepository (polling)
+    ↓ delegates draw to:
+ClawRenderer (Canvas procedural)
+    ├ drawLobsterAtPosition()       <- 既有，繪 Lobster 身體
+    ├ drawLobsterEyesForEntity()    <- 既有，繪眼睛 (lid 依 SLEEPING)
+    ├ drawMessageBubble()           <- 既有，bubble + emoji
+    ├ drawEntityBadge()             <- 既有，多 entity 標籤
+    └ drawMultiEntity()             <- 既有，多 entity layout
 ```
 
-**實作策略**:
-- 使用 `<canvas>` 而非 CSS `background-position`（GPU 加速、低記憶體）
-- 預載入 spritesheet（`<link rel="preload" as="image">`）
-- visibility: hidden 時暫停動畫（節省 CPU）
-- requestAnimationFrame 而非 setInterval（避免背景 tab 跑空轉）
+### 4.2 v0.2 新增：CompanionDescriptor 解析層
 
-### 4.4 過渡動畫
+```
+ClawEngine.onDraw()
+    ↓
+[NEW] CompanionResolver.getCurrent(entityId)
+    ↓
+CompanionDescriptor { assetType, asset, supportedStates, stateAssets }
+    ↓
+[NEW] CompanionRenderRouter.route(descriptor, currentState, canvas, position)
+    ├ assetType=procedural → ProceduralCompanionDrawer (既有 Lobster drawer 屬於此類)
+    ├ assetType=spritesheet → SpritesheetCompanionDrawer (新增)
+    └ assetType=vector → VectorCompanionDrawer (v0.2 reject, schema 預留)
+```
 
-- **fade**: 預設，state 切換時 200 ms opacity 0.3 → 1
-- **slide**: alert/celebrating 用，從容器外滑入
-- **bounce**: playing 用，scale 1 → 1.1 → 1（150 ms）
-- **none**: 強制無過渡（測試 / debug）
+**不變**：
+- `WallpaperService` lifecycle
+- `ClawStatusRepository` polling 邏輯
+- `drawMessageBubble`、`drawEntityBadge`、`drawMultiEntity` layout 程式碼
+- `bobOffset`（sleep stretches）等 state 視覺特效
 
-### 4.5 性能 & 記憶體
+**改動**：
+- `drawLobsterAtPosition` / `drawLobsterEyesForEntity` → 包進 `ProceduralCompanionDrawer.draw()`，by descriptor.asset.params 驅動 body color / eye style 等參數
+- `CharacterState` enum → 改為 `String` 型別（per N4 動態 state）
+- `getStateEmoji(state: String)` 從 hardcoded switch → 改查 descriptor.stateAssets[state].emoji（fallback 到 IDLE emoji 😐）
+
+### 4.3 procedural drawer (Lobster 為示範)
+
+`ProceduralCompanionDrawer` 是既有 Lobster 繪圖法的廣義化：
+
+```kotlin
+class ProceduralCompanionDrawer(
+    private val descriptor: CompanionDescriptor
+) : CompanionDrawer {
+    override fun draw(canvas: Canvas, state: String, position: PointF) {
+        val params = descriptor.asset.params
+        val bodyColor = parseColor(params["bodyColor"] as? String ?: "#e63946")
+        // ... 沿用既有 drawLobsterAtPosition 演算法，body color 從 params 取
+        // ... eye style / antenna style 等也從 params 取
+    }
+}
+```
+
+未來若有 procedural 的「貓伙伴」「兔伙伴」（不上傳 spritesheet 的低門檻創作），可在 Android 端新增對應 drawer key（`cat-procedural`、`bunny-procedural`），CompanionResolver 依 `asset.renderer` 路由。
+
+### 4.4 spritesheet drawer
+
+`SpritesheetCompanionDrawer` 用於社群上傳的 webp/png 序列幀：
+
+```kotlin
+class SpritesheetCompanionDrawer(
+    private val descriptor: CompanionDescriptor,
+    private val sheetBitmap: Bitmap
+) : CompanionDrawer {
+    override fun draw(canvas: Canvas, state: String, position: PointF) {
+        val stateAsset = descriptor.stateAssets[state] ?: descriptor.stateAssets["IDLE"]!!
+        val (srcX, srcY, frameW, frameH) = computeFrameRect(stateAsset, frameTick)
+        canvas.drawBitmap(sheetBitmap, srcRect, dstRect, paint)
+    }
+}
+```
+
+- sheet 在 CompanionResolver 載入時 decode → 快取在 LRU（最多 3 張，避免記憶體爆）
+- 未載入時 fallback 顯示 IDLE 靜態 avatar PNG
+
+### 4.5 多 entity 場景
+
+既有 `drawMultiEntity` 不變。每個 entity 獨立查 CompanionResolver → 各自 route 到對應 drawer。記憶體 budget：同時最多 3 張 spritesheet decode 在記憶體（其餘用靜態 avatar）。
+
+### 4.6 性能 & 記憶體（Android 引擎 baseline）
 
 | 指標 | 目標 |
 |---|---|
-| 初始載入 | spritesheet ≤ 800 KB，3G 下 ≤ 3 s |
-| FPS | 桌機 60 fps，行動 30 fps |
-| 記憶體 | <50 MB（單伙伴） |
-| CPU | idle 時 <2%，working 時 <5% |
-| 切換伙伴 | 老伙伴 unload → 新伙伴 load，總 <1 s |
+| 載入單一 procedural 伙伴 | <50 ms |
+| 載入單一 spritesheet 伙伴 | <300 ms（含 decode）|
+| FPS | 30 fps（Wallpaper service 標準）|
+| 記憶體上限 | <80 MB（含 3 張 spritesheet decode）|
+| spritesheet 檔案大小 | ≤ 600 KB |
+| state 切換延遲 | <100 ms |
 
-LOD 策略（distance-based 但實際是 viewport-size-based）:
-- viewport <480 px → 載入 lite spritesheet
-- viewport ≥ 480 → 載入 standard
-- 「高品質模式」開關（settings）→ 載入 hi-res
+### 4.7 LOD 與省電
+
+- 螢幕關閉 / 桌布不可見時暫停動畫（既有 `onVisibilityChanged` hook 即可）
+- 電量低於 15% 時自動降為 `IDLE` 靜態（不跑動畫，省電）
+- 「高品質模式」設定：spritesheet 滿幀；關閉時抽 1/2 幀
 
 ---
 
-## 5. Agent 大頭照同步
+## 5. Agent 大頭照（idle frame 固定，per N1 + Hank §1 編輯）
 
 ### 5.1 同步規則
 
-當前伙伴改變時，以下位置的 avatar 自動更新:
+當前伙伴改變時，以下位置的 avatar 自動更新（per N1 「要可替換 Lobster 整體」）：
 
 1. `entity_card.iconUrl` — entity card 主頭像
-2. chat header 對話列頭像
+2. chat 對話列頭像
 3. kanban card `assignedBots[].avatar`
 4. plaza / arena ranking 頭像
 5. mention 預覽卡頭像
 
-### 5.2 抽幀邏輯
+### 5.2 idle frame 固定 PNG（不再每次抽幀）
 
-從伙伴 spritesheet 抽出 `idle` 狀態 frame 0 作為 avatar:
+每個 published 伙伴在送審通過時，由 backend **一次性生成 avatar.png**：
 
-```js
-// pseudo
-const sheet = await loadImage(pet.spritesheet.url);
-const frame = pet.states.idle;
-const canvas = document.createElement('canvas');
-canvas.width = canvas.height = 256;
-canvas.getContext('2d').drawImage(
-  sheet,
-  0,  // srcX = frame 0
-  frame.row * pet.spritesheet.frameHeight,  // srcY
-  pet.spritesheet.frameWidth, pet.spritesheet.frameHeight,
-  0, 0, 256, 256
-);
-const avatarDataUrl = canvas.toDataURL('image/webp', 0.85);
-```
+- procedural 伙伴：backend 在虛擬 canvas 跑一次 IDLE frame 0 → 輸出 256×256 PNG
+- spritesheet 伙伴：backend 從 sheet 抽 IDLE row × frame 0 → 輸出 256×256 PNG
+- creator 也可上傳自製 avatar override（會覆寫自動生成）
 
-抽出的 avatar **快取在 device_vars** (`PETDX_AVATAR_CACHE_<entityId>`)，避免每次重抽。
+avatar.png 與 CompanionDescriptor 一起儲存在 `/static/companions/<id>/avatar.png`。
 
-### 5.3 多 entity 場景
+### 5.3 多 entity 持有
 
-若使用者切換為 bot #2 (LOBSTER) → 桌布伙伴 = LOBSTER 的伙伴；若切到 bot #1 (Mac_F) → 桌布伙伴 = Mac_F 的伙伴。每個 entity 獨立持有「當前伙伴」狀態（vault 內 `PETDX_CURRENT_<entityId>`）。
-
-對話介面同時顯示多個 entity 時（kanban / mention），每個 entity 顯示自己的伙伴 avatar。
+每個 entity 獨立持有「當前伙伴」狀態：vault 內 `PETDX_CURRENT_<entityId>=<companionId>`。
+對話介面同時顯示多個 entity 時（kanban / mention），每個 entity 顯示自己的伙伴 avatar.png。
 
 ### 5.4 同步延遲
 
-切換伙伴 → 大頭照同步預期 < 500 ms（含 cache 寫入）。失敗 fallback 到原 entity card icon。
+切換伙伴 → 大頭照同步預期 < 300 ms（avatar.png 是固定檔案，不需 client 端抽幀）。失敗 fallback 到原 entity card icon。
+
+### 5.5 客戶端快取
+
+vault 同時寫入 `PETDX_AVATAR_<entityId>=<avatar.png url>`，client 端優先從 vault 讀（避免每次 query CompanionDescriptor）。
 
 ---
 
-## 6. 狀態切換邏輯
+## 6. 狀態切換邏輯（動態 state list）
 
-### 6.1 state machine
+### 6.1 state 來源（與 v0.1 一致，新增 dynamic 支援）
 
-```
-                ┌────────┐
-   ┌─→ idle ──→│working │──→ celebrating ──┐
-   │           └────────┘                   │
-   │              ↑↓                        │
-   │           thinking                     │
-   │              ↑↓                        │
-   │            alert ←──── nudge / push    │
-   │              ↑                         │
-   │            sad ←────── error           │
-   │              ↑                         │
-   ↑          eating ←───── XP gain         │
-   │              ↑                         │
-   │           playing ←──── user click     │
-   │              ↓                         │
-   └────── sleeping ←──── 5min idle         │
-                  └─────────────────────────┘
-```
-
-### 6.2 觸發來源
-
-| 來源 | event 名稱 | 對應 state |
+| 來源 | event 名稱 | 預設對應 state |
 |---|---|---|
-| `/api/transform` `state` 欄位 | state-change | working / thinking / idle |
-| `/api/mission/card/*/move` | card-status | working (in_progress) / celebrating (done) |
-| WebSocket push (broadcast) | push | alert |
-| client-side mouse | click-pet | playing |
-| 5min 無 event | timeout | sleeping |
-| `/api/entity/level-up` | xp-gain | eating |
-| HTTP 5xx error | error | sad |
+| `/api/transform` `state` 欄位 | state-change | BUSY / IDLE 等 |
+| `/api/mission/card/*/move` | card-status | BUSY (in_progress) / EXCITED (done) |
+| WebSocket push (broadcast) | push | ALERT (若伙伴支援) |
+| client-side mouse | click-pet | PLAYING (若伙伴支援) |
+| 5 min 無 event | timeout | SLEEPING |
+| `/api/entity/level-up` | xp-gain | EATING |
+| HTTP 5xx error | error | SAD (若伙伴支援) |
 
-### 6.3 跨頁面持久化
+### 6.2 mismatch 處理（per N4）
 
-當前伙伴的 state 寫入 `localStorage.petdx_current_state` + 透過 `BroadcastChannel('petdx')` 同步多個 tab。WebView 內透過 `window.postMessage` 與 native 同步（行動裝置）。
+Agent 送出某個 state，但當前伙伴 `supportedStates` 不包含時：
 
-### 6.4 一次性動畫處理
+1. 渲染器靜默 fallback 到 IDLE
+2. 不回 4xx error
+3. 不寫 client-side console warn（避免訊號污染）
+4. backend `state-event` API 回 200 OK，body 含 `{ resolved: "IDLE", reason: "unsupported" }`（agent 想知道可選擇 log）
 
-`celebrating`、`eating`、`alert` 為 `loop:false` 一次性動畫。播放完成後 fallback 回 `idle`（或當前 state）。
+### 6.3 跨頁面持久化（既有，不變）
+
+- Android 端：當前 state 由 `ClawStatusRepository` polling 維護
+- WebView 內：透過 `window.postMessage` 與 native 同步
+- Web portal（設定頁瀏覽器）：localStorage 僅快取「當前伙伴 id」，不持久化 state
+
+### 6.4 Help API（per N4）
+
+```
+GET /api/companion/<companionId>/states/help
+→ {
+    "companionId": "petdx-lobster-default",
+    "supportedStates": ["IDLE","BUSY","EATING","SLEEPING","EXCITED"],
+    "stateAssets": { ... }  // 含 fps / loop / hint
+  }
+```
+
+Agent 在切換伙伴後**主動呼叫**此 API 一次，cache supportedStates，後續送 state-event 前先 local check。
+詳細 schema 見 Backend API spec §3.5。
+
+### 6.5 一次性動畫處理
+
+`stateAssets[state].loop = false` 為一次性動畫（如 EXCITED celebrate）。播放完成後 fallback 回 IDLE 或當前 baseline state（以 polling repository 為準）。
 
 ---
 
-## 7. 創作者工作台
+## 7. 創作者工作台（Android 內 + 設定頁）
 
-進入點: `portal/companion-creator.html`
+進入點：設定頁 → 「桌布伙伴」 → 「創作我的伙伴」。
+v0.2 MVP 在 web 設定頁實作，Android in-app 入口直接 deep-link 到 WebView。
 
 ### 7.1 主介面
 
 四個 tab：
 
-1. **設計器**: pet.json 表單 + 即時預覽
-2. **Spritesheet 工具**: 上傳、裁切、自動分幀
-3. **動畫預覽**: 9 狀態切換播放
-4. **發布**: 草稿管理、社群提交、創作統計
+1. **基本資訊**：CompanionDescriptor metadata 表單（name / description / tags / category / license）
+2. **assetType 選擇 + 上傳**：三選一引導
+3. **State 編輯**：勾選支援哪些 state，每個 state 設定 fps / loop / hint
+4. **預覽 + 發布**：即時預覽各 state、儲存草稿、送審
 
-### 7.2 設計器
+### 7.2 assetType 選擇
 
-左側表單（pet.json 各欄位），右側即時預覽 320×320。
+| assetType | UI 流程 |
+|---|---|
+| `procedural` | 顏色 picker + 形狀 preset 下拉（v0.2 MVP 只開 Lobster 變色）|
+| `spritesheet` | drag-drop webp/png + 標 frame 尺寸 + 自動分幀預覽 |
+| `vector` | (v0.2 disabled，UI 顯示「coming soon」) |
 
-- 表單分區：基本資訊 / spritesheet / states / metadata / i18n
-- 每個欄位即時驗證（紅框 + 訊息）
-- 「JSON 模式」toggle 切換為純 JSON 編輯（monaco editor）
-- 自動儲存到 `localStorage` + 「儲存草稿」按鈕寫到 device_vars
+### 7.3 spritesheet 工具
 
-### 7.3 Spritesheet 工具
+- **上傳**：drag-drop 或選檔
+- **裁切**：設定 frame 尺寸（預設 256×256）+ rows × cols + 起始偏移
+- **自動分幀**：抽取每 row 第 0 frame 顯示縮圖
+- **State mapping**：拖拉 state 到對應 row（state 列表動態，創作者選了哪些就顯示哪些）
 
-- **上傳**: drag-drop 或選檔（webp/png/gif）
-- **裁切**: 設定 frame 尺寸（預設 256×256）+ rows × cols + 起始偏移
-- **自動分幀**: 抽取每 row 第 0 frame 顯示縮圖
-- **狀態 mapping**: 拖拉 9 狀態到對應 row
-- **預覽**: 各狀態獨立播放，可調 fps
+### 7.4 預覽
 
-### 7.4 動畫預覽
-
-3×3 grid 顯示 9 狀態同時播放（可 hover 暫停 / 點擊單獨展開）。
+- 各狀態獨立播放，可調 fps
+- 「行動裝置 emulate」按鈕：模擬 Wallpaper service 240×240 顯示尺寸
+- 「Avatar 預覽」按鈕：顯示自動從 IDLE frame 0 抽出的 avatar.png
 
 ### 7.5 草稿與發布
 
-- **草稿**: device_vars `PETDX_DRAFT_<id>`，最多 10 個
-- **送審**: 提交後狀態為 `pending_review`
-- **公開**: 審核通過 → `published`
-- **更新**: 已公開伙伴可發新 version（v1.1.0），舊 user 自動 prompt 升級
+- **草稿**：device_vars `PETDX_DRAFT_<draftId>`，最多 10 個
+- **送審**：提交後狀態為 `pending_review`
+- **公開**：審核通過 → `published` + 系統自動生成 avatar.png
+- **更新**：已公開伙伴可發新 version（v1.1.0），舊 user 自動 prompt 升級
 
 ### 7.6 創作統計
 
 - 各伙伴下載數、收藏數、評分、留言
-- 收益面板（若啟用社群分潤）：累積 XP / wallet credit
-- 趨勢圖（30 天）
+- **e 幣收益面板**（per Q2）：累積使用次數 × 單次 e 幣率，趨勢圖（30 天）
+- 對接 wallet 後顯示已入帳 e 幣餘額
 
 ---
 
@@ -429,31 +468,31 @@ const avatarDataUrl = canvas.toDataURL('image/webp', 0.85);
 ### 8.1 提交流程
 
 ```
-創作者完成 pet.json + spritesheet
+創作者完成 CompanionDescriptor + asset
          ↓
     POST /api/companion/submit
          ↓
    pending_review 狀態
          ↓
   ┌──────────────────────┐
-  │ 審核（人 + 自動）       │
-  │  - 內容過濾（NSFW）    │
+  │ 審核（device owner）   │
+  │  - 內容過濾             │
   │  - 檔案大小 / 格式      │
   │  - 重複偵測              │
   │  - 版權檢查（license）  │
+  │  - assetType 安全檢查   │
   └──────────────────────┘
          ↓
-  通過 → published / 退回 → returned (附理由)
-         ↓
-  公開到瀏覽器，計入創作者統計
+  通過 → published + 系統生成 avatar.png + 計入創作者統計
+  退回 → returned (附理由)
 ```
 
 ### 8.2 審核機制
 
-- **自動**: 檔案規格、必填欄位、license 標記、重複 hash 比對
-- **人工**: device owner 或指定 reviewer entity 進行內容審核
-- **AI 輔助**: NSFW / 暴力 / 政治敏感分類器（可設閾值）
-- **快速通道**: 認證創作者（>5 個 published）skip 自動審查
+- **自動**：檔案規格、必填欄位、license 標記、重複 hash 比對、forbidden-script 檢查
+- **人工**：device owner 或指定 reviewer entity 進行內容審核
+- **AI 輔助**：NSFW / 暴力 / 政治敏感分類器（可設閾值）
+- **快速通道**：認證創作者（>5 個 published）skip 自動審查
 
 ### 8.3 評分與留言
 
@@ -462,12 +501,12 @@ const avatarDataUrl = canvas.toDataURL('image/webp', 0.85);
 - 創作者可回覆留言（一層）
 - 檢舉機制（騷擾 / 垃圾 / 不當內容）
 
-### 8.4 收益分潤（Phase 4 wallet 對接）
+### 8.4 e 幣分潤（per Q2）
 
-- 預設關閉；device owner 可在 settings 啟用
-- 啟用後，每次「設為當前伙伴」事件 → 創作者得 1 XP（或設定金額）
+- **預設啟用**：每次他人「設為當前伙伴」事件 → 創作者得 N e 幣
+- 單次 e 幣率 = device owner 在 settings 設定（預設 1 e 幣 / 切換）
 - 對接 wallet：使用者付費購買限定伙伴 → 70% 創作者 / 30% 平台
-- **本 spec 不定義具體金額**，待 Phase 4 wallet 規格確認
+- 詳細金額 / 上限 / 防刷規則待 Phase 4 wallet spec 確認
 
 ### 8.5 內容下架
 
@@ -479,109 +518,120 @@ const avatarDataUrl = canvas.toDataURL('image/webp', 0.85);
 
 ## 9. 跨平台相容性
 
-| 平台 | 桌布渲染 | 大頭照同步 | 瀏覽器 | 創作者工作台 |
-|---|---|---|---|---|
-| Web (Chrome/Safari) | ✅ canvas | ✅ | ✅ | ✅ |
-| Android WebView | ✅ canvas | ✅ | ✅ | ⚠️ 限基本功能 |
-| iOS WebView | ✅ canvas | ✅ | ✅ | ⚠️ 限基本功能 |
-| Android home screen widget | ✅ native (Phase 2) | ✅ | ❌ | ❌ |
-| iOS WidgetKit | ✅ native (Phase 2) | ✅ | ❌ | ❌ |
+| 平台 | Phase 1 (本 spec) | Phase 2+ (另開 spec) |
+|---|---|---|
+| Android App 動態桌布 | ✅ 主入口 | — |
+| Android WebView (設定頁) | ✅ 瀏覽器 + 創作者工作台 | — |
+| Web portal (設定頁) | ✅ 瀏覽器 + 創作者工作台 | — |
+| iOS App | — | iOS WidgetKit 桌布 |
+| Android home screen widget | — | 原生 widget |
+| Web portal 動畫桌布 (canvas 渲染) | ❌ 不在範圍 | 視需求另議 |
 
-**Phase 1**（本 spec 範圍）: 全部 WebView 為主，原生 widget 未涵蓋
-**Phase 2**: 原生 home screen widget（另開 spec）
+**v0.1 → v0.2 主要差異**：v0.1 的 Web canvas 渲染矩陣 / iOS WebView / Android WebView 桌布**全部下架**，本 spec 鎖定 Android 既有引擎增強。
 
 ---
 
 ## 10. 視覺規範
 
-### 10.1 色彩
+### 10.1 設定頁瀏覽器（web/WebView）
 
-依循既有 EClaw design token (`backend/public/shared/design-tokens.css`):
+依循既有 EClaw design token (`backend/public/shared/design-tokens.css`)：
 
 - 主色: `--color-primary` (orange)
 - 背景: `--color-bg-secondary`
 - 文字: `--color-text-primary` / `--color-text-muted`
 - 伙伴卡片陰影: `0 2px 8px rgba(0,0,0,0.06)`，hover `0 4px 16px rgba(0,0,0,0.12)`
 
-### 10.2 字型
+### 10.2 Android 動態桌布
 
-- 標題: `--font-display`（系統預設）
-- 內文: `--font-body`
-- 數字（下載數 / 評分）: `--font-mono`
+沿用 `ClawRenderer` 既有調色（背景漸層、bubble 顏色、emoji 字型大小）。
+新增 procedural 伙伴的調色透過 CompanionDescriptor.asset.params 傳入。
 
-### 10.3 間距
+### 10.3 字型與間距
 
 8 px grid。卡片內 padding 12，卡片間 gap 16。
+標題 `--font-display`、內文 `--font-body`、數字 `--font-mono`。
 
-### 10.4 動畫節奏
+### 10.4 動畫節奏（設定頁瀏覽器）
 
 - hover transition: 200 ms ease-out
-- state 切換 fade: 200 ms ease-in-out
-- celebrating bounce: cubic-bezier(0.34, 1.56, 0.64, 1)
-- 所有動畫 prefers-reduced-motion 時降為 fade 或關閉
+- state 預覽切換: 200 ms ease-in-out
+- 所有動畫 `prefers-reduced-motion` 時降為 fade 或關閉
 
 ### 10.5 icon
 
-從 EClaw existing icon set，缺項自製（lucide-react / hero-icons 風格）。
+從 EClaw existing icon set，缺項自製。
 
 ---
 
-## 11. 開放問題（待 Mac_F #1 / Hank 確認）
+## 11. Q-list 解決紀錄（封存）
 
-| # | 問題 | v0.1 假設 | 可選方案 |
+| # | 問題 | v0.1 假設 | v0.2 解 (Hank 2026-05-10) | 對應段落 |
+|---|---|---|---|---|
+| Q1 | 主軸取捨 | 動畫桌布為主、大頭照同步衍生 | **Android 桌布既有動畫的增強**（不重建 web portal） | §1, §4 |
+| Q2 | 創作者收益分潤 | 預設關閉，Phase 4 啟用 | **預設啟用 e 幣分潤**（透過貢獻 Android 桌布 API） | §8.4 |
+| Q3 | 是否與既有 entity 視覺一致 | 不要求 | （未變動，沿用 v0.1）| §2 |
+| Q4 | 系統內建伙伴數量 | 5 個 | （未變動，sysprep card 細化） | — |
+| Q5 | 9 狀態是否強制全有 | 只強制 idle | **不限制狀態種類數量**，每伙伴自報 supportedStates | §2.3, §6 |
+| Q6 | 行動 home 全螢幕桌布是否強制 | 可關閉 | （已不在範圍）| §1.3 |
+| Q7 | 社群審核強度 | 一律審核 + 認證快速通道 | （未變動）| §8.2 |
+| Q8 | spritesheet 上限 | 800 KB 標準 / 200 KB lite | **600 KB 單一檔案**（Android 引擎 baseline）| §4.6 |
+| Q9 | Live2D / Spine 支援 | 否 | （schema 預留 vector 但 v0.2 reject）| §2.2 |
+| Q10 | 9 狀態動畫的 default fps | 4-12 各狀態不同 | **由 stateAssets 各自定**（無統一預設）| §2.1 |
+| N1 | 大頭照可替換 Lobster 整體 | — | **同步全部 5 處 avatar slot** | §5.1 |
+| N2 | 設定裡建立伙伴搜尋頁面 | — | **設定頁入口**（不再 portal/wallpaper-browser.html） | §3 |
+| N3 | 沒用到的 API 砍 | — | **砍 v0.1 一半 endpoint**（state-event/avatar-sync 等） | Backend API spec §A |
+| N4 | 動態 state list + help API | — | **GET /companion/:id/states/help** | §6.4 |
+| N5 | E2E 驗證 avatar≠companion mismatch | — | **加入 E2E 卡 scope** | §12 |
+
+---
+
+## 12. 下游 impl 卡 mapping (v0.2)
+
+| Impl 卡 | v0.1 對應 | v0.2 改動 | 對應章節 |
 |---|---|---|---|
-| Q1 | 主軸取捨 | 動畫桌布為主、大頭照同步衍生 | 反過來 / 兩者並重 |
-| Q2 | 伙伴是否與既有 entity 視覺一致 | 不要求 — 伙伴是純美術角色，與 entity 是「使用者選擇」關係 | 強制 entity 自帶預設伙伴 |
-| Q3 | 創作者收益分潤 | 預設關閉，Phase 4 wallet 對接後啟用 | 一開始就上 XP-only 收益 |
-| Q4 | 系統內建伙伴數量 | 5 個（覆蓋常見 mood × color）| 1 個 / 10 個 |
-| Q5 | 9 狀態是否強制全有 | 只強制 idle，其他可省略 fallback | 全部強制 |
-| Q6 | 行動 home 全螢幕桌布是否強制 | 可關閉（settings 預設開）| 強制 / 預設關 |
-| Q7 | 社群審核強度 | 一律審核 + 認證快速通道 | 全自動（AI only）/ 全人工 |
-| Q8 | spritesheet 上限 | 800 KB 標準 / 200 KB lite | 可調 |
-| Q9 | 是否支援 Live2D / Spine | 否（v1 純 spritesheet）| Phase 2 加入 |
-| Q10 | 9 狀態動畫的 default fps | 4-12 各狀態不同 | 統一 8 |
+| [Backend] 伙伴系統 API | 全 18 endpoints | **砍半** (~9 endpoints) + 新增 `/states/help` | §2, §5.2, §6, §8 |
+| [Frontend] Android 引擎 CompanionDescriptor 接入 | 桌布伙伴動畫系統 (web canvas) | **改寫**：CompanionResolver + RenderRouter + Procedural/Spritesheet drawers | §4 |
+| [Avatar] 伙伴 idle PNG snapshot | (從前獨立卡？) | **合併**入 Frontend 卡作為 §5 子任務 | §5 |
+| [UI] 設定頁伙伴瀏覽器 + 創作者工作台 | 兩張卡（瀏覽器 + 創作者）| **合併**為一張：共用設定頁入口 | §3, §7 |
+| [API] 社群伙伴貢獻系統 | 同名 | （保留） | §8 |
+| [Test] Petdx E2E | 同名 | **加入 N5 verification**（avatar 與當前伙伴一致性檢查） | §3, §4, §5 |
+
+**子卡總數**：v0.1 6 張 → v0.2 5 張。
 
 ---
 
-## 12. 下游 impl 卡 mapping
+## 附錄 A — REST API 草案 v0.2（移轉到 Backend API spec）
 
-| Impl 卡 | 對應章節 |
-|---|---|
-| [Backend] 伙伴系統 API 設計 | §2 (data model), §5.2 (avatar cache), §6.2 (state events), §8 (community) |
-| [Frontend] 桌布伙伴動畫系統 | §4 (rendering), §6 (state machine) |
-| [UI] 伙伴瀏覽器與選擇器 | §3 (browser) |
-| [Test] Petdx E2E 測試 | §3, §4, §5 (跨平台 §9) |
-| [API] 社群伙伴貢獻系統 | §8 |
-| [UI] 伙伴創作者工作台 | §7 |
-
----
-
-## 附錄 A — REST API 草案（送 Backend 卡細化）
+詳細 endpoint 定義見 `petdx-backend-api-spec.md` v0.2。本附錄僅列入口：
 
 ```
-GET    /api/companion/list?category=&mood=&color=&q=&sort=&page=&limit=
+# 列表 / 選擇 / 當前
+GET    /api/companion/list
 GET    /api/companion/:id
-POST   /api/companion/select       { companionId }
-GET    /api/companion/current      → 當前 entity 的伙伴
-GET    /api/companion/states/:id   → 9 狀態定義
-POST   /api/companion/state-event  { event:'card-done'|'error'|'xp-gain'|... }
+POST   /api/companion/select
+GET    /api/companion/current
+GET    /api/companion/:id/states/help          # NEW v0.2
 
-POST   /api/companion/submit       (multipart: pet.json + sheet.webp)
-POST   /api/companion/draft        (儲存草稿)
+# 創作者
+POST   /api/companion/submit
+POST   /api/companion/draft
 GET    /api/companion/drafts
 DELETE /api/companion/draft/:id
-POST   /api/companion/review/:id   { decision:'approve'|'reject', reason }
+POST   /api/companion/review/:id
 
-POST   /api/companion/favorite     { companionId, on:true|false }
+# 社群
+POST   /api/companion/favorite
 GET    /api/companion/favorites
-POST   /api/companion/rate         { companionId, stars:1-5 }
-POST   /api/companion/comment      { companionId, text }
-
-POST   /api/companion/avatar-sync  { companionId } → 主動觸發抽幀並寫入 entity card
-GET    /api/companion/community?author=&page=
+POST   /api/companion/rate
+POST   /api/companion/comment
+GET    /api/companion/community
 ```
 
-所有端點 deviceId + botSecret + entityId 三件式 auth（與既有 `/api/transform` 一致）。
+**v0.1 → v0.2 砍掉**：
+- `POST /api/companion/state-event` （改用既有 `/api/transform` `state` 欄位）
+- `POST /api/companion/avatar-sync` （改為 publish 時自動生成 avatar.png）
+- `GET /api/companion/states/:id` （合併入 `/states/help`）
 
 ---
 
@@ -589,20 +639,24 @@ GET    /api/companion/community?author=&page=
 
 ```
 /static/companions/<id>/
-├── pet.json
-├── sheet.webp           # 標準
-├── sheet-lite.webp      # 行動裝置
-├── sheet-hires.webp     # 高品質
-├── thumbnail.webp       # 160×160 縮圖（grid 用）
-└── README.md            # 創作者選填
+├── descriptor.json        # CompanionDescriptor (取代 v0.1 pet.json)
+├── avatar.png             # idle frame snapshot, 256×256 (publish 時生成)
+├── thumbnail.webp         # 144×144 grid 用 (publish 時生成)
+└── asset/                 # asset 檔案 (依 assetType 變化)
+    ├── procedural-params.json     # assetType=procedural
+    ├── sheet.webp                  # assetType=spritesheet
+    └── vector.svg + keyframes.json # assetType=vector (v0.2 預留)
 ```
 
-device_vars keys:
+device_vars keys：
 - `PETDX_CURRENT_<entityId>` — 當前伙伴 id
-- `PETDX_AVATAR_CACHE_<entityId>` — base64 avatar (data: url)
+- `PETDX_AVATAR_<entityId>` — 當前伙伴 avatar.png url（client 端快取）
 - `PETDX_FAVORITES_<entityId>` — JSON array of companion ids
-- `PETDX_DRAFT_<draftId>` — 草稿 pet.json
-- `PETDX_HIGH_QUALITY` — boolean，是否載入 hi-res
+- `PETDX_DRAFT_<draftId>` — 草稿 CompanionDescriptor
+
+**v0.1 → v0.2 移除**：
+- `PETDX_AVATAR_CACHE_<entityId>` (base64 抽幀) — 改用固定 avatar.png url
+- `PETDX_HIGH_QUALITY` (是否載入 hi-res) — Android 引擎自己處理
 
 ---
 
@@ -611,3 +665,4 @@ device_vars keys:
 | 版本 | 日期 | 作者 | 變更 |
 |---|---|---|---|
 | v0.1 | 2026-05-10 | LOBSTER #2 | 初版（Mac_F #1 silent fallback draft）|
+| v0.2 | 2026-05-10 | LOBSTER #2 | 整合 Hank web_chat Q-list 回應：鎖定 Android 既有引擎增強 / 砍 web canvas 路徑 / 動態 state list + help API / e 幣分潤預設啟用 / Avatar 改 idle PNG snapshot / 設定頁入口 / 子卡 6→5 |


### PR DESCRIPTION
## Summary

Petdx 規格書 v0.2，整合 Hank 2026-05-10 web_chat 的 Q-list 回應 (Q1/Q2/Q5 + N1–N5) 與 §1 線上編輯。**範圍鎖定 Android App 既有動態桌布系統的增強**，下架 v0.1 的 web canvas 渲染管線。

## Why v0.2

Hank 在 channel chat 明確界定：「我只要 Android 桌布現有動畫的增強，而不是重新重建一個 web portal 的夥伴頁面」。v0.1 假設了 web canvas 為主軸，方向偏離。v0.2 把主軸鎖回既有 `WallpaperService` + `ClawRenderer`，新增 CompanionDescriptor 解析層做素材路由。

## UIUX 變更

| 項目 | v0.1 | v0.2 |
|---|---|---|
| 主軸 | Web canvas 桌布 | Android 既有引擎增強 |
| asset 模型 | spritesheet only (固定) | procedural / spritesheet / vector (動態) |
| 9 狀態 | 強制全有 (idle 必填) | 動態 supportedStates (idle 必填) |
| 大頭照 | client-side 抽幀 + base64 | publish 時生成 PNG，client 讀 url |
| 瀏覽器入口 | `portal/wallpaper-browser.html` | 設定頁內入口 |
| 創作者工作台 | 獨立頁 | 設定頁內入口 |
| 跨平台矩陣 | Web/Android/iOS WebView | Phase 1 only Android (其他另開 spec) |
| 收益分潤 | Phase 4 啟用 | **預設啟用 e 幣**（per Q2） |
| 子卡數 | 6 | 5 (Avatar 併 Frontend) |

## Backend API 變更

| 項目 | v0.1 | v0.2 |
|---|---|---|
| 端點數 | 18 | 14 |
| state-event | ✅ | ❌ (改用 `/api/transform` `state`) |
| sync | ✅ | ❌ (avatar.png publish 時生) |
| states/:id (固定) | ✅ | ❌ (合併入 `/states/help`) |
| **states/help** | — | ✅ NEW (動態 state list 查詢) |
| **:id/earnings** | — | ✅ NEW (e 幣分潤查詢) |
| companion_earnings 表 | 預留 | 必建 |
| companion_state_events 表 | ✅ | ❌ (改用 audit_log) |
| descriptor schema | pet_json + spritesheet_url/lite/hires | descriptor + asset_type + asset_url + avatar_url + supported_states |

## Q-list 解決一覽

| Hank 回應 | v0.2 落點 |
|---|---|
| Q1: Android 增強，不重建 web portal | UIUX §1, §4 |
| Q2: e 幣分潤透過貢獻 Android 桌布 API | API §3.4, §3.15, schema §4.6 |
| Q5: 不應限制狀態種類數量 | UIUX §2.3, API §3.3 |
| N1: 可替換 Lobster 整體 | UIUX §5.1 |
| N2: 設定頁建立伙伴搜尋 + 預覽動作 | UIUX §3 |
| N3: 沒用到的就砍 | API §2 (砍 4 端點) |
| N4: 動態 state list + help API | API §3.3 + UIUX §6.4 |
| N5: E2E 驗證 avatar≠companion mismatch | UIUX §12 (E2E 卡 scope) |

## Test plan

- [ ] 自審：兩份 spec markdown 渲染檢查（確認表格 + code block 不破版）
- [ ] Hank review：上傳到 R2 給 Hank 線上閱讀
- [ ] CI：i18n syntax check / ESLint / Critical portal pages 預期 pass（無 i18n.js 與 portal HTML 變更）
- [ ] 下游卡解 block：merge 後重新整理 5 張 P2 impl 卡 scope