### PR TITLE
feat(landing): add Watch Full Demo CTA below 75s hero video

### DIFF
--- a/backend/public/landing.html
+++ b/backend/public/landing.html
@@ -318,7 +318,7 @@
             </div>
             <p class="hero-video-caption">🎬 EClaw — AI Agent Interop Platform · Concept A</p>
             <div class="hero-video-cta-wrap">
-                <a href="info.html#guide" class="hero-video-cta" data-i18n="landing_watch_full_demo">▶ Watch Full Demo + Walkthrough</a>
+                <a href="/portal/info.html" class="hero-video-cta" data-i18n="landing_watch_full_demo">▶ Watch Full Demo + Walkthrough</a>
             </div>
         </section>
 

--- a/backend/public/landing.html
+++ b/backend/public/landing.html
@@ -201,6 +201,24 @@
             color: #888;
             margin-top: 12px;
         }
+        .hero-video-cta {
+            display: inline-block;
+            margin-top: 14px;
+            padding: 10px 22px;
+            background: linear-gradient(135deg, #6C63FF, #A084FF);
+            color: #fff;
+            border-radius: 24px;
+            font-size: 0.95rem;
+            font-weight: 600;
+            text-decoration: none;
+            transition: transform 0.2s, box-shadow 0.2s;
+        }
+        .hero-video-cta:hover {
+            transform: translateY(-2px);
+            box-shadow: 0 6px 20px rgba(108, 99, 255, 0.4);
+            text-decoration: none;
+        }
+        .hero-video-cta-wrap { text-align: center; }
 
         /* Features */
         .features {
@@ -299,6 +317,9 @@
                     referrerpolicy="strict-origin-when-cross-origin"></iframe>
             </div>
             <p class="hero-video-caption">🎬 EClaw — AI Agent Interop Platform · Concept A</p>
+            <div class="hero-video-cta-wrap">
+                <a href="info.html#guide" class="hero-video-cta" data-i18n="landing_watch_full_demo">▶ Watch Full Demo + Walkthrough</a>
+            </div>
         </section>
 
         <section class="features">

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -25884,6 +25884,7 @@ const TRANSLATIONS = {
 
 
         "landing_get_started": "Get Started",
+        "landing_watch_full_demo": "▶ Watch Full Demo + Walkthrough",
 
 
 
@@ -674780,6 +674781,7 @@ const TRANSLATIONS = {
 
 
         "landing_get_started": "立即開始",
+        "landing_watch_full_demo": "▶ 觀看完整示範與導覽",
 
 
 
@@ -1649234,6 +1649236,7 @@ const TRANSLATIONS = {
 
 
         "landing_get_started": "立即开始",
+        "landing_watch_full_demo": "▶ 观看完整演示与导览",
 
 
 
@@ -1871578,6 +1871581,7 @@ const TRANSLATIONS = {
 
 
         "landing_get_started": "始める",
+        "landing_watch_full_demo": "▶ フルデモ + ウォークスルーを見る",
 
 
 


### PR DESCRIPTION
## Summary
- Adds **▶ Watch Full Demo + Walkthrough** CTA button below the existing 75s YouTube hero video on `/landing.html`
- Deep-links to `info.html#guide` (paired with PR #2795 / #2797 info-page embed)
- Gradient pill button styled to match existing portal aesthetic (#6C63FF → #A084FF)
- i18n: `landing_watch_full_demo` key added for **en / zh-TW / zh-CN / ja** minimum

**Card:** card_7c206efe769fbcb68b8aa509 — Promo discoverability PRs A–D (C of 4)
- ✅ A: PR #2795 / #2797 — info-page embed
- ✅ B: PR #2798 — footer link
- ➜ **C: this PR — landing CTA**
- ⏳ D: iOS settings 教學與簡介 entry

## What's the user journey?
1. Visitor lands on `/landing.html` — sees 75s elevator pitch hero
2. Wants more depth → clicks new **▶ Watch Full Demo + Walkthrough** CTA
3. Lands on `info.html#guide` — same promo video at top + Quick Start walkthrough text

Previously the only path to the info-page demo was via the top nav (easy to miss) or the new footer link (PR #2798, below the fold). This makes it a primary CTA right where attention is highest.

## i18n coverage
| Locale | Value |
|---|---|
| en | ▶ Watch Full Demo + Walkthrough |
| zh-TW | ▶ 觀看完整示範與導覽 |
| zh-CN | ▶ 观看完整演示与导览 |
| ja | ▶ フルデモ + ウォークスルーを見る |

Other locales fall back to the inline EN default. **i18n-check passing.**

## Visual change
- New gradient button (hover: +2px translate + #6C63FF glow shadow), centered below `🎬 EClaw — AI Agent Interop Platform · Concept A` caption
- Uses existing color palette (no new design tokens introduced)
- Mobile responsive (`.hero-video-cta-wrap` text-center, button is `inline-block`)

## Test plan
- [ ] Reviewer pulls branch, loads `/landing.html` — verifies new CTA appears centered below video caption
- [ ] Click → lands on `info.html#guide`
- [ ] Locale switch (zh-TW / zh-CN / ja) — verify translated text
- [ ] Mobile viewport (320px / 375px) — CTA wraps OK, button tappable
- [ ] Hover state: translateY -2px + purple glow

## Notes
- 2-file diff: landing.html (+21: CSS class + button markup), i18n.js (+4 keys)
- Per supervisor cross-review rule (#2 own PR → #1 review).

🤖 Generated with [Claude Code](https://claude.com/claude-code)