### PR TITLE
fix(i18n): fill 11 missing zh keys post-#2920/#2921 (card_de6970)

### DIFF
--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -905969,6 +905969,15 @@ const TRANSLATIONS = {
 
 
         "kanban_nudge_per_entity_throttle_label": "🅰️ 內容督促：同一實體一個間隔最多 1 張",
+        "kanban_nudge_per_entity_section_label": "依實體覆寫",
+        "kanban_nudge_per_entity_section_desc": "為特定實體自訂間隔、欄位與節流。批次大小與優先順序模式維持裝置全域設定。",
+        "kanban_nudge_per_entity_pick_placeholder": "— 選擇一個實體 —",
+        "kanban_nudge_per_entity_clear": "重設為裝置預設值",
+        "kanban_nudge_per_entity_hint_prefix": "切換欄位，以覆寫此實體的裝置預設值。",
+        "kanban_nudge_per_entity_override_interval": "覆寫間隔",
+        "kanban_nudge_per_entity_override_statuses": "覆寫欄位",
+        "kanban_nudge_per_entity_override_throttle": "覆寫節流",
+        "kanban_nudge_per_entity_throttle_short": "將此實體限制為每個間隔最多 1 次督促",
 
 
 
@@ -1077644,6 +1077653,7 @@ const TRANSLATIONS = {
 
 
         "kb_funnel_search": "搜尋…",
+        "kb_funnel_tag": "標籤…",
 
 
 
@@ -1080333,6 +1080343,7 @@ const TRANSLATIONS = {
 
         "kb_label_requires_screenshot": "需截圖審查（完成時附截圖才可推進 review/done）",
         "kb_label_gated": "Launch-gate（發布閘）——開啟時，L1/L2/L3 自動升級跳过此卡；卡片離開發布就緒後自動解除",
+        "kb_gate_backlog_only_hint": "發布閘（Launch-gate）僅適用於待辦積壓卡片",
 
 
 


### PR DESCRIPTION
## Summary
- Surgical 11-key fill into the `zh` (Traditional Chinese) locale block
- Keys added: `kanban_nudge_per_entity_section_label/desc/pick_placeholder/clear/hint_prefix/override_interval/override_statuses/override_throttle/throttle_short`, plus `kb_funnel_tag` and one related key
- All other audited locales (ar/ja/de/es/fr/id/ko/th/vi/hi/ms/zh-CN) already missing=0 on current main after #2920+#2921

## Context
- Card: `card_de6970091ee5e78a9da15bfe` (P2)
- Re-PR after closed #2923 — that PR's branch was based pre-#2920/#2921 and would have wiped 100k+ lines of merged dedup/fill work
- #6 rebased onto fresh `origin/main` in `EClaw-i18n-locale-gaps-2921` worktree, scoped down to actual remaining gap (11 zh keys), validated, then I packaged for PR

## Why zh (not zh-TW)
EClaw fallback chain is `zh-TW → zh → en`. Per repo convention (`feedback_check_i18n_fallback_before_emergency`), `zh` block holds Traditional Chinese as default for the zh family; zh-TW is intentionally thin. en, zh-CN, zh-TW are untouched.

## Validation (per #6 report)
- [x] `node backend/scripts/i18n-check.js` → missing=0 extra=0 across ar/zh/ja/de/es/fr/id/ko/th/vi/hi/ms/zh-CN
- [x] `node --check backend/public/shared/i18n.js` → clean
- [x] `node backend/scripts/i18n-lint-dup-keys.js` → clean
- [x] `npm test -- --runInBand` → 211 suites / 3040 passed / 1 skipped

## Acceptance
- requires_screenshot_review: false (string-only changes)
- Card will close on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)