### PR TITLE
spec(web-interactive-dev): v1 UI + diff→prompt contract

### DIFF
--- a/docs/web-interactive-dev/api-contract.json
+++ b/docs/web-interactive-dev/api-contract.json
@@ -1,0 +1,245 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://github.com/HankHuang0516/web-interactive-dev/blob/main/docs/api-contract.json",
+  "title": "web-interactive-dev DiffEnvelope v1",
+  "description": "Normative contract for the JSON returned by InteractiveDevSession.exportDiff(). See docs/spec.md §3.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "session", "edits"],
+  "properties": {
+    "version": {
+      "const": "web-interactive-dev/v1",
+      "description": "Schema version. Hard-pinned in v1 — Agents check this before parsing."
+    },
+    "session": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "createdAt", "source"],
+      "properties": {
+        "id":        { "type": "string", "pattern": "^wid_[a-f0-9]{8,}$" },
+        "createdAt": { "type": "string", "format": "date-time" },
+        "source":    { "$ref": "#/$defs/SourceInput" }
+      }
+    },
+    "edits": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/Edit" }
+    }
+  },
+  "$defs": {
+    "SourceInput": {
+      "oneOf": [
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "byteLength"],
+          "properties": {
+            "kind":       { "const": "html-paste" },
+            "uriHint":    { "type": "string", "maxLength": 256 },
+            "byteLength": { "type": "integer", "minimum": 0 }
+          }
+        },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "url"],
+          "properties": {
+            "kind":       { "const": "html-url" },
+            "url":        { "type": "string", "format": "uri" },
+            "byteLength": { "type": "integer", "minimum": 0 }
+          }
+        }
+      ]
+    },
+
+    "TargetLocator": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["selector", "selectorKind", "confidence"],
+      "properties": {
+        "selector":     { "type": "string", "minLength": 1, "maxLength": 1024 },
+        "selectorKind": { "enum": ["css", "data-id", "xpath"] },
+        "fallbackText": { "type": "string", "maxLength": 240 },
+        "rect": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["x", "y", "w", "h"],
+          "properties": {
+            "x": { "type": "integer" },
+            "y": { "type": "integer" },
+            "w": { "type": "integer", "minimum": 0 },
+            "h": { "type": "integer", "minimum": 0 }
+          }
+        },
+        "confidence":   { "type": "number", "minimum": 0, "maximum": 1 }
+      }
+    },
+
+    "Edit": {
+      "oneOf": [
+        { "$ref": "#/$defs/TextEdit" },
+        { "$ref": "#/$defs/StyleEdit" },
+        { "$ref": "#/$defs/AttributeEdit" },
+        { "$ref": "#/$defs/ReplaceEdit" },
+        { "$ref": "#/$defs/RemoveEdit" }
+      ]
+    },
+
+    "EditCommon": {
+      "type": "object",
+      "required": ["id", "kind", "target"],
+      "properties": {
+        "id":     { "type": "string", "pattern": "^edit_[a-zA-Z0-9_]{1,32}$" },
+        "kind":   { "enum": ["text", "style", "attribute", "replace", "remove"] },
+        "target": { "$ref": "#/$defs/TargetLocator" },
+        "intent": { "type": "string", "maxLength": 280 }
+      }
+    },
+
+    "TextEdit": {
+      "allOf": [
+        { "$ref": "#/$defs/EditCommon" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "id", "target", "before", "after"],
+          "properties": {
+            "kind":   { "const": "text" },
+            "id":     {},
+            "target": {},
+            "intent": {},
+            "before": {
+              "type": "object", "additionalProperties": false,
+              "required": ["textContent"],
+              "properties": { "textContent": { "type": "string" } }
+            },
+            "after": {
+              "type": "object", "additionalProperties": false,
+              "required": ["textContent"],
+              "properties": { "textContent": { "type": "string" } }
+            }
+          }
+        }
+      ]
+    },
+
+    "StyleEdit": {
+      "allOf": [
+        { "$ref": "#/$defs/EditCommon" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "id", "target", "before", "after"],
+          "properties": {
+            "kind":   { "const": "style" },
+            "id":     {},
+            "target": {},
+            "intent": {},
+            "before": { "$ref": "#/$defs/StylePayload" },
+            "after":  { "$ref": "#/$defs/StylePayload" }
+          }
+        }
+      ]
+    },
+
+    "StylePayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "style": {
+          "type": "object",
+          "description": "CSS property → value (allowlisted set per spec §2.3).",
+          "additionalProperties": { "type": ["string", "null"] }
+        },
+        "customCss": {
+          "type": "string",
+          "description": "Opaque CSS text for properties outside the allowlist.",
+          "maxLength": 4096
+        }
+      }
+    },
+
+    "AttributeEdit": {
+      "allOf": [
+        { "$ref": "#/$defs/EditCommon" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "id", "target", "before", "after"],
+          "properties": {
+            "kind":   { "const": "attribute" },
+            "id":     {},
+            "target": {},
+            "intent": {},
+            "before": { "$ref": "#/$defs/AttributePayload" },
+            "after":  { "$ref": "#/$defs/AttributePayload" }
+          }
+        }
+      ]
+    },
+
+    "AttributePayload": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["attributes"],
+      "properties": {
+        "attributes": {
+          "type": "object",
+          "description": "attribute name → value. null in 'after' means remove.",
+          "additionalProperties": { "type": ["string", "null"] }
+        }
+      }
+    },
+
+    "ReplaceEdit": {
+      "allOf": [
+        { "$ref": "#/$defs/EditCommon" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "id", "target", "before", "after"],
+          "properties": {
+            "kind":   { "const": "replace" },
+            "id":     {},
+            "target": {},
+            "intent": {},
+            "before": {
+              "type": "object", "additionalProperties": false,
+              "required": ["outerHTML"],
+              "properties": { "outerHTML": { "type": "string", "maxLength": 16384 } }
+            },
+            "after": {
+              "type": "object", "additionalProperties": false,
+              "required": ["outerHTML"],
+              "properties": { "outerHTML": { "type": "string", "maxLength": 16384 } }
+            }
+          }
+        }
+      ]
+    },
+
+    "RemoveEdit": {
+      "allOf": [
+        { "$ref": "#/$defs/EditCommon" },
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["kind", "id", "target", "before", "after"],
+          "properties": {
+            "kind":   { "const": "remove" },
+            "id":     {},
+            "target": {},
+            "intent": {},
+            "before": {
+              "type": "object", "additionalProperties": false,
+              "required": ["outerHTML"],
+              "properties": { "outerHTML": { "type": "string", "maxLength": 16384 } }
+            },
+            "after":  { "type": "null" }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/docs/web-interactive-dev/e2e-scenarios.md
+++ b/docs/web-interactive-dev/e2e-scenarios.md
@@ -1,0 +1,108 @@
+# web-interactive-dev — v1 E2E Scenarios
+
+> Five happy-path scenarios. **All scenarios are browser-only.** No network calls, no auth, no EClaw integration. Each scenario is testable against the static-site build via Playwright or Cypress; manual repro steps are listed for review.
+
+Pre-state common to every scenario:
+- Build target is hosted on `http://localhost:5173/` (or `file://`).
+- The user opens the page. No prior session in `localStorage`.
+- A test fixture HTML is pasted into the **Source** tab. The fixture is committed under `tests/fixtures/landing.html` and is plain semantic HTML (one `<header>`, one `<main>` with a hero `<section>`, one `<a id="buy">` button, two `<article class="card">` blocks).
+
+---
+
+## Scenario 1 — Edit hero headline text (single edit)
+
+**User intent**: Translate the H1 from English to zh-TW.
+
+**Steps**:
+1. Press `P` to arm pointing. Pointer becomes a crosshair.
+2. Hover over the H1; the 2-px outline + tag chip (`<h1>`) appears.
+3. Click the H1. The right panel opens on the **Text** tab pre-filled with `"Welcome to MyApp"`.
+4. Change the value to `"歡迎光臨 MyApp"`. Press `⌘/Ctrl+Enter`.
+5. The edits list shows one row: `▸ h1 → "歡迎光臨 MyApp"`.
+6. Click **Export Prompt**. The Prompt view renders.
+7. Click the **⧉ Copy** icon.
+
+**Expected**:
+- The clipboard contains a string whose `## edit_01 — text` block contains exactly:
+  - `before.textContent: "Welcome to MyApp"`
+  - `after.textContent:  "歡迎光臨 MyApp"`
+- The raw JSON block at the bottom of the prompt validates against `docs/api-contract.json`.
+- The preview pane still shows the ORIGINAL text (`"Welcome to MyApp"`). v1 does not mutate the preview — only the diff envelope.
+
+---
+
+## Scenario 2 — Change a button background color (style edit, allowlisted property)
+
+**User intent**: Recolor the primary CTA from blue to red.
+
+**Steps**:
+1. Press `P`, click `button.cta`.
+2. Switch to the **Style** tab. The current `background-color` shows as `#1a73e8` (computed from the inline / linked stylesheet).
+3. Edit it to `#d63b3b`. Press Save.
+4. The edits list now has one row: `▸ .cta → background-color #d63b3b`.
+5. Click **Export Prompt**.
+
+**Expected**:
+- The diff envelope's `edits[0]` has `kind:"style"`, `before.style["background-color"]:"#1a73e8"`, `after.style["background-color"]:"#d63b3b"`.
+- The `customCss` field is absent (we only used the allowlisted property).
+- Prompt body shows the before/after style blocks formatted as JSON, not as raw CSS.
+
+---
+
+## Scenario 3 — Change an anchor `href` (attribute edit)
+
+**User intent**: Add a UTM parameter to the buy link.
+
+**Steps**:
+1. Press `P`, click `a#buy`.
+2. Switch to **Attribute** tab. Existing attributes are listed; `href = /checkout?v=1`.
+3. Edit `href` to `/checkout?v=2&utm=hero`. Save.
+
+**Expected**:
+- One row in the edits list: `▸ a#buy → href=/checkout?v=2&utm=hero`.
+- The diff envelope's edit has `kind:"attribute"`, `before.attributes.href:"/checkout?v=1"`, `after.attributes.href:"/checkout?v=2&utm=hero"`.
+- `confidence` on the target is ≥ 0.95 (because `#buy` is an id).
+
+---
+
+## Scenario 4 — Multi-edit batch + reorder + export (three edits in one session)
+
+**User intent**: Combine Scenarios 1, 2, 3 into a single prompt and export them as one batch, with edits reordered.
+
+**Steps**:
+1. Perform Scenario 1, 2, 3 in that order, but DO NOT export between them.
+2. The edits list shows three rows in chronological order.
+3. Drag edit #3 (the `href` change) above edit #1. New order: `href`, `text`, `style`.
+4. Click **Export Prompt**.
+
+**Expected**:
+- The exported `DiffEnvelope` has `edits: [attribute, text, style]` — in the dragged order, NOT chronological.
+- The prompt body's `## edit_01`, `## edit_02`, `## edit_03` headings reflect that same order.
+- The session ID (`session.id`) is identical for all three edits in the envelope.
+- The diff envelope still passes the JSON Schema after reorder.
+
+---
+
+## Scenario 5 — Discard an edit before export
+
+**User intent**: User makes three edits, decides the style change was wrong, drops it, then exports the remaining two.
+
+**Steps**:
+1. Perform Scenario 1, 2, 3 in order.
+2. Hover over the **style** row in the edits list. Click the trash-can icon (or swipe-left on mobile).
+3. A confirm chip appears (`Remove this edit? · Undo`). Click outside or wait 4s — chip dismisses and the row is gone.
+4. The edits list now has two rows: text + attribute (chronological).
+5. Click **Export Prompt**.
+
+**Expected**:
+- The exported envelope has `edits.length === 2`. No `edit_02` style entry present.
+- Edit IDs are not renumbered — the surviving entries keep their original IDs (`edit_01`, `edit_03`).
+- The Prompt header line `# Edits requested (N)` reads `(2)`, not `(3)`.
+
+---
+
+## Notes for the test harness (informative — not part of acceptance)
+
+- All five scenarios assert on **the exported envelope** (`session.exportDiff()`) and **the exported prompt string** (`session.exportPrompt()`), not on the preview DOM. The preview iframe is sandboxed and read-only by design in v1.
+- `session.id` is generated at `createSession()` time; it must remain stable across edits within one tab session and must change when the user clicks **Reset**.
+- A grep-based smoke test runs against the built bundle and asserts that none of `eclaw`, `botSecret`, `device-vars`, `publicCode`, `entityId`, `bridge-auth` appears in any output `.js` / `.css` / `.html` — wired by U96 as part of the standalone repo's CI.

--- a/docs/web-interactive-dev/spec.md
+++ b/docs/web-interactive-dev/spec.md
@@ -1,0 +1,262 @@
+# web-interactive-dev — v1 Spec
+
+> Tracker card: `card_ba085c28d403e57a51e8c931`
+> Standalone repo (post-merge target): `github.com/HankHuang0516/web-interactive-dev` (created by U96).
+> This file lives in the EClaw repo only for the Spec PR review window. U96 copies it verbatim into the standalone repo.
+
+## 0. Platform & Dependency Gate (HARD)
+
+- **v1 = WEB ONLY**. The artifact runs in a modern browser (Chromium ≥ 120, Safari ≥ 17, Firefox ≥ 121). No native iOS/Android wrappers in v1.
+- **Build target: static site / SPA** (no server runtime). Output is a folder of `.html` + `.js` + `.css` that can be served by any static host (Pages, Cloudflare Pages, file://, `python -m http.server`). Rationale: the entire diff→prompt pipeline runs client-side; a server adds an attack surface and a deploy dependency without enabling any v1 user need.
+- **No EClaw dependency, period.** v1 must not:
+  - Import any EClaw npm package, fetch any `eclawbot.com` URL, or read any EClaw-shaped config (`device-vars`, `botSecret`, `entityId`, `publicCode`, channel keys).
+  - Embed an EClaw bridge, channel adapter, kanban call, or bot dispatch.
+  - Assume a logged-in EClaw identity. v1 is **single local user**: state is `localStorage` + in-memory only.
+- **CI gate (must ship with the standalone repo)**: a grep-based test that fails if `eclaw`, `botSecret`, `device-vars`, or `publicCode` appears anywhere under `src/` or `public/`. Wired by U96.
+
+## 1. Problem statement
+
+A developer wants to point at an element on a rendered page (their own HTML, or HTML they pasted in), edit it visually (text / style / attribute), and walk away with a **prompt string** that any LLM Agent (Claude, GPT, etc.) can ingest to reproduce the same edit in source code. v1 does not generate code; it generates *the request for code* in a deterministic, agent-friendly shape.
+
+## 2. UI scope — point-and-edit + side panel
+
+### 2.1 Layout
+
+```
+┌───────────────────────────────────────────────┬──────────────────────┐
+│                                               │  Edits (3)           │
+│            <preview iframe>                   │  ─────────────────── │
+│                                               │  ▸ h1 → "新標題"     │
+│      [pointer crosshair when armed]           │  ▸ .cta → color:red  │
+│                                               │  ▸ a#buy → href=…    │
+│                                               │  ─────────────────── │
+│                                               │  [ Export Prompt ⧉ ] │
+└───────────────────────────────────────────────┴──────────────────────┘
+[Source ▸] [Edits ▸] [Prompt ▸]   ← bottom tab strip
+```
+
+- **Preview pane (left)**: an `<iframe sandbox="allow-same-origin">` rendering the user's HTML. Pointer overlay highlights the hovered element with a 2px outline + tag chip.
+- **Edits pane (right)**: stacked list of pending edits; each row shows target locator + a one-line summary of the change. Click expands inline editors. Drag to reorder, swipe-left to discard.
+- **Bottom tab strip**: toggles between three modal views — `Source` (paste/load HTML), `Edits` (the right pane, on mobile), `Prompt` (the rendered output preview before copy).
+
+### 2.2 Interaction states
+
+| State        | Pointer | Click action                                            | Exit |
+|--------------|---------|---------------------------------------------------------|------|
+| `idle`       | default | no-op                                                   | —    |
+| `armed`      | crosshair | element selected → opens edit panel; state → `editing` | Esc → `idle` |
+| `editing`    | default | clicks land in panel inputs                             | Save → record edit + back to `idle`; Cancel → drop |
+| `prompt-view`| default | read-only render of the prompt string                   | Back → `idle` |
+
+Keyboard: `P` arms / disarms pointing. `⌘/Ctrl+Enter` in any input commits the edit. `⌘/Ctrl+Shift+P` exports the prompt to clipboard.
+
+### 2.3 Editable surfaces (v1)
+
+For a picked element, the side panel exposes exactly three tabs:
+
+1. **Text** — `textContent` (single-line or multiline depending on tagName).
+2. **Style** — a curated allowlist: `color`, `background-color`, `font-size`, `font-weight`, `padding`, `margin`, `border-radius`, `display`, `text-align`. Free-form CSS goes through a "Custom CSS" textarea that we treat as opaque string.
+3. **Attribute** — `href`, `src`, `alt`, `title`, `class`, `id`, plus a free-form "Add attribute" row (key/value).
+
+Anything outside the allowlist must still be representable via the *Custom CSS* + *Add attribute* escape hatches — the contract never silently drops user intent.
+
+### 2.4 Target locator
+
+A picked element is identified by a locator object (shared with the diff format, §3):
+
+```
+{
+  "selector":   "main > section.hero > h1",     // css selector relative to <body>
+  "selectorKind": "css",                         // "css" | "data-id" | "xpath" (v1 emits "css")
+  "fallbackText": "Welcome to MyApp",            // first 80 chars of original textContent, for human readability
+  "rect":       { "x": 120, "y": 84, "w": 540, "h": 36 },  // page coords at pick time, for visual reference
+  "confidence": 0.85                             // 0..1; bumped to 0.95 if [id] or [data-*] was usable
+}
+```
+
+`selector` generation follows the same priority order point-edit-demo uses today (data-attr > id > stable class chain > nth-of-type), so the contract is consistent with prior internal practice without depending on it.
+
+## 3. Diff format — JSON (decision + rationale)
+
+**v1 emits a JSON diff envelope, NOT unified diff.** The schema is in `api-contract.json`; the worked example is here.
+
+### 3.1 Why JSON, not unified diff
+
+| Need (v1)                                  | Unified diff      | JSON envelope     |
+|--------------------------------------------|-------------------|-------------------|
+| Express "change attribute X on element Y"  | hard (line-based) | trivial (typed)   |
+| Express style edits that are not in source | impossible        | first-class       |
+| Carry locator + confidence + rect          | requires comments | structured field  |
+| Filter / merge programmatically            | regex-and-pray    | `Array.filter`    |
+| Convert JSON → unified diff downstream     | n/a               | one transform     |
+| Convert unified diff → structured JSON     | lossy             | n/a               |
+
+Unified diff assumes the user's edit *is* a textual line change. Most of our v1 edits aren't — they're DOM mutations against a rendered preview where the source may be HTML, JSX, MDX, Vue SFC, or pasted snippet. JSON is the lossless superset; a downstream consumer can synthesise unified diff from it. The reverse is not true.
+
+### 3.2 Shape (informative — schema is normative)
+
+```json
+{
+  "version": "web-interactive-dev/v1",
+  "session": {
+    "id": "wid_8b3e5f2a",                                  
+    "createdAt": "2026-06-03T13:00:00Z",
+    "source": {
+      "kind": "html-paste",                                  
+      "uriHint": "user-supplied-2026-06-03.html",           
+      "byteLength": 18243
+    }
+  },
+  "edits": [
+    {
+      "id": "edit_01",
+      "kind": "text",                                        
+      "target": {
+        "selector": "main > section.hero > h1",
+        "selectorKind": "css",
+        "fallbackText": "Welcome to MyApp",
+        "rect": {"x":120,"y":84,"w":540,"h":36},
+        "confidence": 0.85
+      },
+      "before": { "textContent": "Welcome to MyApp" },
+      "after":  { "textContent": "歡迎光臨 MyApp" },
+      "intent": "rewrite hero headline in zh-TW"
+    },
+    {
+      "id": "edit_02",
+      "kind": "style",
+      "target": { "selector": "button.cta", "selectorKind": "css",
+                  "fallbackText": "Buy now", "confidence": 0.92,
+                  "rect":{"x":140,"y":420,"w":160,"h":44} },
+      "before": { "style": { "background-color": "#1a73e8" } },
+      "after":  { "style": { "background-color": "#d63b3b" } }
+    },
+    {
+      "id": "edit_03",
+      "kind": "attribute",
+      "target": { "selector": "a#buy", "selectorKind": "css",
+                  "fallbackText": "Buy →", "confidence": 0.98,
+                  "rect":{"x":160,"y":478,"w":120,"h":24} },
+      "before": { "attributes": { "href": "/checkout?v=1" } },
+      "after":  { "attributes": { "href": "/checkout?v=2&utm=hero" } }
+    }
+  ]
+}
+```
+
+### 3.3 Edit `kind` enum (v1)
+
+- `text` — `textContent` mutation only
+- `style` — one or more allowlisted CSS properties OR `customCss` opaque string
+- `attribute` — one or more `key→value` attribute mutations (incl. add / remove via `null`)
+- `replace` — full `outerHTML` replacement (escape hatch when the three above can't express the intent)
+- `remove` — element removed (before/after asymmetric: `after` is `null`)
+
+v1 deliberately omits `insert`. Inserting new DOM requires a parent + index contract we don't want to lock in yet; it lands in v2.
+
+## 4. Prompt template (Agent output)
+
+The exporter renders the JSON envelope into a single prompt string. Template is deterministic — same JSON → same string, byte-for-byte (stable key ordering, no timestamps in the body).
+
+### 4.1 Concrete example (continuing §3.2)
+
+````
+You are editing a web page based on a designer's point-and-edit session.
+
+# Source
+- kind: html-paste
+- uriHint: user-supplied-2026-06-03.html
+- byteLength: 18243
+
+# Edits requested (3)
+
+## edit_01 — text
+- target: main > section.hero > h1   (confidence 0.85)
+- visible text was: "Welcome to MyApp"
+- before.textContent: "Welcome to MyApp"
+- after.textContent:  "歡迎光臨 MyApp"
+- intent: rewrite hero headline in zh-TW
+
+## edit_02 — style
+- target: button.cta   (confidence 0.92)
+- visible text was: "Buy now"
+- before.style: { "background-color": "#1a73e8" }
+- after.style:  { "background-color": "#d63b3b" }
+
+## edit_03 — attribute
+- target: a#buy   (confidence 0.98)
+- visible text was: "Buy →"
+- before.attributes: { "href": "/checkout?v=1" }
+- after.attributes:  { "href": "/checkout?v=2&utm=hero" }
+
+# Instructions to the agent
+1. Apply each edit to the canonical source for this page. If the source is HTML, find the element by selector; if the source is a component (JSX / Vue / MDX), locate the equivalent node by the fallbackText + selector hint.
+2. Preserve indentation, surrounding markup, and comments. Touch only what an edit demands.
+3. If an edit cannot be applied unambiguously (selector ambiguous, fallbackText not found), STOP and report which edits are blocked and why — do not guess.
+4. Return the modified source as a unified diff against the file you were given.
+
+# Raw envelope (verbatim, for tools that prefer JSON)
+```json
+{...the JSON from §3.2...}
+```
+````
+
+### 4.2 Template invariants
+
+- **Stable ordering**: edits appear in the order they were committed; keys within objects are emitted in schema order, not insertion order.
+- **Lossless raw block**: the full JSON envelope is always appended so an Agent that ignores the prose still sees everything.
+- **No EClaw vocabulary**: prompt body never mentions `entity`, `bot`, `device-vars`, `publicCode`, or any EClaw term.
+- **Locale of the prose**: English. The *user's edits* may be any language; the *instructions to the agent* are English so behavior is portable across LLMs.
+
+## 5. Public API surface
+
+The repo ships a single small library plus the host page. Anyone consuming it programmatically goes through one entry:
+
+```ts
+// public surface — exported from src/index.ts
+export interface InteractiveDevSession {
+  pickElement(opts?: { armOnly?: boolean }): Promise<TargetLocator>;
+  recordEdit(edit: PendingEdit): EditId;
+  removeEdit(id: EditId): void;
+  exportDiff(): DiffEnvelope;          // returns the JSON object in §3.2 shape
+  exportPrompt(): string;              // returns the rendered string in §4.1 shape
+  reset(): void;
+}
+
+export function createSession(source: SourceInput): InteractiveDevSession;
+```
+
+Wire form:
+
+- `SourceInput = { kind:'html-paste', html:string, uriHint?:string } | { kind:'html-url', url:string }` (URL form is fetched same-origin only in v1).
+- `PendingEdit` is the union of the five edit `kind`s in §3.3.
+- `DiffEnvelope` matches `api-contract.json` exactly.
+
+The JSON Schema in `api-contract.json` is the **normative** contract; the TS types above are illustrative. A schema validator (`ajv`) runs on every `exportDiff()` call; a failure throws synchronously and never produces a prompt.
+
+## 6. Out of scope (v1) — explicit
+
+- EClaw kanban / device-vars / entity routing / bridge-auth / publisher.
+- Multi-user, login, sync, cloud persistence.
+- Mobile native, PWA install, offline service worker.
+- Inserting new DOM (`kind:'insert'`) — see §3.3.
+- Source-AST-aware edits (parsing JSX/Vue to mutate code, not DOM).
+- Round-tripping a *unified diff* INTO the envelope. Outbound only.
+
+## 7. Acceptance criteria for this spec
+
+- **AC-spec-1**: `spec.md`, `api-contract.json`, `e2e-scenarios.md` all present under `docs/web-interactive-dev/`.
+- **AC-spec-2**: `api-contract.json` is a valid JSON Schema (`$schema: draft-07`) and validates the §3.2 example.
+- **AC-spec-3**: `spec.md` contains a Platform Gate (§0) that names every banned EClaw concept.
+- **AC-spec-4**: Three deliverables make zero reference to `eclawbot.com`, `botSecret`, `device-vars`, `publicCode`, `entityId`, `bridge-auth`. (Excluding this PR's metadata and the in-repo review process.)
+- **AC-spec-5**: §3 picks **JSON** with a rationale table; §4 ships one fully-rendered concrete prompt example.
+- **AC-spec-6**: §5 fits on one screen — single `createSession()` entry, six methods, two shapes.
+- **AC-spec-7**: Reviewer #6 (yrt82n) gives an explicit ✅ in PR comments before merge.
+
+## 8. Open questions deferred to v2
+
+- AST-aware source resolution (mapping a DOM target back to a JSX node).
+- `insert` edits + parent/index contract.
+- Multi-page sessions (navigation while picking).
+- A pluggable prompt template (today: one canonical template; future: user-supplied).
+- A unified-diff *output* mode for consumers that want it pre-converted.


### PR DESCRIPTION
## Summary

Draft v1 spec for **web-interactive-dev** — a standalone web-only repo (target: github.com/HankHuang0516/web-interactive-dev, created separately by U96). Tracker: `card_ba085c28d403e57a51e8c931`.

Three deliverables under `docs/web-interactive-dev/`:

- **`spec.md`** — Platform/EClaw-dep gate (§0), UI scope (§2 point-and-edit + side panel), diff format **decision: JSON, not unified-diff** with rationale table (§3), prompt template with a fully-rendered example (§4), public API surface (§5), out-of-scope (§6), acceptance criteria (§7).
- **`api-contract.json`** — Draft-07 JSON Schema for the `DiffEnvelope`. The spec §3.2 example validates against it (verified with ajv locally).
- **`e2e-scenarios.md`** — Five browser-only happy paths: text edit, allowlisted style edit, attribute edit, multi-edit batch with reorder, discard-then-export.

**Why this PR opens against the EClaw repo even though the artifact is standalone**: it's the review surface only. After #6 signs off and this merges, U96 copies the files verbatim into the standalone repo, then U97/later starts implementation there. No code under `backend/`, `app/`, `ios-app/` changes — docs-only.

## Hard EClaw-dependency gate

v1 of web-interactive-dev MUST NOT import EClaw, call `eclawbot.com`, read `device-vars`/`botSecret`/`entityId`/`publicCode`, or assume an EClaw identity. The standalone repo CI will grep-fail builds that violate this (wired by U96). See `spec.md` §0 and AC-spec-4.

## Acceptance criteria (from spec §7)

- [x] AC-spec-1: three files present under `docs/web-interactive-dev/`
- [x] AC-spec-2: `api-contract.json` is valid JSON Schema (draft-07) and validates the §3.2 example (ajv verified locally)
- [x] AC-spec-3: §0 names every banned EClaw concept
- [x] AC-spec-4: zero un-gated references to `eclawbot.com`, `botSecret`, `device-vars`, `publicCode`, `entityId`, `bridge-auth` (every mention is inside the §0 gate, §6 out-of-scope, or §7 AC list)
- [x] AC-spec-5: §3 picks JSON with rationale table; §4 ships one fully-rendered concrete prompt
- [x] AC-spec-6: §5 fits on one screen — one `createSession()` entry + six methods + two shapes
- [ ] **AC-spec-7: Reviewer #6 (yrt82n) explicit OK in PR comments — gating merge**

Cross-review per card: #5 (Hermes).

## Test plan

- [ ] #6 reviews `spec.md` + `api-contract.json` + `e2e-scenarios.md`, posts explicit OK or change-requests in a PR comment
- [ ] If #6 requests changes, U97 amends and pushes; loop until OK
- [ ] After OK, U97 squash-merges and comments on `card_ba085c28` with PR URL + status `done`
- [ ] U96 picks up the standalone-repo infra task once this merges

## Code-Review Checklist (docs-only PR)

Per `docs/code-review-checklist.md` — docs-only PR, applying the template:

**Part A**
- A1 Logic trace — NO-OP (no code)
- A2 Test coverage — NO-OP (no code); §7 lists acceptance criteria; E2E scenarios listed in `e2e-scenarios.md` for the implementation PR to honor
- A3 Return shape — OK: JSON Schema is the canonical contract, validated against the §3.2 example with ajv
- A4 What-this-does-NOT-fix — OK: §6 "Out of scope (v1)" explicitly lists EClaw deps, multi-user, mobile, `insert` edits, AST-aware edits, unified-diff inbound
- A5 Security — OK: §0 forbids server runtime, network calls, EClaw identity; preview iframe is `sandbox="allow-same-origin"`; v1 is single-user, localStorage only

**Part B**
- B1 `/api/help` update — NO-OP (no API change in EClaw)
- B2 Related docs — OK: this IS the doc; existing `docs/specs/mission-page-interactive-dev-tab.md` is left untouched (it's about the EClaw-coupled point-edit demo, not this standalone spec)
- B3 i18n audit — NO-OP (no UI strings yet; spec §4.2 states the agent-instruction prose stays English on purpose for LLM portability)
- B4 Info page — NO-OP (no portal change)
- B5 Debug endpoint — NO-OP (no backend behavior)
