### PR TITLE
fix(portal): petdx-browser cookie-session fallback for device-login

### DIFF
--- a/backend/public/portal/petdx-browser.html
+++ b/backend/public/portal/petdx-browser.html
@@ -734,19 +734,43 @@
     }
 
     // ── Boot ─────────────────────────────────────────────────────
-    // Seed activeEntityId from URL (?entityId=) then localStorage. URL wins
-    // so a deep-link like ".../petdx-browser.html?entityId=3" lands you on
-    // that entity's scope without needing the dropdown.
-    (function seedActiveEntity() {
+    // Cookie-session fallback: other portal pages (dashboard/chat/mission)
+    // trust the device-login cookie. Petdx historically only read URL or
+    // localStorage, so a freshly logged-in user (no localStorage seed) saw
+    // "尚未登入". Ask /api/auth/me once and persist creds to localStorage so
+    // the existing sync getCreds() path keeps working.
+    async function bootstrapCookieSession() {
+        const url = new URLSearchParams(location.search);
+        const hasUrl = !!url.get('deviceId') && (!!url.get('deviceSecret') || !!url.get('botSecret'));
+        const hasLocal = !!localStorage.getItem('eclaw_device_id')
+            && !!localStorage.getItem('eclaw_device_secret');
+        if (hasUrl || hasLocal) return;
+        try {
+            const r = await fetch('/api/auth/me', { credentials: 'include' });
+            if (!r.ok) return;
+            const j = await r.json();
+            if (j && j.success && j.user && j.user.deviceId && j.user.deviceSecret) {
+                localStorage.setItem('eclaw_device_id', j.user.deviceId);
+                localStorage.setItem('eclaw_device_secret', j.user.deviceSecret);
+            }
+        } catch (e) { /* swallow — login warn surfaces if creds still absent */ }
+    }
+
+    (async function init() {
+        await bootstrapCookieSession();
+
+        // Seed activeEntityId from URL (?entityId=) then localStorage. URL wins
+        // so a deep-link like ".../petdx-browser.html?entityId=3" lands you on
+        // that entity's scope without needing the dropdown.
         const c = getCreds();
         const stored = localStorage.getItem(ACTIVE_ENTITY_KEY) || '';
         activeEntityId = c.entityId || stored || '';
-    })();
 
-    renderFilters();
-    loadEntities();
-    loadList();
-    refreshOwnerState();
+        renderFilters();
+        loadEntities();
+        loadList();
+        refreshOwnerState();
+    })();
 }());
 </script>
 </body>


### PR DESCRIPTION
## Summary
- petdx-browser.html now hits `/api/auth/me` when URL and localStorage are both empty, persisting `deviceId`/`deviceSecret` so the rest of the page (sync `getCreds()` path) works unchanged
- Unifies petdx auth with how dashboard/chat/mission already trust the device-login cookie
- Init body wrapped in async IIFE so `loadList()` runs after the cookie bootstrap settles

## Root cause
`getCreds()` at L228-229 read only `url.get('deviceId') || localStorage.getItem('eclaw_device_id')`. A user freshly logged in via `/api/auth/device-login` has the cookie set, but localStorage is empty unless some other page seeded it. Result: same valid session works on chat/dashboard/mission but petdx shows "⚠ 尚未登入或找不到 device 憑證".

## Test plan
- [x] Self E2E: Playwright headless → device-login → visit `/portal/petdx-browser.html` (no URL creds, fresh context) → gallery loads with pets
- [x] Existing URL-creds path unchanged (`hasUrl` short-circuits bootstrap)
- [x] Existing localStorage-creds path unchanged (`hasLocal` short-circuits bootstrap)
- [x] Cookie missing / `/api/auth/me` 401 → falls through to existing login warn
- [ ] Manual desktop + mobile screenshots after deploy

## Card
card_ec49eb8fbc2ae4e0ef5482d0 — blocks #6 promo video must-record item #1 (1784 pets gallery)

🤖 Generated with [Claude Code](https://claude.com/claude-code)