### PR TITLE
feat(petdx): companion browser portal + deviceSecret read auth + system seed

### DIFF
--- a/backend/companion-api.js
+++ b/backend/companion-api.js
@@ -117,33 +117,53 @@ async function initCompanionDatabase(serverLog = console.log) {
     }
 }
 
-module.exports = function companionFactory({ authenticateBot, serverLog } = {}) {
+module.exports = function companionFactory({ authenticateBot, authenticateDeviceOrBot, serverLog } = {}) {
     if (typeof authenticateBot !== 'function') {
         throw new Error('companionFactory requires authenticateBot');
     }
     const log = serverLog || (() => {});
     const router = express.Router();
 
-    function authBot(req, res, next) {
+    // Read endpoints accept either device-owner (deviceSecret) or bot
+    // (botSecret+entityId) auth so portal pages with deviceSecret in
+    // localStorage can browse the catalog without holding per-bot secrets.
+    // `req.botAuth.entityId` may be null on device-only auth — `scope=mine`
+    // still requires botSecret because it filters by author entity.
+    function authReader(req, res, next) {
         const deviceId = req.query.deviceId || req.body?.deviceId;
+        const deviceSecret = req.query.deviceSecret || req.body?.deviceSecret;
         const botSecret = req.query.botSecret || req.body?.botSecret;
         const entityIdRaw = req.query.entityId || req.body?.entityId;
-        const entityId = parseInt(entityIdRaw, 10);
+        const entityId = entityIdRaw != null ? parseInt(entityIdRaw, 10) : null;
 
-        if (!deviceId || !botSecret || !Number.isFinite(entityId)) {
-            return res.status(400).json({ success: false, error: 'deviceId, botSecret, entityId required' });
+        if (!deviceId || (!deviceSecret && !botSecret)) {
+            return res.status(400).json({ success: false, error: 'deviceId + (deviceSecret | botSecret+entityId) required' });
         }
-        if (!authenticateBot(deviceId, entityId, botSecret)) {
+        let ok = false;
+        if (typeof authenticateDeviceOrBot === 'function') {
+            ok = authenticateDeviceOrBot({
+                deviceId, deviceSecret, botSecret,
+                entityId: Number.isFinite(entityId) ? entityId : undefined,
+            });
+        } else if (botSecret && Number.isFinite(entityId)) {
+            ok = authenticateBot(deviceId, entityId, botSecret);
+        }
+        if (!ok) {
             return res.status(401).json({ success: false, error: 'Invalid credentials' });
         }
-        req.botAuth = { deviceId, botSecret, entityId };
+        req.botAuth = {
+            deviceId,
+            botSecret: botSecret || null,
+            entityId: Number.isFinite(entityId) ? entityId : null,
+            authMode: deviceSecret ? 'device' : 'bot',
+        };
         next();
     }
 
     // ── GET /api/companion/list ───────────────────────────────────
     // Query: category, mood, color, q, tags, sort, scope, assetType,
     //        page, limit, author
-    router.get('/list', authBot, async (req, res) => {
+    router.get('/list', authReader, async (req, res) => {
         const { category, mood, color, q, sort, scope, assetType, author } = req.query;
         const tags = parseTags(req.query.tags);
         const page = parsePositiveInt(req.query.page, 1);
@@ -168,6 +188,9 @@ module.exports = function companionFactory({ authenticateBot, serverLog } = {}) 
         if (scopeKey === 'system')    conds.push("scope = 'system'");
         if (scopeKey === 'community') conds.push("scope = 'community'");
         if (scopeKey === 'mine') {
+            if (req.botAuth.entityId == null) {
+                return res.status(400).json({ success: false, error: 'scope_mine_requires_entity' });
+            }
             conds.push(`author_entity_id = ${bind(req.botAuth.entityId)}`);
             conds.push(`device_id = ${bind(req.botAuth.deviceId)}`);
         }
@@ -229,7 +252,7 @@ module.exports = function companionFactory({ authenticateBot, serverLog } = {}) 
     });
 
     // ── GET /api/companion/:id ────────────────────────────────────
-    router.get('/:id', authBot, async (req, res) => {
+    router.get('/:id', authReader, async (req, res) => {
         const { id } = req.params;
         if (!/^[a-z0-9-]{1,80}$/i.test(id)) {
             return res.status(400).json({ success: false, error: 'invalid_companion_id' });
@@ -249,8 +272,10 @@ module.exports = function companionFactory({ authenticateBot, serverLog } = {}) 
                 return res.status(404).json({ success: false, error: 'companion_not_found' });
             }
             const row = r.rows[0];
-            const isOwner = row.author_entity_id === req.botAuth.entityId
-                && row.device_id === req.botAuth.deviceId;
+            const isOwner = req.botAuth.authMode === 'device'
+                ? row.device_id === req.botAuth.deviceId
+                : (row.author_entity_id === req.botAuth.entityId
+                    && row.device_id === req.botAuth.deviceId);
             if (row.status !== 'published' && row.scope !== 'system' && !isOwner) {
                 return res.status(404).json({ success: false, error: 'companion_not_found' });
             }

--- a/backend/companion_schema.sql
+++ b/backend/companion_schema.sql
@@ -56,3 +56,38 @@ CREATE INDEX IF NOT EXISTS idx_companions_popular       ON companions(download_c
 CREATE INDEX IF NOT EXISTS idx_companions_recent        ON companions(published_at DESC)   WHERE status = 'published';
 CREATE INDEX IF NOT EXISTS idx_companions_asset_type    ON companions(asset_type, status);
 CREATE INDEX IF NOT EXISTS idx_companions_tags          ON companions USING GIN (tags);
+
+-- ============================================
+-- Seed: official system companions (built-in; idempotent)
+-- ============================================
+-- These are the procedural drawers shipped in public/shared/petdx-renderer.js.
+-- ON CONFLICT DO NOTHING keeps repeat runs safe; updates go through a new
+-- version + deploy, not by editing seeded rows here.
+
+INSERT INTO companions (
+    id, name, version, author_entity_id, device_id,
+    descriptor, asset_type, supported_states, scope, status,
+    license, category, mood, color, tags,
+    created_at, updated_at, published_at
+) VALUES
+(
+    'petdx-lobster-default', '預設龍蝦 Lobster (Default)', '1.0.0',
+    NULL, NULL,
+    '{"id":"petdx-lobster-default","name":"預設龍蝦","assetType":"procedural","asset":{"renderer":"lobster-procedural","params":{"bodyColor":"#e63946","eyeStyle":"bead","antennaStyle":"double-curl"}},"supportedStates":["IDLE","BUSY","EATING","SLEEPING","EXCITED"],"stateAssets":{"IDLE":{"loop":true,"fps":4},"BUSY":{"loop":true,"fps":6},"EATING":{"loop":true,"fps":6},"SLEEPING":{"loop":true,"fps":2},"EXCITED":{"loop":false,"fps":12}}}'::jsonb,
+    'procedural',
+    '["IDLE","BUSY","EATING","SLEEPING","EXCITED"]'::jsonb,
+    'system', 'published', 'EClaw-default',
+    'mascot', 'happy', '#e63946', '["mascot","default","lobster"]'::jsonb,
+    1778000000000, 1778000000000, 1778000000000
+),
+(
+    'petdx-lobster-blue', '海洋龍蝦 Lobster (Blue)', '1.0.0',
+    NULL, NULL,
+    '{"id":"petdx-lobster-blue","name":"海洋龍蝦","assetType":"procedural","asset":{"renderer":"lobster-procedural","params":{"bodyColor":"#0d6efd"}},"supportedStates":["IDLE","BUSY","SLEEPING","EXCITED"],"stateAssets":{"IDLE":{"loop":true,"fps":4},"BUSY":{"loop":true,"fps":6},"SLEEPING":{"loop":true,"fps":2},"EXCITED":{"loop":false,"fps":12}}}'::jsonb,
+    'procedural',
+    '["IDLE","BUSY","SLEEPING","EXCITED"]'::jsonb,
+    'system', 'published', 'EClaw-default',
+    'mascot', 'calm', '#0d6efd', '["mascot","ocean","lobster"]'::jsonb,
+    1778000000000, 1778000000000, 1778000000000
+)
+ON CONFLICT (id) DO NOTHING;

--- a/backend/index.js
+++ b/backend/index.js
@@ -2091,6 +2091,7 @@ app.use('/api/bot', botTools.router);
 // ============================================
 const companionModule = require('./companion-api')({
     authenticateBot,
+    authenticateDeviceOrBot,
     serverLog,
 });
 app.use('/api/companion', companionModule.router);

--- a/backend/public/portal/petdx-browser.html
+++ b/backend/public/portal/petdx-browser.html
@@ -1,0 +1,617 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Petdx 伙伴瀏覽器 / Companion Browser</title>
+<meta name="description" content="EClaw Petdx companion browser — preview, filter, and pick procedural companions for your wallpaper.">
+<style>
+    :root {
+        --bg: #0d0d10;
+        --panel: #16161c;
+        --panel-2: #1c1c24;
+        --text: #e8e8e8;
+        --muted: #8c8c95;
+        --border: #2a2a32;
+        --accent: #e63946;
+        --accent-soft: rgba(230, 57, 70, 0.12);
+        --ok: #4caf50;
+    }
+    * { box-sizing: border-box; }
+    html, body {
+        margin: 0; padding: 0;
+        background: var(--bg);
+        color: var(--text);
+        font: 14px/1.5 -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang TC", "Noto Sans TC", sans-serif;
+        min-height: 100vh;
+    }
+    .topbar {
+        position: sticky; top: 0; z-index: 5;
+        background: rgba(13, 13, 16, 0.92);
+        backdrop-filter: blur(8px);
+        border-bottom: 1px solid var(--border);
+        padding: 12px 16px;
+    }
+    .topbar-row {
+        max-width: 1280px; margin: 0 auto;
+        display: flex; flex-wrap: wrap; align-items: center; gap: 12px;
+    }
+    .topbar h1 { font-size: 18px; margin: 0; flex: 0 0 auto; }
+    .topbar .sub { color: var(--muted); font-size: 12px; margin-left: 4px; }
+    .search {
+        flex: 1 1 200px; min-width: 200px;
+        background: var(--panel); border: 1px solid var(--border);
+        color: var(--text); padding: 8px 12px; border-radius: 6px;
+        font: inherit;
+    }
+    .search:focus { outline: none; border-color: var(--accent); }
+    .filters {
+        max-width: 1280px; margin: 0 auto;
+        display: flex; flex-wrap: wrap; gap: 6px; padding-top: 8px;
+    }
+    .chip {
+        background: var(--panel); border: 1px solid var(--border);
+        color: var(--text); padding: 4px 10px; border-radius: 999px;
+        font-size: 12px; cursor: pointer;
+        transition: background 0.12s, border-color 0.12s;
+    }
+    .chip:hover { border-color: var(--accent); }
+    .chip.active { background: var(--accent-soft); border-color: var(--accent); color: var(--accent); }
+    .chip-group { display: inline-flex; flex-wrap: wrap; gap: 4px; align-items: center; }
+    .chip-label { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; padding: 0 4px; }
+    main {
+        max-width: 1280px; margin: 0 auto; padding: 16px;
+    }
+    .status-bar {
+        display: flex; justify-content: space-between; color: var(--muted);
+        font-size: 12px; margin-bottom: 12px;
+    }
+    .grid {
+        display: grid;
+        grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+        gap: 12px;
+    }
+    .card {
+        background: var(--panel); border: 1px solid var(--border);
+        border-radius: 10px; padding: 10px; cursor: pointer;
+        transition: transform 0.12s, border-color 0.12s;
+        display: flex; flex-direction: column; gap: 8px;
+    }
+    .card:hover { border-color: var(--accent); transform: translateY(-2px); }
+    .card canvas {
+        width: 100%; aspect-ratio: 1 / 1;
+        background: #000; border-radius: 8px;
+        display: block;
+    }
+    .card .name { font-size: 13px; font-weight: 600; }
+    .card .meta {
+        display: flex; flex-wrap: wrap; gap: 4px;
+        color: var(--muted); font-size: 11px;
+    }
+    .card .scope {
+        font-size: 10px; padding: 1px 6px; border-radius: 999px;
+        background: var(--panel-2); border: 1px solid var(--border);
+        text-transform: uppercase; letter-spacing: 0.05em;
+    }
+    .card .scope.system    { color: #ffb04a; border-color: #5a3000; }
+    .card .scope.community { color: #4ac2ff; border-color: #003a5a; }
+    .card .scope.mine      { color: var(--ok); border-color: #054b0c; }
+    .empty {
+        text-align: center; color: var(--muted);
+        padding: 80px 16px;
+    }
+    .empty button {
+        margin-top: 12px;
+        background: var(--accent); border: none; color: #fff;
+        padding: 8px 16px; border-radius: 6px; cursor: pointer;
+        font: inherit;
+    }
+    .login-warn {
+        padding: 12px; margin-bottom: 12px;
+        background: #5a3000; color: #ffb04a;
+        border-radius: 8px; font-size: 13px;
+    }
+    .login-warn a { color: #ffd99a; }
+
+    /* Detail modal */
+    .modal-bg {
+        position: fixed; inset: 0; z-index: 10;
+        background: rgba(0, 0, 0, 0.7);
+        display: none; align-items: center; justify-content: center;
+        padding: 16px;
+    }
+    .modal-bg.open { display: flex; }
+    .modal {
+        background: var(--panel); border-radius: 12px;
+        max-width: 640px; width: 100%; max-height: 90vh; overflow-y: auto;
+        padding: 20px;
+    }
+    .modal-canvas {
+        width: 100%; max-width: 320px; aspect-ratio: 1 / 1;
+        background: #000; border-radius: 8px; margin: 12px auto; display: block;
+    }
+    .modal h2 { margin: 0 0 4px; font-size: 18px; }
+    .modal .modal-meta { color: var(--muted); font-size: 12px; margin-bottom: 12px; }
+    .modal .state-buttons {
+        display: flex; flex-wrap: wrap; gap: 6px; margin: 8px 0;
+        justify-content: center;
+    }
+    .modal button {
+        background: var(--panel-2); border: 1px solid var(--border);
+        color: var(--text); padding: 6px 12px; border-radius: 6px;
+        font: inherit; cursor: pointer;
+    }
+    .modal button:hover { border-color: var(--accent); }
+    .modal button.primary { background: var(--accent); border-color: var(--accent); color: #fff; }
+    .modal-actions {
+        display: flex; flex-wrap: wrap; gap: 8px; margin-top: 16px;
+        border-top: 1px solid var(--border); padding-top: 12px;
+    }
+    .modal pre {
+        background: var(--panel-2); border-radius: 8px;
+        padding: 10px; font-size: 11px; overflow: auto;
+        max-height: 200px; margin: 0;
+    }
+    .modal .close {
+        position: absolute; top: 12px; right: 16px;
+        background: none; border: none; color: var(--muted);
+        font-size: 22px; cursor: pointer;
+    }
+    .modal-host { position: relative; }
+
+    @media (max-width: 600px) {
+        .topbar h1 { font-size: 16px; }
+        .grid { grid-template-columns: repeat(auto-fill, minmax(140px, 1fr)); }
+    }
+</style>
+</head>
+<body>
+
+<div class="topbar">
+    <div class="topbar-row">
+        <h1>Petdx 伙伴瀏覽器</h1>
+        <span class="sub">Companion Browser · v0.2</span>
+        <input id="search" class="search" type="search" placeholder="搜尋伙伴名稱或描述 / Search…" autocomplete="off">
+    </div>
+    <div class="filters" id="filters"></div>
+</div>
+
+<main>
+    <div id="login-warn" class="login-warn" style="display: none;">
+        ⚠️ 尚未登入或找不到 device 憑證。請先 <a href="/portal/index.html">登入主控台</a>，或在開發模式下用 <code>?deviceId=...&deviceSecret=...</code> 帶入。
+    </div>
+    <div class="status-bar">
+        <span id="status">載入中…</span>
+        <span id="pagination"></span>
+    </div>
+    <div id="grid" class="grid"></div>
+    <div id="empty" class="empty" style="display: none;">
+        <div>沒有符合條件的伙伴 / No companions match your filter.</div>
+        <button onclick="resetFilters()">清除篩選 / Reset</button>
+    </div>
+</main>
+
+<div id="modal" class="modal-bg" role="dialog" aria-modal="true">
+    <div class="modal modal-host">
+        <button class="close" id="modal-close" aria-label="Close">×</button>
+        <div id="modal-body"></div>
+    </div>
+</div>
+
+<script src="/shared/petdx-renderer.js"></script>
+<script>
+(function () {
+    'use strict';
+
+    // ── Auth ──────────────────────────────────────────────────────
+    function getCreds() {
+        const url = new URLSearchParams(location.search);
+        const deviceId = url.get('deviceId') || localStorage.getItem('eclaw_device_id') || '';
+        const deviceSecret = url.get('deviceSecret') || localStorage.getItem('eclaw_device_secret') || '';
+        const entityId = url.get('entityId') || '';
+        const botSecret = url.get('botSecret') || '';
+        return { deviceId, deviceSecret, entityId, botSecret };
+    }
+
+    function authQuery() {
+        const c = getCreds();
+        const p = new URLSearchParams();
+        if (c.deviceId) p.set('deviceId', c.deviceId);
+        if (c.deviceSecret) p.set('deviceSecret', c.deviceSecret);
+        if (c.entityId) p.set('entityId', c.entityId);
+        if (c.botSecret) p.set('botSecret', c.botSecret);
+        return p;
+    }
+
+    // ── Filter state ──────────────────────────────────────────────
+    const FILTER_GROUPS = [
+        { key: 'scope',     label: '範圍', options: [
+            { v: '',          t: '全部' },
+            { v: 'system',    t: '官方' },
+            { v: 'community', t: '社群' },
+            { v: 'mine',      t: '我的' },
+        ] },
+        { key: 'category',  label: '類型', options: [
+            { v: '',        t: '全部' },
+            { v: 'mascot',  t: '吉祥物' },
+            { v: 'animal',  t: '動物' },
+            { v: 'human',   t: '人物' },
+            { v: 'robot',   t: '機器人' },
+            { v: 'custom',  t: '自訂' },
+        ] },
+        { key: 'sort', label: '排序', options: [
+            { v: 'popular',   t: '熱門' },
+            { v: 'recent',    t: '最新' },
+            { v: 'rating',    t: '評分' },
+            { v: 'favorites', t: '收藏' },
+        ] },
+    ];
+    const filterState = { scope: '', category: '', sort: 'popular' };
+    let searchTerm = '';
+    let searchTimer = 0;
+
+    // ── Renderer pool ─────────────────────────────────────────────
+    // One PetdxRenderer controller per visible card. We tear down on
+    // re-render to keep rAF count bounded.
+    const activeRenderers = [];
+    function tearDownRenderers() {
+        while (activeRenderers.length) {
+            try { activeRenderers.pop().stop(); } catch (e) { /* swallow */ }
+        }
+    }
+
+    // ── Filter UI ─────────────────────────────────────────────────
+    function renderFilters() {
+        const root = document.getElementById('filters');
+        root.innerHTML = '';
+        FILTER_GROUPS.forEach(group => {
+            const g = document.createElement('div');
+            g.className = 'chip-group';
+            const lbl = document.createElement('span');
+            lbl.className = 'chip-label';
+            lbl.textContent = group.label;
+            g.appendChild(lbl);
+            group.options.forEach(opt => {
+                const c = document.createElement('button');
+                c.className = 'chip';
+                if (filterState[group.key] === opt.v) c.classList.add('active');
+                c.textContent = opt.t;
+                c.addEventListener('click', () => {
+                    filterState[group.key] = opt.v;
+                    renderFilters();
+                    loadList();
+                });
+                g.appendChild(c);
+            });
+            root.appendChild(g);
+        });
+    }
+
+    window.resetFilters = function () {
+        Object.keys(filterState).forEach(k => filterState[k] = (k === 'sort' ? 'popular' : ''));
+        searchTerm = '';
+        document.getElementById('search').value = '';
+        renderFilters();
+        loadList();
+    };
+
+    // ── List loader ───────────────────────────────────────────────
+    async function loadList() {
+        const status = document.getElementById('status');
+        const grid = document.getElementById('grid');
+        const empty = document.getElementById('empty');
+        const pagination = document.getElementById('pagination');
+
+        const creds = getCreds();
+        if (!creds.deviceId || (!creds.deviceSecret && !creds.botSecret)) {
+            document.getElementById('login-warn').style.display = 'block';
+            status.textContent = '未登入';
+            return;
+        }
+
+        status.textContent = '載入中…';
+        empty.style.display = 'none';
+        tearDownRenderers();
+        grid.innerHTML = '';
+
+        const q = authQuery();
+        if (filterState.scope)    q.set('scope', filterState.scope);
+        if (filterState.category) q.set('category', filterState.category);
+        if (filterState.sort)     q.set('sort', filterState.sort);
+        if (searchTerm)           q.set('q', searchTerm);
+        q.set('limit', '60');
+
+        let data;
+        try {
+            const r = await fetch('/api/companion/list?' + q.toString());
+            data = await r.json();
+            if (!data.success) {
+                status.textContent = '載入失敗：' + (data.error || r.status);
+                return;
+            }
+        } catch (err) {
+            status.textContent = '網路錯誤：' + err.message;
+            return;
+        }
+
+        const items = data.companions || [];
+        status.textContent = '共 ' + (data.total || 0) + ' 個伙伴';
+        pagination.textContent = items.length === data.total
+            ? ''
+            : '顯示前 ' + items.length + ' 個';
+
+        if (!items.length) {
+            empty.style.display = 'block';
+            return;
+        }
+
+        items.forEach(card => {
+            const node = renderCardNode(card);
+            grid.appendChild(node);
+        });
+    }
+
+    // ── Card node ─────────────────────────────────────────────────
+    function renderCardNode(card) {
+        const div = document.createElement('div');
+        div.className = 'card';
+        div.tabIndex = 0;
+        div.setAttribute('role', 'button');
+        div.dataset.companionId = card.id;
+
+        const canvas = document.createElement('canvas');
+        canvas.width = 200; canvas.height = 200;
+        div.appendChild(canvas);
+
+        const name = document.createElement('div');
+        name.className = 'name';
+        name.textContent = card.name;
+        div.appendChild(name);
+
+        const meta = document.createElement('div');
+        meta.className = 'meta';
+        if (card.scope) {
+            const s = document.createElement('span');
+            s.className = 'scope ' + card.scope;
+            s.textContent = card.scope;
+            meta.appendChild(s);
+        }
+        if (card.category) {
+            const c = document.createElement('span');
+            c.textContent = '· ' + card.category;
+            meta.appendChild(c);
+        }
+        div.appendChild(meta);
+
+        // Animate: build a synthetic descriptor from the card payload
+        // so we can preview without a second API call. The full
+        // descriptor with params lives behind GET /:id which the modal
+        // uses for the bigger preview.
+        const rendererKey = rendererKeyFromCard(card);
+        const descriptor = {
+            id: card.id,
+            name: card.name,
+            assetType: card.assetType || 'procedural',
+            asset: {
+                renderer: rendererKey,
+                params: { bodyColor: card.color, color: card.color },
+            },
+            supportedStates: card.supportedStates && card.supportedStates.length
+                ? card.supportedStates
+                : ['IDLE'],
+            stateAssets: { IDLE: { fps: 4, loop: true } },
+        };
+
+        try {
+            const r = PetdxRenderer.createRenderer({
+                canvas, descriptor, state: 'IDLE',
+                onError: () => {}, // keep grid alive on bad frame
+            });
+            r.start();
+            activeRenderers.push(r);
+        } catch (e) {
+            // descriptor invalid — leave canvas blank
+        }
+
+        const open = () => openDetail(card);
+        div.addEventListener('click', open);
+        div.addEventListener('keydown', e => {
+            if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); open(); }
+        });
+        return div;
+    }
+
+    function rendererKeyFromCard(card) {
+        // descriptor.asset.renderer isn't surfaced on the list payload.
+        // Best-effort guess from name/tags so the grid doesn't render
+        // every non-lobster as a lobster. Unknown -> fallback-blob, which
+        // is registered in petdx-renderer.js and shows a generic preview.
+        const name = (card.name || '').toLowerCase();
+        const tags = (card.tags || []).map(t => String(t).toLowerCase());
+        if (name.includes('lobster') || name.includes('龍蝦') || tags.includes('lobster')) {
+            return 'lobster-procedural';
+        }
+        return 'fallback-blob';
+    }
+
+    // ── Detail modal ──────────────────────────────────────────────
+    let modalRenderer = null;
+    let modalDescriptor = null;
+
+    async function openDetail(card) {
+        const modal = document.getElementById('modal');
+        const body = document.getElementById('modal-body');
+        body.innerHTML = '<div style="padding: 40px; text-align: center; color: var(--muted);">載入中…</div>';
+        modal.classList.add('open');
+
+        const q = authQuery();
+        let detail = null;
+        try {
+            const r = await fetch('/api/companion/' + encodeURIComponent(card.id) + '?' + q.toString());
+            const data = await r.json();
+            if (data.success) detail = data.companion;
+        } catch (e) { /* fall through */ }
+
+        if (!detail) {
+            body.innerHTML = '<h2>' + escapeHtml(card.name) + '</h2><p>無法載入詳細資訊。</p>';
+            return;
+        }
+        renderModalBody(detail);
+    }
+
+    function renderModalBody(detail) {
+        const body = document.getElementById('modal-body');
+        body.innerHTML = '';
+
+        const h = document.createElement('h2');
+        h.textContent = detail.name;
+        body.appendChild(h);
+
+        const meta = document.createElement('div');
+        meta.className = 'modal-meta';
+        meta.textContent = [
+            detail.scope,
+            detail.category || '',
+            detail.assetType || '',
+            'v' + (detail.version || '1.0.0'),
+        ].filter(Boolean).join(' · ');
+        body.appendChild(meta);
+
+        const canvas = document.createElement('canvas');
+        canvas.className = 'modal-canvas';
+        canvas.width = 320; canvas.height = 320;
+        body.appendChild(canvas);
+
+        const stateBtns = document.createElement('div');
+        stateBtns.className = 'state-buttons';
+        body.appendChild(stateBtns);
+
+        modalDescriptor = detail.descriptor && detail.descriptor.assetType
+            ? detail.descriptor
+            : {
+                id: detail.id, name: detail.name,
+                assetType: detail.assetType || 'procedural',
+                asset: { renderer: rendererKeyFromCard(detail), params: { color: detail.color } },
+                supportedStates: detail.supportedStates || ['IDLE'],
+                stateAssets: { IDLE: { fps: 4, loop: true } },
+            };
+
+        try {
+            if (modalRenderer) modalRenderer.stop();
+            modalRenderer = PetdxRenderer.createRenderer({
+                canvas, descriptor: modalDescriptor, state: 'IDLE',
+                onError: () => {},
+            });
+            modalRenderer.start();
+        } catch (e) {
+            canvas.style.display = 'none';
+        }
+
+        (modalDescriptor.supportedStates || ['IDLE']).forEach(state => {
+            const b = document.createElement('button');
+            b.textContent = state;
+            if (state === 'IDLE') b.classList.add('primary');
+            b.addEventListener('click', () => {
+                if (!modalRenderer) return;
+                modalRenderer.setState(state);
+                Array.from(stateBtns.children).forEach(c => c.classList.remove('primary'));
+                b.classList.add('primary');
+            });
+            stateBtns.appendChild(b);
+        });
+
+        const actions = document.createElement('div');
+        actions.className = 'modal-actions';
+        const selectBtn = document.createElement('button');
+        selectBtn.className = 'primary';
+        selectBtn.textContent = '一鍵切換 / Select';
+        selectBtn.addEventListener('click', () => onSelect(detail));
+        const favBtn = document.createElement('button');
+        favBtn.textContent = '☆ 收藏 / Favorite';
+        favBtn.addEventListener('click', () => onFavorite(detail));
+        actions.appendChild(selectBtn);
+        actions.appendChild(favBtn);
+        body.appendChild(actions);
+
+        if (detail.descriptor) {
+            const pre = document.createElement('pre');
+            pre.textContent = JSON.stringify(detail.descriptor, null, 2);
+            body.appendChild(pre);
+        }
+    }
+
+    async function onSelect(detail) {
+        // Stage 2 endpoint: POST /api/companion/select
+        // Returns 404 today; show informative message.
+        const q = authQuery();
+        try {
+            const r = await fetch('/api/companion/select?' + q.toString(), {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ companionId: detail.id, ...Object.fromEntries(q.entries()) }),
+            });
+            if (r.status === 404) {
+                alert('「一鍵切換」端點 (Stage 2) 尚未上線；切換功能即將推出。');
+                return;
+            }
+            const data = await r.json();
+            if (data.success) {
+                alert('已切換為 ' + detail.name);
+            } else {
+                alert('切換失敗：' + (data.error || r.status));
+            }
+        } catch (err) {
+            alert('網路錯誤：' + err.message);
+        }
+    }
+
+    async function onFavorite(detail) {
+        const q = authQuery();
+        try {
+            const r = await fetch('/api/companion/' + encodeURIComponent(detail.id) + '/favorite?' + q.toString(), {
+                method: 'POST',
+            });
+            if (r.status === 404) {
+                alert('「收藏」端點 (Stage 2) 尚未上線；收藏功能即將推出。');
+                return;
+            }
+            const data = await r.json();
+            alert(data.success ? '已加入收藏' : '收藏失敗：' + (data.error || r.status));
+        } catch (err) {
+            alert('網路錯誤：' + err.message);
+        }
+    }
+
+    function closeModal() {
+        document.getElementById('modal').classList.remove('open');
+        if (modalRenderer) { modalRenderer.stop(); modalRenderer = null; }
+    }
+    document.getElementById('modal-close').addEventListener('click', closeModal);
+    document.getElementById('modal').addEventListener('click', (e) => {
+        if (e.target.id === 'modal') closeModal();
+    });
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') closeModal();
+    });
+
+    // ── Search input ─────────────────────────────────────────────
+    document.getElementById('search').addEventListener('input', (e) => {
+        searchTerm = e.target.value.trim();
+        clearTimeout(searchTimer);
+        searchTimer = setTimeout(loadList, 250);
+    });
+
+    // ── Helpers ──────────────────────────────────────────────────
+    function escapeHtml(s) {
+        return String(s).replace(/[&<>"']/g, c => ({
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;',
+        }[c]));
+    }
+
+    // ── Boot ─────────────────────────────────────────────────────
+    renderFilters();
+    loadList();
+}());
+</script>
+</body>
+</html>

--- a/backend/tests/jest/companion-api.test.js
+++ b/backend/tests/jest/companion-api.test.js
@@ -32,12 +32,23 @@ const DEVICE = 'dev-test';
 const ENTITY = 7;
 const SECRET = 'good-secret';
 
-function makeApp({ authenticateBot } = {}) {
+const DEVICE_SECRET = 'good-device-secret';
+
+function makeApp({ authenticateBot, authenticateDeviceOrBot } = {}) {
     const app = express();
     app.use(express.json());
-    const auth = authenticateBot || ((d, e, s) =>
+    const authBot = authenticateBot || ((d, e, s) =>
         d === DEVICE && e === ENTITY && s === SECRET);
-    const mod = companionFactory({ authenticateBot: auth });
+    const authDevOrBot = authenticateDeviceOrBot || (({ deviceId, deviceSecret, botSecret, entityId }) => {
+        if (deviceId !== DEVICE) return false;
+        if (deviceSecret === DEVICE_SECRET) return true;
+        if (botSecret === SECRET && entityId === ENTITY) return true;
+        return false;
+    });
+    const mod = companionFactory({
+        authenticateBot: authBot,
+        authenticateDeviceOrBot: authDevOrBot,
+    });
     app.use('/api/companion', mod.router);
     return app;
 }
@@ -155,6 +166,58 @@ describe('companion-api: GET /list auth + validation', () => {
         expect(listCall[0]).toMatch(/author_entity_id = \$\d/);
         expect(listCall[0]).toMatch(/device_id = \$\d/);
         expect(listCall[1]).toEqual(expect.arrayContaining([ENTITY, DEVICE]));
+    });
+});
+
+describe('companion-api: deviceSecret auth path (portal pages)', () => {
+    beforeEach(() => __mockQuery.mockReset());
+
+    test('200 with deviceSecret only (no entityId) for default scope', async () => {
+        __mockQuery
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [{ total: 0 }] });
+        const res = await request(makeApp())
+            .get('/api/companion/list')
+            .query({ deviceId: DEVICE, deviceSecret: DEVICE_SECRET });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+    });
+
+    test('400 when scope=mine requested with deviceSecret-only auth', async () => {
+        const res = await request(makeApp())
+            .get('/api/companion/list')
+            .query({ deviceId: DEVICE, deviceSecret: DEVICE_SECRET, scope: 'mine' });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('scope_mine_requires_entity');
+    });
+
+    test('401 on wrong deviceSecret', async () => {
+        const res = await request(makeApp())
+            .get('/api/companion/list')
+            .query({ deviceId: DEVICE, deviceSecret: 'wrong' });
+        expect(res.status).toBe(401);
+    });
+
+    test('detail accepts deviceSecret and returns published companion', async () => {
+        __mockQuery.mockResolvedValueOnce({
+            rowCount: 1,
+            rows: [{
+                id: 'petdx-pub', name: 'P', version: '1.0.0',
+                author_entity_id: null, device_id: null,
+                descriptor: {}, asset_type: 'procedural', asset_url: null,
+                avatar_url: null, thumbnail_url: null,
+                supported_states: ['IDLE'], scope: 'system', status: 'published',
+                license: 'EClaw-default', tags: [], i18n_data: null,
+                category: null, mood: null, color: null,
+                download_count: 0, favorite_count: 0, rating_avg: null,
+                rating_count: 0, comment_count: 0, published_at: 1778000000000,
+            }],
+        });
+        const res = await request(makeApp())
+            .get('/api/companion/petdx-pub')
+            .query({ deviceId: DEVICE, deviceSecret: DEVICE_SECRET });
+        expect(res.status).toBe(200);
+        expect(res.body.companion.id).toBe('petdx-pub');
     });
 });
 


### PR DESCRIPTION
## Summary

End-to-end Petdx companion picking flow: descriptor row in Postgres → `/api/companion/list` (now reachable from portal pages) → `/portal/petdx-browser.html` grid with live previews powered by `petdx-renderer.js` (#2572).

- **`backend/companion-api.js`** — factory now also accepts `authenticateDeviceOrBot`. `/list` and `/:id` accept either deviceSecret (portal device-owner creds) or botSecret+entityId. `scope=mine` still requires entityId so non-bot callers can't impersonate ownership. `authMode` is forwarded so the detail `isOwner` check works for both auth paths.
- **`backend/index.js`** — pass `authenticateDeviceOrBot` into `companionFactory`.
- **`backend/companion_schema.sql`** — idempotent seed for two system companions (`petdx-lobster-default`, `petdx-lobster-blue`), `status=published`, `scope=system`. `ON CONFLICT DO NOTHING` so re-running boot init is safe.
- **`backend/public/portal/petdx-browser.html`** — the browser page itself.
  - localStorage auth via `eclaw_device_id` / `eclaw_device_secret`; URL params override for ad-hoc testing.
  - Filter chips: scope / category / sort. Debounced (250ms) search input → `?q=`.
  - Responsive grid: `auto-fill 180px` desktop → `auto-fill 140px` ≤ 600px.
  - Live procedural preview per card via `PetdxRenderer.createRenderer`. `rendererKeyFromCard` heuristic: name/tags match → `lobster-procedural`; otherwise → `fallback-blob` (registered grey-circle placeholder, so unknown drawer keys still render).
  - `tearDownRenderers` on every reload to keep rAF count bounded.
  - Detail modal: enlarged preview, full `supportedStates` as buttons (toggle live), Select/Favorite stubs that gracefully alert "Stage 2 endpoint forthcoming" on 404.
  - Esc / backdrop click / × all close.
- **`backend/tests/jest/companion-api.test.js`** — +4 tests covering the new deviceSecret auth path: 200 with deviceSecret-only, 400 on `scope=mine` without entityId, 401 on wrong deviceSecret, 200 detail with deviceSecret. All 19 tests green.

## Browser verification (per `feedback_personal_screenshot_review`)

Drove Playwright with 3 stubbed companions on `http://localhost:8765/portal/petdx-browser.html?deviceId=demo&deviceSecret=demo`:
1. **Desktop grid** — red lobster + blue lobster + green fallback-blob (with `?` and IDLE label) all render distinctly. Scope chips (SYSTEM / COMMUNITY) coloured.
2. **Detail modal** — clicking the default lobster opens the enlarged preview with all 5 state buttons (IDLE/BUSY/EATING/SLEEPING/EXCITED) + Select / Favorite + descriptor JSON.
3. **Mobile (390×844)** — 2-col grid, filter chips wrap correctly, name + scope tag readable.

## Test plan

- [x] `npm test -- tests/jest/companion-api.test.js` → 19/19 green
- [x] Browser smoke (desktop + mobile + modal)
- [ ] CI green (ESLint / Critical portal / i18n / Jest / Railway)
- [ ] Self-review of diff before merge per `feedback_i_am_the_reviewer`

## Out of scope (Stage 2 follow-ups)

- POST /api/companion/select (currently 404 → page shows informative alert)
- POST /api/companion/:id/favorite (same)
- "我的" scope from a bot context (requires per-entity entry; today portal user picks at device-owner level)

Card: `card_f35efd67b2e22dc41a6950a4` ([UI] 伙伴瀏覽器與選擇器)
Spec: `docs/specs/petdx-uiux-spec.md` (v0.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)