### PR TITLE
feat(info): backfill PR links for Claude Code + Codex channel repairs

### DIFF
--- a/backend/channel-repair-log.js
+++ b/backend/channel-repair-log.js
@@ -64,7 +64,7 @@ function looksLikeSecret(...vals) {
 
 // Bump when SEED_RECORDS content changes so deployed instances replace the old
 // curated rows (source='seed') in place, without touching monitor/manual rows.
-const SEED_VERSION = 2;
+const SEED_VERSION = 3;
 
 // ============================================
 // SCHEMA BOOTSTRAP — idempotent, safe on every boot.
@@ -125,7 +125,8 @@ const SEED_RECORDS = [
         channel_type: 'claude-code-eclaw-channel', kind: 'fix',
         title: 'Fixed the bot appearing stuck while background work ran',
         detail: 'Previously the assistant could look "busy" and stop replying while long background jobs were running. It now stays responsive and answers your messages normally.',
-        status: 'resolved', occurred_at: '2026-05-11T06:00:00Z'
+        status: 'resolved', occurred_at: '2026-05-11T06:00:00Z',
+        pr_url: 'https://github.com/HankHuang0516/claude-code-eclaw-channel/pull/2'
     },
     {
         channel_type: 'claude-code-eclaw-channel', kind: 'fix',
@@ -150,7 +151,8 @@ const SEED_RECORDS = [
         channel_type: 'codex-eclaw-bridge', kind: 'fix',
         title: 'Automatic reconnection for the Codex connection',
         detail: 'If the connection to Codex stalls, the bridge now restarts it automatically so replies resume on their own, with no manual steps needed.',
-        status: 'resolved', occurred_at: '2026-06-08T05:27:00Z'
+        status: 'resolved', occurred_at: '2026-06-08T05:27:00Z',
+        pr_url: 'https://github.com/HankHuang0516/codex-eclaw-bridge/pull/7'
     }
 ];
 


### PR DESCRIPTION
## Summary
- Adds real merged-PR links to two repair records that previously had none:
  - Claude Code "appearing stuck/busy" fix → claude-code-eclaw-channel#2 (bug-7 long-idle). The fix itself was committed directly to main; #2 is its regression-test/traceability PR.
  - Codex "automatic reconnection" fix → codex-eclaw-bridge#7 (polling-bridge recovery for the Codex channel).
- Both channel repos are public, so the links resolve for end users.
- `SEED_VERSION` 2→3 so deployed seed rows pick up the links in place.
- Remaining records without a PR are operational/upstream guidelines (rate-limit notice, message queue, long-maintenance auto-recovery), which have no code PR by nature.

## Test plan
- [x] jest channel-repair-log green; eslint clean
- [x] local reseed v3 → 3 records carry pr_url (#2, #9, #7)
- [ ] post-deploy: GET shows 3 pr_url; info page renders 3 View PR chips

🤖 Generated with [Claude Code](https://claude.com/claude-code)