### PR TITLE
feat(companion): /api/companion list + detail endpoints (Stage 1)

### DIFF
--- a/backend/companion-api.js
+++ b/backend/companion-api.js
@@ -1,0 +1,268 @@
+/**
+ * Companion API — Petdx 伙伴瀏覽器 / 社群伙伴貢獻系統
+ *
+ * Mounted at: /api/companion
+ *
+ * Spec: docs/specs/petdx-backend-api-spec.md (v0.2)
+ * Stage 1 (this file): read endpoints only — list + detail.
+ *   Stage 2: favorites + select + current
+ *   Stage 3: ratings + comments
+ *   Stage 4: submit + draft + review (creator + device-owner gated)
+ *
+ * Auth: deviceId + botSecret + entityId — same triple as /api/bot/*.
+ * The factory caller injects `authenticateBot(deviceId, entityId, botSecret)`
+ * so we don't reach into the global `devices` map directly.
+ */
+
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const { Pool } = require('pg');
+
+const pool = new Pool({
+    connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
+});
+
+const MAX_LIMIT = 100;
+const DEFAULT_LIMIT = 30;
+
+const ALLOWED_SORTS = new Set(['popular', 'recent', 'rating', 'favorites']);
+const ALLOWED_SCOPES = new Set(['all', 'system', 'community', 'mine']);
+const ALLOWED_ASSET_TYPES = new Set(['procedural', 'spritesheet', 'vector']);
+const ALLOWED_CATEGORIES = new Set(['animal', 'human', 'robot', 'mascot', 'custom']);
+
+function parsePositiveInt(value, fallback, max) {
+    const n = parseInt(value, 10);
+    if (!Number.isFinite(n) || n < 1) return fallback;
+    return max != null ? Math.min(n, max) : n;
+}
+
+function parseTags(raw) {
+    if (!raw) return [];
+    if (Array.isArray(raw)) return raw.map(String).filter(Boolean);
+    return String(raw).split(',').map(s => s.trim()).filter(Boolean).slice(0, 10);
+}
+
+function rowToCompanionCard(row) {
+    return {
+        id: row.id,
+        name: row.name,
+        version: row.version,
+        avatarUrl: row.avatar_url,
+        thumbnailUrl: row.thumbnail_url,
+        author: row.author_entity_id != null
+            ? { entityId: row.author_entity_id }
+            : null,
+        tags: row.tags || [],
+        mood: row.mood,
+        color: row.color,
+        category: row.category,
+        assetType: row.asset_type,
+        supportedStates: row.supported_states || ['IDLE'],
+        stats: {
+            downloads: row.download_count,
+            favorites: row.favorite_count,
+            rating: row.rating_avg,
+            ratingCount: row.rating_count,
+            commentCount: row.comment_count,
+        },
+        scope: row.scope,
+    };
+}
+
+function rowToCompanionDetail(row) {
+    return {
+        ...rowToCompanionCard(row),
+        descriptor: row.descriptor,
+        assetUrl: row.asset_url,
+        license: row.license,
+        i18nData: row.i18n_data,
+        publishedAt: row.published_at,
+        status: row.status,
+    };
+}
+
+async function initCompanionDatabase(serverLog = console.log) {
+    try {
+        const schemaPath = path.join(__dirname, 'companion_schema.sql');
+        const schema = fs.readFileSync(schemaPath, 'utf8');
+
+        const statements = [];
+        let current = '';
+        for (const line of schema.split('\n')) {
+            const trimmed = line.trim();
+            if (trimmed.startsWith('--')) continue;
+            current += line + '\n';
+            if (trimmed.endsWith(';')) {
+                const stmt = current.trim();
+                if (stmt && stmt !== ';') statements.push(stmt);
+                current = '';
+            }
+        }
+        if (current.trim()) statements.push(current.trim());
+
+        for (const statement of statements) {
+            try {
+                await pool.query(statement);
+            } catch (err) {
+                if (!err.message.includes('already exists') &&
+                    !err.message.includes('duplicate key')) {
+                    serverLog('warn', 'companion', `[Companion] Schema warning: ${err.message}`);
+                }
+            }
+        }
+        serverLog('info', 'companion', '[Companion] Schema initialized');
+    } catch (err) {
+        serverLog('error', 'companion', `[Companion] Schema init failed: ${err.message}`);
+    }
+}
+
+module.exports = function companionFactory({ authenticateBot, serverLog } = {}) {
+    if (typeof authenticateBot !== 'function') {
+        throw new Error('companionFactory requires authenticateBot');
+    }
+    const log = serverLog || (() => {});
+    const router = express.Router();
+
+    function authBot(req, res, next) {
+        const deviceId = req.query.deviceId || req.body?.deviceId;
+        const botSecret = req.query.botSecret || req.body?.botSecret;
+        const entityIdRaw = req.query.entityId || req.body?.entityId;
+        const entityId = parseInt(entityIdRaw, 10);
+
+        if (!deviceId || !botSecret || !Number.isFinite(entityId)) {
+            return res.status(400).json({ success: false, error: 'deviceId, botSecret, entityId required' });
+        }
+        if (!authenticateBot(deviceId, entityId, botSecret)) {
+            return res.status(401).json({ success: false, error: 'Invalid credentials' });
+        }
+        req.botAuth = { deviceId, botSecret, entityId };
+        next();
+    }
+
+    // ── GET /api/companion/list ───────────────────────────────────
+    // Query: category, mood, color, q, tags, sort, scope, assetType,
+    //        page, limit, author
+    router.get('/list', authBot, async (req, res) => {
+        const { category, mood, color, q, sort, scope, assetType, author } = req.query;
+        const tags = parseTags(req.query.tags);
+        const page = parsePositiveInt(req.query.page, 1);
+        const limit = parsePositiveInt(req.query.limit, DEFAULT_LIMIT, MAX_LIMIT);
+        const offset = (page - 1) * limit;
+
+        const sortKey = ALLOWED_SORTS.has(sort) ? sort : 'popular';
+        const scopeKey = ALLOWED_SCOPES.has(scope) ? scope : 'all';
+
+        if (assetType && !ALLOWED_ASSET_TYPES.has(assetType)) {
+            return res.status(400).json({ success: false, error: 'invalid_asset_type' });
+        }
+        if (category && !ALLOWED_CATEGORIES.has(category)) {
+            return res.status(400).json({ success: false, error: 'invalid_category' });
+        }
+
+        const conds = ["status = 'published'"];
+        const params = [];
+        // bind(value) → returns the next "$N" placeholder string
+        const bind = (val) => { params.push(val); return '$' + params.length; };
+
+        if (scopeKey === 'system')    conds.push("scope = 'system'");
+        if (scopeKey === 'community') conds.push("scope = 'community'");
+        if (scopeKey === 'mine') {
+            conds.push(`author_entity_id = ${bind(req.botAuth.entityId)}`);
+            conds.push(`device_id = ${bind(req.botAuth.deviceId)}`);
+        }
+        if (category)  conds.push(`category = ${bind(category)}`);
+        if (mood)      conds.push(`mood = ${bind(mood)}`);
+        if (color)     conds.push(`color = ${bind(color)}`);
+        if (assetType) conds.push(`asset_type = ${bind(assetType)}`);
+        if (author) {
+            const authorId = parseInt(author, 10);
+            if (Number.isFinite(authorId)) conds.push(`author_entity_id = ${bind(authorId)}`);
+        }
+        if (q) {
+            const term = '%' + String(q).replace(/[\\%_]/g, c => '\\' + c).slice(0, 80) + '%';
+            const p1 = bind(term);
+            const p2 = bind(term);
+            conds.push(`(name ILIKE ${p1} OR (descriptor->>'description') ILIKE ${p2})`);
+        }
+        if (tags.length) {
+            conds.push(`tags @> ${bind(JSON.stringify(tags))}::jsonb`);
+        }
+
+        const orderBy = {
+            popular:   'download_count DESC, published_at DESC',
+            recent:    'published_at DESC NULLS LAST',
+            rating:    'rating_avg DESC NULLS LAST, rating_count DESC',
+            favorites: 'favorite_count DESC, published_at DESC',
+        }[sortKey];
+
+        const where = conds.join(' AND ');
+        const listSql = `
+            SELECT id, name, version, author_entity_id, descriptor, asset_type, asset_url,
+                   avatar_url, thumbnail_url, supported_states, scope, status, license,
+                   category, mood, color, tags, i18n_data,
+                   download_count, favorite_count, rating_avg, rating_count, comment_count,
+                   published_at
+              FROM companions
+             WHERE ${where}
+             ORDER BY ${orderBy}
+             LIMIT $${params.length + 1} OFFSET $${params.length + 2}
+        `;
+        const countSql = `SELECT COUNT(*)::int AS total FROM companions WHERE ${where}`;
+
+        try {
+            const [listRes, countRes] = await Promise.all([
+                pool.query(listSql, [...params, limit, offset]),
+                pool.query(countSql, params),
+            ]);
+            res.json({
+                success: true,
+                page,
+                limit,
+                total: countRes.rows[0]?.total || 0,
+                companions: listRes.rows.map(rowToCompanionCard),
+            });
+        } catch (err) {
+            log('error', 'companion', `[Companion] list query failed: ${err.message}`);
+            res.status(500).json({ success: false, error: 'query_failed' });
+        }
+    });
+
+    // ── GET /api/companion/:id ────────────────────────────────────
+    router.get('/:id', authBot, async (req, res) => {
+        const { id } = req.params;
+        if (!/^[a-z0-9-]{1,80}$/i.test(id)) {
+            return res.status(400).json({ success: false, error: 'invalid_companion_id' });
+        }
+        try {
+            const r = await pool.query(
+                `SELECT id, name, version, author_entity_id, device_id, descriptor, asset_type,
+                        asset_url, avatar_url, thumbnail_url, supported_states, scope, status,
+                        license, category, mood, color, tags, i18n_data,
+                        download_count, favorite_count, rating_avg, rating_count, comment_count,
+                        published_at
+                   FROM companions
+                  WHERE id = $1`,
+                [id]
+            );
+            if (r.rowCount === 0) {
+                return res.status(404).json({ success: false, error: 'companion_not_found' });
+            }
+            const row = r.rows[0];
+            const isOwner = row.author_entity_id === req.botAuth.entityId
+                && row.device_id === req.botAuth.deviceId;
+            if (row.status !== 'published' && row.scope !== 'system' && !isOwner) {
+                return res.status(404).json({ success: false, error: 'companion_not_found' });
+            }
+            res.json({ success: true, companion: rowToCompanionDetail(row) });
+        } catch (err) {
+            log('error', 'companion', `[Companion] detail query failed: ${err.message}`);
+            res.status(500).json({ success: false, error: 'query_failed' });
+        }
+    });
+
+    return { router, initCompanionDatabase: () => initCompanionDatabase(log) };
+};
+
+module.exports.initCompanionDatabase = initCompanionDatabase;
+module.exports._test = { parseTags, parsePositiveInt, rowToCompanionCard, rowToCompanionDetail };

