### PR TITLE
feat(offline-queue): client-side outbox module (Phase 2 #5 — Q1+Q2 defaults baked in)

### DIFF
--- a/backend/public/portal/shared/outbox.js
+++ b/backend/public/portal/shared/outbox.js
@@ -1,0 +1,237 @@
+/**
+ * Offline delivery outbox — Phase 2 #5 client side.
+ * Spec: docs/offline-delivery-queue-spec.md. Card: card_47ed9a0c.
+ *
+ * Pure-function queue layer that chat.html (and any other send surface) wraps
+ * around its POST /api/transform or /api/client/speak call. Persists pending
+ * sends to localStorage, retries with exponential backoff on reconnect, and
+ * deduplicates server-side via the Idempotency-Key header that the matching
+ * middleware (backend/idempotency-keys.js, PRs #3271/#3272/#3274) consumes.
+ *
+ * Q1+Q2 defaults baked in per Hank autonomy directive 2026-06-10 02:31 TW
+ * (he said "don't wait, find a way", so the spec's proposed defaults apply):
+ *   - Q1 outbox-full policy: drop OLDEST queued entry, banner the user
+ *   - Q2 failed-state lifetime: 7d auto-expire
+ *   - Q3 idempotency on /api/client/speak: yes (already mounted in PR #3274)
+ */
+(function (global) {
+    'use strict';
+
+    var STORAGE_KEY = 'eclaw_outbox';
+    var MAX_ENTRIES = 100;
+    var FAILED_TTL_MS = 7 * 24 * 60 * 60 * 1000;     // 7 days
+    var MAX_ATTEMPTS = 12;
+
+    // Exponential backoff schedule per spec: 0/5s/15s/45s/2m/5m cap.
+    var BACKOFF_MS = [0, 5_000, 15_000, 45_000, 120_000];
+    var BACKOFF_CAP_MS = 300_000;
+
+    function now() {
+        return (global.Date && global.Date.now) ? Date.now() : 0;
+    }
+
+    function uuid() {
+        if (global.crypto && global.crypto.randomUUID) {
+            return global.crypto.randomUUID();
+        }
+        // RFC4122 v4-ish fallback
+        return 'o-' + Math.random().toString(36).slice(2) + '-' + Math.random().toString(36).slice(2);
+    }
+
+    function loadRaw() {
+        try {
+            var raw = global.localStorage && global.localStorage.getItem(STORAGE_KEY);
+            if (!raw) return [];
+            var parsed = JSON.parse(raw);
+            return Array.isArray(parsed) ? parsed : [];
+        } catch (e) {
+            return [];
+        }
+    }
+
+    function saveRaw(entries) {
+        try {
+            if (!global.localStorage) return;
+            global.localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+        } catch (e) {
+            // QuotaExceededError, etc. — caller's banner is best-effort, swallow here.
+        }
+    }
+
+    function backoffFor(attempt) {
+        if (attempt < 0) return 0;
+        if (attempt < BACKOFF_MS.length) return BACKOFF_MS[attempt];
+        return BACKOFF_CAP_MS;
+    }
+
+    function pruneExpired(entries, nowMs) {
+        return entries.filter(function (e) {
+            if (e.state !== 'failed') return true;
+            return (nowMs - (e.createdAt || 0)) <= FAILED_TTL_MS;
+        });
+    }
+
+    function enforceCap(entries) {
+        if (entries.length <= MAX_ENTRIES) return { kept: entries, dropped: [] };
+        // Q1 policy: drop oldest queued first, then oldest retrying, then oldest
+        // failed. Keep failures user-actionable longer than queued churn.
+        var queued = entries.filter(function (e) { return e.state === 'queued'; })
+            .sort(function (a, b) { return (a.createdAt || 0) - (b.createdAt || 0); });
+        var retrying = entries.filter(function (e) { return e.state === 'retrying'; })
+            .sort(function (a, b) { return (a.createdAt || 0) - (b.createdAt || 0); });
+        var failed = entries.filter(function (e) { return e.state === 'failed'; })
+            .sort(function (a, b) { return (a.createdAt || 0) - (b.createdAt || 0); });
+        var sent = entries.filter(function (e) { return e.state === 'sent'; });
+
+        var dropped = [];
+        var totalKept = entries.length;
+        var dropFromList = function (list) {
+            while (totalKept > MAX_ENTRIES && list.length > 0) {
+                dropped.push(list.shift());
+                totalKept--;
+            }
+        };
+        dropFromList(queued);
+        if (totalKept > MAX_ENTRIES) dropFromList(retrying);
+        if (totalKept > MAX_ENTRIES) dropFromList(failed);
+        var kept = sent.concat(queued).concat(retrying).concat(failed);
+        return { kept: kept, dropped: dropped };
+    }
+
+    function load() {
+        var nowMs = now();
+        var pruned = pruneExpired(loadRaw(), nowMs);
+        return pruned;
+    }
+
+    function persist(entries) {
+        var capped = enforceCap(entries);
+        saveRaw(capped.kept);
+        return capped;
+    }
+
+    function enqueue(payload, opts) {
+        opts = opts || {};
+        var entries = load();
+        var entry = {
+            idempotencyKey: opts.idempotencyKey || uuid(),
+            payload: payload || {},
+            state: 'queued',
+            attempts: 0,
+            nextRetryAt: now(),
+            createdAt: now(),
+        };
+        entries.push(entry);
+        var result = persist(entries);
+        return { entry: entry, droppedForCap: result.dropped };
+    }
+
+    function update(idempotencyKey, mutator) {
+        var entries = load();
+        var updatedEntry = null;
+        var nextEntries = entries.map(function (e) {
+            if (e.idempotencyKey !== idempotencyKey) return e;
+            var next = mutator(Object.assign({}, e));
+            updatedEntry = next;
+            return next;
+        });
+        persist(nextEntries);
+        return updatedEntry;
+    }
+
+    function remove(idempotencyKey) {
+        var entries = load();
+        var next = entries.filter(function (e) { return e.idempotencyKey !== idempotencyKey; });
+        persist(next);
+        return next;
+    }
+
+    function clear() {
+        saveRaw([]);
+    }
+
+    function snapshot() {
+        return load();
+    }
+
+    function summary() {
+        var entries = load();
+        var by = { queued: 0, retrying: 0, sent: 0, failed: 0 };
+        entries.forEach(function (e) { if (by[e.state] !== undefined) by[e.state]++; });
+        return { total: entries.length, by: by };
+    }
+
+    function markRetrying(idempotencyKey) {
+        return update(idempotencyKey, function (e) {
+            e.state = 'retrying';
+            return e;
+        });
+    }
+
+    function markSent(idempotencyKey) {
+        return update(idempotencyKey, function (e) {
+            e.state = 'sent';
+            return e;
+        });
+    }
+
+    function markFailed(idempotencyKey, errorMessage) {
+        return update(idempotencyKey, function (e) {
+            e.state = 'failed';
+            if (errorMessage) e.errorMessage = String(errorMessage).slice(0, 500);
+            return e;
+        });
+    }
+
+    function bumpAttempt(idempotencyKey) {
+        return update(idempotencyKey, function (e) {
+            e.attempts = (e.attempts || 0) + 1;
+            e.nextRetryAt = now() + backoffFor(e.attempts);
+            // If we've burned all attempts, terminal-fail the entry.
+            if (e.attempts >= MAX_ATTEMPTS) {
+                e.state = 'failed';
+                e.errorMessage = e.errorMessage || 'max attempts exceeded';
+            } else {
+                e.state = 'queued';
+            }
+            return e;
+        });
+    }
+
+    function nextDueAt() {
+        var entries = load();
+        var due = entries
+            .filter(function (e) { return e.state === 'queued' || e.state === 'retrying'; })
+            .map(function (e) { return e.nextRetryAt || 0; })
+            .sort(function (a, b) { return a - b; });
+        return due.length === 0 ? null : due[0];
+    }
+
+    var api = {
+        STORAGE_KEY: STORAGE_KEY,
+        MAX_ENTRIES: MAX_ENTRIES,
+        FAILED_TTL_MS: FAILED_TTL_MS,
+        MAX_ATTEMPTS: MAX_ATTEMPTS,
+        BACKOFF_MS: BACKOFF_MS,
+        BACKOFF_CAP_MS: BACKOFF_CAP_MS,
+        backoffFor: backoffFor,
+        load: load,
+        snapshot: snapshot,
+        summary: summary,
+        enqueue: enqueue,
+        update: update,
+        remove: remove,
+        clear: clear,
+        markRetrying: markRetrying,
+        markSent: markSent,
+        markFailed: markFailed,
+        bumpAttempt: bumpAttempt,
+        nextDueAt: nextDueAt,
+    };
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    } else if (global) {
+        global.EclawOutbox = api;
+    }
+})(typeof window !== 'undefined' ? window : (typeof global !== 'undefined' ? global : this));

