### PR TITLE
feat(portal): hover-click v1.2a — lock→armed→active state machine

### DIFF
--- a/backend/public/portal/interactive-dev.html
+++ b/backend/public/portal/interactive-dev.html
@@ -8,7 +8,7 @@
     <link rel="icon" type="image/png" href="assets/favicon-32.png">
     <link rel="stylesheet" href="shared/style.css">
     <link rel="stylesheet" href="shared/info.css">
-    <link rel="stylesheet" href="../shared/hover-click-toolbar.css?v=1.1.1">
+    <link rel="stylesheet" href="../shared/hover-click-toolbar.css?v=1.2a">
     <style>
         /* ══════════════ Sub-tabs (same as mission.html / kanban.html) ══════════════ */
         .sub-tabs { display:flex; gap:0; margin-bottom:20px; border-bottom:1px solid var(--card-border); overflow-x:auto; -webkit-overflow-scrolling:touch; scrollbar-width:none; }
@@ -174,9 +174,9 @@
         opens anchored to the picked element. Esc / outside-click dismisses
         per the toolbar's own handlers; the sandbox stays interactive.
     -->
-    <script src="../shared/dom-select.js?v=1.1.1"></script>
-    <script src="../shared/hover-click-toolbar.js?v=1.1.1"></script>
-    <script src="../shared/diff-format.js?v=1.1.1"></script>
+    <script src="../shared/dom-select.js?v=1.2a"></script>
+    <script src="../shared/hover-click-toolbar.js?v=1.2a"></script>
+    <script src="../shared/diff-format.js?v=1.2a"></script>
     <script>
     (function() {
         if (!window.EClawHoverClickToolbar || !document.querySelector('.ped-sandbox')) return;

--- a/backend/public/shared/hover-click-toolbar.css
+++ b/backend/public/shared/hover-click-toolbar.css
@@ -6,17 +6,72 @@
  * Reduced motion respected on both.
  */
 
-/* ----- DOM-select rings (consumed by dom-select.js) ----- */
+/* ----- DOM-select rings (consumed by dom-select.js) -----
+ * v1.2a state machine (Hank feedback 2026-06-03):
+ *   IDLE        — no ring
+ *   PREVIEW     — pointer is over a selectable element (dashed indigo)
+ *   LOCKED      — clicked + toolbar open (solid indigo + soft halo)
+ *   ARMED_*     — toolbar action staged, awaiting drag (amber pulsing outline)
+ *   ACTIVE      — drag in flight (amber solid + heavier shadow)
+ * The state transitions are explicit in JS; the user clicks a chip BEFORE
+ * any drag fires, instead of immediate-grab.
+ */
 .eclaw-dom-select__ring-preview {
   outline: 2px dashed rgba(99, 102, 241, 0.7) !important;
   outline-offset: 2px !important;
   cursor: crosshair !important;
+  transition: outline-color 0.15s ease-out, box-shadow 0.15s ease-out;
 }
 
 .eclaw-dom-select__ring-selected {
   outline: 2px solid rgba(99, 102, 241, 0.95) !important;
   outline-offset: 2px !important;
   box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.15) !important;
+  transition: outline-color 0.15s ease-out, box-shadow 0.15s ease-out;
+}
+
+/* v1.2a: ARMED state — toolbar action staged. Amber to distinguish
+   from the indigo LOCKED state. cursor hints at the upcoming interaction. */
+.eclaw-dom-select__ring-armed-move {
+  outline: 3px solid rgba(245, 158, 11, 0.95) !important;
+  outline-offset: 3px !important;
+  box-shadow: 0 0 0 6px rgba(245, 158, 11, 0.18) !important;
+  cursor: move !important;
+  animation: eclaw-armed-pulse 0.9s ease-in-out infinite;
+}
+
+.eclaw-dom-select__ring-armed-resize {
+  outline: 3px solid rgba(245, 158, 11, 0.95) !important;
+  outline-offset: 3px !important;
+  box-shadow: 0 0 0 6px rgba(245, 158, 11, 0.18) !important;
+  cursor: nwse-resize !important;
+  animation: eclaw-armed-pulse 0.9s ease-in-out infinite;
+}
+
+.eclaw-dom-select__ring-active {
+  outline: 3px solid rgba(245, 158, 11, 1) !important;
+  outline-offset: 3px !important;
+  box-shadow: 0 0 0 8px rgba(245, 158, 11, 0.25), 0 6px 20px rgba(0,0,0,0.25) !important;
+}
+
+@keyframes eclaw-armed-pulse {
+  0%, 100% { box-shadow: 0 0 0 6px rgba(245, 158, 11, 0.18); }
+  50% { box-shadow: 0 0 0 10px rgba(245, 158, 11, 0.32); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .eclaw-dom-select__ring-armed-move,
+  .eclaw-dom-select__ring-armed-resize {
+    animation: none !important;
+  }
+}
+
+/* v1.2a: ARMED-state hint in the toolbar — the active chip glows amber
+   while waiting for the user to drag. */
+.eclaw-hover-click-toolbar__chip[data-armed="true"] {
+  background: rgba(245, 158, 11, 0.15) !important;
+  outline: 2px solid rgba(245, 158, 11, 0.6) !important;
+  outline-offset: 1px !important;
 }
 
 /* ----- Toolbar shell ----- */

--- a/backend/public/shared/hover-click-toolbar.js
+++ b/backend/public/shared/hover-click-toolbar.js
@@ -150,7 +150,12 @@
           e.preventDefault(); doDuplicate(); return;
         }
       }
