### PR TITLE
feat(chat): support message deep links

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -2355,6 +2355,26 @@
         .chat-msg.his-flash > .chat-bubble {
             animation: his-flash 1.4s ease-out;
         }
+        .chat-msg.chat-msg-deeplink > .chat-bubble {
+            outline: 2px solid #60a5fa;
+            box-shadow: 0 0 0 4px rgba(96, 165, 250, 0.22);
+            animation: his-flash 1.4s ease-out;
+        }
+        .chat-deeplink-missing {
+            align-self: stretch;
+            margin: 0 0 10px;
+            padding: 10px 12px;
+            border: 1px solid rgba(244, 67, 54, 0.45);
+            border-radius: 12px;
+            background: rgba(244, 67, 54, 0.08);
+            color: var(--danger);
+            font-size: 13px;
+            line-height: 1.4;
+        }
+        .chat-deeplink-missing:focus {
+            outline: 2px solid rgba(244, 67, 54, 0.75);
+            outline-offset: 2px;
+        }
 
         /* ── Note Preview Modal ── */
         #notePreviewModal .modal-box {
@@ -3053,6 +3073,8 @@
         const xdeviceLookupMissCache = new Set();
         const ENTITY_NO_PROGRESS_MS = 10 * 60 * 1000;
         const entityRuntimeStatus = new Map();
+        let activeChatMessageDeepLinkId = null;
+        let activeChatMessageDeepLinkMissingId = null;
         const CHAT_AVATAR_SIZE_PX = { small: 32, medium: 48, large: 64 };
         let chatAvatarSize = 'medium';
 
@@ -3367,6 +3389,7 @@
             await loadBoundEntities();
             console.log('[CHAT_DEBUG] loadBoundEntities done, loading messages...');
             await loadMessages();
+            await handleChatMessageDeepLink({ showMissingToast: true, scroll: true });
             console.log('[CHAT_DEBUG] loadMessages done, count:', allMessages.length);
             isFirstLoad = false;
 
@@ -4009,6 +4032,9 @@
                     _sourceParseCache.clear();
                     renderFilterChips();
                     renderMessages(prevCount < allMessages.length);
+                    if (!isFirstLoad && getChatMessageDeepLinkId()) {
+                        await handleChatMessageDeepLink({ showMissingToast: false, scroll: false });
+                    }
                     refreshXDeviceLabelsInBackground(allMessages);
                     ChatIntegrityValidator.validateDataLayer(data.messages);
                     await syncCodexAutoApproveTargetsFromServer();
@@ -4155,15 +4181,153 @@
 
         function setFilter(filter) {
             currentFilter = filter;
-
-            document.querySelectorAll('#filterChips .filter-chip').forEach(chip => {
-                chip.classList.toggle('active', chip.dataset.filter === filter);
-            });
-
+            updateActiveFilterChip();
             ensureActiveChipVisible();
-
             renderMessages(false);
         }
