### PR TITLE
feat(kanban): OODA-R Phase 1 #3b — auto-fire preflight on card→in_progress

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -2042,6 +2042,40 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
 
             await bumpVersion(deviceId);
 
+            // OODA-R Phase 1 #3b — auto-fire preflight comment on todo→in_progress.
+            // Pulls similar prior episodes via the same SQL the /preflight endpoint
+            // uses, composes the markdown, and posts it as a system comment.
+            // Failure-isolated: never blocks the move, never throws.
+            if (oldStatus !== 'in_progress' && newStatus === 'in_progress') {
+                (async () => {
+                    try {
+                        const ai = require('./agent-improvement');
+                        const taxonomy = ai.classifyPainTags(
+                            `${card.title || ''}\n\n${card.description || ''}`,
+                            undefined,
+                        );
+                        const r = await pool.query(`
+                            SELECT card_id AS "cardId", entity_id AS "entityId", task_type AS "taskType",
+                                   pain_tags AS "painTags", deliverable, user_visible_result AS "userVisibleResult",
+                                   evidence, missed_checks AS "missedChecks", user_feedback AS "userFeedback",
+                                   severity, occurred_at AS "occurredAt"
+                            FROM agent_improvement_episodes
+                            WHERE device_id = $1 AND pain_tags ?| $2::text[]
+                            ORDER BY occurred_at DESC LIMIT 100
+                        `, [deviceId, taxonomy]);
+                        const similar = ai.selectSimilarEpisodes(taxonomy, r.rows, 5);
+                        const text = ai.composePreflightComment({
+                            cardTitle: card.title || '',
+                            cardDescription: card.description || '',
+                            similarEpisodes: similar,
+                        });
+                        await addSystemComment(cardId, deviceId, text);
+                    } catch (e) {
+                        console.error('[Kanban] OODA-R preflight hook error (non-blocking):', e.message);
+                    }
+                })();
+            }
+
             // Idle-dispatch hook (PR-B). emit() is a no-op when
             // IDLE_DISPATCH_HOOKS_ENABLED !== 'true'. Synchronous, never
             // throws (wrapped internally), and runs after the DB write +

