### PR TITLE
[codex] H3 private repo support for Hermes proxy

### DIFF
--- a/claude-cli-proxy/.env.example
+++ b/claude-cli-proxy/.env.example
@@ -19,6 +19,9 @@ EVAULT_BOT_SECRET=your-service-account-bot-secret
 REPO_GIT_HOST_PATH=github.com/HankHuang0516/realbot.git
 REPO_ALLOWED_ORGS=HankHuang0516
 REPO_REQUIRE_AUTH=false
+# Export selected auth to the Claude CLI child so git push and gh pr commands
+# work in private repos. Tokens are supplied through env/askpass, not remotes.
+REPO_EXPORT_AUTH_TO_CLI=true
 #
 # Recommended vault key names for org-scoped tokens:
 #   GIT_HUB2_<ORG> | GITHUB_TOKEN_<ORG> | GITHUBTOKEN_<ORG> | GIT_<ORG>

--- a/claude-cli-proxy/.env.example
+++ b/claude-cli-proxy/.env.example
@@ -4,15 +4,28 @@ SUPPORT_API_KEY=your-shared-secret-here
 # Port (Railway auto-assigns, default 4000 for local)
 PORT=4000
 
-# GitHub token resolution (for cloning realbot to enable code-aware AI chat).
-# Priority: vault → env GITHUB_TOKEN → anonymous public clone.
+# GitHub token resolution (for cloning the configured repo to enable code-aware
+# AI chat). Priority: org-scoped vault key → optional legacy vault key → env
+# GITHUB_TOKEN → anonymous public clone.
 #
 # PREFERRED: vault-backed via service-account bot. Token rotates centrally
 # without a Railway redeploy, and Railway env never holds the raw PAT.
 EVAULT_API_BASE=https://eclawbot.com
 EVAULT_DEVICE_ID=your-service-account-device-id
 EVAULT_BOT_SECRET=your-service-account-bot-secret
-# (vault must contain one of: GIT_HUB2 | GITHUBTOKEN | GIT)
+# Repo scope. REPO_ALLOWED_ORGS blocks accidental/private-repo access outside
+# the assigned GitHub orgs. If omitted, it defaults to the org in
+# REPO_GIT_HOST_PATH.
+REPO_GIT_HOST_PATH=github.com/HankHuang0516/realbot.git
+REPO_ALLOWED_ORGS=HankHuang0516
+REPO_REQUIRE_AUTH=false
+#
+# Recommended vault key names for org-scoped tokens:
+#   GIT_HUB2_<ORG> | GITHUB_TOKEN_<ORG> | GITHUBTOKEN_<ORG> | GIT_<ORG>
+# where <ORG> is uppercase and non-alphanumeric chars become "_".
+# For HankHuang0516, prefer: GIT_HUB2_HANKHUANG0516.
+EVAULT_GITHUB_TOKEN_KEY=
+EVAULT_ALLOW_GLOBAL_GITHUB_TOKEN=true
 #
 # LEGACY: bare PAT in env (only used if vault lookup returns nothing).
 GITHUB_TOKEN=

--- a/claude-cli-proxy/git_askpass.sh
+++ b/claude-cli-proxy/git_askpass.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+case "$1" in
+  *Username*) printf '%s\n' "${GIT_ASKPASS_USERNAME:-x-access-token}" ;;
+  *Password*) printf '%s\n' "$GIT_ASKPASS_PASSWORD" ;;
+  *) printf '\n' ;;
+esac

--- a/claude-cli-proxy/proxy.py
+++ b/claude-cli-proxy/proxy.py
@@ -38,6 +38,15 @@ from dotenv import load_dotenv
 from fastapi import FastAPI, HTTPException, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
+from repo_auth import (
+    DEFAULT_REPO_HOST_PATH,
+    LEGACY_TOKEN_KEYS,
+    RepoScopeError,
+    env_bool,
+    token_from_vars,
+    token_key_candidates,
+    validate_repo_scope,
+)
 
 load_dotenv(Path(__file__).parent / ".env")
 
