### PR TITLE
fix(portal): avatar drawer cascade-reopen on internal click

### DIFF
--- a/backend/public/portal/shared/entity-status-panel.js
+++ b/backend/public/portal/shared/entity-status-panel.js
@@ -79,7 +79,11 @@
         root.setAttribute('role', 'dialog');
         root.setAttribute('aria-modal', 'true');
         root.setAttribute('aria-label', 'Entity status');
-        root.dataset.entityId = String(eid);
+        // Use targetEntityId (not data-entity-id) so the delegated
+        // attachAvatarClickHandler on document.body doesn't treat clicks inside
+        // the drawer — including the close button or scrim — as a fresh avatar
+        // click and re-open the drawer.
+        root.dataset.targetEntityId = String(eid);
         root.innerHTML = `
             <div class="${ROOT_CLASS}__scrim" data-action="close"></div>
             <div class="${ROOT_CLASS}__sheet">

--- a/backend/public/portal/shared/entity-utils.js
+++ b/backend/public/portal/shared/entity-utils.js
@@ -263,6 +263,11 @@ function getEntityLabelText(entityId) {
 function attachAvatarClickHandler(container, onClick) {
     if (!container || typeof onClick !== 'function') return null;
     const listener = (e) => {
+        // Belt-and-suspenders: ignore any click that originates inside the
+        // entity status drawer itself, regardless of what data-* attributes
+        // its content might happen to carry (close button, scrim, future chip
+        // rows in the P1 operation log section, etc.).
+        if (e.target.closest('.entity-status-panel')) return;
         const el = e.target.closest('[data-entity-id]');
         if (!el || !container.contains(el)) return;
         const eid = parseInt(el.dataset.entityId, 10);


### PR DESCRIPTION
## Bug
Hank reported (2026-06-07 07:59 TW web_chat):
1. Click avatar → drawer opens → click close button → closes → IMMEDIATELY re-opens
2. Click anything inside the drawer → drawer re-opens
3. Effectively the drawer can't be closed once opened

## Root cause
`buildDom()` set `root.dataset.entityId = String(eid)` on the drawer container for title labelling. The delegated `attachAvatarClickHandler` on document.body uses `e.target.closest('[data-entity-id]')` to detect avatar clicks. ANY click inside the drawer would bubble to document.body, `.closest()` would walk up the DOM tree, hit the drawer root carrying `data-entity-id`, and the handler treated it as a fresh avatar click → re-open.

Same cascade-click bug class as the help-icon label-activation fix (PR #3201, this morning). I shipped this pattern twice in one day — saving `feedback_pr_preflight_gates.md` was not enough; the lesson clearly needs to be «whatever overlay/modal I open, its internal click must not match my opener's delegated selector».

## Fix (two layers)
1. **entity-status-panel.js** — drawer root uses `data-target-entity-id` instead of `data-entity-id`, so `.closest('[data-entity-id]')` no longer matches it.
2. **entity-utils.js** — `attachAvatarClickHandler` short-circuits if click target is inside `.entity-status-panel`. Belt-and-suspenders against future descendant chips (P1 operation log card_id chips) that legitimately carry `data-entity-id`.

## Out of this PR (P1 follow-up)
Hank also flagged spec gaps: time timestamp not shown, operation log section enumeration not present, card_id chip highlighting + smart quote missing. Those are all P1 (Block 2 + interactions). Will ship in a single P1 PR (no further split) immediately after this hotfix lands + verifies.

## Test plan
- [ ] Wait for Railway deploy
- [ ] Real Playwright on prod chat.html: click avatar → drawer opens → click close button → drawer closes and STAYS closed
- [ ] Click various spots inside drawer (header, counter rows, body padding) → drawer stays open (no re-open)
- [ ] Click outside drawer (different avatar) → that drawer opens with the new entity
- [ ] Screenshots uploaded to card via `/file` (compressed jpg, /file 413's PNG)

## Reviewer
Self-merge admin-bypass per Hank 2026-06-06 11:51 TW directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)