### PR TITLE
fix(chat,entity-status): kill paste-id-token in quote flow, smart-quote only

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3733,27 +3733,20 @@
                 const pq = localStorage.getItem('eclaw_pending_quote');
                 if (pq) {
                     localStorage.removeItem('eclaw_pending_quote');
-                    const { source, title, excerpt, prefillInput, messageId, meta, ts } = JSON.parse(pq);
+                    // prefillInput intentionally NOT destructured: per Hank
+                    // 2026-06-09 20:10 TW, all quote flows must be smart-quote
+                    // (reply-bar banner + auto-toggle receivers + send-time
+                    // ↩-prefix carries the reference), not paste-id-token. The
+                    // legacy prefillInput consumption dumped raw card_xxx /
+                    // mindmap_<uuid> tokens into the textbox — that's exactly
+                    // the copy-paste behavior to kill. We silently ignore the
+                    // field so existing callers (mission-mindmap.js,
+                    // mission.html, entity-status-panel) can still emit it
+                    // without behavior change at the sink.
+                    const { source, title, excerpt, messageId, meta, ts } = JSON.parse(pq);
                     if (Date.now() - ts < 120000) { // within 2 minutes
                         await openChatMessageDeepLink(messageId, { showMissingToast: true, scroll: true });
                         quoteToChat(source, title, excerpt || '', meta);
-                        // prefillInput: drop a chip token (or any text) directly
-                        // into the input so users can press send without typing.
-                        // Used by mindmap chip 📌 引用 — delivers mindmap_<uuid>
-                        // / card_<id> token, which autolink-chip then renders
-                        // as a chip preview in the sent message.
-                        if (prefillInput) {
-                            const inp = document.getElementById('messageInput');
-                            if (inp) {
-                                inp.value = prefillInput;
-                                inp.focus();
-                                try { inp.setSelectionRange(prefillInput.length, prefillInput.length); } catch(e2) {}
-                            }
-                            // The chat_draft restore below would otherwise
-                            // overwrite the prefill with a stale draft; the
-                            // deep-link explicitly asked for prefill, so it wins.
-                            localStorage.removeItem('chat_draft');
-                        }
                     }
                 }
             } catch(e) {}
@@ -3785,21 +3778,15 @@
                 }
             } catch(e) {}
 
-            // Cross-iframe quote from workspace.html relay — only accepted from same origin
+            // Cross-iframe quote from workspace.html relay — only accepted from same origin.
+            // prefillInput intentionally ignored (see localStorage handler above for
+            // the rationale: smart-quote only, no paste-id-token).
             window.addEventListener('message', async (e) => {
                 if (e.origin !== window.location.origin) return;
                 if (!e.data || e.data.type !== 'eclaw_quote') return;
-                const { source, title, excerpt, prefillInput, messageId, meta } = e.data;
+                const { source, title, excerpt, messageId, meta } = e.data;
                 await openChatMessageDeepLink(messageId, { showMissingToast: true, scroll: true });
                 quoteToChat(source, title, excerpt || '', meta);
-                if (prefillInput) {
-                    const inp = document.getElementById('messageInput');
-                    if (inp) {
-                        inp.value = String(prefillInput);
-                        inp.focus();
-                        try { inp.setSelectionRange(inp.value.length, inp.value.length); } catch(e2) {}
-                    }
-                }
             });
 
             // Mount @mention autocomplete on the message input.

--- a/backend/public/portal/shared/entity-status-panel.js
+++ b/backend/public/portal/shared/entity-status-panel.js
@@ -297,36 +297,22 @@
             const meta = cardId
                 ? { kind: 'card', cardId, cardAssignedBots: cardAssignedBots || [] }
                 : { kind: 'chat-system' };