@@ -61,8 +70,17 @@ MAX_CONCURRENT = 2
 MAX_QUEUE = 8
 
 REPO_DIR = Path(os.getenv("HOME", "/root")) / ".claude" / "repo"
-REPO_GIT_HOST_PATH = "github.com/HankHuang0516/realbot.git"
-REPO_GIT_URL_ANON = f"https://{REPO_GIT_HOST_PATH}"
+REPO_GIT_HOST_PATH = os.getenv("REPO_GIT_HOST_PATH", DEFAULT_REPO_HOST_PATH)
+REPO_ALLOWED_ORGS = os.getenv("REPO_ALLOWED_ORGS", "")
+REPO_REQUIRE_AUTH = env_bool(os.getenv("REPO_REQUIRE_AUTH"), False)
+EVAULT_GITHUB_TOKEN_KEY = os.getenv("EVAULT_GITHUB_TOKEN_KEY", "")
+EVAULT_ALLOW_GLOBAL_GITHUB_TOKEN = env_bool(os.getenv("EVAULT_ALLOW_GLOBAL_GITHUB_TOKEN"), True)
+try:
+    REPO_SCOPE = validate_repo_scope(REPO_GIT_HOST_PATH, REPO_ALLOWED_ORGS)
+    REPO_SCOPE_ERROR = ""
+except RepoScopeError as e:
+    REPO_SCOPE = None
+    REPO_SCOPE_ERROR = str(e)
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s", stream=sys.stdout)
 log = logging.getLogger("claude-proxy")
@@ -616,20 +634,15 @@ Rules:
 
 
 # ── Repo Clone & Sync ────────────────────────
-# Vault key names checked in priority order. GIT_HUB2 is the canonical key
-# Hank uses across bots; GITHUBTOKEN / GIT are accepted aliases.
-_VAULT_TOKEN_KEYS = ("GIT_HUB2", "GITHUBTOKEN", "GIT")
-
-
-def _fetch_vault_github_token() -> Optional[str]:
+def _fetch_vault_github_token(org: str) -> tuple[Optional[str], Optional[str]]:
     """Pull a GitHub PAT from /api/device-vars using service-account bot creds.
 
-    Returns the raw token on success, None on any failure. The token is held
-    only by the immediate caller's frame and the in-memory git remote URL —
-    we never write it to env, log, or disk.
+    Returns (token, key_name) on success, (None, None) on failure. Org-scoped
+    keys are preferred, with legacy global keys enabled only for backwards
+    compatibility.
     """
     if not (EVAULT_DEVICE_ID and EVAULT_BOT_SECRET):
-        return None
+        return None, None
     qs = urllib.parse.urlencode({"deviceId": EVAULT_DEVICE_ID, "botSecret": EVAULT_BOT_SECRET})
     url = f"{EVAULT_API_BASE}/api/device-vars?{qs}"
     try:
@@ -638,58 +651,81 @@ def _fetch_vault_github_token() -> Optional[str]:
             body = json.loads(resp.read().decode("utf-8"))
     except Exception as e:
         log.warning(f"[Vault] Fetch failed: {str(e)[:200]}")
-        return None
+        return None, None
     if not body.get("success"):
         log.warning(f"[Vault] device-vars returned error: {body.get('error')}")
-        return None
+        return None, None
     vars_map = body.get("vars") or {}
