### PR TITLE
feat(app): route chat mission jumps through native tabs

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -637,6 +637,8 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             reopenReason: row.reopen_reason || null,
             requiresPrRework: !!row.requires_pr_rework,
             reworkPrNumber: row.rework_pr_number || null,
+            linkedPrevCardId: row.linked_prev_card_id || null,
+            linkedNextCardId: row.linked_next_card_id || null,
             // Aggregated counts (if present from JOIN)
             commentCount: parseInt(row.comment_count) || 0,
             noteCount: parseInt(row.note_count) || 0,
@@ -1503,7 +1505,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
     router.put('/card/:id', async (req, res) => {
         if (!authenticate(req, res)) return;
         const _p = { ...req.query, ...req.body }; console.log('[Kanban] PUT /card/:id called', { deviceId: _p.deviceId, entityId: _p.entityId, cardId: req.params?.id });
-        const { deviceId, title, description, priority, assignedBots, reviewerEntityId, requiresScreenshotReview, dispatchMode, requiresPrRework, reworkPrNumber } = req.body;
+        const { deviceId, title, description, priority, assignedBots, reviewerEntityId, requiresScreenshotReview, dispatchMode, requiresPrRework, reworkPrNumber, linkedPrevCardId, linkedNextCardId } = req.body;
         const cardId = req.params.id;
 
         try {
@@ -1514,6 +1516,27 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             );
             if (existing.rows.length === 0) {
                 return res.status(404).json({ success: false, error: 'Card not found' });
+            }
+
+            async function normalizeLinkedCardId(raw, fieldName) {
+                if (raw === undefined) return undefined;
+                const value = raw == null ? '' : String(raw).trim();
+                if (!value) return null;
+                if (value === cardId) {
+                    const err = new Error(`${fieldName} cannot point to the same card`);
+                    err.status = 400;
+                    throw err;
+                }
+                const linked = await pool.query(
+                    `SELECT id FROM kanban_cards WHERE id = $1 AND device_id = $2 LIMIT 1`,
+                    [value, deviceId]
+                );
+                if (linked.rows.length === 0) {
+                    const err = new Error(`${fieldName} target card not found`);
+                    err.status = 400;
+                    throw err;
+                }
+                return value;
             }
 
             const updates = [];
@@ -1583,6 +1606,16 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                     updates.push(`requires_pr_rework = TRUE`);
                 }
             }
+            if (linkedPrevCardId !== undefined) {
+                const normalizedPrev = await normalizeLinkedCardId(linkedPrevCardId, 'linkedPrevCardId');
+                updates.push(`linked_prev_card_id = $${paramIdx++}`);
+                params.push(normalizedPrev);
+            }
+            if (linkedNextCardId !== undefined) {
+                const normalizedNext = await normalizeLinkedCardId(linkedNextCardId, 'linkedNextCardId');
+                updates.push(`linked_next_card_id = $${paramIdx++}`);
+                params.push(normalizedNext);
+            }
 
             if (updates.length === 0) {
                 return res.status(400).json({ success: false, error: 'Nothing to update' });
@@ -1603,7 +1636,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             res.json({ success: true, card: serializeCard(result.rows[0]) });
         } catch (err) {
             console.error('[Kanban] Update card error:', err);
-            res.status(500).json({ success: false, error: err.message });
+            res.status(err.status || 500).json({ success: false, error: err.message });
         }
     });
 

--- a/backend/kanban_schema.sql
+++ b/backend/kanban_schema.sql
@@ -223,6 +223,10 @@ ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS reopen_reason TEXT DEFAULT NUL
 ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS requires_pr_rework BOOLEAN DEFAULT FALSE;
 ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS rework_pr_number VARCHAR(64) DEFAULT NULL;
 
+-- Explicit ordered linked-task navigation (chip UX PR A)
+ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS linked_prev_card_id VARCHAR(48) DEFAULT NULL;
+ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS linked_next_card_id VARCHAR(48) DEFAULT NULL;
+
 CREATE INDEX IF NOT EXISTS idx_kanban_cards_pending_dispatch ON kanban_cards(device_id, pending_dispatch, dispatch_mode)
     WHERE pending_dispatch = TRUE;
 

