### PR TITLE
feat(share-chat): twitter card + per-bot og:image/twitter:* in SSR

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -591,6 +591,10 @@ function _renderShareChatSSR(code) {
         `Connect with ${name} — an AI agent on EClawbot. Start a conversation, ask questions, or explore capabilities.`;
     const descAttr = _escapeHtmlAttr(descText);
     const ogTitleAttr = _escapeHtmlAttr(`Chat with ${name} on EClawbot`);
+    const avatarUrl = (entity.avatar && typeof entity.avatar === 'string' && /^https?:\/\//.test(entity.avatar))
+        ? entity.avatar
+        : 'https://eclawbot.com/assets/og-image.png';
+    const avatarAttr = _escapeHtmlAttr(avatarUrl);
 
     const jsonld = {
         '@context': 'https://schema.org',
@@ -635,6 +639,22 @@ function _renderShareChatSSR(code) {
         .replace(
             /<meta property="og:url" content="[^"]*" id="og-url">/,
             `<meta property="og:url" content="${url}" id="og-url">`
+        )
+        .replace(
+            /<meta property="og:image" content="[^"]*" id="og-image">/,
+            `<meta property="og:image" content="${avatarAttr}" id="og-image">`
+        )
+        .replace(
+            /<meta name="twitter:title" content="[^"]*" id="twitter-title">/,
+            `<meta name="twitter:title" content="${ogTitleAttr}" id="twitter-title">`
+        )
+        .replace(
+            /<meta name="twitter:description" content="[^"]*" id="twitter-desc">/,
+            `<meta name="twitter:description" content="${descAttr}" id="twitter-desc">`
+        )
+        .replace(
+            /<meta name="twitter:image" content="[^"]*" id="twitter-image">/,
+            `<meta name="twitter:image" content="${avatarAttr}" id="twitter-image">`
         )
         .replace(
             /<script type="application\/ld\+json" id="jsonld-data"><\/script>/,

--- a/backend/public/portal/share-chat.html
+++ b/backend/public/portal/share-chat.html
@@ -12,11 +12,18 @@
     <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
     <link rel="canonical" href="https://eclawbot.com/portal/share-chat.html">
+    <meta property="og:site_name" content="EClawbot">
+    <meta property="og:locale" content="en_US">
     <meta property="og:title" content="EClawbot - Chat" id="og-title">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="/assets/og-image.png">
+    <meta property="og:image" content="https://eclawbot.com/assets/og-image.png" id="og-image">
     <meta property="og:description" content="Chat with an EClawbot entity" id="og-desc">
     <meta property="og:url" content="https://eclawbot.com/c/" id="og-url">
+    <meta name="twitter:card" content="summary_large_image">
+    <meta name="twitter:site" content="@eclawbot">
+    <meta name="twitter:title" content="EClawbot - Chat" id="twitter-title">
+    <meta name="twitter:description" content="Chat with an EClawbot entity" id="twitter-desc">
+    <meta name="twitter:image" content="https://eclawbot.com/assets/og-image.png" id="twitter-image">
     <style>
         body { background: var(--bg); color: var(--text); font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 0; }
         .share-chat-wrap { max-width: 600px; margin: 0 auto; padding: 16px; height: 100vh; display: flex; flex-direction: column; box-sizing: border-box; }

--- a/backend/tests/jest/share-chat-ssr-og.test.js
+++ b/backend/tests/jest/share-chat-ssr-og.test.js
@@ -16,13 +16,13 @@ const fs = require('fs');
 const src = fs.readFileSync(require.resolve('../../index'), 'utf8');
 
 describe('share-chat SSR helper', () => {
-    function slice(anchor, span = 4500) {
+    function slice(anchor, span = 5500) {
         const i = src.indexOf(anchor);
         expect(i).toBeGreaterThan(-1);
         return src.slice(i, i + span);
     }
 
-    const helperBlock = slice('function _renderShareChatSSR(', 3500);
+    const helperBlock = slice('function _renderShareChatSSR(', 5500);
     const routeBlock = slice("app.get('/c/:code',", 800);
 
     it('helper is defined', () => {
@@ -48,6 +48,24 @@ describe('share-chat SSR helper', () => {
         expect(helperBlock).toContain('id="og-title"');
         expect(helperBlock).toContain('id="og-desc"');
         expect(helperBlock).toContain('id="og-url"');
+    });
+
+    it('personalises og:image with entity avatar (fallback default)', () => {
+        expect(helperBlock).toContain('id="og-image"');
+        expect(helperBlock).toMatch(/og:image"\s+content="\$\{avatarAttr\}"/);
+    });
+
+    it('personalises twitter:title / twitter:description / twitter:image', () => {
+        expect(helperBlock).toContain('id="twitter-title"');
+        expect(helperBlock).toContain('id="twitter-desc"');
+        expect(helperBlock).toContain('id="twitter-image"');
+        expect(helperBlock).toMatch(/twitter:title"\s+content="\$\{ogTitleAttr\}"/);
+        expect(helperBlock).toMatch(/twitter:description"\s+content="\$\{descAttr\}"/);
+        expect(helperBlock).toMatch(/twitter:image"\s+content="\$\{avatarAttr\}"/);
+    });
+
+    it('avatar URL falls back to default when not absolute http(s)', () => {
+        expect(helperBlock).toMatch(/avatarUrl = .*\^https\?:\\\/\\\/.*entity\.avatar.*og-image\.png/s);
     });
 
     it('personalises canonical link', () => {


### PR DESCRIPTION
## Summary
- Add twitter:card (summary_large_image), og:site_name, og:locale to share-chat.html baseline
- Add twitter:title / twitter:description / twitter:image meta tags with `id` hooks for SSR
- Extend `_renderShareChatSSR` in backend/index.js to substitute og:image + twitter:title/description/image with per-bot entity.avatar (fallback to /assets/og-image.png)
- og:image absolute URL (was relative `/assets/og-image.png`)

## Why
share-chat (Proxy Window) gets ~26 views/30d. Step 1 of growth card is auditing OG gaps — jsonld had per-bot image, but `og:image` (what Facebook/LinkedIn/iMessage actually render in preview cards) didn't, and Twitter Card was entirely absent. This PR closes both gaps.

## Test plan
- [x] `node -c backend/index.js` parses clean
- [ ] After deploy, `curl https://eclawbot.com/c/<publicCode>` shows per-bot og:image / twitter:image when bot has avatar
- [ ] twitter.com card-validator returns summary_large_image with bot avatar
- [ ] Fallback: bot without avatar still gets default og-image.png
- [ ] CI green

## Card refs
- Parent: card_2d6a050b31317584387aa018 ([Growth-P1] share-chat traffic)
- Sub: card_170f0a7766a8424d180fb18c (step1 OG audit + fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)