### PR TITLE
feat(agent-improvement): OODA-R Phase 0 #1 — pain taxonomy + episode schema

### DIFF
--- a/backend/agent-improvement/__tests__/fixtures/episodes.js
+++ b/backend/agent-improvement/__tests__/fixtures/episodes.js
@@ -1,0 +1,162 @@
+// Sample episodes — one per painTag in PAIN_TAXONOMY.
+// These are REDACTED stand-ins drawn from the OODA-R kickoff (2026-06-07).
+// Real values for cardId / PR numbers / chat refs are kept; secret values are
+// deliberately omitted (never embedded inline). The redaction tests assert this.
+
+'use strict';
+
+/** @type {import('../../episode-schema').Episode[]} */
+const FIXTURES = [
+  {
+    cardId: 'card_47ed9a0c21dd507d3b726136',
+    entityId: 2,
+    taskType: 'feature_impl',
+    painTags: ['delivery_reliability'],
+    deliverable: 'offline delivery queue + reconnect replay',
+    userVisibleResult: 'pending — Phase 2 #5, not yet shipped',
+    evidence: [
+      { kind: 'card', ref: 'card_47ed9a0c21dd507d3b726136', note: 'Phase 2 #5 subcard' },
+      { kind: 'chat', ref: 'web_chat:2026-06-07T04:28+08:00', note: 'Hank: 一旦斷線訊息就被阻擋' },
+    ],
+    missedChecks: [
+      'no queue dedupe key tested under reconnect',
+      'no UI state surface for queued/retrying/sent/failed',
+    ],
+    userFeedback: '一旦斷線訊息就被阻擋',
+    severity: 'P1',
+    occurredAt: '2026-06-07T04:28:00+08:00',
+  },
+  {
+    cardId: 'card_214d48e395e812b3e909e5ca',
+    entityId: 2,
+    taskType: 'feature_impl',
+    painTags: ['auth_session'],
+    deliverable: 'auth/session persistence + refresh diagnostics',
+    userVisibleResult: 'pending — Phase 2 #6, silent re-login still happens',
+    evidence: [
+      { kind: 'card', ref: 'card_214d48e395e812b3e909e5ca', note: 'Phase 2 #6 subcard' },
+      { kind: 'chat', ref: 'web_chat:2026-06-07T04:28+08:00', note: 'Hank: 帳號莫名要重新登入' },
+    ],
+    missedChecks: [
+      'no refresh-token mutex',
+      'no 401 reason-code surface (silent kick instead of explicit prompt)',
+    ],
+    userFeedback: '帳號莫名要重新登入',
+    severity: 'P1',
+    occurredAt: '2026-06-07T04:28:00+08:00',
+  },
+  {
+    cardId: 'card_14571f26914b9c1eae148362',
+    entityId: 2,
+    taskType: 'feature_impl',
+    painTags: ['redirect_deeplink'],
+    deliverable: 'unified App/Web redirect state machine',
+    userVisibleResult: 'pending — Phase 2 #7, app↔web routing still inconsistent',
+    evidence: [
+      { kind: 'card', ref: 'card_14571f26914b9c1eae148362', note: 'Phase 2 #7 subcard' },
+      { kind: 'chat', ref: 'web_chat:2026-06-07T04:28+08:00', note: 'Hank: App 轉導不穩定 + Web 轉導也不盡人意' },
+    ],
+    missedChecks: [
+      'no canonical route contract across web/app/publicCode/cardId',
+      'no traceId on deep links — cannot diagnose where redirect dropped',
+    ],
+    userFeedback: 'App 轉導不穩定 / Web 轉導也不盡人意',
+    severity: 'P2',
+    occurredAt: '2026-06-07T04:28:00+08:00',
+  },
+  {
+    cardId: 'card_3041',
+    entityId: 2,
+    taskType: 'bugfix',
+    painTags: ['ux_feedback'],
+    deliverable: 'avatar status drawer no_reply counter',
+    userVisibleResult: 'counter stayed at 0 even when #1 silently dropped a2a message — semantic gap',
+    evidence: [
+      { kind: 'pr', ref: 'PR#3221' },
+      { kind: 'pr', ref: 'PR#3222', note: 'same-device deliverToEntity hook' },
+      { kind: 'chat', ref: 'web_chat:2026-06-07T06:00+08:00', note: 'Hank: 為何錯誤累計次數的a2a未回覆次數沒有增加' },
+    ],
+    missedChecks: [
+      'counter hook only covered push-failure not brain-silence',
+      'no E2E that sent a silent probe and asserted counter tick',
+    ],
+    userFeedback: '無法接受 Agent 犯這種低級錯誤',
+    severity: 'P0',
+    occurredAt: '2026-06-07T06:00:00+08:00',
+  },
+  {
+    cardId: 'card_5ac74610cbf1f89440427809',
+    entityId: 2,
+    taskType: 'spec_draft',
+    painTags: ['agent_ownership'],
+    deliverable: 'rule promotion engine + public roadmap tracker',
+    userVisibleResult: 'pending — Phase 4 #9, owner=#2 but execution slot not yet held',
+    evidence: [
+      { kind: 'card', ref: 'card_5ac74610cbf1f89440427809', note: 'Phase 4 #9 subcard' },
+      { kind: 'chat', ref: 'web_chat:2026-06-07T04:28+08:00', note: 'Hank: 任務偷懶 / 不知道自己該做甚麼' },
+    ],
+    missedChecks: [
+      'no auto-suggest when same taxonomy fires N times',
+      'roadmap.html is hard-coded — not pulled from kanban',
+    ],
+    severity: 'P2',
+    occurredAt: '2026-06-07T04:28:00+08:00',
+  },
+  {
+    cardId: 'card_50dccd356888b22d6654e85a',
+    entityId: 2,
+    taskType: 'feature_impl',
+    painTags: ['task_context'],
+    deliverable: 'task-start preflight lint (the PoC)',
+    userVisibleResult: 'pending — Phase 1 #3, blocked on this Phase 0 #1 finishing',
+    evidence: [
+      { kind: 'card', ref: 'card_50dccd356888b22d6654e85a', note: 'Phase 1 #3 subcard' },
+      { kind: 'comment', ref: 'preflight-comment-on-self-2026-06-07T17:13+08:00' },
+    ],
+    missedChecks: [
+      'no episode store to pull prior lessons from until Phase 0 #2 wires ingestion',
+    ],
+    severity: 'P0',
+    occurredAt: '2026-06-07T04:28:00+08:00',
+  },
+  {
+    cardId: 'card_42ffca0d29ce22b369d55ca4',
+    entityId: 2,
+    taskType: 'test_coverage',
+    painTags: ['test_coverage'],
+    deliverable: 'cross-surface E2E matrix for top workflows',
+    userVisibleResult: 'pending — Phase 3 #8, no required-check gate yet',
+    evidence: [
+      { kind: 'card', ref: 'card_42ffca0d29ce22b369d55ca4', note: 'Phase 3 #8 subcard' },
+      { kind: 'chat', ref: 'web_chat:2026-06-07T04:28+08:00', note: 'Hank: 測試沒完整' },
+    ],
+    missedChecks: [
+      'no matrix definition checked in',
+      'CI does not block PR merge on matrix failure',
+    ],
+    userFeedback: '測試沒完整',
+    severity: 'P1',
+    occurredAt: '2026-06-07T04:28:00+08:00',
+  },
+  {
+    cardId: 'card_337040389de34bcb65cf0cb0',
+    entityId: 2,
+    taskType: 'feature_impl',
+    painTags: ['scope_completeness'],
+    deliverable: 'done-evidence gate + anti-laziness guard',
+    userVisibleResult: 'pending — Phase 1 #4, silent-done antipattern still possible',
+    evidence: [
+      { kind: 'card', ref: 'card_337040389de34bcb65cf0cb0', note: 'Phase 1 #4 subcard' },
+      { kind: 'chat', ref: 'web_chat:2026-06-07T04:28+08:00', note: 'Hank: 用戶功能總是不能一次到位 還要修修改改' },
+    ],
+    missedChecks: [
+      'done transitions accept cards without evidence today',
+      'no in_progress >2h heartbeat prompt',
+    ],
+    userFeedback: '用戶功能總是不能一次到位 還要修修改改',
+    severity: 'P0',
+    occurredAt: '2026-06-07T04:28:00+08:00',
+  },
+];
+
+module.exports = FIXTURES;

