### PR TITLE
i18n(ClawRenderer): canvas 空狀態 4 hardcoded EN → strings.xml (14 locales)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
@@ -9,6 +9,7 @@ import android.graphics.Paint
 import android.graphics.RectF
 import android.net.Uri
 import android.text.TextPaint
+import com.hank.clawlive.R
 import com.hank.clawlive.data.local.EntityLayout
 import com.hank.clawlive.data.local.LayoutPreferences
 import com.hank.clawlive.data.model.AgentStatus

--- a/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
@@ -429,18 +429,18 @@ class ClawRenderer(
             if (loading) {
                 textPaint.textSize = 32f
                 textPaint.color = Color.WHITE
-                canvas.drawText("Loading entities…", width / 2f, height / 2f, textPaint)
+                canvas.drawText(context.getString(R.string.claw_renderer_loading_entities), width / 2f, height / 2f, textPaint)
                 return
             }
             // Draw "No entities" message with instructions
             textPaint.textSize = 36f
             textPaint.color = Color.WHITE
-            canvas.drawText("No entities connected", width / 2f, height / 2f - 40f, textPaint)
+            canvas.drawText(context.getString(R.string.claw_renderer_no_entities_connected), width / 2f, height / 2f - 40f, textPaint)
             textPaint.textSize = 24f
             textPaint.color = Color.GRAY
-            canvas.drawText("Open E-Claw app to bind", width / 2f, height / 2f + 20f, textPaint)
+            canvas.drawText(context.getString(R.string.claw_renderer_open_app_to_bind), width / 2f, height / 2f + 20f, textPaint)
             textPaint.textSize = 20f
-            canvas.drawText("entities with OpenClaw bot", width / 2f, height / 2f + 60f, textPaint)
+            canvas.drawText(context.getString(R.string.claw_renderer_with_openclaw_bot), width / 2f, height / 2f + 60f, textPaint)
             return
         }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -565,6 +565,10 @@ GPS: عند الطلب فقط، بلا تتبع في الخلفية، تُفقد
     <string name="file_btn_download">تنزيل</string>
     <string name="chat_load_image_failed">فشل تحميل الصورة</string>
     <string name="wallpaper_no_bound_entities">لا توجد كيانات مربوطة</string>
+    <string name="claw_renderer_loading_entities">جارٍ تحميل الكيانات…</string>
+    <string name="claw_renderer_no_entities_connected">لا توجد كيانات متصلة</string>
+    <string name="claw_renderer_open_app_to_bind">افتح تطبيق E-Claw للربط</string>
+    <string name="claw_renderer_with_openclaw_bot">الكيانات مع بوت OpenClaw</string>
     <string name="main_agent_card_deleted">تم حذف بطاقة الوكيل</string>
     <string name="main_agent_card_saved">تم حفظ بطاقة الوكيل</string>
     <string name="main_delete_failed">فشل الحذف</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -564,6 +564,10 @@ Bei Fragen kontaktieren Sie uns über unsere offizielle E-Mail.
     <string name="file_btn_download">Herunterladen</string>
     <string name="chat_load_image_failed">Bild konnte nicht geladen werden</string>
     <string name="wallpaper_no_bound_entities">Keine gebundenen Entitäten</string>
+    <string name="claw_renderer_loading_entities">Entitäten werden geladen…</string>
+    <string name="claw_renderer_no_entities_connected">Keine Entitäten verbunden</string>
+    <string name="claw_renderer_open_app_to_bind">E-Claw App öffnen zum Binden</string>
+    <string name="claw_renderer_with_openclaw_bot">Entitäten mit OpenClaw-Bot</string>
     <string name="main_agent_card_deleted">Agentenkarte gelöscht</string>
     <string name="main_agent_card_saved">Agentenkarte gespeichert</string>
     <string name="main_delete_failed">Löschen fehlgeschlagen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -305,6 +305,10 @@ Tus comentarios enviados aparecerán aquí.</string>
     <string name="file_btn_download">Descargar</string>
     <string name="chat_load_image_failed">Error al cargar imagen</string>
     <string name="wallpaper_no_bound_entities">Sin entidades vinculadas</string>
+    <string name="claw_renderer_loading_entities">Cargando entidades…</string>
+    <string name="claw_renderer_no_entities_connected">No hay entidades conectadas</string>
+    <string name="claw_renderer_open_app_to_bind">Abre la app E-Claw para vincular</string>
+    <string name="claw_renderer_with_openclaw_bot">entidades con el bot OpenClaw</string>
     <string name="main_agent_card_deleted">Agent Card eliminado</string>
     <string name="main_agent_card_saved">Agent Card guardado</string>
     <string name="main_delete_failed">Error al eliminar</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -564,6 +564,10 @@ Si vous avez des questions, contactez-nous via notre e-mail officiel.
     <string name="file_btn_download">Télécharger</string>
     <string name="chat_load_image_failed">Échec du chargement de l\'image</string>
     <string name="wallpaper_no_bound_entities">Aucune entité liée</string>
