### PR TITLE
[codex] add point-edit coordinate resolver

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1819,6 +1819,10 @@ try {
     mindmapModule = { initMindmapTables: () => {} };
 }
 
+// Point-and-edit demo — coordinate-to-source target resolver.
+const pointEditResolver = require('./point-edit-resolver');
+app.use('/api/point-edit', pointEditResolver.router);
+
 // Scheduled Messages — user-scheduled chat messages (Phase 1: backend)
 let scheduledMessagesModule;
 try {
@@ -21300,6 +21304,7 @@ module.exports._ENTITY_HEARTBEAT_STALE_MS = ENTITY_HEARTBEAT_STALE_MS;
 module.exports._getEntityDaemonStatus = getEntityDaemonStatus;
 module.exports._hermesHealthMonitor = hermesHealthMonitor;
 module.exports._chatPool = chatPool;
+module.exports._pointEditResolver = pointEditResolver;
 module.exports._ACK_DEFAULT_DEADLINE_MS = ACK_DEFAULT_DEADLINE_MS;
 module.exports._ACK_MIN_DEADLINE_MS = ACK_MIN_DEADLINE_MS;
 module.exports._ACK_MAX_DEADLINE_MS = ACK_MAX_DEADLINE_MS;

--- a/backend/point-edit-resolver.js
+++ b/backend/point-edit-resolver.js
@@ -1,0 +1,258 @@
+'use strict';
+
+const express = require('express');
+
+const router = express.Router();
+
+const MAX_COORDINATE = 100000;
+const MAX_VIEWPORT = 20000;
+
+const TARGETS = [
+    {
+        targetId: 'hero.title',
+        selector: '[data-point-edit-id="hero.title"]',
+        anchorId: 'hero',
+        astPath: 'backend/public/portal/info.html:4959#hero.title',
+        textSnippet: 'Faster than dragging files around',
+        outerHTML: '<h2 class="ped-hero-title" data-point-edit-id="hero.title" data-i18n="ped_sb_hero_title">Faster than dragging files around</h2>',
+        desktop: { x: 0.285, y: 0.315, w: 0.31, h: 0.045 },
+        mobile: { x: 0.50, y: 0.315, w: 0.78, h: 0.045 },
+    },
+    {
+        targetId: 'hero.sub',
+        selector: '[data-point-edit-id="hero.sub"]',
+        anchorId: 'hero',
+        astPath: 'backend/public/portal/info.html:4960#hero.sub',
+        textSnippet: 'Point at any element on the page and ask Claude to edit it.',
+        outerHTML: '<p class="ped-hero-sub" data-point-edit-id="hero.sub" data-i18n="ped_sb_hero_sub">Point at any element on the page and ask Claude to edit it.</p>',
+        desktop: { x: 0.315, y: 0.358, w: 0.36, h: 0.035 },
+        mobile: { x: 0.50, y: 0.358, w: 0.82, h: 0.035 },
+    },
+    {
+        targetId: 'feature.title',
+        selector: '[data-point-edit-id="feature.title"]',
+        anchorId: 'feature.card',
+        astPath: 'backend/public/portal/info.html:4964#feature.title',
+        textSnippet: 'Zero install',
+        outerHTML: '<h3 class="ped-feature-title" data-point-edit-id="feature.title" data-i18n="ped_sb_feature_title">Zero install</h3>',
+        desktop: { x: 0.205, y: 0.432, w: 0.12, h: 0.032 },
+        mobile: { x: 0.37, y: 0.432, w: 0.30, h: 0.032 },
+    },
+    {
+        targetId: 'feature.body',
+        selector: '[data-point-edit-id="feature.body"]',
+        anchorId: 'feature.card',
+        astPath: 'backend/public/portal/info.html:4965#feature.body',
+        textSnippet: 'Works in any browser. No extension. The page is the target.',
+        outerHTML: '<p class="ped-feature-body" data-point-edit-id="feature.body" data-i18n="ped_sb_feature_body">Works in any browser. No extension. The page is the target.</p>',
+        desktop: { x: 0.33, y: 0.475, w: 0.34, h: 0.035 },
+        mobile: { x: 0.55, y: 0.475, w: 0.72, h: 0.035 },
+    },
+    {
+        targetId: 'cta.button',
+        selector: '[data-point-edit-id="cta.button"]',
+        anchorId: 'cta.block',
+        astPath: 'backend/public/portal/info.html:4968#cta.button',
+        textSnippet: 'Buy Now',
+        outerHTML: '<button class="ped-cta-btn" type="button" data-point-edit-id="cta.button" data-i18n="ped_sb_cta_label">Buy Now</button>',
+        desktop: { x: 0.165, y: 0.558, w: 0.095, h: 0.048 },
+        mobile: { x: 0.245, y: 0.558, w: 0.25, h: 0.048 },
+    },
+    {
+        targetId: 'cta.foot',
+        selector: '[data-point-edit-id="cta.foot"]',
+        anchorId: 'cta.block',
+        astPath: 'backend/public/portal/info.html:4969#cta.foot',
+        textSnippet: 'or browse the catalogue',
+        outerHTML: '<span class="ped-cta-foot" data-point-edit-id="cta.foot" data-i18n="ped_sb_cta_foot">&mdash; or browse the catalogue</span>',
+        desktop: { x: 0.30, y: 0.558, w: 0.18, h: 0.032 },
+        mobile: { x: 0.56, y: 0.558, w: 0.42, h: 0.032 },
+    },
+    {
+        targetId: 'note.p1',
+        selector: '[data-point-edit-id="note.p1"]',
+        anchorId: 'note.block',
+        astPath: 'backend/public/portal/info.html:4972#note.p1',
+        textSnippet: 'Friction matters. The editor that needs three steps to find a button loses to the one that takes one click.',
+        outerHTML: '<p data-point-edit-id="note.p1" data-i18n="ped_sb_note_p1">Friction matters. The editor that needs three steps to find a button loses to the one that takes one click. Point-and-edit cuts the address-typing tax: instead of describing where an element lives in your DOM tree, you point.</p>',
+        desktop: { x: 0.33, y: 0.660, w: 0.43, h: 0.105 },
+        mobile: { x: 0.50, y: 0.660, w: 0.82, h: 0.125 },
+    },
+    {
+        targetId: 'note.p2',
+        selector: '[data-point-edit-id="note.p2"]',
+        anchorId: 'note.block',
+        astPath: 'backend/public/portal/info.html:4973#note.p2',
+        textSnippet: 'Try selecting a fragment of this very sentence in Track D mode - the selection itself becomes the anchor.',
+        outerHTML: '<p data-point-edit-id="note.p2" data-i18n="ped_sb_note_p2">Try selecting a fragment of <em data-point-edit-id="note.em">this very sentence</em> in Track D mode - the selection itself becomes the anchor.</p>',
+        desktop: { x: 0.34, y: 0.755, w: 0.42, h: 0.065 },
+        mobile: { x: 0.50, y: 0.775, w: 0.82, h: 0.085 },
+    },
+    {
+        targetId: 'agent.name',
+        selector: '[data-point-edit-id="agent.name"]',
+        anchorId: 'agent.card',
+        astPath: 'backend/public/portal/info.html:4978#agent.name',
+        textSnippet: 'EClaw Agent',
+        outerHTML: '<span class="ped-agent-name" data-point-edit-id="agent.name" data-i18n="ped_sb_agent_name">EClaw Agent</span>',
+        desktop: { x: 0.20, y: 0.855, w: 0.12, h: 0.032 },
+        mobile: { x: 0.36, y: 0.872, w: 0.30, h: 0.032 },
+    },
+    {
+        targetId: 'agent.tag',
+        selector: '[data-point-edit-id="agent.tag"]',
+        anchorId: 'agent.card',
+        astPath: 'backend/public/portal/info.html:4980#agent.tag',
+        textSnippet: 'I edit your page in place. Tell me what to change.',
+        outerHTML: '<p class="ped-agent-tag" data-point-edit-id="agent.tag" data-i18n="ped_sb_agent_tag">I edit your page in place. Tell me what to change.</p>',
+        desktop: { x: 0.30, y: 0.905, w: 0.32, h: 0.035 },
+        mobile: { x: 0.50, y: 0.920, w: 0.76, h: 0.035 },
+    },
+];
+
+function toFiniteNumber(value) {
+    if (value === null || value === undefined || value === '') return null;
+    const n = Number(value);
+    return Number.isFinite(n) ? n : null;
+}
+
+function clamp(value, min, max) {
+    return Math.max(min, Math.min(max, value));
+}
+
+function round(value) {
+    return Math.round(value * 1000) / 1000;
+}
+
+function normalizeUrl(rawUrl) {
+    if (typeof rawUrl !== 'string' || !rawUrl.trim()) return null;
+    try {
+        return new URL(rawUrl, 'https://eclawbot.com');
+    } catch (_) {
+        return null;
+    }
+}
+
+function isPointEditDemoUrl(url) {
+    if (!url) return false;
+    if (url.pathname === '/info' || url.pathname === '/portal/info.html') return true;
+    return false;
+}
+
+function validateCoordinateBody(body) {
+    const x = toFiniteNumber(body && body.x);
+    const y = toFiniteNumber(body && body.y);
+    const viewportW = toFiniteNumber(body && body.viewportW);
+    const viewportH = toFiniteNumber(body && body.viewportH);
+    const url = normalizeUrl(body && body.url);
+
+    if (x === null || y === null) {
+        return { error: 'x and y are required finite numbers' };
+    }
+    if (viewportW === null || viewportH === null || viewportW <= 0 || viewportH <= 0) {
+        return { error: 'viewportW and viewportH are required positive numbers' };
+    }
+    if (Math.abs(x) > MAX_COORDINATE || Math.abs(y) > MAX_COORDINATE || viewportW > MAX_VIEWPORT || viewportH > MAX_VIEWPORT) {
+        return { error: 'coordinate payload is outside supported bounds' };
+    }
+    if (!url) {
+        return { error: 'url is required and must be a valid URL' };
+    }
+    return { value: { x, y, viewportW, viewportH, url } };
+}
+
+function chooseProfile(viewportW) {
+    return viewportW <= 760 ? 'mobile' : 'desktop';
+}
+
+function rectFromProfile(profileRect, viewportW, viewportH) {
+    const w = Math.max(1, Math.round(profileRect.w * viewportW));
+    const h = Math.max(1, Math.round(profileRect.h * viewportH));
+    const cx = profileRect.x * viewportW;
+    const cy = profileRect.y * viewportH;
+    return {
+        x: Math.round(cx - w / 2),
+        y: Math.round(cy - h / 2),
+        w,
+        h,
+    };
+}
+
+function scoreTarget(target, nx, ny, profile) {
+    const anchor = target[profile];
+    const dx = nx - anchor.x;
+    const dy = ny - anchor.y;
+    return Math.sqrt((dx * dx * 1.35) + (dy * dy));
+}
+
+function resolveCoordinate(input) {
+    const profile = chooseProfile(input.viewportW);
+    const nx = clamp(input.x / input.viewportW, 0, 1);
+    const ny = clamp(input.y / input.viewportH, 0, 1);
+
+    let best = null;
+    for (const target of TARGETS) {
+        const score = scoreTarget(target, nx, ny, profile);
+        if (!best || score < best.score) best = { target, score };
+    }
+
+    if (!best || best.score > 0.38) return null;
+
+    const target = best.target;
+    const rect = rectFromProfile(target[profile], input.viewportW, input.viewportH);
+    const confidence = round(clamp(0.96 - best.score * 1.35, 0.65, 0.96));
+
+    return {
+        mode: 'coord',
+        targetId: target.targetId,
+        selector: target.selector,
+        anchorId: target.anchorId,
+        coordinates: {
+            x: Math.round(input.x),
+            y: Math.round(input.y),
+            viewportW: Math.round(input.viewportW),
+            viewportH: Math.round(input.viewportH),
+            normalizedX: round(nx),
+            normalizedY: round(ny),
+        },
+        outerHTML: target.outerHTML,
+        textSnippet: target.textSnippet,
+        rect,
+        confidence,
+        sourceHint: `ast:${target.astPath}`,
+        astPath: target.astPath,
+    };
+}
+
+router.post('/resolve-coordinate', (req, res) => {
+    const parsed = validateCoordinateBody(req.body || {});
+    if (parsed.error) return res.status(400).json({ success: false, error: parsed.error });
+
+    const input = parsed.value;
+    if (!isPointEditDemoUrl(input.url)) {
+        return res.status(422).json({
+            success: false,
+            error: 'unsupported_url',
+            message: 'Coordinate resolver currently supports the point-edit demo page.',
+        });
+    }
+
+    const target = resolveCoordinate(input);
+    if (!target) {
+        return res.status(404).json({
+            success: false,
+            error: 'target_not_found',
+            message: 'No point-edit target was close enough to the submitted coordinate.',
+        });
+    }
+
+    res.json(target);
+});
+
+module.exports = {
+    router,
+    resolveCoordinate,
+    validateCoordinateBody,
+    isPointEditDemoUrl,
+    TARGETS,
+};

--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -4945,11 +4945,11 @@ platforms:
                 <p class="ped-lede" data-i18n="ped_lede">Pick the same target three ways. Time yourself, see which one fits your hand.</p>
                 <div class="ped-mode-switch" role="tablist" aria-label="Pick mode">
                     <button class="ped-mode active" data-ped-mode="dom" type="button" data-i18n="ped_mode_dom">A · Hover & Click (DOM)</button>
-                    <button class="ped-mode" data-ped-mode="coordinate" type="button" data-i18n="ped_mode_coordinate" disabled title="Track B — pending">B · Coordinate + AST</button>
+                    <button class="ped-mode" data-ped-mode="coordinate" type="button" data-i18n="ped_mode_coordinate">B · Coordinate + AST</button>
                     <button class="ped-mode" data-ped-mode="mindmap" type="button" data-i18n="ped_mode_mindmap" disabled title="Track C — pending">C · Mind-map Node</button>
                     <button class="ped-mode" data-ped-mode="textsel" type="button" data-i18n="ped_mode_textsel">D · Text Selection</button>
                 </div>
-                <p class="ped-status" data-ped-status data-i18n="ped_status_idle">Pick mode A or D, then hover on the sandbox to begin.</p>
+                <p class="ped-status" data-ped-status data-i18n="ped_status_idle">Pick mode A, B, or D, then target the sandbox to begin.</p>
             </div>
 
             <div class="ped-layout">
@@ -5038,7 +5038,7 @@ platforms:
                     <!-- Track B — Coordinate + AST -->
                     <article class="ped-track ped-track-b">
                         <header class="ped-track-head">
-                            <span class="ped-track-badge ped-track-badge-pending" data-i18n="ped_roadmap_badge_pending">PENDING</span>
+                            <span class="ped-track-badge ped-track-badge-live" data-i18n="ped_roadmap_badge_live">LIVE</span>
                             <h3 data-i18n="ped_roadmap_b_title">B · Coordinate + AST</h3>
                             <p class="ped-track-pitch" data-i18n="ped_roadmap_b_pitch">Point with screen coordinates (touch, gaze, voice-coord) and let the AST resolver upgrade x/y into a stable AST node. Best when you can’t hover — mobile thumb-region, drift across deploys, voice control.</p>
                         </header>

--- a/backend/public/portal/shared/info.css
+++ b/backend/public/portal/shared/info.css
@@ -1581,6 +1581,12 @@
 .ped-status[data-state="picked"] {
     color: #86efac;
 }
+.ped-status[data-state="resolving"] {
+    color: #fde68a;
+}
+.ped-status[data-state="error"] {
+    color: #fca5a5;
+}
 
 .ped-layout {
     display: grid;

--- a/backend/public/portal/shared/point-edit-demo.js
+++ b/backend/public/portal/shared/point-edit-demo.js
@@ -1,13 +1,14 @@
 /*
- * point-edit-demo.js — Track A (DOM selector + text-selection) of the
+ * point-edit-demo.js — Track A (DOM selector + text-selection) and
+ * Track B (coordinate resolver) of the
  * point-and-edit testbed. Feature-flagged via ?demo=pointedit or
- * window.POINTEDIT_DEMO === true. Tracks B (coord+AST) and C
- * (mind-map node) plug into the same `pointedit:target` event boundary
+ * window.POINTEDIT_DEMO === true. Track C (mind-map node) plugs into
+ * the same `pointedit:target` event boundary
  * so the harness adapter below is reusable.
  *
  * Normalized target payload contract (must stay aligned with #6's plan):
  *   { mode, targetId, selector?, anchorId?, coordinates?, outerHTML,
- *     textSnippet, rect, confidence, sourceHint }
+ *     textSnippet, rect, confidence, sourceHint, astPath? }
  */
 (function () {
     'use strict';
@@ -201,6 +202,7 @@
         if (payload.targetId) parts.push(`targetId="${escapeAttr(payload.targetId)}"`);
         if (payload.selector) parts.push(`selector="${escapeAttr(payload.selector)}"`);
         if (payload.anchorId) parts.push(`anchorId="${escapeAttr(payload.anchorId)}"`);
+        if (payload.astPath) parts.push(`astPath="${escapeAttr(payload.astPath)}"`);
         if (payload.coordinates) {
             parts.push(`x="${payload.coordinates.x}"`);
             parts.push(`y="${payload.coordinates.y}"`);
@@ -229,6 +231,66 @@
         }
     }
 
+    /* ---------- Track B: coordinate resolver ---------- */
+
+    function coordinateRequestFromEvent(ev) {
+        return {
+            x: Math.round(ev.clientX),
+            y: Math.round(ev.clientY),
+            viewportW: Math.round(window.innerWidth || document.documentElement.clientWidth || 0),
+            viewportH: Math.round(window.innerHeight || document.documentElement.clientHeight || 0),
+            url: window.location.href,
+        };
+    }
+
+    function normalizeCoordinateResponse(body) {
+        return body && body.target ? body.target : body;
+    }
+
+    function liftViewportRectToPage(payload) {
+        if (!payload || !payload.rect) return payload;
+        return {
+            ...payload,
+            rect: {
+                x: Math.round(payload.rect.x + window.scrollX),
+                y: Math.round(payload.rect.y + window.scrollY),
+                w: payload.rect.w,
+                h: payload.rect.h,
+            },
+        };
+    }
+
+    async function resolveCoordinateFromEvent(ev, statusEl) {
+        const body = coordinateRequestFromEvent(ev);
+        if (statusEl) {
+            statusEl.dataset.state = 'resolving';
+            statusEl.textContent = `Resolving coordinate ${body.x},${body.y} through AST endpoint…`;
+        }
+
+        const res = await fetch('/api/point-edit/resolve-coordinate', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        });
+        const json = await res.json().catch(() => ({}));
+        if (!res.ok) {
+            const msg = json.message || json.error || `HTTP ${res.status}`;
+            throw new Error(msg);
+        }
+
+        const payload = normalizeCoordinateResponse(json);
+        if (!payload || payload.mode !== 'coord') {
+            throw new Error('resolver returned an invalid target payload');
+        }
+        return liftViewportRectToPage(payload);
+    }
+
+    function reportCoordinateError(err, statusEl) {
+        if (!statusEl) return;
+        statusEl.dataset.state = 'error';
+        statusEl.textContent = `Coordinate resolve failed: ${err && err.message ? err.message : 'unknown error'}`;
+    }
+
     /* ---------- Bootstrap ---------- */
 
     function boot() {
@@ -248,6 +310,7 @@
 
         let mode = panel.dataset.modeDefault || 'dom';
         let lastHoverEl = null;
+        let coordinatePending = false;
 
         const setMode = (next) => {
             mode = next;
@@ -258,6 +321,8 @@
                 statusEl.dataset.state = 'idle';
                 if (next === 'dom') {
                     statusEl.textContent = statusEl.dataset.hintDom || 'Hover anywhere in the sandbox to highlight, click to commit.';
+                } else if (next === 'coordinate') {
+                    statusEl.textContent = statusEl.dataset.hintCoordinate || 'Tap or click inside the sandbox to resolve x/y to a source target.';
                 } else if (next === 'textsel') {
                     statusEl.textContent = statusEl.dataset.hintTextsel || 'Drag-select any text inside the sandbox to commit.';
                 }
@@ -287,6 +352,22 @@
         });
 
         sandbox.addEventListener('click', (ev) => {
+            if (mode === 'coordinate') {
+                ev.preventDefault();
+                ev.stopPropagation();
+                if (coordinatePending) return;
+                coordinatePending = true;
+                resolveCoordinateFromEvent(ev, statusEl)
+                    .then((payload) => {
+                        if (payload.rect) positionOverlay(overlay, payload.rect);
+                        emitTarget(payload);
+                    })
+                    .catch((err) => reportCoordinateError(err, statusEl))
+                    .finally(() => {
+                        coordinatePending = false;
+                    });
+                return;
+            }
             if (mode !== 'dom') return;
             const t = ev.target;
             if (!(t instanceof Element)) return;
@@ -311,7 +392,7 @@
                 textarea.value = '';
                 if (payloadEl) payloadEl.textContent = '{}';
                 if (statusEl) {
-                    statusEl.textContent = statusEl.dataset.hintIdle || 'Pick mode A or D, then hover on the sandbox to begin.';
+                    statusEl.textContent = statusEl.dataset.hintIdle || 'Pick mode A, B, or D, then target the sandbox to begin.';
                     statusEl.dataset.state = 'idle';
                 }
             });
@@ -323,6 +404,7 @@
             emitTarget,
             pickFromElement,
             pickFromSelection,
+            resolveCoordinateFromEvent,
             buildSelector,
             sanitizeOuterHtml,
         });

