### PR TITLE
feat(petdx Phase 0): atomic vault sync on /api/companion/select (§0.4a)

### DIFF
--- a/backend/companion-api.js
+++ b/backend/companion-api.js
@@ -193,11 +193,15 @@ async function initCompanionDatabase(serverLog = console.log) {
     }
 }
 
-module.exports = function companionFactory({ authenticateBot, authenticateDeviceOrBot, serverLog } = {}) {
+module.exports = function companionFactory({ authenticateBot, authenticateDeviceOrBot, serverLog, createPetdxPhase0Io } = {}) {
     if (typeof authenticateBot !== 'function') {
         throw new Error('companionFactory requires authenticateBot');
     }
     const log = serverLog || (() => {});
+    // Optional: if not injected (e.g. some unit tests), /api/companion/select
+    // falls back to the legacy log-only path. The §0.4a invariant only holds
+    // when the IO factory is wired in (production + jest integration tests).
+    const petdxIoFactory = typeof createPetdxPhase0Io === 'function' ? createPetdxPhase0Io : null;
     const router = express.Router();
 
     // Submit rate-limit: per-entity sliding window, factory-scoped so unit
@@ -404,7 +408,38 @@ module.exports = function companionFactory({ authenticateBot, authenticateDevice
 
     // ── POST /api/companion/select ────────────────────────────────
     // Body: { companionId, source? }
-    // Appends a row to companion_select_log; returns the newly-current selection.
+    //
+    // Spec: docs/specs/petdx-uiux-spec-amendment-2026-05-31-phase-0-4a.md §0.4a.
+    //
+    // Atomic write across two state layers:
+    //   1. companion_select_log row (with origin='user-selected' — the new
+    //      audit column from the 2026-05-30-companion-origin migration).
+    //   2. Vault keys PETDX_CURRENT_<id>, PETDX_AVATAR_<id>, PETDX_SOURCE_<id>
+    //      via createPetdxPhase0Io().setDeviceVars (the same factory the bind
+    //      hook uses, so write semantics stay consistent).
+    //
+    // The spec invariant is "no partial success." Implementation:
+    //   a. Resolve the avatar URL from the companions row BEFORE any write
+    //      opens, so the write phase only does writes.
+    //   b. Snapshot prior vault values for the three keys (so we can restore
+    //      on a downstream log-tx failure).
+    //   c. Open a tx on a client checked out from the local pool. INSERT
+    //      the log row, but DO NOT commit yet.
+    //   d. Write the vault keys. If that throws, ROLLBACK the log tx and
+    //      return 500 {layer:'vault'}.
+    //   e. Try to COMMIT the log tx. If COMMIT throws, restore the prior
+    //      vault values and return 500 {layer:'log'}.
+    //   f. On success, both layers are consistent: vault matches the latest
+    //      log row, and the §0.4 resolver chain can read either.
+    //
+    // The vault and log writes use different pg pools (the IO factory has its
+    // own chatPool; the log uses companion-api's local pool). True
+    // cross-pool 2PC is not on the table — instead the write order plus
+    // explicit vault restore on log COMMIT failure gives the same observable
+    // guarantee: either both layers reflect the new selection, or neither
+    // does. The only window where they can disagree is between vault write
+    // and log COMMIT, and the restore step closes that window unless the
+    // restore itself throws (logged loudly, then the route returns 500).
     router.post('/select', authReader, async (req, res) => {
         const companionId = req.body?.companionId;
         const source = req.body?.source || 'portal';
@@ -414,9 +449,19 @@ module.exports = function companionFactory({ authenticateBot, authenticateDevice
         if (!ALLOWED_SELECT_SOURCES.has(source)) {
             return res.status(400).json({ success: false, error: 'invalid_source' });
         }
+
+        const deviceId = req.botAuth.deviceId;
+        const entityId = req.botAuth.entityId;
+        const currentKey = `PETDX_CURRENT_${entityId}`;
+        const avatarKey  = `PETDX_AVATAR_${entityId}`;
+        const sourceKey  = `PETDX_SOURCE_${entityId}`;
+        const origin     = 'user-selected';
+
+        let cRow;
         try {
             const cRes = await pool.query(
-                `SELECT id, status, scope, device_id, author_entity_id
+                `SELECT id, status, scope, device_id, author_entity_id,
+                        avatar_url, descriptor
                    FROM companions
                   WHERE id = $1`,
                 [companionId]
@@ -424,35 +469,140 @@ module.exports = function companionFactory({ authenticateBot, authenticateDevice
             if (cRes.rowCount === 0) {
                 return res.status(404).json({ success: false, error: 'companion_not_found' });
             }
-            const c = cRes.rows[0];
+            cRow = cRes.rows[0];
             const isOwner = req.botAuth.authMode === 'device'
-                ? c.device_id === req.botAuth.deviceId
-                : (c.author_entity_id === req.botAuth.entityId
-                    && c.device_id === req.botAuth.deviceId);
-            if (c.status !== 'published' && c.scope !== 'system' && !isOwner) {
+                ? cRow.device_id === deviceId
+                : (cRow.author_entity_id === entityId
+                    && cRow.device_id === deviceId);
+            if (cRow.status !== 'published' && cRow.scope !== 'system' && !isOwner) {
                 return res.status(404).json({ success: false, error: 'companion_not_found' });
             }
+        } catch (err) {
+            log('error', 'companion', `[Companion] select lookup failed: ${err.message}`);
+            return res.status(500).json({ success: false, error: 'query_failed' });
+        }
 
-            const now = Date.now();
-            await pool.query(
+        const resolvedAvatarUrl = resolveCompanionAvatarUrl(cRow, companionId);
+        const now = Date.now();
+
+        // Without the IO factory injected, fall back to the legacy log-only
+        // write path. Unit tests that don't exercise the vault still pass.
+        if (!petdxIoFactory) {
+            try {
+                await pool.query(
+                    `INSERT INTO companion_select_log
+                        (device_id, entity_id, companion_id, selected_at, source, origin)
+                     VALUES ($1, $2, $3, $4, $5, $6)`,
+                    [deviceId, entityId, companionId, now, source, origin]
+                );
+                return res.json({
+                    success: true,
+                    selection: { companionId, selectedAt: now, source },
+                });
+            } catch (err) {
+                log('error', 'companion', `[Companion] select (legacy path) failed: ${err.message}`);
+                return res.status(500).json({ success: false, error: 'query_failed' });
+            }
+        }
+
+        const io = petdxIoFactory();
+        let priorVault;
+        try {
+            priorVault = {
+                [currentKey]: await io.getDeviceVar(deviceId, currentKey),
+                [avatarKey]:  await io.getDeviceVar(deviceId, avatarKey),
+                [sourceKey]:  await io.getDeviceVar(deviceId, sourceKey),
+            };
+        } catch (err) {
+            log('error', 'companion', `[Companion] select vault snapshot failed: ${err.message}`);
+            return res.status(500).json({ success: false, layer: 'vault', error: 'vault_read_failed' });
+        }
+
+        const client = await pool.connect();
+        let txOpened = false;
+        let vaultWritten = false;
+        try {
+            await client.query('BEGIN');
+            txOpened = true;
+
+            await client.query(
                 `INSERT INTO companion_select_log
-                    (device_id, entity_id, companion_id, selected_at, source)
-                 VALUES ($1, $2, $3, $4, $5)`,
-                [req.botAuth.deviceId, req.botAuth.entityId, companionId, now, source]
+                    (device_id, entity_id, companion_id, selected_at, source, origin)
+                 VALUES ($1, $2, $3, $4, $5, $6)`,
+                [deviceId, entityId, companionId, now, source, origin]
             );
-            res.json({
+
+            try {
+                await io.setDeviceVars(deviceId, {
+                    [currentKey]: companionId,
+                    [avatarKey]:  resolvedAvatarUrl,
+                    [sourceKey]:  origin,
+                });
+                vaultWritten = true;
+            } catch (vErr) {
+                await client.query('ROLLBACK');
+                txOpened = false;
+                log('error', 'companion', `[Companion] select vault write failed: ${vErr.message}`);
+                return res.status(500).json({ success: false, layer: 'vault', error: 'vault_write_failed' });
+            }
+
+            try {
+                await client.query('COMMIT');
+                txOpened = false;
+            } catch (cErr) {
+                log('error', 'companion', `[Companion] select log commit failed: ${cErr.message}`);
+                try {
+                    await io.setDeviceVars(deviceId, priorVault);
+                } catch (restoreErr) {
+                    log('error', 'companion', `[Companion] vault restore failed after log COMMIT error: ${restoreErr.message}`);
+                }
+                return res.status(500).json({ success: false, layer: 'log', error: 'log_commit_failed' });
+            }
+
+            return res.json({
                 success: true,
                 selection: {
                     companionId,
                     selectedAt: now,
                     source,
+                    avatarUrl: resolvedAvatarUrl,
+                    origin,
                 },
             });
         } catch (err) {
+            if (txOpened) {
+                try { await client.query('ROLLBACK'); } catch (_) { /* ignore */ }
+            }
+            if (vaultWritten) {
+                try { await io.setDeviceVars(deviceId, priorVault); }
+                catch (restoreErr) {
+                    log('error', 'companion', `[Companion] vault restore failed after late error: ${restoreErr.message}`);
+                }
+            }
             log('error', 'companion', `[Companion] select failed: ${err.message}`);
-            res.status(500).json({ success: false, error: 'query_failed' });
+            return res.status(500).json({ success: false, layer: 'log', error: 'query_failed' });
+        } finally {
+            client.release();
         }
     });
+
+    // Resolve the avatar URL for the vault write. Preference order matches
+    // the §0.4 frontend resolver: explicit avatar_url column wins; otherwise
+    // try descriptor.avatar.url (set by marketplace submit), then fall back
+    // to the Phase 0 static-path convention. This is the value that the
+    // dashboard's fast-paint mirror will read until AvatarPetdx.preload()
+    // resolves on the next page load.
+    function resolveCompanionAvatarUrl(row, companionId) {
+        if (row && typeof row.avatar_url === 'string' && row.avatar_url.trim()) {
+            return row.avatar_url.trim();
+        }
+        const descriptor = row && row.descriptor;
+        if (descriptor && typeof descriptor === 'object') {
+            const url = descriptor.avatar && descriptor.avatar.url;
+            if (typeof url === 'string' && url.trim()) return url.trim();
+        }
+        return `/static/companions/${companionId}/avatar.png`;
+    }
 
     // ── POST /api/companion/:id/favorite ──────────────────────────
     // Body: { action: 'add' | 'remove' | 'toggle' (default) }

--- a/backend/index.js
+++ b/backend/index.js
@@ -2239,6 +2239,11 @@ const companionModule = require('./companion-api')({
     authenticateBot,
     authenticateDeviceOrBot,
     serverLog,
+    // Per spec §0.4a (2026-05-31 amendment): /api/companion/select must
+    // atomically mirror the select into the vault. The factory is hoisted
+    // (function declaration further down in this file) so the forward
+    // reference is safe.
+    createPetdxPhase0Io,
 });
 app.use('/api/companion', companionModule.router);
 if (process.env.NODE_ENV !== 'test') {

--- a/backend/tests/jest/companion-select-vault-sync.test.js
+++ b/backend/tests/jest/companion-select-vault-sync.test.js
@@ -1,0 +1,310 @@
+'use strict';
+
+/**
+ * Companion API — POST /api/companion/select atomic vault-sync tests.
+ *
+ * Spec: docs/specs/petdx-uiux-spec-amendment-2026-05-31-phase-0-4a.md §0.4a.
+ *
+ * The §0.4a invariant is "no partial success". This file covers the four
+ * spec-mandated cases:
+ *
+ *   1. Happy path — both the companion_select_log row (with
+ *      origin='user-selected') AND the three PETDX_*_<id> vault keys are
+ *      written. The response echoes the resolved avatarUrl.
+ *   2. Vault write throws — the log tx ROLLBACKs and no log row lands;
+ *      response is 500 {layer:'vault'}.
+ *   3. Log COMMIT throws — the prior vault values are restored; response
+ *      is 500 {layer:'log'}.
+ *   4. Descriptor URL resolution — the avatar URL written into the vault
+ *      comes from companions.avatar_url first, then descriptor.avatar.url,
+ *      then the static-path fallback.
+ *
+ * The pg mock here is richer than the one in companion-api.test.js because
+ * the §0.4a path uses pool.connect() + tx semantics.
+ */
+
+jest.mock('pg', () => {
+    const mockQuery = jest.fn();
+    const mockClientQuery = jest.fn();
+    const mockRelease = jest.fn();
+    const Pool = jest.fn().mockImplementation(() => ({
+        query: mockQuery,
+        connect: jest.fn().mockResolvedValue({
+            query: mockClientQuery,
+            release: mockRelease,
+        }),
+        end: jest.fn(),
+    }));
+    return {
+        Pool,
+        __mockQuery: mockQuery,
+        __mockClientQuery: mockClientQuery,
+        __mockRelease: mockRelease,
+    };
+});
+
+const express = require('express');
+const request = require('supertest');
+const { __mockQuery, __mockClientQuery, __mockRelease } = require('pg');
+const companionFactory = require('../../companion-api');
+
+const DEVICE = 'dev-vault-test';
+const ENTITY = 7;
+const SECRET = 'good-secret';
+
+function makeIoMock(initialVars = {}) {
+    const vars = { ...initialVars };
+    const writes = [];
+    return {
+        vars,
+        writes,
+        instance: {
+            async getDeviceVar(_deviceId, key) {
+                return Object.prototype.hasOwnProperty.call(vars, key) ? vars[key] : null;
+            },
+            async setDeviceVars(_deviceId, entries) {
+                writes.push({ ...entries });
+                for (const [k, v] of Object.entries(entries)) vars[k] = v;
+            },
+            log: () => {},
+            appendCompanionSelectLog: async () => {},
+        },
+    };
+}
+
+function makeApp({ ioMock, ioFactoryFails = false } = {}) {
+    const app = express();
+    app.use(express.json());
+    const authBot = (d, e, s) => d === DEVICE && e === ENTITY && s === SECRET;
+    const authDevOrBot = ({ deviceId, botSecret, entityId }) =>
+        deviceId === DEVICE && botSecret === SECRET && entityId === ENTITY;
+    const mod = companionFactory({
+        authenticateBot: authBot,
+        authenticateDeviceOrBot: authDevOrBot,
+        createPetdxPhase0Io: ioFactoryFails
+            ? () => { throw new Error('factory boom'); }
+            : () => ioMock.instance,
+    });
+    app.use('/api/companion', mod.router);
+    return app;
+}
+
+const COMPANION_ROW_PUBLISHED = {
+    id: 'petdx-zoro', status: 'published', scope: 'community',
+    device_id: null, author_entity_id: null,
+    avatar_url: 'https://r2.example/zoro/avatar.png',
+    descriptor: { avatar: { url: 'https://r2.example/zoro/descriptor.png' } },
+};
+
+beforeEach(() => {
+    __mockQuery.mockReset();
+    __mockClientQuery.mockReset();
+    __mockRelease.mockReset();
+});
+
+describe('POST /api/companion/select — §0.4a atomic vault sync', () => {
+    test('happy path: log row + 3 vault keys written; response echoes avatarUrl + origin', async () => {
+        const ioMock = makeIoMock();
+        __mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [COMPANION_ROW_PUBLISHED] }); // companion lookup
+        __mockClientQuery
+            .mockResolvedValueOnce({})  // BEGIN
+            .mockResolvedValueOnce({})  // INSERT
+            .mockResolvedValueOnce({}); // COMMIT
+
+        const res = await request(makeApp({ ioMock }))
+            .post('/api/companion/select')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ companionId: 'petdx-zoro', source: 'app' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.selection.companionId).toBe('petdx-zoro');
+        expect(res.body.selection.source).toBe('app');
+        expect(res.body.selection.origin).toBe('user-selected');
+        expect(res.body.selection.avatarUrl).toBe('https://r2.example/zoro/avatar.png');
+
+        // tx ordering: BEGIN, INSERT, COMMIT
+        expect(__mockClientQuery.mock.calls[0][0]).toBe('BEGIN');
+        expect(__mockClientQuery.mock.calls[1][0]).toMatch(/INSERT INTO companion_select_log/);
+        expect(__mockClientQuery.mock.calls[1][0]).toMatch(/origin/);
+        expect(__mockClientQuery.mock.calls[1][1]).toEqual([
+            DEVICE, ENTITY, 'petdx-zoro', expect.any(Number), 'app', 'user-selected',
+        ]);
+        expect(__mockClientQuery.mock.calls[2][0]).toBe('COMMIT');
+
+        // vault: one batched setDeviceVars with the three keys
+        expect(ioMock.writes).toHaveLength(1);
+        expect(ioMock.writes[0]).toEqual({
+            [`PETDX_CURRENT_${ENTITY}`]: 'petdx-zoro',
+            [`PETDX_AVATAR_${ENTITY}`]:  'https://r2.example/zoro/avatar.png',
+            [`PETDX_SOURCE_${ENTITY}`]:  'user-selected',
+        });
+        // client released exactly once
+        expect(__mockRelease).toHaveBeenCalledTimes(1);
+    });
+
+    test('vault write throws → ROLLBACK log tx, response 500 {layer:vault}', async () => {
+        const ioMock = makeIoMock({
+            [`PETDX_CURRENT_${ENTITY}`]: 'petdx-lobster-default',
+            [`PETDX_AVATAR_${ENTITY}`]: '/static/companions/petdx-lobster-default/avatar.png',
+            [`PETDX_SOURCE_${ENTITY}`]: 'phase0-backfill',
+        });
+        // Override setDeviceVars to throw on the FIRST call only (so restore
+        // path doesn't run — there's nothing to restore yet).
+        let writeCount = 0;
+        ioMock.instance.setDeviceVars = async () => {
+            writeCount++;
+            throw new Error('vault disk full');
+        };
+
+        __mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [COMPANION_ROW_PUBLISHED] });
+        __mockClientQuery
+            .mockResolvedValueOnce({})  // BEGIN
+            .mockResolvedValueOnce({})  // INSERT
+            .mockResolvedValueOnce({}); // ROLLBACK
+
+        const res = await request(makeApp({ ioMock }))
+            .post('/api/companion/select')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ companionId: 'petdx-zoro', source: 'app' });
+
+        expect(res.status).toBe(500);
+        expect(res.body.success).toBe(false);
+        expect(res.body.layer).toBe('vault');
+
+        // Last client query MUST be ROLLBACK
+        const last = __mockClientQuery.mock.calls[__mockClientQuery.mock.calls.length - 1];
+        expect(last[0]).toBe('ROLLBACK');
+        // Never COMMITted
+        expect(__mockClientQuery.mock.calls.every(c => c[0] !== 'COMMIT')).toBe(true);
+        expect(writeCount).toBe(1);
+        expect(__mockRelease).toHaveBeenCalledTimes(1);
+    });
+
+    test('log COMMIT throws → prior vault values restored, response 500 {layer:log}', async () => {
+        const PRIOR = {
+            [`PETDX_CURRENT_${ENTITY}`]: 'petdx-lobster-default',
+            [`PETDX_AVATAR_${ENTITY}`]: '/static/companions/petdx-lobster-default/avatar.png',
+            [`PETDX_SOURCE_${ENTITY}`]: 'phase0-backfill',
+        };
+        const ioMock = makeIoMock(PRIOR);
+
+        __mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [COMPANION_ROW_PUBLISHED] });
+        __mockClientQuery
+            .mockResolvedValueOnce({})                                          // BEGIN
+            .mockResolvedValueOnce({})                                          // INSERT
+            .mockRejectedValueOnce(new Error('connection lost during commit')); // COMMIT throws
+
+        const res = await request(makeApp({ ioMock }))
+            .post('/api/companion/select')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ companionId: 'petdx-zoro', source: 'app' });
+
+        expect(res.status).toBe(500);
+        expect(res.body.layer).toBe('log');
+
+        // Vault: two writes — the forward write, then the restore back to prior.
+        expect(ioMock.writes).toHaveLength(2);
+        expect(ioMock.writes[1]).toEqual(PRIOR);
+        // And the in-memory vault state is back at prior values:
+        expect(ioMock.vars).toEqual(PRIOR);
+        expect(__mockRelease).toHaveBeenCalledTimes(1);
+    });
+
+    test('avatar URL preference: avatar_url column wins over descriptor.avatar.url', async () => {
+        const ioMock = makeIoMock();
+        __mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{
+            id: 'petdx-x', status: 'published', scope: 'system',
+            device_id: null, author_entity_id: null,
+            avatar_url: '/explicit/avatar.png',
+            descriptor: { avatar: { url: '/from/descriptor.png' } },
+        }] });
+        __mockClientQuery
+            .mockResolvedValueOnce({})  // BEGIN
+            .mockResolvedValueOnce({})  // INSERT
+            .mockResolvedValueOnce({}); // COMMIT
+
+        const res = await request(makeApp({ ioMock }))
+            .post('/api/companion/select')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ companionId: 'petdx-x', source: 'app' });
+
+        expect(res.status).toBe(200);
+        expect(ioMock.vars[`PETDX_AVATAR_${ENTITY}`]).toBe('/explicit/avatar.png');
+    });
+
+    test('avatar URL preference: descriptor.avatar.url wins when avatar_url column is null', async () => {
+        const ioMock = makeIoMock();
+        __mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{
+            id: 'petdx-x', status: 'published', scope: 'system',
+            device_id: null, author_entity_id: null,
+            avatar_url: null,
+            descriptor: { avatar: { url: '/from/descriptor.png' } },
+        }] });
+        __mockClientQuery
+            .mockResolvedValueOnce({}).mockResolvedValueOnce({}).mockResolvedValueOnce({});
+
+        await request(makeApp({ ioMock }))
+            .post('/api/companion/select')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ companionId: 'petdx-x', source: 'app' });
+
+        expect(ioMock.vars[`PETDX_AVATAR_${ENTITY}`]).toBe('/from/descriptor.png');
+    });
+
+    test('avatar URL preference: static-path fallback when both are missing', async () => {
+        const ioMock = makeIoMock();
+        __mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{
+            id: 'petdx-lobster-default', status: 'published', scope: 'system',
+            device_id: null, author_entity_id: null,
+            avatar_url: null,
+            descriptor: { description: 'procedural-only, no avatar shape' },
+        }] });
+        __mockClientQuery
+            .mockResolvedValueOnce({}).mockResolvedValueOnce({}).mockResolvedValueOnce({});
+
+        await request(makeApp({ ioMock }))
+            .post('/api/companion/select')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ companionId: 'petdx-lobster-default', source: 'app' });
+
+        expect(ioMock.vars[`PETDX_AVATAR_${ENTITY}`])
+            .toBe('/static/companions/petdx-lobster-default/avatar.png');
+    });
+
+    test('factory-not-injected fallback: legacy log-only INSERT (origin still written, no vault writes)', async () => {
+        // No createPetdxPhase0Io passed → legacy code path.
+        const app = (() => {
+            const a = express();
+            a.use(express.json());
+            const mod = companionFactory({
+                authenticateBot: (d, e, s) => d === DEVICE && e === ENTITY && s === SECRET,
+                authenticateDeviceOrBot: ({ deviceId, botSecret, entityId }) =>
+                    deviceId === DEVICE && botSecret === SECRET && entityId === ENTITY,
+            });
+            a.use('/api/companion', mod.router);
+            return a;
+        })();
+
+        __mockQuery
+            .mockResolvedValueOnce({ rowCount: 1, rows: [COMPANION_ROW_PUBLISHED] })
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+        const res = await request(app)
+            .post('/api/companion/select')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
+            .send({ companionId: 'petdx-zoro', source: 'app' });
+
+        expect(res.status).toBe(200);
+        // Legacy path uses pool.query, NOT pool.connect; the second
+        // pool.query call is the INSERT (origin column included).
+        const insert = __mockQuery.mock.calls[1];
+        expect(insert[0]).toMatch(/INSERT INTO companion_select_log/);
+        expect(insert[0]).toMatch(/origin/);
+        expect(insert[1]).toEqual([
+            DEVICE, ENTITY, 'petdx-zoro', expect.any(Number), 'app', 'user-selected',
+        ]);
+        // No client.connect calls in legacy path.
+        expect(__mockClientQuery).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
## Summary

Implements [`docs/specs/petdx-uiux-spec-amendment-2026-05-31-phase-0-4a.md`](./docs/specs/petdx-uiux-spec-amendment-2026-05-31-phase-0-4a.md) §0.4a — closes the backend-side invariant gap that produced this morning's dashboard `❓` regression.

Before this PR, `POST /api/companion/select` only INSERTed into `companion_select_log`. The vault keys (`PETDX_CURRENT_<id>`, `PETDX_AVATAR_<id>`, `PETDX_SOURCE_<id>`) stayed pinned at whatever Phase 0 backfill wrote, so the dashboard's fast-paint enrichment immediately disagreed with the live descriptor URL once any user borrowed an R2 spritesheet companion.

**§0.4a invariant**: every `/select` write either lands both layers (log row with `origin='user-selected'` AND the three vault keys), or neither.

## Implementation

- `companionFactory` accepts an injected `createPetdxPhase0Io` (forward-ref through hoisting from `backend/index.js`).
- `resolveCompanionAvatarUrl()` picks the avatar URL the dashboard will paint: `companions.avatar_url` > `descriptor.avatar.url` > `/static/companions/<id>/avatar.png` fallback.
- Write order: snapshot prior vault values → BEGIN log tx → INSERT log row (with the previously-unused `origin` column) → `setDeviceVars` 3 keys → COMMIT.
  - Vault write throws → ROLLBACK + `500 {layer:'vault'}`. No log row lands.
  - COMMIT throws → restore prior vault + `500 {layer:'log'}`. Vault snaps back to pre-select state.
- Two pg pools (companion-api's local pool + the IO factory's `chatPool`) make true cross-pool 2PC impossible. The snapshot + restore step is what closes the observable gap — either both layers reflect the new selection, or neither does.
- Legacy fallback path (no factory injected — current unit tests) keeps working but now also fills the `origin` column.

## Test plan

- [x] `backend/tests/jest/companion-select-vault-sync.test.js` — 7 cases, all green:
  - Happy path (log + vault written, response echoes `avatarUrl` + `origin`)
  - Vault write throws → ROLLBACK + 500 `{layer:'vault'}`, never COMMITs
  - Log COMMIT throws → vault restored to prior, 500 `{layer:'log'}`
  - Avatar URL precedence: `avatar_url` column wins over descriptor
  - Avatar URL precedence: descriptor wins when column is null
  - Avatar URL precedence: static-path fallback when both missing
  - Factory-not-injected legacy path still works (writes log row + origin)
- [x] `backend/tests/jest/companion-api.test.js` — all 75 existing tests still green
- [x] `backend/tests/jest/portal-entity-avatar-*` + `petdx-*` — all 94 green
- [ ] Post-deploy: Playwright sweep of dashboard after `/select` to confirm smart-match holds without manual refresh

## Spec citation

- §0.4a invariant: spec lines 65–69
- The contract that `/api/companion/select` must satisfy: spec lines 129–146
- Test obligations: spec lines 155–172 (this PR covers obligations 1–4; obligation 5 — enrichment refresh — is already covered by existing entity-enrichment tests; obligation 6 — frontend regression — landed in #3046)

🤖 Generated with [Claude Code](https://claude.com/claude-code)