### PR TITLE
fix(point-edit): graceful shutdown + per-route rate limit + sanitizer reaffirm

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1469,19 +1469,25 @@ setInterval(async () => {
 }, CLEANUP_INTERVAL).unref();
 
 // Graceful shutdown - save data before exit
-process.on('SIGINT', async () => {
-    console.log('[Persistence] Received SIGINT, saving data before exit...');
+async function gracefulShutdown(signal) {
+    console.log(`[Persistence] Received ${signal}, saving data before exit...`);
     await saveData();
     if (usePostgreSQL) await db.closeDatabase();
+    // Close the point-edit headless Chromium so the playwright subprocess
+    // doesn't leak past the parent on Railway redeploys / SIGTERM.
+    try {
+        const pe = require('./point-edit-resolver');
+        if (pe && typeof pe.closeBrowser === 'function') {
+            await pe.closeBrowser();
+        }
+    } catch (err) {
+        console.error('[Shutdown] point-edit closeBrowser failed:', err.message);
+    }
     process.exit(0);
-});
+}
 
-process.on('SIGTERM', async () => {
-    console.log('[Persistence] Received SIGTERM, saving data before exit...');
-    await saveData();
-    if (usePostgreSQL) await db.closeDatabase();
-    process.exit(0);
-});
+process.on('SIGINT', () => gracefulShutdown('SIGINT'));
+process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
 
 // Initialize persistence on startup (async)
 initPersistence().catch(err => {

--- a/backend/point-edit-resolver.js
+++ b/backend/point-edit-resolver.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const express = require('express');
+const rateLimit = require('express-rate-limit');
 const { chromium } = require('playwright');
 
 const router = express.Router();
@@ -22,6 +23,27 @@ const ALLOWED_HOSTS = (process.env.POINT_EDIT_ALLOWED_HOSTS || DEFAULT_ALLOWED_H
     .filter(Boolean);
 const BROWSER_LAUNCH_TIMEOUT_MS = 30000;
 const PAGE_NAV_TIMEOUT_MS = 20000;
+
+// Per-route rate limit: resolveCoordinate boots a headless Playwright page per
+// request — much heavier than typical API calls — so the global 100/min cap
+// is too loose. Default 15/min/IP; operators can tune via env. Disabled when
+// RATE_LIMIT_DISABLED=1 (used in dev + jest).
+const RESOLVE_RATE_LIMIT_MAX = Math.max(
+    1,
+    Number(process.env.POINT_EDIT_RATE_LIMIT_PER_MIN || 15)
+);
+const resolveCoordinateLimiter = rateLimit({
+    windowMs: 60 * 1000,
+    max: RESOLVE_RATE_LIMIT_MAX,
+    standardHeaders: true,
+    legacyHeaders: false,
+    skip: () => process.env.RATE_LIMIT_DISABLED === '1',
+    message: {
+        success: false,
+        error: 'rate_limited',
+        message: `Point-edit resolve-coordinate rate limit exceeded (max ${RESOLVE_RATE_LIMIT_MAX}/min per IP).`,
+    },
+});
 
 let _browserPromise = null;
 async function getBrowser() {
@@ -164,6 +186,11 @@ const SCRIPT_BLOCK_RE = /<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi;
 const ON_ATTR_RE = /\s+on[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi;
 const JAVASCRIPT_URL_RE = /(href|src)\s*=\s*(?:"\s*javascript:[^"]*"|'\s*javascript:[^']*'|javascript:[^\s>]+)/gi;
 
+// Strips obvious script vectors so this outerHTML is safe to embed in a JSON
+// response that callers render as TEXT (debug panel, copy-paste, syntax
+// highlight). If a future caller ever passes this string back into the DOM via
+// innerHTML / dangerouslySetInnerHTML, swap to sanitize-html or DOMPurify —
+// regex strips are not a full XSS sanitizer.
 function sanitizeOuterHTML(html) {
     if (typeof html !== 'string') return '';
     return html
@@ -260,7 +287,7 @@ async function resolveCoordinate(input) {
     };
 }
 
-router.post('/resolve-coordinate', async (req, res) => {
+router.post('/resolve-coordinate', resolveCoordinateLimiter, async (req, res) => {
     const parsed = validateCoordinateBody(req.body || {});
     if (parsed.error) {
         if (parsed.error === 'unsupported_origin') {

--- a/backend/tests/jest/point-edit-resolver-hardening.test.js
+++ b/backend/tests/jest/point-edit-resolver-hardening.test.js
@@ -1,0 +1,93 @@
+/**
+ * Hardening tests for point-edit-resolver — per-route rate limit + graceful
+ * shutdown wiring + sanitizer reaffirm. Follow-up to PR #3010 (Track B v2)
+ * supervisor review (card_d9b6a67dec4756296028d4bf).
+ */
+
+'use strict';
+
+// Force the limiter on for these tests (other test files set RATE_LIMIT_DISABLED=1).
+delete process.env.RATE_LIMIT_DISABLED;
+process.env.POINT_EDIT_RATE_LIMIT_PER_MIN = '3';
+
+jest.mock('playwright', () => {
+    const _browser = {
+        newContext: jest.fn().mockResolvedValue({
+            route: jest.fn().mockResolvedValue(undefined),
+            newPage: jest.fn().mockResolvedValue({
+                goto: jest.fn().mockResolvedValue(undefined),
+                evaluate: jest.fn().mockResolvedValue(null),
+            }),
+            close: jest.fn().mockResolvedValue(undefined),
+        }),
+        close: jest.fn().mockResolvedValue(undefined),
+    };
+    return {
+        chromium: { launch: jest.fn().mockResolvedValue(_browser) },
+        __mock: { _browser },
+    };
+});
+
+const express = require('express');
+const request = require('supertest');
+
+// Require AFTER setting env so the limiter picks up max=3.
+const resolver = require('../../point-edit-resolver');
+
+function makeApp() {
+    const app = express();
+    // express-rate-limit needs to see real-looking IPs; supertest defaults
+    // to 127.0.0.1 which is fine.
+    app.set('trust proxy', false);
+    app.use(express.json());
+    app.use('/api/point-edit', resolver.router);
+    return app;
+}
+
+afterAll(async () => {
+    await resolver.closeBrowser();
+});
+
+describe('per-route rate limiter on POST /api/point-edit/resolve-coordinate', () => {
+    test('returns 429 after the 3rd request in the same window (limit=3 via env)', async () => {
+        const app = makeApp();
+        const body = {
+            x: 10,
+            y: 10,
+            viewportW: 800,
+            viewportH: 600,
+            url: 'https://eclawbot.com/portal/info.html',
+        };
+
+        // First 3 should NOT be 429. They may be 404 (no element resolved
+        // because playwright is mocked to return null) or 200 — both are
+        // "passed the limiter" outcomes.
+        for (let i = 0; i < 3; i++) {
+            const r = await request(app).post('/api/point-edit/resolve-coordinate').send(body);
+            expect(r.status).not.toBe(429);
+        }
+
+        // 4th request from the same supertest client (same IP) should hit the limit.
+        const r4 = await request(app).post('/api/point-edit/resolve-coordinate').send(body);
+        expect(r4.status).toBe(429);
+        expect(r4.body).toMatchObject({ success: false, error: 'rate_limited' });
+        expect(r4.body.message).toMatch(/3\/min/);
+    });
+});
+
+describe('closeBrowser export survives shape changes', () => {
+    test('still exported and callable without throwing', async () => {
+        expect(typeof resolver.closeBrowser).toBe('function');
+        await expect(resolver.closeBrowser()).resolves.toBeUndefined();
+    });
+});
+
+describe('sanitizeOuterHTML — reaffirm scope (no regression vs PR #3010)', () => {
+    test('still strips script / on* / javascript: vectors', () => {
+        const dirty = '<div onclick="x()"><a href="javascript:alert(1)">y</a><script>1</script></div>';
+        const clean = resolver.sanitizeOuterHTML(dirty);
+        expect(clean).not.toMatch(/onclick/i);
+        expect(clean).not.toMatch(/javascript:/i);
+        expect(clean).not.toMatch(/<script/i);
+    });
+});


### PR DESCRIPTION
## Summary

Hardening follow-up to PR #3010 (Track B v2) supervisor review on card_d9b6a67dec4756296028d4bf.

- **Graceful shutdown** — refactor SIGINT/SIGTERM handlers into shared `gracefulShutdown(signal)` that also calls `pointEditResolver.closeBrowser()` before `process.exit(0)`. Without this, the Playwright chromium singleton leaks on every Railway redeploy.
- **Per-route rate limit** — `express-rate-limit` on POST `/api/point-edit/resolve-coordinate`, default 15/min/IP, env-tunable via `POINT_EDIT_RATE_LIMIT_PER_MIN`. `RATE_LIMIT_DISABLED=1` skip preserved for the existing test suite. 4th request in same window returns 429 with `{success:false, error:'rate_limited', message:'…max 15/min per IP…'}`.
- **sanitizer scope reaffirm** — `sanitizeOuterHTML` is still safe for the outerHTML-preview path it serves. Added a WARN comment so the next caller who reaches for innerHTML / DOMParser knows to swap in DOMPurify and re-run the XSS vector matrix instead of trusting the regex layer.

## Test plan
- [x] `npx jest --testPathPattern=tests/jest/point-edit-resolver-hardening` — 3/3 pass (rate limiter 429, closeBrowser still exported, sanitizer no regression)
- [x] `node --check backend/index.js` + `node --check backend/point-edit-resolver.js`
- [ ] Post-merge: Railway redeploy + sanity probe on `/api/point-edit/resolve-coordinate` (200/404 path, then 429 after limit)

Card: card_d9b6a67dec4756296028d4bf