### PR TITLE
feat(avatar): petdx render on card-holder my-cards (Phase 1b)

### DIFF
--- a/backend/public/portal/card-holder.html
+++ b/backend/public/portal/card-holder.html
@@ -709,6 +709,8 @@
     <script src="shared/api.js"></script>
     <script src="shared/nav.js"></script>
     <script src="shared/auth.js"></script>
+    <script src="../shared/petdx-renderer.js"></script>
+    <script src="../shared/avatar-petdx.js"></script>
     <script src="shared/entity-utils.js"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script src="../shared/telemetry.js"></script>
@@ -768,6 +770,20 @@
         // ── Data loading ──
         async function loadAllData() {
             await Promise.all([loadMyCards(), loadRecent(), loadCollected(), loadFriendRequests()]);
+            // Preload petdx companion descriptors for my own cards so the
+            // avatar canvases mount on first paint. Other-bot cards don't
+            // have a local entityId, so they keep the legacy emoji/img path.
+            if (window.AvatarPetdx && currentUser && currentUser.deviceSecret) {
+                const myEntityIds = myCards.map(c => c.entityId).filter(Boolean);
+                if (myEntityIds.length) {
+                    await window.AvatarPetdx.preload({
+                        deviceId: currentUser.deviceId,
+                        deviceSecret: currentUser.deviceSecret,
+                        entityIds: myEntityIds
+                    });
+                    window.AvatarPetdx.autoMount();
+                }
+            }
             rebuildContent();
         }
 
@@ -903,7 +919,7 @@
             const ac = c.agentCard || {};
             let html = `<div class="card-item" onclick="showMyCardDetail('${escapeAttr(c.publicCode)}')">
                 <div class="card-row">
-                    <span class="agent-avatar">${renderAvatarHtml(avatar, 48)}</span>
+                    <span class="agent-avatar">${renderAvatarHtml(avatar, 48, c.entityId)}</span>
                     <div class="agent-meta">
                         <div class="agent-name">${escapeHtml(c.name || c.publicCode)}</div>
                         <span class="agent-code" onclick="event.stopPropagation(); copyCode('${escapeAttr(c.publicCode)}')" title="Click to copy">${escapeHtml(c.publicCode)}</span>
@@ -1072,7 +1088,7 @@
             const content = document.getElementById('detailContent');
             content.innerHTML = `
                 <div class="modal-header">
-                    <span class="agent-avatar">${renderAvatarHtml(avatar, 48)}</span>
+                    <span class="agent-avatar">${renderAvatarHtml(avatar, 48, card.entityId)}</span>
                     <div class="modal-header-info">
                         <h3>${escapeHtml(card.name || card.publicCode)}</h3>
                         <span class="agent-code" onclick="copyCode('${escapeAttr(card.publicCode)}')">${escapeHtml(card.publicCode)}</span>


### PR DESCRIPTION
## Summary
Phase 1b: extends the petdx avatar wiring from PR #2620 to `portal/card-holder.html` so the user's own cards animate the selected companion. Two in-scope `renderAvatarHtml` call sites (`renderMyCardHtml` list row + `showMyCardDetail` modal) thread `c.entityId` through; the other 5 call sites stay on emoji/img because they render cross-device contacts/strangers that have no local entityId.

Card: `card_dea23f7d39b2854b32094bf8` (1/N portal pages in the Phase 1b chain).

## Visual

**Before** — emoji / icon_url fallback (current production behavior):

https://eclawbot.com/api/files/e9130a3f-ace8-4d38-838e-8b505037b3a7

**After** — petdx Tomori canvas mounted in My Cards rows (via this PR's `renderAvatarHtml(avatar, 48, c.entityId)` thread-through + `AvatarPetdx.preload + autoMount`):

https://eclawbot.com/api/files/4a087e3c-59de-4676-8d4c-7e4b1b63375c

> PoC harness uses real `petdx-renderer.js` + `avatar-petdx.js` + `entity-utils.js` from this branch with the Tomori descriptor injected via the `_setDescriptor` test seam. The Railway preview env (pr-2621) is intentionally not pre-provisioned in this repo, so the proof-of-render is captured against the actual frontend files instead of a deploy. Post-merge production capture will be filed on the kanban card as the live verification step.

## Test plan
- [x] BEFORE/AFTER captured against the actual modified `entity-utils.js` + `avatar-petdx.js` (no mocks of the render path itself; descriptor injected via the public `_setDescriptor` test seam).
- [x] BEFORE: `?before` query skips `_setDescriptor` → `renderAvatarHtml` falls back to emoji (or `<img>` for URL avatars) exactly like the current production card-holder.
- [x] AFTER: same harness without the toggle → `renderAvatarHtml` emits the `<canvas data-petdx-entity-id>` placeholder; `AvatarPetdx.autoMount()` instantiates `PetdxRenderer` and starts the rAF loop; Tomori sprite frame shows pixelated, perfectly circle-masked at 48px.
- [x] Out-of-scope sites (friend-request, recent, collected, search-external, openDetail) unmodified — emoji/img fallback unchanged.
- [x] `preload()` dedupes per-entityId, so a user with 10 cards never fans out to 10 `/api/companion/current` calls.
- [ ] Post-merge: re-capture prod card-holder, confirm entity #2 avatar slot animates Tomori; other entities (without a selected companion) stay on emoji.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
