### PR TITLE
feat(petdx): Web Canvas renderer + preview portal (v0.2 PoC)

### DIFF
--- a/backend/public/portal/petdx-preview.html
+++ b/backend/public/portal/petdx-preview.html
@@ -1,0 +1,258 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<meta name="robots" content="noindex">
+<title>Petdx 伙伴渲染預覽 / Companion Renderer Preview</title>
+<style>
+    :root {
+        --bg: #0d0d10;
+        --panel: #1a1a20;
+        --text: #e8e8e8;
+        --muted: #888;
+        --accent: #e63946;
+    }
+    * { box-sizing: border-box; }
+    html, body {
+        margin: 0; padding: 0;
+        background: var(--bg);
+        color: var(--text);
+        font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang TC", sans-serif;
+        min-height: 100vh;
+    }
+    .wrap {
+        max-width: 1080px;
+        margin: 0 auto;
+        padding: 24px 16px 64px;
+    }
+    h1 { font-size: 20px; margin: 0 0 4px; }
+    .sub { color: var(--muted); margin-bottom: 24px; }
+    .stage {
+        display: grid;
+        grid-template-columns: minmax(280px, 360px) 1fr;
+        gap: 24px;
+    }
+    @media (max-width: 720px) {
+        .stage { grid-template-columns: 1fr; }
+    }
+    .canvas-card {
+        background: var(--panel);
+        border-radius: 12px;
+        padding: 16px;
+        text-align: center;
+    }
+    canvas {
+        background: #000;
+        border-radius: 8px;
+        max-width: 100%;
+        aspect-ratio: 1 / 1;
+        width: 320px;
+        height: 320px;
+    }
+    .controls h3 {
+        font-size: 13px; color: var(--muted);
+        text-transform: uppercase; letter-spacing: 0.05em;
+        margin: 16px 0 8px;
+    }
+    .row { display: flex; flex-wrap: wrap; gap: 8px; }
+    button, select {
+        background: var(--panel);
+        border: 1px solid #2a2a30;
+        color: var(--text);
+        padding: 8px 12px;
+        border-radius: 6px;
+        font: inherit;
+        cursor: pointer;
+    }
+    button:hover { border-color: var(--accent); }
+    button.active { background: var(--accent); border-color: var(--accent); }
+    pre {
+        background: var(--panel);
+        border-radius: 8px;
+        padding: 12px;
+        overflow: auto;
+        max-height: 360px;
+        font-size: 12px;
+        margin: 0;
+    }
+    .hint { color: var(--muted); font-size: 12px; margin-top: 4px; }
+    .status {
+        display: inline-block;
+        padding: 2px 8px;
+        background: #2a2a30;
+        border-radius: 4px;
+        font-size: 11px;
+        color: var(--muted);
+    }
+    .status.warn { background: #5a3000; color: #ffb04a; }
+</style>
+</head>
+<body>
+<div class="wrap">
+    <h1>Petdx 伙伴渲染預覽 — v0.2 PoC</h1>
+    <div class="sub">CompanionDescriptor → Canvas 渲染。同一份 descriptor 將來會被 Android WebView 桌布服務直接消費。</div>
+
+    <div class="stage">
+        <div>
+            <div class="canvas-card">
+                <canvas id="petdx-canvas" width="320" height="320"></canvas>
+                <div class="hint">當前狀態：<span id="state-label" class="status">IDLE</span></div>
+            </div>
+
+            <div class="controls">
+                <h3>伙伴 / Companion</h3>
+                <div class="row">
+                    <select id="descriptor-picker"></select>
+                </div>
+
+                <h3>狀態 / State</h3>
+                <div class="row" id="state-buttons"></div>
+
+                <h3>引擎 / Engine</h3>
+                <div class="row">
+                    <button id="btn-start">▶ Start</button>
+                    <button id="btn-stop">■ Stop</button>
+                </div>
+            </div>
+        </div>
+
+        <div class="controls">
+            <h3>Descriptor (JSON)</h3>
+            <pre id="descriptor-json"></pre>
+            <div class="hint">Schema: <code>docs/specs/petdx-uiux-spec.md §2.1</code></div>
+        </div>
+    </div>
+</div>
+
+<script src="/shared/petdx-renderer.js"></script>
+<script>
+(function () {
+    'use strict';
+
+    const SAMPLES = [
+        {
+            id: 'petdx-lobster-default',
+            name: 'Lobster (預設)',
+            version: '1.0.0',
+            author: { entityId: 0, publicCode: 'system', displayName: 'EClaw' },
+            assetType: 'procedural',
+            asset: {
+                renderer: 'lobster-procedural',
+                params: { bodyColor: '#e63946', eyeStyle: 'bead', antennaStyle: 'double-curl' }
+            },
+            supportedStates: ['IDLE', 'BUSY', 'EATING', 'SLEEPING', 'EXCITED'],
+            stateAssets: {
+                IDLE:     { loop: true,  fps: 4,  hint: 'default rest' },
+                BUSY:     { loop: true,  fps: 6,  hint: 'working' },
+                EATING:   { loop: true,  fps: 6,  hint: 'xp gain' },
+                SLEEPING: { loop: true,  fps: 2,  hint: 'long idle' },
+                EXCITED:  { loop: false, fps: 12, hint: 'card done / level up' }
+            },
+            metadata: { tags: ['mascot', 'default'], color: '#e63946', category: 'mascot' },
+            license: 'EClaw-default'
+        },
+        {
+            id: 'petdx-lobster-blue',
+            name: 'Lobster (海洋變體)',
+            version: '1.0.0',
+            author: { entityId: 0, publicCode: 'system', displayName: 'EClaw' },
+            assetType: 'procedural',
+            asset: { renderer: 'lobster-procedural', params: { bodyColor: '#0d6efd' } },
+            supportedStates: ['IDLE', 'BUSY', 'SLEEPING', 'EXCITED'],
+            stateAssets: {
+                IDLE:     { loop: true, fps: 4 },
+                BUSY:     { loop: true, fps: 6 },
+                SLEEPING: { loop: true, fps: 2 },
+                EXCITED:  { loop: false, fps: 12 }
+            },
+            metadata: { color: '#0d6efd', category: 'mascot' },
+            license: 'EClaw-default'
+        },
+        {
+            id: 'petdx-mystery-blob',
+            name: 'Mystery Blob (未知 renderer fallback 範例)',
+            version: '0.1.0',
+            author: { entityId: 0, publicCode: 'system', displayName: 'EClaw' },
+            assetType: 'procedural',
+            asset: { renderer: 'cat-procedural', params: { color: '#34c759' } },
+            supportedStates: ['IDLE', 'PLAYING'],
+            stateAssets: { IDLE: { loop: true, fps: 4 }, PLAYING: { loop: true, fps: 8 } },
+            metadata: { color: '#34c759', category: 'animal' }
+        },
+        {
+            id: 'petdx-spritesheet-stub',
+            name: 'Spritesheet PoC (placeholder)',
+            version: '0.1.0',
+            author: { entityId: 0, publicCode: 'system', displayName: 'EClaw' },
+            assetType: 'spritesheet',
+            asset: { url: '/static/companions/petdx-spritesheet-stub/sheet.webp', frameW: 64, frameH: 64 },
+            supportedStates: ['IDLE'],
+            stateAssets: { IDLE: { loop: true, fps: 4, row: 0, frames: 4 } },
+            metadata: { category: 'custom' }
+        }
+    ];
+
+    const canvas = document.getElementById('petdx-canvas');
+    const picker = document.getElementById('descriptor-picker');
+    const stateButtons = document.getElementById('state-buttons');
+    const stateLabel = document.getElementById('state-label');
+    const descriptorJson = document.getElementById('descriptor-json');
+    const btnStart = document.getElementById('btn-start');
+    const btnStop = document.getElementById('btn-stop');
+
+    SAMPLES.forEach((d, i) => {
+        const opt = document.createElement('option');
+        opt.value = String(i);
+        opt.textContent = d.name + ' — ' + d.id;
+        picker.appendChild(opt);
+    });
+
+    let renderer = PetdxRenderer.createRenderer({
+        canvas,
+        descriptor: SAMPLES[0],
+        onError: (err) => console.warn('[Petdx] render error:', err)
+    });
+    renderer.start();
+
+    function refreshDescriptor(d) {
+        renderer.setDescriptor(d);
+        descriptorJson.textContent = JSON.stringify(d, null, 2);
+        renderStateButtons(d);
+        updateStateLabel();
+    }
+
+    function renderStateButtons(d) {
+        stateButtons.innerHTML = '';
+        d.supportedStates.forEach(state => {
+            const b = document.createElement('button');
+            b.textContent = state;
+            b.dataset.state = state;
+            if (state === renderer.getState()) b.classList.add('active');
+            b.addEventListener('click', () => {
+                const { resolved, didFallback } = renderer.setState(state);
+                stateLabel.textContent = resolved + (didFallback ? ' (fallback)' : '');
+                stateLabel.classList.toggle('warn', didFallback);
+                Array.from(stateButtons.children).forEach(c => c.classList.remove('active'));
+                b.classList.add('active');
+            });
+            stateButtons.appendChild(b);
+        });
+    }
+
+    function updateStateLabel() {
+        stateLabel.textContent = renderer.getState();
+        stateLabel.classList.remove('warn');
+    }
+
+    picker.addEventListener('change', () => {
+        refreshDescriptor(SAMPLES[Number(picker.value)]);
+    });
+    btnStart.addEventListener('click', () => renderer.start());
+    btnStop.addEventListener('click', () => renderer.stop());
+
+    refreshDescriptor(SAMPLES[0]);
+}());
+</script>
+</body>
+</html>

--- a/backend/public/shared/petdx-renderer.js
+++ b/backend/public/shared/petdx-renderer.js
@@ -1,0 +1,299 @@
+/**
+ * Petdx Companion Renderer — Web Canvas reference implementation.
+ *
+ * Spec: docs/specs/petdx-uiux-spec.md (v0.2)
+ *
+ * Why Web first: Hank 2026-05-10 — wallpaper rendering is animation +
+ * descriptor logic, NOT inherently Android-Kotlin work. A Canvas PoC
+ * here doubles as the Android WebView wallpaper's render layer
+ * (WallpaperService becomes a thin shell around a WebView pointing at
+ * a render page that consumes the same descriptor).
+ *
+ * v0.2 MVP scope:
+ *   - assetType: 'procedural' (built-in drawers; this PR ships 'lobster-procedural')
+ *   - assetType: 'spritesheet' (planned, next PR — needs webp asset pipeline)
+ *   - assetType: 'vector' (rejected per spec §2.2)
+ *
+ * Public surface:
+ *   - createRenderer({ canvas, descriptor, state? }) → controller
+ *     Controller has setState(name), setDescriptor(d), start(), stop(), getState().
+ *   - registerProceduralDrawer(rendererKey, drawerFn)
+ *     drawerFn signature: ({ ctx, w, h, t, state, params }) → void
+ *     where t is elapsed seconds (state-local clock).
+ *
+ * Hot-paths intentionally allocation-free; descriptor hot-swap is the
+ * only place where state-clock resets.
+ */
+(function (root, factory) {
+    if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    } else {
+        root.PetdxRenderer = factory();
+    }
+}(typeof self !== 'undefined' ? self : this, function () {
+    'use strict';
+
+    const DEFAULT_STATE = 'IDLE';
+    const DEFAULT_FPS = 4;
+    const DEFAULT_FALLBACK_POLICY = 'silent_to_idle';
+
+    // ── Drawer registry ──────────────────────────────────────────
+    const drawers = new Map();
+
+    function registerProceduralDrawer(rendererKey, fn) {
+        if (typeof rendererKey !== 'string' || !rendererKey) {
+            throw new Error('rendererKey must be non-empty string');
+        }
+        if (typeof fn !== 'function') {
+            throw new Error('drawer must be a function');
+        }
+        drawers.set(rendererKey, fn);
+    }
+
+    function getProceduralDrawer(rendererKey) {
+        return drawers.get(rendererKey) || null;
+    }
+
+    // ── Descriptor validation + state resolution ────────────────
+    function validateDescriptor(d) {
+        if (!d || typeof d !== 'object') return 'descriptor_required';
+        if (!d.id || typeof d.id !== 'string') return 'descriptor_missing_id';
+        if (!d.assetType) return 'descriptor_missing_asset_type';
+        if (!Array.isArray(d.supportedStates) || d.supportedStates.length === 0) {
+            return 'descriptor_missing_supported_states';
+        }
+        if (!d.supportedStates.includes(DEFAULT_STATE)) {
+            return 'descriptor_must_support_idle';
+        }
+        return null;
+    }
+
+    /**
+     * Resolves a requested state against descriptor.supportedStates per
+     * spec §2.3: silent fallback to IDLE if not supported.
+     * Returns { resolved, didFallback }.
+     */
+    function resolveState(descriptor, requested, policy) {
+        const fallback = policy || DEFAULT_FALLBACK_POLICY;
+        const supported = descriptor && descriptor.supportedStates;
+        if (!supported || !supported.includes(requested)) {
+            return { resolved: DEFAULT_STATE, didFallback: true, policy: fallback };
+        }
+        return { resolved: requested, didFallback: false, policy: fallback };
+    }
+
+    function getStateFps(descriptor, stateName) {
+        const sa = descriptor && descriptor.stateAssets && descriptor.stateAssets[stateName];
+        const fps = sa && Number(sa.fps);
+        return Number.isFinite(fps) && fps > 0 ? fps : DEFAULT_FPS;
+    }
+
+    function getStateLoop(descriptor, stateName) {
+        const sa = descriptor && descriptor.stateAssets && descriptor.stateAssets[stateName];
+        if (!sa || sa.loop === undefined) return true;
+        return !!sa.loop;
+    }
+
+    // ── Canvas runner ───────────────────────────────────────────
+    /**
+     * createRenderer({ canvas, descriptor, state?, onError? }) → controller
+     * Throws on first-validation failure; runtime drawer errors are
+     * swallowed and forwarded to onError (if provided) so animation
+     * doesn't die on a single bad frame.
+     */
+    function createRenderer(opts) {
+        const { canvas, descriptor, state, onError } = opts || {};
+        if (!canvas || typeof canvas.getContext !== 'function') {
+            throw new Error('canvas required');
+        }
+        const validationErr = validateDescriptor(descriptor);
+        if (validationErr) throw new Error(validationErr);
+
+        const ctx = canvas.getContext('2d');
+        let currentDescriptor = descriptor;
+        let currentState = resolveState(descriptor, state || DEFAULT_STATE).resolved;
+        let stateClockStart = 0;
+        let rafId = 0;
+        let running = false;
+        let lastFrameTime = 0;
+
+        function tick(now) {
+            if (!running) return;
+            rafId = requestAnimationFrame(tick);
+
+            const fps = getStateFps(currentDescriptor, currentState);
+            const minFrameMs = 1000 / fps;
+            if (now - lastFrameTime < minFrameMs) return;
+            lastFrameTime = now;
+
+            const w = canvas.width;
+            const h = canvas.height;
+            const t = (now - stateClockStart) / 1000;
+
+            try {
+                ctx.clearRect(0, 0, w, h);
+                if (currentDescriptor.assetType === 'procedural') {
+                    const rendererKey = currentDescriptor.asset && currentDescriptor.asset.renderer;
+                    const drawer = getProceduralDrawer(rendererKey) || getProceduralDrawer('fallback-blob');
+                    if (drawer) {
+                        drawer({
+                            ctx, w, h, t,
+                            state: currentState,
+                            params: (currentDescriptor.asset && currentDescriptor.asset.params) || {},
+                        });
+                    }
+                } else if (currentDescriptor.assetType === 'spritesheet') {
+                    // Planned next PR; for now draw a placeholder stripe so
+                    // the preview page makes the gap visible instead of
+                    // failing silently.
+                    drawSpritesheetPlaceholder(ctx, w, h, currentState);
+                }
+            } catch (err) {
+                if (onError) onError(err);
+            }
+        }
+
+        function drawSpritesheetPlaceholder(ctx, w, h, state) {
+            ctx.save();
+            ctx.fillStyle = '#1a1a1a';
+            ctx.fillRect(0, 0, w, h);
+            ctx.fillStyle = '#888';
+            ctx.font = '14px sans-serif';
+            ctx.textAlign = 'center';
+            ctx.fillText('spritesheet renderer — next PR', w / 2, h / 2);
+            ctx.fillText(`state: ${state}`, w / 2, h / 2 + 20);
+            ctx.restore();
+        }
+
+        return {
+            start() {
+                if (running) return;
+                running = true;
+                stateClockStart = performance.now();
+                lastFrameTime = 0;
+                rafId = requestAnimationFrame(tick);
+            },
+            stop() {
+                running = false;
+                if (rafId) cancelAnimationFrame(rafId);
+                rafId = 0;
+            },
+            setState(name) {
+                const { resolved, didFallback } = resolveState(currentDescriptor, name);
+                currentState = resolved;
+                stateClockStart = performance.now();
+                return { resolved, didFallback };
+            },
+            setDescriptor(d) {
+                const err = validateDescriptor(d);
+                if (err) throw new Error(err);
+                currentDescriptor = d;
+                const { resolved } = resolveState(d, currentState);
+                currentState = resolved;
+                stateClockStart = performance.now();
+            },
+            getState() { return currentState; },
+            getDescriptor() { return currentDescriptor; },
+            isRunning() { return running; },
+        };
+    }
+
+    // ── Built-in lobster procedural drawer ──────────────────────
+    // Reference matches the Android engine's existing lobster renderer
+    // (kept simple — antenna sway + claw bob + body breathing).
+    // params: { bodyColor, eyeStyle, antennaStyle }
+    registerProceduralDrawer('lobster-procedural', function lobsterDraw(args) {
+        const { ctx, w, h, t, state, params } = args;
+        const cx = w / 2;
+        const cy = h / 2;
+        const baseR = Math.min(w, h) * 0.28;
+
+        const breathe = state === 'SLEEPING' ? 0.96 + Math.sin(t * 0.8) * 0.02
+                       : state === 'EXCITED'  ? 1.00 + Math.sin(t * 12) * 0.06
+                       : state === 'BUSY'     ? 1.00 + Math.sin(t * 6) * 0.03
+                                              : 1.00 + Math.sin(t * 2.5) * 0.02;
+        const r = baseR * breathe;
+
+        // Body
+        ctx.fillStyle = params.bodyColor || '#e63946';
+        ctx.beginPath();
+        ctx.ellipse(cx, cy, r * 1.1, r * 0.85, 0, 0, Math.PI * 2);
+        ctx.fill();
+
+        // Antenna sway
+        const antSway = Math.sin(t * (state === 'EXCITED' ? 10 : 3)) * 0.18;
+        ctx.strokeStyle = params.bodyColor || '#e63946';
+        ctx.lineWidth = Math.max(2, r * 0.06);
+        ctx.lineCap = 'round';
+        for (const sign of [-1, 1]) {
+            ctx.beginPath();
+            ctx.moveTo(cx + sign * r * 0.35, cy - r * 0.7);
+            ctx.quadraticCurveTo(
+                cx + sign * (r * 0.55 + antSway * 30),
+                cy - r * 1.3,
+                cx + sign * r * 0.6 + sign * antSway * 50,
+                cy - r * 1.5
+            );
+            ctx.stroke();
+        }
+
+        // Eyes — bead style
+        const eyeR = Math.max(2, r * 0.08);
+        const eyeY = cy - r * 0.25;
+        const eyeSpacing = r * 0.30;
+        const blinkClose = (state === 'SLEEPING') ||
+                          (Math.floor(t * 1.3) % 7 === 0 && (t % 1) < 0.12);
+        ctx.fillStyle = '#1a1a1a';
+        for (const sign of [-1, 1]) {
+            if (blinkClose) {
+                ctx.fillRect(cx + sign * eyeSpacing - eyeR, eyeY - 1, eyeR * 2, 2);
+            } else {
+                ctx.beginPath();
+                ctx.arc(cx + sign * eyeSpacing, eyeY, eyeR, 0, Math.PI * 2);
+                ctx.fill();
+            }
+        }
+
+        // Claws bob
+        const clawBob = Math.sin(t * (state === 'BUSY' ? 6 : 2)) * r * 0.08;
+        ctx.fillStyle = params.bodyColor || '#e63946';
+        for (const sign of [-1, 1]) {
+            ctx.beginPath();
+            ctx.ellipse(
+                cx + sign * r * 1.2,
+                cy + r * 0.1 + clawBob * sign,
+                r * 0.35, r * 0.22, sign * 0.3, 0, Math.PI * 2
+            );
+            ctx.fill();
+        }
+    });
+
+    // Fallback placeholder for unknown renderer keys — keeps preview
+    // page functional even when descriptor names a drawer we haven't
+    // registered yet. Color from descriptor.metadata.color or grey.
+    registerProceduralDrawer('fallback-blob', function fallbackDraw(args) {
+        const { ctx, w, h, t, state, params } = args;
+        const cx = w / 2, cy = h / 2;
+        const r = Math.min(w, h) * 0.3 * (1 + Math.sin(t * 2) * 0.05);
+        ctx.fillStyle = (params && params.color) || '#7d7d7d';
+        ctx.beginPath();
+        ctx.arc(cx, cy, r, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.fillStyle = '#fff';
+        ctx.font = '12px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.fillText('?', cx, cy + 4);
+        ctx.fillText(state, cx, cy + r + 16);
+    });
+
+    return {
+        createRenderer,
+        registerProceduralDrawer,
+        getProceduralDrawer,
+        validateDescriptor,
+        resolveState,
+        getStateFps,
+        getStateLoop,
+        DEFAULT_STATE,
+    };
+}));

--- a/backend/tests/jest/petdx-renderer.test.js
+++ b/backend/tests/jest/petdx-renderer.test.js
@@ -1,0 +1,203 @@
+'use strict';
+
+/**
+ * Petdx renderer module tests — pure unit coverage.
+ *
+ * The renderer ships as a UMD module (browser global + CommonJS export);
+ * Jest can require it directly. Canvas-runner branches that need
+ * requestAnimationFrame are NOT exercised here; we cover the deterministic
+ * helpers (validation, state resolution, fps/loop lookup, drawer registry).
+ */
+
+const path = require('path');
+
+const MODULE_PATH = path.resolve(__dirname, '../../public/shared/petdx-renderer.js');
+const PetdxRenderer = require(MODULE_PATH);
+
+const VALID_DESCRIPTOR = Object.freeze({
+    id: 'petdx-test',
+    name: 'Test',
+    assetType: 'procedural',
+    asset: { renderer: 'lobster-procedural', params: { bodyColor: '#fff' } },
+    supportedStates: ['IDLE', 'BUSY', 'SLEEPING'],
+    stateAssets: {
+        IDLE:     { loop: true,  fps: 4 },
+        BUSY:     { loop: true,  fps: 6 },
+        SLEEPING: { loop: true,  fps: 2 },
+    },
+});
+
+describe('validateDescriptor', () => {
+    test('returns null for valid descriptor', () => {
+        expect(PetdxRenderer.validateDescriptor(VALID_DESCRIPTOR)).toBeNull();
+    });
+
+    test('rejects missing descriptor', () => {
+        expect(PetdxRenderer.validateDescriptor(null)).toBe('descriptor_required');
+        expect(PetdxRenderer.validateDescriptor(undefined)).toBe('descriptor_required');
+    });
+
+    test('rejects missing id', () => {
+        const d = { ...VALID_DESCRIPTOR, id: '' };
+        expect(PetdxRenderer.validateDescriptor(d)).toBe('descriptor_missing_id');
+    });
+
+    test('rejects missing assetType', () => {
+        const d = { ...VALID_DESCRIPTOR, assetType: undefined };
+        expect(PetdxRenderer.validateDescriptor(d)).toBe('descriptor_missing_asset_type');
+    });
+
+    test('rejects empty supportedStates', () => {
+        const d = { ...VALID_DESCRIPTOR, supportedStates: [] };
+        expect(PetdxRenderer.validateDescriptor(d)).toBe('descriptor_missing_supported_states');
+    });
+
+    test('rejects descriptor without IDLE in supportedStates', () => {
+        const d = { ...VALID_DESCRIPTOR, supportedStates: ['BUSY'] };
+        expect(PetdxRenderer.validateDescriptor(d)).toBe('descriptor_must_support_idle');
+    });
+});
+
+describe('resolveState (silent fallback to IDLE per spec §2.3)', () => {
+    test('preserves supported state', () => {
+        const r = PetdxRenderer.resolveState(VALID_DESCRIPTOR, 'BUSY');
+        expect(r).toMatchObject({ resolved: 'BUSY', didFallback: false });
+    });
+
+    test('falls back to IDLE for unsupported state', () => {
+        const r = PetdxRenderer.resolveState(VALID_DESCRIPTOR, 'SAD');
+        expect(r).toMatchObject({ resolved: 'IDLE', didFallback: true });
+    });
+
+    test('falls back when descriptor has no supportedStates list', () => {
+        const r = PetdxRenderer.resolveState({}, 'IDLE');
+        expect(r.resolved).toBe('IDLE');
+        expect(r.didFallback).toBe(true);
+    });
+
+    test('default fallback policy is silent_to_idle', () => {
+        const r = PetdxRenderer.resolveState(VALID_DESCRIPTOR, 'NOPE');
+        expect(r.policy).toBe('silent_to_idle');
+    });
+});
+
+describe('getStateFps', () => {
+    test('returns descriptor fps when valid', () => {
+        expect(PetdxRenderer.getStateFps(VALID_DESCRIPTOR, 'BUSY')).toBe(6);
+    });
+
+    test('falls back to default 4 when state missing', () => {
+        expect(PetdxRenderer.getStateFps(VALID_DESCRIPTOR, 'WHATEVER')).toBe(4);
+    });
+
+    test('falls back to default when fps is non-positive', () => {
+        const d = { ...VALID_DESCRIPTOR, stateAssets: { IDLE: { fps: 0 } } };
+        expect(PetdxRenderer.getStateFps(d, 'IDLE')).toBe(4);
+    });
+});
+
+describe('getStateLoop', () => {
+    test('defaults to true when not specified', () => {
+        const d = { ...VALID_DESCRIPTOR, stateAssets: { IDLE: { fps: 4 } } };
+        expect(PetdxRenderer.getStateLoop(d, 'IDLE')).toBe(true);
+    });
+
+    test('returns false when explicit', () => {
+        const d = { ...VALID_DESCRIPTOR, stateAssets: { IDLE: { fps: 4, loop: false } } };
+        expect(PetdxRenderer.getStateLoop(d, 'IDLE')).toBe(false);
+    });
+});
+
+describe('procedural drawer registry', () => {
+    test('registerProceduralDrawer stores fn retrievable by key', () => {
+        PetdxRenderer.registerProceduralDrawer('test-cat', () => {});
+        expect(typeof PetdxRenderer.getProceduralDrawer('test-cat')).toBe('function');
+    });
+
+    test('rejects empty key', () => {
+        expect(() => PetdxRenderer.registerProceduralDrawer('', () => {}))
+            .toThrow(/non-empty/);
+    });
+
+    test('rejects non-function drawer', () => {
+        expect(() => PetdxRenderer.registerProceduralDrawer('bad', 'nope'))
+            .toThrow(/function/);
+    });
+
+    test('built-in lobster-procedural is registered', () => {
+        expect(typeof PetdxRenderer.getProceduralDrawer('lobster-procedural')).toBe('function');
+    });
+
+    test('built-in fallback-blob is registered', () => {
+        expect(typeof PetdxRenderer.getProceduralDrawer('fallback-blob')).toBe('function');
+    });
+
+    test('returns null for unknown renderer key', () => {
+        expect(PetdxRenderer.getProceduralDrawer('does-not-exist')).toBeNull();
+    });
+});
+
+describe('createRenderer factory contract', () => {
+    function makeMockCanvas() {
+        const ctx = {
+            calls: [],
+            clearRect: jest.fn(),
+            save: jest.fn(), restore: jest.fn(),
+            fillRect: jest.fn(), fillText: jest.fn(),
+            beginPath: jest.fn(), arc: jest.fn(), ellipse: jest.fn(),
+            quadraticCurveTo: jest.fn(), moveTo: jest.fn(), stroke: jest.fn(), fill: jest.fn(),
+            set fillStyle(_) {}, get fillStyle() { return ''; },
+            set strokeStyle(_) {}, get strokeStyle() { return ''; },
+            set lineWidth(_) {}, get lineWidth() { return 1; },
+            set lineCap(_) {}, get lineCap() { return 'butt'; },
+            set font(_) {}, get font() { return ''; },
+            set textAlign(_) {}, get textAlign() { return 'start'; },
+        };
+        return {
+            width: 320, height: 320,
+            getContext: () => ctx,
+        };
+    }
+
+    test('throws when canvas missing', () => {
+        expect(() => PetdxRenderer.createRenderer({ descriptor: VALID_DESCRIPTOR }))
+            .toThrow(/canvas/);
+    });
+
+    test('throws when descriptor invalid', () => {
+        expect(() => PetdxRenderer.createRenderer({
+            canvas: makeMockCanvas(),
+            descriptor: { id: 'x', assetType: 'procedural', supportedStates: [] },
+        })).toThrow();
+    });
+
+    test('controller exposes setState/setDescriptor/getState/start/stop', () => {
+        const r = PetdxRenderer.createRenderer({
+            canvas: makeMockCanvas(),
+            descriptor: VALID_DESCRIPTOR,
+            state: 'BUSY',
+        });
+        expect(r.getState()).toBe('BUSY');
+
+        const change = r.setState('SLEEPING');
+        expect(change.resolved).toBe('SLEEPING');
+        expect(change.didFallback).toBe(false);
+
+        const fallback = r.setState('EATING');
+        expect(fallback).toMatchObject({ resolved: 'IDLE', didFallback: true });
+        expect(r.getState()).toBe('IDLE');
+
+        const newDescriptor = { ...VALID_DESCRIPTOR, id: 'petdx-other' };
+        r.setDescriptor(newDescriptor);
+        expect(r.getDescriptor().id).toBe('petdx-other');
+    });
+
+    test('controller defaults to IDLE when initial state unsupported', () => {
+        const r = PetdxRenderer.createRenderer({
+            canvas: makeMockCanvas(),
+            descriptor: VALID_DESCRIPTOR,
+            state: 'NEVERHEARDOFIT',
+        });
+        expect(r.getState()).toBe('IDLE');
+    });
+});


### PR DESCRIPTION
## Summary

CompanionDescriptor renderer reference implementation in pure browser Canvas. Same module powers the upcoming Android WebView-based wallpaper service — no Kotlin renderer port needed.

- **`backend/public/shared/petdx-renderer.js`** — UMD (browser global + CommonJS). `createRenderer({canvas, descriptor, state, onError})` returns a controller (`start/stop/setState/setDescriptor/getState/getDescriptor/isRunning`). Includes silent IDLE fallback (spec §2.3), fps/loop lookup, and a procedural drawer registry. Ships built-in `lobster-procedural` (state-aware breathing + antenna sway + claw bob + bead eyes w/ blink) and `fallback-blob` for unknown renderer keys.
- **`backend/public/portal/petdx-preview.html`** — 4-sample preview portal (default lobster / blue lobster / mystery-blob fallback demo / spritesheet-stub) with state buttons, live descriptor JSON, start/stop, picker.
- **`backend/tests/jest/petdx-renderer.test.js`** — 25 unit tests, all passing locally: `validateDescriptor` / `resolveState` / `getStateFps` / `getStateLoop` / drawer registry / `createRenderer` factory contract.

## Browser verification (per `feedback_personal_screenshot_review`)

Drove playwright against `http://localhost:8765/portal/petdx-preview.html` on three descriptors:

1. **Default** — Lobster default renders (red body, antennae, bead eyes, claws) on dark canvas.
2. **EXCITED state** — clicked EXCITED button; renderer fps + amplitude switched live.
3. **Fallback** — Mystery Blob (`renderer:'cat-procedural'` unknown) correctly falls back to `fallback-blob` (grey/green circle with `?` and state label).

Console clean apart from a benign `favicon.ico` 404.

## Test plan

- [x] `npm test -- tests/jest/petdx-renderer.test.js` → 25/25 green
- [x] `python3 -m http.server` + Playwright smoke on Chrome
- [ ] CI green
- [ ] Self-review of diff before merge per `feedback_i_am_the_reviewer`

## Why this PoC, why now

Hank pushback 2026-05-10 16:37: 「桌布動畫不是 MacE 的強項 你自己應該也能用模擬器測試 為何要分配出去 自己沒試過所有方法之前不要指派出去」. I had pattern-matched "Android wallpaper → #3 Mac_E" without trying my own paths. Web Canvas works without any Kotlin / WallpaperService port — the Android side becomes a thin WebView shell pointing at this renderer.

Spec: `docs/specs/petdx-uiux-spec.md` (v0.2)
Card: `card_ec59a5e0b8523855c0b36e2d` (Petdx 桌布伙伴動畫系統)

🤖 Generated with [Claude Code](https://claude.com/claude-code)