### PR TITLE
feat(plaza): community.html auto-opens detail modal from ?bot=<publicCode>

### DIFF
--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -1287,11 +1287,22 @@
     // Auto-switch to rental tab if URL hash is #rental OR a tour requests it
     const _tourParam = new URLSearchParams(location.search).get('tour');
     const _tourStep = parseInt(new URLSearchParams(location.search).get('step') || '0', 10);
+
+    // Auto-open detail modal when ?bot=<publicCode> is present (SSR per-bot CTA target)
+    const _focusBotCode = new URLSearchParams(location.search).get('bot');
+    function autoFocusBotFromQuery() {
+        if (!_focusBotCode) return;
+        if (!/^[a-z0-9]{4,12}$/i.test(_focusBotCode)) return;
+        openDetail(_focusBotCode);
+    }
+
     if (location.hash === '#rental' || _tourParam === 'track1' || _tourParam === 'track2') {
         const rentalChip = document.querySelector('.plaza-chip[data-filter="rental"]');
         if (rentalChip) { setFilter('rental', rentalChip); } else { loadBots(); }
+        autoFocusBotFromQuery();
     } else {
         loadBots();
+        autoFocusBotFromQuery();
     }
 
     /* ══════ Onboarding Tour (Track 1: Free/Official Bot Rental) ══════ */

--- a/backend/tests/jest/community-bot-focus.test.js
+++ b/backend/tests/jest/community-bot-focus.test.js
@@ -1,0 +1,34 @@
+const fs = require('fs');
+const path = require('path');
+
+const COMMUNITY_HTML = path.join(__dirname, '../../public/portal/community.html');
+const COMMUNITY_SSR = path.join(__dirname, '../../community-ssr.js');
+
+describe('community.html ?bot=<publicCode> auto-focus', () => {
+    const html = fs.readFileSync(COMMUNITY_HTML, 'utf8');
+
+    test('reads bot param via URLSearchParams', () => {
+        expect(html).toMatch(/new URLSearchParams\(location\.search\)\.get\(['"]bot['"]\)/);
+    });
+
+    test('validates publicCode shape (4-12 alnum) before opening detail', () => {
+        expect(html).toMatch(/\/\^\[a-z0-9\]\{4,12\}\$\/i\.test\(_focusBotCode\)/);
+    });
+
+    test('calls openDetail with the focus code', () => {
+        expect(html).toMatch(/openDetail\(_focusBotCode\)/);
+    });
+
+    test('autoFocusBotFromQuery is invoked after entry-point branches', () => {
+        const matches = html.match(/autoFocusBotFromQuery\(\)/g) || [];
+        expect(matches.length).toBeGreaterThanOrEqual(2);
+    });
+});
+
+describe('community-ssr.js liveUrl bridges to ?bot=<publicCode>', () => {
+    const src = fs.readFileSync(COMMUNITY_SSR, 'utf8');
+
+    test('liveUrl points to community.html?bot=<encoded publicCode>', () => {
+        expect(src).toMatch(/community\.html\?bot=\$\{encodeURIComponent\(card\.publicCode\)\}/);
+    });
+});


### PR DESCRIPTION
## Summary
- Phase A.1 follow-up to #2568: makes the SSR→SPA bridge round-trip end-to-end.
- SSR per-bot pages already emit `Open in Plaza` CTAs pointing to `/portal/community.html?bot=<publicCode>`. Before this PR the SPA ignored the query param. Now it auto-opens the matching bot's detail modal on page boot.
- Validates publicCode shape with the same `^[a-z0-9]{4,12}$` regex as `community-ssr.js` to skip wasted `/api/community/card` calls on garbage input.

## Test plan
- [x] `npx jest tests/jest/community-bot-focus.test.js tests/jest/community-ssr.test.js` — 20/20 passing locally
- [ ] Post-deploy: open `https://eclawbot.com/portal/community.html?bot=<known publicCode>` and confirm the bot detail modal pops automatically over the bot grid
- [ ] Post-deploy: click `Open in Plaza` from any `https://eclawbot.com/community/<publicCode>` SSR page and confirm the same auto-open behavior end-to-end
- [ ] Negative: `?bot=` empty / `?bot=../etc` / `?bot=sitemap.xml` → no modal, no API call

🤖 Generated with [Claude Code](https://claude.com/claude-code)