### PR TITLE
feat(petdx-wallpaper): multi-creature drawers + Settings → 瀏覽伙伴 entry

### DIFF
--- a/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
@@ -329,6 +329,15 @@ class SettingsActivity : AppCompatActivity() {
             startActivity(Intent(this, WallpaperPreviewActivity::class.java))
         }
 
+        findViewById<MaterialButton>(R.id.btnBrowseCompanions).setOnClickListener {
+            TelemetryHelper.trackAction("settings_browse_companions")
+            WebViewActivity.launch(
+                this,
+                "https://eclawbot.com/portal/petdx-browser.html",
+                getString(R.string.browse_companions)
+            )
+        }
+
         findViewById<MaterialButton>(R.id.btnFileManager).setOnClickListener {
             startActivity(Intent(this, FileManagerActivity::class.java))
         }

--- a/app/src/main/java/com/hank/clawlive/WallpaperPreviewActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/WallpaperPreviewActivity.kt
@@ -20,6 +20,7 @@ import com.google.android.material.button.MaterialButton
 import com.google.android.material.materialswitch.MaterialSwitch
 import com.hank.clawlive.data.local.DeviceManager
 import com.hank.clawlive.data.local.LayoutPreferences
+import com.hank.clawlive.data.model.CompanionDetail
 import com.hank.clawlive.data.remote.NetworkModule
 import com.hank.clawlive.service.ClawWallpaperService
 import com.hank.clawlive.ui.RecordingIndicatorHelper
@@ -244,6 +245,7 @@ class WallpaperPreviewActivity : AppCompatActivity() {
                 }
 
                 previewView.setEntities(boundEntities)
+                loadCompanions(boundEntities)
 
             } catch (e: Exception) {
                 Timber.e(e, "Failed to load entities")
@@ -253,6 +255,31 @@ class WallpaperPreviewActivity : AppCompatActivity() {
                     Toast.LENGTH_LONG
                 ).show()
             }
+        }
+    }
+
+    /**
+     * Fetch each entity's currently-selected companion in parallel and push
+     * the resulting map into the preview view so renderer dispatch (cat/dog/fish)
+     * runs in the preview as well as the live wallpaper. Spec §4.3.
+     */
+    private fun loadCompanions(entities: List<com.hank.clawlive.data.model.EntityStatus>) {
+        lifecycleScope.launch {
+            val map = mutableMapOf<Int, CompanionDetail?>()
+            for (entity in entities) {
+                val secret = entity.botSecret ?: continue
+                try {
+                    val resp = api.getCurrentCompanion(
+                        deviceId = deviceManager.deviceId,
+                        botSecret = secret,
+                        entityId = entity.entityId
+                    )
+                    map[entity.entityId] = resp.selection?.companion
+                } catch (e: Exception) {
+                    Timber.w(e, "Companion fetch failed for entity ${entity.entityId}")
+                }
+            }
+            previewView.setCompanions(map)
         }
     }
 }

--- a/app/src/main/java/com/hank/clawlive/data/model/CompanionDescriptor.kt
+++ b/app/src/main/java/com/hank/clawlive/data/model/CompanionDescriptor.kt
@@ -91,6 +91,15 @@ data class CompanionDetail(
         val asset = descriptor?.getAsJsonObject("asset") ?: return assetUrl
         return asset.get("sheetUrl")?.asString ?: assetUrl
     }
