### PR TITLE
chore(claude-cli-proxy): ignore .git-askpass + lock case-insensitive allowed-orgs

### DIFF
--- a/claude-cli-proxy/.gitignore
+++ b/claude-cli-proxy/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.pyc
 .venv/
 node_modules/
+.git-askpass

--- a/claude-cli-proxy/tests/test_repo_auth.py
+++ b/claude-cli-proxy/tests/test_repo_auth.py
@@ -25,6 +25,14 @@ class RepoAuthTests(unittest.TestCase):
         with self.assertRaises(RepoScopeError):
             validate_repo_scope("github.com/OtherOrg/private.git", "HankHuang0516")
 
+    def test_validate_repo_scope_is_case_insensitive_on_allowed_orgs(self):
+        scope = validate_repo_scope("github.com/HankHuang0516/realbot.git", "hankhuang0516")
+        self.assertEqual(scope.org, "HankHuang0516")
+        scope = validate_repo_scope("github.com/HankHuang0516/realbot.git", "HANKHUANG0516,otherorg")
+        self.assertEqual(scope.org, "HankHuang0516")
+        with self.assertRaises(RepoScopeError):
+            validate_repo_scope("github.com/OtherOrg/private.git", "hankhuang0516")
+
     def test_token_candidates_prefer_org_scoped_keys(self):
         keys = token_key_candidates("Hank-Huang 0516")
         self.assertEqual(keys[:4], (


### PR DESCRIPTION
## Summary
Two-file followup hardening on top of #2926 / #2928 H3 private repo support.

- `claude-cli-proxy/.gitignore`: ignore the generated `.git-askpass` helper so it never lands in a commit even if a developer runs the proxy with `REPO_DIR` set in-tree.
- `claude-cli-proxy/tests/test_repo_auth.py`: regression test that locks the existing case-insensitive behavior of `REPO_ALLOWED_ORGS`. The logic shipped in #2926 (`allowed_orgs_from_env` lowercases the set; `validate_repo_scope` compares with `scope.org.lower()`) — this test prevents accidental regression.

## Attribution
Implementation reported by Codex #6 in chat but never pushed; packaged + PR'd by #2 LOBSTER per the established `feedback_6_finishes_without_pr` pattern.

## Test plan
- [x] `cd claude-cli-proxy && python3 -m unittest discover -s tests -p 'test_*.py'` → 8 tests OK (was 7 pre-PR)
- [x] New test `test_validate_repo_scope_is_case_insensitive_on_allowed_orgs` exercises lowercase allowlist, mixed-case CSV, and still-rejected unrelated org.
- [x] Verified `.gitignore` actually excludes `.git-askpass` via `git check-ignore` (worktree-local).

## Risk
Minimal. Test-only + gitignore addition; no production code path changes. No new env vars, no behavior changes.

Card: `card_2420446cf14e0d7b73c8697d`