### PR TITLE
feat(settings): add help icons for prompt policy fields

### DIFF
--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1240,7 +1240,9 @@
                         <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;padding:6px 8px;border:1px solid rgba(251,191,36,0.35);border-radius:8px;background:rgba(251,191,36,0.08);">
                             <input type="checkbox" id="kanbanNudgeEntStopMode"
                                    onchange="onKanbanNudgeEntityOverrideToggle('kanban_nudge_stop_mode', this.checked)">
+                            <!-- HELP-KEY: kanban_nudge_per_entity_stop_mode_help -->
                             <span data-i18n="kanban_nudge_per_entity_stop_mode">Stop-mode: pause stale-card reminders for this entity</span>
+                            <span class="help-icon" data-help-content-key="kanban_nudge_per_entity_stop_mode_help"></span>
                         </label>
 
                         <!-- Override row: interval -->
@@ -1248,7 +1250,9 @@
                             <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;">
                                 <input type="checkbox" id="kanbanNudgeEntOverrideInterval"
                                        onchange="onKanbanNudgeEntityOverrideToggle('kanban_nudge_interval_minutes', this.checked)">
+                                <!-- HELP-KEY: kanban_nudge_per_entity_override_interval_help -->
                                 <span data-i18n="kanban_nudge_per_entity_override_interval">Override interval</span>
+                                <span class="help-icon" data-help-content-key="kanban_nudge_per_entity_override_interval_help"></span>
                             </label>
                             <span style="display:flex;align-items:center;gap:4px;padding-left:24px;">
                                 <input type="number" id="kanbanNudgeEntIntervalHours" min="0" max="24" step="1" disabled
@@ -1267,7 +1271,9 @@
                             <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;">
                                 <input type="checkbox" id="kanbanNudgeEntOverrideStatuses"
                                        onchange="onKanbanNudgeEntityOverrideToggle('kanban_nudge_statuses', this.checked)">
+                                <!-- HELP-KEY: kanban_nudge_per_entity_override_statuses_help -->
                                 <span data-i18n="kanban_nudge_per_entity_override_statuses">Override columns</span>
+                                <span class="help-icon" data-help-content-key="kanban_nudge_per_entity_override_statuses_help"></span>
                             </label>
                             <div id="kanbanNudgeEntStatusChips" style="display:flex;flex-wrap:wrap;gap:8px;padding-left:24px;opacity:0.5;">
                                 <label class="nudge-status-chip"><input type="checkbox" value="backlog" data-ent-status onchange="saveKanbanNudgeEntityStatuses()"><span data-i18n="kanban_status_backlog">Backlog</span></label>
@@ -1283,12 +1289,16 @@
                             <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;">
                                 <input type="checkbox" id="kanbanNudgeEntOverrideThrottle"
                                        onchange="onKanbanNudgeEntityOverrideToggle('kanban_nudge_per_entity_throttle', this.checked)">
+                                <!-- HELP-KEY: kanban_nudge_per_entity_override_throttle_help -->
                                 <span data-i18n="kanban_nudge_per_entity_override_throttle">Override throttle</span>
+                                <span class="help-icon" data-help-content-key="kanban_nudge_per_entity_override_throttle_help"></span>
                             </label>
                             <label style="display:flex;align-items:center;gap:8px;font-size:13px;padding-left:24px;cursor:pointer;">
                                 <input type="checkbox" id="kanbanNudgeEntThrottleVal" disabled
                                        onchange="saveKanbanNudgeEntityThrottle()">
+                                <!-- HELP-KEY: kanban_nudge_per_entity_throttle_short_help -->
                                 <span data-i18n="kanban_nudge_per_entity_throttle_short">Cap this entity at 1 nudge per interval</span>
+                                <span class="help-icon" data-help-content-key="kanban_nudge_per_entity_throttle_short_help"></span>
                             </label>
                         </div>
                     </div>
