### PR TITLE
feat(seo): add FAQPage JSON-LD to info.html panel-faq

### DIFF
--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -4761,6 +4761,118 @@ platforms:
              TAB 2: FAQ
              ══════════════════════════════════════════════════ -->
         <div class="info-panel" id="panel-faq">
+            <script type="application/ld+json">
+            {
+              "@context": "https://schema.org",
+              "@type": "FAQPage",
+              "mainEntity": [
+                {
+                  "@type": "Question",
+                  "name": "What is EClawbot?",
+                  "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "EClawbot is an Agent-to-Agent (A2A) communication platform with an AI agent ecosystem. It helps individuals and small businesses build, manage, and deploy AI agents (entities) for inter-agent collaboration, task dispatch, and automation. You can manage everything through the Web Portal, Android app, or iOS app."
+                  }
+                },
+                {
+                  "@type": "Question",
+                  "name": "What is OpenClaw?",
+                  "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "OpenClaw is the bot development ecosystem powered by EClawbot. Bot developers build AI agents on OpenClaw and connect them to EClawbot via Webhook push, Channel Plugin, or A2A protocol for inter-agent communication and task automation."
+                  }
+                },
+                {
+                  "@type": "Question",
+                  "name": "What is the Proxy Window?",
+                  "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "The Proxy Window lets each AI agent have a dedicated public URL. External customers can interact with your agent directly in a browser — placing orders, making inquiries, scheduling appointments — without installing any app. Ideal for e-commerce, consulting, IT support, and more."
+                  }
+                },
+                {
+                  "@type": "Question",
+                  "name": "Is EClawbot free?",
+                  "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Yes. EClawbot offers a free tier with shared bots and unlimited messages. Self-hosted bots have no message limit and are always free. The Web Portal, Agent Card, Mission Control, and A2A features are all available on the free tier."
+                  }
+                },
+                {
+                  "@type": "Question",
+                  "name": "How do I bind a bot to my device?",
+                  "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Go to the Dashboard (Web Portal or app), select an entity slot, and click Generate Code. Copy the binding command and paste it to the bot. The bot will confirm the binding automatically. You can also use the Official Bot Rental for a quick free setup."
+                  }
+                },
+                {
+                  "@type": "Question",
+                  "name": "How many agents can I have?",
+                  "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Each device supports multiple entity slots. Each slot can be bound to a different AI agent with its own identity, skills, chat history, and Agent Card. Slots auto-expand when needed."
+                  }
+                },
+                {
+                  "@type": "Question",
+                  "name": "Which platform should I use?",
+                  "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "All three platforms (Web Portal, Android, iOS) work independently and stay in sync. The Web Portal is recommended for multi-agent management, Mission Control, and enterprise workflows. The Android app adds a live wallpaper experience. Use whichever suits your needs, or all three."
+                  }
+                },
+                {
+                  "@type": "Question",
+                  "name": "What is Broadcast?",
+                  "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Broadcast sends a message to all your bound agents at once via the Transform API (broadcast:true). Great for announcements or coordinating tasks across your entire agent team. Delivery reports track which agents received the broadcast."
+                  }
+                },
+                {
+                  "@type": "Question",
+                  "name": "What is SpeakTo?",
+                  "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "SpeakTo enables direct agent-to-agent communication via the Transform API (speakTo:[PUBLIC_CODE]). One agent can send a message to another specific agent (even cross-device) and receive a reply. This powers A2A collaboration workflows where agents coordinate tasks between themselves."
+                  }
+                },
+                {
+                  "@type": "Question",
+                  "name": "What is Mission Control?",
+                  "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Mission Control is EClawbot built-in task management system. Create tasks (TODO/Mission/Done), assign them to agents, manage notes, configure skills and rules, and define agent personality (soul). Agents are automatically notified when their tasks change."
+                  }
+                },
+                {
+                  "@type": "Question",
+                  "name": "Why use Claude Code Channel instead of OpenClaw Channel?",
+                  "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "The main difference is billing. OpenClaw Channel uses an Anthropic API key and is charged per token; Claude Code Channel uses your claude.ai subscription allowance with a fixed monthly cost and no per-message billing. If you already have a claude.ai Max/Teams subscription, Claude Code Channel costs you nothing extra in API fees. The tradeoff: Claude Code Channel is currently experimental and slightly less stable than OpenClaw Channel."
+                  }
+                },
+                {
+                  "@type": "Question",
+                  "name": "How do I create my own bot?",
+                  "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Bots are built on the OpenClaw platform (hosted on Zeabur). Check the User Guide tab for tutorials, API docs, and skill templates. You can also use the A2A protocol to integrate any external AI agent."
+                  }
+                },
+                {
+                  "@type": "Question",
+                  "name": "Can I use my bot on Telegram too?",
+                  "acceptedAnswer": {
+                    "@type": "Answer",
+                    "text": "Yes. OpenClaw bots support multiple channels including Telegram, Discord, Slack, and more. EClawbot is one channel in the OpenClaw ecosystem. See the Compare tab for platform differences."
+                  }
+                }
+              ]
+            }
+            </script>
             <div class="faq-hero">
                 <div class="faq-hero-title" data-i18n="faq_hero_title">Frequently Asked Questions</div>
                 <div class="faq-hero-subtitle" data-i18n="faq_hero_subtitle">Everything you need to know about EClawbot and the OpenClaw bot platform.</div>


### PR DESCRIPTION
## Summary
- Adds FAQPage JSON-LD to `backend/public/portal/info.html` panel-faq with all 13 Q&A pairs sourced verbatim from the visible markup
- Closes top-priority gap from card_854e23428693d4c62eb7465d (SEO audit U74)
- Single highest-ROI structured-data add: Google FAQPage rich-results render the Q&A inline in SERP

## Coverage
Sections + question count mirrored from existing DOM:
- General — 4
- Setup & Binding — 3
- Features — 4
- Bot Development — 2

Total 13 questions. Each Question carries `acceptedAnswer` with full prose from `data-i18n="faq_a_*"` text.

## Follow-up cards (will open after this lands)
- HowTo JSON-LD on 13 guide-usecase-* panels
- TechArticle on panel-guide / panel-advanced / panel-channel-plugins
- HowTo on panel-quickstart
- BlogPosting on panel-release-notes

## Test plan
- [x] Both ld+json blocks (SoftwareApplication + FAQPage) parse cleanly via `json.loads`
- [x] All 13 entries have `@type:"Question"` + `acceptedAnswer`
- [ ] CI green
- [ ] Merge + Railway deploy
- [ ] Validate via Google Rich Results Test (https://search.google.com/test/rich-results)

🤖 Generated with [Claude Code](https://claude.com/claude-code)