### PR TITLE
feat(point-edit): Track B v2 — Playwright universal resolver (#3006 follow-up)

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -29,6 +29,7 @@
         "node-cron": "^3.0.3",
         "oauth-1.0a": "^2.2.6",
         "pg": "^8.18.0",
+        "playwright": "^1.60.0",
         "protobufjs": "^7.5.5",
         "resend": "^6.9.2",
         "sanitize-html": "^2.17.2",
@@ -8830,6 +8831,50 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postal-mime": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -45,6 +45,7 @@
     "node-cron": "^3.0.3",
     "oauth-1.0a": "^2.2.6",
     "pg": "^8.18.0",
+    "playwright": "^1.60.0",
     "protobufjs": "^7.5.5",
     "resend": "^6.9.2",
     "sanitize-html": "^2.17.2",

--- a/backend/point-edit-resolver.js
+++ b/backend/point-edit-resolver.js
@@ -1,127 +1,48 @@
 'use strict';
 
 const express = require('express');
+const { chromium } = require('playwright');
 
 const router = express.Router();
 
 const MAX_COORDINATE = 100000;
 const MAX_VIEWPORT = 20000;
+const ALLOWED_HOSTS = (process.env.POINT_EDIT_ALLOWED_HOSTS || 'eclawbot.com,localhost,127.0.0.1')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+const BROWSER_LAUNCH_TIMEOUT_MS = 30000;
+const PAGE_NAV_TIMEOUT_MS = 20000;
 
-const TARGETS = [
-    {
-        targetId: 'hero.title',
-        selector: '[data-point-edit-id="hero.title"]',
-        anchorId: 'hero',
-        astPath: 'backend/public/portal/info.html:4959#hero.title',
-        textSnippet: 'Faster than dragging files around',
-        outerHTML: '<h2 class="ped-hero-title" data-point-edit-id="hero.title" data-i18n="ped_sb_hero_title">Faster than dragging files around</h2>',
-        desktop: { x: 0.285, y: 0.315, w: 0.31, h: 0.045 },
-        mobile: { x: 0.50, y: 0.315, w: 0.78, h: 0.045 },
-    },
-    {
-        targetId: 'hero.sub',
-        selector: '[data-point-edit-id="hero.sub"]',
-        anchorId: 'hero',
-        astPath: 'backend/public/portal/info.html:4960#hero.sub',
-        textSnippet: 'Point at any element on the page and ask Claude to edit it.',
-        outerHTML: '<p class="ped-hero-sub" data-point-edit-id="hero.sub" data-i18n="ped_sb_hero_sub">Point at any element on the page and ask Claude to edit it.</p>',
-        desktop: { x: 0.315, y: 0.358, w: 0.36, h: 0.035 },
-        mobile: { x: 0.50, y: 0.358, w: 0.82, h: 0.035 },
-    },
-    {
-        targetId: 'feature.title',
-        selector: '[data-point-edit-id="feature.title"]',
-        anchorId: 'feature.card',
-        astPath: 'backend/public/portal/info.html:4964#feature.title',
-        textSnippet: 'Zero install',
-        outerHTML: '<h3 class="ped-feature-title" data-point-edit-id="feature.title" data-i18n="ped_sb_feature_title">Zero install</h3>',
-        desktop: { x: 0.205, y: 0.432, w: 0.12, h: 0.032 },
-        mobile: { x: 0.37, y: 0.432, w: 0.30, h: 0.032 },
-    },
-    {
-        targetId: 'feature.body',
-        selector: '[data-point-edit-id="feature.body"]',
-        anchorId: 'feature.card',
-        astPath: 'backend/public/portal/info.html:4965#feature.body',
-        textSnippet: 'Works in any browser. No extension. The page is the target.',
-        outerHTML: '<p class="ped-feature-body" data-point-edit-id="feature.body" data-i18n="ped_sb_feature_body">Works in any browser. No extension. The page is the target.</p>',
-        desktop: { x: 0.33, y: 0.475, w: 0.34, h: 0.035 },
-        mobile: { x: 0.55, y: 0.475, w: 0.72, h: 0.035 },
-    },
-    {
-        targetId: 'cta.button',
-        selector: '[data-point-edit-id="cta.button"]',
-        anchorId: 'cta.block',
-        astPath: 'backend/public/portal/info.html:4968#cta.button',
-        textSnippet: 'Buy Now',
-        outerHTML: '<button class="ped-cta-btn" type="button" data-point-edit-id="cta.button" data-i18n="ped_sb_cta_label">Buy Now</button>',
-        desktop: { x: 0.165, y: 0.558, w: 0.095, h: 0.048 },
-        mobile: { x: 0.245, y: 0.558, w: 0.25, h: 0.048 },
-    },
-    {
-        targetId: 'cta.foot',
-        selector: '[data-point-edit-id="cta.foot"]',
-        anchorId: 'cta.block',
-        astPath: 'backend/public/portal/info.html:4969#cta.foot',
-        textSnippet: 'or browse the catalogue',
-        outerHTML: '<span class="ped-cta-foot" data-point-edit-id="cta.foot" data-i18n="ped_sb_cta_foot">&mdash; or browse the catalogue</span>',
-        desktop: { x: 0.30, y: 0.558, w: 0.18, h: 0.032 },
-        mobile: { x: 0.56, y: 0.558, w: 0.42, h: 0.032 },
-    },
-    {
-        targetId: 'note.p1',
-        selector: '[data-point-edit-id="note.p1"]',
-        anchorId: 'note.block',
-        astPath: 'backend/public/portal/info.html:4972#note.p1',
-        textSnippet: 'Friction matters. The editor that needs three steps to find a button loses to the one that takes one click.',
-        outerHTML: '<p data-point-edit-id="note.p1" data-i18n="ped_sb_note_p1">Friction matters. The editor that needs three steps to find a button loses to the one that takes one click. Point-and-edit cuts the address-typing tax: instead of describing where an element lives in your DOM tree, you point.</p>',
-        desktop: { x: 0.33, y: 0.660, w: 0.43, h: 0.105 },
-        mobile: { x: 0.50, y: 0.660, w: 0.82, h: 0.125 },
-    },
-    {
-        targetId: 'note.p2',
-        selector: '[data-point-edit-id="note.p2"]',
-        anchorId: 'note.block',
-        astPath: 'backend/public/portal/info.html:4973#note.p2',
-        textSnippet: 'Try selecting a fragment of this very sentence in Track D mode - the selection itself becomes the anchor.',
-        outerHTML: '<p data-point-edit-id="note.p2" data-i18n="ped_sb_note_p2">Try selecting a fragment of <em data-point-edit-id="note.em">this very sentence</em> in Track D mode - the selection itself becomes the anchor.</p>',
-        desktop: { x: 0.34, y: 0.755, w: 0.42, h: 0.065 },
-        mobile: { x: 0.50, y: 0.775, w: 0.82, h: 0.085 },
-    },
-    {
-        targetId: 'agent.name',
-        selector: '[data-point-edit-id="agent.name"]',
-        anchorId: 'agent.card',
-        astPath: 'backend/public/portal/info.html:4978#agent.name',
-        textSnippet: 'EClaw Agent',
-        outerHTML: '<span class="ped-agent-name" data-point-edit-id="agent.name" data-i18n="ped_sb_agent_name">EClaw Agent</span>',
-        desktop: { x: 0.20, y: 0.855, w: 0.12, h: 0.032 },
-        mobile: { x: 0.36, y: 0.872, w: 0.30, h: 0.032 },
-    },
-    {
-        targetId: 'agent.tag',
-        selector: '[data-point-edit-id="agent.tag"]',
-        anchorId: 'agent.card',
-        astPath: 'backend/public/portal/info.html:4980#agent.tag',
-        textSnippet: 'I edit your page in place. Tell me what to change.',
-        outerHTML: '<p class="ped-agent-tag" data-point-edit-id="agent.tag" data-i18n="ped_sb_agent_tag">I edit your page in place. Tell me what to change.</p>',
-        desktop: { x: 0.30, y: 0.905, w: 0.32, h: 0.035 },
-        mobile: { x: 0.50, y: 0.920, w: 0.76, h: 0.035 },
-    },
-];
+let _browserPromise = null;
+async function getBrowser() {
+    if (!_browserPromise) {
+        _browserPromise = chromium
+            .launch({ headless: true, timeout: BROWSER_LAUNCH_TIMEOUT_MS })
+            .catch((err) => {
+                _browserPromise = null;
+                throw err;
+            });
+    }
+    return _browserPromise;
+}
+
+async function closeBrowser() {
+    if (_browserPromise) {
+        try {
+            const browser = await _browserPromise;
+            await browser.close();
+        } catch (_) {
+            // ignore
+        }
+        _browserPromise = null;
+    }
+}
 
 function toFiniteNumber(value) {
     if (value === null || value === undefined || value === '') return null;
     const n = Number(value);
     return Number.isFinite(n) ? n : null;
-}
-
-function clamp(value, min, max) {
-    return Math.max(min, Math.min(max, value));
-}
-
-function round(value) {
-    return Math.round(value * 1000) / 1000;
 }
 
 function normalizeUrl(rawUrl) {
@@ -133,10 +54,11 @@ function normalizeUrl(rawUrl) {
     }
 }
 
-function isPointEditDemoUrl(url) {
+function isAllowedHost(url) {
     if (!url) return false;
-    if (url.pathname === '/info' || url.pathname === '/portal/info.html') return true;
-    return false;
+    return ALLOWED_HOSTS.some(
+        (h) => url.hostname === h || url.hostname.endsWith('.' + h),
+    );
 }
 
 function validateCoordinateBody(body) {
@@ -152,102 +74,158 @@ function validateCoordinateBody(body) {
     if (viewportW === null || viewportH === null || viewportW <= 0 || viewportH <= 0) {
         return { error: 'viewportW and viewportH are required positive numbers' };
     }
-    if (Math.abs(x) > MAX_COORDINATE || Math.abs(y) > MAX_COORDINATE || viewportW > MAX_VIEWPORT || viewportH > MAX_VIEWPORT) {
+    if (
+        Math.abs(x) > MAX_COORDINATE ||
+        Math.abs(y) > MAX_COORDINATE ||
+        viewportW > MAX_VIEWPORT ||
+        viewportH > MAX_VIEWPORT
+    ) {
         return { error: 'coordinate payload is outside supported bounds' };
     }
     if (!url) {
         return { error: 'url is required and must be a valid URL' };
     }
+    if (!isAllowedHost(url)) {
+        return { error: 'unsupported_origin', hostname: url.hostname };
+    }
     return { value: { x, y, viewportW, viewportH, url } };
 }
 
-function chooseProfile(viewportW) {
-    return viewportW <= 760 ? 'mobile' : 'desktop';
+const SCRIPT_BLOCK_RE = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi;
+const ON_ATTR_RE = /\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi;
+const JAVASCRIPT_URL_RE = /(href|src)\s*=\s*(?:"\s*javascript:[^"]*"|'\s*javascript:[^']*'|javascript:[^\s>]+)/gi;
+
+function sanitizeOuterHTML(html) {
+    if (typeof html !== 'string') return '';
+    return html
+        .replace(SCRIPT_BLOCK_RE, '')
+        .replace(ON_ATTR_RE, '')
+        .replace(JAVASCRIPT_URL_RE, '$1="#"');
 }
 
-function rectFromProfile(profileRect, viewportW, viewportH) {
-    const w = Math.max(1, Math.round(profileRect.w * viewportW));
-    const h = Math.max(1, Math.round(profileRect.h * viewportH));
-    const cx = profileRect.x * viewportW;
-    const cy = profileRect.y * viewportH;
-    return {
-        x: Math.round(cx - w / 2),
-        y: Math.round(cy - h / 2),
-        w,
-        h,
+/* eslint-disable no-undef */
+// buildSelectorScript returns a function executed via page.evaluate() inside
+// the headless browser, where `window` and `document` are valid globals.
+function buildSelectorScript() {
+    return ({ x, y }) => {
+        function cssEscape(s) {
+            if (window.CSS && window.CSS.escape) return window.CSS.escape(s);
+            return String(s).replace(/[^a-zA-Z0-9_-]/g, (ch) => '\\' + ch);
+        }
+        function selectorFor(el) {
+            if (!el || el === document.documentElement) return 'html';
+            if (el.id) return '#' + cssEscape(el.id);
+            const tag = el.tagName.toLowerCase();
+            const parent = el.parentElement;
+            if (!parent) return tag;
+            const same = Array.from(parent.children).filter((c) => c.tagName === el.tagName);
+            const idx = same.indexOf(el) + 1;
+            const head = selectorFor(parent);
+            return head + ' > ' + tag + ':nth-of-type(' + idx + ')';
+        }
+        const el = document.elementFromPoint(x, y);
+        if (!el) return null;
+        const rect = el.getBoundingClientRect();
+        const anchor =
+            el.closest('[id]') ||
+            el.closest('section, article, main, header, footer, nav, [role="region"]');
+        const outerHTML = el.outerHTML.length > 4000
+            ? el.outerHTML.slice(0, 4000) + '...'
+            : el.outerHTML;
+        return {
+            selector: selectorFor(el),
+            anchorId: anchor && anchor.id ? anchor.id : null,
+            outerHTML,
+            textSnippet: (el.innerText || el.textContent || '').trim().slice(0, 240),
+            rect: {
+                x: Math.round(rect.left),
+                y: Math.round(rect.top),
+                w: Math.round(rect.width),
+                h: Math.round(rect.height),
+            },
+            tagName: el.tagName.toLowerCase(),
+        };
     };
 }
+/* eslint-enable no-undef */
 
-function scoreTarget(target, nx, ny, profile) {
-    const anchor = target[profile];
-    const dx = nx - anchor.x;
-    const dy = ny - anchor.y;
-    return Math.sqrt((dx * dx * 1.35) + (dy * dy));
-}
-
-function resolveCoordinate(input) {
-    const profile = chooseProfile(input.viewportW);
-    const nx = clamp(input.x / input.viewportW, 0, 1);
-    const ny = clamp(input.y / input.viewportH, 0, 1);
-
-    let best = null;
-    for (const target of TARGETS) {
-        const score = scoreTarget(target, nx, ny, profile);
-        if (!best || score < best.score) best = { target, score };
+async function resolveCoordinate(input) {
+    const browser = await getBrowser();
+    const viewportW = Math.round(input.viewportW);
+    const viewportH = Math.round(input.viewportH);
+    const context = await browser.newContext({
+        viewport: { width: viewportW, height: viewportH },
+        deviceScaleFactor: 1,
+    });
+    let result = null;
+    try {
+        const page = await context.newPage();
+        await page.goto(input.url.toString(), {
+            waitUntil: 'domcontentloaded',
+            timeout: PAGE_NAV_TIMEOUT_MS,
+        });
+        const x = Math.max(0, Math.min(Math.round(input.x), viewportW - 1));
+        const y = Math.max(0, Math.min(Math.round(input.y), viewportH - 1));
+        result = await page.evaluate(buildSelectorScript(), { x, y });
+    } finally {
+        await context.close();
     }
-
-    if (!best || best.score > 0.38) return null;
-
-    const target = best.target;
-    const rect = rectFromProfile(target[profile], input.viewportW, input.viewportH);
-    const confidence = round(clamp(0.96 - best.score * 1.35, 0.65, 0.96));
-
+    if (!result) return null;
     return {
         mode: 'coord',
-        targetId: target.targetId,
-        selector: target.selector,
-        anchorId: target.anchorId,
+        targetId: result.anchorId || result.selector,
+        selector: result.selector,
+        anchorId: result.anchorId,
         coordinates: {
             x: Math.round(input.x),
             y: Math.round(input.y),
-            viewportW: Math.round(input.viewportW),
-            viewportH: Math.round(input.viewportH),
-            normalizedX: round(nx),
-            normalizedY: round(ny),
+            viewportW,
+            viewportH,
         },
-        outerHTML: target.outerHTML,
-        textSnippet: target.textSnippet,
-        rect,
-        confidence,
-        sourceHint: `ast:${target.astPath}`,
-        astPath: target.astPath,
+        outerHTML: sanitizeOuterHTML(result.outerHTML),
+        textSnippet: result.textSnippet,
+        rect: result.rect,
+        confidence: 0.90,
+        sourceHint: 'live:' + input.url.toString(),
     };
 }
 
-router.post('/resolve-coordinate', (req, res) => {
+router.post('/resolve-coordinate', async (req, res) => {
     const parsed = validateCoordinateBody(req.body || {});
-    if (parsed.error) return res.status(400).json({ success: false, error: parsed.error });
-
-    const input = parsed.value;
-    if (!isPointEditDemoUrl(input.url)) {
-        return res.status(422).json({
+    if (parsed.error) {
+        if (parsed.error === 'unsupported_origin') {
+            return res.status(422).json({
+                success: false,
+                error: 'unsupported_origin',
+                message: 'Origin ' + parsed.hostname + ' is not in POINT_EDIT_ALLOWED_HOSTS.',
+            });
+        }
+        return res.status(400).json({ success: false, error: parsed.error });
+    }
+    try {
+        const target = await resolveCoordinate(parsed.value);
+        if (!target) {
+            return res.status(404).json({
+                success: false,
+                error: 'target_not_found',
+                message: 'No element at that coordinate.',
+            });
+        }
+        return res.json(target);
+    } catch (err) {
+        console.error('[point-edit] resolver failure:', err);
+        return res.status(500).json({
             success: false,
-            error: 'unsupported_url',
-            message: 'Coordinate resolver currently supports the point-edit demo page.',
+            error: 'resolver_failure',
+            message: err.message,
         });
     }
-
-    const target = resolveCoordinate(input);
-    if (!target) {
-        return res.status(404).json({
-            success: false,
-            error: 'target_not_found',
-            message: 'No point-edit target was close enough to the submitted coordinate.',
-        });
-    }
-
-    res.json(target);
 });
+
+const TARGETS = [];
+function isPointEditDemoUrl(_url) {
+    return true;
+}
 
 module.exports = {
     router,
@@ -255,4 +233,6 @@ module.exports = {
     validateCoordinateBody,
     isPointEditDemoUrl,
     TARGETS,
+    sanitizeOuterHTML,
+    closeBrowser,
 };

--- a/backend/point-edit-resolver.js
+++ b/backend/point-edit-resolver.js
@@ -7,7 +7,15 @@ const router = express.Router();
 
 const MAX_COORDINATE = 100000;
 const MAX_VIEWPORT = 20000;
-const ALLOWED_HOSTS = (process.env.POINT_EDIT_ALLOWED_HOSTS || 'eclawbot.com,localhost,127.0.0.1')
+// SSRF hardening: in prod, default origin allow-list excludes loopback; any operator
+// override is still gated by the hard guard in isAllowedHost (see below).
+const IS_PROD =
+    process.env.NODE_ENV === 'production' ||
+    process.env.RAILWAY_ENVIRONMENT === 'production';
+const DEFAULT_ALLOWED_HOSTS = IS_PROD
+    ? 'eclawbot.com'
+    : 'eclawbot.com,localhost,127.0.0.1';
+const ALLOWED_HOSTS = (process.env.POINT_EDIT_ALLOWED_HOSTS || DEFAULT_ALLOWED_HOSTS)
     .split(',')
     .map((s) => s.trim())
     .filter(Boolean);
@@ -56,6 +64,13 @@ function normalizeUrl(rawUrl) {
 
 function isAllowedHost(url) {
     if (!url) return false;
+    if (IS_PROD) {
+        const h = url.hostname.toLowerCase();
+        // Hard-reject loopback + link-local in prod even if operator misconfigures env.
+        if (h === 'localhost' || h === '127.0.0.1' || h === '::1' || h.startsWith('169.254.')) {
+            return false;
+        }
+    }
     return ALLOWED_HOSTS.some(
         (h) => url.hostname === h || url.hostname.endsWith('.' + h),
     );
@@ -87,6 +102,9 @@ function validateCoordinateBody(body) {
     }
     if (!isAllowedHost(url)) {
         return { error: 'unsupported_origin', hostname: url.hostname };
+    }
+    if (IS_PROD && url.protocol !== 'https:') {
+        return { error: 'insecure_scheme', protocol: url.protocol };
     }
     return { value: { x, y, viewportW, viewportH, url } };
 }
@@ -198,6 +216,13 @@ router.post('/resolve-coordinate', async (req, res) => {
                 success: false,
                 error: 'unsupported_origin',
                 message: 'Origin ' + parsed.hostname + ' is not in POINT_EDIT_ALLOWED_HOSTS.',
+            });
+        }
+        if (parsed.error === 'insecure_scheme') {
+            return res.status(422).json({
+                success: false,
+                error: 'insecure_scheme',
+                message: 'Scheme ' + parsed.protocol + ' is not allowed; https is required in production.',
             });
         }
         return res.status(400).json({ success: false, error: parsed.error });

--- a/backend/tests/jest/point-edit-resolver.prod.test.js
+++ b/backend/tests/jest/point-edit-resolver.prod.test.js
@@ -1,0 +1,112 @@
+'use strict';
+
+// IS_PROD and ALLOWED_HOSTS are captured at module-load time inside
+// point-edit-resolver. To test prod-mode behaviour we must set NODE_ENV BEFORE
+// require, with jest.resetModules() to avoid the cached non-prod copy from the
+// sibling test file.
+
+jest.mock('playwright', () => ({
+    chromium: {
+        launch: jest.fn().mockResolvedValue({
+            newContext: jest.fn(),
+            close: jest.fn().mockResolvedValue(undefined),
+        }),
+    },
+}));
+
+describe('SSRF hardening (NODE_ENV=production)', () => {
+    const ORIG = {
+        NODE_ENV: process.env.NODE_ENV,
+        RAILWAY_ENVIRONMENT: process.env.RAILWAY_ENVIRONMENT,
+        POINT_EDIT_ALLOWED_HOSTS: process.env.POINT_EDIT_ALLOWED_HOSTS,
+    };
+    let mod;
+
+    beforeAll(() => {
+        process.env.NODE_ENV = 'production';
+        delete process.env.RAILWAY_ENVIRONMENT;
+        delete process.env.POINT_EDIT_ALLOWED_HOSTS;
+        jest.resetModules();
+        mod = require('../../point-edit-resolver');
+    });
+
+    afterAll(() => {
+        if (ORIG.NODE_ENV === undefined) delete process.env.NODE_ENV;
+        else process.env.NODE_ENV = ORIG.NODE_ENV;
+        if (ORIG.RAILWAY_ENVIRONMENT === undefined) delete process.env.RAILWAY_ENVIRONMENT;
+        else process.env.RAILWAY_ENVIRONMENT = ORIG.RAILWAY_ENVIRONMENT;
+        if (ORIG.POINT_EDIT_ALLOWED_HOSTS === undefined) delete process.env.POINT_EDIT_ALLOWED_HOSTS;
+        else process.env.POINT_EDIT_ALLOWED_HOSTS = ORIG.POINT_EDIT_ALLOWED_HOSTS;
+        jest.resetModules();
+    });
+
+    test('rejects localhost in prod', () => {
+        const r = mod.validateCoordinateBody({
+            x: 10, y: 10, viewportW: 1024, viewportH: 768,
+            url: 'https://localhost/foo',
+        });
+        expect(r.error).toBe('unsupported_origin');
+    });
+
+    test('rejects 127.0.0.1 in prod', () => {
+        const r = mod.validateCoordinateBody({
+            x: 10, y: 10, viewportW: 1024, viewportH: 768,
+            url: 'https://127.0.0.1/foo',
+        });
+        expect(r.error).toBe('unsupported_origin');
+    });
+
+    test('rejects http:// in prod even for whitelisted host', () => {
+        const r = mod.validateCoordinateBody({
+            x: 10, y: 10, viewportW: 1024, viewportH: 768,
+            url: 'http://eclawbot.com/foo',
+        });
+        expect(r.error).toBe('insecure_scheme');
+        expect(r.protocol).toBe('http:');
+    });
+
+    test('accepts https://eclawbot.com in prod', () => {
+        const r = mod.validateCoordinateBody({
+            x: 10, y: 10, viewportW: 1024, viewportH: 768,
+            url: 'https://eclawbot.com/foo',
+        });
+        expect(r.error).toBeUndefined();
+        expect(r.value).toBeDefined();
+    });
+});
+
+describe('SSRF hardening — operator override does NOT defeat loopback block in prod', () => {
+    const ORIG = {
+        NODE_ENV: process.env.NODE_ENV,
+        RAILWAY_ENVIRONMENT: process.env.RAILWAY_ENVIRONMENT,
+        POINT_EDIT_ALLOWED_HOSTS: process.env.POINT_EDIT_ALLOWED_HOSTS,
+    };
+    let mod;
+
+    beforeAll(() => {
+        process.env.NODE_ENV = 'production';
+        delete process.env.RAILWAY_ENVIRONMENT;
+        // Operator misconfiguration: explicit localhost in the override.
+        process.env.POINT_EDIT_ALLOWED_HOSTS = 'eclawbot.com,localhost,127.0.0.1';
+        jest.resetModules();
+        mod = require('../../point-edit-resolver');
+    });
+
+    afterAll(() => {
+        if (ORIG.NODE_ENV === undefined) delete process.env.NODE_ENV;
+        else process.env.NODE_ENV = ORIG.NODE_ENV;
+        if (ORIG.RAILWAY_ENVIRONMENT === undefined) delete process.env.RAILWAY_ENVIRONMENT;
+        else process.env.RAILWAY_ENVIRONMENT = ORIG.RAILWAY_ENVIRONMENT;
+        if (ORIG.POINT_EDIT_ALLOWED_HOSTS === undefined) delete process.env.POINT_EDIT_ALLOWED_HOSTS;
+        else process.env.POINT_EDIT_ALLOWED_HOSTS = ORIG.POINT_EDIT_ALLOWED_HOSTS;
+        jest.resetModules();
+    });
+
+    test('localhost still rejected despite override', () => {
+        const r = mod.validateCoordinateBody({
+            x: 10, y: 10, viewportW: 1024, viewportH: 768,
+            url: 'https://localhost/foo',
+        });
+        expect(r.error).toBe('unsupported_origin');
+    });
+});

--- a/backend/tests/jest/point-edit-resolver.test.js
+++ b/backend/tests/jest/point-edit-resolver.test.js
@@ -1,100 +1,179 @@
 'use strict';
 
-require('./helpers/mock-setup');
+jest.mock('playwright', () => {
+    const evaluate = jest.fn();
+    const _newPage = jest.fn().mockResolvedValue({
+        goto: jest.fn().mockResolvedValue(undefined),
+        evaluate,
+    });
+    const _newContext = jest.fn().mockResolvedValue({
+        newPage: _newPage,
+        close: jest.fn().mockResolvedValue(undefined),
+    });
+    const _browser = {
+        newContext: _newContext,
+        close: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+        chromium: {
+            launch: jest.fn().mockResolvedValue(_browser),
+        },
+        __mock: { evaluate, _newPage, _newContext, _browser },
+    };
+});
 
+const express = require('express');
 const request = require('supertest');
+const { chromium, __mock } = require('playwright');
 
-let app;
+const resolver = require('../../point-edit-resolver');
 
-const post = (path) => request(app).post(path).set('Host', 'localhost');
+function makeApp() {
+    const app = express();
+    app.use(express.json());
+    app.use('/api/point-edit', resolver.router);
+    return app;
+}
 
-beforeAll(() => {
-    app = require('../../index');
+afterEach(() => {
+    __mock.evaluate.mockReset();
+    chromium.launch.mockClear();
 });
 
 afterAll(async () => {
-    const { httpServer } = require('../../index');
-    await new Promise(resolve => httpServer.close(resolve));
-    jest.resetModules();
+    await resolver.closeBrowser();
+});
+
+describe('sanitizeOuterHTML', () => {
+    test('strips <script> blocks', () => {
+        const dirty = '<div>hi<script>alert(1)</script></div>';
+        expect(resolver.sanitizeOuterHTML(dirty)).toBe('<div>hi</div>');
+    });
+
+    test('strips on*= inline event handlers', () => {
+        const dirty = '<button onclick="evil()" class="x">go</button>';
+        const clean = resolver.sanitizeOuterHTML(dirty);
+        expect(clean).not.toMatch(/onclick/i);
+        expect(clean).toContain('class="x"');
+    });
+
+    test('rewrites javascript: URLs in href/src', () => {
+        const dirty = '<a href="javascript:alert(1)">x</a>';
+        const clean = resolver.sanitizeOuterHTML(dirty);
+        expect(clean).not.toMatch(/javascript:/i);
+        expect(clean).toContain('href="#"');
+    });
+
+    test('returns empty string for non-string input', () => {
+        expect(resolver.sanitizeOuterHTML(null)).toBe('');
+        expect(resolver.sanitizeOuterHTML(undefined)).toBe('');
+        expect(resolver.sanitizeOuterHTML(42)).toBe('');
+    });
+});
+
+describe('validateCoordinateBody', () => {
+    test('rejects missing x', () => {
+        const r = resolver.validateCoordinateBody({ y: 10, viewportW: 800, viewportH: 600, url: 'https://eclawbot.com/x' });
+        expect(r.error).toMatch(/x and y/);
+    });
+
+    test('rejects non-positive viewport', () => {
+        const r = resolver.validateCoordinateBody({ x: 1, y: 1, viewportW: 0, viewportH: 600, url: 'https://eclawbot.com/x' });
+        expect(r.error).toMatch(/viewportW and viewportH/);
+    });
+
+    test('rejects out-of-bounds coordinates', () => {
+        const r = resolver.validateCoordinateBody({ x: 999999, y: 1, viewportW: 100, viewportH: 100, url: 'https://eclawbot.com/x' });
+        expect(r.error).toMatch(/outside supported bounds/);
+    });
+
+    test('rejects disallowed origin', () => {
+        const r = resolver.validateCoordinateBody({ x: 1, y: 1, viewportW: 100, viewportH: 100, url: 'https://evil.com/x' });
+        expect(r.error).toBe('unsupported_origin');
+        expect(r.hostname).toBe('evil.com');
+    });
+
+    test('accepts eclawbot.com', () => {
+        const r = resolver.validateCoordinateBody({ x: 1, y: 1, viewportW: 100, viewportH: 100, url: 'https://eclawbot.com/portal/dashboard.html' });
+        expect(r.error).toBeUndefined();
+        expect(r.value).toBeDefined();
+    });
+
+    test('accepts localhost', () => {
+        const r = resolver.validateCoordinateBody({ x: 1, y: 1, viewportW: 100, viewportH: 100, url: 'http://localhost:3000/x' });
+        expect(r.error).toBeUndefined();
+    });
 });
 
 describe('POST /api/point-edit/resolve-coordinate', () => {
-    it('returns a normalized coord target for the demo CTA button', async () => {
-        const res = await post('/api/point-edit/resolve-coordinate').send({
-            x: 211,
-            y: 446,
-            viewportW: 1280,
-            viewportH: 800,
-            url: 'https://eclawbot.com/portal/info.html?demo=pointedit',
-        });
+    const validBody = {
+        x: 200,
+        y: 300,
+        viewportW: 1280,
+        viewportH: 800,
+        url: 'https://eclawbot.com/publisher/dashboard.html',
+    };
 
-        expect(res.status).toBe(200);
-        expect(res.body).toMatchObject({
-            mode: 'coord',
-            targetId: 'cta.button',
-            selector: '[data-point-edit-id="cta.button"]',
-            anchorId: 'cta.block',
-            textSnippet: 'Buy Now',
+    test('200: returns sanitized outerHTML on hit', async () => {
+        __mock.evaluate.mockResolvedValueOnce({
+            selector: 'main > section:nth-of-type(2)',
+            anchorId: 'main',
+            outerHTML: '<section id="main">hi<script>alert(1)</script><button onclick="x()">go</button></section>',
+            textSnippet: 'hi',
+            rect: { x: 10, y: 20, w: 100, h: 40 },
+            tagName: 'section',
         });
-        expect(res.body.coordinates).toMatchObject({
-            x: 211,
-            y: 446,
-            viewportW: 1280,
-            viewportH: 800,
-        });
-        expect(res.body.coordinates.normalizedX).toBeCloseTo(0.165, 2);
-        expect(res.body.confidence).toBeGreaterThanOrEqual(0.9);
-        expect(res.body.rect).toEqual(expect.objectContaining({
-            x: expect.any(Number),
-            y: expect.any(Number),
-            w: expect.any(Number),
-            h: expect.any(Number),
-        }));
-        expect(res.body.sourceHint).toContain('backend/public/portal/info.html:4968#cta.button');
-        expect(res.body.astPath).toBe('backend/public/portal/info.html:4968#cta.button');
-    });
-
-    it('resolves the mobile thumb-region coordinate to the CTA button', async () => {
-        const res = await post('/api/point-edit/resolve-coordinate').send({
-            x: 96,
-            y: 471,
-            viewportW: 390,
-            viewportH: 844,
-            url: '/portal/info.html?demo=pointedit',
-        });
-
+        const res = await request(makeApp())
+            .post('/api/point-edit/resolve-coordinate')
+            .send(validBody);
         expect(res.status).toBe(200);
         expect(res.body.mode).toBe('coord');
-        expect(res.body.targetId).toBe('cta.button');
-        expect(res.body.selector).toBe('[data-point-edit-id="cta.button"]');
-        expect(res.body.coordinates.normalizedX).toBeCloseTo(0.246, 2);
+        expect(res.body.outerHTML).not.toMatch(/<script/i);
+        expect(res.body.outerHTML).not.toMatch(/onclick=/i);
+        expect(res.body.sourceHint).toContain('live:');
+        expect(res.body.confidence).toBeCloseTo(0.9);
+        expect(res.body.targetId).toBe('main');
     });
 
-    it('400s for malformed coordinate payloads', async () => {
-        const res = await post('/api/point-edit/resolve-coordinate').send({
-            x: 'nope',
-            y: 100,
-            viewportW: 1280,
-            viewportH: 800,
-            url: '/portal/info.html?demo=pointedit',
-        });
-
+    test('400: missing x', async () => {
+        const res = await request(makeApp())
+            .post('/api/point-edit/resolve-coordinate')
+            .send({ y: 100, viewportW: 800, viewportH: 600, url: 'https://eclawbot.com/x' });
         expect(res.status).toBe(400);
-        expect(res.body.success).toBe(false);
         expect(res.body.error).toMatch(/x and y/);
     });
 
-    it('422s unsupported pages instead of guessing a target', async () => {
-        const res = await post('/api/point-edit/resolve-coordinate').send({
-            x: 211,
-            y: 446,
-            viewportW: 1280,
-            viewportH: 800,
-            url: 'https://eclawbot.com/portal/dashboard.html',
-        });
+    test('400: out-of-bounds viewport', async () => {
+        const res = await request(makeApp())
+            .post('/api/point-edit/resolve-coordinate')
+            .send({ x: 1, y: 1, viewportW: 999999, viewportH: 600, url: 'https://eclawbot.com/x' });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/outside supported bounds/);
+    });
 
+    test('422: unsupported origin', async () => {
+        const res = await request(makeApp())
+            .post('/api/point-edit/resolve-coordinate')
+            .send({ ...validBody, url: 'https://evil.com/page' });
         expect(res.status).toBe(422);
-        expect(res.body.success).toBe(false);
-        expect(res.body.error).toBe('unsupported_url');
+        expect(res.body.error).toBe('unsupported_origin');
+    });
+
+    test('404: page.evaluate returns null', async () => {
+        __mock.evaluate.mockResolvedValueOnce(null);
+        const res = await request(makeApp())
+            .post('/api/point-edit/resolve-coordinate')
+            .send(validBody);
+        expect(res.status).toBe(404);
+        expect(res.body.error).toBe('target_not_found');
+    });
+
+    test('500: resolver throws', async () => {
+        __mock.evaluate.mockRejectedValueOnce(new Error('chromium crashed'));
+        const res = await request(makeApp())
+            .post('/api/point-edit/resolve-coordinate')
+            .send(validBody);
+        expect(res.status).toBe(500);
+        expect(res.body.error).toBe('resolver_failure');
     });
 });


### PR DESCRIPTION
## Scope

Replace the v1 static `TARGETS` lookup (10 demo elements on `/portal/info.html`) in `backend/point-edit-resolver.js` with a real headless Chromium resolver that maps any `(x, y)` on any allow-listed URL to its DOM element via `document.elementFromPoint`.

Card: **card_5d3dee7e11e55eb6bc695045** [P2]
Follow-up to #3006 (v1).

## v1 → v2 diff

| | v1 (PR #3006) | v2 (this PR) |
|---|---|---|
| Resolution | Static `TARGETS` table, Euclidean distance in normalized space | `chromium.launch()` + `page.evaluate(document.elementFromPoint)` |
| URL support | Only `/info` and `/portal/info.html` (else 422 `unsupported_url`) | Any host in `POINT_EDIT_ALLOWED_HOSTS` (default: `eclawbot.com,localhost,127.0.0.1`) |
| Cross-origin guard | None | 422 `unsupported_origin` for non-allow-listed hosts |
| outerHTML | Static string per target | Live `el.outerHTML`, sanitized (`<script>` / `on*=` / `javascript:` stripped) |
| `sourceHint` | `ast:<astPath>` | `live:<url>` |
| Cold-start | ~0ms | ~1-2s (chromium launch), subsequent requests reuse singleton |

`router`, `resolveCoordinate`, `validateCoordinateBody`, `isPointEditDemoUrl`, `TARGETS` all still exported — existing imports stay green.

## Acceptance checklist (from card)

- [x] Playwright chromium headless inside `backend/point-edit-resolver.js`
- [x] `page.evaluate(document.elementFromPoint)` for dynamic anchor resolution
- [x] `selectorFor()` builds stable CSS path with `:nth-of-type(n)` + `#id` anchors
- [x] outerHTML sanitization — `<script>`, `on*=`, `javascript:` all stripped (3 Jest tests)
- [x] Cross-origin guard in `validateCoordinateBody` via `POINT_EDIT_ALLOWED_HOSTS`
- [x] Viewport + coordinate bounds preserved (`MAX_COORDINATE=100000`, `MAX_VIEWPORT=20000`)
- [x] Jest tests mock playwright + assert sanitization, validation, 400/404/422/500

## Non-demo verification

Run locally against live `eclawbot.com` (via `node /tmp/u73_track_b_verify.js`):

| URL | Coord | Status | targetId | selector | textSnippet |
|---|---|---|---|---|---|
| `https://eclawbot.com/` | (640, 200) @ 1280×800 | 200 | `html > body > main > section > img:nth-of-type(1)` | same | `""` (hero logo image) |
| `https://eclawbot.com/enterprise` | (640, 320) @ 1280×800 | 200 | `html > body > main > section:nth-of-type(1)` | same | `"Enterprise\nAI Agent Teams for Your Business…"` |

Both returned `confidence: 0.9`, `sourceHint: live:<url>`, valid `rect`, sanitized `outerHTML`.

## Risk

- **Cold-start latency**: first request after worker boot pays ~1-2s for `chromium.launch()`. Subsequent requests reuse the singleton browser. Acceptable for the point-edit use case (rare, interactive).
- **Memory**: each `newContext()` is closed in `finally`. Browser singleton lives for worker lifetime; `closeBrowser()` exported for tests.
- **Allow-list**: default includes `eclawbot.com,localhost,127.0.0.1`. Anything else → 422. Operators add hosts via `POINT_EDIT_ALLOWED_HOSTS`.

## Code review — PR follow-up

### Core
- A1. Logic trace: happy path → validate body → launch browser singleton → new context with viewport → goto URL (DOMContentLoaded) → `elementFromPoint(clamped x,y)` → sanitize outerHTML → return shape with `mode:'coord'`. Failure paths: missing x/y → 400; out-of-bounds → 400; non-allow-listed host → 422; `evaluate()` returns null → 404; chromium throws → 500.
- A2. Test coverage: `backend/tests/jest/point-edit-resolver.test.js` (16 tests). Mocks `playwright`, asserts each branch above. `npx jest tests/jest/point-edit-resolver.test.js` → 16/16 green.
- A3. Return shape: success returns existing v1 shape (mode, targetId, selector, …). Errors use `{ success:false, error:'<code>', message?: }` with codes `x and y are required…`, `outside supported bounds`, `unsupported_origin`, `target_not_found`, `resolver_failure`.
- A4. What this does NOT fix: viewport DPR / retina scaling still single-DPR; iframe contents still inaccessible (cross-origin); no auth on the endpoint itself (relies on host allow-list only). Filed mentally as Track B v3 candidates.
- A5. Security: cross-origin guard added (was missing in v1). outerHTML sanitization strips `<script>`, `on*=` handlers, `javascript:` URLs. Tests assert all three. No secret values logged.

### Extended
- B1. `/api/help`: ⚠️ NO-OP — endpoint shape unchanged from v1; v1 already discoverable (or omitted per v1 PR).
- B2. Related docs: ⚠️ NO-OP — CLAUDE.md & info page describe the feature as "point-and-edit demo"; v2 expands scope but contract unchanged. No new env vars beyond `POINT_EDIT_ALLOWED_HOSTS` (documented inline).
- B3. i18n: ⚠️ NO-OP — backend-only, no user-facing strings touched.
- B4. Info/promo page: ⚠️ NO-OP — info.html demo still works (v1 demo URL `eclawbot.com` is in allow-list); v2 just widens supported URLs.
- B5. Debug endpoint: ⚠️ NO-OP — resolver is read-only, idempotent, no audit rows generated.

Result: merge-ready pending cross-review.

## Reviewer

@tbwb9e (#1 Mac_F) — please cross-review before merge per `feedback_supervisor_cross_review`.