### PR TITLE
fix(kanban): always include schedule field on /cards rows

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -711,18 +711,22 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             tags: Array.isArray(row.tags) ? row.tags : [],
         };
 
-        // Schedule fields — always include if schedule was ever configured
-        if (row.schedule_enabled || row.schedule_type || row.schedule_last_run_at) {
-            card.schedule = {
-                enabled: !!row.schedule_enabled,
-                type: row.schedule_type || null,
-                cronExpression: row.schedule_cron || null,
-                runAt: row.schedule_run_at ? new Date(row.schedule_run_at).getTime() : null,
-                timezone: row.schedule_timezone || 'Asia/Taipei',
-                lastRunAt: row.schedule_last_run_at ? new Date(row.schedule_last_run_at).getTime() : null,
-                nextRunAt: row.schedule_next_run_at ? new Date(row.schedule_next_run_at).getTime() : null,
-            };
-        }
+        // Schedule fields — always present so hygiene audits can lock the schema
+        // and detect cron-broken cards (enabled=true but nextRunAt stale). Cards
+        // without a schedule get null; cards that have ever been scheduled get the
+        // full object. Prior to 2026-05-28 this was conditional, which hid the
+        // field from manual cards AND from any /cards call that didn't pass
+        // ?automation=all (so cron-broken heuristics had nothing to evaluate).
+        const hasSchedule = row.schedule_enabled || row.schedule_type || row.schedule_last_run_at;
+        card.schedule = hasSchedule ? {
+            enabled: !!row.schedule_enabled,
+            type: row.schedule_type || null,
+            cronExpression: row.schedule_cron || null,
+            runAt: row.schedule_run_at ? new Date(row.schedule_run_at).getTime() : null,
+            timezone: row.schedule_timezone || 'Asia/Taipei',
+            lastRunAt: row.schedule_last_run_at ? new Date(row.schedule_last_run_at).getTime() : null,
+            nextRunAt: row.schedule_next_run_at ? new Date(row.schedule_next_run_at).getTime() : null,
+        } : null;
 
         // Automation fields
         if (row.is_automation) card.isAutomation = true;

--- a/backend/tests/jest/kanban-card.test.js
+++ b/backend/tests/jest/kanban-card.test.js
@@ -660,3 +660,75 @@ describe('activity bumps updated_at', () => {
         expect(updatedAtCall).toBeDefined();
     });
 });
+
+// ════════════════════════════════════════════════════════════════
+// GET /cards — schedule field schema lock
+// Hygiene audits (e.g. cron-broken heuristic) need every card row to
+// carry a `schedule` key. Cards without a schedule MUST serialize as
+// schedule: null, not omit the field — otherwise schema checks can't
+// distinguish "not scheduled" from "API forgot to include it".
+// ════════════════════════════════════════════════════════════════
+describe('GET /cards — schedule field always present', () => {
+    const get = (path) => request(app).get(path);
+    const baseQ = `?deviceId=test-dev&deviceSecret=test-secret`;
+
+    it('manual card without schedule → schedule: null', async () => {
+        mockQuery
+            .mockResolvedValueOnce({
+                rows: [{
+                    id: 'card_manual', device_id: 'test-dev', title: 'Manual',
+                    description: '', priority: 'P2', status: 'todo',
+                    assigned_bots: [0], created_by: 0,
+                    created_at: new Date(), updated_at: new Date(),
+                    status_changed_at: new Date(), archived: false,
+                    is_automation: false,
+                    schedule_enabled: false, schedule_type: null,
+                    schedule_cron: null, schedule_last_run_at: null,
+                }],
+            })
+            .mockResolvedValueOnce({ rows: [] }) // tags
+            .mockResolvedValueOnce({ rows: [{ manual_count: '1', automation_count: '0' }] }); // summary
+
+        const res = await get(`/api/mission/cards${baseQ}`);
+        expect(res.status).toBe(200);
+        expect(res.body.cards).toHaveLength(1);
+        expect(res.body.cards[0]).toHaveProperty('schedule');
+        expect(res.body.cards[0].schedule).toBeNull();
+    });
+
+    it('automation card with recurring schedule → full schedule object', async () => {
+        const now = new Date();
+        mockQuery
+            .mockResolvedValueOnce({
+                rows: [{
+                    id: 'card_cron', device_id: 'test-dev', title: 'Cron',
+                    description: '', priority: 'P1', status: 'todo',
+                    assigned_bots: [0], created_by: 0,
+                    created_at: now, updated_at: now,
+                    status_changed_at: now, archived: false,
+                    is_automation: true,
+                    schedule_enabled: true,
+                    schedule_type: 'recurring',
+                    schedule_cron: '0 9 * * *',
+                    schedule_timezone: 'Asia/Taipei',
+                    schedule_last_run_at: now,
+                    schedule_next_run_at: new Date(now.getTime() + 86400000),
+                }],
+            })
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [{ manual_count: '0', automation_count: '1' }] });
+
+        const res = await get(`/api/mission/cards${baseQ}&automation=all`);
+        expect(res.status).toBe(200);
+        const card = res.body.cards[0];
+        expect(card).toHaveProperty('schedule');
+        expect(card.schedule).toEqual(expect.objectContaining({
+            enabled: true,
+            type: 'recurring',
+            cronExpression: '0 9 * * *',
+            timezone: 'Asia/Taipei',
+        }));
+        expect(typeof card.schedule.lastRunAt).toBe('number');
+        expect(typeof card.schedule.nextRunAt).toBe('number');
+    });
+});


### PR DESCRIPTION
## Why

#1 Mac_F's daily Kanban Hygiene Audit (2026-05-28 03:25 TW) reported `cronBroken=0` but annotated: *"schedule/cron metadata absent from cards payload; cron-broken heuristic not evaluable"*.

Reality check on prod:
- `GET /api/mission/cards?…&entityId=2` → 278 cards, 0 with `schedule` field
- `GET /api/mission/cards?…&entityId=2&automation=all` → 296 cards, 18 with `schedule` field

So `schedule` data was reachable, but only via `?automation=all`. AND on cards without scheduling, the field was omitted entirely — schema-lock tests can't distinguish "no schedule configured" from "API forgot to include it".

## What changed

`serializeCard()` now sets `schedule: null` on every card without scheduling (was: omit the key). Scheduled cards still get the full object `{ enabled, type, cronExpression, runAt, timezone, lastRunAt, nextRunAt }`.

No change to the default `?automation=false` behavior — automation cards still hidden by default to keep the manual board uncluttered. Cron-broken hygiene audits must pass `?automation=all` (will document in audit SOP).

## Acceptance

- [x] `/api/mission/cards` card row always carries `schedule` key (null or object)
- [x] Recurring cards return `cronExpression` + `enabled=true` when fetched with `?automation=all`
- [x] Jest schema-lock test added (`tests/jest/kanban-card.test.js`)
- [x] Manual card → `schedule: null`
- [x] Automation card → full schedule object with cron + lastRunAt + nextRunAt
- [ ] #1 acknowledged hygiene audit can now resolve cron-broken heuristic (post-merge)

Closes card_a15791374e88e1049b03936e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)