### PR TITLE
feat(kanban): add device-scoped card tags

### DIFF
--- a/backend/api_kanban_tags.js
+++ b/backend/api_kanban_tags.js
@@ -1,0 +1,259 @@
+'use strict';
+
+/**
+ * Device-scoped Kanban card tags.
+ *
+ * Tags are first-class rows (kanban_tags) linked to cards through
+ * kanban_card_tags.  Slugs are normalized as trim/lower strings so duplicate
+ * user input such as " UI " and "ui" resolves to one tag per device.
+ */
+
+const express = require('express');
+const { Pool } = require('pg');
+const safeEqual = require('./safe-equal');
+
+const TAG_SLUG_MAX = 80;
+
+function normalizeTagSlug(raw) {
+    return String(raw || '')
+        .trim()
+        .toLowerCase()
+        .replace(/\s+/g, '-')
+        .replace(/[^a-z0-9._:-]+/g, '-')
+        .replace(/-+/g, '-')
+        .replace(/^-|-$/g, '')
+        .slice(0, TAG_SLUG_MAX);
+}
+
+function displayLabel(raw, slug) {
+    const trimmed = String(raw || '').trim();
+    return (trimmed || slug).slice(0, 120);
+}
+
+module.exports = function (devices, options = {}) {
+    const router = express.Router();
+    const pool = options.pool || new Pool({
+        connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
+    });
+
+    function findEntityByCredentials(deviceId, entityId, botSecret) {
+        const device = devices[deviceId];
+        if (!device) return null;
+        const entity = (device.entities || {})[entityId];
+        if (!entity || !safeEqual(entity.botSecret, botSecret)) return null;
+        return entity;
+    }
+
+    function findDeviceByCredentials(deviceId, deviceSecret) {
+        const device = devices[deviceId];
+        if (!device || !safeEqual(device.deviceSecret, deviceSecret)) return null;
+        return device;
+    }
+
+    function authenticate(req, res) {
+        const params = { ...req.query, ...req.body };
+        const { deviceId, deviceSecret, botSecret, entityId } = params;
+
+        if (!deviceId) {
+            res.status(400).json({ success: false, error: 'Missing deviceId' });
+            return null;
+        }
+
+        if (deviceSecret) {
+            const device = findDeviceByCredentials(deviceId, deviceSecret);
+            if (device) return { deviceId, entityId: entityId ? parseInt(entityId, 10) : 0 };
+        }
+
+        if (botSecret) {
+            const parsedEntityId = parseInt(entityId || 0, 10);
+            const entity = findEntityByCredentials(deviceId, parsedEntityId, botSecret);
+            if (entity) return { deviceId, entityId: parsedEntityId };
+        }
+
+        if (!deviceSecret && !botSecret) {
+            res.status(400).json({ success: false, error: 'Missing deviceSecret or botSecret' });
+        } else {
+            res.status(401).json({ success: false, error: 'Invalid credentials' });
+        }
+        return null;
+    }
+
+    async function cardExistsInDevice(cardId, deviceId, queryable = pool) {
+        const { rows } = await queryable.query(
+            'SELECT id FROM kanban_cards WHERE id = $1 AND device_id = $2 LIMIT 1',
+            [cardId, deviceId]
+        );
+        return rows.length > 0;
+    }
+
+    function mapTagRow(row) {
+        return {
+            id: row.id == null ? null : Number(row.id),
+            slug: row.slug,
+            label: row.label || row.slug,
+            cardCount: row.card_count == null ? undefined : Number(row.card_count),
+            createdBy: row.created_by == null ? undefined : Number(row.created_by),
+            createdAt: row.created_at || null,
+        };
+    }
+
+    async function listTagsForCard(deviceId, cardId) {
+        const { rows } = await pool.query(
+            `SELECT t.id, t.slug, t.label, t.created_by, t.created_at
+             FROM kanban_card_tags ct
+             JOIN kanban_tags t ON t.id = ct.tag_id AND t.device_id = ct.device_id
+             WHERE ct.device_id = $1 AND ct.card_id = $2
+             ORDER BY t.slug`,
+            [deviceId, cardId]
+        );
+        return rows.map(mapTagRow);
+    }
+
+    // GET /card/:cardId/tags — list tags on one card.
+    router.get('/card/:cardId/tags', async (req, res) => {
+        const auth = authenticate(req, res);
+        if (!auth) return;
+        const { deviceId } = auth;
+        const { cardId } = req.params;
+
+        try {
+            if (!(await cardExistsInDevice(cardId, deviceId))) {
+                return res.status(404).json({ success: false, error: 'Card not found' });
+            }
+            res.json({ success: true, cardId, tags: await listTagsForCard(deviceId, cardId) });
+        } catch (err) {
+            console.error('[KanbanTags] GET tags error:', err);
+            res.status(500).json({ success: false, error: 'Internal server error' });
+        }
+    });
+
+    // POST /card/:cardId/tag — normalize/create a device tag and attach it to the card.
+    router.post('/card/:cardId/tag', async (req, res) => {
+        const auth = authenticate(req, res);
+        if (!auth) return;
+        const { deviceId, entityId } = auth;
+        const { cardId } = req.params;
+        const raw = (req.body && (req.body.tag || req.body.slug || req.body.name || req.body.label)) || '';
+        const slug = normalizeTagSlug(raw);
+        const label = displayLabel(raw, slug);
+
+        if (!slug) {
+            return res.status(400).json({ success: false, error: 'Missing tag' });
+        }
+
+        try {
+            if (!(await cardExistsInDevice(cardId, deviceId))) {
+                return res.status(404).json({ success: false, error: 'Card not found' });
+            }
+
+            const existingTag = await pool.query(
+                `SELECT id, slug, label, created_by, created_at
+                 FROM kanban_tags WHERE device_id = $1 AND slug = $2 LIMIT 1`,
+                [deviceId, slug]
+            );
+
+            let tag;
+            let createdTag = false;
+            if (existingTag.rows.length) {
+                tag = existingTag.rows[0];
+            } else {
+                const inserted = await pool.query(
+                    `INSERT INTO kanban_tags (device_id, slug, label, created_by)
+                     VALUES ($1, $2, $3, $4)
+                     ON CONFLICT (device_id, slug) DO UPDATE SET label = kanban_tags.label
+                     RETURNING id, slug, label, created_by, created_at`,
+                    [deviceId, slug, label, entityId || 0]
+                );
+                tag = inserted.rows[0];
+                createdTag = true;
+            }
+
+            const existingLink = await pool.query(
+                `SELECT 1 FROM kanban_card_tags
+                 WHERE device_id = $1 AND card_id = $2 AND tag_id = $3 LIMIT 1`,
+                [deviceId, cardId, tag.id]
+            );
+            let attached = false;
+            if (!existingLink.rows.length) {
+                await pool.query(
+                    `INSERT INTO kanban_card_tags (device_id, card_id, tag_id, created_by)
+                     VALUES ($1, $2, $3, $4)
+                     ON CONFLICT (device_id, card_id, tag_id) DO NOTHING`,
+                    [deviceId, cardId, tag.id, entityId || 0]
+                );
+                attached = true;
+                await pool.query('UPDATE kanban_cards SET updated_at = NOW() WHERE device_id = $1 AND id = $2', [deviceId, cardId]);
+            }
+
+            res.json({
+                success: true,
+                createdTag,
+                attached,
+                cardId,
+                tag: mapTagRow(tag),
+                tags: await listTagsForCard(deviceId, cardId),
+            });
+        } catch (err) {
+            console.error('[KanbanTags] POST tag error:', err);
+            res.status(500).json({ success: false, error: 'Internal server error' });
+        }
+    });
+
+    // DELETE /card/:cardId/tag/:slug — remove one tag from a card. The tag row
+    // remains so filters/graph labels stay stable if another card uses it.
+    router.delete('/card/:cardId/tag/:slug', async (req, res) => {
+        const auth = authenticate(req, res);
+        if (!auth) return;
+        const { deviceId } = auth;
+        const { cardId } = req.params;
+        const slug = normalizeTagSlug(req.params.slug || (req.body && req.body.tag));
+
+        if (!slug) {
+            return res.status(400).json({ success: false, error: 'Missing tag' });
+        }
+
+        try {
+            const result = await pool.query(
+                `DELETE FROM kanban_card_tags
+                 WHERE device_id = $1
+                   AND card_id = $2
+                   AND tag_id IN (
+                       SELECT id FROM kanban_tags WHERE device_id = $1 AND slug = $3
+                   )`,
+                [deviceId, cardId, slug]
+            );
+            if (result.rowCount > 0) {
+                await pool.query('UPDATE kanban_cards SET updated_at = NOW() WHERE device_id = $1 AND id = $2', [deviceId, cardId]);
+            }
+            res.json({ success: true, deleted: result.rowCount, cardId, tag: slug, tags: await listTagsForCard(deviceId, cardId) });
+        } catch (err) {
+            console.error('[KanbanTags] DELETE tag error:', err);
+            res.status(500).json({ success: false, error: 'Internal server error' });
+        }
+    });
+
+    // GET /tags — device-scoped tag catalogue for board filter chips/autocomplete.
+    router.get('/tags', async (req, res) => {
+        const auth = authenticate(req, res);
+        if (!auth) return;
+        const { deviceId } = auth;
+        try {
+            const { rows } = await pool.query(
+                `SELECT t.id, t.slug, t.label, t.created_by, t.created_at,
+                        COUNT(ct.card_id)::int AS card_count
+                 FROM kanban_tags t
+                 LEFT JOIN kanban_card_tags ct ON ct.device_id = t.device_id AND ct.tag_id = t.id
+                 WHERE t.device_id = $1
+                 GROUP BY t.id, t.slug, t.label, t.created_by, t.created_at
+                 ORDER BY t.slug`,
+                [deviceId]
+            );
+            res.json({ success: true, tags: rows.map(mapTagRow) });
+        } catch (err) {
+            console.error('[KanbanTags] GET /tags error:', err);
+            res.status(500).json({ success: false, error: 'Internal server error' });
+        }
+    });
+
+    return { router, _internal: { normalizeTagSlug, displayLabel } };
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -1723,6 +1723,15 @@ try {
     console.error('[KanbanLinks] Failed to load module:', err.message);
 }
 
+// Device-scoped Kanban tags — mounted on same /api/mission path
+try {
+    const kanbanTagsModule = require('./api_kanban_tags')(devices);
+    app.use('/api/mission', kanbanTagsModule.router);
+    console.log('[KanbanTags] Module loaded successfully');
+} catch (err) {
+    console.error('[KanbanTags] Failed to load module:', err.message);
+}
+
 // Idle Dispatch System — smart bot availability-based card dispatch
 try {
     const idleDispatchRouter = require('./api_idle_dispatch');

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -614,6 +614,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             commentCount: parseInt(row.comment_count) || 0,
             noteCount: parseInt(row.note_count) || 0,
             fileCount: parseInt(row.file_count) || 0,
+            tags: Array.isArray(row.tags) ? row.tags : [],
         };
 
         // Schedule fields — always include if schedule was ever configured
@@ -646,6 +647,36 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
         card.chatAnchorCoord = row.chat_anchor_coord || null;
 
         return card;
+    }
+
+
+    async function attachTagsToCards(deviceId, cards) {
+        if (!Array.isArray(cards) || cards.length === 0) return cards;
+        const ids = [...new Set(cards.map(c => c.id).filter(Boolean))];
+        if (ids.length === 0) return cards;
+        try {
+            const idPlaceholders = ids.map((_, i) => `$${i + 2}`).join(',');
+            const result = await pool.query(
+                `SELECT ct.card_id, t.slug, t.label
+                 FROM kanban_card_tags ct
+                 JOIN kanban_tags t ON t.id = ct.tag_id AND t.device_id = ct.device_id
+                 WHERE ct.device_id = $1 AND ct.card_id IN (${idPlaceholders})
+                 ORDER BY t.slug`,
+                [deviceId, ...ids]
+            );
+            const byCard = new Map();
+            for (const row of result.rows) {
+                if (!byCard.has(row.card_id)) byCard.set(row.card_id, []);
+                byCard.get(row.card_id).push({ slug: row.slug, label: row.label || row.slug });
+            }
+            for (const card of cards) card.tags = byCard.get(card.id) || [];
+        } catch (err) {
+            // Backward-compatible during rolling deploy/migration: missing tag
+            // tables should not break core board/card reads.
+            console.warn('[Kanban] attachTagsToCards skipped:', err.message);
+            for (const card of cards) if (!Array.isArray(card.tags)) card.tags = [];
+        }
+        return cards;
     }
 
     // ============================================
