### PR TITLE
docs(roadmap): correct marketplace phase status

### DIFF
--- a/backend/public/portal/roadmap.html
+++ b/backend/public/portal/roadmap.html
@@ -281,8 +281,8 @@
                 </ul>
             </div>
 
-            <div class="rm-phase done">
-                <h3>Phase 1 — <span data-i18n="rm_p1_name">Listings & Interview</span> <span class="rm-status-badge done" data-i18n="rm_complete">Complete</span></h3>
+            <div class="rm-phase partial">
+                <h3>Phase 1 — <span data-i18n="rm_p1_name">Listings & Interview</span> <span class="rm-status-badge partial" data-i18n="rm_in_progress">In Progress</span></h3>
                 <div class="rm-phase-desc" data-i18n="rm_p1_desc">Bot listing CRUD, automated interview scoring, marketplace search, pricing advisor.</div>
                 <ul class="rm-tasks">
                     <li data-i18n="rm_p1_t1">6 new DB tables (listings, interviews, contracts, snapshots, usage events, pricing)</li>
@@ -292,7 +292,7 @@
                     <li data-i18n="rm_p1_t5">64 Jest unit tests</li>
                     <li data-i18n="rm_p1_t6">HTTP probe dispatch to owner webhooks</li>
                     <li class="todo" data-i18n="rm_p1_t7">Market snapshot hourly cron</li>
-                    <li class="todo" data-i18n="rm_p1_t8">Marketplace portal page</li>
+                    <li data-i18n="rm_p1_t8">Marketplace portal page</li>
                 </ul>
             </div>
 


### PR DESCRIPTION
## Summary
- Correct roadmap Phase 1 status to `In Progress` because `Market snapshot hourly cron` is still a TODO.
- Mark `Marketplace portal page` done because `backend/public/portal/marketplace.html` now exists.

## Validation
- `node --check backend/public/shared/i18n.js`
- `git diff --check`
- Scope: `backend/public/portal/roadmap.html` only, 3 insertions / 3 deletions.

## Notes
This is a docs/status correction for the roadmap page; no runtime behavior changes.