@@ -1430,15 +1440,21 @@
             <form id="switchDeviceForm" style="display:flex;flex-direction:column;gap:10px;margin:14px 0;"
                 onsubmit="performSwitchDevice();return false;">
                 <div>
-                    <label for="switchDeviceIdInput" style="display:block;font-size:12px;color:var(--text-muted);margin-bottom:4px;"
-                        data-i18n="settings_device_id">Device ID</label>
+                    <!-- HELP-KEY: settings_device_id_help -->
+                    <label for="switchDeviceIdInput" style="display:block;font-size:12px;color:var(--text-muted);margin-bottom:4px;">
+                        <span data-i18n="settings_device_id">Device ID</span>
+                        <span class="help-icon" data-help-content-key="settings_device_id_help"></span>
+                    </label>
                     <input id="switchDeviceIdInput" type="text" autocomplete="off" spellcheck="false"
                         style="width:100%;padding:8px 10px;border:1px solid var(--card-border);border-radius:6px;font-family:monospace;font-size:13px;background:var(--bg-secondary);color:var(--text-primary);box-sizing:border-box;"
                         placeholder="e.g. 480def4c-2183-4d8e-..." />
                 </div>
                 <div>
-                    <label for="switchDeviceSecretInput" style="display:block;font-size:12px;color:var(--text-muted);margin-bottom:4px;"
-                        data-i18n="settings_device_secret">Device Secret</label>
+                    <!-- HELP-KEY: settings_device_secret_help -->
+                    <label for="switchDeviceSecretInput" style="display:block;font-size:12px;color:var(--text-muted);margin-bottom:4px;">
+                        <span data-i18n="settings_device_secret">Device Secret</span>
+                        <span class="help-icon" data-help-content-key="settings_device_secret_help"></span>
+                    </label>
                     <input id="switchDeviceSecretInput" type="password" autocomplete="off" spellcheck="false"
                         style="width:100%;padding:8px 10px;border:1px solid var(--card-border);border-radius:6px;font-family:monospace;font-size:13px;background:var(--bg-secondary);color:var(--text-primary);box-sizing:border-box;" />
                 </div>

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1001,56 +1001,88 @@
                     <div class="policy-grid">
                         <div class="policy-inline-grid" data-testid="prompt-policy-scope-controls">
                             <label class="policy-field">
-                                <span class="setting-row-label">Policy scope</span>
+                                <!-- HELP-KEY: prompt_policy_scope_help -->
+                                <span class="setting-row-label">
+                                    <span data-i18n="prompt_policy_scope_label">Policy scope</span>
+                                    <span class="help-icon" data-help-content-key="prompt_policy_scope_help"></span>
+                                </span>
                                 <select id="promptPolicyScope" class="policy-select" onchange="onPromptPolicyScopeChange()">
                                     <option value="device">Device default</option>
                                     <option value="entity">Entity override</option>
                                 </select>
                             </label>
                             <label class="policy-field" id="promptPolicyEntityField" style="display:none;">
-                                <span class="setting-row-label">Entity #</span>
+                                <!-- HELP-KEY: prompt_policy_entity_help -->
+                                <span class="setting-row-label">
+                                    <span data-i18n="prompt_policy_entity_label">Entity #</span>
+                                    <span class="help-icon" data-help-content-key="prompt_policy_entity_help"></span>
+                                </span>
                                 <input type="number" id="promptPolicyEntityId" min="0" step="1" value="0" class="policy-input" onchange="onPromptPolicyEntityChange()">
                             </label>
                         </div>
 
                         <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;">
                             <input type="checkbox" id="promptPolicyEnabled">
-                            <span id="promptPolicyEnabledLabel">Enable device prompt policy</span>
+                            <!-- HELP-KEY: prompt_policy_enabled_help -->
+                            <span id="promptPolicyEnabledLabel" data-i18n="prompt_policy_enabled_label">Enable device prompt policy</span>
+                            <span class="help-icon" data-help-content-key="prompt_policy_enabled_help"></span>
                         </label>
 
                         <label style="display:block;">
