### PR TITLE
[codex] Record channel delivery receipts

### DIFF
--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -30,6 +30,7 @@ const {
     reserveChannelPush,
     recordChannelPushResult
 } = require('./channel-backpressure');
+const { recordDeliveryReceipt } = require('./delivery-receipts');
 
 // ── SSRF protection: reject private/internal callback URLs ──
 function isPrivateIp(ip) {
@@ -1331,6 +1332,17 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             if (response.ok) {
                 recordChannelPushResult(backpressureTarget, { success: true });
                 serverLog('info', 'channel', `Callback push OK for Entity ${entityId}`, { deviceId, entityId });
+                recordDeliveryReceipt({
+                    serverLog,
+                    notifyDevice,
+                    deviceId,
+                    entityId,
+                    success: true,
+                    metadata: {
+                        status: response.status,
+                        channelAccountId: account.id
+                    }
+                });
                 return { pushed: true };
             } else {
                 const errText = await response.text().catch(() => '');
@@ -1344,6 +1356,21 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
                 });
                 const retryAfter = Math.ceil((backoff.backoffMs || 0) / 1000);
                 serverLog('warn', 'channel', `Callback push failed HTTP ${response.status}`, { deviceId, entityId, metadata: { status: response.status, error: errText.substring(0, 200), retryAfter, consecutiveFailures: backoff.consecutiveFailures } });
+                recordDeliveryReceipt({
+                    serverLog,
+                    notifyDevice,
+                    deviceId,
+                    entityId,
+                    success: false,
+                    reason: `http_${response.status}`,
+                    metadata: {
+                        status: response.status,
+                        error: errText.substring(0, 200),
+                        channelAccountId: account.id,
+                        retryAfter,
+                        consecutiveFailures: backoff.consecutiveFailures
+                    }
+                });
                 return { pushed: false, reason: `http_${response.status}`, retryAfter, backpressure: true };
             }
         } catch (err) {
@@ -1353,6 +1380,19 @@ module.exports = function (devices, { authMiddleware, serverLog, generateBotSecr
             });
             const retryAfter = Math.ceil((backoff.backoffMs || 0) / 1000);
             serverLog('error', 'channel', `Callback push error: ${err.message}`, { deviceId, entityId, metadata: { retryAfter, consecutiveFailures: backoff.consecutiveFailures } });
+            recordDeliveryReceipt({
+                serverLog,
+                notifyDevice,
+                deviceId,
+                entityId,
+                success: false,
+                reason: err.message,
+                metadata: {
+                    channelAccountId: account.id,
+                    retryAfter,
+                    consecutiveFailures: backoff.consecutiveFailures
+                }
+            });
             return { pushed: false, reason: err.message, retryAfter, backpressure: true };
         }
     }

--- a/backend/delivery-receipts.js
+++ b/backend/delivery-receipts.js
@@ -1,0 +1,104 @@
+'use strict';
+
+const DEFAULT_FAILURE_ALERT_THRESHOLD = 3;
+const deliveryFailureStreaks = new Map();
+
+function deliveryReceiptKey(deviceId, entityId, channel = 'channel_callback') {
+    return `${deviceId || 'unknown_device'}:${entityId ?? 'unknown_entity'}:${channel}`;
+}
+
+function trimReason(reason) {
+    return String(reason || 'unknown').slice(0, 240);
+}
+
+function recordDeliveryReceipt({
+    serverLog,
+    notifyDevice,
+    deviceId,
+    entityId,
+    channel = 'channel_callback',
+    success,
+    reason,
+    metadata = {},
+    threshold = DEFAULT_FAILURE_ALERT_THRESHOLD
+}) {
+    const key = deliveryReceiptKey(deviceId, entityId, channel);
+    const receiptMetadata = {
+        channel,
+        consecutiveFailures: 0,
+        ...metadata
+    };
+
+    if (success) {
+        deliveryFailureStreaks.delete(key);
+        if (serverLog) {
+            serverLog('info', 'delivery_receipt', `Delivery receipt OK for Entity ${entityId}`, {
+                deviceId,
+                entityId,
+                metadata: receiptMetadata
+            });
+        }
+        return { consecutiveFailures: 0, alerted: false };
+    }
+
+    const consecutiveFailures = (deliveryFailureStreaks.get(key) || 0) + 1;
+    deliveryFailureStreaks.set(key, consecutiveFailures);
+    const failureReason = trimReason(reason);
+    const failureMetadata = {
+        ...receiptMetadata,
+        consecutiveFailures,
+        reason: failureReason
+    };
+
+    if (serverLog) {
+        serverLog('warn', 'delivery_receipt', `Delivery receipt failed for Entity ${entityId}: ${failureReason}`, {
+            deviceId,
+            entityId,
+            metadata: failureMetadata
+        });
+    }
+
+    const alerted = consecutiveFailures === threshold + 1;
+    if (alerted) {
+        const title = 'Commander delivery alert';
+        const body = `Entity ${entityId} has ${consecutiveFailures} consecutive delivery failures (${failureReason}).`;
+        if (serverLog) {
+            serverLog('error', 'delivery_alert', body, {
+                deviceId,
+                entityId,
+                metadata: failureMetadata
+            });
+        }
+        if (notifyDevice) {
+            Promise.resolve(notifyDevice(deviceId, {
+                type: 'alert',
+                category: 'delivery_alert',
+                title,
+                body,
+                link: 'chat.html',
+                metadata: failureMetadata
+            })).catch(err => {
+                if (serverLog) {
+                    serverLog('warn', 'delivery_alert', `Commander delivery alert notification failed: ${err.message}`, {
+                        deviceId,
+                        entityId,
+                        metadata: failureMetadata
+                    });
+                }
+            });
+        }
+    }
+
+    return { consecutiveFailures, alerted };
+}
+
+function resetDeliveryReceiptState() {
+    deliveryFailureStreaks.clear();
+}
+
+module.exports = {
+    DEFAULT_FAILURE_ALERT_THRESHOLD,
+    deliveryReceiptKey,
+    recordDeliveryReceipt,
+    resetDeliveryReceiptState
+};

