### PR TITLE
i18n(mindmap): mm_card_open_full × 12 locales (drift batch 2)

### DIFF
--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -653051,6 +653051,7 @@ const TRANSLATIONS = {
 
 
         "mm_card_expand": "展开",
+        "mm_card_open_full": "完整思维导图 →",
 
 
 
@@ -1850435,6 +1850436,7 @@ const TRANSLATIONS = {
 
 
         "mm_card_expand": "展開",
+        "mm_card_open_full": "完全なマインドマップ →",
 
 
 
@@ -2412526,6 +2412528,7 @@ const TRANSLATIONS = {
 
 
         "mm_card_expand": "펼치기",
+        "mm_card_open_full": "전체 마인드맵 →",
 
 
 
@@ -2943156,6 +2943159,7 @@ const TRANSLATIONS = {
 
 
         "mm_card_expand": "ขยาย",
+        "mm_card_open_full": "แผนที่ความคิดเต็ม →",
 
 
 
@@ -3471866,6 +3471870,7 @@ const TRANSLATIONS = {
 
 
         "mm_card_expand": "Mở rộng",
+        "mm_card_open_full": "Bản đồ tư duy đầy đủ →",
 
 
 
@@ -3997248,6 +3997253,7 @@ const TRANSLATIONS = {
 
 
         "mm_card_expand": "Perluas",
+        "mm_card_open_full": "Peta pikiran penuh →",
 
 
 
@@ -4522246,6 +4522252,7 @@ const TRANSLATIONS = {
 
 
         "mm_card_expand": "Déplier",
+        "mm_card_open_full": "Carte mentale complète →",
 
 
 
@@ -5045964,6 +5045971,7 @@ const TRANSLATIONS = {
 
 
         "mm_card_expand": "Expandir",
+        "mm_card_open_full": "Mapa mental completo →",
 
 
 
@@ -5562250,6 +5562258,7 @@ const TRANSLATIONS = {
 
 
         "mm_card_expand": "Aufklappen",
+        "mm_card_open_full": "Vollständige Mindmap →",
 
 
 
@@ -6097868,6 +6097877,7 @@ const TRANSLATIONS = {
 
 
         "mm_card_expand": "Buka",
+        "mm_card_open_full": "Peta minda penuh →",
 
 
 
@@ -6773906,6 +6773916,7 @@ const TRANSLATIONS = {
 
 
         "mm_card_expand": "विस्तार करें",
+        "mm_card_open_full": "पूर्ण माइंडमैप →",
 
 
 
@@ -7462744,6 +7462755,7 @@ const TRANSLATIONS = {
 
 
         "mm_card_expand": "توسيع",
+        "mm_card_open_full": "خريطة ذهنية كاملة →",
 
 
 


### PR DESCRIPTION
## Summary

- Adds `mm_card_open_full` key to 12 non-EN locale blocks in `shared/i18n.js`
- EN canonical key already on main (mindmap.html "Open full mindmap →" link)
- Extracted from Hermes daemon batch 2 output (PR #2715 closed as wedge-replay)

## Locale coverage

| Locale | Translation |
|---|---|
| zh | 完整思维导图 → |
| ja | 完全なマインドマップ → |
| ko | 전체 마인드맵 → |
| th | แผนที่ความคิดเต็ม → |
| vi | Bản đồ tư duy đầy đủ → |
| id | Peta pikiran penuh → |
| fr | Carte mentale complète → |
| es | Mapa mental completo → |
| de | Vollständige Mindmap → |
| ms | Peta minda penuh → |
| hi | पूर्ण माइंडमैप → |
| ar | خريطة ذهنية كاملة → |

## Provenance

Hermes daemon resume-session wedge (per memory `feedback_hermes_resume_wedge`) caused PR #2715 to include 38 whitespace-replay files alongside the legitimate i18n.js delta. This PR lifts only the i18n.js change onto a clean branch off main. PR #2715 will be closed once this lands.

## Test plan

- [x] i18n syntax check (CI)
- [x] Jest unit tests (CI)
- [x] No script-contamination (per-locale keys, native scripts only)