### PR TITLE
fix(mention-parser): ignore @-mentions inside markdown code spans

### DIFF
--- a/backend/mention-parser.js
+++ b/backend/mention-parser.js
@@ -62,6 +62,17 @@ const ALL_TOKEN_RE = /(^|\s)@all(?=\s|$|[^\w])/i;
 // Global form for stripping @all (sequential .replace() needs the /g flag).
 const ALL_TOKEN_GLOBAL_RE = /(^|\s)@all(?=\s|$|[^\w])/gi;
 
+// Markdown code spans — examples / docs inside backticks must NOT route.
+// Replace each code-span region with same-length whitespace so character
+// indices stay aligned (in case any caller relies on them later) but no
+// @-token inside survives the regex passes. Fenced blocks first so the
+// inline single-backtick pass doesn't gobble triple-backtick fences.
+function maskCodeSpansForRouting(text) {
+    return text
+        .replace(/```[\s\S]*?```/g, (m) => ' '.repeat(m.length))
+        .replace(/`[^`\n]+`/g, (m) => ' '.repeat(m.length));
+}
+
 /**
  * Parse mention tokens from raw text and resolve them against the in-memory
  * device map / publicCodeIndex.
@@ -100,8 +111,14 @@ function parseMentions(text, ctx) {
     const devices = (ctx && ctx.devices) || {};
     const publicCodeIndex = (ctx && ctx.publicCodeIndex) || {};
 
+    // Mask code spans so example tokens in backticks don't route. Routing
+    // detection runs against `routedText`; displayText/cleanText continue
+    // to operate on the original `text` (display untouched, cleanText
+    // still strips token characters for Gatekeeper).
+    const routedText = maskCodeSpansForRouting(text);
+
     // @all literal
-    if (ALL_TOKEN_RE.test(text)) result.hasAll = true;
+    if (ALL_TOKEN_RE.test(routedText)) result.hasAll = true;
 
     const seenPublicCodes = new Set();
 
@@ -162,12 +179,12 @@ function parseMentions(text, ctx) {
     };
 
     PUBLIC_CODE_TOKEN_RE.lastIndex = 0;
-    while ((m = PUBLIC_CODE_TOKEN_RE.exec(text)) !== null) {
+    while ((m = PUBLIC_CODE_TOKEN_RE.exec(routedText)) !== null) {
         resolvePublicCodeToken(m[1]);
     }
 
     PUBLIC_CODE_BARE_RE.lastIndex = 0;
-    while ((m = PUBLIC_CODE_BARE_RE.exec(text)) !== null) {
+    while ((m = PUBLIC_CODE_BARE_RE.exec(routedText)) !== null) {
         resolvePublicCodeToken(m[1]);
     }
 
@@ -175,40 +192,72 @@ function parseMentions(text, ctx) {
     //    add new entityIds since resolveEntityId dedupes by publicCode).
     for (const re of [ENTITY_ID_BRACKET_RE, ENTITY_ID_HASH_RE, ENTITY_ID_BARE_RE]) {
         re.lastIndex = 0;
-        while ((m = re.exec(text)) !== null) {
+        while ((m = re.exec(routedText)) !== null) {
             resolveEntityId(parseInt(m[1], 10));
         }
     }
 
-    // 3. displayText: replace each recognised token form with @name.
-    //    Order matches resolution order so a `<@123456>` (resolved as
-    //    publicCode) is replaced before the bracketed-digit pass sees it.
-    const replaceWithName = (regex, lookup) => {
-        result.displayText = result.displayText.replace(regex, (match, captured) => {
-            const hit = lookup(captured);
-            return hit ? `@${hit.name}` : match;
-        });
-    };
-    replaceWithName(PUBLIC_CODE_TOKEN_RE, (code) =>
-        result.mentions.find(x => x.publicCode === code));
-    replaceWithName(PUBLIC_CODE_BARE_RE, (code) =>
-        result.mentions.find(x => x.publicCode === code));
+    // 3+4. Build displayText and cleanText by scanning routedText (code spans
+    //      masked) and splicing replacements into the ORIGINAL text. This way
+    //      backtick-wrapped tokens are preserved as-is in both outputs:
+    //      display keeps the literal backticks visible, and Gatekeeper sees
+    //      the full code-span content (only tokens outside backticks vanish).
     const findByEntityId = (id) => {
         const eid = parseInt(id, 10);
         return result.mentions.find(x => !x.isCrossDevice && x.entityId === eid);
     };
-    replaceWithName(ENTITY_ID_BRACKET_RE, findByEntityId);
-    replaceWithName(ENTITY_ID_HASH_RE, findByEntityId);
-    replaceWithName(ENTITY_ID_BARE_RE, findByEntityId);
+    const findByPublicCode = (code) =>
+        result.mentions.find(x => x.publicCode === code);
 
-    // 4. cleanText: strip every token form + @all; collapse whitespace.
-    //    PUBLIC_CODE_TOKEN_RE first (eats `<@xxxxxx>` whole), then bare form.
-    result.cleanText = text
-        .replace(PUBLIC_CODE_TOKEN_RE, '')
-        .replace(PUBLIC_CODE_BARE_RE, '')
-        .replace(ENTITY_ID_BRACKET_RE, '')
-        .replace(ENTITY_ID_HASH_RE, '')
-        .replace(ENTITY_ID_BARE_RE, '')
+    // Order matches resolution order: PUBLIC_CODE_TOKEN_RE first claims
+    // <@xxxxxx> ranges so ENTITY_ID_BRACKET_RE can't reinterpret <@123456>.
+    const passes = [
+        { re: PUBLIC_CODE_TOKEN_RE, lookup: findByPublicCode },
+        { re: PUBLIC_CODE_BARE_RE,  lookup: findByPublicCode },
+        { re: ENTITY_ID_BRACKET_RE, lookup: findByEntityId },
+        { re: ENTITY_ID_HASH_RE,    lookup: findByEntityId },
+        { re: ENTITY_ID_BARE_RE,    lookup: findByEntityId },
+    ];
+    const spans = [];
+    for (const { re, lookup } of passes) {
+        re.lastIndex = 0;
+        let mm;
+        while ((mm = re.exec(routedText)) !== null) {
+            spans.push({
+                start: mm.index,
+                end: mm.index + mm[0].length,
+                hit: lookup(mm[1]),
+                literal: mm[0],
+            });
+        }
+    }
+    // Sort by start; first occurrence at a position wins (later passes drop).
+    spans.sort((a, b) => a.start - b.start);
+    const filteredSpans = [];
+    let lastEnd = -1;
+    for (const s of spans) {
+        if (s.start < lastEnd) continue; // overlapping later match — skip
+        filteredSpans.push(s);
+        lastEnd = s.end;
+    }
+
+    const sliceWith = (replacer) => {
+        let out = '';
+        let cursor = 0;
+        for (const s of filteredSpans) {
+            out += text.substring(cursor, s.start);
+            out += replacer(s);
+            cursor = s.end;
+        }
+        out += text.substring(cursor);
+        return out;
+    };
+    result.displayText = sliceWith((s) => s.hit ? `@${s.hit.name}` : s.literal);
+
+    // cleanText: strip recognised tokens (outside code spans) + @all,
+    // collapse whitespace. Tokens inside code spans are left intact so
+    // Gatekeeper still sees the full code-span content.
+    result.cleanText = sliceWith(() => '')
         .replace(ALL_TOKEN_GLOBAL_RE, '$1')
         .replace(/\s+/g, ' ')
         .trim();

--- a/backend/tests/jest/mention-parser.test.js
+++ b/backend/tests/jest/mention-parser.test.js
@@ -218,6 +218,151 @@ describe('mention-parser.parseMentions', () => {
         expect(r.mentions[0].publicCode).toBe('q0ue2k');
         expect(r.mentions[0].entityId).toBe(6);
     });
+
+    // ── Markdown code-span guard (2026-05-12 fan-out incident) ──
+    // Inline-code examples in docs ( `@code ...` ) and fenced blocks must not
+    // route. Caused #2→#1 reply to also fan out to #5 because the body
+    // contained example tokens. Regression: prove docs don't cause routes,
+    // real leading @-mentions still do.
+    describe('markdown code spans (fan-out guard)', () => {
+        test('inline-code @publicCode is NOT routed', () => {
+            const ctx = makeCtx();
+            const r = mp.parseMentions('Example token form: `@aaaaaa ...`', ctx);
+            expect(r.mentions).toEqual([]);
+            expect(r.unresolved).toEqual([]);
+            expect(r.hasAll).toBe(false);
+        });
+
+        test('inline-code @#N is NOT routed', () => {
+            const ctx = makeCtx();
+            const r = mp.parseMentions('Use `@#1` for same-device entity tag', ctx);
+            expect(r.mentions).toEqual([]);
+        });
+
+        test('inline-code @all is NOT broadcast', () => {
+            const ctx = makeCtx();
+            const r = mp.parseMentions('Broadcast keyword is `@all` (case-insensitive)', ctx);
+            expect(r.hasAll).toBe(false);
+        });
+
+        test('inline-code <@xxxxxx> is NOT routed', () => {
+            const ctx = makeCtx();
+            const r = mp.parseMentions('Canonical form is `<@aaaaaa>` from UI', ctx);
+            expect(r.mentions).toEqual([]);
+        });
+
+        test('mixed: real leading @code routes, in-code example does NOT', () => {
+            const ctx = makeCtx();
+            const r = mp.parseMentions('@bbbbbb see example `@aaaaaa ...` below', ctx);
+            expect(r.mentions).toHaveLength(1);
+            expect(r.mentions[0].publicCode).toBe('bbbbbb');
+            // Production repro: prior to this fix, both bbbbbb AND aaaaaa
+            // would resolve, causing the @aaaaaa example to fan out.
+            expect(r.mentions.find(m => m.publicCode === 'aaaaaa')).toBeUndefined();
+        });
+
+        test('fenced code block tokens are NOT routed', () => {
+            const ctx = makeCtx();
+            const r = mp.parseMentions(
+                'See routing examples:\n```\n@aaaaaa hi\n@#1 same device\n@all broadcast\n```\nDone.',
+                ctx
+            );
+            expect(r.mentions).toEqual([]);
+            expect(r.hasAll).toBe(false);
+        });
+
+        test('fenced code block does not swallow tokens outside the fence', () => {
+            const ctx = makeCtx();
+            const r = mp.parseMentions(
+                'Heads up @bbbbbb:\n```\n@aaaaaa example\n```\nplease review.',
+                ctx
+            );
+            expect(r.mentions).toHaveLength(1);
+            expect(r.mentions[0].publicCode).toBe('bbbbbb');
+        });
+
+        test('multiple inline-code spans on one line — none route, real one still does', () => {
+            const ctx = makeCtx();
+            const r = mp.parseMentions(
+                '@bbbbbb forms: `@aaaaaa`, `@#1`, `@all` — pick one',
+                ctx
+            );
+            expect(r.mentions).toHaveLength(1);
+            expect(r.mentions[0].publicCode).toBe('bbbbbb');
+            expect(r.hasAll).toBe(false);
+        });
+
+        test('displayText leaves in-code tokens untouched (docs render as-written)', () => {
+            const ctx = makeCtx();
+            const r = mp.parseMentions('Example: `@aaaaaa hi`', ctx);
+            // No resolution → replaceWithName skips unresolved → original text
+            // around backticks preserved.
+            expect(r.displayText).toBe('Example: `@aaaaaa hi`');
+        });
+
+        test('cleanText preserves code-span content (Gatekeeper sees example tokens)', () => {
+            // Mac_F PR #2643 review point #2: routing should ignore code spans,
+            // but Gatekeeper must not lose non-mention code content. Preserving
+            // in-code tokens in cleanText keeps the full code-span string
+            // available for sensitive-word detection; only tokens OUTSIDE
+            // code spans are stripped.
+            const ctx = makeCtx();
+            const r = mp.parseMentions('Example: `@aaaaaa hi`', ctx);
+            expect(r.cleanText).toContain('@aaaaaa hi');
+        });
+
+        test('cleanText still strips OUTSIDE-code tokens (gatekeeper)', () => {
+            const ctx = makeCtx();
+            const r = mp.parseMentions(
+                'Hi @aaaaaa, please see `@bbbbbb` for context.',
+                ctx
+            );
+            // Outside-code @aaaaaa stripped (resolved); in-code @bbbbbb kept.
+            expect(r.cleanText).not.toMatch(/@aaaaaa/);
+            expect(r.cleanText).toContain('@bbbbbb');
+        });
+
+        test('displayText preserves code-span token even when same target is mentioned outside', () => {
+            // Mac_F PR #2643 review point #3: if @bbbbbb appears BOTH outside
+            // (real mention) and inside backticks (doc example), only the
+            // outside occurrence should be rewritten to @Bob; the in-code
+            // example must remain literal.
+            const ctx = makeCtx();
+            const r = mp.parseMentions(
+                'Tag @bbbbbb like this: `@bbbbbb hello`',
+                ctx
+            );
+            expect(r.displayText).toBe('Tag @Bob like this: `@bbbbbb hello`');
+        });
+
+        test('production repro — #2 doc-example message to #1 does NOT also route to #5', () => {
+            // Mirrors the 2026-05-12 m=f4750a2e incident. #2 (LOBSTER, pc=wjkzxz)
+            // sent a reply to #1 (Mac_F, pc=31tlkr) explaining routing forms;
+            // backend mis-parsed `@00vt9i` inside backticks and ALSO routed
+            // to #5 (Hermes, pc=00vt9i).
+            const devices = {
+                'd1': {
+                    entities: {
+                        1: { isBound: true, name: 'Mac_F', publicCode: '31tlkr' },
+                        2: { isBound: true, name: 'LOBSTER', publicCode: 'wjkzxz' },
+                        5: { isBound: true, name: 'Hermes', publicCode: '00vt9i' }
+                    }
+                }
+            };
+            const publicCodeIndex = {
+                '31tlkr': { deviceId: 'd1', entityId: 1 },
+                'wjkzxz': { deviceId: 'd1', entityId: 2 },
+                '00vt9i': { deviceId: 'd1', entityId: 5 }
+            };
+            const ctx = { senderDeviceId: 'd1', devices, publicCodeIndex };
+            const msg = '@31tlkr Token formats: `@#5` ← entityId, `@00vt9i` ← publicCode, `@all` ← broadcast.';
+            const r = mp.parseMentions(msg, ctx);
+            const routed = r.mentions.map(m => m.publicCode);
+            expect(routed).toEqual(['31tlkr']);
+            expect(routed).not.toContain('00vt9i');
+            expect(r.hasAll).toBe(false);
+        });
+    });
 });
 
 describe('mention-parser.decideRouting', () => {


### PR DESCRIPTION
## Summary
- Mask markdown code spans (fenced ``` and inline `` ` ``) to a same-length whitespace shadow **before** routing regexes run. Tokens inside backticks no longer resolve as live mentions.
- Rebuild `displayText` and `cleanText` by splicing the **original** text at the shadow's match positions, so backtick content stays literal in both outputs (display keeps the example visible; Gatekeeper still sees the full code-span string for sensitive-word detection).
- Mention regex objects (`ALL_TOKEN_RE`, the five mention forms, `stripMentionTokens()`) are untouched.

## Why
Production incident m=f4750a2e (2026-05-12): #2 sent a routing-docs message to #1 that included a backtick example `` `@00vt9i ...` ``. The backend's bare publicCode regex `(?<![\w@<])@([a-z0-9]{6})(?![\w])` did **not** exclude backticks in its lookbehind, so the example token was treated as a live mention and the message also fanned out to #5.

This replaces the closed PR #2643 (which bundled unrelated `scripts/update-i18n-1036.js` CRLF churn) and PR #2644 (38-file CRLF churn, zero real changes). Both were closed.

## Coverage of @HankHuang0516's review on #2643
1. **ALL_TOKEN_RE word boundary** — regex object unchanged; only its input (shadow vs raw text) changed. ✓
2. **`stripMentionTokens()` deleting code-span content** — function not modified; Gatekeeper still sees every non-token byte. ✓
3. **`displayText` rewriting code-span tokens when the same target also appears outside** — new position-aware splicing only rewrites occurrences whose match position in the shadow was non-whitespace. Verified with a test where `@bbbbbb` appears both outside and inside backticks. ✓
4. **Drop `scripts/update-i18n-1036.js` churn** — this branch touches mention-parser.js + its test only. ✓

## Test plan
- [x] `npx jest backend/tests/jest/mention-parser.test.js` → 68 pass
- [x] `npx jest backend/tests/jest/mention-parser.test.js backend/tests/jest/mention-gatekeeper.test.js backend/tests/jest/mention-resolver.test.js backend/tests/jest/channel-message-mention-autorouter.test.js` → 97 pass
- [x] Test suite includes the literal m=f4750a2e production repro (#2 → #1 message must NOT also route to #5)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)