### PR TITLE
feat(portal): showConfirm itemName field for destructive dialogs

### DIFF
--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -2283,7 +2283,7 @@
         async function archiveTaskCard(cardId) {
             const card = findCard(cardId);
             if (!card) return;
-            if (!await showConfirm({ message: `Archive "${card.title || card.id}"?`, danger: true })) return;
+            if (!await showConfirm({ message: t('kb_archive_confirm', 'Archive this card?'), itemName: card.title || card.id, danger: true })) return;
             try {
                 await apiCall('DELETE', `/api/mission/card/${cardId}?deviceId=${encodeURIComponent(currentUser.deviceId)}&deviceSecret=${encodeURIComponent(currentUser.deviceSecret)}`);
                 showToast('Archived');
@@ -2450,7 +2450,7 @@
         async function archiveCardFromDetail(cardId) {
             const card = findCard(cardId);
             if (!card) return;
-            if (!await showConfirm({ message: `Archive "${card.title || card.id}"?`, danger: true })) return;
+            if (!await showConfirm({ message: t('kb_archive_confirm', 'Archive this card?'), itemName: card.title || card.id, danger: true })) return;
             await withAutoAction(null, () => apiCall('DELETE', `/api/mission/card/${cardId}?deviceId=${encodeURIComponent(currentUser.deviceId)}&deviceSecret=${encodeURIComponent(currentUser.deviceSecret)}`), {
                 closeOnDone: true, successMsg: '🗑 ' + t('kb_archive', 'Archive'),
             });

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -2290,7 +2290,9 @@
         }
 
         async function deleteNote(id) {
-            if (await showConfirm({ message: i18n.t('mc_confirm_delete'), danger: true })) {
+            const note = dashboard.notes.find(n => n.id === id);
+            const itemName = note ? (note.title || note.id) : id;
+            if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, danger: true })) {
                 dashboard.notes = dashboard.notes.filter(n => n.id !== id);
                 markChanged();
                 renderNotes();
@@ -2306,7 +2308,9 @@
             menu.style.top = e.clientY + 'px';
 
             menu.querySelector('.context-menu-item').onclick = async () => {
-                if (await showConfirm({ message: i18n.t('mc_confirm_delete'), danger: true })) {
+                const note = dashboard.notes.find(n => n.id === id);
+                const itemName = note ? (note.title || note.id) : id;
+                if (await showConfirm({ message: i18n.t('mc_confirm_delete'), itemName, danger: true })) {
                     dashboard.notes = dashboard.notes.filter(n => n.id !== id);
                     markChanged();
                     renderNotes();

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1978,7 +1978,10 @@
         }
 
         async function deleteChannelAccount(id) {
-            if (!await showConfirm({ message: i18n.t('toast_delete_channel_confirm'), danger: true })) return;
+            const acct = (currentUser && Array.isArray(currentUser.channelAccounts))
+                ? currentUser.channelAccounts.find(a => a.id === id) : null;
+            const itemName = acct ? (acct.label || acct.handle || acct.channel || id) : id;
+            if (!await showConfirm({ message: i18n.t('toast_delete_channel_confirm'), itemName, danger: true })) return;
             try {
                 await apiCall('DELETE', `/api/channel/account/${id}`);
                 // Re-fetch fresh user data to sync channel accounts

--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -67,11 +67,17 @@ function showToast(message, type = 'info') {
 /**
  * showConfirm — styled replacement for window.confirm()
  * @param {Object} opts
- * @param {string} opts.message - Main message text
+ * @param {string} opts.message - Main message text. For destructive flows prefer the {itemName} field
+ *   below over baking the item name into this string — it lets the dialog quote the item in distinct
+ *   styling and lets the daily destructive-modals E2E spot-check that the user can see WHAT they're about to destroy.
  * @param {string} [opts.title] - Optional dialog title
  * @param {string} [opts.confirmText='OK'] - Confirm button label
  * @param {string} [opts.cancelText='Cancel'] - Cancel button label
  * @param {boolean} [opts.danger=false] - Red confirm button for destructive actions
+ * @param {string} [opts.itemName] - Name of the specific item being destroyed (card title,
+ *   note name, entity label, etc). When provided AND `danger:true`, the dialog renders this
+ *   below the message in a quoted, bold strip so the user can verify WHICH item they're confirming.
+ *   Omitting it on a `danger:true` call logs a dev-time console.warn (production stays silent).
  * @returns {Promise<boolean>}
  */
 // i18n helper that honours a fallback string. i18n.t(key, params) uses the
@@ -86,7 +92,13 @@ function _tFb(k, fb) {
 
 let _eclawDialogId = 0;
 const _ECLAW_DIALOG_SHADOW_STYLE = 'style="box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);"';
-function showConfirm({ message, title, confirmText, cancelText, danger } = {}) {
+function showConfirm({ message, title, confirmText, cancelText, danger, itemName } = {}) {
+    // Dev-time hint: destructive confirms should name the item so a fast-clicking user can
+    // verify what's about to be destroyed. Localhost / dev hosts only; silent in production.
+    if (danger && !itemName && typeof window !== 'undefined' && window.location
+        && /^(localhost|127\.0\.0\.1|0\.0\.0\.0)$/.test(window.location.hostname)) {
+        console.warn('[showConfirm] danger:true called without itemName — caller should pass `itemName` so the dialog can name the destroyed item. Caller:', new Error().stack);
+    }
     return new Promise((resolve) => {
         const t = _tFb;
         const overlay = document.createElement('div');
@@ -97,9 +109,12 @@ function showConfirm({ message, title, confirmText, cancelText, danger } = {}) {
         const dialogAria = title
             ? `role="alertdialog" aria-modal="true" aria-labelledby="${titleId}" aria-describedby="${messageId}"`
             : `role="alertdialog" aria-modal="true" aria-label="${_escAttr(message)}" aria-describedby="${messageId}"`;
+        const itemStrip = (danger && itemName)
+            ? `<div class="eclaw-confirm-item" style="margin:8px 0 0;padding:8px 12px;background:var(--bg-secondary, rgba(0,0,0,0.04));border-left:3px solid var(--danger, #e53e3e);border-radius:4px;font-weight:600;color:var(--text);word-break:break-word">${_escHtml(itemName)}</div>`
+            : '';
         overlay.innerHTML = `<div class="dialog eclaw-confirm-dialog" ${dialogAria} ${_ECLAW_DIALOG_SHADOW_STYLE}>
             ${title ? `<div class="dialog-title" id="${titleId}">${_escHtml(title)}</div>` : ''}
-            <div class="dialog-body"><p id="${messageId}" style="margin:0;line-height:1.6;color:var(--text-secondary)">${_escHtml(message)}</p></div>
+            <div class="dialog-body"><p id="${messageId}" style="margin:0;line-height:1.6;color:var(--text-secondary)">${_escHtml(message)}</p>${itemStrip}</div>
             <div class="dialog-actions">
                 <button type="button" class="btn btn-outline eclaw-confirm-cancel">${_escHtml(cancelText || t('dialog_cancel', 'Cancel'))}</button>
                 <button type="button" class="btn ${danger ? 'btn-danger' : 'btn-primary'} eclaw-confirm-ok"${danger && !confirmText ? ` aria-label="${_escAttr(t('dialog_confirm_destructive', 'Confirm destructive action'))}"` : ''}>${_escHtml(confirmText || t('dialog_ok', 'OK'))}</button>


### PR DESCRIPTION
## Summary
- Daily 2026-06-06 destructive-modals E2E (parent `card_f14f5ac13148be30d49d0b54`) found a real UX gap: `showConfirm`'s `message` is a free-form string with no enforced way to name the item being destroyed. Some callers bake the name into the message, others leave the message generic — a fast-clicking user can confirm the wrong destruction.
- This PR adds `opts.itemName` to `showConfirm`. When provided AND `danger:true`, the dialog renders a quoted strip with a red left border so the user can verify the specific item. When `danger:true` is called without `itemName` on a dev host, a `console.warn` fires so the gap surfaces during development; production stays silent.
- Migrated the three highest-traffic destructive callers per the card's acceptance:
  - `kanban.html` — `archiveCard` + `archiveCardFromDetail`
  - `mission.html` — `deleteNote` + context-menu variant
  - `settings.html` — `deleteChannelAccount`
- Non-destructive (`danger:false`) callers are unchanged — `itemName` is ignored.

## Visual
```
+----------------------------------+
| Archive this card?               |   <- message (existing styling)
| +------------------------------+ |
| | Petdx Phase 3 monitor cron   | |   <- itemStrip (new: red border-left, bold)
| +------------------------------+ |
|              [Cancel]  [Archive] |
+----------------------------------+
```

## Test plan
- [ ] Daily destructive-modals E2E (06/07 09:15 cron) — existing 6 viewport × page combos still PASS the geometry assertion; the new itemStrip sits inside `.dialog-body` so dialog rect width stays bounded.
- [ ] Manual smoke on kanban: long card title → strip wraps via `word-break:break-word`, dialog still fits 390x844 mobile.
- [ ] Manual smoke on mission delete note: note title shows; if the note doc has no title, fallback `note.id` shows.
- [ ] Manual smoke on settings delete channel: account label / handle / channel name show in fallback chain.

## card_eba2fb9bd91b40d9d4de2671

🤖 Generated with [Claude Code](https://claude.com/claude-code)