### PR TITLE
feat(info): embed 75s promo video on Quick Start tab

### DIFF
--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -71,23 +71,6 @@
                 <p data-i18n="qs_hero_desc">EClawbot 是你的 AI 代理平台。選擇一個場景，立即開始。</p>
             </div>
 
-            <!-- Promo Video: 75-second real-env product walkthrough -->
-            <div class="qs-promo-video-section">
-                <h2 class="qs-promo-video-title" data-i18n="promo_video_title">75 秒看懂 EClawbot</h2>
-                <p class="qs-promo-video-subtitle" data-i18n="promo_video_lede">看看 EClawbot 如何把多個 AI agent 串成可追蹤的 A2A 對話與 kanban 工作流。</p>
-                <div class="qs-promo-video-wrap">
-                    <iframe
-                        src="https://www.youtube.com/embed/3X7CWVCtYbk"
-                        title="EClawbot 75-second demo"
-                        frameborder="0"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                        allowfullscreen
-                        loading="lazy"></iframe>
-                </div>
-            </div>
-
-            <hr class="qs-divider">
-
             <!-- 3 Pain-Point Hero Cards (Bot Marketplace) -->
             <div class="qs-hooks-section">
                 <h2 class="qs-hooks-title" data-i18n="info_hooks_title">💎 三個讓你立刻獲益的方式</h2>
@@ -161,6 +144,22 @@
             <div class="qs-cta">
                 <p data-i18n="qs_cta_text">準備好了嗎？免費註冊，3 分鐘內開始你的第一場 AI 對話。</p>
                 <a class="qs-cta-btn" href="index.html" data-i18n="qs_cta_btn">🚀 立即開始</a>
+            </div>
+
+            <!-- Promo Video: 75-second evergreen product walkthrough (below-fold, opt-in).
+                 Policy: ONE evergreen embed only, non-autoplay, no daily content rotated here. -->
+            <div class="qs-promo-video-section">
+                <h2 class="qs-promo-video-title" data-i18n="promo_video_title">75 秒看懂 EClawbot</h2>
+                <p class="qs-promo-video-subtitle" data-i18n="promo_video_lede">看看 EClawbot 如何把多個 AI agent 串成可追蹤的 A2A 對話與 kanban 工作流。</p>
+                <div class="qs-promo-video-wrap">
+                    <iframe
+                        src="https://www.youtube.com/embed/3X7CWVCtYbk"
+                        title="EClawbot 75-second evergreen demo"
+                        frameborder="0"
+                        allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                        allowfullscreen
+                        loading="lazy"></iframe>
+                </div>
             </div>
 
         </div><!-- /panel-quickstart -->

--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -71,6 +71,23 @@
                 <p data-i18n="qs_hero_desc">EClawbot 是你的 AI 代理平台。選擇一個場景，立即開始。</p>
             </div>
 
+            <!-- Promo Video: 75-second real-env product walkthrough -->
+            <div class="qs-promo-video-section">
+                <h2 class="qs-promo-video-title" data-i18n="promo_video_title">75 秒看懂 EClawbot</h2>
+                <p class="qs-promo-video-subtitle" data-i18n="promo_video_lede">看看 EClawbot 如何把多個 AI agent 串成可追蹤的 A2A 對話與 kanban 工作流。</p>
+                <div class="qs-promo-video-wrap">
+                    <iframe
+                        src="https://www.youtube.com/embed/3X7CWVCtYbk"
+                        title="EClawbot 75-second demo"
+                        frameborder="0"
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                        allowfullscreen
+                        loading="lazy"></iframe>
+                </div>
+            </div>
+
+            <hr class="qs-divider">
+
             <!-- 3 Pain-Point Hero Cards (Bot Marketplace) -->
             <div class="qs-hooks-section">
                 <h2 class="qs-hooks-title" data-i18n="info_hooks_title">💎 三個讓你立刻獲益的方式</h2>

--- a/backend/public/portal/shared/info.css
+++ b/backend/public/portal/shared/info.css
@@ -868,6 +868,40 @@
     max-width: 720px;
     margin: 0 auto 40px;
 }
+.qs-promo-video-section {
+    max-width: 720px;
+    margin: 0 auto 40px;
+    padding: 0 20px;
+    text-align: center;
+}
+.qs-promo-video-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-bottom: 8px;
+}
+.qs-promo-video-subtitle {
+    color: var(--text-secondary);
+    font-size: 0.95rem;
+    margin: 0 auto 20px;
+    max-width: 600px;
+    line-height: 1.5;
+}
+.qs-promo-video-wrap {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    background: #000;
+    border-radius: var(--radius);
+    overflow: hidden;
+    border: 1px solid var(--card-border);
+}
+.qs-promo-video-wrap iframe {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
 .qs-steps-section {
     max-width: 720px;
     margin: 0 auto;
@@ -1103,6 +1137,8 @@
     .cmp-cta-buttons { flex-direction: column; }
     .cmp-cta-buttons .btn { width: 100%; justify-content: center; }
     .qs-hero h1 { font-size: 1.6rem; }
+    .qs-promo-video-title { font-size: 1.25rem; }
+    .qs-promo-video-subtitle { font-size: 0.9rem; }
     .qs-hooks-grid { grid-template-columns: 1fr; }
     .qs-hooks-title { font-size: 1.2rem; }
     .qs-intent-grid { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary
- Embed the 75-second EClawbot promo video at the top of \`/portal/info.html\` Quick Start tab, between the welcome hero and the three pain-point hooks.
- Reason: \`/promo.html\` already exists with the real-env walkthrough (YT \`3X7CWVCtYbk\`), but no portal page links to it. Post-login users hitting info.html for orientation currently have zero path to discover the demo.

## What changed
- \`backend/public/portal/info.html\` (+17 lines): new \`.qs-promo-video-section\` with title, subtitle, and lazy-loaded 16:9 YouTube iframe, plus a \`<hr class="qs-divider">\` to separate from the hooks grid below.
- \`backend/public/portal/shared/info.css\` (+36 lines): \`.qs-promo-video-*\` rules — centered 720px max-width, themed border/radius, \`aspect-ratio: 16/9\` iframe wrap. Mobile breakpoint shrinks title/subtitle.

## i18n
- Reuses existing \`promo_video_title\` (\"75 秒看懂 EClawbot\") and \`promo_video_lede\` keys — already filled in across en/zh/zh-CN/ja and most other locales.
- Zero new dict entries — locales without the keys fall back to inline zh-TW per \`i18n.apply()\` default.

## Plan
This is PR 1 of 4 for promo-video discoverability:
- ✅ PR-A: Quick Start tab embed (this PR)
- ⏳ PR-B: portal footer \"觀看簡介影片\" link
- ⏳ PR-C: landing.html CTA below hero
- ⏳ PR-D: iOS settings \"教學與簡介\" list item

## Test plan
- [ ] Visit \`/portal/info.html\` Quick Start tab after Railway deploy; video embed renders 16:9 with correct title + subtitle in zh-TW.
- [ ] Toggle locale to en — title becomes \"See EClawbot in 75 seconds\", subtitle becomes the en lede.
- [ ] Mobile width (≤768px): title shrinks to 1.25rem, video stays 16:9 within container.
- [ ] No layout shift between hero/promo/hooks; divider separates promo from hooks cleanly.

Card: \`card_7c206efe769fbcb68b8aa509\`