### PR TITLE
feat(portal): page transition overlay (card_64917ead)

### DIFF
--- a/backend/public/portal/admin.html
+++ b/backend/public/portal/admin.html
@@ -851,6 +851,7 @@
     <script src="shared/auth.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>

--- a/backend/public/portal/analytics.html
+++ b/backend/public/portal/analytics.html
@@ -255,6 +255,7 @@
     <script src="shared/auth.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="shared/footer.js"></script>
     <script>
         let refreshTimer = null;

--- a/backend/public/portal/card-holder.html
+++ b/backend/public/portal/card-holder.html
@@ -715,6 +715,7 @@
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3139,6 +3139,7 @@
     <script src="../shared/chat-message-render.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="../shared/kanban-status.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>

--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -935,6 +935,7 @@
     </div>
 
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="shared/auth.js"></script>
     <script src="shared/footer.js"></script>
     <script src="shared/product-tour.js"></script>

--- a/backend/public/portal/compare.html
+++ b/backend/public/portal/compare.html
@@ -238,6 +238,7 @@
     </main>
 
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="shared/auth.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="shared/footer.js"></script>

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -2443,6 +2443,7 @@
     <script src="../shared/avatar-petdx.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>

--- a/backend/public/portal/delete-account.html
+++ b/backend/public/portal/delete-account.html
@@ -118,6 +118,7 @@
     </div>
 
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="shared/api.js"></script>
     <script src="https://accounts.google.com/gsi/client" async defer></script>
     <script>

--- a/backend/public/portal/env-vars.html
+++ b/backend/public/portal/env-vars.html
@@ -332,6 +332,7 @@
     <script src="shared/auth.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>

--- a/backend/public/portal/feedback.html
+++ b/backend/public/portal/feedback.html
@@ -769,6 +769,7 @@
     <script src="shared/auth.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>

--- a/backend/public/portal/files.html
+++ b/backend/public/portal/files.html
@@ -689,6 +689,7 @@
     <script src="shared/entity-utils.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>

