### PR TITLE
docs(specs): mobile-use integration + portal ? icon bidirectional refs

### DIFF
--- a/docs/specs/mobile-use-integration.md
+++ b/docs/specs/mobile-use-integration.md
@@ -1,0 +1,296 @@
+# EClaw ↔ minitap-ai/mobile-use integration spec
+
+| | |
+|---|---|
+| Card | `card_7579f20522a8276240736c7d` |
+| Linked prev | `card_aa15ed2618c9246d11a0f6b1` (research) |
+| Linked next | `card_f693378a99739c82776c1978` (M1 impl) → `card_4331b6d7e31bcb808bfc1733` (M2 impl) |
+| Status | Spec / P1 |
+| Date | 2026-06-03 |
+| Author | #2 (LOBSTER) |
+
+## 1. Motivation
+
+The research card `card_aa15ed26` ([report](../research/2026-06-03-mobile-use-comparison.md)) shows that EClaw and minitap-ai/mobile-use solve the same surface problem (LLM agent drives mobile UI) from opposite directions:
+
+- **EClaw** is a stateless device-control relay. Backend has no agent loop; any external caller decides next action. 6 action primitives. Strong in multi-tenancy + iOS real-device + worldwide reach.
+- **mobile-use** is a full-stack LangGraph mobile agent. 8 specialised agents (planner/cortex/executor/orchestrator/contextor/outputter/summarizer/video_analyzer). 13+ action primitives. Strong in agent-driven task decomposition + multi-LLM, but assumes developer-host adb/idb access.
+
+By exposing EClaw as a `DeviceController` subclass that mobile-use's LangGraph can drive, we get:
+
+1. **mobile-use users gain real-device + iOS support** they don't have today, via EClaw's worldwide installed base.
+2. **EClaw users gain an off-the-shelf agent loop** without writing planner/executor code.
+3. **Both keep their architectural strengths** — EClaw stays stateless, mobile-use stays platform-agnostic.
+
+This spec covers two milestones:
+- **M1** — EClaw control API expands to match mobile-use's primitive set + adds screen-image.
+- **M2** — Python `EclawController(DeviceController)` ships as a mobile-use plugin (upstream PR or fork-as-extension).
+
+## 1.1 Non-goals (v1)
+
+- Driving EClaw devices from mobile-use **without** the user already owning an EClaw deviceSecret. Auth is unchanged.
+- mobile-use planner / cortex modifications. Plugin only.
+- Browser / web target. mobile-use's mobile focus is preserved.
+- Replacing EClaw's existing 6 primitives. They stay, M1 only adds.
+
+## 2. Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│  Caller machine (mac / linux / cloud)                           │
+│                                                                  │
+│   $ python -m mobile_use "Open Settings, tell me battery level" │
+│                          │                                       │
+│                          ▼                                       │
+│   ┌──────────────────────────────────────┐                      │
+│   │  mobile-use LangGraph                │                      │
+│   │  ┌──────────┐  ┌──────────┐  ┌─────┐ │                      │
+│   │  │ planner  │→ │ cortex   │→ │exec │ │                      │
+│   │  └──────────┘  └──────────┘  └──┬──┘ │                      │
+│   └─────────────────────────────────┼────┘                      │
+│                                     │ controller.tap(x,y)        │
+│                                     │ controller.screenshot()    │
+│                                     ▼                            │
+│   ┌──────────────────────────────────────┐                      │
+│   │  EclawController(DeviceController)   │  ← M2 deliverable    │
+│   │  - HTTP POST /api/device/control     │                      │
+│   │  - HTTP POST /api/device/screen-image│                      │
+│   └─────────────────────────────────────┬┘                      │
+└─────────────────────────────────────────┼─────────────────────────┘
+                                          │  HTTPS
+                                          ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  eclawbot.com (Railway)                                          │
+│                                                                  │
+│   ┌──────────────────────────────────────┐                      │
+│   │  backend/index.js                    │                      │
+│   │  /api/device/control   ◄── M1 expand│  swipe/long_press/   │
+│   │  /api/device/screen-image ◄── M1 new│  launch_app/stop_app │
+│   │  Socket.IO relay                     │                      │
+│   └─────────────────────────────────────┬┘                      │
+└─────────────────────────────────────────┼─────────────────────────┘
+                                          │  Socket.IO
+                                          ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  User device (Android / iOS) running EClaw app                  │
+│                                                                  │
+│   ┌──────────────────────────────────────┐                      │
+│   │  AndroidAccessibilityService /        │ ← M1 native handlers │
+│   │  iOS XCUITest helpers / WebView shim  │                      │
+│   │  + MediaProjection screen-image       │                      │
+│   └──────────────────────────────────────┘                      │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+Key contract: EclawController is a **thin adapter**. It does not maintain any agent state — that lives in the LangGraph. EClaw backend remains a stateless relay. The only persistent state is the user's existing `deviceSecret` ↔ device binding.
+
+## 3. M1 — Backend API contract
+
+### 3.1 `/api/device/control` — expanded command set
+
+Existing commands (unchanged): `tap`, `type`, `scroll`, `back`, `home`, `ime_action`.
+
+New commands:
+
+| command | params | semantics |
+|---|---|---|
+| `swipe` | `{startX, startY, endX, endY, durationMs?}` | Single-finger swipe. Default duration 200ms. |
+| `long_press` | `{x, y, durationMs?}` | Long press at point. Default duration 800ms. |
+| `launch_app` | `{packageName}` (Android) or `{bundleId}` (iOS) | Launch by app id. Fails if not installed. |
+| `stop_app` | `{packageName}` / `{bundleId}` | Force-stop the named app. |
+
+Request body (POST JSON):
+```json
+{
+  "deviceId": "<uuid>",
+  "botSecret": "<32-hex>",
+  "entityId": 2,
+  "command": "swipe",
+  "params": {"startX": 100, "startY": 800, "endX": 100, "endY": 200, "durationMs": 250}
+}
+```
+
+Response:
+```json
+{"success": true, "dispatched": "swipe", "ackedAt": 1780486200000}
+```
+
+Error model: `400` on missing/invalid params; `401` on bad creds; `404` if device not connected; `429` if rate-limit exceeded; `500` on Socket.IO relay failure.
+
+### 3.2 `/api/device/screen-image` — new endpoint
+
+Long-poll capture of a raw screen image (PNG). Coexists with the existing `/api/device/screen-capture` which returns UI tree + element list.
+
+Request:
+```
+GET /api/device/screen-image?deviceId=<uuid>&botSecret=<hex>&entityId=2&maxBytes=500000
+```
+
+Response (success):
+```json
+{
+  "success": true,
+  "image": "<base64 PNG>",
+  "width": 1080,
+  "height": 2400,
+  "byteSize": 184230,
+  "timestamp": 1780486201000
+}
+```
+
+Compression: app-side downscales to fit `maxBytes` (default 500 KB) using Android Bitmap.compress() / iOS JPEG fallback. mobile-use's vision agent token cost scales with image bytes; 500 KB ≈ 2-3k tokens for Claude Sonnet vision, acceptable per task step.
+
+Rate-limit: same 500 ms minimum between captures as `/screen-capture`. Both endpoints share a single per-device cool-down counter.
+
+### 3.3 Feature flag
+
+All M1 expansion lives behind env var `ECLAW_MOBILE_USE_API_ENABLED`:
+- Dev / staging: `true` by default.
+- Prod: `false` until M2 is shipped and reviewed.
+
+Existing 6 primitives are NOT gated — only the 4 new commands + `/screen-image` endpoint.
+
+## 4. M1 — Native handler contract
+
+### 4.1 Android
+
+Action primitives dispatched via Socket.IO event `device:control-command` with shape `{command, params}`.
+
+```kotlin
+// app/.../control/ControlDispatcher.kt
+when (command) {
+  "swipe" -> accessibilityService.dispatchGesture(buildSwipe(params))
+  "long_press" -> accessibilityService.dispatchGesture(buildLongPress(params))
+  "launch_app" -> startActivity(packageManager.getLaunchIntentForPackage(params.packageName))
+  "stop_app" -> activityManager.killBackgroundProcesses(params.packageName)
+  // existing commands unchanged
+}
+```
+
+Screen image capture: existing `MediaProjection` flow reused; new path returns full-frame Bitmap via `Bitmap.compress(PNG, quality=85, stream)`, base64-encoded into the Socket.IO ACK.
+
+### 4.2 iOS
+
+iOS v1 has no XCUITest runtime in shipped app. Three options ranked by effort:
+
+1. **WebView shim only (v1 default)**: implement `swipe`/`long_press` via JS dispatched into the active WebView for portal-page-driven tests. Native apps (Settings, etc.) NOT reachable.
+2. **Accessibility query + tap** (v1.5): use UIAccessibilityElement queries to locate then synthesise tap events. Works for accessibility-flagged apps only.
+3. **EClaw app sideloads idb-companion** (v2): adopt fb-idb's idb-companion approach. Heavy; needs Apple-private SPI. Out of scope for M1.
+
+M1 ships option 1; M2 documents iOS limitation in EclawController docstring.
+
+## 5. M2 — `EclawController(DeviceController)` Python class
+
+### 5.1 Class signature
+
+```python
+from mobile_use.controllers.device_controller import DeviceController
+
+class EclawController(DeviceController):
+    def __init__(
+        self,
+        device_id: str,
+        bot_secret: str,
+        entity_id: int = 2,
+        base_url: str = "https://eclawbot.com",
+        timeout_seconds: float = 8.0,
+        prefer_image_screenshot: bool = True,
+    ):
+        ...
+```
+
+`prefer_image_screenshot=True` calls `/api/device/screen-image`; `False` calls `/api/device/screen-capture` for UI tree only (cheaper).
+
+### 5.2 Method mapping
+
+| mobile-use abstract method | EClaw call |
+|---|---|
+| `tap(x, y)` | POST /api/device/control `{command:"tap", params:{x,y}}` |
+| `swipe(x1, y1, x2, y2, duration)` | POST /api/device/control `{command:"swipe", params:{startX, startY, endX, endY, durationMs}}` |
+| `long_press(x, y, duration)` | POST /api/device/control `{command:"long_press", params:{x, y, durationMs}}` |
+| `input_text(text)` | POST /api/device/control `{command:"type", params:{text}}` |
+| `press_key(key)` | POST /api/device/control `{command:"home" \| "back" \| "ime_action"}` (mapped) |
+| `launch_app(name)` | POST /api/device/control `{command:"launch_app", params:{packageName \| bundleId}}` |
+| `stop_app(name)` | POST /api/device/control `{command:"stop_app", params:{packageName \| bundleId}}` |
+| `screenshot()` | GET /api/device/screen-image (or /screen-capture if not preferred) |
+| `back()` | POST /api/device/control `{command:"back"}` |
+| `open_link(url)` | POST /api/device/control `{command:"launch_app", params:{intentUrl: url}}` — Android only v1; iOS via WebView shim |
+| `wait_for_delay(ms)` | client-side `time.sleep(ms/1000)` — no server call |
+| `video_recording` | **not supported v1**; raises `NotImplementedError` |
+| `focus_and_clear_text` / `focus_and_input_text` / `erase_one_char` | client-side: combo of tap + ime_action + type |
+
+mobile-use primitives not in EClaw's M1 set are **polyfilled client-side** (sequences of M1 calls) where possible; otherwise the controller raises `NotImplementedError` with a clear message so the planner can re-plan.
+
+### 5.3 Error model
+
+```python
+class EclawControllerError(Exception): pass
+class EclawAuthError(EclawControllerError): pass        # 401
+class EclawDeviceOfflineError(EclawControllerError): pass # 404 + 'device not connected'
+class EclawRateLimitError(EclawControllerError): pass     # 429
+class EclawServerError(EclawControllerError): pass        # 5xx
+```
+
+mobile-use's executor retries on `EclawRateLimitError` with jittered backoff (3 attempts, 200 ms → 600 ms → 1500 ms). Other errors bubble to the orchestrator which can re-plan.
+
+### 5.4 Package layout (fork-as-extension recommended)
+
+```
+eclaw-mobile-use-driver/        # standalone PyPI package, MIT-licensed
+├── README.md
+├── LICENSE                     # MIT (or Apache-2.0 if matching upstream)
+├── NOTICE                      # cites minitap-ai/mobile-use as the parent abstraction
+├── pyproject.toml
+├── src/eclaw_mobile_use_driver/
+│   ├── __init__.py
+│   ├── controller.py           # EclawController(DeviceController)
+│   ├── transport.py            # HTTP client + retries
+│   └── errors.py
+└── tests/
+    ├── test_controller_unit.py # mock HTTP
+    └── test_integration.py     # against EClaw staging
+```
+
+Why fork-as-extension over upstream PR:
+- Upstream churns fast (10 releases since 2025; latest Jan 2026). Bundling our adapter inside their tree adds release coordination overhead.
+- mobile-use's `DeviceController` is a stable Python interface; extensions can ship out-of-tree.
+- Hank's `feedback_no_new_api_keys` constraint is easier to enforce in our own repo.
+
+If upstream interest is high (will probe via GitHub issue), an upstream PR can follow as a wrapper.
+
+## 6. Acceptance criteria
+
+### 6.1 M1 acceptance (card_f693378a99739c82776c1978)
+
+- **AC1.1** — `jest` tests: 4 new commands + screen-image endpoint each pass authentication, param validation, rate-limit (`backend/tests/jest/screen-control.test.js` extends to ≥ 25 cases total).
+- **AC1.2** — Live probe: a bash script on this Mac drives a real Android emulator through all 4 new commands; expected screen changes confirmed via accessibility tree before/after.
+- **AC1.3** — `/api/device/screen-image` returns base64 PNG ≤ 500 KB; decoded image header is valid PNG.
+- **AC1.4** — Feature flag `ECLAW_MOBILE_USE_API_ENABLED=false` → all 4 new commands + screen-image return `403 {error: "feature-disabled"}`.
+- **AC1.5** — `/api/help?intent=mobile-use` returns curl examples for all new endpoints.
+- **AC1.6** — Spec PR cites this doc section.
+
+### 6.2 M2 acceptance (card_4331b6d7e31bcb808bfc1733)
+
+- **AC2.1** — `pytest -q` runs all unit tests in `tests/test_controller_unit.py` green (≥ 20 cases, mocked HTTP).
+- **AC2.2** — Live integration: run `mobile-use "Open Settings, tell me my battery level"` against EClaw Android emu via `EclawController`. LangGraph console screenshot attached. Battery level extracted matches emulator state.
+- **AC2.3** — License attribution: NOTICE cites mobile-use Apache-2.0 + minitap-ai author; LICENSE file in driver repo is permissive (MIT or Apache-2.0).
+- **AC2.4** — README documents M1 dependency + EclawController constructor + iOS limitation (option 1 only).
+- **AC2.5** — If upstream PR: URL in card comment; if fork-as-extension: PyPI / GitHub repo URL in card comment.
+
+## 7. Rollback
+
+M1: revert PR. Endpoint set returns to 6 commands. Feature flag automatically returns 403 for the 4 new endpoints if env is unset.
+
+M2: driver lives in its own repo / PyPI package. Removing the user's `pip install eclaw-mobile-use-driver` reverts.
+
+No EClaw DB migration. No mobile-use upstream change in v1 (extension model). Risk surface is contained to:
+- A few hundred lines in `backend/index.js` (M1)
+- A few hundred lines in Python driver (M2)
+- App-side gesture / image capture handlers (M1)
+
+## 8. References
+
+- Research card: `card_aa15ed2618c9246d11a0f6b1` → [report](../research/2026-06-03-mobile-use-comparison.md)
+- minitap-ai/mobile-use: https://github.com/minitap-ai/mobile-use (Apache-2.0, v3.3.0 Jan 2026, 2.6k stars)
+- EClaw remote-control inventory: `backend/index.js` `/api/device/*`, `backend/public/portal/screen-control.html`, `app/.../ChatJsBridge.java`
+- Memory: `feedback_spec_first`, `feedback_planning_via_macf`, `feedback_no_new_api_keys`, `feedback_link_card_full_e2e_required`

