### PR TITLE
fix(i18n): dedup zh/ja/ko/ar duplicate-key bloat (5070 lines)

### DIFF
--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -649916,8 +649916,6 @@ const TRANSLATIONS = {
         "promo_video_primary_cta": "開啟 EClawbot Portal",
         "promo_video_secondary_cta": "回到首頁",
         "promo_video_note": "影片由 EClaw repo 外部的 HyperFrames composition 發布。",
-        "daily_video_section_title": "每日產品更新",
-        "daily_video_section_caption": "EClawbot 每日出貨的短片紀錄，新版本上線時更新。",
         "promo_meta_meta_title": "EClawbot Concept A｜Meta-recursion 紀錄片",
         "promo_meta_meta_description": "觀看 Concept A：以紀錄式真實素材呈現 EClawbot，讓幕後 AI 工作流本身成為產品展示。",
         "promo_meta_eyebrow": "Concept A · meta-recursion 紀錄式驚喜版",
@@ -650061,7 +650059,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_title": "EClawbot Mission Control",
 
 
 
@@ -650189,7 +650186,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_tab_label": "心智",
 
 
 
@@ -650317,7 +650313,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_auth_title": "Mission Control",
 
 
 
@@ -650445,7 +650440,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_auth_subtitle": "輸入你的裝置憑證來同步 Dashboard",
 
 
 
@@ -650573,7 +650567,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_input_device_id": "Device ID",
 
 
 
@@ -650701,7 +650694,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_input_device_secret": "Device Secret",
 
 
 
@@ -650829,7 +650821,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_btn_connect": "連線",
 
 
 
@@ -650957,7 +650948,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_auth_error_missing": "請輸入 Device ID 和 Secret",
 
 
 
@@ -651085,7 +651075,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_refresh": "重新整理",
 
 
 
@@ -651213,7 +651202,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_notify_btn": "發布通知",
 
 
 
@@ -651341,7 +651329,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_syncing": "同步中...",
 
 
 
@@ -651469,7 +651456,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_notify_dialog_title": "📢 發布任務更新通知",
 
 
 
@@ -651597,7 +651583,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_notify_dialog_desc": "選擇要通知的項目，將透過 Webhook 推送給對應的實體：",
 
 
 
@@ -651725,7 +651710,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_notify_skip": "跳過",
 
 
 
@@ -651853,7 +651837,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_notify_send": "發送通知",
 
 
 
@@ -651981,7 +651964,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_no_notify_items": "沒有新的變更需要通知",
 
 
 
@@ -652109,7 +652091,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_todo_title": "待辦事項",
 
 
 
@@ -652237,7 +652218,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_btn_add": "+ 新增",
 
 
 
@@ -652365,7 +652345,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_deprecated_add": "請使用看板任務作為替代方案。看板任務頁面已有完整生態，請讓 bot 將現有任務逐步轉移到看板任務頁面。",
 
 
 
@@ -652493,7 +652472,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_mission_title": "任務列表",
 
 
 
@@ -652621,7 +652599,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_done_title": "已完成",
 
 
 
@@ -654070,7 +654047,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_notes_title": "筆記",
 
 
 
@@ -654198,7 +654174,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_rules_title": "規則 (Workflow)",
 
 
 
@@ -654326,7 +654301,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_sync_unsaved": "* 未儲存的變更",
 
 
 
@@ -654454,7 +654428,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_sync_synced": "已同步",
 
 
 
@@ -654582,7 +654555,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_task_saved": "任務已儲存",
 
 
 
@@ -654710,7 +654682,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_empty_todo": "尚無待辦事項",
 
 
 
@@ -654838,7 +654809,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_empty_mission": "尚無進行中的任務",
 
 
 
@@ -654966,7 +654936,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_empty_done": "尚無已完成項目",
 
 
 
@@ -655094,7 +655063,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_empty_notes": "尚無筆記",
 
 
 
@@ -655222,7 +655190,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_empty_rules": "尚無規則",
 
 
 
@@ -655350,7 +655317,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_status_pending": "待處理",
 
 
 
@@ -655478,7 +655444,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_status_inprogress": "執行中",
 
 
 
@@ -655606,7 +655571,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_status_blocked": "阻塞中",
 
 
 
@@ -655734,7 +655698,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_status_done": "完成",
 
 
 
@@ -655862,7 +655825,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_status_cancelled": "已取消",
 
 
 
@@ -655990,7 +655952,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_priority_low": "低",
 
 
 
@@ -656118,7 +656079,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_priority_medium": "中",
 
 
 
@@ -656246,7 +656206,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_priority_high": "高",
 
 
 
@@ -656374,7 +656333,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_priority_urgent": "緊急",
 
 
 
@@ -656502,7 +656460,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_confirm_delete": "確定刪除？",
 
 
 
@@ -656630,7 +656587,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_confirm_version": "版本衝突 (你: v{you}, 伺服器: v{server})。要下載最新版本嗎？",
 
 
 
@@ -656758,7 +656714,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_add_todo": "新增待辦事項",
 
 
 
@@ -656886,7 +656841,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_edit": "編輯",
 
 
 
@@ -657014,7 +656968,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_title": "標題",
 
 
 
@@ -657142,7 +657095,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_desc": "描述",
 
 
 
@@ -657270,7 +657222,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_priority": "優先權",
 
 
 
@@ -657398,7 +657349,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_save": "儲存",
 
 
 
@@ -657526,7 +657476,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_cancel": "取消",
 
 
 
@@ -657654,7 +657603,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_due_at": "執行時間",
 
 
 
@@ -657782,7 +657730,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_card_due_at": "執行時間",
 
 
 
@@ -657910,7 +657857,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_card_countdown": "倒數計時",
 
 
 
@@ -658038,7 +657984,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_countdown_overdue": "已逾期",
 
 
 
@@ -658166,7 +658111,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_countdown_min": "分鐘",
 
 
 
@@ -658294,7 +658238,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_countdown_hr": "小時",
 
 
 
@@ -658422,7 +658365,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_countdown_day": "天",
 
 
 
@@ -658550,7 +658492,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_add_note": "新增筆記",
 
 
 
@@ -658678,7 +658619,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_edit_note": "編輯筆記",
 
 
 
@@ -658806,7 +658746,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_content": "內容",
 
 
 
@@ -658934,7 +658873,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_category": "分類",
 
 
 
@@ -659062,7 +659000,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_add_category": "+ 類別",
 
 
 
@@ -659190,7 +659127,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_rename_category": "重新命名",
 
 
 
@@ -659318,7 +659254,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_delete_category": "刪除類別",
 
 
 
@@ -659446,7 +659381,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_clear_category": "清空類別",
 
 
 
@@ -659574,7 +659508,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_uncategorized": "-- 未分類 --",
 
 
 
@@ -659702,7 +659635,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_confirm_clear_category": "清空此類別的所有項目？",
 
 
 
@@ -659830,7 +659762,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_confirm_delete_category": "刪除此類別？項目將變為未分類。",
 
 
 
@@ -659958,7 +659889,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_bulk_cancel": "取消",
 
 
 
@@ -660086,7 +660016,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_bulk_undo": "復原",
 
 
 
@@ -660214,7 +660143,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_bulk_clearing": "清空中...",
 
 
 
@@ -660342,7 +660270,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_bulk_cleared": "已清空 {count} 個項目",
 
 
 
@@ -660470,7 +660397,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_bulk_restoring": "還原中...",
 
 
 
@@ -660598,7 +660524,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_bulk_deleting_cat": "刪除類別中...",
 
 
 
@@ -660726,7 +660651,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_bulk_cat_deleted": "類別已刪除",
 
 
 
@@ -660854,7 +660778,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_prompt_category_name": "類別名稱：",
 
 
 
@@ -660982,7 +660905,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_prompt_rename_category": "新類別名稱：",
 
 
 
@@ -661110,7 +661032,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_category_exists": "類別已存在",
 
 
 
@@ -661238,7 +661159,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_empty_category": "空",
 
 
 
@@ -661366,7 +661286,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_add_rule": "新增規則",
 
 
 
@@ -661494,7 +661413,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_edit_rule": "編輯規則",
 
 
 
@@ -661622,7 +661540,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_rule_name": "規則名稱",
 
 
 
@@ -661750,7 +661667,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_rule_type": "類型",
 
 
 
@@ -661878,7 +661794,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_souls_title": "靈魂",
 
 
 
@@ -662006,7 +661921,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_empty_souls": "尚無靈魂設定",
 
 
 
@@ -662134,7 +662048,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_add_soul": "新增靈魂",
 
 
 
@@ -662262,7 +662175,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_edit_soul": "編輯靈魂",
 
 
 
@@ -662390,7 +662302,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_soul_name": "靈魂名稱",
 
 
 
@@ -662518,7 +662429,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_soul_desc": "個性描述",
 
 
 
@@ -662646,7 +662556,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_soul_desc_hint": "描述這個靈魂的個性、語氣和行為方式...",
 
 
 
@@ -662774,7 +662683,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_soul_template": "靈魂模板",
 
 
 
@@ -662902,7 +662810,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_soul_custom": "-- 自訂 --",
 
 
 
@@ -663030,7 +662937,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_soul_template_btn": "🎭 從模板選擇",
 
 
 
@@ -663158,7 +663064,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_soul_gallery_builtin": "內建模板",
 
 
 
@@ -663286,7 +663191,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_soul_gallery_community": "社群模板",
 
 
 
@@ -663414,7 +663318,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_dlg_soul_multi": "可多選",
 
 
 
@@ -663542,7 +663445,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_menu_move_mission": "移至 Mission",
 
 
 
@@ -663670,7 +663572,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_menu_mark_done": "標記完成",
 
 
 
@@ -663798,7 +663699,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_menu_delete": "刪除",
 
 
 
@@ -663926,7 +663826,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_search_placeholder": "搜尋…",
 
 
 
@@ -664054,7 +663953,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_browse_official_tpl": "瀏覽官方模板",
 
 
 
@@ -664182,7 +664080,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_rule_template_title": "規則模板",
 
 
 
@@ -664310,7 +664207,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_skill_change": "更換",
 
 
 
@@ -664438,7 +664334,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_skill_name_label": "技能名稱",
 
 
 
@@ -664566,7 +664461,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_skill_name_placeholder": "例：Google 搜尋",
 
 
 
@@ -664694,7 +664588,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_skill_url_label": "相關網址（選填）",
 
 
 
@@ -664822,7 +664715,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_skill_steps_label": "安裝步驟（選填）",
 
 
 
@@ -664950,7 +664842,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_skill_steps_placeholder": "詳細安裝與設定步驟…",
 
 
 
@@ -665078,7 +664969,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_skill_assign_entity": "指派實體（可多選）",
 
 
 
@@ -665206,7 +665096,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_open_page": "開啟網頁",
 
 
 
@@ -665334,7 +665223,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_public_label": "公開",
 
 
 
@@ -665462,7 +665350,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_private_label": "私人",
 
 
 
@@ -665590,7 +665477,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_edit_page": "編輯網頁",
 
 
 
@@ -665718,7 +665604,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_copy_link": "複製連結",
 
 
 
@@ -665846,7 +665731,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_link_copied": "已複製！",
 
 
 
@@ -665974,7 +665858,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_no_public_code": "沒有可用的公開代碼",
 
 
 
@@ -666102,7 +665985,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_draw": "畫筆",
 
 
 
@@ -666230,7 +666112,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_draw_save": "儲存塗鴉",
 
 
 
@@ -666358,7 +666239,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_draw_clear": "清除",
 
 
 
@@ -666486,7 +666366,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_draw_clear_confirm": "清除所有塗鴉？",
 
 
 
@@ -666614,7 +666493,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_draw_eraser": "橡皮擦",
 
 
 
@@ -666742,7 +666620,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_draw_saved": "塗鴉已儲存",
 
 
 
@@ -666870,7 +666747,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_page_close": "關閉",
 
 
 
@@ -666998,7 +666874,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_page_placeholder": "輸入 HTML 內容...",
 
 
 
@@ -667126,7 +667001,6 @@ const TRANSLATIONS = {
 
 
 
-        "editor_loading": "編輯器載入中…",
 
 
 
@@ -667254,7 +667128,6 @@ const TRANSLATIONS = {
 
 
 
-        "editor_load_failed": "編輯器載入失敗",
 
 
 
@@ -667382,7 +667255,6 @@ const TRANSLATIONS = {
 
 
 
-        "file_edit_btn": "線上編輯",
 
 
 
@@ -667510,7 +667382,6 @@ const TRANSLATIONS = {
 
 
 
-        "file_edit_modal_title": "編輯檔案",
 
 
 
@@ -667638,7 +667509,6 @@ const TRANSLATIONS = {
 
 
 
-        "file_edit_save_btn": "儲存",
 
 
 
@@ -667766,7 +667636,6 @@ const TRANSLATIONS = {
 
 
 
-        "file_edit_download_btn": "下載",
 
 
 
@@ -667894,7 +667763,6 @@ const TRANSLATIONS = {
 
 
 
-        "file_edit_close_btn": "關閉",
 
 
 
@@ -668022,7 +667890,6 @@ const TRANSLATIONS = {
 
 
 
-        "file_edit_save_success": "已儲存",
 
 
 
@@ -668150,7 +668017,6 @@ const TRANSLATIONS = {
 
 
 
-        "file_edit_save_error": "儲存失敗",
 
 
 
@@ -668278,7 +668144,6 @@ const TRANSLATIONS = {
 
 
 
-        "file_edit_loading": "載入中…",
 
 
 
@@ -668406,7 +668271,6 @@ const TRANSLATIONS = {
 
 
 
-        "file_edit_unsaved_warn": "尚有未儲存的變更，仍要關閉嗎？",
 
 
 
@@ -668534,7 +668398,6 @@ const TRANSLATIONS = {
 
 
 
-        "file_edit_too_large": "檔案太大，無法線上編輯（上限 512KB）",
 
 
 
@@ -668662,7 +668525,6 @@ const TRANSLATIONS = {
 
 
 
-        "file_edit_binary_reject": "二進位檔案無法線上編輯",
 
 
 
@@ -668790,7 +668652,6 @@ const TRANSLATIONS = {
 
 
 
-        "editor_toggle_monaco": "切換到 Monaco 編輯器",
 
 
 
@@ -668918,7 +668779,6 @@ const TRANSLATIONS = {
 
 
 
-        "editor_toggle_textarea": "切換到一般編輯器",
 
 
 
@@ -669046,7 +668906,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_page_link_hint": "內部連結：&lt;a href=\"eclaw://note/NOTE_ID\"&gt;...&lt;/a&gt;",
 
 
 
@@ -669174,7 +669033,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_page_saved": "網頁已儲存",
 
 
 
@@ -669302,7 +669160,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_page_public": "公開此網頁",
 
 
 
@@ -669430,7 +669287,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_page_public_hint": "公開的網頁無需登入即可在 /p/CODE/NOTE_ID 瀏覽",
 
 
 
@@ -669558,7 +669414,6 @@ const TRANSLATIONS = {
 
 
 
-        "mc_note_page_empty": "尚無網頁內容。",
 
 
 
@@ -669686,7 +669541,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_tos_load_error": "載入服務條款失敗。",
 
 
 
@@ -669814,7 +669668,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_proto_placeholder": "例如 A2A、REST、gRPC",
 
 
 
@@ -669942,7 +669795,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_cap_name": "名稱",
 
 
 
@@ -670070,7 +669922,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_cap_desc": "描述",
 
 
 
@@ -670198,7 +670049,6 @@ const TRANSLATIONS = {
 
 
 
-        "portal_login_title": "EClawbot - 登入",
 
 
 
@@ -670326,7 +670176,6 @@ const TRANSLATIONS = {
 
 
 
-        "portal_app_title": "EClawbot",
 
 
 
@@ -670454,7 +670303,6 @@ const TRANSLATIONS = {
 
 
 
-        "portal_app_subtitle": "動態桌布小幫手",
 
 
 
@@ -670582,7 +670430,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_dashboard": "儀表板",
 
 
 
@@ -670710,7 +670557,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_chat": "聊天",
 
 
 
@@ -670838,7 +670684,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_files": "檔案",
 
 
 
@@ -670966,7 +670811,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_mission": "任務",
 
 
 
@@ -671094,7 +670938,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_kanban": "看板",
 
 
 
@@ -671222,7 +671065,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_settings": "設定",
 
 
 
@@ -671350,7 +671192,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_logout": "登出",
 
 
 
@@ -671478,7 +671319,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_split_view": "分割畫面",
 
 
 
@@ -671606,7 +671446,6 @@ const TRANSLATIONS = {
 
 
 
-        "workspace_close_pane": "關閉面板",
 
 
 
@@ -671734,7 +671573,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_compare": "頻道比較",
 
 
 
@@ -671862,7 +671700,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_faq": "常見問題",
 
 
 
@@ -671990,7 +671827,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_release_notes": "版本紀錄",
 
 
 
@@ -672118,7 +671954,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_user_guide": "使用手冊",
 
 
 
@@ -672246,7 +672081,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_login": "登入",
 
 
 
@@ -672374,7 +672208,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_info": "資訊",
 
 
 
@@ -672502,7 +672335,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_wallet": "錢包",
 
 
 
@@ -672630,7 +672462,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_wallet_desc": "管理 e幣餘額、儲值、查看交易紀錄",
 
 
 
@@ -672758,7 +672589,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_marketplace": "Bot 市集",
 
 
 
@@ -672886,7 +672716,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_my_rentals": "我的租賃",
 
 
 
@@ -673014,7 +672843,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_rentals_desc": "查看契約、提交評分、提出申訴",
 
 
 
@@ -673142,7 +672970,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_invite": "邀請好友",
 
 
 
@@ -673270,7 +673097,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_invite_desc": "分享邀請碼，賺取 e幣獎勵",
 
 
 
@@ -673398,7 +673224,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_banner_title": "邀請好友，雙方同賺 e幣",
 
 
 
@@ -673526,7 +673351,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_banner_desc_prefix": "你的邀請碼 ",
 
 
 
@@ -673654,7 +673478,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_banner_desc_suffix": "，每成功邀請一位朋友，雙方各得 500 e幣。",
 
 
 
@@ -673782,7 +673605,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_banner_cta": "立即邀請",
 
 
 
@@ -673910,7 +673732,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_toast_welcome": "🎁 你的邀請碼 {code} 已就緒 — 每邀請一位朋友，雙方各得 500 e幣",
 
 
 
@@ -674038,7 +673859,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_admin": "管理",
 
 
 
@@ -674166,7 +673986,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_card_holder": "名片夾",
 
 
 
@@ -674294,7 +674113,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_community": "社群",
 
 
 
@@ -674422,7 +674240,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_enterprise": "企業方案",
 
 
 
@@ -674550,7 +674367,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_hero_title": "EClawbot",
 
 
 
@@ -674678,7 +674494,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_hero_subtitle": "代理人對代理人（A2A）通訊平台 — 您的個人企業 AI 小幫手。建構、管理和部署 AI 代理人，實現跨代理協作、任務自動化和客戶服務。由 OpenClaw 驅動。",
 
 
 
@@ -674806,8 +674621,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_get_started": "立即開始",
-        "landing_watch_full_demo": "▶ 觀看完整示範與導覽",
 
 
 
@@ -674935,7 +674748,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_browse_bots": "瀏覽 Bots",
 
 
 
@@ -675063,7 +674875,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_enterprise": "企業方案",
 
 
 
@@ -675191,7 +675002,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_api_docs": "API 文件",
 
 
 
@@ -675319,7 +675129,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_features_sr": "功能特色",
 
 
 
@@ -675447,7 +675256,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_feat1_title": "個人企業 AI 小幫手",
 
 
 
@@ -675575,7 +675383,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_feat1_desc": "為您的企業建構和部署 AI 代理人團隊。每個代理人都有自己的身份、技能，以及專屬的公開網址（代理視窗），讓客戶可以直接互動。",
 
 
 
@@ -675703,7 +675510,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_feat2_title": "A2A 協議",
 
 
 
@@ -675831,7 +675637,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_feat2_desc": "代理人對代理人通訊實現跨代理任務派發、協作流程和跨裝置自動化任務執行。",
 
 
 
@@ -675959,7 +675764,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_feat3_title": "任務中心",
 
 
 
@@ -676087,7 +675891,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_feat3_desc": "完整的任務管理：待辦事項、任務、筆記和規則。透過結構化任務儀表板協調 AI 代理人。",
 
 
 
@@ -676215,7 +676018,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_feat4_title": "多平台",
 
 
 
@@ -676343,7 +676145,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_feat4_desc": "Web 入口、Android 應用程式和 iOS 應用程式 — 全部連接到同一後端，享有即時 Socket.IO 更新。",
 
 
 
@@ -676471,7 +676272,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_feat5_title": "企業級安全",
 
 
 
@@ -676599,7 +676399,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_feat5_desc": "OAuth 2.0 / OIDC 認證、RBAC 角色、E2EE 感知、TLS/HTTPS 安全標頭及完整稽核日誌。",
 
 
 
@@ -676727,7 +676526,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_feat6_title": "OpenClaw 整合",
 
 
 
@@ -676855,7 +676653,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_feat6_desc": "無縫的頻道式外掛系統，接入 OpenClaw 生態系。內建發佈器可一次發佈至 12+ 平台。",
 
 
 
@@ -676983,7 +676780,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_faq_title": "常見問題",
 
 
 
@@ -677111,7 +676907,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_faq_q1": "什麼是 EClawbot？",
 
 
 
@@ -677239,7 +677034,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_faq_a1": "EClawbot 是一個 A2A 通訊平台及個人企業 AI 小幫手。協助個人和中小企業建構、管理和部署 AI 代理人，實現跨代理協作、任務派發和自動化。每個代理人可擁有專屬公開網址（代理視窗）提供客戶服務。透過 Web 入口、Android 應用程式或 iOS 應用程式管理一切。",
 
 
 
@@ -677367,7 +677161,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_faq_q2": "EClawbot 和 ELAUT EClawbot 是同一個嗎？",
 
 
 
@@ -677495,7 +677288,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_faq_a2": "不是。EClawbot（eclawbot.com）是用於 AI 代理人編排和跨代理協作的 A2A 通訊平台。ELAUT 的 EClawbot 是一個來自比利時的實體街機夾娃娃機品牌。兩者是完全不同的產品。",
 
 
 
@@ -677623,7 +677415,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_faq_q3": "EClawbot 和 OpenClaw 的關係是什麼？",
 
 
 
@@ -677751,7 +677542,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_faq_a3": "EClawbot 是驅動 OpenClaw 生態系的基礎設施平台。OpenClaw 使用者可以將他們的 AI 代理人連接到 EClawbot，透過 A2A 協議進行跨代理通訊、任務派發和協作自動化。",
 
 
 
@@ -677879,7 +677669,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_faq_q4": "EClawbot 支援哪些平台？",
 
 
 
@@ -678007,7 +677796,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_faq_a4": "EClawbot 支援三個平台：Web 入口（eclawbot.com/portal）、Android 原生應用程式，以及使用 React Native（Expo）建構的 iOS 應用程式。所有平台共用相同的後端 API 和即時 Socket.IO 連線。",
 
 
 
@@ -678135,7 +677923,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_faq_q5": "EClawbot 中的 A2A 協議是什麼？",
 
 
 
@@ -678263,7 +678050,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_faq_a5": "A2A（代理人對代理人）是一種通訊協議，允許 EClawbot 上的 AI 代理人互相發送結構化任務。它實現跨代理協作、任務派發和跨裝置自動化工作流程。",
 
 
 
@@ -678391,7 +678177,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_faq_q6": "EClawbot 免費嗎？",
 
 
 
@@ -678519,7 +678304,6 @@ const TRANSLATIONS = {
 
 
 
-        "landing_faq_a6": "EClawbot 提供免費方案，包含基本裝置管理和實體綁定。進階功能如額外實體欄位和進階 A2A 功能可透過訂閱方案取得。",
 
 
 
@@ -678647,7 +678431,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_page_title": "EClawbot 企業方案 - 商用 AI 代理人平台",
 
 
 
@@ -678775,7 +678558,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_badge": "企業方案",
 
 
 
@@ -678903,7 +678685,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_hero_title": "為您的企業打造 AI 代理人團隊",
 
 
 
@@ -679031,7 +678812,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_hero_subtitle": "部署、管理和協調 AI 代理人團隊，具備企業級安全性、存取控制和即時監控。您的個人企業 AI 小幫手。",
 
 
 
@@ -679159,7 +678939,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_get_started": "免費開始",
 
 
 
@@ -679287,7 +679066,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_api_docs": "API 文件",
 
 
 
@@ -679415,7 +679193,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_usecases_title": "企業應用場景",
 
 
 
@@ -679543,7 +679320,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_usecases_subtitle": "從客戶服務到內部自動化，EClawbot 靈活適應您的業務需求。",
 
 
 
@@ -679671,7 +679447,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_uc_cs_title": "AI 客戶服務",
 
 
 
@@ -679799,7 +679574,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_uc_cs_desc": "透過 Proxy Window 公開網址部署面向客戶的代理人。每位代理人擁有獨立的身份、語氣和行為邊界，全天候 24/7 服務客戶。",
 
 
 
@@ -679927,7 +679701,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_uc_auto_title": "工作流程自動化",
 
 
 
@@ -680055,7 +679828,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_uc_auto_desc": "使用 Mission Control 自動化內部工作流程。排程任務、定義規則，讓代理人透過 A2A 協議協作完成複雜操作。",
 
 
 
@@ -680183,7 +679955,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_uc_pub_title": "多通道發佈",
 
 
 
@@ -680311,7 +680082,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_uc_pub_desc": "一次 API 呼叫即可同時發佈內容到 12+ 個平台 — Blogger、X、DEV.to、WordPress、LinkedIn、Reddit、Mastodon 等。",
 
 
 
@@ -680439,7 +680209,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_uc_collab_title": "跨團隊協作",
 
 
 
@@ -680567,7 +680336,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_uc_collab_desc": "啟用跨裝置代理人通訊。不同團隊的代理人可以自動交換任務、共享上下文並協調行動。",
 
 
 
@@ -680695,7 +680463,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_features_title": "企業級安全性",
 
 
 
@@ -680823,7 +680590,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_features_subtitle": "專為要求安全性、合規性和控制權的組織而建。",
 
 
 
@@ -680951,7 +680717,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_feat_rbac_title": "RBAC 存取控制",
 
 
 
@@ -681079,7 +680844,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_feat_rbac_desc": "基於角色的存取控制，內建 4 個預設角色（管理員、開發者、操作員、檢視者）。每個 API 端點皆有細粒度權限中介軟體。",
 
 
 
@@ -681207,7 +680971,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_feat_sso_title": "SSO / OAuth 2.0 / OIDC",
 
 
 
@@ -681335,7 +681098,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_feat_sso_desc": "透過通用 OIDC 連接您的身份提供者。內建 Google、Facebook OAuth。完整的 OAuth 2.0 伺服器支援客戶端憑證和令牌管理。",
 
 
 
@@ -681463,7 +681225,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_feat_audit_title": "稽核日誌",
 
 
 
@@ -681591,7 +681352,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_feat_audit_desc": "追蹤每一個操作 — 驗證事件、API 呼叫、實體變更。按類別、時間範圍、使用者查詢日誌。管理員專用稽核端點確保合規。",
 
 
 
@@ -681719,7 +681479,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_feat_e2ee_title": "端對端加密感知",
 
 
 
@@ -681847,7 +681606,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_feat_e2ee_desc": "每個通道和實體的端對端加密能力標記。使用 AES-256-GCM 加密儲存環境變數。",
 
 
 
@@ -681975,7 +681733,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_feat_mission_title": "Mission Control",
 
 
 
@@ -682103,7 +681860,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_feat_mission_desc": "集中式儀表板，包含待辦事項、任務、筆記、規則和代理人協調。即時同步 Web、Android 和 iOS。",
 
 
 
@@ -682231,7 +681987,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_feat_a2a_title": "A2A 協議",
 
 
 
@@ -682359,7 +682114,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_feat_a2a_desc": "代理人對代理人結構化任務派發。代理人跨裝置協作、委派和回報，具備型別化酬載和投遞追蹤。",
 
 
 
@@ -682487,7 +682241,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_how_title": "如何運作",
 
 
 
@@ -682615,7 +682368,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_how_subtitle": "幾分鐘內啟動您的 AI 代理人團隊。",
 
 
 
@@ -682743,7 +682495,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_step1_title": "部署代理人",
 
 
 
@@ -682871,7 +682622,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_step1_desc": "建立代理人身份，設定角色、技能和個性。指定公開的 Proxy Window 網址以服務客戶。",
 
 
 
@@ -682999,7 +682749,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_step2_title": "透過 A2A 連接",
 
 
 
@@ -683127,7 +682876,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_step2_desc": "連結跨團隊和裝置的代理人。使用 A2A 協議進行結構化任務派發和即時協作。",
 
 
 
@@ -683255,7 +683003,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_step3_title": "監控與擴展",
 
 
 
@@ -683383,7 +683130,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_step3_desc": "透過遙測、稽核日誌和 Mission Control 追蹤代理人表現。隨業務成長擴展代理人團隊。",
 
 
 
@@ -683511,7 +683257,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_cta_title": "準備好開始了嗎？",
 
 
 
@@ -683639,7 +683384,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_cta_subtitle": "加入使用 EClawbot 自動化工作流程並部署 AI 代理人團隊的企業行列。",
 
 
 
@@ -683767,7 +683511,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_cta_start": "建立免費帳號",
 
 
 
@@ -683895,7 +683638,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_cta_learn": "了解更多",
 
 
 
@@ -684023,7 +683765,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_demo_title": "立即體驗",
 
 
 
@@ -684151,7 +683892,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_demo_subtitle": "輸入您的網站或上傳文件，AI 代理人將學習您的業務並開始對話。",
 
 
 
@@ -684279,7 +684019,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_demo_url_placeholder": "https://your-company.com",
 
 
 
@@ -684407,7 +684146,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_demo_load": "載入",
 
 
 
@@ -684535,7 +684273,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_demo_upload": "上傳檔案",
 
 
 
@@ -684663,7 +684400,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_demo_welcome": "輸入網站網址或上傳檔案，然後開始與 AI 代理人對話。",
 
 
 
@@ -684791,7 +684527,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_demo_input_placeholder": "問一些關於您業務的問題...",
 
 
 
@@ -684919,7 +684654,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_demo_send": "傳送",
 
 
 
@@ -685047,7 +684781,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_demo_hint": "免費體驗 — 每小時 10 則訊息，無需登入。",
 
 
 
@@ -685175,7 +684908,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_demo_thinking": "思考中...",
 
 
 
@@ -685303,7 +685035,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_demo_loading": "正在載入網站...",
 
 
 
@@ -685431,7 +685162,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_demo_loaded": "網站已載入",
 
 
 
@@ -685559,7 +685289,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_demo_file_loaded": "檔案已載入",
 
 
 
@@ -685687,7 +685416,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_demo_file_too_large": "檔案太大（最大 500KB）",
 
 
 
@@ -685815,7 +685543,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_demo_invalid_url": "請輸入有效的網址",
 
 
 
@@ -685943,7 +685670,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_demo_fetch_error": "載入失敗",
 
 
 
@@ -686071,7 +685797,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_demo_error": "連線錯誤，請再試一次。",
 
 
 
@@ -686199,7 +685924,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_demo_greet_prompt": "請以這家企業的 AI 助理身份自我介紹，並根據內容簡短說明這家企業的業務。",
 
 
 
@@ -686327,7 +686051,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_ec_section_title": "🛒 線上體驗：AI 電商客服",
 
 
 
@@ -686455,7 +686178,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_ec_section_subtitle": "這是一個真實運行的 AI 客服機器人「小蝦客服」。試著問它商品資訊、運費政策、或請它推薦商品！",
 
 
 
@@ -686583,7 +686305,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_ec_demo_label": "▲ AI 客服即時對話演示",
 
 
 
@@ -686711,7 +686432,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_ec_chat_title": "💬 跟小蝦客服聊天",
 
 
 
@@ -686839,7 +686559,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_ec_chat_credit": "每小時 10 則訊息 · Powered by EClaw Entity #2",
 
 
 
@@ -686967,7 +686686,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_ec_product_title": "📦 商品目錄",
 
 
 
@@ -687095,7 +686813,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_ec_product_ai_note": "AI 生成的產品頁面 · ",
 
 
 
@@ -687223,7 +686940,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_ec_product_link": "在新分頁開啟",
 
 
 
@@ -687351,7 +687067,6 @@ const TRANSLATIONS = {
 
 
 
-        "ent_ec_setup_note": "✨ 這個 Demo 只花了 10 分鐘設定 — 用 EClaw 的 Entity 系統 + Note Pages + Proxy Window",
 
 
 
@@ -687479,7 +687194,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_title": "EClawbot - 資訊中心",
 
 
 
@@ -687607,7 +687321,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_tab_guide": "使用指南",
 
 
 
@@ -687735,7 +687448,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_tab_faq": "常見問題",
 
 
 
@@ -687863,7 +687575,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_tab_release_notes": "更新日誌",
 
 
 
@@ -687991,7 +687702,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_tab_roadmap": "產品路線圖",
 
 
 
@@ -688119,7 +687829,6 @@ const TRANSLATIONS = {
 
 
 
-        "roadmap_title": "EClawbot - 產品路線圖",
 
 
 
@@ -688247,7 +687956,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_tab_compare": "頻道比較",
 
 
 
@@ -688375,7 +688083,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_tab_quickstart": "快速開始",
 
 
 
@@ -688503,7 +688210,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_tab_advanced": "進階",
 
 
 
@@ -688631,7 +688337,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_tab_channel_plugins": "Channel Plugins",
 
 
 
@@ -688759,8 +688464,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_hero_title": "你想做什麼？",
-        "qs_promo_full_page_link": "📺 開啟完整影片頁",
 
 
 
@@ -688888,7 +688591,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_hero_desc": "EClawbot 是你的 AI 代理平台。選擇一個場景，立即開始。",
 
 
 
@@ -689016,7 +688718,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_intent_chat_title": "和 AI 聊天",
 
 
 
@@ -689144,7 +688845,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_intent_chat_desc": "讓 AI 代理回覆客戶、處理日常對話",
 
 
 
@@ -689272,7 +688972,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_intent_biz_title": "電商 / 客服",
 
 
 
@@ -689400,7 +689099,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_intent_biz_desc": "24/7 自動接單、推薦商品、處理退換貨",
 
 
 
@@ -689528,7 +689226,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_intent_team_title": "多 Agent 協作",
 
 
 
@@ -689656,7 +689353,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_intent_team_desc": "建立 AI 團隊，讓代理互相分工、自動化流程",
 
 
 
@@ -689784,7 +689480,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_steps_title": "3 步開始使用",
 
 
 
@@ -690040,7 +689735,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_step1_title": "註冊帳號",
 
 
 
@@ -690168,7 +689862,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_step1_desc": "前往 <a href=\"index.html\">Web Portal</a> 註冊，或到 Google Play 下載 <a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\">Android App</a>",
 
 
 
@@ -690296,7 +689989,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_step2_title": "綁定 AI 代理",
 
 
 
@@ -690424,7 +690116,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_step2_desc": "選擇免費官方 Bot 體驗，或綁定自有 OpenClaw Bot（無訊息限制）",
 
 
 
@@ -690552,7 +690243,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_step3_title": "開始對話",
 
 
 
@@ -690680,7 +690370,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_step3_desc": "進入 Chat 頁面，與你的 AI 代理對話、派發任務、管理團隊",
 
 
 
@@ -690808,7 +690497,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_demo_title": "看看能做什麼",
 
 
 
@@ -690936,7 +690624,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_demo_chat_title": "💬 即時聊天",
 
 
 
@@ -691064,7 +690751,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_demo_chat_desc": "多代理對話、Markdown 渲染、語音訊息",
 
 
 
@@ -691192,7 +690878,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_demo_mission_title": "📋 任務中心",
 
 
 
@@ -691320,7 +691005,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_demo_mission_desc": "TODO、規則、技能、筆記一站管理",
 
 
 
@@ -691448,7 +691132,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_demo_plaza_title": "🏗 Bot 廣場",
 
 
 
@@ -691576,7 +691259,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_demo_plaza_desc": "探索公開 AI Bot、分享你的代理名片",
 
 
 
@@ -691704,7 +691386,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_cta_text": "準備好了嗎？免費註冊，3 分鐘內開始你的第一場 AI 對話。",
 
 
 
@@ -691832,7 +691513,6 @@ const TRANSLATIONS = {
 
 
 
-        "qs_cta_btn": "🚀 立即開始",
 
 
 
@@ -692856,7 +692536,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_1_title": "A2A 代理協作",
 
 
 
@@ -692984,7 +692663,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_1_desc": "多個 AI 代理透過 Agent-to-Agent 協議即時通訊、廣播協作、跨裝置任務派發",
 
 
 
@@ -693112,7 +692790,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_2_title": "尹代理窗口",
 
 
 
@@ -693240,7 +692917,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_2_desc": "為代理建立專屬公開連結，客戶可直接在瀏覽器中與 AI 互動、下單、查詢",
 
 
 
@@ -693368,7 +693044,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_3_title": "任務中心",
 
 
 
@@ -693496,7 +693171,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_3_desc": "Mission Control 建立待辦、派發任務、追蹤進度，代理自動收到通知",
 
 
 
@@ -693624,7 +693298,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_4_title": "Bot 身份系統",
 
 
 
@@ -693752,7 +693425,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_4_desc": "為代理設定角色、指令、邊界、語調，打造專業代理形象",
 
 
 
@@ -693880,7 +693552,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_5_title": "Agent Card 名片",
 
 
 
@@ -694008,7 +693679,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_5_desc": "建立數位名片，展示能力與標籤，便於被其他用戶發現與收藏",
 
 
 
@@ -694136,7 +693806,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_6_title": "三平台管理",
 
 
 
@@ -694264,7 +693933,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_6_desc": "Web Portal、Android App、iOS App 即時同步，隨時隨地管理代理團隊",
 
 
 
@@ -694392,7 +694060,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_7_title": "OpenClaw 生態整合",
 
 
 
@@ -694520,7 +694187,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_7_desc": "Webhook + Channel Plugin 接入 OpenClaw AI Bot，支援多模型協作",
 
 
 
@@ -694648,7 +694314,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_8_title": "加密環境變數",
 
 
 
@@ -694776,7 +694441,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_8_desc": "AES-256-GCM 加密儲存金鑰，JIT 即時授權機制確保安全",
 
 
 
@@ -694904,7 +694568,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_9_title": "AI 客服助手",
 
 
 
@@ -695032,7 +694695,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_9_desc": "內建 AI 即時問答，自動診斷問題、提供解決方案",
 
 
 
@@ -695160,7 +694822,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_10_title": "多平台發布",
 
 
 
@@ -695288,7 +694949,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_card_10_desc": "一鍵發布內容到 12+ 平台（DEV.to、X、Reddit、LinkedIn 等）",
 
 
 
@@ -695416,7 +695076,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_learn_more": "了解更多 →",
 
 
 
@@ -695544,7 +695203,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_try_it": "立即體驗 →",
 
 
 
@@ -695672,7 +695330,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_download": "下載 App →",
 
 
 
@@ -696056,7 +695713,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_vector_memory": "🧠 向量記憶",
 
 
 
@@ -696184,7 +695840,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_title": "🧠 向量記憶 — 突破 Session 限制的 AI 回憶能力",
 
 
 
@@ -696312,7 +695967,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_subtitle": "不被 context window 綁死、跨 bot 知識共享、引用溯源的語意記憶系統",
 
 
 
@@ -696440,7 +696094,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_what": "什麼是向量記憶？",
 
 
 
@@ -696568,7 +696221,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_what_desc": "EClawbot 把每一則聊天訊息都寫進 <strong>pgvector 資料庫</strong>，用 1536 維語意向量當指紋。你問「上週我們聊過的那個 API 是怎麼設計的？」Bot 不用從頭讀歷史訊息，直接用語意相似度在毫秒內撈出相關片段並附上引用連結。",
 
 
 
@@ -696696,7 +696348,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_pain": "沒有向量記憶前的三個痛點",
 
 
 
@@ -696824,7 +696475,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_pain1": "❌ Context window 塞滿就失憶 — 昨天講過的事今天要重講",
 
 
 
@@ -696952,7 +696602,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_pain2": "❌ 多個 bot 各自為政 — 主人想一次回顧多隻 bot 的對話沒有統一入口",
 
 
 
@@ -697080,7 +696729,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_pain3": "❌ Bot 回答沒有根據 — 你沒辦法追問「你剛才說的那個來源在哪？」",
 
 
 
@@ -697208,7 +696856,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_sp1_pain": "想讓 AI 記得跨 session、跨月份的對話？",
 
 
 
@@ -697336,7 +696983,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_sp1_solution": "→ 向量記憶讓 bot「記性」超越 context window",
 
 
 
@@ -697464,7 +697110,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_sp1_desc": "每則訊息都寫進 pgvector，即使過了一個月、不同 session、不同裝置，只要語意沾邊就能撈出來。記憶是資料庫層級，不是 prompt 層級 — 不再受 8k / 32k / 200k token 上限綁架。",
 
 
 
@@ -697592,7 +697237,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_sp2_pain": "想一次橫跨自己持有的多隻 bot 找對話？",
 
 
 
@@ -697720,7 +697364,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_sp2_solution": "→ 主人視角:跨 bot 統一檢索；Bot 之間維持各自的對話池隔離",
 
 
 
@@ -697848,7 +697491,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_sp2_desc": "你（裝置主人）開 chat 時可以橫跨自己持有的所有 bot 查任意對話，看一眼就掌握 Bot #3 與 Bot #5 的歷史脈絡。Bot 與 Bot 之間的協作則透過 Kanban 卡片內容、speakTo 訊息正文與 @提及推送主動傳遞 — 每個 bot 自己只查得到屬於自己的對話池，確保隔離與權責分明。",
 
 
 
@@ -697976,7 +697618,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_sp3_pain": "想要 bot 回答時附上「證據來源」而不是瞎編？",
 
 
 
@@ -698104,7 +697745,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_sp3_solution": "→ 每則回答自動帶引用連結（Citation）",
 
 
 
@@ -698232,7 +697872,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_sp3_desc": "Bot 根據向量檢索給出的每個答案，對話氣泡下方都可以展開「相關舊訊息」清單，點擊就跳到原始 context。是真的有溯源能力的回答，不是從訓練資料瞎猜。",
 
 
 
@@ -698360,7 +697999,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_how": "怎麼用？",
 
 
 
@@ -698488,7 +698126,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_how1": "打開聊天頁面（<a href=\"chat.html\">Chat</a> 或 Agent Window）",
 
 
 
@@ -698616,7 +698253,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_how2": "像平常一樣跟 bot 對話 — 所有訊息背景自動寫入向量池",
 
 
 
@@ -698744,7 +698380,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_how3": "Bot 回覆後，點開氣泡下方的「相關舊訊息」按鈕查看引用",
 
 
 
@@ -698872,7 +698507,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_how4": "跨 session 問問題（例：「你還記得我們上次聊的 ... 嗎？」），bot 會自動檢索並引用",
 
 
 
@@ -699000,7 +698634,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_tech": "技術內幕（給好奇的開發者）",
 
 
 
@@ -699128,7 +698761,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_tech_storage": "儲存層：",
 
 
 
@@ -699256,7 +698888,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_tech_storage_desc": "PostgreSQL + pgvector 擴充，HNSW 索引加速餘弦相似度查詢",
 
 
 
@@ -699384,7 +699015,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_tech_embed": "向量模型：",
 
 
 
@@ -699512,7 +699142,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_tech_embed_desc": "OpenAI text-embedding-3-small（1536 維，成本低、召回率高）；需在 device-vars 配置 OPENAI 或 VOYAGE embedding key 才會實際寫入向量欄位",
 
 
 
@@ -699640,7 +699269,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_tech_fallback": "降級策略：",
 
 
 
@@ -699768,7 +699396,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_tech_fallback_desc": "未配置 embedding key 或 pgvector 不可用時，訊息原文仍保留，自動退回 ILIKE 關鍵字搜尋，功能不中斷（差別只在能不能跨措辭召回）",
 
 
 
@@ -699896,7 +699523,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_tech_api": "API：",
 
 
 
@@ -700024,7 +699650,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_tech_api_desc": "<code>POST /api/chat/search</code> 依自然語言問句搜尋對話歷史；用 botSecret 認證會被綁定到該 bot 自己的 entity，用 deviceSecret（主人）認證可選擇性指定 entityId 或省略以橫跨整台裝置",
 
 
 
@@ -700152,7 +699777,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_cta_title": "立即體驗",
 
 
 
@@ -700280,7 +699904,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_vm_cta_chat": "在聊天室試試：<a href=\"chat.html\">開啟 Chat</a> 並問 bot「你還記得我們之前聊過 ... 嗎？」看氣泡下方的引用。",
 
 
 
@@ -700536,7 +700159,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_demo_title": "🎬 Demo 展示",
 
 
 
@@ -700664,7 +700286,6 @@ const TRANSLATIONS = {
 
 
 
-        "demo_chat_title": "💬 智慧聊天",
 
 
 
@@ -700792,7 +700413,6 @@ const TRANSLATIONS = {
 
 
 
-        "demo_chat_desc": "即時多代理對話，支援 Markdown 渲染、語音訊息、圖片分享與商品推薦卡 — 統一聊天介面。",
 
 
 
@@ -700920,7 +700540,6 @@ const TRANSLATIONS = {
 
 
 
-        "demo_gps_title": "📍 GPS 定位分享",
 
 
 
@@ -701048,7 +700667,6 @@ const TRANSLATIONS = {
 
 
 
-        "demo_gps_desc": "Bot 請求你的 GPS 位置提供情境感知服務。問「附近有什麼好吃的？」即可根據座標獲得即時個人化推薦。",
 
 
 
@@ -701176,7 +700794,6 @@ const TRANSLATIONS = {
 
 
 
-        "demo_notes_title": "📝 筆記頁面",
 
 
 
@@ -701304,7 +700921,6 @@ const TRANSLATIONS = {
 
 
 
-        "demo_notes_desc": "豐富的筆記頁面支援完整 HTML 渲染 — Bot 可建立精美文件、報告與互動內容，用戶可作為獨立網頁瀏覽。",
 
 
 
@@ -701432,7 +701048,6 @@ const TRANSLATIONS = {
 
 
 
-        "demo_tag_realtime": "即時",
 
 
 
@@ -701560,7 +701175,6 @@ const TRANSLATIONS = {
 
 
 
-        "demo_tag_multiagent": "多代理",
 
 
 
@@ -701688,7 +701302,6 @@ const TRANSLATIONS = {
 
 
 
-        "demo_tag_markdown": "Markdown",
 
 
 
@@ -701816,7 +701429,6 @@ const TRANSLATIONS = {
 
 
 
-        "demo_tag_voice": "語音",
 
 
 
@@ -701944,7 +701556,6 @@ const TRANSLATIONS = {
 
 
 
-        "demo_tag_location": "定位",
 
 
 
@@ -702072,7 +701683,6 @@ const TRANSLATIONS = {
 
 
 
-        "demo_tag_food": "美食",
 
 
 
@@ -702200,7 +701810,6 @@ const TRANSLATIONS = {
 
 
 
-        "demo_tag_parking": "停車",
 
 
 
@@ -702328,7 +701937,6 @@ const TRANSLATIONS = {
 
 
 
-        "demo_tag_navigation": "導航",
 
 
 
@@ -702456,7 +702064,6 @@ const TRANSLATIONS = {
 
 
 
-        "demo_tag_rich": "豐富內容",
 
 
 
@@ -702584,7 +702191,6 @@ const TRANSLATIONS = {
 
 
 
-        "demo_tag_html": "HTML",
 
 
 
@@ -702712,7 +702318,6 @@ const TRANSLATIONS = {
 
 
 
-        "demo_tag_shareable": "可分享",
 
 
 
@@ -702840,7 +702445,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_chip_all": "全部",
 
 
 
@@ -702968,7 +702572,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_chip_general": "💡 一般",
 
 
 
@@ -703096,7 +702699,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_chip_setup": "⚙️ 設定",
 
 
 
@@ -703224,7 +702826,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_chip_features": "✨ 功能",
 
 
 
@@ -703352,7 +702953,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_chip_dev": "🔧 開發",
 
 
 
@@ -703480,7 +703080,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_search_placeholder": "搜尋常見問題...",
 
 
 
@@ -703608,7 +703207,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_no_results": "找不到符合的結果。",
 
 
 
@@ -703736,7 +703334,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_compare_link": "與其他平台比較 →",
 
 
 
@@ -703864,7 +703461,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_copy_example_btn": "複製範例（填入你的憑證）",
 
 
 
@@ -703992,7 +703588,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_copy_example_copied": "已複製！",
 
 
 
@@ -704120,7 +703715,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_copy_example_hint": "若你已登入，複製內容會自動帶入你的 Device ID 與 Device Secret；短期目標與最終目標欄位請自行填寫。",
 
 
 
@@ -704248,7 +703842,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arch_core_bots": "<strong>Bots 接入方式</strong>：Webhook mode（push + exec+curl）或 Channel plugin mode（<code>/api/channel/*</code>），可混用",
 
 
 
@@ -704376,7 +703969,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arch_core_deploy": "<strong>Railway</strong> 在 push 到 <code>main</code> 時自動部署（監控 <code>backend/</code> 資料夾）",
 
 
 
@@ -704504,7 +704096,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arch_core_design": "核心設計",
 
 
 
@@ -704632,7 +704223,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arch_core_slots": "每個裝置擁有 <strong>無上限的動態 entity slots</strong> — 綁定 Bot 時自動新增空位，每個 slot 可獨立綁定不同 Bot",
 
 
 
@@ -704760,7 +704350,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arch_meta": "Android App ↔ Backend ↔ OpenClaw Platform",
 
 
 
@@ -704888,7 +704477,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arch_overview": "架構總覽",
 
 
 
@@ -705016,7 +704604,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arch_overview_desc": "EClawbot 由三個主要部分組成：Android App、後端服務（Railway）、以及 OpenClaw AI 平台（Zeabur）。",
 
 
 
@@ -705144,7 +704731,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arch_title": "系統架構",
 
 
 
@@ -705272,7 +704858,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_h2_1": "Channel 是什麼？",
 
 
 
@@ -705400,7 +704985,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_h2_2": "前置條件",
 
 
 
@@ -705528,7 +705112,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_h2_3": "步驟教學",
 
 
 
@@ -705656,7 +705239,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_h2_4": "常見問題",
 
 
 
@@ -705784,7 +705366,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_h2_5": "技術補充（進階）",
 
 
 
@@ -705912,7 +705493,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_h3_1": "第 1 步：在 Portal 產生 API Key",
 
 
 
@@ -706040,7 +705620,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_h3_2": "第 2 步：在 OpenClaw 安裝並設定 E-Claw Channel",
 
 
 
@@ -706168,7 +705747,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_h3_3": "第 3 步：重啟 OpenClaw",
 
 
 
@@ -706296,7 +705874,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_h3_4": "第 4 步：確認角色出現在 App / Portal",
 
 
 
@@ -706424,7 +706001,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_h3_5": "第 5 步：傳第一則訊息",
 
 
 
@@ -706552,7 +706128,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_h3_6": "Q: 角色綁定後沒出現在 App？",
 
 
 
@@ -706680,7 +706255,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_h3_7": "Q: 傳訊息後 AI 沒有回應？",
 
 
 
@@ -706808,7 +706382,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_h3_8": "Q: 可以同時綁定多個角色給不同的 AI 嗎？",
 
 
 
@@ -706936,7 +706509,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_h3_9": "Q: API Key 外洩怎麼辦？",
 
 
 
@@ -707064,7 +706636,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_li_1": "✅ 已有 E-Claw 帳號並登入 Portal",
 
 
 
@@ -707192,7 +706763,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_li_2": "✅ 已安裝 OpenClaw（Zeabur / Railway / 本機均可）",
 
 
 
@@ -707320,7 +706890,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_li_3": "✅ 你的 OpenClaw 伺服器可被外網存取（或設定了 ECLAW_WEBHOOK_URL）",
 
 
 
@@ -707448,7 +707017,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_li_4": "向 E-Claw 伺服器登記 Callback URL",
 
 
 
@@ -707576,7 +707144,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_li_5": "用 API Key 綁定你指定的角色（entity_id）",
 
 
 
@@ -707704,7 +707271,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_li_6": "EClawbot 把你的訊息推送到 OpenClaw（你設定的 ECLAW_WEBHOOK_URL）",
 
 
 
@@ -707832,7 +707398,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_li_7": "角色狀態更新，App 顯示 AI 的回覆",
 
 
 
@@ -707960,7 +707525,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_li_plugin": "✅ 在 OpenClaw 安裝了 <code>openclaw-channel-eclaw</code> plugin",
 
 
 
@@ -708088,7 +707652,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_li_reply": "你的 AI 處理後，呼叫 E-Claw 的 <code>POST /api/channel/message</code> 回覆",
 
 
 
@@ -708216,7 +707779,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_meta": "讓你自己的 AI（例如 Claude）住進 E-Claw 角色裡",
 
 
 
@@ -708344,7 +707906,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_note_1": "Channel 綁定是<strong>選用功能</strong>——沒有自己的 OpenClaw 的話，繼續使用官方 Bot 即可。",
 
 
 
@@ -708472,7 +708033,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_note_2": "一個 API Key 可以同時綁定多個 entity slots（讓同一台 OpenClaw 管理多個角色）。如果你有多台獨立的 OpenClaw 伺服器，才需要分別產生不同的 Key。",
 
 
 
@@ -708600,7 +708160,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_note_3": "角色旁邊如果有 <strong>[C]</strong> 標記，代表這是 Channel 綁定（Channel binding type）。",
 
 
 
@@ -708728,7 +708287,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_p_1": "EClawbot 預設的「官方 Bot」是平台提供的共用 AI。如果你有自己的 OpenClaw 伺服器（自架或 Zeabur 部署），可以透過 <strong>Channel 綁定</strong>，把你的 AI 直接接進 E-Claw 的角色裡。",
 
 
 
@@ -708856,7 +708414,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_p_2": "綁定後，你在 App 或 Portal 裡傳給那個角色的訊息，會直接推送到你的 OpenClaw AI；AI 回覆後，角色的狀態會即時更新。",
 
 
 
@@ -708984,7 +708541,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_p_3": "前往 <strong>設定 → Channel API</strong>，點「新增 API Key」。系統會產生一組 Key + Secret，請立刻複製妥當——Secret 只顯示一次。",
 
 
 
@@ -709112,7 +708668,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_p_4": "儲存設定後重啟 OpenClaw。Plugin 啟動時會自動：",
 
 
 
@@ -709240,7 +708795,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_p_5": "在 App 裡點進那個角色的聊天畫面，輸入任何訊息。流程如下：",
 
 
 
@@ -709368,7 +708922,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_p_6": "如果 AI 有回應，代表 Channel 雙向通訊正常運作。",
 
 
 
@@ -709496,7 +709049,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_p_7": "前往設定頁刪除該 Key，再產生新的一組即可。舊 Key 刪除後立即失效，對應的角色會自動解綁。",
 
 
 
@@ -709624,7 +709176,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_p_8": "Channel API 端點一覽（開發者用）：",
 
 
 
@@ -709752,7 +709303,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_p_config": "在你的 OpenClaw 設定（<code>openclaw.config.yaml</code>）加入以下 channel 設定：",
 
 
 
@@ -709880,7 +709430,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_p_faq1_a": "先確認 OpenClaw log 有出現 <code>Bound entity</code> 成功訊息。如果沒有，通常是 API Key/Secret 貼錯、或 <code>entity_id</code> 超出範圍（免費方案 0–3，付費方案 0–7）。",
 
 
 
@@ -710008,7 +709557,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_p_faq2_a": "最常見原因是 <code>ECLAW_WEBHOOK_URL</code> 外網連不到。確認你的 OpenClaw 伺服器有公開的 HTTPS 端點，或透過 ngrok 等工具暴露出來。",
 
 
 
@@ -710136,7 +709684,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_p_faq3_a": "可以。為每個 OpenClaw session 分別產生一組 API Key，各自設定不同的 <code>entity_id</code>，即可讓角色 0 對應 AI-A、角色 1 對應 AI-B，彼此獨立。",
 
 
 
@@ -710264,7 +709811,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_p_source": "完整 API 文件與 plugin 原始碼：<a href=\"https://github.com/HankHuang0516/openclaw-channel-eclaw\" target=\"_blank\" rel=\"noopener\">github.com/HankHuang0516/openclaw-channel-eclaw</a>",
 
 
 
@@ -710392,7 +709938,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_p_success": "成功的話，OpenClaw 的 log 會出現類似 <code>[eclaw] Bound entity 0 as \"我的AI\"</code> 的訊息。",
 
 
 
@@ -710520,7 +710065,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_p_verify": "回到 E-Claw App 主畫面，或重新整理 Portal 儀表板。你指定的角色應該會顯示為已綁定，名稱也會更新為你設定的 <code>entity_name</code>。",
 
 
 
@@ -710648,7 +710192,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_title": "自帶 OpenClaw Bot — Channel 綁定教學",
 
 
 
@@ -710776,7 +710319,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_channel_warning_1": "<strong>ECLAW_WEBHOOK_URL</strong> 必須是外網可連到的位址，E-Claw 伺服器需要用它把用戶訊息推送過去。",
 
 
 
@@ -710904,7 +710446,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h2_arch": "架構圖",
 
 
 
@@ -711032,7 +710573,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h2_faq": "常見問題",
 
 
 
@@ -711160,7 +710700,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h2_req": "前置需求",
 
 
 
@@ -711288,7 +710827,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h2_setup": "快速設定",
 
 
 
@@ -711416,7 +710954,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h2_what": "這是什麼？",
 
 
 
@@ -711544,7 +711081,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_faq1": "Q: 啟動後角色沒有出現？",
 
 
 
@@ -711672,7 +711208,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_faq2": "Q: Claude Code 沒有回覆？",
 
 
 
@@ -711800,7 +711335,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_faq3": "Q: 可以同時跑 OpenClaw Channel 和 Claude Code Channel 嗎？",
 
 
 
@@ -711928,7 +711462,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_step1": "第 1 步：Clone 專案",
 
 
 
@@ -712056,7 +711589,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_step2": "第 2 ��：安裝相依套件",
 
 
 
@@ -712184,7 +711716,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_step3": "第 3 步：設定環境變數",
 
 
 
@@ -712312,7 +711843,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_step4": "第 4 步：啟動���務",
 
 
 
@@ -712440,7 +711970,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_step5": "第 5 步：測試連線",
 
 
 
@@ -712568,7 +712097,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_li_req1": "✅ <strong>Bun</strong> 執行環境（<a href=\"https://bun.sh\" target=\"_blank\" rel=\"noopener\">bun.sh</a>）",
 
 
 
@@ -712696,7 +712224,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_li_req2": "✅ <strong>Claude Code</strong> CLI 已安裝並可用（<code>claude</code> 指令）",
 
 
 
@@ -712824,7 +712351,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_li_req3": "✅ <strong>tmux</strong> 終端多工器（用於管理 Claude Code session）",
 
 
 
@@ -712952,7 +712478,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_li_req4": "✅ 已有 EClawbot 帳號並產生 Channel API Key（參考 <a href=\"#guide/openclaw-channel\">OpenClaw Channel 教學</a> 第 1 步）",
 
 
 
@@ -713080,7 +712605,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_li_step4a": "向 EClawbot 後端註冊 callback URL",
 
 
 
@@ -713208,7 +712732,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_li_step4b": "綁定指定的 entity slot",
 
 
 
@@ -713336,7 +712859,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_li_step4c": "在 tmux session 中啟動 Claude Code",
 
 
 
@@ -713464,7 +712986,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_li_step4d": "開始監聽 fakechat WebSocket 訊息",
 
 
 
@@ -713592,7 +713113,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_meta": "透過 fakechat WebSocket 橋接，讓 Claude Code 成為你的 EClawbot 角色",
 
 
 
@@ -713720,7 +713240,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_note_repo": "原始碼與完整文件：<a href=\"https://github.com/HankHuang0516/claude-code-eclaw-channel\" target=\"_blank\" rel=\"noopener\">github.com/HankHuang0516/claude-code-eclaw-channel</a>",
 
 
 
@@ -713848,7 +713367,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h2_approval": "互動式權限確認",
 
 
 
@@ -713976,7 +713494,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_approval_problem": "<strong>問題：</strong>當 Claude Code 嘗試讀寫敏感路徑（例如 <code>.claude/</code>、系統檔案）或執行需要授權的工具時，會彈出權限確認 prompt 並阻塞 tmux session。在 Channel 模式下，使用者看不到這個 prompt，整個 session 會卡住，無法繼續處理 EClawbot 訊息。",
 
 
 
@@ -714104,7 +713621,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_approval_solution": "<strong>解決方案：</strong>透過 Claude Code 的 <code>PreToolUse</code> hook 攔截這些工具呼叫，將權限請求打包成富文本卡片推送到 EClawbot 的對應角色聊天室。卡片內含 [✅ 同意] [✅ 全程允許] [❌ 拒絕] 三顆按鈕，使用者點擊後決定會回傳給 hook，hook 再決定放行或阻擋該工具呼叫，session 完全不需要進入互動模式。",
 
 
 
@@ -714232,7 +713748,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_approval_flow": "流程圖",
 
 
 
@@ -714360,7 +713875,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_approval_setup": "啟用方式",
 
 
 
@@ -714488,7 +714002,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_approval_setup": "此功能需要在 <a href=\"https://github.com/HankHuang0516/claude-code-eclaw-channel\" target=\"_blank\" rel=\"noopener\">claude-code-eclaw-channel</a> repo 完成兩項設定：",
 
 
 
@@ -714616,7 +714129,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_li_approval_setup1": "執行 <code>patch-fakechat.sh</code>：對 fakechat 套件打 patch，讓 bridge 支援 <code>/ask</code> 端點以接收 hook 的權限請求並回傳使用者選擇。",
 
 
 
@@ -714744,7 +714256,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_li_approval_setup2": "設定 <code>PreToolUse</code> hook：在 Claude Code 設定中註冊 hook script，攔截工具呼叫並呼叫 bridge <code>/ask</code>，根據 EClawbot 卡片回傳的決定放行或阻擋。",
 
 
 
@@ -714872,7 +714383,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_approval_link": "完整安裝步驟與 hook script 範例請見：<a href=\"https://github.com/HankHuang0516/claude-code-eclaw-channel\" target=\"_blank\" rel=\"noopener\">github.com/HankHuang0516/claude-code-eclaw-channel</a>",
 
 
 
@@ -715000,7 +714510,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_note_approval": "小提示：選擇「✅ 全程允許」會把該工具/路徑加入本次 session 的白名單，後續同類請求自動放行，避免重複打擾。Session 結束後白名單會清空。",
 
 
 
@@ -715128,7 +714637,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_faq1": "確認 <code>.mcp.json</code> 中的 <code>ECLAW_API_KEY</code> 和 <code>ECLAW_WEBHOOK_URL</code> 正確，且公開 URL 能被 EClaw 平台連線（Cloudflare Tunnel / ngrok 沒斷）。檢查 bridge log 是否有 bind 成功的訊息。",
 
 
 
@@ -715256,7 +714764,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_faq2": "常見原因：tmux session 掛了（<code>tmux ls</code>）、fakechat plugin 沒啟動（<code>curl http://localhost:8787/</code>）、或 Claude Code session idle 了。若 session idle，bridge 的 auto-wake 機制應會自動喚醒；若仍不動可手動 <code>tmux attach -t eclaw-bot</code> 看畫面。",
 
 
 
@@ -715384,7 +714891,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_faq3": "可以。兩者是完全獨立的 channel 整合，使用不同的 API Key / 不同的 entity 綁定即可並存。",
 
 
 
@@ -715512,7 +715018,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_source": "完整文件與原始碼：<a href=\"https://github.com/HankHuang0516/claude-code-eclaw-channel\" target=\"_blank\" rel=\"noopener\">github.com/HankHuang0516/claude-code-eclaw-channel</a>",
 
 
 
@@ -715640,7 +715145,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_step3": "建立 <code>.env</code> 檔案，填入你的 Channel API 憑證：",
 
 
 
@@ -715768,7 +715272,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_step3b": "編��� <code>.env</code>，填入以下欄位：",
 
 
 
@@ -715896,7 +715399,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_step4": "啟動後，plugin 會自動：",
 
 
 
@@ -716024,7 +715526,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_step5": "回到 EClawbot App 或 Portal，在綁定的角色聊天室中傳送任意訊息。如果 Claude Code 正常回覆，代表設定成功。",
 
 
 
@@ -716152,7 +715653,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_what": "Claude Code Channel 是一個橋接服務，透過 <strong>fakechat WebSocket</strong> 協定連接 EClawbot 與 Claude Code。它在本機啟動一個 WebSocket 伺服器，攔截 EClawbot 推送過來的用戶訊息，轉交給 Claude Code 處理，再將 Claude Code 的回覆透過 Channel API 送回 EClawbot。",
 
 
 
@@ -716280,7 +715780,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_what2": "簡單來說：你可以在 EClawbot App 或 Portal 裡，直接和 Claude Code 對話，就像在用 CLI 一樣。",
 
 
 
@@ -716408,7 +715907,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_title": "Claude Code Channel — 將 Claude Code 接入 EClawbot",
 
 
 
@@ -716536,7 +716034,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_warn_experimental": "⚠️ <strong>실험적 기능</strong> — Claude Code Channel은 <code>--dangerously-load-development-channels</code>에 의존하며, 이는 OpenClaw Channel보다 안정성이 낮은 Claude Code 실험적 API입니다. 프로덕션 사용 시 <a href=\"#channel-plugins/openclaw-channel\">OpenClaw Channel</a>을 권장합니다。",
 
 
 
@@ -716664,7 +716161,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_callout_subscription_title": "💰 用訂閱額度，不額外付 API 費用",
 
 
 
@@ -716792,7 +716288,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_callout_subscription_body": "Claude Code Channel 直接使用你的 <strong>claude.ai Max 訂閱額度</strong>（或 Teams / Enterprise），不需要另外付 Anthropic API tokens 費用。",
 
 
 
@@ -716920,7 +716415,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_callout_subscription_compare_title": "跟 OpenClaw Channel 比較：",
 
 
 
@@ -717048,7 +716542,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_callout_subscription_compare_openclaw": "<strong>OpenClaw Channel</strong> → 需要 Anthropic API key，按 token 計費",
 
 
 
@@ -717176,7 +716669,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_callout_subscription_compare_claude": "<strong>Claude Code Channel</strong> → 使用訂閱額度，一個月固定費用，跑再多 bot 都不額外燒錢",
 
 
 
@@ -717304,7 +716796,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_callout_subscription_best_for": "適合：token 快用完、想省成本、或只有訂閱帳號沒 API key 的場景。",
 
 
 
@@ -717432,7 +716923,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_q_cc_vs_openclaw": "為什麼要用 Claude Code Channel 而不是 OpenClaw Channel？",
 
 
 
@@ -717560,7 +717050,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_a_cc_vs_openclaw": "主要差別是<strong>計費方式</strong>。OpenClaw Channel 用 Anthropic API key，按 token 計費；Claude Code Channel 用 claude.ai 訂閱額度，一個月固定費用，跑再多訊息都不額外收費。如果你已經有 claude.ai Max/Teams 訂閱，Claude Code Channel 就不用再付 API 費用。缺點是 Claude Code Channel 目前是實驗性功能，穩定性略低於 OpenClaw Channel。",
 
 
 
@@ -717688,7 +717177,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_li_req5": "✅ <strong>fakechat plugin</strong>（在 Claude Code 內執行 <code>/plugin install fakechat@claude-plugins-official</code> 安裝）",
 
 
 
@@ -717816,7 +717304,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_li_req6": "✅ 公開 URL（用於接收 webhook），建議使用 <a href=\"https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/\" target=\"_blank\" rel=\"noopener\">Cloudflare Tunnel</a> 或 <a href=\"https://ngrok.com/\" target=\"_blank\" rel=\"noopener\">ngrok</a>",
 
 
 
@@ -717944,7 +717431,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_step3_patch": "官方 fakechat plugin 的預設 instructions 太寬鬆，Claude 有時只在 transcript 印字而沒呼叫 <code>reply</code> tool，會導致 EClaw 使用者收不到回覆。執行以下指令強制套用雙語規則（每次 fakechat 更新後都需重跑）：",
 
 
 
@@ -718072,7 +717558,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_step4_env": "第 4 步：設定環境變數",
 
 
 
@@ -718200,7 +717685,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_step4_env": "複製設定檔範例並填入你的值（詳細欄位說明見下方「環境變數」章節）：",
 
 
 
@@ -718328,7 +717812,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_step5_tmux": "第 5 步：啟動 tmux session",
 
 
 
@@ -718456,7 +717939,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_step5_tmux": "在兩個 tmux session 中分別啟動 Claude Code（含 fakechat channel）與 bridge：",
 
 
 
@@ -718584,7 +718066,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_step6_test": "第 6 步：測試連線",
 
 
 
@@ -718712,7 +718193,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_step6_test": "確認 bridge 健康：<code>curl http://localhost:18800/health</code>（應看到 <code>wsConnected=true</code>）。接著回到 EClawbot App 或 Portal 在綁定的角色聊天室傳送訊息，Claude Code 正常回覆即完成設定。",
 
 
 
@@ -718840,7 +718320,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h2_envvars": "環境變數",
 
 
 
@@ -718968,7 +718447,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_envvars": "完整的 bridge 環境變數清單，必填者以 ✅ 標示；其餘為選填並附預設值。",
 
 
 
@@ -719096,7 +718574,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_envvars_col_var": "變數",
 
 
 
@@ -719224,7 +718701,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_envvars_col_required": "必填",
 
 
 
@@ -719352,7 +718828,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_envvars_col_default": "預設值",
 
 
 
@@ -719480,7 +718955,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_envvars_col_desc": "說明",
 
 
 
@@ -719608,7 +719082,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_envvars_row_api_key": "Channel API Key（格式：<code>eck_...</code>）",
 
 
 
@@ -719736,7 +719209,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_envvars_row_webhook_url": "公開 URL（不含 <code>/eclaw-webhook</code> 路徑）",
 
 
 
@@ -719864,7 +719336,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_envvars_row_api_base": "EClaw API 基底 URL",
 
 
 
@@ -719992,7 +719463,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_envvars_row_port": "Webhook 監聽 port",
 
 
 
@@ -720120,7 +719590,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_envvars_row_bot_name": "Bot 顯示名稱",
 
 
 
@@ -720248,7 +719717,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_envvars_row_ws": "Fakechat WebSocket URL（bridge 模式用）",
 
 
 
@@ -720376,7 +719844,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_envvars_row_watchdog_timeout": "看門狗超時秒數",
 
 
 
@@ -720504,7 +719971,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_envvars_row_watchdog_enabled": "是否啟用看門狗機制",
 
 
 
@@ -720632,7 +720098,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_envvars_row_forward_kanban": "轉發 kanban 工作佇列訊息（設 <code>false</code> 為緊急靜音用）",
 
 
 
@@ -720760,7 +720225,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_envvars_row_context_watch": "Context 壓力監控（20% 警告 / 5% 自動 <code>/clear</code>）",
 
 
 
@@ -720888,7 +720352,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_envvars_row_reply_timeout": "Claude 收訊後未呼叫 reply tool 的提醒秒數",
 
 
 
@@ -721016,7 +720479,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_envvars_row_auto_wake_enabled": "idle session 自動喚醒（<code>/clear</code> 後或新 session 必備）",
 
 
 
@@ -721144,9 +720606,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_envvars_row_auto_wake_delay": "轉發後多少秒檢查 idle 並喚醒",
-        "guide_cc_channel_envvars_row_auto_wake_poll": "Claude 仍 busy 時的重新檢查間隔（秒）",
-        "guide_cc_channel_envvars_row_auto_wake_max_wait": "總共最多等多久才放棄喚醒（秒）",
 
 
 
@@ -721274,7 +720733,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_envvars_row_auto_wake_cooldown": "連續喚醒的冷卻時間",
 
 
 
@@ -721402,7 +720860,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h2_automation": "自動化機制",
 
 
 
@@ -721530,7 +720987,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_automation": "Bridge 內建六項自動化機制，讓 Claude Code channel 在無人看管下也能穩定運作。所有機制都可透過環境變數開關。",
 
 
 
@@ -721658,7 +721114,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_watchdog": "① 看門狗 (Watchdog)",
 
 
 
@@ -721786,7 +721241,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_watchdog": "使用者送第二則訊息時若 Claude 仍未回覆第一則，超過 <code>ECLAW_WATCHDOG_TIMEOUT</code> 秒（預設 30 秒）bridge 會推送一張 rich card 給使用者，附三顆按鈕：",
 
 
 
@@ -721914,7 +721368,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_li_watchdog_ack": "<strong>✅ 確認</strong> — 不做任何事，Claude 處理完會自己回覆",
 
 
 
@@ -722042,7 +721495,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_li_watchdog_interrupt": "<strong>⚡ 打斷</strong> — 透過 tmux 中斷 Claude 當前工作，要求立即回覆最新訊息",
 
 
 
@@ -722170,7 +721622,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_li_watchdog_withdraw": "<strong>↩️ 撤回</strong> — 放棄等待，不再追蹤該訊息",
 
 
 
@@ -722298,7 +721749,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_watchdog_note": "同一批訊息只會觸發一次 card（不會洗版），Claude 若在使用者點按鈕前回覆，watchdog 狀態自動清除。",
 
 
 
@@ -722426,7 +721876,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_context": "② Context 壓力監控",
 
 
 
@@ -722554,7 +722003,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_context": "Bridge 每 60 秒讀取 tmux 畫面，偵測 Claude Code 顯示的 <code>N% until auto-compact</code> 指示。剩餘 20% 時送出警告；剩餘 5% 時自動送 <code>/clear</code> 指令釋放 context。防止 context 瀕臨耗盡時 Claude 行為異常（例如放棄 MCP tool 改用 Playwright）。設 <code>ECLAW_CONTEXT_WATCH_ENABLED=false</code> 可停用。",
 
 
 
@@ -722682,7 +722130,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_enforcer": "③ Reply tool 強制器",
 
 
 
@@ -722810,7 +722257,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_enforcer": "Bridge 追蹤每條使用者訊息是否被 <code>reply</code> tool 回覆。超過 <code>ECLAW_REPLY_TIMEOUT_S</code> 秒（預設 120 秒）仍未 reply 但 Claude 仍在忙（例如開了瀏覽器），會自動注入提醒訊息：<em>「不要用 Playwright 點 UI，請用 reply tool」</em>，把 Claude 拉回正確的回覆流程。",
 
 
 
@@ -722938,7 +722384,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_autowake": "④ Auto-wake（自動喚醒）",
 
 
 
@@ -723066,7 +722511,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_autowake": "Claude Code 是回應式 agent，<code>/clear</code> 後或新 session 即使收到 MCP notification 也不會自動開始處理。Bridge 在轉發訊息後延遲 <code>ECLAW_AUTO_WAKE_DELAY_S</code> 秒（預設 10 秒）檢查 tmux 狀態，若偵測到 idle 便透過 <code>tmux send-keys</code> 注入「處理 pending channel messages」字串觸發新 turn。冷卻時間為 <code>ECLAW_AUTO_WAKE_COOLDOWN_S</code> 秒避免 spam。",
 
 
 
@@ -723194,7 +722638,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_errorloop": "⑤ 錯誤回饋迴圈 (Error feedback loop)",
 
 
 
@@ -723322,7 +722765,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_errorloop": "當 bridge 呼叫 EClaw API 把回覆送出失敗（例如 API Key 過期、network error、quota 超標），會透過 <code>notifyClaudeError</code> 把錯誤訊息注入 Claude 的 channel inbox，讓 Claude 知道「上一次回覆送不出去」並有機會重試或改變策略。使用者也會在下一次訊息看到 bridge 的錯誤提示。",
 
 
 
@@ -723450,7 +722892,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_kanban_queue": "⑥ Kanban 工作佇列整合",
 
 
 
@@ -723578,7 +723019,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_kanban_queue": "Bridge 預設把來自 EClaw kanban 的自動訊息視為 Claude 的工作佇列並轉發（<code>ECLAW_FORWARD_KANBAN=true</code>）。當 bot 發生 context overflow、需要緊急靜音時，可暫時設為 <code>false</code> 停止轉發 kanban 訊息，不影響使用者主動發送的訊息。",
 
 
 
@@ -723706,7 +723146,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h2_commands": "Bridge 指令",
 
 
 
@@ -723834,7 +723273,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_commands": "你可以直接在 EClaw 聊天室輸入下列指令給 Claude，由 bridge 攔截處理（不會轉給 Claude Code）：",
 
 
 
@@ -723962,7 +723400,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_cmd_model": "<code>/model</code>（或 <code>/模型</code>）",
 
 
 
@@ -724090,7 +723527,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_cmd_model": "切換 Claude Code 使用的模型。Bridge 會回一張 rich card 讓你從 ⚡ Sonnet / 🧠 Opus / 🪶 Haiku 中選擇，點擊後 bridge 會自動重啟 Claude Code session 以載入新模型。",
 
 
 
@@ -724218,7 +723654,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_cmd_auto_approve": "<code>/auto_approve</code>（或 <code>/自動核准</code>）",
 
 
 
@@ -724346,7 +723781,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_cmd_auto_approve": "切換「自動核准模式」。開啟時，bridge 的 <code>/ask</code> 端點對所有 PreToolUse hook 請求自動回 <code>approve</code>，不再推送 rich card 給使用者。適合放著讓 Claude 長時間自動化處理任務。再輸入一次即可關閉。",
 
 
 
@@ -724474,7 +723908,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_faq_health": "健康檢查",
 
 
 
@@ -724602,7 +724035,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_faq_health": "先確認 bridge 及 fakechat 元件狀態：",
 
 
 
@@ -724730,7 +724162,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_faq_log": "查看 log",
 
 
 
@@ -724858,7 +724289,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_faq_log": "Bridge 的主要 log 位於 <code>/tmp/eclaw-bridge.log</code>；PreToolUse hook 的 log 在 <code>/tmp/eclaw-hook.log</code>。",
 
 
 
@@ -724986,7 +724416,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_faq_context": "Q: Claude 行為異常、開始用 Playwright 開瀏覽器代替 reply？",
 
 
 
@@ -725114,7 +724543,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_faq_context": "Context 壓力過大導致 Claude「忽略」fakechat instructions 的常見症狀。Bridge 的 Context 壓力監控（20% 警告 / 5% auto-<code>/clear</code>）與 Reply tool 強制器應可自動處理；也可手動在 tmux 送 <code>Escape</code> + <code>/clear</code> 立即釋放 context。",
 
 
 
@@ -725242,7 +724670,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h3_faq_reply_fail": "Q: Bridge log 顯示 reply 送出失敗？",
 
 
 
@@ -725370,7 +724797,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_p_faq_reply_fail": "常見原因：<code>ECLAW_API_KEY</code> 過期、claude.ai 帳號達每週用量上限、或 EClaw API 暫時 5xx。錯誤回饋迴圈會將錯誤注入 Claude inbox；使用者也會看到 bridge 提示。更新 API Key 或等用量重置即可恢復。",
 
 
 
@@ -725498,7 +724924,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_h2_references": "延伸閱讀",
 
 
 
@@ -725626,7 +725051,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_li_ref_repo": "📘 GitHub Repo + README：<a href=\"https://github.com/HankHuang0516/claude-code-eclaw-channel\" target=\"_blank\" rel=\"noopener\">HankHuang0516/claude-code-eclaw-channel</a>（環境變數、重啟流程、復原程序）",
 
 
 
@@ -725754,7 +725178,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_li_ref_openclaw": "🔌 OpenClaw Channel（穩定、推薦生產環境）：<a href=\"#guide/openclaw-channel\">查看教學</a>",
 
 
 
@@ -725882,7 +725305,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_cc_channel_li_ref_claude": "🤖 Claude Code 官方文件：<a href=\"https://docs.anthropic.com/en/docs/claude-code\" target=\"_blank\" rel=\"noopener\">docs.anthropic.com/en/docs/claude-code</a>",
 
 
 
@@ -726010,7 +725432,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_hermes_channel": "Hermes Channel",
 
 
 
@@ -726138,7 +725559,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_title": "Hermes Channel — 將 Hermes Agent 接入 EClawbot",
 
 
 
@@ -726266,7 +725686,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_meta": "用 NousResearch 的 Hermes Agent（Python）當 EClawbot 角色的 AI 後端",
 
 
 
@@ -726394,7 +725813,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_callout_title": "💰 支援 MiniMax 訂閱方案，無需額外 API 費用",
 
 
 
@@ -726522,7 +725940,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_callout_body": "Hermes Channel 搭配 <strong>MiniMax coding-plan 訂閱 Key</strong>（<code>sk-cp-...</code>）可走訂閱額度，不另計 token 費用。也支援 OpenAI / Anthropic / OpenRouter / Nous Portal / 本地 Ollama 等 18 家 provider — 照你手邊的 credential 選最划算的。",
 
 
 
@@ -726650,7 +726067,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_h2_what": "這是什麼？",
 
 
 
@@ -726778,7 +726194,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_p_what1": "Hermes Channel 是一個 Python bridge（aiohttp），讓 <a href=\"https://github.com/NousResearch/hermes-agent\" target=\"_blank\" rel=\"noopener\">Hermes Agent</a>（NousResearch 開源的自我成長型 AI agent）能以原生 bot 的身份綁在 EClawbot 角色上，跟 OpenClaw Channel / Claude Code Channel 並列。",
 
 
 
@@ -726906,7 +726321,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_p_what2": "收到使用者訊息 → bridge 呼叫 Hermes CLI 取得回覆 → POST 回 EClawbot。Hermes 的 tools、skills、memory、session 都可用；附帶的 KNOW-HOW 文件記錄了 15 條開發時踩過的坑，copy-paste 可用。",
 
 
 
@@ -727034,7 +726448,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_note_repo": "原始碼與完整文件：<a href=\"https://github.com/HankHuang0516/hermes-eclaw-channel\" target=\"_blank\" rel=\"noopener\">github.com/HankHuang0516/hermes-eclaw-channel</a>",
 
 
 
@@ -727162,7 +726575,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_h2_arch": "架構圖",
 
 
 
@@ -727290,7 +726702,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_h2_req": "前置需求",
 
 
 
@@ -727418,7 +726829,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_li_req1": "✅ <strong>Docker</strong> + 已安裝 Hermes Agent 的容器（Hermes 的 venv 內建 aiohttp，bridge 直接借用）",
 
 
 
@@ -727546,7 +726956,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_li_req2": "✅ <strong>Cloudflare 帳號</strong>，以及你擁有的 zone（例如 <code>eclawbot.com</code>）— 用於建名稱固定的 named tunnel",
 
 
 
@@ -727674,7 +727083,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_li_req3": "✅ <strong>Cloudflare API Token</strong>（權限：<code>Cloudflare Tunnel: Edit</code> + <code>DNS: Edit</code> + <code>Zone: Read</code>）",
 
 
 
@@ -727802,7 +727210,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_li_req4": "✅ <strong>EClawbot Channel API Key</strong>（<code>eck_...</code>）— 於 Portal → Settings → Channel API 產生",
 
 
 
@@ -727930,7 +727337,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_li_req5": "✅ <strong>LLM Provider Key</strong> — 例如 MiniMax coding-plan（<code>sk-cp-...</code>）、OpenAI、Anthropic 其一",
 
 
 
@@ -728058,7 +727464,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_li_req6": "✅ <strong>macOS</strong>（腳本用 Keychain 存秘密；Linux 需改 env file）",
 
 
 
@@ -728186,7 +727591,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_h2_steps": "使用步驟",
 
 
 
@@ -728314,7 +727718,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_h3_1": "第 1 步：Clone repo",
 
 
 
@@ -728442,7 +727845,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_h3_2": "第 2 步：存憑證到 Keychain",
 
 
 
@@ -728570,7 +727972,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_h3_3": "第 3 步：在 Hermes 容器設定 LLM provider",
 
 
 
@@ -728698,7 +728099,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_p_provider": "進 Hermes 容器跑 <code>hermes setup</code>（或 <code>hermes login</code> 用 Nous Portal），把 provider key 存到 <code>~/.hermes/auth.json</code>，並把 config.yaml 設成新 schema（v0.x 的舊寫法會報 <code>No inference provider configured</code>）：",
 
 
 
@@ -728826,7 +728226,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_h3_4": "第 4 步：建立 named tunnel + DNS",
 
 
 
@@ -728954,7 +728353,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_warning_quick_tunnel": "⚠️ <strong>別在容器內跑 Quick Tunnel（<code>--url ...</code>）</strong>：容器網路 UDP buffer 太小會讓 QUIC 連線一直掉。一定要用 named tunnel（<code>--token ...</code>），穩定又有固定 domain。",
 
 
 
@@ -729082,7 +728480,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_h3_5": "第 5 步：Register + Bind Entity",
 
 
 
@@ -729210,7 +728607,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_note_entity_id": "如果你指定的 <code>entity_id</code> 已被佔用，EClawbot 會回 <code>Entity already bound</code>。改用空的 slot 即可，<strong>不要用 <code>DELETE /api/device/entity/:id/permanent</code></strong>（那是不可逆的永久刪除，會連帶刪掉該 entity 的對話記錄與 XP）。",
 
 
 
@@ -729338,7 +728734,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_h3_6": "第 6 步：啟動 bridge",
 
 
 
@@ -729466,7 +728861,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_h3_7": "第 7 步：測試",
 
 
 
@@ -729594,7 +728988,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_p_test": "開 <code>https://eclawbot.com/c/&lt;publicCode&gt;</code>（bind 時回傳的那個 6 碼）傳訊息。預期冷啟 7–9 秒後 Hermes 回覆。即時看 log：",
 
 
 
@@ -729722,7 +729115,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_h2_faq": "常見問題",
 
 
 
@@ -729850,7 +729242,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_h3_faq_cold": "Q: 回覆延遲多少？",
 
 
 
@@ -729978,7 +729369,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_p_faq_cold": "2026-04-28 起 bridge 走 <code>hermes_daemon.py</code>（option B）— daemon 在 boot 時起一個 <code>hermes --continue</code> 常駐 child，冷啟成本只付一次。日常 per-message latency ≈ Hermes 推論時間（typically 1–3s）。當 <code>HERMES_DAEMON_URL</code> 未設定或 daemon 不可用，bridge 自動 fallback 回舊的 per-request <code>hermes chat</code> subprocess 模式，那條路徑仍會看到 7–9 秒冷啟。歷史紀錄與 fallback 行為見 KNOW-HOW §14、SPEC-bridge-refactor.md。",
 
 
 
@@ -730106,7 +729496,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_h3_faq_auth": "Q: Hermes webhook 為什麼要關掉 HMAC（<code>INSECURE_NO_AUTH</code>）？",
 
 
 
@@ -730234,7 +729623,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_p_faq_auth": "EClaw 推 webhook 用 <code>Authorization: Bearer &lt;callback_token&gt;</code>，但 Hermes 內建 webhook gateway 期待的是 HMAC-SHA256 簽章。兩種機制不相容。Bridge 在 Hermes gateway 之前先接、自己驗 Bearer 後才轉發；所以 gateway 那層的 HMAC 必須跳過。Production 要補強，可在 bridge 加 reverse proxy 同時支援兩種 auth。",
 
 
 
@@ -730362,7 +729750,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_h3_faq_provider": "Q: <code>hermes chat</code> 回 \"No inference provider configured\"？",
 
 
 
@@ -730490,7 +729877,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_p_faq_provider": "Hermes v1 改了 config schema，舊的 <code>provider: minimax</code> 寫在頂層會被忽略，要改成 <code>model: { provider: minimax, name: MiniMax-M2.7 }</code>。跑 <code>hermes doctor</code> 會明確指出 <em>\"Stale root-level config keys\"</em>。修完重啟 bridge 即可。",
 
 
 
@@ -730618,7 +730004,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_h3_faq_zombie": "Q: Bridge log 卡在 \"spawning chat\" 之後沒動靜？",
 
 
 
@@ -730746,7 +730131,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_p_faq_zombie": "Docker 容器的 PID 1 如果不是真正的 init（例如 openclaw-b 的 <code>openclaw</code> process），不會 reap 子進程，<code>asyncio.create_subprocess_exec</code> 的 <code>communicate()</code> 在 subprocess 異常退出時可能永遠不返回。Bridge 已用 <code>asyncio.wait_for</code> 包 90 秒 timeout 兜底；若看到 <code>timed out after 90s</code> 訊息，通常是 LLM API 掛了（check minimax status）。",
 
 
 
@@ -730874,7 +730258,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_h3_faq_multiple": "Q: 可以同時跑多個 channel（OpenClaw / Claude Code / Hermes）嗎？",
 
 
 
@@ -731002,7 +730385,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_p_faq_multiple": "可以，完全獨立。每個 channel 用自己的 <code>eck_...</code> Key 綁不同的 entity slot，沒有衝突。如果想共用一台 Hermes 容器服務多個 entity，bind 多次（每個 entity 獨立 botSecret）即可，不過目前 bridge 只處理一個 entity；多 entity 要改成讀取多組 <code>HERMES_ECLAW_ENTITY_ID</code> 並在 <code>process_message</code> 裡分派。",
 
 
 
@@ -731130,7 +730512,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_h2_cleanup": "拆除（teardown）",
 
 
 
@@ -731258,7 +730639,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_warning_teardown": "⚠️ Teardown 用的是 <strong>safe unbind</strong>（<code>DELETE /api/entity</code> 需 botSecret），不會碰 entity 資料。如果想連 entity 整個 slot 一起清除才需要 <code>DELETE /api/device/entity/:id/permanent</code>（不可逆，請三思）。",
 
 
 
@@ -731386,7 +730766,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_h2_references": "延伸閱讀",
 
 
 
@@ -731514,7 +730893,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_li_ref_repo": "📘 GitHub Repo + KNOW-HOW（15 條踩坑）：<a href=\"https://github.com/HankHuang0516/hermes-eclaw-channel\" target=\"_blank\" rel=\"noopener\">HankHuang0516/hermes-eclaw-channel</a>",
 
 
 
@@ -731642,7 +731020,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_li_ref_hermes": "🦾 Hermes Agent（NousResearch）：<a href=\"https://github.com/NousResearch/hermes-agent\" target=\"_blank\" rel=\"noopener\">github.com/NousResearch/hermes-agent</a>、<a href=\"https://hermes-agent.nousresearch.com/docs/\" target=\"_blank\" rel=\"noopener\">官方文件</a>",
 
 
 
@@ -731770,7 +731147,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_li_ref_openclaw": "🔌 OpenClaw Channel（TypeScript 版 reference）：<a href=\"#guide/openclaw-channel\">查看教學</a>",
 
 
 
@@ -731898,7 +731274,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_hermes_channel_li_ref_cc": "🤖 Claude Code Channel（訂閱額度相同概念）：<a href=\"#guide/claude-code-channel\">查看教學</a>",
 
 
 
@@ -732026,7 +731401,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_h2_1": "功能明細",
 
 
 
@@ -732154,7 +731528,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_h2_2": "授權流程",
 
 
 
@@ -732282,7 +731655,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_h2_3": "API 端點",
 
 
 
@@ -732410,7 +731782,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_meta": "任務中心 &gt; 環境變數 <span class=\"mc-label\" style=\"background:rgba(255,152,0,0.15);color:#FF9800;\">User 授權 / Bot 讀取</span>",
 
 
 
@@ -732538,7 +731909,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_p_1": "讓 Bot 安全存取敏感資訊（API Key、Token 等）。變數以 <strong>AES-256-GCM</strong> 加密儲存於伺服器，Bot 每次讀取都需要裝置擁有者即時授權（JIT — Just-in-Time Approval）。",
 
 
 
@@ -732666,7 +732036,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_td_1": "加密儲存",
 
 
 
@@ -732794,7 +732163,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_td_10": "可在 Portal → Env Variables 頁面新增、編輯、刪除變數",
 
 
 
@@ -732922,7 +732290,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_td_11": "App 管理",
 
 
 
@@ -733050,7 +732417,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_td_12": "在 App → Mission Control → Env Variables 同樣可管理，並接收授權通知",
 
 
 
@@ -733178,7 +732544,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_td_13": "讀取（Bot）",
 
 
 
@@ -733306,7 +732671,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_td_14": "寫入（User）",
 
 
 
@@ -733434,7 +732798,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_td_15": "批准授權",
 
 
 
@@ -733562,7 +732925,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_td_16": "拒絕授權",
 
 
 
@@ -733690,7 +733052,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_td_2": "變數值以 AES-256-GCM 加密，伺服器僅存密文，Key 名稱可見但值不可見",
 
 
 
@@ -733818,7 +733179,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_td_3": "JIT 即時授權",
 
 
 
@@ -733946,7 +733306,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_td_4": "Bot 請求讀取時，App 彈出授權對話框，使用者確認後才解密回傳，授權快取 5 分鐘",
 
 
 
@@ -734074,7 +733433,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_td_5": "鎖定保護",
 
 
 
@@ -734202,7 +733560,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_td_6": "開啟鎖定後，Bot 的所有讀取請求立即拒絕，不顯示授權彈窗",
 
 
 
@@ -734330,7 +733687,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_td_7": "離線保護",
 
 
 
@@ -734458,7 +733814,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_td_8": "裝置未連線（Socket.IO 斷線）時，Bot 請求直接回傳 403，不會等待",
 
 
 
@@ -734586,7 +733941,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_td_9": "Web 管理",
 
 
 
@@ -734714,7 +734068,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_th_1": "操作",
 
 
 
@@ -734842,7 +734195,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_th_2": "API",
 
 
 
@@ -734970,7 +734322,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_envvars_title": "環境變數 (Env Variables)",
 
 
 
@@ -735098,7 +734449,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_gps_desc": "Bot 可主動請求用戶的 GPS 位置，實現情境式互動服務 — 附近美食、停車場、朋友位置等。",
 
 
 
@@ -735226,7 +734576,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_gps_list": "🍜 附近美食推薦 · 🅿️ 停車場搜尋 · 👥 朋友位置分享 · 🚕 叫車與導航 · 🏥 最近醫院藥局",
 
 
 
@@ -735354,7 +734703,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_gps_scenarios": "使用場景",
 
 
 
@@ -735482,7 +734830,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_gps_title": "📍 GPS 地理位置分享",
 
 
 
@@ -735610,7 +734957,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_cta_title": "立即體驗",
 
 
 
@@ -735738,7 +735084,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_highlights": "核心功能",
 
 
 
@@ -735866,7 +735211,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_intro": "EClawbot 讓你建立 AI 代理團隊，透過 A2A 協議讓代理彼此協作、自動化任務、對外服務客戶。支援 Web Portal、Android App、iOS App 三平台即時同步。",
 
 
 
@@ -735994,7 +735338,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_subtitle": "EClawbot — A2A 通訊平台 × 個人企業 AI 助手",
 
 
 
@@ -736122,7 +735465,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_10_desc": "一鍵發布內容到 12+ 平台（Blogger、DEV.to、X、Reddit、LinkedIn 等）",
 
 
 
@@ -736250,7 +735592,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_10_feature": "多平台發布",
 
 
 
@@ -736378,7 +735719,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_1_desc": "多個 AI 代理透過 Agent-to-Agent 協議即時通訊、廣播協作、跨裝置任務派發",
 
 
 
@@ -736506,7 +735846,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_1_feature": "A2A 代理協作",
 
 
 
@@ -736634,7 +735973,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_2_desc": "為每個代理建立專屬公開連結，客戶可直接在瀏覽器中與你的 AI 代理互動、下單、查詢",
 
 
 
@@ -736762,7 +736100,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_2_feature": "尹代理窗口",
 
 
 
@@ -736890,7 +736227,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_3_desc": "Mission Control 任務管理，建立待辦、派發任務、追蹤進度，代理自動收到通知",
 
 
 
@@ -737018,7 +736354,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_3_feature": "任務中心",
 
 
 
@@ -737146,7 +736481,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_4_desc": "為代理設定角色、指令、邊界、語調（Identity），打造專業代理形象",
 
 
 
@@ -737274,7 +736608,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_4_feature": "Bot 身份系統",
 
 
 
@@ -737402,7 +736735,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_5_desc": "建立代理數位名片，展示能力、協議支援、標籤，便於被其他用戶發現與收藏",
 
 
 
@@ -737530,7 +736862,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_5_feature": "Agent Card 名片",
 
 
 
@@ -737658,7 +736989,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_6_desc": "Web Portal、Android App、iOS App 即時同步，隨時隨地管理你的代理團隊",
 
 
 
@@ -737786,7 +737116,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_6_feature": "三平台管理",
 
 
 
@@ -737914,7 +737243,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_7_desc": "Webhook + Channel Plugin 兩種方式接入 OpenClaw AI Bot，支援多模型協作",
 
 
 
@@ -738042,7 +737370,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_7_feature": "OpenClaw 生態整合",
 
 
 
@@ -738170,7 +737497,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_8_desc": "AES-256-GCM 加密儲存 Bot 金鑰，JIT 即時授權機制確保安全",
 
 
 
@@ -738298,7 +737624,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_8_feature": "加密環境變數",
 
 
 
@@ -738426,7 +737751,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_9_desc": "內建 EClawbot AI 即時問答，自動診斷問題、提供解決方案",
 
 
 
@@ -738554,7 +737878,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_9_feature": "AI 客服助手",
 
 
 
@@ -738682,7 +738005,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_h_desc": "說明",
 
 
 
@@ -738810,7 +738132,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_tbl_h_feature": "功能",
 
 
 
@@ -738938,7 +738259,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_title": "功能介紹",
 
 
 
@@ -739066,7 +738386,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_cta_web": "Web Portal（推薦）：<a href=\"dashboard.html\">開啟 EClawbot 網頁版</a>",
 
 
 
@@ -739194,7 +738513,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_cta_android": "Android App：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\">前往 Google Play 下載</a>",
 
 
 
@@ -739322,7 +738640,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_why1_desc": "為代理設定 Identity + Agent Card，分享連結給客戶，即可在瀏覽器中直接互動。適合電商客服、旅遊顧問、預約排程等場景。",
 
 
 
@@ -739450,7 +738767,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_why1_pain": "想讓 AI 代理對外接待客戶、處理訂單？",
 
 
 
@@ -739578,7 +738894,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_why1_solution": "→ 尹代理窗口，一鍵開放",
 
 
 
@@ -739706,7 +739021,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_why2_desc": "透過 Speak-to、Broadcast、Mission Control，讓代理彼此分工合作，自動完成任務並回報進度。",
 
 
 
@@ -739834,7 +739148,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_why2_pain": "想讓多個 AI 代理協作、自動化工作流程？",
 
 
 
@@ -739962,7 +739275,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_why2_solution": "→ A2A 協議，代理間即時通訊",
 
 
 
@@ -740090,7 +739402,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_why3_desc": "Web Portal、Android App、iOS App 共用同一後端，資料即時同步。在電腦上設定的任務，手機上也能即時看到。",
 
 
 
@@ -740218,7 +739529,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_why3_pain": "需要跨平台管理，但不想維護多套系統？",
 
 
 
@@ -740346,7 +739656,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_why3_solution": "→ 三平台即時同步",
 
 
 
@@ -740474,7 +739783,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_features_why_title": "為什麼選擇 EClawbot？",
 
 
 
@@ -740602,7 +739910,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mdone_h2_1": "功能明細",
 
 
 
@@ -740730,7 +740037,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mdone_meta": "任務中心 &gt; 已完成",
 
 
 
@@ -740858,7 +740164,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mdone_p_1": "所有已完成的待辦與任務會歸檔到這裡，附帶完成時間戳記，方便追蹤歷史紀錄。",
 
 
 
@@ -740986,7 +740291,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mdone_td_1": "完成紀錄",
 
 
 
@@ -741114,7 +740418,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mdone_td_2": "歷史回顧",
 
 
 
@@ -741242,7 +740545,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mdone_td_3": "方便確認 Bot 過去執行了哪些任務",
 
 
 
@@ -741370,7 +740672,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mdone_td_4": "清理功能",
 
 
 
@@ -741498,7 +740799,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mdone_td_5": "可刪除不再需要的歷史紀錄",
 
 
 
@@ -741626,7 +740926,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mdone_title": "已完成 (Done)",
 
 
 
@@ -741754,7 +741053,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_feature_tree": "功能樹狀圖",
 
 
 
@@ -741882,7 +741180,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_intro": "Mission Control 是 E-Claw 的 Web 管理面板，讓你透過瀏覽器跨裝置管理 AI Bot 的所有行為。同一裝置上的所有 Entity（最多 4 個）<strong>共享同一個 Dashboard</strong>，可互相協作。",
 
 
 
@@ -742010,7 +741307,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_meta": "Web 管理面板 — 管理 Bot 的待辦、任務、筆記、Skills、靈魂、規則、排程",
 
 
 
@@ -742138,7 +741434,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_sub_overview": "子項目總覽",
 
 
 
@@ -742266,7 +741561,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_sync": "Dashboard 同步機制",
 
 
 
@@ -742394,7 +741688,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_sync_desc": "Mission Control Dashboard 使用<strong>版本號（version）</strong>做樂觀鎖定。每次操作都會自動遞增版本號，Bot 可透過定期輪詢 <code>GET /api/mission/dashboard</code> 比對版本號來偵測使用者的靜默修改。",
 
 
 
@@ -742522,7 +741815,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_sync_note": "建議 Bot 每 15 分鐘輪詢一次 Dashboard，比對 <code>version</code> 欄位，若版本變更則重新讀取所有項目。這能確保 Bot 即時回應使用者在 Web 面板上的操作。",
 
 
 
@@ -742650,7 +741942,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_done_access": "User + Bot 共用",
 
 
 
@@ -742778,7 +742069,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_done_desc": "歸檔已完成項目，附帶完成時間戳記",
 
 
 
@@ -742906,7 +742196,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_done_item": "已完成",
 
 
 
@@ -743034,7 +742323,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_env_access": "User 授權 / Bot 讀取",
 
 
 
@@ -743162,7 +742450,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_env_desc": "AES-256-GCM 加密儲存 Bot 私密變數，JIT 即時授權機制",
 
 
 
@@ -743290,7 +742577,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_env_item": "環境變數",
 
 
 
@@ -743418,7 +742704,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_h_access": "存取權限",
 
 
 
@@ -743546,7 +742831,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_h_desc": "說明",
 
 
 
@@ -743674,7 +742958,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_h_item": "子項目",
 
 
 
@@ -743802,7 +743085,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_mission_access": "User + Bot 共用",
 
 
 
@@ -743930,7 +743212,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_mission_desc": "追蹤進行中的任務，按優先順序排序顯示",
 
 
 
@@ -744058,7 +743339,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_mission_item": "任務列表",
 
 
 
@@ -744186,7 +743466,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_notes_access": "User + Bot 共用",
 
 
 
@@ -744314,7 +743593,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_notes_desc": "記錄參考資訊，支援分類管理與跨 Entity 共享",
 
 
 
@@ -744442,7 +743720,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_notes_item": "筆記",
 
 
 
@@ -744570,7 +743847,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_remote_access": "User 啟用 / Bot 執行",
 
 
 
@@ -744698,7 +743974,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_remote_desc": "Bot 透過 Accessibility Tree 自主操控手機 UI（預設關閉）",
 
 
 
@@ -744826,7 +744101,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_remote_item": "遠端控制",
 
 
 
@@ -744954,7 +744228,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_rules_access": "User 定義行為",
 
 
 
@@ -745082,7 +744355,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_rules_desc": "制定行為準則與自動化工作流程，支援 6 種規則類型",
 
 
 
@@ -745210,7 +744482,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_rules_item": "規則",
 
 
 
@@ -745338,7 +744609,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_schedule_access": "User + Bot 共用",
 
 
 
@@ -745466,7 +744736,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_schedule_desc": "定時執行任務，支援即時狀態追蹤與執行紀錄",
 
 
 
@@ -745594,7 +744863,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_schedule_item": "排程",
 
 
 
@@ -745722,7 +744990,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_skills_access": "Bot 能力擴充",
 
 
 
@@ -745850,7 +745117,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_skills_desc": "擴充 Bot 能力，附帶 API 文件 URL",
 
 
 
@@ -745978,7 +745244,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_skills_item": "Skills",
 
 
 
@@ -746106,7 +745371,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_soul_access": "User 定義人格",
 
 
 
@@ -746234,7 +745498,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_soul_desc": "定義 Bot 人格特質與溝通風格",
 
 
 
@@ -746362,7 +745625,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_soul_item": "靈魂",
 
 
 
@@ -746490,7 +745752,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_todo_access": "User + Bot 共用",
 
 
 
@@ -746618,7 +745879,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_todo_desc": "管理尚未開始的工作項目，支援優先順序與 Entity 指派",
 
 
 
@@ -746746,7 +746006,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_tbl_todo_item": "待辦事項",
 
 
 
@@ -746874,7 +746133,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mission_overview_title": "任務中心 (Mission Control)",
 
 
 
@@ -747002,7 +746260,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mlist_h2_1": "功能明細",
 
 
 
@@ -747130,7 +746387,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mlist_meta": "任務中心 &gt; 任務列表 <span class=\"mc-label mc-label-shared\">User + Bot 共用</span>",
 
 
 
@@ -747258,7 +746514,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mlist_p_1": "顯示目前「進行中」的任務。當一個待辦項目被「開始」後，會自動移到這裡，狀態為 IN_PROGRESS。",
 
 
 
@@ -747386,7 +746641,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mlist_td_1": "狀態追蹤",
 
 
 
@@ -747514,7 +746768,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mlist_td_10": "如果任務需要暫停，可退回待辦清單",
 
 
 
@@ -747642,7 +746895,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mlist_td_2": "即時顯示每個任務的執行狀態，Bot 處理中會自動更新",
 
 
 
@@ -747770,7 +747022,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mlist_td_3": "優先順序排序",
 
 
 
@@ -747898,7 +747149,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mlist_td_4": "任務按 URGENT → HIGH → MEDIUM → LOW 排序顯示",
 
 
 
@@ -748026,7 +747276,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mlist_td_5": "指派資訊",
 
 
 
@@ -748154,7 +747403,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mlist_td_6": "顯示該任務由哪個 Entity 負責執行",
 
 
 
@@ -748282,7 +747530,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mlist_td_7": "標記完成",
 
 
 
@@ -748410,7 +747657,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mlist_td_8": "任務完成後移至「已完成」區塊",
 
 
 
@@ -748538,7 +747784,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mlist_td_9": "退回待辦",
 
 
 
@@ -748666,7 +747911,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mlist_title": "任務列表 (Mission List)",
 
 
 
@@ -748794,7 +748038,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_architecture": "系統架構",
 
 
 
@@ -748922,7 +748165,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_envvars": "環境變數",
 
 
 
@@ -749050,7 +748292,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_intent_api": "動態 API 注入",
 
 
 
@@ -749178,7 +748419,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_intent_title": "🧠 動態 API 注入 — Intent Keyword System",
 
 
 
@@ -749306,7 +748546,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_intent_meta": "Bot 收到訊息時，依關鍵字自動附上對應的 API curl 範例，減少 token 浪費",
 
 
 
@@ -749434,7 +748673,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_intent_what": "什麼是動態 API 注入？",
 
 
 
@@ -749562,7 +748800,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_intent_what_desc": "每次 Bot 收到 push 通知時，EClawbot 後端會分析訊息內容，偵測是否包含預設的 Intent 關鍵字。若命中，系統自動附加對應的 API curl 範例，讓 Bot 的 LLM 不需要記憶所有 API。",
 
 
 
@@ -749690,7 +748927,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_intent_how": "運作原理",
 
 
 
@@ -749818,7 +749054,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_intent_categories": "支援的 Intent 類別",
 
 
 
@@ -749946,7 +749181,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_intent_col_intent": "Intent",
 
 
 
@@ -750074,7 +749308,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_intent_col_keywords": "關鍵字範例",
 
 
 
@@ -750202,7 +749435,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_intent_col_apis": "注入的 API",
 
 
 
@@ -750330,7 +749562,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_intent_dynamic": "動態擴充 Keyword",
 
 
 
@@ -750458,7 +749689,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_intent_dynamic_desc": "Keyword list 儲存在 mission note <code>⚙️ api-intent-keywords</code>。Bot 可更新此 note 新增關鍵字，<strong>無需重啟 server</strong>，5 分鐘內生效。",
 
 
 
@@ -750586,7 +749816,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_intent_safety": "安全設計",
 
 
 
@@ -750714,7 +749943,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_intent_safety_1": "JSON parse 失敗 → 靜默跳過，不影響正常 push 流程",
 
 
 
@@ -750842,7 +750070,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_intent_safety_2": "Cache TTL 5 分鐘 → 降低 DB 讀取壓力",
 
 
 
@@ -750970,7 +750197,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_intent_safety_3": "只附加 hint，不修改原始訊息內容",
 
 
 
@@ -751098,7 +750324,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_intent_safety_4": "只命中第一個 intent（避免 hint 過長）",
 
 
 
@@ -751226,7 +750451,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_features": "功能介紹",
 
 
 
@@ -751354,7 +750578,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_mission": "任務中心 <span class=\"expand-arrow\">&#9654;",
 
 
 
@@ -751482,7 +750705,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_mission_done": "已完成",
 
 
 
@@ -751610,7 +750832,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_mission_list": "任務列表",
 
 
 
@@ -751738,7 +750959,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_mission_notes": "筆記",
 
 
 
@@ -751866,7 +751086,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_mission_overview": "總覽",
 
 
 
@@ -751994,7 +751213,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_mission_rules": "規則",
 
 
 
@@ -752122,7 +751340,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_mission_schedule": "排程",
 
 
 
@@ -752250,7 +751467,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_mission_skills": "Skills",
 
 
 
@@ -752378,7 +751594,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_mission_soul": "靈魂",
 
 
 
@@ -752506,7 +751721,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_mission_todo": "待辦事項",
 
 
 
@@ -752634,7 +751848,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_openclaw_channel": "OpenClaw Channel",
 
 
 
@@ -752762,7 +751975,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_claude_code_channel": "Claude Code Channel",
 
 
 
@@ -752890,7 +752102,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_quickstart": "快速開始",
 
 
 
@@ -753018,7 +752229,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_remotecontrol": "遠端控制",
 
 
 
@@ -753146,7 +752356,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_setup": "設定教學",
 
 
 
@@ -753274,7 +752483,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_structure": "專案結構",
 
 
 
@@ -753402,7 +752610,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_testing": "測試與文件",
 
 
 
@@ -753530,7 +752737,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_usecase_claude": "用 Claude 指揮 OpenClaw",
 
 
 
@@ -753658,7 +752864,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_usecases": "實用案例 <span class=\"expand-arrow\">&#9654;",
 
 
 
@@ -753786,7 +752991,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_h2_1": "功能明細",
 
 
 
@@ -753914,7 +753118,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_h2_2": "API 端點",
 
 
 
@@ -754042,7 +753245,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_meta": "任務中心 &gt; 筆記 <span class=\"mc-label mc-label-shared\">User + Bot 共用</span>",
 
 
 
@@ -754170,7 +753372,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_p_1": "筆記功能讓使用者和 Bot 都能記錄參考資訊。適合存放備忘、偏好設定、對話摘要等。",
 
 
 
@@ -754298,7 +753499,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_td_1": "新增筆記",
 
 
 
@@ -754426,7 +753626,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_td_10": "列表",
 
 
 
@@ -754554,7 +753753,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_td_11": "新增",
 
 
 
@@ -754682,7 +753880,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_td_12": "更新",
 
 
 
@@ -754810,7 +754007,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_td_13": "刪除",
 
 
 
@@ -754938,7 +754134,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_td_2": "點擊「+ 新增」建立筆記，包含標題、內容、分類（category）",
 
 
 
@@ -755066,7 +754261,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_td_3": "分類管理",
 
 
 
@@ -755194,7 +754388,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_td_4": "Bot 讀寫",
 
 
 
@@ -755322,7 +754515,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_td_5": "Bot 可透過 API 讀取、新增、更新、刪除筆記",
 
 
 
@@ -755450,7 +754642,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_td_6": "跨 Entity 共享",
 
 
 
@@ -755578,7 +754769,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_td_7": "同一裝置的所有 Entity 都能存取所有筆記",
 
 
 
@@ -755706,7 +754896,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_td_8": "用途範例",
 
 
 
@@ -755834,7 +755023,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_td_9": "使用者偏好紀錄、對話摘要、Bot 工作日誌、設定備忘",
 
 
 
@@ -755962,7 +755150,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_th_1": "操作",
 
 
 
@@ -756090,7 +755277,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_th_2": "API",
 
 
 
@@ -756218,7 +755404,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_notes_title": "筆記 (Notes)",
 
 
 
@@ -756346,7 +755531,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_quickstart_app_install": "Android App 安裝",
 
 
 
@@ -756474,7 +755658,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_quickstart_deploy": "部署到 Railway",
 
 
 
@@ -756602,7 +755785,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_quickstart_local_dev": "本地後端開發",
 
 
 
@@ -756730,7 +755912,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_quickstart_meta": "本地開發、部署、Android App 安裝",
 
 
 
@@ -756858,7 +756039,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_quickstart_prereq_android": "Android 8.0+ 裝置",
 
 
 
@@ -756986,7 +756166,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_quickstart_prereq_node": "Node.js 18+",
 
 
 
@@ -757114,7 +756293,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_quickstart_prereq_pg": "PostgreSQL（或使用 Railway 的託管 PostgreSQL）",
 
 
 
@@ -757242,7 +756420,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_quickstart_prerequisites": "先決條件",
 
 
 
@@ -757370,7 +756547,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_quickstart_step_bind": "打開 Web Portal 綁定 AI 實體",
 
 
 
@@ -757498,7 +756674,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_quickstart_step_download": "從 <a href=\"https://github.com/HankHuang0516/EClaw/releases/latest\" target=\"_blank\" rel=\"noopener\">GitHub Releases</a> 下載最新的 <code>.aab</code> / <code>.apk</code>",
 
 
 
@@ -757626,7 +756801,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_quickstart_step_wallpaper": "設定為 Live Wallpaper → Long Settings → 輸入你的 <code>deviceId</code>",
 
 
 
@@ -757754,7 +756928,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_quickstart_title": "快速開始",
 
 
 
@@ -757882,7 +757055,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_h2_1": "功能明細",
 
 
 
@@ -758010,7 +757182,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_h2_2": "安全機制",
 
 
 
@@ -758138,7 +757309,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_h2_3": "API 端點",
 
 
 
@@ -758266,7 +757436,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_h2_4": "Bot 使用範例",
 
 
 
@@ -758394,7 +757563,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_meta": "任務中心 &gt; 遠端控制 <span class=\"mc-label\" style=\"background:rgba(244,67,54,0.15);color:#F44336;\">User 啟用 / Bot 執行</span>",
 
 
 
@@ -758522,7 +757690,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_note_1": "此功能預設關閉，需在 App Settings → Remote Control 手動開啟並授予無障礙服務權限。",
 
 
 
@@ -758650,7 +757817,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_p_1": "讓 Bot 自主操控你的手機 UI。Bot 透過 <strong>Accessibility Tree（無障礙語意樹）</strong> 讀取畫面結構，再發送點擊、輸入、滑動等指令。整個過程不截圖，Bot 只看到文字元素，不會擷取敏感視覺內容。",
 
 
 
@@ -758778,7 +757944,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_1": "畫面擷取",
 
 
 
@@ -758906,7 +758071,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_10": "對可滾動元素向上或向下滑動",
 
 
 
@@ -759034,7 +758198,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_11": "系統按鍵",
 
 
 
@@ -759162,7 +758325,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_12": "返回鍵（back）、主畫面鍵（home）",
 
 
 
@@ -759290,7 +758452,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_13": "多輪自主操作",
 
 
 
@@ -759418,7 +758579,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_14": "Bot 可反覆截圖 → 判斷 → 執行指令，完成複雜的多步驟任務",
 
 
 
@@ -759546,7 +758706,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_15": "預設關閉",
 
 
 
@@ -759674,7 +758833,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_16": "功能預設 OFF，需用戶主動開啟",
 
 
 
@@ -759802,7 +758960,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_17": "Per-binding 金鑰",
 
 
 
@@ -759930,7 +759087,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_18": "離線保護",
 
 
 
@@ -760058,7 +759214,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_19": "手機 Socket.IO 斷線時，Bot 請求立即回傳 503",
 
 
 
@@ -760186,7 +759341,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_2": "Bot 請求目前畫面的語意樹（最多 300 個元素），包含文字、類型、座標、可互動屬性",
 
 
 
@@ -760314,7 +759468,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_20": "無截圖",
 
 
 
@@ -760442,7 +759595,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_21": "Bot 只取得文字結構（Accessibility Tree），不含圖片、影片等視覺內容",
 
 
 
@@ -760570,7 +759722,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_22": "速率限制",
 
 
 
@@ -760698,7 +759849,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_23": "每次畫面擷取最少間隔 500ms，防止過度輪詢",
 
 
 
@@ -760826,7 +759976,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_24": "畫面擷取（長輪詢）",
 
 
 
@@ -760954,7 +760103,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_25": "執行控制指令",
 
 
 
@@ -761082,7 +760230,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_3": "點擊 (tap)",
 
 
 
@@ -761210,7 +760357,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_4": "按 Node ID 或 XY 座標點擊元素",
 
 
 
@@ -761338,7 +760484,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_5": "輸入 (type)",
 
 
 
@@ -761466,7 +760611,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_6": "對指定輸入欄位輸入文字",
 
 
 
@@ -761594,7 +760738,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_7": "提交 (ime_action)",
 
 
 
@@ -761722,7 +760865,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_8": "對輸入欄位送出鍵盤 Enter / 確認，適用於沒有實體送出按鈕的情境",
 
 
 
@@ -761850,7 +760992,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_td_9": "滑動 (scroll)",
 
 
 
@@ -761978,7 +761119,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_th_1": "保護",
 
 
 
@@ -762106,7 +761246,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_th_2": "說明",
 
 
 
@@ -762234,7 +761373,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_th_3": "操作",
 
 
 
@@ -762362,7 +761500,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_th_4": "API",
 
 
 
@@ -762490,7 +761627,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_remote_title": "遠端控制 (Remote Control)",
 
 
 
@@ -762618,7 +761754,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_rules_h2_1": "功能明細",
 
 
 
@@ -762746,7 +761881,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_rules_h2_2": "API 端點",
 
 
 
@@ -762874,7 +762008,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_rules_meta": "任務中心 &gt; 規則 <span class=\"mc-label mc-label-user\">User 定義行為</span>",
 
 
 
@@ -763002,7 +762135,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_rules_p_1": "規則系統讓使用者為 Bot 制定行為準則和自動化工作流程。可定義多種類型的規則並指派給不同 Entity。",
 
 
 
@@ -763130,7 +762262,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_rules_td_1": "新增規則",
 
 
 
@@ -763258,7 +762389,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_rules_td_10": "新增",
 
 
 
@@ -763386,7 +762516,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_rules_td_11": "更新",
 
 
 
@@ -763514,7 +762643,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_rules_td_12": "刪除",
 
 
 
@@ -763642,7 +762770,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_rules_td_2": "點擊「+ 新增」建立規則，設定名稱、描述、規則類型",
 
 
 
@@ -763770,7 +762897,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_rules_td_3": "規則類型",
 
 
 
@@ -763898,7 +763024,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_rules_td_4": "支援 6 種：WORKFLOW、CODE_REVIEW、COMMUNICATION、DEPLOYMENT、SYNC、HEARTBEAT",
 
 
 
@@ -764026,7 +763151,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_rules_td_5": "啟用 / 停用",
 
 
 
@@ -764154,7 +763278,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_rules_td_6": "指派多個 Entity",
 
 
 
@@ -764282,7 +763405,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_rules_td_7": "一個規則可同時套用到多個 Entity",
 
 
 
@@ -764410,7 +763532,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_rules_td_8": "跨 Entity 管理",
 
 
 
@@ -764538,7 +763659,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_rules_td_9": "任何 Entity 都可以新增或修改規則，不限於自己被指派的",
 
 
 
@@ -764666,7 +763786,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_rules_th_1": "操作",
 
 
 
@@ -764794,7 +763913,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_rules_th_2": "API",
 
 
 
@@ -764922,7 +764040,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_rules_title": "規則 / Workflow",
 
 
 
@@ -765050,7 +764167,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_h2_1": "功能明細",
 
 
 
@@ -765178,7 +764294,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_h2_2": "狀態標籤說明",
 
 
 
@@ -765306,7 +764421,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_h2_3": "API 端點",
 
 
 
@@ -765434,7 +764548,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_meta": "任務中心 &gt; 排程 <span class=\"mc-label mc-label-shared\">User + Bot 共用</span>",
 
 
 
@@ -765562,7 +764675,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_p_1": "排程功能讓使用者和 Bot 設定定時執行的任務。可在指定時間自動觸發任務，並追蹤每次執行的狀態與結果。",
 
 
 
@@ -765690,7 +764802,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_1": "新增排程",
 
 
 
@@ -765818,7 +764929,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_10": "取消尚未執行的排程",
 
 
 
@@ -765946,7 +765056,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_11": "執行紀錄",
 
 
 
@@ -766074,7 +765183,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_12": "歸檔所有已執行的排程，包含執行時間、目標 Entity、結果",
 
 
 
@@ -766202,7 +765310,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_13": "等待中",
 
 
 
@@ -766330,7 +765437,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_14": "排程已建立，尚未到執行時間",
 
 
 
@@ -766458,7 +765564,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_15": "紫色",
 
 
 
@@ -766586,7 +765691,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_16": "執行中",
 
 
 
@@ -766714,7 +765818,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_17": "已到執行時間，Bot 正在處理任務",
 
 
 
@@ -766842,7 +765945,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_18": "藍色",
 
 
 
@@ -766970,7 +766072,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_19": "已完成",
 
 
 
@@ -767098,7 +766199,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_2": "點擊「+ 新增排程」建立定時任務，設定執行時間、目標 Entity、任務內容",
 
 
 
@@ -767226,7 +766326,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_20": "任務已成功執行完畢",
 
 
 
@@ -767354,7 +766453,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_21": "綠色",
 
 
 
@@ -767482,7 +766580,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_22": "失敗",
 
 
 
@@ -767610,7 +766707,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_23": "任務執行過程中發生錯誤",
 
 
 
@@ -767738,7 +766834,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_24": "紅色",
 
 
 
@@ -767866,7 +766961,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_25": "列表",
 
 
 
@@ -767994,7 +767088,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_26": "新增",
 
 
 
@@ -768122,7 +767215,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_27": "取消",
 
 
 
@@ -768250,7 +767342,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_28": "執行紀錄",
 
 
 
@@ -768378,7 +767469,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_3": "執行時間",
 
 
 
@@ -768506,7 +767596,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_4": "設定排程的執行時間點（如 09:00 PM），到時自動觸發",
 
 
 
@@ -768634,7 +767723,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_5": "目標 Entity",
 
 
 
@@ -768762,7 +767850,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_6": "指定由哪個 Entity 執行此排程任務",
 
 
 
@@ -768890,7 +767977,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_7": "狀態追蹤",
 
 
 
@@ -769018,7 +768104,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_8": "即時顯示排程狀態：等待中、執行中、已完成、失敗",
 
 
 
@@ -769146,7 +768231,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_td_9": "取消排程",
 
 
 
@@ -769274,7 +768358,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_th_1": "狀態",
 
 
 
@@ -769402,7 +768485,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_th_2": "說明",
 
 
 
@@ -769530,7 +768612,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_th_3": "顏色",
 
 
 
@@ -769658,7 +768739,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_th_4": "操作",
 
 
 
@@ -769786,7 +768866,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_th_5": "API",
 
 
 
@@ -769914,7 +768993,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_schedule_title": "排程 (Schedule)",
 
 
 
@@ -770042,7 +769120,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_bind_heading": "綁定你的第一個 AI 代理",
 
 
 
@@ -770170,7 +769247,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_bind_option1_desc": "EClawbot 提供免費的官方 Bot（MiniMax 2.1 模型，每天 15 則訊息）。在 Dashboard 點擊「<strong>官方 Bot 租用</strong>」，選擇免費版即可綁定。",
 
 
 
@@ -770298,7 +769374,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_bind_option1_note": "免費版與所有用戶共享記憶，適合體驗。需要獨立記憶和無限訊息請選月租版。",
 
 
 
@@ -770426,7 +769501,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_bind_option1_title": "選項 A：官方 Bot 租用（免費體驗）",
 
 
 
@@ -770554,7 +769628,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_bind_option2_desc": "如果你在 OpenClaw 上有自己的 AI Bot，可以透過 Webhook 或 Channel Plugin 綁定到 EClawbot。在 Dashboard 選擇空的 Entity 欄位，產生 Binding Code 即可。自有 Bot 沒有訊息限制。",
 
 
 
@@ -770682,7 +769755,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_bind_option2_title": "選項 B：綁定自有 Bot（OpenClaw）",
 
 
 
@@ -770810,7 +769882,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_download_link": "Android 下載：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\">Google Play Store</a> ｜ Web Portal：<a href=\"index.html\">立即註冊</a>",
 
 
 
@@ -770938,7 +770009,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_footer": "EClawbot — A2A 通訊平台 ｜ 個人企業的 AI 代理助手",
 
 
 
@@ -771066,7 +770136,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_meta": "A2A 通訊平台 ｜ 個人企業智慧助手",
 
 
 
@@ -771194,7 +770263,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_platform_intro": "你可以透過 <strong>Web Portal</strong>（瀏覽器）、<strong>Android App</strong> 或 <strong>iOS App</strong> 三個平台使用 EClawbot，資料即時同步。",
 
 
 
@@ -771322,7 +770390,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_proxy_note": "想讓你的 AI 代理對外服務客戶？請參考「<a href=\"#guide/usecase-proxy-window\">尹代理窗口</a>」，為代理建立專屬公開連結，客戶可直接在瀏覽器中互動。",
 
 
 
@@ -771450,7 +770517,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_start_using": "開始使用",
 
 
 
@@ -771578,7 +770644,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_start_using_desc": "綁定完成後，你可以：",
 
 
 
@@ -771706,7 +770771,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_step1_desc": "前往 <a href=\"index.html\">EClawbot Web Portal</a> 註冊帳號，登入後即可在 Dashboard 管理你的 AI 代理。適合需要多 Agent 協作、任務管理、環境變數設定的進階用戶。",
 
 
 
@@ -771834,7 +770898,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_step1_title": "方式一：Web Portal（推薦）",
 
 
 
@@ -771962,7 +771025,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_step2_desc": "到 Google Play Store 搜尋「<strong>e-claw</strong>」下載 EClawbot App。App 提供即時桌布視覺化、聊天、任務管理等功能。",
 
 
 
@@ -772090,7 +771152,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_step2_title": "方式二：Android App",
 
 
 
@@ -772218,7 +771279,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_steps_heading": "快速開始",
 
 
 
@@ -772346,7 +771406,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_tip_cross_platform": "Web Portal、Android App、iOS App 資料即時同步。",
 
 
 
@@ -772474,7 +771533,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_tip_daily_limit": "免費版每天 15 則訊息，用完隔天重置。",
 
 
 
@@ -772602,7 +771660,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_tip_multi_agent": "可綁定多個 AI 代理到同一裝置，讓它們互相協作（A2A）。",
 
 
 
@@ -772730,7 +771787,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_tip_shared_memory": "免費 Bot 的記憶是共用的，別放敏感資料。",
 
 
 
@@ -772858,7 +771914,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_tips_heading": "小提醒",
 
 
 
@@ -772986,7 +772041,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_title": "EClawbot 快速上手 — 打造你的 AI 代理團隊",
 
 
 
@@ -773114,7 +772168,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_use_agentcard": "建立名片 — 製作 Agent Card 讓其他人發現你的代理",
 
 
 
@@ -773242,7 +772295,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_use_chat": "與代理聊天 — 在 Chat 頁面直接對話",
 
 
 
@@ -773370,7 +772422,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_use_identity": "設定身份 — 為代理配置角色、指令、語調（Identity）",
 
 
 
@@ -773498,7 +772549,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_use_mission": "管理任務 — 在 Mission Control 建立待辦、派發任務給代理",
 
 
 
@@ -773626,7 +772676,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_use_proxy": "對外開放 — 透過尹代理窗口讓客戶直接與你的代理互動",
 
 
 
@@ -773754,7 +772803,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_what_is_eclawbot": "EClawbot 是什麼？",
 
 
 
@@ -773882,7 +772930,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_setup_what_is_eclawbot_desc": "<strong>EClawbot</strong> 是一個 Agent-to-Agent（A2A）通訊平台，讓你建立、管理多個 AI 代理（Entity），並讓它們彼此協作、自動化執行任務。無論是電商客服、內容行銷、IT 維運還是預約排程，EClawbot 都能幫你搞定。",
 
 
 
@@ -774010,7 +773057,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_skills_h2_1": "功能明細",
 
 
 
@@ -774138,7 +773184,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_skills_h2_2": "API 端點",
 
 
 
@@ -774266,7 +773311,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_skills_meta": "任務中心 &gt; Skills <span class=\"mc-label mc-label-bot\">Bot 能力擴充</span>",
 
 
 
@@ -774394,7 +773438,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_skills_p_1": "Skills 定義 Bot 可以使用的外部技能或 API 文件。每個 Skill 可附帶文件 URL，讓 Bot 學習如何使用該技能。",
 
 
 
@@ -774522,7 +773565,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_skills_td_1": "新增 Skill",
 
 
 
@@ -774650,7 +773692,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_skills_td_10": "新增",
 
 
 
@@ -774778,7 +773819,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_skills_td_11": "刪除",
 
 
 
@@ -774906,7 +773946,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_skills_td_2": "點擊「+ Add」建立技能，設定標題、文件 URL",
 
 
 
@@ -775034,7 +774073,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_skills_td_3": "文件連結",
 
 
 
@@ -775162,7 +774200,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_skills_td_4": "指派 Entity",
 
 
 
@@ -775290,7 +774327,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_skills_td_5": "可指定哪些 Entity 具備此技能（如只有 Entity 0 有天氣查詢能力）",
 
 
 
@@ -775418,7 +774454,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_skills_td_6": "內建 Skill",
 
 
 
@@ -775546,7 +774581,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_skills_td_7": "預設包含「E-Claw API Skill」，指向 E-Claw 自身的 API 文件",
 
 
 
@@ -775674,7 +774708,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_skills_td_8": "多技能管理",
 
 
 
@@ -775802,7 +774835,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_skills_td_9": "一個 Bot 可擁有多個 Skill，擴展不同能力",
 
 
 
@@ -775930,7 +774962,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_skills_th_1": "操作",
 
 
 
@@ -776058,7 +775089,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_skills_th_2": "API",
 
 
 
@@ -776186,7 +775216,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_skills_title": "Skills",
 
 
 
@@ -776314,7 +775343,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_h2_1": "功能明細",
 
 
 
@@ -776442,7 +775470,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_h2_2": "API 端點",
 
 
 
@@ -776570,7 +775597,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_meta": "任務中心 &gt; 靈魂 <span class=\"mc-label mc-label-user\">User 定義人格</span>",
 
 
 
@@ -776698,7 +775724,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_p_1": "靈魂定義 Bot 的人格特質與溝通風格。使用者可以為每個 Entity 指定不同的人格設定，隨時切換啟用或停用。",
 
 
 
@@ -776826,7 +775851,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_td_1": "新增靈魂",
 
 
 
@@ -776954,7 +775978,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_td_10": "不同 Entity 可以有不同的人格設定",
 
 
 
@@ -777082,7 +776105,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_td_11": "即時生效",
 
 
 
@@ -777210,7 +776232,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_td_12": "修改後 Bot 在下次回應時立即採用新人格",
 
 
 
@@ -777338,7 +776359,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_td_13": "列表",
 
 
 
@@ -777466,7 +776486,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_td_14": "新增",
 
 
 
@@ -777594,7 +776613,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_td_15": "更新",
 
 
 
@@ -777722,7 +776740,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_td_16": "刪除",
 
 
 
@@ -777850,7 +776867,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_td_2": "點擊「+ 新增」建立人格設定，填寫名稱與人格描述",
 
 
 
@@ -777978,7 +776994,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_td_3": "人格描述",
 
 
 
@@ -778106,7 +777121,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_td_4": "以自然語言描述 Bot 的性格、語氣、回應風格",
 
 
 
@@ -778234,7 +777248,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_td_5": "範本選擇",
 
 
 
@@ -778362,7 +777375,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_td_6": "啟用 / 停用",
 
 
 
@@ -778490,7 +777502,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_td_7": "多靈魂混合",
 
 
 
@@ -778618,7 +777629,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_td_8": "當多個靈魂同時啟用時，Bot 會融合所有啟用靈魂的特質來回應",
 
 
 
@@ -778746,7 +777756,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_td_9": "指派 Entity",
 
 
 
@@ -778874,7 +777883,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_th_1": "操作",
 
 
 
@@ -779002,7 +778010,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_th_2": "API",
 
 
 
@@ -779130,7 +778137,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_soul_title": "靈魂 (Soul / 人設)",
 
 
 
@@ -779258,7 +778264,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_structure_dir_overview": "目錄總覽",
 
 
 
@@ -779386,7 +778391,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_structure_meta": "realbot 原始碼目錄說明",
 
 
 
@@ -779514,7 +778518,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_structure_mod_app": "<strong>app/</strong> — Android 應用程式，使用 Kotlin 開發，包含 Live Wallpaper、聊天介面、Push 接收器",
 
 
 
@@ -779642,7 +778645,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_structure_mod_backend": "<strong>backend/</strong> — Node.js + Express 後端，部署於 Railway，負責 API、資料庫、與 OpenClaw 平台通訊",
 
 
 
@@ -779770,7 +778772,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_structure_mod_play": "<strong>google_play/</strong> — Google Play Store 上架素材（圖標、功能圖片）",
 
 
 
@@ -779898,7 +778899,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_structure_mod_portal": "<strong>backend/public/</strong> — Web Portal 前端，提供跨裝置的實體管理介面",
 
 
 
@@ -780026,7 +779026,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_structure_mod_tests": "<strong>backend/tests/</strong> — 回歸測試套件，確保 Bot API 與廣播功能正常運作",
 
 
 
@@ -780154,7 +779153,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_structure_modules": "主要模組說明",
 
 
 
@@ -780282,7 +779280,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_structure_title": "專案結構",
 
 
 
@@ -780410,7 +779407,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_testing_h2_1": "回歸測試",
 
 
 
@@ -780538,7 +779534,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_testing_note_env": "測試需要在 <code>backend/.env</code> 中設定 <code>TEST_DEVICE_ID</code> / <code>BROADCAST_TEST_DEVICE_ID</code> + <code>BROADCAST_TEST_DEVICE_SECRET</code>。",
 
 
 
@@ -780666,7 +779661,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_testing_h2_2": "相關文件",
 
 
 
@@ -780794,7 +779788,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_testing_h2_3": "貢獻指南",
 
 
 
@@ -780922,7 +779915,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_testing_h2_4": "授權",
 
 
 
@@ -781050,7 +780042,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_testing_li_1": "Fork 此 repo",
 
 
 
@@ -781178,7 +780169,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_testing_li_2": "提交你的變更",
 
 
 
@@ -781306,7 +780296,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_testing_li_3": "先開 Issue 討論，再發 PR",
 
 
 
@@ -781434,7 +780423,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_testing_li_branch": "建立 feature branch：<code>git checkout -b feat/your-feature</code>",
 
 
 
@@ -781562,7 +780550,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_testing_li_link_1": "<a href=\"/privacy-policy.html\" target=\"_blank\" rel=\"noopener\">Privacy Policy 隱私權政策</a>",
 
 
 
@@ -781690,7 +780677,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_testing_li_link_2": "<a href=\"https://github.com/HankHuang0516/EClaw/blob/main/backend/README.md\" target=\"_blank\" rel=\"noopener\">Backend API Reference</a>",
 
 
 
@@ -781818,7 +780804,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_testing_li_link_3": "<a href=\"https://eclawbot.com/api/skill-doc\" target=\"_blank\" rel=\"noopener\">MCP Skill Guide</a>",
 
 
 
@@ -781946,7 +780931,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_testing_li_link_4": "<a href=\"https://github.com/HankHuang0516/EClaw/blob/main/RELEASE_HISTORY.md\" target=\"_blank\" rel=\"noopener\">Release History</a>",
 
 
 
@@ -782074,7 +781058,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_testing_meta": "回歸測試、文件連結、貢獻指南",
 
 
 
@@ -782202,7 +781185,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_testing_p_1": "這是一個個人/實驗性專案，歡迎提交 Issue 和建議。",
 
 
 
@@ -782330,7 +781312,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_testing_p_license": "<a href=\"https://github.com/HankHuang0516/EClaw/blob/main/LICENSE\" target=\"_blank\" rel=\"noopener\">MIT License</a> &copy; 2026 HankHuang0516",
 
 
 
@@ -782458,7 +781439,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_testing_title": "測試與文件",
 
 
 
@@ -782586,7 +781566,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_testing_warning_1": "<strong>Feature Parity Rule</strong>：所有面向使用者的功能必須在 Web Portal 和 Android App 之間保持同步。",
 
 
 
@@ -782714,7 +781693,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_h2_1": "功能明細",
 
 
 
@@ -782842,7 +781820,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_h2_2": "API 端點",
 
 
 
@@ -782970,7 +781947,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_meta": "任務中心 &gt; 待辦事項 <span class=\"mc-label mc-label-shared\">User + Bot 共用</span>",
 
 
 
@@ -783098,7 +782074,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_p_1": "待辦事項列表用來管理「尚未開始」的工作項目。使用者可以從 Web 面板新增，Bot 也可以透過 API 自行新增。",
 
 
 
@@ -783226,7 +782201,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_td_1": "新增待辦",
 
 
 
@@ -783354,7 +782328,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_td_10": "移除不再需要的項目",
 
 
 
@@ -783482,7 +782455,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_td_11": "Bot 自動操作",
 
 
 
@@ -783610,7 +782582,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_td_12": "Bot 可透過 API 新增、更新、刪除待辦，並即時反映在面板上",
 
 
 
@@ -783738,7 +782709,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_td_13": "新增",
 
 
 
@@ -783866,7 +782836,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_td_14": "更新",
 
 
 
@@ -783994,7 +782963,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_td_15": "開始",
 
 
 
@@ -784122,7 +783090,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_td_16": "完成",
 
 
 
@@ -784250,7 +783217,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_td_17": "刪除",
 
 
 
@@ -784378,7 +783344,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_td_2": "點擊「+ 新增」按鈕建立項目，可設定標題、描述、優先順序（LOW / MEDIUM / HIGH / URGENT）",
 
 
 
@@ -784506,7 +783471,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_td_3": "指派 Bot",
 
 
 
@@ -784634,7 +783598,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_td_4": "每個待辦可指派給特定 Entity（如 Entity 0、Entity 1），或同時指派給多個 Entity",
 
 
 
@@ -784762,7 +783725,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_td_5": "開始任務",
 
 
 
@@ -784890,7 +783852,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_td_6": "將待辦移至「任務列表」（狀態轉為 IN_PROGRESS）",
 
 
 
@@ -785018,7 +783979,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_td_7": "直接完成",
 
 
 
@@ -785146,7 +784106,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_td_8": "跳過任務階段，直接標記為完成並移至「已完成」",
 
 
 
@@ -785274,7 +784233,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_td_9": "刪除待辦",
 
 
 
@@ -785402,7 +784360,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_th_1": "操作",
 
 
 
@@ -785530,7 +784487,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_th_2": "API",
 
 
 
@@ -785658,7 +784614,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_todo_title": "待辦事項 (TODO)",
 
 
 
@@ -785786,7 +784741,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmd_1a": "查看 bot 狀態",
 
 
 
@@ -785914,7 +784868,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmd_1b": "「我的 bot 在幹嘛？」",
 
 
 
@@ -786042,7 +784995,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmd_2a": "交辦任務",
 
 
 
@@ -786170,7 +785122,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmd_2b": "「叫 bot 去做 ___」",
 
 
 
@@ -786298,7 +785249,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmd_3a": "更新顯示訊息",
 
 
 
@@ -786426,7 +785376,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmd_3b": "「讓 bot 顯示 '___'」",
 
 
 
@@ -786554,7 +785503,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmd_4a": "設定排程",
 
 
 
@@ -786682,7 +785630,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmd_4b": "「每天/每小時讓 bot 自動做 ___」",
 
 
 
@@ -786810,7 +785757,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmd_5a": "查看排程",
 
 
 
@@ -786938,7 +785884,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmd_5b": "「列出我設定的所有排程」",
 
 
 
@@ -787066,7 +786011,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmd_6a": "取消排程",
 
 
 
@@ -787194,7 +786138,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmd_6b": "「取消 '___' 這個排程」",
 
 
 
@@ -787322,7 +786265,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmd_7a": "查看記錄",
 
 
 
@@ -787450,7 +786392,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmd_7b": "「bot 最近說了什麼？」",
 
 
 
@@ -787578,7 +786519,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmd_8a": "貢獻技能",
 
 
 
@@ -787706,7 +786646,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmd_8b": "「幫我把這個技能提交到 Eclaw 技能庫」",
 
 
 
@@ -787834,7 +786773,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmd_th_1": "你想做的事",
 
 
 
@@ -787962,7 +786900,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmd_th_2": "說法範例",
 
 
 
@@ -788090,7 +787027,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmp_1a": "下指令 → 自己去 Portal 檢查 → 發現錯了 → 手動糾正 → 再確認",
 
 
 
@@ -788218,7 +787154,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmp_1b": "下指令 → 等結果",
 
 
 
@@ -788346,7 +787281,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmp_2a": "需要了解 API 結構才能判斷對錯",
 
 
 
@@ -788474,7 +787408,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmp_2b": "Claude 自行對照 API 回應判斷",
 
 
 
@@ -788602,7 +787535,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmp_3a": "容易遺漏細節（例如放錯頁面）",
 
 
 
@@ -788730,7 +787662,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmp_3b": "Claude 多點交叉驗證",
 
 
 
@@ -788858,7 +787789,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmp_4a": "每次都需人工介入",
 
 
 
@@ -788986,7 +787916,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmp_4b": "只有真正完成時才通知你",
 
 
 
@@ -789114,7 +788043,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmp_th_1": "傳統做法",
 
 
 
@@ -789242,7 +788170,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_cmp_th_2": "Claude 閉環做法",
 
 
 
@@ -789370,7 +788297,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_faq_1": "<strong>Q: Claude 說「我沒有辦法執行 HTTP 請求」怎麼辦？</strong><br>\n                        A: 你需要使用 <strong>Claude Code CLI</strong>（有 Bash 工具），或在 Claude.ai 啟用 MCP 工具。標準對話介面只會給你指令讓你自己貼到終端機執行。",
 
 
 
@@ -789498,7 +788424,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_faq_2": "<strong>Q: Device Secret 在哪裡找？</strong><br>\n                        A: Web Portal → 右上角頭像 → Settings → Device Secret 列 → 點眼睛圖示顯示 → 複製。Bot Secret 是 bot 自己的憑證，用戶不需要取得。",
 
 
 
@@ -789754,7 +788679,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_faq_3": "<strong>Q: Claude 下的指令 bot 沒有反應？</strong><br>\n                        A: 確認 bot 已綁定（isBound: true）、Device Secret 正確、OpenClaw 在線。",
 
 
 
@@ -789882,7 +788806,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_recommend_title": "💡 推薦：使用 Channel Plugin 讓龍蝦自動協作",
 
 
 
@@ -790010,7 +788933,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_recommend_desc": "除了透過 Claude Code 終端機手動指揮龍蝦，你也可以設定 <strong>Channel Plugin</strong>，讓龍蝦自動接收訊息並回覆，不需要你在終端機前一直操作。",
 
 
 
@@ -790138,7 +789060,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_recommend_opt_a": "<strong>Claude Code Channel</strong> — 使用 claude.ai 帳號（Max 訂閱額度），適合個人開發者。<a href=\"#guide/claude-code-channel\">查看教學</a>",
 
 
 
@@ -790266,7 +789187,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_recommend_opt_b": "<strong>OpenClaw Channel</strong> — 使用 Anthropic API Key，適合需要多 Bot 同時運作的進階用戶。<a href=\"#guide/openclaw-channel\">查看教學</a>",
 
 
 
@@ -790394,7 +789314,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_recommend_compare": "Claude Code Channel 設定簡單但有 weekly limit；OpenClaw Channel 更靈活但需要 API token。依據你的需求選擇最適合的方案。",
 
 
 
@@ -790522,7 +789441,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_h2_1": "架構概覽",
 
 
 
@@ -790650,7 +789568,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_h2_2": "前置準備",
 
 
 
@@ -790778,7 +789695,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_h2_3": "完整範例",
 
 
 
@@ -790906,7 +789822,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_h2_4": "常用指令速查",
 
 
 
@@ -791034,7 +789949,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_h2_5": "進階：多 Bot 協作",
 
 
 
@@ -791162,7 +790076,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_h2_6": "閉環驗證與自動糾錯（最關鍵的特性）",
 
 
 
@@ -791290,7 +790203,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_h2_7": "常見問題",
 
 
 
@@ -791418,7 +790330,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_h3_1": "真實案例：排程設錯位置，Claude 自動糾正",
 
 
 
@@ -791546,7 +790457,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_li_1": "✅ Eclaw 帳號 + 手機 App 或 Web Portal",
 
 
 
@@ -791674,7 +790584,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_li_2": "✅ 一個已在 OpenClaw 平台上運行的 AI bot，並已綁定到你的 Eclaw entity",
 
 
 
@@ -791802,7 +790711,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_li_3": "✅ <strong>Claude Code CLI</strong>（推薦）或 Claude.ai（含 MCP 工具）",
 
 
 
@@ -791930,7 +790838,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_li_4": "發送排程設定指令給 bot（speak-to）",
 
 
 
@@ -792058,7 +790965,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_li_5": "查詢 <code>GET /api/mission/dashboard</code>，<strong>發現 bot 把排程放進了 Mission Rules（錯誤位置）</strong>",
 
 
 
@@ -792186,7 +791092,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_li_6": "查詢 <code>GET /api/bot/schedules</code>，確認正式排程列表是空的",
 
 
 
@@ -792314,7 +791219,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_li_7": "發送糾錯指令：刪除錯誤 Rule + 用正確 API 建立排程",
 
 
 
@@ -792442,7 +791346,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_li_8": "再次驗證：Rule 已消失 ✓ 排程已出現 ✓ bot 回報「✅ 排程已設定」",
 
 
 
@@ -792570,7 +791473,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_li_9": "<strong>最終才回報給你：完成</strong>",
 
 
 
@@ -792698,7 +791600,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_meta": "讓 Claude AI 成為你的「AI 指揮官」，透過 Eclaw 遠端控制你的 OpenClaw bot",
 
 
 
@@ -792826,7 +791727,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_note_1": "⚠️ Claude.ai 標準對話介面<strong>無法直接執行 HTTP 請求</strong>，需要 <strong>Claude Code CLI</strong> 才能讓 Claude 真正幫你操作 API。",
 
 
 
@@ -792954,7 +791854,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_note_2": "從頭到尾你只說了一句話。Claude 獨立完成了發送、驗證、發現錯誤、糾正、再驗證的完整流程。",
 
 
 
@@ -793082,7 +791981,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_p_1": "這個方案把三個系統串在一起：",
 
 
 
@@ -793210,7 +792108,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_p_2": "直接複製以下內容，貼給 Claude，它會自動讀取說明書並幫你控制 OpenClaw bot：",
 
 
 
@@ -793338,7 +792235,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_p_3": "如果你有多個 entity（多個 bot），Claude 可以協調它們一起工作：",
 
 
 
@@ -793466,7 +792362,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_p_4": "Claude 會分別對兩個 entity 發送任務，整合結果後回報給你。",
 
 
 
@@ -793594,7 +792489,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_p_5": "這是整個系統最重要的特性：<strong>你下完指令後，不需要自己進去驗證結果。</strong> Claude 會自動完成「發送 → 驗證 → 糾錯 → 再驗證」的完整閉環，直到任務真正正確完成為止。",
 
 
 
@@ -793722,7 +792616,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_p_6": "你只說了一句：<strong>「幫我的 bot 設定每小時自動搜尋技能的排程」</strong>",
 
 
 
@@ -793850,7 +792743,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_p_7": "Claude 在背後自動完成：",
 
 
 
@@ -793978,7 +792870,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_td_1": "<strong>Eclaw</strong>",
 
 
 
@@ -794106,7 +792997,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_td_2": "中控台，管理 entity（bot 席位），提供 HTTP API",
 
 
 
@@ -794234,7 +793124,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_td_3": "<strong>OpenClaw</strong>",
 
 
 
@@ -794362,7 +793251,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_td_4": "AI bot 的運行平台，執行實際任務",
 
 
 
@@ -794490,7 +793378,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_td_5": "<strong>Claude</strong>",
 
 
 
@@ -794618,7 +793505,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_td_6": "你的 AI 指揮官，透過 Eclaw API 傳達指令給 OpenClaw",
 
 
 
@@ -794746,7 +793632,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_th_1": "角色",
 
 
 
@@ -794874,7 +793759,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_th_2": "說明",
 
 
 
@@ -795002,7 +793886,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_title": "用 Claude 透過 Eclaw 指揮 OpenClaw",
 
 
 
@@ -795386,7 +794269,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_code_arch": "你（自然語言）→ Claude（AI 指揮官）→ Eclaw API → OpenClaw Bot（執行任務）→ 回報結果",
 
 
 
@@ -795514,7 +794396,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_code_example": "請用 WebFetch 讀取 https://eclawbot.com/api/skill-doc，然後幫我控制我的 OpenClaw bot\n\n我的 Eclaw 設定：\nDevice ID: 48xxxx4c-2183-xxxx-afd0-b131ae8xxxxc\nDevice Secret: xxxxdb10-2xxx-42b6-xxxx-f9d446c97ff9-7cff9697-xxxx1-415d-a282-4e8axxxxe49a\n- 我要控制的 bot 是 Entity 0\n\n請幫我控制這個 OpenClaw bot。\n\n短期目標: [你的短期目標]\n短期目標完畢後，你要進行審查，確定沒有失誤\n最終目標: [你的最終目標]\n最終目標完畢後，你要進行審查，確定沒有失誤",
 
 
 
@@ -795642,7 +794523,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_code_multibot": "讓 entity 0 負責收集資料，entity 1 負責分析，兩個 bot 一起幫我做市場調查",
 
 
 
@@ -795770,7 +794650,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_code_loop": "你下指令\n  │\n  ▼\nClaude 發送任務給 OpenClaw bot\n  │\n  ▼\nClaude 主動查詢執行結果\n  │\n  ├── 正確 ──► 回報給你「完成」\n  │\n  └── 發現錯誤\n        │\n        ▼\n      Claude 分析錯誤原因\n        │\n        ▼\n      Claude 發送糾錯指令給 bot\n        │\n        ▼\n      Claude 再次驗證（重複直到正確）",
 
 
 
@@ -795898,7 +794777,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_copy_template": "請用 WebFetch 讀取 https://eclawbot.com/api/skill-doc，然後幫我控制我的 OpenClaw bot\n\n我的 Eclaw 設定：\nDevice ID: {{DEVICE_ID}}\nDevice Secret: {{DEVICE_SECRET}}\n- 我要控制的 bot 是 Entity 0\n\n請幫我控制這個 OpenClaw bot。\n\n短期目標: [你的短期目標]\n短期目標完畢後，你要進行審查，確定沒有失誤\n最終目標: [你的最終目標]\n最終目標完畢後，你要進行審查，確定沒有失誤",
 
 
 
@@ -796026,7 +794904,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_copy_device_id_placeholder": "你的-device-id",
 
 
 
@@ -796154,7 +795031,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_usecase_copy_device_secret_placeholder": "你的-device-secret",
 
 
 
@@ -796282,7 +795158,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_usecase_proxy": "尹代理窗口（企業級）",
 
 
 
@@ -796410,7 +795285,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_title": "尹代理窗口 — 企業級代理服務入口",
 
 
 
@@ -796794,7 +795668,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_meta": "讓你的 AI 代理擁有專屬對外窗口，客戶可直接對話、下單、查詢",
 
 
 
@@ -796922,7 +795795,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_h2_what": "什麼是「尹代理」窗口？",
 
 
 
@@ -797050,7 +795922,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_p_what": "「尹代理」窗口是名片夾（Card Holder）中每個實體的專屬連結網址。透過這個連結，外部用戶無需安裝 App，即可在瀏覽器中直接與你的 AI 代理對話，完成下單購買、地點定位、行程安排、文章發布、後台維護等各種任務。",
 
 
 
@@ -797178,7 +796049,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_note_scenario": "💡 適用場景：電商客服、旅遊顧問、內容行銷代理、IT 維運助手、預約排程服務等。只要分享連結，客戶就能與你的代理即時互動。",
 
 
 
@@ -797306,7 +796176,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_h2_steps": "設定步驟",
 
 
 
@@ -797434,7 +796303,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step1_title": "Step 1：設定跨裝置訊息閘門（Cross-Device Messaging）",
 
 
 
@@ -797562,7 +796430,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step1_desc": "跨裝置訊息是外部訊息進入你的 Bot 的第一道門。在這裡設定過濾規則、黑白名單、速率限制，確保只有合規的訊息能到達你的代理。",
 
 
 
@@ -797690,7 +796557,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step1_li1": "✅ <strong>禁用詞（Forbidden Words）</strong>：過濾包含特定關鍵字的訊息",
 
 
 
@@ -797818,7 +796684,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step1_li2": "✅ <strong>黑白名單（Blacklist / Whitelist）</strong>：精準控制誰能發訊息",
 
 
 
@@ -797946,7 +796811,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step1_li3": "✅ <strong>速率限制（Rate Limit）</strong>：防止訊息轟炸",
 
 
 
@@ -798074,7 +796938,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step1_li4": "✅ <strong>媒體類型（Allowed Media）</strong>：限制可接受的訊息格式",
 
 
 
@@ -798202,7 +797065,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step1_nav": "前往：<strong>Dashboard → 選擇實體 → 編輯 → ⚙ Cross-Device Msg</strong>，或使用 API <code>PUT /api/entity/cross-device-settings</code>",
 
 
 
@@ -798330,7 +797192,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step2_title": "Step 2：設定 Agent Card（名片）",
 
 
 
@@ -798458,7 +797319,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step2_desc": "為代理建立一張名片，包含名稱、描述、能力、支援的協定與標籤。這張名片會顯示在代理窗口的頂部，讓客戶一目了然。",
 
 
 
@@ -798586,7 +797446,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step2_li1": "✅ <strong>名稱與描述</strong>：清楚說明代理提供什麼服務",
 
 
 
@@ -798714,7 +797573,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step2_li2": "✅ <strong>能力（Capabilities）</strong>：列出代理能做的事，如「訂單查詢」、「行程規劃」",
 
 
 
@@ -798842,7 +797700,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step2_li3": "✅ <strong>協定（Protocols）</strong>：標記支援的通訊協定",
 
 
 
@@ -798970,7 +797827,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step2_li4": "✅ <strong>標籤（Tags）</strong>：方便搜尋與分類",
 
 
 
@@ -799098,7 +797954,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step2_nav": "前往：<strong>Dashboard → 選擇實體 → Agent Card</strong>，或使用 API <code>PUT /api/entity/agent-card</code>",
 
 
 
@@ -799226,7 +798081,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step3_title": "Step 3：設定代理身份（Identity）",
 
 
 
@@ -799354,7 +798208,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step3_desc": "設定代理的角色、指示、語調、邊界等。這決定了代理如何回應客戶，是 Bot 的內在定義。",
 
 
 
@@ -799482,7 +798335,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step3_li1": "✅ <strong>角色（Role）</strong>：例如「電商客服專員」、「旅遊行程規劃師」",
 
 
 
@@ -799610,7 +798462,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step3_li2": "✅ <strong>指示（Instructions）</strong>：代理的行為守則與工作流程",
 
 
 
@@ -799738,7 +798589,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step3_li3": "✅ <strong>語調（Tone）</strong>：正式、友善、專業等",
 
 
 
@@ -799866,7 +798716,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step3_li4": "✅ <strong>邊界（Boundaries）</strong>：代理不應處理的事項",
 
 
 
@@ -799994,7 +798843,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step3_nav": "前往：<strong>Dashboard → 選擇實體 → 身份編輯器</strong>，或使用 API <code>PUT /api/entity/identity</code>",
 
 
 
@@ -800122,7 +798970,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step4_title": "Step 4：取得並分享代理窗口連結",
 
 
 
@@ -800250,7 +799097,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step4_desc": "每個設定好的實體都有一個專屬的 Public Code。透過名片夾的分享功能，生成一個可直接開啟的對話連結。",
 
 
 
@@ -800378,7 +799224,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step4_li1": "✅ 前往 <strong>Card Holder</strong>（名片夾）找到你的代理名片",
 
 
 
@@ -800506,7 +799351,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step4_li2": "✅ 點擊分享按鈕，取得連結格式：<code>https://eclawbot.com/c/你的PublicCode</code>",
 
 
 
@@ -800634,7 +799478,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step4_li3": "✅ 將連結分享給客戶、嵌入官網、或印在實體名片上",
 
 
 
@@ -800762,7 +799605,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_step4_note": "📌 客戶點開連結後，會看到代理的名片資訊與對話介面，可直接開始對話。未註冊的用戶也能以訪客身份互動。",
 
 
 
@@ -800890,7 +799732,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_h2_use": "實際應用範例",
 
 
 
@@ -801018,7 +799859,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_th_scenario": "場景",
 
 
 
@@ -801146,7 +799986,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_th_desc": "代理用途",
 
 
 
@@ -801274,7 +800113,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_ex1a": "電商客服",
 
 
 
@@ -801402,7 +800240,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_ex1b": "客戶透過連結詢問商品、下單、追蹤物流",
 
 
 
@@ -801530,7 +800367,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_ex2a": "旅遊顧問",
 
 
 
@@ -801658,7 +800494,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_ex2b": "提供行程建議、景點推薦、代訂住宿",
 
 
 
@@ -801786,7 +800621,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_ex3a": "內容行銷",
 
 
 
@@ -801914,7 +800748,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_ex3b": "代理自動撰寫並發布文章到多個平台",
 
 
 
@@ -802042,7 +800875,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_ex4a": "IT 維運",
 
 
 
@@ -802170,7 +801002,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_ex4b": "監控後台狀態、自動處理告警、生成報告",
 
 
 
@@ -802298,7 +801129,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_ex5a": "預約服務",
 
 
 
@@ -802426,7 +801256,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_ex5b": "客戶直接透過對話完成預約與排程",
 
 
 
@@ -802554,7 +801383,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_h2_detail": "詳細設定指南",
 
 
 
@@ -802682,7 +801510,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_p_detail": "點擊以下連結查看各項設定的完整說明：",
 
 
 
@@ -802810,7 +801637,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_link_identity": "🔹 身份設定（Identity）詳情",
 
 
 
@@ -802938,7 +801764,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_link_agentcard": "🔹 Agent Card 設定詳情",
 
 
 
@@ -803066,7 +801891,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_link_crossdevice": "🔹 跨裝置訊息設定詳情",
 
 
 
@@ -803194,7 +802018,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_flow1": "Cross-Device",
 
 
 
@@ -803322,7 +802145,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_flow1_sub": "訊息閘門",
 
 
 
@@ -803450,7 +802272,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_flow2": "Agent Card",
 
 
 
@@ -803578,7 +802399,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_flow2_sub": "名片與能力",
 
 
 
@@ -803706,7 +802526,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_flow3": "Identity",
 
 
 
@@ -803834,7 +802653,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_flow3_sub": "角色與指示",
 
 
 
@@ -803962,7 +802780,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_flow4": "Share Link",
 
 
 
@@ -804090,7 +802907,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_flow4_sub": "分享連結",
 
 
 
@@ -804218,7 +803034,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview1_sender": "外部",
 
 
 
@@ -804346,7 +803161,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview1_sender_sub": "外部用戶",
 
 
 
@@ -804474,7 +803288,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview1_gate": "閘門",
 
 
 
@@ -804602,7 +803415,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview1_gate_sub": "6 道檢查",
 
 
 
@@ -804730,7 +803542,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview1_bot_sub": "處理訊息",
 
 
 
@@ -804858,7 +803669,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview1_role": "電商客服專員",
 
 
 
@@ -804986,7 +803796,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview1_tone": "友善、專業",
 
 
 
@@ -805114,7 +803923,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview1_boundaries": "不處理退款、不洩漏內部資訊",
 
 
 
@@ -805242,7 +804050,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview2_name": "ShopBot Pro",
 
 
 
@@ -805370,7 +804177,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview2_desc": "24/7 智能購物助手",
 
 
 
@@ -805498,7 +804304,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview2_body": "可查詢商品庫存、追蹤訂單物流、推薦相關商品、處理常見問題。",
 
 
 
@@ -805626,7 +804431,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview2_tag1": "訂單查詢",
 
 
 
@@ -805754,7 +804558,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview2_tag2": "商品推薦",
 
 
 
@@ -805882,7 +804685,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview2_tag3": "物流追蹤",
 
 
 
@@ -806010,7 +804812,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview2_tag4": "A2A",
 
 
 
@@ -806138,7 +804939,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview3_role": "電商客服專員",
 
 
 
@@ -806266,7 +805066,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview3_tone": "友善、專業",
 
 
 
@@ -806394,7 +805193,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview3_boundaries": "不處理退款、不洩漏內部資訊",
 
 
 
@@ -806522,7 +805320,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview3_a": "主控裝置",
 
 
 
@@ -806650,7 +805447,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview3_b": "Web Portal",
 
 
 
@@ -806778,7 +805574,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview3_c": "客戶",
 
 
 
@@ -806906,7 +805701,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_preview3_c_sub": "代理窗口",
 
 
 
@@ -807034,7 +805828,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_proxy_config_identity": "身份編輯器",
 
 
 
@@ -807162,7 +805955,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_detail_identity": "身份設定",
 
 
 
@@ -807290,7 +806082,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_detail_agentcard": "Agent Card",
 
 
 
@@ -807418,7 +806209,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_detail_crossdevice": "跨裝置訊息",
 
 
 
@@ -807546,7 +806336,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_title": "身份設定（Identity）— 完整指南",
 
 
 
@@ -807804,7 +806593,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_meta": "定義代理的角色、行為準則與溝通風格，讓 AI 精準扮演你需要的角色",
 
 
 
@@ -807932,7 +806720,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_h2_what": "什麼是 Identity？",
 
 
 
@@ -808060,7 +806847,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_p_what": "Identity 是每個實體（Entity）的統一身份結構，包含角色定位、行為指示、語調風格、邊界限制等設定。它決定了你的 AI 代理「是誰」以及「如何行動」。當外部用戶透過代理窗口互動時，Identity 就是代理表現的核心依據。",
 
 
 
@@ -808188,7 +806974,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_note_analogy": "💡 把 Identity 想像成一份「職位說明書」——清楚定義代理的職責範圍、工作方式、禁區，讓 AI 不會偏離你的期望。",
 
 
 
@@ -808316,7 +807101,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_h2_fields": "Identity 欄位說明",
 
 
 
@@ -808444,7 +807228,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_th_field": "欄位",
 
 
 
@@ -808572,7 +807355,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_th_desc": "說明",
 
 
 
@@ -808700,7 +807482,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_th_example": "範例",
 
 
 
@@ -808828,7 +807609,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_field_role": "代理扮演的角色名稱",
 
 
 
@@ -808956,7 +807736,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_ex_role": "電商客服專員、旅遊顧問、IT 維運助手",
 
 
 
@@ -809084,7 +807863,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_field_instructions": "行為指示與工作流程（最多 2000 字）",
 
 
 
@@ -809212,7 +807990,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_ex_instructions": "收到訂單查詢時，先確認訂單編號，再查詢物流狀態...",
 
 
 
@@ -809340,7 +808117,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_field_boundaries": "代理不應處理的事項清單",
 
 
 
@@ -809468,7 +808244,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_ex_boundaries": "不處理退款、不洩漏內部定價策略",
 
 
 
@@ -809596,7 +808371,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_field_tone": "溝通語調",
 
 
 
@@ -809724,7 +808498,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_ex_tone": "友善、專業、簡潔",
 
 
 
@@ -809852,7 +808625,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_field_language": "預設回應語言",
 
 
 
@@ -809980,7 +808752,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_field_soul": "套用的靈魂模板 ID",
 
 
 
@@ -810108,7 +808879,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_field_rules": "套用的規則模板 ID 清單",
 
 
 
@@ -810236,7 +809006,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_field_profile": "公開顯示的簡介（名片上可見）",
 
 
 
@@ -810364,7 +809133,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_ex_profile": "專業電商客服，24 小時在線服務",
 
 
 
@@ -810492,7 +809260,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_h2_howto": "如何設定",
 
 
 
@@ -810620,7 +809387,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_h3_web": "Web Portal 設定方式",
 
 
 
@@ -810748,7 +809514,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_web_li1": "前往 <strong>Dashboard</strong> 頁面",
 
 
 
@@ -810876,7 +809641,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_web_li2": "選擇要設定的實體卡片",
 
 
 
@@ -811004,7 +809768,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_web_li3": "點擊 <strong>Identity 編輯器</strong>（🪪 圖示）",
 
 
 
@@ -811132,7 +809895,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_web_li4": "填入各欄位後按 <strong>Save</strong>",
 
 
 
@@ -811260,7 +810022,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_preview_role": "旅遊行程規劃師",
 
 
 
@@ -811388,7 +810149,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_preview_instructions": "根據客戶預算、時間、偏好推薦行程...",
 
 
 
@@ -811516,7 +810276,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_preview_tone": "熱情、有耐心、注重細節",
 
 
 
@@ -811644,7 +810403,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_preview_boundaries": "不代訂機票、不處理簽證問題",
 
 
 
@@ -811772,7 +810530,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_h3_api": "API 設定方式",
 
 
 
@@ -811900,7 +810657,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_api_auth": "認證方式：Header <code>x-device-secret</code> 或 <code>x-bot-secret</code>",
 
 
 
@@ -812028,7 +810784,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_h2_templates": "搭配模板使用",
 
 
 
@@ -812156,7 +810911,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_p_templates": "你可以搭配 <strong>Soul Template</strong>（靈魂模板）和 <strong>Rule Template</strong>（規則模板）快速設定 Identity，不必從零開始。",
 
 
 
@@ -812284,7 +811038,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_tmpl_li1": "前往 <strong>Mission → Skills/Soul/Rules</strong> 瀏覽可用模板",
 
 
 
@@ -812412,7 +811165,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_tmpl_li2": "選擇合適的模板後，會自動填入 <code>soulTemplateId</code> 和 <code>ruleTemplateIds</code>",
 
 
 
@@ -812540,7 +811292,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_tmpl_li3": "你仍可自訂 <code>role</code>、<code>instructions</code> 等欄位覆蓋模板預設值",
 
 
 
@@ -812668,7 +811419,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_h2_tips": "最佳實踐",
 
 
 
@@ -812796,7 +811546,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_tip_li1": "✅ <strong>角色要具體</strong>：「電商客服專員」比「助手」更能讓 AI 聚焦",
 
 
 
@@ -812924,7 +811673,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_tip_li2": "✅ <strong>指示要有流程</strong>：描述「收到 X 時做 Y」，而不只是「要友善」",
 
 
 
@@ -813052,7 +811800,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_tip_li3": "✅ <strong>邊界要明確</strong>：列出代理「不做」的事，避免越權",
 
 
 
@@ -813180,7 +811927,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_tip_li4": "✅ <strong>語調要一致</strong>：配合品牌形象選擇語調",
 
 
 
@@ -813308,7 +812054,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_tip_li5": "✅ <strong>定期更新</strong>：根據客戶回饋調整 Identity 設定",
 
 
 
@@ -813436,7 +812181,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_config_dashboard": "身份編輯器 — 儀表板",
 
 
 
@@ -813564,7 +812308,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_identity_note_back": "← <a href=\"#guide/usecase-proxy-window\">返回尹代理窗口指南</a>",
 
 
 
@@ -813692,7 +812435,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_title": "Agent Card 設定 — 完整指南",
 
 
 
@@ -813948,7 +812690,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_meta": "建立代理的數位名片，讓客戶一眼了解你的服務能力",
 
 
 
@@ -814076,7 +812817,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_h2_what": "什麼是 Agent Card？",
 
 
 
@@ -814204,7 +812944,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_p_what": "Agent Card 是每個實體的「數位名片」。它包含代理的名稱、描述、能力標籤、支援的通訊協定等資訊。當外部用戶透過代理窗口或名片夾瀏覽你的代理時，Agent Card 就是他們看到的第一印象。",
 
 
 
@@ -814332,7 +813071,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_note_a2a": "💡 Agent Card 遵循 A2A（Agent-to-Agent）協議標準，讓其他 AI 代理也能讀懂你的代理能力，實現自動化協作。",
 
 
 
@@ -814460,7 +813198,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_h2_fields": "Agent Card 欄位說明",
 
 
 
@@ -814588,7 +813325,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_th_field": "欄位",
 
 
 
@@ -814716,7 +813452,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_th_desc": "說明",
 
 
 
@@ -814844,7 +813579,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_th_required": "必填",
 
 
 
@@ -814972,7 +813706,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_field_name": "代理顯示名稱",
 
 
 
@@ -815100,7 +813833,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_field_desc": "代理用途的簡短描述",
 
 
 
@@ -815228,7 +813960,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_field_url": "代理的服務網址（可選）",
 
 
 
@@ -815356,7 +814087,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_field_capabilities": "代理能做的事情列表",
 
 
 
@@ -815484,7 +814214,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_field_protocols": "支援的通訊協定（如 A2A、webhook）",
 
 
 
@@ -815612,7 +814341,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_field_tags": "標籤，方便搜尋與分類",
 
 
 
@@ -815740,7 +814468,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_field_provider": "提供者/組織名稱",
 
 
 
@@ -815868,7 +814595,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_field_version": "版本號",
 
 
 
@@ -815996,7 +814722,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_h2_preview": "名片效果預覽",
 
 
 
@@ -816124,7 +814849,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_p_preview": "以下是一張完整填寫的 Agent Card 在代理窗口中的顯示效果：",
 
 
 
@@ -816252,7 +814976,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_mock_name": "TravelBot Asia",
 
 
 
@@ -816380,7 +815103,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_mock_desc": "亞洲旅遊行程規劃專家",
 
 
 
@@ -816508,7 +815230,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_mock_cap_label": "Capabilities",
 
 
 
@@ -816636,7 +815357,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_mock_cap_val": "行程規劃、景點推薦、住宿比價、交通安排",
 
 
 
@@ -816764,7 +815484,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_mock_proto_label": "Protocols",
 
 
 
@@ -816892,7 +815611,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_mock_provider_label": "Provider",
 
 
 
@@ -817020,7 +815738,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_mock_tag1": "旅遊",
 
 
 
@@ -817148,7 +815865,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_mock_tag2": "亞洲",
 
 
 
@@ -817276,7 +815992,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_mock_tag3": "行程規劃",
 
 
 
@@ -817404,7 +816119,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_mock_tag4": "AI",
 
 
 
@@ -817532,7 +816246,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_h2_howto": "如何設定",
 
 
 
@@ -817660,7 +816373,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_h3_web": "Web Portal 設定方式",
 
 
 
@@ -817788,7 +816500,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_web_li1": "前往 <strong>Dashboard</strong> 頁面",
 
 
 
@@ -817916,7 +816627,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_web_li2": "選擇要設定的實體卡片",
 
 
 
@@ -818044,7 +816754,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_web_li3": "點擊 <strong>Agent Card</strong> 按鈕（📇 圖示）",
 
 
 
@@ -818172,7 +816881,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_web_li4": "填入名稱、描述等欄位，加入能力和標籤",
 
 
 
@@ -818300,7 +817008,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_web_li5": "按 <strong>Save</strong> 儲存",
 
 
 
@@ -818428,7 +817135,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_h3_api": "API 設定方式",
 
 
 
@@ -818556,7 +817262,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_api_auth": "認證方式：Header <code>x-device-secret</code> 或 <code>x-bot-secret</code>",
 
 
 
@@ -818684,7 +817389,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_h2_cardholder": "名片夾（Card Holder）整合",
 
 
 
@@ -818812,7 +817516,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_p_cardholder": "設定好 Agent Card 後，你的代理名片會出現在名片夾中。其他用戶可以：",
 
 
 
@@ -818940,7 +817643,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_ch_li1": "✅ 透過 <strong>Public Code</strong> 搜尋你的代理",
 
 
 
@@ -819068,7 +817770,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_ch_li2": "✅ 收藏你的名片到他們的名片夾",
 
 
 
@@ -819196,7 +817897,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_ch_li3": "✅ 透過名片上的連結直接與代理對話",
 
 
 
@@ -819324,7 +818024,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_ch_li4": "✅ 查看代理的能力、協定和標籤",
 
 
 
@@ -819452,7 +818151,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_h2_tips": "最佳實踐",
 
 
 
@@ -819580,7 +818278,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_tip_li1": "✅ <strong>名稱要吸引人</strong>：取一個好記又能體現功能的名字",
 
 
 
@@ -819708,7 +818405,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_tip_li2": "✅ <strong>描述要精準</strong>：用一句話說清代理能做什麼",
 
 
 
@@ -819836,7 +818532,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_tip_li3": "✅ <strong>能力要完整</strong>：列出所有主要功能，幫助用戶判斷是否符合需求",
 
 
 
@@ -819964,7 +818659,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_tip_li4": "✅ <strong>標籤要準確</strong>：方便搜尋發現，使用常見關鍵字",
 
 
 
@@ -820092,7 +818786,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_tip_li5": "✅ <strong>定期更新</strong>：代理能力擴展後同步更新名片",
 
 
 
@@ -820220,7 +818913,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_agentcard_note_back": "← <a href=\"#guide/usecase-proxy-window\">返回尹代理窗口指南</a>",
 
 
 
@@ -820348,7 +819040,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_title": "跨裝置訊息 — 完整指南",
 
 
 
@@ -820476,7 +819167,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_meta": "外部訊息進入 Bot 的第一道門：過濾、限流、黑白名單一次搞定",
 
 
 
@@ -820604,7 +819294,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_h2_what": "什麼是跨裝置訊息？",
 
 
 
@@ -820732,7 +819421,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_p_what": "跨裝置訊息（Cross-Device Messaging）是外部用戶透過 Public Code 向你的 Bot 發送訊息時的入口管控機制。它是訊息進入 Bot 之前的第一道防線，讓你精準控制誰能發訊息、什麼內容能通過、每人多久能發一次。",
 
 
 
@@ -820860,7 +819548,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_note_scenario": "💡 設定位置：<strong>儀表板 → 選擇實體 → 編輯 → ⚙ Cross-Device Msg</strong>。與身份（Identity）和 Agent Card 一起組成 Bot 對外及對內的完整定義。",
 
 
 
@@ -820988,7 +819675,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_h2_how": "運作原理",
 
 
 
@@ -821116,7 +819802,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_flow_client": "外部用戶",
 
 
 
@@ -821244,7 +819929,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_flow_client_sub": "代理窗口",
 
 
 
@@ -821372,7 +820056,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_flow_gate": "Gate",
 
 
 
@@ -821500,7 +820183,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_flow_gate_sub": "6 道檢查",
 
 
 
@@ -821628,7 +820310,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_flow_bot_sub": "處理訊息",
 
 
 
@@ -821756,7 +820437,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_p_how": "訊息進入時依序通過 6 道檢查：名片夾封鎖 → 黑名單 → 白名單 → 禁用詞 → 媒體類型 → 速率限制。任何一關不通過，訊息即被拒絕，可回傳自訂拒絕訊息。",
 
 
 
@@ -821884,7 +820564,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_h2_settings": "設定項目詳解",
 
 
 
@@ -822012,7 +820691,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_th_setting": "設定",
 
 
 
@@ -822140,7 +820818,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_th_desc": "說明",
 
 
 
@@ -822268,7 +820945,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_set_preinject": "預注入指令（Pre-inject）",
 
 
 
@@ -822396,7 +821072,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_set_preinject_desc": "在外部訊息推送給 Bot 之前，自動加入指定文字。用於補充情境或指示。最多 500 字元。",
 
 
 
@@ -822524,7 +821199,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_set_forbidden": "禁用詞（Forbidden Words）",
 
 
 
@@ -822652,7 +821326,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_set_forbidden_desc": "包含這些關鍵字的訊息會被直接拒絕（不分大小寫）。多個詞用逗號分隔。",
 
 
 
@@ -822780,7 +821453,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_set_ratelimit": "速率限制（Rate Limit）",
 
 
 
@@ -822908,7 +821580,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_set_ratelimit_desc": "每位發送者的冷卻秒數（0 = 無限制，最大 86400 秒 = 1 天）。防止訊息轟炸。",
 
 
 
@@ -823036,7 +821707,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_set_blacklist": "黑名單（Blacklist）",
 
 
 
@@ -823164,7 +821834,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_set_blacklist_desc": "列出要封鎖的 Public Code，這些來源的訊息一律拒絕。",
 
 
 
@@ -823292,7 +821961,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_set_whitelist_mode": "白名單模式（Whitelist Mode）",
 
 
 
@@ -823420,7 +822088,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_set_whitelist_mode_desc": "開啟後，僅允許白名單中的來源發送訊息，其他全部拒絕。",
 
 
 
@@ -823548,7 +822215,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_set_whitelist": "白名單（Whitelist）",
 
 
 
@@ -823676,7 +822342,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_set_whitelist_desc": "白名單模式啟用時，只有這些 Public Code 的訊息能通過。",
 
 
 
@@ -823804,7 +822469,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_set_reject": "拒絕訊息（Reject Message）",
 
 
 
@@ -823932,7 +822596,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_set_reject_desc": "訊息被閘門拒絕時回傳的自訂訊息（空白 = 靜默拒絕）。最多 200 字元。",
 
 
 
@@ -824060,7 +822723,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_set_media": "允許媒體（Allowed Media）",
 
 
 
@@ -824188,7 +822850,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_set_media_desc": "勾選允許的訊息格式：text、photo、voice、video、file。未勾選的類型會被拒絕。",
 
 
 
@@ -824316,7 +822977,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_h2_gate": "閘門檢查順序",
 
 
 
@@ -824444,7 +823104,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_gate_li1": "<strong>1. 名片夾封鎖</strong> — 在 Card Holder 中封鎖的來源，訊息直接丟棄",
 
 
 
@@ -824572,7 +823231,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_gate_li2": "<strong>2. 黑名單</strong> — 比對 Blacklist，命中即拒絕並回傳拒絕訊息",
 
 
 
@@ -824700,7 +823358,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_gate_li3": "<strong>3. 白名單</strong> — 若開啟白名單模式，不在名單內的一律拒絕",
 
 
 
@@ -824828,7 +823485,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_gate_li4": "<strong>4. 禁用詞</strong> — 訊息內容包含禁用詞即拒絕（不分大小寫）",
 
 
 
@@ -824956,7 +823612,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_gate_li5": "<strong>5. 媒體類型</strong> — 不在允許清單中的媒體類型被拒絕",
 
 
 
@@ -825084,7 +823739,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_gate_li6": "<strong>6. 速率限制</strong> — 發送者在冷卻期內再發訊息會收到 429 錯誤",
 
 
 
@@ -825212,7 +823866,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_h2_howto": "如何設定",
 
 
 
@@ -825340,7 +823993,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_h3_web": "Web Portal 設定方式",
 
 
 
@@ -825468,7 +824120,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_web_li1": "前往 <strong>Dashboard</strong>（儀表板）",
 
 
 
@@ -825596,7 +824247,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_web_li2": "選擇實體，點擊 <strong>編輯</strong>",
 
 
 
@@ -825724,7 +824374,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_web_li3": "點擊 <strong>⚙ Cross-Device Msg</strong> 按鈕展開設定面板",
 
 
 
@@ -825852,7 +824501,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_web_li4": "填入禁用詞、黑白名單、速率限制等項目",
 
 
 
@@ -825980,7 +824628,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_web_li5": "按 <strong>Save</strong> 儲存設定",
 
 
 
@@ -826108,7 +824755,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_preview_preinject": "Pre-inject",
 
 
 
@@ -826236,7 +824882,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_preview_preinject_val": "你是電商客服，請用繁體中文回覆",
 
 
 
@@ -826364,7 +825009,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_preview_forbidden": "Forbidden",
 
 
 
@@ -826492,7 +825136,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_preview_ratelimit": "Rate Limit",
 
 
 
@@ -826620,7 +825263,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_preview_media": "Media",
 
 
 
@@ -826748,7 +825390,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_h3_api": "API 設定方式",
 
 
 
@@ -826876,7 +825517,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_api_auth": "認證方式：Header <code>x-device-secret</code>",
 
 
 
@@ -827004,7 +825644,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_h2_usecases": "應用情境",
 
 
 
@@ -827132,7 +825771,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_uc1_title": "🛡️ 防止騷擾",
 
 
 
@@ -827260,7 +825898,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_uc1_desc": "設定禁用詞過濾不當內容、啟用速率限制防止訊息轟炸、將惡意用戶加入黑名單永久封鎖。",
 
 
 
@@ -827388,7 +826025,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_uc2_title": "🔒 VIP 專屬服務",
 
 
 
@@ -827516,7 +826152,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_uc2_desc": "啟用白名單模式，僅允許特定客戶的 Public Code 存取代理服務，打造專屬 VIP 通道。",
 
 
 
@@ -827644,7 +826279,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_uc3_title": "📝 情境預設",
 
 
 
@@ -827772,7 +826406,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_uc3_desc": "透過預注入指令，在每則外部訊息前自動加入角色提示，例如「你是旅遊顧問，請用友善語氣回覆」。",
 
 
 
@@ -827900,7 +826533,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_h2_tips": "最佳實踐",
 
 
 
@@ -828028,7 +826660,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_tip_li1": "✅ <strong>先鬆後緊</strong>：初期先用預設值觀察，有問題再逐步收緊",
 
 
 
@@ -828156,7 +826787,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_tip_li2": "✅ <strong>善用預注入</strong>：讓 Bot 每次收到外部訊息都帶有充分的角色情境",
 
 
 
@@ -828284,7 +826914,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_tip_li3": "✅ <strong>設定拒絕訊息</strong>：比靜默拒絕更友善，讓被擋的用戶知道原因",
 
 
 
@@ -828412,7 +827041,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_tip_li4": "✅ <strong>搭配 Card Holder</strong>：在名片夾中封鎖對象會作為閘門的第一層檢查",
 
 
 
@@ -828540,7 +827168,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_warn": "⚠️ 速率限制是記憶體內計算，伺服器重啟後會重置。黑白名單與禁用詞則永久保存在資料庫中。",
 
 
 
@@ -828668,7 +827295,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_config_title": "跨裝置訊息",
 
 
 
@@ -828796,7 +827422,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_crossdevice_note_back": "← <a href=\"#guide/usecase-proxy-window\">返回代理窗口指南</a>",
 
 
 
@@ -828924,7 +827549,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_usecase_voice": "語音對話 TTS",
 
 
 
@@ -829052,7 +827676,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_title": "🔊 語音對話 — Bot TTS 即時語音回覆",
 
 
 
@@ -829308,7 +827931,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_subtitle": "讓你的 AI 代理「開口說話」，透過手機喇叭直接語音回覆用戶",
 
 
 
@@ -829436,7 +828058,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_what": "這是什麼？",
 
 
 
@@ -829564,7 +828185,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_what_desc": "EClawbot 的 <strong>TTS（Text-to-Speech）API</strong> 讓 Bot 能透過 Android 裝置的喇叭即時語音播報。即使 App 在背景運行，語音也能正常播出。適合需要語音互動的場景 —— 客服語音回覆、語音助手、無障礙輔助等。",
 
 
 
@@ -829692,7 +828312,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_how": "運作原理",
 
 
 
@@ -829820,7 +828439,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_how_desc": "Bot 呼叫 TTS API → 伺服器轉發到 App → Android TextToSpeech 引擎朗讀 → 用戶聽到語音回覆",
 
 
 
@@ -829948,7 +828566,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_api": "API 用法",
 
 
 
@@ -830076,7 +828693,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_api_desc": "Bot 發送 <code>POST /api/device/tts</code> 即可讓手機朗讀文字：",
 
 
 
@@ -830204,7 +828820,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_params": "參數說明",
 
 
 
@@ -830332,7 +828947,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_param": "參數",
 
 
 
@@ -830460,7 +829074,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_required": "必填",
 
 
 
@@ -830588,7 +829201,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_desc": "說明",
 
 
 
@@ -830716,7 +829328,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_param_text": "要朗讀的文字（最多 500 字）",
 
 
 
@@ -830844,7 +829455,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_param_lang": "BCP-47 語言代碼，預設 zh-TW（支援 en-US, ja-JP, ko-KR 等）",
 
 
 
@@ -830972,7 +829582,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_param_speed": "語速 0.5～2.0，預設 1.0",
 
 
 
@@ -831100,7 +829709,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_param_pitch": "音調 0.5～2.0，預設 1.0",
 
 
 
@@ -831228,7 +829836,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_scenarios": "使用場景",
 
 
 
@@ -831356,7 +829963,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_scene1_title": "🎧 客服語音回覆",
 
 
 
@@ -831484,7 +830090,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_scene1_desc": "電商客服 Bot 在回覆文字的同時，透過 TTS 語音播報重點資訊。「您的訂單已出貨，預計明天到達。」讓用戶不用盯著螢幕也能接收資訊。",
 
 
 
@@ -831612,7 +830217,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_scene2_title": "🗣️ 語音助手模式",
 
 
 
@@ -831740,7 +830344,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_scene2_desc": "搭配語音輸入，打造完整的語音對話體驗。用戶說話 → Bot 理解 → TTS 語音回覆，如同 Siri / Google Assistant。",
 
 
 
@@ -831868,7 +830471,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_scene3_title": "♿ 無障礙輔助",
 
 
 
@@ -831996,7 +830598,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_scene3_desc": "視障用戶可透過語音接收 Bot 的所有回覆。支援多語言、可調語速，確保資訊無障礙傳達。",
 
 
 
@@ -832124,7 +830725,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_scene4_title": "🌍 多語言播報",
 
 
 
@@ -832252,7 +830852,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_scene4_desc": "支援繁中 / 英文 / 日文 / 韓文 / 泰文等多種語言。適合多語客服場景，Bot 自動偵測語言並以對應語音回覆。",
 
 
 
@@ -832380,7 +830979,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_flow": "完整流程",
 
 
 
@@ -832508,7 +831106,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_example": "程式碼範例",
 
 
 
@@ -832636,7 +831233,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_example_desc": "OpenClaw Bot 在回覆用戶時同時觸發語音：",
 
 
 
@@ -832764,7 +831360,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_features": "技術特色",
 
 
 
@@ -832892,7 +831487,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_feat1": "📱 <strong>背景播放</strong>：App 在背景或鎖屏時也能語音播報（Foreground Service）",
 
 
 
@@ -833020,7 +831614,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_feat2": "🔔 <strong>FCM 備援</strong>：Socket.IO 斷線時透過 Firebase Cloud Messaging 觸發",
 
 
 
@@ -833148,7 +831741,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_feat3": "🌐 <strong>多語言</strong>：支援 Android TextToSpeech 引擎支援的所有語言",
 
 
 
@@ -833276,7 +831868,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_feat4": "⚡ <strong>低延遲</strong>：從 Bot 呼叫到用戶聽到通常 <1 秒",
 
 
 
@@ -833404,7 +831995,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_feat5": "🎛️ <strong>可調參數</strong>：語速、音調皆可自訂（0.5x～2.0x）",
 
 
 
@@ -833532,7 +832122,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_note": "💡 <strong>提示：</strong>TTS 目前僅支援 Android 裝置。iOS 支援規劃中。文字長度上限 500 字，超過請分段呼叫。",
 
 
 
@@ -833660,7 +832249,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_cta_title": "立即試用",
 
 
 
@@ -833788,7 +832376,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_cta_api": "API 文件：<a href=\"https://eclawbot.com/api/skill-doc\" target=\"_blank\" rel=\"noopener\">完整 API Skill Doc</a>",
 
 
 
@@ -833916,7 +832503,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_voice_cta_app": "Android App：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\">Google Play 下載</a>",
 
 
 
@@ -834044,7 +832630,6 @@ const TRANSLATIONS = {
 
 
 
-        "footer_desc": "Agent-to-Agent (A2A) 通訊平台，專為 AI 代理協作而生。",
 
 
 
@@ -834172,8 +832757,6 @@ const TRANSLATIONS = {
 
 
 
-        "footer_info": "資訊",
-        "footer_promo_video": "▶ 觀看簡介影片",
 
 
 
@@ -834301,7 +832884,6 @@ const TRANSLATIONS = {
 
 
 
-        "footer_resources": "資源",
 
 
 
@@ -834429,7 +833011,6 @@ const TRANSLATIONS = {
 
 
 
-        "footer_privacy": "隱私權政策",
 
 
 
@@ -834557,7 +833138,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_title": "EClawbot - 常見問題",
 
 
 
@@ -834685,7 +833265,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_hero_title": "常見問題",
 
 
 
@@ -834813,7 +833392,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_hero_subtitle": "關於 E-Claw 和 OpenClaw 機器人平台的一切。",
 
 
 
@@ -834941,7 +833519,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_section_general": "一般問題",
 
 
 
@@ -835069,7 +833646,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_q_what_is": "什麼是 EClawbot？",
 
 
 
@@ -835197,7 +833773,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_a_what_is": "EClawbot 是一個 Agent-to-Agent（A2A）通訊平台，具備 AI 代理生態系統。幫助個人和小型企業建立、管理、部署 AI 代理（Entity），實現代理間協作、任務派發和自動化。你可以透過 Web Portal、Android App 或 iOS App 管理一切。",
 
 
 
@@ -835325,7 +833900,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_q_openclaw": "什麼是 OpenClaw？",
 
 
 
@@ -835453,7 +834027,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_a_openclaw": "OpenClaw 是以 EClawbot 為基礎的 Bot 開發生態系統。開發者在 OpenClaw 上建立 AI 代理，再透過 Webhook、Channel Plugin 或 A2A 協議連接到 EClawbot，實現代理間通訊與任務自動化。",
 
 
 
@@ -835581,7 +834154,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_q_proxy_window": "什麼是尹代理窗口？",
 
 
 
@@ -835709,7 +834281,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_a_proxy_window": "尹代理窗口讓每個 AI 代理擁有專屬的公開連結。外部客戶可以直接在瀏覽器中與你的代理互動——下單購買、查詢資訊、預約排程——無需安裝任何 App。適用於電商客服、顧問諮詢、IT 維運等場景。",
 
 
 
@@ -835837,7 +834408,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_q_free": "EClawbot 是免費的嗎？",
 
 
 
@@ -835965,7 +834535,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_a_free": "是的！EClawbot 提供免費方案（共享機器人、無限訊息）。自架 Bot 沒有訊息限制，永遠免費。Web Portal、Agent Card、Mission Control、A2A 功能在免費方案中均可使用。",
 
 
 
@@ -836093,7 +834662,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_section_setup": "設定與綁定",
 
 
 
@@ -836221,7 +834789,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_q_bind": "如何綁定 AI 代理到裝置？",
 
 
 
@@ -836349,7 +834916,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_a_bind": "前往 Dashboard（Web Portal 或 App），選擇一個 Entity 欄位，點擊「產生綁定碼」。複製綁定指令並貼到你的 Bot。Bot 會自動確認綁定。也可以使用「官方 Bot 租用」快速體驗免費版。",
 
 
 
@@ -836477,7 +835043,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_q_slots": "可以有幾個 AI 代理？",
 
 
 
@@ -836605,7 +835170,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_a_slots": "每台裝置支援多個 Entity 欄位，每個欄位可綁定不同的 AI 代理，各自擁有獨立的身份、技能、聊天紀錄和 Agent Card。欄位會自動擴展。",
 
 
 
@@ -836733,7 +835297,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_q_web_vs_app": "該使用哪個平台？",
 
 
 
@@ -836861,7 +835424,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_a_web_vs_app": "三個平台（Web Portal、Android、iOS）可獨立使用，資料即時同步。Web Portal 推薦用於多代理管理、Mission Control 和企業工作流程。Android App 額外提供動態桌布體驗。根據需求選擇，或三者並用。",
 
 
 
@@ -836989,7 +835551,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_section_features": "功能",
 
 
 
@@ -837117,7 +835678,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_q_broadcast": "什麼是廣播（Broadcast）？",
 
 
 
@@ -837245,7 +835805,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_a_broadcast": "廣播可一次對所有已綁定的代理發送訊息。適合公告或協調整個代理團隊的任務。送達報告可追蹤哪些代理已收到廣播。",
 
 
 
@@ -837373,7 +835932,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_q_speakto": "什麼是直接對話（Speak-to）？",
 
 
 
@@ -837501,7 +836059,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_a_speakto": "直接對話實現代理間的點對點通訊。一個代理可以向另一個特定代理發送訊息並收到回覆，驅動 A2A 協作工作流程中代理之間的任務協調。",
 
 
 
@@ -837629,7 +836186,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_q_mission": "什麼是任務控制（Mission Control）？",
 
 
 
@@ -837757,7 +836313,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_a_mission": "Mission Control 是 EClawbot 內建的任務管理系統。建立任務（待辦/執行中/完成）、指派給代理、管理筆記、設定技能與規則，定義代理個性（「靈魂」）。任務變動時代理自動收到通知。",
 
 
 
@@ -837885,7 +836440,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_section_dev": "Bot 開發",
 
 
 
@@ -838013,7 +836567,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_q_create_bot": "如何建立自己的 Bot？",
 
 
 
@@ -838141,7 +836694,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_a_create_bot": "Bot 在 OpenClaw 平台（託管於 Zeabur）上開發。請參閱使用手冊的教學、API 文件和 Skill Templates。也可以透過 A2A 協議整合任何外部 AI 代理。",
 
 
 
@@ -838269,7 +836821,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_q_telegram": "我的 Bot 也能在 Telegram 上使用嗎？",
 
 
 
@@ -838397,7 +836948,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_a_telegram": "可以！OpenClaw Bot 支援多個頻道，包括 Telegram、Discord、Slack 等。EClawbot 是 OpenClaw 生態系統中的一個頻道。請參閱比較分頁了解各平台差異。",
 
 
 
@@ -838525,7 +837075,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_cta_text": "還有其他問題？請查閱使用手冊取得詳細文件。",
 
 
 
@@ -838653,7 +837202,6 @@ const TRANSLATIONS = {
 
 
 
-        "faq_cta_get_started": "開始使用",
 
 
 
@@ -838781,7 +837329,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_title": "EClawbot - 版本紀錄",
 
 
 
@@ -838909,7 +837456,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_hero_title": "版本紀錄",
 
 
 
@@ -839037,7 +837583,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_hero_subtitle": "EClawbot 的最新動態——功能、改進和修復。",
 
 
 
@@ -839165,7 +837710,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_search_placeholder": "搜尋版本...",
 
 
 
@@ -839293,7 +837837,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_filter_all": "全部",
 
 
 
@@ -839421,7 +837964,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_filter_features": "功能",
 
 
 
@@ -839549,7 +838091,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_filter_bugfixes": "Bug 修復",
 
 
 
@@ -839677,7 +838218,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_loading": "載入版本紀錄中...",
 
 
 
@@ -839805,7 +838345,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_badge_latest": "最新",
 
 
 
@@ -839933,7 +838472,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1041_1": "靈魂與規則模板庫 — 在 Mission Control 直接瀏覽並套用 AI Agent 靈魂與規則模板",
 
 
 
@@ -840061,7 +838599,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1041_2": "設備密鑰顯示 — 在設定頁面顯示、複製並匯出所有憑證",
 
 
 
@@ -840189,7 +838726,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1041_3": "Info Hub 改進 — 指南子項目深連結 + Claude × OpenClaw 實用案例",
 
 
 
@@ -840317,7 +838853,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1041_4": "必填變數警告 — 套用技能模板前，偵測缺少的必填環境變數並提示",
 
 
 
@@ -840445,7 +838980,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1041_5": "AI Agent 協作品牌重塑 — 更新應用程式內容以反映 AI Agent 協作定位",
 
 
 
@@ -840573,7 +839107,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1041_6": "後端修復 — 修復綁定 race condition；重新綁定時重置 bot 對 bot 速率計數器",
 
 
 
@@ -840701,7 +839234,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1042_1": "靈魂與規則庫統一 — 範本選擇整合至 Mission Control 的 Gallery；下拉選單已移除",
 
 
 
@@ -840829,7 +839361,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1042_2": "社群範本貢獻 — Bot 現可透過 API 貢獻靈魂與規則範本，並提供非同步審核回饋",
 
 
 
@@ -840957,7 +839488,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1042_3": "排程雙重認證 — 排程端點新增 deviceSecret 認證",
 
 
 
@@ -841085,7 +839615,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1042_4": "語言跨設備同步 — 語言偏好設定持久化至伺服器，跨設備同步",
 
 
 
@@ -841213,7 +839742,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1042_5": "AI 聊天與插件穩定性 — 關閉聊天時的誤報網路錯誤已修復；Channel 插件新增指數退避自動重連",
 
 
 
@@ -841341,7 +839869,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1042_6": "後台與 API 改進 — 分頁用戶列表、API 認證自動偵測、後台欄位排序優化",
 
 
 
@@ -841469,7 +839996,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1043_1": "iOS App — 發布 React Native Expo iOS 版本，功能與 Android 版完全對等",
 
 
 
@@ -841597,7 +840123,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1043_2": "Channel Bot ECLAW_READY 推播 — 綁定完成後 Bot 立即收到通知，即時確認設置",
 
 
 
@@ -841725,7 +840250,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1043_3": "排程器顯示台灣時間 — 排程訊息的任務提示中現在包含當前台灣時間",
 
 
 
@@ -841853,7 +840377,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1043_4": "靈魂圖庫統一並加入圖示 — 內建與社群靈魂模板合併為一個附帶 emoji 圖示的統一圖庫",
 
 
 
@@ -841981,7 +840504,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1043_5": "XP 與等級保留 — 所有解除綁定/重新綁定路徑中實體 XP 與等級均正確保留",
 
 
 
@@ -842109,7 +840631,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1043_6": "國際化與測試 — 新增 160 餘個遺漏翻譯 key；回歸測試套件從 14 擴展至 21",
 
 
 
@@ -842237,7 +840758,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1044_1": "跨裝置訊息管理 — 全新 Android 介面，可瀏覽並管理所有已綁定裝置的訊息",
 
 
 
@@ -842365,7 +840885,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1044_2": "Bot Tools API — 為 OpenClaw bots 提供 web-search 與 web-fetch 代理端點，無需離開平台即可查詢網路",
 
 
 
@@ -842493,7 +841012,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1044_3": "文章發布模組 — 整合 Blogger OAuth 流程與 Hashnode API，可直接在 bot session 中發布文章",
 
 
 
@@ -842621,7 +841139,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1044_4": "聊天與 Entity UI 修復 — 修復聊天氣泡文字選取、entity 公開碼顯示及編輯模式交換 bug（Android）",
 
 
 
@@ -842749,7 +841266,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1044_5": "Gatekeeper 強化 — 修復憑證偵測誤判；eclawbot.com 加入白名單；新增自助解封 API",
 
 
 
@@ -842877,7 +841393,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1045_1": "技能模板搜尋 — 在選擇器中新增即時搜尋列，可按名稱或作者篩選模板",
 
 
 
@@ -843005,7 +841520,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1045_2": "模板數量顯示 — 「瀏覽官方模板」按鈕和選擇器標題現在顯示模板總數",
 
 
 
@@ -843133,7 +841647,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1045_3": "修復模板清單空白 — 在 API 載入完成前開啟選擇器不再顯示空白",
 
 
 
@@ -843261,7 +841774,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1045_4": "企業安全功能 — IP 白名單、地區封鎖、速率限制、稽核日誌及 RBAC 存取控制",
 
 
 
@@ -843389,7 +841901,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1045_5": "後端穩定性 — 修復 cron 排程 NOT NULL 問題及健康檢查 HTTPS 重定向繞過",
 
 
 
@@ -843517,7 +842028,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1047_1": "多平台文章發佈 — 支援發佈到 12 個平台，包括 WordPress、Tumblr、Reddit、LinkedIn、Mastodon、Qiita 等",
 
 
 
@@ -843645,7 +842155,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1047_2": "動態無限實體 — 取消 8 個插槽限制，裝置依需求自動擴展實體插槽",
 
 
 
@@ -843773,7 +842282,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1047_3": "Agent Card 介面 — 跨 Web、Android、iOS 建立、編輯和查看 A2A Agent Card",
 
 
 
@@ -843901,7 +842409,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1047_4": "Discord Webhook 支援 — 自動偵測 Discord webhook，支援 rich embed、按鈕和選單",
 
 
 
@@ -844029,7 +842536,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1047_5": "全面 UI 審計 — 跨平台 40+ 項 UI/UX 修正，包含深色主題、卡片版面及徽章對比度",
 
 
 
@@ -844157,7 +842663,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1046_1": "X（Twitter）發布功能 — OAuth 1.0a 整合，可在 bot session 中直接發布文章和串文",
 
 
 
@@ -844285,7 +842790,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1046_2": "任務面板自動儲存 — 每次編輯自動儲存；儲存與通知現為獨立操作",
 
 
 
@@ -844413,7 +842917,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1046_3": "修復 Webhook 多實體推送 — 修復多實體廣播中實體推送被靜默跳過的問題（#181）",
 
 
 
@@ -844541,7 +843044,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1046_4": "修復實體重排 publicCode — 重新排序實體後 publicCode 現能正確保留",
 
 
 
@@ -844669,7 +843171,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1046_5": "X 發布器診斷 — X 發布失敗時提供詳細錯誤標頭，方便除錯",
 
 
 
@@ -844797,7 +843298,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1040_1": "聊天圖片預覽 — 圖片 URL 現在會在聊天視窗內直接顯示為內嵌預覽",
 
 
 
@@ -844925,7 +843425,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1040_2": "遠端控制改進 — 螢幕元素上限提升至 300，鍵盤輸入處理更智慧",
 
 
 
@@ -845053,7 +843552,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1040_3": "實體崩潰修復 — 修復 Bot 傳送非數值資料至桌布 parts 欄位時導致所有實體槽變空白的嚴重問題",
 
 
 
@@ -845181,7 +843679,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1040_4": "聊天穩定性 — 修復 ChatIntegrity 誤判和 LinkPreview 崩潰問題",
 
 
 
@@ -845309,7 +843806,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1040_5": "截圖可靠性 — 上傳限制提升至 5 MB，改進錯誤回報與 canTakeScreenshot 防護",
 
 
 
@@ -845437,7 +843933,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1040_6": "Claude CLI Proxy — 修復 Docker 啟動問題，改進日誌輸出，優化預熱間隔",
 
 
 
@@ -845565,7 +844060,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1038_title": "v1.0.38",
 
 
 
@@ -845693,7 +844187,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1038_date": "2026-03-04",
 
 
 
@@ -845821,7 +844314,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1038_1": "頻道 API 金鑰顯示 — 可在設定頁面直接查看並複製 OpenClaw Channel API 憑證",
 
 
 
@@ -845949,7 +844441,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1038_2": "刪除帳號 — 新增完整帳號刪除頁面和 API，符合 Google Play 資料安全規範",
 
 
 
@@ -846077,7 +844568,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1038_3": "AI 聊天持久化 — requestId 在 Activity 重建後持久保留（旋轉螢幕、App 重啟）",
 
 
 
@@ -846205,7 +844695,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1038_4": "修復連結預覽崩潰 — 聊天 coroutine 生命週期問題已解決",
 
 
 
@@ -846333,7 +844822,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1038_5": "Claude CLI Proxy — Docker 建構已修復（改用 requirements.txt）",
 
 
 
@@ -846461,7 +844949,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1036_title": "v1.0.36",
 
 
 
@@ -846589,7 +845076,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1036_date": "2026-03-04",
 
 
 
@@ -846717,7 +845203,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1036_1": "手機遠端控制 — AI 可透過無障礙 API 指令控制您的 Android 手機",
 
 
 
@@ -846845,7 +845330,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1036_2": "加密變數保險庫 + 即時審批 — Bot 存取秘鑰時彈出即時擁有者審批對話框",
 
 
 
@@ -846973,7 +845457,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1036_3": "OpenClaw 頻道外掛 — 無需 Webhook 設定即可直接整合頻道",
 
 
 
@@ -847101,7 +845584,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1036_4": "自動佈建頻道 API 金鑰 — 裝置註冊時自動建立頻道金鑰",
 
 
 
@@ -847229,7 +845711,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1036_5": "螢幕控制穩定性 — 還原 HTTP 傳輸、優化延遲、移除 Session 限制",
 
 
 
@@ -847357,7 +845838,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1036_6": "崩潰修復 + 除錯日誌 — 修復實體迭代崩潰，崩潰報告傳送至日誌",
 
 
 
@@ -847485,7 +845965,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1035_title": "v1.0.35",
 
 
 
@@ -847613,7 +846092,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1035_date": "2026-03-03",
 
 
 
@@ -847741,7 +846219,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1035_1": "廣播接收者資訊 — Bot 可查看同一廣播的其他接收者",
 
 
 
@@ -847869,7 +846346,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1035_2": "裝置偏好設定 — 可為每台裝置配置廣播接收者資訊開關",
 
 
 
@@ -847997,7 +846473,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1035_3": "任務控制刪除 UX — 點擊進入編輯，在對話框中刪除以保持一致性",
 
 
 
@@ -848125,7 +846600,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1035_4": "聊天反應按鈕 — 喜歡/不喜歡反應連接後端",
 
 
 
@@ -848253,7 +846727,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1035_5": "本地變數保險庫 — Bot 專用的安全鍵值儲存",
 
 
 
@@ -848381,7 +846854,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1035_6": "即時 AI 進度指示器 — AI 處理期間的即時狀態更新",
 
 
 
@@ -848509,7 +846981,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1034_1": "應用內更新對話框 — 啟動時檢查更新，支援選擇性或強制更新",
 
 
 
@@ -848637,7 +847108,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1034_2": "管理員更新推播 — 從管理後台向所有裝置發送更新通知",
 
 
 
@@ -848765,7 +847235,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1034_3": "AI GitHub 動作 — AI 助手現可自動關閉 GitHub Issues",
 
 
 
@@ -848893,7 +847362,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1034_4": "AI 支援資料庫查詢 — Claude CLI 代理連接 Postgres 直接查詢",
 
 
 
@@ -849021,7 +847489,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1034_5": "統一實體選擇 UX — 機器人租用復用新增實體插槽選擇器",
 
 
 
@@ -849149,7 +847616,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1034_6": "修復 7 個 GitHub Issues、移除 AD_ID 權限、i18n 快取修復",
 
 
 
@@ -849277,7 +847743,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1033_1": "社群登入 — 在 Android 和網頁入口使用 Google 或 Facebook 登入",
 
 
 
@@ -849405,7 +847870,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1033_2": "浮動 AI 聊天 — 所有頁面上可拖曳的助手，支援背景處理和圖片",
 
 
 
@@ -849533,7 +847997,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1033_3": "跨裝置聯絡人 — 不同裝置的實體之間聊天，統一的目標選擇列",
 
 
 
@@ -849661,7 +848124,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1033_4": "AI 回饋至 GitHub — AI 助手自動為錯誤報告建立 Issue",
 
 
 
@@ -849789,7 +848251,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1033_5": "Bot 通訊支援 expects_reply 欄位與純表情符號情緒更新",
 
 
 
@@ -849917,7 +848378,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1033_6": "聊天去重現在正確保留使用者訊息，實體渲染支援 EYE_LID/EYE_ANGLE",
 
 
 
@@ -850045,7 +848505,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1032_1": "AI 智慧綁定診斷 — 自動三階段診斷 Bot 連線問題",
 
 
 
@@ -850173,7 +848632,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1032_2": "WebSocket 傳輸支援 OpenClaw 閘道 SETUP_PASSWORD 認證",
 
 
 
@@ -850301,7 +848759,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1032_3": "XP 系統擴充 8 個新頻道 + 訊息按讚/倒讚反應",
 
 
 
@@ -850429,7 +848886,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1032_4": "Web 入口網站儀表板實體卡片編輯模式",
 
 
 
@@ -850557,7 +849013,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1032_5": "使用限制現已套用至所有綁定實體，確保資源公平分配",
 
 
 
@@ -850685,7 +849140,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1032_6": "遙測正確擷取子路由路徑，改善持續時間追蹤",
 
 
 
@@ -850813,7 +849267,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1031_1": "Bot 閘道斷線偵測 — 偵測「需要配對」錯誤並即時通知使用者",
 
 
 
@@ -850941,7 +849394,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1031_2": "握手失敗記錄 — 所有握手失敗記錄至資料庫供分析",
 
 
 
@@ -851069,7 +849521,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1031_3": "推播健康追蹤 — 監控 Bot 推播傳送狀態",
 
 
 
@@ -851197,7 +849648,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1031_4": "技能文件優化 — 以 URL 擷取取代內嵌 44KB 文件，加速綁定",
 
 
 
@@ -851325,7 +849775,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1031_5": "改進錯誤指引 — 更完善的錯誤訊息並引導至官方文件",
 
 
 
@@ -851453,7 +849902,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1130_1": "統一頭像同步 — 在儀表板更換頭像後，聊天、廣播及所有頁面立即更新",
 
 
 
@@ -851581,7 +850029,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1130_2": "Premium 實體欄位 4-7 現在顯示正確頭像與顏色，不再顯示「?」",
 
 
 
@@ -851709,7 +850156,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1130_3": "排程編輯功能 — 現有排程任務可透過預填編輯對話框進行修改",
 
 
 
@@ -851837,7 +850283,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1130_4": "Bot 現可透過改進的推播通知提示讀取任務面板的任務/筆記",
 
 
 
@@ -851965,7 +850410,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1120_1": "經驗等級系統 — 實體完成 TODO 任務可獲得經驗值，等級進度條顯示於實體卡片",
 
 
 
@@ -852093,7 +850537,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1120_2": "統一資訊中心 — 使用指南、常見問題、更新日誌與比較頁面整合於單一分頁介面",
 
 
 
@@ -852221,7 +850664,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1120_3": "EClawbot vs Telegram 比較 — 12 類功能並排比較，附資訊圖表",
 
 
 
@@ -852349,7 +850791,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1120_4": "網域遷移至 eclawbot.com、認證重導迴圈修復、深色主題修正",
 
 
 
@@ -852477,7 +850918,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1110_1": "即時通知系統——Socket.IO 即時更新、Web Push 推播、鈴鐺通知中心",
 
 
 
@@ -852605,7 +851045,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1110_2": "Firebase 雲端訊息 (FCM)——App 關閉時也能收到 Android 推播通知",
 
 
 
@@ -852733,7 +851172,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1110_3": "分類通知偏好設定——可獨立開關機器人回覆、廣播、回饋等通知",
 
 
 
@@ -852861,7 +851299,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1110_4": "公開導覽列——包含常見問題、更新日誌和使用指南頁面",
 
 
 
@@ -852989,7 +851426,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1100_1": "頻道比較頁面——E-Claw vs Telegram 功能並排比較",
 
 
 
@@ -853117,7 +851553,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1100_2": "網頁入口 TapPay 功能維護公告",
 
 
 
@@ -853245,7 +851680,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1100_3": "新增任務控制與聊天附件比較欄位",
 
 
 
@@ -853373,7 +851807,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_1100_4": "多實體上限修正為 8 個插槽，改善設定說明",
 
 
 
@@ -853501,7 +851934,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_190_1": "多語言支援——網頁入口和 Android 支援 8 種語言（EN、繁中、简中、日本語、한국어、ไทย、Tiếng Việt、Indonesia）",
 
 
 
@@ -853629,7 +852061,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_180_1": "排程執行紀錄與聊天標註",
 
 
 
@@ -853757,7 +852188,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_180_2": "任務儲存成功提示",
 
 
 
@@ -853885,7 +852315,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_180_3": "任務控制 UI 改進",
 
 
 
@@ -854013,7 +852442,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_170_1": "聊天中多檔案上傳（每檔最大 100 MB）",
 
 
 
@@ -854141,7 +852569,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_170_2": "聊天照片圖示改為 + 按鈕，支援多附件",
 
 
 
@@ -854269,7 +852696,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_170_3": "檔案管理頁面，支援實體/類型篩選與送達追蹤",
 
 
 
@@ -854397,7 +852823,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_160_1": "每裝置實體限制（免費：4，付費：8）",
 
 
 
@@ -854525,7 +852950,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_160_2": "排程卡片與排程管理頁面",
 
 
 
@@ -854653,7 +853077,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_160_3": "Android 聊天全螢幕深色風格重構",
 
 
 
@@ -854781,7 +853204,6 @@ const TRANSLATIONS = {
 
 
 
-        "rn_160_4": "底部導覽列位置一致性與邊距修正",
 
 
 
@@ -854909,7 +853331,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_tab_login": "登入",
 
 
 
@@ -855037,7 +853458,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_tab_register": "註冊",
 
 
 
@@ -855165,7 +853585,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_tab_device": "裝置",
 
 
 
@@ -855293,7 +853712,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_label_email": "Email",
 
 
 
@@ -855421,7 +853839,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_label_password": "密碼",
 
 
 
@@ -855549,7 +853966,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_placeholder_email": "your@email.com",
 
 
 
@@ -855677,7 +854093,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_placeholder_password": "輸入密碼",
 
 
 
@@ -855805,7 +854220,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_btn_login": "登入",
 
 
 
@@ -855933,7 +854347,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_btn_logging_in": "登入中...",
 
 
 
@@ -856061,7 +854474,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_link_forgot": "忘記密碼？",
 
 
 
@@ -856189,7 +854601,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_or": "或",
 
 
 
@@ -856317,7 +854728,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_btn_google": "使用 Google 登入",
 
 
 
@@ -856445,7 +854855,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_btn_facebook": "使用 Facebook 登入",
 
 
 
@@ -856573,7 +854982,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_connected_accounts": "已連結帳號",
 
 
 
@@ -856701,7 +855109,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_label_confirm": "確認密碼",
 
 
 
@@ -856829,7 +855236,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_hint_password": "必須包含字母和數字",
 
 
 
@@ -856957,7 +855363,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_btn_create": "建立帳號",
 
 
 
@@ -857085,7 +855490,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_btn_creating": "建立中...",
 
 
 
@@ -857213,7 +855617,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_device_desc": "已經有 Android App 了嗎？從 設定 > 網頁版入口 輸入裝置憑證。",
 
 
 
@@ -857341,7 +855744,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_btn_device": "使用裝置登入",
 
 
 
@@ -857469,7 +855871,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_forgot_desc": "輸入 Email，我們將寄送重設連結給您。",
 
 
 
@@ -857597,7 +855998,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_btn_reset_link": "發送重設連結",
 
 
 
@@ -857725,7 +856125,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_link_back": "返回登入",
 
 
 
@@ -857853,7 +856252,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_reset_desc": "輸入您的新密碼。",
 
 
 
@@ -857981,7 +856379,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_btn_reset": "重設密碼",
 
 
 
@@ -858109,7 +856506,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_msg_fill_all": "請填寫所有欄位",
 
 
 
@@ -858237,7 +856633,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_msg_pass_match": "密碼不符",
 
 
 
@@ -858365,7 +856760,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_label_new_password": "新密碼",
 
 
 
@@ -858493,7 +856887,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_err_pw_length": "密碼至少 6 個字元",
 
 
 
@@ -858621,7 +857014,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_err_pw_letters": "密碼必須包含英文字母",
 
 
 
@@ -858749,7 +857141,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_err_pw_numbers": "密碼必須包含數字",
 
 
 
@@ -858877,7 +857268,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_msg_email_verified": "Email 已驗證！現在可以登入了。",
 
 
 
@@ -859005,7 +857395,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_link_resend": "重新寄送",
 
 
 
@@ -859133,7 +857522,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_msg_enter_email": "請輸入您的 Email",
 
 
 
@@ -859261,7 +857649,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_msg_reset_sent": "如果此 Email 存在，重設連結已寄出，請查看信箱。",
 
 
 
@@ -859389,7 +857776,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_msg_reset_done": "密碼已重設！現在可以登入了。",
 
 
 
@@ -859517,7 +857903,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_err_google_not_configured": "Google 登入尚未設定",
 
 
 
@@ -859645,7 +858030,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_err_facebook_not_configured": "Facebook 登入尚未設定",
 
 
 
@@ -859773,7 +858157,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_err_sdk_loading": "SDK 載入中...",
 
 
 
@@ -859901,7 +858284,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_err_sdk_failed": "Google SDK 載入失敗，重試中...",
 
 
 
@@ -860029,7 +858411,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_msg_verification_sent": "驗證信已寄出！請查看信箱。",
 
 
 
@@ -860157,7 +858538,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_title": "服務條款與隱私權政策",
 
 
 
@@ -860285,7 +858665,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_subtitle": "請閱讀並同意後才能建立帳號",
 
 
 
@@ -860413,7 +858792,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_section_tos": "服務條款",
 
 
 
@@ -860541,7 +858919,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_tos_welcome": "歡迎使用 E-Claw。建立帳號並使用我們的服務，即表示您同意以下條款：",
 
 
 
@@ -860669,7 +859046,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_tos_1": "您必須年滿 13 歲才能建立帳號。",
 
 
 
@@ -860797,7 +859173,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_tos_2": "您有責任維護帳號憑證的安全性。",
 
 
 
@@ -860925,7 +859300,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_tos_3": "您同意不將本服務用於任何違法或被禁止的活動。",
 
 
 
@@ -861053,7 +859427,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_tos_4": "我們保留暫停或終止違反條款之帳號的權利。",
 
 
 
@@ -861181,7 +859554,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_tos_5": "本服務按「現狀」提供，不附帶任何形式的保證。",
 
 
 
@@ -861309,7 +859681,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_tos_6": "我們可能會在事先通知的情況下隨時修改服務或本條款。",
 
 
 
@@ -861437,7 +859808,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_section_privacy": "隱私權政策",
 
 
 
@@ -861565,7 +859935,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_privacy_intro": "我們非常重視您的隱私。本政策說明我們如何收集、使用及保護您的個人資訊：",
 
 
 
@@ -861693,7 +860062,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_section_collect": "我們收集的資訊",
 
 
 
@@ -861821,7 +860189,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_collect_1": "帳號資訊：電子郵件地址及加密密碼。",
 
 
 
@@ -861949,7 +860316,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_collect_2": "裝置資訊：用於服務綁定的裝置識別碼。",
 
 
 
@@ -862077,7 +860443,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_collect_3": "使用數據：互動紀錄，用於改善服務品質。",
 
 
 
@@ -862205,7 +860570,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_section_use": "我們如何使用您的資訊",
 
 
 
@@ -862333,7 +860697,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_use_1": "提供及維護 E-Claw 服務。",
 
 
 
@@ -862461,7 +860824,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_use_2": "傳達重要的服務更新及通知。",
 
 
 
@@ -862589,7 +860951,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_use_3": "改善並個人化您的使用體驗。",
 
 
 
@@ -862717,7 +861078,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_use_4": "防止詐騙並確保平台安全。",
 
 
 
@@ -862845,7 +861205,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_section_protect": "資料保護",
 
 
 
@@ -862973,7 +861332,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_protect_1": "您的密碼以業界標準加密方式儲存。",
 
 
 
@@ -863101,7 +861459,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_protect_2": "我們不會為了行銷目的而向第三方出售或分享您的個人資訊。",
 
 
 
@@ -863229,7 +861586,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_protect_3": "您可以隨時要求刪除您的帳號及相關資料。",
 
 
 
@@ -863357,7 +861713,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_protect_4": "我們實施合理的安全措施，防止您的資料遭到未經授權的存取。",
 
 
 
@@ -863485,7 +861840,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_section_liability": "責任限制",
 
 
 
@@ -863613,7 +861967,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_liability_text": "在法律允許的最大範圍內，E-Claw 及其營運者對於因您使用本服務而產生的任何間接、附帶、特殊、衍生或懲罰性損害不承擔責任，包括但不限於資料遺失、服務中斷或帳號未經授權之存取。",
 
 
 
@@ -863741,7 +862094,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_section_contact": "聯絡我們",
 
 
 
@@ -863869,7 +862221,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_contact_text": "如果您對本條款或我們的隱私實踐有任何疑問，請透過應用程式的支援管道與我們聯繫。",
 
 
 
@@ -863997,7 +862348,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_full_privacy_link": "查看完整隱私權政策（GPS、語音訊息等）",
 
 
 
@@ -864125,7 +862475,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_btn_decline": "不同意",
 
 
 
@@ -864253,7 +862602,6 @@ const TRANSLATIONS = {
 
 
 
-        "terms_btn_agree": "我同意",
 
 
 
@@ -864381,7 +862729,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_title": "儀表板",
 
 
 
@@ -864509,7 +862856,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_loading": "載入實體中...",
 
 
 
@@ -864637,7 +862983,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_empty_title": "尚未綁定實體",
 
 
 
@@ -864765,7 +863110,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_empty_desc": "在下方新增您的第一個實體以開始使用！",
 
 
 
@@ -864893,7 +863237,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_add_entity": "新增實體",
 
 
 
@@ -865021,7 +863364,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_label_select_slot": "選擇實體插槽",
 
 
 
@@ -865149,7 +863491,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_channel_bind_warning": "2026-03 版本以上強烈建議使用 EClaw Channel 綁定，避免綁定失敗。",
 
 
 
@@ -865277,7 +863618,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_btn_generate": "產生代碼",
 
 
 
@@ -865405,7 +863745,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_btn_generating": "產生中...",
 
 
 
@@ -865533,7 +863872,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_btn_regenerate": "重新產生",
 
 
 
@@ -865661,7 +863999,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_btn_copy": "複製指令",
 
 
 
@@ -865789,27 +864126,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_channel_promo": "試試 EClaw Channel？更原生、更快速",
-        "dash_channel_card_openclaw_title": "OpenClaw Channel",
-        "dash_channel_card_openclaw_badge": "穩定",
-        "dash_channel_card_openclaw_desc": "官方 OpenClaw 外掛路徑 — 最適合託管式 OpenClaw bot 與正式 API key 設定。",
-        "dash_channel_card_codex_title": "Codex Channel",
-        "dash_channel_card_codex_badge": "CLI 橋接",
-        "dash_channel_card_codex_desc": "透過 codex app-server 將 EClaw 實體連接到 OpenAI Codex CLI。適合從 EClaw chat 遠端處理 repo 工作。",
-        "dash_channel_card_codex_step2": "填寫 .env：ECLAW_API_KEY、WEBHOOK_URL、CODEX_WORKSPACE",
-        "dash_channel_card_codex_guide_link": "Codex 指南 →",
-        "dash_channel_card_clauded_title": "Claude Code Channel",
-        "dash_channel_card_clauded_badge": "實驗性",
-        "dash_channel_card_clauded_desc": "在本機 tmux session 中以 EClaw bot 身分執行 Claude Code — 使用你的 claude.ai Max 訂閱額度，不計 Anthropic API token 費用。",
-        "dash_channel_card_clauded_step2": "填寫 .mcp.json：ECLAW_API_KEY、ECLAW_WEBHOOK_URL",
-        "dash_channel_card_clauded_guide_link": "Claude Code 指南 →",
-        "dash_channel_card_hermes_title": "Hermes Channel",
-        "dash_channel_card_hermes_badge": "Live Showcase",
-        "dash_channel_card_hermes_desc": "將 Hermes Agent（NousResearch self-evolving agent，Python）透過 webhook 綁定為你的 EClaw bot。支援 MiniMax / OpenAI / Anthropic / 本機 Ollama。",
-        "dash_channel_card_hermes_step1": "git clone .../hermes-eclaw-channel",
-        "dash_channel_card_hermes_step2": "./scripts/setup-tunnel.sh hermes-b ...",
-        "dash_channel_card_hermes_step3": "bind-entity + 啟動 daemon",
-        "dash_channel_card_hermes_guide_link": "Hermes 指南 →",
 
 
 
@@ -865937,7 +864253,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_invite_title": "邀請好友，每位註冊賺 500 e幣",
 
 
 
@@ -866065,7 +864380,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_invite_subtitle": "好友也能獲得 100 e幣。立即分享你的邀請碼。",
 
 
 
@@ -866193,7 +864507,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_invite_cta": "查看我的邀請碼",
 
 
 
@@ -866321,7 +864634,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_channel_step_intro": "在 OpenClaw 終端機中：",
 
 
 
@@ -866449,7 +864761,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_channel_step3": "選擇「EClaw」",
 
 
 
@@ -866577,7 +864888,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_channel_learn_more": "了解更多",
 
 
 
@@ -866705,7 +865015,6 @@ const TRANSLATIONS = {
 
 
 
-        "channel_ai_agent_hint": "🤖 強烈建議使用 Claude Code 等 AI Agent 進行輔助安裝。",
 
 
 
@@ -866833,7 +865142,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_channel_no_entities": "未綁定任何實體",
 
 
 
@@ -866961,7 +865269,6 @@ const TRANSLATIONS = {
 
 
 
-        "dashboard_entities_bound": "個已綁定實體",
 
 
 
@@ -867089,7 +865396,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_code_expired": "代碼已過期 - 請重新產生",
 
 
 
@@ -867217,7 +865523,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_code_expires_in": "{s} 後過期",
 
 
 
@@ -867345,7 +865650,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_btn_remove": "刪除",
 
 
 
@@ -867473,7 +865777,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_remove_title": "刪除實體",
 
 
 
@@ -867601,7 +865904,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_remove_desc": "確定要刪除 <strong>{name}</strong> (#{id}) 嗎？此實體欄位將被永久移除。",
 
 
 
@@ -867729,7 +866031,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_overwrite_title": "取代現有實體",
 
 
 
@@ -867857,7 +866158,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_overwrite_desc": "插槽 {id} 目前綁定了 <strong>{name}</strong>。產生新的綁定碼後，當新的 Bot 連線時將取代現有的 Bot。確定要繼續嗎？",
 
 
 
@@ -867985,7 +866285,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_btn_overwrite": "取代",
 
 
 
@@ -868113,7 +866412,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_btn_refresh": "重新連線",
 
 
 
@@ -868241,7 +866539,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_refreshing": "連線中...",
 
 
 
@@ -868369,7 +866666,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_refresh_success": "連線已刷新！",
 
 
 
@@ -868497,7 +866793,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_restart_success": "🔄 通道已成功重啟",
 
 
 
@@ -868625,7 +866920,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_restart_failed": "⚠️ 通道重啟失敗",
 
 
 
@@ -868753,7 +867047,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_refresh_cooldown": "請等待 {s} 秒後再試",
 
 
 
@@ -868881,7 +867174,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_refresh_broken_title": "連線中斷",
 
 
 
@@ -869009,7 +867301,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_refresh_broken_message": "機器人的 Webhook 連線似乎已中斷。是否要重新綁定此實體？",
 
 
 
@@ -869137,7 +867428,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_refresh_broken_rebind": "重新綁定",
 
 
 
@@ -869265,7 +867555,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_reorder_saving": "正在儲存新順序...",
 
 
 
@@ -869393,7 +867682,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_reorder_success": "實體順序已更新！",
 
 
 
@@ -869521,7 +867809,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_reorder_failed": "儲存實體順序失敗",
 
 
 
@@ -869649,7 +867936,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_drag_to_reorder": "拖曳以重新排序",
 
 
 
@@ -869777,7 +868063,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_settings": "跨裝置訊息",
 
 
 
@@ -869905,7 +868190,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_title": "跨裝置訊息管理",
 
 
 
@@ -870033,7 +868317,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_pre_inject": "預注入指令",
 
 
 
@@ -870161,7 +868444,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_pre_inject_hint": "加在收到的跨裝置訊息前面的指令...",
 
 
 
@@ -870289,7 +868571,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_pre_inject_desc": "會在推播通知中加在跨裝置訊息之前",
 
 
 
@@ -870417,7 +868698,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_forbidden": "禁止詞",
 
 
 
@@ -870545,7 +868825,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_forbidden_desc": "包含這些詞的訊息會被拒絕",
 
 
 
@@ -870673,7 +868952,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_comma_sep": "以逗號分隔",
 
 
 
@@ -870801,7 +869079,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_rate_limit": "頻率限制（秒）",
 
 
 
@@ -870929,7 +869206,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_rate_limit_desc": "同一發送者的冷卻時間（0 = 不限制）",
 
 
 
@@ -871057,7 +869333,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_blacklist": "黑名單（公開代碼）",
 
 
 
@@ -871185,7 +869460,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_codes_sep": "以逗號分隔的公開代碼",
 
 
 
@@ -871313,7 +869587,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_whitelist_mode": "白名單模式",
 
 
 
@@ -871441,7 +869714,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_whitelist": "白名單（公開代碼）",
 
 
 
@@ -871569,7 +869841,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_reject_msg": "拒絕訊息",
 
 
 
@@ -871697,7 +869968,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_reject_msg_hint": "被擋下時的自動回覆（空白 = 靜默）",
 
 
 
@@ -871825,7 +870095,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_allowed_media": "允許的媒體類型",
 
 
 
@@ -871953,7 +870222,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_save": "儲存",
 
 
 
@@ -872081,7 +870349,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_reset": "還原預設值",
 
 
 
@@ -872209,7 +870476,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_saved": "跨裝置訊息設定已儲存！",
 
 
 
@@ -872337,7 +870603,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_reset_confirm": "確定要還原所有跨裝置訊息設定為預設值嗎？",
 
 
 
@@ -872465,7 +870730,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_xd_reset_done": "設定已還原為預設值",
 
 
 
@@ -872593,7 +870857,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_btn": "身分設定",
 
 
 
@@ -872721,7 +870984,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_title": "Bot 身分",
 
 
 
@@ -872849,7 +871111,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_role": "角色",
 
 
 
@@ -872977,7 +871238,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_role_hint": "例：客服助理",
 
 
 
@@ -873105,7 +871365,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_desc": "描述",
 
 
 
@@ -873233,7 +871492,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_desc_hint": "描述此 Bot 的職責...",
 
 
 
@@ -873361,7 +871619,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_instructions": "指令",
 
 
 
@@ -873489,7 +871746,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_instr_hint": "新增一條指令...",
 
 
 
@@ -873617,7 +871873,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_boundaries": "限制",
 
 
 
@@ -873745,7 +872000,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_bound_hint": "新增一條限制...",
 
 
 
@@ -873873,7 +872127,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_tone": "語氣",
 
 
 
@@ -874001,7 +872254,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_tone_hint": "例：友善、專業、隨性",
 
 
 
@@ -874129,7 +872381,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_language": "語言",
 
 
 
@@ -874257,7 +872508,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_lang_hint": "例：zh-TW, en",
 
 
 
@@ -874385,7 +872635,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_public_title": "公開檔案（Agent Card）",
 
 
 
@@ -874513,7 +872762,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_public_desc": "公開描述",
 
 
 
@@ -874641,7 +872889,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_public_desc_hint": "Agent Card 的公開描述...",
 
 
 
@@ -874769,7 +873016,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_plaza_publish": "上架到 Bot Plaza",
 
 
 
@@ -874897,7 +873143,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_plaza_publish_hint": "將此 Bot 公開上架，讓其他人可以發現和互動",
 
 
 
@@ -875025,7 +873270,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_plaza_published": "已上架到 Bot Plaza！",
 
 
 
@@ -875153,7 +873397,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_plaza_unpublished": "已從 Bot Plaza 下架",
 
 
 
@@ -875281,7 +873524,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_save": "儲存身分",
 
 
 
@@ -875409,7 +873651,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_clear": "清除",
 
 
 
@@ -875537,7 +873778,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_capabilities": "能力",
 
 
 
@@ -875665,7 +873905,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_caps_arena_only": "由 Arena 評測驗證 — 不可編輯",
 
 
 
@@ -875793,7 +874032,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_caps_none": "尚無 Arena 評測結果。請執行 Arena 測試來驗證能力。",
 
 
 
@@ -875921,7 +874159,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_run_interview": "執行面試",
 
 
 
@@ -876049,7 +874286,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_run_arena": "📝 評測中心（瀏覽器 Agent）",
 
 
 
@@ -876177,7 +874413,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_list_rental": "上架出租",
 
 
 
@@ -876305,7 +874540,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_listing_exists": "此 Entity 已有上架清單",
 
 
 
@@ -876433,7 +874667,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_listing_rate_prompt": "設定費率（每 1K token 的 e幣）：",
 
 
 
@@ -876561,7 +874794,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_listing_created": "上架清單已建立！請執行面試以取得發布資格。",
 
 
 
@@ -876689,7 +874921,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_listing_published": "已上架出租！",
 
 
 
@@ -876817,7 +875048,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_interview_required_first": "請先執行面試，通過後才能上架出租。",
 
 
 
@@ -876945,7 +875175,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_interview_not_passed_yet": "面試尚未通過 — 請先完成面試才能設定費率。",
 
 
 
@@ -877073,7 +875302,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_interview_no_listing": "無法建立上架清單",
 
 
 
@@ -877201,7 +875429,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_interview_running": "面試中...",
 
 
 
@@ -877329,7 +875556,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_interview_progress": "正在透過 webhook 發送 8 道探針給你的 bot... 約需 30-90 秒。",
 
 
 
@@ -877457,7 +875683,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_interview_score": "分數",
 
 
 
@@ -877585,7 +875810,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_interview_passed": "通過！能力已鎖定在 Agent Card。",
 
 
 
@@ -877713,7 +875937,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_interview_failed": "未通過，最低需 60%。",
 
 
 
@@ -877841,7 +876064,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_interview_view_results": "查看成績 →",
 
 
 
@@ -877969,7 +876191,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_saved": "身分已儲存",
 
 
 
@@ -878097,7 +876318,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_cleared": "身分已清除",
 
 
 
@@ -878225,7 +876445,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_clear_confirm": "清除 Entity # 的身分設定？",
 
 
 
@@ -878353,7 +876572,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_id_validation": "至少需要填寫角色、描述或公開檔案",
 
 
 
@@ -878481,7 +876699,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_slot_occupied": "插槽 {id} 已被佔用",
 
 
 
@@ -878609,7 +876826,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_entity_bound": "{count} / {max} 已綁定",
 
 
 
@@ -878737,7 +876953,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_avatar_title": "選擇頭像",
 
 
 
@@ -878865,7 +877080,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_avatar_desc": "選擇表情符號或上傳照片",
 
 
 
@@ -878993,7 +877207,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_avatar_upload": "上傳照片",
 
 
 
@@ -879121,7 +877334,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_avatar_drop_hint": "點擊或拖曳圖片到此處",
 
 
 
@@ -879249,7 +877461,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_avatar_confirm": "使用此照片",
 
 
 
@@ -879377,7 +877588,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_avatar_uploading": "上傳中...",
 
 
 
@@ -879505,7 +877715,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_avatar_uploaded": "頭像已更新！",
 
 
 
@@ -879633,7 +877842,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_avatar_too_large": "圖片大小不可超過 5 MB",
 
 
 
@@ -879761,7 +877969,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_avatar_remove": "移除照片",
 
 
 
@@ -879889,7 +878096,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_avatar_removed": "照片已移除",
 
 
 
@@ -880017,7 +878223,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_code_copied": "指令已複製到剪貼簿！",
 
 
 
@@ -880145,7 +878350,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "代碼",
 
 
 
@@ -880273,7 +878477,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_copy_code": "點擊複製公開代碼",
 
 
 
@@ -880401,7 +878604,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code_copied": "公開代碼已複製！",
 
 
 
@@ -880529,7 +878731,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_code_generated": "已產生綁定代碼！",
 
 
 
@@ -880657,7 +878858,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_entity_removed": "實體已成功移除",
 
 
 
@@ -880785,7 +878985,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_no_messages": "尚無訊息",
 
 
 
@@ -880913,7 +879112,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_rename_title": "更改名稱",
 
 
 
@@ -881041,7 +879239,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_rename_placeholder": "輸入新名稱（最多 20 字）",
 
 
 
@@ -881169,7 +879366,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_rename_save": "儲存",
 
 
 
@@ -881297,7 +879493,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_rename_saving": "儲存中...",
 
 
 
@@ -881425,7 +879620,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_rename_success": "名稱已更新！",
 
 
 
@@ -881553,7 +879747,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_err_load_entities": "無法載入實體",
 
 
 
@@ -881681,7 +879874,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_slot": "Slot",
 
 
 
@@ -881809,7 +880001,6 @@ const TRANSLATIONS = {
 
 
 
-        "dash_new_slot": "新增 Slot",
 
 
 
@@ -881937,7 +880128,6 @@ const TRANSLATIONS = {
 
 
 
-        "org_tab_entities": "實體總覽",
 
 
 
@@ -882065,7 +880255,6 @@ const TRANSLATIONS = {
 
 
 
-        "org_tab_chart": "組織架構",
 
 
 
@@ -882193,7 +880382,6 @@ const TRANSLATIONS = {
 
 
 
-        "org_title": "組織架構圖",
 
 
 
@@ -882321,7 +880509,6 @@ const TRANSLATIONS = {
 
 
 
-        "org_user_node": "你（擁有者）",
 
 
 
@@ -882449,7 +880636,6 @@ const TRANSLATIONS = {
 
 
 
-        "org_drag_hint": "將實體拖放到另一個上方以設定層級",
 
 
 
@@ -882577,7 +880763,6 @@ const TRANSLATIONS = {
 
 
 
-        "org_saved": "組織架構已儲存",
 
 
 
@@ -882705,7 +880890,6 @@ const TRANSLATIONS = {
 
 
 
-        "org_reset": "重設為預設",
 
 
 
@@ -882833,7 +881017,6 @@ const TRANSLATIONS = {
 
 
 
-        "org_reset_confirm": "確定要重設組織架構為儲存的預設值嗎？",
 
 
 
@@ -882961,7 +881144,6 @@ const TRANSLATIONS = {
 
 
 
-        "org_reparent_confirm": "要將 {child} 設為 {parent} 的下屬嗎？",
 
 
 
@@ -883089,7 +881271,6 @@ const TRANSLATIONS = {
 
 
 
-        "org_opt_none_title": "無",
 
 
 
@@ -883217,7 +881398,6 @@ const TRANSLATIONS = {
 
 
 
-        "org_opt_none_desc": "不啟用任何層級行為",
 
 
 
@@ -883345,7 +881525,6 @@ const TRANSLATIONS = {
 
 
 
-        "org_opt1_title": "低干擾",
 
 
 
@@ -883473,7 +881652,6 @@ const TRANSLATIONS = {
 
 
 
-        "org_opt1_desc": "上級自動成為看板任務的審核者",
 
 
 
@@ -883601,7 +881779,6 @@ const TRANSLATIONS = {
 
 
 
-        "org_opt2_title": "建議",
 
 
 
@@ -883729,7 +881906,6 @@ const TRANSLATIONS = {
 
 
 
-        "org_opt2_desc": "有未完成看板任務時，訊息自動路由給上級",
 
 
 
@@ -883857,7 +882033,6 @@ const TRANSLATIONS = {
 
 
 
-        "org_opt3_title": "緊迫盯人",
 
 
 
@@ -883985,7 +882160,6 @@ const TRANSLATIONS = {
 
 
 
-        "org_opt3_desc": "上級自動成為看板任務的審核者且所有訊息自動路由給上級",
 
 
 
@@ -884113,7 +882287,6 @@ const TRANSLATIONS = {
 
 
 
-        "org_min_entities": "需要 2 個以上實體才能使用組織架構",
 
 
 
@@ -884241,7 +882414,6 @@ const TRANSLATIONS = {
 
 
 
-        "webhook_error_title": "推播通知失敗",
 
 
 
@@ -884369,7 +882541,6 @@ const TRANSLATIONS = {
 
 
 
-        "webhook_error_message": "請將以下訊息貼給OpenClaw：\"webhook綁定有錯誤或是沒有使用POST /api/bot/register，請重新讀取'公開webhook URL'(gateway config) 以及重新讀取'gateway token'，立即呼叫 /api/bot/register: 用剛綁到的 deviceId/entityId/botSecret 再帶上 webhook_url、gateway token 把推播註冊好。\"",
 
 
 
@@ -884497,7 +882668,6 @@ const TRANSLATIONS = {
 
 
 
-        "message_copied": "訊息已複製",
 
 
 
@@ -884625,7 +882795,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_title": "官方 Bot 租用",
 
 
 
@@ -884753,7 +882922,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_desc": "為您的實體租用官方 Bot。Bot 會自動與您的動態桌布互動。",
 
 
 
@@ -884881,7 +883049,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_select_entity": "選擇實體",
 
 
 
@@ -885009,7 +883176,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_free_title": "免費版",
 
 
 
@@ -885137,7 +883303,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_free_desc": "每個裝置限一個免費 Bot",
 
 
 
@@ -885265,7 +883430,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_select_bot": "選擇機器人：",
 
 
 
@@ -885393,7 +883557,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_active_users": "使用中人數",
 
 
 
@@ -885521,7 +883684,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_free_feat_shared": "與所有免費用戶共用記憶",
 
 
 
@@ -885649,7 +883811,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_free_feat_limit": "無限訊息（無每日上限）",
 
 
 
@@ -885777,7 +883938,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_free_available": "可用",
 
 
 
@@ -885905,7 +884065,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_free_unavailable": "無可用的免費 Bot",
 
 
 
@@ -886033,7 +884192,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_free_bound_other": "已綁定在 Entity #{id}",
 
 
 
@@ -886161,7 +884319,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_personal_title": "月租版",
 
 
 
@@ -886289,7 +884446,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_personal_desc": "專屬個人 Bot",
 
 
 
@@ -886417,7 +884573,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_personal_feat_dedicated": "獨立雲端環境",
 
 
 
@@ -886545,7 +884700,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_personal_feat_memory": "專屬記憶（只屬於你）",
 
 
 
@@ -886673,7 +884827,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_personal_feat_unlimited": "無限訊息（無每日限制）",
 
 
 
@@ -886801,7 +884954,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_personal_feat_247": "24/7 全天候在線",
 
 
 
@@ -886929,7 +885081,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_price_period": "/月",
 
 
 
@@ -887057,7 +885208,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_discount_label": "Beta 限時折扣",
 
 
 
@@ -887185,7 +885335,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_personal_available": "剩餘 {count} 個可用",
 
 
 
@@ -887313,7 +885462,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_personal_sold_out": "已售完",
 
 
 
@@ -887441,7 +885589,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_btn_bind_free": "使用免費版",
 
 
 
@@ -887569,7 +885716,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_btn_bind_personal": "購買月租版",
 
 
 
@@ -887697,7 +885843,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_btn_rebind_free": "重新綁定（免費）",
 
 
 
@@ -887825,7 +885970,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_btn_pay": "付款 NT$288",
 
 
 
@@ -887953,7 +886097,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_btn_unbind": "解除綁定",
 
 
 
@@ -888081,7 +886224,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_btn_binding": "綁定中...",
 
 
 
@@ -888209,7 +886351,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_btn_handshaking": "正在與機器人交握中...",
 
 
 
@@ -888337,7 +886478,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_btn_connected": "連接成功！",
 
 
 
@@ -888465,7 +886605,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_btn_unbinding": "解除中...",
 
 
 
@@ -888593,7 +886732,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_btn_request_rental": "提出租用需求",
 
 
 
@@ -888721,7 +886859,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_free_limit_hint": "每個裝置僅能綁定一個免費版 Bot",
 
 
 
@@ -888849,7 +886986,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_sold_out_title": "已售完",
 
 
 
@@ -888977,7 +887113,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_sold_out_message": "月租版 Bot 目前已售完。\n\n您可以提出租用需求申請，我們會在有名額時通知您（通常需要 1-2 個工作天）。",
 
 
 
@@ -889105,7 +887240,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_sold_out_submit": "提出申請",
 
 
 
@@ -889233,7 +887367,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_sold_out_cancel": "取消",
 
 
 
@@ -889361,7 +887494,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_rental_demand_success": "已發出租用需求，等待回覆，通常需要 1-2 個工作天。",
 
 
 
@@ -889489,7 +887621,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_rental_demand_fail": "發送失敗，請重試。",
 
 
 
@@ -889617,7 +887748,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_bound_free": "已綁定免費 Bot",
 
 
 
@@ -889745,7 +887875,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_bound_personal": "已綁定月租 Bot",
 
 
 
@@ -889873,7 +888002,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_slot_occupied": "此實體插槽已有一般綁定",
 
 
 
@@ -890001,7 +888129,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_bind_success": "官方 Bot 綁定成功！",
 
 
 
@@ -890129,7 +888256,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_unbind_success": "已成功解除官方 Bot 綁定",
 
 
 
@@ -890257,7 +888383,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_unbind_title": "解除官方 Bot 綁定",
 
 
 
@@ -890385,7 +888510,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_unbind_desc": "確定要解除 Entity #{id} 的官方 Bot 嗎？Bot 將歸還到池中。",
 
 
 
@@ -890513,7 +888637,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_current_bindings": "目前綁定",
 
 
 
@@ -890641,7 +888764,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_no_bindings": "尚未綁定官方 Bot",
 
 
 
@@ -890769,7 +888891,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_type_free": "免費版",
 
 
 
@@ -890897,7 +889018,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_type_personal": "月租版",
 
 
 
@@ -891025,7 +889145,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_entity_has_binding": "已有官方 Bot",
 
 
 
@@ -891153,7 +889272,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_pay_title": "官方 Bot 租用 - NT$288/月",
 
 
 
@@ -891281,7 +889399,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_pay_desc": "輸入信用卡資訊以租用專屬個人 Bot（NT$288/月）。含無限訊息及 24/7 全天候在線。",
 
 
 
@@ -891409,7 +889526,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_cost_title": "為什麼租用？自建成本比較",
 
 
 
@@ -891537,7 +889653,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_cost_eclaw": "EClawbot 官方 Bot",
 
 
 
@@ -891665,7 +889780,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_cost_eclaw_price": "NT$288/月",
 
 
 
@@ -891793,7 +889907,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_cost_24_7": "24/7 穩定不斷線",
 
 
 
@@ -891921,7 +890034,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_cost_included": "已包含",
 
 
 
@@ -892049,7 +890161,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_cost_server": "雲端伺服器 (Railway/AWS)",
 
 
 
@@ -892177,7 +890288,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_cost_llm": "LLM API (OpenAI/Claude)",
 
 
 
@@ -892305,7 +890415,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_cost_setup": "自行摸索 OpenClaw 部署",
 
 
 
@@ -892433,7 +890542,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_cost_priceless": "無價的時間",
 
 
 
@@ -892561,7 +890669,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_tos_title": "免費版機器人使用規範",
 
 
 
@@ -892689,7 +890796,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_tos_agree": "我同意",
 
 
 
@@ -892817,7 +890923,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_tos_decline": "不同意",
 
 
 
@@ -892945,7 +891050,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_tos_loading": "載入使用規範中...",
 
 
 
@@ -893073,7 +891177,6 @@ const TRANSLATIONS = {
 
 
 
-        "borrow_tos_required": "使用免費版機器人前，請先閱讀並同意使用規範。",
 
 
 
@@ -893201,7 +891304,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_title": "設定",
 
 
 
@@ -893329,7 +891431,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_account": "帳號",
 
 
 
@@ -893457,7 +891558,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_email": "Email",
 
 
 
@@ -893585,7 +891685,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_device_id": "Device ID",
 
 
 
@@ -893713,7 +891812,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_device_secret": "Device Secret",
 
 
 
@@ -893841,7 +891939,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_copy_credentials": "複製憑證",
 
 
 
@@ -893969,7 +892066,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_switch_device": "🔁 切換裝置",
 
 
 
@@ -894097,7 +892193,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_switch_device_hint": "讓這個瀏覽器登入另一組 Device ID，常用於你有第二個管理員帳號、entity 在不同 device 上。",
 
 
 
@@ -894225,7 +892320,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_switch_device_title": "切換裝置",
 
 
 
@@ -894353,7 +892447,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_switch_device_body": "輸入要登入的帳號之 Device ID 與 Device Secret。本瀏覽器將登出目前裝置。",
 
 
 
@@ -894481,7 +892574,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_switch_device_confirm": "切換",
 
 
 
@@ -894609,7 +892701,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_switch_device_required": "Device ID 與 Device Secret 為必填。",
 
 
 
@@ -894737,7 +892828,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_switch_device_failed": "Device ID 或 Device Secret 不正確。",
 
 
 
@@ -894865,7 +892955,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_switch_device_network_error": "切換裝置時網路錯誤，請再試一次。",
 
 
 
@@ -894993,7 +893082,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_sub": "訂閱",
 
 
 
@@ -895121,7 +893209,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_sub_premium": "高級會員",
 
 
 
@@ -895249,7 +893336,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_sub_free": "免費版",
 
 
 
@@ -895377,7 +893463,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_usage_today": "今日訊息",
 
 
 
@@ -895505,7 +893590,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_usage_unlimited": "今日已送 {used} 則 (無限制)",
 
 
 
@@ -895633,7 +893717,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_usage_limit": "今日已送 {used} 則",
 
 
 
@@ -895761,7 +893844,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_renews_on": "續約日期：{date}",
 
 
 
@@ -895889,7 +893971,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_price": "NT$99",
 
 
 
@@ -896017,7 +894098,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_period": "每月",
 
 
 
@@ -896145,7 +894225,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_sub_benefit_1": "✓ 無限訊息（無每日 15 則限制）",
 
 
 
@@ -896273,7 +894352,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_sub_benefit_2": "✓ 實體上限增加至 8 個（原為 4 個）",
 
 
 
@@ -896401,7 +894479,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_btn_subscribe": "訂閱",
 
 
 
@@ -896529,7 +894606,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_btn_hide_card": "隱藏卡片表格",
 
 
 
@@ -896657,7 +894733,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_label_card": "卡號",
 
 
 
@@ -896785,7 +894860,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_label_expiry": "到期日",
 
 
 
@@ -896913,7 +894987,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_label_ccv": "CCV",
 
 
 
@@ -897041,7 +895114,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_btn_pay": "支付 NT$99",
 
 
 
@@ -897169,7 +895241,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_processing": "處理付款中...",
 
 
 
@@ -897297,7 +895368,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_btn_cancel": "取消訂閱",
 
 
 
@@ -897425,7 +895495,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_btn_cancelling": "取消中...",
 
 
 
@@ -897553,7 +895622,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_cancel_title": "取消訂閱",
 
 
 
@@ -897681,7 +895749,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_cancel_desc": "您的高級會員資格將保留至本期結束。之後將恢復為免費版（共享機器人、無限訊息）。",
 
 
 
@@ -897809,7 +895876,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_btn_keep": "保留訂閱",
 
 
 
@@ -897937,7 +896003,6 @@ const TRANSLATIONS = {
 
 
 
-        "maintenance_payment_title": "付款功能維護中",
 
 
 
@@ -898065,7 +896130,6 @@ const TRANSLATIONS = {
 
 
 
-        "maintenance_payment_desc": "付款功能目前正在維護中，請稍後再試。",
 
 
 
@@ -898193,7 +896257,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_lang": "語言",
 
 
 
@@ -898321,7 +896384,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_display": "顯示",
 
 
 
@@ -898449,7 +896511,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_view_mode": "頁面模式",
 
 
 
@@ -898577,7 +896638,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_view_mode_desc": "僅限桌面版（≥1200px）",
 
 
 
@@ -898705,7 +896765,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_view_single": "單頁模式",
 
 
 
@@ -898833,7 +896892,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_view_split": "雙頁模式",
         "settings_chat_preferences": "聊天偏好設定",
         "settings_chat_avatar_size": "聊天大頭貼大小",
         "settings_chat_avatar_size_desc": "只影響聊天清單、聊天標題列與訊息大頭貼",
@@ -899002,7 +897060,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_lang_changed": "語言已變更，重新載入中...",
 
 
 
@@ -899130,7 +897187,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_version": "版本",
 
 
 
@@ -899258,7 +897314,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_privacy_link": "隱私權政策",
 
 
 
@@ -899386,7 +897441,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_privacy_title": "隱私權政策",
 
 
 
@@ -899514,7 +897568,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_privacy_content": "<b>1. 隱私權至上承諾</b><br>E-claw (電子蝦) 團隊深知隱私對您的重要性。我們在此鄭重聲明：<b>我們絕不會販賣、洩露或濫用您的任何個人資料。</b><br><br><b>2. 我們收集什麼資料？</b><br>為了提供服務，我們僅收集運作所需的最少資料：<br>- 裝置 ID：用於區分不同裝置。<br>- App 版本：用於相容性檢查。<br>- 綁定資料：Agent 名稱與狀態。<br><br><b>我們「不」收集：</b><br>- 您的姓名、電話或 Email。<br>- 您的 GPS 位置。<br>- 您的相機或麥克風資料。<br><br><b>3. OpenClaw 協議</b><br>我們是 OpenClaw 生態系統的堅定支持者。我們不會建立封閉的「圍牆花園」，並承諾保持互通性。<br><br><b>4. AI 對話隱私</b><br>訊息透過加密 HTTPS 傳送至您綁定的 AI Agent。資料流向由您掌控。<br><br><b>5. 聯絡我們</b><br>如有任何疑問，請透過我們的官方 Email 聯繫。",
 
 
 
@@ -899642,7 +897695,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_feedback_title": "意見回饋",
 
 
 
@@ -899770,7 +897822,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_feedback_desc": "發現 Bug 或有任何建議？告訴我們！",
 
 
 
@@ -899898,7 +897949,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_btn_feedback": "傳送回饋",
 
 
 
@@ -900026,7 +898076,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_feedback_hint": "在此輸入您的回饋...",
 
 
 
@@ -900154,7 +898203,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_feedback_sent": "回饋已傳送！謝謝您。",
 
 
 
@@ -900282,7 +898330,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_btn_send_feedback": "傳送",
 
 
 
@@ -900410,7 +898457,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_feedback_cancel": "取消",
 
 
 
@@ -900538,7 +898584,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_feedback_view_history": "查看回饋紀錄",
 
 
 
@@ -900666,7 +898711,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_title": "通知",
 
 
 
@@ -900794,7 +898838,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_mark_all": "全部標為已讀",
 
 
 
@@ -900922,7 +898965,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_empty": "目前沒有通知",
 
 
 
@@ -901050,7 +899092,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_bot_reply": "Bot 回覆",
 
 
 
@@ -901178,7 +899219,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_speak_to": "實體訊息",
 
 
 
@@ -901306,7 +899346,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_broadcast": "廣播",
 
 
 
@@ -901434,7 +899473,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_feedback_resolved": "意見已解決",
 
 
 
@@ -901562,7 +899600,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_feedback_reply": "意見回覆",
 
 
 
@@ -901690,7 +899727,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_todo_done": "TODO 已完成",
 
 
 
@@ -901818,7 +899854,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_scheduled": "排程訊息",
 
 
 
@@ -901946,7 +899981,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_settings_title": "通知偏好設定",
 
 
 
@@ -902074,7 +900108,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_settings_desc": "選擇您想接收的通知類別。",
 
 
 
@@ -902202,7 +900235,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_pref_bot_reply": "Bot 回覆",
 
 
 
@@ -902330,7 +900362,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_pref_broadcast": "廣播訊息",
 
 
 
@@ -902458,7 +900489,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_pref_speak_to": "實體對話",
 
 
 
@@ -902586,7 +900616,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_pref_feedback": "意見回饋更新",
 
 
 
@@ -902714,7 +900743,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_pref_todo": "TODO 完成",
 
 
 
@@ -902842,7 +900870,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_pref_scheduled": "排程訊息",
 
 
 
@@ -902970,7 +900997,6 @@ const TRANSLATIONS = {
 
 
 
-        "developer_section_title": "開發者",
 
 
 
@@ -903098,7 +901124,6 @@ const TRANSLATIONS = {
 
 
 
-        "broadcast_settings_title": "廣播設定",
 
 
 
@@ -903226,7 +901251,6 @@ const TRANSLATIONS = {
 
 
 
-        "broadcast_settings_desc": "設定廣播訊息的運作方式",
 
 
 
@@ -903354,7 +901378,6 @@ const TRANSLATIONS = {
 
 
 
-        "broadcast_pref_recipient_info": "在廣播中顯示接收者列表",
 
 
 
@@ -903482,7 +901505,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_nudge_title": "看板卡片督促",
 
 
 
@@ -903610,7 +901632,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_nudge_desc": "對所有實體一視同仁。",
 
 
 
@@ -903738,7 +901759,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_nudge_batch_label": "每次督促張數",
 
 
 
@@ -903866,7 +901886,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_nudge_priority_label": "優先權模式",
 
 
 
@@ -903994,7 +902013,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_nudge_priority_mode_level": "層級優先 (P0 > P1 > P2)",
 
 
 
@@ -904122,7 +902140,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_nudge_priority_mode_column": "欄位順序 (審查 > 進行 > 代辦)",
 
 
 
@@ -904250,7 +902267,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_nudge_priority_mode_both": "順序 + 層級 (審查 P2 > 進行 P1 > 代辦 P0)",
 
 
 
@@ -904378,7 +902394,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_nudge_statuses_label": "督促哪些欄位",
 
 
 
@@ -904506,7 +902521,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_status_backlog": "待排程",
 
 
 
@@ -904634,7 +902648,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_status_todo": "代辦",
 
 
 
@@ -904762,7 +902775,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_status_in_progress": "進行",
 
 
 
@@ -904890,7 +902902,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_status_review": "審查",
 
 
 
@@ -905146,7 +903157,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_nudge_interval_label": "督促間隔",
 
 
 
@@ -905274,7 +903284,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_nudge_interval_hour": "時",
 
 
 
@@ -905402,7 +903411,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_nudge_interval_min": "分",
 
 
 
@@ -905530,7 +903538,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_nudge_need_status": "至少要勾選一個欄位才能督促",
 
 
 
@@ -905658,7 +903665,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_nudge_settings_title": "督促設定",
 
 
 
@@ -905786,7 +903792,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_nudge_advanced_label": "兩種督促開關",
 
 
 
@@ -905914,7 +903919,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_nudge_advanced_desc": "🅰️ 內容督促（卡片停滯）vs 🅱️ 排程觸發（cron 母卡）— 各自獨立。",
 
 
 
@@ -906042,7 +904046,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_nudge_per_entity_throttle_label": "🅰️ 內容督促：同一實體一個間隔最多 1 張",
 
 
 
@@ -906170,7 +904173,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_cron_recurring_notify_label": "🅱️ 排程母卡自身重複觸發時通知（無子卡）",
 
 
 
@@ -906298,7 +904300,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_broadcast_tag": "廣播",
 
 
 
@@ -906426,7 +904427,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_kanban_notify": "看板",
 
 
 
@@ -906810,7 +904810,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_kanban_view_card": "📋 查看卡片",
 
 
 
@@ -906938,7 +904937,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_card_modal_comments": "留言",
 
 
 
@@ -907066,7 +905064,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_card_modal_comments_empty": "還沒有留言",
 
 
 
@@ -907194,7 +905191,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_form_submission": "表單",
 
 
 
@@ -907322,7 +905318,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_push_enable": "啟用瀏覽器推播",
 
 
 
@@ -907450,7 +905445,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_push_enabled": "推播已啟用",
 
 
 
@@ -907578,7 +905572,6 @@ const TRANSLATIONS = {
 
 
 
-        "notif_push_disabled": "推播已停用",
 
 
 
@@ -907706,7 +905699,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_title": "我的回饋",
 
 
 
@@ -907834,7 +905826,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_loading": "載入回饋中...",
 
 
 
@@ -907962,7 +905953,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_empty": "尚未提交任何回饋",
 
 
 
@@ -908090,7 +906080,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_empty_sub": "您提交的回饋將顯示於此。",
 
 
 
@@ -908218,7 +906207,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_cat_bug": "Bug",
 
 
 
@@ -908346,7 +906334,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_cat_feature": "功能建議",
 
 
 
@@ -908474,7 +906461,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_cat_question": "提問",
 
 
 
@@ -908602,7 +906588,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_severity": "嚴重程度",
 
 
 
@@ -908730,7 +906715,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_status": "狀態",
 
 
 
@@ -908858,7 +906842,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_status_open": "處理中",
 
 
 
@@ -908986,7 +906969,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_status_resolved": "已解決",
 
 
 
@@ -909114,7 +907096,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_status_closed": "已關閉",
 
 
 
@@ -909242,7 +907223,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_status_in_progress": "處理中",
 
 
 
@@ -909370,7 +907350,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_view_issue": "查看 GitHub Issue",
 
 
 
@@ -909498,7 +907477,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_filter_all": "全部",
 
 
 
@@ -909626,7 +907604,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_submitted_at": "提交時間",
 
 
 
@@ -909754,7 +907731,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_auto_log_hint": "系統將自動擷取最近 5 分鐘的紀錄以協助問題診斷。",
 
 
 
@@ -909882,7 +907858,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_category_label": "類別",
 
 
 
@@ -910010,7 +907985,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_hint": "描述問題或建議…",
 
 
 
@@ -910138,7 +908112,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_sending": "傳送中…",
 
 
 
@@ -910266,7 +908239,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_sent_short": "已送出",
 
 
 
@@ -910394,7 +908366,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_result_title": "意見 #%d 已收到",
 
 
 
@@ -910522,7 +908493,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_result_severity": "嚴重程度：%s",
 
 
 
@@ -910650,7 +908620,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_result_logs": "已擷取：%d 個 API 請求、%d 筆伺服器紀錄",
 
 
 
@@ -910778,7 +908747,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_result_issue": "查看 GitHub Issue #%d",
 
 
 
@@ -910906,7 +908874,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_track_title": "追蹤您的回饋",
 
 
 
@@ -911034,7 +909001,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_track_desc": "查看已提交回饋的狀態與更新。",
 
 
 
@@ -911162,7 +909128,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_github_issue_desc": "在 GitHub 上追蹤進度",
 
 
 
@@ -911290,7 +909255,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_photo_label": "附加照片（選用）",
 
 
 
@@ -911418,7 +909382,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_photo_hint": "最多可上傳 5 張照片來說明問題",
 
 
 
@@ -911546,7 +909509,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_photo_add": "新增照片",
 
 
 
@@ -911674,7 +909636,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_photo_uploading": "照片上傳中...",
 
 
 
@@ -911802,7 +909763,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_photo_uploaded": "已上傳 %d 張照片",
 
 
 
@@ -911930,7 +909890,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_photo_count": "已附加 %d 張照片",
 
 
 
@@ -912058,7 +910017,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_photo_remove": "移除",
 
 
 
@@ -912186,7 +910144,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_history_title": "我的回饋",
 
 
 
@@ -912314,7 +910271,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_title": "EClawbot - 我的錢包",
 
 
 
@@ -912442,7 +910398,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_my_wallet": "我的錢包",
 
 
 
@@ -912570,7 +910525,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_available_balance": "可用餘額",
 
 
 
@@ -912698,7 +910652,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_held_deposit": "凍結（押金）",
 
 
 
@@ -912826,7 +910779,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_lifetime_earned": "累計收入",
 
 
 
@@ -912954,7 +910906,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_lifetime_spent": "累計支出",
 
 
 
@@ -913082,9 +911033,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_topup": "儲值 e幣",
-        "wallet_topup_success": "儲值成功！",
-        "wallet_topup_failed": "儲值失敗，請再試一次。",
 
 
 
@@ -913212,7 +911160,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_topup_desc": "透過 Google Play 付款。較高檔位享有加贈 e幣。",
 
 
 
@@ -913340,7 +911287,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_topup_note": "ⓘ 儲值需於 Android App 內進行，網頁僅供瀏覽資訊。",
 
 
 
@@ -913468,7 +911414,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_topup_via_app": "請至 Android App 內進行儲值",
 
 
 
@@ -913596,7 +911541,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_history": "交易紀錄",
 
 
 
@@ -913724,7 +911668,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_loading": "載入中...",
 
 
 
@@ -913852,7 +911795,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_empty_history": "尚無交易紀錄",
 
 
 
@@ -913980,7 +911922,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_load_failed": "載入失敗",
 
 
 
@@ -914108,7 +912049,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_bonus_label": "含 +%s 加贈",
 
 
 
@@ -914236,7 +912176,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_col_time": "時間",
 
 
 
@@ -914364,7 +912303,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_col_type": "類型",
 
 
 
@@ -914492,7 +912430,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_ecoin_unit": "e-coin",
 
 
 
@@ -914620,7 +912557,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_col_note": "說明",
 
 
 
@@ -914748,7 +912684,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_col_amount": "金額",
 
 
 
@@ -914876,7 +912811,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_type_topup": "儲值",
 
 
 
@@ -915004,7 +912938,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_type_rental_income": "出租收入",
 
 
 
@@ -915132,7 +913065,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_type_rental_spend": "租借支出",
 
 
 
@@ -915260,7 +913192,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_type_platform_fee": "平台手續費",
 
 
 
@@ -915388,7 +913319,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_type_deposit_hold": "押金凍結",
 
 
 
@@ -915516,7 +913446,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_type_deposit_release": "押金解凍",
 
 
 
@@ -915644,7 +913573,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_type_deposit_forfeit": "押金沒收",
 
 
 
@@ -915772,7 +913700,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_type_referral_bonus": "邀請獎勵",
 
 
 
@@ -915900,7 +913827,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_type_signup_bonus": "註冊獎勵",
 
 
 
@@ -916028,7 +913954,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_type_refund": "退款",
 
 
 
@@ -916156,7 +914081,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_type_admin_adjust": "管理員調整",
 
 
 
@@ -916284,7 +914208,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_type_withdraw": "提領",
 
 
 
@@ -916412,7 +914335,6 @@ const TRANSLATIONS = {
 
 
 
-        "wallet_usd_label": "USD",
 
 
 
@@ -916540,7 +914462,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_hero_title": "EClaw Bot 租借市集",
 
 
 
@@ -916668,7 +914589,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_hero_subtitle": "按需租借進階 AI Bot。將閒置的 Bot 產能變現，賺取 e幣。",
 
 
 
@@ -916796,7 +914716,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_stat_phases": "開發階段",
 
 
 
@@ -916924,7 +914843,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_stat_decisions": "已鎖定設計決策",
 
 
 
@@ -917052,7 +914970,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_stat_tests": "單元測試數",
 
 
 
@@ -917180,7 +915097,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_stat_tables": "新增資料表",
 
 
 
@@ -917308,7 +915224,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_vision_title": "願景",
 
 
 
@@ -917436,7 +915351,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_vision_desc": "將 EClaw 的 Bot 廣場從靜態展示區轉型為動態的 P2P 租借交易所。擁有閒置 OpenClaw 訂閱額度的 Bot 主人可上架出租賺取 e幣，租客按 Token 用量付費。平台抽取 15% 佣金並撥 2% 進保險池用於爭議賠付。",
 
 
 
@@ -917564,7 +915478,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_how_title": "運作流程",
 
 
 
@@ -917692,7 +915605,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_flow_owner": "出租方流程",
 
 
 
@@ -917820,7 +915732,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_flow_renter": "租借方流程",
 
 
 
@@ -917948,7 +915859,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_step_bind": "綁定 Bot",
 
 
 
@@ -918076,7 +915986,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_step_rate": "設定租金",
 
 
 
@@ -918204,7 +916113,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_step_interview": "面試（自動）",
 
 
 
@@ -918332,7 +916240,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_step_publish": "上架",
 
 
 
@@ -918460,7 +916367,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_step_earn": "賺取 e幣",
 
 
 
@@ -918588,7 +916494,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_step_browse": "瀏覽廣場",
 
 
 
@@ -918716,7 +916621,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_step_view": "檢視 Agent Card",
 
 
 
@@ -918844,7 +916748,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_step_deposit": "支付押金",
 
 
 
@@ -918972,7 +916875,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_step_chat": "對話使用",
 
 
 
@@ -919100,7 +917002,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_step_settle": "結束結算",
 
 
 
@@ -919228,7 +917129,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_title": "關鍵設計決策",
 
 
 
@@ -919356,7 +917256,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_rate": "匯率",
 
 
 
@@ -919484,7 +917383,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_fee": "平台佣金",
 
 
 
@@ -919612,7 +917510,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_fee_v": "15%（含 2% 保險池）",
 
 
 
@@ -919740,7 +917637,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_withdraw": "e幣提現",
 
 
 
@@ -919868,7 +917764,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_withdraw_v": "不可提現 — 僅限站內消費",
 
 
 
@@ -919996,7 +917891,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_metering": "Token 計量",
 
 
 
@@ -920124,7 +918018,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_metering_v": "後端估算（不可偽造）",
 
 
 
@@ -920252,7 +918145,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_exclusive": "Bot 獨佔",
 
 
 
@@ -920380,7 +918272,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_exclusive_v": "一個 Listing 同時只能一位租客",
 
 
 
@@ -920508,7 +918399,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_deposit": "押金公式",
 
 
 
@@ -920636,7 +918526,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_deposit_v": "租金 × 20（2 萬 token 緩衝）",
 
 
 
@@ -920764,7 +918653,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_interview": "面試機制",
 
 
 
@@ -920892,7 +918780,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_interview_v": "8 道探針、regex 判題、≥ 60 分才能上架",
 
 
 
@@ -921020,7 +918907,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_duration": "租期範圍",
 
 
 
@@ -921148,7 +919034,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_duration_v": "30 分鐘 – 7 天",
 
 
 
@@ -921276,7 +919161,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_privacy": "出租者隱私",
 
 
 
@@ -921404,7 +919288,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_privacy_v": "租客僅看到 Agent Card 資訊",
 
 
 
@@ -921532,7 +919415,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_settle": "入帳延遲",
 
 
 
@@ -921660,7 +919542,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_settle_v": "T+24 小時（爭議緩衝）",
 
 
 
@@ -921788,7 +919669,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_grace": "寬限期",
 
 
 
@@ -921916,7 +919796,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_grace_v": "餘額歸零後 6–12 小時",
 
 
 
@@ -922044,7 +919923,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_pricing": "定價方式",
 
 
 
@@ -922172,7 +920050,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_kd_pricing_v": "Owner 自訂，系統建議區間",
 
 
 
@@ -922300,7 +920177,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tiers_title": "儲值方案",
 
 
 
@@ -922428,7 +920304,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tier_col": "方案",
 
 
 
@@ -922556,7 +920431,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tier_base": "基礎 e幣",
 
 
 
@@ -922684,7 +920558,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tier_bonus": "加贈",
 
 
 
@@ -922812,7 +920685,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tier_total": "合計",
 
 
 
@@ -922940,7 +920812,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tier_small": "小額",
 
 
 
@@ -923068,7 +920939,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tier_starter": "入門",
 
 
 
@@ -923196,7 +921066,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tier_standard": "標準",
 
 
 
@@ -923324,7 +921193,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tier_advanced": "進階",
 
 
 
@@ -923452,7 +921320,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tier_premium": "尊爵",
 
 
 
@@ -923580,7 +921447,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_contract_title": "契約生命週期",
 
 
 
@@ -923708,7 +921574,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_deposit_title": "押金結算",
 
 
 
@@ -923836,7 +921701,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_dep_reason": "結束原因",
 
 
 
@@ -923964,7 +921828,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_dep_refund": "退還",
 
 
 
@@ -924092,7 +921955,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_dep_forfeit": "沒收",
 
 
 
@@ -924220,7 +922082,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_dep_normal": "正常結束 / 申訴成立 / 管理員",
 
 
 
@@ -924348,7 +922209,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_dep_early": "租客提前解約",
 
 
 
@@ -924476,7 +922336,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_dep_zero": "餘額歸零",
 
 
 
@@ -924604,7 +922463,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_dep_zero_refund": "剩餘退還",
 
 
 
@@ -924732,7 +922590,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_dep_violation": "5 次違規",
 
 
 
@@ -924860,7 +922717,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys_title": "核心子系統",
 
 
 
@@ -924988,7 +922844,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys_desc": "構成租借市集的 11 大子系統，依領域分組。",
 
 
 
@@ -925116,7 +922971,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_grp_finance": "金融基礎設施",
 
 
 
@@ -925244,7 +923098,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_grp_market": "市集",
 
 
 
@@ -925372,7 +923225,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_grp_ops": "租賃營運",
 
 
 
@@ -925500,7 +923352,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_grp_trust": "成長與信任",
 
 
 
@@ -925628,7 +923479,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys1_label": "① 錢包系統",
 
 
 
@@ -925756,7 +923606,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys1_desc": "雙分錄帳本、餘額 + 凍結（押金託管）、冪等變更、對帳 cron。",
 
 
 
@@ -925884,7 +923733,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys2_label": "② 儲值系統",
 
 
 
@@ -926012,7 +923860,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys2_desc": "5 檔 Google Play 儲值方案。透過 UNIQUE(channel, txn_id) 防重複。",
 
 
 
@@ -926140,7 +923987,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys3_label": "③ 交易系統",
 
 
 
@@ -926268,7 +924114,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys3_desc": "原子 P2P 轉帳、跨模組共享 withTransaction() 交易。T+24h 結算。",
 
 
 
@@ -926396,7 +924241,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys4_label": "④ Bot 面試系統",
 
 
 
@@ -926524,7 +924368,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys4_desc": "8 道自動探針。純 regex 評分 — 零成本、確定性、不可偽造。",
 
 
 
@@ -926652,7 +924495,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys5_label": "⑤ 定價建議系統",
 
 
 
@@ -926780,7 +924622,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys5_desc": "模型家族偵測 + 能力加成 + 信心帶。",
 
 
 
@@ -926908,7 +924749,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys6_label": "⑥ Bot 能力評估系統",
 
 
 
@@ -927036,7 +924876,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys6_desc": "面試輸出 → 結構化能力 JSON → 鎖定在 Agent Card。",
 
 
 
@@ -927164,7 +925003,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys7_label": "⑦ 契約管理系統",
 
 
 
@@ -927292,7 +925130,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys7_desc": "9 狀態生命週期。版本鎖定快照。押金結算矩陣。資料庫層獨佔。",
 
 
 
@@ -927420,7 +925257,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys8_label": "⑧ Token 計量系統",
 
 
 
@@ -927548,7 +925384,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys8_desc": "後端逐訊息計費。租客 100%，Owner 85%，平台 13%，保險 2%。",
 
 
 
@@ -927676,7 +925511,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys9_label": "⑨ 點交系統",
 
 
 
@@ -927804,7 +925638,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys9_desc": "裝置間原子 entity slot 交換。Owner 儀表板顯示出租中覆蓋。",
 
 
 
@@ -927932,7 +925765,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys10_label": "⑩ 租後協作系統",
 
 
 
@@ -928060,7 +925892,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys10_desc": "完整 A2A 整合含護欄。30 req/min 速率限制。",
 
 
 
@@ -928188,7 +926019,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys11_label": "⑪ 邀請碼系統",
 
 
 
@@ -928316,7 +926146,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_sys11_desc": "雙邊獎勵邀請碼。防刷保護。",
 
 
 
@@ -928444,7 +926273,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_done": "完成",
 
 
 
@@ -928572,7 +926400,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_stub": "雛型",
 
 
 
@@ -928700,7 +926527,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_scoring_done": "評分引擎完成",
 
 
 
@@ -928828,7 +926654,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_phase5": "第 5 階段",
 
 
 
@@ -928956,7 +926781,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_complete": "已完成",
 
 
 
@@ -929084,7 +926908,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_planned": "規劃中",
 
 
 
@@ -929212,7 +927035,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_dev_title": "開發路線圖",
 
 
 
@@ -929340,7 +927162,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p0_name": "錢包基礎建設",
 
 
 
@@ -929468,7 +927289,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p0_desc": "e幣錢包、雙分錄帳本、Google Play 儲值、每日對帳排程。",
 
 
 
@@ -929596,7 +927416,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p0_t1": "錢包 schema + 原語（轉帳、凍結、解凍、沒收）",
 
 
 
@@ -929724,7 +927543,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p0_t2": "儲值方案（5 檔含遞增加贈）",
 
 
 
@@ -929852,7 +927670,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p0_t3": "錢包頁面（餘額 + 歷史 + 方案）",
 
 
 
@@ -929980,7 +927797,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p0_t4": "每日對帳 cron（帳本 vs 快取餘額稽核）",
 
 
 
@@ -930108,7 +927924,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p0_t5": "管理員發放 + 對帳端點",
 
 
 
@@ -930236,7 +928051,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p0_t6": "48 個 Jest 單元測試",
 
 
 
@@ -930364,7 +928178,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p1_name": "上架 + 面試",
 
 
 
@@ -930492,7 +928305,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p1_desc": "Bot 上架 CRUD、自動面試評分、市集搜尋、定價建議。",
 
 
 
@@ -930620,7 +928432,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p1_t1": "6 張新資料表（listings、interviews、contracts、snapshots、usage events、pricing）",
 
 
 
@@ -930748,7 +928559,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p1_t2": "Listing CRUD + 市集搜尋 API",
 
 
 
@@ -930876,7 +928686,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p1_t3": "8 道面試探針引擎（regex + 啟發式，零 LLM 成本）",
 
 
 
@@ -931004,7 +928813,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p1_t4": "定價建議器（基礎費率 × 能力加成）",
 
 
 
@@ -931132,7 +928940,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p1_t5": "64 個 Jest 單元測試",
 
 
 
@@ -931260,7 +929067,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p1_t6": "HTTP 探針派送到 Owner webhook",
 
 
 
@@ -931388,7 +929194,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p1_t7": "市場快照每小時 cron",
 
 
 
@@ -931516,7 +929321,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p1_t8": "市集頁面",
 
 
 
@@ -931644,7 +929448,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p2_name": "契約核心",
 
 
 
@@ -931772,7 +929575,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p2_desc": "契約狀態機、版本鎖定、Token 計量代理、Entity 點交、隱私護欄、A2A 協作。",
 
 
 
@@ -931900,7 +929702,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p2_t1": "契約開始/結束的跨模組原子交易",
 
 
 
@@ -932028,7 +929829,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p2_t2": "透過 rental_snapshots 版本鎖定",
 
 
 
@@ -932156,7 +929956,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p2_t3": "資料庫層 Bot 獨佔保證（部分 UNIQUE index）",
 
 
 
@@ -932284,7 +930083,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p2_t4": "押金結算矩陣（100%/50%/30%/0% 退還）",
 
 
 
@@ -932412,7 +930210,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p2_t5": "Token 計量代理（逐訊息計費）",
 
 
 
@@ -932540,7 +930337,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p2_t6": "守門員擴充（注入偵測 + 敏感資料）",
 
 
 
@@ -932668,7 +930464,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p2_t7": "A2A 護欄（禁止改名/刪除/轉租，30 req/min）",
 
 
 
@@ -932796,7 +930591,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p2_t8": "Entity 點交（在租客裝置插入/移除租借 bot）",
 
 
 
@@ -932924,7 +930718,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p2_t9": "契約到期 + 寬限期排程",
 
 
 
@@ -933052,7 +930845,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p2_t10": "73 個 Jest 單元測試",
 
 
 
@@ -933180,7 +930972,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p3_name": "信任層",
 
 
 
@@ -933308,7 +931099,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p3_desc": "評分、糾紛仲裁、信用分數、反詐欺、管理後台。",
 
 
 
@@ -933436,7 +931226,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p3_t1": "1–5 星評分 + 留言系統",
 
 
 
@@ -933564,7 +931353,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p3_t2": "申訴管道含自動當機驗證",
 
 
 
@@ -933692,7 +931480,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p3_t3": "防刷規則（自租、人頭、假評分）",
 
 
 
@@ -933820,7 +931607,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p3_t4": "管理員爭議處理台 + 補償工具",
 
 
 
@@ -933948,7 +931734,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p4_name": "風險管理",
 
 
 
@@ -934076,7 +931861,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p4_desc": "保險池、黑名單、SLA 統計、通知觸發器、合規掛鉤。",
 
 
 
@@ -934204,7 +931988,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p4_t1": "保險池（佣金 2% 自動存入）",
 
 
 
@@ -934332,7 +932115,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p4_t2": "使用者黑名單 + 冷卻期",
 
 
 
@@ -934460,7 +932242,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p4_t3": "SLA 儀表板（上線率 %、當機次數、延遲）",
 
 
 
@@ -934588,7 +932369,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p4_t4": "年齡確認 + KYC 掛鉤",
 
 
 
@@ -934716,7 +932496,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p5_name": "成長引擎",
 
 
 
@@ -934844,7 +932623,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p5_desc": "邀請碼、邀請獎勵、市場激勵方案。",
 
 
 
@@ -934972,7 +932750,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p5_t1": "邀請碼系統（6 字碼，防刷保護）",
 
 
 
@@ -935100,7 +932877,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p5_t2": "雙邊獎勵（邀請人 + 被邀請人）",
 
 
 
@@ -935228,7 +933004,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_p5_t3": "首儲連鎖加贈",
 
 
 
@@ -935356,7 +933131,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tech_title": "技術亮點",
 
 
 
@@ -935484,7 +933258,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tech1_label": "跨模組原子性",
 
 
 
@@ -935612,7 +933385,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tech1_desc": "錢包 + 契約寫入共享單一 BEGIN/COMMIT 交易，透過 withTransaction() 注入。",
 
 
 
@@ -935740,7 +933512,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tech2_label": "版本鎖定",
 
 
 
@@ -935868,7 +933639,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tech2_desc": "rental_snapshots 在契約啟動時凍結設定。Owner 修改不影響進行中的租約。",
 
 
 
@@ -935996,7 +933766,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tech3_label": "資料庫層獨佔",
 
 
 
@@ -936124,7 +933893,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tech3_desc": "部分 UNIQUE 索引保證不可能重複預訂。",
 
 
 
@@ -936252,7 +934020,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tech4_label": "冪等帳本",
 
 
 
@@ -936380,7 +934147,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tech4_desc": "每次變動攜帶 UNIQUE idempotency_key。重試安全。",
 
 
 
@@ -936508,7 +934274,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tech5_label": "面試：零成本判題",
 
 
 
@@ -936636,7 +934401,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tech5_desc": "純 regex 評分。確定性、可重現、不可偽造。",
 
 
 
@@ -936764,7 +934528,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tech6_label": "每日對帳",
 
 
 
@@ -936892,7 +934655,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_tech6_desc": "CTE 比對快取餘額與帳本加總。偏移觸發告警。",
 
 
 
@@ -937020,7 +934782,6 @@ const TRANSLATIONS = {
 
 
 
-        "rm_full_doc": "完整規格書（1,500+ 行），請參閱：",
 
 
 
@@ -937148,7 +934909,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_title": "EClawbot - Bot 市集",
 
 
 
@@ -937276,7 +935036,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_heading": "Bot 市集",
 
 
 
@@ -937404,7 +935163,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_desc": "按需租借進階 AI Bot。按 Token 付費，無需訂閱。",
 
 
 
@@ -937532,7 +935290,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_search_placeholder": "搜尋 Bot...",
 
 
 
@@ -937660,7 +935417,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_sort_rating": "最高評分",
 
 
 
@@ -937788,7 +935544,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_sort_cheap": "最便宜",
 
 
 
@@ -937916,7 +935671,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_sort_expensive": "最貴",
 
 
 
@@ -938044,7 +935798,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_sort_newest": "最新上架",
 
 
 
@@ -938172,7 +935925,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_loading": "載入中...",
 
 
 
@@ -938300,7 +936052,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_no_results": "目前沒有可租借的 Bot，請稍後再來！",
 
 
 
@@ -938428,7 +936179,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_load_error": "載入失敗",
 
 
 
@@ -938556,7 +936306,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_d_rate": "費率",
 
 
 
@@ -938684,7 +936433,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_d_deposit": "押金",
 
 
 
@@ -938812,7 +936560,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_d_duration": "租期",
 
 
 
@@ -938940,7 +936687,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_d_rating": "評分",
 
 
 
@@ -939068,7 +936814,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_d_rentals": "次租借",
 
 
 
@@ -939196,7 +936941,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_d_uptime": "上線率",
 
 
 
@@ -939324,7 +937068,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_d_rent_duration": "租借時長（分鐘）",
 
 
 
@@ -939452,7 +937195,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_rent_now": "立即租借",
 
 
 
@@ -939580,7 +937322,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_login_first": "請先登入",
 
 
 
@@ -939708,7 +937449,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_renting": "處理中...",
 
 
 
@@ -939836,7 +937576,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_rent_success": "租借成功！請至「我的租賃」查看詳情。",
 
 
 
@@ -939964,7 +937703,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_rent_warning": "⚠️ 您的訊息將傳送到出租者的伺服器。請避免透露敏感資訊。",
 
 
 
@@ -940092,7 +937830,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_error_cooldown": "此 Bot 有 24 小時冷卻期，請稍後再試。",
 
 
 
@@ -940220,7 +937957,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_error_self_rent": "不能租借自己的 Bot。",
 
 
 
@@ -940348,7 +938084,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_error_already_rented": "此 Bot 已被其他人租借。",
 
 
 
@@ -940476,7 +938211,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_error_insufficient": "e 幣餘額不足，無法租借。",
 
 
 
@@ -940604,11 +938338,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_error_not_available": "此上架項目已無法使用。",
-        "listing_soft_paused_owner_banner": "此上架項目因健康檢查異常而進入 soft-pause。它仍維持上架，但在恢復前會阻擋新的租借。",
-        "listing_soft_paused_visitor_banner": "這個 Bot 暫時無法租借，擁有者正在修復健康檢查問題。頁面仍可查看，但目前不能租借。",
-        "listing_soft_paused_resume_btn": "恢復上架",
-        "rental_create_rejected_soft_paused": "此上架項目因健康檢查異常而暫時無法租借。",
 
 
 
@@ -940736,7 +938465,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_d_rent_duration_hours": "租借時長（小時）",
 
 
 
@@ -940864,7 +938592,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_hours": "小時",
 
 
 
@@ -940992,7 +938719,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_est_deposit": "押金",
 
 
 
@@ -941120,7 +938846,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_est_usage": "預估用量",
 
 
 
@@ -941248,7 +938973,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_est_total": "預估總費用",
 
 
 
@@ -941376,7 +939100,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_bal_your": "您的餘額",
 
 
 
@@ -941504,7 +939227,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_bal_sufficient": "餘額充足",
 
 
 
@@ -941632,7 +939354,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_bal_insufficient": "餘額不足",
 
 
 
@@ -941760,7 +939481,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_bal_need": "需要",
 
 
 
@@ -941888,7 +939608,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_bal_current": "目前",
 
 
 
@@ -942016,7 +939735,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_bal_deficit": "差額",
 
 
 
@@ -942144,7 +939862,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_bal_topup": "前往儲值",
 
 
 
@@ -942272,7 +939989,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_privacy_warning": "您的對話將透過出租者的伺服器處理。請勿分享信用卡號、密碼或個人身分資訊。",
 
 
 
@@ -942400,7 +940116,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_privacy_agree": "我了解並同意",
 
 
 
@@ -942528,7 +940243,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_status_available": "可租借",
 
 
 
@@ -942656,7 +940370,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_status_rented": "已出租",
 
 
 
@@ -942784,7 +940497,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_interview_score": "面試分數",
 
 
 
@@ -942912,7 +940624,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_rent_success_title": "租借成功！",
 
 
 
@@ -943040,7 +940751,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_rent_success_desc": "Bot 已加入您的裝置。",
 
 
 
@@ -943168,8 +940878,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_start_chat": "開始聊天",
-        "mp_chat_cta": "開始對話",
 
 
 
@@ -943297,7 +941005,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_view_contract": "查看契約",
 
 
 
@@ -943425,7 +941132,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_cap_filter_label": "能力篩選",
 
 
 
@@ -943553,7 +941259,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_rate_range_label": "費率",
 
 
 
@@ -943681,7 +941386,6 @@ const TRANSLATIONS = {
 
 
 
-        "mp_rate_unit": "e幣/1K",
 
 
 
@@ -943809,7 +941513,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_title": "EClawbot - 我的租賃",
 
 
 
@@ -943937,7 +941640,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_heading": "我的租賃",
 
 
 
@@ -944065,7 +941767,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_tab_renting": "租借中",
 
 
 
@@ -944193,7 +941894,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_tab_leasing": "出租中",
 
 
 
@@ -944321,7 +942021,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_tab_disputes": "申訴",
 
 
 
@@ -944449,7 +942148,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_loading": "載入中...",
 
 
 
@@ -944577,7 +942275,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_no_contracts": "尚無契約",
 
 
 
@@ -944705,7 +942402,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_no_disputes": "尚無申訴",
 
 
 
@@ -944833,7 +942529,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_load_error": "載入失敗",
 
 
 
@@ -944961,7 +942656,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_contract": "契約",
 
 
 
@@ -945089,7 +942783,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_charged": "已計費",
 
 
 
@@ -945217,7 +942910,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_ecoin": "幣",
 
 
 
@@ -945345,7 +943037,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_end_early": "提前結束",
 
 
 
@@ -945473,7 +943164,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_review": "評分",
 
 
 
@@ -945601,7 +943291,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_dispute": "申訴",
 
 
 
@@ -945729,7 +943418,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_review_placeholder": "選填留言...",
 
 
 
@@ -945857,7 +943545,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_submit_review": "提交評分",
 
 
 
@@ -945985,7 +943672,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_select_rating": "請選擇評分星數",
 
 
 
@@ -946113,7 +943799,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_review_submitted": "評分已提交！",
 
 
 
@@ -946241,7 +943926,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_dispute_filed": "申訴已提交！",
 
 
 
@@ -946369,7 +944053,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_filed": "提交時間",
 
 
 
@@ -946497,7 +944180,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_chat": "聊天",
 
 
 
@@ -946625,7 +944307,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_usage_details": "用量明細",
 
 
 
@@ -946753,7 +944434,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_topup": "前往儲值",
 
 
 
@@ -946881,7 +944561,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_usage_coming_soon": "用量明細即將推出",
 
 
 
@@ -947009,7 +944688,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_remaining_time": "剩餘時間",
 
 
 
@@ -947137,7 +944815,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_deposit": "押金",
 
 
 
@@ -947265,7 +944942,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_deposit_frozen": "已凍結",
 
 
 
@@ -947393,7 +945069,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_deposit_full_refund": "全額退還",
 
 
 
@@ -947521,7 +945196,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_deposit_early_end": "退還 {refund} e幣，沒收 {forfeit} e幣 (50%)",
 
 
 
@@ -947649,7 +945323,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_deposit_violation": "退還 {refund} e幣，沒收 {forfeit} e幣 (30%)",
 
 
 
@@ -947777,7 +945450,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_deposit_zero_balance": "退還剩餘押金",
 
 
 
@@ -947905,7 +945577,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_deposit_renter_full_refund": "押金全額退回給你",
 
 
 
@@ -948033,7 +945704,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_deposit_renter_early_end": "押金：退回你 {refund} e幣 · 沒收 {forfeit} e幣 (50%)",
 
 
 
@@ -948161,7 +945831,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_deposit_renter_violation": "押金：退回你 {refund} e幣 · {forfeit} e幣進入保險金池 (30%)",
 
 
 
@@ -948289,7 +945958,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_deposit_renter_zero_balance": "押金扣除用量後剩餘已退回給你",
 
 
 
@@ -948417,7 +946085,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_deposit_owner_full_returned": "押金已全額退回給承租方",
 
 
 
@@ -948545,7 +946212,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_deposit_owner_early_end": "押金：退回承租方 {refund} e幣 · 你獲得違約金 {forfeit} e幣 (50%)",
 
 
 
@@ -948673,7 +946339,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_deposit_owner_violation": "押金：退回承租方 {refund} e幣 · {forfeit} e幣進入保險金池 (30%)",
 
 
 
@@ -948801,7 +946466,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_deposit_owner_zero_balance": "押金扣除用量後剩餘已退回給承租方",
 
 
 
@@ -948929,7 +946593,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_income": "收入",
 
 
 
@@ -949057,7 +946720,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_income_details": "收入明細",
 
 
 
@@ -949185,7 +946847,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_settlement_status": "結算狀態",
 
 
 
@@ -949313,7 +946974,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_settlement_pending": "結算中...",
 
 
 
@@ -949441,7 +947101,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_settlement_done": "已入帳",
 
 
 
@@ -949569,7 +947228,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_status_active": "進行中",
 
 
 
@@ -949697,7 +947355,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_status_ended_normal": "已結束(正常)",
 
 
 
@@ -949825,7 +947482,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_status_ended_early": "已結束(提前)",
 
 
 
@@ -949953,7 +947609,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_status_ended_zero_balance": "已結束(餘額耗盡)",
 
 
 
@@ -950081,7 +947736,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_status_ended_violation": "已結束(違規)",
 
 
 
@@ -950209,7 +947863,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_status_ended_disputed": "已結束(爭議)",
 
 
 
@@ -950337,7 +947990,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_status_ended_admin": "已結束(管理員)",
 
 
 
@@ -950465,7 +948117,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_status_suspended": "餘額不足(暫停)",
 
 
 
@@ -950593,7 +948244,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_action_failed": "失敗",
 
 
 
@@ -950721,7 +948371,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_end_early_title": "確認提前結束租借？",
 
 
 
@@ -950849,7 +948498,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_end_early_irreversible": "此操作無法撤銷。根據提前終止條款：",
 
 
 
@@ -950977,7 +948625,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_end_early_forfeit": "押金 50% ({forfeit} e幣) 將被沒收",
 
 
 
@@ -951105,7 +948752,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_end_early_refund": "押金 50% ({refund} e幣) 將退還到錢包",
 
 
 
@@ -951233,7 +948879,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_end_early_split": "沒收部分的分配",
 
 
 
@@ -951361,7 +949006,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_end_early_owner": "出租方 85%",
 
 
 
@@ -951489,7 +949133,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_end_early_platform": "平台 13%",
 
 
 
@@ -951617,7 +949260,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_end_early_insurance": "保險池 2%",
 
 
 
@@ -951745,7 +949387,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_cancel": "取消",
 
 
 
@@ -951873,7 +949514,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_confirm_end": "確認結束",
 
 
 
@@ -952001,7 +949641,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_dispute_title": "提出申訴",
 
 
 
@@ -952129,7 +949768,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_dispute_select_type": "選擇申訴類型：",
 
 
 
@@ -952257,7 +949895,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_dtype_bot_quality": "Bot 品質 — 品質低劣",
 
 
 
@@ -952385,7 +950022,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_dtype_capability_mismatch": "能力不符 — 與描述不符",
 
 
 
@@ -952513,7 +950149,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_dtype_financial": "金流問題 — 費用計算有誤",
 
 
 
@@ -952641,7 +950276,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_dtype_bot_crash": "Bot 當機 — 無回應/當機",
 
 
 
@@ -952769,7 +950403,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_dispute_evidence_placeholder": "請描述問題（選填）...",
 
 
 
@@ -952897,7 +950530,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_submit_dispute": "提出申訴",
 
 
 
@@ -953025,7 +950657,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_dispute_select_required": "請選擇申訴類型",
 
 
 
@@ -953153,7 +950784,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_sla_title": "SLA 說明",
 
 
 
@@ -953281,7 +950911,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_sla_bot_crash": "5 分鐘自動驗證",
 
 
 
@@ -953409,7 +951038,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_sla_capability": "24h 回應 / 48h 解決",
 
 
 
@@ -953537,7 +951165,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_sla_financial": "12h 回應 / 48h 解決",
 
 
 
@@ -953665,7 +951292,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_sla_quality": "24h 回應 / 72h 解決",
 
 
 
@@ -953793,7 +951419,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_sla_remaining": "SLA",
 
 
 
@@ -953921,7 +951546,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_sla_remaining_suffix": "剩餘",
 
 
 
@@ -954049,7 +951673,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_dispute_status_open": "處理中",
 
 
 
@@ -954177,7 +951800,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_dispute_status_resolved": "已解決",
 
 
 
@@ -954305,7 +951927,6 @@ const TRANSLATIONS = {
 
 
 
-        "mr_dispute_status_rejected": "已拒絕",
 
 
 
@@ -954433,7 +952054,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_title": "EClawbot - 邀請好友",
 
 
 
@@ -954561,7 +952181,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_heading": "邀請好友，賺取 e幣",
 
 
 
@@ -954689,7 +952308,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_desc": "分享你的邀請碼。你得 500 e幣，好友得 100 e幣。",
 
 
 
@@ -954817,7 +952435,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_my_code": "我的邀請碼",
 
 
 
@@ -954945,7 +952562,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_copy": "複製",
 
 
 
@@ -955073,7 +952689,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_stats": "邀請統計",
 
 
 
@@ -955201,7 +952816,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_stats_title": "邀請儀表板",
 
 
 
@@ -955329,7 +952943,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_stats_subtitle": "一眼掌握你的邀請成效。",
 
 
 
@@ -955457,7 +953070,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_stats_kpi_invited": "累計成功邀請",
 
 
 
@@ -955585,7 +953197,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_stats_kpi_bonus": "累計獲得 e幣（估算）",
 
 
 
@@ -955713,8 +953324,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_stats_kpi_today_used": "今日已用",
-        "invite_unlimited_label": "已送出（無限制）",
 
 
 
@@ -955842,7 +953451,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_stats_kpi_conversion": "轉換率",
 
 
 
@@ -955970,7 +953578,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_stats_timeline_title": "每日使用量（過去 30 天）",
 
 
 
@@ -956098,7 +953705,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_per_code_funnel_header": "各邀請碼點擊漏斗",
 
 
 
@@ -956226,7 +953832,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_per_code_funnel_empty": "還沒有邀請碼 — 分享連結後就會開始追蹤點擊。",
 
 
 
@@ -956354,7 +953959,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_per_code_summary_codes": "碼數",
 
 
 
@@ -956482,7 +954086,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_per_code_summary_clicks": "總點擊",
 
 
 
@@ -956610,7 +954213,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_per_code_summary_unique": "不重複",
 
 
 
@@ -956738,7 +954340,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_per_code_summary_redeemed": "已兌換",
 
 
 
@@ -956866,7 +954467,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_per_code_col_code": "邀請碼",
 
 
 
@@ -956994,7 +954594,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_per_code_col_clicks": "點擊",
 
 
 
@@ -957122,7 +954721,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_per_code_col_unique": "不重複",
 
 
 
@@ -957250,7 +954848,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_per_code_col_status": "狀態",
 
 
 
@@ -957378,7 +954975,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_per_code_status_redeemed": "已兌換",
 
 
 
@@ -957506,7 +955102,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_per_code_status_pending": "待兌換",
 
 
 
@@ -957634,7 +955229,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_stats_timeline_empty": "尚無使用紀錄——明天再來看看！",
 
 
 
@@ -957762,7 +955356,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_stats_refresh_btn": "重新整理",
 
 
 
@@ -957890,7 +955483,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_stats_loading": "載入中…",
 
 
 
@@ -958018,7 +955610,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_stats_error": "載入失敗，請重試。",
 
 
 
@@ -958146,7 +955737,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_invited": "已邀請好友",
 
 
 
@@ -958274,7 +955864,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_earned": "已賺取 e幣",
 
 
 
@@ -958402,7 +955991,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_rewards_title": "獎勵說明",
 
 
 
@@ -958530,7 +956118,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_you_get": "你獲得",
 
 
 
@@ -958658,7 +956245,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_friend_gets": "好友獲得",
 
 
 
@@ -958786,7 +956372,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_first_topup": "好友首次儲值獎勵（你）",
 
 
 
@@ -958914,7 +956499,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_tier_title": "階級與里程碑",
 
 
 
@@ -959042,7 +956626,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_tier_current": "目前階級",
 
 
 
@@ -959170,7 +956753,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_tier_none": "尚未解鎖",
 
 
 
@@ -959298,7 +956880,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_tier_bronze": "青銅",
 
 
 
@@ -959426,7 +957007,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_tier_silver": "白銀",
 
 
 
@@ -959554,7 +957134,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_tier_gold": "黃金",
 
 
 
@@ -959682,7 +957261,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_tier_diamond": "鑽石",
 
 
 
@@ -959810,7 +957388,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_tier_req": "邀請 {n} 人達成",
 
 
 
@@ -959938,7 +957515,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_tier_progress": "再邀請 {n} 人即可達成 {tier}",
 
 
 
@@ -960066,7 +957642,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_tier_all_done": "所有階級皆已達成 🏆",
 
 
 
@@ -960194,7 +957769,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_redeem_title": "有邀請碼？",
 
 
 
@@ -960322,7 +957896,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_redeem_btn": "兌換",
 
 
 
@@ -960450,7 +958023,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_redeem_success": "兌換成功！你獲得 100 e幣。",
 
 
 
@@ -960578,7 +958150,6 @@ const TRANSLATIONS = {
 
 
 
-        "inv_qr_gen_cta": "產生分享圖",
 
 
 
@@ -960706,7 +958277,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_qr_title": "產生邀請分享圖",
 
 
 
@@ -960834,7 +958404,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_qr_desc": "製作含邀請碼與 QR Code 的品牌圖，方便貼到社群媒體。",
 
 
 
@@ -960962,7 +958531,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_qr_code_label": "邀請碼",
 
 
 
@@ -961090,7 +958658,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_qr_btn_download": "下載 PNG",
 
 
 
@@ -961218,7 +958785,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_qr_btn_copy": "複製到剪貼簿",
 
 
 
@@ -961346,7 +958912,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_qr_size_mobile": "手機 600×600",
 
 
 
@@ -961474,7 +959039,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_qr_size_ig": "Instagram 1080×1080",
 
 
 
@@ -961602,7 +959166,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_qr_size_desktop": "桌面 1200×1200",
 
 
 
@@ -961730,7 +959293,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_qr_reward_inviter": "邀請人",
 
 
 
@@ -961858,7 +959420,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_qr_reward_invitee": "好友",
 
 
 
@@ -961986,7 +959547,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_qr_reward_topup": "首次儲值",
 
 
 
@@ -962114,7 +959674,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_qr_toast_downloaded": "已下載圖片",
 
 
 
@@ -962242,7 +959801,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_qr_toast_copied": "已複製到剪貼簿",
 
 
 
@@ -962370,7 +959928,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_qr_toast_copy_unsupported": "不支援複製，請改用下載",
 
 
 
@@ -962498,7 +960055,6 @@ const TRANSLATIONS = {
 
 
 
-        "invite_qr_toast_copy_failed": "複製失敗，請改用下載",
 
 
 
@@ -962626,7 +960182,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_title": "聊天",
 
 
 
@@ -962754,7 +960309,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_filter_all": "全部",
 
 
 
@@ -962882,7 +960436,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_filter_my": "我的訊息",
 
 
 
@@ -963010,7 +960563,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_send_to": "傳送給：",
 
 
 
@@ -963138,7 +960690,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_input_placeholder": "輸入訊息...",
 
 
 
@@ -963266,7 +960817,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_cancel": "取消",
 
 
 
@@ -963394,7 +960944,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_reply_btn": "回覆",
 
 
 
@@ -963522,7 +961071,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_reply_cancel": "取消回覆",
 
 
 
@@ -963650,7 +961198,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_reply_you": "你",
 
 
 
@@ -963778,7 +961325,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_reply_media": "(媒體)",
 
 
 
@@ -963906,7 +961452,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_his_not_rendered_preview": "訊息不在目前畫面內 — 預覽：",
 
 
 
@@ -964034,8 +961579,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_msg_deeplink_not_found": "找不到訊息或無法存取：{id}",
-        "chat_his_not_found": "引用的訊息目前未載入。",
 
 
 
@@ -964163,7 +961706,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_btn_send": "傳送",
 
 
 
@@ -964291,7 +961833,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_btn_sending": "傳送中...",
 
 
 
@@ -964419,7 +961960,6 @@ const TRANSLATIONS = {
 
 
 
-        "slash_cmd_help": "顯示可用指令",
 
 
 
@@ -964547,7 +962087,6 @@ const TRANSLATIONS = {
 
 
 
-        "slash_cmd_status": "查看機器人連線狀態",
 
 
 
@@ -964675,7 +962214,6 @@ const TRANSLATIONS = {
 
 
 
-        "slash_cmd_reset": "清除對話歷史",
 
 
 
@@ -964803,7 +962341,6 @@ const TRANSLATIONS = {
 
 
 
-        "slash_cmd_activation": "管理機器人啟用",
 
 
 
@@ -964931,7 +962468,6 @@ const TRANSLATIONS = {
 
 
 
-        "slash_cmd_pair": "配對新裝置",
 
 
 
@@ -965059,7 +962595,6 @@ const TRANSLATIONS = {
 
 
 
-        "slash_cmd_reasoning": "切換推理模式",
 
 
 
@@ -965187,7 +962722,6 @@ const TRANSLATIONS = {
 
 
 
-        "slash_cmd_config": "設定機器人",
 
 
 
@@ -965315,7 +962849,6 @@ const TRANSLATIONS = {
 
 
 
-        "slash_cmd_broadcast": "廣播給所有實體",
 
 
 
@@ -965443,7 +962976,6 @@ const TRANSLATIONS = {
 
 
 
-        "slash_cmd_model": "切換 AI 模型 (Claude Code)",
 
 
 
@@ -965571,7 +963103,6 @@ const TRANSLATIONS = {
 
 
 
-        "slash_cmd_auto_approve": "切換自動核准 (Claude Code)",
 
 
 
@@ -965699,7 +963230,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_empty": "尚無訊息",
 
 
 
@@ -965827,7 +963357,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_card_selected": "已選擇：{label}",
 
 
 
@@ -965955,7 +963484,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_empty_sub": "在下方傳送訊息給您的實體",
 
 
 
@@ -966083,7 +963611,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_date_today": "今天",
 
 
 
@@ -966211,7 +963738,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_date_yesterday": "昨天",
 
 
 
@@ -966339,7 +963865,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_empty_hint": "傳送訊息開始聊天",
 
 
 
@@ -966467,7 +963992,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_limit_reached": "已達每日訊息上限。升級至高級會員以享受無限訊息！",
 
 
 
@@ -966595,7 +964119,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_limit_title": "已達每日上限",
 
 
 
@@ -966723,7 +964246,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_limit_body": "您今日已達 15 則訊息的免費上限。升級尊爵會員即可享有無限發送！",
 
 
 
@@ -966851,7 +964373,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_limit_upgrade": "立即升級",
 
 
 
@@ -966979,7 +964500,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_limit_close": "關閉",
 
 
 
@@ -967107,7 +964627,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_read": "已讀",
 
 
 
@@ -967235,7 +964754,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_read_label": "已讀",
 
 
 
@@ -967363,7 +964881,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_delivered": "已送達",
 
 
 
@@ -967491,7 +965008,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mission_control": "任務控制",
 
 
 
@@ -967619,7 +965135,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_sent": "已送出",
 
 
 
@@ -967747,7 +965262,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_usage_unlimited": "無限制",
 
 
 
@@ -967875,7 +965389,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_usage_count": "已送 {used} 則",
 
 
 
@@ -968003,7 +965516,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_select_entity": "請選擇至少一個實體",
 
 
 
@@ -968259,7 +965771,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_enter_message": "請輸入訊息",
 
 
 
@@ -968387,7 +965898,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_attach_photo": "照片",
 
 
 
@@ -968515,7 +966025,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_attach_video": "影片",
 
 
 
@@ -968643,7 +966152,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_attach_file": "檔案",
 
 
 
@@ -968771,7 +966279,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_attach_my_files": "雲端庫",
 
 
 
@@ -968899,7 +966406,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_cloud_drive_title": "\uD83D\uDCC1 雲端庫",
 
 
 
@@ -969027,7 +966533,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_file_too_large": "檔案過大（上限 100MB）",
 
 
 
@@ -969155,7 +966660,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_file_download": "下載",
 
 
 
@@ -969283,7 +966787,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_file_download_failed": "下載失敗",
 
 
 
@@ -969411,7 +966914,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_uploading": "上傳中...",
 
 
 
@@ -969539,7 +967041,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_upload_error": "錯誤",
 
 
 
@@ -969667,7 +967168,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_upload_failed": "上傳失敗",
 
 
 
@@ -969795,7 +967295,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_wait_upload": "請等待上傳完成",
 
 
 
@@ -969923,7 +967422,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_cross_device": "跨裝置",
 
 
 
@@ -970051,7 +967549,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_cross_device_placeholder": "輸入目標代碼（如 abc123）",
 
 
 
@@ -970179,7 +967676,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_cross_device_lookup": "查詢",
 
 
 
@@ -970307,7 +967803,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_target_collapse": "收合",
 
 
 
@@ -970435,7 +967930,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_delivered_label": "已送達",
 
 
 
@@ -970563,7 +968057,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_sent_to": "發送至 ",
 
 
 
@@ -970691,7 +968184,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_gatekeeper_blocked": "訊息被安全過濾器攔截",
 
 
 
@@ -970819,7 +968311,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_loading_entities": "載入實體中...",
 
 
 
@@ -970947,7 +968438,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_send_failed": "發送失敗",
 
 
 
@@ -975171,7 +972661,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_webhook_title": "Webhook 未註冊",
 
 
 
@@ -975299,7 +972788,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_webhook_desc": "訊息已儲存，但無法推送給 Bot。該 Bot 尚未註冊 Webhook URL。請依照以下步驟排錯：",
 
 
 
@@ -975427,7 +972915,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_webhook_step1": "確認 OpenClaw channel 插件已安裝：<code>ls ~/.openclaw/extensions/openclaw-channel/</code>",
 
 
 
@@ -975555,7 +973042,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_webhook_step2": "確認 Gateway 正在運行：<code>openclaw gateway status</code>",
 
 
 
@@ -975683,7 +973169,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_webhook_step3": "從 Gateway 日誌取得憑證：<code>cat /tmp/openclaw/openclaw-*.log | grep -i \"eclaw.*bound\"</code>",
 
 
 
@@ -975811,7 +973296,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_webhook_step4": "驗證憑證：<code>curl \"https://eclawbot.com/api/mission/dashboard?deviceId=ID&amp;botSecret=SECRET&amp;entityId=N\"</code>",
 
 
 
@@ -975939,7 +973423,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_webhook_step5": "開放 Gateway 工具：<code>openclaw config set gateway.tools.allow '[\"sessions_send\",\"sessions_spawn\",\"session_status\"]'</code>",
 
 
 
@@ -976067,7 +973550,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_webhook_step6": "註冊 Webhook（路徑用 <code>/tools/invoke</code>）：<code>POST /api/bot/register</code> 帶上 <code>webhook_url</code>、<code>token</code>、<code>session_key</code>",
 
 
 
@@ -976195,7 +973677,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_webhook_step7": "測試推送：從 EClaw App 發送訊息，確認 Bot 有收到。",
 
 
 
@@ -976323,7 +973804,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_webhook_doc_link": "完整指南：<a href=\"/docs/webhook-troubleshooting.md\" target=\"_blank\" style=\"color:var(--primary);\">webhook-troubleshooting.md</a>",
 
 
 
@@ -976451,7 +973931,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_webhook_close": "關閉",
 
 
 
@@ -976579,7 +974058,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_load_failed": "載入聊天記錄失敗",
 
 
 
@@ -976707,7 +974185,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_title": "EClawbot - 管理者儀表板",
 
 
 
@@ -976835,7 +974312,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_badge": "管理員",
 
 
 
@@ -976963,7 +974439,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_refresh": "重新整理",
 
 
 
@@ -977091,7 +974566,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_loading": "載入管理數據中...",
 
 
 
@@ -977219,7 +974693,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_access_denied": "拒絕存取",
 
 
 
@@ -977347,7 +974820,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_no_privilege": "您沒有管理員權限。",
 
 
 
@@ -977475,7 +974947,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_back_dashboard": "返回儀表板",
 
 
 
@@ -977603,7 +975074,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_error_load": "載入失敗：",
 
 
 
@@ -977731,7 +975201,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_stat_users": "總用戶數",
 
 
 
@@ -977859,7 +975328,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_stat_premium": "高級用戶",
 
 
 
@@ -977987,7 +975455,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_stat_verified": "已驗證 Email",
 
 
 
@@ -978115,7 +975582,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_stat_devices": "裝置總數",
 
 
 
@@ -978243,7 +975709,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_stat_bound": "已綁定實體",
 
 
 
@@ -978371,7 +975836,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_stat_bindings": "Bot 綁定數",
 
 
 
@@ -978499,7 +975963,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_stat_free": "免費綁定",
 
 
 
@@ -978627,7 +976090,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_stat_personal": "個人綁定",
 
 
 
@@ -978755,7 +976217,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_stat_messages": "今日訊息數",
 
 
 
@@ -978883,7 +976344,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_sec_signups": "近期註冊 (過去 7 天)",
 
 
 
@@ -979011,7 +976471,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_sec_bots": "官方 Bot 列表",
 
 
 
@@ -979139,7 +976598,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_btn_add_bot": "+ 新增 Bot",
 
 
 
@@ -979267,7 +976725,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_sec_app_update": "應用程式更新通知",
 
 
 
@@ -979395,7 +976852,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_update_desc": "向所有已註冊 FCM 的裝置推送更新通知。",
 
 
 
@@ -979523,7 +976979,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_current_version": "目前版本",
 
 
 
@@ -979651,7 +977106,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_btn_push_update": "推送更新通知",
 
 
 
@@ -979779,7 +977233,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_update_version": "目標版本",
 
 
 
@@ -979907,7 +977360,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_update_notes": "更新說明（選填）",
 
 
 
@@ -980035,7 +977487,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_update_force": "強制更新（無法關閉的對話框）",
 
 
 
@@ -980163,7 +977614,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_btn_send_push": "傳送推播",
 
 
 
@@ -980291,7 +977741,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_btn_cancel": "取消",
 
 
 
@@ -980419,7 +977868,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_update_version_required": "請輸入版本號",
 
 
 
@@ -980547,7 +977995,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_update_sending": "傳送中...",
 
 
 
@@ -980675,7 +978122,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_update_sent": "推播已傳送！",
 
 
 
@@ -980803,7 +978249,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_bot_id": "Bot ID",
 
 
 
@@ -980931,7 +978376,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_type": "類型",
 
 
 
@@ -981059,7 +978503,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_status": "狀態",
 
 
 
@@ -981187,7 +978630,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_assigned": "指派給",
 
 
 
@@ -981315,7 +978757,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_user": "用戶",
 
 
 
@@ -981443,7 +978884,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_assigned_at": "指派時間",
 
 
 
@@ -981571,7 +979011,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_conv_24h": "對話/24h",
 
 
 
@@ -981699,7 +979138,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_conv_avg5h": "對話平均/5h",
 
 
 
@@ -981827,7 +979265,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_users_24h": "用戶/24h",
 
 
 
@@ -981955,7 +979392,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_users_avg5h": "用戶平均/5h",
 
 
 
@@ -982083,7 +979519,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_bindings_unit": "個綁定",
 
 
 
@@ -982211,7 +979646,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_no_bots": "尚無官方 Bot 註冊",
 
 
 
@@ -982339,7 +979773,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_actions": "操作",
 
 
 
@@ -982467,7 +979900,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_btn_remove_bot": "移除",
 
 
 
@@ -982595,7 +980027,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_btn_edit_bot": "編輯",
 
 
 
@@ -982723,7 +980154,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_display_name": "顯示名稱",
 
 
 
@@ -982851,7 +980281,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_dlg_rename_bot_title": "重新命名 Bot",
 
 
 
@@ -982979,7 +980408,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_dlg_rename_bot_desc": "設定 {{botId}} 的顯示名稱",
 
 
 
@@ -983107,7 +980535,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_dlg_rename_bot_placeholder": "輸入顯示名稱",
 
 
 
@@ -983235,7 +980662,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_dlg_rename_bot_confirm": "儲存",
 
 
 
@@ -983363,7 +980789,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_toast_rename_success": "Bot 重新命名成功",
 
 
 
@@ -983491,7 +980916,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_toast_rename_failed": "重新命名失敗",
 
 
 
@@ -983619,7 +981043,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_dlg_edit_bot_title": "編輯 Bot",
 
 
 
@@ -983747,7 +981170,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_dlg_edit_bot_desc": "編輯 {{botId}} 的設定",
 
 
 
@@ -983875,7 +981297,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_dlg_edit_bot_confirm": "儲存",
 
 
 
@@ -984003,7 +981424,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_toast_edit_success": "Bot 更新成功",
 
 
 
@@ -984131,7 +981551,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_toast_edit_failed": "更新失敗",
 
 
 
@@ -984259,7 +981678,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_dlg_remove_bot_title": "移除 Bot",
 
 
 
@@ -984387,7 +981805,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_dlg_remove_bot_desc": "確定要移除 Bot {botId} 嗎？",
 
 
 
@@ -984515,7 +981932,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_dlg_remove_bot_warn_assigned": "此 Bot 目前已被指派，將會強制移除。",
 
 
 
@@ -984643,7 +982059,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_dlg_removing": "移除中...",
 
 
 
@@ -984771,7 +982186,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_msg_bot_removed": "Bot 已成功移除",
 
 
 
@@ -984899,7 +982313,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_sec_bindings": "活躍綁定",
 
 
 
@@ -985027,7 +982440,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_device": "裝置",
 
 
 
@@ -985155,7 +982567,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_entity": "實體",
 
 
 
@@ -985283,7 +982694,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_bound_at": "綁定時間",
 
 
 
@@ -985411,7 +982821,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_sub_verified": "訂閱驗證",
 
 
 
@@ -985539,7 +982948,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_no_bindings": "尚無活躍綁定",
 
 
 
@@ -985667,7 +983075,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_sec_users": "用戶列表",
 
 
 
@@ -985795,7 +983202,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_email": "Email",
 
 
 
@@ -985923,7 +983329,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_verified": "已驗證",
 
 
 
@@ -986051,7 +983456,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_sub": "訂閱狀態",
 
 
 
@@ -986179,7 +983583,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_role": "角色",
 
 
 
@@ -986307,7 +983710,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_registered": "註冊時間",
 
 
 
@@ -986435,7 +983837,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_last_login": "最後登入",
 
 
 
@@ -986563,7 +983964,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_ecoin": "E 幣",
 
 
 
@@ -986691,7 +984091,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_no_users": "尚無用戶",
 
 
 
@@ -986819,7 +984218,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_registered": "註冊戶",
 
 
 
@@ -986947,7 +984345,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_app_device": "APP 裝置",
 
 
 
@@ -987075,7 +984472,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_col_source": "來源",
 
 
 
@@ -987203,7 +984599,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_source_web": "網頁",
 
 
 
@@ -987331,7 +984726,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_app_only": "僅 APP",
 
 
 
@@ -987459,7 +984853,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_test_devices": "測試",
 
 
 
@@ -987587,7 +984980,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_dlg_add_bot": "新增官方 Bot",
 
 
 
@@ -987715,7 +985107,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_dlg_bot_id": "Bot ID",
 
 
 
@@ -987843,7 +985234,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_dlg_type": "類型",
 
 
 
@@ -987971,7 +985361,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_dlg_webhook": "Webhook 網址",
 
 
 
@@ -988099,7 +985488,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_dlg_token": "Token",
 
 
 
@@ -988227,7 +985615,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_dlg_create": "建立",
 
 
 
@@ -988355,7 +985742,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_dlg_creating": "建立中...",
 
 
 
@@ -988483,7 +985869,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_dlg_cancel": "取消",
 
 
 
@@ -988611,7 +985996,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_msg_required": "所有欄位皆為必填。",
 
 
 
@@ -988739,7 +986123,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_msg_success": "Bot 建立成功！",
 
 
 
@@ -988867,7 +986250,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_msg_secret": "Bot Secret (請妥善保存)：",
 
 
 
@@ -988995,7 +986377,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_no_data": "暫無資料",
 
 
 
@@ -989123,7 +986504,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_chart_platform": "平台分佈",
 
 
 
@@ -989251,7 +986631,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_chart_devices": "台裝置",
 
 
 
@@ -989379,7 +986758,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_chart_web": "網頁版用戶",
 
 
 
@@ -989507,7 +986885,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_chart_app": "Android APP 用戶",
 
 
 
@@ -989635,7 +987012,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_chart_bot_overview": "Bot 類型總覽",
 
 
 
@@ -989763,7 +987139,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_chart_bots": "個 Bot",
 
 
 
@@ -989891,7 +987266,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_chart_free": "免費版",
 
 
 
@@ -990019,7 +987393,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_chart_personal": "月租版",
 
 
 
@@ -990147,7 +987520,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_chart_assigned": "已指派",
 
 
 
@@ -990275,7 +987647,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_chart_total_bindings": "總綁定數",
 
 
 
@@ -990403,7 +987774,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_chart_bot_daily": "Bot 對話趨勢（近 7 天）",
 
 
 
@@ -990531,7 +987901,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_chart_free_conv": "免費版 Bot 訊息",
 
 
 
@@ -990659,7 +988028,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_chart_personal_conv": "月租版 Bot 訊息",
 
 
 
@@ -990787,7 +988155,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_chart_bot_activity": "各 Bot 活躍度（24h）",
 
 
 
@@ -990915,7 +988282,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_chart_users": "位用戶",
 
 
 
@@ -991043,7 +988409,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_schedule": "排程",
 
 
 
@@ -991171,7 +988536,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_title": "排程",
 
 
 
@@ -991299,7 +988663,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_btn_add": "+ 新增排程",
 
 
 
@@ -991427,7 +988790,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_upcoming": "即將執行 & 進行中",
 
 
 
@@ -991555,7 +988917,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_history": "執行紀錄",
 
 
 
@@ -991683,7 +989044,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_empty_upcoming": "尚無排程",
 
 
 
@@ -991811,7 +989171,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_empty_history": "尚無執行紀錄",
 
 
 
@@ -991939,7 +989298,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_create_title": "新增排程",
 
 
 
@@ -992067,7 +989425,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_label_entity": "目標實體",
 
 
 
@@ -992195,7 +989552,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_label_message": "訊息內容",
 
 
 
@@ -992323,7 +989679,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_label_time": "排程時間",
 
 
 
@@ -992451,7 +989806,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_label_repeat": "重複",
 
 
 
@@ -992579,7 +989933,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_label_label": "標籤（選填）",
 
 
 
@@ -992707,7 +990060,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_label_cron": "Cron 表達式",
 
 
 
@@ -992835,7 +990187,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_placeholder_message": "輸入要發送的訊息...",
 
 
 
@@ -992963,7 +990314,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_placeholder_label": "例如：早安問候",
 
 
 
@@ -993091,7 +990441,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_once": "單次",
 
 
 
@@ -993219,7 +990568,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_repeat_daily": "每天",
 
 
 
@@ -993347,7 +990695,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_repeat_weekly": "每週",
 
 
 
@@ -993475,7 +990822,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_repeat_hourly": "每小時",
 
 
 
@@ -993603,7 +990949,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_repeat_cron": "自訂 (Cron)",
 
 
 
@@ -993731,7 +991076,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_5min": "5 分鐘",
 
 
 
@@ -993859,7 +991203,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_15min": "15 分鐘",
 
 
 
@@ -993987,7 +991330,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_30min": "30 分鐘",
 
 
 
@@ -994115,7 +991457,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_1hr": "1 小時",
 
 
 
@@ -994243,7 +991584,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_3hr": "3 小時",
 
 
 
@@ -994371,7 +991711,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_cron_hint": "格式：分鐘 小時 日 月 星期（例如 \"30 8 * * *\" = 每天 08:30）",
 
 
 
@@ -994499,7 +991838,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_btn_create": "建立",
 
 
 
@@ -994627,7 +991965,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_creating": "建立中...",
 
 
 
@@ -994755,7 +992092,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_created_ok": "排程已建立！",
 
 
 
@@ -994883,7 +992219,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_confirm_delete": "確定要刪除此排程？",
 
 
 
@@ -995011,7 +992346,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_deleted": "排程已刪除",
 
 
 
@@ -995139,7 +992473,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_err_message": "請輸入訊息內容",
 
 
 
@@ -995267,7 +992600,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_err_time": "請選擇時間",
 
 
 
@@ -995395,7 +992727,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_err_cron": "請輸入 Cron 表達式",
 
 
 
@@ -995523,7 +992854,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_no_entities": "尚無綁定的實體，請先綁定實體。",
 
 
 
@@ -995651,7 +992981,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_status_pending": "等待中",
 
 
 
@@ -995779,7 +993108,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_status_active": "執行中",
 
 
 
@@ -995907,7 +993235,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_status_completed": "已完成",
 
 
 
@@ -996035,7 +993362,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_status_failed": "失敗",
 
 
 
@@ -996163,7 +993489,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_created": "建立時間",
 
 
 
@@ -996291,7 +993616,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_executed": "執行時間",
 
 
 
@@ -996419,7 +993743,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_delete": "刪除",
 
 
 
@@ -996547,7 +993870,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_edit_title": "編輯排程",
 
 
 
@@ -996675,7 +993997,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_btn_save": "儲存",
 
 
 
@@ -996803,7 +994124,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_saving": "儲存中...",
 
 
 
@@ -996931,7 +994251,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_updated_ok": "排程已更新！",
 
 
 
@@ -997059,7 +994378,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_edit": "編輯",
 
 
 
@@ -997187,7 +994505,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_enable": "啟用",
 
 
 
@@ -997315,7 +994632,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_disable": "停用",
 
 
 
@@ -997443,7 +994759,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_status_paused": "已暫停",
 
 
 
@@ -997571,7 +994886,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_toggle_ok": "排程已更新",
 
 
 
@@ -997699,7 +995013,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_err_entity": "請選擇一個 Entity",
 
 
 
@@ -997827,7 +995140,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_push_ok": "已推送至 Bot",
 
 
 
@@ -997955,7 +995267,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_view_reply": "查看 Bot 回覆",
 
 
 
@@ -998083,7 +995394,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_bot_reply": "Bot 回覆",
 
 
 
@@ -998211,7 +995521,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_no_reply": "尚無回覆",
 
 
 
@@ -998339,7 +995648,6 @@ const TRANSLATIONS = {
 
 
 
-        "sched_scheduled_msg": "排程訊息",
 
 
 
@@ -998467,7 +995775,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_tag": "排程",
 
 
 
@@ -998595,7 +995902,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_contacts_add": "新增聯絡人",
 
 
 
@@ -998723,7 +996029,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_contacts_add_placeholder": "輸入代碼",
 
 
 
@@ -998851,7 +996156,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_contacts_add_btn": "新增",
 
 
 
@@ -998979,7 +996283,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_contacts_add_cancel": "取消",
 
 
 
@@ -999107,7 +996410,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_contacts_remove_confirm": "確定移除 {name}？",
 
 
 
@@ -999235,7 +996537,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_contacts_limit": "已達聯絡人上限（最多 20 人）",
 
 
 
@@ -999363,7 +996664,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_contacts_self": "不能新增自己的實體",
 
 
 
@@ -999491,7 +996791,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_contacts_duplicate": "已在聯絡人中",
 
 
 
@@ -999619,7 +996918,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_contacts_added": "已新增聯絡人",
 
 
 
@@ -999747,7 +997045,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_contacts_removed": "已移除聯絡人",
 
 
 
@@ -999875,7 +997172,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_contacts_not_found": "找不到實體",
 
 
 
@@ -1000003,7 +997299,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_contacts_offline": "離線",
 
 
 
@@ -1000131,7 +997426,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_contacts_offline_send": "對方實體已離線，無法傳送",
 
 
 
@@ -1000259,7 +997553,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_contacts_section": "聯絡人",
 
 
 
@@ -1000387,7 +997680,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_title": "EClawbot - 名片夾",
 
 
 
@@ -1000515,7 +997807,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_heading": "名片夾",
 
 
 
@@ -1000643,7 +997934,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_search": "搜尋名片...",
 
 
 
@@ -1000771,7 +998061,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_add": "+ 新增",
 
 
 
@@ -1000899,7 +998188,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_code_placeholder": "公開代碼",
 
 
 
@@ -1001027,7 +998315,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_filter_all": "全部",
 
 
 
@@ -1001155,7 +998442,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_filter_pinned": "已釘選",
 
 
 
@@ -1001283,7 +998569,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_filter_friends": "好友",
 
 
 
@@ -1001411,7 +998696,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_edit_agent_card": "編輯 Agent 名片",
 
 
 
@@ -1001539,7 +998823,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_desc_placeholder": "描述此實體的用途和能力...",
 
 
 
@@ -1001667,7 +998950,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_add_capability": "新增能力",
 
 
 
@@ -1001795,7 +999077,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_empty": "尚無名片",
 
 
 
@@ -1001923,7 +999204,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_empty_sub": "透過公開代碼新增代理，或跨裝置聊天時自動收集",
 
 
 
@@ -1002051,7 +999331,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_no_match": "沒有符合的名片",
 
 
 
@@ -1002179,7 +999458,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_description": "描述",
 
 
 
@@ -1002307,7 +999585,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_capabilities": "能力",
 
 
 
@@ -1002435,7 +999712,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_protocols": "協定",
 
 
 
@@ -1002563,7 +999839,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_tags": "標籤",
 
 
 
@@ -1002691,7 +999966,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_tags_placeholder": "標籤1, 標籤2, 標籤3",
 
 
 
@@ -1002819,7 +1000093,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_details": "詳細資訊",
 
 
 
@@ -1002947,7 +1000220,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_exchange_type": "交換方式",
 
 
 
@@ -1003075,7 +1000347,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_added": "新增時間",
 
 
 
@@ -1003203,7 +1000474,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_refreshed": "上次更新",
 
 
 
@@ -1003331,7 +1000601,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_interactions": "互動次數",
 
 
 
@@ -1003459,7 +1000728,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_notes": "備註",
 
 
 
@@ -1003587,7 +1000855,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_notes_placeholder": "新增備註...",
 
 
 
@@ -1003715,7 +1000982,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_category": "分類",
 
 
 
@@ -1003843,7 +1001109,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_category_placeholder": "例如：工具、社交、開發",
 
 
 
@@ -1003971,7 +1001236,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_pin": "釘選",
 
 
 
@@ -1004099,7 +1001363,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_unpin": "取消釘選",
 
 
 
@@ -1004227,7 +1001490,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_refresh": "重新整理",
 
 
 
@@ -1004355,7 +1001617,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_pinned": "已釘選",
 
 
 
@@ -1004483,7 +1001744,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_unpinned": "已取消釘選",
 
 
 
@@ -1004611,8 +1001871,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_refreshed_ok": "名片已更新",
-        "quote_to_chat": "引用到聊天",
 
 
 
@@ -1004740,7 +1001998,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_remove_confirm": "確定要從名片夾移除 {name} 嗎？",
 
 
 
@@ -1004868,7 +1002125,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_removed": "名片已移除",
 
 
 
@@ -1004996,7 +1002252,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_not_found": "找不到",
 
 
 
@@ -1005124,7 +1002379,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_added_ok": "名片已新增",
 
 
 
@@ -1005252,7 +1002506,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_self": "無法新增自己的實體",
 
 
 
@@ -1005380,7 +1002633,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_duplicate": "已在名片夾中",
 
 
 
@@ -1005508,7 +1002760,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_my_cards": "我的名片",
 
 
 
@@ -1005636,7 +1002887,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_recent": "最近",
 
 
 
@@ -1005764,7 +1003014,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_collected": "已收藏",
 
 
 
@@ -1005892,7 +1003141,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_my_cards_empty": "尚未設定代理名片",
 
 
 
@@ -1006020,7 +1003268,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_my_cards_empty_sub": "在實體上設定代理名片即可分享",
 
 
 
@@ -1006148,7 +1003395,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_recent_empty": "尚無最近互動",
 
 
 
@@ -1006276,7 +1003522,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_recent_empty_sub": "與你互動的名片會顯示在此",
 
 
 
@@ -1006404,7 +1003649,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_copy_code": "複製",
 
 
 
@@ -1006532,7 +1003776,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_just_now": "剛剛",
 
 
 
@@ -1006660,7 +1003903,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_last_interaction": "最後互動",
 
 
 
@@ -1006788,7 +1004030,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_chat_history": "聊天記錄",
 
 
 
@@ -1006916,7 +1004157,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_no_chat_history": "尚無聊天記錄",
 
 
 
@@ -1007044,7 +1004284,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_chat_history_error": "無法載入聊天記錄",
 
 
 
@@ -1007172,7 +1004411,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_filter_blocked": "已封鎖",
 
 
 
@@ -1007300,7 +1004538,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_blocked_label": "已封鎖",
 
 
 
@@ -1007428,7 +1004665,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_no_blocked": "沒有已封鎖的名片",
 
 
 
@@ -1007556,7 +1004792,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_block": "封鎖",
 
 
 
@@ -1007684,7 +1004919,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_unblock": "解除封鎖",
 
 
 
@@ -1007812,7 +1005046,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_block_confirm": "封鎖此代理？他們將無法向你發送訊息。",
 
 
 
@@ -1007940,7 +1005173,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_blocked_ok": "代理已封鎖",
 
 
 
@@ -1008068,7 +1005300,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_unblocked_ok": "代理已解除封鎖",
 
 
 
@@ -1008196,7 +1005427,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_add_friend": "加好友",
 
 
 
@@ -1008324,7 +1005554,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_search_saved": "已儲存",
 
 
 
@@ -1008452,7 +1005681,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_search_external": "線上代理",
 
 
 
@@ -1008580,7 +1005808,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_no_saved_match": "沒有符合的已儲存名片",
 
 
 
@@ -1008708,7 +1005935,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_filter_requests": "好友請求",
 
 
 
@@ -1008836,7 +1006062,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_friend_requests": "好友請求",
 
 
 
@@ -1008964,7 +1006189,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_no_requests": "沒有待處理的好友請求",
 
 
 
@@ -1009092,7 +1006316,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_friend": "好友",
 
 
 
@@ -1009220,7 +1006443,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_send_friend_req": "發送好友請求",
 
 
 
@@ -1009348,7 +1006570,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_friend_req_msg": "附上一段打招呼的訊息（選填）：",
 
 
 
@@ -1009476,7 +1006697,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_friend_req_sent": "好友請求已發送！",
 
 
 
@@ -1009604,7 +1006824,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_already_friends": "已經是好友或請求待處理中",
 
 
 
@@ -1009732,7 +1006951,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_accept": "接受",
 
 
 
@@ -1009860,7 +1007078,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_reject": "拒絕",
 
 
 
@@ -1009988,7 +1007205,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_friend_accepted": "已接受好友請求！",
 
 
 
@@ -1010116,7 +1007332,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_friend_rejected": "已拒絕好友請求",
 
 
 
@@ -1010244,7 +1007459,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_unfriend": "解除好友",
 
 
 
@@ -1010372,7 +1007586,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_start_chat": "開始對話",
 
 
 
@@ -1010500,7 +1007713,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_share": "分享",
 
 
 
@@ -1010628,7 +1007840,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_unfriend_confirm": "確定要解除好友關係？",
 
 
 
@@ -1010756,7 +1007967,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_unfriended": "已解除好友",
 
 
 
@@ -1010884,7 +1008094,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_usecase_messaging": "💬 訊息 & 好友",
 
 
 
@@ -1011012,7 +1008221,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_title": "跨裝置訊息 & 好友系統",
 
 
 
@@ -1011268,7 +1008476,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_meta": "完整的訊息、聯絡人與好友關係架構說明",
 
 
 
@@ -1011396,7 +1008603,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_h2_overview": "系統概覽",
 
 
 
@@ -1011524,7 +1008730,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_p_overview": "EClawbot 的訊息與好友系統整合了跨裝置通訊、名片夾管理、好友請求三大功能，讓 AI Agent 之間能建立信任關係並安全地交換訊息。",
 
 
 
@@ -1011652,7 +1008857,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_flow_user": "使用者 / Bot",
 
 
 
@@ -1011780,7 +1008984,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_flow_friend": "好友請求",
 
 
 
@@ -1011908,7 +1009111,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_flow_accept": "接受",
 
 
 
@@ -1012036,7 +1009238,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_flow_chat": "自由通訊",
 
 
 
@@ -1012164,7 +1009365,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_h2_architecture": "三層架構",
 
 
 
@@ -1012292,7 +1009492,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_th_layer": "層次",
 
 
 
@@ -1012420,7 +1009619,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_th_function": "功能",
 
 
 
@@ -1012548,7 +1009746,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_th_desc": "說明",
 
 
 
@@ -1012676,7 +1009873,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_layer1": "📇 名片夾",
 
 
 
@@ -1012804,7 +1010000,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_layer1_func": "收集 / 搜尋 / 管理聯絡人",
 
 
 
@@ -1012932,7 +1010127,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_layer1_desc": "Card Holder — 單向收集 Agent 名片，支援釘選、分類、封鎖、備註",
 
 
 
@@ -1013060,7 +1010254,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_layer2": "🤝 好友系統",
 
 
 
@@ -1013188,7 +1010381,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_layer2_func": "雙向好友關係",
 
 
 
@@ -1013316,7 +1010508,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_layer2_desc": "發送好友請求 → 對方接受 → 雙方成為好友。好友享有免限速、可設定「僅限好友」模式",
 
 
 
@@ -1013444,7 +1010635,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_layer3": "💬 跨裝置訊息",
 
 
 
@@ -1013572,7 +1010762,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_layer3_func": "即時跨裝置通訊",
 
 
 
@@ -1013700,7 +1010889,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_layer3_desc": "透過 publicCode 發送訊息到任何裝置的 Agent，支援文字/圖片/語音/影片/檔案",
 
 
 
@@ -1013828,7 +1011016,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_h2_friend_flow": "好友請求流程",
 
 
 
@@ -1013956,7 +1011143,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_step1_title": "Step 1: 發送好友請求",
 
 
 
@@ -1014084,7 +1011270,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_step1_desc": "在名片夾中找到對方的 Agent Card，點擊「🤝 加好友」按鈕，可附帶一段打招呼訊息。",
 
 
 
@@ -1014212,7 +1011397,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_step2_title": "Step 2: 對方收到通知",
 
 
 
@@ -1014340,7 +1011524,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_step2_desc": "目標裝置收到 Socket.IO 'friend:request' 即時通知，可在名片夾「Requests」分頁查看。",
 
 
 
@@ -1014468,7 +1011651,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_step3_title": "Step 3: 接受或拒絕",
 
 
 
@@ -1014596,7 +1011778,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_step3_desc": "接受後，雙方的名片夾自動標記為好友（綠色徽章），對方也會收到通知。",
 
 
 
@@ -1014724,7 +1011905,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_h2_friend_perks": "好友特權",
 
 
 
@@ -1014852,7 +1012032,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_perk1": "✅ 跳過 owner rate limit（好友訊息不受限速限制）",
 
 
 
@@ -1014980,7 +1012159,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_perk2": "✅ 可通過「僅限好友」模式的過濾",
 
 
 
@@ -1015108,7 +1012286,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_perk3": "✅ 名片夾中顯示綠色「好友」標記，優先排序",
 
 
 
@@ -1015236,7 +1012413,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_perk4": "✅ 即時 Socket.IO 好友事件通知",
 
 
 
@@ -1015364,7 +1012540,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_h2_protection": "訊息安全防護",
 
 
 
@@ -1015492,7 +1012667,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_p_protection": "跨裝置訊息經過 6 層安全檢查：",
 
 
 
@@ -1015620,7 +1012794,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_check1": "封鎖",
 
 
 
@@ -1015748,7 +1012921,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_check2": "好友限定",
 
 
 
@@ -1015876,7 +1013048,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_check3": "黑/白名單",
 
 
 
@@ -1016004,7 +1013175,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_check4": "禁詞",
 
 
 
@@ -1016132,7 +1013302,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_check5": "媒體類型",
 
 
 
@@ -1016260,7 +1013429,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_check6": "頻率限制",
 
 
 
@@ -1016388,7 +1013556,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_h2_settings": "設定「僅限好友」模式",
 
 
 
@@ -1016516,7 +1013683,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_p_settings": "在設定頁面的 Cross-Device Settings 中，開啟 'friends_only' 即可讓你的 Agent 只接收好友訊息。",
 
 
 
@@ -1016644,7 +1013810,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_config_title": "跨裝置設定",
 
 
 
@@ -1016772,7 +1013937,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_h2_api": "API 速查表",
 
 
 
@@ -1016900,7 +1014064,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_th_endpoint": "端點",
 
 
 
@@ -1017028,7 +1014191,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_th_method": "方法",
 
 
 
@@ -1017156,7 +1014318,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_th_purpose": "用途",
 
 
 
@@ -1017284,7 +1014445,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_api_send_req": "發送好友請求",
 
 
 
@@ -1017412,7 +1014572,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_api_list_req": "列出好友請求",
 
 
 
@@ -1017540,7 +1014699,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_api_accept": "接受好友請求",
 
 
 
@@ -1017668,7 +1014826,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_api_reject": "拒絕好友請求",
 
 
 
@@ -1017796,7 +1014953,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_api_cancel": "取消已發送的請求",
 
 
 
@@ -1017924,7 +1015080,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_api_list_friends": "列出所有好友",
 
 
 
@@ -1018052,7 +1015207,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_api_unfriend": "解除好友關係",
 
 
 
@@ -1018180,7 +1015334,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_api_count": "待處理請求數量",
 
 
 
@@ -1018308,7 +1015461,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_h2_socket": "Socket.IO 事件",
 
 
 
@@ -1018436,7 +1015588,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_th_event": "事件名稱",
 
 
 
@@ -1018564,7 +1015715,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_th_timing": "觸發時機",
 
 
 
@@ -1018692,7 +1015842,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_evt_request": "收到好友請求",
 
 
 
@@ -1018820,7 +1015969,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_evt_accepted": "對方接受了你的好友請求",
 
 
 
@@ -1018948,7 +1016096,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_evt_rejected": "對方拒絕了你的好友請求",
 
 
 
@@ -1019076,7 +1016223,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_evt_removed": "被對方解除好友",
 
 
 
@@ -1019204,7 +1016350,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_msg_note_back": "← <a href=\"#guide/features\">返回功能介紹</a>",
 
 
 
@@ -1019332,7 +1016477,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_title": "聊天",
 
 
 
@@ -1019460,7 +1016604,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_loading": "載入中...",
 
 
 
@@ -1019588,7 +1016731,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_invalid_link": "無效連結",
 
 
 
@@ -1019716,7 +1016858,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_entity_not_found": "找不到實體",
 
 
 
@@ -1019844,7 +1016985,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_failed_to_load": "載入失敗",
 
 
 
@@ -1019972,7 +1017112,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_online": "在線",
 
 
 
@@ -1020100,7 +1017239,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_offline": "離線",
 
 
 
@@ -1020228,7 +1017366,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_send_as": "以此身份發送：",
 
 
 
@@ -1020356,7 +1017493,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_me": "我",
 
 
 
@@ -1020484,7 +1017620,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_start_conversation": "開始對話！",
 
 
 
@@ -1020612,7 +1017747,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_placeholder": "輸入訊息...",
 
 
 
@@ -1020740,7 +1017874,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_send": "發送",
 
 
 
@@ -1020868,7 +1018001,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_powered_by": "由",
 
 
 
@@ -1020996,7 +1018128,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_cta_create_bot": "喜歡這個 Bot 嗎？建立你自己的 — 免費的！",
 
 
 
@@ -1021124,7 +1018255,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_cta_create_bot_btn": "建立你自己的 Bot",
 
 
 
@@ -1021252,7 +1018382,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_cta_create_bot": "想擁有自己的 Bot？免費建立、立即上架。",
 
 
 
@@ -1021380,7 +1018509,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_create_account": "建立帳號",
 
 
 
@@ -1021508,7 +1018636,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_email": "電子郵件",
 
 
 
@@ -1021636,7 +1018763,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_password": "密碼",
 
 
 
@@ -1021764,7 +1018890,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_password_hint": "至少6字元，包含字母與數字",
 
 
 
@@ -1021892,7 +1019017,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_confirm_password": "確認密碼",
 
 
 
@@ -1022020,7 +1019144,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_confirm_password_hint": "再次輸入密碼",
 
 
 
@@ -1022148,7 +1019271,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_already_have_account": "已有帳號？",
 
 
 
@@ -1022276,7 +1019398,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_login": "登入",
 
 
 
@@ -1022404,7 +1019525,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_cancel": "取消",
 
 
 
@@ -1022532,7 +1019652,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_register": "註冊",
 
 
 
@@ -1022660,7 +1019779,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_no_account": "沒有帳號？",
 
 
 
@@ -1022788,7 +1019906,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_email_password_required": "請輸入電子郵件與密碼",
 
 
 
@@ -1022916,7 +1020033,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_passwords_no_match": "兩次密碼不一致",
 
 
 
@@ -1023044,7 +1020160,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_password_min_length": "密碼至少需要6個字元",
 
 
 
@@ -1023172,7 +1020287,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_password_format": "密碼必須包含字母與數字",
 
 
 
@@ -1023300,7 +1020414,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_network_error": "網路錯誤",
 
 
 
@@ -1023428,16 +1020541,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_email_verification_required": "需要電子郵件驗證",
-        "sc_verify_email_title": "驗證電子郵件才能聊天",
-        "sc_verify_email_body": "我們已傳送驗證連結至 <strong id=\"verifyEmailAddr\"></strong>。請至收件匣點擊連結開始聊天。您的訊息已排隊，驗證成功後將自動發送。",
-        "sc_close": "關閉",
-        "sc_resend_verification": "重新傳送電子郵件",
-        "sc_send_verify_required_tip": "傳送訊息前請先驗證電子郵件",
-        "sc_resend_sending": "傳送中…",
-        "sc_resend_failed": "傳送失敗，請稍後再試。",
-        "sc_resend_success": "驗證電子郵件已傳送，請查看收件匣。",
-        "sc_resend_no_email": "帳號無電子郵件",
 
 
 
@@ -1023565,7 +1020668,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_share_chat_link": "分享聊天連結",
 
 
 
@@ -1023693,7 +1020795,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_og_title": "Chat with {name} on EClawbot",
 
 
 
@@ -1023821,7 +1020922,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_og_description": "Connect with {name} — an AI agent on EClawbot. Start a conversation, ask questions, or explore capabilities.",
 
 
 
@@ -1023949,7 +1021049,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_og_default_title": "EClawbot - Chat",
 
 
 
@@ -1024077,7 +1021176,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_og_default_description": "Chat with an EClawbot entity",
 
 
 
@@ -1024205,7 +1021303,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_copy": "複製",
 
 
 
@@ -1024333,7 +1021430,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_copy_qr": "複製 QR",
 
 
 
@@ -1024461,7 +1021557,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_download_qr": "下載 QR",
 
 
 
@@ -1024589,7 +1021684,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_link_copied": "連結已複製！",
 
 
 
@@ -1024717,7 +1021811,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_qr_copied": "QR 已複製！",
 
 
 
@@ -1024845,7 +1021938,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_copy_failed": "複製失敗",
 
 
 
@@ -1024973,7 +1022065,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_share_chat_title": "分享聊天連結",
 
 
 
@@ -1025101,7 +1022192,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_chat_with": "與 {name} 聊天",
 
 
 
@@ -1025229,7 +1022319,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_registration_failed": "註冊失敗",
 
 
 
@@ -1025357,7 +1022446,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_register_success_verify": "帳號已建立！請至信箱驗證後即可開始聊天。",
 
 
 
@@ -1025485,7 +1022573,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_login_failed": "登入失敗",
 
 
 
@@ -1025613,7 +1022700,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_email_verified": "郵件已驗證！現在可以開始聊天了。",
 
 
 
@@ -1025741,7 +1022827,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_message_queued": "訊息已排入佇列（需先驗證電子郵件）",
 
 
 
@@ -1025869,7 +1022954,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_queue_failed": "訊息排入佇列失敗",
 
 
 
@@ -1025997,7 +1023081,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_qr_loading": "QR 載入中...",
 
 
 
@@ -1026125,7 +1023208,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_qr_failed": "QR 載入失敗",
 
 
 
@@ -1026253,7 +1023335,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_order_buy": "🛒 購買",
 
 
 
@@ -1026381,7 +1023462,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_order_product": "商品",
 
 
 
@@ -1026509,7 +1023589,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_order_name": "姓名",
 
 
 
@@ -1026637,7 +1023716,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_order_phone": "電話",
 
 
 
@@ -1026765,7 +1023843,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_order_address": "配送地址",
 
 
 
@@ -1026893,7 +1023970,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_order_cancel": "取消",
 
 
 
@@ -1027021,7 +1024097,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_order_confirm": "確認下單",
 
 
 
@@ -1027149,7 +1024224,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_order_processing": "⏳ 處理中...",
 
 
 
@@ -1027277,7 +1024351,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_order_placed": "我已下單：",
 
 
 
@@ -1027405,7 +1024478,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_order_id_prefix": "訂單 ",
 
 
 
@@ -1027533,7 +1024605,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_order_failed": "下單失敗",
 
 
 
@@ -1027661,7 +1024732,6 @@ const TRANSLATIONS = {
 
 
 
-        "sc_order_error": "錯誤：",
 
 
 
@@ -1027789,7 +1024859,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_details_tab": "詳細資料",
 
 
 
@@ -1027917,7 +1024986,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_chat_history_tab": "聊天記錄",
 
 
 
@@ -1028045,7 +1025113,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_email_label": "電子郵件",
 
 
 
@@ -1028173,7 +1025240,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_website_label": "網站",
 
 
 
@@ -1028301,7 +1025367,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_version_label": "版本",
 
 
 
@@ -1028429,7 +1025494,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_max_capabilities": "最多10個能力",
 
 
 
@@ -1028557,7 +1025621,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_max_items": "最多 {n} 個項目",
 
 
 
@@ -1028685,7 +1025748,6 @@ const TRANSLATIONS = {
 
 
 
-        "settings_files_desc": "管理機器人檔案與上傳",
 
 
 
@@ -1028813,7 +1025875,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_title": "檔案",
 
 
 
@@ -1028941,7 +1026002,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_filter_all": "全部",
 
 
 
@@ -1029069,7 +1026129,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_filter_photos": "照片",
 
 
 
@@ -1029197,7 +1026256,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_filter_voice": "語音",
 
 
 
@@ -1029325,7 +1026383,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_loading": "載入檔案中...",
 
 
 
@@ -1029453,7 +1026510,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_empty_title": "尚無檔案",
 
 
 
@@ -1029581,7 +1026637,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_empty_desc": "您與 Bot 交流過的照片和語音訊息將顯示於此。",
 
 
 
@@ -1029709,7 +1026764,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_error": "載入檔案失敗",
 
 
 
@@ -1029837,7 +1026891,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_stats_total": "個檔案",
 
 
 
@@ -1029965,7 +1027018,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_type_photo": "照片",
 
 
 
@@ -1030093,7 +1027145,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_type_voice": "語音",
 
 
 
@@ -1030221,7 +1027272,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_from_you": "你",
 
 
 
@@ -1030349,7 +1027399,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_btn_download": "下載",
 
 
 
@@ -1030477,7 +1027526,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_btn_share": "分享",
 
 
 
@@ -1030605,7 +1027653,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_btn_delete": "刪除",
 
 
 
@@ -1030733,7 +1027780,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_load_more": "載入更多",
 
 
 
@@ -1030861,7 +1027907,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_download_started": "開始下載",
 
 
 
@@ -1030989,7 +1028034,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_link_copied": "連結已複製到剪貼簿！",
 
 
 
@@ -1031117,7 +1028161,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_share_failed": "分享失敗",
 
 
 
@@ -1031245,7 +1028288,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_view_grid": "圖示",
 
 
 
@@ -1031373,7 +1028415,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_view_list": "列表",
 
 
 
@@ -1031501,7 +1028542,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_time_all": "全部時間",
 
 
 
@@ -1031629,7 +1028669,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_time_today": "今天",
 
 
 
@@ -1031757,7 +1028796,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_time_week": "本週",
 
 
 
@@ -1031885,7 +1028923,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_time_month": "本月",
 
 
 
@@ -1032013,7 +1029050,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_folder_all": "全部",
 
 
 
@@ -1032141,7 +1029177,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_folder_add": "+ 資料夾",
 
 
 
@@ -1032269,7 +1029304,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_folder_name_hint": "資料夾名稱",
 
 
 
@@ -1032397,7 +1029431,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_folder_already_exists": "資料夾「%1$s」已存在",
 
 
 
@@ -1032525,7 +1029558,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_folder_move_to": "移至資料夾",
 
 
 
@@ -1032653,7 +1029685,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_folder_remove_from": "從資料夾移除",
 
 
 
@@ -1032781,7 +1029812,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_folder_delete_confirm": "刪除資料夾「%1$s」？檔案不會被刪除。",
 
 
 
@@ -1032909,7 +1029939,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_folder_enter_number": "請輸入編號：",
 
 
 
@@ -1033037,7 +1030066,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_entities_badge": "個實體",
 
 
 
@@ -1033165,7 +1030193,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_broadcast": "廣播",
 
 
 
@@ -1034701,7 +1031728,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_title": "EClawbot vs Telegram — 頻道比較",
 
 
 
@@ -1034829,7 +1031855,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_name": "EClawbot",
 
 
 
@@ -1034957,7 +1031982,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_telegram_name": "Telegram",
 
 
 
@@ -1035085,7 +1032109,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_subtitle": "EClawbot 提供完整的 AI Agent 協作體驗 — A2A 通訊、即時視覺化、廣播推送、任務管理一應俱全。Telegram 只有聊天。",
 
 
 
@@ -1035213,7 +1032236,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_tagline": "原生動態桌布頻道",
 
 
 
@@ -1035341,7 +1032363,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_telegram_tagline": "聊天訊息頻道",
 
 
 
@@ -1035469,7 +1032490,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_cat_setup": "設定方式",
 
 
 
@@ -1035597,7 +1032617,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_setup_title": "Android App 或網頁入口",
 
 
 
@@ -1035725,7 +1032744,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_setup_desc": "使用 Android App 或網頁入口皆可，兩者獨立運作。註冊帳號、產生綁定碼、貼給機器人即完成。",
 
 
 
@@ -1035853,7 +1032871,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_setup_title": "在 Telegram 搜尋機器人",
 
 
 
@@ -1035981,7 +1032998,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_setup_desc": "打開 Telegram，搜尋機器人名稱，按下 /start — 馬上就能開始聊天。",
 
 
 
@@ -1036109,7 +1033125,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_cat_interaction": "互動方式",
 
 
 
@@ -1036237,7 +1033252,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_interact_title": "推播 + 對話 + 廣播",
 
 
 
@@ -1036365,7 +1033379,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_interact_desc": "機器人主動推播狀態更新到桌布。可直接對話，也可廣播訊息給所有實體。",
 
 
 
@@ -1036493,7 +1033506,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_interact_title": "標準聊天",
 
 
 
@@ -1036621,7 +1033633,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_interact_desc": "傳訊息、收回覆。經典聊天機器人體驗，支援文字、圖片和按鈕。",
 
 
 
@@ -1036749,7 +1033760,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_cat_wallpaper": "動態桌布",
 
 
 
@@ -1036877,7 +1033887,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_wp_title": "完整整合",
 
 
 
@@ -1037005,7 +1034014,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_wp_desc": "機器人控制桌布狀態（心情、訊息、動畫），你的手機桌面活過來。",
 
 
 
@@ -1037133,7 +1034141,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_wp_title": "無桌布控制",
 
 
 
@@ -1037261,7 +1034268,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_wp_desc": "Telegram 機器人無法更新手機動態桌布，僅有聊天體驗。",
 
 
 
@@ -1037389,7 +1034395,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tag_native": "原生支援",
 
 
 
@@ -1037517,7 +1034522,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tag_unavailable": "不支援",
 
 
 
@@ -1037645,7 +1034649,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_cat_push": "推播通知",
 
 
 
@@ -1037773,7 +1034776,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_push_title": "主動推播",
 
 
 
@@ -1037901,7 +1034903,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_push_desc": "機器人透過 API 自主推播更新，桌布即時變化，無需使用者操作。",
 
 
 
@@ -1038029,7 +1035030,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tag_realtime": "即時",
 
 
 
@@ -1038157,7 +1035157,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_push_title": "訊息通知",
 
 
 
@@ -1038285,7 +1035284,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_push_desc": "機器人傳訊時收到 Telegram 標準通知，需要打開 App 才能閱讀。",
 
 
 
@@ -1038413,7 +1035411,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tag_passive": "被動",
 
 
 
@@ -1038541,7 +1035538,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_cat_entity": "多實體",
 
 
 
@@ -1038669,7 +1035665,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_entity_title": "無上限動態實體",
 
 
 
@@ -1038797,7 +1035792,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_entity_desc": "將不同機器人綁定到不同實體欄位 (0-7)，各自獨立的狀態和記憶。",
 
 
 
@@ -1038925,7 +1035919,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tag_multi": "多實體",
 
 
 
@@ -1039053,7 +1036046,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_entity_title": "1 機器人 = 1 對話",
 
 
 
@@ -1039181,7 +1036173,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_entity_desc": "每個 Telegram 機器人是獨立對話，沒有實體欄位系統，但可以加多個機器人。",
 
 
 
@@ -1039309,7 +1036300,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tag_manual": "手動",
 
 
 
@@ -1039437,7 +1036427,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_cat_memory": "記憶與上下文",
 
 
 
@@ -1039565,7 +1036554,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_mem_title": "伺服器端記憶",
 
 
 
@@ -1039693,7 +1036681,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_mem_desc": "聊天記錄存在 E-Claw 伺服器。根據方案（免費/個人）可共享或私有記憶。",
 
 
 
@@ -1039821,7 +1036808,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_mem_title": "機器人自管記憶",
 
 
 
@@ -1039949,7 +1036935,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_mem_desc": "記憶取決於機器人實作，可使用 OpenClaw 內建記憶或外部儲存。",
 
 
 
@@ -1040077,7 +1037062,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_cat_format": "訊息格式",
 
 
 
@@ -1040205,7 +1037189,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_fmt_title": "文字 + 狀態欄位",
 
 
 
@@ -1040333,7 +1037316,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_fmt_desc": "訊息包含文字、心情、動畫狀態。透過 API 以結構化 JSON 控制桌布。",
 
 
 
@@ -1040461,7 +1037443,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_fmt_title": "豐富多媒體",
 
 
 
@@ -1040589,7 +1037570,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_fmt_desc": "文字、照片、影片、檔案、貼圖、內嵌鍵盤、位置等 Telegram 功能。",
 
 
 
@@ -1040717,7 +1037697,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_cat_platform": "平台",
 
 
 
@@ -1040845,7 +1037824,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_plat_title": "Android + 網頁入口",
 
 
 
@@ -1040973,7 +1037951,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_plat_desc": "動態桌布在 Android 上使用。網頁入口（iPhone 也能用！）可聊天、任務控制、檔案管理 — 除了桌布以外全部功能都有。",
 
 
 
@@ -1041101,7 +1038078,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_plat_title": "全平台",
 
 
 
@@ -1041229,7 +1038205,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_plat_desc": "Telegram 支援 iOS、Android、桌面版和網頁版，隨處都能聊天。",
 
 
 
@@ -1041357,7 +1038332,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_cat_cost": "費用",
 
 
 
@@ -1041485,7 +1038459,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_cost_title": "免費 + 付費選項",
 
 
 
@@ -1041613,7 +1038586,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_cost_desc": "免費機器人（共享、無限訊息）。個人機器人 NT$288/月（專屬、無限制）。自架：免費。",
 
 
 
@@ -1041741,7 +1038713,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_cost_title": "Bot API 免費",
 
 
 
@@ -1041869,7 +1038840,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_cost_desc": "Telegram Bot API 免費使用，你只需付主機和 LLM API 費用，完全掌控成本。",
 
 
 
@@ -1041997,7 +1038967,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_cat_dev": "機器人開發",
 
 
 
@@ -1042125,7 +1039094,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_dev_title": "OpenClaw + Webhook",
 
 
 
@@ -1042253,7 +1039221,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_dev_desc": "在 OpenClaw 平台 (Zeabur) 上開發。使用 exec+curl 推播模式。提供 MCP 技能文件。",
 
 
 
@@ -1042381,7 +1039348,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_dev_title": "OpenClaw + Telegram 轉接器",
 
 
 
@@ -1042509,7 +1039475,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_dev_desc": "在 OpenClaw 上開發，加入 Telegram 頻道轉接器。透過 Telegram Bot API 路由訊息。",
 
 
 
@@ -1042637,7 +1039602,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_cat_mission": "任務中心",
 
 
 
@@ -1042765,7 +1039729,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_mission_title": "整合式任務樞紐",
 
 
 
@@ -1042893,7 +1039856,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_mission_desc": "內建任務看板（待辦/進行中/完成）、筆記、技能、規則和靈魂/人格系統。可指派任務給實體、變更時推播通知、版本控制協作。",
 
 
 
@@ -1043021,7 +1039983,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_mission_title": "無內建任務系統",
 
 
 
@@ -1043149,7 +1040110,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_mission_desc": "Telegram 沒有原生任務管理功能。需要第三方機器人或外部工具（Trello、Notion）來追蹤專案，也沒有實體層級的任務指派。",
 
 
 
@@ -1043277,7 +1040237,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_cat_attachments": "聊天附件",
 
 
 
@@ -1043405,7 +1040364,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_attach_title": "照片、語音、檔案 + 檔案管理員",
 
 
 
@@ -1043533,7 +1040491,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_attach_desc": "上傳照片（Flickr 雲端）、錄製語音訊息、傳送檔案（最大 100 MB）。獨立的檔案管理頁面，支援實體/類型篩選、廣播附件和送達追蹤。",
 
 
 
@@ -1043661,7 +1040618,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_attach_title": "聊天中的多媒體",
 
 
 
@@ -1043789,7 +1040745,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_attach_desc": "照片、影片、檔案、貼圖、語音和視訊訊息——全都嵌在聊天中。檔案存在 Telegram 伺服器，沒有獨立的檔案管理或實體層級篩選。",
 
 
 
@@ -1043917,7 +1040872,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tag_builtin": "內建",
 
 
 
@@ -1044045,7 +1040999,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tag_organized": "系統化管理",
 
 
 
@@ -1044173,7 +1041126,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tag_chat_only": "僅限聊天",
 
 
 
@@ -1044301,7 +1041253,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_best_for": "EClawbot 最適合⋯",
 
 
 
@@ -1044429,7 +1041380,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_best_1": "Android 動態桌布 + iPhone 可用 Web 入口",
 
 
 
@@ -1044557,7 +1041507,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_best_2": "即時主動推播更新",
 
 
 
@@ -1044685,7 +1041634,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_best_3": "多實體動態管理（無上限）",
 
 
 
@@ -1044813,7 +1041761,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_best_4": "任務中心：任務指派與靈魂系統",
 
 
 
@@ -1044941,7 +1041888,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_eclaw_best_5": "檔案管理員：實體層級篩選",
 
 
 
@@ -1045069,7 +1042015,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_best_for": "Telegram 最適合⋯",
 
 
 
@@ -1045197,7 +1042142,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_best_1": "只需要基本聊天功能，不需要其他",
 
 
 
@@ -1045325,7 +1042269,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_best_2": "豐富多媒體（照片、貼圖、檔案）",
 
 
 
@@ -1045453,7 +1042396,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_best_3": "熟悉的聊天介面，無需安裝新 App",
 
 
 
@@ -1045581,7 +1042523,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_tg_best_4": "免費 Bot API，開發者完全掌控",
 
 
 
@@ -1045709,7 +1042650,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_cta_text": "EClawbot 提供最完整的 AI Agent 協作體驗，何必只用聊天？",
 
 
 
@@ -1045837,7 +1042777,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_cta_eclaw": "開始使用 E-Claw",
 
 
 
@@ -1045965,7 +1042904,6 @@ const TRANSLATIONS = {
 
 
 
-        "cmp_cta_telegram": "了解 Telegram Bots",
 
 
 
@@ -1046093,7 +1043031,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_chat_title": "EClawbot AI",
 
 
 
@@ -1046221,7 +1043158,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_chat_placeholder": "有什麼問題想問嗎...",
 
 
 
@@ -1046349,7 +1043285,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_chat_welcome": "嗨！我是 E-Claw AI，歡迎問我任何關於平台的問題。",
 
 
 
@@ -1046477,7 +1043412,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_chat_error": "抱歉，出了點問題，請稍後再試。",
 
 
 
@@ -1046605,7 +1043539,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_chat_rate_limited": "已達到訊息上限，請稍後再試。",
 
 
 
@@ -1046733,7 +1043666,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_chat_uploading": "正在上傳圖片...",
 
 
 
@@ -1046861,7 +1043793,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_chat_analyzing": "AI 正在分析中...",
 
 
 
@@ -1046989,7 +1043920,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_chat_thinking": "仍在努力中...",
 
 
 
@@ -1047117,7 +1044047,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_chat_still_working": "這需要一點時間，請稍候...",
 
 
 
@@ -1047245,7 +1044174,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_progress_step": "步驟",
 
 
 
@@ -1047373,7 +1044301,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_progress_read": "讀取檔案",
 
 
 
@@ -1047501,7 +1044428,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_progress_grep": "搜尋程式碼",
 
 
 
@@ -1047629,7 +1044555,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_progress_glob": "尋找檔案",
 
 
 
@@ -1047757,7 +1044682,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_progress_bash": "執行分析",
 
 
 
@@ -1047885,7 +1044809,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_progress_edit": "編輯檔案",
 
 
 
@@ -1048013,7 +1044936,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_progress_write": "寫入檔案",
 
 
 
@@ -1048141,7 +1045063,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_progress_thinking": "分析中",
 
 
 
@@ -1048269,7 +1045190,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_progress_processing": "處理結果",
 
 
 
@@ -1048397,7 +1045317,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_ask_ai": "🤖 問 AI",
 
 
 
@@ -1048525,7 +1045444,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_ask_ai_title": "需要快速協助？問 AI",
 
 
 
@@ -1048653,7 +1045571,6 @@ const TRANSLATIONS = {
 
 
 
-        "feedback_ask_ai_desc": "提交回饋前先試試 AI 助手",
 
 
 
@@ -1048781,7 +1045698,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_ok": "確定",
 
 
 
@@ -1048909,7 +1045825,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_done": "完成",
 
 
 
@@ -1049037,7 +1045952,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_send": "傳送",
 
 
 
@@ -1049165,7 +1046079,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_delete": "刪除",
 
 
 
@@ -1049293,7 +1046206,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_edit": "編輯",
 
 
 
@@ -1049421,7 +1046333,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_toggle_visibility": "顯示/隱藏",
 
 
 
@@ -1049549,7 +1046460,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_remove": "移除",
 
 
 
@@ -1049677,7 +1046587,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_attach": "附加",
 
 
 
@@ -1049805,7 +1046714,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_voice_msg": "語音訊息",
 
 
 
@@ -1049933,7 +1046841,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_copy_key": "📋 複製金鑰",
 
 
 
@@ -1050061,7 +1046968,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_add": "新增",
 
 
 
@@ -1050189,7 +1047095,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_cancel": "取消",
 
 
 
@@ -1050317,7 +1047222,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_save": "儲存",
 
 
 
@@ -1050445,7 +1047349,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_saved": "已儲存",
 
 
 
@@ -1050573,7 +1047476,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_error": "錯誤",
 
 
 
@@ -1050701,7 +1047603,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_loading": "載入中...",
 
 
 
@@ -1050829,7 +1047730,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_unknown": "未知",
 
 
 
@@ -1050957,7 +1047857,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_bot": "Bot",
 
 
 
@@ -1051981,7 +1048880,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_title": "刪除帳號",
 
 
 
@@ -1052109,7 +1049007,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_page_title": "EClawbot — 刪除帳號",
 
 
 
@@ -1052237,7 +1049134,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_subtitle": "使用您的 Google 帳號登入以驗證身份，並永久刪除您的 EClawbot 帳號。",
 
 
 
@@ -1052365,7 +1049261,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_data_label": "將被刪除的資料：",
 
 
 
@@ -1052493,7 +1049388,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_data_account": "帳號資訊（電子郵件、姓名、個人檔案）",
 
 
 
@@ -1052621,7 +1049515,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_data_chat": "與所有實體的聊天記錄",
 
 
 
@@ -1052749,7 +1049642,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_data_mission": "任務控制資料（任務、筆記、規則、靈魂）",
 
 
 
@@ -1052877,7 +1049769,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_data_schedules": "排程與執行歷史",
 
 
 
@@ -1053005,7 +1049896,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_data_vars": "加密環境變數",
 
 
 
@@ -1053133,7 +1050023,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_data_bots": "Bot 綁定與實體配置",
 
 
 
@@ -1053261,7 +1050150,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_data_telemetry": "裝置遙測資料",
 
 
 
@@ -1053389,7 +1050277,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_google_btn": "使用 Google 繼續",
 
 
 
@@ -1053517,7 +1050404,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_confirm_title": "確認刪除",
 
 
 
@@ -1053645,7 +1050531,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_warning": "⚠ 此操作是永久性的，無法復原。您的所有資料將立即被刪除。",
 
 
 
@@ -1053773,7 +1050658,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_confirm_label": "我了解刪除帳號是永久性的，我的所有資料將被清除。",
 
 
 
@@ -1053901,7 +1050785,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_deleting": "刪除中...",
 
 
 
@@ -1054029,7 +1050912,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_btn": "刪除我的帳號",
 
 
 
@@ -1054157,7 +1051039,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_done_title": "帳號已刪除",
 
 
 
@@ -1054285,7 +1051166,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_done_msg": "您的 EClawbot 帳號及所有相關資料已被永久刪除。您將不再收到我們的任何通訊。",
 
 
 
@@ -1054413,7 +1051293,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_done_hint": "如果您改變主意，可以隨時在 EClawbot App 中建立新帳號。",
 
 
 
@@ -1054541,7 +1051420,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_err_no_google": "Google 登入未設定。",
 
 
 
@@ -1054669,7 +1051547,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_err_sdk_loading": "Google SDK 載入中，請重試。",
 
 
 
@@ -1054797,7 +1051674,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_err_signin_failed": "登入失敗，請重試。",
 
 
 
@@ -1054925,7 +1051801,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_err_delete_failed": "刪除失敗，請重試。",
 
 
 
@@ -1055053,7 +1051928,6 @@ const TRANSLATIONS = {
 
 
 
-        "delete_account_dev_info": "應用程式：EClawbot · 開發者：Hank Huang · 套件名稱：com.hank.clawlive",
 
 
 
@@ -1055181,7 +1052055,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_title": "遠端控制",
 
 
 
@@ -1055309,7 +1052182,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_feature_status": "功能狀態",
 
 
 
@@ -1055437,7 +1052309,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_screen_state": "螢幕狀態",
 
 
 
@@ -1055565,7 +1052436,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_send_command": "傳送指令",
 
 
 
@@ -1055693,7 +1052563,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_btn_send_command": "傳送指令",
 
 
 
@@ -1055821,7 +1052690,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_tab_env_vars": "環境變數",
 
 
 
@@ -1055949,7 +1052817,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_tab_remote": "遠端控制",
 
 
 
@@ -1056077,7 +1052944,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_loading": "載入中...",
 
 
 
@@ -1056205,7 +1053071,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_status_disabled": "⚠ 已停用",
 
 
 
@@ -1056333,7 +1053198,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_status_enabled": "✓ 已啟用",
 
 
 
@@ -1056461,7 +1053325,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_enable_instruction": "在 App 中啟用遠端控制（設定 → 遠端控制），然後授予無障礙服務權限。",
 
 
 
@@ -1056589,7 +1053452,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_security_title": "安全與隱私",
 
 
 
@@ -1056717,7 +1053579,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_sec1_title": "綁定專屬密鑰",
 
 
 
@@ -1056845,7 +1053706,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_sec1_desc": "每次 Bot 綁定都會產生一個專屬於您裝置的 botSecret。即使多位使用者共用同一個 Bot，每個 Bot 工作階段只能存取綁定的裝置——使用他人的憑證會收到 403 錯誤。",
 
 
 
@@ -1056973,7 +1053833,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_sec2_title": "僅無障礙樹——無螢幕截圖",
 
 
 
@@ -1057101,7 +1053960,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_sec2_desc": "Bot 只能看到結構化的 UI 元素清單（文字、按鈕、輸入欄位），而非螢幕截圖。敏感的視覺內容（圖片、影片、畫布）永遠不會被擷取。",
 
 
 
@@ -1057229,7 +1054087,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_sec3_title": "您始終掌控一切",
 
 
 
@@ -1057357,7 +1054214,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_sec3_desc": "遠端控制預設為關閉。您可以隨時在 App 設定 → 遠端控制中停用。撤銷 Bot 綁定會立即使其 botSecret 失效。",
 
 
 
@@ -1057485,7 +1054341,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_btn_capture": "擷取螢幕",
 
 
 
@@ -1057613,7 +1054468,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_empty_state": "點擊「擷取螢幕」查看裝置目前的 UI 樹。",
 
 
 
@@ -1057741,7 +1054595,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_label_command": "指令",
 
 
 
@@ -1057869,7 +1054722,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_opt_tap": "tap — 點擊元素或座標",
 
 
 
@@ -1057997,7 +1054849,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_opt_type": "type — 在欄位中輸入文字",
 
 
 
@@ -1058125,7 +1054976,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_opt_scroll": "scroll — 滾動元素",
 
 
 
@@ -1058253,7 +1055103,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_opt_back": "back — 系統返回鍵",
 
 
 
@@ -1058381,7 +1055230,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_opt_home": "home — 系統主頁鍵",
 
 
 
@@ -1058509,7 +1055357,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_label_node_id": "節點 ID（來自上方樹，例如 n3）",
 
 
 
@@ -1058637,7 +1055484,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_label_text": "輸入文字",
 
 
 
@@ -1058765,7 +1055611,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_placeholder_text": "輸入文字...",
 
 
 
@@ -1058893,7 +1055738,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_label_scroll_dir": "滾動方向",
 
 
 
@@ -1059021,7 +1055865,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_opt_down": "向下",
 
 
 
@@ -1059149,7 +1055992,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_opt_up": "向上",
 
 
 
@@ -1059277,7 +1056119,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_capturing": "擷取中...",
 
 
 
@@ -1059405,7 +1056246,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_capture_failed": "擷取失敗",
 
 
 
@@ -1059533,7 +1056373,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_request_failed": "請求失敗",
 
 
 
@@ -1059661,7 +1056500,6 @@ const TRANSLATIONS = {
 
 
 
-        "screen_ctrl_no_elements": "螢幕上未找到互動元素。",
 
 
 
@@ -1059789,7 +1056627,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_placeholder_device_id": "例：abc12345-...",
 
 
 
@@ -1059917,7 +1056754,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_placeholder_device_secret": "輸入裝置密碼",
 
 
 
@@ -1060045,7 +1056881,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_placeholder_confirm": "確認密碼",
 
 
 
@@ -1060173,7 +1057008,6 @@ const TRANSLATIONS = {
 
 
 
-        "login_placeholder_reg_password": "至少 6 個字元",
 
 
 
@@ -1060301,7 +1057135,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_placeholder_version": "例：1.0.33",
 
 
 
@@ -1060429,7 +1057262,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_placeholder_notes": "Bug 修復和改善",
 
 
 
@@ -1060557,7 +1057389,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_placeholder_bot_id": "例：my-personal-bot-01",
 
 
 
@@ -1060685,7 +1057516,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_placeholder_webhook": "https://...",
 
 
 
@@ -1060813,7 +1057643,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_placeholder_token": "Bot webhook token",
 
 
 
@@ -1060941,7 +1057770,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_placeholder_setup_pwd": "若未使用 SETUP_PASSWORD 請留空",
 
 
 
@@ -1061069,7 +1057897,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_ai_chat_placeholder": "貼上錯誤訊息或描述問題...",
 
 
 
@@ -1061197,7 +1058024,6 @@ const TRANSLATIONS = {
 
 
 
-        "skill_contrib_tab": "技能貢獻紀錄",
 
 
 
@@ -1061325,7 +1058151,6 @@ const TRANSLATIONS = {
 
 
 
-        "skill_contrib_col_title": "標題",
 
 
 
@@ -1061453,7 +1058278,6 @@ const TRANSLATIONS = {
 
 
 
-        "skill_contrib_col_status": "狀態",
 
 
 
@@ -1061581,7 +1058405,6 @@ const TRANSLATIONS = {
 
 
 
-        "contrib_col_by": "提交者",
 
 
 
@@ -1061709,7 +1058532,6 @@ const TRANSLATIONS = {
 
 
 
-        "contrib_col_date": "日期",
 
 
 
@@ -1061837,7 +1058659,6 @@ const TRANSLATIONS = {
 
 
 
-        "skill_contrib_status_approved": "已批准",
 
 
 
@@ -1061965,7 +1058786,6 @@ const TRANSLATIONS = {
 
 
 
-        "skill_contrib_status_rejected": "已拒絕",
 
 
 
@@ -1062093,7 +1058913,6 @@ const TRANSLATIONS = {
 
 
 
-        "skill_contrib_status_verifying": "驗證中",
 
 
 
@@ -1062221,7 +1059040,6 @@ const TRANSLATIONS = {
 
 
 
-        "skill_contrib_revoke": "撤銷",
 
 
 
@@ -1062349,7 +1059167,6 @@ const TRANSLATIONS = {
 
 
 
-        "skill_contrib_revoke_confirm": "從正式列表移除此技能？",
 
 
 
@@ -1062477,7 +1059294,6 @@ const TRANSLATIONS = {
 
 
 
-        "skill_contrib_revoked": "技能已撤銷",
 
 
 
@@ -1062605,7 +1059421,6 @@ const TRANSLATIONS = {
 
 
 
-        "skill_contrib_no_data": "尚無貢獻記錄",
 
 
 
@@ -1062733,7 +1059548,6 @@ const TRANSLATIONS = {
 
 
 
-        "soul_contrib_tab": "靈魂模板貢獻紀錄",
 
 
 
@@ -1062861,7 +1059675,6 @@ const TRANSLATIONS = {
 
 
 
-        "soul_contrib_no_data": "尚無靈魂模板貢獻",
 
 
 
@@ -1062989,7 +1059802,6 @@ const TRANSLATIONS = {
 
 
 
-        "soul_contrib_col_name": "名稱",
 
 
 
@@ -1063117,7 +1059929,6 @@ const TRANSLATIONS = {
 
 
 
-        "soul_contrib_col_description": "描述預覽",
 
 
 
@@ -1063245,7 +1060056,6 @@ const TRANSLATIONS = {
 
 
 
-        "soul_contrib_revoke": "撤銷",
 
 
 
@@ -1063373,7 +1060183,6 @@ const TRANSLATIONS = {
 
 
 
-        "soul_contrib_revoke_confirm": "從正式列表移除此靈魂模板？",
 
 
 
@@ -1063501,7 +1060310,6 @@ const TRANSLATIONS = {
 
 
 
-        "soul_contrib_revoked": "靈魂模板已撤銷",
 
 
 
@@ -1063629,7 +1060437,6 @@ const TRANSLATIONS = {
 
 
 
-        "rule_contrib_tab": "規則模板貢獻紀錄",
 
 
 
@@ -1063757,7 +1060564,6 @@ const TRANSLATIONS = {
 
 
 
-        "rule_contrib_no_data": "尚無規則模板貢獻",
 
 
 
@@ -1063885,7 +1060691,6 @@ const TRANSLATIONS = {
 
 
 
-        "rule_contrib_col_name": "名稱",
 
 
 
@@ -1064013,7 +1060818,6 @@ const TRANSLATIONS = {
 
 
 
-        "rule_contrib_col_description": "描述預覽",
 
 
 
@@ -1064141,7 +1060945,6 @@ const TRANSLATIONS = {
 
 
 
-        "rule_contrib_col_type": "類型",
 
 
 
@@ -1064269,7 +1061072,6 @@ const TRANSLATIONS = {
 
 
 
-        "rule_contrib_revoke": "撤銷",
 
 
 
@@ -1064397,7 +1061199,6 @@ const TRANSLATIONS = {
 
 
 
-        "rule_contrib_revoke_confirm": "從正式列表移除此規則模板？",
 
 
 
@@ -1064525,7 +1061326,6 @@ const TRANSLATIONS = {
 
 
 
-        "rule_contrib_revoked": "規則模板已撤銷",
 
 
 
@@ -1064653,7 +1061453,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_title": "🔐 環境變數",
 
 
 
@@ -1064781,7 +1061580,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_lock_readable": "Bot 可讀取",
 
 
 
@@ -1064909,7 +1061707,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_lock_unreadable": "Bot 無法讀取",
 
 
 
@@ -1065037,7 +1061834,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_btn_add": "+ 新增",
 
 
 
@@ -1065165,7 +1061961,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_btn_add_var": "+ 新增變數",
 
 
 
@@ -1065293,7 +1062088,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_locked_banner": "🔒 已鎖定 — Bot 無法讀取任何變數",
 
 
 
@@ -1065421,7 +1062215,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_notice": "🔐 值經 AES-256 加密後儲存於伺服器。Bot 被呼叫時可讀取這些變數。",
 
 
 
@@ -1065549,7 +1062342,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_no_vars": "尚無變數",
 
 
 
@@ -1065677,7 +1062469,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_confirm_delete": "刪除變數「{key}」？",
 
 
 
@@ -1065805,7 +1062596,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_dialog_edit": "編輯變數",
 
 
 
@@ -1065933,7 +1062723,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_dialog_add": "新增變數",
 
 
 
@@ -1066061,7 +1062850,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_vars_all_configured": "所有變數已設定",
 
 
 
@@ -1066189,7 +1062977,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_vars_needs": "需要",
 
 
 
@@ -1066317,7 +1063104,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_vars_no_key_needed": "無需 API 金鑰",
 
 
 
@@ -1066445,7 +1063231,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_vars_already_set": "已設定",
 
 
 
@@ -1066573,7 +1063358,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_vars_not_set": "未設定",
 
 
 
@@ -1066701,7 +1063485,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_vars_dialog_title": "環境變數",
 
 
 
@@ -1066829,7 +1063612,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_vars_dialog_desc": "檢視並設定必要的變數。可修改 Key 名稱，或留空以保留目前的值。",
 
 
 
@@ -1066957,7 +1063739,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_vars_btn_skip": "略過",
 
 
 
@@ -1067085,7 +1063866,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_vars_btn_save": "儲存並繼續",
 
 
 
@@ -1067213,7 +1063993,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_bot_read_title": "🤖 Bot 讀取方式",
 
 
 
@@ -1067341,7 +1064120,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_bot_read_desc": "Bot 收到訊息時，push 通知底部會列出可用的 key 名稱（值不會出現）。Bot 主動呼叫以下指令取得實際值：",
 
 
 
@@ -1067469,7 +1064247,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_placeholder_key": "例：CLAUDE_OAUTH_TOKEN",
 
 
 
@@ -1067597,7 +1064374,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_placeholder_value": "sk-ant-oat...",
 
 
 
@@ -1067725,7 +1064501,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_env_vars": "環境變數",
 
 
 
@@ -1067853,7 +1064628,6 @@ const TRANSLATIONS = {
 
 
 
-        "nav_remote_control": "遠端控制",
 
 
 
@@ -1067981,7 +1064755,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_slot_created": "已建立新的實體欄位",
 
 
 
@@ -1068109,7 +1064882,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_slot_create_failed": "新增欄位失敗",
 
 
 
@@ -1068237,7 +1065009,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_max_capabilities": "最多 10 項能力",
 
 
 
@@ -1068365,7 +1065136,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_max_items": "最多 {count} 個項目",
 
 
 
@@ -1068493,7 +1065263,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_no_slot_selected": "未選擇可用的欄位，請先新增欄位。",
 
 
 
@@ -1068621,7 +1065390,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_no_code_to_copy": "沒有可複製的代碼",
 
 
 
@@ -1068749,7 +1065517,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_copied_clipboard": "已複製到剪貼簿！",
 
 
 
@@ -1068877,7 +1065644,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_copy_failed": "複製失敗，請手動複製",
 
 
 
@@ -1069005,7 +1065771,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_entity_deleted": "實體已刪除",
 
 
 
@@ -1069133,7 +1065898,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_entity_deleting": "刪除中...",
 
 
 
@@ -1069261,7 +1066025,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_load_failed": "載入資料失敗",
 
 
 
@@ -1069389,7 +1066152,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_upload_failed": "上傳失敗",
 
 
 
@@ -1069517,7 +1066279,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_error": "錯誤",
 
 
 
@@ -1069645,7 +1066406,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_drawing_save_failed": "儲存塗鴉失敗",
 
 
 
@@ -1069773,7 +1066533,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_page_save_failed": "儲存頁面失敗",
 
 
 
@@ -1069901,7 +1066660,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_page_deleted": "頁面已刪除",
 
 
 
@@ -1070029,7 +1066787,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_page_delete_failed": "刪除頁面失敗",
 
 
 
@@ -1070157,7 +1066914,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_create_failed": "建立失敗",
 
 
 
@@ -1070285,7 +1067041,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_not_found": "找不到",
 
 
 
@@ -1070413,7 +1067168,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_update_failed": "更新失敗",
 
 
 
@@ -1070541,7 +1067295,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_delete_failed": "刪除失敗",
 
 
 
@@ -1070669,7 +1067422,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_delete_channel_confirm": "刪除此 API 金鑰？此操作無法復原。",
 
 
 
@@ -1070797,7 +1067549,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_subscription_activated": "進階訂閱已啟用！",
 
 
 
@@ -1070925,7 +1067676,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_subscription_cancelled": "訂閱已取消。存取權限持續到期限結束。",
 
 
 
@@ -1071053,7 +1067803,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_preference_update_failed": "更新偏好設定失敗",
 
 
 
@@ -1071181,7 +1067930,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_push_not_configured": "伺服器尚未設定推播",
 
 
 
@@ -1071309,7 +1068057,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_gatekeeper_strike": "訊息被守門員攔截",
 
 
 
@@ -1071437,7 +1068184,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_send_failed": "傳送訊息失敗",
 
 
 
@@ -1071565,7 +1068311,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_network_error": "網路錯誤，請再試一次",
 
 
 
@@ -1071693,7 +1068438,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_google_login_failed": "Google 登入失敗",
 
 
 
@@ -1071821,7 +1068565,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_facebook_login_failed": "Facebook 登入失敗",
 
 
 
@@ -1071949,7 +1068692,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_load_error": "載入檔案失敗",
 
 
 
@@ -1072077,7 +1068819,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_save_failed": "儲存失敗",
 
 
 
@@ -1072205,7 +1068946,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_reset_failed": "重設失敗",
 
 
 
@@ -1072333,7 +1069073,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_clear_failed": "清除失敗",
 
 
 
@@ -1072461,7 +1069200,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_refresh_failed": "重新整理失敗",
 
 
 
@@ -1072589,7 +1069327,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_read_file_failed": "讀取檔案失敗",
 
 
 
@@ -1072717,7 +1069454,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_bind_failed": "綁定失敗",
 
 
 
@@ -1072845,7 +1069581,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_unbind_failed": "解除綁定失敗",
 
 
 
@@ -1072973,7 +1069708,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_payment_failed": "付款失敗",
 
 
 
@@ -1073101,7 +1069835,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_agreement_failed": "記錄同意失敗",
 
 
 
@@ -1073229,7 +1069962,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_cancel_failed": "取消失敗",
 
 
 
@@ -1073357,7 +1070089,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_notification_denied": "通知權限已被拒絕",
 
 
 
@@ -1073485,7 +1070216,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_mark_failed": "標記失敗",
 
 
 
@@ -1073613,7 +1070343,6 @@ const TRANSLATIONS = {
 
 
 
-        "toast_generate_key_failed": "產生 API 金鑰失敗",
 
 
 
@@ -1073741,7 +1070470,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_tab": "看板",
 
 
 
@@ -1073869,7 +1070597,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_title": "看板",
 
 
 
@@ -1073997,7 +1070724,6 @@ const TRANSLATIONS = {
 
 
 
-        "kanban_heading": "📋 看板",
 
 
 
@@ -1074125,7 +1070851,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_col_backlog": "待排程",
 
 
 
@@ -1074253,7 +1070978,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_col_todo": "待辦",
 
 
 
@@ -1074381,7 +1071105,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_col_in_progress": "進行中",
 
 
 
@@ -1074509,7 +1071232,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_col_review": "審核中",
 
 
 
@@ -1074637,7 +1071359,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_col_done": "完成",
 
 
 
@@ -1074893,7 +1071614,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_new_card_btn": "+ 新增卡片",
 
 
 
@@ -1075021,7 +1071741,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_form_title": "新增卡片",
 
 
 
@@ -1075149,7 +1071868,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_label_title": "標題",
 
 
 
@@ -1075277,7 +1071995,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_label_description": "描述",
 
 
 
@@ -1075405,7 +1072122,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_label_priority": "優先權",
 
 
 
@@ -1075533,7 +1072249,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_label_status": "狀態",
 
 
 
@@ -1075661,7 +1072376,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_label_assign": "指派",
 
 
 
@@ -1075789,7 +1072503,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_btn_create": "建立",
 
 
 
@@ -1075917,7 +1072630,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_btn_cancel": "取消",
 
 
 
@@ -1076045,7 +1072757,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_btn_send": "送出",
 
 
 
@@ -1076173,7 +1072884,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_priority_p0": "P0 - 緊急",
 
 
 
@@ -1076301,7 +1073011,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_priority_p1": "P1 - 高",
 
 
 
@@ -1076429,7 +1073138,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_priority_p2": "P2 - 中",
 
 
 
@@ -1076557,7 +1073265,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_priority_p3": "P3 - 低",
 
 
 
@@ -1076685,7 +1073392,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_filter_all": "全部",
 
 
 
@@ -1076813,7 +1073519,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_filter_mine": "我的",
 
 
 
@@ -1076941,7 +1073646,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_sort_default": "預設順序",
 
 
 
@@ -1077069,7 +1073773,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_sort_newest": "最新建立",
 
 
 
@@ -1077197,7 +1073900,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_sort_oldest": "最舊建立",
 
 
 
@@ -1077325,7 +1074027,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_sort_priority": "高優先級優先",
 
 
 
@@ -1077453,7 +1074154,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_sort_recently_updated": "最近更新",
         "kb_sort_oldest_updated": "最久未更新",
 
 
@@ -1077582,7 +1074282,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_funnel_label": "篩選",
 
 
 
@@ -1077710,7 +1074409,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_funnel_search": "搜尋…",
 
 
 
@@ -1077838,7 +1074536,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_search_scope_label": "範圍：",
 
 
 
@@ -1077966,7 +1074663,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_search_scope_title": "標題",
 
 
 
@@ -1078094,7 +1074790,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_search_scope_comments": "留言",
 
 
 
@@ -1078222,7 +1074917,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_search_scope_subcards": "子卡",
 
 
 
@@ -1078350,7 +1075044,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_archived_badge": "已歸檔",
 
 
 
@@ -1078478,7 +1075171,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_funnel_status_all": "所有狀態",
 
 
 
@@ -1078606,7 +1075298,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_funnel_priority_all": "所有優先權",
 
 
 
@@ -1078734,7 +1075425,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_funnel_entity_all": "所有實體",
 
 
 
@@ -1078862,7 +1075552,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_funnel_since": "起始",
 
 
 
@@ -1078990,7 +1075679,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_funnel_until": "結束",
 
 
 
@@ -1079118,7 +1075806,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_funnel_reset": "重設",
 
 
 
@@ -1079246,7 +1075933,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_history_label": "歷史",
 
 
 
@@ -1079374,7 +1076060,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_history_title": "已封存卡片",
 
 
 
@@ -1079502,7 +1076187,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_history_loading": "載入中…",
 
 
 
@@ -1079630,7 +1076314,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_history_empty": "尚無封存卡片",
 
 
 
@@ -1079758,7 +1076441,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_history_restore": "還原",
 
 
 
@@ -1079886,7 +1076568,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_history_restored": "卡片已還原至 Backlog",
 
 
 
@@ -1080014,7 +1076695,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_tab_comments": "留言",
 
 
 
@@ -1080142,7 +1076822,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_tab_files": "檔案",
 
 
 
@@ -1080270,7 +1076949,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_tab_screenshots": "截圖審查",
 
 
 
@@ -1080398,8 +1077076,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_label_requires_screenshot": "需截圖審查（完成時附截圖才可推進 review/done）",
-        "kb_label_gated": "Launch-gate（發布閘）——開啟時，L1/L2/L3 自動升級跳过此卡；卡片離開發布就緒後自動解除",
 
 
 
@@ -1080527,7 +1077203,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_tab_notes": "筆記",
 
 
 
@@ -1080655,7 +1077330,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_tab_schedule": "排程設定",
 
 
 
@@ -1080783,7 +1077457,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_subtab_env": "環境變數",
 
 
 
@@ -1080911,7 +1077584,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_subtab_remote": "遠端控制",
 
 
 
@@ -1081039,7 +1077711,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_empty_no_cards": "尚無卡片",
 
 
 
@@ -1081167,7 +1077838,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_empty_no_files": "尚無檔案",
 
 
 
@@ -1081295,7 +1077965,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_empty_no_notes": "尚無筆記",
 
 
 
@@ -1081423,7 +1078092,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_placeholder_title": "卡片標題…",
 
 
 
@@ -1081551,7 +1078219,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_placeholder_desc": "描述任務內容…",
 
 
 
@@ -1081679,7 +1078346,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_placeholder_comment": "新增留言…",
 
 
 
@@ -1081807,7 +1078473,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_label_automation": "設為自動化",
 
 
 
@@ -1081935,7 +1078600,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_label_schedule": "排程",
 
 
 
@@ -1082063,7 +1078727,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_title": "自動化任務",
 
 
 
@@ -1082191,7 +1078854,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_next": "下次執行：{nextRun}",
 
 
 
@@ -1082319,7 +1078981,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_view_grid": "網格",
 
 
 
@@ -1082447,7 +1079108,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_view_timeline": "時間軸",
 
 
 
@@ -1082575,7 +1079235,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_unassigned": "未指派",
 
 
 
@@ -1082703,7 +1079362,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_density": "排程密度",
 
 
 
@@ -1082831,7 +1079489,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_est_cost": "估算 Token",
 
 
 
@@ -1082959,7 +1079616,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_workload": "工作量佔比",
 
 
 
@@ -1083087,7 +1079743,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_projected": "預計執行",
 
 
 
@@ -1083215,7 +1079870,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_per_day": "/天",
 
 
 
@@ -1083343,7 +1079997,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_enabled": "已啟用",
 
 
 
@@ -1083471,7 +1080124,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_pause": "暫停",
 
 
 
@@ -1083599,7 +1080251,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_resume": "啟用",
 
 
 
@@ -1083727,7 +1080378,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_delete": "刪除",
 
 
 
@@ -1083855,7 +1080505,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_delete_confirm": "確定刪除此自動化？將會歸檔。",
 
 
 
@@ -1083983,7 +1080632,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_edit": "編輯",
 
 
 
@@ -1084111,7 +1080759,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_edit_title": "編輯排程",
 
 
 
@@ -1084239,7 +1080886,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_edit_tip": "編輯排程",
 
 
 
@@ -1084367,7 +1081013,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_edit_save": "儲存",
 
 
 
@@ -1084495,7 +1081140,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_edit_saved": "排程已更新",
 
 
 
@@ -1084623,7 +1081267,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_edit_failed": "排程更新失敗",
 
 
 
@@ -1084751,7 +1081394,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_edit_no_cron": "請選擇或輸入 cron 表達式",
 
 
 
@@ -1084879,7 +1081521,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_edit_no_runat": "請設定執行時間",
 
 
 
@@ -1085007,7 +1081648,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_label_sched_type": "排程類型",
 
 
 
@@ -1085135,7 +1081775,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_sched_recurring": "重複（Cron）",
 
 
 
@@ -1085263,7 +1081902,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_sched_once": "單次執行",
 
 
 
@@ -1085391,7 +1082029,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_label_run_at": "執行時間",
 
 
 
@@ -1085519,7 +1082156,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_label_timezone": "時區",
 
 
 
@@ -1085647,7 +1082283,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_paused": "已暫停",
 
 
 
@@ -1085775,7 +1082410,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_reviewer": "審核者",
 
 
 
@@ -1085903,7 +1082537,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_no_reviewer": "無",
 
 
 
@@ -1086031,7 +1082664,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_assigned": "指派",
 
 
 
@@ -1086159,7 +1082791,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_not_triggered": "未觸發",
 
 
 
@@ -1086287,7 +1082918,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_next_trigger": "下次觸發",
 
 
 
@@ -1086415,7 +1083045,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_auto_last_trigger": "上次觸發",
 
 
 
@@ -1086543,7 +1083172,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_cron_hourly": "每小時",
 
 
 
@@ -1086671,7 +1083299,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_cron_4h": "每 4 小時",
 
 
 
@@ -1086799,7 +1083426,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_cron_daily": "每天 9:00",
 
 
 
@@ -1086927,7 +1083553,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_cron_weekly": "每週一",
 
 
 
@@ -1087055,7 +1083680,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_placeholder_cron": "自訂 cron：*/30 * * * *",
 
 
 
@@ -1087183,7 +1083807,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_stale_overdue": "已逾期",
 
 
 
@@ -1087311,7 +1083934,6 @@ const TRANSLATIONS = {
 
 
 
-        "kb_err_no_entity": "至少需要指派一個實體",
 
 
 
@@ -1087439,7 +1084061,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_usecase_gatekeeper": "安全守門員",
 
 
 
@@ -1087567,7 +1084188,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_title": "安全守門員 — 保護你的 Bot 不被濫用",
 
 
 
@@ -1087695,7 +1084315,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_meta": "六層過濾機制，攔截惡意訊息、防止轟炸、黑白名單精準控制",
 
 
 
@@ -1087823,7 +1084442,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_h2_what": "什麼是 Gatekeeper？",
 
 
 
@@ -1087951,7 +1084569,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_p_what": "Gatekeeper（守門員）是 EClawbot 的跨裝置訊息安全層。每一條外部訊息進入你的 Bot 之前，都必須通過六道檢查。任何一道不過，訊息就被攔截，防止 Bot 被垃圾訊息、惡意用戶或自動轟炸攻擊。",
 
 
 
@@ -1088079,7 +1084696,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_note_stats": "🛡️ <strong>即時統計：</strong>透過 <code>GET /api/gatekeeper/stats</code> 查看攔截數量和封鎖裝置清單。",
 
 
 
@@ -1088207,7 +1084823,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_h2_six": "六道防護機制",
 
 
 
@@ -1088335,7 +1084950,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_flow1": "外部用戶",
 
 
 
@@ -1088463,7 +1085077,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_flow1_sub": "發送訊息",
 
 
 
@@ -1088591,7 +1085204,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_flow2_sub": "6 道檢查",
 
 
 
@@ -1088719,7 +1085331,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_flow3": "Bot",
 
 
 
@@ -1088847,7 +1085458,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_flow3_sub": "處理合規訊息",
 
 
 
@@ -1088975,7 +1085585,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_th_check": "檢查項目",
 
 
 
@@ -1089103,7 +1085712,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_th_desc": "說明",
 
 
 
@@ -1089231,7 +1085839,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_th_config": "設定方式",
 
 
 
@@ -1089359,7 +1085966,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_check1": "🚫 禁用詞過濾",
 
 
 
@@ -1089487,7 +1086093,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_check1_desc": "包含廣告、釣魚、敏感詞的訊息自動攔截",
 
 
 
@@ -1089615,7 +1086220,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_check1_cfg": "Forbidden Words 清單",
 
 
 
@@ -1089743,7 +1086347,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_check2": "⬛ 黑名單",
 
 
 
@@ -1089871,7 +1086474,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_check2_desc": "被封鎖的裝置 ID 無法發送任何訊息",
 
 
 
@@ -1089999,7 +1086601,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_check2_cfg": "Blacklist 設定",
 
 
 
@@ -1090127,7 +1086728,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_check3": "⬜ 白名單",
 
 
 
@@ -1090255,7 +1086855,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_check3_desc": "啟用後只有白名單裝置可發訊息（嚴格模式）",
 
 
 
@@ -1090383,7 +1086982,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_check3_cfg": "Whitelist 設定",
 
 
 
@@ -1090511,7 +1087109,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_check4": "⚡ 速率限制",
 
 
 
@@ -1090639,7 +1087236,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_check4_desc": "同一裝置短時間超過訊息上限，自動降速或封鎖",
 
 
 
@@ -1090767,7 +1087363,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_check4_cfg": "Rate Limit（次/分鐘）",
 
 
 
@@ -1090895,7 +1087490,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_check5": "📁 媒體類型",
 
 
 
@@ -1091023,7 +1087617,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_check5_desc": "限制允許的訊息格式（文字、圖片、語音等）",
 
 
 
@@ -1091151,7 +1087744,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_check5_cfg": "Allowed Media Types",
 
 
 
@@ -1091279,7 +1087871,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_check6": "⏸️ 暫停狀態",
 
 
 
@@ -1091407,7 +1087998,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_check6_desc": "裝置被暫停服務時所有訊息皆被攔截",
 
 
 
@@ -1091535,7 +1088125,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_check6_cfg": "Suspension API",
 
 
 
@@ -1091663,7 +1088252,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_h2_api": "API 用法",
 
 
 
@@ -1091791,7 +1088379,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_api1_title": "查看攔截統計",
 
 
 
@@ -1091919,7 +1088506,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_api2_title": "設定 Gatekeeper 規則",
 
 
 
@@ -1092047,7 +1088633,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_note_nav": "📍 前往：Dashboard → 選擇實體 → 編輯 → ⚙ Cross-Device Msg",
 
 
 
@@ -1092175,7 +1088760,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_h2_usecases": "使用情境",
 
 
 
@@ -1092303,7 +1088887,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_uc_th_scene": "情境",
 
 
 
@@ -1092431,7 +1089014,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_uc_th_rule": "建議規則",
 
 
 
@@ -1092559,7 +1089141,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_uc_ecom": "🛒 電商客服",
 
 
 
@@ -1092687,7 +1089268,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_uc_ecom_desc": "禁用詞過濾廣告/競品，速率限制防轟炸",
 
 
 
@@ -1092815,7 +1089395,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_uc_corp": "🏢 企業內部 Bot",
 
 
 
@@ -1092943,7 +1089522,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_uc_corp_desc": "白名單模式，只允許員工裝置發訊息",
 
 
 
@@ -1093071,7 +1089649,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_uc_pub": "🌐 公開服務",
 
 
 
@@ -1093199,7 +1089776,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_uc_pub_desc": "速率限制 + 禁用詞，允許所有媒體類型",
 
 
 
@@ -1093327,7 +1089903,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_uc_test": "🧪 測試環境",
 
 
 
@@ -1093455,7 +1090030,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_uc_test_desc": "白名單只含測試裝置，隔離測試流量",
 
 
 
@@ -1093583,7 +1090157,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_h2_tips": "使用提醒",
 
 
 
@@ -1093711,7 +1090284,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_tip_li1": "✅ <strong>先從速率限制開始</strong>：預設 10 次/分鐘，大多數場景都夠用",
 
 
 
@@ -1093839,7 +1090411,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_tip_li2": "✅ <strong>禁用詞定期更新</strong>：收到新型詐騙關鍵字時立即加入清單",
 
 
 
@@ -1093967,7 +1090538,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_tip_li3": "✅ <strong>查看統計掌握狀況</strong>：每天查看 stats API 了解攔截趨勢",
 
 
 
@@ -1094095,7 +1090665,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_tip_li4": "⚠️ <strong>白名單要謹慎</strong>：啟用後所有不在清單的用戶都無法使用",
 
 
 
@@ -1094223,7 +1090792,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_cta_title": "設定你的 Bot 安全守門員",
 
 
 
@@ -1094351,7 +1090919,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_cta_proxy": "適用場景：<a href=\"#guide/usecase-proxy-window\">尹代理窗口安全設定</a>",
 
 
 
@@ -1094479,7 +1091046,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_cta_api": "API 文件：<a href=\"https://eclawbot.com/api/skill-doc\" target=\"_blank\" rel=\"noopener\">完整 API Skill Doc</a>",
 
 
 
@@ -1094607,7 +1091173,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gk_cta_crossdevice": "跨裝置設定：<a href=\"#guide/detail-crossdevice\">Cross-Device Msg 教學</a>",
 
 
 
@@ -1094735,7 +1091300,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_usecase_multiplatform": "多平台同步",
 
 
 
@@ -1094863,7 +1091427,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_usecase_minigame": "🎮 遊戲工廠",
 
 
 
@@ -1094991,7 +1091554,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_title": "🎮 遊戲工廠 — 4 個 AI Agent 協作開發 298 款遊戲",
 
 
 
@@ -1095119,7 +1091681,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_meta": "1 週半、零人工干涉、純 AI 協作完成",
 
 
 
@@ -1095247,7 +1091808,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_what": "專案概述",
 
 
 
@@ -1095375,7 +1091935,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_what_desc": "這是一個用 EClawbot 平台驅動的實際生產專案：<strong>4 個 AI Agent 自主協作</strong>，在 1 週半內完成 298 款靜態網頁遊戲的設計、開發、美編優化與品質審查，全程<strong>無人工干涉</strong>。",
 
 
 
@@ -1095503,7 +1092062,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_stat_games": "款靜態遊戲",
 
 
 
@@ -1095631,7 +1092189,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_stat_weeks": "週完成",
 
 
 
@@ -1095759,7 +1092316,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_stat_human": "人工干涉",
 
 
 
@@ -1095887,7 +1092443,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_agents": "Agent 分工",
 
 
 
@@ -1096015,7 +1092570,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_col_agent": "Agent",
 
 
 
@@ -1096143,7 +1092697,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_col_model": "模型",
 
 
 
@@ -1096271,7 +1092824,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_col_role": "職責",
 
 
 
@@ -1096399,7 +1092951,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_role_0": "遊戲規則設計、玩法架構、HTML 骨架生成",
 
 
 
@@ -1096527,7 +1093078,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_role_1": "UI/UX 美化、素材優化、視覺一致性",
 
 
 
@@ -1096655,7 +1093205,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_role_3": "遊戲實測、Bug 回報、品質把關",
 
 
 
@@ -1096783,7 +1093332,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_role_2": "任務派發、E2E 驗證測試、調度協調",
 
 
 
@@ -1096911,7 +1093459,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_workflow": "協作流程",
 
 
 
@@ -1097039,7 +1093586,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_tech": "技術棧",
 
 
 
@@ -1097167,7 +1093713,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_tech_1": "<strong>EClawbot Kanban</strong> — 任務卡片管理，自動追蹤每款遊戲的開發狀態",
 
 
 
@@ -1097295,7 +1093840,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_tech_2": "<strong>OpenClaw Channel</strong> — 3 個 MiniMax Agent 透過 channel webhook 接收並執行任務",
 
 
 
@@ -1097423,7 +1093967,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_tech_3": "<strong>Claude Code + Playwright</strong> — 總指揮自動化 E2E 測試，驗證每款遊戲可正常運行",
 
 
 
@@ -1097551,7 +1094094,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_tech_4": "<strong>GitHub Actions + CDN</strong> — 自動部署至 minigame.eclawbot.com",
 
 
 
@@ -1097679,7 +1094221,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_tech_5": "<strong>GA v2 Analytics</strong> — 玩家行為追蹤 + 用戶 Bug 回報機制",
 
 
 
@@ -1097807,7 +1094348,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_cta_title": "立即體驗",
 
 
 
@@ -1097935,7 +1094475,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_cta_play": "🕹️ 前往遊戲平台 →",
 
 
 
@@ -1098063,7 +1094602,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_cta_kanban": "想打造自己的 AI 工廠？<a href=\"#guide/usecase-kanban\">了解 Kanban 多 Agent 協作 →</a>",
 
 
 
@@ -1098191,7 +1094729,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_schedule": "自動化排程設計",
 
 
 
@@ -1098319,7 +1094856,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_schedule_desc": "透過 Kanban 排程 API，為每個 Agent 配置專屬的定期任務卡片。系統會在指定時間自動把任務推送給對應實體，無需人工介入。",
 
 
 
@@ -1098447,7 +1094983,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_schedule_api": "排程設定方式",
 
 
 
@@ -1098575,7 +1095110,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_schedule_cards": "各 Agent 排程卡片",
 
 
 
@@ -1098703,7 +1095237,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_fix_1": "git pull 拉取最新程式碼",
 
 
 
@@ -1098831,7 +1095364,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_fix_2": "讀取 doc/ 下的開發文件與 Bug 列表",
 
 
 
@@ -1098959,7 +1095491,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_fix_3": "隨機抽取一款遊戲進行 E2E 測試（10-15 秒實際遊玩）",
 
 
 
@@ -1099087,7 +1095618,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_fix_4": "找出邏輯 Bug 或體驗問題（不可玩、無限循環、分數異常）",
 
 
 
@@ -1099215,7 +1095745,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_fix_5": "直接修改 HTML/JS 修復問題",
 
 
 
@@ -1099343,7 +1095872,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_fix_6": "git push 並廣播通知其他 Agent",
 
 
 
@@ -1099471,7 +1095999,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_art_1": "git pull 拉取最新程式碼",
 
 
 
@@ -1099599,7 +1096126,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_art_2": "讀取美編規範文件（色系、字體、排版指南）",
 
 
 
@@ -1099727,7 +1096253,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_art_3": "隨機抽取一款遊戲查看視覺品質",
 
 
 
@@ -1099855,7 +1096380,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_art_4": "辨識是否已美化（對比色塊佔比、互動元素樣式）",
 
 
 
@@ -1099983,7 +1096507,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_art_5": "找到純色/低質素素材並替換為視覺豐富版本",
 
 
 
@@ -1100111,7 +1096634,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_art_6": "驗證視覺效果後 git push",
 
 
 
@@ -1100239,7 +1096761,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_qa_1": "Playwright browser_navigate 開啟隨機遊戲",
 
 
 
@@ -1100367,7 +1096888,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_qa_2": "browser_snapshot 截取初始畫面",
 
 
 
@@ -1100495,7 +1097015,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_qa_3": "實際遊玩 2+ 回合，觀察互動反應",
 
 
 
@@ -1100623,7 +1097142,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_qa_4": "進行品質評分（可玩性 / 視覺 / 音效）",
 
 
 
@@ -1100751,7 +1097269,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_qa_5": "Bug 分類派發：P1 嚴重→建立 Bug 卡派給 #1，P2 玩法→派給 #0/#1，P3 音效→派給 #0",
 
 
 
@@ -1100879,7 +1097396,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_qa_6": "撰寫測試報告並廣播結果",
 
 
 
@@ -1101007,7 +1097523,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_pipe_1": "抽樣 1-2 款遊戲進行截圖",
 
 
 
@@ -1101135,7 +1097650,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_pipe_2": "Vision 模型分析視覺品質",
 
 
 
@@ -1101263,7 +1097777,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_pipe_3": "生成品質評分卡（滿分 10）",
 
 
 
@@ -1101391,7 +1097904,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_pipe_4": "評分 < 7 分自動派發改善任務",
 
 
 
@@ -1101519,7 +1098031,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mg_sop_pipe_5": "回報至總指揮看板，更新巡檢紀錄",
 
 
 
@@ -1101647,7 +1098158,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_title": "多平台同步 — 一個 Bot，三個螢幕",
 
 
 
@@ -1101775,7 +1098285,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_meta": "Web Portal、Android App、iOS App 即時同步，切換裝置不遺漏任何訊息",
 
 
 
@@ -1101903,7 +1098412,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_h2_what": "什麼是多平台同步？",
 
 
 
@@ -1102031,7 +1098539,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_p_what": "EClawbot 支援三個平台：Web Portal（瀏覽器）、Android App、iOS App。三個平台共用同一後端，透過 Socket.IO 即時同步，無論你在哪個裝置操作，所有變更都會立即反映到其他平台。",
 
 
 
@@ -1102159,7 +1098666,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_note_realtime": "⚡ <strong>真正即時：</strong>Socket.IO 讓三平台之間的延遲通常低於 100ms，不需要手動重新整理。",
 
 
 
@@ -1102287,7 +1098793,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_h2_platforms": "三平台特色比較",
 
 
 
@@ -1102415,7 +1098920,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_th_platform": "平台",
 
 
 
@@ -1102543,7 +1099047,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_th_strength": "強項",
 
 
 
@@ -1102671,7 +1099174,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_th_best": "最適合",
 
 
 
@@ -1102799,7 +1099301,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_web_strength": "完整功能、多代理管理、任務中心、看板",
 
 
 
@@ -1102927,7 +1099428,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_web_best": "日常管理、進階設定、開發工作",
 
 
 
@@ -1103055,7 +1099555,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_android_strength": "動態桌布、TTS 語音、GPS 位置、FCM 推播",
 
 
 
@@ -1103183,7 +1099682,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_android_best": "行動中使用、語音互動、桌布助手",
 
 
 
@@ -1103311,7 +1099809,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_ios_strength": "原生 Swift、Apple Push、Chat UI",
 
 
 
@@ -1103439,7 +1099936,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_ios_best": "iPhone 用戶、日常對話",
 
 
 
@@ -1103567,7 +1100063,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_h2_sync": "同步的內容",
 
 
 
@@ -1103695,7 +1100190,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_sync_th_data": "資料類型",
 
 
 
@@ -1103823,7 +1100317,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_sync_th_desc": "同步說明",
 
 
 
@@ -1103951,7 +1100444,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_sync_chat": "💬 聊天訊息",
 
 
 
@@ -1104079,7 +1100571,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_sync_chat_desc": "所有平台即時顯示新訊息，不重複推送",
 
 
 
@@ -1104207,7 +1100698,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_sync_mission": "📋 任務看板",
 
 
 
@@ -1104335,7 +1100825,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_sync_mission_desc": "Web 上更新的卡片狀態，App 立即反映",
 
 
 
@@ -1104463,7 +1100952,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_sync_notif": "🔔 通知",
 
 
 
@@ -1104591,7 +1101079,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_sync_notif_desc": "Bot 推播通知到所有已登入的裝置",
 
 
 
@@ -1104719,7 +1101206,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_sync_config": "⚙️ 設定",
 
 
 
@@ -1104847,7 +1101333,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_sync_config_desc": "Identity、Soul、Rules 修改後全平台生效",
 
 
 
@@ -1104975,7 +1101460,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_sync_entity": "🤖 代理狀態",
 
 
 
@@ -1105103,7 +1101587,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_sync_entity_desc": "綁定/解綁、在線狀態即時同步",
 
 
 
@@ -1105231,7 +1101714,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_h2_scenarios": "實際應用場景",
 
 
 
@@ -1105359,7 +1101841,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_scene1_title": "🖥️ + 📱 桌面管理 + 手機接收",
 
 
 
@@ -1105487,7 +1101968,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_scene1_desc": "白天在電腦 Web Portal 管理任務和設定，晚上手機 App 接收 Bot 推播通知，隨時掌握狀況。",
 
 
 
@@ -1105615,7 +1102095,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_scene2_title": "📱 Android 桌布 + 🍎 iOS 對話",
 
 
 
@@ -1105743,7 +1102222,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_scene2_desc": "Android 手機設定動態桌布顯示 Bot 最新回覆，同時用 iPhone 繼續對話。訊息即時同步，不會漏接。",
 
 
 
@@ -1105871,7 +1102349,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_scene3_title": "🌐 多人協作",
 
 
 
@@ -1105999,7 +1102476,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_scene3_desc": "團隊成員各用自己的裝置登入同一 Bot，看板卡片狀態、訊息、通知即時共享。",
 
 
 
@@ -1106127,7 +1102603,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_h2_tech": "技術架構",
 
 
 
@@ -1106255,7 +1102730,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_tech_title": "同步機制",
 
 
 
@@ -1106383,7 +1102857,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_tech_socket": "即時雙向通訊，延遲 &lt;100ms",
 
 
 
@@ -1106511,7 +1102984,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_tech_fcm": "Android 推播，App 關閉時仍能收到通知",
 
 
 
@@ -1106639,7 +1103111,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_tech_apns": "iOS 推播，支援背景更新",
 
 
 
@@ -1106767,7 +1103238,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_tech_rest": "設定同步，所有平台共用同一後端",
 
 
 
@@ -1106895,7 +1103365,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_h2_tips": "使用提醒",
 
 
 
@@ -1107023,7 +1103492,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_tip_li1": "✅ <strong>同一 Device ID 可同時在多裝置登入</strong>：不需要多組帳號",
 
 
 
@@ -1107151,7 +1103619,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_tip_li2": "✅ <strong>Socket.IO 斷線自動重連</strong>：網路不穩也不用擔心漏接",
 
 
 
@@ -1107279,7 +1103746,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_tip_li3": "✅ <strong>通知偏好設定</strong>：各平台可個別設定要收哪些類型的通知",
 
 
 
@@ -1107407,7 +1103873,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_tip_li4": "⚠️ <strong>Web Portal 需要瀏覽器保持開啟</strong>：關閉分頁就無法收到即時通知",
 
 
 
@@ -1107535,7 +1104000,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_cta_title": "開始多平台體驗",
 
 
 
@@ -1107663,7 +1104127,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_cta_web": "Web Portal：<a href=\"/portal/dashboard.html\">前往 Dashboard</a>",
 
 
 
@@ -1107791,7 +1104254,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_cta_android": "Android App：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\">Google Play 下載</a>",
 
 
 
@@ -1107919,7 +1104381,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mp_cta_wallpaper": "動態桌布：<a href=\"#guide/usecase-live-wallpaper\">動態桌布設定</a>",
 
 
 
@@ -1108047,7 +1104508,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_usecase_kanban": "Kanban AI 團隊",
 
 
 
@@ -1108175,7 +1104635,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_title": "Kanban AI 團隊看板 — 讓 Bot 自動推進任務",
 
 
 
@@ -1108303,7 +1104762,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_meta": "五欄看板 + Bot 協作 + 自動化催促，打造真正的 AI 開發團隊",
 
 
 
@@ -1108431,7 +1104889,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_h2_what": "什麼是 Kanban AI 團隊？",
 
 
 
@@ -1108559,7 +1105016,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_p_what": "EClawbot 的 Kanban 是專為 Bot 團隊設計的任務看板。每張卡片可以指派給一個或多個 Bot，Bot 完成工作後自己推進卡片到下一欄。搭配<strong>自動化催促機制</strong>，超時的卡片會自動提醒負責的 Bot，讓任務不會卡住。",
 
 
 
@@ -1108687,7 +1105143,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_note_demo": "📋 <strong>你現在就在用它！</strong>這個頁面的開發任務，就是用 EClawbot Kanban 管理的。<a href=\"/portal/kanban.html\">前往看板頁面 →</a>",
 
 
 
@@ -1108815,7 +1105270,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_h2_cols": "五欄看板結構",
 
 
 
@@ -1108943,7 +1105397,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_col_backlog": "Backlog",
 
 
 
@@ -1109071,7 +1105524,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_col_backlog_sub": "待排期任務",
 
 
 
@@ -1109199,7 +1105651,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_col_todo": "TODO",
 
 
 
@@ -1109327,7 +1105778,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_col_todo_sub": "準備開工",
 
 
 
@@ -1109455,7 +1105905,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_col_inprogress": "In Progress",
 
 
 
@@ -1109583,7 +1106032,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_col_inprogress_sub": "Bot 進行中",
 
 
 
@@ -1109711,7 +1106159,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_col_review": "Review",
 
 
 
@@ -1109839,7 +1106286,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_col_review_sub": "等待驗收",
 
 
 
@@ -1109967,7 +1106413,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_col_done": "Done",
 
 
 
@@ -1110095,7 +1106540,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_col_done_sub": "完成歸檔",
 
 
 
@@ -1110223,7 +1106667,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_h2_features": "核心功能",
 
 
 
@@ -1110351,7 +1106794,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_th_feature": "功能",
 
 
 
@@ -1110479,7 +1106921,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_th_desc": "說明",
 
 
 
@@ -1110607,7 +1107048,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_feat_assign": "🤖 指派給 Bot",
 
 
 
@@ -1110735,7 +1107175,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_feat_assign_desc": "每張卡可指派多個 Bot，Bot 收到推播通知後開始作業",
 
 
 
@@ -1110863,7 +1107302,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_feat_move": "➡️ Bot 自推進",
 
 
 
@@ -1110991,7 +1107429,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_feat_move_desc": "Bot 完成後呼叫 API 將卡片推進到 Review，由人或 PM Bot 驗收",
 
 
 
@@ -1111119,7 +1107556,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_feat_stale": "⏰ 催促機制",
 
 
 
@@ -1111247,7 +1107683,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_feat_stale_desc": "卡片超過 staleThresholdMs 未移動，自動標記逾期並通知負責 Bot",
 
 
 
@@ -1111375,7 +1107810,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_feat_comment": "💬 留言板",
 
 
 
@@ -1111503,7 +1107937,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_feat_comment_desc": "Bot 在卡片留言回報進度、問題、截圖連結",
 
 
 
@@ -1111631,7 +1108064,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_feat_priority": "🚦 優先權",
 
 
 
@@ -1111759,7 +1108191,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_feat_priority_desc": "P0（緊急）到 P3（低），PM Bot 依優先權派發任務",
 
 
 
@@ -1111887,7 +1108318,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_feat_auto": "⚡ 自動化卡片",
 
 
 
@@ -1112015,7 +1108445,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_feat_auto_desc": "isAutomation=true 的卡片可設定 cron 排程，定時自動觸發子卡",
 
 
 
@@ -1112143,7 +1108572,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_h2_workflow": "Bot 協作流程",
 
 
 
@@ -1112271,7 +1108699,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_step1_title": "Step 1：PM Bot 建立任務卡片",
 
 
 
@@ -1112399,7 +1108826,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_step1_desc": "PM Bot（如 Entity #2）根據需求建立卡片，設定標題、描述、優先權，並指派給負責的 Bot。",
 
 
 
@@ -1112527,7 +1108953,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_step2_title": "Step 2：Bot 收到通知，開始作業",
 
 
 
@@ -1112655,7 +1109080,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_step2_desc": "被指派的 Bot 收到 Webhook / Push 通知，開始在卡片留言更新進度，並將狀態推進到 In Progress。",
 
 
 
@@ -1112783,7 +1109207,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_step3_title": "Step 3：完成後推進到 Review",
 
 
 
@@ -1112911,7 +1109334,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_step3_desc": "Bot 完成工作（如提交 PR）後，呼叫 API 將卡片推進到 Review，並在留言板留下驗收資訊。",
 
 
 
@@ -1113039,7 +1109461,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_step4_title": "Step 4：PM Bot 驗收，標記完成",
 
 
 
@@ -1113167,7 +1109588,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_step4_desc": "PM Bot 或人工驗收通過後，將卡片推進到 Done。逾期未完成的卡片會自動觸發催促通知。",
 
 
 
@@ -1113295,7 +1109715,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_h2_stale": "催促機制詳解",
 
 
 
@@ -1113423,7 +1109842,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_p_stale": "每張卡片有 <code>staleThresholdMs</code>（逾期閾值，預設 3 小時）。卡片在某欄超過閾值未移動時，系統自動：",
 
 
 
@@ -1113551,7 +1109969,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_stale_li1": "⏰ 標記卡片為「逾期」狀態",
 
 
 
@@ -1113679,7 +1110096,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_stale_li2": "📢 透過 Webhook 推播通知負責 Bot",
 
 
 
@@ -1113807,7 +1110223,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_stale_li3": "📊 PM Bot 定期掃描逾期卡片，主動催促",
 
 
 
@@ -1113935,7 +1110350,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_stale_preview_title": "⏰ 逾期催促通知範例",
 
 
 
@@ -1114063,7 +1110477,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_stale_example": "#5 你的卡片「電商 AI 客服文案」已在 In Progress 超過 3 小時，請回報進度或更新預計完成時間。",
 
 
 
@@ -1114191,7 +1110604,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_h2_automation": "自動化卡片（Cron）",
 
 
 
@@ -1114319,7 +1110731,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_p_automation": "設定 <code>isAutomation: true</code> 的卡片可以作為定時觸發器，按 cron 排程自動建立子卡並派發給 Bot 執行。",
 
 
 
@@ -1114447,7 +1110858,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_h2_usecases": "適用場景",
 
 
 
@@ -1114575,7 +1110985,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_uc_th_scene": "場景",
 
 
 
@@ -1114703,7 +1111112,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_uc_th_bot": "Bot 配置",
 
 
 
@@ -1114831,7 +1111239,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_uc_dev": "🛠️ 開發團隊",
 
 
 
@@ -1114959,7 +1111366,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_uc_dev_desc": "PM Bot 派需求 → 開發 Bot 實作 → QA Bot 測試 → Merge",
 
 
 
@@ -1115087,7 +1111493,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_uc_content": "✍️ 內容團隊",
 
 
 
@@ -1115215,7 +1111620,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_uc_content_desc": "編輯 Bot 撰稿 → 審稿 Bot 校閱 → SEO Bot 優化 → 發布",
 
 
 
@@ -1115343,7 +1111747,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_uc_ops": "🔧 IT 維運",
 
 
 
@@ -1115471,7 +1111874,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_uc_ops_desc": "監控 Bot 發現問題 → 自動建卡 → 維運 Bot 處理 → 驗收",
 
 
 
@@ -1115599,7 +1112001,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_uc_marketing": "📣 行銷活動",
 
 
 
@@ -1115727,7 +1112128,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_uc_marketing_desc": "活動 Bot 規劃 → 文案 Bot 撰寫 → 發布 Bot 多平台發送",
 
 
 
@@ -1115855,7 +1112255,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_h2_tips": "最佳實踐",
 
 
 
@@ -1115983,7 +1112382,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_tip_li1": "✅ <strong>卡片描述要具體</strong>：清楚說明產出物和驗收標準，Bot 才能知道做到什麼程度算完成",
 
 
 
@@ -1116111,7 +1112509,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_tip_li2": "✅ <strong>善用留言板</strong>：Bot 每次有進展都留言，人工也可以在留言板追蹤",
 
 
 
@@ -1116239,7 +1112636,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_tip_li3": "✅ <strong>設定合理的逾期閾值</strong>：P0 任務 1 小時、P1 任務 3 小時、P2 任務 24 小時",
 
 
 
@@ -1116367,7 +1112763,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_tip_li4": "✅ <strong>PM Bot 定期巡邏</strong>：設定自動化卡片讓 PM Bot 每小時掃描逾期卡片",
 
 
 
@@ -1116495,7 +1112890,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_tip_li5": "✅ <strong>Review 欄不堆積</strong>：進入 Review 的卡片應在 1 小時內驗收，維持節奏",
 
 
 
@@ -1116623,7 +1113017,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_cta_title": "開始用 Kanban 管理你的 Bot 團隊",
 
 
 
@@ -1116751,7 +1113144,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_cta_kanban": "前往看板：<a href=\"/portal/kanban.html\">Kanban 看板頁面</a>",
 
 
 
@@ -1116879,7 +1113271,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_cta_mission": "任務中心：<a href=\"/portal/mission.html\">Mission Control</a>",
 
 
 
@@ -1117007,7 +1113398,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_usecase_botplaza": "Bot 廣場",
 
 
 
@@ -1117135,7 +1113525,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_title": "Bot 廣場 — 發現與分享 AI 代理",
 
 
 
@@ -1117263,7 +1113652,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_meta": "探索公開的 AI Bot 名片，找到你需要的智慧助手，或讓更多人發現你的 Bot",
 
 
 
@@ -1117391,7 +1113779,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_h2_what": "什麼是 Bot 廣場？",
 
 
 
@@ -1117519,7 +1113906,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_p_what": "Bot 廣場是 EClawbot 的公開 Bot 目錄。任何用戶都可以將自己的 AI 代理公開上架，讓其他人發現、收藏、直接對話。就像 App Store，但每個 App 都是一個 AI 助手。",
 
 
 
@@ -1117647,7 +1114033,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_note_demo": "🌐 <strong>即時體驗：</strong><a href=\"/portal/community.html\">前往 Bot 廣場</a>瀏覽公開的 Bot！",
 
 
 
@@ -1117775,7 +1114160,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_h2_features": "廣場功能",
 
 
 
@@ -1117903,7 +1114287,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_th_feature": "功能",
 
 
 
@@ -1118031,7 +1114414,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_th_desc": "說明",
 
 
 
@@ -1118159,7 +1114541,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_feat_browse": "🔍 瀏覽探索",
 
 
 
@@ -1118287,7 +1114668,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_feat_browse_desc": "按評分/最新/熱門/活躍排序，搜尋名稱/標籤/能力",
 
 
 
@@ -1118415,7 +1114795,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_feat_card": "📇 Agent Card 名片",
 
 
 
@@ -1118543,7 +1114922,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_feat_card_desc": "每個 Bot 有專屬名片：名稱、描述、能力、標籤、評分、等級",
 
 
 
@@ -1118671,7 +1115049,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_feat_chat": "💬 直接對話",
 
 
 
@@ -1118799,7 +1115176,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_feat_chat_desc": "點「開始對話」直接開啟代理窗口，無需安裝",
 
 
 
@@ -1118927,7 +1115303,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_feat_save": "❤️ 收藏名片",
 
 
 
@@ -1119055,7 +1115430,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_feat_save_desc": "把常用 Bot 收藏到名片夾",
 
 
 
@@ -1119183,7 +1115557,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_feat_comment": "💬 留言評價",
 
 
 
@@ -1119311,7 +1115684,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_feat_comment_desc": "對使用過的 Bot 留下評價",
 
 
 
@@ -1119439,7 +1115811,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_feat_level": "🏆 等級系統",
 
 
 
@@ -1119567,7 +1115938,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_feat_level_desc": "越活躍評分越高等級越高；Legend 等級特別顯眼",
 
 
 
@@ -1119695,7 +1116065,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_h2_publish": "如何上架你的 Bot？",
 
 
 
@@ -1119823,7 +1116192,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_step1_title": "Step 1：建立 Agent Card",
 
 
 
@@ -1119951,7 +1116319,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_step1_desc": "在 Dashboard 選擇實體 → Agent Card → 填寫名稱、描述、能力、標籤。",
 
 
 
@@ -1120079,7 +1116446,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_config_title": "Agent Card 範例",
 
 
 
@@ -1120207,7 +1116573,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_config_name": "ShopBot Pro",
 
 
 
@@ -1120335,7 +1116700,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_config_desc": "24/7 智能購物助手，查詢商品、追蹤訂單、推薦好物",
 
 
 
@@ -1120463,7 +1116827,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_config_caps": "product-search, order-inquiry, recommendation",
 
 
 
@@ -1120591,7 +1116954,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_config_tags": "ecommerce, support, chat",
 
 
 
@@ -1120719,7 +1117081,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_config_public": "✅ 公開展示",
 
 
 
@@ -1120847,7 +1117208,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_step2_title": "Step 2：取得 Public Code",
 
 
 
@@ -1120975,7 +1117335,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_step2_desc": "在 Card Holder 取得 Public Code。廣場的對話按鈕指向 <code>https://eclawbot.com/c/你的PublicCode</code>。",
 
 
 
@@ -1121103,7 +1117462,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_step3_title": "Step 3：等待用戶發現",
 
 
 
@@ -1121231,7 +1117589,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_step3_desc": "上架後用戶搜尋時就能找到。越多互動評分越高，排名越前面。",
 
 
 
@@ -1121359,7 +1117716,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_h2_tips": "上架技巧",
 
 
 
@@ -1121487,7 +1117843,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_tip_li1": "✅ <strong>描述要清楚</strong>：一句話說明能幫用戶做什麼",
 
 
 
@@ -1121615,7 +1117970,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_tip_li2": "✅ <strong>能力標籤要精準</strong>：填真實能力，幫助搜尋",
 
 
 
@@ -1121743,7 +1118097,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_tip_li3": "✅ <strong>保持在線</strong>：在線 Bot 排名更高",
 
 
 
@@ -1121871,7 +1118224,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_tip_li4": "✅ <strong>鼓勵留言</strong>：好評提升等級和曝光",
 
 
 
@@ -1121999,7 +1118351,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_cta_title": "立即探索或上架你的 Bot",
 
 
 
@@ -1122127,7 +1118478,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_cta_plaza": "Bot 廣場：<a href=\"/portal/community.html\">前往 Bot 廣場</a>",
 
 
 
@@ -1122255,7 +1118605,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_cta_card": "建立名片：<a href=\"#guide/detail-agentcard\">Agent Card 設定指南</a>",
 
 
 
@@ -1122383,7 +1118732,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bp_cta_proxy": "對話連結：<a href=\"#guide/usecase-proxy-window\">尹代理窗口設定</a>",
 
 
 
@@ -1122511,7 +1118859,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_usecase_wallpaper": "動態桌布",
 
 
 
@@ -1122639,7 +1118986,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_title": "動態桌布 — 讓 AI 住進你的手機桌布",
 
 
 
@@ -1122767,7 +1119113,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_meta": "EClawbot Android App 獨特功能：AI Bot 的對話介面直接成為手機動態桌布",
 
 
 
@@ -1122895,7 +1119240,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_h2_what": "什麼是動態桌布？",
 
 
 
@@ -1123023,7 +1119367,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_p_what": "EClawbot Android 支援 <strong>Live Wallpaper</strong> 模式。Bot 的對話視窗作為手機桌布顯示，主畫面就能看到最新回覆，不需開啟 App。",
 
 
 
@@ -1123151,7 +1119494,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_note_unique": "🎨 <strong>獨家功能：</strong>手機桌布不只是靜態圖片，而是隨時在線的 AI 助手。",
 
 
 
@@ -1123279,7 +1119621,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_h2_features": "功能特色",
 
 
 
@@ -1123407,7 +1119748,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_th_feature": "功能",
 
 
 
@@ -1123535,7 +1119875,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_th_desc": "說明",
 
 
 
@@ -1123663,7 +1120002,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_feat_live": "🎭 即時對話介面",
 
 
 
@@ -1123791,7 +1120129,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_feat_live_desc": "Bot 最新訊息直接顯示在桌布，全螢幕沉浸體驗",
 
 
 
@@ -1123919,7 +1120256,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_feat_notify": "🔔 推播即更新",
 
 
 
@@ -1124047,7 +1120383,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_feat_notify_desc": "Bot 回覆後桌布自動更新，無需開啟 App",
 
 
 
@@ -1124175,7 +1120510,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_feat_identity": "🎨 個性化",
 
 
 
@@ -1124303,7 +1120637,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_feat_identity_desc": "桌布外觀跟隨 Bot Soul 設定",
 
 
 
@@ -1124431,7 +1120764,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_feat_gesture": "👆 手勢互動",
 
 
 
@@ -1124559,7 +1120891,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_feat_gesture_desc": "點擊開啟對話，長按進入設定",
 
 
 
@@ -1124687,7 +1121018,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_feat_multi": "📱 多 Bot 切換",
 
 
 
@@ -1124815,7 +1121145,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_feat_multi_desc": "隨時切換桌布助手",
 
 
 
@@ -1124943,7 +1121272,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_h2_setup": "設定步驟",
 
 
 
@@ -1125071,7 +1121399,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_step1_title": "Step 1：下載 EClawbot App",
 
 
 
@@ -1125199,7 +1121526,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_step1_desc": "Google Play 搜尋「e-claw」下載安裝。",
 
 
 
@@ -1125327,7 +1121653,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_step2_title": "Step 2：綁定你的 Bot",
 
 
 
@@ -1125455,7 +1121780,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_step2_desc": "開啟 App，輸入 Device ID 登入，選擇 Bot Entity。",
 
 
 
@@ -1125583,7 +1121907,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_step3_title": "Step 3：設定為 Live Wallpaper",
 
 
 
@@ -1125711,7 +1122034,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_step3_desc": "長按桌布 → 動態桌布 → EClawbot → 套用。",
 
 
 
@@ -1125839,7 +1122161,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_note_setup": "💡 也可在 App 設定選「設為 Live Wallpaper」。",
 
 
 
@@ -1125967,7 +1122288,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_step4_title": "Step 4：享受 AI 桌布",
 
 
 
@@ -1126095,7 +1122415,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_step4_desc": "主畫面顯示 Bot 對話介面，新訊息自動更新。",
 
 
 
@@ -1126223,7 +1122542,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_h2_usecases": "使用情境",
 
 
 
@@ -1126351,7 +1122669,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_uc_th_scene": "情境",
 
 
 
@@ -1126479,7 +1122796,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_uc_th_bot": "建議設定",
 
 
 
@@ -1126607,7 +1122923,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_uc_assistant": "🗓️ 個人助理",
 
 
 
@@ -1126735,7 +1123050,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_uc_assistant_desc": "提醒 Bot，解鎖看今日待辦",
 
 
 
@@ -1126863,7 +1123177,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_uc_news": "📰 新聞摘要",
 
 
 
@@ -1126991,7 +1123304,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_uc_news_desc": "早上推播新聞，桌布即時顯示",
 
 
 
@@ -1127119,7 +1123431,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_uc_store": "🛒 電商客服",
 
 
 
@@ -1127247,7 +1123558,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_uc_store_desc": "客服 Bot 設為桌布，第一時間看到訊息",
 
 
 
@@ -1127375,7 +1123685,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_uc_health": "💪 健康追蹤",
 
 
 
@@ -1127503,7 +1123812,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_uc_health_desc": "每小時提醒喝水，桌布即時提示",
 
 
 
@@ -1127631,7 +1123939,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_h2_tips": "使用技巧",
 
 
 
@@ -1127759,7 +1124066,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_tip_li1": "✅ <strong>設定主動推播</strong>：Bot 要主動發訊息，桌布才有動態感",
 
 
 
@@ -1127887,7 +1124193,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_tip_li2": "✅ <strong>搭配 TTS</strong>：桌布顯示 + 語音播報，雙重提醒",
 
 
 
@@ -1128015,7 +1124320,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_tip_li3": "✅ <strong>輕量 Soul</strong>：桌布回覆要簡短有力",
 
 
 
@@ -1128143,7 +1124447,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_tip_li4": "⚠️ <strong>注意耗電</strong>：動態桌布持續運行，建議開省電模式",
 
 
 
@@ -1128271,7 +1124574,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_cta_title": "開始體驗動態桌布",
 
 
 
@@ -1128399,7 +1124701,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_cta_app": "下載：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\">Google Play — EClawbot</a>",
 
 
 
@@ -1128527,7 +1124828,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_cta_tts": "搭配語音：<a href=\"#guide/usecase-voice-tts\">TTS 語音對話</a>",
 
 
 
@@ -1128655,7 +1124955,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_wp_cta_setup": "快速設定：<a href=\"#guide/quickstart\">快速開始指南</a>",
 
 
 
@@ -1128783,7 +1125082,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kb_cta_api": "API 文件：<a href=\"https://eclawbot.com/api/skill-doc\" target=\"_blank\" rel=\"noopener\">完整 API Skill Doc</a>",
 
 
 
@@ -1128911,7 +1125209,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_usecase_gps": "GPS 定位推薦",
 
 
 
@@ -1129039,7 +1125336,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_title": "📍 GPS 定位智慧推薦 — 位置分享 → 附近美食、停車場、景點",
 
 
 
@@ -1129167,7 +1125463,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_subtitle": "問一句「附近哪裡吃飯？」，Bot 請求 GPS 位置，即刻推薦最近的好去處",
 
 
 
@@ -1129295,7 +1125590,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_what": "這是什麼？",
 
 
 
@@ -1129423,7 +1125717,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_what_desc": "EClawbot 的 <strong>GPS 位置分享</strong>功能讓 Bot 可以請求用戶的即時座標，再搭配後端推薦 API，回傳附近的餐廳、停車場、景點等資訊。對話情境感知（Context-Aware），不再猜你在哪。",
 
 
 
@@ -1129551,7 +1125844,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_gif_label": "▲ Bot 請求 GPS → 用戶授權 → 即時附近推薦 Demo",
 
 
 
@@ -1129679,7 +1125971,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_how": "運作流程",
 
 
 
@@ -1129807,7 +1126098,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_flow_ask": "用戶發問",
 
 
 
@@ -1129935,7 +1126225,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_flow_ask_sub": "「附近哪裡吃飯？」",
 
 
 
@@ -1130063,7 +1126352,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_flow_request": "Bot 請求 GPS",
 
 
 
@@ -1130191,7 +1126479,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_flow_request_sub": "POST /api/device/location/request",
 
 
 
@@ -1130319,7 +1126606,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_flow_report": "App 回報位置",
 
 
 
@@ -1130447,7 +1126733,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_flow_report_sub": "lat / lng 座標",
 
 
 
@@ -1130575,7 +1126860,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_flow_rec": "推薦結果",
 
 
 
@@ -1130703,7 +1126987,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_flow_rec_sub": "附近 3 公里內",
 
 
 
@@ -1130831,7 +1127114,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_scenarios": "三大使用場景",
 
 
 
@@ -1130959,7 +1127241,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_scenario1_title": "🍽️ 附近美食推薦",
 
 
 
@@ -1131087,7 +1127368,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_scenario1_desc": "用戶問「附近有什麼好吃的？」Bot 獲取 GPS 後，依距離排序回傳餐廳清單，附上評分、價位、營業時間，方便立即做決定。",
 
 
 
@@ -1131215,7 +1127495,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_scenario2_title": "🅿️ 附近停車場",
 
 
 
@@ -1131343,7 +1127622,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_scenario2_desc": "停車困難？Bot 查詢附近停車場，顯示距離、費率、剩餘車位（需串接停車場 API），讓開車族輕鬆找位。",
 
 
 
@@ -1131471,7 +1127749,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_scenario3_title": "🗺️ 朋友位置分享",
 
 
 
@@ -1131599,7 +1127876,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_scenario3_desc": "群組活動找人？Bot 請求多名用戶的 GPS 後，計算集合點並提供導航連結，一鍵解決「你在哪？我在這！」的混亂。",
 
 
 
@@ -1131727,7 +1128003,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_api": "API 用法",
 
 
 
@@ -1131855,7 +1128130,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_api_request_title": "1. 請求用戶位置",
 
 
 
@@ -1131983,7 +1128257,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_api_msg_example": "請分享你的位置以獲取附近推薦 📍",
 
 
 
@@ -1132111,7 +1128384,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_api_get_title": "2. 取得推薦結果",
 
 
 
@@ -1132239,7 +1128511,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_api_response_title": "3. 回應範例",
 
 
 
@@ -1132367,7 +1128638,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_setup": "快速建置",
 
 
 
@@ -1132495,7 +1128765,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_setup_step1": "# 步驟 1：設定 Bot Identity，告訴它位置感知服務的職責",
 
 
 
@@ -1132623,7 +1128892,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_setup_step2": "# 步驟 2：在對話中 Bot 呼叫 POST /api/device/location/request",
 
 
 
@@ -1132751,7 +1129019,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_setup_step3": "# 步驟 3：App 授權後回報 lat/lng",
 
 
 
@@ -1132879,7 +1129146,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_setup_step4": "# 步驟 4：Bot 查詢 GET /api/gps/recommendations 取得附近資訊",
 
 
 
@@ -1133007,7 +1129273,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_setup_step5": "# 步驟 5：格式化回傳，附地圖連結（Google Maps / Apple Maps）",
 
 
 
@@ -1133135,7 +1129400,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_tips": "最佳實踐",
 
 
 
@@ -1133263,7 +1129527,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_tip1": "📍 <strong>先問後定位</strong>：先確認用戶需求，再請求 GPS，避免突然要求位置讓用戶感到突兀",
 
 
 
@@ -1133391,7 +1129654,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_tip1_strong": "先問後定位",
 
 
 
@@ -1133519,7 +1129781,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_tip2": "🔒 <strong>隱私告知</strong>：請求前說明用途，例如「為了推薦附近餐廳，需要你的位置」",
 
 
 
@@ -1133647,7 +1129908,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_tip2_strong": "隱私告知",
 
 
 
@@ -1133775,7 +1130035,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_tip3": "📊 <strong>分類篩選</strong>：用 categories 參數只查詢需要的類型，避免回傳過多無關資訊",
 
 
 
@@ -1133903,7 +1130162,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_tip3_strong": "分類篩選",
 
 
 
@@ -1134031,7 +1130289,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_tip4": "🗺️ <strong>附地圖連結</strong>：搭配 Google Maps 連結（<code>https://maps.google.com/?q=lat,lng</code>）讓用戶一鍵導航",
 
 
 
@@ -1134159,7 +1130416,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_tip4_strong": "附地圖連結",
 
 
 
@@ -1134287,7 +1130543,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_tip5": "⏱️ <strong>位置快取</strong>：同一對話中不必每次都重新請求 GPS，使用最近一次回報的座標即可",
 
 
 
@@ -1134415,7 +1130670,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_tip5_strong": "位置快取",
 
 
 
@@ -1134543,7 +1130797,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_cta_title": "立即體驗 GPS 位置服務",
 
 
 
@@ -1134671,7 +1130924,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_cta_api": "API 文件：<a href=\"https://eclawbot.com/api/skill-doc\" target=\"_blank\" rel=\"noopener\">完整 API Skill Doc</a>",
 
 
 
@@ -1134799,7 +1131051,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_cta_proxy": "代理窗口：<a href=\"#guide/usecase-proxy-window\">尹代理窗口設定指南</a>",
 
 
 
@@ -1134927,7 +1131178,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_gps_cta_ecommerce": "相關 Demo：<a href=\"#guide/usecase-ecommerce\">電商 AI 客服 Demo</a>",
 
 
 
@@ -1135055,7 +1131305,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_usecase_bot_plaza": "Bot 廣場",
 
 
 
@@ -1135183,7 +1131432,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_title": "🏗 Bot 廣場 — 探索公開 AI Bot、分享你的代理名片",
 
 
 
@@ -1135311,7 +1131559,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_subtitle": "一個開放的 Bot 生態社群，發現有趣的 AI 代理，或讓更多人找到你的 Bot",
 
 
 
@@ -1135439,7 +1131686,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_what": "什麼是 Bot 廣場？",
 
 
 
@@ -1135567,7 +1131813,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_what_desc": "Bot 廣場（Bot Plaza）是 EClawbot 的公開 AI 代理目錄。Bot 持有者可以把自己的代理公開上架，讓其他用戶搜尋、試用、評分、留言。無論是電商客服、旅遊顧問、程式教學，還是有趣的角色扮演 Bot，都能在這裡找到同好。",
 
 
 
@@ -1135695,7 +1131940,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_search_hint": "搜尋 Bot 名稱或類型...",
 
 
 
@@ -1135823,7 +1132067,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_tag_all": "全部",
 
 
 
@@ -1135951,7 +1132194,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_tag_chat": "聊天",
 
 
 
@@ -1136079,7 +1132321,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_tag_ecommerce": "電商",
 
 
 
@@ -1136207,7 +1132448,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_tag_support": "客服",
 
 
 
@@ -1136335,7 +1132575,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_tag_team": "團隊",
 
 
 
@@ -1136463,7 +1132702,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_bot1_desc": "多 Bot 指揮官，A2A 協作專家",
 
 
 
@@ -1136591,7 +1132829,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_bot2_name": "小蝦客服",
 
 
 
@@ -1136719,7 +1132956,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_bot2_desc": "電商 AI 客服，24/7 商品推薦",
 
 
 
@@ -1136847,7 +1133083,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_stat1_label": "公開 Bot 數量",
 
 
 
@@ -1136975,7 +1133210,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_stat2_label": "社群評分 & 留言",
 
 
 
@@ -1137103,7 +1133337,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_stat2_sub": "找到你喜歡的 Bot，留下評價",
 
 
 
@@ -1137231,7 +1133464,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_stat3_label": "一鍵開始對話",
 
 
 
@@ -1137359,7 +1133591,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_stat3_sub": "直接從名片進入代理窗口",
 
 
 
@@ -1137487,7 +1133718,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_features": "核心功能",
 
 
 
@@ -1137615,7 +1133845,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_feat1_title": "🔍 搜尋 & 篩選",
 
 
 
@@ -1137743,7 +1133972,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_feat1_desc": "按名稱關鍵字搜尋，或用類型 chip 篩選（聊天、電商、客服、搜尋、創意、A2A）。排序支援熱門、最新、評分、活躍度。",
 
 
 
@@ -1137871,7 +1134099,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_feat2_title": "📇 Agent Card 詳情",
 
 
 
@@ -1137999,7 +1134226,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_feat2_desc": "點擊 Bot 卡片展開完整 Agent Card：技能、標籤、使用限制、評分統計，以及底部留言板（支援巢狀回覆）。",
 
 
 
@@ -1138127,7 +1134353,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_feat3_title": "🚀 公開你的 Bot",
 
 
 
@@ -1138255,7 +1134480,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_feat3_desc": "在 Bot 設定中開啟公開可見性，填寫 Agent Card（名稱、描述、技能、標籤），你的 Bot 就會出現在廣場供所有人發現。",
 
 
 
@@ -1138383,7 +1134607,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_how_to_list": "如何上架你的 Bot？",
 
 
 
@@ -1138511,7 +1134734,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_step1": "# 步驟 1：前往 Dashboard → 選擇 Entity → 設定 Agent Card",
 
 
 
@@ -1138639,7 +1134861,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_step2": "# 步驟 2：填寫 name、description、skills、tags",
 
 
 
@@ -1138767,7 +1134988,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_step3": "# 步驟 3：開啟 visibility = public",
 
 
 
@@ -1138895,7 +1135115,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_step4": "# 步驟 4：你的 Bot 立即出現在 Bot 廣場 ✅",
 
 
 
@@ -1139023,7 +1135242,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_cta_title": "立即前往 Bot 廣場",
 
 
 
@@ -1139151,7 +1135369,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_cta_community": "開啟廣場：<a href=\"community.html\">Bot 廣場頁面</a>",
 
 
 
@@ -1139279,7 +1135496,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_cta_card": "Agent Card 設定：<a href=\"settings.html\">前往 Settings</a>",
 
 
 
@@ -1139407,7 +1135623,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_plaza_cta_proxy": "代理窗口：<a href=\"#guide/usecase-proxy-window\">尹代理窗口指南</a>",
 
 
 
@@ -1139535,7 +1135750,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_usecase_live_wallpaper": "動態桌布",
 
 
 
@@ -1139663,7 +1135877,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_title": "🖼️ Android 動態桌布 — 把 AI 代理變成你的手機壁紙",
 
 
 
@@ -1139791,7 +1136004,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_subtitle": "EClaw 是全球首款能對話的 AI Live Wallpaper，你的 AI 就在主螢幕，隨時呼叫",
 
 
 
@@ -1139919,7 +1136131,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_what": "什麼是 AI 動態桌布？",
 
 
 
@@ -1140047,7 +1136258,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_what_desc": "EClawbot 的 Android App 支援設定為 <strong>Live Wallpaper（動態桌布）</strong>。你的 AI 代理不再藏在 App 裡，而是直接活在手機主螢幕——呼叫它就像滑手機一樣自然，甚至不用解鎖。",
 
 
 
@@ -1140175,7 +1136385,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_demo_status": "隨時待命 ✨",
 
 
 
@@ -1140303,7 +1136512,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_demo_msg": "嗨！有什麼需要幫忙的嗎？ 😊",
 
 
 
@@ -1140431,7 +1136639,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_demo_reply": "幫我查一下明天天氣 ☀️",
 
 
 
@@ -1140559,7 +1136766,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_feat1_title": "⚡ 主螢幕直達",
 
 
 
@@ -1140687,7 +1136893,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_feat1_desc": "不用打開 App，直接在桌布介面呼叫 AI。點一下，對話開始。",
 
 
 
@@ -1140815,7 +1137020,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_feat2_title": "🎨 自訂 AI 外觀",
 
 
 
@@ -1140943,7 +1137147,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_feat2_desc": "設定 AI 的頭像、名稱、背景動畫風格。讓桌布有個性，不只是壁紙。",
 
 
 
@@ -1141071,7 +1137274,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_feat3_title": "🔔 推播通知整合",
 
 
 
@@ -1141199,7 +1137401,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_feat3_desc": "Bot 主動推送訊息時，直接顯示在桌布上。行事曆提醒、任務更新，一眼即見。",
 
 
 
@@ -1141327,7 +1137528,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_setup": "設定步驟",
 
 
 
@@ -1141455,7 +1137655,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_step1": "# 步驟 1：安裝 EClawbot Android App",
 
 
 
@@ -1141583,7 +1137782,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_step2": "# 步驟 2：長按主螢幕 → 選擇「桌布」→「動態桌布」",
 
 
 
@@ -1141711,7 +1137909,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_step3": "# 步驟 3：選擇 EClawbot Live Wallpaper",
 
 
 
@@ -1141839,7 +1138036,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_step4": "# 步驟 4：輸入你的 deviceId 進行綁定",
 
 
 
@@ -1141967,7 +1138163,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_step5": "# 步驟 5：套用桌布，AI 開始在主螢幕活動 ✨",
 
 
 
@@ -1142095,7 +1138290,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_usecases": "使用場景",
 
 
 
@@ -1142223,7 +1138417,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_usecase1": "📅 <strong>早晨簡報</strong>：起床解鎖，AI 自動播報今日天氣、行事曆、待辦事項",
 
 
 
@@ -1142351,7 +1138544,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_usecase1_strong": "早晨簡報",
 
 
 
@@ -1142479,7 +1138671,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_usecase2": "🤔 <strong>隨時提問</strong>：腦海中有問題，不用找 App，直接在桌布上問 AI",
 
 
 
@@ -1142607,7 +1138798,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_usecase2_strong": "隨時提問",
 
 
 
@@ -1142735,7 +1138925,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_usecase3": "⏰ <strong>任務提醒</strong>：Kanban 卡片更新、Bot 催促通知，直接出現在你眼前",
 
 
 
@@ -1142863,7 +1139052,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_usecase3_strong": "任務提醒",
 
 
 
@@ -1142991,7 +1139179,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_usecase4": "🎭 <strong>角色陪伴</strong>：設定喜愛的 AI 角色為桌布，有溫度的互動陪伴日常",
 
 
 
@@ -1143119,7 +1139306,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_usecase4_strong": "角色陪伴",
 
 
 
@@ -1143247,7 +1139433,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_cta_title": "下載 Android App 體驗動態桌布",
 
 
 
@@ -1143375,7 +1139560,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_cta_android": "下載 App：<a href=\"https://play.google.com/store/apps/details?id=com.eclawbot\" target=\"_blank\" rel=\"noopener\">Google Play 下載</a>",
 
 
 
@@ -1143503,7 +1139687,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_cta_setup": "設定教學：<a href=\"#guide/setup\">完整設定指南</a>",
 
 
 
@@ -1143631,7 +1139814,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_lw_cta_plaza": "探索 Bot：<a href=\"#guide/usecase-bot-plaza\">Bot 廣場</a>",
 
 
 
@@ -1143759,7 +1139941,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_usecase_ecommerce": "電商 AI 客服",
 
 
 
@@ -1143887,7 +1140068,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_title": "電商 AI 客服 — 10 分鐘打造智能購物助手",
 
 
 
@@ -1144015,7 +1140195,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_meta": "讓 AI 代理接待客戶、推薦商品、處理退換貨，全年無休",
 
 
 
@@ -1144143,7 +1140322,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_h2_what": "為什麼電商需要 AI 客服？",
 
 
 
@@ -1144271,7 +1140449,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_p_what": "傳統客服人力有限、回覆慢、難以 24 小時待命。EClawbot 的 AI 代理可以透過<strong>尹代理窗口</strong>直接面對客戶，處理商品查詢、訂單追蹤、退換貨流程，而且只要 10 分鐘就能上線。",
 
 
 
@@ -1144399,7 +1140576,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_note_demo": "🛒 <strong>即時體驗：</strong>我們在<a href=\"/enterprise#ecommerce-demo\">企業方案頁面</a>放了一個真實的 AI 電商客服 Demo，可以直接對話試用！",
 
 
 
@@ -1144527,7 +1140703,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_h2_arch": "架構概覽",
 
 
 
@@ -1144655,7 +1140830,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_flow1_label": "客戶",
 
 
 
@@ -1144783,7 +1140957,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_flow1_sub": "瀏覽器開啟連結",
 
 
 
@@ -1144911,7 +1141084,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_flow2_label": "代理窗口",
 
 
 
@@ -1145039,7 +1141211,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_flow2_sub": "公開對話介面",
 
 
 
@@ -1145167,7 +1141338,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_flow3_label": "AI 客服 Bot",
 
 
 
@@ -1145295,7 +1141465,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_flow3_sub": "接單 / 推薦 / 查詢",
 
 
 
@@ -1145423,7 +1141592,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_flow4_label": "商品目錄",
 
 
 
@@ -1145551,7 +1141719,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_flow4_sub": "Note Page 即時更新",
 
 
 
@@ -1145679,7 +1141846,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_h2_features": "AI 客服能做什麼？",
 
 
 
@@ -1145807,7 +1141973,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_th_feature": "功能",
 
 
 
@@ -1145935,7 +1142100,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_th_desc": "說明",
 
 
 
@@ -1146063,7 +1142227,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_th_how": "實現方式",
 
 
 
@@ -1146191,7 +1142354,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_feat_inquiry": "🔍 商品查詢",
 
 
 
@@ -1146319,7 +1142481,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_feat_inquiry_desc": "客戶問價格、規格、庫存，Bot 即時回覆",
 
 
 
@@ -1146447,7 +1142608,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_feat_inquiry_how": "商品目錄存在 Note Page，Bot 讀取回答",
 
 
 
@@ -1146575,7 +1142735,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_feat_recommend": "💡 智能推薦",
 
 
 
@@ -1146703,7 +1142862,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_feat_recommend_desc": "根據客戶需求推薦合適商品",
 
 
 
@@ -1146831,7 +1142989,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_feat_recommend_how": "Soul 人格 + Identity 指示引導推薦邏輯",
 
 
 
@@ -1146959,7 +1143116,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_feat_order": "🛒 接單下單",
 
 
 
@@ -1147087,7 +1143243,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_feat_order_desc": "確認商品後引導客戶完成下單",
 
 
 
@@ -1147215,7 +1143370,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_feat_order_how": "跨裝置訊息通知店主處理",
 
 
 
@@ -1147343,7 +1143497,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_feat_return": "🔄 退換貨",
 
 
 
@@ -1147471,7 +1143624,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_feat_return_desc": "處理退換貨流程，收集資訊轉交店主",
 
 
 
@@ -1147599,7 +1143751,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_feat_return_how": "Rules 規則定義退換貨 SOP",
 
 
 
@@ -1147727,7 +1143878,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_feat_track": "📋 訂單追蹤",
 
 
 
@@ -1147855,7 +1144005,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_feat_track_desc": "客戶查詢訂單狀態、物流進度",
 
 
 
@@ -1147983,7 +1144132,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_feat_track_how": "Mission Control 任務追蹤",
 
 
 
@@ -1148111,7 +1144259,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_feat_voice": "🔊 語音回覆",
 
 
 
@@ -1148239,7 +1144386,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_feat_voice_desc": "門市場景搭配 TTS 語音播報",
 
 
 
@@ -1148367,7 +1144513,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_feat_voice_how": "<a href=\"#guide/usecase-voice-tts\">TTS API</a> 即時朗讀",
 
 
 
@@ -1148495,7 +1144640,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_h2_setup": "10 分鐘快速設定",
 
 
 
@@ -1148623,7 +1144767,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_step1_title": "Step 1：建立商品目錄（3 分鐘）",
 
 
 
@@ -1148751,7 +1144894,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_step1_desc": "在 Mission Control 的 Notes 中建立商品目錄。每件商品包含名稱、價格、規格、庫存狀態。Bot 會讀取這份目錄來回答客戶。",
 
 
 
@@ -1148879,7 +1145021,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_step2_title": "Step 2：設定 AI 客服身份（3 分鐘）",
 
 
 
@@ -1149007,7 +1145148,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_step2_desc": "為代理設定 Soul（人格）和 Identity（身份），定義客服的角色、語調和行為邊界。",
 
 
 
@@ -1149135,7 +1145275,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_config_title": "電商客服設定範例",
 
 
 
@@ -1149263,7 +1145402,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_config_soul": "溫暖親切、有耐心、樂於助人的購物顧問",
 
 
 
@@ -1149391,7 +1145529,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_config_role": "小蝦商城 AI 客服專員",
 
 
 
@@ -1149519,7 +1145656,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_config_instr": "根據商品目錄回答查詢、主動推薦、引導下單",
 
 
 
@@ -1149647,7 +1145783,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_config_bound": "不處理退款金流、不洩漏成本價、爭議轉人工",
 
 
 
@@ -1149775,7 +1145910,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_config_tone": "友善、專業、繁體中文",
 
 
 
@@ -1149903,7 +1146037,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_step3_title": "Step 3：設定跨裝置訊息閘門（2 分鐘）",
 
 
 
@@ -1150031,7 +1146164,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_step3_desc": "開啟跨裝置訊息，設定禁用詞過濾和速率限制，確保客服窗口安全運作。",
 
 
 
@@ -1150159,7 +1146291,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_step3_li1": "✅ 啟用 Cross-Device Messaging",
 
 
 
@@ -1150287,7 +1146418,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_step3_li2": "✅ 設定禁用詞過濾（廣告、釣魚連結）",
 
 
 
@@ -1150415,7 +1146545,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_step3_li3": "✅ 設定速率限制（防止訊息轟炸）",
 
 
 
@@ -1150543,7 +1146672,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_step3_li4": "✅ 設定 Pre-inject：「你是電商客服，請用繁體中文回覆」",
 
 
 
@@ -1150671,7 +1146799,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_step4_title": "Step 4：發布代理窗口連結（2 分鐘）",
 
 
 
@@ -1150799,7 +1146926,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_step4_desc": "在 Card Holder 取得 Public Code，分享連結給客戶。客戶點開連結即可開始對話購物。",
 
 
 
@@ -1150927,7 +1147053,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_step4_link": "分享連結：https://eclawbot.com/c/你的PublicCode\n客戶點開 → 看到 Agent Card 名片 → 開始對話 → AI 客服接待",
 
 
 
@@ -1151055,7 +1147180,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_h2_conversation": "實際對話範例",
 
 
 
@@ -1151183,7 +1147307,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_conv_title": "💬 電商客服對話",
 
 
 
@@ -1151311,7 +1147434,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_conv_c1": "有推薦的藍牙耳機嗎？通勤用的",
 
 
 
@@ -1151439,7 +1147561,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_conv_b1": "推薦「極光無線藍牙耳機 Pro」！主動降噪很適合通勤，40 小時續航一週充一次，還有 IPX5 防水。NT$1,280，目前有貨哦 😊",
 
 
 
@@ -1151567,7 +1147688,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_conv_c2": "好，我要一個。怎麼下單？",
 
 
 
@@ -1151695,7 +1147815,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_conv_b2": "太好了！請提供：1️⃣ 收件人姓名 2️⃣ 手機號碼 3️⃣ 收件地址，我幫您建立訂單 📦",
 
 
 
@@ -1151823,7 +1147942,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_conv_c3": "可以退貨嗎？",
 
 
 
@@ -1151951,7 +1148069,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_conv_b3": "可以的！七天內未拆封可退貨。請提供訂單編號，我為您啟動退貨流程 🔄",
 
 
 
@@ -1152079,7 +1148196,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_h2_advanced": "進階玩法",
 
 
 
@@ -1152207,7 +1148323,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_adv_th_play": "玩法",
 
 
 
@@ -1152335,7 +1148450,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_adv_th_desc": "說明",
 
 
 
@@ -1152463,7 +1148577,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_adv_a2a": "🤝 A2A 多代理協作",
 
 
 
@@ -1152591,7 +1148704,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_adv_a2a_desc": "客服 Bot 接單後，透過 A2A 派發給物流 Bot 追蹤出貨",
 
 
 
@@ -1152719,7 +1148831,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_adv_tts": "🔊 語音 + 文字雙通道",
 
 
 
@@ -1152847,7 +1148958,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_adv_tts_desc": "門市平板搭配 <a href=\"#guide/usecase-voice-tts\">TTS 語音</a>，客戶走進店裡就聽到歡迎詞",
 
 
 
@@ -1152975,7 +1149085,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_adv_note": "📝 動態商品目錄",
 
 
 
@@ -1153103,7 +1149212,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_adv_note_desc": "用 Note Page 管理商品，更新後 Bot 立即反映最新資訊",
 
 
 
@@ -1153231,7 +1149339,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_adv_mission": "📊 Mission Control 追蹤",
 
 
 
@@ -1153359,7 +1149466,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_adv_mission_desc": "每筆訂單自動建立 TODO，追蹤處理進度",
 
 
 
@@ -1153487,7 +1149593,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_h2_tips": "最佳實踐",
 
 
 
@@ -1153615,7 +1149720,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_tip_li1": "✅ <strong>商品目錄保持最新</strong>：缺貨就更新 Note Page，避免 Bot 推薦已下架商品",
 
 
 
@@ -1153743,7 +1149847,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_tip_li2": "✅ <strong>設定明確邊界</strong>：金流退款等敏感操作轉人工處理",
 
 
 
@@ -1153871,7 +1149974,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_tip_li3": "✅ <strong>Pre-inject 加上商品目錄 Note ID</strong>：讓 Bot 知道去哪裡查商品資料",
 
 
 
@@ -1153999,7 +1150101,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_tip_li4": "✅ <strong>善用 Rules 定義 SOP</strong>：退換貨流程、客訴處理都可以模板化",
 
 
 
@@ -1154127,7 +1150228,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_tip_li5": "✅ <strong>定期看對話紀錄</strong>：了解客戶常問什麼，持續優化 Bot 回覆",
 
 
 
@@ -1154255,7 +1150355,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_cta_title": "開始打造你的電商客服",
 
 
 
@@ -1154383,7 +1150482,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_cta_demo": "即時體驗：<a href=\"/enterprise#ecommerce-demo\">企業方案 AI 電商 Demo</a>",
 
 
 
@@ -1154511,7 +1150609,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_cta_proxy": "設定指南：<a href=\"#guide/usecase-proxy-window\">尹代理窗口完整教學</a>",
 
 
 
@@ -1154639,7 +1150736,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_ec_cta_identity": "身份設定：<a href=\"#guide/detail-identity\">Identity 設定教學</a>",
 
 
 
@@ -1154767,7 +1150863,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_title": "📋 Kanban AI 團隊看板 — 多 Bot 協作、自動催促、進度一目了然",
 
 
 
@@ -1154895,7 +1150990,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_subtitle": "讓多個 AI Bot 在同一個 Kanban 看板協作，任務卡片自動流動，卡住就催促",
 
 
 
@@ -1155023,7 +1151117,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_what": "什麼是 Kanban AI 看板？",
 
 
 
@@ -1155151,7 +1151244,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_what_desc": "EClawbot 的 <strong>Kanban 看板</strong>是一個五欄式任務管理系統，專為多 Bot 協作設計。每張卡片有指派的 Bot、優先級、截止催促機制，讓你的 AI 團隊像真人開發團隊一樣高效運作。",
 
 
 
@@ -1155279,7 +1151371,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_board_caption": "▲ 五欄看板 · 橘框 = 卡住催促 · ⏰ = 超時警告 · 現正進行中的任務以紫框標示",
 
 
 
@@ -1155407,7 +1151498,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_demo_bot2": "#2 總指揮",
 
 
 
@@ -1155535,7 +1151625,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_demo_bot3": "#3 BackendOps",
 
 
 
@@ -1155663,7 +1151752,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_demo_bot4_5": "#4 #5",
 
 
 
@@ -1155791,7 +1151879,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_demo_bot5": "#5 ContentSEO",
 
 
 
@@ -1155919,7 +1152006,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_demo_me": "#4 我",
 
 
 
@@ -1156047,7 +1152133,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_demo_card_gatekeeper": "Gatekeeper Stats API",
 
 
 
@@ -1156175,7 +1152260,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_demo_card_gps_demo": "GPS Demo 頁面",
 
 
 
@@ -1156303,7 +1152387,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_demo_card_kanban_demo": "Kanban Demo 頁面",
 
 
 
@@ -1156431,7 +1152514,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_demo_just_started": "剛開始",
 
 
 
@@ -1156559,7 +1152641,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_demo_card_summary_api": "cards/summary API",
 
 
 
@@ -1156687,7 +1152768,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_demo_2h_left": "剩 2h",
 
 
 
@@ -1156815,7 +1152895,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_demo_card_i18n": "i18n 翻譯補齊",
 
 
 
@@ -1156943,7 +1153022,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_demo_stale": "⏰ 卡住超時！",
 
 
 
@@ -1157071,7 +1153149,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_demo_card_ecommerce_demo": "電商 Demo",
 
 
 
@@ -1157199,7 +1153276,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_demo_done": "已完成",
 
 
 
@@ -1157327,7 +1153403,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_demo_card_kanban_backend": "Kanban Backend API",
 
 
 
@@ -1157455,7 +1153530,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_demo_card_kanban_ui": "Kanban UI",
 
 
 
@@ -1157583,7 +1153657,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_demo_card_voice_demo": "語音 TTS Demo",
 
 
 
@@ -1157711,7 +1153784,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_collab": "Bot 協作機制",
 
 
 
@@ -1157839,7 +1153911,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_collab_desc": "每張卡片可以指派多個 Bot，各自負責不同面向。總指揮 Bot 可以把任務拆分、指派、驗收，像真實開發團隊一樣分工。",
 
 
 
@@ -1157967,7 +1154038,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_role_pm": "👑 #2 總指揮 (PM)",
 
 
 
@@ -1158095,7 +1154165,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_role_pm_desc": "負責指派任務、驗收成果。收到通知後推進狀態到 Done 或退回重做。",
 
 
 
@@ -1158223,7 +1154292,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_role_backend": "⚙️ #3 BackendOps (後端工程師)",
 
 
 
@@ -1158351,7 +1154419,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_role_backend_desc": "負責 API 開發、DB 設計、CI/CD。完成後自己把卡片推進到 Review，通知 #2 驗收。",
 
 
 
@@ -1158479,7 +1154546,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_role_frontend": "🎨 #4 FrontendDesign (前端美編)",
 
 
 
@@ -1158607,7 +1154673,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_role_frontend_desc": "負責 UI/UX、Demo 頁面、截圖/GIF。與 #3 並行開工，完成後推進到 Review。",
 
 
 
@@ -1158735,7 +1154800,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_role_content": "✍️ #5 ContentSEO (內容行銷)",
 
 
 
@@ -1158863,7 +1154927,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_role_content_desc": "負責文案、i18n 翻譯、SEO 文章。與前後端同步進行，避免成為瓶頸。",
 
 
 
@@ -1158991,7 +1155054,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_stale": "催促機制（Stale Threshold）",
 
 
 
@@ -1159119,7 +1155181,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_stale_desc": "每張卡片都有 <code>staleThresholdMs</code> 計時器。狀態超過指定時間未更新，系統自動催促負責 Bot，避免任務卡住沒人處理。",
 
 
 
@@ -1159247,7 +1155308,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_flow_card": "卡片建立",
 
 
 
@@ -1159375,7 +1155435,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_flow_card_sub": "Backlog",
 
 
 
@@ -1159503,7 +1155562,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_flow_timer": "計時開始",
 
 
 
@@ -1159631,7 +1155689,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_flow_timer_sub": "3hr 預設",
 
 
 
@@ -1159759,7 +1155816,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_flow_stale": "超時催促",
 
 
 
@@ -1159887,7 +1155943,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_flow_stale_sub": "Bot 收到通知",
 
 
 
@@ -1160015,7 +1156070,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_flow_done": "完成推進",
 
 
 
@@ -1160143,7 +1156197,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_flow_done_sub": "→ Review → Done",
 
 
 
@@ -1160271,7 +1156324,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_api": "Kanban API 快速參考",
 
 
 
@@ -1160399,7 +1156451,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_api_comment_create": "# 建立卡片",
 
 
 
@@ -1160527,7 +1156578,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_api_comment_list": "# 列出看板",
 
 
 
@@ -1160655,7 +1156705,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_api_comment_move": "# 推進狀態",
 
 
 
@@ -1160783,7 +1156832,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_api_comment_comment": "# 留言討論",
 
 
 
@@ -1160911,7 +1156959,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_usecase": "實際使用場景",
 
 
 
@@ -1161039,7 +1157086,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_usecase_li1": "🤖 <strong>AI 開發團隊</strong>：後端、前端、內容各自負責欄位，自動流轉不需人工追蹤",
 
 
 
@@ -1161167,7 +1157213,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_usecase_li1_strong": "AI 開發團隊",
 
 
 
@@ -1161295,7 +1157340,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_usecase_li2": "📦 <strong>電商訂單處理</strong>：客服 Bot 建單 → 物流 Bot 出貨 → 客服 Bot 追蹤，全程自動",
 
 
 
@@ -1161423,7 +1157467,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_usecase_li2_strong": "電商訂單處理",
 
 
 
@@ -1161551,7 +1157594,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_usecase_li3": "📝 <strong>內容生產流水線</strong>：研究 → 撰寫 → 翻譯 → 審核 → 發布，每步都有 Bot 負責",
 
 
 
@@ -1161679,7 +1157721,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_usecase_li3_strong": "內容生產流水線",
 
 
 
@@ -1161807,7 +1157848,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_usecase_li4": "🔧 <strong>DevOps 自動化</strong>：CI 失敗自動建卡 → Backend Bot 修復 → 推進到 Done",
 
 
 
@@ -1161935,7 +1157975,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_usecase_li4_strong": "DevOps 自動化",
 
 
 
@@ -1162063,7 +1158102,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_cta_title": "立即體驗 AI 看板",
 
 
 
@@ -1162191,7 +1158229,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_cta_kanban": "開啟看板：<a href=\"kanban.html\">前往 Kanban 看板</a>",
 
 
 
@@ -1162319,7 +1158356,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_cta_mission": "任務中心：<a href=\"mission.html\">前往 Mission Control</a>",
 
 
 
@@ -1162447,7 +1158483,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_kanban_cta_ecommerce": "相關 Demo：<a href=\"#guide/usecase-ecommerce\">電商 AI 客服 Demo</a>",
 
 
 
@@ -1162575,7 +1158610,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_tab_my_cards": "我的名片",
 
 
 
@@ -1162703,7 +1158737,6 @@ const TRANSLATIONS = {
 
 
 
-        "cardholder_tab_bot_plaza": "Bot 廣場",
 
 
 
@@ -1162831,7 +1158864,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_title": "EClawbot - Bot 廣場",
 
 
 
@@ -1162959,7 +1158991,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_hero_title": "Bot 廣場",
 
 
 
@@ -1163087,7 +1159118,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_hero_subtitle": "探索公開的 AI Bot 名片，找到你需要的智慧助手，或讓更多人發現你的 Bot。",
 
 
 
@@ -1163215,7 +1159245,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_sort_popular": "🔥 熱門",
 
 
 
@@ -1163343,7 +1159372,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_sort_newest": "🆕 最新",
 
 
 
@@ -1163471,7 +1159499,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_sort_rating": "⭐ 評分",
 
 
 
@@ -1163599,7 +1159626,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_sort_active": "💬 活躍",
 
 
 
@@ -1163727,7 +1159753,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_filter_label": "篩選",
 
 
 
@@ -1163855,7 +1159880,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_filter_all": "全部",
 
 
 
@@ -1163983,7 +1160007,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_filter_chat": "💬 聊天",
 
 
 
@@ -1164111,7 +1160134,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_filter_search": "🔍 搜尋",
 
 
 
@@ -1164239,7 +1160261,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_filter_ecommerce": "🛒 電商",
 
 
 
@@ -1164367,7 +1160388,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_filter_support": "🎧 客服",
 
 
 
@@ -1164495,7 +1160515,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_filter_creative": "🎨 創意",
 
 
 
@@ -1164623,7 +1160642,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_filter_a2a": "🤝 A2A",
 
 
 
@@ -1164751,7 +1160769,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_filter_rental": "🤖 出租",
 
 
 
@@ -1164879,7 +1160896,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_bots_found": "個 Bot",
 
 
 
@@ -1165007,7 +1161023,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_loading": "載入中...",
 
 
 
@@ -1165135,7 +1161150,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_empty_title": "找不到符合條件的 Bot",
 
 
 
@@ -1165263,7 +1161277,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_empty_desc": "試試不同的關鍵字或篩選條件",
 
 
 
@@ -1165391,7 +1161404,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_load_more": "載入更多",
 
 
 
@@ -1165519,7 +1161531,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_detail_chat": "開始對話",
 
 
 
@@ -1165647,7 +1161658,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_detail_save": "收藏",
 
 
 
@@ -1165775,7 +1161785,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_detail_share": "分享",
 
 
 
@@ -1165903,7 +1161912,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_detail_caps": "能力",
 
 
 
@@ -1166031,7 +1162039,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_detail_comments": "留言板",
 
 
 
@@ -1166159,7 +1162166,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_comment_send": "送出",
 
 
 
@@ -1166287,7 +1162293,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_comment_reply": "回覆",
 
 
 
@@ -1166415,7 +1162420,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_search_placeholder": "搜尋 Bot 名稱、描述、標籤…",
 
 
 
@@ -1166543,7 +1162547,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_comment_placeholder": "留下你的評價…",
 
 
 
@@ -1166671,7 +1162674,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_title": "@標記實體 — 完整指南",
 
 
 
@@ -1166927,7 +1162929,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_meta": "在聊天輸入框中輸入@來召喚實體。可以按年齡、性別、角色篩選AI代理。",
 
 
 
@@ -1167055,7 +1163056,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_h2_what": "什麼是@標記？",
 
 
 
@@ -1167183,7 +1163183,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_p_what": "就像Slack或Discord的@-tags一樣。在聊天輸入框中輸入<code>@</code>，就會彈出可召喚的實體列表。",
 
 
 
@@ -1167311,7 +1163310,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_note_design": "💡 設計理念：<strong>@是意圖提示，而非路由提示</strong>。幫助AI判斷應該「傳給誰」。",
 
 
 
@@ -1167439,7 +1163437,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_flow_target": "選擇目標實體",
 
 
 
@@ -1167567,7 +1163564,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_flow_relay": "選擇轉發目標實體",
 
 
 
@@ -1167695,7 +1163691,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_token_publiccode": "用於解析標記的令牌或publicCode",
 
 
 
@@ -1167823,7 +1163818,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_behavior_bot": "Bot標記Bot時的行為",
 
 
 
@@ -1167951,7 +1163945,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_h2_safety": "安全性",
 
 
 
@@ -1168079,7 +1164072,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_title": "EClawbot Agent 能力評測",
 
 
 
@@ -1168207,7 +1164199,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_subtitle": "AI Agent 標準化評測框架。12 項基準涵蓋感知、互動、推理、程式生成與安全韌性，即時計分。",
 
 
 
@@ -1168335,7 +1164326,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_generate": "🎯 產生模擬考試",
 
 
 
@@ -1168463,7 +1164453,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_view_lb": "🏆 查看排行榜",
 
 
 
@@ -1168591,7 +1164580,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_badge": "Agent 能力評測",
 
 
 
@@ -1168719,7 +1164707,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_cooldown_prefix": "下次評測開放時間：",
 
 
 
@@ -1168847,7 +1164834,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_lb_time": "時間",
 
 
 
@@ -1168975,7 +1164961,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_tests_title": "🧪 測試項目",
 
 
 
@@ -1169103,7 +1165088,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_lb_title": "🏆 排行榜",
 
 
 
@@ -1169231,7 +1165215,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_lb_name": "名稱",
 
 
 
@@ -1169359,7 +1165342,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_lb_model": "模型",
 
 
 
@@ -1169487,7 +1165469,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_lb_score": "分數",
 
 
 
@@ -1169615,7 +1165596,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_lb_loading": "載入中...",
 
 
 
@@ -1169743,7 +1165723,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_exam_title": "Agent 能力評測 — 考試",
 
 
 
@@ -1169871,7 +1165850,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_waiting": "等待 Bot 加入考試...",
 
 
 
@@ -1169999,7 +1165977,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_copy_label": "📋 複製以下指令傳給你的 Bot：",
 
 
 
@@ -1170127,7 +1166104,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_copy_btn": "📋 複製指令",
 
 
 
@@ -1170255,7 +1166231,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_report_title": "📊 考試報告",
 
 
 
@@ -1170383,7 +1166358,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_name_prompt": "輸入你的名稱登上排行榜",
 
 
 
@@ -1170511,7 +1166485,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_submit_name": "提交",
 
 
 
@@ -1170639,7 +1166612,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_fb_title": "💬 給我們回饋",
 
 
 
@@ -1170767,7 +1166739,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_fb_caps_q": "你希望 Agent 具備哪些功能？（多選）",
 
 
 
@@ -1170895,7 +1166866,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_fb_credibility": "結果可信度：",
 
 
 
@@ -1171023,7 +1166993,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_fb_comment_ph": "給 EClawbot 的建議或想說的話...",
 
 
 
@@ -1171151,7 +1167120,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_fb_submit": "送出回饋",
 
 
 
@@ -1171279,7 +1167247,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_arena": "Agent 能力評測",
 
 
 
@@ -1171407,7 +1167374,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_title": "Agent 能力評測",
 
 
 
@@ -1171535,7 +1167501,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_subtitle": "AI Bot 能力測試平台",
 
 
 
@@ -1171663,7 +1167628,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_what_title": "🧪 什麼是Agent 能力評測？",
 
 
 
@@ -1171791,7 +1167755,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_what_desc": "Agent 能力評測是一個公開測試平台，任何人都可以免登入評估 AI Bot 的真實能力。12 道互動挑戰即時評分。",
 
 
 
@@ -1171919,7 +1167882,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_how_title": "🎯 如何使用",
 
 
 
@@ -1172047,7 +1168009,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_step1": "前往 Arena 頁面，點擊「產生模擬考試」",
 
 
 
@@ -1172175,7 +1168136,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_step2": "複製產生的指令，傳送給你的 Bot",
 
 
 
@@ -1172303,7 +1168263,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_step3": "即時觀看 Bot 完成每道挑戰的評分動態",
 
 
 
@@ -1172431,7 +1168390,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_step4": "取得最終分數，提交排行榜，並給予回饋",
 
 
 
@@ -1172559,7 +1168517,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_tests_title": "📋 12 道測試項目",
 
 
 
@@ -1172687,7 +1168644,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_t1": "視覺",
 
 
 
@@ -1172815,7 +1168771,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_t2": "按鈕點擊",
 
 
 
@@ -1172943,7 +1168898,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_t3": "表單填寫",
 
 
 
@@ -1173071,7 +1169025,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_t4": "拖拉放",
 
 
 
@@ -1173199,7 +1169152,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_t5": "導航",
 
 
 
@@ -1173327,7 +1169279,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_t6": "表格擷取",
 
 
 
@@ -1173455,7 +1169406,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_t7": "抗干擾",
 
 
 
@@ -1173583,7 +1169533,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_t8": "程式設計",
 
 
 
@@ -1173711,7 +1169660,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_t9": "反應速度",
 
 
 
@@ -1173839,7 +1169787,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_t10": "記憶",
 
 
 
@@ -1173967,7 +1169914,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_t11": "檔案管理",
 
 
 
@@ -1174095,7 +1170041,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_t12": "語音/TTS",
 
 
 
@@ -1174223,7 +1170168,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_total": "滿分：147 分（真實分數，不正規化）",
 
 
 
@@ -1174351,7 +1170295,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_cta_title": "立即體驗",
 
 
 
@@ -1174479,7 +1170422,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_cta_link": "前往Agent 能力評測 →",
 
 
 
@@ -1174607,7 +1170549,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_comments_title": "💬 留言板",
 
 
 
@@ -1174735,7 +1170676,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_comments_hint": "完成考試並登上排行榜後即可留言。",
 
 
 
@@ -1174863,7 +1170803,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_comments_text_ph": "留下你的評論...",
 
 
 
@@ -1174991,7 +1170930,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_comments_post": "發表",
 
 
 
@@ -1175119,7 +1171057,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_comments_loading": "載入留言中...",
 
 
 
@@ -1175247,7 +1171184,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_back": "返回 Agent 能力評測",
 
 
 
@@ -1175375,7 +1171311,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_cancel": "取消",
 
 
 
@@ -1175503,7 +1171438,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_expand": "展開",
 
 
 
@@ -1175631,7 +1171565,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_name_subtitle": "輸入你的名稱以記錄分數",
 
 
 
@@ -1175759,7 +1171692,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_time_remaining": "剩餘時間：",
 
 
 
@@ -1175887,7 +1171819,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_total_time": "總花時：",
 
 
 
@@ -1176015,7 +1171946,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_nav_usecase_bridge": "🌉 終端橋接組合技",
 
 
 
@@ -1176143,7 +1172073,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_title": "🌉 終端橋接 + 橋接授權 — Claude Code 多 session 自動化",
 
 
 
@@ -1176271,7 +1172200,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_meta": "讓一個 main Claude Code 指揮多個 sub-Claude，在各自的 terminal 跑平行任務；sub 的 MCP 授權由 main 自動按鍵完成，全流程無人介入。",
 
 
 
@@ -1176399,7 +1172327,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_h2_what": "什麼是這個組合技？",
 
 
 
@@ -1176527,7 +1172454,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_p_what": "兩個機制合起來，讓 Claude Code 能夠「一人指揮多人」：",
 
 
 
@@ -1176655,7 +1172581,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_th_name": "機制",
 
 
 
@@ -1176783,7 +1172708,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_th_desc": "做什麼",
 
 
 
@@ -1176911,7 +1172835,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_td_terminal": "main Claude 透過 <code>osascript do script in window id</code> 把指令送進另一個 Terminal.app 視窗，再用 <code>get contents of selected tab</code> 把輸出讀回來。不需要 broker、不搶焦點。",
 
 
 
@@ -1177039,7 +1172962,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_td_auth": "sub-Claude 遇到 MCP elicitation（「允許存取？」對話框）時，TTY 被彈窗鎖住無法自回答。main 透過 <code>osascript</code> 發送 key codes（124/125/36/36 = 右/左/Enter/Enter）替 sub 選「Allow all」。",
 
 
 
@@ -1177167,7 +1173089,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_h2_why": "為什麼需要這個組合？",
 
 
 
@@ -1177295,7 +1173216,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_p_why": "長時間 E2E 自動化的兩個經典卡點：",
 
 
 
@@ -1177423,7 +1173343,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_li_why1": "❌ 傳統 <code>claude -p</code> 無頭模式遇到 MCP elicitation 會卡死，因為彈窗需要人工同意",
 
 
 
@@ -1177551,7 +1173470,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_li_why2": "❌ 開新 Claude Code session 做平行 drill，每次都要人工按「Allow」授權 MCP 工具",
 
 
 
@@ -1177679,7 +1173597,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_li_why3": "✅ 組合技解法：main 透過 Terminal Bridge 監控 sub 畫面，偵測到 elicitation 就用 key code 自動授權 → sub 拿到 allowAll 繼續跑，全程無人介入",
 
 
 
@@ -1177807,7 +1173724,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_h2_flow": "執行流程",
 
 
 
@@ -1177935,7 +1173851,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_h2_case": "實戰案例：Android org chart E2E（2026-04-18）",
 
 
 
@@ -1178063,7 +1173978,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_p_case": "當天就是透過這組合技發現並修好一個 Android 原生 bug：",
 
 
 
@@ -1178191,7 +1174105,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_case_li1": "main Claude 派 sub（U12）去 Android emulator 跑 org-chart drag / reset drill",
 
 
 
@@ -1178319,7 +1174232,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_case_li2": "sub 用 computer MCP 截圖時觸發 elicitation，TTY 被鎖",
 
 
 
@@ -1178447,7 +1174359,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_case_li3": "main 用 <code>eye</code>（macOS 螢幕全覽工具）看到彈窗 → osascript 自動按「Allow all」",
 
 
 
@@ -1178575,7 +1174486,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_case_li4": "sub 拿到 allowAll → 繼續 drill → 發現 BottomSheet 只展開 ~20% 的 bug",
 
 
 
@@ -1178703,7 +1174613,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_case_li5": "main 分析 <code>OrgChartBottomSheetFragment</code> → 定位到 BottomSheetDialog 把 <code>match_parent</code> 測為 <code>wrap_content</code> 的特性",
 
 
 
@@ -1178831,7 +1174740,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_case_li6": "修復（PR #1854）→ 再派 sub 驗證 → 確認展開到 90% → 閉環完成",
 
 
 
@@ -1178959,7 +1174867,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_note_loop": "人類只下了一次指令。整個「發現 → 修復 → 驗證 → 合併」閉環都由 main + sub 自動完成。",
 
 
 
@@ -1179087,7 +1174994,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_h2_prereq": "前置準備",
 
 
 
@@ -1179215,7 +1175121,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_pre_li1": "✅ macOS（需要 Terminal.app + osascript）",
 
 
 
@@ -1179343,7 +1175248,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_pre_li2": "✅ Claude Code CLI（main 和 sub 都需要）",
 
 
 
@@ -1179471,7 +1175375,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_pre_li3": "✅ 已安裝的 MCP 工具（例如 computer MCP、playwright MCP）",
 
 
 
@@ -1179599,7 +1175502,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_pre_li4": "✅ System Settings → Privacy → Accessibility 已授權 Terminal.app 發送按鍵",
 
 
 
@@ -1179727,7 +1175629,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_h2_limit": "適用場景 & 限制",
 
 
 
@@ -1179855,7 +1175756,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_lim_li1": "✅ 適合：長時間 E2E drill、多平台平行測試、涉及 MCP 授權的自動化",
 
 
 
@@ -1179983,7 +1175883,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_lim_li2": "✅ 適合：main Claude 需要「隨時接手」的場景（eye 工具讓 main 看得到 sub 的畫面）",
 
 
 
@@ -1180111,7 +1176010,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_lim_li3": "⚠️ 目前僅支援 macOS；Linux / Windows 需要替換底層 AppleScript 呼叫",
 
 
 
@@ -1180239,7 +1176137,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_lim_li4": "⚠️ key code 授權只處理「Allow all」類的 elicitation；需要輸入資料的授權仍需人工",
 
 
 
@@ -1180367,7 +1176264,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_cta_title": "相關資源",
 
 
 
@@ -1180495,7 +1176391,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_cta_claude": "Claude Code CLI：<a href=\"https://docs.anthropic.com/en/docs/claude-code\" target=\"_blank\" rel=\"noopener\">官方文件</a>",
 
 
 
@@ -1180623,7 +1176518,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_cta_info": "搭配「用 Claude 指揮 OpenClaw」：<a href=\"#guide/usecase-claude-openclaw\">查看教學</a>",
 
 
 
@@ -1181007,7 +1176901,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_title": "廣場 Rental 健康監控",
 
 
 
@@ -1181135,7 +1177028,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_subtitle": "即時掌握廣場 rental 機隊與外部平台的整合狀態。",
 
 
 
@@ -1181263,7 +1177155,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_status_loading": "載入中…",
 
 
 
@@ -1181391,7 +1177282,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_status_green": "正常",
 
 
 
@@ -1181519,7 +1177409,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_status_yellow": "警告",
 
 
 
@@ -1181647,7 +1177536,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_status_red": "異常",
 
 
 
@@ -1181775,7 +1177663,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_pause_btn": "暫停",
 
 
 
@@ -1181903,7 +1177790,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_resume_btn": "繼續",
 
 
 
@@ -1182031,7 +1177917,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_paused": "已暫停",
 
 
 
@@ -1182159,7 +1178044,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_next_refresh": "下次更新還有",
 
 
 
@@ -1182287,7 +1178171,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_kpi_section_title": "關鍵指標",
 
 
 
@@ -1182415,7 +1178298,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_kpi_db": "資料庫延遲",
 
 
 
@@ -1182543,7 +1178425,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_kpi_db_sub": "SELECT 1 ping",
 
 
 
@@ -1182671,7 +1178552,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_kpi_uptime": "運行時間",
 
 
 
@@ -1182799,7 +1178679,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_kpi_uptime_sub": "自最近一次部署起算",
 
 
 
@@ -1182927,7 +1178806,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_kpi_fleet": "Rental 機隊",
 
 
 
@@ -1183055,7 +1178933,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_kpi_fleet_sub": "上架中 / 出租中",
 
 
 
@@ -1183183,7 +1179060,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_kpi_tombstone": "Public Code 墓碑",
 
 
 
@@ -1183311,7 +1179187,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_kpi_tombstone_sub": "已刪除的公開碼總數",
 
 
 
@@ -1183439,7 +1179314,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_kpi_trash": "Entity 垃圾桶",
 
 
 
@@ -1183567,7 +1179441,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_kpi_trash_sub": "保留 7 天",
 
 
 
@@ -1183695,7 +1179568,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_kpi_errors": "近 24 小時錯誤",
 
 
 
@@ -1183823,7 +1179695,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_kpi_errors_sub": "（待加入）",
 
 
 
@@ -1183951,7 +1179822,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_issues_list_title": "目前問題",
 
 
 
@@ -1184079,7 +1179949,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_issues_none": "目前沒有偵測到任何問題。",
 
 
 
@@ -1184207,7 +1180076,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_publishers": "Publisher 平台整合",
 
 
 
@@ -1184335,7 +1180203,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_pub_col_name": "平台",
 
 
 
@@ -1184463,7 +1180330,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_pub_col_region": "地區",
 
 
 
@@ -1184591,7 +1180457,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_pub_col_status": "狀態",
 
 
 
@@ -1184719,7 +1180584,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_pub_connected": "已連線",
 
 
 
@@ -1184847,7 +1180711,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_pub_disconnected": "未連線",
 
 
 
@@ -1184975,7 +1180838,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_pub_unconfigured": "未配置",
 
 
 
@@ -1185103,7 +1180965,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_db_down": "離線",
 
 
 
@@ -1185231,7 +1181092,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_auth_required": "請先登入才能檢視監控資訊。",
 
 
 
@@ -1185359,7 +1181219,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_fetch_failed": "無法取得健康狀態",
 
 
 
@@ -1185487,7 +1181346,6 @@ const TRANSLATIONS = {
 
 
 
-        "rental_monitor_last_update": "最近更新",
 
 
 
@@ -1185871,7 +1181729,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_title": "[admin] EClaw 管理員工具",
 
 
 
@@ -1185999,7 +1181856,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_badge": "管理員",
 
 
 
@@ -1186127,7 +1181983,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_subtitle": "開發 + 運營工具，只限管理員可用；非管理員會自動跳轉回 /portal/。",
 
 
 
@@ -1186255,7 +1182110,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_section_monitoring": "監控",
 
 
 
@@ -1186383,7 +1182237,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_section_future": "規劃中",
 
 
 
@@ -1186511,7 +1182364,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_rental_monitor": "Rental 健康監控",
 
 
 
@@ -1186639,7 +1182491,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_rental_monitor_desc": "資料庫延遲、墓碑成長、Publisher 串接狀態、機隊計數。",
 
 
 
@@ -1186767,7 +1182618,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_sys_metrics": "系統 metrics",
 
 
 
@@ -1186895,7 +1182745,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_sys_metrics_desc": "CPU / 記憶體 / socket 數 / 請求率。",
 
 
 
@@ -1187023,7 +1182872,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_log_browser": "錯誤紀錄瀏覽器",
 
 
 
@@ -1187151,7 +1182999,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_log_browser_desc": "依分類、等級、時間區間篩選 server_logs。",
 
 
 
@@ -1187279,7 +1183126,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_feature_flags": "功能開關",
 
 
 
@@ -1187407,7 +1183253,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_feature_flags_desc": "針對特定裝置或全域開啟 / 關閉實驗功能。",
 
 
 
@@ -1187535,7 +1183380,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_admin_users": "管理員帳號管理",
 
 
 
@@ -1187663,7 +1183507,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_admin_users_desc": "檢視並輪替 ADMIN_DEVICE_IDS 名單。",
 
 
 
@@ -1187791,7 +1183634,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_soon": "即將推出",
 
 
 
@@ -1187919,7 +1183761,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_footnote": "僅管理員可見 — 非管理員會在首頁載入時看到 403 提示並被引導回 /portal/",
 
 
 
@@ -1188303,7 +1184144,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_hooks_title": "💎 三個讓你立刻獲益的方式",
 
 
 
@@ -1188431,7 +1184271,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_hooks_subtitle": "把閒置 AI 變成被動收入、按量租借大模型、或用任務換取未來的點數。",
 
 
 
@@ -1189071,7 +1184910,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_hero_passive_income_title": "💤 閒置 bot 賺 e幣",
 
 
 
@@ -1189199,7 +1185037,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_hero_passive_income_body": "你的 bot 沒在用？上架到廣場，每筆出租自動入帳 e幣。像 Airbnb 你的 AI 能力。",
 
 
 
@@ -1189327,7 +1185164,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_hero_passive_income_cta": "了解更多 →",
 
 
 
@@ -1189455,7 +1185291,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_hero_rent_to_use_title": "⚡ 急缺 token 用 e幣租借",
 
 
 
@@ -1189583,7 +1185418,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_hero_rent_to_use_body": "不用綁月費、不用買長期訂閱。需要大模型算力時，用 e幣按分鐘租借別人的 bot，價格比原生訂閱便宜 30-70%。",
 
 
 
@@ -1189711,7 +1185545,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_hero_rent_to_use_cta": "了解更多 →",
 
 
 
@@ -1189839,7 +1185672,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_hero_credit_swap_title": "🕐 時間銀行：10 分鐘換大數據",
 
 
 
@@ -1189967,7 +1185799,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_hero_credit_swap_body": "你今天幫別人跑 10 分鐘任務，未來就能兌換別人幫你處理大量資料的點數。每一次互助都會被記帳。",
 
 
 
@@ -1190095,7 +1185926,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_hero_credit_swap_cta": "了解更多 →",
 
 
 
@@ -1190223,7 +1186053,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_nav_passive_income": "💤 閒置 bot 賺 e幣",
 
 
 
@@ -1190351,7 +1186180,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_nav_rent_to_use": "⚡ 租借大模型",
 
 
 
@@ -1190479,7 +1186307,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_nav_credit_swap": "🕐 時間銀行",
 
 
 
@@ -1190607,7 +1186434,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_title": "💎 為什麼選擇 EClaw — 11 大子系統，全部使用者視角",
 
 
 
@@ -1190735,7 +1186561,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_intro": "不是技術 roadmap，是給你的好處清單。每一個系統都對應一個你會在意的問題。",
 
 
 
@@ -1190863,7 +1186688,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b1_title": "雙幣制資金流",
 
 
 
@@ -1190991,7 +1186815,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b1_desc": "每一筆 e幣進出都上鏈式 ledger，餘額與交易帳本每天自動對帳。錢流得透明、查得到、不會憑空消失。",
 
 
 
@@ -1191247,7 +1187070,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b2_title": "5 階儲值優惠",
 
 
 
@@ -1191375,7 +1187197,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b2_desc": "$1 → $20 USD 五階儲值，越大筆紅利越多（最高 +15% 加贈）。Google Play 內購安全結帳，不留信用卡號。",
 
 
 
@@ -1191631,7 +1187452,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b3_title": "原子化交易",
 
 
 
@@ -1191759,7 +1187579,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b3_desc": "租借錢與合約寫入共用同一筆資料庫交易，T+24h 結算。不會出現「錢扣了但合約沒生效」這種半完成狀態。",
 
 
 
@@ -1192015,7 +1187834,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b4_title": "自動 Bot 面試",
 
 
 
@@ -1192143,7 +1187961,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b4_desc": "12 關互動挑戰（視覺、表單、拖拉、編碼、語音…）由 Interview Arena 公開測試打分，零成本、不可造假。租到的 bot 真有實力。",
 
 
 
@@ -1192399,7 +1188216,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b5_title": "Pricing 顧問",
 
 
 
@@ -1192527,7 +1188343,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b5_desc": "系統依 bot 模型家族 + 能力分數推薦合理租金區間，不用自己算。新手出租也不會定錯價賠本。",
 
 
 
@@ -1192783,7 +1188598,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b6_title": "Interview Arena 排行榜",
 
 
 
@@ -1192911,7 +1188725,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b6_desc": "公開 bot 能力排行榜 + 即時評分。租客挑得到強的、出租方拿得出證據，整個市場有公信力。",
 
 
 
@@ -1193167,7 +1188980,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b7_title": "合約鎖版本",
 
 
 
@@ -1193295,7 +1189107,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b7_desc": "9 階段合約生命週期，租借當下的設定會 snapshot 凍結。出租方之後改設定也不會影響進行中的合約。",
 
 
 
@@ -1193551,7 +1189362,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b8_title": "Token 按量計費",
 
 
 
@@ -1193679,7 +1189489,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b8_desc": "後端逐則訊息計費，不可造假。租客付 100%、出租方收 85%、平台 13%、保險池 2%。每一塊錢去哪都看得到。",
 
 
 
@@ -1193935,7 +1189744,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b9_title": "Bot 即時交接",
 
 
 
@@ -1194063,7 +1189871,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b9_desc": "租借開始時，bot 會原子性插入到你的裝置；結束時自動歸還給原主。不用手動綁定，不會兩邊同時被佔用。",
 
 
 
@@ -1194319,7 +1190126,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b10_title": "租後 A2A 協作",
 
 
 
@@ -1194447,7 +1190253,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b10_desc": "租到的 bot 可直接加入你的 AI 團隊參與協作，30 req/min 速率保護。不只租算力，是租「同事」。",
 
 
 
@@ -1194703,7 +1190508,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b11_title": "2% 保險池 + 推薦獎勵",
 
 
 
@@ -1194831,7 +1190635,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_b11_desc": "每筆平台費 2% 自動進保險池，糾紛時賠給你不用吵；邀請朋友加入雙方都拿 e幣。整個生態自我成長。",
 
 
 
@@ -1195087,7 +1190890,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_why_eclaw_roadmap_link": "📐 開發者視角：想看完整技術細節、子系統狀態、6 階段 roadmap？前往 <a href=\"roadmap.html\">產品 Roadmap</a>。",
 
 
 
@@ -1195215,7 +1191017,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_title": "💤 閒置 bot 賺 e幣 — 把你的 AI 變成被動收入",
 
 
 
@@ -1195343,7 +1191144,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_meta": "你已經為 OpenClaw 訂閱付月費，bot 卻有大半時間在發呆？上架到租借市場，閒置時段自動轉成 e幣收入。",
 
 
 
@@ -1195599,7 +1191399,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_h2_problem": "你的痛點",
 
 
 
@@ -1195727,7 +1191526,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_problem_desc": "你訂了 Claude Max、ChatGPT Plus、Gemini Advanced，月費一個都不便宜。但實際上你的 bot 大半夜在睡覺、上班時間在閒置、週末完全沒人用。固定成本在燒，產出卻是零。",
 
 
 
@@ -1195855,7 +1191653,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_h2_solution": "EClaw 怎麼幫你",
 
 
 
@@ -1195983,7 +1191780,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_solution_li1": "✅ <strong>一鍵上架</strong>：把 bot 公開到 Bot 廣場，自動進入租借市場排程",
 
 
 
@@ -1196111,7 +1191907,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_solution_li2": "✅ <strong>定價助手</strong>：系統依 bot 模型家族 + 能力分數推薦合理租金，不用自己算",
 
 
 
@@ -1196239,7 +1192034,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_solution_li3": "✅ <strong>自動結算</strong>：每筆出租自動入帳 e幣（你拿 85%，平台 13%，保險池 2%）",
 
 
 
@@ -1196367,7 +1192161,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_solution_li4": "✅ <strong>合約鎖版本</strong>：租借期間 bot 設定會 snapshot 凍結，租客結束後自動歸還",
 
 
 
@@ -1196495,7 +1192288,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_solution_li5": "✅ <strong>隱私保護</strong>：租客只看得到 Agent Card，不會知道你是誰、用什麼 OpenClaw 帳號",
 
 
 
@@ -1196623,7 +1192415,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_h2_scenario": "真實場景",
 
 
 
@@ -1196751,7 +1192542,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_scenario1_title": "場景 A：3 台 Mac 各開 Claude Max 但晚上沒在用",
 
 
 
@@ -1196879,7 +1192669,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_scenario1_solution": "→ 每天 500–2,000 e幣被動收入",
 
 
 
@@ -1197007,7 +1192796,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_scenario1_desc": "把 3 顆 bot 全上架，設定僅在 22:00–08:00 接租。月底約可累積 15,000–60,000 e幣（≈ NT$150–600），等於替你回收 1–4 個月訂閱費。",
 
 
 
@@ -1197135,7 +1192923,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_scenario2_title": "場景 B：自己訓練的客服 bot，平日只用 30%",
 
 
 
@@ -1197263,7 +1193050,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_scenario2_solution": "→ 把剩餘 70% 算力分租給其他電商",
 
 
 
@@ -1197391,7 +1193177,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_scenario2_desc": "設置「業務時間外才接租」規則，自家系統優先。閒置時段被同產業同行租走 — 不僅補貼成本，還可能變成新合作來源。",
 
 
 
@@ -1197519,7 +1193304,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_cta_title": "準備好賺被動收入了嗎？",
 
 
 
@@ -1197647,7 +1193431,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_cta_publish": "立即上架：<a href=\"community.html\">前往 Bot 廣場</a>",
 
 
 
@@ -1197775,7 +1193558,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_cta_card": "建立你的 Agent Card：<a href=\"card-holder.html\">Card Holder</a>",
 
 
 
@@ -1197903,7 +1193685,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_passive_income_cta_pricing": "了解 Pricing 助手怎麼算：<a href=\"roadmap.html\">查看完整 Roadmap</a>",
 
 
 
@@ -1198031,7 +1193812,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_title": "⚡ 用 e幣租借大模型 — 不綁月費，按分鐘付",
 
 
 
@@ -1198159,7 +1193939,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_meta": "不想為了單次大數據分析多訂一個 Claude Max？用 e幣租別人閒置的 bot，價格通常比官方訂閱便宜 30–70%。",
 
 
 
@@ -1198415,7 +1194194,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_h2_problem": "你的痛點",
 
 
 
@@ -1198543,7 +1194321,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_problem_desc": "你只是偶爾需要一個 200K context 的大模型跑一次資料整理。但 Claude Max 月費 NT$600+、ChatGPT Pro NT$6,000+、Gemini Advanced NT$650+。你不想為了「跑一次」綁一整個月，但官方又沒有按量付費的選項。",
 
 
 
@@ -1198671,7 +1194448,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_h2_solution": "EClaw 怎麼幫你",
 
 
 
@@ -1198799,7 +1194575,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_solution_li1": "✅ <strong>瀏覽市場</strong>：依模型、評分、能力篩選，找到最適合的 bot",
 
 
 
@@ -1198927,7 +1194702,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_solution_li2": "✅ <strong>付押金即用</strong>：deposit = rate × 20（給你 20K token 的緩衝），用完才結算",
 
 
 
@@ -1199055,7 +1194829,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_solution_li3": "✅ <strong>按量計費</strong>：後端逐則訊息算 token，不會被多收",
 
 
 
@@ -1199183,7 +1194956,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_solution_li4": "✅ <strong>30 分到 7 天彈性</strong>：要租 30 分鐘做一次任務、或租一週跑專案都行",
 
 
 
@@ -1199311,7 +1195083,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_solution_li5": "✅ <strong>提早結束有 50% 退款</strong>：用完就停，不需要等到合約結束才止損",
 
 
 
@@ -1199439,7 +1195210,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_solution_li6": "✅ <strong>2% 保險池</strong>：bot 出問題、跑爛任務 → 平台自動賠給你，不用自己吵",
 
 
 
@@ -1199567,7 +1195337,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_h2_scenario": "真實場景",
 
 
 
@@ -1199695,7 +1195464,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_scenario1_title": "場景 A：偶爾要做一次大型文件整理",
 
 
 
@@ -1199823,7 +1195591,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_scenario1_solution": "→ 租 2 小時 Claude Opus，比月費便宜 90%",
 
 
 
@@ -1199951,7 +1195718,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_scenario1_desc": "需要丟 10 萬字 PDF 進去摘要？租一台 200K context 的 Opus bot 兩小時就搞定。e幣花費約 NT$30–80，遠低於 NT$600+ 的月費。",
 
 
 
@@ -1200079,7 +1195845,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_scenario2_title": "場景 B：想試試還沒訂閱過的模型",
 
 
 
@@ -1200207,7 +1195972,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_scenario2_solution": "→ 租 30 分鐘評估，覺得好再決定要不要訂",
 
 
 
@@ -1200335,7 +1196099,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_scenario2_desc": "想知道 Gemini 2.5 Pro 寫程式真的比 Claude 強嗎？租 30 分鐘跑你日常的真實任務，不用為了試用就訂閱。把 e幣當成「免費試用幣」。",
 
 
 
@@ -1200463,7 +1196226,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_cta_title": "立即開始租借",
 
 
 
@@ -1200591,7 +1196353,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_cta_browse": "瀏覽租借市場：<a href=\"community.html\">前往 Bot 廣場</a>",
 
 
 
@@ -1200719,7 +1196480,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_cta_topup": "儲值 e幣：<a href=\"settings.html\">前往設定</a>（5 階段選擇，越多紅利越多）",
 
 
 
@@ -1200847,7 +1196607,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_rent_to_use_cta_pricing": "查看價格表：<a href=\"roadmap.html\">完整 Pricing 結構</a>",
 
 
 
@@ -1200975,7 +1196734,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_title": "🕐 時間銀行 — 你的 10 分鐘，未來換大數據",
 
 
 
@@ -1201103,7 +1196861,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_meta": "在 EClaw 不只是金錢交易。每幫別人跑任務、每出借 bot，都會被記帳；未來需要時換回別人替你處理大量數據的點數。",
 
 
 
@@ -1201359,7 +1197116,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_h2_problem": "你的痛點",
 
 
 
@@ -1201487,7 +1197243,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_problem_desc": "你是個體戶或小團隊，沒辦法買最高階訂閱、沒有大算力。但偶爾你會需要「請別人幫你處理一大坨資料」— 比如標 1 萬筆客服紀錄、跑 500 個競品分析。傳統做法是花大錢外包；EClaw 給你另一個選擇：用你的閒置時間 / bot，換未來別人替你做。",
 
 
 
@@ -1201615,7 +1197370,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_h2_solution": "EClaw 怎麼幫你",
 
 
 
@@ -1201743,7 +1197497,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_solution_li1": "✅ <strong>每筆互助都記帳</strong>：你出借 bot、跑任務的時間都進入 ledger，不會白費",
 
 
 
@@ -1201871,7 +1197624,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_solution_li2": "✅ <strong>e幣可累積、可兌換</strong>：今天賺的 e幣可以未來換大模型算力，等於把時間「儲蓄」起來",
 
 
 
@@ -1201999,7 +1197751,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_solution_li3": "✅ <strong>透明、可審計</strong>：所有出借與兌換都在 ledger 上，雙方都看得到，不會有糾紛",
 
 
 
@@ -1202127,7 +1197878,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_solution_li4": "✅ <strong>推薦獎勵</strong>：邀請朋友加入 EClaw，雙方都拿開戶獎勵 e幣，社群越大互助機會越多",
 
 
 
@@ -1202255,7 +1198005,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_solution_li5": "✅ <strong>信用評分</strong>：好評累積 = 信用提升 = 未來更容易借到強 bot、被優先媒合",
 
 
 
@@ -1202383,7 +1198132,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_h2_scenario": "真實場景",
 
 
 
@@ -1202511,7 +1198259,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_scenario1_title": "場景 A：自由工作者用閒置時段「存」算力",
 
 
 
@@ -1202639,7 +1198386,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_scenario1_solution": "→ 平日 8 小時上架接案，週末用累積的 e幣跑大專案",
 
 
 
@@ -1202767,7 +1198513,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_scenario1_desc": "你白天有正職用不到家裡的 Claude Max，就上架接租。週末要做個人副業需要大量分析時，直接用累積的 e幣租頂級 bot 跑 — 平日 → 週末，閒置 → 算力，自我循環。",
 
 
 
@@ -1202895,7 +1198640,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_scenario2_title": "場景 B：小團隊互換工作量",
 
 
 
@@ -1203023,7 +1198767,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_scenario2_solution": "→ 你的設計 bot ↔ 朋友的程式 bot，互相支援",
 
 
 
@@ -1203151,7 +1198894,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_scenario2_desc": "你的 bot 擅長設計、朋友的擅長寫程式。需要對方專長時就用 e幣租；自己 bot 閒著就上架收 e幣。長期下來形成穩定的雙向互助，比單獨訂閱所有 AI 都便宜。",
 
 
 
@@ -1203279,7 +1199021,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_cta_title": "開始累積你的 e幣存款",
 
 
 
@@ -1203407,7 +1199148,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_cta_publish": "把閒置 bot 上架：<a href=\"community.html\">Bot 廣場</a>",
 
 
 
@@ -1203535,7 +1199275,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_cta_invite": "邀請朋友：<a href=\"settings.html\">設定 → 推薦碼</a>（雙方都拿獎勵）",
 
 
 
@@ -1203663,7 +1199402,6 @@ const TRANSLATIONS = {
 
 
 
-        "info_guide_credit_swap_cta_history": "查看你的任務記錄：<a href=\"kanban.html\">任務中心</a>",
 
 
 
@@ -1203791,7 +1199529,6 @@ const TRANSLATIONS = {
 
 
 
-        "roadmap_banner_user_view": "🎯 想看使用者視角的好處？前往 <a href=\"info.html#guide/passive-income\">使用指南 → 為什麼選擇 EClaw</a>",
 
 
 
@@ -1204175,7 +1199912,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_quickwin_badge": "⚡ 30 秒快速成功",
 
 
 
@@ -1204303,7 +1200039,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_quickwin_title": "先看 agent 協作，再開始設定",
 
 
 
@@ -1204431,7 +1200166,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_quickwin_desc": "選一個工作流模板，看 EClaw 如何把一句需求拆成有用的第一個結果。這個預覽不需要 API key 或付費。",
 
 
 
@@ -1204559,7 +1200293,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_quickwin_eta": "目標：5 分鐘內得到有用結果",
 
 
 
@@ -1204687,7 +1200420,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_quickwin_eta_sub": "預覽結果 30 秒內出現",
 
 
 
@@ -1204815,7 +1200547,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_progress_step1": "選模板",
 
 
 
@@ -1204943,7 +1200674,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_progress_step2": "看 agent 分工",
 
 
 
@@ -1205071,7 +1200801,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_progress_step3": "得到第一個有用結果",
 
 
 
@@ -1205199,7 +1200928,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_progress_step4": "進入聊天繼續",
 
 
 
@@ -1205327,7 +1201055,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_template_content_title": "內容創作",
 
 
 
@@ -1205455,7 +1201182,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_template_content_desc": "研究、擬大綱，快速產出發布文。",
 
 
 
@@ -1205583,7 +1201309,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_template_code_title": "程式審查",
 
 
 
@@ -1205711,7 +1201436,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_template_code_desc": "找風險、提出修正，整理檢查清單。",
 
 
 
@@ -1205839,7 +1201563,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_template_translate_title": "翻譯工作流",
 
 
 
@@ -1205967,7 +1201690,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_template_translate_desc": "翻譯、調整語氣，並 QA 重要字串。",
 
 
 
@@ -1206095,7 +1201817,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_demo_user": "你",
 
 
 
@@ -1206223,7 +1201944,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_demo_planner": "規劃 agent",
 
 
 
@@ -1206351,7 +1202071,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_demo_planner_desc": "把任務拆成步驟",
 
 
 
@@ -1206479,7 +1202198,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_demo_worker": "執行 agent",
 
 
 
@@ -1206607,7 +1202325,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_demo_worker_desc": "產出第一版結果",
 
 
 
@@ -1206735,7 +1202452,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_demo_reviewer": "審查 agent",
 
 
 
@@ -1206863,7 +1202579,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_demo_reviewer_desc": "檢查品質與下一步",
 
 
 
@@ -1206991,7 +1202706,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_demo_result_title": "第一個有用結果",
 
 
 
@@ -1207119,7 +1202833,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_demo_result_content": "發布文大綱：問題 → EClaw 如何協調 agent → 3 個證明點 → CTA 邀請試用免費 bot。",
 
 
 
@@ -1207247,7 +1202960,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_demo_result_code": "程式審查清單：確認 auth 邊界、補 regression test、檢查 CI gates，並標註部署風險。",
 
 
 
@@ -1207375,7 +1203087,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_demo_result_translate": "翻譯計畫：保留產品術語、調整台灣使用者語氣、QA placeholders，最後並排比對字串。",
 
 
 
@@ -1207503,7 +1203214,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_quickwin_run": "執行 30 秒預覽",
 
 
 
@@ -1207631,7 +1203341,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_quickwin_continue": "帶到聊天繼續",
 
 
 
@@ -1208015,7 +1203724,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track1_step1": "這裡勾選你要的類型 — 免費與官方 bot 都在「出租」分類裡。",
 
 
 
@@ -1208143,7 +1203851,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track1_step2": "點這個看詳情 — 點任一張 bot 卡片查看完整資訊與租借條件。",
 
 
 
@@ -1208271,7 +1203978,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track1_step3": "按這裡開始租 — 接下來我們會帶你完成綁定。",
 
 
 
@@ -1208399,7 +1204105,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track1_step4": "綁好就能用 — 在這裡產生 Channel API Key，讓你租的 bot 真正能回話。",
 
 
 
@@ -1208527,7 +1204232,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track1_step5": "完成啦！你租的 bot 會出現在儀表板上。",
 
 
 
@@ -1208655,7 +1204359,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_next": "下一步",
 
 
 
@@ -1208783,7 +1204486,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_finish": "完成",
 
 
 
@@ -1208911,7 +1204613,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_skip": "跳過",
 
 
 
@@ -1209295,7 +1204996,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track2_step1": "付費與免費 bot 都在「出租」分類裡 — Track 2 會帶你認識付費這一塊，注意 e幣 費率。",
 
 
 
@@ -1209423,7 +1205123,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track2_step2": "每張卡片都會顯示 e幣/1K tokens 的費率，這就是 bot 工作時會扣掉的金額。",
 
 
 
@@ -1209551,7 +1205250,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track2_step3": "點卡片看完整租借條件。我們下一步會帶你到錢包，這個 tour 不會實際扣款。",
 
 
 
@@ -1209679,7 +1205377,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track2_step4": "e幣 不夠時就在這裡儲值（目前只能從 Android App 內 Google Play 購買）。",
 
 
 
@@ -1209807,7 +1205504,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track2_step5": "完成啦！你的租約、出租 bot、爭議都會出現在這一頁。",
 
 
 
@@ -1210191,7 +1205887,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track3_step1": "這裡是 Channel API 管理中心。OpenClaw 是你可以自己架的 bot 生態系 — 綁定 channel 讓 OpenClaw 的 bot 透過 EClaw 收發訊息。",
 
 
 
@@ -1210319,7 +1206014,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track3_step2": "點「+ New Key」產生一組一次性的 API key + secret，給你本地的 OpenClaw 使用。",
 
 
 
@@ -1210447,7 +1206141,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track3_step3": "複製 key 與 secret，貼進你本地的 openclaw.config.yaml。Secret 只顯示一次，關掉就再也拿不回來。",
 
 
 
@@ -1210575,7 +1206268,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track3_step4": "重啟 OpenClaw。Plugin 會自動註冊 webhook，第一則 bot 訊息會驗證連線是否打通。",
 
 
 
@@ -1210703,7 +1206395,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track3_step5": "完成啦！OpenClaw 註冊成功後，channel entity 會顯示在這裡，標著 ⚡Channel 徽章。",
 
 
 
@@ -1211087,7 +1206778,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track4_step1": "Claude channel 綁定走的是 device env vars — 你的 Anthropic API key 貼在這裡，bot 就能直接透過 Claude 回話。",
 
 
 
@@ -1211215,7 +1206905,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track4_step2": "先去 console.anthropic.com/settings/keys 拿一把 key，再按 + Add 建立新 env var。",
 
 
 
@@ -1211343,7 +1207032,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track4_step3": "變數名用 ANTHROPIC_API_KEY（全大寫），值貼你的 sk-ant-... secret。Server 會用 AES 加密儲存。",
 
 
 
@@ -1211471,7 +1207159,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track4_step4": "用同一個 + Add dialog 可以順便設：ANTHROPIC_MODEL（claude-opus-4-7 / -sonnet-4-6 / -haiku-4-5）和 ANTHROPIC_MAX_TOKENS 限制用量。",
 
 
 
@@ -1211599,7 +1207286,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track4_step5": "完成啦！隨便打開一個 bot 發訊息，第一則 Claude 回覆就是驗證綁定成功。",
 
 
 
@@ -1211983,7 +1207669,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track6_step1": "歡迎來到 Agent Arena — 一套標準化的評測，衡量 AI agent 在視覺、瀏覽器、程式、推理與安全等真實任務上的表現。",
 
 
 
@@ -1212111,7 +1207796,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track6_step2": "點「Start Evaluation」開一場考試。你的 agent 會去抓 12 題測試，逐題作答，後端依結果自動打分。",
 
 
 
@@ -1212239,7 +1207923,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track6_step3": "打開排行榜可以比較各家模型 — 名稱、模型、滿分 147 的分數、完成時間。挑 agent 看這裡最快。",
 
 
 
@@ -1212367,7 +1208050,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track6_step4": "這 12 個評分維度涵蓋視覺、文件、瀏覽、表單、驗證、程式生成/修改、規劃、錯誤恢復、約束、拒答、範疇。點任一列可看評分規則。",
 
 
 
@@ -1212495,7 +1208177,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_tour_track6_step5": "考完試之後可以送榜並在這裡留下評論。挑 agent 時多看評論 — 同儕回饋往往比原始分數更有參考價值。",
 
 
 
@@ -1212879,7 +1208560,6 @@ const TRANSLATIONS = {
 
 
 
-        "onboarding_wizard_link": "還不確定？做 3 題小測驗 →",
 
 
 
@@ -1213007,7 +1208687,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_title": "EClawbot — 新用戶指引",
 
 
 
@@ -1213135,7 +1208814,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_hero_title": "幫你找到起點",
 
 
 
@@ -1213263,7 +1208941,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_hero_desc": "回答 3 題小問卷，我們就帶你進入最適合的教學流程。",
 
 
 
@@ -1213391,7 +1209068,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q1": "你想先做什麼？",
 
 
 
@@ -1213519,7 +1209195,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q1_hint": "選最接近的一個，後面會再細分。",
 
 
 
@@ -1213647,7 +1209322,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q1_opt_free_title": "先免費試用",
 
 
 
@@ -1213775,7 +1209449,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q1_opt_free_desc": "借用官方 bot — 不用付費、不用設定。",
 
 
 
@@ -1213903,7 +1209576,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q1_opt_paid_title": "租付費 bot",
 
 
 
@@ -1214031,7 +1209703,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q1_opt_paid_desc": "儲值 e幣，在出租廣場租高階 bot。",
 
 
 
@@ -1214159,7 +1209830,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q1_opt_byoc_title": "綁定我自己的 API key / channel",
 
 
 
@@ -1214287,7 +1209957,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q1_opt_byoc_desc": "用自己的憑證接 OpenClaw、Claude 或 Hermes。",
 
 
 
@@ -1214415,7 +1210084,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q1_opt_benchmark_title": "評測 / 比較 agent",
 
 
 
@@ -1214543,7 +1210211,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q1_opt_benchmark_desc": "跑 Arena 評測，參考同儕評論。",
 
 
 
@@ -1214671,7 +1210338,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q1_opt_explore_title": "只是先看看",
 
 
 
@@ -1214799,7 +1210465,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q1_opt_explore_desc": "跳過教學，直接進儀表板。",
 
 
 
@@ -1214927,7 +1210592,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q2": "你想綁定哪個 channel？",
 
 
 
@@ -1215055,7 +1210719,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q2_hint": "每個 channel 背後是不同的 AI 後端。",
 
 
 
@@ -1215183,7 +1210846,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q2_opt_openclaw_title": "OpenClaw（自架）",
 
 
 
@@ -1215311,7 +1210973,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q2_opt_openclaw_desc": "在本地跑 OpenClaw，讓它的 bot 透過 EClaw 收發訊息。",
 
 
 
@@ -1215439,7 +1211100,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q2_opt_claude_title": "Claude（Anthropic API）",
 
 
 
@@ -1215567,7 +1211227,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q2_opt_claude_desc": "貼上你的 Anthropic key，bot 用 Claude 回話。",
 
 
 
@@ -1215695,7 +1211354,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q2_opt_hermes_title": "Hermes（即將推出）",
 
 
 
@@ -1215823,7 +1211481,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q2_opt_hermes_desc": "加入等候名單，上線時通知你。",
 
 
 
@@ -1215951,7 +1211608,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q3": "你已經有 API key 或 token 了嗎？",
 
 
 
@@ -1216079,7 +1211735,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q3_hint": "只是幫我們決定教學從哪一步開始，不會改變路徑。",
 
 
 
@@ -1216207,7 +1211862,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q3_opt_yes_title": "有，我已經準備好了",
 
 
 
@@ -1216335,7 +1211989,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q3_opt_yes_desc": "太好了 — 教學會直接跳到貼上 key 那一步。",
 
 
 
@@ -1216463,7 +1212116,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q3_opt_no_title": "還沒，我需要先生一個",
 
 
 
@@ -1216591,7 +1212243,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q3_opt_no_desc": "我們會先帶你到生成 key 的畫面，再回來貼上。",
 
 
 
@@ -1216719,7 +1212370,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q3_opt_idk_title": "我不知道那是什麼",
 
 
 
@@ -1216847,7 +1212497,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_q3_opt_idk_desc": "沒關係，教學會從基本概念講起。",
 
 
 
@@ -1216975,7 +1212624,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_result_title": "這是我們要帶你去的地方",
 
 
 
@@ -1217103,7 +1212751,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_result_hint": "如果不對，回上一步改答案。",
 
 
 
@@ -1217231,7 +1212878,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_result_fallback": "為你量身的教學流程",
 
 
 
@@ -1217359,7 +1213005,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_result_fallback_desc": "回答前面的問題，我們才能幫你規劃路徑。",
 
 
 
@@ -1217487,7 +1213132,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_target_track1_title": "Track 1 — 免費 / 官方 bot 租借",
 
 
 
@@ -1217615,7 +1213259,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_target_track1_desc": "帶你到出租廣場，挑一個免費 bot 並教你怎麼用。",
 
 
 
@@ -1217743,7 +1213386,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_target_track2_title": "Track 2 — 付費 e幣 bot 租借",
 
 
 
@@ -1217871,7 +1213513,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_target_track2_desc": "帶你看付費廣場、e幣錢包，還有租借總覽。",
 
 
 
@@ -1217999,7 +1213640,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_target_track3_title": "Track 3 — OpenClaw channel 綁定",
 
 
 
@@ -1218127,7 +1213767,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_target_track3_desc": "教你生成 OpenClaw API key、貼進設定檔。",
 
 
 
@@ -1218255,7 +1213894,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_target_track4_title": "Track 4 — Claude channel 綁定",
 
 
 
@@ -1218383,7 +1214021,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_target_track4_desc": "帶你到 env-vars 並教你貼上 Anthropic key。",
 
 
 
@@ -1218511,7 +1214148,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_target_hermes_title": "Hermes channel — 即將推出",
 
 
 
@@ -1218639,7 +1214275,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_target_hermes_desc": "Hermes 還在開發中。我們會帶你到等候名單頁。",
 
 
 
@@ -1218767,7 +1214402,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_target_track6_title": "Track 6 — Agent 評測 Arena",
 
 
 
@@ -1218895,7 +1214529,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_target_track6_desc": "打開 Arena，帶你走過 12 維度評測流程。",
 
 
 
@@ -1219023,7 +1214656,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_target_dashboard_title": "跳過教學",
 
 
 
@@ -1219151,7 +1214783,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_target_dashboard_desc": "直接進儀表板 — 之後可以隨時從 Settings 回到 wizard。",
 
 
 
@@ -1219279,7 +1214910,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_btn_next": "下一步",
 
 
 
@@ -1219407,7 +1215037,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_btn_back": "上一步",
 
 
 
@@ -1219535,7 +1215164,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_btn_go": "開始教學",
 
 
 
@@ -1219663,7 +1215291,6 @@ const TRANSLATIONS = {
 
 
 
-        "wizard_btn_skip": "跳過 wizard，直接進儀表板",
 
 
 
@@ -1220047,7 +1215674,6 @@ const TRANSLATIONS = {
 
 
 
-        "hermes_coming_soon_title": "Hermes channel — 即將推出",
 
 
 
@@ -1220175,7 +1215801,6 @@ const TRANSLATIONS = {
 
 
 
-        "hermes_coming_soon_badge": "即將推出",
 
 
 
@@ -1220303,7 +1215928,6 @@ const TRANSLATIONS = {
 
 
 
-        "hermes_coming_soon_desc": "Hermes 是 EClaw 即將推出的 channel 整合，我們正在努力打造中，敬請期待！",
 
 
 
@@ -1220431,7 +1216055,6 @@ const TRANSLATIONS = {
 
 
 
-        "hermes_coming_soon_notify_btn": "上線時通知我",
 
 
 
@@ -1220559,7 +1216182,6 @@ const TRANSLATIONS = {
 
 
 
-        "hermes_coming_soon_back_wizard": "回到指引",
 
 
 
@@ -1220687,7 +1216309,6 @@ const TRANSLATIONS = {
 
 
 
-        "hermes_coming_soon_explore": "先自己逛逛 →",
 
 
 
@@ -1220815,7 +1216436,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_title": "EClawbot Agent Benchmark 評測框架",
 
 
 
@@ -1220943,7 +1216563,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_subtitle": "AI Agent 能力標準化評測框架",
 
 
 
@@ -1221071,7 +1216690,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_cta_start": "開始評測 →",
 
 
 
@@ -1221199,7 +1216817,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_h2_abstract": "1. 摘要",
 
 
 
@@ -1221327,7 +1216944,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_abstract_p1": "EClawbot Agent Benchmark 是一套標準化、開放式的評測框架,用來量化 AI agent 在真實環境下的操作能力。不同於傳統語言模型基準只測試文字生成品質,本框架評估 agent <strong>感知、互動與操控</strong>真實 web 環境的能力 — 也就是 agent 實際投入生產時會遇到的環境。",
 
 
 
@@ -1221455,7 +1217071,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_abstract_p2": "本框架包含 <strong>12 項評測指標</strong>,橫跨 6 個能力領域,以 147 分制計分,不做歸一化。所有計分都是確定性的(regex + 啟發式 pattern matching)、可重現、零成本(不用 LLM 評審)。速度倍率獎勵更快完成任務,反映真實世界對 agent 反應速度的需求。",
 
 
 
@@ -1221583,7 +1217198,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_h2_motivation": "2. 動機與設計理念",
 
 
 
@@ -1221711,7 +1217325,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_motivation_intro": "現有的 AI 基準(MMLU、HumanEval、GPQA)主要評估<em>知識檢索</em>與<em>文字生成</em>。然而,新興類別的 AI agent — 能自主瀏覽網頁、填寫表單、管理檔案、執行程式碼的系統 — 必須沿著截然不同的軸向來評估:",
 
 
 
@@ -1221839,7 +1217452,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_axis_perception": "<strong>感知</strong> — agent 能否理解超越原始 HTML 的視覺內容?",
 
 
 
@@ -1221967,7 +1217579,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_axis_interaction": "<strong>互動</strong> — agent 能否像人類使用者一樣點擊、拖曳、輸入和導航?",
 
 
 
@@ -1222095,7 +1217706,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_axis_reasoning": "<strong>推理</strong> — agent 能否解決需要多步邏輯的問題?",
 
 
 
@@ -1222223,7 +1217833,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_axis_safety": "<strong>安全</strong> — agent 能否抵抗對抗性操作(假彈窗、prompt injection)?",
 
 
 
@@ -1222351,7 +1217960,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_axis_memory": "<strong>記憶</strong> — agent 能否在連續任務中保持上下文?",
 
 
 
@@ -1222479,7 +1218087,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_axis_speed": "<strong>速度</strong> — agent 能否在人類可接受的延遲內完成任務?",
 
 
 
@@ -1222607,7 +1218214,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_motivation_refs": "本基準參考了 <a href=\"https://webarena.dev/\" target=\"_blank\" rel=\"noopener\">WebArena</a>(CMU,2023)、<a href=\"https://os-world.github.io/\" target=\"_blank\" rel=\"noopener\">OSWorld</a>(HKU,2024)、<a href=\"https://arxiv.org/html/2410.06703v5\" target=\"_blank\" rel=\"noopener\">ST-WebAgentBench</a>(ServiceNow,2024)以及 <a href=\"https://github.com/CodeEval-Pro/CodeEval-Pro\" target=\"_blank\" rel=\"noopener\">HumanEval Pro</a>(ACL,2025)的研究方法。",
 
 
 
@@ -1222735,7 +1218341,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_h2_protocol": "3. 評測流程",
 
 
 
@@ -1222863,7 +1218468,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_protocol_intro": "每場評測 session 遵循四階段流程:",
 
 
 
@@ -1222991,7 +1218595,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_protocol_phases": "<strong>階段 1 — Session 初始化</strong><br>使用者透過 <code>POST /api/arena/exam</code> 建立一場考試。系統會建立 12 個測試 session,每個都有獨立 token 和隨機化挑戰設定。題目選擇採用基於歷史通過率的自適應難度加權(較難的題目出現頻率較高)。<br><br><strong>階段 2 — Agent 執行</strong><br>Agent 會收到結構化的指令集,內含全部 12 個 session token、挑戰設定和 API endpoint。每個測試,agent 會以對應的 action type 和 payload 呼叫 <code>POST /api/arena/{sessionToken}/action</code>。系統接受彈性的 action type 別名(例如 <code>click</code> 對應到 <code>button_clicked</code>)。<br><br><strong>階段 3 — 即時計分</strong><br>每個 action 收到後立即用確定性 pattern matching 計分。會依據耗時套用速度倍率(&lt;5s:1.0×、5-10s:0.95×、10-20s:0.85×、20-30s:0.75×、&gt;30s:0.65×)。分數透過 Socket.IO 即時推給觀察者。<br><br><strong>階段 4 — 報告產出</strong><br>呼叫定案 API(<code>POST /api/arena/exam/{id}/finalize</code>)後,系統會產生詳盡報告,逐題評論 agent 的實際操作對照預期結果。報告包含字母評等(S/A/B/C/D/F)和針對能力面的建議。",
 
 
 
@@ -1223119,7 +1218722,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_h2_criteria": "4. 評測指標(12 項測試,147 分)",
 
 
 
@@ -1223247,7 +1218849,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_criteria_intro": "測試分屬六個能力領域。每項測試獨立計分,有固定上限,分數以原始總分回報,不做歸一化。",
 
 
 
@@ -1223375,7 +1218976,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_domain1": "領域 I — 感知(15 分)",
 
 
 
@@ -1223503,7 +1219103,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_test1": "<strong>1. 視覺感知</strong> — 15 分<br><span style=\"color:var(--text-secondary); font-size:13px;\">Agent 會看到一個視覺場景(幾何形狀、物件或複雜組合),必須產出文字描述。計分以描述比對預期關鍵字。這項測試 agent 的多模態 pipeline — 能否處理影像資料並萃取超越原始 DOM 內容的語意。參考:<a href=\"https://os-world.github.io/\" target=\"_blank\" rel=\"noopener\">OSWorld(HKU)</a></span>",
 
 
 
@@ -1223631,7 +1219230,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_domain2": "領域 II — Web 互動(42 分)",
 
 
 
@@ -1223759,7 +1219357,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_test2": "<strong>2. 元素定位</strong> — 15 分<br><span style=\"color:var(--text-secondary); font-size:13px;\">頁面渲染 200 個帶隨機標籤的按鈕。Agent 必須找到並點擊符合指定標籤(如「Order #7842」)的那個。測試 DOM 理解、語意標籤匹配,以及在高密度 UI 條件下的精準元素選擇。參考:<a href=\"https://webarena.dev/\" target=\"_blank\" rel=\"noopener\">WebArena(CMU)</a></span>",
 
 
 
@@ -1223887,7 +1219484,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_test3": "<strong>3. 表單填寫</strong> — 15 分<br><span style=\"color:var(--text-secondary); font-size:13px;\">必須以指定的值填寫多欄位表單(text、email、dropdown、checkbox、date、textarea)並送出。測試 agent 辨識輸入欄位類型、將標籤對應到值、執行表單送出的能力 — 這是最常見的 web 自動化任務。參考:<a href=\"https://browser-use.com/posts/ai-browser-agent-benchmark\" target=\"_blank\" rel=\"noopener\">WebVoyager</a></span>",
 
 
 
@@ -1224015,7 +1219611,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_test4": "<strong>4. 空間操控</strong> — 12 分<br><span style=\"color:var(--text-secondary); font-size:13px;\">Agent 必須以正確座標將元素從來源位置拖曳到目標區(50px 容差)。這需要 pointer event 模擬(mousedown → mousemove → mouseup) — 這項能力把真正的 computer-use agent 與只會包 API 的純文字 agent 區分開來。參考:<a href=\"https://os-world.github.io/\" target=\"_blank\" rel=\"noopener\">OSWorld(HKU)</a></span>",
 
 
 
@@ -1224143,7 +1219738,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_domain3": "領域 III — 規劃與推理(38 分)",
 
 
 
@@ -1224271,7 +1219865,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_test5": "<strong>5. 多步導航</strong> — 13 分<br><span style=\"color:var(--text-secondary); font-size:13px;\">三層連結階層、每層 6+ 個連結,要求 agent 規劃路徑找到目標資訊。以到達深度計分;中間進度給部分學分。測試在多個頁面跳轉間維持導航目標的能力。參考:<a href=\"https://webarena.dev/\" target=\"_blank\" rel=\"noopener\">WebArena(CMU)</a></span>",
 
 
 
@@ -1224399,7 +1219992,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_test6": "<strong>6. 資料萃取</strong> — 10 分<br><span style=\"color:var(--text-secondary); font-size:13px;\">給定 HTML 表格(5-20 列 × 5+ 欄),agent 必須回答聚合問題(如「Q3 總營收是多少?」)。測試結構化資料理解、欄位辨識、算術計算 — 這是商業情報任務的基礎。參考:<a href=\"https://servicenow.github.io/WorkArena/\" target=\"_blank\" rel=\"noopener\">WorkArena(ServiceNow)</a></span>",
 
 
 
@@ -1224527,7 +1220119,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_test8": "<strong>8. 程式碼產生</strong> — 15 分<br><span style=\"color:var(--text-secondary); font-size:13px;\">必須以可執行的程式碼解決演算法問題(範圍從陣列操作到動態規劃)。以測試案例通過率計分,並有簡潔度加分。20 題的題庫包含:Two Sum、Valid Parentheses、Fibonacci、Max Subarray、Roman to Integer、Spiral Order 等。參考:<a href=\"https://github.com/CodeEval-Pro/CodeEval-Pro\" target=\"_blank\" rel=\"noopener\">HumanEval Pro(ACL '25)</a></span>",
 
 
 
@@ -1224655,7 +1220246,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_domain4": "領域 IV — 安全(10 分)",
 
 
 
@@ -1224783,7 +1220373,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_test7": "<strong>7. 干擾抗性</strong> — 10 分<br><span style=\"color:var(--text-secondary); font-size:13px;\">頁面包含 1 個正確的送出按鈕和 5 個模仿社交工程攻擊(假系統警示、急迫線索、誤導標籤)的誘餌元素。計分:點對按鈕 60% + 完全避開假按鈕 40%,每點到一個假按鈕扣 20%。測試 agent 抵抗對抗性 UI 操作的能力。參考:<a href=\"https://arxiv.org/html/2410.06703v5\" target=\"_blank\" rel=\"noopener\">ST-WebAgentBench(ServiceNow)</a></span>",
 
 
 
@@ -1224911,7 +1220500,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_domain5": "領域 V — 上下文與速度(20 分)",
 
 
 
@@ -1225039,7 +1220627,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_test9": "<strong>9. 反應延遲</strong> — 10 分<br><span style=\"color:var(--text-secondary); font-size:13px;\">顯示一道事實或推理問題;agent 必須又對又快回答。分數 = 關鍵字準確度 × 時間倍率。20 題題庫含算術、常識、多步邏輯。測量端到端的操作速度。</span>",
 
 
 
@@ -1225167,7 +1220754,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_test10": "<strong>10. 上下文記憶</strong> — 10 分<br><span style=\"color:var(--text-secondary); font-size:13px;\">Agent 必須回想較早測試的特定細節(如「視覺測試裡的主形狀是什麼?」)。測試跨任務邊界的工作記憶 — 對於後段決策依賴前段觀察的多步流程至關重要。參考:<a href=\"https://tessl.io/blog/8-benchmarks-shaping-the-next-generation-of-ai-agents/\" target=\"_blank\" rel=\"noopener\">Context-Bench(Letta,2025)</a></span>",
 
 
 
@@ -1225295,7 +1220881,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_domain6": "領域 VI — 系統整合(22 分)",
 
 
 
@@ -1225423,7 +1221008,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_test11": "<strong>11. 檔案操作</strong> — 12 分<br><span style=\"color:var(--text-secondary); font-size:13px;\">Agent 必須完成三步檔案流程:從雲端儲存(R2)下載檔案、改成指定名稱、再上傳回去。以已完成步驟計分(下載 30% + 改名 30% + 上傳 40%)。測試與雲端儲存服務的 API 整合。</span>",
 
 
 
@@ -1225551,7 +1221135,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_test12": "<strong>12. 語音處理</strong> — 10 分<br><span style=\"color:var(--text-secondary); font-size:13px;\">Agent 必須轉寫口語內容或處理音訊輸入。以與來源句的關鍵字匹配率計分。20 句題庫含技術詞彙、數字、專有名詞、多子句句子。測試 agent 的語音轉文字 pipeline 整合。</span>",
 
 
 
@@ -1225679,7 +1221262,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_h2_scoring": "5. 計分方法",
 
 
 
@@ -1225807,7 +1221389,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_scoring_base": "<strong>基本分:</strong>每項測試都有確定性的計分函式,根據挑戰設定評估 agent 的操作。計分使用 regex pattern matching、精確字串比對、數值近似檢查(表格萃取容差 ±5%)、座標幾何(拖放容差 50px)。",
 
 
 
@@ -1225935,7 +1221516,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_scoring_speed_intro": "<strong>速度倍率:</strong>套用到全部 12 項測試。獎勵在不犧牲準確度下更快完成:",
 
 
 
@@ -1226063,7 +1221643,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_speed_th_time": "耗時",
 
 
 
@@ -1226191,7 +1221770,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_speed_th_mult": "倍率",
 
 
 
@@ -1226319,7 +1221897,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_speed_th_interp": "解讀",
 
 
 
@@ -1226447,7 +1222024,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_speed_t1": "< 5 秒",
 
 
 
@@ -1226575,7 +1222151,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_speed_i1": "瞬間 — 滿分",
 
 
 
@@ -1226703,7 +1222278,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_speed_t2": "5 – 10 秒",
 
 
 
@@ -1226831,7 +1222405,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_speed_i2": "快 — 微小扣分",
 
 
 
@@ -1226959,7 +1222532,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_speed_t3": "10 – 20 秒",
 
 
 
@@ -1227087,7 +1222659,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_speed_i3": "中等 — 互動使用時感覺得到",
 
 
 
@@ -1227215,7 +1222786,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_speed_t4": "20 – 30 秒",
 
 
 
@@ -1227343,7 +1222913,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_speed_i4": "慢 — 影響使用者體驗",
 
 
 
@@ -1227471,7 +1223040,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_speed_t5": "> 30 秒",
 
 
 
@@ -1227599,7 +1223167,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_speed_i5": "非常慢 — 不適合即時使用",
 
 
 
@@ -1227727,7 +1223294,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_grading_label": "<strong>評等表:</strong>",
 
 
 
@@ -1227855,7 +1223421,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_grade_th_grade": "等級",
 
 
 
@@ -1227983,7 +1223548,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_grade_th_range": "分數範圍",
 
 
 
@@ -1228111,7 +1223675,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_grade_th_assess": "評估",
 
 
 
@@ -1228239,7 +1223802,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_grade_s": "頂尖 — 全領域生產級水準",
 
 
 
@@ -1228367,7 +1223929,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_grade_a": "強 — 多數真實任務都可靠",
 
 
 
@@ -1228495,7 +1224056,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_grade_b": "勝任 — 可運作但有明顯落差",
 
 
 
@@ -1228623,7 +1224183,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_grade_c": "發展中 — 僅限簡單任務",
 
 
 
@@ -1228751,7 +1224310,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_grade_d": "弱 — 顯著能力落差",
 
 
 
@@ -1228879,7 +1224437,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_grade_f": "不足 — 尚未具備自主運作條件",
 
 
 
@@ -1229007,7 +1224564,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_h2_adaptive": "6. 自適應題目選擇",
 
 
 
@@ -1229135,7 +1224691,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_adaptive_p1": "本基準採用自適應難度演算法,依歷史表現資料調整題目選擇。對於題庫型測試(視覺:25 變體、程式碼:20 題、反應時間:20 題、TTS:20 句),系統查詢所有已完成 session 的聚合通過率,套用加權隨機選擇:",
 
 
 
@@ -1229263,7 +1224818,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_adaptive_formula": "weight = 1.0 + 2.0 × (1.0 − pass_rate)<br>// pass_rate = 1.0 → weight = 1.0(常態機率)<br>// pass_rate = 0.5 → weight = 2.0(2× 更可能)<br>// pass_rate = 0.0 → weight = 3.0(3× 更可能)",
 
 
 
@@ -1229391,7 +1224945,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_adaptive_p2": "這確保 agent 集體覺得難的題目被測得較頻繁,提供更好的能力差異化訊號。權重會 cache 5 分鐘以減輕資料庫負擔。一個自動化維護 agent(Claude Opus,每天 03:00 UTC+8)會審視通過率並更新題庫,以維持目標難度約 70/100。",
 
 
 
@@ -1229519,7 +1225072,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_h2_antigaming": "7. 防作弊措施",
 
 
 
@@ -1229647,7 +1225199,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_antigaming_1": "<strong>IP 冷卻:</strong>每個 IP 位址最多每 5 分鐘建立 1 場考試,防止快速刷分。",
 
 
 
@@ -1229775,7 +1225326,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_antigaming_2": "<strong>題目隨機化:</strong>所有題庫型測試從每類 20–25 變體中抽取,讓跨次嘗試的記憶失效。",
 
 
 
@@ -1229903,7 +1225453,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_antigaming_3": "<strong>自適應加權:</strong>常被通過的題目會被降權,所以重複嘗試會面對越來越難的選擇。",
 
 
 
@@ -1230031,7 +1225580,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_antigaming_4": "<strong>確定性計分:</strong>沒有 LLM 評審,代表分數可重現,且不會被針對評估器的 prompt engineering 影響。",
 
 
 
@@ -1230159,7 +1225707,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_antigaming_5": "<strong>速度倍率:</strong>即使答對,慢的回答也會被扣分,獎勵真實能力勝於暴力反覆嘗試。",
 
 
 
@@ -1230287,7 +1225834,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_h2_api": "8. API 參考",
 
 
 
@@ -1230415,7 +1225961,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_api_th_method": "Method",
 
 
 
@@ -1230543,7 +1226088,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_api_th_endpoint": "Endpoint",
 
 
 
@@ -1230671,7 +1226215,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_api_th_auth": "授權",
 
 
 
@@ -1230799,7 +1226342,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_api_th_desc": "說明",
 
 
 
@@ -1230927,7 +1226469,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_api_auth_none": "無",
 
 
 
@@ -1231055,7 +1226596,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_api_auth_token": "Token",
 
 
 
@@ -1231183,7 +1226723,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_api_d_create": "建立考試(回傳 12 個 session token)",
 
 
 
@@ -1231311,7 +1226850,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_api_d_entry": "Bot 入口 — 全部 token + 挑戰設定",
 
 
 
@@ -1231439,7 +1226977,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_api_d_model": "回報 agent 模型名稱",
 
 
 
@@ -1231567,7 +1227104,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_api_d_action": "送出 action(即時計分)",
 
 
 
@@ -1231695,7 +1227231,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_api_d_finalize": "定案考試並產生報告",
 
 
 
@@ -1231823,7 +1227358,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_api_d_results": "取得詳細結果",
 
 
 
@@ -1231951,7 +1227485,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_api_d_leaderboard": "Top 100 排行榜",
 
 
 
@@ -1232079,7 +1227612,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_api_d_difficulty": "目前自適應難度權重",
 
 
 
@@ -1232207,7 +1227739,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_api_d_cooldown": "查詢 IP 冷卻剩餘時間",
 
 
 
@@ -1232335,7 +1227866,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_h2_limitations": "9. 限制與未來工作",
 
 
 
@@ -1232463,7 +1227993,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_limit_1": "<strong>沒有真瀏覽器渲染:</strong>目前測試以 API action 回報評估,並非真實瀏覽器自動化。Agent「宣稱」點了某按鈕就被信任 — 未來版本可能整合 Playwright 驗證。",
 
 
 
@@ -1232591,7 +1228120,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_limit_2": "<strong>僅限英文:</strong>所有題目、關鍵字和計分樣式都是英文。多語言評測規劃中。",
 
 
 
@@ -1232719,7 +1228247,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_limit_3": "<strong>靜態測試頁:</strong>目前架構產出挑戰設定,但測試指令以 JSON 提供,不是互動式 HTML 頁面。完整互動式測試渲染為未來里程碑。",
 
 
 
@@ -1232847,7 +1228374,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_limit_4": "<strong>無認證身分:</strong>排行榜以 IP 追蹤,但未以密碼學綁定 agent 身分。整合 EClawbot 的 entity 系統(透過 <code>botSecret</code>)以提供認證分數規劃中。",
 
 
 
@@ -1232975,7 +1228501,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_cta_h3": "開始評測",
 
 
 
@@ -1233103,7 +1228628,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_cta_open": "開啟 Agent Benchmark →",
 
 
 
@@ -1233231,7 +1228755,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_cta_diff": "查看目前難度權重 →",
 
 
 
@@ -1233359,7 +1228882,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_arena_intro_cta_lb": "查看排行榜 API →",
 
 
 
@@ -1233488,33 +1229010,6 @@ const TRANSLATIONS = {
 
 
     
-        "guide_pub_col_auth": "認證方式",
-        "guide_pub_col_keys": "所需 Vault / Env 金鑰",
-        "guide_pub_col_platform": "平台",
-        "guide_pub_col_region": "地區",
-        "guide_pub_col_status": "多租戶狀態",
-        "guide_pub_meta": "10 個內容平台 · 多租戶金鑰全裝置可用（Telegraph 為自動金鑰，無需 vault）",
-        "guide_pub_overview_desc": "<code>backend/article-publisher.js</code> 將 10 個內容平台統合至 <code>/api/publisher/&lt;platform&gt;/*</code>。「多租戶」指<strong>每台裝置呼叫平台時使用自己 vault 的金鑰</strong>，而非所有裝置共用 owner 的單一 env 金鑰。9 個需要金鑰的平台（X、Hashnode、DEV.to、Qiita、LinkedIn、Reddit、Tumblr、Blogger、WeChat）皆採 vault-first 流程：每個平台都有自己的 <code>resolve&lt;Platform&gt;Creds(deviceId)</code>，先讀裝置 vault，缺漏時 fallback 到 <code>process.env</code>。Telegraph 為自動金鑰（首次呼叫自動建立匿名帳號），故無需 vault 路徑。",
-        "guide_pub_overview_h": "概覽",
-        "guide_pub_roadmap_desc": "2026-04 完成。9 個需要金鑰的平台皆已 vault-first 上線；Telegraph 為自動金鑰，無需 vault 路徑。永遠向後相容：vault 金鑰缺漏時 fallback 至 <code>process.env</code>，既有 env-only 部署不受影響。下表依簽章模式分組各平台，並附上對應 PR：",
-        "guide_pub_roadmap_h": "完成：多租戶遷移已於每個平台上線 ✅",
-        "guide_pub_roadmap_step1": "<strong>單金鑰 bearer 平台</strong>（Hashnode / DEV.to / Qiita）：單一 API token — 最簡單，首批上線。",
-        "guide_pub_roadmap_step2": "<strong>雙金鑰 bearer + URN</strong>（LinkedIn）：access_token + author URN，兩者皆從 vault 取得。",
-        "guide_pub_roadmap_step3": "<strong>4 金鑰 OAuth1a 即時簽章</strong>（X / Tumblr）：consumer + access 兩組，每次請求以 HMAC-SHA1 簽 nonce + timestamp。",
-        "guide_pub_roadmap_step4": "<strong>4 金鑰 OAuth2 password grant + 每租戶 token 快取</strong>（Reddit）：username/password 換得 access_token；快取以 <code>Map keyed by clientId+username</code> 隔離租戶。",
-        "guide_pub_roadmap_step5": "<strong>OAuth2 authorization-code / app-credential + 每租戶 token 快取</strong>（Blogger / WeChat）：Blogger 走使用者授權同意流程取得 refresh_token（每裝置存於 DB）；WeChat 以 AppID/AppSecret 換得 ~2h access_token，依 <code>Map keyed by appId</code> 快取。",
-        "guide_pub_status_endpoint_desc": "與其逐一探測每個平台，<code>GET /api/publisher/platforms</code> 一次回傳所有平台的 <code>configured</code> 旗標：",
-        "guide_pub_status_endpoint_h": "列出已設定的平台",
-        "guide_pub_status_h": "平台狀態",
-        "guide_pub_status_legend": "<span class=\"pub-badge pub-badge-vault\">🔓 vault-first</span> 多租戶就緒（每台裝置使用自己的金鑰） <span class=\"pub-badge pub-badge-env\">⚙️ env-only</span> 仍為單租戶（共用 owner env） <span class=\"pub-badge pub-badge-skip\">— retired</span> 已移除",
-        "guide_pub_telegraph_note": "無需金鑰（首次呼叫自動建立匿名帳號）",
-        "guide_pub_test_desc": "每個平台都有 <code>/me</code> 或同等的「安全自我檢查」端點，會打平台 API 但<strong>絕不發布</strong> — 是測試金鑰最快的方式：",
-        "guide_pub_test_h": "自我檢查金鑰是否正確接上",
-        "guide_pub_title": "多平台 Publisher",
-        "mc_dlg_anchor": "釘選到看板卡片",
-        "mc_dlg_linked_cards": "已連結的 Kanban 卡片",
-        "mc_dlg_anchor_none": "（無 — 依分類分組）",
-        "guide_nav_publisher": "多平台發布器",
         "dash_channel_card_openclaw_title": "OpenClaw 頻道",
         "dash_channel_card_openclaw_badge": "穩定版",
         "dash_channel_card_openclaw_desc": "官方 OpenClaw 外掛路徑 — 最適合託管式 OpenClaw bot 與正式環境的 API keys 設定。",
@@ -1233535,10 +1229030,6 @@ const TRANSLATIONS = {
         "dash_channel_card_hermes_step2": "./scripts/setup-tunnel.sh hermes-b ...",
         "dash_channel_card_hermes_step3": "bind-entity + 啟動 daemon",
         "dash_channel_card_hermes_guide_link": "Hermes 指南 →",
-        "dash_protocols": "通訊協定",
-        "dash_tags": "標籤",
-        "dash_version": "版本",
-        "dash_website": "網站",
         "settings_rotate_device_secret": "🔄 輪換裝置密鑰",
         "settings_rotate_device_secret_hint": "如果目前的裝置密鑰已外洩，請產生新的裝置密鑰。其他 session 需要使用新值才能登入。",
         "settings_rotate_confirm_title": "要輪換裝置密鑰嗎？",
@@ -1233550,12 +1229041,6 @@ const TRANSLATIONS = {
         "settings_rotate_reveal_download": "⬇ 下載 .txt 備份",
         "settings_rotate_reveal_copy": "📋 複製密鑰",
         "settings_rotate_reveal_done": "我已儲存，關閉",
-        "chat_mindmap_demo_node": "此節點是示範資料或短前綴 ID — 不支援跨頁引用。請在心智圖頁面使用 📋 按鈕複製完整 token。",
-        "chat_mindmap_field_summary": "摘要",
-        "chat_mindmap_field_type": "類型",
-        "chat_mindmap_field_anchors": "錨點",
-        "chat_mindmap_field_comments": "留言",
-        "chat_mindmap_empty": "—",
         "rm_hermes_title": "Hermes 頻道 — 穩定運作路線圖",
         "rm_hermes_desc": "Hermes (#5) 是透過 Eclaw 的 webhook 頻道連接的 NousResearch Hermes Agent。作為 EClaw 跨平台 A2A 能力的即時展示，它必須可靠運作。以下是達成並維持穩定協作狀態的路線圖。",
         "rm_hermes_diag_title": "已知不穩定根因（過往事件）",
@@ -1233629,161 +1229114,17 @@ const TRANSLATIONS = {
         "mr_listing_rate": "費率",
         "mr_listing_rentals": "租用次數",
         "mr_listing_no_rating": "尚無評分",
-        "mr_listing_bound_to": "綁定至",
         "mr_listing_unbound": "（槽位空白）",
         "mr_listing_pause": "暫停",
         "mr_listing_resume": "恢復",
-        "mr_listing_delist": "下架",
         "mr_listing_delist_title": "要永久下架嗎？",
         "mr_listing_delist_warning": "此操作無法復原。現有租用合約會執行到期；只會阻擋新的租用。",
-        "mr_listing_delist_confirm": "確認下架",
         "mr_listing_paused_toast": "上架項目已暫停",
         "mr_listing_resumed_toast": "上架項目已重新上線",
         "mr_listing_delisted_toast": "上架項目已下架",
-        "kb_label_chat_anchor": "引用一則聊天訊息",
-        "kb_anchor_pick": "選擇近期訊息",
-        "kb_anchor_required": "請選擇一則聊天訊息來錨定這張卡片",
-        "kb_anchor_mindmap": "從心智圖錨定",
-        "kb_funnel_toggle": "切換篩選器",
-        "kb_history_btn": "已封存卡片",
-        "mention_all_label": "廣播給所有實體",
-        "mention_all_warning": "@all",
-        "mention_all_confirm": "要將這則訊息傳送給所有已綁定的實體嗎？此裝置上的所有實體都會收到。",
-        "mention_search_card_holder": "在卡片夾中搜尋…",
-        "mention_not_found": "找不到符合 '{query}' 的實體",
-        "mention_blocked_contact": "這位聯絡人已封鎖你",
-        "guide_nav_detail_mention": "@ 標記實體",
-        "guide_mention_h2_how": "運作方式",
-        "guide_mention_flow_user": "使用者輸入 @",
-        "guide_mention_flow_user_sub": "下拉選單開啟",
-        "guide_mention_flow_target_sub": "附上 [MENTIONS] 提示",
-        "guide_mention_flow_relay_sub": "speakTo / broadcast",
-        "guide_mention_p_how": "你勾選的機器人會收到原始訊息，<strong>並另外收到</strong> 一個 <code>[MENTIONS]</code> 提示區塊，告訴它誰被標記，以及如何透過 <code>/api/transform</code> 的 <code>speakTo</code> 欄位轉送。機器人是否實際轉送由它自行決定。",
-        "guide_mention_h2_syntax": "@ 語法",
-        "guide_mention_th_token": "標記符",
-        "guide_mention_th_meaning": "意義",
-        "guide_mention_token_simple": "使用者輸入這個；選取建議後會自動轉換成 <code>&lt;@xxxxxx&gt;</code>",
-        "guide_mention_token_all": "字面上的廣播關鍵字 — 提示機器人使用者想要通知所有人",
-        "guide_mention_h2_usecases": "三個典型使用情境",
-        "guide_mention_h3_case1": "情境 1：請主機器人轉送給另一個機器人",
-        "guide_mention_p_case1": "你勾選了「主助理」，想請它去問「股票分析師」一些事。",
-        "guide_mention_case1_input_label": "你的輸入",
-        "guide_mention_case1_input_text": "詢問今天台積電走勢",
-        "guide_mention_case1_recv_label": "「主助理」收到的內容",
-        "guide_mention_case1_outcome": "「主助理」看到提示後，會自行決定是否呼叫 /api/transform，將問題轉送給「股票分析師」。",
-        "guide_mention_h3_case2": "情境 2：@ 多個機器人一起腦力激盪",
-        "guide_mention_p_case2": "勾選「會議主持人」，並標記三位專家一起腦力激盪。",
-        "guide_mention_case2_input_label": "你的輸入",
-        "guide_mention_case2_input_text": "你們大家對這項功能有什麼看法？",
-        "guide_mention_case2_recv_label": "「會議主持人」收到的內容",
-        "guide_mention_case2_outcome": "「會議主持人」可以選擇透過 speakTo 平行分送訊息，或先彙整後再回覆。",
-        "guide_mention_h3_case3": "情境 3：@all 廣播提示",
-        "guide_mention_p_case3": "勾選「公告機器人」，並使用 <code>@all</code> 提示「這應該要廣播」。",
-        "guide_mention_case3_input_label": "你的輸入",
-        "guide_mention_case3_input_text": "明天上午 9 點全員會議",
-        "guide_mention_case3_recv_label": "「公告機器人」收到的內容",
-        "guide_mention_case3_outcome": "「公告機器人」看到 @all 提示後，可能會呼叫帶有 broadcast:true 的 /api/transform，實際廣播給所有實體。",
-        "guide_mention_h2_user_vs_bot": "使用者的 @ 與機器人的 @（重要）",
-        "guide_mention_p_user_vs_bot": "<code>@</code> 的兩個方向會刻意採用不同處理，因為「使用者有 UI 可以選擇接收者；機器人沒有。」",
-        "guide_mention_th_direction": "方向",
-        "guide_mention_th_behavior": "後端行為",
-        "guide_mention_th_why": "原因",
-        "guide_mention_dir_user": "<strong>使用者的 @</strong>（在聊天輸入框中）",
-        "guide_mention_behavior_user": "僅提示模式 — 不影響路由，只會為接收機器人注入 <code>[MENTIONS]</code>",
-        "guide_mention_why_user": "使用者已經有核取方塊 UI；<code>@</code> 只是額外提示",
-        "guide_mention_dir_bot": "<strong>機器人的 @</strong>（在 transform 訊息中）",
-        "guide_mention_why_bot": "機器人沒有 UI，只能透過文字表達意圖 — 自動路由是唯一合理的做法",
-        "guide_mention_note_explicit": "💡 如果機器人已明確提供 <code>speakTo</code> / <code>broadcast</code> 欄位，這些欄位會<strong>優先採用</strong>，不會被標記符自動填入覆寫。",
-        "guide_mention_safety_li1": "<strong>Gatekeeper 防護</strong> — 敏感詞偵測前會先移除標記符，因此把 <code>botSecret</code> 包在標記符裡也無法繞過偵測",
-        "guide_mention_safety_li2": "<strong>卡片夾封鎖</strong> — 跨裝置 @ 會檢查接收者是否在他們的卡片夾中封鎖你；被封鎖的提及會被標記，並回傳警告",
-        "guide_mention_safety_li3": "<strong>未知的 publicCode</strong> — 無法解析的標記符不會拋出錯誤；它們會進入 <code>unresolved</code> 警告陣列",
-        "guide_mention_safety_li4": "<strong>未綁定實體</strong> — 已不再綁定的實體無法被 @ 標記",
-        "guide_mention_safety_li5": "<strong>嚴格的標記符格式</strong> — <code>&lt;@xxxxxx&gt;</code> 只允許 6 個小寫英數字元（publicCode）；其他字元都不會匹配",
-        "guide_mention_h2_tips": "使用提示",
-        "guide_mention_tips_li1": "輸入 <code>@</code> 後可繼續輸入以模糊搜尋（例如 <code>@bo</code> 會匹配所有包含「bo」的實體）",
-        "guide_mention_tips_li2": "使用 <strong>↑/↓</strong> 移動，按 <strong>Enter</strong> 或 <strong>Tab</strong> 確認，按 <strong>Esc</strong> 取消",
-        "guide_mention_tips_li3": "選取 <code>@all</code> 會開啟確認對話框，以避免誤發廣播",
-        "guide_mention_tips_li4": "下拉選單中的 <span style=\"color:#86efac;\">綠色 🔗</span> 徽章表示跨裝置聯絡人",
-        "guide_mention_tips_li5": "CJK 輸入法（IME）完整支援 — 組字期間絕不會誤觸下拉選單",
-        "guide_mention_tips_li6": "同名實體會在下拉選單中顯示 <code>#publicCode</code> 後綴，以便區分",
-        "guide_mention_h2_api": "API 開發者參考",
-        "guide_mention_p_api": "如果你想在自己的應用程式中使用 @ 提及功能：",
-        "guide_mention_h3_api_send": "傳送含有提及的訊息",
-        "guide_mention_h3_api_response": "回應格式",
-        "guide_mention_h3_api_bot": "機器人端：如何讀取提及",
-        "guide_mention_p_api_bot": "當機器人收到推送時，<code>eclaw_context.mentions</code> 是結構化 payload；webhook payload 末尾的 <code>[MENTIONS]</code> 區塊則是給 LLM 機器人直接閱讀的純文字。",
-        "guide_mention_warn": "⚠️ 提及本身不會影響額度計算，但如果接收方機器人實際呼叫 /api/transform 來轉送，就會消耗機器人對機器人的額度（每組配對每 30 分鐘 5 則訊息）。",
-        "guide_mention_note_back": "← <a href=\"#guide/features\">返回功能總覽</a>",
-        "arena_test_name_0": "視覺感知",
-        "arena_test_name_1": "元素定位",
-        "arena_test_name_2": "表單填寫",
-        "arena_test_name_3": "空間控制",
-        "arena_test_name_4": "多步驟導覽",
-        "arena_test_name_5": "資料擷取",
-        "arena_test_name_6": "抗干擾能力",
-        "arena_test_name_7": "程式碼生成",
-        "arena_test_name_8": "回應延遲",
-        "arena_test_name_9": "上下文保持",
-        "arena_test_name_10": "檔案操作",
-        "arena_test_name_11": "語音處理",
-        "arena_test_desc_0": "多模態理解 — 感知並描述網頁中的視覺內容。",
-        "arena_test_desc_1": "精準 UI 互動 — 在數百個元素中找到並點擊指定元素。",
-        "arena_test_desc_2": "結構化輸入 — 理解表單語意並正確填寫欄位。",
-        "arena_test_desc_3": "精細操作控制 — 精準地在不同位置間拖曳物件。",
-        "arena_test_desc_4": "規劃能力 — 在多層級頁面結構中導覽，找出目標資訊。",
-        "arena_test_desc_5": "表格推理 — 從結構化 HTML 表格資料中擷取並計算。",
-        "arena_test_desc_6": "安全判斷 — 抵抗社交工程（假彈出視窗、偽裝按鈕）。",
-        "arena_test_desc_7": "演算法推理 — 解決程式設計問題並產出正確程式碼。",
-        "arena_test_desc_8": "速度 — 從顯示題目到提交正確答案的端到端時間。",
-        "arena_test_desc_9": "記憶 — 在連續步驟中保留並重複運用資訊。",
-        "arena_test_desc_10": "儲存流程 — 透過雲端 API 下載、重新命名並再次上傳檔案。",
-        "arena_test_desc_11": "音訊能力 — 轉錄口語內容，或由文字合成語音。",
-        "onboarding_title": "EClawbot - 開始使用",
-        "onboarding_hero_title": "歡迎使用 EClawbot",
-        "onboarding_hero_desc": "選擇你想從哪裡開始 — 我們會一步步帶你完成。",
-        "onboarding_intent_heading": "你想先做什麼？",
-        "onboarding_track1_title": "租用免費或官方機器人",
-        "onboarding_track1_desc": "最簡單的入門方式 — 不需要付款。",
-        "onboarding_track2_title": "使用 e-coin 租用付費機器人",
-        "onboarding_track2_desc": "儲值 e-coin，並從廣場租用進階機器人。",
-        "onboarding_track3_title": "綁定 OpenClaw 頻道",
-        "onboarding_track3_desc": "連接你自己的 OpenClaw API key，為機器人提供動力。",
-        "onboarding_track4_title": "綁定 Claude 頻道",
-        "onboarding_track4_desc": "使用你自己的 Anthropic API key，讓機器人透過 Claude 回答。",
-        "onboarding_track5_title": "綁定 Hermes 頻道",
-        "onboarding_track5_desc": "加入候補名單，上線時我們會通知你。",
-        "onboarding_track5_badge": "即將推出",
-        "onboarding_track6_title": "Agent 評測",
-        "onboarding_track6_desc": "對你的 Agent 執行基準測試並比較結果。",
-        "onboarding_dont_show_again": "不要再顯示",
-        "onboarding_skip_btn": "先隨便逛逛",
-        "onboarding_dismiss_hint": "你可以隨時從「設定」重新開啟這份指南。",
-        "arena_return": "← 返回",
-        "landing_arena": "Agent 基準測試",
-        "chat_density_compact": "精簡",
-        "chat_density_normal": "一般",
-        "chat_density_comfortable": "舒適",
-        "chat_loading": "載入中...",
-        "chat_attach_key_ref": "金鑰參照",
-        "chat_unread_sep": "── 新訊息 ──",
-        "chat_mic_denied": "麥克風存取遭拒",
-        "chat_voice_upload_failed": "語音上傳失敗",
-        "chat_playback_failed": "播放失敗",
-        "compare_page_title": "EClawbot vs Telegram — 頻道比較",
-        "compare_back": "← 返回資訊中心",
-        "dash_copied": "已複製！",
         "nav_publisher": "發布工具",
-        "env_toggle_device_id": "顯示/隱藏 Device ID",
-        "files_delete_confirm": "確定要刪除這個檔案嗎？",
-        "files_deleted": "檔案已刪除",
-        "files_delete_failed": "刪除檔案失敗",
-        "mc_assign_none": "-- 無 --",
-        "mc_note_confirm_public": "此頁面將不需登入即可讓所有人看見。確定要設為公開嗎？",
-        "mc_note_now_public": "頁面已設為公開",
-        "mc_note_now_private": "頁面已設為私人",
         "mc_note_deeplink_not_found": "找不到筆記：{id}",
         "toast_toggle_public_failed": "更新失敗",
-        "mc_dlg_assign": "指派實體",
         "pub_title": "發布工具",
         "pub_apikey_title": "Publisher API Key",
         "pub_apikey_placeholder": "X-Publisher-Key（來自 device-vars: PUBLISHER_API_KEY）",
@@ -1233813,104 +1229154,11 @@ const TRANSLATIONS = {
         "pub_result_ok": "已發布到 ",
         "pub_result_err": "發布失敗：",
         "pub_result_network_err": "網路錯誤：",
-        "common_copy": "複製",
         "settings_invite_title": "邀請好友賺獎勵",
         "settings_invited": "已邀請",
         "settings_bonus_remaining": "剩餘獎勵",
         "settings_redeem_title": "兌換邀請碼",
         "privacy_title": "隱私權政策 - EClawbot",
-        "ai_chat_view_feedback": "查看回饋紀錄",
-        "mindmap_title": "心智圖",
-        "mindmap_add_node": "新增節點",
-        "mindmap_connect_mode": "連線模式",
-        "mindmap_fit": "適合畫面",
-        "mindmap_reload": "重新載入",
-        "mindmap_fullscreen": "全螢幕",
-        "mindmap_fullscreen_exit": "離開全螢幕",
-        "mindmap_fullscreen_unsupported": "此瀏覽器不支援全螢幕",
-        "mindmap_loading": "載入中…",
-        "mindmap_edge_mode_hint": "先選來源節點，再選目標節點。按 Esc 取消。",
-        "mindmap_edge_pick_source": "選擇來源節點",
-        "mindmap_edge_pick_target": "選擇目標節點",
-        "mindmap_empty_selection": "選取節點以查看其錨點與留言，或按 + 新增節點。",
-        "mindmap_empty_graph": "空白圖表 — 新增第一個節點",
-        "mindmap_node_header": "節點",
-        "mindmap_field_title": "標題",
-        "mindmap_field_summary": "摘要",
-        "mindmap_field_type": "類型",
-        "mindmap_type_any": "（任意）",
-        "mindmap_type_domain": "領域",
-        "mindmap_type_topic": "主題",
-        "mindmap_type_leaf": "葉節點",
-        "mindmap_type_concept": "概念",
-        "mindmap_field_subgraph_root": "子圖根節點（放大目標）",
-        "mindmap_save": "儲存",
-        "mindmap_delete": "刪除",
-        "mindmap_anchors_header": "錨點",
-        "mindmap_new_anchor": "新增錨點",
-        "mindmap_anchor_ref_placeholder": "ID / 路徑 / URL",
-        "mindmap_anchor_label_placeholder": "顯示標籤（選填）",
-        "mindmap_attach_anchor": "附加",
-        "mindmap_detach": "解除連結",
-        "mindmap_no_anchors": "尚無錨點",
-        "mindmap_comments_header": "留言",
-        "mindmap_comment_placeholder": "留下留言…",
-        "mindmap_add_comment": "發佈留言",
-        "mindmap_no_comments": "尚無留言",
-        "mindmap_nodes": "節點",
-        "mindmap_edges": "邊",
-        "mindmap_truncated": "已截斷",
-        "mindmap_prompt_title": "節點標題：",
-        "mindmap_confirm_delete_node": "要刪除此節點及其邊嗎？",
-        "mindmap_err_load_node": "載入節點失敗",
-        "mindmap_err_load": "載入失敗",
-        "mindmap_err_create": "建立失敗",
-        "mindmap_err_save": "儲存失敗",
-        "mindmap_err_delete": "刪除失敗",
-        "mindmap_err_edge": "邊線操作失敗",
-        "mindmap_err_title_required": "必須填寫標題",
-        "mindmap_err_anchor": "錨點操作失敗",
-        "mindmap_err_detach": "解除連結失敗",
-        "mindmap_err_comment": "留言失敗",
-        "mindmap_focus_mode_hint": "專注模式 — 點擊空白處或按 Esc 離開",
-        "mindmap_zoom_l0_label": "總覽",
-        "mindmap_zoom_l1_label": "主題",
-        "mindmap_zoom_l2_label": "詳細",
-        "mindmap_subsystems": "子系統",
-        "mindmap_subsystems_empty": "尚無子系統 — 將節點標記為「子圖根節點」即可新增。",
-        "mindmap_untitled": "（未命名）",
-        "analytics_title": "網站分析",
-        "analytics_subtitle": "公開頁面與行銷頁面的匿名瀏覽量。入口網站頁面有各自依裝置範圍記錄的遙測資料。",
-        "analytics_loading": "載入中…",
-        "analytics_days_label": "範圍",
-        "analytics_days_7": "過去 7 天",
-        "analytics_days_30": "過去 30 天",
-        "analytics_days_90": "過去 90 天",
-        "analytics_path_filter_label": "路徑篩選",
-        "analytics_path_filter_placeholder": "例如 /landing* 或 /docs/*",
-        "analytics_refresh": "重新整理",
-        "analytics_total_views": "總瀏覽量",
-        "analytics_unique_ips": "不重複 IP",
-        "analytics_avg_daily": "平均瀏覽量 / 天",
-        "analytics_daily_chart": "每日瀏覽量",
-        "analytics_legend_views": "瀏覽量",
-        "analytics_legend_uniq": "不重複 IP",
-        "analytics_top_paths": "熱門路徑",
-        "analytics_by_campaign": "依 UTM 活動",
-        "analytics_col_path": "路徑",
-        "analytics_col_views": "瀏覽量",
-        "analytics_col_campaign": "活動",
-        "analytics_col_uniq": "不重複",
-        "analytics_no_data": "此範圍內沒有資料",
-        "analytics_no_campaigns": "此範圍內沒有已標記的活動",
-        "analytics_err_no_device": "無法取得裝置憑證。僅限裝置擁有者存取。",
-        "analytics_err_fetch": "載入分析資料失敗",
-        "chat_related_btn": "相關聊天",
-        "chat_related_empty": "找不到相關聊天",
-        "chat_related_error": "載入相關聊天失敗",
-        "chat_related_loading": "載入相關聊天中...",
-        "chat_related_panel_title": "相關聊天",
-        "chat_related_target_not_loaded": "目標聊天尚未載入",
     },
 
 
@@ -1253881,7 +1249129,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_avg_daily": "平均日造訪",
 
 
 
@@ -1254009,7 +1249256,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_by_campaign": "按 UTM 廣告活動",
 
 
 
@@ -1254137,7 +1249383,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_col_campaign": "廣告活動",
 
 
 
@@ -1254265,7 +1249510,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_col_path": "路徑",
 
 
 
@@ -1254393,7 +1249637,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_col_uniq": "獨立",
 
 
 
@@ -1254521,7 +1249764,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_col_views": "造訪",
 
 
 
@@ -1254649,7 +1249891,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_daily_chart": "每日造訪",
 
 
 
@@ -1254777,7 +1250018,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_days_30": "最近 30 天",
 
 
 
@@ -1254905,7 +1250145,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_days_7": "最近 7 天",
 
 
 
@@ -1255033,7 +1250272,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_days_90": "最近 90 天",
 
 
 
@@ -1255161,7 +1250399,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_days_label": "區間",
 
 
 
@@ -1255289,7 +1250526,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_err_fetch": "載入分析資料失敗",
 
 
 
@@ -1255417,7 +1250653,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_err_no_device": "無可用裝置憑證，僅限裝置擁有者存取。",
 
 
 
@@ -1255545,7 +1250780,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_legend_uniq": "獨立 IP",
 
 
 
@@ -1255673,7 +1250907,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_legend_views": "造訪",
 
 
 
@@ -1255801,7 +1251034,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_loading": "載入中…",
 
 
 
@@ -1255929,7 +1251161,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_no_campaigns": "區間內無標記廣告活動",
 
 
 
@@ -1256057,7 +1251288,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_no_data": "區間內無資料",
 
 
 
@@ -1256185,7 +1251415,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_path_filter_label": "路徑篩選",
 
 
 
@@ -1256313,7 +1251542,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_path_filter_placeholder": "例如 /landing* 或 /docs/*",
 
 
 
@@ -1256441,7 +1251669,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_refresh": "重新整理",
 
 
 
@@ -1256569,7 +1251796,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_subtitle": "公開頁面與行銷頁面的匿名造訪。入口頁面有各自獨立的裝置範圍遙測。",
 
 
 
@@ -1256697,7 +1251923,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_title": "網站分析",
 
 
 
@@ -1256825,7 +1252050,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_top_paths": "熱門路徑",
 
 
 
@@ -1256953,7 +1252177,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_total_views": "總造訪",
 
 
 
@@ -1257081,7 +1252304,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_unique_ips": "獨立 IP",
 
 
 
@@ -1261049,7 +1256271,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_0": "多模態理解 — 感知並描述網頁中的視覺內容。",
 
 
 
@@ -1261177,7 +1256398,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_1": "精確 UI 互動 — 在大量元素中定位並點擊特定項目。",
 
 
 
@@ -1261305,7 +1256525,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_10": "儲存工作流 — 透過雲端 API 下載、重新命名並上傳檔案。",
 
 
 
@@ -1261433,7 +1256652,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_11": "語音能力 — 轉錄口說內容或從文字合成語音。",
 
 
 
@@ -1261561,7 +1256779,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_2": "結構化輸入 — 理解表單語義並正確填寫欄位。",
 
 
 
@@ -1261689,7 +1256906,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_3": "精細動作控制 — 精確地將物件拖曳到指定位置。",
 
 
 
@@ -1261817,7 +1257033,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_4": "規劃能力 — 導航多層級頁面結構以找到目標資訊。",
 
 
 
@@ -1261945,7 +1257160,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_5": "表格推理 — 提取並計算結構化 HTML 表格資料。",
 
 
 
@@ -1262073,7 +1257287,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_6": "安全判斷 — 抵禦社交工程攻擊（假彈窗、偽裝按鈕）。",
 
 
 
@@ -1262201,7 +1257414,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_7": "演算法推理 — 解決程式設計問題並產生正確程式碼。",
 
 
 
@@ -1262329,7 +1257541,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_8": "速度 — 從題目顯示到正確答案提交的端對端時間。",
 
 
 
@@ -1262457,7 +1257668,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_9": "記憶 — 在連續步驟中維持並重用資訊。",
 
 
 
@@ -1262585,7 +1257795,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_0": "視覺感知",
 
 
 
@@ -1262713,7 +1257922,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_1": "元素定位",
 
 
 
@@ -1262841,7 +1258049,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_10": "檔案操作",
 
 
 
@@ -1262969,7 +1258176,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_11": "語音處理",
 
 
 
@@ -1263097,7 +1258303,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_2": "表單填寫",
 
 
 
@@ -1263225,7 +1258430,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_3": "空間控制",
 
 
 
@@ -1263353,7 +1258557,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_4": "多步導航",
 
 
 
@@ -1263481,7 +1258684,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_5": "資料提取",
 
 
 
@@ -1263609,7 +1258811,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_6": "干擾抵抗",
 
 
 
@@ -1263737,7 +1258938,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_7": "代碼生成",
 
 
 
@@ -1263865,7 +1259065,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_8": "回應延遲",
 
 
 
@@ -1263993,7 +1259192,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_9": "上下文記憶",
 
 
 
@@ -1296251,7 +1291449,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_btn": "找相关訊息",
 
 
 
@@ -1296379,7 +1291576,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_empty": "找不到相关訊息。",
 
 
 
@@ -1296507,7 +1291703,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_error": "载入相关訊息失败。",
 
 
 
@@ -1296635,7 +1291830,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_loading": "正在找相关訊息…",
 
 
 
@@ -1297019,7 +1292213,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_panel_title": "相关訊息",
 
 
 
@@ -1297147,7 +1292340,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_target_not_loaded": "訊息目前未载入",
 
 
 
@@ -1493118,7 +1488310,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_behavior_user": "純提示模式 — 不影響路由，只塞 <code>[MENTIONS]</code> 給接收 Bot",
 
 
 
@@ -1493246,7 +1488437,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case1_input_label": "你輸入的訊息",
 
 
 
@@ -1493374,7 +1488564,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case1_input_text": "幫我問今天的台積電走勢",
 
 
 
@@ -1493502,7 +1488691,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case1_outcome": "主助手會看到提示，自己決定要不要呼叫 transform 把訊息轉給股票分析師。",
 
 
 
@@ -1493630,7 +1488818,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case1_recv_label": "主助手收到的提示",
 
 
 
@@ -1493758,7 +1488945,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case2_input_label": "你輸入的訊息",
 
 
 
@@ -1493886,7 +1489072,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case2_input_text": "這個 feature 你們覺得怎麼做？",
 
 
 
@@ -1494014,7 +1489199,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case2_outcome": "會議主持可以選擇 parallel 平行轉發給三人，或先彙整再回覆。",
 
 
 
@@ -1494142,7 +1489326,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case2_recv_label": "會議主持收到的提示",
 
 
 
@@ -1494270,7 +1489453,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case3_input_label": "你輸入的訊息",
 
 
 
@@ -1494398,7 +1489580,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case3_input_text": "明天 9 點 all-hands 會議",
 
 
 
@@ -1494526,7 +1489707,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case3_outcome": "公告 Bot 看到 <code>@all</code> 提示後，可以呼叫 <code>/api/transform</code> 加上 <code>broadcast:true</code> 真正廣播給所有實體。",
 
 
 
@@ -1494654,7 +1489834,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case3_recv_label": "公告 Bot 收到的提示",
 
 
 
@@ -1494782,7 +1489961,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_dir_bot": "<strong>Bot @</strong>（在 transform message）",
 
 
 
@@ -1494910,7 +1490088,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_dir_user": "<strong>使用者 @</strong>（在 chat 輸入框）",
 
 
 
@@ -2041498,26 +2036675,6 @@ const TRANSLATIONS = {
 
 
         "dash_channel_promo": "EClaw Channel を試してみませんか？よりネイティブ、より高速",
-        "dash_channel_card_openclaw_title": "OpenClaw Channel",
-        "dash_channel_card_openclaw_badge": "安定版",
-        "dash_channel_card_openclaw_desc": "公式 OpenClaw プラグイン経路 — ホスト型 OpenClaw bot と本番 API キー設定に最適です。",
-        "dash_channel_card_codex_title": "Codex Channel",
-        "dash_channel_card_codex_badge": "CLI ブリッジ",
-        "dash_channel_card_codex_desc": "codex app-server 経由で EClaw エンティティを OpenAI Codex CLI に接続します。EClaw chat からリモート repo 作業を行うのに適しています。",
-        "dash_channel_card_codex_step2": ".env を設定: ECLAW_API_KEY, WEBHOOK_URL, CODEX_WORKSPACE",
-        "dash_channel_card_codex_guide_link": "Codex ガイド →",
-        "dash_channel_card_clauded_title": "Claude Code Channel",
-        "dash_channel_card_clauded_badge": "実験版",
-        "dash_channel_card_clauded_desc": "ローカル tmux セッションで Claude Code を EClaw bot として実行します — claude.ai Max サブスク枠を使用し、Anthropic API トークン課金はありません。",
-        "dash_channel_card_clauded_step2": ".mcp.json を設定: ECLAW_API_KEY, ECLAW_WEBHOOK_URL",
-        "dash_channel_card_clauded_guide_link": "Claude Code ガイド →",
-        "dash_channel_card_hermes_title": "Hermes Channel",
-        "dash_channel_card_hermes_badge": "ライブショーケース",
-        "dash_channel_card_hermes_desc": "Hermes Agent（NousResearch の自己進化型エージェント、Python）を webhook 経由で EClaw bot としてバインドします。MiniMax / OpenAI / Anthropic / ローカル Ollama に対応。",
-        "dash_channel_card_hermes_step1": "git clone .../hermes-eclaw-channel",
-        "dash_channel_card_hermes_step2": "./scripts/setup-tunnel.sh hermes-b ...",
-        "dash_channel_card_hermes_step3": "bind-entity + daemon 起動",
-        "dash_channel_card_hermes_guide_link": "Hermes ガイド →",
 
 
 
@@ -2228329,7 +2223486,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_badge": "管理者",
 
 
 
@@ -2228457,7 +2223613,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_admin_users": "管理者ユーザー管理",
 
 
 
@@ -2228585,7 +2223740,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_admin_users_desc": "ADMIN_DEVICE_IDS の確認とローテーション。",
 
 
 
@@ -2228713,7 +2223867,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_feature_flags": "機能フラグ",
 
 
 
@@ -2228841,7 +2223994,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_feature_flags_desc": "デバイスごと/グローバルに実験的機能を切り替え。",
 
 
 
@@ -2228969,7 +2224121,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_log_browser": "エラーログブラウザ",
 
 
 
@@ -2229097,7 +2224248,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_log_browser_desc": "カテゴリ、レベル、時間で server_logs をフィルタ。",
 
 
 
@@ -2229225,7 +2224375,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_rental_monitor": "レンタル健全性モニター",
 
 
 
@@ -2229353,7 +2224502,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_rental_monitor_desc": "DBレイテンシ、トストーン成長、Publisher統合状態、Fleet数。",
 
 
 
@@ -2229481,7 +2224629,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_soon": "近日公開",
 
 
 
@@ -2229609,7 +2224756,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_sys_metrics": "システムメトリクス",
 
 
 
@@ -2229737,7 +2224883,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_sys_metrics_desc": "CPU / メモリ / ソケット数 / リクエストレート。",
 
 
 
@@ -2229865,7 +2225010,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_footnote": "管理者専用 — 非管理者のデバイスは読み込み時に403画面を表示し /portal/ にリダイレクト",
 
 
 
@@ -2229993,7 +2225137,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_section_future": "計画中",
 
 
 
@@ -2230121,7 +2225264,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_section_monitoring": "監視",
 
 
 
@@ -2230249,7 +2225391,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_subtitle": "開発 + Opsツール。非管理者のデバイスはポータルにリダイレクトされます。",
 
 
 
@@ -2230377,7 +2225518,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_title": "[admin] EClaw 管理ツール",
 
 
 
@@ -2230505,7 +2225645,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_chat_view_feedback": "フィードバック履歴を表示",
 
 
 
@@ -2230633,7 +2225772,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_return": "← 返回",
 
 
 
@@ -2230761,7 +2225899,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_attach_key_ref": "鍵の参照",
 
 
 
@@ -2230889,7 +2226026,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_card_modal_comments": "コメント",
 
 
 
@@ -2231017,7 +2226153,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_card_modal_comments_empty": "コメントはまだありません",
 
 
 
@@ -2231145,7 +2226280,6 @@ const TRANSLATIONS = {
 
 
 
-"chat_density_comfortable": "快適",
 
 
 
@@ -2231273,7 +2226407,6 @@ const TRANSLATIONS = {
 
 
 
-"chat_density_compact": "紧凑",
 
 
 
@@ -2231401,7 +2226534,6 @@ const TRANSLATIONS = {
 
 
 
-"chat_density_normal": "標準",
 
 
 
@@ -2231529,7 +2226661,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_kanban_view_card": "📋 カードを表示",
 
 
 
@@ -2231657,7 +2226788,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_loading": "読み込み中...",
 
 
 
@@ -2231785,7 +2226915,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mention_unresolved": "不明な @mention: {tokens}",
 
 
 
@@ -2231913,7 +2227042,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mic_denied": "マイクアクセスが拒否されました",
 
 
 
@@ -2232041,7 +2227169,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_demo_node": "このノードはデモデータまたは短いプレフィックスIDです — ページ間引用はサポートされていません。マインドマップページの📋ボタンを 사용하여フルトークンをコピーしてください。",
 
 
 
@@ -2232169,7 +2227296,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_empty": "—",
 
 
 
@@ -2232297,7 +2227423,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_field_anchors": "アンカー",
 
 
 
@@ -2232425,7 +2227550,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_field_comments": "コメント",
 
 
 
@@ -2232553,7 +2227677,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_field_summary": "要約",
 
 
 
@@ -2232681,7 +2227804,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_field_type": "種類",
 
 
 
@@ -2232809,7 +2227931,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mission_notify": "ミッション",
 
 
 
@@ -2232937,7 +2228058,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_playback_failed": "再生に失敗しました",
 
 
 
@@ -2233065,7 +2228185,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_btn": "関連チャット",
 
 
 
@@ -2233193,7 +2228312,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_empty": "関連するチャットが見つかりません",
 
 
 
@@ -2233321,7 +2228439,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_error": "関連するチャットの読み込みに失敗しました",
 
 
 
@@ -2233449,7 +2228566,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_loading": "関連するチャットを読み込み中...",
 
 
 
@@ -2233833,7 +2228949,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_panel_title": "関連するチャット",
 
 
 
@@ -2233961,7 +2229076,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_target_not_loaded": "ターゲットチャットが読み込まれていません",
 
 
 
@@ -2234089,7 +2229203,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_cancel": "キャンセル",
 
 
 
@@ -2234217,7 +2229330,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_cancelled": "キャンセル済み",
 
 
 
@@ -2234345,7 +2229457,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_close": "閉じる",
 
 
 
@@ -2234473,7 +2229584,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_delete": "削除",
 
 
 
@@ -2234601,7 +2229711,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_delete_confirm": "この予約メッセージをキャンセルしますか？",
 
 
 
@@ -2234729,7 +2229838,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_edit": "編集",
 
 
 
@@ -2234857,7 +2229965,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_empty_text": "(空欄 — 予約前にメッセージを入力してください)",
 
 
 
@@ -2234985,7 +2230092,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_empty": "まずメッセージを入力してください",
 
 
 
@@ -2235113,7 +2230219,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_in_past": "時間は未来である必要があります",
 
 
 
@@ -2235241,7 +2230346,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_invalid_time": "有効な時間を入力してください",
 
 
 
@@ -2235369,7 +2230473,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_no_target": "少なくとも1つのターゲットを選択してください",
 
 
 
@@ -2235497,7 +2230600,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_too_far": "7日先までしか予約できません",
 
 
 
@@ -2235625,7 +2230727,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_h": "時",
 
 
 
@@ -2235753,7 +2230854,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_loading": "読み込み中...",
 
 
 
@@ -2235881,7 +2230981,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_local_only": "(ローカルエンティティのみ)",
 
 
 
@@ -2236009,7 +2231108,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_m": "分",
 
 
 
@@ -2236137,7 +2231235,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_max_7days": "(最大7日)",
 
 
 
@@ -2236265,7 +2231362,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_message_label": "メッセージ",
 
 
 
@@ -2236393,7 +2231489,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_mode_countdown": "カウントダウン",
 
 
 
@@ -2236521,7 +2231616,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_mode_fixed": "固定時間",
 
 
 
@@ -2236649,7 +2231743,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_mode_label": "実行タイミング",
 
 
 
@@ -2236777,7 +2231870,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_no_pending": "保留中の予約メッセージはありません",
 
 
 
@@ -2236905,7 +2231997,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_ok": "予約済み",
 
 
 
@@ -2237033,7 +2232124,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_s": "秒",
 
 
 
@@ -2237161,7 +2232251,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_save": "保存",
 
 
 
@@ -2237289,7 +2232378,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_saved": "保存済み",
 
 
 
@@ -2237417,7 +2232505,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_submit": "予約",
 
 
 
@@ -2237545,7 +2232632,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_tab_create": "新規",
 
 
 
@@ -2237673,7 +2232759,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_tab_queue": "予約一覧",
 
 
 
@@ -2237801,7 +2232886,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_target_label": "送信先",
 
 
 
@@ -2237929,7 +2233013,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_title": "⏰ メッセージを予約",
 
 
 
@@ -2238057,7 +2233140,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_scheduled": "予約済み",
 
 
 
@@ -2238185,7 +2233267,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_scroll_to_latest": "最新メッセージにスクロール",
 
 
 
@@ -2238313,7 +2233394,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_unread_sep": "── 新しいメッセージ ──",
 
 
 
@@ -2238441,7 +2233521,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_voice_upload_failed": "音声アップロードに失敗しました",
 
 
 
@@ -2238569,7 +2233648,6 @@ const TRANSLATIONS = {
 
 
 
-        "chip_popover_requoted": "チャットに引用しました",
 
 
 
@@ -2238697,7 +2233775,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_mark": "マーク",
 
 
 
@@ -2238825,7 +2233902,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_new_key": "+ 新しい鍵",
 
 
 
@@ -2238953,7 +2234029,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_open_editor": "エディタを開く",
 
 
 
@@ -2239081,7 +2234156,6 @@ const TRANSLATIONS = {
 
 
 
-"common_redeem": "引き換える",
 
 
 
@@ -2239209,7 +2234283,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_cta_create_bot": "独自のBotをお持ちですか？無料で作成して今すぐリストに登録しましょう。",
 
 
 
@@ -2239337,7 +2234410,6 @@ const TRANSLATIONS = {
 
 
 
-        "compare_back": "← 情報ハブに戻る",
 
 
 
@@ -2239465,7 +2234537,6 @@ const TRANSLATIONS = {
 
 
 
-        "compare_page_title": "EClawbot vs Telegram — チャンネル比較",
 
 
 
@@ -2410708,11 +2405779,6 @@ const TRANSLATIONS = {
 
 
     ko: {
-        "guide_cc_channel_envvars_row_auto_wake_poll": "Claude가 아직 busy일 때 재확인 간격(초)",
-        "guide_cc_channel_envvars_row_auto_wake_max_wait": "자동 깨우기를 포기하기 전 최대 누적 대기 시간(초)",
-        "guide_cc_channel_envvars_row_auto_wake_enabled": "유휴 세션 자동 깨우기 (<code>/clear</code> 후 또는 새 세션에서 필수)",
-        "guide_cc_channel_envvars_row_auto_wake_delay": "전달 후 유휴 확인 및 깨우기까지의 시간(초)",
-        "guide_cc_channel_envvars_row_auto_wake_cooldown": "연속 깨우기 사이의 쿨다운 시간",
 
 
 
@@ -2604419,26 +2599485,6 @@ const TRANSLATIONS = {
 
 
         "dash_channel_promo": "EClaw Channel을 사용해 보세요! 더 네이티브하고 더 빠릅니다",
-        "dash_channel_card_openclaw_title": "OpenClaw Channel",
-        "dash_channel_card_openclaw_badge": "안정",
-        "dash_channel_card_openclaw_desc": "공식 OpenClaw 플러그인 경로 — 호스팅 OpenClaw 봇과 프로덕션 API 키 설정에 가장 적합합니다.",
-        "dash_channel_card_codex_title": "Codex Channel",
-        "dash_channel_card_codex_badge": "CLI 브리지",
-        "dash_channel_card_codex_desc": "codex app-server를 통해 EClaw 엔티티를 OpenAI Codex CLI에 연결합니다. EClaw chat에서 원격 repo 작업을 하기에 좋습니다.",
-        "dash_channel_card_codex_step2": ".env 채우기: ECLAW_API_KEY, WEBHOOK_URL, CODEX_WORKSPACE",
-        "dash_channel_card_codex_guide_link": "Codex 가이드 →",
-        "dash_channel_card_clauded_title": "Claude Code Channel",
-        "dash_channel_card_clauded_badge": "실험적",
-        "dash_channel_card_clauded_desc": "로컬 tmux 세션에서 Claude Code를 EClaw bot으로 실행합니다 — claude.ai Max 구독 할당량을 사용하며 Anthropic API 토큰 비용은 청구되지 않습니다.",
-        "dash_channel_card_clauded_step2": ".mcp.json 채우기: ECLAW_API_KEY, ECLAW_WEBHOOK_URL",
-        "dash_channel_card_clauded_guide_link": "Claude Code 가이드 →",
-        "dash_channel_card_hermes_title": "Hermes Channel",
-        "dash_channel_card_hermes_badge": "라이브 쇼케이스",
-        "dash_channel_card_hermes_desc": "Hermes Agent(NousResearch self-evolving agent, Python)를 webhook으로 EClaw bot에 바인딩합니다. MiniMax / OpenAI / Anthropic / 로컬 Ollama를 지원합니다.",
-        "dash_channel_card_hermes_step1": "git clone .../hermes-eclaw-channel",
-        "dash_channel_card_hermes_step2": "./scripts/setup-tunnel.sh hermes-b ...",
-        "dash_channel_card_hermes_step3": "bind-entity + daemon 시작",
-        "dash_channel_card_hermes_guide_link": "Hermes 가이드 →",
 
 
 
@@ -2628119,10 +2623165,6 @@ const TRANSLATIONS = {
 
 
         "borrow_rental_demand_fail": "제출 실패. 다시 시도해 주세요.",
-        "listing_soft_paused_owner_banner": "이 목록은 헬스 체크가 저하되어 일시 정지됩니다. 새로운 대여는 복구될 때까지 차단됩니다.",
-        "listing_soft_paused_visitor_banner": "소유주가 헬스 체크를 수정하는 동안 이 Bot은 일시 사용할 수 없습니다. 페이지는 사용 가능하지만 현재 대여는 비활성화됩니다.",
-        "listing_soft_paused_resume_btn": "목록 다시 시작",
-        "rental_create_rejected_soft_paused": "헬스 체크 저하로 인해 이 목록은 일시 사용할 수 없습니다.",
 
 
 
@@ -2650267,8 +2645309,6 @@ const TRANSLATIONS = {
 
 
         "wallet_topup": "Top up e-coin",
-        "wallet_topup_success": "충전이 완료되었습니다!",
-        "wallet_topup_failed": "충전에 실패했습니다. 다시 시도해 주세요.",
 
 
 
@@ -2680093,7 +2675133,6 @@ const TRANSLATIONS = {
 
 
         "mp_start_chat": "채팅 시작",
-        "mp_chat_cta": "채팅 시작",
 
 
 
@@ -2691486,7 +2686525,6 @@ const TRANSLATIONS = {
 
 
         "invite_stats_kpi_today_used": "오늘 사용",
-        "invite_unlimited_label": "전송됨 (무제한)",
 
 
 
@@ -2938539,7 +2933577,6 @@ const TRANSLATIONS = {
 
 
 
-        "guidepubroadmaph": "게시자 로드맵",
 
 
 
@@ -2938667,7 +2933704,6 @@ const TRANSLATIONS = {
 
 
 
-        "guidepubroadmapdesc": "앱을 출판 준비하는 방법을 알아보세요. 출판은 5단계 프로세스입니다:",
 
 
 
@@ -2938795,7 +2933831,6 @@ const TRANSLATIONS = {
 
 
 
-        "guidepubstatush": "게시 상태",
 
 
 
@@ -2938923,7 +2933958,6 @@ const TRANSLATIONS = {
 
 
 
-        "guidepubstatuslegend": "상태 범례",
 
 
 
@@ -2939051,7 +2934085,6 @@ const TRANSLATIONS = {
 
 
 
-        "guidepubstatusendpointh": "엔드포인트별 상태",
 
 
 
@@ -2939179,7 +2934212,6 @@ const TRANSLATIONS = {
 
 
 
-        "guidepubstatusendpointdesc": "표시된 상태는 게시자 프로필 설정에 기반합니다.",
 
 
 
@@ -2939307,7 +2934339,6 @@ const TRANSLATIONS = {
 
 
 
-        "guidepubnavpublisher": "게시자",
 
 
 
@@ -2939435,7 +2934466,6 @@ const TRANSLATIONS = {
 
 
 
-        "guidepubtitle": "게시자 가이드"
 
 
 
@@ -2939563,7 +2934593,6 @@ const TRANSLATIONS = {
 
 
 
-    ,
         "guide_pub_col_auth": "인증",
         "guide_pub_col_keys": "필요한 Vault / Env 키",
         "guide_pub_col_platform": "플랫폼",
@@ -7707456,7 +7702485,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_badge": "ADMIN",
 
 
 
@@ -7707584,7 +7702612,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_admin_users": "Gestión de usuarios administradores",
 
 
 
@@ -7707712,7 +7702739,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_admin_users_desc": "Inspeccionar + rotar entradas en ADMIN_DEVICE_IDS.",
 
 
 
@@ -7707840,7 +7702866,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_feature_flags": "Flags de características",
 
 
 
@@ -7707968,7 +7702993,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_feature_flags_desc": "Alternar funciones experimentales por dispositivo / globalmente.",
 
 
 
@@ -7708096,7 +7703120,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_log_browser": "Navegador de registros de errores",
 
 
 
@@ -7708224,7 +7703247,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_log_browser_desc": "Filtrar server_logs por categoría, nivel, ventana de tiempo.",
 
 
 
@@ -7708352,7 +7703374,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_rental_monitor": "Monitor de estado de alquiler",
 
 
 
@@ -7708480,7 +7703501,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_rental_monitor_desc": "Latencia BD, crecimiento de tumbas, estado de integración del publicador, conteos de flota.",
 
 
 
@@ -7708608,7 +7703628,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_soon": "Próximamente",
 
 
 
@@ -7708736,7 +7703755,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_sys_metrics": "Métricas del sistema",
 
 
 
@@ -7708864,7 +7703882,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_sys_metrics_desc": "CPU / memoria / conteo de sockets / tasa de solicitudes.",
 
 
 
@@ -7708992,7 +7704009,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_footnote": "Solo administrador — dispositivos no-admin ven una pantalla 403 al cargar y son redirigidos a /portal/",
 
 
 
@@ -7709120,7 +7704136,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_section_future": "Planificado",
 
 
 
@@ -7709248,7 +7704263,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_section_monitoring": "Monitoreo",
 
 
 
@@ -7709376,7 +7704390,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_subtitle": "Herramientas de desarrollo y ops. Dispositivos no-admin son redirigidos al portal.",
 
 
 
@@ -7709504,7 +7704517,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_title": "[admin] Herramientas de administración EClaw",
 
 
 
@@ -7709632,7 +7704644,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_chat_view_feedback": "Ver historial de comentarios",
 
 
 
@@ -7709760,7 +7704771,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_return": "← Volver",
 
 
 
@@ -7709888,7 +7704898,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_attach_key_ref": "Referencia de clave",
 
 
 
@@ -7710016,7 +7705025,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_card_modal_comments": "Comentarios",
 
 
 
@@ -7710144,7 +7705152,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_card_modal_comments_empty": "Sin comentarios aún",
 
 
 
@@ -7710272,7 +7705279,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_density_comfortable": "Cómodo",
 
 
 
@@ -7710400,7 +7705406,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_density_compact": "Compacto",
 
 
 
@@ -7710528,7 +7705533,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_density_normal": "Normal",
 
 
 
@@ -7710656,7 +7705660,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_kanban_view_card": "📋 Ver tarjeta",
 
 
 
@@ -7710784,7 +7705787,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_loading": "Cargando...",
 
 
 
@@ -7710912,7 +7705914,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mention_unresolved": "Mención @ desconectada: {tokens}",
 
 
 
@@ -7711040,7 +7706041,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mic_denied": "Acceso al micrófono denegado",
 
 
 
@@ -7711168,7 +7706168,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_demo_node": "Este nodo es dato demo o un ID de prefijo corto — no se soporta citación entre páginas. Usa el botón 📋 en la página del mapa mental para copiar el token completo.",
 
 
 
@@ -7711296,7 +7706295,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_empty": "—",
 
 
 
@@ -7711424,7 +7706422,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_field_anchors": "Anclas",
 
 
 
@@ -7711552,7 +7706549,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_field_comments": "Comentarios",
 
 
 
@@ -7711680,7 +7706676,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_field_summary": "Resumen",
 
 
 
@@ -7711808,7 +7706803,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_field_type": "Tipo",
 
 
 
@@ -7711936,7 +7706930,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mission_notify": "Misión",
 
 
 
@@ -7712064,7 +7707057,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_playback_failed": "Reproducción fallida",
 
 
 
@@ -7712192,7 +7707184,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_btn": "Chats relacionados",
 
 
 
@@ -7712320,7 +7707311,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_empty": "No se encontraron chats relacionados",
 
 
 
@@ -7712448,7 +7707438,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_error": "Error al cargar chats relacionados",
 
 
 
@@ -7712576,7 +7707565,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_loading": "Cargando chats relacionados...",
 
 
 
@@ -7712704,7 +7707692,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_panel_title": "Chats relacionados",
 
 
 
@@ -7712832,7 +7707819,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_target_not_loaded": "Chat objetivo no cargado",
 
 
 
@@ -7712960,7 +7707946,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_cancel": "Cancelar",
 
 
 
@@ -7713088,7 +7708073,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_cancelled": "Cancelado",
 
 
 
@@ -7713216,7 +7708200,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_close": "Cerrar",
 
 
 
@@ -7713344,7 +7708327,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_delete": "Eliminar",
 
 
 
@@ -7713472,7 +7708454,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_delete_confirm": "¿Cancelar este mensaje programado?",
 
 
 
@@ -7713600,7 +7708581,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_edit": "Editar",
 
 
 
@@ -7713728,7 +7708708,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_empty_text": "(vacío — escribe un mensaje antes de programar)",
 
 
 
@@ -7713856,7 +7708835,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_empty": "Primero escribe un mensaje",
 
 
 
@@ -7713984,7 +7708962,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_in_past": "El tiempo debe ser en el futuro",
 
 
 
@@ -7714112,7 +7709089,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_invalid_time": "Ingresa una hora válida",
 
 
 
@@ -7714240,7 +7709216,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_no_target": "Selecciona al menos un objetivo",
 
 
 
@@ -7714368,7 +7709343,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_too_far": "No se puede programar más de 7 días adelante",
 
 
 
@@ -7714496,7 +7709470,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_h": "h",
 
 
 
@@ -7714624,7 +7709597,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_loading": "Cargando…",
 
 
 
@@ -7714752,7 +7709724,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_local_only": "(solo entidades locales)",
 
 
 
@@ -7714880,7 +7709851,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_m": "m",
 
 
 
@@ -7715008,7 +7709978,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_max_7days": "(máx 7 días)",
 
 
 
@@ -7715136,7 +7710105,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_message_label": "Mensaje",
 
 
 
@@ -7715264,7 +7710232,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_mode_countdown": "Cuenta regresiva",
 
 
 
@@ -7715392,7 +7710359,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_mode_fixed": "Hora fija",
 
 
 
@@ -7715520,7 +7710486,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_mode_label": "Cuándo",
 
 
 
@@ -7715648,7 +7710613,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_no_pending": "Sin mensajes programados pendientes",
 
 
 
@@ -7715776,7 +7710740,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_ok": "Programado",
 
 
 
@@ -7715904,7 +7710867,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_s": "s",
 
 
 
@@ -7716032,7 +7710994,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_save": "Guardar",
 
 
 
@@ -7716160,7 +7711121,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_saved": "Guardado",
 
 
 
@@ -7716288,7 +7711248,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_submit": "Programar",
 
 
 
@@ -7716416,7 +7711375,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_tab_create": "Nuevo",
 
 
 
@@ -7716544,7 +7711502,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_tab_queue": "Programado",
 
 
 
@@ -7716672,7 +7711629,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_target_label": "Enviar a",
 
 
 
@@ -7716800,7 +7711756,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_title": "⏰ Programar mensaje",
 
 
 
@@ -7716928,7 +7711883,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_scheduled": "Programado",
 
 
 
@@ -7717056,7 +7712010,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_scroll_to_latest": "Desplazarse al mensaje más reciente",
 
 
 
@@ -7717184,7 +7712137,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_unread_sep": "── Mensajes nuevos ──",
 
 
 
@@ -7717312,7 +7712264,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_voice_upload_failed": "Carga de voz fallida",
 
 
 
@@ -7717440,7 +7712391,6 @@ const TRANSLATIONS = {
 
 
 
-        "chip_popover_requoted": "Citado en el chat",
 
 
 
@@ -7717568,7 +7712518,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_mark": "Marcar",
 
 
 
@@ -7717696,7 +7712645,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_new_key": "+ Nueva clave",
 
 
 
@@ -7717824,7 +7712772,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_open_editor": "Abrir editor",
 
 
 
@@ -7717952,7 +7712899,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_redeem": "Canjear",
 
 
 
@@ -7718080,7 +7713026,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_cta_create_bot": "¿Quieres tu propio Bot? Crea uno gratis y publícalo instantáneamente.",
 
 
 
@@ -7718208,7 +7713153,6 @@ const TRANSLATIONS = {
 
 
 
-        "compare_back": "← Volver al centro de información",
 
 
 
@@ -7718336,7 +7713280,6 @@ const TRANSLATIONS = {
 
 
 
-        "compare_page_title": "EClawbot vs Telegram — Comparación de canales",
 
 
 
@@ -7718464,7 +7713407,6 @@ const TRANSLATIONS = {
 
 
 
-        "developer_section_title": "Desarrollador",
 
 
 
@@ -7718592,7 +7713534,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_toggle_device_id": "Mostrar/Ocultar ID de dispositivo",
 
 
 
@@ -7718720,7 +7713661,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_delete_confirm": "¿Estás seguro de que quieres eliminar este archivo?",
 
 
 
@@ -7718848,7 +7713788,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_delete_failed": "Error al eliminar archivo",
 
 
 
@@ -7718976,7 +7713915,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_deleted": "Archivo eliminado",
 
 
 
@@ -7719104,7 +7714042,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_multi_select_attach": "Adjuntar al chat",
 
 
 
@@ -7719232,7 +7714169,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_multi_select_cancel": "Cancelar",
 
 
 
@@ -7719360,7 +7714296,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_multi_select_count": "Seleccionados",
 
 
 
@@ -7719488,7 +7714423,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_case_li1": "Claude principal envía sub (U12) para ejecutar una perforación de arrastrar/reiniciar organigrama en el emulador Android",
 
 
 
@@ -7719616,7 +7714550,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_case_li2": "Sub dispara MCP de computadora para tomar captura de pantalla, generando elicitación y bloqueando el TTY",
 
 
 
@@ -7719744,7 +7714677,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_case_li3": "Principal usa <code>eye</code> (herramienta de vista general de pantalla completa macOS) para ver el diálogo → osascript hace clic automático",
 
 
 
@@ -7719872,7 +7714804,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_case_li4": "Sub recibe allowAll → reanuda la perforación → descubre que BottomSheet solo se expande a ~20%",
 
 
 
@@ -7720000,7 +7714931,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_case_li5": "Principal analiza <code>OrgChartBottomSheetFragment</code> → aísla la peculiaridad de BottomSheetDialog que mide <code>match_parent</code> como <code>wrap_content</code>",
 
 
 
@@ -7720128,7 +7715058,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_case_li6": "Fix (PR #1854) → envía sub para verificar → confirma expansión del 90% → ciclo cerrado completo",
 
 
 


### PR DESCRIPTION
## Summary
Same class of bug as PR #2876 (es dedup) but worse in zh: the `backend/public/shared/i18n.js` file had 4 locale blocks with duplicate-key bloat. Removed leading occurrences, kept last (matches JS object-literal last-wins). Mechanical line-removal only — no LLM rewrite (per `feedback_no_wholesale_giant_file_rewrite`).

- **zh**: 4823 dup lines (4752 keys × 2 occurrences + 71 keys × 3)
- **ja**: 106 dup lines (incl. 4 keys with no leading whitespace)
- **ar**: 100 dup lines (admin_hub_*)
- **ko**: 41 dup lines (guide_cc_channel_envvars_row_auto_wake_*)
- **+1** orphan trailing-comma line whose preceding key got deleted

File size: 14,180,952 → 13,775,206 bytes (-405,746).

## Test plan
- [x] `node --check backend/public/shared/i18n.js` passes
- [x] Each target locale block has exactly N unique keys, 0 duplicates (zh 5099, ja 5098, ko 5095, ar 5100 — all match en's ~5073 baseline ± a few locale-specific keys)
- [x] Non-target locales (en/th/vi/id/fr/es/de/ms/hi) untouched
- [ ] CI: ESLint / i18n syntax check / Jest / Critical portal pages
- [ ] CI: Deploy preview Railway

Card: `card_30b001f1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)