### PR TITLE
fix(i18n): rename mm_empty_title → mm_state_empty_title in mindmap.html

### DIFF
--- a/backend/public/portal/mindmap.html
+++ b/backend/public/portal/mindmap.html
@@ -157,7 +157,7 @@
 
                 <div class="mm-state" id="mmStateEmpty" hidden>
                     <div class="mm-state-icon">🌱</div>
-                    <div class="mm-state-title" data-i18n="mm_empty_title">No graph data yet</div>
+                    <div class="mm-state-title" data-i18n="mm_state_empty_title">No graph data yet</div>
                     <div class="mm-state-body" data-i18n="mm_empty_body">Once tasks, notes, or chat anchors exist, they'll appear here.</div>
                 </div>
 

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -649400,7 +649400,7 @@ const TRANSLATIONS = {
         "mm_node_owner": "Owner",
         "mm_node_chat": "Chat",
         "mm_loading": "Loading graph…",
-        "mm_empty_title": "No graph data yet",
+        "mm_state_empty_title": "No graph data yet",
         "mm_empty_body": "Once tasks, notes, or chat anchors exist, they'll appear here.",
         "mm_error_title": "Couldn't load the graph",
         "mm_error_retry": "Try again",


### PR DESCRIPTION
## Summary
- Renames new portal-mindmap empty-state key `mm_empty_title` → `mm_state_empty_title` (matches `<div class=\"mm-state-title\">` naming).
- Avoids silent override of the legacy dashboard-mindmap-teaser key already translated across 13 locales (`mission-mindmap.js:1139` + `lang/en.js:35`).
- 2-line change: `portal/mindmap.html` + `shared/i18n.js` (en block).

## Why this matters
JS object literal last-write-wins: my new key (i18n.js:649403) was silently clobbering the legacy key (i18n.js:3737) used by the dashboard teaser. Without this rename, Hermes's incoming 12-locale translation PR would amplify the collision across every locale, breaking the dashboard mindmap CTA copy.

## Test plan
- [x] Local: confirmed the rendered `mmStateEmpty` title pulls from the new key.
- [x] Grep confirms only the new portal page uses `mm_state_empty_title`; legacy `mm_empty_title` still owns its dashboard usage in `mission-mindmap.js` + `lang/*.js`.
- [ ] Post-merge: re-dispatch Hermes i18n with the renamed key list.

Replaces #2682 (which was based on a pre-squash ancestor and unmergeable).

🤖 Generated with [Claude Code](https://claude.com/claude-code)