+    <string name="claw_renderer_loading_entities">Chargement des entités…</string>
+    <string name="claw_renderer_no_entities_connected">Aucune entité connectée</string>
+    <string name="claw_renderer_open_app_to_bind">Ouvrir app E-Claw pour lier</string>
+    <string name="claw_renderer_with_openclaw_bot">entités avec le bot OpenClaw</string>
     <string name="main_agent_card_deleted">Carte d\'agent supprimée</string>
     <string name="main_agent_card_saved">Carte d\'agent enregistrée</string>
     <string name="main_delete_failed">Échec de la suppression</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -564,6 +564,10 @@ GPS: केवल अनुरोध पर, कोई बैकग्राउ�
     <string name="file_btn_download">डाउनलोड</string>
     <string name="chat_load_image_failed">इमेज लोड करने में विफल</string>
     <string name="wallpaper_no_bound_entities">कोई बाउंड एंटिटी नहीं</string>
+    <string name="claw_renderer_loading_entities">एंटिटी लोड हो रही हैं…</string>
+    <string name="claw_renderer_no_entities_connected">कोई एंटिटी कनेक्ट नहीं</string>
+    <string name="claw_renderer_open_app_to_bind">बाइंड करने के लिए E-Claw ऐप खोलें</string>
+    <string name="claw_renderer_with_openclaw_bot">OpenClaw बॉट के साथ एंटिटी</string>
     <string name="main_agent_card_deleted">एजेंट कार्ड हटाया गया</string>
     <string name="main_agent_card_saved">एजेंट कार्ड सहेजा गया</string>
     <string name="main_delete_failed">हटाना विफल</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -293,6 +293,10 @@
     <string name="file_btn_download">Unduh</string>
     <string name="chat_load_image_failed">Gagal memuat gambar</string>
     <string name="wallpaper_no_bound_entities">Tidak ada entitas yang terikat</string>
+    <string name="claw_renderer_loading_entities">Memuat entitas…</string>
+    <string name="claw_renderer_no_entities_connected">Tidak ada entitas terhubung</string>
+    <string name="claw_renderer_open_app_to_bind">Buka app E-Claw untuk mengikat</string>
+    <string name="claw_renderer_with_openclaw_bot">entitas dengan bot OpenClaw</string>
     <string name="main_agent_card_deleted">Agent Card dihapus</string>
     <string name="main_agent_card_saved">Agent Card disimpan</string>
     <string name="main_delete_failed">Penghapusan gagal</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -293,6 +293,10 @@
     <string name="file_btn_download">ダウンロード</string>
     <string name="chat_load_image_failed">画像の読み込みに失敗しました</string>
     <string name="wallpaper_no_bound_entities">バインドされたエンティティがありません</string>
+    <string name="claw_renderer_loading_entities">エンティティを読み込み中…</string>
+    <string name="claw_renderer_no_entities_connected">接続されたエンティティがありません</string>
+    <string name="claw_renderer_open_app_to_bind">バインドするにはE-Clawアプリを開く</string>
+    <string name="claw_renderer_with_openclaw_bot">OpenClawボットのエンティティ</string>
     <string name="main_agent_card_deleted">Agent Card を削除しました</string>
     <string name="main_agent_card_saved">Agent Card を保存しました</string>
     <string name="main_delete_failed">削除に失敗しました</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -293,6 +293,10 @@
     <string name="file_btn_download">다운로드</string>
     <string name="chat_load_image_failed">이미지 로드 실패</string>
     <string name="wallpaper_no_bound_entities">바인드된 엔티티가 없습니다</string>
+    <string name="claw_renderer_loading_entities">엔티티 로딩 중…</string>
+    <string name="claw_renderer_no_entities_connected">연결된 엔티티 없음</string>
+    <string name="claw_renderer_open_app_to_bind">바인드하려면 E-Claw 앱 열기</string>
+    <string name="claw_renderer_with_openclaw_bot">OpenClaw 봇의 엔티티</string>
     <string name="main_agent_card_deleted">Agent Card 삭제됨</string>
     <string name="main_agent_card_saved">Agent Card 저장됨</string>
     <string name="main_delete_failed">삭제 실패</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -564,6 +564,10 @@ Jika anda mempunyai sebarang soalan, sila hubungi kami melalui e-mel rasmi kami.
     <string name="file_btn_download">Muat Turun</string>
     <string name="chat_load_image_failed">Gagal memuat imej</string>
     <string name="wallpaper_no_bound_entities">Tiada entiti terikat</string>
+    <string name="claw_renderer_loading_entities">Memuat entiti…</string>
+    <string name="claw_renderer_no_entities_connected">Tiada entiti bersambung</string>
+    <string name="claw_renderer_open_app_to_bind">Buka app E-Claw untuk mengikat</string>
+    <string name="claw_renderer_with_openclaw_bot">entiti dengan bot OpenClaw</string>
     <string name="main_agent_card_deleted">Kad Ejen dipadam</string>
     <string name="main_agent_card_saved">Kad Ejen disimpan</string>
     <string name="main_delete_failed">Pemadaman gagal</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -293,6 +293,10 @@
     <string name="file_btn_download">ดาวน์โหลด</string>
     <string name="chat_load_image_failed">โหลดรูปภาพไม่สำเร็จ</string>
     <string name="wallpaper_no_bound_entities">ไม่มีเอนทิตีที่ถูกผูกไว้</string>
