### PR TITLE
fix(ios): slow useEntities poll 5s→30s (CF 429 storms)

### DIFF
--- a/ios-app/hooks/useEntities.ts
+++ b/ios-app/hooks/useEntities.ts
@@ -5,7 +5,10 @@ import { deviceApi } from '../services/api';
 import { socketService } from '../services/socketService';
 import { EntityUpdate } from '../services/socketService';
 
-const POLL_INTERVAL = 5000; // 5 seconds, same as Android Wallpaper Service
+// 30s safety-net poll; Socket.IO entity:update carries realtime deltas.
+// Prior 5s value mis-cited Android Wallpaper Service (which uses 30s) and
+// stacked with the socket stream → CF WAF 429 storms on active sessions.
+const POLL_INTERVAL = 30000;
 
 export function useEntities() {
   const { deviceId, deviceSecret } = useAuthStore();
@@ -21,7 +24,7 @@ export function useEntities() {
     }
   }, [deviceId, deviceSecret, setEntities]);
 
-  // Initial fetch + polling (matches Android's 5s interval)
+  // Initial fetch + 30s safety-net poll (realtime updates flow via Socket.IO below).
   useEffect(() => {
     if (!deviceId || !deviceSecret) return;
 


### PR DESCRIPTION
## Summary
- iOS `useEntities` hook polled `GET /api/entities` every **5 seconds** while the Socket.IO `entity:update` stream was already delivering realtime deltas — every active session double-fanned to CF, tripping WAF 429s on Hank's wallpaper.
- The 5s value was justified by a comment that mis-cited Android's wallpaper service interval (`ClawWallpaperService.kt:100` uses 30s, not 5s).
- Slow the poll to **30s** as a Socket.IO safety-net; rely on the socket for realtime.

## Evidence chain
1. Backend `/api/logs?limit=500` returns **zero** entries containing `429` / `rate_limit` for device `480def4c-…` → the 429 lands at the CF WAF layer, *before* our backend rate limiter (so commit `0cfdf41` "retry transient eclaw api rate limits" never applied).
2. Backend `entity_poll` log cadence for the device is ~10s with occasional same-second bursts (`23:14:36 → 46 → 56 → 23:15:06 → 14 → 16 → 26 …`), well above any single declared interval — consistent with the iOS hook firing on top of Android wallpaper + bursts inside `getMultiEntityStatusFlow.forEach`.
3. `ios-app/hooks/useEntities.ts:8`: `POLL_INTERVAL = 5000; // 5 seconds, same as Android Wallpaper Service` — the trailing comment is wrong; `ClawWallpaperService.kt:100/114` explicitly pass `intervalMs = 30000`.
4. `useEntities` already subscribes to `socketService.on<EntityUpdate>('entity:update', …)` — the 5s poll was redundant on top of the realtime path.

## Test plan
- [ ] Build iOS app, leave wallpaper surface active for 30 min, watch CF WAF 429 rate against this device — expect drop from frequent to ~0.
- [ ] Confirm entity list still updates within a few seconds when an entity changes (Socket.IO path).
- [ ] Confirm fallback poll fires every ~30s (devtools network tab / Charles).
- [ ] Backend `/api/logs` `entity_poll` cadence for this device should fall to ~30s steady-state (mixed with Android wallpaper's 30s).

## Acceptance for `card_a7baa3b0b1151099d4523428`
- root cause: CF WAF 429 driven by iOS `useEntities` 5s polling stacked with Socket.IO realtime ✅
- fix direction: reduce polling, keep Socket.IO ✅
- prod verify wallpaper 24h no 429 → after merge + iOS rebuild

## Reviewer
Per card description: `#1 (tbwb9e)` is the planning reviewer; `#6 (yrt82n)` is the fallback after `#1` has been silent (>30 min on this card → silent ~18h on this fire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)