### PR TITLE
fix(avatar-drawer): card chips → autolink-chip popover + quote token

### DIFF
--- a/backend/public/portal/card-holder.html
+++ b/backend/public/portal/card-holder.html
@@ -712,6 +712,8 @@
     <script src="../shared/petdx-renderer.js"></script>
     <script src="../shared/avatar-petdx.js"></script>
     <script src="shared/entity-utils.js"></script>
+    <script src="shared/autolink-chip.js"></script>
+    <script src="shared/autolink-chip-preview.js"></script>
     <script src="shared/entity-status-panel.js"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
     <script src="../shared/telemetry.js"></script>

--- a/backend/public/portal/files.html
+++ b/backend/public/portal/files.html
@@ -687,6 +687,8 @@
     <script src="../shared/petdx-renderer.js"></script>
     <script src="../shared/avatar-petdx.js"></script>
     <script src="shared/entity-utils.js"></script>
+    <script src="shared/autolink-chip.js"></script>
+    <script src="shared/autolink-chip-preview.js"></script>
     <script src="shared/entity-status-panel.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="../shared/i18n.js"></script>

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -1003,6 +1003,8 @@
     <script src="shared/nav.js"></script>
     <script src="shared/auth.js"></script>
     <script src="shared/entity-utils.js"></script>
+    <script src="shared/autolink-chip.js"></script>
+    <script src="shared/autolink-chip-preview.js"></script>
     <script src="shared/entity-status-panel.js"></script>
     <script src="../shared/petdx-renderer.js"></script>
     <script src="../shared/avatar-petdx.js"></script>

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1568,6 +1568,8 @@
     <script src="../shared/petdx-renderer.js"></script>
     <script src="../shared/avatar-petdx.js"></script>
     <script src="shared/entity-utils.js"></script>
+    <script src="shared/autolink-chip.js"></script>
+    <script src="shared/autolink-chip-preview.js"></script>
     <script src="shared/entity-status-panel.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>

--- a/backend/public/portal/shared/entity-status-panel.js
+++ b/backend/public/portal/shared/entity-status-panel.js
@@ -125,8 +125,10 @@
         }[c]));
     }
 
-    // Render event_summary text with card_xxxxxxxx tokens replaced by clickable
-    // status-colored chips. Status comes from event_payload.status if present.
+    // Render event_summary text with card_xxxxxxxx tokens replaced by .autolink-chip
+    // spans so the existing AutolinkChipPreview popover system owns the click —
+    // popover (with "open full page →" inside) instead of full navigate. Status
+    // color comes from event_payload.status if present.
     function renderSummaryHtml(summary, payload) {
         const text = escapeHtml(summary);
         const payloadCardId = payload && payload.card_id;
@@ -136,10 +138,13 @@
             const cardId = match.replace(/^#/, '');
             const status = (payloadCardId === cardId && payloadStatus) || 'todo';
             const color = STATUS_COLOR[status] || STATUS_COLOR.todo;
-            return `<a class="${ROOT_CLASS}__chip" data-card-id="${escapeHtml(cardId)}" `
+            // .autolink-chip + data-ref-type/data-ref-id makes the document-level
+            // listener in autolink-chip-preview.js open the popover on click.
+            return `<span class="autolink-chip ${ROOT_CLASS}__chip" `
+                + `data-ref-type="card" data-ref-id="${escapeHtml(cardId)}" `
+                + `data-card-id="${escapeHtml(cardId)}" `
                 + `style="background:${color}22;border-color:${color};color:${color};" `
-                + `href="/portal/kanban.html?card=${encodeURIComponent(cardId)}" `
-                + `title="Open ${escapeHtml(cardId)}">${escapeHtml(cardId.slice(0, 12))}</a>`;
+                + `title="${escapeHtml(cardId)}">${escapeHtml(cardId.slice(0, 12))}</span>`;
         });
     }
 
