### PR TITLE
fix(petdx Phase 0): live descriptor URL beats stale vault enrichment in §0.4 chain

### DIFF
--- a/backend/public/portal/shared/entity-utils.js
+++ b/backend/public/portal/shared/entity-utils.js
@@ -77,11 +77,25 @@ function _petdxDescriptorAvatarUrl(entityId) {
 }
 
 /**
- * Get the avatar for an entity, per Phase 0 amendment §0.4 priority chain:
+ * Get the avatar for an entity, per the §0.4 priority chain.
+ *
+ * Originally Phase 0 placed the /api/entities enrichment URL ahead of the
+ * live descriptor URL on the assumption that the enrichment ALWAYS reflects
+ * the current companion selection — but `/api/companion/select` updates the
+ * companion-current table without writing back to PETDX_AVATAR_<id>, so the
+ * vault enrichment quickly goes stale once a user borrows or switches
+ * companions through the marketplace. The dashboard then keeps painting the
+ * Phase-0 default lobster even when the entity is wearing a rented sprite
+ * companion (see card_44017ea5 follow-up + Hank's morning report).
+ *
+ * Live descriptor URL is now ahead of vault enrichment. The vault entry stays
+ * in the chain as a fast-paint fallback for the brief window before
+ * AvatarPetdx.preload() resolves.
+ *
  *   1. _entityAvatarMap (explicit non-default avatar — URL or user-set emoji)
  *   2. localStorage user override
- *   3. _entityPetdxAvatarMap (PETDX_AVATAR_<id> from /api/entities enrichment)
- *   4. AvatarPetdx.descriptorAvatarUrl(entityId) — cached descriptor.avatar.url
+ *   3. AvatarPetdx.descriptorAvatarUrl(entityId) — live cached companion URL
+ *   4. _entityPetdxAvatarMap (PETDX_AVATAR_<id> from /api/entities enrichment) — fast-paint fallback
  *   5. live character → emoji (PR #3027 stopgap, kept until §0.6 quarantine ends)
  *   6. legacy ENTITY_CHARS_DEFAULT
  *   7. final emoji fallback
@@ -90,10 +104,10 @@ function getAvatarForEntity(entityId) {
     if (_entityAvatarMap[entityId]) return _entityAvatarMap[entityId];
     const saved = localStorage.getItem('eclaw_avatar_' + entityId);
     if (saved) return saved;
-    const fromEnrichment = _petdxAvatarUrl(entityId);
-    if (fromEnrichment) return fromEnrichment;
     const fromDescriptor = _petdxDescriptorAvatarUrl(entityId);
     if (fromDescriptor) return fromDescriptor;
+    const fromEnrichment = _petdxAvatarUrl(entityId);
+    if (fromEnrichment) return fromEnrichment;
     const fromCharacter = _characterEmoji(entityId);
     if (fromCharacter) return fromCharacter;
     const char = ENTITY_CHARS_DEFAULT[entityId];

--- a/backend/tests/jest/portal-entity-avatar-resolver.test.js
+++ b/backend/tests/jest/portal-entity-avatar-resolver.test.js
@@ -114,6 +114,22 @@ describe('portal entity-utils — Phase 0 petdx-aware resolver chain', () => {
         expect(ctx.getAvatarForEntity(1)).toBe(PETDX_LOBSTER_URL);
     });
 
+    test('live descriptor URL wins over stale vault enrichment when companion was switched via marketplace', () => {
+        // Repro for the morning-after-Phase-0 regression: backfill wrote
+        // PETDX_AVATAR_<id> = lobster URL, then the user borrowed an R2
+        // spritesheet companion via /api/companion/select. /api/companion/select
+        // doesn't sync the vault, so the enrichment goes stale. The live
+        // descriptor must win or the dashboard keeps painting lobster forever.
+        const ctx = loadResolver();
+        const R2_SPRITE = 'https://pub-94495283df974cfea5e98d6a9e3fa462.r2.dev/pets/zoro-9889c11ded54/sprite.webp';
+        ctx.window.AvatarPetdx = {
+            descriptorAvatarUrl: (id) => id === 1 ? R2_SPRITE : null,
+        };
+        ctx.updateEntityMaps([{ entityId: 1, name: 'Mac_F', character: 'LOBSTER', avatar: null,
+            petdxAvatarUrl: PETDX_LOBSTER_URL }]);
+        expect(ctx.getAvatarForEntity(1)).toBe(R2_SPRITE);
+    });
+
     test('character emoji stopgap still fires when no petdx layer answers', () => {
         const ctx = loadResolver();
         ctx.updateEntityMaps([{ entityId: 1, character: 'LOBSTER', avatar: null }]);


### PR DESCRIPTION
## Bug
Closes the regression Hank reported at 09:02 TW (card_ad62e4a follow-up) + the kanban assignee avatar mismatch he flagged.

Even after PR #3044 stopped the dashboard from rendering blank canvases, the entities #1 Mac_F / #4 Eclaw_Office / #5 Hermes / #6 Codex were still showing the Phase-0 default lobster avatar.png instead of the R2 sprite companions they had been switched to via the marketplace (zoro / nezukocoder / kyojuro-rengoku / steve-jobs respectively).

## Root cause
- Phase 0 §0.4 chain order placed `_petdxAvatarUrl` (vault `PETDX_AVATAR_<id>`, via `/api/entities` enrichment) ahead of `AvatarPetdx.descriptorAvatarUrl` (live descriptor).
- `/api/companion/select` updates `companion_select_log` + `companion_current` but does NOT write back to `PETDX_AVATAR_<id>`.
- So after a marketplace borrow / companion switch, the vault enrichment stays pointed at whatever Phase 0 last backfilled (default lobster).
- Browser AvatarPetdx layer correctly fetches the LIVE companion via `/api/companion/current`, but the §0.4 chain hands `renderAvatarHtml` the stale vault URL first.
- Result: dashboard + kanban repaint the Phase-0 default lobster on top of the actual borrowed companion.

E2E confirmation (kanban probe before fix):
```
entity 1: resolverAvatar=/static/.../avatar.png, apDescUrl=https://r2.dev/.../zoro/sprite.webp
entity 4: resolverAvatar=/static/.../avatar.png, apDescUrl=https://r2.dev/.../nezukocoder/sprite.webp
entity 5: resolverAvatar=/static/.../avatar.png, apDescUrl=https://r2.dev/.../kyojuro-rengoku/sprite.webp
entity 6: resolverAvatar=/static/.../avatar.png, apDescUrl=https://r2.dev/.../steve-jobs/sprite.webp
img_petdx_count=80, img_r2_pets_count=0
```

## Fix
Swap steps 3 and 4 in the chain so the live descriptor URL wins over the vault enrichment. Vault stays as a fast-paint fallback for the brief boot window before `AvatarPetdx.preload()` resolves.

## Tests
- +1 jest case in `portal-entity-avatar-resolver.test.js` reproduces the marketplace-borrow scenario
- All 19 resolver cases + 7 canvas-guard cases still pass (26/26)

## Backend follow-up (separate card)
Have `/api/companion/select` also write `PETDX_AVATAR_<id>` + `PETDX_SOURCE_<id> = user-selected` so the vault stops going stale in the first place. Without that, the chain reorder is still correct but the enrichment is permanently misleading for any post-Phase-0 selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)