### PR TITLE
i18n(android): backfill notif_pref_kanban_done* into 12 locales

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -658,8 +658,8 @@ GPS: عند الطلب فقط، بلا تتبع في الخلفية، تُفقد
     <string name="notif_pref_feedback">تحديثات الملاحظات</string>
     <string name="notif_pref_todo">المهام المكتملة</string>
     <string name="notif_pref_scheduled">الرسائل المجدولة</string>
-    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
-    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done">اكتمال بطاقة كانبان</string>
+    <string name="notif_pref_kanban_done_auto">اكتمال أتمتة كانبان</string>
     <string name="notif_prefs_loading">جارٍ تحميل التفضيلات…</string>
     <string name="notif_prefs_error">فشل تحميل تفضيلات الإشعارات</string>
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -658,6 +658,8 @@ GPS: عند الطلب فقط، بلا تتبع في الخلفية، تُفقد
     <string name="notif_pref_feedback">تحديثات الملاحظات</string>
     <string name="notif_pref_todo">المهام المكتملة</string>
     <string name="notif_pref_scheduled">الرسائل المجدولة</string>
+    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
     <string name="notif_prefs_loading">جارٍ تحميل التفضيلات…</string>
     <string name="notif_prefs_error">فشل تحميل تفضيلات الإشعارات</string>
 

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -661,6 +661,8 @@ Bei Fragen kontaktieren Sie uns über unsere offizielle E-Mail.
     <string name="notif_prefs_loading">Einstellungen werden geladen…</string>
     <string name="notif_prefs_error">Benachrichtigungseinstellungen konnten nicht geladen werden</string>
 
+    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
     <!-- Broadcast Settings -->
     <string name="broadcast_settings_title">Broadcast-Einstellungen</string>
     <string name="broadcast_settings_desc">Konfigurieren Sie, wie Broadcast-Nachrichten funktionieren</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -661,8 +661,8 @@ Bei Fragen kontaktieren Sie uns über unsere offizielle E-Mail.
     <string name="notif_prefs_loading">Einstellungen werden geladen…</string>
     <string name="notif_prefs_error">Benachrichtigungseinstellungen konnten nicht geladen werden</string>
 
-    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
-    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done">Kanban-Karte erledigt</string>
+    <string name="notif_pref_kanban_done_auto">Kanban-Automatisierung erledigt</string>
     <!-- Broadcast Settings -->
     <string name="broadcast_settings_title">Broadcast-Einstellungen</string>
     <string name="broadcast_settings_desc">Konfigurieren Sie, wie Broadcast-Nachrichten funktionieren</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -658,8 +658,8 @@ Puedes enviar una solicitud de demanda de alquiler y te notificaremos cuando est
     <string name="schedule_upcoming">Próximos y Activos</string>
     <string name="schedule_updated">¡Horario actualizado!</string>
     <string name="search_hint">Buscar…</string>
-    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
-    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done">Tarjeta Kanban completada</string>
+    <string name="notif_pref_kanban_done_auto">Automatización Kanban completada</string>
     <string name="select">Seleccionar</string>
     <string name="select_bot">Selecciona un bot:</string>
     <string name="select_entity_slot">Seleccionar ranura de entidad</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -658,6 +658,8 @@ Puedes enviar una solicitud de demanda de alquiler y te notificaremos cuando est
     <string name="schedule_upcoming">Próximos y Activos</string>
     <string name="schedule_updated">¡Horario actualizado!</string>
     <string name="search_hint">Buscar…</string>
+    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
     <string name="select">Seleccionar</string>
     <string name="select_bot">Selecciona un bot:</string>
     <string name="select_entity_slot">Seleccionar ranura de entidad</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -658,6 +658,8 @@ Si vous avez des questions, contactez-nous via notre e-mail officiel.
     <string name="notif_pref_feedback">Mises à jour des retours</string>
     <string name="notif_pref_todo">TODO terminé</string>
     <string name="notif_pref_scheduled">Messages planifiés</string>
+    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
     <string name="notif_prefs_loading">Chargement des préférences…</string>
     <string name="notif_prefs_error">Échec du chargement des préférences de notification</string>
 

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -658,8 +658,8 @@ Si vous avez des questions, contactez-nous via notre e-mail officiel.
     <string name="notif_pref_feedback">Mises à jour des retours</string>
     <string name="notif_pref_todo">TODO terminé</string>
     <string name="notif_pref_scheduled">Messages planifiés</string>
-    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
-    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done">Carte Kanban terminée</string>
+    <string name="notif_pref_kanban_done_auto">Automatisation Kanban terminée</string>
     <string name="notif_prefs_loading">Chargement des préférences…</string>
     <string name="notif_prefs_error">Échec du chargement des préférences de notification</string>
 

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -660,6 +660,8 @@ GPS: केवल अनुरोध पर, कोई बैकग्राउ�
     <string name="notif_pref_scheduled">शेड्यूल किए गए संदेश</string>
     <string name="notif_prefs_loading">प्राथमिकताएं लोड हो रही हैं…</string>
     <string name="notif_prefs_error">सूचना प्राथमिकताएं लोड करने में विफल</string>
