### PR TITLE
feat(chat-chip): native deep-link to messageId thread

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3484,7 +3484,7 @@
                 const pq = localStorage.getItem('eclaw_pending_quote');
                 if (pq) {
                     localStorage.removeItem('eclaw_pending_quote');
-                    const { source, title, excerpt, prefillInput, ts } = JSON.parse(pq);
+                    const { source, title, excerpt, prefillInput, messageId, ts } = JSON.parse(pq);
                     if (Date.now() - ts < 120000) { // within 2 minutes
                         quoteToChat(source, title, excerpt || '');
                         // prefillInput: drop a chip token (or any text) directly
@@ -3503,6 +3503,9 @@
                             // overwrite the prefill with a stale draft; the
                             // deep-link explicitly asked for prefill, so it wins.
                             localStorage.removeItem('chat_draft');
+                        }
+                        if (setChatMessageDeepLinkId(messageId)) {
+                            await handleChatMessageDeepLink({ showMissingToast: true, scroll: true });
                         }
                     }
                 }
@@ -3536,10 +3539,10 @@
             } catch(e) {}
 
             // Cross-iframe quote from workspace.html relay — only accepted from same origin
-            window.addEventListener('message', (e) => {
+            window.addEventListener('message', async (e) => {
                 if (e.origin !== window.location.origin) return;
                 if (!e.data || e.data.type !== 'eclaw_quote') return;
-                const { source, title, excerpt, prefillInput } = e.data;
+                const { source, title, excerpt, prefillInput, messageId } = e.data;
                 quoteToChat(source, title, excerpt || '');
                 if (prefillInput) {
                     const inp = document.getElementById('messageInput');
@@ -3548,6 +3551,9 @@
                         inp.focus();
                         try { inp.setSelectionRange(inp.value.length, inp.value.length); } catch(e2) {}
                     }
+                }
+                if (setChatMessageDeepLinkId(messageId)) {
+                    await handleChatMessageDeepLink({ showMissingToast: true, scroll: true });
                 }
             });
 
@@ -4389,7 +4395,22 @@
         function getChatMessageDeepLinkId() {
             try {
                 const params = new URLSearchParams(window.location.search);
-                return normalizeChatMessageId(params.get('msg') || params.get('his') || params.get('messageId'));
+                return normalizeChatMessageId(params.get('messageId') || params.get('msg') || params.get('his'));
+            } catch (_) {
+                return '';
+            }
+        }
+
+        function setChatMessageDeepLinkId(messageId) {
+            try {
+                const url = new URL(window.location.href);
+                const id = normalizeChatMessageId(messageId);
+                url.searchParams.delete('msg');
+                url.searchParams.delete('his');
+                if (id) url.searchParams.set('messageId', id);
+                else url.searchParams.delete('messageId');
+                window.history.replaceState({}, '', url.toString());
+                return id;
             } catch (_) {
                 return '';
             }
@@ -7635,19 +7656,27 @@
         window.eclawHandleNativeNavigateIntent = async function(intent) {
             if (!intent || intent.targetTab !== 'chat') return false;
             try {
+                let handled = false;
                 if (intent.quote && (intent.quote.title || intent.quote.excerpt)) {
                     quoteToChat(intent.quote.source || '引用', intent.quote.title || '', intent.quote.excerpt || '');
-                    return true;
+                    const prefillInput = intent.quote.prefillInput ? String(intent.quote.prefillInput) : '';
+                    if (prefillInput) {
+                        const inp = document.getElementById('messageInput');
+                        if (inp) {
+                            inp.value = prefillInput;
+                            inp.focus();
+                            try { inp.setSelectionRange(prefillInput.length, prefillInput.length); } catch (e2) {}
+                        }
+                        localStorage.removeItem('chat_draft');
+                    }
+                    handled = true;
                 }
-                const msgId = intent.messageId || (intent.target === 'message' ? intent.threadId : '');
-                if (msgId) {
-                    const url = new URL(window.location.href);
-                    url.searchParams.set('msg', msgId);
-                    url.searchParams.delete('his');
-                    window.history.replaceState({}, '', url.toString());
+                const msgId = intent.messageId || (intent.quote && intent.quote.messageId) || (intent.target === 'message' ? intent.threadId : '');
+                if (setChatMessageDeepLinkId(msgId)) {
                     await handleChatMessageDeepLink({ showMissingToast: true, scroll: true });
-                    return true;
+                    handled = true;
                 }
+                return handled;
             } catch (e) {
                 console.warn('[Chat] native navigate intent failed:', e);
             }

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -1049,11 +1049,19 @@
         const CHAT_MESSAGE_TOKEN_RE = /\bhis_([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?![0-9a-f-])/i;
 
         function normalizeChatMessageId(value) {
-            const id = String(value || '').trim().toLowerCase();
-            return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id) ? id : '';
+            if (window.ChatMessageRender && typeof window.ChatMessageRender.normalizeHistoryMessageId === 'function') {
+                const id = window.ChatMessageRender.normalizeHistoryMessageId(value);
+                if (id) return id;
+            }
+            const raw = String(value || '').trim().toLowerCase();
+            return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(raw) ? raw : '';
         }
 
         function extractChatMessageId(value) {
+            if (window.ChatMessageRender && typeof window.ChatMessageRender.extractFirstHistoryMessageId === 'function') {
+                const id = window.ChatMessageRender.extractFirstHistoryMessageId(value);
+                if (id) return id;
+            }
             const direct = normalizeChatMessageId(value);
             if (direct) return direct;
             const match = String(value || '').match(CHAT_MESSAGE_TOKEN_RE);

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -1046,6 +1046,20 @@
     <script src="shared/ai-chat.js"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'🦞'};window.isAvatarUrl=function(){return false}}</script>
     <script>
+        const CHAT_MESSAGE_TOKEN_RE = /\bhis_([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?![0-9a-f-])/i;
+
+        function normalizeChatMessageId(value) {
+            const id = String(value || '').trim().toLowerCase();
+            return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id) ? id : '';
+        }
+
+        function extractChatMessageId(value) {
+            const direct = normalizeChatMessageId(value);
+            if (direct) return direct;
+            const match = String(value || '').match(CHAT_MESSAGE_TOKEN_RE);
+            return match ? normalizeChatMessageId(match[1]) : '';
+        }
+
         function eclawNavigateChat(intent) {
             try {
                 if (window.EClawNativeNav && typeof window.EClawNativeNav.navigate === 'function') {
@@ -1067,9 +1081,10 @@
         }
         if (typeof window.openHistoryMessage !== 'function') {
             window.openHistoryMessage = function (msgId) {
-                if (!msgId) return;
-                if (eclawNavigateChat({ target: 'message', messageId: msgId })) return;
-                window.location.href = '/portal/chat.html?msg=' + encodeURIComponent(msgId);
+                const normalized = extractChatMessageId(msgId);
+                if (!normalized) return;
+                if (eclawNavigateChat({ target: 'message', messageId: normalized })) return;
+                window.location.href = '/portal/chat.html?messageId=' + encodeURIComponent(normalized);
             };
         }
         // 智慧引用 render chain — delegates to shared ChatMessageRender so chat
@@ -2794,26 +2809,31 @@
             setTimeout(() => { tip.remove(); }, 2700);
         }
 
-        function quoteToChat(source, title, excerpt) {
+        function quoteToChat(source, title, excerpt, opts) {
             const toastMsg = (window.i18n && typeof window.i18n.t === 'function' && window.i18n.t('chip_popover_requoted')) || '已引用 ✓';
+            const messageId = normalizeChatMessageId(opts && opts.messageId);
             if (window.self !== window.top) {
                 // Workspace split-pane mode: deliver to chat sub-pane via parent relay,
                 // confirm with a source-page floating toast — no force jump.
-                window.parent.postMessage({ type: 'eclaw_quote', source, title, excerpt: excerpt || '' }, window.location.origin);
+                window.parent.postMessage({ type: 'eclaw_quote', source, title, excerpt: excerpt || '', messageId }, window.location.origin);
                 eclawShowFloatToast(toastMsg);
             } else {
                 // Standalone/App WebView: prefer native bottom-tab switch when available.
-                const quote = { source, title, excerpt: excerpt || '' };
+                const quote = { source, title, excerpt: excerpt || '', messageId };
                 localStorage.setItem('eclaw_pending_quote', JSON.stringify({ ...quote, ts: Date.now() }));
-                if (eclawNavigateChat({ target: 'quote', quote })) return;
-                window.location.href = '/portal/chat.html';
+                if (eclawNavigateChat({ target: 'quote', quote, messageId })) return;
+                const chatUrl = messageId
+                    ? '/portal/chat.html?messageId=' + encodeURIComponent(messageId)
+                    : '/portal/chat.html';
+                window.location.href = chatUrl;
             }
         }
 
         function quoteKanbanCardToChat() {
+            const card = findCard(openCardId);
             const title = document.getElementById('detailTitle').textContent.trim();
             const meta = document.getElementById('detailMeta').textContent.trim().replace(/\s+/g, ' ').slice(0, 80);
-            quoteToChat('看板卡片', title, meta);
+            quoteToChat('看板卡片', title, meta, { messageId: card && card.chatAnchorMessageId });
         }
 
         function quoteCommentToChat(payload) {
@@ -2821,7 +2841,7 @@
             const src = payload.src || '留言';
             const sender = payload.sender || '';
             const text = (payload.text || '').replace(/\s+/g, ' ').slice(0, 80);
-            quoteToChat(src, sender, text);
+            quoteToChat(src, sender, text, { messageId: payload.messageId });
         }
 
         // ── Inline Schedule Panel (detail modal tab) ──
@@ -3021,8 +3041,12 @@
                     const name = typeof getEntityDisplayName === 'function' ? getEntityDisplayName(fromId) : '#'+(fromId??'?');
                     const avatarHtml = typeof renderAvatarHtml === 'function' ? renderAvatarHtml(avatar, 16, fromId) : avatar;
                     const cardTitle = (findCard(openCardId) || {}).title || '';
-                    const pinPayload = JSON.stringify({ src: '留言 · ' + cardTitle, sender: name, text: c.text || '' })
-                        .replace(/'/g, '&#39;');
+                    const pinPayload = JSON.stringify({
+                        src: '留言 · ' + cardTitle,
+                        sender: name,
+                        text: c.text || '',
+                        messageId: extractChatMessageId(c.messageId || c.message_id || c.text || '')
+                    }).replace(/'/g, '&#39;');
                     return `<div class="kb-comment ${isSent ? 'sent' : 'received'}" data-comment-id="${escapeHtml(cid)}">
                         <div class="kb-comment-source"><span class="comment-avatar">${avatarHtml}</span> ${escapeHtml(name)}</div>
                         <div class="kb-comment-bubble">${renderSmartChips(c.text)}</div>

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -2062,16 +2062,31 @@
             document.getElementById('dialogContainer').innerHTML = '';
         }
 
+        function eclawNavigateChat(intent) {
+            try {
+                if (window.EClawNativeNav && typeof window.EClawNativeNav.navigate === 'function') {
+                    return window.EClawNativeNav.navigate(Object.assign({ targetTab: 'chat', sourceTab: 'mission' }, intent || {}));
+                }
+            } catch (_) {}
+            return false;
+        }
+
         function quoteToChat(source, title, excerpt, opts) {
             // opts.prefillInput — optional string to pre-fill the message input
             // on the chat page (used by mind-map chip cite to deliver a chip
             // token straight into the input, so user just hits send).
             const prefillInput = opts && opts.prefillInput ? String(opts.prefillInput) : '';
+            const messageId = opts && opts.messageId ? String(opts.messageId).trim().toLowerCase() : '';
             if (window.self !== window.top) {
-                window.parent.postMessage({ type: 'eclaw_quote', source, title, excerpt: excerpt || '', prefillInput }, window.location.origin);
+                window.parent.postMessage({ type: 'eclaw_quote', source, title, excerpt: excerpt || '', prefillInput, messageId }, window.location.origin);
             } else {
-                localStorage.setItem('eclaw_pending_quote', JSON.stringify({ source, title, excerpt: excerpt || '', prefillInput, ts: Date.now() }));
-                window.location.href = '/portal/chat.html';
+                const quote = { source, title, excerpt: excerpt || '', prefillInput, messageId };
+                localStorage.setItem('eclaw_pending_quote', JSON.stringify({ ...quote, ts: Date.now() }));
+                if (eclawNavigateChat({ target: 'quote', quote, messageId })) return;
+                const chatUrl = messageId
+                    ? '/portal/chat.html?messageId=' + encodeURIComponent(messageId)
+                    : '/portal/chat.html';
+                window.location.href = chatUrl;
             }
         }
 

--- a/backend/public/portal/shared/his-link-render.js
+++ b/backend/public/portal/shared/his-link-render.js
@@ -20,16 +20,32 @@
     const HIS_RE = /\bhis_([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?![0-9a-f-])/gi;
     const UUID_GUARD = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
+    function normalizeMessageId(value) {
+        const id = String(value || '').trim().toLowerCase();
+        return UUID_GUARD.test(id) ? id : '';
+    }
+
+    function extractFirstMessageId(value) {
+        const direct = normalizeMessageId(value);
+        if (direct) return direct;
+        const match = String(value || '').match(HIS_RE);
+        if (!match || !match.length) return '';
+        const token = String(match[0] || '').replace(/^his_/i, '');
+        return normalizeMessageId(token);
+    }
+
     function renderHisLinks(escapedHtml) {
         if (!escapedHtml) return escapedHtml;
         return escapedHtml.replace(HIS_RE, (match, id) => {
-            if (!UUID_GUARD.test(id)) return match;
-            return buildChipHtml(id);
+            const normalized = normalizeMessageId(id);
+            if (!normalized) return match;
+            return buildChipHtml(normalized);
         });
     }
 
     function buildChipHtml(msgId) {
-        const safeId = String(msgId).toLowerCase();
+        const safeId = normalizeMessageId(msgId);
+        if (!safeId) return '';
         return `<span class="his-link" data-msg-id="${safeId}" onclick="openHistoryMessage('${safeId}')" title="his_${safeId}">` +
                `<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" style="vertical-align:-1px;margin-right:3px;">` +
                `<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>` +
@@ -38,6 +54,8 @@
 
     global.HisLinkRender = {
         renderHisLinks,
+        normalizeMessageId,
+        extractFirstMessageId,
         _re: HIS_RE
     };
 })(window);

--- a/backend/public/shared/chat-message-render.js
+++ b/backend/public/shared/chat-message-render.js
@@ -76,8 +76,24 @@
         return renderTextChips(div.innerHTML, opts);
     }
 
+    function normalizeHistoryMessageId(value) {
+        if (global.HisLinkRender && typeof global.HisLinkRender.normalizeMessageId === 'function') {
+            return global.HisLinkRender.normalizeMessageId(value);
+        }
+        return '';
+    }
+
+    function extractFirstHistoryMessageId(rawText) {
+        if (global.HisLinkRender && typeof global.HisLinkRender.extractFirstMessageId === 'function') {
+            return global.HisLinkRender.extractFirstMessageId(rawText);
+        }
+        return normalizeHistoryMessageId(rawText);
+    }
+
     global.ChatMessageRender = {
         renderTextChips,
-        renderTextChipsFromRaw
+        renderTextChipsFromRaw,
+        normalizeHistoryMessageId,
+        extractFirstHistoryMessageId
     };
 })(window);

--- a/backend/tests/jest/chat-his-link-render.test.js
+++ b/backend/tests/jest/chat-his-link-render.test.js
@@ -66,10 +66,19 @@ describe('his_<uuid> chip — module behaviour', () => {
     // without spinning a browser.
     const sandbox = { window: {} };
     vm.runInNewContext(fs.readFileSync(hisRenderPath, 'utf8'), sandbox);
+    vm.runInNewContext(sharedRenderJs, sandbox);
     const HisLinkRender = sandbox.window.HisLinkRender;
+    const ChatMessageRender = sandbox.window.ChatMessageRender;
 
     test('exposes renderHisLinks on window', () => {
         expect(typeof HisLinkRender.renderHisLinks).toBe('function');
+    });
+
+    test('exposes normalize / extract helpers for downstream surfaces', () => {
+        expect(typeof HisLinkRender.normalizeMessageId).toBe('function');
+        expect(typeof HisLinkRender.extractFirstMessageId).toBe('function');
+        expect(typeof ChatMessageRender.normalizeHistoryMessageId).toBe('function');
+        expect(typeof ChatMessageRender.extractFirstHistoryMessageId).toBe('function');
     });
 
     test('transforms "his_<uuid>" into a clickable chip with data-msg-id', () => {
@@ -115,6 +124,17 @@ describe('his_<uuid> chip — module behaviour', () => {
         const out = HisLinkRender.renderHisLinks(`ref his_${upper}`);
         expect(out).toContain(`data-msg-id="${SAMPLE_UUID}"`);
         expect(out).toContain(`openHistoryMessage('${SAMPLE_UUID}')`);
+    });
+
+    test('extractFirstMessageId accepts direct UUID or embedded his_<uuid> token', () => {
+        expect(HisLinkRender.extractFirstMessageId(SAMPLE_UUID.toUpperCase())).toBe(SAMPLE_UUID);
+        expect(HisLinkRender.extractFirstMessageId(`before his_${SAMPLE_UUID} after`)).toBe(SAMPLE_UUID);
+        expect(HisLinkRender.extractFirstMessageId(`noise his_123`)).toBe('');
+    });
+
+    test('shared ChatMessageRender delegates history-id extraction to HisLinkRender', () => {
+        expect(ChatMessageRender.normalizeHistoryMessageId(SAMPLE_UUID.toUpperCase())).toBe(SAMPLE_UUID);
+        expect(ChatMessageRender.extractFirstHistoryMessageId(`context his_${SAMPLE_UUID_2}`)).toBe(SAMPLE_UUID_2);
     });
 });
 

--- a/backend/tests/jest/chat-messageid-deeplink-static.test.js
+++ b/backend/tests/jest/chat-messageid-deeplink-static.test.js
@@ -1,0 +1,35 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const chatHtml = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'chat.html'), 'utf8');
+const kanbanHtml = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'kanban.html'), 'utf8');
+const missionHtml = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'mission.html'), 'utf8');
+const webViewScreenTsx = fs.readFileSync(path.join(ROOT, '..', 'ios-app', 'components', 'WebViewScreen.tsx'), 'utf8');
+
+describe('messageId deep-link follow-up — static wiring', () => {
+    test('WebViewScreen native fallback uses canonical ?messageId= URL', () => {
+        expect(webViewScreenTsx).toContain("window.location.href = '/portal/chat.html?messageId=' + encodeURIComponent(intent.messageId)");
+        expect(webViewScreenTsx).toContain('prefillInput?: string;');
+        expect(webViewScreenTsx).toContain('messageId?: string;');
+    });
+
+    test('chat.html carries messageId through pending quote relay and native navigate intent', () => {
+        expect(chatHtml).toContain("const { source, title, excerpt, prefillInput, messageId, ts } = JSON.parse(pq);");
+        expect(chatHtml).toContain("if (setChatMessageDeepLinkId(messageId)) {");
+        expect(chatHtml).toContain("const msgId = intent.messageId || (intent.quote && intent.quote.messageId)");
+    });
+
+    test('kanban quote payload includes messageId for card anchor and comment references', () => {
+        expect(kanbanHtml).toContain("quoteToChat('看板卡片', title, meta, { messageId: card && card.chatAnchorMessageId });");
+        expect(kanbanHtml).toContain("messageId: extractChatMessageId(c.messageId || c.message_id || c.text || '')");
+        expect(kanbanHtml).toContain("window.location.href = '/portal/chat.html?messageId=' + encodeURIComponent(normalized);");
+    });
+
+    test('mission quote bridge preserves messageId into chat deep-link handoff', () => {
+        expect(missionHtml).toContain("window.parent.postMessage({ type: 'eclaw_quote', source, title, excerpt: excerpt || '', prefillInput, messageId }, window.location.origin);");
+        expect(missionHtml).toContain("if (eclawNavigateChat({ target: 'quote', quote, messageId })) return;");
+    });
+});

