### PR TITLE
fix(client/speak): payload-hash dedupe — 10s window catches client auto-retry

### DIFF
--- a/backend/client-speak-payload-dedupe.js
+++ b/backend/client-speak-payload-dedupe.js
@@ -1,0 +1,93 @@
+'use strict';
+
+// Short-window payload-hash dedupe for /api/client/speak.
+//
+// Background: card_51eb9991e76821f4cd8f7a1e (Hank 2026-06-10 12:08 TW).
+// Some clients (e.g., the claude.ai web_chat embedding) auto-retry a slow
+// /api/client/speak request after 5-10s. Each retry generates a NEW
+// Idempotency-Key, so the existing header-keyed middleware (idempotency-keys.js)
+// can't dedupe. Result: same user-typed message lands twice in chat_messages
+// and the bot receives 2 push notifications.
+//
+// This middleware adds a second dedupe gate keyed on a sha256 of the
+// payload itself (deviceId|entityId|text|source|mediaUrl), with a 10s
+// rolling window. First call processes normally; calls within the window
+// short-circuit with the cached response and X-Client-Speak-Dedupe: hit.
+//
+// Design rules:
+// - Payload-only hashing (no per-call key needed from client)
+// - 10s window (matches observed retry cadence; smaller risks legit repeat-sends)
+// - Per-process in-memory map (across replicas is best-effort; a duplicate
+//   between two replicas within 10s is rare and acceptable as a follow-up)
+// - GC sweeps every 30s
+// - Wraps res.json to cache the actual response payload (status + body)
+
+const crypto = require('crypto');
+
+const DEFAULT_WINDOW_MS = 10_000;
+const GC_INTERVAL_MS = 30_000;
+
+function hashPayload(parts) {
+    return crypto.createHash('sha256').update(JSON.stringify(parts)).digest('hex');
+}
+
+function makeMiddleware(options = {}) {
+    const windowMs = options.windowMs || DEFAULT_WINDOW_MS;
+    const cache = new Map();  // key -> { ts, status, body }
+
+    function gc() {
+        const cutoff = Date.now() - windowMs * 3;
+        for (const [k, v] of cache) {
+            if (v.ts < cutoff) cache.delete(k);
+        }
+    }
+
+    const gcTimer = setInterval(gc, GC_INTERVAL_MS);
+    if (gcTimer.unref) gcTimer.unref();
+
+    function middleware(req, res, next) {
+        const { deviceId, entityId, text, source, mediaUrl } = req.body || {};
+        if (!deviceId || (!text && !mediaUrl)) {
+            return next();  // let handler emit its own validation error
+        }
+
+        // Normalize entityId since it can be number, array, "all", etc.
+        const normalizedEid = Array.isArray(entityId)
+            ? [...entityId].sort().join(',')
+            : String(entityId == null ? '' : entityId);
+
+        const key = hashPayload([
+            deviceId,
+            normalizedEid,
+            String(text || ''),
+            String(source || ''),
+            String(mediaUrl || ''),
+        ]);
+
+        const cached = cache.get(key);
+        if (cached && Date.now() - cached.ts < windowMs) {
+            res.set('X-Client-Speak-Dedupe', 'hit');
+            return res.status(cached.status).json(cached.body);
+        }
+
+        const origJson = res.json.bind(res);
+        res.json = (body) => {
+            const status = res.statusCode || 200;
+            // Only cache 2xx (success) and 4xx (client error) — never 5xx,
+            // so a transient server failure doesn't replay for 10s.
+            if (status < 500) {
+                cache.set(key, { ts: Date.now(), status, body });
+            }
+            return origJson(body);
+        };
+
+        next();
+    }
+
+    middleware._cache = cache;       // exposed for tests
+    middleware._gc = gc;
+    middleware._stop = () => clearInterval(gcTimer);
+    return middleware;
+}
+
+module.exports = { makeMiddleware, hashPayload, DEFAULT_WINDOW_MS };

--- a/backend/index.js
+++ b/backend/index.js
@@ -2292,6 +2292,12 @@ const idempotencyKeys = require('./idempotency-keys');
 let _idempotencyInner = (req, res, next) => next();
 const idempotencyMiddleware = (req, res, next) => _idempotencyInner(req, res, next);
 
+// Payload-hash dedupe for /api/client/speak (card_51eb9991, Hank 2026-06-10 12:08 TW).
+// Catches client-side auto-retries where Idempotency-Key is missing or
+// regenerated per attempt. 10s rolling window keyed on payload sha256.
+const clientSpeakPayloadDedupe = require('./client-speak-payload-dedupe');
+const clientSpeakDedupeMiddleware = clientSpeakPayloadDedupe.makeMiddleware({ windowMs: 10_000 });
+
 // ============================================
 // API DOCS — OpenAPI / Swagger UI
 // ============================================
