### PR TITLE
feat(chat): smart-filter for system messages — categorize & chip group

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -178,6 +178,56 @@
             color: var(--primary);
         }
 
+        /* ── System-message smart filter chips ── */
+        .chip-group-wrapper-sys {
+            margin-top: 6px;
+        }
+        .chip-group-system {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 6px;
+        }
+        .sys-chip {
+            padding: 4px 10px;
+            border-radius: 16px;
+            font-size: 12px;
+            line-height: 1.4;
+            cursor: pointer;
+            background: var(--card);
+            border: 1px solid var(--card-border);
+            color: var(--text-secondary);
+            white-space: nowrap;
+            user-select: none;
+            transition: all 0.15s;
+            flex-shrink: 0;
+            opacity: 0.55;
+        }
+        .sys-chip:hover {
+            opacity: 0.85;
+            border-color: var(--primary);
+        }
+        .sys-chip.active {
+            background: var(--primary);
+            border-color: var(--primary);
+            color: var(--text);
+            opacity: 1;
+        }
+        .sys-hidden-banner {
+            margin: 8px 16px 0;
+            padding: 6px 10px;
+            font-size: 12px;
+            color: var(--text-secondary);
+            background: var(--card);
+            border: 1px dashed var(--card-border);
+            border-radius: 8px;
+            text-align: center;
+            cursor: pointer;
+        }
+        .sys-hidden-banner:hover {
+            border-color: var(--primary);
+            color: var(--primary);
+        }
+
         /* ── Messages Area ── */
         .chat-messages {
             flex: 1;
@@ -2867,6 +2917,16 @@
                     </div>
                     <span class="filter-chip-toggle" id="filterToggle" onclick="toggleFilterExpand()" style="display:none;"></span>
                 </div>
+                <!-- Smart filter — system message categories (multi-select OR, per spec chat-smart-filter-system-messages.md) -->
+                <div class="chip-group-wrapper chip-group-wrapper-sys">
+                    <div class="chip-group chip-group-system" id="systemFilterChips" role="group" aria-label="System message filters">
+                        <button class="sys-chip active" type="button" data-syscat="conversation" onclick="toggleSysCat('conversation')" data-i18n="chat_sys_conversation" title="對話 / Conversation">💬 對話</button>
+                        <button class="sys-chip active" type="button" data-syscat="kanban" onclick="toggleSysCat('kanban')" data-i18n="chat_sys_kanban" title="看板 / Kanban">📋 看板</button>
+                        <button class="sys-chip active" type="button" data-syscat="scheduled" onclick="toggleSysCat('scheduled')" data-i18n="chat_sys_scheduled" title="排程 / Scheduled">⏰ 排程</button>
+                        <button class="sys-chip" type="button" data-syscat="platform" onclick="toggleSysCat('platform')" data-i18n="chat_sys_platform" title="系統 / Platform">🔧 系統</button>
+                        <button class="sys-chip" type="button" data-syscat="health" onclick="toggleSysCat('health')" data-i18n="chat_sys_health" title="健康 / Health">❤️ 健康</button>
+                    </div>
+                </div>
             </div>
 
             <!-- Messages Area -->
@@ -3127,6 +3187,7 @@
     <script src="../shared/petdx-renderer.js"></script>
     <script src="../shared/avatar-petdx.js"></script>
     <script src="shared/entity-utils.js"></script>
+    <script src="shared/chat-source-category.js"></script>
     <script src="shared/mention-autocomplete.js"></script>
     <script src="shared/mention-resolver.js"></script>
     <script src="shared/mention-render.js"></script>
@@ -3167,6 +3228,71 @@
         const entityRuntimeStatus = new Map();
         let activeChatMessageDeepLinkId = null;
         let activeChatMessageDeepLinkMissingId = null;
+
+        // ── System-message smart filter (spec chat-smart-filter-system-messages.md) ──
+        // Active set of 5 categories from ChatSourceCategory. Default per spec:
+        // conversation/kanban/scheduled ON, platform/health OFF. `unknown` always
+        // passes regardless (regression-safe) — not a toggle.
+        let sysFilterActive = (typeof ChatSourceCategory !== 'undefined' && ChatSourceCategory.DEFAULT_ACTIVE)
+            ? Object.assign({}, ChatSourceCategory.DEFAULT_ACTIVE)
+            : { conversation: true, kanban: true, scheduled: true, platform: false, health: false };
+
+        function _sysFilterStorageKey() {
+            const deviceId = (currentUser && currentUser.deviceId) || '';
+            return (typeof ChatSourceCategory !== 'undefined' && ChatSourceCategory.storageKey)
+                ? ChatSourceCategory.storageKey(deviceId)
+                : ('eclaw.chatSysFilter.v1' + (deviceId ? ':' + deviceId : ''));
+        }
+
+        function loadSysFilterFromStorage() {
+            try {
+                const raw = localStorage.getItem(_sysFilterStorageKey());
+                if (!raw) return;
+                const saved = JSON.parse(raw);
+                if (saved && typeof saved === 'object') {
+                    ['conversation', 'kanban', 'scheduled', 'platform', 'health'].forEach(cat => {
+                        if (typeof saved[cat] === 'boolean') sysFilterActive[cat] = saved[cat];
+                    });
+                }
+            } catch (e) { /* ignore parse errors */ }
+        }
+
+        function saveSysFilterToStorage() {
+            try { localStorage.setItem(_sysFilterStorageKey(), JSON.stringify(sysFilterActive)); }
+            catch (e) { /* ignore quota errors */ }
+        }
+
+        function applySysFilterChipState() {
+            const group = document.getElementById('systemFilterChips');
+            if (!group) return;
+            group.querySelectorAll('.sys-chip').forEach(chip => {
+                const cat = chip.dataset.syscat;
+                chip.classList.toggle('active', !!sysFilterActive[cat]);
+                chip.setAttribute('aria-pressed', String(!!sysFilterActive[cat]));
+            });
+        }
+
+        function toggleSysCat(cat) {
+            if (!Object.prototype.hasOwnProperty.call(sysFilterActive, cat)) return;
+            sysFilterActive[cat] = !sysFilterActive[cat];
+            saveSysFilterToStorage();
+            applySysFilterChipState();
+            if (typeof renderMessages === 'function') renderMessages(false);
+        }
+
+        function applySystemFilters(messages) {
+            if (typeof ChatSourceCategory === 'undefined' || !ChatSourceCategory.passesSystemFilter) return messages;
+            return messages.filter(m => ChatSourceCategory.passesSystemFilter(m, sysFilterActive));
+        }
+
+        // 'N hidden' banner click — turn every chip ON (incl platform/health) so
+        // the user can see what's behind the filter without manually toggling 5 chips.
+        function enableAllSysCats() {
+            Object.keys(sysFilterActive).forEach(cat => { sysFilterActive[cat] = true; });
+            saveSysFilterToStorage();
+            applySysFilterChipState();
+            if (typeof renderMessages === 'function') renderMessages(false);
+        }
         const CHAT_AVATAR_SIZE_PX = { small: 32, medium: 48, large: 64 };
         let chatAvatarSize = 'medium';
 
@@ -3482,6 +3608,10 @@
             const user = await checkAuth();
             console.log('[CHAT_DEBUG] checkAuth result:', user ? `deviceId=${user.deviceId}, hasSecret=${!!user.deviceSecret}` : 'NULL');
             if (!user) return;
+            // Hydrate sys-filter chip state from per-device localStorage
+            // (key requires deviceId — see chat-source-category.storageKey).
+            loadSysFilterFromStorage();
+            applySysFilterChipState();
             initPortalSocket();
             initEnvVarBtn(user.deviceId, user.deviceSecret);
             await loadChatAvatarSizePreference();
@@ -4946,12 +5076,20 @@
             const container = document.getElementById('chatMessages');
             const scrollLock = captureChatScrollAnchor(container);
             const shouldFollowBottom = isFirstLoad || (scrollLock && scrollLock.wasAtBottom);
-            const filtered = withRentalHealthSystemMessages(getFilteredMessages());
+            // Apply sys-category filter AFTER withRentalHealthSystemMessages so
+            // synthesized rental_health_system items are subject to the filter
+            // (per #6 amendment 2026-06-01 — health chip OFF must hide them).
+            const beforeSys = withRentalHealthSystemMessages(getFilteredMessages());
+            const filtered = applySystemFilters(beforeSys);
+            const hiddenBySys = beforeSys.length - filtered.length;
 
             const deepLinkMissingHtml = renderChatMessageDeepLinkMissing();
+            const sysHiddenBannerHtml = (hiddenBySys >= 10)
+                ? `<div class="sys-hidden-banner" onclick="enableAllSysCats()" title="${escapeHtml(i18n.t('chat_sys_n_hidden_hint') || 'Click to show all categories')}">${escapeHtml((i18n.t('chat_sys_n_hidden') || '{n} system message(s) hidden by filter — click to show').replace('{n}', String(hiddenBySys)))}</div>`
+                : '';
 
             if (filtered.length === 0) {
-                container.innerHTML = deepLinkMissingHtml + `
+                container.innerHTML = deepLinkMissingHtml + sysHiddenBannerHtml + `
                     <div class="chat-empty">
                         <div class="chat-empty-icon">💬</div>
                         <div class="chat-empty-title" data-i18n="chat_empty">${escapeHtml(i18n.t('chat_empty') || 'No messages yet')}</div>
@@ -4994,7 +5132,7 @@
                 return d.toLocaleDateString([], { month: 'numeric', day: 'numeric' });
             }
 
-            container.innerHTML = deepLinkMissingHtml + displayMessages.map((msg, idx) => {
+            container.innerHTML = deepLinkMissingHtml + sysHiddenBannerHtml + displayMessages.map((msg, idx) => {
                 // Skip earlier messages in a photo run — the last one renders the grid.
                 if (msg._photoGroupSkip) return '';
                 // Walk back over skipped photo-run entries so date separators

--- a/backend/public/portal/shared/chat-source-category.js
+++ b/backend/public/portal/shared/chat-source-category.js
@@ -1,0 +1,115 @@
+/**
+ * Chat source category — collapse `chat_messages.source` raw patterns into
+ * 5 user-facing categories for the smart-filter chips in portal/chat.html.
+ *
+ * Spec: docs/specs/chat-smart-filter-system-messages.md
+ *
+ * Categories: 'conversation' | 'kanban' | 'health' | 'platform' | 'scheduled' | 'unknown'
+ *
+ * Key contract (#6 amendments 2026-06-01):
+ * - `categorizeChatMessage(msg)` is canonical — takes the whole message
+ *   so it can fall back to `is_from_user || is_from_bot` flags for legacy
+ *   bot rows where the source string is unreliable.
+ * - `source.trim()` normalized; SYSTEM/platform case-insensitive.
+ * - `kanban_notify` / `mission_notify` only EXACT or `:`-prefix match
+ *   (never broad prefix — would mis-classify `mission_notifyfoo`).
+ * - `unknown` is the last resort and MUST be shown by default; the UI
+ *   guarantees this via `passesSystemFilter`.
+ */
+(function (global) {
+    'use strict';
+
+    function categorizeChatMessage(msg) {
+        const raw = (msg && msg.source) || '';
+        const s = String(raw).trim();
+        const sLower = s.toLowerCase();
+
+        if (!s) {
+            if (msg && (msg.is_from_user || msg.is_from_bot)) return 'conversation';
+            return 'unknown';
+        }
+
+        if (s === 'web_chat' || s === 'client' ||
+            s === 'android_chat' || s === 'android_widget' || s === 'widget' ||
+            s === 'form_submission' || s === 'bot') return 'conversation';
+
+        if (s.startsWith('entity:') || s.startsWith('xdevice:')) return 'conversation';
+
+        if (s === 'kanban_notify' || s.startsWith('kanban_notify:')) return 'kanban';
+        if (s === 'mission_notify' || s.startsWith('mission_notify:')) return 'kanban';
+        if (s === 'reopen' || s === 'kanban_comments' || s === 'kanban_pending_notify') return 'kanban';
+
+        if (s.startsWith('monitor-healthcheck') ||
+            s.startsWith('monitor-modelcheck') ||
+            s.startsWith('manual-steps') ||
+            s === 'healthcheck' ||
+            s === 'rental_health_system') return 'health';
+
+        if (sLower === 'platform' || sLower === 'system' ||
+            s === 'admin_secret_notify' ||
+            s.startsWith('bind_') ||
+            s.startsWith('bot_register') ||
+            s === 'invite_redeem' ||
+            s.startsWith('codex-') ||
+            s.startsWith('target-mode') ||
+            s === 'target_mode') return 'platform';
+
+        if (s === 'scheduled') return 'scheduled';
+
+        if (msg && (msg.is_from_user || msg.is_from_bot)) return 'conversation';
+
+        // Legacy 中文 label fallback: must end with 主管 (e.g. 'Mac_ClaudeAce主管').
+        // Without this anchor the pattern would match any [A-Za-z_]+ string and
+        // swallow unknown sources into conversation.
+        if (/^[A-Za-z_一-鿿]+主管$/.test(s)) return 'conversation';
+
+        return 'unknown';
+    }
+
+    function categorizeChatSource(source) {
+        return categorizeChatMessage({ source: source });
+    }
+
+    const CATEGORIES = Object.freeze([
+        'conversation', 'kanban', 'scheduled', 'platform', 'health'
+    ]);
+
+    const DEFAULT_ACTIVE = Object.freeze({
+        conversation: true,
+        kanban: true,
+        scheduled: true,
+        platform: false,
+        health: false,
+    });
+
+    const STORAGE_KEY_PREFIX = 'eclaw.chatSysFilter.v1';
+
+    function storageKey(deviceId) {
+        if (!deviceId) return STORAGE_KEY_PREFIX;
+        return STORAGE_KEY_PREFIX + ':' + deviceId;
+    }
+
+    function passesSystemFilter(msg, activeSet) {
+        if (!activeSet) return true;
+        const cat = categorizeChatMessage(msg);
+        if (cat === 'unknown') return true;
+        return !!activeSet[cat];
+    }
+
+    const api = {
+        categorizeChatMessage: categorizeChatMessage,
+        categorizeChatSource: categorizeChatSource,
+        passesSystemFilter: passesSystemFilter,
+        storageKey: storageKey,
+        CATEGORIES: CATEGORIES,
+        DEFAULT_ACTIVE: DEFAULT_ACTIVE,
+        STORAGE_KEY_PREFIX: STORAGE_KEY_PREFIX,
+    };
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    }
+    if (global) {
+        global.ChatSourceCategory = api;
+    }
+})(typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : null);

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -338296,6 +338296,13 @@ const TRANSLATIONS = {
 
 
         "chat_filter_my": "My Messages",
+        "chat_sys_conversation": "💬 Conversation",
+        "chat_sys_kanban": "📋 Kanban",
+        "chat_sys_scheduled": "⏰ Scheduled",
+        "chat_sys_platform": "🔧 System",
+        "chat_sys_health": "❤️ Health",
+        "chat_sys_n_hidden": "{n} system message(s) hidden by filter — click to show",
+        "chat_sys_n_hidden_hint": "Click to show all categories",
 
 
 
@@ -963228,6 +963235,13 @@ const TRANSLATIONS = {
 
 
         "chat_filter_my": "我的訊息",
+        "chat_sys_conversation": "💬 對話",
+        "chat_sys_kanban": "📋 看板",
+        "chat_sys_scheduled": "⏰ 排程",
+        "chat_sys_platform": "🔧 系統",
+        "chat_sys_health": "❤️ 健康",
+        "chat_sys_n_hidden": "{n} 則系統訊息已被 filter 隱藏 — 點此顯示",
+        "chat_sys_n_hidden_hint": "點此顯示全部類別",
 
 
 

--- a/backend/tests/jest/chat-source-category.test.js
+++ b/backend/tests/jest/chat-source-category.test.js
@@ -1,0 +1,167 @@
+'use strict';
+
+const {
+    categorizeChatMessage,
+    categorizeChatSource,
+    passesSystemFilter,
+    storageKey,
+    CATEGORIES,
+    DEFAULT_ACTIVE,
+    STORAGE_KEY_PREFIX,
+} = require('../../public/portal/shared/chat-source-category');
+
+describe('categorizeChatMessage — inventory pattern coverage', () => {
+    test.each([
+        ['web_chat', 'conversation'],
+        ['client', 'conversation'],
+        ['android_chat', 'conversation'],
+        ['android_widget', 'conversation'],
+        ['widget', 'conversation'],
+        ['form_submission', 'conversation'],
+        ['bot', 'conversation'],
+        ['entity:2:LOBSTER->6', 'conversation'],
+        ['entity:6:LOBSTER->2', 'conversation'],
+        ['entity:2:LOBSTER->1,3,4', 'conversation'],
+        ['xdevice:tbwb9e->3xa3h4', 'conversation'],
+        ['Mac_ClaudeAce主管', 'conversation'],
+
+        ['kanban_notify', 'kanban'],
+        ['kanban_notify:2,6', 'kanban'],
+        ['mission_notify', 'kanban'],
+        ['mission_notify:2', 'kanban'],
+        ['reopen', 'kanban'],
+        ['kanban_comments', 'kanban'],
+        ['kanban_pending_notify', 'kanban'],
+
+        ['monitor-healthcheck-2', 'health'],
+        ['monitor-healthcheck', 'health'],
+        ['monitor-modelcheck-6', 'health'],
+        ['manual-steps123-healthcheck-2', 'health'],
+        ['healthcheck', 'health'],
+        ['rental_health_system', 'health'],
+
+        ['platform', 'platform'],
+        ['SYSTEM', 'platform'],
+        ['System', 'platform'],
+        ['system', 'platform'],
+        ['admin_secret_notify', 'platform'],
+        ['bind_handshake', 'platform'],
+        ['bot_register', 'platform'],
+        ['bot_register_handshake', 'platform'],
+        ['invite_redeem', 'platform'],
+        ['codex-final-ack-2', 'platform'],
+        ['target-mode-2', 'platform'],
+        ['target_mode', 'platform'],
+
+        ['scheduled', 'scheduled'],
+    ])('source %s → %s', (source, expected) => {
+        expect(categorizeChatMessage({ source })).toBe(expected);
+    });
+});
+
+describe('false-positive guards (#6 amendment)', () => {
+    test.each([
+        ['mission_notifyfoo', 'unknown'],
+        ['kanban_notifybar', 'unknown'],
+        ['mission_notify_legacy', 'unknown'],
+        ['kanban_notifyXXX', 'unknown'],
+    ])('broad prefix MUST NOT match: %s → %s', (source, expected) => {
+        expect(categorizeChatMessage({ source })).toBe(expected);
+    });
+});
+
+describe('whitespace normalization (source.trim)', () => {
+    test('leading/trailing whitespace trimmed before match', () => {
+        expect(categorizeChatMessage({ source: '  web_chat  ' })).toBe('conversation');
+        expect(categorizeChatMessage({ source: '\tkanban_notify\n' })).toBe('kanban');
+    });
+});
+
+describe('flag fallback for null/empty source', () => {
+    test('null source + is_from_user → conversation', () => {
+        expect(categorizeChatMessage({ source: null, is_from_user: true })).toBe('conversation');
+    });
+    test('empty source + is_from_bot → conversation', () => {
+        expect(categorizeChatMessage({ source: '', is_from_bot: true })).toBe('conversation');
+    });
+    test('null source + no flags → unknown', () => {
+        expect(categorizeChatMessage({ source: null })).toBe('unknown');
+        expect(categorizeChatMessage({})).toBe('unknown');
+    });
+});
+
+describe('flag fallback for unrecognized source', () => {
+    test('unrecognized source + is_from_bot → conversation (legacy bot row)', () => {
+        expect(categorizeChatMessage({ source: 'SomeLegacyBotLabel', is_from_bot: true }))
+            .toBe('conversation');
+    });
+    test('unrecognized source + no flags → unknown', () => {
+        expect(categorizeChatMessage({ source: 'totally_unknown_2026' })).toBe('unknown');
+    });
+});
+
+describe('categorizeChatSource back-compat shim', () => {
+    test('string-only call delegates to message form', () => {
+        expect(categorizeChatSource('kanban_notify')).toBe('kanban');
+        expect(categorizeChatSource('SYSTEM')).toBe('platform');
+        expect(categorizeChatSource('totally_unknown')).toBe('unknown');
+    });
+});
+
+describe('passesSystemFilter', () => {
+    const ALL_ON = {
+        conversation: true, kanban: true, scheduled: true,
+        platform: true, health: true,
+    };
+    const DEFAULT = DEFAULT_ACTIVE;
+
+    test('all chips on → everything passes', () => {
+        expect(passesSystemFilter({ source: 'web_chat' }, ALL_ON)).toBe(true);
+        expect(passesSystemFilter({ source: 'kanban_notify' }, ALL_ON)).toBe(true);
+        expect(passesSystemFilter({ source: 'monitor-healthcheck-2' }, ALL_ON)).toBe(true);
+    });
+
+    test('default state hides platform + health, keeps rest', () => {
+        expect(passesSystemFilter({ source: 'web_chat' }, DEFAULT)).toBe(true);
+        expect(passesSystemFilter({ source: 'kanban_notify' }, DEFAULT)).toBe(true);
+        expect(passesSystemFilter({ source: 'scheduled' }, DEFAULT)).toBe(true);
+        expect(passesSystemFilter({ source: 'monitor-healthcheck-2' }, DEFAULT)).toBe(false);
+        expect(passesSystemFilter({ source: 'platform' }, DEFAULT)).toBe(false);
+    });
+
+    test('unknown ALWAYS passes regardless of chip state (regression-safe)', () => {
+        const allOff = { conversation: false, kanban: false, scheduled: false, platform: false, health: false };
+        expect(passesSystemFilter({ source: 'totally_unknown_xxx' }, allOff)).toBe(true);
+        expect(passesSystemFilter({ source: null }, allOff)).toBe(true);
+    });
+
+    test('null activeSet treated as all-on (defensive)', () => {
+        expect(passesSystemFilter({ source: 'monitor-healthcheck-2' }, null)).toBe(true);
+    });
+});
+
+describe('storageKey', () => {
+    test('per-device key', () => {
+        expect(storageKey('480def4c-2183-4d8e-afd0-b131ae89adcc'))
+            .toBe('eclaw.chatSysFilter.v1:480def4c-2183-4d8e-afd0-b131ae89adcc');
+    });
+    test('no device falls back to prefix only', () => {
+        expect(storageKey('')).toBe(STORAGE_KEY_PREFIX);
+        expect(storageKey(null)).toBe(STORAGE_KEY_PREFIX);
+    });
+});
+
+describe('constants', () => {
+    test('CATEGORIES exposed as frozen array of 5 (unknown excluded)', () => {
+        expect(CATEGORIES).toEqual(['conversation', 'kanban', 'scheduled', 'platform', 'health']);
+        expect(Object.isFrozen(CATEGORIES)).toBe(true);
+        expect(CATEGORIES).not.toContain('unknown');
+    });
+    test('DEFAULT_ACTIVE matches spec defaults', () => {
+        expect(DEFAULT_ACTIVE.conversation).toBe(true);
+        expect(DEFAULT_ACTIVE.kanban).toBe(true);
+        expect(DEFAULT_ACTIVE.scheduled).toBe(true);
+        expect(DEFAULT_ACTIVE.platform).toBe(false);
+        expect(DEFAULT_ACTIVE.health).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
Implements docs/specs/chat-smart-filter-system-messages.md.

Collapses 25+ `chat_messages.source` raw patterns into 5 user-facing categories (conversation / kanban / scheduled / platform / health) and adds a multi-select chip group to `portal/chat.html` so the user can hide kanban_notify nudges, monitor-healthcheck pings, etc. without losing the ability to bring them back.

- `backend/public/portal/shared/chat-source-category.js` — categorize + filter helpers
- `backend/tests/jest/chat-source-category.test.js` — 57 tests, all pass locally, includes #6's false-positive guards (`mission_notifyfoo` must NOT classify as kanban)
- `backend/public/portal/chat.html` — chip group + sys-filter state + localStorage persistence + 'N hidden' banner; filter applied AFTER `withRentalHealthSystemMessages` per #6 amendment

## Card
card_d9f090c474ef6e7210f7361a (will unblock + move to in_progress)

## Test plan
- [x] Jest 57/57 PASS locally
- [ ] Playwright E2E mobile 390x844 + desktop 1280x800 (next commit)
- [ ] i18n en + zh keys — delegated to #3/#4 per feedback_i18n_delegate (UI uses inline fallback so works without dict update)
- [ ] #6 final code review

🤖 Generated with [Claude Code](https://claude.com/claude-code)