### PR TITLE
feat(chat): smart receiver auto-select on quote-reply

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -2132,6 +2132,20 @@
             user-select: none;
         }
 
+        .receiver-hint-auto {
+            display: inline-block;
+            margin-left: 4px;
+            padding: 1px 6px;
+            font-size: 10px;
+            line-height: 1.3;
+            color: var(--primary, #6C63FF);
+            background: rgba(108, 99, 255, 0.12);
+            border: 1px solid rgba(108, 99, 255, 0.45);
+            border-radius: 999px;
+            vertical-align: middle;
+            white-space: nowrap;
+        }
+
         .sched-target-chip input {
             margin: 0;
         }
@@ -3714,10 +3728,10 @@
                 const pq = localStorage.getItem('eclaw_pending_quote');
                 if (pq) {
                     localStorage.removeItem('eclaw_pending_quote');
-                    const { source, title, excerpt, prefillInput, messageId, ts } = JSON.parse(pq);
+                    const { source, title, excerpt, prefillInput, messageId, meta, ts } = JSON.parse(pq);
                     if (Date.now() - ts < 120000) { // within 2 minutes
                         await openChatMessageDeepLink(messageId, { showMissingToast: true, scroll: true });
-                        quoteToChat(source, title, excerpt || '');
+                        quoteToChat(source, title, excerpt || '', meta);
                         // prefillInput: drop a chip token (or any text) directly
                         // into the input so users can press send without typing.
                         // Used by mindmap chip 📌 引用 — delivers mindmap_<uuid>
@@ -3770,9 +3784,9 @@
             window.addEventListener('message', async (e) => {
                 if (e.origin !== window.location.origin) return;
                 if (!e.data || e.data.type !== 'eclaw_quote') return;
-                const { source, title, excerpt, prefillInput, messageId } = e.data;
+                const { source, title, excerpt, prefillInput, messageId, meta } = e.data;
                 await openChatMessageDeepLink(messageId, { showMissingToast: true, scroll: true });
-                quoteToChat(source, title, excerpt || '');
+                quoteToChat(source, title, excerpt || '', meta);
                 if (prefillInput) {
                     const inp = document.getElementById('messageInput');
                     if (inp) {
@@ -4277,12 +4291,24 @@
             persistTargetSelection();
         }
 
-        function updateTargetAll() {
+        function updateTargetAll(opts) {
             const allCb = document.querySelector('#targetAll input');
             const entityCbs = document.querySelectorAll('.target-entity-check input[type="checkbox"]');
             if (entityCbs.length === 0) return;
             const allChecked = Array.from(entityCbs).every(cb => cb.checked);
             allCb.checked = allChecked;
+            // Manual uncheck revokes that receiver's auto-select hint — keep
+            // the badge truthful: it only marks receivers we picked and the
+            // user kept. Still-checked auto-toggled entries keep their badge.
+            // applyAutoToggleReceivers passes skipHintClear when it just
+            // rendered the badges so we don't strip them on the same tick.
+            if (!(opts && opts.skipHintClear)) {
+                Array.from(entityCbs).forEach(cb => {
+                    if (cb.checked) return;
+                    const eid = parseInt(cb.dataset.entity, 10);
+                    if (Number.isFinite(eid)) clearReceiverHintForEntity(eid);
+                });
+            }
             persistTargetSelection();
         }
 
@@ -5469,7 +5495,14 @@
 
                 const replySnippet = stripReplyQuotePrefix(rawText || '').replace(/\n/g, ' ').slice(0, 120);
                 const replySenderName = isSent ? (i18n.t('chat_reply_you') || 'You') : isPlatform ? 'Platform' : (getEntityLabel(msg.entity_id) || '');
-                const replyBtnHtml = (!isSystem && msg.id) ? `<button class="chat-reply-btn" data-msg-id="${escapeHtml(msg.id)}" data-sender="${escapeHtml(replySenderName)}" data-text="${escapeHtml(replySnippet)}" onclick="handleReplyBtn(this);event.stopPropagation()" data-i18n-title="chat_reply_btn" title="Quote">📌</button>` : '';
+                // Smart receiver hint: a quote of a bot message should pre-
+                // toggle the sender entity on the target bar. Self (web_chat)
+                // and platform/system messages stay neutral.
+                const receiverKind = isSent ? 'self' : isPlatform ? 'system' : 'entity';
+                const receiverEntityAttr = (receiverKind === 'entity' && Number.isFinite(msg.entity_id))
+                    ? ` data-receiver-entity-id="${msg.entity_id}"`
+                    : '';
+                const replyBtnHtml = (!isSystem && msg.id) ? `<button class="chat-reply-btn" data-msg-id="${escapeHtml(msg.id)}" data-sender="${escapeHtml(replySenderName)}" data-text="${escapeHtml(replySnippet)}" data-receiver-kind="${receiverKind}"${receiverEntityAttr} onclick="handleReplyBtn(this);event.stopPropagation()" data-i18n-title="chat_reply_btn" title="Quote">📌</button>` : '';
                 const renderedMessageIds = getRenderedMessageIds(msg);
                 const renderedIdsAttr = escapeHtml(renderedMessageIds.join(' '));
 
@@ -6055,12 +6088,23 @@
 
         // ── Quote Reply State ──
         let replyContext = null;
+        // Smart receiver auto-select — entityIds we auto-toggled-on for the
+        // current reply context. Cleared on reply clear, on send, and when
+        // the user manually changes a checkbox (the hint badge belongs to
+        // the auto-toggle, so a manual toggle revokes it).
+        const autoToggledReceiverEntities = new Set();
 
         function handleReplyBtn(btn) {
             const msgId = btn.dataset.msgId;
             const sender = btn.dataset.sender;
             const text = btn.dataset.text;
+            const kind = btn.dataset.receiverKind || '';
+            const entityId = parseInt(btn.dataset.receiverEntityId, 10);
+            const meta = (kind === 'entity' && Number.isFinite(entityId))
+                ? { kind: 'chat-entity', entityId }
+                : { kind: 'chat-system' };
             setReplyContext(msgId, sender, text);
+            applyAutoToggleReceivers(meta);
         }
 
         function setReplyContext(msgId, senderName, text) {
@@ -6075,13 +6119,65 @@
         function clearReplyContext() {
             replyContext = null;
             document.getElementById('replyPreviewBar').classList.remove('show');
+            clearAllReceiverHints();
         }
 
-        // Smart quote: activates the reply bar with source+excerpt, no full-content paste
-        function quoteToChat(source, title, excerpt) {
+        // Smart quote: activates the reply bar with source+excerpt, no full-content paste.
+        // meta carries origin info for smart receiver auto-select:
+        //   { kind: 'card', cardAssignedBots: number[] }    — kanban card → toggle assigned bots
+        //   { kind: 'chat-entity', entityId: number }       — chat msg from a bot → toggle that bot
+        //   { kind: 'chat-system' | other }                 — no auto-toggle
+        // Multi-source rule: chat-entity wins over card (resolved at the caller).
+        function quoteToChat(source, title, excerpt, meta) {
             const senderLabel = '📌 ' + source;
             const previewText = title + (excerpt ? ': ' + excerpt.slice(0, 60) + (excerpt.length > 60 ? '…' : '') : '');
             setReplyContext(null, senderLabel, previewText);
+            applyAutoToggleReceivers(meta || {});
+        }
+
+        function applyAutoToggleReceivers(meta) {
+            clearAllReceiverHints();
+            if (!meta || typeof meta !== 'object') return;
+            let entityIds = [];
+            if (meta.kind === 'chat-entity' && Number.isFinite(meta.entityId)) {
+                entityIds = [meta.entityId];
+            } else if (meta.kind === 'card' && Array.isArray(meta.cardAssignedBots)) {
+                entityIds = meta.cardAssignedBots.filter(id => Number.isFinite(id));
+            } else {
+                return;
+            }
+            const hintLabel = (i18n && typeof i18n.t === 'function' && i18n.t('chat_receiver_hint_auto')) || 'auto';
+            entityIds.forEach(eid => {
+                const cb = document.querySelector('.target-entity-check input[type="checkbox"][data-entity="' + eid + '"]');
+                if (!cb) return;
+                if (!cb.checked) cb.checked = true;
+                const label = cb.closest('.target-entity-check');
+                if (label && !label.querySelector('.receiver-hint-auto')) {
+                    const badge = document.createElement('span');
+                    badge.className = 'receiver-hint-auto';
+                    badge.setAttribute('data-i18n', 'chat_receiver_hint_auto');
+                    badge.textContent = hintLabel;
+                    label.appendChild(badge);
+                }
+                autoToggledReceiverEntities.add(eid);
+            });
+            if (typeof persistTargetSelection === 'function') persistTargetSelection();
+            if (typeof updateTargetAll === 'function') updateTargetAll({ skipHintClear: true });
+        }
+
+        function clearReceiverHintForEntity(entityId) {
+            if (!autoToggledReceiverEntities.has(entityId)) return;
+            const label = document.querySelector('.target-entity-check[data-entity-id="' + entityId + '"]');
+            if (label) {
+                const badge = label.querySelector('.receiver-hint-auto');
+                if (badge) badge.remove();
+            }
+            autoToggledReceiverEntities.delete(entityId);
+        }
+
+        function clearAllReceiverHints() {
+            document.querySelectorAll('.target-entity-check .receiver-hint-auto').forEach(b => b.remove());
+            autoToggledReceiverEntities.clear();
         }
 
         function fileMsgText(index, file, text) {

--- a/backend/tests/jest/chat-kanban-message-deeplink-static.test.js
+++ b/backend/tests/jest/chat-kanban-message-deeplink-static.test.js
@@ -37,7 +37,7 @@ describe('chat message deep-link plumbing', () => {
     test('chat page opens messageId deep-links from query, quotes, and native intents', () => {
         expect(chatHtml).toContain('async function openChatMessageDeepLink(messageId, { showMissingToast = true, scroll = true } = {})');
         expect(chatHtml).toContain("url.searchParams.set('messageId', id);");
-        expect(chatHtml).toContain('const { source, title, excerpt, prefillInput, messageId, ts } = JSON.parse(pq);');
+        expect(chatHtml).toContain('const { source, title, excerpt, prefillInput, messageId, meta, ts } = JSON.parse(pq);');
         expect(chatHtml).toContain('await openChatMessageDeepLink(messageId, { showMissingToast: true, scroll: true });');
         expect(chatHtml).toContain('const msgId = intent.messageId || quote.messageId');
         expect(chatHtml).toContain("quoteToChat(quote.source || '引用', quote.title || '', quote.excerpt || '');");

--- a/backend/tests/jest/chat-quote-smart-receiver.test.js
+++ b/backend/tests/jest/chat-quote-smart-receiver.test.js
@@ -1,0 +1,392 @@
+/**
+ * Static invariant + behavioural test for the chat quote-reply smart
+ * receiver auto-select feature.
+ *
+ * Card: card_5ff6515064f18e25295a5a14.
+ * Spec: when the user quote-replies in chat.html, receiver checkbox(es)
+ * are auto-prefilled based on the source of the quoted context:
+ *   - Quote from a kanban card → assignedBots are toggled on
+ *   - Quote from a chat msg sent by an entity → sender entity toggled on
+ *   - Quote from a system / web_chat msg → no auto-toggle
+ *   - Multi-source: chat-entity wins over card
+ *   - Auto-toggled chips show a 「auto」 hint badge; manual uncheck removes
+ *     the badge for the receiver that was unchecked
+ *
+ * jest.config.js uses testEnvironment: 'node' with no jsdom, so we mirror
+ * the pattern used in filter-summary-invariant.test.js: lock the surface
+ * with regex contracts against the live source, and exercise the auto-
+ * toggle logic by extracting its body and running it against a hand-rolled
+ * DOM stub. Any future edit that drifts away from the contract leaves a
+ * regression fingerprint here.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const chatHtml = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'portal', 'chat.html'),
+    'utf8'
+);
+const kanbanHtml = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'portal', 'kanban.html'),
+    'utf8'
+);
+const i18nJs = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'shared', 'i18n.js'),
+    'utf8'
+);
+
+describe('chat quote-reply smart receiver — chat.html surface', () => {
+    test('quoteToChat accepts a 4th meta arg', () => {
+        expect(chatHtml).toMatch(
+            /function\s+quoteToChat\s*\(\s*source\s*,\s*title\s*,\s*excerpt\s*,\s*meta\s*\)/
+        );
+    });
+
+    test('applyAutoToggleReceivers dispatches on meta.kind for card / chat-entity', () => {
+        expect(chatHtml).toMatch(/function\s+applyAutoToggleReceivers\s*\(\s*meta\s*\)/);
+        // Both code paths must be present so neither rule silently drops
+        // (a regex match keeps both branches honest).
+        expect(chatHtml).toMatch(/meta\.kind\s*===\s*['"]chat-entity['"]/);
+        expect(chatHtml).toMatch(/meta\.kind\s*===\s*['"]card['"]/);
+        expect(chatHtml).toMatch(/meta\.cardAssignedBots/);
+    });
+
+    test('hint badge is rendered with .receiver-hint-auto + data-i18n="chat_receiver_hint_auto"', () => {
+        expect(chatHtml).toMatch(/badge\.className\s*=\s*['"]receiver-hint-auto['"]/);
+        expect(chatHtml).toMatch(/badge\.setAttribute\(\s*['"]data-i18n['"]\s*,\s*['"]chat_receiver_hint_auto['"]\s*\)/);
+        // The badge must hang off the entity checkbox container so it
+        // travels with the chip when the target bar re-renders.
+        expect(chatHtml).toMatch(/label\.appendChild\(\s*badge\s*\)/);
+    });
+
+    test('reply button on chat bubbles carries data-receiver-kind + data-receiver-entity-id', () => {
+        expect(chatHtml).toMatch(/data-receiver-kind="\$\{receiverKind\}"/);
+        expect(chatHtml).toMatch(/data-receiver-entity-id="\$\{msg\.entity_id\}"/);
+        // The kind must split sent / platform / entity so self+system
+        // messages cannot accidentally toggle a receiver.
+        expect(chatHtml).toMatch(/isSent\s*\?\s*['"]self['"]/);
+        expect(chatHtml).toMatch(/isPlatform\s*\?\s*['"]system['"]/);
+    });
+
+    test('handleReplyBtn forwards receiver-kind/receiver-entity-id into meta', () => {
+        expect(chatHtml).toMatch(/btn\.dataset\.receiverKind/);
+        expect(chatHtml).toMatch(/btn\.dataset\.receiverEntityId/);
+        expect(chatHtml).toMatch(
+            /kind\s*===\s*['"]entity['"]\s*&&\s*Number\.isFinite\(\s*entityId\s*\)/
+        );
+        // chat-entity is what applyAutoToggleReceivers branches on, so the
+        // mapping reply-btn-kind:'entity' → meta.kind:'chat-entity' is the
+        // load-bearing contract.
+        expect(chatHtml).toMatch(/kind:\s*['"]chat-entity['"]/);
+        expect(chatHtml).toMatch(/kind:\s*['"]chat-system['"]/);
+    });
+
+    test('localStorage and cross-iframe pickup forward the meta param', () => {
+        // pending_quote pickup at first-load
+        expect(chatHtml).toMatch(
+            /const\s*\{\s*source,\s*title,\s*excerpt,\s*prefillInput,\s*messageId,\s*meta,\s*ts\s*\}\s*=\s*JSON\.parse\(pq\)/
+        );
+        expect(chatHtml).toMatch(/quoteToChat\(\s*source,\s*title,\s*excerpt\s*\|\|\s*['"]['"]\s*,\s*meta\s*\)/);
+        // workspace.html postMessage relay
+        expect(chatHtml).toMatch(
+            /const\s*\{\s*source,\s*title,\s*excerpt,\s*prefillInput,\s*messageId,\s*meta\s*\}\s*=\s*e\.data/
+        );
+    });
+
+    test('manual uncheck revokes the hint via updateTargetAll', () => {
+        // updateTargetAll loops checkboxes and clears the hint of any
+        // entity that became unchecked. skipHintClear is honoured so the
+        // initial render doesn't strip its own freshly-rendered badge.
+        expect(chatHtml).toMatch(/function\s+updateTargetAll\s*\(\s*opts\s*\)/);
+        expect(chatHtml).toMatch(/opts\s*&&\s*opts\.skipHintClear/);
+        expect(chatHtml).toMatch(/clearReceiverHintForEntity\(\s*eid\s*\)/);
+    });
+
+    test('clearReplyContext also clears all hints (no orphan badges after Cancel)', () => {
+        const m = chatHtml.match(/function\s+clearReplyContext\s*\(\)\s*\{[\s\S]{0,400}?\}/);
+        expect(m).not.toBeNull();
+        expect(m[0]).toMatch(/clearAllReceiverHints\(\)/);
+    });
+});
+
+describe('chat quote-reply smart receiver — kanban.html senders', () => {
+    test('quoteToChat relays opts.meta into the postMessage / localStorage payload', () => {
+        expect(kanbanHtml).toMatch(/if\s*\(\s*opts\.meta\s*&&\s*typeof\s+opts\.meta\s*===\s*['"]object['"]\s*\)\s*quote\.meta\s*=\s*opts\.meta/);
+    });
+
+    test('quoteKanbanCardToChat passes kind:"card" + cardAssignedBots from card.assignedBots', () => {
+        // Must read card.assignedBots (not card.assignedEntityIds — see
+        // memory kanban_post_card_shape) and pass them as cardAssignedBots.
+        expect(kanbanHtml).toMatch(/card\.assignedBots/);
+        expect(kanbanHtml).toMatch(/kind:\s*['"]card['"]/);
+        expect(kanbanHtml).toMatch(/cardAssignedBots:\s*assignedBots/);
+    });
+
+    test('quoteCommentToChat: chat-entity wins over surrounding card (multi-source rule)', () => {
+        // The function must check senderEntityId FIRST, then fall back to
+        // card.assignedBots. The order is the test — if it ever flips, the
+        // multi-source rule silently regresses.
+        const fnMatch = kanbanHtml.match(
+            /function\s+quoteCommentToChat\([\s\S]*?\}\s*\n\s*\n/
+        );
+        expect(fnMatch).not.toBeNull();
+        const body = fnMatch[0];
+        const entityIdx = body.search(/kind:\s*['"]chat-entity['"]/);
+        const cardIdx = body.search(/kind:\s*['"]card['"]/);
+        expect(entityIdx).toBeGreaterThan(-1);
+        expect(cardIdx).toBeGreaterThan(-1);
+        expect(entityIdx).toBeLessThan(cardIdx);
+    });
+});
+
+describe('chat_receiver_hint_auto — i18n key parity across 12 locales', () => {
+    // Italian (it) is intentionally out of scope: i18n.js does not have an
+    // it-locale block yet. en/zh-TW/zh/ja/ko/es/pt/fr/de/vi/th/id are the
+    // 12 locales the dispatch covers minus it.
+    const EXPECTED = {
+        en: 'auto',
+        zh: '自动',
+        'zh-TW': '自動',
+        ja: '自動',
+        ko: '자동',
+        th: 'อัตโนมัติ',
+        vi: 'tự động',
+        id: 'otomatis',
+        fr: 'auto',
+        es: 'auto',
+        de: 'auto',
+        pt: 'auto',
+    };
+
+    // Build locale-block index by locating each `<name>:` opener and using
+    // the next opener (or EOF) as the upper bound. We then scan only the
+    // slice that belongs to the locale for its translation.
+    const LOCALE_RE = /^(\s*)("?(en|zh|zh-TW|ja|ko|th|vi|id|fr|es|de|pt|ms|hi|ar)"?):\s*\{\s*$/gm;
+    const matches = [];
+    let m;
+    while ((m = LOCALE_RE.exec(i18nJs)) !== null) {
+        matches.push({ name: m[3], start: m.index });
+    }
+    matches.sort((a, b) => a.start - b.start);
+    const blocks = {};
+    matches.forEach((entry, i) => {
+        const end = i + 1 < matches.length ? matches[i + 1].start : i18nJs.length;
+        blocks[entry.name] = i18nJs.slice(entry.start, end);
+    });
+
+    Object.entries(EXPECTED).forEach(([locale, expected]) => {
+        test(`${locale} → "${expected}"`, () => {
+            const block = blocks[locale];
+            expect(block).toBeDefined();
+            const re = new RegExp(
+                '"chat_receiver_hint_auto"\\s*:\\s*"' +
+                    expected.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') +
+                    '"'
+            );
+            expect(block).toMatch(re);
+        });
+    });
+});
+
+describe('applyAutoToggleReceivers — behaviour against a hand-rolled DOM stub', () => {
+    // jest.config.js uses testEnvironment:'node' with no jsdom. We extract
+    // the function bodies from chat.html, evaluate them inside a tiny
+    // document-like shim, and exercise the three spec cases. This gives us
+    // a behavioural assertion without pulling in a new dep.
+    function makeStubDocument(entityIds) {
+        const labels = entityIds.map(eid => {
+            const cb = {
+                type: 'checkbox',
+                checked: false,
+                dataset: { entity: String(eid) },
+            };
+            const label = {
+                dataset: { entityId: String(eid) },
+                _children: [],
+                _classNames: ['target-check', 'target-entity-check'],
+                className: 'target-check target-entity-check',
+                _input: cb,
+                appendChild(node) {
+                    node._parent = this;
+                    this._children.push(node);
+                },
+                querySelector(sel) {
+                    if (sel.includes('receiver-hint-auto')) {
+                        return this._children.find(c => c.className === 'receiver-hint-auto') || null;
+                    }
+                    return null;
+                },
+                closest(sel) {
+                    if (
+                        sel === '.target-entity-check' ||
+                        sel === '.target-check'
+                    ) {
+                        return this;
+                    }
+                    return null;
+                },
+            };
+            cb.closest = (sel) => label.closest(sel);
+            return label;
+        });
+
+        const all = labels.map(l => l._input);
+        return {
+            labels,
+            querySelector(sel) {
+                const m = sel.match(/\[data-entity="(\d+)"\]/);
+                if (m) {
+                    const cb = all.find(c => c.dataset.entity === m[1]);
+                    return cb || null;
+                }
+                const m2 = sel.match(/\[data-entity-id="(\d+)"\]/);
+                if (m2) {
+                    return labels.find(l => l.dataset.entityId === m2[1]) || null;
+                }
+                return null;
+            },
+            querySelectorAll(sel) {
+                if (sel.includes('receiver-hint-auto')) {
+                    const out = [];
+                    labels.forEach(l => {
+                        l._children
+                            .filter(c => c.className === 'receiver-hint-auto')
+                            .forEach(c => out.push(c));
+                    });
+                    return out;
+                }
+                if (sel.includes('target-entity-check') && sel.includes('input')) {
+                    return all;
+                }
+                return [];
+            },
+            createElement(tag) {
+                const node = {
+                    tagName: tag.toUpperCase(),
+                    className: '',
+                    textContent: '',
+                    _attrs: {},
+                    _parent: null,
+                    setAttribute(k, v) { this._attrs[k] = v; },
+                    remove() {
+                        if (this._parent && Array.isArray(this._parent._children)) {
+                            const idx = this._parent._children.indexOf(this);
+                            if (idx >= 0) this._parent._children.splice(idx, 1);
+                        }
+                    },
+                };
+                return node;
+            },
+        };
+    }
+
+    function extractFunction(name) {
+        const re = new RegExp(
+            `function\\s+${name}\\s*\\([^)]*\\)\\s*\\{`,
+            'g'
+        );
+        const m = re.exec(chatHtml);
+        if (!m) throw new Error(`function ${name} not found`);
+        // Walk braces from the opening `{` until they balance.
+        let depth = 1;
+        let i = m.index + m[0].length;
+        while (i < chatHtml.length && depth > 0) {
+            const ch = chatHtml[i];
+            if (ch === '{') depth++;
+            else if (ch === '}') depth--;
+            i++;
+        }
+        return chatHtml.slice(m.index, i);
+    }
+
+    // Build a sandbox with the three functions we need + a stub document.
+    function makeSandbox(entityIds) {
+        const stubDoc = makeStubDocument(entityIds);
+        const sandbox = {
+            document: stubDoc,
+            autoToggledReceiverEntities: new Set(),
+            i18n: { t: (k) => (k === 'chat_receiver_hint_auto' ? 'auto' : null) },
+            persistTargetSelection: () => {},
+            updateTargetAll: () => {},
+        };
+        // applyAutoToggleReceivers reads/writes autoToggledReceiverEntities,
+        // calls i18n.t, document.querySelector, etc. clearAllReceiverHints
+        // is invoked at the top, and clearReceiverHintForEntity is the
+        // companion. Extract all three.
+        const body =
+            extractFunction('applyAutoToggleReceivers') +
+            '\n' +
+            extractFunction('clearAllReceiverHints') +
+            '\n' +
+            extractFunction('clearReceiverHintForEntity');
+        // Wrap so the sandbox keys behave like free variables.
+        const fn = new Function(
+            'document',
+            'autoToggledReceiverEntities',
+            'i18n',
+            'persistTargetSelection',
+            'updateTargetAll',
+            `${body}\nreturn { applyAutoToggleReceivers, clearAllReceiverHints, clearReceiverHintForEntity };`
+        );
+        const api = fn(
+            sandbox.document,
+            sandbox.autoToggledReceiverEntities,
+            sandbox.i18n,
+            sandbox.persistTargetSelection,
+            sandbox.updateTargetAll
+        );
+        return { sandbox, api };
+    }
+
+    test('card source → each entity in cardAssignedBots is toggled on + badged', () => {
+        const { sandbox, api } = makeSandbox([1, 2, 3]);
+        api.applyAutoToggleReceivers({ kind: 'card', cardAssignedBots: [1, 3] });
+        const cb1 = sandbox.document.querySelector('[data-entity="1"]');
+        const cb2 = sandbox.document.querySelector('[data-entity="2"]');
+        const cb3 = sandbox.document.querySelector('[data-entity="3"]');
+        expect(cb1.checked).toBe(true);
+        expect(cb2.checked).toBe(false);
+        expect(cb3.checked).toBe(true);
+        const badges = sandbox.document.querySelectorAll('.receiver-hint-auto');
+        expect(badges.length).toBe(2);
+    });
+
+    test('chat-entity source → only the sender entity is toggled', () => {
+        const { sandbox, api } = makeSandbox([1, 5, 7]);
+        api.applyAutoToggleReceivers({ kind: 'chat-entity', entityId: 5 });
+        expect(sandbox.document.querySelector('[data-entity="1"]').checked).toBe(false);
+        expect(sandbox.document.querySelector('[data-entity="5"]').checked).toBe(true);
+        expect(sandbox.document.querySelector('[data-entity="7"]').checked).toBe(false);
+        const badges = sandbox.document.querySelectorAll('.receiver-hint-auto');
+        expect(badges.length).toBe(1);
+    });
+
+    test('chat-system source → no toggle, no badge', () => {
+        const { sandbox, api } = makeSandbox([1, 2]);
+        api.applyAutoToggleReceivers({ kind: 'chat-system' });
+        expect(sandbox.document.querySelector('[data-entity="1"]').checked).toBe(false);
+        expect(sandbox.document.querySelector('[data-entity="2"]').checked).toBe(false);
+        const badges = sandbox.document.querySelectorAll('.receiver-hint-auto');
+        expect(badges.length).toBe(0);
+    });
+
+    test('empty / undefined meta → no-op', () => {
+        const { sandbox, api } = makeSandbox([1, 2]);
+        api.applyAutoToggleReceivers(undefined);
+        api.applyAutoToggleReceivers({});
+        api.applyAutoToggleReceivers({ kind: 'card' }); // missing cardAssignedBots
+        expect(sandbox.document.querySelector('[data-entity="1"]').checked).toBe(false);
+        expect(sandbox.document.querySelector('[data-entity="2"]').checked).toBe(false);
+        expect(sandbox.document.querySelectorAll('.receiver-hint-auto').length).toBe(0);
+    });
+
+    test('clearReceiverHintForEntity removes the badge for that entity', () => {
+        const { sandbox, api } = makeSandbox([1, 2]);
+        api.applyAutoToggleReceivers({ kind: 'card', cardAssignedBots: [1, 2] });
+        expect(sandbox.document.querySelectorAll('.receiver-hint-auto').length).toBe(2);
+        api.clearReceiverHintForEntity(1);
+        expect(sandbox.document.querySelectorAll('.receiver-hint-auto').length).toBe(1);
+    });
+});


### PR DESCRIPTION
## Summary
- When a user quote-replies in chat.html, receiver checkbox(es) are auto-prefilled based on the source of the quoted context: kanban-card → `card.assignedBots`, chat msg from a bot → sender `entityId`, system/web_chat → no toggle.
- Multi-source: chat-entity wins over card (resolved at the caller in `quoteCommentToChat`).
- Each auto-toggled chip gets a 「auto」 hint badge; manually unchecking a chip removes the badge only for the receiver that was unchecked.

Card: card_5ff6515064f18e25295a5a14
Dispatch: U91 (re-created from `/tmp/u91_dispatch.txt` after the original card id was not found in prod)

## Files
- `backend/public/portal/chat.html` — `.receiver-hint-auto` CSS pill + `applyAutoToggleReceivers` / `clearReceiverHintForEntity` / `clearAllReceiverHints`, `quoteToChat(source,title,excerpt,meta)` extended, reply button now carries `data-receiver-kind` + `data-receiver-entity-id`, `updateTargetAll(opts)` revokes hints on manual uncheck, postMessage + localStorage pickup forward `meta`.
- `backend/tests/jest/chat-quote-smart-receiver.test.js` (new) — 28 cases: surface invariants on chat.html + kanban.html, 12-locale i18n parity, plus a hand-rolled DOM stub that exercises `card`/`chat-entity`/`chat-system`/empty meta + hint-clear.
- `backend/tests/jest/chat-kanban-message-deeplink-static.test.js` — locked destructure now includes the new `meta` field.

The kanban sender additions (`quoteKanbanCardToChat` + `quoteCommentToChat` smart-meta) and the 12-locale `chat_receiver_hint_auto` key landed in main already via PR #3103 (piggybacked on the interactive-dev tab commit; see the `eclaw_worktree_concurrent_agent_collision` memory). This PR ships the receiving side in chat.html + the regression tests.

## Test plan
- [x] `npx jest tests/jest/chat-quote-smart-receiver.test.js` — 28/28 pass
- [x] `npx jest tests/jest/chat-kanban-message-deeplink-static.test.js` — 3/3 pass (locked destructure updated)
- [x] `npx jest tests/jest/i18n-syntax.test.js` — 12/12 pass
- [x] `node backend/scripts/i18n-check.js` — `chat_receiver_hint_auto` resolves; pre-existing `chat_sys_*` gap unrelated
- [x] `npm run lint` — clean (2 pre-existing warnings outside this PR)
- [x] Full `npx jest` — 3423 pass, 1 pre-existing failure (`showConfirm-a11y-attrs.test.js` line 41 — confirmed failing on main without my changes)
- [ ] Playwright mobile 390×844 + desktop 1280×800 — deferred to post-deploy prod verification (the jest DOM-stub covers the three spec cases + hint-clear)

## Code review — PR self-review

### Core
- A1. Logic trace: quote source → caller builds `meta:{kind, …}` → `quoteToChat` forwards to `setReplyContext` + `applyAutoToggleReceivers` → matching entity checkboxes toggled on + `.receiver-hint-auto` badge appended → `updateTargetAll(opts)` revokes the badge for any chip the user manually unchecks.
- A2. Test coverage: `tests/jest/chat-quote-smart-receiver.test.js` 28 cases (surface + i18n + DOM-stub behaviour); `tests/jest/chat-kanban-message-deeplink-static.test.js` updated.
- A3. Return shape: no API change; UI-only feature. `meta` is purely additive on the postMessage / localStorage payload — old senders that omit it stay no-op.
- A4. What this does NOT fix: `it` Italian locale is out of scope — i18n.js has no `it` block; adding the locale is a separate effort. Other quote senders (community, card-holder, files, mindmap notes) intentionally do NOT pass meta because their sources don't map to a receiver entity per spec.
- A5. Security: postMessage handler still enforces `e.origin === window.location.origin` (unchanged); no new fetch / DOM injection paths.

### Extended
- B1. /api/help: ⚠️ NO-OP — UI-only change, no new REST endpoint.
- B2. Related docs: ⚠️ NO-OP — feature spec is captured on `card_5ff6515064f18e25295a5a14`; no architecture / contract doc affected.
- B3. i18n: ✅ `chat_receiver_hint_auto` added × 12 locales (en/zh-TW/zh/ja/ko/es/pt/fr/de/vi/th/id) via PR #3103. `it` deferred — see A4.
- B4. Info/promo page: ⚠️ NO-OP — chat-internal UX, not surfaced on marketing pages.
- B5. Debug endpoint: ⚠️ NO-OP — pure client-side state, no DB writes, no security-sensitive logic.

Result: merge-ready

🤖 Generated with [Claude Code](https://claude.com/claude-code)