### PR TITLE
fix(android): OfficialBorrow Toast error_unknown fallback (#2974)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/OfficialBorrowActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/OfficialBorrowActivity.kt
@@ -489,7 +489,9 @@ class OfficialBorrowActivity : AppCompatActivity() {
                 Toast.makeText(this@OfficialBorrowActivity, getString(R.string.rental_demand_success), Toast.LENGTH_LONG).show()
             } catch (e: Exception) {
                 Timber.e(e, "Failed to submit rental demand")
-                Toast.makeText(this@OfficialBorrowActivity, getString(R.string.rental_demand_fail, e.message ?: "Unknown error"), Toast.LENGTH_SHORT).show()
+                Toast.makeText(this@OfficialBorrowActivity,
+                    getString(R.string.rental_demand_fail, e.message ?: getString(R.string.error_unknown)),
+                    Toast.LENGTH_SHORT).show()
             }
         }
     }

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -239,6 +239,7 @@
     <string name="background_disabled">الخلفية معطلة</string>
     <string name="error_open_picker">تعذر فتح منتقي الصور</string>
     <string name="error_open_settings">تعذر فتح إعدادات الخلفية</string>
+    <string name="error_unknown">Unknown error</string>
     <string name="bot_label">🤖 %s</string>
     <string name="mission_completed_at">✓ %s</string>
     <string name="playback_failed">فشل التشغيل</string>

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -239,7 +239,7 @@
     <string name="background_disabled">الخلفية معطلة</string>
     <string name="error_open_picker">تعذر فتح منتقي الصور</string>
     <string name="error_open_settings">تعذر فتح إعدادات الخلفية</string>
-    <string name="error_unknown">Unknown error</string>
+    <string name="error_unknown">خطأ غير معروف</string>
     <string name="bot_label">🤖 %s</string>
     <string name="mission_completed_at">✓ %s</string>
     <string name="playback_failed">فشل التشغيل</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -238,7 +238,7 @@
     <string name="background_disabled">Hintergrund deaktiviert</string>
     <string name="error_open_picker">Fotoauswahl kann nicht geöffnet werden</string>
     <string name="error_open_settings">Hintergrund-Einstellungen können nicht geöffnet werden</string>
-    <string name="error_unknown">Unknown error</string>
+    <string name="error_unknown">Unbekannter Fehler</string>
     <string name="bot_label">🤖 %s</string>
     <string name="mission_completed_at">✓ %s</string>
     <string name="playback_failed">Wiedergabe fehlgeschlagen</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -238,6 +238,7 @@
     <string name="background_disabled">Hintergrund deaktiviert</string>
     <string name="error_open_picker">Fotoauswahl kann nicht geöffnet werden</string>
     <string name="error_open_settings">Hintergrund-Einstellungen können nicht geöffnet werden</string>
+    <string name="error_unknown">Unknown error</string>
     <string name="bot_label">🤖 %s</string>
     <string name="mission_completed_at">✓ %s</string>
     <string name="playback_failed">Wiedergabe fehlgeschlagen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -257,7 +257,7 @@ Los registros aparecerán aquí mientras la app funciona.</string>
     <string name="error_occurred">Ocurrió un error</string>
     <string name="error_open_picker">No se puede abrir el selector de fotos</string>
     <string name="error_open_settings">No se puede abrir la configuración del fondo</string>
-    <string name="error_unknown">Unknown error</string>
+    <string name="error_unknown">Error desconocido</string>
     <string name="expand">Expandir</string>
     <string name="expires_in">Expira en %ds</string>
     <string name="failed_add_slot">Error al agregar ranura</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -257,6 +257,7 @@ Los registros aparecerán aquí mientras la app funciona.</string>
     <string name="error_occurred">Ocurrió un error</string>
     <string name="error_open_picker">No se puede abrir el selector de fotos</string>
     <string name="error_open_settings">No se puede abrir la configuración del fondo</string>
