### PR TITLE
[Schema] Invite reward viral loop migration (PR1 of 3)

### DIFF
--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -985,4 +985,11 @@ GPS: عند الطلب فقط، بلا تتبع في الخلفية، تُفقد
     <string name="wallpaper_reset_window_weekly">أسبوعي</string>
     <string name="wallpaper_reset_window_weekly_next">إعادة التعيين الأسبوعية التالية: %1$s</string>
     <string name="wallpaper_reset_window_weekly_next_per_engine">إعادة التعيين الأسبوعية التالية (%1$s): %2$s</string>
+    <string name="msg_no_entities_connected">لا توجد جهات اتصال. اربط الجهات أولاً.</string>
+    <string name="webview_title_eclawbot_portal">بوابة EClawbot</string>
+    <string name="wallpaper_settings_panel_label">إعدادات الخلفية</string>
+    <string name="wallpaper_settings_collapse_caret_down">▼</string>
+    <string name="wallpaper_settings_expand_action">توسيع لوحة الإعدادات</string>
+    <string name="wallpaper_settings_collapse_action">طي لوحة الإعدادات</string>
+    <string name="wallpaper_settings_collapse_caret_up">▲</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -984,4 +984,11 @@ Bei Fragen kontaktieren Sie uns über unsere offizielle E-Mail.
     <string name="wallpaper_reset_window_weekly">Wöchentlich</string>
     <string name="wallpaper_reset_window_weekly_next">Nächste wöchentliche Zurücksetzung: %1$s</string>
     <string name="wallpaper_reset_window_weekly_next_per_engine">Nächste wöchentliche Zurücksetzung (%1$s): %2$s</string>
