### PR TITLE
fix(channel): restore handshake fallback to discovered sessions (#2915)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -15626,14 +15626,26 @@ async function handshakeWithBot(url, token, preferredSessionKey, deviceId, entit
         return { success: true, sessionKey: preferredSessionKey, botResponse: result.botResponse };
     }
 
-    // Step 2: If session not found OR the first send timed out, discover existing sessions
-    // only for diagnostics. Do not retry an arbitrary discovered key: stale gateway
-    // sessions can belong to another org/entity and produce "repo not found" in Hermes.
-    if (result.sessionNotFound || result.timeout) {
-        console.log(`[Handshake] Preferred org/entity session ${result.timeout ? 'timed out' : 'not found'}, discovering sessions for diagnostics...`);
+    // Step 2: If session not found, discover existing sessions and try them as fallback.
+    // The scoped key may not exist yet on older gateways; falling back to discovered
+    // sessions keeps bind-free functional while gateways migrate to scoped sessions.
+    if (result.sessionNotFound) {
+        console.log(`[Handshake] Preferred org/entity session not found, discovering sessions for fallback...`);
         const sessions = await discoverSessions(url, token, authOpts);
         console.log(`[Handshake] Discovered ${sessions.length} sessions: ${JSON.stringify(sessions)}`);
-        console.warn(`[Handshake] No org/entity scoped session found for ${deviceId}:${entityId}; refusing fallback to unscoped sessions`);
+
+        for (const sk of sessions) {
+            if (sk === preferredSessionKey) continue; // already tried
+            console.log(`[Handshake] Trying discovered session: ${sk}...`);
+            const fallbackResult = await sendToSession(url, token, sk, bindMsg, authOpts, sendOpts);
+            if (fallbackResult.success) {
+                console.log(`[Handshake] ✓ Handshake OK with discovered session: ${sk}`);
+                return { success: true, sessionKey: sk, botResponse: fallbackResult.botResponse };
+            }
+        }
+        console.warn(`[Handshake] No discovered session responded successfully for ${deviceId}:${entityId}`);
+    } else if (result.timeout) {
+        console.warn(`[Handshake] Preferred session timed out for ${deviceId}:${entityId}`);
     }
 
     const finalErrorType = result.timeout ? 'timeout'

--- a/backend/public/sitemap.xml
+++ b/backend/public/sitemap.xml
@@ -55,12 +55,6 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://eclawbot.com/portal/compare.html</loc>
-    <lastmod>2026-05-24</lastmod>
-    <changefreq>monthly</changefreq>
-    <priority>0.6</priority>
-  </url>
-  <url>
     <loc>https://eclawbot.com/promo.html</loc>
     <lastmod>2026-05-24</lastmod>
     <changefreq>monthly</changefreq>

--- a/backend/tests/jest/session-scope.test.js
+++ b/backend/tests/jest/session-scope.test.js
@@ -25,11 +25,12 @@ describe('official bot org/entity session scope', () => {
         expect(sanitizeSessionScopePart('org/id:with spaces', 'unknown')).toBe('org_id_with_spaces');
     });
 
-    test('binding code uses scoped keys and does not retry arbitrary discovered sessions', () => {
+    test('binding code uses scoped keys with fallback to discovered sessions', () => {
         const source = fs.readFileSync(path.join(__dirname, '../../index.js'), 'utf8');
         expect(source).toContain("buildOrgEntitySessionKey(freeBot.session_key_template || 'default', deviceId, eId)");
         expect(source).toContain("buildOrgEntitySessionKey(personalBot.session_key_template || 'default', deviceId, eId)");
-        expect(source).toContain("No org/entity scoped session found");
-        expect(source).not.toMatch(/for \(const sk of sessions\)/);
+        // Fallback loop restored so bind-free works when gateway lacks scoped sessions
+        expect(source).toContain("Trying discovered session");
+        expect(source).toMatch(/for \(const sk of sessions\)/);
     });
 });


### PR DESCRIPTION
## Summary
- Restores fallback loop in `handshakeWithBot()` that tries discovered gateway sessions when the scoped session key does not exist
- Fixes persistent 502 on `POST /api/official-borrow/bind-free` caused by PR #2912 removing the fallback
- Removes `compare.html` from sitemap (conflicts with robots.txt Disallow)

## Root Cause
PR #2912 introduced org/entity-scoped session keys but no gateway has these sessions yet. Without the fallback to existing unscoped sessions, all bind-free attempts fail.

## Test plan
- [x] `session-scope.test.js` updated and passing (4/4)
- [x] Full Jest suite: 211 suites, 3039 tests passing
- [ ] Verify bind-free works on production after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)