### PR TITLE
fix(dashboard): widget reads real Claude rate_limits from statusLine hook

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -5529,8 +5529,15 @@
             let sessPct = 0;
             let sessIsEst = false;
             let sessResetMs = null;
+            const liveFive = live && live.rate_limits && live.rate_limits.five_hour;
+            const nestedSessPct = liveFive && Number.isFinite(liveFive.used_percentage) ? liveFive.used_percentage : null;
             if (live && Number.isFinite(live.five_hour_pct)) {
                 sessPct = live.five_hour_pct;
+            } else if (nestedSessPct !== null) {
+                sessPct = nestedSessPct;
+                if (Number.isFinite(liveFive.resets_at)) {
+                    sessResetMs = (liveFive.resets_at * 1000) - Date.now();
+                }
             } else {
                 sessIsEst = true;
                 const cutoff = Date.now() - FIVE_HOURS_MS;
@@ -5557,8 +5564,12 @@
             // Weekly (7d)
             let weekPct = 0;
             let weekIsEst = false;
+            const liveSeven = live && live.rate_limits && live.rate_limits.seven_day;
+            const nestedWeekPct = liveSeven && Number.isFinite(liveSeven.used_percentage) ? liveSeven.used_percentage : null;
             if (live && Number.isFinite(live.seven_day_pct)) {
                 weekPct = live.seven_day_pct;
+            } else if (nestedWeekPct !== null) {
+                weekPct = nestedWeekPct;
             } else {
                 weekIsEst = true;
                 const cutoff = Date.now() - SEVEN_DAYS_MS;


### PR DESCRIPTION
## Summary
- `renderClaudeBars()` in `dashboard.html` was only reading flat `live.five_hour_pct` / `live.seven_day_pct`, which the daemon never populates for Claude (those are Codex-shape fields).
- Real Claude data is at nested `live.rate_limits.five_hour.used_percentage` / `live.rate_limits.seven_day.used_percentage` (sourced from the new `~/.claude/usage-statusline.py` hook persisting `~/.claude/usage-status.json`).
- This patch adds the nested-path fallback as the second condition before the existing `(est)` token-sum branch, so when real % is available the bar shows real %; otherwise behavior is unchanged.

## Evidence
Snapshot endpoint `/api/usage/snapshot` currently returns:
```json
"five_hour":  { "used_percentage": 2,  "resets_at": 1779553800 }
"seven_day":  { "used_percentage": 15, "resets_at": 1779890400 }
```
Without this patch the widget shows `~0% (est)`. With this patch the bars render `2%` (5h) and `15%` (7d) with the real reset countdown, no `(est)` marker.

## Test plan
- [x] Snapshot endpoint confirmed returning nested `rate_limits.{five_hour,seven_day}.used_percentage`
- [x] Existing flat-field code path preserved (no regression for any future flat-shape source)
- [x] Existing `(est)` branch preserved as final fallback
- [ ] Playwright web 1280x800 + mobile 390x844 screenshot of widget post-deploy showing real % without `(est)` marker

Closes card_2c9b875041e9eb61461f9fbc