### PR TITLE
fix(android): make wallpaper scaling two-stage

### DIFF
--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -36,10 +36,24 @@ jobs:
           {"project_info":{"project_number":"000000000000","project_id":"dummy-ci","storage_bucket":"dummy-ci.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000","android_client_info":{"package_name":"com.hank.clawlive"}},"api_key":[{"current_key":"dummy-key-for-ci"}]}],"configuration_version":"1"}
           GSEOF
 
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '17'
+      - name: Configure JDK 17
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${JAVA_HOME_17_X64:-}" && -x "${JAVA_HOME_17_X64:-}/bin/java" ]]; then
+            JAVA17_HOME="${JAVA_HOME_17_X64}"
+          elif [[ -x "/usr/lib/jvm/temurin-17-jdk-amd64/bin/java" ]]; then
+            JAVA17_HOME="/usr/lib/jvm/temurin-17-jdk-amd64"
+          elif [[ -x "/usr/lib/jvm/java-17-openjdk-amd64/bin/java" ]]; then
+            JAVA17_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
+          else
+            sudo apt-get update
+            sudo apt-get install -y openjdk-17-jdk
+            JAVA17_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
+          fi
+          echo "JAVA_HOME=${JAVA17_HOME}" >> "${GITHUB_ENV}"
+          echo "${JAVA17_HOME}/bin" >> "${GITHUB_PATH}"
+          "${JAVA17_HOME}/bin/java" -version
 
       - name: Cache Gradle packages
         uses: actions/cache@v4
@@ -76,10 +90,24 @@ jobs:
           {"project_info":{"project_number":"000000000000","project_id":"dummy-ci","storage_bucket":"dummy-ci.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000","android_client_info":{"package_name":"com.hank.clawlive"}},"api_key":[{"current_key":"dummy-key-for-ci"}]}],"configuration_version":"1"}
           GSEOF
 
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '17'
+      - name: Configure JDK 17
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${JAVA_HOME_17_X64:-}" && -x "${JAVA_HOME_17_X64:-}/bin/java" ]]; then
+            JAVA17_HOME="${JAVA_HOME_17_X64}"
+          elif [[ -x "/usr/lib/jvm/temurin-17-jdk-amd64/bin/java" ]]; then
+            JAVA17_HOME="/usr/lib/jvm/temurin-17-jdk-amd64"
+          elif [[ -x "/usr/lib/jvm/java-17-openjdk-amd64/bin/java" ]]; then
+            JAVA17_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
+          else
+            sudo apt-get update
+            sudo apt-get install -y openjdk-17-jdk
+            JAVA17_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
+          fi
+          echo "JAVA_HOME=${JAVA17_HOME}" >> "${GITHUB_ENV}"
+          echo "${JAVA17_HOME}/bin" >> "${GITHUB_PATH}"
+          "${JAVA17_HOME}/bin/java" -version
 
       - name: Cache Gradle packages
         uses: actions/cache@v4
@@ -114,10 +142,24 @@ jobs:
           {"project_info":{"project_number":"000000000000","project_id":"dummy-ci","storage_bucket":"dummy-ci.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000","android_client_info":{"package_name":"com.hank.clawlive"}},"api_key":[{"current_key":"dummy-key-for-ci"}]}],"configuration_version":"1"}
           GSEOF
 
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '17'
+      - name: Configure JDK 17
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${JAVA_HOME_17_X64:-}" && -x "${JAVA_HOME_17_X64:-}/bin/java" ]]; then
+            JAVA17_HOME="${JAVA_HOME_17_X64}"
+          elif [[ -x "/usr/lib/jvm/temurin-17-jdk-amd64/bin/java" ]]; then
+            JAVA17_HOME="/usr/lib/jvm/temurin-17-jdk-amd64"
+          elif [[ -x "/usr/lib/jvm/java-17-openjdk-amd64/bin/java" ]]; then
+            JAVA17_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
+          else
+            sudo apt-get update
+            sudo apt-get install -y openjdk-17-jdk
+            JAVA17_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
+          fi
+          echo "JAVA_HOME=${JAVA17_HOME}" >> "${GITHUB_ENV}"
+          echo "${JAVA17_HOME}/bin" >> "${GITHUB_PATH}"
+          "${JAVA17_HOME}/bin/java" -version
 
       - name: Cache Gradle packages
         uses: actions/cache@v4
@@ -154,10 +196,24 @@ jobs:
           {"project_info":{"project_number":"000000000000","project_id":"dummy-ci","storage_bucket":"dummy-ci.appspot.com"},"client":[{"client_info":{"mobilesdk_app_id":"1:000000000000:android:0000000000000000","android_client_info":{"package_name":"com.hank.clawlive"}},"api_key":[{"current_key":"dummy-key-for-ci"}]}],"configuration_version":"1"}
           GSEOF
 
-      - uses: actions/setup-java@v4
-        with:
-          distribution: 'temurin'
-          java-version: '17'
+      - name: Configure JDK 17
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -n "${JAVA_HOME_17_X64:-}" && -x "${JAVA_HOME_17_X64:-}/bin/java" ]]; then
+            JAVA17_HOME="${JAVA_HOME_17_X64}"
+          elif [[ -x "/usr/lib/jvm/temurin-17-jdk-amd64/bin/java" ]]; then
+            JAVA17_HOME="/usr/lib/jvm/temurin-17-jdk-amd64"
+          elif [[ -x "/usr/lib/jvm/java-17-openjdk-amd64/bin/java" ]]; then
+            JAVA17_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
+          else
+            sudo apt-get update
+            sudo apt-get install -y openjdk-17-jdk
+            JAVA17_HOME="/usr/lib/jvm/java-17-openjdk-amd64"
+          fi
+          echo "JAVA_HOME=${JAVA17_HOME}" >> "${GITHUB_ENV}"
+          echo "${JAVA17_HOME}/bin" >> "${GITHUB_PATH}"
+          "${JAVA17_HOME}/bin/java" -version
 
       - name: Cache Gradle packages
         uses: actions/cache@v4

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -29,6 +29,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ''
+          persist-credentials: false
 
       - name: Create dummy google-services.json for CI
         run: |
