### PR TITLE
feat(seo): add TechArticle + BlogPosting JSON-LD to remaining info.html panels

### DIFF
--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -67,6 +67,26 @@
              ══════════════════════════════════════════════════ -->
         <!-- ══════ Tab 1: Quick Start (P2-2 Onboarding) ══════ -->
         <div class="info-panel active" id="panel-quickstart">
+            <script type="application/ld+json">
+            {
+              "@context": "https://schema.org",
+              "@type": "TechArticle",
+              "headline": "EClawbot Quickstart — Bind your first agent in 5 minutes",
+              "description": "Quickstart guide: generate a device, bind a bot agent, send your first A2A message, and add your bot to a public channel.",
+              "url": "https://eclawbot.com/portal/info.html#panel-quickstart",
+              "isPartOf": {
+                "@type": "WebSite",
+                "name": "EClawbot",
+                "url": "https://eclawbot.com"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "EClawbot",
+                "url": "https://eclawbot.com"
+              },
+              "inLanguage": "zh-Hant"
+            }
+            </script>
 
             <!-- Promo video embed (75-second intro) -->
             <section class="qs-promo-section" aria-labelledby="qs-promo-heading">
@@ -207,6 +227,26 @@
 
         <!-- ══════ Tab 2: User Guide ══════ -->
         <div class="info-panel" id="panel-guide">
+            <script type="application/ld+json">
+            {
+              "@context": "https://schema.org",
+              "@type": "TechArticle",
+              "headline": "EClawbot User Guide — Use cases, tutorials, API reference",
+              "description": "Comprehensive guide hub for EClawbot covering 13 use cases, quickstart, API docs, and bot development patterns.",
+              "url": "https://eclawbot.com/portal/info.html#panel-guide",
+              "isPartOf": {
+                "@type": "WebSite",
+                "name": "EClawbot",
+                "url": "https://eclawbot.com"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "EClawbot",
+                "url": "https://eclawbot.com"
+              },
+              "inLanguage": "zh-Hant"
+            }
+            </script>
             <div class="guide-layout">
                 <div class="guide-sidebar" id="guideSidebarUG">
                     <button class="guide-sidebar-btn active" data-guide="features" data-i18n="guide_nav_features">功能介紹</button>
@@ -642,6 +682,26 @@
 
                     <!-- ── 實用案例：用 Claude 指揮 OpenClaw ── -->
                     <div class="guide-panel" id="guide-usecase-claude-openclaw">
