### PR TITLE
fix(rental): remove phantom 'webhook test push' step from BIND_COMPLETE

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -5193,14 +5193,8 @@ exec: curl -s -X POST "${apiBase}/api/transform" -H "Content-Type: application/j
 
 Do NOT call /api/bind or /api/bot/register — webhook is already configured for you.
 
-⚠️ IMMEDIATE ACTION REQUIRED:
-1. FIRST: Run this command RIGHT NOW:
-exec: curl -s -X POST "${apiBase}/api/transform" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${entityId},"botSecret":"${botSecret}","targetDeviceId":"${deviceId}","state":"BUSY","message":"Webhook testing in progress... Please don't send me messages through Eclaw until the test succeeds~"}'
-
-2. THEN: Wait for the webhook test push message from the server.
-
-3. AFTER webhook test succeeds, run:
-exec: curl -s -X POST "${apiBase}/api/transform" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${entityId},"botSecret":"${botSecret}","targetDeviceId":"${deviceId}","state":"IDLE","message":"Webhook test passed! I am ready to chat~"}'
+⚠️ IMMEDIATE ACTION REQUIRED — Run this command RIGHT NOW to confirm you're online (server will NOT send any additional test push):
+exec: curl -s -X POST "${apiBase}/api/transform" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${entityId},"botSecret":"${botSecret}","targetDeviceId":"${deviceId}","state":"IDLE","message":"Hi! I am online and ready to chat~"}'
 
 --- E-Claw API Documentation (Latest) ---
 ${skillDoc}`;
@@ -5227,8 +5221,8 @@ YOUR CREDENTIALS (save these):
 
 Every push message will include a pre-filled curl command. Just replace YOUR_REPLY_HERE and execute it.
 
-⚠️ IMMEDIATE ACTION REQUIRED — Run this command RIGHT NOW to confirm you're online:
-exec: curl -s -X POST "https://eclawbot.com/api/transform" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${entityId},"botSecret":"${botSecret}","targetDeviceId":"${deviceId}","state":"IDLE","message":"Webhook test passed! I am ready to chat~"}'`;
+⚠️ IMMEDIATE ACTION REQUIRED — Run this command RIGHT NOW to confirm you're online (server will NOT send any additional test push):
+exec: curl -s -X POST "https://eclawbot.com/api/transform" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${entityId},"botSecret":"${botSecret}","targetDeviceId":"${deviceId}","state":"IDLE","message":"Hi! I am online and ready to chat~"}'`;
                 try {
                     const retryResult = await sendToSession(webhookUrl, webhookToken, sessionKey, shortMsg, authOpts, { timeout: 30000 });
                     if (retryResult.success) {


### PR DESCRIPTION
## 根因 (smoking gun)

`backend/index.js:5198`（修改前）BIND_COMPLETE 指示寫：
> 2. THEN: Wait for the webhook test push message from the server.

但 grep 整個 backend：
```
$ grep -E 'webhook test push|SYSTEM:WEBHOOK_TEST|webhookTest|webhook_test' backend/index.js
5200:2. THEN: Wait for the webhook test push message from the server.
```
**只剩這句指示，server 端零 code 會送出該 push。** Phantom step。

## 症狀

post-deploy (PR #2863) BROADCAST_TEST 3 隻 free bot：
- Cloud_Zeabur ✅ 自動跳過 phantom step 2，直接送 IDLE，正常回 ping
- Mac本地版_A ✗ 嚴格照字面卡在 BUSY，永遠不送 step 3 → user push 60s 無回應
- Mac本地版_B ✗ 同上，entity.message=「Webhook testing in progress...」

跟 @#1 對 code 確認後採納他「step 1+3 合併」建議：bot 收到 BIND_COMPLETE 後**單一**指令立即送 IDLE confirmation，BUSY 跟 phantom test step 都拿掉。

## 修法

`sendBindCredentialsToBot()`（backend/index.js:5175）兩份模板：
- 長版（skill-doc）— 把 3-step 收成 1-step IDLE
- shortMsg fallback — 文字同步成「Hi! I am online and ready to chat~」，並加註「server will NOT send any additional test push」防止未來 bot 又重發 wait-loop

## 驗證計畫

merge 後 Railway 自動部署 → 重跑 BROADCAST_TEST E2E（同 PR #2863 用的 /tmp/rental_e2e.py 等價腳本），預期：
- 3/3 bot 都送出 IDLE confirmation 訊息（不再有「Webhook testing in progress」滯留）
- 3/3 bot 都能回 `healthcheck pong` 給 client/speak push

## Reviewer note

Backend-only 文字常數改動，純後端，不動 API contract / DB schema / handshake timing。

🤖 Generated with [Claude Code](https://claude.com/claude-code)