### PR TITLE
fix(i18n): localize FCM NotificationChannel labels (card_ec8d3a22)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt
+++ b/app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt
@@ -33,14 +33,14 @@ class ClawFcmService : FirebaseMessagingService() {
             if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
             val nm = context.getSystemService(NotificationManager::class.java)
             nm.createNotificationChannel(NotificationChannel(
-                CHANNEL_CHAT, "Chat Messages", NotificationManager.IMPORTANCE_HIGH
-            ).apply { description = "Messages from your entities" })
+                CHANNEL_CHAT, context.getString(R.string.fcm_channel_chat_name), NotificationManager.IMPORTANCE_HIGH
+            ).apply { description = context.getString(R.string.fcm_channel_chat_desc) })
             nm.createNotificationChannel(NotificationChannel(
-                CHANNEL_SYSTEM, "System", NotificationManager.IMPORTANCE_DEFAULT
-            ).apply { description = "System notifications" })
+                CHANNEL_SYSTEM, context.getString(R.string.fcm_channel_system_name), NotificationManager.IMPORTANCE_DEFAULT
+            ).apply { description = context.getString(R.string.fcm_channel_system_desc) })
             nm.createNotificationChannel(NotificationChannel(
-                CHANNEL_FEEDBACK, "Feedback Updates", NotificationManager.IMPORTANCE_DEFAULT
-            ).apply { description = "Feedback status updates" })
+                CHANNEL_FEEDBACK, context.getString(R.string.fcm_channel_feedback_name), NotificationManager.IMPORTANCE_DEFAULT
+            ).apply { description = context.getString(R.string.fcm_channel_feedback_desc) })
         }
     }
 

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -951,4 +951,12 @@ GPS: عند الطلب فقط، بلا تتبع في الخلفية، تُفقد
     <string name="tool_status_writing">جاري كتابة الملف…</string>
     <string name="custom_layout_enabled">تم تفعيل التخطيط المخصص</string>
     <string name="custom_layout_using_preset">استخدام التخطيط الافتراضي</string>
+
+    <!-- FCM Notification Channels -->
+    <string name="fcm_channel_chat_name">محادثة</string>
+    <string name="fcm_channel_chat_desc">رسائل من جهاتك</string>
+    <string name="fcm_channel_system_name">النظام</string>
+    <string name="fcm_channel_system_desc">إشعارات النظام</string>
+    <string name="fcm_channel_feedback_name">تحديثات الملاحظات</string>
+    <string name="fcm_channel_feedback_desc">تحديثات حالة الملاحظات</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -950,4 +950,12 @@ Bei Fragen kontaktieren Sie uns über unsere offizielle E-Mail.
     <string name="tool_status_writing">Datei wird geschrieben…</string>
     <string name="custom_layout_enabled">Benutzerdefiniertes Layout aktiviert</string>
     <string name="custom_layout_using_preset">Standard-Layout verwenden</string>