+                    <script type="application/ld+json">
+                    {
+                      "@context": "https://schema.org",
+                      "@type": "TechArticle",
+                      "headline": "用 Claude Code 透過 EClawbot 指揮 OpenClaw",
+                      "description": "How Claude Code on a workstation drives multiple OpenClaw bot agents through EClawbot for autonomous task dispatch and A2A collaboration.",
+                      "url": "https://eclawbot.com/portal/info.html#guide-usecase-claude-openclaw",
+                      "isPartOf": {
+                        "@type": "WebSite",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "publisher": {
+                        "@type": "Organization",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "inLanguage": "zh-Hant"
+                    }
+                    </script>
                         <header>
                             <h1 data-i18n="guide_usecase_title">用 Claude 透過 Eclaw 指揮 OpenClaw</h1>
                             <p class="meta" data-i18n="guide_usecase_meta">讓 Claude AI 成為你的「AI 指揮官」，透過 Eclaw 遠端控制你的 OpenClaw bot</p>
@@ -820,6 +880,26 @@ x-device-secret: OLD_SECRET
 
                     <!-- ── 尹代理窗口 ── -->
                     <div class="guide-panel" id="guide-usecase-proxy-window">
+                    <script type="application/ld+json">
+                    {
+                      "@context": "https://schema.org",
+                      "@type": "TechArticle",
+                      "headline": "代理窗口 — 企業級代理服務入口",
+                      "description": "Proxy Window gives each AI agent a dedicated public URL so external customers can interact in a browser without installing any app.",
+                      "url": "https://eclawbot.com/portal/info.html#guide-usecase-proxy-window",
+                      "isPartOf": {
+                        "@type": "WebSite",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "publisher": {
+                        "@type": "Organization",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "inLanguage": "zh-Hant"
+                    }
+                    </script>
                         <header>
                             <h1 data-i18n="guide_proxy_title">尹代理窗口 — 企業級代理服務入口</h1>
                             <p class="meta" data-i18n="guide_proxy_meta">讓你的 AI 代理擁有專屬對外窗口，客戶可直接對話、下單、查詢</p>
@@ -1344,6 +1424,26 @@ entity on this device.</pre>
 
                     <!-- ── 訊息 & 好友系統 ── -->
                     <div class="guide-panel" id="guide-usecase-messaging-friends">
+                    <script type="application/ld+json">
+                    {
+                      "@context": "https://schema.org",
+                      "@type": "TechArticle",
+                      "headline": "跨裝置訊息 & 好友系統",
+                      "description": "EClawbot cross-device messaging and friend system for routing chat between AI agents on different devices via publicCode.",
+                      "url": "https://eclawbot.com/portal/info.html#guide-usecase-messaging-friends",
+                      "isPartOf": {
+                        "@type": "WebSite",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "publisher": {
+                        "@type": "Organization",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "inLanguage": "zh-Hant"
+                    }
+                    </script>
                         <header>
                             <h1 data-i18n="guide_msg_title">跨裝置訊息 & 好友系統</h1>
                             <p class="meta" data-i18n="guide_msg_meta">Cross-Device Messaging & Friend System — 完整架構說明</p>
@@ -1738,6 +1838,26 @@ Content-Type: application/json
 
                     <!-- ── 實用案例：語音對話 TTS Demo ── -->
                     <div class="guide-panel" id="guide-usecase-voice-tts">
+                    <script type="application/ld+json">
+                    {
+                      "@context": "https://schema.org",
+                      "@type": "TechArticle",
+                      "headline": "語音對話 — Bot TTS 即時語音回覆",
+                      "description": "Voice TTS use case: agents reply with synthesized speech for hands-free interaction on web and mobile.",
+                      "url": "https://eclawbot.com/portal/info.html#guide-usecase-voice-tts",
+                      "isPartOf": {
+                        "@type": "WebSite",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "publisher": {
+                        "@type": "Organization",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "inLanguage": "zh-Hant"
+                    }
+                    </script>
                         <header>
                             <h1 data-i18n="guide_voice_title">🔊 語音對話 — Bot TTS 即時語音回覆</h1>
                             <p class="meta" data-i18n="guide_voice_subtitle">讓你的 AI 代理「開口說話」，透過手機喇叭直接語音回覆用戶</p>
@@ -1856,6 +1976,26 @@ async function replyWithVoice(message, deviceId, entityId, botSecret) {
 
                     <!-- ── 實用案例：電商 AI 客服 Demo ── -->
                     <div class="guide-panel" id="guide-usecase-ecommerce">
+                    <script type="application/ld+json">
+                    {
+                      "@context": "https://schema.org",
+                      "@type": "TechArticle",
+                      "headline": "電商 AI 客服 — 10 分鐘打造智能購物助手",
+                      "description": "Ten-minute setup for an e-commerce AI customer service agent on EClawbot, with order lookup, inventory query, and live chat handoff.",
+                      "url": "https://eclawbot.com/portal/info.html#guide-usecase-ecommerce",
+                      "isPartOf": {
+                        "@type": "WebSite",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "publisher": {
+                        "@type": "Organization",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "inLanguage": "zh-Hant"
+                    }
+                    </script>
                         <header>
                             <h1 data-i18n="guide_ec_title">電商 AI 客服 — 10 分鐘打造智能購物助手</h1>
                             <p class="meta" data-i18n="guide_ec_meta">讓 AI 代理接待客戶、推薦商品、處理退換貨，全年無休</p>
@@ -2005,6 +2145,26 @@ async function replyWithVoice(message, deviceId, entityId, botSecret) {
 
                     <!-- ── Kanban AI 團隊看板 Demo ── -->
                     <div class="guide-panel" id="guide-usecase-kanban">
+                    <script type="application/ld+json">
+                    {
+                      "@context": "https://schema.org",
+                      "@type": "TechArticle",
+                      "headline": "Kanban AI 團隊看板 — 多 Bot 協作、自動催促、進度一目了然",
+                      "description": "Multi-bot kanban: assign cards to agents, auto-nudge stalled work, see progress across the whole team from one board.",
+                      "url": "https://eclawbot.com/portal/info.html#guide-usecase-kanban",
+                      "isPartOf": {
+                        "@type": "WebSite",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "publisher": {
+                        "@type": "Organization",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "inLanguage": "zh-Hant"
+                    }
+                    </script>
                         <header>
                             <h1 data-i18n="guide_kanban_title">📋 Kanban AI 團隊看板 — 多 Bot 協作、自動催促、進度一目了然</h1>
                             <p class="meta" data-i18n="guide_kanban_subtitle">讓多個 AI Bot 在同一個 Kanban 看板協作，任務卡片自動流動，卡住就催促</p>
@@ -2205,6 +2365,26 @@ POST /api/mission/card/:id/comment
 
                     <!-- ── GPS 定位智慧推薦 Demo ── -->
                     <div class="guide-panel" id="guide-usecase-gps">
+                    <script type="application/ld+json">
+                    {
+                      "@context": "https://schema.org",
+                      "@type": "TechArticle",
+                      "headline": "GPS 定位智慧推薦 — 位置分享 → 附近美食、停車場、景點",
+                      "description": "Share live GPS location to a bot agent to receive nearby restaurant, parking, and attraction recommendations.",
+                      "url": "https://eclawbot.com/portal/info.html#guide-usecase-gps",
+                      "isPartOf": {
+                        "@type": "WebSite",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "publisher": {
+                        "@type": "Organization",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "inLanguage": "zh-Hant"
+                    }
+                    </script>
                         <header>
                             <h1 data-i18n="guide_gps_title">📍 GPS 定位智慧推薦 — 位置分享 → 附近美食、停車場、景點</h1>
                             <p class="meta" data-i18n="guide_gps_subtitle">問一句「附近哪裡吃飯？」，Bot 請求 GPS 位置，即刻推薦最近的好去處</p>
@@ -2323,6 +2503,26 @@ POST /api/mission/card/:id/comment
 
                     <!-- ── 實用案例：Bot 廣場 ── -->
                     <div class="guide-panel" id="guide-usecase-bot-plaza">
+                    <script type="application/ld+json">
+                    {
+                      "@context": "https://schema.org",
+                      "@type": "TechArticle",
+                      "headline": "Bot 廣場 — 發現與分享 AI 代理",
+                      "description": "Bot Plaza discovery: browse, install, and share AI agents from the OpenClaw community.",
+                      "url": "https://eclawbot.com/portal/info.html#guide-usecase-bot-plaza",
+                      "isPartOf": {
+                        "@type": "WebSite",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "publisher": {
+                        "@type": "Organization",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "inLanguage": "zh-Hant"
+                    }
+                    </script>
                         <header>
                             <h1 data-i18n="guide_bp_title">Bot 廣場 — 發現與分享 AI 代理</h1>
                             <p class="meta" data-i18n="guide_bp_meta">探索公開的 AI Bot 名片，找到你需要的智慧助手，或讓更多人發現你的 Bot</p>
@@ -2391,6 +2591,26 @@ POST /api/mission/card/:id/comment
 
                     <!-- ── 實用案例：動態桌布 ── -->
                     <div class="guide-panel" id="guide-usecase-live-wallpaper">
+                    <script type="application/ld+json">
+                    {
+                      "@context": "https://schema.org",
+                      "@type": "TechArticle",
+                      "headline": "動態桌布 — 讓 AI 住進你的手機桌布",
+                      "description": "Live wallpaper companion: an animated AI agent embedded in your Android home-screen wallpaper that responds to taps and weather.",
+                      "url": "https://eclawbot.com/portal/info.html#guide-usecase-live-wallpaper",
+                      "isPartOf": {
+                        "@type": "WebSite",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "publisher": {
+                        "@type": "Organization",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "inLanguage": "zh-Hant"
+                    }
+                    </script>
                         <header>
                             <h1 data-i18n="guide_wp_title">動態桌布 — 讓 AI 住進你的手機桌布</h1>
                             <p class="meta" data-i18n="guide_wp_meta">EClawbot Android App 獨特功能：AI Bot 的對話介面直接成為你的手機動態桌布</p>
@@ -2465,6 +2685,26 @@ POST /api/mission/card/:id/comment
 
                     <!-- ── 實用案例：Gatekeeper 安全守門員 ── -->
                     <div class="guide-panel" id="guide-usecase-gatekeeper">
+                    <script type="application/ld+json">
+                    {
+                      "@context": "https://schema.org",
+                      "@type": "TechArticle",
+                      "headline": "安全守門員 — 保護你的 Bot 不被濫用",
+                      "description": "Gatekeeper rate-limit and abuse protection that shields hosted bots from prompt injection, spam, and runaway loops.",
+                      "url": "https://eclawbot.com/portal/info.html#guide-usecase-gatekeeper",
+                      "isPartOf": {
+                        "@type": "WebSite",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "publisher": {
+                        "@type": "Organization",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "inLanguage": "zh-Hant"
+                    }
+                    </script>
                         <header>
                             <h1 data-i18n="guide_gk_title">安全守門員 — 保護你的 Bot 不被濫用</h1>
                             <p class="meta" data-i18n="guide_gk_meta">六層過濾機制，攔截惡意訊息、防止轟炸、黑白名單精準控制</p>
@@ -2578,6 +2818,26 @@ POST /api/mission/card/:id/comment
 
                     <!-- ── 實用案例：多平台同步 ── -->
                     <div class="guide-panel" id="guide-usecase-multiplatform">
+                    <script type="application/ld+json">
+                    {
+                      "@context": "https://schema.org",
+                      "@type": "TechArticle",
+                      "headline": "多平台同步 — 一個 Bot，三個螢幕",
+                      "description": "Multi-platform sync: one bot identity stays consistent across web portal, Android app, and iOS app with shared history.",
+                      "url": "https://eclawbot.com/portal/info.html#guide-usecase-multiplatform",
+                      "isPartOf": {
+                        "@type": "WebSite",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "publisher": {
+                        "@type": "Organization",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "inLanguage": "zh-Hant"
+                    }
+                    </script>
                         <header>
                             <h1 data-i18n="guide_mp_title">多平台同步 — 一個 Bot，三個螢幕</h1>
                             <p class="meta" data-i18n="guide_mp_meta">Web Portal、Android App、iOS App 即時同步，切換裝置不遺漏任何訊息</p>
@@ -2672,6 +2932,26 @@ POST /api/mission/card/:id/comment
 
                     <!-- ── 遊戲工廠 MiniGame Showcase ── -->
                     <div class="guide-panel" id="guide-usecase-minigame">
+                    <script type="application/ld+json">
+                    {
+                      "@context": "https://schema.org",
+                      "@type": "TechArticle",
+                      "headline": "遊戲工廠 — 4 個 AI Agent 協作開發 298 款遊戲",
+                      "description": "Game factory case study: four collaborating AI agents shipped 298 mini-games via assembly-line A2A workflows.",
+                      "url": "https://eclawbot.com/portal/info.html#guide-usecase-minigame",
+                      "isPartOf": {
+                        "@type": "WebSite",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "publisher": {
+                        "@type": "Organization",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "inLanguage": "zh-Hant"
+                    }
+                    </script>
                         <header>
                             <h1 data-i18n="guide_mg_title">🎮 遊戲工廠 — 4 個 AI Agent 協作開發 298 款遊戲</h1>
                             <p class="meta" data-i18n="guide_mg_meta">1 週半、零人工干涉、純 AI 協作完成</p>
@@ -2824,6 +3104,26 @@ graph LR
 
                     <!-- ── 終端橋接 + 橋接授權 組合技 ── -->
                     <div class="guide-panel" id="guide-usecase-bridge">
+                    <script type="application/ld+json">
+                    {
+                      "@context": "https://schema.org",
+                      "@type": "TechArticle",
+                      "headline": "終端橋接 + 橋接授權 — Claude Code 多 session 自動化",
+                      "description": "Terminal bridge + bridge-auth pattern that lets a commander Claude Code session drive subordinate sessions via osascript without focus theft.",
+                      "url": "https://eclawbot.com/portal/info.html#guide-usecase-bridge",
+                      "isPartOf": {
+                        "@type": "WebSite",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "publisher": {
+                        "@type": "Organization",
+                        "name": "EClawbot",
+                        "url": "https://eclawbot.com"
+                      },
+                      "inLanguage": "zh-Hant"
+                    }
+                    </script>
                         <header>
                             <h1 data-i18n="guide_bridge_title">🌉 終端橋接 + 橋接授權 — Claude Code 多 session 自動化</h1>
                             <p class="meta" data-i18n="guide_bridge_meta">讓一個 main Claude Code 指揮多個 sub-Claude，在各自的 terminal 跑平行任務；sub 的 MCP 授權由 main 自動按鍵完成，全流程無人介入。</p>
@@ -3291,6 +3591,26 @@ sequenceDiagram
 
         <!-- ══════ Tab 3: Advanced ══════ -->
         <div class="info-panel" id="panel-advanced">
+            <script type="application/ld+json">
+            {
+              "@context": "https://schema.org",
+              "@type": "TechArticle",
+              "headline": "EClawbot Advanced — Architecture, A2A protocol, Webhook push",
+              "description": "Advanced topics: A2A protocol design, Webhook push internals, channel plugin architecture, and bot identity layer.",
+              "url": "https://eclawbot.com/portal/info.html#panel-advanced",
+              "isPartOf": {
+                "@type": "WebSite",
+                "name": "EClawbot",
+                "url": "https://eclawbot.com"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "EClawbot",
+                "url": "https://eclawbot.com"
+              },
+              "inLanguage": "zh-Hant"
+            }
+            </script>
             <div class="guide-layout">
                 <div class="guide-sidebar" id="guideSidebarAdv">
                     <button class="guide-sidebar-btn active" data-guide="architecture" data-i18n="guide_nav_architecture">系統架構</button>
@@ -4077,6 +4397,26 @@ done</code></pre></div>
 
         <!-- ══════ Tab: Channel Plugins ══════ -->
         <div class="info-panel" id="panel-channel-plugins">
+            <script type="application/ld+json">
+            {
+              "@context": "https://schema.org",
+              "@type": "TechArticle",
+              "headline": "Channel Plugins — Telegram, Discord, Slack, Webhook bridge",
+              "description": "Channel plugin reference for connecting bots to Telegram, Discord, Slack, and any HTTP-based platform via the bridge layer.",
+              "url": "https://eclawbot.com/portal/info.html#panel-channel-plugins",
+              "isPartOf": {
+                "@type": "WebSite",
+                "name": "EClawbot",
+                "url": "https://eclawbot.com"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "EClawbot",
+                "url": "https://eclawbot.com"
+              },
+              "inLanguage": "zh-Hant"
+            }
+            </script>
             <div class="guide-layout">
                 <div class="guide-sidebar" id="guideSidebarChannelPlugins">
                     <button class="guide-sidebar-btn active" data-guide="openclaw-channel" data-i18n="guide_nav_openclaw_channel">OpenClaw Channel</button>
@@ -4971,6 +5311,31 @@ platforms:
              TAB 3: RELEASE NOTES
              ══════════════════════════════════════════════════ -->
         <div class="info-panel" id="panel-release-notes">
+            <script type="application/ld+json">
+            {
+              "@context": "https://schema.org",
+              "@type": "BlogPosting",
+              "headline": "EClawbot Release Notes",
+              "description": "Release notes feed documenting EClawbot version bumps, feature additions, bug fixes, and migration guides.",
+              "url": "https://eclawbot.com/portal/info.html#panel-release-notes",
+              "isPartOf": {
+                "@type": "WebSite",
+                "name": "EClawbot",
+                "url": "https://eclawbot.com"
+              },
+              "publisher": {
+                "@type": "Organization",
+                "name": "EClawbot",
+                "url": "https://eclawbot.com"
+              },
+              "inLanguage": "zh-Hant",
+              "author": {
+                "@type": "Organization",
+                "name": "EClawbot",
+                "url": "https://eclawbot.com"
+              }
+            }
+            </script>
             <div class="rn-hero">
                 <div class="rn-hero-title" data-i18n="rn_hero_title">Release Notes</div>
                 <div class="rn-hero-subtitle" data-i18n="rn_hero_subtitle">What's new in EClawbot — features, improvements, and fixes across the platform.</div>


### PR DESCRIPTION
## Summary
- Phase 2 of card_854e23428693d4c62eb7465d (SEO structured-data audit)
- Adds 18 new ld+json blocks across the remaining content panels
- Final tally on the page: 20 blocks total — 1 SoftwareApplication + 17 TechArticle + 1 FAQPage (Phase 1 PR #3035) + 1 BlogPosting

## Coverage
- 13 guide-usecase-* panels → TechArticle each, headline mirrors visible h1
- 4 wrapper panels (panel-quickstart, panel-guide, panel-advanced, panel-channel-plugins) → TechArticle
- panel-release-notes → BlogPosting

## Why TechArticle instead of audit-recommended HowTo
Use-case panels are overviews/showcases, not strict step-by-step tutorials. Google penalizes HowTo schema when the page steps don't exactly match the JSON-LD steps; TechArticle has no such constraint and matches the actual content shape.

## Test plan
- [x] All 20 ld+json blocks parse via `json.loads`
- [x] Each TechArticle carries `@context` / `@type` / `headline` / `description` / `url` / `isPartOf` / `publisher` / `inLanguage`
- [ ] CI green
- [ ] Merge + Railway deploy
- [ ] Validate via Google Rich Results Test (Phase 1 FAQPage + Phase 2 TechArticle/BlogPosting)
- [ ] Move card to done

## Skipped from card scope
- `panel-boundaries` — content is policy/scope boundaries, not strictly FAQ. Will revisit if SEO audit re-flags it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)