### PR TITLE
feat(petdx): companion Stage 2 — favorites + select + current

### DIFF
--- a/backend/companion-api.js
+++ b/backend/companion-api.js
@@ -4,8 +4,8 @@
  * Mounted at: /api/companion
  *
  * Spec: docs/specs/petdx-backend-api-spec.md (v0.2)
- * Stage 1 (this file): read endpoints only — list + detail.
- *   Stage 2: favorites + select + current
+ * Stage 1: read endpoints — list + detail.
+ * Stage 2 (this file): + favorites + select + current
  *   Stage 3: ratings + comments
  *   Stage 4: submit + draft + review (creator + device-owner gated)
  *
@@ -30,6 +30,7 @@ const ALLOWED_SORTS = new Set(['popular', 'recent', 'rating', 'favorites']);
 const ALLOWED_SCOPES = new Set(['all', 'system', 'community', 'mine']);
 const ALLOWED_ASSET_TYPES = new Set(['procedural', 'spritesheet', 'vector']);
 const ALLOWED_CATEGORIES = new Set(['animal', 'human', 'robot', 'mascot', 'custom']);
+const ALLOWED_SELECT_SOURCES = new Set(['portal', 'app', 'api']);
 
 function parsePositiveInt(value, fallback, max) {
     const n = parseInt(value, 10);
@@ -247,6 +248,205 @@ module.exports = function companionFactory({ authenticateBot, authenticateDevice
             });
         } catch (err) {
             log('error', 'companion', `[Companion] list query failed: ${err.message}`);
+            res.status(500).json({ success: false, error: 'query_failed' });
+        }
+    });
+
+    // ── GET /api/companion/current ────────────────────────────────
+    // Returns the caller's current selected companion + favorite ids.
+    // Owner key: (deviceId, entityId|null) — so device-only auth gets the
+    // device-level selection bucket, and bot auth gets per-entity.
+    router.get('/current', authReader, async (req, res) => {
+        const ownerEntity = req.botAuth.entityId; // may be null
+        try {
+            // Latest select_log row for (device, entity) → joined to companions
+            // for the descriptor payload. LEFT JOIN so a deleted companion
+            // returns selection=null instead of erroring.
+            const selectSql = `
+                SELECT s.companion_id, s.selected_at, s.source,
+                       c.id, c.name, c.version, c.author_entity_id, c.descriptor,
+                       c.asset_type, c.asset_url, c.avatar_url, c.thumbnail_url,
+                       c.supported_states, c.scope, c.status, c.license,
+                       c.category, c.mood, c.color, c.tags, c.i18n_data,
+                       c.download_count, c.favorite_count, c.rating_avg,
+                       c.rating_count, c.comment_count, c.published_at
+                  FROM companion_select_log s
+             LEFT JOIN companions c ON c.id = s.companion_id
+                 WHERE s.device_id = $1
+                   AND s.entity_id IS NOT DISTINCT FROM $2
+              ORDER BY s.selected_at DESC
+                 LIMIT 1
+            `;
+            const favSql = `
+                SELECT companion_id, created_at
+                  FROM companion_favorites
+                 WHERE device_id = $1
+                   AND entity_id IS NOT DISTINCT FROM $2
+              ORDER BY created_at DESC
+                 LIMIT 200
+            `;
+            const [selRes, favRes] = await Promise.all([
+                pool.query(selectSql, [req.botAuth.deviceId, ownerEntity]),
+                pool.query(favSql,    [req.botAuth.deviceId, ownerEntity]),
+            ]);
+
+            let selection = null;
+            if (selRes.rowCount > 0 && selRes.rows[0].id) {
+                const r = selRes.rows[0];
+                selection = {
+                    selectedAt: Number(r.selected_at),
+                    source: r.source,
+                    companion: rowToCompanionDetail(r),
+                };
+            }
+            res.json({
+                success: true,
+                selection,
+                favorites: favRes.rows.map(r => ({
+                    companionId: r.companion_id,
+                    favoritedAt: Number(r.created_at),
+                })),
+            });
+        } catch (err) {
+            log('error', 'companion', `[Companion] current query failed: ${err.message}`);
+            res.status(500).json({ success: false, error: 'query_failed' });
+        }
+    });
+
+    // ── POST /api/companion/select ────────────────────────────────
+    // Body: { companionId, source? }
+    // Appends a row to companion_select_log; returns the newly-current selection.
+    router.post('/select', authReader, async (req, res) => {
+        const companionId = req.body?.companionId;
+        const source = req.body?.source || 'portal';
+        if (!companionId || !/^[a-z0-9-]{1,80}$/i.test(companionId)) {
+            return res.status(400).json({ success: false, error: 'invalid_companion_id' });
+        }
+        if (!ALLOWED_SELECT_SOURCES.has(source)) {
+            return res.status(400).json({ success: false, error: 'invalid_source' });
+        }
+        try {
+            const cRes = await pool.query(
+                `SELECT id, status, scope, device_id, author_entity_id
+                   FROM companions
+                  WHERE id = $1`,
+                [companionId]
+            );
+            if (cRes.rowCount === 0) {
+                return res.status(404).json({ success: false, error: 'companion_not_found' });
+            }
+            const c = cRes.rows[0];
+            const isOwner = req.botAuth.authMode === 'device'
+                ? c.device_id === req.botAuth.deviceId
+                : (c.author_entity_id === req.botAuth.entityId
+                    && c.device_id === req.botAuth.deviceId);
+            if (c.status !== 'published' && c.scope !== 'system' && !isOwner) {
+                return res.status(404).json({ success: false, error: 'companion_not_found' });
+            }
+
+            const now = Date.now();
+            await pool.query(
+                `INSERT INTO companion_select_log
+                    (device_id, entity_id, companion_id, selected_at, source)
+                 VALUES ($1, $2, $3, $4, $5)`,
+                [req.botAuth.deviceId, req.botAuth.entityId, companionId, now, source]
+            );
+            res.json({
+                success: true,
+                selection: {
+                    companionId,
+                    selectedAt: now,
+                    source,
+                },
+            });
+        } catch (err) {
+            log('error', 'companion', `[Companion] select failed: ${err.message}`);
+            res.status(500).json({ success: false, error: 'query_failed' });
+        }
+    });
+
+    // ── POST /api/companion/:id/favorite ──────────────────────────
+    // Body: { action: 'add' | 'remove' | 'toggle' (default) }
+    // Single row per (device, entity, companion). favorite_count on companions
+    // is kept in sync with INSERT/DELETE side-effects (best-effort, not a
+    // trigger — Stage 2 trades strict consistency for fewer DB primitives).
+    router.post('/:id/favorite', authReader, async (req, res) => {
+        const { id } = req.params;
+        if (!/^[a-z0-9-]{1,80}$/i.test(id)) {
+            return res.status(400).json({ success: false, error: 'invalid_companion_id' });
+        }
+        const action = req.body?.action || 'toggle';
+        if (!['add', 'remove', 'toggle'].includes(action)) {
+            return res.status(400).json({ success: false, error: 'invalid_action' });
+        }
+        try {
+            const cRes = await pool.query(
+                `SELECT id, status, scope, device_id, author_entity_id, favorite_count
+                   FROM companions WHERE id = $1`,
+                [id]
+            );
+            if (cRes.rowCount === 0) {
+                return res.status(404).json({ success: false, error: 'companion_not_found' });
+            }
+            const c = cRes.rows[0];
+            const isOwner = req.botAuth.authMode === 'device'
+                ? c.device_id === req.botAuth.deviceId
+                : (c.author_entity_id === req.botAuth.entityId
+                    && c.device_id === req.botAuth.deviceId);
+            if (c.status !== 'published' && c.scope !== 'system' && !isOwner) {
+                return res.status(404).json({ success: false, error: 'companion_not_found' });
+            }
+
+            const existsRes = await pool.query(
+                `SELECT 1 FROM companion_favorites
+                  WHERE device_id = $1
+                    AND entity_id IS NOT DISTINCT FROM $2
+                    AND companion_id = $3`,
+                [req.botAuth.deviceId, req.botAuth.entityId, id]
+            );
+            const already = existsRes.rowCount > 0;
+            const wantFavorited = action === 'toggle' ? !already : action === 'add';
+
+            if (wantFavorited && !already) {
+                await pool.query(
+                    `INSERT INTO companion_favorites
+                        (device_id, entity_id, companion_id, created_at)
+                     VALUES ($1, $2, $3, $4)`,
+                    [req.botAuth.deviceId, req.botAuth.entityId, id, Date.now()]
+                );
+                await pool.query(
+                    `UPDATE companions SET favorite_count = favorite_count + 1 WHERE id = $1`,
+                    [id]
+                );
+            } else if (!wantFavorited && already) {
+                await pool.query(
+                    `DELETE FROM companion_favorites
+                      WHERE device_id = $1
+                        AND entity_id IS NOT DISTINCT FROM $2
+                        AND companion_id = $3`,
+                    [req.botAuth.deviceId, req.botAuth.entityId, id]
+                );
+                await pool.query(
+                    `UPDATE companions
+                        SET favorite_count = GREATEST(favorite_count - 1, 0)
+                      WHERE id = $1`,
+                    [id]
+                );
+            }
+
+            // Re-read fresh count for accurate client state.
+            const fresh = await pool.query(
+                `SELECT favorite_count FROM companions WHERE id = $1`,
+                [id]
+            );
+            res.json({
+                success: true,
+                favorited: wantFavorited,
+                companionId: id,
+                favoriteCount: fresh.rows[0]?.favorite_count ?? c.favorite_count,
+            });
+        } catch (err) {
+            log('error', 'companion', `[Companion] favorite failed: ${err.message}`);
             res.status(500).json({ success: false, error: 'query_failed' });
         }
     });

