### PR TITLE
feat(portal): avatar status drawer P1 — operation log + chip + quote

### DIFF
--- a/backend/entity-status.js
+++ b/backend/entity-status.js
@@ -1,12 +1,14 @@
 // ============================================
 // Entity Status Module
-// Per-entity cumulative error counters surfaced in the avatar status drawer.
+// Per-entity cumulative error counters + operation log + quote payload,
+// surfaced in the avatar status drawer.
 // Auth: same shape as /api/entities — deviceId+deviceSecret OR deviceId+botSecret
 // (cross-entity observation per Hank 2026-06-06 19:55 TW directive).
 //
-// P0 scope (card_dbe18b333ac98076cc213055):
-//   GET /api/entity-status/:eId → { counters: [{axis,count,lastEventAt}] }
-// P1 (separate PR): operation log section, smart chip, smart quote.
+// Endpoints (card_dbe18b333ac98076cc213055):
+//   GET  /api/entity-status/:eId           → { counters }
+//   GET  /api/entity-status/:eId/log       → { items: [...], nextCursor }
+//   POST /api/entity-status/:eId/quote     → { quote: {...} } for chat-textbox inject
 // ============================================
 
 const express = require('express');
@@ -38,7 +40,97 @@ function initTable(chatPool) {
         );
         CREATE INDEX IF NOT EXISTS idx_eec_lookup
             ON entity_error_counters(device_id, entity_id);
