### PR TITLE
feat(usage-api): /api/usage/{snapshot,timeline} + usage_snapshots table (Plan B Phase 1)

### DIFF
--- a/backend/apply_usage_snapshots_migration.js
+++ b/backend/apply_usage_snapshots_migration.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+
+/**
+ * Apply usage_snapshots migration (Plan B Phase 1).
+ *
+ * Creates the usage_snapshots table used by /api/usage/* endpoints
+ * to store per-device Claude Code / Codex CLI spend snapshots pushed
+ * by the local mac-daemon (~60s cadence).
+ *
+ * Run locally:
+ *   cd backend && node apply_usage_snapshots_migration.js
+ *
+ * Idempotent — safe to re-run.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { Pool } = require('pg');
+
+const pool = new Pool({
+    connectionString: process.env.DATABASE_URL || 'postgresql://localhost:5432/realbot'
+});
+
+async function applyMigration() {
+    const sqlPath = path.join(__dirname, 'migrations', '20260523_usage_snapshots.up.sql');
+    const sql = fs.readFileSync(sqlPath, 'utf8');
+
+    try {
+        console.log('Applying usage_snapshots migration...');
+        await pool.query(sql);
+        console.log('✅ Migration SQL executed');
+
+        // Verify schema
+        const cols = await pool.query(`
+            SELECT column_name, data_type, is_nullable, column_default
+            FROM information_schema.columns
+            WHERE table_name = 'usage_snapshots'
+            ORDER BY ordinal_position
+        `);
+
+        console.log('\n📋 usage_snapshots columns:');
+        for (const row of cols.rows) {
+            console.log(`  ${row.column_name}: ${row.data_type} (null=${row.is_nullable}, default=${row.column_default || 'none'})`);
+        }
+
+        const idx = await pool.query(`
+            SELECT indexname FROM pg_indexes
+            WHERE tablename = 'usage_snapshots'
+            ORDER BY indexname
+        `);
+        console.log('\n📋 Indexes:');
+        for (const row of idx.rows) {
+            console.log(`  ${row.indexname}`);
+        }
+
+        // SELECT smoke
+        const smoke = await pool.query('SELECT * FROM usage_snapshots LIMIT 0');
+        console.log(`\n✅ SELECT * FROM usage_snapshots LIMIT 0 → ${smoke.fields.length} fields:`);
+        console.log('  ' + smoke.fields.map(f => f.name).join(', '));
+
+        console.log('\n🎉 usage_snapshots migration completed successfully!');
+    } catch (err) {
+        console.error('❌ Migration failed:', err.message);
+        process.exit(1);
+    } finally {
+        await pool.end();
+    }
+}
+
+applyMigration();

--- a/backend/index.js
+++ b/backend/index.js
@@ -1475,7 +1475,8 @@ app.get('/api/help', (req, res) => {
         files:      ['file','檔案','upload','download','上傳','下載','ファイル','アップロード','保存','파일','업로드','저장','ไฟล์','อัปโหลด','บันทึก','tệp','tải lên','lưu','unggah','simpan','fichier','téléchargement','enregistrer','archivo','subir','guardar','fail','muat naik'],
         entities:   ['entity','實體','bind','綁定','status','lookup','查詢實體','エンティティ','バインディング','엔티티','연결','바인딩','เอนทิตี','การผูกมัด','thực thể','liên kết','kết nối','entitas','pengikatan','koneksi','entité','liaison','entidad','enlace','vínculo','entiti','sambungan'],
         vault:      ['vault','device-vars','devicevars','secret','api key','apikey','金鑰','密鑰','秘密','保險箱','audit','審計','variables','環境變數','환경 변수','보관소','감사','シークレット','金庫','監査','bí mật','kho','giám sát','rahasia','brankas','audit log'],
-        analytics:  ['analytics','growth','metrics','signup','retention','kpi','viral','k-value','成長','指標','留存','分析','회귀','분석','지표','メトリクス','分析','指標']
+        analytics:  ['analytics','growth','metrics','signup','retention','kpi','viral','k-value','成長','指標','留存','分析','회귀','분석','지표','メトリクス','分析','指標'],
+        usage:      ['usage','spend','token spend','token','claude usage','codex usage','snapshot','timeline','daemon','用量','花費','token 花費','token 用量','使用量','消費','コスト','使用量','사용량','비용']
     };
 
     const matched = Object.entries(INTENT_MAP).find(([category, kws]) =>
@@ -1545,6 +1546,12 @@ app.get('/api/help', (req, res) => {
         analytics: [
             { title: 'Daily growth snapshot (today, owner-admin only)', curl: `curl -s "${apiBase}/api/growth/daily?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}"` },
             { title: 'Daily growth snapshot for a specific date (YYYY-MM-DD)', curl: `curl -s "${apiBase}/api/growth/daily?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}&date=2026-04-17"` }
+        ],
+        usage: [
+            { title: 'POST Claude/Codex spend snapshot (daemon push)', curl: `curl -s -X POST "${apiBase}/api/usage/snapshot" -H "Content-Type: application/json" -d ${d},"captured_at":"2026-05-23T12:00:00Z","daemon_version":"0.1.0","claude":{"sessions":[]},"codex":{"sessions":[]},"pricing_source":"litellm"}'` },
+            { title: 'GET latest snapshot + today/7d/30d aggregates', curl: `curl -s "${apiBase}/api/usage/snapshot?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}"` },
+            { title: 'GET timeline (last 24h)', curl: `curl -s "${apiBase}/api/usage/timeline?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}&hours=24"` },
+            { title: 'GET timeline (last 7 days)', curl: `curl -s "${apiBase}/api/usage/timeline?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}&hours=168"` }
         ]
     };
 
@@ -1554,7 +1561,7 @@ app.get('/api/help', (req, res) => {
     res.json({
         intent,
         matched_category: matched,
-        tip: `Use ?intent=KEYWORD to discover APIs. Categories: messaging, kanban, schedule, notes, search, files, entities, vault`,
+        tip: `Use ?intent=KEYWORD to discover APIs. Categories: messaging, kanban, schedule, notes, search, files, entities, vault, analytics, usage`,
         curl_examples: curlBlock
     });
 });
@@ -1748,6 +1755,15 @@ try {
     console.log('[Growth] Module loaded successfully');
 } catch (err) {
     console.error('[Growth] Failed to load module:', err.message);
+}
+
+// Usage Snapshot API — Plan B Phase 1 (mac-daemon push of Claude/Codex spend)
+try {
+    const usageApiModule = require('./usage-api')(devices);
+    app.use('/api/usage', usageApiModule.router);
+    console.log('[UsageAPI] Module loaded successfully');
+} catch (err) {
+    console.error('[UsageAPI] Failed to load module:', err.message);
 }
 
 // Mindmap — multi-layer thinking graph (Card #19, Phase 1: schema + CRUD)

--- a/backend/migrations/20260523_usage_snapshots.down.sql
+++ b/backend/migrations/20260523_usage_snapshots.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS usage_snapshots_received_idx;
+DROP INDEX IF EXISTS usage_snapshots_device_captured_idx;
+DROP TABLE IF EXISTS usage_snapshots;

--- a/backend/migrations/20260523_usage_snapshots.up.sql
+++ b/backend/migrations/20260523_usage_snapshots.up.sql
@@ -1,0 +1,28 @@
+-- ============================================
+-- Migration: usage_snapshots — Plan B Phase 1
+-- ============================================
+-- Stores per-device Claude Code / Codex CLI token spend snapshots pushed by
+-- the local mac-daemon every ~60s. Dashboard widgets and bot queries read
+-- the latest row + aggregate sums (today/7d/30d) for display.
+--
+-- See: kanban card_c68db1d65325e4122acc86aa
+--      research: claude-code-eclaw-channel/usage_integration_research_2026_05_23.md
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS usage_snapshots (
+    id              BIGSERIAL PRIMARY KEY,
+    device_id       TEXT        NOT NULL,
+    entity_id       INTEGER     NULL,
+    captured_at     TIMESTAMPTZ NOT NULL,
+    received_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    daemon_version  TEXT        NULL,
+    claude_json     JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    codex_json      JSONB       NOT NULL DEFAULT '{}'::jsonb,
+    pricing_source  TEXT        NULL
+);
+
+CREATE INDEX IF NOT EXISTS usage_snapshots_device_captured_idx
+    ON usage_snapshots (device_id, captured_at DESC);
+
+CREATE INDEX IF NOT EXISTS usage_snapshots_received_idx
+    ON usage_snapshots (received_at DESC);

--- a/backend/usage-api.js
+++ b/backend/usage-api.js
@@ -1,0 +1,345 @@
+/**
+ * Usage Snapshot API — Plan B Phase 1
+ *
+ * Mounted at: /api/usage
+ *
+ * Receives per-device Claude Code / Codex CLI token spend snapshots pushed
+ * by the local mac-daemon (~60s cadence), and exposes aggregates for
+ * dashboard widgets / bot queries.
+ *
+ * Endpoints:
+ *   POST /snapshot   — daemon push (auth: deviceSecret OR entityId+botSecret)
+ *   GET  /snapshot   — latest row + today/7d/30d aggregates
+ *   GET  /timeline   — time-series points for the last `hours` (≤ 720)
+ *
+ * See: kanban card_c68db1d65325e4122acc86aa
+ *      research: claude-code-eclaw-channel/usage_integration_research_2026_05_23.md
+ */
+
+const express = require('express');
+const { Pool } = require('pg');
+const safeEqual = require('./safe-equal');
+
+const pool = new Pool({
+    connectionString: process.env.DATABASE_URL || 'postgresql://localhost:5432/realbot'
+});
+
+const MAX_TIMELINE_HOURS = 720;            // 30 days
+const SNAPSHOT_BODY_LIMIT = '200kb';
+const FUTURE_SKEW_TOLERANCE_MS = 5 * 60 * 1000;  // accept ≤5min clock skew
+
+// ============================================
+// SCHEMA BOOTSTRAP — idempotent, safe to call on every boot.
+// Production deploy creates the table on first start without a manual
+// migration step; the migration SQL under migrations/ stays the SoT.
+// ============================================
+async function ensureSchema() {
+    try {
+        await pool.query(`
+            CREATE TABLE IF NOT EXISTS usage_snapshots (
+                id              BIGSERIAL PRIMARY KEY,
+                device_id       TEXT        NOT NULL,
+                entity_id       INTEGER     NULL,
+                captured_at     TIMESTAMPTZ NOT NULL,
+                received_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                daemon_version  TEXT        NULL,
+                claude_json     JSONB       NOT NULL DEFAULT '{}'::jsonb,
+                codex_json      JSONB       NOT NULL DEFAULT '{}'::jsonb,
+                pricing_source  TEXT        NULL
+            )
+        `);
+        await pool.query(`CREATE INDEX IF NOT EXISTS usage_snapshots_device_captured_idx
+            ON usage_snapshots (device_id, captured_at DESC)`);
+        await pool.query(`CREATE INDEX IF NOT EXISTS usage_snapshots_received_idx
+            ON usage_snapshots (received_at DESC)`);
+        console.log('[UsageAPI] usage_snapshots schema ready');
+    } catch (err) {
+        console.error('[UsageAPI] ensureSchema failed:', err.message);
+    }
+}
+
+// ============================================
+// AUTH
+// ============================================
+
+/**
+ * Accept either:
+ *   - deviceSecret matching devices[deviceId].deviceSecret, OR
+ *   - entityId + botSecret matching devices[deviceId].entities[entityId].botSecret
+ *
+ * Returns { ok: true, entityId } on success, { ok: false, status, error } otherwise.
+ */
+function authenticate(devices, { deviceId, deviceSecret, entityId, botSecret }) {
+    if (!deviceId) {
+        return { ok: false, status: 400, error: 'Missing deviceId' };
+    }
+    const device = devices[deviceId];
+    if (!device) {
+        return { ok: false, status: 401, error: 'Invalid credentials' };
+    }
+
+    if (deviceSecret && device.deviceSecret && safeEqual(device.deviceSecret, deviceSecret)) {
+        const eIdNum = entityId !== undefined && entityId !== null && entityId !== ''
+            ? parseInt(entityId, 10) : null;
+        return { ok: true, entityId: Number.isFinite(eIdNum) ? eIdNum : null };
+    }
+
+    if (botSecret && entityId !== undefined && entityId !== null && entityId !== '') {
+        const eIdNum = parseInt(entityId, 10);
+        if (!Number.isFinite(eIdNum)) {
+            return { ok: false, status: 400, error: 'Invalid entityId' };
+        }
+        const entity = device.entities && device.entities[eIdNum];
+        if (entity && entity.botSecret && safeEqual(entity.botSecret, botSecret)) {
+            return { ok: true, entityId: eIdNum };
+        }
+    }
+
+    return { ok: false, status: 401, error: 'Invalid credentials' };
+}
+
+// ============================================
+// AGGREGATION HELPERS
+// ============================================
+
+/**
+ * Sum token + cost fields across the `sessions` array of one engine JSONB blob.
+ * Codex uses `cached_tokens`; Claude uses `cache_creation_tokens`/`cache_read_tokens`.
+ * We surface a unified `sum_input_tokens` / `sum_output_tokens` / `sum_cost_usd`
+ * regardless of which engine is being aggregated.
+ */
+function sumEngineSessions(engineJson) {
+    const sessions = Array.isArray(engineJson?.sessions) ? engineJson.sessions : [];
+    let inputTokens = 0;
+    let outputTokens = 0;
+    let costUsd = 0;
+    for (const s of sessions) {
+        inputTokens  += Number(s.input_tokens)  || 0;
+        outputTokens += Number(s.output_tokens) || 0;
+        costUsd      += Number(s.cost_usd)      || 0;
+    }
+    return {
+        session_count: sessions.length,
+        sum_input_tokens: inputTokens,
+        sum_output_tokens: outputTokens,
+        sum_cost_usd: Math.round(costUsd * 1000000) / 1000000
+    };
+}
+
+function aggregateOverRange(rows) {
+    let claude = { session_count: 0, sum_input_tokens: 0, sum_output_tokens: 0, sum_cost_usd: 0 };
+    let codex  = { session_count: 0, sum_input_tokens: 0, sum_output_tokens: 0, sum_cost_usd: 0 };
+    for (const row of rows) {
+        const c = sumEngineSessions(row.claude_json);
+        const x = sumEngineSessions(row.codex_json);
+        claude.session_count     += c.session_count;
+        claude.sum_input_tokens  += c.sum_input_tokens;
+        claude.sum_output_tokens += c.sum_output_tokens;
+        claude.sum_cost_usd      += c.sum_cost_usd;
+        codex.session_count      += x.session_count;
+        codex.sum_input_tokens   += x.sum_input_tokens;
+        codex.sum_output_tokens  += x.sum_output_tokens;
+        codex.sum_cost_usd       += x.sum_cost_usd;
+    }
+    claude.sum_cost_usd = Math.round(claude.sum_cost_usd * 1000000) / 1000000;
+    codex.sum_cost_usd  = Math.round(codex.sum_cost_usd  * 1000000) / 1000000;
+    return { claude, codex, snapshot_count: rows.length };
+}
+
+// ============================================
+// ROUTER
+// ============================================
+
+module.exports = function(devices) {
+    const router = express.Router();
+
+    // Fire-and-forget bootstrap; harmless if table already exists.
+    ensureSchema().catch(() => {});
+
+    // POST /api/usage/snapshot — daemon push
+    router.post('/snapshot', express.json({ limit: SNAPSHOT_BODY_LIMIT }), async (req, res) => {
+        const body = req.body || {};
+        const auth = authenticate(devices, body);
+        if (!auth.ok) {
+            return res.status(auth.status).json({ success: false, error: auth.error });
+        }
+
+        const { captured_at, daemon_version, claude, codex, pricing_source } = body;
+
+        if (!captured_at || typeof captured_at !== 'string') {
+            return res.status(400).json({ success: false, error: 'Missing captured_at (ISO8601 string)' });
+        }
+        const capturedTs = Date.parse(captured_at);
+        if (!Number.isFinite(capturedTs)) {
+            return res.status(400).json({ success: false, error: 'Invalid captured_at — expected ISO8601' });
+        }
+        if (capturedTs > Date.now() + FUTURE_SKEW_TOLERANCE_MS) {
+            return res.status(400).json({ success: false, error: 'captured_at is in the future' });
+        }
+
+        if (claude !== undefined && (claude === null || typeof claude !== 'object' || Array.isArray(claude))) {
+            return res.status(400).json({ success: false, error: 'claude must be an object' });
+        }
+        if (codex !== undefined && (codex === null || typeof codex !== 'object' || Array.isArray(codex))) {
+            return res.status(400).json({ success: false, error: 'codex must be an object' });
+        }
+
+        const claudeJson = claude || {};
+        const codexJson  = codex  || {};
+        const daemonVer  = (typeof daemon_version === 'string' && daemon_version) ? daemon_version.slice(0, 64) : null;
+        const pricingSrc = (typeof pricing_source === 'string' && pricing_source) ? pricing_source.slice(0, 64) : null;
+
+        try {
+            const r = await pool.query(
+                `INSERT INTO usage_snapshots
+                   (device_id, entity_id, captured_at, daemon_version, claude_json, codex_json, pricing_source)
+                 VALUES ($1, $2, $3, $4, $5::jsonb, $6::jsonb, $7)
+                 RETURNING id, received_at`,
+                [
+                    body.deviceId,
+                    auth.entityId,
+                    new Date(capturedTs).toISOString(),
+                    daemonVer,
+                    JSON.stringify(claudeJson),
+                    JSON.stringify(codexJson),
+                    pricingSrc
+                ]
+            );
+            const row = r.rows[0];
+            return res.json({
+                ok: true,
+                success: true,
+                id: row.id,
+                received_at: row.received_at
+            });
+        } catch (err) {
+            console.error('[UsageAPI] snapshot insert error:', err.message);
+            return res.status(500).json({ success: false, error: 'Internal error' });
+        }
+    });
+
+    // GET /api/usage/snapshot — latest + today/7d/30d aggregates
+    router.get('/snapshot', async (req, res) => {
+        const auth = authenticate(devices, req.query);
+        if (!auth.ok) {
+            return res.status(auth.status).json({ success: false, error: auth.error });
+        }
+        const { deviceId } = req.query;
+
+        try {
+            const latestQ = await pool.query(
+                `SELECT id, device_id, entity_id, captured_at, received_at,
+                        daemon_version, claude_json, codex_json, pricing_source
+                 FROM usage_snapshots
+                 WHERE device_id = $1
+                 ORDER BY captured_at DESC
+                 LIMIT 1`,
+                [deviceId]
+            );
+
+            const latest = latestQ.rows[0] || null;
+
+            const now = Date.now();
+            const dayMs  = 24 * 60 * 60 * 1000;
+            const weekMs = 7  * dayMs;
+            const monthMs = 30 * dayMs;
+
+            // Use Promise.all for the three range queries.
+            const [todayRows, weekRows, monthRows] = await Promise.all([
+                pool.query(
+                    `SELECT claude_json, codex_json FROM usage_snapshots
+                     WHERE device_id = $1 AND captured_at >= $2`,
+                    [deviceId, new Date(now - dayMs).toISOString()]
+                ),
+                pool.query(
+                    `SELECT claude_json, codex_json FROM usage_snapshots
+                     WHERE device_id = $1 AND captured_at >= $2`,
+                    [deviceId, new Date(now - weekMs).toISOString()]
+                ),
+                pool.query(
+                    `SELECT claude_json, codex_json FROM usage_snapshots
+                     WHERE device_id = $1 AND captured_at >= $2`,
+                    [deviceId, new Date(now - monthMs).toISOString()]
+                )
+            ]);
+
+            return res.json({
+                success: true,
+                latest: latest ? {
+                    id: latest.id,
+                    deviceId: latest.device_id,
+                    entityId: latest.entity_id,
+                    captured_at: latest.captured_at,
+                    received_at: latest.received_at,
+                    daemon_version: latest.daemon_version,
+                    pricing_source: latest.pricing_source,
+                    claude: latest.claude_json,
+                    codex:  latest.codex_json
+                } : null,
+                aggregates: {
+                    today: aggregateOverRange(todayRows.rows),
+                    week:  aggregateOverRange(weekRows.rows),
+                    month: aggregateOverRange(monthRows.rows)
+                }
+            });
+        } catch (err) {
+            console.error('[UsageAPI] snapshot get error:', err.message);
+            return res.status(500).json({ success: false, error: 'Internal error' });
+        }
+    });
+
+    // GET /api/usage/timeline?hours=24 — time series points
+    router.get('/timeline', async (req, res) => {
+        const auth = authenticate(devices, req.query);
+        if (!auth.ok) {
+            return res.status(auth.status).json({ success: false, error: auth.error });
+        }
+        const { deviceId } = req.query;
+
+        let hours = parseInt(req.query.hours, 10);
+        if (!Number.isFinite(hours) || hours <= 0) hours = 24;
+        if (hours > MAX_TIMELINE_HOURS) {
+            return res.status(400).json({ success: false, error: `hours must be ≤ ${MAX_TIMELINE_HOURS}` });
+        }
+
+        const sinceIso = new Date(Date.now() - hours * 60 * 60 * 1000).toISOString();
+
+        try {
+            const r = await pool.query(
+                `SELECT captured_at, claude_json, codex_json
+                 FROM usage_snapshots
+                 WHERE device_id = $1 AND captured_at >= $2
+                 ORDER BY captured_at ASC`,
+                [deviceId, sinceIso]
+            );
+
+            const points = r.rows.map(row => {
+                const c = sumEngineSessions(row.claude_json);
+                const x = sumEngineSessions(row.codex_json);
+                return {
+                    captured_at: row.captured_at,
+                    claude_total_tokens: c.sum_input_tokens + c.sum_output_tokens,
+                    codex_total_tokens:  x.sum_input_tokens + x.sum_output_tokens,
+                    claude_total_cost_usd: c.sum_cost_usd,
+                    codex_total_cost_usd:  x.sum_cost_usd
+                };
+            });
+
+            return res.json({
+                success: true,
+                deviceId,
+                hours,
+                since: sinceIso,
+                points
+            });
+        } catch (err) {
+            console.error('[UsageAPI] timeline error:', err.message);
+            return res.status(500).json({ success: false, error: 'Internal error' });
+        }
+    });
+
+    return {
+        router,
+        _internal: { authenticate, sumEngineSessions, aggregateOverRange, MAX_TIMELINE_HOURS, SNAPSHOT_BODY_LIMIT }
+    };
+};


