### PR TITLE
fix(portal): reduce QA-discovered request fanout

### DIFF
--- a/backend/public/portal/feedback.html
+++ b/backend/public/portal/feedback.html
@@ -781,6 +781,12 @@
         let feedbackCategory = 'bug';
         // currentUser is declared in shared/auth.js
         let selectedPhotos = []; // File objects selected for upload
+        let feedbackPhotoObserver = null;
+        const feedbackPhotoQueue = [];
+        const queuedFeedbackPhotoIds = new Set();
+        let activeFeedbackPhotoLoads = 0;
+        const MAX_FEEDBACK_PHOTO_LOADS = 3;
+        let feedbackPhotoGeneration = 0;
 
         window.addEventListener('DOMContentLoaded', async () => {
             renderNav('settings');
@@ -1056,6 +1062,7 @@
         function renderFeedback() {
             const listEl = document.getElementById('feedbackList');
             const emptyEl = document.getElementById('emptyState');
+            resetFeedbackPhotoLoader();
             listEl.innerHTML = '';
 
             const filtered = currentFilter === 'all'
@@ -1130,10 +1137,62 @@
 
             card.innerHTML = html;
 
-            // Load photos asynchronously
-            loadFeedbackPhotos(card, item.id);
+            // Load photos lazily. Feedback history can contain many cards; firing
+            // one /photos request per card on render can self-trigger rate limits.
+            scheduleFeedbackPhotoLoad(card, item.id);
 
             return card;
+        }
+
+        function resetFeedbackPhotoLoader() {
+            if (feedbackPhotoObserver) feedbackPhotoObserver.disconnect();
+            feedbackPhotoObserver = null;
+            feedbackPhotoQueue.length = 0;
+            queuedFeedbackPhotoIds.clear();
+            activeFeedbackPhotoLoads = 0;
+            feedbackPhotoGeneration++;
+
+            if ('IntersectionObserver' in window) {
+                feedbackPhotoObserver = new IntersectionObserver(entries => {
+                    entries.forEach(entry => {
+                        if (!entry.isIntersecting) return;
+                        feedbackPhotoObserver.unobserve(entry.target);
+                        enqueueFeedbackPhotoLoad(entry.target, entry.target.dataset.feedbackId, Number(entry.target.dataset.feedbackPhotoGeneration));
+                    });
+                }, { rootMargin: '250px 0px' });
+            }
+        }
+
+        function scheduleFeedbackPhotoLoad(cardEl, feedbackId) {
+            if (!currentUser?.deviceId || !currentUser?.deviceSecret) return;
+            cardEl.dataset.feedbackId = feedbackId;
+            cardEl.dataset.feedbackPhotoGeneration = String(feedbackPhotoGeneration);
+            if (feedbackPhotoObserver) {
+                feedbackPhotoObserver.observe(cardEl);
+            } else {
+                enqueueFeedbackPhotoLoad(cardEl, feedbackId, feedbackPhotoGeneration);
+            }
+        }
+
+        function enqueueFeedbackPhotoLoad(cardEl, feedbackId, generation = feedbackPhotoGeneration) {
+            if (!cardEl || !feedbackId || generation !== feedbackPhotoGeneration || queuedFeedbackPhotoIds.has(String(feedbackId))) return;
+            queuedFeedbackPhotoIds.add(String(feedbackId));
+            feedbackPhotoQueue.push({ cardEl, feedbackId, generation });
+            drainFeedbackPhotoQueue();
+        }
+
+        function drainFeedbackPhotoQueue() {
+            while (activeFeedbackPhotoLoads < MAX_FEEDBACK_PHOTO_LOADS && feedbackPhotoQueue.length > 0) {
+                const job = feedbackPhotoQueue.shift();
+                if (job.generation !== feedbackPhotoGeneration) continue;
+                activeFeedbackPhotoLoads++;
+                loadFeedbackPhotos(job.cardEl, job.feedbackId)
+                    .finally(() => {
+                        if (job.generation !== feedbackPhotoGeneration) return;
+                        activeFeedbackPhotoLoads--;
+                        drainFeedbackPhotoQueue();
+                    });
+            }
         }
 
         async function loadFeedbackPhotos(cardEl, feedbackId) {

--- a/backend/public/portal/petdx-browser.html
+++ b/backend/public/portal/petdx-browser.html
@@ -599,6 +599,8 @@
     let currentSelectionId = null;
 
     async function refreshOwnerState() {
+        const creds = getCreds();
+        if (!creds.deviceId || (!creds.deviceSecret && !creds.botSecret)) return;
         const q = authQuery();
         try {
             const r = await fetch('/api/companion/current?' + q.toString());

--- a/backend/public/portal/share-chat.html
+++ b/backend/public/portal/share-chat.html
@@ -417,10 +417,13 @@
     (async function init() {
         dbg('info', 'Init started', { url: window.location.href, origin: API_BASE });
 
-        // Extract code from URL path: /c/<code>
-        const parts = window.location.pathname.split('/');
-        targetCode = parts[parts.length - 1] || '';
-        dbg('info', `Target code extracted: "${targetCode}"`, { pathParts: parts });
+        // Extract code from supported share routes: /c/<code> or ?code=<code>.
+        // Do not treat the direct page filename (/portal/share-chat.html) as a bot code.
+        const parts = window.location.pathname.split('/').filter(Boolean);
+        const cIndex = parts.indexOf('c');
+        const urlCode = new URLSearchParams(window.location.search).get('code') || '';
+        targetCode = (cIndex >= 0 && parts[cIndex + 1]) ? parts[cIndex + 1] : urlCode;
+        dbg('info', `Target code extracted: "${targetCode}"`, { pathParts: parts, urlCode });
 
         if (!targetCode || targetCode.length < 4) {
             dbg('error', 'Invalid target code — too short or empty');


### PR DESCRIPTION
## Summary
Fixes three QA/UIUX findings from the 2026-05-12 daily portal regression pass:

- Fixes #2649 by lazy-loading feedback photos with IntersectionObserver and a small concurrency queue, avoiding a `/photos` request fan-out for every feedback card at render time.
- Fixes #2650 by making `share-chat.html` accept only supported share targets (`/c/<code>` or `?code=<code>`) instead of treating the direct page filename as an entity code.
- Fixes #2655 by guarding Petdx owner-state refresh when device credentials are missing, preventing `/api/companion/current?` empty-query 400s on unauthenticated page loads.

## Verification
- `git diff --check`
- `node backend/scripts/portal-smoke-check.js`
- Inline script syntax check for changed HTML files via `new Function(...)`
- Local browser/CDP verification:
  - direct `share-chat.html` shows `Invalid link` and no longer requests `/api/entity/lookup?code=share-chat.html`
  - unauthenticated `petdx-browser.html` shows the login warning and no longer requests `/api/companion/current?`

## Notes
No translation changes. No backend API changes.