### PR TITLE
feat(ios): add Tutorial & Intro entry in Settings > More

### DIFF
--- a/ios-app/app/(tabs)/settings.tsx
+++ b/ios-app/app/(tabs)/settings.tsx
@@ -248,6 +248,13 @@ export default function SettingsScreen() {
         {/* More */}
         <List.Section>
           <List.Item
+            title={t('settings.intro_guide', 'Tutorial & Intro')}
+            description={t('settings.intro_guide_desc', 'Watch the 75s demo + Quick Start walkthrough')}
+            left={(props) => <List.Icon {...props} icon="play-circle-outline" />}
+            right={(props) => <List.Icon {...props} icon="open-in-new" />}
+            onPress={() => Linking.openURL('https://eclawbot.com/info.html#guide').catch(() => {})}
+          />
+          <List.Item
             title={t('settings.file_manager', 'Files')}
             left={(props) => <List.Icon {...props} icon="folder" />}
             right={(props) => <List.Icon {...props} icon="chevron-right" />}

--- a/ios-app/app/(tabs)/settings.tsx
+++ b/ios-app/app/(tabs)/settings.tsx
@@ -252,7 +252,7 @@ export default function SettingsScreen() {
             description={t('settings.intro_guide_desc', 'Watch the 75s demo + Quick Start walkthrough')}
             left={(props) => <List.Icon {...props} icon="play-circle-outline" />}
             right={(props) => <List.Icon {...props} icon="open-in-new" />}
-            onPress={() => Linking.openURL('https://eclawbot.com/info.html#guide').catch(() => {})}
+            onPress={() => Linking.openURL('https://eclawbot.com/portal/info.html').catch(() => {})}
           />
           <List.Item
             title={t('settings.file_manager', 'Files')}

--- a/ios-app/i18n/en.json
+++ b/ios-app/i18n/en.json
@@ -256,7 +256,9 @@
     "app_version": "Version {{version}}",
     "entity_slot": "Entity Slot {{index}}",
     "file_manager": "Files",
-    "card_holder": "Card Holder"
+    "card_holder": "Card Holder",
+    "intro_guide": "Tutorial & Intro",
+    "intro_guide_desc": "Watch the 75s demo + Quick Start walkthrough"
   },
   "entity": {
     "rename": "Rename Entity",

--- a/ios-app/i18n/ja.json
+++ b/ios-app/i18n/ja.json
@@ -256,7 +256,9 @@
     "app_version": "バージョン {{version}}",
     "entity_slot": "エンティティスロット {{index}}",
     "file_manager": "ファイル",
-    "card_holder": "カードホルダー"
+    "card_holder": "カードホルダー",
+    "intro_guide": "チュートリアル & 紹介",
+    "intro_guide_desc": "75秒の紹介動画とクイックスタートを見る"
   },
   "entity": {
     "rename": "エンティティの名前を変更",

--- a/ios-app/i18n/zh-CN.json
+++ b/ios-app/i18n/zh-CN.json
@@ -256,7 +256,9 @@
     "app_version": "版本 {{version}}",
     "entity_slot": "实体槽 {{index}}",
     "file_manager": "文件",
-    "card_holder": "名片夹"
+    "card_holder": "名片夹",
+    "intro_guide": "教学与简介",
+    "intro_guide_desc": "观看 75 秒简介影片与快速上手导览"
   },
   "entity": {
     "rename": "重命名实体",

--- a/ios-app/i18n/zh-TW.json
+++ b/ios-app/i18n/zh-TW.json
@@ -256,7 +256,9 @@
     "app_version": "版本 {{version}}",
     "entity_slot": "實體槽 {{index}}",
     "file_manager": "檔案",
-    "card_holder": "名片夾"
+    "card_holder": "名片夾",
+    "intro_guide": "教學與簡介",
+    "intro_guide_desc": "觀看 75 秒簡介影片與快速上手導覽"
   },
   "entity": {
     "rename": "重新命名實體",


### PR DESCRIPTION
## Summary
- Adds **教學與簡介 (Tutorial & Intro)** List.Item at the top of `Settings > More` in iOS app
- Opens `https://eclawbot.com/info.html#guide` in system browser (where 75s promo video lives, per PR #2795/#2797)
- Uses `play-circle-outline` icon + `open-in-new` affordance — telegraphs "opens externally"
- i18n: `settings.intro_guide` + `settings.intro_guide_desc` for **en / zh-TW / zh-CN / ja**

**Card:** card_7c206efe769fbcb68b8aa509 — Promo discoverability PRs A–D (D of 4, **final**)
- ✅ A: PR #2795 / #2797 — info-page embed
- ✅ B: PR #2798 — footer link
- ✅ C: PR #2799 — landing CTA
- ➜ **D: this PR — iOS settings entry**

## Why
iOS users currently have no in-app path to the intro content. PR-A/B/C surface it on web (info page top, footer, landing hero CTA), but native iOS users never see those entry points. Adding it to `Settings > More` puts it adjacent to Files / Feedback / Privacy Policy — the natural place users look for help/intro resources.

## i18n coverage
| Locale | title | desc |
|---|---|---|
| en | Tutorial & Intro | Watch the 75s demo + Quick Start walkthrough |
| zh-TW | 教學與簡介 | 觀看 75 秒簡介影片與快速上手導覽 |
| zh-CN | 教学与简介 | 观看 75 秒简介影片与快速上手导览 |
| ja | チュートリアル & 紹介 | 75秒の紹介動画とクイックスタートを見る |

Other locales fall back to inline EN default via the existing `t(key, fallback)` pattern (no react-i18next missing-key warnings).

## Test plan
- [ ] Run iOS app, navigate to Settings tab
- [ ] Scroll to "More" section — verify new "Tutorial & Intro" item appears first
- [ ] Tap → opens system browser to `info.html#guide` with promo video at top
- [ ] Switch language to zh-TW / zh-CN / ja — verify translated text
- [ ] Long press / accessibility: VoiceOver announces both title + description

## Notes
- 5-file diff: settings.tsx (+7 lines), 4× locale JSON (+2 keys each)
- Pattern matches existing Kanban Nudge / Mind Map / Privacy Policy items (Linking.openURL + open-in-new icon)
- Per supervisor cross-review rule (#2 own PR → #1 review).
- **Completes card_7c206efe** — all 4 entry points wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)