### PR TITLE
fix(portal): kanban avatars sync on entity rebind

### DIFF
--- a/backend/public/portal/shared/entity-utils.js
+++ b/backend/public/portal/shared/entity-utils.js
@@ -2,16 +2,26 @@
 // Replaces duplicated ENTITY_CHARS across all portal pages
 // Fixes #77 and #76: entity IDs 4+ showed '?' emoji
 
+// Character → default emoji. Mirrors backend _getCharacterDefaultAvatar.
+const CHARACTER_EMOJI = {
+    LOBSTER: '\u{1F99E}',
+    PIG: '\u{1F437}'
+};
+const DEFAULT_CHARACTER_EMOJI = CHARACTER_EMOJI.LOBSTER;
+
+// Retained as a last-resort visual fallback when neither live character nor
+// any avatar source is known — never used to override a server-supplied character.
 const ENTITY_CHARS_DEFAULT = {
-    0: { name: 'Lobster', emoji: '\u{1F99E}' },
-    1: { name: 'Pig', emoji: '\u{1F437}' },
-    2: { name: 'Lobster', emoji: '\u{1F99E}' },
-    3: { name: 'Pig', emoji: '\u{1F437}' }
+    0: { name: 'Lobster', emoji: CHARACTER_EMOJI.LOBSTER },
+    1: { name: 'Lobster', emoji: CHARACTER_EMOJI.LOBSTER },
+    2: { name: 'Lobster', emoji: CHARACTER_EMOJI.LOBSTER },
+    3: { name: 'Lobster', emoji: CHARACTER_EMOJI.LOBSTER }
 };
 
 // Shared state - populated by each page's entity load
 let _entityAvatarMap = {};
 let _entityNameMap = {};