+    <string name="claw_renderer_loading_entities">กำลังโหลด Entity…</string>
+    <string name="claw_renderer_no_entities_connected">ไม่มี Entity เชื่อมต่อ</string>
+    <string name="claw_renderer_open_app_to_bind">เปิดแอป E-Claw เพื่อผูก</string>
+    <string name="claw_renderer_with_openclaw_bot">Entity กับบอท OpenClaw</string>
     <string name="main_agent_card_deleted">ลบ Agent Card แล้ว</string>
     <string name="main_agent_card_saved">บันทึก Agent Card แล้ว</string>
     <string name="main_delete_failed">ลบล้มเหลว</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -293,6 +293,10 @@
     <string name="file_btn_download">Tải xuống</string>
     <string name="chat_load_image_failed">Tải hình ảnh thất bại</string>
     <string name="wallpaper_no_bound_entities">Không có thực thể được liên kết</string>
+    <string name="claw_renderer_loading_entities">Đang tải thực thể…</string>
+    <string name="claw_renderer_no_entities_connected">Không có thực thể kết nối</string>
+    <string name="claw_renderer_open_app_to_bind">Mở app E-Claw để liên kết</string>
+    <string name="claw_renderer_with_openclaw_bot">thực thể với bot OpenClaw</string>
     <string name="main_agent_card_deleted">Đã xóa Agent Card</string>
     <string name="main_agent_card_saved">Đã lưu Agent Card</string>
     <string name="main_delete_failed">Xóa thất bại</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -293,6 +293,10 @@
     <string name="file_btn_download">下载</string>
     <string name="chat_load_image_failed">载入图片失败</string>
     <string name="wallpaper_no_bound_entities">无已绑定实体</string>
+    <string name="claw_renderer_loading_entities">正在加载实体…</string>
+    <string name="claw_renderer_no_entities_connected">无已连接实体</string>
+    <string name="claw_renderer_open_app_to_bind">打开 E-Claw 应用进行绑定</string>
+    <string name="claw_renderer_with_openclaw_bot">OpenClaw 机器人的实体</string>
     <string name="main_agent_card_deleted">Agent Card 已删除</string>
     <string name="main_agent_card_saved">Agent Card 已储存</string>
     <string name="main_delete_failed">删除失败</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -293,6 +293,10 @@
     <string name="file_btn_download">下載</string>
     <string name="chat_load_image_failed">載入圖片失敗</string>
     <string name="wallpaper_no_bound_entities">無已綁定實體</string>
+    <string name="claw_renderer_loading_entities">載入實體中…</string>
+    <string name="claw_renderer_no_entities_connected">無已連接實體</string>
+    <string name="claw_renderer_open_app_to_bind">開啟 E-Claw 應用綁定</string>
+    <string name="claw_renderer_with_openclaw_bot">OpenClaw 機器的實體</string>
     <string name="main_agent_card_deleted">Agent Card 已刪除</string>
     <string name="main_agent_card_saved">Agent Card 已儲存</string>
     <string name="main_delete_failed">刪除失敗</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -579,6 +579,10 @@ If you have any questions, please contact us via our official email.
     <string name="file_btn_download">Download</string>
     <string name="chat_load_image_failed">Failed to load image</string>
     <string name="wallpaper_no_bound_entities">No bound entities</string>
+    <string name="claw_renderer_loading_entities">Loading entities…</string>
+    <string name="claw_renderer_no_entities_connected">No entities connected</string>
+    <string name="claw_renderer_open_app_to_bind">Open E-Claw app to bind</string>
+    <string name="claw_renderer_with_openclaw_bot">entities with OpenClaw bot</string>
     <string name="main_agent_card_deleted">Agent Card deleted</string>
     <string name="main_agent_card_saved">Agent Card saved</string>
     <string name="main_delete_failed">Delete failed</string>


### PR DESCRIPTION
## Summary
4 個 ClawRenderer.kt canvas 畫布上的 hardcoded 英文字串 → strings.xml + 14 個 locale 翻譯

Card: card_a4c0df7ee6c07cf6b9fc1b13

### Changes
- **ClawRenderer.kt** (L432/L438/L441/L443): 4 處 `canvas.drawText("EN string")` → `context.getString(R.string.claw_renderer_xxx)`
- **strings.xml**: 新增 4 個 key (`claw_renderer_loading_entities` / `claw_renderer_no_entities_connected` / `claw_renderer_open_app_to_bind` / `claw_renderer_with_openclaw_bot`)
- **14 locales**: ar, de, es, fr, hi, in, ja, ko, ms, th, vi, zh-rCN, zh-rTW — 實際翻譯，非英文 passthrough

### Screenshot Review
⚠️ requiresScreenshotReview=true — 請在 sim 跑 wallpaper preview（無 entity），截 EN + ja 兩張圖確認字串正確切換後再 merge。

### PR Metadata
- requiresPrRework: false
- reviewerEntityId: 2