### PR TITLE
feat(avatar): petdx render on dashboard entity grid / org chart / bindings (Phase 1b)

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -1927,6 +1927,8 @@
     <script src="shared/nav.js"></script>
     <script src="shared/auth.js"></script>
     <script src="shared/entity-utils.js"></script>
+    <script src="../shared/petdx-renderer.js"></script>
+    <script src="../shared/avatar-petdx.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
     <script src="/socket.io/socket.io.js"></script>
@@ -2302,6 +2304,18 @@
                 entities = newEntities;
                 updateEntityMaps(entities);
 
+                if (window.AvatarPetdx && currentUser && currentUser.deviceSecret) {
+                    const entityIds = entities.map(e => e.entityId).filter(Boolean);
+                    if (entityIds.length) {
+                        await window.AvatarPetdx.preload({
+                            deviceId: currentUser.deviceId,
+                            deviceSecret: currentUser.deviceSecret,
+                            entityIds
+                        });
+                        window.AvatarPetdx.autoMount();
+                    }
+                }
+
                 // Update slot info from server
                 const serverTotal = data.totalSlots || data.maxEntitiesPerDevice || 4;
                 const serverEntityIds = data.entityIds || [];
@@ -2449,7 +2463,7 @@
                 return '<div class="entity-card card" data-entity-id="' + entity.entityId + '"' + (isEditMode ? ' draggable="true"' : '') + '>' +
                     '<div class="entity-card-body">' +
                     '<div class="drag-handle" title="' + i18n.t('dash_drag_to_reorder') + '">&#9776;</div>' +
-                    '<div class="entity-avatar" onclick="openAvatarPicker(' + entity.entityId + ')">' + renderAvatarHtml(avatar) + '</div>' +
+                    '<div class="entity-avatar" onclick="openAvatarPicker(' + entity.entityId + ')">' + renderAvatarHtml(avatar, 48, entity.entityId) + '</div>' +
                     '<div class="entity-info">' +
                     '<div class="entity-name" onclick="openRenamePicker(' + entity.entityId + ', \'' + escapedName + '\')" title="' + i18n.t('dash_rename_title') + '">' + escapeHtml(displayName) + '</div>' +
                     '<div class="entity-badges">' +
@@ -3550,7 +3564,7 @@
 
                 const avatar = getAvatarForEntity(entityId);
                 const name = getEntityDisplayName(entityId);
-                node.innerHTML = '<div class="org-avatar">' + renderAvatarHtml(avatar, 36) + '</div>' +
+                node.innerHTML = '<div class="org-avatar">' + renderAvatarHtml(avatar, 36, entityId) + '</div>' +
                     '<div class="org-name" title="' + name + '">' + name + '</div>';
 
                 // Drag events
@@ -4342,7 +4356,7 @@
 
                 return '<div class="binding-item">' +
                     '<div class="binding-info">' +
-                    '<span class="binding-emoji">' + renderAvatarHtml(avatar, 32) + '</span>' +
+                    '<span class="binding-emoji">' + renderAvatarHtml(avatar, 32, b.entityId) + '</span>' +
                     '<div class="binding-details">' +
                     '<span class="binding-entity-name">Entity ' + b.entityId + '</span>' +
                     '<span class="binding-type"><span class="badge ' + typeBadgeClass + '">' + typeText + '</span></span>' +


### PR DESCRIPTION
## Summary
Phase 1b page 2/5: extends the petdx avatar wiring from PR #2620 (chat) + PR #2621 (card-holder) to `portal/dashboard.html`. Three in-scope `renderAvatarHtml` call sites thread `entityId` through:

- `renderEntities()` — entity-card grid avatar (48px)
- `buildEntityNode()` — org-chart node avatar (36px)
- `renderBindingsList()` — free-bot bindings row avatar (32px)

All three render the device owner's own bound entities, so they all have a local `entityId` that `AvatarPetdx` can resolve via the existing `/api/companion/current` route.

`loadEntities()` now `await`s `AvatarPetdx.preload()` once per poll *before* `renderEntities()` fires, so canvas placeholders are emitted on the first paint rather than after a descriptor flip. `preload()` dedupes per-entityId via the in-flight cache shared with PR #2621, so the dashboard polling cadence does not fan out new `/api/companion/current` calls.

Card: `card_dea23f7d39b2854b32094bf8` (Phase 1b mother — page 2 of 5).

## Visual

**Before** — emoji / icon_url fallback across all three sites:

https://eclawbot.com/api/files/b7b7d80c-08d4-44a5-bca0-73e9d9dde360

**After** — petdx Tomori canvas mounted at 48px / 36px / 32px:

https://eclawbot.com/api/files/0016af30-9783-4b9b-9656-5076d24aa062

> PoC harness uses the real `petdx-renderer.js` + `avatar-petdx.js` + `entity-utils.js` from this branch with the Tomori descriptor injected via the `_setDescriptor` test seam. Tomori is captured mid-idle-loop; the rAF loop continues per `MutationObserver` from `b3ddb8de` so adding/removing rows doesn't leak controllers.

## Test plan
- [x] BEFORE/AFTER captured against the actual modified `dashboard.html` (3 inline scripts parsed clean via `vm.Script`).
- [x] All 3 sizes (48 / 36 / 32) render legible Tomori sprite — pixel-art crispness preserved by `image-rendering: pixelated`.
- [x] `await preload()` placed *before* `renderEntities()` so first paint has canvas placeholders, not img/emoji.
- [x] Polling cadence safe: shared in-flight cache means repeat preload calls are no-ops after the first.
- [x] Out-of-scope sites: cross-device entity lookups in this page (none — dashboard is owner-only) unchanged.
- [ ] Post-merge: live prod re-capture on the kanban mother card once Railway redeploy lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
