### PR TITLE
fix(entity-status): share JWT_SECRET_FALLBACK so cookie auth actually works

### DIFF
--- a/backend/entity-status.js
+++ b/backend/entity-status.js
@@ -23,6 +23,12 @@ const CANONICAL_AXES = [
 
 let pool = null;
 let devicesRef = null;
+// Shared with index.js so we verify cookies against the same secret. Set via
+// bindJwtSecret() at bootstrap. Falling back to process.env.JWT_SECRET works
+// only when that env var is present (i.e. when the secret survives restarts);
+// without the explicit handoff, index.js may generate a per-process random
+// fallback that this module would never match.
+let jwtSecret = null;
 
 function initTable(chatPool) {
     pool = chatPool;
@@ -293,6 +299,14 @@ function bindDevicesRef(devices) {
     devicesRef = devices;
 }
 
+// Share the same JWT signing secret that index.js issues cookies with so
+// authDeviceOrBot can fall back to cookie auth for portal sessions. Without
+// this handoff, the env-only fallback fails whenever process.env.JWT_SECRET
+// is unset (each process generates its own random secret).
+function bindJwtSecret(secret) {
+    jwtSecret = secret || null;
+}
+
 async function getCounters(deviceId, entityId) {
     if (!pool) return [];
     const result = await pool.query(
@@ -350,7 +364,7 @@ function authDeviceOrBot(req) {
         try {
             const jwt = require('jsonwebtoken');
             const decoded = jwt.verify(req.cookies.eclaw_session,
-                process.env.JWT_SECRET || '');
+                jwtSecret || process.env.JWT_SECRET || '');
             if (decoded && decoded.deviceId) {
                 deviceId = decoded.deviceId;
                 if (devicesRef && devicesRef[deviceId]) {
@@ -552,6 +566,7 @@ router.post('/:eId/quote', express.json(), async (req, res) => {
 module.exports = {
     initTable,
     bindDevicesRef,
+    bindJwtSecret,
     getCounters,
     incrementCounter,
     axisForEventType,

--- a/backend/index.js
+++ b/backend/index.js
@@ -2258,6 +2258,7 @@ app.use('/api/publisher', articlePublisher.router);
 // ============================================
 const entityStatus = require('./entity-status');
 entityStatus.bindDevicesRef(devices);
+entityStatus.bindJwtSecret(JWT_SECRET_FALLBACK);
 app.use('/api/entity-status', entityStatus.router);
 
 // ============================================


### PR DESCRIPTION
PR #3224 was insufficient: my cookie verify in entity-status.js used `process.env.JWT_SECRET || ''` while index.js's signing secret falls back to `crypto.randomBytes(32)` when the env var is unset. Mismatched secrets → every valid cookie 403s.

Pass `JWT_SECRET_FALLBACK` into entity-status.js at bootstrap via new `bindJwtSecret()`. Both files now verify against the same key. Env var still wins when both are set; the handoff only matters when env is unset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)