@@ -825,7 +856,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
     router.get('/cards', async (req, res) => {
         if (!authenticate(req, res)) return;
         const { deviceId } = { ...req.query, ...req.body };
-        const { status: filterStatus, assignedBot, priority: filterPriority, automation, q: searchQuery, since, until, includeComments, includeSubcards, includeArchived } = req.query;
+        const { status: filterStatus, assignedBot, priority: filterPriority, automation, q: searchQuery, since, until, includeComments, includeSubcards, includeArchived, tag: filterTag } = req.query;
 
         const hasSearch = !!(searchQuery && typeof searchQuery === 'string' && searchQuery.trim());
         // Search auto-includes archived cards (Hank 2026-04-28: 歸檔卡找不回來 = 知識斷掉);
@@ -875,6 +906,16 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                 params.push(filterPriority);
             }
 
+            if (filterTag && String(filterTag).trim()) {
+                const tagSlug = String(filterTag).trim().toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9._:-]+/g, '-').replace(/-+/g, '-').replace(/^-|-$/g, '').slice(0, 80);
+                query += ` AND c.id IN (
+                    SELECT fct.card_id FROM kanban_card_tags fct
+                    JOIN kanban_tags ft ON ft.id = fct.tag_id AND ft.device_id = fct.device_id
+                    WHERE fct.device_id = $1 AND ft.slug = $${paramIdx++}
+                )`;
+                params.push(tagSlug);
+            }
+
             // Funnel filters added 2026-04-23:
             // ?q=text  → ILIKE match on title (simple text search)
             //   2026-04-28: ?includeComments=true expands to kanban_comments.text;
