### PR TITLE
fix(transform): 400-gate malformed speakTo instead of silent not_found

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -7653,6 +7653,34 @@ function resolveSpeakToTarget(code, senderDeviceId) {
     return null;
 }
 
+/**
+ * Validate that a speakTo array entry parses to one of the supported forms
+ * before we attempt resolution. Used by the /api/transform 400-gate so
+ * malformed LLM input fails fast instead of falling through to silent
+ * not_found (which the calling bot used to treat as a successful delivery
+ * and never retry).
+ *
+ * Supported forms (decorators optional and any combination of < > @ #):
+ *   - 6-char publicCode [a-z0-9]{6}
+ *   - numeric entityId  \d+
+ *
+ * Returns { valid: true } or { valid: false, reason, normalized? }.
+ */
+function validateSpeakToFormat(code) {
+    if (typeof code !== 'string') return { valid: false, reason: 'non_string' };
+    const trimmed = code.trim();
+    if (trimmed.length === 0) return { valid: false, reason: 'empty' };
+    let normalized = trimmed;
+    if (normalized.startsWith('<') && normalized.endsWith('>')) {
+        normalized = normalized.slice(1, -1);
+    }
+    if (normalized.startsWith('@')) normalized = normalized.slice(1);
+    if (normalized.startsWith('#')) normalized = normalized.slice(1);
+    if (/^[a-z0-9]{6}$/.test(normalized)) return { valid: true };
+    if (/^\d+$/.test(normalized)) return { valid: true };
+    return { valid: false, reason: 'unparseable_format', normalized };
+}
+
 function collectMissingSpeakToMentionWarnings(speakToList, mentionParse, senderDeviceId) {
     if (!Array.isArray(speakToList) || speakToList.length === 0) return [];
     const mentioned = new Set((mentionParse?.mentions || []).map(m => `${m.deviceId}:${m.entityId}`));
@@ -7974,6 +8002,34 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
         }
     } else if (!usingBotSecret) {
         return res.status(400).json({ success: false, message: "botSecret required" });
+    }
+
+    // ── speakTo format gate (defensive 400 instead of silent not_found drop) ──
+    // Reject malformed containers, then validate each entry's shape. Bots that
+    // pass freeform strings like "Lobster" or "team-2" used to silently fail
+    // (delivery 0/1 success, sender-only chat row) and never retry; now they
+    // get an actionable 400 with the offending value.
+    if (req.body.speakTo !== undefined && req.body.speakTo !== null && !Array.isArray(req.body.speakTo)) {
+        return res.status(400).json({
+            success: false,
+            error: 'speakTo_invalid_format',
+            got: req.body.speakTo,
+            expected: 'speakTo must be an array of strings'
+        });
+    }
+    if (hadExplicitSpeakTo) {
+        for (const entry of speakTo) {
+            const check = validateSpeakToFormat(entry);
+            if (!check.valid) {
+                return res.status(400).json({
+                    success: false,
+                    error: 'speakTo_invalid_format',
+                    got: entry,
+                    reason: check.reason,
+                    expected: '6-char publicCode [a-z0-9] OR numeric entityId; optional <>/@/# decorators allowed'
+                });
+            }
+        }
     }
 
     // Validate optional senderHint — channel bridges pass this so the server

