### PR TITLE
feat(kanban-nudge): increment counter on L2 escalation

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -3202,6 +3202,15 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             notifyEntities(card.device_id, recipients,
                 `⬆️ 卡片「${card.title}」停滯 ${elapsedHrs}h，已自動升級至 ${newPriority}`,
                 { cardId: card.id });
+            // Reaching L2 means the L1 nudges didn't move the card — credit each
+            // recipient with a kanban_nudge_no_reply tick so the avatar drawer
+            // counter surfaces unresponsive bots.
+            try {
+                const entityStatus = require('./entity-status');
+                for (const eid of recipients) {
+                    entityStatus.incrementCounter(card.device_id, eid, 'kanban_nudge_no_reply');
+                }
+            } catch (_) { /* fire-and-forget */ }
         }
         if (serverLog) serverLog('info', 'kanban', `[Stale] Card ${card.id} escalated ${card.priority}→${newPriority}`, { deviceId: card.device_id });
         return true;


### PR DESCRIPTION
## Summary
- When a kanban card hits Level-2 escalation, the L1 nudge cycle had no effect — assigned bots didn't move the card
- Tick each recipient's `kanban_nudge_no_reply` counter so the avatar status drawer (PR #3202 P0) surfaces which bots are persistently unresponsive
- Fire-and-forget pattern matches the existing `logOperation` calls — increment errors never block the escalation path

First of 4 axes in P1 card `card_134eb036d9036b7ec999f441`. Remaining 3 axes land in separate PRs.

## Test plan
- [ ] Prod (post-deploy): wait for next stale card to hit L2 → check `/api/entity-status/<recipientId>` shows counters[].axis="kanban_nudge_no_reply" count > 0
- [ ] Open avatar drawer on chat/settings → counter row shows the new tick

🤖 Generated with [Claude Code](https://claude.com/claude-code)