@@ -921,6 +962,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
 
             const result = await pool.query(query, params);
             const cards = result.rows.map(serializeCard);
+            await attachTagsToCards(deviceId, cards);
 
             // Group by status for kanban view
             const board = {};
@@ -1291,7 +1333,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
 
             res.json({
                 success: true,
-                cards: result.rows.map(serializeCard),
+                cards: await attachTagsToCards(deviceId, result.rows.map(serializeCard)),
                 total,
                 page,
                 pages: Math.ceil(total / limit)
@@ -1352,6 +1394,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             }
 
             const card = serializeCard(cardResult.rows[0]);
+            await attachTagsToCards(deviceId, [card]);
 
             // Fetch comments (latest 50)
             const commentsResult = await pool.query(
@@ -1553,6 +1596,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
         }
     });
 
+
     // ============================================
     // POST /card/:id/restore — Un-archive a card (bring it back to the board)
     // ============================================
@@ -1585,6 +1629,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             res.status(500).json({ success: false, error: err.message });
         }
     });
+
 
     // ============================================
     // POST /card/:id/move — Move card status
@@ -1805,6 +1850,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
         }
     });
 
+
     // ============================================
     // POST /card/:id/comment — Add comment
     // ============================================
@@ -1896,6 +1942,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
         }
     });
 
+
     // ============================================
     // POST /card/:id/note — Add note
     // ============================================
@@ -1979,6 +2026,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             res.status(500).json({ success: false, error: err.message });
         }
     });
+
 
     // ============================================
     // POST /card/:id/file — Add file (URL-based)

--- a/backend/kanban_schema.sql
+++ b/backend/kanban_schema.sql
@@ -91,6 +91,35 @@ UPDATE kanban_cards SET done_retention_ms = 604800000 WHERE done_retention_ms = 
 -- ============================================
 CREATE INDEX IF NOT EXISTS idx_kanban_cards_device_updated ON kanban_cards(device_id, updated_at DESC);
 
