### PR TITLE
chore(i18n): extract WallpaperPreview hardcoded toast strings

### DIFF
--- a/app/src/main/java/com/hank/clawlive/WallpaperPreviewActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/WallpaperPreviewActivity.kt
@@ -183,7 +183,7 @@ class WallpaperPreviewActivity : AppCompatActivity() {
 
         switchCustomLayout.setOnCheckedChangeListener { _, isChecked ->
             layoutPrefs.useCustomLayout = isChecked
-            val message = if (isChecked) "Custom layout enabled" else "Using preset layout"
+            val message = getString(if (isChecked) R.string.custom_layout_enabled else R.string.custom_layout_using_preset)
             Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
         }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -945,5 +945,7 @@ If you have any questions, please contact us via our official email.
     <string name="tool_status_analyzing">Running analysis…</string>
     <string name="tool_status_editing">Editing file…</string>
     <string name="tool_status_writing">Writing file…</string>
+    <string name="custom_layout_enabled">Custom layout enabled</string>
+    <string name="custom_layout_using_preset">Using preset layout</string>
 </resources>
 


### PR DESCRIPTION
## Summary
- Pull \"Custom layout enabled\" / \"Using preset layout\" out of `WallpaperPreviewActivity.kt:185` into resource keys (`custom_layout_enabled` / `custom_layout_using_preset`).
- Other locales fall back via Android's standard chain — Hermes can translate the 2 keys × 12 non-EN locales separately.

Found by `[自動巡檢] i18n 品質巡檢` cron 2026-05-10 21:01 (card_196f68f95cbed8d9344bde83).

## Test plan
- [x] EN strings.xml has new keys at end of file
- [x] Kotlin call uses `getString(R.string....)` with branch
- [ ] Android Lint green (`MissingTranslation` is disabled in lint config; CI verifies)
- [ ] Jest + i18n syntax checks green (no JS-side change but workflow runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)