### PR TITLE
fix(portal): help-icon popover dismissed instantly inside <label>

### DIFF
--- a/backend/public/shared/help-popover.js
+++ b/backend/public/shared/help-popover.js
@@ -307,6 +307,10 @@
         document.addEventListener('click', (e) => {
             const icon = e.target.closest('.' + ICON_CLASS);
             if (icon) {
+                // Block <label> activation behavior — without this, a help-icon nested
+                // inside <label> triggers a synthesized click on the associated input,
+                // which fires the capture-phase onDocClick and dismisses the popover.
+                e.preventDefault();
                 prepareIcon(icon);
                 onIconClick({ currentTarget: icon, stopPropagation: () => e.stopPropagation() });
             }


### PR DESCRIPTION
## Bug
設定頁 Agent Policy 內容 + 所有 checkbox 的 help-icon 點擊後 popover 出現 0.5 秒就消失。Hank web_chat 2026-06-06 19:55 TW report.

Kanban: card_6506f1593eca3dd830e16f52

## Root cause
`settings.html` 大多數 help-icon 嵌在 `<label>` 內 (e.g. line 1041-1046 "Require test plan" checkbox):

```html
<label ...>
  <input type="checkbox" id="...">
  <span>label text</span>
  <span class="help-icon" data-help-content-key="..."></span>
</label>
```

Click event flow before fix:
1. 用戶點 `.help-icon`
2. `init()` 上的 `document` click listener → `showPopover` → register `document.addEventListener('click', onDocClick, true)` (capture phase)
3. 原 click 結束 bubble. `<label>` 的 default activation behavior 觸發**合成 click on the associated `<input>`** (HTML spec 4.10.4)
4. 合成 click 是新 event → capture phase 立刻打到 `onDocClick`
5. `activeAnchor.contains(input)` = false, `activePopover.contains(input)` = false → `hidePopover()` 立刻關
6. 視覺上: 180ms fade-in + 200ms fade-out → 「0.5 秒就消失」

## Fix
在 `init()` 內 click listener 加 `e.preventDefault()` 阻擋 label activation behavior:

```js
document.addEventListener('click', (e) => {
    const icon = e.target.closest('.' + ICON_CLASS);
    if (icon) {
        e.preventDefault();  // ← block label synthesized input click
        prepareIcon(icon);
        onIconClick({ currentTarget: icon, stopPropagation: () => e.stopPropagation() });
    }
});
```

不再合成 input click → `onDocClick` 不被觸發 → popover 留著。

副作用: 點 help-icon 不會 toggle 同一個 label 內的 checkbox/focus textarea — 這是預期的, 因為點 help 是查 hint, 不該誤動主控件。

## Test plan
- [ ] Playwright E2E /portal/settings.html:
  - Click `prompt_policy_require_plan_help` (checkbox label 內) → popover 出現 → 等 1s → popover 仍可見
  - Click `prompt_policy_codex_override_help` (textarea label 內) → popover 出現 → 等 1s → popover 仍可見
  - Click 別處 → popover 關閉 (regression check)
  - 桌機 1280x800 + 手機 390x844 雙端
- [ ] 截圖 before/after attach 到卡

## Reviewer
Self-merge per Hank 2026-06-06 11:51 TW directive (bridge-only / self-review+push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)