### PR TITLE
feat(info): embed promo video at top of Quick Start tab

### DIFF
--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -65,6 +65,22 @@
         <!-- ══════ Tab 1: Quick Start (P2-2 Onboarding) ══════ -->
         <div class="info-panel active" id="panel-quickstart">
 
+            <!-- Promo video embed (75-second intro) -->
+            <section class="qs-promo-section" aria-labelledby="qs-promo-heading">
+                <h2 id="qs-promo-heading" class="qs-promo-title" data-i18n="promo_video_title">See EClawbot in 75 seconds</h2>
+                <p class="qs-promo-lede" data-i18n="promo_video_lede">Watch how EClawbot turns multiple AI agents into a trackable A2A chat and kanban workflow.</p>
+                <div class="qs-promo-frame">
+                    <iframe
+                        src="https://www.youtube.com/embed/3X7CWVCtYbk"
+                        title="EClawbot — AI agent kanban workflow demo"
+                        loading="lazy"
+                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+                        referrerpolicy="strict-origin-when-cross-origin"
+                        allowfullscreen></iframe>
+                </div>
+                <a class="qs-promo-link" href="/promo.html" target="_blank" rel="noopener" data-i18n="qs_promo_full_page_link">📺 開啟完整影片頁</a>
+            </section>
+
             <!-- Hero: 你想做什麼？ -->
             <div class="qs-hero">
                 <h1 data-i18n="qs_hero_title">你想做什麼？</h1>

