### PR TITLE
fix(chat): render mention autocomplete avatars with companion renderer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -442,6 +442,7 @@ EClaw/
    | Info Pricing Advisor slide claims unavailable GPT-5 tier and unsourced computed scores | `GET /api/debug/info-pricing-slide?deviceId=X&deviceSecret=Y` | 2026-05-04 | Active |
    | Info Integration slide lists unsupported integrations and fake platform/SLA stats | `GET /api/debug/info-integration-slide?deviceId=X&deviceSecret=Y` | 2026-05-05 | Active |
    | Info Guide mobile renders too many sidebar sections/cards/slides as one long vertical wall | `GET /api/debug/info-guide-mobile-layout?deviceId=X&deviceSecret=Y` | 2026-05-05 | Active |
+   | Chat @mention autocomplete dropdown uses legacy avatar instead of Petdx companion appearance | `GET /api/debug/mention-autocomplete-avatar?deviceId=X&deviceSecret=Y` | 2026-05-12 | Active |
 
 6. **Demand Elegance (Balanced)** — 在保持 minimal change 的前提下，追求可讀、一致的程式風格；不為了「漂亮」而過度重構，但也不容忍明顯的 code smell 在新增的程式碼中出現。
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -2424,6 +2424,112 @@ app.get('/api/debug/chat-render-load-order', async (req, res) => {
     }
 });
 
+// Temporary diagnostic endpoint for the 2026-05-12 mention autocomplete avatar
+// bug: chat @mention suggestions must use the shared avatar renderer so local
+// entities with selected Petdx companions show the same partner-system look as
+// the target bar/chat chips. Keep auth strict and content-safe: no secrets, no
+// chat text, no raw companion descriptors.
+app.get('/api/debug/mention-autocomplete-avatar', async (req, res) => {
+    const { deviceId, deviceSecret } = req.query || {};
+    const timestamp = new Date().toISOString();
+    try {
+        if (!deviceId || !deviceSecret) {
+            return res.status(401).json({ success: false, bug: 'mention-autocomplete-avatar', error: 'deviceId and deviceSecret required', timestamp });
+        }
+
+        const memDevice = devices[deviceId];
+        const pool = db._getPool ? db._getPool() : authModule.pool;
+        const dbDevice = pool
+            ? await pool.query('SELECT device_secret FROM devices WHERE device_id = $1', [deviceId])
+            : { rows: [] };
+        const dbDeviceRow = dbDevice.rows[0] || null;
+        const memSecretOk = !!(memDevice && memDevice.deviceSecret && safeEqual(memDevice.deviceSecret, deviceSecret));
+        const dbSecretOk = !!(dbDeviceRow && dbDeviceRow.device_secret && safeEqual(dbDeviceRow.device_secret, deviceSecret));
+        if (!memSecretOk && !dbSecretOk) {
+            return res.status(403).json({ success: false, bug: 'mention-autocomplete-avatar', error: 'Invalid credentials', timestamp });
+        }
+
+        const autocompletePath = path.join(__dirname, 'public', 'portal', 'shared', 'mention-autocomplete.js');
+        const entityUtilsPath = path.join(__dirname, 'public', 'portal', 'shared', 'entity-utils.js');
+        const chatHtmlPath = path.join(__dirname, 'public', 'portal', 'chat.html');
+        const autocompleteJs = fs.readFileSync(autocompletePath, 'utf8');
+        const entityUtilsJs = fs.readFileSync(entityUtilsPath, 'utf8');
+        const chatHtml = fs.readFileSync(chatHtmlPath, 'utf8');
+
+        const entityRows = pool ? await pool.query(
+            `SELECT e.entity_id,
+                    e.is_bound,
+                    e.public_code IS NOT NULL AS has_public_code,
+                    e.avatar IS NOT NULL AS has_avatar,
+                    latest.companion_id AS selected_companion_id
+               FROM entities e
+          LEFT JOIN LATERAL (
+                    SELECT companion_id
+                      FROM companion_select_log s
+                     WHERE s.device_id = e.device_id
+                       AND s.entity_id = e.entity_id
+                  ORDER BY s.selected_at DESC
+                     LIMIT 1
+               ) latest ON true
+              WHERE e.device_id = $1
+           ORDER BY e.entity_id ASC`,
+            [deviceId]
+        ).catch((err) => ({ rows: [], _error: err.message })) : { rows: [] };
+
+        const entities = entityRows.rows || [];
+        res.json({
+            success: true,
+            bug: 'mention-autocomplete-avatar',
+            diagnostics: {
+                server: {
+                    build: SERVER_BUILD_TAG,
+                    startedAt: SERVER_STARTED_AT.toISOString(),
+                    uptimeSec: Math.round(process.uptime()),
+                },
+                auth: {
+                    memSecretOk,
+                    dbSecretOk,
+                    requestUserDeviceId: req.user?.deviceId || null,
+                    requestUserId: req.user?.userId || null,
+                },
+                staticWiring: {
+                    chatLoadsEntityUtilsBeforeMentionAutocomplete:
+                        chatHtml.indexOf('shared/entity-utils.js') >= 0
+                        && chatHtml.indexOf('shared/mention-autocomplete.js') >= 0
+                        && chatHtml.indexOf('shared/entity-utils.js') < chatHtml.indexOf('shared/mention-autocomplete.js'),
+                    entityUtilsHasPetdxRenderPath:
+                        entityUtilsJs.includes('window.AvatarPetdx')
+                        && entityUtilsJs.includes('data-petdx-entity-id'),
+                    autocompleteUsesSharedAvatarRenderer:
+                        autocompleteJs.includes('renderMentionAvatar')
+                        && autocompleteJs.includes('global.renderAvatarHtml')
+                        && autocompleteJs.includes('global.AvatarPetdx.mount(dropdown)'),
+                    autocompleteLegacyInlineOnlyRendererPresent:
+                        /const\s+avatar\s*=\s*it\.avatar\s*&&\s*\/\^https/.test(autocompleteJs),
+                },
+                entitySummary: {
+                    total: entities.length,
+                    bound: entities.filter(e => e.is_bound).length,
+                    mentionEligible: entities.filter(e => e.has_public_code).length,
+                    withAvatar: entities.filter(e => e.has_avatar).length,
+                    withSelectedCompanion: entities.filter(e => e.selected_companion_id).length,
+                    queryError: entityRows._error || null,
+                },
+                expectedClientFlow: {
+                    preloadCompanionsBeforeMentionUse: true,
+                    localMentionEntriesCarryEntityId: true,
+                    suggestionAvatarShouldCallRenderAvatarHtml: true,
+                    avatarPetdxMountCalledAfterDropdownRender: true,
+                },
+            },
+            timestamp,
+        });
+    } catch (err) {
+        console.error('[Debug mention-autocomplete-avatar] failed:', err);
+        res.status(500).json({ success: false, bug: 'mention-autocomplete-avatar', error: err.message, timestamp });
+    }
+});
+
 // Temporary diagnostic endpoint for public Info-page regressions:
 // - roadmap.html must not redirect unauthenticated visitors to index.html
 // - release notes must render Markdown links instead of raw `(https://...)`

