### PR TITLE
fix(promo): pull bad chat-avatar video embed (Hank rejected first cut)

### DIFF
--- a/backend/public/promo-chat-avatar.html
+++ b/backend/public/promo-chat-avatar.html
@@ -120,15 +120,12 @@
         </header>
 
         <section class="video-card" aria-labelledby="promo-video-heading">
-            <h2 id="promo-video-heading" class="sr-only">EClaw chat avatar size 功能 80 秒示範</h2>
-            <div class="video-frame">
-                <video controls preload="metadata" playsinline
-                       poster="/assets/marketing/vector-hero-v1.png"
-                       aria-label="聊天大頭貼大小 32 / 48 / 64 示範影片">
-                    <source src="/promo-videos/chat-avatar-size-2026-05-13.mp4" type="video/mp4">
-                    您的瀏覽器不支援 HTML5 video。
-                    <a href="/promo-videos/chat-avatar-size-2026-05-13.mp4">下載 MP4</a>
-                </video>
+            <h2 id="promo-video-heading" class="sr-only">示範影片重做中</h2>
+            <div class="video-frame" style="display:flex;align-items:center;justify-content:center;text-align:center;padding:32px;">
+                <div>
+                    <div style="font-size:1.1rem;color:#c8c8dd;margin-bottom:8px;">示範影片重做中</div>
+                    <div style="color:#9696ad;font-size:0.95rem;">第一版風格與 EClaw 實際操作體感差距太大，正在重新規劃為真實環境錄屏版本。先看下方三段尺寸說明，或直接到設定試試看。</div>
+                </div>
             </div>
         </section>
 


### PR DESCRIPTION
## Summary
- Hank reviewed the just-deployed /promo-chat-avatar.html 80s video and rejected it: synthetic motion-graphic doesn't match real EClaw UX, BGM off-brand, content not engaging.
- This PR pulls the `<video>` embed and replaces the video card with a short "示範影片重做中" message so the page stays mounted (no link rot) while #6 re-spins a real-environment recorded version on card_6132a3f4a49237d4978705bc.
- MP4 file left in `backend/public/promo-videos/` (no incoming references after this edit) — kept on disk for the moment so the redo can diff against it; will be removed when the new cut ships.

## Why
Hank's feedback (2026-05-13 18:45 TW): "影片他媽做真爛 一點都不像Eclaw真實環境 而且內容一點都不有趣 最怪的是BGM". I had reviewed the first cut for technical specs only (length / resolution / watermark / subtitle overlap) and missed the content-quality bar. Pulling the embed is the immediately reversible fix.

## Test plan
- [x] HTML still parses + page still 200s on prod after deploy
- [x] No `<video>` / `<source>` tag references to chat-avatar-size-2026-05-13.mp4 from the page
- [x] Feature-grid + CTAs preserved
- [ ] Post-deploy: curl https://eclawbot.com/promo-chat-avatar.html shows "示範影片重做中" copy