### PR TITLE
fix(entity-status): card chips in log/drilldown actually open the popover

### DIFF
--- a/backend/public/portal/shared/entity-status-panel.js
+++ b/backend/public/portal/shared/entity-status-panel.js
@@ -408,12 +408,25 @@
                 e.stopPropagation();
                 return;
             }
-            // Card chip click: the chip is now a .autolink-chip span — let the
-            // global AutolinkChipPreview document listener open its popover
-            // (the popover has a "打開完整頁面 →" link to navigate). Stop
-            // propagation so the drawer's own click-outside-closes logic
-            // (if any) doesn't fire.
-            if (e.target.closest('.autolink-chip')) {
+            // Card / autolink-chip click. The earlier comment claimed the
+            // document-level chip-preview handler would open the popover —
+            // it doesn't (autolink-chip-preview.js' document listener only
+            // CLOSES on outside-click). Opening lives on each chip's own
+            // onclick attribute that AutolinkChip.flush() bakes in, but the
+            // chips we render here in entity-status-panel are produced
+            // locally (renderSummaryHtml + renderCounterEvents) and don't
+            // get that inline handler. Invoke the preview opener directly
+            // off the click event so the user gets the popover (cf. Hank
+            // 2026-06-09 18:13 TW bug report w/ annotated photos).
+            const chip = e.target.closest && e.target.closest('.autolink-chip');
+            if (chip) {
+                const refType = chip.getAttribute('data-ref-type');
+                const refId = chip.getAttribute('data-ref-id');
+                if (refType && refId && typeof window.AutolinkChipPreview === 'function') {
+                    try { window.AutolinkChipPreview(refType, refId, chip); } catch (_) { /* ok */ }
+                }
+                // Stop propagation so the outer drawer / chat-page click
+                // listeners don't treat this as a panel-area click.
                 e.stopPropagation();
             }
         });


### PR DESCRIPTION
## Summary
Card chips rendered locally by `entity-status-panel.js` (in `renderSummaryHtml` + `renderCounterEvents`) had no click handler, so clicking them was a no-op. Hank flagged on 2026-06-09 18:13 TW with annotated photos (operation log chip click → nothing; expected → the `KANBAN CARD` popover).

## Root cause
The earlier comment in the panel's click delegation claimed the document-level chip-preview handler would open the popover. It doesn't — `autolink-chip-preview.js`' document listener only handles **close-on-outside-click** (line 313, gated by `if (!stack.length) return`). Opening is owned by each chip's inline `onclick="AutolinkChip.onChipClick(this, event)"` attribute that `AutolinkChip.flush()` bakes in (`autolink-chip.js:62`), which calls `window.AutolinkChipPreview(refType, refId, el)`.

The chips this panel renders (`renderSummaryHtml`'s `replace` for `card_xxx` tokens in event_summary, and `renderCounterEvents`'s chip per drill-down row) build the `.autolink-chip` span manually with `data-ref-type` / `data-ref-id` but skip the inline `onclick`. Result: click reaches `root` delegation, hits the dead-code `stopPropagation`, nothing else fires.

## Fix
In the drawer's existing click delegation, when a click lands on `.autolink-chip` read `data-ref-type` / `data-ref-id` and invoke `window.AutolinkChipPreview(refType, refId, chip)` directly. Keep `stopPropagation` so the chat-page outer click listeners don't treat it as a panel-area click. No HTML change, no inline onclick — delegation only.

## Card
`card_b24fedb43430b40f59161162` (P2)

## Test plan
- [x] `node --check backend/public/portal/shared/entity-status-panel.js`
- [ ] Post-deploy Playwright on `/portal/chat.html`:
  - Open entity drawer; click an operation-log card chip → KANBAN CARD popover appears
  - Click a chip inside a counter drill-down → popover appears
  - Click outside an open popover → popover closes (no regression on the close-on-outside listener)

## Out of scope
- Refactoring the AutolinkChip inline-onclick pattern (cross-cutting, separate cleanup)
- Popover content / layout (the popover already looks correct in 圖2; only the open path was broken)

🤖 Generated with [Claude Code](https://claude.com/claude-code)