### PR TITLE
feat(hermes): H2 health-check cron + 7d SLA + commander alerts (card_07891ac)

### DIFF
--- a/backend/hermes-health-check.js
+++ b/backend/hermes-health-check.js
@@ -1,0 +1,370 @@
+'use strict';
+
+const { execFile: defaultExecFile } = require('child_process');
+
+const DEFAULT_CRON = '23 */6 * * *';
+const DEFAULT_REMOTE = 'origin';
+const DEFAULT_TIMEOUT_MS = 45_000;
+const ALERT_FAILURE_THRESHOLD = 3;
+const SLA_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+const SLA_TARGET_PCT = 99;
+const MAX_ERROR_CHARS = 600;
+
+function parseCsv(value) {
+    return String(value || '')
+        .split(',')
+        .map(s => s.trim())
+        .filter(Boolean);
+}
+
+function positiveInt(value, fallback) {
+    const n = Number(value);
+    return Number.isFinite(n) && n > 0 ? Math.round(n) : fallback;
+}
+
+function sanitizeForLog(value) {
+    return String(value || '')
+        .replace(/(https?:\/\/)[^@\s]+@/gi, '$1[redacted]@')
+        .replace(/\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b/g, '[redacted]')
+        .replace(/\bgithub_pat_[A-Za-z0-9_]{20,}\b/g, '[redacted]')
+        .replace(/\bx-access-token:[^@\s]+@/gi, 'x-access-token:[redacted]@');
+}
+
+function clip(value, max = MAX_ERROR_CHARS) {
+    const s = sanitizeForLog(value).replace(/\s+/g, ' ').trim();
+    return s.length > max ? s.slice(0, max - 3) + '...' : s;
+}
+
+function loadConfig(env = process.env) {
+    const enabled = env.HERMES_HEALTHCHECK_ENABLED !== '0';
+    const repoDir = (env.HERMES_HEALTHCHECK_REPO_DIR || '').trim();
+    const branch = (env.HERMES_HEALTHCHECK_BRANCH || '').trim();
+    const remote = (env.HERMES_HEALTHCHECK_REMOTE || DEFAULT_REMOTE).trim();
+    const timeoutMs = positiveInt(env.HERMES_HEALTHCHECK_TIMEOUT_MS, DEFAULT_TIMEOUT_MS);
+    const commanderDeviceIds = parseCsv(
+        env.HERMES_HEALTHCHECK_NOTIFY_DEVICE_IDS
+        || env.HERMES_COMMANDER_DEVICE_IDS
+        || env.ADMIN_DEVICE_IDS
+    );
+    const cron = (env.HERMES_HEALTHCHECK_CRON || DEFAULT_CRON).trim();
+    const timezone = (env.HERMES_HEALTHCHECK_TIMEZONE || 'UTC').trim();
+
+    let skipReason = null;
+    if (!enabled) skipReason = 'disabled';
+    else if (!repoDir) skipReason = 'HERMES_HEALTHCHECK_REPO_DIR not set';
+    else if (!remote) skipReason = 'HERMES_HEALTHCHECK_REMOTE empty';
+
+    return {
+        enabled,
+        configured: enabled && !skipReason,
+        skipReason,
+        repoDir,
+        branch,
+        remote,
+        timeoutMs,
+        commanderDeviceIds,
+        cron,
+        timezone,
+    };
+}
+
+function execFilePromise(execFileImpl, file, args, options) {
+    return new Promise((resolve, reject) => {
+        execFileImpl(file, args, options, (err, stdout = '', stderr = '') => {
+            if (err) {
+                err.stdout = stdout;
+                err.stderr = stderr;
+                reject(err);
+                return;
+            }
+            resolve({ stdout, stderr });
+        });
+    });
+}
+
+async function execGit(config, execFileImpl, args) {
+    return execFilePromise(
+        execFileImpl,
+        'git',
+        ['-C', config.repoDir, ...args],
+        {
+            timeout: config.timeoutMs,
+            maxBuffer: 256 * 1024,
+            env: {
+                ...process.env,
+                GIT_TERMINAL_PROMPT: '0',
+            },
+        }
+    );
+}
+
+async function resolveBranch(config, execFileImpl) {
+    if (config.branch) return config.branch;
+    const { stdout } = await execGit(config, execFileImpl, ['rev-parse', '--abbrev-ref', 'HEAD']);
+    const branch = stdout.trim();
+    if (!branch || branch === 'HEAD') {
+        throw new Error('detached_head: set HERMES_HEALTHCHECK_BRANCH');
+    }
+    return branch;
+}
+
+async function runGitPushProbe(config, execFileImpl = defaultExecFile) {
+    const startedAt = Date.now();
+    await execGit(config, execFileImpl, ['rev-parse', '--is-inside-work-tree']);
+    const branch = await resolveBranch(config, execFileImpl);
+    const pushSpec = `HEAD:${branch}`;
+    await execGit(config, execFileImpl, ['push', '--dry-run', '--porcelain', config.remote, pushSpec]);
+    return {
+        ok: true,
+        branch,
+        remote: config.remote,
+        pushSpec,
+        durationMs: Date.now() - startedAt,
+    };
+}
+
+function recordSample(state, sample, nowMs) {
+    state.samples.push(sample);
+    const cutoff = nowMs - SLA_WINDOW_MS;
+    state.samples = state.samples.filter(s => s.at >= cutoff);
+}
+
+function computeSla(samples, nowMs = Date.now()) {
+    const cutoff = nowMs - SLA_WINDOW_MS;
+    const recent = samples.filter(s => s.at >= cutoff && !s.skipped);
+    const successCount = recent.filter(s => s.ok).length;
+    const failureCount = recent.filter(s => !s.ok).length;
+    const sampleCount = recent.length;
+    const uptimePct = sampleCount === 0
+        ? null
+        : Math.round((successCount / sampleCount) * 10_000) / 100;
+    return {
+        windowMs: SLA_WINDOW_MS,
+        targetPct: SLA_TARGET_PCT,
+        sampleCount,
+        successCount,
+        failureCount,
+        uptimePct,
+        met: uptimePct == null ? null : uptimePct >= SLA_TARGET_PCT,
+    };
+}
+
+function initialState() {
+    return {
+        running: false,
+        consecutiveFailures: 0,
+        totalRuns: 0,
+        lastRunAt: null,
+        lastOkAt: null,
+        lastFailureAt: null,
+        lastSkippedAt: null,
+        lastAlertAt: null,
+        lastAlertFailureCount: 0,
+        lastDurationMs: null,
+        lastError: null,
+        lastBranch: null,
+        lastRemote: null,
+        skipReason: null,
+        samples: [],
+    };
+}
+
+function createHermesHealthMonitor({
+    env = process.env,
+    execFile = defaultExecFile,
+    notifyDevice = null,
+    audit = () => {},
+    now = () => Date.now(),
+} = {}) {
+    const state = initialState();
+
+    function status() {
+        const config = loadConfig(env);
+        return {
+            enabled: config.enabled,
+            configured: config.configured,
+            running: state.running,
+            cron: config.cron,
+            timezone: config.timezone,
+            remote: config.remote,
+            branch: config.branch || state.lastBranch || null,
+            timeoutMs: config.timeoutMs,
+            notifyDeviceCount: config.commanderDeviceIds.length,
+            skipReason: config.skipReason || state.skipReason || null,
+            consecutiveFailures: state.consecutiveFailures,
+            totalRuns: state.totalRuns,
+            lastRunAt: state.lastRunAt,
+            lastOkAt: state.lastOkAt,
+            lastFailureAt: state.lastFailureAt,
+            lastSkippedAt: state.lastSkippedAt,
+            lastAlertAt: state.lastAlertAt,
+            lastAlertFailureCount: state.lastAlertFailureCount,
+            lastDurationMs: state.lastDurationMs,
+            lastError: state.lastError,
+            sla: computeSla(state.samples, now()),
+        };
+    }
+
+    async function alertCommanders(config, failure) {
+        if (!config.commanderDeviceIds.length || typeof notifyDevice !== 'function') {
+            audit('warn', 'hermes_health', '[HermesHealth] alert not delivered: no commander device configured', {
+                action: 'hermes_health_check',
+                result: 'alert_not_delivered',
+                metadata: { consecutiveFailures: state.consecutiveFailures },
+            });
+            return { sent: 0, skipped: true };
+        }
+
+        const body = `Git push dry-run failed ${state.consecutiveFailures} consecutive times. Last error: ${clip(failure.error || 'unknown_error', 220)}`;
+        const notification = {
+            type: 'system',
+            category: 'delivery_alert',
+            title: 'Hermes health-check failed',
+            body,
+            link: '/portal/roadmap.html',
+            metadata: {
+                kind: 'hermes_health_check',
+                consecutiveFailures: state.consecutiveFailures,
+                lastRunAt: state.lastRunAt,
+                durationMs: state.lastDurationMs,
+                remote: config.remote,
+                branch: failure.branch || config.branch || null,
+            },
+        };
+
+        const results = await Promise.allSettled(
+            config.commanderDeviceIds.map(deviceId => notifyDevice(deviceId, notification))
+        );
+        const sent = results.filter(r => r.status === 'fulfilled').length;
+        state.lastAlertAt = now();
+        state.lastAlertFailureCount = state.consecutiveFailures;
+        audit('warn', 'hermes_health', `[HermesHealth] commander alert sent after ${state.consecutiveFailures} failures`, {
+            action: 'hermes_health_check',
+            result: 'alert_sent',
+            metadata: { sent, requested: config.commanderDeviceIds.length },
+        });
+        return { sent, skipped: false };
+    }
+
+    async function runOnce(reason = 'manual') {
+        const config = loadConfig(env);
+        const startedAt = now();
+        state.running = true;
+        state.lastRunAt = startedAt;
+        state.skipReason = config.skipReason;
+
+        if (!config.configured) {
+            state.running = false;
+            state.lastSkippedAt = startedAt;
+            recordSample(state, { at: startedAt, skipped: true, ok: null }, startedAt);
+            audit('info', 'hermes_health', `[HermesHealth] skipped: ${config.skipReason}`, {
+                action: 'hermes_health_check',
+                result: 'skipped',
+                metadata: { reason, skipReason: config.skipReason },
+            });
+            return { ok: null, skipped: true, reason: config.skipReason };
+        }
+
+        state.totalRuns += 1;
+        const previousFailures = state.consecutiveFailures;
+        try {
+            const probe = await runGitPushProbe(config, execFile);
+            const endedAt = now();
+            state.running = false;
+            state.consecutiveFailures = 0;
+            state.lastOkAt = endedAt;
+            state.lastDurationMs = probe.durationMs;
+            state.lastError = null;
+            state.lastBranch = probe.branch;
+            state.lastRemote = probe.remote;
+            recordSample(state, { at: endedAt, ok: true, durationMs: probe.durationMs }, endedAt);
+            audit('info', 'hermes_health', `[HermesHealth] git push dry-run OK (${probe.remote} ${probe.pushSpec})`, {
+                action: 'hermes_health_check',
+                result: 'ok',
+                metadata: { reason, durationMs: probe.durationMs, branch: probe.branch, remote: probe.remote },
+            });
+            return { ...probe, skipped: false };
+        } catch (err) {
+            const endedAt = now();
+            const error = clip(
+                (err && (err.stderr || err.stdout || err.message)) || 'git_push_probe_failed'
+            );
+            state.running = false;
+            state.consecutiveFailures = previousFailures + 1;
+            state.lastFailureAt = endedAt;
+            state.lastDurationMs = endedAt - startedAt;
+            state.lastError = error;
+            recordSample(state, { at: endedAt, ok: false, error }, endedAt);
+            audit('warn', 'hermes_health', `[HermesHealth] git push dry-run failed (${state.consecutiveFailures} consecutive): ${error}`, {
+                action: 'hermes_health_check',
+                result: 'failed',
+                metadata: {
+                    reason,
+                    consecutiveFailures: state.consecutiveFailures,
+                    durationMs: state.lastDurationMs,
+                },
+            });
+
+            let alert = null;
+            if (state.consecutiveFailures >= ALERT_FAILURE_THRESHOLD
+                && previousFailures < ALERT_FAILURE_THRESHOLD) {
+                alert = await alertCommanders(config, { error, branch: state.lastBranch });
+            }
+
+            return {
+                ok: false,
+                skipped: false,
+                error,
+                consecutiveFailures: state.consecutiveFailures,
+                alert,
+            };
+        }
+    }
+
+    function startCron({ nodeCron } = {}) {
+        const config = loadConfig(env);
+        if (!config.enabled) {
+            console.log('[HermesHealth] disabled via HERMES_HEALTHCHECK_ENABLED=0');
+            return () => {};
+        }
+        if (!config.configured) {
+            console.log(`[HermesHealth] cron not scheduled: ${config.skipReason}`);
+            return () => {};
+        }
+        if (!nodeCron || typeof nodeCron.schedule !== 'function') {
+            throw new Error('nodeCron_required');
+        }
+
+        const task = nodeCron.schedule(config.cron, () => {
+            runOnce('cron').catch(err => {
+                console.error('[HermesHealth] cron tick error:', err && err.message);
+            });
+        }, { timezone: config.timezone });
+        audit('info', 'hermes_health', `[HermesHealth] scheduled ${config.cron} ${config.timezone}`, {
+            action: 'hermes_health_check',
+            result: 'scheduled',
+            metadata: { cron: config.cron, timezone: config.timezone },
+        });
+        return () => {
+            if (task && typeof task.stop === 'function') task.stop();
+        };
+    }
+
+    return {
+        runOnce,
+        getStatus: status,
+        startCron,
+        _state: state,
+    };
+}
+
+module.exports = {
+    createHermesHealthMonitor,
+    runGitPushProbe,
+    loadConfig,
+    sanitizeForLog,
+    computeSla,
+    ALERT_FAILURE_THRESHOLD,
+    DEFAULT_CRON,
+    DEFAULT_TIMEOUT_MS,
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -35,6 +35,7 @@ const sanitizeHtml = require('sanitize-html');
 const compression = require('compression');
 
 const safeEqual = require('./safe-equal');
+const { createHermesHealthMonitor } = require('./hermes-health-check');
 
 // ============================================
 // ADMIN DEVICE GATE
@@ -2179,6 +2180,15 @@ app.use('/api/files', filesModule.router);
 const nodeCron = require('node-cron');
 nodeCron.schedule('17 3 * * *', () => {
     require('./files').cleanupExpiredFiles().catch(err => console.error('[Files] Cleanup cron error:', err));
+});
+
+// Roadmap/Hermes H2: operational health-check. The monitor runs a git push
+// dry-run every 6 hours when HERMES_HEALTHCHECK_REPO_DIR is configured, tracks
+// the 7-day success rate, and alerts commander devices after 3 consecutive
+// failures.
+const hermesHealthMonitor = createHermesHealthMonitor({
+    notifyDevice,
+    audit: serverLog,
 });
 
 missionModule.initMissionDatabase();
@@ -5808,6 +5818,7 @@ app.get('/api/health', (req, res) => {
             ...deliveryHealth,
             stuck: stuckPreview,
         },
+        hermes: hermesHealthMonitor.getStatus(),
     });
 });
 