--- a/backend/migrations/20260515_task_chip_linked_cards.down.sql
+++ b/backend/migrations/20260515_task_chip_linked_cards.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE kanban_cards DROP COLUMN IF EXISTS linked_next_card_id;
+ALTER TABLE kanban_cards DROP COLUMN IF EXISTS linked_prev_card_id;

--- a/backend/migrations/20260515_task_chip_linked_cards.up.sql
+++ b/backend/migrations/20260515_task_chip_linked_cards.up.sql
@@ -1,0 +1,3 @@
+-- Add explicit ordered linked-task pointers for task chip navigation.
+ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS linked_prev_card_id VARCHAR(48) DEFAULT NULL;
+ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS linked_next_card_id VARCHAR(48) DEFAULT NULL;

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -4379,7 +4379,8 @@
 
         function getChatMessageDeepLinkId() {
             try {
-                return normalizeChatMessageId(new URLSearchParams(window.location.search).get('msg'));
+                const params = new URLSearchParams(window.location.search);
+                return normalizeChatMessageId(params.get('msg') || params.get('his'));
             } catch (_) {
                 return '';
             }
@@ -7611,6 +7612,39 @@
             }
         }
 
+        function eclawNavigateMissionCard(cardId) {
+            const id = String(cardId || '').trim();
+            if (!id) return false;
+            try {
+                if (window.EClawNativeNav && typeof window.EClawNativeNav.navigate === 'function') {
+                    return window.EClawNativeNav.navigate({ targetTab: 'mission', target: 'card', cardId: id, sourceTab: 'chat' });
+                }
+            } catch (_) {}
+            return false;
+        }
+
+        window.eclawHandleNativeNavigateIntent = async function(intent) {
+            if (!intent || intent.targetTab !== 'chat') return false;
+            try {
+                if (intent.quote && (intent.quote.title || intent.quote.excerpt)) {
+                    quoteToChat(intent.quote.source || '引用', intent.quote.title || '', intent.quote.excerpt || '');
+                    return true;
+                }
+                const msgId = intent.messageId || (intent.target === 'message' ? intent.threadId : '');
+                if (msgId) {
+                    const url = new URL(window.location.href);
+                    url.searchParams.set('msg', msgId);
+                    url.searchParams.delete('his');
+                    window.history.replaceState({}, '', url.toString());
+                    await handleChatMessageDeepLink({ showMissingToast: true, scroll: true });
+                    return true;
+                }
+            } catch (e) {
+                console.warn('[Chat] native navigate intent failed:', e);
+            }
+            return false;
+        };
+
         function getKanbanCardUrl(cardId) {
             const id = String(cardId || '').trim();
             if (!id) return 'kanban.html';
@@ -7619,6 +7653,7 @@
 
         function openKanbanCard(cardId, event) {
             if (event && typeof event.preventDefault === 'function') event.preventDefault();
+            if (eclawNavigateMissionCard(cardId)) return;
             const url = getKanbanCardUrl(cardId);
             const opened = window.open(url, '_blank', 'noopener');
             if (!opened) window.location.href = url;

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -1017,6 +1017,15 @@
     <script src="shared/ai-chat.js"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'🦞'};window.isAvatarUrl=function(){return false}}</script>
     <script>
+        function eclawNavigateChat(intent) {
+            try {
+                if (window.EClawNativeNav && typeof window.EClawNativeNav.navigate === 'function') {
+                    return window.EClawNativeNav.navigate(Object.assign({ targetTab: 'chat', sourceTab: 'mission' }, intent || {}));
+                }
+            } catch (_) {}
+            return false;
+        }
+
         // Mention chips and his_ chips rendered by shared MentionRender /
         // HisLinkRender call openMentionProfile() / openHistoryMessage() which
         // live in chat.html. Stub them here so kanban-side clicks don't throw —
