### PR TITLE
fix(routing): support Chinese displayName in @-mention parser

### DIFF
--- a/backend/mention-parser.js
+++ b/backend/mention-parser.js
@@ -62,6 +62,52 @@ const ALL_TOKEN_RE = /(^|\s)@all(?=\s|$|[^\w])/i;
 // Global form for stripping @all (sequential .replace() needs the /g flag).
 const ALL_TOKEN_GLOBAL_RE = /(^|\s)@all(?=\s|$|[^\w])/gi;
 
+function isMentionBoundaryBefore(text, atIndex) {
+    if (atIndex <= 0) return true;
+    const ch = text[atIndex - 1];
+    return !(/[\p{L}\p{N}_@<]/u.test(ch));
+}
+
+function isMentionBoundaryAfter(text, endIndex) {
+    if (endIndex >= text.length) return true;
+    const ch = text[endIndex];
+    return !(/[\p{L}\p{N}_]/u.test(ch));
+}
+
+function buildSameDeviceNameCandidates(senderDeviceId, devices) {
+    const senderDevice = devices && devices[senderDeviceId];
+    const entities = senderDevice && senderDevice.entities;
+    if (!entities) return [];
+
+    const seen = new Set();
+    const out = [];
+    for (const [entityIdRaw, entity] of Object.entries(entities)) {
+        const entityId = parseInt(entityIdRaw, 10);
+        if (!entity || !entity.isBound || !entity.publicCode || !Number.isFinite(entityId)) continue;
+        const names = [entity.name, entity.character]
+            .filter(v => typeof v === 'string')
+            .map(v => v.trim())
+            .filter(Boolean);
+        for (const label of names) {
+            const key = `${label}::${entity.publicCode}`;
+            if (seen.has(key)) continue;
+            seen.add(key);
+            out.push({
+                label,
+                entityId,
+                publicCode: entity.publicCode,
+                deviceId: senderDeviceId,
+                name: entity.name || entity.character || `Entity ${entityId}`,
+                isCrossDevice: false,
+                isBound: true
+            });
+        }
+    }
+
+    out.sort((a, b) => b.label.length - a.label.length);
+    return out;
+}
+
 // Markdown code spans — examples / docs inside backticks must NOT route.
 // Replace each code-span region with same-length whitespace so character
 // indices stay aligned (in case any caller relies on them later) but no
