### PR TITLE
fix(tests): align deep-link static assert with prefillInput drop (PR #3263)

### DIFF
--- a/backend/tests/jest/chat-kanban-message-deeplink-static.test.js
+++ b/backend/tests/jest/chat-kanban-message-deeplink-static.test.js
@@ -37,7 +37,8 @@ describe('chat message deep-link plumbing', () => {
     test('chat page opens messageId deep-links from query, quotes, and native intents', () => {
         expect(chatHtml).toContain('async function openChatMessageDeepLink(messageId, { showMissingToast = true, scroll = true } = {})');
         expect(chatHtml).toContain("url.searchParams.set('messageId', id);");
-        expect(chatHtml).toContain('const { source, title, excerpt, prefillInput, messageId, meta, ts } = JSON.parse(pq);');
+        expect(chatHtml).toContain('const { source, title, excerpt, messageId, meta, ts } = JSON.parse(pq);');
+        expect(chatHtml).not.toContain('prefillInput, messageId, meta, ts } = JSON.parse(pq)');
         expect(chatHtml).toContain('await openChatMessageDeepLink(messageId, { showMissingToast: true, scroll: true });');
         expect(chatHtml).toContain('const msgId = intent.messageId || quote.messageId');
         expect(chatHtml).toContain("quoteToChat(quote.source || '引用', quote.title || '', quote.excerpt || '');");

--- a/backend/tests/jest/chat-quote-smart-receiver.test.js
+++ b/backend/tests/jest/chat-quote-smart-receiver.test.js
@@ -84,15 +84,18 @@ describe('chat quote-reply smart receiver — chat.html surface', () => {
     });
 
     test('localStorage and cross-iframe pickup forward the meta param', () => {
-        // pending_quote pickup at first-load
+        // pending_quote pickup at first-load — prefillInput intentionally dropped per PR #3263 smart-quote sink fix
         expect(chatHtml).toMatch(
-            /const\s*\{\s*source,\s*title,\s*excerpt,\s*prefillInput,\s*messageId,\s*meta,\s*ts\s*\}\s*=\s*JSON\.parse\(pq\)/
+            /const\s*\{\s*source,\s*title,\s*excerpt,\s*messageId,\s*meta,\s*ts\s*\}\s*=\s*JSON\.parse\(pq\)/
         );
         expect(chatHtml).toMatch(/quoteToChat\(\s*source,\s*title,\s*excerpt\s*\|\|\s*['"]['"]\s*,\s*meta\s*\)/);
-        // workspace.html postMessage relay
+        // workspace.html postMessage relay — same intentional drop
         expect(chatHtml).toMatch(
-            /const\s*\{\s*source,\s*title,\s*excerpt,\s*prefillInput,\s*messageId,\s*meta\s*\}\s*=\s*e\.data/
+            /const\s*\{\s*source,\s*title,\s*excerpt,\s*messageId,\s*meta\s*\}\s*=\s*e\.data/
         );
+        // Regression guard: prefillInput must NOT reappear in either destructure
+        expect(chatHtml).not.toMatch(/prefillInput,\s*messageId,\s*meta,\s*ts\s*\}\s*=\s*JSON\.parse\(pq\)/);
+        expect(chatHtml).not.toMatch(/prefillInput,\s*messageId,\s*meta\s*\}\s*=\s*e\.data/);
     });
 
     test('manual uncheck revokes the hint via updateTargetAll', () => {


### PR DESCRIPTION
## Summary
Unblock CI on PRs #3265 + #3266. PR #3263 (smart-quote sink fix) intentionally removed `prefillInput` from the localStorage quote-pickup destructure in `backend/public/portal/chat.html:3746`, but the static-assertion test in `chat-kanban-message-deeplink-static.test.js:40` was still pinning the OLD shape — so every subsequent PR's CI hit this stale regression.

## Test plan
- [x] `npx jest backend/tests/jest/chat-kanban-message-deeplink-static.test.js` → 6/6 pass
- [x] Includes positive `expect().not.toContain()` regression guard so prefillInput cannot accidentally come back into the destructure

🤖 Generated with [Claude Code](https://claude.com/claude-code)