-            // prefillInput drops the card_<id> token into the textbox so the
-            // sent message renders the same .autolink-chip preview the rest of
-            // chat does — preserves the deep-link affordance the old text-token
-            // impl gave, but now alongside the reply-bar banner rather than
-            // instead of it.
-            const prefillInput = cardId ? (cardId + ' ') : '';
-
+            // Smart-quote ONLY. The earlier impl pre-filled `card_<id>` into
+            // the textbox so the sent message would render a chip preview,
+            // but that's exactly the paste-id behavior Hank called out as
+            // off-pattern on 2026-06-09 20:10 TW. The reply-bar banner
+            // (📌 source / title: excerpt) + meta + send-time ↩-prefix
+            // already carry the card reference; the receiver bot sees the
+            // chip from meta. No token paste needed.
             if (typeof window.quoteToChat === 'function') {
-                // Same-surface path: chat.html owns this. Just light up the bar.
                 try { window.quoteToChat(source, title, excerpt, meta); } catch (_) { /* ok */ }
-                if (prefillInput) {
-                    const inp = document.getElementById('messageInput');
-                    if (inp) {
-                        const cur = inp.value || '';
-                        // Don't double-stamp the token if the user already has it.
-                        if (cur.indexOf(prefillInput.trim()) === -1) {
-                            inp.value = (cur + (cur && !cur.endsWith(' ') ? ' ' : '') + prefillInput).trimStart();
-                            inp.focus();
-                            try { inp.setSelectionRange(inp.value.length, inp.value.length); } catch (_) { /* ok */ }
-                            inp.dispatchEvent(new Event('input', { bubbles: true }));
-                        }
-                    }
-                }
                 close();
                 return;
             }
             // Cross-page path: hand off via localStorage and navigate.
             try {
                 localStorage.setItem('eclaw_pending_quote', JSON.stringify({
-                    source, title, excerpt, prefillInput, meta, ts: Date.now(),
+                    source, title, excerpt, meta, ts: Date.now(),
                 }));
             } catch (_) { /* private mode etc — fall through to navigation */ }
             close();


### PR DESCRIPTION
## Summary
Hank flagged 2026-06-09 20:10 TW: every 📌 引用 must use the reply-bar banner (`setReplyContext` + auto-toggle receivers + send-time `↩`-prefix), not paste a raw token into the chat textbox.

The legacy `prefillInput` path was still landing `card_xxx` / `mindmap_<uuid>` in messageInput from multiple callers (mind-map node 📌, mission.html 📌, entity-status-panel Quote per PR #3259/#3260).

## Fix (single-sink)
`backend/public/portal/chat.html` — both quote-pickup paths stop consuming `prefillInput`:
- localStorage `eclaw_pending_quote` handler (was lines 3745-3756)
- cross-iframe `eclaw_quote` postMessage handler (was lines 3795-3802)

Callers that still emit `prefillInput` (`mission-mindmap.js`, `mission.html`, `entity-status-panel.js`) are silently ignored — backwards-compat, no behavior change at any non-chat surface.

`backend/public/portal/shared/entity-status-panel.js` — drop the `prefillInput = cardId + ' '` emission + textbox-mutation fallback block that PR #3260 added. `quoteToChat()` alone does the work now.

Per chat.html:6225-6238, sending an empty user-text reply with the reply-bar banner active still finalizes to `↩ <sender>: "<excerpt>"`, so users can "just hit send" without any token paste.

## Card
`card_42da31cf67ef5ab16fe222f7` (P1)

## Test plan
- [x] `node --check` on entity-status-panel.js
- [x] grep `inp.value = prefillInput` → 0 hits post-edit
- [ ] Post-deploy Playwright on `/portal/chat.html`:
  - Stash a pending quote in localStorage with `prefillInput: 'card_xxx'`; navigate to chat; assert `messageInput.value === ''` after pickup runs.
  - Click entity-status-panel Quote on a log row; assert no `card_xxx` lands in textbox; reply-bar shows the title+excerpt.

## Out of scope
- Reply-bar visual restyle
- Removing `prefillInput` emission from non-chat callers (defer — sink-removal is sufficient and keeps backwards-compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)