+    <string name="error_unknown">Unknown error</string>
     <string name="expand">Expandir</string>
     <string name="expires_in">Expira en %ds</string>
     <string name="failed_add_slot">Error al agregar ranura</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -238,7 +238,7 @@
     <string name="background_disabled">Arrière-plan désactivé</string>
     <string name="error_open_picker">Impossible d\'ouvrir le sélecteur de photos</string>
     <string name="error_open_settings">Impossible d\'ouvrir les paramètres de fond d\'écran</string>
-    <string name="error_unknown">Unknown error</string>
+    <string name="error_unknown">Erreur inconnue</string>
     <string name="bot_label">🤖 %s</string>
     <string name="mission_completed_at">✓ %s</string>
     <string name="playback_failed">Échec de la lecture</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -238,6 +238,7 @@
     <string name="background_disabled">Arrière-plan désactivé</string>
     <string name="error_open_picker">Impossible d\'ouvrir le sélecteur de photos</string>
     <string name="error_open_settings">Impossible d\'ouvrir les paramètres de fond d\'écran</string>
+    <string name="error_unknown">Unknown error</string>
     <string name="bot_label">🤖 %s</string>
     <string name="mission_completed_at">✓ %s</string>
     <string name="playback_failed">Échec de la lecture</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -238,7 +238,7 @@
     <string name="background_disabled">बैकग्राउंड अक्षम</string>
     <string name="error_open_picker">फोटो पिकर नहीं खुल सकता</string>
     <string name="error_open_settings">वॉलपेपर सेटिंग्स नहीं खुल सकतीं</string>
-    <string name="error_unknown">Unknown error</string>
+    <string name="error_unknown">अज्ञात त्रुटि</string>
     <string name="bot_label">🤖 %s</string>
     <string name="mission_completed_at">✓ %s</string>
     <string name="playback_failed">प्लेबैक विफल</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -238,6 +238,7 @@
     <string name="background_disabled">बैकग्राउंड अक्षम</string>
     <string name="error_open_picker">फोटो पिकर नहीं खुल सकता</string>
     <string name="error_open_settings">वॉलपेपर सेटिंग्स नहीं खुल सकतीं</string>
+    <string name="error_unknown">Unknown error</string>
     <string name="bot_label">🤖 %s</string>
     <string name="mission_completed_at">✓ %s</string>
     <string name="playback_failed">प्लेबैक विफल</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -248,6 +248,7 @@
     <string name="error_generic">Terjadi kesalahan</string>
     <string name="error_open_picker">Tidak dapat membuka pemilih foto</string>
     <string name="error_open_settings">Tidak dapat membuka pengaturan wallpaper</string>
+    <string name="error_unknown">Unknown error</string>
     <string name="expand">Perluas</string>
     <string name="expires_in">Kedaluwarsa dalam %dd</string>
     <string name="failed_add_slot">Gagal menambahkan slot</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -248,7 +248,7 @@
     <string name="error_generic">Terjadi kesalahan</string>
     <string name="error_open_picker">Tidak dapat membuka pemilih foto</string>
     <string name="error_open_settings">Tidak dapat membuka pengaturan wallpaper</string>
-    <string name="error_unknown">Unknown error</string>
+    <string name="error_unknown">Kesalahan tidak diketahui</string>
     <string name="expand">Perluas</string>
     <string name="expires_in">Kedaluwarsa dalam %dd</string>
     <string name="failed_add_slot">Gagal menambahkan slot</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -248,6 +248,7 @@
     <string name="error_generic">エラーが発生しました</string>
     <string name="error_open_picker">写真ピッカーを開けません</string>
     <string name="error_open_settings">壁紙設定を開けません</string>
