### PR TITLE
fix(portal/shared/api): aria-label on destructive OK button — WCAG 1.4.1

### DIFF
--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -101,7 +101,7 @@ function showConfirm({ message, title, confirmText, cancelText, danger } = {}) {
             <div class="dialog-body"><p id="${messageId}" style="margin:0;line-height:1.6;color:var(--text-secondary)">${_escHtml(message)}</p></div>
             <div class="dialog-actions">
                 <button type="button" class="btn btn-outline eclaw-confirm-cancel">${_escHtml(cancelText || t('dialog_cancel', 'Cancel'))}</button>
-                <button type="button" class="btn ${danger ? 'btn-danger' : 'btn-primary'} eclaw-confirm-ok">${_escHtml(confirmText || t('dialog_ok', 'OK'))}</button>
+                <button type="button" class="btn ${danger ? 'btn-danger' : 'btn-primary'} eclaw-confirm-ok"${danger && !confirmText ? ` aria-label="${_escAttr(t('dialog_confirm_destructive', 'Confirm destructive action'))}"` : ''}>${_escHtml(confirmText || t('dialog_ok', 'OK'))}</button>
             </div>
         </div>`;
         document.body.appendChild(overlay);


### PR DESCRIPTION
## Summary

Closes **card_0a2c388472cc48de82b8b343** (Phase 3 child card from destructive-modals daily E2E 2026-06-04 16:18 TW).

When \`showConfirm({danger:true})\` is called WITHOUT a custom \`confirmText\`, the OK button now carries \`aria-label=\"Confirm destructive action\"\` (i18n key \`dialog_confirm_destructive\`). Visual users keep seeing 'OK' with \`.btn-danger\` (red); screen-reader users hear the destructive semantic instead of the generic 'OK' text alone.

Closes the **WCAG SC 1.4.1 (Use of Color)** gap surfaced by the destructive-modals daily E2E Phase 2 a11y audit (parent card_bf4a2e2d).

## Backward compatibility

- Callers that supply \`confirmText\` (e.g. 'Delete', 'Unbind', 'Archive') get NO aria-label override — their explicit text is authoritative.
- Single-line change inside the existing template literal at L104. No behavior change for non-destructive confirms or for confirms with explicit confirmText.
- New i18n key \`dialog_confirm_destructive\` falls back to the English literal 'Confirm destructive action' when locale missing, so no per-locale work is blocking.

## Test plan

- [x] Code review: single-line aria-label addition gated on \`danger && !confirmText\`.
- [ ] Next destructive-modals daily E2E will assert aria-label presence on \`.btn-danger.eclaw-confirm-ok\` when no confirmText was passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)