### PR TITLE
feat(entity-status): counter drill-down + SVG quote icon + ? help-icon

### DIFF
--- a/backend/entity-status.js
+++ b/backend/entity-status.js
@@ -315,6 +315,19 @@ async function getCounters(deviceId, entityId) {
           WHERE device_id = $1 AND entity_id = $2`,
         [deviceId, entityId]
     );
+    // Currently-open events per axis: rows still sitting in outbound_msg_pending
+    // for this entity-as-recipient. These are the events the panel's drill-down
+    // will surface. `count` (cumulative) stays for backward-compat with any
+    // existing chart/badge; `openCount` is the live health number Hank's spec
+    // is built around — drops as the entity replies.
+    const openRows = await pool.query(
+        `SELECT axis, COUNT(*)::int AS open_count
+           FROM outbound_msg_pending
+          WHERE device_id = $1 AND recipient_entity_id = $2
+          GROUP BY axis`,
+        [deviceId, entityId]
+    );
+    const openByAxis = new Map(openRows.rows.map(r => [r.axis, Number(r.open_count)]));
     const byAxis = new Map(result.rows.map(r => [r.axis, r]));
     // Always surface canonical axes even when count = 0, so the UI can render
     // a stable row order. Extra non-canonical axes (forward-compat) appear after.
@@ -324,18 +337,54 @@ async function getCounters(deviceId, entityId) {
         ordered.push({
             axis,
             count: row ? Number(row.count) : 0,
+            openCount: openByAxis.get(axis) || 0,
             lastEventAt: row && row.last_event_at ? row.last_event_at.toISOString() : null,
         });
         byAxis.delete(axis);
+        openByAxis.delete(axis);
     }
     for (const [axis, row] of byAxis) {
         ordered.push({
             axis,
             count: Number(row.count),
+            openCount: openByAxis.get(axis) || 0,
             lastEventAt: row.last_event_at ? row.last_event_at.toISOString() : null,
         });
+        openByAxis.delete(axis);
+    }
+    // Axes with open pending but no cumulative row yet (fresh counter — sweeper
+    // hasn't fired since first dispatch). Surface them so the drill-down lists
+    // line up even before the cumulative row is created.
+    for (const [axis, openCount] of openByAxis) {
+        ordered.push({ axis, count: 0, openCount, lastEventAt: null });
     }
     return ordered;
+}
+
+// Drill-down: list of currently-open pending events for a single axis.
+// Each row carries enough to render a (timestamp, chip) on the panel —
+// the chip is either a card chip (event_payload.card_id) or a chat-coord
+// chip from message_id. Newest first. Limited to keep the panel snappy.
+async function getCounterEvents(deviceId, entityId, axis, limit) {
+    if (!pool) return [];
+    const lim = Math.max(1, Math.min(100, Number(limit) || 30));
+    const result = await pool.query(
+        `SELECT id, sender_entity_id, event_type, axis, dispatched_at, expires_at, payload_snippet
+           FROM outbound_msg_pending
+          WHERE device_id = $1 AND recipient_entity_id = $2 AND axis = $3
+          ORDER BY dispatched_at DESC
+          LIMIT $4`,
+        [deviceId, entityId, axis, lim]
+    );
+    return result.rows.map(r => ({
+        id: String(r.id),
+        senderEntityId: r.sender_entity_id,
+        eventType: r.event_type,
+        axis: r.axis,
+        dispatchedAt: r.dispatched_at ? r.dispatched_at.toISOString() : null,
+        expiresAt: r.expires_at ? r.expires_at.toISOString() : null,
+        payload: r.payload_snippet,
+    }));
 }
 
 async function incrementCounter(deviceId, entityId, axis) {
@@ -496,6 +545,37 @@ router.get('/:eId', async (req, res) => {
     }
 });
 
+// Drill-down — the (timestamp, chip) list that opens when a user clicks one of
+// the four counter rows on the panel. Returns the currently-pending events for
+// that axis on this entity (i.e. what the live `openCount` counts). Newest first.
+router.get('/:eId/counter/:axis/events', async (req, res) => {
+    const auth = authDeviceOrBot(req);
+    if (!auth) {
+        return res.status(403).json({ success: false, error: 'Invalid credentials' });
+    }
+    const targetEId = parseInt(req.params.eId);
+    if (!Number.isFinite(targetEId) || targetEId < 0) {
+        return res.status(400).json({ success: false, error: 'Invalid entityId' });
+    }
+    const axis = String(req.params.axis || '');
+    if (!/^[a-z][a-z0-9_]{2,63}$/.test(axis)) {
+        return res.status(400).json({ success: false, error: 'Invalid axis' });
+    }
+    try {
+        const items = await getCounterEvents(auth.deviceId, targetEId, axis, req.query.limit);
+        res.json({
+            success: true,
+            deviceId: auth.deviceId,
+            entityId: targetEId,
+            axis,
+            items,
+        });
+    } catch (err) {
+        console.error('[EntityStatus] getCounterEvents error:', err.message);
+        res.status(500).json({ success: false, error: 'internal' });
+    }
+});
+
 router.get('/:eId/log', express.json(), async (req, res) => {
     const auth = authDeviceOrBot(req);
     if (!auth) {
@@ -568,6 +648,7 @@ module.exports = {
     bindDevicesRef,
     bindJwtSecret,
     getCounters,
+    getCounterEvents,
     incrementCounter,
     axisForEventType,
     trackOutbound,

--- a/backend/public/portal/shared/entity-status-panel.js
+++ b/backend/public/portal/shared/entity-status-panel.js
@@ -48,6 +48,30 @@
         done:        '#22c55e',
     };
 
+    // Lucide/Feather-family quote icon. Matches the rest of portal/shared (24x24
+    // viewBox, fill=none, stroke=currentColor, stroke-width=2, round caps) so
+    // the panel doesn't look out of place next to nav, ai-chat, etc.
+    const SVG_QUOTE = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" '
+        + 'stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" '
+        + 'aria-hidden="true" focusable="false">'
+        + '<path d="M3 21c3 0 7-1 7-8V5c0-1.25-.756-2.017-2-2H4c-1.25 0-2 .75-2 1.972V11c0 1.25.75 2 2 2 1 0 1 0 1 1v1c0 1-.5 2-2 2-1 0-1 .989-1 .989C2 18.978 2 21 3 21z"/>'
+        + '<path d="M15 21c3 0 7-1 7-8V5c0-1.25-.757-2.017-2-2h-4c-1.25 0-2 .75-2 1.972V11c0 1.25.75 2 2 2 1 0 1 0 1 1v1c0 1-.5 2-2 2-1 0-1 .989-1 .989C14 18.978 14 21 15 21z"/>'
+        + '</svg>';
+    // Same family as nav.js, just the help-circle variant. Used as the ? icon
+    // next to the panel title.
+    const SVG_HELP = '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" '
+        + 'stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" '
+        + 'aria-hidden="true" focusable="false">'
+        + '<circle cx="12" cy="12" r="10"/>'
+        + '<path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"/>'
+        + '<line x1="12" y1="17" x2="12.01" y2="17"/>'
+        + '</svg>';
+    // Chevron right (collapsed) / down (expanded). Mirrors counter drill-down.
+    const SVG_CHEVRON = '<svg class="' + ROOT_CLASS + '__counter-chevron" width="12" height="12" '
+        + 'viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" '
+        + 'stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">'
+        + '<polyline points="9 6 15 12 9 18"/></svg>';
+
     function pickLabel(axis) {
         const lang = (document.documentElement.getAttribute('lang') || 'en').toLowerCase();
         const isZh = lang.startsWith('zh') || lang === 'tw' || lang === 'cn';
@@ -94,6 +118,16 @@
         qs.set('limit', String(limit || 20));
         if (before) qs.set('before', String(before));
         const res = await fetch(`/api/entity-status/${eid}/log?${qs.toString()}`, {
+            credentials: 'include',
+        });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        return res.json();
+    }
+
+    async function fetchCounterEvents(eid, axis) {
+        const qs = _credQs();
+        qs.set('limit', '50');
+        const res = await fetch(`/api/entity-status/${eid}/counter/${encodeURIComponent(axis)}/events?${qs.toString()}`, {
             credentials: 'include',
         });
         if (!res.ok) throw new Error('HTTP ' + res.status);
@@ -164,7 +198,7 @@
                 <time class="${ROOT_CLASS}__log-time">${escapeHtml(ts)}</time>
                 <span class="${ROOT_CLASS}__log-summary">${summary}</span>
                 <button type="button" class="${ROOT_CLASS}__log-quote" data-action="quote"
-                    data-log-id="${escapeHtml(item.id)}" title="Quote this row">❝</button>
+                    data-log-id="${escapeHtml(item.id)}" title="Quote this row" aria-label="Quote this row">${SVG_QUOTE}</button>
             </li>`;
     }
 