+
+        function updateActiveFilterChip() {
+            document.querySelectorAll('#filterChips .filter-chip').forEach(chip => {
+                chip.classList.toggle('active', chip.dataset.filter === currentFilter);
+            });
+        }
+
+        const CHAT_MESSAGE_ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+        function normalizeChatMessageId(value) {
+            const id = String(value || '').trim().toLowerCase();
+            return CHAT_MESSAGE_ID_RE.test(id) ? id : '';
+        }
+
+        function getChatMessageDeepLinkId() {
+            try {
+                return normalizeChatMessageId(new URLSearchParams(window.location.search).get('msg'));
+            } catch (_) {
+                return '';
+            }
+        }
+
+        function escapeCssIdent(value) {
+            if (window.CSS && typeof CSS.escape === 'function') return CSS.escape(value);
+            return String(value).replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+        }
+
+        function findChatMessageById(messageId) {
+            const id = normalizeChatMessageId(messageId);
+            if (!id) return null;
+            return Array.isArray(allMessages)
+                ? allMessages.find(m => normalizeChatMessageId(m && m.id) === id) || null
+                : null;
+        }
+
+        function getRenderedMessageIds(msg) {
+            const ids = [];
+            const add = (id) => {
+                const normalized = normalizeChatMessageId(id);
+                if (normalized && !ids.includes(normalized)) ids.push(normalized);
+            };
+            add(msg && msg.id);
+            if (Array.isArray(msg && msg._groupedMessages)) msg._groupedMessages.forEach(m => add(m && m.id));
+            if (Array.isArray(msg && msg._photoGroupMessageIds)) msg._photoGroupMessageIds.forEach(add);
+            return ids;
+        }
+
+        function chatMessageDeepLinkSelector(messageId) {
+            const id = escapeCssIdent(normalizeChatMessageId(messageId));
+            if (!id) return '';
+            return `.chat-msg[data-message-id="${id}"], .chat-msg[data-message-ids~="${id}"]`;
+        }
+
+        function renderChatMessageDeepLinkMissing() {
+            if (!activeChatMessageDeepLinkMissingId) return '';
+            const tpl = i18n.t('chat_msg_deeplink_not_found') || 'Message not found or not accessible: {id}';
+            return `<div class="chat-deeplink-missing" role="alert" tabindex="-1">${escapeHtml(tpl.replace('{id}', activeChatMessageDeepLinkMissingId))}</div>`;
+        }
+
+        function filterForChatMessage(msg) {
+            const parsed = parseEntitySource(msg && msg.source);
+            if (parsed && parsed.crossDevice) {
+                if (parsed.fromPublicCode && !myPublicCodeMap[parsed.fromPublicCode]) return `xdevice-${parsed.fromPublicCode}`;
+                const target = (parsed.targets || []).find(code => !myPublicCodeMap[code]) || parsed.targets?.[0];
+                if (target) return `xdevice-${target}`;
+            }
+            if (msg && msg.entity_id !== null && msg.entity_id !== undefined && !Number.isNaN(Number(msg.entity_id))) {
+                return `entity-${Number(msg.entity_id)}`;
+            }
+            return 'all';
+        }
+
+        function applyFilterForChatMessage(msg) {
+            const nextFilter = filterForChatMessage(msg);
+            if (currentFilter !== nextFilter) {
+                currentFilter = nextFilter;
+                updateActiveFilterChip();
+                ensureActiveChipVisible();
+            }
+            renderMessages(false);
+        }
+
+        function highlightChatMessageDeepLink(messageId, { scroll = false } = {}) {
+            const id = normalizeChatMessageId(messageId);
+            if (!id) return false;
+            document.querySelectorAll('.chat-msg.chat-msg-deeplink').forEach(el => el.classList.remove('chat-msg-deeplink'));
+            const selector = chatMessageDeepLinkSelector(id);
+            const el = selector ? document.querySelector(selector) : null;
+            if (!el) return false;
+            el.classList.add('chat-msg-deeplink');
+            if (scroll) {
+                el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+                try {
+                    el.setAttribute('tabindex', '-1');
+                    el.focus({ preventScroll: true });
+                } catch (_) {}
+                setTimeout(() => el.classList.remove('chat-msg-deeplink'), 5000);
+            }
+            return true;
+        }
+
+        async function handleChatMessageDeepLink({ showMissingToast = false, scroll = false } = {}) {
+            const id = getChatMessageDeepLinkId();
+            if (!id) {
+                activeChatMessageDeepLinkId = null;
+                activeChatMessageDeepLinkMissingId = null;
+                document.querySelectorAll('.chat-msg.chat-msg-deeplink').forEach(el => el.classList.remove('chat-msg-deeplink'));
+                return;
+            }
+
+            const msg = findChatMessageById(id);
+            if (!msg) {
+                activeChatMessageDeepLinkId = null;
+                activeChatMessageDeepLinkMissingId = id;
+                renderMessages(false);
+                if (showMissingToast && typeof showToast === 'function') {
+                    const tpl = i18n.t('chat_msg_deeplink_not_found') || 'Message not found or not accessible: {id}';
+                    showToast(tpl.replace('{id}', id), 'error');
+                }
+                return;
+            }
+
+            activeChatMessageDeepLinkMissingId = null;
+            activeChatMessageDeepLinkId = id;
+            applyFilterForChatMessage(msg);
+            requestAnimationFrame(() => {
+                if (highlightChatMessageDeepLink(id, { scroll })) return;
+                if (currentFilter !== 'all') {
+                    currentFilter = 'all';
+                    updateActiveFilterChip();
+                    renderMessages(false);
+                    requestAnimationFrame(() => {
+                        if (!highlightChatMessageDeepLink(id, { scroll }) && showMissingToast && typeof showToast === 'function') {
+                            showToast(i18n.t('chat_his_not_rendered_preview') || 'Message is loaded but not currently rendered.');
+                        }
+                    });
+                }
+            });
+        }
+
+        window.addEventListener('popstate', () => {
+            handleChatMessageDeepLink({ showMissingToast: true, scroll: true });
+        });
 
         // ── Chat Density (Compact / Normal / Comfortable) ──
         function setChatDensity(value) {
@@ -4299,6 +4463,7 @@
                     // Mark all but the last as skipped; attach grid to the last.
                     for (let k = 0; k < run.length - 1; k++) run[k]._photoGroupSkip = true;
                     run[run.length - 1]._photoGroupUrls = urls;
+                    run[run.length - 1]._photoGroupMessageIds = run.map(m => m.id).filter(Boolean);
                 }
                 i = j - 1; // skip past the run
             }
