### PR TITLE
i18n: backfill guide_cc_channel_envvars_row_auto_wake_{poll,max_wait} × 11 locales

### DIFF
--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -1847131,6 +1847131,8 @@ const TRANSLATIONS = {
 
 
     ja: {
+        "guide_cc_channel_envvars_row_auto_wake_poll": "Claude がまだ busy のときの再チェック間隔（秒）",
+        "guide_cc_channel_envvars_row_auto_wake_max_wait": "自動起動を諦めるまでの最大合計待ち時間（秒）",
 
 
 
@@ -2409180,6 +2409182,8 @@ const TRANSLATIONS = {
 
 
     ko: {
+        "guide_cc_channel_envvars_row_auto_wake_poll": "Claude가 아직 busy일 때 재확인 간격(초)",
+        "guide_cc_channel_envvars_row_auto_wake_max_wait": "자동 깨우기를 포기하기 전 최대 누적 대기 시간(초)",
 
 
 
@@ -2939768,6 +2939772,8 @@ const TRANSLATIONS = {
 
 
     th: {
+        "guide_cc_channel_envvars_row_auto_wake_poll": "ช่วงเวลาตรวจสอบซ้ำ (วินาที) ขณะที่ Claude ยังยุ่งอยู่",
+        "guide_cc_channel_envvars_row_auto_wake_max_wait": "เวลารอรวมสูงสุดก่อนยกเลิกการปลุกอัตโนมัติ (วินาที)",
 
 
 
@@ -3465108,6 +3465114,8 @@ const TRANSLATIONS = {
 
 
     vi: {
+        "guide_cc_channel_envvars_row_auto_wake_poll": "Khoảng kiểm tra lại (giây) khi Claude vẫn busy",
+        "guide_cc_channel_envvars_row_auto_wake_max_wait": "Tổng thời gian chờ tối đa trước khi bỏ qua tự đánh thức (giây)",
 
 
 
@@ -3990448,6 +3990456,8 @@ const TRANSLATIONS = {
 
 
     id: {
+        "guide_cc_channel_envvars_row_auto_wake_poll": "Interval pemeriksaan ulang (detik) saat Claude masih sibuk",
+        "guide_cc_channel_envvars_row_auto_wake_max_wait": "Total waktu tunggu maksimum sebelum menyerah membangunkan otomatis (detik)",
 
 
 
@@ -4515404,6 +4515414,8 @@ const TRANSLATIONS = {
 
 
     fr: {
+        "guide_cc_channel_envvars_row_auto_wake_poll": "Intervalle de re-vérification (secondes) tant que Claude est occupé",
+        "guide_cc_channel_envvars_row_auto_wake_max_wait": "Attente totale maximale avant d'abandonner le réveil auto (secondes)",
 
 
 
@@ -5039080,6 +5039092,8 @@ const TRANSLATIONS = {
 
 
     es: {
+        "guide_cc_channel_envvars_row_auto_wake_poll": "Intervalo de re-comprobación (segundos) mientras Claude sigue ocupado",
+        "guide_cc_channel_envvars_row_auto_wake_max_wait": "Espera total máxima antes de abandonar el auto-despertar (segundos)",
 
 
 
@@ -5555324,6 +5555338,8 @@ const TRANSLATIONS = {
 
 
     de: {
+        "guide_cc_channel_envvars_row_auto_wake_poll": "Wiederprüf-Intervall (Sekunden), solange Claude noch beschäftigt ist",
+        "guide_cc_channel_envvars_row_auto_wake_max_wait": "Max. Gesamtwartezeit, bevor Auto-Wake aufgegeben wird (Sekunden)",
 
 
 
@@ -6090900,6 +6090916,8 @@ const TRANSLATIONS = {
 
 
     ms: {
+        "guide_cc_channel_envvars_row_auto_wake_poll": "Selang semakan semula (saat) semasa Claude masih sibuk",
+        "guide_cc_channel_envvars_row_auto_wake_max_wait": "Jumlah masa menunggu maksimum sebelum berhenti auto-wake (saat)",
 
 
 
@@ -6757296,6 +6757314,8 @@ const TRANSLATIONS = {
 
 
     hi: {
+        "guide_cc_channel_envvars_row_auto_wake_poll": "Claude अभी भी busy होने पर पुनः जाँच अंतराल (सेकंड)",
+        "guide_cc_channel_envvars_row_auto_wake_max_wait": "ऑटो-वेक छोड़ने से पहले अधिकतम कुल प्रतीक्षा समय (सेकंड)",
 
 
 
@@ -7455692,6 +7455712,8 @@ const TRANSLATIONS = {
 
 
     ar: {
+        "guide_cc_channel_envvars_row_auto_wake_poll": "فاصل إعادة الفحص (بالثواني) أثناء انشغال Claude",
+        "guide_cc_channel_envvars_row_auto_wake_max_wait": "أقصى زمن انتظار إجمالي قبل التخلي عن الإيقاظ التلقائي (بالثواني)",
 
 
 


### PR DESCRIPTION
## Summary

PR #2646 seeded `guide_cc_channel_envvars_row_auto_wake_poll` and `guide_cc_channel_envvars_row_auto_wake_max_wait` into `en`, `zh`, `zh-CN` only. Drift Scanner (Mac_F #1, 2026-05-13 04:02 TPE) flagged 11 locales missing both keys: `ja`, `ko`, `th`, `vi`, `id`, `fr`, `es`, `de`, `ms`, `hi`, `ar`.

Without these entries the row in `info.html` falls back to the inline Chinese seed text, which is the wrong default for non-EN/non-zh users browsing in their language.

This PR inserts both keys at the top of each of the 11 locale dicts: 2 keys × 11 locales = 22 string additions, no other behavior change.

## Self-fix rationale

Per memory `feedback_i18n_delegate`, i18n delegates to Hermes #5 with Mac_E #3 fallback. Both delegate paths are currently broken:

- Hermes #5 is in an auto-PR loop (PR #2657-2666+ broadcast-triggered CRLF) per the parent card's HOLD rationale
- Mac_E #3 just demonstrated unreliability on the parallel #2669 backfill (shipped literal `NOTIF_KANBAN_DONE_PLACEHOLDER` sentinels as visible strings)

Closed-loop self-fix matches the spirit of `feedback_closed_loop_autonomy`. Card scope honored strictly (2 keys × 11 locales); a deeper drift exists for `_enabled` / `_delay` / `_cooldown` across the same 11 locales + `zh-TW`, but that's out of this card's scope and will be a follow-up.

## Test plan

- [x] `node --check backend/public/shared/i18n.js` passes
- [x] `grep -n guide_cc_channel_envvars_row_auto_wake_poll` returns 14 hits (en, zh, zh-CN, + 11 new)
- [x] `grep -n guide_cc_channel_envvars_row_auto_wake_max_wait` returns 14 hits (same shape)
- [x] Each new entry is correctly placed inside its locale dict (verified by line-number ↔ locale-boundary mapping)
- [ ] After merge: Playwright spot-check 2-3 locales rendering `info.html` row text correctly (will run post-merge)

Closes the kanban card `[i18n] info.html: backfill guide_cc_channel_envvars_row_auto_wake_{poll,max_wait} into 11 locales`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)