### PR TITLE
[H1-T6] backend channel-backpressure: 30/min cap + 429 retry-after

### DIFF
--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -26,6 +26,10 @@ const dnsLookup = require('util').promisify(require('dns').lookup);
 const { enrichContext, materializeChannelText } = require('./push-context');
 const { scanReferences, buildReferencesBlock } = require('./reference-parser');
 const { resolveReferences } = require('./reference-resolver');
+const {
+    reserveChannelPush,
+    recordChannelPushResult
+} = require('./channel-backpressure');
 
 // ── SSRF protection: reject private/internal callback URLs ──
 function isPrivateIp(ip) {
@@ -1210,6 +1214,27 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             return { pushed: false, reason: 'no_channel_callback' };
         }
 
+        const backpressureTarget = { deviceId, entityId, channelAccountId: account.id };
+        const reservation = reserveChannelPush(backpressureTarget);
+        if (!reservation.allowed) {
+            const retryAfter = Math.ceil((reservation.retryAfterMs || 0) / 1000);
+            serverLog('warn', 'channel', `Callback push delayed by ${reservation.reason} for Entity ${entityId}`, {
+                deviceId,
+                entityId,
+                metadata: {
+                    channelAccountId: account.id,
+                    retryAfter,
+                    reason: reservation.reason
+                }
+            });
+            return {
+                pushed: false,
+                reason: reservation.reason,
+                retryAfter,
+                backpressure: true
+            };
+        }
+
         try {
             const headers = { 'Content-Type': 'application/json' };
             if (account.callback_username && account.callback_password) {
@@ -1304,16 +1329,31 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             }
 
             if (response.ok) {
+                recordChannelPushResult(backpressureTarget, { success: true });
                 serverLog('info', 'channel', `Callback push OK for Entity ${entityId}`, { deviceId, entityId });
                 return { pushed: true };
             } else {
                 const errText = await response.text().catch(() => '');
-                serverLog('warn', 'channel', `Callback push failed HTTP ${response.status}`, { deviceId, entityId, metadata: { status: response.status, error: errText.substring(0, 200) } });
-                return { pushed: false, reason: `http_${response.status}` };
+                const backoff = recordChannelPushResult(backpressureTarget, {
+                    success: false,
+                    status: response.status,
+                    reason: `http_${response.status}`,
+                    retryAfter: response.headers && typeof response.headers.get === 'function'
+                        ? response.headers.get('retry-after')
+                        : null
+                });
+                const retryAfter = Math.ceil((backoff.backoffMs || 0) / 1000);
+                serverLog('warn', 'channel', `Callback push failed HTTP ${response.status}`, { deviceId, entityId, metadata: { status: response.status, error: errText.substring(0, 200), retryAfter, consecutiveFailures: backoff.consecutiveFailures } });
+                return { pushed: false, reason: `http_${response.status}`, retryAfter, backpressure: true };
             }
         } catch (err) {
-            serverLog('error', 'channel', `Callback push error: ${err.message}`, { deviceId, entityId });
-            return { pushed: false, reason: err.message };
+            const backoff = recordChannelPushResult(backpressureTarget, {
+                success: false,
+                reason: err.message
+            });
+            const retryAfter = Math.ceil((backoff.backoffMs || 0) / 1000);
+            serverLog('error', 'channel', `Callback push error: ${err.message}`, { deviceId, entityId, metadata: { retryAfter, consecutiveFailures: backoff.consecutiveFailures } });
+            return { pushed: false, reason: err.message, retryAfter, backpressure: true };
         }
     }
 

