### PR TITLE
fix(device/control): revert ECLAW_MOBILE_USE_API_ENABLED global env gate

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1636,12 +1636,12 @@ app.get('/api/help', (req, res) => {
             { title: 'Send type text', curl: `curl -s -X POST "${apiBase}/api/device/control" -H "Content-Type: application/json" -d ${d},"command":"type","params":{"text":"hello"}}'` },
             { title: 'Send scroll', curl: `curl -s -X POST "${apiBase}/api/device/control" -H "Content-Type: application/json" -d ${d},"command":"scroll","params":{"direction":"down","amount":300}}'` },
             { title: 'Send back / home / ime_action', curl: `curl -s -X POST "${apiBase}/api/device/control" -H "Content-Type: application/json" -d ${d},"command":"back"}'  # or "home" / "ime_action"` },
-            { title: 'M1 mobile-use: swipe (requires ECLAW_MOBILE_USE_API_ENABLED=true)', curl: `curl -s -X POST "${apiBase}/api/device/control" -H "Content-Type: application/json" -d ${d},"command":"swipe","params":{"startX":100,"startY":800,"endX":100,"endY":200,"durationMs":250}}'` },
+            { title: 'M1 mobile-use: swipe', curl: `curl -s -X POST "${apiBase}/api/device/control" -H "Content-Type: application/json" -d ${d},"command":"swipe","params":{"startX":100,"startY":800,"endX":100,"endY":200,"durationMs":250}}'` },
             { title: 'M1 mobile-use: long_press', curl: `curl -s -X POST "${apiBase}/api/device/control" -H "Content-Type: application/json" -d ${d},"command":"long_press","params":{"x":150,"y":400,"durationMs":1000}}'` },
             { title: 'M1 mobile-use: launch_app (Android packageName / iOS bundleId)', curl: `curl -s -X POST "${apiBase}/api/device/control" -H "Content-Type: application/json" -d ${d},"command":"launch_app","params":{"packageName":"com.android.settings"}}'` },
             { title: 'M1 mobile-use: stop_app', curl: `curl -s -X POST "${apiBase}/api/device/control" -H "Content-Type: application/json" -d ${d},"command":"stop_app","params":{"packageName":"com.android.settings"}}'` },
             { title: 'M1 mobile-use: screen-image (base64 PNG for vision agents)', curl: `curl -s "${apiBase}/api/device/screen-image?deviceId=${deviceId}&botSecret=${botSecret}&entityId=${eId}&maxBytes=500000"` },
-            { title: 'Spec reference', curl: `# docs/specs/mobile-use-integration.md §3 — M1 control API expand.\n# Feature flag: ECLAW_MOBILE_USE_API_ENABLED=true on backend.\n# Without the flag, swipe/long_press/launch_app/stop_app + /screen-image return 403 feature-disabled.\n# Core primitives (tap/type/scroll/back/home/ime_action) remain ungated.` }
+            { title: 'Spec reference', curl: `# docs/specs/mobile-use-integration.md §3 — M1 control API expand.\n# All 4 new commands + /screen-image are always-on; per-user gating is the\n# existing remote_control_enabled device pref (per feedback_platform_user_rule_compliance).\n# 403 remote_control_disabled returned if the device owner hasn't enabled remote control in app Settings.` }
         ]
     };
 
