### PR TITLE
fix(uiux): continue QA mobile readability sweep for portal pages

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -1855,6 +1855,7 @@
 
             .chip-group-wrapper {
                 gap: 4px;
+                align-items: center;
             }
 
             .chip-group {
@@ -1862,8 +1863,10 @@
                 max-height: none;
                 flex-wrap: nowrap;
                 overflow-x: auto;
+                overflow-y: hidden;
                 -webkit-overflow-scrolling: touch;
                 scrollbar-width: none;          /* Firefox */
+                padding-bottom: 2px;
             }
 
             .chip-group::-webkit-scrollbar {

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -172,7 +172,25 @@
             -webkit-box-orient: vertical;
             overflow: hidden;
             text-overflow: ellipsis;
+            min-height: 2.8em;
+            white-space: normal;
             word-break: break-word;
+        }
+
+        @media (max-width: 640px) {
+            .entity-grid {
+                grid-template-columns: 1fr;
+            }
+            .entity-card-body {
+                gap: 12px;
+                padding: 16px;
+            }
+            .entity-message {
+                -webkit-line-clamp: 1;
+                line-clamp: 1;
+                min-height: 1.4em;
+                font-size: 12px;
+            }
         }
 
         .entity-xp {
@@ -2614,6 +2632,15 @@
             return { level: level, xpInLevel: xpInLevel, xpNeeded: xpNeeded, pct: pct };
         }
 
