### PR TITLE
fix(openclaw-channel): harden EClaw ACK delivery

### DIFF
--- a/openclaw-channel-eclaw/README.md
+++ b/openclaw-channel-eclaw/README.md
@@ -196,6 +196,21 @@ the E-Claw browser chat UI with a fresh nonce. For #1, enable
 background cards are queued ahead of user messages; this prevents background
 feed backlog from starving the interactive reply path.
 
+For #1 model-health failures where the runtime eventually replies after the
+monitor has already timed out, inspect `openclaw-project-f` logs for
+`stalled_agent_run activeWorkKind=embedded_run`. Keep project F's
+`diagnostics.stuckSessionWarnMs` and `diagnostics.stuckSessionAbortMs`
+shorter than the monitor model-health window so stale embedded runs are
+reclaimed before new user-to-bot probes queue behind them. The current
+known-good local values are `60000` and `90000` milliseconds.
+
+For project E / entity #3, keep the MiniMax-verified runtime pinned unless its
+own drift check requires an upgrade. If #3's API ACK is healthy but
+model-health times out or the browser UI shows delayed replies while kanban or
+org-forward traffic is active, enable `ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS=1`
+and `ECLAW_SUPPRESS_BACKGROUND_EVENTS=1` only on `openclaw-e`, then recreate
+that service and verify #3 independently.
+
 ## Troubleshooting
 
 ### `Config invalid: channels.eclaw unknown channel id`

--- a/openclaw-channel-eclaw/src/client.ts
+++ b/openclaw-channel-eclaw/src/client.ts
@@ -6,6 +6,23 @@ import type {
   HeartbeatResponse,
 } from './types.js';
 
+const MESSAGE_RETRY_DELAYS_MS = [250, 750, 1500];
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isTransientMessageFailure(status: number, data: { success?: boolean; message?: string; error?: string }): boolean {
+  if (status === 429 || status >= 500) return true;
+  const reason = String(data.message || data.error || '').toLowerCase();
+  return data.success === false && (
+    reason.includes('server starting up')
+    || reason.includes('retry')
+    || reason.includes('timeout')
+    || reason.includes('temporar')
+  );
+}
+
 /**
  * HTTP client for E-Claw Channel API.
  * Handles all communication between the OpenClaw plugin and the E-Claw backend.
@@ -107,24 +124,45 @@ export class EClawClient {
       throw new Error('Not bound — call bindEntity() first');
     }
 
-    const res = await fetch(`${this.apiBase}/api/channel/message`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        channel_api_key: this.apiKey,
-        deviceId: this.deviceId,
-        entityId: this.entityId,
-        botSecret: this.botSecret,
-        message,
-        state,
-        ...(opts?.mediaType && { mediaType: opts.mediaType }),
-        ...(opts?.mediaUrl && { mediaUrl: opts.mediaUrl }),
-        ...(opts?.speakTo && { speakTo: opts.speakTo.map(String) }),
-        ...(opts?.broadcast && { broadcast: true }),
-      }),
-    });
+    const body = {
+      channel_api_key: this.apiKey,
+      deviceId: this.deviceId,
+      entityId: this.entityId,
+      botSecret: this.botSecret,
+      message,
+      state,
+      ...(opts?.mediaType && { mediaType: opts.mediaType }),
+      ...(opts?.mediaUrl && { mediaUrl: opts.mediaUrl }),
+      ...(opts?.speakTo && { speakTo: opts.speakTo.map(String) }),
+      ...(opts?.broadcast && { broadcast: true }),
+    };
 
-    return await res.json() as MessageResponse;
+    let lastNetworkError: unknown;
+    for (let attempt = 0; attempt <= MESSAGE_RETRY_DELAYS_MS.length; attempt += 1) {
+      try {
+        const res = await fetch(`${this.apiBase}/api/channel/message`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(body),
+        });
+
+        const data = await res.json() as MessageResponse & { message?: string; error?: string };
+        if (
+          attempt < MESSAGE_RETRY_DELAYS_MS.length
+          && isTransientMessageFailure(res.status, data)
+        ) {
+          await sleep(MESSAGE_RETRY_DELAYS_MS[attempt]);
+          continue;
+        }
+        return data;
+      } catch (err) {
+        lastNetworkError = err;
+        if (attempt >= MESSAGE_RETRY_DELAYS_MS.length) break;
+        await sleep(MESSAGE_RETRY_DELAYS_MS[attempt]);
+      }
+    }
+
+    throw lastNetworkError instanceof Error ? lastNetworkError : new Error('message delivery failed');
   }
 
   /** Record this bound entity daemon as alive. */

