### PR TITLE
chore(i18n): add browse_companions translations for 12 locales

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -23,6 +23,7 @@
     <string name="expand">توسيع</string>
     <string name="copy">نسخ</string>
     <string name="broadcast_to_all">بث للجميع</string>
+    <string name="browse_companions">تصفح الرفقاء</string>
     <string name="set_live_wallpaper">تعيين خلفية متحركة</string>
     <string name="expires_in">ينتهي خلال %ds</string>
     <string name="command_copied">تم نسخ الأمر!</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -23,6 +23,7 @@
     <string name="expand">Erweitern</string>
     <string name="copy">Kopieren</string>
     <string name="broadcast_to_all">An alle senden</string>
+    <string name="browse_companions">Begleiter durchsuchen</string>
     <string name="set_live_wallpaper">Live-Hintergrund festlegen</string>
     <string name="expires_in">Läuft ab in %ds</string>
     <string name="command_copied">Befehl kopiert!</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -124,6 +124,7 @@ Pregúntame lo que quieras sobre la plataforma.</string>
     <string name="broadcast_settings_desc">Configura cómo funcionan los mensajes broadcast</string>
     <string name="broadcast_settings_title">Configuración de Broadcast</string>
     <string name="broadcast_to_all">Broadcast a Todos</string>
+    <string name="browse_companions">Explorar Compañeros</string>
     <string name="cancel">Cancelar</string>
     <string name="card_holder">Tarjetero</string>    <string name="card_holder_add_capability">Agregar capacidad</string>    <string name="card_holder_capabilities">Capacidades</string>    <string name="card_holder_protocols">Protocolos</string>    <string name="card_holder_tags">Etiquetas</string>
     <string name="card_holder_tags_hint">Agregar etiqueta…</string>    <string name="category_add">+ Categoría</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -23,6 +23,7 @@
     <string name="expand">Développer</string>
     <string name="copy">Copier</string>
     <string name="broadcast_to_all">Diffuser à tous</string>
+    <string name="browse_companions">Parcourir les Compagnons</string>
     <string name="set_live_wallpaper">Définir le fond d\'écran animé</string>
     <string name="expires_in">Expire dans %ds</string>
     <string name="command_copied">Commande copiée !</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -23,6 +23,7 @@
     <string name="expand">विस्तार करें</string>
     <string name="copy">कॉपी करें</string>
     <string name="broadcast_to_all">सभी को प्रसारित करें</string>
+    <string name="browse_companions">साथी ब्राउज़ करें</string>
     <string name="set_live_wallpaper">लाइव वॉलपेपर सेट करें</string>
     <string name="expires_in">%ds में समाप्त होगा</string>
     <string name="command_copied">कमांड कॉपी हो गया!</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -122,6 +122,7 @@
     <string name="broadcast_settings_desc">Konfigurasi cara kerja pesan siaran</string>
     <string name="broadcast_settings_title">Pengaturan Siaran</string>
     <string name="broadcast_to_all">Siarkan ke Semua</string>
+    <string name="browse_companions">Jelajahi Kawan</string>
     <string name="cancel">Batal</string>    <string name="card_holder_add_capability">Tambah kemampuan</string>    <string name="card_holder_capabilities">Kemampuan</string>    <string name="card_holder_protocols">Protokol</string>    <string name="card_holder_tags">Tag</string>
     <string name="card_holder_tags_hint">Tambah tag…</string>    <string name="category_add">+ Kategori</string>
     <string name="category_add_title">Tambah Kategori</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -122,6 +122,7 @@
     <string name="broadcast_settings_desc">ブロードキャストメッセージの動作を設定</string>
     <string name="broadcast_settings_title">ブロードキャスト設定</string>
     <string name="broadcast_to_all">全体にブロードキャスト</string>
+    <string name="browse_companions">伴侶を閲覧</string>
     <string name="cancel">キャンセル</string>    <string name="card_holder_add_capability">機能を追加</string>    <string name="card_holder_capabilities">機能</string>    <string name="card_holder_protocols">プロトコル</string>    <string name="card_holder_tags">タグ</string>
     <string name="card_holder_tags_hint">タグを追加…</string>    <string name="category_add">+ カテゴリ</string>
     <string name="category_add_title">カテゴリを追加</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -122,6 +122,7 @@
     <string name="broadcast_settings_desc">방송 메시지 작동 방식 설정</string>
     <string name="broadcast_settings_title">방송 설정</string>
     <string name="broadcast_to_all">전체 브로드캐스트</string>
+    <string name="browse_companions">동료 탐색</string>
     <string name="cancel">취소</string>    <string name="card_holder_add_capability">기능 추가</string>    <string name="card_holder_capabilities">기능</string>    <string name="card_holder_protocols">프로토콜</string>    <string name="card_holder_tags">태그</string>
     <string name="card_holder_tags_hint">태그 추가…</string>    <string name="category_add">+ 카테고리</string>
     <string name="category_add_title">카테고리 추가</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -23,6 +23,7 @@
     <string name="expand">Kembangkan</string>
     <string name="copy">Salin</string>
     <string name="broadcast_to_all">Siar ke Semua</string>
