### PR TITLE
docs(roadmap): flip H0 phase badge to done

### DIFF
--- a/backend/public/portal/roadmap.html
+++ b/backend/public/portal/roadmap.html
@@ -391,14 +391,14 @@
                 </div>
             </div>
 
-            <div class="rm-phase partial">
-                <h3>Phase H0 — <span data-i18n="rm_h0_name">Infrastructure Readiness</span> <span class="rm-status-badge partial" data-i18n="rm_in_progress">In Progress</span></h3>
+            <div class="rm-phase done">
+                <h3>Phase H0 — <span data-i18n="rm_h0_name">Infrastructure Readiness</span> <span class="rm-status-badge done" data-i18n="rm_complete">Complete</span></h3>
                 <div class="rm-phase-desc" data-i18n="rm_h0_desc">Resolve basic connectivity: git clone/write access, credential injection, channel authentication.</div>
                 <ul class="rm-tasks">
-                    <li data-i18n="rm_h0_t1">GITHUB_TOKEN injected into claude-cli-proxy via Railway env var (vault → Railway)</li>
+                    <li class="done" data-i18n="rm_h0_t1">GITHUB_TOKEN injected into claude-cli-proxy via Railway env var (vault → Railway)</li>
                     <li class="done" data-i18n="rm_h0_t2">Redeploy proxy; verify Hermes can git clone/push HankHuang0516/EClaw</li>
-                    <li data-i18n="rm_h0_t3">Webhook secret validation on EClaw side matches Hermes egress</li>
-                    <li data-i18n="rm_h0_t4">Hermes speakTo back to Entity 2 (commander) confirms bidirectional A2A</li>
+                    <li class="done" data-i18n="rm_h0_t3">Webhook secret validation on EClaw side matches Hermes egress</li>
+                    <li class="done" data-i18n="rm_h0_t4">Hermes speakTo back to Entity 2 (commander) confirms bidirectional A2A</li>
                 </ul>
             </div>
 


### PR DESCRIPTION
## Summary
- Phase H0 (Infrastructure Readiness) phase-level badge: `partial / In Progress` → `done / Complete`
- H0-t1, t3, t4 now have explicit `class="done"` for visual consistency with t2

## Why
All 4 H0 sub-items have been functionally complete for weeks:
- **t1 GITHUB_TOKEN injected** — claude-cli-proxy reads Railway env; Hermes git ops authenticated
- **t2 Proxy redeploy verified** — Hermes successfully clones/pushes (e.g. PR #2794)
- **t3 Webhook secret validated** — EClaw ↔ Hermes bridge running stable daily
- **t4 Hermes speakTo back to Entity 2** — bidirectional A2A confirmed (commander channel)

This follows PR #2803 which flipped 4 H1/H2/H4 sub-items under the same card.

## Scope
- 1 file: `backend/public/portal/roadmap.html` (5+/5- lines)
- Doc-only. No code, no schema, no API
- i18n keys `rm_complete` / `rm_in_progress` already exist in all 14+ locales (verified pre-push)

## Test plan
- [ ] CI green (lint only — no jest impact)
- [ ] Playwright screenshot: H0 phase badge renders green "Complete" in en/zh-TW
- [ ] #1 supervisor cross-review

card_28d0e47a4b5ad91d51f2578e

🤖 Generated with [Claude Code](https://claude.com/claude-code)