### PR TITLE
fix(api): platform-stats 500 + entity/lookup publicCode alias

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ EClaw/
 │   │   └── docs/
 │   │       └── webhook-troubleshooting.md
 │   ├── tests/                # Regression + integration tests (59 files)
-│   ├── tests/jest/           # Jest unit tests (201 files, CI-run via `npm test`)
+│   ├── tests/jest/           # Jest unit tests (206 files, CI-run via `npm test`)
 │   └── scripts/              # Setup scripts
 ├── app/                      # Android app (Kotlin)
 │   └── src/main/java/com/hank/clawlive/
@@ -1043,7 +1043,7 @@ curl "https://eclawbot.com/api/device-telemetry?deviceId=ID&deviceSecret=SECRET&
 
 ## Test Coverage Summary
 
-**~460 total API routes** across all modules (410 excluding Article Publisher), **~84% covered** by Jest + integration tests (~2946 test cases across 201 Jest files + 59 integration tests).
+**~460 total API routes** across all modules (410 excluding Article Publisher), **~84% covered** by Jest + integration tests (~2995 test cases across 206 Jest files + 59 integration tests).
 
 | Module | Coverage | Notes |
 |--------|----------|-------|
@@ -1136,7 +1136,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | R2 Quota Rich Card | `node backend/tests/test-r2-quota-rich-card.js` | Device ID + Secret | R2 quota exceeded rich card E2E |
 | Subscription Plans Live | `node backend/tests/test-subscription-plans-live.js` | Device ID + Secret | Subscription plans + wallet live verification |
 
-### Jest Unit Tests (CI-run, `npm test`, 201 files)
+### Jest Unit Tests (CI-run, `npm test`, 206 files)
 
 | Test | File | Description |
 |------|------|-------------|
@@ -1211,7 +1211,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 ### Running All Tests
 ```bash
 node backend/run_all_tests.js          # Run all tests sequentially
-cd backend && npm test                  # Jest unit tests (201 files)
+cd backend && npm test                  # Jest unit tests (206 files)
 cd backend && npm run lint              # ESLint
 ```
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -4335,12 +4335,16 @@ app.get('/api/platform-stats', async (req, res) => {
         const pg = authModule.pool;
 
         // User count
-        const userCount = await pg.query('SELECT COUNT(*) as total FROM user_accounts');
+        let userTotal = 0;
+        try {
+            const userCount = await pg.query('SELECT COUNT(*) as total FROM user_accounts');
+            userTotal = parseInt(userCount.rows[0].total);
+        } catch (_) { /* table may not exist */ }
 
-        // Template counts
-        const soulCount = await pg.query('SELECT COUNT(*) as total FROM soul_templates');
-        const ruleCount = await pg.query('SELECT COUNT(*) as total FROM rule_templates');
-        const skillCount = await pg.query('SELECT COUNT(*) as total FROM skill_templates');
+        // Template counts (from in-memory arrays loaded from JSON files)
+        const soulTotal = soulTemplatesData.length;
+        const ruleTotal = ruleTemplatesData.length;
+        const skillTotal = skillTemplatesData.length;
 
         // Bound entities (in-memory, excluding test devices)
         let boundEntities = 0;
@@ -4358,13 +4362,13 @@ app.get('/api/platform-stats', async (req, res) => {
 
         res.json({
             success: true,
-            users: parseInt(userCount.rows[0].total),
+            users: userTotal,
             boundEntities,
             activeDevices,
             templates: {
-                soul: parseInt(soulCount.rows[0].total),
-                rule: parseInt(ruleCount.rows[0].total),
-                skill: parseInt(skillCount.rows[0].total)
+                soul: soulTotal,
+                rule: ruleTotal,
+                skill: skillTotal
             }
         });
     } catch (err) {
@@ -10547,10 +10551,10 @@ app.post('/api/entity/cross-speak', async (req, res) => {
 /**
  * GET /api/entity/lookup
  * Look up entity info by public code (non-sensitive data only).
- * Query: ?code=abc123
+ * Query: ?code=abc123  (also accepts ?publicCode=abc123)
  */
 app.get('/api/entity/lookup', (req, res) => {
-    const code = req.query.code;
+    const code = req.query.code || req.query.publicCode;
     if (!code) {
         return res.status(400).json({ success: false, message: "code query parameter required" });
     }

--- a/backend/tests/jest/health.test.js
+++ b/backend/tests/jest/health.test.js
@@ -273,3 +273,60 @@ describe('Portal static cache headers', () => {
         expect(res.headers['cache-control']).toMatch(/no-cache/);
     });
 });
+
+// ════════════════════════════════════════════════════════════════
+// /api/platform-stats — Regression #2809
+// ════════════════════════════════════════════════════════════════
+describe('GET /api/platform-stats', () => {
+    it('requires deviceId and deviceSecret', async () => {
+        const res = await request(app).get('/api/platform-stats');
+        expect(res.status).toBe(400);
+    });
+
+    it('rejects invalid credentials', async () => {
+        const res = await request(app)
+            .get('/api/platform-stats?deviceId=fake&deviceSecret=fake');
+        expect(res.status).toBe(401);
+    });
+
+    it('does not 500 when called with valid device (template counts from in-memory)', async () => {
+        // Register a device so it exists in the in-memory map
+        const did = 'platform-stats-test-device';
+        const dsec = 'platform-stats-test-secret';
+        await request(app).post('/api/device/register').send({
+            deviceId: did, deviceSecret: dsec, entityId: 0,
+        });
+
+        const res = await request(app)
+            .get(`/api/platform-stats?deviceId=${did}&deviceSecret=${dsec}`);
+        // Must not be 500 (the bug was querying non-existent DB tables)
+        expect(res.status).not.toBe(500);
+        if (res.status === 200) {
+            expect(res.body.success).toBe(true);
+            expect(typeof res.body.templates.soul).toBe('number');
+            expect(typeof res.body.templates.rule).toBe('number');
+            expect(typeof res.body.templates.skill).toBe('number');
+        }
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// /api/entity/lookup — Regression #2810
+// ════════════════════════════════════════════════════════════════
+describe('GET /api/entity/lookup', () => {
+    it('requires code query parameter', async () => {
+        const res = await request(app).get('/api/entity/lookup');
+        expect(res.status).toBe(400);
+    });
+
+    it('accepts publicCode as alias for code (#2810)', async () => {
+        const res = await request(app).get('/api/entity/lookup?publicCode=nonexistent');
+        // Should be 404 (not found) not 400 (missing param)
+        expect(res.status).toBe(404);
+    });
+
+    it('accepts code parameter', async () => {
+        const res = await request(app).get('/api/entity/lookup?code=nonexistent');
+        expect(res.status).toBe(404);
+    });
+});


### PR DESCRIPTION
## Summary
- **#2809**: `/api/platform-stats` returned 500 because it queried non-existent DB tables (`soul_templates`, `rule_templates`, `skill_templates`). Fixed to use in-memory template arrays loaded from JSON files.
- **#2810**: `/api/entity/lookup` only accepted `code` param, but docs/skill-templates reference `publicCode`. Fixed to accept both `code` and `publicCode`.
- Added 6 regression tests in `health.test.js`
- Updated CLAUDE.md test counts (206 suites, 2995 tests)

Closes #2809
Closes #2810

## Test plan
- [x] `npx jest tests/jest/health.test.js` — 19 tests pass
- [x] Full suite: 206 suites, 2995 tests pass
- [x] ESLint: 0 errors
- [x] i18n-check: all EN keys resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)