### PR TITLE
fix(android): wallpaper Weekly reset countdown — per-engine claude/codex/both (parity with 5h)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 96
-        versionName = "1.0.88"
+        versionCode = 97
+        versionName = "1.0.89"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/hank/clawlive/engine/UsageOverlayRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/UsageOverlayRenderer.kt
@@ -242,9 +242,25 @@ class UsageOverlayRenderer(
                 }
         }
         if (layoutPrefs.wallpaperResetShowWeekly) {
-            val resetsAt = nextWeeklyResetEpochMillis()
-            val weeklyTime = formatWeeklyReset(resetsAt)
-            lines.add(context.getString(R.string.wallpaper_reset_window_weekly_next, weeklyTime))
+            val rawCandidates = weeklyResetCandidates(snapshot)
+            if (snapshot == null || rawCandidates.isEmpty()) {
+                val resetsAt = nextWeeklyResetEpochMillis()
+                val weeklyTime = formatWeeklyReset(resetsAt)
+                lines.add(context.getString(R.string.wallpaper_reset_window_weekly_next, weeklyTime))
+            } else {
+                rawCandidates
+                    .filter { isEngineVisibleForReset(it.engineKey) }
+                    .forEach { reset ->
+                        val weeklyTime = formatWeeklyReset((reset.resetsAtSec * 1000.0).toLong())
+                        lines.add(
+                            context.getString(
+                                R.string.wallpaper_reset_window_weekly_next_per_engine,
+                                reset.engineLabel,
+                                weeklyTime
+                            )
+                        )
+                    }
+            }
         }
         return lines
     }
