### PR TITLE
fix(entities): expose botSecret to owner so wallpaper companions poll

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -6480,11 +6480,16 @@ app.get('/api/entities', async (req, res) => {
         if (deviceId !== authedDeviceId) continue;
 
         const device = devices[deviceId];
+        // Owner-level callers (deviceSecret or JWT cookie for this device) get each
+        // entity's botSecret so the Android wallpaper service can spawn per-entity
+        // companion pollers. botSecret-auth callers (peer bots) never see other
+        // entities' secrets.
+        const includeBotSecret = deviceAuthed || (jwtDeviceId && jwtDeviceId === authedDeviceId);
         for (const i of Object.keys(device.entities).map(Number)) {
             const entity = device.entities[i];
             if (!entity) continue;
             if (entity.isBound) {
-                entities.push({
+                const payload = {
                     deviceId: deviceId,
                     entityId: entity.entityId,
                     name: entity.name,
@@ -6516,7 +6521,11 @@ app.get('/api/entities', async (req, res) => {
                         read: m.read || false,
                         delivered: m.delivered || false
                     }))
-                });
+                };
+                if (includeBotSecret && entity.botSecret) {
+                    payload.botSecret = entity.botSecret;
+                }
+                entities.push(payload);
             }
         }
     }

--- a/backend/tests/jest/entities-include-botsecret.test.js
+++ b/backend/tests/jest/entities-include-botsecret.test.js
@@ -1,0 +1,59 @@
+/**
+ * Regression: /api/entities must include each bound entity's botSecret
+ * field in the response when the caller authenticates at owner level
+ * (deviceSecret or JWT cookie for this device). It must NOT include
+ * botSecret for peer-bot callers (botSecret-auth path).
+ *
+ * Pre-fix: Android live-wallpaper service called /api/entities with
+ * deviceSecret, parsed EntityStatus.botSecret as null for every entity,
+ * and ClawWallpaperService.ensureCompanionPollers (which filters
+ * entities.mapNotNull { e -> e.botSecret?.let{} }) skipped all of them.
+ * No companion poller ever started; the wallpaper rendered the
+ * "colored lobster" fallback regardless of petdx selection.
+ *
+ * Post-fix: handler computes `includeBotSecret = deviceAuthed || jwt`
+ * and attaches entity.botSecret to each entity payload when true.
+ */
+
+const fs = require('fs');
+
+const src = fs.readFileSync(require.resolve('../../index'), 'utf8');
+
+function slice(anchor, span = 6500) {
+    const i = src.indexOf(anchor);
+    expect(i).toBeGreaterThan(-1);
+    return src.slice(i, i + span);
+}
+
+describe('/api/entities botSecret exposure', () => {
+    const handler = slice("app.get('/api/entities',", 6500);
+
+    it('derives an includeBotSecret flag from auth mode', () => {
+        expect(handler).toMatch(/const includeBotSecret\s*=\s*deviceAuthed\s*\|\|\s*\(jwtDeviceId\s*&&\s*jwtDeviceId\s*===\s*authedDeviceId\)/);
+    });
+
+    it('only attaches botSecret when the flag is true AND entity has one', () => {
+        expect(handler).toMatch(/if \(includeBotSecret && entity\.botSecret\) \{\s*\n\s*payload\.botSecret = entity\.botSecret;\s*\n\s*\}/);
+    });
+
+    it('does NOT attach botSecret unconditionally inside the payload literal', () => {
+        // Pull the object literal that the handler pushes; it must not
+        // include a bare `botSecret: entity.botSecret` line.
+        const literalStart = handler.indexOf('const payload = {');
+        expect(literalStart).toBeGreaterThan(-1);
+        const literalEnd = handler.indexOf('};', literalStart);
+        const literal = handler.slice(literalStart, literalEnd);
+        expect(literal).not.toMatch(/botSecret:\s*entity\.botSecret/);
+    });
+
+    it('botSecret-auth callers (peer bots) are gated by includeBotSecret', () => {
+        // deviceAuthed is false on the botSecret path, and jwtDeviceId comes
+        // from JWT cookie middleware (req.user); botAuthed alone never
+        // flips includeBotSecret true.
+        expect(handler).toMatch(/let botAuthed = false;/);
+        // includeBotSecret must not reference botAuthed.
+        const flagLine = handler.match(/const includeBotSecret\s*=\s*[^;]+;/);
+        expect(flagLine).not.toBeNull();
+        expect(flagLine[0]).not.toMatch(/botAuthed/);
+    });
+});


### PR DESCRIPTION
## Summary
- `/api/entities` previously dropped `botSecret` from every entity payload, so Android `ClawWallpaperService.ensureCompanionPollers` filtered every entity out of `entities.mapNotNull { e -> e.botSecret?.let{} }` and never spawned `CompanionRepository.getCompanionFlow`. The wallpaper kept rendering the colored-lobster fallback regardless of petdx selection.
- Fix: when caller is owner-level (`deviceSecret` or JWT cookie matches the device), attach `entity.botSecret` to each entity in the response. Peer botSecret-auth callers stay blind to sibling secrets.
- Added `backend/tests/jest/entities-include-botsecret.test.js` to lock the auth gate.

## Why this surfaced now
Hank one-clicked entity #1's companion via petdx; wallpaper kept showing the default lobster. 28 min of logcat captured `Multi-entity status: 6 entities` every 5 s but zero `Companion fetched for entity X` lines — `CompanionRepository.getCompanionFlow` was never invoked because the filter on line 111 of `ClawWallpaperService.kt` rejected every entity for lack of secret.

## Test plan
- [x] `npx jest backend/tests/jest/entities-include-botsecret.test.js` — 4/4 pass
- [x] `npx jest backend/tests/jest/entities-status-botsecret-auth.test.js backend/tests/jest/entities-binding-discovery.test.js` — 132/132 pass (existing auth contract intact)
- [ ] APK rebuild + emulator E2E (after merge): switch entity #1 companion in petdx, expect wallpaper visual update within 30s + logcat `Companion fetched for entity 1: petdex-* (spritesheet)`

Card: `card_9ea46bd5123383f18469cacd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)