### PR TITLE
feat(official-bots): add model_name canonical field + PATCH metadata endpoint

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -207,6 +207,10 @@ async function createTables() {
         // Add display_name column for user-facing bot selection
         await client.query(`ALTER TABLE official_bots ADD COLUMN IF NOT EXISTS display_name TEXT`);
 
+        // Add model_name column — canonical model identifier separate from bot_id slug
+        // (bot_id is immutable PK; model_name is editable and authoritative for what the bot actually runs)
+        await client.query(`ALTER TABLE official_bots ADD COLUMN IF NOT EXISTS model_name TEXT`);
+
         // Add paid_borrow_slots column to devices table (tracks how many personal bots a device has paid for)
         await client.query(`
             ALTER TABLE devices ADD COLUMN IF NOT EXISTS paid_borrow_slots INTEGER DEFAULT 0
@@ -934,11 +938,11 @@ async function saveOfficialBot(bot) {
     try {
         const client = await pool.connect();
         await client.query(
-            `INSERT INTO official_bots (bot_id, bot_type, webhook_url, token, bot_secret, session_key_template, status, assigned_device_id, assigned_entity_id, assigned_at, created_at, setup_username, setup_password, display_name)
-             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+            `INSERT INTO official_bots (bot_id, bot_type, webhook_url, token, bot_secret, session_key_template, status, assigned_device_id, assigned_entity_id, assigned_at, created_at, setup_username, setup_password, display_name, model_name)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
              ON CONFLICT (bot_id)
-             DO UPDATE SET webhook_url = $3, token = $4, bot_secret = $5, session_key_template = $6, status = $7, assigned_device_id = $8, assigned_entity_id = $9, assigned_at = $10, setup_username = $12, setup_password = $13, display_name = $14`,
-            [bot.bot_id, bot.bot_type, bot.webhook_url, bot.token, bot.bot_secret || null, bot.session_key_template || null, bot.status || 'available', bot.assigned_device_id || null, bot.assigned_entity_id ?? null, bot.assigned_at || null, bot.created_at || Date.now(), bot.setup_username || null, bot.setup_password || null, bot.display_name || null]
+             DO UPDATE SET webhook_url = $3, token = $4, bot_secret = $5, session_key_template = $6, status = $7, assigned_device_id = $8, assigned_entity_id = $9, assigned_at = $10, setup_username = $12, setup_password = $13, display_name = $14, model_name = $15`,
+            [bot.bot_id, bot.bot_type, bot.webhook_url, bot.token, bot.bot_secret || null, bot.session_key_template || null, bot.status || 'available', bot.assigned_device_id || null, bot.assigned_entity_id ?? null, bot.assigned_at || null, bot.created_at || Date.now(), bot.setup_username || null, bot.setup_password || null, bot.display_name || null, bot.model_name || null]
         );
         client.release();
         return true;
@@ -970,7 +974,8 @@ async function loadOfficialBots() {
                 created_at: parseInt(row.created_at),
                 setup_username: row.setup_username || null,
                 setup_password: row.setup_password || null,
-                display_name: row.display_name || null
+                display_name: row.display_name || null,
+                model_name: row.model_name || null
             };
         }
         console.log(`[DB] Loaded ${Object.keys(bots).length} official bots`);

--- a/backend/index.js
+++ b/backend/index.js
@@ -5032,7 +5032,7 @@ app.post('/api/admin/push-update', adminAuth, adminCheck, async (req, res) => {
 // POST /api/admin/bots/create - Create new official bot (cookie-based admin auth)
 app.post('/api/admin/bots/create', adminAuth, adminCheck, async (req, res) => {
     try {
-        const { botId, botType, webhookUrl, token, setupUsername, setupPassword } = req.body;
+        const { botId, botType, webhookUrl, token, setupUsername, setupPassword, displayName, modelName } = req.body;
 
         if (!botId || !botType || !webhookUrl || !token) {
             return res.status(400).json({ success: false, error: 'botId, botType, webhookUrl, and token are required' });
@@ -5062,17 +5062,49 @@ app.post('/api/admin/bots/create', adminAuth, adminCheck, async (req, res) => {
             assigned_at: null,
             created_at: Date.now(),
             setup_username: setupUsername || null,
-            setup_password: setupPassword || null
+            setup_password: setupPassword || null,
+            display_name: displayName || null,
+            model_name: modelName || null
         };
 
         officialBots[botId] = bot;
         if (usePostgreSQL) await db.saveOfficialBot(bot);
 
-        console.log(`[Admin Portal] Created official bot: ${botId} (${botType})`);
-        res.json({ success: true, bot: { botId, botType, status: 'available', botSecret } });
+        console.log(`[Admin Portal] Created official bot: ${botId} (${botType}, model=${modelName || 'unset'})`);
+        res.json({ success: true, bot: { botId, botType, status: 'available', botSecret, displayName: bot.display_name, modelName: bot.model_name } });
     } catch (err) {
         console.error('[Admin] Create bot error:', err);
         res.status(500).json({ success: false, error: 'Failed to create bot' });
+    }
+});
+
+// PATCH /api/admin/bots/:botId/metadata - Update editable bot metadata (display_name, model_name).
+// bot_id is immutable PK; this endpoint exists so admins can backfill or correct the
+// human-facing labels without rotating bindings. webhookUrl/token/secret are NOT editable here.
+app.patch('/api/admin/bots/:botId/metadata', adminAuth, adminCheck, async (req, res) => {
+    try {
+        const { botId } = req.params;
+        const { displayName, modelName } = req.body;
+
+        if (typeof displayName === 'undefined' && typeof modelName === 'undefined') {
+            return res.status(400).json({ success: false, error: 'At least one of displayName or modelName is required' });
+        }
+
+        const bot = officialBots[botId];
+        if (!bot) {
+            return res.status(404).json({ success: false, error: 'Bot not found' });
+        }
+
+        if (typeof displayName !== 'undefined') bot.display_name = displayName || null;
+        if (typeof modelName !== 'undefined') bot.model_name = modelName || null;
+
+        if (usePostgreSQL) await db.saveOfficialBot(bot);
+
+        console.log(`[Admin Portal] Updated bot metadata: ${botId} (displayName=${bot.display_name}, modelName=${bot.model_name})`);
+        res.json({ success: true, bot: { botId, displayName: bot.display_name, modelName: bot.model_name } });
+    } catch (err) {
+        console.error('[Admin] Update bot metadata error:', err);
+        res.status(500).json({ success: false, error: 'Failed to update bot metadata' });
     }
 });
 
@@ -14536,6 +14568,7 @@ app.get('/api/official-borrow/free-bots', (req, res) => {
         return {
             botId: bot.bot_id,
             displayName: bot.display_name || bot.bot_id,
+            modelName: bot.model_name || null,
             activeBindings,
             status: bot.status
         };

--- a/backend/tests/jest/admin-auth.test.js
+++ b/backend/tests/jest/admin-auth.test.js
@@ -171,6 +171,7 @@ let app;
 const get = (path) => request(app).get(path).set('Host', 'localhost');
 const post = (path) => request(app).post(path).set('Host', 'localhost');
 const del = (path) => request(app).delete(path).set('Host', 'localhost');
+const patch = (path) => request(app).patch(path).set('Host', 'localhost');
 
 beforeAll(() => {
     app = require('../../index');
@@ -235,6 +236,12 @@ describe('Admin endpoints — unauthenticated access blocked', () => {
         expect(res.status).toBe(401);
     });
 
+    it('PATCH /api/admin/bots/:botId/metadata rejects without auth', async () => {
+        const res = await patch('/api/admin/bots/anybot/metadata')
+            .send({ modelName: 'gpt-5' });
+        expect(res.status).toBe(401);
+    });
+
     it('DELETE /api/admin/official-bot/test rejects without auth', async () => {
         const res = await del('/api/admin/official-bot/test');
         expect(res.status).toBe(401);
@@ -274,6 +281,13 @@ describe('Admin endpoints — non-admin access blocked', () => {
         const res = await post('/api/admin/bots/create')
             .set('Cookie', cookie)
             .send({ botName: 'test' });
+        expect(res.status).toBe(403);
+    });
+
+    it('PATCH /api/admin/bots/:botId/metadata rejects non-admin', async () => {
+        const res = await patch('/api/admin/bots/anybot/metadata')
+            .set('Cookie', cookie)
+            .send({ modelName: 'gpt-5' });
         expect(res.status).toBe(403);
     });
 

--- a/backend/tests/jest/official-borrow.test.js
+++ b/backend/tests/jest/official-borrow.test.js
@@ -206,6 +206,9 @@ describe('GET /api/official-borrow/free-bots', () => {
             expect(bot).toHaveProperty('displayName');
             expect(typeof bot.activeBindings).toBe('number');
             expect(bot).toHaveProperty('status');
+            // modelName is the canonical model identifier (added 2026-05-28).
+            // It MAY be null on bots that haven't been backfilled, but the key must exist.
+            expect(bot).toHaveProperty('modelName');
         }
     });
 });


### PR DESCRIPTION
## Summary
Free-bot listing (`/api/official-borrow/free-bots`) currently surfaces only `botId` (the immutable PK) and `displayName`. Today bot_id doubles as both binding key AND human-facing slug — so when a bot is wired to a different LLM than its bot_id implies (e.g. `bot_id="Mac本地版_MiniMax2.7"` actually runs `openai-codex/gpt-5.5`), renters and rental health audits get the wrong model identity.

Renaming the PK is unsafe (bot_bindings FK + cascade + auth/cache maps), so this PR adds a **separate, editable** `model_name` column that travels alongside `display_name`. Fully additive — no FK impact, no PK rename, existing bots get `modelName: null` until an admin backfills via the new PATCH endpoint.

## Changes
- **db.js**: `ALTER TABLE official_bots ADD COLUMN IF NOT EXISTS model_name TEXT` migration; `saveOfficialBot` / `loadOfficialBots` updated to round-trip the field
- **index.js**:
  - `POST /api/admin/bots/create` accepts optional `modelName` (and `displayName`) at creation time
  - **new** `PATCH /api/admin/bots/:botId/metadata` — admin-only endpoint to update `display_name` / `model_name` on existing bots; `bot_id` remains immutable
  - `GET /api/official-borrow/free-bots` includes `modelName` in each row (null until backfilled)
- **tests/jest/admin-auth.test.js**: auth + non-admin rejection for the new PATCH endpoint (401 + 403)
- **tests/jest/official-borrow.test.js**: assert `modelName` key exists on every free-bot row

## Test plan
- [x] `npx jest` 216 suites / 3095 passed / 0 failed
- [x] `node --check backend/index.js && node --check backend/db.js`
- [ ] Deploy to Railway, then run `curl -s "https://eclawbot.com/api/official-borrow/free-bots"` and verify each row contains the `modelName` key
- [ ] Backfill the 3 existing free bots:
  - `Cloud_Zeabur_MiniMax2.5` → `modelName: "minimax-2.5"` (botId `Zeabug雲端版_MiniMax模型` keeps it)
  - `Local_Mac_MiniMax2.7` → `modelName: "minimax-2.7"` (botId `Mac本地版_MiniMax2.5` keeps it — off-by-0.2 in slug)
  - `Local_Mac_CodexGPT5.5_xhight` → `modelName: "openai-codex/gpt-5.5-xhigh"` (botId `Mac本地版_MiniMax2.7` keeps it — wholly wrong in slug)
- [ ] Update 6h cron SOP (card_c2ddceef description) STEP 4.6 to prefer `modelName` over `botId` for classification slug + audit log labels — followup card

## Why not rename the PK
- `bot_bindings.bot_id` is an FK to `official_bots.bot_id`; renaming requires cascade UPDATE on bindings + auth/cache invalidation + risk of binding flap during deploy
- The user-facing bug is purely about identifying-the-model; the PK can stay as an opaque slug
- This shape (immutable internal ID + mutable canonical metadata) is the standard pattern; it also future-proofs against later model swaps without binding churn

## Refs
- Card: card_c23a03b48cb0bcd87ad84547 (P1 after 6h auto-escalation)
- Sibling closed: card_7affb6720748f7c17ca16157
- Parallel in-flight: PR #2986 (Path A skill-doc IMMEDIATE ACTION redesign) — independent change

🤖 Generated with [Claude Code](https://claude.com/claude-code)