### PR TITLE
Fix portal auth inputs outside native forms

### DIFF
--- a/backend/public/portal/index.html
+++ b/backend/public/portal/index.html
@@ -263,7 +263,7 @@
         </div>
 
         <!-- Login Form -->
-        <div id="loginForm">
+        <form id="loginForm" onsubmit="doLogin();return false;">
             <div class="form-group">
                 <label class="form-label" for="loginEmail" data-i18n="login_label_email">Email</label>
                 <input type="email" class="form-input" id="loginEmail" data-i18n-placeholder="login_placeholder_email"
@@ -272,10 +272,10 @@
             <div class="form-group">
                 <label class="form-label" for="loginPassword" data-i18n="login_label_password">Password</label>
                 <input type="password" class="form-input" id="loginPassword" data-i18n-placeholder="login_placeholder_password"
-                    placeholder="Enter password" onkeydown="if(event.key==='Enter')doLogin()">
+                    placeholder="Enter password">
             </div>
             <div id="loginError" class="error-text" style="display:none"></div>
-            <button class="btn btn-primary btn-block" onclick="doLogin()" id="loginBtn" style="margin-top:16px"
+            <button type="submit" class="btn btn-primary btn-block" id="loginBtn" style="margin-top:16px"
                 data-i18n="login_btn_login">Login</button>
             <p style="text-align:center;margin-top:16px;font-size:13px;">
                 <a href="#" onclick="showTab('forgot');return false;" data-i18n="login_link_forgot">Forgot password?</a>
@@ -285,18 +285,18 @@
                 <span style="color:var(--text-secondary);font-size:13px;" data-i18n="login_or">or</span>
                 <div style="flex:1;height:1px;background:var(--card-border)"></div>
             </div>
-            <button onclick="doGoogleLogin()" style="width:100%;padding:10px 16px;border-radius:8px;border:1px solid var(--card-border);background:var(--card);color:var(--text);cursor:pointer;display:flex;align-items:center;justify-content:center;gap:10px;font-size:14px;margin-bottom:8px;">
+            <button type="button" onclick="doGoogleLogin()" style="width:100%;padding:10px 16px;border-radius:8px;border:1px solid var(--card-border);background:var(--card);color:var(--text);cursor:pointer;display:flex;align-items:center;justify-content:center;gap:10px;font-size:14px;margin-bottom:8px;">
                 <svg width="18" height="18" viewBox="0 0 24 24"><path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.2 3.32v2.77h3.57c2.08-1.92 3.27-4.74 3.27-8.1z"/><path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/><path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"/><path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/></svg>
                 <span data-i18n="login_btn_google">Sign in with Google</span>
             </button>
-            <button onclick="doFacebookLogin()" style="width:100%;padding:10px 16px;border-radius:8px;border:1px solid var(--card-border);background:var(--card);color:var(--text);cursor:pointer;display:flex;align-items:center;justify-content:center;gap:10px;font-size:14px;">
+            <button type="button" onclick="doFacebookLogin()" style="width:100%;padding:10px 16px;border-radius:8px;border:1px solid var(--card-border);background:var(--card);color:var(--text);cursor:pointer;display:flex;align-items:center;justify-content:center;gap:10px;font-size:14px;">
                 <svg width="18" height="18" viewBox="0 0 24 24"><path fill="#1877F2" d="M24 12c0-6.627-5.373-12-12-12S0 5.373 0 12c0 5.99 4.388 10.954 10.125 11.854V15.47H7.078V12h3.047V9.356c0-3.007 1.792-4.668 4.533-4.668 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874V12h3.328l-.532 3.47h-2.796v8.385C19.612 22.954 24 17.99 24 12z"/></svg>
                 <span data-i18n="login_btn_facebook">Sign in with Facebook</span>
             </button>
-        </div>
+        </form>
 
         <!-- Register Form -->
-        <div id="registerForm" style="display:none">
+        <form id="registerForm" style="display:none" onsubmit="doRegister();return false;">
             <div class="form-group">
                 <label class="form-label" for="regEmail" data-i18n="login_label_email">Email</label>
                 <input type="email" class="form-input" id="regEmail" data-i18n-placeholder="login_placeholder_email"
