### PR TITLE
fix(scripts): collectHelpAnnotations uses BACKEND_DIR (3rd Railway-layout path fix)

### DIFF
--- a/backend/scripts/check-settings-help-invariant.js
+++ b/backend/scripts/check-settings-help-invariant.js
@@ -194,8 +194,13 @@ function walk(dir, out = []) {
 }
 
 function collectHelpAnnotations() {
+    // backend uses BACKEND_DIR directly — on Railway the backend tree is at
+    // root (no '/backend' wrapper) so deriving via REPO_ROOT misses files.
+    // Cross-package scans (app/src, ios-app, openclaw-channel-eclaw/src) are
+    // path.join'd off REPO_ROOT and skipped via fs.existsSync in walk() when
+    // those packages aren't deployed (e.g. Railway deploys only backend/).
     const roots = [
-        path.join(REPO_ROOT, 'backend'),
+        BACKEND_DIR,
         path.join(REPO_ROOT, 'app', 'src'),
         path.join(REPO_ROOT, 'ios-app'),
         path.join(REPO_ROOT, 'openclaw-channel-eclaw', 'src'),


### PR DESCRIPTION
## Summary
- 16:17 TW third cron fire: path-bug fix from PR #3078 worked for i18n.js + registry, but collectHelpAnnotations() still uses `path.join(REPO_ROOT, 'backend')` which evaluates to `/backend` on Railway (REPO_ROOT=`/`). On Railway backend is at root, not `/backend`, so annotation scan returned empty and ALL 10 registry keys reported as 'missing HELP-KEY annotation' (false positive).
- Auto-card opened on the 16:17 fire (will check + archive after this fix).

## Fix
- BACKEND_DIR used directly for backend scan in collectHelpAnnotations().
- Other roots (app/src, ios-app, openclaw-channel-eclaw/src) keep REPO_ROOT-joined paths; walk() defensively skips missing dirs via fs.existsSync.

## Test plan
- [x] Local: `node backend/scripts/check-settings-help-invariant.js --all` → 10 annotation keys (was 0 before)
- [x] Local: Jest unchanged (paths in test mock are absolute, not affected)
- [ ] CI: PR CI Hard Gate + Jest + Settings help invariant pass
- [ ] Post-deploy: 17:17 TW fire returns ok=true (real green this time)

🤖 Generated with [Claude Code](https://claude.com/claude-code)