### PR TITLE
feat(offline-queue): flushOutbox + window.online listener (Run 16 gap J4)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3600,11 +3600,28 @@
         });
 
         // ── Init ──
+        // Phase 2 #5 offline queue: on reconnect, replay any queued/retrying
+        // outbox entries. Heartbeat every 30s also catches the case where
+        // navigator.onLine never fired (mobile WebView quirks). Per Run 16
+        // of perpetual E2E card_509e45f9 (gap J4).
+        function _flushOutboxWithSender() {
+            if (!window.EclawOutbox || !window.currentUser) return;
+            return window.EclawOutbox.flushOutbox(async (payload, idempotencyKey) => {
+                return apiCall('POST', '/api/client/speak', payload, { headers: { 'Idempotency-Key': idempotencyKey } });
+            }).catch((err) => { console.warn('[outbox] flush error:', err && err.message); });
+        }
+        window.addEventListener('online', _flushOutboxWithSender);
+        setInterval(() => { if (navigator.onLine) _flushOutboxWithSender(); }, 30_000);
+
         window.addEventListener('DOMContentLoaded', async () => {
             // Detect embed mode (workspace split view)
             if (new URLSearchParams(window.location.search).get('embed') === '1') {
                 document.body.classList.add('embed-mode');
             }
+            // Initial flush on load — catches the case where the user closed
+            // the tab during an in-flight send (state=retrying) and the queue
+            // is sitting in localStorage waiting to be replayed.
+            setTimeout(_flushOutboxWithSender, 2000);
             // Avatar click → entity status drawer (per card_dbe18b333ac98076cc213055 P0.5).
             if (typeof attachAvatarClickHandler === 'function' && window.EntityStatusPanel) {
                 attachAvatarClickHandler(document.body, (eid) => window.EntityStatusPanel.open(eid));

--- a/backend/public/portal/shared/outbox.js
+++ b/backend/public/portal/shared/outbox.js
@@ -207,6 +207,49 @@
         return due.length === 0 ? null : due[0];
     }
 
+    /**
+     * Walk every queued/retrying entry whose nextRetryAt is due and call the
+     * caller-supplied sender. Per-entry state transitions are handled here so
+     * callers stay thin.
+     *
+     * @param {(payload: Object, idempotencyKey: string) => Promise<unknown>} sender
+     *        async function that performs the POST and resolves on 2xx.
+     *        Must throw on network error / non-2xx.
+     * @returns {Promise<{sent:number, failed:number, requeued:number, skipped:number}>}
+     */
+    async function flushOutbox(sender) {
+        var entries = load();
+        var nowMs = now();
+        var sent = 0, failed = 0, requeued = 0, skipped = 0;
+        var due = entries.filter(function (e) {
+            return (e.state === 'queued' || e.state === 'retrying') &&
+                (e.nextRetryAt || 0) <= nowMs;
+        });
+        for (var i = 0; i < due.length; i++) {
+            var e = due[i];
+            markRetrying(e.idempotencyKey);
+            try {
+                await sender(e.payload, e.idempotencyKey);
+                markSent(e.idempotencyKey);
+                sent++;
+            } catch (err) {
+                var msg = err && err.message ? err.message : String(err);
+                // Reschedule via backoff up to MAX_ATTEMPTS; bumpAttempt does the
+                // terminal-fail logic for us.
+                bumpAttempt(e.idempotencyKey);
+                var after = load().find(function (x) { return x.idempotencyKey === e.idempotencyKey; });
+                if (after && after.state === 'failed') {
+                    markFailed(e.idempotencyKey, msg);
+                    failed++;
+                } else {
+                    requeued++;
+                }
+            }
+        }
+        skipped = entries.length - due.length;
+        return { sent: sent, failed: failed, requeued: requeued, skipped: skipped };
+    }
+
     var api = {
         STORAGE_KEY: STORAGE_KEY,
         MAX_ENTRIES: MAX_ENTRIES,
@@ -227,6 +270,7 @@
         markFailed: markFailed,
         bumpAttempt: bumpAttempt,
         nextDueAt: nextDueAt,
+        flushOutbox: flushOutbox,
     };
 
     if (typeof module !== 'undefined' && module.exports) {

--- a/backend/tests/jest/outbox.test.js
+++ b/backend/tests/jest/outbox.test.js
@@ -188,4 +188,58 @@ describe('outbox.js — Phase 2 #5 client queue', () => {
         global.localStorage.setItem(outbox.STORAGE_KEY, '<<<not json>>>');
         expect(outbox.snapshot()).toEqual([]);
     });
+
+    test('flushOutbox sends every queued entry whose nextRetryAt is due', async () => {
+        outbox.enqueue({ m: 'a' }, { idempotencyKey: 'k-a' });
+        outbox.enqueue({ m: 'b' }, { idempotencyKey: 'k-b' });
+        const sender = jest.fn().mockResolvedValue(undefined);
+        const result = await outbox.flushOutbox(sender);
+        expect(result.sent).toBe(2);
+        expect(result.failed).toBe(0);
+        expect(sender).toHaveBeenCalledTimes(2);
+        // All entries now sent
+        const final = outbox.snapshot();
+        expect(final.every(e => e.state === 'sent')).toBe(true);
+    });
+
+    test('flushOutbox marks failed entries when sender throws + bumps attempts', async () => {
+        outbox.enqueue({ m: 'a' }, { idempotencyKey: 'k-a' });
+        const sender = jest.fn().mockRejectedValue(new Error('network'));
+        const result = await outbox.flushOutbox(sender);
+        expect(result.sent).toBe(0);
+        // First throw → not terminal, entry is requeued via bumpAttempt
+        expect(result.requeued + result.failed).toBe(1);
+        const entry = outbox.snapshot()[0];
+        expect(entry.attempts).toBe(1);
+    });
+
+    test('flushOutbox terminal-fails an entry after MAX_ATTEMPTS', async () => {
+        outbox.enqueue({ m: 'a' }, { idempotencyKey: 'k-a' });
+        // Pre-bump to one before max so the next throw terminal-fails
+        for (let i = 0; i < outbox.MAX_ATTEMPTS - 1; i++) outbox.bumpAttempt('k-a');
+        // Reset nextRetryAt to now so flushOutbox picks the entry up
+        outbox.update('k-a', (e) => { e.nextRetryAt = Date.now(); return e; });
+        const sender = jest.fn().mockRejectedValue(new Error('network'));
+        const result = await outbox.flushOutbox(sender);
+        expect(result.failed).toBe(1);
+        expect(outbox.snapshot()[0].state).toBe('failed');
+    });
+
+    test('flushOutbox skips entries whose nextRetryAt is in the future', async () => {
+        outbox.enqueue({ m: 'a' }, { idempotencyKey: 'k-a' });
+        outbox.update('k-a', (e) => { e.nextRetryAt = Date.now() + 60_000; return e; });
+        const sender = jest.fn().mockResolvedValue(undefined);
+        const result = await outbox.flushOutbox(sender);
+        expect(result.sent).toBe(0);
+        expect(sender).not.toHaveBeenCalled();
+    });
+
+    test('flushOutbox ignores already-sent entries', async () => {
+        outbox.enqueue({ m: 'a' }, { idempotencyKey: 'k-a' });
+        outbox.markSent('k-a');
+        const sender = jest.fn().mockResolvedValue(undefined);
+        const result = await outbox.flushOutbox(sender);
+        expect(result.sent).toBe(0);
+        expect(sender).not.toHaveBeenCalled();
+    });
 });


### PR DESCRIPTION
## Summary
Run 16 gap J4 fix. The single most important missing piece of Phase 2 #5.

Server + client foundation already shipped (#3271-#3277, #3279), but NO auto-flush on reconnect / tab-reopen — messages would silently sit in localStorage after a network drop with nothing to retry them. This PR makes "send 5 messages offline, reconnect, see 5 delivered" actually work end-to-end.

## What ships
- `backend/public/portal/shared/outbox.js`: `flushOutbox(sender)` async function. State transitions: 2xx → markSent; throw → bumpAttempt (terminal-fails at MAX_ATTEMPTS).
- `backend/tests/jest/outbox.test.js`: +5 cases (full success, retry on throw, terminal-fail, future-nextRetryAt skip, already-sent skip). 19/19 pass locally.
- `backend/public/portal/chat.html`: `window.addEventListener('online', flushOutbox)` + 30s heartbeat + initial 2s post-DOMContentLoaded flush (catches tab-closed-mid-send).

## Test plan
- [x] Local jest 19/19 pass
- [ ] CI green
- [ ] Post-deploy: open chat.html → check console for `[outbox]` warns absent → flip airplane mode → send 3 messages → toggle online → confirm all 3 delivered without dupes

🤖 Generated with [Claude Code](https://claude.com/claude-code)