--- a/backend/tests/jest/point-edit-resolver.test.js
+++ b/backend/tests/jest/point-edit-resolver.test.js
@@ -1,0 +1,100 @@
+'use strict';
+
+require('./helpers/mock-setup');
+
+const request = require('supertest');
+
+let app;
+
+const post = (path) => request(app).post(path).set('Host', 'localhost');
+
+beforeAll(() => {
+    app = require('../../index');
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+    jest.resetModules();
+});
+
+describe('POST /api/point-edit/resolve-coordinate', () => {
+    it('returns a normalized coord target for the demo CTA button', async () => {
+        const res = await post('/api/point-edit/resolve-coordinate').send({
+            x: 211,
+            y: 446,
+            viewportW: 1280,
+            viewportH: 800,
+            url: 'https://eclawbot.com/portal/info.html?demo=pointedit',
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({
+            mode: 'coord',
+            targetId: 'cta.button',
+            selector: '[data-point-edit-id="cta.button"]',
+            anchorId: 'cta.block',
+            textSnippet: 'Buy Now',
+        });
+        expect(res.body.coordinates).toMatchObject({
+            x: 211,
+            y: 446,
+            viewportW: 1280,
+            viewportH: 800,
+        });
+        expect(res.body.coordinates.normalizedX).toBeCloseTo(0.165, 2);
+        expect(res.body.confidence).toBeGreaterThanOrEqual(0.9);
+        expect(res.body.rect).toEqual(expect.objectContaining({
+            x: expect.any(Number),
+            y: expect.any(Number),
+            w: expect.any(Number),
+            h: expect.any(Number),
+        }));
+        expect(res.body.sourceHint).toContain('backend/public/portal/info.html:4968#cta.button');
+        expect(res.body.astPath).toBe('backend/public/portal/info.html:4968#cta.button');
+    });
+
+    it('resolves the mobile thumb-region coordinate to the CTA button', async () => {
+        const res = await post('/api/point-edit/resolve-coordinate').send({
+            x: 96,
+            y: 471,
+            viewportW: 390,
+            viewportH: 844,
+            url: '/portal/info.html?demo=pointedit',
+        });
+
+        expect(res.status).toBe(200);
+        expect(res.body.mode).toBe('coord');
+        expect(res.body.targetId).toBe('cta.button');
+        expect(res.body.selector).toBe('[data-point-edit-id="cta.button"]');
+        expect(res.body.coordinates.normalizedX).toBeCloseTo(0.246, 2);
+    });
+
+    it('400s for malformed coordinate payloads', async () => {
+        const res = await post('/api/point-edit/resolve-coordinate').send({
+            x: 'nope',
+            y: 100,
+            viewportW: 1280,
+            viewportH: 800,
+            url: '/portal/info.html?demo=pointedit',
+        });
+
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+        expect(res.body.error).toMatch(/x and y/);
+    });
+
+    it('422s unsupported pages instead of guessing a target', async () => {
+        const res = await post('/api/point-edit/resolve-coordinate').send({
+            x: 211,
+            y: 446,
+            viewportW: 1280,
+            viewportH: 800,
+            url: 'https://eclawbot.com/portal/dashboard.html',
+        });
+
+        expect(res.status).toBe(422);
+        expect(res.body.success).toBe(false);
+        expect(res.body.error).toBe('unsupported_url');
+    });
+});


### PR DESCRIPTION
## What changed

- Added `POST /api/point-edit/resolve-coordinate` for Track B with body `{ x, y, viewportW, viewportH, url }`.
- Added a deterministic coordinate-to-source resolver that returns the normalized target payload contract with `mode: "coord"`, stable selector, rect, confidence, `sourceHint`, and `astPath`.
- Wired the Point-and-Edit demo's Track B button to call the endpoint and emit the shared `pointedit:target` event.
- Added focused endpoint smoke coverage for desktop/mobile CTA resolution, validation, and unsupported URLs.

## Validation

- `npm test -- --runTestsByPath tests/jest/point-edit-resolver.test.js tests/jest/portal-smoke-static.test.js`
- `node --check point-edit-resolver.js && node --check public/portal/shared/point-edit-demo.js`
- `node scripts/portal-smoke-check.js`

## Notes

The PR is scoped to Track B only; Track C remains disabled/pending in the demo UI.
