### PR TITLE
[codex] fix(borrow): reuse valid free bindings

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -14514,6 +14514,7 @@ function evaluateOfficialBindingReuse(binding, device, entityId, opts = {}) {
     if (entity.webhook.url !== bot.webhook_url) return { ...base, valid: false, reason: 'webhook_url_mismatch' };
     if (entity.webhook.token !== bot.token) return { ...base, valid: false, reason: 'webhook_token_mismatch' };
     if (!binding.session_key) return { ...base, valid: false, reason: 'binding_missing_session_key' };
+    if (entity.webhook.sessionKey !== binding.session_key) return { ...base, valid: false, reason: 'session_key_mismatch' };
     if (ttlMs <= 0) return { ...base, valid: false, reason: 'binding_reuse_disabled' };
     if (ageMs == null) return { ...base, valid: false, reason: 'binding_bound_at_missing' };
     if (ageMs > ttlMs) return { ...base, valid: false, reason: 'binding_reuse_ttl_expired' };

--- a/backend/index.js
+++ b/backend/index.js
@@ -14425,9 +14425,105 @@ app.delete('/api/admin/official-bot/:botId', adminAuth, adminCheck, async (req, 
 
 // In-memory cache of official bindings (deviceId:entityId -> binding)
 const officialBindingsCache = {};
+const parsedFreeBindingReuseTtlMs = parseInt(process.env.OFFICIAL_FREE_BINDING_REUSE_TTL_MS || '', 10);
+const OFFICIAL_FREE_BINDING_REUSE_TTL_MS = Number.isFinite(parsedFreeBindingReuseTtlMs) && parsedFreeBindingReuseTtlMs > 0
+    ? parsedFreeBindingReuseTtlMs
+    : 24 * 60 * 60 * 1000;
 
 function getBindingCacheKey(deviceId, entityId) {
     return `${deviceId}:${entityId}`;
+}
+
+async function getOfficialBindingAuthoritative(deviceId, entityId) {
+    const cacheKey = getBindingCacheKey(deviceId, entityId);
+    if (usePostgreSQL) {
+        const binding = await db.getOfficialBinding(deviceId, entityId);
+        if (binding) {
+            officialBindingsCache[cacheKey] = binding;
+            return binding;
+        }
+        delete officialBindingsCache[cacheKey];
+        return null;
+    }
+    return officialBindingsCache[cacheKey] || null;
+}
+
+function getOfficialBindingReuseTtlMs(botType) {
+    return botType === 'free' ? OFFICIAL_FREE_BINDING_REUSE_TTL_MS : 0;
+}
+
+function getOfficialBindingAgeMs(binding, now = Date.now()) {
+    const boundAt = Number(binding?.bound_at ?? binding?.boundAt);
+    if (!Number.isFinite(boundAt) || boundAt <= 0) return null;
+    return Math.max(0, now - boundAt);
+}
+
+function publicBindingReuseStatus(status) {
+    return {
+        bound: Boolean(status.binding),
+        valid: Boolean(status.valid),
+        reusable: Boolean(status.valid),
+        reason: status.reason,
+        botId: status.botId || null,
+        botType: status.botType || null,
+        entityId: status.entityId,
+        boundAt: status.boundAt || null,
+        ageMs: status.ageMs,
+        ttlMs: status.ttlMs,
+        remainingMs: status.remainingMs,
+        expiresAt: status.expiresAt || null
+    };
+}
+
+function evaluateOfficialBindingReuse(binding, device, entityId, opts = {}) {
+    const eId = parseInt(entityId);
+    const entity = device?.entities?.[eId];
+    const requestedBotType = opts.requestedBotType || null;
+    const requestedBotId = opts.requestedBotId || null;
+    const now = opts.now || Date.now();
+
+    if (!binding) {
+        return { valid: false, reason: 'no_binding', binding: null, entityId: eId };
+    }
+
+    const botId = binding.bot_id ?? binding.botId;
+    const bot = officialBots[botId];
+    const botType = bot?.bot_type ?? binding.bot_type ?? binding.botType ?? null;
+    const ttlMs = getOfficialBindingReuseTtlMs(botType);
+    const ageMs = getOfficialBindingAgeMs(binding, now);
+    const boundAt = Number(binding.bound_at ?? binding.boundAt);
+    const base = {
+        binding,
+        entityId: eId,
+        botId,
+        botType,
+        boundAt: Number.isFinite(boundAt) ? boundAt : null,
+        ageMs,
+        ttlMs,
+        remainingMs: ageMs == null || ttlMs <= 0 ? null : Math.max(0, ttlMs - ageMs),
+        expiresAt: Number.isFinite(boundAt) && ttlMs > 0 ? boundAt + ttlMs : null
+    };
+
+    if (!bot) return { ...base, valid: false, reason: 'bot_missing' };
+    if (requestedBotType && botType !== requestedBotType) return { ...base, valid: false, reason: 'bot_type_mismatch' };
+    if (requestedBotId && botId !== requestedBotId) return { ...base, valid: false, reason: 'bound_to_different_bot' };
+    if (bot.status === 'disabled') return { ...base, valid: false, reason: 'bot_disabled' };
+    if (!entity || !entity.isBound) return { ...base, valid: false, reason: 'entity_not_bound' };
+    if (!entity.botSecret) return { ...base, valid: false, reason: 'entity_missing_bot_secret' };
+    if (!entity.webhook) return { ...base, valid: false, reason: 'entity_missing_webhook' };
+    if (entity.webhook.url !== bot.webhook_url) return { ...base, valid: false, reason: 'webhook_url_mismatch' };
+    if (entity.webhook.token !== bot.token) return { ...base, valid: false, reason: 'webhook_token_mismatch' };
+    if (!binding.session_key) return { ...base, valid: false, reason: 'binding_missing_session_key' };
+    if (ttlMs <= 0) return { ...base, valid: false, reason: 'binding_reuse_disabled' };
+    if (ageMs == null) return { ...base, valid: false, reason: 'binding_bound_at_missing' };
+    if (ageMs > ttlMs) return { ...base, valid: false, reason: 'binding_reuse_ttl_expired' };
+
+    return { ...base, valid: true, reason: 'valid' };
+}
+
+async function getOfficialBindingReuseStatus(deviceId, entityId, opts = {}) {
+    const binding = await getOfficialBindingAuthoritative(deviceId, entityId);
+    return evaluateOfficialBindingReuse(binding, opts.device || devices[deviceId], entityId, opts);
 }
 
 /**
@@ -14565,6 +14661,48 @@ app.get('/api/official-borrow/status', async (req, res) => {
 });
 
 /**
+ * GET /api/official-borrow/binding-status
+ * Device-secret protected status for one official binding, including whether
+ * the binding can be reused without re-running bind-free/bind-personal.
+ */
+app.get('/api/official-borrow/binding-status', async (req, res) => {
+    const { deviceId, deviceSecret, entityId, botType, botId } = req.query;
+
+    if (!deviceId || !deviceSecret) {
+        return res.status(400).json({ success: false, error: 'deviceId and deviceSecret required' });
+    }
+
+    const eId = parseInt(entityId);
+    if (isNaN(eId) || eId < 0) {
+        return res.status(400).json({ success: false, error: 'Invalid entityId' });
+    }
+
+    const device = devices[deviceId];
+    if (!device || !safeEqual(device.deviceSecret, deviceSecret)) {
+        return res.status(403).json({ success: false, error: 'Invalid device credentials' });
+    }
+
+    if (!isValidEntityId(device, eId)) {
+        return res.status(400).json({ success: false, error: 'Invalid entityId' });
+    }
+
+    const normalizedBotType = botType === 'personal' || botType === 'free' ? botType : null;
+    const status = await getOfficialBindingReuseStatus(deviceId, eId, {
+        device,
+        requestedBotType: normalizedBotType,
+        requestedBotId: botId || null
+    });
+    const publicStatus = publicBindingReuseStatus(status);
+
+    res.json({
+        success: true,
+        ...publicStatus,
+        recommendation: status.valid ? 'reuse_existing_binding' : 'bind_required',
+        skipBindFree: Boolean(status.valid && (normalizedBotType === 'free' || status.botType === 'free'))
+    });
+});
+
+/**
  * GET /api/official-borrow/free-bots
  * List available free bots with active binding counts for user selection.
  */
@@ -14645,6 +14783,30 @@ app.post('/api/official-borrow/bind-free', async (req, res) => {
 
     if (!isValidEntityId(device, eId)) {
         return res.status(400).json({ success: false, error: 'Invalid entityId' });
+    }
+
+    const existingFreeReuse = await getOfficialBindingReuseStatus(deviceId, eId, {
+        device,
+        requestedBotType: 'free',
+        requestedBotId: botId || null
+    });
+    if (existingFreeReuse.valid) {
+        const existingEntity = device.entities[eId];
+        if (existingEntity?.publicCode) {
+            publicCodeIndex[existingEntity.publicCode] = { deviceId, entityId: eId };
+        }
+        console.log(`[Borrow] Reuse: valid free bot ${existingFreeReuse.botId} binding for device ${deviceId} entity ${eId}; skipping handshake`);
+        return res.json({
+            success: true,
+            entityId: eId,
+            botType: 'free',
+            botId: existingFreeReuse.botId,
+            publicCode: existingEntity?.publicCode || null,
+            reusedExistingBinding: true,
+            idempotent: true,
+            bindingStatus: publicBindingReuseStatus(existingFreeReuse),
+            message: 'Free bot binding already valid; reused existing binding'
+        });
     }
 
     // Override mode: auto-unbind if entity already has a binding
@@ -21051,4 +21213,11 @@ module.exports._pendingAck = {
     markAckedById,
     getPendingAckById,
     sweepExpiredAcks,
+};
+module.exports._officialBorrowTest = {
+    officialBots,
+    officialBindingsCache,
+    getBindingCacheKey,
+    getOfficialBindingReuseStatus,
+    OFFICIAL_FREE_BINDING_REUSE_TTL_MS,
 };

--- a/backend/tests/jest/official-borrow-binding-reuse.test.js
+++ b/backend/tests/jest/official-borrow-binding-reuse.test.js
@@ -164,4 +164,27 @@ describe('official borrow free binding reuse', () => {
         expect(res.body.skipBindFree).toBe(false);
         expect(res.body.remainingMs).toBe(0);
     });
+
+    it('marks the binding non-reusable when entity.webhook.sessionKey drifts from binding.session_key', async () => {
+        const { deviceId, deviceSecret, botId } = seedValidFreeBinding();
+        app.devices[deviceId].entities[0].webhook.sessionKey = 'drifted:session:key:from:rehandshake';
+
+        const statusRes = await get('/api/official-borrow/binding-status')
+            .query({ deviceId, deviceSecret, entityId: 0, botType: 'free', botId });
+
+        expect(statusRes.status).toBe(200);
+        expect(statusRes.body.success).toBe(true);
+        expect(statusRes.body.bound).toBe(true);
+        expect(statusRes.body.valid).toBe(false);
+        expect(statusRes.body.reusable).toBe(false);
+        expect(statusRes.body.reason).toBe('session_key_mismatch');
+        expect(statusRes.body.recommendation).toBe('bind_required');
+        expect(statusRes.body.skipBindFree).toBe(false);
+
+        const bindRes = await post('/api/official-borrow/bind-free')
+            .send({ deviceId, deviceSecret, entityId: 0, botId });
+
+        expect(bindRes.body.reusedExistingBinding).not.toBe(true);
+        expect(bindRes.body.idempotent).not.toBe(true);
+    });
 });

--- a/backend/tests/jest/official-borrow-binding-reuse.test.js
+++ b/backend/tests/jest/official-borrow-binding-reuse.test.js
@@ -1,0 +1,167 @@
+/**
+ * Official borrow binding reuse tests.
+ *
+ * Path B hardening: a repeated bind-free call for an already valid persistent
+ * official binding must be idempotent. It should not auto-unbind, handshake,
+ * regenerate credentials, or resend BIND_COMPLETE.
+ */
+
+require('./helpers/mock-setup');
+
+const request = require('supertest');
+const db = require('../../db');
+const gatekeeper = require('../../gatekeeper');
+
+let app;
+
+const get = (path) => request(app).get(path).set('Host', 'localhost').set('Accept-Encoding', 'identity');
+const post = (path) => request(app).post(path).set('Host', 'localhost').set('Accept-Encoding', 'identity');
+
+beforeAll(() => {
+    app = require('../../index');
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+    jest.resetModules();
+});
+
+function clearMap(map) {
+    for (const key of Object.keys(map)) delete map[key];
+}
+
+function seedValidFreeBinding({ ageMs = 60 * 1000, botId = 'free-reuse-bot' } = {}) {
+    const deviceId = 'reuse-device';
+    const deviceSecret = 'reuse-secret';
+    const now = Date.now();
+    const sessionKey = 'default:org:reuse-device:entity:0';
+    const webhookUrl = 'https://gateway.example/tools/invoke';
+    const token = 'gateway-token';
+    const publicCode = 'abc123';
+
+    const entity = {
+        ...app._createDefaultEntity(0),
+        entityId: 0,
+        isBound: true,
+        botSecret: 'entity-bot-secret',
+        publicCode,
+        name: '免費版',
+        state: 'IDLE',
+        message: 'Connected!',
+        rebindCount: 4,
+        lastRebindAt: now - ageMs,
+        lastUpdated: now - ageMs,
+        webhook: {
+            url: webhookUrl,
+            token,
+            sessionKey,
+            registeredAt: now - ageMs,
+        },
+    };
+
+    app.devices[deviceId] = {
+        deviceId,
+        deviceSecret,
+        createdAt: now - ageMs,
+        nextEntityId: 1,
+        entities: { 0: entity },
+    };
+    app._publicCodeIndex[publicCode] = { deviceId, entityId: 0 };
+
+    app._officialBorrowTest.officialBots[botId] = {
+        bot_id: botId,
+        bot_type: 'free',
+        webhook_url: webhookUrl,
+        token,
+        status: 'assigned',
+        session_key_template: 'default',
+    };
+
+    const binding = {
+        bot_id: botId,
+        device_id: deviceId,
+        entity_id: 0,
+        session_key: sessionKey,
+        bound_at: now - ageMs,
+        subscription_verified_at: now - ageMs,
+    };
+    app._officialBorrowTest.officialBindingsCache[
+        app._officialBorrowTest.getBindingCacheKey(deviceId, 0)
+    ] = binding;
+
+    return { deviceId, deviceSecret, botId, binding, entity };
+}
+
+beforeEach(() => {
+    clearMap(app.devices);
+    clearMap(app._publicCodeIndex);
+    clearMap(app._officialBorrowTest.officialBots);
+    clearMap(app._officialBorrowTest.officialBindingsCache);
+    gatekeeper.isDeviceBlocked.mockReturnValue(false);
+    gatekeeper.hasAgreedToTOS.mockReturnValue(true);
+    db.getOfficialBinding.mockImplementation(async (deviceId, entityId) => {
+        return app._officialBorrowTest.officialBindingsCache[
+            app._officialBorrowTest.getBindingCacheKey(deviceId, entityId)
+        ] || null;
+    });
+});
+
+describe('official borrow free binding reuse', () => {
+    it('reports a valid persistent free binding as reusable', async () => {
+        const { deviceId, deviceSecret, botId } = seedValidFreeBinding();
+
+        const res = await get('/api/official-borrow/binding-status')
+            .query({ deviceId, deviceSecret, entityId: 0, botType: 'free', botId });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.bound).toBe(true);
+        expect(res.body.valid).toBe(true);
+        expect(res.body.reusable).toBe(true);
+        expect(res.body.reason).toBe('valid');
+        expect(res.body.recommendation).toBe('reuse_existing_binding');
+        expect(res.body.skipBindFree).toBe(true);
+        expect(res.body.ttlMs).toBe(app._officialBorrowTest.OFFICIAL_FREE_BINDING_REUSE_TTL_MS);
+        expect(res.body.remainingMs).toBeGreaterThan(0);
+    });
+
+    it('makes repeated bind-free idempotent while the binding TTL is valid', async () => {
+        const { deviceId, deviceSecret, botId } = seedValidFreeBinding();
+        const before = app.devices[deviceId].entities[0];
+
+        const res = await post('/api/official-borrow/bind-free')
+            .send({ deviceId, deviceSecret, entityId: 0, botId });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.reusedExistingBinding).toBe(true);
+        expect(res.body.idempotent).toBe(true);
+        expect(res.body.bindingStatus.valid).toBe(true);
+
+        const after = app.devices[deviceId].entities[0];
+        expect(after.botSecret).toBe(before.botSecret);
+        expect(after.rebindCount).toBe(before.rebindCount);
+        expect(after.lastRebindAt).toBe(before.lastRebindAt);
+        expect(after.webhook.registeredAt).toBe(before.webhook.registeredAt);
+        expect(after.publicCode).toBe(before.publicCode);
+    });
+
+    it('marks the binding non-reusable when the reuse TTL has expired', async () => {
+        const ttl = app._officialBorrowTest.OFFICIAL_FREE_BINDING_REUSE_TTL_MS;
+        const { deviceId, deviceSecret, botId } = seedValidFreeBinding({ ageMs: ttl + 1000 });
+
+        const res = await get('/api/official-borrow/binding-status')
+            .query({ deviceId, deviceSecret, entityId: 0, botType: 'free', botId });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.bound).toBe(true);
+        expect(res.body.valid).toBe(false);
+        expect(res.body.reusable).toBe(false);
+        expect(res.body.reason).toBe('binding_reuse_ttl_expired');
+        expect(res.body.recommendation).toBe('bind_required');
+        expect(res.body.skipBindFree).toBe(false);
+        expect(res.body.remainingMs).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary
- Add a server-authoritative official binding reuse check that reads PostgreSQL first, refreshes the in-memory cache from DB, and applies a configurable free-binding reuse TTL (`OFFICIAL_FREE_BINDING_REUSE_TTL_MS`, default 24h).
- Add `GET /api/official-borrow/binding-status` with device-secret auth so callers can ask whether one binding is valid/reusable without binding again.
- Make `POST /api/official-borrow/bind-free` idempotent when the existing free binding is still valid, returning `reusedExistingBinding: true` and skipping auto-unbind, handshake, and BIND_COMPLETE delivery.

## Why
Before this, `bind-free` had no valid-binding noop path: an already-bound entity entered override auto-unbind before checking official binding validity. Health/SOP flows that re-called bind-free could therefore re-trigger handshake + BIND_COMPLETE and reopen the prompt-template echo path fixed in #2986.

## SOP note
For the mom-card/SOP path: call `binding-status` before bind-free. When the response has `valid: true` and `skipBindFree: true`, steps 4.2/4.3/4.7 can be skipped because the server has already confirmed the persistent binding is reusable.

## Test plan
- `node --check backend/index.js`
- `git diff --check`
- `npx jest tests/jest/official-borrow-binding-reuse.test.js --runInBand`
- `npx jest tests/jest/official-borrow.test.js tests/jest/official-borrow-binding-reuse.test.js --runInBand`

## Refs
- Sibling/preceding Path A PR: #2986
- Queued Path B card: `card_e6e98731` / inbound mom-card `394c019b`
