### PR TITLE
fix(portal): inline confirm dialog elevation

### DIFF
--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -85,6 +85,7 @@ function _tFb(k, fb) {
 }
 
 let _eclawDialogId = 0;
+const _ECLAW_DIALOG_SHADOW_STYLE = 'style="box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);"';
 function showConfirm({ message, title, confirmText, cancelText, danger } = {}) {
     return new Promise((resolve) => {
         const t = _tFb;
@@ -96,7 +97,7 @@ function showConfirm({ message, title, confirmText, cancelText, danger } = {}) {
         const dialogAria = title
             ? `role="alertdialog" aria-modal="true" aria-labelledby="${titleId}" aria-describedby="${messageId}"`
             : `role="alertdialog" aria-modal="true" aria-label="${_escAttr(message)}" aria-describedby="${messageId}"`;
-        overlay.innerHTML = `<div class="dialog eclaw-confirm-dialog" ${dialogAria}>
+        overlay.innerHTML = `<div class="dialog eclaw-confirm-dialog" ${dialogAria} ${_ECLAW_DIALOG_SHADOW_STYLE}>
             ${title ? `<div class="dialog-title" id="${titleId}">${_escHtml(title)}</div>` : ''}
             <div class="dialog-body"><p id="${messageId}" style="margin:0;line-height:1.6;color:var(--text-secondary)">${_escHtml(message)}</p></div>
             <div class="dialog-actions">
@@ -164,7 +165,7 @@ function showPrompt({ message, title, defaultValue, placeholder, confirmText, ca
         const dialogAria = title
             ? `role="alertdialog" aria-modal="true" aria-labelledby="${titleId}" aria-describedby="${messageId}"`
             : `role="alertdialog" aria-modal="true" aria-label="${_escAttr(message)}" aria-describedby="${messageId}"`;
-        overlay.innerHTML = `<div class="dialog eclaw-confirm-dialog" ${dialogAria}>
+        overlay.innerHTML = `<div class="dialog eclaw-confirm-dialog" ${dialogAria} ${_ECLAW_DIALOG_SHADOW_STYLE}>
             ${title ? `<div class="dialog-title" id="${titleId}">${_escHtml(title)}</div>` : ''}
             <div class="dialog-body">
                 <p id="${messageId}" style="margin:0 0 12px;line-height:1.6;color:var(--text-secondary)">${_escHtml(message)}</p>


### PR DESCRIPTION
## Summary
Fixes the remaining UIUX gap from #3195: confirm/prompt dialogs now carry the modal elevation directly in the generated `.eclaw-confirm-dialog` markup, so the visual fix is not blocked by stale `/portal/shared/style.css` cache entries.

This keeps the existing CSS rule from #3193, but makes the dialog helper resilient during the shared CSS 4h cache window.

## Card
`card_6d176bef745e6f0df5e41316` — daily QA/UIUX regression (2026-06-05 23:00 TPE)

## Issue
Fixes #3195

## Test plan
- [x] `node -c backend/public/portal/shared/api.js`
- [x] Local static Playwright smoke, desktop `1366x900`:
  - `showConfirm({ danger:true })` backdrop click leaves overlay open
  - Cancel resolves `false`
  - `showConfirm({ danger:false })` backdrop click still dismisses/resolves `false`
  - computed `.eclaw-confirm-dialog` shadow is `rgba(0, 0, 0, 0.5) 0px 8px 32px 0px`
- [x] Same local static Playwright smoke on mobile/WebView-sized `390x844`

## Review
Please route to #2 code review. If PASS, squash merge and verify production computed shadow + danger backdrop behavior after deploy.