### PR TITLE
docs(roadmap): audit Hermes channel status

### DIFF
--- a/backend/public/portal/roadmap.html
+++ b/backend/public/portal/roadmap.html
@@ -396,54 +396,54 @@
                 <div class="rm-phase-desc" data-i18n="rm_h0_desc">Resolve basic connectivity: git clone/write access, credential injection, channel authentication.</div>
                 <ul class="rm-tasks">
                     <li data-i18n="rm_h0_t1">GITHUB_TOKEN injected into claude-cli-proxy via Railway env var (vault → Railway)</li>
-                    <li class="todo" data-i18n="rm_h0_t2">Redeploy proxy; verify Hermes can git clone/push HankHuang0516/EClaw</li>
+                    <li class="done" data-i18n="rm_h0_t2">Redeploy proxy; verify Hermes can git clone/push HankHuang0516/EClaw</li>
                     <li data-i18n="rm_h0_t3">Webhook secret validation on EClaw side matches Hermes egress</li>
                     <li data-i18n="rm_h0_t4">Hermes speakTo back to Entity 2 (commander) confirms bidirectional A2A</li>
                 </ul>
             </div>
 
-            <div class="rm-phase todo">
-                <h3>Phase H1 — <span data-i18n="rm_h1_name">Channel Reliability</span> <span class="rm-status-badge todo" data-i18n="rm_todo">Todo</span></h3>
+            <div class="rm-phase partial">
+                <h3>Phase H1 — <span data-i18n="rm_h1_name">Channel Reliability</span> <span class="rm-status-badge partial" data-i18n="rm_in_progress">In Progress</span></h3>
                 <div class="rm-phase-desc" data-i18n="rm_h1_desc">Fix message delivery gaps, spurious disconnects, and session resumption failures. Targets: ≤2% delivery failure, ≤30s resume.</div>
                 <ul class="rm-tasks">
-                    <li class="todo" data-i18n="rm_h1_t1">Queue back-pressure: cap messageQueue depth at 200; oldest messages moved to dead-letter when cap exceeded (prevents pure-translation fallback)</li>
+                    <li class="done" data-i18n="rm_h1_t1">Queue back-pressure: cap messageQueue depth at 200; oldest messages moved to dead-letter when cap exceeded (prevents pure-translation fallback)</li>
                     <li class="todo" data-i18n="rm_h1_t2">Heartbeat/ping-pong on webhook channel — Hermes must respond within 10s or EClaw marks delivery as failed and retries</li>
                     <li class="todo" data-i18n="rm_h1_t3">Session cache key includes org_id + entity_id — fixes "repo not found" from stale session cache</li>
-                    <li class="todo" data-i18n="rm_h1_t4">EClaw channel logs delivery receipts; alert on &gt;3 consecutive failures → commander notified</li>
-                    <li class="todo" data-i18n="rm_h1_t5">Docker health-check: Railway health endpoint returns 200 only when Hermes message loop is responsive; auto-restart if /health returns 503 for &gt;60s</li>
+                    <li class="partial" data-i18n="rm_h1_t4">EClaw channel logs delivery receipts; alert on &gt;3 consecutive failures → commander notified</li>
+                    <li class="partial" data-i18n="rm_h1_t5">Docker health-check: Railway health endpoint returns 200 only when Hermes message loop is responsive; auto-restart if /health returns 503 for &gt;60s</li>
                     <li class="todo" data-i18n="rm_h1_t6">Rate-limit guard: Hermes respects 30 req/min from EClaw; back-pressure handled via exponential backoff</li>
                 </ul>
             </div>
 
-            <div class="rm-phase todo">
-                <h3>Phase H2 — <span data-i18n="rm_h2_name">Operational Maturity</span> <span class="rm-status-badge todo" data-i18n="rm_todo">Todo</span></h3>
+            <div class="rm-phase partial">
+                <h3>Phase H2 — <span data-i18n="rm_h2_name">Operational Maturity</span> <span class="rm-status-badge partial" data-i18n="rm_in_progress">In Progress</span></h3>
                 <div class="rm-phase-desc" data-i18n="rm_h2_desc">Hermes as a reliable team member: health monitoring, self-healing, SLA tracking. Targets: ≥99% weekly uptime, 6h health-check.</div>
                 <ul class="rm-tasks">
-                    <li class="todo" data-i18n="rm_h2_t1">Hermes accepts i18n batch cards via speakTo and delivers PRs on time</li>
+                    <li class="partial" data-i18n="rm_h2_t1">Hermes accepts i18n batch cards via speakTo and delivers PRs on time</li>
                     <li class="todo" data-i18n="rm_h2_t2">Hermes health-check cron: git push test every 6h; alert commander on 3 consecutive failures</li>
                     <li class="todo" data-i18n="rm_h2_t3">Hermes uses Linear API to update card status after PR merge (closed/labelled)</li>
