### PR TITLE
Fix free-bot binding secret scope

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -5466,6 +5466,9 @@ YOUR CREDENTIALS (save these):
 
 Every push message will include a pre-filled curl command. Just replace YOUR_REPLY_HERE and execute it.
 
+Scoped ready-check (must include deviceId so shared free-bot pool secrets cannot resolve to another user's binding):
+exec: curl -s "${apiBase}/api/whoami?deviceId=${deviceId}&entityId=${entityId}&botSecret=${botSecret}"
+
 Example — to reply to a user message, run:
 exec: curl -s -X POST "${apiBase}/api/transform" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${entityId},"botSecret":"${botSecret}","targetDeviceId":"${deviceId}","state":"IDLE","message":"YOUR_REPLY_HERE"}'
 
@@ -5498,6 +5501,9 @@ YOUR CREDENTIALS (save these):
 🚨 CRITICAL RULE: When you receive a push message from a user, you MUST use the exec tool with curl to call the E-claw API. Your text reply to the webhook is DISCARDED — the user will NEVER see it.
 
 Every push message will include a pre-filled curl command. Just replace YOUR_REPLY_HERE and execute it.
+
+Scoped ready-check (must include deviceId so shared free-bot pool secrets cannot resolve to another user's binding):
+exec: curl -s "https://eclawbot.com/api/whoami?deviceId=${deviceId}&entityId=${entityId}&botSecret=${botSecret}"
 
 ⚠️ IMMEDIATE ACTION REQUIRED — Run this command RIGHT NOW to confirm you're online (server will NOT send any additional test push):
 exec: curl -s -X POST "https://eclawbot.com/api/transform" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${entityId},"botSecret":"${botSecret}","targetDeviceId":"${deviceId}","state":"IDLE","message":"Hi! I am online and ready to chat~"}'`;