-    for k in _VAULT_TOKEN_KEYS:
-        v = vars_map.get(k)
-        if isinstance(v, str) and v.strip():
-            log.info(f"[Vault] Using token from key={k} (vault has {len(vars_map)} keys)")
-            return v.strip()
-    log.warning(f"[Vault] No GitHub token in vault (looked for {_VAULT_TOKEN_KEYS}; vault has {len(vars_map)} keys)")
-    return None
-
-
-def _resolve_repo_url() -> tuple:
-    """Return (url, source) for cloning realbot.
-
-    source ∈ {'vault', 'env', 'anonymous'}. Vault is preferred so the PAT can
-    rotate without a Railway redeploy; env GITHUB_TOKEN is the legacy
-    fallback; anonymous works while the repo is public.
-    """
-    token = _fetch_vault_github_token()
+    keys = token_key_candidates(
+        org,
+        explicit_key=EVAULT_GITHUB_TOKEN_KEY,
+        allow_global=EVAULT_ALLOW_GLOBAL_GITHUB_TOKEN,
+    )
+    token, key = token_from_vars(vars_map, keys)
     if token:
-        return (f"https://{token}@{REPO_GIT_HOST_PATH}", "vault")
+        log.info(f"[Vault] Using GitHub token key={key} for org={org} (vault has {len(vars_map)} keys)")
+        return token, key
+    log.warning(f"[Vault] No GitHub token in vault for org={org} (looked for {keys}; vault has {len(vars_map)} keys)")
+    return None, None
+
+
+def _resolve_repo_auth() -> tuple:
+    """Return (anonymous_url, source, token) for cloning the configured repo.
+
+    source ∈ {'vault:<key>', 'env', 'anonymous'}. Vault is preferred so the PAT
+    can rotate without a Railway redeploy; env GITHUB_TOKEN is the legacy
+    fallback. When REPO_REQUIRE_AUTH is true, anonymous fallback is disabled.
+    """
+    if REPO_SCOPE_ERROR or REPO_SCOPE is None:
+        raise RepoScopeError(REPO_SCOPE_ERROR or "invalid repo scope")
+
+    token, key = _fetch_vault_github_token(REPO_SCOPE.org)
+    if token:
+        return (REPO_SCOPE.url, f"vault:{key}", token)
     if GITHUB_TOKEN:
-        return (f"https://{GITHUB_TOKEN}@{REPO_GIT_HOST_PATH}", "env")
-    return (REPO_GIT_URL_ANON, "anonymous")
+        return (REPO_SCOPE.url, "env", GITHUB_TOKEN)
+    if REPO_REQUIRE_AUTH:
+        raise RepoScopeError(f"repo auth required for {REPO_SCOPE.org}/{REPO_SCOPE.repo}, but no GitHub token was available")
+    return (REPO_SCOPE.url, "anonymous", None)
+
+
+def _git_env(token: Optional[str]) -> dict:
+    env = {**os.environ}
+    if token:
+        env.update({
+            "GIT_ASKPASS": str(Path(__file__).with_name("git_askpass.sh")),
+            "GIT_ASKPASS_USERNAME": "x-access-token",
+            "GIT_ASKPASS_PASSWORD": token,
+            "GIT_TERMINAL_PROMPT": "0",
+        })
+    return env
 
 
 def ensure_repo_clone():
     import subprocess
     try:
-        repo_url, source = _resolve_repo_url()
+        repo_url, source, token = _resolve_repo_auth()
         git_dir = REPO_DIR / ".git"
         if git_dir.exists():
-            log.info(f"[Repo] Pulling latest (auth={source})...")
-            # Refresh remote so a rotated vault token takes effect immediately.
+            log.info(f"[Repo] Pulling latest {REPO_SCOPE.org}/{REPO_SCOPE.repo} (auth={source})...")
+            # Keep the persisted remote token-free. Auth is supplied only to
+            # this git process through GIT_ASKPASS so PATs are not written to
+            # .git/config and can rotate immediately.
             subprocess.run(
                 ["git", "remote", "set-url", "origin", repo_url],
-                cwd=str(REPO_DIR), timeout=10, capture_output=True,
+                cwd=str(REPO_DIR), timeout=10, capture_output=True, check=True,
             )
             subprocess.run(
                 ["git", "pull", "--ff-only"],
-                cwd=str(REPO_DIR), timeout=30, capture_output=True,
+                cwd=str(REPO_DIR), timeout=30, capture_output=True, check=True, env=_git_env(token),
             )
             log.info("[Repo] Updated.")
         else:
