### PR TITLE
fix(openclaw-channel): retry transient message delivery failures

### DIFF
--- a/openclaw-channel-eclaw/README.md
+++ b/openclaw-channel-eclaw/README.md
@@ -334,6 +334,25 @@ ACK failures.
 - After upgrading the plugin in an OpenClaw runtime, restart the owning
   container/service and run both API ACK checks and browser chat ACK checks.
 
+### Channel message send failures are silently treated as delivery success
+
+**Problem:**
+During fleet monitor bursts, the E-Claw API can temporarily return HTTP 429 or
+`Too many requests` for `/api/channel/message`. Older plugin builds returned
+that JSON body to the caller without retrying or throwing. Direct healthcheck
+ACKs and normal replies could therefore be marked as delivered inside
+OpenClaw while the portal still showed only the client echo.
+
+**Countermeasure:**
+- `EClawClient.sendMessage()` retries transient HTTP 429 / rate-limit / server
+  startup / HTTP 5xx responses with bounded backoff before failing the
+  delivery.
+- Non-transient failures now throw instead of being treated as success, so
+  webhook delivery logs expose the real cause.
+- After deploying this mitigation to a runtime extension directory, restart
+  only the affected OpenClaw container and verify API ACK, model-backed reply,
+  and browser UI ACK independently.
+
 ## Major Fix History
 
 A record of critical bug fixes, when they occurred, the problem, and the countermeasure.

--- a/openclaw-channel-eclaw/src/client.ts
+++ b/openclaw-channel-eclaw/src/client.ts
@@ -6,6 +6,20 @@ import type {
   HeartbeatResponse,
 } from './types.js';
 
+const TRANSIENT_ERROR_RE = /(server starting up|too many requests|rate.?limit|HTTP 429|HTTP 5\d\d)/i;
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function responseReason(res: Response, data: { message?: string; error?: string } = {}): string {
+  return data.message || data.error || `HTTP ${res.status}`;
+}
+
+function shouldRetry(res: Response, reason: string): boolean {
+  return res.status === 429 || res.status >= 500 || TRANSIENT_ERROR_RE.test(reason);
+}
+
 /**
  * HTTP client for E-Claw Channel API.
  * Handles all communication between the OpenClaw plugin and the E-Claw backend.
@@ -107,24 +121,39 @@ export class EClawClient {
       throw new Error('Not bound — call bindEntity() first');
     }
 
-    const res = await fetch(`${this.apiBase}/api/channel/message`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        channel_api_key: this.apiKey,
-        deviceId: this.deviceId,
-        entityId: this.entityId,
-        botSecret: this.botSecret,
-        message,
-        state,
-        ...(opts?.mediaType && { mediaType: opts.mediaType }),
-        ...(opts?.mediaUrl && { mediaUrl: opts.mediaUrl }),
-        ...(opts?.speakTo && { speakTo: opts.speakTo.map(String) }),
-        ...(opts?.broadcast && { broadcast: true }),
-      }),
+    const body = JSON.stringify({
+      channel_api_key: this.apiKey,
+      deviceId: this.deviceId,
+      entityId: this.entityId,
+      botSecret: this.botSecret,
+      message,
+      state,
+      ...(opts?.mediaType && { mediaType: opts.mediaType }),
+      ...(opts?.mediaUrl && { mediaUrl: opts.mediaUrl }),
+      ...(opts?.speakTo && { speakTo: opts.speakTo.map(String) }),
+      ...(opts?.broadcast && { broadcast: true }),
     });
 
-    return await res.json() as MessageResponse;
+    const attempts = 5;
+    for (let attempt = 1; attempt <= attempts; attempt += 1) {
+      const res = await fetch(`${this.apiBase}/api/channel/message`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      });
+
+      const data = await res.json().catch(() => ({})) as MessageResponse & { message?: string; error?: string };
+      if (res.ok && data.success !== false) return data;
+
+      const reason = responseReason(res, data);
+      if (attempt < attempts && shouldRetry(res, reason)) {
+        await sleep(Math.min(30_000, 2_000 * attempt));
+        continue;
+      }
+      throw new Error(`Message send failed: ${reason}`);
+    }
+
+    throw new Error('Message send failed');
   }
 
   /** Record this bound entity daemon as alive. */

--- a/openclaw-channel-eclaw/test/client.test.ts
+++ b/openclaw-channel-eclaw/test/client.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EClawClient } from '../src/client.js';
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('EClawClient', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('retries transient channel message rate limits before succeeding', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(jsonResponse(429, { success: false, message: 'Too many requests — try again shortly' }))
+      .mockResolvedValueOnce(jsonResponse(200, { success: true }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new EClawClient({
+      enabled: true,
+      apiBase: 'https://eclawbot.test',
+      apiKey: 'key',
+    });
+    (client as unknown as { deviceId: string; botSecret: string; entityId: number }).deviceId = 'device-1';
+    (client as unknown as { deviceId: string; botSecret: string; entityId: number }).botSecret = 'bot-secret';
+    (client as unknown as { deviceId: string; botSecret: string; entityId: number }).entityId = 1;
+
+    const pending = client.sendMessage('ACK HC123', 'IDLE');
+    await vi.advanceTimersByTimeAsync(2_000);
+
+    await expect(pending).resolves.toMatchObject({ success: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    vi.useRealTimers();
+  });
+
+  it('throws when channel message returns a non-transient failure', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValue(jsonResponse(403, { success: false, message: 'Invalid botSecret' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const client = new EClawClient({
+      enabled: true,
+      apiBase: 'https://eclawbot.test',
+      apiKey: 'key',
+    });
+    (client as unknown as { deviceId: string; botSecret: string; entityId: number }).deviceId = 'device-1';
+    (client as unknown as { deviceId: string; botSecret: string; entityId: number }).botSecret = 'bot-secret';
+    (client as unknown as { deviceId: string; botSecret: string; entityId: number }).entityId = 1;
+
+    await expect(client.sendMessage('hello')).rejects.toThrow('Message send failed: Invalid botSecret');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary\n- retry transient /api/channel/message failures such as HTTP 429, startup, and 5xx responses before failing delivery\n- throw on non-transient channel message failures instead of treating failed JSON responses as success\n- document the fleet health mitigation and add client coverage for retry/non-transient failure behavior\n\n## Verification\n- npm test -- --run\n- npm run build\n- synced built dist to #1/#3/#4 OpenClaw runtime extension directories and restarted only those containers\n- verified #1 API ACK, #6 API ACK, and #1/#3/#4 browser UI ACK replies