### PR TITLE
i18n(ja): fix typo in inv_error_already_owner — 受け取ったています → 受け取っています

### DIFF
--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -2411745,7 +2411745,7 @@ const TRANSLATIONS = {
         "interactive_dev_import_url": "URL",
         "interactive_dev_import_url_hint": "否認式ホワイトリスト。v1ではeclawbot.comドメインとexample.comが許可されています。",
         "inv_error_already": "このコードは既に利用されています。",
-        "inv_error_already_owner": "このユーザーの招待を既に受け取ったています。",
+        "inv_error_already_owner": "このユーザーの招待を既に受け取っています。",
         "inv_error_expired": "この招待コードは期限切れです。",
         "inv_error_max": "この招待コードは利用上限に達しました。",
         "inv_error_not_found": "無効な招待コードです。",


### PR DESCRIPTION
## Summary
Single-character typo fix in Japanese translation of `inv_error_already_owner` (landed in main via PR #3154).

## Why
`受け取った` (past tense form of 受け取る) + `ています` (continuous form) is ungrammatical. The te-form is `受け取って`, which combined with `います` gives `受け取っています` (the standard "have already received" perfective-continuous).

## Detection
Self-flagged by #3 (Mac_E) at the end of PR #3154 review note: "supervisor-supplied text used verbatim, flagging it for reviewer."

## Diff
`backend/public/shared/i18n.js` line ~2411748 — 1 line changed.

## CI
i18n syntax check + Jest unit tests + portal smoke should all pass — no structural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)