### PR TITLE
fix(cron): anchor settings-help-invariant script path to __dirname (P1, false-positive card from 14:17 fire)

### DIFF
--- a/backend/settings-help-invariant-cron.js
+++ b/backend/settings-help-invariant-cron.js
@@ -127,8 +127,18 @@ function execFilePromise(execFileImpl, file, args, options) {
     });
 }
 
+// __dirname-anchored script path. The cron module lives at
+// backend/settings-help-invariant-cron.js, so the sibling scripts/ dir is
+// always at path.resolve(__dirname, 'scripts') regardless of cwd or deploy
+// layout. The earlier path.join(config.repoDir, 'backend', 'scripts', ...)
+// approach assumed cwd-derived repoDir mirrored the git tree, which Railway
+// flattens — first fire 2026-06-01 14:17 TW hit MODULE_NOT_FOUND on
+// '/backend/scripts/check-settings-help-invariant.js' because repoDir
+// resolved to '/' under Railway's flattened layout.
+const RESOLVED_SCRIPT_PATH = path.resolve(__dirname, 'scripts', 'check-settings-help-invariant.js');
+
 async function runInvariantCheck(config, execFileImpl = defaultExecFile) {
-    const scriptPath = path.join(config.repoDir, 'backend', 'scripts', 'check-settings-help-invariant.js');
+    const scriptPath = RESOLVED_SCRIPT_PATH;
     const options = {
         cwd: config.repoDir,
         timeout: config.timeoutMs,

--- a/backend/tests/jest/settings-help-invariant-cron.test.js
+++ b/backend/tests/jest/settings-help-invariant-cron.test.js
@@ -87,9 +87,15 @@ describe('settings-help invariant cron wrapper', () => {
 
         expect(result.ok).toBe(false);
         expect(result.card).toEqual(expect.objectContaining({ created: true, cardId: expect.stringMatching(/^card_/) }));
+        // scriptPath is anchored to the cron module's __dirname (always at
+        // backend/scripts/check-settings-help-invariant.js, regardless of cwd
+        // or repoDir env override). cwd still honors repoDir env so the
+        // invoked script's relative paths inherit it.
+        const path = require('path');
+        const expectedScript = path.resolve(__dirname, '..', '..', 'scripts', 'check-settings-help-invariant.js');
         expect(execFile).toHaveBeenCalledWith(
             process.execPath,
-            ['/repo/backend/scripts/check-settings-help-invariant.js', '--all'],
+            [expectedScript, '--all'],
             expect.objectContaining({ cwd: '/repo', timeout: 60000 }),
             expect.any(Function)
         );


### PR DESCRIPTION
## Summary
- Fixes P1 bug: 14:17 TW first fire of the settings-help-invariant cron (PR #3076, merged ~5 min ago) hit `MODULE_NOT_FOUND` on `/backend/scripts/check-settings-help-invariant.js` because the previous `path.join(config.repoDir, 'backend', 'scripts', ...)` approach assumed Railway's cwd mirrored the git repo layout. On Railway, the flattened deploy makes `repoDir` resolve to `/`, producing a non-existent path.
- Auto-card `card_4ba35abbf3520d12c281533c` was opened on the failing fire (P1 violation card titled "[Infra] Settings help invariant violations (en + zh)"). It's a false positive — I'll archive after this fix deploys + next fire (15:17 TW) confirms green.

## Fix
- `backend/settings-help-invariant-cron.js`: derive `scriptPath` from `path.resolve(__dirname, 'scripts', 'check-settings-help-invariant.js')` — the cron module always lives next to its `scripts/` sibling regardless of cwd. The `cwd` for the spawned process still honors `config.repoDir` (env-overridable), so the script's relative paths inherit it.
- `backend/tests/jest/settings-help-invariant-cron.test.js`: assertion updated to expect the `__dirname`-anchored scriptPath.

## Test plan
- [x] Local: `npx jest tests/jest/settings-help-invariant-cron.test.js` → 4/4 pass
- [x] Local: `node --check backend/settings-help-invariant-cron.js`
- [ ] CI: `PR CI Hard Gate` + Jest unit tests + ESLint pass
- [ ] Post-deploy: next 15:17 TW fire of the cron returns ok=true on a clean tree (no new violation card created)
- [ ] Cleanup: archive `card_4ba35abbf3520d12c281533c` (false-positive from path-bug fire)

🤖 Generated with [Claude Code](https://claude.com/claude-code)