### PR TITLE
fix(portal/kanban): detail more-menu unreachable on mobile (dup toggleTaskOverflow + chip dup + 40px hit-target)

### DIFF
--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -529,7 +529,7 @@
         body.app-webview .kb-task-action-shell { gap:6px; flex-wrap:nowrap; }
         body.app-webview .kb-task-primary-btn { padding:8px 12px; font-size:11px; }
         body.app-webview .kb-task-secondary-row { flex-wrap:nowrap; overflow-x:auto; }
-        body.app-webview .kb-task-chip { max-width:132px; padding:6px 9px; font-size:11px; }
+        body.app-webview .kb-task-chip { max-width:132px; min-height:40px; padding:10px 12px; font-size:11px; }
         body.app-webview .kb-move-btn { padding:6px 10px; font-size:11px; }
 
         /* App WebView: hide redundant heading (sub-tabs already indicate page) */
@@ -622,8 +622,10 @@
             .kb-task-action-shell { gap:6px; flex-wrap:nowrap; }
             .kb-task-primary-btn { padding:8px 12px; font-size:11px; }
             .kb-task-secondary-row { flex-wrap:nowrap; overflow-x:auto; }
-            .kb-task-chip { max-width:132px; padding:6px 9px; font-size:11px; }
-            .kb-move-btn { padding:6px 10px; font-size:11px; }
+            /* Mobile hit-target: chip-drill acceptance ≥40px (2026-06-04 fix) */
+            .kb-task-chip { max-width:132px; padding:10px 12px; font-size:11px; min-height:40px; }
+            .kb-detail-link-chip-row .kb-task-chip { min-height:40px; padding:10px 12px; }
+            .kb-move-btn { padding:10px 14px; font-size:11px; min-height:40px; }
 
             /* Toolbar compact */
             .kb-toolbar { flex-direction:column; align-items:stretch; }
@@ -2212,11 +2214,11 @@
         }
 
         function renderTaskSecondaryActions(card) {
+            // parent/prev/next chips are rendered by renderDetailLinkChipRow() above in the
+            // description area (L2511) with zh-TW titles; keep this row to PR + Chat only
+            // to avoid the duplicate-chip stack the chip-drill surfaced (2026-06-04).
             const actions = [];
             const add = (cls, icon, label, onclick, title) => actions.push(`<button class="kb-task-chip ${cls}" onclick="${onclick}" title="${escapeHtml(title || label)}">${icon}<span>${escapeHtml(label)}</span></button>`);
-            if (card.parentCardId) add('parent', '↟', t('chip_parent','Parent'), `openDetail('${escapeJs(card.parentCardId)}')`, card.parentCardId);
-            if (card.linkedPrevCardId) add('prev', '←', t('chip_prev','Prev'), `openDetail('${escapeJs(card.linkedPrevCardId)}')`, card.linkedPrevCardId);
-            if (card.linkedNextCardId) add('next', '→', t('chip_next','Next'), `openDetail('${escapeJs(card.linkedNextCardId)}')`, card.linkedNextCardId);
             if (getTaskPrUrl(card)) add('pr', '⑂', 'PR', `openTaskPr('${escapeJs(card.id)}')`, getTaskPrUrl(card));
             add('chat', '💬', t('chip_chat','Chat'), `quoteKanbanCardToChat()`, 'Quote this card to Chat');
             return actions.slice(0, 5).join('');
@@ -2246,6 +2248,7 @@
                     `<div class="kb-task-overflow-section"><div class="kb-task-overflow-title">Assignment</div>${assignHtml}</div>` +
                     `<div class="kb-task-overflow-section"><div class="kb-task-overflow-title">Review</div>${reviewerHtml}</div>` +
                     (card.isAutomation ? `<div class="kb-task-overflow-section"><div class="kb-task-overflow-title">Schedule</div>${dispatchHtml}</div>` : '') +
+                    (!card.isAutomation && !card.archived ? renderStatusOverflow(card.id, card.status) : '') +
                     `<div class="kb-task-overflow-section"><div class="kb-task-overflow-title">Admin</div><div class="kb-task-overflow-actions">${adminButtons}</div></div>` +
                 `</div></div>`;
         }
