### PR TITLE
fix(portal): hover-click-demo i18n.js onerror fallback identity fn

### DIFF
--- a/backend/public/portal/hover-click-demo.html
+++ b/backend/public/portal/hover-click-demo.html
@@ -53,7 +53,7 @@
     <pre class="mutation-log" id="log"></pre>
   </div>
 
-  <script src="../shared/i18n.js" onerror="window.i18n=null"></script>
+  <script src="../shared/i18n.js" onerror="window.i18n=function(k,fb){return typeof fb==='string'?fb:k}"></script>
   <script src="../shared/dom-select.js"></script>
   <script src="../shared/hover-click-toolbar.js"></script>
   <script src="../shared/content-import.js"></script>


### PR DESCRIPTION
## Summary
Closes kanban card_1d596a6e (P0 after 12.5h auto-blocked).

Card title is "[i18n/CI/P1] hover-click-demo.html:56 — onerror inline handler 需加上 typeof i18n guard" but the literal interpretation is misleading: line 56's onerror DOES NOT invoke i18n. It just sets window.i18n=null.

The real bug: `window.i18n=null` makes any later caller `i18n('some.key','fb')` throw with "i18n is not a function". The fix is at this onerror handler, not at every call site — replace null with a tiny identity fallback so callers can keep calling unguarded:

\`\`\`
i18n('some.key', 'Default')  →  returns 'Default' when i18n.js failed
i18n('some.key')             →  returns 'some.key'
\`\`\`

Single-line diff, no behavior change when i18n.js loads successfully (i18n.js sets a richer window.i18n that overrides).

## Test plan
- [x] Load /portal/hover-click-demo.html with i18n.js present — behavior unchanged (i18n.js's setter wins)
- [x] Load /portal/hover-click-demo.html with i18n.js 404 — window.i18n is a function, callers don't throw
- [x] CRLF check: file unchanged in line ending (LF preserved)

🤖 Generated with [Claude Code](https://claude.com/claude-code)