### PR TITLE
feat(avatar): petdx render on mission skill/rule/soul entity dialogs (Phase 1b)

### DIFF
--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -939,6 +939,8 @@
     <script src="shared/nav.js"></script>
     <script src="shared/auth.js"></script>
     <script src="shared/entity-utils.js"></script>
+    <script src="../shared/petdx-renderer.js"></script>
+    <script src="../shared/avatar-petdx.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
     <script src="shared/mission-mindmap.js" defer></script>
@@ -1128,6 +1130,18 @@
                 const data = await apiCall('GET', `/api/entities?deviceId=${currentUser.deviceId}`);
                 boundEntities = (data.entities || []).filter(e => e.isBound);
                 updateEntityMaps(boundEntities);
+
+                if (window.AvatarPetdx && currentUser && currentUser.deviceSecret) {
+                    const entityIds = boundEntities.map(e => e.entityId).filter(Boolean);
+                    if (entityIds.length) {
+                        await window.AvatarPetdx.preload({
+                            deviceId: currentUser.deviceId,
+                            deviceSecret: currentUser.deviceSecret,
+                            entityIds
+                        });
+                        window.AvatarPetdx.autoMount();
+                    }
+                }
             } catch (e) {
                 console.warn('Failed to load entities:', e.message);
             }
@@ -1138,7 +1152,7 @@
             boundEntities.forEach(e => {
                 const avatar = getAvatarForEntity(e.entityId);
                 const name = getEntityDisplayName(e.entityId);
-                opts.push({ value: String(e.entityId), label: `${renderAvatarHtml(avatar, 18)} ${name} (#${e.entityId})` });
+                opts.push({ value: String(e.entityId), label: `${renderAvatarHtml(avatar, 18, e.entityId)} ${name} (#${e.entityId})` });
             });
             return opts;
         }
@@ -3056,7 +3070,7 @@
                 const checked = isEdit && (skill.assignedEntities || []).includes(String(e.entityId)) ? 'checked' : '';
                 return `<label>
                     <input type="checkbox" class="skill-entity-cb" value="${e.entityId}" ${checked}>
-                    ${renderAvatarHtml(avatar, 18)} ${esc(name)} (#${e.entityId})
+                    ${renderAvatarHtml(avatar, 18, e.entityId)} ${esc(name)} (#${e.entityId})
                 </label>`;
             }).join('');
 
@@ -3187,7 +3201,7 @@
                 const checked = isEdit && (rule.assignedEntities || []).includes(String(e.entityId)) ? 'checked' : '';
                 return `<label>
                     <input type="checkbox" class="rule-entity-cb" value="${e.entityId}" ${checked}>
-                    ${renderAvatarHtml(avatar, 18)} ${esc(name)} (#${e.entityId})
+                    ${renderAvatarHtml(avatar, 18, e.entityId)} ${esc(name)} (#${e.entityId})
                 </label>`;
             }).join('');
 
@@ -3384,7 +3398,7 @@
                 const checked = isEdit && (soul.assignedEntities || []).includes(String(e.entityId)) ? 'checked' : '';
                 return `<label>
                     <input type="checkbox" class="soul-entity-cb" value="${e.entityId}" ${checked}>
-                    ${renderAvatarHtml(avatar, 18)} ${esc(name)} (#${e.entityId})
+                    ${renderAvatarHtml(avatar, 18, e.entityId)} ${esc(name)} (#${e.entityId})
                 </label>`;
             }).join('');
 


### PR DESCRIPTION
## Summary
Phase 1b page 3/N: extends the petdx avatar wiring from PR #2620 / #2621 / #2622 to `portal/mission.html` so the assign-entity checkboxes in the skill / rule / soul dialogs (and the generic `getEntityOptions` helper) render the user's selected companion at the 18px chip size used inside `<label>` rows.

Mother card: `card_dea23f7d39b2854b32094bf8`.

## Changes
- Added `petdx-renderer.js` + `avatar-petdx.js` script imports.
- `loadBoundEntities()` now awaits `AvatarPetdx.preload({ deviceId, deviceSecret, entityIds })` then calls `autoMount()` before the dialogs render, so the first paint already contains canvas placeholders rather than emoji that swap a tick later.
- 4 call sites updated to `renderAvatarHtml(avatar, 18, e.entityId)`:
  - `getEntityOptions` (option list helper)
  - `openSkillDialog` checkbox `<label>` (line 3059)
  - `openRuleDialog` checkbox `<label>` (line 3190)
  - `openSoulDialog` checkbox `<label>` (line 3387)

`image-rendering: pixelated` on the inline canvas plus `imageSmoothingEnabled = false` in the renderer keeps the sprite crisp at the 18px chip size.

## Visual

**Before** — emoji avatar in the assign-entity dialogs:

https://eclawbot.com/api/files/0526409d-9d1f-487e-b698-c0eb763c1ed2

**After** — petdx Tomori canvas mounted inside the 18px chip across all three dialogs (skill / rule / soul):

https://eclawbot.com/api/files/4a736df3-4ee8-47bd-b5da-d144cdc6d446

> PoC harness loads real `petdx-renderer.js` + `avatar-petdx.js` + `entity-utils.js` from this branch with the Tomori descriptor injected via the `_setDescriptor` test seam (same pattern as PR #2621). Railway preview env `pr-N` is intentionally not pre-provisioned in this repo, so the proof-of-render is captured against the actual frontend files instead of a deploy.

## Test plan
- [x] BEFORE/AFTER captured against the actual modified `mission.html` + `entity-utils.js` + `avatar-petdx.js`
- [x] All three dialog surfaces verified (skill / rule / soul)
- [x] Pixelated rendering preserved at 18px chip size
- [ ] Post-merge live verification on production mission page

🤖 Generated with [Claude Code](https://claude.com/claude-code)