### PR TITLE
[codex] warn on settings help fanout gaps

### DIFF
--- a/backend/scripts/i18n-check.js
+++ b/backend/scripts/i18n-check.js
@@ -4,7 +4,9 @@
  * `data-i18n` (or its -title / -placeholder variants) in HTML, or via
  * `i18n.t('...')` in JS, is missing from the English locale in
  * `backend/public/shared/i18n.js`. Also reports per-locale coverage so
- * translators can see where gaps are.
+ * translators can see where gaps are. The settings-help registry is also
+ * checked as a soft fanout warning so the i18n patrol can file follow-up work
+ * without turning locale backlog into a hard CI block.
  *
  * Run locally: `node backend/scripts/i18n-check.js`
  * Exit codes:
@@ -22,7 +24,11 @@ const REPO_ROOT = path.resolve(__dirname, '..', '..');
 const BACKEND_DIR = path.join(REPO_ROOT, 'backend');
 const PUBLIC_DIR = path.join(BACKEND_DIR, 'public');
 const I18N_FILE = path.join(PUBLIC_DIR, 'shared', 'i18n.js');
+const SETTINGS_HELP_REGISTRY_FILE = path.join(BACKEND_DIR, 'settings-help-keys.json');
 const COVERAGE_WARN_THRESHOLD = 0.8;
+const SETTINGS_HELP_CANONICAL_LOCALES = new Set(['en', 'zh']);
+const SETTINGS_HELP_STUB_LOCALES = new Set(['zh-TW']);
+const COVERAGE_STUB_LOCALES = new Set(['zh-TW']);
 
 function walk(dir, exts) {
     const out = [];
@@ -136,6 +142,67 @@ function loadOrphanBaseline() {
     }
 }
 
