### PR TITLE
chore(audit): daily audit — CLAUDE.md update, sitemap dates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1039,8 +1039,13 @@ curl "https://eclawbot.com/api/device-telemetry?deviceId=ID&deviceSecret=SECRET&
 - **Growth Tracking (v1.1168)**: `growth.js` module for admin bot growth metrics; static serving fix
 - **UIUX Audit Script Alignment (v1.1172)**: QA/UIUX audit test scripts aligned with current portal contracts
 
-### Recent Fixes (v1.1172.x+, 2026-05-14 – 2026-05-21)
+### Recent Fixes (v1.1172.x+, 2026-05-14 – 2026-05-22)
 
+- **Channel Binding Persistence Fix**: Await binding persistence to prevent race conditions on channel bind
+- **i18n es Dedup (PR #2876)**: Dedup 20 `dash_channel_card_*` keys in Spanish locale block
+- **WS Upgrade Origin Fix v2 (PR #2875)**: Drop Origin header on server-to-server WS upgrade in setup scripts
+- **Mention CJK Fix (PR #2874)**: Support same-device CJK display-name tags in @mention parsing
+- **WS Memory Disclosure Fix (PR #2872)**: Patch `ws` uninitialized memory disclosure (GHSA-58qx-3vcg-4xpx)
 - **Share-Chat Verify Email i18n (PR #2868/#2870)**: `sc_verify_email*` keys translated for 13 locales (zh-CN, ja, ko, th, vi, id, fr, es, de, ar, ms, hi + 5 more)
 - **Share-Chat Rich CTA (PR #2867)**: Wire rich CTA action buttons to msgInput for share-chat page
 - **Share-Chat Guest Verify Email (PR #2865)**: Guest verify-email modal + disabled Send for unverified users
@@ -1065,7 +1070,7 @@ curl "https://eclawbot.com/api/device-telemetry?deviceId=ID&deviceSecret=SECRET&
 
 ## Test Coverage Summary
 
-**~460 total API routes** across all modules (410 excluding Article Publisher), **~84% covered** by Jest + integration tests (~3003 test cases across 206 Jest files + 59 integration tests).
+**~460 total API routes** across all modules (410 excluding Article Publisher), **~84% covered** by Jest + integration tests (~3007 test cases across 206 Jest files + 59 integration tests).
 
 | Module | Coverage | Notes |
 |--------|----------|-------|

--- a/backend/public/sitemap.xml
+++ b/backend/public/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://eclawbot.com/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-05-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/portal/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-05-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/api/docs</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-05-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/.well-known/agent.json</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-05-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/enterprise</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-05-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -38,37 +38,37 @@
   </url>
   <url>
     <loc>https://eclawbot.com/llms.txt</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-05-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/arena/</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-05-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/portal/community.html</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-05-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/portal/compare.html</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-05-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/promo.html</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-05-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/promo-meta.html</loc>
-    <lastmod>2026-05-21</lastmod>
+    <lastmod>2026-05-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## Summary
- Update test counts: 206 suites / 3007 tests (was 3003)
- Add 5 recent fix entries to CLAUDE.md (channel binding, i18n es dedup, mention CJK, ws security)
- Update sitemap lastmod dates to 2026-05-22

## Test plan
- [x] Jest 206/206 pass, 3007 tests
- [x] i18n-syntax pass
- [x] i18n-check pass (all EN keys resolve)
- [x] No P0/P1 security issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)