### PR TITLE
fix(setup-scripts): drop Origin header on server-to-server WS upgrade

### DIFF
--- a/backend/scripts/setup_broadcast_webhook.js
+++ b/backend/scripts/setup_broadcast_webhook.js
@@ -30,10 +30,12 @@ const ECLAW_API = process.env.ECLAW_API_URL || 'https://eclawbot.com';
 
 async function wsConnect(url, username, password, gatewayToken, setupPassword) {
   return new Promise((resolve, reject) => {
+    // No Origin header on server-to-server WS upgrade — see PR #2869 for context.
+    // openclaw gateway treats any non-empty Origin as browser-originated and enforces
+    // controlUi.allowedOrigins for ALL clients, rejecting setup scripts with close 1008.
     const ws = new WebSocket(url, {
       headers: {
-        'Authorization': 'Basic ' + Buffer.from(username + ':' + password).toString('base64'),
-        'Origin': 'https://' + new URL(url.replace('wss://', 'https://')).host
+        'Authorization': 'Basic ' + Buffer.from(username + ':' + password).toString('base64')
       }
     });
     let reqCounter = 0;

--- a/backend/scripts/setup_test_bot.js
+++ b/backend/scripts/setup_test_bot.js
@@ -30,10 +30,12 @@ const ECLAW_API = process.env.ECLAW_API_URL || 'https://eclawbot.com';
 
 async function wsConnect(url, username, password, gatewayToken, setupPassword) {
   return new Promise((resolve, reject) => {
+    // No Origin header on server-to-server WS upgrade — see PR #2869 for context.
+    // openclaw gateway treats any non-empty Origin as browser-originated and enforces
+    // controlUi.allowedOrigins for ALL clients, rejecting setup scripts with close 1008.
     const ws = new WebSocket(url, {
       headers: {
-        'Authorization': 'Basic ' + Buffer.from(username + ':' + password).toString('base64'),
-        'Origin': 'https://' + new URL(url.replace('wss://', 'https://')).host
+        'Authorization': 'Basic ' + Buffer.from(username + ':' + password).toString('base64')
       }
     });
     let reqCounter = 0;

--- a/backend/tests/test-ws-auth.js
+++ b/backend/tests/test-ws-auth.js
@@ -32,10 +32,12 @@ async function testWsFlow() {
 
   // Test 1: Connect
   console.log('[Test 1] WebSocket connect + auth...');
+  // No Origin header on server-to-server WS upgrade — see PR #2869 for context.
+  // openclaw gateway treats any non-empty Origin as browser-originated and enforces
+  // controlUi.allowedOrigins for ALL clients, rejecting setup scripts with close 1008.
   const ws = new WebSocket(GATEWAY_URL, {
     headers: {
-      'Authorization': 'Basic ' + Buffer.from(`${SETUP_USERNAME}:${SETUP_PASSWORD}`).toString('base64'),
-      'Origin': `https://clawdbot-railway-template-production-e663.up.railway.app`
+      'Authorization': 'Basic ' + Buffer.from(`${SETUP_USERNAME}:${SETUP_PASSWORD}`).toString('base64')
     }
   });
 


### PR DESCRIPTION
## Summary
Sibling fix to PR #2869. Removes the `'Origin'` header from three setup/diagnostic scripts that hit the same close-1008 against any openclaw gateway with empty `controlUi.allowedOrigins`:

- `backend/scripts/setup_test_bot.js`
- `backend/scripts/setup_broadcast_webhook.js`
- `backend/tests/test-ws-auth.js` (manual diagnostic, not jest — not run in CI)

## Why
PR #2869 fixed `getWsConnection` in `backend/index.js` so the live free-bot push path no longer sends an Origin header. These three scripts predated that path and reach the same gateway with the same anti-pattern, so they reproduce the original failure mode (close 1008 / `CONTROL_UI_ORIGIN_NOT_ALLOWED` + hang) the moment they're run against an unconfigured openclaw deployment.

Root cause (recap from #2869): openclaw gateway's `resolveHandshakeBrowserSecurityContext` sets `enforceOriginCheckForAnyClient = (Origin header present)`. Any non-empty Origin makes the gateway enforce `gateway.controlUi.allowedOrigins` for ALL clients, not just CONTROL_UI/webchat. With empty allowedOrigins (default), the WS upgrade is rejected.

The mitigation is the same one-line removal. Server-to-server WS doesn't need an Origin header.

## Test plan
- [x] `git diff --stat` shows only the 3 files, 6 deletions / 12 insertions (only adding the explanatory comment + removing the Origin line)
- [x] Pattern matches PR #2869 verbatim — same fix, same callsite shape
- [x] No CI impact: `test-ws-auth.js` lives in `backend/tests/` but is NOT in `backend/tests/jest/`; it's a manual diagnostic script (`node test-ws-auth.js`), not picked up by jest's default rootDir
- [ ] Local repro: would need a stale openclaw deployment with the pre-#2869 behavior; verifying live is gated on a stale env, but the change is mechanically identical to the verified #2869 fix

Card: `card_f48a111239e70917d84a84b7`

🤖 Generated with [Claude Code](https://claude.com/claude-code)