### PR TITLE
docs(roadmap): flip 4 Hermes channel items to done per PR evidence

### DIFF
--- a/backend/public/portal/roadmap.html
+++ b/backend/public/portal/roadmap.html
@@ -407,10 +407,10 @@
                 <div class="rm-phase-desc" data-i18n="rm_h1_desc">Fix message delivery gaps, spurious disconnects, and session resumption failures. Targets: ≤2% delivery failure, ≤30s resume.</div>
                 <ul class="rm-tasks">
                     <li class="done" data-i18n="rm_h1_t1">Queue back-pressure: cap messageQueue depth at 200; oldest messages moved to dead-letter when cap exceeded (prevents pure-translation fallback)</li>
-                    <li class="todo" data-i18n="rm_h1_t2">Heartbeat/ping-pong on webhook channel — Hermes must respond within 10s or EClaw marks delivery as failed and retries</li>
+                    <li class="done" data-i18n="rm_h1_t2">Heartbeat/ping-pong on webhook channel — Hermes must respond within 10s or EClaw marks delivery as failed and retries</li>
                     <li class="todo" data-i18n="rm_h1_t3">Session cache key includes org_id + entity_id — fixes "repo not found" from stale session cache</li>
                     <li class="partial" data-i18n="rm_h1_t4">EClaw channel logs delivery receipts; alert on &gt;3 consecutive failures → commander notified</li>
-                    <li class="partial" data-i18n="rm_h1_t5">Docker health-check: Railway health endpoint returns 200 only when Hermes message loop is responsive; auto-restart if /health returns 503 for &gt;60s</li>
+                    <li class="done" data-i18n="rm_h1_t5">Docker health-check: Railway health endpoint returns 200 only when Hermes message loop is responsive; auto-restart if /health returns 503 for &gt;60s</li>
                     <li class="todo" data-i18n="rm_h1_t6">Rate-limit guard: Hermes respects 30 req/min from EClaw; back-pressure handled via exponential backoff</li>
                 </ul>
             </div>
@@ -422,7 +422,7 @@
                     <li class="partial" data-i18n="rm_h2_t1">Hermes accepts i18n batch cards via speakTo and delivers PRs on time</li>
                     <li class="todo" data-i18n="rm_h2_t2">Hermes health-check cron: git push test every 6h; alert commander on 3 consecutive failures</li>
                     <li class="todo" data-i18n="rm_h2_t3">Hermes uses Linear API to update card status after PR merge (closed/labelled)</li>
-                    <li class="partial" data-i18n="rm_h2_t4">Railway restart policy set to always; OOM or stuck loop triggers immediate restart with commander notification</li>
+                    <li class="done" data-i18n="rm_h2_t4">Railway restart policy set to always; OOM or stuck loop triggers immediate restart with commander notification</li>
                     <li data-i18n="rm_h2_t5">Hermes memory persists between sessions via hermes_state.db (already configured)</li>
                     <li class="todo" data-i18n="rm_h2_t6">Structured log pipeline: Hermes emits JSON logs → Railway log drain → Grafana dashboard; P95 response time tracked</li>
                 </ul>
@@ -443,7 +443,7 @@
                 <div class="rm-phase-desc" data-i18n="rm_h4_desc">Hermes Channel page on EClaw portal demonstrating live co-working with other agents as public proof of EClaw's cross-platform A2A.</div>
                 <ul class="rm-tasks">
                     <li class="done" data-i18n="rm_h4_t1">Public Hermes Channel guide page on portal (info.html already exists; content to be expanded)</li>
-                    <li class="partial" data-i18n="rm_h4_t2">Hermes i18n contributions visible as merged PRs — use as proof of cross-platform A2A</li>
+                    <li class="done" data-i18n="rm_h4_t2">Hermes i18n contributions visible as merged PRs — use as proof of cross-platform A2A</li>
                     <li class="todo" data-i18n="rm_h4_t3">Live demo: commander assigns a card, Hermes delivers PR, commander merges — screenshot in portal</li>
                     <li class="todo" data-i18n="rm_h4_t4">Add Hermes to EClaw's agent roster page (agent cards with capability tags)</li>
                 </ul>


### PR DESCRIPTION
## Summary

Audit-driven status updates on `backend/public/portal/roadmap.html` Hermes Channel section. 4 items flipped to `done` based on merged-PR evidence:

| Item | Status before → after | Evidence |
|---|---|---|
| `rm_h1_t2` Heartbeat/ping-pong on webhook channel | todo → done | PR #2215 (6ee0a92f) — `feat(hermes): delivery-stuck heartbeat detection (Phase H1.2)` |
| `rm_h1_t5` Docker health-check + auto-restart on stuck >60s | partial → done | PR #2216 (022c8a01) — `feat(hermes): /api/health 503 → Railway auto-restart on severe stuck (Phase H1.5)` |
| `rm_h2_t4` Railway always-restart policy + commander notification | partial → done | PR #2216 H1.5 (auto-restart) + ghost-entity exclusion PR #2217 |
| `rm_h4_t2` Hermes i18n PRs visible as cross-platform A2A proof | partial → done | 20+ merged i18n PRs since 2026-04 (e.g. #2784, #2780, #2779, #2778, #2777, #2776, #2774, #2767, #2766, #2765, #2762, #2760) |

## Items intentionally NOT flipped

- `rm_h0` phase badge: stays `partial` — task list shows 4/4 ✅ but H0 ground-truth verification needs separate audit
- `rm_h1_t3` org_id session cache: stays `todo` — Hank just filed org-change async card_8bd3629a today
- `rm_h1_t4` delivery receipts + alert: stays `partial` — alerting not visible in PR history
- `rm_h1_t6` rate-limit guard: stays `todo`
- `rm_h2_t1` Hermes delivers PRs on time: stays `partial` — Hermes wedges still occurring (recent #2781 stalled 6h)
- `rm_h2_t2/t3/t6`: stay `todo`
- `rm_h3_*` Private Repo Support: stays `partial`
- `rm_h4_t3/t4`: stay `todo`

## Test plan

- [x] No i18n key text changed (data-i18n keys preserved) → no i18n.js dict update needed
- [x] Only CSS class on `<li>` flipped (`todo`/`partial` → `done`)
- [ ] After merge: load `/portal/roadmap.html` and confirm Hermes phase task rows show ✅ for the 4 flipped items

Linked card: card_28d0e47a4b5ad91d51f2578e