### PR TITLE
feat(petdx): Phase 3 — upstream recovery monitor cron (every 30min)

### DIFF
--- a/backend/companion-api.js
+++ b/backend/companion-api.js
@@ -1266,91 +1266,98 @@ module.exports = function companionFactory({ authenticateBot, authenticateDevice
         R2_KEY_PREFIX,
         PROXY_PATH_PREFIX,
     } = require('./petdex-bridge');
-    router.post('/petdex-recover', authReader, async (req, res) => {
-        if (req.botAuth.authMode !== 'device') {
-            return res.status(403).json({ success: false, error: 'deviceSecret_required' });
-        }
-        const limit = Math.max(1, Math.min(parseInt(req.body && req.body.limit, 10) || 50, 500));
-        const apiBase = process.env.PUBLIC_BASE_URL
+
+    // Shared core — called by the manual POST route below and by the
+    // recurring monitor cron wired in index.js (Phase 3 / card_05aa3f9226b3).
+    // Returns { scanned, promoted, stillBroken, errors } on success or
+    // throws on infra failure (R2 init, pool query). Pool errors bubble up;
+    // per-slug fetch failures are aggregated into errors[] and counted as
+    // stillBroken without aborting the loop.
+    async function runPetdexRecovery({ limit = 50, apiBase } = {}) {
+        const safeLimit = Math.max(1, Math.min(parseInt(limit, 10) || 50, 500));
+        const base = apiBase
+            || process.env.PUBLIC_BASE_URL
             || process.env.BASE_URL
             || process.env.API_BASE
             || 'https://eclawbot.com';
 
-        let r2;
-        try {
-            const { S3Client } = require('@aws-sdk/client-s3');
-            r2 = new S3Client({
-                region: 'auto',
-                endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
-                credentials: {
-                    accessKeyId: process.env.R2_ACCESS_KEY_ID || '',
-                    secretAccessKey: process.env.R2_SECRET_ACCESS_KEY || '',
-                },
-            });
-        } catch (err) {
-            return res.status(500).json({ success: false, error: 'r2_init_failed' });
-        }
+        const { S3Client } = require('@aws-sdk/client-s3');
+        const r2 = new S3Client({
+            region: 'auto',
+            endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+            credentials: {
+                accessKeyId: process.env.R2_ACCESS_KEY_ID || '',
+                secretAccessKey: process.env.R2_SECRET_ACCESS_KEY || '',
+            },
+        });
         const bucket = process.env.R2_BUCKET_NAME || 'eclaw-files';
 
-        try {
-            // Targets: rows that still point upstream (not yet on the proxy)
-            // OR were flagged needs_recovery by an earlier sync attempt.
-            const rows = (await pool.query(
-                `SELECT id, asset_url, descriptor
-                   FROM companions
-                  WHERE asset_type = 'spritesheet'
-                    AND (needs_recovery = TRUE OR asset_url NOT LIKE $1)
-                    AND id LIKE 'petdex-%'
-                  ORDER BY updated_at DESC
-                  LIMIT $2`,
-                [`%${PROXY_PATH_PREFIX}/%`, limit],
-            )).rows;
+        const rows = (await pool.query(
+            `SELECT id, asset_url, descriptor
+               FROM companions
+              WHERE asset_type = 'spritesheet'
+                AND (needs_recovery = TRUE OR asset_url NOT LIKE $1)
+                AND id LIKE 'petdex-%'
+              ORDER BY updated_at DESC
+              LIMIT $2`,
+            [`%${PROXY_PATH_PREFIX}/%`, safeLimit],
+        )).rows;
 
-            let promoted = 0;
-            let stillBroken = 0;
-            const errors = [];
+        let promoted = 0;
+        let stillBroken = 0;
+        const errors = [];
 
-            for (const row of rows) {
-                const slug = row.id.replace(/^petdex-/, '');
-                const upstreamUrl = row.asset_url;
-                if (!slug || !upstreamUrl) {
-                    stillBroken++;
-                    continue;
-                }
-                const upload = await fetchAndUploadSprite({
-                    r2, bucket, slug, upstreamUrl, log,
-                });
-                if (!upload.ok) {
-                    stillBroken++;
-                    if (errors.length < 5) errors.push({ slug, reason: upload.reason });
-                    continue;
-                }
-                const newUrl = spriteProxyUrl(apiBase, slug);
-                // Rewrite the descriptor.asset.url to match — the renderer
-                // reads from the descriptor, not the companions columns.
-                let descriptor = row.descriptor;
-                if (typeof descriptor === 'string') {
-                    try { descriptor = JSON.parse(descriptor); } catch (_) { descriptor = null; }
-                }
-                if (descriptor && descriptor.asset) descriptor.asset.url = newUrl;
-                await pool.query(
-                    `UPDATE companions
-                        SET asset_url = $1,
-                            avatar_url = $1,
-                            thumbnail_url = $1,
-                            descriptor = COALESCE($2::jsonb, descriptor),
-                            needs_recovery = FALSE,
-                            updated_at = $3
-                      WHERE id = $4`,
-                    [newUrl, descriptor ? JSON.stringify(descriptor) : null, Date.now(), row.id],
-                );
-                promoted++;
+        for (const row of rows) {
+            const slug = row.id.replace(/^petdex-/, '');
+            const upstreamUrl = row.asset_url;
+            if (!slug || !upstreamUrl) {
+                stillBroken++;
+                continue;
             }
+            const upload = await fetchAndUploadSprite({
+                r2, bucket, slug, upstreamUrl, log,
+            });
+            if (!upload.ok) {
+                stillBroken++;
+                if (errors.length < 5) errors.push({ slug, reason: upload.reason });
+                continue;
+            }
+            const newUrl = spriteProxyUrl(base, slug);
+            let descriptor = row.descriptor;
+            if (typeof descriptor === 'string') {
+                try { descriptor = JSON.parse(descriptor); } catch (_) { descriptor = null; }
+            }
+            if (descriptor && descriptor.asset) descriptor.asset.url = newUrl;
+            await pool.query(
+                `UPDATE companions
+                    SET asset_url = $1,
+                        avatar_url = $1,
+                        thumbnail_url = $1,
+                        descriptor = COALESCE($2::jsonb, descriptor),
+                        needs_recovery = FALSE,
+                        updated_at = $3
+                  WHERE id = $4`,
+                [newUrl, descriptor ? JSON.stringify(descriptor) : null, Date.now(), row.id],
+            );
+            promoted++;
+        }
 
-            res.json({ success: true, scanned: rows.length, promoted, stillBroken, errors });
+        return { scanned: rows.length, promoted, stillBroken, errors };
+    }
+    router._runPetdexRecovery = runPetdexRecovery;
+
+    router.post('/petdex-recover', authReader, async (req, res) => {
+        if (req.botAuth.authMode !== 'device') {
+            return res.status(403).json({ success: false, error: 'deviceSecret_required' });
+        }
+        const limit = (req.body && req.body.limit) || 50;
+        try {
+            const result = await runPetdexRecovery({ limit });
+            res.json({ success: true, ...result });
         } catch (err) {
             log('error', 'companion', `[Companion] petdex-recover failed: ${err.message}`);
-            res.status(500).json({ success: false, error: 'recover_failed', detail: err.message });
+            const code = /r2|S3|credentials/i.test(err.message) ? 'r2_init_failed' : 'recover_failed';
+            res.status(500).json({ success: false, error: code, detail: err.message });
         }
     });
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -3773,6 +3773,35 @@ nodeCron.schedule('23 4 * * *', async () => {
     }
 });
 
+// Petdx upstream-recovery monitor — spec §4 (Phase 3) / card_05aa3f9226b3.
+// Sweeps companions WHERE needs_recovery=TRUE every 30 minutes. For each
+// orphan slug whose upstream raillyhugo asset is back online, the run
+// fetchAndUploadSprite-mirrors it into R2 and clears the flag. Idempotent
+// (fetchAndUploadSprite HEAD-checks R2 before downloading), so re-running
+// against an already-mirrored row is a no-op. Acceptance is a 24h prod
+// observation of railway logs showing `[PetdexRecoverCron]` rows with
+// non-zero `promoted` counts as upstream slugs come back.
+const petdexRouter = companionModule.router || companionModule;
+nodeCron.schedule('*/30 * * * *', async () => {
+    if (typeof petdexRouter._runPetdexRecovery !== 'function') {
+        serverLog('warn', 'companion', '[PetdexRecoverCron] helper not exported — skipping');
+        return;
+    }
+    try {
+        const result = await petdexRouter._runPetdexRecovery({ limit: 50 });
+        if (result.promoted > 0 || result.stillBroken > 0) {
+            serverLog(
+                'info',
+                'companion',
+                `[PetdexRecoverCron] scanned=${result.scanned} promoted=${result.promoted} stillBroken=${result.stillBroken}`
+                + (result.errors && result.errors.length ? ` firstErr=${JSON.stringify(result.errors[0])}` : ''),
+            );
+        }
+    } catch (err) {
+        serverLog('error', 'companion', `[PetdexRecoverCron] failed: ${err.message}`);
+    }
+});
+
 // ============================================
 // GATEKEEPER - Free Bot Abuse Prevention
 // ============================================


### PR DESCRIPTION
## Summary
- Adds a `*/30 * * * *` `nodeCron.schedule` block in `backend/index.js` that sweeps `companions` rows with `needs_recovery=TRUE` and re-mirrors the upstream raillyhugo sprite into R2 when it comes back online.
- Extracts the existing `/api/companion/petdex-recover` logic into a reusable `runPetdexRecovery({ limit, apiBase })` helper in `backend/companion-api.js`, attached to the router as `_runPetdexRecovery`. The HTTP route is now a thin wrapper that calls the same helper — manual trigger path and scheduled path share one code path.
- Idempotent: `fetchAndUploadSprite` HEAD-checks R2 before downloading, so re-running against an already-mirrored row is a no-op.

## Spec citation
`docs/spec/petdx-uiux-spec-amendment-2026-06-05-phase2-r2-pipeline.md` §4 (Phase 3).

## Card
`card_05aa3f9226b3` ([Petdx Phase 3] Upstream raillyhugo monitor cron). Acceptance: 24h prod observation showing `[PetdexRecoverCron]` log rows with non-zero `promoted` counts as upstream slugs come back, plus card-holder.html auto-pickup on still-broken slugs (zhenyan-king et al.).

## Test plan
- [x] Both files pass `node -c` syntax check
- [x] No behavior change for `POST /api/companion/petdex-recover` (same call path, same response shape, error code mapped to `r2_init_failed` or `recover_failed` based on err text)
- [ ] **Local seed test (deferred to next session due to DB-fixture overhead)**: insert `companions` row with `needs_recovery=true`, deliberately-404 upstream slug → cron tick → row stays `needs_recovery=true`, no `promoted` increment
- [ ] **Local mock-recovery test**: same row, mock upstream restore → cron tick → row flips to `needs_recovery=false`, `promoted=1` in log
- [ ] **Prod 24h observation** (acceptance criterion): Railway logs show `[PetdexRecoverCron] scanned=N promoted=M stillBroken=K` rows over 24h with at least one non-zero `promoted` event as still-broken slugs (zhenyan-king et al.) come back upstream
- [ ] **SCREENSHOT_REQUIRED gate**: prod Railway log screenshot showing cron firing successfully, attached to card after first 24h observation window

## Migration / rollback
- No DB schema change. The `needs_recovery` column already exists (line 212 of `petdex-bridge.js`).
- Rollback is removing the `nodeCron.schedule(...)` block from `index.js` + reverting the helper extraction in `companion-api.js`. The HTTP route would resume its inline-logic form.

## Out of scope (queued for Phase 4)
- Pre-filter HEAD probe of upstream URLs to skip slugs that are still 4xx without doing a full body fetch (saves bandwidth on the long tail). Today `fetchAndUploadSprite` does the upstream GET and returns `ok:false` on 4xx, so the existing code is doing the equivalent — just slightly more bandwidth. Will revisit when long-tail orphan count exceeds the 50-row `limit` per tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)