### PR TITLE
chore(publisher): retire Hashnode (pay-or-drop → drop)

### DIFF
--- a/backend/article-publisher.js
+++ b/backend/article-publisher.js
@@ -1,6 +1,8 @@
 // Article Publisher — Multi-platform article publishing
-// Supported: Blogger, Hashnode, X/Twitter, DEV.to, WordPress.com, Telegraph, Qiita, WeChat,
-//            Tumblr, Reddit, LinkedIn, Mastodon
+// Supported: Blogger, X/Twitter, DEV.to, Telegraph, Qiita, WeChat,
+//            Tumblr, Reddit, LinkedIn
+// Retired: Hashnode (2026-05-27, pay-or-drop → drop), WordPress.com (2026-04-20),
+//          Mastodon (2026-04-15)
 const express = require('express');
 const crypto = require('crypto');
 const OAuth = require('oauth-1.0a');
@@ -69,13 +71,10 @@ const BLOGGER_CREDS_MISSING = {
     error: 'Blogger credentials not set for this device',
     setup_url: '/portal/publisher-setup.html'
 };
-const HASHNODE_API_TOKEN = process.env.HASHNODE_API_TOKEN;
-const HASHNODE_GQL_ENDPOINT = 'https://gql.hashnode.com';
-const HASHNODE_CRED_KEYS = ['HASHNODE_API_TOKEN'];
-const HASHNODE_CREDS_MISSING = {
-    error: 'Hashnode credentials not set for this device',
-    setup_url: '/portal/publisher-setup.html'
-};
+// Hashnode retired 2026-05-27 (pay-or-drop decision — vendor required paid tier
+// for posting beyond a low free quota; ROI didn't justify $25/mo). Routes,
+// constants, and DB tokens removed wholesale; reads from old data won't find
+// a hashnode entry in the platforms list / probes.
 
 // DEV.to (Forem API)
 const DEVTO_API_KEY = process.env.DEVTO_API_KEY;
@@ -606,106 +605,7 @@ router.delete('/blogger/post/:postId', async (req, res) => {
     }
 });
 
-// ============================================
-// HASHNODE PUBLISH / DELETE
-// ============================================
-
-// Resolve the Hashnode API token (vault-first, env fallback). Returns
-// { token, source: 'vault'|'env'|'missing' }. Caller passes token into hashnodeGQL.
-async function resolveHashnodeCreds(deviceId) {
-    if (deviceId && typeof _getDeviceVar === 'function') {
-        try {
-            const v = await _getDeviceVar(deviceId, HASHNODE_CRED_KEYS[0]);
-            if (typeof v === 'string' && v.length > 0) return { token: v, source: 'vault' };
-        } catch (_) { /* fall through to env */ }
-    }
-    if (HASHNODE_API_TOKEN) return { token: HASHNODE_API_TOKEN, source: 'env' };
-    return { token: null, source: 'missing' };
-}
-
-async function hashnodeGQL(query, variables = {}, token = HASHNODE_API_TOKEN) {
-    const res = await fetch(HASHNODE_GQL_ENDPOINT, {
-        method: 'POST',
-        headers: {
-            'Content-Type': 'application/json',
-            Authorization: token
-        },
-        body: JSON.stringify({ query, variables })
-    });
-    const data = await res.json();
-    if (data.errors) throw new Error(data.errors.map(e => e.message).join('; '));
-    return data.data;
-}
-
-// Get current user's publications
-router.get('/hashnode/me', async (req, res) => {
-    try {
-        const deviceId = req.query?.deviceId || null;
-        const { token, source } = await resolveHashnodeCreds(deviceId);
-        if (!token) return res.status(400).json(HASHNODE_CREDS_MISSING);
-        const data = await hashnodeGQL(`query { me { id username publications(first: 10) { edges { node { id title url } } } } }`, {}, token);
-        res.json({ success: true, user: data.me, _credSource: source });
-    } catch (err) {
-        res.status(500).json({ error: err.message });
-    }
-});
-
-router.post('/hashnode/publish', express.json(), async (req, res) => {
-    const { publicationId, title, contentMarkdown, tags, slug, includeReferralCTA, deviceId } = req.body;
-    if (!publicationId || !title || !contentMarkdown) {
-        return res.status(400).json({ error: 'publicationId, title, contentMarkdown required' });
-    }
-
-    try {
-        const { token, source } = await resolveHashnodeCreds(deviceId || null);
-        if (!token) return res.status(400).json(HASHNODE_CREDS_MISSING);
-
-        const finalMarkdown = appendReferralCTA(contentMarkdown, { format: 'md', locale: 'en', skip: includeReferralCTA === false });
-
-        const data = await hashnodeGQL(`
-            mutation PublishPost($input: PublishPostInput!) {
-                publishPost(input: $input) {
-                    post { id title slug url }
-                }
-            }
-        `, {
-            input: {
-                publicationId,
-                title,
-                contentMarkdown: finalMarkdown,
-                slug: slug || title.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, ''),
-                tags: tags ? tags.map(t => typeof t === 'string' ? { slug: t, name: t } : t) : []
-            }
-        }, token);
-        const post = data.publishPost.post;
-        console.log(`[Publisher] Hashnode post created: ${post.id} "${title}" (creds: ${source})`);
-        res.json({ success: true, platform: 'hashnode', postId: post.id, url: post.url, slug: post.slug });
-    } catch (err) {
-        console.error('[Publisher] Hashnode publish error:', err);
-        res.status(500).json({ error: err.message });
-    }
-});
-
-router.delete('/hashnode/post/:postId', express.json(), async (req, res) => {
-    const { postId } = req.params;
-    const deviceId = req.body?.deviceId || req.query?.deviceId || null;
-    try {
-        const { token } = await resolveHashnodeCreds(deviceId);
-        if (!token) return res.status(400).json(HASHNODE_CREDS_MISSING);
-        await hashnodeGQL(`
-            mutation RemovePost($id: ID!) {
-                removePost(input: { id: $id }) {
-                    post { id }
-                }
-            }
-        `, { id: postId }, token);
-        console.log(`[Publisher] Hashnode post deleted: ${postId}`);
-        res.json({ success: true, platform: 'hashnode', deleted: postId });
-    } catch (err) {
-        console.error('[Publisher] Hashnode delete error:', err);
-        res.status(500).json({ error: err.message });
-    }
-});
+// Hashnode publish/delete routes removed 2026-05-27 (pay-or-drop → drop).
 
 // ============================================
 // X (TWITTER) PUBLISH / REPLY / DELETE
