### PR TITLE
fix(wallpaper): stop Android live wallpaper flashing default lobster on companion change

### DIFF
--- a/app/src/main/java/com/hank/clawlive/data/repository/CompanionRepository.kt
+++ b/app/src/main/java/com/hank/clawlive/data/repository/CompanionRepository.kt
@@ -24,10 +24,16 @@ import java.util.concurrent.ConcurrentHashMap
  * Fetches the per-entity current companion (Petdx) and decodes spritesheet
  * bitmaps for the renderer. Two caches:
  *
- *  - `descriptorCache`: per-entity CompanionDetail, refreshed on poll.
- *  - `sheetCache`: LRU bitmap cache keyed by spritesheet URL, capped at 3
- *    entries (per spec §4.6 memory budget) so the wallpaper service stays
- *    well under 80 MB even with multiple bound bots.
+ *  - `descriptorCache`: per-entity CompanionDetail, refreshed on poll. Only
+ *    written AFTER the matching spritesheet (if any) has been preloaded into
+ *    `sheetCache` — atomic swap so the wallpaper draw loop never observes
+ *    "new descriptor, sheet still decoding" (the trigger for the default-
+ *    lobster flash fixed in card_9e52c7b405d0fdd3aad0d2e3).
+ *  - `sheetCache`: LRU bitmap cache keyed by spritesheet URL. Sized at 8 so
+ *    devices with 5–7 bound entities don't churn each other's sheets on
+ *    every poll round (the old cap of 3 caused continuous re-eviction →
+ *    recurring flicker even outside companion-change moments). 8 sheets ×
+ *    ~1 MB each still well under the spec §4.6 80 MB memory budget.
  */
 class CompanionRepository(
     private val api: ClawApiService,
@@ -35,7 +41,7 @@ class CompanionRepository(
 ) {
     private val deviceManager = DeviceManager.getInstance(context)
     private val descriptorCache = ConcurrentHashMap<Int, CompanionDetail>()
-    private val sheetCache = SheetBitmapCache(maxEntries = 3)
+    private val sheetCache = SheetBitmapCache(maxEntries = 8)
     private val ioScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
 
     /** Returns the cached companion for an entity, or null until a fetch lands. */
@@ -76,17 +82,30 @@ class CompanionRepository(
                 )
                 val companion = resp.selection?.companion
                 if (companion != null) {
-                    descriptorCache[entityId] = companion
-                    Timber.d("Companion fetched for entity $entityId: ${companion.id} (${companion.assetType})")
-                    // Pre-warm spritesheet decode so first paint is smooth.
-                    // The flow itself runs on the engine's Main scope, so the
-                    // OkHttp call has to be marshalled to IO.
-                    if (companion.assetType == "spritesheet") {
-                        withContext(Dispatchers.IO) {
-                            sheetCache.getOrLoad(companion.spritesheetUrl() ?: "") {
-                                companion.spritesheetUrl()?.let { fetchBitmap(it) }
+                    // Preload the spritesheet BEFORE swapping the descriptor.
+                    // The wallpaper draw loop reads `cached(entityId)` and
+                    // `getSheet(url)` independently; if we publish the new
+                    // descriptor first, the loop will see "new companion + no
+                    // sheet" for the ~1 s window the OkHttp+decode takes —
+                    // and the old renderer fell back to procedural lobster
+                    // for that whole window, producing the visible flicker.
+                    val sheetReady = if (companion.assetType == "spritesheet") {
+                        val sheetUrl = companion.spritesheetUrl()
+                        if (sheetUrl.isNullOrBlank()) {
+                            true // descriptor is malformed; let renderer's UNSUPPORTED path handle it
+                        } else {
+                            withContext(Dispatchers.IO) {
+                                sheetCache.getOrLoad(sheetUrl) { fetchBitmap(sheetUrl) } != null
                             }
                         }
+                    } else {
+                        true // non-spritesheet (procedural) — no preload needed
+                    }
+                    if (sheetReady) {
+                        descriptorCache[entityId] = companion
+                        Timber.d("Companion fetched for entity $entityId: ${companion.id} (${companion.assetType})")
+                    } else {
+                        Timber.w("Spritesheet preload failed for entity $entityId (${companion.spritesheetUrl()}); keeping previous companion to avoid default-lobster flicker")
                     }
                 }
                 emit(companion)

--- a/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
@@ -482,18 +482,26 @@ class ClawRenderer(
         val radius = 150f * scale
 
         // Petdx companion routing — if the entity has a current companion and
-        // it's a spritesheet asset, render that; procedural assets (and missing
-        // descriptors) fall through to the legacy lobster drawer with optional
-        // body-color override pulled from the descriptor.
+        // it's a spritesheet asset, render that. Procedural assets and missing
+        // descriptors go to the legacy lobster drawer with optional body-color
+        // override. LOADING (sheet decode in flight) deliberately paints
+        // nothing this frame: falling back to procedural lobster here is what
+        // produced the "switch companion → flash to default lobster" bug
+        // (card_9e52c7b405d0fdd3aad0d2e3). A blank gap for one 33 ms tick is
+        // invisible; a wrong-character flash is not.
         val companion = companionRepository?.cached(entity.entityId)
-        val drewSpritesheet = if (companion != null && companion.assetType == "spritesheet") {
+        val drawResult = if (companion != null && companion.assetType == "spritesheet") {
             spritesheetDrawer?.draw(
                 canvas, companion, entity.entityId, entity.state.toString(), centerX, charY, scale
-            ) ?: false
-        } else false
+            ) ?: SpritesheetCompanionDrawer.DrawResult.UNSUPPORTED
+        } else SpritesheetCompanionDrawer.DrawResult.UNSUPPORTED
 
-        if (!drewSpritesheet) {
-            drawLobsterAtPosition(canvas, centerX, charY, entity, scale, companion)
+        when (drawResult) {
+            SpritesheetCompanionDrawer.DrawResult.DRAWN,
+            SpritesheetCompanionDrawer.DrawResult.LOADING -> Unit
+            SpritesheetCompanionDrawer.DrawResult.UNSUPPORTED,
+            SpritesheetCompanionDrawer.DrawResult.ERROR ->
+                drawLobsterAtPosition(canvas, centerX, charY, entity, scale, companion)
         }
 
         // Draw message bubble (ABOVE the entity)

--- a/app/src/main/java/com/hank/clawlive/engine/SpritesheetCompanionDrawer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/SpritesheetCompanionDrawer.kt
@@ -23,6 +23,16 @@ import timber.log.Timber
 class SpritesheetCompanionDrawer(
     private val repository: CompanionRepository
 ) {
+    /**
+     * Distinct outcomes for one draw call. The renderer uses these to decide
+     * whether to fall back to the procedural lobster — only UNSUPPORTED and
+     * ERROR do; LOADING means "sheet is being fetched on the IO scope, just
+     * skip this paint and the next 33 ms tick will pick it up". Mixing
+     * LOADING with the lobster fallback is what produced the post-companion-
+     * change flicker reported on 2026-05-12.
+     */
+    enum class DrawResult { DRAWN, LOADING, UNSUPPORTED, ERROR }
+
     private val paint = Paint().apply {
         isFilterBitmap = true
         isAntiAlias = true
@@ -32,9 +42,8 @@ class SpritesheetCompanionDrawer(
     private val stateStartByEntity = mutableMapOf<Int, Pair<String, Long>>()
 
     /**
-     * Returns true if this entity has a usable spritesheet companion and
-     * something was drawn. Returning false lets the renderer fall back to
-     * the procedural lobster drawer.
+     * Renders one spritesheet frame for the entity. Return value tells the
+     * renderer how to handle the outcome — see [DrawResult].
      */
     fun draw(
         canvas: Canvas,
@@ -44,14 +53,19 @@ class SpritesheetCompanionDrawer(
         centerX: Float,
         centerY: Float,
         scale: Float
-    ): Boolean {
-        val sheet = repository.getSheet(companion.spritesheetUrl()) ?: return false
+    ): DrawResult {
+        val sheetUrl = companion.spritesheetUrl()
+        if (sheetUrl.isNullOrBlank()) return DrawResult.UNSUPPORTED
+        // Cache miss on the main thread schedules an async load and returns
+        // null this frame. That's LOADING, not failure — falling back to
+        // lobster here is the flicker bug.
+        val sheet = repository.getSheet(sheetUrl) ?: return DrawResult.LOADING
         val (frameW, frameH) = companion.spritesheetFrameSize()
-        if (frameW <= 0 || frameH <= 0) return false
+        if (frameW <= 0 || frameH <= 0) return DrawResult.UNSUPPORTED
 
         val supported = companion.supportedStates
         val effectiveState = if (currentState in supported) currentState else "IDLE"
-        val hint = companion.stateAsset(effectiveState) ?: return false
+        val hint = companion.stateAsset(effectiveState) ?: return DrawResult.UNSUPPORTED
 
         // Row defaults to position in supportedStates if descriptor doesn't pin one.
         val row = if (hint.row > 0) hint.row else supported.indexOf(effectiveState).coerceAtLeast(0)
@@ -74,7 +88,7 @@ class SpritesheetCompanionDrawer(
 
         if (srcX + frameW > sheet.width || srcY + frameH > sheet.height) {
             Timber.w("Spritesheet OOB: sheet=${sheet.width}x${sheet.height} src=($srcX,$srcY)+$frameW x $frameH")
-            return false
+            return DrawResult.ERROR
         }
 
         // Render at 300×300 px base scaled by `scale` (matches procedural lobster footprint).
@@ -87,7 +101,7 @@ class SpritesheetCompanionDrawer(
             centerY + renderSize / 2f
         )
         canvas.drawBitmap(sheet, src, dst, paint)
-        return true
+        return DrawResult.DRAWN
     }
 }
 


### PR DESCRIPTION
## Summary
- Card: `card_9e52c7b405d0fdd3aad0d2e3` (P1, screenshot review)
- Bug: After changing 桌布實體外觀 in the Android live wallpaper, the avatar briefly reverts to the default orange lobster before the new sprite appears. Three layers compound to produce the flash:
  - `SpritesheetCompanionDrawer.draw()` returned `Boolean` — `false` meant both "no spritesheet" (correct fallback) and "sheet still loading" (wrong fallback). Replaced with `DrawResult { DRAWN, LOADING, UNSUPPORTED, ERROR }` so `ClawRenderer` only falls back on UNSUPPORTED/ERROR.
  - `CompanionRepository.getCompanionFlow()` wrote the new descriptor into `descriptorCache` BEFORE preloading the sheet, opening a ~1 s window where the draw loop saw "new descriptor + missing sheet" → lobster fallback every frame. Now: preload sheet → only then publish descriptor. If preload fails, keep the previous companion (stale-but-correct beats flash-to-default).
  - `SheetBitmapCache(maxEntries = 3)` was too small for the 5–7 bound entities Hank runs — sheets evicted each other on every poll round, producing the same fallback even outside companion-change moments. Bumped to 8 (~8 MB, well under the §4.6 80 MB budget).

PR #2625 / #2628 targeted the WebView avatar path and didn't fix the reported symptom (it's the Android wallpaper service, not WebView). Card `card_fbfa0ec94d6d481e0e0e73f4` left in done with a redirect comment pointing here.

Diagnosis credit: Mac_F (#1) — he called the Android code path before I had ruled out my WebView hypothesis. I confirmed against `origin/main 3abf62d5` + re-read of the user video (orange-blob frames mid-flicker visible at 1 fps strip).

## Test plan
- [ ] Gradle `:app:compileDebugKotlin` ✅ (clean — verified locally)
- [ ] Install APK on emulator (Pixel 6 API 34 or similar); bind 5+ entities; set live wallpaper
- [ ] Switch companion A → B on entity #2 via portal → wallpaper should transition cleanly, no orange-lobster flash
- [ ] Sit on home screen with 5+ entities × spritesheet companions for 60 s → no recurring flicker
- [ ] Force-stop network mid-companion-change → wallpaper keeps old companion (no lobster fallback)
- [ ] U01 (Android E2E specialist) to drive the full sequence and capture before/after MP4 — APK build owned by Hank per workflow

## Follow-ups (NOT this PR)
- `WallpaperPreviewView.kt:443-453` only renders procedural creatures / lobster — spritesheet preview falls through to the same legacy path. Cosmetic, separate card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)