### PR TITLE
fix(portal): load api before auth on affected pages

### DIFF
--- a/backend/public/portal/publisher-setup.html
+++ b/backend/public/portal/publisher-setup.html
@@ -197,9 +197,9 @@
         </div>
     </main>
 
+    <script src="shared/api.js"></script>
     <script src="shared/auth.js"></script>
     <script src="../shared/telemetry.js"></script>
-    <script src="shared/api.js"></script>
     <script>
         // Phase-1 publisher BYO setup script.
         // Matches the embed-context bootstrap used by env-vars.html: we rely on

--- a/backend/public/portal/publisher.html
+++ b/backend/public/portal/publisher.html
@@ -235,9 +235,9 @@
 
     <script src="../shared/i18n.js"></script>
     <script src="../shared/transition-overlay.js"></script>
-    <script src="shared/auth.js"></script>
     <script src="shared/api.js"></script>
     <script src="shared/nav.js"></script>
+    <script src="shared/auth.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid|EClawIOS/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
     <script src="shared/ai-chat.js"></script>

--- a/backend/public/portal/screen-control.html
+++ b/backend/public/portal/screen-control.html
@@ -299,9 +299,9 @@
 
     <script src="../shared/i18n.js"></script>
     <script src="../shared/transition-overlay.js"></script>
-    <script src="shared/auth.js"></script>
     <script src="shared/api.js"></script>
     <script src="shared/nav.js"></script>
+    <script src="shared/auth.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid|EClawIOS/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
     <script src="shared/ai-chat.js"></script>

--- a/backend/tests/jest/portal-script-order.test.js
+++ b/backend/tests/jest/portal-script-order.test.js
@@ -1,0 +1,43 @@
+const fs = require('fs');
+const path = require('path');
+
+const portalDir = path.join(__dirname, '../../public/portal');
+
+function extractScriptSrcs(html) {
+  return [...html.matchAll(/<script\b[^>]*\bsrc=["']([^"']+)["'][^>]*>/gi)]
+    .map((match) => match[1]);
+}
+
+describe('portal shared script dependency order', () => {
+  test('api.js loads before auth.js and telemetry on every portal page', () => {
+    const failures = [];
+    const pages = fs.readdirSync(portalDir)
+      .filter((entry) => entry.endsWith('.html'))
+      .sort();
+
+    for (const page of pages) {
+      const html = fs.readFileSync(path.join(portalDir, page), 'utf8');
+      const srcs = extractScriptSrcs(html);
+      const apiIdx = srcs.findIndex((src) => /shared\/api\.js$/i.test(src));
+      const authIdx = srcs.findIndex((src) => /shared\/auth\.js$/i.test(src));
+      const telemetryIdx = srcs.findIndex((src) => /telemetry\.js$/i.test(src));
+      const pageFailures = [];
+
+      if (apiIdx !== -1 && authIdx !== -1 && apiIdx > authIdx) {
+        pageFailures.push('api.js loads after auth.js');
+      }
+      if (authIdx !== -1 && telemetryIdx !== -1 && authIdx > telemetryIdx) {
+        pageFailures.push('auth.js loads after telemetry.js');
+      }
+      if (apiIdx !== -1 && telemetryIdx !== -1 && apiIdx > telemetryIdx) {
+        pageFailures.push('api.js loads after telemetry.js');
+      }
+
+      if (pageFailures.length > 0) {
+        failures.push(`${page}: ${pageFailures.join(', ')}`);
+      }
+    }
+
+    expect(failures).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes #3007.
- Reorders shared scripts on publisher, publisher setup, and screen-control portal pages so `api.js` loads before `auth.js`, and telemetry loads after both.
- Adds a Jest regression guard that checks shared script dependency order across every portal HTML page.

## QA / UIUX Audit
- Production live UX validation: 96/96 passed with authenticated credentials.
- Static UX audit: script-order findings reduced to 0. Remaining broad audit findings are pre-existing i18n/auth/a11y backlog signals outside this focused fix.

## Tests
- `npm run smoke:portal`
- `node tests/test-ux-static-audit.js > /tmp/qa-static-uiux-20260529-after.txt` (script-order findings: 0)
- `npx jest --runInBand tests/jest/portal-script-order.test.js tests/jest/portal-smoke-static.test.js tests/jest/portal-static-ids.test.js`
- Targeted UX suite: 22 suites / 383 tests passed

## Review
Requesting #2 supervisor review before merge per governance.