### PR TITLE
fix(portal): restore QA follow-up CI gates

### DIFF
--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -462638,6 +462638,13 @@ const TRANSLATIONS = {
 
 
         "kb_auto_title": "Automations",
+        "kb_auto_filter_search_ph": "Search title / description...",
+        "kb_auto_filter_entity": "Entity",
+        "kb_auto_filter_status": "Status",
+        "kb_auto_filter_all": "All",
+        "kb_auto_filter_invert": "Invert",
+        "kb_auto_filter_reset": "Reset",
+        "kb_auto_filter_empty_hint": "No entity selected - showing all automations.",
 
 
 
@@ -1082737,6 +1082744,13 @@ const TRANSLATIONS = {
 
 
         "kb_auto_title": "自動化任務",
+        "kb_auto_filter_search_ph": "搜尋標題 / 描述...",
+        "kb_auto_filter_entity": "實體",
+        "kb_auto_filter_status": "狀態",
+        "kb_auto_filter_all": "全選",
+        "kb_auto_filter_invert": "反選",
+        "kb_auto_filter_reset": "重設",
+        "kb_auto_filter_empty_hint": "未選擇實體 - 顯示所有自動化任務。",
 
 
 

--- a/backend/tests/jest/portal-entity-avatar-canvas-guard.test.js
+++ b/backend/tests/jest/portal-entity-avatar-canvas-guard.test.js
@@ -63,7 +63,7 @@ describe('renderAvatarHtml — canvas-vs-URL guard (Phase 0 dashboard bug fix)',
         expect(html).not.toContain('<canvas');
     });
 
-    test('emoji avatar still renders as text when no descriptor', () => {
+    test('emoji avatar still renders as clickable span when no descriptor', () => {
         const ctx = loadResolver();
         ctx.window.AvatarPetdx = {
             hasDescriptor: () => false,
@@ -72,7 +72,12 @@ describe('renderAvatarHtml — canvas-vs-URL guard (Phase 0 dashboard bug fix)',
         };
         ctx.updateEntityMaps([{ entityId: 1, character: 'LOBSTER', avatar: '🐱' }]);
         const html = ctx.renderAvatarHtml('🐱', 48, 1);
-        expect(html).toBe('🐱');
+        expect(html).toContain('<span');
+        expect(html).toContain('class="entity-avatar-emoji"');
+        expect(html).toContain('data-entity-id="1"');
+        expect(html).toContain('🐱');
+        expect(html).not.toContain('<canvas');
+        expect(html).not.toContain('<img');
     });
 
     test('_petdxCanRenderCanvas handles missing getDescriptor (older avatar-petdx)', () => {


### PR DESCRIPTION
## Summary
- Add the missing EN/ZH i18n keys used by the kanban automation filter labels/actions.
- Update the avatar canvas guard test to match current emoji avatar behavior: entity emoji avatars render as clickable spans for delegated status-panel clicks.

Fixes #3207

## QA / Validation
- `node scripts/i18n-check.js` -> EN references resolve; only existing soft fanout warnings remain.
- `npx jest tests/jest/portal-entity-avatar-canvas-guard.test.js tests/jest/qa-uiux-20260606-regressions.test.js --runInBand` -> 2 suites / 9 tests passed.
- `git diff --check -- backend/public/shared/i18n.js backend/tests/jest/portal-entity-avatar-canvas-guard.test.js` -> passed.

## Context
Follow-up from the daily QA/UIUX regression task after #3206 was reviewed and admin-merged; Backend CI then exposed these two gate issues.