--- a/backend/channel-backpressure.js
+++ b/backend/channel-backpressure.js
@@ -1,0 +1,142 @@
+'use strict';
+
+const DEFAULT_MAX_PER_WINDOW = 30;
+const DEFAULT_WINDOW_MS = 60 * 1000;
+const DEFAULT_BASE_BACKOFF_MS = 1000;
+const DEFAULT_MAX_BACKOFF_MS = 60 * 1000;
+
+const channelBackpressureState = new Map();
+
+function channelBackpressureKey({ deviceId, entityId, channelAccountId } = {}) {
+    const accountPart = channelAccountId ? `account:${channelAccountId}` : 'account:legacy';
+    return `${deviceId || 'unknown_device'}:${entityId ?? 'unknown_entity'}:${accountPart}`;
+}
+
+function getState(key) {
+    if (!channelBackpressureState.has(key)) {
+        channelBackpressureState.set(key, {
+            timestamps: [],
+            consecutiveFailures: 0,
+            backoffUntil: 0,
+            lastReason: null
+        });
+    }
+    return channelBackpressureState.get(key);
+}
+
+function parseRetryAfterMs(value, now = Date.now()) {
+    if (!value) return null;
+    const numeric = Number(value);
+    if (Number.isFinite(numeric) && numeric >= 0) {
+        return Math.ceil(numeric * 1000);
+    }
+    const parsedDate = Date.parse(value);
+    if (Number.isFinite(parsedDate)) {
+        return Math.max(0, parsedDate - now);
+    }
+    return null;
+}
+
+function reserveChannelPush(target, opts = {}) {
+    const {
+        now = Date.now(),
+        maxPerWindow = DEFAULT_MAX_PER_WINDOW,
+        windowMs = DEFAULT_WINDOW_MS
+    } = opts;
+    const key = typeof target === 'string' ? target : channelBackpressureKey(target);
+    const state = getState(key);
+
+    if (state.backoffUntil > now) {
+        return {
+            allowed: false,
+            key,
+            reason: 'channel_backoff',
+            retryAfterMs: state.backoffUntil - now,
+            consecutiveFailures: state.consecutiveFailures
+        };
+    }
+
+    state.timestamps = state.timestamps.filter(ts => now - ts < windowMs);
+    if (state.timestamps.length >= maxPerWindow) {
+        const retryAfterMs = Math.max(1, (state.timestamps[0] + windowMs) - now);
+        return {
+            allowed: false,
+            key,
+            reason: 'channel_rate_limited',
+            retryAfterMs,
+            remaining: 0
+        };
+    }
+
+    state.timestamps.push(now);
+    return {
+        allowed: true,
+        key,
+        remaining: Math.max(0, maxPerWindow - state.timestamps.length)
+    };
+}
+
+function recordChannelPushResult(target, result = {}, opts = {}) {
+    const {
+        now = Date.now(),
+        baseBackoffMs = DEFAULT_BASE_BACKOFF_MS,
+        maxBackoffMs = DEFAULT_MAX_BACKOFF_MS
+    } = opts;
+    const key = typeof target === 'string' ? target : channelBackpressureKey(target);
+    const state = getState(key);
+
+    if (result.success) {
+        state.consecutiveFailures = 0;
+        state.backoffUntil = 0;
+        state.lastReason = null;
+        return { key, consecutiveFailures: 0, backoffMs: 0, retryAfterMs: 0 };
+    }
+
+    state.consecutiveFailures += 1;
+    state.lastReason = result.reason || (result.status ? `http_${result.status}` : 'unknown');
+
+    const retryAfterMs = parseRetryAfterMs(result.retryAfter, now);
+    const exponentialMs = Math.min(
+        maxBackoffMs,
+        baseBackoffMs * Math.pow(2, Math.max(0, state.consecutiveFailures - 1))
+    );
+    const backoffMs = Math.max(1, retryAfterMs ?? exponentialMs);
+    state.backoffUntil = now + backoffMs;
+
+    return {
+        key,
+        consecutiveFailures: state.consecutiveFailures,
+        backoffMs,
+        retryAfterMs: retryAfterMs || 0,
+        backoffUntil: state.backoffUntil
+    };
+}
+
+function getChannelBackpressureSnapshot(target) {
+    const key = typeof target === 'string' ? target : channelBackpressureKey(target);
+    const state = channelBackpressureState.get(key);
+    if (!state) return null;
+    return {
+        timestamps: [...state.timestamps],
+        consecutiveFailures: state.consecutiveFailures,
+        backoffUntil: state.backoffUntil,
+        lastReason: state.lastReason
+    };
+}
+
+function resetChannelBackpressureState() {
+    channelBackpressureState.clear();
+}
+
+module.exports = {
+    DEFAULT_MAX_PER_WINDOW,
+    DEFAULT_WINDOW_MS,
+    DEFAULT_BASE_BACKOFF_MS,
+    DEFAULT_MAX_BACKOFF_MS,
+    channelBackpressureKey,
+    parseRetryAfterMs,
+    reserveChannelPush,
+    recordChannelPushResult,
+    getChannelBackpressureSnapshot,
+    resetChannelBackpressureState
+};

