### PR TITLE
fix(uiux): resolve public route aliases and mobile overflow

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -317,12 +317,12 @@ app.use('/js', express.static(path.join(__dirname, 'public/js'), {
     }
 }));
 // Landing page
-app.get('/landing', (req, res) => {
+app.get(['/landing', '/landing.html'], (req, res) => {
     res.set('Cache-Control', 'public, max-age=3600');
     res.sendFile(path.join(__dirname, 'public/landing.html'));
 });
 // Enterprise page
-app.get('/enterprise', (req, res) => {
+app.get(['/enterprise', '/enterprise.html'], (req, res) => {
     res.set('Cache-Control', 'public, max-age=3600');
     res.sendFile(path.join(__dirname, 'public/enterprise.html'));
 });
@@ -877,7 +877,7 @@ app.use('/docs', express.static(path.join(__dirname, 'public/docs'), {
 }));
 
 // Privacy policy (public, root-level)
-app.get('/privacy-policy.html', (req, res) => {
+app.get(['/privacy-policy.html', '/privacy-policy'], (req, res) => {
     res.sendFile(path.join(__dirname, 'public/privacy-policy.html'));
 });
 
@@ -3589,7 +3589,8 @@ if (process.env.NODE_ENV !== 'test') setTimeout(() => inviteModule.initInviteDat
 const arenaModule = require('./interview-arena')({ serverLog, io, devices });
 app.use('/api/arena', arenaModule.router);
 // Serve arena public pages (no-cache to prevent CDN stale versions)
-app.get('/arena', (_req, res) => { res.set('Cache-Control', 'no-cache'); res.sendFile(path.join(__dirname, 'public/arena/index.html')); });
+app.get(['/arena', '/arena/index.html'], (_req, res) => { res.set('Cache-Control', 'no-cache'); res.sendFile(path.join(__dirname, 'public/arena/index.html')); });
+app.get('/arena/exam.html', (_req, res) => { res.redirect(302, '/arena'); });
 app.get('/arena/exam/:examId', (_req, res) => { res.set('Cache-Control', 'no-cache'); res.sendFile(path.join(__dirname, 'public/arena/exam.html')); });
 // Bot entry point: returns exam sessions with tokens + challenge configs
 app.get('/arena/test/:examId', async (req, res) => {

--- a/backend/public/assets/mockup-mindmap-v3-dense.html
+++ b/backend/public/assets/mockup-mindmap-v3-dense.html
@@ -359,6 +359,80 @@ body {
   color: var(--text-secondary);
 }
 .mind-foot strong { color: var(--text); }
+
+@media (max-width: 700px) {
+  body { overflow: hidden; }
+  .mockup-banner {
+    padding: 6px 10px;
+    font-size: 11px;
+  }
+  .topnav {
+    height: auto;
+    min-height: 48px;
+    padding: 8px 12px;
+    flex-wrap: wrap;
+  }
+  .topnav .crumbs { font-size: 12px; }
+  .sub-tabs {
+    padding: 0 8px;
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .sub-tab {
+    flex: 0 0 auto;
+    padding: 10px 12px;
+    white-space: nowrap;
+  }
+  .mind-shell {
+    grid-template-columns: 1fr;
+    height: calc(100vh - 48px - 40px - 32px - 30px);
+    min-height: 0;
+  }
+  .sys-rail { display: none; }
+  .mind-canvas-wrap { min-width: 0; }
+  .mm-toolbar {
+    left: 8px;
+    right: 8px;
+    max-width: calc(100vw - 16px);
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .mm-toolbar button {
+    flex: 0 0 auto;
+    white-space: nowrap;
+    padding: 6px 8px;
+  }
+  .mm-search {
+    top: 58px;
+    left: 8px;
+    right: 8px;
+    width: auto;
+    transform: none;
+  }
+  .zoom-tier {
+    top: 104px;
+    right: 8px;
+  }
+  .mind-side {
+    position: absolute;
+    left: 8px;
+    right: 8px;
+    bottom: 8px;
+    z-index: 12;
+    max-height: 34%;
+    border: 1px solid var(--card-border);
+    border-radius: 8px;
+  }
+  .mind-foot {
+    height: 30px;
+    padding: 0 10px;
+    gap: 8px;
+    overflow: hidden;
+    white-space: nowrap;
+  }
+  .mind-foot span { flex: 0 0 auto; }
+  .mind-foot span:last-child { display: none; }
+}
 </style>
 </head>
 <body>

--- a/backend/public/assets/mockup-notepages.html
+++ b/backend/public/assets/mockup-notepages.html
@@ -45,6 +45,58 @@ body { background:#1a1a2e; color:#e0e0e0; font-family:-apple-system,BlinkMacSyst
 /* Animations */
 .highlight { animation: glow 1.5s ease-in-out; }
 @keyframes glow { 0%,100%{box-shadow:none} 50%{box-shadow:0 0 12px rgba(124,131,255,0.5)} }
+
+@media (max-width: 820px) {
+  body { overflow: hidden; }
+  .container {
+    width: calc(100vw - 24px);
+    height: calc(100vh - 24px);
+    max-height: 500px;
+    margin: 12px auto;
+  }
+  .note-list {
+    width: 34%;
+    height: 100%;
+    padding: 12px;
+  }
+  .page-viewer {
+    width: calc(66% - 10px);
+    height: 100%;
+  }
+  .viewer-toolbar,
+  .url-bar {
+    padding-left: 10px;
+    padding-right: 10px;
+    gap: 8px;
+  }
+  .viewer-title,
+  .url-text { min-width: 0; }
+}
+
+@media (max-width: 520px) {
+  .container { max-height: none; }
+  .note-list {
+    position: absolute;
+    inset: 0 auto auto 0;
+    width: 100%;
+    height: 150px;
+    overflow-y: auto;
+  }
+  .page-viewer {
+    left: 0;
+    right: auto;
+    top: 162px;
+    width: 100%;
+    height: calc(100% - 162px);
+  }
+  .note-item {
+    padding: 8px 10px;
+    margin-bottom: 6px;
+  }
+  .page-content { padding: 14px; }
+  .toggle-btn,
+  .copy-btn { flex: 0 0 auto; }
+}
 </style>
 </head>
 <body>

--- a/backend/public/portal/assets/slides/info-credit-swap.html
+++ b/backend/public/portal/assets/slides/info-credit-swap.html
@@ -421,6 +421,73 @@
             transform: scale(1.02);
             box-shadow: 0 8px 24px rgba(243, 156, 18, 0.4);
         }
+
+        @media (max-width: 768px) {
+            .slide-container {
+                padding: 32px 18px;
+                overflow-x: hidden;
+            }
+
+            .header-section { margin-bottom: 32px; }
+
+            .emoji-icon {
+                font-size: 48px;
+                margin-bottom: 16px;
+            }
+
+            .headline {
+                font-size: 32px;
+                line-height: 1.25;
+            }
+
+            .subline {
+                font-size: 17px;
+                margin-bottom: 20px;
+            }
+
+            .central-illustration {
+                width: 100%;
+                margin-bottom: 36px;
+            }
+
+            .time-bank-fusion {
+                width: min(100%, 340px);
+                height: min(86vw, 340px);
+            }
+
+            .clock-coin-hybrid {
+                width: min(72vw, 260px);
+                height: min(72vw, 260px);
+                border-width: 6px;
+            }
+
+            .clock-face {
+                width: calc(100% - 28px);
+                height: calc(100% - 28px);
+            }
+
+            .portfolio-dashboard {
+                right: 0;
+                bottom: -8px;
+                width: min(150px, 40vw);
+                height: 104px;
+                padding: 12px;
+            }
+
+            .feature-cards {
+                grid-template-columns: 1fr;
+                gap: 16px;
+            }
+
+            .feature-card { padding: 18px; }
+
+            .cta-section { margin-top: 32px; }
+            .cta-button {
+                width: 100%;
+                justify-content: center;
+                padding: 14px 20px;
+            }
+        }
     </style>
 </head>
 <body>

--- a/backend/public/portal/assets/slides/info-passive-income.html
+++ b/backend/public/portal/assets/slides/info-passive-income.html
@@ -18,6 +18,7 @@
             min-height: 100vh;
             position: relative;
             overflow-x: hidden;
+            max-width: 100%;
         }
 
         /* Geometric pattern overlay */
@@ -281,8 +282,16 @@
 
         /* Mobile Responsive */
         @media (max-width: 768px) {
+            html,
+            body {
+                width: 100%;
+                max-width: 100%;
+                overflow-x: hidden;
+            }
+
             .slide-container {
                 padding: 24px;
+                overflow-x: hidden;
             }
 
             .content-layout {
@@ -294,6 +303,9 @@
                 order: -1;
                 height: 280px;
                 margin-bottom: 32px;
+                width: 100%;
+                max-width: 100%;
+                overflow: hidden;
             }
 
             .emoji-icon {
@@ -328,6 +340,19 @@
             .robot-container {
                 margin-right: 0;
                 transform: scale(0.8);
+            }
+
+            .digital-clock {
+                right: 0;
+                max-width: 150px;
+                white-space: nowrap;
+            }
+
+            .sleep-indicator { right: 0; }
+
+            .floating-coins {
+                overflow: hidden;
+                inset: 0;
             }
 
             /* Simplified animations for mobile */

--- a/backend/public/portal/hover-click-demo.html
+++ b/backend/public/portal/hover-click-demo.html
@@ -53,7 +53,7 @@
     <pre class="mutation-log" id="log"></pre>
   </div>
 
-  <script src="../shared/i18n.js" onerror="window.i18n=function(k,fb){return typeof fb==='string'?fb:k}"></script>
+  <script src="../shared/i18n.js" onerror="if(typeof i18n==='undefined')window.i18n=function(k,fb){return typeof fb==='string'?fb:k}"></script>
   <script src="../shared/dom-select.js"></script>
   <script src="../shared/hover-click-toolbar.js"></script>
   <script src="../shared/content-import.js"></script>

--- a/backend/tests/jest/showConfirm-a11y-attrs.test.js
+++ b/backend/tests/jest/showConfirm-a11y-attrs.test.js
@@ -38,7 +38,9 @@ describe('showConfirm — ARIA dialog + focus trap', () => {
         // when it appears.
         expect(apiJs).toMatch(/aria-labelledby="\$\{titleId\}"/);
         expect(apiJs).toMatch(/id="\$\{titleId\}"/);
-        expect(apiJs).toMatch(/eclaw-confirm-title-\$\{\+\+_eclawDialogId\}/);
+        expect(apiJs).toMatch(/const\s+dialogId\s*=\s*\+\+_eclawDialogId/);
+        expect(apiJs).toMatch(/eclaw-confirm-title-\$\{dialogId\}/);
+        expect(apiJs).toMatch(/eclaw-confirm-message-\$\{dialogId\}/);
     });
 
     test('title-less variant falls back to aria-label using message text', () => {


### PR DESCRIPTION
## Summary
- Fixes #3138 by serving direct public HTML aliases for landing, enterprise, privacy policy, and arena index; redirects the bare arena exam template to `/arena`.
- Fixes #3139 by adding mobile responsive constraints for dense mindmap and note-pages mockups plus two info slide pages.
- Follow-up CI fixes: aligned the confirm-dialog ARIA ID invariant with the current `dialogId` helper, and added the required `typeof i18n` guard to the hover-click demo fallback handler.

## QA / Validation
- Production QA sweep before fix: 109 routes x 2 viewports; defects filed as #3138 and #3139.
- `node --check backend/index.js`
- `npm run smoke:portal`
- `npx eslint index.js` (0 errors, 1 existing warning: `pg` unused at `index.js:6240`)
- `npx jest tests/jest/showConfirm-a11y-attrs.test.js tests/jest/showConfirm-danger-default-focus.test.js --runInBand`
- `npx jest tests/jest/i18n-syntax.test.js --runInBand`
- Focused Playwright `file://` mobile overflow regression for 4 fixed HTML pages: all pass at 390x844.
- Static route-alias assertion: all 5 alias definitions present and target files exist.

## Review
Requested for #2 code review per supervisor rule. Do not merge until #2 review passes.
