### PR TITLE
chore(i18n): translate WallpaperPreview toast messages (13 locales)

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -933,4 +933,6 @@ GPS: عند الطلب فقط، بلا تتبع في الخلفية، تُفقد
     <string name="tool_status_reading">جاري قراءة الملف…</string>
     <string name="tool_status_searching">جاري البحث في الشيفرة…</string>
     <string name="tool_status_writing">جاري كتابة الملف…</string>
+    <string name="custom_layout_enabled">تم تفعيل التخطيط المخصص</string>
+    <string name="custom_layout_using_preset">استخدام التخطيط الافتراضي</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -933,4 +933,6 @@ Bei Fragen kontaktieren Sie uns über unsere offizielle E-Mail.
     <string name="tool_status_reading">Datei wird gelesen…</string>
     <string name="tool_status_searching">Code wird durchsucht…</string>
     <string name="tool_status_writing">Datei wird geschrieben…</string>
+    <string name="custom_layout_enabled">Benutzerdefiniertes Layout aktiviert</string>
+    <string name="custom_layout_using_preset">Standard-Layout verwenden</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -856,4 +856,6 @@ Tu suscripción permanece activa y puedes reenlazar en cualquier momento (sujeto
     <string name="tool_status_reading">Leyendo archivo…</string>
     <string name="tool_status_searching">Buscando en el código…</string>
     <string name="tool_status_writing">Escribiendo archivo…</string>
+    <string name="custom_layout_enabled">Diseño personalizado activado</string>
+    <string name="custom_layout_using_preset">Usando diseño predeterminado</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -933,4 +933,6 @@ Si vous avez des questions, contactez-nous via notre e-mail officiel.
     <string name="tool_status_reading">Lecture du fichier…</string>
     <string name="tool_status_searching">Recherche dans le code…</string>
     <string name="tool_status_writing">Écriture du fichier…</string>
+    <string name="custom_layout_enabled">Disposition personnalisée activée</string>
+    <string name="custom_layout_using_preset">Disposition par défaut</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -929,8 +929,10 @@ GPS: केवल अनुरोध पर, कोई बैकग्राउ�
 
     <string name="tool_status_analyzing">विश्लेषण चल रहा है…</string>
     <string name="tool_status_editing">फ़ाइल संपादित हो रही है…</string>
-    <string name="tool_status_finding">फ़ाइलें खोज रहा है…</string>
-    <string name="tool_status_reading">फ़ाइल पढ़ रहा है…</string>
+    <string name="tool_status_finding">फ़ाइलें खोज रही है…</string>
+    <string name="tool_status_reading">फ़ाइल पढ़ रही है…</string>
     <string name="tool_status_searching">कोड खोज रहा है…</string>
     <string name="tool_status_writing">फ़ाइल लिखी जा रही है…</string>
+    <string name="custom_layout_enabled">कस्टम लेआउट सक्षम</string>
+    <string name="custom_layout_using_preset">प्रीसेट लेआउट का उपयोग</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -828,4 +828,6 @@ Jika ada pertanyaan, silakan hubungi kami melalui email resmi kami.
     <string name="tool_status_reading">Membaca file…</string>
     <string name="tool_status_searching">Mencari kode…</string>
     <string name="tool_status_writing">Menulis file…</string>
+    <string name="custom_layout_enabled">Tata letak kustom diaktifkan</string>
+    <string name="custom_layout_using_preset">Menggunakan tata letak bawaan</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -829,4 +829,6 @@ GPS：オンデマンドのみ、バックグラウンド追跡なし、サー�
     <string name="tool_status_reading">ファイルを読み込み中…</string>
     <string name="tool_status_searching">コードを検索中…</string>
     <string name="tool_status_writing">ファイルを書き込む中…</string>
+    <string name="custom_layout_enabled">カスタムレイアウトを有効化</string>
+    <string name="custom_layout_using_preset">プリセットレイアウトを使用</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -829,4 +829,6 @@ GPS: 온디맨드만, 백그라운드 추적 없음, 서버 재시작 시 데이
     <string name="tool_status_reading">파일 읽는 중…</string>
     <string name="tool_status_searching">코드 검색 중…</string>
     <string name="tool_status_writing">파일 작성 중…</string>
+    <string name="custom_layout_enabled">사용자 지정 레이아웃 활성화</string>
+    <string name="custom_layout_using_preset">프리셋 레이아웃 사용</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -933,4 +933,6 @@ Jika anda mempunyai sebarang soalan, sila hubungi kami melalui e-mel rasmi kami.
     <string name="tool_status_reading">Membaca fail…</string>
     <string name="tool_status_searching">Mencari kod…</string>
     <string name="tool_status_writing">Menulis fail…</string>
+    <string name="custom_layout_enabled">Tata letak tersuai diaktifkan</string>
+    <string name="custom_layout_using_preset">Menggunakan tata letak lalai</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -828,4 +828,6 @@ GPS：รับตามความต้องการเท่านั้�
     <string name="tool_status_reading">กำลังอ่านไฟล์…</string>
     <string name="tool_status_searching">กำลังค้นหาโค้ด…</string>
     <string name="tool_status_writing">กำลังเขียนไฟล์…</string>
+    <string name="custom_layout_enabled">เปิดใช้งานเลย์เอาต์กำหนดเอง</string>
+    <string name="custom_layout_using_preset">ใช้เลย์เอาต์ตั้งต้น</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -828,4 +828,6 @@ Nếu có bất kỳ câu hỏi nào, vui lòng liên hệ với chúng tôi qua
     <string name="tool_status_reading">Đang đọc tệp…</string>
     <string name="tool_status_searching">Đang tìm kiếm mã…</string>
     <string name="tool_status_writing">Đang ghi tệp…</string>
+    <string name="custom_layout_enabled">Đã bật bố cục tùy chỉnh</string>
+    <string name="custom_layout_using_preset">Đang dùng bố cục mặc định</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -831,4 +831,6 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="tool_status_reading">正在读取文件…</string>
     <string name="tool_status_searching">正在搜索代码…</string>
     <string name="tool_status_writing">正在写入文件…</string>
+    <string name="custom_layout_enabled">已启用自定义布局</string>
+    <string name="custom_layout_using_preset">使用预设布局</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -830,4 +830,6 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="tool_status_reading">正在讀取檔案…</string>
     <string name="tool_status_searching">正在搜尋程式碼…</string>
     <string name="tool_status_writing">正在寫入檔案…</string>
+    <string name="custom_layout_enabled">已啟用自訂排版</string>
+    <string name="custom_layout_using_preset">使用預設配置</string>
 </resources>


### PR DESCRIPTION
## Summary
- Translates the 2 new keys from #2579 (`custom_layout_enabled`, `custom_layout_using_preset`) into 13 non-EN Android locales.
- Salvaged from #2580 (Hermes wandered scope into 38 unrelated backend files via CRLF noise — closing that PR).
- Bonus: hi locale `tool_status_finding`/`tool_status_reading` gender agreement fix (रहा → रही).

| Locale | custom_layout_enabled | custom_layout_using_preset |
|---|---|---|
| zh-rTW | 已啟用自訂排版 | 使用預設配置 |
| zh-rCN | 已启用自定义布局 | 使用预设布局 |
| ja | カスタムレイアウトを有効化 | プリセットレイアウトを使用 |
| ko | 사용자 지정 레이아웃 활성화 | 프리셋 레이아웃 사용 |
| th | เปิดใช้งานเลย์เอาต์กำหนดเอง | ใช้เลย์เอาต์ตั้งต้น |
| vi | Đã bật bố cục tùy chỉnh | Đang dùng bố cục mặc định |
| in | Tata letak kustom diaktifkan | Menggunakan tata letak bawaan |
| ms | Tata letak tersuai diaktifkan | Menggunakan tata letak lalai |
| fr | Disposition personnalisée activée | Disposition par défaut |
| es | Diseño personalizado activado | Usando diseño predeterminado |
| de | Benutzerdefiniertes Layout aktiviert | Standard-Layout verwenden |
| hi | कस्टम लेआउट सक्षम | प्रीसेट लेआउट का उपयोग |
| ar | تم تفعيل التخطيط المخصص | استخدام التخطيط الافتراضي |

## Test plan
- [x] 13 files × +2 lines each (= +26 net new content)
- [x] Each locale uses correct script (hi=Devanagari, ar=Arabic, no Latin fallback)
- [x] No XML escape issues
- [x] `git diff --shortstat`: 13 files changed, 28 insertions(+), 2 deletions(-)
- [ ] Android CI green (Lint + Assemble + Kotlin tests)