### PR TITLE
fix(portal): gate showConfirm backdrop dismiss on !danger + dialog box-shadow

### DIFF
--- a/.agent/playbooks/destructive-modals-e2e.md
+++ b/.agent/playbooks/destructive-modals-e2e.md
@@ -59,13 +59,15 @@ For each combo:
    () => {
      return showConfirm({
        title: 'E2E: destructive modal viewport check',
-       message: i18n?.t?.('confirm_delete') || 'Are you sure you want to delete this?',
+       message: 'Are you sure you want to delete this?',
        danger: true
      }).then(() => {
        // resolved with false from auto-dismiss below; ignore
      });
    }
    ```
+
+   The earlier version of this snippet read `i18n?.t?.('confirm_delete') || '...fallback...'`. Don't restore that: the generic key `confirm_delete` is not registered in `TRANSLATIONS[*]`, so `i18n.t()` returns the literal string `'confirm_delete'` — a truthy value — and the `||` fallback never fires. Real consumers use namespaced keys (`mc_confirm_delete`, `env_confirm_delete`, `sched_confirm_delete`) which DO resolve. For the E2E probe a hard-coded English literal is the right choice; what matters is exercising the modal at the production viewport, not the message content. Spec source: child of card_06a75d056fd5a98c3b4e95d0.
 
    `showConfirm` is a global in `api.js` (sibling to `apiCall`). It returns a Promise that resolves when Cancel/OK is clicked or Esc pressed.
 

--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -113,7 +113,14 @@ function showConfirm({ message, title, confirmText, cancelText, danger } = {}) {
         overlay.querySelector(safeBtnSel).focus();
         overlay.querySelector('.eclaw-confirm-ok').addEventListener('click', () => cleanup(true));
         overlay.querySelector('.eclaw-confirm-cancel').addEventListener('click', () => cleanup(false));
-        overlay.addEventListener('click', (e) => { if (e.target === overlay) cleanup(false); });
+        // Backdrop-tap dismiss: only allowed when NOT destructive. iOS HIG forbids
+        // scrim-dismiss on .alert-style modals because the backdrop is ~80% of a
+        // mobile viewport and accidental thumb-stretch taps shouldn't cancel a
+        // confirmation the user is actively reading. Esc + the explicit Cancel
+        // button still dismiss either way.
+        if (!danger) {
+            overlay.addEventListener('click', (e) => { if (e.target === overlay) cleanup(false); });
+        }
         overlay.addEventListener('keydown', (e) => {
             if (e.key === 'Escape') cleanup(false);
             // For destructive confirms Enter dismisses (= cancel) so an

--- a/backend/public/portal/shared/style.css
+++ b/backend/public/portal/shared/style.css
@@ -941,6 +941,7 @@ a:hover { text-decoration: underline; }
     display: flex;
     flex-direction: column;
     box-sizing: border-box;
+    box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
 }
 
 .dialog-title {


### PR DESCRIPTION
## Summary
Three small changes from the destructive-modals daily E2E Phase 2 findings, addressing UX/HIG, visual hierarchy, and a doc-drift bug.

- **api.js** — wrap the overlay-click→`cleanup(false)` binding in `if (!danger)`. iOS HIG forbids scrim-dismiss on `.alert`-style modals; with `danger:true` the backdrop is ~80% of a mobile viewport and an accidental thumb-stretch tap shouldn't cancel a destructive confirmation. Esc + the explicit Cancel button still dismiss either way. Non-destructive confirms keep the current backdrop-dismiss behavior — zero change.
- **style.css** — add `box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5)` to `.dialog` (which covers `.eclaw-confirm-dialog`). Against the rgba(0,0,0,0.6) scrim on the dark-theme base the dialog was flat with only border-radius for separation; Material Design recommends elevation 24dp for modal dialogs.
- **playbook** — fix the Step 5 example. It used `i18n?.t?.('confirm_delete') || 'fallback'` but the generic `confirm_delete` key is not registered in `TRANSLATIONS[*]` — `i18n.t()` returns the literal string `'confirm_delete'` (truthy), so the `||` fallback never fires. Real consumers use namespaced keys (`mc_confirm_delete`, `env_confirm_delete`, `sched_confirm_delete`).

## Card
`card_fb146983fdf811859d242990` (child of `card_06a75d056fd5a98c3b4e95d0`, destructive-modals daily E2E run on 2026-06-05).

## Acceptance (from the card)
- [x] `showConfirm({danger:true})` overlay click does NOT dismiss (Esc + Cancel still do) — verified at the code level (line 116 wrapped in `if (!danger)`)
- [x] `showConfirm({danger:false})` overlay click still dismisses (no behavior change for non-destructive) — same wrap, only difference is `danger=false` no longer skips the binding
- [x] `box-shadow` added to `.eclaw-confirm-dialog` (via `.dialog`)
- [x] Playbook step 5 updated
- [ ] **Playwright E2E**: deferred to the existing daily destructive-modals cron at 06/06 09:16 TW. The playbook IS the test — it runs 6 combos against production CSS + JS every 24h and a regression on the gate would show as a `dialog gone` after the synthetic-click step that my Phase 2 exploration used. Not duplicating into a new test file.

## Test plan
- [x] `node -c backend/public/portal/shared/api.js` passes
- [ ] Manual sanity in Playwright after merge: trigger `showConfirm({danger:true})` on settings.html, synthetic-click the overlay corner, assert `.eclaw-confirm-overlay` still present. Same for `danger:false` and assert it IS removed. (Will run as part of the 06/06 09:16 daily-cron round.)
- [ ] Visual sanity: dialog now has elevation against the backdrop on dark theme.

## Risk
Low. Single-line behavioral change for `danger:true` only; the `danger:false` code path is byte-identical to before. CSS box-shadow is additive. Playbook is documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes #3194.