+    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
 
     <!-- Broadcast Settings -->
     <string name="broadcast_settings_title">प्रसारण सेटिंग्स</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -660,8 +660,8 @@ GPS: केवल अनुरोध पर, कोई बैकग्राउ�
     <string name="notif_pref_scheduled">शेड्यूल किए गए संदेश</string>
     <string name="notif_prefs_loading">प्राथमिकताएं लोड हो रही हैं…</string>
     <string name="notif_prefs_error">सूचना प्राथमिकताएं लोड करने में विफल</string>
-    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
-    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done">कानबन कार्ड पूर्ण</string>
+    <string name="notif_pref_kanban_done_auto">कानबन ऑटोमेशन पूर्ण</string>
 
     <!-- Broadcast Settings -->
     <string name="broadcast_settings_title">प्रसारण सेटिंग्स</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -658,8 +658,8 @@ Jika ada pertanyaan, silakan hubungi kami melalui email resmi kami.
     <string name="sent">Terkirim!</string>
     <string name="set_live_wallpaper">Atur Wallpaper Hidup</string>
     <string name="set_wallpaper">Atur Wallpaper</string>
-    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
-    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done">Kartu Kanban Selesai</string>
+    <string name="notif_pref_kanban_done_auto">Otomatisasi Kanban Selesai</string>
     <string name="settings_entity_limit">Batas Entitas: %1$d</string>
     <string name="settings_reset">Pengaturan direset</string>
     <string name="settings_title">Pengaturan</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -658,6 +658,8 @@ Jika ada pertanyaan, silakan hubungi kami melalui email resmi kami.
     <string name="sent">Terkirim!</string>
     <string name="set_live_wallpaper">Atur Wallpaper Hidup</string>
     <string name="set_wallpaper">Atur Wallpaper</string>
+    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
     <string name="settings_entity_limit">Batas Entitas: %1$d</string>
     <string name="settings_reset">Pengaturan direset</string>
     <string name="settings_title">Pengaturan</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -658,6 +658,8 @@ GPS：オンデマンドのみ、バックグラウンド追跡なし、サー�
     <string name="sent">送信しました！</string>
     <string name="set_live_wallpaper">ライブ壁紙に設定</string>
     <string name="set_wallpaper">壁紙に設定</string>
+    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
     <string name="settings_entity_limit">エンティティ上限：%1$d</string>
     <string name="settings_reset">設定をリセットしました</string>
     <string name="settings_title">設定</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -658,8 +658,8 @@ GPS：オンデマンドのみ、バックグラウンド追跡なし、サー�
     <string name="sent">送信しました！</string>
     <string name="set_live_wallpaper">ライブ壁紙に設定</string>
     <string name="set_wallpaper">壁紙に設定</string>
-    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
-    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done">カンバンカード完了</string>
+    <string name="notif_pref_kanban_done_auto">カンバン自動化完了</string>
     <string name="settings_entity_limit">エンティティ上限：%1$d</string>
     <string name="settings_reset">設定をリセットしました</string>
     <string name="settings_title">設定</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -658,8 +658,8 @@ GPS: 온디맨드만, 백그라운드 추적 없음, 서버 재시작 시 데이
     <string name="sent">전송 완료!</string>
     <string name="set_live_wallpaper">라이브 배경화면 설정</string>
     <string name="set_wallpaper">배경화면 설정</string>
-    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
-    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done">칸반 카드 완료</string>
+    <string name="notif_pref_kanban_done_auto">칸반 자동화 완료</string>
     <string name="settings_entity_limit">엔티티 제한: %1$d</string>
     <string name="settings_reset">설정이 초기화되었습니다</string>
     <string name="settings_title">설정</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -658,6 +658,8 @@ GPS: 온디맨드만, 백그라운드 추적 없음, 서버 재시작 시 데이
     <string name="sent">전송 완료!</string>
     <string name="set_live_wallpaper">라이브 배경화면 설정</string>
     <string name="set_wallpaper">배경화면 설정</string>
+    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
     <string name="settings_entity_limit">엔티티 제한: %1$d</string>
     <string name="settings_reset">설정이 초기화되었습니다</string>
     <string name="settings_title">설정</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -658,6 +658,8 @@ Jika anda mempunyai sebarang soalan, sila hubungi kami melalui e-mel rasmi kami.
     <string name="notif_pref_feedback">Kemas Kini Maklum Balas</string>
     <string name="notif_pref_todo">TODO Selesai</string>
     <string name="notif_pref_scheduled">Mesej Berjadual</string>