@@ -154,6 +200,7 @@ function parseMentions(text, ctx) {
     //    The bare form is what LLMs naturally write and is parsed as a
     //    convenience so routing intent in `@codex hi` style still works.
     let m;
+    const namedMentionSpans = [];
     const resolvePublicCodeToken = (code) => {
         if (seenPublicCodes.has(code)) return;
         const target = publicCodeIndex[code];
@@ -197,7 +244,53 @@ function parseMentions(text, ctx) {
         }
     }
 
-    // 3+4. Build displayText and cleanText by scanning routedText (code spans
+    // 3. same-device display-name mentions — `@阿尼雅_Codex5.5` and the
+    //    common disambiguated form `@阿尼雅_Codex5.5 #6`. Historically the
+    //    system only supported ASCII-ish publicCode / entityId tokens, so
+    //    Chinese display-name mentions never routed. We intentionally keep
+    //    this same-device-only to avoid ambiguous cross-device name matches.
+    const sameDeviceNameCandidates = buildSameDeviceNameCandidates(senderDeviceId, devices);
+    for (let at = routedText.indexOf('@'); at !== -1; at = routedText.indexOf('@', at + 1)) {
+        if (!isMentionBoundaryBefore(routedText, at)) continue;
+        const tail = routedText.slice(at + 1);
+        for (const candidate of sameDeviceNameCandidates) {
+            if (!tail.startsWith(candidate.label)) continue;
+            const afterName = at + 1 + candidate.label.length;
+            let end = afterName;
+            const suffixMatch = routedText.slice(afterName).match(/^[\s　]*#(\d{1,3})(?![\p{L}\p{N}_])/u);
+            if (suffixMatch && parseInt(suffixMatch[1], 10) === candidate.entityId) {
+                end = afterName + suffixMatch[0].length;
+            }
+            if (!isMentionBoundaryAfter(routedText, end)) continue;
+            if (!seenPublicCodes.has(candidate.publicCode)) {
+                seenPublicCodes.add(candidate.publicCode);
+                result.mentions.push({
+                    publicCode: candidate.publicCode,
+                    deviceId: candidate.deviceId,
+                    entityId: candidate.entityId,
+                    name: candidate.name,
+                    isCrossDevice: false,
+                    isBound: true
+                });
+            }
+            namedMentionSpans.push({
+                start: at,
+                end,
+                hit: {
+                    publicCode: candidate.publicCode,
+                    deviceId: candidate.deviceId,
+                    entityId: candidate.entityId,
+                    name: candidate.name,
+                    isCrossDevice: false,
+                    isBound: true
+                },
+                literal: routedText.slice(at, end)
+            });
+            break;
+        }
+    }
+
+    // 4+5. Build displayText and cleanText by scanning routedText (code spans
     //      masked) and splicing replacements into the ORIGINAL text. This way
     //      backtick-wrapped tokens are preserved as-is in both outputs:
     //      display keeps the literal backticks visible, and Gatekeeper sees
@@ -218,7 +311,7 @@ function parseMentions(text, ctx) {
         { re: ENTITY_ID_HASH_RE,    lookup: findByEntityId },
         { re: ENTITY_ID_BARE_RE,    lookup: findByEntityId },
     ];
-    const spans = [];
+    const spans = namedMentionSpans.slice();
     for (const { re, lookup } of passes) {
         re.lastIndex = 0;
         let mm;

--- a/backend/tests/jest/mention-parser.test.js
+++ b/backend/tests/jest/mention-parser.test.js
@@ -365,6 +365,65 @@ describe('mention-parser.parseMentions', () => {
     });
 });
 
+describe('mention-parser — same-device display-name mentions (CJK / mixed-script)', () => {
+    function makeNameCtx() {
+        const devices = {
+            'dev-sender': {
+                entities: {
+                    1: { isBound: true, name: '小傑富力士_本地蝦Codex5.4_F', publicCode: '31tlkr' },
+                    6: { isBound: true, name: '阿尼雅_Codex5.5', publicCode: 'q0ue2k' }
+                }
+            },
+            'dev-other': {
+                entities: {
+                    6: { isBound: true, name: '阿尼雅_Codex5.5', publicCode: 'zzzz66' }
+                }
+            }
+        };
+        const publicCodeIndex = {
+            '31tlkr': { deviceId: 'dev-sender', entityId: 1 },
+            'q0ue2k': { deviceId: 'dev-sender', entityId: 6 },
+            'zzzz66': { deviceId: 'dev-other', entityId: 6 }
+        };
+        return { senderDeviceId: 'dev-sender', devices, publicCodeIndex };
+    }
+
+    test('resolves a same-device CJK display-name mention', () => {
+        const r = mp.parseMentions('@阿尼雅_Codex5.5 你好', makeNameCtx());
+        expect(r.mentions).toHaveLength(1);
+        expect(r.mentions[0]).toMatchObject({
+            publicCode: 'q0ue2k',
+            entityId: 6,
+            name: '阿尼雅_Codex5.5',
+            isCrossDevice: false
+        });
+    });
+
+    test('production repro — `@阿尼雅_Codex5.5 #6` routes to same-device entity 6', () => {
+        const r = mp.parseMentions('@阿尼雅_Codex5.5 #6 — 我找到真正的 root cause 了', makeNameCtx());
+        expect(r.mentions).toHaveLength(1);
+        expect(r.mentions[0].entityId).toBe(6);
+        expect(r.cleanText).toBe('— 我找到真正的 root cause 了');
+    });
+
+    test('same-device display-name mention ignores identical cross-device names', () => {
+        const r = mp.parseMentions('@阿尼雅_Codex5.5 please check', makeNameCtx());
+        expect(r.mentions).toHaveLength(1);
+        expect(r.mentions[0].deviceId).toBe('dev-sender');
+        expect(r.mentions[0].publicCode).toBe('q0ue2k');
+    });
+
+    test('display-name mentions inside inline code do NOT route', () => {
+        const r = mp.parseMentions('Example token: `@阿尼雅_Codex5.5 #6`', makeNameCtx());
+        expect(r.mentions).toEqual([]);
+    });
+
+    test('glued text before @name does NOT route (boundary guard)', () => {
+        const r = mp.parseMentions('hello@阿尼雅_Codex5.5 world', makeNameCtx());
+        expect(r.mentions).toEqual([]);
+    });
+});
+
 describe('mention-parser.decideRouting', () => {
     test('returns none when no mentions', () => {
         const r = mp.decideRouting({ hasAll: false, mentions: [] });


### PR DESCRIPTION
## Summary
- add same-device display-name mention parsing for CJK / mixed-script names such as `@阿尼雅_Codex5.5`
- support the production repro form `@阿尼雅_Codex5.5 #6` by consuming an optional matching ` #N` disambiguator
- keep existing code-span guards and boundary protections so docs / inline examples still do not route

## Issue
- Closes #2873

## Production evidence
History record `d6b933a1-a315-419b-aa4e-674c37a5c9c3` contained `@阿尼雅_Codex5.5 #6`, but parsed mentions only included entities 1 and 2; entity 6 was missing.

## Validation
- direct parser repro for `@阿尼雅_Codex5.5 #6` now resolves entity 6 and strips the whole mention from `cleanText`
- `NODE_ENV=development npx jest tests/jest/mention-parser.test.js --runInBand` → 73/73 pass

## Notes
- name-based mention resolution is intentionally limited to the sender device to avoid ambiguous cross-device display-name routing
- identical cross-device names are ignored; explicit publicCode forms still handle cross-device fan-out

## Review / follow-up
After review, please have #2 / `@本地ClaudeChan_opus4.7` rerun E2E with the exact form `@阿尼雅_Codex5.5 #6`.