### PR TITLE
[codex] Add PR CI hard gate and contribution guide

### DIFF
--- a/.github/workflows/entity-cards-ci.yml
+++ b/.github/workflows/entity-cards-ci.yml
@@ -15,6 +15,7 @@ on:
       - 'app/src/main/java/com/hank/clawlive/ui/EntityCardAdapter.kt'
       - 'backend/tests/test-entity-cards-stability.js'
       - 'backend/tests/test-entity-management.js'
+      - '.github/workflows/entity-cards-ci.yml'
   pull_request:
     branches: [main]
     paths:
@@ -25,6 +26,7 @@ on:
       - 'app/src/main/java/com/hank/clawlive/ui/EntityCardAdapter.kt'
       - 'backend/tests/test-entity-cards-stability.js'
       - 'backend/tests/test-entity-management.js'
+      - '.github/workflows/entity-cards-ci.yml'
 
 jobs:
   # ── Static Analysis: Verify empty-response guards exist ──

--- a/.github/workflows/pr-ci-hard-gate.yml
+++ b/.github/workflows/pr-ci-hard-gate.yml
@@ -1,0 +1,180 @@
+name: PR CI Hard Gate
+
+on:
+  pull_request_target:
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+
+permissions:
+  checks: read
+  contents: read
+  pull-requests: read
+
+jobs:
+  ci-gate:
+    name: Required PR CI gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.pull_request.draft == false }}
+    steps:
+      - name: Wait for required path-scoped CI
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            if (!pr) {
+              core.notice('No pull_request payload; workflow_dispatch invocation has no PR checks to gate.');
+              return;
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const headSha = pr.head.sha;
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner,
+              repo,
+              pull_number: pr.number,
+              per_page: 100
+            });
+            const changed = files.map(file => file.filename);
+            core.info(`PR #${pr.number} head ${headSha} changed ${changed.length} file(s).`);
+
+            const has = predicate => changed.some(predicate);
+            const exact = names => path => names.includes(path);
+
+            const groups = [
+              {
+                label: 'Backend CI',
+                when: path => path === 'i18n.js' || path.startsWith('backend/') || path === '.github/workflows/backend-ci.yml',
+                checks: ['ESLint', 'i18n syntax check', 'Jest unit tests']
+              },
+              {
+                label: 'Portal Smoke CI',
+                when: path =>
+                  path.startsWith('backend/public/portal/') ||
+                  path.startsWith('backend/public/shared/') ||
+                  [
+                    'backend/scripts/portal-smoke-check.js',
+                    'backend/tests/jest/chat-targets-static.test.js',
+                    'backend/tests/jest/kanban-nav-static.test.js',
+                    'backend/tests/jest/portal-smoke-static.test.js',
+                    'backend/package.json',
+                    'backend/package-lock.json',
+                    '.github/workflows/portal-smoke-ci.yml'
+                  ].includes(path),
+                checks: ['Critical portal pages']
+              },
+              {
+                label: 'Android CI',
+                when: path =>
+                  path.startsWith('app/') ||
+                  path.startsWith('gradle/') ||
+                  ['build.gradle.kts', 'settings.gradle.kts', '.github/workflows/android-ci.yml'].includes(path),
+                checks: ['Android Lint', 'Assemble Debug APK', 'Kotlin Unit Tests']
+              },
+              {
+                label: 'Entity Cards Stability CI',
+                when: exact([
+                  'backend/index.js',
+                  'backend/public/portal/dashboard.html',
+                  'app/src/main/java/com/hank/clawlive/MainActivity.kt',
+                  'app/src/main/java/com/hank/clawlive/data/model/MultiEntityResponse.kt',
+                  'app/src/main/java/com/hank/clawlive/ui/EntityCardAdapter.kt',
+                  'backend/tests/test-entity-cards-stability.js',
+                  'backend/tests/test-entity-management.js',
+                  '.github/workflows/entity-cards-ci.yml'
+                ]),
+                checks: ['Verify entity-cards guards', 'Web/Android feature parity']
+              },
+              {
+                label: 'CLI-Proxy CI',
+                when: path => path.startsWith('claude-cli-proxy/') || path === '.github/workflows/cli-proxy-ci.yml',
+                checks: ['Python unit tests']
+              },
+              {
+                label: 'iOS App i18n Validation',
+                when: path => path.startsWith('ios-app/i18n/') || path === '.github/workflows/ios-i18n-ci.yml',
+                checks: ['i18n key consistency']
+              }
+            ];
+
+            const activeGroups = groups.filter(group => has(group.when));
+            const expected = [...new Set(activeGroups.flatMap(group => group.checks))];
+
+            if (activeGroups.length === 0) {
+              core.notice('No path-scoped CI workflows are required for these files.');
+              return;
+            }
+
+            core.info(`Required CI groups: ${activeGroups.map(group => group.label).join(', ')}`);
+            core.info(`Required check runs: ${expected.join(', ')}`);
+
+            const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+            const listCheckRuns = async () => {
+              const allRuns = [];
+              for (let page = 1; page <= 10; page++) {
+                const response = await github.rest.checks.listForRef({
+                  owner,
+                  repo,
+                  ref: headSha,
+                  per_page: 100,
+                  page
+                });
+                allRuns.push(...response.data.check_runs);
+                if (response.data.check_runs.length < 100) break;
+              }
+              return allRuns;
+            };
+            const sortLatest = runs => runs.sort((a, b) => {
+              const aTime = Date.parse(a.started_at || a.created_at || 0);
+              const bTime = Date.parse(b.started_at || b.created_at || 0);
+              return bTime - aTime;
+            });
+
+            const deadline = Date.now() + 20 * 60 * 1000;
+            let lastLog = 0;
+
+            while (Date.now() < deadline) {
+              const runs = await listCheckRuns();
+
+              const missing = [];
+              const pending = [];
+              const failed = [];
+              const passed = [];
+
+              for (const name of expected) {
+                const latest = sortLatest(runs.filter(run => run.name === name))[0];
+                if (!latest) {
+                  missing.push(name);
+                  continue;
+                }
+                if (latest.status !== 'completed') {
+                  pending.push(`${name} (${latest.status})`);
+                  continue;
+                }
+                if (latest.conclusion !== 'success') {
+                  failed.push(`${name} (${latest.conclusion}) ${latest.html_url}`);
+                  continue;
+                }
+                passed.push(name);
+              }
+
+              if (failed.length > 0) {
+                core.setFailed(`Required CI failed:\n${failed.join('\n')}`);
+                return;
+              }
+
+              if (missing.length === 0 && pending.length === 0) {
+                core.notice(`All required CI passed: ${passed.join(', ')}`);
+                return;
+              }
+
+              if (Date.now() - lastLog > 60 * 1000) {
+                lastLog = Date.now();
+                core.info(`Waiting for required CI. Passed: ${passed.length}; pending: ${pending.join(', ') || 'none'}; missing: ${missing.join(', ') || 'none'}.`);
+              }
+              await sleep(30 * 1000);
+            }
+
+            core.setFailed(`Timed out waiting for required CI on ${headSha}. Missing or pending check runs: ${expected.join(', ')}`);

