### PR TITLE
feat(mindmap): mission.html link to /portal/mindmap.html + deprecate /api/mission/mindmap

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -1051,6 +1051,11 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
         if (kanbanStatus === 'backlog') return 'blocked';
         return 'active';
     }
+    // DEPRECATED: GET /api/mission/mindmap (PR-A static-mockup feed)
+    // Replaced by GET /api/mindmap/graph (PR #2680 force-graph projection;
+    // see /portal/mindmap.html). Kept for the legacy dashboard-teaser on
+    // mission.html until the teaser is migrated to call /api/mindmap/graph
+    // directly. Do not extend; new mindmap consumers must use /api/mindmap/graph.
     router.get('/mindmap', async (req, res) => {
         if (!authenticate(req, res)) return;
         const { deviceId } = { ...req.query, ...req.body };

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -845,6 +845,7 @@
                 <div class="card-header">
                     <h2>🧠 <span data-i18n="mm_card_title">心智圖</span> <span style="font-size:11px;color:var(--text-secondary);font-weight:500;margin-left:6px;" data-i18n="mm_card_beta">(beta)</span></h2>
                     <div class="section-header-actions">
+                        <a class="btn btn-outline btn-sm" href="mindmap.html" id="mmOpenFullLink" data-i18n="mm_card_open_full" style="text-decoration:none;">完整心智圖 →</a>
                         <button class="btn btn-outline btn-sm" id="mmToggleBtn" onclick="toggleMindmap()" data-i18n="mm_card_expand">展開</button>
                     </div>
                 </div>

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -3479,6 +3479,7 @@ const TRANSLATIONS = {
 
 
         "mm_card_expand": "Expand",
+        "mm_card_open_full": "Full mindmap →",
 
 
 


### PR DESCRIPTION
## Summary
- Adds "Full mindmap →" button in the Mission > Mind Map teaser card (mission.html) so users can jump from the dashboard preview into the full force-graph at `/portal/mindmap.html` (PR #2680 / #2684).
- Adds matching en-locale key `mm_card_open_full` to `backend/public/shared/i18n.js`. Other locales will follow in Hermes #5's mm_* translation PR.
- Marks the legacy `GET /api/mission/mindmap` route as `DEPRECATED` in `kanban.js` in favour of `GET /api/mindmap/graph`. The legacy route is preserved for the dashboard teaser's current static-mockup feed; new mindmap consumers must use `/api/mindmap/graph`.

## Test plan
- [x] Local Playwright: link visible on desktop 1280x800, mobile 360, mobile 412, tablet 768
- [x] Local Playwright: clicking `#mmOpenFullLink` lands on `http://localhost:3001/portal/mindmap.html`
- [x] Local Playwright: no console errors across all 4 viewports
- [x] i18n: en-locale fallback renders "Full mindmap →"; zh-TW renders the inline "完整心智圖 →" until Hermes ships the translations
- [x] kanban.js: only comment added; route handler unchanged so the legacy dashboard teaser keeps working

## Screenshots
Desktop and mobile-360 captured during the verification pass; will attach to card_0fa87fe9 along with the standalone mindmap.html screenshot from card_8b2d4404 (PR #2684 perf hardening).

Closes card_0fa87fe9 (mission.html integration).