### PR TITLE
fix(i18n): dedupe backend locale keys via AST

### DIFF
--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -1253814,7 +1253814,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_avg_daily": "平均日造訪",
 
 
 
@@ -1253942,7 +1253941,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_by_campaign": "按 UTM 廣告活動",
 
 
 
@@ -1254070,7 +1254068,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_col_campaign": "廣告活動",
 
 
 
@@ -1254198,7 +1254195,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_col_path": "路徑",
 
 
 
@@ -1254326,7 +1254322,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_col_uniq": "獨立",
 
 
 
@@ -1254454,7 +1254449,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_col_views": "造訪",
 
 
 
@@ -1254582,7 +1254576,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_daily_chart": "每日造訪",
 
 
 
@@ -1254710,7 +1254703,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_days_30": "最近 30 天",
 
 
 
@@ -1254838,7 +1254830,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_days_7": "最近 7 天",
 
 
 
@@ -1254966,7 +1254957,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_days_90": "最近 90 天",
 
 
 
@@ -1255094,7 +1255084,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_days_label": "區間",
 
 
 
@@ -1255222,7 +1255211,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_err_fetch": "載入分析資料失敗",
 
 
 
@@ -1255350,7 +1255338,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_err_no_device": "無可用裝置憑證，僅限裝置擁有者存取。",
 
 
 
@@ -1255478,7 +1255465,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_legend_uniq": "獨立 IP",
 
 
 
@@ -1255606,7 +1255592,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_legend_views": "造訪",
 
 
 
@@ -1255734,7 +1255719,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_loading": "載入中…",
 
 
 
@@ -1255862,7 +1255846,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_no_campaigns": "區間內無標記廣告活動",
 
 
 
@@ -1255990,7 +1255973,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_no_data": "區間內無資料",
 
 
 
@@ -1256118,7 +1256100,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_path_filter_label": "路徑篩選",
 
 
 