@@ -1030,7 +1039,8 @@
         if (typeof window.openHistoryMessage !== 'function') {
             window.openHistoryMessage = function (msgId) {
                 if (!msgId) return;
-                window.location.href = '/portal/chat.html?his=' + encodeURIComponent(msgId);
+                if (eclawNavigateChat({ target: 'message', messageId: msgId })) return;
+                window.location.href = '/portal/chat.html?msg=' + encodeURIComponent(msgId);
             };
         }
         // 智慧引用 render chain — delegates to shared ChatMessageRender so chat
@@ -1190,6 +1200,28 @@
                 loadComments();
             }
         }
+
+        window.eclawHandleNativeNavigateIntent = async function(intent) {
+            if (!intent || intent.targetTab !== 'mission') return false;
+            const cardId = String(intent.cardId || '').trim();
+            if (!cardId) return false;
+            try {
+                const url = new URL(window.location.href);
+                url.searchParams.set('card', cardId);
+                window.history.replaceState({}, '', url.toString().split('#')[0] + '#' + encodeURIComponent(cardId));
+                const card = findCard(cardId);
+                if (card) {
+                    openDetail(cardId);
+                } else {
+                    await loadCards();
+                    handleHashDeepLink();
+                }
+                return true;
+            } catch (e) {
+                console.warn('[Kanban] native navigate intent failed:', e);
+                return false;
+            }
+        };
 
         let automationCards = [];
         let cardProjections = {};
@@ -2491,8 +2523,10 @@
                 window.parent.postMessage({ type: 'eclaw_quote', source, title, excerpt: excerpt || '' }, window.location.origin);
                 eclawShowFloatToast(toastMsg);
             } else {
-                // Standalone: no chat pane reachable → fall back to navigation as before.
-                localStorage.setItem('eclaw_pending_quote', JSON.stringify({ source, title, excerpt: excerpt || '', ts: Date.now() }));
+                // Standalone/App WebView: prefer native bottom-tab switch when available.
+                const quote = { source, title, excerpt: excerpt || '' };
+                localStorage.setItem('eclaw_pending_quote', JSON.stringify({ ...quote, ts: Date.now() }));
+                if (eclawNavigateChat({ target: 'quote', quote })) return;
                 window.location.href = '/portal/chat.html';
             }
         }

--- a/backend/scripts/check-native-tab-navigation.js
+++ b/backend/scripts/check-native-tab-navigation.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const root = path.resolve(__dirname, '..', '..');
+function read(rel) { return fs.readFileSync(path.join(root, rel), 'utf8'); }
+function assertIncludes(file, needle, label) {
+  const body = read(file);
+  if (!body.includes(needle)) throw new Error(`${file} missing ${label || needle}`);
+}
+
+assertIncludes('ios-app/components/WebViewScreen.tsx', "type: 'eclaw:navigate-tab'", 'native navigate bridge message');
+assertIncludes('ios-app/components/WebViewScreen.tsx', 'pendingIntent = intent; // last navigation wins', 'last-intent-wins race handling');
+assertIncludes('ios-app/components/WebViewScreen.tsx', '15000', 'pending intent timeout');
+assertIncludes('ios-app/components/WebViewScreen.tsx', "router.navigate(routeForTab", 'native bottom-tab route dispatch');
+assertIncludes('ios-app/app/(tabs)/chat.tsx', 'tabId="chat"', 'chat tab registration');
+assertIncludes('ios-app/app/(tabs)/mission.tsx', 'tabId="mission"', 'mission tab registration');
+
+assertIncludes('backend/public/portal/chat.html', "params.get('msg') || params.get('his')", 'chat ?his compatibility alias');
+assertIncludes('backend/public/portal/chat.html', 'window.eclawHandleNativeNavigateIntent', 'chat native intent consumer');
+assertIncludes('backend/public/portal/chat.html', 'eclawNavigateMissionCard(cardId)', 'chat-to-mission native card open');
+
+assertIncludes('backend/public/portal/kanban.html', 'eclawNavigateChat({ target: \'message\'', 'kanban history native message navigation');
+assertIncludes('backend/public/portal/kanban.html', "'/portal/chat.html?msg='", 'kanban ?msg fallback, not ?his');
+assertIncludes('backend/public/portal/kanban.html', 'window.eclawHandleNativeNavigateIntent', 'kanban native card intent consumer');
+
+assertIncludes('backend/kanban_schema.sql', 'linked_prev_card_id', 'linked prev schema');
+assertIncludes('backend/kanban_schema.sql', 'linked_next_card_id', 'linked next schema');
+assertIncludes('backend/kanban.js', 'linkedPrevCardId', 'linked prev API serialization/write');
+assertIncludes('backend/kanban.js', 'linkedNextCardId', 'linked next API serialization/write');
+assertIncludes('backend/kanban.js', 'cannot point to the same card', 'self-link validation');
+assertIncludes('backend/kanban.js', 'target card not found', 'target existence validation');
+
+console.log('native tab navigation static checks passed');

