### PR TITLE
[codex][draft] Partial orphan-only backend i18n cleanup

### DIFF
--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -2233676,7 +2233676,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_mode_keyword": "キーワード",
 
 
 
@@ -2938671,7 +2938670,6 @@ const TRANSLATIONS = {
 
 
 
-        "guidepubroadmaph": "게시자 로드맵",
 
 
 
@@ -7693434,7 +7693432,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_demo_text": "تحدث مع بوت العرض التوضيحي — mention @eclaw_support للحصول على استجابة فورية!",
 
 
 
@@ -7693560,9 +7693557,6 @@ const TRANSLATIONS = {
 
 
 
-
-
-        "guide_mention_example": "مثال: @assistant تحقق من حالة الخادم",
 
 
 


### PR DESCRIPTION
## Summary

Partial orphan-only draft for backend i18n cleanup.

This PR only removes a small set of orphaned entries from `backend/public/shared/i18n.js`. It is not the full implementation for `card_150ad6cb154f0c14e5113745` and should remain draft.

## Scope

Included here:

- Remove orphan-only backend i18n entries already present in the branch.

Intentionally not included here:

- Filling `ms`, `hi`, `ja`, `ko`, or `zh-CN` locale gaps.
- Deduplicating locale keys beyond this orphan-only cleanup.
- Marking `card_150ad6cb154f0c14e5113745` done.

Gap-fill tracking:

- #2910 tracks the separate bounded backend locale gap-fill work for `card_150ad6cb154f0c14e5113745`.

## Validation

- `git diff --check HEAD~1..HEAD`
- No all-locale rerun performed, per request.