+function loadSettingsHelpRegistry(filePath = SETTINGS_HELP_REGISTRY_FILE) {
+    try {
+        const raw = JSON.parse(fs.readFileSync(filePath, 'utf8'));
+        return Array.isArray(raw.keys)
+            ? raw.keys
+                .map(entry => ({
+                    labelKey: entry.label_key,
+                    helpKey: entry.help_key,
+                }))
+                .filter(entry => entry.labelKey && entry.helpKey)
+            : [];
+    } catch {
+        return [];
+    }
+}
+
+function realLocaleNames(translations) {
+    return Object.keys(translations || {})
+        .filter(locale => translations[locale] && typeof translations[locale] === 'object')
+        .sort();
+}
+
+function collectSettingsHelpFanoutGaps(translations, registryEntries, {
+    canonicalLocales = SETTINGS_HELP_CANONICAL_LOCALES,
+    stubLocales = SETTINGS_HELP_STUB_LOCALES,
+    locales = null,
+} = {}) {
+    const canonical = canonicalLocales instanceof Set ? canonicalLocales : new Set(canonicalLocales);
+    const stubs = stubLocales instanceof Set ? stubLocales : new Set(stubLocales);
+    const requiredKeys = [...new Set((registryEntries || []).flatMap(entry => [entry.labelKey, entry.helpKey]).filter(Boolean))];
+    if (requiredKeys.length === 0) return [];
+
+    return (locales || realLocaleNames(translations))
+        .filter(locale => !canonical.has(locale) && !stubs.has(locale))
+        .map(locale => {
+            const dict = translations[locale];
+            if (!dict || typeof dict !== 'object') return null;
+            const missingKeys = requiredKeys.filter(key => !Object.prototype.hasOwnProperty.call(dict, key));
+            return missingKeys.length ? { locale, missingKeys } : null;
+        })
+        .filter(Boolean);
+}
+
+function formatSettingsHelpFanoutWarnings(gaps, { maxPreviewKeys = 8 } = {}) {
+    if (!gaps || gaps.length === 0) return [];
+    const totalMissing = gaps.reduce((sum, gap) => sum + gap.missingKeys.length, 0);
+    const lines = [
+        '',
+        `[i18n-check] ⚠  Settings-help fanout gaps: ${totalMissing} missing key(s) across ${gaps.length} locale(s).`,
+        '[i18n-check]    Soft warning only: en + zh stay hard-gated; zh-TW is a thin fallback stub and is skipped.',
+    ];
+    for (const gap of gaps) {
+        const preview = gap.missingKeys.slice(0, maxPreviewKeys).join(', ');
+        const suffix = gap.missingKeys.length > maxPreviewKeys
+            ? `, ... +${gap.missingKeys.length - maxPreviewKeys} more`
+            : '';
+        lines.push(`[i18n-check]    ${gap.locale}: ${gap.missingKeys.length} missing (${preview}${suffix})`);
+    }
+    return lines;
+}
+
 function updateOrphanBaseline() {
     const TRANSLATIONS = loadTranslations();
     const orphans = findOrphanKeys(TRANSLATIONS).sort();
@@ -237,16 +304,33 @@ function main() {
         .sort();
     console.log('\n[i18n-check] Per-locale coverage (vs EN):');
     const below = [];
+    const stubBelow = [];
     for (const lang of langs) {
         const count = Object.keys(TRANSLATIONS[lang] || {}).length;
         const pct = count / enKeys.size;
         const bar = '█'.repeat(Math.round(pct * 20)).padEnd(20, '·');
         const pctStr = (pct * 100).toFixed(1) + '%';
-        console.log(`  ${lang.padEnd(8)} ${bar} ${count.toString().padStart(5)} / ${enKeys.size}  ${pctStr}`);
-        if (pct < COVERAGE_WARN_THRESHOLD) below.push({ lang, pct });
+        const isStub = COVERAGE_STUB_LOCALES.has(lang);
+        console.log(`  ${(isStub ? `${lang}*` : lang).padEnd(8)} ${bar} ${count.toString().padStart(5)} / ${enKeys.size}  ${pctStr}`);
+        if (pct < COVERAGE_WARN_THRESHOLD) {
+            if (isStub) stubBelow.push({ lang, pct });
+            else below.push({ lang, pct });
+        }
     }
     if (below.length) {
         console.log(`\n[i18n-check] ⚠  ${below.length} locale(s) below ${Math.round(COVERAGE_WARN_THRESHOLD*100)}% coverage — users will see English fallback for gaps.`);
+    }
+    if (stubBelow.length) {
+        console.log(`\n[i18n-check] ℹ  Coverage threshold skipped fallback stub locale(s): ${stubBelow.map(({ lang }) => lang).join(', ')}.`);
+    }
+
+    // 5. Settings-help fanout gaps (warn only). The hard invariant gate blocks
+    // missing canonical `en`/`zh` settings help keys; this patrol-side layer
+    // surfaces missing non-canonical locale work without breaking CI or cron.
+    const settingsHelpRegistry = loadSettingsHelpRegistry();
+    const settingsHelpFanoutGaps = collectSettingsHelpFanoutGaps(TRANSLATIONS, settingsHelpRegistry);
+    for (const line of formatSettingsHelpFanoutWarnings(settingsHelpFanoutGaps)) {
+        console.log(line);
     }
 
     console.log('\n✅ [i18n-check] All referenced keys resolve in EN. No runtime "i18n not defined" risk.');
@@ -254,4 +338,10 @@ function main() {
 
 if (require.main === module) main();
 
-module.exports = { findOrphanKeys, loadOrphanBaseline };
+module.exports = {
+    collectSettingsHelpFanoutGaps,
+    findOrphanKeys,
+    formatSettingsHelpFanoutWarnings,
+    loadOrphanBaseline,
+    loadSettingsHelpRegistry,
+};

--- a/backend/tests/jest/settings-help-fanout-warning.test.js
+++ b/backend/tests/jest/settings-help-fanout-warning.test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const {
+    collectSettingsHelpFanoutGaps,
+    formatSettingsHelpFanoutWarnings,
+} = require('../../scripts/i18n-check');
+
+describe('settings-help fanout warnings', () => {
+    const registry = [
+        { labelKey: 'sample_label', helpKey: 'sample_help' },
+        { labelKey: 'other_label', helpKey: 'other_help' },
+    ];
+
+    test('reports non-canonical locale gaps while skipping en, zh, and zh-TW stub', () => {
+        const gaps = collectSettingsHelpFanoutGaps({
+            en: { sample_label: 'Sample', sample_help: 'Help' },
+            zh: { sample_label: '範例', sample_help: '說明' },
+            'zh-TW': {},
+            ja: { sample_label: 'Sample', other_label: 'Other', other_help: 'Other help' },
+            ko: { sample_label: 'Sample', sample_help: 'Help', other_label: 'Other', other_help: 'Other help' },
+            rootLeak: 'not a locale',
+        }, registry);
+
+        expect(gaps).toEqual([
+            { locale: 'ja', missingKeys: ['sample_help'] },
+        ]);
+    });
+
+    test('formats warnings as soft warnings, not hard gate failures', () => {
+        const lines = formatSettingsHelpFanoutWarnings([
+            { locale: 'ja', missingKeys: ['sample_help', 'other_help'] },
+        ], { maxPreviewKeys: 1 });
+
+        expect(lines.join('\n')).toContain('Settings-help fanout gaps');
+        expect(lines.join('\n')).toContain('Soft warning only');
+        expect(lines.join('\n')).toContain('zh-TW is a thin fallback stub and is skipped');
+        expect(lines.join('\n')).toContain('ja: 2 missing (sample_help, ... +1 more)');
+    });
+});

--- a/docs/contribution.md
+++ b/docs/contribution.md
@@ -22,6 +22,8 @@ The canonical locales for this PR are `en` and `zh`. Fanout locales can land lat
 
 Note: `TRANSLATIONS["zh-TW"]` is an intentionally thin override stub (publisher-guide-only); the Traditional Chinese canonical dict lives in `TRANSLATIONS.zh`, with `zh-TW` falling back through `zh` at runtime. The invariant gate checks `zh`, not `zh-TW`.
 
+Fanout SOP: `node backend/scripts/i18n-check.js` emits a soft warning when settings-help keys listed in `backend/settings-help-keys.json` are missing from non-canonical locale blocks. This is backlog signal for i18n patrol cards, not a PR blocker. The warning intentionally skips the `zh-TW` stub because it falls back through `zh`.
+
 For JS-rendered fields, keep the annotation next to the binding call:
 
 ```js

--- a/docs/specs/settings-help-icon.md
+++ b/docs/specs/settings-help-icon.md
@@ -108,7 +108,7 @@ HelpPopover.bindByKey(iconEl, 'kanban_nudge_batch_help');
 
 ### 4.2 Code → help invariant
 - Every `HELP-KEY: <key>` annotation MUST point to a key that exists in `backend/public/shared/i18n.js` for both `en` and `zh` (the canonical pair — see §3.1 architectural note on why `zh`, not `zh-TW`). Missing → CI fail.
-- Fanout locales (the 14 other top-level locales per §3.1) are checked by the patrol cron (warning-level, not hard-block).
+- Fanout locales are checked by the i18n patrol cron (warning-level, not hard-block). The soft layer is `node backend/scripts/i18n-check.js`: it reports settings-help gaps for non-canonical real locale blocks and keeps exit code 0 if EN references are otherwise valid. `zh-TW` is intentionally skipped here because it is a thin fallback stub; Traditional Chinese canonical coverage is enforced through `zh`.
 
 ### 4.3 Help → code invariant (SCOPED to settings-help keys)
 
@@ -174,3 +174,7 @@ Spec is accepted when:
   - §4.1: code examples updated to match PR #3065's content-based API (`data-help-content` not `data-help-key`/`data-help-content-key`), and JS example uses `HelpPopover.bindByKey` per §5.
   - §4.2: fanout count text "12 other top-level locales" → "14 other top-level locales".
   - §7: "16 fanout locales" → "14 fanout locales".
+- 2026-06-01 17:59 TWT — Child 7 soft-warning SOP clarified:
+  - §4.2 names `backend/scripts/i18n-check.js` as the patrol layer for settings-help fanout gaps.
+  - `zh-TW` is explicitly skipped by the soft warning because it is a fallback stub, not a fanout injection target.
+  - Fanout gaps are warning-only and must not change the checker exit code.


### PR DESCRIPTION
## Summary

Adds a soft warning layer to `backend/scripts/i18n-check.js` for settings-help fanout coverage. The hard gate still only blocks missing canonical `en`/`zh` keys, while non-canonical locale gaps are reported as backlog signal.

## Changes

- Load `backend/settings-help-keys.json` and compare label/help keys against real non-canonical locale blocks.
- Skip the thin `zh-TW` fallback stub for both the fanout warning and the low-coverage threshold message.
- Export and cover the fanout gap collector/formatter with focused Jest tests.
- Document the warning-only SOP in the contribution guide and settings-help spec.

## Validation

- `node --check backend/scripts/i18n-check.js`
- `node backend/scripts/i18n-check.js` exits 0 and reports 451 settings-help fanout gaps as warning-only.
- `npx jest --runTestsByPath tests/jest/settings-help-fanout-warning.test.js`