-      if (e.key === 'Escape') { e.preventDefault(); close(); }
+      if (e.key === 'Escape') {
+        // v1.2a: if an action is armed, Esc just disarms (stays LOCKED).
+        // Second Esc closes the toolbar.
+        if (armedAction) { e.preventDefault(); disarm(); return; }
+        e.preventDefault(); close();
+      }
       else if (e.key === 'Tab') {
         // Tab cycles within the toolbar; default browser behaviour handles
         // the in-toolbar focus, we just need to wrap.
@@ -200,6 +205,10 @@
 
     function close() {
       if (!openFlag) return;
+      // v1.2a: clear armed state + amber rings so the target is left clean.
+      if (currentTarget) clearArmedClasses(currentTarget);
+      armedAction = null;
+      Object.values(chipEls).forEach((b) => b && b.removeAttribute('data-armed'));
       openFlag = false;
       shell.hidden = true;
       shell.removeAttribute('data-visible');
@@ -257,8 +266,11 @@
       if (chipId === 'quote') { doQuote(); return; }
       if (!currentTarget) return;
       switch (chipId) {
-        case 'move':   startMove(); break;
-        case 'resize': startResize(); break;
+        // v1.2a: Move/Resize now ARM the action; the user has to press
+        // pointer-down on the LOCKED target to commit. This separates
+        // selection (LOCKED) from interaction (ARMED → ACTIVE).
+        case 'move':   setArmed('move'); break;
+        case 'resize': setArmed('resize'); break;
         case 'style':  showStyleSubpanel(); break;
         case 'duplicate': doDuplicate(); break;
         case 'delete': confirmDelete(); break;
@@ -296,6 +308,150 @@
         ts: Date.now(),
       };
       document.dispatchEvent(new CustomEvent('hover-click:quote', { detail: payload }));
+    }
+
+    // v1.2a state machine: instead of clicking Move and immediately grabbing
+    // the element, we arm the action and wait for a pointerdown on the target.
+    // armedAction is one of: null | 'move' | 'resize'. While armed, the
+    // ring transitions to amber and the cursor changes; the Move/Resize chip
+    // also shows a glow (data-armed="true") so the user sees we're staged.
+    let armedAction = null;
+    function clearArmedClasses(target) {
+      if (!target) return;
+      target.classList.remove(
+        'eclaw-dom-select__ring-armed-move',
+        'eclaw-dom-select__ring-armed-resize',
+        'eclaw-dom-select__ring-active',
+      );
+    }
+    function setArmed(action) {
+      if (!currentTarget) return;
+      // Re-arming the same action toggles off (Esc-equivalent without leaving toolbar focus).
+      const wasArmed = armedAction;
+      Object.values(chipEls).forEach((b) => b && b.removeAttribute('data-armed'));
+      clearArmedClasses(currentTarget);
+      if (wasArmed === action) {
+        armedAction = null;
+        return;
+      }
+      armedAction = action;
+      currentTarget.classList.add(
+        action === 'move'
+          ? 'eclaw-dom-select__ring-armed-move'
+          : 'eclaw-dom-select__ring-armed-resize',
+      );
+      const chip = chipEls[action];
+      if (chip) chip.setAttribute('data-armed', 'true');
+    }
+    function disarm() {
+      if (!armedAction) return;
+      armedAction = null;
+      Object.values(chipEls).forEach((b) => b && b.removeAttribute('data-armed'));
+      clearArmedClasses(currentTarget);
+    }
+
+    // Listen for pointerdown on the LOCKED target while armed → starts drag.
+    document.addEventListener('pointerdown', function(e) {
+      if (!openFlag || !currentTarget || !armedAction) return;
+      if (!currentTarget.contains(e.target) && e.target !== currentTarget) return;
+      e.preventDefault();
+      const action = armedAction;
+      // Transition ARMED → ACTIVE
+      clearArmedClasses(currentTarget);
+      currentTarget.classList.add('eclaw-dom-select__ring-active');
+      Object.values(chipEls).forEach((b) => b && b.removeAttribute('data-armed'));
+      if (action === 'move') doMoveFromPointerDown(e);
+      else if (action === 'resize') doResizeFromPointerDown(e);
+      armedAction = null;
+    }, true);
+
+    function doMoveFromPointerDown(downEvent) {
+      const target = currentTarget;
+      const cs = getComputedStyle(target);
+      const startX0 = parseFloat(cs.left) || 0;
+      const startY0 = parseFloat(cs.top) || 0;
+      const wasPos = cs.position;
+      const beforeHTML = snapshotBefore(target);
+      if (wasPos === 'static') target.style.position = 'relative';
+      const startMouseX = downEvent.clientX;
+      const startMouseY = downEvent.clientY;
+      function moveHandler(e) {
+        target.style.left = `${startX0 + (e.clientX - startMouseX)}px`;
+        target.style.top = `${startY0 + (e.clientY - startMouseY)}px`;
+      }
+      function upHandler() {
+        document.removeEventListener('pointermove', moveHandler, true);
+        document.removeEventListener('pointerup', upHandler, true);
+        clearArmedClasses(target);
+        target.classList.add('eclaw-dom-select__ring-selected');
+        const endLeft = parseFloat(target.style.left) || 0;
+        const endTop = parseFloat(target.style.top) || 0;
+        const r = target.getBoundingClientRect();
+        recordMutation(
+          { type: 'geometry', target,
+            from: { x: startX0, y: startY0, w: r.width, h: r.height },
+            to: { x: endLeft, y: endTop, w: r.width, h: r.height },
+            _beforeHTML: beforeHTML },
+          () => {
+            target.style.left = `${startX0}px`;
+            target.style.top = `${startY0}px`;
+            if (wasPos === 'static') target.style.position = '';
+          },
+          () => {
+            if (wasPos === 'static') target.style.position = 'relative';
+            target.style.left = `${endLeft}px`;
+            target.style.top = `${endTop}px`;
+          },
+        );
+      }
+      document.addEventListener('pointermove', moveHandler, true);
+      document.addEventListener('pointerup', upHandler, true);
+    }
+
+    function doResizeFromPointerDown(downEvent) {
+      const target = currentTarget;
+      const r = target.getBoundingClientRect();
+      const startW = r.width, startH = r.height;
+      const startWidthCss = target.style.width;
+      const startHeightCss = target.style.height;
+      const beforeHTML = snapshotBefore(target);
+      const startX = downEvent.clientX, startY = downEvent.clientY;
+      function moveHandler(e) {
+        const dx = e.clientX - startX;
+        const dy = e.clientY - startY;
+        let newW = startW + dx, newH = startH + dy;
+        if (e.shiftKey) {
+          const ratio = startW / startH;
+          newH = newW / ratio;
+        }
+        target.style.width = `${Math.max(20, newW)}px`;
+        target.style.height = `${Math.max(20, newH)}px`;
+      }
+      function upHandler() {
+        document.removeEventListener('pointermove', moveHandler, true);
+        document.removeEventListener('pointerup', upHandler, true);
+        clearArmedClasses(target);
+        target.classList.add('eclaw-dom-select__ring-selected');
+        const r2 = target.getBoundingClientRect();
+        const endWidthCss = target.style.width;
+        const endHeightCss = target.style.height;
+        recordMutation(
+          { type: 'geometry', target,
+            from: { w: startW, h: startH },
+            to: { w: r2.width, h: r2.height },
+            _beforeHTML: beforeHTML },
+          () => {
+            target.style.width = startWidthCss;
+            target.style.height = startHeightCss;
+          },
+          () => {
+            target.style.width = endWidthCss;
+            target.style.height = endHeightCss;
+          },
+        );
+      }
+      document.addEventListener('pointermove', moveHandler, true);
+      document.addEventListener('pointerup', upHandler, true);
     }
 
     function startMove() {


### PR DESCRIPTION
## Summary

card_1a1b0e0681e65d0b9c0cb6b8 (v1.2 chain slice a). Hank feedback 2026-06-03 16:03 TW: 移動或縮放 UX 怪 — 應該 先鎖定(高亮) → 點擊工具欄 → 高亮漸變 → 與物件互動.

Pre-v1.2 the Move/Resize chip immediately attached a global pointermove listener and started the drag on the next mouse motion. v1.2a wires an explicit state machine:

| State        | Visual                                | Trigger to next state           |
|--------------|---------------------------------------|---------------------------------|
| IDLE         | no toolbar                            | hover an element                |
| PREVIEW      | dashed indigo                         | click commits selection         |
| **LOCKED**   | solid indigo + soft halo              | click Move/Resize chip          |
| **ARMED_*** | amber pulsing outline + cursor change | pointerdown on target           |
| **ACTIVE**   | solid amber + heavier shadow          | pointer release                 |
| → LOCKED     | restored after recordMutation         | second Esc closes toolbar       |

### Implementation
- `setArmed(action)` / `disarm()` helpers + `armedAction` state var
- `data-armed="true"` attribute drives the toolbar chip glow
- New ring classes: `__ring-armed-{move,resize}`, `__ring-active`
- `eclaw-armed-pulse` @keyframes; `prefers-reduced-motion` disables
- Document-level pointerdown listener bridges ARMED → ACTIVE only when pressing on the locked target
- Esc while ARMED disarms (stays LOCKED); second Esc closes
- `close()` and outside-click also clean armed state
- Cache-bust bumped to `?v=1.2a` on the 4 hover-click asset imports

### Verified locally
- cta.button selection → toolbar opens, no armed ring
- Click Move chip → armed-move ring on target + chip data-armed=true
- Esc → disarm (ring cleared, toolbar stays open)
- pointerdown on target while armed → transitions to active + drag flow

## Out of scope (separate v1.2 sub-cards)
- Style picker subpanel (v1.2b)
- Import flow (v1.2c)

🤖 Generated with [Claude Code](https://claude.com/claude-code)