### PR TITLE
fix(transform): drop [SILENT] sentinel + noise before routing

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -17,6 +17,7 @@ const sitePageviews = require('./site-pageviews');
 const feedbackModule = require('./device-feedback');
 const chatIntegrity = require('./chat-integrity');
 const communitySsr = require('./community-ssr');
+const { isLowSignalFwd } = require('./org-fwd-filter');
 const { buildOrgEntitySessionKey, isOrgEntitySessionKey } = require('./session-scope');
 const { assignDefaultCompanionIfMissing } = require('./petdx-phase0-hook');
 // JWT secret: fail-safe random per process if env var is missing (tokens signed in one process won't verify in another)
@@ -8066,6 +8067,17 @@ function collectMissingSpeakToMentionWarnings(speakToList, mentionParse, senderD
     return warnings;
 }
 
+function getSilentTransformSuppressionReason(text) {
+    if (typeof text !== 'string') return null;
+    const trimmed = text.trim();
+    if (!trimmed) return null;
+    if (/^\[SILENT\]$/i.test(trimmed)) return 'silent_token';
+    if (/^\[SILENT\](?:\s|$)/i.test(trimmed) && isLowSignalFwd(trimmed)) {
+        return 'silent_noise';
+    }
+    return null;
+}
+
 /**
  * Gatekeeper Second Lock: mask leaked tokens for free bots.
  * Returns { text, leaked } where text is potentially masked.
@@ -8641,7 +8653,18 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
             `[PLACEHOLDER_LEAK] Entity ${eId} on device ${deviceId} sent bind-ack template verbatim — suppressing propagation`,
             { deviceId, entityId: eId, metadata: { tag: 'PLACEHOLDER_LEAK' } });
     }
-    if (finalMessage !== undefined && !isPlaceholderLeak) entity.message = finalMessage;
+    const silentSuppressionReason = getSilentTransformSuppressionReason(finalMessage);
+    const isSilentMessage = !!silentSuppressionReason;
+    const isSuppressedMessage = isPlaceholderLeak || isSilentMessage;
+    if (isSilentMessage) {
+        serverLog('info', 'transform_silent_drop',
+            `[TRANSFORM_SILENT_DROP] Entity ${eId} on device ${deviceId} sent ${silentSuppressionReason}; suppressing routing propagation`,
+            { deviceId, entityId: eId, metadata: { reason: silentSuppressionReason } });
+        speakTo = undefined;
+        broadcast = false;
+        routingResolvedVia = null;
+    }
+    if (finalMessage !== undefined && !isSuppressedMessage) entity.message = finalMessage;
     if (parts) {
         // Only store numeric values — reject URLs/strings that would crash Android Gson deserialization
         const sanitizedParts = {};
@@ -8686,7 +8709,7 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
     // to happen.
     let transformMentionContext = null;
     let transformMentionParse = null;
-    if (finalMessage) {
+    if (finalMessage && !isSuppressedMessage) {
         const tParse = mentionParser.parseMentions(finalMessage, {
             senderDeviceId: deviceId,
             devices,
@@ -8712,7 +8735,7 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
     // server (not the bridge) decides where the bot's reply routes.
     let senderHintResolution = null;
     const noTargetYet = !broadcast && !(speakTo && Array.isArray(speakTo) && speakTo.length > 0);
-    if (senderHint && noTargetYet && finalMessage) {
+    if (senderHint && noTargetYet && finalMessage && !isSuppressedMessage) {
         const kind = senderHint.kind || 'unknown';
         if (kind === 'broadcast') {
             broadcast = true;
@@ -8755,7 +8778,7 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
         senderHintResolution = {
             kind: senderHint.kind || 'unknown',
             applied: 'none',
-            reason: noTargetYet ? 'no_message' : 'explicit_or_mention_won'
+            reason: isSuppressedMessage ? 'silent_message' : (noTargetYet ? 'no_message' : 'explicit_or_mention_won')
         };
     }
 
@@ -8781,10 +8804,9 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
         routing.warnings.push(...collectMissingSpeakToMentionWarnings(speakTo, transformMentionParse, deviceId));
     }
 
-    // Save bot message to chat history so it appears in Chat page
-    // Skip silent tokens — these are internal signals that should not appear in chat
-    const isSilentMessage = finalMessage && /^\[SILENT\]$/i.test(finalMessage.trim());
-    const isSuppressedMessage = isSilentMessage || isPlaceholderLeak;
+    // Save bot message to chat history so it appears in Chat page.
+    // isSuppressedMessage is computed before routing so silent control payloads
+    // cannot resolve @mentions/senderHint or fan out through speakTo/broadcast.
     // Skip self chat save when speakTo/broadcast is present — deliverToEntity will save with routing source
     const hasDelivery = (broadcast || (speakTo && Array.isArray(speakTo) && speakTo.length > 0));
     if (finalMessage && !isSuppressedMessage) {
@@ -8903,7 +8925,7 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
     // ── Rental response mirroring: if owner entity is leased_out, copy response to renter ──
     // PR #2986 guard — placeholder leaks (the bind-ack template copied verbatim) must NOT
     // mirror into renter.message, renter chat history, Socket.IO update, or push notify.
-    if (entity.rental_status === 'leased_out' && entity.rental_contract_id && finalMessage && !isPlaceholderLeak) {
+    if (entity.rental_status === 'leased_out' && entity.rental_contract_id && finalMessage && !isSuppressedMessage) {
         try {
             const cRow = await db._getPool().query(
                 `SELECT c.renter_device_id FROM rental_contracts c WHERE c.id = $1 AND c.status IN ('active','reserved','suspended_insufficient_funds')`,
@@ -8973,7 +8995,7 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
     // Notify device about bot reply (fire-and-forget)
     // Skip owner notification for leased_out entities — renter gets notified via rental mirror
     const isLeasedOutForNotify = entity.rental_status === 'leased_out';
-    if (finalMessage && !isLeasedOutForNotify && !isPlaceholderLeak) {
+    if (finalMessage && !isLeasedOutForNotify && !isSuppressedMessage) {
         notifyDevice(deviceId, {
             type: 'chat', category: 'bot_reply',
             title: entity.name || `Entity ${eId}`,
@@ -8995,7 +9017,7 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
     // Skip for leased_out entities — rental bot responses belong to the renter's context.
     const kanbanBusyStates = new Set(['BUSY', 'PROCESSING', 'WORKING', 'IN_PROGRESS', 'IN-PROGRESS']);
     const isKanbanBusyState = kanbanBusyStates.has(String(state || '').trim().toUpperCase());
-    if (!isKanbanBusyState && finalMessage && !isPlaceholderLeak && entity.rental_status !== 'leased_out' && kanbanModule && kanbanModule.autoReviewOnTransform) {
+    if (!isKanbanBusyState && finalMessage && !isSuppressedMessage && entity.rental_status !== 'leased_out' && kanbanModule && kanbanModule.autoReviewOnTransform) {
         kanbanModule.autoReviewOnTransform(deviceId, eId, finalMessage, aboutCardId).catch(err => {
             console.error(`[Transform] autoReviewOnTransform failed:`, err.message);
         });
@@ -9003,7 +9025,7 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
 
     // Org chart: auto-forward message to superior entity (fire-and-forget)
     // Skip for leased_out entities — owner's org chart should not apply to rental responses
-    if (finalMessage && entity && entity.rental_status !== 'leased_out' && !isPlaceholderLeak) {
+    if (finalMessage && entity && entity.rental_status !== 'leased_out' && !isSuppressedMessage) {
         orgChartForward(entity, deviceId, finalMessage).catch(() => {});
     }
 
@@ -9020,7 +9042,7 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
     // to run a sender-side fallback save.
     let deliverySaved = false;
 
-    if ((speakTo || broadcast) && finalMessage && !isPlaceholderLeak) {
+    if ((speakTo || broadcast) && finalMessage && !isSuppressedMessage) {
         // If both provided, broadcast takes priority
         if (speakTo && broadcast) {
             warnings.push('Both speakTo and broadcast provided — broadcast takes priority, speakTo ignored.');
@@ -17746,8 +17768,6 @@ async function pushToBot(entity, deviceId, eventType, payload, opts = {}) {
  */
 const ORG_FWD_PREFIX = '[📢 FWD';
 const ORG_TASK_FWD_PREFIX = '[📋 TASK FWD';
