### PR TITLE
fix(rental): expose owner_public_code so plaza CTA routes correctly

### DIFF
--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -867,7 +867,7 @@
                     rentalBots = (data.listings || []).map(l => {
                         const caps = l.capabilities ? Object.keys(l.capabilities).filter(k => l.capabilities[k]?.supported) : [];
                         return {
-                            publicCode: l.id, name: l.title || 'Rental Bot', avatar: l.avatar_url || '🤖',
+                            publicCode: l.owner_public_code || null, name: l.title || 'Rental Bot', avatar: l.avatar_url || '🤖',
                             desc: l.description || (l.model_detected || ''),
                             tags: caps, caps: caps, _capsObj: l.capabilities || {},
                             stars: l.avg_rating || 0, reviews: l.total_rentals || 0,
@@ -976,6 +976,9 @@
                 </div>
             </div>
             ${statusBadge}
+            ${(!isRented && bot.publicCode) ? `<div class="bot-card-action">
+                <button class="bot-card-quick-chat" onclick="event.stopPropagation();window.open('/c/${bot.publicCode}?utm_source=plaza&utm_medium=rental_card','_blank')" title="${tt('mp_chat_cta','\u958b\u59cb\u5c0d\u8a71')}">${tt('mp_chat_cta','\u958b\u59cb\u5c0d\u8a71')} \u2192</button>
+            </div>` : ''}
         </div>`;
     }
 

--- a/backend/rental.js
+++ b/backend/rental.js
@@ -1848,7 +1848,12 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
             // the listing was created (silent identity drift). Owner still sees
             // them in /my-rentals so they can re-publish or delist explicitly.
             const filtered = filterDriftedListings(listings, _interviewDeps?.devices);
-            res.json({ success: true, listings: filtered });
+            const devicesMap = _interviewDeps?.devices;
+            const enriched = filtered.map((l) => {
+                const ent = devicesMap?.[l.owner_device_id]?.entities?.[l.owner_entity_id];
+                return ent?.publicCode ? { ...l, owner_public_code: ent.publicCode } : l;
+            });
+            res.json({ success: true, listings: enriched });
         } catch (err) {
             console.error('[Rental] /marketplace error:', err);
             res.status(500).json({ success: false, error: 'internal_error' });

--- a/backend/tests/jest/rental-marketplace-public-code.test.js
+++ b/backend/tests/jest/rental-marketplace-public-code.test.js
@@ -1,0 +1,41 @@
+/**
+ * Regression: GET /api/rental/marketplace must include each listing's
+ * owner_public_code so the community.html grid can build a /c/:publicCode
+ * URL for the "開始對話" CTA. Pre-fix the response only had owner_device_id
+ * + owner_entity_id, and the UI fell through to listing.id (a UUID) which
+ * /c/:publicCode rejects.
+ */
+
+const fs = require('fs');
+
+const src = fs.readFileSync(require.resolve('../../rental.js'), 'utf8');
+
+function slice(anchor, span = 1500) {
+    const i = src.indexOf(anchor);
+    expect(i).toBeGreaterThan(-1);
+    return src.slice(i, i + span);
+}
+
+describe('rental marketplace owner_public_code enrichment', () => {
+    const route = slice("router.get('/marketplace'", 1500);
+
+    it('enriches each listing with owner_public_code from devices map', () => {
+        expect(route).toMatch(/const devicesMap = _interviewDeps\?\.devices;/);
+        expect(route).toMatch(/devicesMap\?\.\[l\.owner_device_id\]\?\.entities\?\.\[l\.owner_entity_id\]/);
+    });
+
+    it('only attaches owner_public_code when entity has one (no overwrite to null)', () => {
+        expect(route).toMatch(/ent\?\.publicCode \? \{ \.\.\.l, owner_public_code: ent\.publicCode \} : l/);
+    });
+
+    it('enrichment runs AFTER drift filter (so dropped listings stay dropped)', () => {
+        const filterPos = route.indexOf('filterDriftedListings(');
+        const enrichPos = route.indexOf('owner_public_code:');
+        expect(filterPos).toBeGreaterThan(-1);
+        expect(enrichPos).toBeGreaterThan(filterPos);
+    });
+
+    it('response body still uses res.json({ success, listings })', () => {
+        expect(route).toMatch(/res\.json\(\{ success: true, listings: enriched \}\)/);
+    });
+});


### PR DESCRIPTION
## Summary
- `/api/rental/marketplace` now returns `owner_public_code` per listing, enriched from in-memory devices map after the drift filter.
- `community.html` rental card pulls `publicCode` from `l.owner_public_code` (was `l.id` UUID), and `renderRentalCard()` renders the same `bot-card-quick-chat` button as community cards when listing is available.
- UTM split: `utm_medium=rental_card` (vs `card` for community) so marketing can attribute the funnel.

## Why
PR #2610 added 1-click chat to community cards only. Rental cards in the same plaza had no working chat path because:
1. Backend marketplace response lacked publicCode entirely.
2. Frontend silently mapped `publicCode: l.id` (UUID), which `/c/:publicCode` cannot resolve.

## Test plan
- [x] `jest tests/jest/rental-marketplace-public-code.test.js` — 4 new regression tests lock enrichment shape + position
- [x] `jest tests/jest/rental-listing.test.js` — 37/37 existing tests still pass
- [ ] After deploy: curl `/api/rental/marketplace` → confirm `owner_public_code` present
- [ ] Visit `/portal/community.html` → rental listings show 開始對話 button → click → opens `/c/:publicCode`

## Follow-ups
- i18n key `mp_chat_cta` will be filed to Hermes (#5) after merge; UI falls back to literal 開始對話 in the meantime.

Card: card_ae82f909a90aa3143d270f10

🤖 Generated with [Claude Code](https://claude.com/claude-code)