+
+        CREATE TABLE IF NOT EXISTS entity_operation_log (
+            id BIGSERIAL PRIMARY KEY,
+            device_id VARCHAR(64) NOT NULL,
+            entity_id INT NOT NULL,
+            event_type VARCHAR(64) NOT NULL,
+            event_summary TEXT NOT NULL,
+            event_payload JSONB DEFAULT '{}'::jsonb,
+            occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        CREATE INDEX IF NOT EXISTS idx_eol_lookup
+            ON entity_operation_log(device_id, entity_id, occurred_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_eol_event_type
+            ON entity_operation_log(device_id, entity_id, event_type, occurred_at DESC);
     `);
+}
+
+// Best-effort fire-and-forget insert into entity_operation_log. Callers should
+// NOT await this on the request hot path — every kanban/chat/dashboard write
+// would slow down by a synchronous DB round-trip otherwise.
+async function logOperation(deviceId, entityId, eventType, eventSummary, eventPayload) {
+    if (!pool || deviceId == null || entityId == null) return;
+    try {
+        await pool.query(
+            `INSERT INTO entity_operation_log
+                (device_id, entity_id, event_type, event_summary, event_payload)
+             VALUES ($1, $2, $3, $4, $5::jsonb)`,
+            [
+                String(deviceId).slice(0, 64),
+                Number(entityId),
+                String(eventType || 'other').slice(0, 64),
+                String(eventSummary || '').slice(0, 2048),
+                JSON.stringify(eventPayload || {}),
+            ]
+        );
+    } catch (err) {
+        console.error('[EntityStatus] logOperation error:', err.message);
+    }
+}
+
+async function getOperationLog(deviceId, entityId, opts) {
+    if (!pool) return { items: [], nextCursor: null };
+    opts = opts || {};
+    const limit = Math.min(Math.max(parseInt(opts.limit) || 20, 1), 100);
+    const beforeId = parseInt(opts.beforeId) || null;
+    const params = [deviceId, entityId];
+    let cursorClause = '';
+    if (beforeId) {
+        params.push(beforeId);
+        cursorClause = `AND id < $${params.length}`;
+    }
+    params.push(limit);
+    const result = await pool.query(
+        `SELECT id, event_type, event_summary, event_payload, occurred_at
+           FROM entity_operation_log
+          WHERE device_id = $1 AND entity_id = $2
+          ${cursorClause}
+          ORDER BY id DESC
+          LIMIT $${params.length}`,
+        params
+    );
+    const items = result.rows.map(r => ({
+        id: String(r.id),
+        eventType: r.event_type,
+        eventSummary: r.event_summary,
+        eventPayload: r.event_payload || {},
+        occurredAt: r.occurred_at ? r.occurred_at.toISOString() : null,
+    }));
+    return {
+        items,
+        nextCursor: items.length === limit ? items[items.length - 1].id : null,
+    };
+}
+
+async function getLogRowById(deviceId, entityId, logId) {
+    if (!pool) return null;
+    const result = await pool.query(
+        `SELECT id, event_type, event_summary, event_payload, occurred_at
+           FROM entity_operation_log
+          WHERE device_id = $1 AND entity_id = $2 AND id = $3`,
+        [deviceId, entityId, logId]
+    );
+    if (!result.rows.length) return null;
+    const r = result.rows[0];
+    return {
+        id: String(r.id),
+        eventType: r.event_type,
+        eventSummary: r.event_summary,
+        eventPayload: r.event_payload || {},
+        occurredAt: r.occurred_at ? r.occurred_at.toISOString() : null,
+    };
 }
 
 function bindDevicesRef(devices) {
@@ -139,11 +231,81 @@ router.get('/:eId', async (req, res) => {
     }
 });
 
+router.get('/:eId/log', express.json(), async (req, res) => {
+    const auth = authDeviceOrBot(req);
+    if (!auth) {
+        return res.status(403).json({ success: false, error: 'Invalid credentials' });
+    }
+    const targetEId = parseInt(req.params.eId);
+    if (!Number.isFinite(targetEId) || targetEId < 0) {
+        return res.status(400).json({ success: false, error: 'Invalid entityId' });
+    }
+    try {
+        const data = await getOperationLog(auth.deviceId, targetEId, {
+            limit: req.query.limit,
+            beforeId: req.query.before,
+        });
+        res.json({
+            success: true,
+            deviceId: auth.deviceId,
+            entityId: targetEId,
+            items: data.items,
+            nextCursor: data.nextCursor,
+        });
+    } catch (err) {
+        console.error('[EntityStatus] getOperationLog error:', err.message);
+        res.status(500).json({ success: false, error: 'internal' });
+    }
+});
+
+router.post('/:eId/quote', express.json(), async (req, res) => {
+    const auth = authDeviceOrBot(req);
+    if (!auth) {
+        return res.status(403).json({ success: false, error: 'Invalid credentials' });
+    }
+    const targetEId = parseInt(req.params.eId);
+    if (!Number.isFinite(targetEId) || targetEId < 0) {
+        return res.status(400).json({ success: false, error: 'Invalid entityId' });
+    }
+    const logId = parseInt(req.body && req.body.logId);
+    if (!Number.isFinite(logId) || logId <= 0) {
+        return res.status(400).json({ success: false, error: 'logId required' });
+    }
+    try {
+        const row = await getLogRowById(auth.deviceId, targetEId, logId);
+        if (!row) {
+            return res.status(404).json({ success: false, error: 'log row not found' });
+        }
+        // Build a chat-paste-ready quote: a header line + the original summary.
+        // Frontend uses this as the prefix for the user's reply text.
+        const ts = row.occurredAt ? row.occurredAt.replace('T', ' ').replace(/\.\d+Z$/, ' UTC') : '';
+        const quoteText = `> [Entity #${targetEId} ${ts}] ${row.eventSummary}\n> (event: ${row.eventType}${row.eventPayload && row.eventPayload.card_id ? ', card: ' + row.eventPayload.card_id : ''})\n\n`;
+        res.json({
+            success: true,
+            quote: {
+                logId: row.id,
+                entityId: targetEId,
+                eventType: row.eventType,
+                eventSummary: row.eventSummary,
+                occurredAt: row.occurredAt,
+                text: quoteText,
+                payload: row.eventPayload,
+            },
+        });
+    } catch (err) {
+        console.error('[EntityStatus] quote error:', err.message);
+        res.status(500).json({ success: false, error: 'internal' });
+    }
+});
+
 module.exports = {
     initTable,
     bindDevicesRef,
     getCounters,
     incrementCounter,
+    logOperation,
+    getOperationLog,
+    getLogRowById,
     router,
     CANONICAL_AXES,
 };

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -951,6 +951,26 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                 try { await awardEntityXP(deviceId, createdBy, 10); } catch (e) { /* ignore */ }
             }
 