-
-const { isLowSignalFwd } = require('./org-fwd-filter');
 
 async function orgChartForward(entity, deviceId, message, opts = {}) {
     if (!message || message.startsWith(ORG_TASK_FWD_PREFIX) || message.startsWith(ORG_FWD_PREFIX)) return;

--- a/backend/tests/jest/transform-delivery.test.js
+++ b/backend/tests/jest/transform-delivery.test.js
@@ -604,4 +604,51 @@ describe('Transform fallback save on delivery failure', () => {
         expect(fallbackWarn).toBe(false);
         expect(findChatInserts(msg).length).toBe(0);
     });
+
+    it('[SILENT] sentinel with a valid speakTo is dropped before delivery', async () => {
+        clearPoolQueries();
+
+        const msg = '[SILENT]';
+        const res = await post('/api/transform')
+            .send({
+                deviceId,
+                entityId: 0,
+                botSecret: botSecret0,
+                message: msg,
+                state: 'IDLE',
+                speakTo: [code1]
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body.delivery).toBeUndefined();
+        expect(res.body.routing.resolvedVia).toBeNull();
+        expect(res.body.routing.routedTo).toEqual([]);
+        expect(findChatInserts(msg).length).toBe(0);
+    });
+
+    it('[SILENT] sign-off FWD echo noise with senderHint does not auto-route', async () => {
+        clearPoolQueries();
+
+        const msg = `[SILENT] #6 sign-off FWD echo same string ${Date.now()}`;
+        const res = await post('/api/transform')
+            .send({
+                deviceId,
+                entityId: 0,
+                botSecret: botSecret0,
+                message: msg,
+                state: 'IDLE',
+                senderHint: { kind: 'entity', entityId: 1, publicCode: code1 }
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body.delivery).toBeUndefined();
+        expect(res.body.routing.resolvedVia).toBeNull();
+        expect(res.body.routing.routedTo).toEqual([]);
+        expect(res.body.senderHintResolution).toMatchObject({
+            kind: 'entity',
+            applied: 'none',
+            reason: 'silent_message'
+        });
+        expect(findChatInserts(msg).length).toBe(0);
+    });
 });


### PR DESCRIPTION
## Summary
- Server-side drop of `[SILENT]` and `[SILENT] …` low-signal-fwd noise at `/api/transform` before any routing decision (speakTo, broadcast, senderHint, mention parse, chat save, kanban/rental/notify side-effects).
- Logs each drop via `serverLog('info','transform_silent_drop', ...)`.
- 2 new jest regressions + existing fallback-save regression — `transform-delivery.test.js`: 22/22 pass.

## Why
2026-05-31 13:15–13:29 TPE incident: #2 ↔ #6 ack-loop generated ~30 zero-value messages per loop until bot-to-bot quota exhausted. Silent payloads are control signals (recipient should output `[SILENT]` per its prompt to save quota), not chat — server must drop them, not depend on either bot's discipline.

Card: `card_4e0b0450f5d9320584bc1461` (P1)

## Implementation
- New helper `getSilentTransformSuppressionReason(text)` — matches exact `[SILENT]` (case-insensitive) and `[SILENT]` prefix with `isLowSignalFwd()` body.
- Reuses existing `isPlaceholderLeak` pattern: unified `isSuppressedMessage` guards all downstream branches (chat save, mention parse, senderHint resolve, speakTo/broadcast, rental mirror, push notify, kanban auto-review, org-chart forward).
- When silent: `speakTo = undefined; broadcast = false; routingResolvedVia = null`. Response shape stays the same; recipient sees no webhook/notify.

## Scope notes
- This PR is a narrow fix targeting the named `[SILENT]` pattern from the incident. Wider noise classes (bare `.`, whitespace-only, ≤2 chars no alphanum) are deliberately out-of-scope — can land as a follow-up if needed.
- Only `bot` senders are effectively affected: `[SILENT]` from a human user is unlikely; even if sent, current implementation drops it too (acceptable per spec — user wouldn't type this token).
- No DB schema change, no public API contract change.

## Test plan
- [x] `npx jest tests/jest/transform-delivery.test.js --runInBand` → 22/22 pass (incl. 2 new)
- [ ] Smoke after deploy: send `[SILENT]` from #2 speakTo #6 via /api/transform → response 200, `routing.routedTo==[]`, `routing.resolvedVia==null`, no chat_history row
- [ ] Smoke after deploy: send `received` (real content) from #2 speakTo #6 → routes normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)