### PR TITLE
feat(avatar): render selected petdx companion in chat avatars

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -2967,6 +2967,8 @@
     <script src="shared/api.js"></script>
     <script src="shared/nav.js"></script>
     <script src="shared/auth.js"></script>
+    <script src="../shared/petdx-renderer.js"></script>
+    <script src="../shared/avatar-petdx.js"></script>
     <script src="shared/entity-utils.js"></script>
     <script src="shared/mention-autocomplete.js"></script>
     <script src="shared/mention-resolver.js"></script>
@@ -3478,6 +3480,21 @@
                 if (boundEntities.length === 0) boundEntities = allEntities;
                 boundEntityIds = new Set(boundEntities.map(e => e.entityId));
                 updateEntityMaps(boundEntities);
+                // Preload petdx companion descriptors so subsequent renderAvatarHtml
+                // calls (chat bubbles, target bar, entity chips) can emit canvas
+                // placeholders instead of static <img>. Best-effort: failures fall
+                // back to icon_url silently. Auto-mount wires a MutationObserver
+                // that animates canvases as the chat list re-renders.
+                if (window.AvatarPetdx && currentUser.deviceSecret) {
+                    window.AvatarPetdx.preload({
+                        deviceId: currentUser.deviceId,
+                        deviceSecret: currentUser.deviceSecret,
+                        entityIds: boundEntities.map(e => e.entityId)
+                    }).then(() => {
+                        window.AvatarPetdx.autoMount();
+                        renderTargetBar();
+                    });
+                }
                 boundEntities.forEach(e => {
                     recordEntityRuntimeStatus({
                         entityId: e.entityId,
@@ -3561,7 +3578,7 @@
                 label.dataset.entityId = e.entityId;
                 const e2eeBadge = e.encryptionStatus === 'e2ee' ? ' 🔒' : '';
                 label.innerHTML = `<input type="checkbox" data-entity="${e.entityId}" ${isChecked ? 'checked' : ''} onchange="updateTargetAll()">
-                    <span class="target-label-main">${renderAvatarHtml(avatar, 20)} ${escapeHtml(name)} (#${e.entityId})${e2eeBadge}<span class="entity-status-slot">${renderEntityStatusBadge(e.entityId)}</span></span>`;
+                    <span class="target-label-main">${renderAvatarHtml(avatar, 20, e.entityId)} ${escapeHtml(name)} (#${e.entityId})${e2eeBadge}<span class="entity-status-slot">${renderEntityStatusBadge(e.entityId)}</span></span>`;
                 allItems.push({ el: label, type: 'entity' });
             });
 
@@ -3960,7 +3977,7 @@
                 const avatar = getAvatarForEntity(id);
                 const existing = group.querySelector(`[data-filter="entity-${id}"]`);
                 if (existing) {
-                    existing.innerHTML = `${renderAvatarHtml(avatar, 18)} ${getEntityDisplayName(id)} (#${id})`;
+                    existing.innerHTML = `${renderAvatarHtml(avatar, 18, id)} ${getEntityDisplayName(id)} (#${id})`;
                     return;
                 }
 
@@ -3968,7 +3985,7 @@
                 chip.className = `filter-chip filter-chip-entity${currentFilter === 'entity-' + id ? ' active' : ''}`;
                 chip.dataset.filter = `entity-${id}`;
                 chip.onclick = () => setFilter(`entity-${id}`);
-                chip.innerHTML = `${renderAvatarHtml(avatar, 18)} ${getEntityDisplayName(id)} (#${id})`;
+                chip.innerHTML = `${renderAvatarHtml(avatar, 18, id)} ${getEntityDisplayName(id)} (#${id})`;
                 group.insertBefore(chip, myChip);
             });
 

--- a/backend/public/portal/shared/entity-utils.js
+++ b/backend/public/portal/shared/entity-utils.js
@@ -60,11 +60,32 @@ function isAvatarUrl(avatar) {
 
 /**
  * Render an avatar as HTML. Returns an <img> tag for URLs, or emoji text for emoji avatars.
+ *
+ * If `entityId` is provided AND `window.AvatarPetdx` has a cached
+ * companion descriptor for that entity, emits a placeholder canvas
+ * instead so AvatarPetdx.mount() can animate it. Pages should call
+ * AvatarPetdx.preload(...) once on init, then AvatarPetdx.mount(root)
+ * after each batch of markup that contains these placeholders.
+ *
  * @param {string} avatar - emoji string or image URL
  * @param {number} [size=48] - size in px (for image avatars)
+ * @param {number} [entityId] - optional entityId to consider for petdx render
  */
-function renderAvatarHtml(avatar, size) {
+function renderAvatarHtml(avatar, size, entityId) {
     size = size || 48;
+    if (entityId != null
+        && typeof window !== 'undefined'
+        && window.AvatarPetdx
+        && window.AvatarPetdx.hasDescriptor(entityId)) {
+        // imageRendering keeps the spritesheet pixel-art crisp at small sizes;
+        // matches PetdxRenderer's ctx.imageSmoothingEnabled = false.
+        return '<canvas class="entity-avatar-canvas" '
+            + 'data-petdx-entity-id="' + Number(entityId) + '" '
+            + 'width="' + size + '" height="' + size + '" '
+            + 'style="width:' + size + 'px;height:' + size + 'px;'
+            + 'image-rendering:pixelated;border-radius:50%;vertical-align:middle;" '
+            + 'aria-label="entity avatar"></canvas>';
+    }
     if (isAvatarUrl(avatar)) {
         return '<img src="' + avatar + '" class="entity-avatar-img" ' +
             'style="width:' + size + 'px;height:' + size + 'px;" alt="avatar" loading="lazy">';
@@ -98,7 +119,7 @@ function getEntityLabel(entityId) {
     const escapeFn = typeof escapeHtml === 'function' ? escapeHtml
         : typeof esc === 'function' ? esc
         : (s) => s;
-    return `${renderAvatarHtml(avatar, 20)} ${escapeFn(name)} (#${entityId})`;
+    return `${renderAvatarHtml(avatar, 20, entityId)} ${escapeFn(name)} (#${entityId})`;
 }
 
 /**

--- a/backend/public/shared/avatar-petdx.js
+++ b/backend/public/shared/avatar-petdx.js
@@ -1,0 +1,169 @@
+/**
+ * Avatar Petdx mount helper — drops the user's selected companion into
+ * any entity avatar slot. The fallback path keeps the existing emoji /
+ * icon_url rendering when no companion is selected, so this is purely
+ * additive on top of `renderAvatarHtml` from entity-utils.js.
+ *
+ * Two-phase usage:
+ *
+ *   1. `AvatarPetdx.preload({ deviceId, deviceSecret | botSecret, entityIds })`
+ *      Fires one /api/companion/current per entityId, populates the
+ *      module-local cache, returns Promise<void>.
+ *
+ *   2. `AvatarPetdx.mount(rootEl)` walks `rootEl` (default: document)
+ *      for any `<canvas data-petdx-entity-id="N">` placeholders. Where a
+ *      cached descriptor exists, a PetdxRenderer controller is created
+ *      and started; placeholders without a descriptor are left as the
+ *      original element so the page's emoji/icon fallback shows.
+ *
+ * The `renderAvatarHtml(avatar, size, entityId)` extension in entity-utils.js
+ * emits the placeholder canvas when entityId has a cached companion.
+ *
+ * Memory: shares descriptor cache across all callers; the spritesheet
+ * image is also cached inside PetdxRenderer's internal loader so the
+ * same URL never decodes twice on a page.
+ */
+(function (root, factory) {
+    if (typeof module === 'object' && module.exports) {
+        module.exports = factory();
+    } else {
+        root.AvatarPetdx = factory();
+    }
+}(typeof self !== 'undefined' ? self : this, function () {
+    'use strict';
+
+    const descriptorByEntityId = new Map();       // entityId -> descriptor | null
+    const inflightByEntityId = new Map();         // entityId -> Promise
+    const controllersByCanvas = new WeakMap();    // canvas -> controller
+
+    function hasDescriptor(entityId) {
+        return descriptorByEntityId.has(Number(entityId))
+            && descriptorByEntityId.get(Number(entityId)) != null;
+    }
+
+    function getDescriptor(entityId) {
+        return descriptorByEntityId.get(Number(entityId)) || null;
+    }
+
+    async function fetchOne({ deviceId, deviceSecret, botSecret, entityId }) {
+        const eid = Number(entityId);
+        if (inflightByEntityId.has(eid)) return inflightByEntityId.get(eid);
+
+        const params = new URLSearchParams({ deviceId, entityId: String(eid) });
+        if (deviceSecret) params.set('deviceSecret', deviceSecret);
+        else if (botSecret) params.set('botSecret', botSecret);
+        const p = fetch('/api/companion/current?' + params.toString(), {
+            credentials: 'same-origin'
+        }).then(async (r) => {
+            if (!r.ok) {
+                descriptorByEntityId.set(eid, null);
+                return null;
+            }
+            const data = await r.json();
+            const companion = data && data.selection && data.selection.companion;
+            descriptorByEntityId.set(eid, companion || null);
+            return companion || null;
+        }).catch(() => {
+            descriptorByEntityId.set(eid, null);
+            return null;
+        }).finally(() => {
+            inflightByEntityId.delete(eid);
+        });
+        inflightByEntityId.set(eid, p);
+        return p;
+    }
+
+    /**
+     * Batch preload for an array of entityIds. Resolves once every fetch
+     * has settled (so a single misbehaving entry can't stall the rest).
+     */
+    function preload({ deviceId, deviceSecret, botSecret, entityIds }) {
+        if (!deviceId || (!deviceSecret && !botSecret)) {
+            return Promise.resolve();
+        }
+        const ids = Array.from(new Set((entityIds || []).map(Number).filter(Number.isFinite)));
+        if (ids.length === 0) return Promise.resolve();
+        return Promise.all(ids.map((entityId) =>
+            fetchOne({ deviceId, deviceSecret, botSecret, entityId })
+        )).then(() => {});
+    }
+
+    /**
+     * Walk root for placeholder canvases and animate them. Idempotent:
+     * canvases that already have a controller are skipped.
+     */
+    function mount(rootEl) {
+        if (typeof window === 'undefined' || !window.PetdxRenderer) return;
+        const scope = rootEl || document;
+        const nodes = scope.querySelectorAll
+            ? scope.querySelectorAll('canvas[data-petdx-entity-id]')
+            : [];
+        for (const canvas of nodes) {
+            if (controllersByCanvas.has(canvas)) continue;
+            const entityId = Number(canvas.getAttribute('data-petdx-entity-id'));
+            const descriptor = getDescriptor(entityId);
+            if (!descriptor) continue;
+            try {
+                const controller = window.PetdxRenderer.createRenderer({
+                    canvas,
+                    descriptor,
+                    state: canvas.getAttribute('data-petdx-state') || 'IDLE'
+                });
+                controller.start();
+                controllersByCanvas.set(canvas, controller);
+            } catch (err) {
+                if (window.console && window.console.warn) {
+                    window.console.warn('[AvatarPetdx] mount failed for entity', entityId, err.message);
+                }
+            }
+        }
+    }
+
+    /** Stop and detach the controller for a canvas (e.g. node being removed). */
+    function unmount(canvas) {
+        const c = controllersByCanvas.get(canvas);
+        if (c) {
+            try { c.stop(); } catch (_) { /* swallow */ }
+            controllersByCanvas.delete(canvas);
+        }
+    }
+
+    /** Test seam — lets unit tests inject a descriptor without hitting the API. */
+    function _setDescriptor(entityId, descriptor) {
+        descriptorByEntityId.set(Number(entityId), descriptor || null);
+    }
+
+    let observer = null;
+
+    /**
+     * Install a MutationObserver that auto-mounts new placeholder canvases
+     * as the page renders/replaces chat content. Safe to call multiple
+     * times — only one observer is ever attached.
+     */
+    function autoMount() {
+        if (observer || typeof window === 'undefined' || typeof MutationObserver === 'undefined') return;
+        // Initial sweep so existing canvases come up without waiting for a mutation.
+        mount(document);
+        observer = new MutationObserver((mutations) => {
+            let needsScan = false;
+            for (const m of mutations) {
+                if (m.addedNodes && m.addedNodes.length) {
+                    needsScan = true;
+                    break;
+                }
+            }
+            if (needsScan) mount(document);
+        });
+        observer.observe(document.body, { childList: true, subtree: true });
+    }
+
+    return {
+        preload,
+        mount,
+        autoMount,
+        unmount,
+        hasDescriptor,
+        getDescriptor,
+        _setDescriptor,
+    };
+}));

--- a/backend/public/shared/avatar-petdx.js
+++ b/backend/public/shared/avatar-petdx.js
@@ -147,9 +147,24 @@
         observer = new MutationObserver((mutations) => {
             let needsScan = false;
             for (const m of mutations) {
+                if (m.removedNodes && m.removedNodes.length) {
+                    // Stop any running controller whose canvas just left the
+                    // DOM — PetdxRenderer's rAF loop holds a strong ref to its
+                    // controller so without this the WeakMap can't reclaim it
+                    // and the rAF tick keeps firing on a detached canvas.
+                    for (const n of m.removedNodes) {
+                        if (!n || n.nodeType !== 1) continue;
+                        if (n.matches && n.matches('canvas[data-petdx-entity-id]')) {
+                            unmount(n);
+                        }
+                        if (n.querySelectorAll) {
+                            n.querySelectorAll('canvas[data-petdx-entity-id]')
+                                .forEach(unmount);
+                        }
+                    }
+                }
                 if (m.addedNodes && m.addedNodes.length) {
                     needsScan = true;
-                    break;
                 }
             }
             if (needsScan) mount(document);


### PR DESCRIPTION
## Summary
- Extends `renderAvatarHtml(avatar, size, entityId)` in `backend/public/portal/shared/entity-utils.js` to emit a `<canvas data-petdx-entity-id="N">` placeholder when a cached companion descriptor exists for the entity. Otherwise it falls back unchanged to `<img>` (icon_url) or emoji.
- New `backend/public/shared/avatar-petdx.js` — preload + auto-mount helper around `PetdxRenderer`. Public API: `preload({deviceId, deviceSecret|botSecret, entityIds})`, `mount(root)`, `autoMount()` (MutationObserver), `unmount(canvas)`, `hasDescriptor/getDescriptor`, `_setDescriptor` (test seam).
- Wires `chat.html`: after `updateEntityMaps(boundEntities)` it preloads `/api/companion/current` for every bound entity and starts the observer, so chat bubbles, the target bar, and filter chips all pick the canvas branch on first paint.

Card: `card_276bec81f1f5cf9c5391f1ff` (phase 1 — web/chat). Phase 2 will tie animation state to entity status (typing/idle/error).

## Visual
PoC compares `renderAvatarHtml` with and without an injected companion descriptor for entity 2 (Tomori spritesheet). Entity 5 has no companion → confirms the legacy emoji/icon path stays intact.

**Before** (no descriptor, legacy emoji path):
`/api/files/6cf15263-8e7a-4f0b-934d-89d19feed06a` — `avatar-petdx-before.png` — static 🦞 emoji at 20/24/32/48/64px.

**After** (descriptor injected, canvas branch active):
`/api/files/fc57c0cf-bdf3-4dd9-be2e-72335798e491` — `avatar-petdx-after.png` — Tomori spritesheet renders at every size; entity #5 stays on emoji fallback.

Screenshots attached to the kanban card as well (mimeType image/png, requiresScreenshotReview gate passed).

## Risk addressed
Card flagged: *"小尺寸 (32px) 下 spritesheet frame 細節糊掉 — 需先 PoC 一頁"*. PoC confirms Tomori reads clearly at 32px; even 20px chip is still recognizable thanks to `image-rendering: pixelated` + `imageSmoothingEnabled=false` (matches PetdxRenderer's existing behavior).

## Test plan
- [x] `node --check backend/public/shared/avatar-petdx.js` — syntax clean.
- [x] Local PoC page (since deleted) screenshotted at 20/24/32/48/64px via headless Chrome — before/after diff is unambiguous.
- [x] Entity without companion descriptor → emoji/icon fallback unchanged (verified via PoC entity 5).
- [ ] Railway preview: open `/portal/chat.html`, confirm Tomori avatar animates in the target bar + filter chips for entity 2.
- [ ] Verify MutationObserver wires up canvases that appear after initial paint (e.g. swap target entity, observe filter-chip canvas mounts).

## Out of scope (follow-up card)
- Phase 2: derive `data-petdx-state` from entity runtime status so the renderer plays BUSY/HAPPY/SLEEPING animations instead of always IDLE.
- Cardholder + mission portals: same `renderAvatarHtml` chokepoint, will land in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)