--- a/ios-app/app/(tabs)/chat.tsx
+++ b/ios-app/app/(tabs)/chat.tsx
@@ -6,7 +6,7 @@ import WebViewScreen from '../../components/WebViewScreen';
 export default function ChatScreen() {
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
-      <WebViewScreen url="https://eclawbot.com/portal/chat.html" />
+      <WebViewScreen url="https://eclawbot.com/portal/chat.html" tabId="chat" />
     </SafeAreaView>
   );
 }

--- a/ios-app/app/(tabs)/mission.tsx
+++ b/ios-app/app/(tabs)/mission.tsx
@@ -5,7 +5,7 @@ import WebViewScreen from '../../components/WebViewScreen';
 export default function MissionScreen() {
   return (
     <SafeAreaView style={styles.container} edges={['bottom']}>
-      <WebViewScreen url="https://eclawbot.com/portal/mission.html" />
+      <WebViewScreen url="https://eclawbot.com/portal/mission.html" tabId="mission" />
     </SafeAreaView>
   );
 }

--- a/ios-app/components/WebViewScreen.tsx
+++ b/ios-app/components/WebViewScreen.tsx
@@ -1,11 +1,13 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import { View, StyleSheet, ActivityIndicator, BackHandler } from 'react-native';
 import { WebView } from 'react-native-webview';
 import * as Linking from 'expo-linking';
+import { router } from 'expo-router';
 import { useAuthStore } from '../store/authStore';
 
 interface WebViewScreenProps {
   url: string;
+  tabId?: 'chat' | 'mission' | 'home' | 'cards' | 'settings';
 }
 
 // Short-term chrome-hide for #1770 — the full native rewrite is a separate
@@ -36,7 +38,8 @@ const CHROME_HIDE_CSS = `
   }
 `;
 