+
+    /**
+     * Procedural renderer key (e.g. "lobster-procedural", "cat-procedural").
+     * Spec §4.3 — drives ProceduralCreatureDrawer dispatch.
+     */
+    fun proceduralRenderer(): String? {
+        val asset = descriptor?.getAsJsonObject("asset") ?: return null
+        return asset.get("renderer")?.asString
+    }
 }
 
 data class StateAssetHint(

--- a/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
@@ -843,6 +843,18 @@ class ClawRenderer(
             isAntiAlias = true
         }
 
+        // Procedural creature dispatch — non-lobster renderers handled by
+        // ProceduralCreatureDrawer; default falls through to legacy lobster paths.
+        val rendererKey = companion?.proceduralRenderer()
+        val drewCreature = ProceduralCreatureDrawer.draw(
+            canvas, rendererKey, entity, companion, coralBright, coralDark,
+            System.currentTimeMillis() - startTime
+        )
+        if (drewCreature) {
+            canvas.restore()
+            return
+        }
+
         // Body
         val bodyPath = android.graphics.Path().apply {
             moveTo(60f, 10f)

--- a/app/src/main/java/com/hank/clawlive/engine/ProceduralCreatureDrawer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/ProceduralCreatureDrawer.kt
@@ -1,0 +1,357 @@
+package com.hank.clawlive.engine
+
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.Paint
+import android.graphics.Path
+import com.hank.clawlive.data.model.CompanionDetail
+import com.hank.clawlive.data.model.EntityStatus
+import kotlin.math.sin
+
+/**
+ * Procedural drawers keyed by `descriptor.asset.renderer` (spec §4.3).
+ * All drawers operate inside a 120x120 logical viewport so the existing
+ * lobster-style canvas transform in ClawRenderer can wrap them unchanged.
+ *
+ * Adding a new creature: register a new key + body Path in [draw].
+ */
+object ProceduralCreatureDrawer {
+
+    fun supports(rendererKey: String?): Boolean = when (rendererKey) {
+        "cat-procedural", "dog-procedural", "fish-procedural" -> true
+        else -> false
+    }
+
+    /**
+     * Draws creature inside the already-transformed canvas (120x120 viewport).
+     * Returns true if a creature was drawn, false to fall back to default lobster.
+     */
+    fun draw(
+        canvas: Canvas,
+        rendererKey: String?,
+        entity: EntityStatus,
+        companion: CompanionDetail?,
+        bodyColor: Int,
+        darkColor: Int,
+        timeMs: Long
+    ): Boolean = when (rendererKey) {
+        "cat-procedural" -> { drawCat(canvas, entity, bodyColor, darkColor, timeMs); true }
+        "dog-procedural" -> { drawDog(canvas, entity, bodyColor, darkColor, timeMs); true }
+        "fish-procedural" -> { drawFish(canvas, entity, bodyColor, darkColor, timeMs); true }
+        else -> false
+    }
+
+    private fun fillPaint(c: Int) = Paint().apply {
+        style = Paint.Style.FILL; color = c; isAntiAlias = true
+    }
+    private fun strokePaint(c: Int, w: Float = 2f) = Paint().apply {
+        style = Paint.Style.STROKE; color = c; strokeWidth = w
+        strokeCap = Paint.Cap.ROUND; isAntiAlias = true
+    }
+
+    // ---------------------------------------------------------------- Cat
+    private fun drawCat(canvas: Canvas, e: EntityStatus, body: Int, dark: Int, t: Long) {
+        val tailWag = sin(t * 0.005).toFloat() * 8f
+        val ear = fillPaint(body)
+        val bodyP = fillPaint(body)
+        val belly = fillPaint(lighten(body, 0.25f))
+        val outline = strokePaint(dark, 1.5f)
+
+        // Tail (behind body, animated wag)
+        val tail = Path().apply {
+            moveTo(95f, 80f)
+            quadTo(115f + tailWag, 60f, 110f + tailWag, 35f)
+            quadTo(108f + tailWag, 30f, 105f + tailWag, 32f)
+            quadTo(108f + tailWag, 50f, 90f, 78f)
+            close()
+        }
+        canvas.drawPath(tail, bodyP); canvas.drawPath(tail, outline)
+
+        // Body (rounded oval)
+        val bodyPath = Path().apply {
+            moveTo(60f, 30f)
+            cubicTo(25f, 30f, 18f, 70f, 25f, 95f)
+            cubicTo(30f, 110f, 90f, 110f, 95f, 95f)
+            cubicTo(102f, 70f, 95f, 30f, 60f, 30f)
+            close()
+        }
+        canvas.drawPath(bodyPath, bodyP); canvas.drawPath(bodyPath, outline)
+
+        // Belly highlight
+        val bellyPath = Path().apply {
+            moveTo(45f, 65f); cubicTo(42f, 90f, 78f, 90f, 75f, 65f)
+            cubicTo(70f, 60f, 50f, 60f, 45f, 65f); close()
+        }
+        canvas.drawPath(bellyPath, belly)
+
+        // Ears (triangles)
+        val earL = Path().apply {
+            moveTo(35f, 30f); lineTo(28f, 8f); lineTo(50f, 22f); close()
+        }
+        val earR = Path().apply {
+            moveTo(85f, 30f); lineTo(92f, 8f); lineTo(70f, 22f); close()
+        }
+        canvas.drawPath(earL, ear); canvas.drawPath(earL, outline)
+        canvas.drawPath(earR, ear); canvas.drawPath(earR, outline)
+        // Inner ears
+        val pink = fillPaint(Color.argb(255, 255, 180, 200))
+        canvas.drawPath(Path().apply {
+            moveTo(36f, 28f); lineTo(33f, 14f); lineTo(43f, 22f); close()
+        }, pink)
+        canvas.drawPath(Path().apply {
+            moveTo(84f, 28f); lineTo(87f, 14f); lineTo(77f, 22f); close()
+        }, pink)
+
+        // Face features
+        drawCatFace(canvas, e, dark)
+
+        // Front paws
+        canvas.drawCircle(40f, 105f, 8f, bodyP)
+        canvas.drawCircle(80f, 105f, 8f, bodyP)
+    }
+
+    private fun drawCatFace(canvas: Canvas, e: EntityStatus, dark: Int) {
+        val eye = fillPaint(Color.parseColor("#1a1a2e"))
+        val glow = fillPaint(Color.parseColor("#80ffd9"))
+        val sleeping = e.state.toString() == "SLEEPING"
+
+        if (sleeping) {
+            // Closed eyes (curve)
+            val p = strokePaint(Color.parseColor("#1a1a2e"), 2f)
+            canvas.drawArc(46f, 50f, 56f, 60f, 0f, 180f, false, p)
+            canvas.drawArc(64f, 50f, 74f, 60f, 0f, 180f, false, p)
+        } else {
+            canvas.drawCircle(51f, 55f, 4f, eye)
+            canvas.drawCircle(69f, 55f, 4f, eye)
+            // Cyan slit pupil
+            val slit = Paint().apply {
+                color = Color.parseColor("#80ffd9"); style = Paint.Style.FILL; isAntiAlias = true
+            }
+            canvas.drawOval(50f, 53f, 52f, 57f, slit)
+            canvas.drawOval(68f, 53f, 70f, 57f, slit)
+        }
+
+        // Pink nose
+        val nose = fillPaint(Color.parseColor("#ff8fa3"))
+        val noseP = Path().apply {
+            moveTo(57f, 65f); lineTo(63f, 65f); lineTo(60f, 70f); close()
+        }
+        canvas.drawPath(noseP, nose)
+
+        // Mouth
+        val mouth = strokePaint(dark, 1.5f)
+        canvas.drawLine(60f, 70f, 60f, 74f, mouth)
+        canvas.drawArc(54f, 70f, 60f, 78f, 0f, 90f, false, mouth)
+        canvas.drawArc(60f, 70f, 66f, 78f, 90f, 90f, false, mouth)
+
+        // Whiskers
+        val w = strokePaint(dark, 1f)
+        canvas.drawLine(28f, 65f, 48f, 64f, w)
+        canvas.drawLine(28f, 70f, 48f, 70f, w)
+        canvas.drawLine(72f, 64f, 92f, 65f, w)
+        canvas.drawLine(72f, 70f, 92f, 70f, w)
+    }
+
+    // ---------------------------------------------------------------- Dog
+    private fun drawDog(canvas: Canvas, e: EntityStatus, body: Int, dark: Int, t: Long) {
+        val tailWag = sin(t * 0.012).toFloat() * 12f
+        val tongue = e.state.toString() == "EXCITED" || e.state.toString() == "EATING"
+
+        val bodyP = fillPaint(body)
+        val outline = strokePaint(dark, 2f)
+        val belly = fillPaint(lighten(body, 0.3f))
+        val earC = fillPaint(darken(body, 0.7f))
+
+        // Wagging tail
+        val tail = Path().apply {
+            moveTo(98f, 70f)
+            quadTo(115f + tailWag, 55f, 112f + tailWag, 35f)
+            quadTo(110f + tailWag, 30f, 107f + tailWag, 33f)
+            quadTo(106f + tailWag, 50f, 95f, 70f)
+            close()
+        }
+        canvas.drawPath(tail, bodyP); canvas.drawPath(tail, outline)
+
+        // Body
+        val bodyPath = Path().apply {
+            moveTo(60f, 35f)
+            cubicTo(28f, 35f, 20f, 75f, 28f, 100f)
+            cubicTo(35f, 112f, 85f, 112f, 92f, 100f)
+            cubicTo(100f, 75f, 92f, 35f, 60f, 35f)
+            close()
+        }
+        canvas.drawPath(bodyPath, bodyP); canvas.drawPath(bodyPath, outline)
+
+        // Belly
+        canvas.drawPath(Path().apply {
+            moveTo(45f, 75f); cubicTo(42f, 100f, 78f, 100f, 75f, 75f)
+            cubicTo(70f, 70f, 50f, 70f, 45f, 75f); close()
+        }, belly)
+
+        // Floppy ears
+        val earL = Path().apply {
+            moveTo(32f, 35f); cubicTo(20f, 40f, 18f, 65f, 32f, 65f)
+            cubicTo(38f, 60f, 38f, 38f, 32f, 35f); close()
+        }
+        val earR = Path().apply {
+            moveTo(88f, 35f); cubicTo(100f, 40f, 102f, 65f, 88f, 65f)
+            cubicTo(82f, 60f, 82f, 38f, 88f, 35f); close()
+        }
+        canvas.drawPath(earL, earC); canvas.drawPath(earL, outline)
+        canvas.drawPath(earR, earC); canvas.drawPath(earR, outline)
+
+        // Face
+        drawDogFace(canvas, e, dark, tongue)
+
+        // Front paws
+        canvas.drawCircle(40f, 108f, 9f, bodyP)
+        canvas.drawCircle(80f, 108f, 9f, bodyP)
+        canvas.drawCircle(40f, 108f, 9f, outline)
+        canvas.drawCircle(80f, 108f, 9f, outline)
+    }
+
+    private fun drawDogFace(canvas: Canvas, e: EntityStatus, dark: Int, tongue: Boolean) {
+        val eye = fillPaint(Color.parseColor("#1a1a2e"))
+        val sleeping = e.state.toString() == "SLEEPING"
+
+        if (sleeping) {
+            val p = strokePaint(Color.parseColor("#1a1a2e"), 2f)
+            canvas.drawArc(46f, 52f, 56f, 62f, 0f, 180f, false, p)
+            canvas.drawArc(64f, 52f, 74f, 62f, 0f, 180f, false, p)
+        } else {
+            canvas.drawCircle(51f, 57f, 4.5f, eye)
+            canvas.drawCircle(69f, 57f, 4.5f, eye)
+            val white = fillPaint(Color.WHITE)
+            canvas.drawCircle(52f, 56f, 1.5f, white)
+            canvas.drawCircle(70f, 56f, 1.5f, white)
+        }
+
+        // Snout
+        val snout = fillPaint(lighten(dark, 0.6f))
+        val snoutPath = Path().apply {
+            moveTo(50f, 68f); cubicTo(50f, 80f, 70f, 80f, 70f, 68f)
+            cubicTo(70f, 65f, 50f, 65f, 50f, 68f); close()
+        }
+        canvas.drawPath(snoutPath, snout)
+
+        // Black nose
+        val nose = fillPaint(Color.parseColor("#1a1a2e"))
+        val noseP = Path().apply {
+            moveTo(56f, 70f); cubicTo(56f, 76f, 64f, 76f, 64f, 70f)
+            cubicTo(64f, 67f, 56f, 67f, 56f, 70f); close()
+        }
+        canvas.drawPath(noseP, nose)
+
+        if (tongue) {
+            val pink = fillPaint(Color.parseColor("#ff6b8a"))
+            canvas.drawPath(Path().apply {
+                moveTo(57f, 76f); cubicTo(56f, 88f, 64f, 88f, 63f, 76f); close()
+            }, pink)
+        }
+    }
+
+    // ---------------------------------------------------------------- Fish
+    private fun drawFish(canvas: Canvas, e: EntityStatus, body: Int, dark: Int, t: Long) {
+        val finFlap = sin(t * 0.008).toFloat() * 6f
+        val tailWave = sin(t * 0.006).toFloat() * 5f
+
+        val bodyP = fillPaint(body)
+        val outline = strokePaint(dark, 1.5f)
+        val belly = fillPaint(lighten(body, 0.4f))
+        val finC = fillPaint(darken(body, 0.75f))
+
+        // Tail fin (back)
+        val tail = Path().apply {
+            moveTo(20f, 60f)
+            lineTo(5f, 35f + tailWave)
+            lineTo(8f, 60f)
+            lineTo(5f, 85f - tailWave)
+            close()
+        }
+        canvas.drawPath(tail, finC); canvas.drawPath(tail, outline)
+
+        // Body (almond)
+        val bodyPath = Path().apply {
+            moveTo(20f, 60f)
+            cubicTo(25f, 30f, 90f, 30f, 105f, 60f)
+            cubicTo(90f, 90f, 25f, 90f, 20f, 60f)
+            close()
+        }
+        canvas.drawPath(bodyPath, bodyP); canvas.drawPath(bodyPath, outline)
+
+        // Belly stripe
+        canvas.drawPath(Path().apply {
+            moveTo(30f, 65f); cubicTo(40f, 82f, 80f, 82f, 95f, 65f)
+            cubicTo(85f, 75f, 35f, 75f, 30f, 65f); close()
+        }, belly)
+
+        // Top dorsal fin (animated)
+        val dorsal = Path().apply {
+            moveTo(45f, 35f)
+            lineTo(55f, 18f + finFlap)
+            lineTo(65f, 20f + finFlap)
+            lineTo(75f, 35f)
+            close()
+        }
+        canvas.drawPath(dorsal, finC); canvas.drawPath(dorsal, outline)
+
+        // Side fin
+        val sideFin = Path().apply {
+            moveTo(60f, 70f)
+            quadTo(50f, 88f + finFlap, 65f, 80f)
+            close()
+        }
+        canvas.drawPath(sideFin, finC); canvas.drawPath(sideFin, outline)
+
+        // Scales (decorative dots)
+        val scale = fillPaint(darken(body, 0.85f))
+        for (sx in intArrayOf(45, 60, 75, 90)) {
+            for (sy in intArrayOf(50, 65)) {
+                canvas.drawCircle(sx.toFloat(), sy.toFloat(), 3f, scale)
+            }
+        }
+
+        // Eye
+        drawFishFace(canvas, e)
+    }
+
+    private fun drawFishFace(canvas: Canvas, e: EntityStatus) {
+        val sleeping = e.state.toString() == "SLEEPING"
+        val white = fillPaint(Color.WHITE)
+        val pupil = fillPaint(Color.parseColor("#1a1a2e"))
+        val outline = strokePaint(Color.parseColor("#1a1a2e"), 1f)
+
+        canvas.drawCircle(85f, 55f, 6f, white)
+        canvas.drawCircle(85f, 55f, 6f, outline)
+        if (sleeping) {
+            val p = strokePaint(Color.parseColor("#1a1a2e"), 1.5f)
+            canvas.drawLine(80f, 55f, 90f, 55f, p)
+        } else {
+            canvas.drawCircle(86f, 55f, 3f, pupil)
+            canvas.drawCircle(87f, 54f, 1f, white)
+        }
+
+        // Mouth (pucker)
+        val m = strokePaint(Color.parseColor("#1a1a2e"), 1.5f)
+        canvas.drawArc(95f, 60f, 105f, 70f, 90f, 180f, false, m)
+    }
+
+    // ---------------------------------------------------------------- color utils
+    private fun lighten(c: Int, factor: Float): Int {
+        val r = Color.red(c); val g = Color.green(c); val b = Color.blue(c)
+        return Color.rgb(
+            (r + (255 - r) * factor).toInt().coerceIn(0, 255),
+            (g + (255 - g) * factor).toInt().coerceIn(0, 255),
+            (b + (255 - b) * factor).toInt().coerceIn(0, 255),
+        )
+    }
+
+    private fun darken(c: Int, factor: Float): Int {
+        val r = Color.red(c); val g = Color.green(c); val b = Color.blue(c)
+        return Color.rgb(
+            (r * factor).toInt().coerceIn(0, 255),
+            (g * factor).toInt().coerceIn(0, 255),
+            (b * factor).toInt().coerceIn(0, 255),
+        )
+    }
+}

--- a/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
@@ -13,7 +13,9 @@ import android.view.ScaleGestureDetector
 import android.view.View
 import com.hank.clawlive.data.local.LayoutPreferences
 import com.hank.clawlive.R
+import com.hank.clawlive.data.model.CompanionDetail
 import com.hank.clawlive.data.model.EntityStatus
+import com.hank.clawlive.engine.ProceduralCreatureDrawer
 import kotlin.math.ceil
 import kotlin.math.sqrt
 import timber.log.Timber
@@ -36,6 +38,10 @@ class WallpaperPreviewView @JvmOverloads constructor(
 
     // Entities to display (only bound entities)
     private var entities: List<EntityStatus> = emptyList()
+
+    // Per-entity selected companion descriptor — drives renderer dispatch
+    // (cat/dog/fish via ProceduralCreatureDrawer; null falls back to legacy lobster).
+    private var companionsByEntity: Map<Int, CompanionDetail?> = emptyMap()
 
     // Custom positions (percentage 0.0-1.0)
     private val entityPositions = mutableMapOf<Int, Pair<Float, Float>>()
@@ -144,6 +150,15 @@ class WallpaperPreviewView @JvmOverloads constructor(
             entityScales[entity.entityId] = layoutPrefs.getEntityScale(entity.entityId)
         }
 
+        invalidate()
+    }
+
+    /**
+     * Set per-entity selected companion. Triggers re-render so creatures
+     * (cat / dog / fish / lobster variants) appear immediately.
+     */
+    fun setCompanions(map: Map<Int, CompanionDetail?>) {
+        companionsByEntity = map
         invalidate()
     }
 
@@ -415,48 +430,68 @@ class WallpaperPreviewView @JvmOverloads constructor(
         canvas.translate(cx - (60 * svgScale), cy - (60 * svgScale))
         canvas.scale(svgScale, svgScale)
 
-        // Body color based on entity ID
-        val bodyColor = when (entity.entityId) {
-            0 -> Color.parseColor("#FF7F50") // Coral
-            1 -> Color.parseColor("#4CAF50") // Green
-            2 -> Color.parseColor("#2196F3") // Blue
-            3 -> Color.parseColor("#FF9800") // Orange
+        val companion = companionsByEntity[entity.entityId]
+        val bodyColor = parseHexColor(companion?.color) ?: when (entity.entityId) {
+            0 -> Color.parseColor("#FF7F50")
+            1 -> Color.parseColor("#4CAF50")
+            2 -> Color.parseColor("#2196F3")
+            3 -> Color.parseColor("#FF9800")
             else -> Color.parseColor("#FF7F50")
         }
+        val darkColor = darken(bodyColor)
 
-        val bodyPaint = Paint().apply {
-            style = Paint.Style.FILL
-            color = bodyColor
-            isAntiAlias = true
+        // Spec §4.3 — cat/dog/fish dispatch. If renderer matches, the procedural
+        // drawer paints inside the same 120×120 viewport; otherwise fall through
+        // to the legacy lobster preview path so existing companions still render.
+        val rendererKey = companion?.proceduralRenderer()
+        val drewCreature = ProceduralCreatureDrawer.draw(
+            canvas, rendererKey, entity, companion, bodyColor, darkColor,
+            System.currentTimeMillis()
+        )
+
+        if (!drewCreature) {
+            val bodyPaint = Paint().apply {
+                style = Paint.Style.FILL
+                color = bodyColor
+                isAntiAlias = true
+            }
+            val bodyPath = android.graphics.Path().apply {
+                moveTo(60f, 10f)
+                cubicTo(30f, 10f, 15f, 35f, 15f, 55f)
+                cubicTo(15f, 75f, 30f, 95f, 45f, 100f)
+                lineTo(45f, 110f)
+                lineTo(55f, 110f)
+                lineTo(55f, 100f)
+                cubicTo(55f, 100f, 60f, 102f, 65f, 100f)
+                lineTo(65f, 110f)
+                lineTo(75f, 110f)
+                lineTo(75f, 100f)
+                cubicTo(90f, 95f, 105f, 75f, 105f, 55f)
+                cubicTo(105f, 35f, 90f, 10f, 60f, 10f)
+                close()
+            }
+            canvas.drawPath(bodyPath, bodyPaint)
+            val eyePaint = Paint().apply { color = Color.BLACK; style = Paint.Style.FILL; isAntiAlias = true }
+            val eyeGlowPaint = Paint().apply { color = Color.CYAN; style = Paint.Style.FILL; isAntiAlias = true }
+            canvas.drawCircle(45f, 35f, 6f, eyePaint)
+            canvas.drawCircle(46f, 34f, 2f, eyeGlowPaint)
+            canvas.drawCircle(75f, 35f, 6f, eyePaint)
+            canvas.drawCircle(76f, 34f, 2f, eyeGlowPaint)
         }
-
-        // Simple lobster body path
-        val bodyPath = android.graphics.Path().apply {
-            moveTo(60f, 10f)
-            cubicTo(30f, 10f, 15f, 35f, 15f, 55f)
-            cubicTo(15f, 75f, 30f, 95f, 45f, 100f)
-            lineTo(45f, 110f)
-            lineTo(55f, 110f)
-            lineTo(55f, 100f)
-            cubicTo(55f, 100f, 60f, 102f, 65f, 100f)
-            lineTo(65f, 110f)
-            lineTo(75f, 110f)
-            lineTo(75f, 100f)
-            cubicTo(90f, 95f, 105f, 75f, 105f, 55f)
-            cubicTo(105f, 35f, 90f, 10f, 60f, 10f)
-            close()
-        }
-        canvas.drawPath(bodyPath, bodyPaint)
-
-        // Eyes
-        val eyePaint = Paint().apply { color = Color.BLACK; style = Paint.Style.FILL; isAntiAlias = true }
-        val eyeGlowPaint = Paint().apply { color = Color.CYAN; style = Paint.Style.FILL; isAntiAlias = true }
-        canvas.drawCircle(45f, 35f, 6f, eyePaint)
-        canvas.drawCircle(46f, 34f, 2f, eyeGlowPaint)
-        canvas.drawCircle(75f, 35f, 6f, eyePaint)
-        canvas.drawCircle(76f, 34f, 2f, eyeGlowPaint)
 
         canvas.restore()
+    }
+
+    private fun parseHexColor(hex: String?): Int? {
+        if (hex.isNullOrBlank()) return null
+        return try { Color.parseColor(hex) } catch (_: IllegalArgumentException) { null }
+    }
+
+    private fun darken(c: Int, factor: Float = 0.7f): Int {
+        val r = (Color.red(c) * factor).toInt().coerceIn(0, 255)
+        val g = (Color.green(c) * factor).toInt().coerceIn(0, 255)
+        val b = (Color.blue(c) * factor).toInt().coerceIn(0, 255)
+        return Color.rgb(r, g, b)
     }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {

--- a/app/src/main/res/drawable/ic_pets.xml
+++ b/app/src/main/res/drawable/ic_pets.xml
@@ -1,0 +1,21 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M4.5,9.5m-2.5,0a2.5,2.5 0 1,0 5,0a2.5,2.5 0 1,0 -5,0"/>
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M9,5.5m-2.5,0a2.5,2.5 0 1,0 5,0a2.5,2.5 0 1,0 -5,0"/>
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M15,5.5m-2.5,0a2.5,2.5 0 1,0 5,0a2.5,2.5 0 1,0 -5,0"/>
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M19.5,9.5m-2.5,0a2.5,2.5 0 1,0 5,0a2.5,2.5 0 1,0 -5,0"/>
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M17.34,14.86c-0.87,-1.02 -1.6,-1.89 -2.48,-2.91 -0.46,-0.54 -1.05,-1.08 -1.75,-1.32 -0.11,-0.04 -0.22,-0.07 -0.33,-0.09 -0.25,-0.04 -0.52,-0.04 -0.78,-0.04s-0.53,0 -0.79,0.05c-0.11,0.02 -0.22,0.05 -0.33,0.09 -0.7,0.24 -1.28,0.78 -1.75,1.32 -0.87,1.02 -1.6,1.89 -2.48,2.91 -1.31,1.31 -2.92,2.76 -2.62,4.79 0.29,1.02 1.02,2.03 2.33,2.32 0.73,0.15 3.06,-0.44 5.54,-0.44h0.18c2.48,0 4.81,0.58 5.54,0.44 1.31,-0.29 2.04,-1.31 2.33,-2.32 0.31,-2.04 -1.3,-3.49 -2.61,-4.8z"/>
+</vector>

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1016,9 +1016,25 @@
                 android:text="@string/set_wallpaper"
                 android:textColor="@color/text_white_80"
                 app:backgroundTint="@color/surface_input"
-                android:layout_marginBottom="24dp"
+                android:layout_marginBottom="8dp"
                 app:cornerRadius="12dp"
                 app:icon="@drawable/ic_wallpaper"
+                app:iconTint="@color/text_white_80"
+                app:strokeColor="@color/text_dark"
+                app:strokeWidth="1dp"
+                style="@style/Widget.Material3.Button.TonalButton"/>
+
+            <!-- Browse Companions Button (petdx catalog) -->
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnBrowseCompanions"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/browse_companions"
+                android:textColor="@color/text_white_80"
+                app:backgroundTint="@color/surface_input"
+                android:layout_marginBottom="24dp"
+                app:cornerRadius="12dp"
+                app:icon="@drawable/ic_pets"
                 app:iconTint="@color/text_white_80"
                 app:strokeColor="@color/text_dark"
                 app:strokeWidth="1dp"

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -667,6 +667,7 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="sent">已發送！</string>
     <string name="set_live_wallpaper">設定動態桌布</string>
     <string name="set_wallpaper">設定桌布</string>
+    <string name="browse_companions">瀏覽伙伴</string>
     <string name="settings_entity_limit">實體上限：%1$d</string>
     <string name="settings_reset">設定已重置</string>
     <string name="settings_title">設定</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,6 +82,7 @@
     <string name="select_photo">Select Photo</string>
     <string name="reset">Reset</string>
     <string name="set_wallpaper">Set Wallpaper</string>
+    <string name="browse_companions">Browse Companions</string>
     <string name="drag_to_position">Drag entities to position them</string>
     <string name="pinch_to_resize">Pinch to resize, drag to move</string>
     <string name="back">Back</string>


### PR DESCRIPTION
## Summary

Implements the two missing pieces of the petdx wallpaper companion epic that Hank
flagged — visual variety in the preview/live wallpaper, and the Settings entry
into the companion catalog.

### 1. Multi-creature procedural drawers (spec §4.3)

`ClawRenderer.drawLobsterAtPosition` and `WallpaperPreviewView.drawEntityPreview`
now both dispatch through `ProceduralCreatureDrawer` keyed on the companion
descriptor's `asset.renderer`. Cat / dog / fish drawers ship with state-aware
animation (tail wag, fin sway, sleep arcs, eyes, mouth, scales).

Without the preview-side fix Hank's screenshot only showed lobsters with
different colors — that was the legacy id-keyed preview path, not a renderer bug.
Companion color (hex from descriptor) is now preferred over the id-keyed palette.

`WallpaperPreviewActivity.loadCompanions` fetches `/api/companion/current` per
bound entity and pushes the map into the view, so the preview matches what the
live wallpaper service draws.

### 2. Settings → 瀏覽伙伴 (spec §3)

New `btnBrowseCompanions` button in `activity_settings.xml`, sitting directly
under Set Wallpaper, opens `https://eclawbot.com/portal/petdx-browser.html` in
the existing WebView activity. String shipped for `en` + `zh-rTW`; Hermes will
land the rest of the locales in a follow-up.

## Test plan

- [x] `./gradlew :app:assembleDebug` clean
- [x] Cat (`petdx-tabby-cat-v1`) + dog (`petdx-golden-dog-v1`) submitted &
      selected for entity 2; `/api/companion/current` returns the matching
      renderer key
- [ ] Fish (`petdx-clown-fish-v1`) — blocked by 24h submit rate-limit (5/window),
      follow-up tomorrow
- [ ] Visual confirmation on Hank's real device (emulator install does not have
      bound entities so live wallpaper preview is empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)