@@ -17967,6 +17978,18 @@ function serverLog(level, category, message, opts = {}) {
     ).catch(() => {}); // Never throw — logs are non-critical
 }
 
+if (process.env.NODE_ENV !== 'test') {
+    try {
+        hermesHealthMonitor.startCron({ nodeCron });
+    } catch (err) {
+        console.error('[HermesHealth] failed to schedule cron:', err && err.message);
+        serverLog('error', 'hermes_health', `[HermesHealth] failed to schedule cron: ${err && err.message}`, {
+            action: 'hermes_health_check',
+            result: 'schedule_failed',
+        });
+    }
+}
+
 // ── Crash handlers: log uncaught errors to /api/logs (category: crash) before dying ──
 process.on('uncaughtException', async (err) => {
     console.error('[FATAL] Uncaught exception:', err);
@@ -20057,3 +20080,4 @@ module.exports._SEVERE_STUCK_MS = SEVERE_STUCK_MS;
 module.exports._HEALTH_BOOT_GRACE_MS = HEALTH_BOOT_GRACE_MS;
 module.exports._SEVERE_STUCK_MIN_COUNT = SEVERE_STUCK_MIN_COUNT;
 module.exports._evaluateDeliveryHealth = evaluateDeliveryHealth;
+module.exports._hermesHealthMonitor = hermesHealthMonitor;

--- a/backend/public/portal/roadmap.html
+++ b/backend/public/portal/roadmap.html
@@ -420,7 +420,7 @@
                 <div class="rm-phase-desc" data-i18n="rm_h2_desc">Hermes as a reliable team member: health monitoring, self-healing, SLA tracking. Targets: ≥99% weekly uptime, 6h health-check.</div>
                 <ul class="rm-tasks">
                     <li class="partial" data-i18n="rm_h2_t1">Hermes accepts i18n batch cards via speakTo and delivers PRs on time</li>
-                    <li class="todo" data-i18n="rm_h2_t2">Hermes health-check cron: git push test every 6h; alert commander on 3 consecutive failures</li>
+                    <li class="partial" data-i18n="rm_h2_t2">Hermes health-check cron: git push test every 6h; alert commander on 3 consecutive failures</li>
                     <li class="todo" data-i18n="rm_h2_t3">Hermes uses Linear API to update card status after PR merge (closed/labelled)</li>
                     <li class="done" data-i18n="rm_h2_t4">Railway restart policy set to always; OOM or stuck loop triggers immediate restart with commander notification</li>
                     <li data-i18n="rm_h2_t5">Hermes memory persists between sessions via hermes_state.db (already configured)</li>

--- a/backend/tests/jest/hermes-health-check.test.js
+++ b/backend/tests/jest/hermes-health-check.test.js
@@ -1,0 +1,178 @@
+'use strict';
+
+const {
+    ALERT_FAILURE_THRESHOLD,
+    createHermesHealthMonitor,
+    loadConfig,
+    runGitPushProbe,
+    sanitizeForLog,
+} = require('../../hermes-health-check');
+
+function execResponder(handler) {
+    return jest.fn((file, args, options, cb) => {
+        try {
+            const result = handler({ file, args, options });
+            if (result instanceof Error) {
+                cb(result, result.stdout || '', result.stderr || result.message);
+                return;
+            }
+            cb(null, result?.stdout || '', result?.stderr || '');
+        } catch (err) {
+            cb(err, err.stdout || '', err.stderr || err.message);
+        }
+    });
+}
+
+function failingGit(message) {
+    const err = new Error(message);
+    err.code = 128;
+    err.stderr = message;
+    return err;
+}
+
+describe('Hermes H2 health-check monitor', () => {
+    test('requires explicit repo configuration before scheduling git probes', async () => {
+        const execFile = jest.fn();
+        const audit = jest.fn();
+        const monitor = createHermesHealthMonitor({
+            env: {},
+            execFile,
+            audit,
+        });
+
+        expect(loadConfig({}).configured).toBe(false);
+        const result = await monitor.runOnce('manual');
+
+        expect(result).toEqual({
+            ok: null,
+            skipped: true,
+            reason: 'HERMES_HEALTHCHECK_REPO_DIR not set',
+        });
+        expect(execFile).not.toHaveBeenCalled();
+        expect(monitor.getStatus().skipReason).toBe('HERMES_HEALTHCHECK_REPO_DIR not set');
+    });
+
+    test('runs a git push dry-run against the configured remote and branch', async () => {
+        const execFile = execResponder(({ args }) => {
+            if (args.includes('push')) return { stdout: 'dry-run ok\n' };
+            return { stdout: 'true\n' };
+        });
+
+        const result = await runGitPushProbe({
+            repoDir: '/repo/hermes',
+            branch: 'main',
+            remote: 'origin',
+            timeoutMs: 1000,
+        }, execFile);
+
+        expect(result).toEqual(expect.objectContaining({
+            ok: true,
+            branch: 'main',
+            remote: 'origin',
+            pushSpec: 'HEAD:main',
+        }));
+        expect(execFile).toHaveBeenCalledWith(
+            'git',
+            ['-C', '/repo/hermes', 'push', '--dry-run', '--porcelain', 'origin', 'HEAD:main'],
+            expect.objectContaining({
+                timeout: 1000,
+                env: expect.objectContaining({ GIT_TERMINAL_PROMPT: '0' }),
+            }),
+            expect.any(Function)
+        );
+    });
+
+    test('derives current branch when HERMES_HEALTHCHECK_BRANCH is omitted', async () => {
+        const execFile = execResponder(({ args }) => {
+            if (args.includes('--abbrev-ref')) return { stdout: 'feature/hermes-health\n' };
+            if (args.includes('push')) return { stdout: 'dry-run ok\n' };
+            return { stdout: 'true\n' };
+        });
+
+        const result = await runGitPushProbe({
+            repoDir: '/repo/hermes',
+            branch: '',
+            remote: 'origin',
+            timeoutMs: 1000,
+        }, execFile);
+
+        expect(result.branch).toBe('feature/hermes-health');
+        expect(execFile).toHaveBeenCalledWith(
+            'git',
+            ['-C', '/repo/hermes', 'push', '--dry-run', '--porcelain', 'origin', 'HEAD:feature/hermes-health'],
+            expect.any(Object),
+            expect.any(Function)
+        );
+    });
+
+    test('alerts commander devices on the third consecutive failure only', async () => {
+        const notifyDevice = jest.fn().mockResolvedValue(undefined);
+        const audit = jest.fn();
+        const execFile = execResponder(({ args }) => {
+            if (args.includes('push')) {
+                return failingGit('fatal: Authentication failed for https://ghp_secretsecretsecretsecret@github.com/acme/repo.git');
+            }
+            return { stdout: 'true\n' };
+        });
+        const monitor = createHermesHealthMonitor({
+            env: {
+                HERMES_HEALTHCHECK_REPO_DIR: '/repo/hermes',
+                HERMES_HEALTHCHECK_BRANCH: 'main',
+                HERMES_HEALTHCHECK_NOTIFY_DEVICE_IDS: 'device-a,device-b',
+            },
+            execFile,
+            notifyDevice,
+            audit,
+        });
+
+        await monitor.runOnce('test');
+        await monitor.runOnce('test');
+        expect(notifyDevice).not.toHaveBeenCalled();
+
+        const third = await monitor.runOnce('test');
+        expect(third.ok).toBe(false);
+        expect(third.consecutiveFailures).toBe(ALERT_FAILURE_THRESHOLD);
+        expect(notifyDevice).toHaveBeenCalledTimes(2);
+
+        await monitor.runOnce('test');
+        expect(notifyDevice).toHaveBeenCalledTimes(2);
+
+        const notifyPayload = JSON.stringify(notifyDevice.mock.calls);
+        expect(notifyPayload).toContain('Hermes health-check failed');
+        expect(notifyPayload).not.toContain('ghp_secretsecretsecretsecret');
+        expect(monitor.getStatus().lastAlertFailureCount).toBe(ALERT_FAILURE_THRESHOLD);
+    });
+
+    test('success resets consecutive failures and records SLA samples', async () => {
+        let fail = true;
+        const execFile = execResponder(({ args }) => {
+            if (args.includes('push') && fail) return failingGit('network unavailable');
+            return { stdout: args.includes('--abbrev-ref') ? 'main\n' : 'true\n' };
+        });
+        const monitor = createHermesHealthMonitor({
+            env: {
+                HERMES_HEALTHCHECK_REPO_DIR: '/repo/hermes',
+                HERMES_HEALTHCHECK_BRANCH: 'main',
+            },
+            execFile,
+        });
+
+        await monitor.runOnce('test');
+        expect(monitor.getStatus().consecutiveFailures).toBe(1);
+
+        fail = false;
+        await monitor.runOnce('test');
+        const status = monitor.getStatus();
+
+        expect(status.consecutiveFailures).toBe(0);
+        expect(status.lastError).toBe(null);
+        expect(status.sla.sampleCount).toBe(2);
+        expect(status.sla.successCount).toBe(1);
+        expect(status.sla.failureCount).toBe(1);
+    });
+
+    test('sanitizes credentials from git remote errors', () => {
+        expect(sanitizeForLog('https://x-access-token:abc123@github.com/acme/repo.git ghp_abcdefghijklmnopqrstuvwxyz'))
+            .not.toContain('abc123');
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `backend/hermes-health-check.js`: 6h git-push dry-run probe + 7d SLA tracking + commander alerts after 3 consecutive failures
- Wires monitor into `/api/health` (`hermes` block) and nodeCron startup (test-env gated)
- Roadmap `rm_h2_t2` moved `todo` → `partial`
- New unit test: `backend/tests/jest/hermes-health-check.test.js`

## Context
Implementation by #6 Codex. Packaged + PR'd by #2 LOBSTER because #6 moved `card_07891ac51d55509f7d74c4a0` to `done` without opening a PR — this PR restores the proper review-gated flow. Card has been bounced back to `in_progress` until this merges.

## Credential safety
- `sanitizeForLog` redacts `https://<token>@`, `ghp_/gho_/ghu_/ghs_/ghr_*`, `github_pat_*`, and `x-access-token:<>@` from any logged stderr/stdout
- Probe runs `git push --dry-run` only (no actual push)
- `HERMES_HEALTHCHECK_REPO_DIR` not set → monitor cleanly skips with `configured=false`

## Env knobs (all optional)
- `HERMES_HEALTHCHECK_ENABLED` (0 disables)
- `HERMES_HEALTHCHECK_REPO_DIR` (required for probe)
- `HERMES_HEALTHCHECK_BRANCH`
- `HERMES_HEALTHCHECK_REMOTE` (default: origin)
- `HERMES_HEALTHCHECK_TIMEOUT_MS` (default: 45000)
- `HERMES_HEALTHCHECK_CRON` (default: `23 */6 * * *`)
- `HERMES_HEALTHCHECK_TIMEZONE` (default: UTC)
- `HERMES_HEALTHCHECK_NOTIFY_DEVICE_IDS` / `ADMIN_DEVICE_IDS`

## Test plan
- [x] `npm test -- --runTestsByPath tests/jest/hermes-health-check.test.js` (per #6 report)
- [x] `npm test -- --runTestsByPath tests/jest/health.test.js tests/jest/health-503-severe.test.js` (per #6 report)
- [ ] Production env vars set: `HERMES_HEALTHCHECK_REPO_DIR` + commander device IDs
- [ ] After deploy: `curl /api/health` shows `hermes.configured=true`
- [ ] After first cron fire: `hermes.lastCheck` populated

## Acceptance
- requires_screenshot_review: false (no UI surface change beyond a roadmap class toggle)
- Card: `card_07891ac51d55509f7d74c4a0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)