### PR TITLE
feat(avatar): petdx render on kanban auto-assign / pulse / comment avatars (Phase 1b)

### DIFF
--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -946,6 +946,8 @@
     <script src="shared/api.js"></script>
     <script src="shared/nav.js"></script>
     <script src="shared/auth.js"></script>
+    <script src="../shared/petdx-renderer.js"></script>
+    <script src="../shared/avatar-petdx.js"></script>
     <script src="shared/entity-utils.js"></script>
     <script src="shared/entity-link-render.js"></script>
     <script src="shared/note-link-render.js"></script>
@@ -1066,6 +1068,17 @@
                 if (data.entities) {
                     boundEntities = data.entities;
                     if (typeof updateEntityMaps === 'function') updateEntityMaps(boundEntities);
+                    if (window.AvatarPetdx && currentUser && currentUser.deviceSecret) {
+                        const entityIds = boundEntities.map(e => e.entityId).filter(Boolean);
+                        if (entityIds.length) {
+                            await window.AvatarPetdx.preload({
+                                deviceId: currentUser.deviceId,
+                                deviceSecret: currentUser.deviceSecret,
+                                entityIds
+                            });
+                            window.AvatarPetdx.autoMount();
+                        }
+                    }
                 }
             } catch(e) {}
             populateFunnelEntities();
@@ -1890,7 +1903,7 @@
                     boundEntities.filter(e => e.isBound).map(e => {
                         const checked = currentBots.includes(e.entityId) ? ' checked' : '';
                         const label = getEntityDisplayName(e.entityId);
-                        const avatarEl = typeof renderAvatarHtml === 'function' ? renderAvatarHtml(e.avatar, 16) : (e.avatar || '🦞');
+                        const avatarEl = typeof renderAvatarHtml === 'function' ? renderAvatarHtml(e.avatar, 16, e.entityId) : (e.avatar || '🦞');
                         return `<label class="kb-assign-chip${checked ? ' active' : ''}" title="${escapeHtml(label)}">` +
                             `<input type="checkbox" value="${e.entityId}"${checked} onchange="updateAutoAssign('${cardId}')">` +
                             avatarEl + `<span>${escapeHtml(label)}</span></label>`;
@@ -2201,7 +2214,7 @@
             const assignChips = boundEntities.filter(e => e.isBound).map(e => {
                 const checked = currentBots.includes(e.entityId) ? ' checked' : '';
                 const label = getEntityDisplayName(e.entityId);
-                const avatarEl = typeof renderAvatarHtml === 'function' ? renderAvatarHtml(e.avatar, 16) : (e.avatar || '🦞');
+                const avatarEl = typeof renderAvatarHtml === 'function' ? renderAvatarHtml(e.avatar, 16, e.entityId) : (e.avatar || '🦞');
                 return `<label class="kb-assign-chip${checked ? ' active' : ''}" title="${escapeHtml(label)}">` +
                     `<input type="checkbox" value="${e.entityId}"${checked} onchange="spUpdateAssign(this)">` +
                     avatarEl + `<span>${escapeHtml(label)}</span></label>`;
@@ -2376,7 +2389,7 @@
                     const isSent = fromId != null && myEntityIds.has(fromId);
                     const avatar = typeof getAvatarForEntity === 'function' ? getAvatarForEntity(fromId) : '🦞';
                     const name = typeof getEntityDisplayName === 'function' ? getEntityDisplayName(fromId) : '#'+(fromId??'?');
-                    const avatarHtml = typeof renderAvatarHtml === 'function' ? renderAvatarHtml(avatar, 16) : avatar;
+                    const avatarHtml = typeof renderAvatarHtml === 'function' ? renderAvatarHtml(avatar, 16, fromId) : avatar;
                     const cardTitle = (findCard(openCardId) || {}).title || '';
                     const pinPayload = JSON.stringify({ src: '留言 · ' + cardTitle, sender: name, text: c.text || '' })
                         .replace(/'/g, '&#39;');


### PR DESCRIPTION
## Summary
Phase 1b page 4/N: extends the petdx avatar wiring from PR #2620 / #2621 / #2622 / #2623 to `portal/kanban.html` so the three 16px avatar surfaces (auto-assign chip, schedule-pulse assignee chip, card comment header) render the user's selected companion sprite instead of the static emoji.

Mother card: `card_dea23f7d39b2854b32094bf8`.

## Changes
- Added `petdx-renderer.js` + `avatar-petdx.js` script imports.
- Inside the entity-load `try` block, after `boundEntities = data.entities`, added `await AvatarPetdx.preload({ deviceId, deviceSecret, entityIds })` + `autoMount()` so the first board render already has canvas placeholders rather than emoji that swap a tick later.
- 3 call sites updated to pass entityId as the 3rd arg of `renderAvatarHtml(avatar, 16, entityId)`:
  - `kb-auto-assign-chips` map (line ~1903) — uses `e.entityId`
  - schedule-pulse `assignChips` map (line ~2214) — uses `e.entityId`
  - card comment header (line ~2389) — uses `fromId`

The 16px canvas keeps `image-rendering: pixelated` + `imageSmoothingEnabled = false` upstream so the Tomori sprite stays crisp.

## Visual

**Before** — emoji 🦞 / 🐷 / 💼 / 🧝 in chips + comment headers:

https://eclawbot.com/api/files/a4bf8eaa-e3bb-4e49-96dc-466dedb1e20e

**After** — petdx Tomori canvas mounted in all three 16px surfaces:

https://eclawbot.com/api/files/995e387f-c8b8-4461-a8a7-6ae5de620561

> PoC harness loads real `petdx-renderer.js` + `avatar-petdx.js` + `entity-utils.js` from this branch with the Tomori descriptor injected via the `_setDescriptor` test seam (same pattern as PR #2621/#2622/#2623). Railway preview env `pr-N` is intentionally not pre-provisioned in this repo, so the proof-of-render is captured against the actual frontend files instead of a deploy.

## Test plan
- [x] BEFORE/AFTER captured against the actual modified `kanban.html` + `entity-utils.js` + `avatar-petdx.js`
- [x] All three 16px surfaces verified (auto-assign / pulse / comment)
- [x] Pixelated rendering preserved at 16px chip size
- [ ] Post-merge live verification on production kanban page

🤖 Generated with [Claude Code](https://claude.com/claude-code)