+
+    <!-- FCM Notification Channels -->
+    <string name="fcm_channel_chat_name">Chat-Nachrichten</string>
+    <string name="fcm_channel_chat_desc">Nachrichten von deinen Entitäten</string>
+    <string name="fcm_channel_system_name">System</string>
+    <string name="fcm_channel_system_desc">Systembenachrichtigungen</string>
+    <string name="fcm_channel_feedback_name">Feedback-Updates</string>
+    <string name="fcm_channel_feedback_desc">Feedback-Statusaktualisierungen</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -873,4 +873,12 @@ Tu suscripción permanece activa y puedes reenlazar en cualquier momento (sujeto
     <string name="tool_status_writing">Escribiendo archivo…</string>
     <string name="custom_layout_enabled">Diseño personalizado activado</string>
     <string name="custom_layout_using_preset">Usando diseño predeterminado</string>
+
+    <!-- FCM Notification Channels -->
+    <string name="fcm_channel_chat_name">Mensajes de chat</string>
+    <string name="fcm_channel_chat_desc">Mensajes de tus entidades</string>
+    <string name="fcm_channel_system_name">Sistema</string>
+    <string name="fcm_channel_system_desc">Notificaciones del sistema</string>
+    <string name="fcm_channel_feedback_name">Actualizaciones de comentarios</string>
+    <string name="fcm_channel_feedback_desc">Actualizaciones del estado de comentarios</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -950,4 +950,12 @@ Si vous avez des questions, contactez-nous via notre e-mail officiel.
     <string name="tool_status_writing">Écriture du fichier…</string>
     <string name="custom_layout_enabled">Disposition personnalisée activée</string>
     <string name="custom_layout_using_preset">Disposition par défaut</string>
+
+    <!-- FCM Notification Channels -->
+    <string name="fcm_channel_chat_name">Messages de chat</string>
+    <string name="fcm_channel_chat_desc">Messages de vos entités</string>
+    <string name="fcm_channel_system_name">Système</string>
+    <string name="fcm_channel_system_desc">Notifications système</string>
+    <string name="fcm_channel_feedback_name">Mises à jour des retours</string>
+    <string name="fcm_channel_feedback_desc">Mises à jour de l\'état des retours</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -950,4 +950,12 @@ GPS: केवल अनुरोध पर, कोई बैकग्राउ�
     <string name="tool_status_writing">फ़ाइल लिखी जा रही है…</string>
     <string name="custom_layout_enabled">कस्टम लेआउट सक्षम</string>
     <string name="custom_layout_using_preset">प्रीसेट लेआउट का उपयोग</string>
+
+    <!-- FCM Notification Channels -->
+    <string name="fcm_channel_chat_name">चैट संदेश</string>
+    <string name="fcm_channel_chat_desc">आपकी एंटिटी से संदेश</string>
+    <string name="fcm_channel_system_name">सिस्टम</string>
+    <string name="fcm_channel_system_desc">सिस्टम सूचनाएं</string>
+    <string name="fcm_channel_feedback_name">फ़ीडबैक अपडेट</string>
+    <string name="fcm_channel_feedback_desc">फ़ीडबैक स्थिति अपडेट</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -845,4 +845,12 @@ Jika ada pertanyaan, silakan hubungi kami melalui email resmi kami.
     <string name="tool_status_writing">Menulis file…</string>
     <string name="custom_layout_enabled">Tata letak kustom diaktifkan</string>
     <string name="custom_layout_using_preset">Menggunakan tata letak bawaan</string>
+
+    <!-- FCM Notification Channels -->
+    <string name="fcm_channel_chat_name">Pesan obrolan</string>
+    <string name="fcm_channel_chat_desc">Pesan dari entitas Anda</string>
+    <string name="fcm_channel_system_name">Sistem</string>
+    <string name="fcm_channel_system_desc">Notifikasi sistem</string>
+    <string name="fcm_channel_feedback_name">Pembaruan masukan</string>
+    <string name="fcm_channel_feedback_desc">Pembaruan status masukan</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -846,4 +846,12 @@ GPS：オンデマンドのみ、バックグラウンド追跡なし、サー�
     <string name="tool_status_writing">ファイルを書き込む中…</string>
     <string name="custom_layout_enabled">カスタムレイアウトを有効化</string>
     <string name="custom_layout_using_preset">プリセットレイアウトを使用</string>
+
+    <!-- FCM Notification Channels -->
+    <string name="fcm_channel_chat_name">チャットメッセージ</string>
+    <string name="fcm_channel_chat_desc">エンティティからのメッセージ</string>
+    <string name="fcm_channel_system_name">システム</string>
+    <string name="fcm_channel_system_desc">システム通知</string>
+    <string name="fcm_channel_feedback_name">フィードバック更新</string>
+    <string name="fcm_channel_feedback_desc">フィードバック状態の更新</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -846,4 +846,12 @@ GPS: 온디맨드만, 백그라운드 추적 없음, 서버 재시작 시 데이
     <string name="tool_status_writing">파일 작성 중…</string>
     <string name="custom_layout_enabled">사용자 지정 레이아웃 활성화</string>
     <string name="custom_layout_using_preset">프리셋 레이아웃 사용</string>
+
+    <!-- FCM Notification Channels -->
+    <string name="fcm_channel_chat_name">채팅 메시지</string>
+    <string name="fcm_channel_chat_desc">엔티티의 메시지</string>
+    <string name="fcm_channel_system_name">시스템</string>
+    <string name="fcm_channel_system_desc">시스템 알림</string>
+    <string name="fcm_channel_feedback_name">피드백 업데이트</string>
+    <string name="fcm_channel_feedback_desc">피드백 상태 업데이트</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -950,4 +950,12 @@ Jika anda mempunyai sebarang soalan, sila hubungi kami melalui e-mel rasmi kami.
     <string name="tool_status_writing">Menulis fail…</string>
     <string name="custom_layout_enabled">Tata letak tersuai diaktifkan</string>
     <string name="custom_layout_using_preset">Menggunakan tata letak lalai</string>
+
+    <!-- FCM Notification Channels -->
+    <string name="fcm_channel_chat_name">Mesej sembang</string>
+    <string name="fcm_channel_chat_desc">Mesej daripada entiti anda</string>
+    <string name="fcm_channel_system_name">Sistem</string>
+    <string name="fcm_channel_system_desc">Pemberitahuan sistem</string>
+    <string name="fcm_channel_feedback_name">Kemas kini maklum balas</string>
+    <string name="fcm_channel_feedback_desc">Kemas kini status maklum balas</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -845,4 +845,12 @@ GPS：รับตามความต้องการเท่านั้�
     <string name="tool_status_writing">กำลังเขียนไฟล์…</string>
     <string name="custom_layout_enabled">เปิดใช้งานเลย์เอาต์กำหนดเอง</string>
     <string name="custom_layout_using_preset">ใช้เลย์เอาต์ตั้งต้น</string>
+
+    <!-- FCM Notification Channels -->
+    <string name="fcm_channel_chat_name">ข้อความแชท</string>
+    <string name="fcm_channel_chat_desc">ข้อความจากเอนทิตีของคุณ</string>
+    <string name="fcm_channel_system_name">ระบบ</string>
+    <string name="fcm_channel_system_desc">การแจ้งเตือนระบบ</string>
+    <string name="fcm_channel_feedback_name">อัปเดตคำติชม</string>
+    <string name="fcm_channel_feedback_desc">อัปเดตสถานะคำติชม</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -845,4 +845,12 @@ Nếu có bất kỳ câu hỏi nào, vui lòng liên hệ với chúng tôi qua
     <string name="tool_status_writing">Đang ghi tệp…</string>
     <string name="custom_layout_enabled">Đã bật bố cục tùy chỉnh</string>
     <string name="custom_layout_using_preset">Đang dùng bố cục mặc định</string>
+
+    <!-- FCM Notification Channels -->
+    <string name="fcm_channel_chat_name">Tin nhắn trò chuyện</string>
+    <string name="fcm_channel_chat_desc">Tin nhắn từ các thực thể của bạn</string>
+    <string name="fcm_channel_system_name">Hệ thống</string>
+    <string name="fcm_channel_system_desc">Thông báo hệ thống</string>
+    <string name="fcm_channel_feedback_name">Cập nhật phản hồi</string>
+    <string name="fcm_channel_feedback_desc">Cập nhật trạng thái phản hồi</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -848,4 +848,12 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="tool_status_writing">正在写入文件…</string>
     <string name="custom_layout_enabled">已启用自定义布局</string>
     <string name="custom_layout_using_preset">使用预设布局</string>
+
+    <!-- FCM Notification Channels -->
+    <string name="fcm_channel_chat_name">聊天消息</string>
+    <string name="fcm_channel_chat_desc">来自实体的消息</string>
+    <string name="fcm_channel_system_name">系统</string>
+    <string name="fcm_channel_system_desc">系统通知</string>
+    <string name="fcm_channel_feedback_name">反馈更新</string>
+    <string name="fcm_channel_feedback_desc">反馈状态更新</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -846,4 +846,12 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="tool_status_writing">正在寫入檔案…</string>
     <string name="custom_layout_enabled">已啟用自訂排版</string>
     <string name="custom_layout_using_preset">使用預設配置</string>
+
+    <!-- FCM Notification Channels -->
+    <string name="fcm_channel_chat_name">聊天訊息</string>
+    <string name="fcm_channel_chat_desc">來自實體的訊息</string>
+    <string name="fcm_channel_system_name">系統</string>
+    <string name="fcm_channel_system_desc">系統通知</string>
+    <string name="fcm_channel_feedback_name">回饋更新</string>
+    <string name="fcm_channel_feedback_desc">回饋狀態更新</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -690,6 +690,14 @@ If you have any questions, please contact us via our official email.
     <string name="notif_prefs_loading">Loading preferences…</string>
     <string name="notif_prefs_error">Failed to load notification preferences</string>
 
+    <!-- FCM Notification Channels (system-level channel labels shown in OS settings) -->
+    <string name="fcm_channel_chat_name">Chat Messages</string>
+    <string name="fcm_channel_chat_desc">Messages from your entities</string>
+    <string name="fcm_channel_system_name">System</string>
+    <string name="fcm_channel_system_desc">System notifications</string>
+    <string name="fcm_channel_feedback_name">Feedback Updates</string>
+    <string name="fcm_channel_feedback_desc">Feedback status updates</string>
+
     <!-- Broadcast Settings -->
     <string name="broadcast_settings_title">Broadcast Settings</string>
     <string name="broadcast_settings_desc">Configure how broadcast messages work</string>


### PR DESCRIPTION
## Summary
- Replaces 6 hardcoded English NotificationChannel labels in `ClawFcmService.kt` with `context.getString(R.string.fcm_channel_*)` calls so the OS-level channel UI follows the device locale.
- Adds 6 new `fcm_channel_*` keys to `values/strings.xml` (EN source) and to all 13 localized `values-*/strings.xml` files (ar, de, es, fr, hi, in, ja, ko, ms, th, vi, zh-rCN, zh-rTW) with native translations — not EN pass-through.
- Linked card: card_ec8d3a22e35bf522e8fe0ee1 (U54 i18n patrol; U57 take-over after #3 / #4 silently failed).

## Locales touched (14 total)
values (EN), values-ar, values-de, values-es, values-fr, values-hi, values-in, values-ja, values-ko, values-ms, values-th, values-vi, values-zh-rCN, values-zh-rTW.

## Acceptance criteria
- ✅ `grep "Chat Messages\|Messages from your entities\|System notifications\|Feedback Updates\|Feedback status updates" app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt` returns empty.
- ✅ Key count: all 14 strings.xml files contain 6/6 `fcm_channel_*` entries.
- ✅ `git diff --check` clean.
- ✅ `requires_screenshot_review=false` — no in-app UI surface changed; only OS-level NotificationChannel labels shown in system settings.

## Code review checklist (Part A)
- Logic trace: ✅ string lookups go through `context.getString` with the same `R.string.fcm_channel_*` keys defined in every locale.
- Test coverage: ⚠️ NO-OP (per CLAUDE.md feature_parity / `feedback_i18n_translate_not_passthrough` — locale resource correctness is enforced by Android resource compiler; no regression test added).
- Return shape: ✅ unchanged (`createChannels(Context)` still returns Unit).
- What this does NOT fix: notification payload `title`/`body` strings inside `onMessageReceived` are still derived from server payload (`data["title"]`/`data["body"]`) — out of scope.
- Security: ✅ no new input surface; string resources are static.

## Test plan
- [ ] Android build green on CI
- [ ] On a locale-switched device, open Settings → Apps → E-Claw → Notifications and verify channel names render in the device language.
