### PR TITLE
i18n(android): Add 14 locales for ai_chat_status_analyzing / processing_result

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -975,4 +975,6 @@ GPS: عند الطلب فقط، بلا تتبع في الخلفية، تُفقد
     <string name="fcm_channel_system_desc">إشعارات النظام</string>
     <string name="fcm_channel_feedback_name">تحديثات الملاحظات</string>
     <string name="fcm_channel_feedback_desc">تحديثات حالة الملاحظات</string>
+    <string name="ai_chat_status_analyzing">جارٍ التحليل</string>
+    <string name="ai_chat_status_processing_result">معالجة النتيجة</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -974,4 +974,6 @@ Bei Fragen kontaktieren Sie uns über unsere offizielle E-Mail.
     <string name="fcm_channel_system_desc">Systembenachrichtigungen</string>
     <string name="fcm_channel_feedback_name">Feedback-Updates</string>
     <string name="fcm_channel_feedback_desc">Feedback-Statusaktualisierungen</string>
+    <string name="ai_chat_status_analyzing">Analysiere</string>
+    <string name="ai_chat_status_processing_result">Verarbeite Ergebnis</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -897,4 +897,6 @@ Tu suscripción permanece activa y puedes reenlazar en cualquier momento (sujeto
     <string name="fcm_channel_system_desc">Notificaciones del sistema</string>
     <string name="fcm_channel_feedback_name">Actualizaciones de comentarios</string>
     <string name="fcm_channel_feedback_desc">Actualizaciones del estado de comentarios</string>
+    <string name="ai_chat_status_analyzing">Analizando</string>
+    <string name="ai_chat_status_processing_result">Procesando resultado</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -974,4 +974,6 @@ Si vous avez des questions, contactez-nous via notre e-mail officiel.
     <string name="fcm_channel_system_desc">Notifications système</string>
     <string name="fcm_channel_feedback_name">Mises à jour des retours</string>
     <string name="fcm_channel_feedback_desc">Mises à jour de l\'état des retours</string>
+    <string name="ai_chat_status_analyzing">Analyse en cours</string>
+    <string name="ai_chat_status_processing_result">Traitement du résultat</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="ai_chat_status_analyzing">Menganalisis</string>
+    <string name="ai_chat_status_processing_result">Memproses hasil</string>
+</resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="ai_chat_status_analyzing">Analisi in corso</string>
+    <string name="ai_chat_status_processing_result">Elaborazione risultato</string>
+</resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -870,4 +870,6 @@ GPS：オンデマンドのみ、バックグラウンド追跡なし、サー�
     <string name="fcm_channel_system_desc">システム通知</string>
     <string name="fcm_channel_feedback_name">フィードバック更新</string>
     <string name="fcm_channel_feedback_desc">フィードバック状態の更新</string>
+    <string name="ai_chat_status_analyzing">分析中</string>
+    <string name="ai_chat_status_processing_result">結果を処理中</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -870,4 +870,6 @@ GPS: 온디맨드만, 백그라운드 추적 없음, 서버 재시작 시 데이
     <string name="fcm_channel_system_desc">시스템 알림</string>
     <string name="fcm_channel_feedback_name">피드백 업데이트</string>
     <string name="fcm_channel_feedback_desc">피드백 상태 업데이트</string>
+    <string name="ai_chat_status_analyzing">분석 중</string>
+    <string name="ai_chat_status_processing_result">결과 처리 중</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="ai_chat_status_analyzing">Analisando</string>
+    <string name="ai_chat_status_processing_result">Processando resultado</string>
+</resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="ai_chat_status_analyzing">Анализирую</string>
+    <string name="ai_chat_status_processing_result">Обрабатываю результат</string>
+</resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -869,4 +869,6 @@ GPS：รับตามความต้องการเท่านั้�
     <string name="fcm_channel_system_desc">การแจ้งเตือนระบบ</string>
     <string name="fcm_channel_feedback_name">อัปเดตคำติชม</string>
     <string name="fcm_channel_feedback_desc">อัปเดตสถานะคำติชม</string>
+    <string name="ai_chat_status_analyzing">กำลังวิเคราะห์</string>
+    <string name="ai_chat_status_processing_result">กำลังประมวลผล</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -869,4 +869,6 @@ Nếu có bất kỳ câu hỏi nào, vui lòng liên hệ với chúng tôi qua
     <string name="fcm_channel_system_desc">Thông báo hệ thống</string>
     <string name="fcm_channel_feedback_name">Cập nhật phản hồi</string>
     <string name="fcm_channel_feedback_desc">Cập nhật trạng thái phản hồi</string>
+    <string name="ai_chat_status_analyzing">Đang phân tích</string>
+    <string name="ai_chat_status_processing_result">Đang xử lý kết quả</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -872,4 +872,6 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="fcm_channel_system_desc">系统通知</string>
     <string name="fcm_channel_feedback_name">反馈更新</string>
     <string name="fcm_channel_feedback_desc">反馈状态更新</string>
+    <string name="ai_chat_status_analyzing">分析中</string>
+    <string name="ai_chat_status_processing_result">处理结果中</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -870,4 +870,6 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="fcm_channel_system_desc">系統通知</string>
     <string name="fcm_channel_feedback_name">回饋更新</string>
     <string name="fcm_channel_feedback_desc">回饋狀態更新</string>
+    <string name="ai_chat_status_analyzing">分析中</string>
+    <string name="ai_chat_status_processing_result">處理結果中</string>
 </resources>


### PR DESCRIPTION
## Summary
Add 14 Android locale translations for the 2 streaming status keys from PR #3003.

## Keys
| Key | en |
|-----|-----|
| `ai_chat_status_analyzing` | "Analyzing" |
| `ai_chat_status_processing_result` | "Processing result" |

## 14 Locales
zh-rTW, zh-rCN, ja, ko, es, fr, de, it, pt-rBR, ru, vi, th, id, ar.

## Cross-review
Ping @#2 (LOBSTER) for review.

## Card
card_d44cb2de