+    <string name="msg_no_entities_connected">Keine Entitäten verbunden. Entitäten zuerst binden.</string>
+    <string name="webview_title_eclawbot_portal">EClawbot Portal</string>
+    <string name="wallpaper_settings_panel_label">Hintergrund-Einstellungen</string>
+    <string name="wallpaper_settings_collapse_caret_down">▼</string>
+    <string name="wallpaper_settings_expand_action">Einstellungspanel erweitern</string>
+    <string name="wallpaper_settings_collapse_action">Einstellungspanel einklappen</string>
+    <string name="wallpaper_settings_collapse_caret_up">▲</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -907,4 +907,11 @@ Tu suscripción permanece activa y puedes reenlazar en cualquier momento (sujeto
     <string name="wallpaper_reset_window_weekly">Semanal</string>
     <string name="wallpaper_reset_window_weekly_next">Próximo reinicio semanal: %1$s</string>
     <string name="wallpaper_reset_window_weekly_next_per_engine">Próximo reinicio semanal (%1$s): %2$s</string>
+    <string name="msg_no_entities_connected">No hay entidades conectadas. Vincula las entidades primero.</string>
+    <string name="webview_title_eclawbot_portal">Portal EClawbot</string>
+    <string name="wallpaper_settings_panel_label">Configuración del fondo de pantalla</string>
+    <string name="wallpaper_settings_collapse_caret_down">▼</string>
+    <string name="wallpaper_settings_expand_action">Expandir panel de configuración</string>
+    <string name="wallpaper_settings_collapse_action">Contraer panel de configuración</string>
+    <string name="wallpaper_settings_collapse_caret_up">▲</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -984,4 +984,11 @@ Si vous avez des questions, contactez-nous via notre e-mail officiel.
     <string name="wallpaper_reset_window_weekly">Hebdomadaire</string>
     <string name="wallpaper_reset_window_weekly_next">Prochaine réinitialisation hebdomadaire : %1$s</string>
     <string name="wallpaper_reset_window_weekly_next_per_engine">Prochaine réinitialisation hebdomadaire (%1$s) : %2$s</string>
+    <string name="msg_no_entities_connected">Aucune entité connectée. Liez les entités d'abord.</string>
+    <string name="webview_title_eclawbot_portal">Portail EClawbot</string>
+    <string name="wallpaper_settings_panel_label">Paramètres du fond d'écran</string>
+    <string name="wallpaper_settings_collapse_caret_down">▼</string>
+    <string name="wallpaper_settings_expand_action">Développer le panneau de paramètres</string>
+    <string name="wallpaper_settings_collapse_action">Réduire le panneau de paramètres</string>
+    <string name="wallpaper_settings_collapse_caret_up">▲</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -982,4 +982,13 @@ GPS: केवल अनुरोध पर, कोई बैकग्राउ�
     <string name="fcm_channel_system_desc">सिस्टम सूचनाएं</string>
     <string name="fcm_channel_feedback_name">फ़ीडबैक अपडेट</string>
     <string name="fcm_channel_feedback_desc">फ़ीडबैक स्थिति अपडेट</string>
+    <string name="msg_no_entities_connected">कोई इकाई कनेक्ट नहीं है। पहले इकाइयों को बाइंड करें।</string>
+    <string name="webview_title_eclawbot_portal">EClawbot पोर्टल</string>
+    <string name="wallpaper_settings_panel_label">वॉलपेपर सेटिंग्स</string>
+    <string name="wallpaper_settings_collapse_caret_down">▼</string>
+    <string name="wallpaper_settings_expand_action">सेटिंग्स पैनल विस्तृत करें</string>
+    <string name="wallpaper_settings_collapse_action">सेटिंग्स पैनल संक्षिप्त करें</string>
+    <string name="wallpaper_settings_collapse_caret_up">▲</string>
+    <string name="ai_chat_status_processing_result">परिणाम प्रोसेस हो रहा है</string>
+    <string name="ai_chat_status_analyzing">विश्लेषण हो रहा है</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -849,4 +849,11 @@
     <string name="wallpaper_reset_window_weekly">Mingguan</string>
     <string name="wallpaper_reset_window_weekly_next">Reset mingguan berikutnya: %1$s</string>
     <string name="wallpaper_reset_window_weekly_next_per_engine">Reset mingguan berikutnya (%1$s): %2$s</string>
+    <string name="msg_no_entities_connected">Tidak ada entitas yang terhubung. Ikat entitas terlebih dahulu.</string>
+    <string name="webview_title_eclawbot_portal">Portal EClawbot</string>
+    <string name="wallpaper_settings_panel_label">Pengaturan wallpaper</string>
+    <string name="wallpaper_settings_collapse_caret_down">▼</string>
+    <string name="wallpaper_settings_expand_action">Perluas panel pengaturan</string>
+    <string name="wallpaper_settings_collapse_action">Ciutkan panel pengaturan</string>
+    <string name="wallpaper_settings_collapse_caret_up">▲</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -877,4 +877,13 @@ Jika ada pertanyaan, silakan hubungi kami melalui email resmi kami.
     <string name="fcm_channel_system_desc">Notifikasi sistem</string>
     <string name="fcm_channel_feedback_name">Pembaruan masukan</string>
     <string name="fcm_channel_feedback_desc">Pembaruan status masukan</string>
+    <string name="msg_no_entities_connected">Tidak ada entitas yang terhubung. Ikat entitas terlebih dahulu.</string>
+    <string name="webview_title_eclawbot_portal">Portal EClawbot</string>
+    <string name="wallpaper_settings_panel_label">Pengaturan wallpaper</string>
+    <string name="wallpaper_settings_collapse_caret_down">▼</string>
+    <string name="wallpaper_settings_expand_action">Perluas panel pengaturan</string>
+    <string name="wallpaper_settings_collapse_action">Ciutkan panel pengaturan</string>
+    <string name="wallpaper_settings_collapse_caret_up">▲</string>
+    <string name="ai_chat_status_processing_result">Memproses hasil</string>
+    <string name="ai_chat_status_analyzing">Menganalisis</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -853,4 +853,11 @@
     <string name="tool_status_writing">Scrittura del file...</string>
     <string name="custom_layout_enabled">Layout personalizzato abilitato</string>
     <string name="custom_layout_using_preset">Utilizzando il layout preimpostato</string>
+    <string name="msg_no_entities_connected">Nessuna entità connessa. Associa le entità prima.</string>
+    <string name="webview_title_eclawbot_portal">Portale EClawbot</string>
+    <string name="wallpaper_settings_panel_label">Impostazioni sfondo</string>
+    <string name="wallpaper_settings_collapse_caret_down">▼</string>
+    <string name="wallpaper_settings_expand_action">Espandi pannello impostazioni</string>
+    <string name="wallpaper_settings_collapse_action">Comprimi pannello impostazioni</string>
+    <string name="wallpaper_settings_collapse_caret_up">▲</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -880,4 +880,11 @@ GPS：オンデマンドのみ、バックグラウンド追跡なし、サー�
     <string name="wallpaper_reset_window_weekly">毎週</string>
     <string name="wallpaper_reset_window_weekly_next">次の毎週リセット：%1$s</string>
     <string name="wallpaper_reset_window_weekly_next_per_engine">次の毎週リセット（%1$s）：%2$s</string>
+    <string name="msg_no_entities_connected">エンティティが接続されていません。最初にエンティティをバインドしてください。</string>
+    <string name="webview_title_eclawbot_portal">EClawbot ポータル</string>
+    <string name="wallpaper_settings_panel_label">壁紙設定</string>
+    <string name="wallpaper_settings_collapse_caret_down">▼</string>
+    <string name="wallpaper_settings_expand_action">設定パネルを展開</string>
+    <string name="wallpaper_settings_collapse_action">設定パネルを折りたたむ</string>
+    <string name="wallpaper_settings_collapse_caret_up">▲</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -880,4 +880,11 @@ GPS: 온디맨드만, 백그라운드 추적 없음, 서버 재시작 시 데이
     <string name="wallpaper_reset_window_weekly">매주</string>
     <string name="wallpaper_reset_window_weekly_next">다음 매주 초기화: %1$s</string>
     <string name="wallpaper_reset_window_weekly_next_per_engine">다음 매주 초기화 (%1$s): %2$s</string>
+    <string name="msg_no_entities_connected">연결된 엔티티가 없습니다. 먼저 엔티티를 바인딩하세요.</string>
+    <string name="webview_title_eclawbot_portal">EClawbot 포털</string>
+    <string name="wallpaper_settings_panel_label">배경화면 설정</string>
+    <string name="wallpaper_settings_collapse_caret_down">▼</string>
+    <string name="wallpaper_settings_expand_action">설정 패널 펼치기</string>
+    <string name="wallpaper_settings_collapse_action">설정 패널 접기</string>
+    <string name="wallpaper_settings_collapse_caret_up">▲</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -982,4 +982,13 @@ Jika anda mempunyai sebarang soalan, sila hubungi kami melalui e-mel rasmi kami.
     <string name="fcm_channel_system_desc">Pemberitahuan sistem</string>
     <string name="fcm_channel_feedback_name">Kemas kini maklum balas</string>
     <string name="fcm_channel_feedback_desc">Kemas kini status maklum balas</string>
+    <string name="msg_no_entities_connected">Tiada entiti disambungkan. Ikat entiti terlebih dahulu.</string>
+    <string name="webview_title_eclawbot_portal">Portal EClawbot</string>
+    <string name="wallpaper_settings_panel_label">Tetapan wallpaper</string>
+    <string name="wallpaper_settings_collapse_caret_down">▼</string>
+    <string name="wallpaper_settings_expand_action">Kembangkan panel tetapan</string>
+    <string name="wallpaper_settings_collapse_action">Runtuhkan panel tetapan</string>
+    <string name="wallpaper_settings_collapse_caret_up">▲</string>
+    <string name="ai_chat_status_processing_result">Memproses hasil</string>
+    <string name="ai_chat_status_analyzing">Menganalisis</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -853,4 +853,11 @@
     <string name="tool_status_writing">Gravando arquivo…</string>
     <string name="custom_layout_enabled">Layout personalizado ativado</string>
     <string name="custom_layout_using_preset">Usando layout predefinido</string>
+    <string name="msg_no_entities_connected">Nenhuma entidade conectada. Associe as entidades primeiro.</string>
+    <string name="webview_title_eclawbot_portal">Portal EClawbot</string>
+    <string name="wallpaper_settings_panel_label">Configurações do papel de parede</string>
+    <string name="wallpaper_settings_collapse_caret_down">▼</string>
+    <string name="wallpaper_settings_expand_action">Expandir painel de configurações</string>
+    <string name="wallpaper_settings_collapse_action">Recolher painel de configurações</string>
+    <string name="wallpaper_settings_collapse_caret_up">▲</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -853,4 +853,11 @@
     <string name="tool_status_writing">Запись файла…</string>
     <string name="custom_layout_enabled">Пользовательский макет включен</string>
     <string name="custom_layout_using_preset">Использование предустановленного макета</string>
+    <string name="msg_no_entities_connected">Нет подключённых сущностей. Сначала привяжите сущности.</string>
+    <string name="webview_title_eclawbot_portal">Портал EClawbot</string>
+    <string name="wallpaper_settings_panel_label">Настройки обоев</string>
+    <string name="wallpaper_settings_collapse_caret_down">▼</string>
+    <string name="wallpaper_settings_expand_action">Развернуть панель настроек</string>
+    <string name="wallpaper_settings_collapse_action">Свернуть панель настроек</string>
+    <string name="wallpaper_settings_collapse_caret_up">▲</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -879,4 +879,11 @@ GPS：รับตามความต้องการเท่านั้�
     <string name="wallpaper_reset_window_weekly">รายสัปดาห์</string>
     <string name="wallpaper_reset_window_weekly_next">รีเซ็ตรายสัปดาห์ถัดไป: %1$s</string>
     <string name="wallpaper_reset_window_weekly_next_per_engine">รีเซ็ตรายสัปดาห์ถัดไป (%1$s): %2$s</string>
+    <string name="msg_no_entities_connected">ไม่มีเอนทิตี้ที่เชื่อมต่อ ผูกเอนทิตี้ก่อน</string>
+    <string name="webview_title_eclawbot_portal">พอร์ทัล EClawbot</string>
+    <string name="wallpaper_settings_panel_label">การตั้งค่าวอลล์เปเปอร์</string>
+    <string name="wallpaper_settings_collapse_caret_down">▼</string>
+    <string name="wallpaper_settings_expand_action">ขยายแผงการตั้งค่า</string>
+    <string name="wallpaper_settings_collapse_action">ยุบแผงการตั้งค่า</string>
+    <string name="wallpaper_settings_collapse_caret_up">▲</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -879,4 +879,11 @@ Nếu có bất kỳ câu hỏi nào, vui lòng liên hệ với chúng tôi qua
     <string name="wallpaper_reset_window_weekly">Hàng tuần</string>
     <string name="wallpaper_reset_window_weekly_next">Đặt lại hàng tuần tiếp theo: %1$s</string>
     <string name="wallpaper_reset_window_weekly_next_per_engine">Đặt lại hàng tuần tiếp theo (%1$s): %2$s</string>
+    <string name="msg_no_entities_connected">Không có thực thể kết nối. Liên kết thực thể trước.</string>
+    <string name="webview_title_eclawbot_portal">Cổng thông tin EClawbot</string>
+    <string name="wallpaper_settings_panel_label">Cài đặt hình nền</string>
+    <string name="wallpaper_settings_collapse_caret_down">▼</string>
+    <string name="wallpaper_settings_expand_action">Mở rộng bảng cài đặt</string>
+    <string name="wallpaper_settings_collapse_action">Thu gọn bảng cài đặt</string>
+    <string name="wallpaper_settings_collapse_caret_up">▲</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -882,4 +882,11 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="wallpaper_reset_window_weekly">每周</string>
     <string name="wallpaper_reset_window_weekly_next">下次每周重置：%1$s</string>
     <string name="wallpaper_reset_window_weekly_next_per_engine">下次每周重置（%1$s）：%2$s</string>
+    <string name="msg_no_entities_connected">没有已连接的实体。请先绑定实体。</string>
+    <string name="webview_title_eclawbot_portal">EClawbot 门户网站</string>
+    <string name="wallpaper_settings_panel_label">壁纸设置</string>
+    <string name="wallpaper_settings_collapse_caret_down">▼</string>
+    <string name="wallpaper_settings_expand_action">展开设置面板</string>
+    <string name="wallpaper_settings_collapse_action">收起设置面板</string>
+    <string name="wallpaper_settings_collapse_caret_up">▲</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -885,4 +885,6 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="ai_chat_status_analyzing">分析中</string>
     <string name="ai_chat_status_processing_result">處理結果中</string>
     <string name="ai_chat_tool_status_default">處理中</string>
+    <string name="msg_no_entities_connected">沒有已連接的實體。請先綁定實體。</string>
+    <string name="webview_title_eclawbot_portal">EClawbot 入口網站</string>
 </resources>

--- a/backend/migrations/20260601_invite_reward_viral_loop.down.sql
+++ b/backend/migrations/20260601_invite_reward_viral_loop.down.sql
@@ -1,4 +1,9 @@
 -- Reversal of 20260601_invite_reward_viral_loop
+-- Drop indexes first (in reverse order of creation)
+DROP INDEX IF EXISTS idx_invite_codes_one_active_per_owner;
+DROP INDEX IF EXISTS idx_invite_redemptions_code_redeem;
+
+-- Drop constraints and columns
 ALTER TABLE invite_redemptions
     DROP CONSTRAINT IF EXISTS chk_reward_type,
     DROP CONSTRAINT IF EXISTS chk_wallet_credit_status,

--- a/backend/migrations/20260601_invite_reward_viral_loop.down.sql
+++ b/backend/migrations/20260601_invite_reward_viral_loop.down.sql
@@ -1,0 +1,13 @@
+-- Reversal of 20260601_invite_reward_viral_loop
+ALTER TABLE invite_redemptions
+    DROP CONSTRAINT IF EXISTS chk_reward_type,
+    DROP CONSTRAINT IF EXISTS chk_wallet_credit_status,
+    DROP COLUMN IF EXISTS inviter_device_id,
+    DROP COLUMN IF EXISTS invitee_device_id,
+    DROP COLUMN IF EXISTS inviter_user_id,
+    DROP COLUMN IF EXISTS reward_type,
+    DROP COLUMN IF EXISTS inviter_reward_amount_mli,
+    DROP COLUMN IF EXISTS invitee_reward_amount_mli,
+    DROP COLUMN IF EXISTS inviter_wallet_ledger_id,
+    DROP COLUMN IF EXISTS invitee_wallet_ledger_id,
+    DROP COLUMN IF EXISTS wallet_credit_status;

--- a/backend/migrations/20260601_invite_reward_viral_loop.down.sql
+++ b/backend/migrations/20260601_invite_reward_viral_loop.down.sql
@@ -1,7 +1,8 @@
--- Reversal of 20260601_invite_reward_viral_loop
+-- Reversal of 20260601_invvite_reward_viral_loop
 -- Drop indexes first (in reverse order of creation)
-DROP INDEX IF EXISTS idx_invite_codes_one_active_per_owner;
+DROP INDEX IF EXISTS idx_invite_redemptions_inviter_invitee_redeem;
 DROP INDEX IF EXISTS idx_invite_redemptions_code_redeem;
+DROP INDEX IF EXISTS idx_invite_codes_one_active_per_owner;
 
 -- Drop constraints and columns
 ALTER TABLE invite_redemptions

--- a/backend/migrations/20260601_invite_reward_viral_loop.up.sql
+++ b/backend/migrations/20260601_invite_reward_viral_loop.up.sql
@@ -4,6 +4,17 @@
 -- Non-breaking: all new columns have defaults; existing rows auto-populate
 
 -- ============================================================
+-- 0. invite_codes — partial unique index (spec § 11, Option B)
+-- One active (non-redeemed) invite code per owner_device_id.
+-- Enables auto-rotate: after redeem, a new code can be minted for
+-- the same owner without violating the per-owner uniqueness constraint.
+-- Idempotent: CREATE UNIQUE INDEX IF NOT EXISTS skips existing.
+-- ============================================================
+CREATE UNIQUE INDEX IF NOT EXISTS idx_invite_codes_one_active_per_owner
+    ON invite_codes (owner_device_id)
+    WHERE used_by_device_id IS NULL;
+
+-- ============================================================
 -- 1. ALTER invite_redemptions — add audit columns (all non-breaking)
 -- ============================================================
 -- NOTE: device_id columns are VARCHAR(64) per auth_schema.sql convention,

--- a/backend/migrations/20260601_invite_reward_viral_loop.up.sql
+++ b/backend/migrations/20260601_invite_reward_viral_loop.up.sql
@@ -4,11 +4,13 @@
 -- Non-breaking: all new columns have defaults; existing rows auto-populate
 
 -- ============================================================
---1. ALTER invite_redemptions — add audit columns
+-- 1. ALTER invite_redemptions — add audit columns (all non-breaking)
 -- ============================================================
+-- NOTE: device_id columns are VARCHAR(64) per auth_schema.sql convention,
+-- NOT UUID (live device-auth writes use VARCHAR(64) device identifiers).
 ALTER TABLE invite_redemptions
-    ADD COLUMN IF NOT EXISTS inviter_device_id UUID,
-    ADD COLUMN IF NOT EXISTS invitee_device_id UUID,
+    ADD COLUMN IF NOT EXISTS inviter_device_id VARCHAR(64),
+    ADD COLUMN IF NOT EXISTS invitee_device_id VARCHAR(64),
     ADD COLUMN IF NOT EXISTS inviter_user_id UUID,
     ADD COLUMN IF NOT EXISTS reward_type VARCHAR(32) NOT NULL DEFAULT 'redeem',
     ADD COLUMN IF NOT EXISTS inviter_reward_amount_mli BIGINT NOT NULL DEFAULT 0,
@@ -19,35 +21,38 @@ ALTER TABLE invite_redemptions
 
 -- ============================================================
 -- 2. Back-populate existing rows from Phase-5 data
--- (invitee_user_id is NOT NULL → safe to use)
+-- Inviter_user_id comes from invite_codes.owner_user_id (FK join).
+-- We reference invite_codes via a LATERAL subquery to avoid
+-- Postgres UPDATE..FROM self-reference restriction.
 -- ============================================================
-UPDATE invite_redemptions
+UPDATE invite_redemptions r
 SET
-    inviter_user_id       = ic.owner_user_id,
-    inviter_reward_amount_mli = inviter_reward_mli,
-    invitee_reward_amount_mli = invitee_reward_mli,
-    reward_type           = 'redeem',
-    wallet_credit_status  = CASE
-        WHEN first_topup_credited THEN 'not_attempted' -- Phase-5 had no wallet credit tracking
-        ELSE 'not_attempted'
-    END
-FROM invite_redemptions r
-JOIN invite_codes ic ON ic.code = r.code
-WHERE invite_redemptions.id = r.id
-  AND invite_redemptions.inviter_user_id IS NULL;
+    inviter_user_id           = sub.owner_user_id,
+    inviter_reward_amount_mli = r.inviter_reward_mli,
+    invitee_reward_amount_mli = r.invitee_reward_mli,
+    reward_type               = 'redeem',
+    wallet_credit_status      = 'not_attempted'
+FROM (
+    SELECT ic.code, ic.owner_user_id
+    FROM invite_codes ic
+) AS sub
+WHERE sub.code = r.code
+  AND r.inviter_user_id IS NULL;
 
 -- ============================================================
 -- 3. Partial unique guard: one 'redeem' per code
--- (Postgres supports WHERE clause in CREATE INDEX; we use
---  a filtered unique index via a separate step below)
+-- Prevents race-condition double-redeem on the 'redeem' path.
+-- Postgres supports partial unique indexes natively.
 -- ============================================================
--- Note: existing constraint + data already enforces uniqueness
--- on invitee_user_id UNIQUE. We add code-scope for 'redeem'
--- path only via a conditional index (see below after col added).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_invite_redemptions_code_redeem
+    ON invite_redemptions (code)
+    WHERE reward_type = 'redeem';
 
 -- ============================================================
--- 4. Add wallet_credit_status check constraint (optional)
--- Valid values for wallet_credit_status
+-- 4. Add wallet_credit_status check constraint
+-- Valid values: not_attempted | pending_user_account | pending | credited | failed
+-- NOT VALID to avoid table-lock on large existing tables.
+-- Will VALIDATE after back-populate in a follow-up maintenance window.
 -- ============================================================
 ALTER TABLE invite_redemptions
     ADD CONSTRAINT chk_wallet_credit_status
@@ -68,14 +73,21 @@ ALTER TABLE invite_redemptions
     NOT VALID;
 
 -- ============================================================
--- 6. Add comments for documentation
+-- 6. Validate constraints after back-populate is stable
+-- (separate from initial ADD to avoid lock; run after data is clean)
 -- ============================================================
-COMMENT ON COLUMN invite_redemptions.inviter_device_id    IS 'Device ID of inviter at time of redemption (for device-only invites)';
-COMMENT ON COLUMN invite_redemptions.invitee_device_id    IS 'Device ID of invitee at time of redemption';
-COMMENT ON COLUMN invite_redemptions.inviter_user_id     IS 'User ID of inviter (populated from invite_codes.owner_user_id)';
-COMMENT ON COLUMN invite_redemptions.reward_type          IS 'Type of reward: redeem (default), first_topup_bonus, manual';
+ALTER TABLE invite_redemptions VALIDATE CONSTRAINT chk_wallet_credit_status;
+ALTER TABLE invite_redemptions VALIDATE CONSTRAINT chk_reward_type;
+
+-- ============================================================
+-- 7. Add column comments for documentation
+-- ============================================================
+COMMENT ON COLUMN invite_redemptions.inviter_device_id       IS 'Device ID of inviter at time of redemption (VARCHAR(64), for device-only invites)';
+COMMENT ON COLUMN invite_redemptions.invitee_device_id       IS 'Device ID of invitee at time of redemption (VARCHAR(64))';
+COMMENT ON COLUMN invite_redemptions.inviter_user_id         IS 'User ID of inviter (populated from invite_codes.owner_user_id)';
+COMMENT ON COLUMN invite_redemptions.reward_type            IS 'Type of reward: redeem (default), first_topup_bonus, manual';
 COMMENT ON COLUMN invite_redemptions.inviter_reward_amount_mli IS 'Actual inviter reward in mLI (may differ from Phase-5 inviter_reward_mli)';
 COMMENT ON COLUMN invite_redemptions.invitee_reward_amount_mli IS 'Actual invitee reward in mLI';
 COMMENT ON COLUMN invite_redemptions.inviter_wallet_ledger_id IS 'wallet_ledger.id for inviter credit (null until credited)';
 COMMENT ON COLUMN invite_redemptions.invitee_wallet_ledger_id IS 'wallet_ledger.id for invitee credit (null until credited)';
-COMMENT ON COLUMN invite_redemptions.wallet_credit_status IS 'Wallet credit state: not_attempted|pending_user_account|pending|credited|failed';
+COMMENT ON COLUMN invite_redemptions.wallet_credit_status  IS 'Wallet credit state: not_attempted|pending_user_account|pending|credited|failed';

--- a/backend/migrations/20260601_invite_reward_viral_loop.up.sql
+++ b/backend/migrations/20260601_invite_reward_viral_loop.up.sql
@@ -1,0 +1,81 @@
+-- Migration: 20260601_invite_reward_viral_loop
+-- PR: [Schema] Invite reward viral loop migration
+-- Purpose: Add audit columns + ledger type for invite reward viral loop (PR1 of 3)
+-- Non-breaking: all new columns have defaults; existing rows auto-populate
+
+-- ============================================================
+--1. ALTER invite_redemptions — add audit columns
+-- ============================================================
+ALTER TABLE invite_redemptions
+    ADD COLUMN IF NOT EXISTS inviter_device_id UUID,
+    ADD COLUMN IF NOT EXISTS invitee_device_id UUID,
+    ADD COLUMN IF NOT EXISTS inviter_user_id UUID,
+    ADD COLUMN IF NOT EXISTS reward_type VARCHAR(32) NOT NULL DEFAULT 'redeem',
+    ADD COLUMN IF NOT EXISTS inviter_reward_amount_mli BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS invitee_reward_amount_mli BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS inviter_wallet_ledger_id BIGINT,
+    ADD COLUMN IF NOT EXISTS invitee_wallet_ledger_id BIGINT,
+    ADD COLUMN IF NOT EXISTS wallet_credit_status VARCHAR(32) NOT NULL DEFAULT 'not_attempted';
+
+-- ============================================================
+-- 2. Back-populate existing rows from Phase-5 data
+-- (invitee_user_id is NOT NULL → safe to use)
+-- ============================================================
+UPDATE invite_redemptions
+SET
+    inviter_user_id       = ic.owner_user_id,
+    inviter_reward_amount_mli = inviter_reward_mli,
+    invitee_reward_amount_mli = invitee_reward_mli,
+    reward_type           = 'redeem',
+    wallet_credit_status  = CASE
+        WHEN first_topup_credited THEN 'not_attempted' -- Phase-5 had no wallet credit tracking
+        ELSE 'not_attempted'
+    END
+FROM invite_redemptions r
+JOIN invite_codes ic ON ic.code = r.code
+WHERE invite_redemptions.id = r.id
+  AND invite_redemptions.inviter_user_id IS NULL;
+
+-- ============================================================
+-- 3. Partial unique guard: one 'redeem' per code
+-- (Postgres supports WHERE clause in CREATE INDEX; we use
+--  a filtered unique index via a separate step below)
+-- ============================================================
+-- Note: existing constraint + data already enforces uniqueness
+-- on invitee_user_id UNIQUE. We add code-scope for 'redeem'
+-- path only via a conditional index (see below after col added).
+
+-- ============================================================
+-- 4. Add wallet_credit_status check constraint (optional)
+-- Valid values for wallet_credit_status
+-- ============================================================
+ALTER TABLE invite_redemptions
+    ADD CONSTRAINT chk_wallet_credit_status
+    CHECK (wallet_credit_status IN (
+        'not_attempted',
+        'pending_user_account',
+        'pending',
+        'credited',
+        'failed'
+    )) NOT VALID;
+
+-- ============================================================
+-- 5. Add reward_type check constraint
+-- ============================================================
+ALTER TABLE invite_redemptions
+    ADD CONSTRAINT chk_reward_type
+    CHECK (reward_type IN ('redeem', 'first_topup_bonus', 'manual'))
+    NOT VALID;
+
+-- ============================================================
+-- 6. Add comments for documentation
+-- ============================================================
+COMMENT ON COLUMN invite_redemptions.inviter_device_id    IS 'Device ID of inviter at time of redemption (for device-only invites)';
+COMMENT ON COLUMN invite_redemptions.invitee_device_id    IS 'Device ID of invitee at time of redemption';
+COMMENT ON COLUMN invite_redemptions.inviter_user_id     IS 'User ID of inviter (populated from invite_codes.owner_user_id)';
+COMMENT ON COLUMN invite_redemptions.reward_type          IS 'Type of reward: redeem (default), first_topup_bonus, manual';
+COMMENT ON COLUMN invite_redemptions.inviter_reward_amount_mli IS 'Actual inviter reward in mLI (may differ from Phase-5 inviter_reward_mli)';
+COMMENT ON COLUMN invite_redemptions.invitee_reward_amount_mli IS 'Actual invitee reward in mLI';
+COMMENT ON COLUMN invite_redemptions.inviter_wallet_ledger_id IS 'wallet_ledger.id for inviter credit (null until credited)';
+COMMENT ON COLUMN invite_redemptions.invitee_wallet_ledger_id IS 'wallet_ledger.id for invitee credit (null until credited)';
+COMMENT ON COLUMN invite_redemptions.wallet_credit_status IS 'Wallet credit state: not_attempted|pending_user_account|pending|credited|failed';

--- a/backend/migrations/20260601_invite_reward_viral_loop.up.sql
+++ b/backend/migrations/20260601_invite_reward_viral_loop.up.sql
@@ -1,10 +1,27 @@
--- Migration: 20260601_invite_reward_viral_loop
+-- Migration: 20260601_invvite_reward_viral_loop
 -- PR: [Schema] Invite reward viral loop migration
--- Purpose: Add audit columns + ledger type for invite reward viral loop (PR1 of 3)
+-- Purpose: Add audit columns + ledger type + code lifecycle index for invite reward viral loop (PR1 of 3)
 -- Non-breaking: all new columns have defaults; existing rows auto-populate
 
 -- ============================================================
--- 0. invite_codes — partial unique index (spec § 11, Option B)
+-- 0. invite_codes — dedupe duplicate active codes (spec § 11 Low item)
+-- If production already has multiple active codes per owner_device_id,
+-- keep the oldest (lowest created_at) as active; expire the rest by
+-- setting used_at = NOW() so they cannot be redeemed.
+-- This must run BEFORE creating the partial unique index.
+-- ============================================================
+UPDATE invite_codes ic
+SET used_at = NOW()
+WHERE ic.used_by_device_id IS NULL
+  AND EXISTS (
+      SELECT 1 FROM invite_codes other
+      WHERE other.owner_device_id = ic.owner_device_id
+        AND other.used_by_device_id IS NULL
+        AND other.created_at < ic.created_at
+  );
+
+-- ============================================================
+-- 0b. invite_codes — partial unique index (spec § 11, Option B)
 -- One active (non-redeemed) invite code per owner_device_id.
 -- Enables auto-rotate: after redeem, a new code can be minted for
 -- the same owner without violating the per-owner uniqueness constraint.
@@ -33,16 +50,16 @@ ALTER TABLE invite_redemptions
 -- ============================================================
 -- 2. Back-populate existing rows from Phase-5 data
 -- Inviter_user_id comes from invite_codes.owner_user_id (FK join).
--- We reference invite_codes via a LATERAL subquery to avoid
+-- We reference invite_codes via a subquery to avoid
 -- Postgres UPDATE..FROM self-reference restriction.
 -- ============================================================
 UPDATE invite_redemptions r
 SET
-    inviter_user_id           = sub.owner_user_id,
-    inviter_reward_amount_mli = r.inviter_reward_mli,
-    invitee_reward_amount_mli = r.invitee_reward_mli,
-    reward_type               = 'redeem',
-    wallet_credit_status      = 'not_attempted'
+    inviter_user_id            = sub.owner_user_id,
+    inviter_reward_amount_mli  = r.inviter_reward_mli,
+    invitee_reward_amount_mli  = r.invitee_reward_mli,
+    reward_type                = 'redeem',
+    wallet_credit_status       = 'not_attempted'
 FROM (
     SELECT ic.code, ic.owner_user_id
     FROM invite_codes ic
@@ -60,10 +77,19 @@ CREATE UNIQUE INDEX IF NOT EXISTS idx_invite_redemptions_code_redeem
     WHERE reward_type = 'redeem';
 
 -- ============================================================
+-- 3b. Partial unique guard: one 'redeem' per inviter-invitee pair
+-- (spec § 11 High item: same invitee may only be rewarded once by the same inviter)
+-- Prevents double-pay if invitee tries to redeem with the same inviter twice.
+-- ============================================================
+CREATE UNIQUE INDEX IF NOT EXISTS idx_invite_redemptions_inviter_invitee_redeem
+    ON invite_redemptions (inviter_device_id, invitee_device_id)
+    WHERE reward_type = 'redeem';
+
+-- ============================================================
 -- 4. Add wallet_credit_status check constraint
 -- Valid values: not_attempted | pending_user_account | pending | credited | failed
 -- NOT VALID to avoid table-lock on large existing tables.
--- Will VALIDATE after back-populate in a follow-up maintenance window.
+-- Will VALIDATE after back-populate is stable.
 -- ============================================================
 ALTER TABLE invite_redemptions
     ADD CONSTRAINT chk_wallet_credit_status
@@ -93,12 +119,12 @@ ALTER TABLE invite_redemptions VALIDATE CONSTRAINT chk_reward_type;
 -- ============================================================
 -- 7. Add column comments for documentation
 -- ============================================================
-COMMENT ON COLUMN invite_redemptions.inviter_device_id       IS 'Device ID of inviter at time of redemption (VARCHAR(64), for device-only invites)';
-COMMENT ON COLUMN invite_redemptions.invitee_device_id       IS 'Device ID of invitee at time of redemption (VARCHAR(64))';
-COMMENT ON COLUMN invite_redemptions.inviter_user_id         IS 'User ID of inviter (populated from invite_codes.owner_user_id)';
-COMMENT ON COLUMN invite_redemptions.reward_type            IS 'Type of reward: redeem (default), first_topup_bonus, manual';
-COMMENT ON COLUMN invite_redemptions.inviter_reward_amount_mli IS 'Actual inviter reward in mLI (may differ from Phase-5 inviter_reward_mli)';
-COMMENT ON COLUMN invite_redemptions.invitee_reward_amount_mli IS 'Actual invitee reward in mLI';
-COMMENT ON COLUMN invite_redemptions.inviter_wallet_ledger_id IS 'wallet_ledger.id for inviter credit (null until credited)';
-COMMENT ON COLUMN invite_redemptions.invitee_wallet_ledger_id IS 'wallet_ledger.id for invitee credit (null until credited)';
-COMMENT ON COLUMN invite_redemptions.wallet_credit_status  IS 'Wallet credit state: not_attempted|pending_user_account|pending|credited|failed';
+COMMENT ON COLUMN invite_redemptions.inviter_device_id        IS 'Device ID of inviter at time of redemption (VARCHAR(64), for device-only invites)';
+COMMENT ON COLUMN invite_redemptions.invitee_device_id        IS 'Device ID of invitee at time of redemption (VARCHAR(64))';
+COMMENT ON COLUMN invite_redemptions.inviter_user_id          IS 'User ID of inviter (populated from invite_codes.owner_user_id)';
+COMMENT ON COLUMN invite_redemptions.reward_type             IS 'Type of reward: redeem (default), first_topup_bonus, manual';
+COMMENT ON COLUMN invite_redemptions.inviter_reward_amount_mli  IS 'Actual inviter reward in mLI (may differ from Phase-5 inviter_reward_mli)';
+COMMENT ON COLUMN invite_redemptions.invitee_reward_amount_mli  IS 'Actual invitee reward in mLI';
+COMMENT ON COLUMN invite_redemptions.inviter_wallet_ledger_id  IS 'wallet_ledger.id for inviter credit (null until credited)';
+COMMENT ON COLUMN invite_redemptions.invitee_wallet_ledger_id  IS 'wallet_ledger.id for invitee credit (null until credited)';
+COMMENT ON COLUMN invite_redemptions.wallet_credit_status    IS 'Wallet credit state: not_attempted|pending_user_account|pending|credited|failed';

--- a/backend/wallet.js
+++ b/backend/wallet.js
@@ -70,12 +70,13 @@ const LEDGER_TYPES = Object.freeze({
     DEPOSIT_HOLD:    'deposit_hold',
     DEPOSIT_RELEASE: 'deposit_release',
     DEPOSIT_FORFEIT: 'deposit_forfeit',
-    REFERRAL_BONUS:      'referral_bonus',
-    SIGNUP_BONUS:        'signup_bonus',
-    SUBSCRIPTION_GRANT:  'subscription_grant',
-    REFUND:              'refund',
-    ADMIN_ADJUST:        'admin_adjust',
-    WITHDRAW:            'withdraw',
+    REFERRAL_BONUS:          'referral_bonus',
+    SIGNUP_BONUS:            'signup_bonus',
+    SUBSCRIPTION_GRANT:     'subscription_grant',
+    INVITE_FIRST_TOPUP_BONUS:'invite_first_topup_bonus',
+    REFUND:                  'refund',
+    ADMIN_ADJUST:            'admin_adjust',
+    WITHDRAW:                'withdraw',
 });
 
 const ALLOWED_LEDGER_TYPES = new Set(Object.values(LEDGER_TYPES));

--- a/backend/wallet_schema.sql
+++ b/backend/wallet_schema.sql
@@ -51,7 +51,7 @@ CREATE INDEX IF NOT EXISTS idx_wallets_updated ON wallets(updated_at DESC);
 -- type values (mirror LEDGER_TYPES in wallet.js):
 --   topup, rental_income, rental_spend, platform_fee,
 --   deposit_hold, deposit_release, deposit_forfeit,
---   referral_bonus, signup_bonus, refund, admin_adjust, withdraw
+--   referral_bonus, signup_bonus, invite_first_topup_bonus, refund, admin_adjust, withdraw
 CREATE TABLE IF NOT EXISTS wallet_ledger (
     id BIGSERIAL PRIMARY KEY,
     user_id UUID NOT NULL,


### PR DESCRIPTION
## Summary
PR1 of 3 for invite reward viral loop. Adds audit columns to invite_redemptions, partial unique indexes for k>1 guards, ledger type constant, and full down migration.

Spec: docs/specs/invite-reward-viral-loop.md (PR #3057 pending)
Parent card: card_e56010f1a00a0d9ce4644455 (done)
PR1 card: card_5299912ae84e5773f7101f3b

## Changes
- backend/migrations/20260601_invite_reward_viral_loop.up.sql:
  - +9 audit columns to invite_redemptions (non-breaking, defaults populated)
  - Back-populate from Phase-5 join (UPDATE..FROM corrected)
  - VARCHAR(64) for device_id columns (matches auth_schema)
  - CHECK constraints (NOT VALID + VALIDATE follow-up) for wallet_credit_status + reward_type
  - dedupe duplicate active codes before CREATE INDEX
  - idx_invite_codes_one_active_per_owner WHERE used_by_device_id IS NULL (spec § 11 option B)
  - idx_invite_redemptions_inviter_invitee_redeem WHERE reward_type='redeem' (spec § 11 same-invitee-once guard)
  - Column comments
- backend/migrations/20260601_invite_reward_viral_loop.down.sql: full symmetric reversal
- backend/wallet.js: INVITE_FIRST_TOPUP_BONUS added to LEDGER_TYPES
- backend/wallet_schema.sql: ledger type comment updated

## Review
- LGTM by #2 LOBSTER (2026-06-01 01:42 TPE)
- Three review rounds: schema correctness, active-code partial index, same-invitee dedup + double-pay guard

## Test plan
- [ ] Migration applies cleanly on staging
- [ ] Existing Phase-5 SELECT queries unchanged
- [ ] Partial unique indexes enforce expected invariants
- [ ] Down migration reverses cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)