### PR TITLE
feat(kanban): device push on card done (manual + auto/cron)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1663,6 +1663,7 @@ try {
         getMissionApiHints,
         pushToBot,
         orgChart: orgChartModule,
+        notifyDevice,
     });
     app.use('/api/mission', kanbanModule.router);
     console.log('[Kanban] Module loaded successfully');

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -177,7 +177,7 @@ async function initKanbanDatabase() {
 /**
  * Factory: receives in-memory devices object from index.js
  */
-module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pushToChannelCallback, saveChatMessage, getMissionApiHints, pushToBot, orgChart } = {}) {
+module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pushToChannelCallback, saveChatMessage, getMissionApiHints, pushToBot, orgChart, notifyDevice } = {}) {
     const router = express.Router();
 
     // Health check
@@ -1591,6 +1591,22 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
                 }
             }
 
+            // Device-level push: surface card-done events to the owner's web/FCM
+            // push channel so completions don't only land in assigned-bot inboxes.
+            // `kanban_done_auto` is a separate prefs key so users can mute the
+            // chatty cron/auto-generated children without losing manual closures.
+            if (newStatus === 'done' && typeof notifyDevice === 'function') {
+                const isAuto = !!card.is_auto_generated;
+                notifyDevice(deviceId, {
+                    type: 'kanban',
+                    category: isAuto ? 'kanban_done_auto' : 'kanban_done',
+                    title: isAuto ? '✅ 自動任務完成' : '✅ 任務完成',
+                    body: card.title,
+                    link: `/portal/kanban.html?card=${cardId}`,
+                    metadata: { cardId, isAuto, fromStatus: oldStatus }
+                }).catch(() => {});
+            }
+
             // If this is an auto-generated child card moving to Done → update parent
             if (newStatus === 'done' && card.is_auto_generated && card.parent_card_id) {
                 console.log(`[Kanban] Child card ${cardId} done, updating parent ${card.parent_card_id}`);
@@ -2904,6 +2920,20 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
                     `✅ Bot #${entityId} 已回報完成，自動結案${msgPreview}`);
 
                 console.log(`[Kanban] Auto-done: child card ${card.id} (${card.title}) marked done by entity ${entityId}${reviewerId != null ? `, reviewer: #${reviewerId}` : ''}`);
+
+                // Auto-close bypasses /move, so notifyDevice fires here too.
+                // Always classified as kanban_done_auto since this branch only
+                // runs for bot-reported IDLE auto-completions.
+                if (typeof notifyDevice === 'function') {
+                    notifyDevice(deviceId, {
+                        type: 'kanban',
+                        category: 'kanban_done_auto',
+                        title: '✅ 自動任務完成',
+                        body: card.title,
+                        link: `/portal/kanban.html?card=${card.id}`,
+                        metadata: { cardId: card.id, isAuto: true, autoClosedBy: entityId }
+                    }).catch(() => {});
+                }
 
                 // Award XP for completing task
                 if (awardEntityXP) {

--- a/backend/notifications.js
+++ b/backend/notifications.js
@@ -11,7 +11,9 @@ const DEFAULT_PREFS = {
     feedback_reply: true,
     todo_done: true,
     scheduled: true,
-    platform_command: true
+    platform_command: true,
+    kanban_done: true,
+    kanban_done_auto: true
 };
 
 let pool = null;

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -2143,7 +2143,9 @@
             { key: 'feedback_resolved', i18n: 'notif_pref_feedback', label: 'Feedback updates' },
             { key: 'feedback_reply', i18n: 'notif_pref_feedback', label: 'Feedback replies', hidden: true },
             { key: 'todo_done', i18n: 'notif_pref_todo', label: 'TODO completion' },
-            { key: 'scheduled', i18n: 'notif_pref_scheduled', label: 'Scheduled messages' }
+            { key: 'scheduled', i18n: 'notif_pref_scheduled', label: 'Scheduled messages' },
+            { key: 'kanban_done', i18n: 'notif_pref_kanban_done', label: 'Kanban card done' },
+            { key: 'kanban_done_auto', i18n: 'notif_pref_kanban_done_auto', label: 'Kanban auto/cron card done' }
         ];
 
         async function loadNotifPreferences() {

--- a/backend/public/shared/lang/en.js
+++ b/backend/public/shared/lang/en.js
@@ -2081,6 +2081,8 @@ const EN_TRANSLATIONS = {
         "notif_pref_feedback": "Feedback Updates",
         "notif_pref_todo": "TODO Completed",
         "notif_pref_scheduled": "Scheduled Messages",
+        "notif_pref_kanban_done": "Kanban Card Done",
+        "notif_pref_kanban_done_auto": "Kanban Auto/Cron Card Done",
         "developer_section_title": "Developer",
         "broadcast_settings_title": "Broadcast Settings",
         "broadcast_settings_desc": "Configure how broadcast messages work",

--- a/backend/tests/jest/kanban-done-push-categories.test.js
+++ b/backend/tests/jest/kanban-done-push-categories.test.js
@@ -1,0 +1,47 @@
+/**
+ * Unit test for kanban_done / kanban_done_auto notification categories.
+ *
+ * Hank 2026-05-10 (card_8a4e2bb268ed2120a8cf3362):
+ * Card-done events should now fire device-level push (web/FCM), with auto/cron
+ * card completions on a separate prefs key so chatty crons can be muted
+ * without losing manual closures.
+ */
+
+const { DEFAULT_PREFS, isCategoryEnabled } = require('../../notifications');
+
+describe('kanban_done / kanban_done_auto — DEFAULT_PREFS', () => {
+    test('kanban_done is registered and defaults to true', () => {
+        expect(DEFAULT_PREFS.kanban_done).toBe(true);
+    });
+
+    test('kanban_done_auto is registered and defaults to true', () => {
+        expect(DEFAULT_PREFS.kanban_done_auto).toBe(true);
+    });
+});
+
+describe('kanban_done / kanban_done_auto — isCategoryEnabled gating', () => {
+    test('kanban_done=false suppresses notification', () => {
+        expect(isCategoryEnabled({ kanban_done: false }, 'kanban_done')).toBe(false);
+    });
+
+    test('kanban_done_auto=false suppresses notification', () => {
+        expect(isCategoryEnabled({ kanban_done_auto: false }, 'kanban_done_auto')).toBe(false);
+    });
+
+    test('toggles are independent (muting auto does not mute manual)', () => {
+        const prefs = { kanban_done: true, kanban_done_auto: false };
+        expect(isCategoryEnabled(prefs, 'kanban_done')).toBe(true);
+        expect(isCategoryEnabled(prefs, 'kanban_done_auto')).toBe(false);
+    });
+
+    test('toggles are independent (muting manual does not mute auto)', () => {
+        const prefs = { kanban_done: false, kanban_done_auto: true };
+        expect(isCategoryEnabled(prefs, 'kanban_done')).toBe(false);
+        expect(isCategoryEnabled(prefs, 'kanban_done_auto')).toBe(true);
+    });
+
+    test('missing keys fail-open (default true)', () => {
+        expect(isCategoryEnabled({}, 'kanban_done')).toBe(true);
+        expect(isCategoryEnabled({}, 'kanban_done_auto')).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- Wire `notifyDevice` into kanban `/card/:id/move` (manual moves) and `autoReviewOnTransform` (bot IDLE auto-close) so card-done events fire device-level web-push / FCM, not just assigned-bot channel/webhook.
- Two prefs keys: `kanban_done` (manual) and `kanban_done_auto` (cron / auto-generated child) — both default-on; user can mute the chatty auto stream without losing manual closure visibility.
- Settings UI exposes both toggles; en baseline shipped, other locales follow via Hermes i18n batch.

Card: `card_8a4e2bb268ed2120a8cf3362` ([Notif] Card Done 提醒：手動 / 自動兩類都要推, P2).

## Files
- `backend/notifications.js` — add 2 keys to `DEFAULT_PREFS`
- `backend/index.js` — pass `notifyDevice` into kanban factory deps
- `backend/kanban.js` — destructure `notifyDevice`, fire on `/move` done branch + `autoReviewOnTransform` direct-done update
- `backend/public/portal/settings.html` — 2 new entries in `NOTIF_PREF_CATEGORIES`
- `backend/public/shared/lang/en.js` — `notif_pref_kanban_done` + `notif_pref_kanban_done_auto`
- `backend/tests/jest/kanban-done-push-categories.test.js` — 7 new unit tests (DEFAULT_PREFS registration + isCategoryEnabled gating + independence)

## Test plan
- [x] `node -c` syntax check on notifications.js, kanban.js, index.js
- [x] `npx jest tests/jest/kanban-done-push-categories` → 7/7 pass
- [x] `npx jest tests/jest/notification` → 13/13 pass (one pre-existing `pg` mock infra failure unrelated to this PR)
- [ ] Post-merge on Railway: move a manual card to done → expect web-push toast + bell badge increment
- [ ] Post-merge on Railway: cron child card auto-closes → expect web-push only when `kanban_done_auto=true`
- [ ] i18n follow-up: dispatch Hermes for 13-locale fill of `notif_pref_kanban_done` / `notif_pref_kanban_done_auto`

🤖 Generated with [Claude Code](https://claude.com/claude-code)