--- a/backend/tests/jest/kanban-ooda-r-preflight-hook.test.js
+++ b/backend/tests/jest/kanban-ooda-r-preflight-hook.test.js
@@ -1,0 +1,199 @@
+/**
+ * Phase 1 #3b — auto-fire preflight on kanban move→in_progress.
+ * Card: card_6dcaa492b063d0d79041158b
+ *
+ * The hook in backend/kanban.js POST /card/:id/move is an inline async IIFE
+ * inside a closure that captures pool + addSystemComment. We can't unit-test
+ * the IIFE in isolation without spinning up the whole router. Instead this
+ * file tests the composition we wired in — the SAME sequence of calls the
+ * hook makes — against a mocked pool + addSystemComment shim, exercising:
+ *   1. classifyPainTags fires on the card text
+ *   2. SELECT against agent_improvement_episodes uses pain_tags ?| $2::text[]
+ *   3. selectSimilarEpisodes ranks down to top-5
+ *   4. composePreflightComment receives the right shape
+ *   5. addSystemComment is called with the composed text
+ *   6. Trigger fires ONLY on oldStatus !== 'in_progress' && newStatus === 'in_progress'
+ *   7. Composer/SELECT throw does NOT propagate (failure-isolated)
+ *
+ * This is the exact same algorithm the kanban.js IIFE uses, copy-faithful;
+ * the test guards regression on the algorithm even if someone refactors the
+ * IIFE later.
+ */
+'use strict';
+
+const ai = require('../../agent-improvement');
+
+/**
+ * Reproduces the OODA-R hook body verbatim — the inline IIFE in kanban.js.
+ * Kept in sync with that body manually; if the IIFE changes, this changes.
+ * Returns the promise of the side-effect so tests can await completion.
+ */
+async function runPreflightHook({ pool, addSystemComment, card, deviceId, cardId, oldStatus, newStatus }) {
+    if (oldStatus === 'in_progress' || newStatus !== 'in_progress') return { fired: false };
+    try {
+        const taxonomy = ai.classifyPainTags(
+            `${card.title || ''}\n\n${card.description || ''}`,
+            undefined,
+        );
+        const r = await pool.query(
+            `SELECT ... FROM agent_improvement_episodes WHERE device_id = $1 AND pain_tags ?| $2::text[] ORDER BY occurred_at DESC LIMIT 100`,
+            [deviceId, taxonomy],
+        );
+        const similar = ai.selectSimilarEpisodes(taxonomy, r.rows, 5);
+        const text = ai.composePreflightComment({
+            cardTitle: card.title || '',
+            cardDescription: card.description || '',
+            similarEpisodes: similar,
+        });
+        await addSystemComment(cardId, deviceId, text);
+        return { fired: true, taxonomy, similarCount: similar.length, text };
+    } catch (e) {
+        return { fired: true, error: e.message };
+    }
+}
+
+function makePool(rows = []) {
+    return {
+        query: jest.fn(async () => ({ rows })),
+    };
+}
+
+describe('OODA-R preflight auto-fire hook (Phase 1 #3b)', () => {
+    test('fires on todo→in_progress', async () => {
+        const pool = makePool([]);
+        const addSystemComment = jest.fn(async () => {});
+        const result = await runPreflightHook({
+            pool, addSystemComment,
+            card: { title: '帳號莫名要重新登入', description: '修 session refresh' },
+            deviceId: 'dev1', cardId: 'card_test',
+            oldStatus: 'todo', newStatus: 'in_progress',
+        });
+        expect(result.fired).toBe(true);
+        expect(result.taxonomy).toContain('auth_session');
+        expect(addSystemComment).toHaveBeenCalledTimes(1);
+        const [cid, did, text] = addSystemComment.mock.calls[0];
+        expect(cid).toBe('card_test');
+        expect(did).toBe('dev1');
+        expect(text).toMatch(/本任務如何避免過往同類錯誤/);
+        expect(text).toMatch(/Required checklist/);
+    });
+
+    test('fires on backlog→in_progress', async () => {
+        const pool = makePool([]);
+        const addSystemComment = jest.fn(async () => {});
+        const result = await runPreflightHook({
+            pool, addSystemComment,
+            card: { title: 'x', description: '' },
+            deviceId: 'd', cardId: 'c',
+            oldStatus: 'backlog', newStatus: 'in_progress',
+        });
+        expect(result.fired).toBe(true);
+        expect(addSystemComment).toHaveBeenCalled();
+    });
+
+    test('does NOT fire on in_progress→in_progress (no-op self-loop already rejected upstream, double-safety here)', async () => {
+        const pool = makePool([]);
+        const addSystemComment = jest.fn(async () => {});
+        const result = await runPreflightHook({
+            pool, addSystemComment,
+            card: { title: 'x' },
+            deviceId: 'd', cardId: 'c',
+            oldStatus: 'in_progress', newStatus: 'in_progress',
+        });
+        expect(result.fired).toBe(false);
+        expect(addSystemComment).not.toHaveBeenCalled();
+    });
+
+    test('does NOT fire on in_progress→review', async () => {
+        const pool = makePool([]);
+        const addSystemComment = jest.fn(async () => {});
+        const result = await runPreflightHook({
+            pool, addSystemComment,
+            card: { title: 'x' },
+            deviceId: 'd', cardId: 'c',
+            oldStatus: 'in_progress', newStatus: 'review',
+        });
+        expect(result.fired).toBe(false);
+        expect(addSystemComment).not.toHaveBeenCalled();
+    });
+
+    test('does NOT fire on todo→backlog', async () => {
+        const pool = makePool([]);
+        const addSystemComment = jest.fn(async () => {});
+        const result = await runPreflightHook({
+            pool, addSystemComment,
+            card: { title: 'x' },
+            deviceId: 'd', cardId: 'c',
+            oldStatus: 'todo', newStatus: 'backlog',
+        });
+        expect(result.fired).toBe(false);
+    });
+
+    test('SELECT query receives taxonomy as PG text[] param', async () => {
+        const pool = makePool([]);
+        const addSystemComment = jest.fn(async () => {});
+        await runPreflightHook({
+            pool, addSystemComment,
+            card: { title: '一旦斷線訊息就被阻擋' },
+            deviceId: 'd', cardId: 'c',
+            oldStatus: 'todo', newStatus: 'in_progress',
+        });
+        expect(pool.query).toHaveBeenCalledTimes(1);
+        const [, params] = pool.query.mock.calls[0];
+        expect(params[0]).toBe('d');
+        expect(Array.isArray(params[1])).toBe(true);
+        expect(params[1]).toContain('delivery_reliability');
+    });
+
+    test('failure isolation: pool error returns fired:true with error, does NOT throw', async () => {
+        const pool = { query: jest.fn(async () => { throw new Error('db blew up'); }) };
+        const addSystemComment = jest.fn(async () => {});
+        const result = await runPreflightHook({
+            pool, addSystemComment,
+            card: { title: 'x' },
+            deviceId: 'd', cardId: 'c',
+            oldStatus: 'todo', newStatus: 'in_progress',
+        });
+        expect(result.fired).toBe(true);
+        expect(result.error).toMatch(/db blew up/);
+        expect(addSystemComment).not.toHaveBeenCalled();
+    });
+
+    test('failure isolation: addSystemComment error does NOT throw', async () => {
+        const pool = makePool([]);
+        const addSystemComment = jest.fn(async () => { throw new Error('comment insert failed'); });
+        const result = await runPreflightHook({
+            pool, addSystemComment,
+            card: { title: 'x' },
+            deviceId: 'd', cardId: 'c',
+            oldStatus: 'todo', newStatus: 'in_progress',
+        });
+        expect(result.fired).toBe(true);
+        expect(result.error).toMatch(/comment insert failed/);
+    });
+
+    test('passes similarEpisodes through composer (top-5 ranking applied)', async () => {
+        const fakeRows = Array.from({ length: 7 }, (_, i) => ({
+            cardId: `card_${i}`, entityId: 2, taskType: 'bugfix',
+            painTags: ['ux_feedback'],
+            deliverable: 'd', userVisibleResult: 'u',
+            evidence: [], missedChecks: [`lesson ${i}`],
+            severity: 'P1',
+            occurredAt: `2026-06-0${i + 1}T00:00:00Z`,
+        }));
+        const pool = makePool(fakeRows);
+        const addSystemComment = jest.fn(async () => {});
+        const result = await runPreflightHook({
+            pool, addSystemComment,
+            card: { title: '使用者回饋差', description: '' },
+            deviceId: 'd', cardId: 'c',
+            oldStatus: 'todo', newStatus: 'in_progress',
+        });
+        expect(result.similarCount).toBe(5);
+        // newest 5 of 7 should be cited
+        expect(result.text).toMatch(/lesson 6/);
+        expect(result.text).toMatch(/lesson 2/);
+        expect(result.text).not.toMatch(/lesson 0/);
+        expect(result.text).not.toMatch(/lesson 1/);
+    });
+});


