### PR TITLE
fix(portal): complete 401 redirect sweep + mobile UIUX truncation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ app/build/
 .idea/
 .vscode/
 .claude/
+.codex/
 # .agent/ — tracked (contains release workflow)
 nul
 compile_log.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1054,7 +1054,7 @@ curl "https://eclawbot.com/api/device-telemetry?deviceId=ID&deviceSecret=SECRET&
 
 ## Test Coverage Summary
 
-**~460 total API routes** across all modules (410 excluding Article Publisher), **~84% covered** by Jest + integration tests (~2995 test cases across 206 Jest files + 59 integration tests).
+**~460 total API routes** across all modules (410 excluding Article Publisher), **~84% covered** by Jest + integration tests (~3001 test cases across 206 Jest files + 59 integration tests).
 
 | Module | Coverage | Notes |
 |--------|----------|-------|

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -1859,17 +1859,26 @@
 
             .chip-group {
                 gap: 4px;
-                max-height: 30px;
+                max-height: none;
+                flex-wrap: nowrap;
+                overflow-x: auto;
+                -webkit-overflow-scrolling: touch;
+                scrollbar-width: none;          /* Firefox */
+            }
+
+            .chip-group::-webkit-scrollbar {
+                display: none;                  /* Chrome/Safari */
+            }
+
+            /* Toggle not needed on mobile — all chips visible in scroll row */
+            .filter-chip-toggle {
+                display: none !important;
             }
 
             .filter-chip {
                 padding: 4px 10px;
                 font-size: 11px;
-            }
-
-            .filter-chip-toggle {
-                padding: 4px 8px;
-                font-size: 11px;
+                flex-shrink: 0;
             }
 
             .target-bar {
@@ -7793,7 +7802,7 @@
         }
 
         async function fetchListingData(auth, listingId) {
-            const resp = await apiCall('GET', `/api/rental/listing/${listingId}?${auth}`);
+            const resp = await apiCall('GET', `/api/rental/listing/${listingId}?${auth}`, null, { skip401Redirect: true });
             if (!resp || !resp.listing) return null;
             const l = resp.listing;
 
@@ -7812,7 +7821,7 @@
         }
 
         async function fetchExamData(auth, examId) {
-            const resp = await apiCall('GET', `/api/arena/exam/${examId}/results?${auth}`);
+            const resp = await apiCall('GET', `/api/arena/exam/${examId}/results?${auth}`, null, { skip401Redirect: true });
             if (!resp) return null;
 
             const exam = resp.exam || resp;
@@ -7827,7 +7836,7 @@
 
         async function fetchContractData(auth, contractId) {
             // Contracts endpoint returns list — filter by ID
-            const resp = await apiCall('GET', `/api/rental/my-contracts?${auth}`);
+            const resp = await apiCall('GET', `/api/rental/my-contracts?${auth}`, null, { skip401Redirect: true });
             if (!resp || !resp.contracts) return null;
             const c = resp.contracts.find(x => x.id === contractId || x.id.startsWith(contractId));
             if (!c) return null;

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -167,12 +167,12 @@
             margin-top: 8px;
             line-height: 1.4;
             display: -webkit-box;
-            -webkit-line-clamp: 2;
-            line-clamp: 2;
+            -webkit-line-clamp: 5;
+            line-clamp: 5;
             -webkit-box-orient: vertical;
             overflow: hidden;
             text-overflow: ellipsis;
-            min-height: 2.8em;
+            word-break: break-word;
         }
 
         .entity-xp {
@@ -947,6 +947,17 @@
         }
 
         /* Responsive */
+        @media (max-width: 768px) {
+            .entity-message {
+                -webkit-line-clamp: 2;
+                line-clamp: 2;
+                font-size: 12px;
+            }
+            .entity-card-body {
+                padding: 14px;
+                gap: 12px;
+            }
+        }
         @media (max-width: 640px) {
             .entity-grid {
                 grid-template-columns: 1fr;

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -618,6 +618,10 @@
             /* Automation: stack on mobile */
             .kb-auto-grid { flex-wrap:nowrap; }
             .kb-auto-card { flex:0 0 180px; }
+
+            /* Card scanability: truncate description + hide dep chips on board cards */
+            .kb-card-desc { -webkit-line-clamp:3; max-height:calc(1.4em * 3); overflow:hidden; text-overflow:ellipsis; word-break:break-word; }
+            .kb-card .kb-dep-chips-container { display:none; }
         }
         @media (min-width: 769px) {
             .kb-mobile-list { display:none; }

--- a/backend/public/portal/my-rentals.html
+++ b/backend/public/portal/my-rentals.html
@@ -198,13 +198,13 @@
             wrap.innerHTML = `<div class="mr-empty">${tt('mr_loading', 'Loading...')}</div>`;
             try {
                 if (currentTab === 'disputes') {
-                    const data = await apiCall('GET', '/api/rental/my-disputes?limit=50');
+                    const data = await apiCall('GET', '/api/rental/my-disputes?limit=50', null, { skip401Redirect: true });
                     renderDisputes(data?.disputes || []);
                 } else if (currentTab === 'listings') {
-                    const data = await apiCall('GET', '/api/rental/my-listings');
+                    const data = await apiCall('GET', '/api/rental/my-listings', null, { skip401Redirect: true });
                     renderListings(data?.listings || []);
                 } else {
-                    const data = await apiCall('GET', `/api/rental/my-contracts?role=${currentTab}&limit=50`);
+                    const data = await apiCall('GET', `/api/rental/my-contracts?role=${currentTab}&limit=50`, null, { skip401Redirect: true });
                     renderContracts(data?.contracts || []);
                 }
             } catch (err) {

--- a/backend/public/portal/my-rentals.html
+++ b/backend/public/portal/my-rentals.html
@@ -394,7 +394,7 @@
         async function pauseListing(listingId, btn) {
             btn.disabled = true;
             try {
-                await apiCall('POST', `/api/rental/listing/${listingId}/pause`);
+                await apiCall('POST', `/api/rental/listing/${listingId}/pause`, null, { skip401Redirect: true });
                 showToast(tt('mr_listing_paused_toast', 'Listing paused'), 'success');
                 loadTab();
             } catch (err) {
@@ -407,7 +407,7 @@
             btn.disabled = true;
             try {
                 /* Resume = re-publish a paused listing */
-                await apiCall('POST', `/api/rental/listing/${listingId}/publish`);
+                await apiCall('POST', `/api/rental/listing/${listingId}/publish`, null, { skip401Redirect: true });
                 showToast(tt('mr_listing_resumed_toast', 'Listing live again'), 'success');
                 loadTab();
             } catch (err) {
@@ -436,7 +436,7 @@
             btn.disabled = true;
             btn.textContent = '...';
             try {
-                await apiCall('DELETE', `/api/rental/listing/${listingId}`);
+                await apiCall('DELETE', `/api/rental/listing/${listingId}`, null, { skip401Redirect: true });
                 const overlay = btn.closest('.mr-modal-overlay');
                 if (overlay) overlay.remove();
                 showToast(tt('mr_listing_delisted_toast', 'Listing delisted'), 'success');
@@ -485,7 +485,7 @@
             btn.disabled = true;
             btn.textContent = '...';
             try {
-                await apiCall('POST', `/api/rental/contract/${contractId}/end`, { endReason: 'ended_early_by_renter' });
+                await apiCall('POST', `/api/rental/contract/${contractId}/end`, { endReason: 'ended_early_by_renter' }, { skip401Redirect: true });
                 const overlay = btn.closest('.mr-modal-overlay');
                 if (overlay) overlay.remove();
                 loadTab();
@@ -534,7 +534,7 @@
             btn.disabled = true;
             btn.textContent = '...';
             try {
-                await apiCall('POST', `/api/rental/contract/${contractId}/dispute`, { type: selected.value, evidence });
+                await apiCall('POST', `/api/rental/contract/${contractId}/dispute`, { type: selected.value, evidence }, { skip401Redirect: true });
                 overlay.remove();
                 showToast(tt('mr_dispute_filed', 'Dispute filed!'), 'success');
                 switchTab('disputes');
@@ -572,7 +572,7 @@
             if (!rating) { showToast(tt('mr_select_rating', 'Please select a rating'), 'error'); return; }
             const comment = document.getElementById(`comment-${contractId}`).value;
             try {
-                await apiCall('POST', `/api/rental/contract/${contractId}/review`, { rating, comment });
+                await apiCall('POST', `/api/rental/contract/${contractId}/review`, { rating, comment }, { skip401Redirect: true });
                 showToast(tt('mr_review_submitted', 'Review submitted!'), 'success');
                 loadTab();
             } catch (err) { showToast(err.message || tt('mr_action_failed', 'Failed'), 'error'); }

--- a/backend/public/portal/shared/agent-card-editor.js
+++ b/backend/public/portal/shared/agent-card-editor.js
@@ -251,7 +251,7 @@ window.AgentCardEditor = (function() {
 
         try {
             // Ensure a listing exists for this entity
-            var listings = await apiCall('GET', '/api/rental/my-listings');
+            var listings = await apiCall('GET', '/api/rental/my-listings', null, { skip401Redirect: true });
             var existing = (listings.listings || []).find(function(l) {
                 return String(l.owner_entity_id) === String(this.entityId);
             }.bind(this));
@@ -303,7 +303,7 @@ window.AgentCardEditor = (function() {
 
     AgentCardEditor.prototype._openArena = async function() {
         try {
-            var listings = await apiCall('GET', '/api/rental/my-listings');
+            var listings = await apiCall('GET', '/api/rental/my-listings', null, { skip401Redirect: true });
             var existing = (listings.listings || []).find(function(l) {
                 return String(l.owner_entity_id) === String(this.entityId);
             }.bind(this));
@@ -325,7 +325,7 @@ window.AgentCardEditor = (function() {
 
     AgentCardEditor.prototype._listForRental = async function() {
         try {
-            var listings = await apiCall('GET', '/api/rental/my-listings');
+            var listings = await apiCall('GET', '/api/rental/my-listings', null, { skip401Redirect: true });
             var existing = (listings.listings || []).find(function(l) {
                 return String(l.owner_entity_id) === String(this.entityId);
             }.bind(this));

--- a/backend/public/portal/wallet.html
+++ b/backend/public/portal/wallet.html
@@ -272,7 +272,7 @@
 
         async function loadTiers() {
             try {
-                const data = await apiCall('GET', '/api/wallet/topup/tiers');
+                const data = await apiCall('GET', '/api/wallet/topup/tiers', null, { skip401Redirect: true });
                 if (!data || !data.success) return;
                 const grid = document.getElementById('tierGrid');
                 grid.innerHTML = '';

--- a/backend/public/portal/wallet.html
+++ b/backend/public/portal/wallet.html
@@ -255,7 +255,7 @@
 
         async function loadBalance() {
             try {
-                const data = await apiCall('GET', '/api/wallet/balance');
+                const data = await apiCall('GET', '/api/wallet/balance', null, { skip401Redirect: true });
                 if (!data || !data.success) return;
                 const w = data.wallet;
                 document.getElementById('balanceEcoin').textContent = w.balance_ecoin.toLocaleString();
@@ -351,7 +351,7 @@
 
         async function loadHistory() {
             try {
-                const data = await apiCall('GET', '/api/wallet/history?limit=50');
+                const data = await apiCall('GET', '/api/wallet/history?limit=50', null, { skip401Redirect: true });
                 if (!data || !data.success) return;
                 const wrap = document.getElementById('ledgerWrap');
                 if (!data.entries || data.entries.length === 0) {

--- a/backend/public/sitemap.xml
+++ b/backend/public/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://eclawbot.com/</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-05-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/portal/</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-05-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/api/docs</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-05-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/.well-known/agent.json</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-05-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/enterprise</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-05-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -38,37 +38,37 @@
   </url>
   <url>
     <loc>https://eclawbot.com/llms.txt</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-05-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/arena/</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-05-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/portal/community.html</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-05-20</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/portal/compare.html</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-05-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/promo.html</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-05-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/promo-meta.html</loc>
-    <lastmod>2026-05-19</lastmod>
+    <lastmod>2026-05-20</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## Summary
- **401 redirect sweep**: Add `skip401Redirect: true` to all remaining rental/wallet/arena `apiCall()` invocations across wallet.html, my-rentals.html, chat.html, and agent-card-editor.js — prevents device-login users from being bounced to dashboard
- **#2845 Chat mobile filter chips**: Horizontal scrollable row instead of wrapping multi-row stack
- **#2844 Kanban mobile cards**: 3-line description clamp + hide dependency chips on mobile
- **#2843 Dashboard entity cards**: 2-line message clamp on mobile, 5 lines on desktop
- Housekeeping: .codex/ in .gitignore, sitemap dates, CLAUDE.md test count

## Test plan
- [x] Jest 206 suites / 3001 tests pass
- [x] i18n-syntax + i18n-check pass
- [x] CSS class coverage test passes
- [ ] Verify mobile chat filter chips scroll horizontally
- [ ] Verify kanban cards show truncated descriptions on mobile
- [ ] Verify dashboard entity messages truncated on mobile

Closes #2843, closes #2844, closes #2845

🤖 Generated with [Claude Code](https://claude.com/claude-code)