### PR TITLE
feat(entity-status): add aggregate counters endpoint

### DIFF
--- a/backend/entity-status.js
+++ b/backend/entity-status.js
@@ -208,6 +208,40 @@ function authDeviceOrBot(req) {
 
 const router = express.Router();
 
+// Aggregate counters across every entity bound on the caller's device.
+// Powers the avatar-drawer overview, dashboards, and cross-entity admin pages
+// without requiring callers to loop /:eId per entity.
+router.get('/', async (req, res) => {
+    const auth = authDeviceOrBot(req);
+    if (!auth) {
+        return res.status(403).json({ success: false, error: 'Invalid credentials' });
+    }
+    if (!pool || !devicesRef || !devicesRef[auth.deviceId]) {
+        return res.status(404).json({ success: false, error: 'device not found' });
+    }
+    try {
+        const entIds = Object.keys(devicesRef[auth.deviceId].entities || {})
+            .map(k => parseInt(k, 10))
+            .filter(n => Number.isFinite(n) && n >= 0)
+            .sort((a, b) => a - b);
+        const entities = [];
+        for (const eid of entIds) {
+            entities.push({
+                entityId: eid,
+                counters: await getCounters(auth.deviceId, eid),
+            });
+        }
+        res.json({
+            success: true,
+            deviceId: auth.deviceId,
+            entities,
+        });
+    } catch (err) {
+        console.error('[EntityStatus] aggregate getCounters error:', err.message);
+        res.status(500).json({ success: false, error: 'internal' });
+    }
+});
+
 router.get('/:eId', async (req, res) => {
     const auth = authDeviceOrBot(req);
     if (!auth) {


### PR DESCRIPTION
## Summary
- New `GET /api/entity-status` (no eId) returns counters across every entity bound on the caller's device — `{ entities: [{ entityId, counters: [...] }, ...] }`
- Powers the avatar-drawer cross-entity overview Hank asked about ("你現在可以查看其他實體 看其他實體的累計錯誤次數？"); the per-entity `/:eId` endpoint is preserved unchanged
- Auth reuses `authDeviceOrBot` so deviceSecret OR botSecret+entityId both work

Part of P1 card `card_134eb036d9036b7ec999f441`. Increment-hook (4 axes) lands in a separate PR.

## Test plan
- [ ] Curl prod `GET /api/entity-status?deviceId=...&botSecret=...&entityId=2` post-deploy → 200 + entities[] for #1/#2/#3/#4/#5/#6 with their counters (currently all 0, expected)
- [ ] Curl prod `GET /api/entity-status/3?deviceId=...&botSecret=...&entityId=2` → still works, single entity
- [ ] 403 path: bogus botSecret → 403 unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)