--- a/backend/companion_schema.sql
+++ b/backend/companion_schema.sql
@@ -58,6 +58,50 @@ CREATE INDEX IF NOT EXISTS idx_companions_asset_type    ON companions(asset_type
 CREATE INDEX IF NOT EXISTS idx_companions_tags          ON companions USING GIN (tags);
 
 -- ============================================
+-- companion_favorites — per (device, entity) favorite list
+-- ============================================
+-- (device_id, entity_id, companion_id) is the unique grain. entity_id may be
+-- NULL for device-only favoriting (deviceSecret auth path); the unique
+-- index COALESCEs entity_id to -1 so device-level rows still dedupe.
+
+CREATE TABLE IF NOT EXISTS companion_favorites (
+    id            BIGSERIAL PRIMARY KEY,
+    device_id     TEXT NOT NULL,
+    entity_id     INTEGER,
+    companion_id  TEXT NOT NULL REFERENCES companions(id) ON DELETE CASCADE,
+    created_at    BIGINT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_companion_favorites_unique
+    ON companion_favorites (device_id, COALESCE(entity_id, -1), companion_id);
+CREATE INDEX IF NOT EXISTS idx_companion_favorites_companion
+    ON companion_favorites (companion_id);
+CREATE INDEX IF NOT EXISTS idx_companion_favorites_owner
+    ON companion_favorites (device_id, entity_id);
+
+-- ============================================
+-- companion_select_log — append-only history of "select pet" actions
+-- ============================================
+-- Latest row per (device_id, entity_id) is the current selection. We keep a
+-- history rather than a single mutable row so we can show recent activity
+-- and let users undo. entity_id NULL = device-level selection.
+
+CREATE TABLE IF NOT EXISTS companion_select_log (
+    id            BIGSERIAL PRIMARY KEY,
+    device_id     TEXT NOT NULL,
+    entity_id     INTEGER,
+    companion_id  TEXT NOT NULL REFERENCES companions(id) ON DELETE CASCADE,
+    selected_at   BIGINT NOT NULL,
+    source        TEXT NOT NULL DEFAULT 'portal'
+                  CHECK (source IN ('portal','app','api'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_companion_select_owner_time
+    ON companion_select_log (device_id, entity_id, selected_at DESC);
+CREATE INDEX IF NOT EXISTS idx_companion_select_companion
+    ON companion_select_log (companion_id);
+
+-- ============================================
 -- Seed: official system companions (built-in; idempotent)
 -- ============================================
 -- These are the procedural drawers shipped in public/shared/petdx-renderer.js.

--- a/backend/public/portal/petdx-browser.html
+++ b/backend/public/portal/petdx-browser.html
@@ -524,11 +524,12 @@
         actions.className = 'modal-actions';
         const selectBtn = document.createElement('button');
         selectBtn.className = 'primary';
-        selectBtn.textContent = '一鍵切換 / Select';
+        selectBtn.textContent = currentSelectionId === detail.id
+            ? '✓ 目前選用' : '一鍵切換 / Select';
         selectBtn.addEventListener('click', () => onSelect(detail));
         const favBtn = document.createElement('button');
-        favBtn.textContent = '☆ 收藏 / Favorite';
-        favBtn.addEventListener('click', () => onFavorite(detail));
+        favBtn.textContent = favoriteIds.has(detail.id) ? '★ 已收藏' : '☆ 收藏';
+        favBtn.addEventListener('click', () => onFavorite(detail, favBtn));
         actions.appendChild(selectBtn);
         actions.appendChild(favBtn);
         body.appendChild(actions);
@@ -540,22 +541,36 @@
         }
     }
 
+    // Local cache populated from /current on load + every favorite toggle.
+    // Used to label the modal favorite button correctly (add vs remove).
+    const favoriteIds = new Set();
+    let currentSelectionId = null;
+
+    async function refreshOwnerState() {
+        const q = authQuery();
+        try {
+            const r = await fetch('/api/companion/current?' + q.toString());
+            if (!r.ok) return;
+            const data = await r.json();
+            favoriteIds.clear();
+            (data.favorites || []).forEach(f => favoriteIds.add(f.companionId));
+            currentSelectionId = data.selection?.companion?.id || null;
+        } catch (_) {
+            // Non-fatal: portal still works without state echo.
+        }
+    }
+
     async function onSelect(detail) {
-        // Stage 2 endpoint: POST /api/companion/select
-        // Returns 404 today; show informative message.
         const q = authQuery();
         try {
             const r = await fetch('/api/companion/select?' + q.toString(), {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ companionId: detail.id, ...Object.fromEntries(q.entries()) }),
+                body: JSON.stringify({ companionId: detail.id, source: 'portal' }),
             });
-            if (r.status === 404) {
-                alert('「一鍵切換」端點 (Stage 2) 尚未上線；切換功能即將推出。');
-                return;
-            }
-            const data = await r.json();
-            if (data.success) {
+            const data = await r.json().catch(() => ({}));
+            if (r.ok && data.success) {
+                currentSelectionId = detail.id;
                 alert('已切換為 ' + detail.name);
             } else {
                 alert('切換失敗：' + (data.error || r.status));
@@ -565,18 +580,22 @@
         }
     }
 
-    async function onFavorite(detail) {
+    async function onFavorite(detail, btn) {
         const q = authQuery();
         try {
             const r = await fetch('/api/companion/' + encodeURIComponent(detail.id) + '/favorite?' + q.toString(), {
                 method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ action: 'toggle' }),
             });
-            if (r.status === 404) {
-                alert('「收藏」端點 (Stage 2) 尚未上線；收藏功能即將推出。');
-                return;
+            const data = await r.json().catch(() => ({}));
+            if (r.ok && data.success) {
+                if (data.favorited) favoriteIds.add(detail.id);
+                else favoriteIds.delete(detail.id);
+                if (btn) btn.textContent = data.favorited ? '★ 已收藏' : '☆ 收藏';
+            } else {
+                alert('收藏失敗：' + (data.error || r.status));
             }
-            const data = await r.json();
-            alert(data.success ? '已加入收藏' : '收藏失敗：' + (data.error || r.status));
         } catch (err) {
             alert('網路錯誤：' + err.message);
         }
@@ -611,6 +630,7 @@
     // ── Boot ─────────────────────────────────────────────────────
     renderFilters();
     loadList();
+    refreshOwnerState();
 }());
 </script>
 </body>

--- a/backend/tests/jest/companion-api.test.js
+++ b/backend/tests/jest/companion-api.test.js
@@ -282,3 +282,203 @@ describe('companion-api: GET /:id', () => {
         expect(res.body.companion.scope).toBe('system');
     });
 });
