### PR TITLE
feat(chat): collapse 2 filter rows into 1 summary chip + popover panel

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -2866,6 +2866,7 @@
     <script src="https://cdn.jsdelivr.net/npm/dompurify/dist/purify.min.js"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/styles/github-dark.min.css">
     <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@11/build/highlight.min.js"></script>
+    <link rel="stylesheet" href="../shared/filter-summary.css">
 </head>
 
 <body>
@@ -2909,6 +2910,8 @@
                         <button type="button" data-density="comfortable" onclick="setChatDensity('comfortable')" title="Comfortable" data-i18n-title="chat_density_comfortable">A</button>
                     </div>
                 </div>
+                <div class="filter-summary-anchor" id="filterSummaryAnchor" style="position:relative;"></div>
+                <div class="filter-bar-legacy" id="filterBarLegacy">
                 <div class="chip-group-wrapper">
                     <div class="chip-group" id="filterChips">
                         <button class="filter-chip active" data-filter="all" onclick="setFilter('all')" data-i18n="chat_filter_all">All</button>
@@ -2927,6 +2930,7 @@
                         <button class="sys-chip" type="button" data-syscat="health" onclick="toggleSysCat('health')" data-i18n="chat_sys_health" title="健康 / Health">❤️ 健康</button>
                     </div>
                 </div>
+                </div><!-- /#filterBarLegacy — moved into filter-summary panel at boot -->
             </div>
 
             <!-- Messages Area -->
@@ -3188,6 +3192,7 @@
     <script src="../shared/avatar-petdx.js"></script>
     <script src="shared/entity-utils.js"></script>
     <script src="shared/chat-source-category.js"></script>
+    <script src="../shared/filter-summary.js"></script>
     <script src="shared/mention-autocomplete.js"></script>
     <script src="shared/mention-resolver.js"></script>
     <script src="shared/mention-render.js"></script>
@@ -3608,6 +3613,37 @@
             const user = await checkAuth();
             console.log('[CHAT_DEBUG] checkAuth result:', user ? `deviceId=${user.deviceId}, hasSecret=${!!user.deviceSecret}` : 'NULL');
             if (!user) return;
+
+            // ── Filter summary primitive — collapse 2 filter rows into 1 chip ──
+            // Spec: docs/specs/chat-page-filter-bar-collapse.md
+            try {
+                const anchor = document.getElementById('filterSummaryAnchor');
+                const legacy = document.getElementById('filterBarLegacy');
+                if (anchor && legacy && typeof createFilterSummary === 'function') {
+                    const sysCatDefault = { conversation: true, kanban: true, scheduled: true, platform: false, health: false };
+                    window.__filterSummary = createFilterSummary({
+                        anchorEl: anchor,
+                        panelContent: (panelEl) => { panelEl.appendChild(legacy); legacy.style.display = ''; },
+                        countActive: () => {
+                            let n = 0;
+                            const scope = document.querySelector('#filterChips .filter-chip.active');
+                            if (scope && scope.dataset.filter && scope.dataset.filter !== 'all') n++;
+                            document.querySelectorAll('#systemFilterChips .sys-chip').forEach(c => {
+                                const cat = c.dataset.syscat;
+                                const isActive = c.classList.contains('active');
+                                if (cat in sysCatDefault && sysCatDefault[cat] !== isActive) n++;
+                            });
+                            return n;
+                        },
+                        i18nKey: 'chat_filter',
+                    });
+                    // Refresh summary count whenever the user toggles anything inside the panel
+                    legacy.addEventListener('click', () => {
+                        try { setTimeout(() => window.__filterSummary && window.__filterSummary.refresh(), 0); } catch (e) {}
+                    }, true);
+                }
+            } catch (e) { console.warn('[chat] filter-summary init failed:', e); }
+
             // Hydrate sys-filter chip state from per-device localStorage
             // (key requires deviceId — see chat-source-category.storageKey).
             loadSysFilterFromStorage();

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3614,13 +3614,24 @@
             console.log('[CHAT_DEBUG] checkAuth result:', user ? `deviceId=${user.deviceId}, hasSecret=${!!user.deviceSecret}` : 'NULL');
             if (!user) return;
 
