### PR TITLE
[Cleanup] Remove weak 「實體一視同仁」section-desc from kanban-nudge settings

### DIFF
--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1089,8 +1089,6 @@
             </div>
 
             <div class="notif-content" id="kanbanNudgeContent">
-                <p class="section-desc" data-i18n="kanban_nudge_desc">Applies uniformly to all entities.</p>
-
                 <div class="setting-row">
                     <!-- HELP-KEY: kanban_nudge_batch_help -->
                     <span class="setting-row-label" data-i18n="kanban_nudge_batch_label">Cards per cycle</span>


### PR DESCRIPTION
## Summary
- Child 2 of card_af9e8feee8282c1b7407a367 (parent Settings help-icon initiative).
- Removes the `<p data-i18n=\"kanban_nudge_desc\">Applies uniformly to all entities.</p>` line above the kanban-nudge settings block. Hank flagged this as misleading — the device-wide vs per-entity scope actually varies per-field, so the blanket label was wrong.
- The new ? icon system shipped in PR #3068 (child 3) now provides per-field accurate scope via:
  - `kanban_nudge_batch_help` — explicitly device-wide L1 cap
  - `kanban_nudge_per_entity_section_help` — per-entity overrides
  - `kanban_nudge_advanced_help` — points to advanced override section

## Test plan
- [x] HELP-KEY annotations for all 7 kanban_nudge fields already present (verified via prior CI on PR #3068)
- [x] Settings Help Invariant CI should pass (only HTML structural cleanup; no _help keys touched)
- [x] PR CI Hard Gate should pass (path-scoped: only Critical portal pages + ESLint + Jest)
- [ ] Manual: open portal/settings.html → kanban-nudge section, confirm no stale paragraph above the rows + each field's ? icon still works

## Spec reference
docs/specs/settings-help-icon.md §1: "Settings pages today use inline labels and short hover hints. Weak inline copy (「實體一視同仁」) misleads users about scope."

🤖 Generated with [Claude Code](https://claude.com/claude-code)