### PR TITLE
feat(companion): bridge crafter-station/petdex gallery (1784 pets)

### DIFF
--- a/backend/companion-api.js
+++ b/backend/companion-api.js
@@ -18,6 +18,7 @@ const express = require('express');
 const fs = require('fs');
 const path = require('path');
 const { Pool } = require('pg');
+const { syncPetdexCatalog } = require('./petdex-bridge');
 
 const pool = new Pool({
     connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
@@ -101,7 +102,7 @@ function validateSubmittedDescriptor(body) {
 }
 
 function rowToCompanionCard(row) {
-    return {
+    const card = {
         id: row.id,
         name: row.name,
         version: row.version,
@@ -125,6 +126,16 @@ function rowToCompanionCard(row) {
         },
         scope: row.scope,
     };
+    // Spritesheet companions need the asset URL + frame metadata on the grid
+    // so cards can animate without a follow-up /:id fetch per tile. Procedural
+    // cards already work off the renderer-key heuristic in petdx-browser.html.
+    if (row.asset_type === 'spritesheet') {
+        card.assetUrl = row.asset_url;
+        const d = row.descriptor || {};
+        if (d.asset) card.asset = d.asset;
+        if (d.stateAssets) card.stateAssets = d.stateAssets;
+    }
+    return card;
 }
 
 function rowToCompanionDetail(row) {
@@ -169,6 +180,14 @@ async function initCompanionDatabase(serverLog = console.log) {
             }
         }
         serverLog('info', 'companion', '[Companion] Schema initialized');
+
+        // Petdex 公開 gallery mirror — fire-and-forget so a network blip
+        // can't block server startup. Re-runs on every init are upserts.
+        if (process.env.PETDEX_SYNC_ON_BOOT !== '0') {
+            syncPetdexCatalog(pool, serverLog).catch((err) => {
+                serverLog('warn', 'petdex-bridge', `[Petdex] background sync failed: ${err.message}`);
+            });
+        }
     } catch (err) {
         serverLog('error', 'companion', `[Companion] Schema init failed: ${err.message}`);
     }
@@ -1057,6 +1076,23 @@ module.exports = function companionFactory({ authenticateBot, authenticateDevice
         } catch (err) {
             log('error', 'companion', `[Companion] detail query failed: ${err.message}`);
             res.status(500).json({ success: false, error: 'query_failed' });
+        }
+    });
+
+    // ── POST /petdex-sync — manual Petdex catalog refresh ──────────
+    // deviceSecret-auth (owner-only) on top of authReader's `deviceSecret`
+    // branch; runs the same upsert as boot-time init. Cheap to retry, the
+    // bridge is idempotent.
+    router.post('/petdex-sync', authReader, async (req, res) => {
+        if (req.botAuth.authMode !== 'device') {
+            return res.status(403).json({ success: false, error: 'deviceSecret_required' });
+        }
+        try {
+            const result = await syncPetdexCatalog(pool, log);
+            res.json({ success: true, ...result });
+        } catch (err) {
+            log('error', 'companion', `[Companion] petdex-sync failed: ${err.message}`);
+            res.status(500).json({ success: false, error: 'sync_failed' });
         }
     });
 

--- a/backend/petdex-bridge.js
+++ b/backend/petdex-bridge.js
@@ -1,0 +1,204 @@
+/**
+ * Petdex Bridge — mirrors crafter-station/petdex public gallery into our
+ * companions table as `scope='community'` rows with `asset_type='spritesheet'`.
+ *
+ * Why: 自有目錄只有 5 隻 (3 物種)；對接 Petdex 1779 隻可一次補滿瀏覽量。Petdex
+ * 是 MIT-licensed 公開 gallery (https://github.com/crafter-station/petdex)，
+ * 圖檔 hot-link 自其 R2 bucket，本表只存 URL + descriptor，不複製二進位資產。
+ *
+ * Sprite convention (from crafter-station/petdex packages/petdex-desktop/src/main.zig):
+ *   - Sheet 1536×1872, COLS=8 ROWS=9, every frame 192×208.
+ *   - Row 0 idle (variable), row 1 running-right (8f), row 2 running-left (8f),
+ *     row 3 waving (4f), row 4 jumping (5f), row 5 failed (8f),
+ *     row 6 waiting (6f), row 7 running (6f), row 8 review (6f).
+ *
+ * Our state mapping (EClaw companion state → Petdex animation row):
+ *   IDLE → 0(idle), BUSY → 7(running), WALKING → 1(running-right),
+ *   SLEEPING → 6(waiting), EXCITED → 4(jumping), HAPPY → 3(waving).
+ */
+
+const MANIFEST_URL = 'https://petdex.crafter.run/api/manifest';
+
+// Animation table — rows + per-frame durations in milliseconds. The idle row
+// uses variable durations per frame (matches petdex desktop); all other rows
+// use a single `dur` plus an optional `last` for the trailing frame.
+const PETDEX_ANIMATIONS = {
+    idle:           { row: 0, frames: [280, 110, 110, 140, 140, 320] },
+    'running-right':{ row: 1, count: 8, dur: 120, last: 220 },
+    'running-left': { row: 2, count: 8, dur: 120, last: 220 },
+    waving:         { row: 3, count: 4, dur: 140, last: 280 },
+    jumping:        { row: 4, count: 5, dur: 140, last: 280 },
+    failed:         { row: 5, count: 8, dur: 140, last: 240 },
+    waiting:        { row: 6, count: 6, dur: 150, last: 260 },
+    running:        { row: 7, count: 6, dur: 120, last: 220 },
+    review:         { row: 8, count: 6, dur: 150, last: 280 },
+};
+
+const STATE_TO_ANIMATION = {
+    IDLE:     'idle',
+    BUSY:     'running',
+    WALKING:  'running-right',
+    SLEEPING: 'waiting',
+    EXCITED:  'jumping',
+    HAPPY:    'waving',
+};
+
+const KIND_TO_CATEGORY = {
+    creature:  'animal',
+    character: 'human',
+    object:    'mascot',
+};
+
+const SHEET_COLS = 8;
+const SHEET_ROWS = 9;
+const FRAME_WIDTH = 192;
+const FRAME_HEIGHT = 208;
+
+async function fetchPetdexManifest() {
+    const res = await fetch(MANIFEST_URL, {
+        headers: { 'Accept': 'application/json', 'User-Agent': 'EClaw-petdex-bridge/1.0' },
+    });
+    if (!res.ok) {
+        throw new Error(`Petdex manifest fetch failed: HTTP ${res.status}`);
+    }
+    const data = await res.json();
+    if (!data || !Array.isArray(data.pets)) {
+        throw new Error('Petdex manifest shape invalid (expected .pets array)');
+    }
+    return data.pets;
+}
+
+function buildDescriptor(pet) {
+    const animations = {};
+    for (const [name, anim] of Object.entries(PETDEX_ANIMATIONS)) {
+        animations[name] = { row: anim.row };
+        if (Array.isArray(anim.frames)) {
+            animations[name].frames = anim.frames;
+        } else {
+            animations[name].count = anim.count;
+            animations[name].dur = anim.dur;
+            if (anim.last != null) animations[name].last = anim.last;
+        }
+    }
+
+    const stateAssets = {};
+    for (const [state, animName] of Object.entries(STATE_TO_ANIMATION)) {
+        stateAssets[state] = { animation: animName, loop: true };
+    }
+
+    return {
+        id: `petdex-${pet.slug}`,
+        name: pet.displayName,
+        assetType: 'spritesheet',
+        asset: {
+            url: pet.spritesheetUrl,
+            cols: SHEET_COLS,
+            rows: SHEET_ROWS,
+            frameWidth: FRAME_WIDTH,
+            frameHeight: FRAME_HEIGHT,
+            animations,
+        },
+        supportedStates: Object.keys(STATE_TO_ANIMATION),
+        stateAssets,
+        sourceAttribution: {
+            project: 'crafter-station/petdex',
+            license: 'MIT',
+            slug: pet.slug,
+            submittedBy: pet.submittedBy || null,
+            petJsonUrl: pet.petJsonUrl || null,
+            zipUrl: pet.zipUrl || null,
+        },
+    };
+}
+
+async function upsertPetdexCompanion(pool, pet) {
+    const id = `petdex-${pet.slug}`;
+    const descriptor = buildDescriptor(pet);
+    const category = KIND_TO_CATEGORY[pet.kind] || 'mascot';
+    const supportedStates = Object.keys(STATE_TO_ANIMATION);
+    const tags = ['petdex', pet.kind || 'creature'];
+    const now = Date.now();
+
+    await pool.query(
+        `INSERT INTO companions (
+            id, name, version, author_entity_id, device_id,
+            descriptor, asset_type, asset_url, avatar_url, thumbnail_url,
+            supported_states, scope, status, license, category,
+            mood, color, tags,
+            created_at, updated_at, published_at
+        ) VALUES (
+            $1, $2, '1.0.0', NULL, NULL,
+            $3::jsonb, 'spritesheet', $4, $5, $5,
+            $6::jsonb, 'community', 'published', 'MIT', $7,
+            NULL, NULL, $8::jsonb,
+            $9, $9, $9
+        )
+        ON CONFLICT (id) DO UPDATE SET
+            name = EXCLUDED.name,
+            descriptor = EXCLUDED.descriptor,
+            asset_url = EXCLUDED.asset_url,
+            avatar_url = EXCLUDED.avatar_url,
+            thumbnail_url = EXCLUDED.thumbnail_url,
+            supported_states = EXCLUDED.supported_states,
+            category = EXCLUDED.category,
+            tags = EXCLUDED.tags,
+            updated_at = EXCLUDED.updated_at
+        `,
+        [
+            id,
+            pet.displayName || pet.slug,
+            JSON.stringify(descriptor),
+            pet.spritesheetUrl,
+            pet.spritesheetUrl,
+            JSON.stringify(supportedStates),
+            category,
+            JSON.stringify(tags),
+            now,
+        ],
+    );
+}
+
+async function syncPetdexCatalog(pool, serverLog = console.log) {
+    const log = typeof serverLog === 'function' ? serverLog : () => {};
+    let inserted = 0;
+    let failed = 0;
+    let total = 0;
+    try {
+        const pets = await fetchPetdexManifest();
+        total = pets.length;
+        log('info', 'petdex-bridge', `[Petdex] fetched ${total} pets from manifest`);
+        for (const pet of pets) {
+            if (!pet || !pet.slug || !pet.spritesheetUrl) {
+                failed++;
+                continue;
+            }
+            try {
+                await upsertPetdexCompanion(pool, pet);
+                inserted++;
+            } catch (err) {
+                failed++;
+                if (failed <= 3) {
+                    log('warn', 'petdex-bridge', `[Petdex] upsert ${pet.slug} failed: ${err.message}`);
+                }
+            }
+        }
+        log('info', 'petdex-bridge', `[Petdex] sync complete — ok=${inserted} failed=${failed} total=${total}`);
+    } catch (err) {
+        log('error', 'petdex-bridge', `[Petdex] sync failed: ${err.message}`);
+    }
+    return { total, inserted, failed };
+}
+
+module.exports = {
+    syncPetdexCatalog,
+    fetchPetdexManifest,
+    buildDescriptor,
+    PETDEX_ANIMATIONS,
+    STATE_TO_ANIMATION,
+    KIND_TO_CATEGORY,
+    SHEET_COLS,
+    SHEET_ROWS,
+    FRAME_WIDTH,
+    FRAME_HEIGHT,
+    MANIFEST_URL,
+};

--- a/backend/public/portal/petdx-browser.html
+++ b/backend/public/portal/petdx-browser.html
@@ -387,20 +387,37 @@
         // so we can preview without a second API call. The full
         // descriptor with params lives behind GET /:id which the modal
         // uses for the bigger preview.
-        const rendererKey = rendererKeyFromCard(card);
-        const descriptor = {
-            id: card.id,
-            name: card.name,
-            assetType: card.assetType || 'procedural',
-            asset: {
-                renderer: rendererKey,
-                params: { bodyColor: card.color, color: card.color },
-            },
-            supportedStates: card.supportedStates && card.supportedStates.length
-                ? card.supportedStates
-                : ['IDLE'],
-            stateAssets: { IDLE: { fps: 4, loop: true } },
-        };
+        const assetType = card.assetType || 'procedural';
+        let descriptor;
+        if (assetType === 'spritesheet' && card.asset && card.asset.url) {
+            // Spritesheet cards (Petdex bridge) carry asset metadata + state→
+            // animation map on the list payload — pass them through.
+            descriptor = {
+                id: card.id,
+                name: card.name,
+                assetType: 'spritesheet',
+                asset: card.asset,
+                supportedStates: card.supportedStates && card.supportedStates.length
+                    ? card.supportedStates
+                    : ['IDLE'],
+                stateAssets: card.stateAssets || { IDLE: { animation: 'idle', loop: true } },
+            };
+        } else {
+            const rendererKey = rendererKeyFromCard(card);
+            descriptor = {
+                id: card.id,
+                name: card.name,
+                assetType,
+                asset: {
+                    renderer: rendererKey,
+                    params: { bodyColor: card.color, color: card.color },
+                },
+                supportedStates: card.supportedStates && card.supportedStates.length
+                    ? card.supportedStates
+                    : ['IDLE'],
+                stateAssets: { IDLE: { fps: 4, loop: true } },
+            };
+        }
 
         try {
             const r = PetdxRenderer.createRenderer({

--- a/backend/public/shared/petdx-renderer.js
+++ b/backend/public/shared/petdx-renderer.js
@@ -9,9 +9,11 @@
  * (WallpaperService becomes a thin shell around a WebView pointing at
  * a render page that consumes the same descriptor).
  *
- * v0.2 MVP scope:
- *   - assetType: 'procedural' (built-in drawers; this PR ships 'lobster-procedural')
- *   - assetType: 'spritesheet' (planned, next PR — needs webp asset pipeline)
+ * v0.3 scope (Petdex bridge):
+ *   - assetType: 'procedural' (built-in drawers; ships lobster/dog/cat)
+ *   - assetType: 'spritesheet' (Petdx mirror — 8×9 grid, 192×208 per frame;
+ *     descriptor.asset = { url, cols, rows, frameWidth, frameHeight, animations },
+ *     descriptor.stateAssets[STATE] = { animation: 'idle'|..., loop })
  *   - assetType: 'vector' (rejected per spec §2.2)
  *
  * Public surface:
@@ -36,6 +38,27 @@
     const DEFAULT_STATE = 'IDLE';
     const DEFAULT_FPS = 4;
     const DEFAULT_FALLBACK_POLICY = 'silent_to_idle';
+
+    // ── Spritesheet image cache ─────────────────────────────────
+    // Multiple renderer instances on the same page (the grid is 1 canvas
+    // per card) hit the same R2 URLs; cache by URL so the browser only
+    // decodes once and frames share an HTMLImageElement.
+    const spriteImageCache = new Map(); // url → { img, ready, error }
+
+    function loadSpritesheet(url) {
+        if (!url) return null;
+        let entry = spriteImageCache.get(url);
+        if (entry) return entry;
+        entry = { img: new Image(), ready: false, error: false };
+        // No crossOrigin: Petdex R2 doesn't send ACAO, and we only drawImage
+        // (never read pixels back). The canvas becomes "tainted" which blocks
+        // toDataURL/getImageData — neither of which the wallpaper renderer needs.
+        entry.img.onload = () => { entry.ready = true; };
+        entry.img.onerror = () => { entry.error = true; };
+        entry.img.src = url;
+        spriteImageCache.set(url, entry);
+        return entry;
+    }
 
     // ── Drawer registry ──────────────────────────────────────────
     const drawers = new Map();
@@ -94,6 +117,46 @@
         return !!sa.loop;
     }
 
+    // For spritesheet descriptors: resolve the animation row to use from a
+    // requested state. stateAssets[STATE].animation names a row in
+    // descriptor.asset.animations; if missing we fall back to the 'idle'
+    // animation which every Petdex sheet has (row 0).
+    function pickAnimationName(descriptor, stateName) {
+        const sa = descriptor && descriptor.stateAssets && descriptor.stateAssets[stateName];
+        if (sa && typeof sa.animation === 'string') return sa.animation;
+        return 'idle';
+    }
+
+    // Given an animation entry (`{ row, frames: [durMs,...] }` for idle, or
+    // `{ row, count, dur, last? }` for uniform animations) compute the frame
+    // column to display at `elapsedMs` into the animation. Non-looping
+    // animations clamp to the last frame.
+    function computeFrameIndex(anim, elapsedMs, looping) {
+        let frameDurations;
+        if (Array.isArray(anim.frames)) {
+            frameDurations = anim.frames;
+        } else if (typeof anim.count === 'number' && anim.count > 0) {
+            frameDurations = new Array(anim.count).fill(anim.dur || 120);
+            if (anim.last != null) frameDurations[anim.count - 1] = anim.last;
+        } else {
+            return 0;
+        }
+        const total = frameDurations.reduce((a, b) => a + b, 0);
+        if (total <= 0) return 0;
+        let t = elapsedMs;
+        if (looping !== false) {
+            t = ((t % total) + total) % total;
+        } else if (t >= total) {
+            return frameDurations.length - 1;
+        }
+        let acc = 0;
+        for (let i = 0; i < frameDurations.length; i++) {
+            acc += frameDurations[i];
+            if (t < acc) return i;
+        }
+        return frameDurations.length - 1;
+    }
+
     // ── Canvas runner ───────────────────────────────────────────
     /**
      * createRenderer({ canvas, descriptor, state?, onError? }) → controller
@@ -121,10 +184,15 @@
             if (!running) return;
             rafId = requestAnimationFrame(tick);
 
-            const fps = getStateFps(currentDescriptor, currentState);
-            const minFrameMs = 1000 / fps;
-            if (now - lastFrameTime < minFrameMs) return;
-            lastFrameTime = now;
+            // Spritesheets use the anim table's per-frame durations directly,
+            // so we don't throttle here — let rAF drive resolution.
+            // Procedural drawers honour their descriptor.stateAssets.*.fps.
+            if (currentDescriptor.assetType !== 'spritesheet') {
+                const fps = getStateFps(currentDescriptor, currentState);
+                const minFrameMs = 1000 / fps;
+                if (now - lastFrameTime < minFrameMs) return;
+                lastFrameTime = now;
+            }
 
             const w = canvas.width;
             const h = canvas.height;
@@ -143,25 +211,57 @@
                         });
                     }
                 } else if (currentDescriptor.assetType === 'spritesheet') {
-                    // Planned next PR; for now draw a placeholder stripe so
-                    // the preview page makes the gap visible instead of
-                    // failing silently.
-                    drawSpritesheetPlaceholder(ctx, w, h, currentState);
+                    drawSpritesheetFrame(ctx, w, h, currentDescriptor, currentState, now - stateClockStart);
                 }
             } catch (err) {
                 if (onError) onError(err);
             }
         }
 
-        function drawSpritesheetPlaceholder(ctx, w, h, state) {
+        function drawSpritesheetFrame(ctx, w, h, descriptor, state, elapsedMs) {
+            const asset = descriptor.asset || {};
+            const sheet = loadSpritesheet(asset.url);
+            if (!sheet || sheet.error) {
+                drawSpritesheetMessage(ctx, w, h, state, sheet && sheet.error ? '⚠︎ sheet load failed' : 'no sprite url');
+                return;
+            }
+            if (!sheet.ready) {
+                drawSpritesheetMessage(ctx, w, h, state, '…');
+                return;
+            }
+
+            const animName = pickAnimationName(descriptor, state);
+            const animations = asset.animations || {};
+            const anim = animations[animName] || animations.idle;
+            if (!anim) {
+                drawSpritesheetMessage(ctx, w, h, state, animName + '?');
+                return;
+            }
+
+            const frameIndex = computeFrameIndex(anim, elapsedMs, descriptor.stateAssets && descriptor.stateAssets[state] && descriptor.stateAssets[state].loop !== false);
+            const fw = asset.frameWidth || 192;
+            const fh = asset.frameHeight || 208;
+            const sx = frameIndex * fw;
+            const sy = (anim.row || 0) * fh;
+
+            const scale = Math.min(w / fw, h / fh);
+            const dw = fw * scale;
+            const dh = fh * scale;
+            const dx = (w - dw) / 2;
+            const dy = (h - dh) / 2;
+            ctx.imageSmoothingEnabled = false;
+            ctx.drawImage(sheet.img, sx, sy, fw, fh, dx, dy, dw, dh);
+        }
+
+        function drawSpritesheetMessage(ctx, w, h, state, msg) {
             ctx.save();
             ctx.fillStyle = '#1a1a1a';
             ctx.fillRect(0, 0, w, h);
             ctx.fillStyle = '#888';
-            ctx.font = '14px sans-serif';
+            ctx.font = '12px sans-serif';
             ctx.textAlign = 'center';
-            ctx.fillText('spritesheet renderer — next PR', w / 2, h / 2);
-            ctx.fillText(`state: ${state}`, w / 2, h / 2 + 20);
+            ctx.fillText(msg, w / 2, h / 2);
+            ctx.fillText(state, w / 2, h / 2 + 14);
             ctx.restore();
         }
 
@@ -477,6 +577,8 @@
         resolveState,
         getStateFps,
         getStateLoop,
+        pickAnimationName,
+        computeFrameIndex,
         DEFAULT_STATE,
     };
 }));

--- a/backend/tests/jest/petdex-bridge.test.js
+++ b/backend/tests/jest/petdex-bridge.test.js
@@ -1,0 +1,132 @@
+/**
+ * Petdex bridge unit tests — descriptor shape + sync (mocked pool/fetch).
+ * The renderer-side frame-index math is exercised in petdx-renderer.test.js.
+ */
+
+const bridge = require('../../petdex-bridge');
+
+describe('buildDescriptor', () => {
+    it('produces a spritesheet descriptor with all 9 animations', () => {
+        const d = bridge.buildDescriptor({
+            slug: 'boba',
+            displayName: 'Boba',
+            kind: 'creature',
+            spritesheetUrl: 'https://r2/boba.webp',
+            petJsonUrl: 'https://r2/boba.json',
+            zipUrl: 'https://r2/boba.zip',
+            submittedBy: 'railly',
+        });
+        expect(d.id).toBe('petdex-boba');
+        expect(d.assetType).toBe('spritesheet');
+        expect(d.asset.url).toBe('https://r2/boba.webp');
+        expect(d.asset.cols).toBe(8);
+        expect(d.asset.rows).toBe(9);
+        expect(d.asset.frameWidth).toBe(192);
+        expect(d.asset.frameHeight).toBe(208);
+        expect(Object.keys(d.asset.animations).sort()).toEqual([
+            'failed', 'idle', 'jumping', 'review',
+            'running', 'running-left', 'running-right',
+            'waiting', 'waving',
+        ]);
+        // idle uses variable per-frame durations
+        expect(Array.isArray(d.asset.animations.idle.frames)).toBe(true);
+        expect(d.asset.animations.idle.frames.length).toBe(6);
+        // uniform animations use {count, dur, last?}
+        expect(d.asset.animations.running.count).toBe(6);
+        expect(d.asset.animations.running.dur).toBe(120);
+        expect(d.asset.animations.running.last).toBe(220);
+    });
+
+    it('maps every EClaw state to a row via stateAssets', () => {
+        const d = bridge.buildDescriptor({
+            slug: 'cortana',
+            displayName: 'Cortana',
+            kind: 'character',
+            spritesheetUrl: 'https://r2/cortana.webp',
+        });
+        expect(d.supportedStates).toEqual(['IDLE', 'BUSY', 'WALKING', 'SLEEPING', 'EXCITED', 'HAPPY']);
+        expect(d.stateAssets.IDLE.animation).toBe('idle');
+        expect(d.stateAssets.BUSY.animation).toBe('running');
+        expect(d.stateAssets.WALKING.animation).toBe('running-right');
+        expect(d.stateAssets.SLEEPING.animation).toBe('waiting');
+        expect(d.stateAssets.EXCITED.animation).toBe('jumping');
+        expect(d.stateAssets.HAPPY.animation).toBe('waving');
+    });
+
+    it('attaches Petdex provenance + MIT license', () => {
+        const d = bridge.buildDescriptor({
+            slug: 'pixel-panda',
+            displayName: 'Pixel Panda',
+            kind: 'creature',
+            spritesheetUrl: 'https://r2/pixel-panda.webp',
+            submittedBy: 'user42',
+        });
+        expect(d.sourceAttribution.project).toBe('crafter-station/petdex');
+        expect(d.sourceAttribution.license).toBe('MIT');
+        expect(d.sourceAttribution.slug).toBe('pixel-panda');
+        expect(d.sourceAttribution.submittedBy).toBe('user42');
+    });
+});
+
+describe('syncPetdexCatalog', () => {
+    const originalFetch = global.fetch;
+    afterEach(() => { global.fetch = originalFetch; });
+
+    function mockPool() {
+        const calls = [];
+        return {
+            calls,
+            query: jest.fn(async (sql, params) => {
+                calls.push({ sql: sql.slice(0, 60), params });
+                return { rows: [] };
+            }),
+        };
+    }
+
+    it('upserts every valid pet and skips malformed entries', async () => {
+        global.fetch = jest.fn(async () => ({
+            ok: true,
+            json: async () => ({
+                generatedAt: '2026-05-12',
+                total: 4,
+                pets: [
+                    { slug: 'boba', displayName: 'Boba', kind: 'creature', spritesheetUrl: 'https://r2/boba.webp' },
+                    { slug: 'cortana', displayName: 'Cortana', kind: 'character', spritesheetUrl: 'https://r2/cortana.webp' },
+                    null,                                          // dropped: nullish
+                    { slug: 'broken' },                            // dropped: no spritesheetUrl
+                ],
+            }),
+        }));
+        const pool = mockPool();
+        const log = jest.fn();
+        const result = await bridge.syncPetdexCatalog(pool, log);
+        expect(result.total).toBe(4);
+        expect(result.inserted).toBe(2);
+        expect(result.failed).toBe(2);
+        expect(pool.calls.length).toBe(2);
+        expect(pool.calls[0].params[0]).toBe('petdex-boba');
+        expect(pool.calls[1].params[0]).toBe('petdex-cortana');
+    });
+
+    it('counts DB failures and surfaces them without throwing', async () => {
+        global.fetch = jest.fn(async () => ({
+            ok: true,
+            json: async () => ({
+                pets: [{ slug: 'a', displayName: 'A', kind: 'creature', spritesheetUrl: 'https://r2/a.webp' }],
+            }),
+        }));
+        const pool = { query: jest.fn(async () => { throw new Error('db down'); }) };
+        const log = jest.fn();
+        const result = await bridge.syncPetdexCatalog(pool, log);
+        expect(result.inserted).toBe(0);
+        expect(result.failed).toBe(1);
+    });
+
+    it('returns zeros when the manifest fetch fails', async () => {
+        global.fetch = jest.fn(async () => ({ ok: false, status: 502 }));
+        const pool = mockPool();
+        const result = await bridge.syncPetdexCatalog(pool, () => {});
+        expect(result.inserted).toBe(0);
+        expect(result.total).toBe(0);
+    });
+});

--- a/backend/tests/jest/petdx-renderer.test.js
+++ b/backend/tests/jest/petdx-renderer.test.js
@@ -201,3 +201,67 @@ describe('createRenderer factory contract', () => {
         expect(r.getState()).toBe('IDLE');
     });
 });
+
+describe('spritesheet helpers (Petdex bridge)', () => {
+    const SPRITESHEET_DESCRIPTOR = Object.freeze({
+        id: 'petdex-boba',
+        name: 'Boba',
+        assetType: 'spritesheet',
+        asset: {
+            url: 'https://example/boba.webp',
+            cols: 8, rows: 9, frameWidth: 192, frameHeight: 208,
+            animations: {
+                idle: { row: 0, frames: [280, 110, 110, 140, 140, 320] },
+                running: { row: 7, count: 6, dur: 120, last: 220 },
+                waving: { row: 3, count: 4, dur: 140, last: 280 },
+            },
+        },
+        supportedStates: ['IDLE', 'BUSY', 'HAPPY'],
+        stateAssets: {
+            IDLE: { animation: 'idle', loop: true },
+            BUSY: { animation: 'running', loop: true },
+            HAPPY: { animation: 'waving', loop: false },
+        },
+    });
+
+    test('pickAnimationName routes state to animation name, fallback to idle', () => {
+        expect(PetdxRenderer.pickAnimationName(SPRITESHEET_DESCRIPTOR, 'IDLE')).toBe('idle');
+        expect(PetdxRenderer.pickAnimationName(SPRITESHEET_DESCRIPTOR, 'BUSY')).toBe('running');
+        expect(PetdxRenderer.pickAnimationName(SPRITESHEET_DESCRIPTOR, 'NOPE')).toBe('idle');
+        expect(PetdxRenderer.pickAnimationName({}, 'IDLE')).toBe('idle');
+    });
+
+    test('computeFrameIndex over a frames[] table walks per-frame durations', () => {
+        const idle = SPRITESHEET_DESCRIPTOR.asset.animations.idle;
+        // frames: [280, 110, 110, 140, 140, 320] — cumulative 280/390/500/640/780/1100
+        expect(PetdxRenderer.computeFrameIndex(idle, 0, true)).toBe(0);
+        expect(PetdxRenderer.computeFrameIndex(idle, 279, true)).toBe(0);
+        expect(PetdxRenderer.computeFrameIndex(idle, 280, true)).toBe(1);
+        expect(PetdxRenderer.computeFrameIndex(idle, 399, true)).toBe(2);
+        expect(PetdxRenderer.computeFrameIndex(idle, 781, true)).toBe(5);
+        // looping wraps at total=1100
+        expect(PetdxRenderer.computeFrameIndex(idle, 1100, true)).toBe(0);
+        expect(PetdxRenderer.computeFrameIndex(idle, 1100 + 281, true)).toBe(1);
+    });
+
+    test('computeFrameIndex over a uniform count/dur table honours last-frame override', () => {
+        const running = SPRITESHEET_DESCRIPTOR.asset.animations.running;
+        // 6 frames; first 5 are 120ms, last is 220ms → cumulative 120/240/360/480/600/820
+        expect(PetdxRenderer.computeFrameIndex(running, 0, true)).toBe(0);
+        expect(PetdxRenderer.computeFrameIndex(running, 119, true)).toBe(0);
+        expect(PetdxRenderer.computeFrameIndex(running, 120, true)).toBe(1);
+        expect(PetdxRenderer.computeFrameIndex(running, 599, true)).toBe(4);
+        expect(PetdxRenderer.computeFrameIndex(running, 600, true)).toBe(5);
+        expect(PetdxRenderer.computeFrameIndex(running, 819, true)).toBe(5);
+        // wraps at 820
+        expect(PetdxRenderer.computeFrameIndex(running, 820, true)).toBe(0);
+    });
+
+    test('computeFrameIndex non-looping clamps to last frame past total', () => {
+        const waving = SPRITESHEET_DESCRIPTOR.asset.animations.waving;
+        // count=4, dur=140, last=280 → 140/280/420/700
+        expect(PetdxRenderer.computeFrameIndex(waving, 700, false)).toBe(3);
+        expect(PetdxRenderer.computeFrameIndex(waving, 9999, false)).toBe(3);
+        expect(PetdxRenderer.computeFrameIndex(waving, 140, false)).toBe(1);
+    });
+});


### PR DESCRIPTION
## Summary
Mirror the public crafter-station/petdex gallery into our `companions` table so the Petdx browser jumps from **5 partners → 1700+** in one shot. The github reference Hank flagged (2026-05-09 channel msg) was https://github.com/crafter-station/petdex — MIT-licensed, R2-hosted 8×9 spritesheets with a fixed 9-animation convention.

Card: `card_5f77126b9995ebe1e124fd0a`

## What's new
- **`backend/petdex-bridge.js`** — fetches `https://petdex.crafter.run/api/manifest` and upserts each pet into `companions` as `scope='community'`, `asset_type='spritesheet'`, `license='MIT'`, with descriptor containing the 9-animation table (idle / running / running-right / running-left / waving / jumping / failed / waiting / review). Fires once after schema init (gated by `PETDEX_SYNC_ON_BOOT`, default on). Idempotent — re-runs are upserts.
- **`POST /api/companion/petdex-sync`** — deviceSecret-only manual re-sync.
- **`shared/petdx-renderer.js`** — implements the previously-stubbed `assetType:'spritesheet'` path. URL-cached HTMLImageElement + per-row anim table; no `crossOrigin` so R2's missing ACAO doesn't block (canvas becomes taintable but the wallpaper renderer never reads pixels back). Skips the procedural FPS throttle since the anim table drives per-frame timing.
- **`companion-api.js`** — surfaces `asset` + `stateAssets` on the list payload for spritesheet rows so the grid can animate every tile without a follow-up `GET /:id` per card. Procedural payload unchanged.
- **`portal/petdx-browser.html`** — threads spritesheet asset metadata into the renderer descriptor; procedural fall-through preserved.

## State mapping (EClaw → Petdex row)
| State | Animation | Row |
|---|---|---|
| IDLE | idle | 0 |
| BUSY | running | 7 |
| WALKING | running-right | 1 |
| SLEEPING | waiting | 6 |
| EXCITED | jumping | 4 |
| HAPPY | waving | 3 |

(Animation row table extracted from `crafter-station/petdex` `packages/petdex-desktop/src/main.zig`.)

## Licensing & attribution
- Petdex repo is MIT. Each row carries `descriptor.sourceAttribution = { project, license, slug, submittedBy, petJsonUrl, zipUrl }` so the UI can render proper credit (Stage 2 — TODO: footer chip).
- No binary assets are copied into this repo — sprites hot-link to Petdex's public R2 bucket.

## Test plan
- [x] `npx jest backend/tests/jest/companion-api.test.js backend/tests/jest/petdex-bridge.test.js backend/tests/jest/petdx-renderer.test.js` → **110 tests pass**
  - +6 bridge unit tests (descriptor shape, sync upsert, malformed-entry skip, DB-failure counting, manifest-fetch failure)
  - +5 renderer tests (`pickAnimationName`, `computeFrameIndex` over `frames[]` table / uniform `count/dur/last` table / non-looping clamp)
- [x] Live manifest probe via `fetchPetdexManifest()`: returns **1784 pets** as of 2026-05-12 (was 1779 at investigation start)
- [x] Playwright drill against a 4-cell grid loading 3 real spritesheets + 1 bad-url sanity:
  - IDLE: all 3 render correct row-0 frame (Boba sipping boba, Clawd with headphones, Cortana standing)
  - EXCITED: state switch animates to row-4 (Cortana mid-jump, Clawd jumping pose)
  - Bad URL: graceful "⚠︎ sheet load failed" fallback, no crash
  - Console: 0 errors (only the intentional ERR_NAME_NOT_RESOLVED from the bad-url cell)

## Stage 2 (follow-ups, not in this PR)
- Hide the E2E test stub from the public browser (Hank flagged this earlier)
- Attribution footer chip in the detail modal
- Favorites/ratings UX polish for the bigger catalog (1.7k entries → need debounced search)

🤖 Generated with [Claude Code](https://claude.com/claude-code)