+
+// ── Stage 2 ────────────────────────────────────────────────────────────
+// favorites / select / current. We mock pg query side-effects in sequence,
+// so the order of mockResolvedValueOnce calls matches the route's query
+// order. Tests only assert on shape + bind args, not transactional safety.
+
+describe('companion-api: GET /current', () => {
+    beforeEach(() => __mockQuery.mockReset());
+
+    test('200 returns null selection + empty favorites for fresh user', async () => {
+        __mockQuery
+            .mockResolvedValueOnce({ rowCount: 0, rows: [] })   // select_log lookup
+            .mockResolvedValueOnce({ rowCount: 0, rows: [] });  // favorites
+        const res = await request(makeApp())
+            .get('/api/companion/current')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY });
+        expect(res.status).toBe(200);
+        expect(res.body).toEqual({ success: true, selection: null, favorites: [] });
+    });
+
+    test('200 returns full descriptor + favorite list when populated', async () => {
+        __mockQuery
+            .mockResolvedValueOnce({
+                rowCount: 1,
+                rows: [{
+                    companion_id: 'petdx-pub', selected_at: 1778100000000, source: 'portal',
+                    id: 'petdx-pub', name: 'Pub', version: '1.0.0', author_entity_id: null,
+                    descriptor: { description: 'p' }, asset_type: 'procedural',
+                    asset_url: null, avatar_url: null, thumbnail_url: null,
+                    supported_states: ['IDLE'], scope: 'system', status: 'published',
+                    license: 'EClaw-default', tags: [], i18n_data: null,
+                    category: null, mood: null, color: null,
+                    download_count: 0, favorite_count: 0, rating_avg: null,
+                    rating_count: 0, comment_count: 0, published_at: 1778000000000,
+                }],
+            })
+            .mockResolvedValueOnce({
+                rowCount: 1,
+                rows: [{ companion_id: 'petdx-fav', created_at: 1778090000000 }],
+            });
+        const res = await request(makeApp())
+            .get('/api/companion/current')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY });
+        expect(res.status).toBe(200);
+        expect(res.body.selection.companion.id).toBe('petdx-pub');
+        expect(res.body.selection.selectedAt).toBe(1778100000000);
+        expect(res.body.favorites).toEqual([
+            { companionId: 'petdx-fav', favoritedAt: 1778090000000 },
+        ]);
+    });
+
+    test('binds entityId IS NOT DISTINCT FROM null on device-only auth', async () => {
+        __mockQuery
+            .mockResolvedValueOnce({ rowCount: 0, rows: [] })
+            .mockResolvedValueOnce({ rowCount: 0, rows: [] });
+        await request(makeApp())
+            .get('/api/companion/current')
+            .query({ deviceId: DEVICE, deviceSecret: DEVICE_SECRET });
+        const selectCall = __mockQuery.mock.calls[0];
+        expect(selectCall[0]).toMatch(/IS NOT DISTINCT FROM/);
+        expect(selectCall[1]).toEqual([DEVICE, null]);
+    });
+});
+
+describe('companion-api: POST /select', () => {
+    beforeEach(() => __mockQuery.mockReset());
+
+    test('400 on missing companionId', async () => {
+        const res = await request(makeApp())
+            .post('/api/companion/select')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({});
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('invalid_companion_id');
+    });
+
+    test('400 on bad source', async () => {
+        const res = await request(makeApp())
+            .post('/api/companion/select')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ companionId: 'petdx-x', source: 'cron' });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('invalid_source');
+    });
+
+    test('404 when companion missing', async () => {
+        __mockQuery.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+        const res = await request(makeApp())
+            .post('/api/companion/select')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ companionId: 'petdx-nope' });
+        expect(res.status).toBe(404);
+        expect(res.body.error).toBe('companion_not_found');
+    });
+
+    test('200 inserts log row and echoes selection', async () => {
+        __mockQuery
+            .mockResolvedValueOnce({                            // companions lookup
+                rowCount: 1,
+                rows: [{
+                    id: 'petdx-pub', status: 'published', scope: 'system',
+                    device_id: null, author_entity_id: null,
+                }],
+            })
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] });  // INSERT
+        const res = await request(makeApp())
+            .post('/api/companion/select')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ companionId: 'petdx-pub', source: 'app' });
+        expect(res.status).toBe(200);
+        expect(res.body.selection.companionId).toBe('petdx-pub');
+        expect(res.body.selection.source).toBe('app');
+        const insertCall = __mockQuery.mock.calls[1];
+        expect(insertCall[0]).toMatch(/INSERT INTO companion_select_log/);
+        expect(insertCall[1].slice(0, 3)).toEqual([DEVICE, ENTITY, 'petdx-pub']);
+        expect(insertCall[1][4]).toBe('app');
+    });
+});
+
+describe('companion-api: POST /:id/favorite', () => {
+    beforeEach(() => __mockQuery.mockReset());
+
+    test('400 on bad action', async () => {
+        const res = await request(makeApp())
+            .post('/api/companion/petdx-x/favorite')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ action: 'star' });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('invalid_action');
+    });
+
+    test('404 when companion missing', async () => {
+        __mockQuery.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+        const res = await request(makeApp())
+            .post('/api/companion/petdx-nope/favorite')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ action: 'add' });
+        expect(res.status).toBe(404);
+    });
+
+    test('toggle on a non-favorite companion adds + bumps count', async () => {
+        const baseCompanion = {
+            id: 'petdx-pub', status: 'published', scope: 'system',
+            device_id: null, author_entity_id: null, favorite_count: 4,
+        };
+        __mockQuery
+            .mockResolvedValueOnce({ rowCount: 1, rows: [baseCompanion] })       // lookup
+            .mockResolvedValueOnce({ rowCount: 0, rows: [] })                    // exists?
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] })                    // INSERT fav
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] })                    // UPDATE count
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{ favorite_count: 5 }] }); // re-read
+        const res = await request(makeApp())
+            .post('/api/companion/petdx-pub/favorite')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({});
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({
+            success: true, favorited: true, companionId: 'petdx-pub', favoriteCount: 5,
+        });
+    });
+
+    test('toggle on an existing favorite removes + decrements count', async () => {
+        const baseCompanion = {
+            id: 'petdx-pub', status: 'published', scope: 'system',
+            device_id: null, author_entity_id: null, favorite_count: 5,
+        };
+        __mockQuery
+            .mockResolvedValueOnce({ rowCount: 1, rows: [baseCompanion] })
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{ '?column?': 1 }] })   // exists
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] })                    // DELETE
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] })                    // UPDATE
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{ favorite_count: 4 }] });
+        const res = await request(makeApp())
+            .post('/api/companion/petdx-pub/favorite')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ action: 'toggle' });
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({ favorited: false, favoriteCount: 4 });
+    });
+
+    test('add on already-favorite is a no-op (count unchanged)', async () => {
+        const baseCompanion = {
+            id: 'petdx-pub', status: 'published', scope: 'system',
+            device_id: null, author_entity_id: null, favorite_count: 5,
+        };
+        __mockQuery
+            .mockResolvedValueOnce({ rowCount: 1, rows: [baseCompanion] })
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{ '?column?': 1 }] })   // exists
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{ favorite_count: 5 }] }); // re-read only
+        const res = await request(makeApp())
+            .post('/api/companion/petdx-pub/favorite')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ action: 'add' });
+        expect(res.status).toBe(200);
+        expect(res.body.favorited).toBe(true);
+        expect(res.body.favoriteCount).toBe(5);
+        // Only 3 queries: lookup + exists + re-read. No INSERT/UPDATE.
+        expect(__mockQuery.mock.calls).toHaveLength(3);
+    });
+});


### PR DESCRIPTION
## Summary
- Adds three Stage 2 read/write endpoints on top of the Stage 1 browser landed in #2573:
  - `POST /api/companion/select` — append-only select_log row
  - `POST /api/companion/:id/favorite` — toggle/add/remove with synchronized `favorite_count`
  - `GET /api/companion/current` — current selection + recent favorites for caller
- Two new tables (`companion_favorites`, `companion_select_log`) with the right indexes; `entity_id IS NOT DISTINCT FROM` lets device-only auth share its own bucket cleanly.
- Portal `petdx-browser.html` modal Select / Favorite buttons now hit real endpoints; labels reflect server state on load and after each toggle.

## Test plan
- [x] Jest 31/31 (12 new Stage 2 cases): /current shape, /select bind args, /favorite toggle add+remove+already-favorite no-op
- [x] ESLint clean
- [ ] CI green
- [ ] Self-review + merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)