@@ -4504,8 +4669,10 @@
             const shouldFollowBottom = isFirstLoad || (scrollLock && scrollLock.wasAtBottom);
             const filtered = getFilteredMessages();
 
+            const deepLinkMissingHtml = renderChatMessageDeepLinkMissing();
+
             if (filtered.length === 0) {
-                container.innerHTML = `
+                container.innerHTML = deepLinkMissingHtml + `
                     <div class="chat-empty">
                         <div class="chat-empty-icon">💬</div>
                         <div class="chat-empty-title" data-i18n="chat_empty">${escapeHtml(i18n.t('chat_empty') || 'No messages yet')}</div>
@@ -4548,7 +4715,7 @@
                 return d.toLocaleDateString([], { month: 'numeric', day: 'numeric' });
             }
 
-            container.innerHTML = displayMessages.map((msg, idx) => {
+            container.innerHTML = deepLinkMissingHtml + displayMessages.map((msg, idx) => {
                 // Skip earlier messages in a photo run — the last one renders the grid.
                 if (msg._photoGroupSkip) return '';
                 // Walk back over skipped photo-run entries so date separators
@@ -4828,9 +4995,11 @@
                 const replySnippet = stripReplyQuotePrefix(rawText || '').replace(/\n/g, ' ').slice(0, 120);
                 const replySenderName = isSent ? (i18n.t('chat_reply_you') || 'You') : isPlatform ? 'Platform' : (getEntityLabel(msg.entity_id) || '');
                 const replyBtnHtml = msg.id ? `<button class="chat-reply-btn" data-msg-id="${escapeHtml(msg.id)}" data-sender="${escapeHtml(replySenderName)}" data-text="${escapeHtml(replySnippet)}" onclick="handleReplyBtn(this);event.stopPropagation()" data-i18n-title="chat_reply_btn" title="Quote">📌</button>` : '';
+                const renderedMessageIds = getRenderedMessageIds(msg);
+                const renderedIdsAttr = escapeHtml(renderedMessageIds.join(' '));
 
                 return `${dateSep}${unreadSep}
-                    <div class="chat-msg ${msgClass}${isGrouped ? ' grouped' : ''}" data-message-id="${escapeHtml(msg.id || '')}" style="position:relative">
+                    <div class="chat-msg ${msgClass}${isGrouped ? ' grouped' : ''}" data-message-id="${escapeHtml(normalizeChatMessageId(msg.id) || msg.id || '')}" data-message-ids="${renderedIdsAttr}" style="position:relative">
                         <div class="chat-source">${sourceLabel}</div>
                         <div class="chat-bubble${isMdRendered ? ' md-rendered' : ''}" data-full-time="${escapeHtml(fullTime)}">${textHtml}${mediaHtml}${inlineImgHtml}${cardHtml}${cardRefHtml}${attachmentsHtml}</div>
                         ${replyBtnHtml}

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -339134,6 +339134,7 @@ const TRANSLATIONS = {
 
 
 
+        "chat_msg_deeplink_not_found": "Message not found or not accessible: {id}",
         "chat_his_not_found": "Referenced message is not currently loaded.",
 
 
@@ -963889,6 +963890,7 @@ const TRANSLATIONS = {
 
 
 
+        "chat_msg_deeplink_not_found": "找不到訊息或無法存取：{id}",
         "chat_his_not_found": "引用的訊息目前未載入。",
 
 
@@ -1293771,6 +1293773,7 @@ const TRANSLATIONS = {
 
 
 
+        "chat_msg_deeplink_not_found": "找不到消息或无法访问：{id}",
         "chat_his_not_found": "引用的訊息目前未载入。",
 
 
@@ -2136406,6 +2136409,7 @@ const TRANSLATIONS = {
 
 
 
+        "chat_msg_deeplink_not_found": "メッセージが見つからないか、アクセスできません: {id}",
         "chat_his_not_found": "参照されたメッセージは現在読み込まれていません。",
 
 
@@ -2698413,6 +2698417,7 @@ const TRANSLATIONS = {
 
 
 
+        "chat_msg_deeplink_not_found": "메시지를 찾을 수 없거나 접근할 수 없습니다: {id}",
         "chat_his_not_found": "참조된 메시지가 현재 로드되지 않았습니다.",
 
 
@@ -3219188,6 +3219193,7 @@ const TRANSLATIONS = {
 
 
 
+        "chat_msg_deeplink_not_found": "ไม่พบข้อความหรือไม่สามารถเข้าถึงได้: {id}",
         "chat_his_not_found": "ข้อความที่อ้างอิงยังไม่ได้โหลดในขณะนี้",
 
 
@@ -3747899,6 +3747905,7 @@ const TRANSLATIONS = {
 
 
 
+        "chat_msg_deeplink_not_found": "Không tìm thấy tin nhắn hoặc không thể truy cập: {id}",
         "chat_his_not_found": "Tin nhắn được tham chiếu hiện chưa được tải.",
 
 
@@ -4273154,6 +4273161,7 @@ const TRANSLATIONS = {
 
 
 
+        "chat_msg_deeplink_not_found": "Pesan tidak ditemukan atau tidak dapat diakses: {id}",
         "chat_his_not_found": "Pesan yang dirujuk belum dimuat saat ini.",
 
 
@@ -4809545,6 +4809553,7 @@ const TRANSLATIONS = {
 
 
 
+        "chat_msg_deeplink_not_found": "Message introuvable ou inaccessible : {id}",
         "chat_his_not_found": "Le message référencé n est pas chargé.",
 
 
@@ -5330448,6 +5330457,7 @@ const TRANSLATIONS = {
 
 
 
+        "chat_msg_deeplink_not_found": "Mensaje no encontrado o inaccesible: {id}",
         "chat_his_not_found": "El mensaje referenciado no está cargado actualmente.",
 
 
@@ -5847499,6 +5847509,7 @@ const TRANSLATIONS = {
 
 
 
+        "chat_msg_deeplink_not_found": "Nachricht nicht gefunden oder nicht zugänglich: {id}",
         "chat_his_not_found": "Die referenzierte Nachricht ist derzeit nicht geladen.",
 
 
@@ -6329106,6 +6329117,7 @@ const TRANSLATIONS = {
 
 
 
+        "chat_msg_deeplink_not_found": "Mesej tidak ditemui atau tidak boleh diakses: {id}",
         "chat_his_not_found": "Mesej yang dirujuk belum dimuatkan.",
 
 
@@ -6864474,6 +6864486,7 @@ const TRANSLATIONS = {
 
 
 
+        "chat_msg_deeplink_not_found": "संदेश नहीं मिला या पहुँच योग्य नहीं है: {id}",
         "chat_his_not_found": "संदर्भित संदेश वर्तमान में लोड नहीं है।",
 
 
@@ -7693984,6 +7693997,7 @@ const TRANSLATIONS = {
 
 
 
+        "chat_msg_deeplink_not_found": "الرسالة غير موجودة أو لا يمكن الوصول إليها: {id}",
         "chat_his_not_found": "الرسالة المشار إليها غير محملة حاليًا.",
 
 


### PR DESCRIPTION
## Summary
- support `/portal/chat.html?msg=<messageId>` after auth + chat history load
- select the relevant entity/cross-device context before scrolling where possible
- scroll to and temporarily highlight the target message without obscuring content
- show a non-breaking missing/deleted/inaccessible message state + toast, even when the current filter still has other messages
- handle browser back/forward by clearing/reapplying the `msg` param behavior
- keep the highlight/missing state accessible (`role=alert`, focusable missing banner)
- add `chat_msg_deeplink_not_found` for the current locale set present in `backend/public/shared/i18n.js`

## Implementation notes
- grouped broadcast/photo-run bubbles now carry `data-message-ids` so deep-links can still resolve when several message IDs render as one bubble
- chat refresh re-applies deep-link state without stealing scroll after initial load
- no backend API changes; resolution is against the already loaded chat history window

## Validation
- `git diff --check -- backend/public/portal/chat.html backend/public/shared/i18n.js`
- `node --check backend/public/shared/i18n.js`
- extracted inline scripts from `backend/public/portal/chat.html` and parsed each with `new Function(...)` via Node
- GitHub Actions on latest SHA: ESLint ✅, i18n syntax check ✅, Critical portal pages ✅; Jest unit tests still in progress at last check

## E2E / screenshots
Authenticated visual E2E should still verify:
- direct `/portal/chat.html?msg=<messageId>` after login/session initialization
- target entity/cross-device context is selected before scrolling
- missing/deleted/inaccessible message ID shows the not-found state without breaking chat
- grouped broadcast/photo messages can still resolve via `data-message-ids`
- browser back/forward clears/re-applies the `msg` param sanely
- 360 / 412 / 768 / desktop + mobile WebView
