### PR TITLE
feat(kanban): cron-spawn jitter + lane backpressure to prevent same-tick wedge

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -475,10 +475,10 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             `SELECT COUNT(*)::int AS n
                FROM kanban_cards
               WHERE device_id = $1
-                AND $2 = ANY(assigned_bots::integer[])
+                AND assigned_bots @> $2::jsonb
                 AND archived = false
                 AND status IN ('todo','in_progress','review')`,
-            [deviceId, Number(botId)]
+            [deviceId, JSON.stringify([Number(botId)])]
         );
         return r.rows[0]?.n || 0;
     }
@@ -2837,7 +2837,10 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                         // before notify, combined with the serial-await spawn loop,
                         // staggers same-tick siblings naturally without delaying the
                         // child card INSERT or the user-visible nextRunAt.
-                        const jitterMaxMs = Number(process.env.CRON_NOTIFY_JITTER_MS) || 30000;
+                        // Parse with Number.isFinite guard so explicit 0 stays 0 (`|| 30000`
+                        // would coerce 0 back to default — flagged by #1 cross-review).
+                        const jitterMaxRaw = Number(process.env.CRON_NOTIFY_JITTER_MS);
+                        const jitterMaxMs = Number.isFinite(jitterMaxRaw) && jitterMaxRaw >= 0 ? jitterMaxRaw : 30000;
                         const jitterMs = jitterMaxMs > 0 ? Math.floor(Math.random() * jitterMaxMs) : 0;
                         if (jitterMs > 0) {
                             console.log(`[Kanban] Automation child ${childCard.id}: jitter ${jitterMs}ms before notify`);
@@ -2850,7 +2853,10 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                             childTitle
                         });
                         const payload = { description: card.description, cardId: childCard.id };
