### PR TITLE
fix(share-chat): wire rich CTA actions to msgInput

### DIFF
--- a/backend/public/portal/share-chat.html
+++ b/backend/public/portal/share-chat.html
@@ -1355,7 +1355,7 @@
         } else if (action.action === 'order' || action.action === 'buy') {
             showOrderDialog(block);
         } else if (action.action === 'send' && action.text) {
-            const input = document.getElementById('messageInput');
+            const input = document.getElementById('msgInput');
             if (input) {
                 input.value = action.text;
                 input.dispatchEvent(new Event('input'));
@@ -1418,7 +1418,7 @@
                 dialog.remove();
                 window.open(result.paymentUrl, '_blank');
                 // Also tell the bot
-                const input = document.getElementById('messageInput');
+                const input = document.getElementById('msgInput');
                 if (input) {
                     input.value = ((typeof i18n !== 'undefined' && i18n.t) ? i18n.t('sc_order_placed') : 'I ordered: ') + (product.name || ((typeof i18n !== 'undefined' && i18n.t) ? i18n.t('sc_order_product') : 'Product')) + ' (' + ((typeof i18n !== 'undefined' && i18n.t) ? i18n.t('sc_order_id_prefix') : 'Order ') + result.orderId + ')';
                     input.dispatchEvent(new Event('input'));

--- a/backend/tests/jest/share-chat.test.js
+++ b/backend/tests/jest/share-chat.test.js
@@ -340,6 +340,11 @@ describe('share-chat registration flow (static analysis)', () => {
             expect(count).toBeGreaterThanOrEqual(langs.length);
         }
     });
+
+    it('rich-card actions target the visible #msgInput composer', () => {
+        expect(html).toContain("document.getElementById('msgInput')");
+        expect(html).not.toContain("document.getElementById('messageInput')");
+    });
 });
 
 // ════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary
- fix Share Chat rich-card CTA flows that were targeting a nonexistent `#messageInput`
- route both quick-send CTAs and order follow-up messaging through the real public composer `#msgInput`
- add a regression test so the share-chat page cannot silently drift back to the wrong composer id

## Issue
- Closes #2866

## QA / audit context
This came out of the daily QA/UIUX sweep on the newest portal surfaces after re-auditing:
- `share-chat` (found issue #2866)
- `settings` (no new blocking issue found in this pass)
- `kanban` launch-gate flow (no new blocking issue found in this pass)

## Validation
- inline `share-chat.html` script parse
- `npx jest tests/jest/share-chat.test.js --runInBand`

## Risk
Low. The fix is isolated to Share Chat CTA handlers plus one static regression assertion.

## Review
Ready for #2 code review.