### PR TITLE
fix(chat): atomic-load target bar — no partial render before contacts

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3687,7 +3687,7 @@
                         entityIds: boundEntities.map(e => e.entityId)
                     }).then(() => {
                         window.AvatarPetdx.autoMount();
-                        renderTargetBar();
+                        if (contactsLoaded) renderTargetBar();
                     });
                 }
                 boundEntities.forEach(e => {
@@ -3710,10 +3710,11 @@
                 if (currentUser.deviceId) {
                     myPublicCodeMap[currentUser.deviceId] = { entityId: -1, label: 'You' };
                 }
-                renderTargetBar();
                 loadContacts();
             } catch (e) {
                 console.warn('Failed to load entities:', e.message);
+                contactsLoaded = true;
+                renderTargetBar();
             }
         }
 
@@ -3739,6 +3740,8 @@
                 renderTargetBar();
             } catch (e) {
                 console.warn('Failed to load contacts:', e.message);
+                contactsLoaded = true;
+                renderTargetBar();
             }
         }
 


### PR DESCRIPTION
## Summary
- Eliminate the "+2 → +7" race in chat "傳送給" target bar
- Bound entities + contacts now both resolve before first render
- Loading hint (already exists) stays visible until both done; no partial-selectable window

## Root cause (verified)
Three async paths each called `renderTargetBar()`:
1. `loadBoundEntities()` success → render with entities only (no contacts)
2. `AvatarPetdx.preload.then()` → render whenever it resolves (race vs contacts)
3. `loadContacts()` success → full render

Users saw a partial bar (≈ #1#2 + maybe ▲+0~2) for the first 5-10s until path #3 fired. Hank reported: 「傳送對象只能選 #1#2 展開數字也顯示 +2 只能等一陣子 才會出現正常 +7」.

## Repro evidence (U37, Android emu v1.0.84 / versionCode 92, card `card_eb86031012e24878a15b08e9`)
- shot0_loading: chat tab entering, "傳送給:" row empty
- shot1_early: "傳送給: ✓ 免費版 (#0)" — only 1 entity visible, no ▲+N
- shot2_settled (≈9s): "傳送給: ✓ 免費版 (#0) ▲+8" — full 9 entities

## Fix
- Drop the premature `renderTargetBar()` inside `loadBoundEntities()` success
- Gate `AvatarPetdx.preload.then()` render behind `contactsLoaded`
- Catch blocks now `contactsLoaded = true` + `renderTargetBar()` so load failures don't leave an infinite spinner

## E2E plan
Post-merge: U37 reload chat tab in Android emu. Expected: row stays on loading hint until ~1-3s after contacts resolve, then renders all chips in one pass. No "+2 → +7" delay window.

Companion PRs:
- #2830 (already merged): compact 20px avatar — cosmetic part of same Hank report
- Separate card `card_f317492524fa68871e2b31a1`: Android native nav bridge for task→chat tap

Refs: card_eb86031012e24878a15b08e9

🤖 Generated with [Claude Code](https://claude.com/claude-code)