### PR DESCRIPTION
## Summary

Plan B Phase 1 — backend-only landing of the Claude Code / Codex CLI spend pipeline.
Phase 2 (mac-daemon push) and Phase 3 (dashboard widget) are separate cards.

Closes card_c68db1d65325e4122acc86aa.

Research: `claude-code-eclaw-channel/usage_integration_research_2026_05_23.md`

### What lands here

- **`usage_snapshots` table** (`backend/migrations/20260523_usage_snapshots.{up,down}.sql`) — JSONB columns for `claude_json`/`codex_json`, `captured_at` + `received_at`, `daemon_version`, `pricing_source`. Indexes: `(device_id, captured_at DESC)`, `(received_at DESC)`.
- **`POST /api/usage/snapshot`** — accepts `deviceSecret` OR (`entityId`+`botSecret`); validates `captured_at` is ISO-8601 and not more than 5 min in the future; requires `claude`/`codex` to be objects; body capped at **200 KB** via `express.json({ limit: '200kb' })`.
- **`GET /api/usage/snapshot`** — returns `latest` snapshot + today/7d/30d aggregates summing `input_tokens`/`output_tokens`/`cost_usd` across `claude.sessions` and `codex.sessions`.
- **`GET /api/usage/timeline?hours=…`** — time-series points for the last `hours` (clamped ≤ 720 = 30 days); shape per point `{ captured_at, claude_total_tokens, codex_total_tokens, claude_total_cost_usd, codex_total_cost_usd }`; empty array when no rows.
- **`/api/help` intent docs** — adds a `usage:*` category (POST + GET snapshot + timeline curl templates) and lists `usage` in the tip line.
- **Self-bootstrapping schema** (`ensureSchema()`) at module load so Railway prod doesn't need a manual migration; `migrations/` remains the SoT. `apply_usage_snapshots_migration.js` provided for explicit local runs.

