### PR TITLE
feat(kanban): launch_gated flag suppresses L1/L2/L3 on backlog cards

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -702,6 +702,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             reworkPrNumber: row.rework_pr_number || null,
             linkedPrevCardId: row.linked_prev_card_id || null,
             linkedNextCardId: row.linked_next_card_id || null,
+            launchGated: !!row.launch_gated,
             // Aggregated counts (if present from JOIN)
             commentCount: parseInt(row.comment_count) || 0,
             noteCount: parseInt(row.note_count) || 0,
@@ -1838,10 +1839,15 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                 }
             }
 
+            // launch_gated only applies to backlog cards waiting on an external
+            // launch / verification gate. Any move out of backlog auto-clears it
+            // so stale-detection re-enables when the card enters real workflow.
             const result = await pool.query(
                 `UPDATE kanban_cards
                  SET status = $1, assigned_bots = $2::jsonb, status_changed_at = NOW(),
-                     last_stale_nudge_at = NULL, updated_at = NOW()
+                     last_stale_nudge_at = NULL,
+                     launch_gated = CASE WHEN $1 = 'backlog' THEN launch_gated ELSE FALSE END,
+                     updated_at = NOW()
                  WHERE id = $3 AND device_id = $4
                  RETURNING *`,
                 [newStatus, JSON.stringify(bots), cardId, deviceId]
@@ -2419,6 +2425,55 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
     });
 
     // ============================================
