### PR TITLE
feat(mission): link notes to kanban cards

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -1295,6 +1295,36 @@ module.exports = function (devices, { awardEntityXP, serverLog, pushToEntity, pu
                 updatedAt: new Date(r.updated_at).getTime()
             }));
 
+            // Fetch first-class Mission notes linked to this Kanban card.
+            // Notes live in mission_dashboard.notes JSONB; the join table is
+            // explicit/device-scoped and supplies reliable force-graph edges.
+            try {
+                const linkedNotesResult = await pool.query(
+                    `SELECT l.note_id, l.created_at AS linked_at, note AS note_json
+                     FROM mission_note_card_links l
+                     JOIN mission_dashboard md ON md.device_id = l.device_id
+                     CROSS JOIN LATERAL jsonb_array_elements(COALESCE(md.notes, '[]'::jsonb)) AS n(note)
+                     WHERE l.device_id = $1
+                       AND l.card_id = $2
+                       AND note->>'id' = l.note_id
+                     ORDER BY l.created_at DESC`,
+                    [deviceId, cardId]
+                );
+                card.linkedMissionNotes = linkedNotesResult.rows.map(r => ({
+                    id: r.note_id,
+                    title: r.note_json.title || '(untitled note)',
+                    category: r.note_json.category || 'general',
+                    excerpt: String(r.note_json.content || '').slice(0, 160),
+                    linkedAt: new Date(r.linked_at).getTime(),
+                }));
+                card.linkedMissionNoteCount = card.linkedMissionNotes.length;
+            } catch (linkedErr) {
+                // Backward-compatible: a missing migration should not break card detail.
+                console.warn('[Kanban] Linked mission notes query skipped:', linkedErr.message);
+                card.linkedMissionNotes = [];
+                card.linkedMissionNoteCount = 0;
+            }
+
             // Fetch files — regenerate fresh R2 signed URLs for rows that were
             // stored as fileId refs (stored url in DB is just a legacy cache).
             const filesResult = await pool.query(

--- a/backend/mindmap-graph-projection.js
+++ b/backend/mindmap-graph-projection.js
@@ -12,7 +12,7 @@
  *   parent          — kanban_cards.parent_card_id
  *   blocks          — kanban_card_dependencies.dependency_type='blocks'
  *   owner           — assigned_bots / mission_notes.created_by
- *   note_on_card    — mindmap_node_anchors cross-correlation (note + kanban_card)
+ *   note_on_card    — mission_note_card_links + mindmap_node_anchors cross-correlation (note + kanban_card)
  *   chat_anchor     — kanban_cards.chat_anchor_message_id + anchor cross-correlation
  *                     (amendment A from PR #2679 review)
  *
@@ -240,6 +240,7 @@ function projectGraph({
     cards,
     initialCardIds,
     depRows,
+    noteCardLinkRows = [],
     commentCounts,
     noteCounts,
     notes,
@@ -402,8 +403,25 @@ function projectGraph({
         }
     }
 
-    // 4. note_on_card edges via mindmap_node_anchors cross-correlation
+    // 4. note_on_card edges via first-class mission_note_card_links
     const seenNoteCard = new Set();
+    for (const l of noteCardLinkRows) {
+        if (!noteIds.has(l.note_id) || !cardIds.has(l.card_id)) continue;
+        const key = `${l.note_id}->${l.card_id}`;
+        if (seenNoteCard.has(key)) continue;
+        seenNoteCard.add(key);
+        links.push(buildLink({
+            id: `note_card_link:${l.note_id}:${l.card_id}`,
+            source: `note:${l.note_id}`,
+            target: `task:${l.card_id}`,
+            type: 'note_on_card',
+            weight: 2.2,
+            evidence: 'mission_note_card_links',
+        }));
+        edgeCounts.note_on_card++;
+    }
+
+    // 5. note_on_card edges via mindmap_node_anchors cross-correlation
     for (const [, anchors] of anchorsByNode) {
         const cardAnchors = anchors.filter(a => a.anchor_type === 'kanban_card');
         const noteAnchors = anchors.filter(a => a.anchor_type === 'note');
@@ -429,8 +447,8 @@ function projectGraph({
         }
     }
 
-    // 5. chat_anchor edges — amendment A
-    //    5a) kanban_cards.chat_anchor_message_id direct field
+    // 6. chat_anchor edges — amendment A
+    //    6a) kanban_cards.chat_anchor_message_id direct field
     for (const c of cards) {
         const mid = c.chat_anchor_message_id;
         if (!mid || !nodeIdSet.has(`chat:${mid}`)) continue;
@@ -445,7 +463,7 @@ function projectGraph({
         }));
         edgeCounts.chat_anchor++;
     }
-    //    5b) mindmap_node_anchors cross-correlation (note↔chat / card↔chat)
+    //    6b) mindmap_node_anchors cross-correlation (note↔chat / card↔chat)
     const seenChat = new Set();
     for (const [, anchors] of anchorsByNode) {
         const chatAnchors = anchors.filter(a => a.anchor_type === 'chat_message');

--- a/backend/mindmap.js
+++ b/backend/mindmap.js
@@ -960,27 +960,50 @@ function createMindmapModule(devices) {
                     ),
                 ]);
 
-            // 4) Mission notes
+            // 4) Mission notes — canonical source is mission_dashboard.notes JSONB.
             let notes = [];
             if (options.includeNotes) {
-                const noteWhere = ['device_id = $1'];
+                const noteWhere = ['md.device_id = $1'];
                 const noteArgs = [deviceId];
                 let np = 2;
                 if (options.scope === 'entity') {
-                    noteWhere.push(`created_by = $${np}`);
-                    noteArgs.push(String(options.callerEntityId));
+                    noteWhere.push(`note->>'createdBy' = $${np}`);
+                    noteArgs.push(`entity_${options.callerEntityId}`);
                     np++;
                 }
                 const noteSql = `
-                    SELECT id, title, content, category, created_by, updated_at
-                    FROM mission_notes
+                    SELECT
+                        note->>'id' AS id,
+                        COALESCE(note->>'title', '') AS title,
+                        COALESCE(note->>'content', '') AS content,
+                        COALESCE(note->>'category', 'general') AS category,
+                        CASE
+                            WHEN note->>'createdBy' LIKE 'entity_%' THEN substring(note->>'createdBy' FROM 8)
+                            ELSE note->>'createdBy'
+                        END AS created_by,
+                        CASE
+                            WHEN (note->>'updatedAt') ~ '^[0-9]+$' THEN to_timestamp((note->>'updatedAt')::double precision / 1000)
+                            ELSE NULL
+                        END AS updated_at
+                    FROM mission_dashboard md
+                    CROSS JOIN LATERAL jsonb_array_elements(COALESCE(md.notes, '[]'::jsonb)) AS n(note)
                     WHERE ${noteWhere.join(' AND ')}
-                    ORDER BY updated_at DESC NULLS LAST
+                      AND COALESCE(note->>'id', '') <> ''
+                    ORDER BY CASE WHEN (note->>'updatedAt') ~ '^[0-9]+$' THEN (note->>'updatedAt')::bigint ELSE 0 END DESC
                     LIMIT ${hardCardCap}
                 `;
                 const notesResult = await pool.query(noteSql, noteArgs);
                 notes = notesResult.rows;
             }
+
+            const noteIds = [...new Set(notes.map(n => n.id).filter(Boolean))];
+            const noteCardLinksResult = (noteIds.length === 0 && allCardIds.length === 0) ? { rows: [] } : await pool.query(
+                `SELECT note_id, card_id
+                 FROM mission_note_card_links
+                 WHERE device_id = $1
+                   AND (note_id = ANY($2::varchar[]) OR card_id = ANY($3::varchar[]))`,
+                [deviceId, noteIds, allCardIds]
+            );
 
             // 5) Mindmap anchors (cross-correlation: note↔card, note↔chat, card↔chat)
             const anchorsResult = await pool.query(
@@ -997,6 +1020,7 @@ function createMindmapModule(devices) {
                 cards,
                 initialCardIds,
                 depRows: depsResult.rows,
+                noteCardLinkRows: noteCardLinksResult.rows,
                 commentCounts: commentCounts.rows,
                 noteCounts: noteCounts.rows,
                 notes,

--- a/backend/mission.js
+++ b/backend/mission.js
@@ -72,6 +72,118 @@ function substituteEnvVars(text, vars) {
     );
 }
 
+
+function normalizeLinkedCardIds(raw) {
+    if (raw === undefined) return undefined;
+    if (raw === null || raw === '') return [];
+    const arr = Array.isArray(raw) ? raw : String(raw).split(',');
+    const seen = new Set();
+    const out = [];
+    for (const v of arr) {
+        const id = String(v && typeof v === 'object' ? (v.id || v.cardId || v.value || '') : v || '').trim();
+        if (!id || seen.has(id)) continue;
+        seen.add(id);
+        out.push(id);
+    }
+    return out;
+}
+
+function getLinkedCardIdsFromNote(note) {
+    const explicit = normalizeLinkedCardIds(note && note.linkedCardIds);
+    if (explicit !== undefined) return explicit;
+    // Compatibility bridge: old note.anchor={type:'kanban_card',refId} remains
+    // useful as a one-card link until users explicitly edit linkedCardIds.
+    const anchor = note && mindmapMirror.normalizeAnchor(note.anchor);
+    return anchor && anchor.type === 'kanban_card' ? [anchor.refId] : [];
+}
+
+async function assertCardsBelongToDevice(queryable, deviceId, cardIds) {
+    const ids = normalizeLinkedCardIds(cardIds) || [];
+    if (ids.length === 0) return ids;
+    const result = await queryable.query(
+        `SELECT id FROM kanban_cards WHERE device_id = $1 AND id = ANY($2::varchar[])`,
+        [deviceId, ids]
+    );
+    const found = new Set(result.rows.map(r => r.id));
+    const missing = ids.filter(id => !found.has(id));
+    if (missing.length > 0) {
+        const err = new Error(`Invalid linkedCardIds for this device: ${missing.join(', ')}`);
+        err.statusCode = 400;
+        throw err;
+    }
+    return ids;
+}
+
+async function replaceNoteCardLinks(queryable, deviceId, noteId, cardIds, entityId) {
+    const ids = await assertCardsBelongToDevice(queryable, deviceId, cardIds);
+    await queryable.query(
+        `DELETE FROM mission_note_card_links WHERE device_id = $1 AND note_id = $2`,
+        [deviceId, noteId]
+    );
+    for (const cardId of ids) {
+        await queryable.query(
+            `INSERT INTO mission_note_card_links (device_id, note_id, card_id, created_by)
+             VALUES ($1, $2, $3, $4)
+             ON CONFLICT (device_id, note_id, card_id) DO NOTHING`,
+            [deviceId, noteId, cardId, entityId == null ? 0 : Number(entityId) || 0]
+        );
+    }
+    return ids;
+}
+
+async function hydrateNoteCardLinks(queryable, deviceId, notes) {
+    if (!Array.isArray(notes) || notes.length === 0) return notes || [];
+    const ids = notes.map(n => n && n.id).filter(Boolean);
+    if (ids.length === 0) return notes;
+    const result = await queryable.query(
+        `SELECT note_id, card_id
+         FROM mission_note_card_links
+         WHERE device_id = $1 AND note_id = ANY($2::varchar[])
+         ORDER BY created_at, card_id`,
+        [deviceId, ids]
+    );
+    const byNote = new Map();
+    for (const row of result.rows) {
+        if (!byNote.has(row.note_id)) byNote.set(row.note_id, []);
+        byNote.get(row.note_id).push(row.card_id);
+    }
+    return notes.map(note => ({
+        ...note,
+        linkedCardIds: byNote.has(note.id) ? byNote.get(note.id) : getLinkedCardIdsFromNote(note),
+    }));
+}
+
+function findNoteById(notes, noteId) {
+    return (notes || []).find(n => n && n.id === noteId) || null;
+}
+
+async function replaceLinkedCardsInDashboard(queryable, deviceId, noteId, cardIds) {
+    const result = await queryable.query(
+        'SELECT notes FROM mission_dashboard WHERE device_id = $1 FOR UPDATE',
+        [deviceId]
+    );
+    if (result.rows.length === 0) {
+        const err = new Error('Dashboard not found');
+        err.statusCode = 404;
+        throw err;
+    }
+    const notes = result.rows[0].notes || [];
+    const note = findNoteById(notes, noteId);
+    if (!note) {
+        const err = new Error(`Note not found: "${noteId}"`);
+        err.statusCode = 404;
+        throw err;
+    }
+    note.linkedCardIds = cardIds;
+    note.updatedAt = Date.now();
+    const updateResult = await queryable.query(
+        `UPDATE mission_dashboard SET notes = $2, last_synced_at = NOW()
+         WHERE device_id = $1 RETURNING version`,
+        [deviceId, JSON.stringify(notes)]
+    );
+    return { note, version: updateResult.rows[0] && updateResult.rows[0].version };
+}
+
 function applyVarSubstitution(dashboard, dvRow) {
     // Skip decryption if no {{KEY}} references exist anywhere
     const hasRefs =
@@ -376,7 +488,7 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
                 todoList: row.todo_list,
                 missionList: row.mission_list,
                 doneList: row.done_list,
-                notes: row.notes,
+                notes: await hydrateNoteCardLinks(pool, deviceId, row.notes || []),
                 rules: row.rules,
                 skills: skills,
                 souls: row.souls || [],
@@ -450,6 +562,14 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
                 uploadedSkills = [...systemSkills, ...uploadedSkills];
             }
 
+            const uploadedNotes = dashboard.notes || [];
+            for (const note of uploadedNotes) {
+                const linked = normalizeLinkedCardIds(note && note.linkedCardIds);
+                if (linked !== undefined) {
+                    note.linkedCardIds = await assertCardsBelongToDevice(client, deviceId, linked);
+                }
+            }
+
             // Update dashboard (Trigger will auto-increment version)
             const result = await client.query(
                 `UPDATE mission_dashboard
@@ -469,6 +589,22 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
                 ]
             );
 
+            const existingNoteIds = new Set(existingNotes.map(n => n && n.id).filter(Boolean));
+            const uploadedNoteIds = new Set(uploadedNotes.map(n => n && n.id).filter(Boolean));
+            const deletedNoteIds = [...existingNoteIds].filter(id => !uploadedNoteIds.has(id));
+            if (deletedNoteIds.length > 0) {
+                await client.query(
+                    `DELETE FROM mission_note_card_links
+                     WHERE device_id = $1 AND note_id = ANY($2::varchar[])`,
+                    [deviceId, deletedNoteIds]
+                );
+            }
+            for (const note of uploadedNotes) {
+                if (!note || !note.id || !Object.prototype.hasOwnProperty.call(note, 'linkedCardIds')) continue;
+                const ids = await replaceNoteCardLinks(client, deviceId, note.id, note.linkedCardIds, entityId);
+                note.linkedCardIds = ids;
+            }
+
             // Log sync action
             await client.query(
                 'SELECT record_sync_action($1, $2, $3, $4, $5, $6, $7)',
@@ -482,7 +618,6 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
             // dashboard commit; failures are logged + swallowed because the
             // mirror is a derived read model.
             try {
-                const uploadedNotes = dashboard.notes || [];
                 const existingById = new Map(existingNotes.map(n => [n.id, n]));
                 const uploadedById = new Map(uploadedNotes.map(n => [n.id, n]));
                 for (const note of uploadedNotes) {
@@ -494,7 +629,8 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
                         before.title !== note.title ||
                         before.content !== note.content ||
                         before.category !== note.category ||
-                        JSON.stringify(before.anchor || null) !== JSON.stringify(note.anchor || null)
+                        JSON.stringify(before.anchor || null) !== JSON.stringify(note.anchor || null) ||
+                        JSON.stringify(getLinkedCardIdsFromNote(before)) !== JSON.stringify(getLinkedCardIdsFromNote(note))
                     ) {
                         fireMirror(mindmapMirror.mirrorNoteUpdate, [pool, deviceId, entityId, note]);
                     }
@@ -518,7 +654,7 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
         } catch (error) {
             await client.query('ROLLBACK');
             console.error('[Mission] Error updating dashboard:', error);
-            res.status(500).json({ success: false, error: error.message });
+            res.status(error.statusCode || 500).json({ success: false, error: error.message });
         } finally {
             client.release();
         }
@@ -712,6 +848,7 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
                 [deviceId]
             );
             let notes = result.rows.length > 0 ? (result.rows[0].notes || []) : [];
+            notes = await hydrateNoteCardLinks(pool, deviceId, notes);
             if (category) {
                 notes = notes.filter(n => (n.category || 'general') === category);
             }
@@ -731,6 +868,7 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
     router.post('/note/add', async (req, res) => {
         if (!authenticate(req, res)) return;
         const { deviceId, entityId, title, content, category, anchor } = req.body;
+        const linkedCardIdsInput = normalizeLinkedCardIds(req.body.linkedCardIds);
 
         if (!title) {
             return res.status(400).json({ success: false, error: 'Missing title' });
@@ -751,6 +889,9 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
                 'SELECT notes FROM mission_dashboard WHERE device_id = $1 FOR UPDATE', [deviceId]
             );
             const notes = (result.rows[0] && result.rows[0].notes) || [];
+            const linkedCardIds = linkedCardIdsInput !== undefined
+                ? await assertCardsBelongToDevice(client, deviceId, linkedCardIdsInput)
+                : [];
             const newNote = {
                 id: noteId,
                 title: title.trim(),
@@ -759,9 +900,13 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
                 createdAt: Date.now(),
                 updatedAt: Date.now(),
                 createdBy: entityId != null ? `entity_${entityId}` : 'bot',
-                ...(normAnchor ? { anchor: normAnchor } : {})
+                ...(normAnchor ? { anchor: normAnchor } : {}),
+                ...(linkedCardIdsInput !== undefined ? { linkedCardIds } : {})
             };
             notes.push(newNote);
+            if (linkedCardIdsInput !== undefined) {
+                await replaceNoteCardLinks(client, deviceId, noteId, linkedCardIds, entityId);
+            }
             const updateResult = await client.query(
                 'UPDATE mission_dashboard SET notes = $2, last_synced_at = NOW() WHERE device_id = $1 RETURNING version',
                 [deviceId, JSON.stringify(notes)]
@@ -782,7 +927,7 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
         } catch (error) {
             await client.query('ROLLBACK');
             console.error('[Mission] Error adding note:', error);
-            res.status(500).json({ success: false, error: error.message });
+            res.status(error.statusCode || 500).json({ success: false, error: error.message });
         } finally {
             client.release();
         }
@@ -805,6 +950,8 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
         const newAnchor = anchorTouched
             ? (req.body.anchor === null ? null : mindmapMirror.normalizeAnchor(req.body.anchor))
             : undefined;
+        const linkedCardIdsTouched = Object.prototype.hasOwnProperty.call(req.body, 'linkedCardIds');
+        const linkedCardIdsInput = linkedCardIdsTouched ? normalizeLinkedCardIds(req.body.linkedCardIds) : undefined;
 
         if (!title) {
             return res.status(400).json({ success: false, error: 'Missing title' });
@@ -839,6 +986,13 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
                 if (newAnchor) note.anchor = newAnchor;
                 else delete note.anchor;
             }
+            if (linkedCardIdsTouched) {
+                if (!note.id) {
+                    await client.query('ROLLBACK');
+                    return res.status(400).json({ success: false, error: 'Cannot link cards: note is missing id' });
+                }
+                note.linkedCardIds = await replaceNoteCardLinks(client, deviceId, note.id, linkedCardIdsInput, entityId);
+            }
             note.updatedAt = Date.now();
 
             const updateResult = await client.query(
@@ -860,6 +1014,7 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
                 // mirror treats `undefined` as "leave parent alone" and
                 // `null` as "clear anchor → fall back to category".
                 ...(anchorTouched ? { anchor: newAnchor } : {}),
+                ...(linkedCardIdsTouched ? { linkedCardIds: note.linkedCardIds } : {}),
             };
             fireMirror(mindmapMirror.mirrorNoteUpdate, [pool, deviceId, entityId, mirrorNote]);
 
@@ -867,7 +1022,7 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
         } catch (error) {
             await client.query('ROLLBACK');
             console.error('[Mission] Error updating note:', error);
-            res.status(500).json({ success: false, error: error.message });
+            res.status(error.statusCode || 500).json({ success: false, error: error.message });
         } finally {
             client.release();
         }
@@ -909,6 +1064,9 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
 
             const deletedNote = notes[foundIdx];
             notes.splice(foundIdx, 1);
+            if (deletedNote && deletedNote.id) {
+                await client.query('DELETE FROM mission_note_card_links WHERE device_id = $1 AND note_id = $2', [deviceId, deletedNote.id]);
+            }
 
             const updateResult = await client.query(
                 `UPDATE mission_dashboard SET notes = $2, last_synced_at = NOW()
@@ -929,6 +1087,123 @@ module.exports = function(devices, { awardEntityXP: _awardEntityXP, serverLog } 
             await client.query('ROLLBACK');
             console.error('[Mission] Error deleting note:', error);
             res.status(500).json({ success: false, error: error.message });
+        } finally {
+            client.release();
+        }
+    });
+
+
+    // ============================================
+    // Mission note ↔ Kanban card explicit link API
+    // ============================================
+    router.get('/note/:noteId/cards', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const deviceId = req.query.deviceId || req.body.deviceId;
+        const { noteId } = req.params;
+        try {
+            const notesRow = await pool.query('SELECT notes FROM mission_dashboard WHERE device_id = $1', [deviceId]);
+            const note = findNoteById(notesRow.rows[0] && notesRow.rows[0].notes, noteId);
+            if (!note) return res.status(404).json({ success: false, error: `Note not found: "${noteId}"` });
+            const links = await pool.query(
+                `SELECT l.card_id, l.created_at, c.title, c.status, c.priority
+                 FROM mission_note_card_links l
+                 JOIN kanban_cards c ON c.id = l.card_id AND c.device_id = l.device_id
+                 WHERE l.device_id = $1 AND l.note_id = $2
+                 ORDER BY l.created_at, l.card_id`,
+                [deviceId, noteId]
+            );
+            res.json({
+                success: true,
+                noteId,
+                linkedCardIds: links.rows.map(r => r.card_id),
+                cards: links.rows.map(r => ({
+                    id: r.card_id,
+                    title: r.title,
+                    status: r.status,
+                    priority: r.priority,
+                    linkedAt: new Date(r.created_at).getTime(),
+                })),
+            });
+        } catch (error) {
+            console.error('[Mission] Error listing note/card links:', error);
+            res.status(500).json({ success: false, error: error.message });
+        }
+    });
+
+    router.put('/note/:noteId/cards', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const params = { ...req.query, ...req.body };
+        const { deviceId, entityId } = params;
+        const { noteId } = req.params;
+        const linkedCardIds = normalizeLinkedCardIds(params.linkedCardIds !== undefined ? params.linkedCardIds : params.cardIds);
+        if (linkedCardIds === undefined) return res.status(400).json({ success: false, error: 'Missing linkedCardIds' });
+        const client = await pool.connect();
+        try {
+            await client.query('BEGIN');
+            const ids = await replaceNoteCardLinks(client, deviceId, noteId, linkedCardIds, entityId);
+            const { note, version } = await replaceLinkedCardsInDashboard(client, deviceId, noteId, ids);
+            await client.query('COMMIT');
+            fireMirror(mindmapMirror.mirrorNoteUpdate, [pool, deviceId, entityId, { ...note, linkedCardIds: ids }]);
+            res.json({ success: true, noteId, linkedCardIds: ids, item: note, version });
+        } catch (error) {
+            await client.query('ROLLBACK');
+            console.error('[Mission] Error replacing note/card links:', error);
+            res.status(error.statusCode || 500).json({ success: false, error: error.message });
+        } finally {
+            client.release();
+        }
+    });
+
+    router.post('/note/:noteId/card', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const params = { ...req.query, ...req.body };
+        const { deviceId, entityId, cardId } = params;
+        const { noteId } = req.params;
+        if (!cardId) return res.status(400).json({ success: false, error: 'Missing cardId' });
+        const client = await pool.connect();
+        try {
+            await client.query('BEGIN');
+            const current = await client.query(
+                `SELECT card_id FROM mission_note_card_links WHERE device_id = $1 AND note_id = $2 ORDER BY created_at, card_id`,
+                [deviceId, noteId]
+            );
+            const ids = normalizeLinkedCardIds([...current.rows.map(r => r.card_id), cardId]);
+            const validated = await replaceNoteCardLinks(client, deviceId, noteId, ids, entityId);
+            const { note, version } = await replaceLinkedCardsInDashboard(client, deviceId, noteId, validated);
+            await client.query('COMMIT');
+            fireMirror(mindmapMirror.mirrorNoteUpdate, [pool, deviceId, entityId, { ...note, linkedCardIds: validated }]);
+            res.json({ success: true, noteId, linkedCardIds: validated, item: note, version });
+        } catch (error) {
+            await client.query('ROLLBACK');
+            console.error('[Mission] Error adding note/card link:', error);
+            res.status(error.statusCode || 500).json({ success: false, error: error.message });
+        } finally {
+            client.release();
+        }
+    });
+
+    router.delete('/note/:noteId/card/:cardId', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const deviceId = req.body.deviceId || req.query.deviceId;
+        const entityId = req.body.entityId || req.query.entityId;
+        const { noteId, cardId } = req.params;
+        const client = await pool.connect();
+        try {
+            await client.query('BEGIN');
+            const current = await client.query(
+                `SELECT card_id FROM mission_note_card_links WHERE device_id = $1 AND note_id = $2 ORDER BY created_at, card_id`,
+                [deviceId, noteId]
+            );
+            const ids = current.rows.map(r => r.card_id).filter(id => id !== cardId);
+            await replaceNoteCardLinks(client, deviceId, noteId, ids, entityId);
+            const { note, version } = await replaceLinkedCardsInDashboard(client, deviceId, noteId, ids);
+            await client.query('COMMIT');
+            fireMirror(mindmapMirror.mirrorNoteUpdate, [pool, deviceId, entityId, { ...note, linkedCardIds: ids }]);
+            res.json({ success: true, noteId, linkedCardIds: ids, deleted: current.rows.some(r => r.card_id === cardId) ? 1 : 0, version });
+        } catch (error) {
+            await client.query('ROLLBACK');
+            console.error('[Mission] Error deleting note/card link:', error);
+            res.status(error.statusCode || 500).json({ success: false, error: error.message });
         } finally {
             client.release();
         }
@@ -2459,7 +2734,8 @@ async function submitPayment() {
                 [deviceId, JSON.stringify(notes)]
             );
             
-            // Delete associated note page if exists
+            // Delete associated note/card links and note page if exists
+            await client.query('DELETE FROM mission_note_card_links WHERE device_id = $1 AND note_id = $2', [deviceId, id]);
             await client.query('DELETE FROM note_pages WHERE device_id = $1 AND note_id = $2', [deviceId, id]);
 
             await client.query('COMMIT');

--- a/backend/mission_schema.sql
+++ b/backend/mission_schema.sql
@@ -333,3 +333,26 @@ ALTER TABLE mission_rules ALTER COLUMN id DROP DEFAULT;
 ALTER TABLE mission_rules ALTER COLUMN id TYPE VARCHAR(48) USING id::text;
 ALTER TABLE mission_rules ALTER COLUMN id SET DEFAULT ('rule_' || encode(gen_random_bytes(12), 'hex'));
 ALTER TABLE mission_sync_log ALTER COLUMN item_id TYPE VARCHAR(48) USING item_id::text;
+
+-- ============================================
+-- Mission note ↔ Kanban card explicit links
+-- Source of truth for first-class note_on_card graph edges.
+-- Notes live in mission_dashboard.notes JSONB, so note_id is validated in
+-- route code and cannot use a database FK. Cards are validated device-scoped
+-- before insert/update.
+-- ============================================
+CREATE TABLE IF NOT EXISTS mission_note_card_links (
+    id BIGSERIAL PRIMARY KEY,
+    device_id VARCHAR(64) NOT NULL REFERENCES mission_dashboard(device_id) ON DELETE CASCADE,
+    note_id VARCHAR(48) NOT NULL,
+    card_id VARCHAR(48) NOT NULL,
+    created_by INTEGER DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(device_id, note_id, card_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_mission_note_card_links_note
+ON mission_note_card_links(device_id, note_id);
+
+CREATE INDEX IF NOT EXISTS idx_mission_note_card_links_card
+ON mission_note_card_links(device_id, card_id);

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -1835,6 +1835,20 @@
             el.innerHTML = html;
         }
 
+        function noteLinkedCardIds(note) {
+            return Array.isArray(note && note.linkedCardIds)
+                ? note.linkedCardIds.filter(Boolean)
+                : [];
+        }
+
+        function linkedCardBadgeHtml(note) {
+            const ids = noteLinkedCardIds(note);
+            if (!ids.length) return '';
+            const cardById = new Map((_kanbanCardsCache || []).map(c => [c.id, c]));
+            const titles = ids.map(id => (cardById.get(id)?.title || id).slice(0, 60)).join('\n');
+            return `<span class="item-badge" title="${esc(titles)}">🔗 ${ids.length}</span>`;
+        }
+
         function renderNoteItemHtml(n) {
             const hasPage = notePageIds.has(n.id);
             return `
@@ -1843,6 +1857,7 @@
                  onclick="showEditNote('${n.id}')" oncontextmenu="showNoteMenu(event,'${n.id}')">
                 <div class="item-row">
                     <span class="item-title">${esc(n.title)}</span>
+                    ${linkedCardBadgeHtml(n)}
                     ${hasPage ? `<span class="${notePagePublic[n.id] ? 'note-public-tag' : 'note-private-tag'}">${notePagePublic[n.id] ? '🌐 ' + (i18n.t('mc_note_public_label') || 'Public') : '🔒 ' + (i18n.t('mc_note_private_label') || 'Private')}</span><button class="note-page-btn" onclick="event.stopPropagation();openPageViewer('${n.id}')" title="${i18n.t('mc_note_open_page')}">🌐</button>` : ''}
                     <button class="item-delete" onclick="event.stopPropagation();deleteNote('${n.id}')" title="${i18n.t('common_delete')}">&times;</button>
                 </div>
@@ -2019,12 +2034,29 @@
             return opts;
         }
 
+        function getLinkedCardOptions(cards, currentIds) {
+            const selected = new Set((currentIds || []).map(String));
+            const opts = cards.map(c => ({
+                value: c.id,
+                label: `🔗 ${(c.title || c.id).slice(0, 60)}`
+            }));
+            for (const id of selected) {
+                if (id && !opts.some(o => o.value === id)) opts.push({ value: id, label: `🔗 ${id}` });
+            }
+            return opts;
+        }
+
+        function parseLinkedCardIdsFromDialogValue(value) {
+            return String(value || '').split(',').map(s => s.trim()).filter(Boolean);
+        }
+
         async function showAddNote() {
             const cards = await getKanbanCardsForAnchor();
             showDialog(i18n.t('mc_dlg_add_note'), [
                 { key: 'title', label: i18n.t('mc_dlg_title'), value: '' },
                 { key: 'content', label: i18n.t('mc_dlg_content'), type: 'textarea', value: '' },
                 { key: 'category', label: i18n.t('mc_dlg_category'), type: 'select', value: '', options: getCategoryOptions('notes') },
+                { key: 'linkedCardIds', label: i18n.t('mc_dlg_linked_cards') || 'Linked Kanban cards', type: 'multiselect', value: '', options: getLinkedCardOptions(cards, []) },
                 { key: 'anchor', label: i18n.t('mc_dlg_anchor') || '釘到看板卡片', type: 'select', value: '', options: getAnchorOptions(cards, null) }
             ], vals => {
                 if (!vals.title.trim()) return;
@@ -2037,6 +2069,7 @@
                     createdAt: Date.now(),
                     updatedAt: Date.now(),
                     createdBy: 'user',
+                    linkedCardIds: parseLinkedCardIdsFromDialogValue(vals.linkedCardIds),
                     ...(anchor ? { anchor } : {})
                 });
                 markChanged();
@@ -2053,12 +2086,14 @@
                 { key: 'title', label: i18n.t('mc_dlg_title'), value: note.title },
                 { key: 'content', label: i18n.t('mc_dlg_content'), type: 'textarea', value: note.content },
                 { key: 'category', label: i18n.t('mc_dlg_category'), type: 'select', value: note.category || '', options: getCategoryOptions('notes') },
+                { key: 'linkedCardIds', label: i18n.t('mc_dlg_linked_cards') || 'Linked Kanban cards', type: 'multiselect', value: noteLinkedCardIds(note).join(','), options: getLinkedCardOptions(cards, noteLinkedCardIds(note)) },
                 { key: 'anchor', label: i18n.t('mc_dlg_anchor') || '釘到看板卡片', type: 'select', value: pickerValueFromAnchor(note.anchor), options: getAnchorOptions(cards, note.anchor) }
             ], vals => {
                 if (!vals.title.trim()) return;
                 note.title = vals.title.trim();
                 note.content = vals.content.trim();
                 note.category = vals.category || null;
+                note.linkedCardIds = parseLinkedCardIdsFromDialogValue(vals.linkedCardIds);
                 const newAnchor = anchorFromPickerValue(vals.anchor);
                 if (newAnchor) note.anchor = newAnchor;
                 else delete note.anchor;

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -9368,6 +9368,7 @@ const TRANSLATIONS = {
 
 
         "mc_dlg_anchor": "Pin to kanban card",
+        "mc_dlg_linked_cards": "Linked Kanban cards",
 
 
 
@@ -1823822,6 +1823823,7 @@ const TRANSLATIONS = {
 
 
         "mc_dlg_anchor": "釘選至 kanban 卡片",
+        "mc_dlg_linked_cards": "連結的 Kanban 卡片",
 
 
 
@@ -2408192,6 +2408194,7 @@ const TRANSLATIONS = {
 
 
         "mc_dlg_anchor": "カンバンカードにピン留め",
+        "mc_dlg_linked_cards": "リンクされたカンバンカード",
 
 
 

--- a/backend/tests/jest/mindmap-graph.test.js
+++ b/backend/tests/jest/mindmap-graph.test.js
@@ -220,6 +220,33 @@ describe('mindmap-graph-projection — pure helpers', () => {
         expect(result.stats.edgeCounts.owner).toBeGreaterThanOrEqual(2);
     });
 
+    test('projectGraph emits note_on_card edges from explicit mission_note_card_links', () => {
+        const result = projection.projectGraph({
+            cards: [
+                { id: 'card_a', title: 'A', description: '', priority: 'P1', status: 'todo', parent_card_id: null, is_automation: false, assigned_bots: [], created_by: 0, reviewer_entity_id: null, chat_anchor_message_id: null, archived: false, updated_at: null },
+            ],
+            initialCardIds: new Set(['card_a']),
+            depRows: [],
+            noteCardLinkRows: [{ note_id: 'note_a', card_id: 'card_a' }],
+            commentCounts: [],
+            noteCounts: [],
+            notes: [{ id: 'note_a', title: 'linked note', content: '', category: 'general', created_by: '2', updated_at: null }],
+            anchorRows: [],
+            entityMap: {},
+            options: projection.parseGraphOptions(
+                { includeNotes: 'true', includeOwners: 'none' },
+                { isDeviceAuth: true, callerEntityId: null }
+            ),
+        });
+        const edge = result.links.find(l => l.type === 'note_on_card');
+        expect(edge).toMatchObject({
+            source: 'note:note_a',
+            target: 'task:card_a',
+            evidence: 'mission_note_card_links',
+        });
+        expect(result.stats.edgeCounts.note_on_card).toBe(1);
+    });
+
     test('projectGraph emits chat_anchor edges (amendment A)', () => {
         const cards = [
             { id: 'card_a', title: 'pinned to chat', description: '', priority: 'P1', status: 'todo', parent_card_id: null, is_automation: false, assigned_bots: [2], created_by: 1, reviewer_entity_id: null, chat_anchor_message_id: 'msg-pinned', archived: false, updated_at: null },
@@ -378,7 +405,9 @@ describe('GET /api/mindmap/graph — HTTP', () => {
             .mockResolvedValueOnce({ rows: [{ card_id: 'card_p', cnt: 2 }] })
             // 3b) note counts
             .mockResolvedValueOnce({ rows: [] })
-            // 4) mission_notes
+            // 4) mission notes from dashboard JSON
+            .mockResolvedValueOnce({ rows: [] })
+            // 4b) explicit note/card links
             .mockResolvedValueOnce({ rows: [] })
             // 5) mindmap_node_anchors
             .mockResolvedValueOnce({ rows: [] });
@@ -437,6 +466,7 @@ describe('GET /api/mindmap/graph — HTTP', () => {
             .mockResolvedValueOnce({ rows: [] }) // comment counts
             .mockResolvedValueOnce({ rows: [] }) // note counts
             .mockResolvedValueOnce({ rows: [] }) // mission notes
+            .mockResolvedValueOnce({ rows: [] }) // explicit note/card links
             .mockResolvedValueOnce({ rows: [] }); // anchors
 
         const res = await request(app).get('/api/mindmap/graph' + AUTH);
@@ -448,6 +478,35 @@ describe('GET /api/mindmap/graph — HTTP', () => {
         expect(chatEdge.source).toBe('task:card_a');
         expect(chatEdge.target).toBe('chat:msg-xyz');
         expect(chatEdge.evidence).toBe('kanban_cards.chat_anchor_message_id');
+    });
+
+    test('explicit note/card links are projected into graph output', async () => {
+        mockQuery.mockReset();
+        mockQuery
+            .mockResolvedValueOnce({
+                rows: [{
+                    id: 'card_a', title: 'A', description: '', priority: 'P1', status: 'todo',
+                    parent_card_id: null, is_automation: false,
+                    assigned_bots: [], created_by: 0, reviewer_entity_id: null,
+                    chat_anchor_message_id: null, archived: false, updated_at: null,
+                }],
+            })
+            .mockResolvedValueOnce({ rows: [] }) // deps
+            .mockResolvedValueOnce({ rows: [] }) // comment counts
+            .mockResolvedValueOnce({ rows: [] }) // note counts
+            .mockResolvedValueOnce({ rows: [{ id: 'note_a', title: 'N', content: '', category: 'general', created_by: '2', updated_at: null }] }) // mission notes
+            .mockResolvedValueOnce({ rows: [{ note_id: 'note_a', card_id: 'card_a' }] }) // explicit note/card links
+            .mockResolvedValueOnce({ rows: [] }); // anchors
+
+        const res = await request(app).get('/api/mindmap/graph' + AUTH);
+        expect(res.status).toBe(200);
+        const edge = res.body.graph.links.find(l => l.type === 'note_on_card');
+        expect(edge).toMatchObject({
+            source: 'note:note_a',
+            target: 'task:card_a',
+            evidence: 'mission_note_card_links',
+        });
+        expect(res.body.stats.edgeCounts.note_on_card).toBe(1);
     });
 
     test('503 when pool unset (initMindmapTables not run)', async () => {

--- a/backend/tests/jest/mission-notes-rules.test.js
+++ b/backend/tests/jest/mission-notes-rules.test.js
@@ -31,8 +31,8 @@ jest.mock('pg', () => {
     globalThis.__missionState = state;
 
     function runQuery(sql, params = []) {
-        state.lastQuery = { sql, params };
         const norm = sql.replace(/\s+/g, ' ').trim();
+        if (!/mission_note_card_links/i.test(norm)) state.lastQuery = { sql, params };
 
         // This is the regression guard: if the handler ever queries the
         // legacy tables again, bail loudly.
@@ -50,6 +50,9 @@ jest.mock('pg', () => {
         if (/SELECT rules FROM mission_dashboard/i.test(norm)) {
             const row = state.dashboard[params[0]];
             return { rows: row ? [{ rules: row.rules }] : [], rowCount: row ? 1 : 0 };
+        }
+        if (/FROM mission_note_card_links/i.test(norm)) {
+            return { rows: [], rowCount: 0 };
         }
         return { rows: [], rowCount: 0 };
     }

--- a/backend/tests/jest/mission.test.js
+++ b/backend/tests/jest/mission.test.js
@@ -9,10 +9,11 @@
 // Exposed so deeper tests can seed SELECT/UPDATE responses per-case.
 // Keep the `mock` prefix — Jest allows only mock* identifiers in jest.mock factories.
 const mockClientQuery = jest.fn().mockResolvedValue({ rows: [] });
+const mockPoolQuery = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
 
 jest.mock('pg', () => ({
     Pool: jest.fn().mockImplementation(() => ({
-        query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+        query: mockPoolQuery,
         connect: jest.fn().mockImplementation(() => Promise.resolve({
             query: mockClientQuery,
             release: jest.fn(),
@@ -316,21 +317,31 @@ describe('Deep persistence assertions in update endpoints', () => {
         capturedWrites = [];
         dashboardRow = { notes: [], rules: [], skills: [], souls: [] };
 
-        mockClientQuery.mockImplementation(async (sql, params) => {
+        const queryImpl = async (sql, params) => {
             const s = typeof sql === 'string' ? sql.trim() : '';
             if (/^(BEGIN|COMMIT|ROLLBACK)/i.test(s)) return { rows: [] };
+            if (/FROM kanban_cards/i.test(s)) {
+                const wanted = Array.isArray(params && params[1]) ? new Set(params[1]) : new Set();
+                const rows = ['card_a', 'card_b'].filter(id => wanted.has(id)).map(id => ({ id }));
+                return { rows };
+            }
+            if (/^(DELETE|INSERT)/i.test(s)) return { rows: [], rowCount: 1 };
             if (/^SELECT/i.test(s)) return { rows: [dashboardRow] };
             if (/^UPDATE/i.test(s)) {
                 capturedWrites.push({ sql: s, params });
                 return { rows: [{ version: 42 }] };
             }
             return { rows: [] };
-        });
+        };
+        mockClientQuery.mockImplementation(queryImpl);
+        mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
     });
 
     afterEach(() => {
         mockClientQuery.mockReset();
         mockClientQuery.mockResolvedValue({ rows: [] });
+        mockPoolQuery.mockReset();
+        mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
     });
 
     const writeFor = (column) => capturedWrites.find(w => w.sql.includes(`SET ${column}`));
@@ -435,6 +446,99 @@ describe('Deep persistence assertions in update endpoints', () => {
             .send({ ...auth, title: 'N1', content: 'just a body change' });
         expect(res.status).toBe(200);
         expect(persisted('notes')[0].anchor).toEqual(original);
+    });
+    it('note/update — linkedCardIds replaces explicit note/card links and persists note JSON', async () => {
+        dashboardRow.notes = [{ id: 'note_a', title: 'N1', content: 'body' }];
+        const res = await post('/api/mission/note/update')
+            .send({ ...auth, title: 'N1', entityId: 0, linkedCardIds: ['card_a', 'card_b', 'card_a'] });
+        expect(res.status).toBe(200);
+        expect(persisted('notes')[0].linkedCardIds).toEqual(['card_a', 'card_b']);
+        const sql = capturedWrites.map(w => w.sql).join('\n');
+        expect(sql).toMatch(/mission_dashboard SET notes/);
+    });
+
+    it('note/update — invalid linkedCardIds returns 400 before persisting', async () => {
+        dashboardRow.notes = [{ id: 'note_a', title: 'N1', content: 'body' }];
+        const res = await post('/api/mission/note/update')
+            .send({ ...auth, title: 'N1', linkedCardIds: ['missing_card'] });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/Invalid linkedCardIds/);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// Mission note ↔ Kanban card explicit link CRUD
+// ════════════════════════════════════════════════════════════════
+describe('Mission note/card link CRUD', () => {
+    const auth = { deviceId: 'test-dev', deviceSecret: 'test-secret', entityId: 0 };
+    let dashboardRow;
+    let cardRows;
+    let linkRows;
+
+    beforeEach(() => {
+        dashboardRow = { notes: [{ id: 'note_a', title: 'N1', content: 'body' }] };
+        cardRows = [
+            { id: 'card_a', title: 'Card A', status: 'todo', priority: 'P1' },
+            { id: 'card_b', title: 'Card B', status: 'review', priority: 'P2' },
+        ];
+        linkRows = [{ note_id: 'note_a', card_id: 'card_a', title: 'Card A', status: 'todo', priority: 'P1', created_at: new Date('2026-05-13T00:00:00Z') }];
+        const queryImpl = async (sql, params) => {
+            const s = typeof sql === 'string' ? sql.trim() : '';
+            if (/^(BEGIN|COMMIT|ROLLBACK)/i.test(s)) return { rows: [] };
+            if (/FROM kanban_cards/i.test(s)) {
+                const wanted = Array.isArray(params && params[1]) ? new Set(params[1]) : new Set(cardRows.map(c => c.id));
+                return { rows: cardRows.filter(c => wanted.has(c.id)) };
+            }
+            if (/FROM mission_dashboard/i.test(s)) return { rows: [dashboardRow] };
+            if (/FROM mission_note_card_links/i.test(s)) return { rows: linkRows };
+            if (/^UPDATE/i.test(s)) {
+                if (/SET notes/.test(s)) dashboardRow.notes = JSON.parse(params[1]);
+                return { rows: [{ version: 7 }] };
+            }
+            if (/^(DELETE|INSERT)/i.test(s)) return { rows: [], rowCount: 1 };
+            return { rows: [] };
+        };
+        mockClientQuery.mockImplementation(queryImpl);
+        mockPoolQuery.mockImplementation(queryImpl);
+    });
+
+    afterEach(() => {
+        mockClientQuery.mockReset();
+        mockClientQuery.mockResolvedValue({ rows: [] });
+        mockPoolQuery.mockReset();
+        mockPoolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+    });
+
+    it('GET /note/:noteId/cards lists device-scoped linked cards', async () => {
+        const res = await get('/api/mission/note/note_a/cards').query(auth);
+        expect(res.status).toBe(200);
+        expect(res.body.linkedCardIds).toEqual(['card_a']);
+        expect(res.body.cards[0]).toMatchObject({ id: 'card_a', title: 'Card A' });
+    });
+
+    it('PUT /note/:noteId/cards replaces links and mirrors note JSON', async () => {
+        const res = await request(missionApp)
+            .put('/api/mission/note/note_a/cards')
+            .send({ ...auth, linkedCardIds: ['card_a', 'card_b'] });
+        expect(res.status).toBe(200);
+        expect(res.body.linkedCardIds).toEqual(['card_a', 'card_b']);
+        expect(dashboardRow.notes[0].linkedCardIds).toEqual(['card_a', 'card_b']);
+    });
+
+    it('PUT /note/:noteId/cards rejects invalid card ids for device isolation', async () => {
+        const res = await request(missionApp)
+            .put('/api/mission/note/note_a/cards')
+            .send({ ...auth, linkedCardIds: ['card_a', 'card_elsewhere'] });
+        expect(res.status).toBe(400);
+    });
+
+    it('DELETE /note/:noteId/card/:cardId clears one link', async () => {
+        const res = await request(missionApp)
+            .delete('/api/mission/note/note_a/card/card_a')
+            .send(auth);
+        expect(res.status).toBe(200);
+        expect(res.body.linkedCardIds).toEqual([]);
+        expect(dashboardRow.notes[0].linkedCardIds).toEqual([]);
     });
 });
 

--- a/docs/adr/mission-note-card-links.md
+++ b/docs/adr/mission-note-card-links.md
@@ -1,0 +1,44 @@
+# Mission note ↔ Kanban card explicit links
+
+## Context
+
+`docs/spec/mindmap-force-graph.md` §12.3 requires strong `note_on_card` edges. Before this change, note/card relationships were inferred from `mindmap_node_anchors` or from a single `note.anchor`, which made graph output fragile and hard to edit from Mission notes.
+
+Mission notes remain stored in `mission_dashboard.notes` JSONB for backward compatibility. The explicit relationship is persisted separately in `mission_note_card_links`.
+
+## Model
+
+`mission_note_card_links` columns:
+
+- `device_id`
+- `note_id`
+- `card_id`
+- `created_by`
+- `created_at`
+- unique `(device_id, note_id, card_id)`
+
+All writes validate:
+
+1. the request is authenticated for the device;
+2. the note exists in `mission_dashboard.notes` for that device;
+3. every linked Kanban card exists in `kanban_cards` for that same device.
+
+The table intentionally does not FK to Mission notes because notes are currently JSONB entries, not rows.
+
+## API surface
+
+- `POST /api/mission/note/add` accepts `linkedCardIds`.
+- `POST /api/mission/note/update` accepts `linkedCardIds`; `[]` clears all card links.
+- Dashboard bulk save persists `note.linkedCardIds` into the join table.
+- `GET /api/mission/note/:noteId/cards` lists linked cards.
+- `PUT /api/mission/note/:noteId/cards` replaces links.
+- `POST /api/mission/note/:noteId/card` adds one link.
+- `DELETE /api/mission/note/:noteId/card/:cardId` removes one link.
+
+## Graph behavior
+
+`/api/mindmap/graph` now emits `note_on_card` edges from `mission_note_card_links` with evidence `mission_note_card_links`. Legacy `mindmap_node_anchors` cross-correlation still runs afterward as a bridge, with duplicate note/card pairs de-duped.
+
+## Backfill strategy
+
+Backfill from existing anchors is explicitly deferred for this PR. Runtime graph output already bridges old anchor-derived relationships, so no relationship is lost. A future migration can scan notes with `anchor.type === "kanban_card"` and insert `(device_id, note_id, anchor.refId)` after device-scoped card validation.


### PR DESCRIPTION
## Summary
- add `mission_note_card_links` as the explicit device-scoped Mission note ↔ Kanban card join model
- support `linkedCardIds` in note add/update and dashboard bulk-save, plus link CRUD endpoints
- hydrate `/api/mission/dashboard` and `/api/mission/notes` with linked card ids
- add Mission note editor multiselect + note-list link count badge
- expose linked Mission notes on Kanban card detail
- update `/api/mindmap/graph` to emit strong `note_on_card` edges from `mission_note_card_links`, while keeping anchor-derived bridge edges as fallback
- document the model and deferred anchor backfill strategy

## API
- `POST /api/mission/note/add` accepts `linkedCardIds`
- `POST /api/mission/note/update` accepts `linkedCardIds` (`[]` clears)
- `GET /api/mission/note/:noteId/cards`
- `PUT /api/mission/note/:noteId/cards`
- `POST /api/mission/note/:noteId/card`
- `DELETE /api/mission/note/:noteId/card/:cardId`

## Validation
- `node --check backend/mission.js backend/mindmap.js backend/mindmap-graph-projection.js backend/kanban.js backend/tests/jest/mission.test.js backend/tests/jest/mindmap-graph.test.js backend/tests/jest/mission-notes-rules.test.js`
- parsed all inline scripts in `backend/public/portal/mission.html` with Node `new Function(...)`
- `git diff --check -- backend/mission.js backend/mission_schema.sql backend/mindmap.js backend/mindmap-graph-projection.js backend/kanban.js backend/public/portal/mission.html backend/tests/jest/mission.test.js backend/tests/jest/mission-notes-rules.test.js backend/tests/jest/mindmap-graph.test.js docs/adr/mission-note-card-links.md`
- `./node_modules/.bin/jest tests/jest/mission.test.js tests/jest/mission-notes-rules.test.js --forceExit` ✅ 61 tests
- `./node_modules/.bin/jest tests/jest/mindmap-graph.test.js --forceExit` ✅ 23 tests
- `./node_modules/.bin/eslint mission.js mindmap.js mindmap-graph-projection.js kanban.js ...` → 0 errors; existing warning in `kanban.js:3003` plus ignored-file warnings for HTML/tests

## Notes
Backfill from old `note.anchor.type === "kanban_card"` is documented as deferred. Runtime graph output still bridges old anchor-derived relationships, so existing edges continue to render until a data migration lands.
