### PR TITLE
feat(agent-improvement): OODA-R Phase 1 #3a — preflight composer + endpoint

### DIFF
--- a/backend/agent-improvement.js
+++ b/backend/agent-improvement.js
@@ -28,6 +28,15 @@ const {
     validateEpisode,
     assertNoSecrets,
 } = require('./agent-improvement/episode-schema');
+const {
+    KEYWORD_TO_TAG,
+    TASKTYPE_TO_TAG,
+    classifyPainTags,
+} = require('./agent-improvement/classifier');
+const {
+    composePreflightComment,
+    selectSimilarEpisodes,
+} = require('./agent-improvement/preflight');
 
 let pool = null;
 let devicesRef = null;
@@ -60,52 +69,6 @@ function initTable(chatPool) {
 
 function bindDevicesRef(ref) {
     devicesRef = ref;
-}
-
-// Keyword → painTag heuristic. Order matters: first match wins per taxonomy
-// scan but we accumulate matches into a set so a single feedback line can
-// emit multiple tags. Upgrade path: swap this for an LLM classifier behind
-// the same signature without changing call sites.
-const KEYWORD_TO_TAG = Object.freeze([
-    { tag: 'delivery_reliability', kws: ['offline', 'queue', 'reconnect', 'delivery', '斷線', '送不出', '訊息被阻擋', '無法送達', 'retry', 'backoff'] },
-    { tag: 'auth_session',         kws: ['login', 'session', '登入', '重新登入', 'token', 'refresh', '401', 'auth', '帳號'] },
-    { tag: 'redirect_deeplink',    kws: ['redirect', 'deep link', 'deeplink', '轉導', 'universal link', 'app links', 'route'] },
-    { tag: 'ux_feedback',          kws: ['feedback', '回饋', '使用者看不到', 'silent', '無感', 'no signal', '不知道送出沒'] },
-    { tag: 'agent_ownership',      kws: ['偷懶', 'slack', 'ownership', '誰負責', 'handoff', 'idle', '沒人接'] },
-    { tag: 'task_context',         kws: ['不知道該做', 'context', '不知道做甚麼', '不知道自己要做', 'scope unclear', '沒說清楚'] },
-    { tag: 'test_coverage',        kws: ['測試', 'test', 'coverage', 'no e2e', 'mock', '沒測'] },
-    { tag: 'scope_completeness',   kws: ['不能一次到位', '修修改改', 'rework', 'partial', '未完成', 'incomplete'] },
-]);
-
-const TASKTYPE_TO_TAG = Object.freeze({
-    pr_review: 'scope_completeness',
-    test_coverage: 'test_coverage',
-    spec_draft: 'task_context',
-    bugfix: 'ux_feedback',
-});
-
-/**
- * Heuristic classifier. Returns a non-empty array of painTag strings.
- * Falls back to ['scope_completeness'] when no signal matches — that tag is
- * the catch-all "we shipped something incomplete" bucket.
- * @param {string} text
- * @param {string} [taskType]
- * @returns {string[]}
- */
-function classifyPainTags(text, taskType) {
-    const hits = new Set();
-    const haystack = (text || '').toLowerCase();
-    for (const { tag, kws } of KEYWORD_TO_TAG) {
-        for (const kw of kws) {
-            if (haystack.includes(kw.toLowerCase())) {
-                hits.add(tag);
-                break;
-            }
-        }
-    }
-    if (taskType && TASKTYPE_TO_TAG[taskType]) hits.add(TASKTYPE_TO_TAG[taskType]);
-    if (hits.size === 0) hits.add('scope_completeness');
-    return Array.from(hits);
 }
 
 /**
@@ -241,11 +204,61 @@ router.get('/episodes', async (req, res) => {
     }
 });
 
+// Phase 1 #3a — preflight composer endpoint. Pulls candidate episodes from the
+// store, ranks them against the card's classified taxonomy, returns the
+// composed markdown. The caller (Hank, or the #3b auto-fire hook) decides
+// whether to post the resulting text as a kanban comment.
+router.post('/preflight', express.json({ limit: '64kb' }), async (req, res) => {
+    const auth = authDeviceOrBot(req);
+    if (!auth) return res.status(403).json({ success: false, error: 'Invalid credentials' });
+    if (!pool) return res.status(503).json({ success: false, error: 'store not ready' });
+
+    const cardTitle = (req.body?.cardTitle || '').toString();
+    const cardDescription = (req.body?.cardDescription || '').toString();
+    const taskType = (req.body?.taskType || '').toString() || undefined;
+    if (!cardTitle.trim()) {
+        return res.status(400).json({ success: false, error: 'cardTitle required' });
+    }
+
+    const taxonomy = classifyPainTags(`${cardTitle}\n\n${cardDescription}`, taskType);
+
+    try {
+        const r = await pool.query(`
+            SELECT card_id AS "cardId", entity_id AS "entityId", task_type AS "taskType",
+                   pain_tags AS "painTags", deliverable, user_visible_result AS "userVisibleResult",
+                   evidence, missed_checks AS "missedChecks", user_feedback AS "userFeedback",
+                   severity, occurred_at AS "occurredAt"
+            FROM agent_improvement_episodes
+            WHERE device_id = $1
+              AND pain_tags ?| $2::text[]
+            ORDER BY occurred_at DESC
+            LIMIT 100
+        `, [auth.deviceId, taxonomy]);
+
+        const similar = selectSimilarEpisodes(taxonomy, r.rows, 5);
+        const preflightText = composePreflightComment({
+            cardTitle, cardDescription, similarEpisodes: similar, taskType,
+        });
+        return res.json({
+            success: true,
+            taxonomy,
+            similarCount: similar.length,
+            candidateCount: r.rows.length,
+            preflightText,
+        });
+    } catch (err) {
+        console.error('[AgentImprovement] preflight error:', err.message);
+        return res.status(500).json({ success: false, error: 'internal' });
+    }
+});
+
 module.exports = {
     initTable,
     bindDevicesRef,
     classifyPainTags,
     ingestEpisode,
+    composePreflightComment,
+    selectSimilarEpisodes,
     router,
     KEYWORD_TO_TAG,
     TASKTYPE_TO_TAG,

--- a/backend/agent-improvement/classifier.js
+++ b/backend/agent-improvement/classifier.js
@@ -1,0 +1,51 @@
+// OODA-R classifier — keyword + taskType heuristic that maps free-form
+// feedback text to PAIN_TAXONOMY tags. Lives in its own module so both
+// agent-improvement.js (ingestion) and preflight.js (composer) can import
+// it without a circular dependency.
+
+'use strict';
+
+const KEYWORD_TO_TAG = Object.freeze([
+    { tag: 'delivery_reliability', kws: ['offline', 'queue', 'reconnect', 'delivery', '斷線', '送不出', '訊息被阻擋', '無法送達', 'retry', 'backoff'] },
+    { tag: 'auth_session',         kws: ['login', 'session', '登入', '重新登入', 'token', 'refresh', '401', 'auth', '帳號'] },
+    { tag: 'redirect_deeplink',    kws: ['redirect', 'deep link', 'deeplink', '轉導', 'universal link', 'app links', 'route'] },
+    { tag: 'ux_feedback',          kws: ['feedback', '回饋', '使用者看不到', 'silent', '無感', 'no signal', '不知道送出沒'] },
+    { tag: 'agent_ownership',      kws: ['偷懶', 'slack', 'ownership', '誰負責', 'handoff', 'idle', '沒人接'] },
+    { tag: 'task_context',         kws: ['不知道該做', 'context', '不知道做甚麼', '不知道自己要做', 'scope unclear', '沒說清楚'] },
+    { tag: 'test_coverage',        kws: ['測試', 'test', 'coverage', 'no e2e', 'mock', '沒測'] },
+    { tag: 'scope_completeness',   kws: ['不能一次到位', '修修改改', 'rework', 'partial', '未完成', 'incomplete'] },
+]);
+
+const TASKTYPE_TO_TAG = Object.freeze({
+    pr_review: 'scope_completeness',
+    test_coverage: 'test_coverage',
+    spec_draft: 'task_context',
+    bugfix: 'ux_feedback',
+});
+
+/**
+ * @param {string} text
+ * @param {string} [taskType]
+ * @returns {string[]}
+ */
+function classifyPainTags(text, taskType) {
+    const hits = new Set();
+    const haystack = (text || '').toLowerCase();
+    for (const { tag, kws } of KEYWORD_TO_TAG) {
+        for (const kw of kws) {
+            if (haystack.includes(kw.toLowerCase())) {
+                hits.add(tag);
+                break;
+            }
+        }
+    }
+    if (taskType && TASKTYPE_TO_TAG[taskType]) hits.add(TASKTYPE_TO_TAG[taskType]);
+    if (hits.size === 0) hits.add('scope_completeness');
+    return Array.from(hits);
+}
+
+module.exports = {
+    KEYWORD_TO_TAG,
+    TASKTYPE_TO_TAG,
+    classifyPainTags,
+};

--- a/backend/agent-improvement/preflight.js
+++ b/backend/agent-improvement/preflight.js
@@ -1,0 +1,140 @@
+// OODA-R Phase 1 #3a — preflight composer.
+// Card: card_50dccd356888b22d6654e85a
+// Parent: card_be59aa034883fe36d3645a27
+//
+// Given a card (title + description), produce the markdown text of the
+// preflight comment that should appear when the card transitions to
+// in_progress:
+//   1. "本任務如何避免過往同類錯誤" — bullets mined from prior episodes
+//      that share painTags with the card's classified taxonomy
+//   2. Required scope / acceptance / test / evidence-plan checklist
+//
+// Pure-data: takes a card + already-loaded episodes (+ optional recent
+// PR risks). The route layer is responsible for fetching the episodes;
+// this module never touches the DB or the network. That's the seam
+// that keeps the composer unit-testable and lets #3b wire it into the
+// kanban move hook without reshape.
+
+'use strict';
+
+const { classifyPainTags } = require('./classifier');
+
+/**
+ * Rank prior episodes by how many of their painTags overlap the card's
+ * classified taxonomy. Ties broken by occurredAt DESC.
+ *
+ * @param {string[]} cardTaxonomy   painTags emitted from the card text
+ * @param {object[]} allEpisodes    candidates (shape: validateEpisode-compatible)
+ * @param {number} [limit=5]
+ * @returns {object[]}
+ */
+function selectSimilarEpisodes(cardTaxonomy, allEpisodes, limit = 5) {
+    if (!Array.isArray(cardTaxonomy) || cardTaxonomy.length === 0) return [];
+    if (!Array.isArray(allEpisodes)) return [];
+    const cardSet = new Set(cardTaxonomy);
+    const scored = [];
+    for (const ep of allEpisodes) {
+        const tags = Array.isArray(ep.painTags) ? ep.painTags : [];
+        let overlap = 0;
+        for (const t of tags) if (cardSet.has(t)) overlap++;
+        if (overlap === 0) continue;
+        scored.push({ ep, overlap, ts: Date.parse(ep.occurredAt) || 0 });
+    }
+    scored.sort((a, b) => (b.overlap - a.overlap) || (b.ts - a.ts));
+    return scored.slice(0, limit).map(s => s.ep);
+}
+
+/**
+ * Mine the one-line "lesson learned" from an episode. Prefers a missedCheck
+ * (it says what would have caught the bug) over the userFeedback (which
+ * says what hurt). Returns empty string when nothing useful is on the record.
+ *
+ * @param {object} ep
+ * @returns {string}
+ */
+function extractLessons(ep) {
+    if (!ep || typeof ep !== 'object') return '';
+    if (Array.isArray(ep.missedChecks) && ep.missedChecks.length > 0) {
+        return ep.missedChecks[0];
+    }
+    if (typeof ep.userFeedback === 'string' && ep.userFeedback.trim()) {
+        return ep.userFeedback.trim();
+    }
+    if (typeof ep.userVisibleResult === 'string' && ep.userVisibleResult.trim()) {
+        return ep.userVisibleResult.trim();
+    }
+    return '';
+}
+
+function formatEpisodeCite(ep) {
+    const parts = [];
+    if (ep.cardId) parts.push(ep.cardId);
+    if (ep.severity) parts.push(ep.severity);
+    return parts.length ? `[${parts.join(' · ')}]` : '';
+}
+
+/**
+ * Compose the preflight comment markdown for a card.
+ *
+ * @param {object} params
+ * @param {string} params.cardTitle
+ * @param {string} [params.cardDescription]
+ * @param {object[]} [params.similarEpisodes]   already-ranked, top-K
+ * @param {object[]} [params.recentRisks]       shape: { ref, summary }; populated by #3b's git scanner
+ * @param {string} [params.taskType]            optional taskType hint for classifier
+ * @returns {string}
+ */
+function composePreflightComment({
+    cardTitle = '',
+    cardDescription = '',
+    similarEpisodes = [],
+    recentRisks = [],
+    taskType,
+} = {}) {
+    const text = `${cardTitle}\n\n${cardDescription}`;
+    const taxonomy = classifyPainTags(text, taskType);
+
+    const lines = [];
+    lines.push('[OODA-R preflight — auto-composed]');
+    lines.push('');
+    lines.push(`Classified painTags: \`${taxonomy.join('`, `')}\``);
+    lines.push('');
+
+    lines.push('## 本任務如何避免過往同類錯誤');
+    if (similarEpisodes.length === 0) {
+        lines.push('No prior episodes match this taxonomy yet. This is the first task in its category — fill the missedChecks field thoroughly when closing.');
+    } else {
+        for (const ep of similarEpisodes) {
+            const lesson = extractLessons(ep);
+            if (!lesson) continue;
+            const cite = formatEpisodeCite(ep);
+            lines.push(`- ${cite ? cite + ' ' : ''}${lesson}`);
+        }
+    }
+    lines.push('');
+
+    if (recentRisks.length > 0) {
+        lines.push('## Recent same-area PR risks');
+        for (const r of recentRisks) {
+            lines.push(`- ${r.ref}: ${r.summary}`);
+        }
+        lines.push('');
+    }
+
+    lines.push('## Required checklist (fill before moving to done)');
+    lines.push('- [ ] **Scope** — what files / endpoints / surfaces will change; what stays untouched');
+    lines.push('- [ ] **Acceptance** — concrete, verifiable conditions; no "should work" language');
+    lines.push('- [ ] **Test plan** — specific commands; jest test names if unit; URL if E2E');
+    lines.push('- [ ] **Evidence plan** — where the post-run proof will live (PR link, screenshot, jest output file)');
+    lines.push('- [ ] **Out-of-scope** — explicit deferral list so the close-out can be audited');
+    lines.push('');
+    lines.push('Move to done ONLY after evidence comment cites all five items.');
+
+    return lines.join('\n');
+}
+
+module.exports = {
+    composePreflightComment,
+    selectSimilarEpisodes,
+    extractLessons,
+};

--- a/backend/tests/jest/agent-improvement-preflight.test.js
+++ b/backend/tests/jest/agent-improvement-preflight.test.js
@@ -1,0 +1,141 @@
+/**
+ * Phase 1 #3a — preflight composer + selector + lesson-extractor.
+ * Card: card_50dccd356888b22d6654e85a
+ */
+'use strict';
+
+const {
+    composePreflightComment,
+    selectSimilarEpisodes,
+    extractLessons,
+} = require('../../agent-improvement/preflight');
+
+const FIXTURE_EPISODES = require('../../agent-improvement/__tests__/fixtures/episodes');
+
+describe('extractLessons()', () => {
+    test('prefers first missedCheck', () => {
+        const ep = { missedChecks: ['no E2E hit prod URL', 'no screenshot'], userFeedback: 'X' };
+        expect(extractLessons(ep)).toBe('no E2E hit prod URL');
+    });
+
+    test('falls back to userFeedback when no missedChecks', () => {
+        expect(extractLessons({ missedChecks: [], userFeedback: 'felt slow' })).toBe('felt slow');
+    });
+
+    test('falls back to userVisibleResult when no userFeedback', () => {
+        expect(extractLessons({ missedChecks: [], userVisibleResult: 'avatar broke' })).toBe('avatar broke');
+    });
+
+    test('returns empty when nothing mineable', () => {
+        expect(extractLessons({})).toBe('');
+        expect(extractLessons(null)).toBe('');
+    });
+});
+
+describe('selectSimilarEpisodes()', () => {
+    test('returns [] when card taxonomy empty', () => {
+        expect(selectSimilarEpisodes([], FIXTURE_EPISODES)).toEqual([]);
+    });
+
+    test('matches by taxonomy overlap', () => {
+        const r = selectSimilarEpisodes(['ux_feedback'], FIXTURE_EPISODES, 3);
+        expect(r.length).toBeGreaterThan(0);
+        for (const ep of r) {
+            expect(ep.painTags).toContain('ux_feedback');
+        }
+    });
+
+    test('skips episodes with zero overlap', () => {
+        const onlyAuth = FIXTURE_EPISODES.filter(e => e.painTags.includes('auth_session'));
+        const fake = [...onlyAuth, { painTags: ['delivery_reliability'], occurredAt: '2026-06-07T00:00:00Z' }];
+        const r = selectSimilarEpisodes(['auth_session'], fake);
+        for (const ep of r) {
+            expect(ep.painTags).toContain('auth_session');
+        }
+    });
+
+    test('ranks higher-overlap above lower-overlap', () => {
+        const candidates = [
+            { painTags: ['ux_feedback'], occurredAt: '2026-06-01T00:00:00Z', deliverable: 'one-tag' },
+            { painTags: ['ux_feedback', 'test_coverage'], occurredAt: '2026-06-01T00:00:00Z', deliverable: 'two-tag' },
+        ];
+        const r = selectSimilarEpisodes(['ux_feedback', 'test_coverage'], candidates, 2);
+        expect(r[0].deliverable).toBe('two-tag');
+        expect(r[1].deliverable).toBe('one-tag');
+    });
+
+    test('tie-breaks by occurredAt DESC', () => {
+        const candidates = [
+            { painTags: ['auth_session'], occurredAt: '2026-06-01T00:00:00Z', deliverable: 'older' },
+            { painTags: ['auth_session'], occurredAt: '2026-06-07T00:00:00Z', deliverable: 'newer' },
+        ];
+        const r = selectSimilarEpisodes(['auth_session'], candidates);
+        expect(r[0].deliverable).toBe('newer');
+    });
+
+    test('respects limit', () => {
+        const r = selectSimilarEpisodes(['delivery_reliability', 'ux_feedback'], FIXTURE_EPISODES, 1);
+        expect(r.length).toBe(1);
+    });
+});
+
+describe('composePreflightComment()', () => {
+    test('contains required headings even with no similar episodes', () => {
+        const text = composePreflightComment({
+            cardTitle: 'random one-off task with nothing to compare against',
+        });
+        expect(text).toMatch(/本任務如何避免過往同類錯誤/);
+        expect(text).toMatch(/Required checklist/);
+        expect(text).toMatch(/Scope/);
+        expect(text).toMatch(/Acceptance/);
+        expect(text).toMatch(/Test plan/);
+        expect(text).toMatch(/Evidence plan/);
+        expect(text).toMatch(/Out-of-scope/);
+    });
+
+    test('emits explicit "no prior episodes" line when similarEpisodes is empty', () => {
+        const text = composePreflightComment({ cardTitle: 'whatever' });
+        expect(text).toMatch(/No prior episodes match/);
+    });
+
+    test('emits lesson bullets for each similar episode', () => {
+        const ep = {
+            cardId: 'card_xyz', severity: 'P0',
+            painTags: ['ux_feedback'],
+            missedChecks: ['counter hook only covered push-failure not brain-silence'],
+            occurredAt: '2026-06-07T00:00:00Z',
+            deliverable: 'd', userVisibleResult: 'u', entityId: 2, taskType: 'bugfix', evidence: [],
+        };
+        const text = composePreflightComment({
+            cardTitle: 'avatar drawer feedback bug',
+            cardDescription: 'fixing user feedback path',
+            similarEpisodes: [ep],
+        });
+        expect(text).toMatch(/card_xyz · P0/);
+        expect(text).toMatch(/counter hook only covered push-failure/);
+    });
+
+    test('classifies the card taxonomy and prints it', () => {
+        const text = composePreflightComment({
+            cardTitle: '帳號莫名要重新登入 bug',
+            cardDescription: '',
+        });
+        expect(text).toMatch(/auth_session/);
+    });
+
+    test('recentRisks section is omitted when empty', () => {
+        const text = composePreflightComment({ cardTitle: 'x' });
+        expect(text).not.toMatch(/Recent same-area PR risks/);
+    });
+
+    test('recentRisks section renders when populated', () => {
+        const text = composePreflightComment({
+            cardTitle: 'x',
+            recentRisks: [
+                { ref: 'PR#3221', summary: 'counter hook missed same-device path' },
+            ],
+        });
+        expect(text).toMatch(/Recent same-area PR risks/);
+        expect(text).toMatch(/PR#3221: counter hook missed/);
+    });
+});


### PR DESCRIPTION
## Summary
The PoC at the heart of OODA-R. Given a card title/description, classify it into PAIN_TAXONOMY, pull prior episodes that share tags, compose a preflight comment with:
1. "本任務如何避免過往同類錯誤" — lessons mined from missedChecks of similar prior episodes
2. Required scope / acceptance / test / evidence-plan / out-of-scope checklist

**Sliced for blast control.** This PR is the composer + endpoint. Auto-fire on kanban move (#3b) and done-gate enforcement (#3c) come as follow-up subcards.

## What's new
- **`backend/agent-improvement/classifier.js`** — extracted from `agent-improvement.js` so preflight.js and ingestion can both import `classifyPainTags` without a circular dependency. No behavior change (the cycle would have made `composePreflightComment` reference `undefined` at module load; tests caught it during smoke).
- **`backend/agent-improvement/preflight.js`**:
  - `composePreflightComment({cardTitle, cardDescription, similarEpisodes, recentRisks, taskType})` → markdown
  - `selectSimilarEpisodes(taxonomy, allEpisodes, limit=5)` — overlap-rank + tie-break by occurredAt DESC
  - `extractLessons(ep)` — fallback ladder: missedChecks → userFeedback → userVisibleResult → ""
- **`POST /api/agent-improvement/preflight`** — server fetches matching episodes via JSONB `?|` operator, ranks via `selectSimilarEpisodes`, returns `{taxonomy, similarCount, candidateCount, preflightText}`. Same auth as `/episode`.
- **16 new jest tests** in `tests/jest/agent-improvement-preflight.test.js`

Combined: **50/50 jest passing** (20 schema + 14 ingest + 16 preflight).

## Sample composer output
```
[OODA-R preflight — auto-composed]

Classified painTags: `auth_session`

## 本任務如何避免過往同類錯誤
- [card_demo · P1] no refresh-token mutex

## Required checklist (fill before moving to done)
- [ ] **Scope** — what files / endpoints / surfaces will change; what stays untouched
- [ ] **Acceptance** — concrete, verifiable conditions; no "should work" language
- [ ] **Test plan** — specific commands; jest test names if unit; URL if E2E
- [ ] **Evidence plan** — where the post-run proof will live (PR link, screenshot, jest output file)
- [ ] **Out-of-scope** — explicit deferral list so the close-out can be audited

Move to done ONLY after evidence comment cites all five items.
```

## Card
- card_50dccd356888b22d6654e85a (P0, Phase 1 #3) — this PR (#3a slice)
- card_be59aa034883fe36d3645a27 (P0 parent)

## Test plan
- [x] `npx jest tests/jest/agent-improvement --no-coverage` → 50/50 passed locally
- [x] `node -c` all four modules clean
- [x] Smoke-import + render sample (above) confirms classifier wiring works end-to-end
- [ ] Post-deploy `curl POST /api/agent-improvement/preflight` smoke → next session

## Out-of-scope, deferred (subcards will be filed at close-out)
- Auto-fire on kanban move → Phase 1 #3b
- Done-gate enforcement → Phase 1 #3c
- Last-3-same-area PR risks from git → composer accepts `recentRisks` param; populating it is #3b
- LLM-driven phrasing

🤖 Generated with [Claude Code](https://claude.com/claude-code)