+            // P1: log operation for entity status drawer block 2.
+            // One row per assigned entity so each can see this in their own log.
+            try {
+                const entityStatus = require('./entity-status');
+                for (const botId of bots) {
+                    entityStatus.logOperation(
+                        deviceId, botId, 'card_create',
+                        `Created task card #${card.id} (${(card.title || '').slice(0, 60)})`,
+                        { card_id: card.id, title: card.title, priority: card.priority, status: card.status }
+                    );
+                }
+                if (createdBy && !bots.includes(createdBy)) {
+                    entityStatus.logOperation(
+                        deviceId, createdBy, 'card_create',
+                        `Created task card #${card.id} (${(card.title || '').slice(0, 60)})`,
+                        { card_id: card.id, title: card.title, priority: card.priority, status: card.status }
+                    );
+                }
+            } catch (e) { /* fire-and-forget */ }
+
             res.json({ success: true, card });
         } catch (err) {
             console.error('[Kanban] Create card error:', err);
@@ -1845,6 +1865,20 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             await addSystemComment(cardId, deviceId, '🗄️ 卡片已歸檔');
             await bumpVersion(deviceId);
 
+            // P1: log operation for entity status drawer
+            try {
+                const entityStatus = require('./entity-status');
+                const archivedCard = result.rows[0] || {};
+                const bots = Array.isArray(archivedCard.assigned_bots) ? archivedCard.assigned_bots : [];
+                for (const botId of bots) {
+                    entityStatus.logOperation(
+                        deviceId, Number(botId), 'card_delete',
+                        `Archived card #${archivedCard.id} (${(archivedCard.title || '').slice(0, 50)})`,
+                        { card_id: archivedCard.id, title: archivedCard.title }
+                    );
+                }
+            } catch (e) { /* fire-and-forget */ }
+
             res.json({ success: true, message: 'Card archived' });
         } catch (err) {
             console.error('[Kanban] Archive card error:', err);
@@ -2078,6 +2112,19 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                     console.error(`[Kanban] Failed to update parent card ${card.parent_card_id}:`, parentErr.message);
                 }
             }