@@ -2307,8 +2207,7 @@ function getPlatformsStatus() {
     return [
         { id: 'blogger', name: 'Blogger', region: 'global', authType: 'oauth', contentFormat: 'html',
           configured: !!(BLOGGER_CLIENT_ID && BLOGGER_CLIENT_SECRET) },
-        { id: 'hashnode', name: 'Hashnode', region: 'global', authType: 'api_key', contentFormat: 'markdown',
-          configured: !!HASHNODE_API_TOKEN },
+        // Hashnode retired 2026-05-27 (pay-or-drop → drop).
         { id: 'x', name: 'X (Twitter)', region: 'global', authType: 'oauth1a', contentFormat: 'text',
           configured: !!(process.env.X_CONSUMER_KEY && process.env.X_ACCESS_TOKEN) },
         { id: 'devto', name: 'DEV.to', region: 'global', authType: 'api_key', contentFormat: 'markdown',
@@ -2363,18 +2262,7 @@ router.get('/health', async (req, res) => {
             // Blogger uses DB-backed OAuth; checking if we have stored tokens is enough
             return { configured: true };
         }),
-        // Hashnode
-        probe('hashnode', 'Hashnode', async () => {
-            if (!HASHNODE_API_TOKEN) return { skip: true, reason: 'HASHNODE_API_TOKEN not set' };
-            const r = await fetch(HASHNODE_GQL_ENDPOINT, {
-                method: 'POST',
-                headers: { Authorization: HASHNODE_API_TOKEN, 'Content-Type': 'application/json' },
-                body: JSON.stringify({ query: '{ me { id username } }' })
-            });
-            const d = await r.json();
-            if (d.errors) throw Object.assign(new Error(d.errors[0].message), { status: 401 });
-            return { user: d.data?.me?.username };
-        }),
+        // Hashnode probe removed 2026-05-27 — platform retired.
         // DEV.to
         probe('devto', 'DEV.to', async () => {
             if (!DEVTO_API_KEY) return { skip: true, reason: 'DEVTO_API_KEY not set' };

--- a/backend/docs/specs/vault.md
+++ b/backend/docs/specs/vault.md
@@ -5,7 +5,7 @@
 **Db tables:** `device_vars` (one row per device), `device_vars_audit` (append-only mutation log)
 
 The vault is the per-device secret store: env-style key/value pairs (X_API_KEY,
-ANTHROPIC_API_KEY, HASHNODE_PUBLICATION_ID, …) that an entity needs at runtime
+ANTHROPIC_API_KEY, DEVTO_API_KEY, …) that an entity needs at runtime
 but the platform must not see in plaintext. This spec captures the encryption
 boundary, the dual-auth read model, the no-whitelist rule for rental, and the
 mutation safeguards. Constants are cited **by name + value** so a grep against

--- a/backend/index.js
+++ b/backend/index.js
@@ -2179,7 +2179,7 @@ app.use('/api/oauth', oauthServer.router);
 oauthServer.initOAuthDatabase();
 
 // ============================================
-// ARTICLE PUBLISHER — Blogger + Hashnode
+// ARTICLE PUBLISHER — Blogger + DEV.to + X + Qiita + Tumblr + Reddit + LinkedIn + Telegraph + WeChat
 // ============================================
 const articlePublisher = require('./article-publisher');
 app.use('/api/publisher', articlePublisher.router);

--- a/backend/public/llms.txt
+++ b/backend/public/llms.txt
@@ -17,7 +17,7 @@ EClawbot (eclawbot.com) is an A2A communication platform and personal enterprise
 - **Chat Vector Search**: Semantic search powered by pgvector cosine similarity with keyword fallback
 - **Discord Integration**: Native Discord slash commands (/ask, /status, /mission) with Ed25519 signature verification
 - **Community Hub**: Community template hub for sharing and discovering bot skill, soul, and rule templates
-- **Article Publishing**: Multi-platform publishing to 12 platforms (Blogger, Hashnode, X, DEV.to, WordPress, Telegraph, Qiita, WeChat, Tumblr, Reddit, LinkedIn, Mastodon)
+- **Article Publishing**: Multi-platform publishing to 9 platforms (Blogger, X, DEV.to, Telegraph, Qiita, WeChat, Tumblr, Reddit, LinkedIn)
 - **GPS Recommendations**: Location-based entity discovery and smart recommendations
 - **Multi-Platform**: Web Portal, Android app, and iOS app with feature parity
 - **OpenClaw Integration**: Channel-based plugin system for the OpenClaw ecosystem

--- a/backend/public/portal/assets/slides/info-guide-publisher.html
+++ b/backend/public/portal/assets/slides/info-guide-publisher.html
@@ -16,8 +16,8 @@
   <main class="slide">
     <section>
       <div class="eyebrow">🌐 Guide / Publisher</div>
-      <h1>一篇內容，<span class="accent">發布到 10 個平台</span></h1>
-      <p class="lead">EClaw Publisher 把 X、Blogger、Hashnode、DEV.to 等 10 個內容平台，統一成同一組可自動化的發布 API。</p>
+      <h1>一篇內容，<span class="accent">發布到 9 個平台</span></h1>
+      <p class="lead">EClaw Publisher 把 X、Blogger、DEV.to、Qiita 等 9 個內容平台，統一成同一組可自動化的發布 API。</p>
       <div class="bullets">
         <div><b>🔑</b><span>每個 device 使用自己的 vault keys，不再共用 owner 的全站 env 金鑰。</span></div>
         <div><b>🧪</b><span>每個平台都有 safe self-check endpoint，先驗證金鑰，不會誤發布。</span></div>
@@ -30,12 +30,11 @@
           <h2>Vault-first，多租戶內容中控台</h2>
           <p>每個平台各自 resolve credentials；vault miss 才 fallback env，兼容舊部署又支援用戶自帶金鑰。</p>
         </div>
-        <div class="badge"><strong>10</strong><span>PLATFORMS</span></div>
+        <div class="badge"><strong>9</strong><span>PLATFORMS</span></div>
       </div>
       <div class="platforms">
         <div class="platform"><b>𝕏</b><strong>X</strong><span>OAuth1a</span></div>
         <div class="platform"><b>📝</b><strong>Blogger</strong><span>OAuth2</span></div>
-        <div class="platform"><b>🟢</b><strong>Hashnode</strong><span>API token</span></div>
         <div class="platform"><b>💻</b><strong>DEV.to</strong><span>API key</span></div>
         <div class="platform"><b>⚡</b><strong>Telegraph</strong><span>auto-key</span></div>
         <div class="platform"><b>🇯🇵</b><strong>Qiita</strong><span>Bearer</span></div>

--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -3914,9 +3914,9 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
 
                         <h2 data-i18n="guide_pub_overview_h">總覽</h2>
                         <p data-i18n="guide_pub_overview_desc">
-                            <code>backend/article-publisher.js</code> 把 10 個內容平台統一在 <code>/api/publisher/&lt;platform&gt;/*</code> 之下。
+                            <code>backend/article-publisher.js</code> 把 9 個內容平台統一在 <code>/api/publisher/&lt;platform&gt;/*</code> 之下。
                             「多租戶」指的是<strong>每個 device 用自己金鑰庫裡的金鑰</strong>呼叫對應平台，而非全站共用 owner 一把 env 金鑰。
-                            9 個需要金鑰的平台（X、Hashnode、DEV.to、Qiita、LinkedIn、Reddit、Tumblr、Blogger、WeChat）全部走 vault-first 流程：每平台一個 <code>resolve&lt;Platform&gt;Creds(deviceId)</code>，先讀 device vault，缺 key 才 fallback 到 <code>process.env</code>。Telegraph 是 auto-key（首次呼叫匿名建帳）所以不需要 vault 路徑。
+                            8 個需要金鑰的平台（X、DEV.to、Qiita、LinkedIn、Reddit、Tumblr、Blogger、WeChat）全部走 vault-first 流程：每平台一個 <code>resolve&lt;Platform&gt;Creds(deviceId)</code>，先讀 device vault，缺 key 才 fallback 到 <code>process.env</code>。Telegraph 是 auto-key（首次呼叫匿名建帳）所以不需要 vault 路徑。
                         </p>
 
                         <h2 data-i18n="guide_pub_status_h">平台狀態總表</h2>
@@ -3948,13 +3948,6 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                                     <td>global</td>
                                     <td>OAuth2</td>
                                     <td><code>BLOGGER_CLIENT_ID</code> · <code>BLOGGER_CLIENT_SECRET</code> （+ DB refresh_token）</td>
-                                    <td><span class="pub-badge pub-badge-vault">🔓 vault-first</span></td>
-                                </tr>
-                                <tr>
-                                    <td><strong>Hashnode</strong></td>
-                                    <td>global</td>
-                                    <td>API Key</td>
-                                    <td><code>HASHNODE_API_TOKEN</code></td>
                                     <td><span class="pub-badge pub-badge-vault">🔓 vault-first</span></td>
                                 </tr>
                                 <tr>
@@ -4026,7 +4019,7 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
                         <h2 data-i18n="guide_pub_roadmap_h">已完工：multi-tenant migration 全平台上線 ✅</h2>
                         <p data-i18n="guide_pub_roadmap_desc">2026-04 完工。9 個需要金鑰的平台全部走 vault-first；Telegraph 為 auto-key 不需 vault。一律 backwards-compat：vault 缺 key 自動 fallback 到 <code>process.env</code>，舊部署零影響。下表為各平台簽章類型 + 上線 PR 對照：</p>
                         <ol>
-                            <li data-i18n="guide_pub_roadmap_step1"><strong>1-key bearer 平台</strong>（Hashnode / DEV.to / Qiita）：單把 API token，最簡單，先收尾。</li>
+                            <li data-i18n="guide_pub_roadmap_step1"><strong>1-key bearer 平台</strong>（DEV.to / Qiita）：單把 API token，最簡單，先收尾。</li>
                             <li data-i18n="guide_pub_roadmap_step2"><strong>2-key bearer + URN</strong>（LinkedIn）：access_token + author URN，兩把都從 vault 取。</li>
                             <li data-i18n="guide_pub_roadmap_step3"><strong>4-key OAuth1a 即時簽章</strong>（X / Tumblr）：consumer + access 各一對，每次 request 用 HMAC-SHA1 即時簽 nonce + timestamp。</li>
                             <li data-i18n="guide_pub_roadmap_step4"><strong>4-key OAuth2 password grant + per-tenant token cache</strong>（Reddit）：username/password 換 access_token，cache 用 <code>Map keyed by clientId+username</code> 防跨租戶污染。</li>
@@ -4039,9 +4032,9 @@ curl -s -X POST "https://eclawbot.com/api/mission/note/update" \
 curl -s -H "X-Publisher-Key: $PUBLISHER_API_KEY" \
   "https://eclawbot.com/api/publisher/x/me?deviceId=DEVICE_ID"
 
-# Hashnode / DEV.to / Qiita / Tumblr / Reddit / LinkedIn / WeChat / Blogger / Telegraph
+# DEV.to / Qiita / Tumblr / Reddit / LinkedIn / WeChat / Blogger / Telegraph
 # 全都有對應 GET /&lt;platform&gt;/me 或 /status，回 200 = 金鑰活著
-for p in hashnode devto qiita tumblr reddit linkedin; do
+for p in devto qiita tumblr reddit linkedin; do
   echo "=== $p ==="
   curl -s -H "X-Publisher-Key: $PUBLISHER_API_KEY" \
     "https://eclawbot.com/api/publisher/$p/me" | head -c 200

--- a/backend/public/portal/publisher.html
+++ b/backend/public/portal/publisher.html
@@ -374,23 +374,7 @@
                 }),
                 path: '/api/publisher/devto/publish'
             },
-            hashnode: {
-                fields: [
-                    { key: 'publicationId', type: 'text', label: 'Publication ID',
-                        hint: 'Hashnode publicationId — required. Add to device-vars as HASHNODE_PUBLICATION_ID and paste here, or use your workspace URL.' ,
-                        required: true },
-                    { key: 'title', type: 'text', label: 'Title', required: true },
-                    { key: 'contentMarkdown', type: 'textarea', label: 'Markdown body', required: true, tall: true },
-                    { key: 'tags', type: 'text', label: 'Tags (comma-separated)' }
-                ],
-                toBody: s => ({
-                    publicationId: s.publicationId,
-                    title: s.title,
-                    contentMarkdown: s.contentMarkdown,
-                    tags: splitTags(s.tags)
-                }),
-                path: '/api/publisher/hashnode/publish'
-            },
+            // Hashnode form removed 2026-05-27 — platform retired.
             qiita: {
                 fields: [
                     { key: 'title', type: 'text', label: 'Title', required: true },

--- a/backend/tests/jest/monitoring.test.js
+++ b/backend/tests/jest/monitoring.test.js
@@ -265,19 +265,19 @@ describe('classifyPublisher (threshold math)', () => {
     const { _classifyPublisher: classify } = require('../../index');
 
     it('configured platform with no error → connected', () => {
-        expect(classify({ id: 'hashnode', configured: true })).toBe('connected');
+        expect(classify({ id: 'devto', configured: true })).toBe('connected');
     });
 
     it('configured but lastError → disconnected', () => {
-        expect(classify({ id: 'hashnode', configured: true, error: 'token expired' })).toBe('disconnected');
+        expect(classify({ id: 'devto', configured: true, error: 'token expired' })).toBe('disconnected');
     });
 
     it('configured but expiresAt in past → disconnected', () => {
-        expect(classify({ id: 'hashnode', configured: true, expiresAt: Date.now() - 1000 })).toBe('disconnected');
+        expect(classify({ id: 'devto', configured: true, expiresAt: Date.now() - 1000 })).toBe('disconnected');
     });
 
     it('configured with future expiresAt → connected', () => {
-        expect(classify({ id: 'hashnode', configured: true, expiresAt: Date.now() + 1000 })).toBe('connected');
+        expect(classify({ id: 'devto', configured: true, expiresAt: Date.now() + 1000 })).toBe('connected');
     });
 
     it('unconfigured platform with no setup trace → unconfigured', () => {
@@ -340,7 +340,7 @@ describe('GET /api/monitoring/rental-health threshold math (status)', () => {
         const origFn = articlePublisher.getPlatformsStatus;
         articlePublisher.getPlatformsStatus = () => ([
             { id: 'blogger', name: 'Blogger', region: 'global', configured: true, error: 'token expired' },
-            { id: 'hashnode', name: 'Hashnode', region: 'global', configured: true, error: 'api quota exceeded' },
+            { id: 'qiita', name: 'Qiita', region: 'ja', configured: true, error: 'api quota exceeded' },
             { id: 'devto', name: 'DEV.to', region: 'global', configured: true, error: 'unauthorized' },
             { id: 'telegraph', name: 'Telegraph', region: 'global', configured: true },
         ]);
@@ -360,7 +360,7 @@ describe('GET /api/monitoring/rental-health threshold math (status)', () => {
         const origFn = articlePublisher.getPlatformsStatus;
         articlePublisher.getPlatformsStatus = () => ([
             { id: 'blogger', name: 'Blogger', region: 'global', configured: true, error: 'token expired' },
-            { id: 'hashnode', name: 'Hashnode', region: 'global', configured: true, error: 'api quota exceeded' },
+            { id: 'qiita', name: 'Qiita', region: 'ja', configured: true, error: 'api quota exceeded' },
             { id: 'telegraph', name: 'Telegraph', region: 'global', configured: true },
             { id: 'reddit', name: 'Reddit', region: 'global', configured: false },
         ]);
@@ -421,13 +421,14 @@ describe('GET /api/monitoring/rental-health happy path', () => {
         expect(res.body.db.entityTrash.oldestRowAgeSeconds).toBe(3600);
     });
 
-    it('publishers list contains 10 platforms (mastodon retired 2026-04-15, wordpress retired 2026-04-20)', async () => {
+    it('publishers list contains 9 platforms (mastodon retired 2026-04-15, wordpress 2026-04-20, hashnode 2026-05-27)', async () => {
         const res = await request(app)
             .get('/api/monitoring/rental-health?key=test-monitoring-key-1234');
-        expect(res.body.publishers.length).toBe(10);
+        expect(res.body.publishers.length).toBe(9);
         const ids = res.body.publishers.map(p => p.id);
         expect(ids).not.toContain('mastodon');
         expect(ids).not.toContain('wordpress');
+        expect(ids).not.toContain('hashnode');
         expect(res.body.publishers[0]).toMatchObject({
             id: expect.any(String),
             name: expect.any(String),

--- a/backend/tests/jest/publisher-extended.test.js
+++ b/backend/tests/jest/publisher-extended.test.js
@@ -3,7 +3,6 @@
  *
  * Tests input validation for publisher platforms NOT covered by publisher.test.js:
  * - Blogger (OAuth + publish + delete)
- * - Hashnode (publish + delete)
  * - X/Twitter (tweet + delete)
  * - Tumblr (publish + delete)
  * - Reddit (submit + delete)
@@ -204,27 +203,7 @@ describe('GET /api/publisher/blogger/status', () => {
     });
 });
 
-// ════════════════════════════════════════════════════════════════
-// Hashnode
-// ════════════════════════════════════════════════════════════════
-describe('POST /api/publisher/hashnode/publish', () => {
-    it('rejects missing title', async () => {
-        const res = await post('/api/publisher/hashnode/publish')
-            .send({ contentMarkdown: '# Test', publicationId: 'pub-1' });
-        expect([400, 501]).toContain(res.status);
-    });
-
-    it('rejects missing contentMarkdown', async () => {
-        const res = await post('/api/publisher/hashnode/publish')
-            .send({ title: 'Test', publicationId: 'pub-1' });
-        expect([400, 501]).toContain(res.status);
-    });
-
-    it('rejects empty body', async () => {
-        const res = await post('/api/publisher/hashnode/publish').send({});
-        expect([400, 501]).toContain(res.status);
-    });
-});
+// Hashnode endpoint tests removed 2026-05-27 — platform retired (pay-or-drop → drop).
 
 // ════════════════════════════════════════════════════════════════
 // X/Twitter
@@ -327,10 +306,7 @@ describe('Publisher delete endpoints', () => {
         expect(res.status).toBeGreaterThanOrEqual(400);
     });
 
-    it('DELETE /api/publisher/hashnode/post/:id responds', async () => {
-        const res = await del('/api/publisher/hashnode/post/123');
-        expect(res.status).toBeGreaterThanOrEqual(400);
-    });
+    // DELETE hashnode test removed 2026-05-27 — platform retired.
 
     it('DELETE /api/publisher/x/tweet/:id responds', async () => {
         const res = await del('/api/publisher/x/tweet/123');
@@ -362,10 +338,7 @@ describe('Publisher delete endpoints', () => {
 // /me endpoints — should require platform config
 // ════════════════════════════════════════════════════════════════
 describe('Publisher /me endpoints', () => {
-    it('GET /api/publisher/hashnode/me responds', async () => {
-        const res = await get('/api/publisher/hashnode/me');
-        expect(res.status).toBeGreaterThanOrEqual(400);
-    });
+    // GET hashnode/me test removed 2026-05-27 — platform retired.
 
     it('GET /api/publisher/x/me responds', async () => {
         const res = await get('/api/publisher/x/me');

--- a/backend/tests/jest/publisher-integration.test.js
+++ b/backend/tests/jest/publisher-integration.test.js
@@ -35,17 +35,18 @@ const del = (path) => request(publisherApp).delete(path);
 
 // ════════════════════════════════════════════════════════════════
 // GET /api/publisher/platforms — post-retirement list (10 platforms;
-// mastodon retired 2026-04-15, wordpress retired 2026-04-20)
+// mastodon retired 2026-04-15, wordpress retired 2026-04-20, hashnode retired 2026-05-27)
 // ════════════════════════════════════════════════════════════════
 describe('GET /api/publisher/platforms', () => {
     it('returns list of all supported platforms', async () => {
         const res = await get('/api/publisher/platforms');
         expect(res.status).toBe(200);
         expect(Array.isArray(res.body.platforms)).toBe(true);
-        expect(res.body.platforms.length).toBeGreaterThanOrEqual(10);
+        expect(res.body.platforms.length).toBeGreaterThanOrEqual(9);
         const ids = res.body.platforms.map(p => p.id);
         expect(ids).not.toContain('mastodon');
         expect(ids).not.toContain('wordpress');
+        expect(ids).not.toContain('hashnode');
     });
 
     it('each platform has required fields', async () => {
@@ -66,7 +67,7 @@ describe('Publish endpoints reject without platform API keys', () => {
         // Telegraph excluded — auto-creates account without API key, returns 200
         { method: 'post', path: '/api/publisher/qiita/publish', body: { title: 'T', body: 'B' }, name: 'Qiita' },
         { method: 'post', path: '/api/publisher/x/tweet', body: { text: 'hello' }, name: 'X/Twitter' },
-        { method: 'post', path: '/api/publisher/hashnode/publish', body: { title: 'T', content: 'C' }, name: 'Hashnode' },
+        // Hashnode removed 2026-05-27 — platform retired (pay-or-drop → drop).
         { method: 'post', path: '/api/publisher/wordpress/publish', body: { title: 'T', content: 'C' }, name: 'WordPress' },
         { method: 'post', path: '/api/publisher/tumblr/publish', body: { title: 'T', body: 'B' }, name: 'Tumblr' },
         { method: 'post', path: '/api/publisher/reddit/submit', body: { title: 'T', subreddit: 'r' }, name: 'Reddit' },
@@ -112,7 +113,6 @@ describe('/me endpoints reject without credentials', () => {
     const meEndpoints = [
         '/api/publisher/devto/me',
         '/api/publisher/x/me',
-        '/api/publisher/hashnode/me',
         '/api/publisher/qiita/me',
         '/api/publisher/tumblr/me',
         '/api/publisher/reddit/me',
@@ -139,9 +139,5 @@ describe('Delete endpoints reject without credentials', () => {
         expect(res.status).toBeGreaterThanOrEqual(400);
         expect(res.status).toBeLessThan(600);
     });
-
-    it('Hashnode delete returns error', async () => {
-        const res = await del('/api/publisher/hashnode/post/abc');
-        expect(res.status).toBeGreaterThanOrEqual(400);
-    });
+    // Hashnode delete test removed 2026-05-27 — platform retired.
 });

--- a/backend/tests/jest/publisher.test.js
+++ b/backend/tests/jest/publisher.test.js
@@ -256,19 +256,21 @@ describe('GET /api/publisher/platforms', () => {
         const res = await request(app).get('/api/publisher/platforms');
         expect(res.status).toBe(200);
         expect(res.body.success).toBe(true);
-        expect(res.body.platforms).toHaveLength(10);
+        expect(res.body.platforms).toHaveLength(9);
     });
 
     it('includes all expected platform IDs', async () => {
         const res = await request(app).get('/api/publisher/platforms');
         const ids = res.body.platforms.map(p => p.id);
         expect(ids).toEqual(expect.arrayContaining([
-            'blogger', 'hashnode', 'x', 'devto', 'telegraph', 'qiita', 'wechat',
+            'blogger', 'x', 'devto', 'telegraph', 'qiita', 'wechat',
             'tumblr', 'reddit', 'linkedin'
         ]));
-        // mastodon retired 2026-04-15; wordpress retired 2026-04-20 (owner's
-        // wp.com site suspended). Routes still exist for token recovery but
-        // platforms are no longer in the public list.
+        // hashnode retired 2026-05-27 (pay-or-drop → drop); mastodon retired
+        // 2026-04-15; wordpress retired 2026-04-20 (owner's wp.com site
+        // suspended). Routes for mastodon/wordpress still exist for token
+        // recovery; hashnode routes removed wholesale.
+        expect(ids).not.toContain('hashnode');
         expect(ids).not.toContain('mastodon');
         expect(ids).not.toContain('wordpress');
     });

--- a/backend/tests/test-publisher-platforms.js
+++ b/backend/tests/test-publisher-platforms.js
@@ -49,12 +49,13 @@ async function run() {
         assert(status === 200, 'GET /platforms returns 200');
         assert(data.success === true, 'Response has success: true');
         assert(Array.isArray(data.platforms), 'platforms is array');
-        assert(data.platforms.length === 11, `11 platforms listed (got ${data.platforms.length})`);
+        assert(data.platforms.length === 9, `9 platforms listed (got ${data.platforms.length}) — mastodon retired 2026-04-15, wordpress 2026-04-20, hashnode 2026-05-27`);
 
         const ids = data.platforms.map(p => p.id);
-        for (const expected of ['blogger', 'hashnode', 'x', 'devto', 'wordpress', 'telegraph', 'qiita', 'wechat', 'tumblr', 'reddit', 'linkedin']) {
+        for (const expected of ['blogger', 'x', 'devto', 'telegraph', 'qiita', 'wechat', 'tumblr', 'reddit', 'linkedin']) {
             assert(ids.includes(expected), `Platform "${expected}" present`);
         }
+        assert(!ids.includes('hashnode'), 'Hashnode retired 2026-05-27 — no longer in platforms list');
         assert(!ids.includes('mastodon'), 'Mastodon retired — no longer in platforms list');
 
         const telegraph = data.platforms.find(p => p.id === 'telegraph');


### PR DESCRIPTION
## Summary
- **Hashnode publisher integration removed** — vendor required paid tier (~\$25/mo) for posting beyond the low free quota; Hank's call was 直接砍掉. Closes card_e19084f4db9ee638383313c2 (Vendor / Hashnode pay-or-drop).
- 9 platforms remain in /api/publisher: Blogger, X, DEV.to, Telegraph, Qiita, WeChat, Tumblr, Reddit, LinkedIn (Mastodon retired 2026-04-15, WordPress 2026-04-20 — both retain routes for token recovery; Hashnode dropped wholesale).

## Test plan
- [x] \`npx jest tests/jest/publisher.test.js tests/jest/publisher-integration.test.js tests/jest/publisher-extended.test.js tests/jest/monitoring.test.js --runInBand\` → 97/97 pass on this branch
- [x] \`node -e \"require('./backend/article-publisher')\"\` → module loads cleanly
- [x] grep \`hashnode|HASHNODE|Hashnode\` across backend/ → only retirement markers + historical CHANGELOG entries remain
- [ ] After merge: spot-check \`GET /api/publisher/platforms\` on Railway returns 9 (no hashnode), \`GET /api/publisher/health\` no longer probes hashnode

## What was removed (vs. retired-with-marker)
**Removed wholesale (no token recovery value):**
- \`HASHNODE_API_TOKEN\`, \`HASHNODE_GQL_ENDPOINT\`, \`HASHNODE_CRED_KEYS\`, \`HASHNODE_CREDS_MISSING\` constants
- \`resolveHashnodeCreds()\`, \`hashnodeGQL()\` helpers
- \`GET /api/publisher/hashnode/me\`, \`POST /api/publisher/hashnode/publish\`, \`DELETE /api/publisher/hashnode/post/:postId\` routes
- \`hashnode\` entry from \`getPlatformsStatus()\` + \`/health\` probe
- portal UI: publisher.html form, info.html table row + curl example + roadmap step, slide tile + lead copy

**Kept as retirement markers** (so future devs see why it's gone):
- 1-line \"Hashnode retired 2026-05-27 (pay-or-drop → drop)\" comments at each removal site (mirrors the WordPress / Mastodon style)

## Out of scope (follow-ups)
- i18n strings in \`backend/public/shared/i18n.js\` that mention Hashnode (e.g. \`guide_pub_roadmap_step1\`, \`rn_1044_3\`) — orphaned keys, no UI displays them now. Will file an i18n cleanup card to #3/#4 separately per memory rule.
- CHANGELOG.md historical entries — kept as-is for traceability.

## Card
card_e19084f4db9ee638383313c2 → will move to done after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)