--- a/openclaw-channel-eclaw/src/webhook-handler.ts
+++ b/openclaw-channel-eclaw/src/webhook-handler.ts
@@ -82,6 +82,10 @@ export function createWebhookHandler(
       const directAck = String(msg.text || '').match(/^ECLAW_HEALTHCHECK\s+([A-Za-z0-9_-]+)(?=\s|$)/m);
       if (directAck) {
         if (client) {
+          // /api/client/speak writes a "Received" echo around webhook delivery.
+          // A short delay keeps the synthetic ACK as the final visible state
+          // without occupying the model reply path.
+          await new Promise((resolve) => setTimeout(resolve, 3000));
           await client.sendMessage(`ACK ${directAck[1]}`, 'IDLE');
         }
         return;

--- a/openclaw-channel-eclaw/test/client.test.ts
+++ b/openclaw-channel-eclaw/test/client.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EClawClient } from '../src/client.js';
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    status,
+    ok: status >= 200 && status < 300,
+    json: vi.fn().mockResolvedValue(body),
+  } as unknown as Response;
+}
+
+async function boundClient(fetchMock: ReturnType<typeof vi.fn>): Promise<EClawClient> {
+  const client = new EClawClient({
+    apiBase: 'https://example.invalid',
+    apiKey: 'test-channel-key',
+  });
+  fetchMock.mockResolvedValueOnce(jsonResponse(200, {
+    success: true,
+    deviceId: 'device-1',
+    entityId: 4,
+    botSecret: 'bot-secret',
+  }));
+  await client.bindEntity(4, 'Eclaw_Office');
+  return client;
+}
+
+describe('EClawClient message delivery retries', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('retries transient channel message network failures', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const client = await boundClient(fetchMock);
+
+    fetchMock
+      .mockRejectedValueOnce(new Error('fetch failed'))
+      .mockResolvedValueOnce(jsonResponse(200, { success: true }));
+
+    const promise = client.sendMessage('ACK HC4abc', 'IDLE');
+    await vi.advanceTimersByTimeAsync(250);
+
+    await expect(promise).resolves.toEqual({ success: true });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('retries transient server starting responses', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    const client = await boundClient(fetchMock);
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(503, { success: false, message: 'Server starting up — please retry in a few seconds' }))
+      .mockResolvedValueOnce(jsonResponse(200, { success: true }));
+
+    const promise = client.sendMessage('MODEL_HEALTH MH4abc entity=#4', 'IDLE');
+    await vi.advanceTimersByTimeAsync(250);
+
+    await expect(promise).resolves.toEqual({ success: true });
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});

--- a/openclaw-channel-eclaw/test/webhook-handler.test.ts
+++ b/openclaw-channel-eclaw/test/webhook-handler.test.ts
@@ -5,12 +5,14 @@ import { setClient } from '../src/outbound.js';
 
 describe('createWebhookHandler', () => {
   afterEach(() => {
+    vi.useRealTimers();
     delete process.env.ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS;
     delete process.env.ECLAW_SKIP_KANBAN_NOTIFICATIONS;
     delete process.env.ECLAW_SUPPRESS_BACKGROUND_EVENTS;
   });
 
   it('acks healthcheck messages without dispatching agent work', async () => {
+    vi.useFakeTimers();
     const dispatchReplyWithBufferedBlockDispatcher = vi.fn();
     setPluginRuntime({
       channel: {
@@ -32,7 +34,7 @@ describe('createWebhookHandler', () => {
       end: vi.fn(),
     };
 
-    await handler({
+    const promise = handler({
       method: 'POST',
       body: {
         deviceId: 'device-1',
@@ -43,6 +45,11 @@ describe('createWebhookHandler', () => {
 
     expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'application/json' });
     expect(res.end).toHaveBeenCalledWith(JSON.stringify({ ok: true }));
+    expect(client.sendMessage).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(3000);
+    await promise;
+
     expect(client.sendMessage).toHaveBeenCalledWith('ACK abc_123-XYZ', 'IDLE');
     expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary
- add bounded retry for transient EClaw channel message delivery failures
- delay direct healthcheck ACK briefly so EClaw Received echo does not overwrite the final ACK state
- add coverage for retry and delayed direct ACK behavior

## Verification
- npm test -- --run in openclaw-channel-eclaw
- runtime sync to #1/#3/#4 extension dist
- monitor-eclaw-once.sh reached monitor_pass_after_repair
- browser UI ACK passed for #1/#3/#4