### PR TITLE
chore: daily audit 2026-05-19 — sitemap, npm fix, CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1039,6 +1039,17 @@ curl "https://eclawbot.com/api/device-telemetry?deviceId=ID&deviceSecret=SECRET&
 - **Growth Tracking (v1.1168)**: `growth.js` module for admin bot growth metrics; static serving fix
 - **UIUX Audit Script Alignment (v1.1172)**: QA/UIUX audit test scripts aligned with current portal contracts
 
+### Recent Fixes (v1.1172.x+, 2026-05-14 – 2026-05-17)
+
+- **Chat 401 Redirect Fix (PR #2833)**: `loadRentalHealthStatus()` in chat.html now uses silent fetch instead of `apiCall()` to prevent 401 redirects bouncing device-only sessions to dashboard
+- **Chat Target Bar Atomic Load (PR #2831)**: Await contacts before first render to prevent partial target bar display
+- **Chat Compact Avatar (PR #2830)**: 20px avatar in target bar for App WebView (only shows entity #1 #2)
+- **Security: sanitize-html XSS + protobufjs + exam.html (PR #2829)**: P0 sanitize-html XSS patch, P1 protobufjs prototype pollution, exam.html innerHTML escape
+- **Kanban Comments Pagination (PR #2816)**: GET card returns latest 50 comments; comments endpoint exposes `total` count
+- **Platform Stats Fix (PR #2818)**: Fix platform-stats 500 error; entity/lookup publicCode alias support
+- **Task Chip UX (PR #2825)**: Group task chip actions in portal
+- **App Chat-Mission Navigation (PR #2824)**: Route chat mission jumps through native Android tabs
+
 ---
 
 ## Test Coverage Summary

--- a/backend/public/sitemap.xml
+++ b/backend/public/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://eclawbot.com/</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/portal/</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/api/docs</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/.well-known/agent.json</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/enterprise</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -38,37 +38,37 @@
   </url>
   <url>
     <loc>https://eclawbot.com/llms.txt</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/arena/</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/portal/community.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/portal/compare.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/promo.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/promo-meta.html</loc>
-    <lastmod>2026-05-11</lastmod>
+    <lastmod>2026-05-19</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,9 +111,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
-      "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -624,12 +624,12 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "9.0.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-      "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
       "license": "ISC",
       "dependencies": {
-        "brace-expansion": "^2.0.1"
+        "brace-expansion": "^2.0.2"
       },
       "engines": {
         "node": ">=16 || 14 >=14.17"


### PR DESCRIPTION
## Summary
- Update sitemap lastmod dates to 2026-05-19
- Fix root npm vulnerabilities (brace-expansion ReDoS, minimatch ReDoS)
- Document recent fixes (PRs #2816–#2833) in CLAUDE.md

## Self-Review Checklist
✅ Logic trace — trivial metadata changes
✅ Test coverage — 206 suites / 2995 tests pass
⚠️ NO-OP return shape — no API changes
⚠️ NO-OP what-this-does-NOT-fix — no behavior changes
✅ Security — npm vulnerabilities fixed
⚠️ NO-OP /api/help — no new endpoints
✅ Related docs — CLAUDE.md updated
✅ i18n audit — all keys resolve
⚠️ NO-OP info page — no new features
⚠️ NO-OP debug endpoint — no bugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)