### PR TITLE
fix(counters): track brain silence, not just push failure (Hank 14:00 TW)

### DIFF
--- a/backend/entity-status.js
+++ b/backend/entity-status.js
@@ -54,7 +54,163 @@ function initTable(chatPool) {
             ON entity_operation_log(device_id, entity_id, occurred_at DESC);
         CREATE INDEX IF NOT EXISTS idx_eol_event_type
             ON entity_operation_log(device_id, entity_id, event_type, occurred_at DESC);
+
+        CREATE TABLE IF NOT EXISTS outbound_msg_pending (
+            id BIGSERIAL PRIMARY KEY,
+            device_id VARCHAR(64) NOT NULL,
+            sender_entity_id INT NOT NULL,
+            recipient_entity_id INT NOT NULL,
+            event_type VARCHAR(64) NOT NULL,
+            axis VARCHAR(64) NOT NULL,
+            dispatched_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            expires_at TIMESTAMPTZ NOT NULL,
+            payload_snippet TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_omp_expires_at
+            ON outbound_msg_pending(expires_at);
+        CREATE INDEX IF NOT EXISTS idx_omp_match
+            ON outbound_msg_pending(device_id, sender_entity_id, recipient_entity_id, axis);
     `);
+}
+
+// Axis selection mirrors the buckets the drawer surfaces; pushToBot eventType
+// → which counter ticks when the recipient stays silent. Keep these in sync
+// with the legacy push-failure hook in backend/index.js — both should agree on
+// which axis a given eventType belongs to.
+function axisForEventType(eventType) {
+    if (eventType === 'cross_device_message'
+        || eventType === 'entity_message'
+        || eventType === 'entity_broadcast') return 'a2a_no_reply';
+    if (eventType === 'system_message'
+        || eventType === 'model_healthcheck'
+        || eventType === 'kanban_nudge') return 'system_msg_no_reply';
+    return 'chat_no_reply';
+}
+
+// Per-axis grace window before a pending row counts as unanswered. Tuned to
+// the rough p99 reply latency for each channel — chat users expect quick
+// turnaround; bot-to-bot routing through transform takes longer; system
+// probes are async by design.
+function expiryMsForAxis(axis) {
+    if (axis === 'chat_no_reply') return 90 * 1000;          // 90s
+    if (axis === 'a2a_no_reply') return 5 * 60 * 1000;       // 5 min
+    if (axis === 'system_msg_no_reply') return 10 * 60 * 1000; // 10 min
+    return 5 * 60 * 1000;
+}
+
+// Track an outbound message that succeeded at the push layer (HTTP 200). The
+// recipient still owes a reply within the axis-specific grace window; if it
+// arrives we delete the row (markReplyReceived), otherwise the sweeper ticks
+// the counter. Fire-and-forget — never await on the hot push path.
+async function trackOutbound(deviceId, senderEntityId, recipientEntityId, eventType, payloadSnippet) {
+    if (!pool || deviceId == null || recipientEntityId == null) return;
+    const axis = axisForEventType(eventType);
+    const expiryMs = expiryMsForAxis(axis);
+    try {
+        await pool.query(
+            `INSERT INTO outbound_msg_pending
+                (device_id, sender_entity_id, recipient_entity_id, event_type, axis, expires_at, payload_snippet)
+             VALUES ($1, $2, $3, $4, $5, NOW() + ($6 || ' milliseconds')::interval, $7)`,
+            [
+                String(deviceId).slice(0, 64),
+                Number(senderEntityId) || 0,
+                Number(recipientEntityId),
+                String(eventType || 'other').slice(0, 64),
+                axis,
+                String(expiryMs),
+                payloadSnippet ? String(payloadSnippet).slice(0, 240) : null,
+            ]
+        );
+    } catch (err) {
+        console.error('[EntityStatus] trackOutbound error:', err.message);
+    }
+}
+
+// Called when an incoming transform/speak from `senderEntityId` arrives. Match
+// the oldest pending row where the recipient (the bot that owed us a reply)
+// matches our incoming sender. Delete it so the sweeper doesn't tick.
+//
+// Heuristic: match by (device, recipient = incoming sender). Optional eventType
+// filter for same-channel matching; pass null to match any pending row.
+async function markReplyReceived(deviceId, replyFromEntityId, eventType) {
+    if (!pool || deviceId == null || replyFromEntityId == null) return 0;
+    try {
+        const params = [deviceId, Number(replyFromEntityId)];
+        let extra = '';
+        if (eventType) {
+            params.push(axisForEventType(eventType));
+            extra = `AND axis = $${params.length}`;
+        }
+        const result = await pool.query(
+            `DELETE FROM outbound_msg_pending
+              WHERE id IN (
+                SELECT id FROM outbound_msg_pending
+                 WHERE device_id = $1
+                   AND recipient_entity_id = $2
+                   ${extra}
+                 ORDER BY dispatched_at ASC
+                 LIMIT 1
+              )`,
+            params
+        );
+        return result.rowCount || 0;
+    } catch (err) {
+        console.error('[EntityStatus] markReplyReceived error:', err.message);
+        return 0;
+    }
+}
+
+// Sweeper: pick up every row whose expires_at has passed, tick the matching
+// counter, and remove the row. Runs once per minute on a setInterval registered
+// at bootstrap. Idempotent — the COUNT increment uses UPSERT, the DELETE
+// targets the exact ids we just promoted, so a duplicate run is a no-op.
+async function sweepExpired() {
+    if (!pool) return { tickedCount: 0 };
+    try {
+        const expired = await pool.query(
+            `SELECT id, device_id, recipient_entity_id, axis
+               FROM outbound_msg_pending
+              WHERE expires_at <= NOW()
+              LIMIT 500`
+        );
+        if (!expired.rows.length) return { tickedCount: 0 };
+        for (const row of expired.rows) {
+            try {
+                await pool.query(`
+                    INSERT INTO entity_error_counters (device_id, entity_id, axis, count, last_event_at)
+                    VALUES ($1, $2, $3, 1, NOW())
+                    ON CONFLICT (device_id, entity_id, axis) DO UPDATE
+                    SET count = entity_error_counters.count + 1,
+                        last_event_at = NOW(),
+                        updated_at = NOW()
+                `, [row.device_id, row.recipient_entity_id, row.axis]);
+            } catch (err) {
+                console.error('[EntityStatus] sweepExpired upsert error:', err.message);
+            }
+        }
+        const ids = expired.rows.map(r => r.id);
+        await pool.query(
+            `DELETE FROM outbound_msg_pending WHERE id = ANY($1::bigint[])`,
+            [ids]
+        );
+        return { tickedCount: ids.length };
+    } catch (err) {
+        console.error('[EntityStatus] sweepExpired error:', err.message);
+        return { tickedCount: 0 };
+    }
+}
+
+// Bootstrap the sweeper so the production process ticks counters without
+// needing an external cron. Returns the interval handle for tests that want
+// to stop it. Single-instance only — if multiple replicas come up, dedup later
+// with a row-level lock; today we run single-replica on Railway.
+function startSweeper(intervalMs) {
+    const ms = Math.max(15000, parseInt(intervalMs) || 60000);
+    return setInterval(() => {
+        sweepExpired().catch(err => {
+            console.error('[EntityStatus] sweep tick error:', err.message);
+        });
+    }, ms);
 }
 
 // Best-effort fire-and-forget insert into entity_operation_log. Callers should
@@ -337,6 +493,11 @@ module.exports = {
     bindDevicesRef,
     getCounters,
     incrementCounter,
+    axisForEventType,
+    trackOutbound,
+    markReplyReceived,
+    sweepExpired,
+    startSweeper,
     logOperation,
     getOperationLog,
     getLogRowById,

--- a/backend/index.js
+++ b/backend/index.js
@@ -8660,6 +8660,16 @@ app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
     if (!deviceId) {
         return res.status(400).json({ success: false, message: "deviceId required" });
     }
+    // The very act of an entity calling /api/transform means it produced a reply
+    // — clear any pending outbound row where this entity was the recipient that
+    // owed us an answer. Fire-and-forget: a stale row that survives this call
+    // will get caught by the sweeper in the next minute, so we never block.
+    if (entityId != null) {
+        try {
+            const entityStatus = require('./entity-status');
+            entityStatus.markReplyReceived(deviceId, entityId, null);
+        } catch (_) { /* ignore */ }
+    }
 
     // ── Dual-auth: channel key XOR botSecret ──
     const channelKey = req.headers['x-channel-key'];
@@ -18016,6 +18026,21 @@ async function pushToBot(entity, deviceId, eventType, payload, opts = {}) {
 
             if (entity.pendingRename) { entity.pendingRename = null; }
             entity.pushStatus = { ok: true, at: Date.now() };
+            // Track the outbound push so the brain-silence sweeper can tick the
+            // no_reply counter for this recipient if they don't reply in time.
+            // Fire-and-forget — the pushToBot hot path must not block on this.
+            try {
+                const entityStatus = require('./entity-status');
+                const senderEntityId = (payload && (payload.senderEntityId || payload.from_entity_id)) || 0;
+                const snippet = (payload && (payload.message || payload.text || payload.title)) || '';
+                entityStatus.trackOutbound(
+                    deviceId,
+                    senderEntityId,
+                    entity.entityId,
+                    eventType,
+                    typeof snippet === 'string' ? snippet : JSON.stringify(snippet).slice(0, 240)
+                );
+            } catch (_) { /* ignore */ }
             return { pushed: true };
         } else {
             const errorText = await response.text().catch(() => '');
@@ -18879,7 +18904,9 @@ feedbackModule.initFeedbackTable(chatPool);
 feedbackModule.initFeedbackPhotosTable(chatPool);
 notifModule.initNotificationTables(chatPool);
 devicePrefs.initTable(chatPool);
-entityStatus.initTable(chatPool).catch(err => console.error('[EntityStatus] initTable error:', err.message));
+entityStatus.initTable(chatPool)
+    .then(() => entityStatus.startSweeper(60_000))
+    .catch(err => console.error('[EntityStatus] initTable error:', err.message));
 orgChartModule.initTable(chatPool);
 crossDeviceSettings.initTable(chatPool);
 chatIntegrity.initIntegrityTable(chatPool);

--- a/backend/migrations/20260607_outbound_msg_pending_p0_fix.down.sql
+++ b/backend/migrations/20260607_outbound_msg_pending_p0_fix.down.sql
@@ -1,0 +1,4 @@
+-- Down: 20260607_outbound_msg_pending_p0_fix
+DROP INDEX IF EXISTS idx_omp_match;
+DROP INDEX IF EXISTS idx_omp_expires_at;
+DROP TABLE IF EXISTS outbound_msg_pending;

--- a/backend/migrations/20260607_outbound_msg_pending_p0_fix.up.sql
+++ b/backend/migrations/20260607_outbound_msg_pending_p0_fix.up.sql
@@ -1,0 +1,33 @@
+-- Migration: 20260607_outbound_msg_pending_p0_fix
+-- Outbound message tracking for the avatar status drawer's no_reply counters.
+-- Solves the semantic gap where the existing axes only ticked on push delivery
+-- failure (HTTP 4xx/5xx, AbortError) and missed the real case Hank flagged:
+-- push succeeded with HTTP 200 but the recipient bot never wrote a reply back.
+
+CREATE TABLE IF NOT EXISTS outbound_msg_pending (
+    id BIGSERIAL PRIMARY KEY,
+    device_id VARCHAR(64) NOT NULL,
+    sender_entity_id INT NOT NULL,
+    recipient_entity_id INT NOT NULL,
+    event_type VARCHAR(64) NOT NULL,
+    axis VARCHAR(64) NOT NULL,
+    dispatched_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ NOT NULL,
+    payload_snippet TEXT
+);
+
+-- Sweeper scans expired rows by axis; recipient_entity_id is the entity that
+-- gets credited with the no_reply tick when its row expires unmatched.
+CREATE INDEX IF NOT EXISTS idx_omp_expires_at
+    ON outbound_msg_pending(expires_at);
+
+-- Reply matching walks (device, recipient→sender, axis) so each incoming
+-- transform/speak can delete the matching pending row before it expires.
+CREATE INDEX IF NOT EXISTS idx_omp_match
+    ON outbound_msg_pending(device_id, sender_entity_id, recipient_entity_id, axis);
+
+COMMENT ON TABLE outbound_msg_pending IS
+    'Tracks outbound bot-to-bot / user-to-bot / system-to-bot messages that have not yet been answered. '
+    'Inserted by pushToBot on success. Deleted when the recipient writes a matching reply within expires_at. '
+    'Swept once per minute: expired-unmatched rows tick the entity_error_counters axis for the recipient. '
+    'Powers the avatar status drawer no_reply counters with the correct semantic (brain silence) instead of the previous push-failure-only signal.';


### PR DESCRIPTION
## Summary
Closes the semantic bug Hank caught at 14:00 TW: the no_reply counters in PR #3216 only fired on push-transport errors (4xx/5xx, AbortError). A `pushToBot` that returned HTTP 200 — webhook acked — but whose recipient bot never actually replied left the counter at 0.

The fix is a small outbound-tracking layer in `entity-status.js`:

1. **New `outbound_msg_pending` table**, indexed for two access patterns:
   - sweeping by `expires_at`
   - matching by `(device_id, sender_entity_id, recipient_entity_id, axis)`
2. **`trackOutbound(deviceId, sender, recipient, eventType, snippet)`** inserts a pending row with an axis-specific grace window: chat=90s, a2a=5min, system_msg=10min.
3. **`markReplyReceived(deviceId, replyFrom, eventType?)`** deletes the oldest matching pending row when the recipient writes anything back via `/api/transform`.
4. **`sweepExpired()`** runs once a minute (via `startSweeper` at bootstrap), ticks `entity_error_counters` for every row past `expires_at`, and deletes the swept ids.

Wire-in points:
- `pushToBot` success branch (line ~18018) → `trackOutbound` after HTTP 200 + non-error
- `/api/transform` handler entry → `markReplyReceived` for the incoming `entityId` (the bot that just produced a reply)
- `index.js` bootstrap → `startSweeper(60_000)`

`kanban_nudge_no_reply` already uses the L2-escalation proxy (PR #3214) which has correct brain-silence semantics, so it stays as-is.

Closes `card_83defc91e6b013cd9dfb9c66` (P0 bug filed at 14:03 TW).
Parent `card_134eb036d9036b7ec999f441` reopens for proper close-out.

## Test plan
- [ ] Post-deploy: dispatch a `/api/transform` to a bot with intentionally bad webhook (drops the message). Wait 5 minutes. Confirm `a2a_no_reply` for that recipient went from 0 → 1 via `GET /api/entity-status/<eId>`.
- [ ] Same dispatch, but bot replies within 5 min via `/api/transform`. Confirm counter stays at 0.
- [ ] Sweeper cron heartbeat: tail logs for `[EntityStatus] sweep tick` (none in normal flow; only error path logs).
- [ ] Avatar drawer renders the new non-zero count on chat/settings/mission/card-holder/files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)