@@ -311,29 +311,29 @@
             <div class="form-group">
                 <label class="form-label" for="regPasswordConfirm" data-i18n="login_label_confirm">Confirm Password</label>
                 <input type="password" class="form-input" id="regPasswordConfirm" data-i18n-placeholder="login_placeholder_confirm"
-                    placeholder="Confirm password" onkeydown="if(event.key==='Enter')doRegister()">
+                    placeholder="Confirm password">
             </div>
             <div id="regError" class="error-text" style="display:none"></div>
             <div id="regSuccess" class="success-text" style="display:none"></div>
-            <button class="btn btn-primary btn-block" onclick="doRegister()" id="regBtn" style="margin-top:16px"
+            <button type="submit" class="btn btn-primary btn-block" id="regBtn" style="margin-top:16px"
                 data-i18n="login_btn_create">Create Account</button>
             <div style="display:flex;align-items:center;gap:12px;margin:20px 0 12px;">
                 <div style="flex:1;height:1px;background:var(--card-border)"></div>
                 <span style="color:var(--text-secondary);font-size:13px;" data-i18n="login_or">or</span>
                 <div style="flex:1;height:1px;background:var(--card-border)"></div>
             </div>
-            <button onclick="doGoogleLogin()" style="width:100%;padding:10px 16px;border-radius:8px;border:1px solid var(--card-border);background:var(--card);color:var(--text);cursor:pointer;display:flex;align-items:center;justify-content:center;gap:10px;font-size:14px;margin-bottom:8px;">
+            <button type="button" onclick="doGoogleLogin()" style="width:100%;padding:10px 16px;border-radius:8px;border:1px solid var(--card-border);background:var(--card);color:var(--text);cursor:pointer;display:flex;align-items:center;justify-content:center;gap:10px;font-size:14px;margin-bottom:8px;">
                 <svg width="18" height="18" viewBox="0 0 24 24"><path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.2 3.32v2.77h3.57c2.08-1.92 3.27-4.74 3.27-8.1z"/><path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/><path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z"/><path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/></svg>
                 <span data-i18n="login_btn_google">Sign in with Google</span>
             </button>
-            <button onclick="doFacebookLogin()" style="width:100%;padding:10px 16px;border-radius:8px;border:1px solid var(--card-border);background:var(--card);color:var(--text);cursor:pointer;display:flex;align-items:center;justify-content:center;gap:10px;font-size:14px;">
+            <button type="button" onclick="doFacebookLogin()" style="width:100%;padding:10px 16px;border-radius:8px;border:1px solid var(--card-border);background:var(--card);color:var(--text);cursor:pointer;display:flex;align-items:center;justify-content:center;gap:10px;font-size:14px;">
                 <svg width="18" height="18" viewBox="0 0 24 24"><path fill="#1877F2" d="M24 12c0-6.627-5.373-12-12-12S0 5.373 0 12c0 5.99 4.388 10.954 10.125 11.854V15.47H7.078V12h3.047V9.356c0-3.007 1.792-4.668 4.533-4.668 1.312 0 2.686.235 2.686.235v2.953H15.83c-1.491 0-1.956.925-1.956 1.874V12h3.328l-.532 3.47h-2.796v8.385C19.612 22.954 24 17.99 24 12z"/></svg>
                 <span data-i18n="login_btn_facebook">Sign in with Facebook</span>
             </button>
-        </div>
+        </form>
 
         <!-- Device Login Form -->
-        <div id="deviceForm" style="display:none">
+        <form id="deviceForm" style="display:none" onsubmit="doDeviceLogin();return false;">
             <p style="color:var(--text-secondary);font-size:14px;margin-bottom:16px;" data-i18n="login_device_desc">
                 Already have the Android app? Enter your device credentials from Settings > Web Portal.
             </p>
@@ -343,34 +343,33 @@
             </div>
             <div class="form-group">
                 <label class="form-label" for="deviceSecret" data-i18n="mc_input_device_secret">Device Secret</label>
-                <input type="password" class="form-input" id="deviceSecret" data-i18n-placeholder="login_placeholder_device_secret" placeholder="Enter device secret"
-                    onkeydown="if(event.key==='Enter')doDeviceLogin()">
+                <input type="password" class="form-input" id="deviceSecret" data-i18n-placeholder="login_placeholder_device_secret" placeholder="Enter device secret">
             </div>
             <div id="deviceError" class="error-text" style="display:none"></div>
