### PR TITLE
feat(ai-support): pass per-request caller creds to claude-cli-proxy /chat (H3 Phase 2)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -34,6 +34,24 @@ VOYAGE_API_KEY=
 CLAUDE_CLI_PROXY_URL=http://claude-cli-proxy.railway.internal:4000
 SUPPORT_API_KEY=your-shared-secret-here
 
+# Claude CLI proxy — per-request caller credentials (H3 multi-tenant).
+# When both CALLER_DEVICE_ID and CALLER_BOT_SECRET are set, the backend sends
+# them on every POST /chat so the proxy fetches THIS deployment's GitHub PAT
+# from its vault (/api/device-vars) instead of using its own boot-time env
+# token. Leave unset to keep legacy single-tenant behavior (the proxy will
+# fall back to EVAULT_LEGACY_BOOT_CLONE env-token path).
+CLAUDE_PROXY_CALLER_DEVICE_ID=
+CLAUDE_PROXY_CALLER_BOT_SECRET=
+# Optional overrides — proxy defaults are used when these are unset.
+# REPO_HOST_PATH form: github.com/<org>/<repo>.git
+CLAUDE_PROXY_REPO_HOST_PATH=
+# Vault key to read the GitHub PAT from (e.g. GIT_HUB2). When unset, proxy
+# tries org-scoped keys (GIT_HUB2_<ORG>, GITHUB_TOKEN_<ORG>) then global.
+CLAUDE_PROXY_VAULT_KEY=
+# Comma-separated org allowlist; refuses /chat when repo_host_path falls
+# outside this list. When unset, proxy uses its REPO_ALLOWED_ORGS default.
+CLAUDE_PROXY_ALLOWED_ORGS=
+
 # OAuth Social Login
 GOOGLE_CLIENT_ID=your-google-client-id.apps.googleusercontent.com
 FACEBOOK_APP_ID=your-facebook-app-id

--- a/backend/ai-support.js
+++ b/backend/ai-support.js
@@ -87,6 +87,26 @@ module.exports = function (devices, chatPool, { serverLog, getWebhookFixInstruct
         }
     }, 1800000);
 
+    // ── claude-cli-proxy per-request caller auth (H3 multi-tenant) ──
+    // Returns the extra ChatRequest fields the proxy uses to fetch THIS
+    // tenant's GitHub PAT from their own vault instead of falling through
+    // to the proxy's legacy EVAULT_LEGACY_BOOT_CLONE env-token path.
+    // Returns {} when the deployment hasn't configured caller creds, so the
+    // proxy keeps its legacy env-token behavior until the env vars land.
+    function proxyCallerAuthFields() {
+        const callerDeviceId = process.env.CLAUDE_PROXY_CALLER_DEVICE_ID || '';
+        const callerBotSecret = process.env.CLAUDE_PROXY_CALLER_BOT_SECRET || '';
+        if (!callerDeviceId || !callerBotSecret) return {};
+        const fields = {
+            caller_device_id: callerDeviceId,
+            caller_bot_secret: callerBotSecret,
+        };
+        if (process.env.CLAUDE_PROXY_REPO_HOST_PATH) fields.repo_host_path = process.env.CLAUDE_PROXY_REPO_HOST_PATH;
+        if (process.env.CLAUDE_PROXY_VAULT_KEY) fields.vault_key = process.env.CLAUDE_PROXY_VAULT_KEY;
+        if (process.env.CLAUDE_PROXY_ALLOWED_ORGS) fields.allowed_orgs = process.env.CLAUDE_PROXY_ALLOWED_ORGS;
+        return fields;
+    }
+
     // ── Auto-create GitHub issue (for AI-initiated actions) ──
     async function autoCreateIssue(action, user) {
         const token = process.env.GITHUB_TOKEN;
@@ -1283,7 +1303,8 @@ module.exports = function (devices, chatPool, { serverLog, getWebhookFixInstruct
                         role: isAdmin ? 'admin' : 'user',
                         email: req.user.email,
                         diagnostics: deviceDiag
-                    }
+                    },
+                    ...proxyCallerAuthFields()
                 }),
                 signal: AbortSignal.timeout(130000)
             });