+let _entityCharacterMap = {};
 
 /**
  * Call after fetching entities from API to populate shared maps.
@@ -20,35 +30,47 @@ let _entityNameMap = {};
 function updateEntityMaps(entities) {
     _entityAvatarMap = {};
     _entityNameMap = {};
+    _entityCharacterMap = {};
     (entities || []).forEach(e => {
         if (e.avatar) _entityAvatarMap[e.entityId] = e.avatar;
         if (e.name) _entityNameMap[e.entityId] = e.name;
+        if (e.character) _entityCharacterMap[e.entityId] = e.character;
     });
+}
+
+function _characterEmoji(entityId) {
+    const c = _entityCharacterMap[entityId];
+    return c ? (CHARACTER_EMOJI[c] || DEFAULT_CHARACTER_EMOJI) : null;
 }
 
 /**
  * Get the avatar emoji for an entity.
- * Priority: server avatar > localStorage > ENTITY_CHARS_DEFAULT > fallback by modulo
+ * Priority: server avatar > localStorage > live character → emoji > legacy default > fallback
  */
 function getAvatarForEntity(entityId) {
     if (_entityAvatarMap[entityId]) return _entityAvatarMap[entityId];
     const saved = localStorage.getItem('eclaw_avatar_' + entityId);
     if (saved) return saved;
+    const fromCharacter = _characterEmoji(entityId);
+    if (fromCharacter) return fromCharacter;
     const char = ENTITY_CHARS_DEFAULT[entityId];
     if (char) return char.emoji;
-    // For entity IDs 4+, cycle through defaults by modulo
-    return ENTITY_CHARS_DEFAULT[entityId % 4]?.emoji || '\u{1F99E}';
+    return ENTITY_CHARS_DEFAULT[entityId % 4]?.emoji || DEFAULT_CHARACTER_EMOJI;
 }
 
 /**
  * Get the display name for an entity.
- * Priority: server name > ENTITY_CHARS_DEFAULT > fallback by parity
+ * Priority: server name > live character > legacy default > parity fallback
  */
 function getEntityDisplayName(entityId) {
     if (_entityNameMap[entityId]) return _entityNameMap[entityId];
+    const c = _entityCharacterMap[entityId];
+    if (c) {
+        return c.charAt(0) + c.slice(1).toLowerCase();
+    }
     const char = ENTITY_CHARS_DEFAULT[entityId];
     if (char) return char.name;
-    return (entityId % 2 === 0 ? 'Lobster' : 'Pig');
+    return 'Lobster';
 }
 
 /**
@@ -100,11 +122,13 @@ function renderAvatarHtml(avatar, size, entityId) {
 function getAvatarText(entityId) {
     const avatar = getAvatarForEntity(entityId);
     if (isAvatarUrl(avatar)) {
-        // URL avatar → use default emoji fallback
+        // URL avatar → use live-character emoji, then legacy default, then fallback
+        const fromCharacter = _characterEmoji(entityId);
+        if (fromCharacter) return fromCharacter;
         const char = ENTITY_CHARS_DEFAULT[entityId] || ENTITY_CHARS_DEFAULT[entityId % 4];
-        return char?.emoji || '\u{1F99E}';
+        return char?.emoji || DEFAULT_CHARACTER_EMOJI;
     }
-    return avatar || '\u{1F99E}';
+    return avatar || DEFAULT_CHARACTER_EMOJI;
 }
 
 /**

--- a/backend/tests/jest/portal-entity-avatar-resolver.test.js
+++ b/backend/tests/jest/portal-entity-avatar-resolver.test.js
@@ -1,0 +1,101 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const SRC_PATH = path.join(__dirname, '../../public/portal/shared/entity-utils.js');
+const SRC = fs.readFileSync(SRC_PATH, 'utf8');
+
+const LOBSTER = '\u{1F99E}';
+const PIG = '\u{1F437}';
+
+function loadResolver() {
+    const ctx = {
+        window: {},
+        localStorage: { _data: {}, getItem(k) { return this._data[k] || null; }, setItem(k, v) { this._data[k] = v; } },
+        console,
+    };
+    vm.createContext(ctx);
+    vm.runInContext(SRC, ctx);
+    return ctx;
+}
+
+describe('portal entity-utils — character-driven avatar resolver (rebind sync)', () => {
+    test('character=LOBSTER avatar=null on entityId=1 resolves to LOBSTER (not hardcoded PIG)', () => {
+        const ctx = loadResolver();
+        ctx.updateEntityMaps([{ entityId: 1, name: 'Mac_F', character: 'LOBSTER', avatar: null }]);
+        expect(ctx.getAvatarForEntity(1)).toBe(LOBSTER);
+        expect(ctx.getAvatarText(1)).toBe(LOBSTER);
+    });
+
+    test('character=LOBSTER avatar=null on entityId=5 resolves to LOBSTER (not mod-4 fallback PIG)', () => {
+        const ctx = loadResolver();
+        ctx.updateEntityMaps([{ entityId: 5, name: 'Hermes', character: 'LOBSTER', avatar: null }]);
+        expect(ctx.getAvatarForEntity(5)).toBe(LOBSTER);
+    });
+
+    test('character=PIG avatar=null resolves to PIG', () => {
+        const ctx = loadResolver();
+        ctx.updateEntityMaps([{ entityId: 2, name: 'Pigtest', character: 'PIG', avatar: null }]);
+        expect(ctx.getAvatarForEntity(2)).toBe(PIG);
+    });
+
+    test('explicit avatar emoji wins over character default', () => {
+        const ctx = loadResolver();
+        ctx.updateEntityMaps([{ entityId: 1, name: 'Mac_F', character: 'LOBSTER', avatar: '\u{1F431}' }]);
+        expect(ctx.getAvatarForEntity(1)).toBe('\u{1F431}');
+    });
+
+    test('URL avatar — getAvatarText falls back to character emoji, not id-default', () => {
+        const ctx = loadResolver();
+        ctx.updateEntityMaps([{ entityId: 1, name: 'Mac_F', character: 'LOBSTER', avatar: 'https://x/a.jpg' }]);
+        expect(ctx.getAvatarText(1)).toBe(LOBSTER);
+    });
+
+    test('unknown character resolves to LOBSTER default (not PIG via id-mapping)', () => {
+        const ctx = loadResolver();
+        ctx.updateEntityMaps([{ entityId: 1, name: 'X', character: 'SHEEP', avatar: null }]);
+        expect(ctx.getAvatarForEntity(1)).toBe(LOBSTER);
+    });
+
+    test('display name comes from server, not legacy character-id table', () => {
+        const ctx = loadResolver();
+        ctx.updateEntityMaps([{ entityId: 1, name: 'Mac_F', character: 'LOBSTER', avatar: null }]);
+        expect(ctx.getEntityDisplayName(1)).toBe('Mac_F');
+    });
+
+    test('updateEntityMaps clears stale character state on subsequent calls', () => {
+        const ctx = loadResolver();
+        ctx.updateEntityMaps([{ entityId: 1, character: 'PIG', avatar: null }]);
+        expect(ctx.getAvatarForEntity(1)).toBe(PIG);
+        ctx.updateEntityMaps([{ entityId: 1, character: 'LOBSTER', avatar: null }]);
+        expect(ctx.getAvatarForEntity(1)).toBe(LOBSTER);
+    });
+});
+
+describe('portal entity-utils — static guard against id-based hardcoded character defaults', () => {
+    test('ENTITY_CHARS_DEFAULT no longer maps any entityId to PIG', () => {
+        const idDefaultMatch = SRC.match(/const\s+ENTITY_CHARS_DEFAULT\s*=\s*\{([\s\S]*?)\};/);
+        expect(idDefaultMatch).not.toBeNull();
+        const body = idDefaultMatch[1];
+        expect(body).not.toMatch(/1F437/);
+        expect(body).not.toMatch(/Pig/);
+    });
+
+    test('CHARACTER_EMOJI map is the canonical character→emoji table', () => {
+        expect(SRC).toMatch(/CHARACTER_EMOJI\s*=\s*\{[\s\S]*LOBSTER[\s\S]*PIG[\s\S]*\}/);
+    });
+
+    test('_entityCharacterMap is populated by updateEntityMaps', () => {
+        expect(SRC).toMatch(/_entityCharacterMap\s*=\s*\{\}/);
+        expect(SRC).toMatch(/_entityCharacterMap\[e\.entityId\]\s*=\s*e\.character/);
+    });
+
+    test('getAvatarForEntity consults character map before falling back to id-defaults', () => {
+        const fnMatch = SRC.match(/function\s+getAvatarForEntity[\s\S]*?\n\}/);
+        expect(fnMatch).not.toBeNull();
+        const charLine = fnMatch[0].indexOf('_characterEmoji');
+        const legacyLine = fnMatch[0].indexOf('ENTITY_CHARS_DEFAULT[entityId]');
+        expect(charLine).toBeGreaterThan(-1);
+        expect(legacyLine).toBeGreaterThan(charLine);
+    });
+});


### PR DESCRIPTION
## Summary

- Resolver in `portal/shared/entity-utils.js` now consults the **live `e.character`** field from `/api/entities` before falling back to legacy defaults — fixes stale 🐷 on entities whose binding character changed.
- New `CHARACTER_EMOJI` map mirrors backend `_getCharacterDefaultAvatar` (LOBSTER→🦞, PIG→🐷, unknown→🦞).
- `updateEntityMaps` now also captures `e.character` into a shared `_entityCharacterMap`, cleared on every call so rebinds invalidate cleanly.
- `getAvatarForEntity` and `getAvatarText` both patched — URL avatars also fall back via live character rather than the legacy id-keyed default.
- `ENTITY_CHARS_DEFAULT` slots flattened to Lobster — retained only as a final visual fallback when neither character nor avatar is known.

## Root cause

`portal/shared/entity-utils.js` had:

```js
const ENTITY_CHARS_DEFAULT = { 0:Lobster, 1:Pig, 2:Lobster, 3:Pig };

function updateEntityMaps(entities) {
  _entityAvatarMap = {};
  entities.forEach(e => { if (e.avatar) _entityAvatarMap[e.entityId] = e.avatar; });
  // never read e.character
}

function getAvatarForEntity(id) {
  if (_entityAvatarMap[id]) return _entityAvatarMap[id];
  if (localStorage.getItem('eclaw_avatar_' + id)) return …;
  const char = ENTITY_CHARS_DEFAULT[id];
  if (char) return char.emoji;
  return ENTITY_CHARS_DEFAULT[id % 4]?.emoji;
}
```

So any entity with `avatar=null` fell through to the **id-based hardcoded table**, ignoring the live `character` field. Entity #1 → 🐷, entity #5 (`5 % 4 = 1`) → 🐷 — regardless of what the server actually reported.

## E2E evidence (before fix)

| Entity | API character | API avatar | Kanban displayed | Cards | Status |
|--------|---------------|-----------|------------------|-------|--------|
| #1 Mac_F | LOBSTER | null | 🐷 | 52 | ❌ stale |
| #2 主管 | LOBSTER | 🐱 | 🐱 | 214 | ✅ |
| #3 Mac_E | LOBSTER | 🐱 | 🐱 | 18 | ✅ |
| #4 Eclaw_Office | LOBSTER | null | 🦞 | 0 | ✅ |
| #5 Hermes | LOBSTER | null | 🐷 | 2 | ❌ stale |
| #6 Codex | LOBSTER | null | 🦞 | 24 | ✅ |

Screenshots committed in commander session:
- `kanban_avatar_sync_bug_desktop_1280x800.png` (before)
- `kanban_avatar_sync_bug_mobile_390x844.png` (before)

After-fix screenshots will land on the card once the deploy goes through.

## Test plan
- [x] `backend/tests/jest/portal-entity-avatar-resolver.test.js` — 8 vm/behavior tests pin the rebind contract (LOBSTER/PIG/avatar-precedence/unknown-char/rebind-cycle) + 4 static-guard tests on the source ban any future id-keyed PIG default and require `_characterEmoji` to be consulted before id-defaults.
- [x] Local `npx jest backend/tests/jest/portal-entity-avatar-resolver.test.js` — 12/12 pass.
- [ ] CI green.
- [ ] After deploy: open `portal/kanban.html`, confirm #1 Mac_F and #5 Hermes chips render 🦞.
- [ ] After deploy: capture mobile (390×844) + desktop (1280×800) after-screenshots, attach to `card_ad62e4a07bc657bcca16ccd9`.

## Scope notes
- `backend/public/shared/avatar-petdx.js` audited — caches companion descriptors by entityId and only mounts a canvas; does **not** share the same hardcoded character table. No change required (confirmed with #6).
- Existing `backend/tests/jest/character-avatar-sync.test.js` covers the **server-side** sync rule; the new file covers the **client resolver** path that was missing.
- `requiresScreenshotReview=true` on the tracking card. Visual delta on #1 Mac_F (🐷→🦞) is intentional, not a regression.

Resolves card `card_ad62e4a07bc657bcca16ccd9`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)