--- a/docs/specs/portal-bidirectional-refs.md
+++ b/docs/specs/portal-bidirectional-refs.md
@@ -1,0 +1,202 @@
+# Portal `?` icon — bidirectional references spec
+
+| | |
+|---|---|
+| Card | `card_a20b69d79f4aba684e7d04ec` |
+| Linked prev | `card_aa15ed2618c9246d11a0f6b1` (research card that surfaced the need) |
+| Status | Spec + Impl / P1 |
+| Date | 2026-06-03 |
+| Author | #2 (LOBSTER) |
+
+## 1. Motivation
+
+The EClaw chat bridge already auto-expands references when a user mentions a card id, PR number, or spec doc — the `[REFERENCES — CONTEXT]` block in inbound payloads is a working example. That expansion only happens at chat-send time and is one-way: the chat sees the referenced thing, but the referenced thing does not know it was cited.
+
+Hank's 2026-06-03 chat request:
+
+> card_aa15ed26 直接全做 + 整理 SPEC + ? icon 雙向參照
+
+surfaces three asks. The first two are handled by `card_7579f20522a8276240736c7d`. This card is the third: make the reference graph visible inside portal UI, and make it **bidirectional** so an artifact's `?` panel shows both *what it cites* and *who cites it*.
+
+Concrete pain it removes:
+- When I open a spec doc in portal `/docs`, I can't see which cards / PRs implement it.
+- When I look at a card, I can't see which spec doc grounds it without digging through the description body.
+- When a PR is opened, the linked card and spec are buried in PR body markdown that nobody reads twice.
+
+## 1.1 Non-goals (v1)
+
+- A full knowledge-graph UI (think Obsidian). v1 surfaces in-place popovers only.
+- Cross-device refs. v1 is scoped to a single EClaw device's kanban + repos + portal.
+- Editing references through the UI. v1 reads only; refs are derived from text content.
+- Refs to arbitrary URLs. v1 supports four kinds: **card**, **spec**, **pr**, **doc** (research docs under `docs/research/`).
+
+## 2. Surfaces — where `?` appears
+
+| Surface | Where | Trigger | Position |
+|---|---|---|---|
+| Kanban card | `portal/kanban.html`, kanban card list / detail | always-visible `?` next to card title | next to `…` menu |
+| Spec doc | `portal/docs.html` rendering `docs/specs/*.md` | always-visible `?` in doc header | next to title `h1` |
+| Research doc | `portal/docs.html` rendering `docs/research/*.md` | same as spec doc | same |
+| PR card | `portal/prs.html` (new, optional v1.5) | `?` next to PR row | inline |
+| Chat quote bubble | `portal/chat.html` reference cards | `?` already implicit via expand; v1 reuses same data | inline |
+
+`?` is a 16-px round button with the glyph `ⓘ` (info circle) — `?` is the user-facing nickname but the glyph is `ⓘ` because it scans better in non-CJK locales. The CSS class is `eclaw-refs-icon`. Aria-label: `"Show related cards, specs, and PRs"`.
+
+## 3. Backend contract
+
+### 3.1 `GET /api/refs?from=<id>` — get refs for an artifact
+
+```
+GET /api/refs?from=card_aa15ed2618c9246d11a0f6b1&deviceId=<uuid>&botSecret=<hex>&entityId=2
+```
+
+Response:
+```json
+{
+  "success": true,
+  "from": {"kind": "card", "id": "card_aa15ed26...", "label": "Eclaw 遠端控制 vs minitap-ai/mobile-use"},
+  "refs": [
+    {"kind": "spec",   "id": "docs/specs/mobile-use-integration.md", "label": "mobile-use integration", "direction": "out"},
+    {"kind": "spec",   "id": "docs/specs/portal-bidirectional-refs.md", "label": "portal ? icon refs", "direction": "out"},
+    {"kind": "doc",    "id": "docs/research/2026-06-03-mobile-use-comparison.md", "label": "mobile-use comparison report", "direction": "out"},
+    {"kind": "pr",     "id": "3123", "label": "docs(research): EClaw vs minitap-ai/mobile-use", "direction": "in"},
+    {"kind": "card",   "id": "card_7579f20...", "label": "mobile-use integration full spec", "direction": "out"},
+    {"kind": "card",   "id": "card_a20b69d7...", "label": "portal ? icon bidirectional refs", "direction": "out"}
+  ]
+}
+```
+
+`direction`:
+- `out` — the `from` artifact mentions the ref (looking at the from, it points outward).
+- `in` — the ref mentions `from` (looking at the from, the ref points inward — back-link).
+
+### 3.2 Source-of-truth scan
+
+The refs index is built from these sources, scanned every 5 min by a background job:
+
+| ref kind | scan source |
+|---|---|
+| card | `kanban.cards.description / scope / linkedPrevCardId / linkedNextCardId / comments.text` |
+| spec | files under `docs/specs/**/*.md` (git working tree at HEAD on main) |
+| doc | files under `docs/research/**/*.md` |
+| pr | `gh pr list --state all --limit 200` — title + body |
+
+Pattern matching:
+- `card_[a-f0-9]{24}` for card ids
+- `docs/specs/[\w-]+\.md` and `docs/research/[\w-]+\.md` for doc paths
+- `#\d{3,5}` for PR numbers (validated against the gh listing)
+
+Cache: in-memory map keyed by `from` id, TTL 5 min, written to disk at `backend/.cache/refs.json` for warm start.
+
+### 3.3 `GET /api/refs/graph` (v1.5, optional)
+
+Returns the full edge list for a graph view. Out of scope for v1; spec'd here so the API shape is stable from the start.
+
+```json
+{
+  "success": true,
+  "nodes": [{"kind":"card","id":"...","label":"..."}, ...],
+  "edges": [{"from":"card_X","to":"docs/specs/Y.md"}, ...]
+}
+```
+
+## 4. Frontend contract — `?` popover
+
+### 4.1 Component shell
+
+```html
+<button class="eclaw-refs-icon" data-refs-from="card_aa15ed26..." aria-label="Show related cards, specs, and PRs">ⓘ</button>
+```
+
+A single shared script (`backend/public/shared/refs-popover.js`) wires the click handler. On click:
+
+1. POST not needed; GET `/api/refs?from=<id>` with cached creds.
+2. Render a popover anchored under the `?` button.
+3. Popover content: two columns — **Outgoing** (this cites ↓) and **Incoming** (← cites this). Each row is a clickable link.
+
+### 4.2 Mock — ASCII
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  ⓘ References for card_aa15ed26...                  [ × ]   │
+├─────────────────────────────────────────────────────────────┤
+│  This card cites (out):                                      │
+│   📄 docs/specs/mobile-use-integration.md                    │
+│   📄 docs/specs/portal-bidirectional-refs.md                 │
+│   📄 docs/research/2026-06-03-mobile-use-comparison.md       │
+│   📋 card_7579f205... mobile-use integration full spec       │
+│   📋 card_a20b69d7... portal ? icon bidirectional refs       │
+│                                                              │
+│  Cited by (in):                                              │
+│   🔀 PR #3123 docs(research): EClaw vs minitap-ai/mobile-use │
+│                                                              │
+└─────────────────────────────────────────────────────────────┘
+```
+
+CSS rules live in `backend/public/shared/refs-popover.css`. Mobile (≤720 px) uses bottom-sheet variant matching `shared/hover-click-toolbar.css` mobile pattern. Reduced motion respected.
+
+### 4.3 i18n
+
+```jsonc
+{
+  "refs.popover_title": "References",
+  "refs.section_out": "This cites",
+  "refs.section_in": "Cited by",
+  "refs.empty": "No related items yet.",
+  "refs.error": "Couldn't load related items."
+}
+```
+
+EN dictionary update + delegation to #3/#4 for non-EN per `feedback_i18n_delegate`.
+
+## 5. Schema
+
+```ts
+type RefKind = "card" | "spec" | "doc" | "pr";
+type RefDirection = "in" | "out";
+
+interface Ref {
+  kind: RefKind;
+  id: string;          // card_xxx | docs/specs/foo.md | docs/research/bar.md | PR number as string
+  label: string;       // human-readable; truncated to 80 chars
+  direction: RefDirection;
+}
+
+interface RefsResponse {
+  success: true;
+  from: { kind: RefKind; id: string; label: string };
+  refs: Ref[];
+}
+```
+
+## 6. Phasing
+
+| Phase | Scope | Card status |
+|---|---|---|
+| **Phase 1 (this spec PR)** | Spec doc only. No code. | spec PR opened against this card |
+| **Phase 2 (impl backend + scan)** | `/api/refs` endpoint + 5-min scan job + cache | impl card spawned with linkedPrev to this card |
+| **Phase 3 (impl frontend)** | `shared/refs-popover.{js,css}` + i18n keys + wire `?` into kanban/docs/PR portal pages | impl card spawned |
+| **Phase 4 (back-link scan)** | Inbound direction works (PR body mentions card_X → card's `?` panel shows back-link) | included in Phase 2 |
+| **Phase 5 (graph view)** | `/api/refs/graph` + dedicated `/portal/refs/graph.html` | OPTIONAL, deferred to v1.5 if Phase 1-4 are usable |
+
+## 7. Acceptance criteria
+
+- **AC1** — Spec PR merged after Hank + #1/#6 review per `feedback_spec_first`.
+- **AC2** — `GET /api/refs?from=<id>` returns valid `RefsResponse` for any of the 4 ref kinds.
+- **AC3** — Background scan runs every 5 min and refreshes the cache without blocking requests.
+- **AC4** — Clicking `?` on any of the 3 v1 surfaces (kanban / spec doc / research doc) opens the popover with at least one out-direction ref.
+- **AC5** — Back-link auto-populates: open PR mentioning `card_X` in its body → card_X's `?` shows the PR as incoming, no manual editing.
+- **AC6** — Mobile bottom-sheet variant at 390 × 844 viewport.
+- **AC7** — Playwright prod E2E covering all 3 v1 surfaces + screenshots attached to the impl card per `feedback_personal_screenshot_review`.
+
+## 8. Rollback
+
+- Spec PR revert removes the doc only.
+- Phase 2 impl behind env flag `ECLAW_REFS_INDEX_ENABLED`; flag off → endpoint returns `{success:true, refs:[]}` — `?` icon renders an empty popover but doesn't break the UI.
+- Phase 3 impl: removing `<script src="shared/refs-popover.js">` from portal pages removes all `?` icons; no other DOM impact.
+
+## 9. References
+
+- Research card that surfaced the ask: `card_aa15ed2618c9246d11a0f6b1`
+- Existing chat-side reference expansion pattern: bridge's `[REFERENCES — CONTEXT]` block (see `claude-code-eclaw-channel/bridge.ts`)
+- Memory: `feedback_spec_first`, `feedback_link_card_full_e2e_required`, `feedback_i18n_delegate`, `feedback_personal_screenshot_review`


### PR DESCRIPTION
## Summary

Two spec docs driven by Hank chat 2026-06-03 19:29 TW (「card_aa15ed26 直接全做+整理SPEC+? icon 雙向參照」):

### 1. `docs/specs/mobile-use-integration.md` (card_7579f20...)
- M1: EClaw `/api/device/control` adds swipe / long_press / launch_app / stop_app primitives + new `/api/device/screen-image` (base64 PNG)
- M2: Python `EclawController(DeviceController)` ships as fork-as-extension to mobile-use's LangGraph
- 8 sections: motivation, arch (ASCII diagram), M1 API contract, M1 native handlers (Android + iOS), M2 class signature + method mapping + error model, acceptance for both milestones, rollback, references
- Feature flag `ECLAW_MOBILE_USE_API_ENABLED` (default off in prod until M2 ready)

### 2. `docs/specs/portal-bidirectional-refs.md` (card_a20b69d7...)
- Portal `?` icon (glyph `ⓘ`) on kanban cards / spec docs / research docs / PRs → popover with outgoing + incoming refs
- `GET /api/refs?from=<id>` backend; 5-min scan over kanban DB + `docs/specs/**/*.md` + `docs/research/**/*.md` + `gh pr list`
- 5-phase plan: spec → backend + scan → frontend popover → back-link auto-pop → graph view (v1.5)
- Direction: `out` (this cites) + `in` (cited by)
- i18n keys + mobile bottom-sheet variant

## Cards (filed earlier this turn)
- card_7579f20522a8276240736c7d — spec (this PR's primary)
- card_f693378a99739c82776c1978 — impl M1 (backlog; blocked-by spec sign-off)
- card_4331b6d7e31bcb808bfc1733 — impl M2 (backlog; chained after M1)
- card_a20b69d79f4aba684e7d04ec — ? icon spec + impl (parallel)

## Test plan
- [ ] Hank review of recommendation + scope
- [ ] #1 Mac_F sign-off on PR/scope splits per `feedback_planning_via_macf`
- [ ] On approval: file Phase 2 + 3 impl sub-cards for the `?` icon work
- [ ] Mobile-use M1 starts immediately on green-light

🤖 Generated with [Claude Code](https://claude.com/claude-code)