--- a/backend/public/portal/shared/mention-autocomplete.js
+++ b/backend/public/portal/shared/mention-autocomplete.js
@@ -51,6 +51,30 @@
         return div.innerHTML;
     }
 
+    function renderMentionAvatar(entry) {
+        if (entry.isAll) {
+            return '<span class="mention-avatar">📢</span>';
+        }
+
+        const avatar = entry.avatar || '🤖';
+        const entityId = entry.entityId != null ? entry.entityId : undefined;
+
+        // Keep @mention suggestions visually aligned with the rest of Chat.
+        // The shared renderer emits AvatarPetdx canvas placeholders for local
+        // entities that have a selected companion, and falls back to image/emoji
+        // avatars for older pages or cross-device contacts.
+        if (typeof global.renderAvatarHtml === 'function') {
+            return '<span class="mention-avatar mention-avatar-shared">'
+                + global.renderAvatarHtml(avatar, 20, entityId)
+                + '</span>';
+        }
+
+        if (avatar && /^https?:/.test(avatar)) {
+            return `<img class="mention-avatar mention-avatar-img" src="${escapeHtml(avatar)}" alt="">`;
+        }
+        return `<span class="mention-avatar">${escapeHtml(avatar)}</span>`;
+    }
+
     /**
      * Attach autocomplete to a textarea.
      * @param {HTMLTextAreaElement} textarea
@@ -107,14 +131,12 @@
             const html = state.items.map((it, idx) => {
                 if (it.isAll) {
                     return `<div class="mention-item mention-all ${idx === state.activeIndex ? 'active' : ''}" data-idx="${idx}" role="option">
-                        <span class="mention-avatar">📢</span>
+                        ${renderMentionAvatar(it)}
                         <span class="mention-name">${escapeHtml(i18n.allLabel || 'Broadcast to all')}</span>
                         <span class="mention-badge mention-warn">${escapeHtml(i18n.allWarning || '@all')}</span>
                     </div>`;
                 }
-                const avatar = it.avatar && /^https?:/.test(it.avatar)
-                    ? `<img class="mention-avatar mention-avatar-img" src="${escapeHtml(it.avatar)}" alt="">`
-                    : `<span class="mention-avatar">${escapeHtml(it.avatar || '🤖')}</span>`;
+                const avatar = renderMentionAvatar(it);
                 const crossBadge = it.isCrossDevice ? '<span class="mention-badge">🔗</span>' : '';
                 return `<div class="mention-item ${idx === state.activeIndex ? 'active' : ''}" data-idx="${idx}" role="option">
                     ${avatar}
@@ -124,6 +146,9 @@
                 </div>`;
             }).join('');
             dropdown.innerHTML = html;
+            if (global.AvatarPetdx && typeof global.AvatarPetdx.mount === 'function') {
+                global.AvatarPetdx.mount(dropdown);
+            }
             // Wire click handlers
             dropdown.querySelectorAll('.mention-item').forEach(el => {
                 el.addEventListener('mousedown', (e) => {

--- a/backend/tests/jest/mention-ux-static.test.js
+++ b/backend/tests/jest/mention-ux-static.test.js
@@ -17,6 +17,7 @@ const chatHtml = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'chat.html'
 const i18nJs = fs.readFileSync(path.join(ROOT, 'public', 'shared', 'i18n.js'), 'utf8');
 const indexJs = fs.readFileSync(path.join(ROOT, 'index.js'), 'utf8');
 const sharedRenderJs = fs.readFileSync(path.join(ROOT, 'public', 'shared', 'chat-message-render.js'), 'utf8');
+const mentionAutocompleteJs = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'shared', 'mention-autocomplete.js'), 'utf8');
 
 describe('Mention feature — static wiring', () => {
     test('mention-autocomplete.js and mention-render.js are present in portal/shared', () => {
@@ -75,6 +76,26 @@ describe('Mention feature — static wiring', () => {
         expect(sendMsgBody).not.toMatch(/targets\.local\s*=\s*\(boundEntities\s*\|\|\s*\[\]\)\.map/);
         // Auto-add path: mention resolver result must be merged into targets via push()
         expect(sendMsgBody).toMatch(/targets\.local\.push\(/);
+    });
+
+    test('mention autocomplete uses shared avatar renderer for Petdx partner avatars', () => {
+        // Regression: the @mention dropdown hand-rendered an old emoji/img
+        // avatar, so entities with selected companions did not match the
+        // partner-system look used elsewhere in Chat.
+        expect(mentionAutocompleteJs).toContain('function renderMentionAvatar');
+        expect(mentionAutocompleteJs).toContain('global.renderAvatarHtml(avatar, 20, entityId)');
+        expect(mentionAutocompleteJs).toContain('global.AvatarPetdx.mount(dropdown)');
+        expect(mentionAutocompleteJs).not.toMatch(/const\s+avatar\s*=\s*it\.avatar\s*&&\s*\/\^https/);
+
+        const attachIdx = chatHtml.indexOf('MentionAutocomplete.attach');
+        const attachSnippet = chatHtml.slice(attachIdx, attachIdx + 1600);
+        expect(attachSnippet).toContain('entityId: e.entityId');
+    });
+
+    test('mention autocomplete avatar debug endpoint is registered', () => {
+        expect(indexJs).toContain("/api/debug/mention-autocomplete-avatar");
+        expect(indexJs).toContain("bug: 'mention-autocomplete-avatar'");
+        expect(indexJs).toContain('autocompleteUsesSharedAvatarRenderer');
     });
 });
 


### PR DESCRIPTION
## Summary
- Route chat @mention autocomplete suggestion avatars through the shared `renderAvatarHtml` helper so local entities with selected Petdx companions render with the partner-system canvas appearance.
- Mount `AvatarPetdx` after dropdown render so newly inserted suggestion canvases animate immediately.
- Add authenticated debug diagnostics at `GET /api/debug/mention-autocomplete-avatar` and register it in `AGENTS.md`.
- Extend mention UX static regression coverage.

## Verification
- `cd backend && npx jest tests/jest/mention-ux-static.test.js --runInBand`
- `cd backend && node --check index.js`
- `cd backend && node --check public/portal/shared/mention-autocomplete.js`
- `git diff --check`

Note: Jest prints an existing config warning about `runInBand`, but the suite passes.
