### PR TITLE
fix(chat): stop chat.html bouncing to dashboard via /api/rental/health-status 401 race

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3826,7 +3826,7 @@
                 const qs = new URLSearchParams({ t: String(Date.now()) });
                 if (mock) qs.set('mockStatus', mock);
                 if (mock && ownerEntityId !== undefined && ownerEntityId !== null) qs.set('ownerEntityId', String(ownerEntityId));
-                const data = await apiCall('GET', `/api/rental/health-status?${qs.toString()}`);
+                const data = await apiCall('GET', `/api/rental/health-status?${qs.toString()}`, null, { skip401Redirect: true });
                 rentalHealthByEntity.clear();
                 if (data && data.success && Array.isArray(data.statuses)) {
                     data.statuses.forEach(h => {


### PR DESCRIPTION
## Summary
- 修掉 [card_29ae1bf3c95f42e5fef49249](https://eclawbot.com/portal/kanban.html?card=card_29ae1bf3c95f42e5fef49249) (P0, E2E-found): 進入 `/portal/chat.html` 會被神秘導去 `/portal/dashboard.html`。
- 根因：`loadRentalHealthStatus()` 用裸 `apiCall` 打 `/api/rental/health-status`；當 session 是 device-only（userId=null）會 401，`apiCall` 內建的 401-handler **同步**執行 `window.location.href='index.html'`，再才丟 error。chat.html 的 try/catch 來不及救——警告寫出來時頁面已經在離開，`index.html` 看到 session 還活著就再轉去 `dashboard.html`。
- 修法：照 `nav.js:139` / `auth.js:37` 同樣的 `{ skip401Redirect: true }` 旗標，讓 401 只丟 throw 不亂跳。`try/catch` 本來就只是想記 warn + 留空 `rentalHealthByEntity`。

## Repro (prod)
```
Playwright → https://eclawbot.com/portal/chat.html?deviceId=…&deviceSecret=…
console: [CHAT_DEBUG] checkAuth result: ...
         Failed to load rental health status: unauthenticated     ← 401 +redirect 同時發生
         [DOM] Password field is not contained in a form @ index.html:0   ← 已經跑到 index
document.location → /portal/dashboard.html
```
device-only session（含 `BROADCAST_TEST_DEVICE`、未綁 user 的 WebView shell）必中；有完整 email 登入的 user 暫時看不到，但同 race 隨時可能跳出。

## Test plan
- [x] Reproduced on prod with BROADCAST_TEST_DEVICE (`device-only` session) → silent redirect chat→dashboard
- [ ] Post-merge Railway preview / staging: 同 URL 應停在 chat.html，控制台只剩 warn，不再有 password-field@index.html
- [ ] Full-login user smoke: 進 chat → 不應退化（unchanged path）
- [ ] No new console errors on chat.html boot

## Risk
- 1 行 diff，僅加 `skip401Redirect: true`，等同 `nav.js:139` 既有用法。
- `loadRentalHealthStatus` 的 catch block 不變，UI 在 401 時依然降級成空 `rentalHealthByEntity`（target bar 不顯示 health pill），不會破壞 chat 主流程。

## Card status
- card_29ae1bf3c95f42e5fef49249 → in_review pending this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)