### PR TITLE
fix(mindmap): fallback to device scope when entityId is null

### DIFF
--- a/backend/public/portal/mindmap.html
+++ b/backend/public/portal/mindmap.html
@@ -390,7 +390,12 @@
                 return;
             }
             if (!MM_USER) return;
-            const scope = document.getElementById('mmScope').value;
+            const scopeSelect = document.getElementById('mmScope');
+            let scope = scopeSelect.value;
+            if (scope === 'entity' && MM_USER.entityId == null) {
+                scope = 'device';
+                scopeSelect.value = 'device';
+            }
             const params = new URLSearchParams({
                 deviceId: MM_USER.deviceId || '',
                 scope


### PR DESCRIPTION
## Summary
- Mindmap defaulted dropdown to \"entity\" but \`MM_USER.entityId\` is never populated (\`/api/auth/me\` doesn't include entityId for device-owner sessions), so every fresh load fired \`/api/mindmap/graph?scope=entity\` without entityId → 400 error screen \"無法載入圖形 / scope=entity requires entityId\".
- Fix: in \`fetchGraph()\`, when the dropdown is on \`entity\` but \`MM_USER.entityId\` is null, silently demote to \`device\` and update the select so the UI matches.

## Test plan
- [x] Repro: visit \`/portal/mindmap.html\` on prod (v1.0.83) → error screen
- [ ] After deploy: same URL renders graph at \`scope=device\` and dropdown shows \"All on device\"
- [ ] Manually switching back to \"My work\" still works for sessions where entityId IS populated (no regression)

Audit context: discovered while doing v1.0.82/83 visual audit for #6 promo video redo (audit card `card_99fd3f6e119b9ae6cb15d376`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)