### PR TITLE
feat(petdx): companion Stage 3 — ratings + comments

### DIFF
--- a/backend/companion-api.js
+++ b/backend/companion-api.js
@@ -5,8 +5,8 @@
  *
  * Spec: docs/specs/petdx-backend-api-spec.md (v0.2)
  * Stage 1: read endpoints — list + detail.
- * Stage 2 (this file): + favorites + select + current
- *   Stage 3: ratings + comments
+ * Stage 2: favorites + select + current
+ * Stage 3 (this file): + ratings + comments
  *   Stage 4: submit + draft + review (creator + device-owner gated)
  *
  * Auth: deviceId + botSecret + entityId — same triple as /api/bot/*.
@@ -447,6 +447,288 @@ module.exports = function companionFactory({ authenticateBot, authenticateDevice
             });
         } catch (err) {
             log('error', 'companion', `[Companion] favorite failed: ${err.message}`);
+            res.status(500).json({ success: false, error: 'query_failed' });
+        }
+    });
+
+    // ── GET /api/companion/:id/rating ─────────────────────────────
+    // Caller's own rating (used to pre-fill the star UI). 200 + stars=null
+    // when caller hasn't rated yet — distinct from 404 (companion missing).
+    router.get('/:id/rating', authReader, async (req, res) => {
+        const { id } = req.params;
+        if (!/^[a-z0-9-]{1,80}$/i.test(id)) {
+            return res.status(400).json({ success: false, error: 'invalid_companion_id' });
+        }
+        try {
+            const exists = await pool.query(
+                `SELECT 1 FROM companions WHERE id = $1`,
+                [id]
+            );
+            if (exists.rowCount === 0) {
+                return res.status(404).json({ success: false, error: 'companion_not_found' });
+            }
+            const r = await pool.query(
+                `SELECT stars, created_at, updated_at
+                   FROM companion_ratings
+                  WHERE companion_id = $1
+                    AND device_id = $2
+                    AND entity_id IS NOT DISTINCT FROM $3`,
+                [id, req.botAuth.deviceId, req.botAuth.entityId]
+            );
+            res.json({
+                success: true,
+                companionId: id,
+                stars: r.rowCount > 0 ? r.rows[0].stars : null,
+                createdAt: r.rowCount > 0 ? Number(r.rows[0].created_at) : null,
+                updatedAt: r.rowCount > 0 ? Number(r.rows[0].updated_at) : null,
+            });
+        } catch (err) {
+            log('error', 'companion', `[Companion] rating get failed: ${err.message}`);
+            res.status(500).json({ success: false, error: 'query_failed' });
+        }
+    });
+
+    // ── POST /api/companion/:id/rating ────────────────────────────
+    // Body: { stars: 1..5 }. Upsert per (device, entity). Recompute
+    // companions.rating_avg + rating_count atomically (well, two queries —
+    // good enough for v1; trigger upgrade can come with comment moderation).
+    router.post('/:id/rating', authReader, async (req, res) => {
+        const { id } = req.params;
+        if (!/^[a-z0-9-]{1,80}$/i.test(id)) {
+            return res.status(400).json({ success: false, error: 'invalid_companion_id' });
+        }
+        const stars = parseInt(req.body?.stars, 10);
+        if (!Number.isFinite(stars) || stars < 1 || stars > 5) {
+            return res.status(400).json({ success: false, error: 'invalid_stars' });
+        }
+        try {
+            const cRes = await pool.query(
+                `SELECT id, status, scope, device_id, author_entity_id
+                   FROM companions WHERE id = $1`,
+                [id]
+            );
+            if (cRes.rowCount === 0) {
+                return res.status(404).json({ success: false, error: 'companion_not_found' });
+            }
+            const c = cRes.rows[0];
+            const isOwner = req.botAuth.authMode === 'device'
+                ? c.device_id === req.botAuth.deviceId
+                : (c.author_entity_id === req.botAuth.entityId
+                    && c.device_id === req.botAuth.deviceId);
+            if (c.status !== 'published' && c.scope !== 'system' && !isOwner) {
+                return res.status(404).json({ success: false, error: 'companion_not_found' });
+            }
+
+            const now = Date.now();
+            const existsRes = await pool.query(
+                `SELECT id FROM companion_ratings
+                  WHERE companion_id = $1
+                    AND device_id = $2
+                    AND entity_id IS NOT DISTINCT FROM $3`,
+                [id, req.botAuth.deviceId, req.botAuth.entityId]
+            );
+            if (existsRes.rowCount > 0) {
+                await pool.query(
+                    `UPDATE companion_ratings
+                        SET stars = $1, updated_at = $2
+                      WHERE id = $3`,
+                    [stars, now, existsRes.rows[0].id]
+                );
+            } else {
+                await pool.query(
+                    `INSERT INTO companion_ratings
+                        (device_id, entity_id, companion_id, stars, created_at, updated_at)
+                     VALUES ($1, $2, $3, $4, $5, $5)`,
+                    [req.botAuth.deviceId, req.botAuth.entityId, id, stars, now]
+                );
+            }
+
+            const aggRes = await pool.query(
+                `SELECT COUNT(*)::int AS n, AVG(stars)::real AS avg
+                   FROM companion_ratings WHERE companion_id = $1`,
+                [id]
+            );
+            const { n, avg } = aggRes.rows[0];
+            await pool.query(
+                `UPDATE companions
+                    SET rating_count = $1, rating_avg = $2
+                  WHERE id = $3`,
+                [n, avg, id]
+            );
+
+            res.json({
+                success: true,
+                companionId: id,
+                stars,
+                ratingAvg: avg,
+                ratingCount: n,
+            });
+        } catch (err) {
+            log('error', 'companion', `[Companion] rating post failed: ${err.message}`);
+            res.status(500).json({ success: false, error: 'query_failed' });
+        }
+    });
+
+    // ── GET /api/companion/:id/comments?page&limit ────────────────
+    // Public read (all callers see the same list). Excludes soft-deleted rows.
+    router.get('/:id/comments', authReader, async (req, res) => {
+        const { id } = req.params;
+        if (!/^[a-z0-9-]{1,80}$/i.test(id)) {
+            return res.status(400).json({ success: false, error: 'invalid_companion_id' });
+        }
+        const page = parsePositiveInt(req.query.page, 1);
+        const limit = parsePositiveInt(req.query.limit, 30, 100);
+        const offset = (page - 1) * limit;
+        try {
+            const exists = await pool.query(
+                `SELECT 1 FROM companions WHERE id = $1`,
+                [id]
+            );
+            if (exists.rowCount === 0) {
+                return res.status(404).json({ success: false, error: 'companion_not_found' });
+            }
+            const [listRes, countRes] = await Promise.all([
+                pool.query(
+                    `SELECT id, entity_id, text, created_at
+                       FROM companion_comments
+                      WHERE companion_id = $1 AND deleted_at IS NULL
+                   ORDER BY created_at DESC
+                      LIMIT $2 OFFSET $3`,
+                    [id, limit, offset]
+                ),
+                pool.query(
+                    `SELECT COUNT(*)::int AS n
+                       FROM companion_comments
+                      WHERE companion_id = $1 AND deleted_at IS NULL`,
+                    [id]
+                ),
+            ]);
+            res.json({
+                success: true,
+                page,
+                limit,
+                total: countRes.rows[0]?.n || 0,
+                comments: listRes.rows.map(r => ({
+                    id: String(r.id),
+                    author: r.entity_id != null ? { entityId: r.entity_id } : null,
+                    text: r.text,
+                    createdAt: Number(r.created_at),
+                })),
+            });
+        } catch (err) {
+            log('error', 'companion', `[Companion] comments list failed: ${err.message}`);
+            res.status(500).json({ success: false, error: 'query_failed' });
+        }
+    });
+
+    // ── POST /api/companion/:id/comment ───────────────────────────
+    // Body: { text }. 1-500 chars after trim. Bumps companions.comment_count.
+    router.post('/:id/comment', authReader, async (req, res) => {
+        const { id } = req.params;
+        if (!/^[a-z0-9-]{1,80}$/i.test(id)) {
+            return res.status(400).json({ success: false, error: 'invalid_companion_id' });
+        }
+        const text = String(req.body?.text || '').trim();
+        if (text.length < 1 || text.length > 500) {
+            return res.status(400).json({ success: false, error: 'invalid_comment_text' });
+        }
+        try {
+            const cRes = await pool.query(
+                `SELECT id, status, scope, device_id, author_entity_id
+                   FROM companions WHERE id = $1`,
+                [id]
+            );
+            if (cRes.rowCount === 0) {
+                return res.status(404).json({ success: false, error: 'companion_not_found' });
+            }
+            const c = cRes.rows[0];
+            const isOwner = req.botAuth.authMode === 'device'
+                ? c.device_id === req.botAuth.deviceId
+                : (c.author_entity_id === req.botAuth.entityId
+                    && c.device_id === req.botAuth.deviceId);
+            if (c.status !== 'published' && c.scope !== 'system' && !isOwner) {
+                return res.status(404).json({ success: false, error: 'companion_not_found' });
+            }
+
+            const ins = await pool.query(
+                `INSERT INTO companion_comments
+                    (device_id, entity_id, companion_id, text, created_at)
+                 VALUES ($1, $2, $3, $4, $5)
+                 RETURNING id, created_at`,
+                [req.botAuth.deviceId, req.botAuth.entityId, id, text, Date.now()]
+            );
+            await pool.query(
+                `UPDATE companions
+                    SET comment_count = comment_count + 1
+                  WHERE id = $1`,
+                [id]
+            );
+
+            const r = ins.rows[0];
+            res.json({
+                success: true,
+                comment: {
+                    id: String(r.id),
+                    companionId: id,
+                    author: req.botAuth.entityId != null
+                        ? { entityId: req.botAuth.entityId }
+                        : null,
+                    text,
+                    createdAt: Number(r.created_at),
+                },
+            });
+        } catch (err) {
+            log('error', 'companion', `[Companion] comment post failed: ${err.message}`);
+            res.status(500).json({ success: false, error: 'query_failed' });
+        }
+    });
+
+    // ── DELETE /api/companion/comment/:cid ────────────────────────
+    // Author or companion owner can soft-delete. We do NOT cascade through
+    // /:id because the comment id is globally unique and the path looks
+    // cleaner for portal UIs that already hold the comment id.
+    router.delete('/comment/:cid', authReader, async (req, res) => {
+        const cid = parseInt(req.params.cid, 10);
+        if (!Number.isFinite(cid) || cid < 1) {
+            return res.status(400).json({ success: false, error: 'invalid_comment_id' });
+        }
+        try {
+            const r = await pool.query(
+                `SELECT c.id, c.companion_id, c.device_id, c.entity_id, c.deleted_at,
+                        co.device_id AS owner_device_id, co.author_entity_id AS owner_entity_id
+                   FROM companion_comments c
+              LEFT JOIN companions co ON co.id = c.companion_id
+                  WHERE c.id = $1`,
+                [cid]
+            );
+            if (r.rowCount === 0) {
+                return res.status(404).json({ success: false, error: 'comment_not_found' });
+            }
+            const row = r.rows[0];
+            if (row.deleted_at != null) {
+                return res.status(404).json({ success: false, error: 'comment_not_found' });
+            }
+            const isAuthor = row.device_id === req.botAuth.deviceId
+                && (row.entity_id == null || row.entity_id === req.botAuth.entityId);
+            const isCompanionOwner = row.owner_device_id === req.botAuth.deviceId
+                && (req.botAuth.authMode === 'device'
+                    || row.owner_entity_id === req.botAuth.entityId);
+            if (!isAuthor && !isCompanionOwner) {
+                return res.status(403).json({ success: false, error: 'forbidden' });
+            }
+            await pool.query(
+                `UPDATE companion_comments SET deleted_at = $1 WHERE id = $2`,
+                [Date.now(), cid]
+            );
+            await pool.query(
+                `UPDATE companions
+                    SET comment_count = GREATEST(comment_count - 1, 0)
+                  WHERE id = $1`,
+                [row.companion_id]
+            );
+            res.json({ success: true, commentId: String(cid) });
+        } catch (err) {
+            log('error', 'companion', `[Companion] comment delete failed: ${err.message}`);
             res.status(500).json({ success: false, error: 'query_failed' });
         }
     });

--- a/backend/companion_schema.sql
+++ b/backend/companion_schema.sql
@@ -102,6 +102,52 @@ CREATE INDEX IF NOT EXISTS idx_companion_select_companion
     ON companion_select_log (companion_id);
 
 -- ============================================
+-- companion_ratings — single mutable row per (device, entity, companion)
+-- ============================================
+-- Stars are 1..5 ints. We store updated_at separately so the API can show
+-- "edited" without hiding the original review timestamp. companions.rating_avg
+-- and rating_count are recomputed on every upsert/delete (small enough table
+-- per companion that a SELECT AVG is fine).
+
+CREATE TABLE IF NOT EXISTS companion_ratings (
+    id            BIGSERIAL PRIMARY KEY,
+    device_id     TEXT NOT NULL,
+    entity_id     INTEGER,
+    companion_id  TEXT NOT NULL REFERENCES companions(id) ON DELETE CASCADE,
+    stars         INTEGER NOT NULL CHECK (stars BETWEEN 1 AND 5),
+    created_at    BIGINT NOT NULL,
+    updated_at    BIGINT NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_companion_ratings_unique
+    ON companion_ratings (device_id, COALESCE(entity_id, -1), companion_id);
+CREATE INDEX IF NOT EXISTS idx_companion_ratings_companion
+    ON companion_ratings (companion_id);
+
+-- ============================================
+-- companion_comments — append + soft-delete log
+-- ============================================
+-- text length capped at 500 (validated in API). deleted_at != NULL hides the
+-- row from list queries; companions.comment_count is decremented on delete
+-- but we keep the row for moderator audit. Author-only or companion-owner
+-- can delete (enforced in router).
+
+CREATE TABLE IF NOT EXISTS companion_comments (
+    id            BIGSERIAL PRIMARY KEY,
+    device_id     TEXT NOT NULL,
+    entity_id     INTEGER,
+    companion_id  TEXT NOT NULL REFERENCES companions(id) ON DELETE CASCADE,
+    text          TEXT NOT NULL,
+    created_at    BIGINT NOT NULL,
+    deleted_at    BIGINT
+);
+
+CREATE INDEX IF NOT EXISTS idx_companion_comments_companion_time
+    ON companion_comments (companion_id, created_at DESC) WHERE deleted_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_companion_comments_owner
+    ON companion_comments (device_id, entity_id);
+
+-- ============================================
 -- Seed: official system companions (built-in; idempotent)
 -- ============================================
 -- These are the procedural drawers shipped in public/shared/petdx-renderer.js.

--- a/backend/tests/jest/companion-api.test.js
+++ b/backend/tests/jest/companion-api.test.js
@@ -482,3 +482,200 @@ describe('companion-api: POST /:id/favorite', () => {
         expect(__mockQuery.mock.calls).toHaveLength(3);
     });
 });
+
+// ── Stage 3 ────────────────────────────────────────────────────────────
+// ratings + comments. Mocked query order matches the route order.
+
+describe('companion-api: GET /:id/rating', () => {
+    beforeEach(() => __mockQuery.mockReset());
+
+    test('200 stars=null when caller has no rating yet', async () => {
+        __mockQuery
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{ '?column?': 1 }] })  // exists
+            .mockResolvedValueOnce({ rowCount: 0, rows: [] });
+        const res = await request(makeApp())
+            .get('/api/companion/petdx-pub/rating')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY });
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({ companionId: 'petdx-pub', stars: null });
+    });
+
+    test('200 returns existing stars', async () => {
+        __mockQuery
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{ '?column?': 1 }] })
+            .mockResolvedValueOnce({
+                rowCount: 1,
+                rows: [{ stars: 4, created_at: 1, updated_at: 2 }],
+            });
+        const res = await request(makeApp())
+            .get('/api/companion/petdx-pub/rating')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY });
+        expect(res.body.stars).toBe(4);
+    });
+});
+
+describe('companion-api: POST /:id/rating', () => {
+    beforeEach(() => __mockQuery.mockReset());
+
+    test('400 on stars out of range', async () => {
+        const res = await request(makeApp())
+            .post('/api/companion/petdx-pub/rating')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ stars: 7 });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('invalid_stars');
+    });
+
+    test('200 inserts when no prior row exists, recomputes avg+count', async () => {
+        const baseCompanion = {
+            id: 'petdx-pub', status: 'published', scope: 'system',
+            device_id: null, author_entity_id: null,
+        };
+        __mockQuery
+            .mockResolvedValueOnce({ rowCount: 1, rows: [baseCompanion] })       // companions lookup
+            .mockResolvedValueOnce({ rowCount: 0, rows: [] })                    // exists rating
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] })                    // INSERT
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{ n: 3, avg: 4.33 }] }) // agg
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] });                   // UPDATE companions
+        const res = await request(makeApp())
+            .post('/api/companion/petdx-pub/rating')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ stars: 5 });
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({
+            stars: 5, ratingAvg: 4.33, ratingCount: 3,
+        });
+    });
+
+    test('200 updates existing rating without inserting a new row', async () => {
+        const baseCompanion = {
+            id: 'petdx-pub', status: 'published', scope: 'system',
+            device_id: null, author_entity_id: null,
+        };
+        __mockQuery
+            .mockResolvedValueOnce({ rowCount: 1, rows: [baseCompanion] })
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 99 }] })          // existing
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] })                    // UPDATE rating
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{ n: 1, avg: 2.0 }] })
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+        const res = await request(makeApp())
+            .post('/api/companion/petdx-pub/rating')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ stars: 2 });
+        expect(res.status).toBe(200);
+        const updateCall = __mockQuery.mock.calls[2];
+        expect(updateCall[0]).toMatch(/UPDATE companion_ratings/);
+        expect(updateCall[1][0]).toBe(2);
+    });
+});
+
+describe('companion-api: comments list + create + delete', () => {
+    beforeEach(() => __mockQuery.mockReset());
+
+    test('200 GET /comments returns paginated soft-delete-filtered list', async () => {
+        __mockQuery
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{ '?column?': 1 }] })   // exists
+            .mockResolvedValueOnce({                                             // list
+                rowCount: 1,
+                rows: [{ id: 7, entity_id: 12, text: 'hi', created_at: 1778100000000 }],
+            })
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{ n: 1 }] });           // count
+        const res = await request(makeApp())
+            .get('/api/companion/petdx-pub/comments')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY });
+        expect(res.status).toBe(200);
+        expect(res.body.total).toBe(1);
+        expect(res.body.comments[0]).toEqual({
+            id: '7', author: { entityId: 12 }, text: 'hi', createdAt: 1778100000000,
+        });
+    });
+
+    test('400 on empty comment text', async () => {
+        const res = await request(makeApp())
+            .post('/api/companion/petdx-pub/comment')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ text: '   ' });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('invalid_comment_text');
+    });
+
+    test('400 on overlong comment text', async () => {
+        const res = await request(makeApp())
+            .post('/api/companion/petdx-pub/comment')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ text: 'x'.repeat(501) });
+        expect(res.status).toBe(400);
+    });
+
+    test('200 POST /comment inserts and bumps comment_count', async () => {
+        const baseCompanion = {
+            id: 'petdx-pub', status: 'published', scope: 'system',
+            device_id: null, author_entity_id: null,
+        };
+        __mockQuery
+            .mockResolvedValueOnce({ rowCount: 1, rows: [baseCompanion] })
+            .mockResolvedValueOnce({                                             // INSERT RETURNING
+                rowCount: 1,
+                rows: [{ id: 42, created_at: 1778200000000 }],
+            })
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] });                   // UPDATE count
+        const res = await request(makeApp())
+            .post('/api/companion/petdx-pub/comment')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ text: '好可愛!' });
+        expect(res.status).toBe(200);
+        expect(res.body.comment).toMatchObject({
+            id: '42', companionId: 'petdx-pub',
+            author: { entityId: ENTITY }, text: '好可愛!',
+        });
+    });
+
+    test('403 when neither author nor companion owner tries to delete', async () => {
+        __mockQuery.mockResolvedValueOnce({
+            rowCount: 1,
+            rows: [{
+                id: 5, companion_id: 'petdx-pub',
+                device_id: 'someone-else', entity_id: 999, deleted_at: null,
+                owner_device_id: 'other-dev', owner_entity_id: 1,
+            }],
+        });
+        const res = await request(makeApp())
+            .delete('/api/companion/comment/5')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY });
+        expect(res.status).toBe(403);
+    });
+
+    test('200 author can delete own comment, decrements count', async () => {
+        __mockQuery
+            .mockResolvedValueOnce({                                             // SELECT
+                rowCount: 1,
+                rows: [{
+                    id: 5, companion_id: 'petdx-pub',
+                    device_id: DEVICE, entity_id: ENTITY, deleted_at: null,
+                    owner_device_id: null, owner_entity_id: null,
+                }],
+            })
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] })                    // UPDATE deleted_at
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] });                   // UPDATE count
+        const res = await request(makeApp())
+            .delete('/api/companion/comment/5')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY });
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({ success: true, commentId: '5' });
+    });
+
+    test('404 when comment already soft-deleted', async () => {
+        __mockQuery.mockResolvedValueOnce({
+            rowCount: 1,
+            rows: [{
+                id: 5, companion_id: 'petdx-pub',
+                device_id: DEVICE, entity_id: ENTITY, deleted_at: 1778000000000,
+                owner_device_id: null, owner_entity_id: null,
+            }],
+        });
+        const res = await request(makeApp())
+            .delete('/api/companion/comment/5')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY });
+        expect(res.status).toBe(404);
+    });
+});


### PR DESCRIPTION
## Summary
- Adds the rating + comment endpoints on top of Stages 1+2; community-contribution UX (Stage 4) plugs in next.
- Two new tables (`companion_ratings`, `companion_comments`); ratings are a single mutable row per (device,entity,companion), comments are append + soft-delete with a partial index for cheap "live list" queries.
- Companion-owner OR original author can delete a comment.

## Test plan
- [x] Jest 43/43 (12 new Stage 3 cases): rating upsert vs update path, /comments pagination, comment validation, delete authorization (403 for outsiders, 200 for author, 404 for already-deleted)
- [x] ESLint clean
- [ ] CI green
- [ ] Self-review + merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)