### PR TITLE
feat(seo): SSR per-bot Plaza pages + dynamic community sitemap

### DIFF
--- a/backend/community-ssr.js
+++ b/backend/community-ssr.js
@@ -1,0 +1,180 @@
+// Server-side rendered Bot Plaza pages for SEO.
+// Crawler-friendly per-bot detail pages + dynamic sitemap.
+// Browsers and human users still get the full client-side experience via the
+// "Open in Plaza" CTA that links back to /portal/community.html?bot=<code>.
+
+const PUBLIC_CODE_RE = /^[a-z0-9]{4,12}$/i;
+
+function escapeHtml(s) {
+    if (s == null) return '';
+    return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function escapeJsonForScript(value) {
+    return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+function isValidPublicCode(code) {
+    return typeof code === 'string' && PUBLIC_CODE_RE.test(code);
+}
+
+function buildJsonLd(card, canonicalUrl) {
+    const tags = (card.agentCard && Array.isArray(card.agentCard.tags)) ? card.agentCard.tags : [];
+    const capabilities = (card.agentCard && Array.isArray(card.agentCard.capabilities)) ? card.agentCard.capabilities : [];
+    const description = (card.agentCard && card.agentCard.description) || `${card.name} — AI agent on EClawbot Bot Plaza.`;
+    return {
+        '@context': 'https://schema.org',
+        '@type': 'WebPage',
+        name: card.name,
+        description,
+        url: canonicalUrl,
+        primaryImageOfPage: 'https://eclawbot.com/assets/og-image.png',
+        about: {
+            '@type': 'SoftwareApplication',
+            name: card.name,
+            applicationCategory: 'AIApplication',
+            operatingSystem: 'Web',
+            description,
+            keywords: tags.concat(capabilities).join(', '),
+            offers: { '@type': 'Offer', price: '0', priceCurrency: 'USD' },
+            aggregateRating: card.ratingCount > 0 ? {
+                '@type': 'AggregateRating',
+                ratingValue: card.avgRating,
+                ratingCount: card.ratingCount
+            } : undefined
+        },
+        isPartOf: {
+            '@type': 'WebSite',
+            name: 'EClawbot',
+            url: 'https://eclawbot.com'
+        }
+    };
+}
+
+function renderBotPageHtml(card) {
+    const canonicalUrl = `https://eclawbot.com/community/${encodeURIComponent(card.publicCode)}`;
+    const liveUrl = `https://eclawbot.com/portal/community.html?bot=${encodeURIComponent(card.publicCode)}`;
+    const description = (card.agentCard && card.agentCard.description) || `${card.name} — AI agent on EClawbot Bot Plaza.`;
+    const tags = (card.agentCard && Array.isArray(card.agentCard.tags)) ? card.agentCard.tags : [];
+    const capabilities = (card.agentCard && Array.isArray(card.agentCard.capabilities)) ? card.agentCard.capabilities : [];
+    const protocols = (card.agentCard && Array.isArray(card.agentCard.protocols)) ? card.agentCard.protocols : [];
+    const title = `${card.name} — EClawbot Bot Plaza`;
+    const ldJson = escapeJsonForScript(buildJsonLd(card, canonicalUrl));
+    const tagChips = tags.map(t => `<li class="chip">${escapeHtml(t)}</li>`).join('');
+    const capChips = capabilities.map(c => `<li class="chip chip-cap">${escapeHtml(c)}</li>`).join('');
+    const protoChips = protocols.map(p => `<li class="chip chip-proto">${escapeHtml(p)}</li>`).join('');
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>${escapeHtml(title)}</title>
+<meta name="description" content="${escapeHtml(description)}">
+<link rel="canonical" href="${escapeHtml(canonicalUrl)}">
+<meta property="og:type" content="profile">
+<meta property="og:title" content="${escapeHtml(title)}">
+<meta property="og:description" content="${escapeHtml(description)}">
+<meta property="og:url" content="${escapeHtml(canonicalUrl)}">
+<meta property="og:site_name" content="EClawbot">
+<meta property="og:image" content="https://eclawbot.com/assets/og-image.png">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="${escapeHtml(title)}">
+<meta name="twitter:description" content="${escapeHtml(description)}">
+<meta name="twitter:image" content="https://eclawbot.com/assets/og-image.png">
+<script type="application/ld+json">${ldJson}</script>
+<style>
+:root{--bg:#0D0D1A;--card:#1A1A2E;--border:#333355;--text:#fff;--muted:#aaa;--primary:#6C63FF;--accent:#FFD23F}
+*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;line-height:1.5}
+a{color:var(--primary);text-decoration:none}a:hover{text-decoration:underline}
+.wrap{max-width:760px;margin:0 auto;padding:32px 20px}
+.crumb{font-size:13px;color:var(--muted);margin-bottom:18px}
+.hero{display:flex;gap:18px;align-items:center;background:var(--card);border:1px solid var(--border);border-radius:14px;padding:24px}
+.avatar{font-size:54px;width:84px;height:84px;display:flex;align-items:center;justify-content:center;background:#222244;border-radius:50%;flex-shrink:0}
+.title-block h1{margin:0 0 4px;font-size:26px}
+.title-block .role{color:var(--muted);font-size:14px}
+.meta-row{margin-top:8px;font-size:13px;color:var(--muted)}
+.meta-row span{margin-right:14px}
+.section{margin-top:28px}.section h2{font-size:17px;margin:0 0 10px;color:var(--accent)}
+.desc{background:var(--card);border:1px solid var(--border);border-radius:10px;padding:16px;color:#dcdcef}
+.chips{list-style:none;padding:0;margin:0;display:flex;flex-wrap:wrap;gap:8px}
+.chip{background:#252540;border:1px solid var(--border);border-radius:16px;padding:5px 12px;font-size:13px;color:#cfcfee}
+.chip-cap{border-color:#5a52e0;color:#cfcaff}.chip-proto{border-color:#4FC3F7;color:#bfe8ff}
+.cta{margin-top:32px;text-align:center}
+.cta a.btn{display:inline-block;background:var(--primary);color:#fff;padding:12px 28px;border-radius:24px;font-weight:600;font-size:15px}
+.cta a.btn:hover{background:#5A52E0;text-decoration:none}
+.foot{margin-top:40px;padding-top:18px;border-top:1px solid var(--border);font-size:12px;color:var(--muted);text-align:center}
+.foot a{color:var(--muted)}
+</style>
+</head>
+<body>
+<main class="wrap">
+<nav class="crumb"><a href="/portal/community.html">EClawbot Bot Plaza</a> &rsaquo; ${escapeHtml(card.name)}</nav>
+<header class="hero">
+<div class="avatar" aria-hidden="true">${escapeHtml(card.avatar || '🤖')}</div>
+<div class="title-block">
+<h1>${escapeHtml(card.name)}</h1>
+<div class="role">${escapeHtml(card.character || 'AI Agent')}</div>
+<div class="meta-row">
+<span>Lv.${escapeHtml(card.level)}</span>
+<span>${escapeHtml(card.messageCount)} messages</span>
+${card.ratingCount > 0 ? `<span>★ ${escapeHtml(card.avgRating.toFixed(1))} (${escapeHtml(card.ratingCount)})</span>` : ''}
+</div>
+</div>
+</header>
+<section class="section">
+<h2>About</h2>
+<p class="desc">${escapeHtml(description)}</p>
+</section>
+${capabilities.length ? `<section class="section"><h2>Capabilities</h2><ul class="chips">${capChips}</ul></section>` : ''}
+${tags.length ? `<section class="section"><h2>Tags</h2><ul class="chips">${tagChips}</ul></section>` : ''}
+${protocols.length ? `<section class="section"><h2>Protocols</h2><ul class="chips">${protoChips}</ul></section>` : ''}
+<div class="cta">
+<a class="btn" href="${escapeHtml(liveUrl)}" rel="canonical-app">Open in Plaza</a>
+</div>
+<footer class="foot">
+<a href="/portal/community.html">Browse all bots</a> &middot; <a href="https://eclawbot.com/">EClawbot home</a>
+</footer>
+</main>
+</body>
+</html>`;
+}
+
+function renderNotFoundHtml(publicCode) {
+    const safeCode = escapeHtml(publicCode || '');
+    return `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"><title>Bot not found — EClawbot</title>
+<meta name="robots" content="noindex">
+<meta name="description" content="The requested bot was not found on EClawbot Bot Plaza.">
+<style>body{font-family:system-ui;background:#0D0D1A;color:#fff;text-align:center;padding:80px 20px}a{color:#6C63FF}</style>
+</head><body>
+<h1>Bot not found</h1>
+<p>No public bot with code <code>${safeCode}</code>.</p>
+<p><a href="/portal/community.html">Browse all bots &rarr;</a></p>
+</body></html>`;
+}
+
+function renderCommunitySitemapXml(bots) {
+    const today = new Date().toISOString().slice(0, 10);
+    const entries = bots.map(b => {
+        const code = encodeURIComponent(b.publicCode);
+        const lastmod = (b.publishedAt ? new Date(b.publishedAt) : new Date()).toISOString().slice(0, 10);
+        return `  <url><loc>https://eclawbot.com/community/${code}</loc><lastmod>${lastmod}</lastmod><changefreq>weekly</changefreq><priority>0.6</priority></url>`;
+    }).join('\n');
+    return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://eclawbot.com/portal/community.html</loc><lastmod>${today}</lastmod><changefreq>daily</changefreq><priority>0.8</priority></url>
+${entries}
+</urlset>`;
+}
+
+module.exports = {
+    renderBotPageHtml,
+    renderNotFoundHtml,
+    renderCommunitySitemapXml,
+    isValidPublicCode,
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -16,6 +16,7 @@ const telemetry = require('./device-telemetry');
 const sitePageviews = require('./site-pageviews');
 const feedbackModule = require('./device-feedback');
 const chatIntegrity = require('./chat-integrity');
+const communitySsr = require('./community-ssr');
 // JWT secret: fail-safe random per process if env var is missing (tokens signed in one process won't verify in another)
 const JWT_SECRET_FALLBACK = process.env.JWT_SECRET || require('crypto').randomBytes(32).toString('hex');
 
@@ -251,6 +252,31 @@ app.get('/sitemap.xml', (req, res) => {
 });
 app.get('/llms.txt', (req, res) => {
     res.type('text/plain').sendFile(path.join(__dirname, 'public/llms.txt'));
+});
+
+// SEO: per-bot SSR landing pages for individual public bots.
+// Crawlers get a fully rendered HTML page with title/meta/OG/JSON-LD; humans
+// follow the "Open in Plaza" CTA into the JS plaza for full interactivity.
+app.get('/community/:publicCode', async (req, res) => {
+    const { publicCode } = req.params;
+    if (!communitySsr.isValidPublicCode(publicCode)) {
+        return res.status(404).type('text/html').send(communitySsr.renderNotFoundHtml(publicCode));
+    }
+    const card = await db.getPublicCardDetail(publicCode);
+    if (!card) {
+        return res.status(404).type('text/html').send(communitySsr.renderNotFoundHtml(publicCode));
+    }
+    res.set('Cache-Control', 'public, max-age=300');
+    res.type('text/html').send(communitySsr.renderBotPageHtml(card));
+});
+
+// SEO: dynamic sitemap of every public bot, regenerated per request.
+// Cheap (single SELECT, capped at 500 rows) and lets crawlers discover bots
+// the moment they go public, without a build step.
+app.get('/community/sitemap.xml', async (req, res) => {
+    const bots = await db.searchPublicCards({ limit: 500, offset: 0, sort: 'newest' });
+    res.set('Cache-Control', 'public, max-age=600');
+    res.type('application/xml').send(communitySsr.renderCommunitySitemapXml(bots));
 });
 // Serve public assets (OG image, etc.) — cache aggressively to reduce egress
 app.use('/assets', express.static(path.join(__dirname, 'public/assets'), {

--- a/backend/public/robots.txt
+++ b/backend/public/robots.txt
@@ -38,3 +38,4 @@ Allow: /api/docs
 Allow: /.well-known/agent.json
 
 Sitemap: https://eclawbot.com/sitemap.xml
+Sitemap: https://eclawbot.com/community/sitemap.xml

--- a/backend/tests/jest/community-ssr.test.js
+++ b/backend/tests/jest/community-ssr.test.js
@@ -1,0 +1,128 @@
+/**
+ * Community SSR renderer contract — locks the SEO-critical bits so a future
+ * styling tweak can't silently strip <title>, JSON-LD, canonical, or escaping.
+ */
+
+const ssr = require('../../community-ssr');
+
+const SAMPLE = {
+    publicCode: '31tlkr',
+    name: 'Ｍac_ClaudeAce主管',
+    character: 'LOBSTER',
+    avatar: '🦸',
+    agentCard: {
+        tags: ['eclaw', 'commander', 'automation'],
+        capabilities: ['orchestration', 'backend-dev'],
+        protocols: ['A2A', 'HTTP'],
+        description: 'EClaw 總指揮 Claude Code',
+    },
+    avgRating: 4.5,
+    ratingCount: 12,
+    messageCount: 87,
+    publishedAt: '2026-04-25T05:46:43.886Z',
+    level: 30,
+    xp: 89380,
+    state: 'IDLE',
+};
+
+describe('community-ssr.isValidPublicCode', () => {
+    it('accepts 6-char alphanumeric codes', () => {
+        expect(ssr.isValidPublicCode('31tlkr')).toBe(true);
+        expect(ssr.isValidPublicCode('AbCd12')).toBe(true);
+    });
+    it('rejects bad shapes', () => {
+        expect(ssr.isValidPublicCode('abc')).toBe(false);          // too short
+        expect(ssr.isValidPublicCode('a'.repeat(20))).toBe(false); // too long
+        expect(ssr.isValidPublicCode('has space')).toBe(false);
+        expect(ssr.isValidPublicCode('drop;table')).toBe(false);
+        expect(ssr.isValidPublicCode(null)).toBe(false);
+        expect(ssr.isValidPublicCode(undefined)).toBe(false);
+    });
+});
+
+describe('community-ssr.renderBotPageHtml', () => {
+    const html = ssr.renderBotPageHtml(SAMPLE);
+
+    it('emits <title> with bot name', () => {
+        expect(html).toContain('<title>Ｍac_ClaudeAce主管 — EClawbot Bot Plaza</title>');
+    });
+    it('emits canonical link to /community/<code>', () => {
+        expect(html).toContain('<link rel="canonical" href="https://eclawbot.com/community/31tlkr">');
+    });
+    it('emits Open Graph tags', () => {
+        expect(html).toContain('property="og:title"');
+        expect(html).toContain('property="og:url" content="https://eclawbot.com/community/31tlkr"');
+    });
+    it('emits a JSON-LD block with name + description', () => {
+        const jsonLd = html.match(/<script type="application\/ld\+json">([\s\S]+?)<\/script>/);
+        expect(jsonLd).toBeTruthy();
+        const data = JSON.parse(jsonLd[1]);
+        expect(data['@type']).toBe('WebPage');
+        expect(data.name).toBe('Ｍac_ClaudeAce主管');
+        expect(data.about.aggregateRating.ratingValue).toBe(4.5);
+    });
+    it('renders capabilities and tags as chips', () => {
+        expect(html).toContain('orchestration');
+        expect(html).toContain('eclaw');
+        expect(html).toContain('A2A');
+    });
+    it('links the live plaza CTA with the bot code', () => {
+        expect(html).toContain('href="https://eclawbot.com/portal/community.html?bot=31tlkr"');
+    });
+});
+
+describe('community-ssr.renderBotPageHtml — escaping', () => {
+    it('escapes HTML in name and description', () => {
+        const card = {
+            ...SAMPLE,
+            name: '<script>alert(1)</script>',
+            agentCard: { ...SAMPLE.agentCard, description: 'A & B "quoted" </script>' },
+        };
+        const html = ssr.renderBotPageHtml(card);
+        expect(html).not.toContain('<script>alert(1)</script>');
+        expect(html).toContain('&lt;script&gt;alert(1)&lt;/script&gt;');
+        expect(html).toContain('A &amp; B &quot;quoted&quot; &lt;/script&gt;');
+    });
+    it('escapes </script> inside JSON-LD payload', () => {
+        const card = { ...SAMPLE, name: 'Bot</script><img src=x>' };
+        const html = ssr.renderBotPageHtml(card);
+        const ldBlock = html.match(/<script type="application\/ld\+json">([\s\S]+?)<\/script>/)[1];
+        expect(ldBlock).not.toContain('</script>');
+        expect(ldBlock).toContain('\\u003c/script');
+    });
+    it('omits aggregateRating block when ratingCount is 0', () => {
+        const card = { ...SAMPLE, ratingCount: 0, avgRating: 0 };
+        const html = ssr.renderBotPageHtml(card);
+        const ld = JSON.parse(html.match(/<script type="application\/ld\+json">([\s\S]+?)<\/script>/)[1]);
+        expect(ld.about.aggregateRating).toBeUndefined();
+    });
+});
+
+describe('community-ssr.renderNotFoundHtml', () => {
+    it('returns a noindex 404 page that escapes the requested code', () => {
+        const html = ssr.renderNotFoundHtml('<bad>');
+        expect(html).toContain('<meta name="robots" content="noindex">');
+        expect(html).toContain('&lt;bad&gt;');
+        expect(html).not.toContain('<bad>');
+    });
+});
+
+describe('community-ssr.renderCommunitySitemapXml', () => {
+    it('includes the plaza root + a per-bot URL for each entry', () => {
+        const xml = ssr.renderCommunitySitemapXml([
+            { publicCode: 'aaa111', publishedAt: '2026-04-01T00:00:00Z' },
+            { publicCode: 'bbb222', publishedAt: '2026-05-09T00:00:00Z' },
+        ]);
+        expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+        expect(xml).toContain('<loc>https://eclawbot.com/portal/community.html</loc>');
+        expect(xml).toContain('<loc>https://eclawbot.com/community/aaa111</loc>');
+        expect(xml).toContain('<loc>https://eclawbot.com/community/bbb222</loc>');
+        expect(xml).toContain('<lastmod>2026-04-01</lastmod>');
+        expect(xml).toContain('<lastmod>2026-05-09</lastmod>');
+    });
+    it('handles empty bot list', () => {
+        const xml = ssr.renderCommunitySitemapXml([]);
+        expect(xml).toContain('<urlset');
+        expect(xml).toContain('<loc>https://eclawbot.com/portal/community.html</loc>');
+    });
+});


### PR DESCRIPTION
## Summary

Per-bot SSR landing pages so each public bot has a crawlable URL. The existing `/portal/community.html` plaza is client-rendered (loads bots via fetch), so individual bots have no anchor in the initial HTML — search engines see a "Loading…" placeholder and stop. This adds a server-rendered route alongside the JS plaza.

- `GET /community/:publicCode` — renders title / description / OG / Twitter Card / JSON-LD `WebPage` for one bot. Humans get an "Open in Plaza" CTA into the JS plaza for the full interactive view; crawlers index the static markup directly.
- `GET /community/sitemap.xml` — dynamic per-request sitemap of every public bot from `db.searchPublicCards` (capped at 500). No build step; new bots are discoverable as soon as they go public.
- `robots.txt` — declares the new sitemap so crawlers find it on first hit.
- 14 jest tests lock shape, HTML escaping, JSON-LD `</script>` guard (XSS), conditional `aggregateRating`, and sitemap output.

Phase B (full SSR for `/portal/community.html` itself or static prerendering) deliberately deferred — this PoC validates the pattern with the per-bot URL gap (the actual missing piece), without touching the existing plaza UI.

## Test plan

- [ ] `npx jest tests/jest/community-ssr.test.js` — 14/14 passing locally
- [ ] `node --check backend/index.js` — no syntax errors
- [ ] After Railway deploy: `curl -A 'curl/8.4.0' https://eclawbot.com/community/31tlkr` returns 200 with `<title>` containing bot name + JSON-LD block
- [ ] `curl https://eclawbot.com/community/sitemap.xml` returns valid XML with at least the LOBSTER entry
- [ ] `curl https://eclawbot.com/community/zzzzzz` returns 404 + `<meta name="robots" content="noindex">` for unknown codes
- [ ] `curl https://eclawbot.com/community/has%20space` returns 404 (input validation)
- [ ] Existing `/portal/community.html` and `/sitemap.xml` unchanged — backward compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)