### PR TITLE
fix(seo): redirect legacy /info|/kanban|/settings|/index .html → /portal/* (301)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -339,8 +339,20 @@ app.use('/promo-videos', express.static(path.join(__dirname, 'public/promo-video
     }
 }));
 // Info Hub page — redirect to /portal/info.html so relative asset paths resolve correctly
-app.get('/info', (req, res) => {
+app.get(['/info', '/info.html'], (req, res) => {
     res.redirect(301, '/portal/info.html');
+});
+
+// Kanban / Settings / root index — sibling redirects so legacy bookmarks + SEO + share
+// links from before the portal/ migration keep working instead of returning hard-404.
+app.get(['/kanban', '/kanban.html'], (req, res) => {
+    res.redirect(301, '/portal/kanban.html');
+});
+app.get(['/settings', '/settings.html'], (req, res) => {
+    res.redirect(301, '/portal/settings.html');
+});
+app.get('/index.html', (req, res) => {
+    res.redirect(301, '/portal/index.html');
 });
 
 // Account deletion page — clean URL for Google Play Data Safety form

--- a/backend/tests/jest/portal-legacy-redirects.test.js
+++ b/backend/tests/jest/portal-legacy-redirects.test.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+
+const serverSrc = fs.readFileSync(path.join(__dirname, '../../index.js'), 'utf8');
+
+function expectRedirect(routes, target) {
+  const routeList = routes.map(r => `'${r}'`).join(', ');
+  const handlerRegex = new RegExp(
+    `app\\.get\\(\\s*(?:\\[\\s*${routeList}\\s*\\]|${routes.length === 1 ? `'${routes[0]}'` : ''})\\s*,[\\s\\S]{1,200}res\\.redirect\\(\\s*301\\s*,\\s*['"]${target.replace(/\//g, '\\/')}['"]\\s*\\)`,
+    'm'
+  );
+  expect(serverSrc).toMatch(handlerRegex);
+}
+
+describe('portal legacy redirects (Bug/SEO old /*.html paths)', () => {
+  test('/info and /info.html → /portal/info.html', () => {
+    expectRedirect(['/info', '/info.html'], '/portal/info.html');
+  });
+
+  test('/kanban and /kanban.html → /portal/kanban.html', () => {
+    expectRedirect(['/kanban', '/kanban.html'], '/portal/kanban.html');
+  });
+
+  test('/settings and /settings.html → /portal/settings.html', () => {
+    expectRedirect(['/settings', '/settings.html'], '/portal/settings.html');
+  });
+
+  test('/index.html → /portal/index.html', () => {
+    expectRedirect(['/index.html'], '/portal/index.html');
+  });
+});


### PR DESCRIPTION
## Summary
- Extend the existing `/info` 301 redirect to also accept `/info.html`
- Add same-shape `/kanban`, `/kanban.html`, `/settings`, `/settings.html` handlers → `/portal/*.html`
- Add `/index.html` → `/portal/index.html`
- Skip `/about` — `/portal/about.html` does not exist
- New jest structural test mirroring `portal-auth-forms.test.js` style from PR #3021

## Why
U83 daily QA discovered pre-portal/-migration paths returning hard-404:

```
curl -I https://eclawbot.com/info.html       # 404
curl -I https://eclawbot.com/kanban          # 404
curl -I https://eclawbot.com/settings.html   # 404
```

`/info` already redirects (line 343 before this PR), but the `.html` sibling didn't. `/kanban`, `/settings` had no handler at all. Old bookmarks, SEO inbound links from articles, social shares — all dead.

## After deploy
- `/info`, `/info.html` → 301 → `/portal/info.html`
- `/kanban`, `/kanban.html` → 301 → `/portal/kanban.html`
- `/settings`, `/settings.html` → 301 → `/portal/settings.html`
- `/index.html` → 301 → `/portal/index.html`

## Test plan
- [x] `npx jest tests/jest/portal-legacy-redirects.test.js` → 4/4 pass
- [ ] Post-deploy verify with `curl -I https://eclawbot.com/info.html` → 301
- [ ] sitemap.xml / robots.txt audit (deferred — separate card if needed)

Card: original task description from `[Bug/SEO] 舊 /*.html 路徑 hard-404`

🤖 Generated with [Claude Code](https://claude.com/claude-code)