### PR TITLE
fix(dashboard): show Claude weekly bar reset countdown

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -5564,12 +5564,16 @@
             // Weekly (7d)
             let weekPct = 0;
             let weekIsEst = false;
+            let weekResetMs = null;
             const liveSeven = live && live.rate_limits && live.rate_limits.seven_day;
             const nestedWeekPct = liveSeven && Number.isFinite(liveSeven.used_percentage) ? liveSeven.used_percentage : null;
             if (live && Number.isFinite(live.seven_day_pct)) {
                 weekPct = live.seven_day_pct;
             } else if (nestedWeekPct !== null) {
                 weekPct = nestedWeekPct;
+                if (Number.isFinite(liveSeven.resets_at)) {
+                    weekResetMs = (liveSeven.resets_at * 1000) - Date.now();
+                }
             } else {
                 weekIsEst = true;
                 const cutoff = Date.now() - SEVEN_DAYS_MS;
@@ -5582,7 +5586,7 @@
                 weekPct = (tokens / CLAUDE_7D_LIMIT_TOKENS) * 100;
             }
             paintBar('claudeWeekFill', 'claudeWeekPct', 'claudeWeekReset',
-                Math.round(weekPct), weekIsEst, null, 'd',
+                Math.round(weekPct), weekIsEst, weekResetMs, 'd',
                 'dashboard_usage_widget_weekly_used');
         }
 


### PR DESCRIPTION
## Summary
- PR #2895 wired Claude **Session (5h)** to render a `Reset in Xh Ym` countdown from `live.rate_limits.five_hour.resets_at`, but the Claude **Weekly (7d)** branch of `renderClaudeBars` still passed a hardcoded `null` into `paintBar`. Users with live nested-percentage data saw `15% used` with no reset hint.
- This PR mirrors the 5h pattern in the Weekly branch: declare `weekResetMs`, derive it from `liveSeven.resets_at` inside the nested-percentage branch, pass it to `paintBar` in place of the hardcoded `null`.

## Diff
```diff
             // Weekly (7d)
             let weekPct = 0;
             let weekIsEst = false;
+            let weekResetMs = null;
             const liveSeven = live && live.rate_limits && live.rate_limits.seven_day;
             const nestedWeekPct = liveSeven && Number.isFinite(liveSeven.used_percentage) ? liveSeven.used_percentage : null;
             if (live && Number.isFinite(live.seven_day_pct)) {
                 weekPct = live.seven_day_pct;
             } else if (nestedWeekPct !== null) {
                 weekPct = nestedWeekPct;
+                if (Number.isFinite(liveSeven.resets_at)) {
+                    weekResetMs = (liveSeven.resets_at * 1000) - Date.now();
+                }
             } else {
                 ...
             }
             paintBar('claudeWeekFill', 'claudeWeekPct', 'claudeWeekReset',
-                Math.round(weekPct), weekIsEst, null, 'd',
+                Math.round(weekPct), weekIsEst, weekResetMs, 'd',
                 'dashboard_usage_widget_weekly_used');
```

Single-language single-file edit. `paintBar`, `fmtResetCountdown`, and the `dashboard_usage_widget_reset_in` i18n key already handle the `'d'` granularity, so no other code or i18n changes were needed.

## What this does NOT fix
- The fallback estimate branch (no live nested `used_percentage` available) still has no reset countdown for the 7-day window — there's no authoritative reset timestamp to surface in that case. Out of scope.

## Test plan
- [x] `node backend/scripts/i18n-check.js` — all referenced keys resolve in EN.
- [x] `cd backend && npx jest tests/jest/i18n-syntax.test.js` — 12 / 12 pass.
- [ ] E2E screenshots (web 1280x800 + mobile 390x844) captured post-merge against prod showing the weekly bar with `Reset in Xd`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)