### PR TITLE
fix(android): bump production app version to 1.0.87

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 94
-        versionName = "1.0.86"
+        versionCode = 95
+        versionName = "1.0.87"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
## Summary
- bump Android production version to versionCode 95 / versionName 1.0.87 for Google Play production release

## Verification
- ./gradlew :app:testDebugUnitTest :app:lintDebug :app:bundleRelease --no-daemon
- ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.hank.clawlive.WallpaperPreviewUiTest --no-daemon

## Release
- Google Play production currently has versionCode 86
- Google Play internal currently has versionCode 94
- This PR prepares a fresh production AAB with versionCode 95 from current main