### PR TITLE
fix(i18n): fix 6 trailing-comma syntax errors in 10-locale batch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ EClaw/
 │   │   └── docs/
 │   │       └── webhook-troubleshooting.md
 │   ├── tests/                # Regression + integration tests (59 files)
-│   ├── tests/jest/           # Jest unit tests (184 files, CI-run via `npm test`)
+│   ├── tests/jest/           # Jest unit tests (201 files, CI-run via `npm test`)
 │   └── scripts/              # Setup scripts
 ├── app/                      # Android app (Kotlin)
 │   └── src/main/java/com/hank/clawlive/
@@ -1043,7 +1043,7 @@ curl "https://eclawbot.com/api/device-telemetry?deviceId=ID&deviceSecret=SECRET&
 
 ## Test Coverage Summary
 
-**~460 total API routes** across all modules (410 excluding Article Publisher), **~84% covered** by Jest + integration tests (~2895 test cases across 198 Jest files + 59 integration tests).
+**~460 total API routes** across all modules (410 excluding Article Publisher), **~84% covered** by Jest + integration tests (~2946 test cases across 201 Jest files + 59 integration tests).
 
 | Module | Coverage | Notes |
 |--------|----------|-------|
@@ -1136,7 +1136,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | R2 Quota Rich Card | `node backend/tests/test-r2-quota-rich-card.js` | Device ID + Secret | R2 quota exceeded rich card E2E |
 | Subscription Plans Live | `node backend/tests/test-subscription-plans-live.js` | Device ID + Secret | Subscription plans + wallet live verification |
 
-### Jest Unit Tests (CI-run, `npm test`, 184 files)
+### Jest Unit Tests (CI-run, `npm test`, 201 files)
 
 | Test | File | Description |
 |------|------|-------------|
@@ -1211,7 +1211,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 ### Running All Tests
 ```bash
 node backend/run_all_tests.js          # Run all tests sequentially
-cd backend && npm test                  # Jest unit tests (146 files)
+cd backend && npm test                  # Jest unit tests (201 files)
 cd backend && npm run lint              # ESLint
 ```
 

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -3467264,7 +3467264,7 @@ const TRANSLATIONS = {
         "info_slide_why_eclaw_b8_token_metering_cta": "ดูสไลด์ Claude Design →",
         "info_slide_why_eclaw_b9_live_bot_handover_cta": "ดูสไลด์ Claude Design →",
         "info_slide_why_eclaw_b10_post_rental_a2a_collaboration_cta": "ดูสไลด์ Claude Design →",
-        "info_slide_why_eclaw_b11_insurance_pool_referral_rewards_cta": "ดูสไลด์ Claude Design →",},
+        "info_slide_why_eclaw_b11_insurance_pool_referral_rewards_cta": "ดูสไลด์ Claude Design →"},
 
 
 
@@ -4519460,7 +4519460,7 @@ const TRANSLATIONS = {
         "wizard_target_track4_title": "Track 4 — penautan channel Claude",
         "wizard_target_track6_desc": "Kami akan membuka Arena dan memandu Anda melalui benchmark 12 dimensi.",
         "wizard_target_track6_title": "Track 6 — arena evaluasi agen",
-        "wizard_title": "EClawbot — Wizard Onboarding",},
+        "wizard_title": "EClawbot — Wizard Onboarding"},
 
 
 
@@ -5043221,7 +5043221,7 @@ const TRANSLATIONS = {
         "info_slide_why_eclaw_b8_token_metering_cta": "Voir la diapositive Claude Design →",
         "info_slide_why_eclaw_b9_live_bot_handover_cta": "Voir la diapositive Claude Design →",
         "info_slide_why_eclaw_b10_post_rental_a2a_collaboration_cta": "Voir la diapositive Claude Design →",
-        "info_slide_why_eclaw_b11_insurance_pool_referral_rewards_cta": "Voir la diapositive Claude Design →",},
+        "info_slide_why_eclaw_b11_insurance_pool_referral_rewards_cta": "Voir la diapositive Claude Design →"},
 
 
 
@@ -6764240,7 +6764240,7 @@ const TRANSLATIONS = {
         "wizard_target_track4_title": "Trek 4 — pautan saluran Claude",
         "wizard_target_track6_desc": "Kami akan membuka Arena dan membimbing anda melalui penanda aras 12 dimensi.",
         "wizard_target_track6_title": "Trek 6 — arena penilaian ejen",
-        "wizard_title": "EClawbot — Wizard Pengenalan",},
+        "wizard_title": "EClawbot — Wizard Pengenalan"},
 
 
 
@@ -7462721,7 +7462721,7 @@ const TRANSLATIONS = {
         "info_slide_why_eclaw_b8_token_metering_cta": "Claude Design स्लाइड देखें →",
         "info_slide_why_eclaw_b9_live_bot_handover_cta": "Claude Design स्लाइड देखें →",
         "info_slide_why_eclaw_b10_post_rental_a2a_collaboration_cta": "Claude Design स्लाइड देखें →",
-        "info_slide_why_eclaw_b11_insurance_pool_referral_rewards_cta": "Claude Design स्लाइड देखें →",},
+        "info_slide_why_eclaw_b11_insurance_pool_referral_rewards_cta": "Claude Design स्लाइड देखें →"},
 
 
 
@@ -8010034,7 +8010034,7 @@ const TRANSLATIONS = {
         "info_slide_why_eclaw_b8_token_metering_cta": "عرض شريحة Claude Design ←",
         "info_slide_why_eclaw_b9_live_bot_handover_cta": "عرض شريحة Claude Design ←",
         "info_slide_why_eclaw_b10_post_rental_a2a_collaboration_cta": "عرض شريحة Claude Design ←",
-        "info_slide_why_eclaw_b11_insurance_pool_referral_rewards_cta": "عرض شريحة Claude Design ←",}
+        "info_slide_why_eclaw_b11_insurance_pool_referral_rewards_cta": "عرض شريحة Claude Design ←"}
 
 
 


### PR DESCRIPTION
## Summary
- Fix 6 `,}` trailing-comma JS parse errors in th/fr/hi/ar/id/ms locale blocks that would crash i18n.js on load
- Update CLAUDE.md test suite counts: 198→201 files, 2895→2946 tests

## Test plan
- [x] `node backend/scripts/i18n-check.js` passes
- [x] `npx jest --testPathPattern=i18n-syntax` — 12/12 pass
- [x] Full Jest suite: 201/201 suites, 2946 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)