### PR TITLE
fix(wallpaper): off-load spritesheet fetch to IO so per-petdx sprites render

### DIFF
--- a/app/src/main/java/com/hank/clawlive/data/repository/CompanionRepository.kt
+++ b/app/src/main/java/com/hank/clawlive/data/repository/CompanionRepository.kt
@@ -7,9 +7,15 @@ import com.hank.clawlive.data.local.DeviceManager
 import com.hank.clawlive.data.model.CompanionDetail
 import com.hank.clawlive.data.remote.ClawApiService
 import com.hank.clawlive.data.remote.NetworkModule
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import okhttp3.Request
 import timber.log.Timber
 import java.util.concurrent.ConcurrentHashMap
@@ -30,13 +36,24 @@ class CompanionRepository(
     private val deviceManager = DeviceManager.getInstance(context)
     private val descriptorCache = ConcurrentHashMap<Int, CompanionDetail>()
     private val sheetCache = SheetBitmapCache(maxEntries = 3)
+    private val ioScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     /** Returns the cached companion for an entity, or null until a fetch lands. */
     fun cached(entityId: Int): CompanionDetail? = descriptorCache[entityId]
 
-    /** Returns a decoded spritesheet bitmap, loading on first access. */
+    /**
+     * Returns a decoded spritesheet bitmap. The wallpaper draw loop runs on
+     * the Main thread, so we never block here: a cache miss schedules an
+     * async fetch on the IO scope and returns null this frame. The next draw
+     * tick (33ms later) will find the bitmap and paint it.
+     */
     fun getSheet(url: String?): Bitmap? {
         if (url.isNullOrBlank()) return null
+        sheetCache.peek(url)?.let { return it }
+        if (android.os.Looper.myLooper() == android.os.Looper.getMainLooper()) {
+            ioScope.launch { sheetCache.getOrLoad(url) { fetchBitmap(url) } }
+            return null
+        }
         return sheetCache.getOrLoad(url) { fetchBitmap(url) }
     }
 
@@ -62,8 +79,14 @@ class CompanionRepository(
                     descriptorCache[entityId] = companion
                     Timber.d("Companion fetched for entity $entityId: ${companion.id} (${companion.assetType})")
                     // Pre-warm spritesheet decode so first paint is smooth.
+                    // The flow itself runs on the engine's Main scope, so the
+                    // OkHttp call has to be marshalled to IO.
                     if (companion.assetType == "spritesheet") {
-                        getSheet(companion.spritesheetUrl())
+                        withContext(Dispatchers.IO) {
+                            sheetCache.getOrLoad(companion.spritesheetUrl() ?: "") {
+                                companion.spritesheetUrl()?.let { fetchBitmap(it) }
+                            }
+                        }
                     }
                 }
                 emit(companion)
@@ -76,6 +99,7 @@ class CompanionRepository(
 
     /** Drop caches when the wallpaper engine tears down. */
     fun release() {
+        ioScope.cancel()
         descriptorCache.clear()
         sheetCache.clear()
     }
@@ -106,24 +130,35 @@ class CompanionRepository(
      * runs on the main thread but loads happen on the IO scope.
      */
     private class SheetBitmapCache(private val maxEntries: Int) {
+        private val lock = Any()
         private val map = LinkedHashMap<String, Bitmap>(maxEntries, 0.75f, true)
 
-        @Synchronized
+        /** Non-blocking lookup — used from the Main draw thread. */
+        fun peek(url: String): Bitmap? = synchronized(lock) { map[url] }
+
         fun getOrLoad(url: String, loader: () -> Bitmap?): Bitmap? {
-            map[url]?.let { return it }
+            synchronized(lock) { map[url]?.let { return it } }
             val bmp = loader() ?: return null
-            map[url] = bmp
-            while (map.size > maxEntries) {
-                val evict = map.entries.iterator().next()
-                map.remove(evict.key)?.recycle()
+            synchronized(lock) {
+                map[url]?.let {
+                    // Another caller won the race; drop ours, return theirs.
+                    bmp.recycle()
+                    return it
+                }
+                map[url] = bmp
+                while (map.size > maxEntries) {
+                    val evict = map.entries.iterator().next()
+                    map.remove(evict.key)?.recycle()
+                }
             }
             return bmp
         }
 
-        @Synchronized
         fun clear() {
-            map.values.forEach { runCatching { it.recycle() } }
-            map.clear()
+            synchronized(lock) {
+                map.values.forEach { runCatching { it.recycle() } }
+                map.clear()
+            }
         }
     }
 }

--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -867,7 +867,7 @@
                     rentalBots = (data.listings || []).map(l => {
                         const caps = l.capabilities ? Object.keys(l.capabilities).filter(k => l.capabilities[k]?.supported) : [];
                         return {
-                            publicCode: l.id, name: l.title || 'Rental Bot', avatar: l.avatar_url || '🤖',
+                            publicCode: l.owner_public_code || null, name: l.title || 'Rental Bot', avatar: l.avatar_url || '🤖',
                             desc: l.description || (l.model_detected || ''),
                             tags: caps, caps: caps, _capsObj: l.capabilities || {},
                             stars: l.avg_rating || 0, reviews: l.total_rentals || 0,
@@ -976,6 +976,9 @@
                 </div>
             </div>
             ${statusBadge}
+            ${(!isRented && bot.publicCode) ? `<div class="bot-card-action">
+                <button class="bot-card-quick-chat" onclick="event.stopPropagation();window.open('/c/${bot.publicCode}?utm_source=plaza&utm_medium=rental_card','_blank')" title="${tt('mp_chat_cta','\u958b\u59cb\u5c0d\u8a71')}">${tt('mp_chat_cta','\u958b\u59cb\u5c0d\u8a71')} \u2192</button>
+            </div>` : ''}
         </div>`;
     }
 

--- a/backend/rental.js
+++ b/backend/rental.js
@@ -1848,7 +1848,12 @@ module.exports = function rentalFactory({ authMiddleware, adminMiddleware, walle
             // the listing was created (silent identity drift). Owner still sees
             // them in /my-rentals so they can re-publish or delist explicitly.
             const filtered = filterDriftedListings(listings, _interviewDeps?.devices);
-            res.json({ success: true, listings: filtered });
+            const devicesMap = _interviewDeps?.devices;
+            const enriched = filtered.map((l) => {
+                const ent = devicesMap?.[l.owner_device_id]?.entities?.[l.owner_entity_id];
+                return ent?.publicCode ? { ...l, owner_public_code: ent.publicCode } : l;
+            });
+            res.json({ success: true, listings: enriched });
         } catch (err) {
             console.error('[Rental] /marketplace error:', err);
             res.status(500).json({ success: false, error: 'internal_error' });

--- a/backend/tests/jest/rental-marketplace-public-code.test.js
+++ b/backend/tests/jest/rental-marketplace-public-code.test.js
@@ -1,0 +1,41 @@
+/**
+ * Regression: GET /api/rental/marketplace must include each listing's
+ * owner_public_code so the community.html grid can build a /c/:publicCode
+ * URL for the "開始對話" CTA. Pre-fix the response only had owner_device_id
+ * + owner_entity_id, and the UI fell through to listing.id (a UUID) which
+ * /c/:publicCode rejects.
+ */
+
+const fs = require('fs');
+
+const src = fs.readFileSync(require.resolve('../../rental.js'), 'utf8');
+
+function slice(anchor, span = 1500) {
+    const i = src.indexOf(anchor);
+    expect(i).toBeGreaterThan(-1);
+    return src.slice(i, i + span);
+}
+
+describe('rental marketplace owner_public_code enrichment', () => {
+    const route = slice("router.get('/marketplace'", 1500);
+
+    it('enriches each listing with owner_public_code from devices map', () => {
+        expect(route).toMatch(/const devicesMap = _interviewDeps\?\.devices;/);
+        expect(route).toMatch(/devicesMap\?\.\[l\.owner_device_id\]\?\.entities\?\.\[l\.owner_entity_id\]/);
+    });
+
+    it('only attaches owner_public_code when entity has one (no overwrite to null)', () => {
+        expect(route).toMatch(/ent\?\.publicCode \? \{ \.\.\.l, owner_public_code: ent\.publicCode \} : l/);
+    });
+
+    it('enrichment runs AFTER drift filter (so dropped listings stay dropped)', () => {
+        const filterPos = route.indexOf('filterDriftedListings(');
+        const enrichPos = route.indexOf('owner_public_code:');
+        expect(filterPos).toBeGreaterThan(-1);
+        expect(enrichPos).toBeGreaterThan(filterPos);
+    });
+
+    it('response body still uses res.json({ success, listings })', () => {
+        expect(route).toMatch(/res\.json\(\{ success: true, listings: enriched \}\)/);
+    });
+});


### PR DESCRIPTION
## Summary
- PR #2615 + #2577 already fixed the data path (botSecret exposure + per-entity companion poller), but the rendered wallpaper still showed 6 identical lobsters because `CompanionRepository.fetchBitmap` ran synchronous OkHttp on `Dispatchers.Main` (the wallpaper engine's coroutine scope).
- Every spritesheet load threw `NetworkOnMainThreadException`, the bitmap cache stayed empty, and the renderer fell back to the orange-lobster sprite for every entity.
- Fix off-loads bitmap fetches to a dedicated `Dispatchers.IO` scope. `getSheet()` is now Main-safe: cache hit returns instantly; cache miss launches an IO load and returns null this frame (next 33 ms draw tick picks it up). `SheetBitmapCache` lock split into peek/load phases so the Main thread never blocks on an in-flight HTTP request.

## Test plan
- [x] FileTimberTree log shows `Companion fetched for entity 1: petdex-gon-freecss` + entity 2 petdex-tomori-2, zero `NetworkOnMainThreadException`, zero `Spritesheet fetch HTTP` errors.
- [x] Visual E2E on Pixel 8 Pro emulator (API 35) — wallpaper renders Gon Freecss sprite for entity 1, Tomori sprite for entity 2, lobster fallback for entities without petdx selection (correct).
- [x] No ANR or jank when the draw loop racing with concurrent IO loads — peek-only lock path verified.
- [ ] Sanity-check on real device (deferred to internal-test build).

Evidence screenshot at: `claude-code-eclaw-channel/wallpaper-fix-verification.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)