### PR TITLE
feat(petdx): renderer emoji fallback + bridge descriptor kind — Phase 1 (clean re-scope of #3173)

### DIFF
--- a/backend/petdex-bridge.js
+++ b/backend/petdex-bridge.js
@@ -89,6 +89,7 @@ function buildDescriptor(pet) {
     return {
         id: `petdex-${pet.slug}`,
         name: pet.displayName,
+        kind: pet.kind || 'object',
         assetType: 'spritesheet',
         asset: {
             url: pet.spritesheetUrl,

--- a/backend/public/shared/petdx-renderer.js
+++ b/backend/public/shared/petdx-renderer.js
@@ -222,7 +222,10 @@
             const asset = descriptor.asset || {};
             const sheet = loadSpritesheet(asset.url);
             if (!sheet || sheet.error) {
-                drawSpritesheetMessage(ctx, w, h, state, sheet && sheet.error ? '⚠︎ sheet load failed' : 'no sprite url');
+                // Spec §3.4: per-kind emoji + name-initial badge when sprite load fails or url is missing.
+                // The original "⚠︎ sheet load failed" / "no sprite url" diagnostic is kept in console
+                // via spriteImageCache (see loadSpritesheet) so debuggability is preserved.
+                drawSpritesheetFallback(ctx, w, h, descriptor);
                 return;
             }
             if (!sheet.ready) {
@@ -268,6 +271,41 @@
             ctx.textAlign = 'center';
             ctx.fillText(msg, w / 2, h / 2);
             ctx.fillText(state, w / 2, h / 2 + 14);
+            ctx.restore();
+        }
+
+        function drawSpritesheetFallback(ctx, w, h, descriptor) {
+            // Per-kind emoji + name-initial badge, used when sprite asset is missing
+            // or failed to load. See docs/specs/petdx-uiux-spec-amendment-2026-06-05-self-host-sprite.md §3.4.
+            const kind = descriptor && (descriptor.kind || (descriptor.sourceAttribution && descriptor.sourceAttribution.kind));
+            const emojiByKind = { creature: '🐾', character: '🧑', object: '🎯' };
+            const emoji = emojiByKind[kind] || '🦞';
+            const name = (descriptor && descriptor.name) || '';
+            const initial = name.trim().charAt(0).toUpperCase();
+
+            ctx.save();
+            ctx.fillStyle = '#1a1a1a';
+            ctx.fillRect(0, 0, w, h);
+
+            ctx.font = Math.floor(h * 0.7) + 'px "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif';
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'middle';
+            ctx.fillText(emoji, w / 2, h * 0.55);
+
+            if (initial) {
+                const badgeR = Math.min(w, h) * 0.16;
+                const bx = w - badgeR;
+                const by = badgeR;
+                ctx.beginPath();
+                ctx.arc(bx, by, badgeR, 0, Math.PI * 2);
+                ctx.fillStyle = '#3a3a3a';
+                ctx.fill();
+                ctx.fillStyle = '#fff';
+                ctx.font = 'bold ' + Math.floor(badgeR * 1.2) + 'px sans-serif';
+                ctx.textAlign = 'center';
+                ctx.textBaseline = 'middle';
+                ctx.fillText(initial, bx, by + 1);
+            }
             ctx.restore();
         }
 


### PR DESCRIPTION
## Summary
Clean re-scope of #3173 per #6's review. Original branch had a stale `fix(openclaw-channel): preserve eclaw reply targets` commit mixed in; this branch is reset to `origin/main` with **only** the petdx Phase 1 commit.

Spec & content unchanged from #3173 (which #6 had reviewed and confirmed code-quality OK; jest 10 suites / 111 tests green).

## Diff
- `backend/public/shared/petdx-renderer.js`: new `drawSpritesheetFallback` — per-kind emoji + initial badge when sprite load fails or url missing
- `backend/petdex-bridge.js`: `buildDescriptor` now propagates `pet.kind`

2 files, 40+/1-.

## Spec sections cited
- `docs/specs/petdx-uiux-spec-amendment-2026-06-05-self-host-sprite.md` §3.4
- §5 Phase 1

## Test plan
- [x] node --check on both edited files
- [x] `npx jest --testPathPatterns='petdex|petdx|portal-entity-avatar'` → 10 suites / 111 tests pass (pre-clean)
- [ ] CI re-runs on fresh branch
- [ ] #6 confirms scope clean, admin-merge
- [ ] Post-merge prod E2E re-screenshot card-holder web+mobile (parent bug card)

Closes #3173.
Parent bug: kanban `card_101194c7ce179b76beea2e69`
Impl card: kanban `card_bded216113d0e600f7f4589b`

🤖 Generated with [Claude Code](https://claude.com/claude-code)