### PR TITLE
fix(avatar-drawer): exclude entity-selector surfaces from avatar click

### DIFF
--- a/backend/public/portal/shared/entity-utils.js
+++ b/backend/public/portal/shared/entity-utils.js
@@ -268,6 +268,14 @@ function attachAvatarClickHandler(container, onClick) {
         // its content might happen to carry (close button, scrim, future chip
         // rows in the P1 operation log section, etc.).
         if (e.target.closest('.entity-status-panel')) return;
+        // Entity-selector surfaces own the click — opening the status drawer
+        // here would steal the user's intent (pick this entity as a filter /
+        // target). The closest() walk catches both opt-in markers and the
+        // currently-known selector containers.
+        if (e.target.closest('[data-no-avatar-click]')) return;
+        if (e.target.closest('.entity-selector')) return;
+        if (e.target.closest('#entityFilters')) return;
+        if (e.target.closest('.kb-auto-filter')) return;
         const el = e.target.closest('[data-entity-id]');
         if (!el || !container.contains(el)) return;
         const eid = parseInt(el.dataset.entityId, 10);


### PR DESCRIPTION
## Summary
- Avatar click handler was opening the status drawer on clicks inside entity-selection UI (kanban auto-filter chips, files page entity filters, petdx dropdown), stealing the user's intent for those original features.
- Add `closest()` guards in `attachAvatarClickHandler` for `[data-no-avatar-click]`, `.entity-selector`, `#entityFilters`, `.kb-auto-filter`.

Reported by Hank in web_chat 2026-06-07 11:09 TW — fix #2 of 3 in the P2 follow-up card `card_605cb3799a30fe9874e6c7ad`. Remaining 2 fixes (chip → popover, quote → autolink token) will land in follow-up PRs.

## Test plan
- [x] Local diff inspection confirms guard ordering (before `[data-entity-id]` walk)
- [ ] Prod Playwright on kanban auto-filter chips, files page, petdx browser
- [ ] Confirm avatar click STILL fires on dashboard/chat/settings/mission/card-holder where it should

🤖 Generated with [Claude Code](https://claude.com/claude-code)