### PR TITLE
[codex] fix(org-chart): suppress silent FWD echo loops

### DIFF
--- a/backend/org-fwd-filter.js
+++ b/backend/org-fwd-filter.js
@@ -16,6 +16,7 @@ const ORG_FWD_NOISE_PATTERNS = [
     /^\s*line \d+ column \d+/i,
     /^\s*\[[^\]]{1,40}回應超時\]\s*$/,
     /^\s*\[[^\]]{1,40}response timeout\]\s*$/i,
+    /^\s*\[SILENT\]\s*#?\d+\s+sign[- ]off\s+FWD\s+echo\b/i,
     /^\s*(ping|pong|ack|ok|received|noted)\s*[.!]*\s*$/i,
 ];
 

--- a/backend/tests/jest/org-fwd-filter.test.js
+++ b/backend/tests/jest/org-fwd-filter.test.js
@@ -74,6 +74,17 @@ describe('isLowSignalFwd()', () => {
         });
     });
 
+    describe('silent sign-off echo noise (the FWD same-string ack loop)', () => {
+        it('suppresses [SILENT] sign-off FWD echo control messages', () => {
+            expect(isLowSignalFwd('[SILENT] #6 sign-off FWD echo (相同字串) — 已 ack 過，繼續寫 jest test + commit + PR。')).toBe(true);
+            expect(isLowSignalFwd('[SILENT] #12 sign off fwd echo same string')).toBe(true);
+        });
+
+        it('does NOT suppress other silent status messages with real work', () => {
+            expect(isLowSignalFwd('[SILENT] #6 PR #3028 ready; Jest passed and branch pushed')).toBe(false);
+        });
+    });
+
     describe('one-word ack noise (the ack-of-ack loop)', () => {
         it('suppresses bare "ack" / "ACK" / "ack."', () => {
             expect(isLowSignalFwd('ack')).toBe(true);


### PR DESCRIPTION
## What changed
- Added org-forward noise filtering for `[SILENT] #... sign-off FWD echo` control-plane echoes.
- Added Jest coverage for the exact same-string FWD echo form plus a pass-through guard for real silent status updates.

## Why
Silent org-chart forwarding can route bot control-plane echoes upward again when an entity repeats the sign-off FWD echo text. That is low-signal loop noise, not user-visible work status.

## Impact
Legitimate status messages still pass through; only the targeted sign-off FWD echo pattern is suppressed before `orgChartForward()` silently pushes to the superior entity.

## Validation
- `git diff --check`
- `npm test -- --runInBand tests/jest/org-fwd-filter.test.js` (repo script matched the full `tests/jest` suite: 227 suites passed, 3211 tests passed, 1 skipped)