### PR TITLE
fix(openclaw-channel): support OpenClaw 2026.5.20

### DIFF
--- a/openclaw-channel-eclaw/README.md
+++ b/openclaw-channel-eclaw/README.md
@@ -35,8 +35,19 @@ channels:
         apiKey: "eck_..."       # From E-Claw Portal → Settings → Channel API
         apiSecret: "ecs_..."    # From E-Claw Portal → Settings → Channel API
         apiBase: "https://eclawbot.com"
+        webhookUrl: "https://your-openclaw-domain.com"  # Base URL only; plugin appends /eclaw-webhook
         entityId: 0             # Entity slot (0-3 free tier, 0-7 premium). Omit to auto-assign.
         botName: "My Bot"       # Display name in E-Claw (max 20 chars)
+```
+
+For OpenClaw `2026.5.20+`, local or side-loaded channel plugins should also be
+explicitly trusted so cold-start validation can resolve the channel before
+runtime code finishes loading:
+
+```yaml
+plugins:
+  allow:
+    - openclaw-channel
 ```
 
 ## Getting API Credentials
@@ -242,6 +253,32 @@ After the script completes, do a **full service restart** from Zeabur Dashboard.
 ### In-process restart (`SIGUSR1`) doesn't apply channel config changes
 
 In-process restart validates the config before loading plugins, so `channels.eclaw` appears as an unknown channel and the restart fails. Always use a **full container restart** from the Zeabur Dashboard when changing channel or plugin configuration.
+
+---
+
+### OpenClaw `2026.5.20+`: local plugin trust and `channelConfigs`
+
+**Problem:**
+After upgrading OpenClaw to `2026.5.20`, OpenClaw warns when a side-loaded
+channel plugin declares `channels: ["eclaw"]` without manifest-owned
+`channelConfigs` metadata, and also warns when a local extension is loaded
+without an explicit `plugins.allow` trust pin. The bot can still start, but
+cold-path config validation, setup UI, and channel discovery may not know the
+shape of `channels.eclaw` before runtime loads.
+
+**Countermeasure:**
+- `openclaw.plugin.json` now mirrors the E-Claw account schema under
+  `channelConfigs.eclaw.schema`.
+- `apiSecret` remains optional for existing channel API-key deployments; do not
+  make it a required manifest field unless every deployed account has been
+  migrated.
+- Add `plugins.allow: ["openclaw-channel"]` to each OpenClaw config that
+  side-loads this extension.
+- Keep `channels.eclaw.accounts.<name>.webhookUrl` as the public base URL only
+  (for example `https://f.eclawbot.com`); the plugin appends
+  `/eclaw-webhook` and logs the full registered callback on startup.
+- After changing plugin trust or channel config, do a full service/container
+  restart and then verify with a browser-side E-Claw chat ACK.
 
 ---
 

--- a/openclaw-channel-eclaw/openclaw.plugin.json
+++ b/openclaw-channel-eclaw/openclaw.plugin.json
@@ -4,6 +4,39 @@
   "version": "1.0.0",
   "description": "E-Claw AI chat platform channel for OpenClaw",
   "channels": ["eclaw"],
+  "channelConfigs": {
+    "eclaw": {
+      "label": "E-Claw",
+      "description": "Connect OpenClaw to E-Claw live wallpaper entities.",
+      "schema": {
+        "type": "object",
+        "additionalProperties": false,
+        "properties": {
+          "accounts": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "enabled": { "type": "boolean", "default": true },
+                "apiKey": { "type": "string", "description": "Channel API Key (eck_...)" },
+                "apiSecret": { "type": "string", "description": "Channel API Secret (ecs_...)" },
+                "apiBase": { "type": "string", "default": "https://eclawbot.com" },
+                "webhookUrl": { "type": "string", "description": "Public OpenClaw base URL; the plugin appends /eclaw-webhook." },
+                "entityId": { "type": "number", "minimum": 0, "maximum": 7, "description": "Optional: entity slot to use (0-7). If omitted, auto-assigned to first free slot." },
+                "botName": { "type": "string", "maxLength": 20 }
+              },
+              "required": ["apiKey"]
+            }
+          }
+        }
+      },
+      "commands": {
+        "nativeCommandsAutoEnabled": true,
+        "nativeSkillsAutoEnabled": true
+      }
+    }
+  },
   "configSchema": {
     "type": "object",
     "properties": {
@@ -16,10 +49,11 @@
             "apiKey": { "type": "string", "description": "Channel API Key (eck_...)" },
             "apiSecret": { "type": "string", "description": "Channel API Secret (ecs_...)" },
             "apiBase": { "type": "string", "default": "https://eclawbot.com" },
+            "webhookUrl": { "type": "string", "description": "Public OpenClaw base URL; the plugin appends /eclaw-webhook." },
             "entityId": { "type": "number", "minimum": 0, "maximum": 7, "description": "Optional: entity slot to use (0-7). If omitted, auto-assigned to first free slot." },
             "botName": { "type": "string", "maxLength": 20 }
           },
-          "required": ["apiKey", "apiSecret"]
+          "required": ["apiKey"]
         }
       }
     }


### PR DESCRIPTION
## Summary
- add channelConfigs.eclaw metadata for latest OpenClaw channel discovery
- keep apiSecret optional for existing API-key deployments
- document plugins.allow and webhookUrl base-URL mitigation for OpenClaw 2026.5.20+

## Verification
- npm run lint
- npm run build
- manifest JSON parse check
- #1 OpenClaw upgraded to 2026.5.20 and browser chat ACK verified