@@ -287,8 +321,16 @@
             <div class="${ROOT_CLASS}__sheet">
                 <header class="${ROOT_CLASS}__header">
                     <strong class="${ROOT_CLASS}__title">Entity #${eid}</strong>
+                    <button type="button" class="${ROOT_CLASS}__help"
+                        data-action="help" aria-label="What does this panel show?"
+                        aria-expanded="false" title="What does this panel show?">${SVG_HELP}</button>
+                    <span class="${ROOT_CLASS}__header-spacer"></span>
                     <button type="button" class="${ROOT_CLASS}__close" aria-label="Close" data-action="close">✕</button>
                 </header>
+                <div class="${ROOT_CLASS}__help-popover" data-role="help-popover" hidden>
+                    <p><strong>Counters</strong> — each row counts open events the entity hasn&#39;t acted on. Number is live: it drops as the entity replies. Click a counter to see <em>which</em> events.</p>
+                    <p><strong>Operation log</strong> — recent kanban / message / system events for this entity, newest first. Card chips open the card&#39;s popover; ${SVG_QUOTE} quotes the row into your chat composer.</p>
+                </div>
                 <section class="${ROOT_CLASS}__section" data-section="counters">
                     <h3 class="${ROOT_CLASS}__section-title">累計錯誤次數 / Error counters</h3>
                     <ul class="${ROOT_CLASS}__counter-list" data-role="counter-list">
