### PR TITLE
fix(portal/nagoya-trip): map-link invisible on dark hero/day-banner

### DIFF
--- a/backend/public/portal/nagoya-trip-20260513/index.html
+++ b/backend/public/portal/nagoya-trip-20260513/index.html
@@ -24,7 +24,7 @@
     --cream-deep: #f1ebd8;
     --ink: #2a2a2a;
     --ink-soft: #5a5a5a;
-    --ink-faint: #8b8579;
+    --ink-faint: #6e6859;
     --line: #d8cfb6;
     --line-light: #ebe4cf;
     --rose: #a4513e;
@@ -369,7 +369,7 @@
     border-radius: 999px;
   }
   .schedule .item .tags .meal { color: var(--rose); }
-  .schedule .item .tags .transit { color: var(--gold-deep); }
+  .schedule .item .tags .transit { color: #7a5614; }
   .schedule .item .tags .lodging { color: var(--forest); }
   .day-tips {
     margin-top: 18px;
@@ -569,6 +569,14 @@
     color: var(--gold-deep);
   }
   .map-link:hover { color: var(--gold-deep); }
+  /* On dark forest backgrounds, the default forest-green text overlaps the bg.
+     Lift map-links inside .hero / .day-banner to gold-soft so locations stay legible. */
+  .hero .map-link,
+  .day-banner .map-link { color: var(--gold-soft); }
+  .hero .map-link::after,
+  .day-banner .map-link::after { color: var(--gold-soft); }
+  .hero .map-link:hover,
+  .day-banner .map-link:hover { color: var(--cream); }
 
   /* ===== Parking shortcut button (next to each place name) ===== */
   .parking-btn {


### PR DESCRIPTION
## Summary
- Hank reported https://eclawbot.com/portal/nagoya-trip-20260513/ had text overlapping the background — Playwright WCAG sweep found **23 `.map-link` anchors rendering with contrast 1.00** (dark green text on the dark green hero gradient and day-banner blocks), plus two AA failures (`.meal/.ja` ink-faint 3.4, `.transit` gold-deep 4.42).
- Root cause: the JS at the bottom of `index.html` auto-wraps location names matching `locations.json` in `<a class="map-link">`. `.map-link` uses `color: var(--forest)` (#1f4030). When those auto-injected anchors land in `.hero` (`linear-gradient #122a1f → #1f4030`) or `.day-banner` (`background: #1f4030`), they vanish.
- Fix is CSS-only (10 net lines, no JS / no template changes):
  - `.hero .map-link` / `.day-banner .map-link` → `var(--gold-soft)` (matches the existing hero-eyebrow/hero-sub palette), `:hover` → `var(--cream)`.
  - `--ink-faint` `#8b8579` → `#6e6859` to lift `.overview .meal` and `.lodging-card .ja` past AA 4.5 on the cream canvas.
  - `.schedule .item .tags .transit` overridden to `#7a5614` to lift the transit pill past AA on the `--cream-deep` pill background.

## Test plan
- [x] Playwright contrast audit (re-run after fix): 0 invisible (contrast < 3), 0 AA failures.
- [x] Web 1280x800 screenshot of hero — location anchors visible in gold-soft underline.
- [x] Web 1280x800 screenshot of Day 1 banner — "AEON Mall 常滑↗", "AEON Mall Tokoname↗" visible in gold-soft.
- [x] Mobile 390x844 screenshot of hero — same anchors visible.
- [x] Mobile 390x844 screenshot of Day 1 banner — same anchors visible.
- [ ] Post-merge prod re-screenshot once Railway deploys.

## Notes
- No i18n change needed (file is single-locale zh-Hant).
- No JS change — the auto-wrap behavior is preserved; only the color now adapts to context.
- The `.map-link` rule used outside `.hero`/`.day-banner` (white feature cards, body copy on cream) keeps its original `--forest` color and 12+ contrast — verified by the audit.