### PR TITLE
docs(specs): chat-page-filter-bar-collapse — clarify collapse covers BOTH chip rows

### DIFF
--- a/docs/specs/chat-page-filter-bar-collapse.md
+++ b/docs/specs/chat-page-filter-bar-collapse.md
@@ -16,6 +16,8 @@ Today `portal/chat.html` stacks **two** filter rows directly above the message a
 [ 💬 對話 ] [ 📋 看板 ] [ ⏰ 排程 ] [ 🔧 系統 ] [ ❤️ 健康 ]      ←  #systemFilterChips (smart filter)
 ```
 
+**Both rows are eligible for collapse in v1.** The summary-chip + panel primitive defined in §2 hides both `#filterChips` and `#systemFilterChips` in the collapsed state; neither row is treated as a privileged always-visible affordance. This was the source of a 2026-06-03 ambiguity reported by Hank from the prod chat page — see §2.1 for the explicit hidden-set.
+
 On desktop the rows wrap; on mobile each row is a horizontal scroll with a fade-out + `#filterToggle` overflow indicator. Together they occupy ~96px of vertical space on mobile (≈11% of a 390×844 viewport) just to expose controls the user touches rarely after the first read.
 
 User pain reported by Hank: 「目前看起來散亂」. Concrete UX failures:
@@ -47,6 +49,8 @@ Introduce a **summary-chip + popover panel** primitive in `backend/public/shared
 - `(3)` text comes from `data-i18n="chat_filter_summary_count"` so locales can render it idiomatically.
 - Clicking / tapping opens the expanded panel.
 - Long-press on mobile opens the panel and announces it via `aria-live` for screen readers.
+
+**Hidden in this state:** both `#filterChips` (entity scope row) **AND** `#systemFilterChips` (smart-filter row). The summary chip is the **sole visible filter affordance** in the collapsed state — no chip row peeks out, no partial-row reveal, no smart-filter row left always-visible as a "primary" affordance. If either row is visible while the summary chip is rendered, the collapse has regressed. (2026-06-03 clarification — earlier wireframe drafts only showed the panel-side payload, leaving room to read the smart-filter row as "out of collapse scope". It is not.)
 
 ### 2.2 Expanded state (panel)
 
@@ -158,7 +162,7 @@ Mobile reuses the existing `.scroll-to-bottom-btn` z-index layer; popover uses t
 
 ## 6. Rollback
 
-The primitive is gated behind a single import in chat.html; reverting the integration commit removes the summary chip and restores the original two-row layout. No DB or backend changes; no data migration.
+The primitive is gated behind a single import in chat.html; reverting the integration commit removes the summary chip and restores the original two-row layout. **Reverting the integration commit restores BOTH rows to their always-visible state** — `#filterChips` and `#systemFilterChips` both go back to always-rendered above the message area, identical to the pre-PR layout. No partial-collapse fallback state exists; rollback is all-or-nothing. No DB or backend changes; no data migration.
 
 ---
 


### PR DESCRIPTION
## Summary

Hank flagged 2026-06-03 from prod chat that §2.2 wireframe shows both chip groups inside the expanded panel, but §2.1 doesn't explicitly say `#systemFilterChips` (smart-filter row) is hidden in the collapsed state. Earlier readers could parse "summary chip + entity row collapsed" as "smart-filter row stays always-visible." That's not the design.

Three targeted clarifications, no impl change.

### Collapse scope (per Hank's request)
**The collapse covers BOTH `#filterChips` (entity scope row) AND `#systemFilterChips` (smart-filter row).** The summary chip is the sole visible filter affordance in the collapsed state — no row peeks out, no smart-filter row left always-visible. PR #3095 already implements this correctly; this PR locks the spec to match so future readers/maintainers don't misread the wireframe.

### Edits

- **§1 Problem statement** — adds "Both rows are eligible for collapse in v1" right after the two-row wireframe, so the scope decision is visible at the top of the spec.
- **§2.1 Collapsed state** — adds explicit "Hidden in this state: both #filterChips AND #systemFilterChips" block with a regression signal ("if either row is visible while the summary chip is rendered, the collapse has regressed").
- **§6 Rollback** — spells out that reverting the integration commit restores BOTH rows to always-visible (no partial-collapse fallback state; all-or-nothing).

## Out of scope
- Impl (PR #3095 is already correct, both rows handled)
- i18n keys (no key changes)
- §2.2 wireframe (already correct)

## Test plan
- [x] Spec self-review against §2.2 wireframe — §2.1 / §1 / §6 now consistent with the panel diagram
- [x] No impl files touched (only `docs/specs/chat-page-filter-bar-collapse.md`)
- [ ] Cross-link comment posted on this card + parent spec card `card_11776d156c2bfd9c92ee81bf` + impl card after merge

Driver: kanban nudge 2026-06-03 14:25 TW on card_d11d2d6c (P3 spec).

🤖 Generated with [Claude Code](https://claude.com/claude-code)