### PR TITLE
fix(android): wallpaper countdown renders independently of snapshot==null guard (card_4018404d)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/engine/UsageOverlayRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/UsageOverlayRenderer.kt
@@ -194,6 +194,7 @@ class UsageOverlayRenderer(
         val lines = mutableListOf(context.getString(R.string.wallpaper_usage_overlay_title))
         if (snapshot == null) {
             lines.add(context.getString(R.string.wallpaper_usage_overlay_syncing))
+            formatResetCountdownLine(snapshot)?.let(lines::add)
             return lines
         }
 


### PR DESCRIPTION
## Why
Retro E2E on merged PR #3005 (parent card_5a63c923, merge SHA 4e7e324f) found that the new wallpaper reset-countdown toggle (Off / 5h / Weekly) shipped a visible RadioGroup but the actual countdown TEXT never renders when the device is in an unbound / cold-start state.

Root cause in `UsageOverlayRenderer.kt:194-198`:

```kotlin
val lines = mutableListOf(context.getString(R.string.wallpaper_usage_overlay_title))
if (snapshot == null) {
    lines.add(context.getString(R.string.wallpaper_usage_overlay_syncing))
    return lines  // <-- early return blocked formatResetCountdownLine() below
}
// ...
formatResetCountdownLine(snapshot)?.let(lines::add)  // never reached when snapshot==null
```

Weekly path uses pure `Calendar` math via `nextWeeklyResetEpochMillis()` and never needs snapshot data — the early-return was strictly a design defect. 5h path needs Claude/Codex `rateLimits.fiveHour.resetsAt`, so it can degrade gracefully when absent.

## Fix
One-line addition: invoke `formatResetCountdownLine(snapshot)` inside the snapshot==null branch before the early return. Behavior:

- **Weekly** — pure Calendar math, always renders `Next weekly reset: Mon HH:MM` when toggle is on.
- **5h** — `nextFiveHourResetEpochSec(snapshot)` already returns null when snapshot lacks rateLimits, so the existing `?: return null` in `formatResetCountdownLine()` silently omits the line. Consistent with how the existing engine-usage strip degrades on unbound devices.
- **Off** — `when` block returns null in the else branch; no line added; no regression.

## E2E (real device, Pixel_9a API 36, build from this branch on emulator-5554)

| State | Expected | Observed | Screenshot |
|---|---|---|---|
| Off | No countdown line | Overlay shows only `Usage / Usage syncing...` | [off-png](https://eclaw-files.a9ea84990ec49fdfd03e23197f2c6857.r2.cloudflarestorage.com/files/480def4c-2183-4d8e-afd0-b131ae89adcc/131aff4f-cf07-435c-8b04-5d0ee6827f45/wallpaper_e2e_FIXED_02_off.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=57f969c0ce692bdd5d45e71bd7b5bec2%2F20260529%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260529T010851Z&X-Amz-Expires=259200&X-Amz-Signature=d33bdb118d91aacec9bd06261e084eb6b52a497222be90bc37fefc40b5836fbe&X-Amz-SignedHeaders=host&response-content-disposition=inline%3B%20filename%3D%22wallpaper_e2e_FIXED_02_off.png%22&x-amz-checksum-mode=ENABLED&x-id=GetObject) |
| 5h | Silently skipped (no cached rateLimits) | Overlay shows only `Usage / Usage syncing...`, no exception text | [5h-png](https://eclaw-files.a9ea84990ec49fdfd03e23197f2c6857.r2.cloudflarestorage.com/files/480def4c-2183-4d8e-afd0-b131ae89adcc/a8b91ea3-ce8c-42cf-b32c-bd3e99a0e08a/wallpaper_e2e_FIXED_03_5h.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=57f969c0ce692bdd5d45e71bd7b5bec2%2F20260529%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260529T010851Z&X-Amz-Expires=259200&X-Amz-Signature=1c0d89399e8f954f7227b48624a1a5a73258be8c204f7300068305ca887a1d27&X-Amz-SignedHeaders=host&response-content-disposition=inline%3B%20filename%3D%22wallpaper_e2e_FIXED_03_5h.png%22&x-amz-checksum-mode=ENABLED&x-id=GetObject) |
| Weekly | `Next weekly reset: Mon HH:MM` renders | Overlay shows `Usage / Usage syncing... / Next weekly reset: Mon 00:00` | [weekly-png](https://eclaw-files.a9ea84990ec49fdfd03e23197f2c6857.r2.cloudflarestorage.com/files/480def4c-2183-4d8e-afd0-b131ae89adcc/fa8d869f-2bbd-4b67-a425-a0e67c128dae/wallpaper_e2e_FIXED_04_weekly.png?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Content-Sha256=UNSIGNED-PAYLOAD&X-Amz-Credential=57f969c0ce692bdd5d45e71bd7b5bec2%2F20260529%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20260529T010852Z&X-Amz-Expires=259200&X-Amz-Signature=8d4bff5fa080e03747de9e59e498422c304d33cb44e280b948c4cc30f9d21f79&X-Amz-SignedHeaders=host&response-content-disposition=inline%3B%20filename%3D%22wallpaper_e2e_FIXED_04_weekly.png%22&x-amz-checksum-mode=ENABLED&x-id=GetObject) |

UI verification via `uiautomator dump` at each transition confirmed RadioGroup selection state matches the visible canvas text. Screenshot URLs are R2 presigned (72h TTL); also attached to card_4018404d for permanence.

## Diff
Single-line change in `UsageOverlayRenderer.kt`. No scope creep, no test scaffold invention (no existing UsageOverlay tests in repo).

## Closes
- card_4018404d2e0e385ef3aa89ee (P1 fix)

## Related
- PR #3005 (the original feature, parent card_5a63c923)
- Found by retro E2E flagged by Hank in web_chat 2026-05-29 08:24 TW