### E2E smoke evidence (run against local realbot DB + minimal mount harness)

**Migration apply**
```
$ DATABASE_URL=postgresql://localhost:5432/realbot node apply_usage_snapshots_migration.js
✅ Migration SQL executed
📋 usage_snapshots columns:
  id: bigint (null=NO, default=nextval(...))
  device_id: text (null=NO)
  entity_id: integer (null=YES)
  captured_at: timestamp with time zone (null=NO)
  received_at: timestamp with time zone (null=NO, default=now())
  daemon_version: text (null=YES)
  claude_json: jsonb (null=NO, default='{}'::jsonb)
  codex_json: jsonb (null=NO, default='{}'::jsonb)
  pricing_source: text (null=YES)
📋 Indexes:
  usage_snapshots_device_captured_idx
  usage_snapshots_pkey
  usage_snapshots_received_idx
✅ SELECT * FROM usage_snapshots LIMIT 0 → 9 fields
```

**POST /api/usage/snapshot — deviceSecret auth → 200**
Request: `deviceSecret`, `captured_at` 5 min ago, one Claude session + one Codex session.
```
HTTP 200
{"ok":true,"success":true,"id":"1","received_at":"2026-05-23T08:23:53.487Z"}
```

**POST /api/usage/snapshot — botSecret+entityId auth → 200**
```
HTTP 200
{"ok":true,"success":true,"id":"2","received_at":"2026-05-23T08:24:00.199Z"}
```