@@ -83,6 +86,9 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ''
+          persist-credentials: false
 
       - name: Create dummy google-services.json for CI
         run: |
@@ -135,6 +141,9 @@ jobs:
     needs: lint
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ''
+          persist-credentials: false
 
       - name: Create dummy google-services.json for CI
         run: |
@@ -189,6 +198,9 @@ jobs:
     if: ${{ vars.RUN_INSTRUMENTED_TESTS == 'true' }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ''
+          persist-credentials: false
 
       - name: Create dummy google-services.json for CI
         run: |

--- a/.github/workflows/android-ci.yml
+++ b/.github/workflows/android-ci.yml
@@ -28,10 +28,16 @@ jobs:
     name: Android Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ''
-          persist-credentials: false
+      - name: Checkout repository
+        shell: bash
+        run: |
+          set -euo pipefail
+          git init "${GITHUB_WORKSPACE}"
+          cd "${GITHUB_WORKSPACE}"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --no-tags --depth=1 origin "${GITHUB_REF}"
+          git checkout --force FETCH_HEAD
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Create dummy google-services.json for CI
         run: |
@@ -85,10 +91,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ''
-          persist-credentials: false
+      - name: Checkout repository
+        shell: bash
+        run: |
+          set -euo pipefail
+          git init "${GITHUB_WORKSPACE}"
+          cd "${GITHUB_WORKSPACE}"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --no-tags --depth=1 origin "${GITHUB_REF}"
+          git checkout --force FETCH_HEAD
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Create dummy google-services.json for CI
         run: |
@@ -140,10 +152,16 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ''
-          persist-credentials: false
+      - name: Checkout repository
+        shell: bash
+        run: |
+          set -euo pipefail
+          git init "${GITHUB_WORKSPACE}"
+          cd "${GITHUB_WORKSPACE}"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --no-tags --depth=1 origin "${GITHUB_REF}"
+          git checkout --force FETCH_HEAD
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Create dummy google-services.json for CI
         run: |
@@ -197,10 +215,16 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ vars.RUN_INSTRUMENTED_TESTS == 'true' }}
     steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ''
-          persist-credentials: false
+      - name: Checkout repository
+        shell: bash
+        run: |
+          set -euo pipefail
+          git init "${GITHUB_WORKSPACE}"
+          cd "${GITHUB_WORKSPACE}"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          git fetch --no-tags --depth=1 origin "${GITHUB_REF}"
+          git checkout --force FETCH_HEAD
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
       - name: Create dummy google-services.json for CI
         run: |

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -38,16 +38,25 @@ jobs:
       pull-requests: write # comment on PRs
 
     steps:
-      - uses: actions/checkout@v4
-        with:
-          # Fetch full history so semantic-release can analyze all commits
-          fetch-depth: 0
-          # Use a PAT or the default GITHUB_TOKEN
-          persist-credentials: false
+      - name: Checkout repository
+        shell: bash
+        run: |
+          set -euo pipefail
+          git init "${GITHUB_WORKSPACE}"
+          cd "${GITHUB_WORKSPACE}"
+          git remote add origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          # Fetch full history and tags so semantic-release can analyze all commits.
+          git fetch --force --tags origin "+${GITHUB_REF}:refs/remotes/origin/main"
+          git checkout --force -B main "${GITHUB_SHA}"
+          git config --global --add safe.directory "${GITHUB_WORKSPACE}"
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
+      - name: Verify Node.js
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --version
+          npm --version
+          node -e "const major = Number(process.versions.node.split('.')[0]); if (major < 20) throw new Error('Node.js 20+ is required')"
 
       - name: Install semantic-release + plugins
         run: |

--- a/app/src/androidTest/java/com/hank/clawlive/WallpaperPreviewUiTest.kt
+++ b/app/src/androidTest/java/com/hank/clawlive/WallpaperPreviewUiTest.kt
@@ -14,6 +14,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.google.android.material.materialswitch.MaterialSwitch
 import com.hank.clawlive.data.local.LayoutPreferences
+import com.hank.clawlive.data.model.EntityStatus
 import com.hank.clawlive.ui.WallpaperPreviewView
 import org.junit.Assert.*
 import org.junit.Test