-                            <span class="setting-row-label">Device instructions</span>
+                            <!-- HELP-KEY: prompt_policy_instructions_help -->
+                            <span class="setting-row-label">
+                                <span data-i18n="prompt_policy_instructions_label">Device instructions</span>
+                                <span class="help-icon" data-help-content-key="prompt_policy_instructions_help"></span>
+                            </span>
                             <textarea id="promptPolicyInstructions" class="policy-textarea" placeholder="One instruction per line"></textarea>
                         </label>
 
                         <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:10px;">
                             <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;">
                                 <input type="checkbox" id="promptPolicyRequirePlan">
-                                <span>Require test plan</span>
+                                <!-- HELP-KEY: prompt_policy_require_plan_help -->
+                                <span data-i18n="prompt_policy_require_plan_label">Require test plan</span>
+                                <span class="help-icon" data-help-content-key="prompt_policy_require_plan_help"></span>
                             </label>
                             <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;">
                                 <input type="checkbox" id="promptPolicyRequireMilestones">
-                                <span>Require milestone updates</span>
+                                <!-- HELP-KEY: prompt_policy_require_milestones_help -->
+                                <span data-i18n="prompt_policy_require_milestones_label">Require milestone updates</span>
+                                <span class="help-icon" data-help-content-key="prompt_policy_require_milestones_help"></span>
                             </label>
                             <label style="display:flex;align-items:center;gap:8px;font-size:13px;">
-                                <span>Heartbeat min</span>
+                                <!-- HELP-KEY: prompt_policy_heartbeat_help -->
+                                <span data-i18n="prompt_policy_heartbeat_label">Heartbeat min</span>
+                                <span class="help-icon" data-help-content-key="prompt_policy_heartbeat_help"></span>
                                 <input type="number" id="promptPolicyHeartbeatMinutes" min="1" max="30" step="1"
                                        style="width:70px;padding:6px 8px;border:1px solid var(--card-border);border-radius:6px;background:var(--bg);color:var(--text);text-align:right;">
                             </label>
                         </div>
 
                         <label style="display:block;">
-                            <span class="setting-row-label">Codex override</span>
+                            <!-- HELP-KEY: prompt_policy_codex_override_help -->
+                            <span class="setting-row-label">
+                                <span data-i18n="prompt_policy_codex_override_label">Codex override</span>
+                                <span class="help-icon" data-help-content-key="prompt_policy_codex_override_help"></span>
+                            </span>
                             <textarea id="promptPolicyCodexOverride" class="policy-textarea" placeholder="Codex-only instructions"></textarea>
                         </label>
 
                         <label style="display:block;">
-                            <span class="setting-row-label">Claude Code override</span>
+                            <!-- HELP-KEY: prompt_policy_claude_override_help -->
+                            <span class="setting-row-label">
+                                <span data-i18n="prompt_policy_claude_override_label">Claude Code override</span>
+                                <span class="help-icon" data-help-content-key="prompt_policy_claude_override_help"></span>
+                            </span>
                             <textarea id="promptPolicyClaudeOverride" class="policy-textarea" placeholder="Claude Code-only instructions"></textarea>
                         </label>
 
                         <label style="display:block;">
