### PR TITLE
fix(point-edit Track C): refresh anchor registry on entering mindmap mode

### DIFF
--- a/backend/public/portal/shared/point-edit-demo.js
+++ b/backend/public/portal/shared/point-edit-demo.js
@@ -368,6 +368,12 @@
                 b.classList.toggle('active', b.dataset.pedMode === next);
             });
             if (mindmap) mindmap.hidden = next !== 'mindmap';
+            // When entering mindmap mode, refresh the anchor registry. If the
+            // panel was hidden at boot (`?demo=pointedit` users land on another
+            // tab first), `getBoundingClientRect` returned all-zeros — once the
+            // panel is visible we have real layout to capture so the next click
+            // emits a meaningful `rect`.
+            if (next === 'mindmap') refreshAnchorRegistry();
             if (statusEl) {
                 statusEl.dataset.state = 'idle';
                 if (next === 'dom') {

--- a/backend/tests/jest/point-edit-demo-mindmap.test.js
+++ b/backend/tests/jest/point-edit-demo-mindmap.test.js
@@ -56,6 +56,8 @@ describe('Track C — mind-map mock', () => {
         expect(b).toMatch(/mode !== ['"]mindmap['"]/);
         // Registry refresh on resize so rect stays accurate
         expect(b).toMatch(/window\.addEventListener\(['"]resize['"], refreshAnchorRegistry/);
+        // Registry refresh on entering mindmap mode (panel may have been hidden at boot)
+        expect(b).toMatch(/if \(next === ['"]mindmap['"]\) refreshAnchorRegistry\(\)/);
     });
 
     test('HTML widget exposes 6 nodes mapped to the canonical sandbox anchors', () => {


### PR DESCRIPTION
## Summary
Follow-up to PR #3040 (Track C mind-map mock). The boot-time anchor registry captures `getBoundingClientRect` for every sandbox `[data-point-edit-id]` block, but the rect is all-zeros when `panel-point-edit-demo` is hidden at boot. Users arriving via `?demo=pointedit` land on `panel-quickstart` by default, so the first click on a mind-map node was emitting `rect: {x:0, y:0, w:0, h:0}`.

## Fix
Call `refreshAnchorRegistry()` inside `setMode()` when transitioning into mindmap mode, on top of the existing resize listener. By that point the panel is visible so `getBoundingClientRect` returns real geometry.

## Test plan
- [x] jest case asserts the new line is present in `boot()` (8/8 still pass)
- [x] Local JS syntax check
- Spotted during PR #3040 prod E2E — composer payload pane showed `rect: {x: 0, ...}` on first click; with this fix it should report the real sandbox-relative geometry

🤖 Generated with [Claude Code](https://claude.com/claude-code)