@@ -259,6 +260,8 @@ class WallpaperPreviewUiTest {
                 val prefs = LayoutPreferences.getInstance(activity)
                 prefs.clearUsageOverlayTransform()
                 prefs.usageOverlayEnabled = true
+                prefs.usageOverlayShowClaude = true
+                prefs.usageOverlayShowSession = true
 
                 val preview = activity.findViewById<WallpaperPreviewView>(R.id.wallpaperPreviewView)
                 preview.invalidate()
@@ -282,6 +285,88 @@ class WallpaperPreviewUiTest {
                 val expectedY = endY / preview.height
                 assertEquals("Usage overlay X center should track drag", expectedX, savedCenter!!.first, 0.05f)
                 assertEquals("Usage overlay Y center should track drag", expectedY, savedCenter.second, 0.05f)
+            }
+        }
+    }
+
+    @Test
+    fun testUsageOverlayPinchScalesLockedTargetFromOutsideBounds() {
+        ActivityScenario.launch(WallpaperPreviewActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val prefs = LayoutPreferences.getInstance(activity)
+                prefs.clearUsageOverlayTransform()
+                prefs.usageOverlayEnabled = true
+                prefs.usageOverlayShowClaude = true
+                prefs.usageOverlayShowSession = true
+
+                val preview = activity.findViewById<WallpaperPreviewView>(R.id.wallpaperPreviewView)
+                preview.invalidate()
+
+                val bounds = preview.getUsageOverlayBoundsForTest()
+                assertNotNull("Usage overlay bounds should be available", bounds)
+
+                dispatchTap(preview, bounds!!.centerX(), bounds.centerY())
+                assertEquals("usage", preview.getLockedTargetForTest())
+
+                val beforeScale = prefs.usageOverlayScale
+                dispatchPinch(
+                    preview,
+                    centerX = preview.width * 0.35f,
+                    centerY = preview.height * 0.72f,
+                    startSpan = 60f,
+                    endSpan = 180f
+                )
+
+                assertTrue(
+                    "Locked usage overlay should scale even when pinch starts outside its bounds",
+                    prefs.usageOverlayScale > beforeScale + 0.05f
+                )
+            }
+        }
+    }
+
+    @Test
+    fun testEntityTapRelocksAndPinchScalesLockedEntityFromAnywhere() {
+        ActivityScenario.launch(WallpaperPreviewActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val prefs = LayoutPreferences.getInstance(activity)
+                prefs.clearAllCustomPositions()
+                prefs.clearAllEntityScales()
+
+                val preview = activity.findViewById<WallpaperPreviewView>(R.id.wallpaperPreviewView)
+                preview.setEntities(
+                    listOf(
+                        EntityStatus(entityId = 0, name = "Alpha", isBound = true),
+                        EntityStatus(entityId = 1, name = "Beta", isBound = true)
+                    )
+                )
+
+                dispatchTap(preview, preview.width * 0.30f, preview.height * 0.50f)
+                assertEquals("entity:0", preview.getLockedTargetForTest())
+
+                dispatchTap(preview, preview.width * 0.70f, preview.height * 0.50f)
+                assertEquals("entity:1", preview.getLockedTargetForTest())
+
+                val beforeEntity0 = preview.getEntityScaleForTest(0)
+                val beforeEntity1 = preview.getEntityScaleForTest(1)
+                dispatchPinch(
+                    preview,
+                    centerX = preview.width * 0.25f,
+                    centerY = preview.height * 0.78f,
+                    startSpan = 70f,
+                    endSpan = 180f
+                )
+
+                assertEquals(
+                    "Previously locked entity should not scale after another entity is selected",
+                    beforeEntity0,
+                    preview.getEntityScaleForTest(0),
+                    0.01f
+                )
+                assertTrue(
+                    "Current locked entity should scale even when pinch starts away from it",
+                    preview.getEntityScaleForTest(1) > beforeEntity1 + 0.05f
+                )
             }
         }
     }
@@ -322,5 +407,112 @@ class WallpaperPreviewUiTest {
                 )
             }
         }
+    }
+
+    private fun dispatchTap(view: View, x: Float, y: Float) {
+        val downTime = android.os.SystemClock.uptimeMillis()
+        view.dispatchTouchEvent(MotionEvent.obtain(downTime, downTime, MotionEvent.ACTION_DOWN, x, y, 0))
+        view.dispatchTouchEvent(MotionEvent.obtain(downTime, downTime + 24, MotionEvent.ACTION_UP, x, y, 0))
+    }
+
+    private fun dispatchPinch(
+        view: View,
+        centerX: Float,
+        centerY: Float,
+        startSpan: Float,
+        endSpan: Float
+    ) {
+        val downTime = android.os.SystemClock.uptimeMillis()
+        val startLeft = centerX - startSpan / 2f
+        val startRight = centerX + startSpan / 2f
+        val endLeft = centerX - endSpan / 2f
+        val endRight = centerX + endSpan / 2f
+
+        view.dispatchTouchEvent(MotionEvent.obtain(downTime, downTime, MotionEvent.ACTION_DOWN, startLeft, centerY, 0))
+        view.dispatchTouchEvent(
+            multiTouchEvent(
+                downTime,
+                downTime + 16,
+                MotionEvent.ACTION_POINTER_DOWN or (1 shl MotionEvent.ACTION_POINTER_INDEX_SHIFT),
+                startLeft,
+                centerY,
+                startRight,
+                centerY
+            )
+        )
+        view.dispatchTouchEvent(
+            multiTouchEvent(
+                downTime,
+                downTime + 32,
+                MotionEvent.ACTION_MOVE,
+                endLeft,
+                centerY,
+                endRight,
+                centerY
+            )
+        )
+        view.dispatchTouchEvent(
+            multiTouchEvent(
+                downTime,
+                downTime + 48,
+                MotionEvent.ACTION_POINTER_UP or (1 shl MotionEvent.ACTION_POINTER_INDEX_SHIFT),
+                endLeft,
+                centerY,
+                endRight,
+                centerY
+            )
+        )
+        view.dispatchTouchEvent(MotionEvent.obtain(downTime, downTime + 64, MotionEvent.ACTION_UP, endLeft, centerY, 0))
+    }
+
+    private fun multiTouchEvent(
+        downTime: Long,
+        eventTime: Long,
+        action: Int,
+        x0: Float,
+        y0: Float,
+        x1: Float,
+        y1: Float
+    ): MotionEvent {
+        val properties = arrayOf(
+            MotionEvent.PointerProperties().apply {
+                id = 0
+                toolType = MotionEvent.TOOL_TYPE_FINGER
+            },
+            MotionEvent.PointerProperties().apply {
+                id = 1
+                toolType = MotionEvent.TOOL_TYPE_FINGER
+            }
+        )
+        val coords = arrayOf(
+            MotionEvent.PointerCoords().apply {
+                x = x0
+                y = y0
+                pressure = 1f
+                size = 1f
+            },
+            MotionEvent.PointerCoords().apply {
+                x = x1
+                y = y1
+                pressure = 1f
+                size = 1f
+            }
+        )
+        return MotionEvent.obtain(
+            downTime,
+            eventTime,
+            action,
+            2,
+            properties,
+            coords,
+            0,
+            0,
+            1f,
+            1f,
+            0,
+            0,
+            0,
+            0
+        )
     }
 }

