### PR TITLE
[Frontend] Fix invite viral loop metrics contract

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3174,18 +3174,21 @@
         // Fires 'invite_activation' beacon once per user after their first bot chat
         // following an invite code redemption. Uses localStorage to de-duplicate.
         const INVITE_ACTIVATION_KEY = 'invite_activation_fired_v1';
+        const INVITE_REDEEMED_KEY = 'invite_redeemed_v1';
 
         function fireInviteActivationOnce() {
             try {
+                if (localStorage.getItem(INVITE_REDEEMED_KEY) !== '1') return;
                 if (localStorage.getItem(INVITE_ACTIVATION_KEY)) return;
                 localStorage.setItem(INVITE_ACTIVATION_KEY, '1');
-            } catch (_) { /* localStorage blocked */ }
+            } catch (_) { return; }
 
             // Fire beacon via portal beacon endpoint (works pre-login too)
             try {
-                const entry = { action: 'invite_activation', meta: {}, ts: Date.now() };
+                const meta = { source: 'invite_redeem' };
+                const entry = { action: 'invite_activation', meta, ts: Date.now() };
                 if (typeof telemetry !== 'undefined' && telemetry.trackAction) {
-                    telemetry.trackAction('invite_activation', {});
+                    telemetry.trackAction('invite_activation', meta);
                 }
                 // Fallback direct fetch
                 fetch('/api/portal/beacons', {

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -1945,6 +1945,11 @@
             border-color: rgba(245,158,11,0.3);
             color: #f59e0b;
         }
+        .kvalue-k-model-badge.legacy {
+            background: rgba(148,163,184,0.12);
+            border-color: rgba(148,163,184,0.3);
+            color: #94a3b8;
+        }
         .kvalue-loading { color: var(--text-secondary, #aaa); font-size: 13px; text-align: center; padding: 20px 0; }
         .kvalue-empty { color: var(--text-muted, #888); font-size: 12px; text-align: center; padding: 16px 0; }
         .kvalue-error { color: #ef4444; font-size: 12px; text-align: center; padding: 12px 0; }
@@ -5941,31 +5946,48 @@
             if (!content) return;
 
             // The invite_k object is embedded in the daily response by PR2 backend.
-            // Fallback: compose from invite_conversion + invite_clicks if invite_k not present.
+            // Legacy fallback is cumulative and cannot produce a valid same-day k value.
             const inviteK = data.invite_k || null;
             const inviteConversion = data.invite_conversion || {};
             const inviteClicks = data.invite_clicks || [];
+            const metricValue = (...values) => {
+                for (const value of values) {
+                    if (value === null || value === undefined || value === '') continue;
+                    const n = Number(value);
+                    if (Number.isFinite(n)) return n;
+                }
+                return 0;
+            };
+            const nullableMetric = value => {
+                if (value === null || value === undefined || value === '') return null;
+                const n = Number(value);
+                return Number.isFinite(n) ? n : null;
+            };
+            const fmt = n => n == null ? '—' : Number(n).toLocaleString();
 
-            // Try to extract k-value data from available fields
             let shares = 0, clicks = 0, redeemed = 0, activated = 0;
             let kObserved = null, kModel = null;
+            let legacyFallback = false;
 
-            if (inviteK) {
-                shares = inviteK.shares ?? 0;
-                clicks = inviteK.clicks ?? 0;
-                redeemed = inviteK.redeemed ?? 0;
-                activated = inviteK.activated ?? 0;
-                kObserved = inviteK.k_observed ?? null;
-                kModel = inviteK.k_model ?? null;
+            const hasInviteKContract = inviteK && (
+                Object.prototype.hasOwnProperty.call(inviteK, 'share_events') ||
+                Object.prototype.hasOwnProperty.call(inviteK, 'unique_clicks') ||
+                Object.prototype.hasOwnProperty.call(inviteK, 'k_observed') ||
+                Object.prototype.hasOwnProperty.call(inviteK, 'activated_invitees')
+            );
+
+            if (hasInviteKContract) {
+                shares = metricValue(inviteK.share_events, inviteK.shares);
+                clicks = metricValue(inviteK.unique_clicks, inviteK.clicks);
+                redeemed = metricValue(inviteK.redeemed);
+                activated = metricValue(inviteK.activated_invitees, inviteK.activated);
+                kObserved = nullableMetric(inviteK.k_observed);
+                kModel = nullableMetric(inviteK.k_model);
             } else {
-                // Compose from invite_conversion + invite_clicks if invite_k not in response yet
-                shares = inviteConversion.total_codes ?? 0;
-                redeemed = inviteConversion.redeemed_codes ?? 0;
-                clicks = inviteClicks.reduce ? inviteClicks.reduce((s, r) => s + (r.clicks || 0), 0) : 0;
-                // activated not available without event tracking — show as N/A
-                if (shares > 0 && redeemed > 0) {
-                    kObserved = parseFloat((redeemed / shares).toFixed(3));
-                }
+                legacyFallback = true;
+                shares = metricValue(inviteConversion.total_codes);
+                redeemed = metricValue(inviteK?.total_redemptions, inviteConversion.redeemed_codes);
+                clicks = Array.isArray(inviteClicks) ? inviteClicks.reduce((s, r) => s + (Number(r.clicks) || 0), 0) : 0;
             }
 
             // Show empty if no data
@@ -5981,7 +6003,6 @@
             // KPI grid
             const kpiGrid = document.getElementById('kvalueKpiGrid');
             if (kpiGrid) {
-                const fmt = n => n == null ? '—' : n.toLocaleString();
                 kpiGrid.innerHTML = `
                     <div class="kvalue-kpi-card">
                         <div class="kvalue-kpi-value">${fmt(shares)}</div>
@@ -5996,7 +6017,7 @@
                         <div class="kvalue-kpi-label">Redeemed</div>
                     </div>
                     <div class="kvalue-kpi-card">
-                        <div class="kvalue-kpi-value">${activated > 0 ? fmt(activated) : '—'}</div>
+                        <div class="kvalue-kpi-value">${legacyFallback ? '—' : fmt(activated)}</div>
                         <div class="kvalue-kpi-label">Activated (P1)</div>
                     </div>
                     <div class="kvalue-kpi-card k-value ${kObserved != null && kObserved >= 1 ? 'overunity' : ''}">
@@ -6030,7 +6051,7 @@
                     </div>
                     <div class="kvalue-funnel-arrow">→</div>
                     <div class="kvalue-funnel-step">
-                        <div class="kvalue-funnel-value">${activated > 0 ? fmt(activated) : '—'}</div>
+                        <div class="kvalue-funnel-value">${legacyFallback ? '—' : fmt(activated)}</div>
                         <div class="kvalue-funnel-label">activated (${pct(activated, redeemed)}%)</div>
                     </div>`;
             }
@@ -6047,6 +6068,13 @@
                             ${overunity ? 'Viral ✓' : 'Below threshold'}
                         </span>
                     </div>`;
+            } else if (kModelEl && legacyFallback) {
+                kModelEl.innerHTML = `
+                    <div class="kvalue-k-model-badge legacy">
+                        Legacy cumulative fallback — k unavailable
+                    </div>`;
+            } else if (kModelEl) {
+                kModelEl.innerHTML = '';
             }
         }
 

--- a/backend/public/portal/invite.html
+++ b/backend/public/portal/invite.html
@@ -461,13 +461,30 @@
 
         function translateRedeemError(code) {
             const map = {
+                'self_invite': tt('inv_error_self', 'You cannot use your own invite code.'),
                 'self_invite_forbidden': tt('inv_error_self', 'You cannot use your own invite code.'),
+                'invite_code_already_used': tt('inv_error_already', 'This code has already been used.'),
                 'already_redeemed': tt('inv_error_already', 'This code has already been used.'),
+                'invitee_already_redeemed_owner': tt('inv_error_already_owner', 'You have already redeemed an invite from this user.'),
+                'invite_code_not_found': tt('inv_error_not_found', 'Invalid invite code.'),
                 'code_not_found': tt('inv_error_not_found', 'Invalid invite code.'),
                 'code_expired': tt('inv_error_expired', 'This invite code has expired.'),
                 'code_max_uses_reached': tt('inv_error_max', 'This invite code has reached its usage limit.'),
+                'wallet_user_required': tt('inv_error_wallet_required', 'Please sign in to receive wallet rewards.'),
             };
             return map[code] || null;
+        }
+
+        function ecoinFromMli(value) {
+            const n = Number(value);
+            if (!Number.isFinite(n)) return null;
+            return n / 1000;
+        }
+
+        function formatEcoin(value) {
+            const n = Number(value);
+            if (!Number.isFinite(n)) return null;
+            return Number.isInteger(n) ? String(n) : n.toFixed(3).replace(/0+$/, '').replace(/\.$/, '');
         }
 
         async function redeemCode() {
@@ -476,11 +493,32 @@
             try {
                 const data = await apiCall('POST', '/api/invite/redeem', { code });
                 if (data?.success) {
-                    // Show detailed reward result
-                    const inviteeReward = data.inviteeRewardEcoin ?? data.wallet_rewards?.invitee ?? 100;
-                    const inviterReward = data.inviterRewardEcoin ?? data.wallet_rewards?.inviter ?? 500;
-                    const msg = tt('inv_redeem_success_detail',
-                        `Redeemed! You received +${inviteeReward} e-coin. The inviter got +${inviterReward} e-coin.`);
+                    const walletRewards = data.wallet_rewards || {};
+                    const inviteeReward = data.inviteeRewardEcoin
+                        ?? data.invitee_reward_ecoin
+                        ?? ecoinFromMli(walletRewards.invitee_reward_mli)
+                        ?? walletRewards.invitee;
+                    const inviterReward = data.inviterRewardEcoin
+                        ?? data.inviter_reward_ecoin
+                        ?? ecoinFromMli(walletRewards.inviter_reward_mli)
+                        ?? walletRewards.inviter;
+                    const inviteeRewardText = formatEcoin(inviteeReward);
+                    const inviterRewardText = formatEcoin(inviterReward);
+                    const walletStatus = walletRewards.status || null;
+                    let msg;
+                    if (walletStatus === 'pending_user_account' || walletStatus === 'skipped_device_only') {
+                        msg = tt('inv_redeem_success_pending',
+                            `Redeemed! Your invite is recorded. Wallet rewards are ${walletStatus === 'pending_user_account' ? 'pending account binding' : 'not available for this device-only session'}.`);
+                    } else if (walletStatus === 'credited' || walletStatus === 'already_credited') {
+                        msg = tt('inv_redeem_success_detail',
+                            `Redeemed! You received +${inviteeRewardText || 0} e-coin. The inviter got +${inviterRewardText || 0} e-coin.`);
+                    } else if (inviteeRewardText || inviterRewardText) {
+                        msg = tt('inv_redeem_success_detail',
+                            `Redeemed! You received +${inviteeRewardText || 0} e-coin. The inviter got +${inviterRewardText || 0} e-coin.`);
+                    } else {
+                        msg = data.message || tt('inv_redeem_success', 'Invite code redeemed!');
+                    }
+                    try { localStorage.setItem('invite_redeemed_v1', '1'); } catch (_) {}
                     showToast(msg, 'success');
                     loadStats();
                 } else {

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -335580,6 +335580,17 @@ const TRANSLATIONS = {
 
 
         "inv_redeem_success": "Code redeemed! You received 100 e-coin.",
+        "inv_error_self": "You cannot use your own invite code.",
+        "inv_error_already": "This code has already been used.",
+        "inv_error_already_owner": "You have already redeemed an invite from this user.",
+        "inv_error_not_found": "Invalid invite code.",
+        "inv_error_expired": "This invite code has expired.",
+        "inv_error_max": "This invite code has reached its usage limit.",
+        "inv_error_wallet_required": "Please sign in to receive wallet rewards.",
+        "inv_redeem_success_pending": "Redeemed! Your invite is recorded. Wallet rewards are pending.",
+        "inv_redeem_success_detail": "Redeemed! You received e-coin. The inviter got e-coin.",
+        "kvalue_date_label": "Date:",
+        "kvalue_refresh": "Refresh",
 
 
 

--- a/backend/tests/jest/growth.test.js
+++ b/backend/tests/jest/growth.test.js
@@ -66,10 +66,12 @@ function setupAdminQueries({
     total_codes = 0, redeemed_codes = 0,
     sourceRows,
     inviteClicksRows,
+    inviteKRow,
 } = {}) {
     const finalSourceRows = sourceRows || [{ source: 'web_portal', count: signups }];
     const finalInviteClicksRows = inviteClicksRows || [];
-    // is_admin lookup → 6 metric queries (parallel order: signups, retention, plaza, invite, invite_clicks, source_channel)
+    const finalInviteKRow = inviteKRow || { total_redemptions: 0, inviters_with_redemption: 0, total_invitees: 0 };
+    // is_admin lookup → 7 metric queries (parallel order: signups, retention, plaza, invite, invite_clicks, source_channel, invite_k)
     mockQuery
         .mockResolvedValueOnce({ rows: [{ is_admin: true }] })
         .mockResolvedValueOnce({ rows: [{ c: signups }] })
@@ -77,7 +79,8 @@ function setupAdminQueries({
         .mockResolvedValueOnce({ rows: [{ c: plaza }] })
         .mockResolvedValueOnce({ rows: [{ total_codes, redeemed_codes }] })
         .mockResolvedValueOnce({ rows: finalInviteClicksRows })
-        .mockResolvedValueOnce({ rows: finalSourceRows });
+        .mockResolvedValueOnce({ rows: finalSourceRows })
+        .mockResolvedValueOnce({ rows: [finalInviteKRow] });
 }
 
 describe('Growth /daily auth', () => {
@@ -110,7 +113,7 @@ describe('Growth /daily auth', () => {
 });
 
 describe('Growth /daily aggregation contract', () => {
-    it('returns the 5 metrics + date + follow-ups list', async () => {
+    it('returns the daily metric contract including invite_k', async () => {
         setupAdminQueries({
             signups: 7, cohort: 20, active: 8, plaza: 3, total_codes: 50, redeemed_codes: 11,
             sourceRows: [{ source: 'invite', count: 4 }, { source: 'web_portal', count: 3 }],
@@ -123,11 +126,14 @@ describe('Growth /daily aggregation contract', () => {
         expect(res.body.retention_7d).toEqual({ cohort_size: 20, active_size: 8, pct: 40 });
         expect(res.body.plaza_new_listed_today).toBe(3);
         expect(res.body.invite_conversion).toEqual({ total_codes: 50, redeemed_codes: 11, pct: 22 });
+        expect(res.body.invite_k).toEqual({
+            date: res.body.date,
+            k: null,
+            total_redemptions: 0,
+            inviters_with_redemption: 0,
+            total_invitees: 0,
+        });
         expect(res.body.date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
-        expect(Array.isArray(res.body.follow_ups)).toBe(true);
-        expect(res.body.follow_ups.length).toBe(3);
-        expect(res.body.follow_ups.some(s => /schema lacks signup_source/i.test(s))).toBe(false);
-        expect(res.body.follow_ups.some(s => /invite_conversion.*cumulative/i.test(s))).toBe(true);
     });
 
     it('source_channel SQL groups by signup_source without leaking user rows', async () => {

--- a/backend/tests/jest/invite-redemption-policy.test.js
+++ b/backend/tests/jest/invite-redemption-policy.test.js
@@ -22,13 +22,19 @@ describe('invite redemption policy — Option B (per-code-once)', () => {
     test('per-code-once check remains at the top of the handler', () => {
         // A code whose used_by_device_id is already set must 409.
         expect(INDEX_JS).toMatch(
-            /if \(used_by_device_id\) return res\.status\(409\)\.json\(\{ success: false, error: 'Invite code already used' \}\)/
+            /if \(used_by_device_id\)\s*\{\s*return \{ error: 'Invite code already used', status: 409 \};\s*\}/
         );
     });
 
     test('self-invite guard remains', () => {
         expect(INDEX_JS).toMatch(
-            /if \(owner_device_id === deviceId\) return res\.status\(400\)/
+            /if \(owner_device_id === deviceId\)\s*\{\s*return \{ error: 'Cannot redeem your own invite code', status: 400 \};\s*\}/
+        );
+    });
+
+    test('transaction early errors are returned through the response handler', () => {
+        expect(INDEX_JS).toMatch(
+            /if \(result\.error\)\s*\{\s*return res\.status\(result\.status\)\.json\(\{ success: false, error: result\.error \}\);\s*\}/
         );
     });
 

--- a/backend/tests/jest/invite-tiers.test.js
+++ b/backend/tests/jest/invite-tiers.test.js
@@ -103,7 +103,8 @@ describe('invite tier/milestone wiring', () => {
     test('/api/invite/redeem credits milestones via bitmask UPDATE', () => {
         expect(INDEX_JS).toMatch(/milestones_claimed\s*=\s*\$2/);
         expect(INDEX_JS).toMatch(/for\s*\(\s*const\s+t\s+of\s+INVITE_TIERS\s*\)/);
-        expect(INDEX_JS).toMatch(/inviter_milestones_unlocked/);
+        expect(INDEX_JS).toMatch(/let\s+addBonus\s*=\s*0/);
+        expect(INDEX_JS).toMatch(/bonus_messages\s*=\s*bonus_messages\s*\+\s*\$1/);
     });
 
     test('/api/invite/stats exposes tier + unlocked_tiers + tier_catalog', () => {


### PR DESCRIPTION
## Summary
- Align dashboard invite k-value rendering with the PR2/spec response fields: share_events, unique_clicks, redeemed, activated_invitees, k_observed, and k_model, with a legacy fallback for the current cumulative invite_k shape.
- Gate invite_activation telemetry on a successful invite redemption marker so ordinary first bot chats do not count as invite activations.
- Align invite redeem success/error handling with wallet_rewards status and *_reward_mli fields.
- Add the matching EN i18n fallback keys required by the portal i18n syntax check.
- Refresh stale backend guard tests for the merged PR2 transactional invite redeem flow and growth invite_k query.

## Context
Original PR3 already landed on main as #3061. This clean branch is based on latest main and fixes the PR3 review blockers without carrying the unrelated i18n changes from #3062.

Kanban: card_30385b0a4ad73483d45d1da3
Supersedes: #3062

## Validation
- npm ci --include=dev
- npx jest tests/jest/growth.test.js tests/jest/invite-redemption-policy.test.js tests/jest/invite-tiers.test.js --runInBand
- npm run smoke:portal
- node --check public/shared/i18n.js
- node scripts/i18n-check.js
- git diff --check -- backend/public/portal/chat.html backend/public/portal/invite.html backend/public/portal/dashboard.html backend/public/shared/i18n.js backend/tests/jest/growth.test.js backend/tests/jest/invite-redemption-policy.test.js backend/tests/jest/invite-tiers.test.js