--- a/backend/tests/jest/channel-backpressure.test.js
+++ b/backend/tests/jest/channel-backpressure.test.js
@@ -1,0 +1,58 @@
+const {
+    channelBackpressureKey,
+    parseRetryAfterMs,
+    reserveChannelPush,
+    recordChannelPushResult,
+    resetChannelBackpressureState
+} = require('../../channel-backpressure');
+
+describe('channel callback backpressure', () => {
+    beforeEach(() => {
+        resetChannelBackpressureState();
+    });
+
+    test('caps outbound channel pushes at 30 per minute per account/entity', () => {
+        const target = { deviceId: 'dev-a', entityId: 6, channelAccountId: 42 };
+
+        for (let i = 0; i < 30; i += 1) {
+            const reservation = reserveChannelPush(target, { now: 1000 + i });
+            expect(reservation.allowed).toBe(true);
+        }
+
+        const blocked = reserveChannelPush(target, { now: 1030 });
+        expect(blocked.allowed).toBe(false);
+        expect(blocked.reason).toBe('channel_rate_limited');
+        expect(blocked.retryAfterMs).toBeGreaterThan(0);
+    });
+
+    test('applies exponential backoff after callback failures and resets on success', () => {
+        const target = { deviceId: 'dev-a', entityId: 6, channelAccountId: 42 };
+        const key = channelBackpressureKey(target);
+
+        const first = recordChannelPushResult(key, { success: false, reason: 'timeout' }, { now: 10_000 });
+        expect(first.backoffMs).toBe(1000);
+
+        const blocked = reserveChannelPush(key, { now: 10_500 });
+        expect(blocked.allowed).toBe(false);
+        expect(blocked.reason).toBe('channel_backoff');
+
+        const second = recordChannelPushResult(key, { success: false, reason: 'timeout' }, { now: 12_000 });
+        expect(second.backoffMs).toBe(2000);
+
+        const reset = recordChannelPushResult(key, { success: true }, { now: 15_000 });
+        expect(reset.consecutiveFailures).toBe(0);
+        expect(reserveChannelPush(key, { now: 15_001 }).allowed).toBe(true);
+    });
+
+    test('honors Retry-After headers before exponential defaults', () => {
+        const target = { deviceId: 'dev-a', entityId: 6, channelAccountId: 42 };
+        const backoff = recordChannelPushResult(target, {
+            success: false,
+            status: 429,
+            retryAfter: '7'
+        }, { now: 20_000 });
+
+        expect(backoff.backoffMs).toBe(7000);
+        expect(parseRetryAfterMs('7', 20_000)).toBe(7000);
+    });
+});

