### PR TITLE
feat(offline-queue): mount idempotency middleware on /api/client/speak (Q3 default)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -11204,7 +11204,7 @@ app.post('/api/device/entity/avatar/upload', avatarUpload.single('file'), async 
  *
  * If bot has registered webhook, push notification is sent.
  */
-app.post('/api/client/speak', async (req, res) => {
+app.post('/api/client/speak', idempotencyMiddleware, async (req, res) => {
     const { deviceId, deviceSecret, entityId, text, source = "client", mediaType, mediaUrl, attachments } = req.body;
 
     if (!deviceId) {


### PR DESCRIPTION
## Summary
Phase 2 #5 Q3 default. Card: card_47ed9a0c.

Spec `docs/offline-delivery-queue-spec.md` open Q3 asked "idempotency on `/api/client/speak` too?" with default proposal "yes, both". Mounting the existing middleware (PR #3271) on the user-side route too, so a queued retry from a spotty mobile connection deduplicates the same way as `/api/transform`.

## Why now
Q3 is the lowest-risk of the 3 open questions:
- symmetric with the existing `/api/transform` mount
- reversible by removing one middleware arg
- doesn't change client behavior unless caller sends `Idempotency-Key`

Q1 (outbox-full policy) + Q2 (failed-state lifetime) have rewrite cost if guessed wrong — still pending Hank's explicit answer before client outbox work proceeds.

## Test plan
- [x] Local syntax check: `node -c backend/index.js`
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)