### PR TITLE
fix(roadmap): OODA-R intro line matches the 7-step list

### DIFF
--- a/backend/public/portal/roadmap.html
+++ b/backend/public/portal/roadmap.html
@@ -305,7 +305,7 @@
 
             <h3 style="font-size:14px;font-weight:700;margin:14px 0 8px;">🔁 Self-improvement loop — OODA-R framework</h3>
             <p style="font-size:13px;line-height:1.7;color:var(--text-secondary);margin-bottom:8px;">
-                Observe → Orient → Decide → Act → Reinforce. Each agent task produces an episode record that feeds a shared taxonomy; subsequent tasks query that store at preflight time so the same failures don't re-ship.
+                Observe → Orient → Retrieve → Decide → Act → Verify → Reinforce. Each agent task produces an episode record that feeds a shared taxonomy; subsequent tasks query that store at preflight time so the same failures don't re-ship.
             </p>
             <ol style="font-size:13px;line-height:1.7;padding-left:22px;margin-bottom:16px;">
                 <li><strong>Observe</strong>: every card emits an episode record (goal, type, deliverable, user-visible result, evidence, missed checks)</li>


### PR DESCRIPTION
## Summary
- Intro line read "Observe → Orient → Decide → Act → Reinforce" but the numbered list directly below has 7 steps including **Retrieve** and **Verify**.
- Updated intro to "Observe → Orient → Retrieve → Decide → Act → Verify → Reinforce" so the mnemonic matches.
- #6 (Codex) caught this on prod via Chrome Computer Use after PR #3217 deployed.

## Test plan
- [ ] Post-deploy reload roadmap.html → intro line + numbered list both contain Retrieve + Verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)