@@ -11204,7 +11210,7 @@ app.post('/api/device/entity/avatar/upload', avatarUpload.single('file'), async 
  *
  * If bot has registered webhook, push notification is sent.
  */
-app.post('/api/client/speak', idempotencyMiddleware, async (req, res) => {
+app.post('/api/client/speak', idempotencyMiddleware, clientSpeakDedupeMiddleware, async (req, res) => {
     const { deviceId, deviceSecret, entityId, text, source = "client", mediaType, mediaUrl, attachments } = req.body;
 
     if (!deviceId) {

--- a/backend/tests/jest/client-speak-payload-dedupe.test.js
+++ b/backend/tests/jest/client-speak-payload-dedupe.test.js
@@ -1,0 +1,180 @@
+'use strict';
+
+/**
+ * Payload-hash dedupe middleware for /api/client/speak.
+ * Card: card_51eb9991e76821f4cd8f7a1e (Hank 2026-06-10 12:08 TW).
+ *
+ * Asserts the dedupe gate behaves correctly for the observed real-world
+ * pattern: client-side auto-retry of the same payload within 10s.
+ */
+
+const { makeMiddleware, hashPayload, DEFAULT_WINDOW_MS } = require('../../client-speak-payload-dedupe');
+
+function mockReq(body) {
+    return { body };
+}
+
+function mockRes() {
+    const res = {
+        statusCode: 200,
+        _headers: {},
+        _jsonBody: null,
+        set(k, v) { this._headers[k.toLowerCase()] = v; return this; },
+        status(code) { this.statusCode = code; return this; },
+        json(body) { this._jsonBody = body; return this; },
+    };
+    return res;
+}
+
+describe('client-speak-payload-dedupe middleware', () => {
+    let mw;
+
+    beforeEach(() => {
+        mw = makeMiddleware({ windowMs: 10_000 });
+    });
+
+    afterEach(() => {
+        if (mw && mw._stop) mw._stop();
+    });
+
+    test('first call: no cache hit, passes through to next() and wraps res.json', () => {
+        const req = mockReq({ deviceId: 'd1', entityId: 5, text: 'hello', source: 'web_chat' });
+        const res = mockRes();
+        const next = jest.fn();
+        mw(req, res, next);
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(res._headers['x-client-speak-dedupe']).toBeUndefined();
+
+        // Simulate handler responding
+        res.json({ success: true, id: 'msg-1' });
+        expect(res._jsonBody).toEqual({ success: true, id: 'msg-1' });
+        expect(mw._cache.size).toBe(1);
+    });
+
+    test('second call with identical payload within window: cache HIT, short-circuits with cached response + X-Client-Speak-Dedupe header', () => {
+        const body = { deviceId: 'd1', entityId: 5, text: 'hello', source: 'web_chat' };
+
+        // First call
+        const req1 = mockReq(body);
+        const res1 = mockRes();
+        mw(req1, res1, jest.fn());
+        res1.json({ success: true, id: 'msg-1' });
+
+        // Second call (same payload)
+        const req2 = mockReq(body);
+        const res2 = mockRes();
+        const next2 = jest.fn();
+        mw(req2, res2, next2);
+        expect(next2).not.toHaveBeenCalled();
+        expect(res2._headers['x-client-speak-dedupe']).toBe('hit');
+        expect(res2.statusCode).toBe(200);
+        expect(res2._jsonBody).toEqual({ success: true, id: 'msg-1' });
+    });
+
+    test('different text: no dedupe (different hash)', () => {
+        const req1 = mockReq({ deviceId: 'd1', entityId: 5, text: 'hello', source: 'web_chat' });
+        const res1 = mockRes();
+        mw(req1, res1, jest.fn());
+        res1.json({ success: true, id: 'msg-1' });
+
+        const req2 = mockReq({ deviceId: 'd1', entityId: 5, text: 'world', source: 'web_chat' });
+        const res2 = mockRes();
+        const next2 = jest.fn();
+        mw(req2, res2, next2);
+        expect(next2).toHaveBeenCalledTimes(1);
+        expect(res2._headers['x-client-speak-dedupe']).toBeUndefined();
+    });
+
+    test('different deviceId: no dedupe (cross-device safety)', () => {
+        const req1 = mockReq({ deviceId: 'd1', entityId: 5, text: 'hello', source: 'web_chat' });
+        const res1 = mockRes();
+        mw(req1, res1, jest.fn());
+        res1.json({ success: true });
+
+        const req2 = mockReq({ deviceId: 'd2', entityId: 5, text: 'hello', source: 'web_chat' });
+        const res2 = mockRes();
+        const next2 = jest.fn();
+        mw(req2, res2, next2);
+        expect(next2).toHaveBeenCalledTimes(1);
+    });
+
+    test('different entityId: no dedupe', () => {
+        const req1 = mockReq({ deviceId: 'd1', entityId: 5, text: 'hello' });
+        const res1 = mockRes();
+        mw(req1, res1, jest.fn());
+        res1.json({ success: true });
+
+        const req2 = mockReq({ deviceId: 'd1', entityId: 6, text: 'hello' });
+        const res2 = mockRes();
+        const next2 = jest.fn();
+        mw(req2, res2, next2);
+        expect(next2).toHaveBeenCalledTimes(1);
+    });
+
+    test('array entityId is normalized (order-independent)', () => {
+        const req1 = mockReq({ deviceId: 'd1', entityId: [3, 5], text: 'hello' });
+        const res1 = mockRes();
+        mw(req1, res1, jest.fn());
+        res1.json({ success: true, broadcast: true });
+
+        // Same broadcast, different array order — should still dedupe
+        const req2 = mockReq({ deviceId: 'd1', entityId: [5, 3], text: 'hello' });
+        const res2 = mockRes();
+        const next2 = jest.fn();
+        mw(req2, res2, next2);
+        expect(next2).not.toHaveBeenCalled();
+        expect(res2._jsonBody).toEqual({ success: true, broadcast: true });
+    });
+
+    test('missing deviceId or text+mediaUrl: pass-through (let handler validate)', () => {
+        const req = mockReq({ entityId: 5 });  // no deviceId
+        const res = mockRes();
+        const next = jest.fn();
+        mw(req, res, next);
+        expect(next).toHaveBeenCalledTimes(1);
+        expect(mw._cache.size).toBe(0);
+    });
+
+    test('5xx response NOT cached (avoids replaying transient server errors)', () => {
+        const body = { deviceId: 'd1', entityId: 5, text: 'hello' };
+        const req1 = mockReq(body);
+        const res1 = mockRes();
+        mw(req1, res1, jest.fn());
+        res1.status(503).json({ error: 'Server starting up' });
+
+        // Second call should NOT see cached 503; should pass to handler again
+        const req2 = mockReq(body);
+        const res2 = mockRes();
+        const next2 = jest.fn();
+        mw(req2, res2, next2);
+        expect(next2).toHaveBeenCalledTimes(1);
+        expect(res2._headers['x-client-speak-dedupe']).toBeUndefined();
+    });
+
+    test('4xx response IS cached (deterministic validation errors)', () => {
+        const body = { deviceId: 'd1', entityId: 5, text: 'hello' };
+        const req1 = mockReq(body);
+        const res1 = mockRes();
+        mw(req1, res1, jest.fn());
+        res1.status(400).json({ error: 'bad payload' });
+
+        const req2 = mockReq(body);
+        const res2 = mockRes();
+        const next2 = jest.fn();
+        mw(req2, res2, next2);
+        expect(next2).not.toHaveBeenCalled();
+        expect(res2.statusCode).toBe(400);
+        expect(res2._jsonBody).toEqual({ error: 'bad payload' });
+    });
+
+    test('hashPayload is deterministic across calls', () => {
+        const a = hashPayload(['d1', '5', 'hello', 'web_chat', '']);
+        const b = hashPayload(['d1', '5', 'hello', 'web_chat', '']);
+        expect(a).toBe(b);
+        expect(a).toHaveLength(64);  // sha256 hex
+    });
+
+    test('DEFAULT_WINDOW_MS is 10s per card spec', () => {
+        expect(DEFAULT_WINDOW_MS).toBe(10_000);
+    });
+});


### PR DESCRIPTION
## Summary
Fixes the bug Hank flagged 2026-06-10 12:08 TW: 「為什麼我明明只發送出1則訊息 會出現2則訊息？」 (card_51eb9991e76821f4cd8f7a1e).

## Root cause
chat_history shows Hank's own dup-pairs land 5-10s apart (NOT a server race — would be ms). The claude.ai web_chat client auto-retries slow `/api/client/speak` requests with a NEW Idempotency-Key per retry, so the existing header-keyed middleware can't dedupe.

## Fix
New `backend/client-speak-payload-dedupe.js` middleware. Hashes the payload (deviceId|entityId|text|source|mediaUrl) with sha256, 10s rolling cache, short-circuits cached calls with `X-Client-Speak-Dedupe: hit`. Mounted AFTER the Idempotency-Key middleware so well-behaved clients still benefit from header-keyed dedupe.

## Test plan
- [x] 11/11 jest pass (`backend/tests/jest/client-speak-payload-dedupe.test.js`)
- [x] node --check on edited files
- [ ] Post-deploy: Hank's next web_chat send → 1 chat_messages row + 1 push (was 2)

## Card link
card_51eb9991e76821f4cd8f7a1e — `[Bug/P1] web_chat 1 send → 2 messages visible`

🤖 Generated with [Claude Code](https://claude.com/claude-code)