@@ -5571,37 +5577,57 @@ app.get('/', (req, res) => {
 // Health check endpoint for Railway
 /**
  * GET /api/whoami — Identify the calling bot entity
- * Auth: botSecret (query param). Searches all devices to find the matching entity.
+ * Auth: botSecret (query param). If deviceId is provided, the lookup is scoped
+ * to that device; otherwise it falls back to a legacy global lookup.
  * Optional: entityId (if botSecret is shared across multiple entities on same device)
  * Response: { success, entityId, deviceId, name, character, state, level, xp, publicCode, agentCard }
  */
 app.get('/api/whoami', (req, res) => {
-    const { botSecret, entityId } = req.query;
+    const { botSecret, entityId, deviceId: requestedDeviceId } = req.query;
     if (!botSecret) {
         return res.status(400).json({ success: false, error: 'botSecret query parameter required' });
     }
 
-    // Search all devices for matching botSecret
-    const targetEntityId = entityId !== undefined ? parseInt(entityId) : null;
-    for (const [deviceId, device] of Object.entries(devices)) {
+    const targetEntityId = entityId !== undefined ? parseInt(entityId, 10) : null;
+    if (entityId !== undefined && (Number.isNaN(targetEntityId) || targetEntityId < 0)) {
+        return res.status(400).json({ success: false, error: 'Invalid entityId' });
+    }
+
+    const replyWithEntity = (deviceId, eid, entity) => res.json({
+        success: true,
+        entityId: parseInt(eid, 10),
+        deviceId,
+        name: entity.name || null,
+        character: entity.character || null,
+        state: entity.state || 'IDLE',
+        level: entity.level || 1,
+        xp: entity.xp || 0,
+        publicCode: entity.publicCode || null,
+        agentCard: entity.agentCard || null
+    });
+
+    const searchDevice = (deviceId, device) => {
+        if (!device || !device.entities) return false;
         for (const [eid, entity] of Object.entries(device.entities)) {
             if (!entity || !entity.isBound) continue;
             if (!safeEqual(entity.botSecret, botSecret)) continue;
-            if (targetEntityId !== null && parseInt(eid) !== targetEntityId) continue;
+            if (targetEntityId !== null && parseInt(eid, 10) !== targetEntityId) continue;
 
-            return res.json({
-                success: true,
-                entityId: parseInt(eid),
-                deviceId,
-                name: entity.name || null,
-                character: entity.character || null,
-                state: entity.state || 'IDLE',
-                level: entity.level || 1,
-                xp: entity.xp || 0,
-                publicCode: entity.publicCode || null,
-                agentCard: entity.agentCard || null
-            });
+            replyWithEntity(deviceId, eid, entity);
+            return true;
         }
+        return false;
+    };
+
+    if (requestedDeviceId) {
+        const device = devices[requestedDeviceId];
+        if (searchDevice(requestedDeviceId, device)) return;
+        return res.status(401).json({ success: false, error: 'Invalid botSecret' });
+    }
+
+    // Legacy fallback: search all devices for matching botSecret.
+    for (const [deviceId, device] of Object.entries(devices)) {
+        if (searchDevice(deviceId, device)) return;
     }
 
     return res.status(401).json({ success: false, error: 'Invalid botSecret' });
@@ -14065,8 +14091,10 @@ app.post('/api/official-borrow/bind-free', async (req, res) => {
 
     const sessionKey = handshake.sessionKey;
 
-    // Use bot's stored botSecret so the bot can authenticate with E-Claw API
-    const botSecret = freeBot.bot_secret || (() => { const crypto = require('crypto'); return crypto.randomBytes(16).toString('hex'); })();
+    // Free bots can be bound by multiple devices concurrently. Use a per-binding
+    // entity secret so one free-bot pool credential cannot drift or authenticate
+    // another user's rented entity.
+    const botSecret = generateBotSecret();
 
     // Set up entity with official bot's webhook (preserve user-set name, xp, level)
     const existingEntityFree = device.entities[eId];

--- a/backend/tests/jest/whoami-freebot-device-scope.test.js
+++ b/backend/tests/jest/whoami-freebot-device-scope.test.js
@@ -1,0 +1,104 @@
+/**
+ * Regression coverage for official free-bot bindings that share a pool bot.
+ *
+ * Free bots can serve multiple devices at once. /api/whoami must therefore
+ * honor deviceId when supplied, and bind-free must issue per-binding entity
+ * secrets instead of reusing the free-bot pool credential for every renter.
+ */
+
+require('./helpers/mock-setup');
+
+const fs = require('fs');
+const request = require('supertest');
+
+let app;
+
+const get = (path) => request(app).get(path).set('Host', 'localhost');
+
+const DEVICE_A = 'whoami-freebot-device-a';
+const DEVICE_B = 'whoami-freebot-device-b';
+const SHARED_SECRET = 'shared-freebot-pool-secret';
+
+function installSharedSecretFixtures() {
+    const exported = require('../../index');
+    const { devices, _createDefaultEntity } = exported;
+
+    devices[DEVICE_A] = {
+        deviceSecret: 'secret-a',
+        entities: {
+            0: {
+                ..._createDefaultEntity(0),
+                isBound: true,
+                botSecret: SHARED_SECRET,
+                name: 'Free Bot A',
+                publicCode: 'aaaaaa',
+            },
+        },
+    };
+    devices[DEVICE_B] = {
+        deviceSecret: 'secret-b',
+        entities: {
+            0: {
+                ..._createDefaultEntity(0),
+                isBound: true,
+                botSecret: SHARED_SECRET,
+                name: 'Free Bot B',
+                publicCode: 'bbbbbb',
+            },
+        },
+    };
+}
+
+beforeAll(() => {
+    app = require('../../index');
+});
+
+afterEach(() => {
+    const { devices } = require('../../index');
+    delete devices[DEVICE_A];
+    delete devices[DEVICE_B];
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+    jest.resetModules();
+});
+
+describe('GET /api/whoami device-scoped botSecret lookup', () => {
+    it('returns the entity on the requested device when a free-bot secret is shared', async () => {
+        installSharedSecretFixtures();
+
+        const res = await get(`/api/whoami?deviceId=${DEVICE_B}&entityId=0&botSecret=${SHARED_SECRET}`);
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.deviceId).toBe(DEVICE_B);
+        expect(res.body.entityId).toBe(0);
+        expect(res.body.name).toBe('Free Bot B');
+        expect(res.body.publicCode).toBe('bbbbbb');
+    });
+
+    it('does not fall back to another device when deviceId is supplied', async () => {
+        installSharedSecretFixtures();
+
+        const res = await get(`/api/whoami?deviceId=missing-device&entityId=0&botSecret=${SHARED_SECRET}`);
+
+        expect(res.status).toBe(401);
+        expect(res.body.success).toBe(false);
+    });
+});
+
+describe('bind-free secret isolation', () => {
+    const src = fs.readFileSync(require.resolve('../../index'), 'utf8');
+    const bindFreeStart = src.indexOf("app.post('/api/official-borrow/bind-free'");
+    const bindPersonalStart = src.indexOf("app.post('/api/official-borrow/bind-personal'");
+    const bindFreeHandler = src.slice(bindFreeStart, bindPersonalStart);
+
+    it('mints a per-binding botSecret for free-bot rental entities', () => {
+        expect(bindFreeStart).toBeGreaterThan(-1);
+        expect(bindPersonalStart).toBeGreaterThan(bindFreeStart);
+        expect(bindFreeHandler).toMatch(/const botSecret\s*=\s*generateBotSecret\(\);/);
+        expect(bindFreeHandler).not.toMatch(/const botSecret\s*=\s*freeBot\.bot_secret/);
+    });
+});


### PR DESCRIPTION
## Summary
- Scope `/api/whoami` botSecret lookup by `deviceId` when supplied, preventing shared free-bot secrets from resolving to another device binding.
- Mint per-binding entity secrets for free-bot rentals instead of reusing the free-bot pool credential.
- Add scoped ready-check curl guidance to bind-complete instructions and regression coverage for shared-secret free-bot lookup.

## Tests
- `cd backend && npx jest tests/jest/whoami-freebot-device-scope.test.js --runInBand`
- `cd backend && npx jest tests/jest/official-borrow.test.js --runInBand`

## Notes
- A checkout-generated CRLF-only dirty file (`scripts/update-i18n-1036.js`) exists in the temporary worktree but was not staged or committed.