+    <string name="error_unknown">Unknown error</string>
     <string name="expand">展開</string>
     <string name="expires_in">あと %d秒で期限切れ</string>
     <string name="failed_add_slot">スロットの追加に失敗しました</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -248,7 +248,7 @@
     <string name="error_generic">エラーが発生しました</string>
     <string name="error_open_picker">写真ピッカーを開けません</string>
     <string name="error_open_settings">壁紙設定を開けません</string>
-    <string name="error_unknown">Unknown error</string>
+    <string name="error_unknown">不明なエラー</string>
     <string name="expand">展開</string>
     <string name="expires_in">あと %d秒で期限切れ</string>
     <string name="failed_add_slot">スロットの追加に失敗しました</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -248,6 +248,7 @@
     <string name="error_generic">오류가 발생했습니다</string>
     <string name="error_open_picker">사진 선택기를 열 수 없습니다</string>
     <string name="error_open_settings">배경화면 설정을 열 수 없습니다</string>
+    <string name="error_unknown">Unknown error</string>
     <string name="expand">펼치기</string>
     <string name="expires_in">%d초 후 만료</string>
     <string name="failed_add_slot">슬롯 추가에 실패했습니다</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -248,7 +248,7 @@
     <string name="error_generic">오류가 발생했습니다</string>
     <string name="error_open_picker">사진 선택기를 열 수 없습니다</string>
     <string name="error_open_settings">배경화면 설정을 열 수 없습니다</string>
-    <string name="error_unknown">Unknown error</string>
+    <string name="error_unknown">알 수 없는 오류</string>
     <string name="expand">펼치기</string>
     <string name="expires_in">%d초 후 만료</string>
     <string name="failed_add_slot">슬롯 추가에 실패했습니다</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -238,6 +238,7 @@
     <string name="background_disabled">Latar belakang dilumpuhkan</string>
     <string name="error_open_picker">Tidak dapat membuka pemilih foto</string>
     <string name="error_open_settings">Tidak dapat membuka tetapan kertas dinding</string>
+    <string name="error_unknown">Unknown error</string>
     <string name="bot_label">🤖 %s</string>
     <string name="mission_completed_at">✓ %s</string>
     <string name="playback_failed">Main balik gagal</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -238,7 +238,7 @@
     <string name="background_disabled">Latar belakang dilumpuhkan</string>
     <string name="error_open_picker">Tidak dapat membuka pemilih foto</string>
     <string name="error_open_settings">Tidak dapat membuka tetapan kertas dinding</string>
-    <string name="error_unknown">Unknown error</string>
+    <string name="error_unknown">Ralat tidak diketahui</string>
     <string name="bot_label">🤖 %s</string>
     <string name="mission_completed_at">✓ %s</string>
     <string name="playback_failed">Main balik gagal</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -248,7 +248,7 @@
     <string name="error_generic">เกิดข้อผิดพลาด</string>
     <string name="error_open_picker">ไม่สามารถเปิดตัวเลือกรูปภาพ</string>
     <string name="error_open_settings">ไม่สามารถเปิดการตั้งค่าวอลเปเปอร์</string>
-    <string name="error_unknown">Unknown error</string>
+    <string name="error_unknown">เกิดข้อผิดพลาดที่ไม่ทราบ</string>
     <string name="expand">ขยาย</string>
     <string name="expires_in">หมดอายุใน %d วินาที</string>
     <string name="failed_add_slot">เพิ่มช่องไม่สำเร็จ</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -248,6 +248,7 @@
     <string name="error_generic">เกิดข้อผิดพลาด</string>
     <string name="error_open_picker">ไม่สามารถเปิดตัวเลือกรูปภาพ</string>
     <string name="error_open_settings">ไม่สามารถเปิดการตั้งค่าวอลเปเปอร์</string>
+    <string name="error_unknown">Unknown error</string>
     <string name="expand">ขยาย</string>
     <string name="expires_in">หมดอายุใน %d วินาที</string>
     <string name="failed_add_slot">เพิ่มช่องไม่สำเร็จ</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -248,7 +248,7 @@
     <string name="error_generic">Đã xảy ra lỗi</string>
     <string name="error_open_picker">Không thể mở trình chọn ảnh</string>
     <string name="error_open_settings">Không thể mở cài đặt hình nền</string>