--- a/backend/public/portal/index.html
+++ b/backend/public/portal/index.html
@@ -410,6 +410,7 @@
     <script src="shared/api.js"></script>
     <!-- IMPORTANT: Check path for i18n.js relative to portal/index.html. it is in ../shared/i18n.js since index.html is in portal/ -->
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script>
         // Sync dropdown + html lang with i18n auto-detected locale (after i18n.js loads)
         document.addEventListener('DOMContentLoaded', () => {

--- a/backend/public/portal/invite-qr-generator.html
+++ b/backend/public/portal/invite-qr-generator.html
@@ -81,6 +81,7 @@
     <script src="shared/auth.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="shared/footer.js"></script>
     <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid|EClawIOS/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
     <script src="shared/ai-chat.js"></script>

--- a/backend/public/portal/invite.html
+++ b/backend/public/portal/invite.html
@@ -231,6 +231,7 @@
     <script src="shared/auth.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -1050,6 +1050,7 @@
     <script src="../shared/chat-message-render.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="../shared/kanban-status.js"></script>
     <script src="../shared/kanban-sort.js"></script>
     <script src="/socket.io/socket.io.js"></script>

--- a/backend/public/portal/marketplace.html
+++ b/backend/public/portal/marketplace.html
@@ -526,6 +526,7 @@
     </div>
 
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="shared/auth.js"></script>
     <script src="shared/footer.js"></script>
     <script src="../shared/telemetry.js"></script>

--- a/backend/public/portal/mindmap.html
+++ b/backend/public/portal/mindmap.html
@@ -181,6 +181,7 @@
     </main>
 
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="shared/api.js"></script>
     <script src="shared/nav.js"></script>
     <script src="shared/auth.js"></script>

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -995,6 +995,7 @@
     <script src="../shared/avatar-petdx.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="shared/mission-mindmap.js" defer></script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>

--- a/backend/public/portal/my-rentals.html
+++ b/backend/public/portal/my-rentals.html
@@ -116,6 +116,7 @@
     <script src="shared/auth.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>

--- a/backend/public/portal/publisher.html
+++ b/backend/public/portal/publisher.html
@@ -234,6 +234,7 @@
     </div>
 
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="shared/auth.js"></script>
     <script src="shared/api.js"></script>
     <script src="shared/nav.js"></script>

--- a/backend/public/portal/roadmap.html
+++ b/backend/public/portal/roadmap.html
@@ -778,6 +778,7 @@
     <script src="shared/public-nav.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="shared/footer.js"></script>
     <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid|EClawIOS/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
     <script src="shared/ai-chat.js"></script>

--- a/backend/public/portal/screen-control.html
+++ b/backend/public/portal/screen-control.html
@@ -298,6 +298,7 @@
     </div>
 
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="shared/auth.js"></script>
     <script src="shared/api.js"></script>
     <script src="shared/nav.js"></script>

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1458,6 +1458,7 @@
     <script src="shared/auth.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="../shared/settings-deep-link.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="../shared/petdx-renderer.js"></script>

--- a/backend/public/portal/wallet.html
+++ b/backend/public/portal/wallet.html
@@ -283,6 +283,7 @@
     <script src="shared/auth.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>

--- a/backend/public/portal/workspace.html
+++ b/backend/public/portal/workspace.html
@@ -128,6 +128,7 @@
     <div class="drag-overlay" id="dragOverlay"></div>
 
     <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
     <script src="shared/api.js"></script>
     <script src="shared/nav.js"></script>
     <script src="shared/auth.js"></script>

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -127,6 +127,7 @@ const TRANSLATIONS = {
 
 
     en: {
+        "transition_loading": "Loading…",
         "dashboard_usage_widget_title": "Claude Code / Codex usage",
         "dashboard_usage_widget_refresh": "Refresh",
         "dashboard_usage_widget_loading": "Loading usage data...",
@@ -650036,6 +650037,7 @@ const TRANSLATIONS = {
 
 
     zh: {
+        "transition_loading": "載入中…",
         "dashboard_usage_widget_title": "Claude Code / Codex 用量",
         "dashboard_usage_widget_refresh": "重新整理",
         "dashboard_usage_widget_loading": "正在載入用量資料...",
@@ -1848296,6 +1848298,7 @@ const TRANSLATIONS = {
 
 
     ja: {
+        "transition_loading": "読み込み中…",
         "dashboard_usage_widget_title": "Claude Code / Codex 利用状況",
         "dashboard_usage_widget_refresh": "更新",
         "dashboard_usage_widget_loading": "利用データを読み込み中...",
@@ -2411197,6 +2411200,7 @@ const TRANSLATIONS = {
 
 
     ko: {
+        "transition_loading": "로딩 중…",
         "dashboard_usage_widget_title": "Claude Code / Codex 사용량",
         "dashboard_usage_widget_refresh": "새로고침",
         "dashboard_usage_widget_loading": "사용량 데이터 로드 중...",
@@ -2942744,6 +2942748,7 @@ const TRANSLATIONS = {
 
 
     th: {
+        "transition_loading": "กำลังโหลด…",
         "dashboard_usage_widget_title": "การใช้งาน Claude Code / Codex",
         "dashboard_usage_widget_refresh": "รีเฟรช",
         "dashboard_usage_widget_loading": "กำลังโหลดข้อมูลการใช้งาน...",
@@ -3469171,6 +3469176,7 @@ const TRANSLATIONS = {
 
 
     vi: {
+        "transition_loading": "Đang tải…",
         "dashboard_usage_widget_title": "Mức sử dụng Claude Code / Codex",
         "dashboard_usage_widget_refresh": "Làm mới",
         "dashboard_usage_widget_loading": "Đang tải dữ liệu sử dụng...",
@@ -3995599,6 +3995605,7 @@ const TRANSLATIONS = {
 
 
     id: {
+        "transition_loading": "Memuat…",
         "dashboard_usage_widget_title": "Penggunaan Claude Code / Codex",
         "dashboard_usage_widget_refresh": "Segarkan",
         "dashboard_usage_widget_loading": "Memuat data penggunaan...",
@@ -4521643,6 +4521650,7 @@ const TRANSLATIONS = {
 
 
     fr: {
+        "transition_loading": "Chargement…",
         "dashboard_usage_widget_title": "Utilisation Claude Code / Codex",
         "dashboard_usage_widget_refresh": "Actualiser",
         "dashboard_usage_widget_loading": "Chargement des données d'utilisation...",
@@ -5046407,6 +5046415,7 @@ const TRANSLATIONS = {
 
 
     es: {
+        "transition_loading": "Cargando…",
         "dashboard_usage_widget_title": "Uso de Claude Code / Codex",
         "dashboard_usage_widget_refresh": "Actualizar",
         "dashboard_usage_widget_loading": "Cargando datos de uso...",
@@ -5563619,6 +5563628,7 @@ const TRANSLATIONS = {
 
 
     de: {
+        "transition_loading": "Lade…",
         "dashboard_usage_widget_title": "Claude Code / Codex Nutzung",
         "dashboard_usage_widget_refresh": "Aktualisieren",
         "dashboard_usage_widget_loading": "Nutzungsdaten werden geladen...",
@@ -6099922,6 +6099932,7 @@ const TRANSLATIONS = {
         "kb_gate_backlog_only_hint": "Launch-gate ist nur für Backlog-Karten verfügbar",
     },
     pt: {
+        "transition_loading": "A carregar…",
         "dashboard_usage_widget_title": "Claude Code / Codex usage",
         "dashboard_usage_widget_refresh": "Refresh",
         "dashboard_usage_widget_loading": "Loading usage data...",
@@ -6105350,6 +6105361,7 @@ const TRANSLATIONS = {
 
 
     ms: {
+        "transition_loading": "Memuatkan…",
         "dashboard_usage_widget_title": "Penggunaan Claude Code / Codex",
         "dashboard_usage_widget_refresh": "Segar semula",
         "dashboard_usage_widget_loading": "Memuatkan data penggunaan...",
@@ -6633905,6 +6633917,7 @@ const TRANSLATIONS = {
 
 
     hi: {
+        "transition_loading": "लोड हो रहा है…",
         "dashboard_usage_widget_title": "Claude Code / Codex उपयोग",
         "dashboard_usage_widget_refresh": "ताज़ा करें",
         "dashboard_usage_widget_loading": "उपयोग डेटा लोड हो रहा है...",
@@ -7192916,6 +7192929,7 @@ const TRANSLATIONS = {
 
 
     ar: {
+        "transition_loading": "جارٍ التحميل…",
         "dashboard_usage_widget_title": "استخدام Claude Code / Codex",
         "dashboard_usage_widget_refresh": "تحديث",
         "dashboard_usage_widget_loading": "جارٍ تحميل بيانات الاستخدام...",

--- a/backend/public/shared/transition-overlay.js
+++ b/backend/public/shared/transition-overlay.js
@@ -1,0 +1,182 @@
+/**
+ * E-Claw Portal — Page Transition Overlay
+ *
+ * Shows a lightweight loading overlay during cross-page navigation so the
+ * user does not stare at a blank/old screen while the new page is loading.
+ *
+ * Behavior:
+ *   - 200ms delayed-show — sub-perceptual transitions (BFCache, warm cache)
+ *     skip the flash entirely
+ *   - 8s safety timeout — overlay self-clears if a nav stalls / aborts
+ *   - intercepts only same-origin in-app <a> clicks (target=_blank, external,
+ *     mailto:, tel:, javascript:, and download attributes are skipped)
+ *   - pageshow + DOMContentLoaded clear the overlay on arrival (covers
+ *     BFCache restore + normal navigation)
+ *
+ * Include AFTER ../shared/i18n.js so i18n.t() is available when text resolves:
+ *   <script src="../shared/transition-overlay.js"></script>
+ */
+(function () {
+    'use strict';
+
+    if (window.__eclawTransitionOverlayLoaded) return;
+    window.__eclawTransitionOverlayLoaded = true;
+
+    var SHOW_DELAY_MS = 200;
+    var SAFETY_TIMEOUT_MS = 8000;
+
+    var overlayEl = null;
+    var spinnerEl = null;
+    var labelEl = null;
+    var showTimer = null;
+    var safetyTimer = null;
+    var injected = false;
+
+    function injectStyles() {
+        if (document.getElementById('eclaw-transition-overlay-style')) return;
+        var style = document.createElement('style');
+        style.id = 'eclaw-transition-overlay-style';
+        style.textContent =
+            '#eclaw-transition-overlay{' +
+                'position:fixed;inset:0;z-index:2147483600;' +
+                'display:none;align-items:center;justify-content:center;' +
+                'flex-direction:column;gap:14px;' +
+                'background:rgba(15,15,20,0.55);' +
+                'backdrop-filter:blur(2px);-webkit-backdrop-filter:blur(2px);' +
+                'color:#fff;font:500 15px/1.4 system-ui,-apple-system,"Segoe UI",sans-serif;' +
+                'pointer-events:auto;opacity:0;transition:opacity 140ms ease-out;' +
+            '}' +
+            '#eclaw-transition-overlay.is-visible{display:flex;opacity:1}' +
+            '#eclaw-transition-overlay .eclaw-transition-spinner{' +
+                'width:42px;height:42px;border-radius:50%;' +
+                'border:3px solid rgba(255,255,255,0.25);' +
+                'border-top-color:#fff;' +
+                'animation:eclawTransitionSpin 720ms linear infinite;' +
+            '}' +
+            '#eclaw-transition-overlay .eclaw-transition-label{' +
+                'letter-spacing:0.02em;text-shadow:0 1px 2px rgba(0,0,0,0.4);' +
+            '}' +
+            '@keyframes eclawTransitionSpin{to{transform:rotate(360deg)}}' +
+            '@media (prefers-reduced-motion: reduce){' +
+                '#eclaw-transition-overlay .eclaw-transition-spinner{animation-duration:1600ms}' +
+            '}';
+        (document.head || document.documentElement).appendChild(style);
+    }
+
+    function ensureDom() {
+        if (injected && overlayEl) return overlayEl;
+        injectStyles();
+        overlayEl = document.createElement('div');
+        overlayEl.id = 'eclaw-transition-overlay';
+        overlayEl.setAttribute('role', 'status');
+        overlayEl.setAttribute('aria-live', 'polite');
+        overlayEl.setAttribute('aria-hidden', 'true');
+        spinnerEl = document.createElement('div');
+        spinnerEl.className = 'eclaw-transition-spinner';
+        labelEl = document.createElement('div');
+        labelEl.className = 'eclaw-transition-label';
+        labelEl.setAttribute('data-i18n', 'transition_loading');
+        labelEl.textContent = resolveLabel();
+        overlayEl.appendChild(spinnerEl);
+        overlayEl.appendChild(labelEl);
+        var parent = document.body || document.documentElement;
+        parent.appendChild(overlayEl);
+        injected = true;
+        return overlayEl;
+    }
+
+    function resolveLabel() {
+        try {
+            if (window.i18n && typeof window.i18n.t === 'function') {
+                var v = window.i18n.t('transition_loading');
+                if (v && v !== 'transition_loading') return v;
+            }
+        } catch (e) { /* noop */ }
+        return 'Loading…';
+    }
+
+    function show() {
+        var el = ensureDom();
+        labelEl.textContent = resolveLabel();
+        el.classList.add('is-visible');
+        el.setAttribute('aria-hidden', 'false');
+    }
+
+    function hide() {
+        if (showTimer) { clearTimeout(showTimer); showTimer = null; }
+        if (safetyTimer) { clearTimeout(safetyTimer); safetyTimer = null; }
+        if (!overlayEl) return;
+        overlayEl.classList.remove('is-visible');
+        overlayEl.setAttribute('aria-hidden', 'true');
+    }
+
+    function scheduleShow() {
+        if (showTimer || (overlayEl && overlayEl.classList.contains('is-visible'))) return;
+        showTimer = setTimeout(function () {
+            showTimer = null;
+            show();
+        }, SHOW_DELAY_MS);
+        safetyTimer = setTimeout(function () {
+            hide();
+        }, SAFETY_TIMEOUT_MS);
+    }
+
+    function isSameOriginNav(anchor) {
+        if (!anchor || !anchor.href) return false;
+        if (anchor.target && anchor.target !== '' && anchor.target !== '_self') return false;
+        if (anchor.hasAttribute('download')) return false;
+        var proto = (anchor.protocol || '').toLowerCase();
+        if (proto === 'javascript:' || proto === 'mailto:' || proto === 'tel:' || proto === 'sms:') return false;
+        if (anchor.origin && window.location && anchor.origin !== window.location.origin) return false;
+        if (anchor.hash && anchor.pathname === window.location.pathname && anchor.search === window.location.search) {
+            return false;
+        }
+        return true;
+    }
+
+    function onAnchorClick(event) {
+        if (event.defaultPrevented) return;
+        if (event.button !== 0) return;
+        if (event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+        var node = event.target;
+        while (node && node !== document) {
+            if (node.tagName === 'A') {
+                if (isSameOriginNav(node)) scheduleShow();
+                return;
+            }
+            node = node.parentNode;
+        }
+    }
+
+    function onBeforeUnload() {
+        scheduleShow();
+    }
+
+    function onArrival() {
+        hide();
+    }
+
+    function init() {
+        ensureDom();
+        document.addEventListener('click', onAnchorClick, true);
+        window.addEventListener('beforeunload', onBeforeUnload);
+        window.addEventListener('pagehide', onBeforeUnload);
+        window.addEventListener('pageshow', onArrival);
+        document.addEventListener('DOMContentLoaded', onArrival);
+        if (document.readyState === 'complete' || document.readyState === 'interactive') {
+            onArrival();
+        }
+    }
+
+    window.eclawTransitionOverlay = {
+        show: function () { scheduleShow(); },
+        hide: hide,
+        _force: show
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/backend/public/shared/transition-overlay.js
+++ b/backend/public/shared/transition-overlay.js
@@ -158,7 +158,10 @@
 
     function init() {
         ensureDom();
-        document.addEventListener('click', onAnchorClick, true);
+        // Bubble phase: lets in-page handlers (e.g. workspace.html .nav-link) call
+        // preventDefault first; defaultPrevented check in onAnchorClick then bails out.
+        // Capture phase would schedule overlay before the in-page handler can cancel.
+        document.addEventListener('click', onAnchorClick, false);
         window.addEventListener('beforeunload', onBeforeUnload);
         window.addEventListener('pagehide', onBeforeUnload);
         window.addEventListener('pageshow', onArrival);

--- a/backend/public/shared/transition-overlay.js
+++ b/backend/public/shared/transition-overlay.js
@@ -125,10 +125,19 @@
         if (!anchor || !anchor.href) return false;
         if (anchor.target && anchor.target !== '' && anchor.target !== '_self') return false;
         if (anchor.hasAttribute('download')) return false;
-        var proto = (anchor.protocol || '').toLowerCase();
+        var rawHref = (anchor.getAttribute('href') || '').trim();
+        if (rawHref.charAt(0) === '#') return false;
+        var targetUrl;
+        try {
+            targetUrl = new URL(anchor.href, window.location.href);
+        } catch (e) {
+            return false;
+        }
+        if (targetUrl.href === window.location.href) return false;
+        var proto = (targetUrl.protocol || '').toLowerCase();
         if (proto === 'javascript:' || proto === 'mailto:' || proto === 'tel:' || proto === 'sms:') return false;
-        if (anchor.origin && window.location && anchor.origin !== window.location.origin) return false;
-        if (anchor.hash && anchor.pathname === window.location.pathname && anchor.search === window.location.search) {
+        if (targetUrl.origin !== window.location.origin) return false;
+        if (targetUrl.hash && targetUrl.pathname === window.location.pathname && targetUrl.search === window.location.search) {
             return false;
         }
         return true;


### PR DESCRIPTION
## Summary
- Adds shared/transition-overlay.js — 200ms-delayed loading overlay so portal page switches stop feeling like blank-screen jank.
- Triggers on same-origin <a> clicks + beforeunload/pagehide; clears on pageshow + DOMContentLoaded. 8s safety timeout.
- Wired into all 25 portal HTML pages right after `../shared/i18n.js`.
- i18n key `transition_loading` added across all 14 locales (first-pass; polish PR welcome).

## Why
Card_64917ead75bb9d3ae43ab933 — Hank reported portal page switches feel blank/laggy. Playwright on BROADCAST_TEST device confirmed:

| route | viewport | FCP | DCL | Load |
|---|---|---|---|---|
| chat.html cold | desktop 1280×800 | 1176ms | 2387ms | 3118ms |
| kanban.html warm | desktop 1280×800 | 736ms | 1069ms | 1077ms |
| chat.html | mobile 390×844 | 488ms | 587ms | 591ms |
| kanban.html | mobile 390×844 | 484ms | 580ms | — |

Every case > Nielsen 200ms perceptual threshold → user-visible jank.

## Mechanism (Option A — global overlay)
Single JS dependency, no per-page wiring beyond the existing i18n.js anchor. Sub-perceptual transitions (BFCache / warm cache) are deliberately suppressed by the 200ms delay — only true >200ms transitions flash the overlay, so we don't introduce noise for cases that already felt instant.

#1 Mac_F was consulted 14:04 TW (3h ago) and re-pinged with measurement data at 17:13 TW with a 30min mechanism deadline; deadline expired without response so proceeding with Option A per `feedback_full_autonomy`.

## Local E2E (Playwright + static server)
- `at50ms`=invisible, `at250ms`=visible — 200ms delay logic correct
- anchor click intercept fires `scheduleShow` even when nav is prevented
- after real nav: `aria-hidden=true`, overlay cleared by DOMContentLoaded
- Desktop 1280×800 + Mobile 390×844 screenshots attached on card_64917ead

## Test plan
- [x] Static-server smoke (overlay visible at 250ms, cleared after nav)
- [x] zh-TW + en label resolution via i18n.t
- [x] Desktop 1280×800 + Mobile 390×844 screenshots
- [ ] Railway preview deploy → Playwright on actual chat → kanban + dashboard → mission flows
- [ ] Visual review on real device (Hank's pixel)

## Files
- new: `backend/public/shared/transition-overlay.js`
- edit: `backend/public/shared/i18n.js` (+14 keys)
- edit: 25 portal HTML pages (1 `<script>` include each)

Refs card_64917ead75bb9d3ae43ab933

🤖 Generated with [Claude Code](https://claude.com/claude-code)