### PR TITLE
fix(org-chart): notify affected bots on hierarchy change (card_8bd3629a)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -327,7 +327,7 @@ EClaw/
 | `/api/link-preview` | index.js | URL link preview extraction (Open Graph/Twitter meta) |
 | `/api/gatekeeper/stats` | index.js | Gatekeeper aggregate interception statistics |
 | `/api/gps/recommendations` | gps-recommendations.js | GPS-based entity recommendations (demo) |
-| `/api/device/org-chart` | org-chart.js + index.js | Organization hierarchy chart (GET/PUT hierarchy + behavior options) |
+| `/api/device/org-chart` | org-chart.js + index.js | Organization hierarchy chart (GET/PUT hierarchy + behavior options). PUT emits Socket.IO `org-chart:updated` to the device room and pushes a `{type:'org_chart_changed'}` message to each affected entity's messageQueue so polling bots learn of the change. |
 | `/api/kanban/cards/summary` | index.js | Kanban card summary endpoint |
 | `/api/mindmap/*` | mindmap.js + mindmap-mirror.js | Mind map CRUD (nodes, edges, anchors, comments), AI traverse, note-mirror backfill |
 | `/api/analytics/*` | site-pageviews.js | Site pageview analytics aggregation |

--- a/backend/index.js
+++ b/backend/index.js
@@ -17150,6 +17150,10 @@ app.put('/api/device/org-chart', async (req, res) => {
         return res.status(400).json({ success: false, error: 'hierarchy or options required' });
     }
 
+    // Snapshot pre-update hierarchy so we can diff affected entities after the write.
+    const beforeChart = await orgChartModule.getOrgChart(deviceId);
+    const oldHierarchy = (beforeChart && beforeChart.hierarchy) || {};
+
     const updates = {};
     if (hierarchy !== undefined) updates.hierarchy = hierarchy;
     if (options !== undefined) updates.options = options;
@@ -17159,8 +17163,48 @@ app.put('/api/device/org-chart', async (req, res) => {
         return res.status(400).json({ success: false, error: result.error });
     }
 
-    // Notify connected clients
+    // Notify connected clients (device-owner portal via Socket.IO room)
     io.to(deviceId).emit('org-chart:updated', result.orgChart);
+
+    // Notify affected bots via per-entity messageQueue. Socket.IO only reaches the
+    // device-room subscribers (portal), not the bot polling clients — so without
+    // this hook, bots whose superior or subordinate set just changed keep operating
+    // on stale hierarchy until their next cache TTL elapses or they restart.
+    if (hierarchy !== undefined) {
+        try {
+            const newHierarchy = (result.orgChart && result.orgChart.hierarchy) || {};
+            const affected = orgChartModule.computeAffectedEntities(oldHierarchy, newHierarchy);
+            const device = devices[deviceId];
+            if (affected.size > 0 && device && device.entities) {
+                const changedAt = Date.now();
+                for (const eId of affected) {
+                    const toEntity = device.entities[eId];
+                    if (!toEntity || !toEntity.isBound) continue;
+                    const oldSuperior = orgChartModule.getSuperior(oldHierarchy, eId);
+                    const newSuperior = orgChartModule.getSuperior(newHierarchy, eId);
+                    const oldSubs = orgChartModule.getSubordinates(oldHierarchy, eId);
+                    const newSubs = orgChartModule.getSubordinates(newHierarchy, eId);
+                    enqueueMessage(toEntity, {
+                        type: 'org_chart_changed',
+                        text: `[system] org-chart updated — superior: ${oldSuperior} → ${newSuperior}`,
+                        deviceId,
+                        entityId: eId,
+                        oldSuperior,
+                        newSuperior,
+                        oldSubordinates: oldSubs,
+                        newSubordinates: newSubs,
+                        changedAt,
+                        timestamp: changedAt,
+                        from: 'system:org_chart',
+                        fromEntityId: 0,
+                        read: false
+                    }, 'org_chart_change');
+                }
+            }
+        } catch (err) {
+            console.warn('[OrgChart] notify affected bots failed:', err && err.message);
+        }
+    }
 
     res.json({ success: true, orgChart: result.orgChart });
 });

--- a/backend/org-chart.js
+++ b/backend/org-chart.js
@@ -353,6 +353,39 @@ function invalidateCache(deviceId) {
     cache.delete(deviceId);
 }
 
