### PR TITLE
fix(portal): mobile delete-modal clipped right edge (P0)

### DIFF
--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -135,6 +135,10 @@
             background: var(--card-border);
             color: var(--text-secondary);
             flex-shrink: 0;
+            max-width: 40%;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
         }
 
         .item-detail {

--- a/backend/public/portal/shared/style.css
+++ b/backend/public/portal/shared/style.css
@@ -61,6 +61,11 @@
 
 * { box-sizing: border-box; margin: 0; padding: 0; }
 
+html, body {
+    overflow-x: hidden;
+    max-width: 100vw;
+}
+
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
     background: var(--bg);
@@ -910,12 +915,17 @@ a:hover { text-decoration: underline; }
    ========================================== */
 .dialog-overlay {
     position: fixed;
-    inset: 0;
+    top: 0;
+    left: 0;
+    width: 100vw;
+    width: 100dvw;
+    height: 100vh;
+    height: 100dvh;
     background: rgba(0, 0, 0, 0.6);
     display: flex;
     align-items: center;
     justify-content: center;
-    z-index: 300;
+    z-index: 600;
 }
 
 .dialog {
@@ -1112,7 +1122,7 @@ a:hover { text-decoration: underline; }
 
     /* Dialog — mobile bottom-sheet */
     .dialog-overlay { align-items: flex-end; }
-    .dialog { padding: 16px; min-width: auto; max-height: 85vh; max-height: 85dvh; border-radius: var(--radius) var(--radius) 0 0; width: 100vw; max-width: 100vw; }
+    .dialog { padding: 16px; min-width: auto; max-height: 85vh; max-height: 85dvh; border-radius: var(--radius) var(--radius) 0 0; width: 100%; max-width: 100%; }
     .dialog-actions { flex-direction: column; }
     .dialog-actions .btn { width: 100%; justify-content: center; }
 


### PR DESCRIPTION
## Summary
- P0: Hank reported 2026-05-25 19:57 — tapping X on a note card → 「確定刪除？」 popup overflows viewport right edge on mobile, Cancel/OK half-cut.
- Root cause: `.item-badge` `flex-shrink:0` with no truncate let long note content inflate mission page to **892px wide on a 375px viewport**. iOS Safari `position:fixed` follows the layout viewport when the page horizontally overflows, so the centered modal extended offscreen.
- Hardened on first fix — 4 stacked layers (overflow guard / explicit dvw modal / mobile width:100% / badge truncate) + z-index bump (300 → 600) so `aiChatFab` no longer covers OK at the bottom-sheet position.

## What changed
- `shared/style.css`
  - `html, body { overflow-x: hidden; max-width: 100vw }` — global guard so any future content overflow can't push fixed elements offscreen
  - `.dialog-overlay`: replaced `inset:0` with explicit `top:0; left:0; width:100dvw; height:100dvh` (and `100vw/100vh` fallback) — sizes to **visual** viewport, not layout
  - mobile `.dialog`: `width:100vw → width:100%` (parent-bounded; vw on iOS includes overflow)
  - `.dialog-overlay` z-index `300 → 600` (above `aiChatFab` z-index 500)
- `mission.html`
  - `.item-badge` adds `max-width:40%; overflow:hidden; text-overflow:ellipsis; white-space:nowrap` — fixes the actual content-overflow source

## Verification (390x844 Playwright)
- **Before:** modal Cancel/OK clipped right; horizontal scrollbar; doc width 892px
- **After v4 (CSS only):** modal full-width, no clip; but `aiChatFab` still covered OK
- **After v5 (z-index 600):** Cancel + OK fully visible, no FAB overlap, no horizontal scroll

Screenshots will be attached via card comment (chat-only artifacts).

## Test plan
- [x] Playwright 390x844 baseline repro (clipped)
- [x] Playwright 390x844 after-fix (full visibility)
- [ ] iOS sim verify on iPhone 17 Pro after merge (U01)
- [ ] Add destructive-modals to daily E2E whitelist (follow-up card)

## Card
- `card_002b6ae0ba63ed945a7a1b69` — moving to `review` on PR open

🤖 Generated with [Claude Code](https://claude.com/claude-code)