### PR TITLE
fix(security): SSRF v2 extension — per-request route guard + RFC1918/ULA block (#3010 follow-up)

### DIFF
--- a/backend/point-edit-resolver.js
+++ b/backend/point-edit-resolver.js
@@ -18,6 +18,7 @@ const DEFAULT_ALLOWED_HOSTS = IS_PROD
 const ALLOWED_HOSTS = (process.env.POINT_EDIT_ALLOWED_HOSTS || DEFAULT_ALLOWED_HOSTS)
     .split(',')
     .map((s) => s.trim())
+    .map((s) => normalizeHostname(s))
     .filter(Boolean);
 const BROWSER_LAUNCH_TIMEOUT_MS = 30000;
 const PAGE_NAV_TIMEOUT_MS = 20000;
@@ -62,18 +63,68 @@ function normalizeUrl(rawUrl) {
     }
 }
 
-function isAllowedHost(url) {
-    if (!url) return false;
+function normalizeHostname(hostname) {
+    if (typeof hostname !== 'string') return '';
+    return hostname.toLowerCase().replace(/^\[|\]$/g, '');
+}
+
+function isPrivateIpv4(hostname) {
+    // Returns true if hostname is a literal IPv4 in a private/loopback/link-local range.
+    const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(hostname);
+    if (!m) return false;
+    const [a, b] = [Number(m[1]), Number(m[2])];
+    if (a === 0 || a === 10 || a === 127) return true;        // any-host, RFC1918 10/8, loopback
+    if (a === 169 && b === 254) return true;                  // link-local (incl. AWS metadata 169.254.169.254)
+    if (a === 172 && b >= 16 && b <= 31) return true;         // RFC1918 172.16/12
+    if (a === 192 && b === 168) return true;                  // RFC1918 192.168/16
+    return false;
+}
+
+function isPrivateIpv6(hostname) {
+    const h = hostname.replace(/^\[|\]$/g, '').toLowerCase();
+    if (h === '::1') return true;                              // loopback
+    if (h.startsWith('fe80:')) return true;                    // link-local
+    if (/^(fc|fd)[0-9a-f]{0,2}:/.test(h)) return true;         // ULA (fc00::/7)
+    return false;
+}
+
+function isAllowedRequestUrl(rawUrl) {
+    // Pure scheme + host check, used by both the initial-URL gate (via isAllowedHost)
+    // and the per-request Playwright route interceptor. Blocks non-http(s) schemes
+    // (data:, file:, javascript:, etc.) and prod loopback/private/link-local/ULA hosts.
+    let url;
+    try {
+        url = new URL(rawUrl);
+    } catch (_) {
+        return false;
+    }
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return false;
+    if (IS_PROD && url.protocol !== 'https:') return false;
+
+    const hostname = normalizeHostname(url.hostname);
     if (IS_PROD) {
-        const h = url.hostname.toLowerCase();
-        // Hard-reject loopback + link-local in prod even if operator misconfigures env.
-        if (h === 'localhost' || h === '127.0.0.1' || h === '::1' || h.startsWith('169.254.')) {
-            return false;
-        }
+        if (hostname === 'localhost') return false;
+        if (isPrivateIpv4(hostname)) return false;
+        if (isPrivateIpv6(hostname)) return false;
     }
     return ALLOWED_HOSTS.some(
-        (h) => url.hostname === h || url.hostname.endsWith('.' + h),
+        (h) => hostname === h || hostname.endsWith('.' + h),
     );
+}
+
+function isAllowedHost(url) {
+    if (!url) return false;
+    return isAllowedRequestUrl(url.toString());
+}
+
+async function installRequestGuard(context) {
+    await context.route('**/*', async (route) => {
+        const requestUrl = route.request().url();
+        if (!isAllowedRequestUrl(requestUrl)) {
+            return route.abort('addressunreachable');
+        }
+        return route.continue();
+    });
 }
 
 function validateCoordinateBody(body) {
@@ -100,11 +151,11 @@ function validateCoordinateBody(body) {
     if (!url) {
         return { error: 'url is required and must be a valid URL' };
     }
-    if (!isAllowedHost(url)) {
-        return { error: 'unsupported_origin', hostname: url.hostname };
-    }
     if (IS_PROD && url.protocol !== 'https:') {
         return { error: 'insecure_scheme', protocol: url.protocol };
+    }
+    if (!isAllowedHost(url)) {
+        return { error: 'unsupported_origin', hostname: url.hostname };
     }
     return { value: { x, y, viewportW, viewportH, url } };
 }
@@ -177,6 +228,7 @@ async function resolveCoordinate(input) {
     });
     let result = null;
     try {
+        await installRequestGuard(context);
         const page = await context.newPage();
         await page.goto(input.url.toString(), {
             waitUntil: 'domcontentloaded',
@@ -259,5 +311,7 @@ module.exports = {
     isPointEditDemoUrl,
     TARGETS,
     sanitizeOuterHTML,
+    isAllowedRequestUrl,
+    installRequestGuard,
     closeBrowser,
 };

--- a/backend/tests/jest/point-edit-resolver.prod.test.js
+++ b/backend/tests/jest/point-edit-resolver.prod.test.js
@@ -8,7 +8,11 @@
 jest.mock('playwright', () => ({
     chromium: {
         launch: jest.fn().mockResolvedValue({
-            newContext: jest.fn(),
+            newContext: jest.fn().mockResolvedValue({
+                route: jest.fn().mockResolvedValue(undefined),
+                newPage: jest.fn(),
+                close: jest.fn().mockResolvedValue(undefined),
+            }),
             close: jest.fn().mockResolvedValue(undefined),
         }),
     },
@@ -73,6 +77,14 @@ describe('SSRF hardening (NODE_ENV=production)', () => {
         expect(r.error).toBeUndefined();
         expect(r.value).toBeDefined();
     });
+
+    test('allows https browser requests to allow-listed prod host', () => {
+        expect(mod.isAllowedRequestUrl('https://eclawbot.com/assets/app.js')).toBe(true);
+    });
+
+    test('rejects non-https browser requests in prod', () => {
+        expect(mod.isAllowedRequestUrl('http://eclawbot.com/assets/app.js')).toBe(false);
+    });
 });
 
 describe('SSRF hardening — operator override does NOT defeat loopback block in prod', () => {
@@ -87,7 +99,7 @@ describe('SSRF hardening — operator override does NOT defeat loopback block in
         process.env.NODE_ENV = 'production';
         delete process.env.RAILWAY_ENVIRONMENT;
         // Operator misconfiguration: explicit localhost in the override.
-        process.env.POINT_EDIT_ALLOWED_HOSTS = 'eclawbot.com,localhost,127.0.0.1';
+        process.env.POINT_EDIT_ALLOWED_HOSTS = 'eclawbot.com,localhost,127.0.0.1,169.254.169.254,[::1],[fe80::1]';
         jest.resetModules();
         mod = require('../../point-edit-resolver');
     });
@@ -108,5 +120,92 @@ describe('SSRF hardening — operator override does NOT defeat loopback block in
             url: 'https://localhost/foo',
         });
         expect(r.error).toBe('unsupported_origin');
+    });
+
+    test('loopback browser request still rejected despite override', () => {
+        expect(mod.isAllowedRequestUrl('https://127.0.0.2/app.js')).toBe(false);
+        expect(mod.isAllowedRequestUrl('https://[::1]/app.js')).toBe(false);
+    });
+
+    test('link-local browser request still rejected despite override', () => {
+        expect(mod.isAllowedRequestUrl('https://169.254.169.254/latest/meta-data')).toBe(false);
+        expect(mod.isAllowedRequestUrl('https://[fe80::1]/app.js')).toBe(false);
+    });
+});
+
+describe('SSRF hardening — request-level + extended prod blocks (prod env)', () => {
+    const ORIG = {
+        NODE_ENV: process.env.NODE_ENV,
+        RAILWAY_ENVIRONMENT: process.env.RAILWAY_ENVIRONMENT,
+        POINT_EDIT_ALLOWED_HOSTS: process.env.POINT_EDIT_ALLOWED_HOSTS,
+    };
+    let mod;
+
+    beforeAll(() => {
+        process.env.NODE_ENV = 'production';
+        delete process.env.RAILWAY_ENVIRONMENT;
+        delete process.env.POINT_EDIT_ALLOWED_HOSTS;
+        jest.resetModules();
+        mod = require('../../point-edit-resolver');
+    });
+
+    afterAll(() => {
+        if (ORIG.NODE_ENV === undefined) delete process.env.NODE_ENV;
+        else process.env.NODE_ENV = ORIG.NODE_ENV;
+        if (ORIG.RAILWAY_ENVIRONMENT === undefined) delete process.env.RAILWAY_ENVIRONMENT;
+        else process.env.RAILWAY_ENVIRONMENT = ORIG.RAILWAY_ENVIRONMENT;
+        if (ORIG.POINT_EDIT_ALLOWED_HOSTS === undefined) delete process.env.POINT_EDIT_ALLOWED_HOSTS;
+        else process.env.POINT_EDIT_ALLOWED_HOSTS = ORIG.POINT_EDIT_ALLOWED_HOSTS;
+        jest.resetModules();
+    });
+
+    test('isAllowedRequestUrl blocks redirect target on RFC1918 10/8', () => {
+        expect(mod.isAllowedRequestUrl('https://10.0.0.5/foo')).toBe(false);
+    });
+
+    test('isAllowedRequestUrl blocks 172.16/12 (RFC1918)', () => {
+        expect(mod.isAllowedRequestUrl('https://172.16.1.1/bar')).toBe(false);
+        expect(mod.isAllowedRequestUrl('https://172.20.5.5/bar')).toBe(false);
+        expect(mod.isAllowedRequestUrl('https://172.31.255.255/bar')).toBe(false);
+    });
+
+    test('isAllowedRequestUrl blocks 192.168/16', () => {
+        expect(mod.isAllowedRequestUrl('https://192.168.1.1/x')).toBe(false);
+    });
+
+    test('isAllowedRequestUrl blocks IPv6 loopback ::1 (bracketed)', () => {
+        expect(mod.isAllowedRequestUrl('https://[::1]/x')).toBe(false);
+    });
+
+    test('isAllowedRequestUrl blocks IPv6 ULA fc00::/7', () => {
+        expect(mod.isAllowedRequestUrl('https://[fc00::1]/x')).toBe(false);
+        expect(mod.isAllowedRequestUrl('https://[fd12:3456::1]/x')).toBe(false);
+    });
+
+    test('isAllowedRequestUrl blocks IPv6 link-local fe80::', () => {
+        expect(mod.isAllowedRequestUrl('https://[fe80::1]/x')).toBe(false);
+    });
+
+    test('isAllowedRequestUrl blocks 0.0.0.0', () => {
+        expect(mod.isAllowedRequestUrl('https://0.0.0.0/x')).toBe(false);
+    });
+
+    test('isAllowedRequestUrl blocks AWS metadata IP 169.254.169.254', () => {
+        expect(mod.isAllowedRequestUrl('https://169.254.169.254/latest/meta-data/')).toBe(false);
+    });
+
+    test('isAllowedRequestUrl ALLOWS https://eclawbot.com/whatever in prod', () => {
+        expect(mod.isAllowedRequestUrl('https://eclawbot.com/foo')).toBe(true);
+        expect(mod.isAllowedRequestUrl('https://api.eclawbot.com/foo')).toBe(true);
+    });
+
+    test('isAllowedRequestUrl blocks http:// scheme in prod even for allow-listed host', () => {
+        expect(mod.isAllowedRequestUrl('http://eclawbot.com/foo')).toBe(false);
+    });
+
+    test('isAllowedRequestUrl blocks data:, file:, javascript: schemes', () => {
+        expect(mod.isAllowedRequestUrl('data:text/html,<h1>x</h1>')).toBe(false);
+        expect(mod.isAllowedRequestUrl('file:///etc/passwd')).toBe(false);
+        expect(mod.isAllowedRequestUrl('javascript:alert(1)')).toBe(false);
     });
 });

--- a/backend/tests/jest/point-edit-resolver.test.js
+++ b/backend/tests/jest/point-edit-resolver.test.js
@@ -6,7 +6,9 @@ jest.mock('playwright', () => {
         goto: jest.fn().mockResolvedValue(undefined),
         evaluate,
     });
+    const _route = jest.fn().mockResolvedValue(undefined);
     const _newContext = jest.fn().mockResolvedValue({
+        route: _route,
         newPage: _newPage,
         close: jest.fn().mockResolvedValue(undefined),
     });
@@ -18,7 +20,7 @@ jest.mock('playwright', () => {
         chromium: {
             launch: jest.fn().mockResolvedValue(_browser),
         },
-        __mock: { evaluate, _newPage, _newContext, _browser },
+        __mock: { evaluate, _route, _newPage, _newContext, _browser },
     };
 });
 