-const INJECTED_JS = `
+function buildInjectedJs(tabId?: string) {
+  return `
 (function() {
   try {
     // Block AI chat widget in app WebView (same as Android EClawAndroid UA check)
@@ -71,14 +74,104 @@ const INJECTED_JS = `
       window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'auth-diag-error', err: String(e) }));
     }
   }
+  try {
+    window.EClawNativeNav = {
+      navigate: function(intent) {
+        if (window.ReactNativeWebView && window.ReactNativeWebView.postMessage) {
+          window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'eclaw:navigate-tab', intent: intent || {} }));
+          return true;
+        }
+        return false;
+      }
+    };
+    if (window.ReactNativeWebView && window.ReactNativeWebView.postMessage) {
+      window.ReactNativeWebView.postMessage(JSON.stringify({ type: 'eclaw:webview-ready', tabId: ${JSON.stringify(tabId || null)}, href: String(window.location.href || '') }));
+    }
+  } catch (_) {}
 })();
 true;
 `;
+}
 
-export default function WebViewScreen({ url }: WebViewScreenProps) {
+type NativeNavIntent = {
+  targetTab?: 'chat' | 'mission';
+  target?: 'thread' | 'message' | 'card' | 'quote';
+  threadId?: string;
+  messageId?: string;
+  cardId?: string;
+  quote?: { source?: string; title?: string; excerpt?: string };
+};
+
+type RegisteredWebView = { ref: React.RefObject<WebView | null>; ready: boolean };
+
+const registeredWebViews: Partial<Record<string, RegisteredWebView>> = {};
+let pendingIntent: NativeNavIntent | null = null;
+let pendingIntentTimer: ReturnType<typeof setTimeout> | null = null;
+
+function routeForTab(tab: string) {
+  return tab === 'chat' ? '/(tabs)/chat' : tab === 'mission' ? '/(tabs)/mission' : '/(tabs)';
+}
+
+function intentScript(intent: NativeNavIntent) {
+  return `
+    (function(){
+      try {
+        var intent = ${JSON.stringify(intent)};
+        if (typeof window.eclawHandleNativeNavigateIntent === 'function') {
+          window.eclawHandleNativeNavigateIntent(intent);
+        } else if (intent.targetTab === 'chat' && intent.messageId) {
+          window.location.href = '/portal/chat.html?msg=' + encodeURIComponent(intent.messageId);
+        } else if (intent.targetTab === 'mission' && intent.cardId) {
+          window.location.href = '/portal/kanban.html?card=' + encodeURIComponent(intent.cardId) + '#' + encodeURIComponent(intent.cardId);
+        }
+      } catch (e) { console.warn('[EClawNativeNav] consume failed', e); }
+    })();
+    true;
+  `;
+}
+
+function deliverIntent(intent: NativeNavIntent) {
+  const targetTab = intent.targetTab;
+  if (!targetTab) return false;
+  const entry = registeredWebViews[targetTab];
+  if (!entry || !entry.ready || !entry.ref.current) return false;
+  entry.ref.current.injectJavaScript(intentScript(intent));
+  return true;
+}
+
+function queueIntent(intent: NativeNavIntent) {
+  pendingIntent = intent; // last navigation wins; avoids stale multi-tap races
+  if (pendingIntentTimer) clearTimeout(pendingIntentTimer);
+  pendingIntentTimer = setTimeout(() => { pendingIntent = null; pendingIntentTimer = null; }, 15000);
+}
+
+function consumePendingIntent(tabId?: string) {
+  if (!tabId || !pendingIntent || pendingIntent.targetTab !== tabId) return;
+  if (deliverIntent(pendingIntent)) {
+    pendingIntent = null;
+    if (pendingIntentTimer) { clearTimeout(pendingIntentTimer); pendingIntentTimer = null; }
+  }
+}
+
+function handleNativeNavigate(intent: NativeNavIntent) {
+  if (!intent || !intent.targetTab) return;
+  queueIntent(intent);
+  router.navigate(routeForTab(intent.targetTab) as never);
+  setTimeout(() => consumePendingIntent(intent.targetTab), 80);
+}
+
+export default function WebViewScreen({ url, tabId }: WebViewScreenProps) {
   const { deviceId, deviceSecret, authToken } = useAuthStore();
   const webViewRef = useRef<WebView>(null);
   const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!tabId) return;
+    registeredWebViews[tabId] = { ref: webViewRef, ready: false };
+    return () => {
+      if (registeredWebViews[tabId]?.ref === webViewRef) delete registeredWebViews[tabId];
+    };
+  }, [tabId]);
 
   const sep = url.includes('?') ? '&' : '?';
   const qs: string[] = ['embed=1', 'hideChrome=1'];
@@ -93,18 +186,31 @@ export default function WebViewScreen({ url }: WebViewScreenProps) {
         ref={webViewRef}
         source={{ uri: fullUrl }}
         style={styles.webview}
-        injectedJavaScript={INJECTED_JS}
+        injectedJavaScript={buildInjectedJs(tabId)}
         javaScriptEnabled
         domStorageEnabled
         startInLoadingState
         allowsBackForwardNavigationGestures
         webviewDebuggingEnabled={__DEV__}
-        onLoadEnd={() => setLoading(false)}
+        onLoadEnd={() => {
+          setLoading(false);
+          if (tabId && registeredWebViews[tabId]) {
+            registeredWebViews[tabId]!.ready = true;
+            setTimeout(() => consumePendingIntent(tabId), 30);
+          }
+        }}
         onMessage={(event) => {
           // Bridge console.log from WebView to RN logs (visible via Expo Go / Metro)
           try {
             const data = JSON.parse(event.nativeEvent.data);
             console.log('[WebView]', data);
+            if (data && data.type === 'eclaw:webview-ready' && tabId && registeredWebViews[tabId]) {
+              // Handshake observed. The intent is consumed after onLoadEnd so
+              // portal handlers (e.g. eclawHandleNativeNavigateIntent) are installed.
+            }
+            if (data && data.type === 'eclaw:navigate-tab') {
+              handleNativeNavigate(data.intent || {});
+            }
           } catch { /* ignore */ }
         }}
         userAgent="Mozilla/5.0 EClawIOS"


### PR DESCRIPTION
## Summary
PR A for `card_171784b25e8618bd229da7f3`.

- Adds App/WebView native bottom-tab navigation bridge (`eclaw:navigate-tab`) so Mission→Chat and Chat→Mission jumps route through Expo/native tabs instead of pushing foreign routes into the current WebView stack.
- Adds last-intent-wins pending navigation queue with 15s timeout; pending intents are consumed after target WebView `onLoadEnd` so portal handlers are installed before anchor delivery.
- Normalizes chat message anchors to canonical `?msg=<messageId>` and keeps `?his=` as a compatibility alias.
- Fixes Kanban-side `his_` dead-link fallback from `?his=` to `?msg=` and prefers native Chat tab navigation when inside the App WebView.
- Adds Chat→Mission card opening through native Mission tab where available.
- Adds nullable linked task schema/API serialization/write path: `linkedPrevCardId` / `linkedNextCardId` (`linked_prev_card_id` / `linked_next_card_id`). PR B will render chip UI.

## #2 A/B/C requirements

### A. linked schema write path
Handled in PR A:
- `kanban_schema.sql` + migration add `linked_prev_card_id`, `linked_next_card_id`.
- `serializeCard()` returns `linkedPrevCardId`, `linkedNextCardId`.
- `PUT /api/mission/card/:id` accepts optional `linkedPrevCardId` / `linkedNextCardId`.
- Server validation: target must exist in same device and cannot point to self. Empty/null clears the field.
- No setting UI in PR A; PR B or a follow-up can expose controls.

### B. `?his=` dead-link
Handled in PR A:
- Kanban stub now routes history chips to Chat with `?msg=`.
- Chat deep-link parser accepts `?his=` as a compatibility alias, but canonical output is `?msg=`.

### C. pending-intent race / timeout
Handled in PR A:
- Native side stores one pending navigate intent only; rapid consecutive intents are last-intent-wins to avoid stale jumps.
- Target tab is selected through Expo Router native tab route.
- Intent delivery waits until target WebView `onLoadEnd`; if the target WebView is already mounted/ready, it focuses and injects without reload.
- Pending intent auto-clears after 15s if target page never becomes ready (e.g. portal 502 / load failure), preventing unbounded queue buildup.

## Validation
- `node --check backend/kanban.js` PASS
- `node --check backend/scripts/check-native-tab-navigation.js` PASS
- `node backend/scripts/check-native-tab-navigation.js` PASS
- Inline script syntax extraction + `node --check` PASS for:
  - `backend/public/portal/chat.html`
  - `backend/public/portal/kanban.html`
- `git diff --check` PASS
- `cd ios-app && npm ci --include=dev` PASS (existing warnings/vulns only)
- `cd ios-app && npx tsc --noEmit --pretty false` still reports pre-existing baseline TS errors (SafeAreaView `edges`, wallet IAP product fields, notification behavior, entity store types). No new `WebViewScreen` / changed-file-specific TS errors were reported.

## E2E expected for #2
- iOS WebView + Android WebView + Web: Mission→Chat and Chat→Mission.
- Message-specific anchor scroll/highlight via `messageId` / `?msg=`.
- Stack sanity: source tab state is preserved after cross-tab jump/back.
- Linked prev/next UI is not in this PR; only schema/API write path is included for PR B.

## Governance
#1 authored. #2 supervisor review + merge required; no self-merge.