### PR TITLE
fix(uiux): harden chat previews and roster preview

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -5202,7 +5202,7 @@
 
             // Fetch link previews for visible messages
             container.querySelectorAll('.link-preview-slot[data-url]').forEach(slot => {
-                if (slot.children.length > 0) return; // already loaded
+                if (slot.children.length > 0 || slot.dataset.previewLoading === '1') return; // already loaded/in flight
                 fetchLinkPreview(slot.dataset.url, slot);
             });
 
@@ -6536,44 +6536,74 @@
             } catch { return false; }
         }
 
-        // Link preview cache (client-side)
+        // Link preview cache (client-side). Values are rendered HTML, 'none', or
+        // 'backoff'. Keep a separate in-flight map so chat history rerenders do not
+        // fan out duplicate requests for the same URL.
         const linkPreviewClientCache = {};
+        const linkPreviewInFlight = {};
+        let linkPreviewBackoffUntil = 0;
+
+        function normalizePreviewUrl(url) {
+            try {
+                const parsed = new URL(String(url || '').trim(), window.location.href);
+                if (!['http:', 'https:'].includes(parsed.protocol)) return null;
+                if (!parsed.hostname || parsed.hostname === window.location.hostname) return null;
+                return parsed.href;
+            } catch {
+                return null;
+            }
+        }
 
         async function fetchLinkPreview(url, container) {
-            if (linkPreviewClientCache[url] === 'none') return;
-            if (linkPreviewClientCache[url]) {
+            const normalizedUrl = normalizePreviewUrl(url);
+            if (!normalizedUrl) { linkPreviewClientCache[url] = 'none'; return; }
+            if (Date.now() < linkPreviewBackoffUntil) { linkPreviewClientCache[normalizedUrl] = 'backoff'; return; }
+            if (linkPreviewClientCache[normalizedUrl] === 'none' || linkPreviewClientCache[normalizedUrl] === 'backoff') return;
+            if (linkPreviewClientCache[normalizedUrl]) {
                 preserveChatScrollDuring(() => {
-                    container.innerHTML = linkPreviewClientCache[url];
+                    container.innerHTML = linkPreviewClientCache[normalizedUrl];
                 }, { settle: true });
                 return;
             }
+            if (linkPreviewInFlight[normalizedUrl]) return;
+
+            container.dataset.previewLoading = '1';
+            linkPreviewInFlight[normalizedUrl] = true;
             try {
-                const res = await fetch(`/api/link-preview?url=${encodeURIComponent(url)}`);
-                if (!res.ok) { linkPreviewClientCache[url] = 'none'; return; }
+                const res = await fetch(`/api/link-preview?url=${encodeURIComponent(normalizedUrl)}`);
+                if (res.status === 429) {
+                    linkPreviewBackoffUntil = Date.now() + 60000;
+                    linkPreviewClientCache[normalizedUrl] = 'backoff';
+                    return;
+                }
+                if (!res.ok) { linkPreviewClientCache[normalizedUrl] = 'none'; return; }
                 const data = await res.json();
-                if (!data.title && !data.description) { linkPreviewClientCache[url] = 'none'; return; }
+                if (!data.title && !data.description) { linkPreviewClientCache[normalizedUrl] = 'none'; return; }
 
                 let domain = '';
-                try { domain = new URL(url).hostname; } catch {}
+                try { domain = new URL(normalizedUrl).hostname; } catch {}
 
                 const imgHtml = data.image
                     ? `<img class="link-preview-img" src="${escapeHtml(data.image)}" alt="" onerror="this.style.display='none'">`
                     : '';
-                const cardHtml = `<a class="link-preview" href="${escapeHtml(url)}" target="_blank" rel="noopener">
+                const cardHtml = `<a class="link-preview" href="${escapeHtml(normalizedUrl)}" target="_blank" rel="noopener">
                     ${imgHtml}
                     <div class="link-preview-body">
-                        <div class="link-preview-title">${escapeHtml(data.title)}</div>
+                        <div class="link-preview-title">${escapeHtml(data.title || domain)}</div>
                         ${data.description ? `<div class="link-preview-desc">${escapeHtml(data.description)}</div>` : ''}
                         <div class="link-preview-domain">${escapeHtml(domain)}</div>
                     </div>
                 </a>`;
 
-                linkPreviewClientCache[url] = cardHtml;
+                linkPreviewClientCache[normalizedUrl] = cardHtml;
                 preserveChatScrollDuring(() => {
                     container.innerHTML = cardHtml;
                 }, { settle: true });
             } catch {
-                linkPreviewClientCache[url] = 'none';
+                linkPreviewClientCache[normalizedUrl] = 'none';
+            } finally {
+                delete linkPreviewInFlight[normalizedUrl];
+                if (container) delete container.dataset.previewLoading;
             }
         }
 

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -4492,7 +4492,7 @@
                 });
                 list.appendChild(item);
             });
-            if (typeof i18n !== 'undefined') i18n.applyPage();
+            if (typeof i18n !== 'undefined' && typeof i18n.apply === 'function') i18n.apply();
         }
 
         function updateBorrowButtons() {

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -2569,6 +2569,18 @@
             const ownerEntityId = ownerRosterId(user);
             const note = document.getElementById('rosterStatusNote');
             if (note) note.textContent = rosterT('settings_roster_loading', 'Loading roster…');
+
+            // The owner-roster UI is currently a preview surface. Production does not
+            // expose /api/owner/roster/* routes yet, so calling them on every settings
+            // load creates user-visible 404 noise in Network/console. Keep the panel
+            // useful with preview data until the backend explicitly opts in.
+            if (!window.__ownerRosterApiEnabled) {
+                ownerRosterState = rosterMockData();
+                if (note) note.textContent = rosterT('settings_roster_mock_note', 'Preview mode: backend roster endpoints are not available yet; showing mock data.');
+                renderOwnerRoster();
+                return;
+            }
+
             try {
                 const [listingsResp, rentalsResp, historyResp] = await Promise.all([
                     apiCall('GET', `/api/owner/roster/listings?ownerEntityId=${encodeURIComponent(ownerEntityId)}`).catch(e => ({ error:e })),


### PR DESCRIPTION
## Summary
- Fixes confirmed issues from QA/UIUX daily regression issue #2768.
- Hardens chat link previews to avoid duplicate fetch storms, invalid/self URL previews, and repeated 429 hammering.
- Removes production 404 noise from Settings owner-roster preview by keeping it in preview/mock mode until backend explicitly opts in.
- Replaces dashboard stale `i18n.applyPage()` call with current `i18n.apply()` API.

## Validation
- `node backend/tests/test-ux-static-audit.js` ✅ (script completed; known existing findings remain tracked in #2768)
- Inline `<script>` syntax check for changed pages ✅
- `git diff --cached --check` ✅
- Changed files only:
  - `backend/public/portal/chat.html`
  - `backend/public/portal/dashboard.html`
  - `backend/public/portal/settings.html`

## QA context
GitHub issue: #2768

Browser/mobile sweep report excerpt:

```md
# EClaw QA/UIUX Browser Sweep — 0310

**Date:** 2026-05-13 UTC  
**Target:** production `https://eclawbot.com` plus static context from `/tmp/EClaw`  
**Scope:** `/portal/index.html`, `/portal/dashboard.html`, `/portal/chat.html`, `/portal/kanban.html`, `/portal/settings.html`, `/portal/marketplace.html`, `/portal/info.html`, `/arena`  
**Viewports:** desktop `1365x900`, mobile/narrow `390x844`  
**Artifacts inspected:**
- `/tmp/qa_uiux_static_audit_0310.log`
- `/tmp/qa_uiux_parity_0310.log`
- `/tmp/qa_uiux_http_sweep_0310.json`
- Browser raw outputs: `/tmp/qa_uiux_browser_sweep_raw_0310.json`, `/tmp/qa_uiux_browser_sweep_loggedin_raw_0310.json`

## Executive summary

Production is broadly loadable. Public pages and auth redirects are working, and I did not see page-crashing runtime exceptions on the swept pages. The most useful confirmed fixes are:

1. **Settings calls missing/old roster endpoints:** `GET /api/owner/roster/history`, `/rentals`, `/listings` return `404` on production settings.
2. **Chat over-fetch/rate-limit behavior:** logged-in chat triggered `/api/link-preview` `400` and then many `429` responses, especially on mobile reload.
3. **Dashboard warning:** `Failed to load free bots: i18n.applyPage is not a function` appears in production console on dashboard.
4. **Mobile tap target polish:** several key controls are below 44px, most visibly the mobile menu/brand buttons, chat density controls, small close/edit/avatar buttons, and marketplace capability chips.
5. **Info mobile tab strip:** one tab extends outside the viewport, but the document itself does not horizontally overflow; likely a scrollable-tab UX issue rather than a layout break.

Unauthenticated access blocks deeper interaction for dashboard/chat/kanban/settings as expected: those pages redirect to `/portal/index.html` after `/api/auth/me` returns `401`. I used a logged-in browser session for a limited visual/loadability sweep, but did not create/edit/delete data.

## Page-by-page findings

### `/portal/index.html` — login / public landing

**Confirmed good**
- Loads `200` on desktop and mobile.
- No console/runtime exceptions observed.
- Empty login submit gives visible inline feedback: `Please fill in all fields`.
- No page-level horizontal overflow on desktop or mobile.
- Footer is visible.

**Confirmed issues / polish**
- Several tap targets are under 44px high:
  - `Forgot password?` around `114x15`.
  - OAuth buttons around `358–368x40`.
  - footer/help links around `21px` high.
- This is not a blocker, but it is real on mobile and aligns with the static accessibility/tap-target concerns.

**Static-audit notes**
- Static audit flagged one unhandled Facebook OAuth API call. Browser sweep did not exercise OAuth because that would leave the app; keep as code-review item.
- Static audit flagged missing empty-state fallback on login. Not confirmed as a user-visible browser issue in the unauthenticated state.

### `/portal/dashboard.html`

**Unauthenticated behavior**
- Redirects to `/portal/index.html` on desktop/mobile after expected `401 /api/auth/me`.
- No runtime exceptions during redirect.

**Logged-in loadability**
- Loads `200`, desktop and mobile.
- Header/nav present. Mobile collapses to a menu button.
- No page-level horizontal overflow.

**Confirmed issue**
- Production console warning on desktop dashboard:
  - `Failed to load free bots: i18n.applyPage is not a function`
- This likely means the free/borrowed bot section is using an outdated i18n API or calling `applyPage` before the expected helper exists.

**Mobile/tap polish**
- Mobile menu button around `36x30`, brand around `28x28`, edit button around `33x32`, dismiss button around `31x26`; all below recommended 44px touch target.

**Repro**
1. Log in to production.
2. Open `https://eclawbot.com/portal/dashboard.html`.
3. Open console.
4. Observe warning: `Failed to load free bots: i18n.applyPage is not a function`.

### `/portal/chat.html`

**Unauthenticated behavior**
- Redirects to `/portal/index.html` after expected `401 /api/auth/me`.

**Logged-in loadability**
- Loads `200`, desktop and mobile.
- No page-level horizontal overflow.
- No uncaught JS exceptions observed.

**Confirmed issue: link-preview API noise / rate limiting**
- Desktop logged-in load saw `400 Fetch /api/link-preview`.
- Mobile logged-in load saw repeated `/api/link-preview` failures, including many `429` responses.
- This looks like link-preview work running on page load/history render without enough validation, debounce, caching, or 429 backoff.

**Confirmed mobile/tap UX issue**
- Chat density controls are very small on mobile:
  - `Compact`/`Normal`/`Comfortable` equivalents around `23x14`, `25x17`, `27x20` in the zh-TW session.
- Entity avatar/action controls around `20x20` also fail mobile tap target guidance.

**Repro**
1. Log in to production.
2. Open `https://eclawbot.com/portal/chat.html`.
3. Use mobile/narrow viewport around `390x844`, reload.
4. Watch Network for `/api/link-preview` requests.
5. Observe `400` and repeated `429` responses; inspect density controls for sub-44px tap targets.

### `/portal/kanban.html`

**Unauthenticated behavior**
- Redirects to `/portal/index.html` after expected `401 /api/auth/me`.

**Logged-in loadability**
- Loads `200`, desktop and mobile.
- Header/nav present; mobile menu present.
- Primary `+ 新增卡片` / add-card CTA visible.
- No page-level horizontal overflow.
- No runtime exceptions or HTTP errors observed in the limited sweep.

**Polish**
- Several nav/filter buttons are under 44px high, especially on mobile (`24–34px` tall filter/subnav controls). This is a usability issue but not a load blocker.

**Static-audit notes**
- Static audit flagged unhandled API calls in Kanban. Not confirmed via passive browser load because authenticated interaction was not performed beyond load/visual sweep. Keep as code-review/interaction-test item.

### `/portal/settings.html`

**Unauthenticated behavior**
- Redirects to `/portal/index.html` after expected `401 /api/auth/me`.

**Logged-in loadability**
- Desktop loads `200` and shows settings UI.
- Mobile later redirected to login due production `429` on auth/session calls during the sweep; treat this as rate-limit side effect from repeated QA loads, but it exposed missing user-friendly 429 handling.

**Confirmed issue: production 404s**
- Desktop settings page requested these endpoints and received `404`:
  - `GET /api/owner/roster/history`
  - `GET /api/owner/roster/rentals`
  - `GET /api/owner/roster/listings`
- These are likely stale frontend calls, missing backend routes, or a feature flag/visibility bug.

**Additional observed rate-limit responses**
- During repeated sweeps, settings also saw `429` on wallet/notification/auth/telemetry calls. The 429s may be QA-induced, but the user-facing outcome on mobile was a redirect to login instead of a clear rate-limit state.

**Repro**
1. Log in to production.
2. Open `https://eclawbot.com/portal/settings.html`.
3. Open Network panel.
4. Observe `404` responses for `/api/owner/roster/history`, `/api/owner/roster/rentals`, `/api/owner/roster/listings`.

### `/portal/marketplace.html`

**Confirmed behavior**
- `marketplace.html` is a redirect shim to `community.html#rental`.
- Public/unauthenticated and logged-in views both load `200` after redirect.
- Header/nav present in the destination page; mobile menu present.
- No page-level horizontal overflow.
- Primary CTA `Create your own Bot` / `建立你自己的 Bot` visible.

**Observed issue / polish**
- Capability chips on mobile are only about `24px` high; if they are tappable filters, they should be at least 44px high or have larger hit areas.
- Logged-in sweep saw `429 /api/rental/marketplace` after repeated QA loads. This may be rate-limit side effect, but marketplace should show a clear retry/backoff empty/error state if the list fails.

**Static-audit notes**
- Treat standalone `marketplace.html` static checks with caution: production intentionally redirects to `community.html#rental`, so many marketplace UX findings need to be validated against `community.html` instead.

### `/portal/info.html`

**Confirmed good**
- Public page loads `200` on desktop and mobile.
- Logged-in page also loads `200`.
- No runtime exceptions observed.
- Header/nav present; mobile menu present.
- No document-level horizontal overflow.

**Confirmed/likely issue**
- In unauthenticated mobile viewport, the `Channel Plugin` tab/button extends beyond the right edge (`left≈301`, `right≈430` in a `390px` viewport). Because `documentElement.scrollWidth` stayed within viewport, this is probably an intentional horizontal tab strip, but the affordance is weak: users may not realize tabs are horizontally scrollable.

**Static-audit false positives / clarified**
- Static audit flagged orphaned `rnSearch` and `rnFilter`; source inspection confirms handlers exist in `/tmp/EClaw/backend/public/portal/shared/info.js` (`addEventListener` for both). This is a static-audit false pos
```