-            <button class="btn btn-primary btn-block" onclick="doDeviceLogin()" id="deviceBtn" style="margin-top:16px"
+            <button type="submit" class="btn btn-primary btn-block" id="deviceBtn" style="margin-top:16px"
                 data-i18n="login_btn_device">Login with Device</button>
-        </div>
+        </form>
 
         <!-- Forgot Password Form -->
-        <div id="forgotForm" style="display:none">
+        <form id="forgotForm" style="display:none" onsubmit="doForgot();return false;">
             <p style="color:var(--text-secondary);font-size:14px;margin-bottom:16px;" data-i18n="login_forgot_desc">
                 Enter your email and we'll send you a reset link.
             </p>
             <div class="form-group">
                 <label class="form-label" for="forgotEmail" data-i18n="login_label_email">Email</label>
                 <input type="email" class="form-input" id="forgotEmail" data-i18n-placeholder="login_placeholder_email"
-                    placeholder="your@email.com" onkeydown="if(event.key==='Enter')doForgot()">
+                    placeholder="your@email.com">
             </div>
             <div id="forgotMsg" style="display:none"></div>
-            <button class="btn btn-primary btn-block" onclick="doForgot()" id="forgotBtn" style="margin-top:16px"
+            <button type="submit" class="btn btn-primary btn-block" id="forgotBtn" style="margin-top:16px"
                 data-i18n="login_btn_reset_link">Send Reset Link</button>
             <p style="text-align:center;margin-top:16px;font-size:13px;">
                 <a href="#" onclick="showTab('login');return false;" data-i18n="login_link_back">Back to login</a>
             </p>
-        </div>
+        </form>
 
         <!-- Reset Password Form -->
-        <div id="resetForm" style="display:none">
+        <form id="resetForm" style="display:none" onsubmit="doReset();return false;">
             <p style="color:var(--text-secondary);font-size:14px;margin-bottom:16px;" data-i18n="login_reset_desc">
                 Enter your new password.
             </p>
@@ -383,13 +382,12 @@
             <div class="form-group">
                 <label class="form-label" for="resetPasswordConfirm" data-i18n="login_label_confirm">Confirm Password</label>
                 <input type="password" class="form-input" id="resetPasswordConfirm"
-                    data-i18n-placeholder="login_placeholder_confirm" placeholder="Confirm password"
-                    onkeydown="if(event.key==='Enter')doReset()">
+                    data-i18n-placeholder="login_placeholder_confirm" placeholder="Confirm password">
             </div>
             <div id="resetMsg" style="display:none"></div>
-            <button class="btn btn-primary btn-block" onclick="doReset()" id="resetBtn" style="margin-top:16px"
+            <button type="submit" class="btn btn-primary btn-block" id="resetBtn" style="margin-top:16px"
                 data-i18n="login_btn_reset">Reset Password</button>
-        </div>
+        </form>
     </div>
 
 

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1365,7 +1365,8 @@
                 data-i18n="settings_switch_device_body">
                 Enter the Device ID and Device Secret of the account you want to sign into. This browser will be signed out of the current device.
             </p>
-            <div style="display:flex;flex-direction:column;gap:10px;margin:14px 0;">
+            <form id="switchDeviceForm" style="display:flex;flex-direction:column;gap:10px;margin:14px 0;"
+                onsubmit="performSwitchDevice();return false;">
                 <div>
                     <label for="switchDeviceIdInput" style="display:block;font-size:12px;color:var(--text-muted);margin-bottom:4px;"
                         data-i18n="settings_device_id">Device ID</label>
@@ -1381,11 +1382,11 @@
                 </div>
                 <div id="switchDeviceError"
                     style="display:none;font-size:12px;color:var(--danger);line-height:1.4;"></div>
-            </div>
+            </form>
             <div class="dialog-actions">
-                <button class="btn btn-outline" onclick="closeSwitchDeviceDialog()"
+                <button type="button" class="btn btn-outline" onclick="closeSwitchDeviceDialog()"
                     data-i18n="common_cancel">Cancel</button>
-                <button class="btn btn-primary" id="btnConfirmSwitchDevice" onclick="performSwitchDevice()"
+                <button type="submit" form="switchDeviceForm" class="btn btn-primary" id="btnConfirmSwitchDevice"
                     data-i18n="settings_switch_device_confirm">Switch</button>
             </div>
         </div>

