### PR TITLE
fix(borrow): bind skill doc echoes back as greeting reply

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -5672,8 +5672,8 @@ exec: curl -s -X POST "${apiBase}/api/transform" -H "Content-Type: application/j
 
 Do NOT call /api/bind or /api/bot/register — webhook is already configured for you.
 
-⚠️ IMMEDIATE ACTION REQUIRED — Run this command RIGHT NOW to confirm you're online (server will NOT send any additional test push):
-exec: curl -s -X POST "${apiBase}/api/transform" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${entityId},"botSecret":"${botSecret}","targetDeviceId":"${deviceId}","state":"IDLE","message":"Hi! I am online and ready to chat~"}'
+⚠️ IMMEDIATE ACTION REQUIRED — Run this command RIGHT NOW to confirm you're online (one-time bind-ack only — do NOT replay this payload on later user messages; every future reply must echo the user's instruction, not this example):
+exec: curl -s -X POST "${apiBase}/api/transform" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${entityId},"botSecret":"${botSecret}","targetDeviceId":"${deviceId}","state":"IDLE","message":"[BIND_READY entity=${entityId}]"}'
 
 --- E-Claw API Documentation (Latest) ---
 ${skillDoc}`;
@@ -5703,8 +5703,8 @@ Every push message will include a pre-filled curl command. Just replace YOUR_REP
 Scoped ready-check (must include deviceId so shared free-bot pool secrets cannot resolve to another user's binding):
 exec: curl -s "https://eclawbot.com/api/whoami?deviceId=${deviceId}&entityId=${entityId}&botSecret=${botSecret}"
 
-⚠️ IMMEDIATE ACTION REQUIRED — Run this command RIGHT NOW to confirm you're online (server will NOT send any additional test push):
-exec: curl -s -X POST "https://eclawbot.com/api/transform" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${entityId},"botSecret":"${botSecret}","targetDeviceId":"${deviceId}","state":"IDLE","message":"Hi! I am online and ready to chat~"}'`;
+⚠️ IMMEDIATE ACTION REQUIRED — Run this command RIGHT NOW to confirm you're online (one-time bind-ack only — do NOT replay this payload on later user messages; every future reply must echo the user's instruction, not this example):
+exec: curl -s -X POST "https://eclawbot.com/api/transform" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${entityId},"botSecret":"${botSecret}","targetDeviceId":"${deviceId}","state":"IDLE","message":"[BIND_READY entity=${entityId}]"}'`;
                 try {
                     const retryResult = await sendToSession(webhookUrl, webhookToken, sessionKey, shortMsg, authOpts, { timeout: 30000 });
                     if (retryResult.success) {

--- a/backend/index.js
+++ b/backend/index.js
@@ -5672,7 +5672,7 @@ exec: curl -s -X POST "${apiBase}/api/transform" -H "Content-Type: application/j
 
 Do NOT call /api/bind or /api/bot/register — webhook is already configured for you.
 
-⚠️ IMMEDIATE ACTION REQUIRED — Run this command RIGHT NOW to confirm you're online (one-time bind-ack only — do NOT replay this payload on later user messages; every future reply must echo the user's instruction, not this example):
+⚠️ IMMEDIATE ACTION REQUIRED — Run this command RIGHT NOW to confirm you're online (one-time bind-ack only — do NOT replay this payload on later user messages; every future reply must be based on the current push message / user request, not this example):
 exec: curl -s -X POST "${apiBase}/api/transform" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${entityId},"botSecret":"${botSecret}","targetDeviceId":"${deviceId}","state":"IDLE","message":"[BIND_READY entity=${entityId}]"}'
 
 --- E-Claw API Documentation (Latest) ---
@@ -5703,7 +5703,7 @@ Every push message will include a pre-filled curl command. Just replace YOUR_REP
 Scoped ready-check (must include deviceId so shared free-bot pool secrets cannot resolve to another user's binding):
 exec: curl -s "https://eclawbot.com/api/whoami?deviceId=${deviceId}&entityId=${entityId}&botSecret=${botSecret}"
 
-⚠️ IMMEDIATE ACTION REQUIRED — Run this command RIGHT NOW to confirm you're online (one-time bind-ack only — do NOT replay this payload on later user messages; every future reply must echo the user's instruction, not this example):
+⚠️ IMMEDIATE ACTION REQUIRED — Run this command RIGHT NOW to confirm you're online (one-time bind-ack only — do NOT replay this payload on later user messages; every future reply must be based on the current push message / user request, not this example):
 exec: curl -s -X POST "https://eclawbot.com/api/transform" -H "Content-Type: application/json" -d '{"deviceId":"${deviceId}","entityId":${entityId},"botSecret":"${botSecret}","targetDeviceId":"${deviceId}","state":"IDLE","message":"[BIND_READY entity=${entityId}]"}'`;
                 try {
                     const retryResult = await sendToSession(webhookUrl, webhookToken, sessionKey, shortMsg, authOpts, { timeout: 30000 });


### PR DESCRIPTION
## Summary

- The BIND_COMPLETE skill doc sent to every newly-bound official bot embedded a literal `"message":"Hi! I am online and ready to chat~"` payload under an "⚠️ IMMEDIATE ACTION REQUIRED" header.
- Free-bot health probes (15-min cron) unbind+rebind each shot, so the doc lands seconds before the strict-ACK probe. Models with weaker prompt-following (CodexGPT-5.5 xhigh thinking) replayed the example greeting on the next user message instead of complying with the probe — classified as `first_token_but_wrong_answer` on the rental probe.
- Replace example payload with `[BIND_READY entity=N]` marker and add explicit *"one-time bind-ack only — do NOT replay"* guidance so the example can't be mistaken for a general-purpose reply template.

## Repro / evidence

- 6h health audit `card_a6acc243` 2026-05-27 18:03 — 2/3 ack_ok; CodexGPT-5.5_xhight failed.
- Re-classification of 2026-05-28 00:24 cron (`/tmp/rental_e2e_v35_reclassified.json`): same bot shot1=no reply, shot2=`Hi! I am online and ready to chat~`. Other 2 free bots returned the strict ACK token on shot2.
- Investigation card: `card_7affb6720748f7c17ca16157`.

## Test plan

- [ ] Bind a fresh free bot via `/api/official-borrow/bind-free` and confirm the BIND_COMPLETE push contains `[BIND_READY entity=N]` and the "one-time" guidance line.
- [ ] Send a follow-up probe message; bot must not echo the marker or the greeting.
- [ ] Re-run the 6h health cron and confirm CodexGPT-5.5_xhight reaches `ack_ok` on shot2 (or surfaces a different, clearer failure mode if the model still misroutes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)