### PR TITLE
feat(petdx): Phase 2 — bridge R2 sprite pipeline + public sprite proxy

### DIFF
--- a/backend/companion_schema.sql
+++ b/backend/companion_schema.sql
@@ -201,3 +201,17 @@ ALTER TABLE companion_select_log ADD COLUMN IF NOT EXISTS origin TEXT;
 
 CREATE INDEX IF NOT EXISTS idx_companion_select_origin
     ON companion_select_log (device_id, entity_id, origin);
+
+-- ============================================
+-- Phase 2 amendment (2026-06-05): companions.needs_recovery
+-- ============================================
+-- Per docs/specs/petdx-uiux-spec-amendment-2026-06-05-phase2-r2-pipeline.md §3.4:
+-- petdex-bridge.syncPetdexCatalog now downloads each upstream sprite and
+-- self-hosts it in EClaw R2. Rows whose upstream fetch failed (e.g. the
+-- 2026-06 raillyhugo Worker outage) get needs_recovery=true and keep the
+-- upstream URL so the Phase 1 renderer emoji fallback fires for them. The
+-- Phase 3 monitor cron flips them back when upstream recovers.
+ALTER TABLE companions ADD COLUMN IF NOT EXISTS needs_recovery BOOLEAN NOT NULL DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_companions_needs_recovery
+    ON companions (needs_recovery) WHERE needs_recovery;

