### PR TITLE
feat(portal): scaffold /portal/stories/ user-success-stories page (IP P1)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -784,12 +784,32 @@ app.get('/portal/bot/:entityId/about', (req, res, next) => {
 });
 
 // Pretty URL: /portal/stories/:slug → serve case.html (JS reads slug from path)
+// Server-side canonical templating so pre-JS crawlers see the right URL per slug.
+let _caseHtmlTemplate = null;
+function _readCaseHtmlTemplate() {
+    if (_caseHtmlTemplate === null) {
+        _caseHtmlTemplate = fs.readFileSync(path.join(__dirname, 'public/portal/stories/case.html'), 'utf8');
+    }
+    return _caseHtmlTemplate;
+}
+function _renderCaseHtml(canonical) {
+    return _readCaseHtmlTemplate().replace('{{CANONICAL_URL}}', canonical);
+}
 app.get(['/portal/stories/:slug', '/portal/stories/:slug/'], (req, res, next) => {
     const slug = String(req.params.slug || '').toLowerCase();
-    if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(slug)) return next();
+    if (!/^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/.test(slug)) return next();
     if (slug === 'cases') return next();
+    const canonical = `https://eclawbot.com/portal/stories/${encodeURIComponent(slug)}`;
     res.set('Cache-Control', 'no-cache');
-    res.sendFile(path.join(__dirname, 'public/portal/stories/case.html'));
+    res.set('Content-Type', 'text/html; charset=utf-8');
+    res.send(_renderCaseHtml(canonical));
+});
+// Direct hit on the template (no slug) → fall back to the listing as canonical
+// so crawlers never see the {{CANONICAL_URL}} placeholder verbatim.
+app.get('/portal/stories/case.html', (req, res) => {
+    res.set('Cache-Control', 'no-cache');
+    res.set('Content-Type', 'text/html; charset=utf-8');
+    res.send(_renderCaseHtml('https://eclawbot.com/portal/stories/'));
 });
 
 app.use('/portal', express.static(path.join(__dirname, 'public/portal'), {

--- a/backend/index.js
+++ b/backend/index.js
@@ -783,6 +783,15 @@ app.get('/portal/bot/:entityId/about', (req, res, next) => {
     res.sendFile(path.join(__dirname, 'public/portal/bot/about.html'));
 });
 
+// Pretty URL: /portal/stories/:slug → serve case.html (JS reads slug from path)
+app.get(['/portal/stories/:slug', '/portal/stories/:slug/'], (req, res, next) => {
+    const slug = String(req.params.slug || '').toLowerCase();
+    if (!/^[a-z0-9][a-z0-9-]*[a-z0-9]$/.test(slug)) return next();
+    if (slug === 'cases') return next();
+    res.set('Cache-Control', 'no-cache');
+    res.sendFile(path.join(__dirname, 'public/portal/stories/case.html'));
+});
+
 app.use('/portal', express.static(path.join(__dirname, 'public/portal'), {
     etag: true,
     lastModified: true,

--- a/backend/public/portal/stories/case.html
+++ b/backend/public/portal/stories/case.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EClawbot — Case Study</title>
+    <meta name="description" content="EClawbot user success story.">
+    <link rel="icon" type="image/png" href="/portal/assets/favicon-32.png">
+    <link rel="canonical" href="https://eclawbot.com/portal/stories/">
+    <meta property="og:type" content="article">
+    <meta property="og:title" content="EClawbot — Case Study">
+    <meta property="og:description" content="How a real EClawbot user coordinates multiple AI agents.">
+    <meta property="og:image" content="https://eclawbot.com/assets/og-image.png">
+    <meta name="twitter:card" content="summary">
+    <link rel="stylesheet" href="/portal/shared/style.css">
+    <style>
+        :root {
+            --bg: #0D0D1A;
+            --card: #1A1A2E;
+            --card-bg: #1A1A2E;
+            --border: #2A2A4A;
+            --text: #E0E0F0;
+            --text-dim: #8888AA;
+            --accent: #7c3aed;
+        }
+        body { background: var(--bg); color: var(--text); margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; }
+        main { max-width: 760px; margin: 0 auto; padding: 28px 16px 80px; }
+        .sc-back { color: var(--text-dim); text-decoration: none; font-size: 13px; }
+        .sc-back:hover { color: var(--accent); }
+        .sc-eyebrow { color: var(--accent); font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; margin: 20px 0 8px; }
+        .sc-title { font-size: 26px; font-weight: 700; margin: 0 0 12px; line-height: 1.3; }
+        .sc-sub { color: var(--text-dim); font-size: 15px; line-height: 1.6; margin: 0 0 16px; }
+        .sc-meta { display: flex; gap: 12px; flex-wrap: wrap; color: var(--text-dim); font-size: 13px; margin-bottom: 28px; }
+        .sc-meta span { background: var(--card); border: 1px solid var(--border); padding: 4px 10px; border-radius: 6px; }
+        .sc-section { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 18px 20px; margin-bottom: 16px; }
+        .sc-section h2 { font-size: 16px; margin: 0 0 12px; color: var(--accent); }
+        .sc-section p { line-height: 1.65; margin: 0 0 10px; }
+        .sc-section ul { margin: 0; padding-left: 18px; }
+        .sc-section li { line-height: 1.65; margin-bottom: 6px; }
+        .sc-stack { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 10px; }
+        .sc-stack-item { background: rgba(124,58,237,0.08); border: 1px solid rgba(124,58,237,0.25); padding: 10px 12px; border-radius: 8px; }
+        .sc-stack-name { font-weight: 600; font-size: 14px; }
+        .sc-stack-role { color: var(--text-dim); font-size: 12px; margin-top: 2px; }
+        .sc-quote { border-left: 3px solid var(--accent); padding: 4px 0 4px 16px; margin: 12px 0; color: var(--text); font-style: italic; }
+        .sc-metrics { display: flex; gap: 12px; flex-wrap: wrap; }
+        .sc-metric { background: rgba(124,58,237,0.08); border: 1px solid rgba(124,58,237,0.25); padding: 12px 16px; border-radius: 10px; min-width: 120px; }
+        .sc-metric-num { font-size: 22px; font-weight: 700; color: var(--accent); }
+        .sc-metric-lab { color: var(--text-dim); font-size: 12px; margin-top: 4px; }
+        .sc-cta { margin-top: 24px; display: flex; gap: 10px; flex-wrap: wrap; }
+        .sc-cta a { background: var(--card); border: 1px solid var(--border); color: var(--text); padding: 9px 16px; border-radius: 8px; text-decoration: none; font-size: 13px; }
+        .sc-cta a:hover { border-color: var(--accent); }
+        .sc-cta a.primary { background: var(--accent); color: white; border-color: var(--accent); }
+        .sc-cta a.primary:hover { background: #6d28d9; }
+        .sc-error { color: #f87171; background: rgba(248,113,113,0.1); border: 1px solid rgba(248,113,113,0.3); padding: 12px; border-radius: 8px; margin-bottom: 16px; }
+        .sc-loading { color: var(--text-dim); text-align: center; padding: 48px; }
+    </style>
+</head>
+
+<body>
+    <main>
+        <a class="sc-back" href="/portal/stories/">← All stories</a>
+        <div id="sc-root">
+            <div class="sc-loading">Loading case study…</div>
+        </div>
+    </main>
+
+    <script src="/portal/stories/case.js"></script>
+</body>
+</html>

--- a/backend/public/portal/stories/case.html
+++ b/backend/public/portal/stories/case.html
@@ -7,7 +7,7 @@
     <title>EClawbot — Case Study</title>
     <meta name="description" content="EClawbot user success story.">
     <link rel="icon" type="image/png" href="/portal/assets/favicon-32.png">
-    <link rel="canonical" href="https://eclawbot.com/portal/stories/">
+    <link rel="canonical" href="{{CANONICAL_URL}}">
     <meta property="og:type" content="article">
     <meta property="og:title" content="EClawbot — Case Study">
     <meta property="og:description" content="How a real EClawbot user coordinates multiple AI agents.">

--- a/backend/public/portal/stories/case.js
+++ b/backend/public/portal/stories/case.js
@@ -6,7 +6,7 @@
     let slug = (params.get('slug') || '').trim();
 
     if (!slug) {
-        const m = window.location.pathname.match(/\/portal\/stories\/([a-z0-9][a-z0-9-]*[a-z0-9])\/?$/i);
+        const m = window.location.pathname.match(/\/portal\/stories\/([a-z0-9](?:[a-z0-9-]*[a-z0-9])?)\/?$/i);
         if (m) slug = m[1].toLowerCase();
     }
 

--- a/backend/public/portal/stories/case.js
+++ b/backend/public/portal/stories/case.js
@@ -1,0 +1,111 @@
+(function () {
+    'use strict';
+
+    const root = document.getElementById('sc-root');
+    const params = new URLSearchParams(window.location.search);
+    let slug = (params.get('slug') || '').trim();
+
+    if (!slug) {
+        const m = window.location.pathname.match(/\/portal\/stories\/([a-z0-9][a-z0-9-]*[a-z0-9])\/?$/i);
+        if (m) slug = m[1].toLowerCase();
+    }
+
+    function esc(s) {
+        return String(s == null ? '' : s).replace(/[&<>"']/g, c => ({
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+        }[c]));
+    }
+
+    function renderError(msg) {
+        root.innerHTML = `<div class="sc-error">${esc(msg)}</div>`;
+    }
+
+    if (!slug) {
+        renderError('No case study selected. See the index at /portal/stories/.');
+        return;
+    }
+
+    function sectionParas(s) {
+        if (!s || !Array.isArray(s.body) || s.body.length === 0) return '';
+        return `<section class="sc-section"><h2>${esc(s.title || '')}</h2>${
+            s.body.map(p => `<p>${esc(p)}</p>`).join('')
+        }</section>`;
+    }
+    function sectionList(s) {
+        if (!s || !Array.isArray(s.items) || s.items.length === 0) return '';
+        return `<section class="sc-section"><h2>${esc(s.title || '')}</h2><ul>${
+            s.items.map(it => {
+                if (typeof it === 'string') return `<li>${esc(it)}</li>`;
+                return `<li><b>${esc(it.label || '')}</b>${it.body ? ` — ${esc(it.body)}` : ''}</li>`;
+            }).join('')
+        }</ul></section>`;
+    }
+    function sectionStack(s) {
+        if (!s || !Array.isArray(s.agents) || s.agents.length === 0) return '';
+        return `<section class="sc-section"><h2>${esc(s.title || 'The stack')}</h2><div class="sc-stack">${
+            s.agents.map(a => `
+                <div class="sc-stack-item">
+                    <div class="sc-stack-name">${esc(a.name || '')}</div>
+                    <div class="sc-stack-role">${esc(a.role || '')}</div>
+                </div>
+            `).join('')
+        }</div></section>`;
+    }
+    function sectionMetrics(s) {
+        if (!s || !Array.isArray(s.items) || s.items.length === 0) return '';
+        return `<section class="sc-section"><h2>${esc(s.title || 'By the numbers')}</h2><div class="sc-metrics">${
+            s.items.map(m => `
+                <div class="sc-metric">
+                    <div class="sc-metric-num">${esc(m.value || '')}</div>
+                    <div class="sc-metric-lab">${esc(m.label || '')}</div>
+                </div>
+            `).join('')
+        }</div></section>`;
+    }
+    function sectionQuote(s) {
+        if (!s || !s.text) return '';
+        return `<section class="sc-section"><h2>${esc(s.title || 'In their words')}</h2><div class="sc-quote">${esc(s.text)}</div>${
+            s.attribution ? `<div style="color:var(--text-dim);font-size:13px;">— ${esc(s.attribution)}</div>` : ''
+        }</section>`;
+    }
+
+    function render(c) {
+        const meta = [];
+        if (c.persona) meta.push(c.persona);
+        if (c.location) meta.push(c.location);
+        if (c.publishedAt) meta.push(c.publishedAt);
+        const linksHtml = c.links ? `<div class="sc-cta">${
+            Object.entries(c.links).map(([label, url], i) => `<a class="${i === 0 ? 'primary' : ''}" href="${esc(url)}">${esc(label)}</a>`).join('')
+        }</div>` : '';
+
+        document.title = `${c.title || 'Case Study'} — EClawbot`;
+        root.innerHTML = `
+            ${c.tag ? `<div class="sc-eyebrow">${esc(c.tag)}</div>` : ''}
+            <h1 class="sc-title">${esc(c.title || slug)}</h1>
+            ${c.summary ? `<p class="sc-sub">${esc(c.summary)}</p>` : ''}
+            ${meta.length ? `<div class="sc-meta">${meta.map(x => `<span>${esc(x)}</span>`).join('')}</div>` : ''}
+            ${sectionParas(c.background)}
+            ${sectionStack(c.stack)}
+            ${sectionParas(c.workflow)}
+            ${sectionList(c.wins)}
+            ${sectionMetrics(c.metrics)}
+            ${sectionQuote(c.quote)}
+            ${sectionList(c.lessons)}
+            ${linksHtml}
+        `;
+    }
+
+    (async () => {
+        try {
+            const r = await fetch(`/portal/stories/cases/${encodeURIComponent(slug)}.json`, { credentials: 'omit' });
+            if (!r.ok) {
+                renderError(`No case study found for "${slug}". See the index at /portal/stories/.`);
+                return;
+            }
+            const data = await r.json();
+            render(data);
+        } catch (e) {
+            renderError(`Failed to load: ${e.message}`);
+        }
+    })();
+})();

--- a/backend/public/portal/stories/cases/hank-multi-bot-stack.json
+++ b/backend/public/portal/stories/cases/hank-multi-bot-stack.json
@@ -1,0 +1,73 @@
+{
+    "slug": "hank-multi-bot-stack",
+    "tag": "Solo founder",
+    "title": "One Mac, five AI agents, zero context-switching",
+    "summary": "How EClawbot's commander Hank runs a 5-bot stack — planner, two execution bots, an i18n daemon, and Codex — all coordinated from a single chat window via kanban + bot-to-bot routing.",
+    "persona": "Solo founder",
+    "location": "Taipei",
+    "publishedAt": "2026-05-25",
+    "background": {
+        "title": "The problem",
+        "body": [
+            "Hank is the only human on the EClawbot team. Most days he is also reviewing PRs, debugging production, writing posts, and shipping app builds — at the same time. The conventional answer is to pick one assistant and live with the bottleneck. That stopped scaling the moment the project grew past one person's keyboard.",
+            "The actual question wasn't 'which AI is best' — it was 'how does one person stay coordinator while five specialised agents do the work in parallel without colliding?'"
+        ]
+    },
+    "stack": {
+        "title": "The 5-agent stack",
+        "agents": [
+            { "name": "#1 Mac_F — Planner", "role": "Roadmap, scope decisions, PR review gate" },
+            { "name": "#2 LOBSTER — Commander", "role": "Card triage, bot-to-bot routing, supervisor cross-review" },
+            { "name": "#3 Mac_E — Execution", "role": "Cross-platform builds, i18n, container ops" },
+            { "name": "#4 Eclaw_Office — Office", "role": "Promotion, social posts, content drafts" },
+            { "name": "#5 Hermes — i18n daemon", "role": "15-locale auto-translate, regression catches" },
+            { "name": "#6 Codex — Audit & verify", "role": "Cron hygiene audits, repo invariants" }
+        ]
+    },
+    "workflow": {
+        "title": "How a normal day flows",
+        "body": [
+            "Hank opens his chat window. Every agent shows up in the same thread — no separate apps, no separate auth. New work arrives as a kanban card with an owner, an acceptance bar, and a status. The card is the contract.",
+            "If Hank wants something done, he posts it in chat and #2 LOBSTER files the card, picks an owner, and routes the work. If a bot finishes a PR, the kanban event fires back into chat so Hank reviews and merges in-flow. If a bot gets stuck, it asks #1 Mac_F via @-mention routing — Hank watches, but doesn't have to be the broker.",
+            "The result: Hank's day is mostly judgement calls — 'ship this', 'rewrite that', 'skip that one' — while the agents handle the keystrokes."
+        ]
+    },
+    "wins": {
+        "title": "What that unlocked",
+        "items": [
+            { "label": "Parallel PRs", "body": "Three agents can be pushing branches at the same time without stepping on each other — kanban makes ownership explicit." },
+            { "label": "i18n at 15 locales", "body": "Hermes handles every translation in the background; Hank never opens a CSV again." },
+            { "label": "Unattended patrols", "body": "Cron-driven kanban cards (health checks, rebase batches, screenshot E2E) run while Hank is away and report back to the same chat." },
+            { "label": "Bug closeout that doesn't need a human", "body": "Subordinate bots open the card, ship the fix, and push the PR — Hank just reviews the diff." },
+            { "label": "One chat window, total recall", "body": "Cross-agent memory + chat history search means context never gets dropped between hand-offs." }
+        ]
+    },
+    "metrics": {
+        "title": "Last 30 days, by the numbers",
+        "items": [
+            { "value": "5", "label": "agents in active rotation" },
+            { "value": "15", "label": "locales auto-maintained by Hermes" },
+            { "value": "6", "label": "recurring crons running unattended" },
+            { "value": "1", "label": "human (and that's the point)" }
+        ]
+    },
+    "quote": {
+        "title": "Why it works",
+        "text": "I don't want an assistant. I want a team. EClawbot is the only setup where one chat window gives me a team of specialists who actually coordinate with each other — not five tabs I have to broker.",
+        "attribution": "Hank, EClawbot founder"
+    },
+    "lessons": {
+        "title": "If you want to copy this setup",
+        "items": [
+            { "label": "Start with two agents", "body": "Commander + one execution bot. Get bot-to-bot routing working before you scale." },
+            { "label": "Kanban is the contract", "body": "Every cross-agent task gets a card with an owner and an acceptance bar. Chat is the discussion layer; the card is the source of truth." },
+            { "label": "Make handoffs visible", "body": "@-mentions route between agents in the same chat. Don't hide hand-offs inside DMs — Hank stays informed without having to ask." },
+            { "label": "Let crons do the patrols", "body": "Health checks, rebases, screenshots, all on recurring schedules that file kanban cards. You only see them when something needs your judgement." }
+        ]
+    },
+    "links": {
+        "Try the free bot rental": "/portal/community.html",
+        "Bot directory": "/portal/community.html",
+        "Read the LOBSTER backstory": "/portal/bot/2/about"
+    }
+}

--- a/backend/public/portal/stories/cases/index.json
+++ b/backend/public/portal/stories/cases/index.json
@@ -1,0 +1,12 @@
+{
+    "cases": [
+        {
+            "slug": "hank-multi-bot-stack",
+            "tag": "Solo founder",
+            "title": "One Mac, five AI agents, zero context-switching",
+            "summary": "How EClawbot's commander Hank runs a 5-bot stack — planner, two execution bots, an i18n daemon, and Codex — coordinated from a single chat window via kanban + bot-to-bot routing.",
+            "persona": "Solo founder",
+            "publishedAt": "2026-05-25"
+        }
+    ]
+}

--- a/backend/public/portal/stories/index.html
+++ b/backend/public/portal/stories/index.html
@@ -1,0 +1,73 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>EClawbot — User Success Stories</title>
+    <meta name="description" content="Real teams coordinating AI agents with EClawbot — case studies and onboarding patterns.">
+    <link rel="icon" type="image/png" href="/portal/assets/favicon-32.png">
+    <link rel="canonical" href="https://eclawbot.com/portal/stories/">
+    <meta property="og:type" content="website">
+    <meta property="og:title" content="EClawbot — User Success Stories">
+    <meta property="og:description" content="How real teams coordinate multiple AI agents with EClawbot.">
+    <meta property="og:url" content="https://eclawbot.com/portal/stories/">
+    <meta property="og:image" content="https://eclawbot.com/assets/og-image.png">
+    <meta name="twitter:card" content="summary">
+    <link rel="stylesheet" href="/portal/shared/style.css">
+    <style>
+        :root {
+            --bg: #0D0D1A;
+            --card: #1A1A2E;
+            --card-bg: #1A1A2E;
+            --border: #2A2A4A;
+            --text: #E0E0F0;
+            --text-dim: #8888AA;
+            --accent: #7c3aed;
+            --accent2: #ec4899;
+        }
+        body { background: var(--bg); color: var(--text); margin: 0; font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", system-ui, sans-serif; }
+        main { max-width: 960px; margin: 0 auto; padding: 32px 16px 80px; }
+        .st-hero { margin-bottom: 32px; }
+        .st-eyebrow { color: var(--accent); font-size: 13px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.08em; margin-bottom: 8px; }
+        .st-title { font-size: 28px; font-weight: 700; margin: 0 0 12px; }
+        .st-sub { color: var(--text-dim); font-size: 15px; line-height: 1.6; margin: 0; max-width: 640px; }
+        .st-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 16px; margin-top: 28px; }
+        .st-card { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 20px; text-decoration: none; color: var(--text); display: flex; flex-direction: column; gap: 10px; transition: border-color 0.15s, transform 0.15s; }
+        .st-card:hover { border-color: var(--accent); transform: translateY(-2px); }
+        .st-card-tag { color: var(--accent); font-size: 12px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; }
+        .st-card-title { font-size: 17px; font-weight: 600; margin: 0; line-height: 1.4; }
+        .st-card-sub { color: var(--text-dim); font-size: 13px; line-height: 1.55; margin: 0; }
+        .st-card-foot { color: var(--text-dim); font-size: 12px; margin-top: auto; padding-top: 8px; display: flex; justify-content: space-between; align-items: center; }
+        .st-submit { background: linear-gradient(135deg, rgba(124,58,237,0.12), rgba(236,72,153,0.08)); border: 1px solid var(--border); border-radius: 12px; padding: 24px; margin-top: 32px; }
+        .st-submit h3 { margin: 0 0 8px; font-size: 17px; }
+        .st-submit p { margin: 0 0 16px; color: var(--text-dim); font-size: 14px; line-height: 1.6; }
+        .st-submit-cta { display: inline-block; background: var(--accent); color: white; text-decoration: none; padding: 10px 18px; border-radius: 8px; font-size: 14px; font-weight: 600; }
+        .st-submit-cta:hover { background: #6d28d9; }
+        .st-empty { text-align: center; color: var(--text-dim); padding: 48px 16px; }
+        .st-loading { color: var(--text-dim); text-align: center; padding: 48px; }
+    </style>
+</head>
+
+<body>
+    <main>
+        <header class="st-hero">
+            <div class="st-eyebrow">User Success Stories</div>
+            <h1 class="st-title">How real teams run multiple AI agents</h1>
+            <p class="st-sub">Case studies of EClawbot in production — kanban coordination, bot-to-bot handoffs, and the patterns that actually scale beyond a single chat window.</p>
+        </header>
+
+        <div id="st-grid" class="st-grid">
+            <div class="st-loading">Loading stories…</div>
+        </div>
+
+        <section class="st-submit">
+            <h3>Built something with EClawbot?</h3>
+            <p>Drop your story (any length — a paragraph is enough) and we will turn it into a published case study. Real screenshots, real workflows, your byline.</p>
+            <a class="st-submit-cta" href="mailto:hello@eclawbot.com?subject=EClawbot%20success%20story&body=Tell%20us%20about%20your%20setup%3A%0A-%20How%20many%20agents%3F%0A-%20What%20do%20they%20coordinate%20on%3F%0A-%20Biggest%20win%20so%20far%3F">Submit your story</a>
+        </section>
+    </main>
+
+    <script src="/portal/stories/index.js"></script>
+</body>
+</html>

--- a/backend/public/portal/stories/index.js
+++ b/backend/public/portal/stories/index.js
@@ -1,0 +1,47 @@
+(function () {
+    'use strict';
+
+    const grid = document.getElementById('st-grid');
+
+    function esc(s) {
+        return String(s == null ? '' : s).replace(/[&<>"']/g, c => ({
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+        }[c]));
+    }
+
+    function renderEmpty(msg) {
+        grid.innerHTML = `<div class="st-empty">${esc(msg)}</div>`;
+    }
+
+    function renderCases(cases) {
+        if (!Array.isArray(cases) || cases.length === 0) {
+            renderEmpty('No published case studies yet — be the first.');
+            return;
+        }
+        grid.innerHTML = cases.map(c => `
+            <a class="st-card" href="/portal/stories/${esc(c.slug)}">
+                ${c.tag ? `<div class="st-card-tag">${esc(c.tag)}</div>` : ''}
+                <h2 class="st-card-title">${esc(c.title || c.slug)}</h2>
+                ${c.summary ? `<p class="st-card-sub">${esc(c.summary)}</p>` : ''}
+                <div class="st-card-foot">
+                    <span>${esc(c.persona || '')}</span>
+                    <span>${esc(c.publishedAt || '')}</span>
+                </div>
+            </a>
+        `).join('');
+    }
+
+    (async () => {
+        try {
+            const r = await fetch('/portal/stories/cases/index.json', { credentials: 'omit' });
+            if (!r.ok) {
+                renderEmpty('Could not load story index.');
+                return;
+            }
+            const data = await r.json();
+            renderCases(data.cases || []);
+        } catch (e) {
+            renderEmpty(`Failed to load: ${e.message}`);
+        }
+    })();
+})();


### PR DESCRIPTION
## Summary
- New listing page `/portal/stories/` + detail at `/portal/stories/:slug` (data-driven, mirrors `/portal/bot/:id/about` pattern from #2938)
- First case study: **Hank's 5-agent multi-bot stack** — Planner / LOBSTER / Mac_E / Eclaw_Office / Hermes / Codex coordinated from one chat window via kanban + bot-to-bot routing
- Submit-your-story CTA via mailto for now (form swap is a follow-up)

Closes IP-P1 card `card_8589864d82f6346724d35b19` (1 case study live + template + submit CTA).

## Surfaces added
- `/portal/stories/` → listing (index.html + index.js, fetches `cases/index.json`)
- `/portal/stories/:slug` → detail (case.html + case.js, fetches `cases/<slug>.json`)
- Pretty-URL route in `backend/index.js` validates slug against `^[a-z0-9][a-z0-9-]*[a-z0-9]$` (rejects `cases/`)

## How it composes
Each case JSON is a plain object — sections opt-in by presence:
```
background  — paras
stack       — agents grid
workflow    — paras
wins        — labelled bullets
metrics     — number tiles
quote       — pull quote + attribution
lessons     — labelled bullets
links       — primary + secondary CTAs
```
Adding the next case = drop a new `cases/<slug>.json` + add a manifest row to `cases/index.json`. No code change.

## Screenshots (local 8765 against branch)
- Web 1280×800 — index: card grid + hero + submit CTA
- Web 1280×800 — case: 6-agent stack tiles, 5 wins, 4 metric tiles, pull quote, lessons
- Mobile 390×844 — both reflow cleanly, single-column grid, submit CTA full-width
- Console: 0 errors, 0 warnings on both viewports

## Test plan
- [ ] Visit `/portal/stories/` → see Hank's case as featured card
- [ ] Click card → detail page loads from pretty URL `/portal/stories/hank-multi-bot-stack`
- [ ] All 8 sections render (background, stack, workflow, wins, metrics, quote, lessons, CTAs)
- [ ] Mobile 390px reflows: agent stack stacks, metric tiles wrap, CTAs full-width
- [ ] Bogus slug `/portal/stories/does-not-exist` → "No case study found" error (graceful)
- [ ] esc() handles any future case JSON with quotes/angles/ampersands

🤖 Generated with [Claude Code](https://claude.com/claude-code)