+/**
+ * Diff two hierarchy snapshots and return the set of entity IDs whose
+ * position in the chart changed: either their superior moved, or their
+ * direct subordinate set changed. The USER root sentinel is never
+ * included (it's not an entity). Used to decide which polling bots
+ * need an `org_chart_changed` queue message after a PUT.
+ */
+function computeAffectedEntities(oldH, newH) {
+    const childToParent = (h) => {
+        const m = {};
+        for (const [p, kids] of Object.entries(h || {})) {
+            if (!Array.isArray(kids)) continue;
+            for (const k of kids) m[String(k)] = p;
+        }
+        return m;
+    };
+    const oldSup = childToParent(oldH);
+    const newSup = childToParent(newH);
+    const affected = new Set();
+    const allKids = new Set([...Object.keys(oldSup), ...Object.keys(newSup)]);
+    for (const childKey of allKids) {
+        if (oldSup[childKey] === newSup[childKey]) continue;
+        const childId = parseInt(childKey, 10);
+        if (!isNaN(childId)) affected.add(childId);
+        for (const parentKey of [oldSup[childKey], newSup[childKey]]) {
+            if (!parentKey || parentKey === 'USER') continue;
+            const parentId = parseInt(parentKey, 10);
+            if (!isNaN(parentId)) affected.add(parentId);
+        }
+    }
+    return affected;
+}
+
 module.exports = {
     DEFAULT_OPTIONS,
     initTable,
@@ -365,5 +398,6 @@ module.exports = {
     validateHierarchy,
     validateOptions,
     onEntityDeleted,
-    invalidateCache
+    invalidateCache,
+    computeAffectedEntities
 };

--- a/backend/tests/jest/org-chart.test.js
+++ b/backend/tests/jest/org-chart.test.js
@@ -438,3 +438,58 @@ describe('PUT /api/device/org-chart', () => {
         expect(res.status).toBeGreaterThanOrEqual(400);
     });
 });
+
+// ════════════════════════════════════════════════════════════════
+// computeAffectedEntities — used to decide which polling bots
+// need an `org_chart_changed` queue message after a PUT.
+// ════════════════════════════════════════════════════════════════
+describe('computeAffectedEntities()', () => {
+    it('returns empty set when hierarchy unchanged', () => {
+        const h = { USER: [1, 2, 3] };
+        const r = orgChart.computeAffectedEntities(h, h);
+        expect(r.size).toBe(0);
+    });
+
+    it('flags the moved entity and its new superior when nesting under a bot', () => {
+        const before = { USER: [1, 2, 3] };
+        const after = { USER: [1, 2], '1': [3] };
+        const r = orgChart.computeAffectedEntities(before, after);
+        expect([...r].sort()).toEqual([1, 3]);
+    });
+
+    it('flags reparented entity plus both old and new superior on cross-parent moves', () => {
+        const before = { USER: [1, 2, 3, 4], '3': [5] };
+        const after = { USER: [1, 2, 3, 4], '4': [5] };
+        const r = orgChart.computeAffectedEntities(before, after);
+        expect([...r].sort((a, b) => a - b)).toEqual([3, 4, 5]);
+    });
+
+    it('flags only the new entity when one is added under USER', () => {
+        const before = { USER: [1, 2] };
+        const after = { USER: [1, 2, 99] };
+        const r = orgChart.computeAffectedEntities(before, after);
+        expect([...r]).toEqual([99]);
+    });
+
+    it('handles empty/missing old hierarchy (fresh chart)', () => {
+        const r = orgChart.computeAffectedEntities({}, { USER: [1] });
+        expect([...r]).toEqual([1]);
+    });
+
+    it('excludes the USER root sentinel from the affected set', () => {
+        const before = { USER: [1] };
+        const after = { USER: [], '1': [] };
+        const r = orgChart.computeAffectedEntities(before, after);
+        // #1 left USER → only #1 is an affected entity; USER itself is not an entity.
+        for (const id of r) expect(typeof id).toBe('number');
+        expect([...r]).toEqual([1]);
+    });
+
+    it('flags entity removed from one superior even if not re-attached', () => {
+        const before = { USER: [1, 2], '1': [3] };
+        const after = { USER: [1, 2] };
+        const r = orgChart.computeAffectedEntities(before, after);
+        // #3's old superior was #1; both #1 and #3 are affected.
+        expect([...r].sort((a, b) => a - b)).toEqual([1, 3]);
+    });
+});


### PR DESCRIPTION
## Summary
- `PUT /api/device/org-chart` previously only emitted Socket.IO `org-chart:updated` to the device room, which reaches the owner portal but **not** per-entity bot polling clients
- After a hierarchy edit, bots whose superior or subordinate set just changed kept operating on stale data until cache TTL (60 s) or restart
- Diff old vs new hierarchy at the route boundary; enqueue `{type:'org_chart_changed', oldSuperior, newSuperior, oldSubordinates, newSubordinates, changedAt}` onto the messageQueue of every affected entity so the next poll surfaces the change
- Helper `computeAffectedEntities(oldH, newH)` extracted to `backend/org-chart.js` for reuse + isolation

## What "affected" means
An entity is in the affected set when **its position in the chart changed**:
- own superior moved (old parent → new parent), OR
- its direct subordinate set changed (a child moved in/out)

USER is the root sentinel, never an entity, never enqueued.

## Test plan
- [x] `node -c backend/index.js` + `node -c backend/org-chart.js` syntax
- [x] `npx jest backend/tests/jest/org-chart.test.js` — 121 passed (7 new diff cases)
- [ ] CI green
- [ ] Live curl: PUT a hierarchy change, observe `org_chart_changed` envelope on the next `/api/client/poll` for the moved entity

## Files
- `backend/index.js` — PUT /api/device/org-chart route + try/catch around enqueue
- `backend/org-chart.js` — export `computeAffectedEntities`
- `backend/tests/jest/org-chart.test.js` — 7 new diff cases
- `AGENTS.md` — endpoint-table row updated with notification behavior

Fixes `card_8bd3629a` — "Bug/P2 Org-change 缺少 async 系統通知 — 使用者換組織時 related bots 沒收到事件"

🤖 Generated with [Claude Code](https://claude.com/claude-code)