### PR TITLE
fix(channel): ack healthchecks before agent dispatch

### DIFF
--- a/openclaw-channel-eclaw/README.md
+++ b/openclaw-channel-eclaw/README.md
@@ -289,6 +289,24 @@ shape of `channels.eclaw` before runtime loads.
 3. In E-Claw Portal, confirm the entity shows as channel-bound (green dot)
 4. Check server logs: `curl "https://eclawbot.com/api/logs?deviceId=...&deviceSecret=...&limit=20"`
 
+### Healthcheck ACKs are routed through long-running agent work
+
+**Problem:**
+Fleet monitors send `ECLAW_HEALTHCHECK <nonce>` through the same browser/API
+message path as normal user chat. On GPT-backed OpenClaw projects, a busy or
+tool-heavy agent session can treat the healthcheck as ordinary work, run tools,
+or leave the entity message stuck at the client echo instead of replying
+`ACK <nonce>`. The E-Claw channel is healthy, but the monitor records repeated
+ACK failures.
+
+**Countermeasure:**
+- The webhook now detects `ECLAW_HEALTHCHECK <nonce>` before dispatching to the
+  OpenClaw agent and replies through the E-Claw channel with `ACK <nonce>`.
+- Model-health checks still go through the agent so model/reasoning policy is
+  validated independently from transport health.
+- After upgrading the plugin in an OpenClaw runtime, restart the owning
+  container/service and run both API ACK checks and browser chat ACK checks.
+
 ## Major Fix History
 
 A record of critical bug fixes, when they occurred, the problem, and the countermeasure.

--- a/openclaw-channel-eclaw/src/webhook-handler.ts
+++ b/openclaw-channel-eclaw/src/webhook-handler.ts
@@ -52,6 +52,14 @@ export function createWebhookHandler(
       const client = getClient(accountId);
       const conversationId = msg.conversationId || `${msg.deviceId}:${msg.entityId}`;
 
+      const directAck = String(msg.text || '').match(/^ECLAW_HEALTHCHECK\s+([A-Za-z0-9]+)\b/m);
+      if (directAck) {
+        if (client) {
+          await client.sendMessage(`ACK ${directAck[1]}`, 'IDLE');
+        }
+        return;
+      }
+
       // Capture event context for deliver routing
       const event = msg.event || 'message';
       const fromEntityId = msg.fromEntityId;

--- a/openclaw-channel-eclaw/test/webhook-handler.test.ts
+++ b/openclaw-channel-eclaw/test/webhook-handler.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createWebhookHandler } from '../src/webhook-handler.js';
+import { setPluginRuntime } from '../src/runtime.js';
+import { setClient } from '../src/outbound.js';
+
+describe('createWebhookHandler', () => {
+  it('acks healthcheck messages without dispatching agent work', async () => {
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn();
+    setPluginRuntime({
+      channel: {
+        reply: {
+          finalizeInboundContext: vi.fn(),
+          dispatchReplyWithBufferedBlockDispatcher,
+        },
+      },
+    });
+
+    const client = {
+      sendMessage: vi.fn().mockResolvedValue({ success: true }),
+    };
+    setClient('default', client as any);
+
+    const handler = createWebhookHandler('token', 'default', {});
+    const res = {
+      writeHead: vi.fn(),
+      end: vi.fn(),
+    };
+
+    await handler({
+      method: 'POST',
+      body: {
+        deviceId: 'device-1',
+        entityId: 0,
+        text: 'ECLAW_HEALTHCHECK abc123',
+      },
+    }, res);
+
+    expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'application/json' });
+    expect(res.end).toHaveBeenCalledWith(JSON.stringify({ ok: true }));
+    expect(client.sendMessage).toHaveBeenCalledWith('ACK abc123', 'IDLE');
+    expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Reply to ECLAW_HEALTHCHECK messages directly from the E-Claw channel webhook with ACK <nonce>
- Avoid routing transport healthchecks into long-running OpenClaw agent work
- Document the healthcheck behavior and add a vitest regression test

## Verification
- cd openclaw-channel-eclaw && npm run build
- cd openclaw-channel-eclaw && npm run lint
- cd openclaw-channel-eclaw && npm test