### PR TITLE
feat(portal): wire entity status drawer to 5 remaining non-dashboard surfaces

### DIFF
--- a/backend/public/portal/card-holder.html
+++ b/backend/public/portal/card-holder.html
@@ -712,6 +712,7 @@
     <script src="../shared/petdx-renderer.js"></script>
     <script src="../shared/avatar-petdx.js"></script>
     <script src="shared/entity-utils.js"></script>
+    <script src="shared/entity-status-panel.js"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
@@ -753,6 +754,9 @@
         if (__isEmbedded) document.body.classList.add('embedded');
 
         window.addEventListener('DOMContentLoaded', async () => {
+            if (typeof attachAvatarClickHandler === 'function' && window.EntityStatusPanel) {
+                attachAvatarClickHandler(document.body, (eid) => window.EntityStatusPanel.open(eid));
+            }
             renderNav('card-holder');
             if (typeof renderFooter === 'function') renderFooter();
             const user = await checkAuth();

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3205,6 +3205,7 @@
     <script src="../shared/petdx-renderer.js"></script>
     <script src="../shared/avatar-petdx.js"></script>
     <script src="shared/entity-utils.js"></script>
+    <script src="shared/entity-status-panel.js"></script>
     <script src="shared/chat-source-category.js"></script>
     <script src="../shared/filter-summary.js"></script>
     <script src="shared/mention-autocomplete.js"></script>
@@ -3601,6 +3602,10 @@
             // Detect embed mode (workspace split view)
             if (new URLSearchParams(window.location.search).get('embed') === '1') {
                 document.body.classList.add('embed-mode');
+            }
+            // Avatar click → entity status drawer (per card_dbe18b333ac98076cc213055 P0.5).
+            if (typeof attachAvatarClickHandler === 'function' && window.EntityStatusPanel) {
+                attachAvatarClickHandler(document.body, (eid) => window.EntityStatusPanel.open(eid));
             }
 
             // Highlight current density button (value already applied pre-paint)

--- a/backend/public/portal/files.html
+++ b/backend/public/portal/files.html
@@ -687,6 +687,7 @@
     <script src="../shared/petdx-renderer.js"></script>
     <script src="../shared/avatar-petdx.js"></script>
     <script src="shared/entity-utils.js"></script>
+    <script src="shared/entity-status-panel.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>
     <script src="../shared/transition-overlay.js"></script>
@@ -807,6 +808,9 @@
 
         // --- Init ---
         window.addEventListener('DOMContentLoaded', async () => {
+            if (typeof attachAvatarClickHandler === 'function' && window.EntityStatusPanel) {
+                attachAvatarClickHandler(document.body, (eid) => window.EntityStatusPanel.open(eid));
+            }
             renderNav('files');
             if (typeof renderFooter === 'function') renderFooter();
             const user = await checkAuth();

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -1003,6 +1003,7 @@
     <script src="shared/nav.js"></script>
     <script src="shared/auth.js"></script>
     <script src="shared/entity-utils.js"></script>
+    <script src="shared/entity-status-panel.js"></script>
     <script src="../shared/petdx-renderer.js"></script>
     <script src="../shared/avatar-petdx.js"></script>
     <script src="../shared/telemetry.js"></script>
@@ -1251,6 +1252,9 @@
 
         window.addEventListener('DOMContentLoaded', async () => {
             try {
+            if (typeof attachAvatarClickHandler === 'function' && window.EntityStatusPanel) {
+                attachAvatarClickHandler(document.body, (eid) => window.EntityStatusPanel.open(eid));
+            }
             // Detect embed mode (workspace split view). Keep sub-tabs visible so
             // users can still reach env-vars / remote-control / publisher — those
             // are sub-pages of Mission and are not reachable from the workspace

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1568,6 +1568,7 @@
     <script src="../shared/petdx-renderer.js"></script>
     <script src="../shared/avatar-petdx.js"></script>
     <script src="shared/entity-utils.js"></script>
+    <script src="shared/entity-status-panel.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
     <script src="shared/product-tour.js"></script>
@@ -1582,6 +1583,9 @@
         // Initialization
         // ============================================
         window.addEventListener('DOMContentLoaded', async () => {
+            if (typeof attachAvatarClickHandler === 'function' && window.EntityStatusPanel) {
+                attachAvatarClickHandler(document.body, (eid) => window.EntityStatusPanel.open(eid));
+            }
             renderNav('settings');
             if (typeof renderFooter === 'function') renderFooter();
 


### PR DESCRIPTION
## Why
PR #3202 (avatar status drawer P0) only wired kanban.html as the proof surface. Hank caught this 2026-06-07 07:06 TW («為何我在聊天頁面按你實體大頭照沒有反應？»): chat.html, settings.html, mission.html, card-holder.html, files.html all render entity avatars but had no script tag + no DOMContentLoaded init, so clicks did nothing.

Card: card_dbe18b333ac98076cc213055

## Diff
5 files, +21 / -0. Two-line pattern per page:
1. `<script src="shared/entity-status-panel.js"></script>` right after `entity-utils.js`
2. `attachAvatarClickHandler(document.body, (eid) => window.EntityStatusPanel.open(eid))` at the top of the existing DOMContentLoaded init block (before renderNav so handler is live before any other interactive code).

## Intentionally skipped
- **dashboard.html** — owns the avatar-change UX (replacing the photo, per Hank's «除了儀表板(換照片)» original wording).
- **share-chat.html** — anonymous public page, no auth, status drawer would have no credentials to call `/api/entity-status/:eId`.

## Test plan
**Per new memory `feedback_e2e_post_deploy_real_url.md` (this morning's hard lesson):**
- [ ] Wait for Railway deploy to ship d52f32a → b4c19672
- [ ] Playwright navigate to **prod** `https://eclawbot.com/portal/chat.html` (real auth, real cookie), click an entity avatar in chat header → drawer opens with 4 counter axes
- [ ] Same on `settings.html` → entity binding row avatar → drawer opens
- [ ] Same on `mission.html` → note assignee avatar → drawer opens
- [ ] Same on `card-holder.html` → entity profile avatar → drawer opens
- [ ] Same on `files.html` → file ownership avatar → drawer opens
- [ ] Mobile 390x844 spot-check on chat + settings (the two most likely click surfaces)
- [ ] All screenshots uploaded **to the kanban card** via `POST /api/mission/card/:id/file`, not just sent via fakechat

Local mock harness explicitly NOT used this round (the lesson Hank just gave me).

## Reviewer
Self-merge admin-bypass per Hank 2026-06-06 11:51 TW directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)