-                        const backpressureThreshold = Number(process.env.CRON_NOTIFY_BACKPRESSURE_THRESHOLD) || 5;
+                        // Same Number.isFinite guard so threshold=0 (= always backpressure)
+                        // is a valid escape hatch and doesn't silently coerce to 5.
+                        const backpressureRaw = Number(process.env.CRON_NOTIFY_BACKPRESSURE_THRESHOLD);
+                        const backpressureThreshold = Number.isFinite(backpressureRaw) && backpressureRaw >= 0 ? backpressureRaw : 5;
                         for (const botId of bots) {
                             try {
                                 const hasPending = await botHasPendingNotify(card.device_id, botId);

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -466,6 +466,23 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
         return r.rows.length > 0;
     }
 
+    // Lane backpressure — count active workload (todo/in_progress/review) for a
+    // bot to decide whether an incoming cron-spawned notify should be downgraded
+    // from immediate push to the smart queue. See spawnAutomationChild dispatch
+    // block for the threshold and the Layer-1 jitter that pairs with this check.
+    async function botActiveWorkload(deviceId, botId) {
+        const r = await pool.query(
+            `SELECT COUNT(*)::int AS n
+               FROM kanban_cards
+              WHERE device_id = $1
+                AND $2 = ANY(assigned_bots::integer[])
+                AND archived = false
+                AND status IN ('todo','in_progress','review')`,
+            [deviceId, Number(botId)]
+        );
+        return r.rows[0]?.n || 0;
+    }
+
     async function enqueuePendingNotify(deviceId, botId, cardId, message, payload) {
         await pool.query(
             `INSERT INTO kanban_pending_notify (device_id, bot_entity_id, card_id, msg, payload)
@@ -2814,21 +2831,41 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                     // wakeup chain. Spec: docs/mission-v2-kanban-spec.md §十一
                     // "通知 gates（smart per-bot queue）".
                     if (bots.length > 0) {
+                        // Layer 1 — Cron-spawn jitter (0–CRON_NOTIFY_JITTER_MS, default 30s).
+                        // Same-minute mom crons used to push 5+ notifies into one bot lane
+                        // in ≤7s, wedging the chat queue (card_a19dc866). Random delay
+                        // before notify, combined with the serial-await spawn loop,
+                        // staggers same-tick siblings naturally without delaying the
+                        // child card INSERT or the user-visible nextRunAt.
+                        const jitterMaxMs = Number(process.env.CRON_NOTIFY_JITTER_MS) || 30000;
+                        const jitterMs = jitterMaxMs > 0 ? Math.floor(Math.random() * jitterMaxMs) : 0;
+                        if (jitterMs > 0) {
+                            console.log(`[Kanban] Automation child ${childCard.id}: jitter ${jitterMs}ms before notify`);
+                            await new Promise(r => setTimeout(r, jitterMs));
+                        }
+
                         const lang = await getDeviceLanguage(card.device_id);
                         const msg = tKanban(lang, 'automationTrigger', {
                             title: card.title,
                             childTitle
                         });
                         const payload = { description: card.description, cardId: childCard.id };
+                        const backpressureThreshold = Number(process.env.CRON_NOTIFY_BACKPRESSURE_THRESHOLD) || 5;
                         for (const botId of bots) {
                             try {
                                 const hasPending = await botHasPendingNotify(card.device_id, botId);
-                                if (hasPending) {
+                                // Layer 2 — Lane backpressure (card_a19dc866). When the bot's
+                                // active workload (todo/in_progress/review) crosses threshold,
+                                // downgrade immediate push to the smart queue so the bot drains
+                                // one task at a time instead of receiving N concurrent chats.
+                                const workload = await botActiveWorkload(card.device_id, botId);
+                                const backpressure = workload >= backpressureThreshold;
+                                if (hasPending || backpressure) {
                                     await enqueuePendingNotify(card.device_id, botId, childCard.id, msg, payload);
-                                    console.log(`[Kanban] Smart-queue: enqueued notify for bot #${botId} card ${childCard.id} (bot has pending notify)`);
+                                    console.log(`[Kanban] Smart-queue: enqueued notify for bot #${botId} card ${childCard.id} (hasPending=${hasPending}, workload=${workload}, backpressure=${backpressure})`);
                                 } else {
                                     await notifyEntities(card.device_id, [botId], msg, payload);
-                                    console.log(`[Kanban] Smart-queue: pushed immediate notify for bot #${botId} card ${childCard.id} (queue empty)`);
+                                    console.log(`[Kanban] Smart-queue: pushed immediate notify for bot #${botId} card ${childCard.id} (workload=${workload})`);
                                 }
                             } catch (notifyErr) {
                                 console.error(`[Kanban] Smart-queue notify failed for bot #${botId}:`, notifyErr.message);

--- a/backend/tests/jest/kanban-cron-jitter-backpressure.test.js
+++ b/backend/tests/jest/kanban-cron-jitter-backpressure.test.js
@@ -37,7 +37,15 @@ describe('cron-spawn jitter — Layer 1', () => {
     });
 
     test('jitter ceiling is configurable via CRON_NOTIFY_JITTER_MS env, default 30s', () => {
-        expect(kanbanSrc).toMatch(/Number\(process\.env\.CRON_NOTIFY_JITTER_MS\)\s*\|\|\s*30000/);
+        expect(kanbanSrc).toMatch(/Number\(process\.env\.CRON_NOTIFY_JITTER_MS\)/);
+        expect(kanbanSrc).toMatch(/Number\.isFinite\(jitterMaxRaw\)[\s\S]{0,80}\?\s*jitterMaxRaw\s*:\s*30000/);
+    });
+
+    test('explicit CRON_NOTIFY_JITTER_MS=0 is preserved (not coerced to default)', () => {
+        // Critical: `Number("0") || 30000` evaluates to 30000 — that bug must
+        // not return. Parse must use Number.isFinite, not ||. Flagged by
+        // #1 cross-review on PR #2791.
+        expect(kanbanSrc).not.toMatch(/Number\(process\.env\.CRON_NOTIFY_JITTER_MS\)\s*\|\|/);
     });
 
     test('jitter is random within [0, max), not fixed', () => {
@@ -72,8 +80,26 @@ describe('lane backpressure — Layer 2', () => {
         expect(helper[0]).toMatch(/status IN \('todo','in_progress','review'\)/);
     });
 
+    test('botActiveWorkload uses JSONB membership (not invalid integer[] cast)', () => {
+        // assigned_bots is JSONB; integer[] cast fails at runtime. Flagged by
+        // #1 cross-review on PR #2791. Must use @> with JSON.stringify param,
+        // matching the existing pattern at L917.
+        const helper = kanbanSrc.match(/async function botActiveWorkload[\s\S]*?\n    \}/);
+        expect(helper).not.toBeNull();
+        expect(helper[0]).toMatch(/assigned_bots @> \$2::jsonb/);
+        expect(helper[0]).toMatch(/JSON\.stringify\(\[Number\(botId\)\]\)/);
+        expect(helper[0]).not.toMatch(/assigned_bots::integer\[\]/);
+    });
+
     test('backpressure threshold is configurable via env, default 5', () => {
-        expect(kanbanSrc).toMatch(/Number\(process\.env\.CRON_NOTIFY_BACKPRESSURE_THRESHOLD\)\s*\|\|\s*5/);
+        expect(kanbanSrc).toMatch(/Number\(process\.env\.CRON_NOTIFY_BACKPRESSURE_THRESHOLD\)/);
+        expect(kanbanSrc).toMatch(/Number\.isFinite\(backpressureRaw\)[\s\S]{0,80}\?\s*backpressureRaw\s*:\s*5/);
+    });
+
+    test('explicit CRON_NOTIFY_BACKPRESSURE_THRESHOLD=0 is preserved (escape hatch)', () => {
+        // 0 means "always treat lane as backpressured" — used in tests/staging
+        // to force the smart-queue path. Must not coerce back to 5.
+        expect(kanbanSrc).not.toMatch(/Number\(process\.env\.CRON_NOTIFY_BACKPRESSURE_THRESHOLD\)\s*\|\|/);
     });
 
     test('notify decision uses (hasPending || backpressure) to choose enqueue path', () => {

--- a/backend/tests/jest/kanban-cron-jitter-backpressure.test.js
+++ b/backend/tests/jest/kanban-cron-jitter-backpressure.test.js
@@ -1,0 +1,120 @@
+'use strict';
+
+/**
+ * Cron-spawn jitter + lane backpressure (card_a19dc866) — code-shape regression tests.
+ *
+ * 2026-05-14 04:02–04:08 UTC: 5 same-minute mom-card crons (all on the
+ * "every 2h, minute 0" schedule) pushed 5 notifyEntities calls into the #1
+ * bot lane within ~7s. messageQueue
+ * grew from 7 → 11, wait time 295s → 797s. Hank manually staggered the moms
+ * to 05/10/15/20/25 minutes. This PR adds infra-level prevention so the wedge
+ * cannot recur from a future co-scheduled batch.
+ *
+ * Style follows kanban-smart-notify-queue.test.js — static source-grep rather
+ * than live DB integration. Behavioral coverage rides on the existing kanban
+ * smoke + smart-queue tests; this file pins the new invariants only.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const kanbanSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'kanban.js'),
+    'utf8'
+);
+
+describe('cron-spawn jitter — Layer 1', () => {
+    test('jitter delay applied before notify push, after child INSERT', () => {
+        const childIdxStart = kanbanSrc.indexOf('Automation child created:');
+        const jitterIdx = kanbanSrc.indexOf('jitter ${jitterMs}ms before notify');
+        const notifyIdx = kanbanSrc.indexOf('Smart-queue: pushed immediate notify');
+        expect(childIdxStart).toBeGreaterThan(-1);
+        expect(jitterIdx).toBeGreaterThan(-1);
+        expect(notifyIdx).toBeGreaterThan(-1);
+        // Order: child INSERT log → jitter log → notify push log
+        expect(jitterIdx).toBeGreaterThan(childIdxStart);
+        expect(notifyIdx).toBeGreaterThan(jitterIdx);
+    });
+
+    test('jitter ceiling is configurable via CRON_NOTIFY_JITTER_MS env, default 30s', () => {
+        expect(kanbanSrc).toMatch(/Number\(process\.env\.CRON_NOTIFY_JITTER_MS\)\s*\|\|\s*30000/);
+    });
+
+    test('jitter is random within [0, max), not fixed', () => {
+        expect(kanbanSrc).toMatch(/Math\.floor\(Math\.random\(\)\s*\*\s*jitterMaxMs\)/);
+    });
+
+    test('jitter=0 short-circuits the setTimeout (so tests can disable)', () => {
+        // Setting CRON_NOTIFY_JITTER_MS=0 must skip the await sleep — otherwise
+        // unit tests with fake timers cannot observe the rest of the spawn loop.
+        expect(kanbanSrc).toMatch(/jitterMaxMs > 0 \? Math\.floor\(Math\.random\(\)/);
+        expect(kanbanSrc).toMatch(/if \(jitterMs > 0\) \{[\s\S]{0,200}setTimeout\(r, jitterMs\)/);
+    });
+
+    test('jitter is applied inside the `if (bots.length > 0)` block, not gating the child INSERT', () => {
+        // Critical invariant: the child card must be persisted before we sleep.
+        // Otherwise a crash during jitter loses the card entirely.
+        const insertMatch = kanbanSrc.match(/const childResult = await pool\.query\(\s*`INSERT INTO kanban_cards/);
+        const jitterMatch = kanbanSrc.match(/jitter \$\{jitterMs\}ms before notify/);
+        expect(insertMatch).not.toBeNull();
+        expect(jitterMatch).not.toBeNull();
+        expect(jitterMatch.index).toBeGreaterThan(insertMatch.index);
+    });
+});
+
+describe('lane backpressure — Layer 2', () => {
+    test('botActiveWorkload helper is defined and reads from kanban_cards', () => {
+        expect(kanbanSrc).toMatch(/async function botActiveWorkload\(deviceId, botId\)/);
+        const helper = kanbanSrc.match(/async function botActiveWorkload[\s\S]*?\n    \}/);
+        expect(helper).not.toBeNull();
+        expect(helper[0]).toMatch(/FROM kanban_cards/);
+        expect(helper[0]).toMatch(/archived = false/);
+        expect(helper[0]).toMatch(/status IN \('todo','in_progress','review'\)/);
+    });
+
+    test('backpressure threshold is configurable via env, default 5', () => {
+        expect(kanbanSrc).toMatch(/Number\(process\.env\.CRON_NOTIFY_BACKPRESSURE_THRESHOLD\)\s*\|\|\s*5/);
+    });
+
+    test('notify decision uses (hasPending || backpressure) to choose enqueue path', () => {
+        expect(kanbanSrc).toMatch(/const workload = await botActiveWorkload\(card\.device_id, botId\)/);
+        expect(kanbanSrc).toMatch(/const backpressure = workload >= backpressureThreshold/);
+        expect(kanbanSrc).toMatch(/if \(hasPending \|\| backpressure\)/);
+    });
+
+    test('backpressure log line surfaces both signals for debug', () => {
+        // Operators need to distinguish "queue had pending" from "lane backpressured"
+        // when triaging future wedges; log line must expose both.
+        expect(kanbanSrc).toMatch(
+            /enqueued notify for bot #\$\{botId\}[\s\S]{0,200}hasPending=\$\{hasPending\}, workload=\$\{workload\}, backpressure=\$\{backpressure\}/
+        );
+    });
+
+    test('immediate push path also logs workload for telemetry', () => {
+        expect(kanbanSrc).toMatch(/pushed immediate notify for bot #\$\{botId\}[\s\S]{0,80}workload=\$\{workload\}/);
+    });
+});
+
+describe('safety — what must NOT change', () => {
+    test('child card INSERT still uses status=todo and inherits screenshot review', () => {
+        // Sanity: confirm the new jitter/backpressure code didn't disturb the
+        // existing spawn behavior (status, inheritance).
+        expect(kanbanSrc).toMatch(/VALUES \(\$1, \$2, \$3, \$4, \$5, 'todo', \$6::jsonb/);
+        expect(kanbanSrc).toMatch(/requires_screenshot_review\)\n\s*VALUES/);
+    });
+
+    test('user-visible schedule_next_run_at is NOT delayed by jitter', () => {
+        // task description explicit: "不改 nextRunAt". Confirm the UPDATE that
+        // writes schedule_next_run_at sits before the jitter sleep, not after.
+        const nextRunMatch = kanbanSrc.match(/schedule_next_run_at = \$1,\s+active_child_id = \$2/);
+        const jitterMatch = kanbanSrc.match(/jitter \$\{jitterMs\}ms before notify/);
+        expect(nextRunMatch).not.toBeNull();
+        expect(jitterMatch).not.toBeNull();
+        expect(jitterMatch.index).toBeGreaterThan(nextRunMatch.index);
+    });
+
+    test('botHasPendingNotify is still consulted (smart-queue Phase 2 preserved)', () => {
+        // Layer 2 must compose with the existing Phase 2 logic, not replace it.
+        expect(kanbanSrc).toMatch(/const hasPending = await botHasPendingNotify\(card\.device_id, botId\)/);
+    });
+});


### PR DESCRIPTION
## Summary

card_a19dc866. 2026-05-14 04:02-04:08 UTC: 5 mom-cards on the same `every 2h, minute 0` schedule fired together; 5 `notifyEntities` calls landed in bot #1's lane within ~7s. `messageQueue` 7 → 11, wait time 295s → 797s. Hank manually staggered the moms to minutes 05/10/15/20/25 — this PR adds infra-level prevention so the wedge cannot recur from a future co-scheduled batch.

## Layers

**Layer 1 — Cron-spawn jitter** (between child INSERT and notify push)
- `CRON_NOTIFY_JITTER_MS` env, default `30000` (30s)
- Random uniform `[0, jitterMaxMs)` per spawned child
- Applied AFTER child INSERT + AFTER `schedule_next_run_at` UPDATE — so child persistence is durable and user-visible nextRunAt is unaffected
- `jitterMaxMs=0` short-circuits `setTimeout` so unit tests can disable

**Layer 2 — Lane backpressure**
- New helper `botActiveWorkload(deviceId, botId)` — counts `todo|in_progress|review` cards assigned to the bot (archived=false)
- `CRON_NOTIFY_BACKPRESSURE_THRESHOLD` env, default `5`
- Decision: `if (hasPending || backpressure) enqueuePendingNotify else notifyEntities`
- Composes with Phase 2 smart-queue (`botHasPendingNotify`) — does not replace it
- Both code paths log `workload` for telemetry; enqueue path also logs `hasPending` + `backpressure` to disambiguate triage

## Files

- `backend/kanban.js` — +40 / -3
  - `botActiveWorkload` helper directly after `botHasPendingNotify` (L468)
  - jitter + backpressure block inside `if (bots.length > 0)` in `spawnAutomationChild` notify section (L2816)
- `backend/tests/jest/kanban-cron-jitter-backpressure.test.js` — new, 120 lines
  - 13 static source-grep invariants (style matches `kanban-smart-notify-queue.test.js`)

## Safety / what does NOT change

- Child INSERT: still `status='todo'`, still inherits `requires_screenshot_review`
- `schedule_next_run_at` UPDATE: still occurs BEFORE jitter — user sees correct next run time immediately
- `botHasPendingNotify` Phase 2 check: still consulted before the new backpressure branch
- No new external deps, no migration

## Test plan

- [x] `npx jest backend/tests/jest/kanban-cron-jitter-backpressure.test.js` — 13/13 PASS
- [x] `npx jest backend/tests/jest/kanban-smart-notify-queue.test.js backend/tests/jest/kanban-stale-skip-recurring.test.js backend/tests/jest/kanban-dispatch-mode-ux.test.js` — 23/23 PASS (no sibling regression)
- [ ] @#1 cross-review per supervisor pairing
- [ ] Post-merge: monitor next 4h cron tick; expect to see `Smart-queue: pushed immediate notify ... workload=N` lines and (if any lane crosses 5) `enqueued notify ... backpressure=true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)