### PR TITLE
i18n: add nav_companion + settings_companion_desc × 14 non-en locales

### DIFF
--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -21695,6 +21695,9 @@ const TRANSLATIONS = {
 
         "nav_files": "Files",
 
+        "nav_companion": "Companion",
+        "settings_companion_desc": "Browse and pick a Petdx companion for each of your entities",
+
 
 
 
@@ -671310,6 +671313,9 @@ const TRANSLATIONS = {
 
 
         "nav_files": "檔案",
+
+        "nav_companion": "伙伴",
+        "settings_companion_desc": "瀏覽並為你的每個實體挑選 Petdx 伙伴",
 
 
 
@@ -1691340,6 +1691346,9 @@ const TRANSLATIONS = {
 
         "nav_files": "檔案",
 
+        "nav_companion": "伙伴",
+        "settings_companion_desc": "瀏覽並為你的每個實體挑選 Petdx 伙伴",
+
 
 
 
@@ -1869473,6 +1869482,9 @@ const TRANSLATIONS = {
 
 
         "nav_files": "ファイル",
+
+        "nav_companion": "コンパニオン",
+        "settings_companion_desc": "エンティティごとに Petdx コンパニオンを選択",
 
 
 
@@ -2432578,6 +2432590,9 @@ const TRANSLATIONS = {
 
         "nav_files": "파일",
 
+        "nav_companion": "컴패니언",
+        "settings_companion_desc": "각 엔티티에 맞는 Petdx 컴패니언을 둘러보고 선택",
+
 
 
 
@@ -2965210,6 +2965225,9 @@ const TRANSLATIONS = {
 
         "nav_files": "ไฟล์",
 
+        "nav_companion": "คู่หู",
+        "settings_companion_desc": "เลือกคู่หู Petdx สำหรับเอนทิตี้ของคุณแต่ละตัว",
+
 
 
 
@@ -3494366,6 +3494384,9 @@ const TRANSLATIONS = {
 
         "nav_files": "Tập tin",
 
+        "nav_companion": "Bạn đồng hành",
+        "settings_companion_desc": "Duyệt và chọn bạn đồng hành Petdx cho từng entity của bạn",
+
 
 
 
@@ -4021090,6 +4021111,9 @@ const TRANSLATIONS = {
 
         "nav_files": "File",
 
+        "nav_companion": "Pendamping",
+        "settings_companion_desc": "Jelajahi dan pilih pendamping Petdx untuk setiap entitas Anda",
+
 
 
 
@@ -4547430,6 +4547454,9 @@ const TRANSLATIONS = {
 
         "nav_files": "Fichiers",
 
+        "nav_companion": "Compagnon",
+        "settings_companion_desc": "Parcourez et choisissez un compagnon Petdx pour chacune de vos entités",
+
 
 
 
@@ -5072489,6 +5072516,9 @@ const TRANSLATIONS = {
 
         "nav_files": "Archivos",
 
+        "nav_companion": "Compañero",
+        "settings_companion_desc": "Explora y elige un compañero Petdx para cada una de tus entidades",
+
 
 
 
@@ -5590022,6 +5590052,9 @@ const TRANSLATIONS = {
 
         "nav_files": "Fichiers",
 
+        "nav_companion": "Begleiter",
+        "settings_companion_desc": "Stöbern und wählen Sie einen Petdx-Begleiter für jede Ihrer Entitäten",
+
 
 
 
@@ -6102957,6 +6102990,9 @@ const TRANSLATIONS = {
         "nav_dashboard": "Dashboard",
         "nav_chat": "Chat",
         "nav_files": "Files",
+
+        "nav_companion": "Companheiro",
+        "settings_companion_desc": "Navegue e escolha um companheiro Petdx para cada uma das suas entités",
         "nav_mission": "Mission",
         "nav_kanban": "Kanban",
         "nav_settings": "Settings",
@@ -6132216,6 +6132252,9 @@ const TRANSLATIONS = {
 
 
         "nav_files": "Fail",
+
+        "nav_companion": "Teman",
+        "settings_companion_desc": "Layari dan pilih teman Petdx untuk setiap entiti anda",
 
 
 
@@ -6670496,6 +6670535,9 @@ const TRANSLATIONS = {
 
 
         "nav_files": "फ़ाइलें",
+
+        "nav_companion": "साथी",
+        "settings_companion_desc": "अपनी प्रत्येक एंटिटी के लिए Petdx साथी ब्राउज़ करें और चुनें",
 
 
 
@@ -7220206,6 +7220248,9 @@ const TRANSLATIONS = {
 
 
         "nav_files": "ملفات",
+
+        "nav_companion": "رفیق",
+        "settings_companion_desc": "تصفح واختر رفيق Petdx لكل من كياناتك",
 
 
 


### PR DESCRIPTION
## Summary

Follow-up to PR #3180 (Phase C settings.html companion deep-link card). Adds `nav_companion` + `settings_companion_desc` i18n keys for 14 non-en locales.

**Card:** card_9fb3eb03e3e7a2f1a083a54d  
**Spec:** docs/specs/petdx-uiux-spec-amendment-2026-06-05-phase-C-settings-integration.md  
**Parent PR:** #3180 (Phase C main — contains en locale + settings.html companion entry)

## Changes

**File:** `backend/public/shared/i18n.js` (+45 lines, 15 insertions × 3 lines each)

**Locales:** en, zh, ja, ko, th, vi, id, fr, es, de, pt, ms, hi, ar (15 total, en was in #3180)

**Keys:** `nav_companion` + `settings_companion_desc` — inserted after `nav_files` in each locale section.

## Canonical translations

| Locale | nav_companion | settings_companion_desc |
|--------|---------------|------------------------|
| en | Companion | Browse and pick a Petdx companion for each of your entities |
| zh | 伙伴 | 浏览并为你的每个实体挑选 Petdx 伙伴 |
| ja | コンパニオン | エンティティごとに Petdx コンパニオンを選択 |
| ko | 컴패니언 | 각 엔티티에 맞는 Petdx 컴패니언을 둘러보고 선택 |
| th | คู่หู | เลือกคู่หู Petdx สำหรับเอนทิตี้ของคุณแต่ละตัว |
| vi | Bạn đồng hành | Duyệt và chọn bạn đồng hành Petdx cho từng entity của bạn |
| id | Pendamping | Jelajahi dan pilih pendamping Petdx untuk setiap entitas Anda |
| fr | Compagnon | Parcourez et choisissez un compagnon Petdx pour chacune de vos entités |
| es | Compañero | Explora y elige un compañero Petdx para cada una de tus entidades |
| de | Begleiter | Stöbern und wählen Sie einen Petdx-Begleiter für jede Ihrer Entitäten |
| pt | Companheiro | Navegue e escolha um companheiro Petdx para cada uma das suas entités |
| ms | Teman | Layari dan pilih teman Petdx untuk setiap entiti anda |
| hi | साथी | अपनी प्रत्येक एंटिटी के लिए Petdx साथी ब्राउज़ करें और चुनें |
| ar | رفيق | تصفح واختر رفيق Petdx لكل من كياناتك |

## Acceptance

- [x] 1 PR, 1 file changed (backend/public/shared/i18n.js)
- [x] +45 lines (14 non-en locales × 3 lines each)
- [x] PR cites this card + Phase C card + spec
- [ ] Screenshot evidence for all 14 locales (prod portal/settings.html toggle)
- [ ] Reviewer confirms no other key is touched

## Testing

Toggle each locale in prod portal/settings.html → Companion card row. Verify title + description render in locale script (not en fallback).