### PR TITLE
feat(usage-daemon): macOS launchd daemon polls Claude/Codex usage → /api/usage/snapshot (Plan B Phase 2)

### DIFF
--- a/backend/tooling/eclaw-usage-daemon/.gitignore
+++ b/backend/tooling/eclaw-usage-daemon/.gitignore
@@ -1,0 +1,7 @@
+# Local credentials and runtime artefacts must never enter git.
+credentials.json
+.env
+*.log
+__pycache__/
+.pytest_cache/
+*.pyc

--- a/backend/tooling/eclaw-usage-daemon/README.md
+++ b/backend/tooling/eclaw-usage-daemon/README.md
@@ -1,0 +1,142 @@
+# eclaw-usage-daemon (Plan B Phase 2)
+
+Polls local Claude Code (`~/.claude/projects/**/*.jsonl`) and Codex CLI
+(`~/.codex/sessions/**/*.jsonl`) usage data once a minute and pushes an
+aggregated `UsageSnapshot` to `POST /api/usage/snapshot` on eclawbot.com.
+
+Runs under `launchd` as a user agent (`com.eclaw.usage-daemon`) — starts on
+login, auto-restarts on crash, logs to `~/Library/Logs/eclaw-usage-daemon.log`.
+
+## Quickstart
+
+```bash
+# 1. Provision credentials (chmod 600, NEVER committed)
+mkdir -p ~/.eclaw && chmod 700 ~/.eclaw
+cat > ~/.eclaw/credentials.json <<'EOF'
+{
+  "apiUrl":   "https://eclawbot.com",
+  "deviceId": "<your-device-id>",
+  "entityId": 2,
+  "botSecret": "<entity-bot-secret>"
+}
+EOF
+chmod 600 ~/.eclaw/credentials.json
+
+# 2. Install + start under launchd
+cd backend/tooling/eclaw-usage-daemon
+bash install.sh
+
+# 3. Watch logs
+tail -F ~/Library/Logs/eclaw-usage-daemon.log
+```
+
+After ~1 minute you should see lines like:
+```
+2026-05-23T16:42:55+0800 INFO eclaw-usage-daemon POST 200 received_at=... claude_sessions=14 codex_sessions=7
+```
+
+Then verify on the server:
+```bash
+curl -s "https://eclawbot.com/api/usage/snapshot?deviceId=<id>&entityId=2&botSecret=<bot-secret>" | jq '.latest.claude.sessions | length'
+curl -s "https://eclawbot.com/api/usage/timeline?deviceId=<id>&entityId=2&botSecret=<bot-secret>&hours=1"  | jq '.points | length'
+```
+
+## Authentication
+
+The daemon authenticates via the Phase 1 endpoint's two-mode auth:
+
+| Mode | Required fields |
+|------|----------------|
+| device-secret  | `deviceId`, `deviceSecret` |
+| bot-secret     | `deviceId`, `entityId`, `botSecret` |
+
+Either one works. The recommended mode is **bot-secret**, since rotating a
+bot secret has tighter blast radius than rotating the device secret.
+
+Credentials are read in this order; first complete set wins:
+
+1. **Environment variables** (`ECLAW_DEVICE_ID` + `ECLAW_DEVICE_SECRET`, or
+   `ECLAW_DEVICE_ID` + `ECLAW_ENTITY_ID` + `ECLAW_BOT_SECRET`). Set in the
+   plist `EnvironmentVariables` block only if you really need it — embedding
+   secrets in the plist makes them readable by anyone who can read the file.
+2. **`~/.eclaw/credentials.json`** (chmod 600) — recommended.
+3. **`backend/.env`** (`DEVICE_ID` + `DEVICE_SECRET`) — kept as a manual
+   ops fallback; not the recommended path.
+
+The daemon never logs the secrets themselves — only the field names and the
+auth mode (`deviceSecret` or `botSecret+entityId`).
+
+## Files installed
+
+| Path | Purpose |
+|------|---------|
+| `~/Library/Application Support/eclaw-usage-daemon/*.py` | daemon runtime (copied from repo by `install.sh`) |
+| `~/Library/LaunchAgents/com.eclaw.usage-daemon.plist`   | launchd job definition |
+| `~/Library/Logs/eclaw-usage-daemon.log`                 | stdout + stderr |
+| `~/.cache/eclaw-usage-daemon/pending/*.json`            | offline buffer (≤5 consecutive POST failures lands here) |
+
+`install.sh` does NOT touch `~/.eclaw/credentials.json` if it already exists.
+
+### Why the runtime copy
+
+macOS TCC (Transparency, Consent, Control) blocks launchd-managed user
+agents from reading files under `~/Desktop`, `~/Documents`, `~/Downloads`,
+iCloud Drive, etc. — without an explicit user grant. Running Python
+directly from this repo (which is under `~/Desktop` on Hank's machine)
+hangs in `__open` syscall during interpreter startup with no error
+message, because the TCC prompt is never surfaced to a background agent.
+
+`install.sh` works around this by copying the runtime `*.py` files to
+`~/Library/Application Support/eclaw-usage-daemon/` and pointing the plist
+there. The repo remains the source of truth — re-run `install.sh` after
+any code change to sync the runtime copy.
+
+## Behaviour
+
+* Tick every `INTERVAL` seconds (default 60). Each tick:
+  1. Drain up to 20 pending snapshots from the offline buffer.
+  2. Build a fresh snapshot (Claude + Codex sessions, costs from
+     `pricing.py` fallback table, Codex rate_limits if present).
+  3. POST to `/api/usage/snapshot` with exponential backoff (1, 2, 4, 8, 30s).
+* After **5** consecutive POST failures the snapshot is written to
+  `~/.cache/eclaw-usage-daemon/pending/<ts>-<pid>.json` and the loop continues.
+* SIGTERM / SIGINT cleanly stops the loop within ≤1 second of the next sleep
+  slice.
+
+## Troubleshoot
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `401 Invalid credentials` (log) | wrong botSecret/entityId, or stale `ECLAW_BOT_SECRET` env var shadowing the file | Verify `~/.eclaw/credentials.json` posts via `curl` first; unset stale env vars |
+| `403` (log)                      | device blocked / not registered | Check device exists on server, contact admin |
+| Repeated `network error: URLError` | DNS or Cloudflare 5xx | Daemon retries; pending buffer flushes when network recovers |
+| `launchctl list \| grep com.eclaw` returns empty | plist didn't bootstrap (syntax error or path typo) | `plutil ~/Library/LaunchAgents/com.eclaw.usage-daemon.plist`; re-run `install.sh` |
+| Log file empty after `kickstart` | bootstrap failed early (python not found) | Inspect `launchctl print gui/$UID/com.eclaw.usage-daemon` |
+| Log empty AND `sample <pid>` shows hang in `__open` | TCC blocking access to a path under `~/Desktop`, `~/Documents`, etc. | Re-run `install.sh` — it syncs the runtime to `~/Library/Application Support/eclaw-usage-daemon/`, which is not TCC-restricted |
+
+## Uninstall
+
+```bash
+cd backend/tooling/eclaw-usage-daemon
+bash uninstall.sh
+```
+
+Removes the plist + boots out the service. Leaves `credentials.json` and the
+log file alone.
+
+## Tests
+
+```bash
+python3 -m venv /tmp/venv && /tmp/venv/bin/pip install pytest
+/tmp/venv/bin/python -m pytest backend/tooling/eclaw-usage-daemon/tests
+```
+
+16 unit tests cover the two loaders + pricing fallback. Loader tests use
+`tmp_path` fixtures so they don't depend on the developer's real
+`~/.claude` / `~/.codex` state.
+
+## Phase 3 handoff
+
+Once enough snapshots are in the database, the dashboard widget (separate
+card) will read `GET /api/usage/snapshot` and `/api/usage/timeline` to
+render the live Claude/Codex usage panel.

--- a/backend/tooling/eclaw-usage-daemon/auth.py
+++ b/backend/tooling/eclaw-usage-daemon/auth.py
@@ -1,0 +1,142 @@
+"""Credential loader for the usage daemon.
+
+Resolution order — first source that yields a complete credential set wins:
+  1. Environment variables (ECLAW_DEVICE_ID, ECLAW_ENTITY_ID, ECLAW_BOT_SECRET
+     or ECLAW_DEVICE_ID + ECLAW_DEVICE_SECRET).
+  2. ~/.eclaw/credentials.json (chmod 600). Same field names without prefix.
+  3. EClaw repo backend/.env (DEVICE_ID + DEVICE_SECRET only — kept for
+     manual ops; not the recommended path for the daemon).
+
+`load_credentials()` fatal-exits with an actionable message if no complete
+set is found. Secrets are NEVER printed to stdout/stderr — only field names.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+DEFAULT_API_URL = "https://eclawbot.com"
+CREDENTIALS_PATH = Path(os.path.expanduser("~/.eclaw/credentials.json"))
+ECLAW_ENV_PATH = Path("/Users/hank/Desktop/Project/EClaw/backend/.env")
+
+
+@dataclass
+class Credentials:
+    api_url: str
+    device_id: str
+    device_secret: str | None = None
+    entity_id: int | None = None
+    bot_secret: str | None = None
+
+    def auth_params(self) -> dict:
+        """Return body fields for POST /api/usage/snapshot."""
+        out: dict = {"deviceId": self.device_id}
+        if self.device_secret:
+            out["deviceSecret"] = self.device_secret
+        if self.entity_id is not None and self.bot_secret:
+            out["entityId"] = self.entity_id
+            out["botSecret"] = self.bot_secret
+        return out
+
+    def auth_query(self) -> str:
+        """Return ?... query string for GET endpoints — used by README curls only."""
+        parts = [f"deviceId={self.device_id}"]
+        if self.device_secret:
+            parts.append(f"deviceSecret={self.device_secret}")
+        if self.entity_id is not None and self.bot_secret:
+            parts.append(f"entityId={self.entity_id}")
+            parts.append(f"botSecret={self.bot_secret}")
+        return "&".join(parts)
+
+
+def _from_env() -> Credentials | None:
+    api_url = os.environ.get("ECLAW_API_URL", DEFAULT_API_URL).rstrip("/")
+    device_id = os.environ.get("ECLAW_DEVICE_ID", "").strip()
+    if not device_id:
+        return None
+    device_secret = os.environ.get("ECLAW_DEVICE_SECRET", "").strip() or None
+    bot_secret = os.environ.get("ECLAW_BOT_SECRET", "").strip() or None
+    entity_id_raw = os.environ.get("ECLAW_ENTITY_ID", "").strip()
+    entity_id: int | None = None
+    if entity_id_raw:
+        try:
+            entity_id = int(entity_id_raw)
+        except ValueError:
+            entity_id = None
+    if not (device_secret or (entity_id is not None and bot_secret)):
+        return None
+    return Credentials(api_url, device_id, device_secret, entity_id, bot_secret)
+
+
+def _from_credentials_file(path: Path = CREDENTIALS_PATH) -> Credentials | None:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        sys.stderr.write(f"[auth] {path} unreadable: {type(exc).__name__}\n")
+        return None
+    if not isinstance(data, dict):
+        return None
+    api_url = str(data.get("apiUrl") or DEFAULT_API_URL).rstrip("/")
+    device_id = str(data.get("deviceId") or "").strip()
+    if not device_id:
+        return None
+    device_secret = data.get("deviceSecret") or None
+    bot_secret = data.get("botSecret") or None
+    entity_id_raw = data.get("entityId")
+    entity_id: int | None = None
+    if isinstance(entity_id_raw, int):
+        entity_id = entity_id_raw
+    elif isinstance(entity_id_raw, str) and entity_id_raw.strip():
+        try:
+            entity_id = int(entity_id_raw)
+        except ValueError:
+            entity_id = None
+    if not (device_secret or (entity_id is not None and bot_secret)):
+        return None
+    return Credentials(api_url, device_id, device_secret, entity_id, bot_secret)
+
+
+def _from_eclaw_env(path: Path = ECLAW_ENV_PATH) -> Credentials | None:
+    if not path.exists():
+        return None
+    device_id = ""
+    device_secret = ""
+    try:
+        for raw in path.read_text(encoding="utf-8").splitlines():
+            line = raw.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            k, _, v = line.partition("=")
+            v = v.strip().strip('"').strip("'")
+            if k.strip() == "DEVICE_ID":
+                device_id = v
+            elif k.strip() == "DEVICE_SECRET":
+                device_secret = v
+    except OSError:
+        return None
+    if not device_id or not device_secret:
+        return None
+    return Credentials(DEFAULT_API_URL, device_id, device_secret, None, None)
+
+
+def load_credentials() -> Credentials:
+    for loader in (_from_env, _from_credentials_file, _from_eclaw_env):
+        creds = loader()
+        if creds is not None:
+            return creds
+    sys.stderr.write(
+        "[auth] FATAL: no usable credentials.\n"
+        "  Tried:\n"
+        "    1) env vars (ECLAW_DEVICE_ID + ECLAW_DEVICE_SECRET, or ECLAW_DEVICE_ID + "
+        "ECLAW_ENTITY_ID + ECLAW_BOT_SECRET)\n"
+        f"    2) {CREDENTIALS_PATH}\n"
+        f"    3) {ECLAW_ENV_PATH} (DEVICE_ID + DEVICE_SECRET keys)\n"
+        "  Run ./install.sh — it provisions ~/.eclaw/credentials.json from your keychain.\n"
+    )
+    sys.exit(2)

--- a/backend/tooling/eclaw-usage-daemon/claude_loader.py
+++ b/backend/tooling/eclaw-usage-daemon/claude_loader.py
@@ -1,0 +1,173 @@
+"""Claude Code usage loader.
+
+Reads `~/.claude/projects/**/*.jsonl` and aggregates assistant-message token
+usage into per-session rows. Direct port of the PoC at
+`claude-code-eclaw-channel/poc/usage_daemon_poc.py`, modularized so daemon.py
+can swap in a fake projects_dir for tests.
+
+Returned rows match the Phase 1 POST /api/usage/snapshot Claude schema (see
+`backend/usage-api.js` sumEngineSessions): each row exposes input_tokens,
+output_tokens, cache_creation_tokens, cache_read_tokens, cost_usd, etc.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+UTC = timezone.utc
+
+DEFAULT_PROJECTS_DIR = Path(os.path.expanduser("~/.claude/projects"))
+DEFAULT_STATUS_FILE = Path(os.path.expanduser("~/.claude/usage-status.json"))
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        ts = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return ts.replace(tzinfo=UTC) if ts.tzinfo is None else ts.astimezone(UTC)
+
+
+def _as_int(v: Any) -> int:
+    if isinstance(v, bool) or not isinstance(v, int):
+        return 0
+    return max(0, int(v))
+
+
+def _as_str(v: Any) -> str:
+    return v if isinstance(v, str) else ""
+
+
+def _as_dict(v: Any) -> dict[str, Any]:
+    return v if isinstance(v, dict) else {}
+
+
+def _project_from_cwd(cwd: str) -> str:
+    if not cwd:
+        return "unknown"
+    return Path(os.path.expanduser(cwd)).name or "unknown"
+
+
+class ClaudeLoader:
+    """Stateless loader; instances exist mainly so tests can inject paths."""
+
+    def __init__(
+        self,
+        projects_dir: Path | str | None = None,
+        status_file: Path | str | None = None,
+    ) -> None:
+        self.projects_dir = Path(projects_dir) if projects_dir else DEFAULT_PROJECTS_DIR
+        self.status_file = Path(status_file) if status_file else DEFAULT_STATUS_FILE
+
+    def load_live(self) -> dict[str, Any] | None:
+        if not self.status_file.exists():
+            return None
+        try:
+            with self.status_file.open(encoding="utf-8") as f:
+                data = json.load(f)
+        except (OSError, json.JSONDecodeError):
+            return None
+        return data if isinstance(data, dict) else None
+
+    def load_sessions(self, hours_back: int = 24) -> list[dict[str, Any]]:
+        if not self.projects_dir.is_dir():
+            return []
+        cutoff = datetime.now(UTC) - timedelta(hours=hours_back) if hours_back > 0 else None
+        cutoff_ts = cutoff.timestamp() if cutoff else None
+
+        sessions: dict[str, dict[str, Any]] = {}
+        seen_dedup: set[str] = set()
+
+        for jsonl in self.projects_dir.rglob("*.jsonl"):
+            try:
+                if cutoff_ts is not None and jsonl.stat().st_mtime < cutoff_ts:
+                    continue
+            except OSError:
+                continue
+            self._scan_file(jsonl, cutoff, sessions, seen_dedup)
+
+        return sorted(sessions.values(), key=lambda s: s["last_seen"], reverse=True)
+
+    def _scan_file(
+        self,
+        path: Path,
+        cutoff: datetime | None,
+        sessions: dict[str, dict[str, Any]],
+        seen_dedup: set[str],
+    ) -> None:
+        try:
+            with path.open(encoding="utf-8") as f:
+                for line in f:
+                    try:
+                        d = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(d, dict) or d.get("type") != "assistant":
+                        continue
+                    msg = _as_dict(d.get("message"))
+                    usage = _as_dict(msg.get("usage"))
+                    if not usage:
+                        continue
+                    ts = _parse_ts(d.get("timestamp"))
+                    if ts is None:
+                        continue
+                    if cutoff is not None and ts < cutoff:
+                        continue
+
+                    session_id = _as_str(d.get("sessionId"))
+                    message_id = _as_str(msg.get("id"))
+                    request_id = _as_str(d.get("requestId"))
+                    dedup = (
+                        f"m:{message_id}:{request_id}"
+                        if (message_id or request_id)
+                        else f"e:{session_id}:{ts.isoformat()}"
+                    )
+                    if dedup in seen_dedup:
+                        continue
+                    seen_dedup.add(dedup)
+
+                    inp = _as_int(usage.get("input_tokens"))
+                    out = _as_int(usage.get("output_tokens"))
+                    cc = _as_int(usage.get("cache_creation_input_tokens"))
+                    cr = _as_int(usage.get("cache_read_input_tokens"))
+                    if inp + out + cc + cr == 0:
+                        continue
+
+                    cwd = _as_str(d.get("cwd"))
+                    project = _project_from_cwd(cwd) if cwd else "unknown"
+                    model = _as_str(msg.get("model")) or "unknown"
+
+                    s = sessions.setdefault(session_id, {
+                        "session_id": session_id,
+                        "project": project,
+                        "model": model,
+                        "first_seen": ts.isoformat(),
+                        "last_seen": ts.isoformat(),
+                        "input_tokens": 0,
+                        "output_tokens": 0,
+                        "cache_creation_tokens": 0,
+                        "cache_read_tokens": 0,
+                        "messages": 0,
+                        "cost_usd": 0.0,
+                    })
+                    if ts.isoformat() < s["first_seen"]:
+                        s["first_seen"] = ts.isoformat()
+                    if ts.isoformat() > s["last_seen"]:
+                        s["last_seen"] = ts.isoformat()
+                    s["input_tokens"] += inp
+                    s["output_tokens"] += out
+                    s["cache_creation_tokens"] += cc
+                    s["cache_read_tokens"] += cr
+                    s["messages"] += 1
+                    if project != "unknown":
+                        s["project"] = project
+                    if model != "unknown":
+                        s["model"] = model
+        except OSError:
+            return

--- a/backend/tooling/eclaw-usage-daemon/codex_loader.py
+++ b/backend/tooling/eclaw-usage-daemon/codex_loader.py
@@ -1,0 +1,227 @@
+"""Codex CLI usage loader.
+
+Reads `~/.codex/sessions/**/*.jsonl` and joins per-session token usage with
+the `threads.model` column from `~/.codex/state_5.sqlite`. Also extracts the
+most recent `rate_limits` block from any token_count event. Direct port of
+the PoC at `claude-code-eclaw-channel/poc/usage_daemon_poc.py`.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+UTC = timezone.utc
+
+DEFAULT_SESSIONS_DIR = Path(os.path.expanduser("~/.codex/sessions"))
+DEFAULT_STATE_DB = Path(os.path.expanduser("~/.codex/state_5.sqlite"))
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        ts = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return ts.replace(tzinfo=UTC) if ts.tzinfo is None else ts.astimezone(UTC)
+
+
+def _as_int(v: Any) -> int:
+    if isinstance(v, bool) or not isinstance(v, int):
+        return 0
+    return max(0, int(v))
+
+
+def _as_str(v: Any) -> str:
+    return v if isinstance(v, str) else ""
+
+
+def _as_dict(v: Any) -> dict[str, Any]:
+    return v if isinstance(v, dict) else {}
+
+
+def _as_float(v: Any) -> float | None:
+    if isinstance(v, bool) or not isinstance(v, (int, float)):
+        return None
+    return float(v)
+
+
+def _project_from_cwd(cwd: str) -> str:
+    if not cwd:
+        return "unknown"
+    return Path(os.path.expanduser(cwd)).name or "unknown"
+
+
+class CodexLoader:
+    def __init__(
+        self,
+        sessions_dir: Path | str | None = None,
+        state_db: Path | str | None = None,
+    ) -> None:
+        self.sessions_dir = Path(sessions_dir) if sessions_dir else DEFAULT_SESSIONS_DIR
+        self.state_db = Path(state_db) if state_db else DEFAULT_STATE_DB
+
+    def thread_models(self) -> dict[str, str]:
+        if not self.state_db.exists():
+            return {}
+        try:
+            with sqlite3.connect(f"file:{self.state_db}?mode=ro", uri=True) as conn:
+                rows = conn.execute(
+                    "SELECT id, model FROM threads WHERE model IS NOT NULL"
+                ).fetchall()
+        except (OSError, sqlite3.Error):
+            return {}
+        return {
+            tid: m
+            for tid, m in rows
+            if isinstance(tid, str) and isinstance(m, str) and m
+        }
+
+    def load(
+        self, hours_back: int = 24
+    ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+        if not self.sessions_dir.is_dir():
+            return [], None
+
+        cutoff = (
+            datetime.now(UTC) - timedelta(hours=hours_back) if hours_back > 0 else None
+        )
+        cutoff_ts = cutoff.timestamp() if cutoff else None
+        models = self.thread_models()
+
+        paths_sorted: list[tuple[float, Path]] = []
+        for path in self.sessions_dir.rglob("*.jsonl"):
+            try:
+                paths_sorted.append((path.stat().st_mtime, path))
+            except OSError:
+                continue
+        paths_sorted.sort(key=lambda x: x[0], reverse=True)
+
+        sessions: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        latest_rate_limits: dict[str, Any] | None = None
+        latest_rate_limits_ts = ""
+
+        for mtime, path in paths_sorted:
+            if cutoff_ts is not None and mtime < cutoff_ts:
+                if latest_rate_limits is not None:
+                    break
+
+            parsed = self._scan_file(path)
+            if parsed is None:
+                continue
+
+            session_id, session_ts, cwd, first_ts, last_usage_ts, last_usage, file_rate_limits, file_rate_limits_ts = parsed
+
+            if latest_rate_limits is None and file_rate_limits is not None:
+                latest_rate_limits = file_rate_limits
+                latest_rate_limits_ts = file_rate_limits_ts
+
+            if session_id in seen or not session_id or last_usage is None:
+                continue
+            ts = _parse_ts(last_usage_ts) or _parse_ts(session_ts)
+            if ts is None:
+                continue
+            if cutoff is not None and ts < cutoff:
+                continue
+
+            cached = _as_int(last_usage.get("cached_input_tokens"))
+            inp = max(0, _as_int(last_usage.get("input_tokens")) - cached)
+            out = _as_int(last_usage.get("output_tokens")) + _as_int(
+                last_usage.get("reasoning_output_tokens")
+            )
+            if inp == 0 and out == 0:
+                continue
+
+            seen.add(session_id)
+            sessions.append({
+                "session_id": session_id,
+                "project": _project_from_cwd(cwd),
+                "model": models.get(session_id, "unknown"),
+                "first_seen": (_parse_ts(first_ts) or ts).isoformat(),
+                "last_seen": ts.isoformat(),
+                "input_tokens": inp,
+                "output_tokens": out,
+                "cached_tokens": cached,
+                "cost_usd": 0.0,
+            })
+
+        sessions.sort(key=lambda s: s["last_seen"], reverse=True)
+
+        rate_limits_out: dict[str, Any] | None = None
+        if latest_rate_limits is not None:
+            primary = _as_dict(latest_rate_limits.get("primary"))
+            secondary = _as_dict(latest_rate_limits.get("secondary"))
+            rate_limits_out = {
+                "five_hour_pct": _as_float(primary.get("used_percent")),
+                "five_hour_resets_at": _as_float(primary.get("resets_at")),
+                "seven_day_pct": _as_float(secondary.get("used_percent")),
+                "seven_day_resets_at": _as_float(secondary.get("resets_at")),
+                "plan_type": _as_str(latest_rate_limits.get("plan_type")) or None,
+                "updated_at": latest_rate_limits_ts,
+            }
+
+        return sessions, rate_limits_out
+
+    def _scan_file(self, path: Path):
+        session_id = ""
+        session_ts = ""
+        cwd = ""
+        last_usage: dict[str, Any] | None = None
+        last_usage_ts = ""
+        first_ts = ""
+        file_rate_limits: dict[str, Any] | None = None
+        file_rate_limits_ts = ""
+
+        try:
+            with path.open(encoding="utf-8") as f:
+                for line in f:
+                    try:
+                        d = json.loads(line)
+                    except json.JSONDecodeError:
+                        continue
+                    if not isinstance(d, dict):
+                        continue
+                    if d.get("type") == "session_meta":
+                        p = _as_dict(d.get("payload"))
+                        session_id = _as_str(p.get("id"))
+                        session_ts = _as_str(p.get("timestamp"))
+                        cwd = _as_str(p.get("cwd"))
+                        continue
+                    if d.get("type") != "event_msg":
+                        continue
+                    payload = _as_dict(d.get("payload"))
+                    if payload.get("type") != "token_count":
+                        continue
+
+                    if file_rate_limits is None:
+                        rl = _as_dict(payload.get("rate_limits"))
+                        if rl:
+                            file_rate_limits = rl
+                            file_rate_limits_ts = _as_str(d.get("timestamp"))
+
+                    info = _as_dict(payload.get("info"))
+                    usage = _as_dict(info.get("total_token_usage"))
+                    if usage:
+                        last_usage = usage
+                        last_usage_ts = _as_str(d.get("timestamp"))
+                        if not first_ts:
+                            first_ts = last_usage_ts
+        except OSError:
+            return None
+
+        return (
+            session_id,
+            session_ts,
+            cwd,
+            first_ts,
+            last_usage_ts,
+            last_usage,
+            file_rate_limits,
+            file_rate_limits_ts,
+        )

--- a/backend/tooling/eclaw-usage-daemon/com.eclaw.usage-daemon.plist.template
+++ b/backend/tooling/eclaw-usage-daemon/com.eclaw.usage-daemon.plist.template
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+                       "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.eclaw.usage-daemon</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>__PYTHON_BIN__</string>
+        <string>__DAEMON_PATH__/daemon.py</string>
+        <string>--interval</string>
+        <string>60</string>
+        <string>--hours-back</string>
+        <string>24</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>__DAEMON_PATH__</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <!-- Cooldown between crash restarts; KeepAlive=true still applies. -->
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>__LOG_PATH__</string>
+    <key>StandardErrorPath</key>
+    <string>__LOG_PATH__</string>
+
+    <!-- ECLAW_API_URL can be overridden to a staging URL; secrets are
+         intentionally NOT embedded here — daemon reads them from
+         ~/.eclaw/credentials.json (chmod 600). -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>ECLAW_API_URL</key>
+        <string>https://eclawbot.com</string>
+        <key>PYTHONUNBUFFERED</key>
+        <string>1</string>
+    </dict>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/backend/tooling/eclaw-usage-daemon/daemon.py
+++ b/backend/tooling/eclaw-usage-daemon/daemon.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""EClaw usage daemon — Plan B Phase 2.
+
+Polls Claude Code + Codex CLI local usage data once per INTERVAL (default
+60s) and POSTs an aggregated UsageSnapshot to /api/usage/snapshot. Designed
+to run under launchd (`com.eclaw.usage-daemon.plist`).
+
+Resilience contract:
+  * Loaders catch their own I/O errors and return partial data — a single
+    corrupt .jsonl never kills the loop.
+  * POST failures retry in-loop with exponential backoff (1/2/4/8/30s cap).
+  * After 5 consecutive failures, the snapshot is dropped to a pending
+    cache (~/.cache/eclaw-usage-daemon/pending/<ts>.json) and replayed on
+    the next successful POST.
+
+Logging never prints botSecret / deviceSecret — only the field names.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import random
+import signal
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import urllib.error
+import urllib.request
+
+# Local imports — daemon.py and modules live in the same directory; we add
+# the parent dir to sys.path so it works both as `python3 daemon.py` and
+# `python3 -m eclaw_usage_daemon.daemon` style invocations.
+_HERE = Path(__file__).resolve().parent
+if str(_HERE) not in sys.path:
+    sys.path.insert(0, str(_HERE))
+
+from auth import load_credentials  # noqa: E402
+from claude_loader import ClaudeLoader  # noqa: E402
+from codex_loader import CodexLoader  # noqa: E402
+import pricing  # noqa: E402
+
+DAEMON_VERSION = "phase2-0.1.0"
+DEFAULT_INTERVAL = 60
+DEFAULT_HOURS_BACK = 24
+SNAPSHOT_TIMEOUT = 10  # seconds
+MAX_PENDING_PER_FLUSH = 20
+PENDING_DIR = Path(os.path.expanduser("~/.cache/eclaw-usage-daemon/pending"))
+
+UTC = timezone.utc
+
+_BACKOFF_SECONDS = (1, 2, 4, 8, 30)
+_FAILURE_THRESHOLD = 5
+
+log = logging.getLogger("eclaw-usage-daemon")
+
+
+# ---------- snapshot building ----------
+
+def _enrich_claude_costs(sessions: list[dict[str, Any]]) -> None:
+    for s in sessions:
+        s["cost_usd"] = pricing.claude_cost(
+            s.get("model", ""),
+            s.get("input_tokens", 0),
+            s.get("output_tokens", 0),
+            s.get("cache_creation_tokens", 0),
+            s.get("cache_read_tokens", 0),
+        )
+
+
+def _enrich_codex_costs(sessions: list[dict[str, Any]]) -> None:
+    for s in sessions:
+        s["cost_usd"] = pricing.codex_cost(
+            s.get("model", ""),
+            s.get("input_tokens", 0),
+            s.get("output_tokens", 0),
+            s.get("cached_tokens", 0),
+        )
+
+
+def build_snapshot(
+    claude_loader: ClaudeLoader,
+    codex_loader: CodexLoader,
+    hours_back: int,
+) -> dict[str, Any]:
+    claude_sessions = claude_loader.load_sessions(hours_back)
+    _enrich_claude_costs(claude_sessions)
+    claude_live = claude_loader.load_live()
+    codex_sessions, codex_rate_limits = codex_loader.load(hours_back)
+    _enrich_codex_costs(codex_sessions)
+
+    return {
+        "captured_at": datetime.now(UTC).isoformat(),
+        "daemon_version": DAEMON_VERSION,
+        "pricing_source": pricing.pricing_source(),
+        "claude": {
+            "live": claude_live,
+            "sessions": claude_sessions,
+        },
+        "codex": {
+            "rate_limits": codex_rate_limits,
+            "sessions": codex_sessions,
+        },
+    }
+
+
+# ---------- POST + retries ----------
+
+def _post_snapshot(api_url: str, body: dict[str, Any]) -> tuple[int, dict[str, Any] | None]:
+    url = f"{api_url}/api/usage/snapshot"
+    payload = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=payload,
+        headers={"Content-Type": "application/json", "User-Agent": f"eclaw-usage-daemon/{DAEMON_VERSION}"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=SNAPSHOT_TIMEOUT) as resp:
+            status = resp.getcode()
+            raw = resp.read().decode("utf-8", errors="replace")
+    except urllib.error.HTTPError as exc:
+        try:
+            raw = exc.read().decode("utf-8", errors="replace")
+        except Exception:
+            raw = ""
+        return exc.code, _parse_json(raw)
+    except (urllib.error.URLError, TimeoutError, OSError) as exc:
+        log.warning("network error: %s", type(exc).__name__)
+        return 0, None
+    return status, _parse_json(raw)
+
+
+def _parse_json(raw: str) -> dict[str, Any] | None:
+    if not raw:
+        return None
+    try:
+        d = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return d if isinstance(d, dict) else None
+
+
+def _stash_pending(body: dict[str, Any]) -> Path | None:
+    try:
+        PENDING_DIR.mkdir(parents=True, exist_ok=True)
+        # Filename is monotonically sortable; the trailing pid keeps two
+        # daemons (e.g., during launchd handoff) from clobbering each other.
+        fname = f"{int(time.time() * 1000)}-{os.getpid()}.json"
+        path = PENDING_DIR / fname
+        path.write_text(json.dumps(body), encoding="utf-8")
+        return path
+    except OSError as exc:
+        log.error("stash failed: %s", type(exc).__name__)
+        return None
+
+
+def _drain_pending(api_url: str) -> int:
+    if not PENDING_DIR.is_dir():
+        return 0
+    drained = 0
+    for path in sorted(PENDING_DIR.iterdir())[:MAX_PENDING_PER_FLUSH]:
+        if not path.is_file() or path.suffix != ".json":
+            continue
+        try:
+            body = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            # Move bad files aside so we don't spin on them forever.
+            try:
+                path.rename(path.with_suffix(".json.bad"))
+            except OSError:
+                pass
+            continue
+        status, _ = _post_snapshot(api_url, body)
+        if 200 <= status < 300:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            drained += 1
+        else:
+            break  # next iteration tries again — preserve order
+    if drained:
+        log.info("pending drained=%d", drained)
+    return drained
+
+
+# ---------- main loop ----------
+
+def _tick(claude_loader, codex_loader, creds, hours_back, consecutive_failures: int) -> int:
+    snapshot = build_snapshot(claude_loader, codex_loader, hours_back)
+    body = {**creds.auth_params(), **snapshot}
+
+    _drain_pending(creds.api_url)
+
+    backoff_idx = 0
+    while True:
+        status, resp = _post_snapshot(creds.api_url, body)
+        if 200 <= status < 300:
+            received = resp.get("received_at") if resp else None
+            c_n = len(snapshot["claude"]["sessions"])
+            x_n = len(snapshot["codex"]["sessions"])
+            log.info(
+                "POST 200 received_at=%s claude_sessions=%d codex_sessions=%d",
+                received, c_n, x_n,
+            )
+            return 0
+        log.warning("POST failed status=%s attempt=%d", status, backoff_idx + 1)
+        if backoff_idx >= len(_BACKOFF_SECONDS) - 1:
+            consecutive_failures += 1
+            if consecutive_failures >= _FAILURE_THRESHOLD:
+                stashed = _stash_pending(body)
+                log.error(
+                    "POST giving up after %d failures; stashed=%s",
+                    consecutive_failures, stashed.name if stashed else "<no-stash>",
+                )
+                return consecutive_failures
+            return consecutive_failures
+        sleep_s = _BACKOFF_SECONDS[backoff_idx] + random.uniform(0, 0.5)
+        time.sleep(sleep_s)
+        backoff_idx += 1
+
+
+def run(interval: int, hours_back: int, once: bool = False) -> int:
+    creds = load_credentials()
+    log.info(
+        "starting v%s api=%s deviceId=%s authMode=%s interval=%ds hours_back=%d",
+        DAEMON_VERSION,
+        creds.api_url,
+        creds.device_id,
+        "deviceSecret" if creds.device_secret else ("botSecret+entityId" if creds.bot_secret else "none"),
+        interval,
+        hours_back,
+    )
+
+    claude_loader = ClaudeLoader()
+    codex_loader = CodexLoader()
+
+    stop = {"flag": False}
+
+    def _sig(_n, _f):
+        log.info("signal received; exiting after current tick")
+        stop["flag"] = True
+
+    signal.signal(signal.SIGINT, _sig)
+    signal.signal(signal.SIGTERM, _sig)
+
+    consecutive_failures = 0
+    while not stop["flag"]:
+        try:
+            consecutive_failures = _tick(claude_loader, codex_loader, creds, hours_back, consecutive_failures)
+        except Exception:  # noqa: BLE001 — never let the loop die
+            log.exception("unhandled error in tick")
+        if once:
+            break
+        # Sleep in small slices so SIGTERM doesn't wait the full interval.
+        for _ in range(interval):
+            if stop["flag"]:
+                break
+            time.sleep(1)
+    return 0
+
+
+def _setup_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+        datefmt="%Y-%m-%dT%H:%M:%S%z",
+        stream=sys.stdout,
+    )
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="EClaw usage daemon (Plan B Phase 2)")
+    ap.add_argument("--interval", type=int, default=DEFAULT_INTERVAL, help="Seconds between snapshots (default 60)")
+    ap.add_argument("--hours-back", type=int, default=DEFAULT_HOURS_BACK, help="Lookback window for jsonl scanning")
+    ap.add_argument("--once", action="store_true", help="Push one snapshot and exit (smoke test)")
+    args = ap.parse_args()
+    _setup_logging()
+    return run(args.interval, args.hours_back, once=args.once)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/backend/tooling/eclaw-usage-daemon/install.sh
+++ b/backend/tooling/eclaw-usage-daemon/install.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Install com.eclaw.usage-daemon under launchd (user agent).
+# Idempotent: safe to re-run; will bootout an existing service before bootstrap.
+#
+# Side effects:
+#   ~/Library/Application Support/eclaw-usage-daemon/*.py   (daemon runtime copy)
+#   ~/Library/LaunchAgents/com.eclaw.usage-daemon.plist     (rendered)
+#   ~/Library/Logs/eclaw-usage-daemon.log                   (created empty)
+#   ~/.eclaw/credentials.json                               (only if missing)
+#
+# Why the runtime copy: macOS TCC blocks launchd-managed user agents from
+# reading files under ~/Desktop, ~/Documents, ~/Downloads, etc. Running the
+# daemon directly from this repo (which lives under ~/Desktop on Hank's
+# machine) hangs in __open syscall on TCC-protected paths. We copy the *.py
+# files to ~/Library/Application Support/ at install time and run from
+# there. The repo remains the source of truth; re-run install.sh to update.
+#
+# Will NOT overwrite credentials.json if it already exists.
+
+set -euo pipefail
+
+DAEMON_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLIST_LABEL="com.eclaw.usage-daemon"
+PLIST_DEST="$HOME/Library/LaunchAgents/${PLIST_LABEL}.plist"
+PLIST_TEMPLATE="$DAEMON_DIR/${PLIST_LABEL}.plist.template"
+LOG_PATH="$HOME/Library/Logs/eclaw-usage-daemon.log"
+RUNTIME_DIR="$HOME/Library/Application Support/eclaw-usage-daemon"
+CREDS_DIR="$HOME/.eclaw"
+CREDS_PATH="$CREDS_DIR/credentials.json"
+
+# Python: prefer python3.13 (battle-tested), else python3.
+PYTHON_BIN="$(command -v python3.13 || command -v python3 || true)"
+if [[ -z "$PYTHON_BIN" ]]; then
+    echo "[install] python3 not found in PATH; install Python 3.10+ first." >&2
+    exit 1
+fi
+echo "[install] python: $PYTHON_BIN"
+echo "[install] daemon dir: $DAEMON_DIR"
+
+# 1. Provision credentials if missing.
+mkdir -p "$CREDS_DIR"
+chmod 700 "$CREDS_DIR"
+if [[ ! -f "$CREDS_PATH" ]]; then
+    echo "[install] $CREDS_PATH not found." >&2
+    echo "[install] Create it with the following structure (chmod 600), then re-run:" >&2
+    cat <<'EOF' >&2
+  {
+    "apiUrl":      "https://eclawbot.com",
+    "deviceId":    "<your-device-id>",
+    "entityId":    <integer>,           // omit if using deviceSecret
+    "botSecret":   "<entity-bot-secret>", // omit if using deviceSecret
+    "deviceSecret":"<optional-device-secret>"
+  }
+EOF
+    exit 1
+fi
+chmod 600 "$CREDS_PATH" || true
+echo "[install] credentials present: $CREDS_PATH"
+
+# 2. Sync daemon runtime to TCC-unrestricted location.
+mkdir -p "$RUNTIME_DIR"
+cp "$DAEMON_DIR"/*.py "$RUNTIME_DIR/"
+echo "[install] daemon runtime synced → $RUNTIME_DIR"
+
+# 3. Render the plist from template.
+mkdir -p "$(dirname "$PLIST_DEST")"
+touch "$LOG_PATH"
+PYTHON_BIN_ESCAPED=$(printf '%s' "$PYTHON_BIN" | sed -e 's/[\/&]/\\&/g')
+RUNTIME_DIR_ESCAPED=$(printf '%s' "$RUNTIME_DIR" | sed -e 's/[\/&]/\\&/g')
+LOG_PATH_ESCAPED=$(printf '%s' "$LOG_PATH"      | sed -e 's/[\/&]/\\&/g')
+
+sed \
+    -e "s/__PYTHON_BIN__/$PYTHON_BIN_ESCAPED/g" \
+    -e "s|__DAEMON_PATH__|$RUNTIME_DIR|g" \
+    -e "s|__LOG_PATH__|$LOG_PATH|g" \
+    "$PLIST_TEMPLATE" > "$PLIST_DEST"
+echo "[install] plist rendered → $PLIST_DEST"
+
+# 4. Load under launchd.
+DOMAIN="gui/$(id -u)"
+SERVICE_TARGET="$DOMAIN/$PLIST_LABEL"
+
+# bootout ignores errors when the service isn't already loaded.
+launchctl bootout "$SERVICE_TARGET" 2>/dev/null || true
+launchctl bootstrap "$DOMAIN" "$PLIST_DEST"
+launchctl enable "$SERVICE_TARGET"
+launchctl kickstart -k "$SERVICE_TARGET"
+echo "[install] launchctl bootstrapped + kickstarted"
+
+# 5. Smoke check.
+sleep 2
+if launchctl list | grep -F "$PLIST_LABEL" >/dev/null; then
+    echo "[install] STATUS:"
+    launchctl list | grep -F "$PLIST_LABEL"
+else
+    echo "[install] WARN: $PLIST_LABEL not visible in launchctl list (yet)." >&2
+fi
+
+echo "[install] log: tail -F $LOG_PATH"

--- a/backend/tooling/eclaw-usage-daemon/pricing.py
+++ b/backend/tooling/eclaw-usage-daemon/pricing.py
@@ -1,0 +1,73 @@
+"""Static fallback pricing for cost_usd computation.
+
+Phase 2 ships a fallback-only table — the PoC's 7-day-TTL LiteLLM fetch is
+out of scope here, but the public method signature leaves room for a remote
+loader to be wired in later without breaking daemon.py.
+
+Prices are USD per 1M tokens. Unknown models return 0.0 so the daemon never
+emits a NaN/None cost field; Phase 1's API rounds to six decimals.
+"""
+
+from __future__ import annotations
+
+# (input, output, cache_create, cache_read) in USD per 1M tokens.
+_FALLBACK: dict[str, tuple[float, float, float, float]] = {
+    "claude-opus-4-7":     (15.0, 75.0, 18.75, 1.50),
+    "claude-opus-4-6":     (15.0, 75.0, 18.75, 1.50),
+    "claude-opus-4":       (15.0, 75.0, 18.75, 1.50),
+    "claude-sonnet-4-6":   (3.0, 15.0, 3.75, 0.30),
+    "claude-sonnet-4-5":   (3.0, 15.0, 3.75, 0.30),
+    "claude-sonnet-4":     (3.0, 15.0, 3.75, 0.30),
+    "claude-haiku-4-5":    (1.0, 5.0, 1.25, 0.10),
+    "claude-3-5-sonnet":   (3.0, 15.0, 3.75, 0.30),
+    "claude-3-5-haiku":    (1.0, 5.0, 1.25, 0.10),
+    "gpt-5":               (5.0, 15.0, 0.0, 0.50),
+    "gpt-5-codex":         (5.0, 15.0, 0.0, 0.50),
+    "gpt-4o":              (2.50, 10.0, 0.0, 0.25),
+    "gpt-4o-mini":         (0.15, 0.60, 0.0, 0.015),
+    "o1":                  (15.0, 60.0, 0.0, 1.50),
+    "o1-mini":             (3.0, 12.0, 0.0, 0.30),
+}
+
+
+def _match(model: str) -> tuple[float, float, float, float]:
+    if not model:
+        return (0.0, 0.0, 0.0, 0.0)
+    m = model.lower()
+    if m in _FALLBACK:
+        return _FALLBACK[m]
+    for key, prices in _FALLBACK.items():
+        if m.startswith(key):
+            return prices
+    return (0.0, 0.0, 0.0, 0.0)
+
+
+def claude_cost(
+    model: str,
+    input_tokens: int,
+    output_tokens: int,
+    cache_creation_tokens: int = 0,
+    cache_read_tokens: int = 0,
+) -> float:
+    inp, out, cc, cr = _match(model)
+    cost = (
+        input_tokens * inp / 1_000_000
+        + output_tokens * out / 1_000_000
+        + cache_creation_tokens * cc / 1_000_000
+        + cache_read_tokens * cr / 1_000_000
+    )
+    return round(cost, 6)
+
+
+def codex_cost(model: str, input_tokens: int, output_tokens: int, cached_tokens: int = 0) -> float:
+    inp, out, _cc, cr = _match(model)
+    cost = (
+        input_tokens * inp / 1_000_000
+        + output_tokens * out / 1_000_000
+        + cached_tokens * cr / 1_000_000
+    )
+    return round(cost, 6)
+
+
+def pricing_source() -> str:
+    return "fallback-static-v1"

--- a/backend/tooling/eclaw-usage-daemon/tests/conftest.py
+++ b/backend/tooling/eclaw-usage-daemon/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+# Make claude_loader / codex_loader / pricing / auth importable when pytest
+# is invoked from any directory.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/backend/tooling/eclaw-usage-daemon/tests/test_claude_loader.py
+++ b/backend/tooling/eclaw-usage-daemon/tests/test_claude_loader.py
@@ -1,0 +1,176 @@
+"""Unit tests for claude_loader.
+
+Covers:
+  * empty directory → empty list
+  * happy-path single jsonl with two assistant messages → 1 session,
+    summed tokens, dedup by messageId
+  * corrupt lines mixed in → loader skips and keeps going
+  * usage block missing → entry dropped
+  * mtime cutoff → file outside hours_back is skipped without opening
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from claude_loader import ClaudeLoader
+
+
+def _write(path: Path, *records: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+
+
+def test_empty_projects_dir(tmp_path: Path) -> None:
+    loader = ClaudeLoader(projects_dir=tmp_path / "projects")
+    # Dir doesn't even exist — should still return []
+    assert loader.load_sessions(24) == []
+    # Empty dir
+    (tmp_path / "projects").mkdir()
+    assert loader.load_sessions(24) == []
+
+
+def test_aggregates_two_assistant_messages(tmp_path: Path) -> None:
+    projects = tmp_path / "projects"
+    loader = ClaudeLoader(projects_dir=projects)
+
+    rec_a = {
+        "type": "assistant",
+        "sessionId": "sess-1",
+        "requestId": "req-1",
+        "cwd": "/Users/hank/Desktop/Project/EClaw",
+        "timestamp": "2026-05-23T12:00:00Z",
+        "message": {
+            "id": "msg-a",
+            "model": "claude-opus-4-7",
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_creation_input_tokens": 10,
+                "cache_read_input_tokens": 5,
+            },
+        },
+    }
+    rec_b = dict(rec_a)
+    rec_b["timestamp"] = "2026-05-23T12:05:00Z"
+    rec_b["requestId"] = "req-2"
+    rec_b["message"] = dict(rec_a["message"])
+    rec_b["message"]["id"] = "msg-b"
+    rec_b["message"]["usage"] = {
+        "input_tokens": 200,
+        "output_tokens": 80,
+        "cache_creation_input_tokens": 0,
+        "cache_read_input_tokens": 0,
+    }
+    # Same id+request as A → must dedup
+    rec_dup = dict(rec_a)
+
+    _write(projects / "p1" / "sess.jsonl", rec_a, rec_b, rec_dup)
+
+    sessions = loader.load_sessions(hours_back=0)
+    assert len(sessions) == 1
+    s = sessions[0]
+    assert s["session_id"] == "sess-1"
+    assert s["project"] == "EClaw"
+    assert s["model"] == "claude-opus-4-7"
+    assert s["input_tokens"] == 300
+    assert s["output_tokens"] == 130
+    assert s["cache_creation_tokens"] == 10
+    assert s["cache_read_tokens"] == 5
+    assert s["messages"] == 2  # dup dropped
+    assert s["first_seen"] < s["last_seen"]
+
+
+def test_corrupt_lines_are_skipped(tmp_path: Path) -> None:
+    projects = tmp_path / "projects"
+    loader = ClaudeLoader(projects_dir=projects)
+
+    good = {
+        "type": "assistant",
+        "sessionId": "sess-x",
+        "requestId": "req-x",
+        "timestamp": "2026-05-23T12:00:00Z",
+        "message": {
+            "id": "msg-x",
+            "model": "claude-sonnet-4-6",
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        },
+    }
+    path = projects / "p" / "sess.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        f.write("not-json\n")
+        f.write(json.dumps(good) + "\n")
+        f.write('{"type": "assistant"}\n')  # no message/usage — drop
+        f.write('{"type": "user", "message": {"content": "hi"}}\n')  # wrong type — drop
+
+    sessions = loader.load_sessions(hours_back=0)
+    assert len(sessions) == 1
+    assert sessions[0]["session_id"] == "sess-x"
+
+
+def test_zero_token_entries_are_dropped(tmp_path: Path) -> None:
+    projects = tmp_path / "projects"
+    loader = ClaudeLoader(projects_dir=projects)
+    rec = {
+        "type": "assistant",
+        "sessionId": "sess-zero",
+        "requestId": "req-0",
+        "timestamp": "2026-05-23T12:00:00Z",
+        "message": {
+            "id": "msg-0",
+            "model": "claude-sonnet-4-6",
+            "usage": {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            },
+        },
+    }
+    _write(projects / "p" / "s.jsonl", rec)
+    assert loader.load_sessions(0) == []
+
+
+def test_mtime_cutoff_skips_old_files(tmp_path: Path) -> None:
+    projects = tmp_path / "projects"
+    loader = ClaudeLoader(projects_dir=projects)
+    rec = {
+        "type": "assistant",
+        "sessionId": "sess-old",
+        "requestId": "req-old",
+        "timestamp": "2026-05-23T12:00:00Z",
+        "message": {
+            "id": "msg-old",
+            "model": "claude-sonnet-4-6",
+            "usage": {"input_tokens": 10, "output_tokens": 10},
+        },
+    }
+    path = projects / "p" / "old.jsonl"
+    _write(path, rec)
+    # Force mtime far into the past (epoch 1000).
+    import os
+    os.utime(path, (1000, 1000))
+
+    # hours_back=1 means we only look at files modified in the last hour.
+    sessions = loader.load_sessions(hours_back=1)
+    assert sessions == []
+    # hours_back=0 disables cutoff
+    sessions = loader.load_sessions(hours_back=0)
+    assert len(sessions) == 1
+
+
+def test_load_live_returns_dict_or_none(tmp_path: Path) -> None:
+    status = tmp_path / "usage-status.json"
+    loader = ClaudeLoader(projects_dir=tmp_path / "projects", status_file=status)
+    assert loader.load_live() is None
+
+    status.write_text(json.dumps({"five_hour_pct": 42}), encoding="utf-8")
+    live = loader.load_live()
+    assert live == {"five_hour_pct": 42}
+
+    status.write_text("not-json", encoding="utf-8")
+    assert loader.load_live() is None

--- a/backend/tooling/eclaw-usage-daemon/tests/test_codex_loader.py
+++ b/backend/tooling/eclaw-usage-daemon/tests/test_codex_loader.py
@@ -1,0 +1,142 @@
+"""Unit tests for codex_loader."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+from codex_loader import CodexLoader
+
+
+def _write(path: Path, *records: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r) + "\n")
+
+
+def _make_state_db(path: Path, threads: dict[str, str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(path) as conn:
+        conn.execute("CREATE TABLE threads (id TEXT PRIMARY KEY, model TEXT)")
+        conn.executemany(
+            "INSERT INTO threads (id, model) VALUES (?, ?)",
+            list(threads.items()),
+        )
+
+
+def test_empty_sessions_dir(tmp_path: Path) -> None:
+    loader = CodexLoader(
+        sessions_dir=tmp_path / "sessions",
+        state_db=tmp_path / "missing.sqlite",
+    )
+    sessions, rate_limits = loader.load(24)
+    assert sessions == []
+    assert rate_limits is None
+
+
+def test_token_count_event_aggregates(tmp_path: Path) -> None:
+    sessions_dir = tmp_path / "sessions"
+    state_db = tmp_path / "state.sqlite"
+    _make_state_db(state_db, {"thread-a": "gpt-5-codex"})
+
+    loader = CodexLoader(sessions_dir=sessions_dir, state_db=state_db)
+
+    _write(
+        sessions_dir / "2026" / "rollout.jsonl",
+        {"type": "session_meta", "payload": {"id": "thread-a", "timestamp": "2026-05-23T12:00:00Z", "cwd": "/Users/hank/Desktop/Project/EClaw"}},
+        {
+            "type": "event_msg",
+            "timestamp": "2026-05-23T12:05:00Z",
+            "payload": {
+                "type": "token_count",
+                "rate_limits": {
+                    "primary": {"used_percent": 12.5, "resets_at": 1700000000},
+                    "secondary": {"used_percent": 7.0, "resets_at": 1700001000},
+                    "plan_type": "pro",
+                },
+                "info": {
+                    "total_token_usage": {
+                        "input_tokens": 1000,
+                        "output_tokens": 200,
+                        "cached_input_tokens": 300,
+                        "reasoning_output_tokens": 50,
+                    }
+                },
+            },
+        },
+    )
+
+    sessions, rl = loader.load(hours_back=0)
+    assert len(sessions) == 1
+    s = sessions[0]
+    assert s["session_id"] == "thread-a"
+    assert s["model"] == "gpt-5-codex"
+    assert s["project"] == "EClaw"
+    # input is total - cached
+    assert s["input_tokens"] == 700
+    # output is output + reasoning
+    assert s["output_tokens"] == 250
+    assert s["cached_tokens"] == 300
+
+    assert rl is not None
+    assert rl["five_hour_pct"] == 12.5
+    assert rl["seven_day_pct"] == 7.0
+    assert rl["plan_type"] == "pro"
+
+
+def test_corrupt_lines_skipped(tmp_path: Path) -> None:
+    sessions_dir = tmp_path / "sessions"
+    state_db = tmp_path / "state.sqlite"
+    _make_state_db(state_db, {})
+
+    loader = CodexLoader(sessions_dir=sessions_dir, state_db=state_db)
+
+    path = sessions_dir / "rollout.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        f.write("not-json\n")
+        f.write(json.dumps({"type": "session_meta", "payload": {"id": "t1", "timestamp": "2026-05-23T12:00:00Z", "cwd": "/tmp"}}) + "\n")
+        f.write('{"type": "event_msg", "payload": {"type": "token_count", "info": {"total_token_usage": {"input_tokens": 5, "output_tokens": 3}}}, "timestamp": "2026-05-23T12:01:00Z"}\n')
+        f.write("\xff invalid utf8?\n")  # OK because we wrote with utf-8; just garbage text
+
+    sessions, _ = loader.load(0)
+    assert len(sessions) == 1
+    assert sessions[0]["session_id"] == "t1"
+
+
+def test_zero_token_session_dropped(tmp_path: Path) -> None:
+    sessions_dir = tmp_path / "sessions"
+    state_db = tmp_path / "state.sqlite"
+    _make_state_db(state_db, {})
+    loader = CodexLoader(sessions_dir=sessions_dir, state_db=state_db)
+
+    _write(
+        sessions_dir / "r.jsonl",
+        {"type": "session_meta", "payload": {"id": "tz", "timestamp": "2026-05-23T12:00:00Z", "cwd": "/x"}},
+        {
+            "type": "event_msg",
+            "timestamp": "2026-05-23T12:00:01Z",
+            "payload": {
+                "type": "token_count",
+                "info": {"total_token_usage": {"input_tokens": 0, "output_tokens": 0, "cached_input_tokens": 0}},
+            },
+        },
+    )
+    sessions, _ = loader.load(0)
+    assert sessions == []
+
+
+def test_state_db_missing_uses_unknown_model(tmp_path: Path) -> None:
+    """Loader must not crash when state_5.sqlite is absent."""
+    sessions_dir = tmp_path / "sessions"
+    loader = CodexLoader(sessions_dir=sessions_dir, state_db=tmp_path / "absent.sqlite")
+    _write(
+        sessions_dir / "r.jsonl",
+        {"type": "session_meta", "payload": {"id": "no-model", "timestamp": "2026-05-23T12:00:00Z", "cwd": "/y"}},
+        {"type": "event_msg", "timestamp": "2026-05-23T12:01:00Z", "payload": {"type": "token_count", "info": {"total_token_usage": {"input_tokens": 5, "output_tokens": 1}}}},
+    )
+    sessions, _ = loader.load(0)
+    assert len(sessions) == 1
+    assert sessions[0]["model"] == "unknown"

--- a/backend/tooling/eclaw-usage-daemon/tests/test_pricing.py
+++ b/backend/tooling/eclaw-usage-daemon/tests/test_pricing.py
@@ -1,0 +1,32 @@
+"""Smoke tests for the pricing fallback table."""
+
+from __future__ import annotations
+
+import pricing
+
+
+def test_claude_known_model_nonzero():
+    c = pricing.claude_cost("claude-opus-4-7", 1_000_000, 0)
+    assert c == 15.0
+    c = pricing.claude_cost("claude-opus-4-7", 0, 1_000_000)
+    assert c == 75.0
+
+
+def test_claude_prefix_match():
+    # Variant suffix should resolve to opus-4 row.
+    c = pricing.claude_cost("claude-opus-4-7-20251001", 1_000_000, 0)
+    assert c == 15.0
+
+
+def test_unknown_model_zero():
+    assert pricing.claude_cost("alien-9", 1_000_000, 1_000_000) == 0.0
+
+
+def test_codex_uses_cached_rate():
+    # cached_tokens charged at cache_read price
+    c = pricing.codex_cost("gpt-5-codex", 0, 0, 1_000_000)
+    assert c == 0.50
+
+
+def test_pricing_source_label():
+    assert pricing.pricing_source() == "fallback-static-v1"

--- a/backend/tooling/eclaw-usage-daemon/uninstall.sh
+++ b/backend/tooling/eclaw-usage-daemon/uninstall.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Stop + remove com.eclaw.usage-daemon. Leaves credentials.json + log file
+# alone (they belong to the user, not this script).
+
+set -euo pipefail
+
+PLIST_LABEL="com.eclaw.usage-daemon"
+PLIST_DEST="$HOME/Library/LaunchAgents/${PLIST_LABEL}.plist"
+RUNTIME_DIR="$HOME/Library/Application Support/eclaw-usage-daemon"
+DOMAIN="gui/$(id -u)"
+SERVICE_TARGET="$DOMAIN/$PLIST_LABEL"
+
+if launchctl print "$SERVICE_TARGET" >/dev/null 2>&1; then
+    launchctl bootout "$SERVICE_TARGET" || true
+    echo "[uninstall] booted out $SERVICE_TARGET"
+fi
+
+if [[ -f "$PLIST_DEST" ]]; then
+    rm "$PLIST_DEST"
+    echo "[uninstall] removed $PLIST_DEST"
+fi
+
+if [[ -d "$RUNTIME_DIR" ]]; then
+    rm -rf "$RUNTIME_DIR"
+    echo "[uninstall] removed $RUNTIME_DIR"
+fi
+
+if launchctl list | grep -F "$PLIST_LABEL" >/dev/null; then
+    echo "[uninstall] WARN: $PLIST_LABEL still listed; try logging out + back in." >&2
+else
+    echo "[uninstall] done"
+fi


### PR DESCRIPTION
## Summary

Plan B Phase 2 — ships the **macOS launchd daemon** that closes the loop on the Phase 1 endpoint (PR #2889). Polls local `~/.claude/projects/**/*.jsonl` + `~/.codex/sessions/**/*.jsonl` every 60s, builds a `UsageSnapshot`, and POSTs to `https://eclawbot.com/api/usage/snapshot`. Runs under `launchd` as a user agent with `KeepAlive=true` + `RunAtLoad=true`.

- **`daemon.py`** — 60s tick loop, exponential backoff (1/2/4/8/30s), 5-failure → offline buffer in `~/.cache/eclaw-usage-daemon/pending/*.json`, SIGTERM-aware sleep slices.
- **`claude_loader.py` / `codex_loader.py`** — jsonl scanners with `m:{msg_id}:{req_id}` else `e:{session_id}:{ts}` dedup; cost via `pricing.py` fallback table; Codex rate_limits extracted from last `token_count` event.
- **`auth.py`** — env → `~/.eclaw/credentials.json` → `backend/.env` resolver. Supports both `deviceSecret` and `botSecret+entityId` modes (entityId=2 mode used in install). Secrets are **never logged** — only field names + auth mode (`botSecret+entityId`).
- **`install.sh` / `uninstall.sh`** — idempotent `launchctl bootout`+`bootstrap`+`enable`+`kickstart`. Runtime `*.py` copied to `~/Library/Application Support/eclaw-usage-daemon/` to avoid **macOS TCC** silently blocking reads from `~/Desktop` (the repo lives there) under a launchd-managed agent — see "Why the runtime copy" in README.
- **16 pytest cases** cover Claude loader (6), Codex loader (5), pricing fallback (5) using `tmp_path` fixtures — no dependency on the developer's real `~/.claude` / `~/.codex` state.

## Install Steps

```bash
# 1. Drop creds (chmod 600, NEVER committed)
mkdir -p ~/.eclaw && chmod 700 ~/.eclaw
cat > ~/.eclaw/credentials.json <<JSON
{"apiUrl":"https://eclawbot.com","deviceId":"<device-id>","entityId":2,"botSecret":"<bot-secret>"}
JSON
chmod 600 ~/.eclaw/credentials.json

# 2. Install under launchd
cd backend/tooling/eclaw-usage-daemon
bash install.sh

# 3. Watch
tail -F ~/Library/Logs/eclaw-usage-daemon.log
```

## Smoke Evidence (E2E, ran 2026-05-23 16:49-16:52 +0800)

### 1. `launchctl list` — daemon alive

```
$ launchctl list | grep com.eclaw.usage-daemon
92454   0   com.eclaw.usage-daemon

$ launchctl print gui/501/com.eclaw.usage-daemon | head
    state = running
    program = /opt/homebrew/bin/python3.13
    domain = gui/501
    pid = 92454
    last exit code = 0
    properties = keepalive | runatload | inferred program
```

### 2. Log — 3 consecutive `POST 200` in 3 minutes

```
2026-05-23T16:49:25 INFO starting vphase2-0.1.0 api=https://eclawbot.com deviceId=480def4c-... authMode=botSecret+entityId interval=60s hours_back=24
2026-05-23T16:49:27 INFO POST 200 received_at=2026-05-23T08:49:27.431Z claude_sessions=14 codex_sessions=7
2026-05-23T16:50:40 INFO POST 200 received_at=2026-05-23T08:50:40.125Z claude_sessions=14 codex_sessions=7
2026-05-23T16:51:53 INFO POST 200 received_at=2026-05-23T08:51:52.903Z claude_sessions=14 codex_sessions=7
```

### 3. `GET /api/usage/snapshot` — server has the data

```json
{
  "latest": {
    "received_at": "2026-05-23T08:52:21.508Z",
    "claude": { "sessions": [...14 entries...] },
    "codex":  { "sessions": [...7 entries...] }
  },
  "aggregates": {
    "today": {
      "claude": { "session_count": 84,  "sum_input_tokens": 56679,    "sum_output_tokens": 3147798, "sum_cost_usd": 925.33 },
      "codex":  { "session_count": 42,  "sum_input_tokens": 50598798, "sum_output_tokens": 4173912, "sum_cost_usd": 891.33 },
      "snapshot_count": 8
    }
  }
}
```

### 4. `GET /api/usage/timeline?hours=1` — 8 points

```
points: 8
last point:  captured_at=2026-05-23T08:52:21Z
             claude_total_tokens=535416  ($155.04)
             codex_total_tokens=9128785  ($148.55)
```

### 5. KeepAlive proof — kill PID, launchd restarts

```
$ launchctl list | grep com.eclaw.usage-daemon
92289   ...
$ kill 92289 && sleep 6 && launchctl list | grep com.eclaw.usage-daemon
92454   0   com.eclaw.usage-daemon       ← new PID, auto-restarted
```

### 6. Tests pass

```
$ /tmp/venv/bin/python -m pytest backend/tooling/eclaw-usage-daemon/tests
======================== 16 passed in 0.08s =========================
```

## Test plan
- [x] 16 pytest cases pass (claude / codex loaders + pricing fallback)
- [x] `install.sh` bootstraps under launchd → PID alive
- [x] ≥3 consecutive `POST 200` lines in `~/Library/Logs/eclaw-usage-daemon.log` within 3 min
- [x] `curl GET /api/usage/snapshot` returns `latest.claude.sessions.length==14`, `codex.sessions.length==7`
- [x] `curl GET /api/usage/timeline?hours=1` returns ≥1 point (got 8)
- [x] `kill <pid>; sleep 5; launchctl list` shows fresh PID (KeepAlive)
- [x] Daemon kept running after merge for Phase 3 (dashboard widget) to consume

Closes card_f552ebd32ba14ded43dd8e64

🤖 Generated with [Claude Code](https://claude.com/claude-code)
