### PR TITLE
feat(portal): bidirectional ? icon refs (card/spec/PR/research)

### DIFF
--- a/backend/api_refs.js
+++ b/backend/api_refs.js
@@ -1,0 +1,513 @@
+'use strict';
+
+/**
+ * api_refs.js — bidirectional reference index for portal `?` icon.
+ *
+ * Spec: docs/specs/portal-bidirectional-refs.md (PR #3124 + #3131 amendments).
+ *
+ * Endpoint:
+ *   GET /api/refs?from=<id>&deviceId=<uuid>&botSecret=<hex>&entityId=<n>
+ *
+ * Index sources (scanned every REFS_SCAN_INTERVAL_MS, default 5 min):
+ *   - kanban_cards: description, title, linked_prev_card_id, linked_next_card_id
+ *   - kanban_card_dependencies: (card_id ↔ depends_on_card_id)
+ *   - kanban_card_links: (source_card_id ↔ target_card_id)
+ *   - kanban_comments: text
+ *   - docs/specs/**\/*.md (git working tree at HEAD on main)
+ *   - docs/research/**\/*.md
+ *   - gh pr list --state all --limit 200 --json number,title,body,url,state,updatedAt
+ *
+ * Cache:
+ *   - In-memory: Map<"<deviceId>|<kind>|<id>", Ref[]>
+ *   - Disk warm-start: backend/.cache/refs.json (in .gitignore)
+ *
+ * Gated by env flag ECLAW_REFS_INDEX_ENABLED (default off in prod); flag off →
+ * endpoint returns `{success:true, refs:[]}` so `?` popover renders empty
+ * without breaking the UI (per spec §8 rollback).
+ */
+
+const express = require('express');
+const fs = require('fs');
+const path = require('path');
+const { execFile } = require('child_process');
+const { promisify } = require('util');
+const { Pool } = require('pg');
+
+const execFileAsync = promisify(execFile);
+
+const SCAN_INTERVAL_MS = parseInt(process.env.ECLAW_REFS_SCAN_INTERVAL_MS || '300000', 10); // 5 min default
+const CACHE_DIR = path.join(__dirname, '.cache');
+const CACHE_FILE = path.join(CACHE_DIR, 'refs.json');
+const REPO_ROOT = path.resolve(__dirname, '..');
+
+// ── Regex patterns (mirror reference-parser.js + spec §3.2) ───────────────────
+const CARD_RE = /\bcard_([a-f0-9]{24})\b/gi;
+const SPEC_RE = /docs\/specs\/([\w-]+)\.md/g;
+const RESEARCH_RE = /docs\/research\/([\w-]+)\.md/g;
+const PR_RE = /#(\d{3,5})\b/g;
+
+const REF_KINDS = ['card', 'spec', 'doc', 'pr'];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function normalizeFromId(rawFromId) {
+    if (!rawFromId || typeof rawFromId !== 'string') return null;
+    if (rawFromId.startsWith('card_')) return { kind: 'card', id: rawFromId.toLowerCase() };
+    if (rawFromId.startsWith('docs/specs/')) return { kind: 'spec', id: rawFromId };
+    if (rawFromId.startsWith('docs/research/')) return { kind: 'doc', id: rawFromId };
+    if (/^\d+$/.test(rawFromId)) return { kind: 'pr', id: rawFromId };
+    if (/^#\d+$/.test(rawFromId)) return { kind: 'pr', id: rawFromId.slice(1) };
+    return null;
+}
+
+function cacheKey(deviceId, kind, id) {
+    return `${deviceId}|${kind}|${id}`;
+}
+
+function scanText(text) {
+    if (!text || typeof text !== 'string') return [];
+    const out = [];
+    const seen = new Set();
+    const push = (kind, id) => {
+        const k = `${kind}:${id}`;
+        if (seen.has(k)) return;
+        seen.add(k);
+        out.push({ kind, id });
+    };
+    let m;
+    CARD_RE.lastIndex = 0;
+    while ((m = CARD_RE.exec(text)) !== null) push('card', 'card_' + m[1].toLowerCase());
+    SPEC_RE.lastIndex = 0;
+    while ((m = SPEC_RE.exec(text)) !== null) push('spec', 'docs/specs/' + m[1] + '.md');
+    RESEARCH_RE.lastIndex = 0;
+    while ((m = RESEARCH_RE.exec(text)) !== null) push('doc', 'docs/research/' + m[1] + '.md');
+    PR_RE.lastIndex = 0;
+    while ((m = PR_RE.exec(text)) !== null) push('pr', m[1]);
+    return out;
+}
+
+function truncateLabel(s) {
+    if (!s) return '';
+    const t = String(s).replace(/\s+/g, ' ').trim();
+    return t.length > 80 ? t.slice(0, 77) + '…' : t;
+}
+
+// ── Scanners ──────────────────────────────────────────────────────────────────
+
+async function scanKanbanCards(pool, deviceId) {
+    // Returns array of { from: {kind,id,label}, refs: [{kind, id}] }
+    const cards = await pool.query(
+        `SELECT id, title, description, linked_prev_card_id, linked_next_card_id
+         FROM kanban_cards
+         WHERE device_id = $1 AND archived = false`,
+        [deviceId]
+    );
+    const out = [];
+    for (const row of cards.rows) {
+        const from = { kind: 'card', id: row.id, label: truncateLabel(row.title) };
+        const refs = scanText((row.title || '') + '\n' + (row.description || ''));
+        if (row.linked_prev_card_id) refs.push({ kind: 'card', id: row.linked_prev_card_id });
+        if (row.linked_next_card_id) refs.push({ kind: 'card', id: row.linked_next_card_id });
+        out.push({ from, refs });
+    }
+    return out;
+}
+
+async function scanKanbanComments(pool, deviceId) {
+    const rows = await pool.query(
+        `SELECT card_id, text FROM kanban_comments
+         WHERE device_id = $1 AND is_system = false`,
+        [deviceId]
+    );
+    const byCard = new Map();
+    for (const r of rows.rows) {
+        const refs = scanText(r.text || '');
+        if (!byCard.has(r.card_id)) byCard.set(r.card_id, []);
+        byCard.get(r.card_id).push(...refs);
+    }
+    return byCard;
+}
+
+async function scanKanbanDependencies(pool, deviceId) {
+    const rows = await pool.query(
+        `SELECT card_id, depends_on_card_id FROM kanban_card_dependencies WHERE device_id = $1`,
+        [deviceId]
+    );
+    return rows.rows.map(r => ({ from: r.card_id, to: r.depends_on_card_id }));
+}
+
+async function scanKanbanLinks(pool, deviceId) {
+    const rows = await pool.query(
+        `SELECT source_card_id, target_card_id FROM kanban_card_links WHERE device_id = $1`,
+        [deviceId]
+    );
+    return rows.rows.map(r => ({ from: r.source_card_id, to: r.target_card_id }));
+}
+
+function scanDocsTree(subdir) {
+    const dir = path.join(REPO_ROOT, 'docs', subdir);
+    if (!fs.existsSync(dir)) return [];
+    const out = [];
+    for (const fname of fs.readdirSync(dir)) {
+        if (!fname.endsWith('.md')) continue;
+        const fullPath = path.join(dir, fname);
+        const relId = `docs/${subdir}/${fname}`;
+        let body = '';
+        let title = fname.replace(/\.md$/, '');
+        try {
+            body = fs.readFileSync(fullPath, 'utf8');
+            const h1Match = body.match(/^#\s+(.+)$/m);
+            if (h1Match) title = h1Match[1].trim();
+        } catch (_) { /* skip unreadable */ }
+        const kind = subdir === 'specs' ? 'spec' : 'doc';
+        out.push({
+            from: { kind, id: relId, label: truncateLabel(title) },
+            refs: scanText(body),
+        });
+    }
+    return out;
+}
+
+async function scanGhPrs() {
+    try {
+        const { stdout } = await execFileAsync('gh', [
+            'pr', 'list',
+            '--state', 'all',
+            '--limit', '200',
+            '--json', 'number,title,body,url,state,updatedAt',
+        ], { cwd: REPO_ROOT, maxBuffer: 16 * 1024 * 1024, timeout: 30000 });
+        const prs = JSON.parse(stdout);
+        return prs.map(pr => ({
+            from: {
+                kind: 'pr',
+                id: String(pr.number),
+                label: truncateLabel(pr.title),
+            },
+            refs: scanText((pr.title || '') + '\n' + (pr.body || '')),
+        }));
+    } catch (_err) {
+        // gh unavailable / not authed: degrade gracefully (no PR refs this scan)
+        return [];
+    }
+}
+
+// ── Index build ───────────────────────────────────────────────────────────────
+
+function freshIndex() {
+    // forward[key] = Set<refKey>     (out refs from key)
+    // reverse[refKey] = Set<key>     (in refs into refKey)
+    // labels[key] = "human label"    (for both sides)
+    return { forward: new Map(), reverse: new Map(), labels: new Map() };
+}
+
+function keyOf(kind, id) { return `${kind}|${id}`; }
+function parseKey(k) {
+    const idx = k.indexOf('|');
+    return { kind: k.slice(0, idx), id: k.slice(idx + 1) };
+}
+
+function addEdge(idx, fromKind, fromId, toKind, toId) {
+    if (!REF_KINDS.includes(fromKind) || !REF_KINDS.includes(toKind)) return;
+    const a = keyOf(fromKind, fromId);
+    const b = keyOf(toKind, toId);
+    if (a === b) return; // self-loop
+    if (!idx.forward.has(a)) idx.forward.set(a, new Set());
+    if (!idx.reverse.has(b)) idx.reverse.set(b, new Set());
+    idx.forward.get(a).add(b);
+    idx.reverse.get(b).add(a);
+}
+
+function setLabel(idx, kind, id, label) {
+    if (!label) return;
+    const k = keyOf(kind, id);
+    if (!idx.labels.has(k)) idx.labels.set(k, label);
+}
+
+async function buildIndexForDevice(pool, deviceId) {
+    const idx = freshIndex();
+
+    // Kanban cards: text refs + linked_prev/_next
+    const cardScans = await scanKanbanCards(pool, deviceId);
+    for (const entry of cardScans) {
+        setLabel(idx, entry.from.kind, entry.from.id, entry.from.label);
+        for (const r of entry.refs) {
+            addEdge(idx, entry.from.kind, entry.from.id, r.kind, r.id);
+        }
+    }
+
+    // Kanban comments: ref expressions in user-authored comment text
+    const commentByCard = await scanKanbanComments(pool, deviceId);
+    for (const [cardId, refs] of commentByCard.entries()) {
+        for (const r of refs) addEdge(idx, 'card', cardId, r.kind, r.id);
+    }
+
+    // Structured kanban edges
+    const deps = await scanKanbanDependencies(pool, deviceId);
+    for (const d of deps) addEdge(idx, 'card', d.from, 'card', d.to);
+
+    const links = await scanKanbanLinks(pool, deviceId);
+    for (const l of links) addEdge(idx, 'card', l.from, 'card', l.to);
+
+    // Docs
+    for (const entry of scanDocsTree('specs')) {
+        setLabel(idx, entry.from.kind, entry.from.id, entry.from.label);
+        for (const r of entry.refs) addEdge(idx, entry.from.kind, entry.from.id, r.kind, r.id);
+    }
+    for (const entry of scanDocsTree('research')) {
+        setLabel(idx, entry.from.kind, entry.from.id, entry.from.label);
+        for (const r of entry.refs) addEdge(idx, entry.from.kind, entry.from.id, r.kind, r.id);
+    }
+
+    // PRs
+    for (const entry of await scanGhPrs()) {
+        setLabel(idx, entry.from.kind, entry.from.id, entry.from.label);
+        for (const r of entry.refs) addEdge(idx, entry.from.kind, entry.from.id, r.kind, r.id);
+    }
+
+    return idx;
+}
+
+function lookupRefs(idx, deviceId, kind, id) {
+    const k = keyOf(kind, id);
+    const out = [];
+    const fwd = idx.forward.get(k);
+    if (fwd) {
+        for (const refK of fwd) {
+            const { kind: rk, id: rid } = parseKey(refK);
+            out.push({
+                kind: rk,
+                id: rid,
+                label: idx.labels.get(refK) || rid,
+                direction: 'out',
+            });
+        }
+    }
+    const rev = idx.reverse.get(k);
+    if (rev) {
+        for (const refK of rev) {
+            const { kind: rk, id: rid } = parseKey(refK);
+            out.push({
+                kind: rk,
+                id: rid,
+                label: idx.labels.get(refK) || rid,
+                direction: 'in',
+            });
+        }
+    }
+    // Dedup (kind, id, direction)
+    const seen = new Set();
+    const dedup = [];
+    for (const r of out) {
+        const dk = `${r.kind}|${r.id}|${r.direction}`;
+        if (seen.has(dk)) continue;
+        seen.add(dk);
+        dedup.push(r);
+    }
+    return dedup;
+}
+
+// ── Cache persistence ─────────────────────────────────────────────────────────
+
+function indexToJson(idx) {
+    const labels = {};
+    for (const [k, v] of idx.labels.entries()) labels[k] = v;
+    const forward = {};
+    for (const [k, v] of idx.forward.entries()) forward[k] = Array.from(v);
+    return { labels, forward };
+}
+
+function indexFromJson(json) {
+    const idx = freshIndex();
+    if (!json || typeof json !== 'object') return idx;
+    if (json.labels) {
+        for (const k of Object.keys(json.labels)) idx.labels.set(k, json.labels[k]);
+    }
+    if (json.forward) {
+        for (const k of Object.keys(json.forward)) {
+            const arr = json.forward[k] || [];
+            idx.forward.set(k, new Set(arr));
+            for (const b of arr) {
+                if (!idx.reverse.has(b)) idx.reverse.set(b, new Set());
+                idx.reverse.get(b).add(k);
+            }
+        }
+    }
+    return idx;
+}
+
+function writeCache(deviceIndices) {
+    try {
+        if (!fs.existsSync(CACHE_DIR)) fs.mkdirSync(CACHE_DIR, { recursive: true });
+        const payload = { v: 1, updatedAt: new Date().toISOString(), devices: {} };
+        for (const [deviceId, idx] of deviceIndices.entries()) {
+            payload.devices[deviceId] = indexToJson(idx);
+        }
+        fs.writeFileSync(CACHE_FILE, JSON.stringify(payload), 'utf8');
+    } catch (_) { /* best-effort warm-start; cold-start always works */ }
+}
+
+function readCache() {
+    try {
+        if (!fs.existsSync(CACHE_FILE)) return new Map();
+        const raw = fs.readFileSync(CACHE_FILE, 'utf8');
+        const payload = JSON.parse(raw);
+        const out = new Map();
+        for (const deviceId of Object.keys(payload.devices || {})) {
+            out.set(deviceId, indexFromJson(payload.devices[deviceId]));
+        }
+        return out;
+    } catch (_) {
+        return new Map();
+    }
+}
+
+// ── Auth helper ───────────────────────────────────────────────────────────────
+
+function authDevice(devices, req) {
+    const deviceId = req.query.deviceId || req.body?.deviceId;
+    const botSecret = req.query.botSecret || req.body?.botSecret;
+    if (!deviceId || !botSecret) return null;
+    const dev = devices?.[deviceId];
+    if (!dev) return null;
+    // Match the shape used elsewhere in the codebase: bot_secret stored on
+    // entity records keyed by entityId. We accept any entity's botSecret on
+    // this device (the refs read is device-scoped, not per-entity).
+    if (dev.bot_secret && dev.bot_secret === botSecret) return deviceId;
+    if (Array.isArray(dev.entities)) {
+        for (const ent of dev.entities) {
+            if (ent.bot_secret === botSecret) return deviceId;
+        }
+    }
+    return null;
+}
+
+// ── Factory ───────────────────────────────────────────────────────────────────
+
+function createRefsModule(devices, helpers = {}) {
+    const { serverLog } = helpers;
+    const pool = helpers.pool || new Pool({
+        connectionString: process.env.DATABASE_URL || 'postgresql://user:pass@localhost:5432/realbot',
+    });
+    const log = serverLog || ((..._args) => {});
+    const router = express.Router();
+
+    const ENABLED = process.env.ECLAW_REFS_INDEX_ENABLED === '1' ||
+                    process.env.ECLAW_REFS_INDEX_ENABLED === 'true';
+
+    // deviceId → Index
+    let deviceIndices = readCache();
+    let scanTimer = null;
+    let scanInFlight = false;
+
+    async function refreshAllDevices() {
+        if (scanInFlight) return;
+        scanInFlight = true;
+        try {
+            // Discover devices: union of currently-known devices + cached
+            const ids = new Set(Object.keys(devices || {}));
+            for (const id of deviceIndices.keys()) ids.add(id);
+            const next = new Map();
+            for (const deviceId of ids) {
+                try {
+                    next.set(deviceId, await buildIndexForDevice(pool, deviceId));
+                } catch (e) {
+                    // keep previous index if scan fails for this device
+                    const prev = deviceIndices.get(deviceId);
+                    if (prev) next.set(deviceId, prev);
+                    log && log('refs.scan.device_error', { deviceId, err: e?.message });
+                }
+            }
+            deviceIndices = next;
+            writeCache(deviceIndices);
+            log && log('refs.scan.complete', { devices: deviceIndices.size });
+        } finally {
+            scanInFlight = false;
+        }
+    }
+
+    function startScanLoop() {
+        if (!ENABLED) return;
+        if (scanTimer) return;
+        // kick off an initial scan, then on interval
+        refreshAllDevices().catch(() => {});
+        scanTimer = setInterval(() => {
+            refreshAllDevices().catch(() => {});
+        }, SCAN_INTERVAL_MS);
+        if (typeof scanTimer.unref === 'function') scanTimer.unref();
+    }
+
+    function stopScanLoop() {
+        if (scanTimer) {
+            clearInterval(scanTimer);
+            scanTimer = null;
+        }
+    }
+
+    // GET /api/refs?from=<id>
+    router.get('/refs', async (req, res) => {
+        if (!ENABLED) {
+            return res.json({ success: true, refs: [], from: null, enabled: false });
+        }
+        const deviceId = authDevice(devices, req);
+        if (!deviceId) return res.status(401).json({ success: false, error: 'unauthorized' });
+
+        const rawFrom = req.query.from;
+        const from = normalizeFromId(rawFrom);
+        if (!from) return res.status(400).json({ success: false, error: 'invalid_from' });
+
+        const idx = deviceIndices.get(deviceId);
+        if (!idx) {
+            // No scan has populated this device yet; trigger background scan and return empty.
+            refreshAllDevices().catch(() => {});
+            return res.json({ success: true, refs: [], from: { ...from, label: from.id }, warming: true });
+        }
+
+        const refs = lookupRefs(idx, deviceId, from.kind, from.id);
+        const label = idx.labels.get(keyOf(from.kind, from.id)) || from.id;
+        return res.json({
+            success: true,
+            from: { ...from, label },
+            refs,
+        });
+    });
+
+    // GET /api/refs/health — admin/debug
+    router.get('/refs/health', (req, res) => {
+        return res.json({
+            success: true,
+            enabled: ENABLED,
+            scanIntervalMs: SCAN_INTERVAL_MS,
+            devices: deviceIndices.size,
+            cacheFile: CACHE_FILE,
+        });
+    });
+
+    startScanLoop();
+
+    return {
+        router,
+        // Exposed for tests / shutdown:
+        _internals: {
+            refreshAllDevices,
+            stopScanLoop,
+            getIndex: (deviceId) => deviceIndices.get(deviceId),
+            indexToJson,
+            indexFromJson,
+            scanText,
+            normalizeFromId,
+            cacheKey,
+            buildIndexForDevice,
+            lookupRefs,
+            keyOf,
+        },
+    };
+}
+
+module.exports = createRefsModule;
+module.exports._private = {
+    scanText,
+    normalizeFromId,
+    cacheKey,
+    keyOf,
+    truncateLabel,
+};

--- a/backend/api_refs.js
+++ b/backend/api_refs.js
@@ -32,6 +32,7 @@ const path = require('path');
 const { execFile } = require('child_process');
 const { promisify } = require('util');
 const { Pool } = require('pg');
+const safeEqual = require('./safe-equal');
 
 const execFileAsync = promisify(execFile);
 
@@ -362,20 +363,28 @@ function readCache() {
 }
 
 // ── Auth helper ───────────────────────────────────────────────────────────────
-
+// Mirrors the kanban.js / mission.js authenticate() pattern so the portal calls
+// from kanban.html (which already pass deviceSecret) and bot calls (which pass
+// botSecret + entityId) both work. Refs reads are device-scoped, so any valid
+// credential pair for the device is accepted.
 function authDevice(devices, req) {
-    const deviceId = req.query.deviceId || req.body?.deviceId;
-    const botSecret = req.query.botSecret || req.body?.botSecret;
-    if (!deviceId || !botSecret) return null;
-    const dev = devices?.[deviceId];
-    if (!dev) return null;
-    // Match the shape used elsewhere in the codebase: bot_secret stored on
-    // entity records keyed by entityId. We accept any entity's botSecret on
-    // this device (the refs read is device-scoped, not per-entity).
-    if (dev.bot_secret && dev.bot_secret === botSecret) return deviceId;
-    if (Array.isArray(dev.entities)) {
-        for (const ent of dev.entities) {
-            if (ent.bot_secret === botSecret) return deviceId;
+    const params = { ...(req.query || {}), ...(req.body || {}) };
+    const { deviceId, deviceSecret, botSecret, entityId } = params;
+    if (!deviceId) return null;
+    const device = devices?.[deviceId];
+    if (!device) return null;
+    if (deviceSecret && safeEqual(device.deviceSecret, deviceSecret)) return deviceId;
+    if (botSecret) {
+        // entities is an object map keyed by entityId.
+        const entities = device.entities || {};
+        if (entityId !== undefined && entityId !== null && entityId !== '') {
+            const entity = entities[entityId] || entities[parseInt(entityId, 10)];
+            if (entity && safeEqual(entity.botSecret, botSecret)) return deviceId;
+        } else {
+            // Fall through: any entity on the device with matching botSecret.
+            for (const k of Object.keys(entities)) {
+                if (safeEqual(entities[k]?.botSecret, botSecret)) return deviceId;
+            }
         }
     }
     return null;

--- a/backend/index.js
+++ b/backend/index.js
@@ -1832,6 +1832,18 @@ try {
     console.error('[KanbanTags] Failed to load module:', err.message);
 }
 
+// Portal `?` icon bidirectional refs index — spec docs/specs/portal-bidirectional-refs.md
+// Gated by env flag ECLAW_REFS_INDEX_ENABLED (default off in prod per spec §8).
+try {
+    const refsModule = require('./api_refs')(devices, { serverLog });
+    app.use('/api', refsModule.router);
+    const refsEnabled = process.env.ECLAW_REFS_INDEX_ENABLED === '1' ||
+                        process.env.ECLAW_REFS_INDEX_ENABLED === 'true';
+    console.log('[Refs] Module loaded (enabled=' + refsEnabled + ')');
+} catch (err) {
+    console.error('[Refs] Failed to load module:', err.message);
+}
+
 // Idle Dispatch System — smart bot availability-based card dispatch
 try {
     const idleDispatchRouter = require('./api_idle_dispatch');

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -7,6 +7,7 @@
     <title data-i18n="kanban_title">EClawbot - Kanban Board</title>
     <link rel="icon" type="image/png" href="assets/favicon-32.png">
     <link rel="stylesheet" href="shared/style.css">
+    <link rel="stylesheet" href="../shared/refs-popover.css">
     <style>
         /* ══════════════ Sub-tabs (same as mission.html) ══════════════ */
         .sub-tabs { display:flex; gap:0; margin-bottom:20px; border-bottom:1px solid var(--card-border); overflow-x:auto; -webkit-overflow-scrolling:touch; scrollbar-width:none; }
@@ -1065,6 +1066,8 @@
     <script src="../shared/transition-overlay.js"></script>
     <script src="../shared/kanban-status.js"></script>
     <script src="../shared/kanban-sort.js"></script>
+    <script src="../shared/help-popover.js"></script>
+    <script src="../shared/refs-popover.js"></script>
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
@@ -1878,7 +1881,10 @@
                     ${archivedBadge}
                     <span class="kb-card-assigned">${renderAssignedAvatars(card.assignedBots)}</span>
                 </div>
-                <div class="kb-card-title">${escapeHtml(card.title)}</div>
+                <div class="kb-card-title">
+                    ${escapeHtml(card.title)}
+                    <button type="button" class="eclaw-refs-icon" data-refs-from="${card.id}" aria-label="Show related cards, specs, and PRs" title="References" onclick="event.stopPropagation()">ⓘ</button>
+                </div>
                 ${renderTags(card.tags)}
                 ${card.description ? '<div class="kb-card-desc">'+escapeHtml(compactKanbanPreview(card.description))+'</div>' : ''}
                 <div class="kb-card-footer">

--- a/backend/public/shared/help-popover.js
+++ b/backend/public/shared/help-popover.js
@@ -141,9 +141,16 @@
     }
 
     // ── Build popover DOM ──────────────────────────────────────────────────────
-    function buildPopover(content) {
+    function buildPopover(content, opts) {
+        opts = opts || {};
         const el = document.createElement('div');
         el.className = POPOVER_CLASS;
+        if (opts.variant === 'sheet') el.classList.add(POPOVER_CLASS + '--sheet');
+        if (opts.extraClass) el.classList.add(opts.extraClass);
+        if (typeof opts.maxWidth === 'number' && opts.maxWidth > 0) {
+            el.style.setProperty('--help-popover-max-width', opts.maxWidth + 'px');
+            el.style.maxWidth = opts.maxWidth + 'px';
+        }
         el.setAttribute('role', 'tooltip');
         el.setAttribute('tabindex', '-1');
         el.id = `${POPOVER_CLASS}-${++popoverSeq}`;
@@ -159,7 +166,7 @@
 
         const closeBtn = document.createElement('button');
         closeBtn.className = POPOVER_CLASS + '-close';
-        closeBtn.setAttribute('aria-label', 'Close help');
+        closeBtn.setAttribute('aria-label', opts.closeLabel || 'Close help');
         closeBtn.textContent = '✕';
         closeBtn.type = 'button';
         closeBtn.addEventListener('click', () => hidePopover());
@@ -170,10 +177,25 @@
     }
 
     // ── Show / Hide ────────────────────────────────────────────────────────────
-    function showPopover(content, anchor, placement = 'top') {
+    /**
+     * showPopover(content, anchor, placementOrOpts)
+     *   placementOrOpts may be:
+     *     - a string ('top'|'bottom'|'left'|'right')   → legacy placement
+     *     - an object { placement?, maxWidth?, variant?: 'tooltip'|'sheet', extraClass?, closeLabel? }
+     * `variant: 'sheet'` engages the mobile bottom-sheet layout (CSS-driven).
+     */
+    function showPopover(content, anchor, placementOrOpts) {
+        let placement = 'top';
+        let opts = {};
+        if (typeof placementOrOpts === 'string') {
+            placement = placementOrOpts;
+        } else if (placementOrOpts && typeof placementOrOpts === 'object') {
+            opts = placementOrOpts;
+            if (opts.placement) placement = opts.placement;
+        }
         hidePopover(); // close any existing
 
-        const popover = buildPopover(content);
+        const popover = buildPopover(content, opts);
         document.body.appendChild(popover);
         anchor.setAttribute('aria-describedby', popover.id);
         activeDescribedBy = { anchor, id: popover.id };
@@ -303,9 +325,11 @@
         });
     }
 
-    /** Show popover programmatically */
-    function show(content, anchor, placement) {
-        showPopover(content, anchor, placement);
+    /** Show popover programmatically.
+     *  Signature: show(content, anchor, placementOrOpts) — see showPopover().
+     */
+    function show(content, anchor, placementOrOpts) {
+        showPopover(content, anchor, placementOrOpts);
     }
 
     /** Hide active popover */

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -267169,6 +267169,12 @@ const TRANSLATIONS = {
 
         "kanban_nudge_batch_label": "Cards per cycle",
         "kanban_nudge_batch_help": "Maximum number of L1 stale cards picked per cron tick — device-wide cap, NOT per-entity. L2 (priority bump) and L3 (auto-block) escalations are unaffected. See L1/L2/L3 in the kanban-nudge spec.",
+        "refs.popover_title": "References",
+        "refs.section_out": "This cites",
+        "refs.section_in": "Cited by",
+        "refs.empty": "No related items yet.",
+        "refs.error": "Couldn't load related items.",
+        "refs.close": "Close references",
 
 
 

--- a/backend/public/shared/refs-popover.css
+++ b/backend/public/shared/refs-popover.css
@@ -1,0 +1,156 @@
+/* refs-popover.css — `?` icon bidirectional refs popover.
+ * Spec: docs/specs/portal-bidirectional-refs.md §4.1.
+ *
+ * The popover DOM is built by shared/help-popover.js with `extraClass:
+ * 'eclaw-refs-icon-anchor'`. This stylesheet styles the icon button itself
+ * and the popover's inner content (header / sections / rows). The popover
+ * shell (positioning, focus ring, close button) is owned by help-popover.css.
+ */
+
+/* ── ⓘ button ────────────────────────────────────────────────────────────── */
+.eclaw-refs-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    margin-left: 4px;
+    padding: 0;
+    border: 0;
+    background: transparent;
+    color: var(--muted, #888);
+    font-size: 14px;
+    line-height: 1;
+    border-radius: 50%;
+    cursor: pointer;
+    transition: color 0.12s ease-out, background 0.12s ease-out;
+    vertical-align: middle;
+}
+.eclaw-refs-icon:hover,
+.eclaw-refs-icon:focus-visible {
+    color: var(--accent, #6f7df4);
+    background: rgba(111, 125, 244, 0.12);
+    outline: none;
+}
+.eclaw-refs-icon:focus-visible {
+    box-shadow: 0 0 0 2px rgba(111, 125, 244, 0.35);
+}
+
+/* ── Popover inner content ──────────────────────────────────────────────── */
+.eclaw-refs-icon-popover {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    min-width: 240px;
+    max-width: 340px;
+    font-size: 13px;
+    line-height: 1.45;
+    color: var(--text, #e0e0e0);
+}
+
+.eclaw-refs-icon-header {
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    padding-bottom: 6px;
+}
+.eclaw-refs-icon-title {
+    margin: 0;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--text, #e0e0e0);
+}
+.eclaw-refs-icon-subtitle {
+    font-size: 11px;
+    color: var(--muted, #888);
+    margin-top: 2px;
+    word-break: break-all;
+}
+
+.eclaw-refs-icon-section + .eclaw-refs-icon-section {
+    border-top: 1px dashed rgba(255, 255, 255, 0.05);
+    padding-top: 6px;
+}
+
+.eclaw-refs-icon-section-title {
+    margin: 0 0 4px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--muted, #888);
+}
+
+.eclaw-refs-icon-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+.eclaw-refs-icon-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 0;
+    min-width: 0;
+}
+.eclaw-refs-icon-glyph {
+    flex: 0 0 auto;
+    font-size: 13px;
+    line-height: 1;
+}
+.eclaw-refs-icon-link {
+    flex: 1 1 auto;
+    color: var(--accent, #93a4ff);
+    text-decoration: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+}
+.eclaw-refs-icon-link:hover,
+.eclaw-refs-icon-link:focus-visible {
+    text-decoration: underline;
+    outline: none;
+}
+
+.eclaw-refs-icon-empty {
+    margin: 2px 0 0;
+    font-size: 12px;
+    font-style: italic;
+    color: var(--muted, #888);
+}
+.eclaw-refs-icon-error {
+    color: #f08080;
+    font-size: 12px;
+}
+.eclaw-refs-icon-loading {
+    color: var(--muted, #888);
+    font-size: 13px;
+    padding: 4px 0;
+}
+
+/* ── Mobile bottom-sheet variant ────────────────────────────────────────── */
+@media (max-width: 720px) {
+    .help-popover.help-popover--sheet {
+        position: fixed !important;
+        left: 0 !important;
+        right: 0 !important;
+        bottom: 0 !important;
+        top: auto !important;
+        width: 100vw !important;
+        max-width: 100vw !important;
+        border-radius: 14px 14px 0 0;
+        padding-bottom: env(safe-area-inset-bottom, 12px);
+    }
+    .eclaw-refs-icon-popover {
+        max-width: 100%;
+        min-width: 0;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .eclaw-refs-icon {
+        transition: none;
+    }
+}

--- a/backend/public/shared/refs-popover.js
+++ b/backend/public/shared/refs-popover.js
@@ -27,16 +27,21 @@
     const REFS_ENDPOINT = '/api/refs';
 
     // ── Auth ──────────────────────────────────────────────────────────────────
+    // Matches the kanban portal convention: `window.currentUser.deviceId /
+    // deviceSecret / entityId` is the canonical source set by shared/auth.js.
+    // Test stubs may inject `window.deviceState` instead.
     function readCreds() {
         try {
+            const cu = window.currentUser || {};
             const ds = window.deviceState || {};
             return {
-                deviceId: ds.deviceId || localStorage.getItem('eclaw.deviceId'),
-                botSecret: ds.botSecret || localStorage.getItem('eclaw.botSecret'),
-                entityId: ds.entityId || localStorage.getItem('eclaw.entityId') || '2',
+                deviceId: cu.deviceId || ds.deviceId || null,
+                deviceSecret: cu.deviceSecret || ds.deviceSecret || null,
+                botSecret: cu.botSecret || ds.botSecret || null,
+                entityId: cu.entityId ?? ds.entityId ?? null,
             };
         } catch (_) {
-            return { deviceId: null, botSecret: null, entityId: '2' };
+            return { deviceId: null, deviceSecret: null, botSecret: null, entityId: null };
         }
     }
 
@@ -174,15 +179,23 @@
 
     // ── Fetch ─────────────────────────────────────────────────────────────────
     async function fetchRefs(fromId) {
-        const { deviceId, botSecret, entityId } = readCreds();
-        if (!deviceId || !botSecret) {
+        const { deviceId, deviceSecret, botSecret, entityId } = readCreds();
+        if (!deviceId) throw new Error('missing_creds');
+        const params = ['from=' + encodeURIComponent(fromId),
+                        'deviceId=' + encodeURIComponent(deviceId)];
+        // Prefer deviceSecret (kanban portal convention); fall back to botSecret
+        // for bot-authed callers / tests.
+        if (deviceSecret) {
+            params.push('deviceSecret=' + encodeURIComponent(deviceSecret));
+        } else if (botSecret) {
+            params.push('botSecret=' + encodeURIComponent(botSecret));
+        } else {
             throw new Error('missing_creds');
         }
-        const url = REFS_ENDPOINT
-            + '?from=' + encodeURIComponent(fromId)
-            + '&deviceId=' + encodeURIComponent(deviceId)
-            + '&botSecret=' + encodeURIComponent(botSecret)
-            + '&entityId=' + encodeURIComponent(entityId);
+        if (entityId !== null && entityId !== undefined && entityId !== '') {
+            params.push('entityId=' + encodeURIComponent(entityId));
+        }
+        const url = REFS_ENDPOINT + '?' + params.join('&');
         const res = await fetch(url, { credentials: 'same-origin' });
         if (!res.ok) throw new Error('http_' + res.status);
         const json = await res.json();

--- a/backend/public/shared/refs-popover.js
+++ b/backend/public/shared/refs-popover.js
@@ -1,0 +1,284 @@
+/**
+ * refs-popover.js — `?` icon bidirectional references popover.
+ *
+ * Spec: docs/specs/portal-bidirectional-refs.md (PR #3124 + #3131).
+ *
+ * Usage:
+ *   <button class="eclaw-refs-icon" data-refs-from="card_aa15ed26..."
+ *           aria-label="Show related cards, specs, and PRs">ⓘ</button>
+ *
+ *   On click: GET /api/refs?from=<id> → render popover anchored on the icon.
+ *   Content is two sections — Outgoing (this cites) + Incoming (cited by).
+ *
+ *   Reuses shared/help-popover.js for show/hide/focus-trap/ESC plumbing.
+ *   Adds `variant: 'sheet'` automatically on mobile (≤720 px).
+ *
+ * Public API (window.RefsPopover):
+ *   - init():            re-bind newly-added .eclaw-refs-icon elements
+ *   - open(anchor):      open popover programmatically for a given icon
+ *   - close():           close the popover
+ */
+(function () {
+    'use strict';
+
+    const ICON_CLASS = 'eclaw-refs-icon';
+    const MOBILE_BREAKPOINT = 720;
+    const DESKTOP_MAX_WIDTH = 360;
+    const REFS_ENDPOINT = '/api/refs';
+
+    // ── Auth ──────────────────────────────────────────────────────────────────
+    function readCreds() {
+        try {
+            const ds = window.deviceState || {};
+            return {
+                deviceId: ds.deviceId || localStorage.getItem('eclaw.deviceId'),
+                botSecret: ds.botSecret || localStorage.getItem('eclaw.botSecret'),
+                entityId: ds.entityId || localStorage.getItem('eclaw.entityId') || '2',
+            };
+        } catch (_) {
+            return { deviceId: null, botSecret: null, entityId: '2' };
+        }
+    }
+
+    // ── i18n shim ─────────────────────────────────────────────────────────────
+    function t(key, fallback) {
+        try {
+            if (window.i18n && typeof window.i18n.t === 'function') {
+                const v = window.i18n.t(key);
+                if (v && v !== key) return v;
+            }
+        } catch (_) {}
+        return fallback;
+    }
+
+    // ── Icon glyphs by kind ───────────────────────────────────────────────────
+    const KIND_GLYPH = {
+        card:  '📋',
+        spec:  '📄',
+        doc:   '📘',
+        pr:    '🔀',
+    };
+
+    function navHrefFor(ref) {
+        switch (ref.kind) {
+            case 'card':
+                return `/portal/kanban.html#${encodeURIComponent(ref.id)}`;
+            case 'spec':
+            case 'doc':
+                // Source-view fallback while portal/docs.html doesn't exist (per #6 scope).
+                return `https://github.com/HankHuang0516/EClaw/blob/main/${ref.id}`;
+            case 'pr':
+                return `https://github.com/HankHuang0516/EClaw/pull/${ref.id}`;
+            default:
+                return '#';
+        }
+    }
+
+    // ── Render ────────────────────────────────────────────────────────────────
+    function renderRow(ref, fromId) {
+        const li = document.createElement('li');
+        li.className = ICON_CLASS + '-row';
+        li.setAttribute('data-ref-kind', ref.kind);
+
+        const glyph = document.createElement('span');
+        glyph.className = ICON_CLASS + '-glyph';
+        glyph.textContent = KIND_GLYPH[ref.kind] || '🔗';
+        glyph.setAttribute('aria-hidden', 'true');
+
+        const link = document.createElement('a');
+        link.className = ICON_CLASS + '-link';
+        link.href = navHrefFor(ref);
+        if (ref.kind === 'pr' || ref.kind === 'spec' || ref.kind === 'doc') {
+            // Cross-origin (github) opens in new tab so we don't navigate away.
+            link.target = '_blank';
+            link.rel = 'noopener noreferrer';
+        }
+        link.dataset.refFrom = fromId;
+        link.dataset.refKind = ref.kind;
+        link.dataset.refId = ref.id;
+
+        const label = ref.label || ref.id;
+        link.textContent = label;
+        link.title = `${ref.kind}: ${ref.id}`;
+
+        li.appendChild(glyph);
+        li.appendChild(link);
+        return li;
+    }
+
+    function renderPopover(payload) {
+        const wrap = document.createElement('div');
+        wrap.className = ICON_CLASS + '-popover';
+
+        const fromId = payload?.from?.id || '?';
+        const fromKind = payload?.from?.kind || 'item';
+        const fromLabel = payload?.from?.label || fromId;
+
+        const header = document.createElement('div');
+        header.className = ICON_CLASS + '-header';
+        const title = document.createElement('h3');
+        title.className = ICON_CLASS + '-title';
+        title.textContent = t('refs.popover_title', 'References');
+        const subtitle = document.createElement('div');
+        subtitle.className = ICON_CLASS + '-subtitle';
+        subtitle.textContent = `${fromKind}: ${fromLabel}`;
+        subtitle.title = fromId;
+        header.appendChild(title);
+        header.appendChild(subtitle);
+        wrap.appendChild(header);
+
+        const refs = Array.isArray(payload?.refs) ? payload.refs : [];
+        const outRefs = refs.filter(r => r.direction === 'out');
+        const inRefs  = refs.filter(r => r.direction === 'in');
+
+        const buildSection = (label, items) => {
+            const sec = document.createElement('section');
+            sec.className = ICON_CLASS + '-section';
+            const h = document.createElement('h4');
+            h.className = ICON_CLASS + '-section-title';
+            h.textContent = label;
+            sec.appendChild(h);
+            if (!items.length) {
+                const empty = document.createElement('p');
+                empty.className = ICON_CLASS + '-empty';
+                empty.textContent = t('refs.empty', 'No related items yet.');
+                sec.appendChild(empty);
+            } else {
+                const ul = document.createElement('ul');
+                ul.className = ICON_CLASS + '-list';
+                for (const r of items) ul.appendChild(renderRow(r, fromId));
+                sec.appendChild(ul);
+            }
+            return sec;
+        };
+
+        wrap.appendChild(buildSection(t('refs.section_out', 'This cites'), outRefs));
+        wrap.appendChild(buildSection(t('refs.section_in', 'Cited by'), inRefs));
+        return wrap;
+    }
+
+    function renderError() {
+        const el = document.createElement('div');
+        el.className = ICON_CLASS + '-error';
+        el.textContent = t('refs.error', 'Couldn\'t load related items.');
+        return el;
+    }
+
+    function renderLoading() {
+        const el = document.createElement('div');
+        el.className = ICON_CLASS + '-loading';
+        el.textContent = '…';
+        el.setAttribute('aria-live', 'polite');
+        return el;
+    }
+
+    // ── Fetch ─────────────────────────────────────────────────────────────────
+    async function fetchRefs(fromId) {
+        const { deviceId, botSecret, entityId } = readCreds();
+        if (!deviceId || !botSecret) {
+            throw new Error('missing_creds');
+        }
+        const url = REFS_ENDPOINT
+            + '?from=' + encodeURIComponent(fromId)
+            + '&deviceId=' + encodeURIComponent(deviceId)
+            + '&botSecret=' + encodeURIComponent(botSecret)
+            + '&entityId=' + encodeURIComponent(entityId);
+        const res = await fetch(url, { credentials: 'same-origin' });
+        if (!res.ok) throw new Error('http_' + res.status);
+        const json = await res.json();
+        if (!json || json.success !== true) throw new Error('api_error');
+        return json;
+    }
+
+    // ── Popover plumbing (reuses HelpPopover) ─────────────────────────────────
+    function getPopover() {
+        return window.HelpPopover;
+    }
+
+    function popoverOpts() {
+        const isMobile = window.matchMedia
+            && window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT}px)`).matches;
+        return {
+            maxWidth: DESKTOP_MAX_WIDTH,
+            variant: isMobile ? 'sheet' : 'tooltip',
+            extraClass: ICON_CLASS + '-anchor',
+            closeLabel: t('refs.close', 'Close references'),
+            placement: 'bottom',
+        };
+    }
+
+    async function openPopoverFor(anchor) {
+        const fromId = anchor.getAttribute('data-refs-from');
+        if (!fromId) return;
+        const Pop = getPopover();
+        if (!Pop) return;
+        Pop.show(renderLoading(), anchor, popoverOpts());
+        try {
+            const payload = await fetchRefs(fromId);
+            Pop.show(renderPopover(payload), anchor, popoverOpts());
+        } catch (_) {
+            Pop.show(renderError(), anchor, popoverOpts());
+        }
+    }
+
+    function onIconClick(e) {
+        e.preventDefault();
+        e.stopPropagation();
+        const icon = e.currentTarget;
+        openPopoverFor(icon);
+    }
+
+    function onIconKeyDown(e) {
+        if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            e.stopPropagation();
+            openPopoverFor(e.currentTarget);
+        }
+    }
+
+    function bindIcon(icon) {
+        if (icon.__refsBound) return;
+        icon.__refsBound = true;
+        if (!icon.hasAttribute('tabindex')) icon.setAttribute('tabindex', '0');
+        if (!icon.hasAttribute('role')) icon.setAttribute('role', 'button');
+        if (!icon.hasAttribute('aria-label')) {
+            icon.setAttribute('aria-label', 'Show related cards, specs, and PRs');
+        }
+        if (!icon.textContent || icon.textContent.trim() === '') icon.textContent = 'ⓘ';
+        icon.addEventListener('click', onIconClick);
+        icon.addEventListener('keydown', onIconKeyDown);
+    }
+
+    function init() {
+        document.querySelectorAll('.' + ICON_CLASS).forEach(bindIcon);
+    }
+
+    // Observer for dynamic content (e.g., kanban card re-renders).
+    function watch() {
+        if (!('MutationObserver' in window)) return;
+        const obs = new MutationObserver((mutations) => {
+            for (const m of mutations) {
+                for (const n of m.addedNodes) {
+                    if (!(n instanceof HTMLElement)) continue;
+                    if (n.classList && n.classList.contains(ICON_CLASS)) bindIcon(n);
+                    n.querySelectorAll && n.querySelectorAll('.' + ICON_CLASS).forEach(bindIcon);
+                }
+            }
+        });
+        obs.observe(document.body, { childList: true, subtree: true });
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', () => { init(); watch(); });
+    } else {
+        init();
+        watch();
+    }
+
+    window.RefsPopover = {
+        init,
+        open: openPopoverFor,
+        close: () => { const p = getPopover(); if (p) p.hide(); },
+        _internals: { renderPopover, fetchRefs, navHrefFor, popoverOpts },
+    };
+})();

--- a/backend/tests/e2e/refs-popover.spec.js
+++ b/backend/tests/e2e/refs-popover.spec.js
@@ -51,8 +51,8 @@ ${extraStyle}
 </head>
 <body>
 <script>
-  // Stub creds + fetch
-  window.deviceState = { deviceId: 'dev-test', botSecret: 'sec-test', entityId: '2' };
+  // Stub creds + fetch — match kanban portal convention (window.currentUser).
+  window.currentUser = { deviceId: 'dev-test', deviceSecret: 'sec-test', entityId: '2' };
   window.__capturedFetches = [];
   window.__fetchResolver = null;
   window.fetch = (url) => {
@@ -127,11 +127,30 @@ test('desktop: ? icon click → popover renders Outgoing + Incoming', async () =
         assert(out.length === 2, `outgoing rows=${out.length}, expected 2`);
         assert(inn.length === 1, `incoming rows=${inn.length}, expected 1`);
 
-        // fetch was called with correct URL shape
+        // fetch was called with correct URL shape — using window.currentUser
+        // convention (deviceSecret, not botSecret)
         const urls = await page.evaluate(() => window.__capturedFetches);
         assert(urls.length === 1, `fetches=${urls.length}`);
         assert(urls[0].includes('/api/refs?from=card_aa15ed26'), 'fetch URL: ' + urls[0]);
         assert(urls[0].includes('deviceId=dev-test'), 'fetch creds: ' + urls[0]);
+        assert(urls[0].includes('deviceSecret=sec-test'), 'expected deviceSecret in URL, was: ' + urls[0]);
+        assert(!urls[0].includes('botSecret='), 'should NOT include botSecret when deviceSecret present: ' + urls[0]);
+    });
+});
+
+test('auth: botSecret fallback when deviceSecret absent (bot-authed caller)', async () => {
+    const html = buildHtml().replace(
+        "window.currentUser = { deviceId: 'dev-test', deviceSecret: 'sec-test', entityId: '2' };",
+        "window.currentUser = { deviceId: 'dev-test', botSecret: 'bot-test', entityId: 2 };"
+    );
+    await withPage({ viewport: { width: 1280, height: 800 }, html }, async (page) => {
+        await page.click('.eclaw-refs-icon');
+        await page.waitForSelector('.eclaw-refs-icon-title');
+        const urls = await page.evaluate(() => window.__capturedFetches);
+        assert(urls.length === 1, `fetches=${urls.length}`);
+        assert(urls[0].includes('botSecret=bot-test'), 'expected botSecret fallback: ' + urls[0]);
+        assert(urls[0].includes('entityId=2'), 'expected entityId in URL: ' + urls[0]);
+        assert(!urls[0].includes('deviceSecret='), 'should NOT include deviceSecret: ' + urls[0]);
     });
 });
 

--- a/backend/tests/e2e/refs-popover.spec.js
+++ b/backend/tests/e2e/refs-popover.spec.js
@@ -1,0 +1,216 @@
+/**
+ * E2E: refs-popover.spec.js
+ *
+ * Tests the portal `?` icon → bidirectional references popover.
+ * Inline-HTML pattern (no running server): a stub `fetch` returns canned
+ * `/api/refs` payloads so the popover render + click-nav can be asserted
+ * deterministically.
+ *
+ * Run: npx playwright test backend/tests/e2e/refs-popover.spec.js
+ * Or:  node backend/tests/e2e/refs-popover.spec.js   (standalone)
+ *
+ * Spec: docs/specs/portal-bidirectional-refs.md (#3124 + #3131).
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { chromium } = require('playwright');
+
+const ROOT = path.join(__dirname, '..', '..');
+const HELP_POPOVER_JS = fs.readFileSync(path.join(ROOT, 'public', 'shared', 'help-popover.js'), 'utf8');
+const REFS_POPOVER_JS = fs.readFileSync(path.join(ROOT, 'public', 'shared', 'refs-popover.js'), 'utf8');
+const REFS_POPOVER_CSS = fs.readFileSync(path.join(ROOT, 'public', 'shared', 'refs-popover.css'), 'utf8');
+const CHROMIUM_EXECUTABLE = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE ||
+    (fs.existsSync('/usr/bin/chromium') ? '/usr/bin/chromium' : undefined);
+
+const CARD_ID = 'card_aa15ed2618c9246d11a0f6b1';
+
+const REFS_PAYLOAD = {
+    success: true,
+    from: { kind: 'card', id: CARD_ID, label: 'Research card' },
+    refs: [
+        { kind: 'spec', id: 'docs/specs/portal-bidirectional-refs.md', label: 'portal ? icon refs', direction: 'out' },
+        { kind: 'card', id: 'card_7579f205c0a8276240736c7d', label: 'mobile-use integration', direction: 'out' },
+        { kind: 'pr', id: '3123', label: 'docs(research): EClaw vs minitap', direction: 'in' },
+    ],
+};
+
+const buildHtml = (extraStyle = '') => `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Refs Popover E2E</title>
+<style>
+${REFS_POPOVER_CSS}
+body { font-family: sans-serif; background: #1e1e2e; color: #e0e0e0; padding: 40px; }
+.help-popover { position: absolute; background: #2b2b3d; border: 1px solid #444; border-radius: 8px; padding: 12px; box-shadow: 0 6px 20px rgba(0,0,0,0.4); }
+.help-popover-close { position: absolute; top: 4px; right: 4px; background: transparent; color: inherit; border: 0; cursor: pointer; }
+.kb-card-title { font-weight: 600; }
+${extraStyle}
+</style>
+</head>
+<body>
+<script>
+  // Stub creds + fetch
+  window.deviceState = { deviceId: 'dev-test', botSecret: 'sec-test', entityId: '2' };
+  window.__capturedFetches = [];
+  window.__fetchResolver = null;
+  window.fetch = (url) => {
+    window.__capturedFetches.push(url);
+    return Promise.resolve({
+      ok: true,
+      json: async () => (${JSON.stringify(REFS_PAYLOAD)}),
+    });
+  };
+  window.i18n = { t: (k) => ({
+    "refs.popover_title": "References",
+    "refs.section_out":   "This cites",
+    "refs.section_in":    "Cited by",
+    "refs.empty":         "No related items yet.",
+    "refs.error":         "Could not load related items.",
+    "refs.close":         "Close references",
+  }[k] || k) };
+</script>
+
+<div class="kb-card" data-card-id="${CARD_ID}">
+  <div class="kb-card-title">
+    Card title here
+    <button type="button" class="eclaw-refs-icon" data-refs-from="${CARD_ID}"
+            aria-label="Show related cards, specs, and PRs"
+            title="References">ⓘ</button>
+  </div>
+</div>
+
+<script>${HELP_POPOVER_JS}</script>
+<script>${REFS_POPOVER_JS}</script>
+</body>
+</html>`;
+
+const SUITE = [];
+function test(name, fn) { SUITE.push({ name, fn }); }
+function assert(cond, msg) {
+    if (!cond) throw new Error('assertion failed: ' + msg);
+}
+
+async function withPage(opts, fn) {
+    const browser = await chromium.launch({ headless: true, executablePath: CHROMIUM_EXECUTABLE });
+    const ctx = await browser.newContext(opts.viewport ? { viewport: opts.viewport } : {});
+    const page = await ctx.newPage();
+    if (process.env.DEBUG_REFS_E2E) {
+        page.on('console', m => console.log('[page]', m.type(), m.text()));
+        page.on('pageerror', e => console.log('[page-err]', e.message));
+    }
+    await page.setContent(opts.html || buildHtml(opts.extraStyle));
+    await page.waitForLoadState('domcontentloaded');
+    try {
+        await fn(page);
+    } finally {
+        await browser.close();
+    }
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+test('desktop: ? icon click → popover renders Outgoing + Incoming', async () => {
+    await withPage({ viewport: { width: 1280, height: 800 } }, async (page) => {
+        await page.click('.eclaw-refs-icon');
+        const popover = await page.waitForSelector('.help-popover', { timeout: 2000 });
+        assert(popover, 'popover element exists');
+
+        // Header renders
+        const title = await page.textContent('.eclaw-refs-icon-title');
+        assert(title?.trim() === 'References', `title was "${title}"`);
+
+        // Outgoing section has 2 rows; Incoming has 1
+        const out = await page.$$('.eclaw-refs-icon-section >> nth=0 >> .eclaw-refs-icon-row');
+        const inn = await page.$$('.eclaw-refs-icon-section >> nth=1 >> .eclaw-refs-icon-row');
+        assert(out.length === 2, `outgoing rows=${out.length}, expected 2`);
+        assert(inn.length === 1, `incoming rows=${inn.length}, expected 1`);
+
+        // fetch was called with correct URL shape
+        const urls = await page.evaluate(() => window.__capturedFetches);
+        assert(urls.length === 1, `fetches=${urls.length}`);
+        assert(urls[0].includes('/api/refs?from=card_aa15ed26'), 'fetch URL: ' + urls[0]);
+        assert(urls[0].includes('deviceId=dev-test'), 'fetch creds: ' + urls[0]);
+    });
+});
+
+test('desktop: chip link href points to portal/kanban for cards and github for spec/PR', async () => {
+    await withPage({ viewport: { width: 1280, height: 800 } }, async (page) => {
+        await page.click('.eclaw-refs-icon');
+        await page.waitForSelector('.eclaw-refs-icon-link');
+        const links = await page.$$eval('.eclaw-refs-icon-link', els => els.map(el => ({
+            href: el.getAttribute('href'),
+            kind: el.dataset.refKind,
+            id: el.dataset.refId,
+            target: el.getAttribute('target'),
+        })));
+        const spec = links.find(l => l.kind === 'spec');
+        const card = links.find(l => l.kind === 'card');
+        const pr = links.find(l => l.kind === 'pr');
+        assert(spec && spec.href.includes('github.com') && spec.target === '_blank',
+            'spec link: ' + JSON.stringify(spec));
+        assert(card && card.href.includes('/portal/kanban.html#card_7579f205'),
+            'card link: ' + JSON.stringify(card));
+        assert(pr && pr.href.includes('github.com/HankHuang0516/EClaw/pull/3123') && pr.target === '_blank',
+            'pr link: ' + JSON.stringify(pr));
+    });
+});
+
+test('desktop: ESC closes popover and restores focus to ? icon', async () => {
+    await withPage({ viewport: { width: 1280, height: 800 } }, async (page) => {
+        await page.click('.eclaw-refs-icon');
+        await page.waitForSelector('.help-popover');
+        await page.keyboard.press('Escape');
+        // After ESC the popover fades out (setTimeout 200ms); allow time
+        await page.waitForTimeout(300);
+        const stillThere = await page.$('.help-popover-visible');
+        assert(!stillThere, 'popover should be hidden after ESC');
+        const focused = await page.evaluate(() => document.activeElement?.className || '');
+        assert(focused.includes('eclaw-refs-icon'),
+            'focus restored, was: ' + focused);
+    });
+});
+
+test('mobile: 390x844 popover renders bottom-sheet variant', async () => {
+    await withPage({ viewport: { width: 390, height: 844 } }, async (page) => {
+        await page.click('.eclaw-refs-icon');
+        await page.waitForSelector('.help-popover');
+        const isSheet = await page.evaluate(() => {
+            const pop = document.querySelector('.help-popover');
+            return pop && pop.classList.contains('help-popover--sheet');
+        });
+        assert(isSheet, 'help-popover--sheet class should be applied on mobile');
+    });
+});
+
+test('error path: fetch fails → error message renders', async () => {
+    const errStyle = '';
+    const html = buildHtml(errStyle).replace(
+        'window.fetch = (url) => {',
+        'window.fetch = (url) => { window.__capturedFetches.push(url); return Promise.resolve({ ok: false, status: 500, json: async () => ({}) }); };\nwindow.__unused = () => {'
+    );
+    await withPage({ viewport: { width: 1280, height: 800 }, html }, async (page) => {
+        await page.click('.eclaw-refs-icon');
+        await page.waitForSelector('.eclaw-refs-icon-error');
+        const txt = await page.textContent('.eclaw-refs-icon-error');
+        assert(txt && txt.length > 0, 'error message rendered: ' + txt);
+    });
+});
+
+// ── Runner ─────────────────────────────────────────────────────────────────
+(async () => {
+    let pass = 0, fail = 0;
+    for (const t of SUITE) {
+        try {
+            await t.fn();
+            console.log(`  ✓ ${t.name}`);
+            pass++;
+        } catch (e) {
+            console.error(`  ✗ ${t.name} — ${e.message}`);
+            fail++;
+        }
+    }
+    console.log(`\nrefs-popover.spec.js: ${pass} passed, ${fail} failed`);
+    process.exit(fail ? 1 : 0);
+})();

--- a/backend/tests/jest/api-refs-auth.test.js
+++ b/backend/tests/jest/api-refs-auth.test.js
@@ -1,0 +1,216 @@
+/**
+ * api_refs.js auth + scan tests (Jest).
+ *
+ * Verifies the auth helper accepts the EClaw-shaped credentials (per #6's
+ * NACK on PR #3132): `devices[deviceId].deviceSecret` for portal callers and
+ * `devices[deviceId].entities[entityId].botSecret` for bot callers, and
+ * rejects mismatched/missing credentials.
+ *
+ * Also exercises the pure scan-text helper so the regex set is regression-
+ * checked separately from the DB path.
+ */
+
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+const createRefsModule = require('../../api_refs');
+const { scanText, normalizeFromId, cacheKey, keyOf } = require('../../api_refs')._private;
+const express = require('express');
+const http = require('http');
+
+function makeDevices() {
+    return {
+        'dev-A': {
+            deviceSecret: 'sec-A',
+            entities: {
+                2: { botSecret: 'bot-A2' },
+                3: { botSecret: 'bot-A3' },
+            },
+        },
+        'dev-B': {
+            deviceSecret: 'sec-B',
+            entities: {
+                2: { botSecret: 'bot-B2' },
+            },
+        },
+    };
+}
+
+function spinUp() {
+    const devices = makeDevices();
+    // Force enable so the endpoint actually exercises auth (and skip the timer).
+    const prevEnabled = process.env.ECLAW_REFS_INDEX_ENABLED;
+    process.env.ECLAW_REFS_INDEX_ENABLED = '1';
+    const mod = createRefsModule(devices);
+    process.env.ECLAW_REFS_INDEX_ENABLED = prevEnabled;
+    mod._internals.stopScanLoop(); // don't keep the scan timer alive in tests
+
+    const app = express();
+    app.use('/api', mod.router);
+    return { app, devices, mod };
+}
+
+function request(app, urlPath) {
+    return new Promise((resolve, reject) => {
+        const server = app.listen(0, () => {
+            const port = server.address().port;
+            http.get(`http://127.0.0.1:${port}${urlPath}`, (res) => {
+                let body = '';
+                res.on('data', (c) => (body += c));
+                res.on('end', () => {
+                    server.close();
+                    try {
+                        resolve({ status: res.statusCode, json: body ? JSON.parse(body) : null });
+                    } catch (e) { reject(e); }
+                });
+            }).on('error', reject);
+        });
+    });
+}
+
+describe('api_refs scanText regex set (spec §3.2 patterns)', () => {
+    test('extracts card ids, spec/doc paths, and PR numbers', () => {
+        const out = scanText(
+            'see card_aa15ed2618c9246d11a0f6b1 + ' +
+            'docs/specs/portal-bidirectional-refs.md + ' +
+            'docs/research/2026-06-03-mobile-use-comparison.md + ' +
+            'PR #3124, also CARD_AA15ED2618C9246D11A0F6B1 (case-insensitive)'
+        );
+        const kinds = out.map(r => r.kind);
+        expect(kinds).toContain('card');
+        expect(kinds).toContain('spec');
+        expect(kinds).toContain('doc');
+        expect(kinds).toContain('pr');
+        // card_ matches are deduped by lowercased id
+        expect(out.filter(r => r.kind === 'card').length).toBe(1);
+        expect(out.find(r => r.kind === 'pr').id).toBe('3124');
+    });
+
+    test('returns empty array on null/empty text', () => {
+        expect(scanText('')).toEqual([]);
+        expect(scanText(null)).toEqual([]);
+        expect(scanText(undefined)).toEqual([]);
+    });
+});
+
+describe('api_refs normalizeFromId', () => {
+    test.each([
+        ['card_aa15ed2618c9246d11a0f6b1', { kind: 'card', id: 'card_aa15ed2618c9246d11a0f6b1' }],
+        ['docs/specs/portal-bidirectional-refs.md', { kind: 'spec', id: 'docs/specs/portal-bidirectional-refs.md' }],
+        ['docs/research/2026-06-03-mobile-use-comparison.md', { kind: 'doc', id: 'docs/research/2026-06-03-mobile-use-comparison.md' }],
+        ['3124', { kind: 'pr', id: '3124' }],
+        ['#3124', { kind: 'pr', id: '3124' }],
+    ])('normalizes %s', (input, expected) => {
+        expect(normalizeFromId(input)).toEqual(expected);
+    });
+
+    test('rejects unknown shapes', () => {
+        expect(normalizeFromId('')).toBeNull();
+        expect(normalizeFromId(null)).toBeNull();
+        expect(normalizeFromId('foo://bar')).toBeNull();
+    });
+});
+
+describe('api_refs cacheKey + keyOf', () => {
+    test('cacheKey includes deviceId for multi-device isolation', () => {
+        expect(cacheKey('dev-A', 'card', 'card_x')).toBe('dev-A|card|card_x');
+        expect(cacheKey('dev-A', 'card', 'card_x'))
+            .not.toBe(cacheKey('dev-B', 'card', 'card_x'));
+    });
+    test('keyOf is kind|id', () => {
+        expect(keyOf('spec', 'docs/specs/foo.md')).toBe('spec|docs/specs/foo.md');
+    });
+});
+
+describe('api_refs auth (HTTP) — deviceSecret path (portal caller)', () => {
+    test('GET /api/refs with valid deviceSecret returns success', async () => {
+        const { app } = spinUp();
+        const r = await request(app, '/api/refs?from=card_aa15ed2618c9246d11a0f6b1&deviceId=dev-A&deviceSecret=sec-A');
+        expect(r.status).toBe(200);
+        expect(r.json.success).toBe(true);
+    });
+
+    test('GET /api/refs with wrong deviceSecret → 401', async () => {
+        const { app } = spinUp();
+        const r = await request(app, '/api/refs?from=card_aa15ed2618c9246d11a0f6b1&deviceId=dev-A&deviceSecret=wrong');
+        expect(r.status).toBe(401);
+    });
+
+    test('GET /api/refs with deviceSecret from another device → 401', async () => {
+        const { app } = spinUp();
+        const r = await request(app, '/api/refs?from=card_aa15ed2618c9246d11a0f6b1&deviceId=dev-A&deviceSecret=sec-B');
+        expect(r.status).toBe(401);
+    });
+});
+
+describe('api_refs auth (HTTP) — botSecret path (bot caller)', () => {
+    test('GET /api/refs with valid entityId+botSecret returns success', async () => {
+        const { app } = spinUp();
+        const r = await request(app, '/api/refs?from=card_aa15ed2618c9246d11a0f6b1&deviceId=dev-A&entityId=2&botSecret=bot-A2');
+        expect(r.status).toBe(200);
+        expect(r.json.success).toBe(true);
+    });
+
+    test('GET /api/refs with botSecret but no entityId still matches by scan → success', async () => {
+        const { app } = spinUp();
+        const r = await request(app, '/api/refs?from=card_aa15ed2618c9246d11a0f6b1&deviceId=dev-A&botSecret=bot-A3');
+        expect(r.status).toBe(200);
+        expect(r.json.success).toBe(true);
+    });
+
+    test('GET /api/refs with wrong botSecret → 401', async () => {
+        const { app } = spinUp();
+        const r = await request(app, '/api/refs?from=card_aa15ed2618c9246d11a0f6b1&deviceId=dev-A&entityId=2&botSecret=wrong');
+        expect(r.status).toBe(401);
+    });
+
+    test('GET /api/refs with cross-device botSecret → 401', async () => {
+        const { app } = spinUp();
+        const r = await request(app, '/api/refs?from=card_aa15ed2618c9246d11a0f6b1&deviceId=dev-A&entityId=2&botSecret=bot-B2');
+        expect(r.status).toBe(401);
+    });
+});
+
+describe('api_refs auth (HTTP) — missing credentials', () => {
+    test('no deviceId → 401', async () => {
+        const { app } = spinUp();
+        const r = await request(app, '/api/refs?from=card_aa15ed2618c9246d11a0f6b1');
+        expect(r.status).toBe(401);
+    });
+
+    test('deviceId only, no secret → 401', async () => {
+        const { app } = spinUp();
+        const r = await request(app, '/api/refs?from=card_aa15ed2618c9246d11a0f6b1&deviceId=dev-A');
+        expect(r.status).toBe(401);
+    });
+
+    test('unknown deviceId → 401', async () => {
+        const { app } = spinUp();
+        const r = await request(app, '/api/refs?from=card_aa15ed2618c9246d11a0f6b1&deviceId=nonexistent&deviceSecret=foo');
+        expect(r.status).toBe(401);
+    });
+});
+
+describe('api_refs feature flag off (default)', () => {
+    test('GET /api/refs returns success:true with empty refs when ECLAW_REFS_INDEX_ENABLED is unset', async () => {
+        const prevEnabled = process.env.ECLAW_REFS_INDEX_ENABLED;
+        delete process.env.ECLAW_REFS_INDEX_ENABLED;
+        const devices = makeDevices();
+        const mod = createRefsModule(devices);
+        mod._internals.stopScanLoop();
+        const app = express();
+        app.use('/api', mod.router);
+        process.env.ECLAW_REFS_INDEX_ENABLED = prevEnabled;
+
+        // Even with valid creds, when flag is off the endpoint short-circuits.
+        const r = await request(app, '/api/refs?from=card_aa15ed2618c9246d11a0f6b1&deviceId=dev-A&deviceSecret=sec-A');
+        expect(r.status).toBe(200);
+        expect(r.json.success).toBe(true);
+        expect(r.json.refs).toEqual([]);
+        expect(r.json.enabled).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

Implements portal `?` icon bidirectional references — the third ask from Hank's 2026-06-03 chat (`card_aa15ed26 直接全做 + 整理 SPEC + ? icon 雙向參照`). Card `card_a20b69d79f4aba684e7d04ec`; U94 owner.

Spec stack: PR #3124 (merged) + PR #3131 (merged — #6 review amendments). #6 yrt82n verbal approval captured in card comments + chat audit trail at 2026-06-03T13:57 UTC; formal GitHub approval blocked by connector permissions (`403 Resource not accessible by integration`) per #6's note.

## Surfaces

| Surface | This PR | Deferred |
|---|---|---|
| `portal/kanban.html` card list/detail | ✅ ? icon wired next to `.kb-card-title` | — |
| `portal/docs.html` rendering specs/research | — | follow-up card (page doesn't exist yet, per #6 scope-cut) |
| `portal/prs.html` | — | v1.5 (per spec §2) |
| Backend scan + API | ✅ full v1 scope incl. doc-citation backrefs | — |

## Backend (`backend/api_refs.js`)
- `GET /api/refs?from=<id>` returns `{ success, from, refs[] }`; each ref has `{ kind, id, label, direction: 'in' | 'out' }`. `from` accepts `card_*`, `docs/specs/*.md`, `docs/research/*.md`, or PR number.
- 5-min background scan over: `kanban_cards.{description,title,linked_prev_card_id,linked_next_card_id}` + `kanban_card_dependencies` + `kanban_card_links` + `kanban_comments.text` + `docs/specs/**/*.md` + `docs/research/**/*.md` + `gh pr list --json number,title,body,url,state,updatedAt`.
- Cache: in-memory keyed by `<deviceId>|<kind>|<id>`; warm-start at `backend/.cache/refs.json` (gitignored). Multi-device isolation by construction (key includes deviceId).
- Env flag `ECLAW_REFS_INDEX_ENABLED` (default off in prod per spec §8). Flag off → endpoint returns `{success:true, refs:[]}` so the icon renders an empty popover without breaking the UI.

## Frontend (`backend/public/shared/refs-popover.{js,css}`)
- Click handler on `.eclaw-refs-icon[data-refs-from]` → `GET /api/refs` → renders popover with two sections: **Outgoing** (this cites) + **Incoming** (cited by).
- Reuses `shared/help-popover.js` for show/hide/focus-trap/ESC plumbing via a new minimal options hook (`maxWidth`, `variant: 'tooltip' | 'sheet'`). No fork.
- Mobile bottom-sheet at ≤720 px via the `sheet` variant; `prefers-reduced-motion` respected.
- MutationObserver re-binds dynamically rendered card icons.
- Click navigation: cards → `/portal/kanban.html#<id>`; specs/docs/PRs → github.com source view in a new tab (interim until `docs.html` ships).

## Wiring
- `backend/public/portal/kanban.html`: `?` button rendered next to `.kb-card-title` in `renderCard()` template; stylesheet + scripts included in `<head>` / pre-`socket.io.js` block.
- `backend/index.js`: mounts `require('./api_refs')(devices, {serverLog})` at `/api` after the existing kanban modules.

## i18n
- 5 EN keys added to `shared/i18n.js` per spec §4.3: `refs.popover_title`, `refs.section_out`, `refs.section_in`, `refs.empty`, `refs.error` (+ `refs.close` for the close-button aria-label). Non-EN delegated per `feedback_i18n_delegate`.

## E2E (`backend/tests/e2e/refs-popover.spec.js`)
Inline-HTML Playwright suite (no running server) mirroring `help-popover.spec.js`. Stubs `window.fetch`. **5 cases, all green locally:**

```
✓ desktop: ? icon click → popover renders Outgoing + Incoming
✓ desktop: chip link href points to portal/kanban for cards and github for spec/PR
✓ desktop: ESC closes popover and restores focus to ? icon
✓ mobile: 390x844 popover renders bottom-sheet variant
✓ error path: fetch fails → error message renders

refs-popover.spec.js: 5 passed, 0 failed
```

## Acceptance criteria (spec §7)

- AC1 — spec PR signed off by #6 ✅ (#3131 merged; verbal approval recorded)
- AC2 — `/api/refs?from=<id>` returns valid `RefsResponse` for all 4 ref kinds ✅
- AC3 — 5-min scan + non-blocking cache refresh ✅
- AC4 — clicking `?` on the kanban surface opens the popover with out-direction refs ✅ (E2E)
- AC5 — back-refs auto-populate from all source kinds (PR body + spec/research doc + card desc/comments), not PR-only ✅ (per #6's §3.2 + AC5 amendments)
- AC6 — 390 × 844 mobile bottom-sheet variant ✅ (E2E)
- AC7 — E2E + prod URL screenshot ✅ E2E in this PR; prod URL screenshot will be attached on impl card move-to-done after merge (`feedback_prod_url_screenshot_before_done`)

## Follow-ups (out of scope of this PR)
- `portal/docs.html` page that renders `docs/specs/*.md` + `docs/research/*.md`, then wires `?` icon on those pages (per #6 deferral).
- `portal/prs.html` (spec §2 marks v1.5).
- Graph view `GET /api/refs/graph` + `/portal/refs/graph.html` (spec §3.3 / §6 Phase 5, optional).

## Test plan
- [x] Local Playwright E2E green (5/5)
- [ ] Prod URL smoke after deploy: open kanban, click ? icon on card_a20b69d7, verify popover lists the spec PR + linkedPrev research card; capture desktop 1280×800 + mobile 390×844 screenshots
- [ ] Move card → done after prod verify

## Links
- Card: `card_a20b69d79f4aba684e7d04ec`
- Spec PR (original, merged un-reviewed): #3124
- Spec amendment PR (merged with #6 sign-off): #3131
- Linked prev research card: `card_aa15ed2618c9246d11a0f6b1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)