### PR TITLE
i18n(android): externalize AiChatViewModel streaming status strings

### DIFF
--- a/app/src/main/java/com/hank/clawlive/ui/AiChatViewModel.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/AiChatViewModel.kt
@@ -374,8 +374,8 @@ class AiChatViewModel(application: Application) : AndroidViewModel(application) 
                 }
                 "$label…$suffix"
             }
-            "thinking" -> "Analyzing…$suffix"
-            "tool_result" -> "Processing result…$suffix"
+            "thinking" -> context.getString(R.string.ai_chat_status_analyzing) + "…$suffix"
+            "tool_result" -> context.getString(R.string.ai_chat_status_processing_result) + "…$suffix"
             else -> null
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -148,6 +148,8 @@
     <string name="ai_chat_tool_status_grep">Searching code</string>
     <string name="ai_chat_tool_status_read">Reading file</string>
     <string name="ai_chat_tool_status_write">Writing file</string>
+    <string name="ai_chat_status_analyzing">Analyzing</string>
+    <string name="ai_chat_status_processing_result">Processing result</string>
     <string name="msg_no_entities_connected">No entities connected. Bind entities first.</string>
     <string name="webview_title_eclawbot_portal">EClawbot Portal</string>
 


### PR DESCRIPTION
## Summary
- Adds `ai_chat_status_analyzing` + `ai_chat_status_processing_result` to `values/strings.xml` (en source).
- Rewrites `AiChatViewModel.kt:377-378` to use `context.getString(R.string.X) + "…\$suffix"`, keeping suffix formatting + ellipsis Kotlin-side (matches existing tool_status pattern at L367-372).
- Two strings missed by PR #2998's site list, caught by #3 Mac_E during PR #2999 audit.
- Card: card_d44cb2debedae7e8912c03c3

## Why
Both strings fire on every streaming agent-progress label tick (thinking branch + tool_result branch). Without externalization they stay English even when the device locale switches.

## Test plan
- [x] Android Lint
- [x] Kotlin Unit Tests
- [x] Assemble Debug APK
- [ ] U01 sim E2E: chat streaming shows expected text on zh-TW device (currently falls back to en source — Hermes #5 will add the 14-locale translations in a follow-up PR per card spec).
- [ ] requiresScreenshotReview gated post-merge (sim E2E artifact).

## Follow-up
Dispatch Hermes (#5) for 14 locales × 2 keys = 28 translations after this PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)