### PR TITLE
docs(roadmap): flip Hermes H2 t1 + t2 partial → done

### DIFF
--- a/backend/public/portal/roadmap.html
+++ b/backend/public/portal/roadmap.html
@@ -665,8 +665,8 @@
                 <h3>Phase H2 — <span data-i18n="rm_h2_name">Operational Maturity</span> <span class="rm-status-badge partial" data-i18n="rm_in_progress">In Progress</span></h3>
                 <div class="rm-phase-desc" data-i18n="rm_h2_desc">Hermes as a reliable team member: health monitoring, self-healing, SLA tracking. Targets: ≥99% weekly uptime, 6h health-check.</div>
                 <ul class="rm-tasks">
-                    <li class="partial" data-i18n="rm_h2_t1">Hermes accepts i18n batch cards via speakTo and delivers PRs on time</li>
-                    <li class="partial" data-i18n="rm_h2_t2">Hermes health-check cron: git push test every 6h; alert commander on 3 consecutive failures</li>
+                    <li class="done" data-i18n="rm_h2_t1">Hermes accepts i18n batch cards via speakTo and delivers PRs on time</li>
+                    <li class="done" data-i18n="rm_h2_t2">Hermes health-check cron: git push test every 6h; alert commander on 3 consecutive failures</li>
                     <li class="todo" data-i18n="rm_h2_t3">Hermes uses Linear API to update card status after PR merge (closed/labelled)</li>
                     <li class="done" data-i18n="rm_h2_t4">Railway restart policy set to always; OOM or stuck loop triggers immediate restart with commander notification</li>
                     <li data-i18n="rm_h2_t5">Hermes memory persists between sessions via hermes_state.db (already configured)</li>


### PR DESCRIPTION
## Summary
- 2026-06-09 roadmap audit (per Hank): flip H2 t1 (i18n batch delivery) + H2 t2 (health-check cron) from `partial` to `done` after direct verification.
- Remaining H2/H3 partial + todo items stay (filed as kanban cards card_665e0f92 / card_d3983f06 / card_1242aaa5 / card_9a3649b0 awaiting Hermes consult on Linear key, log drain, per-org token, UAC ordering).

## Verification
- **H2 t1**: PR #3237 (feat(i18n): ja settings-help fanout — 27 keys, 1st of 12 locales) merged 2026-06-08 by Hermes. Delivery-on-time confirmed.
- **H2 t2**: `backend/hermes-health-check.js` line 5 `DEFAULT_CRON = '23 */6 * * *'` (every 6h) + line 8 `ALERT_FAILURE_THRESHOLD = 3` (matches spec) + jest test at `backend/tests/jest/hermes-health-check.test.js`.

## Test plan
- [ ] After merge + Railway deploy: GET https://eclawbot.com/portal/roadmap.html → scroll to "🤖 Hermes Channel" → Phase H2 → confirm t1 + t2 render with `done` (green) badge, not `partial` (yellow).
- [ ] Mobile 390x844 + desktop 1280x800 screenshots attached to meta card `card_c1c7ae1e22ae126a3610f2aa`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)