--- a/backend/companion_schema.sql
+++ b/backend/companion_schema.sql
@@ -1,0 +1,58 @@
+-- @brm-crossref: Petdx Companion (伙伴瀏覽器 + 社群伙伴貢獻系統)
+-- Spec: docs/specs/petdx-backend-api-spec.md (v0.2)
+-- Stage 1 (this file): companions main table only.
+-- Stage 2+ will add companion_favorites / companion_ratings / companion_comments
+-- / companion_select_log in follow-up PRs.
+-- ============================================
+
+-- ============================================
+-- companions — main catalog table
+-- ============================================
+-- Keys: id is the public companion identifier (e.g. "petdx-orange-cat-001").
+-- author_entity_id NULL = system built-in (no creator).
+-- descriptor stores the full CompanionDescriptor JSON; supported_states is
+-- denormalized as a JSON array on the row to keep /states/help cheap.
+-- scope+status compound index covers the common community list query
+-- (scope='community' AND status='published') with cheap ORDER BY tie-breaks.
+
+CREATE TABLE IF NOT EXISTS companions (
+    id               TEXT PRIMARY KEY,
+    name             TEXT NOT NULL,
+    version          TEXT NOT NULL DEFAULT '1.0.0',
+    author_entity_id INTEGER,
+    device_id        TEXT,
+    descriptor       JSONB NOT NULL,
+    asset_type       TEXT NOT NULL CHECK (asset_type IN ('procedural','spritesheet','vector')),
+    asset_url        TEXT,
+    avatar_url       TEXT,
+    thumbnail_url    TEXT,
+    supported_states JSONB NOT NULL DEFAULT '["IDLE"]'::jsonb,
+    scope            TEXT NOT NULL DEFAULT 'community'
+                       CHECK (scope IN ('system','community','private')),
+    status           TEXT NOT NULL DEFAULT 'pending_review'
+                       CHECK (status IN ('pending_review','published','rejected','hidden','pending_changes')),
+    license          TEXT NOT NULL DEFAULT 'EClaw-default',
+    category         TEXT,
+    mood             TEXT,
+    color            TEXT,
+    tags             JSONB NOT NULL DEFAULT '[]'::jsonb,
+    i18n_data        JSONB,
+    download_count   INTEGER NOT NULL DEFAULT 0 CHECK (download_count >= 0),
+    favorite_count   INTEGER NOT NULL DEFAULT 0 CHECK (favorite_count >= 0),
+    rating_avg       REAL,
+    rating_count     INTEGER NOT NULL DEFAULT 0 CHECK (rating_count >= 0),
+    comment_count    INTEGER NOT NULL DEFAULT 0 CHECK (comment_count >= 0),
+    created_at       BIGINT NOT NULL,
+    updated_at       BIGINT NOT NULL,
+    published_at     BIGINT,
+    rejected_at      BIGINT,
+    reject_reason    TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_companions_status        ON companions(status);
+CREATE INDEX IF NOT EXISTS idx_companions_author        ON companions(author_entity_id);
+CREATE INDEX IF NOT EXISTS idx_companions_scope_status  ON companions(scope, status);
+CREATE INDEX IF NOT EXISTS idx_companions_popular       ON companions(download_count DESC) WHERE status = 'published';
+CREATE INDEX IF NOT EXISTS idx_companions_recent        ON companions(published_at DESC)   WHERE status = 'published';
+CREATE INDEX IF NOT EXISTS idx_companions_asset_type    ON companions(asset_type, status);
+CREATE INDEX IF NOT EXISTS idx_companions_tags          ON companions USING GIN (tags);

--- a/backend/index.js
+++ b/backend/index.js
@@ -2087,6 +2087,18 @@ const botTools = require('./bot-tools');
 app.use('/api/bot', botTools.router);
 
 // ============================================
+// COMPANION (Petdx 伙伴瀏覽器 / 社群伙伴貢獻系統)
+// ============================================
+const companionModule = require('./companion-api')({
+    authenticateBot,
+    serverLog,
+});
+app.use('/api/companion', companionModule.router);
+if (process.env.NODE_ENV !== 'test') {
+    setTimeout(() => companionModule.initCompanionDatabase(), 2500);
+}
+
+// ============================================
 // FILE UPLOAD SYSTEM (Cloudflare R2)
 // ============================================
 const filesModule = require('./files')(devices);

--- a/backend/tests/jest/companion-api.test.js
+++ b/backend/tests/jest/companion-api.test.js
@@ -1,0 +1,221 @@
+'use strict';
+
+/**
+ * Companion API Stage 1 — read endpoints unit tests.
+ *
+ * Covers:
+ *   - helper exports (parseTags / parsePositiveInt / row mappers)
+ *   - factory contract: requires authenticateBot, mounts /list + /:id
+ *   - 400 on missing creds, 401 on bad creds (auth middleware)
+ *   - input validation (invalid_asset_type, invalid_category, invalid_companion_id)
+ *   - happy-path query shape (mocked pg pool)
+ *
+ * pg is mocked module-wide so the require chain doesn't open a real connection
+ * when CI runs without DATABASE_URL.
+ */
+
+jest.mock('pg', () => {
+    const mockQuery = jest.fn();
+    const Pool = jest.fn().mockImplementation(() => ({
+        query: mockQuery,
+        end: jest.fn(),
+    }));
+    return { Pool, __mockQuery: mockQuery };
+});
+
+const express = require('express');
+const request = require('supertest');
+const { __mockQuery } = require('pg');
+const companionFactory = require('../../companion-api');
+
+const DEVICE = 'dev-test';
+const ENTITY = 7;
+const SECRET = 'good-secret';
+
+function makeApp({ authenticateBot } = {}) {
+    const app = express();
+    app.use(express.json());
+    const auth = authenticateBot || ((d, e, s) =>
+        d === DEVICE && e === ENTITY && s === SECRET);
+    const mod = companionFactory({ authenticateBot: auth });
+    app.use('/api/companion', mod.router);
+    return app;
+}
+
+describe('companion-api: helpers', () => {
+    const { parseTags, parsePositiveInt, rowToCompanionCard, rowToCompanionDetail } =
+        companionFactory._test;
+
+    test('parseTags splits comma list, trims, drops empties, caps at 10', () => {
+        expect(parseTags('cat, orange ,cute')).toEqual(['cat', 'orange', 'cute']);
+        expect(parseTags('')).toEqual([]);
+        expect(parseTags(undefined)).toEqual([]);
+        expect(parseTags(Array(20).fill('x'))).toHaveLength(20); // arrays not capped (already structured)
+        expect(parseTags(Array(20).fill('x').join(','))).toHaveLength(10);
+    });
+
+    test('parsePositiveInt clamps to fallback / max', () => {
+        expect(parsePositiveInt('5', 1)).toBe(5);
+        expect(parsePositiveInt('-1', 1)).toBe(1);
+        expect(parsePositiveInt('abc', 30, 100)).toBe(30);
+        expect(parsePositiveInt('500', 30, 100)).toBe(100);
+    });
+
+    test('rowToCompanionCard projects expected fields', () => {
+        const row = {
+            id: 'petdx-x', name: 'X', version: '1.0.0', author_entity_id: 12,
+            avatar_url: '/a.png', thumbnail_url: '/t.webp', tags: ['k'],
+            mood: 'happy', color: '#fff', category: 'animal',
+            asset_type: 'spritesheet', supported_states: ['IDLE'],
+            download_count: 1, favorite_count: 2, rating_avg: 4.5,
+            rating_count: 3, comment_count: 4, scope: 'community',
+        };
+        const card = rowToCompanionCard(row);
+        expect(card.id).toBe('petdx-x');
+        expect(card.author).toEqual({ entityId: 12 });
+        expect(card.stats).toEqual({
+            downloads: 1, favorites: 2, rating: 4.5, ratingCount: 3, commentCount: 4,
+        });
+    });
+
+    test('rowToCompanionDetail extends card with descriptor fields', () => {
+        const row = {
+            id: 'petdx-x', name: 'X', version: '1.0.0', author_entity_id: null,
+            descriptor: { description: 'hi' }, asset_type: 'procedural',
+            supported_states: ['IDLE'], scope: 'system', status: 'published',
+            license: 'MIT', i18n_data: null, published_at: 1778000000000,
+            tags: [], download_count: 0, favorite_count: 0, rating_avg: null,
+            rating_count: 0, comment_count: 0,
+        };
+        const det = rowToCompanionDetail(row);
+        expect(det.descriptor).toEqual({ description: 'hi' });
+        expect(det.author).toBeNull();
+        expect(det.license).toBe('MIT');
+        expect(det.publishedAt).toBe(1778000000000);
+    });
+});
+
+describe('companion-api: factory contract', () => {
+    test('throws if authenticateBot missing', () => {
+        expect(() => companionFactory({})).toThrow(/authenticateBot/);
+    });
+
+    test('returns router + initCompanionDatabase', () => {
+        const m = companionFactory({ authenticateBot: () => true });
+        expect(typeof m.initCompanionDatabase).toBe('function');
+        expect(m.router).toBeDefined();
+    });
+});
+
+describe('companion-api: GET /list auth + validation', () => {
+    beforeEach(() => __mockQuery.mockReset());
+
+    test('400 when deviceId/botSecret/entityId missing', async () => {
+        const res = await request(makeApp()).get('/api/companion/list');
+        expect(res.status).toBe(400);
+        expect(res.body).toMatchObject({ success: false });
+    });
+
+    test('401 on bad creds', async () => {
+        const res = await request(makeApp())
+            .get('/api/companion/list')
+            .query({ deviceId: DEVICE, botSecret: 'wrong', entityId: ENTITY });
+        expect(res.status).toBe(401);
+    });
+
+    test('400 on invalid assetType', async () => {
+        const res = await request(makeApp())
+            .get('/api/companion/list')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY, assetType: 'rainbow' });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('invalid_asset_type');
+    });
+
+    test('200 returns paginated shape on empty result set', async () => {
+        __mockQuery
+            .mockResolvedValueOnce({ rows: [] })                     // list
+            .mockResolvedValueOnce({ rows: [{ total: 0 }] });        // count
+        const res = await request(makeApp())
+            .get('/api/companion/list')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY });
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({
+            success: true, page: 1, limit: 30, total: 0, companions: [],
+        });
+    });
+
+    test('mine scope binds entityId + deviceId in WHERE', async () => {
+        __mockQuery
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [{ total: 0 }] });
+        await request(makeApp())
+            .get('/api/companion/list')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY, scope: 'mine' });
+        const listCall = __mockQuery.mock.calls[0];
+        expect(listCall[0]).toMatch(/author_entity_id = \$\d/);
+        expect(listCall[0]).toMatch(/device_id = \$\d/);
+        expect(listCall[1]).toEqual(expect.arrayContaining([ENTITY, DEVICE]));
+    });
+});
+
+describe('companion-api: GET /:id', () => {
+    beforeEach(() => __mockQuery.mockReset());
+
+    test('400 on invalid id shape', async () => {
+        const res = await request(makeApp())
+            .get('/api/companion/has space')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('invalid_companion_id');
+    });
+
+    test('404 when not found', async () => {
+        __mockQuery.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+        const res = await request(makeApp())
+            .get('/api/companion/petdx-missing')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY });
+        expect(res.status).toBe(404);
+        expect(res.body.error).toBe('companion_not_found');
+    });
+
+    test('404 hides pending_review companions from non-owners', async () => {
+        __mockQuery.mockResolvedValueOnce({
+            rowCount: 1,
+            rows: [{
+                id: 'petdx-pending', name: 'X', author_entity_id: 999, device_id: 'other-dev',
+                status: 'pending_review', scope: 'community', descriptor: {},
+                asset_type: 'spritesheet', supported_states: ['IDLE'], tags: [],
+                download_count: 0, favorite_count: 0, rating_avg: null,
+                rating_count: 0, comment_count: 0,
+            }],
+        });
+        const res = await request(makeApp())
+            .get('/api/companion/petdx-pending')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY });
+        expect(res.status).toBe(404);
+    });
+
+    test('200 returns descriptor for published companion', async () => {
+        __mockQuery.mockResolvedValueOnce({
+            rowCount: 1,
+            rows: [{
+                id: 'petdx-ok', name: 'OK', version: '1.0.0',
+                author_entity_id: null, device_id: null,
+                descriptor: { description: 'hello' },
+                asset_type: 'procedural', asset_url: null,
+                avatar_url: '/a.png', thumbnail_url: '/t.webp',
+                supported_states: ['IDLE'], scope: 'system', status: 'published',
+                license: 'EClaw-default', tags: [], i18n_data: null,
+                category: null, mood: null, color: null,
+                download_count: 0, favorite_count: 0, rating_avg: null,
+                rating_count: 0, comment_count: 0, published_at: 1778000000000,
+            }],
+        });
+        const res = await request(makeApp())
+            .get('/api/companion/petdx-ok')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY });
+        expect(res.status).toBe(200);
+        expect(res.body.companion.descriptor).toEqual({ description: 'hello' });
+        expect(res.body.companion.scope).toBe('system');
+    });
+});


