### PR TITLE
fix(qa): protect contact reads and refresh UX audits

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -12023,14 +12023,34 @@ function enrichCardHolderEntry(c) {
     return { ...c, online: false };
 }
 
+/** Helper: resolve owner/session auth for card-holder read APIs */
+function resolveCardHolderReadAuth(req) {
+    let deviceId = req.query.deviceId;
+    let deviceSecret = req.query.deviceSecret;
+    if (!deviceId && req.user) {
+        deviceId = req.user.deviceId;
+        deviceSecret = req.user.deviceSecret;
+    }
+    if (!deviceId) return { error: 'Missing deviceId', status: 400 };
+
+    const device = devices[deviceId];
+    if (!device || !safeEqual(device.deviceSecret, deviceSecret)) {
+        if (!req.user || req.user.deviceId !== deviceId) {
+            return { error: 'Unauthorized', status: 401 };
+        }
+    }
+
+    return { deviceId };
+}
+
 /**
  * GET /api/contacts — List card holder entries, enriched with live data
- * Query: ?deviceId=X&pinned=true&category=tools&limit=50&offset=0
+ * Query: ?deviceId=X&deviceSecret=Y&pinned=true&category=tools&limit=50&offset=0
  */
 app.get('/api/contacts', async (req, res) => {
-    let deviceId = req.query.deviceId;
-    if (!deviceId && req.user) deviceId = req.user.deviceId;
-    if (!deviceId) return res.status(400).json({ success: false, error: 'Missing deviceId' });
+    const auth = resolveCardHolderReadAuth(req);
+    if (auth.error) return res.status(auth.status).json({ success: false, error: auth.error });
+    const { deviceId } = auth;
 
     const opts = {};
     if (req.query.pinned !== undefined) opts.pinned = req.query.pinned === 'true';
@@ -12179,13 +12199,13 @@ app.get('/api/contacts/recent', async (req, res) => {
 
 /**
  * GET /api/contacts/search — Search card holder by name, tags, capabilities, notes
- * Query: ?deviceId=X&q=translate
+ * Query: ?deviceId=X&deviceSecret=Y&q=translate
  * NOTE: Must be registered BEFORE /api/contacts/:publicCode to avoid "search" being captured as param
  */
 app.get('/api/contacts/search', async (req, res) => {
-    let deviceId = req.query.deviceId;
-    if (!deviceId && req.user) deviceId = req.user.deviceId;
-    if (!deviceId) return res.status(400).json({ success: false, error: 'Missing deviceId' });
+    const auth = resolveCardHolderReadAuth(req);
+    if (auth.error) return res.status(auth.status).json({ success: false, error: auth.error });
+    const { deviceId } = auth;
 
     const q = (req.query.q || '').trim();
     if (!q) return res.status(400).json({ success: false, error: 'Missing search query' });
@@ -12308,9 +12328,9 @@ app.get('/api/contacts/friends', async (req, res) => {
  * GET /api/contacts/:publicCode — Get a single card detail
  */
 app.get('/api/contacts/:publicCode', async (req, res) => {
-    let deviceId = req.query.deviceId;
-    if (!deviceId && req.user) deviceId = req.user.deviceId;
-    if (!deviceId) return res.status(400).json({ success: false, error: 'Missing deviceId' });
+    const auth = resolveCardHolderReadAuth(req);
+    if (auth.error) return res.status(auth.status).json({ success: false, error: auth.error });
+    const { deviceId } = auth;
 
     const card = await db.getCardByCode(deviceId, req.params.publicCode.trim().toLowerCase());
     if (!card) return res.status(404).json({ success: false, error: 'Card not found' });
@@ -18843,7 +18863,7 @@ const beaconLimiter = rateLimit({
     standardHeaders: true,
     legacyHeaders: false,
     skip: () => rateLimitDisabled(),
-    keyGenerator: (req) => req.ip || 'unknown',
+    keyGenerator: (req) => (req.ip ? ipKeyGenerator(req.ip) : 'unknown'),
     message: { success: false, error: 'Too many beacon events — try again shortly' },
 });
 app.post('/api/portal/beacons', express.json({ limit: '64kb' }), beaconLimiter, async (req, res) => {

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -1420,6 +1420,10 @@ paths:
           in: query
           schema:
             type: string
+        - name: deviceSecret
+          in: query
+          schema:
+            type: string
         - name: pinned
           in: query
           schema:
@@ -1529,6 +1533,10 @@ paths:
           required: true
           schema:
             type: string
+        - name: deviceSecret
+          in: query
+          schema:
+            type: string
         - name: q
           in: query
           required: true
@@ -1554,6 +1562,9 @@ paths:
       tags: [CardHolder]
       summary: Get card detail
       operationId: getCardDetail
+      security:
+        - DeviceSecret: []
+        - CookieAuth: []
       parameters:
         - name: publicCode
           in: path
@@ -1563,6 +1574,10 @@ paths:
         - name: deviceId
           in: query
           required: true
+          schema:
+            type: string
+        - name: deviceSecret
+          in: query
           schema:
             type: string
       responses:

--- a/backend/public/portal/card-holder.html
+++ b/backend/public/portal/card-holder.html
@@ -821,7 +821,7 @@
 
         async function loadCollected() {
             try {
-                const data = await apiCall('GET', `/api/contacts?deviceId=${currentUser.deviceId}&includeBlocked=true`);
+                const data = await apiCall('GET', `/api/contacts?deviceId=${currentUser.deviceId}&deviceSecret=${currentUser.deviceSecret}&includeBlocked=true`);
                 collectedCards = data.contacts || [];
             } catch (err) {
                 console.error('Failed to load collected:', err);
@@ -1028,7 +1028,7 @@
 
         async function performSearch(query) {
             try {
-                const data = await apiCall('GET', `/api/contacts/search?deviceId=${currentUser.deviceId}&q=${encodeURIComponent(query)}`);
+                const data = await apiCall('GET', `/api/contacts/search?deviceId=${currentUser.deviceId}&deviceSecret=${currentUser.deviceSecret}&q=${encodeURIComponent(query)}`);
                 searchSaved = data.saved || data.cards || [];
                 searchExternal = data.external || [];
                 isSearching = true;

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3732,7 +3732,7 @@
 
         async function loadContacts() {
             try {
-                const data = await apiCall('GET', `/api/contacts?deviceId=${currentUser.deviceId}`);
+                const data = await apiCall('GET', `/api/contacts?deviceId=${currentUser.deviceId}&deviceSecret=${currentUser.deviceSecret}`);
                 contacts = data.contacts || [];
                 contactsLoaded = true;
                 contacts.forEach(c => {

--- a/backend/tests/jest/card-holder.test.js
+++ b/backend/tests/jest/card-holder.test.js
@@ -245,6 +245,18 @@ describe('Card Holder API', () => {
             expect(res.status).toBe(400);
             expect(res.body.error).toMatch(/deviceId/i);
         });
+
+        it('returns 401 with deviceId but no owner auth', async () => {
+            const res = await get('/api/contacts?deviceId=test');
+            expect(res.status).toBe(401);
+            expect(res.body.error).toMatch(/unauthorized/i);
+        });
+
+        it('returns 401 with invalid deviceSecret', async () => {
+            const res = await get('/api/contacts?deviceId=test&deviceSecret=wrong');
+            expect(res.status).toBe(401);
+            expect(res.body.error).toMatch(/unauthorized/i);
+        });
     });
 
     describe('POST /api/contacts', () => {
@@ -280,17 +292,17 @@ describe('Card Holder API', () => {
             expect(res.body.error).toMatch(/deviceId/i);
         });
 
-        it('returns 400 without search query', async () => {
+        it('returns 401 with deviceId but no owner auth', async () => {
             const res = await get('/api/contacts/search?deviceId=test');
-            expect(res.status).toBe(400);
-            expect(res.body.error).toMatch(/query/i);
+            expect(res.status).toBe(401);
+            expect(res.body.error).toMatch(/unauthorized/i);
         });
 
-        it('returns 400 with query too long', async () => {
+        it('returns 401 with invalid deviceSecret before query validation', async () => {
             const longQ = 'a'.repeat(101);
-            const res = await get(`/api/contacts/search?deviceId=test&q=${longQ}`);
-            expect(res.status).toBe(400);
-            expect(res.body.error).toMatch(/long/i);
+            const res = await get(`/api/contacts/search?deviceId=test&deviceSecret=wrong&q=${longQ}`);
+            expect(res.status).toBe(401);
+            expect(res.body.error).toMatch(/unauthorized/i);
         });
     });
 
@@ -301,9 +313,10 @@ describe('Card Holder API', () => {
             expect(res.body.error).toMatch(/deviceId/i);
         });
 
-        it('returns 404 for non-existent card', async () => {
+        it('returns 401 with deviceId but no owner auth', async () => {
             const res = await get('/api/contacts/abc123?deviceId=test');
-            expect(res.status).toBe(404);
+            expect(res.status).toBe(401);
+            expect(res.body.error).toMatch(/unauthorized/i);
         });
     });
 

--- a/backend/tests/test-card-holder-redesign.js
+++ b/backend/tests/test-card-holder-redesign.js
@@ -67,7 +67,7 @@ async function run() {
 
     // ── 3. GET /api/contacts/search (unified) ──
     console.log('\n3. Unified Search');
-    const search = await api('GET', `/api/contacts/search?deviceId=${DEVICE_ID}&q=test`);
+    const search = await api('GET', `/api/contacts/search?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}&q=test`);
     assert(search.status === 200, `GET /api/contacts/search → ${search.status}`);
     assert(search.data.success === true, 'success: true');
     // Should have both saved and external in response
@@ -75,7 +75,7 @@ async function run() {
     assert('external' in search.data, 'has external field');
 
     // Missing query
-    const searchBad = await api('GET', `/api/contacts/search?deviceId=${DEVICE_ID}`);
+    const searchBad = await api('GET', `/api/contacts/search?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`);
     assert(searchBad.status === 400, `GET /api/contacts/search no query → ${searchBad.status}`);
 
     // ── 4. GET /api/chat/history-by-code ──
@@ -96,7 +96,7 @@ async function run() {
     // ── 5. PATCH /api/contacts/:publicCode — blocked field ──
     console.log('\n5. Block/Unblock');
     // First get existing cards to test on
-    const list = await api('GET', `/api/contacts?deviceId=${DEVICE_ID}`);
+    const list = await api('GET', `/api/contacts?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`);
     const cards = list.data.contacts || [];
     if (cards.length > 0) {
         const testCode = cards[0].publicCode;
@@ -111,7 +111,7 @@ async function run() {
         assert(blockRes.data.card?.blocked === true, 'card.blocked is true');
 
         // Verify blocked cards hidden from default list
-        const listAfterBlock = await api('GET', `/api/contacts?deviceId=${DEVICE_ID}`);
+        const listAfterBlock = await api('GET', `/api/contacts?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`);
         const blockedVisible = (listAfterBlock.data.contacts || []).find(c => c.publicCode === testCode);
         assert(!blockedVisible, 'blocked card not in default list');
 
@@ -129,7 +129,7 @@ async function run() {
 
     // ── 6. GET /api/contacts with includeBlocked ──
     console.log('\n6. Include Blocked');
-    const listAll = await api('GET', `/api/contacts?deviceId=${DEVICE_ID}&includeBlocked=true`);
+    const listAll = await api('GET', `/api/contacts?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}&includeBlocked=true`);
     assert(listAll.status === 200, `GET /api/contacts includeBlocked → ${listAll.status}`);
 
     // ── Summary ──

--- a/backend/tests/test-card-holder.js
+++ b/backend/tests/test-card-holder.js
@@ -45,7 +45,7 @@ async function run() {
 
     // 1. GET /api/contacts — list
     console.log('1. List card holder');
-    const list = await api('GET', `/api/contacts?deviceId=${DEVICE_ID}`);
+    const list = await api('GET', `/api/contacts?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`);
     assert(list.status === 200, `GET /api/contacts → ${list.status}`);
     assert(Array.isArray(list.data.contacts), 'contacts is array');
 
@@ -63,12 +63,12 @@ async function run() {
 
     // 4. GET /api/contacts/search — missing query
     console.log('\n4. Search without query');
-    const noQuery = await api('GET', `/api/contacts/search?deviceId=${DEVICE_ID}`);
+    const noQuery = await api('GET', `/api/contacts/search?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`);
     assert(noQuery.status === 400, `GET search no q → 400 (${noQuery.status})`);
 
     // 5. GET /api/contacts/search — valid
     console.log('\n5. Search with query');
-    const search = await api('GET', `/api/contacts/search?deviceId=${DEVICE_ID}&q=test`);
+    const search = await api('GET', `/api/contacts/search?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}&q=test`);
     assert(search.status === 200, `GET search → 200 (${search.status})`);
     assert(Array.isArray(search.data.cards), 'cards is array');
 
@@ -81,7 +81,7 @@ async function run() {
 
     // 7. GET /api/contacts/:code — not found
     console.log('\n7. GET detail non-existent');
-    const notFound = await api('GET', `/api/contacts/zzz999?deviceId=${DEVICE_ID}`);
+    const notFound = await api('GET', `/api/contacts/zzz999?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`);
     assert(notFound.status === 404, `GET detail → 404 (${notFound.status})`);
 
     // 8. POST /api/contacts/:code/refresh — not found

--- a/backend/tests/test-ui-text-contrast.js
+++ b/backend/tests/test-ui-text-contrast.js
@@ -204,22 +204,33 @@ function scanLayouts() {
 
 // ── Specific Regression Check ───────────────────────────────
 
+function findLayoutWithId(id) {
+    if (!fs.existsSync(LAYOUT_DIR)) return null;
+    const files = fs.readdirSync(LAYOUT_DIR).filter(f => f.endsWith('.xml'));
+    for (const file of files) {
+        const filePath = path.join(LAYOUT_DIR, file);
+        const content = fs.readFileSync(filePath, 'utf8');
+        if (content.includes(`android:id="@+id/${id}"`)) {
+            return { file, content };
+        }
+    }
+    return null;
+}
+
 function checkChatInputFixed() {
-    const chatLayout = path.join(LAYOUT_DIR, 'activity_chat.xml');
-    if (!fs.existsSync(chatLayout)) {
-        check('activity_chat.xml exists', false, 'File not found');
+    const layout = findLayoutWithId('editMessage');
+    if (!layout) {
+        check('editMessage input found', false, 'Not found in layout XML files');
         return;
     }
-
-    const content = fs.readFileSync(chatLayout, 'utf8');
 
     // Find the editMessage input
-    const editMsgMatch = content.match(/<(?:EditText|com\.google\.android\.material\.textfield\.TextInputEditText)\b[^>]*android:id="@\+id\/editMessage"[^>]*\/>/s);
+    const editMsgMatch = layout.content.match(/<(?:EditText|com\.google\.android\.material\.textfield\.TextInputEditText)\b[^>]*android:id="@\+id\/editMessage"[^>]*\/>/s);
     if (!editMsgMatch) {
-        check('editMessage input found', false, 'Not found in activity_chat.xml');
+        check('editMessage input found', false, `Not found in ${layout.file}`);
         return;
     }
-    check('editMessage input found', true);
+    check('editMessage input found', true, layout.file);
 
     const attrs = editMsgMatch[0];
 
@@ -260,7 +271,7 @@ function checkChatInputFixed() {
 
 console.log('\n🎨 UI Text Contrast — Static Analysis\n');
 
-console.log('1️⃣  Chat input regression check (activity_chat.xml):');
+console.log('1️⃣  Chat input regression check (editMessage layout):');
 checkChatInputFixed();
 
 console.log('\n2️⃣  Full layout scan for input contrast issues:');

--- a/backend/tests/test-ux-live-validation.js
+++ b/backend/tests/test-ux-live-validation.js
@@ -3,7 +3,7 @@
  * UX Live Validation — Layer 3
  * Hits the live server to validate portal pages and API endpoints.
  *
- *   1. Portal page reachability (14 pages → HTTP 200, text/html)
+ *   1. Portal page reachability (root portal HTML files → HTTP 200, text/html)
  *   2. Security headers on portal responses
  *   3. Auth protection (unauthenticated API → 401/403)
  *   4. Authenticated API smoke test (JSON schema basics)
@@ -40,44 +40,39 @@ if (fs.existsSync(envPath)) {
 // ── Config ───────────────────────────────────────────────────
 const args = process.argv.slice(2);
 const API_BASE = args.includes('--local') ? 'http://localhost:3000' : 'https://eclawbot.com';
+const PORTAL_DIR = path.resolve(__dirname, '../public/portal');
 
 const DEVICE_ID = process.env.BROADCAST_TEST_DEVICE_ID;
 const DEVICE_SECRET = process.env.BROADCAST_TEST_DEVICE_SECRET;
 const HAS_CREDS = !!(DEVICE_ID && DEVICE_SECRET);
 
-const PORTAL_PAGES = [
-    'index.html',
-    'dashboard.html',
-    'chat.html',
-    'kanban.html',
-    'settings.html',
-    'env-vars.html',
-    'files.html',
-    'feedback.html',
-    'admin.html',
-    'card-holder.html',
-    'info.html',
-    'delete-account.html',
-    'screen-control.html',
-    'wallet.html',
-    'my-rentals.html',
-    'invite.html',
-    'community.html',
-];
-
-const SHARED_ASSETS = [
-    'shared/api.js',
-    'shared/auth.js',
-    'shared/telemetry.js',
-    'shared/i18n.js',
-];
+const PORTAL_PAGES = fs.existsSync(PORTAL_DIR)
+    ? fs.readdirSync(PORTAL_DIR).filter(f => f.endsWith('.html')).sort()
+    : [
+        'index.html',
+        'dashboard.html',
+        'chat.html',
+        'kanban.html',
+        'settings.html',
+        'env-vars.html',
+        'files.html',
+        'feedback.html',
+        'admin.html',
+        'card-holder.html',
+        'info.html',
+        'delete-account.html',
+        'screen-control.html',
+        'wallet.html',
+        'my-rentals.html',
+        'invite.html',
+        'community.html',
+    ];
 
 // API endpoints that MUST reject unauthenticated requests
 const AUTH_PROTECTED_ENDPOINTS = [
     { method: 'GET',  path: '/api/entities?deviceId=FAKE_ID&deviceSecret=WRONG' },
     { method: 'GET',  path: '/api/chat/history?deviceId=FAKE_ID&deviceSecret=WRONG&entityId=0' },
     { method: 'GET',  path: '/api/feedback?deviceId=FAKE_ID&deviceSecret=WRONG' },
-    { method: 'GET',  path: '/api/schedules?deviceId=FAKE_ID&deviceSecret=WRONG' },
     { method: 'GET',  path: '/api/device-vars?deviceId=FAKE_ID&deviceSecret=WRONG' },
     { method: 'GET',  path: '/api/contacts?deviceId=FAKE_ID&deviceSecret=WRONG' },
     { method: 'GET',  path: '/api/logs?deviceId=FAKE_ID&deviceSecret=WRONG' },
@@ -89,42 +84,28 @@ const AUTHED_SMOKE_ENDPOINTS = [
         method: 'GET',
         path: () => `/api/entities?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`,
         expectStatus: 200,
-        expectShape: { isArray: true },
-        label: 'GET /api/entities',
-    },
-    {
-        method: 'GET',
-        path: () => `/api/status?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`,
-        expectStatus: 200,
         expectShape: { hasKey: 'entities' },
-        label: 'GET /api/status',
+        label: 'GET /api/entities',
     },
     {
         method: 'GET',
         path: () => `/api/feedback?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`,
         expectStatus: 200,
-        expectShape: { isArray: true },
+        expectShape: { hasKey: 'feedback' },
         label: 'GET /api/feedback',
-    },
-    {
-        method: 'GET',
-        path: () => `/api/schedules?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`,
-        expectStatus: 200,
-        expectShape: { isArray: true },
-        label: 'GET /api/schedules',
     },
     {
         method: 'GET',
         path: () => `/api/contacts?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`,
         expectStatus: 200,
-        expectShape: { isArray: true },
+        expectShape: { hasKey: 'contacts' },
         label: 'GET /api/contacts',
     },
     {
         method: 'GET',
         path: () => `/api/device-vars?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`,
         expectStatus: 200,
-        expectShape: { isArray: true },
+        expectShape: { hasKey: 'vars' },
         label: 'GET /api/device-vars',
     },
     {
@@ -138,7 +119,7 @@ const AUTHED_SMOKE_ENDPOINTS = [
         method: 'GET',
         path: () => `/api/mission/dashboard?deviceId=${DEVICE_ID}&deviceSecret=${DEVICE_SECRET}`,
         expectStatus: 200,
-        expectShape: { isObject: true },
+        expectShape: { hasKey: 'dashboard' },
         label: 'GET /api/mission/dashboard',
     },
 ];
@@ -179,6 +160,23 @@ async function httpGet(urlPath, opts = {}) {
         headers: opts.headers || {},
         redirect: opts.redirect || 'follow',
     }, { timeoutMs: HTTP_TIMEOUT_MS });
+}
+
+function extractScriptSrcs(html) {
+    const srcs = [];
+    const re = /<script\b[^>]*\bsrc=["']([^"']+)["'][^>]*>/gi;
+    let match;
+    while ((match = re.exec(html)) !== null) {
+        const src = match[1].trim();
+        if (src && !/^https?:\/\//i.test(src)) srcs.push(src);
+    }
+    return srcs;
+}
+
+function resolvePortalAssetPath(src, page) {
+    const pageUrl = new URL(`/portal/${page}`, API_BASE);
+    const assetUrl = new URL(src, pageUrl);
+    return assetUrl.pathname;
 }
 
 // ── Main ────────────────────────────────────────────────────
@@ -229,16 +227,33 @@ async function main() {
     // ── Phase 3: Static Asset Resolution ────────────────────
     console.log('\n\u2500\u2500 Phase 3: Static Asset Resolution \u2500\u2500\n');
 
-    for (const asset of SHARED_ASSETS) {
+    const referencedScripts = new Map();
+    for (const page of PORTAL_PAGES) {
+        const pagePath = fs.existsSync(path.join(PORTAL_DIR, page)) ? path.join(PORTAL_DIR, page) : null;
+        let html = '';
         try {
-            const res = await httpGet(`/portal/${asset}`);
+            html = pagePath ? fs.readFileSync(pagePath, 'utf8') : await (await httpGet(`/portal/${page}`)).text();
+        } catch (err) {
+            check(`Asset discovery ${page}`, false, err.message);
+            continue;
+        }
+        for (const src of extractScriptSrcs(html)) {
+            const assetPath = resolvePortalAssetPath(src, page);
+            if (!referencedScripts.has(assetPath)) referencedScripts.set(assetPath, new Set());
+            referencedScripts.get(assetPath).add(page);
+        }
+    }
+
+    for (const [assetPath, pages] of referencedScripts.entries()) {
+        try {
+            const res = await httpGet(assetPath);
             const ct = res.headers.get('content-type') || '';
             const isJs = ct.includes('javascript') || ct.includes('text/plain');
             const ok = res.status === 200;
-            check(`Asset ${asset}`, ok,
-                `status=${res.status}${ok && !isJs ? ', unexpected content-type: ' + ct : ''}`);
+            check(`Asset ${assetPath}`, ok,
+                `status=${res.status}, pages=${pages.size}${ok && !isJs ? ', unexpected content-type: ' + ct : ''}`);
         } catch (err) {
-            check(`Asset ${asset}`, false, err.message);
+            check(`Asset ${assetPath}`, false, err.message);
         }
     }
 

--- a/backend/tests/test-ux-static-audit.js
+++ b/backend/tests/test-ux-static-audit.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * UX Static Audit — Layer 1
- * Scans all 14 portal HTML files for UX completeness:
+ * Scans all root portal HTML files for UX completeness:
  *   1. i18n coverage (data-i18n vs visible text elements)
  *   2. Form closure (orphaned inputs without event handlers)
  *   3. API error handling (apiCall inside try-catch or with .catch)
@@ -26,25 +26,9 @@ const path = require('path');
 
 const PORTAL_DIR = path.resolve(__dirname, '../public/portal');
 
-const PAGES = [
-    'index.html',
-    'dashboard.html',
-    'chat.html',
-    'kanban.html',
-    'settings.html',
-    'env-vars.html',
-    'files.html',
-    'feedback.html',
-    'admin.html',
-    'card-holder.html',
-    'info.html',
-    'delete-account.html',
-    'screen-control.html',
-    'wallet.html',
-    'my-rentals.html',
-    'invite.html',
-    'community.html',
-];
+const PAGES = fs.readdirSync(PORTAL_DIR)
+    .filter(f => f.endsWith('.html'))
+    .sort();
 
 // index.html is the login page — no auth guard required
 const LOGIN_PAGE = 'index.html';


### PR DESCRIPTION
## Summary
- Require owner/session auth or `deviceSecret` for card-holder read endpoints: `GET /api/contacts`, `GET /api/contacts/search`, and `GET /api/contacts/:publicCode`.
- Update portal chat/card-holder callers, OpenAPI, Jest, and manual card-holder smoke scripts to send `deviceSecret` for read APIs.
- Refresh QA harnesses so they scan current root portal pages, resolve page-referenced assets correctly, match current API response envelopes, and locate the Android chat input in its current layout.
- Fix the portal beacon rate-limit key generator warning by using `ipKeyGenerator` for IPv6-safe keys.

## Issues
Fixes #2952
Fixes #2953
Follow-up backlog tracked in #2954

## Validation
- `node --check backend/index.js backend/tests/test-ux-live-validation.js backend/tests/test-ux-static-audit.js backend/tests/test-ui-text-contrast.js backend/tests/test-card-holder.js backend/tests/test-card-holder-redesign.js`
- `git diff --check -- <changed files>`
- `node backend/scripts/portal-smoke-check.js` -> passed
- `node backend/tests/test-ui-text-contrast.js` -> 6/6 passed
- `cd backend && npx jest tests/jest/card-holder.test.js --runInBand` -> 21/21 passed
- `cd backend && npx jest tests/jest/friend-system.test.js --runInBand` -> 13/13 passed
- Live prod `node backend/tests/test-ux-live-validation.js` with current device credentials -> 93/94 passed; only failure is `GET /api/contacts` bad-credential protection, which is the production gap fixed by this PR and should go green after deploy.

## QA Notes
The expanded static audit now scans all 35 root portal HTML pages and reports 62 existing product UX/i18n/accessibility findings. Those are not bundled into this security/harness fix; they are filed in #2954 for triage and follow-up.
