### PR TITLE
fix(android): wallpaper countdown can show both 5h+weekly + label source + free drag (card_feef9f6ef1b9ed6c3bbd3cc2)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/WallpaperPreviewActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/WallpaperPreviewActivity.kt
@@ -8,7 +8,7 @@ import android.view.View
 import android.widget.CheckBox
 import android.widget.ImageButton
 import android.widget.LinearLayout
-import android.widget.RadioGroup
+import android.widget.TextView
 import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
@@ -46,7 +46,8 @@ class WallpaperPreviewActivity : AppCompatActivity() {
     private lateinit var checkUsageCodex: CheckBox
     private lateinit var checkUsageSession: CheckBox
     private lateinit var checkUsageWeekly: CheckBox
-    private lateinit var radioResetWindow: RadioGroup
+    private lateinit var checkReset5h: CheckBox
+    private lateinit var checkResetWeekly: CheckBox
     private lateinit var btnSelectPhoto: MaterialButton
     private lateinit var btnReset: MaterialButton
     private lateinit var btnSetWallpaper: MaterialButton
@@ -54,6 +55,10 @@ class WallpaperPreviewActivity : AppCompatActivity() {
 
     private lateinit var topBar: LinearLayout
     private lateinit var bottomControls: LinearLayout
+    private lateinit var settingsCollapseHandle: LinearLayout
+    private lateinit var settingsCollapsibleContent: LinearLayout
+    private lateinit var settingsCollapseIndicator: TextView
+    private var settingsCollapsed: Boolean = false
 
     private val api = NetworkModule.api
     private val deviceManager by lazy { DeviceManager.getInstance(this) }
@@ -133,13 +138,17 @@ class WallpaperPreviewActivity : AppCompatActivity() {
         checkUsageCodex = findViewById(R.id.checkUsageCodex)
         checkUsageSession = findViewById(R.id.checkUsageSession)
         checkUsageWeekly = findViewById(R.id.checkUsageWeekly)
-        radioResetWindow = findViewById(R.id.radioResetWindow)
+        checkReset5h = findViewById(R.id.checkReset5h)
+        checkResetWeekly = findViewById(R.id.checkResetWeekly)
         btnSelectPhoto = findViewById(R.id.btnSelectPhoto)
         btnReset = findViewById(R.id.btnReset)
         btnSetWallpaper = findViewById(R.id.btnSetWallpaper)
         btnBack = findViewById(R.id.btnBack)
         topBar = findViewById(R.id.topBar)
         bottomControls = findViewById(R.id.bottomControls)
+        settingsCollapseHandle = findViewById(R.id.settingsCollapseHandle)
+        settingsCollapsibleContent = findViewById(R.id.settingsCollapsibleContent)
+        settingsCollapseIndicator = findViewById(R.id.settingsCollapseIndicator)
 
         // Initialize switch states from preferences
         previewView.setCompanionRepository(companionRepository)
@@ -155,13 +164,8 @@ class WallpaperPreviewActivity : AppCompatActivity() {
         checkUsageCodex.isChecked = layoutPrefs.usageOverlayShowCodex
         checkUsageSession.isChecked = layoutPrefs.usageOverlayShowSession
         checkUsageWeekly.isChecked = layoutPrefs.usageOverlayShowWeekly
-        radioResetWindow.check(
-            when (layoutPrefs.wallpaperResetWindow) {
-                LayoutPreferences.RESET_WINDOW_5H -> R.id.radioReset5h
-                LayoutPreferences.RESET_WINDOW_WEEKLY -> R.id.radioResetWeekly
-                else -> R.id.radioResetOff
-            }
-        )
+        checkReset5h.isChecked = layoutPrefs.wallpaperResetShowFiveHour
+        checkResetWeekly.isChecked = layoutPrefs.wallpaperResetShowWeekly
 
         // Show/hide photo button based on background switch
         updatePhotoButtonVisibility()
@@ -265,14 +269,33 @@ class WallpaperPreviewActivity : AppCompatActivity() {
         checkUsageSession.setOnCheckedChangeListener(usageItemListener)
         checkUsageWeekly.setOnCheckedChangeListener(usageItemListener)
 
-        radioResetWindow.setOnCheckedChangeListener { _, checkedId ->
-            layoutPrefs.wallpaperResetWindow = when (checkedId) {
-                R.id.radioReset5h -> LayoutPreferences.RESET_WINDOW_5H
-                R.id.radioResetWeekly -> LayoutPreferences.RESET_WINDOW_WEEKLY
-                else -> LayoutPreferences.RESET_WINDOW_OFF
+        val resetItemListener = android.widget.CompoundButton.OnCheckedChangeListener { button, isChecked ->
+            when (button.id) {
+                R.id.checkReset5h -> layoutPrefs.wallpaperResetShowFiveHour = isChecked
+                R.id.checkResetWeekly -> layoutPrefs.wallpaperResetShowWeekly = isChecked
             }
             previewView.invalidate()
         }
+        checkReset5h.setOnCheckedChangeListener(resetItemListener)
+        checkResetWeekly.setOnCheckedChangeListener(resetItemListener)
+
+        settingsCollapseHandle.setOnClickListener {
+            setSettingsCollapsed(!settingsCollapsed)
+        }
+    }
+
+    private fun setSettingsCollapsed(collapsed: Boolean) {
+        settingsCollapsed = collapsed
+        settingsCollapsibleContent.visibility = if (collapsed) View.GONE else View.VISIBLE
+        settingsCollapseIndicator.text = getString(
+            if (collapsed) R.string.wallpaper_settings_collapse_caret_up
+            else R.string.wallpaper_settings_collapse_caret_down
+        )
+        settingsCollapseIndicator.contentDescription = getString(
+            if (collapsed) R.string.wallpaper_settings_expand_action
+            else R.string.wallpaper_settings_collapse_action
+        )
+        bottomControls.post { updatePreviewUsageOverlayInsets() }
     }
 
     private fun updatePhotoButtonVisibility() {
@@ -285,9 +308,8 @@ class WallpaperPreviewActivity : AppCompatActivity() {
         checkUsageCodex.isEnabled = enabled
         checkUsageSession.isEnabled = enabled
         checkUsageWeekly.isEnabled = enabled
-        for (i in 0 until radioResetWindow.childCount) {
-            radioResetWindow.getChildAt(i).isEnabled = enabled
-        }
+        checkReset5h.isEnabled = enabled
+        checkResetWeekly.isEnabled = enabled
     }
 
     private fun updatePreviewUsageOverlayInsets() {

--- a/app/src/main/java/com/hank/clawlive/data/local/LayoutPreferences.kt
+++ b/app/src/main/java/com/hank/clawlive/data/local/LayoutPreferences.kt
@@ -359,15 +359,65 @@ class LayoutPreferences private constructor(context: Context) {
             prefs.edit().putBoolean(KEY_USAGE_OVERLAY_SHOW_WEEKLY, value).apply()
         }
 
-    var wallpaperResetWindow: String
-        get() = prefs.getString(KEY_WALLPAPER_RESET_WINDOW, RESET_WINDOW_OFF) ?: RESET_WINDOW_OFF
-        set(value) {
-            val normalized = when (value) {
-                RESET_WINDOW_5H, RESET_WINDOW_WEEKLY -> value
-                else -> RESET_WINDOW_OFF
+    var wallpaperResetShowFiveHour: Boolean
+        get() {
+            if (prefs.contains(KEY_WALLPAPER_RESET_SHOW_5H)) {
+                return prefs.getBoolean(KEY_WALLPAPER_RESET_SHOW_5H, false)
             }
-            prefs.edit().putString(KEY_WALLPAPER_RESET_WINDOW, normalized).apply()
+            if (prefs.contains(KEY_WALLPAPER_RESET_WINDOW)) {
+                return legacyResetWindowValue() in listOf(RESET_WINDOW_5H, RESET_WINDOW_5H_WEEKLY)
+            }
+            // New user with no prefs ever set: default both 5h and Weekly to ON.
+            // Why: a fresh user should see countdowns by default; the only way to
+            // get both off is an explicit user toggle, not a silent first-launch state.
+            return true
         }
+        set(value) {
+            writeResetWindowSelection(value, wallpaperResetShowWeekly)
+        }
+
+    var wallpaperResetShowWeekly: Boolean
+        get() {
+            if (prefs.contains(KEY_WALLPAPER_RESET_SHOW_WEEKLY)) {
+                return prefs.getBoolean(KEY_WALLPAPER_RESET_SHOW_WEEKLY, false)
+            }
+            if (prefs.contains(KEY_WALLPAPER_RESET_WINDOW)) {
+                return legacyResetWindowValue() in listOf(RESET_WINDOW_WEEKLY, RESET_WINDOW_5H_WEEKLY)
+            }
+            return true
+        }
+        set(value) {
+            writeResetWindowSelection(wallpaperResetShowFiveHour, value)
+        }
+
+    var wallpaperResetWindow: String
+        get() = resetWindowValue(wallpaperResetShowFiveHour, wallpaperResetShowWeekly)
+        set(value) {
+            val showFiveHour = value in listOf(RESET_WINDOW_5H, RESET_WINDOW_5H_WEEKLY)
+            val showWeekly = value in listOf(RESET_WINDOW_WEEKLY, RESET_WINDOW_5H_WEEKLY)
+            writeResetWindowSelection(showFiveHour, showWeekly)
+        }
+
+    private fun legacyResetWindowValue(): String {
+        return prefs.getString(KEY_WALLPAPER_RESET_WINDOW, RESET_WINDOW_OFF) ?: RESET_WINDOW_OFF
+    }
+
+    private fun writeResetWindowSelection(showFiveHour: Boolean, showWeekly: Boolean) {
+        prefs.edit()
+            .putBoolean(KEY_WALLPAPER_RESET_SHOW_5H, showFiveHour)
+            .putBoolean(KEY_WALLPAPER_RESET_SHOW_WEEKLY, showWeekly)
+            .putString(KEY_WALLPAPER_RESET_WINDOW, resetWindowValue(showFiveHour, showWeekly))
+            .apply()
+    }
+
+    private fun resetWindowValue(showFiveHour: Boolean, showWeekly: Boolean): String {
+        return when {
+            showFiveHour && showWeekly -> RESET_WINDOW_5H_WEEKLY
+            showFiveHour -> RESET_WINDOW_5H
+            showWeekly -> RESET_WINDOW_WEEKLY
+            else -> RESET_WINDOW_OFF
+        }
+    }
 
     companion object {
         private const val PREFS_NAME = "entity_layout_prefs"
@@ -392,10 +442,13 @@ class LayoutPreferences private constructor(context: Context) {
         private const val KEY_USAGE_OVERLAY_SHOW_SESSION = "usage_overlay_show_session"
         private const val KEY_USAGE_OVERLAY_SHOW_WEEKLY = "usage_overlay_show_weekly"
         private const val KEY_WALLPAPER_RESET_WINDOW = "wallpaper_reset_window"
+        private const val KEY_WALLPAPER_RESET_SHOW_5H = "wallpaper_reset_show_5h"
+        private const val KEY_WALLPAPER_RESET_SHOW_WEEKLY = "wallpaper_reset_show_weekly"
 
         const val RESET_WINDOW_OFF = "off"
         const val RESET_WINDOW_5H = "5h"
         const val RESET_WINDOW_WEEKLY = "weekly"
+        const val RESET_WINDOW_5H_WEEKLY = "5h_weekly"
 
         // Display mode constants
         const val MODE_SINGLE = 1

--- a/app/src/main/java/com/hank/clawlive/engine/UsageOverlayRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/UsageOverlayRenderer.kt
@@ -5,12 +5,15 @@ import android.graphics.Canvas
 import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.RectF
+import android.os.Build
 import android.text.TextPaint
 import com.hank.clawlive.R
 import com.hank.clawlive.data.local.LayoutPreferences
 import com.hank.clawlive.data.local.UsageOverlayPosition
 import com.hank.clawlive.data.model.UsageSnapshotLatest
+import java.text.SimpleDateFormat
 import java.util.Calendar
+import java.util.Date
 import java.util.Locale
 import kotlin.math.roundToInt
 
@@ -194,7 +197,7 @@ class UsageOverlayRenderer(
         val lines = mutableListOf(context.getString(R.string.wallpaper_usage_overlay_title))
         if (snapshot == null) {
             lines.add(context.getString(R.string.wallpaper_usage_overlay_syncing))
-            formatResetCountdownLine(snapshot)?.let(lines::add)
+            lines.addAll(formatResetCountdownLines(snapshot))
             return lines
         }
 
@@ -220,33 +223,50 @@ class UsageOverlayRenderer(
             lines.add(context.getString(R.string.wallpaper_usage_overlay_syncing))
         }
 
-        formatResetCountdownLine(snapshot)?.let(lines::add)
+        lines.addAll(formatResetCountdownLines(snapshot))
         return lines
     }
 
-    private fun formatResetCountdownLine(snapshot: UsageSnapshotLatest?): String? {
-        return when (layoutPrefs.wallpaperResetWindow) {
-            LayoutPreferences.RESET_WINDOW_5H -> {
-                val resetsAt = nextFiveHourResetEpochSec(snapshot) ?: return null
-                val hhmm = formatHourMinute((resetsAt * 1000.0).toLong())
-                context.getString(R.string.wallpaper_reset_window_5h_next, hhmm)
-            }
-            LayoutPreferences.RESET_WINDOW_WEEKLY -> {
-                val resetsAt = nextWeeklyResetEpochMillis()
-                val mondayHhmm = formatWeeklyReset(resetsAt)
-                context.getString(R.string.wallpaper_reset_window_weekly_next, mondayHhmm)
-            }
-            else -> null
+    private fun formatResetCountdownLines(snapshot: UsageSnapshotLatest?): List<String> {
+        val lines = mutableListOf<String>()
+        if (layoutPrefs.wallpaperResetShowFiveHour) {
+            fiveHourResetCandidates(snapshot)
+                .filter { isEngineVisibleForReset(it.engineKey) }
+                .forEach { reset ->
+                    val hhmm = formatHourMinute((reset.resetsAtSec * 1000.0).toLong())
+                    lines.add(context.getString(R.string.wallpaper_reset_window_5h_next, reset.engineLabel, hhmm))
+                }
         }
+        if (layoutPrefs.wallpaperResetShowWeekly) {
+            val resetsAt = nextWeeklyResetEpochMillis()
+            val weeklyTime = formatWeeklyReset(resetsAt)
+            lines.add(context.getString(R.string.wallpaper_reset_window_weekly_next, weeklyTime))
+        }
+        return lines
     }
 
-    private fun nextFiveHourResetEpochSec(snapshot: UsageSnapshotLatest?): Double? {
-        if (snapshot == null) return null
+    private fun fiveHourResetCandidates(snapshot: UsageSnapshotLatest?): List<ResetCandidate> {
+        if (snapshot == null) return emptyList()
         val claudeReset = snapshot.claude?.live?.rateLimits?.fiveHour?.resetsAt
         val codexReset = snapshot.codex?.rateLimits?.fiveHourResetsAt
         val nowSec = System.currentTimeMillis() / 1000.0
-        val candidates = listOfNotNull(claudeReset, codexReset).filter { it > nowSec }
-        return candidates.minOrNull()
+        return listOfNotNull(
+            claudeReset?.let {
+                ResetCandidate(ENGINE_KEY_CLAUDE, context.getString(R.string.wallpaper_usage_engine_claude), it)
+            },
+            codexReset?.let {
+                ResetCandidate(ENGINE_KEY_CODEX, context.getString(R.string.wallpaper_usage_engine_codex), it)
+            }
+        ).filter { it.resetsAtSec > nowSec }
+            .sortedBy { it.resetsAtSec }
+    }
+
+    private fun isEngineVisibleForReset(engineKey: String): Boolean {
+        return when (engineKey) {
+            ENGINE_KEY_CLAUDE -> layoutPrefs.usageOverlayShowClaude
+            ENGINE_KEY_CODEX -> layoutPrefs.usageOverlayShowCodex
+            else -> true
+        }
     }
 
     private fun nextWeeklyResetEpochMillis(): Long {
@@ -263,23 +283,21 @@ class UsageOverlayRenderer(
     }
 
     private fun formatHourMinute(epochMillis: Long): String {
-        val cal = Calendar.getInstance().apply { timeInMillis = epochMillis }
-        return String.format(
-            Locale.US,
-            "%02d:%02d",
-            cal.get(Calendar.HOUR_OF_DAY),
-            cal.get(Calendar.MINUTE)
-        )
+        return SimpleDateFormat("HH:mm", currentLocale()).format(Date(epochMillis))
     }
 
     private fun formatWeeklyReset(epochMillis: Long): String {
-        val cal = Calendar.getInstance().apply { timeInMillis = epochMillis }
-        return String.format(
-            Locale.US,
-            "Mon %02d:%02d",
-            cal.get(Calendar.HOUR_OF_DAY),
-            cal.get(Calendar.MINUTE)
-        )
+        return SimpleDateFormat("EEE HH:mm", currentLocale()).format(Date(epochMillis))
+    }
+
+    private fun currentLocale(): Locale {
+        val configuration = context.resources.configuration
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            configuration.locales[0]
+        } else {
+            @Suppress("DEPRECATION")
+            configuration.locale ?: Locale.getDefault()
+        }
     }
 
     private fun formatEngineLine(label: String, sessionPct: Double?, weeklyPct: Double?): String? {
@@ -297,5 +315,16 @@ class UsageOverlayRenderer(
     private fun formatPct(value: Double?): String {
         val pct = value?.takeIf { it.isFinite() }?.roundToInt() ?: return "--"
         return "${pct.coerceIn(0, 999)}%"
+    }
+
+    private data class ResetCandidate(
+        val engineKey: String,
+        val engineLabel: String,
+        val resetsAtSec: Double
+    )
+
+    companion object {
+        private const val ENGINE_KEY_CLAUDE = "claude"
+        private const val ENGINE_KEY_CODEX = "codex"
     }
 }

--- a/app/src/main/java/com/hank/clawlive/engine/UsageOverlayRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/UsageOverlayRenderer.kt
@@ -191,36 +191,40 @@ class UsageOverlayRenderer(
     }
 
     fun buildLines(snapshot: UsageSnapshotLatest?): List<String> {
-        if (!layoutPrefs.usageOverlayShowClaude && !layoutPrefs.usageOverlayShowCodex) return emptyList()
-        if (!layoutPrefs.usageOverlayShowSession && !layoutPrefs.usageOverlayShowWeekly) return emptyList()
+        val usageSectionVisible =
+            (layoutPrefs.usageOverlayShowClaude || layoutPrefs.usageOverlayShowCodex) &&
+                (layoutPrefs.usageOverlayShowSession || layoutPrefs.usageOverlayShowWeekly)
+        val resetSectionVisible =
+            layoutPrefs.wallpaperResetShowFiveHour || layoutPrefs.wallpaperResetShowWeekly
+        if (!usageSectionVisible && !resetSectionVisible) return emptyList()
 
-        val lines = mutableListOf(context.getString(R.string.wallpaper_usage_overlay_title))
-        if (snapshot == null) {
-            lines.add(context.getString(R.string.wallpaper_usage_overlay_syncing))
-            lines.addAll(formatResetCountdownLines(snapshot))
-            return lines
-        }
-
-        if (layoutPrefs.usageOverlayShowClaude) {
-            formatEngineLine(
-                context.getString(R.string.wallpaper_usage_engine_claude),
-                snapshot.claude?.live?.fiveHourPct
-                    ?: snapshot.claude?.live?.rateLimits?.fiveHour?.usedPercentage,
-                snapshot.claude?.live?.sevenDayPct
-                    ?: snapshot.claude?.live?.rateLimits?.sevenDay?.usedPercentage
-            )?.let(lines::add)
-        }
-
-        if (layoutPrefs.usageOverlayShowCodex) {
-            formatEngineLine(
-                context.getString(R.string.wallpaper_usage_engine_codex),
-                snapshot.codex?.rateLimits?.fiveHourPct,
-                snapshot.codex?.rateLimits?.sevenDayPct
-            )?.let(lines::add)
-        }
-
-        if (lines.size == 1) {
-            lines.add(context.getString(R.string.wallpaper_usage_overlay_syncing))
+        val lines = mutableListOf<String>()
+        if (usageSectionVisible) {
+            lines.add(context.getString(R.string.wallpaper_usage_overlay_title))
+            if (snapshot == null) {
+                lines.add(context.getString(R.string.wallpaper_usage_overlay_syncing))
+            } else {
+                val usageLineStart = lines.size
+                if (layoutPrefs.usageOverlayShowClaude) {
+                    formatEngineLine(
+                        context.getString(R.string.wallpaper_usage_engine_claude),
+                        snapshot.claude?.live?.fiveHourPct
+                            ?: snapshot.claude?.live?.rateLimits?.fiveHour?.usedPercentage,
+                        snapshot.claude?.live?.sevenDayPct
+                            ?: snapshot.claude?.live?.rateLimits?.sevenDay?.usedPercentage
+                    )?.let(lines::add)
+                }
+                if (layoutPrefs.usageOverlayShowCodex) {
+                    formatEngineLine(
+                        context.getString(R.string.wallpaper_usage_engine_codex),
+                        snapshot.codex?.rateLimits?.fiveHourPct,
+                        snapshot.codex?.rateLimits?.sevenDayPct
+                    )?.let(lines::add)
+                }
+                if (lines.size == usageLineStart) {
+                    lines.add(context.getString(R.string.wallpaper_usage_overlay_syncing))
+                }
+            }
         }
 
         lines.addAll(formatResetCountdownLines(snapshot))
@@ -262,6 +266,11 @@ class UsageOverlayRenderer(
     }
 
     private fun isEngineVisibleForReset(engineKey: String): Boolean {
+        // When no engine is visible in the usage section, reset countdowns operate in
+        // standalone mode (no per-engine filter). This lets the user run reset-only mode
+        // — disable both Claude/Codex usage rows but still see the 5h countdown.
+        val anyEngineVisible = layoutPrefs.usageOverlayShowClaude || layoutPrefs.usageOverlayShowCodex
+        if (!anyEngineVisible) return true
         return when (engineKey) {
             ENGINE_KEY_CLAUDE -> layoutPrefs.usageOverlayShowClaude
             ENGINE_KEY_CODEX -> layoutPrefs.usageOverlayShowCodex

--- a/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
@@ -586,7 +586,7 @@ class WallpaperPreviewView @JvmOverloads constructor(
 
         when (event.actionMasked) {
             MotionEvent.ACTION_DOWN -> {
-                findUsageOverlayAtPosition(x, y)?.let { bounds ->
+                findUsageOverlayAtPosition(x, y, expanded = false)?.let { bounds ->
                     lockUsageOverlay()
                     draggingUsageOverlay = true
                     draggingEntityIndex = -1
@@ -605,6 +605,15 @@ class WallpaperPreviewView @JvmOverloads constructor(
                     val pos = entityPositions[entity.entityId] ?: Pair(0.5f, 0.5f)
                     dragOffsetX = pos.first * width - x
                     dragOffsetY = pos.second * height - y
+                    invalidate()
+                    return true
+                }
+
+                findUsageOverlayAtPosition(x, y, expanded = true)?.let { bounds ->
+                    lockUsageOverlay()
+                    draggingUsageOverlay = true
+                    usageOverlayDragOffsetX = bounds.centerX() - x
+                    usageOverlayDragOffsetY = bounds.centerY() - y
                     invalidate()
                     return true
                 }
@@ -705,7 +714,7 @@ class WallpaperPreviewView @JvmOverloads constructor(
 
         val focusX = pointerFocusX(event)
         val focusY = pointerFocusY(event)
-        findUsageOverlayAtPosition(focusX, focusY)?.let {
+        findUsageOverlayAtPosition(focusX, focusY, expanded = false)?.let {
             lockUsageOverlay()
             isScalingUsageOverlay = true
             isScaling = true
@@ -716,6 +725,14 @@ class WallpaperPreviewView @JvmOverloads constructor(
         val hitEntityIndex = findEntityAtPosition(focusX, focusY)
         if (lockEntity(hitEntityIndex)) {
             scalingEntityIndex = hitEntityIndex
+            isScaling = true
+            invalidate()
+            return true
+        }
+
+        findUsageOverlayAtPosition(focusX, focusY, expanded = true)?.let {
+            lockUsageOverlay()
+            isScalingUsageOverlay = true
             isScaling = true
             invalidate()
             return true
@@ -784,7 +801,8 @@ class WallpaperPreviewView @JvmOverloads constructor(
             
             // Scale hit radius with entity scale
             val entityScale = entityScales[entity.entityId] ?: 1.0f
-            val hitRadius = width * hitRadiusFactor * entityScale
+            val minHitRadius = 32f * resources.displayMetrics.density
+            val hitRadius = maxOf(width * hitRadiusFactor * entityScale, minHitRadius)
 
             val dx = touchX - entityX
             val dy = touchY - entityY
@@ -835,9 +853,22 @@ class WallpaperPreviewView @JvmOverloads constructor(
         onCustomLayoutEnabled?.invoke()
     }
 
-    private fun findUsageOverlayAtPosition(touchX: Float, touchY: Float): RectF? {
+    private fun findUsageOverlayAtPosition(touchX: Float, touchY: Float, expanded: Boolean): RectF? {
         val bounds = getUsageOverlayBoundsForTest() ?: return null
-        return if (bounds.contains(touchX, touchY)) bounds else null
+        val hitBounds = if (expanded) expandedUsageOverlayHitBounds(bounds) else bounds
+        return if (hitBounds.contains(touchX, touchY)) bounds else null
+    }
+
+    private fun expandedUsageOverlayHitBounds(bounds: RectF): RectF {
+        val density = resources.displayMetrics.density
+        val horizontalPad = 18f * density
+        val verticalPad = 18f * density
+        val minTouchTarget = 48f * density
+        val extraX = maxOf(horizontalPad, (minTouchTarget - bounds.width()) / 2f)
+        val extraY = maxOf(verticalPad, (minTouchTarget - bounds.height()) / 2f)
+        return RectF(bounds).apply {
+            inset(-extraX.coerceAtLeast(0f), -extraY.coerceAtLeast(0f))
+        }
     }
 
     fun getUsageOverlayBoundsForTest(): RectF? {

--- a/app/src/main/res/layout/activity_wallpaper_preview.xml
+++ b/app/src/main/res/layout/activity_wallpaper_preview.xml
@@ -50,8 +50,48 @@
         android:layout_height="wrap_content"
         android:layout_gravity="bottom"
         android:orientation="vertical"
-        android:paddingTop="16dp"
+        android:paddingTop="8dp"
         android:background="@drawable/gradient_bottom_fade">
+
+        <!-- Collapse/Expand Handle -->
+        <LinearLayout
+            android:id="@+id/settingsCollapseHandle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:background="?attr/selectableItemBackground"
+            android:paddingTop="4dp"
+            android:paddingBottom="4dp"
+            android:layout_marginBottom="4dp">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/wallpaper_settings_panel_label"
+                android:textColor="@android:color/white"
+                android:textSize="14sp"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/settingsCollapseIndicator"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/wallpaper_settings_collapse_caret_down"
+                android:textColor="@android:color/white"
+                android:textSize="16sp"
+                android:paddingStart="8dp"
+                android:paddingEnd="8dp"
+                android:contentDescription="@string/wallpaper_settings_collapse_action" />
+
+        </LinearLayout>
+
+        <LinearLayout
+            android:id="@+id/settingsCollapsibleContent"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical">
 
         <!-- Custom Layout Toggle -->
         <LinearLayout
@@ -200,25 +240,14 @@
                 android:textColor="@color/text_white_60"
                 android:textSize="12sp" />
 
-            <RadioGroup
-                android:id="@+id/radioResetWindow"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="2dp"
                 android:orientation="horizontal">
 
-                <RadioButton
-                    android:id="@+id/radioResetOff"
-                    android:layout_width="0dp"
-                    android:layout_height="48dp"
-                    android:layout_weight="1"
-                    android:buttonTint="@color/lobster_orange"
-                    android:text="@string/wallpaper_reset_window_off"
-                    android:textColor="@android:color/white"
-                    android:textSize="13sp" />
-
-                <RadioButton
-                    android:id="@+id/radioReset5h"
+                <CheckBox
+                    android:id="@+id/checkReset5h"
                     android:layout_width="0dp"
                     android:layout_height="48dp"
                     android:layout_weight="1"
@@ -227,8 +256,8 @@
                     android:textColor="@android:color/white"
                     android:textSize="13sp" />
 
-                <RadioButton
-                    android:id="@+id/radioResetWeekly"
+                <CheckBox
+                    android:id="@+id/checkResetWeekly"
                     android:layout_width="0dp"
                     android:layout_height="48dp"
                     android:layout_weight="1"
@@ -237,7 +266,7 @@
                     android:textColor="@android:color/white"
                     android:textSize="13sp" />
 
-            </RadioGroup>
+            </LinearLayout>
 
         </LinearLayout>
 
@@ -290,6 +319,8 @@
             android:textColor="@color/text_secondary"
             android:textSize="12sp"
             android:gravity="center" />
+
+        </LinearLayout>
 
     </LinearLayout>
 

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -790,6 +790,17 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="wallpaper_usage_window_session_label">Session</string>
     <string name="wallpaper_usage_window_weekly">7d</string>
     <string name="wallpaper_usage_window_weekly_label">Weekly</string>
+    <string name="wallpaper_reset_window_label">倒數時段</string>
+    <string name="wallpaper_reset_window_off">關閉</string>
+    <string name="wallpaper_reset_window_5h">5 小時</string>
+    <string name="wallpaper_reset_window_weekly">每週</string>
+    <string name="wallpaper_reset_window_5h_next">下個 5h 重置 (%1$s)：%2$s</string>
+    <string name="wallpaper_reset_window_weekly_next">下個每週重置：%1$s</string>
+    <string name="wallpaper_settings_panel_label">桌布設定</string>
+    <string name="wallpaper_settings_collapse_action">收起設定面板</string>
+    <string name="wallpaper_settings_expand_action">展開設定面板</string>
+    <string name="wallpaper_settings_collapse_caret_down">▼</string>
+    <string name="wallpaper_settings_collapse_caret_up">▲</string>
     <string name="web_portal">網頁入口</string>
     <string name="webhook_error_message">請將以下訊息貼給OpenClaw：\"webhook綁定有錯誤或是沒有使用POST /api/bot/register，請重新讀取\'公開webhook URL\'(gateway config) 以及重新讀取\'gateway token\'，立即呼叫 /api/bot/register: 用剛綁到的 deviceId/entityId/botSecret 再帶上 webhook_url、gateway token 把推播註冊好。\"</string>
     <string name="webhook_error_title">推播通知失敗</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -104,8 +104,13 @@
     <string name="wallpaper_reset_window_off">Off</string>
     <string name="wallpaper_reset_window_5h">5h</string>
     <string name="wallpaper_reset_window_weekly">Weekly</string>
-    <string name="wallpaper_reset_window_5h_next">Next 5h reset: %1$s</string>
+    <string name="wallpaper_reset_window_5h_next">Next 5h reset (%1$s): %2$s</string>
     <string name="wallpaper_reset_window_weekly_next">Next weekly reset: %1$s</string>
+    <string name="wallpaper_settings_panel_label">Wallpaper settings</string>
+    <string name="wallpaper_settings_collapse_action">Collapse settings panel</string>
+    <string name="wallpaper_settings_expand_action">Expand settings panel</string>
+    <string name="wallpaper_settings_collapse_caret_down">▼</string>
+    <string name="wallpaper_settings_collapse_caret_up">▲</string>
     <string name="back">Back</string>
     
     <!-- Layout Editor -->


### PR DESCRIPTION
## Summary

Address three UX issues from PR #3005 retro feedback (card `card_feef9f6ef1b9ed6c3bbd3cc2`):

### Issue 1 — Allow 5h + Weekly countdown simultaneously
- `LayoutPreferences.wallpaperResetShowFiveHour` / `wallpaperResetShowWeekly` getters now distinguish "explicit OFF" from "never set", so **fresh installs default both to ON**
- Legacy `wallpaperResetWindow` (mutex 4-state) values still migrate correctly: `5h_weekly` → both ON; `5h` → 5h only; `weekly` → weekly only; `off` → both OFF
- Existing users who explicitly disabled either window keep their setting

### Issue 2 — Label 5h reset countdown by engine source
- Replace single-pick `nextFiveHourReset()` with list-returning `fiveHourResetCandidates()`
- `UsageOverlayRenderer.formatResetCountdownLines()` now emits one line per engine (Claude/Codex) when both have data, using the existing parameterized `wallpaper_reset_window_5h_next` (`Next 5h reset (%1$s): %2$s`)
- New `engineKey` field on `ResetCandidate` + `isEngineVisibleForReset()` filter so toggling the Claude/Codex usage-overlay checkboxes also hides the matching reset line

### Issue 3 — Free drag in bottom half (previously blocked by settings panel)
- `WallpaperPreviewView`: drag bounds now use the screen rect with 48dp expanded hit-box (`expandedUsageOverlayHitBounds()`), so the overlay can be touched even inside the settings panel area
- `activity_wallpaper_preview.xml`: wrap settings content in `settingsCollapsibleContent`; new `settingsCollapseHandle` row (TextView label + ▼/▲ chevron) collapses the panel via View.GONE so the bottom half of the canvas becomes available for the overlay
- `WallpaperPreviewActivity`: handle click + collapse state; re-emit canvas insets when state changes

### i18n
- New EN strings (5): `wallpaper_settings_panel_label`, `wallpaper_settings_collapse_action`, `wallpaper_settings_expand_action`, `wallpaper_settings_collapse_caret_down`, `wallpaper_settings_collapse_caret_up`
- `wallpaper_reset_window_5h_next` format string changed from 1-arg → 2-arg (`%1$s` engine + `%2$s` time)
- zh-rTW: 11 backfilled (6 wallpaper_reset_window_* + 5 wallpaper_settings_*)
- Other 12 locales handled by separate Hermes MT card `card_7a03c40c`

## Test plan

- [x] `./gradlew :app:assembleDebug` — clean compile (15m 45s, no warnings on changed files)
- [ ] Set A — display combos
  - [ ] A1: both OFF — no reset countdown
  - [ ] A2: 5h only — Claude AND Codex lines visible
  - [ ] A3: weekly only — single weekly line
  - [ ] A4: both ON — Claude 5h + Codex 5h + weekly
- [ ] Set B — drag hit-box
  - [ ] B1: drag overlay to top-left corner
  - [ ] B2: drag to top-right
  - [ ] B3: drag to bottom-left (previously blocked by settings panel)
  - [ ] B4: drag to bottom-right (previously blocked by settings panel)

## Code review checklist

Self-review against `docs/code-review-checklist.md` will be posted after CI passes.