--- a/backend/notifications.js
+++ b/backend/notifications.js
@@ -12,6 +12,7 @@ const DEFAULT_PREFS = {
     todo_done: true,
     scheduled: true,
     platform_command: true,
+    delivery_alert: true,
     kanban_done: true,
     kanban_done_auto: true
 };

--- a/backend/tests/jest/delivery-receipts.test.js
+++ b/backend/tests/jest/delivery-receipts.test.js
@@ -1,0 +1,50 @@
+const {
+    recordDeliveryReceipt,
+    resetDeliveryReceiptState
+} = require('../../delivery-receipts');
+const fs = require('fs');
+const path = require('path');
+
+describe('delivery receipt logging and commander alerting', () => {
+    let serverLog;
+    let notifyDevice;
+
+    beforeEach(() => {
+        resetDeliveryReceiptState();
+        serverLog = jest.fn();
+        notifyDevice = jest.fn().mockResolvedValue(undefined);
+    });
+
+    test('logs successes and resets the failure streak', () => {
+        recordDeliveryReceipt({ serverLog, notifyDevice, deviceId: 'dev-a', entityId: 6, success: false, reason: 'http_502' });
+        const result = recordDeliveryReceipt({ serverLog, notifyDevice, deviceId: 'dev-a', entityId: 6, success: true });
+        const nextFailure = recordDeliveryReceipt({ serverLog, notifyDevice, deviceId: 'dev-a', entityId: 6, success: false, reason: 'timeout' });
+
+        expect(result).toEqual({ consecutiveFailures: 0, alerted: false });
+        expect(nextFailure.consecutiveFailures).toBe(1);
+        expect(serverLog).toHaveBeenCalledWith('info', 'delivery_receipt', expect.stringContaining('Delivery receipt OK'), expect.any(Object));
+    });
+
+    test('alerts commander after more than three consecutive failures', () => {
+        for (let i = 0; i < 3; i += 1) {
+            const result = recordDeliveryReceipt({ serverLog, notifyDevice, deviceId: 'dev-a', entityId: 6, success: false, reason: 'http_503' });
+            expect(result.alerted).toBe(false);
+        }
+
+        const fourth = recordDeliveryReceipt({ serverLog, notifyDevice, deviceId: 'dev-a', entityId: 6, success: false, reason: 'http_503' });
+
+        expect(fourth).toEqual({ consecutiveFailures: 4, alerted: true });
+        expect(notifyDevice).toHaveBeenCalledWith('dev-a', expect.objectContaining({
+            type: 'alert',
+            category: 'delivery_alert',
+            title: 'Commander delivery alert'
+        }));
+        expect(serverLog).toHaveBeenCalledWith('error', 'delivery_alert', expect.stringContaining('4 consecutive delivery failures'), expect.any(Object));
+    });
+
+    test('channel callback exception path records a defined account id', () => {
+        const source = fs.readFileSync(path.join(__dirname, '../../channel-api.js'), 'utf8');
+        expect(source).toMatch(/channelAccountId:\s*account\.id/);
+        expect(source).not.toContain('metadata: { channelAccountId }');
+    });
+});


### PR DESCRIPTION
## Summary
- Record delivery receipts for channel callback success, HTTP failure, and exception paths.
- Alert the commander after repeated callback delivery failures through the existing notification system.
- Fix the callback exception metadata to use `account.id` instead of an undefined `channelAccountId` variable.
- Rebased on the latest `origin/main` and preserved channel backpressure behavior.

## Validation
- `node --check backend/channel-api.js`
- `npx jest tests/jest/delivery-receipts.test.js --runInBand`