### PR TITLE
fix(petdx): refresh owner state on detail dialog open

### DIFF
--- a/backend/public/portal/petdx-browser.html
+++ b/backend/public/portal/petdx-browser.html
@@ -446,11 +446,16 @@
 
         const q = authQuery();
         let detail = null;
-        try {
-            const r = await fetch('/api/companion/' + encodeURIComponent(card.id) + '?' + q.toString());
-            const data = await r.json();
-            if (data.success) detail = data.companion;
-        } catch (e) { /* fall through */ }
+        // Re-pull /current alongside the descriptor so the favorite/select
+        // buttons reflect cross-device state (e.g. user starred on web,
+        // opened in-app a moment later). Boot-time refreshOwnerState()
+        // alone goes stale within seconds.
+        const [detailRes] = await Promise.all([
+            fetch('/api/companion/' + encodeURIComponent(card.id) + '?' + q.toString())
+                .then(r => r.json()).catch(() => null),
+            refreshOwnerState(),
+        ]);
+        if (detailRes && detailRes.success) detail = detailRes.companion;
 
         if (!detail) {
             body.innerHTML = '<h2>' + escapeHtml(card.name) + '</h2><p>無法載入詳細資訊。</p>';


### PR DESCRIPTION
## Summary
- `openDetail()` now refreshes `/api/companion/current` in parallel with the descriptor fetch so the modal's favorite/select buttons reflect cross-device state at open time, not just boot-time.
- Closes card_b41ca0bc3563d889547b2a2a (P2): user stars Golden Dog on web, opens in-app WebView a moment later → dialog showed ☆ (stale `favoriteIds` Set from boot).

## Why this is the right scope
- Bug card explicitly says: "詳情 dialog open 時應 fetch /api/companion/current (含 favorites array) 並把當前已收藏 companion 反映為 ★ 已收藏 狀態"
- Boot-time `refreshOwnerState()` runs once and goes stale within seconds; modal needs its own fetch.
- Only ~5 lines touched, no API change.

## Test plan
- [x] Diff-stat clean (1 file, +10/-5)
- [ ] Live verify on Railway after merge: web favorite Golden Dog → reload portal → open dialog → assert ★ 已收藏 shows
- [ ] In-app WebView (Android) verify same flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)