-    <string name="error_unknown">Unknown error</string>
+    <string name="error_unknown">Lỗi không xác định</string>
     <string name="expand">Mở rộng</string>
     <string name="expires_in">Hết hạn sau %d giây</string>
     <string name="failed_add_slot">Thêm vị trí thất bại</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -248,6 +248,7 @@
     <string name="error_generic">Đã xảy ra lỗi</string>
     <string name="error_open_picker">Không thể mở trình chọn ảnh</string>
     <string name="error_open_settings">Không thể mở cài đặt hình nền</string>
+    <string name="error_unknown">Unknown error</string>
     <string name="expand">Mở rộng</string>
     <string name="expires_in">Hết hạn sau %d giây</string>
     <string name="failed_add_slot">Thêm vị trí thất bại</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -248,7 +248,7 @@
     <string name="error_generic">发生错误</string>
     <string name="error_open_picker">无法打开照片选择器</string>
     <string name="error_open_settings">无法打开壁纸设置</string>
-    <string name="error_unknown">Unknown error</string>
+    <string name="error_unknown">未知错误</string>
     <string name="expand">展开</string>
     <string name="expires_in">%d秒后过期</string>
     <string name="failed_add_slot">添加槽位失败</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -248,6 +248,7 @@
     <string name="error_generic">发生错误</string>
     <string name="error_open_picker">无法打开照片选择器</string>
     <string name="error_open_settings">无法打开壁纸设置</string>
+    <string name="error_unknown">Unknown error</string>
     <string name="expand">展开</string>
     <string name="expires_in">%d秒后过期</string>
     <string name="failed_add_slot">添加槽位失败</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -248,7 +248,7 @@
     <string name="error_generic">發生錯誤</string>
     <string name="error_open_picker">無法開啟照片選擇器</string>
     <string name="error_open_settings">無法開啟桌布設定</string>
-    <string name="error_unknown">Unknown error</string>
+    <string name="error_unknown">未知錯誤</string>
     <string name="expand">展開</string>
     <string name="expires_in">%d 秒後過期</string>
     <string name="failed_add_slot">新增欄位失敗</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -248,6 +248,7 @@
     <string name="error_generic">發生錯誤</string>
     <string name="error_open_picker">無法開啟照片選擇器</string>
     <string name="error_open_settings">無法開啟桌布設定</string>
+    <string name="error_unknown">Unknown error</string>
     <string name="expand">展開</string>
     <string name="expires_in">%d 秒後過期</string>
     <string name="failed_add_slot">新增欄位失敗</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -244,6 +244,7 @@
     <string name="background_disabled">Background disabled</string>
     <string name="error_open_picker">Cannot open photo picker</string>
     <string name="error_open_settings">Cannot open wallpaper settings</string>
+    <string name="error_unknown">Unknown error</string>
     <string name="bot_label">🤖 %s</string>
     <string name="mission_completed_at">✓ %s</string>
     <string name="playback_failed">Playback failed</string>


### PR DESCRIPTION
## Summary
Replace hardcoded English 'Unknown error' fallback in `OfficialBorrowActivity.kt` with `getString(R.string.error_unknown)`.
Also add `error_unknown` key to `values/strings.xml` + 13 locale files.

## Changes
- `OfficialBorrowActivity.kt`: replace `e.message ?: "Unknown error"` with `e.message ?: getString(R.string.error_unknown)`
- `values/strings.xml`: +1 key `error_unknown=Unknown error`
- `values-{locale}/strings.xml` (13 files): +1 key per locale

## Testing
- Android lint: `./gradlew lint`
- Build: `./gradlew assembleDebug`

## Related
- card_3f6520b0