### PR TITLE
fix(portal): handle screen-control auth redirect and Petdx mobile overflow

### DIFF
--- a/backend/public/portal/petdx-preview.html
+++ b/backend/public/portal/petdx-preview.html
@@ -33,6 +33,7 @@
         grid-template-columns: minmax(280px, 360px) 1fr;
         gap: 24px;
     }
+    .stage > * { min-width: 0; }
     @media (max-width: 720px) {
         .stage { grid-template-columns: 1fr; }
     }
@@ -64,6 +65,7 @@
         border-radius: 6px;
         font: inherit;
         cursor: pointer;
+        max-width: 100%;
     }
     button:hover { border-color: var(--accent); }
     button.active { background: var(--accent); border-color: var(--accent); }
@@ -72,6 +74,7 @@
         border-radius: 8px;
         padding: 12px;
         overflow: auto;
+        max-width: 100%;
         max-height: 360px;
         font-size: 12px;
         margin: 0;

--- a/backend/public/portal/screen-control.html
+++ b/backend/public/portal/screen-control.html
@@ -312,6 +312,7 @@
             renderNav('mission');
             if (typeof renderFooter === 'function') renderFooter();
             currentUser = await checkAuth();
+            if (!currentUser) return;
             document.getElementById('loadingState').style.display = 'none';
             document.getElementById('pageContent').style.display = 'block';
             loadStatus();


### PR DESCRIPTION
## Summary
- stop screen-control initialization after unauthenticated `checkAuth()` returns null
- allow Petdx preview grid/content to shrink on mobile to avoid horizontal overflow

## Validation
- `npm run smoke:portal`
- Playwright local static sweep: 36 portal HTML pages × desktop/mobile = 72 checks, 0 failures

Fixes #3071.

Kanban: card_dbc72e5fe9d369eca1b5d3b1