### PR TITLE
fix(notifications): add kanban_done + kanban_done_auto toggles to Android Settings

### DIFF
--- a/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
@@ -1038,6 +1038,8 @@ class SettingsActivity : AppCompatActivity() {
         NotifPrefCategory("speak_to", R.string.notif_pref_speak_to),
         NotifPrefCategory("feedback_resolved", R.string.notif_pref_feedback),
         NotifPrefCategory("todo_done", R.string.notif_pref_todo),
+        NotifPrefCategory("kanban_done", R.string.notif_pref_kanban_done),
+        NotifPrefCategory("kanban_done_auto", R.string.notif_pref_kanban_done_auto),
         NotifPrefCategory("scheduled", R.string.notif_pref_scheduled)
     )
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -483,7 +483,7 @@
     <string name="notif_pref_broadcast">廣播訊息</string>
     <string name="notif_pref_feedback">使用者回饋</string>
     <string name="notif_pref_kanban_done">看板任務完成</string>
-    <string name="notif_pref_kanban_done_auto">看板自動任務完成</string>
+    <string name="notif_pref_kanban_done_auto">看板自動化任務完成</string>
     <string name="notif_pref_scheduled">定時任務</string>
     <string name="notif_pref_speak_to">私聊訊息</string>
     <string name="notif_pref_title">通知設定</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -482,6 +482,8 @@
     <string name="notif_pref_bot_reply">機器人回覆</string>
     <string name="notif_pref_broadcast">廣播訊息</string>
     <string name="notif_pref_feedback">使用者回饋</string>
+    <string name="notif_pref_kanban_done">看板任務完成</string>
+    <string name="notif_pref_kanban_done_auto">看板自動任務完成</string>
     <string name="notif_pref_scheduled">定時任務</string>
     <string name="notif_pref_speak_to">私聊訊息</string>
     <string name="notif_pref_title">通知設定</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -673,8 +673,8 @@ If you have any questions, please contact us via our official email.
     <string name="notif_pref_speak_to">Entity Messages</string>
     <string name="notif_pref_feedback">Feedback Updates</string>
     <string name="notif_pref_todo">TODO Completed</string>
-    <string name="notif_pref_kanban_done">Kanban Card Done</string>
-    <string name="notif_pref_kanban_done_auto">Kanban Auto Card Done</string>
+    <string name="notif_pref_kanban_done">Kanban Card Completed</string>
+    <string name="notif_pref_kanban_done_auto">Kanban Automation Completed</string>
     <string name="notif_pref_scheduled">Scheduled Messages</string>
     <string name="notif_prefs_loading">Loading preferences…</string>
     <string name="notif_prefs_error">Failed to load notification preferences</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -673,6 +673,8 @@ If you have any questions, please contact us via our official email.
     <string name="notif_pref_speak_to">Entity Messages</string>
     <string name="notif_pref_feedback">Feedback Updates</string>
     <string name="notif_pref_todo">TODO Completed</string>
+    <string name="notif_pref_kanban_done">Kanban Card Done</string>
+    <string name="notif_pref_kanban_done_auto">Kanban Auto Card Done</string>
     <string name="notif_pref_scheduled">Scheduled Messages</string>
     <string name="notif_prefs_loading">Loading preferences…</string>
     <string name="notif_prefs_error">Failed to load notification preferences</string>


### PR DESCRIPTION
## Summary
- Android `SettingsActivity.notifCategories` was missing `kanban_done` + `kanban_done_auto`
- Backend (`notifications.js` DEFAULT_PREFS) and Web Portal (`settings.html`) already render these toggles
- Users on Android couldn't disable kanban task-complete notifications

## Bug context
Hank flagged via channel: 看板任務完成的通知設定在 App 找不到 UIUX，使用者沒辦法 disable.

Card: `card_9459223bf5d8114cab803a64` (P1 UX)

## Changes
- `SettingsActivity.kt`: added 2 entries to `notifCategories` list
- `values/strings.xml`: EN strings — "Kanban Card Completed" / "Kanban Automation Completed"
- `values-zh-rTW/strings.xml`: 繁中 — 「看板任務完成」/「看板自動化任務完成」
- Remaining 12 locales (zh-CN, ja, ko, vi, th, in, es, ms, hi, fr, de, ar) → i18n delegation to Hermes

## E2E verification
Built debug APK locally, installed on emulator-5554 (Pixel_9a, Android 35, debug `fix/kanban-notif-toggle-android`):

1. **Settings → Notifications** renders new toggles between TODO Completed and Scheduled Messages, default ON ✅
2. **Tap toggle** flips Kanban Card Completed ON (purple) → OFF (gray); uses existing `updateNotifPref()` → `PUT /api/notification-preferences` ✅
3. **Persistence (Mac_F review)**: After `am force-stop` + cold relaunch, `loadNotificationPreferences()` re-fetches from backend; Kanban Card Completed renders correctly OFF ✅

Backend FCM suppression already covered by existing `kanban-done-push-categories.test.js`.

Screenshots attached to kanban card `card_9459223bf5d8114cab803a64`:
- `notif_full_e2e.png` — all 8 toggles rendering
- `toggle_off_initial.png` — toggle visually flips after tap
- `persistence_cold_relaunch.png` — toggle still OFF after app relaunch

## Mac_F review (2026-05-12 24:33 TPE)
1. ~~RELEASE_HISTORY duplicate `## Recent`~~ — pre-existing in the file (4 of them); not introduced by this PR. Tracked as separate cleanup PR.
2. ✅ UX wording renamed per review
3. ✅ Persistence E2E added; backend test reference noted

## Test plan
- [x] Compile: `./gradlew :app:assembleDebug` — BUILD SUCCESSFUL
- [x] E2E: new toggles render, interactive, persist across cold relaunch
- [ ] Hermes follow-up PR for 12 remaining locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)