--- a/backend/index.js
+++ b/backend/index.js
@@ -2287,6 +2287,15 @@ if (process.env.NODE_ENV !== 'test') {
 const filesModule = require('./files')(devices);
 app.use('/api/files', filesModule.router);
 
+// ============================================
+// PETDX PUBLIC SPRITE PROXY (Cloudflare R2, no auth)
+// ============================================
+// Spec: docs/specs/petdx-uiux-spec-amendment-2026-06-05-phase2-r2-pipeline.md §3.2
+// Streams sprite.webp bytes from R2 directly so descriptor URLs are stable
+// and CDN-cacheable. Slug whitelist + no listing surface per #1 sign-off.
+const petdxRoute = require('./petdex-route');
+app.use('/api/petdx', petdxRoute.createRouter({ log: serverLog }));
+
 // Daily cleanup of expired files (runs at 03:17 server time)
 const nodeCron = require('node-cron');
 nodeCron.schedule('17 3 * * *', () => {

--- a/backend/petdex-bridge.js
+++ b/backend/petdex-bridge.js
@@ -237,10 +237,31 @@ async function upsertPetdexCompanion(pool, pet, { r2, bucket, apiBase, log }) {
     return upload;
 }
 
+// Lazy default-construct an R2 client from env if the caller didn't pass one.
+// Keeps backward-compat with the original (pool, logger) signature and lets
+// existing prod callers in companion-api.js work without any change.
+function defaultR2Client() {
+    try {
+        const { S3Client } = require('@aws-sdk/client-s3');
+        return new S3Client({
+            region: 'auto',
+            endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+            credentials: {
+                accessKeyId: process.env.R2_ACCESS_KEY_ID || '',
+                secretAccessKey: process.env.R2_SECRET_ACCESS_KEY || '',
+            },
+        });
+    } catch (_) {
+        return null;
+    }
+}
+
 async function syncPetdexCatalog(pool, options = {}) {
-    const log = typeof options.serverLog === 'function' ? options.serverLog
-              : (typeof options === 'function' ? options : console.log);
-    const r2 = options.r2 || null;
+    // Old positional shape: syncPetdexCatalog(pool, logger). New shape:
+    // syncPetdexCatalog(pool, { r2, bucket, apiBase, serverLog }).
+    if (typeof options === 'function') options = { serverLog: options };
+    const log = typeof options.serverLog === 'function' ? options.serverLog : console.log;
+    const r2 = options.r2 || defaultR2Client();
     const bucket = options.bucket || process.env.R2_BUCKET_NAME || 'eclaw-files';
     const apiBase = options.apiBase
         || process.env.PUBLIC_BASE_URL

--- a/backend/petdex-bridge.js
+++ b/backend/petdex-bridge.js
@@ -3,8 +3,13 @@
  * companions table as `scope='community'` rows with `asset_type='spritesheet'`.
  *
  * Why: 自有目錄只有 5 隻 (3 物種)；對接 Petdex 1779 隻可一次補滿瀏覽量。Petdex
- * 是 MIT-licensed 公開 gallery (https://github.com/crafter-station/petdex)，
- * 圖檔 hot-link 自其 R2 bucket，本表只存 URL + descriptor，不複製二進位資產。
+ * 是 MIT-licensed 公開 gallery (https://github.com/crafter-station/petdex).
+ *
+ * Phase 2 (PR #3176 spec) — sprite binaries are self-hosted in EClaw R2 at
+ * `petdx-sprites/{slug}/sprite.webp`, served from a public proxy at
+ * `/api/petdx/:slug/sprite.webp`. The upstream raillyhugo Worker is no
+ * longer a runtime dependency — bridge fetches at sync time, caches the
+ * bytes on our R2, and writes the EClaw-owned URL into the descriptor.
  *
  * Sprite convention (from crafter-station/petdex packages/petdex-desktop/src/main.zig):
  *   - Sheet 1536×1872, COLS=8 ROWS=9, every frame 192×208.
@@ -18,6 +23,8 @@
  */
 
 const MANIFEST_URL = 'https://petdex.crafter.run/api/manifest';
+const R2_KEY_PREFIX = 'petdx-sprites';
+const PROXY_PATH_PREFIX = '/api/petdx';
 
 // Animation table — rows + per-frame durations in milliseconds. The idle row
 // uses variable durations per frame (matches petdex desktop); all other rows
@@ -112,26 +119,94 @@ function buildDescriptor(pet) {
     };
 }
 
-async function upsertPetdexCompanion(pool, pet) {
+// Phase 2 (#3176 spec §3.3): fetch sprite bytes from upstream + cache in EClaw R2.
+// Returns { ok, cached, status, bytes } so the caller can distinguish a true
+// upstream not-found from an R2 auth/config failure (per #1 sign-off guardrail).
+async function fetchAndUploadSprite({ r2, bucket, slug, upstreamUrl, log }) {
+    const key = `${R2_KEY_PREFIX}/${slug}/sprite.webp`;
+    if (!r2 || !bucket) {
+        return { ok: false, reason: 'r2_unconfigured', key };
+    }
+
+    // Idempotency: HEAD R2 first. Distinguish true 404 (NotFound / NoSuchKey)
+    // from auth/config failure so we never silently mistake bad creds for a
+    // cache miss + write garbage.
+    try {
+        const { HeadObjectCommand } = require('@aws-sdk/client-s3');
+        await r2.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+        return { ok: true, cached: true, key };
+    } catch (err) {
+        const code = err && (err.name || err.Code);
+        const status = err && err.$metadata && err.$metadata.httpStatusCode;
+        const isNotFound = code === 'NotFound' || code === 'NoSuchKey' || status === 404;
+        if (!isNotFound) {
+            log('error', 'petdex-bridge', `[Petdex] R2 HEAD ${key} failed (not 404): ${code || status || err.message}`);
+            return { ok: false, reason: 'r2_head_failed', key };
+        }
+    }
+
+    let upstream;
+    try {
+        upstream = await fetch(upstreamUrl, {
+            headers: { 'User-Agent': 'EClaw-petdex-bridge/2.0' },
+        });
+    } catch (err) {
+        return { ok: false, reason: 'upstream_fetch_error', key, error: err.message };
+    }
+    if (!upstream.ok) {
+        return { ok: false, reason: 'upstream_not_ok', key, status: upstream.status };
+    }
+    const buf = Buffer.from(await upstream.arrayBuffer());
+
+    try {
+        const { PutObjectCommand } = require('@aws-sdk/client-s3');
+        await r2.send(new PutObjectCommand({
+            Bucket: bucket,
+            Key: key,
+            Body: buf,
+            ContentType: 'image/webp',
+            CacheControl: 'public, max-age=31536000, immutable',
+        }));
+    } catch (err) {
+        log('error', 'petdex-bridge', `[Petdex] R2 PUT ${key} failed: ${err.message}`);
+        return { ok: false, reason: 'r2_put_failed', key };
+    }
+    return { ok: true, cached: false, key, bytes: buf.length };
+}
+
+function spriteProxyUrl(apiBase, slug) {
+    return `${apiBase}${PROXY_PATH_PREFIX}/${slug}/sprite.webp`;
+}
+
+async function upsertPetdexCompanion(pool, pet, { r2, bucket, apiBase, log }) {
     const id = `petdex-${pet.slug}`;
-    const descriptor = buildDescriptor(pet);
     const category = KIND_TO_CATEGORY[pet.kind] || 'mascot';
     const supportedStates = Object.keys(STATE_TO_ANIMATION);
     const tags = ['petdex', pet.kind || 'creature'];
     const now = Date.now();
+
+    // Phase 2: try to self-host the sprite. On success, the descriptor + DB
+    // columns point at the EClaw-owned proxy URL. On any failure, fall back
+    // to the upstream URL so the Phase 1 renderer emoji fallback still fires.
+    const upload = await fetchAndUploadSprite({
+        r2, bucket, slug: pet.slug, upstreamUrl: pet.spritesheetUrl, log,
+    });
+    const url = upload.ok ? spriteProxyUrl(apiBase, pet.slug) : pet.spritesheetUrl;
+    const needsRecovery = !upload.ok;
+    const descriptor = buildDescriptor({ ...pet, spritesheetUrl: url });
 
     await pool.query(
         `INSERT INTO companions (
             id, name, version, author_entity_id, device_id,
             descriptor, asset_type, asset_url, avatar_url, thumbnail_url,
             supported_states, scope, status, license, category,
-            mood, color, tags,
+            mood, color, tags, needs_recovery,
             created_at, updated_at, published_at
         ) VALUES (
             $1, $2, '1.0.0', NULL, NULL,
             $3::jsonb, 'spritesheet', $4, $5, $5,
             $6::jsonb, 'community', 'published', 'MIT', $7,
-            NULL, NULL, $8::jsonb,
+            NULL, NULL, $8::jsonb, $10,
             $9, $9, $9
         )
         ON CONFLICT (id) DO UPDATE SET
@@ -143,26 +218,40 @@ async function upsertPetdexCompanion(pool, pet) {
             supported_states = EXCLUDED.supported_states,
             category = EXCLUDED.category,
             tags = EXCLUDED.tags,
+            needs_recovery = EXCLUDED.needs_recovery,
             updated_at = EXCLUDED.updated_at
         `,
         [
             id,
             pet.displayName || pet.slug,
             JSON.stringify(descriptor),
-            pet.spritesheetUrl,
-            pet.spritesheetUrl,
+            url,
+            url,
             JSON.stringify(supportedStates),
             category,
             JSON.stringify(tags),
             now,
+            needsRecovery,
         ],
     );
+    return upload;
 }
 
-async function syncPetdexCatalog(pool, serverLog = console.log) {
-    const log = typeof serverLog === 'function' ? serverLog : () => {};
+async function syncPetdexCatalog(pool, options = {}) {
+    const log = typeof options.serverLog === 'function' ? options.serverLog
+              : (typeof options === 'function' ? options : console.log);
+    const r2 = options.r2 || null;
+    const bucket = options.bucket || process.env.R2_BUCKET_NAME || 'eclaw-files';
+    const apiBase = options.apiBase
+        || process.env.PUBLIC_BASE_URL
+        || process.env.BASE_URL
+        || process.env.API_BASE
+        || 'https://eclawbot.com';
+
     let inserted = 0;
     let failed = 0;
+    let needsRecovery = 0;
+    let cached = 0;
     let total = 0;
     try {
         const pets = await fetchPetdexManifest();
@@ -174,8 +263,10 @@ async function syncPetdexCatalog(pool, serverLog = console.log) {
                 continue;
             }
             try {
-                await upsertPetdexCompanion(pool, pet);
+                const result = await upsertPetdexCompanion(pool, pet, { r2, bucket, apiBase, log });
                 inserted++;
+                if (result.cached) cached++;
+                if (!result.ok) needsRecovery++;
             } catch (err) {
                 failed++;
                 if (failed <= 3) {
@@ -183,16 +274,19 @@ async function syncPetdexCatalog(pool, serverLog = console.log) {
                 }
             }
         }
-        log('info', 'petdex-bridge', `[Petdex] sync complete — ok=${inserted} failed=${failed} total=${total}`);
+        log('info', 'petdex-bridge', `[Petdex] sync complete — ok=${inserted} cached=${cached} needs_recovery=${needsRecovery} failed=${failed} total=${total}`);
     } catch (err) {
         log('error', 'petdex-bridge', `[Petdex] sync failed: ${err.message}`);
     }
-    return { total, inserted, failed };
+    return { total, inserted, failed, needsRecovery, cached };
 }
 
 module.exports = {
     syncPetdexCatalog,
     fetchPetdexManifest,
+    fetchAndUploadSprite,
+    upsertPetdexCompanion,
+    spriteProxyUrl,
     buildDescriptor,
     PETDEX_ANIMATIONS,
     STATE_TO_ANIMATION,
@@ -202,4 +296,6 @@ module.exports = {
     FRAME_WIDTH,
     FRAME_HEIGHT,
     MANIFEST_URL,
+    R2_KEY_PREFIX,
+    PROXY_PATH_PREFIX,
 };

--- a/backend/petdex-route.js
+++ b/backend/petdex-route.js
@@ -1,0 +1,66 @@
+/**
+ * Petdex public sprite proxy — serves `/api/petdx/:slug/sprite.webp` directly
+ * from R2 without requiring deviceId/botSecret. Petdex sprites are MIT-licensed
+ * public gallery assets; no auth needed.
+ *
+ * Spec: docs/specs/petdx-uiux-spec-amendment-2026-06-05-phase2-r2-pipeline.md §3.2
+ * Phase 2 PR: #3176 (spec)
+ *
+ * #1 sign-off guardrails:
+ *   - Slug whitelist (no directory traversal, no R2 object listing surface).
+ *   - Stream the bytes through the backend; do not 302 to a signed R2 URL.
+ *   - Cache-Control: public, max-age=31536000, immutable — slugs are immutable
+ *     per Petdex convention; rotate the key if upstream ever mutates.
+ */
+
+const express = require('express');
+const { S3Client, GetObjectCommand } = require('@aws-sdk/client-s3');
+
+const SLUG_PATTERN = /^[a-z0-9][a-z0-9-]{0,128}$/;
+
+function createRouter({ r2, bucket, log } = {}) {
+    const router = express.Router();
+    const client = r2 || new S3Client({
+        region: 'auto',
+        endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+        credentials: {
+            accessKeyId: process.env.R2_ACCESS_KEY_ID || '',
+            secretAccessKey: process.env.R2_SECRET_ACCESS_KEY || '',
+        },
+    });
+    const bucketName = bucket || process.env.R2_BUCKET_NAME || 'eclaw-files';
+    const logger = typeof log === 'function' ? log : () => {};
+
+    router.get('/:slug/sprite.webp', async (req, res) => {
+        const { slug } = req.params;
+        if (!slug || !SLUG_PATTERN.test(slug)) {
+            return res.status(404).type('text/plain').send('not found');
+        }
+        const key = `petdx-sprites/${slug}/sprite.webp`;
+        try {
+            const out = await client.send(new GetObjectCommand({ Bucket: bucketName, Key: key }));
+            res.setHeader('Content-Type', 'image/webp');
+            res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+            if (out.ContentLength != null) res.setHeader('Content-Length', String(out.ContentLength));
+            if (out.ETag) res.setHeader('ETag', out.ETag);
+            out.Body.pipe(res);
+            out.Body.on('error', (err) => {
+                logger('warn', 'petdex-route', `[petdx] stream ${slug} failed: ${err.message}`);
+                if (!res.headersSent) res.status(502).end();
+                else res.end();
+            });
+        } catch (err) {
+            const code = err && (err.name || err.Code);
+            const status = err && err.$metadata && err.$metadata.httpStatusCode;
+            if (code === 'NoSuchKey' || code === 'NotFound' || status === 404) {
+                return res.status(404).type('text/plain').send('not found');
+            }
+            logger('error', 'petdex-route', `[petdx] R2 GET ${slug} failed: ${code || status || err.message}`);
+            return res.status(502).type('text/plain').send('upstream error');
+        }
+    });
+
+    return router;
+}
+
+module.exports = { createRouter, SLUG_PATTERN };


### PR DESCRIPTION
## Summary
Implements the petdx Phase 2 spec merged in #3176. The bridge now self-hosts every upstream sprite in EClaw R2 and the renderer reads them from a new public proxy route — the upstream `raillyhugo.workers.dev` Worker is no longer a runtime dependency. Live end-to-end proof with `boba` already posted in fakechat `m1780626406096-120` before the spec landed.

## Files
- `backend/petdex-bridge.js` — `fetchAndUploadSprite` + `spriteProxyUrl` helpers; `syncPetdexCatalog` rewritten to download → R2 → swap descriptor URL; distinguishes true upstream NotFound from R2 auth/config errors so bad creds never get treated as a cache miss (per #1 sign-off).
- `backend/petdex-route.js` (new) — `GET /api/petdx/:slug/sprite.webp` streams from R2, slug whitelist `[a-z0-9][a-z0-9-]*`, no listing surface, no signed-URL exposure.
- `backend/index.js` — mounts the new router at `/api/petdx`.
- `backend/companion_schema.sql` — `needs_recovery` BOOLEAN column + partial index.

## #1 sign-off guardrails (all included)
1. R2 layout `petdx-sprites/{slug}/sprite.webp` + HEAD idempotency.
2. Zero-auth proxy with slug whitelist; no directory/listing; never expose signed R2 URL.
3. `PUBLIC_BASE_URL || BASE_URL || API_BASE || 'https://eclawbot.com'` fallback chain (no `undefined/api/petdx/...`).
4. `Cache-Control: public, max-age=31536000, immutable`.

## Test plan
- [x] `node --check` on all 4 edited files
- [x] `npx jest --testPathPatterns='petdex|petdx|portal-entity-avatar'` → 10 suites / 111 tests pass
- [ ] CI runs on fresh branch
- [ ] After merge: smoke `GET https://eclawbot.com/api/petdx/boba/sprite.webp` returns 200 + image/webp + immutable cache header
- [ ] Trigger a bridge sync, verify a few companions rows now point at `/api/petdx/...` and the 6 EClaw entities still flag `needs_recovery=true` (upstream still 403)

## Parent / siblings
Parent bug: kanban `card_101194c7ce179b76beea2e69`
Phase 1 PR: #3175 (merged)
Phase 2 spec PR: #3176 (merged)
Phase 3 (upstream monitor cron) + Phase C (settings picker) come later, separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)