+            // Hydrate sys-filter chip state from per-device localStorage
+            // (key requires deviceId — see chat-source-category.storageKey).
+            loadSysFilterFromStorage();
+            applySysFilterChipState();
+
             // ── Filter summary primitive — collapse 2 filter rows into 1 chip ──
             // Spec: docs/specs/chat-page-filter-bar-collapse.md
+            // Init AFTER hydration so the initial count reflects the persisted state,
+            // not the markup defaults (per #1 Mac_F review on PR #3095).
             try {
                 const anchor = document.getElementById('filterSummaryAnchor');
                 const legacy = document.getElementById('filterBarLegacy');
                 if (anchor && legacy && typeof createFilterSummary === 'function') {
-                    const sysCatDefault = { conversation: true, kanban: true, scheduled: true, platform: false, health: false };
+                    // Read default set from chat-source-category.js so this stays in sync
+                    // if the smart-filter defaults ever change.
+                    const sysCatDefault = (window.ChatSourceCategory && window.ChatSourceCategory.DEFAULT_ACTIVE)
+                        ? window.ChatSourceCategory.DEFAULT_ACTIVE
+                        : { conversation: true, kanban: true, scheduled: true, platform: false, health: false };
                     window.__filterSummary = createFilterSummary({
                         anchorEl: anchor,
                         panelContent: (panelEl) => { panelEl.appendChild(legacy); legacy.style.display = ''; },
@@ -3637,17 +3648,27 @@
                         },
                         i18nKey: 'chat_filter',
                     });
-                    // Refresh summary count whenever the user toggles anything inside the panel
+                    // Refresh summary count whenever the user toggles anything inside the panel.
                     legacy.addEventListener('click', () => {
                         try { setTimeout(() => window.__filterSummary && window.__filterSummary.refresh(), 0); } catch (e) {}
                     }, true);
+                    // Wrap external entry points (chips outside the panel — e.g. the "{n} hidden" banner
+                    // calls enableAllSysCats() — so the summary count stays in sync.
+                    const _wrap = (name) => {
+                        const orig = window[name];
+                        if (typeof orig !== 'function') return;
+                        window[name] = function () {
+                            const r = orig.apply(this, arguments);
+                            try { window.__filterSummary && window.__filterSummary.refresh(); } catch (e) {}
+                            return r;
+                        };
+                    };
+                    _wrap('setFilter');
+                    _wrap('toggleSysCat');
+                    _wrap('enableAllSysCats');
                 }
             } catch (e) { console.warn('[chat] filter-summary init failed:', e); }
 
-            // Hydrate sys-filter chip state from per-device localStorage
-            // (key requires deviceId — see chat-source-category.storageKey).
-            loadSysFilterFromStorage();
-            applySysFilterChipState();
             initPortalSocket();
             initEnvVarBtn(user.deviceId, user.deviceSecret);
             await loadChatAvatarSizePreference();

--- a/backend/public/shared/filter-summary.css
+++ b/backend/public/shared/filter-summary.css
@@ -45,12 +45,15 @@
   display: none;
 }
 