-                    <li class="todo" data-i18n="rm_h2_t4">Railway restart policy set to always; OOM or stuck loop triggers immediate restart with commander notification</li>
+                    <li class="partial" data-i18n="rm_h2_t4">Railway restart policy set to always; OOM or stuck loop triggers immediate restart with commander notification</li>
                     <li data-i18n="rm_h2_t5">Hermes memory persists between sessions via hermes_state.db (already configured)</li>
                     <li class="todo" data-i18n="rm_h2_t6">Structured log pipeline: Hermes emits JSON logs → Railway log drain → Grafana dashboard; P95 response time tracked</li>
                 </ul>
             </div>
 
-            <div class="rm-phase todo">
-                <h3>Phase H3 — <span data-i18n="rm_h3_name">Private Repo Support</span> <span class="rm-status-badge todo" data-i18n="rm_todo">Todo</span></h3>
+            <div class="rm-phase partial">
+                <h3>Phase H3 — <span data-i18n="rm_h3_name">Private Repo Support</span> <span class="rm-status-badge partial" data-i18n="rm_in_progress">In Progress</span></h3>
                 <div class="rm-phase-desc" data-i18n="rm_h3_desc">Hermes can operate on private repositories. Aligned with <a href="info.html#guide/card_f531861e" style="color:var(--primary);">card_f531861e</a> (claude-cli-proxy vault integration). Target: Hermes can clone/push to any EClaw org private repo without anonymous fallback.</div>
                 <ul class="rm-tasks">
-                    <li class="todo" data-i18n="rm_h3_t1">claude-cli-proxy reads GIT_HUB2 from vault (card_f531861e) — Hermes git operations use authenticated context instead of anonymous fallback</li>
+                    <li class="partial" data-i18n="rm_h3_t1">claude-cli-proxy reads GIT_HUB2 from vault (card_f531861e) — Hermes git operations use authenticated context instead of anonymous fallback</li>
                     <li class="todo" data-i18n="rm_h3_t2">Per-org credential scope: Hermes receives org-specific token; cannot access repos outside assigned orgs</li>
-                    <li class="todo" data-i18n="rm_h3_t3">Hermes tested against a private test repo — clone, branch, commit, push, PR all succeed</li>
+                    <li class="partial" data-i18n="rm_h3_t3">Hermes tested against a private test repo — clone, branch, commit, push, PR all succeed</li>
                 </ul>
             </div>
 
-            <div class="rm-phase todo">
-                <h3>Phase H4 — <span data-i18n="rm_h4_name">Showcase Ready</span> <span class="rm-status-badge todo" data-i18n="rm_todo">Todo</span></h3>
+            <div class="rm-phase partial">
+                <h3>Phase H4 — <span data-i18n="rm_h4_name">Showcase Ready</span> <span class="rm-status-badge partial" data-i18n="rm_in_progress">In Progress</span></h3>
                 <div class="rm-phase-desc" data-i18n="rm_h4_desc">Hermes Channel page on EClaw portal demonstrating live co-working with other agents as public proof of EClaw's cross-platform A2A.</div>
                 <ul class="rm-tasks">
-                    <li class="todo" data-i18n="rm_h4_t1">Public Hermes Channel guide page on portal (info.html already exists; content to be expanded)</li>
-                    <li class="todo" data-i18n="rm_h4_t2">Hermes i18n contributions visible as merged PRs — use as proof of cross-platform A2A</li>
+                    <li class="done" data-i18n="rm_h4_t1">Public Hermes Channel guide page on portal (info.html already exists; content to be expanded)</li>
+                    <li class="partial" data-i18n="rm_h4_t2">Hermes i18n contributions visible as merged PRs — use as proof of cross-platform A2A</li>
                     <li class="todo" data-i18n="rm_h4_t3">Live demo: commander assigns a card, Hermes delivers PR, commander merges — screenshot in portal</li>
                     <li class="todo" data-i18n="rm_h4_t4">Add Hermes to EClaw's agent roster page (agent cards with capability tags)</li>
                 </ul>


### PR DESCRIPTION
## Summary
- updates the Hermes Channel roadmap section statuses based on current implementation/prod evidence
- marks portal guide availability done, private-repo/push capability in progress, and reliability/daemon-health work in progress rather than todo
- does not touch non-Hermes roadmap sections

## Audit notes
- H0 t2: Hermes has demonstrated GitHub branch/PR push capability, but quality issues remain elsewhere.
- H1/H2: reliability is in progress, not done; current Hermes daemon wedge / restart requirement means health-check and delivery maturity remain incomplete.
- H3: private repo support is partially proven by PR attempts, but scoped credential correctness still needs review.
- H4 t1: `info.html` already includes `guide-hermes-channel`; Dashboard Hermes promo PR #2708 links to `info.html#channel-plugins/hermes-channel`.
- H4 t2: i18n contribution proof is in progress; current PRs are blocked by Hermes daemon wedge and should not be marked done.

## Validation
- `git diff --check -- backend/public/portal/roadmap.html` passed

## Screenshots
Docs/roadmap-only status audit. Screenshot capture is left for #2 authenticated E2E because the local static portal redirects without a backend session.
