### PR TITLE
fix(openclaw-channel): ack target-mode healthcheck nonces

### DIFF
--- a/openclaw-channel-eclaw/README.md
+++ b/openclaw-channel-eclaw/README.md
@@ -302,6 +302,8 @@ ACK failures.
 **Countermeasure:**
 - The webhook now detects `ECLAW_HEALTHCHECK <nonce>` before dispatching to the
   OpenClaw agent and replies through the E-Claw channel with `ACK <nonce>`.
+  Nonces may contain letters, numbers, underscores, or hyphens, matching the
+  monitor/browser UI target-mode probes.
 - Model-health checks still go through the agent so model/reasoning policy is
   validated independently from transport health.
 - After upgrading the plugin in an OpenClaw runtime, restart the owning

--- a/openclaw-channel-eclaw/src/webhook-handler.ts
+++ b/openclaw-channel-eclaw/src/webhook-handler.ts
@@ -52,7 +52,7 @@ export function createWebhookHandler(
       const client = getClient(accountId);
       const conversationId = msg.conversationId || `${msg.deviceId}:${msg.entityId}`;
 
-      const directAck = String(msg.text || '').match(/^ECLAW_HEALTHCHECK\s+([A-Za-z0-9]+)\b/m);
+      const directAck = String(msg.text || '').match(/^ECLAW_HEALTHCHECK\s+([A-Za-z0-9_-]+)(?=\s|$)/m);
       if (directAck) {
         if (client) {
           await client.sendMessage(`ACK ${directAck[1]}`, 'IDLE');

--- a/openclaw-channel-eclaw/test/webhook-handler.test.ts
+++ b/openclaw-channel-eclaw/test/webhook-handler.test.ts
@@ -31,13 +31,13 @@ describe('createWebhookHandler', () => {
       body: {
         deviceId: 'device-1',
         entityId: 0,
-        text: 'ECLAW_HEALTHCHECK abc123',
+        text: 'ECLAW_HEALTHCHECK abc_123-XYZ',
       },
     }, res);
 
     expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'application/json' });
     expect(res.end).toHaveBeenCalledWith(JSON.stringify({ ok: true }));
-    expect(client.sendMessage).toHaveBeenCalledWith('ACK abc123', 'IDLE');
+    expect(client.sendMessage).toHaveBeenCalledWith('ACK abc_123-XYZ', 'IDLE');
     expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- allow target-mode healthcheck nonces with underscores or hyphens to use the direct ACK path
- keep browser/API health probes out of long-running OpenClaw agent work
- document the nonce format in the OpenClaw EClaw channel README

## Verification
- npm test
- npm run build
- synced built channel plugin to #1 project-f and #3 project-e runtime extensions
- restarted #1/#3 OpenClaw containers
- verified #1/#3 local and public health
- verified #1-#6 user-to-bot ACK replies
- verified Chrome Web chat UI ACK for #1 and #3