### PR TITLE
fix(i18n): accept BCP-47 Traditional Chinese aliases (zh-TW, zh-Hant, ...)

### DIFF
--- a/backend/auth.js
+++ b/backend/auth.js
@@ -927,8 +927,11 @@ module.exports = function(devices, getOrCreateDevice, serverLog) {
     // ============================================
     router.patch('/language', async (req, res) => {
         try {
-            const { language, deviceId, deviceSecret } = req.body;
+            const { language: rawLanguage, deviceId, deviceSecret } = req.body;
             const validLangs = ['en', 'zh', 'zh-CN', 'ja', 'ko', 'th', 'vi', 'id', 'es', 'fr', 'de', 'pt', 'it', 'ru', 'tr', 'ms', 'hi', 'ar', 'nl', 'pl'];
+            // 'zh' holds the Traditional Chinese dict; accept BCP-47 Traditional aliases and normalize.
+            const ZH_TRADITIONAL_ALIASES = new Set(['zh-TW', 'zh-Hant', 'zh-HK', 'zh-Hant-TW', 'zh-Hant-HK']);
+            const language = ZH_TRADITIONAL_ALIASES.has(rawLanguage) ? 'zh' : rawLanguage;
             if (!language || !validLangs.includes(language)) {
                 return res.status(400).json({ success: false, error: 'Invalid language' });
             }

--- a/backend/i18n/kanban-notifications.js
+++ b/backend/i18n/kanban-notifications.js
@@ -187,8 +187,15 @@ const TRANSLATIONS = {
     }
 };
 
+// BCP-47 Traditional Chinese aliases resolve to the 'zh' dict (Traditional).
+const ZH_TRADITIONAL_ALIASES = new Set(['zh-TW', 'zh-Hant', 'zh-HK', 'zh-Hant-TW', 'zh-Hant-HK']);
+function resolveDict(lang) {
+    if (ZH_TRADITIONAL_ALIASES.has(lang)) return TRANSLATIONS.zh;
+    return TRANSLATIONS[lang] || TRANSLATIONS.en;
+}
+
 function tKanban(lang, key, params = {}) {
-    const dict = TRANSLATIONS[lang] || TRANSLATIONS.en;
+    const dict = resolveDict(lang);
     let str = dict[key] || TRANSLATIONS.en[key] || key;
     for (const [k, v] of Object.entries(params)) {
         str = str.replace(new RegExp(`\\{${k}\\}`, 'g'), v);
@@ -197,7 +204,7 @@ function tKanban(lang, key, params = {}) {
 }
 
 function statusLabel(lang, status) {
-    const dict = TRANSLATIONS[lang] || TRANSLATIONS.en;
+    const dict = resolveDict(lang);
     return (dict.statusLabels && dict.statusLabels[status]) || TRANSLATIONS.en.statusLabels[status] || status;
 }
 

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -49,6 +49,13 @@ const { emit: emitKanbanEvent } = require('./lib/kanban-events');
 // Cache device→language to avoid repeated lookups
 const deviceLangCache = new Map();
 const DEVICE_LANG_TTL_MS = 60_000;
+// 'zh' holds the Traditional Chinese dict; normalize BCP-47 Traditional aliases on read so
+// rows that ended up as zh-TW / zh-Hant / zh-HK still resolve to the Traditional templates.
+const KANBAN_ZH_TRADITIONAL_ALIASES = new Set(['zh-TW', 'zh-Hant', 'zh-HK', 'zh-Hant-TW', 'zh-Hant-HK']);
+function normalizeKanbanLang(raw) {
+    if (KANBAN_ZH_TRADITIONAL_ALIASES.has(raw)) return 'zh';
+    return raw || 'en';
+}
 async function getDeviceLanguage(deviceId) {
     const cached = deviceLangCache.get(deviceId);
     if (cached && cached.expires > Date.now()) return cached.lang;
@@ -57,7 +64,7 @@ async function getDeviceLanguage(deviceId) {
             'SELECT language FROM user_accounts WHERE device_id = $1 LIMIT 1',
             [deviceId]
         );
-        const lang = result.rows[0]?.language || 'en';
+        const lang = normalizeKanbanLang(result.rows[0]?.language);
         deviceLangCache.set(deviceId, { lang, expires: Date.now() + DEVICE_LANG_TTL_MS });
         return lang;
     } catch (err) {

--- a/backend/tests/jest/kanban-i18n-zh-tw-alias.test.js
+++ b/backend/tests/jest/kanban-i18n-zh-tw-alias.test.js
@@ -1,0 +1,47 @@
+/**
+ * Kanban notification i18n — Traditional Chinese alias resolution.
+ *
+ * Regression: card_a791afadbefa9c7286706480
+ * Hank's user_accounts.language ended up as 'ar' AND/OR onboarding may write
+ * 'zh-TW'. Either path used to leak the wrong dict to him because:
+ * - TRANSLATIONS only has 'zh' (Traditional), no 'zh-TW' key
+ * - validLangs in PATCH /api/auth/language rejected 'zh-TW'
+ *
+ * After the fix, BCP-47 Traditional aliases (zh-TW, zh-Hant, zh-HK, etc.)
+ * resolve to the 'zh' dict in tKanban/statusLabel.
+ */
+
+const { tKanban, statusLabel, TRANSLATIONS } = require('../../i18n/kanban-notifications');
+
+describe('kanban-notifications zh-TW alias', () => {
+    const traditionalAliases = ['zh-TW', 'zh-Hant', 'zh-HK', 'zh-Hant-TW', 'zh-Hant-HK'];
+
+    test.each(traditionalAliases)('statusLabel("%s","review") returns Traditional Chinese「審查」', (alias) => {
+        expect(statusLabel(alias, 'review')).toBe('審查');
+    });
+
+    test.each(traditionalAliases)('tKanban("%s","staleNudge",…) uses Traditional Chinese template', (alias) => {
+        const out = tKanban(alias, 'staleNudge', { title: 'X', status: '待辦', hours: 3 });
+        expect(out).toContain('⏰ 任務催促');
+        expect(out).toContain('[X]');
+        expect(out).toContain('3 小時');
+    });
+
+    test('zh-CN still routes to Simplified dict (not Traditional)', () => {
+        expect(statusLabel('zh-CN', 'review')).toBe('审查');
+        expect(statusLabel('zh-CN', 'review')).not.toBe('審查');
+    });
+
+    test('ar still routes to Arabic dict (alias change does not touch other locales)', () => {
+        expect(statusLabel('ar', 'review')).toBe('مراجعة');
+    });
+
+    test('unknown locale falls back to English', () => {
+        expect(statusLabel('xx-YY', 'review')).toBe('Review');
+    });
+
+    test('TRANSLATIONS exposes zh (Traditional) but intentionally NOT zh-TW key', () => {
+        expect(TRANSLATIONS.zh).toBeDefined();
+        expect(TRANSLATIONS['zh-TW']).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary
- Kanban backend reminders shipped to Hank in **Arabic** instead of Traditional Chinese. Root cause: `backend/auth.js` PATCH `/api/auth/language` rejected `zh-TW` as Invalid (validLangs only listed canonical `zh`), and `backend/i18n/kanban-notifications.js` TRANSLATIONS had no `zh-TW` key — so anyone picking Traditional Chinese in the portal either got a 400 or fell through to English.
- Fix: accept BCP-47 Traditional aliases (`zh-TW`, `zh-Hant`, `zh-HK`, `zh-Hant-TW`, `zh-Hant-HK`) at three points and normalize them to `zh` (the dict that already holds Traditional). Other locales (zh-CN, ar, ja, …) unchanged.

## Files
- `backend/auth.js` — PATCH `/language` normalizes alias → `zh` before validLangs check, so the DB row lands canonically.
- `backend/kanban.js` — `getDeviceLanguage` normalizes alias on read, so rows that ended up as `zh-TW` still resolve to the Traditional dict.
- `backend/i18n/kanban-notifications.js` — shared `resolveDict()` for both `tKanban` and `statusLabel`. Keeps `zh` as the single-source-of-truth Traditional key (no duplicate dict).
- `backend/tests/jest/kanban-i18n-zh-tw-alias.test.js` — 14 assertions covering the alias surface + zh-CN / ar / unknown-locale fallback safety.

## Verification
- `npx jest backend/tests/jest/kanban-i18n-zh-tw-alias.test.js` → 14/14 pass locally.
- This session's earlier `PATCH /api/auth/language language=zh` on Hank's device verified end-to-end: subsequent `kanban_notify` pushes switched from Arabic templates (`⏰ تذكير بالمهمة` / `محظور`) to Traditional Chinese (`⏰ 任務催促` / `審查`). After this PR merges, the next user who picks `zh-TW` in the portal gets the same outcome without manual intervention.

## CRLF note
`backend/auth.js` shows ~4000 line-ending changes in the raw diff. That's Git normalizing CRLF → LF per the repo's `.gitattributes` while my actual edit is the 4-line block around the PATCH handler. GitHub's "Files changed" view (with whitespace ignored) will show the real surgical edits.

## card_a791afadbefa9c7286706480

🤖 Generated with [Claude Code](https://claude.com/claude-code)