@@ -1496,7 +1517,8 @@ module.exports = function (devices, chatPool, { serverLog, getWebhookFixInstruct
                 body: JSON.stringify({
                     message: proxyMessage,
                     history,
-                    device_context: { ...ctx, diagnostics: deviceDiag }
+                    device_context: { ...ctx, diagnostics: deviceDiag },
+                    ...proxyCallerAuthFields()
                 }),
                 signal: controller.signal
             });


### PR DESCRIPTION
## Summary

Phase 1 (PR #2937) made `proxy.py` resolve auth per-request — but only when the caller passes the new optional `ChatRequest` fields. Until now the EClaw backend kept sending the legacy payload, so every request fell through to the proxy's `EVAULT_LEGACY_BOOT_CLONE` env-token path.

This PR wires the backend to populate those fields:

- **New helper** `proxyCallerAuthFields()` in `backend/ai-support.js` reads `CLAUDE_PROXY_CALLER_DEVICE_ID` + `CLAUDE_PROXY_CALLER_BOT_SECRET` (and optional `REPO_HOST_PATH` / `VAULT_KEY` / `ALLOWED_ORGS` overrides) and returns the dict to merge into the `/chat` POST body.
- **Both `/chat` call sites** (`POST /chat` and `POST /chat?stream=1`) now spread the helper's fields into the JSON body.
- **Safe rollout:** helper returns `{}` when env vars aren't set, so deployments that haven't been reconfigured stay on the legacy env-token path — no breaking change.
- `backend/.env.example` documents the new vars + the rollout semantics.

## Why

Per Hank's `feedback_platform_user_rule_compliance` directive: every EClaw feature must work for **all** worldwide device-owners with no carveouts. Phase 1 gave the proxy the *capability* for per-request multi-tenant auth; this PR makes the backend actually *use* it.

## Rollout

This PR can ship before Railway env is configured (legacy path stays active). Sequence:

1. **Merge this PR** → backend deploys, helper returns `{}` until env vars are set, behavior unchanged.
2. **Set Railway env vars on EClaw backend** (`card_ee7bab784d737b6fd0b9db39`, currently blocked):
   - `CLAUDE_PROXY_CALLER_DEVICE_ID`
   - `CLAUDE_PROXY_CALLER_BOT_SECRET`
   - (optional) `CLAUDE_PROXY_REPO_HOST_PATH`, `CLAUDE_PROXY_VAULT_KEY`, `CLAUDE_PROXY_ALLOWED_ORGS`
3. **Smoke test:** hit `/api/ai-support/proxy-status` (forwards proxy `/health`) — should report `mode: "multi-tenant"` and `activeTenants >= 1` (legacy boot-clone counts as one).
4. **24h stable** with `vault:<key>` prefix in proxy logs → flip `EVAULT_LEGACY_BOOT_CLONE=0` on the proxy.
5. **Drop env-token fallback** in `proxy.py` (followup PR).

## Test plan

- [x] Helper logic unit-tested in isolation: empty env → `{}`, partial creds → `{}`, full minimal → 2 fields, full opts → 5 fields
- [x] `node --check` clean; `vm.Script` parse-test passes on the modified module
- [x] Helper is called from exactly 2 spots (`POST /chat` and `POST /chat?stream=1`); no other proxy endpoints affected
- [ ] CI Jest suite (`backend/tests/jest/ai-support*.test.js`) — no helper-specific tests added; existing tests already cover the `/chat` shape
- [ ] **Followup (after Railway env vars):** hit `/api/ai-support/proxy-status` from prod; confirm `repo.mode=multi-tenant` and `activeTenants >= 2` after two distinct callers
- [ ] **Followup:** check proxy logs for `[Vault] device=…` lines instead of the env-token boot-clone log

## Refs

- Closes `card_3c9deab486202d1efee61f2f` (H3 Phase 2)
- Phase 1: PR #2937 / `card_4dde8ccc247c9fa19e8f1c49`
- Railway env coord: `card_ee7bab784d737b6fd0b9db39`

🤖 Generated with [Claude Code](https://claude.com/claude-code)