### PR TITLE
i18n(mc_dlg_linked_cards): fill th/vi/id/fr/hi/ar → 13/13 coverage

### DIFF
--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -2950718,6 +2950718,7 @@ const TRANSLATIONS = {
 
 
         "mc_dlg_category": "หมวดหมู่",
+        "mc_dlg_linked_cards": "การ์ดคันบังที่เชื่อมโยง",
 
 
 
@@ -3479450,6 +3479451,7 @@ const TRANSLATIONS = {
 
 
         "mc_dlg_category": "Danh mục",
+        "mc_dlg_linked_cards": "Thẻ Kanban đã liên kết",
 
 
 
@@ -4004854,6 +4004856,7 @@ const TRANSLATIONS = {
 
 
         "mc_dlg_category": "Kategori",
+        "mc_dlg_linked_cards": "Kartu Kanban tertaut",
 
 
 
@@ -4529874,6 +4529877,7 @@ const TRANSLATIONS = {
 
 
         "mc_dlg_category": "Catégorie...",
+        "mc_dlg_linked_cards": "Cartes Kanban liées",
 
 
 
@@ -6784105,6 +6784109,7 @@ const TRANSLATIONS = {
 
 
         "mc_dlg_category": "श्रेणी",
+        "mc_dlg_linked_cards": "लिंक की गई कानबन कार्ड",
 
 
 
@@ -7473093,6 +7473098,7 @@ const TRANSLATIONS = {
 
 
         "mc_dlg_category": "الفئة",
+        "mc_dlg_linked_cards": "بطاقات كانبان المرتبطة",
 
 
 


### PR DESCRIPTION
## Summary

- Adds `mc_dlg_linked_cards` to 6 missing locales (th, vi, id, fr, hi, ar)
- Brings total coverage to 13/13 locales (acceptance: `grep -c '\"mc_dlg_linked_cards\"' = 13`)
- Diff is **+6 lines, no other change** — no line-ending churn, no other keys touched
- Card requested 10 locales; verified ko/es/de/ms are already merged in earlier batches, leaving 6

## Placement

In en the sequence is `mc_dlg_category → mc_dlg_anchor → mc_dlg_linked_cards`. The 6 added locales don't have `mc_dlg_anchor` either, so this places the new key immediately after each locale's `mc_dlg_category` — preserving relative position to surrounding dialog keys.

## Translations

| Locale | Value | Notes |
|---|---|---|
| th | การ์ดคันบังที่เชื่อมโยง | per card spec |
| vi | Thẻ Kanban đã liên kết | per card spec |
| id | Kartu Kanban tertaut | per card spec |
| fr | Cartes Kanban liées | per card spec |
| hi | लिंक की गई कानबन कार्ड | card's suggested value had Unicode replacement chars; this is clean Hindi for \"linked kanban cards\" |
| ar | بطاقات كانبان المرتبطة | per card spec |

## Test plan

- [x] `grep -c '\"mc_dlg_linked_cards\"' backend/public/shared/i18n.js` → 13
- [x] `node --check backend/public/shared/i18n.js` clean
- [x] `git diff --shortstat --ignore-cr-at-eol --ignore-all-space` → 1 file changed, 6 insertions(+)
- [ ] CI green

Refs card: \`[i18n] mc_dlg_linked_cards — 10 missing locales\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)