### PR TITLE
feat(portal/nagoya): parking shortcut buttons on itinerary rows

### DIFF
--- a/backend/public/portal/nagoya-trip-20260513/index.html
+++ b/backend/public/portal/nagoya-trip-20260513/index.html
@@ -569,6 +569,36 @@
     color: var(--gold-deep);
   }
   .map-link:hover { color: var(--gold-deep); }
+
+  /* ===== Parking shortcut button (next to each place name) ===== */
+  .parking-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 3px;
+    margin-left: 8px;
+    padding: 1px 9px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--cream);
+    background: var(--forest);
+    border-radius: var(--radius);
+    text-decoration: none;
+    white-space: nowrap;
+    vertical-align: 1px;
+    transition: background .15s, transform .12s, color .15s;
+    line-height: 1.5;
+  }
+  .parking-btn::after { content: none; }
+  .parking-btn:hover {
+    background: var(--gold);
+    color: var(--forest-deep);
+    transform: translateY(-1px);
+  }
+  .parking-btn:active { transform: translateY(0); }
+  @media (max-width: 720px) {
+    .parking-btn { font-size: 11px; padding: 1px 7px; margin-left: 6px; }
+  }
+
   img.zoomable-img {
     cursor: zoom-in;
     transition: filter .16s ease, transform .16s ease;
@@ -1123,6 +1153,7 @@
     ["AEON Mall Tokoname (常滑)", "イオンモール常滑 2-20-3 Rinku-cho Tokoname Aichi"],
     ["AEON Mall Tokoname", "イオンモール常滑 2-20-3 Rinku-cho Tokoname Aichi"],
     ["AEON Mall 常滑", "イオンモール常滑 2-20-3 Rinku-cho Tokoname Aichi"],
+    ["AEON Mall", "イオンモール常滑 2-20-3 Rinku-cho Tokoname Aichi"],
     ["FUSE COFFEE nagoya", "FUSE COFFEE nagoya 〒460-0003 愛知県名古屋市中区錦2-8-28"],
     ["Masago", "Masago 名古屋 朝食"],
     ["名古屋港水族館", "名古屋港水族館 3-1 Minatomachi Minato-ku Nagoya Aichi"],
@@ -1173,6 +1204,26 @@
   const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const pattern = new RegExp(sortedTargets.map(t => esc(t.label)).join("|"), "g");
   const lookup = new Map(sortedTargets.map(t => [t.label, t]));
+
+  // Inject 🅿️ parking shortcut next to each itinerary place name.
+  // Matches the longest label from mapTargets so transit/airport/check-in rows
+  // (which aren't in mapTargets) automatically get no button.
+  document.querySelectorAll(".schedule .item .place").forEach(placeEl => {
+    if (placeEl.querySelector(".parking-btn")) return;
+    const text = placeEl.textContent;
+    const matched = sortedTargets.find(t => text.indexOf(t.label) !== -1);
+    if (!matched) return;
+    const btn = document.createElement("a");
+    btn.className = "parking-btn";
+    btn.href = mapUrl(matched.query + " 駐車場");
+    btn.target = "_blank";
+    btn.rel = "noopener";
+    btn.title = "找 " + matched.label + " 附近的停車場";
+    btn.setAttribute("aria-label", "在 Google 地圖搜尋 " + matched.label + " 附近的停車場");
+    btn.textContent = "🅿️ 停車";
+    placeEl.appendChild(btn);
+  });
+
   const roots = document.querySelectorAll(".hero-text, main, footer.footer");
   roots.forEach(root => {
     const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {


### PR DESCRIPTION
## Summary
Adds a 🅿️ **停車** button next to every attraction / restaurant in the Nagoya 5天4夜 itinerary table. Click → Google Maps search for *"<place> 駐車場"* in a new tab (driving + parking discovery in one tap).

Reuses the existing `mapTargets` curated list (58 places + new AEON Mall alias), so transit / rental-desk / check-in rows (not in `mapTargets`) automatically get no button — keeps the visual gates clean.

## Behavior
- Desktop: forest-green pill, hover → gold, micro-elevation.
- Mobile (≤720px): font 11px, padding tighter, margin tighter.
- Coexists with auto-linkify (TreeWalker rejects `<a>` so no recursion).

## Test plan
- [x] Playwright headless render → 27 parking buttons in DOM, 127 existing map-links unchanged
- [x] No JS errors / no console errors (`page.on('pageerror')` empty)
- [x] Sample URLs encoded correctly e.g. `https://www.google.com/maps/search/?api=1&query=ni%3Ano%20...%20%E9%A7%90%E8%BB%8A%E5%A0%B4`
- [x] Mobile 414×800 viewport screenshot — buttons sized down, no overflow
- [x] Hover state visible on desktop screenshot
- [ ] Hank visual sanity check after prod CF cache invalidates (≤2 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)