+    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
     <string name="notif_prefs_loading">Memuat keutamaan…</string>
     <string name="notif_prefs_error">Gagal memuat keutamaan pemberitahuan</string>
 

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -658,8 +658,8 @@ Jika anda mempunyai sebarang soalan, sila hubungi kami melalui e-mel rasmi kami.
     <string name="notif_pref_feedback">Kemas Kini Maklum Balas</string>
     <string name="notif_pref_todo">TODO Selesai</string>
     <string name="notif_pref_scheduled">Mesej Berjadual</string>
-    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
-    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done">Kad Kanban Selesai</string>
+    <string name="notif_pref_kanban_done_auto">Automasi Kanban Selesai</string>
     <string name="notif_prefs_loading">Memuat keutamaan…</string>
     <string name="notif_prefs_error">Gagal memuat keutamaan pemberitahuan</string>
 

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -658,8 +658,8 @@ GPS：รับตามความต้องการเท่านั้�
     <string name="sent">ส่งแล้ว!</string>
     <string name="set_live_wallpaper">ตั้งวอลเปเปอร์สด</string>
     <string name="set_wallpaper">ตั้งวอลเปเปอร์</string>
-    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
-    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done">การ์ดคันบังเสร็จสิ้น</string>
+    <string name="notif_pref_kanban_done_auto">ระบบอัตโนมัติคันบังเสร็จสิ้น</string>
     <string name="settings_entity_limit">Entity Limit: %1$d</string>
     <string name="settings_reset">รีเซ็ตการตั้งค่าแล้ว</string>
     <string name="settings_title">ตั้งค่า</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -658,6 +658,8 @@ GPS：รับตามความต้องการเท่านั้�
     <string name="sent">ส่งแล้ว!</string>
     <string name="set_live_wallpaper">ตั้งวอลเปเปอร์สด</string>
     <string name="set_wallpaper">ตั้งวอลเปเปอร์</string>
+    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
     <string name="settings_entity_limit">Entity Limit: %1$d</string>
     <string name="settings_reset">รีเซ็ตการตั้งค่าแล้ว</string>
     <string name="settings_title">ตั้งค่า</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -658,6 +658,8 @@ Nếu có bất kỳ câu hỏi nào, vui lòng liên hệ với chúng tôi qua
     <string name="sent">Đã gửi!</string>
     <string name="set_live_wallpaper">Đặt hình nền động</string>
     <string name="set_wallpaper">Đặt hình nền</string>
+    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
     <string name="settings_entity_limit">Entity Limit: %1$d</string>
     <string name="settings_reset">Đã đặt lại cài đặt</string>
     <string name="settings_title">Cài đặt</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -658,8 +658,8 @@ Nếu có bất kỳ câu hỏi nào, vui lòng liên hệ với chúng tôi qua
     <string name="sent">Đã gửi!</string>
     <string name="set_live_wallpaper">Đặt hình nền động</string>
     <string name="set_wallpaper">Đặt hình nền</string>
-    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
-    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done">Thẻ Kanban hoàn thành</string>
+    <string name="notif_pref_kanban_done_auto">Tự động hóa Kanban hoàn thành</string>
     <string name="settings_entity_limit">Entity Limit: %1$d</string>
     <string name="settings_reset">Đã đặt lại cài đặt</string>
     <string name="settings_title">Cài đặt</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -662,6 +662,8 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="set_wallpaper">设置壁纸</string>
     <string name="settings_entity_limit">实体上限：%1$d</string>
     <string name="settings_reset">设置已重置</string>
+    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
     <string name="settings_title">设置</string>
     <string name="show_label">显示</string>
     <string name="sign_in_facebook">使用 Facebook 登录</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -662,8 +662,8 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="set_wallpaper">设置壁纸</string>
     <string name="settings_entity_limit">实体上限：%1$d</string>
     <string name="settings_reset">设置已重置</string>
-    <string name="notif_pref_kanban_done">NOTIF_KANBAN_DONE_PLACEHOLDER</string>
-    <string name="notif_pref_kanban_done_auto">NOTIF_KANBAN_AUTO_PLACEHOLDER</string>
+    <string name="notif_pref_kanban_done">看板卡片已完成</string>
+    <string name="notif_pref_kanban_done_auto">看板自动化已完成</string>
     <string name="settings_title">设置</string>
     <string name="show_label">显示</string>
     <string name="sign_in_facebook">使用 Facebook 登录</string>


### PR DESCRIPTION
## Summary
Backfill missing Android locale translations for notif_pref_kanban_done + notif_pref_kanban_done_auto (upstream commit a7109095 added only default + zh-rTW).

## Changes
12 locales updated: values-ar, values-de, values-es, values-fr, values-hi, values-in, values-ja, values-ko, values-ms, values-th, values-vi, values-zh-rCN

## New keys
- `notif_pref_kanban_done` = "Kanban Card Completed" (English reference)
- `notif_pref_kanban_done_auto` = "Kanban Automation Completed" (English reference)

**Note:** Placeholder values added; actual translations to be filled by localizers.

## Scope
Strictly limited to the 12 listed strings.xml files + 2 new string entries each. No other files modified.