### PR TITLE
fix(org-chart): suppress low-signal noise in silent FWD-to-superior path

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -17367,8 +17367,14 @@ async function pushToBot(entity, deviceId, eventType, payload, opts = {}) {
 const ORG_FWD_PREFIX = '[📢 FWD';
 const ORG_TASK_FWD_PREFIX = '[📋 TASK FWD';
 
+const { isLowSignalFwd } = require('./org-fwd-filter');
+
 async function orgChartForward(entity, deviceId, message, opts = {}) {
     if (!message || message.startsWith(ORG_TASK_FWD_PREFIX) || message.startsWith(ORG_FWD_PREFIX)) return;
+    if (isLowSignalFwd(message)) {
+        serverLog('info', 'org_forward_skip', `#${entity.entityId} suppressed low-signal fwd: "${String(message).trim().slice(0, 60)}"`, { deviceId, entityId: entity.entityId });
+        return;
+    }
 
     try {
         const orgData = await orgChartModule.getOrgChart(deviceId);

--- a/backend/org-fwd-filter.js
+++ b/backend/org-fwd-filter.js
@@ -1,0 +1,35 @@
+/**
+ * Org-chart forward noise filter.
+ *
+ * orgChartForward() in index.js silently routes any bot message up the org
+ * chart to the user's superior. Sibling bots whose webhook handler crashes
+ * (JSON parse errors), or that send bare "[<name> 回應超時]" status markers,
+ * or that ack-the-ack with one-word replies, were flooding the user's
+ * channel with low-signal noise. This filter drops those before the silent
+ * push happens.
+ */
+
+const ORG_FWD_NOISE_PATTERNS = [
+    /^\s*Unexpected (non-whitespace character after JSON|token .* in JSON|end of JSON)/i,
+    /^\s*SyntaxError: Unexpected/i,
+    /^\s*at position \d+/i,
+    /^\s*line \d+ column \d+/i,
+    /^\s*\[[^\]]{1,40}回應超時\]\s*$/,
+    /^\s*\[[^\]]{1,40}response timeout\]\s*$/i,
+    /^\s*(ping|pong|ack|ok|received|noted)\s*[.!]*\s*$/i,
+];
+
+const ORG_FWD_MIN_BODY_LEN = 12;
+
+function isLowSignalFwd(message) {
+    if (!message) return true;
+    const trimmed = String(message).trim();
+    if (trimmed.length < ORG_FWD_MIN_BODY_LEN) return true;
+    return ORG_FWD_NOISE_PATTERNS.some(re => re.test(trimmed));
+}
+
+module.exports = {
+    isLowSignalFwd,
+    ORG_FWD_NOISE_PATTERNS,
+    ORG_FWD_MIN_BODY_LEN,
+};

--- a/backend/tests/jest/org-fwd-filter.test.js
+++ b/backend/tests/jest/org-fwd-filter.test.js
@@ -1,0 +1,119 @@
+/**
+ * Unit tests for org-fwd-filter — guards orgChartForward() against silently
+ * routing low-signal noise (JSON parse errors, bare timeout markers, one-word
+ * acks) up the org chart and into the user's channel.
+ */
+
+const { isLowSignalFwd, ORG_FWD_MIN_BODY_LEN } = require('../../org-fwd-filter');
+
+describe('isLowSignalFwd()', () => {
+    describe('falsy / trivial bodies', () => {
+        it('returns true for null / undefined / empty', () => {
+            expect(isLowSignalFwd(null)).toBe(true);
+            expect(isLowSignalFwd(undefined)).toBe(true);
+            expect(isLowSignalFwd('')).toBe(true);
+            expect(isLowSignalFwd('   ')).toBe(true);
+        });
+
+        it('returns true for bodies shorter than ORG_FWD_MIN_BODY_LEN', () => {
+            expect(isLowSignalFwd('hi')).toBe(true);
+            expect(isLowSignalFwd('a b c')).toBe(true);
+            const justUnder = 'x'.repeat(ORG_FWD_MIN_BODY_LEN - 1);
+            expect(isLowSignalFwd(justUnder)).toBe(true);
+        });
+
+        it('returns false for bodies at or above ORG_FWD_MIN_BODY_LEN with content', () => {
+            const exactlyAt = 'meaningful !'; // 12 chars
+            expect(exactlyAt.length).toBe(ORG_FWD_MIN_BODY_LEN);
+            expect(isLowSignalFwd(exactlyAt)).toBe(false);
+        });
+    });
+
+    describe('JSON parse error noise (the original Mac_E flood)', () => {
+        it('suppresses "Unexpected non-whitespace character after JSON"', () => {
+            expect(isLowSignalFwd('Unexpected non-whitespace character after JSON at position 42')).toBe(true);
+        });
+
+        it('suppresses "Unexpected token X in JSON"', () => {
+            expect(isLowSignalFwd('Unexpected token < in JSON at position 0')).toBe(true);
+        });
+
+        it('suppresses "Unexpected end of JSON"', () => {
+            expect(isLowSignalFwd('Unexpected end of JSON input')).toBe(true);
+        });
+
+        it('suppresses "SyntaxError: Unexpected ..."', () => {
+            expect(isLowSignalFwd('SyntaxError: Unexpected token } in JSON at position 17')).toBe(true);
+        });
+
+        it('suppresses bare "at position N" stack trace fragments', () => {
+            expect(isLowSignalFwd('at position 1234')).toBe(true);
+        });
+
+        it('suppresses bare "line N column M" parse fragments', () => {
+            expect(isLowSignalFwd('line 3 column 12')).toBe(true);
+        });
+    });
+
+    describe('timeout marker noise (the Hermes empty FWD loop)', () => {
+        it('suppresses "[Hermes 回應超時]"', () => {
+            expect(isLowSignalFwd('[Hermes 回應超時]')).toBe(true);
+        });
+
+        it('suppresses "[#3 回應超時]"', () => {
+            expect(isLowSignalFwd('[#3 回應超時]')).toBe(true);
+        });
+
+        it('suppresses "[Hermes response timeout]" (case-insensitive)', () => {
+            expect(isLowSignalFwd('[Hermes response timeout]')).toBe(true);
+            expect(isLowSignalFwd('[HERMES RESPONSE TIMEOUT]')).toBe(true);
+        });
+
+        it('does NOT suppress a timeout marker that comes with extra context', () => {
+            expect(isLowSignalFwd('[Hermes 回應超時] retrying with backoff=30s, attempt=3')).toBe(false);
+        });
+    });
+
+    describe('one-word ack noise (the ack-of-ack loop)', () => {
+        it('suppresses bare "ack" / "ACK" / "ack."', () => {
+            expect(isLowSignalFwd('ack')).toBe(true);
+            expect(isLowSignalFwd('ACK')).toBe(true);
+            expect(isLowSignalFwd('ack.')).toBe(true);
+            expect(isLowSignalFwd('ack!')).toBe(true);
+        });
+
+        it('suppresses bare "ok" / "received" / "noted" / "ping" / "pong"', () => {
+            expect(isLowSignalFwd('ok')).toBe(true);
+            expect(isLowSignalFwd('received')).toBe(true);
+            expect(isLowSignalFwd('noted')).toBe(true);
+            expect(isLowSignalFwd('ping')).toBe(true);
+            expect(isLowSignalFwd('pong')).toBe(true);
+        });
+
+        it('does NOT suppress an ack that carries real status', () => {
+            expect(isLowSignalFwd('ack — PR #3015 merged, deploying to prod now')).toBe(false);
+        });
+    });
+
+    describe('real messages must pass through (no false positives)', () => {
+        it('lets normal status reports through', () => {
+            expect(isLowSignalFwd('Card 7a03c4 moved to in_progress, ETA 2h')).toBe(false);
+        });
+
+        it('lets task completions through', () => {
+            expect(isLowSignalFwd('PR #3015 ready for review — orgChartForward FWD noise filter')).toBe(false);
+        });
+
+        it('lets multi-line bodies through', () => {
+            expect(isLowSignalFwd('Heads up:\nMac_E container restarted at 12:00, all jobs back online.')).toBe(false);
+        });
+
+        it('lets Chinese sentences through', () => {
+            expect(isLowSignalFwd('已完成 Android i18n it locale × 845 keys 的機翻填補，待你 review。')).toBe(false);
+        });
+
+        it('lets a long ack with context through', () => {
+            expect(isLowSignalFwd('收到，正在處理 card_a60568c，預計 30 分鐘內回報')).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Adds noise filter to `orgChartForward()` so JSON parse errors, bare `[Hermes 回應超時]` timeout markers, and one-word acks no longer flood the user's channel via the silent org-chart push path.
- Fixes card_0cd7cffe5cf26fa024b00c25 (Mac_E P0 — 6.9h stale, escalated P3→P1→P0) **and** card_a60568c129a56340db4f5810 (Hermes #5 empty-FWD loop — same root cause).
- Extracted filter to `backend/org-fwd-filter.js` so it has direct jest coverage without booting the whole 17k-line `index.js`.

## Root cause
`orgChartForward()` at backend/index.js:17370 walked the org chart and pushed any non-empty, non-already-prefixed message up to the superior entity with `unifiedPush(..., 'org_forward', ...)`. No content filter. When a sibling bot's webhook crashed and emitted `Unexpected non-whitespace character after JSON at position N`, or Hermes's wrapper emitted a bare `[Hermes 回應超時]` heartbeat, those went straight to the user as `[📢 FWD from #N] <noise>` with no context.

## What's filtered (drop)
- Bodies < 12 chars after trim
- JSON parse error fragments: `Unexpected (non-whitespace character after JSON|token … in JSON|end of JSON …)`, `SyntaxError: Unexpected …`, bare `at position N`, bare `line N column M`
- Bare timeout markers: `[<≤40 chars> 回應超時]`, `[<…> response timeout]` (case-insensitive) — only if the body is **only** that marker; markers carrying extra context pass
- Bare one-word acks: `ping`, `pong`, `ack`, `ok`, `received`, `noted` (with optional `.` / `!`)

## What still passes (no false positives, verified in tests)
- Multi-line status, real reports, Chinese sentences, ack-with-status, timeout marker + retry detail

## Test plan
- [x] `npx jest --testPathPattern=tests/jest/org-fwd-filter` → 21/21 pass locally
- [x] `node --check backend/index.js`
- [x] Smoke `require('./org-fwd-filter')` confirms exports + behavior
- [ ] CI green
- [ ] Post-merge: watch channel for next 30 min — expect zero `[📢 FWD] Unexpected …` and zero bare `[Hermes 回應超時]`

## Observability
Suppressed forwards are logged via `serverLog('info', 'org_forward_skip', …)` with the first 60 chars of the dropped message so we can audit false positives via the standard `/api/logs` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)