### PR TITLE
feat(petdx phase 0): admin backfill endpoint for in-process hook invocation

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -6854,6 +6854,65 @@ async function runPetdxPhase0AutoAssign(deviceId, entity, ctx) {
     }
 }
 
+// POST /api/admin/petdx-phase0/backfill
+// Owner-auth admin endpoint that runs the petdx Phase 0 default-companion
+// assignment hook in 'backfill' mode for every bound entity on the device.
+// Mirrors backend/scripts/petdx-phase0-backfill.js but runs in-process so
+// Phase 0 acceptance §0.8 #8 (kanban prod E2E) doesn't require Railway CLI
+// access. See spec §0.5.
+app.post('/api/admin/petdx-phase0/backfill', async (req, res) => {
+    const { deviceId, deviceSecret, commit } = req.body || {};
+    if (!deviceId || !deviceSecret) {
+        return res.status(400).json({ success: false, error: 'deviceId and deviceSecret are required' });
+    }
+    const device = devices[deviceId];
+    if (!device || !safeEqual(device.deviceSecret, deviceSecret)) {
+        return res.status(401).json({ success: false, error: 'Invalid device credentials' });
+    }
+
+    const entityIds = Object.keys(device.entities || {}).map(Number).filter(Number.isFinite);
+    const results = { assigned: [], skipped: [], errors: [] };
+    const ctxBase = { mode: 'backfill', source: 'backfill-script' };
+    const io = createPetdxPhase0Io();
+
+    for (const eId of entityIds) {
+        const entity = device.entities[eId];
+        if (!entity || !entity.isBound) {
+            results.skipped.push({ entityId: eId, reason: 'not_bound' });
+            continue;
+        }
+        const entityForHook = {
+            entityId: eId,
+            character: entity.character,
+            avatar: entity.avatar,
+            rental_status: entity.rentalStatus || entity.rental_status || null,
+            identity: entity.identity || null,
+        };
+        try {
+            const result = commit === true
+                ? await assignDefaultCompanionIfMissing(deviceId, entityForHook, ctxBase, io)
+                : await (async () => {
+                    const dryIo = {
+                        ...io,
+                        setDeviceVars: async () => {},
+                        setDeviceVar: async () => {},
+                        appendCompanionSelectLog: async () => {},
+                    };
+                    return assignDefaultCompanionIfMissing(deviceId, entityForHook, ctxBase, dryIo);
+                })();
+            if (result && result.assigned) {
+                results.assigned.push({ entityId: eId, companion: result.assigned, avatarUrl: result.avatarUrl, source: result.source });
+            } else if (result && result.skipped) {
+                results.skipped.push({ entityId: eId, reason: result.skipped });
+            }
+        } catch (err) {
+            results.errors.push({ entityId: eId, error: err.message });
+        }
+    }
+
+    res.json({ success: true, deviceId, committed: commit === true, results });
+});
+
 
 // ============================================
 // REMOTE SCREEN CONTROL

--- a/backend/tests/jest/admin-petdx-phase0-backfill.test.js
+++ b/backend/tests/jest/admin-petdx-phase0-backfill.test.js
@@ -1,0 +1,45 @@
+const fs = require('fs');
+const path = require('path');
+
+const SRC = fs.readFileSync(path.join(__dirname, '../../index.js'), 'utf8');
+
+// Grab the whole handler body: from the route registration to the closing
+// res.json line at the bottom. Both endpoints fit on a contiguous span so a
+// fixed-radius window around the route header captures the body cleanly.
+function handlerBody() {
+    const start = SRC.indexOf(`app.post('/api/admin/petdx-phase0/backfill'`);
+    if (start < 0) throw new Error('route not registered');
+    const end = SRC.indexOf('committed: commit === true', start);
+    if (end < 0) throw new Error('response shape not found');
+    return SRC.slice(start, end + 200);
+}
+
+describe('POST /api/admin/petdx-phase0/backfill', () => {
+    test('endpoint is registered', () => {
+        expect(SRC).toMatch(/app\.post\(['"]\/api\/admin\/petdx-phase0\/backfill['"]/);
+    });
+    test('requires deviceId + deviceSecret', () => {
+        const body = handlerBody();
+        expect(body).toMatch(/deviceId and deviceSecret are required/);
+        expect(body).toMatch(/safeEqual\(device\.deviceSecret,\s*deviceSecret\)/);
+    });
+    test('dispatches the petdx Phase 0 hook in backfill mode', () => {
+        const body = handlerBody();
+        expect(body).toMatch(/mode:\s*['"]backfill['"]/);
+        expect(body).toMatch(/source:\s*['"]backfill-script['"]/);
+        expect(body).toMatch(/assignDefaultCompanionIfMissing/);
+    });
+    test('honors dry-run by stubbing the IO writes', () => {
+        const body = handlerBody();
+        expect(body).toMatch(/setDeviceVars:\s*async \(\) => \{\}/);
+        expect(body).toMatch(/setDeviceVar:\s*async \(\) => \{\}/);
+        expect(body).toMatch(/appendCompanionSelectLog:\s*async \(\) => \{\}/);
+    });
+    test('returns committed flag + per-entity results buckets', () => {
+        const body = handlerBody();
+        expect(body).toMatch(/results\.assigned\.push/);
+        expect(body).toMatch(/results\.skipped\.push/);
+        expect(body).toMatch(/results\.errors\.push/);
+        expect(body).toMatch(/committed:\s*commit === true/);
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `POST /api/admin/petdx-phase0/backfill` (deviceSecret auth) that iterates every bound entity on the device and invokes `assignDefaultCompanionIfMissing` in `'backfill'` mode
- Mirrors `backend/scripts/petdx-phase0-backfill.js` but runs in-process — no Railway CLI / workstation env required to populate existing devices
- Supports `{commit: true|false}` body flag — default dry-run swaps in IO stubs so callers preview before writing

## Why
Spec §0.8 #8 (kanban prod E2E for default-companion render) blocks on every existing entity having `PETDX_AVATAR_<id>` populated. The standalone script needs `DATABASE_URL` + `SEAL_KEY` in the caller's env, which my channel-claude-code session can't reach safely (DB URL is a managed secret). An in-process endpoint closes the gap cleanly.

## Test plan
- [x] Jest test (`tests/jest/admin-petdx-phase0-backfill.test.js`) — 5 cases covering route registration, auth check, hook dispatch shape, dry-run IO stubbing, response buckets
- [ ] CI green on this PR
- [ ] Merge + Railway deploy
- [ ] Dry-run call → confirm entity bucket counts match `/api/entities` shape
- [ ] Commit call → verify `/api/entities` now returns `petdxAvatarUrl` for #1, #4, #5, #6 (#2, #3 preserved per `user-custom-avatar` skip)
- [ ] Kanban prod E2E screenshots desktop + mobile, attach to card_f0afd335 — closes spec §0.8 #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)