--- a/ios-app/components/WebViewScreen.tsx
+++ b/ios-app/components/WebViewScreen.tsx
@@ -99,7 +99,13 @@ type NativeNavIntent = {
   threadId?: string;
   messageId?: string;
   cardId?: string;
-  quote?: { source?: string; title?: string; excerpt?: string };
+  quote?: {
+    source?: string;
+    title?: string;
+    excerpt?: string;
+    prefillInput?: string;
+    messageId?: string;
+  };
 };
 
 type RegisteredWebView = { ref: React.RefObject<WebView | null>; ready: boolean };
@@ -120,7 +126,7 @@ function intentScript(intent: NativeNavIntent) {
         if (typeof window.eclawHandleNativeNavigateIntent === 'function') {
           window.eclawHandleNativeNavigateIntent(intent);
         } else if (intent.targetTab === 'chat' && intent.messageId) {
-          window.location.href = '/portal/chat.html?msg=' + encodeURIComponent(intent.messageId);
+          window.location.href = '/portal/chat.html?messageId=' + encodeURIComponent(intent.messageId);
         } else if (intent.targetTab === 'mission' && intent.cardId) {
           window.location.href = '/portal/kanban.html?card=' + encodeURIComponent(intent.cardId) + '#' + encodeURIComponent(intent.cardId);
         }


### PR DESCRIPTION
## Summary
- carry `messageId` through native chat-tab navigation fallback in `WebViewScreen.tsx`
- preserve `messageId` through kanban / mission quote handoff so chat opens the correct thread/message
- centralize `his_<uuid>` extraction in shared helpers for downstream surfaces
- add static regression guards for messageId deep-link wiring

## Scope
- Item 1: native `WebViewScreen.tsx` messageId handoff
- Item 2: kanban quote payload embeds / preserves messageId when a source reference exists
- Item 3 web alias (`chat.html?messageId=`) was already merged separately in #2838 / `1785a873`

## Validation
- `npx -y jest@29.7.0 --runInBand backend/tests/jest/chat-his-link-render.test.js backend/tests/jest/chat-messageid-deeplink-static.test.js`
- 22 / 22 tests passing

## Pending before final review
- [ ] Android sim E2E
- [ ] iOS sim E2E
- [ ] before/after screenshots for screenshot-review gate
- [ ] confirm no-regression fallback when no `messageId` is present
