### PR TITLE
fix(scripts): anchor check-settings-help-invariant paths off __dirname (Railway flattened layout)

### DIFF
--- a/backend/scripts/check-settings-help-invariant.js
+++ b/backend/scripts/check-settings-help-invariant.js
@@ -17,8 +17,16 @@ const path = require('path');
 const vm = require('vm');
 const { execFileSync } = require('child_process');
 
-const REPO_ROOT = path.resolve(__dirname, '..', '..');
-const BACKEND_DIR = path.join(REPO_ROOT, 'backend');
+// __dirname-anchored paths. BACKEND_DIR is always the parent of scripts/.
+// REPO_ROOT is one level above BACKEND_DIR — but on Railway the backend
+// directory is deployed at root (no <repo>/backend/ wrapper), so BACKEND_DIR
+// can equal '/' on Railway and REPO_ROOT computed via `..` would step outside
+// the deploy tree. The fix is to anchor BACKEND_DIR off __dirname and use it
+// directly for backend-internal lookups (i18n.js, settings-help-keys.json),
+// only falling through to REPO_ROOT for cross-package scans (e.g. ios-app/,
+// openclaw-channel-eclaw/) which are handled separately in walk()'s root list.
+const BACKEND_DIR = path.resolve(__dirname, '..');
+const REPO_ROOT = path.resolve(BACKEND_DIR, '..');
 const PUBLIC_DIR = path.join(BACKEND_DIR, 'public');
 const I18N_FILE = path.join(PUBLIC_DIR, 'shared', 'i18n.js');
 const REGISTRY_FILE = path.join(BACKEND_DIR, 'settings-help-keys.json');


### PR DESCRIPTION
## Summary
- Follow-up to PR #3077. The 15:17 TW second cron fire revealed a second path-bug: the cron successfully spawned the check script (script-path fix worked), but the SCRIPT ITSELF hit `ENOENT: /backend/public/shared/i18n.js` because its REPO_ROOT was computed as `path.resolve(__dirname, '..', '..')` which gives `/` on Railway's flattened layout (`__dirname = /scripts`), then `path.join(REPO_ROOT, 'backend')` produced a non-existent `/backend`.
- Auto-card opened: `card_dd0f10568429dcfb171b9c47` (will archive after this fix deploys + next fire goes green).

## Fix
- `BACKEND_DIR = path.resolve(__dirname, '..')` — always the parent of `scripts/`, regardless of cwd or Railway's flattened layout.
- `REPO_ROOT` derived from BACKEND_DIR for cross-package scans (ios-app/, openclaw-channel-eclaw/); walk() already handles missing dirs defensively via fs.existsSync.

## Test plan
- [x] Local: `node backend/scripts/check-settings-help-invariant.js --all` → OK with new path resolution
- [x] Local: Jest 4/4 (settings-help-invariant-cron.test.js)
- [ ] CI: PR CI Hard Gate + path-scoped checks
- [ ] Post-deploy: 16:17 TW fire returns ok=true on clean tree
- [ ] Cleanup: archive `card_dd0f10568429dcfb171b9c47` after green fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)