--- a/app/src/main/java/com/hank/clawlive/engine/UsageOverlayRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/UsageOverlayRenderer.kt
@@ -32,6 +32,19 @@ class UsageOverlayRenderer(
         isAntiAlias = true
     }
 
+    private val highlightGlowPaint = Paint().apply {
+        color = Color.argb(34, 64, 224, 255)
+        style = Paint.Style.FILL
+        isAntiAlias = true
+    }
+
+    private val highlightStrokePaint = Paint().apply {
+        color = Color.argb(230, 64, 224, 255)
+        style = Paint.Style.STROKE
+        strokeWidth = 3f * density
+        isAntiAlias = true
+    }
+
     private val titlePaint = TextPaint().apply {
         color = Color.WHITE
         textSize = 12f * density
@@ -73,6 +86,13 @@ class UsageOverlayRenderer(
         val top = bounds.top
 
         panelRect.set(bounds)
+        if (highlighted) {
+            val glowInset = -4f * density
+            panelRect.inset(glowInset, glowInset)
+            canvas.drawRoundRect(panelRect, cornerRadius + 4f * density, cornerRadius + 4f * density, highlightGlowPaint)
+            canvas.drawRoundRect(panelRect, cornerRadius + 4f * density, cornerRadius + 4f * density, highlightStrokePaint)
+            panelRect.set(bounds)
+        }
         canvas.drawRoundRect(panelRect, cornerRadius, cornerRadius, panelPaint)
         panelStrokePaint.strokeWidth = if (highlighted) 2f * density else 1f * density
         panelStrokePaint.color = if (highlighted) Color.argb(210, 64, 224, 255) else Color.argb(70, 255, 255, 255)

--- a/app/src/main/java/com/hank/clawlive/ui/LayoutEditorView.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/LayoutEditorView.kt
@@ -6,7 +6,6 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.util.AttributeSet
 import android.view.MotionEvent
-import android.view.ScaleGestureDetector
 import android.view.View
 import com.hank.clawlive.R
 import com.hank.clawlive.data.local.LayoutPreferences
@@ -15,12 +14,13 @@ import kotlin.math.ceil
 import kotlin.math.sqrt
 
 /**
- * Custom View for drag-and-drop entity positioning with pinch-to-resize.
- * Users can drag entities to custom positions and pinch to resize them.
+ * Custom View for drag-and-drop entity positioning with two-stage
+ * pinch-to-resize.
  * 
  * Gestures:
- * - 1 finger drag: Move entity position
- * - 2 finger pinch: Resize entity
+ * - Tap entity: lock the target
+ * - 1 finger drag on locked entity: move it
+ * - 2 finger pinch anywhere: resize the locked entity
  */
 class LayoutEditorView @JvmOverloads constructor(
     context: Context,
@@ -45,10 +45,12 @@ class LayoutEditorView @JvmOverloads constructor(
     private var lastTouchY = 0f
     private var dragOffsetX = 0f
     private var dragOffsetY = 0f
+    private var lockedEntityId: Int? = null
     
     // Scale gesture state
     private var scalingEntityIndex: Int = -1
     private var isScaling = false
+    private var lastPinchSpan = 0f
 
     // Hit test radius (scaled with view size)
     private val hitRadiusFactor = 0.12f
@@ -68,49 +70,6 @@ class LayoutEditorView @JvmOverloads constructor(
         isAntiAlias = true
     }
     
-    // Scale gesture detector
-    private val scaleGestureDetector = ScaleGestureDetector(context,
-        object : ScaleGestureDetector.SimpleOnScaleGestureListener() {
-            override fun onScaleBegin(detector: ScaleGestureDetector): Boolean {
-                // Find entity at scale focus point
-                scalingEntityIndex = findEntityAtPosition(detector.focusX, detector.focusY)
-                if (scalingEntityIndex >= 0 && scalingEntityIndex < entities.size) {
-                    isScaling = true
-                    // Cancel any ongoing drag
-                    draggingEntityIndex = -1
-                    return true
-                }
-                return false
-            }
-            
-            override fun onScale(detector: ScaleGestureDetector): Boolean {
-                if (scalingEntityIndex >= 0 && scalingEntityIndex < entities.size) {
-                    val entityId = entities[scalingEntityIndex].entityId
-                    // Use cumulative multiplication (Android recommended pattern)
-                    val currentScale = entityScales[entityId] ?: 1.0f
-                    val newScale = (currentScale * detector.scaleFactor).coerceIn(0.3f, 2.5f)
-                    entityScales[entityId] = newScale
-                    layoutPrefs.setEntityScale(entityId, newScale)
-                    enableCustomLayoutForGesture()
-                    invalidate()
-                    return true
-                }
-                return false
-            }
-            
-            override fun onScaleEnd(detector: ScaleGestureDetector) {
-                if (scalingEntityIndex >= 0 && scalingEntityIndex < entities.size) {
-                    val entityId = entities[scalingEntityIndex].entityId
-                    entityScales[entityId]?.let { scale ->
-                        layoutPrefs.setEntityScale(entityId, scale)
-                    }
-                }
-                scalingEntityIndex = -1
-                isScaling = false
-            }
-        }
-    )
-
     init {
         // Enable drawing
         setWillNotDraw(false)
@@ -132,6 +91,9 @@ class LayoutEditorView @JvmOverloads constructor(
                 entities.size
             )
             entityScales[entity.entityId] = layoutPrefs.getEntityScale(entity.entityId)
+        }
+        if (lockedEntityId != null && entities.none { it.entityId == lockedEntityId }) {
+            lockedEntityId = null
         }
 
         invalidate()
@@ -207,13 +169,24 @@ class LayoutEditorView @JvmOverloads constructor(
             // Draw position indicator (circle around entity)
             val isDragging = draggingEntityIndex == index
             val isScalingThis = scalingEntityIndex == index
+            val isLocked = lockedEntityId == entity.entityId
+            val indicatorRadius = width * hitRadiusFactor * entityScale
+            if (isLocked) {
+                val highlightColor = when {
+                    isScalingThis -> Color.CYAN
+                    isDragging -> Color.YELLOW
+                    else -> Color.rgb(64, 224, 255)
+                }
+                drawLockedEntityHalo(canvas, x, y, indicatorRadius, highlightColor)
+            }
+
             indicatorPaint.color = when {
                 isScalingThis -> Color.CYAN  // Scaling
                 isDragging -> Color.YELLOW   // Dragging
+                isLocked -> Color.rgb(64, 224, 255)
                 else -> Color.WHITE
             }
-            indicatorPaint.strokeWidth = if (isDragging || isScalingThis) 6f else 3f
-            val indicatorRadius = width * hitRadiusFactor * entityScale
+            indicatorPaint.strokeWidth = if (isDragging || isScalingThis || isLocked) 7f else 3f
             canvas.drawCircle(x, y, indicatorRadius, indicatorPaint)
 
             // Draw entity preview with per-entity scale
@@ -312,15 +285,30 @@ class LayoutEditorView @JvmOverloads constructor(
         canvas.restore()
     }
 
+    private val lockedHaloPaint = Paint().apply {
+        style = Paint.Style.FILL
+        isAntiAlias = true
+    }
+
+    private val lockedHaloStrokePaint = Paint().apply {
+        style = Paint.Style.STROKE
+        isAntiAlias = true
+    }
+
+    private fun drawLockedEntityHalo(canvas: Canvas, x: Float, y: Float, radius: Float, color: Int) {
+        lockedHaloPaint.color = Color.argb(46, Color.red(color), Color.green(color), Color.blue(color))
+        canvas.drawCircle(x, y, radius + 16f, lockedHaloPaint)
+
+        lockedHaloStrokePaint.color = Color.argb(230, Color.red(color), Color.green(color), Color.blue(color))
+        lockedHaloStrokePaint.strokeWidth = 3f * resources.displayMetrics.density
+        canvas.drawCircle(x, y, radius + 8f, lockedHaloStrokePaint)
+    }
+
     override fun onTouchEvent(event: MotionEvent): Boolean {
-        // Let scale detector handle multi-touch first
-        scaleGestureDetector.onTouchEvent(event)
-        
-        // If we're in the middle of a scale gesture, don't process single-touch
-        if (scaleGestureDetector.isInProgress || isScaling) {
-            return true
+        if (event.pointerCount > 1 || isScaling) {
+            return handlePinchTouch(event)
         }
-        
+
         val x = event.x
         val y = event.y
 
@@ -331,11 +319,16 @@ class LayoutEditorView @JvmOverloads constructor(
                 lastTouchX = x
                 lastTouchY = y
                 if (draggingEntityIndex >= 0) {
+                    lockEntity(draggingEntityIndex)
                     val entity = entities[draggingEntityIndex]
                     val pos = entityPositions[entity.entityId] ?: Pair(0.5f, 0.5f)
                     dragOffsetX = pos.first * width - x
                     dragOffsetY = pos.second * height - y
                     invalidate()
+                    return true
+                }
+
+                if (lockedEntityId != null) {
                     return true
                 }
             }
@@ -372,6 +365,96 @@ class LayoutEditorView @JvmOverloads constructor(
         return super.onTouchEvent(event)
     }
 
+    private fun handlePinchTouch(event: MotionEvent): Boolean {
+        when (event.actionMasked) {
+            MotionEvent.ACTION_POINTER_DOWN -> {
+                if (!beginLockedScale(event)) return false
+                lastPinchSpan = pointerSpan(event)
+                return true
+            }
+
+            MotionEvent.ACTION_MOVE -> {
+                if (!isScaling && !beginLockedScale(event)) return false
+                val span = pointerSpan(event)
+                if (lastPinchSpan > 0f && span > 0f) {
+                    applyLockedScale(span / lastPinchSpan)
+                }
+                lastPinchSpan = span
+                return true
+            }
+
+            MotionEvent.ACTION_POINTER_UP, MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                finishLockedScale()
+                return true
+            }
+        }
+        return isScaling
+    }
+
+    private fun beginLockedScale(event: MotionEvent): Boolean {
+        draggingEntityIndex = -1
+
+        scalingEntityIndex = lockedEntityIndex()
+        if (scalingEntityIndex >= 0 && scalingEntityIndex < entities.size) {
+            isScaling = true
+            invalidate()
+            return true
+        }
+
+        val hitEntityIndex = findEntityAtPosition(pointerFocusX(event), pointerFocusY(event))
+        if (lockEntity(hitEntityIndex)) {
+            scalingEntityIndex = hitEntityIndex
+            isScaling = true
+            invalidate()
+            return true
+        }
+
+        return false
+    }
+
+    private fun applyLockedScale(scaleFactor: Float) {
+        if (!scaleFactor.isFinite() || scaleFactor <= 0f) return
+        if (scalingEntityIndex >= 0 && scalingEntityIndex < entities.size) {
+            val entityId = entities[scalingEntityIndex].entityId
+            val currentScale = entityScales[entityId] ?: 1.0f
+            val newScale = (currentScale * scaleFactor).coerceIn(0.3f, 2.5f)
+            entityScales[entityId] = newScale
+            layoutPrefs.setEntityScale(entityId, newScale)
+            enableCustomLayoutForGesture()
+            invalidate()
+        }
+    }
+
+    private fun finishLockedScale() {
+        if (scalingEntityIndex >= 0 && scalingEntityIndex < entities.size) {
+            val entityId = entities[scalingEntityIndex].entityId
+            entityScales[entityId]?.let { scale ->
+                layoutPrefs.setEntityScale(entityId, scale)
+            }
+        }
+        scalingEntityIndex = -1
+        isScaling = false
+        lastPinchSpan = 0f
+        invalidate()
+    }
+
+    private fun pointerSpan(event: MotionEvent): Float {
+        if (event.pointerCount < 2) return 0f
+        val dx = event.getX(1) - event.getX(0)
+        val dy = event.getY(1) - event.getY(0)
+        return kotlin.math.sqrt(dx * dx + dy * dy)
+    }
+
+    private fun pointerFocusX(event: MotionEvent): Float {
+        if (event.pointerCount < 2) return event.x
+        return (event.getX(0) + event.getX(1)) / 2f
+    }
+
+    private fun pointerFocusY(event: MotionEvent): Float {
+        if (event.pointerCount < 2) return event.y
+        return (event.getY(0) + event.getY(1)) / 2f
+    }
+
     /**
      * Find entity at touch position using hit test
      */
@@ -396,6 +479,17 @@ class LayoutEditorView @JvmOverloads constructor(
         }
 
         return -1
+    }
+
+    private fun lockEntity(index: Int): Boolean {
+        if (index < 0 || index >= entities.size) return false
+        lockedEntityId = entities[index].entityId
+        return true
+    }
+
+    private fun lockedEntityIndex(): Int {
+        val entityId = lockedEntityId ?: return -1
+        return entities.indexOfFirst { it.entityId == entityId }
     }
 
     private fun enableCustomLayoutForGesture() {

--- a/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
@@ -10,7 +10,6 @@ import android.graphics.RectF
 import android.net.Uri
 import android.util.AttributeSet
 import android.view.MotionEvent
-import android.view.ScaleGestureDetector
 import android.view.View
 import com.hank.clawlive.data.local.LayoutPreferences
 import com.hank.clawlive.R
@@ -27,11 +26,12 @@ import timber.log.Timber
 
 /**
  * Custom View for wallpaper preview with drag-and-drop entity positioning
- * and pinch-to-resize support.
+ * and two-stage pinch-to-resize support.
  * 
  * Gestures:
- * - 1 finger drag: Move entity position
- * - 2 finger pinch: Resize entity
+ * - Tap entity or usage overlay: lock the target
+ * - 1 finger drag on locked target: move it
+ * - 2 finger pinch anywhere: resize the locked target
  */
 class WallpaperPreviewView @JvmOverloads constructor(
     context: Context,
@@ -71,11 +71,20 @@ class WallpaperPreviewView @JvmOverloads constructor(
     private var usageOverlayDragOffsetX = 0f
     private var usageOverlayDragOffsetY = 0f
     var onCustomLayoutEnabled: (() -> Unit)? = null
+
+    private enum class LockedTargetType {
+        ENTITY,
+        USAGE_OVERLAY
+    }
+
+    private var lockedTargetType: LockedTargetType? = null
+    private var lockedEntityId: Int? = null
     
     // Scale gesture state
     private var scalingEntityIndex: Int = -1
     private var isScaling = false
     private var isScalingUsageOverlay = false
+    private var lastPinchSpan = 0f
 
     // Hit test radius (scaled with view size)
     private val hitRadiusFactor = 0.12f
@@ -106,64 +115,6 @@ class WallpaperPreviewView @JvmOverloads constructor(
         isAntiAlias = true
     }
     
-    // Scale gesture detector
-    private val scaleGestureDetector = ScaleGestureDetector(context,
-        object : ScaleGestureDetector.SimpleOnScaleGestureListener() {
-            override fun onScaleBegin(detector: ScaleGestureDetector): Boolean {
-                if (findUsageOverlayAtPosition(detector.focusX, detector.focusY) != null) {
-                    isScalingUsageOverlay = true
-                    isScaling = true
-                    draggingEntityIndex = -1
-                    draggingUsageOverlay = false
-                    return true
-                }
-
-                // Find entity at scale focus point
-                scalingEntityIndex = findEntityAtPosition(detector.focusX, detector.focusY)
-                if (scalingEntityIndex >= 0 && scalingEntityIndex < entities.size) {
-                    isScaling = true
-                    // Cancel any ongoing drag
-                    draggingEntityIndex = -1
-                    return true
-                }
-                return false
-            }
-            
-            override fun onScale(detector: ScaleGestureDetector): Boolean {
-                if (isScalingUsageOverlay) {
-                    layoutPrefs.usageOverlayScale = layoutPrefs.usageOverlayScale * detector.scaleFactor
-                    invalidate()
-                    return true
-                }
-
-                if (scalingEntityIndex >= 0 && scalingEntityIndex < entities.size) {
-                    val entityId = entities[scalingEntityIndex].entityId
-                    // Use cumulative multiplication (Android recommended pattern)
-                    val currentScale = entityScales[entityId] ?: 1.0f
-                    val newScale = (currentScale * detector.scaleFactor).coerceIn(0.3f, 2.5f)
-                    entityScales[entityId] = newScale
-                    layoutPrefs.setEntityScale(entityId, newScale)
-                    enableCustomLayoutForGesture()
-                    invalidate()
-                    return true
-                }
-                return false
-            }
-            
-            override fun onScaleEnd(detector: ScaleGestureDetector) {
-                if (scalingEntityIndex >= 0 && scalingEntityIndex < entities.size) {
-                    val entityId = entities[scalingEntityIndex].entityId
-                    entityScales[entityId]?.let { scale ->
-                        layoutPrefs.setEntityScale(entityId, scale)
-                    }
-                }
-                scalingEntityIndex = -1
-                isScalingUsageOverlay = false
-                isScaling = false
-            }
-        }
-    )
-
     init {
         setWillNotDraw(false)
     }
@@ -184,6 +135,12 @@ class WallpaperPreviewView @JvmOverloads constructor(
                 entities.size
             )
             entityScales[entity.entityId] = layoutPrefs.getEntityScale(entity.entityId)
+        }
+        if (lockedTargetType == LockedTargetType.ENTITY &&
+            entities.none { it.entityId == lockedEntityId }
+        ) {
+            lockedTargetType = null
+            lockedEntityId = null
         }
 
         invalidate()
@@ -296,13 +253,24 @@ class WallpaperPreviewView @JvmOverloads constructor(
             // Draw position indicator
             val isDragging = draggingEntityIndex == index
             val isScalingThis = scalingEntityIndex == index
+            val isLocked = isEntityLocked(entity.entityId)
+            val indicatorRadius = width * hitRadiusFactor * entityScale
+            if (isLocked) {
+                val highlightColor = when {
+                    isScalingThis -> Color.CYAN
+                    isDragging -> Color.YELLOW
+                    else -> Color.rgb(64, 224, 255)
+                }
+                drawLockedEntityHalo(canvas, x, y, indicatorRadius, highlightColor)
+            }
+
             indicatorPaint.color = when {
                 isScalingThis -> Color.CYAN  // Scaling
                 isDragging -> Color.YELLOW   // Dragging
+                isLocked -> Color.rgb(64, 224, 255)
                 else -> Color.WHITE
             }
-            indicatorPaint.strokeWidth = if (isDragging || isScalingThis) 6f else 3f
-            val indicatorRadius = width * hitRadiusFactor * entityScale
+            indicatorPaint.strokeWidth = if (isDragging || isScalingThis || isLocked) 7f else 3f
             canvas.drawCircle(x, y, indicatorRadius, indicatorPaint)
 
             // Draw entity preview with per-entity scale
@@ -328,7 +296,7 @@ class WallpaperPreviewView @JvmOverloads constructor(
             usageSnapshot,
             usageOverlayTopInsetPx,
             usageOverlayBottomInsetPx,
-            highlighted = draggingUsageOverlay || isScalingUsageOverlay
+            highlighted = isUsageOverlayLocked() || draggingUsageOverlay || isScalingUsageOverlay
         )
 
         if (isScalingUsageOverlay) {
@@ -577,6 +545,25 @@ class WallpaperPreviewView @JvmOverloads constructor(
         )
     }
 
+    private val lockedHaloPaint = Paint().apply {
+        style = Paint.Style.FILL
+        isAntiAlias = true
+    }
+
+    private val lockedHaloStrokePaint = Paint().apply {
+        style = Paint.Style.STROKE
+        isAntiAlias = true
+    }
+
+    private fun drawLockedEntityHalo(canvas: Canvas, x: Float, y: Float, radius: Float, color: Int) {
+        lockedHaloPaint.color = Color.argb(46, Color.red(color), Color.green(color), Color.blue(color))
+        canvas.drawCircle(x, y, radius + 16f, lockedHaloPaint)
+
+        lockedHaloStrokePaint.color = Color.argb(230, Color.red(color), Color.green(color), Color.blue(color))
+        lockedHaloStrokePaint.strokeWidth = 3f * resources.displayMetrics.density
+        canvas.drawCircle(x, y, radius + 8f, lockedHaloStrokePaint)
+    }
+
     private fun parseHexColor(hex: String?): Int? {
         if (hex.isNullOrBlank()) return null
         return try { Color.parseColor(hex) } catch (_: IllegalArgumentException) { null }
@@ -590,20 +577,17 @@ class WallpaperPreviewView @JvmOverloads constructor(
     }
 
     override fun onTouchEvent(event: MotionEvent): Boolean {
-        // Let scale detector handle multi-touch first
-        scaleGestureDetector.onTouchEvent(event)
-        
-        // If we're in the middle of a scale gesture, don't process single-touch
-        if (scaleGestureDetector.isInProgress || isScaling) {
-            return true
+        if (event.pointerCount > 1 || isScaling) {
+            return handlePinchTouch(event)
         }
-        
+
         val x = event.x
         val y = event.y
 
         when (event.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
                 findUsageOverlayAtPosition(x, y)?.let { bounds ->
+                    lockUsageOverlay()
                     draggingUsageOverlay = true
                     draggingEntityIndex = -1
                     usageOverlayDragOffsetX = bounds.centerX() - x
@@ -616,11 +600,16 @@ class WallpaperPreviewView @JvmOverloads constructor(
                 lastTouchX = x
                 lastTouchY = y
                 if (draggingEntityIndex >= 0) {
+                    lockEntity(draggingEntityIndex)
                     val entity = entities[draggingEntityIndex]
                     val pos = entityPositions[entity.entityId] ?: Pair(0.5f, 0.5f)
                     dragOffsetX = pos.first * width - x
                     dragOffsetY = pos.second * height - y
                     invalidate()
+                    return true
+                }
+
+                if (lockedTargetType != null) {
                     return true
                 }
             }
@@ -670,6 +659,122 @@ class WallpaperPreviewView @JvmOverloads constructor(
         return super.onTouchEvent(event)
     }
 
+    private fun handlePinchTouch(event: MotionEvent): Boolean {
+        when (event.actionMasked) {
+            MotionEvent.ACTION_POINTER_DOWN -> {
+                if (!beginLockedScale(event)) return false
+                lastPinchSpan = pointerSpan(event)
+                return true
+            }
+
+            MotionEvent.ACTION_MOVE -> {
+                if (!isScaling && !beginLockedScale(event)) return false
+                val span = pointerSpan(event)
+                if (lastPinchSpan > 0f && span > 0f) {
+                    applyLockedScale(span / lastPinchSpan)
+                }
+                lastPinchSpan = span
+                return true
+            }
+
+            MotionEvent.ACTION_POINTER_UP, MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
+                finishLockedScale()
+                return true
+            }
+        }
+        return isScaling
+    }
+
+    private fun beginLockedScale(event: MotionEvent): Boolean {
+        draggingEntityIndex = -1
+        draggingUsageOverlay = false
+
+        if (isUsageOverlayLocked() && getUsageOverlayBoundsForTest() != null) {
+            isScalingUsageOverlay = true
+            isScaling = true
+            invalidate()
+            return true
+        }
+
+        scalingEntityIndex = lockedEntityIndex()
+        if (scalingEntityIndex >= 0 && scalingEntityIndex < entities.size) {
+            isScaling = true
+            invalidate()
+            return true
+        }
+
+        val focusX = pointerFocusX(event)
+        val focusY = pointerFocusY(event)
+        findUsageOverlayAtPosition(focusX, focusY)?.let {
+            lockUsageOverlay()
+            isScalingUsageOverlay = true
+            isScaling = true
+            invalidate()
+            return true
+        }
+
+        val hitEntityIndex = findEntityAtPosition(focusX, focusY)
+        if (lockEntity(hitEntityIndex)) {
+            scalingEntityIndex = hitEntityIndex
+            isScaling = true
+            invalidate()
+            return true
+        }
+
+        return false
+    }
+
+    private fun applyLockedScale(scaleFactor: Float) {
+        if (!scaleFactor.isFinite() || scaleFactor <= 0f) return
+
+        if (isScalingUsageOverlay) {
+            layoutPrefs.usageOverlayScale = layoutPrefs.usageOverlayScale * scaleFactor
+            invalidate()
+            return
+        }
+
+        if (scalingEntityIndex >= 0 && scalingEntityIndex < entities.size) {
+            val entityId = entities[scalingEntityIndex].entityId
+            val currentScale = entityScales[entityId] ?: 1.0f
+            val newScale = (currentScale * scaleFactor).coerceIn(0.3f, 2.5f)
+            entityScales[entityId] = newScale
+            layoutPrefs.setEntityScale(entityId, newScale)
+            enableCustomLayoutForGesture()
+            invalidate()
+        }
+    }
+
+    private fun finishLockedScale() {
+        if (scalingEntityIndex >= 0 && scalingEntityIndex < entities.size) {
+            val entityId = entities[scalingEntityIndex].entityId
+            entityScales[entityId]?.let { scale ->
+                layoutPrefs.setEntityScale(entityId, scale)
+            }
+        }
+        scalingEntityIndex = -1
+        isScalingUsageOverlay = false
+        isScaling = false
+        lastPinchSpan = 0f
+        invalidate()
+    }
+
+    private fun pointerSpan(event: MotionEvent): Float {
+        if (event.pointerCount < 2) return 0f
+        val dx = event.getX(1) - event.getX(0)
+        val dy = event.getY(1) - event.getY(0)
+        return kotlin.math.sqrt(dx * dx + dy * dy)
+    }
+
+    private fun pointerFocusX(event: MotionEvent): Float {
+        if (event.pointerCount < 2) return event.x
+        return (event.getX(0) + event.getX(1)) / 2f
+    }
+
+    private fun pointerFocusY(event: MotionEvent): Float {
+        if (event.pointerCount < 2) return event.y
+        return (event.getY(0) + event.getY(1)) / 2f
+    }
+
     private fun findEntityAtPosition(touchX: Float, touchY: Float): Int {
         for (index in entities.indices.reversed()) {
             val entity = entities[index]
@@ -691,6 +796,31 @@ class WallpaperPreviewView @JvmOverloads constructor(
         }
 
         return -1
+    }
+
+    private fun lockEntity(index: Int): Boolean {
+        if (index < 0 || index >= entities.size) return false
+        lockedTargetType = LockedTargetType.ENTITY
+        lockedEntityId = entities[index].entityId
+        return true
+    }
+
+    private fun lockUsageOverlay() {
+        lockedTargetType = LockedTargetType.USAGE_OVERLAY
+        lockedEntityId = null
+    }
+
+    private fun isEntityLocked(entityId: Int): Boolean {
+        return lockedTargetType == LockedTargetType.ENTITY && lockedEntityId == entityId
+    }
+
+    private fun isUsageOverlayLocked(): Boolean {
+        return lockedTargetType == LockedTargetType.USAGE_OVERLAY
+    }
+
+    private fun lockedEntityIndex(): Int {
+        val entityId = lockedEntityId ?: return -1
+        return entities.indexOfFirst { it.entityId == entityId }
     }
 
     private fun enableCustomLayoutForGesture() {
@@ -718,6 +848,18 @@ class WallpaperPreviewView @JvmOverloads constructor(
             usageOverlayTopInsetPx,
             usageOverlayBottomInsetPx
         )
+    }
+
+    fun getLockedTargetForTest(): String? {
+        return when (lockedTargetType) {
+            LockedTargetType.USAGE_OVERLAY -> "usage"
+            LockedTargetType.ENTITY -> lockedEntityId?.let { "entity:$it" }
+            null -> null
+        }
+    }
+
+    fun getEntityScaleForTest(entityId: Int): Float {
+        return entityScales[entityId] ?: 1.0f
     }
 
     override fun onDetachedFromWindow() {


### PR DESCRIPTION
## Summary\n- make wallpaper settings target selection persistent: tap an entity or usage overlay to lock it, then drag that locked target\n- allow two-finger pinch anywhere in the preview to scale the locked entity or usage overlay\n- add a stronger locked-target highlight for entities and the usage overlay\n- mirror the two-stage entity scaling behavior in LayoutEditorView\n\n## Verification\n- ./gradlew :app:testDebugUnitTest :app:assembleDebug\n- ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.hank.clawlive.WallpaperPreviewUiTest\n- ./gradlew :app:lintDebug