### PR TITLE
feat(android): Wallpaper settings — 5h/weekly reset countdown toggle (card_5a63c923)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/WallpaperPreviewActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/WallpaperPreviewActivity.kt
@@ -8,6 +8,7 @@ import android.view.View
 import android.widget.CheckBox
 import android.widget.ImageButton
 import android.widget.LinearLayout
+import android.widget.RadioGroup
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
@@ -45,6 +46,7 @@ class WallpaperPreviewActivity : AppCompatActivity() {
     private lateinit var checkUsageCodex: CheckBox
     private lateinit var checkUsageSession: CheckBox
     private lateinit var checkUsageWeekly: CheckBox
+    private lateinit var radioResetWindow: RadioGroup
     private lateinit var btnSelectPhoto: MaterialButton
     private lateinit var btnReset: MaterialButton
     private lateinit var btnSetWallpaper: MaterialButton
@@ -131,6 +133,7 @@ class WallpaperPreviewActivity : AppCompatActivity() {
         checkUsageCodex = findViewById(R.id.checkUsageCodex)
         checkUsageSession = findViewById(R.id.checkUsageSession)
         checkUsageWeekly = findViewById(R.id.checkUsageWeekly)
+        radioResetWindow = findViewById(R.id.radioResetWindow)
         btnSelectPhoto = findViewById(R.id.btnSelectPhoto)
         btnReset = findViewById(R.id.btnReset)
         btnSetWallpaper = findViewById(R.id.btnSetWallpaper)
@@ -152,6 +155,13 @@ class WallpaperPreviewActivity : AppCompatActivity() {
         checkUsageCodex.isChecked = layoutPrefs.usageOverlayShowCodex
         checkUsageSession.isChecked = layoutPrefs.usageOverlayShowSession
         checkUsageWeekly.isChecked = layoutPrefs.usageOverlayShowWeekly
+        radioResetWindow.check(
+            when (layoutPrefs.wallpaperResetWindow) {
+                LayoutPreferences.RESET_WINDOW_5H -> R.id.radioReset5h
+                LayoutPreferences.RESET_WINDOW_WEEKLY -> R.id.radioResetWeekly
+                else -> R.id.radioResetOff
+            }
+        )
 
         // Show/hide photo button based on background switch
         updatePhotoButtonVisibility()
@@ -254,6 +264,15 @@ class WallpaperPreviewActivity : AppCompatActivity() {
         checkUsageCodex.setOnCheckedChangeListener(usageItemListener)
         checkUsageSession.setOnCheckedChangeListener(usageItemListener)
         checkUsageWeekly.setOnCheckedChangeListener(usageItemListener)
+
+        radioResetWindow.setOnCheckedChangeListener { _, checkedId ->
+            layoutPrefs.wallpaperResetWindow = when (checkedId) {
+                R.id.radioReset5h -> LayoutPreferences.RESET_WINDOW_5H
+                R.id.radioResetWeekly -> LayoutPreferences.RESET_WINDOW_WEEKLY
+                else -> LayoutPreferences.RESET_WINDOW_OFF
+            }
+            previewView.invalidate()
+        }
     }
 
     private fun updatePhotoButtonVisibility() {
@@ -266,6 +285,9 @@ class WallpaperPreviewActivity : AppCompatActivity() {
         checkUsageCodex.isEnabled = enabled
         checkUsageSession.isEnabled = enabled
         checkUsageWeekly.isEnabled = enabled
+        for (i in 0 until radioResetWindow.childCount) {
+            radioResetWindow.getChildAt(i).isEnabled = enabled
+        }
     }
 
     private fun updatePreviewUsageOverlayInsets() {

--- a/app/src/main/java/com/hank/clawlive/data/local/LayoutPreferences.kt
+++ b/app/src/main/java/com/hank/clawlive/data/local/LayoutPreferences.kt
@@ -359,6 +359,16 @@ class LayoutPreferences private constructor(context: Context) {
             prefs.edit().putBoolean(KEY_USAGE_OVERLAY_SHOW_WEEKLY, value).apply()
         }
 
+    var wallpaperResetWindow: String
+        get() = prefs.getString(KEY_WALLPAPER_RESET_WINDOW, RESET_WINDOW_OFF) ?: RESET_WINDOW_OFF
+        set(value) {
+            val normalized = when (value) {
+                RESET_WINDOW_5H, RESET_WINDOW_WEEKLY -> value
+                else -> RESET_WINDOW_OFF
+            }
+            prefs.edit().putString(KEY_WALLPAPER_RESET_WINDOW, normalized).apply()
+        }
+
     companion object {
         private const val PREFS_NAME = "entity_layout_prefs"
         private const val KEY_LAYOUT = "layout_type"
@@ -381,6 +391,11 @@ class LayoutPreferences private constructor(context: Context) {
         private const val KEY_USAGE_OVERLAY_SHOW_CODEX = "usage_overlay_show_codex"
         private const val KEY_USAGE_OVERLAY_SHOW_SESSION = "usage_overlay_show_session"
         private const val KEY_USAGE_OVERLAY_SHOW_WEEKLY = "usage_overlay_show_weekly"
+        private const val KEY_WALLPAPER_RESET_WINDOW = "wallpaper_reset_window"
+
+        const val RESET_WINDOW_OFF = "off"
+        const val RESET_WINDOW_5H = "5h"
+        const val RESET_WINDOW_WEEKLY = "weekly"
 
         // Display mode constants
         const val MODE_SINGLE = 1

--- a/app/src/main/java/com/hank/clawlive/engine/UsageOverlayRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/UsageOverlayRenderer.kt
@@ -10,6 +10,8 @@ import com.hank.clawlive.R
 import com.hank.clawlive.data.local.LayoutPreferences
 import com.hank.clawlive.data.local.UsageOverlayPosition
 import com.hank.clawlive.data.model.UsageSnapshotLatest
+import java.util.Calendar
+import java.util.Locale
 import kotlin.math.roundToInt
 
 class UsageOverlayRenderer(
@@ -216,7 +218,67 @@ class UsageOverlayRenderer(
         if (lines.size == 1) {
             lines.add(context.getString(R.string.wallpaper_usage_overlay_syncing))
         }
+
+        formatResetCountdownLine(snapshot)?.let(lines::add)
         return lines
+    }
+
+    private fun formatResetCountdownLine(snapshot: UsageSnapshotLatest?): String? {
+        return when (layoutPrefs.wallpaperResetWindow) {
+            LayoutPreferences.RESET_WINDOW_5H -> {
+                val resetsAt = nextFiveHourResetEpochSec(snapshot) ?: return null
+                val hhmm = formatHourMinute((resetsAt * 1000.0).toLong())
+                context.getString(R.string.wallpaper_reset_window_5h_next, hhmm)
+            }
+            LayoutPreferences.RESET_WINDOW_WEEKLY -> {
+                val resetsAt = nextWeeklyResetEpochMillis()
+                val mondayHhmm = formatWeeklyReset(resetsAt)
+                context.getString(R.string.wallpaper_reset_window_weekly_next, mondayHhmm)
+            }
+            else -> null
+        }
+    }
+
+    private fun nextFiveHourResetEpochSec(snapshot: UsageSnapshotLatest?): Double? {
+        if (snapshot == null) return null
+        val claudeReset = snapshot.claude?.live?.rateLimits?.fiveHour?.resetsAt
+        val codexReset = snapshot.codex?.rateLimits?.fiveHourResetsAt
+        val nowSec = System.currentTimeMillis() / 1000.0
+        val candidates = listOfNotNull(claudeReset, codexReset).filter { it > nowSec }
+        return candidates.minOrNull()
+    }
+
+    private fun nextWeeklyResetEpochMillis(): Long {
+        val cal = Calendar.getInstance()
+        cal.set(Calendar.HOUR_OF_DAY, 0)
+        cal.set(Calendar.MINUTE, 0)
+        cal.set(Calendar.SECOND, 0)
+        cal.set(Calendar.MILLISECOND, 0)
+        val daysUntilMonday = ((Calendar.MONDAY - cal.get(Calendar.DAY_OF_WEEK) + 7) % 7).let {
+            if (it == 0) 7 else it
+        }
+        cal.add(Calendar.DAY_OF_YEAR, daysUntilMonday)
+        return cal.timeInMillis
+    }
+
+    private fun formatHourMinute(epochMillis: Long): String {
+        val cal = Calendar.getInstance().apply { timeInMillis = epochMillis }
+        return String.format(
+            Locale.US,
+            "%02d:%02d",
+            cal.get(Calendar.HOUR_OF_DAY),
+            cal.get(Calendar.MINUTE)
+        )
+    }
+
+    private fun formatWeeklyReset(epochMillis: Long): String {
+        val cal = Calendar.getInstance().apply { timeInMillis = epochMillis }
+        return String.format(
+            Locale.US,
+            "Mon %02d:%02d",
+            cal.get(Calendar.HOUR_OF_DAY),
+            cal.get(Calendar.MINUTE)
+        )
     }
 
     private fun formatEngineLine(label: String, sessionPct: Double?, weeklyPct: Double?): String? {

--- a/app/src/main/res/layout/activity_wallpaper_preview.xml
+++ b/app/src/main/res/layout/activity_wallpaper_preview.xml
@@ -192,6 +192,53 @@
 
             </LinearLayout>
 
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="6dp"
+                android:text="@string/wallpaper_reset_window_label"
+                android:textColor="@color/text_white_60"
+                android:textSize="12sp" />
+
+            <RadioGroup
+                android:id="@+id/radioResetWindow"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="2dp"
+                android:orientation="horizontal">
+
+                <RadioButton
+                    android:id="@+id/radioResetOff"
+                    android:layout_width="0dp"
+                    android:layout_height="48dp"
+                    android:layout_weight="1"
+                    android:buttonTint="@color/lobster_orange"
+                    android:text="@string/wallpaper_reset_window_off"
+                    android:textColor="@android:color/white"
+                    android:textSize="13sp" />
+
+                <RadioButton
+                    android:id="@+id/radioReset5h"
+                    android:layout_width="0dp"
+                    android:layout_height="48dp"
+                    android:layout_weight="1"
+                    android:buttonTint="@color/lobster_orange"
+                    android:text="@string/wallpaper_reset_window_5h"
+                    android:textColor="@android:color/white"
+                    android:textSize="13sp" />
+
+                <RadioButton
+                    android:id="@+id/radioResetWeekly"
+                    android:layout_width="0dp"
+                    android:layout_height="48dp"
+                    android:layout_weight="1"
+                    android:buttonTint="@color/lobster_orange"
+                    android:text="@string/wallpaper_reset_window_weekly"
+                    android:textColor="@android:color/white"
+                    android:textSize="13sp" />
+
+            </RadioGroup>
+
         </LinearLayout>
 
         <!-- Select Photo Button (only visible when background enabled) -->

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -100,6 +100,12 @@
     <string name="wallpaper_usage_window_weekly">7d</string>
     <string name="wallpaper_usage_window_session_label">Session</string>
     <string name="wallpaper_usage_window_weekly_label">Weekly</string>
+    <string name="wallpaper_reset_window_label">Reset countdown</string>
+    <string name="wallpaper_reset_window_off">Off</string>
+    <string name="wallpaper_reset_window_5h">5h</string>
+    <string name="wallpaper_reset_window_weekly">Weekly</string>
+    <string name="wallpaper_reset_window_5h_next">Next 5h reset: %1$s</string>
+    <string name="wallpaper_reset_window_weekly_next">Next weekly reset: %1$s</string>
     <string name="back">Back</string>
     
     <!-- Layout Editor -->


### PR DESCRIPTION
## Scope

Android wallpaper settings reset-interval toggle (card_5a63c92358457200209ac8a5).

3-way `wallpaper_reset_window` SharedPreferences key (`off` / `5h` / `weekly`, default `off`).
When set to `5h` or `weekly`, an extra countdown line is rendered below the existing 5h/7d usage strip in `UsageOverlayRenderer`:

- `5h` → `Next 5h reset: HH:MM` — computed from min of `claude.live.rateLimits.fiveHour.resetsAt` and `codex.rateLimits.fiveHourResetsAt` (both epoch seconds, sliding window per [aqua5230/usage statusLine spec](https://github.com/aqua5230/usage#statusline-spec))
- `weekly` → `Next weekly reset: Mon HH:MM` — local-TZ next Monday 00:00 via `Calendar`

## Files

- `app/src/main/java/com/hank/clawlive/data/local/LayoutPreferences.kt` — new `wallpaperResetWindow` property + 4 companion constants (`KEY_WALLPAPER_RESET_WINDOW`, `RESET_WINDOW_OFF/5H/WEEKLY`)
- `app/src/main/res/layout/activity_wallpaper_preview.xml` — RadioGroup `radioResetWindow` with 3 options inside `usageOverlayPanel`
- `app/src/main/java/com/hank/clawlive/WallpaperPreviewActivity.kt` — bind + initial check + listener + enable/disable parity with usage-overlay switch
- `app/src/main/java/com/hank/clawlive/engine/UsageOverlayRenderer.kt` — `buildLines()` appends `formatResetCountdownLine()`; helpers compute next 5h reset (sliding-window candidate min) + next Monday 00:00 local
- `app/src/main/res/values/strings.xml` — 6 EN source strings (label + 3 radio labels + 2 countdown templates)

## Screenshots

Verified on Pixel_9a emulator (API 34, 1080×2424) using synthetic snapshot.

| State | fileId |
|-------|--------|
| off (no countdown line) | `4cd933d6-ed31-4ef1-bee3-59e8857f2f3a` |
| 5h (`Next 5h reset: 01:40`) | `66bd2c75-7f32-4ec7-8079-b21591e9bd81` |
| weekly (`Next weekly reset: Mon 00:00`) | `4fb09e40-4e55-4ffb-bf7a-363381f22e35` |

Each fileId resolves to its PNG via `GET https://eclawbot.com/api/files/<fileId>`.

## EN source strings

```xml
<string name="wallpaper_reset_window_label">Reset countdown</string>
<string name="wallpaper_reset_window_off">Off</string>
<string name="wallpaper_reset_window_5h">5h</string>
<string name="wallpaper_reset_window_weekly">Weekly</string>
<string name="wallpaper_reset_window_5h_next">Next 5h reset: %1$s</string>
<string name="wallpaper_reset_window_weekly_next">Next weekly reset: %1$s</string>
```

## Locale follow-up

This PR ships EN only. Hermes / #3 Mac_E will batch the 3 new keys × 14 locales as a separate PR.

## Test plan

- [x] APK builds clean, installs on Pixel_9a emulator
- [x] Toggle persists across activity restarts via SharedPreferences
- [x] Off state: overlay renders only existing 5h/7d % strip, no countdown
- [x] 5h state: countdown picks the sooner of Claude/Codex `resetsAt`
- [x] Weekly state: countdown shows `Mon HH:MM` for next Monday 00:00 local
- [x] RadioGroup disabled when usage-overlay master switch is off
- [x] Synthetic snapshot E2E exercises both Claude and Codex paths

@HankHuang0516 — please review.
