### PR TITLE
feat(i18n): zh-TW backfill 8 keys (soft-pause + chat + invite + wallet)

### DIFF
--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -2940677,6 +2940677,14 @@ const TRANSLATIONS = {
         "guide_cc_channel_envvars_row_auto_wake_poll": "Claude 仍 busy 時的重新檢查間隔（秒）",
         "guide_cc_channel_envvars_row_auto_wake_max_wait": "總共最多等多久才放棄喚醒（秒）",
         "guide_cc_channel_envvars_row_auto_wake_cooldown": "連續喚醒的冷卻時間",
+        "listing_soft_paused_owner_banner": "此上架項目因健康檢查異常而進入 soft-pause。它仍維持上架，但在恢復前會阻擋新的租借。",
+        "listing_soft_paused_visitor_banner": "這個 Bot 暫時無法租借，擁有者正在修復健康檢查問題。頁面仍可查看，但目前不能租借。",
+        "listing_soft_paused_resume_btn": "恢復上架",
+        "rental_create_rejected_soft_paused": "此上架項目因健康檢查異常而暫時無法租借。",
+        "mp_chat_cta": "開始對話",
+        "invite_unlimited_label": "已送出（無限制）",
+        "wallet_topup_success": "儲值成功！",
+        "wallet_topup_failed": "儲值失敗，請再試一次。",
 
 
 


### PR DESCRIPTION
Backfill 8 missing keys to the zh-TW locale block in `backend/public/shared/i18n.js`.

## Context

- PR #2808 added `listing_soft_paused_*` + `rental_create_rejected_soft_paused` to 10 locales but missed zh-TW.
- PR #2807 added `mp_chat_cta` / `invite_unlimited_label` / `wallet_topup_success` / `wallet_topup_failed` to 14 locales but missed zh-TW.
- This PR closes the gap: all 8 keys now present in 15 locale blocks (was 14).

## Why I shipped this myself

Card_f24edf7f was originally assigned to #4 Eclaw_Office. #4 hit two stale-session blockers:
1. First attempt (`i18n/zhtw-backfill-8keys`): wholesale rewrite of i18n.js (8M deletions) from stale base `f25f3af0`. Force-deleted.
2. Second attempt (`i18n/zhtw-backfill-8keys-v2`): only 4 keys, inserted into zh (Simplified) block instead of zh-TW, claimed 2 wallet keys 'already existed' (false in zh-TW).

Per `feedback_stale_session_replay` (fall back after 2 misses) — taking over via targeted Edit.

## Diff stat
```
backend/public/shared/i18n.js | 8 ++++++++
1 file changed, 8 insertions(+)
```

## Verification
- All 8 keys grep to 15 occurrences each (15 locales now cover them).
- Node `vm` syntax check passes; `TRANSLATIONS['zh-TW']` loads cleanly with 21 keys.
- Anchor: inserted after `guide_cc_channel_envvars_row_auto_wake_cooldown` at line 2940679.

Closes card_f24edf7f8052491f6c658c08.