### PR TITLE
feat(avatar-drawer): hook chat_no_reply + a2a_no_reply + system_msg_no_reply

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -18076,6 +18076,24 @@ async function pushToBot(entity, deviceId, eventType, payload, opts = {}) {
 
         const reasonCode = isAbort ? 'push_timeout' : err.message;
         entity.pushStatus = { ok: false, reason: reasonCode, at: Date.now() };
+        // Tick the matching no_reply axis for the avatar status drawer. We bucket
+        // by pushToBot eventType so the drawer surfaces *which* channel went
+        // silent (user chat vs bot-to-bot vs system probe). Fire-and-forget —
+        // a counter write must never mask the underlying push failure.
+        try {
+            const entityStatus = require('./entity-status');
+            let axis = 'chat_no_reply';
+            if (eventType === 'cross_device_message'
+                || eventType === 'entity_message'
+                || eventType === 'entity_broadcast') {
+                axis = 'a2a_no_reply';
+            } else if (eventType === 'system_message'
+                || eventType === 'model_healthcheck'
+                || eventType === 'kanban_nudge') {
+                axis = 'system_msg_no_reply';
+            }
+            entityStatus.incrementCounter(deviceId, entity.entityId, axis);
+        } catch (_) { /* ignore */ }
         return { pushed: false, reason: reasonCode };
     }
 }


### PR DESCRIPTION
## Summary
Closes the remaining 3 axes for `card_134eb036d9036b7ec999f441`. Single hook in `pushToBot`'s error path discriminates by `eventType`:

| eventType | Axis |
|---|---|
| `new_message` / default user push | `chat_no_reply` |
| `cross_device_message` / `entity_message` / `entity_broadcast` | `a2a_no_reply` |
| `system_message` / `model_healthcheck` / `kanban_nudge` | `system_msg_no_reply` |

Both `AbortError`/`TimeoutError` (push gateway didn't ACK within 15s) and hard webhook errors (`ENOTFOUND`/`ECONNREFUSED`/TLS) count as a no_reply tick — either way the recipient bot didn't deliver a response. Fire-and-forget; counter write never masks the underlying push failure.

With PR #3214 (kanban_nudge_no_reply on L2 escalation) already merged, all 4 axes from the P0 sprint now have at least one source of truth feeding them.

## Test plan
- [ ] Prod (post-deploy): trigger a known-bad push (bot offline / fake target) → check `/api/entity-status/<eId>` shows the relevant axis incremented from 0 → 1
- [ ] Open avatar drawer → counter row reflects the tick
- [ ] Aggregate endpoint `/api/entity-status` shows cross-entity counters

🤖 Generated with [Claude Code](https://claude.com/claude-code)