--- a/backend/tests/jest/outbox.test.js
+++ b/backend/tests/jest/outbox.test.js
@@ -1,0 +1,191 @@
+'use strict';
+
+/**
+ * Tests for the offline outbox module (Phase 2 #5 client).
+ * Card: card_47ed9a0c. Spec: docs/offline-delivery-queue-spec.md.
+ *
+ * Module is browser-side but exports a CommonJS shape so jest can require it.
+ * localStorage is faked per-test via a small in-memory store assigned to
+ * global.localStorage before each suite.
+ */
+
+function makeFakeStorage() {
+    var store = {};
+    return {
+        getItem: function (k) { return Object.prototype.hasOwnProperty.call(store, k) ? store[k] : null; },
+        setItem: function (k, v) { store[k] = String(v); },
+        removeItem: function (k) { delete store[k]; },
+        clear: function () { store = {}; },
+        _store: function () { return store; },
+    };
+}
+
+describe('outbox.js — Phase 2 #5 client queue', () => {
+    let outbox;
+
+    beforeEach(() => {
+        global.localStorage = makeFakeStorage();
+        // Re-require to get a fresh module-level state each test
+        jest.resetModules();
+        outbox = require('../../public/portal/shared/outbox.js');
+    });
+
+    afterEach(() => {
+        delete global.localStorage;
+    });
+
+    test('starts empty', () => {
+        expect(outbox.snapshot()).toEqual([]);
+        expect(outbox.summary()).toEqual({ total: 0, by: { queued: 0, retrying: 0, sent: 0, failed: 0 } });
+    });
+
+    test('enqueue persists entries with required shape', () => {
+        const result = outbox.enqueue({ deviceId: 'd', message: 'hi' });
+        expect(result.entry.state).toBe('queued');
+        expect(result.entry.attempts).toBe(0);
+        expect(result.entry.idempotencyKey).toMatch(/.+/);
+        expect(outbox.snapshot()).toHaveLength(1);
+    });
+
+    test('caller can supply idempotencyKey for replay-stable retries', () => {
+        outbox.enqueue({ message: 'a' }, { idempotencyKey: 'fixed-key-1234' });
+        expect(outbox.snapshot()[0].idempotencyKey).toBe('fixed-key-1234');
+    });
+
+    test('markRetrying / markSent / markFailed transition state', () => {
+        const r = outbox.enqueue({ message: 'a' });
+        const k = r.entry.idempotencyKey;
+        outbox.markRetrying(k);
+        expect(outbox.snapshot()[0].state).toBe('retrying');
+        outbox.markSent(k);
+        expect(outbox.snapshot()[0].state).toBe('sent');
+        outbox.markFailed(k, 'boom');
+        expect(outbox.snapshot()[0].state).toBe('failed');
+        expect(outbox.snapshot()[0].errorMessage).toBe('boom');
+    });
+
+    test('bumpAttempt schedules next retry per backoff schedule', () => {
+        const r = outbox.enqueue({ message: 'a' });
+        const k = r.entry.idempotencyKey;
+        for (let i = 0; i < 5; i++) outbox.bumpAttempt(k);
+        const entry = outbox.snapshot()[0];
+        expect(entry.attempts).toBe(5);
+        // After 5 bumps the entry is back in queued state with nextRetryAt set
+        expect(entry.state).toBe('queued');
+    });
+
+    test('bumpAttempt over MAX_ATTEMPTS terminal-fails the entry', () => {
+        const r = outbox.enqueue({ message: 'a' });
+        const k = r.entry.idempotencyKey;
+        for (let i = 0; i < outbox.MAX_ATTEMPTS; i++) outbox.bumpAttempt(k);
+        const entry = outbox.snapshot()[0];
+        expect(entry.state).toBe('failed');
+        expect(entry.attempts).toBe(outbox.MAX_ATTEMPTS);
+    });
+
+    test('backoffFor returns spec schedule', () => {
+        expect(outbox.backoffFor(0)).toBe(0);
+        expect(outbox.backoffFor(1)).toBe(5_000);
+        expect(outbox.backoffFor(2)).toBe(15_000);
+        expect(outbox.backoffFor(3)).toBe(45_000);
+        expect(outbox.backoffFor(4)).toBe(120_000);
+        // Beyond schedule, cap kicks in
+        expect(outbox.backoffFor(5)).toBe(outbox.BACKOFF_CAP_MS);
+        expect(outbox.backoffFor(99)).toBe(outbox.BACKOFF_CAP_MS);
+    });
+
+    test('summary buckets entries by state', () => {
+        outbox.enqueue({ m: 1 });
+        const r2 = outbox.enqueue({ m: 2 });
+        outbox.markRetrying(r2.entry.idempotencyKey);
+        const r3 = outbox.enqueue({ m: 3 });
+        outbox.markSent(r3.entry.idempotencyKey);
+        const r4 = outbox.enqueue({ m: 4 });
+        outbox.markFailed(r4.entry.idempotencyKey, 'x');
+        expect(outbox.summary()).toEqual({ total: 4, by: { queued: 1, retrying: 1, sent: 1, failed: 1 } });
+    });
+
+    test('clear() empties the store', () => {
+        outbox.enqueue({ m: 1 });
+        outbox.enqueue({ m: 2 });
+        outbox.clear();
+        expect(outbox.snapshot()).toEqual([]);
+    });
+
+    test('remove(key) drops a single entry', () => {
+        const a = outbox.enqueue({ m: 'a' });
+        outbox.enqueue({ m: 'b' });
+        outbox.remove(a.entry.idempotencyKey);
+        const left = outbox.snapshot();
+        expect(left).toHaveLength(1);
+        expect(left[0].payload.m).toBe('b');
+    });
+
+    test('Q1 cap policy: drops OLDEST queued first when at MAX_ENTRIES', () => {
+        // Seed the storage directly so we don't blow up with 100 enqueue() calls
+        const seeds = [];
+        for (let i = 0; i < outbox.MAX_ENTRIES; i++) {
+            seeds.push({
+                idempotencyKey: 'seed-' + i,
+                payload: { i },
+                state: 'queued',
+                attempts: 0,
+                nextRetryAt: 0,
+                createdAt: i,                              // 0..99 monotonic
+            });
+        }
+        global.localStorage.setItem(outbox.STORAGE_KEY, JSON.stringify(seeds));
+        const r = outbox.enqueue({ m: 'fresh' }, { idempotencyKey: 'fresh-key' });
+        expect(r.droppedForCap.length).toBeGreaterThan(0);
+        // Oldest seed (createdAt=0) should be dropped
+        const droppedKeys = r.droppedForCap.map(function (e) { return e.idempotencyKey; });
+        expect(droppedKeys).toContain('seed-0');
+        // Fresh entry kept
+        const finalKeys = outbox.snapshot().map(function (e) { return e.idempotencyKey; });
+        expect(finalKeys).toContain('fresh-key');
+    });
+
+    test('Q2 GC: failed entries older than FAILED_TTL_MS are pruned on next load', () => {
+        const ancient = {
+            idempotencyKey: 'old-fail',
+            payload: {},
+            state: 'failed',
+            attempts: 12,
+            nextRetryAt: 0,
+            createdAt: Date.now() - (outbox.FAILED_TTL_MS + 60_000),
+            errorMessage: 'long-gone',
+        };
+        const fresh = {
+            idempotencyKey: 'fresh-fail',
+            payload: {},
+            state: 'failed',
+            attempts: 12,
+            nextRetryAt: 0,
+            createdAt: Date.now(),
+            errorMessage: 'still-relevant',
+        };
+        global.localStorage.setItem(outbox.STORAGE_KEY, JSON.stringify([ancient, fresh]));
+        const snap = outbox.snapshot();
+        expect(snap.map(e => e.idempotencyKey)).toEqual(['fresh-fail']);
+    });
+
+    test('nextDueAt returns the soonest queued/retrying retry time', () => {
+        const a = outbox.enqueue({ m: 'a' });
+        const b = outbox.enqueue({ m: 'b' });
+        // Manually move b's nextRetryAt earlier
+        outbox.update(b.entry.idempotencyKey, function (e) {
+            e.nextRetryAt = 100;
+            return e;
+        });
+        outbox.update(a.entry.idempotencyKey, function (e) {
+            e.nextRetryAt = 500;
+            return e;
+        });
+        expect(outbox.nextDueAt()).toBe(100);
+    });
+
+    test('corrupted localStorage falls back to empty', () => {
+        global.localStorage.setItem(outbox.STORAGE_KEY, '<<<not json>>>');
+        expect(outbox.snapshot()).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Summary
Phase 2 #5 next slice (card_47ed9a0c). Hank autonomy directive 2026-06-10 02:31 TW (`不要等了 自己想辦法全部解決了吧`) so the spec's proposed defaults for Q1 and Q2 are baked in:

| Open question | Default shipped |
|---|---|
| Q1 outbox-full | drop OLDEST queued first, then retrying, then failed |
| Q2 failed-state lifetime | 7d auto-expire on next load() |
| Q3 idempotency on /api/client/speak | already mounted (PR #3274) |

## What ships
- `backend/public/portal/shared/outbox.js` — pure-function localStorage queue. Browser-side + CommonJS shim so jest can require it. API: `enqueue`, `markRetrying|Sent|Failed`, `bumpAttempt`, `nextDueAt`, `snapshot`, `summary`, `clear`, `remove`, `backoffFor`.
- `backend/tests/jest/outbox.test.js` — 14/14 pass locally:
  - state transitions (queued/retrying/sent/failed)
  - exp-backoff schedule (0/5s/15s/45s/2m/5m cap)
  - MAX_ATTEMPTS=12 terminal-fails
  - Q1 cap policy drops oldest queued
  - Q2 GC prunes failed entries older than 7d
  - corrupted localStorage falls back to empty
  - nextDueAt scheduler

## Out of scope (next PR)
- chat.html send-path wire-up
- Inline bubble rendering (queued/retrying/sent/failed states)
- Top-of-scroll banner with live queue count
- E2E: Playwright network-off → 5 messages → reconnect → 5 delivered

## Test plan
- [x] Local jest 14/14 pass
- [ ] CI green
- [ ] Post-merge: chat.html wire-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)