### PR TITLE
fix(openclaw-channel): suppress background events for interactive agents

### DIFF
--- a/openclaw-channel-eclaw/README.md
+++ b/openclaw-channel-eclaw/README.md
@@ -170,7 +170,8 @@ Device owners can schedule messages to be sent to your bot at a specific time (o
 |----------|----------|-------------|
 | `ECLAW_WEBHOOK_URL` | Production | Public URL for receiving inbound messages |
 | `ECLAW_WEBHOOK_PORT` | Optional | Webhook server port (default: random) |
-| `ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS` | Optional | Set to `1` for high-priority interactive agents that receive many kanban reminder cards. The webhook is still ACKed for stale `⏰` nudge notifications without occupying the model reply path; assignment, move, reopen, review, and escalation notifications still dispatch normally. |
+| `ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS` | Optional | Set to `1` for high-priority interactive agents that receive many kanban cards. The webhook is still ACKed, but `kanban_notification` events do not occupy the model reply path, so normal web chat and `/api/client/speak` probes stay responsive. |
+| `ECLAW_SUPPRESS_BACKGROUND_EVENTS` | Optional | Set to `1` to suppress the default low-priority background event set (`kanban_notification`, `org_forward`), or set a comma-separated event list such as `org_forward`. Use per runtime, not globally, when a background feed is starving an interactive entity. |
 
 ## OpenClaw Version Drift Mitigation
 
@@ -191,10 +192,9 @@ docker exec openclaw-project-f openclaw --version
 After the recreate, verify startup logs show the intended runtime model, for
 example `agent model: openai-codex/gpt-5.5 (thinking=xhigh, ...)`, then test
 the E-Claw browser chat UI with a fresh nonce. For #1, enable
-`ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS=1` when stale `⏰` kanban reminder cards
-are recurring ahead of user messages; this prevents reminder backlog from
-starving the interactive reply path while preserving task-assignment, movement,
-reopen, review, and escalation pushes.
+`ECLAW_SUPPRESS_BACKGROUND_EVENTS=1` when recurring kanban or `org_forward`
+background cards are queued ahead of user messages; this prevents background
+feed backlog from starving the interactive reply path.
 
 ## Troubleshooting
 

--- a/openclaw-channel-eclaw/src/webhook-handler.ts
+++ b/openclaw-channel-eclaw/src/webhook-handler.ts
@@ -6,17 +6,27 @@ function envFlagEnabled(name: string): boolean {
   return /^(1|true|yes|on)$/i.test(String(process.env[name] || '').trim());
 }
 
-function kanbanNotificationSuppressionEnabled(): boolean {
-  return envFlagEnabled('ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS')
-    || envFlagEnabled('ECLAW_SKIP_KANBAN_NOTIFICATIONS');
+function envListIncludes(name: string, value: string, defaults: readonly string[] = []): boolean {
+  const raw = String(process.env[name] || '').trim();
+  if (!raw) return false;
+  if (/^(1|true|yes|on)$/i.test(raw)) return defaults.includes(value);
+  return raw
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean)
+    .includes(value);
 }
 
-function isStaleNudgeKanbanNotification(msg: EClawInboundMessage): boolean {
-  return String(msg.text || '').trimStart().startsWith('⏰');
-}
+const DEFAULT_BACKGROUND_EVENTS = ['kanban_notification', 'org_forward'] as const;
 
-function shouldSuppressKanbanNotification(msg: EClawInboundMessage): boolean {
-  return kanbanNotificationSuppressionEnabled() && isStaleNudgeKanbanNotification(msg);
+function shouldSuppressInboundEvent(event: string): boolean {
+  if (
+    event === 'kanban_notification'
+    && (envFlagEnabled('ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS') || envFlagEnabled('ECLAW_SKIP_KANBAN_NOTIFICATIONS'))
+  ) {
+    return true;
+  }
+  return envListIncludes('ECLAW_SUPPRESS_BACKGROUND_EVENTS', event, DEFAULT_BACKGROUND_EVENTS);
 }
 
 /**
@@ -85,8 +95,8 @@ export function createWebhookHandler(
       const eclawCtx = msg.eclaw_context;
       const silentToken = eclawCtx?.silentToken ?? '[SILENT]';
 
-      if (event === 'kanban_notification' && shouldSuppressKanbanNotification(msg)) {
-        console.log('[E-Claw] Stale kanban nudge suppressed by runtime policy; webhook ACKed without occupying the model reply path');
+      if (shouldSuppressInboundEvent(event)) {
+        console.log(`[E-Claw] Background event ${event} suppressed by runtime policy; webhook ACKed without occupying the model reply path`);
         return;
       }
 

--- a/openclaw-channel-eclaw/test/webhook-handler.test.ts
+++ b/openclaw-channel-eclaw/test/webhook-handler.test.ts
@@ -7,6 +7,7 @@ describe('createWebhookHandler', () => {
   afterEach(() => {
     delete process.env.ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS;
     delete process.env.ECLAW_SKIP_KANBAN_NOTIFICATIONS;
+    delete process.env.ECLAW_SUPPRESS_BACKGROUND_EVENTS;
   });
 
   it('acks healthcheck messages without dispatching agent work', async () => {
@@ -46,7 +47,7 @@ describe('createWebhookHandler', () => {
     expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });
 
-  it('can ack stale kanban nudges without occupying the model reply path', async () => {
+  it('can ack kanban notifications without occupying the model reply path', async () => {
     process.env.ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS = '1';
     const dispatchReplyWithBufferedBlockDispatcher = vi.fn();
     setPluginRuntime({
@@ -76,7 +77,7 @@ describe('createWebhookHandler', () => {
         entityId: 1,
         event: 'kanban_notification',
         from: 'kanban',
-        text: '⏰ Task nudge: [Fix the bug]\nStuck in "In Progress" for 3h, please continue',
+        text: '📋 New task assigned: 🔥 [P0] Fix the bug\nStatus: TODO',
       },
     }, res);
 
@@ -86,15 +87,47 @@ describe('createWebhookHandler', () => {
     expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });
 
-  it.each([
-    ['new assignment', '📋 New task assigned: 🔥 [P0] Fix the bug\nStatus: TODO'],
-    ['status move', '➡️ Task status changed: [Fix the bug]\nTODO → In Progress'],
-    ['reopen', '♻️ Card reopened: Fix the bug\nDone → TODO\nReason: needs rework'],
-    ['review', '🔍 Pending review: [Fix the bug]\nMoved from In Progress to Review. Please review.'],
-    ['priority escalation', '⬆️ Card "Fix the bug" has been stuck for 6h and was upgraded to P0'],
-    ['block escalation', '🚫 Card "Fix the bug" has been stuck for 24h and was moved to blocked'],
-  ])('does not suppress %s kanban notifications', async (_caseName, text) => {
-    process.env.ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS = '1';
+  it('can ack org_forward background events without occupying the model reply path', async () => {
+    process.env.ECLAW_SUPPRESS_BACKGROUND_EVENTS = '1';
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn();
+    setPluginRuntime({
+      channel: {
+        reply: {
+          finalizeInboundContext: vi.fn(),
+          dispatchReplyWithBufferedBlockDispatcher,
+        },
+      },
+    });
+
+    const client = {
+      sendMessage: vi.fn().mockResolvedValue({ success: true }),
+    };
+    setClient('default', client as any);
+
+    const handler = createWebhookHandler('token', 'default', {});
+    const res = {
+      writeHead: vi.fn(),
+      end: vi.fn(),
+    };
+
+    await handler({
+      method: 'POST',
+      body: {
+        deviceId: 'device-1',
+        entityId: 1,
+        event: 'org_forward',
+        from: 'entity:4',
+        text: 'Forwarded org update from another entity',
+      },
+    }, res);
+
+    expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'application/json' });
+    expect(res.end).toHaveBeenCalledWith(JSON.stringify({ ok: true }));
+    expect(client.sendMessage).not.toHaveBeenCalled();
+    expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+  });
+
+  it('continues dispatching kanban notifications when suppression is disabled', async () => {
     const dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockResolvedValue(undefined);
     const finalizeInboundContext = vi.fn((ctx) => ctx);
     setPluginRuntime({
@@ -124,7 +157,7 @@ describe('createWebhookHandler', () => {
         entityId: 1,
         event: 'kanban_notification',
         from: 'kanban',
-        text,
+        text: '📋 New task assigned: 🔥 [P0] Fix the bug\nStatus: TODO',
       },
     }, res);
 


### PR DESCRIPTION
## Summary\n- add per-runtime background event suppression for kanban_notification/org_forward\n- document #1 OpenClaw drift/background-event mitigation\n- cover kanban and org_forward suppression with tests\n\n## Verification\n- npm test\n- npm run build\n- monitor-eclaw-once.sh passed after Target Mode repair\n- browser UI ACK passed for #1/#3/#4