### PR TITLE
fix(hover-click v1.3.1): cache-bust to ?v=1.3.1

### DIFF
--- a/backend/public/portal/interactive-dev.html
+++ b/backend/public/portal/interactive-dev.html
@@ -8,7 +8,7 @@
     <link rel="icon" type="image/png" href="assets/favicon-32.png">
     <link rel="stylesheet" href="shared/style.css">
     <link rel="stylesheet" href="shared/info.css">
-    <link rel="stylesheet" href="../shared/hover-click-toolbar.css?v=1.3">
+    <link rel="stylesheet" href="../shared/hover-click-toolbar.css?v=1.3.1">
     <style>
         /* ══════════════ Sub-tabs (same as mission.html / kanban.html) ══════════════ */
         .sub-tabs { display:flex; gap:0; margin-bottom:20px; border-bottom:1px solid var(--card-border); overflow-x:auto; -webkit-overflow-scrolling:touch; scrollbar-width:none; }
@@ -256,10 +256,10 @@
         opens anchored to the picked element. Esc / outside-click dismisses
         per the toolbar's own handlers; the sandbox stays interactive.
     -->
-    <script src="../shared/dom-select.js?v=1.3"></script>
-    <script src="../shared/hover-click-toolbar.js?v=1.3"></script>
-    <script src="../shared/diff-format.js?v=1.3"></script>
-    <script src="../shared/content-import.js?v=1.3"></script>
+    <script src="../shared/dom-select.js?v=1.3.1"></script>
+    <script src="../shared/hover-click-toolbar.js?v=1.3.1"></script>
+    <script src="../shared/diff-format.js?v=1.3.1"></script>
+    <script src="../shared/content-import.js?v=1.3.1"></script>
     <script>
     // v1.2c Import modal wiring
     (function() {


### PR DESCRIPTION
## Summary
Cloudflare edge cache had `?v=1.3` already cached (probably from a probe at 09:19 TW) BEFORE the v1.3 deploy completed at 10:27. Users hit `cf-cache-status: HIT` with the OLD assets. Bumping to `?v=1.3.1` forces revalidation.

## Card
card_db6af96f9808d8949e9a9a1f → linkedPrev card_e3e0d94efb6f388a91f01f47

## Test plan
- [ ] `curl /shared/hover-click-toolbar.js?v=1.3.1` returns `drag_handle_aria` marker
- [ ] Prod E2E re-run with cache-busted query

🤖 Generated with [Claude Code](https://claude.com/claude-code)