--- a/backend/agent-improvement/episode-schema.js
+++ b/backend/agent-improvement/episode-schema.js
@@ -1,0 +1,186 @@
+// OODA-R Phase 0 #1 — Episode schema + pain taxonomy.
+// Card: card_e9de7607cd9a838462148328
+// Parent: card_be59aa034883fe36d3645a27
+//
+// An "episode" is one durable record of an agent task outcome that we can
+// later mine for preflight lessons (Phase 1 #3) and rule promotion (Phase 4 #9).
+// The taxonomy below is the closed set of pain categories every episode is
+// classified into; downstream consumers (preflight lint, dashboards, rule
+// promotion) read this constant — never hard-code their own copy.
+
+'use strict';
+
+/**
+ * Closed set of pain-category tags. Adding a tag is a roadmap-level decision;
+ * Phase 1 #3 preflight prompts pivot off these strings directly.
+ * @type {readonly string[]}
+ */
+const PAIN_TAXONOMY = Object.freeze([
+  'delivery_reliability',   // message delivery, offline queue, push failures
+  'auth_session',           // login persistence, token refresh, silent kicks
+  'redirect_deeplink',      // app↔web routing, universal links, deep links
+  'ux_feedback',            // user-visible feedback quality, delivery state surfacing
+  'agent_ownership',        // agent slacking off, unclear who-owns-what, handoff drops
+  'task_context',           // agent not knowing what to do, missing scope context
+  'test_coverage',          // missing/insufficient test cases, no E2E, mock-only
+  'scope_completeness',     // feature shipped partial / not-first-time-right
+]);
+
+const PAIN_TAXONOMY_SET = new Set(PAIN_TAXONOMY);
+
+/**
+ * Closed set of severity levels. Mirrors Kanban priority terminology.
+ * @type {readonly string[]}
+ */
+const SEVERITY_LEVELS = Object.freeze(['P0', 'P1', 'P2', 'P3']);
+const SEVERITY_SET = new Set(SEVERITY_LEVELS);
+
+/**
+ * @typedef {Object} EpisodeEvidence
+ * @property {string} kind       e.g. 'pr', 'screenshot', 'log', 'comment', 'chat'
+ * @property {string} ref        opaque pointer (URL, file path, PR number, chat msg id)
+ * @property {string} [note]     short human-readable description, no secrets
+ */
+
+/**
+ * @typedef {Object} Episode
+ * @property {string} cardId                 Kanban card id this episode is anchored to
+ * @property {number} entityId               EClaw entity that owned the task
+ * @property {string} taskType               short slug: e.g. 'pr_review', 'feature_impl', 'bugfix', 'spec_draft'
+ * @property {string[]} painTags             non-empty subset of PAIN_TAXONOMY
+ * @property {string} deliverable            one-line description of what was supposed to ship
+ * @property {string} userVisibleResult      one-line description of what the user actually saw
+ * @property {EpisodeEvidence[]} evidence    pointers to PRs / screenshots / logs (no inline secrets)
+ * @property {string[]} missedChecks         preflight items that should have caught this, in retrospect
+ * @property {string} [userFeedback]         redacted snippet of user-side correction, if any
+ * @property {('P0'|'P1'|'P2'|'P3')} severity
+ * @property {string} occurredAt             ISO-8601 timestamp
+ */
+
+/**
+ * Hex-32+ rule catches Railway tokens, raw bot secrets, db connection ids.
+ * The literal strings catch human-written secret labels even if the value is masked.
+ */
+const SECRET_PATTERNS = Object.freeze([
+  /\bbot[_-]?secret\b/i,
+  /\bdevice[_-]?secret\b/i,
+  /\bBearer\s+[A-Za-z0-9._\-]+/,
+  /\bsk-[A-Za-z0-9]{16,}/,
+  /\bRAILWAY_[A-Z_]+\s*[:=]/,
+  /\bJWT_SECRET[A-Z_]*\s*[:=]/,
+  /\bpassword\s*[:=]\s*\S+/i,
+  /\b[a-f0-9]{32,}\b/i,
+]);
+
+/**
+ * Scan a string for any secret-shaped substring. Returns the first matched
+ * pattern's source for easy error messages, or null when clean.
+ * @param {string} text
+ * @returns {string|null}
+ */
+function findSecret(text) {
+  if (typeof text !== 'string' || text.length === 0) return null;
+  for (const re of SECRET_PATTERNS) {
+    if (re.test(text)) return re.source;
+  }
+  return null;
+}
+
+/**
+ * Walk an Episode and assert no string field — including nested evidence
+ * fields — contains a secret-shaped substring. Throws on first hit.
+ * @param {Episode} ep
+ */
+function assertNoSecrets(ep) {
+  const visit = (val, path) => {
+    if (typeof val === 'string') {
+      const hit = findSecret(val);
+      if (hit) {
+        throw new Error(`episode contains secret-shaped substring at ${path}: pattern=${hit}`);
+      }
+    } else if (Array.isArray(val)) {
+      val.forEach((item, i) => visit(item, `${path}[${i}]`));
+    } else if (val && typeof val === 'object') {
+      for (const k of Object.keys(val)) visit(val[k], `${path}.${k}`);
+    }
+  };
+  visit(ep, 'episode');
+}
+
+/**
+ * Validate that an arbitrary object satisfies the Episode shape. Returns a
+ * list of validation errors; empty array means valid.
+ * @param {unknown} obj
+ * @returns {string[]}
+ */
+function validateEpisode(obj) {
+  const errs = [];
+  if (!obj || typeof obj !== 'object') {
+    return ['episode is not an object'];
+  }
+  const ep = /** @type {Record<string, unknown>} */ (obj);
+
+  const required = [
+    ['cardId', 'string'],
+    ['entityId', 'number'],
+    ['taskType', 'string'],
+    ['painTags', 'array'],
+    ['deliverable', 'string'],
+    ['userVisibleResult', 'string'],
+    ['evidence', 'array'],
+    ['missedChecks', 'array'],
+    ['severity', 'string'],
+    ['occurredAt', 'string'],
+  ];
+  for (const [field, kind] of required) {
+    const v = ep[field];
+    if (v === undefined || v === null) {
+      errs.push(`missing required field: ${field}`);
+      continue;
+    }
+    if (kind === 'array' && !Array.isArray(v)) errs.push(`${field} must be array`);
+    else if (kind !== 'array' && typeof v !== kind) errs.push(`${field} must be ${kind}`);
+  }
+
+  if (Array.isArray(ep.painTags)) {
+    if (ep.painTags.length === 0) errs.push('painTags must be non-empty');
+    for (const tag of ep.painTags) {
+      if (!PAIN_TAXONOMY_SET.has(tag)) errs.push(`painTags contains unknown tag: ${tag}`);
+    }
+  }
+
+  if (typeof ep.severity === 'string' && !SEVERITY_SET.has(ep.severity)) {
+    errs.push(`severity must be one of ${SEVERITY_LEVELS.join(',')}`);
+  }
+
+  if (typeof ep.occurredAt === 'string' && Number.isNaN(Date.parse(ep.occurredAt))) {
+    errs.push('occurredAt must be ISO-8601 parseable');
+  }
+
+  if (Array.isArray(ep.evidence)) {
+    ep.evidence.forEach((e, i) => {
+      if (!e || typeof e !== 'object') {
+        errs.push(`evidence[${i}] must be object`);
+        return;
+      }
+      if (typeof e.kind !== 'string') errs.push(`evidence[${i}].kind must be string`);
+      if (typeof e.ref !== 'string') errs.push(`evidence[${i}].ref must be string`);
+    });
+  }
+
+  if (typeof ep.userFeedback !== 'undefined' && typeof ep.userFeedback !== 'string') {
+    errs.push('userFeedback must be string when present');
+  }
+
+  return errs;
+}
+
+module.exports = {
+  PAIN_TAXONOMY,
+  PAIN_TAXONOMY_SET,
+  SEVERITY_LEVELS,
+  SECRET_PATTERNS,
+  findSecret,
+  assertNoSecrets,
+  validateEpisode,
+};