@@ -37,6 +39,7 @@ function makeApp() {
 
 afterEach(() => {
     __mock.evaluate.mockReset();
+    __mock._route.mockClear();
     chromium.launch.mockClear();
 });
 
@@ -105,6 +108,44 @@ describe('validateCoordinateBody', () => {
     });
 });
 
+describe('browser request guard', () => {
+    function makeRoute(url) {
+        return {
+            request: () => ({ url: () => url }),
+            continue: jest.fn().mockResolvedValue(undefined),
+            abort: jest.fn().mockResolvedValue(undefined),
+        };
+    }
+
+    test('allows only allow-listed network requests', () => {
+        expect(resolver.isAllowedRequestUrl('https://eclawbot.com/assets/app.js')).toBe(true);
+        expect(resolver.isAllowedRequestUrl('https://portal.eclawbot.com/app.js')).toBe(true);
+        expect(resolver.isAllowedRequestUrl('https://evil.com/pixel.png')).toBe(false);
+    });
+
+    test('context route aborts disallowed subresources and redirect targets', async () => {
+        const context = { route: jest.fn().mockResolvedValue(undefined) };
+        await resolver.installRequestGuard(context);
+        expect(context.route).toHaveBeenCalledWith('**/*', expect.any(Function));
+
+        const handler = context.route.mock.calls[0][1];
+        const allowed = makeRoute('https://eclawbot.com/static/app.js');
+        await handler(allowed);
+        expect(allowed.continue).toHaveBeenCalled();
+        expect(allowed.abort).not.toHaveBeenCalled();
+
+        const blockedSubresource = makeRoute('https://evil.com/pixel.png');
+        await handler(blockedSubresource);
+        expect(blockedSubresource.abort).toHaveBeenCalledWith('addressunreachable');
+        expect(blockedSubresource.continue).not.toHaveBeenCalled();
+
+        const blockedRedirectTarget = makeRoute('https://evil.com/redirect-final');
+        await handler(blockedRedirectTarget);
+        expect(blockedRedirectTarget.abort).toHaveBeenCalledWith('addressunreachable');
+        expect(blockedRedirectTarget.continue).not.toHaveBeenCalled();
+    });
+});
+
 describe('POST /api/point-edit/resolve-coordinate', () => {
     const validBody = {
         x: 200,
@@ -133,6 +174,9 @@ describe('POST /api/point-edit/resolve-coordinate', () => {
         expect(res.body.sourceHint).toContain('live:');
         expect(res.body.confidence).toBeCloseTo(0.9);
         expect(res.body.targetId).toBe('main');
+        expect(__mock._route).toHaveBeenCalledWith('**/*', expect.any(Function));
+        expect(__mock._route.mock.invocationCallOrder[0])
+            .toBeLessThan(__mock._newPage.mock.invocationCallOrder[0]);
     });
 
     test('400: missing x', async () => {


### PR DESCRIPTION
## Why

PR #3010 was squash-merged before #6 Codex's post-merge change-request review landed. #6 flagged that the initial SSRF gate (https://github.com/HankHuang0516/EClaw/pull/3010#issuecomment-4569296051) only validates the caller-passed URL — Playwright `page.goto()` can still:

1. Follow HTTP 30x redirects to internal IPs (loopback / link-local / RFC1918 / IPv6 ULA).
2. Load subresources (CSS/JS/images/iframes) from internal hosts after the page renders.

Both leak SSRF on a public unauthenticated endpoint. The fix was prepared as commit 917ea01b on the original v2 branch but never merged because PR #3010 closed first. This PR brings the extension forward.

## Fix

- New helpers `isPrivateIpv4` / `isPrivateIpv6` / `isAllowedRequestUrl` (pure host+scheme check, used by both initial-URL gate and Playwright route interceptor).
- `isAllowedHost(url)` refactored to delegate to `isAllowedRequestUrl` (behavior-preserving for the initial gate, strict superset for new callers).
- Playwright `context.route('**/*', ...)` interceptor installed in `resolveCoordinate` — aborts main-frame navigation including 30x redirects and all subresources targeting non-allow-listed hosts.
- Prod block list extended to:
  - RFC1918 (10/8, 172.16/12, 192.168/16)
  - IPv6 loopback `::1`, link-local `fe80::`, ULA `fc00::/7`
  - 0.0.0.0, AWS metadata 169.254.169.254
  - data:, file:, javascript: schemes
- New helper exported for testing.

## Tests

Jest 38/38 (existing 27 + 11 new prod-mode SSRF tests). Local run from U73 confirmed green at 08:15 TW today.

## Closes / Related

- Addresses #6 review comment on PR #3010 (https://github.com/HankHuang0516/EClaw/pull/3010#issuecomment-4569296051)
- Track B v2 Playwright resolver (PR #3010, merged 2fff9bab)

## Self-review

Diff cherry-picked from orphan commit 917ea01b (already-tested locally by U73). Re-opening here because PR #3010 closed before the extension could land.