@@ -2434,15 +2437,6 @@
             if (kind === 'reopen') return openReopenDialog(cardId);
             if (kind === 'toggleSchedule') return toggleAutoSchedule(cardId, value === 'true');
             if (kind === 'restore') return restoreCard(cardId);
-        }
-
-        function toggleTaskOverflow(cardId, event) {
-            if (event) event.stopPropagation();
-            document.querySelectorAll('.kb-task-overflow.open').forEach(el => {
-                if (el.id !== 'taskOverflow-' + cardId) el.classList.remove('open');
-            });
-            const el = document.getElementById('taskOverflow-' + cardId);
-            if (el) el.classList.toggle('open');
         }
 
         function openCardPr(cardId) {


### PR DESCRIPTION
## Summary
- Chip UX drill 2026-06-04 (Playwright 390x844 prod, card_62c0e6ee items 2/3/4) found that the detail-modal **More overflow menu opens 0/100 taps** because a second `toggleTaskOverflow(cardId, event)` declaration (L2439) shadowed the original `toggleTaskOverflow(event)` (L2225). The only live renderer (L2244) wires the single-arg signature, so on tap the function received `(event, undefined)` → `cardId === event object` → `getElementById('taskOverflow-[object PointerEvent]')` → null → panel never toggled.
- Archive (item 3) and Status-change buttons (item 4) live inside that menu, so 3/5 chip-drill items failed by extension.
- Same drill surfaced **duplicate prev/next chips** (two renderers fire — zh-TW `上一張/下一張` + en `Prev/Next`) and **30px hit-target** (< drill's ≥40px acceptance).

## Changes
1. Delete dead `toggleTaskOverflow(cardId, event)` at L2439 (the shadowing dup). Keep L2225 `toggleTaskOverflow(event)` which matches the live `onclick="toggleTaskOverflow(event)"` wiring at L2244.
2. `renderTaskSecondaryActions` (L2214): drop parent/prev/next adds — navigation chips stay only on `renderDetailLinkChipRow` row above (zh-TW labels). Action-bar row keeps PR + Chat.
3. `renderTaskOverflowActions` (L2238): add Status section for non-automation/non-archived cards via existing `renderStatusOverflow` helper — exposes todo/in_progress/review/done buttons in the overflow so item 4 (tap-to-specific-status) works.
4. Mobile media-query (≤500px L625): bump `.kb-task-chip` and `.kb-move-btn` padding 10×12 + `min-height: 40px` per drill acceptance.

## Why not also delete `renderTaskActionBar` (L2411) / `renderTaskSecondaryChips` (L2383)?
They are dead code (never called — `renderTaskActionShell` at L2253 is the only `moveBar.innerHTML` renderer per L2570). Removing them now would inflate this diff with a separate cleanup. Filed as follow-up todo on the bug card.

## Test plan
- [x] Static: `node vm.Script` parse on all 4 inline `<script>` blocks → 4/4 clean.
- [x] Source-code diagnosis matches independent #6 audit.
- [ ] Post-deploy prod Playwright @ 390x844:
  - Open card detail modal → tap ⋮ More → screenshot panel `.kb-task-overflow.open` with Assignment / Review / Status / Admin sections visible.
  - Verify Archive button hit-target rect.height ≥ 40px.
  - Tap a status button (e.g. review → todo) → verify server `/api/mission/cards` reflects new status.
  - Open card with linkedPrev + linkedNext → verify exactly one `← 上一張 / 下一張 →` chip pair (no `Prev/Next` duplicate).
- [ ] Run drill card_62c0e6ee items 2/3/4/5 again to confirm all PASS.

Closes [Bug/P0] card_2341be65129c6efd6bf1cd65. Supersedes [Bug/P1] card_7b5c440c (false-positive — chips DO render via `.kb-detail-link-chip-row`, prior drill used wrong selectors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)