### PR TITLE
feat(portal): destructive modal Cancel aria-label + showConfirm i18n-key warn

### DIFF
--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -95,9 +95,21 @@ const _ECLAW_DIALOG_SHADOW_STYLE = 'style="box-shadow: 0 8px 32px rgba(0, 0, 0, 
 function showConfirm({ message, title, confirmText, cancelText, danger, itemName } = {}) {
     // Dev-time hint: destructive confirms should name the item so a fast-clicking user can
     // verify what's about to be destroyed. Localhost / dev hosts only; silent in production.
-    if (danger && !itemName && typeof window !== 'undefined' && window.location
-        && /^(localhost|127\.0\.0\.1|0\.0\.0\.0)$/.test(window.location.hostname)) {
+    const _isDevHost = typeof window !== 'undefined' && window.location
+        && /^(localhost|127\.0\.0\.1|0\.0\.0\.0)$/.test(window.location.hostname);
+    if (danger && !itemName && _isDevHost) {
         console.warn('[showConfirm] danger:true called without itemName — caller should pass `itemName` so the dialog can name the destroyed item. Caller:', new Error().stack);
+    }
+    // Dev-time hint: catch contributors who pass a raw i18n key as title/message and the
+    // lookup resolves to itself (key not registered in TRANSLATIONS[*]). Without this the
+    // dialog renders the literal key string to the user with no console signal.
+    if (_isDevHost && typeof i18n !== 'undefined' && i18n.t) {
+        [['title', title], ['message', message]].forEach(([field, val]) => {
+            if (typeof val !== 'string' || !val) return;
+            if (/^[a-z][a-z0-9_]+$/.test(val) && i18n.t(val) === val) {
+                console.warn(`[showConfirm] ${field} looks like an unresolved i18n key (t() returned the key itself): "${val}"`);
+            }
+        });
     }
     return new Promise((resolve) => {
         const t = _tFb;
@@ -116,7 +128,7 @@ function showConfirm({ message, title, confirmText, cancelText, danger, itemName
             ${title ? `<div class="dialog-title" id="${titleId}">${_escHtml(title)}</div>` : ''}
             <div class="dialog-body"><p id="${messageId}" style="margin:0;line-height:1.6;color:var(--text-secondary)">${_escHtml(message)}</p>${itemStrip}</div>
             <div class="dialog-actions">
-                <button type="button" class="btn btn-outline eclaw-confirm-cancel">${_escHtml(cancelText || t('dialog_cancel', 'Cancel'))}</button>
+                <button type="button" class="btn btn-outline eclaw-confirm-cancel"${danger && !cancelText ? ` aria-label="${_escAttr(t('dialog_cancel_aria', 'Cancel, keep current state'))}"` : ''}>${_escHtml(cancelText || t('dialog_cancel', 'Cancel'))}</button>
                 <button type="button" class="btn ${danger ? 'btn-danger' : 'btn-primary'} eclaw-confirm-ok"${danger && !confirmText ? ` aria-label="${_escAttr(t('dialog_confirm_destructive', 'Confirm destructive action'))}"` : ''}>${_escHtml(confirmText || (danger ? t('dialog_confirm', 'Confirm') : t('dialog_ok', 'OK')))}</button>
             </div>
         </div>`;


### PR DESCRIPTION
## Summary
- Adds `aria-label` to Cancel button in destructive `showConfirm()` (`'Cancel, keep current state'` via `t('dialog_cancel_aria', ...)`) so screen readers hear the destructive context, not just the word "Cancel".
- Adds dev-host `console.warn` when a caller passes a raw i18n key as `title`/`message` that resolves to itself — catches contributors who write `showConfirm({title: 'confirm_delete'})` and would otherwise ship the literal key as visible text.

## Source
Destructive-modals daily E2E playbook Phase 2 finding 2026-06-09 10:33 TW. Card `card_a326b729b0e5130d831b83e7` (P3 enhance).

## What changed
`backend/public/portal/shared/api.js` — `showConfirm()`:
1. Cancel button gets parallel `aria-label` when `danger && !cancelText`, mirroring the existing OK button pattern.
2. New dev-only i18n-key probe (`/^[a-z][a-z0-9_]+\$/` + `i18n.t(val) === val`) on `title`/`message`. Localhost / 127.0.0.1 / 0.0.0.0 only; silent in production. Same gating as the existing `itemName` dev warn.

## i18n note
`dialog_cancel_aria` follows the existing `dialog_*` family pattern of key-with-English-fallback baked in via `_tFb`. No locale block edits in this PR — `dialog_cancel`, `dialog_ok`, `dialog_confirm`, `dialog_confirm_destructive` all currently rely on fallback the same way. Per-locale fanout for the new aria string is a follow-up that can be batched via PR #3254's AST insert tool.

## Test plan
- [x] Diff inspected; minimal surgical edits, no behavior change in non-destructive flows
- [x] Existing OK-button aria-label pattern preserved
- [ ] Next 24h destructive-modals daily E2E cron will verify `cancel.aria-label !== null` in its evaluate output (already in the playbook's evidence step)

## Out of scope
- backdrop click-to-dismiss (already correctly disabled for destructive per Apple HIG)
- trigger animation / dark mode / loading state
- per-locale fanout for `dialog_cancel_aria` (follow-up; rest of dialog_* family is also English-only via fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)