-            log.info(f"[Repo] Cloning repository (auth={source})...")
+            log.info(f"[Repo] Cloning {REPO_SCOPE.org}/{REPO_SCOPE.repo} (auth={source})...")
             REPO_DIR.mkdir(parents=True, exist_ok=True)
             subprocess.run(
                 ["git", "clone", "--depth", "50", repo_url, str(REPO_DIR)],
-                timeout=120, capture_output=True,
+                timeout=120, capture_output=True, check=True, env=_git_env(token),
             )
             log.info(f"[Repo] Cloned to {REPO_DIR} (auth={source})")
     except Exception as e:
@@ -812,7 +848,20 @@ async def require_auth(request: Request):
 # ── Health Check ─────────────────────────────
 @app.get("/health")
 async def health():
-    health_data = {"status": "ok", "service": "eclaw-claude-cli-proxy", "claude_cli": "unknown"}
+    health_data = {
+        "status": "ok",
+        "service": "eclaw-claude-cli-proxy",
+        "claude_cli": "unknown",
+        "repo": {
+            "hostPath": REPO_SCOPE.host_path if REPO_SCOPE else REPO_GIT_HOST_PATH,
+            "org": REPO_SCOPE.org if REPO_SCOPE else None,
+            "allowedOrgs": REPO_ALLOWED_ORGS or (REPO_SCOPE.org if REPO_SCOPE else None),
+            "requireAuth": REPO_REQUIRE_AUTH,
+            "globalVaultFallback": EVAULT_ALLOW_GLOBAL_GITHUB_TOKEN,
+            "legacyTokenKeys": list(LEGACY_TOKEN_KEYS),
+            "scopeError": REPO_SCOPE_ERROR or None,
+        },
+    }
     try:
         proc = await asyncio.create_subprocess_exec(
             CLAUDE_BIN, "--version",

--- a/claude-cli-proxy/proxy.py
+++ b/claude-cli-proxy/proxy.py
@@ -42,6 +42,7 @@ from repo_auth import (
     DEFAULT_REPO_HOST_PATH,
     LEGACY_TOKEN_KEYS,
     RepoScopeError,
+    build_git_auth_env,
     env_bool,
     token_from_vars,
     token_key_candidates,
@@ -75,6 +76,7 @@ REPO_ALLOWED_ORGS = os.getenv("REPO_ALLOWED_ORGS", "")
 REPO_REQUIRE_AUTH = env_bool(os.getenv("REPO_REQUIRE_AUTH"), False)
 EVAULT_GITHUB_TOKEN_KEY = os.getenv("EVAULT_GITHUB_TOKEN_KEY", "")
 EVAULT_ALLOW_GLOBAL_GITHUB_TOKEN = env_bool(os.getenv("EVAULT_ALLOW_GLOBAL_GITHUB_TOKEN"), True)
+REPO_EXPORT_AUTH_TO_CLI = env_bool(os.getenv("REPO_EXPORT_AUTH_TO_CLI"), True)
 try:
     REPO_SCOPE = validate_repo_scope(REPO_GIT_HOST_PATH, REPO_ALLOWED_ORGS)
     REPO_SCOPE_ERROR = ""
@@ -689,15 +691,25 @@ def _resolve_repo_auth() -> tuple:
     return (REPO_SCOPE.url, "anonymous", None)
 
 
-def _git_env(token: Optional[str]) -> dict:
-    env = {**os.environ}
-    if token:
-        env.update({
-            "GIT_ASKPASS": str(Path(__file__).with_name("git_askpass.sh")),
-            "GIT_ASKPASS_USERNAME": "x-access-token",
-            "GIT_ASKPASS_PASSWORD": token,
-            "GIT_TERMINAL_PROMPT": "0",
-        })
+def _git_env(token: Optional[str], base_env: Optional[dict] = None, expose_cli_token: bool = False) -> dict:
+    return build_git_auth_env(
+        base_env or os.environ,
+        token,
+        str(Path(__file__).with_name("git_askpass.sh")),
+        expose_cli_token=expose_cli_token,
+    )
+
+
+def _repo_cli_env(base_env: dict) -> dict:
+    if not REPO_EXPORT_AUTH_TO_CLI:
+        return _git_env(None, base_env)
+    try:
+        _, source, token = _resolve_repo_auth()
+    except Exception as e:
+        log.warning(f"[Repo] CLI git auth unavailable: {str(e)[:200]}")
+        return _git_env(None, base_env)
+    env = _git_env(token, base_env, expose_cli_token=bool(token))
+    env["ECLAW_REPO_AUTH_SOURCE"] = source
     return env
 
 
@@ -857,6 +869,7 @@ async def health():
             "org": REPO_SCOPE.org if REPO_SCOPE else None,
             "allowedOrgs": REPO_ALLOWED_ORGS or (REPO_SCOPE.org if REPO_SCOPE else None),
             "requireAuth": REPO_REQUIRE_AUTH,
+            "exportAuthToCli": REPO_EXPORT_AUTH_TO_CLI,
             "globalVaultFallback": EVAULT_ALLOW_GLOBAL_GITHUB_TOKEN,
             "legacyTokenKeys": list(LEGACY_TOKEN_KEYS),
             "scopeError": REPO_SCOPE_ERROR or None,
@@ -1032,6 +1045,8 @@ async def chat(req: ChatRequest, request: Request):
 
     child_cwd = str(REPO_DIR) if REPO_DIR.exists() else str(Path(__file__).parent)
     child_env = {**os.environ, "HOME": os.environ.get("HOME", "/root"), "CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS": "1"}
+    if REPO_DIR.exists():
+        child_env = _repo_cli_env(child_env)
 
     # ── Streaming mode: use async generator + StreamingResponse ──
     if want_stream:

--- a/claude-cli-proxy/repo_auth.py
+++ b/claude-cli-proxy/repo_auth.py
@@ -1,0 +1,101 @@
+"""GitHub repository auth helpers for claude-cli-proxy.
+
+This module is dependency-free so its scope and token-selection rules can be
+unit-tested without importing the FastAPI proxy app.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Mapping, Optional, Sequence
+
+
+DEFAULT_REPO_HOST_PATH = "github.com/HankHuang0516/realbot.git"
+LEGACY_TOKEN_KEYS = ("GIT_HUB2", "GITHUBTOKEN", "GIT")
+
+
+class RepoScopeError(ValueError):
+    """Raised when a configured repo is outside the allowed org scope."""
+
+
+@dataclass(frozen=True)
+class RepoScope:
+    host: str
+    org: str
+    repo: str
+    host_path: str
+    url: str
+
+
+def env_bool(value: Optional[str], default: bool = False) -> bool:
+    if value is None or value == "":
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _csv(value: str) -> list[str]:
+    return [item.strip() for item in value.split(",") if item.strip()]
+
+
+def normalize_org_key(org: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9]+", "_", org.strip()).strip("_").upper()
+    return normalized or "DEFAULT"
+
+
+def parse_github_host_path(raw_host_path: str) -> RepoScope:
+    value = (raw_host_path or "").strip()
+    value = re.sub(r"^https?://", "", value)
+    value = value.strip("/")
+    match = re.match(r"^(github\.com)/([^/\s]+)/([^/\s]+?)(?:\.git)?$", value, re.I)
+    if not match:
+        raise RepoScopeError("REPO_GIT_HOST_PATH must look like github.com/<org>/<repo>.git")
+    host, org, repo = match.groups()
+    host = host.lower()
+    host_path = f"{host}/{org}/{repo}.git"
+    return RepoScope(host=host, org=org, repo=repo, host_path=host_path, url=f"https://{host_path}")
+
+
+def allowed_orgs_from_env(value: str, default_org: str) -> set[str]:
+    configured = _csv(value or "")
+    orgs = configured or [default_org]
+    return {org.lower() for org in orgs}
+
+
+def validate_repo_scope(raw_host_path: str, allowed_orgs: str = "") -> RepoScope:
+    scope = parse_github_host_path(raw_host_path)
+    allowed = allowed_orgs_from_env(allowed_orgs, scope.org)
+    if scope.org.lower() not in allowed:
+        allowed_display = ", ".join(sorted(allowed))
+        raise RepoScopeError(f"repo org '{scope.org}' is outside REPO_ALLOWED_ORGS ({allowed_display})")
+    return scope
+
+
+def token_key_candidates(org: str, explicit_key: str = "", allow_global: bool = True) -> tuple[str, ...]:
+    keys: list[str] = []
+    if explicit_key.strip():
+        keys.append(explicit_key.strip())
+
+    org_key = normalize_org_key(org)
+    keys.extend((
+        f"GIT_HUB2_{org_key}",
+        f"GITHUB_TOKEN_{org_key}",
+        f"GITHUBTOKEN_{org_key}",
+        f"GIT_{org_key}",
+    ))
+    if allow_global:
+        keys.extend(LEGACY_TOKEN_KEYS)
+
+    deduped: list[str] = []
+    for key in keys:
+        if key not in deduped:
+            deduped.append(key)
+    return tuple(deduped)
+
+
+def token_from_vars(vars_map: Mapping[str, object], keys: Sequence[str]) -> tuple[Optional[str], Optional[str]]:
+    for key in keys:
+        value = vars_map.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip(), key
+    return None, None

--- a/claude-cli-proxy/repo_auth.py
+++ b/claude-cli-proxy/repo_auth.py
@@ -99,3 +99,25 @@ def token_from_vars(vars_map: Mapping[str, object], keys: Sequence[str]) -> tupl
         if isinstance(value, str) and value.strip():
             return value.strip(), key
     return None, None
+
+
+def build_git_auth_env(
+    base_env: Mapping[str, str],
+    token: Optional[str],
+    askpass_path: str,
+    expose_cli_token: bool = False,
+) -> dict[str, str]:
+    env = dict(base_env)
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    if not token:
+        return env
+
+    env.update({
+        "GIT_ASKPASS": askpass_path,
+        "GIT_ASKPASS_USERNAME": "x-access-token",
+        "GIT_ASKPASS_PASSWORD": token,
+    })
+    if expose_cli_token:
+        env["GH_TOKEN"] = token
+        env["GITHUB_TOKEN"] = token
+    return env

--- a/claude-cli-proxy/tests/test_repo_auth.py
+++ b/claude-cli-proxy/tests/test_repo_auth.py
@@ -6,6 +6,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from repo_auth import (
     RepoScopeError,
+    build_git_auth_env,
     parse_github_host_path,
     token_from_vars,
     token_key_candidates,
@@ -49,6 +50,20 @@ class RepoAuthTests(unittest.TestCase):
             keys,
         )
         self.assertEqual((token, key), ("scoped", "GIT_HUB2_HANKHUANG0516"))
+
+    def test_git_auth_env_disables_interactive_prompts_without_token(self):
+        env = build_git_auth_env({"HOME": "/tmp/home"}, None, "/tmp/askpass")
+        self.assertEqual(env["HOME"], "/tmp/home")
+        self.assertEqual(env["GIT_TERMINAL_PROMPT"], "0")
+        self.assertNotIn("GIT_ASKPASS_PASSWORD", env)
+
+    def test_git_auth_env_exports_askpass_and_cli_tokens(self):
+        env = build_git_auth_env({"HOME": "/tmp/home"}, "secret-token", "/tmp/askpass", expose_cli_token=True)
+        self.assertEqual(env["GIT_ASKPASS"], "/tmp/askpass")
+        self.assertEqual(env["GIT_ASKPASS_USERNAME"], "x-access-token")
+        self.assertEqual(env["GIT_ASKPASS_PASSWORD"], "secret-token")
+        self.assertEqual(env["GH_TOKEN"], "secret-token")
+        self.assertEqual(env["GITHUB_TOKEN"], "secret-token")
 
 
 if __name__ == "__main__":

--- a/claude-cli-proxy/tests/test_repo_auth.py
+++ b/claude-cli-proxy/tests/test_repo_auth.py
@@ -1,0 +1,55 @@
+import unittest
+from pathlib import Path
+import sys
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from repo_auth import (
+    RepoScopeError,
+    parse_github_host_path,
+    token_from_vars,
+    token_key_candidates,
+    validate_repo_scope,
+)
+
+
+class RepoAuthTests(unittest.TestCase):
+    def test_parse_github_host_path_normalizes_https_url(self):
+        scope = parse_github_host_path("https://github.com/HankHuang0516/EClaw")
+        self.assertEqual(scope.host_path, "github.com/HankHuang0516/EClaw.git")
+        self.assertEqual(scope.url, "https://github.com/HankHuang0516/EClaw.git")
+        self.assertEqual(scope.org, "HankHuang0516")
+
+    def test_validate_repo_scope_rejects_unassigned_org(self):
+        with self.assertRaises(RepoScopeError):
+            validate_repo_scope("github.com/OtherOrg/private.git", "HankHuang0516")
+
+    def test_token_candidates_prefer_org_scoped_keys(self):
+        keys = token_key_candidates("Hank-Huang 0516")
+        self.assertEqual(keys[:4], (
+            "GIT_HUB2_HANK_HUANG_0516",
+            "GITHUB_TOKEN_HANK_HUANG_0516",
+            "GITHUBTOKEN_HANK_HUANG_0516",
+            "GIT_HANK_HUANG_0516",
+        ))
+        self.assertIn("GIT_HUB2", keys)
+
+    def test_token_candidates_can_disable_global_fallback(self):
+        keys = token_key_candidates("HankHuang0516", allow_global=False)
+        self.assertNotIn("GIT_HUB2", keys)
+        self.assertIn("GIT_HUB2_HANKHUANG0516", keys)
+
+    def test_token_from_vars_returns_first_scoped_key(self):
+        keys = token_key_candidates("HankHuang0516")
+        token, key = token_from_vars(
+            {
+                "GIT_HUB2": "legacy",
+                "GIT_HUB2_HANKHUANG0516": "scoped",
+            },
+            keys,
+        )
+        self.assertEqual((token, key), ("scoped", "GIT_HUB2_HANKHUANG0516"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- Added scoped GitHub repo auth helpers for `claude-cli-proxy`.
- Reads org-scoped vault keys before legacy global keys, with optional anonymous fallback blocked by `REPO_REQUIRE_AUTH`.
- Keeps git remotes token-free by using `GIT_ASKPASS` for clone/pull.
- Exports the selected auth context to the Claude CLI child process so private-repo `git push` and `gh pr` flows can work from the synced repo.
- Exposes repo auth state in `/health` and documents the new env knobs in `.env.example`.

## Why

Hermes H3 requires private repository support. The previous proxy path could fall back to anonymous public clone behavior, which fails or becomes ambiguous for private repos.

## Impact

Hermes/Claude CLI proxy deployments can target configured private GitHub repos under allowed orgs, use vault-rotated credentials, and avoid persisting PATs in `.git/config`.

## Checks

- `python3 -m unittest discover -s claude-cli-proxy/tests -p 'test_repo_auth.py'`
- `python3 -m py_compile claude-cli-proxy/proxy.py claude-cli-proxy/repo_auth.py`
- `git diff --check -- claude-cli-proxy/.env.example claude-cli-proxy/proxy.py claude-cli-proxy/repo_auth.py claude-cli-proxy/tests/test_repo_auth.py`