@@ -1256246,7 +1256227,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_path_filter_placeholder": "例如 /landing* 或 /docs/*",
 
 
 
@@ -1256374,7 +1256354,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_refresh": "重新整理",
 
 
 
@@ -1256502,7 +1256481,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_subtitle": "公開頁面與行銷頁面的匿名造訪。入口頁面有各自獨立的裝置範圍遙測。",
 
 
 
@@ -1256630,7 +1256608,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_title": "網站分析",
 
 
 
@@ -1256758,7 +1256735,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_top_paths": "熱門路徑",
 
 
 
@@ -1256886,7 +1256862,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_total_views": "總造訪",
 
 
 
@@ -1257014,7 +1256989,6 @@ const TRANSLATIONS = {
 
 
 
-        "analytics_unique_ips": "獨立 IP",
 
 
 
@@ -1260982,7 +1260956,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_0": "多模態理解 — 感知並描述網頁中的視覺內容。",
 
 
 
@@ -1261110,7 +1261083,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_1": "精確 UI 互動 — 在大量元素中定位並點擊特定項目。",
 
 
 
@@ -1261238,7 +1261210,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_10": "儲存工作流 — 透過雲端 API 下載、重新命名並上傳檔案。",
 
 
 
@@ -1261366,7 +1261337,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_11": "語音能力 — 轉錄口說內容或從文字合成語音。",
 
 
 
@@ -1261494,7 +1261464,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_2": "結構化輸入 — 理解表單語義並正確填寫欄位。",
 
 
 
@@ -1261622,7 +1261591,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_3": "精細動作控制 — 精確地將物件拖曳到指定位置。",
 
 
 
@@ -1261750,7 +1261718,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_4": "規劃能力 — 導航多層級頁面結構以找到目標資訊。",
 
 
 
@@ -1261878,7 +1261845,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_5": "表格推理 — 提取並計算結構化 HTML 表格資料。",
 
 
 
@@ -1262006,7 +1261972,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_6": "安全判斷 — 抵禦社交工程攻擊（假彈窗、偽裝按鈕）。",
 
 
 
@@ -1262134,7 +1262099,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_7": "演算法推理 — 解決程式設計問題並產生正確程式碼。",
 
 
 
@@ -1262262,7 +1262226,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_8": "速度 — 從題目顯示到正確答案提交的端對端時間。",
 
 
 
@@ -1262390,7 +1262353,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_desc_9": "記憶 — 在連續步驟中維持並重用資訊。",
 
 
 
@@ -1262518,7 +1262480,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_0": "視覺感知",
 
 
 
@@ -1262646,7 +1262607,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_1": "元素定位",
 
 
 
@@ -1262774,7 +1262734,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_10": "檔案操作",
 
 
 
@@ -1262902,7 +1262861,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_11": "語音處理",
 
 
 
@@ -1263030,7 +1262988,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_2": "表單填寫",
 
 
 
@@ -1263158,7 +1263115,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_3": "空間控制",
 
 
 
@@ -1263286,7 +1263242,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_4": "多步導航",
 
 
 
@@ -1263414,7 +1263369,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_5": "資料提取",
 
 
 
@@ -1263542,7 +1263496,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_6": "干擾抵抗",
 
 
 
@@ -1263670,7 +1263623,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_7": "代碼生成",
 
 
 
@@ -1263798,7 +1263750,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_8": "回應延遲",
 
 
 
@@ -1263926,7 +1263877,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_test_name_9": "上下文記憶",
 
 
 
@@ -1296184,7 +1296134,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_btn": "找相关訊息",
 
 
 
@@ -1296312,7 +1296261,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_empty": "找不到相关訊息。",
 
 
 
@@ -1296440,7 +1296388,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_error": "载入相关訊息失败。",
 
 
 
@@ -1296568,7 +1296515,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_loading": "正在找相关訊息…",
 
 
 
@@ -1296952,7 +1296898,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_panel_title": "相关訊息",
 
 
 
@@ -1297080,7 +1297025,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_target_not_loaded": "訊息目前未载入",
 
 
 
@@ -1493051,7 +1492995,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_behavior_user": "純提示模式 — 不影響路由，只塞 <code>[MENTIONS]</code> 給接收 Bot",
 
 
 
@@ -1493179,7 +1493122,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case1_input_label": "你輸入的訊息",
 
 
 
@@ -1493307,7 +1493249,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case1_input_text": "幫我問今天的台積電走勢",
 
 
 
@@ -1493435,7 +1493376,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case1_outcome": "主助手會看到提示，自己決定要不要呼叫 transform 把訊息轉給股票分析師。",
 
 
 
@@ -1493563,7 +1493503,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case1_recv_label": "主助手收到的提示",
 
 
 
@@ -1493691,7 +1493630,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case2_input_label": "你輸入的訊息",
 
 
 
@@ -1493819,7 +1493757,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case2_input_text": "這個 feature 你們覺得怎麼做？",
 
 
 
@@ -1493947,7 +1493884,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case2_outcome": "會議主持可以選擇 parallel 平行轉發給三人，或先彙整再回覆。",
 
 
 
@@ -1494075,7 +1494011,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case2_recv_label": "會議主持收到的提示",
 
 
 
@@ -1494203,7 +1494138,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case3_input_label": "你輸入的訊息",
 
 
 
@@ -1494331,7 +1494265,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case3_input_text": "明天 9 點 all-hands 會議",
 
 
 
@@ -1494459,7 +1494392,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case3_outcome": "公告 Bot 看到 <code>@all</code> 提示後，可以呼叫 <code>/api/transform</code> 加上 <code>broadcast:true</code> 真正廣播給所有實體。",
 
 
 
@@ -1494587,7 +1494519,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_case3_recv_label": "公告 Bot 收到的提示",
 
 
 
@@ -1494715,7 +1494646,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_dir_bot": "<strong>Bot @</strong>（在 transform message）",
 
 
 
@@ -1494843,7 +1494773,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_mention_dir_user": "<strong>使用者 @</strong>（在 chat 輸入框）",
 
 
 
@@ -2041471,26 +2041400,6 @@ const TRANSLATIONS = {
 
 
         "dash_channel_promo": "EClaw Channel を試してみませんか？よりネイティブ、より高速",
-        "dash_channel_card_openclaw_title": "OpenClaw Channel",
-        "dash_channel_card_openclaw_badge": "安定版",
-        "dash_channel_card_openclaw_desc": "公式 OpenClaw プラグイン経路 — ホスト型 OpenClaw bot と本番 API キー設定に最適です。",
-        "dash_channel_card_codex_title": "Codex Channel",
-        "dash_channel_card_codex_badge": "CLI ブリッジ",
-        "dash_channel_card_codex_desc": "codex app-server 経由で EClaw エンティティを OpenAI Codex CLI に接続します。EClaw chat からリモート repo 作業を行うのに適しています。",
-        "dash_channel_card_codex_step2": ".env を設定: ECLAW_API_KEY, WEBHOOK_URL, CODEX_WORKSPACE",
-        "dash_channel_card_codex_guide_link": "Codex ガイド →",
-        "dash_channel_card_clauded_title": "Claude Code Channel",
-        "dash_channel_card_clauded_badge": "実験版",
-        "dash_channel_card_clauded_desc": "ローカル tmux セッションで Claude Code を EClaw bot として実行します — claude.ai Max サブスク枠を使用し、Anthropic API トークン課金はありません。",
-        "dash_channel_card_clauded_step2": ".mcp.json を設定: ECLAW_API_KEY, ECLAW_WEBHOOK_URL",
-        "dash_channel_card_clauded_guide_link": "Claude Code ガイド →",
-        "dash_channel_card_hermes_title": "Hermes Channel",
-        "dash_channel_card_hermes_badge": "ライブショーケース",
-        "dash_channel_card_hermes_desc": "Hermes Agent（NousResearch の自己進化型エージェント、Python）を webhook 経由で EClaw bot としてバインドします。MiniMax / OpenAI / Anthropic / ローカル Ollama に対応。",
-        "dash_channel_card_hermes_step1": "git clone .../hermes-eclaw-channel",
-        "dash_channel_card_hermes_step2": "./scripts/setup-tunnel.sh hermes-b ...",
-        "dash_channel_card_hermes_step3": "bind-entity + daemon 起動",
-        "dash_channel_card_hermes_guide_link": "Hermes ガイド →",
 
 
 
@@ -2228309,7 +2228218,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_badge": "管理者",
 
 
 
@@ -2228437,7 +2228345,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_admin_users": "管理者ユーザー管理",
 
 
 
@@ -2228565,7 +2228472,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_admin_users_desc": "ADMIN_DEVICE_IDS の確認とローテーション。",
 
 
 
@@ -2228693,7 +2228599,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_feature_flags": "機能フラグ",
 
 
 
@@ -2228821,7 +2228726,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_feature_flags_desc": "デバイスごと/グローバルに実験的機能を切り替え。",
 
 
 
@@ -2228949,7 +2228853,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_log_browser": "エラーログブラウザ",
 
 
 
@@ -2229077,7 +2228980,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_log_browser_desc": "カテゴリ、レベル、時間で server_logs をフィルタ。",
 
 
 
@@ -2229205,7 +2229107,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_rental_monitor": "レンタル健全性モニター",
 
 
 
@@ -2229333,7 +2229234,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_rental_monitor_desc": "DBレイテンシ、トストーン成長、Publisher統合状態、Fleet数。",
 
 
 
@@ -2229461,7 +2229361,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_soon": "近日公開",
 
 
 
@@ -2229589,7 +2229488,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_sys_metrics": "システムメトリクス",
 
 
 
@@ -2229717,7 +2229615,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_sys_metrics_desc": "CPU / メモリ / ソケット数 / リクエストレート。",
 
 
 
@@ -2229845,7 +2229742,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_footnote": "管理者専用 — 非管理者のデバイスは読み込み時に403画面を表示し /portal/ にリダイレクト",
 
 
 
@@ -2229973,7 +2229869,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_section_future": "計画中",
 
 
 
@@ -2230101,7 +2229996,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_section_monitoring": "監視",
 
 
 
@@ -2230229,7 +2230123,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_subtitle": "開発 + Opsツール。非管理者のデバイスはポータルにリダイレクトされます。",
 
 
 
@@ -2230357,7 +2230250,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_title": "[admin] EClaw 管理ツール",
 
 
 
@@ -2230485,7 +2230377,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_chat_view_feedback": "フィードバック履歴を表示",
 
 
 
@@ -2230613,7 +2230504,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_return": "← 返回",
 
 
 
@@ -2230741,7 +2230631,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_attach_key_ref": "鍵の参照",
 
 
 
@@ -2230869,7 +2230758,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_card_modal_comments": "コメント",
 
 
 
@@ -2230997,7 +2230885,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_card_modal_comments_empty": "コメントはまだありません",
 
 
 
@@ -2231125,7 +2231012,6 @@ const TRANSLATIONS = {
 
 
 
-"chat_density_comfortable": "快適",
 
 
 
@@ -2231253,7 +2231139,6 @@ const TRANSLATIONS = {
 
 
 
-"chat_density_compact": "紧凑",
 
 
 
@@ -2231381,7 +2231266,6 @@ const TRANSLATIONS = {
 
 
 
-"chat_density_normal": "標準",
 
 
 
@@ -2231509,7 +2231393,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_kanban_view_card": "📋 カードを表示",
 
 
 
@@ -2231637,7 +2231520,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_loading": "読み込み中...",
 
 
 
@@ -2231765,7 +2231647,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mention_unresolved": "不明な @mention: {tokens}",
 
 
 
@@ -2231893,7 +2231774,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mic_denied": "マイクアクセスが拒否されました",
 
 
 
@@ -2232021,7 +2231901,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_demo_node": "このノードはデモデータまたは短いプレフィックスIDです — ページ間引用はサポートされていません。マインドマップページの📋ボタンを 사용하여フルトークンをコピーしてください。",
 
 
 
@@ -2232149,7 +2232028,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_empty": "—",
 
 
 
@@ -2232277,7 +2232155,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_field_anchors": "アンカー",
 
 
 
@@ -2232405,7 +2232282,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_field_comments": "コメント",
 
 
 
@@ -2232533,7 +2232409,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_field_summary": "要約",
 
 
 
@@ -2232661,7 +2232536,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_field_type": "種類",
 
 
 
@@ -2232789,7 +2232663,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mission_notify": "ミッション",
 
 
 
@@ -2232917,7 +2232790,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_playback_failed": "再生に失敗しました",
 
 
 
@@ -2233045,7 +2232917,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_btn": "関連チャット",
 
 
 
@@ -2233173,7 +2233044,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_empty": "関連するチャットが見つかりません",
 
 
 
@@ -2233301,7 +2233171,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_error": "関連するチャットの読み込みに失敗しました",
 
 
 
@@ -2233429,7 +2233298,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_loading": "関連するチャットを読み込み中...",
 
 
 
@@ -2233812,7 +2233680,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_panel_title": "関連するチャット",
 
 
 
@@ -2233940,7 +2233807,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_target_not_loaded": "ターゲットチャットが読み込まれていません",
 
 
 
@@ -2234068,7 +2233934,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_cancel": "キャンセル",
 
 
 
@@ -2234196,7 +2234061,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_cancelled": "キャンセル済み",
 
 
 
@@ -2234324,7 +2234188,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_close": "閉じる",
 
 
 
@@ -2234452,7 +2234315,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_delete": "削除",
 
 
 
@@ -2234580,7 +2234442,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_delete_confirm": "この予約メッセージをキャンセルしますか？",
 
 
 
@@ -2234708,7 +2234569,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_edit": "編集",
 
 
 
@@ -2234836,7 +2234696,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_empty_text": "(空欄 — 予約前にメッセージを入力してください)",
 
 
 
@@ -2234964,7 +2234823,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_empty": "まずメッセージを入力してください",
 
 
 
@@ -2235092,7 +2234950,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_in_past": "時間は未来である必要があります",
 
 
 
@@ -2235220,7 +2235077,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_invalid_time": "有効な時間を入力してください",
 
 
 
@@ -2235348,7 +2235204,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_no_target": "少なくとも1つのターゲットを選択してください",
 
 
 
@@ -2235476,7 +2235331,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_too_far": "7日先までしか予約できません",
 
 
 
@@ -2235604,7 +2235458,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_h": "時",
 
 
 
@@ -2235732,7 +2235585,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_loading": "読み込み中...",
 
 
 
@@ -2235860,7 +2235712,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_local_only": "(ローカルエンティティのみ)",
 
 
 
@@ -2235988,7 +2235839,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_m": "分",
 
 
 
@@ -2236116,7 +2235966,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_max_7days": "(最大7日)",
 
 
 
@@ -2236244,7 +2236093,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_message_label": "メッセージ",
 
 
 
@@ -2236372,7 +2236220,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_mode_countdown": "カウントダウン",
 
 
 
@@ -2236500,7 +2236347,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_mode_fixed": "固定時間",
 
 
 
@@ -2236628,7 +2236474,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_mode_label": "実行タイミング",
 
 
 
@@ -2236756,7 +2236601,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_no_pending": "保留中の予約メッセージはありません",
 
 
 
@@ -2236884,7 +2236728,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_ok": "予約済み",
 
 
 
@@ -2237012,7 +2236855,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_s": "秒",
 
 
 
@@ -2237140,7 +2236982,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_save": "保存",
 
 
 
@@ -2237268,7 +2237109,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_saved": "保存済み",
 
 
 
@@ -2237396,7 +2237236,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_submit": "予約",
 
 
 
@@ -2237524,7 +2237363,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_tab_create": "新規",
 
 
 
@@ -2237652,7 +2237490,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_tab_queue": "予約一覧",
 
 
 
@@ -2237780,7 +2237617,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_target_label": "送信先",
 
 
 
@@ -2237908,7 +2237744,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_title": "⏰ メッセージを予約",
 
 
 
@@ -2238036,7 +2237871,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_scheduled": "予約済み",
 
 
 
@@ -2238164,7 +2237998,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_scroll_to_latest": "最新メッセージにスクロール",
 
 
 
@@ -2238292,7 +2238125,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_unread_sep": "── 新しいメッセージ ──",
 
 
 
@@ -2238420,7 +2238252,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_voice_upload_failed": "音声アップロードに失敗しました",
 
 
 
@@ -2238548,7 +2238379,6 @@ const TRANSLATIONS = {
 
 
 
-        "chip_popover_requoted": "チャットに引用しました",
 
 
 
@@ -2238676,7 +2238506,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_mark": "マーク",
 
 
 
@@ -2238804,7 +2238633,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_new_key": "+ 新しい鍵",
 
 
 
@@ -2238932,7 +2238760,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_open_editor": "エディタを開く",
 
 
 
@@ -2239060,7 +2238887,6 @@ const TRANSLATIONS = {
 
 
 
-"common_redeem": "引き換える",
 
 
 
@@ -2239188,7 +2239014,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_cta_create_bot": "独自のBotをお持ちですか？無料で作成して今すぐリストに登録しましょう。",
 
 
 
@@ -2239316,7 +2239141,6 @@ const TRANSLATIONS = {
 
 
 
-        "compare_back": "← 情報ハブに戻る",
 
 
 
@@ -2239444,7 +2239268,6 @@ const TRANSLATIONS = {
 
 
 
-        "compare_page_title": "EClawbot vs Telegram — チャンネル比較",
 
 
 
@@ -2604431,26 +2604254,6 @@ const TRANSLATIONS = {
 
 
         "dash_channel_promo": "EClaw Channel을 사용해 보세요! 더 네이티브하고 더 빠릅니다",
-        "dash_channel_card_openclaw_title": "OpenClaw Channel",
-        "dash_channel_card_openclaw_badge": "안정",
-        "dash_channel_card_openclaw_desc": "공식 OpenClaw 플러그인 경로 — 호스팅 OpenClaw 봇과 프로덕션 API 키 설정에 가장 적합합니다.",
-        "dash_channel_card_codex_title": "Codex Channel",
-        "dash_channel_card_codex_badge": "CLI 브리지",
-        "dash_channel_card_codex_desc": "codex app-server를 통해 EClaw 엔티티를 OpenAI Codex CLI에 연결합니다. EClaw chat에서 원격 repo 작업을 하기에 좋습니다.",
-        "dash_channel_card_codex_step2": ".env 채우기: ECLAW_API_KEY, WEBHOOK_URL, CODEX_WORKSPACE",
-        "dash_channel_card_codex_guide_link": "Codex 가이드 →",
-        "dash_channel_card_clauded_title": "Claude Code Channel",
-        "dash_channel_card_clauded_badge": "실험적",
-        "dash_channel_card_clauded_desc": "로컬 tmux 세션에서 Claude Code를 EClaw bot으로 실행합니다 — claude.ai Max 구독 할당량을 사용하며 Anthropic API 토큰 비용은 청구되지 않습니다.",
-        "dash_channel_card_clauded_step2": ".mcp.json 채우기: ECLAW_API_KEY, ECLAW_WEBHOOK_URL",
-        "dash_channel_card_clauded_guide_link": "Claude Code 가이드 →",
-        "dash_channel_card_hermes_title": "Hermes Channel",
-        "dash_channel_card_hermes_badge": "라이브 쇼케이스",
-        "dash_channel_card_hermes_desc": "Hermes Agent(NousResearch self-evolving agent, Python)를 webhook으로 EClaw bot에 바인딩합니다. MiniMax / OpenAI / Anthropic / 로컬 Ollama를 지원합니다.",
-        "dash_channel_card_hermes_step1": "git clone .../hermes-eclaw-channel",
-        "dash_channel_card_hermes_step2": "./scripts/setup-tunnel.sh hermes-b ...",
-        "dash_channel_card_hermes_step3": "bind-entity + daemon 시작",
-        "dash_channel_card_hermes_guide_link": "Hermes 가이드 →",
 
 
 
@@ -7707850,7 +7707653,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_badge": "ADMIN",
 
 
 
@@ -7707978,7 +7707780,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_admin_users": "Gestión de usuarios administradores",
 
 
 
@@ -7708106,7 +7707907,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_admin_users_desc": "Inspeccionar + rotar entradas en ADMIN_DEVICE_IDS.",
 
 
 
@@ -7708234,7 +7708034,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_feature_flags": "Flags de características",
 
 
 
@@ -7708362,7 +7708161,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_feature_flags_desc": "Alternar funciones experimentales por dispositivo / globalmente.",
 
 
 
@@ -7708490,7 +7708288,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_log_browser": "Navegador de registros de errores",
 
 
 
@@ -7708618,7 +7708415,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_log_browser_desc": "Filtrar server_logs por categoría, nivel, ventana de tiempo.",
 
 
 
@@ -7708746,7 +7708542,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_rental_monitor": "Monitor de estado de alquiler",
 
 
 
@@ -7708874,7 +7708669,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_rental_monitor_desc": "Latencia BD, crecimiento de tumbas, estado de integración del publicador, conteos de flota.",
 
 
 
@@ -7709002,7 +7708796,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_soon": "Próximamente",
 
 
 
@@ -7709130,7 +7708923,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_sys_metrics": "Métricas del sistema",
 
 
 
@@ -7709258,7 +7709050,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_card_sys_metrics_desc": "CPU / memoria / conteo de sockets / tasa de solicitudes.",
 
 
 
@@ -7709386,7 +7709177,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_footnote": "Solo administrador — dispositivos no-admin ven una pantalla 403 al cargar y son redirigidos a /portal/",
 
 
 
@@ -7709514,7 +7709304,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_section_future": "Planificado",
 
 
 
@@ -7709642,7 +7709431,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_section_monitoring": "Monitoreo",
 
 
 
@@ -7709770,7 +7709558,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_subtitle": "Herramientas de desarrollo y ops. Dispositivos no-admin son redirigidos al portal.",
 
 
 
@@ -7709898,7 +7709685,6 @@ const TRANSLATIONS = {
 
 
 
-        "admin_hub_title": "[admin] Herramientas de administración EClaw",
 
 
 
@@ -7710026,7 +7709812,6 @@ const TRANSLATIONS = {
 
 
 
-        "ai_chat_view_feedback": "Ver historial de comentarios",
 
 
 
@@ -7710154,7 +7709939,6 @@ const TRANSLATIONS = {
 
 
 
-        "arena_return": "← Volver",
 
 
 
@@ -7710282,7 +7710066,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_attach_key_ref": "Referencia de clave",
 
 
 
@@ -7710410,7 +7710193,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_card_modal_comments": "Comentarios",
 
 
 
@@ -7710538,7 +7710320,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_card_modal_comments_empty": "Sin comentarios aún",
 
 
 
@@ -7710666,7 +7710447,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_density_comfortable": "Cómodo",
 
 
 
@@ -7710794,7 +7710574,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_density_compact": "Compacto",
 
 
 
@@ -7710922,7 +7710701,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_density_normal": "Normal",
 
 
 
@@ -7711050,7 +7710828,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_kanban_view_card": "📋 Ver tarjeta",
 
 
 
@@ -7711178,7 +7710955,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_loading": "Cargando...",
 
 
 
@@ -7711306,7 +7711082,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mention_unresolved": "Mención @ desconectada: {tokens}",
 
 
 
@@ -7711434,7 +7711209,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mic_denied": "Acceso al micrófono denegado",
 
 
 
@@ -7711562,7 +7711336,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_demo_node": "Este nodo es dato demo o un ID de prefijo corto — no se soporta citación entre páginas. Usa el botón 📋 en la página del mapa mental para copiar el token completo.",
 
 
 
@@ -7711690,7 +7711463,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_empty": "—",
 
 
 
@@ -7711818,7 +7711590,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_field_anchors": "Anclas",
 
 
 
@@ -7711946,7 +7711717,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_field_comments": "Comentarios",
 
 
 
@@ -7712074,7 +7711844,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_field_summary": "Resumen",
 
 
 
@@ -7712202,7 +7711971,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mindmap_field_type": "Tipo",
 
 
 
@@ -7712330,7 +7712098,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_mission_notify": "Misión",
 
 
 
@@ -7712458,7 +7712225,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_playback_failed": "Reproducción fallida",
 
 
 
@@ -7712586,7 +7712352,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_btn": "Chats relacionados",
 
 
 
@@ -7712714,7 +7712479,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_empty": "No se encontraron chats relacionados",
 
 
 
@@ -7712842,7 +7712606,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_error": "Error al cargar chats relacionados",
 
 
 
@@ -7712970,7 +7712733,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_loading": "Cargando chats relacionados...",
 
 
 
@@ -7713098,7 +7712860,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_panel_title": "Chats relacionados",
 
 
 
@@ -7713226,7 +7712987,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_related_target_not_loaded": "Chat objetivo no cargado",
 
 
 
@@ -7713354,7 +7713114,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_cancel": "Cancelar",
 
 
 
@@ -7713482,7 +7713241,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_cancelled": "Cancelado",
 
 
 
@@ -7713610,7 +7713368,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_close": "Cerrar",
 
 
 
@@ -7713738,7 +7713495,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_delete": "Eliminar",
 
 
 
@@ -7713866,7 +7713622,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_delete_confirm": "¿Cancelar este mensaje programado?",
 
 
 
@@ -7713994,7 +7713749,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_edit": "Editar",
 
 
 
@@ -7714122,7 +7713876,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_empty_text": "(vacío — escribe un mensaje antes de programar)",
 
 
 
@@ -7714250,7 +7714003,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_empty": "Primero escribe un mensaje",
 
 
 
@@ -7714378,7 +7714130,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_in_past": "El tiempo debe ser en el futuro",
 
 
 
@@ -7714506,7 +7714257,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_invalid_time": "Ingresa una hora válida",
 
 
 
@@ -7714634,7 +7714384,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_no_target": "Selecciona al menos un objetivo",
 
 
 
@@ -7714762,7 +7714511,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_err_too_far": "No se puede programar más de 7 días adelante",
 
 
 
@@ -7714890,7 +7714638,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_h": "h",
 
 
 
@@ -7715018,7 +7714765,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_loading": "Cargando…",
 
 
 
@@ -7715146,7 +7714892,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_local_only": "(solo entidades locales)",
 
 
 
@@ -7715274,7 +7715019,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_m": "m",
 
 
 
@@ -7715402,7 +7715146,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_max_7days": "(máx 7 días)",
 
 
 
@@ -7715530,7 +7715273,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_message_label": "Mensaje",
 
 
 
@@ -7715658,7 +7715400,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_mode_countdown": "Cuenta regresiva",
 
 
 
@@ -7715786,7 +7715527,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_mode_fixed": "Hora fija",
 
 
 
@@ -7715914,7 +7715654,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_mode_label": "Cuándo",
 
 
 
@@ -7716042,7 +7715781,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_no_pending": "Sin mensajes programados pendientes",
 
 
 
@@ -7716170,7 +7715908,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_ok": "Programado",
 
 
 
@@ -7716298,7 +7716035,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_s": "s",
 
 
 
@@ -7716426,7 +7716162,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_save": "Guardar",
 
 
 
@@ -7716554,7 +7716289,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_saved": "Guardado",
 
 
 
@@ -7716682,7 +7716416,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_submit": "Programar",
 
 
 
@@ -7716810,7 +7716543,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_tab_create": "Nuevo",
 
 
 
@@ -7716938,7 +7716670,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_tab_queue": "Programado",
 
 
 
@@ -7717066,7 +7716797,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_target_label": "Enviar a",
 
 
 
@@ -7717194,7 +7716924,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_schedule_title": "⏰ Programar mensaje",
 
 
 
@@ -7717322,7 +7717051,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_scheduled": "Programado",
 
 
 
@@ -7717450,7 +7717178,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_scroll_to_latest": "Desplazarse al mensaje más reciente",
 
 
 
@@ -7717578,7 +7717305,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_unread_sep": "── Mensajes nuevos ──",
 
 
 
@@ -7717706,7 +7717432,6 @@ const TRANSLATIONS = {
 
 
 
-        "chat_voice_upload_failed": "Carga de voz fallida",
 
 
 
@@ -7717834,7 +7717559,6 @@ const TRANSLATIONS = {
 
 
 
-        "chip_popover_requoted": "Citado en el chat",
 
 
 
@@ -7717962,7 +7717686,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_mark": "Marcar",
 
 
 
@@ -7718090,7 +7717813,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_new_key": "+ Nueva clave",
 
 
 
@@ -7718218,7 +7717940,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_open_editor": "Abrir editor",
 
 
 
@@ -7718346,7 +7718067,6 @@ const TRANSLATIONS = {
 
 
 
-        "common_redeem": "Canjear",
 
 
 
@@ -7718474,7 +7718194,6 @@ const TRANSLATIONS = {
 
 
 
-        "community_cta_create_bot": "¿Quieres tu propio Bot? Crea uno gratis y publícalo instantáneamente.",
 
 
 
@@ -7718602,7 +7718321,6 @@ const TRANSLATIONS = {
 
 
 
-        "compare_back": "← Volver al centro de información",
 
 
 
@@ -7718730,7 +7718448,6 @@ const TRANSLATIONS = {
 
 
 
-        "compare_page_title": "EClawbot vs Telegram — Comparación de canales",
 
 
 
@@ -7718858,7 +7718575,6 @@ const TRANSLATIONS = {
 
 
 
-        "developer_section_title": "Desarrollador",
 
 
 
@@ -7718986,7 +7718702,6 @@ const TRANSLATIONS = {
 
 
 
-        "env_toggle_device_id": "Mostrar/Ocultar ID de dispositivo",
 
 
 
@@ -7719114,7 +7718829,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_delete_confirm": "¿Estás seguro de que quieres eliminar este archivo?",
 
 
 
@@ -7719242,7 +7718956,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_delete_failed": "Error al eliminar archivo",
 
 
 
@@ -7719370,7 +7719083,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_deleted": "Archivo eliminado",
 
 
 
@@ -7719498,7 +7719210,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_multi_select_attach": "Adjuntar al chat",
 
 
 
@@ -7719626,7 +7719337,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_multi_select_cancel": "Cancelar",
 
 
 
@@ -7719754,7 +7719464,6 @@ const TRANSLATIONS = {
 
 
 
-        "files_multi_select_count": "Seleccionados",
 
 
 
@@ -7719882,7 +7719591,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_case_li1": "Claude principal envía sub (U12) para ejecutar una perforación de arrastrar/reiniciar organigrama en el emulador Android",
 
 
 
@@ -7720010,7 +7719718,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_case_li2": "Sub dispara MCP de computadora para tomar captura de pantalla, generando elicitación y bloqueando el TTY",
 
 
 
@@ -7720138,7 +7719845,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_case_li3": "Principal usa <code>eye</code> (herramienta de vista general de pantalla completa macOS) para ver el diálogo → osascript hace clic automático",
 
 
 
@@ -7720266,7 +7719972,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_case_li4": "Sub recibe allowAll → reanuda la perforación → descubre que BottomSheet solo se expande a ~20%",
 
 
 
@@ -7720394,7 +7720099,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_case_li5": "Principal analiza <code>OrgChartBottomSheetFragment</code> → aísla la peculiaridad de BottomSheetDialog que mide <code>match_parent</code> como <code>wrap_content</code>",
 
 
 
@@ -7720522,7 +7720226,6 @@ const TRANSLATIONS = {
 
 
 
-        "guide_bridge_case_li6": "Fix (PR #1854) → envía sub para verificar → confirma expansión del 90% → ciclo cerrado completo",
 
 
 

--- a/backend/scripts/i18n-lint-dup-keys.js
+++ b/backend/scripts/i18n-lint-dup-keys.js
@@ -1,91 +1,194 @@
 #!/usr/bin/env node
 /**
  * i18n-lint-dup-keys.js
- * Detects duplicate top-level keys within each locale block in i18n.js.
- * Run: node scripts/i18n-lint-dup-keys.js [i18n_path]
- * Exit codes: 0 = clean, 1 = dups found, 2 = file error
+ *
+ * Detects duplicate direct keys within each TRANSLATIONS locale block in
+ * i18n.js. With --fix, removes earlier duplicates and keeps the last property,
+ * matching JavaScript object literal runtime semantics.
+ *
+ * Run: node scripts/i18n-lint-dup-keys.js [--fix] [i18n_path]
+ * Exit codes: 0 = clean/fixed, 1 = dups found, 2 = file or parse error
  */
 
 'use strict';
 
 const path = require('path');
 const fs = require('fs');
