### PR TITLE
fix(db): backfill model_name on 3 existing free bots (PR #2987 follow-up)

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -211,6 +211,15 @@ async function createTables() {
         // (bot_id is immutable PK; model_name is editable and authoritative for what the bot actually runs)
         await client.query(`ALTER TABLE official_bots ADD COLUMN IF NOT EXISTS model_name TEXT`);
 
+        // Backfill model_name for the 3 existing free bots whose bot_id PKs were
+        // mislabeled at create time (see closed card_c23a03b4). display_name is
+        // truthful (matches actual wiring); bot_id is the immutable slug. Key the
+        // backfill on display_name + WHERE model_name IS NULL so it's idempotent
+        // and won't clobber any admin-portal edits.
+        await client.query(`UPDATE official_bots SET model_name = 'minimax-2.5' WHERE display_name = 'Cloud_Zeabur_MiniMax2.5' AND model_name IS NULL`);
+        await client.query(`UPDATE official_bots SET model_name = 'minimax-2.7' WHERE display_name = 'Local_Mac_MiniMax2.7' AND model_name IS NULL`);
+        await client.query(`UPDATE official_bots SET model_name = 'openai-codex/gpt-5.5-xhigh' WHERE display_name = 'Local_Mac_CodexGPT5.5_xhight' AND model_name IS NULL`);
+
         // Add paid_borrow_slots column to devices table (tracks how many personal bots a device has paid for)
         await client.query(`
             ALTER TABLE devices ADD COLUMN IF NOT EXISTS paid_borrow_slots INTEGER DEFAULT 0


### PR DESCRIPTION
## Summary
- Backfill `official_bots.model_name` for the 3 existing free bots (currently all NULL after PR #2987 b34e1657 added the column)
- Idempotent display_name-keyed UPDATEs in db.js init — safe to re-run, becomes no-op after first apply
- No code/route surface change; pure migration

## Why display_name keyed (not bot_id PK)
The 3 existing free bots have mislabeled bot_id slugs (see closed card_c23a03b4):
- bot_id \`Mac本地版_MiniMax2.7\` actually wires to CodexGPT-5.5_xhight
- bot_id \`Mac本地版_MiniMax2.5\` actually wires to MiniMax-2.7

display_name reflects actual wiring; bot_id is the immutable stale PK. Keying on display_name avoids encoding the historical mislabel into the backfill.

## Mapping
| display_name | model_name |
|---|---|
| Cloud_Zeabur_MiniMax2.5 | minimax-2.5 |
| Local_Mac_MiniMax2.7 | minimax-2.7 |
| Local_Mac_CodexGPT5.5_xhight | openai-codex/gpt-5.5-xhigh |

## Test plan
- [x] \`node --check backend/db.js && node --check backend/index.js\` passes
- [x] \`npx jest --runInBand tests/jest/admin-auth.test.js tests/jest/official-borrow.test.js\` — 46/46 pass
- [ ] After Railway deploy, GET /api/official-borrow/free-bots returns populated modelName for all 3 bots
- [x] requiresScreenshotReview=false (DB migration, no UI)

Card: card_934ab22c4af45e335782725c
Sibling: card_c23a03b4 (closed)