### PR TITLE
fix(portal): v1.2b1 Style undo — snapshot original BEFORE live preview

### DIFF
--- a/backend/public/portal/interactive-dev.html
+++ b/backend/public/portal/interactive-dev.html
@@ -8,7 +8,7 @@
     <link rel="icon" type="image/png" href="assets/favicon-32.png">
     <link rel="stylesheet" href="shared/style.css">
     <link rel="stylesheet" href="shared/info.css">
-    <link rel="stylesheet" href="../shared/hover-click-toolbar.css?v=1.2d1">
+    <link rel="stylesheet" href="../shared/hover-click-toolbar.css?v=1.2b1">
     <style>
         /* ══════════════ Sub-tabs (same as mission.html / kanban.html) ══════════════ */
         .sub-tabs { display:flex; gap:0; margin-bottom:20px; border-bottom:1px solid var(--card-border); overflow-x:auto; -webkit-overflow-scrolling:touch; scrollbar-width:none; }
@@ -230,10 +230,10 @@
         opens anchored to the picked element. Esc / outside-click dismisses
         per the toolbar's own handlers; the sandbox stays interactive.
     -->
-    <script src="../shared/dom-select.js?v=1.2d1"></script>
-    <script src="../shared/hover-click-toolbar.js?v=1.2d1"></script>
-    <script src="../shared/diff-format.js?v=1.2d1"></script>
-    <script src="../shared/content-import.js?v=1.2d1"></script>
+    <script src="../shared/dom-select.js?v=1.2b1"></script>
+    <script src="../shared/hover-click-toolbar.js?v=1.2b1"></script>
+    <script src="../shared/diff-format.js?v=1.2b1"></script>
+    <script src="../shared/content-import.js?v=1.2b1"></script>
     <script>
     // v1.2c Import modal wiring
     (function() {

--- a/backend/public/shared/hover-click-toolbar.js
+++ b/backend/public/shared/hover-click-toolbar.js
@@ -822,20 +822,34 @@
       `;
       shell.appendChild(panel);
       stylePanelEl = panel;
+      // v1.2b1: expose a flushPending() for closeStyleSubpanel so any
+      // in-flight debounce commits immediately (otherwise quick edits
+      // followed by panel close lose the history entry).
+      panel._flushPending = function() {
+        Object.keys(sessionDebounce).forEach((key) => {
+          if (sessionDebounce[key] != null) {
+            clearTimeout(sessionDebounce[key]);
+            const input = panel.querySelector(`[data-style-key="${key}"]`);
+            if (input) {
+              const unit = input.dataset.unit || '';
+              const value = unit && input.value !== '' ? `${input.value}${unit}` : input.value;
+              commitProperty(key, value);
+            }
+            sessionDebounce[key] = null;
+          }
+        });
+      };
 
       // Track session-level mutation: commit one entry per (property,
       // target) pair on debounce. Map keyed by style property.
       const sessionDebounce = {};
       const sessionSnapshots = {}; // property → original value when first edited
       function commitProperty(key, value) {
-        // Commit happens after debounce; capture the BEFORE value once.
-        if (!(key in sessionSnapshots)) {
-          sessionSnapshots[key] = target.style[key] !== '' ? target.style[key] : null;
-        }
+        // v1.2b1: sessionSnapshots[key] is captured in the 'input' handler
+        // BEFORE the live preview overwrites target.style[key]. By the time
+        // commit fires, sessionSnapshots[key] is the true ORIGINAL value.
         const before = sessionSnapshots[key];
         target.style[key] = value;
-        // Replace any prior history entry for this key with the new BEFORE→to.
-        // We don't dedupe in history; rapid edits get one entry per debounce.
         recordMutation(
           { type: 'style', target, property: key, from: before, to: value, _beforeHTML: beforeHTML },
           () => { target.style[key] = before == null ? '' : before; },
@@ -850,7 +864,13 @@
         const unit = input.dataset.unit || '';
         const rawValue = input.value;
         const value = unit && rawValue !== '' ? `${rawValue}${unit}` : rawValue;
-        // Live preview (no history yet)
+        // v1.2b1 fix: snapshot the ORIGINAL inline value BEFORE the live
+        // preview overwrites it. Previously commit-time snapshot saw the
+        // already-previewed value, making undo a no-op.
+        if (!(key in sessionSnapshots)) {
+          sessionSnapshots[key] = target.style[key] !== '' ? target.style[key] : null;
+        }
+        // Live preview
         target.style[key] = value;
         // Debounce commit to history
         clearTimeout(sessionDebounce[key]);
@@ -873,6 +893,9 @@
 
     function closeStyleSubpanel() {
       if (stylePanelEl) {
+        // v1.2b1: flush any pending live-preview debounce so the user's
+        // last value is recorded to history before the panel goes away.
+        if (stylePanelEl._flushPending) stylePanelEl._flushPending();
         stylePanelEl.remove();
         stylePanelEl = null;
       }


### PR DESCRIPTION
card_39fafc10ae41d557823d107e (P0 hotfix). Style picker undo was a no-op because sessionSnapshots[key] was captured AFTER the live preview overwrote target.style[key]. Detail in commit body. Full audit of other mutators confirmed only Style had the race.