### PR TITLE
feat(chat): link card previews to kanban

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -2685,6 +2685,29 @@
             max-height: 300px;
             overflow-y: auto;
         }
+        #entityPreviewModal .entity-card-actions {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 8px;
+            margin-bottom: 12px;
+        }
+        #entityPreviewModal .entity-open-kanban {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            padding: 8px 12px;
+            border-radius: 8px;
+            border: 1px solid rgba(74, 158, 255, 0.45);
+            background: rgba(74, 158, 255, 0.14);
+            color: var(--primary, #4a9eff);
+            font-size: 13px;
+            font-weight: 700;
+            text-decoration: none;
+        }
+        #entityPreviewModal .entity-open-kanban:hover {
+            background: rgba(74, 158, 255, 0.22);
+            border-color: rgba(74, 158, 255, 0.75);
+        }
         #entityPreviewModal .entity-comments {
             margin-top: 12px;
             padding: 12px;
@@ -6433,6 +6456,14 @@
             return div.innerHTML;
         }
 
+        function escapeJs(str) {
+            return String(str || '')
+                .replace(/\\/g, '\\\\')
+                .replace(/'/g, "\\'")
+                .replace(/\n/g, '\\n')
+                .replace(/\r/g, '\\r');
+        }
+
         // Peel off the "↩ <sender>: \"<quoted excerpt>\"\n\n" header that sendMessage
         // prepends to replies, so downstream previews/snippets show the real body
         // instead of nesting quote-inside-quote when users reply to a reply.
@@ -7550,6 +7581,19 @@
             }
         }
 
+        function getKanbanCardUrl(cardId) {
+            const id = String(cardId || '').trim();
+            if (!id) return 'kanban.html';
+            return `kanban.html?card=${encodeURIComponent(id)}#${encodeURIComponent(id)}`;
+        }
+
+        function openKanbanCard(cardId, event) {
+            if (event && typeof event.preventDefault === 'function') event.preventDefault();
+            const url = getKanbanCardUrl(cardId);
+            const opened = window.open(url, '_blank', 'noopener');
+            if (!opened) window.location.href = url;
+        }
+
         async function fetchCardData(auth, cardId) {
             const [resp, commentsResp, filesResp] = await Promise.all([
                 apiCall('GET', `/api/mission/card/${cardId}?${auth}`),
@@ -7575,7 +7619,14 @@
             const commentsLabel = i18n.t('chat_card_modal_comments') || 'Comments';
             const commentsEmpty = i18n.t('chat_card_modal_comments_empty') || 'No comments yet';
 
-            let html = `<div class="entity-meta">
+            const openKanbanLabel = i18n.t('mm_preview_open_task') || 'Open in Kanban';
+            const kanbanUrl = getKanbanCardUrl(c.id || cardId);
+
+            let html = `<div class="entity-card-actions">
+                <a class="entity-open-kanban" href="${escapeHtml(kanbanUrl)}" target="_blank" rel="noopener" onclick="openKanbanCard('${escapeJs(c.id || cardId)}', event)">📋 ${escapeHtml(openKanbanLabel)}</a>
+            </div>`;
+
+            html += `<div class="entity-meta">
                 <div class="entity-meta-item"><div class="entity-meta-label">Status</div><div class="entity-meta-value">${emoji} ${status}</div></div>
                 <div class="entity-meta-item"><div class="entity-meta-label">Priority</div><div class="entity-meta-value">${escapeHtml(priority)}</div></div>
                 <div class="entity-meta-item"><div class="entity-meta-label">Assigned</div><div class="entity-meta-value">${escapeHtml(assigned)}</div></div>

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -1128,10 +1128,13 @@
         function parseDeepLinkHash() {
             // Accept either single-hash (#card_X[?#comment-Y]) or double-hash
             // (#card_X#comment-Y). location.hash normalises to one leading '#'.
+            // Also accept ?card=card_X, used by chat/mindmap fallbacks where
+            // WebViews may strip or rewrite hash-only navigation.
+            const params = new URLSearchParams(window.location.search || '');
+            const queryCard = params.get('card') || params.get('cardId');
             const raw = (window.location.hash || '').replace(/^#/, '');
-            if (!raw) return null;
-            const parts = raw.split('#');
-            const head = parts[0] || '';
+            const parts = raw ? raw.split('#') : [];
+            const head = queryCard || parts[0] || '';
             const cardMatch = /^card_[a-f0-9]{8,}$/i.exec(head);
             if (!cardMatch) return null;
             let commentAnchor = null;
@@ -1146,7 +1149,11 @@
             const target = parseDeepLinkHash();
             if (!target) return;
             const card = findCard(target.cardId);
-            if (!card) return; // card not loaded yet — loadCards finished, but it's gone
+            if (!card) {
+                const msg = (t('toast_not_found', 'Not found') || 'Not found') + ': ' + target.cardId;
+                showToast(msg, true);
+                return;
+            }
             pendingCommentAnchor = target.commentAnchor || null;
             if (openCardId !== target.cardId) {
                 openDetail(target.cardId);


### PR DESCRIPTION
## Summary
- Adds a visible “Open in Kanban” action to chat card preview modals.
- Reuses the existing localized `mm_preview_open_task` key, so no new visible string/key is needed.
- Links to `kanban.html?card=<cardId>#<cardId>` for WebView-safe fallback plus existing hash deep-link support.
- Extends Kanban deep-link handling to accept `?card=` / `?cardId=` and show a localized not-found toast instead of a silent dead click.

## Implementation notes
- Focused PR only; no broad card renderer rewrite.
- Existing smart-chip popover link remains unchanged.
- Chat modal action opens a new tab when possible and falls back to same-tab navigation if popup/new-tab is blocked.

## Validation
- Extracted inline scripts from `backend/public/portal/chat.html` and `backend/public/portal/kanban.html`; both passed `node --check`.
- `git diff --cached --check` passed before commit.

## Manual E2E checklist for #2
- Desktop chat: open a `card_...` preview → click “Open in Kanban” → Kanban opens target card detail.
- Narrow mobile/WebView chat: same path; if new tab is blocked, fallback navigation still reaches Kanban.
- Kanban direct route: `kanban.html?card=card_x#card_x` opens target card.
- Missing/inaccessible card: route shows not-found toast instead of silently doing nothing.
