### PR TITLE
[codex] Finish marketplace P1 cleanup

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -3114,6 +3114,22 @@ const rentalModule = require('./rental')({
 });
 app.use('/api/rental', rentalModule.router);
 
+let rentalDatabaseReady = false;
+async function refreshRentalPricingMarketSnapshots(source = 'cron') {
+    if (!rentalDatabaseReady) return { skipped: 'rental_database_not_ready' };
+    if (typeof rentalModule?.refreshPricingMarketSnapshots !== 'function') {
+        return { skipped: 'snapshot_refresh_unavailable' };
+    }
+    try {
+        const result = await rentalModule.refreshPricingMarketSnapshots();
+        serverLog('info', 'rental', `[MarketSnapshot] ${source}: families=${result.familyCount} listings=${result.listingCount}`);
+        return result;
+    } catch (err) {
+        serverLog('error', 'rental', `[MarketSnapshot] ${source} failed: ${err.message}`);
+        return { error: err.message };
+    }
+}
+
 // P0 Phase 3: when an entity slot is rebound, every active listing pointing
 // at it now references a different bot. Auto-pause the listings so the
 // marketplace stops booking the slot. Owner can manually re-publish or delist.
@@ -3161,6 +3177,8 @@ async function terminateRentalContractsOnRebind(deviceId, entityId) {
 if (process.env.NODE_ENV !== 'test') {
     setTimeout(async () => {
         await rentalModule.initRentalDatabase();
+        rentalDatabaseReady = true;
+        await refreshRentalPricingMarketSnapshots('startup');
         // BUG-D3: Wait for persistence before reconciliation (685+ devices)
         const maxWait = 60;
         for (let i = 0; i < maxWait && !persistenceReady; i++) {
@@ -3185,6 +3203,13 @@ if (process.env.NODE_ENV !== 'test') {
             console.warn('[Rental] Skipped reconciliation — persistence not ready after 60s');
         }
     }, 2500);
+
+    // Hourly market pricing snapshot for the rental marketplace advisor.
+    nodeCron.schedule('11 * * * *', () => {
+        refreshRentalPricingMarketSnapshots('hourly').catch((err) => {
+            serverLog('error', 'rental', `[MarketSnapshot] cron dispatch failed: ${err.message}`);
+        });
+    });
 }
 
 // ============================================

--- a/backend/pricing-advisor.js
+++ b/backend/pricing-advisor.js
@@ -10,7 +10,7 @@
  *   - Market percentile from `pricing_market_snapshots`
  *
  * This module is pure: no DB writes, only reads. The snapshot table is
- * populated by a separate hourly cron (added in a follow-up PR).
+ * populated by the hourly rental market snapshot cron.
  */
 /* @brm-crossref: ⑤ Pricing Advisor
  * Design doc: docs/plans/2026-04-10-bot-rental-marketplace-design.md

--- a/backend/public/portal/marketplace.html
+++ b/backend/public/portal/marketplace.html
@@ -580,8 +580,16 @@
 
         async function getRentalUser() {
             if (window.currentUser) return window.currentUser;
-            const data = await fetchJson('/api/auth/me');
-            window.currentUser = data.user || null;
+            try {
+                const data = await fetchJson('/api/auth/me');
+                window.currentUser = data.user || null;
+            } catch (err) {
+                // WebView clients have no cookie session; swallow 401 so the
+                // localStorage deviceId fallback in rentListing can take over.
+                // Only redirect to login when /api/rental/contract itself 401s.
+                if (err.status !== 401) throw err;
+                window.currentUser = null;
+            }
             return window.currentUser;
         }
 

--- a/backend/public/portal/marketplace.html
+++ b/backend/public/portal/marketplace.html
@@ -481,33 +481,33 @@
                 <option value="rate_desc" data-i18n="mp_sort_expensive">Most Expensive</option>
             </select>
             <select class="mp-select" id="capabilitySelect" aria-label="Capability filter">
-                <option value="">All capabilities</option>
+                <option value="" data-i18n="mp_cap_filter_label">Capabilities</option>
                 <option value="python_exec">Python</option>
                 <option value="web_browse">Web browse</option>
                 <option value="vision">Vision</option>
                 <option value="reasoning">Reasoning</option>
                 <option value="coding">Coding</option>
             </select>
-            <input class="mp-field mp-rate-field" id="minRateInput" type="number" min="0" step="1" placeholder="Min e/1K" aria-label="Minimum e-coin per 1000 tokens">
-            <input class="mp-field mp-rate-field" id="maxRateInput" type="number" min="0" step="1" placeholder="Max e/1K" aria-label="Maximum e-coin per 1000 tokens">
+            <input class="mp-field mp-rate-field" id="minRateInput" type="number" min="0" step="1" placeholder="Min e/1K" data-i18n-placeholder="mp_rate_min_placeholder" aria-label="Minimum e-coin per 1000 tokens">
+            <input class="mp-field mp-rate-field" id="maxRateInput" type="number" min="0" step="1" placeholder="Max e/1K" data-i18n-placeholder="mp_rate_max_placeholder" aria-label="Maximum e-coin per 1000 tokens">
         </section>
 
         <section class="mp-stats" aria-label="Marketplace statistics">
             <div class="mp-stat">
                 <div class="mp-stat-value" id="statListings">0</div>
-                <div class="mp-stat-label">Available listings</div>
+                <div class="mp-stat-label" data-i18n="mp_stat_available_listings">Available listings</div>
             </div>
             <div class="mp-stat">
                 <div class="mp-stat-value" id="statMedian">-</div>
-                <div class="mp-stat-label">Median e-coin / 1K</div>
+                <div class="mp-stat-label" data-i18n="mp_stat_median_rate">Median e-coin / 1K</div>
             </div>
             <div class="mp-stat">
                 <div class="mp-stat-value" id="statCapabilities">0</div>
-                <div class="mp-stat-label">Capability tags</div>
+                <div class="mp-stat-label" data-i18n="mp_stat_capability_tags">Capability tags</div>
             </div>
             <div class="mp-stat">
                 <div class="mp-stat-value" id="statRented">0</div>
-                <div class="mp-stat-label">Currently rented</div>
+                <div class="mp-stat-label" data-i18n="mp_stat_currently_rented">Currently rented</div>
             </div>
         </section>
 
@@ -760,7 +760,7 @@
                     <div class="mp-detail-cell"><b>${tt('mp_d_duration', 'Duration')}</b>${Number(listing.min_rental_minutes || 30)}-${Number(listing.max_rental_minutes || 10080)} minutes</div>
                     <div class="mp-detail-cell"><b>${tt('mp_d_rating', 'Rating')}</b>${Number(listing.avg_rating || 0).toFixed(1)} / ${Number(listing.total_rentals || 0)} ${tt('mp_d_rentals', 'rentals')}</div>
                 </div>
-                <div class="mp-tags">${caps.length ? caps.map((cap) => `<span class="mp-tag">${esc(cap)}</span>`).join('') : '<span class="mp-muted">No supported capabilities reported</span>'}</div>
+                <div class="mp-tags">${caps.length ? caps.map((cap) => `<span class="mp-tag">${esc(cap)}</span>`).join('') : `<span class="mp-muted">${tt('mp_no_caps_reported', 'No supported capabilities reported')}</span>`}</div>
                 <label class="mp-muted" for="durationHours" style="display:block;margin-top:16px;">${tt('mp_d_rent_duration_hours', 'Rental duration (hours)')}</label>
                 <input class="mp-field" id="durationHours" type="number" min="${esc(minHours)}" max="${esc(maxHours)}" step="0.5" value="${esc(defaultHours)}" oninput="updateEstimate(${esc(rateMli)})">
                 <div class="mp-detail-cell" style="margin-top:10px;" id="estimateBox"></div>

--- a/backend/public/portal/marketplace.html
+++ b/backend/public/portal/marketplace.html
@@ -1,10 +1,835 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Redirecting to Bot Plaza...</title>
-    <script>window.location.replace('community.html#rental');</script>
+    <title data-i18n="mp_title">EClawbot - Bot Marketplace</title>
+    <meta name="description" content="Browse rentable EClawbot agents, compare rates, and start a bot rental contract.">
+    <link rel="icon" type="image/png" href="assets/favicon-32.png">
+    <link rel="canonical" href="https://eclawbot.com/portal/marketplace.html">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="EClawbot - Bot Marketplace">
+    <meta property="og:description" content="Browse rentable EClawbot agents, compare rates, and start a bot rental contract.">
+    <meta property="og:url" content="https://eclawbot.com/portal/marketplace.html">
+    <meta property="og:site_name" content="EClawbot">
+    <meta property="og:image" content="https://eclawbot.com/assets/og-image.png">
+    <link rel="stylesheet" href="shared/style.css">
+    <style>
+        :root {
+            --bg: #0D0D1A;
+            --card: #1A1A2E;
+            --card-border: #333355;
+            --input-bg: #252540;
+            --primary: #6C63FF;
+            --success: #10b981;
+            --warning: #f59e0b;
+            --danger: #ef4444;
+            --text: #ffffff;
+            --text-secondary: #b8b8c7;
+            --text-muted: #85859a;
+            --radius-sm: 8px;
+            --radius-pill: 999px;
+        }
+
+        body {
+            margin: 0;
+            background: var(--bg);
+            color: var(--text);
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+        }
+
+        .mp-container {
+            width: min(1180px, calc(100% - 32px));
+            margin: 0 auto;
+            padding: 24px 0 36px;
+        }
+
+        .mp-header {
+            display: flex;
+            align-items: flex-end;
+            justify-content: space-between;
+            gap: 20px;
+            margin-bottom: 18px;
+        }
+
+        .mp-title {
+            margin: 0 0 6px;
+            font-size: 28px;
+            line-height: 1.15;
+            font-weight: 760;
+            letter-spacing: 0;
+        }
+
+        .mp-subtitle {
+            margin: 0;
+            max-width: 620px;
+            color: var(--text-secondary);
+            font-size: 14px;
+            line-height: 1.5;
+        }
+
+        .mp-header-actions {
+            display: flex;
+            gap: 10px;
+            flex-wrap: wrap;
+            justify-content: flex-end;
+        }
+
+        .mp-btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 40px;
+            padding: 0 14px;
+            border-radius: var(--radius-sm);
+            border: 1px solid var(--card-border);
+            background: var(--input-bg);
+            color: var(--text);
+            font: inherit;
+            font-size: 13px;
+            font-weight: 650;
+            cursor: pointer;
+            text-decoration: none;
+            white-space: nowrap;
+        }
+
+        .mp-btn.primary {
+            border-color: var(--success);
+            background: var(--success);
+            color: #06130f;
+        }
+
+        .mp-btn:disabled {
+            opacity: 0.55;
+            cursor: not-allowed;
+        }
+
+        .mp-toolbar {
+            display: grid;
+            grid-template-columns: minmax(220px, 1fr) repeat(4, max-content);
+            gap: 10px;
+            align-items: center;
+            padding: 12px;
+            border: 1px solid var(--card-border);
+            border-radius: var(--radius-sm);
+            background: rgba(26, 26, 46, 0.78);
+            margin-bottom: 14px;
+        }
+
+        .mp-field,
+        .mp-select {
+            min-height: 40px;
+            border: 1px solid var(--card-border);
+            border-radius: var(--radius-sm);
+            background: var(--input-bg);
+            color: var(--text);
+            font: inherit;
+            font-size: 13px;
+            outline: none;
+        }
+
+        .mp-field {
+            width: 100%;
+            box-sizing: border-box;
+            padding: 0 12px;
+        }
+
+        .mp-select {
+            padding: 0 32px 0 12px;
+        }
+
+        .mp-rate-field {
+            width: 96px;
+        }
+
+        .mp-stats {
+            display: grid;
+            grid-template-columns: repeat(4, minmax(0, 1fr));
+            gap: 10px;
+            margin-bottom: 16px;
+        }
+
+        .mp-stat {
+            border: 1px solid var(--card-border);
+            border-radius: var(--radius-sm);
+            padding: 12px;
+            background: rgba(26, 26, 46, 0.6);
+        }
+
+        .mp-stat-value {
+            font-size: 20px;
+            font-weight: 760;
+            line-height: 1.2;
+        }
+
+        .mp-stat-label {
+            margin-top: 4px;
+            color: var(--text-secondary);
+            font-size: 12px;
+        }
+
+        .mp-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+            gap: 12px;
+        }
+
+        .mp-card {
+            min-height: 246px;
+            display: flex;
+            flex-direction: column;
+            border: 1px solid var(--card-border);
+            border-left: 3px solid var(--success);
+            border-radius: var(--radius-sm);
+            background: var(--card);
+            padding: 14px;
+            cursor: pointer;
+        }
+
+        .mp-card.rented {
+            border-left-color: var(--danger);
+        }
+
+        .mp-card-header {
+            display: grid;
+            grid-template-columns: 48px minmax(0, 1fr);
+            gap: 10px;
+            align-items: center;
+            margin-bottom: 10px;
+        }
+
+        .mp-avatar {
+            width: 48px;
+            height: 48px;
+            border-radius: var(--radius-sm);
+            display: grid;
+            place-items: center;
+            background: var(--input-bg);
+            color: var(--text-secondary);
+            font-weight: 760;
+            overflow: hidden;
+        }
+
+        .mp-avatar img {
+            width: 100%;
+            height: 100%;
+            object-fit: cover;
+        }
+
+        .mp-card-title {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            font-weight: 720;
+            font-size: 15px;
+        }
+
+        .mp-card-model {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            color: var(--text-secondary);
+            font-size: 12px;
+            margin-top: 3px;
+        }
+
+        .mp-desc {
+            color: var(--text-secondary);
+            font-size: 13px;
+            line-height: 1.45;
+            min-height: 56px;
+            display: -webkit-box;
+            -webkit-line-clamp: 3;
+            -webkit-box-orient: vertical;
+            overflow: hidden;
+        }
+
+        .mp-card-row {
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 10px;
+            margin-top: 12px;
+        }
+
+        .mp-rate {
+            font-weight: 760;
+            color: var(--success);
+        }
+
+        .mp-muted {
+            color: var(--text-secondary);
+            font-size: 12px;
+        }
+
+        .mp-tags {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 5px;
+            min-height: 24px;
+            margin-top: 12px;
+        }
+
+        .mp-tag {
+            max-width: 130px;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            padding: 3px 8px;
+            border-radius: var(--radius-pill);
+            background: var(--input-bg);
+            color: var(--text-secondary);
+            font-size: 11px;
+        }
+
+        .mp-card-actions {
+            display: flex;
+            gap: 8px;
+            margin-top: auto;
+            padding-top: 14px;
+        }
+
+        .mp-status {
+            display: inline-flex;
+            align-items: center;
+            min-height: 24px;
+            padding: 0 9px;
+            border-radius: var(--radius-pill);
+            background: rgba(16, 185, 129, 0.14);
+            color: #6ee7b7;
+            font-size: 11px;
+            font-weight: 700;
+        }
+
+        .mp-status.rented {
+            background: rgba(239, 68, 68, 0.14);
+            color: #fca5a5;
+        }
+
+        .mp-empty,
+        .mp-loading {
+            min-height: 240px;
+            display: grid;
+            place-items: center;
+            border: 1px dashed var(--card-border);
+            border-radius: var(--radius-sm);
+            color: var(--text-secondary);
+            text-align: center;
+            padding: 24px;
+        }
+
+        .mp-modal {
+            position: fixed;
+            inset: 0;
+            z-index: 1000;
+            display: none;
+            align-items: center;
+            justify-content: center;
+            padding: 18px;
+            background: rgba(0, 0, 0, 0.64);
+        }
+
+        .mp-modal.open {
+            display: flex;
+        }
+
+        .mp-dialog {
+            width: min(620px, 100%);
+            max-height: min(760px, 90vh);
+            overflow: auto;
+            border: 1px solid var(--card-border);
+            border-radius: var(--radius-sm);
+            background: var(--card);
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.45);
+        }
+
+        .mp-dialog-head {
+            position: sticky;
+            top: 0;
+            z-index: 1;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 12px;
+            padding: 14px 16px;
+            border-bottom: 1px solid var(--card-border);
+            background: var(--card);
+        }
+
+        .mp-close {
+            width: 36px;
+            height: 36px;
+            border-radius: var(--radius-sm);
+            border: 1px solid var(--card-border);
+            background: var(--input-bg);
+            color: var(--text);
+            cursor: pointer;
+            font-size: 18px;
+        }
+
+        .mp-dialog-body {
+            padding: 16px;
+        }
+
+        .mp-detail-grid {
+            display: grid;
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+            gap: 10px;
+            margin: 14px 0;
+        }
+
+        .mp-detail-cell {
+            border: 1px solid var(--card-border);
+            border-radius: var(--radius-sm);
+            padding: 10px;
+            background: rgba(37, 37, 64, 0.66);
+        }
+
+        .mp-detail-cell b {
+            display: block;
+            margin-bottom: 5px;
+            font-size: 12px;
+            color: var(--text-secondary);
+        }
+
+        .mp-consent {
+            display: grid;
+            grid-template-columns: 18px minmax(0, 1fr);
+            gap: 8px;
+            align-items: start;
+            margin: 12px 0;
+            color: var(--text-secondary);
+            font-size: 13px;
+            line-height: 1.4;
+        }
+
+        @media (max-width: 820px) {
+            .mp-header {
+                align-items: flex-start;
+                flex-direction: column;
+            }
+
+            .mp-header-actions {
+                justify-content: flex-start;
+            }
+
+            .mp-toolbar {
+                grid-template-columns: 1fr 1fr;
+            }
+
+            .mp-toolbar .mp-field:first-child {
+                grid-column: 1 / -1;
+            }
+
+            .mp-stats {
+                grid-template-columns: repeat(2, minmax(0, 1fr));
+            }
+        }
+
+        @media (max-width: 520px) {
+            .mp-container {
+                width: min(100% - 20px, 1180px);
+                padding-top: 14px;
+            }
+
+            .mp-title {
+                font-size: 23px;
+            }
+
+            .mp-toolbar,
+            .mp-stats,
+            .mp-detail-grid {
+                grid-template-columns: 1fr;
+            }
+
+            .mp-rate-field {
+                width: 100%;
+            }
+
+            .mp-grid {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
 </head>
-<body><p>Redirecting to <a href="community.html#rental">Bot Plaza</a>...</p></body>
+
+<body>
+    <script src="shared/nav.js"></script>
+    <script>
+        renderNav('marketplace');
+    </script>
+
+    <main class="mp-container">
+        <section class="mp-header" aria-label="Marketplace header">
+            <div>
+                <h1 class="mp-title" data-i18n="mp_heading">Bot Marketplace</h1>
+                <p class="mp-subtitle" data-i18n="mp_desc">Rent premium AI bots on-demand. Pay per token, no subscription required.</p>
+            </div>
+            <div class="mp-header-actions">
+                <a class="mp-btn" href="my-rentals.html" data-i18n="nav_my_rentals">My Rentals</a>
+                <a class="mp-btn primary" href="card-holder.html" data-i18n="dash_plaza_publish">Publish to Bot Plaza</a>
+            </div>
+        </section>
+
+        <section class="mp-toolbar" aria-label="Marketplace filters">
+            <input class="mp-field" id="searchInput" type="search" placeholder="Search bots..." data-i18n-placeholder="mp_search_placeholder" maxlength="100">
+            <select class="mp-select" id="sortSelect" aria-label="Sort listings">
+                <option value="rating" data-i18n="mp_sort_rating">Top Rated</option>
+                <option value="newest" data-i18n="mp_sort_newest">Newest</option>
+                <option value="rate_asc" data-i18n="mp_sort_cheap">Cheapest</option>
+                <option value="rate_desc" data-i18n="mp_sort_expensive">Most Expensive</option>
+            </select>
+            <select class="mp-select" id="capabilitySelect" aria-label="Capability filter">
+                <option value="">All capabilities</option>
+                <option value="python_exec">Python</option>
+                <option value="web_browse">Web browse</option>
+                <option value="vision">Vision</option>
+                <option value="reasoning">Reasoning</option>
+                <option value="coding">Coding</option>
+            </select>
+            <input class="mp-field mp-rate-field" id="minRateInput" type="number" min="0" step="1" placeholder="Min e/1K" aria-label="Minimum e-coin per 1000 tokens">
+            <input class="mp-field mp-rate-field" id="maxRateInput" type="number" min="0" step="1" placeholder="Max e/1K" aria-label="Maximum e-coin per 1000 tokens">
+        </section>
+
+        <section class="mp-stats" aria-label="Marketplace statistics">
+            <div class="mp-stat">
+                <div class="mp-stat-value" id="statListings">0</div>
+                <div class="mp-stat-label">Available listings</div>
+            </div>
+            <div class="mp-stat">
+                <div class="mp-stat-value" id="statMedian">-</div>
+                <div class="mp-stat-label">Median e-coin / 1K</div>
+            </div>
+            <div class="mp-stat">
+                <div class="mp-stat-value" id="statCapabilities">0</div>
+                <div class="mp-stat-label">Capability tags</div>
+            </div>
+            <div class="mp-stat">
+                <div class="mp-stat-value" id="statRented">0</div>
+                <div class="mp-stat-label">Currently rented</div>
+            </div>
+        </section>
+
+        <section id="statePanel" class="mp-loading" data-i18n="mp_loading">Loading...</section>
+        <section class="mp-grid" id="listingGrid" aria-live="polite"></section>
+    </main>
+
+    <div class="mp-modal" id="detailModal" role="dialog" aria-modal="true" aria-labelledby="detailTitle" onclick="if (event.target === this) closeDetail()">
+        <div class="mp-dialog">
+            <div class="mp-dialog-head">
+                <strong id="detailTitle" data-i18n="cardholder_details">Details</strong>
+                <button class="mp-close" type="button" onclick="closeDetail()" aria-label="Close" data-i18n-aria-label="mc_note_page_close">x</button>
+            </div>
+            <div class="mp-dialog-body" id="detailBody"></div>
+        </div>
+    </div>
+
+    <script src="../shared/i18n.js"></script>
+    <script src="shared/auth.js"></script>
+    <script src="shared/footer.js"></script>
+    <script src="../shared/telemetry.js"></script>
+    <script>
+        const state = {
+            listings: [],
+            filtered: [],
+            loading: false,
+            debounce: null,
+            detail: null,
+        };
+
+        function tt(key, fallback) {
+            if (window.i18n && typeof window.i18n.t === 'function') {
+                const translated = window.i18n.t(key);
+                return translated === key ? fallback : translated;
+            }
+            return fallback;
+        }
+
+        function esc(value) {
+            return String(value == null ? '' : value)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
+        function ecoin(mli, digits = 1) {
+            const n = Number(mli || 0) / 1000;
+            return Number.isFinite(n) ? n.toFixed(digits) : '0.0';
+        }
+
+        function supportedCaps(capabilities) {
+            if (!capabilities || typeof capabilities !== 'object') return [];
+            return Object.keys(capabilities).filter((key) => capabilities[key] && capabilities[key].supported === true);
+        }
+
+        async function fetchJson(path, options) {
+            const res = await fetch(location.origin + path, Object.assign({ credentials: 'include' }, options || {}));
+            let data = null;
+            try { data = await res.json(); } catch (_) { data = null; }
+            if (!res.ok || (data && data.success === false)) {
+                const err = new Error((data && data.error) || ('HTTP ' + res.status));
+                err.status = res.status;
+                err.data = data;
+                throw err;
+            }
+            return data || {};
+        }
+
+        async function getRentalUser() {
+            if (window.currentUser) return window.currentUser;
+            const data = await fetchJson('/api/auth/me');
+            window.currentUser = data.user || null;
+            return window.currentUser;
+        }
+
+        function buildQuery() {
+            const params = new URLSearchParams({
+                sort: document.getElementById('sortSelect').value || 'rating',
+                limit: '80',
+            });
+            const cap = document.getElementById('capabilitySelect').value;
+            const min = Number(document.getElementById('minRateInput').value || 0);
+            const max = Number(document.getElementById('maxRateInput').value || 0);
+            if (cap) params.set('capability', cap);
+            if (Number.isFinite(min) && min > 0) params.set('minRateMli', String(Math.round(min * 1000)));
+            if (Number.isFinite(max) && max > 0) params.set('maxRateMli', String(Math.round(max * 1000)));
+            return params;
+        }
+
+        async function loadMarketplace() {
+            state.loading = true;
+            renderState(tt('mp_loading', 'Loading...'));
+            try {
+                const data = await fetchJson('/api/rental/marketplace?' + buildQuery().toString());
+                state.listings = (data.listings || []).map((listing) => ({
+                    ...listing,
+                    caps: supportedCaps(listing.capabilities),
+                }));
+                filterLocal();
+            } catch (err) {
+                renderState(tt('mp_load_error', 'Failed to load'));
+                console.error('[Marketplace] load failed:', err);
+            } finally {
+                state.loading = false;
+            }
+        }
+
+        function filterLocal() {
+            const query = document.getElementById('searchInput').value.trim().toLowerCase();
+            state.filtered = state.listings.filter((listing) => {
+                if (!query) return true;
+                const haystack = [
+                    listing.title,
+                    listing.description,
+                    listing.model_detected,
+                    ...(listing.caps || []),
+                ].join(' ').toLowerCase();
+                return haystack.includes(query);
+            });
+            renderStats();
+            renderGrid();
+        }
+
+        function renderStats() {
+            const rates = state.filtered
+                .map((listing) => Number(listing.rate_mli_per_ktoken || 0))
+                .filter((rate) => Number.isFinite(rate) && rate > 0)
+                .sort((a, b) => a - b);
+            const median = rates.length ? rates[Math.floor((rates.length - 1) / 2)] : 0;
+            const caps = new Set(state.filtered.flatMap((listing) => listing.caps || []));
+            document.getElementById('statListings').textContent = String(state.filtered.length);
+            document.getElementById('statMedian').textContent = rates.length ? ecoin(median) : '-';
+            document.getElementById('statCapabilities').textContent = String(caps.size);
+            document.getElementById('statRented').textContent = String(state.filtered.filter((listing) => listing.has_active_contract).length);
+        }
+
+        function renderState(message) {
+            const panel = document.getElementById('statePanel');
+            const grid = document.getElementById('listingGrid');
+            panel.className = message && message === tt('mp_loading', 'Loading...') ? 'mp-loading' : 'mp-empty';
+            panel.textContent = message;
+            panel.style.display = message ? 'grid' : 'none';
+            grid.innerHTML = '';
+        }
+
+        function renderGrid() {
+            const panel = document.getElementById('statePanel');
+            const grid = document.getElementById('listingGrid');
+            if (!state.filtered.length) {
+                renderState(tt('mp_no_results', 'No bots available yet. Check back later!'));
+                return;
+            }
+            panel.style.display = 'none';
+            grid.innerHTML = state.filtered.map(renderCard).join('');
+        }
+
+        function renderAvatar(listing) {
+            const avatar = listing.avatar_url || '';
+            if (/^https?:\/\//.test(avatar)) {
+                return `<img src="${esc(avatar)}" alt="">`;
+            }
+            const title = String(listing.title || 'Bot').trim();
+            return esc(title.slice(0, 1).toUpperCase() || 'B');
+        }
+
+        function renderCard(listing) {
+            const isRented = !!listing.has_active_contract;
+            const caps = (listing.caps || []).slice(0, 4);
+            const rate = ecoin(listing.rate_mli_per_ktoken);
+            const deposit = ecoin(Number(listing.rate_mli_per_ktoken || 0) * 20, 0);
+            return `
+                <article class="mp-card ${isRented ? 'rented' : ''}" onclick="openDetail('${esc(listing.id)}')">
+                    <div class="mp-card-header">
+                        <div class="mp-avatar">${renderAvatar(listing)}</div>
+                        <div>
+                            <div class="mp-card-title">${esc(listing.title || 'Rental Bot')}</div>
+                            <div class="mp-card-model">${esc(listing.model_detected || 'Model pending')}</div>
+                        </div>
+                    </div>
+                    <div class="mp-desc">${esc(listing.description || 'No description provided yet.')}</div>
+                    <div class="mp-card-row">
+                        <span class="mp-rate">${rate} e / 1K</span>
+                        <span class="mp-muted">${tt('mp_d_deposit', 'Deposit')} ${deposit} e</span>
+                    </div>
+                    <div class="mp-card-row">
+                        <span class="mp-status ${isRented ? 'rented' : ''}">${isRented ? tt('mp_status_rented', 'Rented') : tt('mp_status_available', 'Available')}</span>
+                        <span class="mp-muted">${Number(listing.avg_rating || 0).toFixed(1)} ${tt('mp_d_rating', 'Rating')}</span>
+                    </div>
+                    <div class="mp-tags">${caps.map((cap) => `<span class="mp-tag">${esc(cap)}</span>`).join('')}</div>
+                    <div class="mp-card-actions">
+                        <button class="mp-btn" type="button" onclick="event.stopPropagation();openDetail('${esc(listing.id)}')">${tt('cardholder_details', 'Details')}</button>
+                        ${listing.owner_public_code ? `<a class="mp-btn" onclick="event.stopPropagation()" href="/c/${esc(listing.owner_public_code)}?utm_source=marketplace&utm_medium=card" target="_blank" rel="noopener">${tt('mp_chat_cta', 'Start chat')}</a>` : ''}
+                    </div>
+                </article>`;
+        }
+
+        async function openDetail(listingId) {
+            const modal = document.getElementById('detailModal');
+            const body = document.getElementById('detailBody');
+            const title = document.getElementById('detailTitle');
+            modal.classList.add('open');
+            body.innerHTML = `<div class="mp-loading">${tt('mp_loading', 'Loading...')}</div>`;
+            try {
+                const data = await fetchJson('/api/rental/listing/' + encodeURIComponent(listingId));
+                const listing = data.listing || data;
+                state.detail = listing;
+                title.textContent = listing.title || tt('cardholder_details', 'Details');
+                body.innerHTML = renderDetail(listing);
+                updateEstimate(Number(listing.rate_mli_per_ktoken || 0));
+            } catch (err) {
+                body.innerHTML = `<div class="mp-empty">${tt('mp_load_error', 'Failed to load')}</div>`;
+                console.error('[Marketplace] detail failed:', err);
+            }
+        }
+
+        function closeDetail() {
+            document.getElementById('detailModal').classList.remove('open');
+            state.detail = null;
+        }
+
+        function renderDetail(listing) {
+            const caps = supportedCaps(listing.capabilities);
+            const rateMli = Number(listing.rate_mli_per_ktoken || 0);
+            const minHours = Math.max(0.5, Number(listing.min_rental_minutes || 30) / 60);
+            const maxHours = Math.max(minHours, Number(listing.max_rental_minutes || 10080) / 60);
+            const defaultHours = Math.min(maxHours, Math.max(minHours, 1));
+            const isRented = !!listing.has_active_contract;
+            return `
+                <div class="mp-card-header">
+                    <div class="mp-avatar">${renderAvatar(listing)}</div>
+                    <div>
+                        <div class="mp-card-title">${esc(listing.title || 'Rental Bot')}</div>
+                        <div class="mp-card-model">${esc(listing.model_detected || 'Model pending')}</div>
+                    </div>
+                </div>
+                <p class="mp-subtitle">${esc(listing.description || 'No description provided yet.')}</p>
+                <div class="mp-detail-grid">
+                    <div class="mp-detail-cell"><b>${tt('mp_d_rate', 'Rate')}</b>${ecoin(rateMli)} e-coin / 1K tokens</div>
+                    <div class="mp-detail-cell"><b>${tt('mp_d_deposit', 'Deposit')}</b>${ecoin(rateMli * 20, 0)} e-coin</div>
+                    <div class="mp-detail-cell"><b>${tt('mp_d_duration', 'Duration')}</b>${Number(listing.min_rental_minutes || 30)}-${Number(listing.max_rental_minutes || 10080)} minutes</div>
+                    <div class="mp-detail-cell"><b>${tt('mp_d_rating', 'Rating')}</b>${Number(listing.avg_rating || 0).toFixed(1)} / ${Number(listing.total_rentals || 0)} ${tt('mp_d_rentals', 'rentals')}</div>
+                </div>
+                <div class="mp-tags">${caps.length ? caps.map((cap) => `<span class="mp-tag">${esc(cap)}</span>`).join('') : '<span class="mp-muted">No supported capabilities reported</span>'}</div>
+                <label class="mp-muted" for="durationHours" style="display:block;margin-top:16px;">${tt('mp_d_rent_duration_hours', 'Rental duration (hours)')}</label>
+                <input class="mp-field" id="durationHours" type="number" min="${esc(minHours)}" max="${esc(maxHours)}" step="0.5" value="${esc(defaultHours)}" oninput="updateEstimate(${esc(rateMli)})">
+                <div class="mp-detail-cell" style="margin-top:10px;" id="estimateBox"></div>
+                <label class="mp-consent">
+                    <input id="rentalConsent" type="checkbox" onchange="updateRentButton()">
+                    <span>${tt('mp_privacy_agree', 'I understand and agree')}</span>
+                </label>
+                <button class="mp-btn primary" id="rentButton" type="button" onclick="rentListing('${esc(listing.id)}')" ${isRented ? 'disabled' : ''}>${isRented ? tt('mp_status_rented', 'Rented') : tt('mp_rent_now', 'Rent Now')}</button>
+                <div class="mp-muted" id="rentMessage" style="margin-top:10px;"></div>
+            `;
+        }
+
+        function updateEstimate(rateMli) {
+            const hours = Number(document.getElementById('durationHours')?.value || 1);
+            const estimate = Number.isFinite(hours) ? Math.max(0, hours * rateMli) : rateMli;
+            const box = document.getElementById('estimateBox');
+            if (box) box.innerHTML = `<b>${tt('mp_est_usage', 'Estimated usage')}</b>${ecoin(estimate)} e-coin`;
+            updateRentButton();
+        }
+
+        function updateRentButton() {
+            const btn = document.getElementById('rentButton');
+            const consent = document.getElementById('rentalConsent');
+            if (!btn || btn.textContent === tt('mp_status_rented', 'Rented')) return;
+            btn.disabled = !consent?.checked;
+        }
+
+        async function rentListing(listingId) {
+            const btn = document.getElementById('rentButton');
+            const msg = document.getElementById('rentMessage');
+            const hours = Number(document.getElementById('durationHours')?.value || 1);
+            const durationMinutes = Math.max(30, Math.round(hours * 60));
+            btn.disabled = true;
+            msg.textContent = tt('mp_renting', 'Processing...');
+            try {
+                const user = await getRentalUser();
+                const renterDeviceId = user?.deviceId || user?.device_id
+                    || localStorage.getItem('deviceId')
+                    || localStorage.getItem('eclaw_device_id');
+                if (!renterDeviceId) throw new Error('renter_device_id_missing');
+                await fetchJson('/api/rental/contract', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ listingId, renterDeviceId, durationMinutes }),
+                });
+                msg.textContent = tt('mp_rent_success', 'Rental started! Check My Rentals for details.');
+                setTimeout(() => { window.location.href = 'my-rentals.html'; }, 900);
+            } catch (err) {
+                if (err.status === 401) {
+                    window.location.href = 'index.html?next=marketplace.html';
+                    return;
+                }
+                msg.textContent = (err.data && err.data.error) || err.message || tt('mp_load_error', 'Failed to load');
+                btn.disabled = false;
+            }
+        }
+
+        function bindControls() {
+            ['sortSelect', 'capabilitySelect', 'minRateInput', 'maxRateInput'].forEach((id) => {
+                document.getElementById(id).addEventListener('change', loadMarketplace);
+            });
+            document.getElementById('searchInput').addEventListener('input', () => {
+                clearTimeout(state.debounce);
+                state.debounce = setTimeout(filterLocal, 150);
+            });
+            document.addEventListener('keydown', (event) => {
+                if (event.key === 'Escape') closeDetail();
+            });
+        }
+
+        document.addEventListener('DOMContentLoaded', () => {
+            bindControls();
+            loadMarketplace();
+            if (typeof renderFooter === 'function') renderFooter();
+            if (typeof i18n !== 'undefined') i18n.apply();
+        });
+    </script>
+</body>
+
 </html>

--- a/backend/public/portal/roadmap.html
+++ b/backend/public/portal/roadmap.html
@@ -291,8 +291,8 @@
                     <li data-i18n="rm_p1_t4">Pricing advisor (base rate × capability multiplier)</li>
                     <li data-i18n="rm_p1_t5">64 Jest unit tests</li>
                     <li data-i18n="rm_p1_t6">HTTP probe dispatch to owner webhooks</li>
-                    <li class="todo" data-i18n="rm_p1_t7">Market snapshot hourly cron</li>
-                    <li class="todo" data-i18n="rm_p1_t8">Marketplace portal page</li>
+                    <li data-i18n="rm_p1_t7">Market snapshot hourly cron</li>
+                    <li data-i18n="rm_p1_t8">Marketplace portal page</li>
                 </ul>
             </div>
 

--- a/backend/public/portal/shared/nav.js
+++ b/backend/public/portal/shared/nav.js
@@ -14,6 +14,7 @@ function renderNav(activePage) {
         { id: 'card-holder', i18nKey: 'nav_card_holder', label: 'Cards', href: 'card-holder.html', icon: '🗂️' },
         { id: 'invite', i18nKey: 'nav_invite', label: 'Invite Friends', href: 'invite.html', icon: '🎁' },
         { id: 'community', i18nKey: 'nav_community', label: 'Community', href: 'community.html', icon: '🏪' },
+        { id: 'marketplace', i18nKey: 'nav_marketplace', label: 'Marketplace', href: 'marketplace.html', icon: '🤝' },
         { id: 'settings', i18nKey: 'nav_settings', label: 'Settings', href: 'settings.html', icon: '⚙️' },
         { id: 'info', i18nKey: 'nav_info', label: 'Info', href: 'info.html', icon: '📖' }
     ];

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -315548,6 +315548,13 @@ const TRANSLATIONS = {
 
 
         "mp_rate_unit": "e\u5e63/1K",
+        "mp_rate_min_placeholder": "Min e/1K",
+        "mp_rate_max_placeholder": "Max e/1K",
+        "mp_stat_available_listings": "Available listings",
+        "mp_stat_median_rate": "Median e-coin / 1K",
+        "mp_stat_capability_tags": "Capability tags",
+        "mp_stat_currently_rented": "Currently rented",
+        "mp_no_caps_reported": "No supported capabilities reported",
 
 
 
@@ -943748,6 +943755,13 @@ const TRANSLATIONS = {
 
 
         "mp_rate_unit": "e幣/1K",
+        "mp_rate_min_placeholder": "最低 e/1K",
+        "mp_rate_max_placeholder": "最高 e/1K",
+        "mp_stat_available_listings": "可租借列表",
+        "mp_stat_median_rate": "e 幣中位費率 / 1K",
+        "mp_stat_capability_tags": "能力標籤",
+        "mp_stat_currently_rented": "目前已出租",
+        "mp_no_caps_reported": "未回報支援能力",
 
 
 
@@ -1676868,6 +1676882,13 @@ const TRANSLATIONS = {
 
 
         "mp_rate_unit": "e幣/1K",
+        "mp_rate_min_placeholder": "最低 e/1K",
+        "mp_rate_max_placeholder": "最高 e/1K",
+        "mp_stat_available_listings": "可租借列表",
+        "mp_stat_median_rate": "e 币中位费率 / 1K",
+        "mp_stat_capability_tags": "能力标签",
+        "mp_stat_currently_rented": "当前已出租",
+        "mp_no_caps_reported": "未报告支持能力",
 
 
 
@@ -2117953,6 +2117974,13 @@ const TRANSLATIONS = {
 
 
         "mp_rate_unit": "eコイン/1K",
+        "mp_rate_min_placeholder": "最小 e/1K",
+        "mp_rate_max_placeholder": "最大 e/1K",
+        "mp_stat_available_listings": "利用可能な掲載",
+        "mp_stat_median_rate": "eコイン中央値 / 1K",
+        "mp_stat_capability_tags": "能力タグ",
+        "mp_stat_currently_rented": "現在レンタル中",
+        "mp_no_caps_reported": "対応機能の報告なし",
 
 
 
@@ -2680738,6 +2680766,13 @@ const TRANSLATIONS = {
 
 
         "mp_rate_unit": "e코인/1K",
+        "mp_rate_min_placeholder": "최소 e/1K",
+        "mp_rate_max_placeholder": "최대 e/1K",
+        "mp_stat_available_listings": "대여 가능 목록",
+        "mp_stat_median_rate": "e-coin 중앙값 / 1K",
+        "mp_stat_capability_tags": "기능 태그",
+        "mp_stat_currently_rented": "현재 대여 중",
+        "mp_no_caps_reported": "지원되는 기능 정보 없음",
 
 
 
@@ -2940887,6 +2940922,13 @@ const TRANSLATIONS = {
         "listing_soft_paused_resume_btn": "恢復上架",
         "rental_create_rejected_soft_paused": "此上架項目因健康檢查異常而暫時無法租借。",
         "mp_chat_cta": "開始對話",
+        "mp_rate_min_placeholder": "最低 e/1K",
+        "mp_rate_max_placeholder": "最高 e/1K",
+        "mp_stat_available_listings": "可租借列表",
+        "mp_stat_median_rate": "e 幣中位費率 / 1K",
+        "mp_stat_capability_tags": "能力標籤",
+        "mp_stat_currently_rented": "目前已出租",
+        "mp_no_caps_reported": "未回報支援能力",
         "invite_unlimited_label": "已送出（無限制）",
         "wallet_topup_success": "儲值成功！",
         "wallet_topup_failed": "儲值失敗，請再試一次。",
@@ -3439024,6 +3439066,13 @@ const TRANSLATIONS = {
 
 
         "mp_rate_unit": "e幣/1K",
+        "mp_rate_min_placeholder": "ต่ำสุด e/1K",
+        "mp_rate_max_placeholder": "สูงสุด e/1K",
+        "mp_stat_available_listings": "รายการที่พร้อมให้เช่า",
+        "mp_stat_median_rate": "ค่ามัธยฐาน e-coin / 1K",
+        "mp_stat_capability_tags": "แท็กความสามารถ",
+        "mp_stat_currently_rented": "กำลังเช่าอยู่",
+        "mp_no_caps_reported": "ไม่มีการรายงานความสามารถที่รองรับ",
 
 
 
@@ -3967831,6 +3967880,13 @@ const TRANSLATIONS = {
 
 
         "mp_rate_unit": "e幣/1K",
+        "mp_rate_min_placeholder": "Tối thiểu e/1K",
+        "mp_rate_max_placeholder": "Tối đa e/1K",
+        "mp_stat_available_listings": "Danh sách sẵn sàng thuê",
+        "mp_stat_median_rate": "Trung vị e-coin / 1K",
+        "mp_stat_capability_tags": "Thẻ năng lực",
+        "mp_stat_currently_rented": "Đang được thuê",
+        "mp_no_caps_reported": "Không có khả năng được hỗ trợ",
 
 
 
@@ -4494945,6 +4495001,13 @@ const TRANSLATIONS = {
 
 
         "mp_rate_unit": "e幣/1K",
+        "mp_rate_min_placeholder": "Min e/1K",
+        "mp_rate_max_placeholder": "Maks e/1K",
+        "mp_stat_available_listings": "Listing tersedia",
+        "mp_stat_median_rate": "Median e-coin / 1K",
+        "mp_stat_capability_tags": "Tag kemampuan",
+        "mp_stat_currently_rented": "Sedang disewa",
+        "mp_no_caps_reported": "Tidak ada kapabilitas yang dilaporkan",
 
 
 
@@ -4794590,6 +4794653,13 @@ const TRANSLATIONS = {
 
 
         "mp_rate_unit": "e-coins/1K",
+        "mp_rate_min_placeholder": "Min e/1K",
+        "mp_rate_max_placeholder": "Max e/1K",
+        "mp_stat_available_listings": "Annonces disponibles",
+        "mp_stat_median_rate": "Médiane e-coin / 1K",
+        "mp_stat_capability_tags": "Étiquettes de capacités",
+        "mp_stat_currently_rented": "Actuellement loués",
+        "mp_no_caps_reported": "Aucune capacité prise en charge signalée",
 
 
 
@@ -5317460,6 +5317530,13 @@ const TRANSLATIONS = {
 
 
         "mp_rate_unit": "e-monedas/1K",
+        "mp_rate_min_placeholder": "Mín e/1K",
+        "mp_rate_max_placeholder": "Máx e/1K",
+        "mp_stat_available_listings": "Anuncios disponibles",
+        "mp_stat_median_rate": "Mediana e-coin / 1K",
+        "mp_stat_capability_tags": "Etiquetas de capacidades",
+        "mp_stat_currently_rented": "Actualmente alquilados",
+        "mp_no_caps_reported": "Sin capacidades compatibles reportadas",
 
 
 
@@ -5835910,6 +5835987,13 @@ const TRANSLATIONS = {
 
 
         "mp_rate_unit": "e-Münzen/1K",
+        "mp_rate_min_placeholder": "Min. e/1K",
+        "mp_rate_max_placeholder": "Max. e/1K",
+        "mp_stat_available_listings": "Verfügbare Einträge",
+        "mp_stat_median_rate": "Median e-Coin / 1K",
+        "mp_stat_capability_tags": "Fähigkeits-Tags",
+        "mp_stat_currently_rented": "Derzeit gemietet",
+        "mp_no_caps_reported": "Keine unterstützten Fähigkeiten gemeldet",
 
 
 
@@ -6563720,6 +6563804,13 @@ const TRANSLATIONS = {
 
 
         "mp_rate_unit": "e-coin/1K",
+        "mp_rate_min_placeholder": "Min e/1K",
+        "mp_rate_max_placeholder": "Maks e/1K",
+        "mp_stat_available_listings": "Senarai tersedia",
+        "mp_stat_median_rate": "Median e-coin / 1K",
+        "mp_stat_capability_tags": "Tag keupayaan",
+        "mp_stat_currently_rented": "Sedang disewa",
+        "mp_no_caps_reported": "Tiada keupayaan disokong dilaporkan",
 
 
 
@@ -7128110,6 +7128201,13 @@ const TRANSLATIONS = {
 
 
         "mp_rate_unit": "e-coin/1K",
+        "mp_rate_min_placeholder": "न्यूनतम e/1K",
+        "mp_rate_max_placeholder": "अधिकतम e/1K",
+        "mp_stat_available_listings": "उपलब्ध लिस्टिंग",
+        "mp_stat_median_rate": "मध्य e-coin / 1K",
+        "mp_stat_capability_tags": "क्षमता टैग",
+        "mp_stat_currently_rented": "अभी किराए पर",
+        "mp_no_caps_reported": "कोई समर्थित क्षमता रिपोर्ट नहीं की गई",
 
 
 
@@ -7653624,6 +7653722,13 @@ const TRANSLATIONS = {
 
 
         "mp_rate_unit": "e-coin/1K",
+        "mp_rate_min_placeholder": "الحد الأدنى e/1K",
+        "mp_rate_max_placeholder": "الحد الأقصى e/1K",
+        "mp_stat_available_listings": "القوائم المتاحة",
+        "mp_stat_median_rate": "وسيط e-coin / 1K",
+        "mp_stat_capability_tags": "وسوم القدرات",
+        "mp_stat_currently_rented": "مؤجرة حالياً",
+        "mp_no_caps_reported": "لم يتم الإبلاغ عن قدرات مدعومة",
 
 
 

--- a/backend/rental.js
+++ b/backend/rental.js
@@ -30,6 +30,7 @@ const path = require('path');
 const { runInterview, getProbeList } = require('./bot-interview');
 const safeEqual = require('./safe-equal');
 const { newContractId } = require('./entity-id');
+const { detectFamily } = require('./pricing-advisor');
 
 const pool = new Pool({
     connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot'
@@ -178,6 +179,94 @@ function toDateOrNull(value) {
     if (!value) return null;
     const d = value instanceof Date ? value : new Date(value);
     return Number.isFinite(d.getTime()) ? d : null;
+}
+
+function percentileDisc(sortedValues, fraction) {
+    if (!Array.isArray(sortedValues) || sortedValues.length === 0) return null;
+    const rank = Math.max(1, Math.ceil(sortedValues.length * fraction));
+    return sortedValues[Math.min(sortedValues.length - 1, rank - 1)];
+}
+
+function normalizeRateMli(value) {
+    const parsed = Number.parseInt(value, 10);
+    return Number.isSafeInteger(parsed) && parsed > 0 ? parsed : null;
+}
+
+async function refreshPricingMarketSnapshots({
+    snapshotAt = new Date(),
+    client = pool,
+} = {}) {
+    const at = toDateOrNull(snapshotAt) || new Date();
+    const marketRows = await client.query(
+        `SELECT bl.id,
+                bl.model_detected,
+                bl.rate_mli_per_ktoken,
+                COUNT(c.id)::int AS started_contracts,
+                COUNT(c.id) FILTER (WHERE c.status = 'ended_normal')::int AS successful_contracts
+           FROM bot_listings bl
+           LEFT JOIN rental_contracts c ON c.listing_id = bl.id
+          WHERE bl.status = 'listed'
+            AND bl.interview_passed = TRUE
+            AND bl.rate_mli_per_ktoken > 0
+            AND (bl.soft_pause_until IS NULL OR bl.soft_pause_until <= NOW())
+          GROUP BY bl.id, bl.model_detected, bl.rate_mli_per_ktoken`
+    );
+
+    const byFamily = new Map();
+    for (const row of marketRows.rows || []) {
+        const rate = normalizeRateMli(row.rate_mli_per_ktoken);
+        if (rate == null) continue;
+        const family = detectFamily(row.model_detected);
+        if (!byFamily.has(family)) {
+            byFamily.set(family, { rates: [], started: 0, successful: 0 });
+        }
+        const bucket = byFamily.get(family);
+        bucket.rates.push(rate);
+        bucket.started += Number.parseInt(row.started_contracts, 10) || 0;
+        bucket.successful += Number.parseInt(row.successful_contracts, 10) || 0;
+    }
+
+    const rows = [];
+    for (const [family, bucket] of [...byFamily.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+        bucket.rates.sort((a, b) => a - b);
+        const rentalSuccessRate = bucket.started > 0
+            ? Number((bucket.successful / bucket.started).toFixed(3))
+            : null;
+        const snapshotRow = {
+            modelFamily: family,
+            listingCount: bucket.rates.length,
+            rateP25Mli: percentileDisc(bucket.rates, 0.25),
+            rateP50Mli: percentileDisc(bucket.rates, 0.50),
+            rateP75Mli: percentileDisc(bucket.rates, 0.75),
+            rateP95Mli: percentileDisc(bucket.rates, 0.95),
+            rentalSuccessRate,
+        };
+        await client.query(
+            `INSERT INTO pricing_market_snapshots
+                (snapshot_at, model_family, listing_count,
+                 rate_p25_mli, rate_p50_mli, rate_p75_mli, rate_p95_mli,
+                 rental_success_rate)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+            [
+                at,
+                snapshotRow.modelFamily,
+                snapshotRow.listingCount,
+                snapshotRow.rateP25Mli,
+                snapshotRow.rateP50Mli,
+                snapshotRow.rateP75Mli,
+                snapshotRow.rateP95Mli,
+                snapshotRow.rentalSuccessRate,
+            ]
+        );
+        rows.push(snapshotRow);
+    }
+
+    return {
+        snapshotAt: at.toISOString(),
+        familyCount: rows.length,
+        listingCount: rows.reduce((sum, row) => sum + row.listingCount, 0),
+        rows,
+    };
 }
 
 // ============================================
@@ -2830,6 +2919,7 @@ module.exports = function rentalFactory({ authMiddleware, softAuthMiddleware, ad
         getListing,
         listMyListings,
         searchMarketplace,
+        refreshPricingMarketSnapshots,
         filterDriftedListings,
         startRental,
         endRental,
@@ -2879,5 +2969,6 @@ module.exports.DEPOSIT_TOKEN_MULTIPLIER = DEPOSIT_TOKEN_MULTIPLIER;
 module.exports.INTERVIEW_PASS_SCORE = INTERVIEW_PASS_SCORE;
 
 module.exports.isListingSoftPaused = isListingSoftPaused;
+module.exports.refreshPricingMarketSnapshots = refreshPricingMarketSnapshots;
 module.exports.LISTING_SOFT_PAUSE_REASON_HEALTH_DEGRADED = LISTING_SOFT_PAUSE_REASON_HEALTH_DEGRADED;
 module.exports.LISTING_HEALTH_OK_RECOVERY_STREAK = LISTING_HEALTH_OK_RECOVERY_STREAK;

--- a/backend/scripts/portal-smoke-check.js
+++ b/backend/scripts/portal-smoke-check.js
@@ -25,6 +25,10 @@ const CRITICAL_PAGES = [
         file: 'portal/info.html',
         anchors: ['id="panel-channel-plugins"', 'id="guide-codex-channel"', 'codex-eclaw-bridge'],
     },
+    {
+        file: 'portal/marketplace.html',
+        anchors: ['id="listingGrid"', 'id="detailModal"', '/api/rental/marketplace?', '/api/rental/contract'],
+    },
 ];
 
 function fail(errors, file, message) {

--- a/backend/tests/jest/portal-static-ids.test.js
+++ b/backend/tests/jest/portal-static-ids.test.js
@@ -34,11 +34,15 @@ describe('portal static HTML IDs', () => {
     expect(html).toContain("btn.setAttribute('aria-label', toggleLabel)");
   });
 
-  test('marketplace redirect shim keeps mobile viewport metadata', () => {
+  test('marketplace portal keeps mobile metadata and sends renter device id', () => {
     const marketplacePath = path.join(__dirname, '../../public/portal/marketplace.html');
     const html = fs.readFileSync(marketplacePath, 'utf8');
 
     expect(html).toMatch(/<meta\s+name=["']viewport["']\s+content=["']width=device-width,\s*initial-scale=1\.0["']>/);
+    expect(html).not.toContain("window.location.replace('community.html#rental')");
+    expect(html).toContain('/api/rental/marketplace?');
+    expect(html).toContain('/api/rental/contract');
+    expect(html).toContain('renterDeviceId');
   });
 
 });

--- a/backend/tests/jest/rental-listing.test.js
+++ b/backend/tests/jest/rental-listing.test.js
@@ -9,6 +9,8 @@
 jest.mock('pg', () => {
     const state = {
         listings: [],
+        contracts: [],
+        snapshots: [],
         nextId: 1,
     };
     globalThis.__rentalFakeState = state;
@@ -186,6 +188,42 @@ jest.mock('pg', () => {
             return { rows, rowCount: rows.length };
         }
 
+        // Market snapshot refresh: aggregate listed, interview-passed listings by model family.
+        if (/^SELECT bl\.id, bl\.model_detected, bl\.rate_mli_per_ktoken, COUNT\(c\.id\)::int AS started_contracts/i.test(norm)) {
+            const now = Date.now();
+            const rows = state.listings
+                .filter(l => l.status === 'listed' && l.interview_passed === true)
+                .filter(l => Number(l.rate_mli_per_ktoken) > 0)
+                .filter(l => !l.soft_pause_until || new Date(l.soft_pause_until).getTime() <= now)
+                .map((l) => {
+                    const contracts = state.contracts.filter(c => c.listing_id === l.id);
+                    return {
+                        id: l.id,
+                        model_detected: l.model_detected,
+                        rate_mli_per_ktoken: l.rate_mli_per_ktoken,
+                        started_contracts: contracts.length,
+                        successful_contracts: contracts.filter(c => c.status === 'ended_normal').length,
+                    };
+                });
+            return { rows, rowCount: rows.length };
+        }
+
+        if (/^INSERT INTO pricing_market_snapshots/i.test(norm)) {
+            const [snapshotAt, modelFamily, listingCount, rateP25Mli, rateP50Mli,
+                   rateP75Mli, rateP95Mli, rentalSuccessRate] = params;
+            state.snapshots.push({
+                snapshot_at: snapshotAt,
+                model_family: modelFamily,
+                listing_count: listingCount,
+                rate_p25_mli: rateP25Mli,
+                rate_p50_mli: rateP50Mli,
+                rate_p75_mli: rateP75Mli,
+                rate_p95_mli: rateP95Mli,
+                rental_success_rate: rentalSuccessRate,
+            });
+            return { rows: [], rowCount: 1 };
+        }
+
         // Marketplace search (handles bl. table alias prefix from LEFT JOIN query)
         if (/FROM bot_listings\b.*WHERE\b.*status\s*=\s*'listed'/i.test(norm)) {
             let rows = state.listings.filter(l => l.status === 'listed' && l.interview_passed);
@@ -253,6 +291,8 @@ const OTHER = '22222222-2222-2222-2222-222222222222';
 function resetState() {
     const state = globalThis.__rentalFakeState;
     state.listings.length = 0;
+    state.contracts.length = 0;
+    state.snapshots.length = 0;
     state.nextId = 1;
 }
 beforeEach(() => { resetState(); });
@@ -536,6 +576,83 @@ describe('rental: searchMarketplace', () => {
         }
         const results = await api.searchMarketplace({ limit: 2 });
         expect(results).toHaveLength(2);
+    });
+});
+
+describe('rental: refreshPricingMarketSnapshots', () => {
+    function seedMarketRow(row) {
+        globalThis.__rentalFakeState.listings.push({
+            id: row.id,
+            owner_user_id: row.ownerUserId || OWNER,
+            owner_device_id: row.ownerDeviceId || `device-${row.id}`,
+            owner_entity_id: row.ownerEntityId || 0,
+            title: row.title || row.id,
+            description: '',
+            rate_mli_per_ktoken: row.rateMli,
+            min_rental_minutes: 30,
+            max_rental_minutes: 1440,
+            model_detected: row.model,
+            capabilities: {},
+            benchmark_score: {},
+            interview_passed: row.interviewPassed !== false,
+            avg_rating: 0,
+            total_rentals: 0,
+            uptime_pct: 100,
+            status: row.status || 'listed',
+            soft_pause_until: row.softPauseUntil || null,
+            soft_pause_reason: null,
+            bound_rebind_count: 0,
+            created_at: new Date(),
+            updated_at: new Date(),
+        });
+    }
+
+    test('aggregates active listed rates by detected model family', async () => {
+        seedMarketRow({ id: 'sonnet-a', model: 'Claude Sonnet 4', rateMli: 5000 });
+        seedMarketRow({ id: 'sonnet-b', model: 'claude-3.5-sonnet', rateMli: 7000 });
+        seedMarketRow({ id: 'mini-a', model: 'gpt-4o-mini', rateMli: 2000 });
+        seedMarketRow({ id: 'draft-ignored', model: 'Claude Sonnet', rateMli: 9000, status: 'draft' });
+        seedMarketRow({ id: 'failed-ignored', model: 'Claude Sonnet', rateMli: 9000, interviewPassed: false });
+        seedMarketRow({ id: 'paused-ignored', model: 'Claude Sonnet', rateMli: 9000, softPauseUntil: '2999-01-01T00:00:00.000Z' });
+        globalThis.__rentalFakeState.contracts.push(
+            { id: 'c1', listing_id: 'sonnet-a', status: 'ended_normal' },
+            { id: 'c2', listing_id: 'sonnet-b', status: 'ended_normal' },
+            { id: 'c3', listing_id: 'sonnet-b', status: 'ended_early_by_renter' },
+        );
+
+        const result = await api.refreshPricingMarketSnapshots({
+            snapshotAt: '2026-05-24T00:00:00.000Z',
+        });
+
+        expect(result.familyCount).toBe(2);
+        expect(result.listingCount).toBe(3);
+        expect(result.rows).toEqual([
+            {
+                modelFamily: 'gpt-4o-mini',
+                listingCount: 1,
+                rateP25Mli: 2000,
+                rateP50Mli: 2000,
+                rateP75Mli: 2000,
+                rateP95Mli: 2000,
+                rentalSuccessRate: null,
+            },
+            {
+                modelFamily: 'sonnet',
+                listingCount: 2,
+                rateP25Mli: 5000,
+                rateP50Mli: 5000,
+                rateP75Mli: 7000,
+                rateP95Mli: 7000,
+                rentalSuccessRate: 0.667,
+            },
+        ]);
+        expect(globalThis.__rentalFakeState.snapshots).toHaveLength(2);
+        expect(globalThis.__rentalFakeState.snapshots[1]).toMatchObject({
+            model_family: 'sonnet',
+            listing_count: 2,
+            rate_p50_mli: 5000,
+            rental_success_rate: 0.667,
+        });
     });
 });
 

--- a/docs/plans/2026-04-10-bot-rental-marketplace-design.md
+++ b/docs/plans/2026-04-10-bot-rental-marketplace-design.md
@@ -792,7 +792,7 @@ For `ended_zero_balance`: the token metering proxy (`chargeRentalUsage`) deducts
 | Schedule | Job | Status |
 |----------|-----|--------|
 | `23 4 * * *` (daily 04:23) | Wallet reconcile audit | ✅ |
-| (TBD) hourly | Pricing market snapshot aggregation | 🟡 P1 follow-up |
+| `11 * * * *` (hourly at :11) | Pricing market snapshot aggregation | ✅ |
 | (TBD) per-minute | Contract expiration sweep (active → ended_normal) | 🔴 P2-F |
 | (TBD) per-minute | Grace period expiration sweep | 🔴 P2-C |
 | (TBD) T+24h | Owner pending_income release sweep | 🔴 P2-C |
@@ -1014,7 +1014,7 @@ Rate limit: 30 req/min via `express-rate-limit` keyed on `rental_contract_id`.
 | Phase | Theme | Scope | Status | PR(s) |
 |-------|-------|-------|--------|-------|
 | **P0** | Wallet foundation | `wallets`, `wallet_ledger`, `topup_orders`, primitives, reconcile cron | ✅ Complete | #1656 commits `a5dd33ea`, `6938c92d`, `073a125b` |
-| **P1** | Listings + advisor | `bot_listings`, `bot_interviews`, listing CRUD, marketplace, interview scoring, pricing advisor | 🟡 Foundation done; Arena integration complete; market snapshot cron pending | #1656 commit `073a125b` |
+| **P1** | Listings + advisor | `bot_listings`, `bot_interviews`, listing CRUD, marketplace, interview scoring, pricing advisor | 🟡 Foundation done; Arena integration, market snapshot cron, and marketplace portal complete; listing editor/mobile parity pending | #1656 commit `073a125b` |
 | **P2** | Contract core | Contract state machine, atomic start/end, version lock, token metering proxy, grace period, entity handover, gatekeeper extension, A2A collab | 🟡 P2-A/B done (financial); P2-C/D/E/F pending | #1656 commit `267c09d7` |
 | **P3** | Trust layer | Reviews, disputes, credit score, fraud detection, admin workqueue | 🔴 Not started | — |
 | **P4** | Risk management | Insurance pool, blacklist, SLA display, notifications, audit hardening | 🔴 Not started | — |
@@ -1054,8 +1054,8 @@ Legend: ✅ done, 🟡 partial, 🔴 not started, 🔒 human-blocked
 - ✅ Arena integration — 12-challenge interactive evaluation via interview-arena.js
 - ✅ `arena_exams` + `arena_sessions` table writes (real-time)
 - 🔴 Interview rate limit enforcement (3/listing/7d)
-- 🔴 Market snapshot cron (hourly aggregation)
-- 🔴 Marketplace portal page (`marketplace.html`)
+- ✅ Market snapshot cron (hourly aggregation)
+- ✅ Marketplace portal page (`marketplace.html`)
 - 🔴 Listing editor portal page
 - 🔴 Interview runner UI
 - 🔒 Android `MarketplaceActivity.kt` (feature parity rule)
@@ -1521,7 +1521,7 @@ backend/
 ├── public/
 │   ├── portal/
 │   │   ├── wallet.html        # User wallet page (balance + tiers + history)
-│   │   └── marketplace.html   # [P1 follow-up] Marketplace search page
+│   │   └── marketplace.html   # Marketplace search page
 │   └── shared/
 │       └── i18n.js            # Added wallet_* keys (en + zh-TW so far)
 └── tests/jest/
@@ -1558,14 +1558,15 @@ backend/
 └── scripts/
     ├── wallet-reconcile.js    # Standalone reconcile script (cron-callable)
     ├── rental-grace-sweep.js  # P2-C: grace period expiration cron
-    ├── rental-expire-sweep.js # P2-C: contract auto-expiration cron
-    └── pricing-snapshot-cron.js # P1 follow-up: hourly market aggregation
+    └── rental-expire-sweep.js # P2-C: contract auto-expiration cron
 
 backend/public/portal/
 ├── rental-listing-edit.html   # P1: listing editor
 ├── rental-contract-detail.html # P2: contract viewing page
 └── admin-rental.html          # P3: admin dispute workqueue
 ```
+
+Pricing snapshot aggregation now runs from `backend/index.js` at `11 * * * *`.
 
 ---
 
@@ -2377,7 +2378,7 @@ CREATE UNIQUE INDEX idx_contracts_exclusive_active
 | 排程 | 作業 | 狀態 |
 |----------|-----|--------|
 | `23 4 * * *`（每日 04:23） | 錢包對帳審計 | ✅ |
-| （待定）每小時 | 定價市場快照聚合 | 🟡 P1 後續 |
+| `11 * * * *`（每小時 :11） | 定價市場快照聚合 | ✅ |
 | （待定）每分鐘 | 合約過期掃描（active → ended_normal） | 🔴 P2-F |
 | （待定）每分鐘 | 寬限期過期掃描 | 🔴 P2-C |
 | （待定）T+24h | 所有者 pending_income 釋放掃描 | 🔴 P2-C |
@@ -2602,7 +2603,7 @@ CREATE UNIQUE INDEX idx_contracts_exclusive_active
 | 階段 | 主題 | 範圍 | 狀態 | PR(s) |
 |-------|-------|-------|--------|-------|
 | **P0** | 錢包基礎 | `wallets`、`wallet_ledger`、`topup_orders`、原語、reconcile cron | ✅ 完成 | #1656 commits `a5dd33ea`、`6938c92d`、`073a125b` |
-| **P1** | 上架商品 + 顧問 | `bot_listings`、`bot_interviews`、上架商品 CRUD、市集、面試評分、定價顧問 | 🟡 基礎完成；HTTP 探針分發 + 市場快照 cron 待定 | #1656 commit `073a125b` |
+| **P1** | 上架商品 + 顧問 | `bot_listings`、`bot_interviews`、上架商品 CRUD、市集、面試評分、定價顧問 | 🟡 基礎完成；Arena 整合、市場快照 cron、市集入口頁完成；上架編輯器/行動端對等仍待補 | #1656 commit `073a125b` |
 | **P2** | 合約核心 | 合約狀態機、原子開始/結束、版本鎖、token 計量代理、寬限期、entity 交接、看門狗擴展、A2A 協作 | 🟡 P2-A/B 完成（財務）；P2-C/D/E/F 待定 | #1656 commit `267c09d7` |
 | **P3** | 信任層 | 評論、爭議、信用評分、欺詐檢測、管理員工作隊列 | 🔴 未開始 | — |
 
@@ -2643,8 +2644,8 @@ CREATE UNIQUE INDEX idx_contracts_exclusive_active
 - 🔴 HTTP 探針分發器 — POST 到所有者 webhook，透過 `/api/transform` 回調收集
 - 🔴 直播面試期間的 `bot_interviews` 表格寫入
 - 🔴 面試速率限制強制執行（每上架商品/7 天 3 次）
-- 🔴 市場快照 cron（每小時聚合）
-- 🔴 市集入口頁面（`marketplace.html`）
+- ✅ 市場快照 cron（每小時聚合）
+- ✅ 市集入口頁面（`marketplace.html`）
 - 🔴 上架商品編輯器入口頁面
 - 🔴 面試執行器 UI
 - 🔒 Android `MarketplaceActivity.kt`（功能對等規則）
@@ -3110,7 +3111,7 @@ backend/
 ├── public/
 │   ├── portal/
 │   │   ├── wallet.html        # User wallet page (balance + tiers + history)
-│   │   └── marketplace.html   # [P1 follow-up] Marketplace search page
+│   │   └── marketplace.html   # Marketplace search page
 │   └── shared/
 │       └── i18n.js            # Added wallet_* keys (en + zh-TW so far)
 └── tests/jest/
@@ -3147,14 +3148,15 @@ backend/
 └── scripts/
     ├── wallet-reconcile.js    # Standalone reconcile script (cron-callable)
     ├── rental-grace-sweep.js  # P2-C: grace period expiration cron
-    ├── rental-expire-sweep.js # P2-C: contract auto-expiration cron
-    └── pricing-snapshot-cron.js # P1 follow-up: hourly market aggregation
+    └── rental-expire-sweep.js # P2-C: contract auto-expiration cron
 
 backend/public/portal/
 ├── rental-listing-edit.html   # P1: listing editor
 ├── rental-contract-detail.html # P2: contract viewing page
 └── admin-rental.html          # P3: admin dispute workqueue
 ```
+
+定價市場快照聚合現在由 `backend/index.js` 以 `11 * * * *` 排程執行。
 
 ---
 


### PR DESCRIPTION
## Summary
- add hourly rental pricing market snapshot aggregation and schedule it at minute 11 after rental DB init
- replace the marketplace redirect shim with a real portal page for browsing, filtering, detail viewing, and starting rentals
- expose Marketplace in portal nav and update roadmap/design-doc P1 status

## Validation
- `node --check backend/rental.js backend/pricing-advisor.js backend/index.js`
- `npm run smoke:portal`
- `./node_modules/.bin/jest tests/jest/rental-listing.test.js tests/jest/portal-static-ids.test.js --silent` (passes; Jest emits the repo existing `runInBand` config warning)
- `git diff --check`

## Notes
- No authenticated browser screenshot/E2E was run in this pass.
