### PR TITLE
fix(portal): safe-default-focus on destructive confirm dialogs

### DIFF
--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -99,13 +99,21 @@ function showConfirm({ message, title, confirmText, cancelText, danger } = {}) {
         </div>`;
         document.body.appendChild(overlay);
         const cleanup = (result) => { overlay.remove(); resolve(result); };
-        overlay.querySelector('.eclaw-confirm-ok').focus();
+        // Safe default focus: when danger=true, focus Cancel so a stray
+        // Enter / Space does not commit the destructive action. Matches the
+        // Material Design and Apple HIG guidance for destructive confirms.
+        const safeBtnSel = danger ? '.eclaw-confirm-cancel' : '.eclaw-confirm-ok';
+        overlay.querySelector(safeBtnSel).focus();
         overlay.querySelector('.eclaw-confirm-ok').addEventListener('click', () => cleanup(true));
         overlay.querySelector('.eclaw-confirm-cancel').addEventListener('click', () => cleanup(false));
         overlay.addEventListener('click', (e) => { if (e.target === overlay) cleanup(false); });
         overlay.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') cleanup(false);
-            if (e.key === 'Enter') cleanup(true);
+            // For destructive confirms Enter dismisses (= cancel) so an
+            // accidental keypress on a focused Cancel button still resolves
+            // false. Non-danger confirms keep the original Enter=confirm
+            // ergonomics so OK-flow dialogs still feel snappy.
+            if (e.key === 'Enter') cleanup(!danger ? true : false);
         });
     });
 }

--- a/backend/tests/jest/showConfirm-danger-default-focus.test.js
+++ b/backend/tests/jest/showConfirm-danger-default-focus.test.js
@@ -1,0 +1,56 @@
+/**
+ * Static invariant test for the destructive-confirm safe-default-focus fix.
+ *
+ * Card: card_31cbbcd885097364f19cbd40 (P0, Phase 2 finding from the
+ * destructive-modals daily E2E parent card_d7824a8f6ab6b3f20bad73aa).
+ *
+ * jest.config.js uses testEnvironment: 'node' so a true JSDOM behaviour
+ * assertion is not possible without adding a test-only dep. Instead we
+ * lock the surface here: any future edit that removes the danger-aware
+ * focus selector or the Enter-while-danger short-circuit silently
+ * regresses the safety invariant.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const apiJs = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'portal', 'shared', 'api.js'),
+    'utf8'
+);
+
+describe('showConfirm — destructive-modal safe default focus', () => {
+    test('focuses Cancel button when danger=true', () => {
+        // The selector must branch on `danger` so a stray Enter / Space on
+        // an automatically-focused element does not commit the destructive
+        // action. See card_31cbbcd885097364f19cbd40 and Material Design /
+        // Apple HIG guidance for destructive confirms.
+        expect(apiJs).toMatch(
+            /danger\s*\?\s*['"]\.eclaw-confirm-cancel['"]\s*:\s*['"]\.eclaw-confirm-ok['"]/
+        );
+    });
+
+    test('Enter on a destructive confirm does NOT commit', () => {
+        // Enter handler must skip cleanup(true) when danger is set. The
+        // previous unconditional `cleanup(true)` shipped destructive ops on
+        // any keyboard-focused Enter, which violated the safety invariant.
+        expect(apiJs).toMatch(/if\s*\(\s*e\.key\s*===\s*['"]Enter['"]\s*\)\s*cleanup\(\s*!danger/);
+    });
+
+    test('Esc still cancels regardless of danger flag', () => {
+        // Esc behaviour is unchanged — danger-aware focus must not break
+        // the universal Esc-dismisses contract.
+        expect(apiJs).toMatch(/if\s*\(\s*e\.key\s*===\s*['"]Escape['"]\s*\)\s*cleanup\(\s*false\s*\)/);
+    });
+
+    test('non-danger confirm keeps Enter=confirm ergonomics', () => {
+        // The fix must preserve the snappy OK-flow for non-destructive
+        // dialogs — Enter should still resolve true when danger is falsy.
+        // We assert via the same `cleanup(!danger ? true : false)` expression
+        // — when danger is false, the inner ternary evaluates to true.
+        const enterLine = apiJs.match(/e\.key\s*===\s*['"]Enter['"][^;]*;?/);
+        expect(enterLine).not.toBeNull();
+        expect(enterLine[0]).toMatch(/!danger\s*\?\s*true\s*:\s*false/);
+    });
+});


### PR DESCRIPTION
## Summary

- Branch the `showConfirm()` auto-focus selector on the `danger` flag so destructive confirms focus the Cancel button instead of the red OK. Non-destructive dialogs keep auto-focus on OK.
- When `danger=true`, Enter resolves as Cancel (`cleanup(false)`) so a stray keystroke on the focused Cancel button cannot commit the destructive action. Esc keeps the universal dismiss contract.
- Static invariant jest test (testEnvironment is `node`, no jsdom) grep-locks the focus selector + Enter short-circuit + unchanged Esc/non-danger paths.

Aligns with Material Design and Apple HIG guidance: destructive confirms reserve default focus and the primary keyboard shortcut for the safe choice.

## Card

- card_31cbbcd885097364f19cbd40 (P0) — Phase 2 finding from the destructive-modals daily E2E parent card_d7824a8f6ab6b3f20bad73aa.

## Test plan

- [x] `npx jest tests/jest/showConfirm-danger-default-focus.test.js` — 4/4 pass.
- [ ] Manual: open `portal/kanban.html`, trigger any delete confirm, press Enter — expect dismiss (cancel), not delete. Repeat for `portal/settings.html` "clear all data" and any other destructive flow.
- [ ] Visual regression: existing destructive confirms still render the red OK button (no styling change), just no longer auto-focused.
- [ ] Follow-up: extend `.agent/playbooks/destructive-modals-e2e.md` Phase 1 with the "Enter on danger=true must dismiss" step (separate PR — tracked on the parent card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)