### PR TITLE
feat(version): add build_hash and build_time to /api/version

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -739,12 +739,14 @@ app.use('/mission', express.static(path.join(__dirname, 'public'), {
 // revalidation, so an unchanged src URL serves the pre-deploy bundle
 // well after a merge. Appending ?v=<sha> makes the URL change on every
 // deploy and invalidates both caches immediately.
-const SCRIPT_VERSION = (
+const BUILD_HASH = (
     process.env.RAILWAY_GIT_COMMIT_SHA ||
     process.env.GIT_COMMIT_SHA ||
     process.env.VERCEL_GIT_COMMIT_SHA ||
-    String(Date.now())
-).slice(0, 12);
+    ''
+);
+const BUILD_TIME = new Date().toISOString();
+const SCRIPT_VERSION = (BUILD_HASH || String(Date.now())).slice(0, 12);
 
 const isProductionRuntime = () =>
     process.env.NODE_ENV === 'production' || Boolean(process.env.RAILWAY_ENVIRONMENT);
@@ -6285,6 +6287,8 @@ app.get('/api/version', (req, res) => {
             portal: ['auth', 'dashboard', 'chat', 'mission', 'settings', 'subscription', 'i18n', 'avatar-picker'],
             android: ['auth', 'dashboard', 'chat', 'mission', 'settings', 'subscription', 'i18n', 'avatar-picker', 'live-wallpaper', 'widget']
         },
+        build_hash: BUILD_HASH || null,
+        build_time: BUILD_TIME,
         lastSync: Date.now()
     };
 

--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -438,15 +438,32 @@ paths:
               schema:
                 type: object
                 properties:
-                  buildId:
+                  api:
                     type: string
-                  version:
+                  portal:
                     type: string
-                  latestAppVersion:
+                  android:
                     type: string
-                  forceUpdateBelow:
+                  features:
+                    type: object
+                    properties:
+                      portal:
+                        type: array
+                        items: { type: string }
+                      android:
+                        type: array
+                        items: { type: string }
+                  build_hash:
                     type: string
                     nullable: true
+                    description: Full git commit SHA of the deployed backend (from RAILWAY_GIT_COMMIT_SHA). Null when running outside a git-tagged deploy. Cron consumers use this to detect rollbacks.
+                  build_time:
+                    type: string
+                    format: date-time
+                    description: ISO timestamp captured at server module load (effectively the deploy time on Railway).
+                  lastSync:
+                    type: integer
+                    description: Server epoch ms at response time.
 
   # ── Device Management ──
   /api/device/register:


### PR DESCRIPTION
## Summary

- `/api/version` now returns `build_hash` (full git SHA from `RAILWAY_GIT_COMMIT_SHA` with env-var fallbacks, or `null` outside a tagged deploy) and `build_time` (ISO timestamp captured at module load).
- Re-uses the same env chain that already powers `SCRIPT_VERSION` for cache-busting — `SCRIPT_VERSION` keeps its 12-char slice + `Date.now()` fallback so its behaviour is unchanged.
- OpenAPI `/api/version` response schema realigned with the actual handler shape (it had drifted to `buildId/latestAppVersion/forceUpdateBelow` that the handler never returned) and the two new fields documented.

## Why

The Golden-Path E2E cron (kanban card_e8eb928c9b4d61ec0f66d928, step 2 "rollback-detection") was failing every cycle because it expected a `build_hash` field that `/api/version` never exposed. Today's 13:10 run flagged step 2 FAIL despite the deploy being healthy — pure test-spec/API mismatch. Follow-up card_7ec01a9d3815d51d9536ba50 was filed during today's review to close this gap.

With this change the cron can compare `build_hash` across consecutive probes to detect:
- Rollbacks: hash regresses to an older SHA.
- Stale deploys: hash unchanged for N hours despite a merged commit on `main`.
- Mid-deploy flapping: hash flips between two SHAs across probes.

Without scraping `/api/health` build strings.

## Test plan

- [ ] `node --check backend/index.js` passes locally.
- [ ] After Railway deploy, `curl -s https://eclawbot.com/api/version | jq '.build_hash,.build_time'` returns a 40-char SHA + ISO timestamp.
- [ ] `build_hash` matches `git rev-parse origin/main` for the deployed commit.
- [ ] Update Golden-Path cron step 2 spec on card_e8eb928c9b4d61ec0f66d928 to check `build_hash` presence + stability instead of the legacy field (filed under card_7ec01a9d3815d51d9536ba50).
- [ ] Confirm `/api/version?appVersion=1.0.50` still emits the `update` block (no regression on update-check path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)