@@ -307,10 +349,32 @@
         root.addEventListener('click', (e) => {
             const action = e.target?.dataset?.action || e.target?.closest('[data-action]')?.dataset?.action;
             if (action === 'close') { close(); return; }
+            if (action === 'help') {
+                const btn = e.target.closest('[data-action="help"]');
+                const pop = root.querySelector('[data-role="help-popover"]');
+                if (pop && btn) {
+                    const open = pop.hasAttribute('hidden') ? false : true;
+                    if (open) { pop.setAttribute('hidden', ''); btn.setAttribute('aria-expanded', 'false'); }
+                    else { pop.removeAttribute('hidden'); btn.setAttribute('aria-expanded', 'true'); }
+                }
+                e.stopPropagation();
+                return;
+            }
             if (action === 'quote') {
                 const btn = e.target.closest('[data-action="quote"]');
                 const logId = btn && btn.dataset.logId;
                 if (logId) handleQuoteClick(eid, logId);
+                e.stopPropagation();
+                return;
+            }
+            // Counter drill-down: clicking a counter row expands the open
+            // events that comprise the live `openCount`. Toggles closed on
+            // a second click. Doesn't fire if the user clicked inside an
+            // already-rendered drill-down child (those bubble up).
+            const counterRow = e.target.closest && e.target.closest(`.${ROOT_CLASS}__counter-row[data-axis]`);
+            if (counterRow && !e.target.closest(`.${ROOT_CLASS}__counter-events`)) {
+                const axis = counterRow.dataset.axis;
+                if (axis) toggleCounterDrilldown(root, eid, axis, counterRow);
                 e.stopPropagation();
                 return;
             }
@@ -333,12 +397,84 @@
             list.innerHTML = `<li class="${ROOT_CLASS}__counter-row" data-state="empty">No counters yet.</li>`;
             return;
         }
-        list.innerHTML = counters.map(c => `
-            <li class="${ROOT_CLASS}__counter-row" data-axis="${c.axis}">
+        // Live counter = openCount when the backend provides it; fall back to
+        // cumulative count for old clients / old backends. Hank's spec: the
+        // displayed number is "what's currently open", not lifetime total.
+        list.innerHTML = counters.map(c => {
+            const live = (typeof c.openCount === 'number') ? c.openCount : c.count;
+            return `
+            <li class="${ROOT_CLASS}__counter-row" data-axis="${c.axis}"
+                role="button" tabindex="0"
+                aria-expanded="false"
+                aria-label="${pickLabel(c.axis)}: ${live} open. Click to see which events.">
+                ${SVG_CHEVRON}
                 <span class="${ROOT_CLASS}__counter-label">${pickLabel(c.axis)}</span>
-                <span class="${ROOT_CLASS}__counter-value">${c.count}</span>
-            </li>
-        `).join('');
+                <span class="${ROOT_CLASS}__counter-value">${live}</span>
+            </li>`;
+        }).join('');
+    }
+
+    // Render the drill-down rows for one axis. Each row = (timestamp, chip).
+    // Chip is a card chip if event payload carries card_id, otherwise a
+    // message-coord chip from message_id. The list lives as a child <ul>
+    // appended to the counter row so it slots in-line under the counter that
+    // owns it (no second drawer push).
+    function renderCounterEvents(items) {
+        if (!items || items.length === 0) {
+            return `<li class="${ROOT_CLASS}__counter-event-row" data-state="empty">No open events.</li>`;
+        }
+        return items.map(it => {
+            const ts = formatTs(it.dispatchedAt);
+            let chipHtml = '';
+            const cardId = it.payload && it.payload.card_id;
+            const messageId = it.payload && (it.payload.message_id || it.payload.msg_id);
+            if (cardId) {
+                const status = (it.payload && it.payload.status) || 'todo';
+                const color = STATUS_COLOR[status] || STATUS_COLOR.todo;
+                chipHtml = `<span class="autolink-chip ${ROOT_CLASS}__chip" `
+                    + `data-ref-type="card" data-ref-id="${escapeHtml(cardId)}" `
+                    + `data-card-id="${escapeHtml(cardId)}" `
+                    + `style="background:${color}22;border-color:${color};color:${color};" `
+                    + `title="${escapeHtml(cardId)}">${escapeHtml(cardId.slice(0, 12))}</span>`;
+            } else if (messageId) {
+                chipHtml = `<span class="autolink-chip ${ROOT_CLASS}__chip" `
+                    + `data-ref-type="message" data-ref-id="${escapeHtml(messageId)}" `
+                    + `title="${escapeHtml(messageId)}">msg ${escapeHtml(String(messageId).slice(-6))}</span>`;
+            } else {
+                chipHtml = `<span class="${ROOT_CLASS}__chip" title="${escapeHtml(it.eventType || '')}">`
+                    + `${escapeHtml(it.eventType || 'event')}</span>`;
+            }
+            return `<li class="${ROOT_CLASS}__counter-event-row" data-event-id="${escapeHtml(it.id)}">
+                <time class="${ROOT_CLASS}__counter-event-time">${escapeHtml(ts)}</time>
+                <span class="${ROOT_CLASS}__counter-event-chip">${chipHtml}</span>
+            </li>`;
+        }).join('');
+    }
+
+    async function toggleCounterDrilldown(root, eid, axis, counterRow) {
+        if (!counterRow) return;
+        const existing = counterRow.nextElementSibling
+            && counterRow.nextElementSibling.matches(`.${ROOT_CLASS}__counter-events[data-axis="${axis}"]`)
+            ? counterRow.nextElementSibling : null;
+        if (existing) {
+            existing.remove();
+            counterRow.setAttribute('aria-expanded', 'false');
+            counterRow.classList.remove(`${ROOT_CLASS}__counter-row--expanded`);
+            return;
+        }
+        const list = document.createElement('ul');
+        list.className = `${ROOT_CLASS}__counter-events`;
+        list.dataset.axis = axis;
+        list.innerHTML = `<li class="${ROOT_CLASS}__counter-event-row" data-state="loading">Loading…</li>`;
+        counterRow.insertAdjacentElement('afterend', list);
+        counterRow.setAttribute('aria-expanded', 'true');
+        counterRow.classList.add(`${ROOT_CLASS}__counter-row--expanded`);
+        try {
+            const data = await fetchCounterEvents(eid, axis);
+            list.innerHTML = renderCounterEvents(data.items || []);
+        } catch (err) {
+            list.innerHTML = `<li class="${ROOT_CLASS}__counter-event-row" data-state="error">Failed to load: ${escapeHtml(err.message)}</li>`;
+        }
     }
 
     function ensureStyles() {
@@ -369,13 +505,38 @@
 .${ROOT_CLASS}__section-title { font-size: 13px; font-weight: 600;
     color: var(--text-secondary, #aaa); margin: 0 0 10px; text-transform: uppercase; letter-spacing: 0.04em; }
 .${ROOT_CLASS}__counter-list { list-style: none; margin: 0; padding: 0; }
-.${ROOT_CLASS}__counter-row { display: flex; justify-content: space-between; align-items: center;
-    padding: 8px 0; border-bottom: 1px dashed var(--card-border, #333); }
+.${ROOT_CLASS}__counter-row { display: grid; grid-template-columns: 16px 1fr auto; gap: 8px;
+    align-items: center; padding: 8px 0; border-bottom: 1px dashed var(--card-border, #333);
+    cursor: pointer; user-select: none; }
+.${ROOT_CLASS}__counter-row[data-state] { grid-template-columns: 1fr; cursor: default;
+    color: var(--text-muted, #888); font-style: italic; padding: 12px 0; }
 .${ROOT_CLASS}__counter-row:last-child { border-bottom: none; }
+.${ROOT_CLASS}__counter-row:hover:not([data-state]) { background: rgba(255,255,255,0.03); }
+.${ROOT_CLASS}__counter-row:focus { outline: 2px solid var(--primary, #6c63ff); outline-offset: -2px; border-radius: 4px; }
+.${ROOT_CLASS}__counter-chevron { transition: transform 0.15s ease; color: var(--text-muted, #888); }
+.${ROOT_CLASS}__counter-row--expanded .${ROOT_CLASS}__counter-chevron { transform: rotate(90deg); }
 .${ROOT_CLASS}__counter-label { font-size: 13px; color: var(--text, #e0e0e0); }
 .${ROOT_CLASS}__counter-value { font-size: 16px; font-weight: 600; color: var(--primary, #6c63ff);
     background: rgba(108,99,255,0.12); padding: 2px 10px; border-radius: 999px; min-width: 32px;
     text-align: center; }
+.${ROOT_CLASS}__counter-events { list-style: none; margin: 4px 0 8px 24px; padding: 0;
+    border-left: 2px solid var(--card-border, #333); }
+.${ROOT_CLASS}__counter-event-row { display: grid; grid-template-columns: auto 1fr; gap: 8px;
+    align-items: center; padding: 4px 8px; font-size: 12px; color: var(--text-secondary, #aaa); }
+.${ROOT_CLASS}__counter-event-row[data-state] { grid-template-columns: 1fr; text-align: center;
+    color: var(--text-muted, #888); font-style: italic; padding: 8px; }
+.${ROOT_CLASS}__counter-event-time { font-variant-numeric: tabular-nums; font-size: 11px;
+    color: var(--text-muted, #888); }
+.${ROOT_CLASS}__help { background: none; border: none; color: var(--text-muted, #888);
+    cursor: pointer; padding: 4px; border-radius: 6px; display: inline-flex; align-items: center; }
+.${ROOT_CLASS}__help:hover, .${ROOT_CLASS}__help[aria-expanded="true"] { color: var(--primary, #6c63ff); background: rgba(108,99,255,0.1); }
+.${ROOT_CLASS}__header-spacer { flex: 1; }
+.${ROOT_CLASS}__help-popover { padding: 12px 18px; font-size: 12.5px; line-height: 1.55;
+    color: var(--text-secondary, #aaa); background: var(--bg-secondary, rgba(108,99,255,0.04));
+    border-bottom: 1px solid var(--card-border, #333); }
+.${ROOT_CLASS}__help-popover p { margin: 0 0 8px; }
+.${ROOT_CLASS}__help-popover p:last-child { margin-bottom: 0; }
+.${ROOT_CLASS}__help-popover svg { vertical-align: -2px; }
 .${ROOT_CLASS}__placeholder-note { font-size: 12px; color: var(--text-muted, #888); font-style: italic; }
 .${ROOT_CLASS}__log-list { list-style: none; margin: 0; padding: 0; }
 .${ROOT_CLASS}__log-row { display: grid; grid-template-columns: auto 1fr auto; gap: 8px;
@@ -464,6 +625,14 @@
         if (e.key === 'Escape') {
             e.stopPropagation();
             close();
+        } else if ((e.key === 'Enter' || e.key === ' ') && rootEl) {
+            // Counter row keyboard activation (focused counter expands via
+            // Enter/Space, same as a button — they have role="button" set).
+            const active = document.activeElement;
+            if (active && active.classList && active.classList.contains(ROOT_CLASS + '__counter-row') && active.dataset.axis) {
+                e.preventDefault();
+                toggleCounterDrilldown(rootEl, currentEid, active.dataset.axis, active);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Three Hank-flagged improvements to the Entity Status drawer (`/api/entity-status/:eid` panel):
1. **Counter drill-down + live `openCount`** — click a counter row to see the events that drive it; number reflects currently-open pending events (drops as the entity replies), not lifetime accumulation.
2. **SVG quote icon** — the lone `❝` glyph on log rows replaced with a Lucide/Feather-family SVG matching the rest of `portal/shared/`.
3. **? help-icon next to title** — popover with two-paragraph self-doc covering counter semantics + Quote behavior.

## Source
`card_d89bd90ca94c6dd63400fdfc` (P2 — Hank 2026-06-09 14:12 TW chat + annotated screenshot https://live.staticflickr.com/65535/55323939598_87a5bc74ee_b.jpg attached on card).

## Backend changes (`backend/entity-status.js`)
- `getCounters()` now joins `outbound_msg_pending` per axis to return `openCount` alongside the existing cumulative `count`. Cumulative stays on the wire for back-compat with any badge/chart consumer.
- New `getCounterEvents(deviceId, entityId, axis, limit)` returns the rows that comprise the live count.
- New route `GET /api/entity-status/:eId/counter/:axis/events` (auth = same as `/:eId`). Default limit 30, capped at 100. Axis validated against `/^[a-z][a-z0-9_]{2,63}$/`.

## Frontend changes (`backend/public/portal/shared/entity-status-panel.js`)
- `renderCounters` prefers `openCount`; counter rows get `role=button`, `tabindex=0`, `aria-expanded`, chevron that rotates 90° on expand.
- New `renderCounterEvents` + `toggleCounterDrilldown` — inline list under the clicked counter. Chip kind is auto-selected from payload: card chip (reuses `.autolink-chip` popover) → message-coord chip → event-type chip.
- New `fetchCounterEvents` against the new endpoint.
- `SVG_QUOTE` constant — 24x24 viewBox, fill=none, stroke=currentColor, stroke-width=2, round caps. Replaces the inline `❝` on the log-row Quote button.
- `SVG_HELP` + `SVG_CHEVRON` from the same family.
- Header now has `<button class="entity-status-panel__help">` + `<div class="entity-status-panel__help-popover" hidden>`. Clicking the `?` toggles the popover; aria-expanded mirrors state.
- Keyboard: `Esc` still closes; `Enter`/`Space` on a focused counter row toggles drill-down (existing `_onEsc` listener handles it).

## Test plan
- [x] `npx jest backend/tests/jest/chat-entity-status-badges.test.js` → 25/25 pass (5 suites). Counter wire shape only adds `openCount`; no field rename / removal.
- [x] `node --check` on both edited files
- [ ] Post-merge / Railway: open Entity Status panel on prod, click each counter row, verify drill-down expands with timestamps + chips, verify Quote icon is SVG not glyph, click `?` and read the popover.

## Out of scope (next PR)
- Auto-resolve / explicit-clear of pending rows when entity actually replies (this PR surfaces the truth; the replied-detected → row-cleared path lives elsewhere and is tracked via the existing sweeper).
- Counter math overhaul (which event types map to which axis) — same taxonomy.
- i18n fanout for the new help popover strings (matches existing English-only pattern in this file's `COUNTER_LABELS_EN` family).

🤖 Generated with [Claude Code](https://claude.com/claude-code)