+
+            // P1: log operation for entity status drawer
+            try {
+                const entityStatus = require('./entity-status');
+                const bots = Array.isArray(updatedCard.assignedBots) ? updatedCard.assignedBots : [];
+                for (const botId of bots) {
+                    entityStatus.logOperation(
+                        deviceId, Number(botId), 'card_status',
+                        `Card #${updatedCard.id} status ${oldStatus} → ${newStatus} (${(updatedCard.title || '').slice(0, 50)})`,
+                        { card_id: updatedCard.id, title: updatedCard.title, status: newStatus, from: oldStatus }
+                    );
+                }
+            } catch (e) { /* fire-and-forget */ }
 
             res.json({ success: true, card: updatedCard, transition: { from: oldStatus, to: newStatus } });
         } catch (err) {

--- a/backend/migrations/20260607_entity_operation_log_p1.down.sql
+++ b/backend/migrations/20260607_entity_operation_log_p1.down.sql
@@ -1,0 +1,4 @@
+-- Down: 20260607_entity_operation_log_p1
+DROP INDEX IF EXISTS idx_eol_event_type;
+DROP INDEX IF EXISTS idx_eol_lookup;
+DROP TABLE IF EXISTS entity_operation_log;

--- a/backend/migrations/20260607_entity_operation_log_p1.up.sql
+++ b/backend/migrations/20260607_entity_operation_log_p1.up.sql
@@ -1,0 +1,25 @@
+-- Migration: 20260607_entity_operation_log_p1
+-- PR: [Feature/P1] Entity status panel — operation log + smart chip + smart quote
+-- Builds on 20260606_entity_status_panel_p0 (entity_error_counters).
+
+CREATE TABLE IF NOT EXISTS entity_operation_log (
+    id BIGSERIAL PRIMARY KEY,
+    device_id VARCHAR(64) NOT NULL,
+    entity_id INT NOT NULL,
+    event_type VARCHAR(64) NOT NULL,
+    event_summary TEXT NOT NULL,
+    event_payload JSONB DEFAULT '{}'::jsonb,
+    occurred_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_eol_lookup
+    ON entity_operation_log(device_id, entity_id, occurred_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_eol_event_type
+    ON entity_operation_log(device_id, entity_id, event_type, occurred_at DESC);
+
+COMMENT ON TABLE entity_operation_log IS
+    'Chronological log of operations performed by/affecting an entity. Surfaced in the entity status drawer block 2. '
+    'event_type values: card_create | card_edit | card_status | card_delete | msg_received | a2a_received | system_msg | dashboard_op | counter_inc | other. '
+    'event_summary is the human-readable 1-line description shown in the UI list. '
+    'event_payload carries full structured context (card_id, sender_entity_id, msg excerpt, etc.) used by chip render + quote injection.';

--- a/backend/public/portal/shared/entity-status-panel.js
+++ b/backend/public/portal/shared/entity-status-panel.js
@@ -36,6 +36,17 @@
 
     let rootEl = null;
     let currentEid = null;
+    let logCursor = null;        // pagination cursor for /log endpoint
+    let logLoading = false;
+    let logScrollObserver = null;
+    const STATUS_COLOR = {
+        backlog:     '#9ca3af',
+        todo:        '#3b82f6',
+        in_progress: '#f59e0b',
+        review:      '#a855f7',
+        blocked:     '#ef4444',
+        done:        '#22c55e',
+    };
 
     function pickLabel(axis) {
         const lang = (document.documentElement.getAttribute('lang') || 'en').toLowerCase();
@@ -57,7 +68,7 @@
         };
     }
 
-    async function fetchStatus(eid) {
+    function _credQs() {
         const c = readCreds();
         const qs = new URLSearchParams();
         if (c.deviceId) qs.set('deviceId', c.deviceId);
@@ -66,11 +77,170 @@
             qs.set('botSecret', c.botSecret);
             if (c.entityId) qs.set('entityId', String(c.entityId));
         }
+        return qs;
+    }
+
+    async function fetchStatus(eid) {
+        const qs = _credQs();
         const res = await fetch(`/api/entity-status/${eid}?${qs.toString()}`, {
             credentials: 'include',
         });
         if (!res.ok) throw new Error('HTTP ' + res.status);
         return res.json();
+    }
+
+    async function fetchLog(eid, before, limit) {
+        const qs = _credQs();
+        qs.set('limit', String(limit || 20));
+        if (before) qs.set('before', String(before));
+        const res = await fetch(`/api/entity-status/${eid}/log?${qs.toString()}`, {
+            credentials: 'include',
+        });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        return res.json();
+    }
+
+    async function fetchQuote(eid, logId) {
+        const c = readCreds();
+        const body = { logId: Number(logId) };
+        if (c.deviceId) body.deviceId = c.deviceId;
+        if (c.deviceSecret) body.deviceSecret = c.deviceSecret;
+        else if (c.botSecret) {
+            body.botSecret = c.botSecret;
+            if (c.entityId) body.entityId = Number(c.entityId);
+        }
+        const res = await fetch(`/api/entity-status/${eid}/quote`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+            credentials: 'include',
+        });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        return res.json();
+    }
+
+    function escapeHtml(s) {
+        return String(s || '').replace(/[&<>"']/g, (c) => ({
+            '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+        }[c]));
+    }
+
+    // Render event_summary text with card_xxxxxxxx tokens replaced by clickable
+    // status-colored chips. Status comes from event_payload.status if present.
+    function renderSummaryHtml(summary, payload) {
+        const text = escapeHtml(summary);
+        const payloadCardId = payload && payload.card_id;
+        const payloadStatus = (payload && payload.status) || null;
+        // Match card_<hex|alnum>{6,32} — covers card_71d075680e6e2c952fbc3ffe etc.
+        return text.replace(/(card_[a-zA-Z0-9]{6,32})|(#card_[a-zA-Z0-9]{6,32})/g, (match) => {
+            const cardId = match.replace(/^#/, '');
+            const status = (payloadCardId === cardId && payloadStatus) || 'todo';
+            const color = STATUS_COLOR[status] || STATUS_COLOR.todo;
+            return `<a class="${ROOT_CLASS}__chip" data-card-id="${escapeHtml(cardId)}" `
+                + `style="background:${color}22;border-color:${color};color:${color};" `
+                + `href="/portal/kanban.html?card=${encodeURIComponent(cardId)}" `
+                + `title="Open ${escapeHtml(cardId)}">${escapeHtml(cardId.slice(0, 12))}</a>`;
+        });
+    }
+
+    function formatTs(iso) {
+        if (!iso) return '';
+        const d = new Date(iso);
+        if (Number.isNaN(d.getTime())) return iso;
+        const pad = (n) => String(n).padStart(2, '0');
+        return `${pad(d.getMonth() + 1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`;
+    }
+
+    function renderLogRow(item) {
+        const ts = formatTs(item.occurredAt);
+        const summary = renderSummaryHtml(item.eventSummary, item.eventPayload);
+        return `
+            <li class="${ROOT_CLASS}__log-row" data-log-id="${escapeHtml(item.id)}" data-event-type="${escapeHtml(item.eventType)}">
+                <time class="${ROOT_CLASS}__log-time">${escapeHtml(ts)}</time>
+                <span class="${ROOT_CLASS}__log-summary">${summary}</span>
+                <button type="button" class="${ROOT_CLASS}__log-quote" data-action="quote"
+                    data-log-id="${escapeHtml(item.id)}" title="Quote this row">❝</button>
+            </li>`;
+    }
+
+    function appendLogRows(root, items) {
+        const list = root.querySelector('[data-role="log-list"]');
+        if (!list) return;
+        const sentinel = list.querySelector('[data-role="log-sentinel"]');
+        if (!items || !items.length) {
+            if (list.querySelector('[data-state="empty"]')) return;
+            if (!list.querySelector('[data-log-id]')) {
+                list.insertAdjacentHTML('afterbegin',
+                    `<li class="${ROOT_CLASS}__log-row" data-state="empty">No operations yet.</li>`);
+            }
+            if (sentinel) sentinel.style.display = 'none';
+            return;
+        }
+        const emptyMark = list.querySelector('[data-state="empty"]');
+        if (emptyMark) emptyMark.remove();
+        const html = items.map(renderLogRow).join('');
+        if (sentinel) sentinel.insertAdjacentHTML('beforebegin', html);
+        else list.insertAdjacentHTML('beforeend', html);
+    }
+
+    async function loadMoreLog(root, eid) {
+        if (logLoading) return;
+        if (logCursor === null && root.dataset.logFetchedOnce === '1') return;
+        logLoading = true;
+        try {
+            const data = await fetchLog(eid, logCursor, 20);
+            root.dataset.logFetchedOnce = '1';
+            appendLogRows(root, data.items || []);
+            logCursor = data.nextCursor || null;
+            const sentinel = root.querySelector('[data-role="log-sentinel"]');
+            if (sentinel && !logCursor) sentinel.style.display = 'none';
+        } catch (err) {
+            const list = root.querySelector('[data-role="log-list"]');
+            if (list && !list.querySelector('[data-state="error"]')) {
+                list.insertAdjacentHTML('beforeend',
+                    `<li class="${ROOT_CLASS}__log-row" data-state="error">Failed to load log: ${escapeHtml(err.message)}</li>`);
+            }
+        } finally {
+            logLoading = false;
+        }
+    }
+
+    function setupInfiniteScroll(root, eid) {
+        const sentinel = root.querySelector('[data-role="log-sentinel"]');
+        if (!sentinel || !('IntersectionObserver' in window)) return;
+        logScrollObserver = new IntersectionObserver((entries) => {
+            if (entries.some(e => e.isIntersecting)) loadMoreLog(root, eid);
+        }, { root: root.querySelector(`.${ROOT_CLASS}__sheet`), rootMargin: '120px' });
+        logScrollObserver.observe(sentinel);
+    }
+
+    async function handleQuoteClick(eid, logId) {
+        try {
+            const res = await fetchQuote(eid, logId);
+            if (!res.quote || !res.quote.text) return;
+            // Try common chat textbox selectors; degrade to clipboard if none found.
+            const targets = [
+                'textarea#chatInput', 'textarea#chat-input', '#chatTextarea',
+                'textarea[data-chat-input]', 'textarea[name="message"]',
+            ];
+            let pasted = false;
+            for (const sel of targets) {
+                const ta = document.querySelector(sel);
+                if (ta && typeof ta.value === 'string') {
+                    ta.value = res.quote.text + ta.value;
+                    ta.focus();
+                    try { ta.setSelectionRange(0, 0); } catch (_) { /* ok */ }
+                    pasted = true;
+                    break;
+                }
+            }
+            if (!pasted && navigator.clipboard && navigator.clipboard.writeText) {
+                await navigator.clipboard.writeText(res.quote.text);
+            }
+            close();
+        } catch (err) {
+            console.warn('[EntityStatusPanel] quote error:', err.message);
+        }
     }
 
     function buildDom(eid) {
@@ -97,15 +267,29 @@
                         <li class="${ROOT_CLASS}__counter-row" data-state="loading">Loading…</li>
                     </ul>
                 </section>
-                <section class="${ROOT_CLASS}__section ${ROOT_CLASS}__section--placeholder">
+                <section class="${ROOT_CLASS}__section" data-section="log">
                     <h3 class="${ROOT_CLASS}__section-title">操作 log / Operation log</h3>
-                    <p class="${ROOT_CLASS}__placeholder-note">P1 follow-up — see card_dbe18b333ac98076cc213055.</p>
+                    <ol class="${ROOT_CLASS}__log-list" data-role="log-list">
+                        <li class="${ROOT_CLASS}__log-row" data-state="loading">Loading…</li>
+                        <li class="${ROOT_CLASS}__log-sentinel" data-role="log-sentinel" aria-hidden="true"></li>
+                    </ol>
                 </section>
             </div>
         `;
         root.addEventListener('click', (e) => {
-            const action = e.target?.dataset?.action;
-            if (action === 'close') close();
+            const action = e.target?.dataset?.action || e.target?.closest('[data-action]')?.dataset?.action;
+            if (action === 'close') { close(); return; }
+            if (action === 'quote') {
+                const btn = e.target.closest('[data-action="quote"]');
+                const logId = btn && btn.dataset.logId;
+                if (logId) handleQuoteClick(eid, logId);
+                e.stopPropagation();
+                return;
+            }
+            // Card chip click: let default <a> navigation happen, just close drawer.
+            if (e.target.closest('.' + ROOT_CLASS + '__chip')) {
+                close();
+            }
         });
         return root;
     }
@@ -161,6 +345,27 @@
     background: rgba(108,99,255,0.12); padding: 2px 10px; border-radius: 999px; min-width: 32px;
     text-align: center; }
 .${ROOT_CLASS}__placeholder-note { font-size: 12px; color: var(--text-muted, #888); font-style: italic; }
+.${ROOT_CLASS}__log-list { list-style: none; margin: 0; padding: 0; }
+.${ROOT_CLASS}__log-row { display: grid; grid-template-columns: auto 1fr auto; gap: 8px;
+    align-items: start; padding: 8px 0; border-bottom: 1px dashed var(--card-border, #333);
+    font-size: 12.5px; line-height: 1.45; }
+.${ROOT_CLASS}__log-row[data-state="empty"], .${ROOT_CLASS}__log-row[data-state="loading"],
+.${ROOT_CLASS}__log-row[data-state="error"] {
+    grid-template-columns: 1fr; color: var(--text-muted, #888); font-style: italic;
+    text-align: center; padding: 16px 0; }
+.${ROOT_CLASS}__log-time { font-variant-numeric: tabular-nums; color: var(--text-muted, #888);
+    font-size: 11px; padding-top: 2px; }
+.${ROOT_CLASS}__log-summary { color: var(--text, #e0e0e0); word-break: break-word; }
+.${ROOT_CLASS}__log-quote { background: none; border: none; color: var(--text-muted, #888);
+    cursor: pointer; font-size: 13px; padding: 2px 6px; border-radius: 4px;
+    opacity: 0; transition: opacity 0.15s, color 0.15s; }
+.${ROOT_CLASS}__log-row:hover .${ROOT_CLASS}__log-quote { opacity: 1; }
+.${ROOT_CLASS}__log-quote:hover { color: var(--primary, #6c63ff); background: rgba(108,99,255,0.1); }
+.${ROOT_CLASS}__log-sentinel { padding: 0; border: none; height: 1px; }
+.${ROOT_CLASS}__chip { display: inline-block; font-size: 11px; padding: 1px 8px; margin: 0 2px;
+    border-radius: 999px; border: 1px solid transparent; text-decoration: none;
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace; vertical-align: baseline; }
+.${ROOT_CLASS}__chip:hover { filter: brightness(1.4); text-decoration: none; }
         `.trim();
         document.head.appendChild(style);
     }
@@ -191,15 +396,31 @@
                 list.innerHTML = `<li class="${ROOT_CLASS}__counter-row" data-state="error">Failed to load: ${err.message}</li>`;
             }
         }
+
+        // Initial log fetch + infinite scroll setup.
+        logCursor = null;
+        const logList = rootEl.querySelector('[data-role="log-list"]');
+        if (logList) {
+            // Clear "Loading…" placeholder before first paint.
+            logList.querySelectorAll('[data-state="loading"]').forEach(n => n.remove());
+        }
+        await loadMoreLog(rootEl, targetEid);
+        setupInfiniteScroll(rootEl, targetEid);
     }
 
     function close() {
         if (!rootEl) return;
         document.removeEventListener('keydown', _onEsc);
+        if (logScrollObserver) {
+            try { logScrollObserver.disconnect(); } catch (_) { /* ok */ }
+            logScrollObserver = null;
+        }
         rootEl.classList.remove(ROOT_CLASS + '--visible');
         const el = rootEl;
         rootEl = null;
         currentEid = null;
+        logCursor = null;
+        logLoading = false;
         setTimeout(() => { if (el.parentNode) el.parentNode.removeChild(el); }, 240);
     }
 


### PR DESCRIPTION
## Scope
Hank green-lit full P1 sprint at 2026-06-07 00:13 UTC «全部動工不要等我». Card: card_dbe18b333ac98076cc213055.

Ships the entire Block 2 of the entity status drawer feature: operation log + smart chip + smart quote + infinite scroll + backend table + kanban hooks.

## Diff (5 files, +468 / -9)
- `backend/migrations/20260607_entity_operation_log_p1.up/down.sql` — new `entity_operation_log` table + 2 indexes
- `backend/entity-status.js` — `logOperation()` / `getOperationLog()` / `getLogRowById()` + GET /log + POST /quote
- `backend/kanban.js` — fire `logOperation` on card create / move / archive
- `backend/public/portal/shared/entity-status-panel.js` — log section render + card_id chip with status color + quote ❝ button + IntersectionObserver infinite scroll + paste-to-chat-textarea quote target with clipboard fallback

## Out of scope (P2)
- Counter increment hooks (chat / a2a / kanban-nudge no-reply paths). Drawer + table wired; flipping the hooks later is additive.
- Dashboard avatar-picker extraction for settings reuse. Orthogonal refactor.

## Test plan (real prod E2E per `feedback_e2e_post_deploy_real_url.md`)
- [ ] Wait for Railway deploy
- [ ] Click avatar on chat.html → drawer shows: 4 counter rows + log list with real kanban activity (today's many card creates/moves), each card_xxx as colored chip + quote ❝ button
- [ ] Click a card chip → navigate to /portal/kanban.html?card=<id>
- [ ] Click quote ❝ → quote text pasted into chat textarea + drawer closes
- [ ] Scroll log list to bottom → IntersectionObserver fires → next 20 rows load
- [ ] Click close button → drawer stays closed (no cascade reopen, fix from PR #3210)
- [ ] Mobile 390x844 layout intact
- [ ] Screenshots uploaded to card `/file` (jpg compressed)

## Reviewer
Self-merge admin-bypass per Hank 2026-06-06 11:51 TW directive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)