+const espree = require('espree');
 
-const I18N_PATH = process.argv[2] || path.join(__dirname, '../public/shared/i18n.js');
+const args = process.argv.slice(2);
+const FIX = args.includes('--fix');
+const I18N_PATH = args.find(arg => !arg.startsWith('--'))
+  || path.join(__dirname, '../public/shared/i18n.js');
 
-// Match `xx:` or `xx-XX:` locale headers, with optional surrounding quotes.
-const LOCALE_HEADER_RE = /^"?([a-z]{2}(?:[-_][A-Z]{2})?)"?:\s*\{/;
+const LOCALE_KEY_RE = /^[a-z]{2}(?:[-_][A-Z]{2})?$/;
 
-// Count `{` and `}` outside string literals. Honors `\"` escapes within "..." strings.
-function countBracesOutsideStrings(line, startInString) {
-  let opens = 0;
-  let closes = 0;
-  let inString = startInString;
-  let escape = false;
-  for (let i = 0; i < line.length; i++) {
-    const ch = line[i];
-    if (escape) { escape = false; continue; }
-    if (inString) {
-      if (ch === '\\') { escape = true; continue; }
-      if (ch === '"') { inString = false; continue; }
-      continue;
-    }
-    if (ch === '"') { inString = true; continue; }
-    if (ch === '{') opens++;
-    else if (ch === '}') closes++;
-  }
-  return { opens, closes, inString };
+function parseSource(source, filePath) {
+  return espree.parse(source, {
+    ecmaVersion: 'latest',
+    sourceType: 'script',
+    range: true,
+    loc: true,
+    comment: false,
+    tokens: false,
+    filePath,
+  });
 }
 
-function findLocaleBlocks(lines) {
-  const blocks = {};
-  let braceDepth = 0;
-  let inTranslations = false;
-  let inString = false;
+function getPropertyKey(prop) {
+  if (!prop || prop.type !== 'Property' || prop.computed) return null;
+  if (!prop.key) return null;
 
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    const trimmed = line.trimStart();
-    const indent = line.length - trimmed.length;
+  if (prop.key.type === 'Identifier') return prop.key.name;
+  if (prop.key.type === 'Literal') return String(prop.key.value);
 
-    // Locale header check uses brace depth at *start* of this line.
-    // Accept indent up to 4 (some locales like "zh-CN": have indent 0).
-    if (!inString && braceDepth === 1 && inTranslations && indent <= 4) {
-      const m = trimmed.match(LOCALE_HEADER_RE);
-      if (m) blocks[m[1]] = i + 1;
-    }
-
-    if (!inTranslations && line.includes('TRANSLATIONS') && line.includes('=')) {
-      inTranslations = true;
-    }
-
-    const counts = countBracesOutsideStrings(line, inString);
-    braceDepth += counts.opens - counts.closes;
-    inString = counts.inString;
-  }
-
-  return blocks;
+  return null;
 }
 
-function findDuplicateKeys(lines, startLine, endLine) {
-  const keyPositions = {};
-  const dups = [];
-  // Match indented `"key":` at any depth within the locale block.
-  const keyRe = /^\s+"([a-zA-Z0-9_-]+)":/;
-
-  for (let i = startLine - 1; i < Math.min(endLine - 1, lines.length); i++) {
-    const m = lines[i].match(keyRe);
-    if (m) {
-      const key = m[1];
-      if (key in keyPositions) {
-        dups.push({ key, first: keyPositions[key], dup: i + 1 });
-      } else {
-        keyPositions[key] = i + 1;
+function findTranslationsObject(ast) {
+  for (const stmt of ast.body || []) {
+    if (stmt.type !== 'VariableDeclaration') continue;
+    for (const decl of stmt.declarations || []) {
+      if (
+        decl.id
+        && decl.id.type === 'Identifier'
+        && decl.id.name === 'TRANSLATIONS'
+        && decl.init
+        && decl.init.type === 'ObjectExpression'
+      ) {
+        return decl.init;
       }
     }
   }
+  return null;
+}
 
-  return dups;
+function collectLocaleReports(translationsObject) {
+  const reports = [];
+
+  for (const localeProp of translationsObject.properties || []) {
+    const locale = getPropertyKey(localeProp);
+    if (!locale || !LOCALE_KEY_RE.test(locale)) continue;
+    if (!localeProp.value || localeProp.value.type !== 'ObjectExpression') continue;
+
+    const seen = new Map();
+    for (const prop of localeProp.value.properties || []) {
+      const key = getPropertyKey(prop);
+      if (!key) continue;
+      if (!seen.has(key)) seen.set(key, []);
+      seen.get(key).push(prop);
+    }
+
+    const duplicates = [];
+    for (const [key, props] of seen.entries()) {
+      if (props.length <= 1) continue;
+      const kept = props[props.length - 1];
+      for (const prop of props.slice(0, -1)) {
+        duplicates.push({
+          key,
+          removeLine: prop.loc.start.line,
+          keepLine: kept.loc.start.line,
+          prop,
+        });
+      }
+    }
+
+    reports.push({
+      locale,
+      startLine: localeProp.loc.start.line,
+      endLine: localeProp.value.loc.end.line,
+      duplicates,
+    });
+  }
+
+  return reports;
+}
+
+function propertyRemovalRange(source, prop) {
+  let start = source.lastIndexOf('\n', prop.range[0] - 1) + 1;
+  let end = prop.range[1];
+
+  while (end < source.length && /[ \t]/.test(source[end])) end++;
+  if (source[end] === ',') end++;
+  while (end < source.length && /[ \t]/.test(source[end])) end++;
+
+  if (source[end] === '\r' && source[end + 1] === '\n') {
+    end += 2;
+  } else if (source[end] === '\n' || source[end] === '\r') {
+    end += 1;
+  } else {
+    let before = start - 1;
+    while (before >= 0 && /[ \t]/.test(source[before])) before--;
+    if (source[before] === ',') start = before;
+  }
+
+  return [start, end];
+}
+
+function applyFix(source, reports) {
+  const ranges = [];
+
+  for (const report of reports) {
+    for (const duplicate of report.duplicates) {
+      ranges.push({
+        range: propertyRemovalRange(source, duplicate.prop),
+        duplicate,
+      });
+    }
+  }
+
+  ranges.sort((a, b) => b.range[0] - a.range[0]);
+
+  let fixed = source;
+  let previousStart = source.length;
+  for (const item of ranges) {
+    const [start, end] = item.range;
+    if (start < 0 || end < start || end > source.length || end > previousStart) {
+      throw new Error(`overlapping removal while fixing "${item.duplicate.key}"`);
+    }
+    fixed = fixed.slice(0, start) + fixed.slice(end);
+    previousStart = start;
+  }
+
+  return fixed;
+}
+
+function summarize(reports) {
+  let totalDups = 0;
+  let failCount = 0;
+
+  for (const report of reports) {
+    const dups = report.duplicates;
+    if (dups.length > 0) {
+      totalDups += dups.length;
+      failCount++;
+      console.error(`FAIL: ${report.locale} (L${report.startLine}-L${report.endLine}): ${dups.length} duplicate key(s)`);
+      for (const dup of dups.slice(0, 5)) {
+        console.error(`  "${dup.key}": remove L${dup.removeLine}, keep L${dup.keepLine} (last wins)`);
+      }
+      if (dups.length > 5) {
+        console.error(`  ... and ${dups.length - 5} more (not shown)`);
+      }
+    } else {
+      console.log(`PASS: ${report.locale} (L${report.startLine}-L${report.endLine}): clean`);
+    }
+  }
+
+  console.error('\n=== SUMMARY ===');
+  return { totalDups, failCount };
+}
+
+function loadReports(source, filePath) {
+  const ast = parseSource(source, filePath);
+  const translationsObject = findTranslationsObject(ast);
+  if (!translationsObject) {
+    throw new Error('No TRANSLATIONS object found. Is this the i18n.js file?');
+  }
+  const reports = collectLocaleReports(translationsObject);
+  if (reports.length === 0) {
+    throw new Error('No locale blocks found. Is this the i18n.js file?');
+  }
+  return reports;
 }
 
 function main() {
@@ -97,53 +200,41 @@ function main() {
     process.exit(2);
   }
 
-  const lines = content.split('\n');
-  const blocks = findLocaleBlocks(lines);
-
-  if (Object.keys(blocks).length === 0) {
-    console.error('Error: No locale blocks found. Is this the i18n.js file?');
+  let reports;
+  try {
+    reports = loadReports(content, I18N_PATH);
+  } catch (err) {
+    console.error(`Error: ${err.message}`);
     process.exit(2);
   }
 
-  const sorted = Object.entries(blocks).sort((a, b) => a[1] - b[1]);
+  const { totalDups, failCount } = summarize(reports);
 
-  const localeEnds = {};
-  for (let i = 0; i < sorted.length; i++) {
-    localeEnds[sorted[i][0]] = i + 1 < sorted.length ? sorted[i + 1][1] - 1 : lines.length + 1;
+  if (totalDups === 0) {
+    console.error(`All ${reports.length} locale block(s) are clean.`);
+    return;
   }
 
-  const dupsByLocale = {};
-  let hasErrors = false;
-
-  for (const [locale, startLine] of sorted) {
-    const endLine = localeEnds[locale];
-    const dups = findDuplicateKeys(lines, startLine, endLine);
-    dupsByLocale[locale] = dups;
-
-    if (dups.length > 0) {
-      hasErrors = true;
-      console.error(`FAIL: ${locale} (L${startLine}–L${endLine}): ${dups.length} duplicate key(s)`);
-      for (const dup of dups.slice(0, 5)) {
-        console.error(`  "${dup.key}": first at L${dup.first}, duplicate at L${dup.dup}`);
-      }
-      if (dups.length > 5) {
-        console.error(`  ... and ${dups.length - 5} more (not shown)`);
-      }
-    } else {
-      console.log(`PASS: ${locale} (L${startLine}–L${endLine}): clean`);
-    }
-  }
-
-  console.error('\n=== SUMMARY ===');
-  if (hasErrors) {
-    const totalDups = sorted.reduce((sum, [l]) => sum + dupsByLocale[l].length, 0);
-    const failCount = sorted.filter(([l]) => dupsByLocale[l].length > 0).length;
+  if (!FIX) {
     console.error(`Total: ${totalDups} duplicate key(s) across ${failCount} locale(s)`);
     process.exit(1);
-  } else {
-    console.error(`All ${sorted.length} locale block(s) are clean.`);
-    process.exit(0);
   }
+
+  let fixed;
+  try {
+    fixed = applyFix(content, reports);
+    const fixedReports = loadReports(fixed, I18N_PATH);
+    const remaining = fixedReports.reduce((sum, report) => sum + report.duplicates.length, 0);
+    if (remaining > 0) {
+      throw new Error(`${remaining} duplicate key(s) remain after fix`);
+    }
+  } catch (err) {
+    console.error(`Error: --fix failed: ${err.message}`);
+    process.exit(2);
+  }
+
+  fs.writeFileSync(I18N_PATH, fixed, 'utf8');
+  console.error(`Fixed ${totalDups} duplicate key(s) across ${failCount} locale(s); kept last value for each key.`);
 }
 
 main();

--- a/backend/tests/jest/i18n-lint-dup-keys.test.js
+++ b/backend/tests/jest/i18n-lint-dup-keys.test.js
@@ -7,18 +7,25 @@
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const { execFileSync } = require('child_process');
+const { execFileSync, spawnSync } = require('child_process');
 
 const SCRIPT = path.resolve(__dirname, '../../scripts/i18n-lint-dup-keys.js');
 
-function runLint(source) {
+function runLint(source, extraArgs = []) {
   const tmp = path.join(os.tmpdir(), `i18n-lint-fixture-${Date.now()}-${Math.random().toString(36).slice(2)}.js`);
   fs.writeFileSync(tmp, source, 'utf8');
   try {
-    const out = execFileSync('node', [SCRIPT, tmp], { encoding: 'utf8' });
-    return { code: 0, stdout: out, stderr: '' };
-  } catch (err) {
-    return { code: err.status, stdout: err.stdout || '', stderr: err.stderr || '' };
+    const res = spawnSync(process.execPath, [SCRIPT, ...extraArgs, tmp], { encoding: 'utf8' });
+    const content = fs.readFileSync(tmp, 'utf8');
+    return {
+      code: res.status,
+      stdout: res.stdout || '',
+      stderr: res.stderr || '',
+      content,
+    };
+  } catch {
+    const content = fs.existsSync(tmp) ? fs.readFileSync(tmp, 'utf8') : '';
+    return { code: 1, stdout: '', stderr: '', content };
   } finally {
     fs.unlinkSync(tmp);
   }
@@ -85,6 +92,27 @@ describe('i18n-lint-dup-keys parser', () => {
     expect(res.stderr).toContain('"key_a"');
     expect(res.stdout).toContain('PASS: de');
     expect(res.code).toBe(1);
+  });
+
+  test('--fix removes earlier duplicates and keeps the last value', () => {
+    const src = [
+      'const TRANSLATIONS = {',
+      '    en: {',
+      '        "key_a": "first",',
+      '        "key_b": "second",',
+      '        "key_a": "last",',
+      '    },',
+      '};',
+      '',
+    ].join('\n');
+    const res = runLint(src, ['--fix']);
+    expect(res.stderr).toContain('Fixed 1 duplicate key(s)');
+    expect(res.content).not.toContain('"key_a": "first"');
+    expect(res.content).toContain('"key_a": "last"');
+
+    const clean = runLint(res.content);
+    expect(clean.stdout).toContain('PASS: en');
+    expect(clean.code).toBe(0);
   });
 
   test('does NOT flag same key across different locales as duplicate', () => {


### PR DESCRIPTION
## Summary
- replace the backend i18n duplicate-key linter with AST parsing and a `--fix` mode
- remove 297 earlier duplicate locale entries from `backend/public/shared/i18n.js`, preserving JavaScript last-wins values
- add a regression test for `--fix` last-wins cleanup

## Verification
- `npm run lint:i18n-dups`
- `node backend/scripts/i18n-check.js`
- `node --check backend/scripts/i18n-lint-dup-keys.js && node --check backend/public/shared/i18n.js`
- `npx eslint scripts/i18n-lint-dup-keys.js`
- `npx jest tests/jest/i18n-lint-dup-keys.test.js`
- `npx jest tests/jest/i18n-syntax.test.js`

Note: Jest prints the repo's existing `runInBand` config warning, but both focused suites pass.