### PR TITLE
fix(gateway-ws): drop Origin header on server-to-server WS upgrade

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -15186,10 +15186,13 @@ async function getWsConnection(httpUrl, token, setupUsername, setupPassword) {
     console.log(`[GatewayWS] Opening new connection to ${wsUrl}`);
 
     return new Promise((resolve, reject) => {
+        // No Origin header on server-to-server WS upgrade. openclaw gateway treats
+        // any non-empty Origin as browser-originated and enforces controlUi.allowedOrigins
+        // for ALL clients (resolveHandshakeBrowserSecurityContext), rejecting with
+        // CONTROL_UI_ORIGIN_NOT_ALLOWED + close 1008.
         const ws = new WebSocket(wsUrl, {
             headers: {
-                'Authorization': 'Basic ' + Buffer.from(`${setupUsername}:${setupPassword}`).toString('base64'),
-                'Origin': `https://${new URL(httpUrl).host}`
+                'Authorization': 'Basic ' + Buffer.from(`${setupUsername}:${setupPassword}`).toString('base64')
             }
         });
 


### PR DESCRIPTION
## Summary
- Remove `Origin` header from `getWsConnection` WS upgrade in `backend/index.js`. openclaw gateway's `resolveHandshakeBrowserSecurityContext` treats any non-empty Origin header as browser-originated and enforces `gateway.controlUi.allowedOrigins` allowlist for ALL clients — not just CONTROL_UI/webchat. With empty allowlist (default) the WS upgrade is rejected with `CONTROL_UI_ORIGIN_NOT_ALLOWED` close 1008, causing free-bot pushes to fail with `push_timeout` via stale pool reuse.
- Fixes silent failure on free bots whose freebot DB row has `setup_username`+`setup_password` populated (forces `gatewayFetch` onto the WS path). Affected: `Local_Mac_MiniMax2.7` (project-e), `Local_Mac_CodexGPT5.5_xhight` (project-f). `Cloud_Zeabur_MiniMax2.5` was unaffected since it has no setup creds and falls through to the HTTP path.

## Root cause trace
- gateway-cli (`/app/dist/gateway-cli-yb-PhDCz.js` line 40338) `resolveHandshakeBrowserSecurityContext`:
  ```js
  const hasBrowserOriginHeader = Boolean(params.requestOrigin && params.requestOrigin.trim() !== "");
  return { hasBrowserOriginHeader, enforceOriginCheckForAnyClient: hasBrowserOriginHeader, ... };
  ```
- gateway-cli line 40609 wraps the origin check in `if (enforceOriginCheckForAnyClient || isControlUi || isWebchat) { ... checkBrowserOrigin(...) }` — so any Origin header triggers it.
- EClaw backend sends `Origin: https://X.eclawbot.com` which is not in the empty `gateway.controlUi.allowedOrigins` → reject → close 1008.

## Verification
Direct WS probe against `wss://e.eclawbot.com` (used the same `ws` lib + connect frame the backend uses):

| Origin header | Result |
|---|---|
| `https://e.eclawbot.com` | close 1008 `origin not allowed` |
| (none) | `ok:true` + hello-ok payload + protocol:3 + features list + health/tick events streaming |

Probe scripts: `/tmp/ws_connect_probe2.js`, `/tmp/ws_full_probe.js`.

## Test plan
- [ ] Manual re-run of v2 SKILL `api-health-rental-e2e` on `Local_Mac_MiniMax2.7` + `Local_Mac_CodexGPT5.5_xhight` free bots after deploy: expect `pushed=True` + reply received
- [ ] Confirm `Cloud_Zeabur_MiniMax2.5` (HTTP path, unaffected) still replies post-deploy
- [ ] Watch Railway logs for any `[GatewayWS]` close 1008 entries to confirm none appear

## Related
- Kanban card `card_a05198473bd4c696b70ac837` (P0)
- Memory `reference_channel_api_key_probe.md` updated with corrected diagnosis

🤖 Generated with [Claude Code](https://claude.com/claude-code)