### PR TITLE
[codex] Scope official bot sessions by org entity

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -17,6 +17,7 @@ const sitePageviews = require('./site-pageviews');
 const feedbackModule = require('./device-feedback');
 const chatIntegrity = require('./chat-integrity');
 const communitySsr = require('./community-ssr');
+const { buildOrgEntitySessionKey, isOrgEntitySessionKey } = require('./session-scope');
 // JWT secret: fail-safe random per process if env var is missing (tokens signed in one process won't verify in another)
 const JWT_SECRET_FALLBACK = process.env.JWT_SECRET || require('crypto').randomBytes(32).toString('hex');
 
@@ -13812,8 +13813,9 @@ app.post('/api/official-borrow/bind-free', async (req, res) => {
         return res.status(404).json({ success: false, error: 'No free bot available' });
     }
 
-    // Handshake with bot to discover a working session key and get welcome message
-    const preferredKey = freeBot.session_key_template || 'default';
+    // Handshake with an org/entity scoped session so a stale gateway session from
+    // another org cannot be reused and point the bot at the wrong repo context.
+    const preferredKey = buildOrgEntitySessionKey(freeBot.session_key_template || 'default', deviceId, eId);
     const freeBotAuthOpts = { setupUsername: freeBot.setup_username, setupPassword: freeBot.setup_password };
     const handshake = await handshakeWithBot(freeBot.webhook_url, freeBot.token, preferredKey, deviceId, eId, 'free', freeBotAuthOpts);
 
@@ -13979,8 +13981,9 @@ app.post('/api/official-borrow/bind-personal', async (req, res) => {
         return res.status(404).json({ success: false, error: 'sold_out', message: 'No personal bots available' });
     }
 
-    // Handshake with bot to discover a working session key and get welcome message
-    const preferredKey = personalBot.session_key_template || 'default';
+    // Handshake with an org/entity scoped session so a stale gateway session from
+    // another org cannot be reused and point the bot at the wrong repo context.
+    const preferredKey = buildOrgEntitySessionKey(personalBot.session_key_template || 'default', deviceId, eId);
     const personalBotAuthOpts = { setupUsername: personalBot.setup_username, setupPassword: personalBot.setup_password };
     const handshake = await handshakeWithBot(personalBot.webhook_url, personalBot.token, preferredKey, deviceId, eId, 'personal', personalBotAuthOpts);
 
@@ -14313,8 +14316,12 @@ app.post('/api/entity/refresh', async (req, res) => {
             return res.status(409).json({ success: false, error: 'Personal bot is no longer assigned to this device', webhookBroken: true });
         }
 
-        // Attempt handshake
-        const preferredKey = binding.session_key || bot.session_key_template || 'default';
+        // Attempt handshake. Keep an existing key only when it already matches
+        // this org/entity scope; otherwise mint the scoped key from the bot template.
+        const baseSessionKey = bot.session_key_template || 'default';
+        const preferredKey = isOrgEntitySessionKey(binding.session_key, baseSessionKey, deviceId, eId)
+            ? binding.session_key
+            : buildOrgEntitySessionKey(baseSessionKey, deviceId, eId);
         const botAuthOpts = { setupUsername: bot.setup_username, setupPassword: bot.setup_password };
         const handshake = await handshakeWithBot(bot.webhook_url, bot.token, preferredKey, deviceId, eId, bot.bot_type, botAuthOpts);
 
@@ -15592,9 +15599,10 @@ async function discoverSessions(url, token, authOpts = {}) {
 
 /**
  * Helper: Handshake with bot during binding.
- * 1. Try sessions_send with bot's configured session key
- * 2. If "No session found", discover existing sessions via sessions_list
- * 3. Use first available session, send binding notification
+ * 1. Try sessions_send with the org/entity scoped session key
+ * 2. If "No session found", discover sessions only for diagnostics
+ * 3. Never fall back to arbitrary discovered sessions because those can belong
+ *    to another org/entity and carry stale repo context
  * 4. Return working session key and bot's response
  */
 async function handshakeWithBot(url, token, preferredSessionKey, deviceId, entityId, botType, authOpts = {}) {
@@ -15619,22 +15627,13 @@ async function handshakeWithBot(url, token, preferredSessionKey, deviceId, entit
     }
 
     // Step 2: If session not found OR the first send timed out, discover existing sessions
-    // and retry. Timeout often means the gateway accepted the call but the bot took too
-    // long to reply on the preferred key — a different session may be warm and faster.
+    // only for diagnostics. Do not retry an arbitrary discovered key: stale gateway
+    // sessions can belong to another org/entity and produce "repo not found" in Hermes.
     if (result.sessionNotFound || result.timeout) {
-        console.log(`[Handshake] Preferred session ${result.timeout ? 'timed out' : 'not found'}, discovering sessions...`);
+        console.log(`[Handshake] Preferred org/entity session ${result.timeout ? 'timed out' : 'not found'}, discovering sessions for diagnostics...`);
         const sessions = await discoverSessions(url, token, authOpts);
         console.log(`[Handshake] Discovered ${sessions.length} sessions: ${JSON.stringify(sessions)}`);
-
-        for (const sk of sessions) {
-            if (sk === preferredSessionKey) continue;  // already tried
-            console.log(`[Handshake] Trying discovered session: ${sk}...`);
-            result = await sendToSession(url, token, sk, bindMsg, authOpts, sendOpts);
-            if (result.success) {
-                console.log(`[Handshake] ✓ Handshake OK with discovered key: ${sk}`);
-                return { success: true, sessionKey: sk, botResponse: result.botResponse };
-            }
-        }
+        console.warn(`[Handshake] No org/entity scoped session found for ${deviceId}:${entityId}; refusing fallback to unscoped sessions`);
     }
 
     const finalErrorType = result.timeout ? 'timeout'

--- a/backend/session-scope.js
+++ b/backend/session-scope.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const MAX_SESSION_SCOPE_PART = 80;
+
+function sanitizeSessionScopePart(value, fallback = 'unknown', allowColon = false) {
+    const raw = String(value ?? '').trim();
+    const pattern = allowColon ? /[^A-Za-z0-9._:-]+/g : /[^A-Za-z0-9._-]+/g;
+    const sanitized = raw.replace(pattern, '_').replace(/^_+|_+$/g, '');
+    return (sanitized || fallback).slice(0, MAX_SESSION_SCOPE_PART);
+}
+
+function buildOrgEntitySessionKey(baseKey, orgId, entityId) {
+    const base = sanitizeSessionScopePart(baseKey || 'default', 'default', true);
+    const org = sanitizeSessionScopePart(orgId, 'unknown_org');
+    const entity = sanitizeSessionScopePart(entityId, 'unknown_entity');
+    return `${base}:org:${org}:entity:${entity}`;
+}
+
+function isOrgEntitySessionKey(sessionKey, baseKey, orgId, entityId) {
+    if (!sessionKey) return false;
+    return sessionKey === buildOrgEntitySessionKey(baseKey, orgId, entityId);
+}
+
+module.exports = {
+    buildOrgEntitySessionKey,
+    isOrgEntitySessionKey,
+    sanitizeSessionScopePart
+};

--- a/backend/tests/jest/session-scope.test.js
+++ b/backend/tests/jest/session-scope.test.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+const path = require('path');
+
+const {
+    buildOrgEntitySessionKey,
+    isOrgEntitySessionKey,
+    sanitizeSessionScopePart
+} = require('../../session-scope');
+
+describe('official bot org/entity session scope', () => {
+    test('builds session keys that include org and entity identity', () => {
+        expect(buildOrgEntitySessionKey('agent:main', 'org 7', 6))
+            .toBe('agent:main:org:org_7:entity:6');
+    });
+
+    test('rejects stale session keys from a different org or entity', () => {
+        const key = buildOrgEntitySessionKey('agent:main', 'org-a', 6);
+        expect(isOrgEntitySessionKey(key, 'agent:main', 'org-a', 6)).toBe(true);
+        expect(isOrgEntitySessionKey(key, 'agent:main', 'org-b', 6)).toBe(false);
+        expect(isOrgEntitySessionKey(key, 'agent:main', 'org-a', 7)).toBe(false);
+    });
+
+    test('sanitizes scope pieces without dropping useful base-key separators', () => {
+        expect(sanitizeSessionScopePart('agent:main/session', 'default', true)).toBe('agent:main_session');
+        expect(sanitizeSessionScopePart('org/id:with spaces', 'unknown')).toBe('org_id_with_spaces');
+    });
+
+    test('binding code uses scoped keys and does not retry arbitrary discovered sessions', () => {
+        const source = fs.readFileSync(path.join(__dirname, '../../index.js'), 'utf8');
+        expect(source).toContain("buildOrgEntitySessionKey(freeBot.session_key_template || 'default', deviceId, eId)");
+        expect(source).toContain("buildOrgEntitySessionKey(personalBot.session_key_template || 'default', deviceId, eId)");
+        expect(source).toContain("No org/entity scoped session found");
+        expect(source).not.toMatch(/for \(const sk of sessions\)/);
+    });
+});


### PR DESCRIPTION
## Summary
- Build org/entity-scoped official bot session keys for free and personal bot binding.
- Keep existing refresh session keys only when they match the current org/entity scope.
- Stop retrying arbitrary discovered sessions during official bot handshake to avoid stale cross-org repo context.

## Validation
- `node --check backend/index.js`
- `npx jest tests/jest/session-scope.test.js --runInBand`