### PR DESCRIPTION
## Summary
Converts the OODA-R loop from advisory to operational. Until this PR, the composer shipped in #3228 is an endpoint nobody calls. After this PR, every `todo→in_progress` (or `backlog→in_progress`) transition auto-receives a preflight comment that cites prior episode lessons + the required scope/acceptance/test/evidence/out-of-scope checklist.

## What's new
- **`backend/kanban.js` POST /card/:id/move** — after the existing UPDATE + system comment + notify chain (so the move is durable first), detect `oldStatus !== 'in_progress' && newStatus === 'in_progress'` and run a fire-and-forget async block:
  1. lazy-require `./agent-improvement`
  2. `classifyPainTags(title + description)` → taxonomy
  3. `SELECT` from `agent_improvement_episodes WHERE pain_tags ?| taxonomy`
  4. `selectSimilarEpisodes` top-5
  5. `composePreflightComment({...})`
  6. `addSystemComment(cardId, deviceId, text)`
- **Failure isolation**: try/catch with `console.error` — never re-throws. The move always succeeds.

## Tests
**9 new** in `tests/jest/kanban-ooda-r-preflight-hook.test.js`, inlining the hook body verbatim against a mocked pool + addSystemComment:
- fires on `todo→in_progress` and `backlog→in_progress`
- does NOT fire on `in_progress→in_progress` / `in_progress→review` / `todo→backlog`
- SELECT params carry the taxonomy as PG `text[]`
- composed text includes 本任務如何避免過往同類錯誤 + Required checklist
- pool throw + comment-insert throw never propagate
- top-5 ranking still applied when 7 candidates match

**Full agent-improvement + hook suite: 59/59 passing.**

## Card
- card_6dcaa492b063d0d79041158b (P0, Phase 1 #3b) — this PR
- card_be59aa034883fe36d3645a27 (P0 Strategic parent)

## Test plan
- [x] `npx jest tests/jest/agent-improvement tests/jest/kanban-ooda-r --no-coverage` → 59/59 passed locally
- [x] `node -c backend/kanban.js` clean
- [ ] Post-deploy: create a fresh card, move to in_progress, confirm composer comment appears within 5s (deferred to next session — needs Railway deploy of #3227 to settle so the DB table exists in prod)

## Out of scope, deferred
- Done-gate enforcement → Phase 1 #3c (`card_040f1edeaec149afdbb73a29`)
- Bypass flag for trivial cards → could roll into #3c
- last-3-same-area PR risks population → separate

🤖 Generated with [Claude Code](https://claude.com/claude-code)