--- a/.github/workflows/pr-ci-hard-gate.yml
+++ b/.github/workflows/pr-ci-hard-gate.yml
@@ -88,6 +88,20 @@ jobs:
                 checks: ['Verify entity-cards guards', 'Web/Android feature parity']
               },
               {
+                label: 'Settings Help Invariant CI',
+                when: path =>
+                  /^backend\/public\/(?:.*\/)?settings[^/]*\.html$/.test(path) ||
+                  [
+                    'backend/public/shared/i18n.js',
+                    'backend/settings-help-keys.json',
+                    'backend/scripts/generate-settings-help-keys.js',
+                    'backend/scripts/check-settings-help-invariant.js',
+                    '.github/workflows/settings-help-invariant-ci.yml',
+                    '.github/workflows/pr-ci-hard-gate.yml'
+                  ].includes(path),
+                checks: ['Settings help invariant']
+              },
+              {
                 label: 'CLI-Proxy CI',
                 when: path => path.startsWith('claude-cli-proxy/') || path === '.github/workflows/cli-proxy-ci.yml',
                 checks: ['Python unit tests']

--- a/.github/workflows/settings-help-invariant-ci.yml
+++ b/.github/workflows/settings-help-invariant-ci.yml
@@ -1,0 +1,54 @@
+name: Settings Help Invariant CI
+
+on:
+  push:
+    branches: ['**']
+    paths:
+      - 'backend/public/settings*.html'
+      - 'backend/public/**/settings*.html'
+      - 'backend/public/shared/i18n.js'
+      - 'backend/settings-help-keys.json'
+      - 'backend/scripts/generate-settings-help-keys.js'
+      - 'backend/scripts/check-settings-help-invariant.js'
+      - '.github/workflows/settings-help-invariant-ci.yml'
+      - '.github/workflows/pr-ci-hard-gate.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'backend/public/settings*.html'
+      - 'backend/public/**/settings*.html'
+      - 'backend/public/shared/i18n.js'
+      - 'backend/settings-help-keys.json'
+      - 'backend/scripts/generate-settings-help-keys.js'
+      - 'backend/scripts/check-settings-help-invariant.js'
+      - '.github/workflows/settings-help-invariant-ci.yml'
+      - '.github/workflows/pr-ci-hard-gate.yml'
+
+jobs:
+  settings-help-invariant:
+    name: Settings help invariant
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Check settings label/help/HELP-KEY invariant
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            node backend/scripts/check-settings-help-invariant.js \
+              --base "${{ github.event.pull_request.base.sha }}" \
+              --head HEAD
+          else
+            if git rev-parse HEAD~1 >/dev/null 2>&1; then
+              node backend/scripts/check-settings-help-invariant.js --base HEAD~1 --head HEAD
+            else
+              node backend/scripts/check-settings-help-invariant.js --all
+            fi
+          fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,8 @@ EClawbot uses a PR-first workflow. Do not push directly to `main`; open a featur
 3. Run the local checks that match the files you touched.
 4. Open a PR into `main`.
 5. Complete the self-review checklist in [`docs/code-review-checklist.md`](docs/code-review-checklist.md).
-6. Wait for `PR CI Hard Gate / Required PR CI gate` to pass before merge.
+6. For settings field changes, follow [`docs/contribution.md`](docs/contribution.md).
+7. Wait for `PR CI Hard Gate / Required PR CI gate` to pass before merge.
 
 The hard gate is the single branch-protection status that should be required. It runs on every PR and waits for the path-scoped CI jobs that apply to the changed files. If an expected workflow is missing, skipped by mistake, cancelled, or failing, the hard gate fails.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to EClawbot
+
+EClawbot uses a PR-first workflow. Do not push directly to `main`; open a feature branch, run the relevant local checks, and let GitHub Actions complete before merge.
+
+## Pull Request Flow
+
+1. Create a branch from current `main`.
+2. Keep the change focused and avoid unrelated formatting churn.
+3. Run the local checks that match the files you touched.
+4. Open a PR into `main`.
+5. Complete the self-review checklist in [`docs/code-review-checklist.md`](docs/code-review-checklist.md).
+6. Wait for `PR CI Hard Gate / Required PR CI gate` to pass before merge.
+
+The hard gate is the single branch-protection status that should be required. It runs on every PR and waits for the path-scoped CI jobs that apply to the changed files. If an expected workflow is missing, skipped by mistake, cancelled, or failing, the hard gate fails.
+
+## Local Checks
+
+Backend changes:
+
+```bash
+cd backend
+npm run lint
+npm test
+```
+
+Portal or shared frontend changes:
+
+```bash
+cd backend
+npm run smoke:portal
+npx jest tests/jest/portal-smoke-static.test.js tests/jest/chat-targets-static.test.js tests/jest/kanban-nav-static.test.js --runInBand
+```
+
+Changes to `backend/public/shared/i18n.js` or portal HTML:
+
+```bash
+cd backend
+npm test -- --testPathPattern=i18n-syntax
+node scripts/i18n-check.js
+```
+
+Android changes:
+
+```bash
+./gradlew lintDebug testDebugUnitTest assembleDebug --no-daemon
+```
+
+CLI proxy changes:
+
+```bash
+cd claude-cli-proxy
+python -m unittest tests.test_repo_auth tests.test_multi_tenant -v
+```
+
+iOS locale changes:
+
+```bash
+node -e "const fs=require('fs'); const dir='ios-app/i18n'; for (const f of fs.readdirSync(dir).filter(x=>x.endsWith('.json'))) JSON.parse(fs.readFileSync(dir+'/'+f,'utf8')); console.log('iOS locale JSON parsed');"
+```
+
+## CI Requirements
+
+Repository branch protection should require only:
+
+```text
+PR CI Hard Gate / Required PR CI gate
+```
+
+The individual path-scoped workflow jobs should stay optional in branch protection. Requiring them directly can leave PRs blocked when a workflow is correctly skipped because its files were not touched.
+
+## Secrets
+
+Never include device secrets, API tokens, private keys, database URLs, or production credentials in commits, PR bodies, logs, screenshots, or review comments. Use redacted examples such as `YOUR_DEVICE_ID` and `YOUR_BOT_SECRET`.

--- a/backend/scripts/check-settings-help-invariant.js
+++ b/backend/scripts/check-settings-help-invariant.js
@@ -1,0 +1,281 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Settings help invariant gate.
+ *
+ * Enforces the settings field trio from docs/specs/settings-help-icon.md:
+ *   <field>_label + <field>_help + a nearby HELP-KEY annotation.
+ *
+ * The full help -> code invariant is scoped by backend/settings-help-keys.json
+ * when that generated registry exists. Before the registry lands, the checker
+ * still gates newly added/modified settings labels from the PR diff.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+const { execFileSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const BACKEND_DIR = path.join(REPO_ROOT, 'backend');
+const PUBLIC_DIR = path.join(BACKEND_DIR, 'public');
+const I18N_FILE = path.join(PUBLIC_DIR, 'shared', 'i18n.js');
+const REGISTRY_FILE = path.join(BACKEND_DIR, 'settings-help-keys.json');
+const SETTINGS_FILE_RE = /^backend\/public\/(?:.*\/)?settings[^/]*\.html$/;
+const LABEL_RE = /\bdata-i18n\s*=\s*["']([A-Za-z0-9_.-]+)_label["']/g;
+const HELP_ANNOTATION_RE = /HELP-KEY:\s*([A-Za-z0-9_.-]+)/g;
+
+function parseArgs(argv) {
+    const args = { all: false, base: null, head: 'HEAD' };
+    for (let i = 0; i < argv.length; i += 1) {
+        const arg = argv[i];
+        if (arg === '--all') args.all = true;
+        else if (arg === '--base') args.base = argv[++i];
+        else if (arg === '--head') args.head = argv[++i];
+        else if (arg === '--help') {
+            console.log('Usage: node backend/scripts/check-settings-help-invariant.js [--base <ref>] [--head <ref>] [--all]');
+            process.exit(0);
+        } else {
+            throw new Error(`Unknown argument: ${arg}`);
+        }
+    }
+    return args;
+}
+
+function runGit(args) {
+    return execFileSync('git', args, {
+        cwd: REPO_ROOT,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+    });
+}
+
+function diffRange(base, head) {
+    if (!base) return null;
+    return `${base}...${head || 'HEAD'}`;
+}
+
+function listChangedFiles(base, head) {
+    const range = diffRange(base, head);
+    if (!range) return [];
+    try {
+        return runGit(['diff', '--name-only', range])
+            .split(/\r?\n/)
+            .map((line) => line.trim())
+            .filter(Boolean);
+    } catch (err) {
+        console.warn(`[settings-help] Could not list changed files for ${range}: ${err.message}`);
+        return [];
+    }
+}
+
+function loadTranslations() {
+    const src = fs.readFileSync(I18N_FILE, 'utf8');
+    const noop = () => {};
+    const sandbox = {
+        _result: null,
+        localStorage: { getItem: noop, setItem: noop },
+        navigator: { language: 'en' },
+        document: {
+            querySelectorAll: () => [],
+            documentElement: { lang: 'en' },
+            addEventListener: noop,
+            getElementById: () => null,
+        },
+        window: { location: { search: '' } },
+        setTimeout: noop,
+        console: { log: noop, warn: noop, error: noop },
+    };
+    vm.createContext(sandbox);
+    vm.runInContext(`${src}\n_result = TRANSLATIONS;`, sandbox, { timeout: 5000 });
+    if (!sandbox._result || typeof sandbox._result !== 'object') {
+        throw new Error('Failed to extract TRANSLATIONS from backend/public/shared/i18n.js');
+    }
+    return sandbox._result;
+}
+
+function hasTranslation(translations, locale, key) {
+    return !!(
+        translations[locale] &&
+        typeof translations[locale] === 'object' &&
+        Object.prototype.hasOwnProperty.call(translations[locale], key)
+    );
+}
+
+function loadRegistry() {
+    if (!fs.existsSync(REGISTRY_FILE)) return null;
+    const raw = JSON.parse(fs.readFileSync(REGISTRY_FILE, 'utf8'));
+    const entries = Array.isArray(raw.keys) ? raw.keys : [];
+    return entries.map((entry) => ({
+        fieldKey: entry.field_key,
+        labelKey: entry.label_key,
+        helpKey: entry.help_key,
+        source: 'registry',
+    }));
+}
+
+function collectDiffAddedSettingsLabels(base, head) {
+    const range = diffRange(base, head);
+    if (!range) return [];
+    let diff;
+    try {
+        diff = runGit(['diff', '--unified=0', '--no-ext-diff', range, '--', 'backend/public']);
+    } catch (err) {
+        console.warn(`[settings-help] Could not read settings diff for ${range}: ${err.message}`);
+        return [];
+    }
+
+    const labels = new Map();
+    let currentFile = null;
+    for (const line of diff.split(/\r?\n/)) {
+        if (line.startsWith('+++ b/')) {
+            currentFile = line.slice('+++ b/'.length);
+            continue;
+        }
+        if (!currentFile || !SETTINGS_FILE_RE.test(currentFile)) continue;
+        if (!line.startsWith('+') || line.startsWith('+++')) continue;
+        LABEL_RE.lastIndex = 0;
+        let match;
+        while ((match = LABEL_RE.exec(line)) !== null) {
+            labels.set(match[1], currentFile);
+        }
+    }
+    return [...labels.entries()].map(([fieldKey, sourceFile]) => ({
+        fieldKey,
+        labelKey: `${fieldKey}_label`,
+        helpKey: `${fieldKey}_help`,
+        source: `diff:${sourceFile}`,
+    }));
+}
+
+function shouldSkipDir(name) {
+    return name === '.git' ||
+        name === 'node_modules' ||
+        name === 'build' ||
+        name === '.gradle' ||
+        name === '.kotlin' ||
+        name === 'release_v1.0.75' ||
+        name === 'release_v1.0.76' ||
+        name === 'release_v1.0.78' ||
+        name === 'release_v1.0.79' ||
+        name === 'release_v1.0.80' ||
+        name === 'release_v1.0.85' ||
+        name === 'release_v1.0.88' ||
+        name === 'release_v1.0.89';
+}
+
+function shouldScanFile(filePath) {
+    if (filePath === I18N_FILE) return false;
+    const rel = path.relative(REPO_ROOT, filePath);
+    if (rel.startsWith('docs/')) return false;
+    return /\.(html|js|jsx|ts|tsx|kt|java|mjs|cjs)$/.test(filePath);
+}
+
+function walk(dir, out = []) {
+    if (!fs.existsSync(dir)) return out;
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (entry.isDirectory()) {
+            if (!shouldSkipDir(entry.name)) walk(path.join(dir, entry.name), out);
+        } else {
+            const full = path.join(dir, entry.name);
+            if (shouldScanFile(full)) out.push(full);
+        }
+    }
+    return out;
+}
+
+function collectHelpAnnotations() {
+    const roots = [
+        path.join(REPO_ROOT, 'backend'),
+        path.join(REPO_ROOT, 'app', 'src'),
+        path.join(REPO_ROOT, 'ios-app'),
+        path.join(REPO_ROOT, 'openclaw-channel-eclaw', 'src'),
+    ];
+    const annotations = new Map();
+    for (const file of roots.flatMap((root) => walk(root))) {
+        const text = fs.readFileSync(file, 'utf8');
+        HELP_ANNOTATION_RE.lastIndex = 0;
+        let match;
+        while ((match = HELP_ANNOTATION_RE.exec(text)) !== null) {
+            const key = match[1];
+            const line = text.slice(0, match.index).split(/\r?\n/).length;
+            if (!annotations.has(key)) annotations.set(key, []);
+            annotations.get(key).push(`${path.relative(REPO_ROOT, file)}:${line}`);
+        }
+    }
+    return annotations;
+}
+
+function addRequired(required, entry) {
+    if (!entry.fieldKey || !entry.labelKey || !entry.helpKey) return;
+    if (!required.has(entry.helpKey)) required.set(entry.helpKey, { ...entry });
+}
+
+function main() {
+    const args = parseArgs(process.argv.slice(2));
+    const translations = loadTranslations();
+    const registry = loadRegistry();
+    const changedFiles = args.all ? [] : listChangedFiles(args.base, args.head);
+    const diffLabels = args.all ? [] : collectDiffAddedSettingsLabels(args.base, args.head);
+    const annotations = collectHelpAnnotations();
+
+    const required = new Map();
+    if (registry) {
+        for (const entry of registry) addRequired(required, entry);
+    }
+    for (const entry of diffLabels) addRequired(required, entry);
+
+    const registryHelpKeys = new Set((registry || []).map((entry) => entry.helpKey));
+    const errors = [];
+
+    for (const entry of required.values()) {
+        for (const locale of ['en', 'zh-TW']) {
+            if (!hasTranslation(translations, locale, entry.labelKey)) {
+                errors.push(`${entry.source}: missing ${locale} label key ${entry.labelKey}`);
+            }
+            if (!hasTranslation(translations, locale, entry.helpKey)) {
+                errors.push(`${entry.source}: missing ${locale} help key ${entry.helpKey}`);
+            }
+        }
+        if (!annotations.has(entry.helpKey)) {
+            errors.push(`${entry.source}: missing HELP-KEY annotation for ${entry.helpKey}`);
+        }
+        if (registry && entry.source.startsWith('diff:') && !registryHelpKeys.has(entry.helpKey)) {
+            errors.push(`${entry.source}: ${entry.helpKey} is not present in backend/settings-help-keys.json; regenerate the registry`);
+        }
+    }
+
+    for (const [helpKey, locations] of annotations.entries()) {
+        for (const locale of ['en', 'zh-TW']) {
+            if (!hasTranslation(translations, locale, helpKey)) {
+                errors.push(`HELP-KEY ${helpKey} at ${locations.join(', ')} points to missing ${locale} i18n key`);
+            }
+        }
+    }
+
+    if (errors.length > 0) {
+        console.error('\nFAIL: settings help invariant violations:\n');
+        for (const error of errors) console.error(`  - ${error}`);
+        console.error('\nEvery settings field added or listed in backend/settings-help-keys.json must have:');
+        console.error('  1. <field>_label in en and zh-TW');
+        console.error('  2. <field>_help in en and zh-TW');
+        console.error('  3. A code-side HELP-KEY annotation pointing at <field>_help');
+        process.exit(1);
+    }
+
+    const changedSummary = changedFiles.length ? `${changedFiles.length} changed file(s)` : 'no diff range';
+    const registrySummary = registry ? `${registry.length} registry key(s)` : 'no registry yet';
+    const diffSummary = diffLabels.length ? `${diffLabels.length} added/modified settings label(s)` : 'no added settings labels';
+    console.log(`[settings-help] OK: ${registrySummary}; ${diffSummary}; ${annotations.size} annotation key(s); ${changedSummary}.`);
+}
+
+if (require.main === module) main();
+
+module.exports = {
+    collectDiffAddedSettingsLabels,
+    collectHelpAnnotations,
+    hasTranslation,
+    loadRegistry,
+    loadTranslations,
+};

--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -1,0 +1,47 @@
+# Contribution Guide
+
+## 新增 settings 欄位的 3-piece 義務
+
+Every new labeled settings field must ship three linked pieces in the same PR:
+
+1. `<field>_label` in `backend/public/shared/i18n.js`.
+2. `<field>_help` in `backend/public/shared/i18n.js`.
+3. A nearby `HELP-KEY` annotation at the render or binding site.
+
+Example:
+
+```html
+<!-- HELP-KEY: kanban_nudge_batch_help -->
+<label for="kanban_nudge_batch_size">
+  <span data-i18n="kanban_nudge_batch_label">Cards per cycle</span>
+  <span class="help-icon" data-help-content="{{ i18n.get('kanban_nudge_batch_help') }}"></span>
+</label>
+```
+
+The canonical locales for this PR are `en` and `zh-TW`. Fanout locales can land later, but the PR gate blocks if either canonical locale is missing the label or help key.
+
+For JS-rendered fields, keep the annotation next to the binding call:
+
+```js
+// HELP-KEY: kanban_nudge_batch_help
+HelpPopover.bindByKey(iconEl, 'kanban_nudge_batch_help');
+```
+
+When `backend/settings-help-keys.json` exists, regenerate it with:
+
+```bash
+node backend/scripts/generate-settings-help-keys.js
+```
+
+Then run the local gate before opening the PR:
+
+```bash
+node backend/scripts/check-settings-help-invariant.js --base origin/main --head HEAD
+```
+
+The gate prevents these regressions:
+
+- A settings field is added or modified without the matching `<field>_help`.
+- A `HELP-KEY` annotation points to a missing dictionary key.
+- A help key listed in `backend/settings-help-keys.json` has no code-side annotation.
+- A help key is removed while a `HELP-KEY` annotation still references it.


### PR DESCRIPTION
## Summary
- Add a `PR CI Hard Gate` workflow that runs on PRs and waits for the path-scoped CI checks required by the files changed.
- Document the PR-first contribution flow, local check commands, and the single branch-protection status to require.
- Align Entity Cards CI triggers with the hard gate so edits to `.github/workflows/entity-cards-ci.yml` start the checks the gate waits for.

## Validation
- Parsed `.github/workflows/pr-ci-hard-gate.yml`, `.github/workflows/entity-cards-ci.yml`, and `CONTRIBUTING.md` with Ruby YAML loading.
- Ran a targeted Node consistency check for hard-gate check names and Entity Cards workflow path triggers.
- Ran `git diff --check`.

## Notes
- `actionlint` was not available locally; npm package attempts for `actionlint` and `@rhysd/actionlint` did not provide a runnable linter, so validation is syntax plus targeted consistency checks.
