### PR TITLE
feat(mindmap): GET /api/mindmap/graph force-graph projection

### DIFF
--- a/backend/mindmap-graph-projection.js
+++ b/backend/mindmap-graph-projection.js
@@ -1,0 +1,550 @@
+/**
+ * Mindmap force-graph projection — pure mapping functions.
+ *
+ * Spec: docs/spec/mindmap-force-graph.md
+ *
+ * Builds the `{nodes, links}` payload consumed by react-force-graph-2d
+ * (public/portal/mindmap.html). All functions here are pure so the unit
+ * tests in tests/jest/mindmap-graph.test.js can exercise the mapping
+ * without booting express or pg.
+ *
+ * Edge type set (MVP):
+ *   parent          — kanban_cards.parent_card_id
+ *   blocks          — kanban_card_dependencies.dependency_type='blocks'
+ *   owner           — assigned_bots / mission_notes.created_by
+ *   note_on_card    — mindmap_node_anchors cross-correlation (note + kanban_card)
+ *   chat_anchor     — kanban_cards.chat_anchor_message_id + anchor cross-correlation
+ *                     (amendment A from PR #2679 review)
+ *
+ * Edge types reserved for follow-up cards: references, related, tag.
+ */
+
+'use strict';
+
+const SCHEMA_VERSION = 1;
+const LABEL_MAX = 80;
+const TITLE_MAX = 200;
+const SUMMARY_MAX = 240;
+const NODE_LIMIT_DEFAULT = 1000;
+const EDGE_LIMIT_DEFAULT = 2000;
+const NODE_LIMIT_HARD = 2000;
+const EDGE_LIMIT_HARD = 4000;
+
+const PRIORITY_VAL = { P0: 8, P1: 6, P2: 4, P3: 3 };
+
+function clip(s, max) {
+    if (s === null || s === undefined) return '';
+    const str = String(s);
+    return str.length > max ? str.slice(0, max) : str;
+}
+
+function parseBoolFlag(raw, def) {
+    if (raw === undefined || raw === null || raw === '') return def;
+    const s = String(raw).toLowerCase();
+    if (['1', 'true', 'yes', 'y', 'on'].includes(s)) return true;
+    if (['0', 'false', 'no', 'n', 'off'].includes(s)) return false;
+    return def;
+}
+
+function clampInt(raw, def, min, max) {
+    const n = parseInt(raw, 10);
+    if (!Number.isFinite(n)) return def;
+    return Math.max(min, Math.min(max, n));
+}
+
+function parseNumericCreatedBy(v) {
+    if (v === null || v === undefined || v === '') return null;
+    const n = parseInt(v, 10);
+    return Number.isFinite(n) && String(n) === String(v).trim() ? n : null;
+}
+
+function pickOwnerEntityId(card) {
+    const bots = Array.isArray(card.assigned_bots) ? card.assigned_bots : [];
+    if (bots.length > 0 && Number.isFinite(bots[0])) return bots[0];
+    if (Number.isFinite(card.created_by) && card.created_by !== 0) return card.created_by;
+    return null;
+}
+
+function taskVal(priority, isAutomation, status) {
+    let v = PRIORITY_VAL[priority] || 4;
+    if (isAutomation) v += 1;
+    if (status === 'blocked') v += 1;
+    return v;
+}
+
+function buildTaskNode(card, commentCount, noteCount) {
+    const ownerEntityId = pickOwnerEntityId(card);
+    const assigned = (Array.isArray(card.assigned_bots) ? card.assigned_bots : []).filter(Number.isFinite);
+    return {
+        id: `task:${card.id}`,
+        sourceId: card.id,
+        label: clip(card.title, LABEL_MAX),
+        fullTitle: clip(card.title, TITLE_MAX),
+        type: 'task',
+        status: card.status || 'todo',
+        priority: card.priority || 'P2',
+        ownerEntityId,
+        assignedEntityIds: assigned,
+        reviewerEntityId: card.reviewer_entity_id == null ? null : Number(card.reviewer_entity_id),
+        parentCardId: card.parent_card_id || null,
+        isAutomation: !!card.is_automation,
+        archived: !!card.archived,
+        summary: clip((card.description || '').replace(/\s+/g, ' ').trim(), SUMMARY_MAX),
+        commentCount: Number.isFinite(commentCount) ? commentCount : 0,
+        noteCount: Number.isFinite(noteCount) ? noteCount : 0,
+        updatedAt: card.updated_at ? new Date(card.updated_at).toISOString() : null,
+        url: `/portal/kanban.html?card=${encodeURIComponent(card.id)}`,
+        colorKey: `status:${card.status || 'todo'}`,
+        val: taskVal(card.priority, card.is_automation, card.status),
+    };
+}
+
+function buildNoteNode(note) {
+    const ownerEntityId = parseNumericCreatedBy(note.created_by);
+    return {
+        id: `note:${note.id}`,
+        sourceId: note.id,
+        label: clip(note.title, LABEL_MAX),
+        fullTitle: clip(note.title, TITLE_MAX),
+        type: 'note',
+        category: note.category || 'general',
+        ownerEntityId,
+        summary: clip((note.content || '').replace(/\s+/g, ' ').trim(), SUMMARY_MAX),
+        updatedAt: note.updated_at ? new Date(note.updated_at).toISOString() : null,
+        url: `/portal/mission.html?note=${encodeURIComponent(note.id)}`,
+        colorKey: `note:${note.category || 'general'}`,
+        val: 4,
+    };
+}
+
+function buildOwnerNode(entityId, entityRecord) {
+    const label = (entityRecord && (entityRecord.character || entityRecord.name)) || `Entity ${entityId}`;
+    return {
+        id: `owner:${entityId}`,
+        sourceId: String(entityId),
+        label: clip(label, LABEL_MAX),
+        fullTitle: clip(label, TITLE_MAX),
+        type: 'owner',
+        ownerEntityId: entityId,
+        avatar: (entityRecord && entityRecord.avatar) || null,
+        colorKey: 'owner',
+        val: 6,
+    };
+}
+
+function buildChatNode(messageId, displayLabel) {
+    const label = displayLabel || `chat #${String(messageId).slice(0, 8)}`;
+    return {
+        id: `chat:${messageId}`,
+        sourceId: messageId,
+        label: clip(label, LABEL_MAX),
+        fullTitle: clip(label, TITLE_MAX),
+        type: 'chat',
+        url: `/portal/chat.html?msg=${encodeURIComponent(messageId)}`,
+        colorKey: 'chat',
+        val: 3,
+    };
+}
+
+function buildLink({ id, source, target, type, weight, evidence, directional }) {
+    return {
+        id,
+        source,
+        target,
+        type,
+        label: type,
+        weight,
+        directional: !!directional,
+        colorKey: `edge:${type}`,
+        evidence,
+    };
+}
+
+/**
+ * Apply node/edge caps. Drops trailing nodes after `limitNodes` (the caller
+ * is responsible for sorting first), then drops any links whose endpoints
+ * fell off, then caps total links at `limitEdges`. Returns truncation counts.
+ */
+function applyCaps(nodes, links, limitNodes, limitEdges) {
+    let truncatedNodes = 0;
+    let truncatedLinks = 0;
+    if (nodes.length > limitNodes) {
+        truncatedNodes = nodes.length - limitNodes;
+        nodes.length = limitNodes;
+    }
+    const keptIds = new Set(nodes.map(n => n.id));
+    const survivingLinks = links.filter(l => keptIds.has(l.source) && keptIds.has(l.target));
+    truncatedLinks += links.length - survivingLinks.length;
+    links.length = 0;
+    links.push(...survivingLinks);
+    if (links.length > limitEdges) {
+        truncatedLinks += links.length - limitEdges;
+        links.length = limitEdges;
+    }
+    return { truncatedNodes, truncatedLinks };
+}
+
+/**
+ * Sort task cards before truncation per spec §8.2: non-archived first,
+ * non-done first, P0→P3, then most recently updated. Mutates the array.
+ */
+function sortCardsForCap(cards) {
+    const prio = { P0: 0, P1: 1, P2: 2, P3: 3 };
+    cards.sort((a, b) => {
+        const aArch = a.archived ? 1 : 0, bArch = b.archived ? 1 : 0;
+        if (aArch !== bArch) return aArch - bArch;
+        const aDone = a.status === 'done' ? 1 : 0, bDone = b.status === 'done' ? 1 : 0;
+        if (aDone !== bDone) return aDone - bDone;
+        const ap = prio[a.priority] ?? 4, bp = prio[b.priority] ?? 4;
+        if (ap !== bp) return ap - bp;
+        const at = a.updated_at ? new Date(a.updated_at).getTime() : 0;
+        const bt = b.updated_at ? new Date(b.updated_at).getTime() : 0;
+        return bt - at;
+    });
+}
+
+/**
+ * Parse query params off the request, returning a normalized options object.
+ * `isDeviceAuth` toggles the default scope (device for deviceSecret,
+ * entity for botSecret).
+ */
+function parseGraphOptions(query, { isDeviceAuth, callerEntityId }) {
+    const scopeRaw = (query.scope || '').toString().toLowerCase();
+    const scope = ['device', 'entity'].includes(scopeRaw)
+        ? scopeRaw
+        : (isDeviceAuth ? 'device' : 'entity');
+    const includeOwnersRaw = (query.includeOwners || '').toString().toLowerCase();
+    const includeOwners = ['none', 'active', 'all'].includes(includeOwnersRaw)
+        ? includeOwnersRaw : 'active';
+    return {
+        scope,
+        callerEntityId,
+        includeArchived: parseBoolFlag(query.includeArchived, false),
+        includeDone: parseBoolFlag(query.includeDone, false),
+        includeNotes: parseBoolFlag(query.includeNotes, true),
+        includeOwners,
+        includeNeighbors: parseBoolFlag(query.includeNeighbors, scope === 'entity'),
+        includeTextFallbackRefs: parseBoolFlag(query.includeTextFallbackRefs, false),
+        limitNodes: clampInt(query.limitNodes, NODE_LIMIT_DEFAULT, 1, NODE_LIMIT_HARD),
+        limitEdges: clampInt(query.limitEdges, EDGE_LIMIT_DEFAULT, 1, EDGE_LIMIT_HARD),
+    };
+}
+
+/**
+ * Core projection — pure. Takes pre-fetched DB rows and the device entity
+ * map, returns the final {nodes, links, stats} payload. The route in
+ * mindmap.js is responsible for running the SQL batches and supplying these
+ * inputs; this function does the mapping.
+ */
+function projectGraph({
+    cards,
+    initialCardIds,
+    depRows,
+    commentCounts,
+    noteCounts,
+    notes,
+    anchorRows,
+    entityMap,
+    options,
+}) {
+    const commentByCard = new Map(commentCounts.map(r => [r.card_id, r.cnt]));
+    const noteByCard = new Map(noteCounts.map(r => [r.card_id, r.cnt]));
+
+    const cardIds = new Set(cards.map(c => c.id));
+    const noteIds = new Set(notes.map(n => n.id));
+
+    // Group anchors by mindmap node so each node's anchor-set is queryable.
+    const anchorsByNode = new Map();
+    for (const a of anchorRows) {
+        if (!anchorsByNode.has(a.node_id)) anchorsByNode.set(a.node_id, []);
+        anchorsByNode.get(a.node_id).push(a);
+    }
+
+    const nodes = [];
+    const links = [];
+    const nodeIdSet = new Set();
+    const ownerNeed = new Set();
+    const sourceCounts = { task: 0, note: 0, owner: 0, chat: 0 };
+
+    // ── Task nodes ──
+    for (const c of cards) {
+        const node = buildTaskNode(c, commentByCard.get(c.id) || 0, noteByCard.get(c.id) || 0);
+        nodes.push(node);
+        nodeIdSet.add(node.id);
+        sourceCounts.task++;
+        const owner = pickOwnerEntityId(c);
+        if (owner != null) ownerNeed.add(owner);
+        for (const eid of (Array.isArray(c.assigned_bots) ? c.assigned_bots : [])) {
+            if (Number.isFinite(eid)) ownerNeed.add(eid);
+        }
+        if (c.reviewer_entity_id != null) ownerNeed.add(Number(c.reviewer_entity_id));
+    }
+
+    // ── Note nodes ──
+    if (options.includeNotes) {
+        for (const n of notes) {
+            const node = buildNoteNode(n);
+            nodes.push(node);
+            nodeIdSet.add(node.id);
+            sourceCounts.note++;
+            if (node.ownerEntityId != null) ownerNeed.add(node.ownerEntityId);
+        }
+    }
+
+    // ── Owner nodes ──
+    if (options.includeOwners !== 'none') {
+        const ownerCandidates = options.includeOwners === 'all'
+            ? new Set([
+                ...ownerNeed,
+                ...Object.keys(entityMap || {}).map(k => parseInt(k, 10)).filter(Number.isFinite),
+            ])
+            : ownerNeed;
+        for (const eid of ownerCandidates) {
+            const id = `owner:${eid}`;
+            if (nodeIdSet.has(id)) continue;
+            nodes.push(buildOwnerNode(eid, entityMap && entityMap[eid]));
+            nodeIdSet.add(id);
+            sourceCounts.owner++;
+        }
+    }
+
+    // ── Chat nodes ── (amendment A: chat_message becomes a first-class graph node)
+    // Source 1: kanban_cards.chat_anchor_message_id pinned at file-time.
+    // Source 2: mindmap_node_anchors cross-correlation (a mindmap_node bridges
+    //           note↔chat or card↔chat anchors).
+    const chatMsgIds = new Set();
+    for (const c of cards) {
+        if (c.chat_anchor_message_id) chatMsgIds.add(c.chat_anchor_message_id);
+    }
+    for (const [, anchors] of anchorsByNode) {
+        const chatAnchors = anchors.filter(a => a.anchor_type === 'chat_message');
+        if (chatAnchors.length === 0) continue;
+        const hasIncluded = anchors.some(a =>
+            (a.anchor_type === 'kanban_card' && cardIds.has(a.anchor_ref)) ||
+            (a.anchor_type === 'note' && noteIds.has(a.anchor_ref))
+        );
+        if (!hasIncluded) continue;
+        for (const ca of chatAnchors) chatMsgIds.add(ca.anchor_ref);
+    }
+    for (const msgId of chatMsgIds) {
+        const id = `chat:${msgId}`;
+        if (nodeIdSet.has(id)) continue;
+        nodes.push(buildChatNode(msgId));
+        nodeIdSet.add(id);
+        sourceCounts.chat++;
+    }
+
+    // ── Edges ──
+    const edgeCounts = { parent: 0, blocks: 0, owner: 0, note_on_card: 0, chat_anchor: 0 };
+
+    // 1. Parent edges (only when both endpoints in result set)
+    for (const c of cards) {
+        if (!c.parent_card_id || !cardIds.has(c.parent_card_id)) continue;
+        links.push(buildLink({
+            id: `parent:${c.parent_card_id}:${c.id}`,
+            source: `task:${c.parent_card_id}`,
+            target: `task:${c.id}`,
+            type: 'parent',
+            weight: 2,
+            evidence: 'kanban_cards.parent_card_id',
+            directional: true,
+        }));
+        edgeCounts.parent++;
+    }
+
+    // 2. Blocks edges (kanban_card_dependencies)
+    for (const d of depRows) {
+        if (!cardIds.has(d.card_id) || !cardIds.has(d.depends_on_card_id)) continue;
+        if ((d.dependency_type || 'blocks') !== 'blocks') continue;
+        links.push(buildLink({
+            id: `blocks:${d.depends_on_card_id}:${d.card_id}`,
+            source: `task:${d.depends_on_card_id}`,
+            target: `task:${d.card_id}`,
+            type: 'blocks',
+            weight: 3,
+            evidence: 'kanban_card_dependencies',
+            directional: true,
+        }));
+        edgeCounts.blocks++;
+    }
+
+    // 3. Owner edges
+    if (options.includeOwners !== 'none') {
+        for (const c of cards) {
+            const bots = Array.isArray(c.assigned_bots) ? c.assigned_bots : [];
+            for (const eid of bots) {
+                if (!Number.isFinite(eid) || !nodeIdSet.has(`owner:${eid}`)) continue;
+                links.push(buildLink({
+                    id: `owner:${eid}:task:${c.id}`,
+                    source: `owner:${eid}`,
+                    target: `task:${c.id}`,
+                    type: 'owner',
+                    weight: 1,
+                    evidence: 'kanban_cards.assigned_bots',
+                    directional: false,
+                }));
+                edgeCounts.owner++;
+            }
+        }
+        for (const n of notes) {
+            const eid = parseNumericCreatedBy(n.created_by);
+            if (eid == null || !nodeIdSet.has(`owner:${eid}`)) continue;
+            links.push(buildLink({
+                id: `owner:${eid}:note:${n.id}`,
+                source: `owner:${eid}`,
+                target: `note:${n.id}`,
+                type: 'owner',
+                weight: 1,
+                evidence: 'mission_notes.created_by',
+                directional: false,
+            }));
+            edgeCounts.owner++;
+        }
+    }
+
+    // 4. note_on_card edges via mindmap_node_anchors cross-correlation
+    const seenNoteCard = new Set();
+    for (const [, anchors] of anchorsByNode) {
+        const cardAnchors = anchors.filter(a => a.anchor_type === 'kanban_card');
+        const noteAnchors = anchors.filter(a => a.anchor_type === 'note');
+        if (cardAnchors.length === 0 || noteAnchors.length === 0) continue;
+        for (const na of noteAnchors) {
+            if (!nodeIdSet.has(`note:${na.anchor_ref}`)) continue;
+            for (const ca of cardAnchors) {
+                if (!nodeIdSet.has(`task:${ca.anchor_ref}`)) continue;
+                const key = `${na.anchor_ref}|${ca.anchor_ref}`;
+                if (seenNoteCard.has(key)) continue;
+                seenNoteCard.add(key);
+                links.push(buildLink({
+                    id: `note_on_card:${na.anchor_ref}:${ca.anchor_ref}`,
+                    source: `note:${na.anchor_ref}`,
+                    target: `task:${ca.anchor_ref}`,
+                    type: 'note_on_card',
+                    weight: 2,
+                    evidence: 'mindmap_node_anchors',
+                    directional: false,
+                }));
+                edgeCounts.note_on_card++;
+            }
+        }
+    }
+
+    // 5. chat_anchor edges — amendment A
+    //    5a) kanban_cards.chat_anchor_message_id direct field
+    for (const c of cards) {
+        const mid = c.chat_anchor_message_id;
+        if (!mid || !nodeIdSet.has(`chat:${mid}`)) continue;
+        links.push(buildLink({
+            id: `chat_anchor:task:${c.id}:${mid}`,
+            source: `task:${c.id}`,
+            target: `chat:${mid}`,
+            type: 'chat_anchor',
+            weight: 1,
+            evidence: 'kanban_cards.chat_anchor_message_id',
+            directional: false,
+        }));
+        edgeCounts.chat_anchor++;
+    }
+    //    5b) mindmap_node_anchors cross-correlation (note↔chat / card↔chat)
+    const seenChat = new Set();
+    for (const [, anchors] of anchorsByNode) {
+        const chatAnchors = anchors.filter(a => a.anchor_type === 'chat_message');
+        if (chatAnchors.length === 0) continue;
+        const noteAnchors = anchors.filter(a => a.anchor_type === 'note');
+        const cardAnchors = anchors.filter(a => a.anchor_type === 'kanban_card');
+        for (const ca of chatAnchors) {
+            const chatId = `chat:${ca.anchor_ref}`;
+            if (!nodeIdSet.has(chatId)) continue;
+            for (const na of noteAnchors) {
+                const src = `note:${na.anchor_ref}`;
+                if (!nodeIdSet.has(src)) continue;
+                const key = `${src}|${chatId}`;
+                if (seenChat.has(key)) continue;
+                seenChat.add(key);
+                links.push(buildLink({
+                    id: `chat_anchor:note:${na.anchor_ref}:${ca.anchor_ref}`,
+                    source: src,
+                    target: chatId,
+                    type: 'chat_anchor',
+                    weight: 1,
+                    evidence: 'mindmap_node_anchors',
+                    directional: false,
+                }));
+                edgeCounts.chat_anchor++;
+            }
+            for (const cda of cardAnchors) {
+                const src = `task:${cda.anchor_ref}`;
+                if (!nodeIdSet.has(src)) continue;
+                const key = `${src}|${chatId}`;
+                if (seenChat.has(key)) continue;
+                seenChat.add(key);
+                links.push(buildLink({
+                    id: `chat_anchor:task:${cda.anchor_ref}:${ca.anchor_ref}`,
+                    source: src,
+                    target: chatId,
+                    type: 'chat_anchor',
+                    weight: 1,
+                    evidence: 'mindmap_node_anchors',
+                    directional: false,
+                }));
+                edgeCounts.chat_anchor++;
+            }
+        }
+    }
+
+    // ── Caps ──
+    const { truncatedNodes, truncatedLinks } = applyCaps(
+        nodes, links, options.limitNodes, options.limitEdges
+    );
+
+    // After truncation, re-tally source counts so they match `nodes`.
+    const finalSourceCounts = { task: 0, note: 0, owner: 0, chat: 0 };
+    for (const n of nodes) {
+        if (finalSourceCounts[n.type] !== undefined) finalSourceCounts[n.type]++;
+    }
+    const finalEdgeCounts = { parent: 0, blocks: 0, owner: 0, note_on_card: 0, chat_anchor: 0 };
+    for (const l of links) {
+        if (finalEdgeCounts[l.type] !== undefined) finalEdgeCounts[l.type]++;
+    }
+
+    return {
+        nodes,
+        links,
+        stats: {
+            nodeCount: nodes.length,
+            linkCount: links.length,
+            truncated: truncatedNodes > 0 || truncatedLinks > 0,
+            truncatedNodes,
+            truncatedLinks,
+            sourceCounts: finalSourceCounts,
+            edgeCounts: finalEdgeCounts,
+            initialCardScope: initialCardIds.size,
+        },
+    };
+}
+
+module.exports = {
+    SCHEMA_VERSION,
+    NODE_LIMIT_DEFAULT,
+    EDGE_LIMIT_DEFAULT,
+    NODE_LIMIT_HARD,
+    EDGE_LIMIT_HARD,
+    LABEL_MAX,
+    SUMMARY_MAX,
+    PRIORITY_VAL,
+    clip,
+    parseBoolFlag,
+    clampInt,
+    parseNumericCreatedBy,
+    pickOwnerEntityId,
+    taskVal,
+    buildTaskNode,
+    buildNoteNode,
+    buildOwnerNode,
+    buildChatNode,
+    buildLink,
+    applyCaps,
+    sortCardsForCap,
+    parseGraphOptions,
+    projectGraph,
+};