@@ -19232,14 +19232,12 @@ app.post('/api/device/screen-result', (req, res) => {
  * GET /api/device/screen-image
  * M1 mobile-use parity (docs/specs/mobile-use-integration.md §3.2).
  * Long-poll capture of a raw screen image (PNG) for vision-based agents.
- * Auth: deviceId + (botSecret | deviceSecret). Gated by ECLAW_MOBILE_USE_API_ENABLED env.
+ * Auth: deviceId + (botSecret | deviceSecret). Per-user gating is the existing
+ * remote_control_enabled device pref (per feedback_platform_user_rule_compliance —
+ * no global env flag that decides for ALL EClawbot users).
  * Shares the 500ms rate-limit + the same pending-map as /screen-capture.
  */
 app.get('/api/device/screen-image', async (req, res) => {
-    if (process.env.ECLAW_MOBILE_USE_API_ENABLED !== 'true') {
-        return res.status(403).json({ success: false, error: 'feature-disabled',
-            message: 'screen-image requires ECLAW_MOBILE_USE_API_ENABLED=true' });
-    }
     const { deviceId, entityId, botSecret, deviceSecret, maxBytes } = req.query;
     if (!deviceId || (botSecret === undefined && deviceSecret === undefined)) {
         return res.status(400).json({ success: false, error: 'deviceId and botSecret (or deviceSecret) required' });
@@ -19336,8 +19334,9 @@ app.post('/api/device/screen-image-result', (req, res) => {
  *    or { deviceId, entityId, deviceSecret, command, params } — device owner auth (portal)
  *
  * Core commands: tap, type, scroll, back, home, ime_action (always available).
- * M1 mobile-use parity commands (ECLAW_MOBILE_USE_API_ENABLED=true): swipe, long_press,
- *   launch_app, stop_app. See docs/specs/mobile-use-integration.md §3.1.
+ * M1 mobile-use parity commands (always-on, per-user via remote_control_enabled
+ * pref): swipe, long_press, launch_app, stop_app. See
+ * docs/specs/mobile-use-integration.md §3.1.
  */
 app.post('/api/device/control', async (req, res) => {
     const { deviceId, entityId, botSecret, deviceSecret, command, params } = req.body;
@@ -19346,17 +19345,16 @@ app.post('/api/device/control', async (req, res) => {
         return res.status(400).json({ success: false, error: 'deviceId and command required' });
     }
 
-    // Core primitives — always available
-    const CORE_COMMANDS = new Set(['tap', 'type', 'scroll', 'back', 'home', 'ime_action']);
-    // M1 mobile-use parity — gated by ECLAW_MOBILE_USE_API_ENABLED env var
-    // (default false in prod until M2 ships per docs/specs/mobile-use-integration.md §3.3)
-    const M1_COMMANDS = new Set(['swipe', 'long_press', 'launch_app', 'stop_app']);
-    const mobileUseEnabled = process.env.ECLAW_MOBILE_USE_API_ENABLED === 'true';
-    if (M1_COMMANDS.has(command) && !mobileUseEnabled) {
-        return res.status(403).json({ success: false, error: 'feature-disabled',
-            message: 'mobile-use control primitives require ECLAW_MOBILE_USE_API_ENABLED=true' });
-    }
-    const VALID_COMMANDS = mobileUseEnabled ? new Set([...CORE_COMMANDS, ...M1_COMMANDS]) : CORE_COMMANDS;
+    // Core primitives + M1 mobile-use parity (swipe / long_press / launch_app /
+    // stop_app). All commands are available to any caller whose deviceSecret /
+    // botSecret pair authenticates; per-user opt-in is the existing
+    // remote_control_enabled device pref (gated below). Global env flags are
+    // not used here — per feedback_platform_user_rule_compliance, EClawbot is a
+    // global agent-collab platform and features must work for ALL users.
+    const VALID_COMMANDS = new Set([
+        'tap', 'type', 'scroll', 'back', 'home', 'ime_action',
+        'swipe', 'long_press', 'launch_app', 'stop_app',
+    ]);
     if (!VALID_COMMANDS.has(command)) {
         return res.status(400).json({ success: false, error: `Invalid command. Must be one of: ${[...VALID_COMMANDS].join(', ')}` });
     }

--- a/backend/tests/jest/screen-control.test.js
+++ b/backend/tests/jest/screen-control.test.js
@@ -246,36 +246,12 @@ describe('POST /api/device/control', () => {
 });
 
 // ════════════════════════════════════════════════════════════════
-// M1 mobile-use parity — gated commands + new screen-image endpoint
-// docs/specs/mobile-use-integration.md §3
+// M1 mobile-use parity — always-on commands + new screen-image endpoint
+// docs/specs/mobile-use-integration.md §3 (env-gate reverted per
+// feedback_platform_user_rule_compliance — global env flags banned)
 // ════════════════════════════════════════════════════════════════
-describe('POST /api/device/control — M1 mobile-use commands (gated)', () => {
-    const M1_ENV_KEY = 'ECLAW_MOBILE_USE_API_ENABLED';
-    let originalEnv;
-    beforeAll(() => { originalEnv = process.env[M1_ENV_KEY]; });
-    afterAll(() => {
-        if (originalEnv === undefined) delete process.env[M1_ENV_KEY];
-        else process.env[M1_ENV_KEY] = originalEnv;
-    });
-
-    it.each(['swipe', 'long_press', 'launch_app', 'stop_app'])(
-        'returns 403 feature-disabled when flag is off: %s',
-        async (command) => {
-            delete process.env[M1_ENV_KEY];
-            const deviceId = `m1-off-${command}`;
-            const secret = await registerDevice(deviceId);
-            const res = await post('/api/device/control')
-                .send({ deviceId, deviceSecret: secret, command, entityId: 0,
-                        params: command === 'swipe' ? { startX:0, startY:0, endX:10, endY:10 }
-                              : command === 'long_press' ? { x:5, y:5 }
-                              : { packageName: 'com.example' } });
-            expect(res.status).toBe(403);
-            expect(res.body.error).toBe('feature-disabled');
-        }
-    );
-
-    it('swipe accepts valid params with flag on', async () => {
-        process.env[M1_ENV_KEY] = 'true';
+describe('POST /api/device/control — M1 mobile-use commands (always-on)', () => {
+    it('swipe accepts valid params', async () => {
         const deviceId = 'm1-swipe-ok';
         const secret = await registerDevice(deviceId);
         const res = await post('/api/device/control')
@@ -286,7 +262,6 @@ describe('POST /api/device/control — M1 mobile-use commands (gated)', () => {
     });
 
     it('swipe rejects non-numeric coords (400)', async () => {
-        process.env[M1_ENV_KEY] = 'true';
         const deviceId = 'm1-swipe-bad';
         const secret = await registerDevice(deviceId);
         const res = await post('/api/device/control')
@@ -296,8 +271,7 @@ describe('POST /api/device/control — M1 mobile-use commands (gated)', () => {
         expect(res.body.error).toMatch(/swipe requires numeric/);
     });
 
-    it('long_press accepts valid coords with flag on', async () => {
-        process.env[M1_ENV_KEY] = 'true';
+    it('long_press accepts valid coords', async () => {
         const deviceId = 'm1-lp-ok';
         const secret = await registerDevice(deviceId);
         const res = await post('/api/device/control')
@@ -307,7 +281,6 @@ describe('POST /api/device/control — M1 mobile-use commands (gated)', () => {
     });
 
     it('long_press rejects missing coords (400)', async () => {
-        process.env[M1_ENV_KEY] = 'true';
         const deviceId = 'm1-lp-bad';
         const secret = await registerDevice(deviceId);
         const res = await post('/api/device/control')
@@ -316,8 +289,7 @@ describe('POST /api/device/control — M1 mobile-use commands (gated)', () => {
         expect(res.body.error).toMatch(/long_press requires numeric/);
     });
 
-    it('launch_app accepts packageName with flag on', async () => {
-        process.env[M1_ENV_KEY] = 'true';
+    it('launch_app accepts packageName', async () => {
         const deviceId = 'm1-launch-ok';
         const secret = await registerDevice(deviceId);
         const res = await post('/api/device/control')
@@ -327,7 +299,6 @@ describe('POST /api/device/control — M1 mobile-use commands (gated)', () => {
     });
 
     it('launch_app rejects empty params (400)', async () => {
-        process.env[M1_ENV_KEY] = 'true';
         const deviceId = 'm1-launch-bad';
         const secret = await registerDevice(deviceId);
         const res = await post('/api/device/control')
@@ -336,8 +307,7 @@ describe('POST /api/device/control — M1 mobile-use commands (gated)', () => {
         expect(res.body.error).toMatch(/packageName.*bundleId/);
     });
 
-    it('stop_app accepts bundleId with flag on', async () => {
-        process.env[M1_ENV_KEY] = 'true';
+    it('stop_app accepts bundleId', async () => {
         const deviceId = 'm1-stop-ok';
         const secret = await registerDevice(deviceId);
         const res = await post('/api/device/control')
@@ -345,41 +315,31 @@ describe('POST /api/device/control — M1 mobile-use commands (gated)', () => {
                     params: { bundleId: 'com.apple.Preferences' } });
         expect(res.status).toBe(200);
     });
+
+    it('rejects unknown command (400) — sanity check vocabulary did not regress', async () => {
+        const deviceId = 'm1-bogus';
+        const secret = await registerDevice(deviceId);
+        const res = await post('/api/device/control')
+            .send({ deviceId, deviceSecret: secret, command: 'not_a_command', entityId: 0 });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/invalid command/i);
+    });
 });
 
-describe('GET /api/device/screen-image — M1 mobile-use endpoint', () => {
-    const M1_ENV_KEY = 'ECLAW_MOBILE_USE_API_ENABLED';
-    let originalEnv;
-    beforeAll(() => { originalEnv = process.env[M1_ENV_KEY]; });
-    afterAll(() => {
-        if (originalEnv === undefined) delete process.env[M1_ENV_KEY];
-        else process.env[M1_ENV_KEY] = originalEnv;
-    });
-
-    it('returns 403 feature-disabled when flag is off', async () => {
-        delete process.env[M1_ENV_KEY];
-        const res = await request(app).get('/api/device/screen-image')
-            .query({ deviceId: 'si-off', deviceSecret: 'sec' });
-        expect(res.status).toBe(403);
-        expect(res.body.error).toBe('feature-disabled');
-    });
-
-    it('returns 400 when deviceId missing (flag on)', async () => {
-        process.env[M1_ENV_KEY] = 'true';
+describe('GET /api/device/screen-image — M1 mobile-use endpoint (always-on)', () => {
+    it('returns 400 when deviceId missing', async () => {
         const res = await request(app).get('/api/device/screen-image')
             .query({ deviceSecret: 'sec' });
         expect(res.status).toBe(400);
     });
 
-    it('returns 404 for unknown device (flag on)', async () => {
-        process.env[M1_ENV_KEY] = 'true';
+    it('returns 404 for unknown device', async () => {
         const res = await request(app).get('/api/device/screen-image')
             .query({ deviceId: 'unknown-si', deviceSecret: 'sec' });
         expect(res.status).toBe(404);
     });
 
     it('returns 503 device_offline when device not connected via socket', async () => {
-        process.env[M1_ENV_KEY] = 'true';
         const deviceId = 'si-offline';
         const secret = await registerDevice(deviceId);
         const res = await request(app).get('/api/device/screen-image')

--- a/docs/specs/mobile-use-integration.md
+++ b/docs/specs/mobile-use-integration.md
@@ -142,13 +142,11 @@ Compression: app-side downscales to fit `maxBytes` (default 500 KB) using Androi
 
 Rate-limit: same 500 ms minimum between captures as `/screen-capture`. Both endpoints share a single per-device cool-down counter.
 
-### 3.3 Feature flag
+### 3.3 Gating — per-user, not global
 
-All M1 expansion lives behind env var `ECLAW_MOBILE_USE_API_ENABLED`:
-- Dev / staging: `true` by default.
-- Prod: `false` until M2 is shipped and reviewed.
+The M1 commands + `/screen-image` are always available on the API surface, exactly like the existing 6 primitives. Per-user opt-in is the existing `remote_control_enabled` device preference (toggled by the user in app Settings, persisted via `/api/device-preferences`). No global env flag gates the feature for the whole platform.
 
-Existing 6 primitives are NOT gated — only the 4 new commands + `/screen-image` endpoint.
+This is a hard rule from `feedback_platform_user_rule_compliance`: EClawbot is a global agent-collab platform and a single env var on Railway must not decide behaviour for every user worldwide. (Earlier drafts of this spec had an `ECLAW_MOBILE_USE_API_ENABLED` global flag; that was reverted in `card_f03617476ab053d54384ae79` before any production user reached the endpoints.)
 
 ## 4. M1 — Native handler contract
 
@@ -265,7 +263,7 @@ If upstream interest is high (will probe via GitHub issue), an upstream PR can f
 - **AC1.1** — `jest` tests: 4 new commands + screen-image endpoint each pass authentication, param validation, rate-limit (`backend/tests/jest/screen-control.test.js` extends to ≥ 25 cases total).
 - **AC1.2** — Live probe: a bash script on this Mac drives a real Android emulator through all 4 new commands; expected screen changes confirmed via accessibility tree before/after.
 - **AC1.3** — `/api/device/screen-image` returns base64 PNG ≤ 500 KB; decoded image header is valid PNG.
-- **AC1.4** — Feature flag `ECLAW_MOBILE_USE_API_ENABLED=false` → all 4 new commands + screen-image return `403 {error: "feature-disabled"}`.
+- **AC1.4** — Per-user gate: `remote_control_enabled=false` on a device → all 4 new commands + screen-image return `403 {error: "remote_control_disabled"}` exactly like the existing 6 primitives. No global env flag involved.
 - **AC1.5** — `/api/help?intent=mobile-use` returns curl examples for all new endpoints.
 - **AC1.6** — Spec PR cites this doc section.
 
@@ -279,7 +277,7 @@ If upstream interest is high (will probe via GitHub issue), an upstream PR can f
 
 ## 7. Rollback
 
-M1: revert PR. Endpoint set returns to 6 commands. Feature flag automatically returns 403 for the 4 new endpoints if env is unset.
+M1: revert PR. Endpoint set returns to 6 commands. (No env flag exists; per-user `remote_control_enabled` gate keeps the existing surface unchanged.)
 
 M2: driver lives in its own repo / PyPI package. Removing the user's `pip install eclaw-mobile-use-driver` reverts.
 


### PR DESCRIPTION
## Summary

Hank 2026-06-03 19:57 TW called out that the M1 PR #3125 introduced `ECLAW_MOBILE_USE_API_ENABLED` — a single Railway env var that decides whether swipe / long_press / launch_app / stop_app / `/api/device/screen-image` are usable for **every** EClawbot user worldwide. That's exactly the single-tenant carveout banned by `feedback_platform_user_rule_compliance`.

The existing per-user `remote_control_enabled` device preference (which the 6 core primitives already use) is the correct opt-in surface. M1 commands now sit alongside the 6 cores in one `VALID_COMMANDS` set, gated by the same pref.

## Card
- `card_f03617476ab053d54384ae79` — P0 revert
- Linked prev: `card_f693378a99739c82776c1978` (M1 ship)

## What changed
- `backend/index.js`
  - `/api/device/control`: remove the `M1_COMMANDS` env check; merge into always-on `VALID_COMMANDS`. Per-command param validation kept.
  - `/api/device/screen-image`: remove the env check at the function head.
  - `/api/help` `remote_control` intent: drop the "requires ECLAW_MOBILE_USE_API_ENABLED" label; rewrite spec-reference curl to document the per-user pref.
  - All inline docstrings rewritten to point at `remote_control_enabled`.
- `backend/tests/jest/screen-control.test.js`
  - Drop 5 flag-off → 403 feature-disabled cases.
  - Rewrite M1 describe blocks as always-on; add a vocabulary-regression case.
  - **36 / 36 pass locally**.
- `docs/specs/mobile-use-integration.md`
  - §3.3 Feature flag → §3.3 Gating — per-user, not global, citing `feedback_platform_user_rule_compliance`.
  - AC1.4 expected error code → 403 `remote_control_disabled` (not feature-disabled).
  - §7 Rollback: drop env-flag rollback reference.

## Why P0
The current behaviour on prod is the wrong default (off-everywhere) AND it's the wrong design. No matter which value Hank picks for that env var, the design itself violates the platform rule. Reverting now keeps the original M1 intent (4 new commands + image endpoint) while restoring the correct global-platform behaviour.

## Test plan
- [x] `npx jest tests/jest/screen-control.test.js` — 36 / 36 pass
- [ ] CI: same suite green
- [ ] Prod curl probe post-merge: `swipe` on a bound device → device-level result (503 / remote_control_disabled / 200), NOT 403 feature-disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)