+    // PUT /card/:id/gate — Toggle launch-gate suppression (backlog only)
+    // Cards with launchGated=true are excluded from stale-card scan, so L1
+    // nudges + L2/L3 escalation cannot fire on them. Use only for backlog
+    // cards explicitly waiting on a launch / verification gate. Flag auto-
+    // clears on any /move out of backlog.
+    // ============================================
+    router.put('/card/:id/gate', async (req, res) => {
+        if (!authenticate(req, res)) return;
+        const _p = { ...req.query, ...req.body }; console.log('[Kanban] PUT /card/:id/gate called', { deviceId: _p.deviceId, entityId: _p.entityId, cardId: req.params?.id });
+        const { deviceId, enabled } = req.body;
+        const cardId = req.params.id;
+
+        if (typeof enabled !== 'boolean') {
+            return res.status(400).json({ success: false, error: 'enabled (boolean) required' });
+        }
+
+        try {
+            const existing = await pool.query(
+                `SELECT status FROM kanban_cards WHERE id = $1 AND device_id = $2 AND archived = false`,
+                [cardId, deviceId]
+            );
+            if (existing.rows.length === 0) {
+                return res.status(404).json({ success: false, error: 'Card not found' });
+            }
+            if (enabled && existing.rows[0].status !== 'backlog') {
+                return res.status(400).json({
+                    success: false,
+                    error: 'launch_gated can only be enabled on backlog cards',
+                    code: 'GATE_NOT_BACKLOG',
+                    hint: 'Move card to backlog first, then enable the gate.'
+                });
+            }
+
+            const result = await pool.query(
+                `UPDATE kanban_cards
+                 SET launch_gated = $1, updated_at = NOW()
+                 WHERE id = $2 AND device_id = $3
+                 RETURNING *`,
+                [enabled, cardId, deviceId]
+            );
+
+            res.json({ success: true, card: serializeCard(result.rows[0]) });
+        } catch (err) {
+            console.error('[Kanban] Gate card error:', err);
+            res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
+    // ============================================
     // PUT /card/:id/schedule — Set schedule
     // ============================================
     router.put('/card/:id/schedule', async (req, res) => {
@@ -2616,6 +2671,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                   AND status IN ('backlog', 'todo', 'in_progress', 'review')
                   AND EXTRACT(EPOCH FROM (NOW() - status_changed_at)) * 1000 > stale_threshold_ms
                   AND (schedule_enabled = false OR schedule_type != 'recurring' OR schedule_enabled IS NULL)
+                  AND (launch_gated = FALSE OR launch_gated IS NULL)
             `);
 
             if (result.rows.length === 0) return;

--- a/backend/kanban_schema.sql
+++ b/backend/kanban_schema.sql
@@ -227,6 +227,12 @@ ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS rework_pr_number VARCHAR(64) D
 ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS linked_prev_card_id VARCHAR(48) DEFAULT NULL;
 ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS linked_next_card_id VARCHAR(48) DEFAULT NULL;
 
+-- Launch-gate suppression (2026-05-20): backlog cards explicitly waiting on
+-- an external launch / verification gate can opt out of L1 nudge + L2/L3
+-- escalation. Auto-clears whenever status leaves backlog so the flag cannot
+-- be carried into todo/in_progress and silently muffle stale-detection there.
+ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS launch_gated BOOLEAN DEFAULT FALSE;
+
 CREATE INDEX IF NOT EXISTS idx_kanban_cards_pending_dispatch ON kanban_cards(device_id, pending_dispatch, dispatch_mode)
     WHERE pending_dispatch = TRUE;
 

--- a/backend/migrations/20260520_kanban_launch_gated.down.sql
+++ b/backend/migrations/20260520_kanban_launch_gated.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE kanban_cards DROP COLUMN IF EXISTS launch_gated;

--- a/backend/migrations/20260520_kanban_launch_gated.up.sql
+++ b/backend/migrations/20260520_kanban_launch_gated.up.sql
@@ -1,0 +1,7 @@
+-- Launch-gate suppression for backlog cards
+-- See feedback_kanban_backlog_vs_blocked (Mac_F 2026-05-19) + card_8af4544e8f8f05f70cdfd022.
+-- A backlog card with launch_gated=TRUE is excluded from the stale-card scan,
+-- so it cannot fire L1 nudges or auto-escalate (L2 priority bump / L3 → blocked).
+-- The flag is automatically cleared on POST /card/:id/move whenever the card
+-- leaves backlog, preventing accidental nudge-suppression on real work-in-flight.
+ALTER TABLE kanban_cards ADD COLUMN IF NOT EXISTS launch_gated BOOLEAN DEFAULT FALSE;

--- a/backend/tests/jest/kanban-launch-gated-skip.test.js
+++ b/backend/tests/jest/kanban-launch-gated-skip.test.js
@@ -1,0 +1,89 @@
+'use strict';
+
+/**
+ * Regression test — stale-escalation must skip launch_gated backlog cards.
+ *
+ * Background: Mac_F 2026-05-19 locked the kanban semantic split as
+ *   backlog = drafted, awaiting future launch / verification gate
+ *   blocked = near-term execution stuck on external dependency
+ * The pre-existing checkStaleCards() query treated backlog identically
+ * to todo / in_progress / review, so launch-gated backlog cards fired
+ * L1 nudges every 3h and would auto-escalate to L2 / L3 (→ blocked),
+ * polluting the blocked queue and contradicting Mac_F's lock.
+ *
+ * Fix: per-card launch_gated flag (settable only on backlog cards via
+ * PUT /card/:id/gate). The stale-scan SELECT excludes gated rows, the
+ * /move handler auto-clears the flag when status leaves backlog, and
+ * serializeCard surfaces launchGated to clients.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const kanbanSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'kanban.js'),
+    'utf8'
+);
+
+function extractFunctionBody(src, signature) {
+    const start = src.indexOf(signature);
+    if (start === -1) throw new Error(`function not found: ${signature}`);
+    const open = src.indexOf('{', start);
+    let depth = 0;
+    for (let i = open; i < src.length; i++) {
+        const ch = src[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+            depth--;
+            if (depth === 0) return src.slice(open, i + 1);
+        }
+    }
+    throw new Error(`unterminated function: ${signature}`);
+}
+
+describe('checkStaleCards — launch_gated skip filter', () => {
+    const body = extractFunctionBody(kanbanSrc, 'async function checkStaleCards()');
+
+    test('SELECT excludes launch_gated cards', () => {
+        expect(body).toMatch(
+            /launch_gated\s*=\s*FALSE\s+OR\s+launch_gated\s+IS\s+NULL/i
+        );
+    });
+
+    test('recurring-schedule skip is still present (no regression vs prior fix)', () => {
+        expect(body).toMatch(
+            /schedule_enabled\s*=\s*false\s+OR\s+schedule_type\s*!=\s*'recurring'\s+OR\s+schedule_enabled\s+IS\s+NULL/
+        );
+    });
+});
+
+describe('serializeCard — launchGated surface', () => {
+    test('returns launchGated boolean', () => {
+        expect(kanbanSrc).toMatch(/launchGated:\s*!!row\.launch_gated/);
+    });
+});
+
+describe('POST /card/:id/move — auto-clear launch_gated', () => {
+    test('UPDATE clears launch_gated when newStatus is not backlog', () => {
+        // CASE expression: keep flag only when staying in backlog,
+        // force FALSE for every other transition.
+        expect(kanbanSrc).toMatch(
+            /launch_gated\s*=\s*CASE\s+WHEN\s+\$1\s*=\s*'backlog'\s+THEN\s+launch_gated\s+ELSE\s+FALSE\s+END/
+        );
+    });
+});
+
+describe('PUT /card/:id/gate — backlog-only enforcement', () => {
+    test('endpoint is registered', () => {
+        expect(kanbanSrc).toMatch(/router\.put\(['"]\/card\/:id\/gate['"]/);
+    });
+
+    test('rejects enable on non-backlog status with GATE_NOT_BACKLOG', () => {
+        expect(kanbanSrc).toMatch(/GATE_NOT_BACKLOG/);
+        expect(kanbanSrc).toMatch(/launch_gated can only be enabled on backlog cards/);
+    });
+
+    test('requires enabled boolean in body', () => {
+        expect(kanbanSrc).toMatch(/typeof enabled !== ['"]boolean['"]/);
+    });
+});


### PR DESCRIPTION
## Summary

- Adds per-card `launch_gated` boolean (backlog-only) that excludes a card from the stale-card scan, suppressing L1 nudges and L2/L3 escalation.
- Flag auto-clears on `POST /card/:id/move` when status leaves `backlog`, so it can't silently muffle stale-detection on real work-in-flight.
- New `PUT /card/:id/gate {enabled: bool}` endpoint; rejects `enable=true` on non-backlog cards with `GATE_NOT_BACKLOG`.
- 7-test jest regression suite pinning the SQL filter, serializer, move-handler reset, and endpoint shape.

## Why

Mac_F (#1) 2026-05-19 locked the kanban semantic split as:
- **backlog** = drafted, awaiting future launch / verification gate
- **blocked** = near-term execution stuck on external dependency

But `checkStaleCards()` treated backlog identically to todo / in_progress / review — firing L1 nudges every 3h on launch-gated cards and auto-escalating them via L3 (`→ blocked`) at 12h, polluting the blocked column and contradicting #1's lock. Growth-P1b (card_8de83bef1c91529d2e106081) was the live example: drafts merged, gate is "P0 deploy + beacons fire" which can take days, yet the card was racking up L1 noise.

The kanban-bug card (card_8af4544e8f8f05f70cdfd022) was firing L1 on itself, which is the bug fixing itself.

## Files

- `backend/kanban_schema.sql` + `backend/migrations/20260520_kanban_launch_gated.{up,down}.sql` — idempotent `ADD COLUMN IF NOT EXISTS launch_gated BOOLEAN DEFAULT FALSE`.
- `backend/kanban.js`:
  - `checkStaleCards()` SELECT excludes `launch_gated = FALSE OR launch_gated IS NULL`.
  - `serializeCard()` surfaces `launchGated: !!row.launch_gated`.
  - `POST /card/:id/move` UPDATE sets `launch_gated = CASE WHEN newStatus='backlog' THEN launch_gated ELSE FALSE END`.
  - New `PUT /card/:id/gate` route validates backlog-only + boolean enabled.
- `backend/tests/jest/kanban-launch-gated-skip.test.js` — 7 regression tests.

## Test plan

- [x] `node --check backend/kanban.js` — syntax clean
- [x] `jest kanban-launch-gated-skip.test.js` — 7/7 pass
- [x] `jest kanban-stale-skip-recurring.test.js` — 4/4 still pass (no regression on prior fix)
- [x] All other kanban-* suites pass (23 suites green; FAILs in run are unrelated env-setup issues like missing `JWT_SECRET`)
- [ ] After deploy: `curl PUT /card/card_8de83bef1c91529d2e106081/gate {enabled:true}` and verify L1 stops firing on Growth-P1b
- [ ] After deploy: re-verify gate auto-clears by moving a gated backlog card → todo

## Rollout

Schema change is `ADD COLUMN IF NOT EXISTS` so it's safe to deploy without rolling clients first; old clients simply won't see the new `launchGated` field. Down migration provided.

🤖 Generated with [Claude Code](https://claude.com/claude-code)