### PR TITLE
ci: add cli-proxy-ci.yml gate for claude-cli-proxy unit tests

### DIFF
--- a/.github/workflows/cli-proxy-ci.yml
+++ b/.github/workflows/cli-proxy-ci.yml
@@ -1,0 +1,43 @@
+name: CLI-Proxy CI
+
+# Unit tests for claude-cli-proxy/ (FastAPI multi-tenant proxy in front of
+# claude-cli). Mirrors backend-ci.yml shape but pinned to Python.
+#
+# Discovery context: PR #2937 (H3 Phase 1) shipped with empty
+# statusCheckRollup because the existing workflows (backend-ci.yml etc.)
+# don't watch claude-cli-proxy/**. This workflow closes that gap so future
+# cli-proxy PRs run the 21 existing unit tests as a PR gate.
+
+on:
+  push:
+    branches: ['**']
+    paths:
+      - 'claude-cli-proxy/**'
+      - '.github/workflows/cli-proxy-ci.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'claude-cli-proxy/**'
+      - '.github/workflows/cli-proxy-ci.yml'
+
+jobs:
+  unit:
+    name: Python unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          # Pinned to match claude-cli-proxy/Dockerfile (python:3.12-slim).
+          python-version: '3.12'
+          cache: 'pip'
+          cache-dependency-path: claude-cli-proxy/requirements.txt
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+        working-directory: claude-cli-proxy
+
+      - name: Run unittest suite
+        run: python -m unittest tests.test_repo_auth tests.test_multi_tenant -v
+        working-directory: claude-cli-proxy


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/cli-proxy-ci.yml` to close the statusCheckRollup gap discovered during PR #2937 H3 Phase 1 review — `claude-cli-proxy/` wasn't covered by `backend-ci.yml`'s paths filter, so its 21 existing unit tests only ran locally.
- Pattern mirrors `backend-ci.yml`: triggers on push (all branches) + PR (against main) when paths touch `claude-cli-proxy/**` or this workflow itself.
- Python pinned to `3.12` to match `claude-cli-proxy/Dockerfile` (`python:3.12-slim`).
- `pip` cache keyed on `claude-cli-proxy/requirements.txt`.
- Runs `python -m unittest tests.test_repo_auth tests.test_multi_tenant -v` from `claude-cli-proxy/`.

## Test plan

- [x] Local dry-run: `cd claude-cli-proxy && python3 -m unittest tests.test_repo_auth tests.test_multi_tenant` → 21/21 passing in <1s.
- [ ] CI fires on this PR (this PR touches `.github/workflows/cli-proxy-ci.yml` so it's self-watching).
- [ ] Next PR that touches `claude-cli-proxy/**` shows this check in its statusCheckRollup.

## Card

card_f1aec22833ae28f36a82add3 ([Infra] Add CI workflow for claude-cli-proxy tests, P0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)