### PR TITLE
fix(showConfirm): default to 'Confirm' instead of 'OK' for danger flows

### DIFF
--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -117,7 +117,7 @@ function showConfirm({ message, title, confirmText, cancelText, danger, itemName
             <div class="dialog-body"><p id="${messageId}" style="margin:0;line-height:1.6;color:var(--text-secondary)">${_escHtml(message)}</p>${itemStrip}</div>
             <div class="dialog-actions">
                 <button type="button" class="btn btn-outline eclaw-confirm-cancel">${_escHtml(cancelText || t('dialog_cancel', 'Cancel'))}</button>
-                <button type="button" class="btn ${danger ? 'btn-danger' : 'btn-primary'} eclaw-confirm-ok"${danger && !confirmText ? ` aria-label="${_escAttr(t('dialog_confirm_destructive', 'Confirm destructive action'))}"` : ''}>${_escHtml(confirmText || t('dialog_ok', 'OK'))}</button>
+                <button type="button" class="btn ${danger ? 'btn-danger' : 'btn-primary'} eclaw-confirm-ok"${danger && !confirmText ? ` aria-label="${_escAttr(t('dialog_confirm_destructive', 'Confirm destructive action'))}"` : ''}>${_escHtml(confirmText || (danger ? t('dialog_confirm', 'Confirm') : t('dialog_ok', 'OK')))}</button>
             </div>
         </div>`;
         document.body.appendChild(overlay);


### PR DESCRIPTION
## Summary
- `showConfirm({danger:true})` without explicit `confirmText` rendered "OK" on the destructive red button — generic and contrary to Apple HIG / Material Design which call for action-specific verbs on destructive confirms.
- Danger branch now picks `dialog_confirm` (fallback: "Confirm"); non-danger keeps `dialog_ok` (fallback: "OK"). Existing callers passing explicit `confirmText` unchanged.
- Neither `dialog_confirm` nor `dialog_ok` exist as registered i18n keys today — both render via inline fallback. So no cross-locale i18n diff to ship.

Closes `card_0d2847b44b789afee249b3d7` (Phase 3 follow-up from this morning's destructive-modals daily E2E).

## Test plan
- [ ] Reload settings/kanban/mission, trigger any `showConfirm({danger:true})` path without explicit `confirmText` → button now reads "Confirm"
- [ ] Existing destructive callers that pass `confirmText` (delete-note etc) unchanged
- [ ] Non-danger confirms still read "OK"

🤖 Generated with [Claude Code](https://claude.com/claude-code)