--- a/backend/tests/jest/portal-auth-forms.test.js
+++ b/backend/tests/jest/portal-auth-forms.test.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const path = require('path');
+
+const portalDir = path.join(__dirname, '../../public/portal');
+
+function readPortalPage(page) {
+  return fs.readFileSync(path.join(portalDir, page), 'utf8');
+}
+
+function formRange(html, formId) {
+  const formStart = html.search(new RegExp(`<form\\b[^>]*\\bid=["']${formId}["']`, 'i'));
+  expect(formStart).toBeGreaterThanOrEqual(0);
+  const formEnd = html.indexOf('</form>', formStart);
+  expect(formEnd).toBeGreaterThan(formStart);
+  return { start: formStart, end: formEnd };
+}
+
+function expectInsideForm(html, formId, elementId) {
+  const range = formRange(html, formId);
+  const elementIndex = html.search(new RegExp(`\\bid=["']${elementId}["']`, 'i'));
+  expect(elementIndex).toBeGreaterThan(range.start);
+  expect(elementIndex).toBeLessThan(range.end);
+}
+
+describe('portal auth forms', () => {
+  test('login page password credentials live inside native forms', () => {
+    const html = readPortalPage('index.html');
+
+    [
+      ['loginForm', 'loginEmail'],
+      ['loginForm', 'loginPassword'],
+      ['registerForm', 'regEmail'],
+      ['registerForm', 'regPassword'],
+      ['registerForm', 'regPasswordConfirm'],
+      ['deviceForm', 'deviceId'],
+      ['deviceForm', 'deviceSecret'],
+      ['forgotForm', 'forgotEmail'],
+      ['resetForm', 'resetPassword'],
+      ['resetForm', 'resetPasswordConfirm'],
+    ].forEach(([formId, elementId]) => expectInsideForm(html, formId, elementId));
+
+    expect(html).toMatch(/<form\b[^>]*\bid=["']loginForm["'][^>]*\bonsubmit=["']doLogin\(\);return false;["']/i);
+    expect(html).toMatch(/<form\b[^>]*\bid=["']registerForm["'][^>]*\bonsubmit=["']doRegister\(\);return false;["']/i);
+    expect(html).toMatch(/<form\b[^>]*\bid=["']deviceForm["'][^>]*\bonsubmit=["']doDeviceLogin\(\);return false;["']/i);
+    expect(html).toMatch(/<form\b[^>]*\bid=["']forgotForm["'][^>]*\bonsubmit=["']doForgot\(\);return false;["']/i);
+    expect(html).toMatch(/<form\b[^>]*\bid=["']resetForm["'][^>]*\bonsubmit=["']doReset\(\);return false;["']/i);
+  });
+
+  test('settings switch-device secret is submitted through a native form', () => {
+    const html = readPortalPage('settings.html');
+
+    expectInsideForm(html, 'switchDeviceForm', 'switchDeviceIdInput');
+    expectInsideForm(html, 'switchDeviceForm', 'switchDeviceSecretInput');
+    expect(html).toMatch(/<form\b[^>]*\bid=["']switchDeviceForm["'][^>]*\bonsubmit=["']performSwitchDevice\(\);return false;["']/i);
+    expect(html).toMatch(/<button\b[^>]*\btype=["']submit["'][^>]*\bform=["']switchDeviceForm["'][^>]*\bid=["']btnConfirmSwitchDevice["']/i);
+  });
+});


### PR DESCRIPTION
## Summary

- Wrap login, register, device login, forgot password, reset password, and settings switch-device credentials in native `<form>` elements.
- Convert primary submit buttons to native submit buttons and OAuth/cancel actions to `type="button"`.
- Add a static Jest regression guard so password/credential inputs stay associated with their expected forms.

Fixes #3020.

## Validation

- `npx jest tests/jest/portal-auth-forms.test.js --runInBand`
- Chromium CDP local static check: 0 password-field-outside-form warnings on patched `index.html` and `settings.html`; all login password inputs resolve to their expected form IDs.

## QA Context

Daily QA/UIUX card: `card_2675dafc0d456be3251dafcf`.

Reviewer: #2 / LOBSTER.