@@ -253,6 +269,22 @@ class UsageOverlayRenderer(
         if (snapshot == null) return emptyList()
         val claudeReset = snapshot.claude?.live?.rateLimits?.fiveHour?.resetsAt
         val codexReset = snapshot.codex?.rateLimits?.fiveHourResetsAt
+        val nowSec = System.currentTimeMillis() / 1000.0
+        return listOfNotNull(
+            claudeReset?.let {
+                ResetCandidate(ENGINE_KEY_CLAUDE, context.getString(R.string.wallpaper_usage_engine_claude), it)
+            },
+            codexReset?.let {
+                ResetCandidate(ENGINE_KEY_CODEX, context.getString(R.string.wallpaper_usage_engine_codex), it)
+            }
+        ).filter { it.resetsAtSec > nowSec }
+            .sortedBy { it.resetsAtSec }
+    }
+
+    private fun weeklyResetCandidates(snapshot: UsageSnapshotLatest?): List<ResetCandidate> {
+        if (snapshot == null) return emptyList()
+        val claudeReset = snapshot.claude?.live?.rateLimits?.sevenDay?.resetsAt
+        val codexReset = snapshot.codex?.rateLimits?.sevenDayResetsAt
         val nowSec = System.currentTimeMillis() / 1000.0
         return listOfNotNull(
             claudeReset?.let {

--- a/app/src/main/java/com/hank/clawlive/engine/UsageOverlayRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/UsageOverlayRenderer.kt
@@ -242,13 +242,14 @@ class UsageOverlayRenderer(
                 }
         }
         if (layoutPrefs.wallpaperResetShowWeekly) {
-            val rawCandidates = weeklyResetCandidates(snapshot)
-            if (snapshot == null || rawCandidates.isEmpty()) {
+            val hasRawWeeklyReset = snapshot?.claude?.live?.rateLimits?.sevenDay?.resetsAt != null ||
+                snapshot?.codex?.rateLimits?.sevenDayResetsAt != null
+            if (snapshot == null || !hasRawWeeklyReset) {
                 val resetsAt = nextWeeklyResetEpochMillis()
                 val weeklyTime = formatWeeklyReset(resetsAt)
                 lines.add(context.getString(R.string.wallpaper_reset_window_weekly_next, weeklyTime))
             } else {
-                rawCandidates
+                weeklyResetCandidates(snapshot)
                     .filter { isEngineVisibleForReset(it.engineKey) }
                     .forEach { reset ->
                         val weeklyTime = formatWeeklyReset((reset.resetsAtSec * 1000.0).toLong())

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -796,6 +796,7 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="wallpaper_reset_window_weekly">每週</string>
     <string name="wallpaper_reset_window_5h_next">下個 5h 重置 (%1$s)：%2$s</string>
     <string name="wallpaper_reset_window_weekly_next">下個每週重置：%1$s</string>
+    <string name="wallpaper_reset_window_weekly_next_per_engine">下個每週重置 (%1$s)：%2$s</string>
     <string name="wallpaper_settings_panel_label">桌布設定</string>
     <string name="wallpaper_settings_collapse_action">收起設定面板</string>
     <string name="wallpaper_settings_expand_action">展開設定面板</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -106,6 +106,7 @@
     <string name="wallpaper_reset_window_weekly">Weekly</string>
     <string name="wallpaper_reset_window_5h_next">Next 5h reset (%1$s): %2$s</string>
     <string name="wallpaper_reset_window_weekly_next">Next weekly reset: %1$s</string>
+    <string name="wallpaper_reset_window_weekly_next_per_engine">Next weekly reset (%1$s): %2$s</string>
     <string name="wallpaper_settings_panel_label">Wallpaper settings</string>
     <string name="wallpaper_settings_collapse_action">Collapse settings panel</string>
     <string name="wallpaper_settings_expand_action">Expand settings panel</string>


### PR DESCRIPTION
## Summary
- New `weeklyResetCandidates(snapshot)` parallels `fiveHourResetCandidates` — reads `snapshot.claude.live.rateLimits.sevenDay.resetsAt` + `snapshot.codex.rateLimits.sevenDayResetsAt` (wire `seven_day_resets_at`)
- Weekly branch in `formatResetCountdownLines` now applies `isEngineVisibleForReset` filter and emits one line per visible engine, same shape as the 5h branch
- New string `wallpaper_reset_window_weekly_next_per_engine` in `values/` + `values-zh-rTW/` (matches existing 2-locale `weekly_next` coverage; Hermes follow-up for remaining 14 locales)
- Fallback gate (per #6 design): legacy local Monday 00:00 line shows only when `snapshot == null` OR both raw `sevenDay` epochs are missing — never after engine filter empties the list (avoids generic-Monday false-positive in Claude-only / Codex-only modes)
- No `WallpaperSettings` UI change; existing Claude/Codex visibility toggles already control engine selection

## Why
Hank reported on v1.0.88 internal (2026-05-30 11:06 TW) that the Weekly reset line ignored the engine selection — only ever showed Claude (actually showed a generic local-time Monday 00:00 with no engine label). Spec from card_5a63c923 was Claude/Codex/Both, parity with 5h.

Root cause: `formatResetCountdownLines` Weekly branch was a single `nextWeeklyResetEpochMillis()` (local Monday calc) + template `wallpaper_reset_window_weekly_next` with only `%1$s = time`, no engine slot.

PR #3018 (`feat(android): wallpaper reset-interval toggle`) shipped the per-engine pipeline for 5h only; Weekly was missed.

## Design lock (#6 Codex review 2026-05-30 11:10 TW)
- Q1: model paths confirmed (UsageSnapshotModels.kt:50)
- Q2: server-supplied epoch preferred, local Monday legacy fallback only
- Q3: do NOT fallback after engine filter empties — would mis-show generic Monday for Claude-only/Codex-only toggle
- Q4: 5h collapse out of scope for this fix

## Test plan
- [ ] Real device Pixel_9a v1.0.89 build screenshots: Weekly + Claude only / Weekly + Codex only / Weekly + Both — 3 distinct visual states
- [ ] Fallback path: snapshot null OR both `sevenDay` raw missing → legacy `wallpaper_reset_window_weekly_next` line still renders
- [ ] No regression on 5h branch (unchanged)
- [ ] zh-TW + en strings resolve; other locales fall back to en (Hermes follow-up)

Card: `card_655e5b3f3d69b040d531230d`
Release target: v1.0.89 versionCode 97 → Play Internal

🤖 Generated with [Claude Code](https://claude.com/claude-code)