--- a/backend/mindmap.js
+++ b/backend/mindmap.js
@@ -33,6 +33,7 @@ const express = require('express');
 const safeEqual = require('./safe-equal');
 const { callAnthropic } = require('./anthropic-client');
 const mindmapMirror = require('./mindmap-mirror');
+const graphProjection = require('./mindmap-graph-projection');
 
 const NODE_TYPES = new Set(['domain', 'topic', 'leaf', 'concept']);
 const EDGE_TYPES = new Set(['relates_to', 'causes', 'extends', 'opposes', 'parent_of']);
@@ -845,11 +846,189 @@ function createMindmapModule(devices) {
         }
     });
 
+    // ─── GET /graph ─────────────────────────────────────────────────────────
+    // Force-graph projection (react-force-graph-2d native shape).
+    // Spec: docs/spec/mindmap-force-graph.md (PR #2679).
+    //
+    // Returns {success, graph:{nodes, links}, stats, meta}.
+    // Composes data across kanban_cards + kanban_card_dependencies +
+    // kanban_comments/notes + mission_notes + mindmap_node_anchors so the
+    // frontend gets a single payload usable by ForceGraph2D directly.
+    router.get('/graph', async (req, res) => {
+        const deviceId = authenticate(req, res);
+        if (!deviceId) return;
+        if (!requirePool(res)) return;
+
+        const callerEntityId = getEntityId(req);
+        const isDeviceAuth = !!req.query.deviceSecret;
+        const options = graphProjection.parseGraphOptions(req.query, { isDeviceAuth, callerEntityId });
+        if (options.scope === 'entity' && options.callerEntityId == null) {
+            return res.status(400).json({
+                success: false,
+                error: 'scope=entity requires entityId',
+            });
+        }
+
+        try {
+            // 1) Cards in scope. We over-fetch by 2× node limit so the
+            //    deterministic sort+truncate happens in projectGraph rather
+            //    than at the SQL boundary (keeps test fixtures simpler).
+            const cardWhere = ['device_id = $1'];
+            const cardArgs = [deviceId];
+            let p = 2;
+            if (!options.includeArchived) cardWhere.push('archived = FALSE');
+            if (!options.includeDone) cardWhere.push("status <> 'done'");
+            if (options.scope === 'entity') {
+                cardWhere.push(
+                    `(assigned_bots @> $${p}::jsonb OR created_by = $${p + 1} OR reviewer_entity_id = $${p + 1})`
+                );
+                cardArgs.push(JSON.stringify([options.callerEntityId]), options.callerEntityId);
+                p += 2;
+            }
+            const hardCardCap = Math.min(options.limitNodes * 2, graphProjection.NODE_LIMIT_HARD * 2);
+            const cardSql = `
+                SELECT id, title, description, priority, status, parent_card_id, is_automation,
+                       assigned_bots, created_by, reviewer_entity_id, chat_anchor_message_id,
+                       archived, updated_at
+                FROM kanban_cards
+                WHERE ${cardWhere.join(' AND ')}
+                ORDER BY
+                    CASE WHEN archived THEN 1 ELSE 0 END,
+                    CASE WHEN status = 'done' THEN 1 ELSE 0 END,
+                    CASE priority WHEN 'P0' THEN 0 WHEN 'P1' THEN 1 WHEN 'P2' THEN 2 WHEN 'P3' THEN 3 ELSE 4 END,
+                    updated_at DESC NULLS LAST
+                LIMIT ${hardCardCap}
+            `;
+            const cardsResult = await pool.query(cardSql, cardArgs);
+            let cards = cardsResult.rows;
+            const initialCardIds = new Set(cards.map(c => c.id));
+
+            // 1a) Neighbor expansion (entity scope): pull parent + dep
+            //     neighbors that aren't already in scope so cross-edges resolve.
+            let neighborIds = new Set();
+            if (options.includeNeighbors && cards.length > 0) {
+                for (const c of cards) {
+                    if (c.parent_card_id && !initialCardIds.has(c.parent_card_id)) {
+                        neighborIds.add(c.parent_card_id);
+                    }
+                }
+            }
+
+            // 2) Dependencies (also seeds neighborIds)
+            const depsResult = cards.length === 0 ? { rows: [] } : await pool.query(
+                `SELECT card_id, depends_on_card_id, dependency_type
+                 FROM kanban_card_dependencies
+                 WHERE device_id = $1
+                   AND (card_id = ANY($2::varchar[]) OR depends_on_card_id = ANY($2::varchar[]))`,
+                [deviceId, [...initialCardIds]]
+            );
+            if (options.includeNeighbors) {
+                for (const d of depsResult.rows) {
+                    if (!initialCardIds.has(d.card_id)) neighborIds.add(d.card_id);
+                    if (!initialCardIds.has(d.depends_on_card_id)) neighborIds.add(d.depends_on_card_id);
+                }
+            }
+
+            // 1b) Fetch neighbor card rows
+            if (neighborIds.size > 0) {
+                const neighborRows = await pool.query(
+                    `SELECT id, title, description, priority, status, parent_card_id, is_automation,
+                            assigned_bots, created_by, reviewer_entity_id, chat_anchor_message_id,
+                            archived, updated_at
+                     FROM kanban_cards
+                     WHERE device_id = $1 AND id = ANY($2::varchar[])`,
+                    [deviceId, [...neighborIds]]
+                );
+                cards = cards.concat(neighborRows.rows);
+            }
+
+            const allCardIds = [...new Set(cards.map(c => c.id))];
+
+            // 3) Aggregate counts
+            const [commentCounts, noteCounts] = allCardIds.length === 0
+                ? [{ rows: [] }, { rows: [] }]
+                : await Promise.all([
+                    pool.query(
+                        `SELECT card_id, COUNT(*)::int AS cnt FROM kanban_comments
+                         WHERE device_id = $1 AND card_id = ANY($2::varchar[]) GROUP BY card_id`,
+                        [deviceId, allCardIds]
+                    ),
+                    pool.query(
+                        `SELECT card_id, COUNT(*)::int AS cnt FROM kanban_notes
+                         WHERE device_id = $1 AND card_id = ANY($2::varchar[]) GROUP BY card_id`,
+                        [deviceId, allCardIds]
+                    ),
+                ]);
+
+            // 4) Mission notes
+            let notes = [];
+            if (options.includeNotes) {
+                const noteWhere = ['device_id = $1'];
+                const noteArgs = [deviceId];
+                let np = 2;
+                if (options.scope === 'entity') {
+                    noteWhere.push(`created_by = $${np}`);
+                    noteArgs.push(String(options.callerEntityId));
+                    np++;
+                }
+                const noteSql = `
+                    SELECT id, title, content, category, created_by, updated_at
+                    FROM mission_notes
+                    WHERE ${noteWhere.join(' AND ')}
+                    ORDER BY updated_at DESC NULLS LAST
+                    LIMIT ${hardCardCap}
+                `;
+                const notesResult = await pool.query(noteSql, noteArgs);
+                notes = notesResult.rows;
+            }
+
+            // 5) Mindmap anchors (cross-correlation: note↔card, note↔chat, card↔chat)
+            const anchorsResult = await pool.query(
+                `SELECT node_id, anchor_type, anchor_ref, display_label
+                 FROM mindmap_node_anchors
+                 WHERE device_id = $1 AND anchor_type IN ('kanban_card','note','chat_message')`,
+                [deviceId]
+            );
+
+            // Sort cards before projection so cap-truncation prefers active P0 work.
+            graphProjection.sortCardsForCap(cards);
+
+            const projection = graphProjection.projectGraph({
+                cards,
+                initialCardIds,
+                depRows: depsResult.rows,
+                commentCounts: commentCounts.rows,
+                noteCounts: noteCounts.rows,
+                notes,
+                anchorRows: anchorsResult.rows,
+                entityMap: (devices && devices[deviceId] && devices[deviceId].entities) || {},
+                options,
+            });
+
+            res.json({
+                success: true,
+                graph: { nodes: projection.nodes, links: projection.links },
+                stats: projection.stats,
+                meta: {
+                    generatedAt: new Date().toISOString(),
+                    deviceId,
+                    scope: options.scope,
+                    entityId: options.scope === 'entity' ? options.callerEntityId : null,
+                    schemaVersion: graphProjection.SCHEMA_VERSION,
+                    layoutStorageKey: `mindmap:force-layout:v1:${deviceId}:${options.scope}:${options.scope === 'entity' ? options.callerEntityId : 'owner'}`,
+                },
+            });
+        } catch (err) {
+            console.error('[Mindmap] GET /graph failed:', err.message);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
     return {
         router,
         initMindmapTables,
         // Exported for unit tests:
-        _internal: { isUuid, clampStr, NODE_TYPES, EDGE_TYPES, ANCHOR_TYPES, MAX_TRAVERSE_DEPTH, MAX_TRAVERSE_NODES },
+        _internal: { isUuid, clampStr, NODE_TYPES, EDGE_TYPES, ANCHOR_TYPES, MAX_TRAVERSE_DEPTH, MAX_TRAVERSE_NODES, graphProjection },
     };
 }
 

--- a/backend/tests/jest/mindmap-graph.test.js
+++ b/backend/tests/jest/mindmap-graph.test.js
@@ -1,0 +1,462 @@
+/**
+ * GET /api/mindmap/graph — force-graph projection
+ *
+ * Two layers:
+ *   1) Pure projection unit tests against mindmap-graph-projection.js
+ *      (no express, no pg) — covers node/edge mapping, caps, scope flags.
+ *   2) HTTP-level tests against the mounted route via supertest with a
+ *      sequenced mockQuery, matching the pattern used by kanban-mindmap.test.js.
+ *
+ * Amendment A (chat_anchor edges) and dual-auth scope behavior are both
+ * verified — these were the two extensions added on top of the base spec
+ * during the PR #2679 review.
+ */
+
+const projection = require('../../mindmap-graph-projection');
+
+// ─── Layer 1: pure projection unit tests ─────────────────────────────────
+describe('mindmap-graph-projection — pure helpers', () => {
+    test('parseBoolFlag accepts truthy and falsy spellings, falls back to default', () => {
+        expect(projection.parseBoolFlag('true', false)).toBe(true);
+        expect(projection.parseBoolFlag('1', false)).toBe(true);
+        expect(projection.parseBoolFlag('YES', false)).toBe(true);
+        expect(projection.parseBoolFlag('false', true)).toBe(false);
+        expect(projection.parseBoolFlag('no', true)).toBe(false);
+        expect(projection.parseBoolFlag('', true)).toBe(true);
+        expect(projection.parseBoolFlag(undefined, false)).toBe(false);
+        expect(projection.parseBoolFlag('garbage', true)).toBe(true);
+    });
+
+    test('clampInt clamps and falls back', () => {
+        expect(projection.clampInt('500', 100, 1, 1000)).toBe(500);
+        expect(projection.clampInt('5000', 100, 1, 1000)).toBe(1000);
+        expect(projection.clampInt('-5', 100, 1, 1000)).toBe(1);
+        expect(projection.clampInt(undefined, 100, 1, 1000)).toBe(100);
+        expect(projection.clampInt('not-a-number', 100, 1, 1000)).toBe(100);
+    });
+
+    test('parseNumericCreatedBy distinguishes "2" from "user"', () => {
+        expect(projection.parseNumericCreatedBy('2')).toBe(2);
+        expect(projection.parseNumericCreatedBy('0')).toBe(0);
+        expect(projection.parseNumericCreatedBy('user')).toBeNull();
+        expect(projection.parseNumericCreatedBy('system')).toBeNull();
+        expect(projection.parseNumericCreatedBy(null)).toBeNull();
+        expect(projection.parseNumericCreatedBy('')).toBeNull();
+    });
+
+    test('pickOwnerEntityId prefers first assigned bot, falls back to created_by', () => {
+        expect(projection.pickOwnerEntityId({ assigned_bots: [5, 2], created_by: 1 })).toBe(5);
+        expect(projection.pickOwnerEntityId({ assigned_bots: [], created_by: 1 })).toBe(1);
+        expect(projection.pickOwnerEntityId({ assigned_bots: [], created_by: 0 })).toBeNull();
+        expect(projection.pickOwnerEntityId({ assigned_bots: null, created_by: null })).toBeNull();
+    });
+
+    test('taskVal weighted by priority, automation, blocked', () => {
+        expect(projection.taskVal('P0', false, 'todo')).toBe(8);
+        expect(projection.taskVal('P1', false, 'todo')).toBe(6);
+        expect(projection.taskVal('P2', true, 'todo')).toBe(5);
+        expect(projection.taskVal('P3', false, 'blocked')).toBe(4);
+        expect(projection.taskVal('P0', true, 'blocked')).toBe(10);
+        expect(projection.taskVal(undefined, false, 'todo')).toBe(4);
+    });
+
+    test('buildTaskNode produces forced shape with prefixed id + deep link', () => {
+        const node = projection.buildTaskNode({
+            id: 'card_abc123',
+            title: '[P1] Fix rental refund',
+            description: '   Implement   second-level\nrefunds...   ',
+            priority: 'P1',
+            status: 'in_progress',
+            parent_card_id: null,
+            assigned_bots: [2, 5],
+            created_by: 1,
+            reviewer_entity_id: 2,
+            is_automation: false,
+            archived: false,
+            chat_anchor_message_id: 'msg-xyz',
+            updated_at: '2026-05-13T01:45:00.000Z',
+        }, 4, 1);
+        expect(node.id).toBe('task:card_abc123');
+        expect(node.sourceId).toBe('card_abc123');
+        expect(node.type).toBe('task');
+        expect(node.status).toBe('in_progress');
+        expect(node.priority).toBe('P1');
+        expect(node.ownerEntityId).toBe(2);
+        expect(node.assignedEntityIds).toEqual([2, 5]);
+        expect(node.reviewerEntityId).toBe(2);
+        expect(node.commentCount).toBe(4);
+        expect(node.noteCount).toBe(1);
+        expect(node.summary).toBe('Implement second-level refunds...');
+        expect(node.summary.length).toBeLessThanOrEqual(240);
+        expect(node.url).toBe('/portal/kanban.html?card=card_abc123');
+        expect(node.colorKey).toBe('status:in_progress');
+        expect(node.val).toBe(6);
+    });
+
+    test('buildNoteNode maps numeric created_by to ownerEntityId', () => {
+        const numeric = projection.buildNoteNode({
+            id: 'note_def',
+            title: 'Spec note',
+            content: 'See spec.',
+            category: 'spec',
+            created_by: '2',
+            updated_at: '2026-05-13T00:00:00Z',
+        });
+        expect(numeric.id).toBe('note:note_def');
+        expect(numeric.type).toBe('note');
+        expect(numeric.ownerEntityId).toBe(2);
+        expect(numeric.category).toBe('spec');
+        expect(numeric.url).toBe('/portal/mission.html?note=note_def');
+
+        const stringOwner = projection.buildNoteNode({
+            id: 'note_zzz',
+            title: 'User note',
+            content: '',
+            category: 'general',
+            created_by: 'user',
+        });
+        expect(stringOwner.ownerEntityId).toBeNull();
+    });
+
+    test('buildOwnerNode uses entity record character name when available', () => {
+        const node = projection.buildOwnerNode(2, { character: 'LOBSTER', avatar: 'http://a.png' });
+        expect(node.id).toBe('owner:2');
+        expect(node.label).toBe('LOBSTER');
+        expect(node.avatar).toBe('http://a.png');
+        expect(node.type).toBe('owner');
+        const fallback = projection.buildOwnerNode(99, undefined);
+        expect(fallback.label).toBe('Entity 99');
+    });
+
+    test('buildChatNode produces chat:<id> with deep link', () => {
+        const node = projection.buildChatNode('msg-abc12345', null);
+        expect(node.id).toBe('chat:msg-abc12345');
+        expect(node.type).toBe('chat');
+        expect(node.url).toBe('/portal/chat.html?msg=msg-abc12345');
+    });
+
+    test('applyCaps drops trailing nodes and orphaned links', () => {
+        const nodes = [
+            { id: 'a' }, { id: 'b' }, { id: 'c' }, { id: 'd' },
+        ];
+        const links = [
+            { source: 'a', target: 'b' },
+            { source: 'c', target: 'd' },
+            { source: 'b', target: 'd' },
+        ];
+        const r = projection.applyCaps(nodes, links, 2, 10);
+        expect(nodes.map(n => n.id)).toEqual(['a', 'b']);
+        expect(r.truncatedNodes).toBe(2);
+        expect(links).toEqual([{ source: 'a', target: 'b' }]);
+        expect(r.truncatedLinks).toBe(2);
+    });
+
+    test('parseGraphOptions defaults scope from auth type', () => {
+        const dev = projection.parseGraphOptions({}, { isDeviceAuth: true, callerEntityId: null });
+        expect(dev.scope).toBe('device');
+        expect(dev.includeNeighbors).toBe(false);
+        expect(dev.includeNotes).toBe(true);
+
+        const ent = projection.parseGraphOptions({}, { isDeviceAuth: false, callerEntityId: 2 });
+        expect(ent.scope).toBe('entity');
+        expect(ent.callerEntityId).toBe(2);
+        expect(ent.includeNeighbors).toBe(true);
+
+        const explicit = projection.parseGraphOptions(
+            { scope: 'entity', includeNotes: 'false', limitNodes: '20', limitEdges: '40' },
+            { isDeviceAuth: true, callerEntityId: 2 }
+        );
+        expect(explicit.scope).toBe('entity');
+        expect(explicit.includeNotes).toBe(false);
+        expect(explicit.limitNodes).toBe(20);
+        expect(explicit.limitEdges).toBe(40);
+    });
+
+    test('projectGraph wires parent + blocks + owner edges', () => {
+        const cards = [
+            { id: 'card_p', title: 'parent', description: '', priority: 'P0', status: 'in_progress', parent_card_id: null, is_automation: false, assigned_bots: [2], created_by: 1, reviewer_entity_id: null, chat_anchor_message_id: null, archived: false, updated_at: '2026-05-13T00:00:00Z' },
+            { id: 'card_c', title: 'child',  description: '', priority: 'P1', status: 'todo',        parent_card_id: 'card_p', is_automation: false, assigned_bots: [5], created_by: 2, reviewer_entity_id: 1, chat_anchor_message_id: null, archived: false, updated_at: '2026-05-13T00:00:00Z' },
+        ];
+        const initialCardIds = new Set(['card_p', 'card_c']);
+        const result = projection.projectGraph({
+            cards,
+            initialCardIds,
+            depRows: [
+                { card_id: 'card_c', depends_on_card_id: 'card_p', dependency_type: 'blocks' },
+            ],
+            commentCounts: [{ card_id: 'card_p', cnt: 3 }],
+            noteCounts: [],
+            notes: [],
+            anchorRows: [],
+            entityMap: {
+                2: { character: 'LOBSTER' },
+                5: { character: 'Hermes' },
+                1: { character: 'Mac_F' },
+            },
+            options: projection.parseGraphOptions({}, { isDeviceAuth: true, callerEntityId: null }),
+        });
+
+        const ids = result.nodes.map(n => n.id).sort();
+        // 2 tasks, 3 owners (entities 1, 2, 5 — needed by assigned/reviewer/owner)
+        expect(ids).toEqual(expect.arrayContaining(['task:card_p', 'task:card_c', 'owner:1', 'owner:2', 'owner:5']));
+
+        const edgeTypes = result.links.map(l => l.type).sort();
+        expect(edgeTypes).toContain('parent');
+        expect(edgeTypes).toContain('blocks');
+        expect(edgeTypes).toContain('owner');
+
+        const parentEdge = result.links.find(l => l.type === 'parent');
+        expect(parentEdge.source).toBe('task:card_p');
+        expect(parentEdge.target).toBe('task:card_c');
+        expect(parentEdge.directional).toBe(true);
+
+        const blocksEdge = result.links.find(l => l.type === 'blocks');
+        // "card_p blocks card_c" semantics — source is the prerequisite.
+        expect(blocksEdge.source).toBe('task:card_p');
+        expect(blocksEdge.target).toBe('task:card_c');
+
+        expect(result.stats.edgeCounts.parent).toBe(1);
+        expect(result.stats.edgeCounts.blocks).toBe(1);
+        expect(result.stats.edgeCounts.owner).toBeGreaterThanOrEqual(2);
+    });
+
+    test('projectGraph emits chat_anchor edges (amendment A)', () => {
+        const cards = [
+            { id: 'card_a', title: 'pinned to chat', description: '', priority: 'P1', status: 'todo', parent_card_id: null, is_automation: false, assigned_bots: [2], created_by: 1, reviewer_entity_id: null, chat_anchor_message_id: 'msg-pinned', archived: false, updated_at: null },
+        ];
+        const result = projection.projectGraph({
+            cards,
+            initialCardIds: new Set(['card_a']),
+            depRows: [],
+            commentCounts: [],
+            noteCounts: [],
+            notes: [
+                { id: 'note_a', title: 'cross-linked note', content: '', category: 'general', created_by: '2', updated_at: null },
+            ],
+            anchorRows: [
+                // mindmap_node that bridges note_a + chat msg-mirror + card_a
+                { node_id: 'mm-1', anchor_type: 'note',          anchor_ref: 'note_a',     display_label: null },
+                { node_id: 'mm-1', anchor_type: 'chat_message', anchor_ref: 'msg-mirror', display_label: null },
+                { node_id: 'mm-1', anchor_type: 'kanban_card',  anchor_ref: 'card_a',     display_label: null },
+            ],
+            entityMap: { 2: { character: 'LOBSTER' }, 1: { character: 'Mac_F' } },
+            options: projection.parseGraphOptions(
+                { includeNotes: 'true' },
+                { isDeviceAuth: true, callerEntityId: null }
+            ),
+        });
+
+        const chatNodes = result.nodes.filter(n => n.type === 'chat').map(n => n.id).sort();
+        expect(chatNodes).toEqual(['chat:msg-mirror', 'chat:msg-pinned']);
+
+        const chatEdges = result.links.filter(l => l.type === 'chat_anchor');
+        // Expect: task:card_a → chat:msg-pinned (direct field)
+        //          task:card_a → chat:msg-mirror (anchor cross-correlation)
+        //          note:note_a → chat:msg-mirror (anchor cross-correlation)
+        const pairs = new Set(chatEdges.map(e => `${e.source}->${e.target}`));
+        expect(pairs.has('task:card_a->chat:msg-pinned')).toBe(true);
+        expect(pairs.has('task:card_a->chat:msg-mirror')).toBe(true);
+        expect(pairs.has('note:note_a->chat:msg-mirror')).toBe(true);
+        expect(result.stats.edgeCounts.chat_anchor).toBe(3);
+
+        // And the mindmap_node also bridges note_a ↔ card_a — note_on_card edge.
+        const noteOnCard = result.links.find(l => l.type === 'note_on_card');
+        expect(noteOnCard).toBeTruthy();
+        expect(noteOnCard.source).toBe('note:note_a');
+        expect(noteOnCard.target).toBe('task:card_a');
+    });
+
+    test('projectGraph respects limitNodes by dropping trailing nodes + orphans', () => {
+        const cards = Array.from({ length: 5 }, (_, i) => ({
+            id: `card_${i}`, title: `t${i}`, description: '',
+            priority: 'P2', status: 'todo', parent_card_id: null, is_automation: false,
+            assigned_bots: [], created_by: 0, reviewer_entity_id: null,
+            chat_anchor_message_id: null, archived: false, updated_at: null,
+        }));
+        const result = projection.projectGraph({
+            cards,
+            initialCardIds: new Set(cards.map(c => c.id)),
+            depRows: [],
+            commentCounts: [],
+            noteCounts: [],
+            notes: [],
+            anchorRows: [],
+            entityMap: {},
+            options: projection.parseGraphOptions(
+                { includeOwners: 'none', limitNodes: '2', limitEdges: '10', includeNotes: 'false' },
+                { isDeviceAuth: true, callerEntityId: null }
+            ),
+        });
+        expect(result.nodes.length).toBe(2);
+        expect(result.stats.truncatedNodes).toBe(3);
+        expect(result.stats.truncated).toBe(true);
+    });
+});
+
+// ─── Layer 2: HTTP route (supertest + mocked pool) ───────────────────────
+const mockQuery = jest.fn();
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: (...args) => mockQuery(...args),
+        connect: jest.fn().mockResolvedValue({
+            query: jest.fn().mockResolvedValue({ rows: [] }),
+            release: jest.fn(),
+        }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+jest.mock('../../safe-equal', () => (a, b) => a === b);
+
+const express = require('express');
+const request = require('supertest');
+
+describe('GET /api/mindmap/graph — HTTP', () => {
+    let app;
+    const devices = {
+        'dev-1': {
+            deviceSecret: 'sec-1',
+            entities: {
+                2: { isBound: true, botSecret: 'bot-2', character: 'LOBSTER' },
+                5: { isBound: true, botSecret: 'bot-5', character: 'Hermes' },
+            },
+        },
+    };
+
+    beforeAll(async () => {
+        app = express();
+        app.use(express.json());
+        const mindmapModule = require('../../mindmap')(devices);
+        // initMindmapTables wires the module-level `pool` closure. The mocked
+        // pg.Pool above returns a stub whose `query` delegates to mockQuery,
+        // so any SELECT in `/graph` flows through our sequence.
+        const pgPool = new (require('pg').Pool)();
+        await mindmapModule.initMindmapTables(pgPool);
+        app.use('/api/mindmap', mindmapModule.router);
+    });
+
+    beforeEach(() => {
+        mockQuery.mockReset();
+        // The init phase fires several CREATE TABLE queries — re-assert after reset.
+        mockQuery.mockResolvedValue({ rows: [] });
+    });
+
+    const AUTH = '?deviceId=dev-1&deviceSecret=sec-1';
+
+    test('400 when deviceId missing', async () => {
+        const res = await request(app).get('/api/mindmap/graph');
+        expect(res.status).toBe(400);
+    });
+
+    test('401 for invalid device credentials', async () => {
+        const res = await request(app).get('/api/mindmap/graph?deviceId=dev-1&deviceSecret=wrong');
+        expect(res.status).toBe(401);
+    });
+
+    test('400 scope=entity without entityId', async () => {
+        const res = await request(app).get('/api/mindmap/graph' + AUTH + '&scope=entity');
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/entityId/);
+    });
+
+    test('happy path: returns graph + meta + edgeCounts', async () => {
+        mockQuery.mockReset();
+        mockQuery
+            // 1) cards
+            .mockResolvedValueOnce({
+                rows: [
+                    { id: 'card_p', title: 'parent', description: '', priority: 'P0', status: 'in_progress', parent_card_id: null, is_automation: false, assigned_bots: [2], created_by: 1, reviewer_entity_id: null, chat_anchor_message_id: null, archived: false, updated_at: '2026-05-13T00:00:00Z' },
+                    { id: 'card_c', title: 'child',  description: '', priority: 'P1', status: 'todo',        parent_card_id: 'card_p', is_automation: false, assigned_bots: [5], created_by: 2, reviewer_entity_id: 1, chat_anchor_message_id: null, archived: false, updated_at: '2026-05-13T00:00:00Z' },
+                ],
+            })
+            // 2) dependencies
+            .mockResolvedValueOnce({
+                rows: [{ card_id: 'card_c', depends_on_card_id: 'card_p', dependency_type: 'blocks' }],
+            })
+            // 3a) comment counts
+            .mockResolvedValueOnce({ rows: [{ card_id: 'card_p', cnt: 2 }] })
+            // 3b) note counts
+            .mockResolvedValueOnce({ rows: [] })
+            // 4) mission_notes
+            .mockResolvedValueOnce({ rows: [] })
+            // 5) mindmap_node_anchors
+            .mockResolvedValueOnce({ rows: [] });
+
+        const res = await request(app).get('/api/mindmap/graph' + AUTH);
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.meta.schemaVersion).toBe(1);
+        expect(res.body.meta.scope).toBe('device');
+        expect(res.body.meta.layoutStorageKey).toBe('mindmap:force-layout:v1:dev-1:device:owner');
+
+        const ids = res.body.graph.nodes.map(n => n.id);
+        expect(ids).toContain('task:card_p');
+        expect(ids).toContain('task:card_c');
+        // Owner nodes for entities 1, 2, 5 (and reviewer 1)
+        expect(ids).toContain('owner:1');
+        expect(ids).toContain('owner:2');
+        expect(ids).toContain('owner:5');
+
+        const types = res.body.graph.links.map(l => l.type);
+        expect(types).toContain('parent');
+        expect(types).toContain('blocks');
+        expect(types).toContain('owner');
+        expect(res.body.stats.edgeCounts.parent).toBe(1);
+        expect(res.body.stats.edgeCounts.blocks).toBe(1);
+    });
+
+    test('entity scope: layout key + entityId in meta', async () => {
+        mockQuery.mockReset();
+        mockQuery
+            .mockResolvedValueOnce({ rows: [] }) // cards
+            // No deps query when cards.length === 0 (route short-circuits)
+            .mockResolvedValueOnce({ rows: [] }) // mission_notes
+            .mockResolvedValueOnce({ rows: [] }); // anchors
+
+        const res = await request(app)
+            .get('/api/mindmap/graph?deviceId=dev-1&botSecret=bot-2&entityId=2');
+        expect(res.status).toBe(200);
+        expect(res.body.meta.scope).toBe('entity');
+        expect(res.body.meta.entityId).toBe(2);
+        expect(res.body.meta.layoutStorageKey).toBe('mindmap:force-layout:v1:dev-1:entity:2');
+    });
+
+    test('chat_anchor edge surfaces when card has chat_anchor_message_id', async () => {
+        mockQuery.mockReset();
+        mockQuery
+            .mockResolvedValueOnce({
+                rows: [{
+                    id: 'card_a', title: 'pinned', description: '', priority: 'P1', status: 'todo',
+                    parent_card_id: null, is_automation: false,
+                    assigned_bots: [], created_by: 0, reviewer_entity_id: null,
+                    chat_anchor_message_id: 'msg-xyz', archived: false, updated_at: null,
+                }],
+            })
+            .mockResolvedValueOnce({ rows: [] }) // deps
+            .mockResolvedValueOnce({ rows: [] }) // comment counts
+            .mockResolvedValueOnce({ rows: [] }) // note counts
+            .mockResolvedValueOnce({ rows: [] }) // mission notes
+            .mockResolvedValueOnce({ rows: [] }); // anchors
+
+        const res = await request(app).get('/api/mindmap/graph' + AUTH);
+        expect(res.status).toBe(200);
+        const chatNode = res.body.graph.nodes.find(n => n.id === 'chat:msg-xyz');
+        expect(chatNode).toBeTruthy();
+        const chatEdge = res.body.graph.links.find(l => l.type === 'chat_anchor');
+        expect(chatEdge).toBeTruthy();
+        expect(chatEdge.source).toBe('task:card_a');
+        expect(chatEdge.target).toBe('chat:msg-xyz');
+        expect(chatEdge.evidence).toBe('kanban_cards.chat_anchor_message_id');
+    });
+
+    test('503 when pool unset (initMindmapTables not run)', async () => {
+        // Fresh module without initMindmapTables — pool stays null.
+        const isolated = express();
+        isolated.use(express.json());
+        const mod = require('../../mindmap')(devices);
+        isolated.use('/api/mindmap', mod.router);
+        const res = await request(isolated).get('/api/mindmap/graph' + AUTH);
+        expect(res.status).toBe(503);
+    });
+});


### PR DESCRIPTION
## Summary
Implements the **backend projection** step of the mind-map force-graph rollout (spec PR #2679, card `card_4813875b`).

Adds `GET /api/mindmap/graph` returning the react-force-graph-2d-native shape:

```json
{
  "success": true,
  "graph": { "nodes": [...], "links": [...] },
  "stats": { "nodeCount": N, "linkCount": M, "edgeCounts": {...}, "truncated": false },
  "meta": { "schemaVersion": 1, "scope": "device|entity", "layoutStorageKey": "..." }
}
```

### Data sources composed
- `kanban_cards` — task nodes (with priority, status, owner, automation, archived)
- `kanban_card_dependencies` — blocks edges (`dependency_type='blocks'`)
- `kanban_comments` / `kanban_notes` — aggregate counts on task nodes
- `mission_notes` — note nodes
- `mindmap_node_anchors` — cross-correlation for `note_on_card` + `chat_anchor` edges

### Edge types (MVP)
- `parent` — `kanban_cards.parent_card_id`
- `blocks` — `kanban_card_dependencies`
- `owner` — `assigned_bots` / `mission_notes.created_by`
- `note_on_card` — mindmap node bridging note + kanban_card anchors
- `chat_anchor` — **amendment A** from the PR #2679 review:
  - direct from `kanban_cards.chat_anchor_message_id`
  - cross-correlation when a `mindmap_node_anchors` row bridges note/card with `chat_message`

Tag / explicit-references edges are deferred to the 補強 follow-up cards (`card_95773e5c`, `card_d895451c`).

### Dual-auth + scope
- `deviceSecret` → `scope=device` (full device graph)
- `botSecret + entityId` → `scope=entity` (assigned/created + reviewer + immediate parent/dep neighbors)
- `scope=entity` without `entityId` → 400

### Caps
- `limitNodes` default 1000 (hard 2000), `limitEdges` default 2000 (hard 4000)
- Stable sort before truncation: not-archived → not-done → P0→P3 → recently-updated
- `stats.truncatedNodes` / `stats.truncatedLinks` reported

### Tests
21 new cases in `backend/tests/jest/mindmap-graph.test.js`:
- Pure projection helpers (parseBoolFlag, clampInt, owner pick, taskVal, node builders, applyCaps, parseGraphOptions)
- `projectGraph` integration: parent + blocks + owner edge wiring
- `projectGraph` integration: chat_anchor amendment A (direct + cross-correlation)
- `projectGraph` truncation: drops trailing nodes + orphan links
- HTTP route: 400 missing deviceId, 401 wrong secret, 400 scope=entity without entityId
- HTTP route: happy path returns `meta.schemaVersion=1`, `layoutStorageKey`, edgeCounts
- HTTP route: entity scope produces `entity:<id>` layout key + `meta.entityId`
- HTTP route: chat_anchor edge surfaces with `evidence='kanban_cards.chat_anchor_message_id'`
- HTTP route: 503 when pool not yet initialized

All 158 main-repo mindmap-related jest tests pass. (2 test suite failures in stale `.claude/worktrees/` from other Claude sessions are pre-existing and unrelated — missing `node_modules` in those worktrees.)

## Test plan
- [x] `npx jest tests/jest/mindmap-graph.test.js` → 21 passing
- [x] `npx jest tests/jest/mindmap.test.js tests/jest/mindmap-mirror.test.js tests/jest/kanban-mindmap.test.js tests/jest/mindmap-graph.test.js` → 158 passing in main repo
- [ ] After merge: smoke `GET /api/mindmap/graph` against staging with both deviceSecret + botSecret auth
- [ ] Frontend prototype card `card_054836f6` consumes this shape directly

## Follow-ups (already filed by Mac_F)
- `card_054836f6` — Frontend prototype `mindmap.html` (depends on this PR)
- `card_8b2d4404` — Perf hardening 1000/2000 @ 30fps
- `card_0fa87fe9` — Mission integration
- `card_95773e5c` — Tag system (補強)
- `card_d895451c` — Explicit card links (補強)
- `card_5d3b3578` — Note ↔ card explicit link (補強)
- `card_458c0f9c` — Note deep-link (補強)
- `card_18e2e941` — Chat message deep-link (補強)

🤖 Generated with [Claude Code](https://claude.com/claude-code)