### PR TITLE
fix(portal): QA/UIUX automation backlog + plaza search freshness

### DIFF
--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -1082,6 +1082,7 @@
     let rateMin = 1;
     let rateMax = 50;
     let _rateDebounce = null;
+    let loadBotsRequestSeq = 0;
 
     /* ══════ API ══════ */
     async function apiFetch(path) {
@@ -1181,6 +1182,7 @@
     // Default: merge rental listings + community bots in one grid.
     // "出租" filter narrows to rental-only; other filters narrow to community-only.
     async function loadBots() {
+        const requestSeq = ++loadBotsRequestSeq;
         document.getElementById('loading').style.display = 'flex';
         try {
             const isRentalOnly = currentFilter === 'rental';
@@ -1246,13 +1248,17 @@
             }
 
             // 3. Merge: rental listings first (highlighted), then community
+            if (requestSeq !== loadBotsRequestSeq) return;
             allBots = [...rentalBots, ...communityBots];
             renderGrid(allBots);
         } catch (e) {
+            if (requestSeq !== loadBotsRequestSeq) return;
             console.error('loadBots:', e);
             document.getElementById('emptyState').style.display = 'block';
         } finally {
-            document.getElementById('loading').style.display = 'none';
+            if (requestSeq === loadBotsRequestSeq) {
+                document.getElementById('loading').style.display = 'none';
+            }
         }
     }
 

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -1380,16 +1380,27 @@
         // ── Automation filter state (per Hank 2026-06-06 16:57 TW card_bb89696b...) ──
         // Persisted in localStorage so each user's filter selection survives reload.
         const AUTO_FILTER_LS_KEY = 'kanban_auto_filter_v1';
-        const AUTO_FILTER_STATUSES = ['todo','in_progress','review','done','blocked'];
+        const AUTO_FILTER_STATUSES = ['backlog','todo','in_progress','review','done','blocked'];
+        const LEGACY_AUTO_FILTER_STATUSES = ['todo','in_progress','review','done','blocked'];
+        function normalizeAutoFilterStatuses(rawStatuses) {
+            if (!Array.isArray(rawStatuses) || !rawStatuses.length) {
+                return AUTO_FILTER_STATUSES;
+            }
+            const known = rawStatuses.filter(s => AUTO_FILTER_STATUSES.includes(s));
+            // PR #3203 initially shipped without `backlog`. Users who loaded that
+            // build can have the old full-default set persisted; migrate that set
+            // so backlog automations remain visible by default after the fix.
+            const isLegacyFullDefault = LEGACY_AUTO_FILTER_STATUSES.every(s => known.includes(s))
+                && !known.includes('backlog');
+            return isLegacyFullDefault ? ['backlog', ...known] : known;
+        }
         const autoFilterState = (() => {
             try {
                 const raw = JSON.parse(localStorage.getItem(AUTO_FILTER_LS_KEY) || '{}');
                 return {
                     search: typeof raw.search === 'string' ? raw.search : '',
                     entities: new Set(Array.isArray(raw.entities) ? raw.entities.map(Number) : []),
-                    statuses: new Set(Array.isArray(raw.statuses) && raw.statuses.length
-                        ? raw.statuses.filter(s => AUTO_FILTER_STATUSES.includes(s))
-                        : AUTO_FILTER_STATUSES),
+                    statuses: new Set(normalizeAutoFilterStatuses(raw.statuses)),
                 };
             } catch {
                 return { search: '', entities: new Set(), statuses: new Set(AUTO_FILTER_STATUSES) };
@@ -1410,7 +1421,7 @@
             const hasEntityFilter = autoFilterState.entities.size > 0;
             const statuses = autoFilterState.statuses;
             return cards.filter(c => {
-                // Status chip filter — empty set means show none, full default set means show all 5.
+                // Status chip filter — empty set means show none, full default set means show all board statuses.
                 if (statuses.size > 0 && !statuses.has(c.status)) return false;
                 // Entity filter — empty set = show all (per spec: '沒勾選 → 顯示全部').
                 if (hasEntityFilter) {

--- a/backend/tests/jest/qa-uiux-20260606-regressions.test.js
+++ b/backend/tests/jest/qa-uiux-20260606-regressions.test.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const kanbanHtml = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'kanban.html'), 'utf8');
+const communityHtml = fs.readFileSync(path.join(ROOT, 'public', 'portal', 'community.html'), 'utf8');
+
+describe('QA/UIUX 2026-06-06 regression guards', () => {
+    test('kanban automation status filter includes Backlog and migrates the legacy 5-status default', () => {
+        expect(kanbanHtml).toContain("const AUTO_FILTER_STATUSES = ['backlog','todo','in_progress','review','done','blocked'];");
+        expect(kanbanHtml).toContain('const LEGACY_AUTO_FILTER_STATUSES');
+        expect(kanbanHtml).toContain("return isLegacyFullDefault ? ['backlog', ...known] : known;");
+    });
+
+    test('Bot Plaza search ignores stale loadBots responses from older filter/search requests', () => {
+        expect(communityHtml).toContain('let loadBotsRequestSeq = 0;');
+        expect(communityHtml).toContain('const requestSeq = ++loadBotsRequestSeq;');
+        expect(communityHtml).toContain('if (requestSeq !== loadBotsRequestSeq) return;');
+        expect(communityHtml).toContain('if (requestSeq === loadBotsRequestSeq)');
+    });
+});


### PR DESCRIPTION
## Summary
- Restore Backlog as a first-class status in the kanban automation filter, including migration for the PR #3203 legacy 5-status localStorage default.
- Guard Bot Plaza `loadBots()` rendering so stale earlier search/filter responses cannot overwrite the current query results.
- Add static regression guards for both QA/UIUX findings.

Fixes #3204
Fixes #3205

## QA / Validation
- Production route matrix: 111 routes x desktop/mobile = 222 checks, 0 horizontal overflow, 0 page errors; auth-gated blanks rechecked as expected redirects to login.
- Focused Playwright pre-fix repro: Backlog automation hidden by default; no Backlog status chip.
- Focused Playwright post-fix: status chips include Backlog; grid shows both Backlog + Todo automation cards by default.
- Controlled Bot Plaza race post-fix: delayed stale initial response no longer overwrites `q=no-match`; final state stays count=0, empty=true, loading=none.
- `npx jest tests/jest/kanban-dispatch-mode-ux.test.js tests/jest/community-bot-focus.test.js tests/jest/community-ssr.test.js tests/jest/qa-uiux-20260606-regressions.test.js --runInBand` -> 4 suites / 27 tests passed.

## Notes
- The temporary QA worktree also has unrelated CRLF normalization noise from checkout; only the three intended files are staged/committed in this PR.