### PR TITLE
i18n(android): extract 3 hardcoded UI strings to strings.xml

### DIFF
--- a/app/src/main/java/com/hank/clawlive/MessageActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/MessageActivity.kt
@@ -111,7 +111,7 @@ class MessageActivity : AppCompatActivity() {
                 if (boundIds.isEmpty()) {
                     Toast.makeText(
                         this@MessageActivity,
-                        "No entities connected. Bind entities first.",
+                        getString(R.string.msg_no_entities_connected),
                         Toast.LENGTH_LONG
                     ).show()
                 }

--- a/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
@@ -366,7 +366,7 @@ class SettingsActivity : AppCompatActivity() {
         // Account Status Card listeners
         btnAccountOpenPortal.setOnClickListener {
             TelemetryHelper.trackAction("account_card_open_portal")
-            WebViewActivity.launch(this, "https://eclawbot.com/portal/dashboard.html", "EClawbot Portal")
+            WebViewActivity.launch(this, "https://eclawbot.com/portal/dashboard.html", getString(R.string.webview_title_eclawbot_portal))
         }
 
         tvAccountCopyCredentials.setOnClickListener {

--- a/app/src/main/java/com/hank/clawlive/ui/AiChatViewModel.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/AiChatViewModel.kt
@@ -362,7 +362,7 @@ class AiChatViewModel(application: Application) : AndroidViewModel(application) 
         val suffix = if (turn > 0) " (Step $turn/15)" else ""
         return when (progress["event"]) {
             "tool_use" -> {
-                val tool = progress["tool"] as? String ?: "Processing"
+                val tool = progress["tool"] as? String ?: context.getString(R.string.ai_chat_tool_status_default)
                 val label = when (tool) {
                     "Read" -> context.getString(R.string.ai_chat_tool_status_read)
                     "Grep" -> context.getString(R.string.ai_chat_tool_status_grep)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -142,11 +142,14 @@
     <string name="ai_chat_view_feedback">View Feedback History →</string>
 
     <string name="ai_chat_tool_status_bash">Running analysis</string>
+    <string name="ai_chat_tool_status_default">Processing</string>
     <string name="ai_chat_tool_status_edit">Editing file</string>
     <string name="ai_chat_tool_status_glob">Finding files</string>
     <string name="ai_chat_tool_status_grep">Searching code</string>
     <string name="ai_chat_tool_status_read">Reading file</string>
     <string name="ai_chat_tool_status_write">Writing file</string>
+    <string name="msg_no_entities_connected">No entities connected. Bind entities first.</string>
+    <string name="webview_title_eclawbot_portal">EClawbot Portal</string>
 
     <!-- Chat -->
     <string name="chat_history">Chat</string>


### PR DESCRIPTION
## Summary
- 3 UI sites moved from hardcoded English literals to `getString(R.string.*)`.
- 3 new en `<string>` entries added to `app/src/main/res/values/strings.xml`.
- Sites #4 OfficialBorrow and #5 ChatRepository from the audit are deliberately NOT changed — both are non-UI English literals (API payload + backend sentinel match) that must stay in source-English.

Closes work on `card_118c1787356d5425e863814b` ([i18n] Android Kotlin 硬編碼 UI 英文 — 5 個 site 需移到 strings.xml).

## Sites changed (3)
| File:Line | Original | New key |
|---|---|---|
| `MessageActivity.kt:114` | `"No entities connected. Bind entities first."` | `msg_no_entities_connected` |
| `AiChatViewModel.kt:365` | `"Processing"` (fallback when `progress["tool"]` is null) | `ai_chat_tool_status_default` |
| `SettingsActivity.kt:369` | `"EClawbot Portal"` (WebView title) | `webview_title_eclawbot_portal` |

## Sites intentionally NOT changed (out-of-scope, audit over-scoped)
| File:Line | Reason |
|---|---|
| `OfficialBorrowActivity.kt:485` (`"Monthly bot rental demand"`) | API payload body sent to `/api/feedback?category=rental_demand`. Backend filters on the literal English string (`message='Monthly bot rental demand'`) for demand aggregation. Localizing would split the count across N locales and break the dashboard query. |
| `ChatRepository.kt:166` (`"No message"`) | Sentinel in `passiveMessages: List<String>` matched verbatim against `entity.message` from the backend. The backend persists these English literals; localizing the client-side match list would let backend-English values bypass the filter. |

Documented inline in the commit body so the next audit doesn't re-open these.

## Follow-up (deferred to #5 Hermes)
The 3 new keys live in `values/strings.xml` only. 14 locale variants (`values-{ar,de,es,fr,hi,in,ja,ko,ms,th,vi,zh,zh-rCN,zh-rTW}/strings.xml`) need the 3 keys translated. Android resource fallback to `values/` works at runtime until then. Will dispatch a separate card to Hermes after this merges.

## Test plan
- [ ] CI compileDebug passes (verifies `R.string.msg_no_entities_connected` etc resolve)
- [ ] Manual: launch app, force entity-list empty path → Toast shows "No entities connected. Bind entities first."
- [ ] Manual: open Settings → Account card → "Open Portal" button → WebView title bar reads "EClawbot Portal"
- [ ] Manual: trigger an AI chat with a tool the localized when-cases don't cover (e.g. WebSearch) — label flows through `else -> tool` path correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)