### PR TITLE
fix(counters): also hook deliverToEntity for same-device routing

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -8595,6 +8595,27 @@ async function deliverToEntity(opts) {
         bindingType = bot ? bot.bot_type : null;
     }
 
+    // Track the routed message so the brain-silence sweeper can credit the
+    // recipient with an a2a_no_reply tick when they go silent past the grace
+    // window. We hook here (not only in pushToBot) because same-device
+    // routing skips the push layer entirely — the recipient consumes via
+    // polling/socket — and our P1 sprint missed this path. Fire-and-forget.
+    if (expectsReply) {
+        try {
+            const entityStatus = require('./entity-status');
+            const a2aEventType = isBroadcast ? 'entity_broadcast'
+                : isCrossDevice ? 'cross_device_message'
+                : 'entity_message';
+            entityStatus.trackOutbound(
+                targetDeviceId,
+                fromId,
+                toId,
+                a2aEventType,
+                typeof text === 'string' ? text.slice(0, 240) : ''
+            );
+        } catch (_) { /* ignore */ }
+    }
+
     return {
         entityId: toId,
         character: toEntity.character,


### PR DESCRIPTION
## Summary
PR #3221 hooked `trackOutbound` in `pushToBot`'s HTTP-200 success branch only. Same-device `/api/transform` routing skips `pushToBot` entirely — `deliverToEntity` writes to chat_history and enqueues for the recipient to poll/socket — so the pending row was never inserted for that path.

My own E2E verification proved this: #2 → #5 silent probe sat for 6 min with `a2a_no_reply` still at 0 because the row was never tracked.

Hook now also fires in `deliverToEntity` right before its return, with `eventType` chosen by broadcast/cross-device/same-device. Same fire-and-forget pattern; skipped when `expectsReply=false`.

## Test plan
- [ ] Post-deploy: dispatch silent probe `#2 → #5` (same-device, polling-only recipient). Wait 5+ min. Confirm `a2a_no_reply` for `#5` goes from 0 → 1.
- [ ] Same dispatch, but `#5` replies via `/api/transform` within 5 min → counter stays at 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)