### PR TITLE
fix(entity-status): JWT cookie session fallback (Hank 403)

### DIFF
--- a/backend/entity-status.js
+++ b/backend/entity-status.js
@@ -337,10 +337,29 @@ async function incrementCounter(deviceId, entityId, axis) {
 }
 
 function authDeviceOrBot(req) {
-    const deviceId = req.query.deviceId || req.body?.deviceId;
+    let deviceId = req.query.deviceId || req.body?.deviceId;
     const deviceSecret = req.query.deviceSecret || req.body?.deviceSecret;
     const botSecret = req.query.botSecret || req.body?.botSecret;
     const callerEntityId = parseInt(req.query.entityId || req.body?.entityId) || 0;
+
+    // Portal sessions hit this endpoint with a JWT cookie and no explicit
+    // device/bot secret in the query string. Mirror the same fallback used by
+    // /api/entities and friends so the avatar drawer doesn't 403 against
+    // logged-in users. The cookie carries the device the session is bound to.
+    if (!deviceId && req.cookies && req.cookies.eclaw_session) {
+        try {
+            const jwt = require('jsonwebtoken');
+            const decoded = jwt.verify(req.cookies.eclaw_session,
+                process.env.JWT_SECRET || '');
+            if (decoded && decoded.deviceId) {
+                deviceId = decoded.deviceId;
+                if (devicesRef && devicesRef[deviceId]) {
+                    return { deviceId, callerEntityId };
+                }
+            }
+        } catch (_) { /* invalid/expired token — fall through to the 403 */ }
+    }
+
     if (!deviceId || !devicesRef || !devicesRef[deviceId]) return null;
     const device = devicesRef[deviceId];
     if (deviceSecret && safeEqual(device.deviceSecret, deviceSecret)) {


### PR DESCRIPTION
## Summary
Hank's portal session opened the avatar drawer and got HTTP 403 on both `/api/entity-status/:eId` (counters) and `/api/entity-status/:eId/log`. Root cause: the drawer's `readCreds()` only sees `window.*` / localStorage values, which are empty on JWT-cookie sessions, so no query auth was sent.

Authorize via `eclaw_session` cookie as a fallback, mirroring the pattern already in `/api/entities` and friends. Cookie-only sessions can now load counters + operation log without exposing secrets to JS.

## Test plan
- [ ] Hank reload avatar drawer in current session → 200 OK, counters + log populate
- [ ] Existing query-string callers (this session's E2E probes) still work — fallback only fires when query auth absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)