### PR TITLE
fix(settings): remove blocked checkbox from kanban_nudge_statuses + dedup save

### DIFF
--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1127,12 +1127,20 @@
                         <span class="help-icon" data-help-content-key="kanban_nudge_statuses_help"></span>
                     </span>
                     <!-- Match this row to NUDGEABLE_STATUSES in shared/kanban-status.js. 'done' is intentionally excluded. -->
+                    <!--
+                        'blocked' is intentionally omitted from these checkboxes.
+                        Blocked cards wait on external dependencies (other entities, manual
+                        review, screenshot-gate, etc.), so periodic nudges add noise without
+                        helping unblock. backend/kanban.js SQL pre-filter also hard-excludes
+                        'blocked' from the stale-card candidate query (line 2700) — offering
+                        the checkbox here was misleading (toggling it had no effect).
+                        Per Hank 2026-06-01 16:57 TW directive.
+                    -->
                     <div style="display:flex;flex-wrap:wrap;gap:8px;">
                         <label class="nudge-status-chip"><input type="checkbox" value="backlog" onchange="saveKanbanNudgeStatuses()"><span data-i18n="kanban_status_backlog">Backlog</span></label>
                         <label class="nudge-status-chip"><input type="checkbox" value="todo" onchange="saveKanbanNudgeStatuses()"><span data-i18n="kanban_status_todo">Todo</span></label>
                         <label class="nudge-status-chip"><input type="checkbox" value="in_progress" onchange="saveKanbanNudgeStatuses()"><span data-i18n="kanban_status_in_progress">In Progress</span></label>
                         <label class="nudge-status-chip"><input type="checkbox" value="review" onchange="saveKanbanNudgeStatuses()"><span data-i18n="kanban_status_review">Review</span></label>
-                        <label class="nudge-status-chip"><input type="checkbox" value="blocked" onchange="saveKanbanNudgeStatuses()"><span data-i18n="kanban_status_blocked">Blocked</span></label>
                     </div>
                 </div>
 
@@ -1237,12 +1245,12 @@
                                        onchange="onKanbanNudgeEntityOverrideToggle('kanban_nudge_statuses', this.checked)">
                                 <span data-i18n="kanban_nudge_per_entity_override_statuses">Override columns</span>
                             </label>
+                            <!-- 'blocked' omitted; see device-wide chip block above. -->
                             <div id="kanbanNudgeEntStatusChips" style="display:flex;flex-wrap:wrap;gap:8px;padding-left:24px;opacity:0.5;">
                                 <label class="nudge-status-chip"><input type="checkbox" value="backlog" data-ent-status onchange="saveKanbanNudgeEntityStatuses()"><span data-i18n="kanban_status_backlog">Backlog</span></label>
                                 <label class="nudge-status-chip"><input type="checkbox" value="todo" data-ent-status onchange="saveKanbanNudgeEntityStatuses()"><span data-i18n="kanban_status_todo">Todo</span></label>
                                 <label class="nudge-status-chip"><input type="checkbox" value="in_progress" data-ent-status onchange="saveKanbanNudgeEntityStatuses()"><span data-i18n="kanban_status_in_progress">In Progress</span></label>
                                 <label class="nudge-status-chip"><input type="checkbox" value="review" data-ent-status onchange="saveKanbanNudgeEntityStatuses()"><span data-i18n="kanban_status_review">Review</span></label>
-                                <label class="nudge-status-chip"><input type="checkbox" value="blocked" data-ent-status onchange="saveKanbanNudgeEntityStatuses()"><span data-i18n="kanban_status_blocked">Blocked</span></label>
                             </div>
                         </div>
 
@@ -2837,7 +2845,15 @@
         }
 
         async function saveKanbanNudgeStatuses() {
-            const checked = Array.from(document.querySelectorAll('.nudge-status-chip input[type="checkbox"]:checked')).map(cb => cb.value);
+            // The selector previously matched ANY '.nudge-status-chip input' on the page,
+            // which included the per-entity override chips marked with [data-ent-status].
+            // When both panels had values selected, the array contained duplicates
+            // (one entry per chip group). Filter to device-wide chips only and dedup
+            // defensively in case future markup adds another chip source.
+            const raw = Array.from(document.querySelectorAll('.nudge-status-chip input[type="checkbox"]:checked'))
+                .filter(cb => !cb.hasAttribute('data-ent-status'))
+                .map(cb => cb.value);
+            const checked = Array.from(new Set(raw));
             // Guard: require at least one status (otherwise nudges would never fire).
             if (checked.length === 0) {
                 showToast(i18n.t('kanban_nudge_need_status') || 'Select at least one column', 'error');
@@ -3023,7 +3039,8 @@
         }
 
         async function saveKanbanNudgeEntityStatuses() {
-            const checked = Array.from(document.querySelectorAll('input[data-ent-status]:checked')).map(cb => cb.value);
+            const raw = Array.from(document.querySelectorAll('input[data-ent-status]:checked')).map(cb => cb.value);
+            const checked = Array.from(new Set(raw));  // defensive dedup
             if (checked.length === 0) {
                 showToast(i18n.t('kanban_nudge_need_status') || 'Select at least one column', 'error');
                 renderKanbanNudgeEntityPanel();


### PR DESCRIPTION
## Summary
Per Hank 2026-06-01 16:57 TW directive: 「blocked 卡通常等別人解，督促沒幫助 → 那督促設定就該移除這個勾選項目」.

backend/kanban.js stale-card SQL (line 2700) already hard-excludes 'blocked' from the candidate query, so the "Blocked" checkbox in the UI was inert — toggling it had no effect. Removing the chip aligns UI with backend behavior.

Bonus: fix latent dedup bug in `saveKanbanNudgeStatuses` — the selector matched BOTH device-wide chips and per-entity override chips (same class). Observed in Hank's actual prefs: `['backlog','todo','in_progress','review','blocked','backlog','todo','in_progress','review']` (9 entries / 5 unique).

## Changes
- Remove device-wide "Blocked" chip from kanban_nudge_statuses group
- Remove per-entity "Blocked" chip from override panel  
- `saveKanbanNudgeStatuses`: filter out [data-ent-status] + dedup via Set
- `saveKanbanNudgeEntityStatuses`: dedup defensively via Set
- Add explanatory HTML comments at both chip groups documenting the omission

## Test plan
- [ ] Open portal/settings.html, verify "Blocked" chip absent in both chip groups
- [ ] Toggle chips with per-entity panel open simultaneously, verify saved value has no duplicates
- [ ] CI: PR CI Hard Gate + path-scoped checks

## Note re: PR #3080
PR #3080 (child 9 expansion) also touches settings.html but at different lines. Whichever merges first triggers a small rebase for the other. No semantic overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)