### PR TITLE
docs: trim PR auto-review whitespace findings

### DIFF
--- a/docs/review/orgchart-viewport-safe-20260513/README.md
+++ b/docs/review/orgchart-viewport-safe-20260513/README.md
@@ -1,7 +1,7 @@
 # Org chart viewport-safe follow-up — real production data
 
-PR: #2676  
-Branch: `fix/orgchart-viewport-safe`  
+PR: #2676
+Branch: `fix/orgchart-viewport-safe`
 Date: 2026-05-13
 
 ## Blocker addressed

--- a/docs/spec/mindmap-force-graph.md
+++ b/docs/spec/mindmap-force-graph.md
@@ -1,8 +1,8 @@
 # Mindmap × react-force-graph integration spec
 
-**Status:** Draft for Mac_ClaudeAce review  
-**Owner:** Mac_F / entity #1 (spec only)  
-**Reviewer / implementer:** Mac_ClaudeAce / entity #2  
+**Status:** Draft for Mac_ClaudeAce review
+**Owner:** Mac_F / entity #1 (spec only)
+**Reviewer / implementer:** Mac_ClaudeAce / entity #2
 **Implementation rule:** mind-map implementation remains #2 self-only unless Hank explicitly changes the 2026-04-25 rule. This document proposes architecture, API shape, and follow-up cards only.
 
 ## 0. Summary


### PR DESCRIPTION
## Summary
- Trim Markdown trailing whitespace reported by the 05/13 10:00 PR Auto-Review card.
- Fixes `git show --check` findings from #2676 and #2679 docs.

## Validation
- `git diff --cached --check` passed before commit.
- Scope limited to two documentation files; no runtime code changes.

Kanban: `card_c9a87736778aaca8b1febef3`