### PR TITLE
feat(offline-queue): idempotency_keys expired-row sweeper (Run 1 gap A4)

### DIFF
--- a/backend/idempotency-keys.js
+++ b/backend/idempotency-keys.js
@@ -39,6 +39,32 @@ async function ensureTable(pool) {
     `);
 }
 
+async function sweepExpired(pool) {
+    if (!pool || typeof pool.query !== 'function') return { deleted: 0 };
+    try {
+        const result = await pool.query(
+            'DELETE FROM idempotency_keys WHERE expires_at < NOW() RETURNING id'
+        );
+        return { deleted: result.rowCount || result.rows.length || 0 };
+    } catch (err) {
+        console.error('[idem] sweepExpired error:', err && err.message);
+        return { deleted: 0, error: err && err.message };
+    }
+}
+
+function startSweeper(pool, intervalMs) {
+    const ms = Math.max(60_000, parseInt(intervalMs) || 5 * 60_000);
+    return setInterval(() => {
+        sweepExpired(pool).then((res) => {
+            if (res.deleted > 0) {
+                console.log(`[idem] swept ${res.deleted} expired rows`);
+            }
+        }).catch((err) => {
+            console.error('[idem] sweep tick error:', err && err.message);
+        });
+    }, ms);
+}
+
 function hashKey(deviceId, key) {
     return crypto.createHash('sha256').update(`${deviceId}|${key}`).digest('hex');
 }
@@ -93,6 +119,8 @@ function makeMiddleware(pool, { ttlHours = TTL_HOURS } = {}) {
 module.exports = {
     makeMiddleware,
     ensureTable,
+    sweepExpired,
+    startSweeper,
     hashKey,
     isValidClientKey,
     TTL_HOURS,

--- a/backend/index.js
+++ b/backend/index.js
@@ -18877,7 +18877,12 @@ if (mindmapModule && typeof mindmapModule.initMindmapTables === 'function') {
 // Wire idempotency-keys middleware to the real pool now that chatPool exists.
 // Spec: docs/offline-delivery-queue-spec.md, card: card_47ed9a0c.
 _idempotencyInner = idempotencyKeys.makeMiddleware(chatPool);
-idempotencyKeys.ensureTable(chatPool).catch((err) => {
+idempotencyKeys.ensureTable(chatPool).then(() => {
+    // Run sweeper every 5 minutes so expired (>24h) rows are deleted instead of
+    // growing the table unbounded. Found 02:36 TW 2026-06-10 via Run 1 of the
+    // perpetual E2E card (gap A4).
+    idempotencyKeys.startSweeper(chatPool, 5 * 60_000);
+}).catch((err) => {
     console.warn('[idem] ensureTable failed (retries on first request):', err && err.message);
 });
 

--- a/backend/tests/jest/idempotency-keys.test.js
+++ b/backend/tests/jest/idempotency-keys.test.js
@@ -2,6 +2,7 @@
 
 const {
     makeMiddleware,
+    sweepExpired,
     hashKey,
     isValidClientKey,
     TTL_HOURS,
@@ -200,5 +201,37 @@ describe('idempotency-keys middleware', () => {
 
     test('constants expose TTL_HOURS = 24', () => {
         expect(TTL_HOURS).toBe(24);
+    });
+
+    test('sweepExpired deletes rows with expires_at < NOW() and returns count', async () => {
+        const deleted = [];
+        const fakePool = {
+            async query(sql) {
+                if (sql.startsWith('DELETE FROM idempotency_keys')) {
+                    deleted.push(sql);
+                    return { rowCount: 3, rows: [{ id: 1 }, { id: 2 }, { id: 3 }] };
+                }
+                return { rows: [] };
+            },
+        };
+        const res = await sweepExpired(fakePool);
+        expect(res.deleted).toBe(3);
+        expect(deleted[0]).toContain('expires_at < NOW()');
+    });
+
+    test('sweepExpired swallows DB errors and returns deleted=0', async () => {
+        const fakePool = {
+            async query() { throw new Error('boom-sweep'); },
+        };
+        const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const res = await sweepExpired(fakePool);
+        expect(res.deleted).toBe(0);
+        expect(res.error).toBe('boom-sweep');
+        errSpy.mockRestore();
+    });
+
+    test('sweepExpired no-ops when pool is null/missing', async () => {
+        await expect(sweepExpired(null)).resolves.toEqual({ deleted: 0 });
+        await expect(sweepExpired({})).resolves.toEqual({ deleted: 0 });
     });
 });


### PR DESCRIPTION
## Summary
First fix from the perpetual E2E card (card_509e45f9) Run 1. Idempotency middleware ships on prod (PR #3271+#3272+#3274) but Run 1's grep-the-source audit found gap A4: no sweeper for expired (>24h) rows → table grows unbounded.

## Changes
- `backend/idempotency-keys.js`: new `sweepExpired(pool)` + `startSweeper(pool, intervalMs)`. Same shape as the `outbound_msg_pending` sweeper in entity-status.js.
- `backend/index.js`: `startSweeper(chatPool, 5*60_000)` fires after `ensureTable()` resolves.
- `backend/tests/jest/idempotency-keys.test.js`: +3 cases (delete count, DB error swallowed, null-pool no-op). 13/13 pass locally.

## Test plan
- [x] Local jest 13/13 pass
- [ ] CI green
- [ ] Post-deploy: observe `[idem] swept N expired rows` log line after the 5-min interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)