### PR TITLE
feat(offline-queue): wire idempotency-keys middleware into /api/transform (Phase 2 #5 B)

### DIFF
--- a/backend/idempotency-keys.js
+++ b/backend/idempotency-keys.js
@@ -20,6 +20,25 @@ const TTL_HOURS = 24;
 const MIN_KEY_LEN = 8;
 const MAX_KEY_LEN = 128;
 
+// Inline DDL matches the outbound_msg_pending pattern in entity-status.js.
+// The migrations/20260609_idempotency_keys.up.sql file mirrors this shape
+// for the historical record + the explicit down sibling.
+async function ensureTable(pool) {
+    if (!pool || typeof pool.query !== 'function') return;
+    await pool.query(`
+        CREATE TABLE IF NOT EXISTS idempotency_keys (
+            id BIGSERIAL PRIMARY KEY,
+            hash CHAR(64) NOT NULL UNIQUE,
+            response_blob JSONB NOT NULL,
+            status_code SMALLINT NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            expires_at TIMESTAMPTZ NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_idem_expires_at
+            ON idempotency_keys(expires_at);
+    `);
+}
+
 function hashKey(deviceId, key) {
     return crypto.createHash('sha256').update(`${deviceId}|${key}`).digest('hex');
 }
@@ -73,6 +92,7 @@ function makeMiddleware(pool, { ttlHours = TTL_HOURS } = {}) {
 
 module.exports = {
     makeMiddleware,
+    ensureTable,
     hashKey,
     isValidClientKey,
     TTL_HOURS,

--- a/backend/index.js
+++ b/backend/index.js
@@ -2283,6 +2283,15 @@ const agentImprovement = require('./agent-improvement');
 agentImprovement.bindDevicesRef(devices);
 app.use('/api/agent-improvement', agentImprovement.router);
 
+// IDEMPOTENCY KEYS — required up here so /api/transform can reference the
+// middleware reference; the actual implementation + pool wire-up + ensureTable
+// run once chatPool is initialized further down (see chatPool block). The
+// wrapper holds a mutable inner; Express captures the wrapper at registration
+// time and dispatches through it.
+const idempotencyKeys = require('./idempotency-keys');
+let _idempotencyInner = (req, res, next) => next();
+const idempotencyMiddleware = (req, res, next) => _idempotencyInner(req, res, next);
+
 // ============================================
 // API DOCS — OpenAPI / Swagger UI
 // ============================================
@@ -8678,7 +8687,7 @@ function transformMaybeMultipart(req, res, next) {
     }
     return next();
 }
-app.post('/api/transform', transformMaybeMultipart, async (req, res) => {
+app.post('/api/transform', transformMaybeMultipart, idempotencyMiddleware, async (req, res) => {
     // Multipart sends text fields as strings; re-parse the JSON-shaped ones
     // and coerce scalar types so downstream logic stays uniform with JSON mode.
     if (req.file || String(req.headers['content-type'] || '').toLowerCase().startsWith('multipart/form-data')) {
@@ -18864,6 +18873,13 @@ sitePageviews.initPageviewsTable(chatPool);
 if (mindmapModule && typeof mindmapModule.initMindmapTables === 'function') {
     mindmapModule.initMindmapTables(chatPool);
 }
+
+// Wire idempotency-keys middleware to the real pool now that chatPool exists.
+// Spec: docs/offline-delivery-queue-spec.md, card: card_47ed9a0c.
+_idempotencyInner = idempotencyKeys.makeMiddleware(chatPool);
+idempotencyKeys.ensureTable(chatPool).catch((err) => {
+    console.warn('[idem] ensureTable failed (retries on first request):', err && err.message);
+});
 
 // Anonymous portal beacons table (for growth funnel tracking)
 (async () => {


### PR DESCRIPTION
## Summary
Follow-up to PR #3271 — the middleware now ACTUALLY runs on `/api/transform` so retries are deduplicated. Card: card_47ed9a0c.

## Changes
- `backend/idempotency-keys.js`: added `ensureTable(pool)` with inline `CREATE IF NOT EXISTS` DDL, mirroring the outbound_msg_pending pattern in entity-status.js. The .sql migration files in PR #3271 remain as the historical record + down sibling.
- `backend/index.js`:
  - require idempotency-keys early so the /api/transform handler can reference the middleware
  - wrapper pattern: Express captures `idempotencyMiddleware` at registration; the inner implementation swaps in lazily after `chatPool` is initialized
  - mount on `POST /api/transform` after the multipart parser so `req.body.deviceId` is populated

## Behavior
- Legacy clients (no `Idempotency-Key` header) pass through with only a constant-time header check
- Clients that send `Idempotency-Key` get cached responses on retry within 24h
- DB lookup failure → falls through to handler (availability > perfect dedupe)

## Test plan
- [x] Local syntax check: `node -c backend/index.js`
- [x] Jest: `npx jest backend/tests/jest/idempotency-keys.test.js` → 10/10 pass
- [ ] CI Backend Jest + ESLint + Critical Portal Pages all SUCCESS
- [ ] Post-deploy: probe POST /api/transform with same Idempotency-Key twice → second returns `X-Idempotent-Hit: 1` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)