### PR TITLE
fix(portal): 3 QA-audit visual bugs (#2592 #2593 #2594)

### DIFF
--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -663,7 +663,7 @@
             .modal-content { max-height: 90vh; margin: 10px; }
         }
         @media (max-width: 480px) {
-            .plaza-grid { grid-template-columns: repeat(2, 1fr); gap: 6px; }
+            .plaza-grid { grid-template-columns: 1fr; gap: 8px; }
             .plaza-chip { min-height: 44px; height: 44px; line-height: 44px; padding: 0 12px; font-size: 11px; }
         }
     </style>

--- a/backend/public/portal/files.html
+++ b/backend/public/portal/files.html
@@ -54,6 +54,10 @@
             align-items: center;
         }
 
+        #entityFilters {
+            display: contents;
+        }
+
         .filter-chip {
             padding: 6px 14px;
             border-radius: var(--radius-pill);

--- a/backend/public/portal/invite.html
+++ b/backend/public/portal/invite.html
@@ -480,7 +480,7 @@
                 const _input = document.getElementById('redeemInput');
                 if (_input) _input.value = _redeemParam;
             }
-            renderNav('settings');
+            renderNav('invite');
             if (typeof renderFooter === 'function') renderFooter();
             if (typeof i18n !== 'undefined') i18n.apply();
             const refreshBtn = document.getElementById('invRefreshBtn');


### PR DESCRIPTION
## Summary
Three small portal UI fixes filed during the daily QA/UIUX regression audit (`card_11e528ae33fb982eb709ad3c`):

- **#2592** `community.html` mobile bot grid overflowed viewport — `<480px` was still forcing `repeat(2, 1fr)`. Now `1fr` (single column).
- **#2593** `invite.html` top nav highlighted "Settings" instead of "Invite Friends" — `renderNav('settings')` typo. Now `renderNav('invite')`.
- **#2594** `files.html` bot filter chips stacked as a 130px vertical column — `#entityFilters` wrapper blocked the parent's `flex-wrap`. Added `display: contents` so chips become direct flex children of `.filter-bar`.

Total diff: **+6 / −2** across 3 files.

## Verification
Each fix verified in Playwright (mobile 420×844 + desktop 1280×800) by injecting the patched CSS / re-running `renderNav` on the live site before committing:
- `qa-2026-05-10/fix-verify-community-mobile.png` — single-column stack, no overflow
- `qa-2026-05-10/fix-verify-files-mobile.png` — chips wrap inline
- DOM probe confirmed `Invite Friends` link gets `nav-link active` after re-render

## Test plan
- [x] community.html `<480px` viewport: bot cards stack 1-per-row, no horizontal scroll
- [x] invite.html: "Invite Friends" tab highlighted in top nav (desktop + mobile drawer)
- [x] files.html: bot chips render horizontally with `All / Photos / Voice` instead of vertical column
- [ ] CI pass (lint + jest)

Closes #2592, closes #2593, closes #2594.

🤖 Generated with [Claude Code](https://claude.com/claude-code)