@@ -217,25 +222,48 @@
     async function handleQuoteClick(eid, logId) {
         try {
             const res = await fetchQuote(eid, logId);
-            if (!res.quote || !res.quote.text) return;
-            // Try common chat textbox selectors; degrade to clipboard if none found.
-            const targets = [
-                'textarea#chatInput', 'textarea#chat-input', '#chatTextarea',
-                'textarea[data-chat-input]', 'textarea[name="message"]',
-            ];
-            let pasted = false;
-            for (const sel of targets) {
-                const ta = document.querySelector(sel);
-                if (ta && typeof ta.value === 'string') {
-                    ta.value = res.quote.text + ta.value;
-                    ta.focus();
-                    try { ta.setSelectionRange(0, 0); } catch (_) { /* ok */ }
-                    pasted = true;
-                    break;
-                }
+            if (!res.quote) return;
+            // Preferred path: insert a card_<id> token so the chat renderer
+            // turns it into the same .autolink-chip popover as every other
+            // quoted card on the platform — single quote style across the app
+            // instead of a free-form "> [Entity #X ...]" block.
+            const cardId = res.quote.payload && res.quote.payload.card_id;
+            const chatInput = document.getElementById('messageInput');
+            if (cardId && chatInput) {
+                const token = ' ' + cardId + ' ';
+                const cur = chatInput.value || '';
+                const pos = chatInput.selectionStart != null ? chatInput.selectionStart : cur.length;
+                chatInput.value = cur.slice(0, pos) + token + cur.slice(pos);
+                chatInput.focus();
+                const caret = pos + token.length;
+                try { chatInput.setSelectionRange(caret, caret); } catch (_) { /* ok */ }
+                chatInput.dispatchEvent(new Event('input', { bubbles: true }));
+                close();
+                return;
             }
-            if (!pasted && navigator.clipboard && navigator.clipboard.writeText) {
-                await navigator.clipboard.writeText(res.quote.text);
+            // Fallback for log rows without a card_id payload (msg/system/etc):
+            // legacy quote block — kept for parity with rows that don't have a
+            // chip token to lean on. Try common chat textbox selectors first;
+            // last-resort clipboard write.
+            if (res.quote.text) {
+                const targets = [
+                    'textarea#messageInput', 'textarea#chatInput', 'textarea#chat-input',
+                    '#chatTextarea', 'textarea[data-chat-input]', 'textarea[name="message"]',
+                ];
+                let pasted = false;
+                for (const sel of targets) {
+                    const ta = document.querySelector(sel);
+                    if (ta && typeof ta.value === 'string') {
+                        ta.value = res.quote.text + ta.value;
+                        ta.focus();
+                        try { ta.setSelectionRange(0, 0); } catch (_) { /* ok */ }
+                        pasted = true;
+                        break;
+                    }
+                }
+                if (!pasted && navigator.clipboard && navigator.clipboard.writeText) {
+                    await navigator.clipboard.writeText(res.quote.text);
+                }
             }
             close();
         } catch (err) {
@@ -286,9 +314,13 @@
                 e.stopPropagation();
                 return;
             }
-            // Card chip click: let default <a> navigation happen, just close drawer.
-            if (e.target.closest('.' + ROOT_CLASS + '__chip')) {
-                close();
+            // Card chip click: the chip is now a .autolink-chip span — let the
+            // global AutolinkChipPreview document listener open its popover
+            // (the popover has a "打開完整頁面 →" link to navigate). Stop
+            // propagation so the drawer's own click-outside-closes logic
+            // (if any) doesn't fire.
+            if (e.target.closest('.autolink-chip')) {
+                e.stopPropagation();
             }
         });
         return root;


### PR DESCRIPTION
## Summary
Closes Hank's 2026-06-07 11:09 TW feedback items #1 (quote 風格不一致) + #3 (chip 直接 nav 應改 popover).

- **Chip rendering**: `<a class="entity-status-panel__chip" href=...>` → `<span class="autolink-chip" data-ref-type="card" data-ref-id="...">`. The document-level listener in `autolink-chip-preview.js` already owns clicks on `.autolink-chip` and opens its popover (title / status / desc / last-2 comments + 📌 requote + "打開完整頁面 →" connector). No more full-page navigation — popover first, jump only on explicit connector tap.
- **Quote button**: prefers inserting a `card_<id>` token into `#messageInput` so the chat renderer turns it into the same `.autolink-chip` as every other smart-quote in the app. Drops the multi-line `> [Entity #X ts] summary` block for card rows. Fallback preserved for non-card log rows (a2a, system_msg, etc) that don't carry a `card_id` payload.
- **Script load**: settings / mission / card-holder / files now pull `autolink-chip.js` + `autolink-chip-preview.js` (kanban + chat already had them).
- Removes the chip→close-drawer handler; popover ownership is cleaner.

PR #3212 covered fix #2 (entity-selector exclusion guard) in the same card.

## Test plan
- [ ] Prod Playwright on each of 5 pages (chat / settings / mission / card-holder / files): open avatar drawer → click a card chip → popover appears (no navigation), title visible, "打開完整頁面 →" link works
- [ ] Click ❝ quote button on a card-payload log row → `#messageInput` gets `card_<id>` token; chat-message-render turns it into a chip
- [ ] Confirm autolink-chip-preview popover styling matches Hank's "現有彈跳式" expectation

🤖 Generated with [Claude Code](https://claude.com/claude-code)