### PR TITLE
fix(wallpaper): show 'Loading entities…' until first API response

### DIFF
--- a/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
@@ -397,9 +397,15 @@ class ClawRenderer(
 
     /**
      * Draw multiple entities on the canvas.
+     *
+     * @param loading when true, the engine has not yet received its first
+     *   getMultiEntityStatusFlow response — render a transient "Loading…"
+     *   placeholder instead of the permanent "No entities connected" message.
+     *   Prevents the Live Wallpaper chooser preview from flashing the empty
+     *   message while the first network call is still in flight.
      */
     private var multiDrawCount = 0
-    fun drawMultiEntity(canvas: Canvas, entities: List<EntityStatus>) {
+    fun drawMultiEntity(canvas: Canvas, entities: List<EntityStatus>, loading: Boolean = false) {
         multiDrawCount++
         val width = canvas.width.toFloat()
         val height = canvas.height.toFloat()
@@ -420,6 +426,12 @@ class ClawRenderer(
         }
 
         if (entities.isEmpty()) {
+            if (loading) {
+                textPaint.textSize = 32f
+                textPaint.color = Color.WHITE
+                canvas.drawText("Loading entities…", width / 2f, height / 2f, textPaint)
+                return
+            }
             // Draw "No entities" message with instructions
             textPaint.textSize = 36f
             textPaint.color = Color.WHITE

--- a/app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt
+++ b/app/src/main/java/com/hank/clawlive/service/ClawWallpaperService.kt
@@ -60,6 +60,13 @@ class ClawWallpaperService : WallpaperService() {
         // Multi-entity status list (start empty - only show bound entities)
         private var currentEntities: List<EntityStatus> = emptyList()
 
+        // Tracks whether observeStatus has received its first response. Until
+        // then, draw() shows "Loading entities…" instead of the permanent
+        // "No entities connected" placeholder — prevents the Live Wallpaper
+        // chooser preview from flashing that message while the first network
+        // call is still in flight.
+        private var hasFirstResponse = false
+
         private val drawRunnable = Runnable { draw() }
 
         override fun onCreate(surfaceHolder: SurfaceHolder?) {
@@ -85,6 +92,7 @@ class ClawWallpaperService : WallpaperService() {
                                 Timber.d("First entity: id=${e.entityId}, name=${e.name}, state=${e.state}")
                             }
                             currentEntities = response.entities
+                            hasFirstResponse = true
                             ensureCompanionPollers(response.entities)
                             if (visible) draw()
                         }
@@ -198,7 +206,7 @@ class ClawWallpaperService : WallpaperService() {
                     if (drawCount <= 3) {
                     }
                     if (multiEntityMode) {
-                        renderer.drawMultiEntity(canvas, currentEntities)
+                        renderer.drawMultiEntity(canvas, currentEntities, loading = !hasFirstResponse)
                     } else {
                         renderer.draw(canvas, currentStatus)
                     }


### PR DESCRIPTION
## Summary
- Add `hasFirstResponse: Boolean` flag in `ClawWallpaperService.ClawEngine`; flip true after first emission from `repository.getMultiEntityStatusFlow`.
- `ClawRenderer.drawMultiEntity` accepts new `loading: Boolean = false` param. When `true` AND entity list is empty → renders "Loading entities…" instead of the permanent "No entities connected" placeholder.
- `draw()` passes `loading = !hasFirstResponse` so the chooser preview, which fires `onVisibilityChanged(true) → draw()` before any network response is in, no longer flashes the onboarding copy at users who already have entities bound.

## Why
Closes card_7b4d1f58f764ea83cdf9b313. ClawWallpaperService runs in a separate process; `currentEntities` starts empty by design. Live Wallpaper chooser preview is brief and the first `draw()` fires before the multi-entity API roundtrip completes — users with 6 bound entities still saw "No entities connected — Open E-Claw app to bind entities with OpenClaw bot" in the chooser, which looks like an onboarding regression.

## Test plan
- [ ] **U01 Android E2E required** — install APK, Settings → Set Wallpaper → system Live Wallpaper chooser → confirm preview shows "Loading entities…" briefly then renders bound entities (no flash of "No entities connected").
- [ ] Verify that a device with **zero** bound entities still gets the original "No entities connected" + bind-instructions copy after the first response (not regressed).
- [x] Code review: only 2 files touched, +22/-2; renderer change is additive (default param keeps existing callers working).

🤖 Generated with [Claude Code](https://claude.com/claude-code)