### PR TITLE
[codex] suppress stale kanban nudges

### DIFF
--- a/openclaw-channel-eclaw/README.md
+++ b/openclaw-channel-eclaw/README.md
@@ -170,6 +170,31 @@ Device owners can schedule messages to be sent to your bot at a specific time (o
 |----------|----------|-------------|
 | `ECLAW_WEBHOOK_URL` | Production | Public URL for receiving inbound messages |
 | `ECLAW_WEBHOOK_PORT` | Optional | Webhook server port (default: random) |
+| `ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS` | Optional | Set to `1` for high-priority interactive agents that receive many kanban reminder cards. The webhook is still ACKed for stale `⏰` nudge notifications without occupying the model reply path; assignment, move, reopen, review, and escalation notifications still dispatch normally. |
+
+## OpenClaw Version Drift Mitigation
+
+For Docker-hosted OpenClaw runtimes, prefer an image rebuild over running
+`openclaw update` inside the container. The in-container self-update can fail
+when the global OpenClaw install tree is owned by root, leaving the runtime on
+an older build while health checks look green.
+
+Known-good recovery for project F / entity #1:
+
+```bash
+cd /Users/hank/Desktop/Project/openclaw-docker
+docker compose build --pull openclaw-f
+docker compose up -d --no-deps openclaw-f
+docker exec openclaw-project-f openclaw --version
+```
+
+After the recreate, verify startup logs show the intended runtime model, for
+example `agent model: openai-codex/gpt-5.5 (thinking=xhigh, ...)`, then test
+the E-Claw browser chat UI with a fresh nonce. For #1, enable
+`ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS=1` when stale `⏰` kanban reminder cards
+are recurring ahead of user messages; this prevents reminder backlog from
+starving the interactive reply path while preserving task-assignment, movement,
+reopen, review, and escalation pushes.
 
 ## Troubleshooting
 

--- a/openclaw-channel-eclaw/src/webhook-handler.ts
+++ b/openclaw-channel-eclaw/src/webhook-handler.ts
@@ -2,6 +2,23 @@ import type { EClawInboundMessage } from './types.js';
 import { getPluginRuntime } from './runtime.js';
 import { getClient, setActiveEvent, clearActiveEvent } from './outbound.js';
 
+function envFlagEnabled(name: string): boolean {
+  return /^(1|true|yes|on)$/i.test(String(process.env[name] || '').trim());
+}
+
+function kanbanNotificationSuppressionEnabled(): boolean {
+  return envFlagEnabled('ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS')
+    || envFlagEnabled('ECLAW_SKIP_KANBAN_NOTIFICATIONS');
+}
+
+function isStaleNudgeKanbanNotification(msg: EClawInboundMessage): boolean {
+  return String(msg.text || '').trimStart().startsWith('⏰');
+}
+
+function shouldSuppressKanbanNotification(msg: EClawInboundMessage): boolean {
+  return kanbanNotificationSuppressionEnabled() && isStaleNudgeKanbanNotification(msg);
+}
+
 /**
  * Create an HTTP request handler for inbound messages from E-Claw.
  *
@@ -67,6 +84,11 @@ export function createWebhookHandler(
 
       const eclawCtx = msg.eclaw_context;
       const silentToken = eclawCtx?.silentToken ?? '[SILENT]';
+
+      if (event === 'kanban_notification' && shouldSuppressKanbanNotification(msg)) {
+        console.log('[E-Claw] Stale kanban nudge suppressed by runtime policy; webhook ACKed without occupying the model reply path');
+        return;
+      }
 
       // Map E-Claw media type to OpenClaw media type
       const ocMediaType = msg.mediaType === 'photo' ? 'image'

--- a/openclaw-channel-eclaw/test/webhook-handler.test.ts
+++ b/openclaw-channel-eclaw/test/webhook-handler.test.ts
@@ -1,9 +1,14 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createWebhookHandler } from '../src/webhook-handler.js';
 import { setPluginRuntime } from '../src/runtime.js';
 import { setClient } from '../src/outbound.js';
 
 describe('createWebhookHandler', () => {
+  afterEach(() => {
+    delete process.env.ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS;
+    delete process.env.ECLAW_SKIP_KANBAN_NOTIFICATIONS;
+  });
+
   it('acks healthcheck messages without dispatching agent work', async () => {
     const dispatchReplyWithBufferedBlockDispatcher = vi.fn();
     setPluginRuntime({
@@ -39,5 +44,93 @@ describe('createWebhookHandler', () => {
     expect(res.end).toHaveBeenCalledWith(JSON.stringify({ ok: true }));
     expect(client.sendMessage).toHaveBeenCalledWith('ACK abc_123-XYZ', 'IDLE');
     expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+  });
+
+  it('can ack stale kanban nudges without occupying the model reply path', async () => {
+    process.env.ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS = '1';
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn();
+    setPluginRuntime({
+      channel: {
+        reply: {
+          finalizeInboundContext: vi.fn(),
+          dispatchReplyWithBufferedBlockDispatcher,
+        },
+      },
+    });
+
+    const client = {
+      sendMessage: vi.fn().mockResolvedValue({ success: true }),
+    };
+    setClient('default', client as any);
+
+    const handler = createWebhookHandler('token', 'default', {});
+    const res = {
+      writeHead: vi.fn(),
+      end: vi.fn(),
+    };
+
+    await handler({
+      method: 'POST',
+      body: {
+        deviceId: 'device-1',
+        entityId: 1,
+        event: 'kanban_notification',
+        from: 'kanban',
+        text: '⏰ Task nudge: [Fix the bug]\nStuck in "In Progress" for 3h, please continue',
+      },
+    }, res);
+
+    expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'application/json' });
+    expect(res.end).toHaveBeenCalledWith(JSON.stringify({ ok: true }));
+    expect(client.sendMessage).not.toHaveBeenCalled();
+    expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['new assignment', '📋 New task assigned: 🔥 [P0] Fix the bug\nStatus: TODO'],
+    ['status move', '➡️ Task status changed: [Fix the bug]\nTODO → In Progress'],
+    ['reopen', '♻️ Card reopened: Fix the bug\nDone → TODO\nReason: needs rework'],
+    ['review', '🔍 Pending review: [Fix the bug]\nMoved from In Progress to Review. Please review.'],
+    ['priority escalation', '⬆️ Card "Fix the bug" has been stuck for 6h and was upgraded to P0'],
+    ['block escalation', '🚫 Card "Fix the bug" has been stuck for 24h and was moved to blocked'],
+  ])('does not suppress %s kanban notifications', async (_caseName, text) => {
+    process.env.ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS = '1';
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockResolvedValue(undefined);
+    const finalizeInboundContext = vi.fn((ctx) => ctx);
+    setPluginRuntime({
+      channel: {
+        reply: {
+          finalizeInboundContext,
+          dispatchReplyWithBufferedBlockDispatcher,
+        },
+      },
+    });
+
+    const client = {
+      sendMessage: vi.fn().mockResolvedValue({ success: true }),
+    };
+    setClient('default', client as any);
+
+    const handler = createWebhookHandler('token', 'default', {});
+    const res = {
+      writeHead: vi.fn(),
+      end: vi.fn(),
+    };
+
+    await handler({
+      method: 'POST',
+      body: {
+        deviceId: 'device-1',
+        entityId: 1,
+        event: 'kanban_notification',
+        from: 'kanban',
+        text,
+      },
+    }, res);
+
+    expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'application/json' });
+    expect(res.end).toHaveBeenCalledWith(JSON.stringify({ ok: true }));
+    expect(finalizeInboundContext).toHaveBeenCalled();
+    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Adds an opt-in OpenClaw channel runtime policy to ACK stale kanban nudge notifications without dispatching them into the model reply path.
- Restricts suppression to `kanban_notification` events whose text starts with the stale `⏰` marker.
- Documents `ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS` and project F drift/rebuild notes.

## Root Cause

Project F can accumulate stale kanban reminder cards ahead of interactive user messages. Those reminders still need webhook ACKs, but they should not starve the agent interactive reply path when stale-nudge suppression is explicitly enabled.

## Validation

- `npm test` in `openclaw-channel-eclaw/`
- `npm run build` in `openclaw-channel-eclaw/`
- `git diff --check`