### PR TITLE
[codex] keep valid Codex rate limits

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -5579,8 +5579,10 @@
         // Rate thresholds (tokens in the last hour, Claude + Codex combined).
         const RATE_HEAVY_PER_HOUR  = 10_000_000;
         const RATE_NORMAL_PER_HOUR =  1_000_000;
+        const CODEX_RATE_LIMIT_CACHE_KEY = 'eclaw.dashboard.codexRateLimits.v1';
         let pollTimer = null;
         let lastFetchOk = false;
+        let lastValidCodexRateLimits = null;
 
         function t(key, fallback) {
             return (typeof i18n !== 'undefined' && typeof i18n.t === 'function') ? i18n.t(key) : fallback;
@@ -5638,6 +5640,89 @@
                     resetEl.textContent = '';
                 }
             }
+        }
+
+        function numberOrNull(value) {
+            if (value === null || value === undefined || value === '') return null;
+            const n = Number(value);
+            return Number.isFinite(n) ? n : null;
+        }
+
+        function isInvalidRawCodexRateLimits(rl) {
+            if (!rl || typeof rl !== 'object') return true;
+            const primary = rl.primary && typeof rl.primary === 'object' ? rl.primary : null;
+            if (primary && Number(primary.window_minutes) === 0) return true;
+            return Object.prototype.hasOwnProperty.call(rl, 'secondary') && rl.secondary == null;
+        }
+
+        function normalizeCodexRateLimits(rl) {
+            if (!rl || typeof rl !== 'object') return null;
+            if (isInvalidRawCodexRateLimits(rl)) return null;
+
+            if (rl.primary || rl.secondary) {
+                const primary = (rl.primary && typeof rl.primary === 'object') ? rl.primary : {};
+                const secondary = (rl.secondary && typeof rl.secondary === 'object') ? rl.secondary : {};
+                return {
+                    five_hour_pct: numberOrNull(primary.used_percent),
+                    five_hour_resets_at: numberOrNull(primary.resets_at),
+                    seven_day_pct: numberOrNull(secondary.used_percent),
+                    seven_day_resets_at: numberOrNull(secondary.resets_at),
+                    plan_type: typeof rl.plan_type === 'string' ? rl.plan_type : null,
+                    updated_at: typeof rl.updated_at === 'string' ? rl.updated_at : ''
+                };
+            }
+
+            return {
+                five_hour_pct: numberOrNull(rl.five_hour_pct),
+                five_hour_resets_at: numberOrNull(rl.five_hour_resets_at),
+                seven_day_pct: numberOrNull(rl.seven_day_pct),
+                seven_day_resets_at: numberOrNull(rl.seven_day_resets_at),
+                plan_type: typeof rl.plan_type === 'string' ? rl.plan_type : null,
+                updated_at: typeof rl.updated_at === 'string' ? rl.updated_at : ''
+            };
+        }
+
+        function isValidCodexRateLimits(rl) {
+            const normalized = normalizeCodexRateLimits(rl);
+            return !!normalized
+                && Number.isFinite(normalized.five_hour_pct)
+                && Number.isFinite(normalized.seven_day_pct);
+        }
+
+        function readCachedCodexRateLimits() {
+            try {
+                if (!window.localStorage) return null;
+                const cached = JSON.parse(window.localStorage.getItem(CODEX_RATE_LIMIT_CACHE_KEY) || 'null');
+                return isValidCodexRateLimits(cached) ? normalizeCodexRateLimits(cached) : null;
+            } catch (_) {
+                return null;
+            }
+        }
+
+        function writeCachedCodexRateLimits(rl) {
+            try {
+                if (window.localStorage && isValidCodexRateLimits(rl)) {
+                    window.localStorage.setItem(CODEX_RATE_LIMIT_CACHE_KEY, JSON.stringify(normalizeCodexRateLimits(rl)));
+                }
+            } catch (_) { /* localStorage is best-effort only. */ }
+        }
+
+        function resolveCodexRateLimits(rl) {
+            if (isValidCodexRateLimits(rl)) {
+                lastValidCodexRateLimits = normalizeCodexRateLimits(rl);
+                writeCachedCodexRateLimits(lastValidCodexRateLimits);
+                return lastValidCodexRateLimits;
+            }
+            if (!lastValidCodexRateLimits) lastValidCodexRateLimits = readCachedCodexRateLimits();
+            return lastValidCodexRateLimits;
+        }
+
+        function withResolvedCodexRateLimits(latest) {
+            if (!latest || !latest.codex) return latest;
+            const resolved = resolveCodexRateLimits(latest.codex.rate_limits);
+            return Object.assign({}, latest, {
+                codex: Object.assign({}, latest.codex, { rate_limits: resolved })
+            });
         }
 
         function renderClaudeBars(latest) {
@@ -5876,14 +5961,15 @@
                 if (!snapRes.ok) throw new Error('http ' + snapRes.status);
                 const snap = await snapRes.json();
                 if (!snap.success) throw new Error(snap.error || 'snapshot failed');
+                const latest = withResolvedCodexRateLimits(snap.latest);
 
                 lastFetchOk = true;
                 showContent();
-                renderClaudeBars(snap.latest);
-                renderCodexBars(snap.latest);
-                renderProjects(snap.latest);
-                renderStatusFooter(snap.latest, snap.aggregates);
-                renderHealth(snap.latest);
+                renderClaudeBars(latest);
+                renderCodexBars(latest);
+                renderProjects(latest);
+                renderStatusFooter(latest, snap.aggregates);
+                renderHealth(latest);
             } catch (err) {
                 console.warn('[UsageWidget] load failed:', err && err.message);
                 if (!lastFetchOk) showError();

--- a/backend/tests/jest/dashboard-usage-widget-rate-limits.test.js
+++ b/backend/tests/jest/dashboard-usage-widget-rate-limits.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const DASHBOARD_HTML = path.resolve(__dirname, '../../public/portal/dashboard.html');
+
+function makeLocalStorage() {
+    const store = new Map();
+    return {
+        getItem(key) {
+            return store.has(key) ? store.get(key) : null;
+        },
+        setItem(key, value) {
+            store.set(key, String(value));
+        }
+    };
+}
+
+function loadUsageHelpers(localStorage = makeLocalStorage()) {
+    const html = fs.readFileSync(DASHBOARD_HTML, 'utf8');
+    const match = html.match(/const CODEX_RATE_LIMIT_CACHE_KEY[\s\S]*?\n\s*function renderClaudeBars/);
+    expect(match).toBeTruthy();
+    const helperCode = match[0].replace(/\n\s*function renderClaudeBars$/, '');
+    const context = {
+        window: { localStorage }
+    };
+
+    return vm.runInNewContext(
+        helperCode + '\n({ normalizeCodexRateLimits, isValidCodexRateLimits, resolveCodexRateLimits, withResolvedCodexRateLimits });',
+        context
+    );
+}
+
+describe('Dashboard usage widget Codex rate limits', () => {
+    test('rejects the Codex CLI zero-window raw rate-limit block', () => {
+        const helpers = loadUsageHelpers();
+        expect(helpers.isValidCodexRateLimits({
+            primary: { used_percent: 0.0, window_minutes: 0, resets_at: 1780000000 },
+            secondary: null,
+            plan_type: 'pro'
+        })).toBe(false);
+    });
+
+    test('falls back to the previous valid flat Codex rate limits', () => {
+        const helpers = loadUsageHelpers();
+        const valid = {
+            five_hour_pct: 42,
+            five_hour_resets_at: 1780000000,
+            seven_day_pct: 17,
+            seven_day_resets_at: 1780500000,
+            plan_type: 'pro',
+            updated_at: '2026-06-03T10:00:00Z'
+        };
+
+        expect(helpers.resolveCodexRateLimits(valid)).toEqual(valid);
+        expect(helpers.resolveCodexRateLimits({
+            five_hour_pct: 0,
+            five_hour_resets_at: 1780000000,
+            seven_day_pct: null,
+            seven_day_resets_at: null,
+            plan_type: 'pro'
+        })).toEqual(valid);
+    });
+
+    test('falls back to cached valid Codex rate limits after reload', () => {
+        const localStorage = makeLocalStorage();
+        const firstLoad = loadUsageHelpers(localStorage);
+        const valid = {
+            five_hour_pct: 34,
+            five_hour_resets_at: 1780000100,
+            seven_day_pct: 12,
+            seven_day_resets_at: 1780500100,
+            plan_type: 'pro',
+            updated_at: '2026-06-03T10:01:00Z'
+        };
+
+        firstLoad.resolveCodexRateLimits(valid);
+        const secondLoad = loadUsageHelpers(localStorage);
+
+        expect(secondLoad.resolveCodexRateLimits({
+            primary: { used_percent: 0.0, window_minutes: 0, resets_at: 1780000200 },
+            secondary: null,
+            plan_type: 'pro'
+        })).toEqual(valid);
+    });
+
+    test('loader renders with resolved latest snapshot data', () => {
+        const html = fs.readFileSync(DASHBOARD_HTML, 'utf8');
+        expect(html).toContain('const latest = withResolvedCodexRateLimits(snap.latest);');
+        expect(html).toContain('renderCodexBars(latest);');
+        expect(html).not.toContain('renderCodexBars(snap.latest);');
+    });
+});

--- a/backend/tooling/eclaw-usage-daemon/codex_loader.py
+++ b/backend/tooling/eclaw-usage-daemon/codex_loader.py
@@ -51,6 +51,22 @@ def _as_float(v: Any) -> float | None:
     return float(v)
 
 
+def _is_valid_rate_limits(v: Any) -> bool:
+    rl = _as_dict(v)
+    if not rl:
+        return False
+    primary = _as_dict(rl.get("primary"))
+    secondary = _as_dict(rl.get("secondary"))
+    if not primary or not secondary:
+        return False
+    if _as_float(primary.get("window_minutes")) == 0:
+        return False
+    return (
+        _as_float(primary.get("used_percent")) is not None
+        and _as_float(secondary.get("used_percent")) is not None
+    )
+
+
 def _project_from_cwd(cwd: str) -> str:
     if not cwd:
         return "unknown"
@@ -199,11 +215,10 @@ class CodexLoader:
                     if payload.get("type") != "token_count":
                         continue
 
-                    if file_rate_limits is None:
-                        rl = _as_dict(payload.get("rate_limits"))
-                        if rl:
-                            file_rate_limits = rl
-                            file_rate_limits_ts = _as_str(d.get("timestamp"))
+                    rl = _as_dict(payload.get("rate_limits"))
+                    if _is_valid_rate_limits(rl):
+                        file_rate_limits = rl
+                        file_rate_limits_ts = _as_str(d.get("timestamp"))
 
                     info = _as_dict(payload.get("info"))
                     usage = _as_dict(info.get("total_token_usage"))

--- a/backend/tooling/eclaw-usage-daemon/tests/test_codex_loader.py
+++ b/backend/tooling/eclaw-usage-daemon/tests/test_codex_loader.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 from pathlib import Path
 
@@ -84,6 +85,116 @@ def test_token_count_event_aggregates(tmp_path: Path) -> None:
     assert rl["five_hour_pct"] == 12.5
     assert rl["seven_day_pct"] == 7.0
     assert rl["plan_type"] == "pro"
+
+
+def test_bad_rate_limit_block_skips_to_previous_valid(tmp_path: Path) -> None:
+    sessions_dir = tmp_path / "sessions"
+    state_db = tmp_path / "state.sqlite"
+    _make_state_db(state_db, {})
+
+    loader = CodexLoader(sessions_dir=sessions_dir, state_db=state_db)
+
+    old_path = sessions_dir / "old.jsonl"
+    new_path = sessions_dir / "new.jsonl"
+    _write(
+        old_path,
+        {"type": "session_meta", "payload": {"id": "old", "timestamp": "2026-06-03T09:00:00Z", "cwd": "/old"}},
+        {
+            "type": "event_msg",
+            "timestamp": "2026-06-03T09:01:00Z",
+            "payload": {
+                "type": "token_count",
+                "rate_limits": {
+                    "primary": {"used_percent": 51.0, "resets_at": 1780000000},
+                    "secondary": {"used_percent": 22.0, "resets_at": 1780500000},
+                    "plan_type": "pro",
+                },
+                "info": {"total_token_usage": {"input_tokens": 10, "output_tokens": 5}},
+            },
+        },
+    )
+    _write(
+        new_path,
+        {"type": "session_meta", "payload": {"id": "new", "timestamp": "2026-06-03T10:00:00Z", "cwd": "/new"}},
+        {
+            "type": "event_msg",
+            "timestamp": "2026-06-03T10:01:00Z",
+            "payload": {
+                "type": "token_count",
+                "rate_limits": {
+                    "primary": {"used_percent": 0.0, "window_minutes": 0, "resets_at": 1780000100},
+                    "secondary": None,
+                    "plan_type": "pro",
+                },
+                "info": {"total_token_usage": {"input_tokens": 12, "output_tokens": 6}},
+            },
+        },
+    )
+    os.utime(old_path, (1000, 1000))
+    os.utime(new_path, (2000, 2000))
+
+    sessions, rl = loader.load(hours_back=0)
+    assert len(sessions) == 2
+    assert rl is not None
+    assert rl["five_hour_pct"] == 51.0
+    assert rl["seven_day_pct"] == 22.0
+
+
+def test_file_rate_limits_keep_last_valid_block(tmp_path: Path) -> None:
+    sessions_dir = tmp_path / "sessions"
+    state_db = tmp_path / "state.sqlite"
+    _make_state_db(state_db, {})
+
+    loader = CodexLoader(sessions_dir=sessions_dir, state_db=state_db)
+
+    _write(
+        sessions_dir / "rollout.jsonl",
+        {"type": "session_meta", "payload": {"id": "thread-a", "timestamp": "2026-06-03T09:00:00Z", "cwd": "/x"}},
+        {
+            "type": "event_msg",
+            "timestamp": "2026-06-03T09:01:00Z",
+            "payload": {
+                "type": "token_count",
+                "rate_limits": {
+                    "primary": {"used_percent": 8.0, "resets_at": 1780000000},
+                    "secondary": {"used_percent": 3.0, "resets_at": 1780500000},
+                    "plan_type": "pro",
+                },
+                "info": {"total_token_usage": {"input_tokens": 10, "output_tokens": 5}},
+            },
+        },
+        {
+            "type": "event_msg",
+            "timestamp": "2026-06-03T09:02:00Z",
+            "payload": {
+                "type": "token_count",
+                "rate_limits": {
+                    "primary": {"used_percent": 0.0, "window_minutes": 0, "resets_at": 1780000100},
+                    "secondary": None,
+                    "plan_type": "pro",
+                },
+                "info": {"total_token_usage": {"input_tokens": 12, "output_tokens": 6}},
+            },
+        },
+        {
+            "type": "event_msg",
+            "timestamp": "2026-06-03T09:03:00Z",
+            "payload": {
+                "type": "token_count",
+                "rate_limits": {
+                    "primary": {"used_percent": 19.0, "resets_at": 1780000200},
+                    "secondary": {"used_percent": 7.0, "resets_at": 1780500200},
+                    "plan_type": "pro",
+                },
+                "info": {"total_token_usage": {"input_tokens": 14, "output_tokens": 7}},
+            },
+        },
+    )
+
+    _, rl = loader.load(hours_back=0)
+    assert rl is not None
+    assert rl["five_hour_pct"] == 19.0
+    assert rl["seven_day_pct"] == 7.0
 
 
 def test_corrupt_lines_skipped(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- ignore malformed Codex CLI rate-limit blocks with zero-minute primary windows or missing secondary data
- keep the latest valid Codex rate limits in the usage daemon and dashboard widget
- add focused Python and Jest regression coverage for fallback and localStorage cache behavior

## Root Cause
Codex session logs can emit a transient raw rate-limit block with `primary.window_minutes = 0` and `secondary = null`. The loader/dashboard accepted that as fresh data, which replaced valid usage percentages with unusable values.

## Validation
- `/tmp/venv/bin/python -m pytest backend/tooling/eclaw-usage-daemon/tests/test_codex_loader.py`
- `cd backend && npx jest --runInBand tests/jest/dashboard-usage-widget-rate-limits.test.js`

## Notes
- An accidental broader `npm test -- --runInBand backend/tests/jest/dashboard-usage-widget-rate-limits.test.js` run expanded into the full backend suite and was stopped; it surfaced an unrelated existing failure in `tests/jest/showConfirm-a11y-attrs.test.js` before termination.
