### PR TITLE
test(jest): ignore .claude/worktrees + .git from scan (Run 9 gap J1)

### DIFF
--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -4,6 +4,10 @@ module.exports = {
     // Set required env vars before any test module loads
     setupFiles: ['./tests/jest/helpers/env-setup.js'],
     testMatch: ['**/tests/jest/**/*.test.js'],
+    // Worktrees from concurrent claude sessions pollute the test scan and
+    // crash on missing 'pg' from their stale node_modules; skip them.
+    // Found 2026-06-10 02:57 TW via Run 9 of the perpetual E2E card (gap J1).
+    testPathIgnorePatterns: ['/node_modules/', '/.claude/', '/.git/'],
     testTimeout: 15000,
     // Prevent open handles from keeping Jest alive
     forceExit: true,


### PR DESCRIPTION
## Summary
Run 9 gap J1 fix. Perpetual E2E card_509e45f9.

When multiple concurrent claude-code sessions create git worktrees in `.claude/worktrees/`, jest scans them by default and crashes on `Cannot find module 'pg'` from their stale node_modules. Local dev gets ~310 failing suites; CI was green because Railway runners don't have the worktrees.

Add `testPathIgnorePatterns: ['/node_modules/', '/.claude/', '/.git/']` to `backend/jest.config.js`.

## Test plan
- [x] `cd backend && npx jest` before: 310 failed / 740 passed
- [x] `cd backend && npx jest` after: 265 passed / 3665 tests / 0 fail
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)