+
+-- ============================================
+-- Migration: Device-scoped Kanban tags
+-- Explicit many-to-many tags for board filters and force-graph clustering.
+-- Tags are normalized by API as trim/lower slugs; label preserves display text.
+-- ============================================
+CREATE TABLE IF NOT EXISTS kanban_tags (
+    id BIGSERIAL PRIMARY KEY,
+    device_id VARCHAR(64) NOT NULL,
+    slug VARCHAR(80) NOT NULL,
+    label VARCHAR(120) NOT NULL,
+    created_by INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(device_id, slug)
+);
+
+CREATE TABLE IF NOT EXISTS kanban_card_tags (
+    device_id VARCHAR(64) NOT NULL,
+    card_id VARCHAR(48) NOT NULL REFERENCES kanban_cards(id) ON DELETE CASCADE,
+    tag_id BIGINT NOT NULL REFERENCES kanban_tags(id) ON DELETE CASCADE,
+    created_by INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY(device_id, card_id, tag_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_kanban_tags_device_slug ON kanban_tags(device_id, slug);
+CREATE INDEX IF NOT EXISTS idx_kanban_card_tags_card ON kanban_card_tags(device_id, card_id);
+CREATE INDEX IF NOT EXISTS idx_kanban_card_tags_tag ON kanban_card_tags(device_id, tag_id);
+
 -- ============================================
 -- Kanban Comments Table (留言板)
 -- ============================================

--- a/backend/migrations/20260513_kanban_card_tags.down.sql
+++ b/backend/migrations/20260513_kanban_card_tags.down.sql
@@ -1,0 +1,6 @@
+-- Reversible rollback for device-scoped Kanban tags.
+DROP INDEX IF EXISTS idx_kanban_card_tags_tag;
+DROP INDEX IF EXISTS idx_kanban_card_tags_card;
+DROP INDEX IF EXISTS idx_kanban_tags_device_slug;
+DROP TABLE IF EXISTS kanban_card_tags;
+DROP TABLE IF EXISTS kanban_tags;

--- a/backend/migrations/20260513_kanban_card_tags.up.sql
+++ b/backend/migrations/20260513_kanban_card_tags.up.sql
@@ -1,0 +1,28 @@
+
+-- ============================================
+-- Migration: Device-scoped Kanban tags
+-- Explicit many-to-many tags for board filters and force-graph clustering.
+-- Tags are normalized by API as trim/lower slugs; label preserves display text.
+-- ============================================
+CREATE TABLE IF NOT EXISTS kanban_tags (
+    id BIGSERIAL PRIMARY KEY,
+    device_id VARCHAR(64) NOT NULL,
+    slug VARCHAR(80) NOT NULL,
+    label VARCHAR(120) NOT NULL,
+    created_by INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    UNIQUE(device_id, slug)
+);
+
+CREATE TABLE IF NOT EXISTS kanban_card_tags (
+    device_id VARCHAR(64) NOT NULL,
+    card_id VARCHAR(48) NOT NULL REFERENCES kanban_cards(id) ON DELETE CASCADE,
+    tag_id BIGINT NOT NULL REFERENCES kanban_tags(id) ON DELETE CASCADE,
+    created_by INTEGER NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY(device_id, card_id, tag_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_kanban_tags_device_slug ON kanban_tags(device_id, slug);
+CREATE INDEX IF NOT EXISTS idx_kanban_card_tags_card ON kanban_card_tags(device_id, card_id);
+CREATE INDEX IF NOT EXISTS idx_kanban_card_tags_tag ON kanban_card_tags(device_id, tag_id);

--- a/backend/mindmap-graph-projection.js
+++ b/backend/mindmap-graph-projection.js
@@ -17,11 +17,12 @@
  *                     (amendment A from PR #2679 review)
  *   related/references/duplicates/causes/supports/contradicts
  *                   — kanban_card_links explicit non-hierarchical edges
+ *   tag             — kanban_card_tags explicit tag membership, when includeTags=true
  */
 
 'use strict';
 
-const SCHEMA_VERSION = 1;
+const SCHEMA_VERSION = 2;
 const LABEL_MAX = 80;
 const TITLE_MAX = 200;
 const SUMMARY_MAX = 240;
@@ -132,6 +133,20 @@ function buildOwnerNode(entityId, entityRecord) {
     };
 }
 
+
+function buildTagNode(tag) {
+    return {
+        id: `tag:${tag.slug}`,
+        sourceId: tag.slug,
+        label: clip(tag.label || tag.slug, LABEL_MAX),
+        fullTitle: clip(tag.label || tag.slug, TITLE_MAX),
+        type: 'tag',
+        slug: tag.slug,
+        colorKey: 'tag',
+        val: Math.max(3, Math.min(10, Number(tag.card_count) || 3)),
+    };
+}
+
 function buildChatNode(messageId, displayLabel) {
     const label = displayLabel || `chat #${String(messageId).slice(0, 8)}`;
     return {
@@ -225,6 +240,7 @@ function parseGraphOptions(query, { isDeviceAuth, callerEntityId }) {
         includeOwners,
         includeNeighbors: parseBoolFlag(query.includeNeighbors, scope === 'entity'),
         includeTextFallbackRefs: parseBoolFlag(query.includeTextFallbackRefs, false),
+        includeTags: parseBoolFlag(query.includeTags, false),
         limitNodes: clampInt(query.limitNodes, NODE_LIMIT_DEFAULT, 1, NODE_LIMIT_HARD),
         limitEdges: clampInt(query.limitEdges, EDGE_LIMIT_DEFAULT, 1, EDGE_LIMIT_HARD),
     };
@@ -241,6 +257,7 @@ function projectGraph({
     initialCardIds,
     depRows,
     cardLinkRows = [],
+    tagRows = [],
     noteCardLinkRows = [],
     commentCounts,
     noteCounts,
@@ -266,7 +283,7 @@ function projectGraph({
     const links = [];
     const nodeIdSet = new Set();
     const ownerNeed = new Set();
-    const sourceCounts = { task: 0, note: 0, owner: 0, chat: 0 };
+    const sourceCounts = { task: 0, note: 0, owner: 0, chat: 0, tag: 0 };
 
     // ── Task nodes ──
     for (const c of cards) {
@@ -310,6 +327,25 @@ function projectGraph({
         }
     }
 
+    // ── Tag nodes ──
+    if (options.includeTags) {
+        const bySlug = new Map();
+        for (const r of tagRows || []) {
+            if (!cardIds.has(r.card_id) || !r.slug) continue;
+            if (!bySlug.has(r.slug)) {
+                bySlug.set(r.slug, { slug: r.slug, label: r.label || r.slug, card_count: 0 });
+            }
+            bySlug.get(r.slug).card_count += 1;
+        }
+        for (const tag of [...bySlug.values()].sort((a, b) => a.slug.localeCompare(b.slug))) {
+            const id = `tag:${tag.slug}`;
+            if (nodeIdSet.has(id)) continue;
+            nodes.push(buildTagNode(tag));
+            nodeIdSet.add(id);
+            sourceCounts.tag++;
+        }
+    }
+
     // ── Chat nodes ── (amendment A: chat_message becomes a first-class graph node)
     // Source 1: kanban_cards.chat_anchor_message_id pinned at file-time.
     // Source 2: mindmap_node_anchors cross-correlation (a mindmap_node bridges
@@ -343,6 +379,7 @@ function projectGraph({
         owner: 0,
         note_on_card: 0,
         chat_anchor: 0,
+        tag: 0,
         related: 0,
         references: 0,
         duplicates: 0,
@@ -397,6 +434,29 @@ function projectGraph({
             directional,
         }));
         edgeCounts[relationType] = (edgeCounts[relationType] || 0) + 1;
+    }
+
+    // 4. Tag edges (optional explicit clustering hubs)
+    if (options.includeTags) {
+        const seenTagLinks = new Set();
+        for (const r of tagRows || []) {
+            if (!cardIds.has(r.card_id) || !r.slug) continue;
+            const src = `tag:${r.slug}`;
+            const target = `task:${r.card_id}`;
+            const key = `${src}|${target}`;
+            if (!nodeIdSet.has(src) || seenTagLinks.has(key)) continue;
+            seenTagLinks.add(key);
+            links.push(buildLink({
+                id: `tag:${r.slug}:${r.card_id}`,
+                source: src,
+                target,
+                type: 'tag',
+                weight: 1.8,
+                evidence: 'kanban_card_tags',
+                directional: false,
+            }));
+            edgeCounts.tag++;
+        }
     }
 
     // 4. Owner edges
@@ -546,7 +606,7 @@ function projectGraph({
     );
 
     // After truncation, re-tally source counts so they match `nodes`.
-    const finalSourceCounts = { task: 0, note: 0, owner: 0, chat: 0 };
+    const finalSourceCounts = { task: 0, note: 0, owner: 0, chat: 0, tag: 0 };
     for (const n of nodes) {
         if (finalSourceCounts[n.type] !== undefined) finalSourceCounts[n.type]++;
     }
@@ -592,6 +652,7 @@ module.exports = {
     buildTaskNode,
     buildNoteNode,
     buildOwnerNode,
+    buildTagNode,
     buildChatNode,
     buildLink,
     applyCaps,

--- a/backend/mindmap.js
+++ b/backend/mindmap.js
@@ -955,6 +955,16 @@ function createMindmapModule(devices) {
 
             const allCardIds = [...new Set(cards.map(c => c.id))];
 
+            // 2b) Tags (optional explicit clustering hubs)
+            const tagRowsResult = (!options.includeTags || allCardIds.length === 0) ? { rows: [] } : await pool.query(
+                `SELECT ct.card_id, t.slug, t.label
+                 FROM kanban_card_tags ct
+                 JOIN kanban_tags t ON t.id = ct.tag_id AND t.device_id = ct.device_id
+                 WHERE ct.device_id = $1 AND ct.card_id = ANY($2::varchar[])
+                 ORDER BY t.slug, ct.card_id`,
+                [deviceId, allCardIds]
+            );
+
             // 3) Aggregate counts
             const [commentCounts, noteCounts] = allCardIds.length === 0
                 ? [{ rows: [] }, { rows: [] }]
@@ -1032,6 +1042,7 @@ function createMindmapModule(devices) {
                 initialCardIds,
                 depRows: depsResult.rows,
                 cardLinkRows: cardLinksResult.rows,
+                tagRows: tagRowsResult.rows,
                 noteCardLinkRows: noteCardLinksResult.rows,
                 commentCounts: commentCounts.rows,
                 noteCounts: noteCounts.rows,

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -205,6 +205,12 @@
         .kb-modal-tab.active { color:var(--primary); border-bottom-color:var(--primary); }
         .kb-modal-panel { display:none; padding:16px 24px; }
         .kb-modal-panel.active { display:block; }
+
+        .kb-tag-row { display:flex; flex-wrap:wrap; gap:6px; align-items:center; margin-top:8px; }
+        .kb-tag-chip { display:inline-flex; align-items:center; gap:4px; padding:2px 8px; border-radius:999px; background:rgba(99,102,241,.14); color:var(--primary,#6366f1); font-size:12px; font-weight:600; border:1px solid rgba(99,102,241,.24); }
+        .kb-tag-chip button { border:0; background:transparent; color:inherit; cursor:pointer; padding:0; font-size:12px; }
+        .kb-tag-form { display:flex; gap:6px; align-items:center; margin-top:8px; width:100%; }
+        .kb-tag-form input { min-width:120px; flex:1; padding:6px 8px; border:1px solid var(--card-border,#ccc); border-radius:6px; background:var(--input-bg,#fff); color:var(--text,#111); }
         #panel-comments.active {
             display:flex;
             flex-direction:column;
@@ -681,6 +687,8 @@
             <select id="funnelEntity" onchange="onFunnelChange()" style="padding:6px 10px; border:1px solid #ccc; border-radius:6px;">
                 <option value="" data-i18n="kb_funnel_entity_all">All entities</option>
             </select>
+            <input type="text" id="funnelTag" placeholder="Tag…" data-i18n-placeholder="kb_funnel_tag"
+                   oninput="onFunnelChange()" style="padding:6px 10px; border:1px solid #ccc; border-radius:6px; min-width:120px;">
             <label style="font-size:13px; color:#666;">
                 <span data-i18n="kb_funnel_since">Since</span>:
                 <input type="date" id="funnelSince" onchange="onFunnelChange()" style="padding:4px 6px; border:1px solid #ccc; border-radius:6px;">
@@ -1043,7 +1051,7 @@
         let allCards = [];
         let currentFilter = 'all';
         let currentSort = 'updated_desc';
-        let funnelState = { q: '', status: '', priority: '', assignedBot: '', since: '', until: '', includeComments: false, includeSubcards: false };
+        let funnelState = { q: '', status: '', priority: '', assignedBot: '', tag: '', since: '', until: '', includeComments: false, includeSubcards: false };
         let funnelDebounce = null;
         let historyPage = 1;
         let mobileTab = 'backlog';
@@ -1217,6 +1225,26 @@
             return apiCall('GET', `/api/mission/card/${cardId}/messages?deviceId=${encodeURIComponent(currentUser.deviceId)}&deviceSecret=${encodeURIComponent(currentUser.deviceSecret)}&limit=${limit}`);
         }
 
+
+
+        async function apiGetCardTags(cardId) {
+            return apiCall('GET', `/api/mission/card/${cardId}/tags?deviceId=${encodeURIComponent(currentUser.deviceId)}&deviceSecret=${encodeURIComponent(currentUser.deviceSecret)}`);
+        }
+
+        async function apiAddCardTag(cardId, tag) {
+            return apiCall('POST', `/api/mission/card/${cardId}/tag`, {
+                deviceId: currentUser.deviceId,
+                deviceSecret: currentUser.deviceSecret,
+                tag,
+            });
+        }
+
+        async function apiRemoveCardTag(cardId, slug) {
+            return apiCall('DELETE', `/api/mission/card/${cardId}/tag/${encodeURIComponent(slug)}`, {
+                deviceId: currentUser.deviceId,
+                deviceSecret: currentUser.deviceSecret,
+            });
+        }
 
         async function apiGetCardLinks(cardId) {
             return apiCall('GET', `/api/mission/card/${cardId}/links?deviceId=${encodeURIComponent(currentUser.deviceId)}&deviceSecret=${encodeURIComponent(currentUser.deviceSecret)}`);
@@ -1607,6 +1635,18 @@
             }
         }
 
+
+        function renderTags(tags, opts = {}) {
+            if (!Array.isArray(tags) || !tags.length) return '';
+            const removable = !!opts.removable;
+            return `<div class="kb-tag-row">` + tags.map(tag => {
+                const slug = tag && tag.slug ? String(tag.slug) : '';
+                const label = tag && tag.label ? String(tag.label) : slug;
+                const removeBtn = removable ? `<button type="button" title="Remove tag" onclick="event.stopPropagation(); removeCardTag('${escapeJs(openCardId || '')}','${escapeJs(slug)}')">×</button>` : '';
+                return `<span class="kb-tag-chip" title="tag:${escapeHtml(slug)}">#${escapeHtml(label)}${removeBtn}</span>`;
+            }).join('') + `</div>`;
+        }
+
         function renderCard(card) {
             console.log('[Kanban] renderCard:', card.id, card.title, 'assigned:', card.assignedBots);
             const isStale = card.is_stale ? ' stale' : '';
@@ -1629,6 +1669,7 @@
                     <span class="kb-card-assigned">${renderAssignedAvatars(card.assignedBots)}</span>
                 </div>
                 <div class="kb-card-title">${escapeHtml(card.title)}</div>
+                ${renderTags(card.tags)}
                 ${card.description ? '<div class="kb-card-desc">'+renderSmartChips(card.description)+'</div>' : ''}
                 <div class="kb-card-footer">
                     ${commentCount ? '<span>💬 '+commentCount+'</span>' : ''}
@@ -1700,6 +1741,7 @@
                 status: document.getElementById('funnelStatus').value,
                 priority: document.getElementById('funnelPriority').value,
                 assignedBot: document.getElementById('funnelEntity').value,
+                tag: document.getElementById('funnelTag').value.trim(),
                 since: document.getElementById('funnelSince').value,
                 until: document.getElementById('funnelUntil').value,
                 includeComments: checks.some(c => c.value === 'comments' && c.checked),
@@ -1722,7 +1764,7 @@
         }
 
         function resetFunnel() {
-            ['funnelSearch','funnelStatus','funnelPriority','funnelEntity','funnelSince','funnelUntil'].forEach(id => {
+            ['funnelSearch','funnelStatus','funnelPriority','funnelEntity','funnelTag','funnelSince','funnelUntil'].forEach(id => {
                 const el = document.getElementById(id);
                 if (el) el.value = '';
             });
@@ -1735,7 +1777,7 @@
                     lab.classList.toggle('active', lab.dataset.scope === 'title');
                 });
             }
-            funnelState = { q: '', status: '', priority: '', assignedBot: '', since: '', until: '', includeComments: false, includeSubcards: false };
+            funnelState = { q: '', status: '', priority: '', assignedBot: '', tag: '', since: '', until: '', includeComments: false, includeSubcards: false };
             syncFunnelUrl();
             loadCards();
         }
@@ -1750,6 +1792,7 @@
             if (funnelState.status) p.push('status=' + encodeURIComponent(funnelState.status));
             if (funnelState.priority) p.push('priority=' + encodeURIComponent(funnelState.priority));
             if (funnelState.assignedBot) p.push('assignedBot=' + encodeURIComponent(funnelState.assignedBot));
+            if (funnelState.tag) p.push('tag=' + encodeURIComponent(funnelState.tag));
             if (funnelState.since) p.push('since=' + encodeURIComponent(new Date(funnelState.since).toISOString()));
             if (funnelState.until) {
                 const untilEnd = new Date(funnelState.until);
@@ -1944,6 +1987,7 @@
                 ${scheduleInfo}
                 ${card.description ? '<div class="kb-detail-desc">'+renderSmartChips(card.description)+'</div>' : ''}
                 <div class="kb-dep-chips-container kb-detail-dep-chips" data-dep-card-id="${cardId}"></div>
+                <div id="detailTagsPanel" style="width:100%;margin-top:10px;padding:10px;border:1px solid var(--border-color,#333);border-radius:8px;background:rgba(255,255,255,.03)"></div>
                 <div id="detailCardLinks" class="kb-card-link-panel" style="width:100%;margin-top:10px;padding:10px;border:1px solid var(--border-color,#333);border-radius:8px;background:rgba(255,255,255,.03)">
                     <div style="font-weight:600;margin-bottom:8px">🔗 Card links</div>
                     <div class="kb-muted">Loading links…</div>
@@ -1955,6 +1999,8 @@
                     detailDepContainer.innerHTML = renderDependencyChips(dependencies, dependents);
                 });
             }
+            renderDetailTags(card.tags || []);
+            refreshDetailTags(cardId);
             loadCardLinksForDetail(cardId);
 
             // Move bar — shared assign + reviewer UI for all cards
@@ -2032,6 +2078,61 @@
             document.getElementById('detailModal').classList.add('show');
         }
 
+
+
+        function renderDetailTags(tags) {
+            const panel = document.getElementById('detailTagsPanel');
+            if (!panel) return;
+            panel.innerHTML = `
+                <div style="font-weight:600;margin-bottom:8px">🏷 Tags</div>
+                ${renderTags(tags || [], { removable: true }) || '<div class="kb-muted" style="font-size:12px">No tags</div>'}
+                <div class="kb-tag-form">
+                    <input id="detailTagInput" placeholder="Add tag…" onkeydown="if(event.key==='Enter')addCardTag('${escapeJs(openCardId || '')}')">
+                    <button class="kb-move-btn" type="button" onclick="addCardTag('${escapeJs(openCardId || '')}')">Add</button>
+                </div>`;
+        }
+
+        async function refreshDetailTags(cardId) {
+            try {
+                const data = await apiGetCardTags(cardId);
+                const card = findCard(cardId);
+                if (card) card.tags = data.tags || [];
+                renderDetailTags(data.tags || []);
+            } catch (err) {
+                console.warn('[Kanban] refresh tags failed:', err.message);
+            }
+        }
+
+        async function addCardTag(cardId) {
+            const input = document.getElementById('detailTagInput');
+            const raw = input ? input.value : '';
+            if (!cardId || !raw.trim()) return;
+            try {
+                const data = await apiAddCardTag(cardId, raw);
+                if (input) input.value = '';
+                const card = findCard(cardId);
+                if (card) card.tags = data.tags || [];
+                renderDetailTags(data.tags || []);
+                renderBoard(true);
+                showToast('Tag added');
+            } catch (err) {
+                showToast('Add tag failed: ' + (err.message || err), true);
+            }
+        }
+
+        async function removeCardTag(cardId, slug) {
+            if (!cardId || !slug) return;
+            try {
+                const data = await apiRemoveCardTag(cardId, slug);
+                const card = findCard(cardId);
+                if (card) card.tags = data.tags || [];
+                renderDetailTags(data.tags || []);
+                renderBoard(true);
+                showToast('Tag removed');
+            } catch (err) {
+                showToast('Remove tag failed: ' + (err.message || err), true);
+            }
+        }
 
         function escapeJs(value) {
             return String(value == null ? '' : value)

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -457833,6 +457833,7 @@ const TRANSLATIONS = {
 
 
         "kb_funnel_search": "Search…",
+        "kb_funnel_tag": "Tag…",
 
 
 

--- a/backend/tests/jest/__fixtures__/kanban-dep-schema.js
+++ b/backend/tests/jest/__fixtures__/kanban-dep-schema.js
@@ -19,9 +19,64 @@ const MINIMAL_SCHEMA = `
         id VARCHAR(48) PRIMARY KEY,
         device_id VARCHAR(64) NOT NULL,
         title VARCHAR(255) NOT NULL,
+        description TEXT DEFAULT '',
+        priority VARCHAR(8) DEFAULT 'P2',
+        assigned_bots JSONB DEFAULT '[]'::jsonb,
+        created_by INTEGER DEFAULT 0,
+        reviewer_entity_id INTEGER DEFAULT NULL,
+        status_changed_at TIMESTAMPTZ DEFAULT NOW(),
+        stale_threshold_ms BIGINT DEFAULT 10800000,
+        done_retention_ms BIGINT DEFAULT 604800000,
+        archived BOOLEAN DEFAULT FALSE,
+        is_automation BOOLEAN DEFAULT FALSE,
+        parent_card_id VARCHAR(48) DEFAULT NULL,
+        is_auto_generated BOOLEAN DEFAULT FALSE,
+        dispatch_mode VARCHAR(20) DEFAULT 'immediate',
+        pending_dispatch BOOLEAN DEFAULT FALSE,
+        chat_anchor_message_id TEXT DEFAULT NULL,
+        chat_anchor_coord JSONB DEFAULT NULL,
+        requires_screenshot_review BOOLEAN DEFAULT FALSE,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        updated_at TIMESTAMPTZ DEFAULT NOW(),
         has_dependencies BOOLEAN DEFAULT FALSE,
         dependency_status VARCHAR(16) DEFAULT 'ready',
         status VARCHAR(16) DEFAULT 'todo'
+    );
+
+
+
+    CREATE TABLE kanban_comments (
+        id UUID PRIMARY KEY,
+        card_id VARCHAR(48) NOT NULL REFERENCES kanban_cards(id) ON DELETE CASCADE,
+        device_id VARCHAR(64) NOT NULL,
+        from_entity_id INTEGER NOT NULL DEFAULT 0,
+        text TEXT NOT NULL DEFAULT '',
+        is_system BOOLEAN DEFAULT FALSE,
+        created_at TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE TABLE kanban_notes (
+        id UUID PRIMARY KEY,
+        card_id VARCHAR(48) NOT NULL REFERENCES kanban_cards(id) ON DELETE CASCADE,
+        device_id VARCHAR(64) NOT NULL,
+        title VARCHAR(255) NOT NULL DEFAULT '',
+        content TEXT NOT NULL DEFAULT '',
+        from_entity_id INTEGER NOT NULL DEFAULT 0,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        updated_at TIMESTAMPTZ DEFAULT NOW()
+    );
+
+    CREATE TABLE kanban_files (
+        id UUID PRIMARY KEY,
+        card_id VARCHAR(48) NOT NULL REFERENCES kanban_cards(id) ON DELETE CASCADE,
+        device_id VARCHAR(64) NOT NULL,
+        filename VARCHAR(255) NOT NULL DEFAULT '',
+        url TEXT NOT NULL DEFAULT '',
+        mime_type VARCHAR(128) DEFAULT NULL,
+        file_size BIGINT DEFAULT NULL,
+        uploaded_by INTEGER NOT NULL DEFAULT 0,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        file_id TEXT DEFAULT NULL
     );
 
     CREATE TABLE kanban_card_dependencies (
@@ -54,6 +109,30 @@ const MINIMAL_SCHEMA = `
     CREATE INDEX idx_kanban_card_links_source ON kanban_card_links(device_id, source_card_id);
     CREATE INDEX idx_kanban_card_links_target ON kanban_card_links(device_id, target_card_id);
     CREATE INDEX idx_kanban_card_links_relation ON kanban_card_links(device_id, relation_type);
+
+
+    CREATE TABLE kanban_tags (
+        id BIGSERIAL PRIMARY KEY,
+        device_id VARCHAR(64) NOT NULL,
+        slug VARCHAR(80) NOT NULL,
+        label VARCHAR(120) NOT NULL,
+        created_by INTEGER NOT NULL DEFAULT 0,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        UNIQUE(device_id, slug)
+    );
+
+    CREATE TABLE kanban_card_tags (
+        device_id VARCHAR(64) NOT NULL,
+        card_id VARCHAR(48) NOT NULL REFERENCES kanban_cards(id) ON DELETE CASCADE,
+        tag_id BIGINT NOT NULL REFERENCES kanban_tags(id) ON DELETE CASCADE,
+        created_by INTEGER NOT NULL DEFAULT 0,
+        created_at TIMESTAMPTZ DEFAULT NOW(),
+        PRIMARY KEY(device_id, card_id, tag_id)
+    );
+
+    CREATE INDEX idx_kanban_tags_device_slug ON kanban_tags(device_id, slug);
+    CREATE INDEX idx_kanban_card_tags_card ON kanban_card_tags(device_id, card_id);
+    CREATE INDEX idx_kanban_card_tags_tag ON kanban_card_tags(device_id, tag_id);
 `;
 
 async function bootstrap() {
@@ -114,10 +193,30 @@ async function insertLink(pool, deviceId, source, target, relationType = 'relate
     );
 }
 
+
+async function insertTag(pool, deviceId, cardId, rawSlug, label) {
+    const slug = String(rawSlug).trim().toLowerCase();
+    const tag = await pool.query(
+        `INSERT INTO kanban_tags (device_id, slug, label)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (device_id, slug) DO UPDATE SET label = EXCLUDED.label
+         RETURNING id`,
+        [deviceId, slug, label || slug]
+    );
+    await pool.query(
+        `INSERT INTO kanban_card_tags (device_id, card_id, tag_id)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (device_id, card_id, tag_id) DO NOTHING`,
+        [deviceId, cardId, tag.rows[0].id]
+    );
+}
+
 async function reset(pool) {
+    await pool.query('DELETE FROM kanban_card_tags');
+    await pool.query('DELETE FROM kanban_tags');
     await pool.query('DELETE FROM kanban_card_links');
     await pool.query('DELETE FROM kanban_card_dependencies');
     await pool.query('DELETE FROM kanban_cards');
 }
 
-module.exports = { MINIMAL_SCHEMA, bootstrap, insertCard, insertEdge, insertLink, reset };
+module.exports = { MINIMAL_SCHEMA, bootstrap, insertCard, insertEdge, insertLink, insertTag, reset };

--- a/backend/tests/jest/api-kanban-tags.test.js
+++ b/backend/tests/jest/api-kanban-tags.test.js
@@ -1,0 +1,135 @@
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+const { bootstrap, insertCard, insertTag, reset } = require('./__fixtures__/kanban-dep-schema');
+
+const DEVICE_A = 'dev-a';
+const DEVICE_B = 'dev-b';
+const ENTITY_ID = 7;
+const BOT_SECRET = 'test-bot-secret';
+const DEVICE_SECRET = 'test-device-secret';
+
+function devices() {
+    return {
+        [DEVICE_A]: {
+            deviceSecret: DEVICE_SECRET,
+            entities: { [ENTITY_ID]: { botSecret: BOT_SECRET } },
+        },
+        [DEVICE_B]: {
+            deviceSecret: 'other-device-secret',
+            entities: { [ENTITY_ID]: { botSecret: 'other-bot-secret' } },
+        },
+    };
+}
+
+function buildTagApp(pool) {
+    const factory = require('../../api_kanban_tags');
+    const { router } = factory(devices(), { pool });
+    const app = express();
+    app.use(express.json());
+    app.use('/api/mission', router);
+    return app;
+}
+
+function buildKanbanAppWithMockedPool(pool) {
+    jest.resetModules();
+    jest.doMock('pg', () => ({ Pool: jest.fn(() => pool) }));
+    jest.doMock('@aws-sdk/client-s3', () => ({
+        S3Client: jest.fn(),
+        GetObjectCommand: jest.fn(),
+    }));
+    jest.doMock('@aws-sdk/s3-request-presigner', () => ({ getSignedUrl: jest.fn() }));
+    const factory = require('../../kanban');
+    const { router } = factory(devices(), {});
+    const app = express();
+    app.use(express.json());
+    app.use('/api/mission', router);
+    return app;
+}
+
+const botAuth = { deviceId: DEVICE_A, entityId: ENTITY_ID, botSecret: BOT_SECRET };
+const deviceAuthQS = `deviceId=${DEVICE_A}&deviceSecret=${DEVICE_SECRET}`;
+
+describe('Kanban tags API and board filtering', () => {
+    let pool;
+    let tagApp;
+
+    beforeAll(async () => {
+        ({ pool } = await bootstrap());
+        tagApp = buildTagApp(pool);
+    });
+
+    beforeEach(async () => {
+        await reset(pool);
+        await insertCard(pool, 'A', DEVICE_A, 'A task');
+        await insertCard(pool, 'B', DEVICE_A, 'B task');
+        await insertCard(pool, 'A', DEVICE_B, 'B-side A');
+    });
+
+    afterEach(() => {
+        jest.dontMock('pg');
+        jest.dontMock('@aws-sdk/client-s3');
+        jest.dontMock('@aws-sdk/s3-request-presigner');
+    });
+
+    test('POST normalizes duplicate tag input and GET lists one card tag', async () => {
+        const first = await request(tagApp)
+            .post('/api/mission/card/A/tag')
+            .send({ ...botAuth, tag: '  UI Polish  ' });
+        expect(first.status).toBe(200);
+        expect(first.body).toMatchObject({ success: true, createdTag: true, attached: true });
+        expect(first.body.tag.slug).toBe('ui-polish');
+
+        const second = await request(tagApp)
+            .post('/api/mission/card/A/tag')
+            .send({ ...botAuth, tag: 'ui-polish' });
+        expect(second.status).toBe(200);
+        expect(second.body).toMatchObject({ success: true, createdTag: false, attached: false });
+        expect(second.body.tags).toHaveLength(1);
+
+        const list = await request(tagApp).get(`/api/mission/card/A/tags?deviceId=${DEVICE_A}&entityId=${ENTITY_ID}&botSecret=${BOT_SECRET}`);
+        expect(list.status).toBe(200);
+        expect(list.body.tags.map(t => t.slug)).toEqual(['ui-polish']);
+    });
+
+    test('DELETE removes a tag from only the requested card', async () => {
+        await insertTag(pool, DEVICE_A, 'A', 'ui', 'UI');
+        await insertTag(pool, DEVICE_A, 'B', 'ui', 'UI');
+
+        const del = await request(tagApp)
+            .delete('/api/mission/card/A/tag/ui')
+            .send(botAuth);
+        expect(del.status).toBe(200);
+        expect(del.body).toMatchObject({ success: true, deleted: 1 });
+        expect(del.body.tags).toEqual([]);
+
+        const b = await request(tagApp).get(`/api/mission/card/B/tags?deviceId=${DEVICE_A}&entityId=${ENTITY_ID}&botSecret=${BOT_SECRET}`);
+        expect(b.body.tags.map(t => t.slug)).toEqual(['ui']);
+    });
+
+    test('device isolation prevents cross-device card/tag visibility', async () => {
+        await insertTag(pool, DEVICE_A, 'A', 'ui', 'UI');
+        await insertTag(pool, DEVICE_B, 'A', 'secret', 'Secret');
+
+        const visible = await request(tagApp).get(`/api/mission/card/A/tags?deviceId=${DEVICE_A}&entityId=${ENTITY_ID}&botSecret=${BOT_SECRET}`);
+        expect(visible.status).toBe(200);
+        expect(visible.body.tags.map(t => t.slug)).toEqual(['ui']);
+
+        const crossAuth = { deviceId: DEVICE_A, entityId: ENTITY_ID, botSecret: 'other-bot-secret', tag: 'x' };
+        const forbidden = await request(tagApp).post('/api/mission/card/A/tag').send(crossAuth);
+        expect(forbidden.status).toBe(401);
+    });
+
+    test('GET /cards?tag filters the board to tagged cards', async () => {
+        await insertTag(pool, DEVICE_A, 'A', 'ui', 'UI');
+        await insertTag(pool, DEVICE_A, 'B', 'backend', 'Backend');
+        await insertTag(pool, DEVICE_B, 'A', 'ui', 'Other UI');
+
+        const app = buildKanbanAppWithMockedPool(pool);
+        const res = await request(app).get(`/api/mission/cards?${deviceAuthQS}&tag=ui&automation=all`);
+        expect(res.status).toBe(200);
+        expect(res.body.cards.map(c => c.id)).toEqual(['A']);
+        expect(res.body.cards[0].tags.map(t => t.slug)).toEqual(['ui']);
+    });
+});

--- a/backend/tests/jest/mindmap-graph.test.js
+++ b/backend/tests/jest/mindmap-graph.test.js
@@ -156,6 +156,7 @@ describe('mindmap-graph-projection — pure helpers', () => {
         expect(dev.scope).toBe('device');
         expect(dev.includeNeighbors).toBe(false);
         expect(dev.includeNotes).toBe(true);
+        expect(dev.includeTags).toBe(false);
 
         const ent = projection.parseGraphOptions({}, { isDeviceAuth: false, callerEntityId: 2 });
         expect(ent.scope).toBe('entity');
@@ -218,6 +219,52 @@ describe('mindmap-graph-projection — pure helpers', () => {
         expect(result.stats.edgeCounts.parent).toBe(1);
         expect(result.stats.edgeCounts.blocks).toBe(1);
         expect(result.stats.edgeCounts.owner).toBeGreaterThanOrEqual(2);
+    });
+
+    test('projectGraph emits tag nodes and tag edges only when requested', () => {
+        const cards = [
+            { id: 'card_a', title: 'A', description: '', priority: 'P1', status: 'todo', parent_card_id: null, is_automation: false, assigned_bots: [], created_by: 0, reviewer_entity_id: null, chat_anchor_message_id: null, archived: false, updated_at: null },
+            { id: 'card_b', title: 'B', description: '', priority: 'P1', status: 'todo', parent_card_id: null, is_automation: false, assigned_bots: [], created_by: 0, reviewer_entity_id: null, chat_anchor_message_id: null, archived: false, updated_at: null },
+        ];
+        const base = {
+            cards,
+            initialCardIds: new Set(cards.map(c => c.id)),
+            depRows: [],
+            cardLinkRows: [],
+            tagRows: [
+                { card_id: 'card_a', slug: 'ui', label: 'UI' },
+                { card_id: 'card_b', slug: 'ui', label: 'UI' },
+                { card_id: 'card_b', slug: 'backend', label: 'Backend' },
+            ],
+            commentCounts: [],
+            noteCounts: [],
+            notes: [],
+            anchorRows: [],
+            entityMap: {},
+        };
+
+        const off = projection.projectGraph({
+            ...base,
+            options: projection.parseGraphOptions({ includeOwners: 'none' }, { isDeviceAuth: true, callerEntityId: null }),
+        });
+        expect(off.nodes.some(n => n.type === 'tag')).toBe(false);
+        expect(off.links.some(l => l.type === 'tag')).toBe(false);
+
+        const on = projection.projectGraph({
+            ...base,
+            options: projection.parseGraphOptions({ includeOwners: 'none', includeTags: 'true' }, { isDeviceAuth: true, callerEntityId: null }),
+        });
+        expect(on.nodes).toEqual(expect.arrayContaining([
+            expect.objectContaining({ id: 'tag:ui', type: 'tag', slug: 'ui' }),
+            expect.objectContaining({ id: 'tag:backend', type: 'tag', slug: 'backend' }),
+        ]));
+        expect(on.links).toEqual(expect.arrayContaining([
+            expect.objectContaining({ source: 'tag:ui', target: 'task:card_a', type: 'tag', evidence: 'kanban_card_tags' }),
+            expect.objectContaining({ source: 'tag:ui', target: 'task:card_b', type: 'tag', evidence: 'kanban_card_tags' }),
+            expect.objectContaining({ source: 'tag:backend', target: 'task:card_b', type: 'tag', evidence: 'kanban_card_tags' }),
+        ]));
+        expect(on.stats.sourceCounts.tag).toBe(2);
+        expect(on.stats.edgeCounts.tag).toBe(3);
     });
 
     test('projectGraph emits explicit card link edges', () => {
@@ -457,7 +504,7 @@ describe('GET /api/mindmap/graph — HTTP', () => {
         const res = await request(app).get('/api/mindmap/graph' + AUTH);
         expect(res.status).toBe(200);
         expect(res.body.success).toBe(true);
-        expect(res.body.meta.schemaVersion).toBe(1);
+        expect(res.body.meta.schemaVersion).toBe(2);
         expect(res.body.meta.scope).toBe('device');
         expect(res.body.meta.layoutStorageKey).toBe('mindmap:force-layout:v1:dev-1:device:owner');
 


### PR DESCRIPTION
## Summary
- add normalized, device-scoped Kanban tag tables (`kanban_tags`, `kanban_card_tags`) with reversible/idempotent migrations
- add card tag CRUD APIs and board `?tag=<slug>` filtering, with tags included on board/card reads
- add card detail UI tag chips/add/remove controls and funnel tag filter
- add optional `/api/mindmap/graph?includeTags=true` `tag:<slug>` nodes and `type: tag` links

## Tests
- `git diff --check` (passes; worktree prints existing CRLF warning for `scripts/update-i18n-1036.js`, not staged)
- `node --check backend/api_kanban_tags.js`
- `node --check backend/kanban.js`
- `node --check backend/mindmap.js`
- `node --check backend/mindmap-graph-projection.js`
- extracted `backend/public/portal/kanban.html` inline script → `node --check /tmp/kanban-inline.js`
- `cd backend && npx jest tests/jest/api-kanban-tags.test.js tests/jest/mindmap-graph.test.js --runInBand` → 2 suites / 30 tests passed (Jest reports existing config warning: unknown `runInBand`)