--- a/backend/index.js
+++ b/backend/index.js
@@ -7660,9 +7660,10 @@ function resolveSpeakToTarget(code, senderDeviceId) {
  * not_found (which the calling bot used to treat as a successful delivery
  * and never retry).
  *
- * Supported forms (decorators optional and any combination of < > @ #):
- *   - 6-char publicCode [a-z0-9]{6}
- *   - numeric entityId  \d+
+ * Supported forms (decorators stripped in this fixed order, mirroring
+ * resolveSpeakToTarget: outer angle brackets, then leading @, then leading #):
+ *   - 6-char publicCode [a-z0-9]{6}        e.g. "tbwb9e", "@tbwb9e", "<@tbwb9e>"
+ *   - numeric entityId  \d+                e.g. "6", "#6", "@#6", "<#6>"
  *
  * Returns { valid: true } or { valid: false, reason, normalized? }.
  */

--- a/backend/tests/jest/transform-delivery.test.js
+++ b/backend/tests/jest/transform-delivery.test.js
@@ -107,7 +107,7 @@ describe('Transform + speakTo', () => {
                 botSecret: botSecret0,
                 message: 'Test invalid code',
                 state: 'IDLE',
-                speakTo: ['nonexistent-code-xyz']
+                speakTo: ['zzzzzz']
             });
         expect(res.status).toBe(200);
         expect(res.body.delivery.results[0].success).toBe(false);
@@ -514,7 +514,7 @@ describe('Transform fallback save on delivery failure', () => {
                 botSecret: botSecret0,
                 message: msg,
                 state: 'IDLE',
-                speakTo: ['nonexistent-code-xyz']
+                speakTo: ['zzzzzz']
             });
 
         expect(res.status).toBe(200);
@@ -596,7 +596,7 @@ describe('Transform fallback save on delivery failure', () => {
                 botSecret: botSecret0,
                 message: msg,
                 state: 'IDLE',
-                speakTo: ['nonexistent-code-xyz']
+                speakTo: ['zzzzzz']
             });
 
         expect(res.status).toBe(200);

--- a/backend/tests/jest/transform-speakto-tolerant-formats.test.js
+++ b/backend/tests/jest/transform-speakto-tolerant-formats.test.js
@@ -162,8 +162,8 @@ describe('POST /api/transform — speakTo tolerant formats (#2291)', () => {
         expect(res.body.delivery?.results?.[0]?.entityId).toBe(1);
     });
 
-    test('speakTo: ["nonexistent"] still returns not_found (regression)', async () => {
-        const tag = `TOL-NF-${Date.now()}`;
+    test('speakTo: ["notreal"] (unparseable format) → 400 speakTo_invalid_format', async () => {
+        const tag = `TOL-FMT-${Date.now()}`;
         const res = await post('/api/transform').send({
             deviceId,
             entityId: 2,
@@ -173,17 +173,52 @@ describe('POST /api/transform — speakTo tolerant formats (#2291)', () => {
             speakTo: ['notreal'],
         });
 
-        expect(res.status).toBe(200);
-        const result = res.body.delivery?.results?.[0];
-        expect(result?.success).toBe(false);
-        expect(result?.reason).toBe('not_found');
-
-        // Fallback save still creates ONE sender-side row.
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+        expect(res.body.error).toBe('speakTo_invalid_format');
+        expect(res.body.got).toBe('notreal');
+        // Gate fires before delivery — no chat row should have been saved
         const rows = rowsForProbe(tag);
-        expect(rows).toHaveLength(1);
-        // Critical: NO misleading routing arrow that pretends a target was reached.
-        // pendingA2A is from entity 0 — pre-fix this row would be `->0`.
-        expect(/->\d+$/.test(rows[0].source)).toBe(false);
+        expect(rows).toHaveLength(0);
+    });
+
+    test.each([
+        ['Lobster',     'mixed-case word (likely entity name)'],
+        ['team-2',      'with hyphen'],
+        ['abc',         'too short'],
+        ['ABCDEF',      'uppercase 6-char'],
+        ['  ',          'whitespace only'],
+        ['',            'empty string'],
+        ['@@abc123',    'double-@ junk'],
+        ['hello world', 'with space'],
+    ])('speakTo: [%j] (%s) → 400 speakTo_invalid_format', async (badEntry) => {
+        const res = await post('/api/transform').send({
+            deviceId,
+            entityId: 2,
+            botSecret: botSecret2,
+            state: 'IDLE',
+            message: `BAD-${Date.now()}`,
+            speakTo: [badEntry],
+        });
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('speakTo_invalid_format');
+        expect(res.body.got).toBe(badEntry);
+    });
+
+    test('speakTo: "abc123" (non-array container) → 400 speakTo_invalid_format', async () => {
+        const res = await post('/api/transform').send({
+            deviceId,
+            entityId: 2,
+            botSecret: botSecret2,
+            state: 'IDLE',
+            message: `BAD-CONTAINER-${Date.now()}`,
+            speakTo: 'abc123',
+        });
+
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('speakTo_invalid_format');
+        expect(res.body.expected).toMatch(/array/);
     });
 
     test('speakTo: ["#999"] (numeric but invalid entity) → not_found, no phantom anchor', async () => {


### PR DESCRIPTION
## Summary
- Pre-validate `speakTo` entries with `validateSpeakToFormat()` against the two supported shapes (6-char publicCode, numeric entityId, with optional `<>` / `@` / `#` decorators stripped in fixed order).
- Reject malformed shapes (non-array container, freeform strings like `"Lobster"`, `"team-2"`, whitespace, empty) with `400 { error: "speakTo_invalid_format", got }` so the calling bot has an actionable error.
- Parseable-but-not-found targets (e.g. `"#999"`) still flow through the existing fallback-save path — only unparseable shapes fail fast.
- Card: card_b0a5ee9d (P0)

## Why
LLM bots routinely emit freeform `speakTo: ["Lobster"]` thinking it maps to entity name. Pre-fix, the server silently dropped to `not_found`, the bot saw `200 { success: false }` and rarely retried — message effectively lost. Now the bot gets a 400 with the rejected value and the expected format string, making the failure mode self-correcting.

## Caller migration (API note)
**Breaking for callers that previously relied on the silent failure path.** What changes:
| Caller intent | Before | After |
|---|---|---|
| `speakTo: [1]` (int) | `200 { delivery.results: [success:false, reason:"not_found"] }` | `400 { error:"speakTo_invalid_format", got:1, reason:"non_string" }` |
| `speakTo: ["Lobster"]` (entity name) | same silent 200 | `400 { error, got:"Lobster", reason:"unparseable_format" }` |
| `speakTo: "abc123"` (string, not array) | router crash / inconsistent | `400 { error, got:"abc123", expected:"speakTo must be an array of strings" }` |
| `speakTo: ["#999"]` (parseable, missing) | fallback-save row with phantom anchor | unchanged: fallback-save row (no phantom anchor — fixed in PR #2291) |
| `speakTo: ["tbwb9e"]`, `["#6"]`, `["@#6"]`, `["<#6>"]`, `["@tbwb9e"]`, `["<@tbwb9e>"]` | resolves | unchanged: still resolves |

Bot callers that were treating `200 + success:false` as "delivered" must update their retry/error handling: a `400` is now thrown synchronously. Server-internal callers (mention-router, senderHint auto-populate) are unaffected — they always emit decorator-free publicCodes, so they parse cleanly.

## Test plan
- [x] `transform-speakto-tolerant-formats.test.js` — 16/16 pass (covers `#1`, `@#1`, `<#1>`, `@<publicCode>`, `<@publicCode>`, `notreal`, 8x bad-entry table, non-array container, `#999` parseable-but-missing)
- [x] `transform-delivery.test.js` — 20/20 pass (regression on fallback-save path; `'nonexistent-code-xyz'` swapped to `'zzzzzz'` to exercise unallocated-but-parseable fallback)
- [x] CI 10/10 green pre-tighten — re-running on JSDoc nit fix
- [ ] Smoke check against staging once merged: send `speakTo: ["Lobster"]` → expect 400 + `error: speakTo_invalid_format`
- [ ] Confirm decorator forms (`#1`, `@#1`, `<#1>`) still resolve in prod

## Review
- #1 Mac_F: **LGTM** (GH comment 4565829080) — 400 contract right, uppercase stays 400, parseable-but-unallocated still fallback. Non-blocking: tighten JSDoc wording (✓ addressed in 77e5917b) + add caller changelog (✓ added above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)