### PR TITLE
i18n: externalize 6 AI chat tool status labels (read/grep/glob/bash/edit/write)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/ui/AiChatViewModel.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/AiChatViewModel.kt
@@ -364,12 +364,12 @@ class AiChatViewModel(application: Application) : AndroidViewModel(application) 
             "tool_use" -> {
                 val tool = progress["tool"] as? String ?: "Processing"
                 val label = when (tool) {
-                    "Read" -> "Reading file"
-                    "Grep" -> "Searching code"
-                    "Glob" -> "Finding files"
-                    "Bash" -> "Running analysis"
-                    "Edit" -> "Editing file"
-                    "Write" -> "Writing file"
+                    "Read" -> getString(R.string.ai_chat_tool_status_read)
+                    "Grep" -> getString(R.string.ai_chat_tool_status_grep)
+                    "Glob" -> getString(R.string.ai_chat_tool_status_glob)
+                    "Bash" -> getString(R.string.ai_chat_tool_status_bash)
+                    "Edit" -> getString(R.string.ai_chat_tool_status_edit)
+                    "Write" -> getString(R.string.ai_chat_tool_status_write)
                     else -> tool
                 }
                 "$label…$suffix"

--- a/app/src/main/java/com/hank/clawlive/ui/AiChatViewModel.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/AiChatViewModel.kt
@@ -364,12 +364,12 @@ class AiChatViewModel(application: Application) : AndroidViewModel(application) 
             "tool_use" -> {
                 val tool = progress["tool"] as? String ?: "Processing"
                 val label = when (tool) {
-                    "Read" -> getString(R.string.ai_chat_tool_status_read)
-                    "Grep" -> getString(R.string.ai_chat_tool_status_grep)
-                    "Glob" -> getString(R.string.ai_chat_tool_status_glob)
-                    "Bash" -> getString(R.string.ai_chat_tool_status_bash)
-                    "Edit" -> getString(R.string.ai_chat_tool_status_edit)
-                    "Write" -> getString(R.string.ai_chat_tool_status_write)
+                    "Read" -> context.getString(R.string.ai_chat_tool_status_read)
+                    "Grep" -> context.getString(R.string.ai_chat_tool_status_grep)
+                    "Glob" -> context.getString(R.string.ai_chat_tool_status_glob)
+                    "Bash" -> context.getString(R.string.ai_chat_tool_status_bash)
+                    "Edit" -> context.getString(R.string.ai_chat_tool_status_edit)
+                    "Write" -> context.getString(R.string.ai_chat_tool_status_write)
                     else -> tool
                 }
                 "$label…$suffix"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -122,6 +122,15 @@
     <string name="ai_chat_image_unavailable">رفع الصور غير متاح مؤقتًا.</string>
     <string name="ai_chat_view_feedback">عرض سجل الملاحظات →</string>
 
+    <string name="ai_chat_tool_status_bash">جاري تشغيل التحليل</string>
+    <string name="ai_chat_tool_status_edit">جاري تعديل الملف</string>
+    <string name="ai_chat_tool_status_glob">جاري البحث عن الملفات</string>
+    <string name="ai_chat_tool_status_grep">جاري البحث في الكود</string>
+    <string name="ai_chat_tool_status_read">جاري قراءة الملف</string>
+    <string name="ai_chat_tool_status_write">جاري كتابة الملف</string>
+
+
+
     <!-- Chat -->
     <string name="chat_history">الدردشة</string>
     <string name="chat_offline_message">تعذر الاتصال. يرجى التحقق من اتصال الإنترنت.</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -122,6 +122,14 @@
     <string name="ai_chat_image_unavailable">Bild-Upload ist vorübergehend nicht verfügbar.</string>
     <string name="ai_chat_view_feedback">Feedback-Verlauf anzeigen →</string>
 
+    <string name="ai_chat_tool_status_bash">Analyse wird ausgeführt</string>
+    <string name="ai_chat_tool_status_edit">Datei wird bearbeitet</string>
+    <string name="ai_chat_tool_status_glob">Dateien werden gesucht</string>
+    <string name="ai_chat_tool_status_grep">Code wird durchsucht</string>
+    <string name="ai_chat_tool_status_read">Datei wird gelesen</string>
+    <string name="ai_chat_tool_status_write">Datei wird geschrieben</string>
+
+
     <!-- Chat -->
     <string name="chat_history">Chat</string>
     <string name="chat_offline_message">Verbindung nicht möglich. Bitte überprüfen Sie Ihre Internetverbindung.</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -59,6 +59,14 @@ La app se reiniciará para cargar tus datos.</string>
     <string name="ai_chat_title">Asistente AI</string>
     <string name="ai_chat_uploading">Subiendo imagen(es)…</string>
     <string name="ai_chat_view_feedback">Ver Historial de Comentarios →</string>
+
+    <string name="ai_chat_tool_status_bash">Ejecutando análisis</string>
+    <string name="ai_chat_tool_status_edit">Editando archivo</string>
+    <string name="ai_chat_tool_status_glob">Buscando archivos</string>
+    <string name="ai_chat_tool_status_grep">Buscando código</string>
+    <string name="ai_chat_tool_status_read">Leyendo archivo</string>
+    <string name="ai_chat_tool_status_write">Escribiendo archivo</string>
+
     <string name="ai_chat_welcome">¡Hola! Soy E-Claw AI.
 Pregúntame lo que quieras sobre la plataforma.</string>
     <string name="already_bound_free">Enlazado (Gratis)</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -122,6 +122,14 @@
     <string name="ai_chat_image_unavailable">Le téléversement d\'images est temporairement indisponible.</string>
     <string name="ai_chat_view_feedback">Voir l\'historique des retours →</string>
 
+    <string name="ai_chat_tool_status_bash">Analyse en cours</string>
+    <string name="ai_chat_tool_status_edit">Modification du fichier</string>
+    <string name="ai_chat_tool_status_glob">Recherche de fichiers</string>
+    <string name="ai_chat_tool_status_grep">Recherche dans le code</string>
+    <string name="ai_chat_tool_status_read">Lecture du fichier</string>
+    <string name="ai_chat_tool_status_write">Écriture du fichier</string>
+
+
     <!-- Chat -->
     <string name="chat_history">Chat</string>
     <string name="chat_offline_message">Connexion impossible. Vérifiez votre connexion Internet.</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -122,6 +122,14 @@
     <string name="ai_chat_image_unavailable">इमेज अपलोड अस्थायी रूप से अनुपलब्ध है।</string>
     <string name="ai_chat_view_feedback">फीडबैक इतिहास देखें →</string>
 
+    <string name="ai_chat_tool_status_bash">विश्लेषण चला रहा है</string>
+    <string name="ai_chat_tool_status_edit">फ़ाइल संपादित कर रहा है</string>
+    <string name="ai_chat_tool_status_glob">फ़ाइलें खोज रहा है</string>
+    <string name="ai_chat_tool_status_grep">कोड खोज रहा है</string>
+    <string name="ai_chat_tool_status_read">फ़ाइल पढ़ रहा है</string>
+    <string name="ai_chat_tool_status_write">फ़ाइल लिख रहा है</string>
+
+
     <!-- Chat -->
     <string name="chat_history">चैट</string>
     <string name="chat_offline_message">कनेक्ट नहीं हो पा रहा। कृपया अपना इंटरनेट कनेक्शन जांचें।</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -59,6 +59,14 @@
     <string name="ai_chat_title">Asisten AI</string>
     <string name="ai_chat_uploading">Mengunggah gambar…</string>
     <string name="ai_chat_view_feedback">Lihat Riwayat Umpan Balik →</string>
+
+    <string name="ai_chat_tool_status_bash">Menjalankan analisis</string>
+    <string name="ai_chat_tool_status_edit">Mengedit file</string>
+    <string name="ai_chat_tool_status_glob">Mencari file</string>
+    <string name="ai_chat_tool_status_grep">Mencari kode</string>
+    <string name="ai_chat_tool_status_read">Membaca file</string>
+    <string name="ai_chat_tool_status_write">Menulis file</string>
+
     <string name="ai_chat_welcome">Halo! Saya AI E-Claw.\nTanyakan apa saja tentang platform ini.</string>
     <string name="already_bound_free">Terikat (Gratis)</string>
     <string name="already_bound_personal">Terikat (Bulanan)</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -59,6 +59,14 @@
     <string name="ai_chat_title">AIアシスタント</string>
     <string name="ai_chat_uploading">画像をアップロード中…</string>
     <string name="ai_chat_view_feedback">フィードバック履歴を表示 →</string>
+
+    <string name="ai_chat_tool_status_bash">分析を実行中</string>
+    <string name="ai_chat_tool_status_edit">ファイルを編集中</string>
+    <string name="ai_chat_tool_status_glob">ファイルを検索中</string>
+    <string name="ai_chat_tool_status_grep">コードを検索中</string>
+    <string name="ai_chat_tool_status_read">ファイルを読み込み中</string>
+    <string name="ai_chat_tool_status_write">ファイルを書き込み中</string>
+
     <string name="ai_chat_welcome">こんにちは！私はE-Claw AIです。\nプラットフォームについて何でもご質問ください。</string>
     <string name="already_bound_free">バインド済み（無料）</string>
     <string name="already_bound_personal">バインド済み（月額）</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -59,6 +59,14 @@
     <string name="ai_chat_title">AI 어시스턴트</string>
     <string name="ai_chat_uploading">이미지 업로드 중…</string>
     <string name="ai_chat_view_feedback">피드백 기록 보기 →</string>
+
+    <string name="ai_chat_tool_status_bash">분석 실행 중</string>
+    <string name="ai_chat_tool_status_edit">파일 편집 중</string>
+    <string name="ai_chat_tool_status_glob">파일 검색 중</string>
+    <string name="ai_chat_tool_status_grep">코드 검색 중</string>
+    <string name="ai_chat_tool_status_read">파일 읽는 중</string>
+    <string name="ai_chat_tool_status_write">파일 작성 중</string>
+
     <string name="ai_chat_welcome">안녕하세요! 저는 E-Claw AI입니다.\n플랫폼에 대해 무엇이든 질문해 주세요.</string>
     <string name="already_bound_free">바인딩됨 (무료)</string>
     <string name="already_bound_personal">바인딩됨 (월정액)</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -122,6 +122,14 @@
     <string name="ai_chat_image_unavailable">Muat naik gambar tidak tersedia buat sementara waktu.</string>
     <string name="ai_chat_view_feedback">Lihat Sejarah Maklum Balas →</string>
 
+    <string name="ai_chat_tool_status_bash">Menjalankan analisis</string>
+    <string name="ai_chat_tool_status_edit">Mengedit fail</string>
+    <string name="ai_chat_tool_status_glob">Mencari fail</string>
+    <string name="ai_chat_tool_status_grep">Mencari kod</string>
+    <string name="ai_chat_tool_status_read">Membaca fail</string>
+    <string name="ai_chat_tool_status_write">Menulis fail</string>
+
+
     <!-- Chat -->
     <string name="chat_history">Sembang</string>
     <string name="chat_offline_message">Tidak dapat menyambung. Sila semak sambungan internet anda.</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -59,6 +59,14 @@
     <string name="ai_chat_title">ผู้ช่วย AI</string>
     <string name="ai_chat_uploading">กำลังอัปโหลดรูปภาพ…</string>
     <string name="ai_chat_view_feedback">ดูประวัติความคิดเห็น →</string>
+
+    <string name="ai_chat_tool_status_bash">กำลังรันการวิเคราะห์</string>
+    <string name="ai_chat_tool_status_edit">กำลังแก้ไขไฟล์</string>
+    <string name="ai_chat_tool_status_glob">กำลังค้นหาไฟล์</string>
+    <string name="ai_chat_tool_status_grep">กำลังค้นหาโค้ด</string>
+    <string name="ai_chat_tool_status_read">กำลังอ่านไฟล์</string>
+    <string name="ai_chat_tool_status_write">กำลังเขียนไฟล์</string>
+
     <string name="ai_chat_welcome">สวัสดี! ฉันคือ E-Claw AI\nถามอะไรเกี่ยวกับแพลตฟอร์มได้เลย</string>
     <string name="already_bound_free">ผูกแล้ว (ฟรี)</string>
     <string name="already_bound_personal">ผูกแล้ว (รายเดือน)</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -59,6 +59,14 @@
     <string name="ai_chat_title">Trợ lý AI</string>
     <string name="ai_chat_uploading">Đang tải hình ảnh lên…</string>
     <string name="ai_chat_view_feedback">Xem lịch sử phản hồi →</string>
+
+    <string name="ai_chat_tool_status_bash">Đang chạy phân tích</string>
+    <string name="ai_chat_tool_status_edit">Đang chỉnh sửa tệp</string>
+    <string name="ai_chat_tool_status_glob">Đang tìm tệp</string>
+    <string name="ai_chat_tool_status_grep">Đang tìm kiếm mã</string>
+    <string name="ai_chat_tool_status_read">Đang đọc tệp</string>
+    <string name="ai_chat_tool_status_write">Đang ghi tệp</string>
+
     <string name="ai_chat_welcome">Xin chào! Tôi là E-Claw AI.\nHỏi tôi bất cứ điều gì về nền tảng này.</string>
     <string name="already_bound_free">Đã liên kết (Miễn phí)</string>
     <string name="already_bound_personal">Đã liên kết (Tháng)</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -59,6 +59,14 @@
     <string name="ai_chat_title">AI 对话</string>
     <string name="ai_chat_uploading">正在上传…</string>
     <string name="ai_chat_view_feedback">查看反馈</string>
+
+    <string name="ai_chat_tool_status_bash">正在运行分析</string>
+    <string name="ai_chat_tool_status_edit">正在编辑文件</string>
+    <string name="ai_chat_tool_status_glob">正在查找文件</string>
+    <string name="ai_chat_tool_status_grep">正在搜索代码</string>
+    <string name="ai_chat_tool_status_read">正在读取文件</string>
+    <string name="ai_chat_tool_status_write">正在写入文件</string>
+
     <string name="ai_chat_welcome">你好！有什么我可以帮你的？</string>
     <string name="already_bound_free">已绑定（免费）</string>
     <string name="already_bound_personal">已绑定（包月）</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -59,6 +59,14 @@
     <string name="ai_chat_title">AI 對話</string>
     <string name="ai_chat_uploading">正在上傳…</string>
     <string name="ai_chat_view_feedback">查看回饋</string>
+
+    <string name="ai_chat_tool_status_bash">正在執行分析</string>
+    <string name="ai_chat_tool_status_edit">正在編輯檔案</string>
+    <string name="ai_chat_tool_status_glob">正在尋找檔案</string>
+    <string name="ai_chat_tool_status_grep">正在搜尋程式碼</string>
+    <string name="ai_chat_tool_status_read">正在讀取檔案</string>
+    <string name="ai_chat_tool_status_write">正在寫入檔案</string>
+
     <string name="ai_chat_welcome">你好！有什麼我可以幫你的？</string>
     <string name="already_bound_free">已綁定 (免費版)</string>
     <string name="already_bound_personal">已綁定 (月租版)</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -126,6 +126,13 @@
     <string name="ai_chat_image_unavailable">Image upload is temporarily unavailable.</string>
     <string name="ai_chat_view_feedback">View Feedback History →</string>
 
+    <string name="ai_chat_tool_status_bash">Running analysis</string>
+    <string name="ai_chat_tool_status_edit">Editing file</string>
+    <string name="ai_chat_tool_status_glob">Finding files</string>
+    <string name="ai_chat_tool_status_grep">Searching code</string>
+    <string name="ai_chat_tool_status_read">Reading file</string>
+    <string name="ai_chat_tool_status_write">Writing file</string>
+
     <!-- Chat -->
     <string name="chat_history">Chat</string>
     <string name="chat_offline_message">Unable to connect. Please check your internet connection.</string>


### PR DESCRIPTION
## Summary
Externalize 6 hardcoded English tool status labels in `AiChatViewModel.kt` to strings.xml i18n resources.

## Changes

### Files modified (15 files, 118 insertions, 6 deletions)

**Kotlin** (`app/src/main/java/com/hank/clawlive/ui/AiChatViewModel.kt`)
- Lines 367-372: Replace hardcoded English strings with `getString(R.string.ai_chat_tool_status_xxx)`

**String resources** (`app/src/main/res/values*/strings.xml`)
- Added 6 new string resources per locale:
  - `ai_chat_tool_status_read` = "Reading file"
  - `ai_chat_tool_status_grep` = "Searching code"
  - `ai_chat_tool_status_glob` = "Finding files"
  - `ai_chat_tool_status_bash` = "Running analysis"
  - `ai_chat_tool_status_edit` = "Editing file"
  - `ai_chat_tool_status_write` = "Writing file"

### Locales covered (14 total)
- `values/` (default/en): ✓
- `values-ar` (Arabic): ✓
- `values-de` (German): ✓
- `values-es` (Spanish): ✓
- `values-fr` (French): ✓
- `values-hi` (Hindi): ✓
- `values-in` (Indonesian): ✓
- `values-ja` (Japanese): ✓
- `values-ko` (Korean): ✓
- `values-ms` (Malay): ✓
- `values-th` (Thai): ✓
- `values-vi` (Vietnamese): ✓
- `values-zh-rCN` (Chinese Simplified): ✓
- `values-zh-rTW` (Chinese Traditional): ✓

## Bug reference
- Source card: P2 task from i18n quality inspection cron card_674530513d (2026-05-14)
- Fixes hardcoded English labels visible in AI chat "What is AI doing" status display
- Follows same pattern as PR #1725 which externalized 5 other AiChatViewModel hardcoded strings