### PR TITLE
feat(portal): avatar status panel P0 — counter drawer + cross-entity API

### DIFF
--- a/backend/entity-status.js
+++ b/backend/entity-status.js
@@ -1,0 +1,149 @@
+// ============================================
+// Entity Status Module
+// Per-entity cumulative error counters surfaced in the avatar status drawer.
+// Auth: same shape as /api/entities — deviceId+deviceSecret OR deviceId+botSecret
+// (cross-entity observation per Hank 2026-06-06 19:55 TW directive).
+//
+// P0 scope (card_dbe18b333ac98076cc213055):
+//   GET /api/entity-status/:eId → { counters: [{axis,count,lastEventAt}] }
+// P1 (separate PR): operation log section, smart chip, smart quote.
+// ============================================
+
+const express = require('express');
+const safeEqual = require('./safe-equal');
+
+const CANONICAL_AXES = [
+    'chat_no_reply',
+    'a2a_no_reply',
+    'kanban_nudge_no_reply',
+    'system_msg_no_reply',
+];
+
+let pool = null;
+let devicesRef = null;
+
+function initTable(chatPool) {
+    pool = chatPool;
+    return pool.query(`
+        CREATE TABLE IF NOT EXISTS entity_error_counters (
+            id BIGSERIAL PRIMARY KEY,
+            device_id VARCHAR(64) NOT NULL,
+            entity_id INT NOT NULL,
+            axis VARCHAR(64) NOT NULL,
+            count INT NOT NULL DEFAULT 0,
+            last_event_at TIMESTAMPTZ,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            UNIQUE(device_id, entity_id, axis)
+        );
+        CREATE INDEX IF NOT EXISTS idx_eec_lookup
+            ON entity_error_counters(device_id, entity_id);
+    `);
+}
+
+function bindDevicesRef(devices) {
+    devicesRef = devices;
+}
+
+async function getCounters(deviceId, entityId) {
+    if (!pool) return [];
+    const result = await pool.query(
+        `SELECT axis, count, last_event_at
+           FROM entity_error_counters
+          WHERE device_id = $1 AND entity_id = $2`,
+        [deviceId, entityId]
+    );
+    const byAxis = new Map(result.rows.map(r => [r.axis, r]));
+    // Always surface canonical axes even when count = 0, so the UI can render
+    // a stable row order. Extra non-canonical axes (forward-compat) appear after.
+    const ordered = [];
+    for (const axis of CANONICAL_AXES) {
+        const row = byAxis.get(axis);
+        ordered.push({
+            axis,
+            count: row ? Number(row.count) : 0,
+            lastEventAt: row && row.last_event_at ? row.last_event_at.toISOString() : null,
+        });
+        byAxis.delete(axis);
+    }
+    for (const [axis, row] of byAxis) {
+        ordered.push({
+            axis,
+            count: Number(row.count),
+            lastEventAt: row.last_event_at ? row.last_event_at.toISOString() : null,
+        });
+    }
+    return ordered;
+}
+
+async function incrementCounter(deviceId, entityId, axis) {
+    if (!pool) return;
+    await pool.query(`
+        INSERT INTO entity_error_counters (device_id, entity_id, axis, count, last_event_at)
+        VALUES ($1, $2, $3, 1, NOW())
+        ON CONFLICT (device_id, entity_id, axis) DO UPDATE
+        SET count = entity_error_counters.count + 1,
+            last_event_at = NOW(),
+            updated_at = NOW()
+    `, [deviceId, entityId, axis]);
+}
+
+function authDeviceOrBot(req) {
+    const deviceId = req.query.deviceId || req.body?.deviceId;
+    const deviceSecret = req.query.deviceSecret || req.body?.deviceSecret;
+    const botSecret = req.query.botSecret || req.body?.botSecret;
+    const callerEntityId = parseInt(req.query.entityId || req.body?.entityId) || 0;
+    if (!deviceId || !devicesRef || !devicesRef[deviceId]) return null;
+    const device = devicesRef[deviceId];
+    if (deviceSecret && safeEqual(device.deviceSecret, deviceSecret)) {
+        return { deviceId, callerEntityId };
+    }
+    if (botSecret) {
+        const ents = device.entities || {};
+        if (callerEntityId > 0) {
+            const e = ents[callerEntityId];
+            if (e && e.isBound && e.botSecret && safeEqual(e.botSecret, botSecret)) {
+                return { deviceId, callerEntityId };
+            }
+        } else {
+            const match = Object.entries(ents).find(([, e]) =>
+                e && e.isBound && e.botSecret && safeEqual(e.botSecret, botSecret));
+            if (match) return { deviceId, callerEntityId: Number(match[0]) };
+        }
+    }
+    return null;
+}
+
+const router = express.Router();
+
+router.get('/:eId', async (req, res) => {
+    const auth = authDeviceOrBot(req);
+    if (!auth) {
+        return res.status(403).json({ success: false, error: 'Invalid credentials' });
+    }
+    const targetEId = parseInt(req.params.eId);
+    if (!Number.isFinite(targetEId) || targetEId < 0) {
+        return res.status(400).json({ success: false, error: 'Invalid entityId' });
+    }
+    try {
+        const counters = await getCounters(auth.deviceId, targetEId);
+        res.json({
+            success: true,
+            deviceId: auth.deviceId,
+            entityId: targetEId,
+            counters,
+        });
+    } catch (err) {
+        console.error('[EntityStatus] getCounters error:', err.message);
+        res.status(500).json({ success: false, error: 'internal' });
+    }
+});
+
+module.exports = {
+    initTable,
+    bindDevicesRef,
+    getCounters,
+    incrementCounter,
+    router,
+    CANONICAL_AXES,
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -2252,6 +2252,14 @@ const articlePublisher = require('./article-publisher');
 app.use('/api/publisher', articlePublisher.router);
 
 // ============================================
+// ENTITY STATUS PANEL — counters surfaced when user clicks any non-dashboard avatar.
+// P0: counters; P1 (next PR) adds operation log + smart chip + smart quote.
+// ============================================
+const entityStatus = require('./entity-status');
+entityStatus.bindDevicesRef(devices);
+app.use('/api/entity-status', entityStatus.router);
+
+// ============================================
 // API DOCS — OpenAPI / Swagger UI
 // ============================================
 const apiDocs = require('./api-docs')();
@@ -18771,6 +18779,7 @@ feedbackModule.initFeedbackTable(chatPool);
 feedbackModule.initFeedbackPhotosTable(chatPool);
 notifModule.initNotificationTables(chatPool);
 devicePrefs.initTable(chatPool);
+entityStatus.initTable(chatPool).catch(err => console.error('[EntityStatus] initTable error:', err.message));
 orgChartModule.initTable(chatPool);
 crossDeviceSettings.initTable(chatPool);
 chatIntegrity.initIntegrityTable(chatPool);

--- a/backend/migrations/20260606_entity_status_panel_p0.down.sql
+++ b/backend/migrations/20260606_entity_status_panel_p0.down.sql
@@ -1,0 +1,3 @@
+-- Migration down: 20260606_entity_status_panel_p0
+DROP INDEX IF EXISTS idx_eec_lookup;
+DROP TABLE IF EXISTS entity_error_counters;

--- a/backend/migrations/20260606_entity_status_panel_p0.up.sql
+++ b/backend/migrations/20260606_entity_status_panel_p0.up.sql
@@ -1,0 +1,25 @@
+-- Migration: 20260606_entity_status_panel_p0
+-- PR: [Feature/P0] Entity status panel — counter table for entity_error_counters
+-- Purpose: persist cumulative error counters per entity, used by the entity
+-- status drawer that opens when a user clicks any non-dashboard avatar.
+-- Non-breaking: brand-new table.
+
+CREATE TABLE IF NOT EXISTS entity_error_counters (
+    id BIGSERIAL PRIMARY KEY,
+    device_id VARCHAR(64) NOT NULL,
+    entity_id INT NOT NULL,
+    axis VARCHAR(64) NOT NULL,
+    count INT NOT NULL DEFAULT 0,
+    last_event_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(device_id, entity_id, axis)
+);
+
+CREATE INDEX IF NOT EXISTS idx_eec_lookup
+    ON entity_error_counters(device_id, entity_id);
+
+COMMENT ON TABLE entity_error_counters IS
+    'Per-entity cumulative error counters surfaced in the entity status drawer. '
+    'axis examples: chat_no_reply, a2a_no_reply, kanban_nudge_no_reply, system_msg_no_reply. '
+    'New axes can be added without schema changes — counter rows are upserted on (device_id, entity_id, axis).';

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -1055,6 +1055,7 @@
     <script src="../shared/petdx-renderer.js"></script>
     <script src="../shared/avatar-petdx.js"></script>
     <script src="shared/entity-utils.js"></script>
+    <script src="shared/entity-status-panel.js"></script>
     <script src="shared/entity-link-render.js"></script>
     <script src="shared/note-link-render.js"></script>
     <script src="shared/mention-render.js"></script>
@@ -1200,6 +1201,11 @@
             const _isEmbed = new URLSearchParams(window.location.search).get('embed') === '1';
             if (_isEmbed) {
                 document.body.classList.add('embed-mode');
+            }
+            // Avatar click → entity status drawer (per card_dbe18b333ac98076cc213055).
+            // Delegated on document.body so chips rendered after initial paint still fire.
+            if (typeof attachAvatarClickHandler === 'function' && window.EntityStatusPanel) {
+                attachAvatarClickHandler(document.body, (eid) => window.EntityStatusPanel.open(eid));
             }
             renderNav('kanban');
             if (typeof renderFooter === 'function') renderFooter();

--- a/backend/public/portal/shared/entity-status-panel.js
+++ b/backend/public/portal/shared/entity-status-panel.js
@@ -1,0 +1,214 @@
+/**
+ * Entity Status Panel — drawer that shows cumulative error counters for an
+ * entity. Opens when a user clicks any non-dashboard avatar.
+ *
+ * P0 (this PR, per card_dbe18b333ac98076cc213055):
+ *   - Counter section (Block 1)
+ * P1 (follow-up):
+ *   - Operation log (Block 2), smart chip, smart quote
+ *
+ * Per Hank 2026-06-06 19:55 TW directive: drawer data fetched via public
+ * GET /api/entity-status/:eId, which authenticates by deviceSecret OR botSecret
+ * so other entities on the same device can also call it for observation.
+ *
+ * API surface (global window.EntityStatusPanel):
+ *   open(entityId, opts?) — fetch + render + slide-in
+ *   close()              — slide-out + remove
+ *   isOpen()             — bool
+ */
+
+(function () {
+    'use strict';
+
+    const ROOT_CLASS = 'entity-status-panel';
+    const COUNTER_LABELS_ZH = {
+        chat_no_reply:         '已讀聊天未回覆',
+        a2a_no_reply:          '實體對實體訊息未回覆',
+        kanban_nudge_no_reply: '任務催促未回覆',
+        system_msg_no_reply:   '系統訊息未回覆',
+    };
+    const COUNTER_LABELS_EN = {
+        chat_no_reply:         'Chats read but not replied',
+        a2a_no_reply:          'Entity-to-entity msgs not acked',
+        kanban_nudge_no_reply: 'Task nudges not acted on',
+        system_msg_no_reply:   'System msgs not acked',
+    };
+
+    let rootEl = null;
+    let currentEid = null;
+
+    function pickLabel(axis) {
+        const lang = (document.documentElement.getAttribute('lang') || 'en').toLowerCase();
+        const isZh = lang.startsWith('zh') || lang === 'tw' || lang === 'cn';
+        const dict = isZh ? COUNTER_LABELS_ZH : COUNTER_LABELS_EN;
+        return dict[axis] || axis;
+    }
+
+    function readCreds() {
+        // Reuse the same credential plumbing that every portal page already
+        // sets up (api.js / auth.js writes to window.EClawAuth or localStorage).
+        const w = window;
+        const ls = (k) => { try { return localStorage.getItem(k); } catch { return null; } };
+        return {
+            deviceId: w.DEVICE_ID || w.deviceId || ls('deviceId'),
+            deviceSecret: w.DEVICE_SECRET || w.deviceSecret || ls('deviceSecret'),
+            botSecret: w.BOT_SECRET || w.botSecret || ls('botSecret'),
+            entityId: w.ENTITY_ID || w.entityId || ls('entityId'),
+        };
+    }
+
+    async function fetchStatus(eid) {
+        const c = readCreds();
+        const qs = new URLSearchParams();
+        if (c.deviceId) qs.set('deviceId', c.deviceId);
+        if (c.deviceSecret) qs.set('deviceSecret', c.deviceSecret);
+        else if (c.botSecret) {
+            qs.set('botSecret', c.botSecret);
+            if (c.entityId) qs.set('entityId', String(c.entityId));
+        }
+        const res = await fetch(`/api/entity-status/${eid}?${qs.toString()}`, {
+            credentials: 'include',
+        });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        return res.json();
+    }
+
+    function buildDom(eid) {
+        const root = document.createElement('aside');
+        root.className = ROOT_CLASS;
+        root.setAttribute('role', 'dialog');
+        root.setAttribute('aria-modal', 'true');
+        root.setAttribute('aria-label', 'Entity status');
+        root.dataset.entityId = String(eid);
+        root.innerHTML = `
+            <div class="${ROOT_CLASS}__scrim" data-action="close"></div>
+            <div class="${ROOT_CLASS}__sheet">
+                <header class="${ROOT_CLASS}__header">
+                    <strong class="${ROOT_CLASS}__title">Entity #${eid}</strong>
+                    <button type="button" class="${ROOT_CLASS}__close" aria-label="Close" data-action="close">✕</button>
+                </header>
+                <section class="${ROOT_CLASS}__section" data-section="counters">
+                    <h3 class="${ROOT_CLASS}__section-title">累計錯誤次數 / Error counters</h3>
+                    <ul class="${ROOT_CLASS}__counter-list" data-role="counter-list">
+                        <li class="${ROOT_CLASS}__counter-row" data-state="loading">Loading…</li>
+                    </ul>
+                </section>
+                <section class="${ROOT_CLASS}__section ${ROOT_CLASS}__section--placeholder">
+                    <h3 class="${ROOT_CLASS}__section-title">操作 log / Operation log</h3>
+                    <p class="${ROOT_CLASS}__placeholder-note">P1 follow-up — see card_dbe18b333ac98076cc213055.</p>
+                </section>
+            </div>
+        `;
+        root.addEventListener('click', (e) => {
+            const action = e.target?.dataset?.action;
+            if (action === 'close') close();
+        });
+        return root;
+    }
+
+    function renderCounters(root, counters) {
+        const list = root.querySelector('[data-role="counter-list"]');
+        if (!list) return;
+        if (!counters || counters.length === 0) {
+            list.innerHTML = `<li class="${ROOT_CLASS}__counter-row" data-state="empty">No counters yet.</li>`;
+            return;
+        }
+        list.innerHTML = counters.map(c => `
+            <li class="${ROOT_CLASS}__counter-row" data-axis="${c.axis}">
+                <span class="${ROOT_CLASS}__counter-label">${pickLabel(c.axis)}</span>
+                <span class="${ROOT_CLASS}__counter-value">${c.count}</span>
+            </li>
+        `).join('');
+    }
+
+    function ensureStyles() {
+        if (document.getElementById('entity-status-panel-style')) return;
+        const style = document.createElement('style');
+        style.id = 'entity-status-panel-style';
+        style.textContent = `
+.${ROOT_CLASS} { position: fixed; inset: 0; z-index: 9998; pointer-events: none; }
+.${ROOT_CLASS}__scrim { position: absolute; inset: 0; background: rgba(0,0,0,0.45);
+    opacity: 0; transition: opacity 0.18s ease; pointer-events: auto; }
+.${ROOT_CLASS}--visible .${ROOT_CLASS}__scrim { opacity: 1; }
+.${ROOT_CLASS}__sheet { position: absolute; top: 0; right: 0; bottom: 0;
+    width: min(420px, 92vw); background: var(--card, #1e1e2e); color: var(--text, #e0e0e0);
+    box-shadow: -8px 0 32px rgba(0,0,0,0.5); transform: translateX(100%);
+    transition: transform 0.22s ease; pointer-events: auto; display: flex; flex-direction: column;
+    overflow-y: auto; }
+.${ROOT_CLASS}--visible .${ROOT_CLASS}__sheet { transform: translateX(0); }
+@media (max-width: 480px) {
+    .${ROOT_CLASS}__sheet { width: 100vw; }
+}
+.${ROOT_CLASS}__header { display: flex; align-items: center; justify-content: space-between;
+    padding: 14px 18px; border-bottom: 1px solid var(--card-border, #333); }
+.${ROOT_CLASS}__title { font-size: 16px; font-weight: 600; }
+.${ROOT_CLASS}__close { background: none; border: none; color: var(--text-muted, #888);
+    cursor: pointer; font-size: 18px; padding: 4px 8px; border-radius: 6px; }
+.${ROOT_CLASS}__close:hover { color: var(--text, #fff); background: rgba(255,255,255,0.06); }
+.${ROOT_CLASS}__section { padding: 14px 18px; border-bottom: 1px solid var(--card-border, #333); }
+.${ROOT_CLASS}__section-title { font-size: 13px; font-weight: 600;
+    color: var(--text-secondary, #aaa); margin: 0 0 10px; text-transform: uppercase; letter-spacing: 0.04em; }
+.${ROOT_CLASS}__counter-list { list-style: none; margin: 0; padding: 0; }
+.${ROOT_CLASS}__counter-row { display: flex; justify-content: space-between; align-items: center;
+    padding: 8px 0; border-bottom: 1px dashed var(--card-border, #333); }
+.${ROOT_CLASS}__counter-row:last-child { border-bottom: none; }
+.${ROOT_CLASS}__counter-label { font-size: 13px; color: var(--text, #e0e0e0); }
+.${ROOT_CLASS}__counter-value { font-size: 16px; font-weight: 600; color: var(--primary, #6c63ff);
+    background: rgba(108,99,255,0.12); padding: 2px 10px; border-radius: 999px; min-width: 32px;
+    text-align: center; }
+.${ROOT_CLASS}__placeholder-note { font-size: 12px; color: var(--text-muted, #888); font-style: italic; }
+        `.trim();
+        document.head.appendChild(style);
+    }
+
+    async function open(eid, opts) {
+        opts = opts || {};
+        const targetEid = Number(eid);
+        if (!Number.isFinite(targetEid) || targetEid < 0) return;
+        if (rootEl) close();
+
+        ensureStyles();
+        rootEl = buildDom(targetEid);
+        document.body.appendChild(rootEl);
+        currentEid = targetEid;
+
+        // Animate in on the next frame so the CSS transition fires.
+        requestAnimationFrame(() => rootEl.classList.add(ROOT_CLASS + '--visible'));
+
+        // ESC closes.
+        document.addEventListener('keydown', _onEsc);
+
+        try {
+            const data = await fetchStatus(targetEid);
+            renderCounters(rootEl, data.counters);
+        } catch (err) {
+            const list = rootEl.querySelector('[data-role="counter-list"]');
+            if (list) {
+                list.innerHTML = `<li class="${ROOT_CLASS}__counter-row" data-state="error">Failed to load: ${err.message}</li>`;
+            }
+        }
+    }
+
+    function close() {
+        if (!rootEl) return;
+        document.removeEventListener('keydown', _onEsc);
+        rootEl.classList.remove(ROOT_CLASS + '--visible');
+        const el = rootEl;
+        rootEl = null;
+        currentEid = null;
+        setTimeout(() => { if (el.parentNode) el.parentNode.removeChild(el); }, 240);
+    }
+
+    function isOpen() {
+        return !!rootEl;
+    }
+
+    function _onEsc(e) {
+        if (e.key === 'Escape') {
+            e.stopPropagation();
+            close();
+        }
+    }
+
+    window.EntityStatusPanel = { open, close, isOpen };
+})();

--- a/backend/public/portal/shared/entity-utils.js
+++ b/backend/public/portal/shared/entity-utils.js
@@ -187,19 +187,24 @@ function _petdxCanRenderCanvas(entityId) {
 }
 function renderAvatarHtml(avatar, size, entityId) {
     size = size || 48;
+    const eidAttr = entityId != null ? ' data-entity-id="' + Number(entityId) + '"' : '';
     if (entityId != null && _petdxCanRenderCanvas(entityId)) {
         // imageRendering keeps the spritesheet pixel-art crisp at small sizes;
         // matches PetdxRenderer's ctx.imageSmoothingEnabled = false.
-        return '<canvas class="entity-avatar-canvas" '
-            + 'data-petdx-entity-id="' + Number(entityId) + '" '
-            + 'width="' + size + '" height="' + size + '" '
-            + 'style="width:' + size + 'px;height:' + size + 'px;'
-            + 'image-rendering:pixelated;border-radius:50%;vertical-align:middle;" '
-            + 'aria-label="entity avatar"></canvas>';
+        return '<canvas class="entity-avatar-canvas"' + eidAttr
+            + ' data-petdx-entity-id="' + Number(entityId) + '"'
+            + ' width="' + size + '" height="' + size + '"'
+            + ' style="width:' + size + 'px;height:' + size + 'px;'
+            + 'image-rendering:pixelated;border-radius:50%;vertical-align:middle;"'
+            + ' aria-label="entity avatar"></canvas>';
     }
     if (isAvatarUrl(avatar)) {
-        return '<img src="' + avatar + '" class="entity-avatar-img" ' +
-            'style="width:' + size + 'px;height:' + size + 'px;" alt="avatar" loading="lazy">';
+        return '<img src="' + avatar + '" class="entity-avatar-img"' + eidAttr +
+            ' style="width:' + size + 'px;height:' + size + 'px;" alt="avatar" loading="lazy">';
+    }
+    // Emoji fallback — wrap in a span so the click delegate can resolve entityId.
+    if (entityId != null) {
+        return '<span class="entity-avatar-emoji"' + eidAttr + '>' + (avatar || '\u{1F99E}') + '</span>';
     }
     return avatar || '\u{1F99E}';
 }
@@ -243,4 +248,29 @@ function getEntityLabelText(entityId) {
     const emoji = getAvatarText(entityId);
     const name = getEntityDisplayName(entityId);
     return `${emoji} ${name} (#${entityId})`;
+}
+
+/**
+ * Attach a delegated click handler to `container` that fires `onClick(entityId)`
+ * whenever the user clicks any element with `data-entity-id` (covers canvas /
+ * img / emoji-span avatars rendered by renderAvatarHtml).
+ *
+ * Skip dashboard surfaces — they own the avatar-change UX; per Hank 2026-06-06
+ * 19:40 TW directive, every OTHER surface opens the entity status drawer.
+ *
+ * Returns the listener so callers can detach if needed.
+ */
+function attachAvatarClickHandler(container, onClick) {
+    if (!container || typeof onClick !== 'function') return null;
+    const listener = (e) => {
+        const el = e.target.closest('[data-entity-id]');
+        if (!el || !container.contains(el)) return;
+        const eid = parseInt(el.dataset.entityId, 10);
+        if (!Number.isFinite(eid) || eid < 0) return;
+        e.preventDefault();
+        e.stopPropagation();
+        onClick(eid, el);
+    };
+    container.addEventListener('click', listener);
+    return listener;
 }


### PR DESCRIPTION
## Scope
P0 slice of card_dbe18b333ac98076cc213055 (Hank web_chat 2026-06-06 19:40-19:55 TW).

Click any **non-dashboard** avatar → side-drawer opens → cumulative error counters for that entity (chat_no_reply / a2a_no_reply / kanban_nudge_no_reply / system_msg_no_reply).

Per Hank's later addition: drawer data also exposed via public GET so **other entities on the same device** can observe each other (cross-entity behavior visibility for collaboration / monitoring).

## Diff
| File | Purpose |
|------|---------|
| `backend/migrations/20260606_entity_status_panel_p0.{up,down}.sql` | new `entity_error_counters` table |
| `backend/entity-status.js` (new) | Module + router. `getCounters` / `incrementCounter` / `GET /api/entity-status/:eId` |
| `backend/index.js` | Mount router + `initTable(chatPool)` |
| `backend/public/portal/shared/entity-status-panel.js` (new) | `window.EntityStatusPanel.{open,close,isOpen}`, self-injected styles, ESC close |
| `backend/public/portal/shared/entity-utils.js` | `attachAvatarClickHandler(container, onClick)` helper + stamp `data-entity-id` on canvas/img/emoji-span variants |
| `backend/public/portal/kanban.html` | Wire panel + helper (proof surface for P0) |

## Auth shape
Same as `/api/entities` — accepts `deviceId+deviceSecret` OR `deviceId+botSecret(+entityId)`. Cross-entity bots get observability without owning the deviceSecret.

## P1 follow-up (separate PR, per phasing in card spec)
- Operation log (Block 2) — chronological reverse + infinite scroll + smart chip + smart quote
- Counter increment hooks in chat / a2a / kanban-notify code paths (counters all start at 0 until then)
- Settings page avatar-change UX reuse
- Wire remaining 5-6 portal surfaces (mission, chat, settings, agent-card, card-holder, files) — one-liner per page

## Test plan
- [ ] DB: smoke `node -e \"const m=require('./backend/entity-status.js'); console.log(m.CANONICAL_AXES)\"` ✅ passed locally
- [ ] Module loads: `node -e \"require('./backend/index.js')\"` (full app boot)
- [ ] Playwright E2E once Railway deploys: 1280x800 + 390x844, click kanban assignee avatar → drawer opens with 4 axes at 0 → ESC closes
- [ ] Cross-entity API: bot #3's botSecret can call `/api/entity-status/2` and get counters

## Reviewer
Self-merge admin-bypass per Hank 2026-06-06 11:51 TW directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)