-                            <span class="setting-row-label">Hermes override</span>
+                            <!-- HELP-KEY: prompt_policy_hermes_override_help -->
+                            <span class="setting-row-label">
+                                <span data-i18n="prompt_policy_hermes_override_label">Hermes override</span>
+                                <span class="help-icon" data-help-content-key="prompt_policy_hermes_override_help"></span>
+                            </span>
                             <textarea id="promptPolicyHermesOverride" class="policy-textarea" placeholder="Hermes-only instructions"></textarea>
                         </label>
 

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -624131,6 +624131,26 @@ const TRANSLATIONS = {
 
 
         "settings_save_policy": "Save Device Policy",
+        "prompt_policy_scope_label": "Policy scope",
+        "prompt_policy_scope_help": "Choose whether the prompt policy applies device-wide by default or overrides a single entity. Entity override only affects the selected entity.",
+        "prompt_policy_entity_label": "Entity #",
+        "prompt_policy_entity_help": "Entity number receiving this override. Use this only when policy scope is Entity override.",
+        "prompt_policy_enabled_label": "Enable device prompt policy",
+        "prompt_policy_enabled_help": "When enabled, channel bridges inject the saved policy into agent system prompts for this device or entity.",
+        "prompt_policy_instructions_label": "Device instructions",
+        "prompt_policy_instructions_help": "One instruction per line. Keep rules global, stable, and safe for every agent on this device.",
+        "prompt_policy_require_plan_label": "Require test plan",
+        "prompt_policy_require_plan_help": "Ask agents to include an explicit test plan before coding or deployment work when this policy applies.",
+        "prompt_policy_require_milestones_label": "Require milestone updates",
+        "prompt_policy_require_milestones_help": "Ask agents to report progress milestones during longer tasks so the operator can track status.",
+        "prompt_policy_heartbeat_label": "Heartbeat min",
+        "prompt_policy_heartbeat_help": "Minimum minutes between proactive heartbeat messages for agents using this policy.",
+        "prompt_policy_codex_override_label": "Codex override",
+        "prompt_policy_codex_override_help": "Extra instructions appended only for Codex sessions. Leave blank unless Codex needs different behavior.",
+        "prompt_policy_claude_override_label": "Claude Code override",
+        "prompt_policy_claude_override_help": "Extra instructions appended only for Claude Code sessions. Leave blank unless Claude Code needs different behavior.",
+        "prompt_policy_hermes_override_label": "Hermes override",
+        "prompt_policy_hermes_override_help": "Extra instructions appended only for Hermes sessions. Leave blank unless Hermes needs different behavior.",
 
 
 
@@ -1052169,6 +1052189,26 @@ const TRANSLATIONS = {
 
 
         "settings_save_policy": "儲存裝置策略",
+        "prompt_policy_scope_label": "策略範圍",
+        "prompt_policy_scope_help": "選擇提示詞策略要套用到整台裝置預設值，或只覆寫單一實體。實體覆寫只影響選定的實體。",
+        "prompt_policy_entity_label": "實體 #",
+        "prompt_policy_entity_help": "要套用這個覆寫的實體編號。只有策略範圍選擇「實體覆寫」時才需要填寫。",
+        "prompt_policy_enabled_label": "啟用裝置提示詞策略",
+        "prompt_policy_enabled_help": "啟用後，通道橋接會把儲存的策略注入此裝置或實體的代理系統提示詞。",
+        "prompt_policy_instructions_label": "裝置指示",
+        "prompt_policy_instructions_help": "每行一條指示。請保持規則全域、穩定，且對此裝置上的所有代理都安全。",
+        "prompt_policy_require_plan_label": "要求測試計畫",
+        "prompt_policy_require_plan_help": "要求代理在程式或部署工作前先列出明確測試計畫。",
+        "prompt_policy_require_milestones_label": "要求里程碑更新",
+        "prompt_policy_require_milestones_help": "要求代理在較長任務中回報進度里程碑，方便操作者追蹤狀態。",
+        "prompt_policy_heartbeat_label": "心跳最小分鐘",
+        "prompt_policy_heartbeat_help": "使用此策略的代理主動心跳訊息之間，至少要間隔的分鐘數。",
+        "prompt_policy_codex_override_label": "Codex 覆寫",
+        "prompt_policy_codex_override_help": "只追加到 Codex 工作階段的額外指示。除非 Codex 需要不同規則，否則留空。",
+        "prompt_policy_claude_override_label": "Claude Code 覆寫",
+        "prompt_policy_claude_override_help": "只追加到 Claude Code 工作階段的額外指示。除非 Claude Code 需要不同規則，否則留空。",
+        "prompt_policy_hermes_override_label": "Hermes 覆寫",
+        "prompt_policy_hermes_override_help": "只追加到 Hermes 工作階段的額外指示。除非 Hermes 需要不同規則，否則留空。",
 
 
 

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -255221,6 +255221,7 @@ const TRANSLATIONS = {
 
 
         "settings_device_id": "Device ID",
+        "settings_device_id_help": "The unique identifier for the device/account you want this browser to use. Pair it with the matching Device Secret.",
 
 
 
@@ -255349,6 +255350,7 @@ const TRANSLATIONS = {
 
 
         "settings_device_secret": "Device Secret",
+        "settings_device_secret_help": "The private secret for the selected Device ID. Treat it like a password and only enter it for devices you control.",
 
 
 
@@ -269483,10 +269485,15 @@ const TRANSLATIONS = {
         "kanban_nudge_per_entity_clear": "Reset to device default",
         "kanban_nudge_per_entity_hint_prefix": "Toggle a field to override the device default for this entity.",
         "kanban_nudge_per_entity_override_interval": "Override interval",
+        "kanban_nudge_per_entity_override_interval_help": "Enable this to set a custom reminder interval for the selected entity instead of using the device default.",
         "kanban_nudge_per_entity_override_statuses": "Override columns",
+        "kanban_nudge_per_entity_override_statuses_help": "Enable this to choose which kanban columns trigger reminders for the selected entity.",
         "kanban_nudge_per_entity_override_throttle": "Override throttle",
+        "kanban_nudge_per_entity_override_throttle_help": "Enable this to override whether this entity is capped at one reminder per interval.",
         "kanban_nudge_per_entity_throttle_short": "Cap this entity at 1 nudge per interval",
+        "kanban_nudge_per_entity_throttle_short_help": "When checked, this entity receives at most one stale-card reminder during its effective interval, even if multiple cards qualify.",
         "kanban_nudge_per_entity_stop_mode": "Stop-mode: pause stale-card reminders for this entity",
+        "kanban_nudge_per_entity_stop_mode_help": "Temporarily pauses stale-card reminders for this entity without changing device-wide nudge settings.",
         "kanban_nudge_stop_mode_avatar_title": "Nudge stop-mode enabled",
 
 
@@ -893889,6 +893896,7 @@ const TRANSLATIONS = {
 
 
         "settings_device_id": "Device ID",
+        "settings_device_id_help": "要讓此瀏覽器使用的裝置/帳號唯一識別碼。需要搭配相符的 Device Secret。",
 
 
 
@@ -894017,6 +894025,7 @@ const TRANSLATIONS = {
 
 
         "settings_device_secret": "Device Secret",
+        "settings_device_secret_help": "選定 Device ID 的私密金鑰。請像密碼一樣保護，只在你控制的裝置上輸入。",
 
 
 
@@ -906359,10 +906368,15 @@ const TRANSLATIONS = {
         "kanban_nudge_per_entity_clear": "重設為裝置預設值",
         "kanban_nudge_per_entity_hint_prefix": "切換欄位即可為此實體覆寫裝置預設值。",
         "kanban_nudge_per_entity_override_interval": "覆寫間隔",
+        "kanban_nudge_per_entity_override_interval_help": "啟用後，可為選定實體設定自訂提醒間隔，而不是使用裝置預設值。",
         "kanban_nudge_per_entity_override_statuses": "覆寫欄位",
+        "kanban_nudge_per_entity_override_statuses_help": "啟用後，可選擇哪些看板欄位會對選定實體觸發提醒。",
         "kanban_nudge_per_entity_override_throttle": "覆寫節流",
+        "kanban_nudge_per_entity_override_throttle_help": "啟用後，可覆寫此實體是否限制為每個間隔最多一次提醒。",
         "kanban_nudge_per_entity_throttle_short": "限制此實體每個間隔最多 1 次提醒",
+        "kanban_nudge_per_entity_throttle_short_help": "勾選後，即使多張卡符合條件，此實體在有效間隔內最多只會收到一次停滯卡提醒。",
         "kanban_nudge_per_entity_stop_mode": "Stop-mode：暫停此實體的內容督促提醒",
+        "kanban_nudge_per_entity_stop_mode_help": "暫時停止此實體的停滯卡提醒，不改變整台裝置的督促設定。",
         "kanban_nudge_stop_mode_avatar_title": "已啟用督促 stop-mode",
 
 

--- a/backend/scripts/generate-settings-help-keys.js
+++ b/backend/scripts/generate-settings-help-keys.js
@@ -29,24 +29,45 @@ function extractLabelKeys(htmlPath) {
   if (!fs.existsSync(full)) return [];
   const html = fs.readFileSync(full, 'utf8');
   const matches = [...html.matchAll(/data-i18n="([^"]+)_label"/g)];
-  return matches.map((m) => m[1]);
+  return matches.map((m) => ({
+    field_key: m[1],
+    label_key: `${m[1]}_label`,
+    help_key: `${m[1]}_help`,
+  }));
 }
 
-const all = new Set();
+function extractHelpIconEntries(htmlPath) {
+  const full = path.join(ROOT, htmlPath);
+  if (!fs.existsSync(full)) return [];
+  const html = fs.readFileSync(full, 'utf8');
+  const matches = [...html.matchAll(/data-help-content-key="([^"]+_help)"/g)];
+  return matches.map((m) => {
+    const helpKey = m[1];
+    const nearby = html.slice(Math.max(0, m.index - 800), m.index);
+    const labelMatches = [...nearby.matchAll(/data-i18n="([^"]+)"/g)];
+    const labelKey = labelMatches.length ? labelMatches[labelMatches.length - 1][1] : helpKey.replace(/_help$/, '_label');
+    return {
+      field_key: helpKey.replace(/_help$/, ''),
+      label_key: labelKey,
+      help_key: helpKey,
+    };
+  });
+}
+
+const all = new Map();
 for (const page of SETTINGS_PAGES) {
-  for (const baseKey of extractLabelKeys(page)) {
-    all.add(baseKey);
+  for (const entry of extractLabelKeys(page)) {
+    all.set(entry.help_key, entry);
+  }
+  for (const entry of extractHelpIconEntries(page)) {
+    all.set(entry.help_key, entry);
   }
 }
 
 const registry = {
   generated_at: 'GENERATED — do not hand-edit',
   source: SETTINGS_PAGES,
-  keys: [...all].sort().map((k) => ({
-    field_key: k,
-    label_key: `${k}_label`,
-    help_key: `${k}_help`,
-  })),
+  keys: [...all.values()].sort((a, b) => a.help_key.localeCompare(b.help_key)),
 };
 
 const outPath = path.join(__dirname, '..', 'settings-help-keys.json');

--- a/backend/settings-help-keys.json
+++ b/backend/settings-help-keys.json
@@ -53,6 +53,56 @@
       "field_key": "kanban_nudge_statuses",
       "label_key": "kanban_nudge_statuses_label",
       "help_key": "kanban_nudge_statuses_help"
+    },
+    {
+      "field_key": "prompt_policy_claude_override",
+      "label_key": "prompt_policy_claude_override_label",
+      "help_key": "prompt_policy_claude_override_help"
+    },
+    {
+      "field_key": "prompt_policy_codex_override",
+      "label_key": "prompt_policy_codex_override_label",
+      "help_key": "prompt_policy_codex_override_help"
+    },
+    {
+      "field_key": "prompt_policy_enabled",
+      "label_key": "prompt_policy_enabled_label",
+      "help_key": "prompt_policy_enabled_help"
+    },
+    {
+      "field_key": "prompt_policy_entity",
+      "label_key": "prompt_policy_entity_label",
+      "help_key": "prompt_policy_entity_help"
+    },
+    {
+      "field_key": "prompt_policy_heartbeat",
+      "label_key": "prompt_policy_heartbeat_label",
+      "help_key": "prompt_policy_heartbeat_help"
+    },
+    {
+      "field_key": "prompt_policy_hermes_override",
+      "label_key": "prompt_policy_hermes_override_label",
+      "help_key": "prompt_policy_hermes_override_help"
+    },
+    {
+      "field_key": "prompt_policy_instructions",
+      "label_key": "prompt_policy_instructions_label",
+      "help_key": "prompt_policy_instructions_help"
+    },
+    {
+      "field_key": "prompt_policy_require_milestones",
+      "label_key": "prompt_policy_require_milestones_label",
+      "help_key": "prompt_policy_require_milestones_help"
+    },
+    {
+      "field_key": "prompt_policy_require_plan",
+      "label_key": "prompt_policy_require_plan_label",
+      "help_key": "prompt_policy_require_plan_help"
+    },
+    {
+      "field_key": "prompt_policy_scope",
+      "label_key": "prompt_policy_scope_label",
+      "help_key": "prompt_policy_scope_help"
     }
   ]
 }

--- a/backend/settings-help-keys.json
+++ b/backend/settings-help-keys.json
@@ -35,14 +35,39 @@
       "help_key": "kanban_nudge_interval_help"
     },
     {
+      "field_key": "kanban_nudge_per_entity_override_interval",
+      "label_key": "kanban_nudge_per_entity_override_interval",
+      "help_key": "kanban_nudge_per_entity_override_interval_help"
+    },
+    {
+      "field_key": "kanban_nudge_per_entity_override_statuses",
+      "label_key": "kanban_nudge_per_entity_override_statuses",
+      "help_key": "kanban_nudge_per_entity_override_statuses_help"
+    },
+    {
+      "field_key": "kanban_nudge_per_entity_override_throttle",
+      "label_key": "kanban_nudge_per_entity_override_throttle",
+      "help_key": "kanban_nudge_per_entity_override_throttle_help"
+    },
+    {
       "field_key": "kanban_nudge_per_entity_section",
       "label_key": "kanban_nudge_per_entity_section_label",
       "help_key": "kanban_nudge_per_entity_section_help"
     },
     {
+      "field_key": "kanban_nudge_per_entity_stop_mode",
+      "label_key": "kanban_nudge_per_entity_stop_mode",
+      "help_key": "kanban_nudge_per_entity_stop_mode_help"
+    },
+    {
       "field_key": "kanban_nudge_per_entity_throttle",
       "label_key": "kanban_nudge_per_entity_throttle_label",
       "help_key": "kanban_nudge_per_entity_throttle_help"
+    },
+    {
+      "field_key": "kanban_nudge_per_entity_throttle_short",
+      "label_key": "kanban_nudge_per_entity_throttle_short",
+      "help_key": "kanban_nudge_per_entity_throttle_short_help"
     },
     {
       "field_key": "kanban_nudge_priority",
@@ -103,6 +128,16 @@
       "field_key": "prompt_policy_scope",
       "label_key": "prompt_policy_scope_label",
       "help_key": "prompt_policy_scope_help"
+    },
+    {
+      "field_key": "settings_device_id",
+      "label_key": "settings_device_id",
+      "help_key": "settings_device_id_help"
+    },
+    {
+      "field_key": "settings_device_secret",
+      "label_key": "settings_device_secret",
+      "help_key": "settings_device_secret_help"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Expand settings-help registry coverage for user-facing settings fields in settings.html.
- Add click help icons and HELP-KEY annotations for Agent Policy controls, per-entity nudge override controls, and Switch Device credential fields.
- Add canonical en + zh label/help copy where required.
- Update backend/scripts/generate-settings-help-keys.js so the registry can include help-icon entries whose existing label key does not end in _label.
- Regenerate backend/settings-help-keys.json; registry now covers 27 settings help keys.

## Validation
- node backend/scripts/check-settings-help-invariant.js --all
- node backend/scripts/i18n-check.js
- Structural smoke: verified all 27 registry help keys have both HELP-KEY annotations and data-help-content-key bindings.
- Remaining label nodes without help are excluded radio/status chips or empty labels from the current scan.

Kanban: card_3a14e3589ceb2cba00c09f08 registry expansion.