### PR TITLE
fix(rental): don't pollute entity.message on push gateway timeout

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -16091,18 +16091,32 @@ async function pushToBot(entity, deviceId, eventType, payload, opts = {}) {
         console.error(`[Push] Full error:`, err);
         serverLog('error', 'push_error', `Entity ${entity.entityId} push exception: ${err.message}`, { deviceId, entityId: entity.entityId });
 
-        // Notify device about webhook failure via entity message
-        // BUT skip if bot already responded via /api/transform during the push (lastUpdated changed)
-        if (entity.lastUpdated && entity.lastUpdated > pushStartedAt) {
-            console.log(`[Push] Skipping WEBHOOK_ERROR — bot already responded via transform during push (Device ${deviceId} Entity ${entity.entityId})`);
+        // AbortError / TimeoutError: gateway didn't ack within 15s but the bot may
+        // still be processing and reply async via /api/transform. Don't pollute
+        // entity.message with diagnostic text (push_status carries the signal).
+        // Without this guard, a slow-but-successful round trip races: catch fires
+        // before transform writes the reply → entity.message = WEBHOOK_ERROR briefly →
+        // transform overwrites → user/client polling between the two sees noise.
+        const isAbort = err.name === 'AbortError' || err.name === 'TimeoutError'
+            || /aborted|timeout/i.test(err.message || '');
+
+        if (!isAbort) {
+            // Hard connection failure (ENOTFOUND / ECONNREFUSED / TLS / etc.) — surface to UI.
+            // Skip if bot already responded via /api/transform during the push (lastUpdated changed).
+            if (entity.lastUpdated && entity.lastUpdated > pushStartedAt) {
+                console.log(`[Push] Skipping WEBHOOK_ERROR — bot already responded via transform during push (Device ${deviceId} Entity ${entity.entityId})`);
+            } else {
+                entity.message = `[SYSTEM:WEBHOOK_ERROR] Push connection failed: ${err.message}`;
+                entity.lastUpdated = Date.now();
+                console.log(`[Push] Set WEBHOOK_ERROR system message for Device ${deviceId} Entity ${entity.entityId}`);
+            }
         } else {
-            entity.message = `[SYSTEM:WEBHOOK_ERROR] Push connection failed: ${err.message}`;
-            entity.lastUpdated = Date.now();
-            console.log(`[Push] Set WEBHOOK_ERROR system message for Device ${deviceId} Entity ${entity.entityId}`);
+            console.log(`[Push] Push gateway timeout (no ack in 15s) — bot may reply async via /api/transform. Not polluting entity.message. Device ${deviceId} Entity ${entity.entityId}`);
         }
 
-        entity.pushStatus = { ok: false, reason: err.message, at: Date.now() };
-        return { pushed: false, reason: err.message };
+        const reasonCode = isAbort ? 'push_timeout' : err.message;
+        entity.pushStatus = { ok: false, reason: reasonCode, at: Date.now() };
+        return { pushed: false, reason: reasonCode };
     }
 }
 


### PR DESCRIPTION
## Summary
- Stops `[SYSTEM:WEBHOOK_ERROR]` from briefly landing in `entity.message` when a slow-but-successful bot round-trip exceeds the 15s gateway-ack timeout but still replies via `/api/transform`.
- Normalizes the `/api/client/speak` `targets[].reason` from the raw `"The operation was aborted due to timeout"` string to a clean `push_timeout` code.
- Hard connection failures (ENOTFOUND / ECONNREFUSED / TLS) still set the WEBHOOK_ERROR marker so Android `StateRepository` can render its localized error UI.

## Why
E2E rental drill (BROADCAST_TEST device against `/api/official-borrow/*` free bots) observed:
- A) `/api/client/speak` returning `reason: "The operation was aborted due to timeout"` from round 3+ even when message + reply succeeded
- B) `entity.message` briefly polluted with `[SYSTEM:WEBHOOK_ERROR] Push connection failed: ...` on transient webhook slowness

Both stem from the catch block at `pushToBot` racing against the bot's async reply path.

Tracked in card_6097e8e2cdc63a8c016a1955.

## Test plan
- [x] backend/tests/jest/a2a-message-rendering.test.js (unchanged behavior, system-message skip pattern still passes)
- [x] backend/tests/jest/cross-speak-channel.test.js
- [ ] Manual E2E: rebind BROADCAST_TEST → free bot, run 5-round speak, verify no `[SYSTEM:WEBHOOK_ERROR]` in entity.message + chat_history clean (will run after Railway deploys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)