### PR TITLE
feat(dashboard): add Claude Code channel guide card

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -1851,6 +1851,33 @@
                                     <a class="channel-promo-link" href="https://github.com/HankHuang0516/codex-eclaw-bridge" target="_blank" rel="noopener">GitHub →</a>
                                 </div>
                             </div>
+
+                            <div class="channel-guide-card">
+                                <div class="channel-guide-title">
+                                    <span>Claude Code Channel</span>
+                                    <span class="channel-guide-badge">Experimental</span>
+                                </div>
+                                <div class="channel-guide-desc">Run Claude Code in a local tmux session as your EClaw bot — uses your claude.ai Max subscription quota, no Anthropic API tokens billed.</div>
+                                <div class="channel-step-code" onclick="copyText('git clone https://github.com/HankHuang0516/claude-code-eclaw-channel.git && cd claude-code-eclaw-channel && bun install', this)">
+                                    <span class="channel-step-num">1</span>
+                                    <code>git clone .../claude-code-eclaw-channel && bun install</code>
+                                    <span class="channel-step-copy">⧉</span>
+                                </div>
+                                <div class="channel-step-code" onclick="copyText('cp .mcp.json.example .mcp.json\n# then edit .mcp.json:\n#   ECLAW_API_KEY=eck_your_key\n#   ECLAW_WEBHOOK_URL=https://your-public-url.example.com', this)">
+                                    <span class="channel-step-num">2</span>
+                                    <code>fill .mcp.json: ECLAW_API_KEY, ECLAW_WEBHOOK_URL</code>
+                                    <span class="channel-step-copy">⧉</span>
+                                </div>
+                                <div class="channel-step-code" onclick="copyText('./patch-fakechat.sh && bun run bridge.ts', this)">
+                                    <span class="channel-step-num">3</span>
+                                    <code>./patch-fakechat.sh && bun run bridge.ts</code>
+                                    <span class="channel-step-copy">⧉</span>
+                                </div>
+                                <div class="channel-guide-actions">
+                                    <a class="channel-promo-link" href="info.html#channel-plugins/claude-code-channel">Claude Code guide →</a>
+                                    <a class="channel-promo-link" href="https://github.com/HankHuang0516/claude-code-eclaw-channel" target="_blank" rel="noopener">GitHub →</a>
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
## Summary

Completes the Mac_F + me follow-up split for PR #2640.

Adds the third tray card to dashboard's *Try EClaw Channel?* section, mirroring the Codex card layout exactly. Auto-fit grid (`minmax(280px, 1fr)`) keeps the visual rhythm — OpenClaw / Codex / Claude Code.

**Card content**
- Title + **Experimental** badge (per info.html guide warning about `--dangerously-load-development-channels`)
- 3-step compressed copy-paste install:
  1) `git clone` + `bun install`
  2) `cp .mcp.json.example .mcp.json` + fill `ECLAW_API_KEY` + `ECLAW_WEBHOOK_URL`
  3) `./patch-fakechat.sh && bun run bridge.ts`
- Action row: Claude Code guide (`info.html#channel-plugins/claude-code-channel`) + GitHub link

**Selling point in card description** — uses your claude.ai Max subscription quota, no Anthropic API tokens billed. This is the actual differentiator vs OpenClaw / Codex paths.

**i18n**
No `data-i18n` attributes on title/badge/desc — matches the OpenClaw / Codex inline-EN pattern Mac_F established in #2640. Hermes drift scanner will queue i18n backfill if/when keys get formalized for the whole tray.

## Test plan

- [x] HTML structure sanity — 3 `channel-guide-card` in grid, balanced divs
- [x] Diff is purely additive (+27 lines, no existing markup edited)
- [ ] Personal playwright web + mobile screenshot review (post-deploy, against prod)
- [ ] Verify info.html#channel-plugins/claude-code-channel anchor resolves
- [ ] Verify GitHub link opens in new tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)