+    <string name="browse_companions">Layari Kawan</string>
     <string name="set_live_wallpaper">Tetapkan Kertas Dinding Langsung</string>
     <string name="expires_in">Tamat dalam %ds</string>
     <string name="command_copied">Arahan disalin!</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -122,6 +122,7 @@
     <string name="broadcast_settings_desc">กำหนดค่าการทำงานของข้อความแพร่ภาพ</string>
     <string name="broadcast_settings_title">การตั้งค่าการแพร่ภาพ</string>
     <string name="broadcast_to_all">ส่งถึงทุกคน</string>
+    <string name="browse_companions">เรียกดูเพื่อน</string>
     <string name="cancel">ยกเลิก</string>    <string name="card_holder_add_capability">เพิ่มความสามารถ</string>    <string name="card_holder_capabilities">ความสามารถ</string>    <string name="card_holder_protocols">โปรโตคอล</string>    <string name="card_holder_tags">แท็ก</string>
     <string name="card_holder_tags_hint">เพิ่มแท็ก…</string>    <string name="category_add">+ หมวดหมู่</string>
     <string name="category_add_title">เพิ่มหมวดหมู่</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -122,6 +122,7 @@
     <string name="broadcast_settings_desc">Cấu hình cách hoạt động của tin nhắn phát sóng</string>
     <string name="broadcast_settings_title">Cài đặt phát sóng</string>
     <string name="broadcast_to_all">Phát tới tất cả</string>
+    <string name="browse_companions">Duyệt bạn đồng hành</string>
     <string name="cancel">Hủy</string>    <string name="card_holder_add_capability">Thêm khả năng</string>    <string name="card_holder_capabilities">Khả năng</string>    <string name="card_holder_protocols">Giao thức</string>    <string name="card_holder_tags">Thẻ</string>
     <string name="card_holder_tags_hint">Thêm thẻ…</string>    <string name="category_add">+ Danh mục</string>
     <string name="category_add_title">Thêm danh mục</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -122,6 +122,7 @@
     <string name="broadcast_settings_desc">配置广播消息的工作方式</string>
     <string name="broadcast_settings_title">广播设置</string>
     <string name="broadcast_to_all">广播给全部</string>
+    <string name="browse_companions">浏览伙伴</string>
     <string name="cancel">取消</string>    <string name="card_holder_add_capability">添加能力</string>    <string name="card_holder_capabilities">功能</string>    <string name="card_holder_protocols">协议</string>    <string name="card_holder_tags">标签</string>
     <string name="card_holder_tags_hint">添加标签…</string>    <string name="category_add">+ 添加分类</string>
     <string name="category_add_title">添加分类</string>


### PR DESCRIPTION
## Summary
- 5.5h i18n auto-patrol cron flagged that `browse_companions` (added by PR #2578 for the new Settings → 瀏覽伙伴 entry) was only in `values/strings.xml` (en) and `values-zh-rTW/strings.xml`.
- This PR fills the 12 missing locales: ar, de, es, fr, hi, in, ja, ko, ms, th, vi, zh-rCN.
- Each file gets exactly one new line; nothing else touched. Backend `i18n.js` deliberately left alone (owned by the hourly i18n-drift cron).

## Translations (verified by Hermes #5, locale-script audit)
| Locale | Value | Script check |
|--------|-------|--------------|
| ar | تصفح الرفقاء | Arabic only ✓ |
| de | Begleiter durchsuchen | German only ✓ |
| es | Explorar Compañeros | Spanish only ✓ |
| fr | Parcourir les Compagnons | French only ✓ |
| hi | साथी ब्राउज़ करें | Devanagari only ✓ |
| in | Jelajahi Kawan | Indonesian only ✓ |
| ja | 伴侶を閲覧 | Japanese only ✓ |
| ko | 동료 탐색 | Korean only ✓ |
| ms | Layari Kawan | Malay only ✓ |
| th | เรียกดูเพื่อน | Thai only ✓ |
| vi | Duyệt bạn đồng hành | Vietnamese only ✓ |
| zh-rCN | 浏览伙伴 | Simplified Chinese only ✓ |

## Why this replaces #2588
PR #2588 had the correct 12 string additions but also picked up 31 CRLF→LF whitespace-only rewrites in backend test files (Hermes daemon's git autocrlf side effect — 0 semantic changes, 9k+ noise lines, wrong PR title). This PR keeps just the 12 lines.

## Test plan
- [ ] CI: `android-ci.yml` lint + build green (no other strings.xml changes, no resource conflicts).
- [ ] CI: `i18n-syntax.test.js` jest passes (no Android backend i18n.js touched).
- [ ] Local check: each new line passes `xmllint --noout strings.xml` (no escape issues).
- [ ] After merge: hourly `browse_companions` audit no longer reports drift.

## Related
- Patrol parent card: `card_fab06174567e4260aee40e44`
- Drift card (this PR closes): `card_e337e0845eb7726c422165d8`
- Original feature PR: #2578

🤖 Generated with [Claude Code](https://claude.com/claude-code)