### PR TITLE
fix(dashboard): widget Projects list uses sessions[].project (Phase 3.2 bug)

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -5611,7 +5611,9 @@
                 const lastSeen = s && s.last_seen ? Date.parse(s.last_seen) : NaN;
                 if (!Number.isFinite(lastSeen) || lastSeen < sinceMs) continue;
                 const tokens = (Number(s.input_tokens) || 0) + (Number(s.output_tokens) || 0);
-                let name = s && s.project_id ? String(s.project_id) : '';
+                let name = '';
+                if (s && s.project) name = String(s.project);
+                else if (s && s.project_id) name = String(s.project_id);
                 if (!name && s && s.cwd) {
                     const parts = String(s.cwd).split('/').filter(Boolean);
                     name = parts.length ? parts[parts.length - 1] : String(s.cwd);


### PR DESCRIPTION
## Summary
- V2 widget shipped in PR #2891 but `Projects today` only showed one bucket called `unknown` because `groupSessionsByProject()` read `sessions[].project_id` while the daemon snapshot emits `sessions[].project`.
- 1-line typo fix; widget will now show real project names: claude-code-eclaw-channel, EClaw, hank, poc, backend, etc.

## Root cause
\`backend/public/portal/dashboard.html:5614\` reads \`s.project_id\` — daemon never sets that field. Verified via curl /api/usage/snapshot.

## Fix
Try \`.project\` → \`.project_id\` → cwd-basename → \"unknown\". Backward-compatible (still handles legacy \`.project_id\` if any older daemon emits it).

## Test plan
- [x] Field-name verified against live snapshot (17 claude sessions across 5 projects + 7 codex sessions)
- [ ] Post-merge prod Playwright verify — widget shows top 5 real project names with token counts

## Backward compat
- No backend / schema / daemon change
- Snapshot payload unchanged

Closes card_5bb07c88a7b67767545bc371

🤖 Generated with [Claude Code](https://claude.com/claude-code)