### PR TITLE
fix(entity-status): tighten counter-events axis to CANONICAL_AXES whitelist

### DIFF
--- a/backend/entity-status.js
+++ b/backend/entity-status.js
@@ -561,6 +561,11 @@ router.get('/:eId/counter/:axis/events', async (req, res) => {
     if (!/^[a-z][a-z0-9_]{2,63}$/.test(axis)) {
         return res.status(400).json({ success: false, error: 'Invalid axis' });
     }
+    // card_f20e3635: tighten beyond regex to the actual canonical 4 axes so
+    // arbitrary well-formed-but-unknown labels don't pass through to SQL.
+    if (!CANONICAL_AXES.includes(axis)) {
+        return res.status(400).json({ success: false, error: 'Invalid axis' });
+    }
     try {
         const items = await getCounterEvents(auth.deviceId, targetEId, axis, req.query.limit);
         res.json({


### PR DESCRIPTION
## Summary
card_f20e36356153da62c6f1c9e7 — auto-escalated P0 stale 6.4h. ≤10 LOC hardening.

## What
After the existing axis regex check in /:eid/counter/:axis/events, also validate the axis is in `CANONICAL_AXES` (4 known labels). Was: regex-valid-but-unknown axes returned HTTP 200 + empty items. Now: HTTP 400 'Invalid axis'.

## Acceptance verified
- node --check clean
- Logic: regex stays as first gate; CANONICAL_AXES.includes is second

🤖 Generated with [Claude Code](https://claude.com/claude-code)