### PR TITLE
i18n(kanban): translate kb_label_gated for 12 locales

### DIFF
--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -1080379,6 +1080379,7 @@ const TRANSLATIONS = {
 
 
         "kb_label_requires_screenshot": "需截圖審查（完成時附截圖才可推進 review/done）",
+        "kb_label_gated": "Launch-gate（發布閘）——開啟時，L1/L2/L3 自動升級跳过此卡；卡片離開發布就緒後自動解除",
 
 
 
@@ -2258883,6 +2258884,7 @@ const TRANSLATIONS = {
 
 
         "kb_label_requires_screenshot": "スクリーンショットのレビューが必要です（レビュー/完了に移動する前に添付）",
+        "kb_label_gated": "Launch-gate（起動闸）——バックログで有効にするとL1/L2/L3自動エスカレーションがスキップ；カードがバックログを離れれば自動解除",
 
 
 
@@ -2810361,6 +2810363,7 @@ const TRANSLATIONS = {
 
 
         "kb_label_requires_screenshot": "스크린샷 검토 필요 (검토/완료로 이동하기 전에 스크린샷 첨부)",
+        "kb_label_gated": "Launch-gate（런치 게이트）——백로그에서 활성화 시 L1/L2/L3 자동 에스컬레이션 건너뛰기; 카드가 백로그를 벗어나면 자동 해제",
 
 
 
@@ -3330240,6 +3330243,7 @@ const TRANSLATIONS = {
 
 
         "kb_label_requires_screenshot": "Requires screenshot review (attach a screenshot before moving to review/done)",
+        "kb_label_gated": "Launch-gate（ประตูเปิดตัว）——เปิดในแบล็กล็อกจะข้าม L1/L2/L3 อัตโนมัติ; การ์ดออกจากแบล็กล็อกจะปิดเอง",
 
 
 
@@ -3859004,6 +3859008,7 @@ const TRANSLATIONS = {
 
 
         "kb_label_requires_screenshot": "Requires screenshot review (attach a screenshot before moving to review/done)",
+        "kb_label_gated": "Launch-gate（Cổng khởi động）——Khi bật trong backlog, L1/L2/L3 tự động bỏ qua thẻ này; Tự động tắt khi thẻ rời backlog",
 
 
 
@@ -4385179,6 +4385184,7 @@ const TRANSLATIONS = {
 
 
         "kb_label_requires_screenshot": "Requires screenshot review (attach a screenshot before moving to review/done)",
+        "kb_label_gated": "Launch-gate（Gercek laci）——Ketika aktif di backlog, L1/L2/L3 auto-escalation akan melewati kartu ini; Nonaktif otomatis saat kartu keluar dari backlog",
 
 
 
@@ -4922747,6 +4922753,7 @@ const TRANSLATIONS = {
 
 
         "kb_label_requires_screenshot": "Requires screenshot review (attach a screenshot before moving to review/done)",
+        "kb_label_gated": "Launch-gate（barrière de lancement）——Lorsqu'elle est active dans le backlog, L1/L2/L3 ignore cette carte automatiquement ; se désactive quand la carte quitte le backlog",
 
 
 
@@ -5442425,6 +5442432,7 @@ const TRANSLATIONS = {
 
 
         "kb_label_requires_screenshot": "Requiere revisión de capturas (adjuntar antes de pasar a review/done)",
+        "kb_label_gated": "Launch-gate（puerta de lanzamiento）——Si está activa en backlog, L1/L2/L3 omite esta tarjeta automáticamente; Se desactiva al salir del backlog",
 
 
 
@@ -5963967,6 +5963975,7 @@ const TRANSLATIONS = {
 
 
         "kb_label_requires_screenshot": "Screenshot-Prüfung erforderlich (Screenshot anhängen, bevor du zu Prüfung/Fertig wechselst)",
+        "kb_label_gated": "Launch-gate（Starttor）——Wenn im Backlog aktiviert, überspringen L1/L2/L3 diese Karte automatisch; Wird automatisch deaktiviert, wenn die Karte das Backlog verlässt",
 
 
 
@@ -6433993,6 +6434002,7 @@ const TRANSLATIONS = {
 
 
         "kb_label_requires_screenshot": "Requires screenshot review (attach a screenshot before moving to review/done)",
+        "kb_label_gated": "Launch-gate（pintu lancar）——Bila aktif dalam backlog, L1/L2/L3 auto-escalation akan langkau kad ini; Akan matinya automatik bila kad keluar dari backlog",
 
 
 
@@ -6873907,6 +6873917,7 @@ const TRANSLATIONS = {
 
 
         "kb_label_requires_screenshot": "स्क्रीनशॉट समीक्षा आवश्यक है (समीक्षा/पूर्ण में ले जाने से पहले स्क्रीनशॉट अटैच करें)",
+        "kb_label_gated": "Launch-gate（लॉन्च गेट）——बैकलॉग में सक्रिय होने पर L1/L2/L3 ऑटो-एस्केलेशन इस कार्ड को छोड़ देता है; कार्ड के बैकलॉग छोड़ने पर स्वचालित रूप से साफ़ हो जाता है",
 
 
 
@@ -7520323,6 +7520334,7 @@ const TRANSLATIONS = {
 
 
         "kb_label_requires_screenshot": "يتطلب مراجعة لقطة شاشة (أرفق قبل الانتقال إلى review/done)",
+        "kb_label_gated": "Launch-gate（بوابة الإطلاق）——عند تفعيلها في القائمة الاحتياطية، تتخطى L1/L2/L3 ترقية هذه البطاقة تلقائيًا؛ تُلغى تلقائيًا عند مغادرة البطاقة للقائمة الاحتياطية",
 
 
 


### PR DESCRIPTION
i18n translation for kb_label_gated across 12 locales. 1 file changed.