### PR TITLE
fix(kanban): GET card returns latest 50 comments + total count

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -1423,9 +1423,11 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             const card = serializeCard(cardResult.rows[0]);
             await attachTagsToCards(deviceId, [card]);
 
-            // Fetch comments (latest 50)
+            // Fetch latest 50 comments (was: oldest 50 — invisible new comments on long cards)
             const commentsResult = await pool.query(
-                `SELECT * FROM kanban_comments WHERE card_id = $1 ORDER BY created_at ASC LIMIT 50`,
+                `SELECT * FROM (
+                    SELECT * FROM kanban_comments WHERE card_id = $1 ORDER BY created_at DESC LIMIT 50
+                ) sub ORDER BY created_at ASC`,
                 [cardId]
             );
             card.comments = commentsResult.rows.map(r => ({
@@ -1974,7 +1976,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
         if (!authenticate(req, res)) return;
         const { deviceId } = { ...req.query, ...req.body };
         const cardId = req.params.id;
-        const limit = Math.min(100, Math.max(1, parseInt(req.query.limit) || 50));
+        const limit = Math.min(500, Math.max(1, parseInt(req.query.limit) || 50));
         const offset = Math.max(0, parseInt(req.query.offset) || 0);
 
         try {
@@ -1986,6 +1988,12 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             if (cardCheck.rows.length === 0) {
                 return res.status(404).json({ success: false, error: 'Card not found' });
             }
+
+            const totalResult = await pool.query(
+                `SELECT COUNT(*)::int AS total FROM kanban_comments WHERE card_id = $1`,
+                [cardId]
+            );
+            const total = totalResult.rows[0]?.total ?? 0;
 
             const result = await pool.query(
                 `SELECT * FROM kanban_comments WHERE card_id = $1 ORDER BY created_at ASC LIMIT $2 OFFSET $3`,
@@ -2000,7 +2008,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                 createdAt: new Date(r.created_at).getTime()
             }));
 
-            res.json({ success: true, comments, total: comments.length });
+            res.json({ success: true, comments, total, limit, offset });
         } catch (err) {
             console.error('[Kanban] List comments error:', err);
             res.status(500).json({ success: false, error: err.message });


### PR DESCRIPTION
## Bug

Cards with >50 comments lose visibility of new ones:

- `GET /api/mission/card/:id` returned **oldest** 50 comments (ORDER BY ASC LIMIT 50), so any new comment after the 50th appeared in `commentCount` but never in the `comments[]` array. Affected at least `card_126b72b9` (141 comments) and `card_4880d6f8`.
- `GET /api/mission/card/:id/comments` hard-capped `limit` at 100 and reported `total: comments.length` (page size, not real total), so clients could not page past 100 and could not detect there was more.

Knock-on effects: bot @-mentions on long cards dropped silently; review reject + reassign cycle on i18n multi-round cards became unobservable.

## Fix

1. **GET /card/:id** — subquery `DESC LIMIT 50` then outer `ORDER BY ASC` returns latest 50 in chronological order.
2. **GET /card/:id/comments** — bump limit cap to 500; add a `SELECT COUNT(*)` for the real `total`; echo `limit` + `offset` so clients can paginate. Default page size unchanged (50).

## Test plan

- Long card (>50 comments): GET card → `comments[].at(-1).createdAt` is now within last hour, not from days ago.
- GET /comments?offset=100&limit=50 returns rows 101-150 (previously capped at 100).
- GET /comments returns `{total: N}` matching the card-level `commentCount`.

Closes card_495bbf5895eb05e27526a714.