### PR TITLE
chore(i18n): soft-pause keys × 10 locales (rebased from #2805)

### DIFF
--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -2628053,6 +2628053,10 @@ const TRANSLATIONS = {
 
 
         "borrow_rental_demand_fail": "제출 실패. 다시 시도해 주세요.",
+        "listing_soft_paused_owner_banner": "이 목록은 헬스 체크가 저하되어 일시 정지됩니다. 새로운 대여는 복구될 때까지 차단됩니다.",
+        "listing_soft_paused_visitor_banner": "소유주가 헬스 체크를 수정하는 동안 이 Bot은 일시 사용할 수 없습니다. 페이지는 사용 가능하지만 현재 대여는 비활성화됩니다.",
+        "listing_soft_paused_resume_btn": "목록 다시 시작",
+        "rental_create_rejected_soft_paused": "헬스 체크 저하로 인해 이 목록은 일시 사용할 수 없습니다.",
 
 
 
@@ -3160590,6 +3160594,10 @@ const TRANSLATIONS = {
 
 
         "borrow_rental_demand_fail": "ส่งไม่สำเร็จ กรุณาลองอีกครั้ง",
+        "listing_soft_paused_owner_banner": "รายการนี้หยุดชั่วคราวเนื่องจากการตรวจสอบสถานะ รายการจะยังคงแสดง แต่การเช่าใหม่จะถูกบล็อกจนกว่าจะฟื้นตัว",
+        "listing_soft_paused_visitor_banner": "Bot นี้ไม่พร้อมใช้งานชั่วคราวในขณะที่เจ้าของแก้ไขการตรวจสอบสถานะ หน้ายังพร้อใช้งาน แต่การเช่าจะถูกปิดในขณะนี้",
+        "listing_soft_paused_resume_btn": "เปิดใช้งานรายการอีกครั้ง",
+        "rental_create_rejected_soft_paused": "รายการนี้ไม่พร้อมใช้งานชั่วคราวเนื่องจากการตรวจสอบสถานะ",
 
 
 
@@ -3689346,6 +3689354,10 @@ const TRANSLATIONS = {
 
 
         "borrow_rental_demand_fail": "Gửi thất bại. Vui lòng thử lại.",
+        "listing_soft_paused_owner_banner": "Danh sách này tạm dừng do kiểm tra sức khỏe bị suy giảm. Nó vẫn được liệt kê nhưng cho thuê mới sẽ bị chặn cho đến khi phục hồi.",
+        "listing_soft_paused_visitor_banner": "Bot này tạm không khả dụng trong khi chủ sở hữu sửa kiểm tra sức khỏe. Trang vẫn khả dụng nhưng cho thuê bị vô hiệu hóa bây giờ.",
+        "listing_soft_paused_resume_btn": "Tiếp tục danh sách",
+        "rental_create_rejected_soft_paused": "Danh sách này tạm không khả dụng do kiểm tra sức khỏe bị suy giảm.",
 
 
 
@@ -4215513,6 +4215525,10 @@ const TRANSLATIONS = {
 
 
         "borrow_rental_demand_fail": "Gagal mengirim. Silakan coba lagi.",
+        "listing_soft_paused_owner_banner": "Daftar ini dijeda sementara karena pemeriksaan kesehatan turun. Tetap tercantum tetapi sewa baru diblokir hingga pulih.",
+        "listing_soft_paused_visitor_banner": "Bot ini sementara tidak tersedia sementara pemilik memperbaiki pemeriksaan kesehatan. Halaman tetap tersedia tetapi sewa dinonaktifkan untuk saat ini.",
+        "listing_soft_paused_resume_btn": "Lanjutkan daftar",
+        "rental_create_rejected_soft_paused": "Daftar ini sementara tidak tersedia karena pemeriksaan kesehatan turun.",
 
 
 
@@ -4741424,6 +4741440,10 @@ const TRANSLATIONS = {
 
 
         "borrow_rental_demand_fail": "Échec de la soumission. Veuillez réessayer.",
+        "listing_soft_paused_owner_banner": "Cette annonce est en pause car les vérifications de santé sont dégradées. Elle reste listée mais les nouvelles locations sont bloquées jusqu'à récupération.",
+        "listing_soft_paused_visitor_banner": "Ce bot est temporairement indisponible pendant que le propriétaire corrige les vérifications de santé. La page reste disponible mais la location est désactivée pour le moment.",
+        "listing_soft_paused_resume_btn": "Reprendre l'annonce",
+        "rental_create_rejected_soft_paused": "Cette offre n'est pas disponible temporairement en raison de vérifications de santé dégradées.",
 
 
 
@@ -5264654,6 +5264674,10 @@ const TRANSLATIONS = {
 
 
         "borrow_rental_demand_fail": "Error al enviar solicitud. Por favor intenta de nuevo...",
+        "listing_soft_paused_owner_banner": "Esta lista está en pausa porque las verificaciónes de salud están degradadas. Permanece listada, pero los nuevos alquileres están bloqueados hasta la recuperación.",
+        "listing_soft_paused_visitor_banner": "Este bot está temporalmente no disponible mientras el propietario corrige las verificaciónes de salud. La página permanece disponible, pero el alquiler está desactivado por ahora.",
+        "listing_soft_paused_resume_btn": "Reanudar lista",
+        "rental_create_rejected_soft_paused": "Esta oferta está temporalmente no disponible debido a verificaciónes de salud degradadas.",
 
 
 
@@ -5782791,6 +5782815,10 @@ const TRANSLATIONS = {
 
 
         "borrow_rental_demand_fail": "Anfrage konnte nicht eingereicht werden. Bitte versuchen Sie es erneut.",
+        "listing_soft_paused_owner_banner": "Diese Liste ist pausiert, weil die Gesundheitsprüfungen beeinträchtigt sind. Sie bleibt gelistet, aber neue Vermietungen sind bis zur Wiederherstellung blockiert.",
+        "listing_soft_paused_visitor_banner": "Dieser Bot ist vorübergehend nicht verfügbar, während der Eigentümer die Gesundheitsprüfungen korrigiert. Die Seite bleibt verfügbar, aber das Mieten ist jetzt deaktiviert.",
+        "listing_soft_paused_resume_btn": "Liste fortsetzen",
+        "rental_create_rejected_soft_paused": "Dieses Angebot ist vorübergehend nicht verfügbar wegen beeinträchtigter Gesundheitsprüfungen.",
 
 
 
@@ -6313970,6 +6313998,10 @@ const TRANSLATIONS = {
 
 
         "borrow_rental_demand_fail": "Gagal menghantar permintaan. Sila cuba lagi.",
+        "listing_soft_paused_owner_banner": "Senarai ini dijeda lembut kerana pemeriksaan kesihatan merosot. Ia kekal disenaraikan tetapi sewa baru disekat sehingga pulih.",
+        "listing_soft_paused_visitor_banner": "Bot ini tidak tersedia buat sementara sambil pemilik membaiki pemeriksaan kesihatan. Halaman kekal tersedia tetapi sewa dinyahaktifkan buat masa ini.",
+        "listing_soft_paused_resume_btn": "Sambung senarai",
+        "rental_create_rejected_soft_paused": "Senarai ini tidak tersedia buat sementara kerana pemeriksaan kesihatan merosot.",
 
 
 
@@ -7179803,6 +7179835,10 @@ const TRANSLATIONS = {
 
 
         "borrow_rental_demand_fail": "अनुरोध भेजने में विफल। कृपया पुनः प्रयास करें।",
+        "listing_soft_paused_owner_banner": "यह सूची स्वास्थ्य जांच में गिरावट के कारण अस्थायी रूप से रोकी गई है। यह सूचीबद्ध रहती है, लेकिन पुनर्प्राप्ति तक नए किराये अवरुद्ध हैं।",
+        "listing_soft_paused_visitor_banner": "यह बॉट मालिक द्वारा स्वास्थ्य जांच सुधारने के दौरान अस्थायी रूप से अनुपलब्ध है। पृष्ठ उपलब्ध रहता है, लेकिन किराया अभी के लिए अक्षम है।",
+        "listing_soft_paused_resume_btn": "सूची पुनः आरंभ करें",
+        "rental_create_rejected_soft_paused": "स्वास्थ्य जांच में गिरावट के कारण यह प्रस्ताव अस्थायी रूप से अनुपलब्ध है।",
 
 
 
@@ -7680144,6 +7680180,10 @@ const TRANSLATIONS = {
 
 
         "borrow_rental_demand_fail": "فشل إرسال الطلب. يرجى المحاولة مرة أخرى.",
+        "listing_soft_paused_owner_banner": "هذا القائمة معلقة مؤقتاً لأن فحوصات الصحة متدهورة. تظل مدرجة لكن الإيجارات الجديدة محظورة حتى الاستعادة.",
+        "listing_soft_paused_visitor_banner": "هذا البوت غير متاح مؤقتاً بينما المالك يصلح فحوصات الصحة. الصفحة تظل متاحة لكن الإيجار معطل حالياً.",
+        "listing_soft_paused_resume_btn": "استئناف القائمة",
+        "rental_create_rejected_soft_paused": "هذا العرض غير متاح مؤقتاً بسبب فحوصات الصحة المتدهورة.",
 
 
 


### PR DESCRIPTION
## Summary

Rebased version of PR #2805 to resolve merge conflicts and CI failures.

#4 Eclaw_Office's original branch (`i18n/softpause-keys-11-locales`) was based on stale main from May 9 — it inherited a pre-existing trailing-comma syntax error in the ES locale block (fixed on main by #2771 a few days later), causing CI to fail despite the soft-pause additions themselves being clean.

This branch re-applies the same +40 lines (10 locales × 4 keys) onto current main, preserving #4's translations verbatim including the two typo fixes from commit 5306c411 (Indonesian key-name corruption + French English passthrough).

## Coverage

After this PR merges, soft-pause keys will cover:
- Already on main (4): en, zh, zh-CN, ja
- Added here (10): ko, th, vi, id, fr, es, de, ms, hi, ar
- **Still missing (1):** zh-TW — flagged for a follow-up

## Test plan

- [x] `node --check backend/public/shared/i18n.js` passes locally
- [x] `npm test -- --testPathPattern=i18n` passes locally (2981 passed, 1 unrelated identity.test.js failure)
- [ ] CI Backend (ESLint + i18n syntax check + Jest) green
- [ ] Close PR #2805 after this merges

Closes part of PR #2805. Replaces conflicted history with clean rebased delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)