### PR TITLE
fix(openapi): un-nest Lookup description from CardHolder

### DIFF
--- a/backend/openapi.yaml
+++ b/backend/openapi.yaml
@@ -58,9 +58,9 @@ tags:
   - name: AgentCard
     description: A2A capability discovery
   - name: Lookup
+    description: Entity lookup and contacts
   - name: CardHolder
     description: Agent card holder (collected business cards)
-    description: Entity lookup and contacts
   - name: Auth
     description: User authentication and account management
   - name: Bot


### PR DESCRIPTION
## Summary
- Fixes duplicate-key in `backend/openapi.yaml` tags section: `Lookup` had no description while `CardHolder` had two — the second was Lookup's misplaced text.
- Strict YAML parsers (js-yaml v4 default) throw on duplicate keys; Swagger UI tolerates last-write-wins, so prod docs viewer was unaffected. Pure cleanup.
- Refs card_768a4908718ab68398fcf26c (P3 chore).

## Test plan
- [x] `js-yaml` parse of `backend/openapi.yaml` returns 12 tags, no errors
- [x] `Lookup` → "Entity lookup and contacts" / `CardHolder` → "Agent card holder (collected business cards)"
- [ ] CI lint passes (PR #2962 lint check should be green now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)