### PR TITLE
feat(offline-queue): idempotency-key middleware + migration (Phase 2 #5 sub-deliverable A)

### DIFF
--- a/backend/idempotency-keys.js
+++ b/backend/idempotency-keys.js
@@ -1,0 +1,81 @@
+'use strict';
+
+// Server-side idempotency-key dedupe for /api/transform.
+// Card: card_47ed9a0c (OODA-R Phase 2 #5 offline delivery queue).
+// Spec: docs/offline-delivery-queue-spec.md.
+//
+// Express middleware that caches the (status, response body) of the FIRST
+// call for a given (deviceId, Idempotency-Key) pair, then short-circuits
+// subsequent calls within 24h to return the cached response.
+//
+// Design rules:
+// - Raw client key never lands in the DB — only sha256(deviceId|key).
+// - Missing header → no-op (legacy clients keep working).
+// - DB lookup error → fall through to handler (availability > perfect dedupe).
+// - First-write insert is async + ON CONFLICT DO NOTHING (race-safe).
+
+const crypto = require('crypto');
+
+const TTL_HOURS = 24;
+const MIN_KEY_LEN = 8;
+const MAX_KEY_LEN = 128;
+
+function hashKey(deviceId, key) {
+    return crypto.createHash('sha256').update(`${deviceId}|${key}`).digest('hex');
+}
+
+function isValidClientKey(key) {
+    if (typeof key !== 'string') return false;
+    if (key.length < MIN_KEY_LEN || key.length > MAX_KEY_LEN) return false;
+    return /^[\w.\-]+$/.test(key);
+}
+
+function makeMiddleware(pool, { ttlHours = TTL_HOURS } = {}) {
+    return async function idempotencyMiddleware(req, res, next) {
+        const clientKey = req.get('Idempotency-Key') || req.get('idempotency-key');
+        const deviceId = req.body && req.body.deviceId;
+        if (!clientKey || !deviceId || !isValidClientKey(clientKey)) {
+            return next();
+        }
+        const hash = hashKey(deviceId, clientKey);
+
+        try {
+            const cached = await pool.query(
+                'SELECT response_blob, status_code FROM idempotency_keys WHERE hash = $1 AND expires_at > NOW()',
+                [hash]
+            );
+            if (cached.rows.length > 0) {
+                res.set('X-Idempotent-Hit', '1');
+                return res.status(cached.rows[0].status_code).json(cached.rows[0].response_blob);
+            }
+        } catch (err) {
+            console.warn('[idem] cache lookup failed:', err && err.message);
+            return next();
+        }
+
+        const origJson = res.json.bind(res);
+        res.json = (body) => {
+            const status = res.statusCode || 200;
+            pool.query(
+                `INSERT INTO idempotency_keys (hash, response_blob, status_code, expires_at)
+                 VALUES ($1, $2::jsonb, $3, NOW() + ($4 || ' hours')::interval)
+                 ON CONFLICT (hash) DO NOTHING`,
+                [hash, JSON.stringify(body), status, String(ttlHours)]
+            ).catch((err) => {
+                console.warn('[idem] insert failed:', err && err.message);
+            });
+            return origJson(body);
+        };
+
+        next();
+    };
+}
+
+module.exports = {
+    makeMiddleware,
+    hashKey,
+    isValidClientKey,
+    TTL_HOURS,
+    MIN_KEY_LEN,
+    MAX_KEY_LEN,
+};

--- a/backend/migrations/20260609_idempotency_keys.down.sql
+++ b/backend/migrations/20260609_idempotency_keys.down.sql
@@ -1,0 +1,2 @@
+-- Reverses 20260609_idempotency_keys.up.sql
+DROP TABLE IF EXISTS idempotency_keys;

--- a/backend/migrations/20260609_idempotency_keys.up.sql
+++ b/backend/migrations/20260609_idempotency_keys.up.sql
@@ -1,0 +1,24 @@
+-- Migration: 20260609_idempotency_keys
+-- Server-side idempotency-key dedupe for /api/transform.
+-- Card: card_47ed9a0c (OODA-R Phase 2 #5 offline delivery queue).
+-- Spec: docs/offline-delivery-queue-spec.md.
+--
+-- When a client retries a queued send, the server must return the SAME
+-- response (status + body) as the first call instead of double-processing.
+-- The dedupe key is sha256(deviceId + clientIdempotencyKey) so the raw
+-- key never lands in the DB; per-device collision is impossible.
+
+CREATE TABLE IF NOT EXISTS idempotency_keys (
+    id BIGSERIAL PRIMARY KEY,
+    hash CHAR(64) NOT NULL UNIQUE,
+    response_blob JSONB NOT NULL,
+    status_code SMALLINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    expires_at TIMESTAMPTZ NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_idem_expires_at
+    ON idempotency_keys(expires_at);
+
+COMMENT ON TABLE idempotency_keys IS
+    'Caches POST /api/transform responses keyed by sha256(deviceId|clientIdempotencyKey) for 24h, so client retries of a queued offline send return the original response instead of double-processing.';

--- a/backend/tests/jest/idempotency-keys.test.js
+++ b/backend/tests/jest/idempotency-keys.test.js
@@ -1,0 +1,204 @@
+'use strict';
+
+const {
+    makeMiddleware,
+    hashKey,
+    isValidClientKey,
+    TTL_HOURS,
+    MIN_KEY_LEN,
+    MAX_KEY_LEN,
+} = require('../../idempotency-keys');
+
+function makeReq({ key = null, deviceId = 'dev-test' } = {}) {
+    const headers = {};
+    if (key !== null) headers['idempotency-key'] = key;
+    return {
+        get(name) {
+            return headers[String(name).toLowerCase()];
+        },
+        body: { deviceId },
+    };
+}
+
+function makeRes() {
+    const res = {
+        statusCode: 200,
+        sentBody: undefined,
+        sentStatus: undefined,
+        setHeaders: {},
+        status(code) { this.statusCode = code; this.sentStatus = code; return this; },
+        set(name, val) { this.setHeaders[name] = val; return this; },
+        json(body) { this.sentBody = body; return body; },
+    };
+    return res;
+}
+
+function makePool(initialRows = []) {
+    let rows = initialRows.slice();
+    let insertFails = false;
+    let lookupFails = false;
+    return {
+        rows: () => rows.slice(),
+        breakLookup() { lookupFails = true; },
+        breakInsert() { insertFails = true; },
+        async query(sql, params) {
+            if (lookupFails && sql.startsWith('SELECT')) throw new Error('boom');
+            if (sql.startsWith('SELECT')) {
+                const hit = rows.find((r) => r.hash === params[0] && r.expires_at > Date.now());
+                return { rows: hit ? [{ response_blob: hit.response_blob, status_code: hit.status_code }] : [] };
+            }
+            if (sql.startsWith('INSERT')) {
+                if (insertFails) throw new Error('boom-insert');
+                const exists = rows.some((r) => r.hash === params[0]);
+                if (!exists) {
+                    rows.push({
+                        hash: params[0],
+                        response_blob: JSON.parse(params[1]),
+                        status_code: params[2],
+                        expires_at: Date.now() + 24 * 60 * 60 * 1000,
+                    });
+                }
+                return { rows: [] };
+            }
+            return { rows: [] };
+        },
+    };
+}
+
+describe('idempotency-keys middleware', () => {
+    test('no Idempotency-Key header → next() without touching pool', async () => {
+        const pool = makePool();
+        const middleware = makeMiddleware(pool);
+        const req = makeReq({ key: null });
+        const res = makeRes();
+        let called = false;
+        await middleware(req, res, () => { called = true; });
+        expect(called).toBe(true);
+        expect(res.sentBody).toBeUndefined();
+        expect(pool.rows()).toHaveLength(0);
+    });
+
+    test('first call caches the response after handler writes it', async () => {
+        const pool = makePool();
+        const middleware = makeMiddleware(pool);
+        const req = makeReq({ key: 'abc-12345-xyz' });
+        const res = makeRes();
+        let nextCalled = false;
+        await middleware(req, res, () => { nextCalled = true; });
+        expect(nextCalled).toBe(true);
+        res.status(201).json({ ok: true, id: 'msg-1' });
+        // Insert is fire-and-forget; await a tick.
+        await new Promise((r) => setImmediate(r));
+        expect(pool.rows()).toHaveLength(1);
+        expect(pool.rows()[0].response_blob).toEqual({ ok: true, id: 'msg-1' });
+        expect(pool.rows()[0].status_code).toBe(201);
+    });
+
+    test('second call with same (deviceId, key) returns cached blob + X-Idempotent-Hit:1', async () => {
+        const pool = makePool();
+        const middleware = makeMiddleware(pool);
+        const key = 'replay-key-001';
+
+        const req1 = makeReq({ key });
+        const res1 = makeRes();
+        await middleware(req1, res1, () => {});
+        res1.status(200).json({ ok: true, processed: 'first' });
+        await new Promise((r) => setImmediate(r));
+
+        const req2 = makeReq({ key });
+        const res2 = makeRes();
+        let nextCalled = false;
+        await middleware(req2, res2, () => { nextCalled = true; });
+
+        expect(nextCalled).toBe(false);
+        expect(res2.setHeaders['X-Idempotent-Hit']).toBe('1');
+        expect(res2.sentStatus).toBe(200);
+        expect(res2.sentBody).toEqual({ ok: true, processed: 'first' });
+    });
+
+    test('different deviceId with same key → cache miss (per-device scoping)', async () => {
+        const pool = makePool();
+        const middleware = makeMiddleware(pool);
+        const key = 'replay-key-002';
+
+        const req1 = makeReq({ key, deviceId: 'dev-A' });
+        const res1 = makeRes();
+        await middleware(req1, res1, () => {});
+        res1.status(200).json({ from: 'A' });
+        await new Promise((r) => setImmediate(r));
+
+        const req2 = makeReq({ key, deviceId: 'dev-B' });
+        const res2 = makeRes();
+        let nextCalled = false;
+        await middleware(req2, res2, () => { nextCalled = true; });
+        expect(nextCalled).toBe(true);
+        expect(res2.sentBody).toBeUndefined();
+    });
+
+    test('DB lookup failure → falls through to handler', async () => {
+        const pool = makePool();
+        pool.breakLookup();
+        const middleware = makeMiddleware(pool);
+        const req = makeReq({ key: 'any-valid-key' });
+        const res = makeRes();
+        let nextCalled = false;
+        await middleware(req, res, () => { nextCalled = true; });
+        expect(nextCalled).toBe(true);
+    });
+
+    test('DB insert failure → handler still returns correctly (logs warning)', async () => {
+        const pool = makePool();
+        pool.breakInsert();
+        const middleware = makeMiddleware(pool);
+        const req = makeReq({ key: 'insert-fail-key' });
+        const res = makeRes();
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        await middleware(req, res, () => {});
+        const ret = res.status(200).json({ ok: true });
+        expect(ret).toEqual({ ok: true });
+        await new Promise((r) => setImmediate(r));
+        warnSpy.mockRestore();
+    });
+
+    test('invalid client key (too short / wrong chars) → no-op next()', async () => {
+        const pool = makePool();
+        const middleware = makeMiddleware(pool);
+        for (const bad of ['short', 'with spaces!', 'a'.repeat(MAX_KEY_LEN + 1)]) {
+            const req = makeReq({ key: bad });
+            const res = makeRes();
+            let nextCalled = false;
+            await middleware(req, res, () => { nextCalled = true; });
+            expect(nextCalled).toBe(true);
+            expect(res.sentBody).toBeUndefined();
+        }
+    });
+
+    test('hashKey produces stable 64-char hex per (deviceId, key)', () => {
+        const h1 = hashKey('dev-X', 'key-1');
+        const h2 = hashKey('dev-X', 'key-1');
+        const h3 = hashKey('dev-X', 'key-2');
+        const h4 = hashKey('dev-Y', 'key-1');
+        expect(h1).toBe(h2);
+        expect(h1).not.toBe(h3);
+        expect(h1).not.toBe(h4);
+        expect(h1).toMatch(/^[a-f0-9]{64}$/);
+    });
+
+    test('isValidClientKey enforces length + charset', () => {
+        expect(isValidClientKey('abc12345')).toBe(true);
+        expect(isValidClientKey('a'.repeat(MIN_KEY_LEN))).toBe(true);
+        expect(isValidClientKey('a'.repeat(MAX_KEY_LEN))).toBe(true);
+        expect(isValidClientKey('a'.repeat(MIN_KEY_LEN - 1))).toBe(false);
+        expect(isValidClientKey('a'.repeat(MAX_KEY_LEN + 1))).toBe(false);
+        expect(isValidClientKey('hash key with space')).toBe(false);
+        expect(isValidClientKey('hash@invalid')).toBe(false);
+        expect(isValidClientKey('hash-valid_123.x')).toBe(true);
+        expect(isValidClientKey(null)).toBe(false);
+        expect(isValidClientKey(undefined)).toBe(false);
+        expect(isValidClientKey(42)).toBe(false);
+    });
+
+    test('constants expose TTL_HOURS = 24', () => {
+        expect(TTL_HOURS).toBe(24);
+    });
+});


### PR DESCRIPTION
## Summary
First implementation slice of Phase 2 #5 offline delivery queue (card_47ed9a0c). Spec landed in PR #3270 (`docs/offline-delivery-queue-spec.md`); this PR ships the server-side foundation.

## What ships
- `backend/migrations/20260609_idempotency_keys.up.sql` + down sibling
- `backend/idempotency-keys.js` — Express middleware factory `makeMiddleware(pool)` that caches `(status, body)` on the first call for a given `(deviceId, Idempotency-Key)` and short-circuits subsequent calls within 24h
- `backend/tests/jest/idempotency-keys.test.js` — 10 cases (10/10 pass locally)

## Design notes
- Raw client key never lands in the DB — `hash = sha256(deviceId|key)`
- Missing header → no-op (legacy clients keep working)
- DB lookup error → fall through to handler (availability > perfect dedupe)
- First-write insert is async + `ON CONFLICT DO NOTHING` (race-safe)
- Not yet wired into `/api/transform` — that's a separate follow-up PR so this stays small and reversible

## Test plan
- [x] Local: `npx jest backend/tests/jest/idempotency-keys.test.js` → 10/10 pass
- [ ] CI Backend Jest + Critical Portal Pages + i18n syntax all SUCCESS
- [ ] Post-merge: run migration on Railway before the wire-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)