### PR TITLE
fix(petdx Phase 0): dashboard ❓ avatars — guard renderAvatarHtml canvas branch against procedural-only descriptors

### DIFF
--- a/backend/public/portal/shared/entity-utils.js
+++ b/backend/public/portal/shared/entity-utils.js
@@ -153,13 +153,23 @@ function _petdxCanRenderCanvas(entityId) {
     const d = window.AvatarPetdx.getDescriptor(entityId);
     if (!d) return false;
     // Spritesheet renderer is the only path PetdxRenderer.createRenderer
-    // currently knows how to draw. Procedural descriptors are recorded
-    // in the descriptor cache for future Phase 0.1 use but must not win
-    // the canvas branch today.
+    // currently knows how to draw end-to-end. Procedural descriptors are
+    // recorded in the descriptor cache for future Phase 0.1 use but must
+    // not win the canvas branch today (the lobster-procedural drawer
+    // exists, but the mount → createRenderer wiring still needs work —
+    // tracked separately).
+    //
+    // Defense in depth (per #6 review on PR #3044): also require a sheet
+    // URL on the descriptor. A "tagged spritesheet but no URL" descriptor
+    // — possible during transient API failures — would otherwise emit a
+    // canvas that PetdxRenderer can't draw, reproducing the same ❓ bug.
     const inner = d.descriptor || d;
-    if (inner && inner.assetType === 'spritesheet') return true;
-    if (d.assetType === 'spritesheet') return true;
-    return false;
+    const node = inner && inner.assetType === 'spritesheet' ? inner
+        : d.assetType === 'spritesheet' ? d
+        : null;
+    if (!node) return false;
+    const sheetUrl = (node.asset && node.asset.url) || node.assetUrl;
+    return typeof sheetUrl === 'string' && sheetUrl.length > 0;
 }
 function renderAvatarHtml(avatar, size, entityId) {
     size = size || 48;

--- a/backend/public/portal/shared/entity-utils.js
+++ b/backend/public/portal/shared/entity-utils.js
@@ -127,21 +127,43 @@ function isAvatarUrl(avatar) {
  * Render an avatar as HTML. Returns an <img> tag for URLs, or emoji text for emoji avatars.
  *
  * If `entityId` is provided AND `window.AvatarPetdx` has a cached
- * companion descriptor for that entity, emits a placeholder canvas
- * instead so AvatarPetdx.mount() can animate it. Pages should call
+ * companion descriptor for that entity AND that descriptor has a
+ * renderable spritesheet asset, emits a placeholder canvas so
+ * AvatarPetdx.mount() can animate it. Pages should call
  * AvatarPetdx.preload(...) once on init, then AvatarPetdx.mount(root)
  * after each batch of markup that contains these placeholders.
+ *
+ * Procedural-only descriptors (e.g. the Phase 0 petdx-lobster-default,
+ * which carries `asset.renderer: 'lobster-procedural'` but no
+ * spritesheet) intentionally fall through to the URL/emoji path, since
+ * PetdxRenderer can't draw them yet (Phase 0.1 follow-up). Without
+ * this guard the canvas placeholder is emitted and stays blank, which
+ * the user sees as a ❓ on the dashboard chip — exactly the bug
+ * card_44017ea5 captured the morning after PR #3032 backfilled
+ * default petdx companions for every entity.
  *
  * @param {string} avatar - emoji string or image URL
  * @param {number} [size=48] - size in px (for image avatars)
  * @param {number} [entityId] - optional entityId to consider for petdx render
  */
+function _petdxCanRenderCanvas(entityId) {
+    if (typeof window === 'undefined' || !window.AvatarPetdx) return false;
+    if (!window.AvatarPetdx.hasDescriptor(entityId)) return false;
+    if (typeof window.AvatarPetdx.getDescriptor !== 'function') return false;
+    const d = window.AvatarPetdx.getDescriptor(entityId);
+    if (!d) return false;
+    // Spritesheet renderer is the only path PetdxRenderer.createRenderer
+    // currently knows how to draw. Procedural descriptors are recorded
+    // in the descriptor cache for future Phase 0.1 use but must not win
+    // the canvas branch today.
+    const inner = d.descriptor || d;
+    if (inner && inner.assetType === 'spritesheet') return true;
+    if (d.assetType === 'spritesheet') return true;
+    return false;
+}
 function renderAvatarHtml(avatar, size, entityId) {
     size = size || 48;
-    if (entityId != null
-        && typeof window !== 'undefined'
-        && window.AvatarPetdx
-        && window.AvatarPetdx.hasDescriptor(entityId)) {
+    if (entityId != null && _petdxCanRenderCanvas(entityId)) {
         // imageRendering keeps the spritesheet pixel-art crisp at small sizes;
         // matches PetdxRenderer's ctx.imageSmoothingEnabled = false.
         return '<canvas class="entity-avatar-canvas" '

--- a/backend/tests/jest/portal-entity-avatar-canvas-guard.test.js
+++ b/backend/tests/jest/portal-entity-avatar-canvas-guard.test.js
@@ -1,0 +1,90 @@
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const SRC_PATH = path.join(__dirname, '../../public/portal/shared/entity-utils.js');
+const SRC = fs.readFileSync(SRC_PATH, 'utf8');
+
+function loadResolver() {
+    const ctx = {
+        window: {},
+        localStorage: { _data: {}, getItem(k) { return this._data[k] || null; }, setItem(k, v) { this._data[k] = v; } },
+        console,
+    };
+    vm.createContext(ctx);
+    vm.runInContext(SRC, ctx);
+    return ctx;
+}
+
+const PETDX_LOBSTER_URL = '/static/companions/petdx-lobster-default/avatar.png';
+
+describe('renderAvatarHtml — canvas-vs-URL guard (Phase 0 dashboard bug fix)', () => {
+    test('procedural descriptor falls through to <img> tag — does not emit blank canvas', () => {
+        const ctx = loadResolver();
+        // Simulate the petdx-lobster-default descriptor that PR #3032 backfilled —
+        // procedural asset, no spritesheet, descriptor.avatar.url is null.
+        ctx.window.AvatarPetdx = {
+            hasDescriptor: (id) => id === 1,
+            getDescriptor: (id) => id === 1 ? {
+                assetType: 'procedural',
+                descriptor: { assetType: 'procedural', asset: { renderer: 'lobster-procedural' } },
+            } : null,
+            descriptorAvatarUrl: () => null,
+        };
+        ctx.updateEntityMaps([{ entityId: 1, character: 'LOBSTER', avatar: null, petdxAvatarUrl: PETDX_LOBSTER_URL }]);
+        const html = ctx.renderAvatarHtml(ctx.getAvatarForEntity(1), 48, 1);
+        expect(html).toContain('<img');
+        expect(html).toContain('src="' + PETDX_LOBSTER_URL + '"');
+        expect(html).not.toContain('data-petdx-entity-id');
+        expect(html).not.toContain('<canvas');
+    });
+
+    test('spritesheet descriptor still emits canvas placeholder (Phase 0.1 + custom companions)', () => {
+        const ctx = loadResolver();
+        ctx.window.AvatarPetdx = {
+            hasDescriptor: (id) => id === 2,
+            getDescriptor: (id) => id === 2 ? {
+                assetType: 'spritesheet',
+                descriptor: { assetType: 'spritesheet', asset: { url: 'https://r2/sprite.webp' } },
+            } : null,
+            descriptorAvatarUrl: () => 'https://r2/sprite.webp',
+        };
+        ctx.updateEntityMaps([{ entityId: 2, character: 'LOBSTER', avatar: '🐱' }]);
+        const html = ctx.renderAvatarHtml(ctx.getAvatarForEntity(2), 48, 2);
+        expect(html).toContain('<canvas');
+        expect(html).toContain('data-petdx-entity-id="2"');
+    });
+
+    test('no AvatarPetdx loaded — emits img for URL avatars (baseline)', () => {
+        const ctx = loadResolver();
+        ctx.updateEntityMaps([{ entityId: 1, character: 'LOBSTER', avatar: null, petdxAvatarUrl: PETDX_LOBSTER_URL }]);
+        const html = ctx.renderAvatarHtml(ctx.getAvatarForEntity(1), 48, 1);
+        expect(html).toContain('<img src="' + PETDX_LOBSTER_URL + '"');
+        expect(html).not.toContain('<canvas');
+    });
+
+    test('emoji avatar still renders as text when no descriptor', () => {
+        const ctx = loadResolver();
+        ctx.window.AvatarPetdx = {
+            hasDescriptor: () => false,
+            getDescriptor: () => null,
+            descriptorAvatarUrl: () => null,
+        };
+        ctx.updateEntityMaps([{ entityId: 1, character: 'LOBSTER', avatar: '🐱' }]);
+        const html = ctx.renderAvatarHtml('🐱', 48, 1);
+        expect(html).toBe('🐱');
+    });
+
+    test('_petdxCanRenderCanvas handles missing getDescriptor (older avatar-petdx)', () => {
+        const ctx = loadResolver();
+        ctx.window.AvatarPetdx = {
+            hasDescriptor: () => true,
+            // getDescriptor missing — older builds
+        };
+        ctx.updateEntityMaps([{ entityId: 1, character: 'LOBSTER', avatar: null, petdxAvatarUrl: PETDX_LOBSTER_URL }]);
+        const html = ctx.renderAvatarHtml(ctx.getAvatarForEntity(1), 48, 1);
+        // Without getDescriptor, the guard refuses canvas → falls back to img
+        expect(html).toContain('<img');
+        expect(html).not.toContain('<canvas');
+    });
+});

--- a/backend/tests/jest/portal-entity-avatar-canvas-guard.test.js
+++ b/backend/tests/jest/portal-entity-avatar-canvas-guard.test.js
@@ -87,4 +87,36 @@ describe('renderAvatarHtml — canvas-vs-URL guard (Phase 0 dashboard bug fix)',
         expect(html).toContain('<img');
         expect(html).not.toContain('<canvas');
     });
+
+    test('spritesheet descriptor with no sheet URL is treated as un-renderable (per #6 review)', () => {
+        const ctx = loadResolver();
+        ctx.window.AvatarPetdx = {
+            hasDescriptor: () => true,
+            // descriptor is tagged spritesheet but the API failed to return a sheet URL.
+            // Emitting a canvas would reproduce the same blank-canvas ❓ that motivated this fix.
+            getDescriptor: () => ({
+                assetType: 'spritesheet',
+                descriptor: { assetType: 'spritesheet', asset: {} },
+            }),
+        };
+        ctx.updateEntityMaps([{ entityId: 1, character: 'LOBSTER', avatar: null, petdxAvatarUrl: PETDX_LOBSTER_URL }]);
+        const html = ctx.renderAvatarHtml(ctx.getAvatarForEntity(1), 48, 1);
+        expect(html).toContain('<img src="' + PETDX_LOBSTER_URL + '"');
+        expect(html).not.toContain('<canvas');
+    });
+
+    test('spritesheet descriptor with assetUrl (alt shape) also flows through', () => {
+        const ctx = loadResolver();
+        ctx.window.AvatarPetdx = {
+            hasDescriptor: () => true,
+            getDescriptor: () => ({
+                assetType: 'spritesheet',
+                assetUrl: 'https://r2/sheet.webp',
+            }),
+        };
+        ctx.updateEntityMaps([{ entityId: 1, character: 'LOBSTER', avatar: '🐱' }]);
+        const html = ctx.renderAvatarHtml('🐱', 48, 1);
+        expect(html).toContain('<canvas');
+        expect(html).toContain('data-petdx-entity-id="1"');
+    });
 });


### PR DESCRIPTION
## Bug
Closes card_44017ea5. Hank woke up to find the dashboard chip for #1 / #4 / #5 / #6 showing ❓ instead of the procedural lobster avatar. Only #2 / #3 (which have real R2 spritesheet companions) kept rendering correctly.

## Root cause
After PR #3032 backfilled `PETDX_CURRENT_<id> = petdx-lobster-default` for every default entity, the Phase 0 §0.4 resolver chain correctly returned `/static/companions/petdx-lobster-default/avatar.png`. But `renderAvatarHtml` short-circuits on `AvatarPetdx.hasDescriptor(id)` and always emits a canvas placeholder when ANY descriptor is cached — ignoring the URL the resolver just computed.

PetdxRenderer can only draw spritesheet descriptors. The petdx-lobster-default descriptor is `assetType: 'procedural'` with `asset.renderer: 'lobster-procedural'`, which PetdxRenderer doesn't implement yet. The canvas stays blank → browser surfaces ❓.

## E2E proof
Playwright on https://eclawbot.com/portal/dashboard.html (before fix):
```
entity 1: resolverAvatar=/static/.../avatar.png, apHasDesc:true, apDescUrl:null
entity 2: resolverAvatar=🐱, apDescUrl=https://pub-...r2.dev/.../sprite.webp
canvas_petdx_count=6, img_petdx_count=0, question_marks_visible=1
```

## Fix
Add `_petdxCanRenderCanvas(entityId)` that only returns true when the cached descriptor's `assetType === 'spritesheet'`. Procedural-only descriptors fall through to the URL/emoji branch, which picks up the avatar.png URL via the §0.4 resolver chain.

## Follow-up (separate card)
Phase 0.1: implement `lobster-procedural` renderer in PetdxRenderer so the canvas-driven animation path works for procedural descriptors. Until then the static avatar.png is the correct visual.

## Test plan
- [x] 5 new jest cases in `tests/jest/portal-entity-avatar-canvas-guard.test.js` (procedural → img, spritesheet → canvas, missing AvatarPetdx → baseline, emoji unchanged, missing getDescriptor safety)
- [x] 18 existing `portal-entity-avatar-resolver.test.js` cases still pass
- [ ] CI green
- [ ] Merge + Railway deploy
- [ ] Reload dashboard.html and verify all 6 entities render proper avatars (4 procedural lobster img + 2 R2 sprite canvas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)