### PR TITLE
fix(petdx Phase 0): skip vault mirror when /select has no entity context

### DIFF
--- a/backend/companion-api.js
+++ b/backend/companion-api.js
@@ -485,9 +485,13 @@ module.exports = function companionFactory({ authenticateBot, authenticateDevice
         const resolvedAvatarUrl = resolveCompanionAvatarUrl(cRow, companionId);
         const now = Date.now();
 
-        // Without the IO factory injected, fall back to the legacy log-only
-        // write path. Unit tests that don't exercise the vault still pass.
-        if (!petdxIoFactory) {
+        // Vault mirror is per-entity. Device-secret auth (no botSecret) carries
+        // no entity context, so there's no PETDX_*_<id> to mirror — fall through
+        // to the legacy log-only path. Without this guard the vault would
+        // accumulate PETDX_CURRENT_null / PETDX_AVATAR_null / PETDX_SOURCE_null
+        // dead keys on every device-secret select, which the §0.4 resolver
+        // chain never reads but they pollute /api/device-vars output.
+        if (!petdxIoFactory || entityId == null) {
             try {
                 await pool.query(
                     `INSERT INTO companion_select_log

--- a/backend/tests/jest/companion-select-vault-sync.test.js
+++ b/backend/tests/jest/companion-select-vault-sync.test.js
@@ -272,6 +272,43 @@ describe('POST /api/companion/select — §0.4a atomic vault sync', () => {
             .toBe('/static/companions/petdx-lobster-default/avatar.png');
     });
 
+    test('device-secret auth (entityId=null) skips vault write but still fills log + origin', async () => {
+        const ioMock = makeIoMock();
+        // No __mockClientQuery responses — should never be called.
+        __mockQuery
+            .mockResolvedValueOnce({ rowCount: 1, rows: [COMPANION_ROW_PUBLISHED] })
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] }); // legacy INSERT via pool.query
+
+        // Override the auth predicate so deviceSecret-only succeeds with entityId=null.
+        const app = express();
+        app.use(express.json());
+        const mod = companionFactory({
+            authenticateBot: (d, e, s) => false,
+            authenticateDeviceOrBot: ({ deviceId, deviceSecret }) =>
+                deviceId === DEVICE && deviceSecret === 'dev-secret',
+            createPetdxPhase0Io: () => ioMock.instance,
+        });
+        app.use('/api/companion', mod.router);
+
+        const res = await request(app)
+            .post('/api/companion/select')
+            .query({ deviceId: DEVICE, deviceSecret: 'dev-secret' })  // no entityId
+            .send({ companionId: 'petdx-zoro', source: 'app' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.selection.companionId).toBe('petdx-zoro');
+        // Vault must NOT be touched.
+        expect(ioMock.writes).toHaveLength(0);
+        // Log INSERT used the legacy pool.query path.
+        expect(__mockClientQuery).not.toHaveBeenCalled();
+        const insert = __mockQuery.mock.calls[1];
+        expect(insert[0]).toMatch(/INSERT INTO companion_select_log/);
+        // entityId column gets null since none was provided.
+        expect(insert[1]).toEqual([
+            DEVICE, null, 'petdx-zoro', expect.any(Number), 'app', 'user-selected',
+        ]);
+    });
+
     test('factory-not-injected fallback: legacy log-only INSERT (origin still written, no vault writes)', async () => {
         // No createPetdxPhase0Io passed → legacy code path.
         const app = (() => {


### PR DESCRIPTION
## Summary

Follow-up to #3050. Caught during prod E2E verification — the §0.4a atomic-sync path was firing for **every** `/select` call, including device-secret auth (no entityId). That produced literal `_null`-suffixed vault entries:

```
PETDX_AVATAR_null  = /static/companions/petdx-lobster-default/avatar.png
PETDX_CURRENT_null = petdx-lobster-default
PETDX_SOURCE_null  = user-selected
```

The §0.4 resolver chain reads `PETDX_*_<entityId>` by integer entityId, so these dead keys are functionally harmless — they just clutter `/api/device-vars` output and would confuse anyone debugging vault state.

## Fix

Route device-secret + `entityId=null` requests through the legacy log-only path:
- `companion_select_log` row still lands with `origin='user-selected'`
- Response shape unchanged
- Vault mirror skipped (nothing to mirror for)

## Test plan

- [x] New jest case in `companion-select-vault-sync.test.js`: deviceSecret auth → log row via `pool.query`, `pool.connect()` never called, zero vault writes
- [x] All 83 companion-api jest tests green
- [x] Will re-verify on prod after merge: BROADCAST_TEST device's vault should no longer accumulate `_null` keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)