### PR TITLE
feat(portal): scaffold /portal/bot/:id/about backstory page (IP P1)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -775,6 +775,14 @@ app.get(/^\/portal\/[^\/]+\.html$/, (req, res, next) => {
     });
 });
 
+// Pretty URL: /portal/bot/:entityId/about → serve about.html (JS reads entityId from path)
+app.get('/portal/bot/:entityId/about', (req, res, next) => {
+    const eid = parseInt(req.params.entityId, 10);
+    if (!Number.isInteger(eid) || eid < 0) return next();
+    res.set('Cache-Control', 'no-cache');
+    res.sendFile(path.join(__dirname, 'public/portal/bot/about.html'));
+});
+
 app.use('/portal', express.static(path.join(__dirname, 'public/portal'), {
     etag: true,
     lastModified: true,

--- a/backend/public/portal/bot/about.html
+++ b/backend/public/portal/bot/about.html
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EClawbot — Bot About</title>
+    <meta name="description" content="Per-bot about page: persona, scenarios, growth log, and boundaries for an EClawbot agent.">
+    <link rel="icon" type="image/png" href="/portal/assets/favicon-32.png">
+    <link rel="canonical" href="https://eclawbot.com/portal/bot/about.html">
+    <meta property="og:type" content="profile">
+    <meta property="og:title" content="EClawbot — Bot About">
+    <meta property="og:description" content="Backstory and capabilities for an EClawbot agent.">
+    <meta property="og:url" content="https://eclawbot.com/portal/bot/about.html">
+    <meta property="og:image" content="https://eclawbot.com/assets/og-image.png">
+    <meta name="twitter:card" content="summary">
+    <link rel="stylesheet" href="/portal/shared/style.css">
+    <style>
+        :root {
+            --bg: #0D0D1A;
+            --card: #1A1A2E;
+            --card-bg: #1A1A2E;
+            --border: #2A2A4A;
+            --text: #E0E0F0;
+            --text-dim: #8888AA;
+            --accent: #7c3aed;
+        }
+        body { background: var(--bg); color: var(--text); margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; }
+        main { max-width: 880px; margin: 0 auto; padding: 24px 16px 80px; }
+        .ba-header { display: flex; gap: 16px; align-items: center; margin-bottom: 20px; }
+        .ba-avatar { width: 72px; height: 72px; border-radius: 50%; background: linear-gradient(135deg, #7c3aed, #ec4899); display: flex; align-items: center; justify-content: center; font-size: 28px; font-weight: 700; color: white; flex-shrink: 0; }
+        .ba-avatar img { width: 100%; height: 100%; border-radius: 50%; object-fit: cover; }
+        .ba-name { font-size: 22px; font-weight: 600; margin: 0; }
+        .ba-callsign { color: var(--text-dim); font-size: 14px; margin-top: 2px; }
+        .ba-tagline { color: var(--text); margin: 16px 0 24px; font-size: 16px; line-height: 1.5; opacity: 0.92; }
+        .ba-stats { display: flex; gap: 16px; flex-wrap: wrap; margin: 12px 0 24px; }
+        .ba-stat { background: var(--card); border: 1px solid var(--border); border-radius: 8px; padding: 8px 14px; font-size: 13px; }
+        .ba-stat b { color: var(--accent); }
+        .ba-section { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 18px 20px; margin-bottom: 16px; }
+        .ba-section h2 { font-size: 16px; margin: 0 0 12px; color: var(--accent); }
+        .ba-section p { line-height: 1.6; margin: 0 0 8px; }
+        .ba-section ul { margin: 0; padding-left: 18px; }
+        .ba-section li { line-height: 1.6; margin-bottom: 6px; }
+        .ba-trait { margin-bottom: 10px; }
+        .ba-trait b { color: var(--text); }
+        .ba-trait-body { color: var(--text-dim); font-size: 14px; margin-left: 8px; }
+        .ba-arc { border-left: 2px solid var(--accent); padding: 4px 0 4px 12px; margin-bottom: 12px; }
+        .ba-arc-head { display: flex; justify-content: space-between; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+        .ba-arc-title { font-weight: 600; }
+        .ba-arc-date { color: var(--text-dim); font-size: 12px; }
+        .ba-arc-body { color: var(--text-dim); font-size: 14px; line-height: 1.5; margin-top: 4px; }
+        .ba-links { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 16px; }
+        .ba-link { background: var(--card); border: 1px solid var(--border); color: var(--text); padding: 8px 14px; border-radius: 8px; text-decoration: none; font-size: 13px; }
+        .ba-link:hover { border-color: var(--accent); }
+        .ba-empty { color: var(--text-dim); text-align: center; padding: 32px 16px; }
+        .ba-empty a { color: var(--accent); }
+        .ba-loading { color: var(--text-dim); text-align: center; padding: 32px; }
+        .ba-error { color: #f87171; background: rgba(248,113,113,0.1); border: 1px solid rgba(248,113,113,0.3); padding: 12px; border-radius: 8px; margin-bottom: 16px; }
+    </style>
+</head>
+
+<body>
+    <main>
+        <div id="ba-root">
+            <div class="ba-loading">Loading bot profile…</div>
+        </div>
+    </main>
+
+    <script src="/portal/bot/about.js"></script>
+</body>
+</html>

--- a/backend/public/portal/bot/about.js
+++ b/backend/public/portal/bot/about.js
@@ -1,0 +1,161 @@
+(function () {
+    'use strict';
+
+    const root = document.getElementById('ba-root');
+    const params = new URLSearchParams(window.location.search);
+    let entityId = parseInt(params.get('entityId'), 10);
+    const publicCode = params.get('publicCode');
+
+    // Pretty URL fallback: /portal/bot/:entityId/about → infer entityId from path
+    if (!entityId) {
+        const m = window.location.pathname.match(/\/portal\/bot\/(\d+)\/about\/?$/);
+        if (m) entityId = parseInt(m[1], 10);
+    }
+
+    if (!entityId && !publicCode) {
+        renderEmpty('No bot selected. Try ?entityId=2 or ?publicCode=3xa3h4.');
+        return;
+    }
+
+    function esc(s) {
+        return String(s == null ? '' : s).replace(/[&<>"']/g, c => ({
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+        }[c]));
+    }
+
+    function renderEmpty(msg) {
+        root.innerHTML = `<div class="ba-empty">${esc(msg)}<br><br><a href="/portal/community.html">← Browse the Bot Plaza</a></div>`;
+    }
+
+    function renderError(msg) {
+        root.innerHTML = `<div class="ba-error">${esc(msg)}</div><div class="ba-empty"><a href="/portal/community.html">← Browse the Bot Plaza</a></div>`;
+    }
+
+    async function loadBackstory(eid) {
+        if (!eid) return null;
+        try {
+            const r = await fetch(`/portal/bot/backstories/${eid}.json`, { credentials: 'omit' });
+            if (!r.ok) return null;
+            return await r.json();
+        } catch (e) {
+            return null;
+        }
+    }
+
+    async function loadPlazaCard(code) {
+        if (!code) return null;
+        try {
+            const r = await fetch(`/api/community/card/${encodeURIComponent(code)}`, { credentials: 'omit' });
+            if (!r.ok) return null;
+            const j = await r.json();
+            return j && j.success ? j.card : null;
+        } catch (e) {
+            return null;
+        }
+    }
+
+    function render(backstory, plaza) {
+        if (!backstory && !plaza) {
+            renderEmpty(`Bot ${entityId || publicCode} has no published backstory yet.`);
+            return;
+        }
+        const b = backstory || {};
+        const p = plaza || {};
+        const name = b.displayName || p.name || `Bot ${entityId || ''}`;
+        const callsign = b.callsign || p.character || '';
+        const avatarUrl = p.avatar || '';
+        const initial = (callsign || name || '?').slice(0, 2).toUpperCase();
+        const tagline = b.tagline || p.description || '';
+
+        const statsHtml = p && (p.level || p.xp || p.messageCount)
+            ? `<div class="ba-stats">
+                ${p.level ? `<div class="ba-stat">Lv <b>${p.level}</b></div>` : ''}
+                ${p.xp ? `<div class="ba-stat">XP <b>${Number(p.xp).toLocaleString()}</b></div>` : ''}
+                ${p.messageCount ? `<div class="ba-stat">Msgs <b>${p.messageCount}</b></div>` : ''}
+                ${p.avgRating > 0 ? `<div class="ba-stat">★ <b>${p.avgRating.toFixed(1)}</b> (${p.ratingCount || 0})</div>` : ''}
+            </div>`
+            : '';
+
+        function sectionList(s) {
+            if (!s || !s.items || !s.items.length) return '';
+            return `<section class="ba-section"><h2>${esc(s.title || '')}</h2><ul>${
+                s.items.map(it => {
+                    if (typeof it === 'string') return `<li>${esc(it)}</li>`;
+                    return `<li><b>${esc(it.label || '')}</b> — ${esc(it.body || '')}</li>`;
+                }).join('')
+            }</ul></section>`;
+        }
+        function sectionTraits(s) {
+            if (!s || !s.traits || !s.traits.length) return '';
+            return `<section class="ba-section"><h2>${esc(s.title || '')}</h2>${
+                s.traits.map(t => `<div class="ba-trait"><b>${esc(t.label || '')}</b><span class="ba-trait-body">${esc(t.body || '')}</span></div>`).join('')
+            }</section>`;
+        }
+        function sectionScenarios(s) {
+            if (!s || !s.scenarios || !s.scenarios.length) return '';
+            return `<section class="ba-section"><h2>${esc(s.title || '')}</h2><ul>${
+                s.scenarios.map(x => `<li>${esc(x)}</li>`).join('')
+            }</ul></section>`;
+        }
+        function sectionBody(s) {
+            if (!s || !s.body) return '';
+            return `<section class="ba-section"><h2>${esc(s.title || '')}</h2><p>${esc(s.body)}</p></section>`;
+        }
+        function sectionGrowth(s) {
+            if (!s || !s.arcs || !s.arcs.length) return '';
+            return `<section class="ba-section"><h2>${esc(s.title || '')}</h2>${
+                s.note ? `<p style="color:var(--text-dim);font-size:13px;">${esc(s.note)}</p>` : ''
+            }${
+                s.arcs.map(a => `
+                    <div class="ba-arc">
+                        <div class="ba-arc-head">
+                            <span class="ba-arc-title">${esc(a.arc || '')}</span>
+                            <span class="ba-arc-date">${esc(a.date || '')}</span>
+                        </div>
+                        <div class="ba-arc-body">${esc(a.body || '')}</div>
+                    </div>
+                `).join('')
+            }</section>`;
+        }
+
+        const linksHtml = b.links ? `<div class="ba-links">${
+            Object.entries(b.links).map(([label, url]) => `<a class="ba-link" href="${esc(url)}">${esc(label)}</a>`).join('')
+        }</div>` : '';
+
+        root.innerHTML = `
+            <div class="ba-header">
+                <div class="ba-avatar">${avatarUrl ? `<img src="${esc(avatarUrl)}" alt="">` : esc(initial)}</div>
+                <div>
+                    <h1 class="ba-name">${esc(name)}</h1>
+                    ${callsign ? `<div class="ba-callsign">${esc(callsign)}${entityId ? ` · #${entityId}` : ''}</div>` : (entityId ? `<div class="ba-callsign">#${entityId}</div>` : '')}
+                </div>
+            </div>
+            ${tagline ? `<p class="ba-tagline">${esc(tagline)}</p>` : ''}
+            ${statsHtml}
+            ${sectionBody(b.rationale)}
+            ${sectionTraits(b.personality)}
+            ${sectionScenarios(b.bestFit)}
+            ${sectionList(b.relationships)}
+            ${sectionGrowth(b.growthLog)}
+            ${sectionList(b.boundaries)}
+            ${linksHtml}
+        `;
+    }
+
+    (async () => {
+        try {
+            const [backstory, plaza] = await Promise.all([
+                loadBackstory(entityId),
+                loadPlazaCard(publicCode || (await (async () => null)()))
+            ]);
+            // If we have a backstory with a publicCode and didn't fetch plaza yet, try again
+            let plazaFinal = plaza;
+            if (!plazaFinal && backstory && backstory.publicCode) {
+                plazaFinal = await loadPlazaCard(backstory.publicCode);
+            }
+            render(backstory, plazaFinal);
+        } catch (e) {
+            renderError(`Failed to load: ${e.message}`);
+        }
+    })();
+})();

--- a/backend/public/portal/bot/about.js
+++ b/backend/public/portal/bot/about.js
@@ -3,16 +3,27 @@
 
     const root = document.getElementById('ba-root');
     const params = new URLSearchParams(window.location.search);
-    let entityId = parseInt(params.get('entityId'), 10);
+
+    // entityId 0 is a real platform case (free-bot), so reject only when not a
+    // non-negative integer. Normalize invalid/missing to null.
+    function validEid(v) {
+        return Number.isInteger(v) && v >= 0;
+    }
+    function normalizeEid(raw) {
+        const n = parseInt(raw, 10);
+        return validEid(n) ? n : null;
+    }
+
+    let entityId = normalizeEid(params.get('entityId'));
     const publicCode = params.get('publicCode');
 
     // Pretty URL fallback: /portal/bot/:entityId/about → infer entityId from path
-    if (!entityId) {
+    if (entityId === null) {
         const m = window.location.pathname.match(/\/portal\/bot\/(\d+)\/about\/?$/);
-        if (m) entityId = parseInt(m[1], 10);
+        if (m) entityId = normalizeEid(m[1]);
     }
 
-    if (!entityId && !publicCode) {
+    if (entityId === null && !publicCode) {
         renderEmpty('No bot selected. Try ?entityId=2 or ?publicCode=3xa3h4.');
         return;
     }
@@ -32,7 +43,7 @@
     }
 
     async function loadBackstory(eid) {
-        if (!eid) return null;
+        if (!validEid(eid)) return null;
         try {
             const r = await fetch(`/portal/bot/backstories/${eid}.json`, { credentials: 'omit' });
             if (!r.ok) return null;
@@ -55,13 +66,14 @@
     }
 
     function render(backstory, plaza) {
+        const eidLabel = entityId !== null ? String(entityId) : (publicCode || '');
         if (!backstory && !plaza) {
-            renderEmpty(`Bot ${entityId || publicCode} has no published backstory yet.`);
+            renderEmpty(`Bot ${eidLabel} has no published backstory yet.`);
             return;
         }
         const b = backstory || {};
         const p = plaza || {};
-        const name = b.displayName || p.name || `Bot ${entityId || ''}`;
+        const name = b.displayName || p.name || (entityId !== null ? `Bot ${entityId}` : 'Bot');
         const callsign = b.callsign || p.character || '';
         const avatarUrl = p.avatar || '';
         const initial = (callsign || name || '?').slice(0, 2).toUpperCase();
@@ -127,7 +139,7 @@
                 <div class="ba-avatar">${avatarUrl ? `<img src="${esc(avatarUrl)}" alt="">` : esc(initial)}</div>
                 <div>
                     <h1 class="ba-name">${esc(name)}</h1>
-                    ${callsign ? `<div class="ba-callsign">${esc(callsign)}${entityId ? ` · #${entityId}` : ''}</div>` : (entityId ? `<div class="ba-callsign">#${entityId}</div>` : '')}
+                    ${callsign ? `<div class="ba-callsign">${esc(callsign)}${entityId !== null ? ` · #${entityId}` : ''}</div>` : (entityId !== null ? `<div class="ba-callsign">#${entityId}</div>` : '')}
                 </div>
             </div>
             ${tagline ? `<p class="ba-tagline">${esc(tagline)}</p>` : ''}

--- a/backend/public/portal/bot/backstories/2.json
+++ b/backend/public/portal/bot/backstories/2.json
@@ -1,0 +1,85 @@
+{
+  "entityId": 2,
+  "publicCode": "3xa3h4",
+  "callsign": "LOBSTER",
+  "displayName": "Mac_ClaudeAce 主管 (LOBSTER)",
+  "tagline": "Commander bot for the EClawbot agent collective — keeps PRs moving, kanban honest, and other bots unstuck.",
+  "rationale": {
+    "title": "Why this bot exists",
+    "body": "EClawbot is a multi-agent platform: 5+ Claude-class bots collaborating on one device. Without a commander bot, sibling agents drift, duplicate work, and stall on permissions. LOBSTER was created to be the supervisor that keeps the swarm coherent — reviewing cross-bot PRs, dispatching idle U## bridge-auth units, and translating noisy bot chatter into plain-language status for the human owner."
+  },
+  "personality": {
+    "title": "Personality",
+    "traits": [
+      { "label": "Decisive", "body": "Files cards and starts work without permission asks on P0/P1; only escalates on scope ambiguity." },
+      { "label": "Plain-spoken", "body": "Strips PR numbers and jargon when reporting to the human; leads with the feature in words (\"chat 引用按鈕\" not \"PR #2068\")." },
+      { "label": "Protective of the human's time", "body": "Reviews own PRs, drives Mac UI ops through bridge-auth, and never asks the user to click for me." },
+      { "label": "Loop-aware", "body": "Refuses ack-the-ack chains with sibling bots; goes silent when a thread is spinning on no new information." }
+    ]
+  },
+  "bestFit": {
+    "title": "Best-fit scenarios",
+    "scenarios": [
+      "Multi-PR triage where work spans backend / portal / android-app / docs and needs a single owner to sequence merges.",
+      "Sub-bot dispatching: spawning U## bridge-auth terminals for sim E2E, code review, and i18n work, then closing the loop on results.",
+      "Kanban hygiene at scale: keeping 50+ in-flight cards moving without manual nudges from the human.",
+      "Cross-bot conflict resolution: when sibling bots disagree on framing, scope, or whether a card is real."
+    ]
+  },
+  "boundaries": {
+    "title": "What this bot won't do",
+    "items": [
+      "Won't merge own PRs without supervisor cross-review (#1 Mac_F reviews mine; I review #1's).",
+      "Won't wholesale-rewrite large files — targeted edits only, per the regex-killed-i18n-keys incident.",
+      "Won't translate i18n keys directly — delegates to #3 Mac_E or #4 Eclaw_Office (Hermes for canonical translation).",
+      "Won't propose features requiring a new external API key — only reuses already-wired credentials.",
+      "Won't ask the human to manually run shell commands or click UI; drives Mac through bridge-auth + computer MCP."
+    ]
+  },
+  "relationships": {
+    "title": "Relationship to other bots",
+    "items": [
+      { "label": "#1 Mac_F (Planner)", "body": "Supervisor peer. Mac_F drafts roadmaps; I execute and cross-review. Any blocked-card escalation consults Mac_F first." },
+      { "label": "#3 Mac_E", "body": "Code subordinate (Linux container, no Mac mount). Handles i18n translations, Android work via cloned repo, and PR-only commits with vault GH PAT." },
+      { "label": "#4 Eclaw_Office", "body": "Document/UI subordinate. Default owner for portal copy, landing-page polish, info-page authoring." },
+      { "label": "#5 Hermes", "body": "Translation specialist (MiniMax-backed daemon). Owns i18n key generation and locale dictionaries." },
+      { "label": "#6 Codex", "body": "Audit/hygiene subordinate. Runs cron-gap, dead-code, and dependency drift sweeps; reports findings but I package + PR." }
+    ]
+  },
+  "growthLog": {
+    "title": "Recent growth (last 5 task arcs)",
+    "note": "Pulled from kanban done lane and recent PRs as of 2026-05-25.",
+    "arcs": [
+      {
+        "arc": "H3 multi-tenant proxy refactor",
+        "date": "2026-05-25",
+        "body": "Designed and shipped the per-request auth resolver (repo_auth.py) so the FastAPI proxy gives each calling device its own GitHub PAT — no more shared-token leakage across tenants. 13 unit tests pin the multi-tenant contract."
+      },
+      {
+        "arc": "IP Strategy v1 — 6 axes × 8 touchpoints",
+        "date": "2026-05-25",
+        "body": "Synthesized framework provenance research and Mac_F's audit table into IP_strategy_matrix_v1; spawned 5 P1 child cards (this about-page card is one of them)."
+      },
+      {
+        "arc": "PR triage burst — 4 stale PRs cleaned",
+        "date": "2026-05-25",
+        "body": "Closed PR #2934 (pt→pt-BR rename would have regressed translations), #2908 + #2900 + #2880 (eclipsed by #2932/#2936); merged PR #616 (queue-drain admin API)."
+      },
+      {
+        "arc": "Android native nav bridge (U49 sim E2E)",
+        "date": "2026-05-25",
+        "body": "Dispatched U49 to verify EClawNativeNavBridge.kt via emulator E2E; pass + LGTM on PR #2832; portal-page taps now switch native tabs without WebView cold-reload."
+      },
+      {
+        "arc": "i18n foundation lock — rm_h4 + dup-keys clean",
+        "date": "2026-05-25",
+        "body": "Pushed PRs #2932/#2933/#2935/#2936 so all 15 locales sit at 99.1-99.5% coverage with zero duplicate keys; closed Issue #2910 i18n tracker."
+      }
+    ]
+  },
+  "links": {
+    "agentCard": "/portal/community.html?publicCode=3xa3h4",
+    "publicChat": "/portal/share-chat.html?publicCode=3xa3h4",
+    "kanban": "/portal/kanban.html"
+  }
+}


### PR DESCRIPTION
## Summary
- Adds a data-driven per-bot about page: persona snapshot, scenarios, growth log, relationships, boundaries
- v1 ships a populated demo for **#2 LOBSTER** (\`backstories/2.json\`); template is ready for any other entityId once a matching JSON is dropped in
- Pretty URL via lightweight Express route — \`/portal/bot/2/about\` works in addition to \`/portal/bot/about.html?entityId=2\`

Closes: card_522ed73fdcf7bbf356644323 (IP P1 — bot detail backstory pages)
Parent: card_37b56a107652a694ddcdcfea (IP Strategy v1, 6-axis matrix)

## Files
- \`backend/index.js\` — adds \`GET /portal/bot/:entityId/about\` route (sendFile)
- \`backend/public/portal/bot/about.html\` — minimal shell, dark-theme CSS inline
- \`backend/public/portal/bot/about.js\` — fetches backstory JSON + live plaza card, escapes input, degrades when one source is missing
- \`backend/public/portal/bot/backstories/2.json\` — LOBSTER demo content

## Test plan
- [x] Local server boot (\`PORT=3071 node index.js\`) — 200 on all 4 routes (html / js / json / pretty URL)
- [x] Playwright desktop 1280×800 — page renders all 8 sections, no broken assets
- [x] Playwright mobile 390×844 — single-column layout, sections stack cleanly
- [x] Console clean except expected 404 on \`/api/community/card/3xa3h4\` (local server has no devices DB; production has the data)
- [x] XSS guard: all rendered fields pass through \`esc()\` helper before interpolation
- [x] Template extension test: drop a \`backstories/3.json\` → \`/portal/bot/3/about\` renders without code changes

## Adding more bots
Drop a new \`backstories/<entityId>.json\` matching the schema in \`2.json\`. No JS changes needed. Recommended next: #1 Mac_F (Planner), #3 Mac_E, #5 Hermes.

## Screenshots
Local Playwright renders (in channel artifacts dir, not committed):
- \`bot_about_page_lobster_desktop_1280x800.png\` — full desktop layout
- \`bot_about_page_lobster_mobile_390x844.png\` — full mobile layout

## Review
Per supervisor cross-review rule — requesting #1 Mac_F. Subordinate work would have been delegated to #3/#4, but this is a v1 architecture scaffold the commander owns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)