+        function compactEntityMessagePreview(raw) {
+            var text = String(raw || '').replace(/```[\s\S]*?```/g, ' ').replace(/`([^`]+)`/g, '$1');
+            text = text.replace(/\[(.*?)\]\((.*?)\)/g, '$1');
+            text = text.replace(/[*_~>#-]+/g, ' ');
+            text = text.replace(/\s+/g, ' ').trim();
+            if (!text) return 'No messages yet';
+            return text.length > 120 ? text.slice(0, 117).trimEnd() + '…' : text;
+        }
+
         // --- Rendering ---
         function renderEntities() {
             const grid = document.getElementById('entityGrid');
@@ -2636,7 +2663,7 @@
                 const avatar = getAvatarForEntity(entity.entityId);
                 const state = entity.state || 'idle';
                 const stateBadgeClass = getStateBadgeClass(state);
-                const lastMsg = entity.message || 'No messages yet';
+                const lastMsg = compactEntityMessagePreview(entity.message);
                 const time = formatTime(entity.lastUpdated);
                 const escapedName = escapeHtml(displayName).replace(/'/g, "\\'");
 

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -85,7 +85,7 @@
         .kb-card-avatar-name { color:var(--text-secondary); font-weight:500; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; max-width:60px; }
 
         .kb-card-title { font-size:13px; font-weight:600; color:var(--text); margin-bottom:4px; line-height:1.4; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; }
-        .kb-card-desc { font-size:11px; color:var(--text-secondary); line-height:1.4; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; margin-bottom:8px; }
+        .kb-card-desc { font-size:11px; color:var(--text-secondary); line-height:1.4; display:-webkit-box; -webkit-line-clamp:2; -webkit-box-orient:vertical; overflow:hidden; margin-bottom:8px; white-space:normal; word-break:break-word; }
         .kb-card-footer { display:flex; gap:8px; font-size:10px; color:var(--text-muted); flex-wrap:wrap; align-items:center; }
         .kb-card-footer span { display:flex; align-items:center; gap:2px; }
         .kb-card-countdown { font-weight:600; }
@@ -615,12 +615,18 @@
             .kb-toolbar { flex-direction:column; align-items:stretch; }
             .kb-toolbar-actions { justify-content:space-between; }
 
+            /* Compact list cards */
+            .kb-card-desc {
+                -webkit-line-clamp: 1;
+                line-clamp: 1;
+                margin-bottom: 6px;
+            }
+
             /* Automation: stack on mobile */
             .kb-auto-grid { flex-wrap:nowrap; }
             .kb-auto-card { flex:0 0 180px; }
 
-            /* Card scanability: truncate description + hide dep chips on board cards */
-            .kb-card-desc { -webkit-line-clamp:3; max-height:calc(1.4em * 3); overflow:hidden; text-overflow:ellipsis; word-break:break-word; }
+            /* Card scanability: hide dep chips on board cards */
             .kb-card .kb-dep-chips-container { display:none; }
         }
         @media (min-width: 769px) {
@@ -1765,7 +1771,7 @@
                 </div>
                 <div class="kb-card-title">${escapeHtml(card.title)}</div>
                 ${renderTags(card.tags)}
-                ${card.description ? '<div class="kb-card-desc">'+renderSmartChips(card.description)+'</div>' : ''}
+                ${card.description ? '<div class="kb-card-desc">'+escapeHtml(compactKanbanPreview(card.description))+'</div>' : ''}
                 <div class="kb-card-footer">
                     ${commentCount ? '<span>💬 '+commentCount+'</span>' : ''}
                     ${noteCount ? '<span>📝 '+noteCount+'</span>' : ''}
@@ -2213,6 +2219,15 @@
             if (card.status === 'in_progress') return { label: '👀 Review', kind: 'move', value: 'review' };
             if (card.status === 'blocked') return { label: '▶ Resume', kind: 'move', value: 'in_progress' };
             return { label: '▶ Start', kind: 'move', value: 'in_progress' };
+        }
+
+        function compactKanbanPreview(raw) {
+            let text = String(raw || '').replace(/```[\s\S]*?```/g, ' ').replace(/`([^`]+)`/g, '$1');
+            text = text.replace(/\[(.*?)\]\((.*?)\)/g, '$1');
+            text = text.replace(/[*_~>#-]+/g, ' ');
+            text = text.replace(/\s+/g, ' ').trim();
+            if (!text) return '';
+            return text.length > 110 ? text.slice(0, 107).trimEnd() + '…' : text;
         }
 
         function taskChip(kind, label, title, onClick) {

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -706,6 +706,32 @@
             flex-shrink: 0;
             flex-wrap: wrap;
         }
+        @media (max-width: 640px) {
+            .wv-toolbar {
+                gap: 4px;
+                padding: 8px 10px;
+                align-items: flex-start;
+            }
+            .wv-toolbar-title {
+                width: 100%;
+                order: -1;
+            }
+            .wv-toolbar-sep {
+                display: none;
+            }
+            .wv-toolbar button {
+                padding: 5px 8px;
+                font-size: 12px;
+            }
+            #wvColor,
+            #wvSize,
+            #btnClearView,
+            #btnWvPrivacy,
+            #btnWvCopyLink,
+            #btnWvEditHtml {
+                display: none;
+            }
+        }
         .wv-toolbar button {
             border: none;
             background: var(--input-bg);

--- a/backend/public/portal/my-rentals.html
+++ b/backend/public/portal/my-rentals.html
@@ -12,6 +12,24 @@
         .mr-tab { padding: 10px 18px; background: none; border: none; border-bottom: 2px solid transparent; color: var(--text-secondary); font-size: 13px; font-weight: 600; cursor: pointer; }
         .mr-tab.active { color: var(--primary); border-bottom-color: var(--primary); }
 
+        @media (max-width: 640px) {
+            .mr-tabs {
+                overflow-x: auto;
+                overflow-y: hidden;
+                flex-wrap: nowrap;
+                -webkit-overflow-scrolling: touch;
+                scrollbar-width: none;
+                padding-bottom: 2px;
+            }
+            .mr-tabs::-webkit-scrollbar { display: none; }
+            .mr-tab {
+                flex: 0 0 auto;
+                padding: 9px 14px;
+                font-size: 12px;
+                white-space: nowrap;
+            }
+        }
+
         .mr-section { background: var(--card); border: 1px solid var(--card-border); border-radius: var(--radius); padding: 18px; margin-bottom: 14px; }
         .mr-contract { display: flex; justify-content: space-between; align-items: center; flex-wrap: wrap; gap: 10px; }
         .mr-contract-info { flex: 1; min-width: 200px; }

--- a/backend/public/portal/wallet.html
+++ b/backend/public/portal/wallet.html
@@ -155,6 +155,66 @@
             background: var(--input-bg);
             border: 1px solid var(--card-border);
         }
+        .ledger-note-cell {
+            color: var(--text-secondary);
+            font-size: 12px;
+            word-break: break-word;
+        }
+        @media (max-width: 640px) {
+            .balance-row {
+                flex-direction: column;
+                gap: 12px;
+            }
+            .ledger-table {
+                border-collapse: separate;
+                border-spacing: 0 10px;
+            }
+            .ledger-table thead {
+                display: none;
+            }
+            .ledger-table,
+            .ledger-table tbody,
+            .ledger-table tr,
+            .ledger-table td {
+                display: block;
+                width: 100%;
+            }
+            .ledger-table tr {
+                background: var(--input-bg);
+                border: 1px solid var(--card-border);
+                border-radius: var(--radius-sm);
+                padding: 12px;
+            }
+            .ledger-table td {
+                border-bottom: none;
+                padding: 0;
+                margin-top: 10px;
+                text-align: left !important;
+            }
+            .ledger-table td:first-child {
+                margin-top: 0;
+            }
+            .ledger-table td::before {
+                content: attr(data-label);
+                display: block;
+                font-size: 10px;
+                font-weight: 700;
+                letter-spacing: 0.04em;
+                text-transform: uppercase;
+                color: var(--text-muted);
+                margin-bottom: 4px;
+            }
+            .ledger-note-cell {
+                font-size: 13px;
+                line-height: 1.45;
+            }
+            .ledger-amount {
+                display: inline-flex;
+                align-items: baseline;
+                gap: 4px;
+                font-size: 15px;
+            }
+        }
         .empty-state {
             text-align: center;
             padding: 40px 20px;
@@ -251,6 +311,15 @@
         function tt(key, fallback) {
             const v = (typeof i18n !== 'undefined') ? i18n.t(key) : null;
             return (v && v !== key) ? v : fallback;
+        }
+
+        function escapeHtml(value) {
+            return String(value == null ? '' : value)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
         }
 
         async function loadBalance() {
@@ -377,10 +446,10 @@
                     const cls = delta >= 0 ? 'credit' : 'debit';
                     const sign = delta >= 0 ? '+' : '−';
                     html += `<tr>
-                        <td>${dateStr}</td>
-                        <td><span class="ledger-type">${ledgerTypeLabel(e.type)}</span></td>
-                        <td style="color:var(--text-secondary);font-size:12px;">${e.note || ''}</td>
-                        <td class="ledger-amount ${cls}" style="text-align:right;">${sign}${ecoin.toLocaleString()} ${ledgerUnit}</td>
+                        <td data-label="${escapeHtml(colTime)}">${dateStr}</td>
+                        <td data-label="${escapeHtml(colType)}"><span class="ledger-type">${escapeHtml(ledgerTypeLabel(e.type))}</span></td>
+                        <td data-label="${escapeHtml(colNote)}" class="ledger-note-cell">${escapeHtml(e.note || '')}</td>
+                        <td data-label="${escapeHtml(colAmount)}" class="ledger-amount ${cls}" style="text-align:right;">${sign}${ecoin.toLocaleString()} ${escapeHtml(ledgerUnit)}</td>
                     </tr>`;
                 }
                 html += '</tbody></table>';

--- a/backend/public/portal/workspace.html
+++ b/backend/public/portal/workspace.html
@@ -97,6 +97,29 @@
 
         /* Active tab highlights in nav */
         .nav-link.active-pane { border-bottom: 2px solid var(--accent, #7c6aef); }
+
+        @media (max-width: 768px) {
+            .pane-labels {
+                height: auto;
+                min-height: 38px;
+                padding: 6px 8px 4px;
+                gap: 6px;
+            }
+            .pane-label {
+                cursor: pointer;
+            }
+            .workspace-container {
+                height: calc(100vh - 94px);
+            }
+            .workspace-pane {
+                min-width: 100%;
+                width: 100% !important;
+            }
+            .workspace-divider,
+            .drag-overlay {
+                display: none !important;
+            }
+        }
     </style>
 </head>
 <body>
@@ -128,8 +151,15 @@
 
     // ── State: ordered array of panes ──
     let panes = [];   // [{ id: 'chat', width: 0.5 }, ...]
+    let activePaneIdx = 0;
+    let _lastMobileMode = null;
 
     function t(key, fb) { return typeof i18n !== 'undefined' ? i18n.t(key) : fb; }
+    function isMobileWorkspace() { return window.matchMedia('(max-width: 768px)').matches; }
+    function clampActivePaneIdx() {
+        if (panes.length === 0) activePaneIdx = 0;
+        else activePaneIdx = Math.max(0, Math.min(activePaneIdx, panes.length - 1));
+    }
 
     function pageIdFromHref(href) {
         for (const [id, p] of Object.entries(PAGES)) { if (p.href === href) return id; }
@@ -157,6 +187,8 @@
         }
 
         if (panes.length === 0) panes = [{ id: 'dashboard', width: 1 }];
+        activePaneIdx = 0;
+        _lastMobileMode = isMobileWorkspace();
 
         // Restore widths from localStorage
         try {
@@ -184,6 +216,11 @@
         if (!PAGES[pageId]) return;
         const idx = panes.findIndex(p => p.id === pageId);
         if (idx >= 0) {
+            if (isMobileWorkspace()) {
+                activePaneIdx = idx;
+                render();
+                return;
+            }
             // Already open — close it (unless it's the only one)
             if (panes.length <= 1) return;
             panes.splice(idx, 1);
@@ -191,8 +228,10 @@
         } else {
             // Add new pane at the left
             panes.unshift({ id: pageId, width: 0 });
+            activePaneIdx = 0;
             normalizeWidths();
         }
+        clampActivePaneIdx();
         render();
     }
 
@@ -212,24 +251,29 @@
 
     function renderContainer() {
         bustChatPaneCache();
+        clampActivePaneIdx();
         const container = document.getElementById('workspaceContainer');
+        const mobileMode = isMobileWorkspace();
         container.innerHTML = '';
 
-        panes.forEach((pane, i) => {
-            // Iframe
+        const panesToRender = mobileMode
+            ? [{ pane: panes[activePaneIdx], paneIndex: activePaneIdx }]
+            : panes.map((pane, i) => ({ pane, paneIndex: i }));
+
+        panesToRender.forEach(({ pane, paneIndex }, renderIdx) => {
+            if (!pane) return;
             const iframe = document.createElement('iframe');
             iframe.className = 'workspace-pane';
-            iframe.id = 'pane-' + i;
-            iframe.style.width = (pane.width * 100).toFixed(2) + '%';
+            iframe.id = 'pane-' + paneIndex;
+            iframe.style.width = mobileMode ? '100%' : (pane.width * 100).toFixed(2) + '%';
             const pageInfo = PAGES[pane.id];
             if (pageInfo) iframe.src = pageInfo.href + '?embed=1';
             container.appendChild(iframe);
 
-            // Divider between panes
-            if (i < panes.length - 1) {
+            if (!mobileMode && renderIdx < panesToRender.length - 1) {
                 const div = document.createElement('div');
                 div.className = 'workspace-divider';
-                div.setAttribute('data-index', i);
+                div.setAttribute('data-index', paneIndex);
                 div.addEventListener('mousedown', startDividerDrag);
                 container.appendChild(div);
             }
@@ -240,6 +284,7 @@
     let dragIndex = -1;
 
     function startDividerDrag(e) {
+        if (isMobileWorkspace()) return;
         e.preventDefault();
         dragIndex = parseInt(e.target.getAttribute('data-index'));
         e.target.classList.add('dragging');
@@ -289,20 +334,28 @@
 
     function renderLabels() {
         const bar = document.getElementById('paneLabels');
+        const mobileMode = isMobileWorkspace();
+        clampActivePaneIdx();
         bar.innerHTML = '';
 
         panes.forEach((pane, i) => {
             const span = document.createElement('span');
-            span.className = 'pane-label' + (i === 0 ? ' active' : '');
+            span.className = 'pane-label' + ((mobileMode ? i === activePaneIdx : i === 0) ? ' active' : '');
             span.style.borderBottomColor = COLORS[i % COLORS.length];
             span.style.borderBottom = '2px solid ' + COLORS[i % COLORS.length];
-            span.setAttribute('draggable', 'true');
+            span.setAttribute('draggable', mobileMode ? 'false' : 'true');
             span.setAttribute('data-idx', i);
 
             const p = PAGES[pane.id];
             const icon = p ? p.icon : '';
             const label = p ? t(p.i18nKey, p.label) : pane.id;
             span.innerHTML = `${icon} ${label}`;
+
+            span.addEventListener('click', () => {
+                if (!mobileMode) return;
+                activePaneIdx = i;
+                render();
+            });
 
             // Close button (only if more than 1 pane)
             if (panes.length > 1) {
@@ -314,32 +367,33 @@
                 span.appendChild(close);
             }
 
-            // Drag to reorder
-            span.addEventListener('dragstart', (e) => {
-                dragLabelIdx = i;
-                e.dataTransfer.effectAllowed = 'move';
-                span.style.opacity = '0.5';
-            });
-            span.addEventListener('dragend', () => {
-                span.style.opacity = '';
-                dragLabelIdx = -1;
-                bar.querySelectorAll('.pane-label').forEach(el => el.classList.remove('drag-over'));
-            });
-            span.addEventListener('dragover', (e) => {
-                e.preventDefault();
-                e.dataTransfer.dropEffect = 'move';
-                span.classList.add('drag-over');
-            });
-            span.addEventListener('dragleave', () => { span.classList.remove('drag-over'); });
-            span.addEventListener('drop', (e) => {
-                e.preventDefault();
-                span.classList.remove('drag-over');
-                if (dragLabelIdx < 0 || dragLabelIdx === i) return;
-                // Swap panes
-                const moved = panes.splice(dragLabelIdx, 1)[0];
-                panes.splice(i, 0, moved);
-                render();
-            });
+            if (!mobileMode) {
+                // Drag to reorder
+                span.addEventListener('dragstart', (e) => {
+                    dragLabelIdx = i;
+                    e.dataTransfer.effectAllowed = 'move';
+                    span.style.opacity = '0.5';
+                });
+                span.addEventListener('dragend', () => {
+                    span.style.opacity = '';
+                    dragLabelIdx = -1;
+                    bar.querySelectorAll('.pane-label').forEach(el => el.classList.remove('drag-over'));
+                });
+                span.addEventListener('dragover', (e) => {
+                    e.preventDefault();
+                    e.dataTransfer.dropEffect = 'move';
+                    span.classList.add('drag-over');
+                });
+                span.addEventListener('dragleave', () => { span.classList.remove('drag-over'); });
+                span.addEventListener('drop', (e) => {
+                    e.preventDefault();
+                    span.classList.remove('drag-over');
+                    if (dragLabelIdx < 0 || dragLabelIdx === i) return;
+                    const moved = panes.splice(dragLabelIdx, 1)[0];
+                    panes.splice(i, 0, moved);
+                    render();
+                });
+            }
 
             bar.appendChild(span);
         });
@@ -348,6 +402,8 @@
     function removePane(idx) {
         if (panes.length <= 1) return;
         panes.splice(idx, 1);
+        if (activePaneIdx >= panes.length) activePaneIdx = panes.length - 1;
+        clampActivePaneIdx();
         normalizeWidths();
         render();
     }
@@ -380,6 +436,15 @@
         if (e.key === 'eclaw-view-mode' && e.newValue === 'single') {
             window.location.href = (panes[0]?.id || 'dashboard') + '.html';
         }
+    });
+
+    window.addEventListener('resize', () => {
+        const mobileMode = isMobileWorkspace();
+        if (mobileMode === _lastMobileMode) return;
+        _lastMobileMode = mobileMode;
+        if (!mobileMode) activePaneIdx = 0;
+        clampActivePaneIdx();
+        render();
     });
 
     // ── Cross-pane quote routing ──


### PR DESCRIPTION
## Summary
- continue the QA/UIUX sweep with a focused mobile-readability batch across portal pages
- compact noisy dashboard / kanban previews so list views behave like status surfaces instead of transcript dumps
- improve mobile control density in chat, my-rentals, mission, wallet, and workspace

## Scope
- `dashboard.html`: compact raw entity message previews + tighter mobile card layout
- `kanban.html`: compact board-card descriptions on mobile + plain-text preview summarization
- `chat.html`: keep filter chips in a tighter horizontal row on mobile
- `my-rentals.html`: horizontal-scroll fallback for the 4-tab mobile bar
- `mission.html`: hide advanced page-viewer controls on narrow screens
- `wallet.html`: convert cramped mobile ledger rows into readable stacked rows
- `workspace.html`: add mobile single-pane fallback instead of preserving side-by-side split panes

## Issue mapping
- Closes #2848
- Closes #2850
- Closes #2852
- Closes #2853
- Continues the earlier scanability fixes from #2843 / #2844 / #2845

## Validation
- `npm run smoke:portal`
- `npx jest tests/jest/portal-smoke-static.test.js tests/jest/chat-targets-static.test.js tests/jest/kanban-nav-static.test.js --runInBand`
- inline-script parse check for touched pages: `wallet.html`, `workspace.html`, `my-rentals.html`, `mission.html`
- source-level assertions for all 7 touched pages
- headless Chromium check for `workspace.html?panes=dashboard,chat`
  - mobile `390x844` => 1 rendered iframe
  - desktop `1200x900` => 2 rendered iframes

## Review
Per current governance, this branch is ready for #2 peer review.
