### PR TITLE
[codex] Export private repo auth to Hermes CLI child

### DIFF
--- a/claude-cli-proxy/.env.example
+++ b/claude-cli-proxy/.env.example
@@ -19,6 +19,9 @@ EVAULT_BOT_SECRET=your-service-account-bot-secret
 REPO_GIT_HOST_PATH=github.com/HankHuang0516/realbot.git
 REPO_ALLOWED_ORGS=HankHuang0516
 REPO_REQUIRE_AUTH=false
+# Export selected auth to the Claude CLI child so git push and gh pr commands
+# work in private repos. Tokens are supplied through env/askpass, not remotes.
+REPO_EXPORT_AUTH_TO_CLI=true
 #
 # Recommended vault key names for org-scoped tokens:
 #   GIT_HUB2_<ORG> | GITHUB_TOKEN_<ORG> | GITHUBTOKEN_<ORG> | GIT_<ORG>

--- a/claude-cli-proxy/proxy.py
+++ b/claude-cli-proxy/proxy.py
@@ -42,6 +42,7 @@ from repo_auth import (
     DEFAULT_REPO_HOST_PATH,
     LEGACY_TOKEN_KEYS,
     RepoScopeError,
+    build_git_auth_env,
     env_bool,
     token_from_vars,
     token_key_candidates,
@@ -75,6 +76,7 @@ REPO_ALLOWED_ORGS = os.getenv("REPO_ALLOWED_ORGS", "")
 REPO_REQUIRE_AUTH = env_bool(os.getenv("REPO_REQUIRE_AUTH"), False)
 EVAULT_GITHUB_TOKEN_KEY = os.getenv("EVAULT_GITHUB_TOKEN_KEY", "")
 EVAULT_ALLOW_GLOBAL_GITHUB_TOKEN = env_bool(os.getenv("EVAULT_ALLOW_GLOBAL_GITHUB_TOKEN"), True)
+REPO_EXPORT_AUTH_TO_CLI = env_bool(os.getenv("REPO_EXPORT_AUTH_TO_CLI"), True)
 try:
     REPO_SCOPE = validate_repo_scope(REPO_GIT_HOST_PATH, REPO_ALLOWED_ORGS)
     REPO_SCOPE_ERROR = ""
@@ -689,15 +691,25 @@ def _resolve_repo_auth() -> tuple:
     return (REPO_SCOPE.url, "anonymous", None)
 
 
-def _git_env(token: Optional[str]) -> dict:
-    env = {**os.environ}
-    if token:
-        env.update({
-            "GIT_ASKPASS": str(Path(__file__).with_name("git_askpass.sh")),
-            "GIT_ASKPASS_USERNAME": "x-access-token",
-            "GIT_ASKPASS_PASSWORD": token,
-            "GIT_TERMINAL_PROMPT": "0",
-        })
+def _git_env(token: Optional[str], base_env: Optional[dict] = None, expose_cli_token: bool = False) -> dict:
+    return build_git_auth_env(
+        base_env or os.environ,
+        token,
+        str(Path(__file__).with_name("git_askpass.sh")),
+        expose_cli_token=expose_cli_token,
+    )
+
+
+def _repo_cli_env(base_env: dict) -> dict:
+    if not REPO_EXPORT_AUTH_TO_CLI:
+        return _git_env(None, base_env)
+    try:
+        _, source, token = _resolve_repo_auth()
+    except Exception as e:
+        log.warning(f"[Repo] CLI git auth unavailable: {str(e)[:200]}")
+        return _git_env(None, base_env)
+    env = _git_env(token, base_env, expose_cli_token=bool(token))
+    env["ECLAW_REPO_AUTH_SOURCE"] = source
     return env
 
 
@@ -857,6 +869,7 @@ async def health():
             "org": REPO_SCOPE.org if REPO_SCOPE else None,
             "allowedOrgs": REPO_ALLOWED_ORGS or (REPO_SCOPE.org if REPO_SCOPE else None),
             "requireAuth": REPO_REQUIRE_AUTH,
+            "exportAuthToCli": REPO_EXPORT_AUTH_TO_CLI,
             "globalVaultFallback": EVAULT_ALLOW_GLOBAL_GITHUB_TOKEN,
             "legacyTokenKeys": list(LEGACY_TOKEN_KEYS),
             "scopeError": REPO_SCOPE_ERROR or None,
@@ -1032,6 +1045,8 @@ async def chat(req: ChatRequest, request: Request):
 
     child_cwd = str(REPO_DIR) if REPO_DIR.exists() else str(Path(__file__).parent)
     child_env = {**os.environ, "HOME": os.environ.get("HOME", "/root"), "CLAUDE_DANGEROUSLY_SKIP_PERMISSIONS": "1"}
+    if REPO_DIR.exists():
+        child_env = _repo_cli_env(child_env)
 
     # ── Streaming mode: use async generator + StreamingResponse ──
     if want_stream:

--- a/claude-cli-proxy/repo_auth.py
+++ b/claude-cli-proxy/repo_auth.py
@@ -99,3 +99,25 @@ def token_from_vars(vars_map: Mapping[str, object], keys: Sequence[str]) -> tupl
         if isinstance(value, str) and value.strip():
             return value.strip(), key
     return None, None
+
+
+def build_git_auth_env(
+    base_env: Mapping[str, str],
+    token: Optional[str],
+    askpass_path: str,
+    expose_cli_token: bool = False,
+) -> dict[str, str]:
+    env = dict(base_env)
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    if not token:
+        return env
+
+    env.update({
+        "GIT_ASKPASS": askpass_path,
+        "GIT_ASKPASS_USERNAME": "x-access-token",
+        "GIT_ASKPASS_PASSWORD": token,
+    })
+    if expose_cli_token:
+        env["GH_TOKEN"] = token
+        env["GITHUB_TOKEN"] = token
+    return env

--- a/claude-cli-proxy/tests/test_repo_auth.py
+++ b/claude-cli-proxy/tests/test_repo_auth.py
@@ -6,6 +6,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from repo_auth import (
     RepoScopeError,
+    build_git_auth_env,
     parse_github_host_path,
     token_from_vars,
     token_key_candidates,
@@ -49,6 +50,20 @@ class RepoAuthTests(unittest.TestCase):
             keys,
         )
         self.assertEqual((token, key), ("scoped", "GIT_HUB2_HANKHUANG0516"))
+
+    def test_git_auth_env_disables_interactive_prompts_without_token(self):
+        env = build_git_auth_env({"HOME": "/tmp/home"}, None, "/tmp/askpass")
+        self.assertEqual(env["HOME"], "/tmp/home")
+        self.assertEqual(env["GIT_TERMINAL_PROMPT"], "0")
+        self.assertNotIn("GIT_ASKPASS_PASSWORD", env)
+
+    def test_git_auth_env_exports_askpass_and_cli_tokens(self):
+        env = build_git_auth_env({"HOME": "/tmp/home"}, "secret-token", "/tmp/askpass", expose_cli_token=True)
+        self.assertEqual(env["GIT_ASKPASS"], "/tmp/askpass")
+        self.assertEqual(env["GIT_ASKPASS_USERNAME"], "x-access-token")
+        self.assertEqual(env["GIT_ASKPASS_PASSWORD"], "secret-token")
+        self.assertEqual(env["GH_TOKEN"], "secret-token")
+        self.assertEqual(env["GITHUB_TOKEN"], "secret-token")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- Exports the selected repo auth context to the Claude CLI child process when the synced repo is used.
- Supplies git auth via `GIT_ASKPASS` and exposes `GH_TOKEN`/`GITHUB_TOKEN` for `gh pr` workflows without writing PATs into git remotes.
- Adds `REPO_EXPORT_AUTH_TO_CLI` to `/health` and `.env.example`.
- Adds focused unit coverage for non-interactive git auth env construction.

## Why

Hermes H3 private repo support needs more than authenticated proxy clone/pull. The CLI child must also have authenticated context for branch, push, and PR operations against private repositories.

## Impact

Proxy deployments with vault-backed GitHub credentials can let the Claude CLI child operate in private repos while keeping the persisted origin URL token-free.

Supersedes draft PR #2927, which duplicated the already-merged base H3 proxy-auth commit.

## Checks

- `python3 -m unittest discover -s claude-cli-proxy/tests -p 'test_repo_auth.py'`
- `python3 -m py_compile claude-cli-proxy/proxy.py claude-cli-proxy/repo_auth.py`
- `git diff --check HEAD~1..HEAD`