**GET /api/usage/snapshot → 200**
```json
{
  "success": true,
  "latest": {
    "id": "2", "deviceId": "smoke-device-001", "entityId": 0,
    "captured_at": "2026-05-23T08:21:00.000Z",
    "received_at": "2026-05-23T08:24:00.199Z",
    "daemon_version": "0.1.0-poc", "pricing_source": null,
    "claude": { "sessions": [ { "session_id":"s2", "input_tokens":2000, "output_tokens":500, "cost_usd":0.05, ... } ] },
    "codex":  { "sessions": [] }
  },
  "aggregates": {
    "today": {
      "claude": { "session_count": 2, "sum_input_tokens": 14345, "sum_output_tokens": 7289, "sum_cost_usd": 0.1734 },
      "codex":  { "session_count": 1, "sum_input_tokens": 4321,  "sum_output_tokens": 1000, "sum_cost_usd": 0.0345 },
      "snapshot_count": 2
    },
    "week":  { ... same shape ... },
    "month": { ... same shape ... }
  }
}
```

**GET /api/usage/timeline?hours=1 → 200**
```json
{
  "success": true, "deviceId": "smoke-device-001", "hours": 1,
  "since": "2026-05-23T07:24:12.848Z",
  "points": [
    {"captured_at":"2026-05-23T08:18:53.000Z","claude_total_tokens":19134,"codex_total_tokens":5321,"claude_total_cost_usd":0.1234,"codex_total_cost_usd":0.0345},
    {"captured_at":"2026-05-23T08:21:00.000Z","claude_total_tokens":2500, "codex_total_tokens":0,   "claude_total_cost_usd":0.05,  "codex_total_cost_usd":0}
  ]
}
```