--- a/backend/tests/jest/channel-callback-backpressure.test.js
+++ b/backend/tests/jest/channel-callback-backpressure.test.js
@@ -1,0 +1,134 @@
+jest.mock('../../db', () => ({
+    getChannelAccountById: jest.fn(),
+    getChannelAccountByDevice: jest.fn()
+}));
+
+const db = require('../../db');
+const channelApiFactory = require('../../channel-api');
+const { resetChannelBackpressureState } = require('../../channel-backpressure');
+
+function makeResponse({ ok, status, retryAfter = null, body = '' }) {
+    return {
+        ok,
+        status,
+        headers: {
+            get: jest.fn((name) => String(name).toLowerCase() === 'retry-after' ? retryAfter : null)
+        },
+        text: jest.fn().mockResolvedValue(body)
+    };
+}
+
+function makeChannelModule(serverLog = jest.fn()) {
+    const devices = {
+        'dev-a': {
+            entities: {
+                6: {
+                    entityId: 6,
+                    character: 'Hermes',
+                    botSecret: 'bot-secret',
+                    messageQueue: [],
+                    isBound: true
+                }
+            }
+        }
+    };
+
+    return channelApiFactory(devices, {
+        authMiddleware: (_req, _res, next) => next(),
+        serverLog,
+        generateBotSecret: () => 'bot-secret',
+        generatePublicCode: () => 'pub123',
+        publicCodeIndex: {},
+        saveChatMessage: jest.fn(),
+        io: { to: () => ({ emit: jest.fn() }) },
+        saveData: jest.fn().mockResolvedValue(true),
+        createDefaultEntity: (entityId) => ({ entityId, messageQueue: [] }),
+        apiBase: 'https://eclawbot.com',
+        awardEntityXP: jest.fn(),
+        XP_AMOUNTS: {},
+        notifyDevice: jest.fn(),
+        deliverToEntity: jest.fn(),
+        gatekeeperCheckText: (_deviceId, _entityId, text) => ({ text }),
+        resolveSpeakToTarget: jest.fn(),
+        checkBotToBotRateLimit: () => true,
+        checkCrossSpeakRateLimit: () => true,
+        crossDeviceSettings: null,
+        devicePrefs: { getPrefs: jest.fn().mockResolvedValue({}) },
+        recentBroadcasts: {},
+        BOT2BOT_MAX_MESSAGES: 8,
+        db: {},
+        getMissionApiHints: () => '',
+        buildIdentitySetupHint: () => '',
+        buildBroadcastRecipientBlock: () => '',
+        chatPool: null
+    });
+}
+
+describe('pushToChannelCallback backpressure integration', () => {
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+        resetChannelBackpressureState();
+        db.getChannelAccountById.mockResolvedValue({
+            id: 42,
+            device_id: 'dev-a',
+            callback_url: 'https://hermes.example/eclaw-webhook',
+            callback_token: 'callback-token',
+            e2ee_capable: false
+        });
+        db.getChannelAccountByDevice.mockResolvedValue(null);
+        global.fetch = jest.fn().mockResolvedValue(makeResponse({ ok: true, status: 200 }));
+    });
+
+    afterEach(() => {
+        global.fetch = originalFetch;
+        jest.clearAllMocks();
+    });
+
+    test('stops the 31st callback push inside one minute', async () => {
+        const channelModule = makeChannelModule();
+
+        for (let i = 0; i < 30; i += 1) {
+            const result = await channelModule.pushToChannelCallback('dev-a', 6, { text: `msg ${i}` }, 42);
+            expect(result).toEqual({ pushed: true });
+        }
+
+        const blocked = await channelModule.pushToChannelCallback('dev-a', 6, { text: 'msg 31' }, 42);
+        expect(blocked.pushed).toBe(false);
+        expect(blocked.reason).toBe('channel_rate_limited');
+        expect(blocked.backpressure).toBe(true);
+        expect(blocked.retryAfter).toBeGreaterThan(0);
+        expect(global.fetch).toHaveBeenCalledTimes(30);
+    });
+
+    test('honors remote 429 Retry-After and skips pushes during backoff', async () => {
+        const serverLog = jest.fn();
+        const channelModule = makeChannelModule(serverLog);
+        global.fetch = jest.fn().mockResolvedValueOnce(makeResponse({
+            ok: false,
+            status: 429,
+            retryAfter: '7',
+            body: 'slow down'
+        }));
+
+        const first = await channelModule.pushToChannelCallback('dev-a', 6, { text: 'msg' }, 42);
+        expect(first).toEqual({
+            pushed: false,
+            reason: 'http_429',
+            retryAfter: 7,
+            backpressure: true
+        });
+
+        const second = await channelModule.pushToChannelCallback('dev-a', 6, { text: 'blocked' }, 42);
+        expect(second.pushed).toBe(false);
+        expect(second.reason).toBe('channel_backoff');
+        expect(second.retryAfter).toBeGreaterThan(0);
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+        expect(serverLog).toHaveBeenCalledWith(
+            'warn',
+            'channel',
+            expect.stringContaining('Callback push delayed'),
+            expect.any(Object)
+        );
+    });
+});


### PR DESCRIPTION
## Summary
- Add server-side channel callback backpressure with a 30/minute cap per device/entity/channel account.
- Respect remote 429 Retry-After values and apply exponential backoff after callback failures.
- Wire callback push responses to return retryAfter/backpressure metadata when delayed or failed.
- Complements HankHuang0516/hermes-eclaw-channel#23 for defense in depth: bridge caps outbound and EClaw-server caps callbacks.

Review/merge: @HankHuang0516

## Tests
- `NODE_PATH=/Users/hank/Desktop/Project/EClaw/backend/node_modules /Users/hank/Desktop/Project/EClaw/backend/node_modules/.bin/jest --runInBand tests/jest/channel-backpressure.test.js tests/jest/channel-callback-backpressure.test.js tests/jest/rate-limit.test.js`
- 3 suites, 8 tests passed:
  - `tests/jest/channel-backpressure.test.js` (3 tests)
  - `tests/jest/channel-callback-backpressure.test.js` (2 tests)
  - `tests/jest/rate-limit.test.js` (3 tests)