### PR TITLE
[test] settings help invariant synthetic failure

### DIFF
--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1098,6 +1098,10 @@
                            onchange="saveKanbanNudgePref('kanban_nudge_batch_size', Math.max(1, Math.min(20, parseInt(this.value)||1)))">
                 </div>
 
+                <div class="setting-row">
+                    <span class="setting-row-label" data-i18n="synthetic_settings_gate_label">Synthetic gate</span>
+                </div>
+
                 <div class="setting-row" style="flex-direction:column;align-items:stretch;">
                     <span class="setting-row-label" style="margin-bottom:8px;" data-i18n="kanban_nudge_priority_label">Priority mode</span>
                     <label style="display:flex;align-items:center;gap:8px;padding:4px 0;font-size:13px;cursor:pointer;">


### PR DESCRIPTION
Synthetic verification for card_31d01ae499369ddc68c6ccba. First commit intentionally adds a settings label without label/help/HELP-KEY trio so Settings Help Invariant CI should fail; follow-up commit will add the trio and should pass.