### PR DESCRIPTION
## Summary

- 第一段 Petdx 社群伙伴貢獻 API 落地：`GET /api/companion/list`（含 category / mood / color / q / tags / sort / scope / assetType / author 篩選）+ `GET /api/companion/:id`（pending/rejected 對非作者 404 hide）。
- DB schema 只開 `companions` 主表（PostgreSQL JSONB + GIN tags index + 五條讀取索引）；favorites/ratings/comments/select_log 留在 Stage 2-4。
- Auth 沿用 `/api/bot/*` 既有的 `authenticateBot(deviceId, entityId, botSecret)`；factory inject pattern 與 wallet/subscription 一致。
- 15 條 jest 單元測試（helpers / factory contract / auth 400+401 / 輸入驗證 / 分頁 shape / `scope=mine` 綁定 / pending hide）— `pg` 在測試裡被整個 mock 掉，不需要 DATABASE_URL。

## Stage breakdown

| Stage | Scope | Status |
|---|---|---|
| **1 (this PR)** | `companions` 表 + list/detail 讀端點 | ✅ |
| 2 | favorites + select + current + earnings | TODO |
| 3 | ratings + comments | TODO |
| 4 | submit + draft + review (creator + device-owner gated) | TODO |

## Test plan
- [x] `npx jest tests/jest/companion-api.test.js` — 15/15 pass
- [x] Full backend jest run — 2777 passed / 1 skipped / 0 fail (193 suites)
- [x] `node --check backend/companion-api.js` + `node --check backend/index.js`
- [ ] Post-deploy curl: `GET /api/companion/list?deviceId=...&botSecret=...&entityId=...` returns `{success:true, total:0, companions:[]}` on empty table

## Spec / 卡

- Spec: `docs/specs/petdx-backend-api-spec.md` (v0.2)
- Card: `card_4b5537f703561b560f8759af`（社群伙伴貢獻 API）

🤖 Generated with [Claude Code](https://claude.com/claude-code)