-/* Overlay used on mobile only (backdrop behind bottom-sheet panel) */
+/* Overlay used on mobile only (backdrop behind bottom-sheet panel).
+ * z-index kept BELOW the shared showConfirm() .dialog-overlay (600) so a
+ * confirm popped while the filter sheet is open layers above it (#1 Mac_F
+ * review on PR #3095). */
 .eclaw-filter-summary__overlay {
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.35);
-  z-index: 9000;
+  z-index: 500;
 }
 
 .eclaw-filter-summary__overlay[hidden] {
@@ -69,7 +72,8 @@
   border: 1px solid var(--card-border, #d0d4dc);
   border-radius: 10px;
   box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
-  z-index: 9100;
+  /* Below showConfirm .dialog-overlay (600) so destructive confirms stack on top. */
+  z-index: 510;
   padding: 12px 14px 14px;
 }
 

--- a/backend/public/shared/filter-summary.css
+++ b/backend/public/shared/filter-summary.css
@@ -1,0 +1,137 @@
+/**
+ * filter-summary.css — paired styles for createFilterSummary()
+ * Spec: docs/specs/chat-page-filter-bar-collapse.md §2
+ * Z-index aligned with shared/api.js showConfirm overlay layer (PR #3088).
+ */
+
+.eclaw-filter-summary {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 12px;
+  border: 1px solid var(--card-border, #d0d4dc);
+  border-radius: 16px;
+  background: var(--bg, #fff);
+  color: var(--text, #222);
+  font-size: 14px;
+  cursor: pointer;
+  line-height: 1;
+}
+
+.eclaw-filter-summary:hover {
+  background: var(--card-bg-hover, #f5f6f8);
+}
+
+.eclaw-filter-summary.is-active {
+  border-color: var(--accent, #4a7dff);
+  color: var(--accent, #4a7dff);
+}
+
+.eclaw-filter-summary.is-active .eclaw-filter-summary__count {
+  color: var(--accent, #4a7dff);
+  font-weight: 600;
+}
+
+.eclaw-filter-summary__icon {
+  font-size: 14px;
+}
+
+.eclaw-filter-summary__label {
+  display: inline-block;
+}
+
+.eclaw-filter-summary__count[hidden] {
+  display: none;
+}
+
+/* Overlay used on mobile only (backdrop behind bottom-sheet panel) */
+.eclaw-filter-summary__overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.35);
+  z-index: 9000;
+}
+
+.eclaw-filter-summary__overlay[hidden] {
+  display: none;
+}
+
+/* Panel — desktop default: popover anchored under the chip */
+.eclaw-filter-summary__panel {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  min-width: 280px;
+  max-width: 480px;
+  background: var(--bg, #fff);
+  color: var(--text, #222);
+  border: 1px solid var(--card-border, #d0d4dc);
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
+  z-index: 9100;
+  padding: 12px 14px 14px;
+}
+
+.eclaw-filter-summary__panel[hidden] {
+  display: none;
+}
+
+/* Mobile (≤600px): full-width bottom-sheet */
+.eclaw-filter-summary__panel.is-mobile {
+  position: fixed;
+  top: auto;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  width: 100%;
+  max-width: none;
+  border-radius: 14px 14px 0 0;
+  padding: 14px 16px 20px;
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.eclaw-filter-summary__panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.eclaw-filter-summary__panel-title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+}
+
+.eclaw-filter-summary__close {
+  border: none;
+  background: transparent;
+  font-size: 18px;
+  color: var(--text, #222);
+  cursor: pointer;
+  line-height: 1;
+  padding: 4px 8px;
+}
+
+.eclaw-filter-summary__close::before {
+  content: '✕';
+}
+
+.eclaw-filter-summary__close:hover {
+  color: var(--accent, #4a7dff);
+}
+
+.eclaw-filter-summary__panel-body > * + * {
+  margin-top: 10px;
+}
+
+/* Respect reduced motion: no slide-in animation. (Default has none; this is a
+ * future guard if we add one.) */
+@media (prefers-reduced-motion: reduce) {
+  .eclaw-filter-summary__panel {
+    transition: none !important;
+    animation: none !important;
+  }
+}

--- a/backend/public/shared/filter-summary.js
+++ b/backend/public/shared/filter-summary.js
@@ -1,0 +1,194 @@
+/**
+ * filter-summary.js — summary-chip + collapsible panel primitive
+ * Spec: docs/specs/chat-page-filter-bar-collapse.md
+ *
+ * Lets a page show a single 36/32-px chip "Filters (n)" by default, and expand
+ * an anchored popover panel on tap/click. Chat is the first adopter; kanban /
+ * mission may adopt later by passing their own panelContent + countActive.
+ *
+ * Dependencies (loaded by the host page):
+ *   - shared/i18n.js (window.i18n.t)
+ *   - shared/filter-summary.css
+ */
+(function (root) {
+  'use strict';
+
+  const ZWS = '​';
+  let _seq = 0;
+
+  /**
+   * @param {Object} opts
+   * @param {HTMLElement} opts.anchorEl - container where the summary chip mounts.
+   * @param {(panelEl:HTMLElement)=>void} opts.panelContent - callback invoked once with the empty panel body; populate it with your existing chip groups.
+   * @param {()=>number} opts.countActive - returns the number of non-default selections; used for the count badge + active class.
+   * @param {string} opts.i18nKey - base key, e.g. "chat_filter". Looks up `${key}_summary_label`, `${key}_summary_count`, `${key}_summary_close`.
+   * @param {()=>void} [opts.onOpen]
+   * @param {()=>void} [opts.onClose]
+   * @returns {{open:Function, close:Function, refresh:Function, destroy:Function, panelEl:HTMLElement, summaryEl:HTMLElement, isOpen:()=>boolean}}
+   */
+  function createFilterSummary(opts) {
+    if (!opts || !opts.anchorEl) throw new Error('filter-summary: anchorEl is required');
+    if (typeof opts.panelContent !== 'function') throw new Error('filter-summary: panelContent must be a function');
+    if (typeof opts.countActive !== 'function') throw new Error('filter-summary: countActive must be a function');
+
+    const id = ++_seq;
+    const i18nKey = opts.i18nKey || 'filter';
+    const t = (suffix, fallback) => {
+      try {
+        const k = `${i18nKey}_summary_${suffix}`;
+        const v = root.i18n && typeof root.i18n.t === 'function' ? root.i18n.t(k) : null;
+        return v && v !== k ? v : fallback;
+      } catch (e) {
+        return fallback;
+      }
+    };
+
+    const labelText = t('label', 'Filters');
+    const countTemplate = t('count', 'Filters ({n})');
+    const closeAriaText = t('close', 'Close filter panel');
+
+    // Build summary chip
+    const summary = document.createElement('button');
+    summary.type = 'button';
+    summary.className = 'eclaw-filter-summary';
+    summary.id = `eclaw-filter-summary-${id}`;
+    summary.setAttribute('aria-haspopup', 'dialog');
+    summary.setAttribute('aria-expanded', 'false');
+    summary.innerHTML = `
+      <span class="eclaw-filter-summary__icon" aria-hidden="true">⛃</span>
+      <span class="eclaw-filter-summary__label"></span>
+      <span class="eclaw-filter-summary__count" aria-hidden="true"></span>
+    `;
+
+    // Build panel + overlay (mobile only; desktop uses pure popover)
+    const overlay = document.createElement('div');
+    overlay.className = 'eclaw-filter-summary__overlay';
+    overlay.hidden = true;
+
+    const panel = document.createElement('div');
+    panel.className = 'eclaw-filter-summary__panel';
+    panel.id = `eclaw-filter-summary-panel-${id}`;
+    panel.setAttribute('role', 'dialog');
+    panel.setAttribute('aria-modal', 'false');
+    panel.setAttribute('aria-labelledby', `eclaw-filter-summary-title-${id}`);
+    panel.hidden = true;
+
+    const panelHeader = document.createElement('div');
+    panelHeader.className = 'eclaw-filter-summary__panel-header';
+    panelHeader.innerHTML = `
+      <h2 class="eclaw-filter-summary__panel-title" id="eclaw-filter-summary-title-${id}"></h2>
+      <button type="button" class="eclaw-filter-summary__close" aria-label=""></button>
+    `;
+    const panelBody = document.createElement('div');
+    panelBody.className = 'eclaw-filter-summary__panel-body';
+    panel.appendChild(panelHeader);
+    panel.appendChild(panelBody);
+
+    // Mount: summary into anchorEl. overlay/panel into anchorEl as well (panel positioned relative to it).
+    opts.anchorEl.appendChild(summary);
+    opts.anchorEl.appendChild(overlay);
+    opts.anchorEl.appendChild(panel);
+
+    // Populate panel body once (host provides chip groups)
+    opts.panelContent(panelBody);
+
+    const labelEl = summary.querySelector('.eclaw-filter-summary__label');
+    const countEl = summary.querySelector('.eclaw-filter-summary__count');
+    const titleEl = panelHeader.querySelector('.eclaw-filter-summary__panel-title');
+    const closeBtn = panelHeader.querySelector('.eclaw-filter-summary__close');
+    titleEl.textContent = labelText;
+    closeBtn.setAttribute('aria-label', closeAriaText);
+
+    function setCountUI(n) {
+      labelEl.textContent = labelText;
+      if (n > 0) {
+        countEl.hidden = false;
+        // countTemplate looks like "Filters ({n})"; we only render the parenthesized part.
+        const tail = countTemplate.replace(/.*?(\(.*\)).*/, '$1').replace('{n}', String(n));
+        countEl.textContent = tail && tail !== countTemplate ? tail : `(${n})`;
+        summary.classList.add('is-active');
+      } else {
+        countEl.hidden = true;
+        countEl.textContent = '';
+        summary.classList.remove('is-active');
+      }
+    }
+
+    function refresh() {
+      const n = Number(opts.countActive()) || 0;
+      setCountUI(n);
+    }
+
+    let opened = false;
+    let lastFocus = null;
+
+    const isMobile = () => window.innerWidth <= 600;
+
+    function open() {
+      if (opened) return;
+      opened = true;
+      lastFocus = document.activeElement;
+      panel.hidden = false;
+      overlay.hidden = !isMobile();
+      summary.setAttribute('aria-expanded', 'true');
+      panel.classList.toggle('is-mobile', isMobile());
+      // Default focus on the close button (per spec PR #3088 safe-default-focus)
+      setTimeout(() => { try { closeBtn.focus({ preventScroll: true }); } catch (e) {} }, 0);
+      document.addEventListener('keydown', onKey, true);
+      document.addEventListener('mousedown', onOutsideMouse, true);
+      document.addEventListener('touchstart', onOutsideMouse, { capture: true, passive: true });
+      if (typeof opts.onOpen === 'function') opts.onOpen();
+    }
+
+    function close() {
+      if (!opened) return;
+      opened = false;
+      panel.hidden = true;
+      overlay.hidden = true;
+      summary.setAttribute('aria-expanded', 'false');
+      document.removeEventListener('keydown', onKey, true);
+      document.removeEventListener('mousedown', onOutsideMouse, true);
+      document.removeEventListener('touchstart', onOutsideMouse, { capture: true });
+      try { if (lastFocus && lastFocus.focus) lastFocus.focus({ preventScroll: true }); } catch (e) {}
+      lastFocus = null;
+      refresh();
+      if (typeof opts.onClose === 'function') opts.onClose();
+    }
+
+    function onKey(ev) {
+      if (ev.key === 'Escape') {
+        ev.stopPropagation();
+        close();
+      }
+    }
+    function onOutsideMouse(ev) {
+      if (panel.contains(ev.target)) return;
+      if (summary.contains(ev.target)) return;
+      close();
+    }
+
+    summary.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      if (opened) close(); else open();
+    });
+    closeBtn.addEventListener('click', (ev) => { ev.preventDefault(); close(); });
+
+    // Initial render
+    refresh();
+
+    return {
+      open, close, refresh,
+      destroy() {
+        close();
+        summary.remove();
+        overlay.remove();
+        panel.remove();
+      },
+      isOpen() { return opened; },
+      panelEl: panelBody,
+      summaryEl: summary,
+    };
+  }
+
+  root.createFilterSummary = createFilterSummary;
+})(typeof window !== 'undefined' ? window : globalThis);


### PR DESCRIPTION
## Summary
Implements the spec from PR #3090 (`docs/specs/chat-page-filter-bar-collapse.md`). Today `portal/chat.html` stacks two filter rows (entity scope + system-message categories) above the message area, eating ~96px of mobile vertical real estate even when defaults are active. This PR collapses both rows into a single summary chip ("Filters" / "Filters (n)") that opens an anchored popover panel containing the original two rows verbatim.

The chip-level UI is moved into a new shared primitive `createFilterSummary()` so kanban / mission / community can adopt later without re-implementing the wrapper.

## Changes
- **New** `backend/public/shared/filter-summary.{js,css}` — primitive (chip + popover/bottom-sheet panel, default focus on ✕, click-outside / Esc dismiss, aria-haspopup/expanded).
- **Edit** `backend/public/portal/chat.html`:
  - Mount `<div id="filterSummaryAnchor">` before the existing filter rows.
  - Wrap the existing `#filterChips` + `#systemFilterChips` rows in `#filterBarLegacy`; primitive moves this node into the panel at boot.
  - Refresh the count badge after any click inside the panel so the collapsed summary always reflects the applied filter.

## Acceptance covered by this PR
- [x] Spec §2.1 — Collapsed state shows a single chip with count badge; non-default selections set `.is-active`.
- [x] Spec §2.2 — Expanded state shows the original two chip rows verbatim; ✕ / outside-click / Esc dismiss.
- [x] Spec §2.3 — Primitive lives in `backend/public/shared/` with the documented API.
- [x] Spec §2.4 — Desktop popover (max-width 480px); mobile bottom-sheet (max-height 60vh).
- [x] Spec §3.1 — ✕ receives default focus per PR #3088 pattern.

## Acceptance follow-ups (tracked separately)
- [ ] Spec §3.2 — Manual screenshot diff at 390×844 / 1280×800 (will attach after running Playwright E2E).
- [ ] Spec §3.3 — i18n keys `chat_filter_summary_label` / `_count` / `_close` for all 13 locales. Primitive falls back to English strings if keys are missing, so this PR is shippable without; follow-up i18n card will be filed.
- [ ] Spec §3.4 — Static jest invariant test (same pattern as PR #3088's `showConfirm-danger-default-focus.test.js`). Follow-up card will be filed.

## Spec open questions (decisions taken in this PR)
1. Summary chip placement → **above** the messages area (per spec lean).
2. Panel animation → **none** in v1 (matches `prefers-reduced-motion`; spec left open).
3. Scope toggle (`All` / `My Messages`) → **inside the panel** (folded together with entity chips; spec proposal).
4. `#filterToggle` overflow chip → kept inside the panel; the panel scrolls vertically on mobile so the overflow indicator is unnecessary, but I left it in place to minimize footprint of this PR.
5. Count → single `Filters (n)` counter; not split into `(1) · Hidden (2)`.
6. Reset-filters link → not added in v1. Cheap to add later if a usage signal warrants it.

## Test plan
- [ ] Load `chat.html` on desktop 1280×800 — summary chip visible, panel closed, no count badge in default state.
- [ ] Toggle off `📋 看板` → summary chip count goes to (1) + becomes `.is-active`.
- [ ] Tap chip → panel opens; tap outside → panel closes; Esc → panel closes; ✕ → panel closes.
- [ ] Mobile 390×844 — chip + bottom-sheet panel; vertical savings ≥48px in default state.
- [ ] Confirm legacy filter behavior unchanged (`setFilter` / `toggleSysCat` still work inside the panel).

## Cards
- Implementation: card_caab8b826d45bf13d76e4216 (P1)
- Parent spec: card_11776d156c2bfd9c92ee81bf (PR #3090)

🤖 Generated with [Claude Code](https://claude.com/claude-code)