### PR TITLE
docs(info.html): add 2 missing auto-wake env vars (POLL_S, MAX_WAIT_S)

### DIFF
--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -4188,6 +4188,8 @@ tmux send-keys -t eclaw-bridge 'cd /path/to/claude-code-eclaw-channel && \
                                     <tr><td><code>ECLAW_REPLY_TIMEOUT_S</code></td><td></td><td><code>120</code></td><td data-i18n="guide_cc_channel_envvars_row_reply_timeout">Claude 收訊後未呼叫 reply tool 的提醒秒數</td></tr>
                                     <tr><td><code>ECLAW_AUTO_WAKE_ENABLED</code></td><td></td><td><code>true</code></td><td data-i18n="guide_cc_channel_envvars_row_auto_wake_enabled">idle session 自動喚醒（<code>/clear</code> 後或新 session 必備）</td></tr>
                                     <tr><td><code>ECLAW_AUTO_WAKE_DELAY_S</code></td><td></td><td><code>10</code></td><td data-i18n="guide_cc_channel_envvars_row_auto_wake_delay">轉發後多少秒檢查 idle 並喚醒</td></tr>
+                                    <tr><td><code>ECLAW_AUTO_WAKE_POLL_S</code></td><td></td><td><code>5</code></td><td data-i18n="guide_cc_channel_envvars_row_auto_wake_poll">Claude 仍 busy 時的重新檢查間隔（秒）</td></tr>
+                                    <tr><td><code>ECLAW_AUTO_WAKE_MAX_WAIT_S</code></td><td></td><td><code>300</code></td><td data-i18n="guide_cc_channel_envvars_row_auto_wake_max_wait">總共最多等多久才放棄喚醒（秒）</td></tr>
                                     <tr><td><code>ECLAW_AUTO_WAKE_COOLDOWN_S</code></td><td></td><td><code>60</code></td><td data-i18n="guide_cc_channel_envvars_row_auto_wake_cooldown">連續喚醒的冷卻時間</td></tr>
                                 </tbody>
                             </table>

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -74647,6 +74647,8 @@ const TRANSLATIONS = {
 
 
         "guide_cc_channel_envvars_row_auto_wake_delay": "Seconds after forwarding to check for idle and wake",
+        "guide_cc_channel_envvars_row_auto_wake_poll": "Re-check interval (seconds) while Claude is still busy",
+        "guide_cc_channel_envvars_row_auto_wake_max_wait": "Max total wait before giving up on auto-wake (seconds)",
 
 
 
@@ -720954,6 +720956,8 @@ const TRANSLATIONS = {
 
 
         "guide_cc_channel_envvars_row_auto_wake_delay": "轉發後多少秒檢查 idle 並喚醒",
+        "guide_cc_channel_envvars_row_auto_wake_poll": "Claude 仍 busy 時的重新檢查間隔（秒）",
+        "guide_cc_channel_envvars_row_auto_wake_max_wait": "總共最多等多久才放棄喚醒（秒）",
 
 
 
@@ -1392850,6 +1392854,8 @@ const TRANSLATIONS = {
 
 
         "guide_cc_channel_envvars_row_auto_wake_delay": "轉发后多少秒檢查 idle 並喚醒",
+        "guide_cc_channel_envvars_row_auto_wake_poll": "Claude 仍 busy 时的重新检查间隔（秒）",
+        "guide_cc_channel_envvars_row_auto_wake_max_wait": "总共最多等多久才放弃唤醒（秒）",
 
 
 


### PR DESCRIPTION
## Summary
- Add 2 user-tunable env vars to the Claude Code channel guide's env-var table in `info.html`: `ECLAW_AUTO_WAKE_POLL_S` (default `5`) and `ECLAW_AUTO_WAKE_MAX_WAIT_S` (default `300`).
- Seed both new `data-i18n` keys in `shared/i18n.js` for EN + zh-TW + zh-CN (same 3 locales as the rest of the auto-wake row; other 11 locales fall back to EN per i18n.apply chain).

## Why
`bridge.ts:101-102` reads both vars from `process.env`; both surface in `/health` response (`bridge.ts:683-684`) and are user-tunable per `README.md:171-172` of `claude-code-eclaw-channel`. The env-var table previously listed 9 vars and omitted these 2 — fresh users tuning auto-wake polling had no docs.

## Test plan
- [ ] Open Portal → Info Page → Channel Plugins → Claude Code Channel guide → env-var table should now show 11 rows including `ECLAW_AUTO_WAKE_POLL_S` (5) + `ECLAW_AUTO_WAKE_MAX_WAIT_S` (300)
- [ ] Switch locale to zh-TW + zh-CN, verify descriptions translate correctly
- [ ] Switch locale to ja/ko/etc → descriptions fall back to EN (expected, per existing pattern)
- [ ] `node -e "require(...)"` parse passes for `shared/i18n.js` (verified locally — TypeError on localStorage is browser-only, unrelated)

Card: `card_ab36a9fe8cae107c500dd2a4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)