### PR TITLE
feat(entity-status): Achievements backend slice (6-axis canonical set)

### DIFF
--- a/backend/entity-status.js
+++ b/backend/entity-status.js
@@ -21,6 +21,19 @@ const CANONICAL_AXES = [
     'system_msg_no_reply',
 ];
 
+// card_8ca0b6acb1fb3d7a0b650dfd — Achievement axes (Hank 2026-06-10 09:04 TW).
+// 3 Hank-flagged (tasks_done / chat_upvotes / chat_downvotes) + 3 self-added
+// (prs_merged / cards_reviewed / notes_authored). Same regex/whitelist
+// hardening pattern as CANONICAL_AXES per card_f20e3635 fix.
+const CANONICAL_ACHIEVEMENTS = [
+    'tasks_done',
+    'chat_upvotes',
+    'chat_downvotes',
+    'prs_merged',
+    'cards_reviewed',
+    'notes_authored',
+];
+
 let pool = null;
 let devicesRef = null;
 // Shared with index.js so we verify cookies against the same secret. Set via
@@ -387,6 +400,152 @@ async function getCounterEvents(deviceId, entityId, axis, limit) {
     }));
 }
 
+// ────────────────────────────────────────────────────────────────────────────
+// Achievements — card_8ca0b6acb1fb3d7a0b650dfd
+// Mirrors the counter pattern but cumulative-only (no openCount). Each axis
+// aggregates a different domain table. Backend slice only; frontend rendering
+// + i18n keys ship in a follow-up PR.
+// ────────────────────────────────────────────────────────────────────────────
+
+async function getAchievements(deviceId, entityId) {
+    if (!pool) return [];
+    const eid = Number(entityId);
+    if (!Number.isFinite(eid) || eid < 0) return [];
+
+    const results = await Promise.all(CANONICAL_ACHIEVEMENTS.map(async (axis) => {
+        let count = 0;
+        let lastEventAt = null;
+        try {
+            if (axis === 'tasks_done') {
+                const r = await pool.query(
+                    `SELECT COUNT(*)::int AS c, MAX(updated_at) AS ts
+                       FROM kanban_cards
+                      WHERE device_id = $1 AND status = 'done'
+                        AND $2 = ANY(assigned_bots)`,
+                    [deviceId, eid]
+                );
+                count = Number(r.rows[0]?.c || 0);
+                lastEventAt = r.rows[0]?.ts || null;
+            } else if (axis === 'chat_upvotes' || axis === 'chat_downvotes') {
+                const col = axis === 'chat_upvotes' ? 'like_count' : 'dislike_count';
+                const r = await pool.query(
+                    `SELECT COALESCE(SUM(${col}), 0)::int AS c, MAX(created_at) AS ts
+                       FROM chat_messages
+                      WHERE device_id = $1 AND entity_id = $2 AND is_from_bot = true
+                        AND ${col} > 0`,
+                    [deviceId, eid]
+                );
+                count = Number(r.rows[0]?.c || 0);
+                lastEventAt = r.rows[0]?.ts || null;
+            } else if (axis === 'cards_reviewed') {
+                // Q1 default per Hank's spec: count all reviewer participation
+                // (signed-off + bounced both count).
+                const r = await pool.query(
+                    `SELECT COUNT(*)::int AS c, MAX(updated_at) AS ts
+                       FROM kanban_cards
+                      WHERE device_id = $1 AND reviewer_entity_id = $2
+                        AND status IN ('in_progress','done')`,
+                    [deviceId, eid]
+                );
+                count = Number(r.rows[0]?.c || 0);
+                lastEventAt = r.rows[0]?.ts || null;
+            } else if (axis === 'notes_authored') {
+                const r = await pool.query(
+                    `SELECT COUNT(*)::int AS c, MAX(created_at) AS ts
+                       FROM mission_notes
+                      WHERE device_id = $1 AND entity_id = $2`,
+                    [deviceId, eid]
+                );
+                count = Number(r.rows[0]?.c || 0);
+                lastEventAt = r.rows[0]?.ts || null;
+            }
+            // prs_merged: skipped in backend (would need GH API or per-entity
+            // commit-author mapping that we don't store); always 0 until v2.
+        } catch (err) {
+            // Per-axis failure isolated: log + treat as 0 so one missing
+            // table (e.g. mission_notes on a fresh device) doesn't abort all axes.
+            console.warn(`[Achievements] axis=${axis} query failed:`, err && err.message);
+        }
+        return {
+            axis,
+            count,
+            lastEventAt: lastEventAt ? new Date(lastEventAt).toISOString() : null,
+        };
+    }));
+    return results;
+}
+
+async function getAchievementEvents(deviceId, entityId, axis, limit) {
+    if (!pool) return [];
+    if (!CANONICAL_ACHIEVEMENTS.includes(axis)) return [];
+    const lim = Math.max(1, Math.min(100, Number(limit) || 30));
+    const eid = Number(entityId);
+
+    try {
+        if (axis === 'tasks_done') {
+            const r = await pool.query(
+                `SELECT id, title, updated_at
+                   FROM kanban_cards
+                  WHERE device_id = $1 AND status = 'done'
+                    AND $2 = ANY(assigned_bots)
+                  ORDER BY updated_at DESC LIMIT $3`,
+                [deviceId, eid, lim]
+            );
+            return r.rows.map(row => ({
+                ts: row.updated_at ? row.updated_at.toISOString() : null,
+                chip: { kind: 'card', cardId: row.id, label: row.title },
+            }));
+        }
+        if (axis === 'chat_upvotes' || axis === 'chat_downvotes') {
+            const col = axis === 'chat_upvotes' ? 'like_count' : 'dislike_count';
+            const r = await pool.query(
+                `SELECT id, text, created_at
+                   FROM chat_messages
+                  WHERE device_id = $1 AND entity_id = $2 AND is_from_bot = true
+                    AND ${col} > 0
+                  ORDER BY created_at DESC LIMIT $3`,
+                [deviceId, eid, lim]
+            );
+            return r.rows.map(row => ({
+                ts: row.created_at ? row.created_at.toISOString() : null,
+                chip: { kind: 'chat', messageId: row.id, excerpt: (row.text || '').slice(0, 60) },
+            }));
+        }
+        if (axis === 'cards_reviewed') {
+            const r = await pool.query(
+                `SELECT id, title, updated_at
+                   FROM kanban_cards
+                  WHERE device_id = $1 AND reviewer_entity_id = $2
+                    AND status IN ('in_progress','done')
+                  ORDER BY updated_at DESC LIMIT $3`,
+                [deviceId, eid, lim]
+            );
+            return r.rows.map(row => ({
+                ts: row.updated_at ? row.updated_at.toISOString() : null,
+                chip: { kind: 'card', cardId: row.id, label: row.title },
+            }));
+        }
+        if (axis === 'notes_authored') {
+            const r = await pool.query(
+                `SELECT id, title, created_at
+                   FROM mission_notes
+                  WHERE device_id = $1 AND entity_id = $2
+                  ORDER BY created_at DESC LIMIT $3`,
+                [deviceId, eid, lim]
+            );
+            return r.rows.map(row => ({
+                ts: row.created_at ? row.created_at.toISOString() : null,
+                chip: { kind: 'note', noteId: row.id, label: row.title },
+            }));
+        }
+        // prs_merged: empty until v2 (see getAchievements comment)
+        return [];
+    } catch (err) {
+        console.warn(`[Achievements] events axis=${axis} failed:`, err && err.message);
+        return [];
+    }
+}
+
 async function incrementCounter(deviceId, entityId, axis) {
     if (!pool) return;
     await pool.query(`
@@ -581,6 +740,61 @@ router.get('/:eId/counter/:axis/events', async (req, res) => {
     }
 });
 
+// Achievements panel data — card_8ca0b6acb1fb3d7a0b650dfd.
+router.get('/:eId/achievements', async (req, res) => {
+    const auth = authDeviceOrBot(req);
+    if (!auth) {
+        return res.status(403).json({ success: false, error: 'Invalid credentials' });
+    }
+    const targetEId = parseInt(req.params.eId);
+    if (!Number.isFinite(targetEId) || targetEId < 0) {
+        return res.status(400).json({ success: false, error: 'Invalid entityId' });
+    }
+    try {
+        const items = await getAchievements(auth.deviceId, targetEId);
+        res.json({
+            success: true,
+            deviceId: auth.deviceId,
+            entityId: targetEId,
+            achievements: items,
+        });
+    } catch (err) {
+        console.error('[EntityStatus] getAchievements error:', err.message);
+        res.status(500).json({ success: false, error: 'internal' });
+    }
+});
+
+router.get('/:eId/achievement/:axis/events', async (req, res) => {
+    const auth = authDeviceOrBot(req);
+    if (!auth) {
+        return res.status(403).json({ success: false, error: 'Invalid credentials' });
+    }
+    const targetEId = parseInt(req.params.eId);
+    if (!Number.isFinite(targetEId) || targetEId < 0) {
+        return res.status(400).json({ success: false, error: 'Invalid entityId' });
+    }
+    const axis = String(req.params.axis || '');
+    // Same regex+whitelist defense-in-depth pattern as counter-events
+    // (card_f20e3635 fix). The whitelist check is the load-bearing one;
+    // the regex stays as belt-and-suspenders against header injection.
+    if (!/^[a-z][a-z0-9_]{2,63}$/.test(axis) || !CANONICAL_ACHIEVEMENTS.includes(axis)) {
+        return res.status(400).json({ success: false, error: 'Invalid axis' });
+    }
+    try {
+        const items = await getAchievementEvents(auth.deviceId, targetEId, axis, req.query.limit);
+        res.json({
+            success: true,
+            deviceId: auth.deviceId,
+            entityId: targetEId,
+            axis,
+            items,
+        });
+    } catch (err) {
+        console.error('[EntityStatus] getAchievementEvents error:', err.message);
+        res.status(500).json({ success: false, error: 'internal' });
+    }
+});
+
 router.get('/:eId/log', express.json(), async (req, res) => {
     const auth = authDeviceOrBot(req);
     if (!auth) {
@@ -665,4 +879,7 @@ module.exports = {
     getLogRowById,
     router,
     CANONICAL_AXES,
+    CANONICAL_ACHIEVEMENTS,
+    getAchievements,
+    getAchievementEvents,
 };

--- a/backend/tests/jest/entity-status-achievements.test.js
+++ b/backend/tests/jest/entity-status-achievements.test.js
@@ -1,0 +1,161 @@
+'use strict';
+
+/**
+ * Backend slice tests for the Achievements panel.
+ * Card: card_8ca0b6acb1fb3d7a0b650dfd (Hank 2026-06-10 09:04 TW).
+ *
+ * Pool-mocked tests asserting the per-axis query shape and aggregation
+ * behavior. Verifies the 6-axis CANONICAL_ACHIEVEMENTS surface, isolation
+ * by (deviceId, entityId), and event drill-down chip shapes.
+ */
+
+const entityStatus = require('../../entity-status');
+
+function makePool(rowsByQuery) {
+    return {
+        async query(sql, params) {
+            const s = sql.replace(/\s+/g, ' ').trim();
+            for (const matcher of rowsByQuery) {
+                if (matcher.match(s, params)) return { rows: matcher.rows(params) };
+            }
+            return { rows: [] };
+        },
+    };
+}
+
+describe('Achievements backend slice', () => {
+    const DEVICE = 'd1';
+    const ENTITY = 2;
+
+    test('CANONICAL_ACHIEVEMENTS has the 6 expected axes in order', () => {
+        expect(entityStatus.CANONICAL_ACHIEVEMENTS).toEqual([
+            'tasks_done',
+            'chat_upvotes',
+            'chat_downvotes',
+            'prs_merged',
+            'cards_reviewed',
+            'notes_authored',
+        ]);
+    });
+
+    test('getAchievements returns 6 rows in canonical order with count 0 when pool is empty', async () => {
+        entityStatus.initTable(makePool([]));
+        const items = await entityStatus.getAchievements(DEVICE, ENTITY);
+        expect(items).toHaveLength(6);
+        expect(items.map(x => x.axis)).toEqual(entityStatus.CANONICAL_ACHIEVEMENTS);
+        items.forEach(item => {
+            expect(item.count).toBe(0);
+            expect(item.lastEventAt).toBeNull();
+        });
+    });
+
+    test('getAchievements aggregates tasks_done by status=done AND $entity=ANY(assigned_bots)', async () => {
+        const lastTs = new Date('2026-06-10T12:00:00Z');
+        const pool = makePool([
+            {
+                match: (s) => s.includes('FROM kanban_cards') && s.includes('status = \'done\'') && s.includes('ANY(assigned_bots)'),
+                rows: (p) => {
+                    expect(p[0]).toBe(DEVICE);
+                    expect(p[1]).toBe(ENTITY);
+                    return [{ c: 17, ts: lastTs }];
+                },
+            },
+        ]);
+        entityStatus.initTable(pool);
+        const items = await entityStatus.getAchievements(DEVICE, ENTITY);
+        const done = items.find(x => x.axis === 'tasks_done');
+        expect(done.count).toBe(17);
+        expect(done.lastEventAt).toBe(lastTs.toISOString());
+    });
+
+    test('getAchievements chat_upvotes uses like_count column', async () => {
+        const pool = makePool([
+            {
+                match: (s) => s.includes('FROM chat_messages') && s.includes('like_count') && s.includes('is_from_bot = true'),
+                rows: () => [{ c: 42, ts: new Date('2026-06-10T10:00:00Z') }],
+            },
+        ]);
+        entityStatus.initTable(pool);
+        const items = await entityStatus.getAchievements(DEVICE, ENTITY);
+        expect(items.find(x => x.axis === 'chat_upvotes').count).toBe(42);
+    });
+
+    test('getAchievements chat_downvotes uses dislike_count column', async () => {
+        const pool = makePool([
+            {
+                match: (s) => s.includes('FROM chat_messages') && s.includes('dislike_count') && s.includes('is_from_bot = true'),
+                rows: () => [{ c: 3, ts: null }],
+            },
+        ]);
+        entityStatus.initTable(pool);
+        const items = await entityStatus.getAchievements(DEVICE, ENTITY);
+        expect(items.find(x => x.axis === 'chat_downvotes').count).toBe(3);
+    });
+
+    test('getAchievements cards_reviewed counts ALL reviewer participation (Q1 default)', async () => {
+        const pool = makePool([
+            {
+                match: (s) => s.includes('FROM kanban_cards') && s.includes('reviewer_entity_id') && s.includes("status IN ('in_progress','done')"),
+                rows: () => [{ c: 11, ts: null }],
+            },
+        ]);
+        entityStatus.initTable(pool);
+        const items = await entityStatus.getAchievements(DEVICE, ENTITY);
+        expect(items.find(x => x.axis === 'cards_reviewed').count).toBe(11);
+    });
+
+    test('getAchievements prs_merged stays at 0 in this slice (v2 follow-up)', async () => {
+        entityStatus.initTable(makePool([]));
+        const items = await entityStatus.getAchievements(DEVICE, ENTITY);
+        expect(items.find(x => x.axis === 'prs_merged').count).toBe(0);
+    });
+
+    test('getAchievementEvents for tasks_done returns card chips', async () => {
+        const pool = makePool([
+            {
+                match: (s) => s.includes('FROM kanban_cards') && s.includes('ANY(assigned_bots)') && s.includes('ORDER BY updated_at DESC'),
+                rows: () => [
+                    { id: 'card_a', title: 'Ship X', updated_at: new Date('2026-06-10T08:00:00Z') },
+                    { id: 'card_b', title: 'Ship Y', updated_at: new Date('2026-06-09T08:00:00Z') },
+                ],
+            },
+        ]);
+        entityStatus.initTable(pool);
+        const items = await entityStatus.getAchievementEvents(DEVICE, ENTITY, 'tasks_done', 10);
+        expect(items).toHaveLength(2);
+        expect(items[0].chip).toEqual({ kind: 'card', cardId: 'card_a', label: 'Ship X' });
+    });
+
+    test('getAchievementEvents for chat_upvotes returns chat chips with truncated excerpt', async () => {
+        const longText = 'x'.repeat(120);
+        const pool = makePool([
+            {
+                match: (s) => s.includes('FROM chat_messages') && s.includes('like_count') && s.includes('ORDER BY created_at DESC'),
+                rows: () => [{ id: 'msg_1', text: longText, created_at: new Date('2026-06-10T08:00:00Z') }],
+            },
+        ]);
+        entityStatus.initTable(pool);
+        const items = await entityStatus.getAchievementEvents(DEVICE, ENTITY, 'chat_upvotes', 10);
+        expect(items[0].chip.kind).toBe('chat');
+        expect(items[0].chip.excerpt).toHaveLength(60);
+    });
+
+    test('getAchievementEvents rejects non-canonical axis (whitelist)', async () => {
+        entityStatus.initTable(makePool([]));
+        const items = await entityStatus.getAchievementEvents(DEVICE, ENTITY, 'not_canonical', 10);
+        expect(items).toEqual([]);
+    });
+
+    test('getAchievementEvents limit cap = 100', async () => {
+        let capturedLimit = null;
+        const pool = makePool([
+            {
+                match: (s) => s.includes('FROM kanban_cards') && s.includes('ANY(assigned_bots)'),
+                rows: (p) => { capturedLimit = p[2]; return []; },
+            },
+        ]);
+        entityStatus.initTable(pool);
+        await entityStatus.getAchievementEvents(DEVICE, ENTITY, 'tasks_done', 99999);
+        expect(capturedLimit).toBe(100);
+    });
+});


### PR DESCRIPTION
## Summary
Backend slice of card_8ca0b6acb1fb3d7a0b650dfd (Hank 2026-06-10 09:04 TW achievement list request, auto-escalated P0 stale 6h). Frontend + i18n ship in a v2 PR.

## What landed
- `CANONICAL_ACHIEVEMENTS` constant: tasks_done / chat_upvotes / chat_downvotes (Hank 3) + prs_merged / cards_reviewed / notes_authored (self 3)
- `getAchievements(deviceId, entityId)` + `getAchievementEvents(...)` with per-axis SQL isolation
- 2 new routes: `GET /:eId/achievements` and `GET /:eId/achievement/:axis/events`
- Same regex + CANONICAL whitelist defense-in-depth pattern as PR #3289 fix
- 11/11 jest pass

## Q1 default applied
'cards_reviewed' counts ALL reviewer participation per spec default.

## Out of scope (v2)
- Frontend renderAchievements() in entity-status-panel.js
- 8 i18n keys × 7 locales
- requiresScreenshotReview before/after screenshots
- prs_merged GH API integration (stays at 0)

## Card link
card_8ca0b6acb1fb3d7a0b650dfd

🤖 Generated with [Claude Code](https://claude.com/claude-code)