--- a/backend/tests/jest/agent-improvement-episode-schema.test.js
+++ b/backend/tests/jest/agent-improvement-episode-schema.test.js
@@ -1,0 +1,147 @@
+/**
+ * Phase 0 #1 — episode schema + redaction + taxonomy coverage.
+ * Card: card_e9de7607cd9a838462148328
+ * Parent: card_be59aa034883fe36d3645a27
+ *
+ * jest.config.js uses testEnvironment: 'node'. No JSDOM needed — schema is
+ * a pure data contract.
+ */
+'use strict';
+
+const {
+  PAIN_TAXONOMY,
+  SEVERITY_LEVELS,
+  findSecret,
+  assertNoSecrets,
+  validateEpisode,
+} = require('../../agent-improvement/episode-schema');
+
+const FIXTURES = require('../../agent-improvement/__tests__/fixtures/episodes');
+
+describe('PAIN_TAXONOMY', () => {
+  test('has exactly the 8 closed-set tags the roadmap commits to', () => {
+    expect(PAIN_TAXONOMY).toEqual([
+      'delivery_reliability',
+      'auth_session',
+      'redirect_deeplink',
+      'ux_feedback',
+      'agent_ownership',
+      'task_context',
+      'test_coverage',
+      'scope_completeness',
+    ]);
+  });
+
+  test('is frozen so downstream consumers cannot silently extend it', () => {
+    expect(Object.isFrozen(PAIN_TAXONOMY)).toBe(true);
+  });
+});
+
+describe('validateEpisode()', () => {
+  test('accepts every fixture as valid', () => {
+    for (const ep of FIXTURES) {
+      const errs = validateEpisode(ep);
+      expect(errs).toEqual([]);
+    }
+  });
+
+  test('rejects missing required fields', () => {
+    const errs = validateEpisode({});
+    expect(errs).toContain('missing required field: cardId');
+    expect(errs).toContain('missing required field: entityId');
+    expect(errs).toContain('missing required field: painTags');
+    expect(errs).toContain('missing required field: severity');
+  });
+
+  test('rejects unknown painTag', () => {
+    const ep = { ...FIXTURES[0], painTags: ['something_made_up'] };
+    const errs = validateEpisode(ep);
+    expect(errs.some(e => e.includes('unknown tag: something_made_up'))).toBe(true);
+  });
+
+  test('rejects empty painTags array', () => {
+    const ep = { ...FIXTURES[0], painTags: [] };
+    const errs = validateEpisode(ep);
+    expect(errs).toContain('painTags must be non-empty');
+  });
+
+  test('rejects severity outside closed set', () => {
+    const ep = { ...FIXTURES[0], severity: 'P9' };
+    const errs = validateEpisode(ep);
+    expect(errs.some(e => e.startsWith('severity must be one of'))).toBe(true);
+  });
+
+  test('rejects non-ISO occurredAt', () => {
+    const ep = { ...FIXTURES[0], occurredAt: 'last Tuesday' };
+    const errs = validateEpisode(ep);
+    expect(errs).toContain('occurredAt must be ISO-8601 parseable');
+  });
+
+  test('rejects evidence entries missing kind/ref', () => {
+    const ep = { ...FIXTURES[0], evidence: [{ kind: 'pr' }] };
+    const errs = validateEpisode(ep);
+    expect(errs.some(e => e.startsWith('evidence[0].ref'))).toBe(true);
+  });
+
+  test('returns non-object error for null input', () => {
+    expect(validateEpisode(null)).toEqual(['episode is not an object']);
+  });
+});
+
+describe('findSecret() / assertNoSecrets()', () => {
+  test('flags bot_secret label', () => {
+    expect(findSecret('see bot_secret value below')).not.toBeNull();
+  });
+
+  test('flags Bearer token shape', () => {
+    expect(findSecret('Authorization: Bearer abc.def.ghi')).not.toBeNull();
+  });
+
+  test('flags hex-32+ run', () => {
+    expect(findSecret('token=' + 'a'.repeat(32))).not.toBeNull();
+  });
+
+  test('flags RAILWAY_ env reference with assignment', () => {
+    expect(findSecret('RAILWAY_TOKEN=abc123')).not.toBeNull();
+  });
+
+  test('flags password assignment', () => {
+    expect(findSecret('password = hunter2')).not.toBeNull();
+  });
+
+  test('passes clean strings', () => {
+    expect(findSecret('PR#3221 ticked counter for entityId=1')).toBeNull();
+    expect(findSecret('card_e9de7607cd9a838462148328')).toBeNull();
+  });
+
+  test('every fixture passes assertNoSecrets', () => {
+    for (const ep of FIXTURES) {
+      expect(() => assertNoSecrets(ep)).not.toThrow();
+    }
+  });
+
+  test('assertNoSecrets throws when a nested evidence note contains a secret', () => {
+    const ep = {
+      ...FIXTURES[0],
+      evidence: [{ kind: 'log', ref: 'logs/x.log', note: 'bot_secret=oops' }],
+    };
+    expect(() => assertNoSecrets(ep)).toThrow(/secret-shaped/);
+  });
+});
+
+describe('taxonomy coverage by fixtures', () => {
+  test('every PAIN_TAXONOMY tag has at least one fixture', () => {
+    const covered = new Set();
+    for (const ep of FIXTURES) {
+      for (const t of ep.painTags) covered.add(t);
+    }
+    const missing = PAIN_TAXONOMY.filter(t => !covered.has(t));
+    expect(missing).toEqual([]);
+  });
+
+  test('every fixture severity is in the closed set', () => {
+    for (const ep of FIXTURES) {
+      expect(SEVERITY_LEVELS).toContain(ep.severity);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Foundation for the self-improvement loop Hank greenlit at 12:28 TW (2026-06-07). One closed-set of pain tags + one validated episode shape, owned in one file, so every later phase reads from the same source of truth.

- 8-tag closed-set taxonomy: `delivery_reliability / auth_session / redirect_deeplink / ux_feedback / agent_ownership / task_context / test_coverage / scope_completeness`
- `validateEpisode(obj)` — pure-data contract check; missing fields, unknown tags, out-of-set severity, non-ISO timestamps all surface as `string[]` errors
- `findSecret / assertNoSecrets` — recursive walk against patterns for `bot_secret` label, `Bearer`, `RAILWAY_/JWT_` env assignments, `password=`, hex-32+ runs
- 8 fixtures (one per painTag) drawn from today's pain list; redaction tests assert no fixture leaks secrets
- 20-test jest spec: taxonomy shape, every rejection case, secret-pattern hits/misses, coverage assertions

## Scope kept tight
Storage / ingestion endpoint = Phase 0 #2 (`card_2024e5eebe1411b9a798fc28`) — intentionally out-of-scope here.

## Card
- card_e9de7607cd9a838462148328 (P1) — this PR
- card_be59aa034883fe36d3645a27 (P0 parent)

## Test plan
- [x] `npx jest tests/jest/agent-improvement-episode-schema.test.js --no-coverage` → 20/20 passed locally (0.284s)
- [x] No secret-shaped substrings in fixtures (assertNoSecrets walks every fixture in test)
- [x] Taxonomy coverage assertion: every painTag has ≥1 fixture
- [x] No production code path imports this yet — pure data contract, no runtime risk

🤖 Generated with [Claude Code](https://claude.com/claude-code)