### PR TITLE
revert(daily): roll back Day 151 embed — YouTube _H-ZoIgE3NY unavailable

### DIFF
--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -104,26 +104,26 @@
                 <a class="qs-promo-link" href="/promo.html" target="_blank" rel="noopener" data-i18n="qs_promo_full_page_link">📺 開啟完整影片頁</a>
             </section>
 
-            <!-- Daily highlight: Day 151 — Petdx 自有化, 少一個外部 SPOF (6/05) -->
-            <section class="qs-promo-section qs-daily-highlight" aria-labelledby="qs-day151-heading"
+            <!-- Daily highlight: Day 144 — 三條 P0 同日 ship (5/29) -->
+            <section class="qs-promo-section qs-daily-highlight" aria-labelledby="qs-day144-heading"
                 style="margin-top: 12px; padding-top: 8px; border-top: 1px dashed rgba(124,58,237,0.25);">
-                <h2 id="qs-day151-heading" class="qs-promo-title" style="font-size: 1.05em; color: #42d4f4;">
-                    🦞 Day 151 — Petdx 自有化, 少一個外部 SPOF
+                <h2 id="qs-day144-heading" class="qs-promo-title" style="font-size: 1.05em; color: #42d4f4;">
+                    🚢 Day 144 — 三條 P0 同日 ship
                 </h2>
                 <p class="qs-promo-lede" style="font-size: 0.92em; opacity: 0.85;">
-                    6/05 出貨：六實體大頭照從外部 CDN 403 → R2 self-host 全恢復。Phase 2 R2 pipeline (#3175) · Phase 2.5 orphan recovery (#3179) · Phase C settings 入口 (#3180)。66s · 9:16 · 真實 EClaw UI。
+                    5/29 出貨：FWD noise filter (#3014) · URL fetch SSRF guard (#3013) · 桌布倒數修復 (#3012)。60s · 9:16 · 無聲。
                 </p>
                 <div class="qs-promo-frame" style="max-width: 360px; aspect-ratio: 9 / 16;">
-                    <iframe
-                        src="https://www.youtube.com/embed/_H-ZoIgE3NY"
-                        title="Day 151 — Petdx 自有化, 少一個外部 SPOF"
-                        loading="lazy"
-                        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-                        referrerpolicy="strict-origin-when-cross-origin"
-                        allowfullscreen
-                        style="width:100%; height:100%; border:0; border-radius: 12px; background: #000;"></iframe>
+                    <video
+                        src="assets/day144_3p0_ship.mp4"
+                        poster="assets/day144_3p0_ship_poster.jpg"
+                        controls
+                        playsinline
+                        preload="metadata"
+                        style="width:100%; height:100%; object-fit:cover; border-radius: 12px; background: #000;">
+                        Your browser does not support HTML5 video.
+                    </video>
                 </div>
-                <a class="qs-promo-link" href="https://youtube.com/shorts/_H-ZoIgE3NY" target="_blank" rel="noopener" style="font-size: 0.85em;">📺 在 YouTube Shorts 開啟</a>
             </section>
 
             <!-- Hero: 你想做什麼？ -->


### PR DESCRIPTION
## Why

Per #6 (yrt82n) at 14:34 TW: prod `info.html` shows 「無法播放影片」 and `yt-dlp` confirms the video is unavailable. PR #3184 wired `_H-ZoIgE3NY` as the daily-highlight embed but the URL doesn't actually play.

## What

Reverts the rotating slot back to Day 144 / 5/29 (local `assets/day144_3p0_ship.mp4` — known good). Evergreen 75s embed untouched.

## Follow-up

- #6 to confirm YouTube Studio visibility on `_H-ZoIgE3NY` OR re-upload a working video
- Once working ID lands → re-roll the embed PR
- Daily kanban card stays in_progress until working embed lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)
