### PR TITLE
fix(openclaw-channel): preserve EClaw reply targets

### DIFF
--- a/openclaw-channel-eclaw/README.md
+++ b/openclaw-channel-eclaw/README.md
@@ -170,8 +170,8 @@ Device owners can schedule messages to be sent to your bot at a specific time (o
 |----------|----------|-------------|
 | `ECLAW_WEBHOOK_URL` | Production | Public URL for receiving inbound messages |
 | `ECLAW_WEBHOOK_PORT` | Optional | Webhook server port (default: random) |
-| `ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS` | Optional | Set to `1` for high-priority interactive agents that receive many kanban cards. The webhook is still ACKed, but `kanban_notification` events do not occupy the model reply path, so normal web chat and `/api/client/speak` probes stay responsive. |
-| `ECLAW_SUPPRESS_BACKGROUND_EVENTS` | Optional | Set to `1` to suppress the default low-priority background event set (`kanban_notification`, `org_forward`), or set a comma-separated event list such as `org_forward`. Use per runtime, not globally, when a background feed is starving an interactive entity. |
+| `ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS` | Optional | Set to `1` only for agents where kanban cards are intentionally notification-only. The webhook is still ACKed, but `kanban_notification` events do not occupy the model reply path, so the agent will not execute those task nudges. |
+| `ECLAW_SUPPRESS_BACKGROUND_EVENTS` | Optional | Set to `1` to suppress the default low-priority background event set (`org_forward`), or set a comma-separated event list such as `org_forward`. Kanban task notifications are model-routed by default; use `ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS=1` only when that is the intended behavior. |
 
 ## OpenClaw Version Drift Mitigation
 
@@ -190,11 +190,29 @@ docker exec openclaw-project-f openclaw --version
 ```
 
 After the recreate, verify startup logs show the intended runtime model, for
-example `agent model: openai-codex/gpt-5.5 (thinking=xhigh, ...)`, then test
-the E-Claw browser chat UI with a fresh nonce. For #1, enable
-`ECLAW_SUPPRESS_BACKGROUND_EVENTS=1` when recurring kanban or `org_forward`
-background cards are queued ahead of user messages; this prevents background
-feed backlog from starving the interactive reply path.
+example `agent model: openai/gpt-5.5 (thinking=xhigh, ...)`, then confirm the
+configured model entry has `agentRuntime.id=codex`. Older OpenClaw builds may
+log `openai-codex/gpt-5.5`; OpenClaw 2026.6.1 migrates this to canonical
+`openai/gpt-5.5` while preserving Codex OAuth routing through `agentRuntime`.
+
+After upgrading to OpenClaw 2026.6.1, run `openclaw doctor --fix` once inside
+the recreated container. It migrates legacy `openai-codex` provider config,
+auth profiles, session routes, and model refs to the canonical OpenAI provider.
+Without that migration, project F can start with stale config or fail model
+turns with provider 400/403 errors.
+
+Then test the E-Claw browser chat UI with a fresh nonce and a model-backed
+reply-path probe. API `/api/client/speak` health probes may set `from` to a
+source label such as `targeted-model-health`; the channel must not treat that
+label as the message-tool reply target. Current channel builds route replies
+through the stable E-Claw conversation id (`deviceId:entityId`) and declare an
+E-Claw target resolver so OpenClaw's `message` tool can send the reply instead
+of failing with `Unknown target`.
+
+For task-execution agents such as #1 and #3, keep kanban notifications
+model-routed. If low-priority organization forwards are starving the
+interactive reply path, use `ECLAW_SUPPRESS_BACKGROUND_EVENTS=org_forward`
+rather than suppressing kanban task nudges.
 
 ## Troubleshooting
 

--- a/openclaw-channel-eclaw/README.md
+++ b/openclaw-channel-eclaw/README.md
@@ -189,6 +189,35 @@ docker compose up -d --no-deps openclaw-f
 docker exec openclaw-project-f openclaw --version
 ```
 
+Known-good recovery for project E / entity #3 after version drift:
+
+```bash
+cd /Users/hank/Desktop/Project/openclaw-docker
+# project E intentionally reuses the same verified runtime image as project F;
+# its MiniMax default model remains controlled by project-e's mounted config.
+docker compose up -d --no-deps --force-recreate openclaw-e
+docker exec openclaw-project-e openclaw --version
+docker exec openclaw-project-e openclaw plugins list --json
+```
+
+Expected post-upgrade state for #3:
+
+- `openclaw --version` reports `OpenClaw 2026.6.1`.
+- The loaded `openclaw-channel` plugin reports version `1.3.1` and is sourced
+  from `/home/node/.openclaw/npm/projects/.../@eclaw/openclaw-channel`.
+- `session.reset` is set to an idle reset window so six-hour fleet monitors do
+  not reuse a stale, task-heavy MiniMax conversation indefinitely.
+- API ACK, model-backed reply-path, and browser UI ACK all pass for entity #3.
+
+If #3 has an older untracked side-loaded extension, `openclaw plugins update`
+will report no install record. Install the tracked npm package instead:
+
+```bash
+docker exec openclaw-project-e \
+  openclaw plugins install @eclaw/openclaw-channel@1.3.1
+docker restart openclaw-project-e
+```
+
 After the recreate, verify startup logs show the intended runtime model, for
 example `agent model: openai/gpt-5.5 (thinking=xhigh, ...)`, then confirm the
 configured model entry has `agentRuntime.id=codex`. Older OpenClaw builds may
@@ -208,6 +237,12 @@ label as the message-tool reply target. Current channel builds route replies
 through the stable E-Claw conversation id (`deviceId:entityId`) and declare an
 E-Claw target resolver so OpenClaw's `message` tool can send the reply instead
 of failing with `Unknown target`.
+
+For model-health probes, avoid ambiguous text such as `entity=#3` in the
+expected reply. Some MiniMax turns can shorten that to only `3`, which proves a
+model turn happened but fails nonce validation. Prefer an unambiguous nonce-only
+line such as `MODEL_HEALTH_OK_<nonce>` and pass/fail on the nonce, not on a
+self-reported model name.
 
 For task-execution agents such as #1 and #3, keep kanban notifications
 model-routed. If low-priority organization forwards are starving the

--- a/openclaw-channel-eclaw/src/channel.ts
+++ b/openclaw-channel-eclaw/src/channel.ts
@@ -3,6 +3,14 @@ import { sendText, sendMedia } from './outbound.js';
 import { startAccount } from './gateway.js';
 import { eclawOnboardingAdapter } from './onboarding.js';
 
+function normalizeEClawMessagingTarget(target: string): string {
+  return target.trim();
+}
+
+function looksLikeEClawTargetId(target: string): boolean {
+  return target.trim().length > 0;
+}
+
 /**
  * E-Claw ChannelPlugin definition.
  *
@@ -35,6 +43,22 @@ export const eclawChannel = {
   config: {
     listAccountIds,
     resolveAccount,
+  },
+
+  messaging: {
+    targetPrefixes: ['eclaw'],
+    normalizeTarget: normalizeEClawMessagingTarget,
+    inferTargetChatType: () => 'direct',
+    targetResolver: {
+      looksLikeId: looksLikeEClawTargetId,
+      hint: '<conversationId|publicCode|source>',
+    },
+  },
+
+  agentPrompt: {
+    messageToolHints: () => [
+      '- E-Claw targeting: omit `target` to reply to the current entity conversation. Explicit targets may be the E-Claw conversation id, public code, or source label resolved by the channel.',
+    ],
   },
 
   outbound: {

--- a/openclaw-channel-eclaw/src/webhook-handler.ts
+++ b/openclaw-channel-eclaw/src/webhook-handler.ts
@@ -17,7 +17,9 @@ function envListIncludes(name: string, value: string, defaults: readonly string[
     .includes(value);
 }
 
-const DEFAULT_BACKGROUND_EVENTS = ['kanban_notification', 'org_forward'] as const;
+// Keep kanban notifications model-routed by default. They are task nudges, not
+// passive telemetry; suppressing them ACKs the webhook but prevents execution.
+const DEFAULT_BACKGROUND_EVENTS = ['org_forward'] as const;
 
 function shouldSuppressInboundEvent(event: string): boolean {
   if (
@@ -78,6 +80,7 @@ export function createWebhookHandler(
       const rt = getPluginRuntime();
       const client = getClient(accountId);
       const conversationId = msg.conversationId || `${msg.deviceId}:${msg.entityId}`;
+      const replyTarget = conversationId || msg.from || accountId;
 
       const directAck = String(msg.text || '').match(/^ECLAW_HEALTHCHECK\s+([A-Za-z0-9_-]+)(?=\s|$)/m);
       if (directAck) {
@@ -155,9 +158,10 @@ export function createWebhookHandler(
         Provider: 'eclaw',
         OriginatingChannel: 'eclaw',
         AccountId: accountId,
-        From: msg.from,
-        To: conversationId,
-        OriginatingTo: msg.from,
+        From: replyTarget,
+        To: replyTarget,
+        OriginatingTo: replyTarget,
+        SenderName: msg.from,
         SessionKey: conversationId,
         Body: body,
         RawBody: body,

--- a/openclaw-channel-eclaw/test/webhook-handler.test.ts
+++ b/openclaw-channel-eclaw/test/webhook-handler.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createWebhookHandler } from '../src/webhook-handler.js';
+import { eclawChannel } from '../src/channel.js';
 import { setPluginRuntime } from '../src/runtime.js';
 import { setClient } from '../src/outbound.js';
 
@@ -125,6 +126,97 @@ describe('createWebhookHandler', () => {
     expect(res.end).toHaveBeenCalledWith(JSON.stringify({ ok: true }));
     expect(client.sendMessage).not.toHaveBeenCalled();
     expect(dispatchReplyWithBufferedBlockDispatcher).not.toHaveBeenCalled();
+  });
+
+  it('does not suppress kanban notifications through the generic background flag', async () => {
+    process.env.ECLAW_SUPPRESS_BACKGROUND_EVENTS = '1';
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockResolvedValue(undefined);
+    const finalizeInboundContext = vi.fn((ctx) => ctx);
+    setPluginRuntime({
+      channel: {
+        reply: {
+          finalizeInboundContext,
+          dispatchReplyWithBufferedBlockDispatcher,
+        },
+      },
+    });
+
+    const client = {
+      sendMessage: vi.fn().mockResolvedValue({ success: true }),
+    };
+    setClient('default', client as any);
+
+    const handler = createWebhookHandler('token', 'default', {});
+    const res = {
+      writeHead: vi.fn(),
+      end: vi.fn(),
+    };
+
+    await handler({
+      method: 'POST',
+      body: {
+        deviceId: 'device-1',
+        entityId: 1,
+        event: 'kanban_notification',
+        from: 'kanban',
+        text: '📋 New task assigned: 🔥 [P0] Fix the bug\nStatus: TODO',
+      },
+    }, res);
+
+    expect(res.writeHead).toHaveBeenCalledWith(200, { 'Content-Type': 'application/json' });
+    expect(res.end).toHaveBeenCalledWith(JSON.stringify({ ok: true }));
+    expect(finalizeInboundContext).toHaveBeenCalled();
+    expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+  });
+
+  it('uses a stable E-Claw conversation id as the reply target instead of the webhook source label', async () => {
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockResolvedValue(undefined);
+    const finalizeInboundContext = vi.fn((ctx) => ctx);
+    setPluginRuntime({
+      channel: {
+        reply: {
+          finalizeInboundContext,
+          dispatchReplyWithBufferedBlockDispatcher,
+        },
+      },
+    });
+
+    const client = {
+      sendMessage: vi.fn().mockResolvedValue({ success: true }),
+    };
+    setClient('default', client as any);
+
+    const handler = createWebhookHandler('token', 'default', {});
+    const res = {
+      writeHead: vi.fn(),
+      end: vi.fn(),
+    };
+
+    await handler({
+      method: 'POST',
+      body: {
+        deviceId: 'device-1',
+        entityId: 1,
+        event: 'message',
+        from: 'targeted-doctor-model-health-1',
+        text: 'hello',
+      },
+    }, res);
+
+    expect(finalizeInboundContext).toHaveBeenCalled();
+    expect(finalizeInboundContext.mock.calls[0]?.[0]).toMatchObject({
+      From: 'device-1:1',
+      To: 'device-1:1',
+      OriginatingTo: 'device-1:1',
+      SenderName: 'targeted-doctor-model-health-1',
+      SessionKey: 'device-1:1',
+    });
+  });
+
+  it('declares an E-Claw target resolver for source labels and conversation ids', () => {
+    expect(eclawChannel.messaging.targetResolver.looksLikeId('targeted-doctor-model-health-1')).toBe(true);
+    expect(eclawChannel.messaging.targetResolver.looksLikeId('device-1:1')).toBe(true);
+    expect(eclawChannel.messaging.normalizeTarget('  device-1:1  ')).toBe('device-1:1');
   });
 
   it('continues dispatching kanban notifications when suppression is disabled', async () => {


### PR DESCRIPTION
## Summary\n- keep kanban notifications model-routed by default while allowing org_forward suppression\n- route EClaw replies through stable conversation ids instead of webhook source labels\n- add EClaw target resolver metadata so OpenClaw message tool can reply to client-speak/browser probes\n- document OpenClaw 2026.6.1 Codex provider migration and reply-path mitigation\n\n## Verification\n- npm run lint\n- npm test\n- npm run build\n- synced runtime channel dist to #1/#3 and verified #1/#3 API ACK + model-backed reply path\n- browser UI ACK passed for #1/#3/#4\n- full monitor passed with currentFailureCount=0\n