### PR TITLE
fix(app): WebView pages honor app-selected locale via ?lang= URL param

### DIFF
--- a/app/src/main/java/com/hank/clawlive/MainActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/MainActivity.kt
@@ -263,7 +263,8 @@ class MainActivity : AppCompatActivity() {
         val deviceId = deviceManager.deviceId
         val deviceSecret = deviceManager.deviceSecret
         val baseUrl = "https://eclawbot.com/portal/dashboard.html"
-        wv.loadUrl("$baseUrl?embed=1&deviceId=$deviceId&deviceSecret=$deviceSecret")
+        val url = "$baseUrl?embed=1&deviceId=$deviceId&deviceSecret=$deviceSecret"
+        wv.loadUrl(com.hank.clawlive.util.PortalUrlHelper.withAppLang(this, url))
     }
 
     private fun injectCredentials(webView: WebView?) {

--- a/app/src/main/java/com/hank/clawlive/MissionControlActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/MissionControlActivity.kt
@@ -105,7 +105,7 @@ class MissionControlActivity : AppCompatActivity() {
         val url = if (deviceId != null && deviceSecret != null)
             "$baseUrl?deviceId=$deviceId&deviceSecret=$deviceSecret"
         else baseUrl
-        wv.loadUrl(url)
+        wv.loadUrl(com.hank.clawlive.util.PortalUrlHelper.withAppLang(this, url))
     }
 
     private fun injectCredentials(webView: WebView?) {

--- a/app/src/main/java/com/hank/clawlive/WebViewActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/WebViewActivity.kt
@@ -146,10 +146,10 @@ class WebViewActivity : AppCompatActivity() {
         val deviceId = deviceManager.deviceId
         val deviceSecret = deviceManager.deviceSecret
         val sep = if (baseUrl.contains("?")) "&" else "?"
-        val url = if (deviceId != null && deviceSecret != null)
+        val withCreds = if (deviceId != null && deviceSecret != null)
             "$baseUrl${sep}deviceId=$deviceId&deviceSecret=$deviceSecret&embed=1"
         else "$baseUrl${sep}embed=1"
-        wv.loadUrl(url)
+        wv.loadUrl(com.hank.clawlive.util.PortalUrlHelper.withAppLang(this, withCreds))
     }
 
     private fun injectCredentials(webView: WebView?) {

--- a/app/src/main/java/com/hank/clawlive/ui/OrgChartBottomSheetFragment.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/OrgChartBottomSheetFragment.kt
@@ -86,7 +86,7 @@ class OrgChartBottomSheetFragment : BottomSheetDialogFragment() {
                 append(dm.deviceSecret)
             }
         }
-        wv.loadUrl(url)
+        wv.loadUrl(com.hank.clawlive.util.PortalUrlHelper.withAppLang(requireContext(), url))
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/hank/clawlive/ui/chat/ChatWebViewManager.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/chat/ChatWebViewManager.kt
@@ -71,7 +71,11 @@ class ChatWebViewManager(
         offlineView.visibility = View.GONE
         loadingIndicator.visibility = View.VISIBLE
         webView.visibility = View.VISIBLE
-        webView.loadUrl("$baseUrl/portal/chat.html")
+        webView.loadUrl(
+            com.hank.clawlive.util.PortalUrlHelper.withAppLang(
+                webView.context, "$baseUrl/portal/chat.html"
+            )
+        )
     }
 
     fun canGoBack(): Boolean = webView.canGoBack()

--- a/app/src/main/java/com/hank/clawlive/util/LocaleHelper.kt
+++ b/app/src/main/java/com/hank/clawlive/util/LocaleHelper.kt
@@ -1,0 +1,54 @@
+package com.hank.clawlive.util
+
+import android.content.Context
+import android.net.Uri
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.core.os.LocaleListCompat
+import java.util.Locale
+
+object LocaleHelper {
+    private val SUPPORTED = setOf(
+        "en", "zh", "zh-CN", "ja", "ko", "th", "vi", "id",
+        "fr", "es", "de", "ms", "hi", "ar"
+    )
+
+    fun toPortalLang(locale: Locale?): String {
+        if (locale == null) return "en"
+        val lang = locale.language.lowercase()
+        val country = locale.country.uppercase()
+        val script = locale.script
+        if (lang == "zh") {
+            val simplified = script == "Hans" || country == "CN" || country == "SG"
+            return if (simplified) "zh-CN" else "zh"
+        }
+        val normalized = if (lang == "in") "id" else lang
+        return if (normalized in SUPPORTED) normalized else "en"
+    }
+
+    @Suppress("UNUSED_PARAMETER")
+    fun currentPortalLang(context: Context): String {
+        val locales = AppCompatDelegate.getApplicationLocales()
+        val locale = if (!locales.isEmpty) locales.get(0)
+        else LocaleListCompat.getDefault().get(0)
+        return toPortalLang(locale)
+    }
+}
+
+object PortalUrlHelper {
+    fun withAppLang(context: Context, url: String): String =
+        withLang(url, LocaleHelper.currentPortalLang(context))
+
+    fun withLang(url: String, lang: String): String {
+        val uri = Uri.parse(url)
+        val builder = uri.buildUpon().clearQuery()
+        uri.queryParameterNames.forEach { name ->
+            if (name != "lang") {
+                uri.getQueryParameters(name).forEach { value ->
+                    builder.appendQueryParameter(name, value)
+                }
+            }
+        }
+        builder.appendQueryParameter("lang", lang)
+        return builder.build().toString()
+    }
+}


### PR DESCRIPTION
## Summary

Bug reported by Hank 2026-05-13 07:38 TPE: "我 App 設定的語言，其他頁面因為是 WebView 似乎沒有同步 App 的語系設定" — Android per-app language picker affected native screens only; WebView pages stayed on `navigator.language`.

**Root cause**: portal `i18n.js` picks locale by:
1. URL `?lang=` query param (Priority 1, also writes back to localStorage)
2. localStorage `eclaw-language`
3. `navigator.language`

The app never passed a lang hint, so it fell through to `navigator.language`, which inside a WebView doesn't reflect `AppCompatDelegate.setApplicationLocales`.

**Fix**: append `?lang=<portal-code>` at every `loadUrl` site. Approach reviewed by Mac_F (#1) — preferred over `WebSettings.setAcceptLanguage` because portal locale resolution is JS-side, can't see HTTP `Accept-Language`.

## Changes

New `util/LocaleHelper.kt`:
- `LocaleHelper.toPortalLang(Locale)` — Android tag → portal code; falls back to `en` for unsupported locales; `zh-Hans/CN/SG` → `zh-CN`; rest of `zh*` → `zh`; `in` → `id` (Indonesian Android historical tag)
- `LocaleHelper.currentPortalLang(Context)` — reads `AppCompatDelegate.getApplicationLocales()`, falls back to `LocaleListCompat.getDefault()`
- `PortalUrlHelper.withAppLang(Context, url)` — drops any existing `lang` (app locale wins over stale URL hint), then appends current `lang=` via `Uri.Builder` (correct encoding, preserves other params)

5 WebView load points wired up:
- `WebViewActivity.kt:152` — generic portal host (covers most pages via `WebViewActivity.launch(...)` from SettingsActivity / BottomNavHelper)
- `MainActivity.kt:266` — dashboard embed
- `MissionControlActivity.kt:108` — mission.html
- `ChatWebViewManager.kt:74` — chat.html
- `OrgChartBottomSheetFragment.kt:89` — dashboard orgchart embed

## Out of scope (intentional)

- **No `i18n.js` change** — Priority 1 URL plumbing already works portal-side.
- **No server config change** — server lang persistence (`SettingsActivity.syncLanguageToServer`) unaffected.
- **No `onPageFinished` localStorage injection** — URL param is sufficient on first load; if E2E reveals SPA navigation issues, can add as follow-up.
- **No `SettingsActivity` mapping dedup** — existing `when` blocks at L460/L924 could call `LocaleHelper.toPortalLang` but that's a refactor; keeping diff tight for this bug.

## Test plan

Per Hank's directive (#1 review before merge; E2E after merge):

- [x] Mac_F (#1) approach review: ✅ approved A+B path (URL `?lang=`), correctly steered away from `WebSettings.setAcceptLanguage`
- [ ] Manual locale-switch E2E after merge:
  - [ ] Switch app locale to `ja` → open dashboard / kanban / chat / orgchart / mission — verify URL has `lang=ja` + page renders in Japanese
  - [ ] Switch to `en` → same five pages render in English
  - [ ] Switch to `zh-TW` (system) → pages render in traditional Chinese (`lang=zh`)
  - [ ] Existing query-string preservation: open a page that already has `?focus=...` or `?embed=1&deviceId=...` and confirm `&lang=` appended cleanly without breaking device credentials
- [ ] Drift scanner / lint: not applicable (Kotlin-only change, no `i18n.js` keys added)

Refs: `card_1d264ebb9f253af1e0707e45`

🤖 Generated with [Claude Code](https://claude.com/claude-code)