**DB SELECT verification**
```
 id |    device_id     | entity_id | claude_sessions | codex_sessions
----+------------------+-----------+-----------------+----------------
  1 | smoke-device-001 |           |               1 |              1
  2 | smoke-device-001 |         0 |               1 |              0
```
(Row 1 used deviceSecret-only auth → `entity_id` NULL; row 2 used bot auth → `entity_id` 0. Both expected.)

### Negative cases

| Case | Status | Body |
|------|--------|------|
| Bad `deviceSecret` | **401** | `{"success":false,"error":"Invalid credentials"}` |
| No auth at all | **401** | `{"success":false,"error":"Invalid credentials"}` |
| Missing `captured_at` | **400** | `{"success":false,"error":"Missing captured_at (ISO8601 string)"}` |
| `captured_at` in 2099 | **400** | `{"success":false,"error":"captured_at is in the future"}` |
| `claude` is a string | **400** | `{"success":false,"error":"claude must be an object"}` |
| `timeline?hours=999` | **400** | `{"success":false,"error":"hours must be ≤ 720"}` |
| ~485 KB body (over 200 KB cap) | **413** | `PayloadTooLargeError: request entity too large` |

## Test plan
- [x] Migration applies idempotently on local realbot DB; `SELECT * FROM usage_snapshots LIMIT 0` returns the 9 expected fields.
- [x] POST snapshot accepts both auth paths (deviceSecret vs botSecret+entityId) and produces a row with the expected `entity_id` value.
- [x] GET snapshot returns latest + today/7d/30d aggregates with correct token + cost sums.
- [x] GET timeline returns ASC-ordered points with reduced shape.
- [x] 401 / 400 / 413 all return the documented error shapes.
- [x] `/api/help?intent=usage` returns the new curl templates (verified via code path; intent matcher includes "usage", "spend", "token", etc.).
- [ ] Live `eclawbot.com` deploy returns 401 (not 404) on `GET /api/usage/snapshot` after Railway picks up the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)