### PR TITLE
i18n: add nav_companion + settings_companion_desc × 14 non-en locales

### DIFF
--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -671313,6 +671313,9 @@ const TRANSLATIONS = {
 
         "nav_files": "檔案",
 
+        "nav_companion": "伙伴",
+        "settings_companion_desc": "瀏覽並為你的每個實體挑選 Petdx 伙伴",
+
 
 
 
@@ -1691342,6 +1691345,9 @@ const TRANSLATIONS = {
 
         "nav_files": "檔案",
 
+        "nav_companion": "伙伴",
+        "settings_companion_desc": "瀏覽並為你的每個實體挑選 Petdx 伙伴",
+
 
 
 
@@ -1869475,6 +1869481,9 @@ const TRANSLATIONS = {
 
 
         "nav_files": "ファイル",
+
+        "nav_companion": "コンパニオン",
+        "settings_companion_desc": "エンティティごとに Petdx コンパニオンを選択",
 
 
 
@@ -2432580,6 +2432589,9 @@ const TRANSLATIONS = {
 
         "nav_files": "파일",
 
+        "nav_companion": "컴패니언",
+        "settings_companion_desc": "각 엔티티에 맞는 Petdx 컴패니언을 둘러보고 선택",
+
 
 
 
@@ -2965212,6 +2965224,9 @@ const TRANSLATIONS = {
 
         "nav_files": "ไฟล์",
 
+        "nav_companion": "คู่หู",
+        "settings_companion_desc": "เลือกคู่หู Petdx สำหรับเอนทิตี้ของคุณแต่ละตัว",
+
 
 
 
@@ -3494368,6 +3494383,9 @@ const TRANSLATIONS = {
 
         "nav_files": "Tập tin",
 
+        "nav_companion": "Bạn đồng hành",
+        "settings_companion_desc": "Duyệt và chọn bạn đồng hành Petdx cho từng entity của bạn",
+
 
 
 
@@ -4021092,6 +4021110,9 @@ const TRANSLATIONS = {
 
         "nav_files": "File",
 
+        "nav_companion": "Pendamping",
+        "settings_companion_desc": "Jelajahi dan pilih pendamping Petdx untuk setiap entitas Anda",
+
 
 
 
@@ -4547432,6 +4547453,9 @@ const TRANSLATIONS = {
 
         "nav_files": "Fichiers",
 
+        "nav_companion": "Compagnon",
+        "settings_companion_desc": "Parcourez et choisissez un compagnon Petdx pour chacune de vos entités",
+
 
 
 
@@ -5072491,6 +5072515,9 @@ const TRANSLATIONS = {
 
         "nav_files": "Archivos",
 
+        "nav_companion": "Compañero",
+        "settings_companion_desc": "Explora y elige un compañero Petdx para cada una de tus entidades",
+
 
 
 
@@ -5590024,6 +5590051,9 @@ const TRANSLATIONS = {
 
         "nav_files": "Fichiers",
 
+        "nav_companion": "Begleiter",
+        "settings_companion_desc": "Stöbern und wählen Sie einen Petdx-Begleiter für jede Ihrer Entitäten",
+
 
 
 
@@ -6102959,6 +6102989,9 @@ const TRANSLATIONS = {
         "nav_dashboard": "Dashboard",
         "nav_chat": "Chat",
         "nav_files": "Files",
+
+        "nav_companion": "Companheiro",
+        "settings_companion_desc": "Navegue e escolha um companheiro Petdx para cada uma das suas entités",
         "nav_mission": "Mission",
         "nav_kanban": "Kanban",
         "nav_settings": "Settings",
@@ -6132218,6 +6132251,9 @@ const TRANSLATIONS = {
 
 
         "nav_files": "Fail",
+
+        "nav_companion": "Teman",
+        "settings_companion_desc": "Layari dan pilih teman Petdx untuk setiap entiti anda",
 
 
 
@@ -6670498,6 +6670534,9 @@ const TRANSLATIONS = {
 
 
         "nav_files": "फ़ाइलें",
+
+        "nav_companion": "साथी",
+        "settings_companion_desc": "अपनी प्रत्येक एंटिटी के लिए Petdx साथी ब्राउज़ करें और चुनें",
 
 
 
@@ -7220208,6 +7220247,9 @@ const TRANSLATIONS = {
 
 
         "nav_files": "ملفات",
+
+        "nav_companion": "رفیق",
+        "settings_companion_desc": "تصفح واختر رفيق Petdx لكل من كياناتك",
 
 
 


### PR DESCRIPTION
Follow-up to PR #3180. Adds nav_companion + settings_companion_desc for 14 non-en locales.