### PR TITLE
fix(seo): swap /community route order so sitemap.xml resolves

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -254,6 +254,18 @@ app.get('/llms.txt', (req, res) => {
     res.type('text/plain').sendFile(path.join(__dirname, 'public/llms.txt'));
 });
 
+// SEO: dynamic sitemap of every public bot, regenerated per request.
+// Cheap (single SELECT, capped at 500 rows) and lets crawlers discover bots
+// the moment they go public, without a build step.
+// MUST be declared BEFORE /community/:publicCode — Express matches in
+// declaration order and `sitemap.xml` would otherwise be captured as a
+// (malformed) publicCode and 404 with the not-found page.
+app.get('/community/sitemap.xml', async (req, res) => {
+    const bots = await db.searchPublicCards({ limit: 500, offset: 0, sort: 'newest' });
+    res.set('Cache-Control', 'public, max-age=600');
+    res.type('application/xml').send(communitySsr.renderCommunitySitemapXml(bots));
+});
+
 // SEO: per-bot SSR landing pages for individual public bots.
 // Crawlers get a fully rendered HTML page with title/meta/OG/JSON-LD; humans
 // follow the "Open in Plaza" CTA into the JS plaza for full interactivity.
@@ -268,15 +280,6 @@ app.get('/community/:publicCode', async (req, res) => {
     }
     res.set('Cache-Control', 'public, max-age=300');
     res.type('text/html').send(communitySsr.renderBotPageHtml(card));
-});
-
-// SEO: dynamic sitemap of every public bot, regenerated per request.
-// Cheap (single SELECT, capped at 500 rows) and lets crawlers discover bots
-// the moment they go public, without a build step.
-app.get('/community/sitemap.xml', async (req, res) => {
-    const bots = await db.searchPublicCards({ limit: 500, offset: 0, sort: 'newest' });
-    res.set('Cache-Control', 'public, max-age=600');
-    res.type('application/xml').send(communitySsr.renderCommunitySitemapXml(bots));
 });
 // Serve public assets (OG image, etc.) — cache aggressively to reduce egress
 app.use('/assets', express.static(path.join(__dirname, 'public/assets'), {

--- a/backend/tests/jest/community-ssr.test.js
+++ b/backend/tests/jest/community-ssr.test.js
@@ -37,6 +37,26 @@ describe('community-ssr.isValidPublicCode', () => {
         expect(ssr.isValidPublicCode('drop;table')).toBe(false);
         expect(ssr.isValidPublicCode(null)).toBe(false);
         expect(ssr.isValidPublicCode(undefined)).toBe(false);
+        // Anything with a dot is rejected — also why the sitemap.xml route
+        // must be declared BEFORE /community/:publicCode in index.js.
+        expect(ssr.isValidPublicCode('sitemap.xml')).toBe(false);
+        expect(ssr.isValidPublicCode('robots.txt')).toBe(false);
+    });
+});
+
+describe('community-ssr route ordering (index.js)', () => {
+    it('declares /community/sitemap.xml before /community/:publicCode', () => {
+        // Regression: the original PR had the routes in the opposite order so
+        // GET /community/sitemap.xml fell into the publicCode handler and
+        // returned a 404 not-found page instead of the XML sitemap.
+        const fs = require('fs');
+        const path = require('path');
+        const src = fs.readFileSync(path.join(__dirname, '../../index.js'), 'utf8');
+        const sitemapIdx = src.indexOf("app.get('/community/sitemap.xml'");
+        const publicCodeIdx = src.indexOf("app.get('/community/:publicCode'");
+        expect(sitemapIdx).toBeGreaterThan(0);
+        expect(publicCodeIdx).toBeGreaterThan(0);
+        expect(sitemapIdx).toBeLessThan(publicCodeIdx);
     });
 });
 


### PR DESCRIPTION
## Summary

Hotfix for #2568. Express matches routes in declaration order; the original PR put `/community/:publicCode` before `/community/sitemap.xml`, so requests to the sitemap URL were captured as a (malformed) `publicCode`, failed `isValidPublicCode`, and returned the not-found HTML page instead of XML.

Self-curl verification right after Railway deploy caught it:

\`\`\`
curl https://eclawbot.com/community/sitemap.xml
→ HTTP 404
→ <h1>Bot not found</h1><p>No public bot with code <code>sitemap.xml</code></p>
\`\`\`

Fix: swap declaration order. Per-bot pages still work (verified `/community/31tlkr` returned 200 with title + JSON-LD).

Locked the order with a source-grep regression test so any future edit that re-introduces the bug fails CI.

## Test plan

- [x] `npx jest tests/jest/community-ssr.test.js` — 15/15 (was 14, +1 regression test)
- [ ] After deploy: `curl https://eclawbot.com/community/sitemap.xml` returns XML with `<urlset>` containing per-bot URLs
- [ ] `curl https://eclawbot.com/community/31tlkr` still returns 200 + bot page

🤖 Generated with [Claude Code](https://claude.com/claude-code)