### PR TITLE
Fix Info page boundaries deep link

### DIFF
--- a/backend/public/portal/shared/info.js
+++ b/backend/public/portal/shared/info.js
@@ -286,7 +286,7 @@ function handleHash() {
         if (window._navigateToGuide) window._navigateToGuide(guideId);
         return;
     }
-    const validTabs = ['guide', 'faq', 'release-notes', 'compare', 'advanced', 'channel-plugins'];
+    const validTabs = ['quickstart', 'guide', 'advanced', 'channel-plugins', 'faq', 'release-notes', 'boundaries'];
     if (validTabs.includes(hash)) {
         switchInfoTab(hash);
     }

--- a/backend/tests/jest/info-public-pages.test.js
+++ b/backend/tests/jest/info-public-pages.test.js
@@ -116,6 +116,21 @@ describe('release notes Markdown rendering', () => {
     });
 });
 
+describe('info page hash tab routing', () => {
+    test('hash router supports every rendered info tab and no stale tab ids', () => {
+        const html = fs.readFileSync(INFO_HTML, 'utf8');
+        const source = fs.readFileSync(INFO_JS, 'utf8');
+        const tabIds = [...html.matchAll(/data-info-tab=["']([^"']+)["']/g)].map(match => match[1]);
+        const validTabsMatch = source.match(/const validTabs = \[([^\]]+)\]/);
+
+        expect(validTabsMatch).toBeTruthy();
+        const validTabs = [...validTabsMatch[1].matchAll(/['"]([^'"]+)['"]/g)].map(match => match[1]);
+
+        expect(validTabs).toEqual(tabIds);
+        expect(validTabs).toContain('boundaries');
+    });
+});
+
 describe('info-public-pages debug endpoint registration', () => {
     test('backend exposes an authenticated temporary debug endpoint for the info public-page bugs', () => {
         const source = fs.readFileSync(INDEX_JS, 'utf8');


### PR DESCRIPTION
## Summary
- Fix `/portal/info.html#boundaries` so it opens the Bot Boundaries tab instead of falling back to Quick Start.
- Keep the Info page hash allow-list synchronized with rendered `data-info-tab` ids, removing the stale `compare` hash route.
- Add regression coverage for the tab/hash allow-list.

Fixes #2983.

## Validation
- `npx jest tests/jest/info-public-pages.test.js --runInBand`
- `npx jest tests/jest/portal-smoke-static.test.js tests/jest/info-guide-mobile-layout.test.js --runInBand`
- `node scripts/portal-smoke-check.js`
- `npx jest tests/jest/portal-static-ids.test.js tests/jest/portal-smoke-static.test.js tests/jest/kanban-dispatch-mode-ux.test.js tests/jest/onboarding-quickwin.test.js tests/jest/info-guide-mobile-layout.test.js tests/jest/info-public-pages.test.js --runInBand`
- `node tests/test_widget_ux.js`
- `node tests/test-ux-live-validation.js` with authenticated env: 95/95 passed

## Notes
- OpenClaw browser controller was disabled during review, so browser automation could not be used. The repro was confirmed statically and covered by regression tests plus live endpoint validation.