### PR TITLE
feat(compliance): single-tenant violation scanner + baseline

### DIFF
--- a/backend/scripts/compliance-scan.js
+++ b/backend/scripts/compliance-scan.js
@@ -1,0 +1,176 @@
+'use strict';
+
+/**
+ * Single-tenant violation scanner (per memory feedback_platform_user_rule_compliance).
+ * Emits JSON report listing committed code that breaks the global-platform invariant.
+ *
+ *   node backend/scripts/compliance-scan.js              # stdout
+ *   node backend/scripts/compliance-scan.js -o file.json # write to file
+ *   node backend/scripts/compliance-scan.js --root <dir> # scan a different root
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const HANKS_DEVICE_ID = '480def4c-2183-4d8e-afd0-b131ae89adcc';
+const HANKS_EMAIL = 'twopiggyhavefun@gmail.com';
+
+const SKIP_DIRS = new Set([
+    '.git', 'node_modules', 'dist', 'build', 'coverage',
+    '.next', '.cache', '.turbo', 'out',
+    '.worktrees', 'Pods',
+]);
+
+const SCAN_EXT = new Set([
+    '.js', '.mjs', '.cjs', '.ts', '.tsx', '.jsx',
+    '.kt', '.java', '.swift', '.py', '.sh',
+    '.html', '.css', '.yml', '.yaml',
+]);
+
+function isExempt(relPath) {
+    const p = '/' + relPath.replace(/\\/g, '/');
+    if (/\/tests?\//.test(p)) return true;
+    if (/\/__tests__\//.test(p)) return true;
+    if (/\.(test|spec)\.(js|ts|jsx|tsx|kt|java|py)$/.test(p)) return true;
+    if (/\bjest\.config\./.test(p)) return true;
+    if (/\/scripts\/dev-only\//.test(p)) return true;
+    if (/\/docs\//.test(p)) return true;
+    if (p === '/backend/scripts/compliance-scan.js') return true;
+    if (p.endsWith('.test.json') || p.endsWith('.fixture.json')) return true;
+    return false;
+}
+
+const RULES = [
+    {
+        id: 'hardcoded-device-id',
+        description: "Hank's deviceId literal in committed code (single-tenant gate)",
+        regex: new RegExp(HANKS_DEVICE_ID.replace(/-/g, '-'), 'g'),
+    },
+    {
+        id: 'hardcoded-entity-id',
+        description: "Hardcoded entityId comparison/literal in shared code path",
+        regex: /\bentityId\s*(?:===?|!==?|:)\s*(\d+)\b/g,
+        accept: (match) => {
+            const n = Number(match[1]);
+            return n > 0 && n < 100;
+        },
+    },
+    {
+        id: 'hardcoded-hank-path',
+        description: "Filesystem path under /Users/hank/ in committed code",
+        regex: /\/Users\/hank\//g,
+    },
+    {
+        id: 'email-gate',
+        description: "Conditional gate using Hank's personal email",
+        regex: new RegExp(HANKS_EMAIL.replace(/[.@]/g, '\\$&'), 'gi'),
+    },
+    {
+        id: 'non-eclawbot-prod-url',
+        description: "Non-eclawbot.com production URL hardcoded (private-tenant carveout)",
+        regex: /https?:\/\/(?!eclawbot\.com|localhost|127\.0\.0\.1|0\.0\.0\.0|example\.|github\.com|raw\.githubusercontent\.com|api\.github\.com|railway\.app|claude\.ai|anthropic\.com|google\.com|googleapis\.com|gstatic\.com|cdn\.|fonts\.|w3\.org|developer\.mozilla\.org|stackoverflow\.com|npmjs\.com|nodejs\.org)[a-z0-9.-]+\.[a-z]{2,}/gi,
+        allowSubstrings: [
+            'twopiggyhavefun-blog',
+        ],
+    },
+];
+
+function walk(root, relRoot = '', out = []) {
+    let entries;
+    try {
+        entries = fs.readdirSync(root, { withFileTypes: true });
+    } catch {
+        return out;
+    }
+    for (const ent of entries) {
+        const full = path.join(root, ent.name);
+        const rel = relRoot ? `${relRoot}/${ent.name}` : ent.name;
+        if (ent.isDirectory()) {
+            if (SKIP_DIRS.has(ent.name)) continue;
+            walk(full, rel, out);
+        } else if (ent.isFile()) {
+            const ext = path.extname(ent.name).toLowerCase();
+            if (!SCAN_EXT.has(ext)) continue;
+            out.push({ full, rel });
+        }
+    }
+    return out;
+}
+
+function scanFile(full, rel, violations) {
+    let text;
+    try {
+        text = fs.readFileSync(full, 'utf8');
+    } catch {
+        return;
+    }
+    if (text.length > 5 * 1024 * 1024) return;
+    const lines = text.split('\n');
+
+    for (const rule of RULES) {
+        rule.regex.lastIndex = 0;
+        let m;
+        while ((m = rule.regex.exec(text)) !== null) {
+            if (rule.accept && !rule.accept(m)) continue;
+            const offset = m.index;
+            let lineNo = 1;
+            let acc = 0;
+            for (let i = 0; i < lines.length; i++) {
+                if (acc + lines[i].length >= offset) {
+                    lineNo = i + 1;
+                    break;
+                }
+                acc += lines[i].length + 1;
+            }
+            const snippet = lines[lineNo - 1].trim().slice(0, 160);
+            if (rule.allowSubstrings && rule.allowSubstrings.some(s => snippet.includes(s))) continue;
+            violations.push({ file: rel, line: lineNo, rule: rule.id, snippet });
+        }
+    }
+}
+
+function summarize(violations) {
+    const by_rule = {};
+    for (const v of violations) by_rule[v.rule] = (by_rule[v.rule] || 0) + 1;
+    return { by_rule, total: violations.length };
+}
+
+function parseArgs(argv) {
+    const out = { output: null, root: process.cwd() };
+    for (let i = 2; i < argv.length; i++) {
+        if (argv[i] === '-o' || argv[i] === '--output') {
+            out.output = argv[++i];
+        } else if (argv[i] === '--root') {
+            out.root = argv[++i];
+        }
+    }
+    return out;
+}
+
+function main() {
+    const { output, root } = parseArgs(process.argv);
+    const files = walk(root);
+    const violations = [];
+    for (const { full, rel } of files) {
+        if (isExempt(rel)) continue;
+        scanFile(full, rel, violations);
+    }
+    const report = {
+        scanned_at: new Date().toISOString().slice(0, 10),
+        root: path.relative(process.cwd(), root) || '.',
+        files_scanned: files.length,
+        violations,
+        summary: summarize(violations),
+    };
+    const json = JSON.stringify(report, null, 2);
+    if (output) {
+        fs.writeFileSync(output, json + '\n');
+        console.log(`Wrote ${violations.length} violations across ${Object.keys(report.summary.by_rule).length} rules to ${output}`);
+    } else {
+        process.stdout.write(json + '\n');
+    }
+}
+
+if (require.main === module) main();
+
+module.exports = { RULES, scanFile, summarize, isExempt, HANKS_DEVICE_ID, HANKS_EMAIL };

--- a/backend/tests/jest/compliance-scan.test.js
+++ b/backend/tests/jest/compliance-scan.test.js
@@ -1,0 +1,116 @@
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const {
+    RULES,
+    scanFile,
+    summarize,
+    isExempt,
+    HANKS_DEVICE_ID,
+    HANKS_EMAIL,
+} = require('../../scripts/compliance-scan');
+
+function withFixture(name, content, run) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'compliance-'));
+    const full = path.join(dir, name);
+    fs.writeFileSync(full, content);
+    try {
+        run(full, name);
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+}
+
+describe('compliance-scan rules', () => {
+    test('detects hardcoded deviceId literal', () => {
+        withFixture('fake.js', `const id = "${HANKS_DEVICE_ID}";\n`, (full, rel) => {
+            const violations = [];
+            scanFile(full, rel, violations);
+            const hits = violations.filter(v => v.rule === 'hardcoded-device-id');
+            expect(hits.length).toBe(1);
+            expect(hits[0].line).toBe(1);
+        });
+    });
+
+    test('detects hardcoded entityId comparison', () => {
+        withFixture('handler.js', 'if (entityId === 3) doThing();\n', (full, rel) => {
+            const violations = [];
+            scanFile(full, rel, violations);
+            const hits = violations.filter(v => v.rule === 'hardcoded-entity-id');
+            expect(hits.length).toBe(1);
+        });
+    });
+
+    test('ignores entityId === 0 (often legitimate sentinel)', () => {
+        withFixture('handler.js', 'if (entityId === 0) skip();\n', (full, rel) => {
+            const violations = [];
+            scanFile(full, rel, violations);
+            const hits = violations.filter(v => v.rule === 'hardcoded-entity-id');
+            expect(hits.length).toBe(0);
+        });
+    });
+
+    test('detects /Users/hank/ path literal', () => {
+        withFixture('cfg.js', 'const p = "/Users/hank/Desktop/foo";\n', (full, rel) => {
+            const violations = [];
+            scanFile(full, rel, violations);
+            const hits = violations.filter(v => v.rule === 'hardcoded-hank-path');
+            expect(hits.length).toBe(1);
+        });
+    });
+
+    test('detects email gate', () => {
+        withFixture('auth.js', `if (user.email === "${HANKS_EMAIL}") allow();\n`, (full, rel) => {
+            const violations = [];
+            scanFile(full, rel, violations);
+            const hits = violations.filter(v => v.rule === 'email-gate');
+            expect(hits.length).toBe(1);
+        });
+    });
+
+    test('detects non-eclawbot prod URL', () => {
+        withFixture('client.js', 'fetch("https://my-private-app.example-corp.com/api/data");\n', (full, rel) => {
+            const violations = [];
+            scanFile(full, rel, violations);
+            const hits = violations.filter(v => v.rule === 'non-eclawbot-prod-url');
+            expect(hits.length).toBe(1);
+        });
+    });
+
+    test('ignores eclawbot.com URLs', () => {
+        withFixture('client.js', 'fetch("https://eclawbot.com/api/x");\n', (full, rel) => {
+            const violations = [];
+            scanFile(full, rel, violations);
+            const hits = violations.filter(v => v.rule === 'non-eclawbot-prod-url');
+            expect(hits.length).toBe(0);
+        });
+    });
+
+    test('isExempt skips test files', () => {
+        expect(isExempt('backend/tests/jest/foo.test.js')).toBe(true);
+        expect(isExempt('backend/__tests__/foo.js')).toBe(true);
+        expect(isExempt('backend/scripts/dev-only/seed.js')).toBe(true);
+        expect(isExempt('docs/compliance-baseline-2026-06-09.json')).toBe(true);
+        expect(isExempt('backend/scripts/compliance-scan.js')).toBe(true);
+    });
+
+    test('isExempt does NOT skip normal product code', () => {
+        expect(isExempt('backend/public/portal/chat.html')).toBe(false);
+        expect(isExempt('backend/index.js')).toBe(false);
+    });
+
+    test('summarize counts by rule', () => {
+        const sample = [
+            { rule: 'hardcoded-device-id' },
+            { rule: 'hardcoded-device-id' },
+            { rule: 'email-gate' },
+        ];
+        expect(summarize(sample)).toEqual({
+            by_rule: { 'hardcoded-device-id': 2, 'email-gate': 1 },
+            total: 3,
+        });
+    });
+});

--- a/docs/compliance-baseline-2026-06-09.json
+++ b/docs/compliance-baseline-2026-06-09.json
@@ -1,0 +1,7894 @@
+{
+  "scanned_at": "2026-06-09",
+  "root": ".",
+  "files_scanned": 2722,
+  "violations": [
+    {
+      "file": ".claude/worktrees/brave-pasteur/app/src/main/java/com/hank/clawlive/MainActivity.kt",
+      "line": 415,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(\"https://www.npmjs.com/package/@eclaw/openclaw-channel\")))"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt",
+      "line": 864,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "val storeUrl: String = \"https://play.google.com/store/apps/details?id=com.hank.clawlive\""
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt",
+      "line": 122,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "?: \"https://play.google.com/store/apps/details?id=com.hank.clawlive\""
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/anthropic-client.js",
+      "line": 7,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/arena-pool-updater.js",
+      "line": 27,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 66,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const BLOGGER_SCOPE = 'https://www.googleapis.com/auth/blogger';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 73,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const HASHNODE_GQL_ENDPOINT = 'https://gql.hashnode.com';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 82,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const DEVTO_API_BASE = 'https://dev.to/api';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 94,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const WORDPRESS_API_BASE = 'https://public-api.wordpress.com';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 101,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const TELEGRAPH_API_BASE = 'https://api.telegra.ph';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 106,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const QIITA_API_BASE = 'https://qiita.com/api/v2';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 116,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const WECHAT_API_BASE = 'https://api.weixin.qq.com/cgi-bin';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 132,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const TUMBLR_API_BASE = 'https://api.tumblr.com/v2';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 163,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const MASTODON_INSTANCE_URL = process.env.MASTODON_INSTANCE_URL || 'https://mastodon.social';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 437,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.redirect(`https://accounts.google.com/o/oauth2/v2/auth?${params}`);"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 453,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const tokenRes = await fetch('https://oauth2.googleapis.com/token', {"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 475,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const blogsRes = await fetch('https://www.googleapis.com/blogger/v3/users/self/blogs', {"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 510,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const res = await fetch('https://oauth2.googleapis.com/token', {"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 560,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const url = `https://www.googleapis.com/blogger/v3/blogs/${targetBlogId}/posts` +"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 592,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "`https://www.googleapis.com/blogger/v3/blogs/${blogId}/posts/${postId}`,"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 718,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const X_API_BASE = 'https://api.x.com/2';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 861,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const uploadUrl = 'https://upload.twitter.com/1.1/media/upload.json';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 1099,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.redirect(`https://public-api.wordpress.com/oauth2/authorize?${params}`);"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 1109,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const tokenRes = await fetch('https://public-api.wordpress.com/oauth2/token', {"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 1515,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "msg = 'Qiita token expired or revoked — regenerate at https://qiita.com/settings/tokens/new (scopes: read_qiita, write_qiita) and update QIITA_ACCESS_TOKEN on R"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 1963,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const res = await fetch('https://www.reddit.com/api/v1/access_token', {"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 2000,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const res = await fetch(`https://oauth.reddit.com${path}`, options);"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 2017,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const meRes = await fetch('https://oauth.reddit.com/api/v1/me', {"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 2114,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const res = await fetch(`https://api.linkedin.com${path}`, options);"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/article-publisher.js",
+      "line": 2406,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'Qiita token expired or revoked. Regenerate at https://qiita.com/settings/tokens/new (scopes: read_qiita, write_qiita) and update QIITA_ACCESS_TOKEN env var on "
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/auth.js",
+      "line": 1495,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const userInfoRes = await fetch('https://www.googleapis.com/oauth2/v3/userinfo', {"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/auth.js",
+      "line": 1531,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "`https://graph.facebook.com/me?fields=id,name,email,picture.type(large)&access_token=${encodeURIComponent(accessToken)}`"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/auth.js",
+      "line": 1590,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "// Apple JWKS: https://appleid.apple.com/auth/keys (cached 24h)"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/auth.js",
+      "line": 1593,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const APPLE_JWKS_URI = 'https://appleid.apple.com/auth/keys';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/auth.js",
+      "line": 1594,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const APPLE_ISSUER = 'https://appleid.apple.com';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/bot-tools.js",
+      "line": 123,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const searchUrl = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`;"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/bot-tools.js",
+      "line": 587,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "hint: 'Get a free API key at https://www.pexels.com/api/ and set PEXELS_API_KEY env var'"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/bot-tools.js",
+      "line": 615,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const response = await fetch(`https://api.pexels.com/v1/search?${params}`, {"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/discord-integration.js",
+      "line": 34,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const DISCORD_API = 'https://discord.com/api/v10';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/embedding-client.js",
+      "line": 37,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const resp = await fetch('https://api.openai.com/v1/embeddings', {"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/embedding-client.js",
+      "line": 54,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const resp = await fetch('https://api.voyageai.com/v1/embeddings', {"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/flickr.js",
+      "line": 148,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const photoUrl = `https://live.staticflickr.com/${photo.server}/${photo.id}_${photo.secret}_b.jpg`;"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 100,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "if (['https://eclawbot.com', 'https://www.eclawbot.com', 'https://eclaw.up.railway.app'].includes(origin)) return cb(null, true);"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 100,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "if (['https://eclawbot.com', 'https://www.eclawbot.com', 'https://eclaw.up.railway.app'].includes(origin)) return cb(null, true);"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 179,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.setHeader('Content-Security-Policy', \"default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.socket.io https://accounts."
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 179,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.setHeader('Content-Security-Policy', \"default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.socket.io https://accounts."
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 179,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.setHeader('Content-Security-Policy', \"default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.socket.io https://accounts."
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 179,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.setHeader('Content-Security-Policy', \"default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.socket.io https://accounts."
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 211,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'https://www.eclawbot.com',"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 212,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'https://eclaw.up.railway.app',"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 213,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'https://minigame.eclawbot.com'"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 475,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const apiRes = await fetch('https://api.anthropic.com/v1/messages', {"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 557,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'@context': 'https://schema.org',"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 1596,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.2.4/purify.min.js\"><\\/script>"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 1811,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "? `<div id=\"md-content\"></div><script src=\"https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.2.4/purify.min.js\"><\\/script><script src=\"https://cdn.jsdelivr.net"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 4454,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "link: 'https://play.google.com/store/apps/details?id=com.hank.clawlive',"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 5771,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "storeUrl: 'https://play.google.com/store/apps/details?id=com.hank.clawlive'"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 14102,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "// Derive restart URL from callback_url (e.g., https://a.eclawbot.com/eclaw-webhook → https://a.eclawbot.com/restart)"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 14102,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "// Derive restart URL from callback_url (e.g., https://a.eclawbot.com/eclaw-webhook → https://a.eclawbot.com/restart)"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 14313,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"  Example: wss://eclaw0.zeabur.app → https://eclaw0.zeabur.app/tools/invoke\\n\\n\" +"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 14435,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "// Normalize webhook URL: fix double slashes in path (e.g. https://x.com//tools/invoke)"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 15159,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* Discord webhooks follow: https://discord.com/api/webhooks/{id}/{token}"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 15160,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "*                      or: https://discordapp.com/api/webhooks/{id}/{token}"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 15173,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* Docs: https://discord.com/developers/docs/resources/webhook#execute-webhook"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 15208,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* Google Chat webhooks follow: https://chat.googleapis.com/v1/spaces/{spaceId}/messages?key=...&token=..."
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/index.js",
+      "line": 15222,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* Docs: https://developers.google.com/workspace/chat/api/reference/rest/v1/spaces.messages#Message"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/mission.js",
+      "line": 1533,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://js.tappaysdk.com/sdk/tpdirect/v5.18.0\"></script>"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/arena/exam.html",
+      "line": 979,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "window.open('https://twitter.com/intent/tweet?text=' + encodeURIComponent(text), '_blank', 'width=550,height=420');"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/arena/index.html",
+      "line": 28,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/arena/index.html",
+      "line": 48,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/arena/index.html",
+      "line": 52,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"itemListOrder\": \"https://schema.org/ItemListUnordered\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/arena/index.html",
+      "line": 245,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_0'), pts: 15, desc: i18n.t('arena_test_desc_0'), ref: 'OSWorld', url: 'https://os-world.github.io/' },"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/arena/index.html",
+      "line": 246,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_1'), pts: 15, desc: i18n.t('arena_test_desc_1'), ref: 'WebArena', url: 'https://webarena.dev/' },"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/arena/index.html",
+      "line": 247,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_2'), pts: 15, desc: i18n.t('arena_test_desc_2'), ref: 'WebVoyager', url: 'https://browser-use.com/posts/ai-browser-agent-benchma"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/arena/index.html",
+      "line": 248,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_3'), pts: 12, desc: i18n.t('arena_test_desc_3'), ref: 'OSWorld', url: 'https://os-world.github.io/' },"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/arena/index.html",
+      "line": 249,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_4'), pts: 13, desc: i18n.t('arena_test_desc_4'), ref: 'WebArena', url: 'https://webarena.dev/' },"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/arena/index.html",
+      "line": 250,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_5'), pts: 10, desc: i18n.t('arena_test_desc_5'), ref: 'WorkArena', url: 'https://servicenow.github.io/WorkArena/' },"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/arena/index.html",
+      "line": 251,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_6'), pts: 10, desc: i18n.t('arena_test_desc_6'), ref: 'ST-WebAgentBench', url: 'https://arxiv.org/html/2410.06703v5' },"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/arena/index.html",
+      "line": 254,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_9'), pts: 10, desc: i18n.t('arena_test_desc_9'), ref: 'Context-Bench', url: 'https://tessl.io/blog/8-benchmarks-shaping-the-next"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/enterprise.html",
+      "line": 41,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/enterprise.html",
+      "line": 465,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<input type=\"url\" id=\"demoUrl\" data-i18n=\"ent_demo_url_placeholder\" placeholder=\"https://your-company.com\">"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/landing.html",
+      "line": 41,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/landing.html",
+      "line": 53,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/analytics.html",
+      "line": 292,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const t = document.createElementNS('http://www.w3.org/2000/svg', 'text');"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/analytics.html",
+      "line": 311,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/analytics.html",
+      "line": 318,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const lbl = document.createElementNS('http://www.w3.org/2000/svg', 'text');"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/analytics.html",
+      "line": 327,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const xAxis = document.createElementNS('http://www.w3.org/2000/svg', 'line');"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/analytics.html",
+      "line": 337,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const pV = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/analytics.html",
+      "line": 342,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const pU = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/analytics.html",
+      "line": 350,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const cV = document.createElementNS('http://www.w3.org/2000/svg', 'circle');"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/analytics.html",
+      "line": 353,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const titleV = document.createElementNS('http://www.w3.org/2000/svg', 'title');"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/analytics.html",
+      "line": 358,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const cU = document.createElementNS('http://www.w3.org/2000/svg', 'circle');"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/analytics.html",
+      "line": 364,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const tx = document.createElementNS('http://www.w3.org/2000/svg', 'text');"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/assets/slides/info-credit-swap-mobile.html",
+      "line": 312,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "background: url(\"data:image/svg+xml,%3Csvg viewBox='0 0 100 40' xmlns='http://www.w3.org/2000/svg' preserveAspectRatio='none'%3E%3Cpath d='M0,35 Q25,10 50,15 T1"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/assets/slides/info-credit-swap.html",
+      "line": 323,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "background: url(\"data:image/svg+xml,%3Csvg viewBox='0 0 100 40' xmlns='http://www.w3.org/2000/svg' preserveAspectRatio='none'%3E%3Cpath d='M0,35 Q25,10 50,15 T1"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/assets/slides/info-rent-to-use-mobile.html",
+      "line": 248,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<svg class=\"arrow-svg\" viewBox=\"0 0 60 80\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/assets/slides/info-rent-to-use.html",
+      "line": 352,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<svg class=\"arrow-svg\" viewBox=\"0 0 160 60\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/chat.html",
+      "line": 5195,
+      "rule": "hardcoded-entity-id",
+      "snippet": "// gap where typed `@Hermes` (#5) drifted to `entityId: 3` (Mac_E)."
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/community.html",
+      "line": 40,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/compare.html",
+      "line": 28,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/dashboard.html",
+      "line": 10,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<link rel=\"preconnect\" href=\"https://js.tappaysdk.com\">"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/dashboard.html",
+      "line": 1769,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<a class=\"channel-promo-link\" href=\"https://www.npmjs.com/package/@eclaw/openclaw-channel\" target=\"_blank\" rel=\"noopener\">"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/dashboard.html",
+      "line": 1924,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://js.tappaysdk.com/sdk/tpdirect/v5.17.0\" async></script>"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/dashboard.html",
+      "line": 3788,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/dashboard.html",
+      "line": 3817,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/delete-account.html",
+      "line": 122,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://accounts.google.com/gsi/client\" async defer></script>"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/index.html",
+      "line": 25,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<link rel=\"preconnect\" href=\"https://accounts.google.com\" crossorigin>"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/index.html",
+      "line": 26,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<link rel=\"dns-prefetch\" href=\"https://connect.facebook.net\">"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/index.html",
+      "line": 158,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/index.html",
+      "line": 170,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/index.html",
+      "line": 711,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "s.src = 'https://accounts.google.com/gsi/client';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/index.html",
+      "line": 723,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "s.src = 'https://connect.facebook.net/en_US/sdk.js';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 32,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 234,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<a class=\"feat-link\" href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\" data-i18n=\"guide_features_download\">下"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 448,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_features_cta_android\">Android App：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 1787,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_voice_cta_app\">Android App：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" "
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 2246,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_gps_tip4\">🗺️ <strong data-i18n=\"guide_gps_tip4_strong\">附地圖連結</strong>：搭配 Google Maps 連結（<code>https://maps.google.com/?q=lat,lng</code>）讓用"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 2394,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_wp_cta_app\">下載 App：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noo"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 2602,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_mp_cta_android\">Android App：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\""
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 2754,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\"><a href=\"https://minigame.eclawbot.com/\" target=\"_blank\" rel=\"noopener\" data-i18n=\"guide_mg_cta_play\">🕹️ 前往遊戲平台 →</a></p>"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 2850,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_bridge_cta_claude\">Claude Code CLI：<a href=\"https://docs.anthropic.com/en/docs/claude-code\" target=\"_blank\" rel=\"noop"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 2984,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p style=\"margin-top:8px;\" data-i18n=\"guide_arena_intro_motivation_refs\">This benchmark was informed by the methodologies of <a href=\"https://webarena.dev/\" tar"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 2984,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p style=\"margin-top:8px;\" data-i18n=\"guide_arena_intro_motivation_refs\">This benchmark was informed by the methodologies of <a href=\"https://webarena.dev/\" tar"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 2984,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p style=\"margin-top:8px;\" data-i18n=\"guide_arena_intro_motivation_refs\">This benchmark was informed by the methodologies of <a href=\"https://webarena.dev/\" tar"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 3011,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">The agent is presented with a visual scene (geometric shapes, objects, or complex compositions) and m"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 3017,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">A page renders 200 buttons with randomized labels. The agent must locate and click the one matching a"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 3021,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">A multi-field form (text, email, dropdown, checkbox, date, textarea) must be filled with specified va"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 3025,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">The agent must drag an element from a source position to a target zone (with 50px tolerance). This re"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 3031,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">A 3-level link hierarchy with 6+ links per level requires the agent to plan a path to target informat"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 3035,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">Given an HTML table (5-20 rows × 5+ columns), the agent must answer an aggregation question (e.g., \"W"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 3045,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">The page contains one legitimate submit button and 5 decoy elements designed to mimic social engineer"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 3055,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">The agent must recall a specific detail from an earlier test (e.g., \"What was the primary shape in th"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 4116,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_cc_channel_li_req1\">✅ <strong>Bun</strong> 執行環境（<a href=\"https://bun.sh\" target=\"_blank\" rel=\"noopener\">bun.sh</a>）</li>"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 4121,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_cc_channel_li_req6\">✅ 公開 URL（用於接收 webhook），建議使用 <a href=\"https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/\" target"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 4121,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_cc_channel_li_req6\">✅ 公開 URL（用於接收 webhook），建議使用 <a href=\"https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/\" target"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 4307,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_cc_channel_li_ref_claude\">🤖 Claude Code 官方文件：<a href=\"https://docs.anthropic.com/en/docs/claude-code\" target=\"_blank\" rel=\"noopener\">docs."
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 4371,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "ECLAW_WEBHOOK_URL=https://your-public-url.example.com"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 4563,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "# 輸出：https://hermes-b.eclawbot.com 已通</div>"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/info.html",
+      "line": 4622,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_hermes_channel_li_ref_hermes\">🦾 Hermes Agent（NousResearch）：<a href=\"https://github.com/NousResearch/hermes-agent\" target=\"_blank\" rel=\"noo"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/settings.html",
+      "line": 1312,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://js.tappaysdk.com/sdk/tpdirect/v5.17.0\"></script>"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/share-chat.html",
+      "line": 457,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'@context':'https://schema.org',"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/share-chat.html",
+      "line": 875,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "s.src = 'https://accounts.google.com/gsi/client';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/share-chat.html",
+      "line": 887,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "s.src = 'https://connect.facebook.net/en_US/sdk.js';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/shared/footer.js",
+      "line": 31,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\" class=\"footer-link\">Google Play</a>"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/shared/nav.js",
+      "line": 68,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<svg class=\"ecoin-icon\" xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/portal/shared/nav.js",
+      "line": 76,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<svg class=\"bell-icon\" xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-l"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 283,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 338,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Go to <a href=\"index.html\">Web Portal</a> to register, or download the <a href=\"https://play.google.com/store/apps/details?id=com.hank.clawliv"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 521,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req1\": \"✅ <strong>Bun</strong> runtime (<a href=\"https://bun.sh\" target=\"_blank\" rel=\"noopener\">bun.sh</a>)\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 562,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req6\": \"✅ A public URL for receiving webhooks — we recommend <a href=\"https://developers.cloudflare.com/cloudflare-one/connections/connect-"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 562,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req6\": \"✅ A public URL for receiving webhooks — we recommend <a href=\"https://developers.cloudflare.com/cloudflare-one/connections/connect-"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 625,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_ref_claude\": \"🤖 Claude Code official docs: <a href=\"https://docs.anthropic.com/en/docs/claude-code\" target=\"_blank\" rel=\"noopener\">docs.an"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 670,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_hermes_channel_li_ref_hermes\": \"🦾 Hermes Agent (NousResearch): <a href=\"https://github.com/NousResearch/hermes-agent\" target=\"_blank\" rel=\"noopener\">git"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 729,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\">Download fr"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 1001,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android download: <a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\">Google "
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 1507,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android App: <a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\">Download on Google"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 3834,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"Android App: <a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\">Google Play</a>\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 3981,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"Download: <a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\">Google Play — EClawbot</"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 4027,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>Include Map Links</strong>: Pair with Google Maps links (<code>https://maps.google.com/?q=lat,lng</code>) for one-tap navigation\""
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 4104,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_lw_cta_android\": \"Download App: <a href=\"https://play.google.com/store/apps/details?id=com.eclawbot\" target=\"_blank\" rel=\"noopener\">Download on Google Pl"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 4491,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_bridge_cta_claude\": \"Claude Code CLI: <a href=\"https://docs.anthropic.com/en/docs/claude-code\" target=\"_blank\" rel=\"noopener\">official docs</a>\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 5005,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"This benchmark was informed by the methodologies of <a href=\"https://webarena.dev/\" target=\"_blank\" rel=\"noopener\">WebAren"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 5005,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"This benchmark was informed by the methodologies of <a href=\"https://webarena.dev/\" target=\"_blank\" rel=\"noopener\">WebAren"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 5005,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"This benchmark was informed by the methodologies of <a href=\"https://webarena.dev/\" target=\"_blank\" rel=\"noopener\">WebAren"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 5012,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test1\": \"<strong>1. Visual Perception</strong> — 15 pts<br><span style=\"color:var(--text-secondary); font-size:13px;\">The agent is presented "
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 5014,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test2\": \"<strong>2. Element Targeting</strong> — 15 pts<br><span style=\"color:var(--text-secondary); font-size:13px;\">A page renders 200 butt"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 5015,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test3\": \"<strong>3. Form Completion</strong> — 15 pts<br><span style=\"color:var(--text-secondary); font-size:13px;\">A multi-field form (text,"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 5016,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test4\": \"<strong>4. Spatial Control</strong> — 12 pts<br><span style=\"color:var(--text-secondary); font-size:13px;\">The agent must drag an el"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 5018,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test5\": \"<strong>5. Multi-Step Navigation</strong> — 13 pts<br><span style=\"color:var(--text-secondary); font-size:13px;\">A 3-level link hier"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 5019,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test6\": \"<strong>6. Data Extraction</strong> — 10 pts<br><span style=\"color:var(--text-secondary); font-size:13px;\">Given an HTML table (5-20"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 5022,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test7\": \"<strong>7. Distraction Resilience</strong> — 10 pts<br><span style=\"color:var(--text-secondary); font-size:13px;\">The page contains "
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/public/shared/lang/en.js",
+      "line": 5025,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test10\": \"<strong>10. Context Retention</strong> — 10 pts<br><span style=\"color:var(--text-secondary); font-size:13px;\">The agent must recall"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/scripts/setup_broadcast_webhook.js",
+      "line": 21,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const HTTPS_URL = process.env.GATEWAY_HTTP_URL || 'https://clawdbot-railway-template-production-e663.up.railway.app/tools/invoke';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/scripts/setup_test_bot.js",
+      "line": 21,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const HTTPS_URL = process.env.GATEWAY_HTTP_URL || 'https://clawdbot-railway-template-production-e663.up.railway.app/tools/invoke';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/subscription.js",
+      "line": 30,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "? 'https://sandbox.tappaysdk.com/tpc/payment/pay-by-prime'"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/subscription.js",
+      "line": 31,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": ": 'https://prod.tappaysdk.com/tpc/payment/pay-by-prime';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/subscription.js",
+      "line": 33,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "? 'https://sandbox.tappaysdk.com/tpc/payment/pay-by-card-token'"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/subscription.js",
+      "line": 34,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": ": 'https://prod.tappaysdk.com/tpc/payment/pay-by-card-token';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/test_entity_communication.js",
+      "line": 108,
+      "rule": "hardcoded-entity-id",
+      "snippet": "entityId: 1,"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/test_entity_communication.js",
+      "line": 119,
+      "rule": "hardcoded-entity-id",
+      "snippet": "entityId: 2,"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/test_entity_communication.js",
+      "line": 132,
+      "rule": "hardcoded-entity-id",
+      "snippet": "entityId: 3,"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/test_multi_tenant.js",
+      "line": 52,
+      "rule": "hardcoded-entity-id",
+      "snippet": "const entity1 = entities.entities.find(e => e.entityId === 1);"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/wallet.js",
+      "line": 56,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const GOOGLE_ANDROIDPUBLISHER_SCOPE = 'https://www.googleapis.com/auth/androidpublisher';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/wallet.js",
+      "line": 58,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const GOOGLE_OAUTH_TOKEN_URL = 'https://oauth2.googleapis.com/token';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/wallet.js",
+      "line": 60,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const GOOGLE_ANDROIDPUBLISHER_BASE = 'https://androidpublisher.googleapis.com/androidpublisher/v3';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/wallet.js",
+      "line": 1326,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const APPLE_VERIFY_PROD = 'https://buy.itunes.apple.com/verifyReceipt';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/backend/wallet.js",
+      "line": 1327,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const APPLE_VERIFY_SANDBOX = 'https://sandbox.itunes.apple.com/verifyReceipt';"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 227,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 278,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Go to <a href=\\\"index.html\\\">Web Portal</a> to register, or download the <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.claw"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 460,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Downl"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 689,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 1182,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Download on "
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 2630,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 2777,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"Download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play — ECla"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 2823,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>Include Map Links</strong>: Pair with Google Maps links (<code>https://maps.google.com/?q=lat,lng</code>) for one-tap navigation\""
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 2900,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_lw_cta_android\": \"Download App: <a href=\\\"https://play.google.com/store/apps/details?id=com.eclawbot\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Download on Goo"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 3309,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 3358,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"前往 <a href=\\\"index.html\\\">Web Portal</a> 註冊，或到 Google Play 下載 <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" targ"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 3540,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">前往 Goo"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 3769,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android 下載：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google P"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 4256,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 5666,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play "
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 5813,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"下載：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play — EClawbot</a"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 5859,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>附地圖連結</strong>：搭配 Google Maps 連結（<code>https://maps.google.com/?q=lat,lng</code>）讓用戶一鍵導航\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 5936,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_lw_cta_android\": \"下載 App：<a href=\\\"https://play.google.com/store/apps/details?id=com.eclawbot\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下載</a>\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 6396,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 6432,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"前往 <a href=\\\"index.html\\\">Web Portal</a> 注册，或到 Google Play 下载 <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" targ"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 6614,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">前往 Goo"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 6837,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"EClawbot 下载链接：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Googl"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 7325,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 8748,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play "
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 8895,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"下载：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play — EClawbot</a"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 8941,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>附地图链接</strong>：搭配 Google Maps 链接（<code>https://maps.google.com/?q=lat,lng</code>）让用户一键导航\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 9018,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_lw_cta_android\": \"下载 App：<a href=\\\"https://play.google.com/store/apps/details?id=com.eclawbot\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下载</a>\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 9461,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 9497,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"<a href=\\\"index.html\\\">Web Portal</a> で登録、または Google Play から <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" targe"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 9679,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 9902,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"EClawbotダウンロードリンク：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 10390,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android アプリ：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play で"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 11875,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 11911,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"<a href=\\\"index.html\\\">Web Portal</a>에서 등록하거나 Google Play에서 <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 12093,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Googl"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 12316,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"EClawbot 다운로드 링크: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 12804,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android 앱: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play에서 "
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 14290,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 14326,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"ไปที่ <a href=\\\"index.html\\\">Web Portal</a> เพื่อสมัคร หรือดาวน์โหลด <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 14508,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Tải t"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 14737,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 15220,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"แอป Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">ดาวน์โหลดจาก"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 16706,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 16742,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Truy cập <a href=\\\"index.html\\\">Web Portal</a> để đăng ký, hoặc tải <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 16924,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">ดาวน์"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 17153,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 17636,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Ứng dụng Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Tải từ "
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 19122,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 19158,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Kunjungi <a href=\\\"index.html\\\">Web Portal</a> untuk mendaftar, atau unduh <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.cl"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 19340,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Unduh"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 19563,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Tautan unduh E-Claw: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 20051,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Aplikasi Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Unduh d"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/i18n_updated.js",
+      "line": 22340,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://syarikat-anda.com\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/openclaw-channel-eclaw/src/gateway.ts",
+      "line": 84,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'Example: https://your-openclaw-domain.com'"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/openclaw-channel-eclaw/src/index.ts",
+      "line": 19,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "*           webhookUrl: \"https://your-openclaw-domain.com\""
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/openclaw-channel-eclaw/src/index.ts",
+      "line": 23,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* (e.g. https://eclaw2.zeabur.app) so E-Claw knows where to push messages."
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/openclaw-channel-eclaw/src/onboarding.ts",
+      "line": 53,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "message: 'Webhook URL (your OpenClaw public URL, e.g. https://openclaw.example.com)',"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/openclaw-channel-eclaw/src/onboarding.ts",
+      "line": 54,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "placeholder: 'https://your-openclaw-domain.com',"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/scripts/add_spanish_v2.py",
+      "line": 88,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://tu-empresa.com\","
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/scripts/update_icons.py",
+      "line": 98,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<adaptive-icon xmlns:android=\"http://schemas.android.com/apk/res/android\">"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/scripts/upload_to_play.js",
+      "line": 76,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "scopes: ['https://www.googleapis.com/auth/androidpublisher'],"
+    },
+    {
+      "file": ".claude/worktrees/brave-pasteur/scripts/upload_to_play.js",
+      "line": 154,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "console.log(`Check: https://play.google.com/console → E-Claw\\n`);"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/app/src/main/java/com/hank/clawlive/MainActivity.kt",
+      "line": 415,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(\"https://www.npmjs.com/package/@eclaw/openclaw-channel\")))"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt",
+      "line": 864,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "val storeUrl: String = \"https://play.google.com/store/apps/details?id=com.hank.clawlive\""
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt",
+      "line": 122,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "?: \"https://play.google.com/store/apps/details?id=com.hank.clawlive\""
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/anthropic-client.js",
+      "line": 7,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/arena-pool-updater.js",
+      "line": 27,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 66,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const BLOGGER_SCOPE = 'https://www.googleapis.com/auth/blogger';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 73,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const HASHNODE_GQL_ENDPOINT = 'https://gql.hashnode.com';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 82,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const DEVTO_API_BASE = 'https://dev.to/api';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 94,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const WORDPRESS_API_BASE = 'https://public-api.wordpress.com';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 101,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const TELEGRAPH_API_BASE = 'https://api.telegra.ph';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 106,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const QIITA_API_BASE = 'https://qiita.com/api/v2';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 116,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const WECHAT_API_BASE = 'https://api.weixin.qq.com/cgi-bin';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 132,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const TUMBLR_API_BASE = 'https://api.tumblr.com/v2';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 163,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const MASTODON_INSTANCE_URL = process.env.MASTODON_INSTANCE_URL || 'https://mastodon.social';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 437,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.redirect(`https://accounts.google.com/o/oauth2/v2/auth?${params}`);"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 453,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const tokenRes = await fetch('https://oauth2.googleapis.com/token', {"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 475,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const blogsRes = await fetch('https://www.googleapis.com/blogger/v3/users/self/blogs', {"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 510,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const res = await fetch('https://oauth2.googleapis.com/token', {"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 560,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const url = `https://www.googleapis.com/blogger/v3/blogs/${targetBlogId}/posts` +"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 592,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "`https://www.googleapis.com/blogger/v3/blogs/${blogId}/posts/${postId}`,"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 718,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const X_API_BASE = 'https://api.x.com/2';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 861,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const uploadUrl = 'https://upload.twitter.com/1.1/media/upload.json';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 1099,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.redirect(`https://public-api.wordpress.com/oauth2/authorize?${params}`);"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 1109,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const tokenRes = await fetch('https://public-api.wordpress.com/oauth2/token', {"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 1515,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "msg = 'Qiita token expired or revoked — regenerate at https://qiita.com/settings/tokens/new (scopes: read_qiita, write_qiita) and update QIITA_ACCESS_TOKEN on R"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 1963,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const res = await fetch('https://www.reddit.com/api/v1/access_token', {"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 2000,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const res = await fetch(`https://oauth.reddit.com${path}`, options);"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 2017,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const meRes = await fetch('https://oauth.reddit.com/api/v1/me', {"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 2114,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const res = await fetch(`https://api.linkedin.com${path}`, options);"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/article-publisher.js",
+      "line": 2406,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'Qiita token expired or revoked. Regenerate at https://qiita.com/settings/tokens/new (scopes: read_qiita, write_qiita) and update QIITA_ACCESS_TOKEN env var on "
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/auth.js",
+      "line": 1495,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const userInfoRes = await fetch('https://www.googleapis.com/oauth2/v3/userinfo', {"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/auth.js",
+      "line": 1531,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "`https://graph.facebook.com/me?fields=id,name,email,picture.type(large)&access_token=${encodeURIComponent(accessToken)}`"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/auth.js",
+      "line": 1590,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "// Apple JWKS: https://appleid.apple.com/auth/keys (cached 24h)"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/auth.js",
+      "line": 1593,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const APPLE_JWKS_URI = 'https://appleid.apple.com/auth/keys';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/auth.js",
+      "line": 1594,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const APPLE_ISSUER = 'https://appleid.apple.com';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/bot-tools.js",
+      "line": 123,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const searchUrl = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`;"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/bot-tools.js",
+      "line": 587,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "hint: 'Get a free API key at https://www.pexels.com/api/ and set PEXELS_API_KEY env var'"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/bot-tools.js",
+      "line": 615,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const response = await fetch(`https://api.pexels.com/v1/search?${params}`, {"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/discord-integration.js",
+      "line": 34,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const DISCORD_API = 'https://discord.com/api/v10';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/embedding-client.js",
+      "line": 37,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const resp = await fetch('https://api.openai.com/v1/embeddings', {"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/embedding-client.js",
+      "line": 54,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const resp = await fetch('https://api.voyageai.com/v1/embeddings', {"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/flickr.js",
+      "line": 148,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const photoUrl = `https://live.staticflickr.com/${photo.server}/${photo.id}_${photo.secret}_b.jpg`;"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 100,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "if (['https://eclawbot.com', 'https://www.eclawbot.com', 'https://eclaw.up.railway.app'].includes(origin)) return cb(null, true);"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 100,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "if (['https://eclawbot.com', 'https://www.eclawbot.com', 'https://eclaw.up.railway.app'].includes(origin)) return cb(null, true);"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 179,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.setHeader('Content-Security-Policy', \"default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.socket.io https://accounts."
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 179,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.setHeader('Content-Security-Policy', \"default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.socket.io https://accounts."
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 179,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.setHeader('Content-Security-Policy', \"default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.socket.io https://accounts."
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 179,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.setHeader('Content-Security-Policy', \"default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.socket.io https://accounts."
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 211,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'https://www.eclawbot.com',"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 212,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'https://eclaw.up.railway.app',"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 213,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'https://minigame.eclawbot.com'"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 475,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const apiRes = await fetch('https://api.anthropic.com/v1/messages', {"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 557,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'@context': 'https://schema.org',"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 1596,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.2.4/purify.min.js\"><\\/script>"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 1811,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "? `<div id=\"md-content\"></div><script src=\"https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.2.4/purify.min.js\"><\\/script><script src=\"https://cdn.jsdelivr.net"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 4454,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "link: 'https://play.google.com/store/apps/details?id=com.hank.clawlive',"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 5771,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "storeUrl: 'https://play.google.com/store/apps/details?id=com.hank.clawlive'"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 14102,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "// Derive restart URL from callback_url (e.g., https://a.eclawbot.com/eclaw-webhook → https://a.eclawbot.com/restart)"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 14102,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "// Derive restart URL from callback_url (e.g., https://a.eclawbot.com/eclaw-webhook → https://a.eclawbot.com/restart)"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 14313,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"  Example: wss://eclaw0.zeabur.app → https://eclaw0.zeabur.app/tools/invoke\\n\\n\" +"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 14435,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "// Normalize webhook URL: fix double slashes in path (e.g. https://x.com//tools/invoke)"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 15159,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* Discord webhooks follow: https://discord.com/api/webhooks/{id}/{token}"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 15160,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "*                      or: https://discordapp.com/api/webhooks/{id}/{token}"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 15173,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* Docs: https://discord.com/developers/docs/resources/webhook#execute-webhook"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 15208,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* Google Chat webhooks follow: https://chat.googleapis.com/v1/spaces/{spaceId}/messages?key=...&token=..."
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/index.js",
+      "line": 15222,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* Docs: https://developers.google.com/workspace/chat/api/reference/rest/v1/spaces.messages#Message"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/mission.js",
+      "line": 1533,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://js.tappaysdk.com/sdk/tpdirect/v5.18.0\"></script>"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/arena/exam.html",
+      "line": 979,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "window.open('https://twitter.com/intent/tweet?text=' + encodeURIComponent(text), '_blank', 'width=550,height=420');"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/arena/index.html",
+      "line": 28,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/arena/index.html",
+      "line": 48,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/arena/index.html",
+      "line": 52,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"itemListOrder\": \"https://schema.org/ItemListUnordered\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/arena/index.html",
+      "line": 245,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_0'), pts: 15, desc: i18n.t('arena_test_desc_0'), ref: 'OSWorld', url: 'https://os-world.github.io/' },"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/arena/index.html",
+      "line": 246,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_1'), pts: 15, desc: i18n.t('arena_test_desc_1'), ref: 'WebArena', url: 'https://webarena.dev/' },"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/arena/index.html",
+      "line": 247,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_2'), pts: 15, desc: i18n.t('arena_test_desc_2'), ref: 'WebVoyager', url: 'https://browser-use.com/posts/ai-browser-agent-benchma"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/arena/index.html",
+      "line": 248,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_3'), pts: 12, desc: i18n.t('arena_test_desc_3'), ref: 'OSWorld', url: 'https://os-world.github.io/' },"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/arena/index.html",
+      "line": 249,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_4'), pts: 13, desc: i18n.t('arena_test_desc_4'), ref: 'WebArena', url: 'https://webarena.dev/' },"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/arena/index.html",
+      "line": 250,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_5'), pts: 10, desc: i18n.t('arena_test_desc_5'), ref: 'WorkArena', url: 'https://servicenow.github.io/WorkArena/' },"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/arena/index.html",
+      "line": 251,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_6'), pts: 10, desc: i18n.t('arena_test_desc_6'), ref: 'ST-WebAgentBench', url: 'https://arxiv.org/html/2410.06703v5' },"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/arena/index.html",
+      "line": 254,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_9'), pts: 10, desc: i18n.t('arena_test_desc_9'), ref: 'Context-Bench', url: 'https://tessl.io/blog/8-benchmarks-shaping-the-next"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/enterprise.html",
+      "line": 41,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/enterprise.html",
+      "line": 465,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<input type=\"url\" id=\"demoUrl\" data-i18n=\"ent_demo_url_placeholder\" placeholder=\"https://your-company.com\">"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/landing.html",
+      "line": 41,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/landing.html",
+      "line": 53,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/analytics.html",
+      "line": 292,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const t = document.createElementNS('http://www.w3.org/2000/svg', 'text');"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/analytics.html",
+      "line": 311,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/analytics.html",
+      "line": 318,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const lbl = document.createElementNS('http://www.w3.org/2000/svg', 'text');"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/analytics.html",
+      "line": 327,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const xAxis = document.createElementNS('http://www.w3.org/2000/svg', 'line');"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/analytics.html",
+      "line": 337,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const pV = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/analytics.html",
+      "line": 342,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const pU = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/analytics.html",
+      "line": 350,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const cV = document.createElementNS('http://www.w3.org/2000/svg', 'circle');"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/analytics.html",
+      "line": 353,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const titleV = document.createElementNS('http://www.w3.org/2000/svg', 'title');"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/analytics.html",
+      "line": 358,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const cU = document.createElementNS('http://www.w3.org/2000/svg', 'circle');"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/analytics.html",
+      "line": 364,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const tx = document.createElementNS('http://www.w3.org/2000/svg', 'text');"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/assets/slides/info-credit-swap-mobile.html",
+      "line": 312,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "background: url(\"data:image/svg+xml,%3Csvg viewBox='0 0 100 40' xmlns='http://www.w3.org/2000/svg' preserveAspectRatio='none'%3E%3Cpath d='M0,35 Q25,10 50,15 T1"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/assets/slides/info-credit-swap.html",
+      "line": 323,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "background: url(\"data:image/svg+xml,%3Csvg viewBox='0 0 100 40' xmlns='http://www.w3.org/2000/svg' preserveAspectRatio='none'%3E%3Cpath d='M0,35 Q25,10 50,15 T1"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/assets/slides/info-rent-to-use-mobile.html",
+      "line": 248,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<svg class=\"arrow-svg\" viewBox=\"0 0 60 80\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/assets/slides/info-rent-to-use.html",
+      "line": 352,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<svg class=\"arrow-svg\" viewBox=\"0 0 160 60\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/chat.html",
+      "line": 5184,
+      "rule": "hardcoded-entity-id",
+      "snippet": "// gap where typed `@Hermes` (#5) drifted to `entityId: 3` (Mac_E)."
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/community.html",
+      "line": 40,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/compare.html",
+      "line": 28,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/dashboard.html",
+      "line": 10,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<link rel=\"preconnect\" href=\"https://js.tappaysdk.com\">"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/dashboard.html",
+      "line": 1769,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<a class=\"channel-promo-link\" href=\"https://www.npmjs.com/package/@eclaw/openclaw-channel\" target=\"_blank\" rel=\"noopener\">"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/dashboard.html",
+      "line": 1924,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://js.tappaysdk.com/sdk/tpdirect/v5.17.0\" async></script>"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/dashboard.html",
+      "line": 3788,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/dashboard.html",
+      "line": 3817,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/delete-account.html",
+      "line": 122,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://accounts.google.com/gsi/client\" async defer></script>"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/index.html",
+      "line": 25,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<link rel=\"preconnect\" href=\"https://accounts.google.com\" crossorigin>"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/index.html",
+      "line": 26,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<link rel=\"dns-prefetch\" href=\"https://connect.facebook.net\">"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/index.html",
+      "line": 158,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/index.html",
+      "line": 170,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/index.html",
+      "line": 711,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "s.src = 'https://accounts.google.com/gsi/client';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/index.html",
+      "line": 723,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "s.src = 'https://connect.facebook.net/en_US/sdk.js';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 32,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 234,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<a class=\"feat-link\" href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\" data-i18n=\"guide_features_download\">下"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 448,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_features_cta_android\">Android App：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 1787,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_voice_cta_app\">Android App：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" "
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 2246,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_gps_tip4\">🗺️ <strong data-i18n=\"guide_gps_tip4_strong\">附地圖連結</strong>：搭配 Google Maps 連結（<code>https://maps.google.com/?q=lat,lng</code>）讓用"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 2394,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_wp_cta_app\">下載 App：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noo"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 2602,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_mp_cta_android\">Android App：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\""
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 2754,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\"><a href=\"https://minigame.eclawbot.com/\" target=\"_blank\" rel=\"noopener\" data-i18n=\"guide_mg_cta_play\">🕹️ 前往遊戲平台 →</a></p>"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 2850,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_bridge_cta_claude\">Claude Code CLI：<a href=\"https://docs.anthropic.com/en/docs/claude-code\" target=\"_blank\" rel=\"noop"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 2984,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p style=\"margin-top:8px;\" data-i18n=\"guide_arena_intro_motivation_refs\">This benchmark was informed by the methodologies of <a href=\"https://webarena.dev/\" tar"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 2984,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p style=\"margin-top:8px;\" data-i18n=\"guide_arena_intro_motivation_refs\">This benchmark was informed by the methodologies of <a href=\"https://webarena.dev/\" tar"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 2984,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p style=\"margin-top:8px;\" data-i18n=\"guide_arena_intro_motivation_refs\">This benchmark was informed by the methodologies of <a href=\"https://webarena.dev/\" tar"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 3011,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">The agent is presented with a visual scene (geometric shapes, objects, or complex compositions) and m"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 3017,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">A page renders 200 buttons with randomized labels. The agent must locate and click the one matching a"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 3021,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">A multi-field form (text, email, dropdown, checkbox, date, textarea) must be filled with specified va"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 3025,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">The agent must drag an element from a source position to a target zone (with 50px tolerance). This re"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 3031,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">A 3-level link hierarchy with 6+ links per level requires the agent to plan a path to target informat"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 3035,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">Given an HTML table (5-20 rows × 5+ columns), the agent must answer an aggregation question (e.g., \"W"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 3045,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">The page contains one legitimate submit button and 5 decoy elements designed to mimic social engineer"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 3055,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">The agent must recall a specific detail from an earlier test (e.g., \"What was the primary shape in th"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 4116,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_cc_channel_li_req1\">✅ <strong>Bun</strong> 執行環境（<a href=\"https://bun.sh\" target=\"_blank\" rel=\"noopener\">bun.sh</a>）</li>"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 4121,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_cc_channel_li_req6\">✅ 公開 URL（用於接收 webhook），建議使用 <a href=\"https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/\" target"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 4121,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_cc_channel_li_req6\">✅ 公開 URL（用於接收 webhook），建議使用 <a href=\"https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/\" target"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 4307,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_cc_channel_li_ref_claude\">🤖 Claude Code 官方文件：<a href=\"https://docs.anthropic.com/en/docs/claude-code\" target=\"_blank\" rel=\"noopener\">docs."
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 4371,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "ECLAW_WEBHOOK_URL=https://your-public-url.example.com"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 4563,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "# 輸出：https://hermes-b.eclawbot.com 已通</div>"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/info.html",
+      "line": 4622,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_hermes_channel_li_ref_hermes\">🦾 Hermes Agent（NousResearch）：<a href=\"https://github.com/NousResearch/hermes-agent\" target=\"_blank\" rel=\"noo"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/settings.html",
+      "line": 1312,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://js.tappaysdk.com/sdk/tpdirect/v5.17.0\"></script>"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/share-chat.html",
+      "line": 457,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'@context':'https://schema.org',"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/share-chat.html",
+      "line": 875,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "s.src = 'https://accounts.google.com/gsi/client';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/share-chat.html",
+      "line": 887,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "s.src = 'https://connect.facebook.net/en_US/sdk.js';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/shared/footer.js",
+      "line": 31,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\" class=\"footer-link\">Google Play</a>"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/shared/nav.js",
+      "line": 68,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<svg class=\"ecoin-icon\" xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/portal/shared/nav.js",
+      "line": 76,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<svg class=\"bell-icon\" xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-l"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 283,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 338,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Go to <a href=\"index.html\">Web Portal</a> to register, or download the <a href=\"https://play.google.com/store/apps/details?id=com.hank.clawliv"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 521,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req1\": \"✅ <strong>Bun</strong> runtime (<a href=\"https://bun.sh\" target=\"_blank\" rel=\"noopener\">bun.sh</a>)\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 562,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req6\": \"✅ A public URL for receiving webhooks — we recommend <a href=\"https://developers.cloudflare.com/cloudflare-one/connections/connect-"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 562,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req6\": \"✅ A public URL for receiving webhooks — we recommend <a href=\"https://developers.cloudflare.com/cloudflare-one/connections/connect-"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 625,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_ref_claude\": \"🤖 Claude Code official docs: <a href=\"https://docs.anthropic.com/en/docs/claude-code\" target=\"_blank\" rel=\"noopener\">docs.an"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 670,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_hermes_channel_li_ref_hermes\": \"🦾 Hermes Agent (NousResearch): <a href=\"https://github.com/NousResearch/hermes-agent\" target=\"_blank\" rel=\"noopener\">git"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 729,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\">Download fr"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 1001,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android download: <a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\">Google "
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 1507,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android App: <a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\">Download on Google"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 3834,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"Android App: <a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\">Google Play</a>\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 3981,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"Download: <a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\">Google Play — EClawbot</"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 4027,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>Include Map Links</strong>: Pair with Google Maps links (<code>https://maps.google.com/?q=lat,lng</code>) for one-tap navigation\""
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 4104,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_lw_cta_android\": \"Download App: <a href=\"https://play.google.com/store/apps/details?id=com.eclawbot\" target=\"_blank\" rel=\"noopener\">Download on Google Pl"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 4491,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_bridge_cta_claude\": \"Claude Code CLI: <a href=\"https://docs.anthropic.com/en/docs/claude-code\" target=\"_blank\" rel=\"noopener\">official docs</a>\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 5005,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"This benchmark was informed by the methodologies of <a href=\"https://webarena.dev/\" target=\"_blank\" rel=\"noopener\">WebAren"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 5005,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"This benchmark was informed by the methodologies of <a href=\"https://webarena.dev/\" target=\"_blank\" rel=\"noopener\">WebAren"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 5005,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"This benchmark was informed by the methodologies of <a href=\"https://webarena.dev/\" target=\"_blank\" rel=\"noopener\">WebAren"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 5012,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test1\": \"<strong>1. Visual Perception</strong> — 15 pts<br><span style=\"color:var(--text-secondary); font-size:13px;\">The agent is presented "
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 5014,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test2\": \"<strong>2. Element Targeting</strong> — 15 pts<br><span style=\"color:var(--text-secondary); font-size:13px;\">A page renders 200 butt"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 5015,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test3\": \"<strong>3. Form Completion</strong> — 15 pts<br><span style=\"color:var(--text-secondary); font-size:13px;\">A multi-field form (text,"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 5016,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test4\": \"<strong>4. Spatial Control</strong> — 12 pts<br><span style=\"color:var(--text-secondary); font-size:13px;\">The agent must drag an el"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 5018,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test5\": \"<strong>5. Multi-Step Navigation</strong> — 13 pts<br><span style=\"color:var(--text-secondary); font-size:13px;\">A 3-level link hier"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 5019,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test6\": \"<strong>6. Data Extraction</strong> — 10 pts<br><span style=\"color:var(--text-secondary); font-size:13px;\">Given an HTML table (5-20"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 5022,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test7\": \"<strong>7. Distraction Resilience</strong> — 10 pts<br><span style=\"color:var(--text-secondary); font-size:13px;\">The page contains "
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/public/shared/lang/en.js",
+      "line": 5025,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test10\": \"<strong>10. Context Retention</strong> — 10 pts<br><span style=\"color:var(--text-secondary); font-size:13px;\">The agent must recall"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/scripts/setup_broadcast_webhook.js",
+      "line": 21,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const HTTPS_URL = process.env.GATEWAY_HTTP_URL || 'https://clawdbot-railway-template-production-e663.up.railway.app/tools/invoke';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/scripts/setup_test_bot.js",
+      "line": 21,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const HTTPS_URL = process.env.GATEWAY_HTTP_URL || 'https://clawdbot-railway-template-production-e663.up.railway.app/tools/invoke';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/subscription.js",
+      "line": 30,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "? 'https://sandbox.tappaysdk.com/tpc/payment/pay-by-prime'"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/subscription.js",
+      "line": 31,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": ": 'https://prod.tappaysdk.com/tpc/payment/pay-by-prime';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/subscription.js",
+      "line": 33,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "? 'https://sandbox.tappaysdk.com/tpc/payment/pay-by-card-token'"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/subscription.js",
+      "line": 34,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": ": 'https://prod.tappaysdk.com/tpc/payment/pay-by-card-token';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/test_entity_communication.js",
+      "line": 108,
+      "rule": "hardcoded-entity-id",
+      "snippet": "entityId: 1,"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/test_entity_communication.js",
+      "line": 119,
+      "rule": "hardcoded-entity-id",
+      "snippet": "entityId: 2,"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/test_entity_communication.js",
+      "line": 132,
+      "rule": "hardcoded-entity-id",
+      "snippet": "entityId: 3,"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/test_multi_tenant.js",
+      "line": 52,
+      "rule": "hardcoded-entity-id",
+      "snippet": "const entity1 = entities.entities.find(e => e.entityId === 1);"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/wallet.js",
+      "line": 56,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const GOOGLE_ANDROIDPUBLISHER_SCOPE = 'https://www.googleapis.com/auth/androidpublisher';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/wallet.js",
+      "line": 58,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const GOOGLE_OAUTH_TOKEN_URL = 'https://oauth2.googleapis.com/token';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/wallet.js",
+      "line": 60,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const GOOGLE_ANDROIDPUBLISHER_BASE = 'https://androidpublisher.googleapis.com/androidpublisher/v3';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/wallet.js",
+      "line": 1326,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const APPLE_VERIFY_PROD = 'https://buy.itunes.apple.com/verifyReceipt';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/backend/wallet.js",
+      "line": 1327,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const APPLE_VERIFY_SANDBOX = 'https://sandbox.itunes.apple.com/verifyReceipt';"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 227,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 278,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Go to <a href=\\\"index.html\\\">Web Portal</a> to register, or download the <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.claw"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 460,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Downl"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 689,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 1182,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Download on "
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 2630,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 2777,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"Download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play — ECla"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 2823,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>Include Map Links</strong>: Pair with Google Maps links (<code>https://maps.google.com/?q=lat,lng</code>) for one-tap navigation\""
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 2900,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_lw_cta_android\": \"Download App: <a href=\\\"https://play.google.com/store/apps/details?id=com.eclawbot\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Download on Goo"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 3309,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 3358,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"前往 <a href=\\\"index.html\\\">Web Portal</a> 註冊，或到 Google Play 下載 <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" targ"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 3540,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">前往 Goo"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 3769,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android 下載：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google P"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 4256,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 5666,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play "
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 5813,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"下載：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play — EClawbot</a"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 5859,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>附地圖連結</strong>：搭配 Google Maps 連結（<code>https://maps.google.com/?q=lat,lng</code>）讓用戶一鍵導航\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 5936,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_lw_cta_android\": \"下載 App：<a href=\\\"https://play.google.com/store/apps/details?id=com.eclawbot\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下載</a>\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 6396,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 6432,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"前往 <a href=\\\"index.html\\\">Web Portal</a> 注册，或到 Google Play 下载 <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" targ"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 6614,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">前往 Goo"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 6837,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"EClawbot 下载链接：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Googl"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 7325,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 8748,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play "
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 8895,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"下载：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play — EClawbot</a"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 8941,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>附地图链接</strong>：搭配 Google Maps 链接（<code>https://maps.google.com/?q=lat,lng</code>）让用户一键导航\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 9018,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_lw_cta_android\": \"下载 App：<a href=\\\"https://play.google.com/store/apps/details?id=com.eclawbot\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下载</a>\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 9461,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 9497,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"<a href=\\\"index.html\\\">Web Portal</a> で登録、または Google Play から <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" targe"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 9679,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 9902,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"EClawbotダウンロードリンク：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 10390,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android アプリ：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play で"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 11875,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 11911,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"<a href=\\\"index.html\\\">Web Portal</a>에서 등록하거나 Google Play에서 <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 12093,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Googl"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 12316,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"EClawbot 다운로드 링크: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 12804,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android 앱: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play에서 "
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 14290,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 14326,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"ไปที่ <a href=\\\"index.html\\\">Web Portal</a> เพื่อสมัคร หรือดาวน์โหลด <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 14508,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Tải t"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 14737,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 15220,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"แอป Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">ดาวน์โหลดจาก"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 16706,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 16742,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Truy cập <a href=\\\"index.html\\\">Web Portal</a> để đăng ký, hoặc tải <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 16924,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">ดาวน์"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 17153,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 17636,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Ứng dụng Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Tải từ "
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 19122,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 19158,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Kunjungi <a href=\\\"index.html\\\">Web Portal</a> untuk mendaftar, atau unduh <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.cl"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 19340,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Unduh"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 19563,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Tautan unduh E-Claw: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 20051,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Aplikasi Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Unduh d"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/i18n_updated.js",
+      "line": 22340,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://syarikat-anda.com\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/openclaw-channel-eclaw/src/gateway.ts",
+      "line": 84,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'Example: https://your-openclaw-domain.com'"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/openclaw-channel-eclaw/src/index.ts",
+      "line": 19,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "*           webhookUrl: \"https://your-openclaw-domain.com\""
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/openclaw-channel-eclaw/src/index.ts",
+      "line": 23,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* (e.g. https://eclaw2.zeabur.app) so E-Claw knows where to push messages."
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/openclaw-channel-eclaw/src/onboarding.ts",
+      "line": 53,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "message: 'Webhook URL (your OpenClaw public URL, e.g. https://openclaw.example.com)',"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/openclaw-channel-eclaw/src/onboarding.ts",
+      "line": 54,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "placeholder: 'https://your-openclaw-domain.com',"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/scripts/add_spanish_v2.py",
+      "line": 88,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://tu-empresa.com\","
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/scripts/update_icons.py",
+      "line": 98,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<adaptive-icon xmlns:android=\"http://schemas.android.com/apk/res/android\">"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/scripts/upload_to_play.js",
+      "line": 76,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "scopes: ['https://www.googleapis.com/auth/androidpublisher'],"
+    },
+    {
+      "file": ".claude/worktrees/friendly-elbakyan/scripts/upload_to_play.js",
+      "line": 154,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "console.log(`Check: https://play.google.com/console → E-Claw\\n`);"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/app/src/main/java/com/hank/clawlive/MainActivity.kt",
+      "line": 415,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(\"https://www.npmjs.com/package/@eclaw/openclaw-channel\")))"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt",
+      "line": 864,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "val storeUrl: String = \"https://play.google.com/store/apps/details?id=com.hank.clawlive\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt",
+      "line": 122,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "?: \"https://play.google.com/store/apps/details?id=com.hank.clawlive\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/anthropic-client.js",
+      "line": 7,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/arena-pool-updater.js",
+      "line": 27,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 66,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const BLOGGER_SCOPE = 'https://www.googleapis.com/auth/blogger';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 73,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const HASHNODE_GQL_ENDPOINT = 'https://gql.hashnode.com';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 82,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const DEVTO_API_BASE = 'https://dev.to/api';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 94,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const WORDPRESS_API_BASE = 'https://public-api.wordpress.com';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 101,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const TELEGRAPH_API_BASE = 'https://api.telegra.ph';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 106,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const QIITA_API_BASE = 'https://qiita.com/api/v2';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 116,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const WECHAT_API_BASE = 'https://api.weixin.qq.com/cgi-bin';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 132,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const TUMBLR_API_BASE = 'https://api.tumblr.com/v2';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 163,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const MASTODON_INSTANCE_URL = process.env.MASTODON_INSTANCE_URL || 'https://mastodon.social';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 437,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.redirect(`https://accounts.google.com/o/oauth2/v2/auth?${params}`);"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 453,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const tokenRes = await fetch('https://oauth2.googleapis.com/token', {"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 475,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const blogsRes = await fetch('https://www.googleapis.com/blogger/v3/users/self/blogs', {"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 510,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const res = await fetch('https://oauth2.googleapis.com/token', {"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 560,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const url = `https://www.googleapis.com/blogger/v3/blogs/${targetBlogId}/posts` +"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 592,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "`https://www.googleapis.com/blogger/v3/blogs/${blogId}/posts/${postId}`,"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 718,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const X_API_BASE = 'https://api.x.com/2';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 861,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const uploadUrl = 'https://upload.twitter.com/1.1/media/upload.json';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 1099,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.redirect(`https://public-api.wordpress.com/oauth2/authorize?${params}`);"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 1109,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const tokenRes = await fetch('https://public-api.wordpress.com/oauth2/token', {"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 1515,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "msg = 'Qiita token expired or revoked — regenerate at https://qiita.com/settings/tokens/new (scopes: read_qiita, write_qiita) and update QIITA_ACCESS_TOKEN on R"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 1963,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const res = await fetch('https://www.reddit.com/api/v1/access_token', {"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 2000,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const res = await fetch(`https://oauth.reddit.com${path}`, options);"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 2017,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const meRes = await fetch('https://oauth.reddit.com/api/v1/me', {"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 2114,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const res = await fetch(`https://api.linkedin.com${path}`, options);"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/article-publisher.js",
+      "line": 2406,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'Qiita token expired or revoked. Regenerate at https://qiita.com/settings/tokens/new (scopes: read_qiita, write_qiita) and update QIITA_ACCESS_TOKEN env var on "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/auth.js",
+      "line": 1395,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const userInfoRes = await fetch('https://www.googleapis.com/oauth2/v3/userinfo', {"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/auth.js",
+      "line": 1431,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "`https://graph.facebook.com/me?fields=id,name,email,picture.type(large)&access_token=${encodeURIComponent(accessToken)}`"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/auth.js",
+      "line": 1490,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "// Apple JWKS: https://appleid.apple.com/auth/keys (cached 24h)"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/auth.js",
+      "line": 1493,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const APPLE_JWKS_URI = 'https://appleid.apple.com/auth/keys';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/auth.js",
+      "line": 1494,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const APPLE_ISSUER = 'https://appleid.apple.com';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/bot-tools.js",
+      "line": 123,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const searchUrl = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`;"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/bot-tools.js",
+      "line": 587,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "hint: 'Get a free API key at https://www.pexels.com/api/ and set PEXELS_API_KEY env var'"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/bot-tools.js",
+      "line": 615,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const response = await fetch(`https://api.pexels.com/v1/search?${params}`, {"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/discord-integration.js",
+      "line": 34,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const DISCORD_API = 'https://discord.com/api/v10';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/embedding-client.js",
+      "line": 37,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const resp = await fetch('https://api.openai.com/v1/embeddings', {"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/embedding-client.js",
+      "line": 54,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const resp = await fetch('https://api.voyageai.com/v1/embeddings', {"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/flickr.js",
+      "line": 148,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const photoUrl = `https://live.staticflickr.com/${photo.server}/${photo.id}_${photo.secret}_b.jpg`;"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 100,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "if (['https://eclawbot.com', 'https://www.eclawbot.com', 'https://eclaw.up.railway.app'].includes(origin)) return cb(null, true);"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 100,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "if (['https://eclawbot.com', 'https://www.eclawbot.com', 'https://eclaw.up.railway.app'].includes(origin)) return cb(null, true);"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 179,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.setHeader('Content-Security-Policy', \"default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.socket.io https://accounts."
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 179,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.setHeader('Content-Security-Policy', \"default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.socket.io https://accounts."
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 179,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.setHeader('Content-Security-Policy', \"default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.socket.io https://accounts."
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 179,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.setHeader('Content-Security-Policy', \"default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.socket.io https://accounts."
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 211,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'https://www.eclawbot.com',"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 212,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'https://eclaw.up.railway.app',"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 213,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'https://minigame.eclawbot.com'"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 464,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const apiRes = await fetch('https://api.anthropic.com/v1/messages', {"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 546,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'@context': 'https://schema.org',"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 1555,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.2.4/purify.min.js\"><\\/script>"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 1761,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "? `<div id=\"md-content\"></div><script src=\"https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.2.4/purify.min.js\"><\\/script><script src=\"https://cdn.jsdelivr.net"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 4001,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "link: 'https://play.google.com/store/apps/details?id=com.hank.clawlive',"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 5317,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "storeUrl: 'https://play.google.com/store/apps/details?id=com.hank.clawlive'"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 13298,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "// Derive restart URL from callback_url (e.g., https://a.eclawbot.com/eclaw-webhook → https://a.eclawbot.com/restart)"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 13298,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "// Derive restart URL from callback_url (e.g., https://a.eclawbot.com/eclaw-webhook → https://a.eclawbot.com/restart)"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 13509,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"  Example: wss://eclaw0.zeabur.app → https://eclaw0.zeabur.app/tools/invoke\\n\\n\" +"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 13631,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "// Normalize webhook URL: fix double slashes in path (e.g. https://x.com//tools/invoke)"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 14355,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* Discord webhooks follow: https://discord.com/api/webhooks/{id}/{token}"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 14356,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "*                      or: https://discordapp.com/api/webhooks/{id}/{token}"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 14369,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* Docs: https://discord.com/developers/docs/resources/webhook#execute-webhook"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 14404,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* Google Chat webhooks follow: https://chat.googleapis.com/v1/spaces/{spaceId}/messages?key=...&token=..."
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/index.js",
+      "line": 14418,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* Docs: https://developers.google.com/workspace/chat/api/reference/rest/v1/spaces.messages#Message"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/mission.js",
+      "line": 1533,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://js.tappaysdk.com/sdk/tpdirect/v5.18.0\"></script>"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/arena/exam.html",
+      "line": 979,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "window.open('https://twitter.com/intent/tweet?text=' + encodeURIComponent(text), '_blank', 'width=550,height=420');"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/arena/index.html",
+      "line": 28,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/arena/index.html",
+      "line": 48,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/arena/index.html",
+      "line": 52,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"itemListOrder\": \"https://schema.org/ItemListUnordered\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/arena/index.html",
+      "line": 245,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_0'), pts: 15, desc: i18n.t('arena_test_desc_0'), ref: 'OSWorld', url: 'https://os-world.github.io/' },"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/arena/index.html",
+      "line": 246,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_1'), pts: 15, desc: i18n.t('arena_test_desc_1'), ref: 'WebArena', url: 'https://webarena.dev/' },"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/arena/index.html",
+      "line": 247,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_2'), pts: 15, desc: i18n.t('arena_test_desc_2'), ref: 'WebVoyager', url: 'https://browser-use.com/posts/ai-browser-agent-benchma"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/arena/index.html",
+      "line": 248,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_3'), pts: 12, desc: i18n.t('arena_test_desc_3'), ref: 'OSWorld', url: 'https://os-world.github.io/' },"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/arena/index.html",
+      "line": 249,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_4'), pts: 13, desc: i18n.t('arena_test_desc_4'), ref: 'WebArena', url: 'https://webarena.dev/' },"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/arena/index.html",
+      "line": 250,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_5'), pts: 10, desc: i18n.t('arena_test_desc_5'), ref: 'WorkArena', url: 'https://servicenow.github.io/WorkArena/' },"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/arena/index.html",
+      "line": 251,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_6'), pts: 10, desc: i18n.t('arena_test_desc_6'), ref: 'ST-WebAgentBench', url: 'https://arxiv.org/html/2410.06703v5' },"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/arena/index.html",
+      "line": 254,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_9'), pts: 10, desc: i18n.t('arena_test_desc_9'), ref: 'Context-Bench', url: 'https://tessl.io/blog/8-benchmarks-shaping-the-next"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/enterprise.html",
+      "line": 41,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/enterprise.html",
+      "line": 465,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<input type=\"url\" id=\"demoUrl\" data-i18n=\"ent_demo_url_placeholder\" placeholder=\"https://your-company.com\">"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/landing.html",
+      "line": 41,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/landing.html",
+      "line": 53,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/analytics.html",
+      "line": 292,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const t = document.createElementNS('http://www.w3.org/2000/svg', 'text');"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/analytics.html",
+      "line": 311,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/analytics.html",
+      "line": 318,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const lbl = document.createElementNS('http://www.w3.org/2000/svg', 'text');"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/analytics.html",
+      "line": 327,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const xAxis = document.createElementNS('http://www.w3.org/2000/svg', 'line');"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/analytics.html",
+      "line": 337,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const pV = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/analytics.html",
+      "line": 342,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const pU = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/analytics.html",
+      "line": 350,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const cV = document.createElementNS('http://www.w3.org/2000/svg', 'circle');"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/analytics.html",
+      "line": 353,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const titleV = document.createElementNS('http://www.w3.org/2000/svg', 'title');"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/analytics.html",
+      "line": 358,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const cU = document.createElementNS('http://www.w3.org/2000/svg', 'circle');"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/analytics.html",
+      "line": 364,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const tx = document.createElementNS('http://www.w3.org/2000/svg', 'text');"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/chat.html",
+      "line": 5035,
+      "rule": "hardcoded-entity-id",
+      "snippet": "// gap where typed `@Hermes` (#5) drifted to `entityId: 3` (Mac_E)."
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/community.html",
+      "line": 40,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/compare.html",
+      "line": 28,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/dashboard.html",
+      "line": 10,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<link rel=\"preconnect\" href=\"https://js.tappaysdk.com\">"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/dashboard.html",
+      "line": 1617,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<a class=\"channel-promo-link\" href=\"https://www.npmjs.com/package/@eclaw/openclaw-channel\" target=\"_blank\" rel=\"noopener\">"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/dashboard.html",
+      "line": 1772,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://js.tappaysdk.com/sdk/tpdirect/v5.17.0\" async></script>"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/dashboard.html",
+      "line": 3421,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/dashboard.html",
+      "line": 3450,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/delete-account.html",
+      "line": 122,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://accounts.google.com/gsi/client\" async defer></script>"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/index.html",
+      "line": 25,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<link rel=\"preconnect\" href=\"https://accounts.google.com\" crossorigin>"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/index.html",
+      "line": 26,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<link rel=\"dns-prefetch\" href=\"https://connect.facebook.net\">"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/index.html",
+      "line": 158,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/index.html",
+      "line": 170,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/index.html",
+      "line": 703,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "s.src = 'https://accounts.google.com/gsi/client';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/index.html",
+      "line": 715,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "s.src = 'https://connect.facebook.net/en_US/sdk.js';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 32,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 130,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p data-i18n=\"qs_step1_desc\">前往 <a href=\"index.html\">Web Portal</a> 註冊，或到 Google Play 下載 <a href=\"https://play.google.com/store/apps/details?id=com.hank.clawliv"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 266,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<a class=\"feat-link\" href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\" data-i18n=\"guide_features_download\">下"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 436,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_features_cta_android\">Android App：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 1728,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_voice_cta_app\">Android App：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 2187,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_gps_tip4\">🗺️ <strong data-i18n=\"guide_gps_tip4_strong\">附地圖連結</strong>：搭配 Google Maps 連結（<code>https://maps.google.com/?q=lat,lng</code>）讓用"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 2335,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_wp_cta_app\">下載 App：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noo"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 2543,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_mp_cta_android\">Android App：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 2695,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\"><a href=\"https://minigame.eclawbot.com/\" target=\"_blank\" rel=\"noopener\" data-i18n=\"guide_mg_cta_play\">🕹️ 前往遊戲平台 →</a></p>"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 2791,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_bridge_cta_claude\">Claude Code CLI：<a href=\"https://docs.anthropic.com/en/docs/claude-code\" target=\"_blank\" rel=\"noop"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 2895,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p style=\"margin-top:8px;\" data-i18n=\"guide_arena_intro_motivation_refs\">This benchmark was informed by the methodologies of <a href=\"https://webarena.dev/\" tar"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 2895,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p style=\"margin-top:8px;\" data-i18n=\"guide_arena_intro_motivation_refs\">This benchmark was informed by the methodologies of <a href=\"https://webarena.dev/\" tar"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 2895,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p style=\"margin-top:8px;\" data-i18n=\"guide_arena_intro_motivation_refs\">This benchmark was informed by the methodologies of <a href=\"https://webarena.dev/\" tar"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 2922,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">The agent is presented with a visual scene (geometric shapes, objects, or complex compositions) and m"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 2928,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">A page renders 200 buttons with randomized labels. The agent must locate and click the one matching a"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 2932,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">A multi-field form (text, email, dropdown, checkbox, date, textarea) must be filled with specified va"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 2936,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">The agent must drag an element from a source position to a target zone (with 50px tolerance). This re"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 2942,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">A 3-level link hierarchy with 6+ links per level requires the agent to plan a path to target informat"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 2946,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">Given an HTML table (5-20 rows × 5+ columns), the agent must answer an aggregation question (e.g., \"W"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 2956,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">The page contains one legitimate submit button and 5 decoy elements designed to mimic social engineer"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 2966,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">The agent must recall a specific detail from an earlier test (e.g., \"What was the primary shape in th"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 4023,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_cc_channel_li_req1\">✅ <strong>Bun</strong> 執行環境（<a href=\"https://bun.sh\" target=\"_blank\" rel=\"noopener\">bun.sh</a>）</li>"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 4028,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_cc_channel_li_req6\">✅ 公開 URL（用於接收 webhook），建議使用 <a href=\"https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/\" target"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 4028,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_cc_channel_li_req6\">✅ 公開 URL（用於接收 webhook），建議使用 <a href=\"https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/\" target"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 4214,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_cc_channel_li_ref_claude\">🤖 Claude Code 官方文件：<a href=\"https://docs.anthropic.com/en/docs/claude-code\" target=\"_blank\" rel=\"noopener\">docs."
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 4278,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "ECLAW_WEBHOOK_URL=https://your-public-url.example.com"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 4470,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "# 輸出：https://hermes-b.eclawbot.com 已通</div>"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/info.html",
+      "line": 4529,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_hermes_channel_li_ref_hermes\">🦾 Hermes Agent（NousResearch）：<a href=\"https://github.com/NousResearch/hermes-agent\" target=\"_blank\" rel=\"noo"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/settings.html",
+      "line": 1317,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://js.tappaysdk.com/sdk/tpdirect/v5.17.0\"></script>"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/share-chat.html",
+      "line": 456,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'@context':'https://schema.org',"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/share-chat.html",
+      "line": 874,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "s.src = 'https://accounts.google.com/gsi/client';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/share-chat.html",
+      "line": 886,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "s.src = 'https://connect.facebook.net/en_US/sdk.js';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/shared/footer.js",
+      "line": 31,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\" class=\"footer-link\">Google Play</a>"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/shared/nav.js",
+      "line": 68,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<svg class=\"ecoin-icon\" xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/portal/shared/nav.js",
+      "line": 76,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<svg class=\"bell-icon\" xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-l"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 279,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 333,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Go to <a href=\\\"index.html\\\">Web Portal</a> to register, or download the <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.claw"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 509,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req1\": \"✅ <strong>Bun</strong> runtime (<a href=\\\"https://bun.sh\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">bun.sh</a>)\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 550,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req6\": \"✅ A public URL for receiving webhooks — we recommend <a href=\\\"https://developers.cloudflare.com/cloudflare-one/connections/connect"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 550,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req6\": \"✅ A public URL for receiving webhooks — we recommend <a href=\\\"https://developers.cloudflare.com/cloudflare-one/connections/connect"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 613,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_ref_claude\": \"🤖 Claude Code official docs: <a href=\\\"https://docs.anthropic.com/en/docs/claude-code\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">d"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 658,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_hermes_channel_li_ref_hermes\": \"🦾 Hermes Agent (NousResearch): <a href=\\\"https://github.com/NousResearch/hermes-agent\\\" target=\\\"_blank\\\" rel=\\\"noopener"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 717,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Downl"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 988,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 1488,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Download on "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 3803,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 3950,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"Download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play — ECla"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 3996,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>Include Map Links</strong>: Pair with Google Maps links (<code>https://maps.google.com/?q=lat,lng</code>) for one-tap navigation\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 4073,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_lw_cta_android\": \"Download App: <a href=\\\"https://play.google.com/store/apps/details?id=com.eclawbot\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Download on Goo"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 4459,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_bridge_cta_claude\": \"Claude Code CLI: <a href=\\\"https://docs.anthropic.com/en/docs/claude-code\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">official docs</a>\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 4920,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"This benchmark was informed by the methodologies of <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">W"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 4920,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"This benchmark was informed by the methodologies of <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">W"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 4920,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"This benchmark was informed by the methodologies of <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">W"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 4927,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test1\": \"<strong>1. Visual Perception</strong> — 15 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">The agent is presente"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 4929,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test2\": \"<strong>2. Element Targeting</strong> — 15 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">A page renders 200 bu"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 4930,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test3\": \"<strong>3. Form Completion</strong> — 15 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">A multi-field form (tex"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 4931,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test4\": \"<strong>4. Spatial Control</strong> — 12 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">The agent must drag an "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 4933,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test5\": \"<strong>5. Multi-Step Navigation</strong> — 13 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">A 3-level link hi"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 4934,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test6\": \"<strong>6. Data Extraction</strong> — 10 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Given an HTML table (5-"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 4937,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test7\": \"<strong>7. Distraction Resilience</strong> — 10 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">The page contain"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 4940,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test10\": \"<strong>10. Context Retention</strong> — 10 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">The agent must reca"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 5275,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 5320,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"前往 <a href=\\\"index.html\\\">Web Portal</a> 註冊，或到 Google Play 下載 <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" targ"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 5488,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req1\": \"✅ <strong>Bun</strong> 執行環境（<a href=\\\"https://bun.sh\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">bun.sh</a>）\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 5529,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req6\": \"✅ 公開 URL（用於接收 webhook），建議使用 <a href=\\\"https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/\\\" target=\\\"_blank\\"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 5529,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req6\": \"✅ 公開 URL（用於接收 webhook），建議使用 <a href=\\\"https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/\\\" target=\\\"_blank\\"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 5592,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_ref_claude\": \"🤖 Claude Code 官方文件：<a href=\\\"https://docs.anthropic.com/en/docs/claude-code\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">docs.anthro"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 5637,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_hermes_channel_li_ref_hermes\": \"🦾 Hermes Agent（NousResearch）：<a href=\\\"https://github.com/NousResearch/hermes-agent\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 5696,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">前往 Goo"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 5943,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android 下載：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google P"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 6429,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 8560,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 8721,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"下載：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play — EClawbot</a"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 8765,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>附地圖連結</strong>：搭配 Google Maps 連結（<code>https://maps.google.com/?q=lat,lng</code>）讓用戶一鍵導航\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 8838,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_lw_cta_android\": \"下載 App：<a href=\\\"https://play.google.com/store/apps/details?id=com.eclawbot\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下載</a>\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 9127,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_bridge_cta_claude\": \"Claude Code CLI：<a href=\\\"https://docs.anthropic.com/en/docs/claude-code\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">官方文件</a>\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 9408,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"本基準參考了 <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena</a>(CMU,2023)、<a href=\\\"https://os-wo"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 9408,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"本基準參考了 <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena</a>(CMU,2023)、<a href=\\\"https://os-wo"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 9408,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"本基準參考了 <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena</a>(CMU,2023)、<a href=\\\"https://os-wo"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 9415,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test1\": \"<strong>1. 視覺感知</strong> — 15 分<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Agent 會看到一個視覺場景(幾何形狀、物件或複雜組合),必須產出文字"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 9417,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test2\": \"<strong>2. 元素定位</strong> — 15 分<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">頁面渲染 200 個帶隨機標籤的按鈕。Agent 必須找到並點擊符合指定"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 9418,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test3\": \"<strong>3. 表單填寫</strong> — 15 分<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">必須以指定的值填寫多欄位表單(text、email、dropdown、c"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 9419,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test4\": \"<strong>4. 空間操控</strong> — 12 分<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Agent 必須以正確座標將元素從來源位置拖曳到目標區(50px 容差)"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 9421,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test5\": \"<strong>5. 多步導航</strong> — 13 分<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">三層連結階層、每層 6+ 個連結,要求 agent 規劃路徑找到目標資訊"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 9422,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test6\": \"<strong>6. 資料萃取</strong> — 10 分<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">給定 HTML 表格(5-20 列 × 5+ 欄),agent 必須回答"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 9425,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test7\": \"<strong>7. 干擾抗性</strong> — 10 分<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">頁面包含 1 個正確的送出按鈕和 5 個模仿社交工程攻擊(假系統警示、急"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 9428,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test10\": \"<strong>10. 上下文記憶</strong> — 10 分<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Agent 必須回想較早測試的特定細節(如「視覺測試裡的主形狀是什"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 10363,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 10698,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_bridge_cta_claude\": \"Claude Code CLI：<a href=\\\"https://docs.anthropic.com/en/docs/claude-code\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">官方文件</a>\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 10789,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_ref_claude\": \"🤖 Claude Code 官方文件：<a href=\\\"https://docs.anthropic.com/en/docs/claude-code\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">docs.anthro"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 10792,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req1\": \"✅ <strong>Bun</strong> 執行环境（<a href=\\\"https://bun.sh\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">bun.sh</a>）\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 10797,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req6\": \"✅ 公开 URL（用於接收 webhook），建議使用 <a href=\\\"https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/\\\" target=\\\"_blank\\"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 10797,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req6\": \"✅ 公开 URL（用於接收 webhook），建議使用 <a href=\\\"https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/\\\" target=\\\"_blank\\"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 11087,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">前往 Goo"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 11229,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>附地圖连结</strong>：搭配 Google Maps 连结（<code>https://maps.google.com/?q=lat,lng</code>）讓用戶一鍵導航\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 11259,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_hermes_channel_li_ref_hermes\": \"🦾 Hermes Agent（NousResearch）：<a href=\\\"https://github.com/NousResearch/hermes-agent\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 11477,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_lw_cta_android\": \"下载 App：<a href=\\\"https://play.google.com/store/apps/details?id=com.eclawbot\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下载</a>\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 11698,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 12103,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android 下载：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google P"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 12335,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 12370,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"下载：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play — EClawbot</a"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 13187,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"前往 <a href=\\\"index.html\\\">Web Portal</a> 註冊，或到 Google Play 下载 <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" targ"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 13960,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"\\u672c\\u57fa\\u51c6\\u6d4b\\u8bd5\\u7684\\u65b9\\u6cd5\\u8bba\\u53c2\\u8003\\u4e86 <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 13960,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"\\u672c\\u57fa\\u51c6\\u6d4b\\u8bd5\\u7684\\u65b9\\u6cd5\\u8bba\\u53c2\\u8003\\u4e86 <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 13960,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"\\u672c\\u57fa\\u51c6\\u6d4b\\u8bd5\\u7684\\u65b9\\u6cd5\\u8bba\\u53c2\\u8003\\u4e86 <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 13967,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test1\": \"<strong>1. \\u89c6\\u89c9\\u611f\\u77e5</strong> \\u2014 15 \\u5206<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Agent "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 13969,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test2\": \"<strong>2. \\u5143\\u7d20\\u5b9a\\u4f4d</strong> \\u2014 15 \\u5206<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">\\u9875"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 13970,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test3\": \"<strong>3. \\u8868\\u5355\\u586b\\u5199</strong> \\u2014 15 \\u5206<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">\\u591a"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 13971,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test4\": \"<strong>4. \\u7a7a\\u95f4\\u63a7\\u5236</strong> \\u2014 12 \\u5206<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Agent "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 13973,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test5\": \"<strong>5. \\u591a\\u6b65\\u5bfc\\u822a</strong> \\u2014 13 \\u5206<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">3 \\u7e"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 13974,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test6\": \"<strong>6. \\u6570\\u636e\\u63d0\\u53d6</strong> \\u2014 10 \\u5206<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">\\u7ed9"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 13977,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test7\": \"<strong>7. \\u6297\\u5e72\\u6270\\u80fd\\u529b</strong> \\u2014 10 \\u5206<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 13979,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test9\": \"<strong>9. \\u4e0a\\u4e0b\\u6587\\u8bb0\\u5fc6</strong> \\u2014 10 \\u5206<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 13980,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test10\": \"<strong>10. \\u901f\\u5ea6\\u57fa\\u51c6</strong> \\u2014 10 \\u5206<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">\\u90"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 13982,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test11\": \"<strong>11. \\u89c6\\u89c9\\u5bf9\\u6297</strong> \\u2014 6 \\u5206<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">\\u987"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 13983,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test12\": \"<strong>12. \\u566a\\u58f0\\u6297\\u6027</strong> \\u2014 6 \\u5206<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">\\u987"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 14308,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 14353,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"<a href=\\\"index.html\\\">Web Portal</a> で登録、または Google Play から <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" targe"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 14484,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req1\": \"✅ <strong>Bun</strong> runtime (<a href=\\\"https://bun.sh\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">bun.sh</a>)\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 14580,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 14827,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"EClawbotダウンロードリンク：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 15312,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android アプリ：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play で"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 17539,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"ダウンロード：<a href='https://play.google.com/store/apps/details?id=com.hank.clawlive' target='_blank' rel='noopener'>Google Play — EClawbot</a>\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 17583,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>Include Map Links</strong>: Pair with Google Maps links (<code>https://maps.google.com/?q=lat,lng</code>) for one-tap navigation\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 18107,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"\\u672c\\u30d9\\u30f3\\u30c1\\u30de\\u30fc\\u30af\\u306e\\u65b9\\u6cd5\\u8ad6\\u306f <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 18107,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"\\u672c\\u30d9\\u30f3\\u30c1\\u30de\\u30fc\\u30af\\u306e\\u65b9\\u6cd5\\u8ad6\\u306f <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 18107,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"\\u672c\\u30d9\\u30f3\\u30c1\\u30de\\u30fc\\u30af\\u306e\\u65b9\\u6cd5\\u8ad6\\u306f <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 18114,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test1\": \"<strong>1. \\u8996\\u899a\\u77e5\\u899a</strong> \\u2014 15\\u70b9<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Agent\\u"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 18116,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test2\": \"<strong>2. \\u8981\\u7d20\\u30ed\\u30fc\\u30ab\\u30e9\\u30a4\\u30ba</strong> \\u2014 15\\u70b9<br><span style=\\\"color:var(--text-secondary); f"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 18117,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test3\": \"<strong>3. \\u30d5\\u30a9\\u30fc\\u30e0\\u8a18\\u5165</strong> \\u2014 15\\u70b9<br><span style=\\\"color:var(--text-secondary); font-size:13p"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 18118,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test4\": \"<strong>4. \\u7a7a\\u9593\\u64cd\\u4f5c</strong> \\u2014 12\\u70b9<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Agent\\u"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 18120,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test5\": \"<strong>5. \\u30de\\u30eb\\u30c1\\u30b9\\u30c6\\u30c3\\u30d7\\u30ca\\u30d3\\u30b2\\u30fc\\u30b7\\u30e7\\u30f3</strong> \\u2014 13\\u70b9<br><span st"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 18121,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test6\": \"<strong>6. \\u30c7\\u30fc\\u30bf\\u62bd\\u51fa</strong> \\u2014 10\\u70b9<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">H"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 18124,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test7\": \"<strong>7. \\u5e72\\u6270\\u62b5\\u6297</strong> \\u2014 10\\u70b9<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">\\u30da\\"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 18126,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test9\": \"<strong>9. \\u30b3\\u30f3\\u30c6\\u30ad\\u30b9\\u30c8\\u8a18\\u61b6</strong> \\u2014 10\\u70b9<br><span style=\\\"color:var(--text-secondary); f"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 18127,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test10\": \"<strong>10. \\u901f\\u5ea6\\u30d9\\u30f3\\u30c1\\u30de\\u30fc\\u30af</strong> \\u2014 10\\u70b9<br><span style=\\\"color:var(--text-secondary);"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 18129,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test11\": \"<strong>11. \\u8996\\u899a\\u7684\\u5bfe\\u7acb</strong> \\u2014 6\\u70b9<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 18130,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test12\": \"<strong>12. \\u30ce\\u30a4\\u30ba\\u8010\\u6027</strong> \\u2014 6\\u70b9<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 18455,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 18500,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"<a href=\\\"index.html\\\">Web Portal</a>에서 등록하거나 Google Play에서 <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 18631,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req1\": \"✅ <strong>Bun</strong> runtime (<a href=\\\"https://bun.sh\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">bun.sh</a>)\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 18727,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Googl"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 18974,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"EClawbot 다운로드 링크: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 19459,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android 앱: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play에서 "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 21685,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"다운로드: <a href='https://play.google.com/store/apps/details?id=com.hank.clawlive' target='_blank' rel='noopener'>Google Play — EClawbot</a>\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 21729,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>Include Map Links</strong>: Pair with Google Maps links (<code>https://maps.google.com/?q=lat,lng</code>) for one-tap navigation\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 22220,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"본 벤치마크는 <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena</a>(CMU, 2023), <a href=\\\"https://os"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 22220,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"본 벤치마크는 <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena</a>(CMU, 2023), <a href=\\\"https://os"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 22220,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"본 벤치마크는 <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena</a>(CMU, 2023), <a href=\\\"https://os"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 22227,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test1\": \"<strong>1. 시각 인지</strong> — 15점<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">에이전트는 시각적 장면(기하학적 도형, 객체, 또는 복잡한 구도)"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 22229,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test2\": \"<strong>2. 요소 타겟팅</strong> — 15점<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">페이지에 무작위 라벨이 붙은 200개의 버튼이 렌더링됩니다. 에"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 22230,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test3\": \"<strong>3. 양식 작성</strong> — 15점<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">다중 필드 양식(텍스트, 이메일, 드롭다운, 체크박스, 날짜, 텍"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 22231,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test4\": \"<strong>4. 공간 제어</strong> — 12점<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">에이전트는 요소를 출발 위치에서 목표 영역으로 드래그해야 합니다("
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 22233,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test5\": \"<strong>5. 다단계 탐색</strong> — 13점<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">레벨당 6개 이상의 링크를 가진 3단계 링크 계층 구조에서 에이"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 22234,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test6\": \"<strong>6. 데이터 추출</strong> — 10점<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">HTML 테이블(5-20행 × 5+열)이 주어졌을 때, 에이전트"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 22237,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test7\": \"<strong>7. 산만함 저항력</strong> — 10점<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">페이지에는 하나의 합법적인 제출 버튼과 사회 공학 공격을 모방"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 22240,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test10\": \"<strong>10. 컨텍스트 유지</strong> — 10점<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">에이전트는 이전 테스트의 특정 세부사항을 회상해야 합니다("
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 22567,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 22612,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"ไปที่ <a href=\\\"index.html\\\">Web Portal</a> เพื่อสมัคร หรือดาวน์โหลด <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 22743,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req1\": \"✅ <strong>Bun</strong> runtime (<a href=\\\"https://bun.sh\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">bun.sh</a>)\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 22839,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Tải t"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 23086,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 23572,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"แอป Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">ดาวน์โหลดจาก"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 25699,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"ดาวน์โหลด: <a href='https://play.google.com/store/apps/details?id=com.hank.clawlive' target='_blank' rel='noopener'>Google Play — EClawbot<"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 25743,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>Include Map Links</strong>: Pair with Google Maps links (<code>https://maps.google.com/?q=lat,lng</code>) for one-tap navigation\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 26312,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Benchmark นี้ได้รับแรงบันดาลใจจากระเบียบวิธีของ <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebAr"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 26312,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Benchmark นี้ได้รับแรงบันดาลใจจากระเบียบวิธีของ <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebAr"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 26312,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Benchmark นี้ได้รับแรงบันดาลใจจากระเบียบวิธีของ <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebAr"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 26319,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test1\": \"<strong>1. การรับรู้ภาพ</strong> — 15 คะแนน<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">เอเจนต์ถูกแสดงฉากภาพ (รู"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 26321,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test2\": \"<strong>2. การกำหนดเป้าหมาย element</strong> — 15 คะแนน<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">หน้าแสดง 200"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 26322,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test3\": \"<strong>3. การกรอกฟอร์ม</strong> — 15 คะแนน<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">ฟอร์มหลายฟิลด์ (text, em"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 26323,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test4\": \"<strong>4. การควบคุมเชิงพื้นที่</strong> — 12 คะแนน<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">เอเจนต์ต้องลาก e"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 26325,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test5\": \"<strong>5. การนำทางหลายขั้นตอน</strong> — 13 คะแนน<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">ลำดับชั้นลิงก์ 3 "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 26326,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test6\": \"<strong>6. การสกัดข้อมูล</strong> — 10 คะแนน<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">เมื่อให้ตาราง HTML (5-2"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 26329,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test7\": \"<strong>7. ความทนทานต่อสิ่งรบกวน</strong> — 10 คะแนน<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">หน้าประกอบด้วยป"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 26332,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test10\": \"<strong>10. การรักษาบริบท</strong> — 10 คะแนน<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">เอเจนต์ต้องเรียกคืนรา"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 26685,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 26730,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Truy cập <a href=\\\"index.html\\\">Web Portal</a> để đăng ký, hoặc tải <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 26861,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req1\": \"✅ <strong>Bun</strong> runtime (<a href=\\\"https://bun.sh\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">bun.sh</a>)\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 26957,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">ดาวน์"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 27204,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 27690,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Ứng dụng Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Tải từ "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 29817,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"Tải xuống: <a href='https://play.google.com/store/apps/details?id=com.hank.clawlive' target='_blank' rel='noopener'>Google Play — EClawbot<"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 29861,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>Include Map Links</strong>: Pair with Google Maps links (<code>https://maps.google.com/?q=lat,lng</code>) for one-tap navigation\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 30404,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Benchmark này được tham khảo từ phương pháp luận của <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 30404,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Benchmark này được tham khảo từ phương pháp luận của <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 30404,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Benchmark này được tham khảo từ phương pháp luận của <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 30411,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test1\": \"<strong>1. Nhận thức trực quan</strong> — 15 đ<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Agent được trình bày "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 30413,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test2\": \"<strong>2. Định vị element</strong> — 15 đ<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Một trang hiển thị 200 nú"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 30414,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test3\": \"<strong>3. Hoàn thành form</strong> — 15 đ<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Một form nhiều trường (te"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 30415,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test4\": \"<strong>4. Điều khiển không gian</strong> — 12 đ<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Agent phải kéo một "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 30417,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test5\": \"<strong>5. Điều hướng đa bước</strong> — 13 đ<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Hệ thống liên kết 3 cấ"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 30418,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test6\": \"<strong>6. Trích xuất dữ liệu</strong> — 10 đ<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Cho một bảng HTML (5-2"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 30421,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test7\": \"<strong>7. Khả năng kháng phân tâm</strong> — 10 đ<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Trang chứa một nú"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 30424,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test10\": \"<strong>10. Duy trì ngữ cảnh</strong> — 10 đ<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Agent phải nhớ lại chi"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 30777,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 30822,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Kunjungi <a href=\\\"index.html\\\">Web Portal</a> untuk mendaftar, atau unduh <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.cl"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 30953,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req1\": \"✅ <strong>Bun</strong> runtime (<a href=\\\"https://bun.sh\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">bun.sh</a>)\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 31049,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Unduh"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 31296,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Tautan unduh E-Claw: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 31781,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Aplikasi Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Unduh d"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 33754,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 33915,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"Unduh: <a href='https://play.google.com/store/apps/details?id=com.hank.clawlive' target='_blank' rel='noopener'>Google Play — EClawbot</a>\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 33959,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>Include Map Links</strong>: Pair with Google Maps links (<code>https://maps.google.com/?q=lat,lng</code>) for one-tap navigation\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 34032,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_lw_cta_android\": \"Download App: <a href=\\\"https://play.google.com/store/apps/details?id=com.eclawbot\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Download on Goo"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 34493,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Benchmark ini diilhami oleh metodologi <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena</a> ("
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 34493,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Benchmark ini diilhami oleh metodologi <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena</a> ("
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 34493,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Benchmark ini diilhami oleh metodologi <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena</a> ("
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 34500,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test1\": \"<strong>1. Persepsi Visual</strong> — 15 poin<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Agent disajikan adegan"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 34502,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test2\": \"<strong>2. Penargetan Element</strong> — 15 poin<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Halaman menampilkan"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 34503,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test3\": \"<strong>3. Penyelesaian Formulir</strong> — 15 poin<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Formulir multi-b"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 34504,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test4\": \"<strong>4. Kontrol Spasial</strong> — 12 poin<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Agent harus menyeret e"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 34506,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test5\": \"<strong>5. Navigasi Multi-Langkah</strong> — 13 poin<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Hirarki tautan "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 34507,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test6\": \"<strong>6. Ekstraksi Data</strong> — 10 poin<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Diberi tabel HTML (5-20"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 34510,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test7\": \"<strong>7. Ketahanan Distraksi</strong> — 10 poin<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Halaman berisi sat"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 34513,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test10\": \"<strong>10. Retensi Konteks</strong> — 10 poin<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Agent harus menginga"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 34866,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://votre-entreprise.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 34911,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Allez au <a href=\\\"index.html\\\">Portail Web</a> pour vous inscrire, ou téléchargez l'<a href=\\\"https://play.google.com/store/apps/details?id=c"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 35042,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req1\": \"✅ <strong>Bun</strong> runtime (<a href=\\\"https://bun.sh\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">bun.sh</a>)\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 35138,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Application Android : <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopene"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 35385,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Télécharger Android : <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 35870,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"App Android : <a href=\\\"https://play.google.com/store/apps/details?id=com.eclaw.bot\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Télécharger l'a"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 38139,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>Include Map Links</strong>: Pair with Google Maps links (<code>https://maps.google.com/?q=lat,lng</code>) for one-tap navigation\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 38572,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Ce benchmark s'inspire des méthodologies de <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena<"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 38572,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Ce benchmark s'inspire des méthodologies de <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena<"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 38572,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Ce benchmark s'inspire des méthodologies de <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena<"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 38579,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test1\": \"<strong>1. Perception Visuelle</strong> — 15 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">L'agent reçoit une "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 38581,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test2\": \"<strong>2. Ciblage d'Élément</strong> — 15 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Une page affiche 200 "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 38582,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test3\": \"<strong>3. Remplissage de Formulaire</strong> — 15 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Un formulaire"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 38583,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test4\": \"<strong>4. Contrôle Spatial</strong> — 12 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">L'agent doit faire gli"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 38585,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test5\": \"<strong>5. Navigation Multi-Étapes</strong> — 13 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Une hiérarchie "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 38586,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test6\": \"<strong>6. Extraction de Données</strong> — 10 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">À partir d'une ta"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 38589,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test7\": \"<strong>7. Résilience aux Distractions</strong> — 10 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">La page con"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 38592,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test10\": \"<strong>10. Rétention de Contexte</strong> — 10 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">L'agent doit se"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 38945,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://tu-empresa.com...\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 39121,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req1\": \"✅ <strong>Bun</strong> runtime (<a href=\\\"https://bun.sh\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">bun.sh</a>)\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 39217,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"App Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Desca"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 39464,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Descarga Android: <a href=\\\"https://play.google.com/store/ap...\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 39949,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"App Android: <a href=\\\"https://play.google.com/store/apps/de...\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 41994,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"App Android: <a href=\\\"https://play.google.com/store/apps/de...\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 42619,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Este benchmark se basa en las metodologías de <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebAren"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 42619,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Este benchmark se basa en las metodologías de <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebAren"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 42619,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Este benchmark se basa en las metodologías de <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebAren"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 42626,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test1\": \"<strong>1. Percepción Visual</strong> — 15 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Al agente se le prese"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 42628,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test2\": \"<strong>2. Localización de Elementos</strong> — 15 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Una página re"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 42629,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test3\": \"<strong>3. Cumplimentación de Formularios</strong> — 15 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Un formu"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 42630,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test4\": \"<strong>4. Control Espacial</strong> — 12 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">El agente debe arrastr"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 42632,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test5\": \"<strong>5. Navegación Multi-Etapa</strong> — 13 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Una jerarquía de"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 42633,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test6\": \"<strong>6. Extracción de Datos</strong> — 10 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Dada una tabla HTML"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 42636,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test7\": \"<strong>7. Resiliencia ante Distracciones</strong> — 10 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">La págin"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 42639,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test10\": \"<strong>10. Retención de Contexto</strong> — 10 pts<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">El agente debe "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 42992,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://ihr-unternehmen.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 43168,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req1\": \"✅ <strong>Bun</strong> runtime (<a href=\\\"https://bun.sh\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">bun.sh</a>)\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 43264,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Von G"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 46271,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>Include Map Links</strong>: Pair with Google Maps links (<code>https://maps.google.com/?q=lat,lng</code>) for one-tap navigation\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 46704,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Dieser Benchmark wurde durch die Methodologien von <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">We"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 46704,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Dieser Benchmark wurde durch die Methodologien von <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">We"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 46704,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Dieser Benchmark wurde durch die Methodologien von <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">We"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 46711,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test1\": \"<strong>1. Visuelle Wahrnehmung</strong> — 15 Pkt.<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Dem Agenten wird "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 46713,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test2\": \"<strong>2. Element-Targeting</strong> — 15 Pkt.<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Eine Seite rendert 2"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 46714,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test3\": \"<strong>3. Formularvervollständigung</strong> — 15 Pkt.<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Ein mehrfeld"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 46715,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test4\": \"<strong>4. Räumliche Steuerung</strong> — 12 Pkt.<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Der Agent muss ein"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 46717,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test5\": \"<strong>5. Mehrstufige Navigation</strong> — 13 Pkt.<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Eine 3-stufige "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 46718,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test6\": \"<strong>6. Datenextraktion</strong> — 10 Pkt.<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Bei einer HTML-Tabelle"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 46721,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test7\": \"<strong>7. Ablenkungs-Resilienz</strong> — 10 Pkt.<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Die Seite enthält"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 46724,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test10\": \"<strong>10. Kontextretention</strong> — 10 Pkt.<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Der Agent muss sich"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 47070,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://syarikat-anda.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 47113,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Pergi ke <a href=\\\"index.html\\\">Portal Web</a> untuk mendaftar atau muat turun <a href=\\\"https://play.google.com/store/apps/details?id=com.han"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 47244,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req1\": \"✅ <strong>Bun</strong> runtime (<a href=\\\"https://bun.sh\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">bun.sh</a>)\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 47331,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Apl Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Muat "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 47577,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Muat turun Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 48057,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Apl Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Muat turun d"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 49618,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"Apl Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 49773,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"Muat turun: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play — EC"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 49817,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>Sertakan Pautan Peta</strong>: Gandingkan dengan pautan Peta Google (<code>https://maps.google.com/?q=lat,lng</code>) untuk navig"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 49890,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_lw_cta_android\": \"Muat Turun Apl: <a href=\\\"https://play.google.com/store/apps/details?id=com.eclawbot\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Muat turun di"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 51897,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Penanda aras ini dimaklumkan oleh metodologi <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 51897,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Penanda aras ini dimaklumkan oleh metodologi <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 51897,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"Penanda aras ini dimaklumkan oleh metodologi <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 51904,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test1\": \"<strong>1. Persepsi Visual</strong> — 15 mata<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Agen disajikan dengan "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 51906,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test2\": \"<strong>2. Penyasaran Elemen</strong> — 15 mata<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Halaman menampilkan "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 51907,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test3\": \"<strong>3. Pengisian Borang</strong> — 15 mata<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Borang berbilang meda"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 51908,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test4\": \"<strong>4. Kawalan Spatial</strong> — 12 mata<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Agen mesti menyeret el"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 51910,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test5\": \"<strong>5. Navigasi Berbilang Langkah</strong> — 13 mata<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Hierarki pa"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 51911,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test6\": \"<strong>6. Pengekstrakan Data</strong> — 10 mata<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Diberi jadual HTML "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 51914,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test7\": \"<strong>7. Daya Tahan Gangguan</strong> — 10 mata<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Halaman mengandung"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 51917,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test10\": \"<strong>10. Kekekalan Konteks</strong> — 10 mata<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">Agen mesti menging"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 52238,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 52281,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Go to <a href=\\\\\\\"index.html\\\\\\\">Web Portal</a> to register, or download the <a href=\\\\\\\"https://play.google.com/store/apps/details?id=com.han"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 54077,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req1\": \"✅ <strong>Bun</strong> runtime (<a href=\\\"https://bun.sh\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">bun.sh</a>)\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 54628,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>Include Map Links</strong>: Pair with Google Maps links (<code>https://maps.google.com/?q=lat,lng</code>) for one-tap navigation\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 57021,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"यह बेंचमार्क <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena</a> (CMU, 2023), <a href=\\\"http"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 57021,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"यह बेंचमार्क <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena</a> (CMU, 2023), <a href=\\\"http"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 57021,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"यह बेंचमार्क <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena</a> (CMU, 2023), <a href=\\\"http"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 57028,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test1\": \"<strong>1. दृश्य दृष्टि</strong> — 15 अंक<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">एजेंट को एक दृश्य दृश्य (ज"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 57030,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test2\": \"<strong>2. तत्व लक्ष्यीकरण</strong> — 15 अंक<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">एक पृष्ठ यादृच्छिक लेबल"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 57031,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test3\": \"<strong>3. फॉर्म पूर्णता</strong> — 15 अंक<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">एक बहु-क्षेत्र फॉर्म (टेक"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 57032,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test4\": \"<strong>4. स्थानिक नियंत्रण</strong> — 12 अंक<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">एजेंट को एक तत्व को स्"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 57034,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test5\": \"<strong>5. बहु-चरणीय नेविगेशन</strong> — 13 अंक<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">प्रति स्तर 6+ लिंक क"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 57035,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test6\": \"<strong>6. डेटा निष्कर्षण</strong> — 10 अंक<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">एक HTML तालिका (5-20 पंक"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 57038,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test7\": \"<strong>7. विकर्षण लचीलापन</strong> — 10 अंक<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">पृष्ठ में एक वैध जमा बट"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 57041,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test10\": \"<strong>10. संदर्भ धारण</strong> — 10 अंक<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">एजेंट को एक पहले के परीक्"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 57387,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 57430,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Go to <a href=\\\\\\\"index.html\\\\\\\">Web Portal</a> to register, or download the <a href=\\\\\\\"https://play.google.com/store/apps/details?id=com.han"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 57561,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_cc_channel_li_req1\": \"✅ <strong>Bun</strong> runtime (<a href=\\\"https://bun.sh\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">bun.sh</a>)\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 60116,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>Include Map Links</strong>: Pair with Google Maps links (<code>https://maps.google.com/?q=lat,lng</code>) for one-tap navigation\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 61082,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"استرشد هذا المعيار بمنهجيات <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena</a> (CMU، 2023)،"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 61082,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"استرشد هذا المعيار بمنهجيات <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena</a> (CMU، 2023)،"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 61082,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_motivation_refs\": \"استرشد هذا المعيار بمنهجيات <a href=\\\"https://webarena.dev/\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">WebArena</a> (CMU، 2023)،"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 61089,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test1\": \"<strong>1. الإدراك البصري</strong> — 15 نقطة<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">يُعرض على الوكيل مشهد ب"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 61091,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test2\": \"<strong>2. استهداف العناصر</strong> — 15 نقطة<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">تعرض الصفحة 200 زر بتس"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 61092,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test3\": \"<strong>3. إكمال النموذج</strong> — 15 نقطة<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">يجب ملء نموذج متعدد الحق"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 61093,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test4\": \"<strong>4. التحكم المكاني</strong> — 12 نقطة<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">يجب على الوكيل سحب عنصر"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 61095,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test5\": \"<strong>5. التنقل متعدد الخطوات</strong> — 13 نقطة<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">يتطلب تسلسل هرمي "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 61096,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test6\": \"<strong>6. استخراج البيانات</strong> — 10 نقاط<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">عند إعطاء جدول HTML ("
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 61099,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test7\": \"<strong>7. مقاومة التشتيت</strong> — 10 نقاط<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">تحتوي الصفحة على زر إرس"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/public/shared/i18n.js",
+      "line": 61102,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_arena_intro_test10\": \"<strong>10. الاحتفاظ بالسياق</strong> — 10 نقاط<br><span style=\\\"color:var(--text-secondary); font-size:13px;\\\">يجب على الوكيل تذكر"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/scripts/setup_broadcast_webhook.js",
+      "line": 21,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const HTTPS_URL = process.env.GATEWAY_HTTP_URL || 'https://clawdbot-railway-template-production-e663.up.railway.app/tools/invoke';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/scripts/setup_test_bot.js",
+      "line": 21,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const HTTPS_URL = process.env.GATEWAY_HTTP_URL || 'https://clawdbot-railway-template-production-e663.up.railway.app/tools/invoke';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/subscription.js",
+      "line": 30,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "? 'https://sandbox.tappaysdk.com/tpc/payment/pay-by-prime'"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/subscription.js",
+      "line": 31,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": ": 'https://prod.tappaysdk.com/tpc/payment/pay-by-prime';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/subscription.js",
+      "line": 33,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "? 'https://sandbox.tappaysdk.com/tpc/payment/pay-by-card-token'"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/subscription.js",
+      "line": 34,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": ": 'https://prod.tappaysdk.com/tpc/payment/pay-by-card-token';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/test_entity_communication.js",
+      "line": 108,
+      "rule": "hardcoded-entity-id",
+      "snippet": "entityId: 1,"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/test_entity_communication.js",
+      "line": 119,
+      "rule": "hardcoded-entity-id",
+      "snippet": "entityId: 2,"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/test_entity_communication.js",
+      "line": 132,
+      "rule": "hardcoded-entity-id",
+      "snippet": "entityId: 3,"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/test_multi_tenant.js",
+      "line": 52,
+      "rule": "hardcoded-entity-id",
+      "snippet": "const entity1 = entities.entities.find(e => e.entityId === 1);"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/wallet.js",
+      "line": 56,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const GOOGLE_ANDROIDPUBLISHER_SCOPE = 'https://www.googleapis.com/auth/androidpublisher';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/wallet.js",
+      "line": 58,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const GOOGLE_OAUTH_TOKEN_URL = 'https://oauth2.googleapis.com/token';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/wallet.js",
+      "line": 60,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const GOOGLE_ANDROIDPUBLISHER_BASE = 'https://androidpublisher.googleapis.com/androidpublisher/v3';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/wallet.js",
+      "line": 1326,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const APPLE_VERIFY_PROD = 'https://buy.itunes.apple.com/verifyReceipt';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/backend/wallet.js",
+      "line": 1327,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const APPLE_VERIFY_SANDBOX = 'https://sandbox.itunes.apple.com/verifyReceipt';"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 227,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 278,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Go to <a href=\\\"index.html\\\">Web Portal</a> to register, or download the <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.claw"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 460,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Downl"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 689,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 1182,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Download on "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 2630,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 2777,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"Download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play — ECla"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 2823,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>Include Map Links</strong>: Pair with Google Maps links (<code>https://maps.google.com/?q=lat,lng</code>) for one-tap navigation\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 2900,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_lw_cta_android\": \"Download App: <a href=\\\"https://play.google.com/store/apps/details?id=com.eclawbot\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Download on Goo"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 3309,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 3358,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"前往 <a href=\\\"index.html\\\">Web Portal</a> 註冊，或到 Google Play 下載 <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" targ"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 3540,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">前往 Goo"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 3769,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android 下載：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google P"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 4256,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 5666,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 5813,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"下載：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play — EClawbot</a"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 5859,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>附地圖連結</strong>：搭配 Google Maps 連結（<code>https://maps.google.com/?q=lat,lng</code>）讓用戶一鍵導航\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 5936,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_lw_cta_android\": \"下載 App：<a href=\\\"https://play.google.com/store/apps/details?id=com.eclawbot\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下載</a>\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 6396,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 6432,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"前往 <a href=\\\"index.html\\\">Web Portal</a> 注册，或到 Google Play 下载 <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" targ"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 6614,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">前往 Goo"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 6837,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"EClawbot 下载链接：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Googl"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 7325,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 8748,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 8895,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"下载：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play — EClawbot</a"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 8941,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>附地图链接</strong>：搭配 Google Maps 链接（<code>https://maps.google.com/?q=lat,lng</code>）让用户一键导航\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 9018,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_lw_cta_android\": \"下载 App：<a href=\\\"https://play.google.com/store/apps/details?id=com.eclawbot\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下载</a>\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 9461,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 9497,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"<a href=\\\"index.html\\\">Web Portal</a> で登録、または Google Play から <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" targe"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 9679,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 9902,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"EClawbotダウンロードリンク：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 10390,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android アプリ：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play で"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 11875,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 11911,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"<a href=\\\"index.html\\\">Web Portal</a>에서 등록하거나 Google Play에서 <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 12093,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Googl"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 12316,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"EClawbot 다운로드 링크: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 12804,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android 앱: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play에서 "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 14290,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 14326,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"ไปที่ <a href=\\\"index.html\\\">Web Portal</a> เพื่อสมัคร หรือดาวน์โหลด <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 14508,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Tải t"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 14737,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 15220,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"แอป Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">ดาวน์โหลดจาก"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 16706,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 16742,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Truy cập <a href=\\\"index.html\\\">Web Portal</a> để đăng ký, hoặc tải <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 16924,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">ดาวน์"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 17153,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 17636,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Ứng dụng Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Tải từ "
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 19122,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 19158,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Kunjungi <a href=\\\"index.html\\\">Web Portal</a> untuk mendaftar, atau unduh <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.cl"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 19340,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Unduh"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 19563,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Tautan unduh E-Claw: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 20051,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Aplikasi Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Unduh d"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/i18n_updated.js",
+      "line": 22340,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://syarikat-anda.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/openclaw-channel-eclaw/src/gateway.ts",
+      "line": 84,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'Example: https://your-openclaw-domain.com'"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/openclaw-channel-eclaw/src/index.ts",
+      "line": 19,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "*           webhookUrl: \"https://your-openclaw-domain.com\""
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/openclaw-channel-eclaw/src/index.ts",
+      "line": 23,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* (e.g. https://eclaw2.zeabur.app) so E-Claw knows where to push messages."
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/openclaw-channel-eclaw/src/onboarding.ts",
+      "line": 53,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "message: 'Webhook URL (your OpenClaw public URL, e.g. https://openclaw.example.com)',"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/openclaw-channel-eclaw/src/onboarding.ts",
+      "line": 54,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "placeholder: 'https://your-openclaw-domain.com',"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/scripts/add_spanish_v2.py",
+      "line": 88,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://tu-empresa.com\","
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/scripts/update_icons.py",
+      "line": 98,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<adaptive-icon xmlns:android=\"http://schemas.android.com/apk/res/android\">"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/scripts/upload_to_play.js",
+      "line": 76,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "scopes: ['https://www.googleapis.com/auth/androidpublisher'],"
+    },
+    {
+      "file": ".claude/worktrees/modest-feynman/scripts/upload_to_play.js",
+      "line": 154,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "console.log(`Check: https://play.google.com/console → E-Claw\\n`);"
+    },
+    {
+      "file": "app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt",
+      "line": 880,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "val storeUrl: String = \"https://play.google.com/store/apps/details?id=com.hank.clawlive\""
+    },
+    {
+      "file": "app/src/main/java/com/hank/clawlive/fcm/ClawFcmService.kt",
+      "line": 122,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "?: \"https://play.google.com/store/apps/details?id=com.hank.clawlive\""
+    },
+    {
+      "file": "backend/agent-improvement/audit-rules.js",
+      "line": 35,
+      "rule": "hardcoded-device-id",
+      "snippet": "const HANK_HEX_DEVICE = '480def4c-2183-4d8e-afd0-b131ae89adcc';"
+    },
+    {
+      "file": "backend/agent-improvement/audit-rules.js",
+      "line": 64,
+      "rule": "hardcoded-entity-id",
+      "snippet": "rationale: 'EClawbot entity slots are user-configurable. `entityId === 2` (etc.) outside a routing seam single-tenants the feature.',"
+    },
+    {
+      "file": "backend/agent-improvement/audit-rules.js",
+      "line": 54,
+      "rule": "hardcoded-hank-path",
+      "snippet": "title: 'Absolute path under /Users/hank/ in shipped code',"
+    },
+    {
+      "file": "backend/anthropic-client.js",
+      "line": 7,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';"
+    },
+    {
+      "file": "backend/arena-pool-updater.js",
+      "line": 27,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 68,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const BLOGGER_SCOPE = 'https://www.googleapis.com/auth/blogger';"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 81,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const DEVTO_API_BASE = 'https://dev.to/api';"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 93,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const WORDPRESS_API_BASE = 'https://public-api.wordpress.com';"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 100,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const TELEGRAPH_API_BASE = 'https://api.telegra.ph';"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 105,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const QIITA_API_BASE = 'https://qiita.com/api/v2';"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 115,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const WECHAT_API_BASE = 'https://api.weixin.qq.com/cgi-bin';"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 131,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const TUMBLR_API_BASE = 'https://api.tumblr.com/v2';"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 162,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const MASTODON_INSTANCE_URL = process.env.MASTODON_INSTANCE_URL || 'https://mastodon.social';"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 438,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.redirect(`https://accounts.google.com/o/oauth2/v2/auth?${params}`);"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 454,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const tokenRes = await fetch('https://oauth2.googleapis.com/token', {"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 476,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const blogsRes = await fetch('https://www.googleapis.com/blogger/v3/users/self/blogs', {"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 511,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const res = await fetch('https://oauth2.googleapis.com/token', {"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 561,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const url = `https://www.googleapis.com/blogger/v3/blogs/${targetBlogId}/posts` +"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 593,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "`https://www.googleapis.com/blogger/v3/blogs/${blogId}/posts/${postId}`,"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 620,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const X_API_BASE = 'https://api.x.com/2';"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 763,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const uploadUrl = 'https://upload.twitter.com/1.1/media/upload.json';"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 1001,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.redirect(`https://public-api.wordpress.com/oauth2/authorize?${params}`);"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 1011,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const tokenRes = await fetch('https://public-api.wordpress.com/oauth2/token', {"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 1417,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "msg = 'Qiita token expired or revoked — regenerate at https://qiita.com/settings/tokens/new (scopes: read_qiita, write_qiita) and update QIITA_ACCESS_TOKEN on R"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 1854,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const res = await fetch('https://www.reddit.com/api/v1/access_token', {"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 1891,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const res = await fetch(`https://oauth.reddit.com${path}`, options);"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 1908,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const meRes = await fetch('https://oauth.reddit.com/api/v1/me', {"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 2004,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const res = await fetch(`https://api.linkedin.com${path}`, options);"
+    },
+    {
+      "file": "backend/article-publisher.js",
+      "line": 2284,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'Qiita token expired or revoked. Regenerate at https://qiita.com/settings/tokens/new (scopes: read_qiita, write_qiita) and update QIITA_ACCESS_TOKEN env var on "
+    },
+    {
+      "file": "backend/auth.js",
+      "line": 1498,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const userInfoRes = await fetch('https://www.googleapis.com/oauth2/v3/userinfo', {"
+    },
+    {
+      "file": "backend/auth.js",
+      "line": 1534,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "`https://graph.facebook.com/me?fields=id,name,email,picture.type(large)&access_token=${encodeURIComponent(accessToken)}`"
+    },
+    {
+      "file": "backend/auth.js",
+      "line": 1593,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "// Apple JWKS: https://appleid.apple.com/auth/keys (cached 24h)"
+    },
+    {
+      "file": "backend/auth.js",
+      "line": 1596,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const APPLE_JWKS_URI = 'https://appleid.apple.com/auth/keys';"
+    },
+    {
+      "file": "backend/auth.js",
+      "line": 1597,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const APPLE_ISSUER = 'https://appleid.apple.com';"
+    },
+    {
+      "file": "backend/bot-tools.js",
+      "line": 123,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const searchUrl = `https://html.duckduckgo.com/html/?q=${encodeURIComponent(query)}`;"
+    },
+    {
+      "file": "backend/bot-tools.js",
+      "line": 587,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "hint: 'Get a free API key at https://www.pexels.com/api/ and set PEXELS_API_KEY env var'"
+    },
+    {
+      "file": "backend/bot-tools.js",
+      "line": 615,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const response = await fetch(`https://api.pexels.com/v1/search?${params}`, {"
+    },
+    {
+      "file": "backend/community-ssr.js",
+      "line": 31,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'@context': 'https://schema.org',"
+    },
+    {
+      "file": "backend/community-ssr.js",
+      "line": 169,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">"
+    },
+    {
+      "file": "backend/discord-integration.js",
+      "line": 34,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const DISCORD_API = 'https://discord.com/api/v10';"
+    },
+    {
+      "file": "backend/embedding-client.js",
+      "line": 37,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const resp = await fetch('https://api.openai.com/v1/embeddings', {"
+    },
+    {
+      "file": "backend/embedding-client.js",
+      "line": 54,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const resp = await fetch('https://api.voyageai.com/v1/embeddings', {"
+    },
+    {
+      "file": "backend/flickr.js",
+      "line": 148,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const photoUrl = `https://live.staticflickr.com/${photo.server}/${photo.id}_${photo.secret}_b.jpg`;"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 106,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "if (['https://eclawbot.com', 'https://www.eclawbot.com', 'https://eclaw.up.railway.app'].includes(origin)) return cb(null, true);"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 106,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "if (['https://eclawbot.com', 'https://www.eclawbot.com', 'https://eclaw.up.railway.app'].includes(origin)) return cb(null, true);"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 185,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.setHeader('Content-Security-Policy', \"default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.socket.io https://accounts."
+    },
+    {
+      "file": "backend/index.js",
+      "line": 185,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.setHeader('Content-Security-Policy', \"default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.socket.io https://accounts."
+    },
+    {
+      "file": "backend/index.js",
+      "line": 185,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.setHeader('Content-Security-Policy', \"default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.socket.io https://accounts."
+    },
+    {
+      "file": "backend/index.js",
+      "line": 185,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "res.setHeader('Content-Security-Policy', \"default-src 'self'; script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.socket.io https://accounts."
+    },
+    {
+      "file": "backend/index.js",
+      "line": 217,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'https://www.eclawbot.com',"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 218,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'https://eclaw.up.railway.app',"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 219,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'https://minigame.eclawbot.com'"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 555,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const apiRes = await fetch('https://api.anthropic.com/v1/messages', {"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 641,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'@context': 'https://schema.org',"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 1770,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.2.4/purify.min.js\"><\\/script>"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 2051,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "? `<div id=\"md-content\"></div><script src=\"https://cdnjs.cloudflare.com/ajax/libs/dompurify/3.2.4/purify.min.js\"><\\/script><script src=\"https://cdn.jsdelivr.net"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 5135,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "link: 'https://play.google.com/store/apps/details?id=com.hank.clawlive',"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 6275,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const shareUrl = `https://minigame.eclawbot.com/?ref=${code}&utm_source=invite&utm_medium=share&utm_campaign=viral_loop`;"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 6882,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "storeUrl: 'https://play.google.com/store/apps/details?id=com.hank.clawlive'"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 16298,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "// Derive restart URL from callback_url (e.g., https://a.eclawbot.com/eclaw-webhook → https://a.eclawbot.com/restart)"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 16298,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "// Derive restart URL from callback_url (e.g., https://a.eclawbot.com/eclaw-webhook → https://a.eclawbot.com/restart)"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 16509,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"  Example: wss://eclaw0.zeabur.app → https://eclaw0.zeabur.app/tools/invoke\\n\\n\" +"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 16631,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "// Normalize webhook URL: fix double slashes in path (e.g. https://x.com//tools/invoke)"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 17389,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* Discord webhooks follow: https://discord.com/api/webhooks/{id}/{token}"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 17390,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "*                      or: https://discordapp.com/api/webhooks/{id}/{token}"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 17403,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* Docs: https://discord.com/developers/docs/resources/webhook#execute-webhook"
+    },
+    {
+      "file": "backend/index.js",
+      "line": 17438,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* Google Chat webhooks follow: https://chat.googleapis.com/v1/spaces/{spaceId}/messages?key=...&token=..."
+    },
+    {
+      "file": "backend/index.js",
+      "line": 17452,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* Docs: https://developers.google.com/workspace/chat/api/reference/rest/v1/spaces.messages#Message"
+    },
+    {
+      "file": "backend/mission.js",
+      "line": 1808,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://js.tappaysdk.com/sdk/tpdirect/v5.18.0\"></script>"
+    },
+    {
+      "file": "backend/petdex-bridge.js",
+      "line": 25,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const MANIFEST_URL = 'https://petdex.crafter.run/api/manifest';"
+    },
+    {
+      "file": "backend/petdex-bridge.js",
+      "line": 159,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'Referer': 'https://petdex.crafter.run/',"
+    },
+    {
+      "file": "backend/public/arena/exam.html",
+      "line": 979,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "window.open('https://twitter.com/intent/tweet?text=' + encodeURIComponent(text), '_blank', 'width=550,height=420');"
+    },
+    {
+      "file": "backend/public/arena/index.html",
+      "line": 28,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/arena/index.html",
+      "line": 48,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/arena/index.html",
+      "line": 52,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"itemListOrder\": \"https://schema.org/ItemListUnordered\","
+    },
+    {
+      "file": "backend/public/arena/index.html",
+      "line": 245,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_0'), pts: 15, desc: i18n.t('arena_test_desc_0'), ref: 'OSWorld', url: 'https://os-world.github.io/' },"
+    },
+    {
+      "file": "backend/public/arena/index.html",
+      "line": 246,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_1'), pts: 15, desc: i18n.t('arena_test_desc_1'), ref: 'WebArena', url: 'https://webarena.dev/' },"
+    },
+    {
+      "file": "backend/public/arena/index.html",
+      "line": 247,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_2'), pts: 15, desc: i18n.t('arena_test_desc_2'), ref: 'WebVoyager', url: 'https://browser-use.com/posts/ai-browser-agent-benchma"
+    },
+    {
+      "file": "backend/public/arena/index.html",
+      "line": 248,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_3'), pts: 12, desc: i18n.t('arena_test_desc_3'), ref: 'OSWorld', url: 'https://os-world.github.io/' },"
+    },
+    {
+      "file": "backend/public/arena/index.html",
+      "line": 249,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_4'), pts: 13, desc: i18n.t('arena_test_desc_4'), ref: 'WebArena', url: 'https://webarena.dev/' },"
+    },
+    {
+      "file": "backend/public/arena/index.html",
+      "line": 250,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_5'), pts: 10, desc: i18n.t('arena_test_desc_5'), ref: 'WorkArena', url: 'https://servicenow.github.io/WorkArena/' },"
+    },
+    {
+      "file": "backend/public/arena/index.html",
+      "line": 251,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_6'), pts: 10, desc: i18n.t('arena_test_desc_6'), ref: 'ST-WebAgentBench', url: 'https://arxiv.org/html/2410.06703v5' },"
+    },
+    {
+      "file": "backend/public/arena/index.html",
+      "line": 254,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "{ name: i18n.t('arena_test_name_9'), pts: 10, desc: i18n.t('arena_test_desc_9'), ref: 'Context-Bench', url: 'https://tessl.io/blog/8-benchmarks-shaping-the-next"
+    },
+    {
+      "file": "backend/public/enterprise.html",
+      "line": 41,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/enterprise.html",
+      "line": 465,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<input type=\"url\" id=\"demoUrl\" data-i18n=\"ent_demo_url_placeholder\" placeholder=\"https://your-company.com\">"
+    },
+    {
+      "file": "backend/public/landing.html",
+      "line": 41,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/landing.html",
+      "line": 53,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/landing.html",
+      "line": 312,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "src=\"https://www.youtube-nocookie.com/embed/OkphZN8pRX8?rel=0\""
+    },
+    {
+      "file": "backend/public/portal/about-founder.html",
+      "line": 196,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "href=\"https://twitter.com/intent/tweet?text=One%20workflow%3A%20bug%20%E2%86%92%20planner%20%E2%86%92%20executor%20%E2%86%92%20reviewer%20%E2%86%92%20release.%2"
+    },
+    {
+      "file": "backend/public/portal/about-founder.html",
+      "line": 198,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "href=\"https://www.linkedin.com/sharing/share-offsite/?url=https%3A%2F%2Feclawbot.com%2Fportal%2Fabout-founder.html\">LinkedIn</a>"
+    },
+    {
+      "file": "backend/public/portal/about-founder.html",
+      "line": 200,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "href=\"https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Feclawbot.com%2Fportal%2Fabout-founder.html\">Facebook</a>"
+    },
+    {
+      "file": "backend/public/portal/analytics.html",
+      "line": 293,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const t = document.createElementNS('http://www.w3.org/2000/svg', 'text');"
+    },
+    {
+      "file": "backend/public/portal/analytics.html",
+      "line": 312,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');"
+    },
+    {
+      "file": "backend/public/portal/analytics.html",
+      "line": 319,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const lbl = document.createElementNS('http://www.w3.org/2000/svg', 'text');"
+    },
+    {
+      "file": "backend/public/portal/analytics.html",
+      "line": 328,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const xAxis = document.createElementNS('http://www.w3.org/2000/svg', 'line');"
+    },
+    {
+      "file": "backend/public/portal/analytics.html",
+      "line": 338,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const pV = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');"
+    },
+    {
+      "file": "backend/public/portal/analytics.html",
+      "line": 343,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const pU = document.createElementNS('http://www.w3.org/2000/svg', 'polyline');"
+    },
+    {
+      "file": "backend/public/portal/analytics.html",
+      "line": 351,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const cV = document.createElementNS('http://www.w3.org/2000/svg', 'circle');"
+    },
+    {
+      "file": "backend/public/portal/analytics.html",
+      "line": 354,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const titleV = document.createElementNS('http://www.w3.org/2000/svg', 'title');"
+    },
+    {
+      "file": "backend/public/portal/analytics.html",
+      "line": 359,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const cU = document.createElementNS('http://www.w3.org/2000/svg', 'circle');"
+    },
+    {
+      "file": "backend/public/portal/analytics.html",
+      "line": 365,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const tx = document.createElementNS('http://www.w3.org/2000/svg', 'text');"
+    },
+    {
+      "file": "backend/public/portal/assets/slides/info-credit-swap-mobile.html",
+      "line": 312,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "background: url(\"data:image/svg+xml,%3Csvg viewBox='0 0 100 40' xmlns='http://www.w3.org/2000/svg' preserveAspectRatio='none'%3E%3Cpath d='M0,35 Q25,10 50,15 T1"
+    },
+    {
+      "file": "backend/public/portal/assets/slides/info-credit-swap.html",
+      "line": 323,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "background: url(\"data:image/svg+xml,%3Csvg viewBox='0 0 100 40' xmlns='http://www.w3.org/2000/svg' preserveAspectRatio='none'%3E%3Cpath d='M0,35 Q25,10 50,15 T1"
+    },
+    {
+      "file": "backend/public/portal/assets/slides/info-rent-to-use-mobile.html",
+      "line": 248,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<svg class=\"arrow-svg\" viewBox=\"0 0 60 80\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">"
+    },
+    {
+      "file": "backend/public/portal/assets/slides/info-rent-to-use.html",
+      "line": 352,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<svg class=\"arrow-svg\" viewBox=\"0 0 160 60\" fill=\"none\" xmlns=\"http://www.w3.org/2000/svg\">"
+    },
+    {
+      "file": "backend/public/portal/chat.html",
+      "line": 6250,
+      "rule": "hardcoded-entity-id",
+      "snippet": "// gap where typed `@Hermes` (#5) drifted to `entityId: 3` (Mac_E)."
+    },
+    {
+      "file": "backend/public/portal/community.html",
+      "line": 40,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/compare.html",
+      "line": 28,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/dashboard.html",
+      "line": 10,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<link rel=\"preconnect\" href=\"https://js.tappaysdk.com\">"
+    },
+    {
+      "file": "backend/public/portal/dashboard.html",
+      "line": 2317,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<a class=\"channel-promo-link\" href=\"https://www.npmjs.com/package/@eclaw/openclaw-channel\" target=\"_blank\" rel=\"noopener\">npm →</a>"
+    },
+    {
+      "file": "backend/public/portal/dashboard.html",
+      "line": 2332,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<div class=\"channel-step-code\" onclick=\"copyText('ECLAW_API_KEY=eck_your_key\\nECLAW_WEBHOOK_URL=https://your-public-url.example.com\\nCODEX_WORKSPACE=/absolute/p"
+    },
+    {
+      "file": "backend/public/portal/dashboard.html",
+      "line": 2359,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<div class=\"channel-step-code\" onclick=\"copyText('cp .mcp.json.example .mcp.json\\n# then edit .mcp.json:\\n#   ECLAW_API_KEY=eck_your_key\\n#   ECLAW_WEBHOOK_URL="
+    },
+    {
+      "file": "backend/public/portal/dashboard.html",
+      "line": 2554,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://js.tappaysdk.com/sdk/tpdirect/v5.17.0\" async></script>"
+    },
+    {
+      "file": "backend/public/portal/dashboard.html",
+      "line": 4519,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');"
+    },
+    {
+      "file": "backend/public/portal/dashboard.html",
+      "line": 4548,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');"
+    },
+    {
+      "file": "backend/public/portal/delete-account.html",
+      "line": 123,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://accounts.google.com/gsi/client\" async defer></script>"
+    },
+    {
+      "file": "backend/public/portal/index.html",
+      "line": 25,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<link rel=\"preconnect\" href=\"https://accounts.google.com\" crossorigin>"
+    },
+    {
+      "file": "backend/public/portal/index.html",
+      "line": 26,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<link rel=\"dns-prefetch\" href=\"https://connect.facebook.net\">"
+    },
+    {
+      "file": "backend/public/portal/index.html",
+      "line": 158,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/index.html",
+      "line": 170,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/index.html",
+      "line": 712,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "s.src = 'https://accounts.google.com/gsi/client';"
+    },
+    {
+      "file": "backend/public/portal/index.html",
+      "line": 724,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "s.src = 'https://connect.facebook.net/en_US/sdk.js';"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 32,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 73,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 98,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "src=\"https://www.youtube.com/embed/3X7CWVCtYbk\""
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 119,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "src=\"https://www.youtube.com/embed/6hD9OTwc4jo\""
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 127,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<a class=\"qs-promo-link\" href=\"https://youtube.com/shorts/6hD9OTwc4jo\" target=\"_blank\" rel=\"noopener\" style=\"font-size: 0.85em;\">📺 在 YouTube Shorts 開啟</a>"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 218,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "src=\"https://www.youtube.com/embed/3X7CWVCtYbk\""
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 233,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 332,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<a class=\"feat-link\" href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\" data-i18n=\"guide_features_download\">下"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 546,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_features_cta_android\">Android App：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 688,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 886,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 1430,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 1844,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 1974,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_voice_cta_app\">Android App：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" "
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 1982,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 2151,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 2371,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 2493,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_gps_tip4\">🗺️ <strong data-i18n=\"guide_gps_tip4_strong\">附地圖連結</strong>：搭配 Google Maps 連結（<code>https://maps.google.com/?q=lat,lng</code>）讓用"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 2509,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 2597,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 2681,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_wp_cta_app\">下載 App：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noo"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 2691,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 2824,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 2929,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_mp_cta_android\">Android App：<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\""
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 2938,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 3101,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\"><a href=\"https://minigame.eclawbot.com/\" target=\"_blank\" rel=\"noopener\" data-i18n=\"guide_mg_cta_play\">🕹️ 前往遊戲平台 →</a></p>"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 3110,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 3217,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p class=\"cta-item\" data-i18n=\"[html]guide_bridge_cta_claude\">Claude Code CLI：<a href=\"https://docs.anthropic.com/en/docs/claude-code\" target=\"_blank\" rel=\"noop"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 3417,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p style=\"margin-top:8px;\" data-i18n=\"guide_arena_intro_motivation_refs\">This benchmark was informed by the methodologies of <a href=\"https://webarena.dev/\" tar"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 3417,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p style=\"margin-top:8px;\" data-i18n=\"guide_arena_intro_motivation_refs\">This benchmark was informed by the methodologies of <a href=\"https://webarena.dev/\" tar"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 3417,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<p style=\"margin-top:8px;\" data-i18n=\"guide_arena_intro_motivation_refs\">This benchmark was informed by the methodologies of <a href=\"https://webarena.dev/\" tar"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 3444,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">The agent is presented with a visual scene (geometric shapes, objects, or complex compositions) and m"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 3450,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">A page renders 200 buttons with randomized labels. The agent must locate and click the one matching a"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 3454,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">A multi-field form (text, email, dropdown, checkbox, date, textarea) must be filled with specified va"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 3458,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">The agent must drag an element from a source position to a target zone (with 50px tolerance). This re"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 3464,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">A 3-level link hierarchy with 6+ links per level requires the agent to plan a path to target informat"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 3468,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">Given an HTML table (5-20 rows × 5+ columns), the agent must answer an aggregation question (e.g., \"W"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 3478,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">The page contains one legitimate submit button and 5 decoy elements designed to mimic social engineer"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 3488,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<span style=\"color:var(--text-secondary); font-size:13px;\">The agent must recall a specific detail from an earlier test (e.g., \"What was the primary shape in th"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 3597,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 4403,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 4582,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_cc_channel_li_req1\">✅ <strong>Bun</strong> 執行環境（<a href=\"https://bun.sh\" target=\"_blank\" rel=\"noopener\">bun.sh</a>）</li>"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 4587,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_cc_channel_li_req6\">✅ 公開 URL（用於接收 webhook），建議使用 <a href=\"https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/\" target"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 4587,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_cc_channel_li_req6\">✅ 公開 URL（用於接收 webhook），建議使用 <a href=\"https://developers.cloudflare.com/cloudflare-one/connections/connect-apps/\" target"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 4775,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_cc_channel_li_ref_claude\">🤖 Claude Code 官方文件：<a href=\"https://docs.anthropic.com/en/docs/claude-code\" target=\"_blank\" rel=\"noopener\">docs."
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 4839,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "ECLAW_WEBHOOK_URL=https://your-public-url.example.com"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 5031,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "# 輸出：https://hermes-b.eclawbot.com 已通</div>"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 5090,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<li data-i18n=\"guide_hermes_channel_li_ref_hermes\">🦾 Hermes Agent（NousResearch）：<a href=\"https://github.com/NousResearch/hermes-agent\" target=\"_blank\" rel=\"noo"
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 5107,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/info.html",
+      "line": 5317,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"@context\": \"https://schema.org\","
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 14,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<section class=\"hero\" id=\"top\"><div class=\"hero-grid\"><div><span class=\"eyebrow\">名古屋旅行 · 11 張圖智慧互參照</span><h1>把行程、地圖、住宿與美食整理成一頁式 Atlas</h1><p>這個靜態頁把 11 張來源圖片整理成"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 16,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55267004840_fc30e1b11e_b.jpg\" alt=\"名古屋伴手禮精選\">"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 20,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55266610541_92152cb44d_b.jpg\" alt=\"名古屋自由行主視覺\">"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 24,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55266610586_df1d0e3b24_b.jpg\" alt=\"行程重點速讀\">"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 28,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55266610571_24c3311c56_b.jpg\" alt=\"名古屋地圖與區域關係\">"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 32,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55265702052_f5871a5f34_b.jpg\" alt=\"行李準備清單\">"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 36,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55266610576_560b39c1b5_b.jpg\" alt=\"Day 1 行程\">"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 40,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55267004865_7a67a8b5d0_b.jpg\" alt=\"Day 2 行程\">"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 44,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55266841314_8cb278c708_b.jpg\" alt=\"住宿資訊\">"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 48,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55265702067_97db035882_b.jpg\" alt=\"Day 3 行程\">"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 52,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55266743803_9e12f24aa5_b.jpg\" alt=\"Day 4 行程\">"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 56,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55267004850_4ff2b4b26d_b.jpg\" alt=\"Day 5 行程\">"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 62,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<div class=\"story-media\"><img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55267004840_fc30e1b11e_b.jpg\" alt=\"名古屋伴手禮精選\"></div>"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 66,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<div class=\"story-media\"><img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55266610541_92152cb44d_b.jpg\" alt=\"名古屋自由行主視覺\"></div>"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 70,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<div class=\"story-media\"><img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55266610586_df1d0e3b24_b.jpg\" alt=\"行程重點速讀\"></div>"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 74,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<div class=\"story-media\"><img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55266610571_24c3311c56_b.jpg\" alt=\"名古屋地圖與區域關係\"></div>"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 78,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<div class=\"story-media\"><img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55265702052_f5871a5f34_b.jpg\" alt=\"行李準備清單\"></div>"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 82,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<div class=\"story-media\"><img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55266610576_560b39c1b5_b.jpg\" alt=\"Day 1 行程\"></div>"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 86,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<div class=\"story-media\"><img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55267004865_7a67a8b5d0_b.jpg\" alt=\"Day 2 行程\"></div>"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 90,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<div class=\"story-media\"><img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55266841314_8cb278c708_b.jpg\" alt=\"住宿資訊\"></div>"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 94,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<div class=\"story-media\"><img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55265702067_97db035882_b.jpg\" alt=\"Day 3 行程\"></div>"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 98,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<div class=\"story-media\"><img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55266743803_9e12f24aa5_b.jpg\" alt=\"Day 4 行程\"></div>"
+    },
+    {
+      "file": "backend/public/portal/nagoya-image-atlas-20260513.html",
+      "line": 102,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<div class=\"story-media\"><img loading=\"lazy\" src=\"https://live.staticflickr.com/65535/55267004850_4ff2b4b26d_b.jpg\" alt=\"Day 5 行程\"></div>"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/index.html",
+      "line": 10,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<meta property=\"og:image\" content=\"https://live.staticflickr.com/65535/55266610541_92152cb44d_b.jpg\" />"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/index.html",
+      "line": 739,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img src=\"https://live.staticflickr.com/65535/55266610541_92152cb44d_b.jpg\" alt=\"名古屋自由行封面\" />"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/index.html",
+      "line": 844,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img src=\"https://live.staticflickr.com/65535/55266610576_560b39c1b5_b.jpg\" alt=\"Day 1 行程\" />"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/index.html",
+      "line": 880,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img src=\"https://live.staticflickr.com/65535/55267004865_7a67a8b5d0_b.jpg\" alt=\"Day 2 行程\" />"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/index.html",
+      "line": 915,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img src=\"https://live.staticflickr.com/65535/55265702067_97db035882_b.jpg\" alt=\"Day 3 行程\" />"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/index.html",
+      "line": 951,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img src=\"https://live.staticflickr.com/65535/55266743803_9e12f24aa5_b.jpg\" alt=\"Day 4 行程\" />"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/index.html",
+      "line": 986,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img src=\"https://live.staticflickr.com/65535/55267004850_4ff2b4b26d_b.jpg\" alt=\"Day 5 行程\" />"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/index.html",
+      "line": 1024,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img src=\"https://live.staticflickr.com/65535/55266841314_8cb278c708_b.jpg\" alt=\"Hotel JAL City Nagoya Nishiki\" />"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/index.html",
+      "line": 1041,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img src=\"https://live.staticflickr.com/65535/55266841314_8cb278c708_b.jpg\" alt=\"J Hotel Rinku\" />"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/index.html",
+      "line": 1071,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<a class=\"highlight-card\" href=\"https://www.google.com/maps/search/?api=1&query=%E5%90%8D%E5%8F%A4%E5%B1%8B%E6%B8%AF%E6%B0%B4%E6%97%8F%E9%A4%A8%203-1%20Minatoma"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/index.html",
+      "line": 1072,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<a class=\"highlight-card\" href=\"https://www.google.com/maps/search/?api=1&query=Ghibli%20Park%20Aichi%20Expo%20Memorial%20Park\" target=\"_blank\" rel=\"noopener\"><"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/index.html",
+      "line": 1073,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<a class=\"highlight-card\" href=\"https://www.google.com/maps/search/?api=1&query=LEGOLAND%20Japan%202-2-1%20Kinjofuto%20Minato-ku%20Nagoya\" target=\"_blank\" rel=\""
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/index.html",
+      "line": 1074,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<a class=\"highlight-card\" href=\"https://www.google.com/maps/search/?api=1&query=%E5%A4%A7%E9%A0%88%E5%95%86%E5%BA%97%E8%A1%97%20Osu%20Shopping%20District%20Nago"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/index.html",
+      "line": 1075,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<a class=\"highlight-card\" href=\"https://www.google.com/maps/search/?api=1&query=Sakae%20Nagoya%20Shopping%20District\" target=\"_blank\" rel=\"noopener\"><span class"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/index.html",
+      "line": 1087,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img src=\"https://live.staticflickr.com/65535/55267004840_fc30e1b11e_b.jpg\" alt=\"名古屋伴手禮精選\" />"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/index.html",
+      "line": 1124,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img src=\"https://live.staticflickr.com/65535/55266610571_24c3311c56_b.jpg\" alt=\"名古屋地圖\" />"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/index.html",
+      "line": 1128,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<img src=\"https://live.staticflickr.com/65535/55265702052_f5871a5f34_b.jpg\" alt=\"行李準備清單\" />"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/index.html",
+      "line": 1209,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const mapUrl = (query) => \"https://www.google.com/maps/search/?api=1&query=\" + encodeURIComponent(query);"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/map-embed.html",
+      "line": 214,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "地圖資料 © <a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\" rel=\"noopener\">OpenStreetMap</a> 貢獻者 ・"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/map-embed.html",
+      "line": 215,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "底圖 <a href=\"https://leafletjs.com/\" target=\"_blank\" rel=\"noopener\">Leaflet</a>"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/map-embed.html",
+      "line": 246,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const svg = `<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"28\" height=\"36\" viewBox=\"0 0 28 36\">"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/map-embed.html",
+      "line": 267,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "attribution: '© <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors'"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/map.html",
+      "line": 248,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "地圖資料 © <a href=\"https://www.openstreetmap.org/copyright\" target=\"_blank\" rel=\"noopener\">OpenStreetMap</a> 貢獻者 ・"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/map.html",
+      "line": 249,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "底圖 <a href=\"https://leafletjs.com/\" target=\"_blank\" rel=\"noopener\">Leaflet</a> ・"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/map.html",
+      "line": 276,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const svg = `<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"30\" height=\"40\" viewBox=\"0 0 30 40\">"
+    },
+    {
+      "file": "backend/public/portal/nagoya-trip-20260513/map.html",
+      "line": 294,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "attribution: '© <a href=\"https://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors'"
+    },
+    {
+      "file": "backend/public/portal/settings.html",
+      "line": 1556,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<script src=\"https://js.tappaysdk.com/sdk/tpdirect/v5.17.0\"></script>"
+    },
+    {
+      "file": "backend/public/portal/share-chat.html",
+      "line": 480,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'@context':'https://schema.org',"
+    },
+    {
+      "file": "backend/public/portal/share-chat.html",
+      "line": 907,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "s.src = 'https://accounts.google.com/gsi/client';"
+    },
+    {
+      "file": "backend/public/portal/share-chat.html",
+      "line": 919,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "s.src = 'https://connect.facebook.net/en_US/sdk.js';"
+    },
+    {
+      "file": "backend/public/portal/shared/footer.js",
+      "line": 32,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<a href=\"https://play.google.com/store/apps/details?id=com.hank.clawlive\" target=\"_blank\" rel=\"noopener\" class=\"footer-link\">Google Play</a>"
+    },
+    {
+      "file": "backend/public/portal/shared/nav.js",
+      "line": 69,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<svg class=\"ecoin-icon\" xmlns=\"http://www.w3.org/2000/svg\" width=\"16\" height=\"16\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-"
+    },
+    {
+      "file": "backend/public/portal/shared/nav.js",
+      "line": 77,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<svg class=\"bell-icon\" xmlns=\"http://www.w3.org/2000/svg\" width=\"20\" height=\"20\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-l"
+    },
+    {
+      "file": "backend/public/promo-meta.html",
+      "line": 155,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "src=\"https://www.youtube.com/embed/fgHY1bXg1xk\""
+    },
+    {
+      "file": "backend/public/promo.html",
+      "line": 155,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "src=\"https://www.youtube.com/embed/3X7CWVCtYbk\""
+    },
+    {
+      "file": "backend/public/promo.html",
+      "line": 169,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "src=\"https://www.youtube.com/embed/BhXBsrSTcsY\""
+    },
+    {
+      "file": "backend/public/shared/help-popover.js",
+      "line": 39,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const HELP_ICON_SVG = `<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"14\" height=\"14\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" str"
+    },
+    {
+      "file": "backend/scripts/setup_broadcast_webhook.js",
+      "line": 21,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const HTTPS_URL = process.env.GATEWAY_HTTP_URL || 'https://clawdbot-railway-template-production-e663.up.railway.app/tools/invoke';"
+    },
+    {
+      "file": "backend/scripts/setup_test_bot.js",
+      "line": 21,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const HTTPS_URL = process.env.GATEWAY_HTTP_URL || 'https://clawdbot-railway-template-production-e663.up.railway.app/tools/invoke';"
+    },
+    {
+      "file": "backend/subscription.js",
+      "line": 30,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "? 'https://sandbox.tappaysdk.com/tpc/payment/pay-by-prime'"
+    },
+    {
+      "file": "backend/subscription.js",
+      "line": 31,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": ": 'https://prod.tappaysdk.com/tpc/payment/pay-by-prime';"
+    },
+    {
+      "file": "backend/subscription.js",
+      "line": 33,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "? 'https://sandbox.tappaysdk.com/tpc/payment/pay-by-card-token'"
+    },
+    {
+      "file": "backend/subscription.js",
+      "line": 34,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": ": 'https://prod.tappaysdk.com/tpc/payment/pay-by-card-token';"
+    },
+    {
+      "file": "backend/test_entity_communication.js",
+      "line": 108,
+      "rule": "hardcoded-entity-id",
+      "snippet": "entityId: 1,"
+    },
+    {
+      "file": "backend/test_entity_communication.js",
+      "line": 119,
+      "rule": "hardcoded-entity-id",
+      "snippet": "entityId: 2,"
+    },
+    {
+      "file": "backend/test_entity_communication.js",
+      "line": 132,
+      "rule": "hardcoded-entity-id",
+      "snippet": "entityId: 3,"
+    },
+    {
+      "file": "backend/test_multi_tenant.js",
+      "line": 52,
+      "rule": "hardcoded-entity-id",
+      "snippet": "const entity1 = entities.entities.find(e => e.entityId === 1);"
+    },
+    {
+      "file": "backend/tooling/eclaw-usage-daemon/auth.py",
+      "line": 24,
+      "rule": "hardcoded-hank-path",
+      "snippet": "ECLAW_ENV_PATH = Path(\"/Users/hank/Desktop/Project/EClaw/backend/.env\")"
+    },
+    {
+      "file": "backend/wallet.js",
+      "line": 55,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const GOOGLE_ANDROIDPUBLISHER_SCOPE = 'https://www.googleapis.com/auth/androidpublisher';"
+    },
+    {
+      "file": "backend/wallet.js",
+      "line": 57,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const GOOGLE_OAUTH_TOKEN_URL = 'https://oauth2.googleapis.com/token';"
+    },
+    {
+      "file": "backend/wallet.js",
+      "line": 59,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const GOOGLE_ANDROIDPUBLISHER_BASE = 'https://androidpublisher.googleapis.com/androidpublisher/v3';"
+    },
+    {
+      "file": "backend/wallet.js",
+      "line": 1326,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const APPLE_VERIFY_PROD = 'https://buy.itunes.apple.com/verifyReceipt';"
+    },
+    {
+      "file": "backend/wallet.js",
+      "line": 1327,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "const APPLE_VERIFY_SANDBOX = 'https://sandbox.itunes.apple.com/verifyReceipt';"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 227,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 278,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Go to <a href=\\\"index.html\\\">Web Portal</a> to register, or download the <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.claw"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 460,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Downl"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 689,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 1182,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Download on "
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 2630,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 2777,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"Download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play — ECla"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 2823,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>Include Map Links</strong>: Pair with Google Maps links (<code>https://maps.google.com/?q=lat,lng</code>) for one-tap navigation\""
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 2900,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_lw_cta_android\": \"Download App: <a href=\\\"https://play.google.com/store/apps/details?id=com.eclawbot\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Download on Goo"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 3309,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 3358,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"前往 <a href=\\\"index.html\\\">Web Portal</a> 註冊，或到 Google Play 下載 <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" targ"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 3540,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">前往 Goo"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 3769,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android 下載：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google P"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 4256,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 5666,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play "
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 5813,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"下載：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play — EClawbot</a"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 5859,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>附地圖連結</strong>：搭配 Google Maps 連結（<code>https://maps.google.com/?q=lat,lng</code>）讓用戶一鍵導航\","
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 5936,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_lw_cta_android\": \"下載 App：<a href=\\\"https://play.google.com/store/apps/details?id=com.eclawbot\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下載</a>\","
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 6396,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 6432,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"前往 <a href=\\\"index.html\\\">Web Portal</a> 注册，或到 Google Play 下载 <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" targ"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 6614,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">前往 Goo"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 6837,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"EClawbot 下载链接：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Googl"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 7325,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 8748,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_mp_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play "
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 8895,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_wp_cta_app\": \"下载：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play — EClawbot</a"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 8941,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_gps_tip4\": \"🗺️ <strong>附地图链接</strong>：搭配 Google Maps 链接（<code>https://maps.google.com/?q=lat,lng</code>）让用户一键导航\","
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 9018,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_lw_cta_android\": \"下载 App：<a href=\\\"https://play.google.com/store/apps/details?id=com.eclawbot\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play 下载</a>\","
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 9461,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 9497,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"<a href=\\\"index.html\\\">Web Portal</a> で登録、または Google Play から <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" targe"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 9679,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 9902,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"EClawbotダウンロードリンク：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 10390,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android アプリ：<a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play で"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 11875,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 11911,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"<a href=\\\"index.html\\\">Web Portal</a>에서 등록하거나 Google Play에서 <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 12093,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Googl"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 12316,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"EClawbot 다운로드 링크: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 12804,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Android 앱: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Google Play에서 "
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 14290,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 14326,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"ไปที่ <a href=\\\"index.html\\\">Web Portal</a> เพื่อสมัคร หรือดาวน์โหลด <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 14508,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Tải t"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 14737,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 15220,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"แอป Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">ดาวน์โหลดจาก"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 16706,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 16742,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Truy cập <a href=\\\"index.html\\\">Web Portal</a> để đăng ký, hoặc tải <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 16924,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">ดาวน์"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 17153,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Android download: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">G"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 17636,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Ứng dụng Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Tải từ "
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 19122,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://your-company.com\","
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 19158,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"qs_step1_desc\": \"Kunjungi <a href=\\\"index.html\\\">Web Portal</a> untuk mendaftar, atau unduh <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.cl"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 19340,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_features_cta_android\": \"Android App: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Unduh"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 19563,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_setup_download_link\": \"Tautan unduh E-Claw: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 20051,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"guide_voice_cta_app\": \"Aplikasi Android: <a href=\\\"https://play.google.com/store/apps/details?id=com.hank.clawlive\\\" target=\\\"_blank\\\" rel=\\\"noopener\\\">Unduh d"
+    },
+    {
+      "file": "i18n_updated.js",
+      "line": 22340,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://syarikat-anda.com\","
+    },
+    {
+      "file": "openclaw-channel-eclaw/src/gateway.ts",
+      "line": 97,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "'Example: https://your-openclaw-domain.com'"
+    },
+    {
+      "file": "openclaw-channel-eclaw/src/index.ts",
+      "line": 18,
+      "rule": "hardcoded-entity-id",
+      "snippet": "*           entityId: 1"
+    },
+    {
+      "file": "openclaw-channel-eclaw/src/index.ts",
+      "line": 20,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "*           webhookUrl: \"https://your-openclaw-domain.com\""
+    },
+    {
+      "file": "openclaw-channel-eclaw/src/index.ts",
+      "line": 24,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "* (e.g. https://eclaw2.zeabur.app) so E-Claw knows where to push messages."
+    },
+    {
+      "file": "openclaw-channel-eclaw/src/onboarding.ts",
+      "line": 53,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "message: 'Webhook URL (your OpenClaw public URL, e.g. https://openclaw.example.com)',"
+    },
+    {
+      "file": "openclaw-channel-eclaw/src/onboarding.ts",
+      "line": 54,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "placeholder: 'https://your-openclaw-domain.com',"
+    },
+    {
+      "file": "scripts/add_spanish_v2.py",
+      "line": 88,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "\"ent_demo_url_placeholder\": \"https://tu-empresa.com\","
+    },
+    {
+      "file": "scripts/update_icons.py",
+      "line": 98,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "<adaptive-icon xmlns:android=\"http://schemas.android.com/apk/res/android\">"
+    },
+    {
+      "file": "scripts/upload_to_play.js",
+      "line": 76,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "scopes: ['https://www.googleapis.com/auth/androidpublisher'],"
+    },
+    {
+      "file": "scripts/upload_to_play.js",
+      "line": 154,
+      "rule": "non-eclawbot-prod-url",
+      "snippet": "console.log(`Check: https://play.google.com/console → E-Claw\\n`);"
+    }
+  ],
+  "summary": {
+    "by_rule": {
+      "non-eclawbot-prod-url": 1288,
+      "hardcoded-entity-id": 22,
+      "hardcoded-device-id": 1,
+      "hardcoded-hank-path": 2
+    },
+    "total": 1313
+  }
+}


### PR DESCRIPTION
## Summary
Deliverable A of strategic compliance card_923709f5 (multi-tenant audit cron). Detection-only scanner + initial baseline snapshot. No cron, no fixes — those are Parts B + C, deferred.

Slice card: card_53fda6553a66ee0db4fda8da

## Rules detected (5)
1. `hardcoded-device-id` — Hank's deviceId literal in committed code
2. `hardcoded-entity-id` — `entityId === N` where N>0 in shared paths
3. `hardcoded-hank-path` — `/Users/hank/` filesystem literals
4. `email-gate` — Hank's personal email used as a conditional gate
5. `non-eclawbot-prod-url` — production URLs outside the allowlist (cdn/fonts/github/railway/etc.)

## Exemptions
`tests/`, `__tests__/`, `.test.{js,ts,…}`, `scripts/dev-only/`, `docs/`, `.worktrees/`, `Pods/`, and the scanner itself.

## Baseline
`docs/compliance-baseline-2026-06-09.json`:
- 2722 files scanned
- 1313 violations across 4 rules
- Breakdown: 1288 URL (mostly legit doc/CDN — will progressively allowlist), 22 entityId, 2 hank paths, 1 deviceId
- 25 non-URL hits = real signal for follow-up cards

## Test plan
- [x] Local: `npx jest backend/tests/jest/compliance-scan.test.js` → 10/10 pass
- [x] CLI dry-run: `node backend/scripts/compliance-scan.js --root . -o docs/compliance-baseline-2026-06-09.json` → writes JSON, prints count
- [ ] CI Jest gate passes
- [ ] Post-merge: wire-back comment on parent card_923709f5 with PR URL + baseline path + the 25 real findings count

## Out of scope (parent card_923709f5 Parts B + C, deferred)
- Multi-tenant E2E matrix
- Weekly cron + delta-vs-baseline alerting
- Actually fixing the 25 real findings (one card per finding once Hank confirms which to prioritize)

🤖 Generated with [Claude Code](https://claude.com/claude-code)