--- a/backend/public/portal/shared/info.css
+++ b/backend/public/portal/shared/info.css
@@ -745,6 +745,56 @@
 .cmp-cta-buttons { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
 
 /* ══════════════ Onboarding (P2-2) ══════════════ */
+.qs-promo-section {
+    max-width: 880px;
+    margin: 24px auto 8px;
+    padding: 20px 16px 8px;
+    text-align: center;
+}
+.qs-promo-title {
+    font-size: 1.55rem;
+    font-weight: 800;
+    margin: 0 0 8px;
+    background: linear-gradient(135deg, var(--primary), #4FC3F7);
+    -webkit-background-clip: text;
+    background-clip: text;
+    -webkit-text-fill-color: transparent;
+}
+.qs-promo-lede {
+    font-size: 0.98rem;
+    color: var(--text-secondary);
+    max-width: 620px;
+    margin: 0 auto 16px;
+    line-height: 1.55;
+}
+.qs-promo-frame {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 16 / 9;
+    overflow: hidden;
+    border-radius: var(--radius, 14px);
+    background: #05050d;
+    border: 1px solid var(--card-border, rgba(255,255,255,.12));
+    box-shadow: 0 18px 50px rgba(0,0,0,.35);
+}
+.qs-promo-frame iframe {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+}
+.qs-promo-link {
+    display: inline-block;
+    margin-top: 12px;
+    font-size: 0.9rem;
+    color: var(--text-secondary);
+    text-decoration: none;
+}
+.qs-promo-link:hover {
+    color: var(--primary);
+    text-decoration: underline;
+}
 .qs-hero {
     text-align: center;
     padding: 48px 20px 36px;

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -41244,6 +41244,7 @@ const TRANSLATIONS = {
 
 
         "qs_hero_title": "What do you want to do?",
+        "qs_promo_full_page_link": "📺 Open full video page",
 
 
 
@@ -688732,6 +688733,7 @@ const TRANSLATIONS = {
 
 
         "qs_hero_title": "你想做什麼？",
+        "qs_promo_full_page_link": "📺 開啟完整影片頁",
 
 
 
@@ -1709266,6 +1709268,7 @@ const TRANSLATIONS = {
 
 
         "qs_hero_title": "你想做什麼？",
+        "qs_promo_full_page_link": "📺 開啟完整影片頁",
 
 
 
@@ -1885530,6 +1885533,7 @@ const TRANSLATIONS = {
 
 
         "qs_hero_title": "何をしたいですか？",
+        "qs_promo_full_page_link": "📺 フル動画ページを開く",
 
 
 
@@ -2448436,6 +2448440,7 @@ const TRANSLATIONS = {
 
 
         "qs_hero_title": "무엇을 하고 싶으신가요?",
+        "qs_promo_full_page_link": "📺 전체 동영상 페이지 열기",
 
 
 
@@ -2980844,6 +2980849,7 @@ const TRANSLATIONS = {
 
 
         "qs_hero_title": "คุณต้องการทำอะไร?",
+        "qs_promo_full_page_link": "📺 เปิดหน้าวิดีโอเต็ม",
 
 
 
@@ -3509599,6 +3509605,7 @@ const TRANSLATIONS = {
 
 
         "qs_hero_title": "Bạn muốn làm gì?",
+        "qs_promo_full_page_link": "📺 Mở trang video đầy đủ",
 
 
 
@@ -4035893,6 +4035900,7 @@ const TRANSLATIONS = {
 
 
         "qs_hero_title": "Apa yang ingin Anda lakukan?",
+        "qs_promo_full_page_link": "📺 Buka halaman video lengkap",
 
 
 
@@ -4561803,6 +4561811,7 @@ const TRANSLATIONS = {
 
 
         "qs_hero_title": "Que voulez-vous faire ?",
+        "qs_promo_full_page_link": "📺 Ouvrir la page vidéo complète",
 
 
 
@@ -5086140,6 +5086149,7 @@ const TRANSLATIONS = {
 
 
         "qs_hero_title": "¿Qué quieres hacer?...",
+        "qs_promo_full_page_link": "📺 Abrir la página de vídeo completa",
 
 
 
@@ -5603554,6 +5603564,7 @@ const TRANSLATIONS = {
 
 
         "qs_hero_title": "Was möchten Sie tun?",
+        "qs_promo_full_page_link": "📺 Vollständige Videoseite öffnen",
 
 
 
@@ -6138954,6 +6138965,7 @@ const TRANSLATIONS = {
 
 
         "qs_hero_title": "Apa awak mahu buat?",
+        "qs_promo_full_page_link": "📺 Buka halaman video penuh",
 
 
 
@@ -6815728,6 +6815740,7 @@ const TRANSLATIONS = {
 
 
         "qs_hero_title": "आप क्या करना चाहते हैं?",
+        "qs_promo_full_page_link": "📺 पूर्ण वीडियो पृष्ठ खोलें",
 
 
 
@@ -7505126,6 +7505139,7 @@ const TRANSLATIONS = {
 
 
         "qs_hero_title": "ماذا تريد أن تفعل؟",
+        "qs_promo_full_page_link": "📺 افتح صفحة الفيديو الكاملة",
 
 
 


### PR DESCRIPTION
## Summary
- Surfaces `/promo.html` (orphan until now) by embedding the 75-second YouTube video at the top of the Quick Start tab in `info.html` — first thing visitors see in the onboarding panel.
- Reuses existing `promo_video_title` / `promo_video_lede` i18n keys (already in 12+ locales); adds new `qs_promo_full_page_link` key across all 14 supported locales (en/zh/ja/ko/zh-TW/th/vi/id/fr/es/de/ms/hi/ar).
- New `.qs-promo-section` CSS scoped to the Quick Start panel — 16:9 aspect-ratio iframe, gradient title matching `.qs-hero`, mobile-friendly.

## Context
Part of card_7c206efe `Promo video discoverability — info page + footer + landing CTA + iOS`. This is **PR-A of 4** per Hank's spec:
- **PR-A (this):** info.html Quick Start embed
- PR-B: shared/footer.js 觀看簡介影片 link
- PR-C: landing.html Watch full demo CTA
- PR-D: ios-app settings.tsx 教學與簡介 list item

ship-as-you-go per `feedback_ship_increments_no_local_accumulation`.

## Verification
Headless Chrome screenshots at 1280×900 (desktop) and 412×892 (mobile) — both show:
- Title `75 秒看懂 EClawbot` (zh i18n applied correctly)
- 16:9 YouTube iframe with thumbnail
- `📺 開啟完整影片頁` link below
- `.qs-hero` "你想做什麼？" intact below promo block

Inline values render in zh by default; locales swap via existing `i18n.apply()` at DOMContentLoaded.

## Test plan
- [x] Local render at desktop + mobile viewports (see screenshots embedded in card_7c206efe)
- [ ] Visual check after deploy on https://eclawbot.com/portal/info.html
- [ ] i18n smoke: switch language to en/ja/ko and confirm `qs_promo_full_page_link` localizes

🤖 Generated with [Claude Code](https://claude.com/claude-code)