### PR TITLE
feat(chat): outbox queue-count banner + bubble state classes (card_751775f0)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -80,6 +80,30 @@
         .outbox-banner-icon { font-size: 14px; line-height: 1; }
         .outbox-banner-text { line-height: 1.3; }
 
+        /* Outbox bubble states — spec acceptance #4 (card_751775f0). */
+        .msg-outbox { cursor: pointer; }
+        .msg-outbox .msg-outbox-spinner,
+        .msg-outbox .msg-outbox-warn { display: none; vertical-align: middle; margin-left: 6px; }
+        .msg-outbox-queued .chat-bubble,
+        .msg-outbox-retrying .chat-bubble { opacity: 0.85; }
+        .msg-outbox-queued .chat-bubble { background: #ececec; color: #555; }
+        body.dark .msg-outbox-queued .chat-bubble { background: #2a2a2a; color: #bbb; }
+        .msg-outbox-retrying .chat-bubble { background: #fff4d1; color: #5d4317; }
+        body.dark .msg-outbox-retrying .chat-bubble { background: #3a3220; color: #e8d488; }
+        .msg-outbox-failed .chat-bubble { border: 1.5px solid #d94f4f; background: #fdecec; color: #5a1a1a; }
+        body.dark .msg-outbox-failed .chat-bubble { background: #3a1e1e; color: #ffb4b4; border-color: #b34141; }
+        .msg-outbox-queued .msg-outbox-spinner,
+        .msg-outbox-retrying .msg-outbox-spinner {
+            display: inline-block;
+            width: 10px; height: 10px;
+            border: 2px solid #bbb;
+            border-top-color: #5d4317;
+            border-radius: 50%;
+            animation: outbox-spin 0.9s linear infinite;
+        }
+        .msg-outbox-failed .msg-outbox-warn { display: inline; font-size: 14px; }
+        @keyframes outbox-spin { to { transform: rotate(360deg); } }
+
         .chat-container {
             display: flex;
             flex-direction: column;
@@ -3227,6 +3251,7 @@
     <script src="shared/auth.js"></script>
     <!-- Phase 2 #5 offline delivery queue: load before sendMessage runs. -->
     <script src="shared/outbox.js"></script>
+    <script src="shared/outbox-ui.js"></script>
     <script src="../shared/petdx-renderer.js"></script>
     <script src="../shared/avatar-petdx.js"></script>
     <script src="shared/entity-utils.js"></script>
@@ -3637,29 +3662,72 @@
         setInterval(() => { if (navigator.onLine) _flushOutboxWithSender(); }, 30_000);
 
         // Outbox queue-count banner — card_751775f0 (offline-queue spec acceptance #5).
-        // Polls EclawOutbox.summary() every 2s. Banner hidden when 0 queued + 0 retrying.
+        // Polls EclawOutbox.summary() every 5s. Banner hidden when 0 queued + 0 retrying.
         function _updateOutboxBanner() {
             const el = document.getElementById('outboxBanner');
             const txtEl = document.getElementById('outboxBannerText');
-            if (!el || !txtEl || !window.EclawOutbox || typeof window.EclawOutbox.summary !== 'function') return;
+            if (!el || !txtEl || !window.EclawOutbox || !window.EclawOutboxUI) return;
             let s;
             try { s = window.EclawOutbox.summary(); } catch (e) { return; }
-            const by = (s && s.by) || {};
-            const queued = by.queued || 0;
-            const retrying = by.retrying || 0;
-            if (queued === 0 && retrying === 0) {
-                el.hidden = true;
-                txtEl.textContent = '';
+            window.EclawOutboxUI.updateBanner(el, txtEl, s, (k) => (window.i18n && i18n.t ? i18n.t(k) : k));
+        }
+        setInterval(_updateOutboxBanner, 5_000);
+        window.addEventListener('online', _updateOutboxBanner);
+
+        // Outbox bubble tap handlers — spec acceptance #4 (card_751775f0).
+        // queued/retrying → confirm cancel. failed → menu (retry / delete).
+        function _onOutboxCancel(key) {
+            const t = (k, fb) => (window.i18n && i18n.t ? i18n.t(k) : null) || fb;
+            const msg = t('chat_outbox_cancel_confirm', 'Cancel this queued message?');
+            if (typeof showConfirm === 'function') {
+                showConfirm(msg, () => {
+                    try { window.EclawOutbox && window.EclawOutbox.remove(key); } catch (_) { /* noop */ }
+                    const c = document.getElementById('chatMessages');
+                    if (c && window.EclawOutboxUI) window.EclawOutboxUI.removeBubble(c, key);
+                    _updateOutboxBanner();
+                });
+            } else if (window.confirm(msg)) {
+                try { window.EclawOutbox && window.EclawOutbox.remove(key); } catch (_) { /* noop */ }
+                const c = document.getElementById('chatMessages');
+                if (c && window.EclawOutboxUI) window.EclawOutboxUI.removeBubble(c, key);
+                _updateOutboxBanner();
+            }
+        }
+        function _onOutboxFailedMenu(key) {
+            const t = (k, fb) => (window.i18n && i18n.t ? i18n.t(k) : null) || fb;
+            // Native confirm: OK = retry (re-enqueue with fresh idempotencyKey),
+            // Cancel = open delete prompt. Keeps the menu mobile-friendly.
+            const wantRetry = window.confirm(t('chat_outbox_failed_retry_q', 'Retry sending this message?'));
+            if (wantRetry) {
+                try {
+                    const snap = window.EclawOutbox.snapshot();
+                    const entry = snap.find(e => e.idempotencyKey === key);
+                    if (entry) {
+                        window.EclawOutbox.remove(key);
+                        const c = document.getElementById('chatMessages');
+                        if (c && window.EclawOutboxUI) window.EclawOutboxUI.removeBubble(c, key);
+                        // Re-enqueue same payload — gets a fresh idempotencyKey + queued state.
+                        window.EclawOutbox.enqueue(entry.payload);
+                        if (typeof _flushOutboxWithSender === 'function') _flushOutboxWithSender();
+                    }
+                } catch (_) { /* noop */ }
+                _updateOutboxBanner();
                 return;
             }
-            const parts = [];
-            if (queued > 0) parts.push(queued + ' queued');
-            if (retrying > 0) parts.push(retrying + ' retrying');
-            txtEl.textContent = parts.join(' · ');
-            el.hidden = false;
+            const wantDelete = window.confirm(t('chat_outbox_failed_delete_q', 'Delete this failed message?'));
+            if (wantDelete) {
+                try { window.EclawOutbox && window.EclawOutbox.remove(key); } catch (_) { /* noop */ }
+                const c = document.getElementById('chatMessages');
+                if (c && window.EclawOutboxUI) window.EclawOutboxUI.removeBubble(c, key);
+                _updateOutboxBanner();
+            }
         }
-        setInterval(_updateOutboxBanner, 2_000);
-        window.addEventListener('online', _updateOutboxBanner);
+        (function _bindOutboxTaps() {
+            const c = document.getElementById('chatMessages');
+            if (c && window.EclawOutboxUI) {
+                window.EclawOutboxUI.attachTapHandlers(c, { onCancel: _onOutboxCancel, onFailedMenu: _onOutboxFailedMenu });
+            }
+        })();
 
         window.addEventListener('DOMContentLoaded', async () => {
             // Detect embed mode (workspace split view)
@@ -6391,17 +6459,26 @@
                             pendingConfirmCommand = null;
                         }
                         // Phase 2 #5 offline-queue wrap: enqueue + tag with
-                        // Idempotency-Key so a retry from a spotty connection
-                        // hits the server-side cache (PRs #3271/#3272/#3274/#3276).
-                        // Outbox state surfaces nowhere yet; UI bubbles in a follow-up.
+                        // Idempotency-Key + render an inline outbox bubble.
+                        // Spec acceptance #4+#5 (card_751775f0).
                         let __outboxEntry = null;
                         let __idempotencyKey = null;
+                        const __chatContainer = document.getElementById('chatMessages');
                         if (window.EclawOutbox) {
                             try {
                                 const enqueued = window.EclawOutbox.enqueue(speakBody);
                                 __outboxEntry = enqueued && enqueued.entry;
                                 __idempotencyKey = __outboxEntry && __outboxEntry.idempotencyKey;
-                                if (__outboxEntry) window.EclawOutbox.markRetrying(__idempotencyKey);
+                                if (__outboxEntry && __chatContainer && window.EclawOutboxUI) {
+                                    window.EclawOutboxUI.renderQueuedBubble(__chatContainer, { idempotencyKey: __idempotencyKey, text: finalText });
+                                }
+                                if (__outboxEntry) {
+                                    window.EclawOutbox.markRetrying(__idempotencyKey);
+                                    if (__chatContainer && window.EclawOutboxUI) {
+                                        window.EclawOutboxUI.setBubbleState(__chatContainer, __idempotencyKey, 'retrying');
+                                    }
+                                }
+                                _updateOutboxBanner();
                             } catch (e) { /* outbox is best-effort, never block send */ }
                         }
                         let speakResp;
@@ -6410,10 +6487,20 @@
                             speakResp = await apiCall('POST', '/api/client/speak', speakBody, __opts);
                             if (__idempotencyKey && window.EclawOutbox) {
                                 window.EclawOutbox.markSent(__idempotencyKey);
+                                // Drop the inline bubble — loadMessages() will re-render with
+                                // the real server message id below.
+                                if (__chatContainer && window.EclawOutboxUI) {
+                                    window.EclawOutboxUI.removeBubble(__chatContainer, __idempotencyKey);
+                                }
+                                _updateOutboxBanner();
                             }
                         } catch (e) {
                             if (__idempotencyKey && window.EclawOutbox) {
                                 window.EclawOutbox.markFailed(__idempotencyKey, e && e.message);
+                                if (__chatContainer && window.EclawOutboxUI) {
+                                    window.EclawOutboxUI.setBubbleState(__chatContainer, __idempotencyKey, 'failed');
+                                }
+                                _updateOutboxBanner();
                             }
                             throw e;
                         }

--- a/backend/public/portal/shared/outbox-ui.js
+++ b/backend/public/portal/shared/outbox-ui.js
@@ -1,0 +1,160 @@
+/**
+ * Outbox UI helpers — spec acceptance #4 (bubble states) + #5 (banner).
+ * Card: card_751775f0435f3a17e669d12a. Spec: docs/offline-delivery-queue-spec.md.
+ *
+ * Pure DOM helpers separated from chat.html so they can be exercised under
+ * jsdom in Jest without booting the whole portal page. Three responsibilities:
+ *   1. updateBanner()      — flips #outboxBanner visibility + text from stats
+ *   2. renderQueuedBubble  — appends an inline outbox bubble while the entry
+ *                            sits in localStorage waiting to be flushed
+ *   3. setBubbleState/remove — flip the bubble's state class on transitions
+ *   4. attachTapHandlers    — delegated click → cancel/retry/delete
+ */
+(function (global) {
+    'use strict';
+
+    var STATES = ['queued', 'retrying', 'sent', 'failed'];
+
+    function tt(t, key, fallback) {
+        if (typeof t === 'function') {
+            try { var v = t(key); if (v && v !== key) return v; } catch (_e) { /* swallow */ }
+        }
+        return fallback;
+    }
+
+    function updateBanner(bannerEl, textEl, stats, t) {
+        if (!bannerEl || !textEl) return;
+        var by = (stats && stats.by) || {};
+        var queued = by.queued || 0;
+        var retrying = by.retrying || 0;
+        if (queued === 0 && retrying === 0) {
+            bannerEl.hidden = true;
+            textEl.textContent = '';
+            return;
+        }
+        var parts = [];
+        if (queued > 0) {
+            var qTpl = tt(t, 'chat_outbox_queued_n', '{n} queued');
+            parts.push(qTpl.replace('{n}', String(queued)));
+        }
+        if (retrying > 0) {
+            var rTpl = tt(t, 'chat_outbox_retrying_n', '{n} retrying');
+            parts.push(rTpl.replace('{n}', String(retrying)));
+        }
+        textEl.textContent = parts.join(' · ');
+        bannerEl.hidden = false;
+    }
+
+    function findBubble(container, idempotencyKey) {
+        if (!container || !idempotencyKey) return null;
+        return container.querySelector('[data-outbox-key="' + cssEscape(idempotencyKey) + '"]');
+    }
+
+    function cssEscape(s) {
+        // jsdom may lack CSS.escape; escape only what closes the attr-value
+        // selector — backslash and the surrounding double quote.
+        return String(s).replace(/["\\]/g, '\\$&');
+    }
+
+    function renderQueuedBubble(container, opts) {
+        if (!container || !opts || !opts.idempotencyKey) return null;
+        var existing = findBubble(container, opts.idempotencyKey);
+        if (existing) return existing;
+        var doc = container.ownerDocument || global.document;
+        var wrap = doc.createElement('div');
+        wrap.className = 'chat-msg sent msg-outbox msg-outbox-queued';
+        wrap.setAttribute('data-outbox-key', opts.idempotencyKey);
+        wrap.setAttribute('role', 'button');
+        wrap.setAttribute('tabindex', '0');
+
+        var bubble = doc.createElement('div');
+        bubble.className = 'chat-bubble';
+        bubble.textContent = String(opts.text || '');
+        wrap.appendChild(bubble);
+
+        var spinner = doc.createElement('span');
+        spinner.className = 'msg-outbox-spinner';
+        spinner.setAttribute('aria-hidden', 'true');
+        wrap.appendChild(spinner);
+
+        var warn = doc.createElement('span');
+        warn.className = 'msg-outbox-warn';
+        warn.setAttribute('aria-hidden', 'true');
+        warn.textContent = '⚠️';
+        wrap.appendChild(warn);
+
+        container.appendChild(wrap);
+        return wrap;
+    }
+
+    function setBubbleState(container, idempotencyKey, state) {
+        var el = findBubble(container, idempotencyKey);
+        if (!el) return null;
+        if (STATES.indexOf(state) === -1) return el;
+        STATES.forEach(function (s) {
+            el.classList.remove('msg-outbox-' + s);
+        });
+        el.classList.add('msg-outbox-' + state);
+        return el;
+    }
+
+    function removeBubble(container, idempotencyKey) {
+        var el = findBubble(container, idempotencyKey);
+        if (el && el.parentNode) el.parentNode.removeChild(el);
+        return !!el;
+    }
+
+    function classifyClick(target) {
+        // Walk up to find the nearest outbox bubble + its state.
+        var el = target;
+        while (el && el !== el.ownerDocument) {
+            if (el.classList && el.classList.contains('msg-outbox')) {
+                var key = el.getAttribute('data-outbox-key');
+                var state = STATES.find(function (s) { return el.classList.contains('msg-outbox-' + s); }) || null;
+                return { el: el, key: key, state: state };
+            }
+            el = el.parentNode;
+        }
+        return null;
+    }
+
+    function attachTapHandlers(container, callbacks) {
+        if (!container || !callbacks) return function () {};
+        function onClick(ev) {
+            var hit = classifyClick(ev.target);
+            if (!hit || !hit.key) return;
+            if (hit.state === 'queued' || hit.state === 'retrying') {
+                if (typeof callbacks.onCancel === 'function') {
+                    ev.preventDefault();
+                    ev.stopPropagation();
+                    callbacks.onCancel(hit.key, hit.el);
+                }
+            } else if (hit.state === 'failed') {
+                if (typeof callbacks.onFailedMenu === 'function') {
+                    ev.preventDefault();
+                    ev.stopPropagation();
+                    callbacks.onFailedMenu(hit.key, hit.el);
+                }
+            }
+        }
+        container.addEventListener('click', onClick);
+        return function detach() { container.removeEventListener('click', onClick); };
+    }
+
+    var api = {
+        STATES: STATES,
+        updateBanner: updateBanner,
+        renderQueuedBubble: renderQueuedBubble,
+        setBubbleState: setBubbleState,
+        removeBubble: removeBubble,
+        findBubble: findBubble,
+        classifyClick: classifyClick,
+        attachTapHandlers: attachTapHandlers,
+    };
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    } else if (global) {
+        global.EclawOutboxUI = api;
+    }
+})(typeof window !== 'undefined' ? window : (typeof global !== 'undefined' ? global : this));

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650115,7 +650115,13 @@ const TRANSLATIONS = {
 
 
 
-    },
+    
+        "chat_outbox_queued_n": "{n} queued",
+        "chat_outbox_retrying_n": "{n} retrying",
+        "chat_outbox_cancel_confirm": "Cancel this queued message?",
+        "chat_outbox_failed_retry_q": "Retry sending this message?",
+        "chat_outbox_failed_delete_q": "Delete this failed message?",
+},
 
 
 
@@ -1234697,7 +1234703,13 @@ const TRANSLATIONS = {
         "refs.popover_title": "引用",
         "refs.section_in": "被引用",
         "refs.section_out": "引用",        "chat_related_target_not_loaded": "目標聊天尚未載入",
-    },
+    
+        "chat_outbox_queued_n": "{n} 則排隊中",
+        "chat_outbox_retrying_n": "{n} 則重試中",
+        "chat_outbox_cancel_confirm": "取消這則排隊中的訊息？",
+        "chat_outbox_failed_retry_q": "重新傳送這則訊息？",
+        "chat_outbox_failed_delete_q": "刪除這則失敗的訊息？",
+},
 
 
 
@@ -1848784,7 +1848796,13 @@ const TRANSLATIONS = {
         "prompt_policy_scope_help": "选择提示词策略要应用到整台设备默认值，或只覆盖单一实体。实体覆盖只影响选定的实体。",
         "settings_device_id_help": "要让此浏览器使用的设备/账号唯一标识符。需要搭配相符的 Device Secret。",
         "settings_device_secret_help": "选定 Device ID 的私钥。请像密码一样保护，只在你控制的设备上输入。",
-    },
+    
+        "chat_outbox_queued_n": "{n} 条排队中",
+        "chat_outbox_retrying_n": "{n} 条重试中",
+        "chat_outbox_cancel_confirm": "取消这条排队中的消息？",
+        "chat_outbox_failed_retry_q": "重新发送这条消息？",
+        "chat_outbox_failed_delete_q": "删除这条失败的消息？",
+},
 
 
 
@@ -2411876,7 +2411894,13 @@ const TRANSLATIONS = {
         "prompt_policy_scope_help": "プロンプトポリシーをデバイス全体にデフォルトで適用するか、特定のエンティティを上書きするかを選択します。",
         "settings_device_id_help": "このブラウザで使用するデバイス/アカウントの一意の識別子。ペアリングする際は対応する Device Secret と一緒に保管してください。",
         "settings_device_secret_help": "選択した Device ID の秘密キー。パスワードとして扱い、信頼するデバイスにのみ入力してください。",
-    },
+    
+        "chat_outbox_queued_n": "{n} 件キュー中",
+        "chat_outbox_retrying_n": "{n} 件再試行中",
+        "chat_outbox_cancel_confirm": "このキュー中のメッセージをキャンセルしますか？",
+        "chat_outbox_failed_retry_q": "このメッセージを再送信しますか？",
+        "chat_outbox_failed_delete_q": "この失敗したメッセージを削除しますか？",
+},
 
 
 
@@ -2942073,7 +2942097,13 @@ const TRANSLATIONS = {
         "prompt_policy_scope_label": "정책 범위",
         "prompt_policy_scope_help": "프롬프트 정책을 기기 전체에 기본으로 적용할지 또는 특정 엔티티를 재정의할지 선택합니다.",
         "settings_device_id_help": "이 브라우저에서 사용할 기기/계정의 고유 식별자입니다. 페어링할 때 해당 Device Secret과 함께 보관하세요.",
-        "settings_device_secret_help": "선택한 Device ID의 비밀 키입니다. 비밀번호처럼 취급하고 신뢰할 수 있는 기기에만 입력하세요.",    },
+        "settings_device_secret_help": "선택한 Device ID의 비밀 키입니다. 비밀번호처럼 취급하고 신뢰할 수 있는 기기에만 입력하세요.",    
+        "chat_outbox_queued_n": "{n}개 대기 중",
+        "chat_outbox_retrying_n": "{n}개 재시도 중",
+        "chat_outbox_cancel_confirm": "대기 중인 이 메시지를 취소하시겠습니까?",
+        "chat_outbox_failed_retry_q": "이 메시지를 다시 보내시겠습니까?",
+        "chat_outbox_failed_delete_q": "실패한 이 메시지를 삭제하시겠습니까?",
+},
 
 
 
@@ -2943642,7 +2943672,13 @@ const TRANSLATIONS = {
 
 
 
-    },
+    ,
+        "chat_outbox_queued_n": "{n} 則排隊中",
+        "chat_outbox_retrying_n": "{n} 則重試中",
+        "chat_outbox_cancel_confirm": "取消這則排隊中的訊息？",
+        "chat_outbox_failed_retry_q": "重新傳送這則訊息？",
+        "chat_outbox_failed_delete_q": "刪除這則失敗的訊息？",
+},
 
 
 
@@ -3470405,7 +3470441,13 @@ const TRANSLATIONS = {
         "kanban_nudge_per_entity_section_help": "การตั้งค่า nudge ต่อเอนทิตี เอนทิตีแต่ละตัวสามารถแทนที่ช่วงเวลา สถานะ และโหมดหยุดได้อย่างอิสระ ใช้เมื่อหนึ่งเอนทิตีต้องการจังหวะที่เงียบกว่าหรือตัวกรองสถานะที่แตกต่างกัน",
         "kanban_nudge_per_entity_throttle_help": "ข้ามการ์ดหากผู้รับที่กำหนดคนใดคนหนึ่งของมันถูก nudge แล้วภายในช่วงเวลาที่มีผลของพวกเขา ป้องกัน ping ซ้ำเมื่อหลายการ์ดมุ่งเป้าไปที่เอนทิตีเดียวกัน แนะนำให้เปิด",
         "kanban_nudge_priority_help": "ลำดับการเรียงเมื่อเลือกชุดถัดไปของการ์ดที่ค้าง 'priority_first' เลือกลำดับความสำคัญสูงกว่าก่อนที่เก่ากว่า; 'age_first' เลือกที่เก่าที่สุดไม่ว่าลำดับความสำคัญใด",
-        "kanban_nudge_statuses_help": "สถานะการ์ดใดที่กระตุ้น nudge ค่าเริ่มต้นคือ todo + in_progress + review + blocked การยกเว้น 'blocked' เป็นเรื่องปกติเมื่อการ์ดที่ถูกบล็อกรอผู้อื่นจริงๆ",},
+        "kanban_nudge_statuses_help": "สถานะการ์ดใดที่กระตุ้น nudge ค่าเริ่มต้นคือ todo + in_progress + review + blocked การยกเว้น 'blocked' เป็นเรื่องปกติเมื่อการ์ดที่ถูกบล็อกรอผู้อื่นจริงๆ",
+        "chat_outbox_queued_n": "อยู่ในคิว {n} รายการ",
+        "chat_outbox_retrying_n": "กำลังลองใหม่ {n} รายการ",
+        "chat_outbox_cancel_confirm": "ยกเลิกข้อความที่อยู่ในคิวนี้?",
+        "chat_outbox_failed_retry_q": "ลองส่งข้อความนี้อีกครั้ง?",
+        "chat_outbox_failed_delete_q": "ลบข้อความที่ล้มเหลวนี้?",
+},
 
 
 
@@ -3997169,7 +3997211,13 @@ const TRANSLATIONS = {
         "kanban_nudge_per_entity_section_help": "Cấu hình nhắc theo từng thực thể. Mỗi thực thể có thể ghi đè khoảng, trạng thái và chế độ dừng độc lập. Sử dụng khi một thực thể muốn nhịp độ yên tĩnh hơn hoặc bộ lọc trạng thái khác.",
         "kanban_nudge_per_entity_throttle_help": "Bỏ qua thẻ nếu bất kỳ người nhận được giao nào đã được nhắc trong khoảng hiệu dụng của họ. Ngăn ping trùng lặp khi nhiều thẻ nhắm đến cùng một thực thể. Khuyến nghị BẬT.",
         "kanban_nudge_priority_help": "Thứ tự sắp xếp khi chọn lô thẻ trì trệ tiếp theo. 'priority_first' chọn ưu tiên cao hơn trước cái cũ hơn; 'age_first' chọn cái cũ nhất bất kể ưu tiên.",
-        "kanban_nudge_statuses_help": "Trạng thái thẻ nào kích hoạt nhắc. Mặc định là todo + in_progress + review + blocked. Loại trừ 'blocked' phổ biến khi các thẻ bị chặn thực sự đang chờ người khác.",},
+        "kanban_nudge_statuses_help": "Trạng thái thẻ nào kích hoạt nhắc. Mặc định là todo + in_progress + review + blocked. Loại trừ 'blocked' phổ biến khi các thẻ bị chặn thực sự đang chờ người khác.",
+        "chat_outbox_queued_n": "{n} đang chờ",
+        "chat_outbox_retrying_n": "{n} đang thử lại",
+        "chat_outbox_cancel_confirm": "Hủy tin nhắn đang chờ này?",
+        "chat_outbox_failed_retry_q": "Gửi lại tin nhắn này?",
+        "chat_outbox_failed_delete_q": "Xóa tin nhắn thất bại này?",
+},
 
 
 
@@ -4523549,7 +4523597,13 @@ const TRANSLATIONS = {
         "kanban_nudge_per_entity_section_help": "Konfigurasi nudge per-entitas. Setiap entitas dapat mengganti interval, status, dan mode-berhenti secara independen. Digunakan saat satu entitas menginginkan irama lebih tenang atau filter status berbeda.",
         "kanban_nudge_per_entity_throttle_help": "Lewati kartu jika salah satu penerima yang ditugaskan sudah di-nudge dalam interval efektif mereka. Mencegah ping duplikat saat beberapa kartu menargetkan entitas yang sama. Direkomendasikan ON.",
         "kanban_nudge_priority_help": "Urutan pengurutan saat memilih batch kartu macet berikutnya. 'priority_first' memilih prioritas lebih tinggi sebelum yang lebih lama; 'age_first' memilih yang tertua tanpa memandang prioritas.",
-        "kanban_nudge_statuses_help": "Status kartu mana yang memicu nudge. Default adalah todo + in_progress + review + blocked. Mengecualikan 'blocked' umum saat kartu yang diblokir benar-benar menunggu orang lain.",},
+        "kanban_nudge_statuses_help": "Status kartu mana yang memicu nudge. Default adalah todo + in_progress + review + blocked. Mengecualikan 'blocked' umum saat kartu yang diblokir benar-benar menunggu orang lain.",
+        "chat_outbox_queued_n": "{n} dalam antrian",
+        "chat_outbox_retrying_n": "{n} mencoba lagi",
+        "chat_outbox_cancel_confirm": "Batalkan pesan dalam antrian ini?",
+        "chat_outbox_failed_retry_q": "Coba kirim ulang pesan ini?",
+        "chat_outbox_failed_delete_q": "Hapus pesan yang gagal ini?",
+},
 
 
 
@@ -5048649,7 +5048703,13 @@ const TRANSLATIONS = {
         "kanban_nudge_per_entity_section_help": "Configuration de nudge par entité. Chaque entité peut remplacer indépendamment l'intervalle, les statuts et le mode d'arrêt. Utilisé lorsqu'une entité veut une cadence plus calme ou des filtres de statut différents.",
         "kanban_nudge_per_entity_throttle_help": "Ignorer une carte si l'un de ses destinataires assignés a déjà été nudge dans son intervalle effectif. Empêche les pings dupliqués lorsque plusieurs cartes ciblent la même entité. Recommandé ACTIVÉ.",
         "kanban_nudge_priority_help": "Ordre de tri lors de la sélection du prochain lot de cartes bloquées. 'priority_first' choisit une priorité plus élevée avant les plus anciennes ; 'age_first' choisit les plus anciennes indépendamment de la priorité.",
-        "kanban_nudge_statuses_help": "Quels statuts de carte déclenchent des nudges. Par défaut, c'est todo + in_progress + review + blocked. Exclure 'blocked' est courant lorsque les cartes bloquées attendent vraiment d'autres.",},
+        "kanban_nudge_statuses_help": "Quels statuts de carte déclenchent des nudges. Par défaut, c'est todo + in_progress + review + blocked. Exclure 'blocked' est courant lorsque les cartes bloquées attendent vraiment d'autres.",
+        "chat_outbox_queued_n": "{n} en attente",
+        "chat_outbox_retrying_n": "{n} en cours de réessai",
+        "chat_outbox_cancel_confirm": "Annuler ce message en attente ?",
+        "chat_outbox_failed_retry_q": "Réessayer d'envoyer ce message ?",
+        "chat_outbox_failed_delete_q": "Supprimer ce message échoué ?",
+},
 
 
 
@@ -5566223,6 +5566283,12 @@ const TRANSLATIONS = {
         "kanban_nudge_per_entity_throttle_help": "Omitir una tarjeta si alguno de sus destinatarios asignados ya fue nudgeado dentro de su intervalo efectivo. Previene pings duplicados cuando varias tarjetas apuntan a la misma entidad. Recomendado ACTIVADO.",
         "kanban_nudge_priority_help": "Orden de clasificación al elegir el próximo lote de tarjetas estancadas. 'priority_first' elige mayor prioridad antes que las más antiguas; 'age_first' elige las más antiguas independientemente de la prioridad.",
         "kanban_nudge_statuses_help": "Qué estados de tarjeta activan nudges. Predeterminado es todo + in_progress + review + blocked. Excluir 'blocked' es común cuando las tarjetas bloqueadas realmente esperan a otros.",
+
+        "chat_outbox_queued_n": "{n} en cola",
+        "chat_outbox_retrying_n": "{n} reintentando",
+        "chat_outbox_cancel_confirm": "¿Cancelar este mensaje en cola?",
+        "chat_outbox_failed_retry_q": "¿Reintentar enviar este mensaje?",
+        "chat_outbox_failed_delete_q": "¿Eliminar este mensaje fallido?",
 },
 
 
@@ -6103117,7 +6103183,13 @@ const TRANSLATIONS = {
         "kanban_nudge_per_entity_section_help": "Pro-Entität-Nudge-Konfiguration. Jede Entität kann Intervall, Status und Stoppmodus unabhängig überschreiben. Wird verwendet, wenn eine Entität eine ruhigere Kadenz oder unterschiedliche Statusfilter wünscht.",
         "kanban_nudge_per_entity_throttle_help": "Eine Karte überspringen, wenn einer ihrer zugewiesenen Empfänger bereits innerhalb seines effektiven Intervalls genudgt wurde. Verhindert doppelte Pings, wenn mehrere Karten dieselbe Entität anvisieren. EIN empfohlen.",
         "kanban_nudge_priority_help": "Sortierreihenfolge bei der Auswahl der nächsten Charge von Stockungskarten. 'priority_first' wählt höhere Priorität vor älteren; 'age_first' wählt die ältesten unabhängig von der Priorität.",
-        "kanban_nudge_statuses_help": "Welche Kartenstatus Nudges auslösen. Standard ist todo + in_progress + review + blocked. Das Ausschließen von 'blocked' ist üblich, wenn blockierte Karten wirklich auf andere warten.",    },
+        "kanban_nudge_statuses_help": "Welche Kartenstatus Nudges auslösen. Standard ist todo + in_progress + review + blocked. Das Ausschließen von 'blocked' ist üblich, wenn blockierte Karten wirklich auf andere warten.",    
+        "chat_outbox_queued_n": "{n} in der Warteschlange",
+        "chat_outbox_retrying_n": "{n} werden erneut versucht",
+        "chat_outbox_cancel_confirm": "Diese Nachricht in der Warteschlange abbrechen?",
+        "chat_outbox_failed_retry_q": "Diese Nachricht erneut senden?",
+        "chat_outbox_failed_delete_q": "Diese fehlgeschlagene Nachricht löschen?",
+},
     pt: {
         "transition_loading": "A carregar…",
         "dashboard_usage_widget_title": "Claude Code / Codex usage",
@@ -6108500,6 +6108572,12 @@ const TRANSLATIONS = {
         "kanban_nudge_per_entity_throttle_help": "Pule um cartão se algum de seus destinatários atribuídos já foi nudge dentro de seu intervalo efetivo. Evita pings duplicados quando vários cartões visam a mesma entidade. Recomendado LIGADO.",
         "kanban_nudge_priority_help": "Ordem de classificação ao escolher o próximo lote de cartões parados. 'priority_first' escolhe maior prioridade antes dos mais antigos; 'age_first' escolhe os mais antigos independentemente da prioridade.",
         "kanban_nudge_statuses_help": "Quais status de cartão acionam nudges. Padrão é todo + in_progress + review + blocked. Excluir 'blocked' é comum quando cartões bloqueados realmente esperam por outros.",
+
+        "chat_outbox_queued_n": "{n} na fila",
+        "chat_outbox_retrying_n": "{n} tentando novamente",
+        "chat_outbox_cancel_confirm": "Cancelar esta mensagem na fila?",
+        "chat_outbox_failed_retry_q": "Tentar enviar esta mensagem novamente?",
+        "chat_outbox_failed_delete_q": "Excluir esta mensagem com falha?",
 },
 
 
@@ -6637263,7 +6637341,13 @@ const TRANSLATIONS = {
         "kanban_nudge_per_entity_section_help": "Konfigurasi dorongan setiap entiti. Setiap entiti boleh mengatasi selang, status dan mod-henti secara bebas. Digunakan apabila satu entiti mahukan irama lebih senyap atau penapis status berbeza.",
         "kanban_nudge_per_entity_throttle_help": "Langkau kad jika mana-mana penerima yang ditugaskan sudah didorong dalam selang berkesan mereka. Mengelakkan ping pendua apabila beberapa kad menyasarkan entiti yang sama. Disyorkan HIDUP.",
         "kanban_nudge_priority_help": "Susunan isihan apabila memilih kumpulan kad terbantut berikutnya. 'priority_first' memilih keutamaan lebih tinggi sebelum yang lebih lama; 'age_first' memilih yang tertua tanpa mengira keutamaan.",
-        "kanban_nudge_statuses_help": "Status kad mana yang mencetuskan dorongan. Lalai ialah todo + in_progress + review + blocked. Mengecualikan 'blocked' adalah biasa apabila kad disekat benar-benar menunggu orang lain.",},
+        "kanban_nudge_statuses_help": "Status kad mana yang mencetuskan dorongan. Lalai ialah todo + in_progress + review + blocked. Mengecualikan 'blocked' adalah biasa apabila kad disekat benar-benar menunggu orang lain.",
+        "chat_outbox_queued_n": "{n} dalam baris gilir",
+        "chat_outbox_retrying_n": "{n} sedang cuba semula",
+        "chat_outbox_cancel_confirm": "Batalkan mesej dalam baris gilir ini?",
+        "chat_outbox_failed_retry_q": "Cuba hantar semula mesej ini?",
+        "chat_outbox_failed_delete_q": "Padam mesej yang gagal ini?",
+},
 
 
 
@@ -7196483,6 +7196567,12 @@ const TRANSLATIONS = {
         "kanban_nudge_per_entity_throttle_help": "यदि इसके किसी भी असाइन किए गए प्राप्तकर्ता को उनके प्रभावी अंतराल के भीतर पहले से ही nudge किया गया है तो कार्ड छोड़ें। जब कई कार्ड एक ही इकाई को लक्षित करते हैं तो डुप्लिकेट पिंग को रोकता है। चालू अनुशंसित।",
         "kanban_nudge_priority_help": "रुके हुए कार्डों के अगले बैच को चुनते समय सॉर्ट ऑर्डर। 'priority_first' पुराने से पहले उच्च प्राथमिकता चुनता है; 'age_first' प्राथमिकता की परवाह किए बिना सबसे पुराने को चुनता है।",
         "kanban_nudge_statuses_help": "कौन सी कार्ड स्थितियां nudges ट्रिगर करती हैं। डिफ़ॉल्ट todo + in_progress + review + blocked है। 'blocked' को छोड़ना सामान्य है जब अवरुद्ध कार्ड वास्तव में दूसरों की प्रतीक्षा कर रहे हों।",
+
+        "chat_outbox_queued_n": "{n} कतार में",
+        "chat_outbox_retrying_n": "{n} पुनः प्रयास हो रहा है",
+        "chat_outbox_cancel_confirm": "इस कतारबद्ध संदेश को रद्द करें?",
+        "chat_outbox_failed_retry_q": "इस संदेश को पुनः भेजें?",
+        "chat_outbox_failed_delete_q": "इस असफल संदेश को हटाएं?",
 },
 
 
@@ -7744829,6 +7744919,12 @@ const TRANSLATIONS = {
         "kanban_nudge_per_entity_throttle_help": "تخطى البطاقة إذا تم بالفعل nudge أي من المستلمين المعينين لها ضمن فاصلهم الفعال. يمنع pings المكررة عندما تستهدف بطاقات متعددة نفس الكيان. يُوصى بالتشغيل.",
         "kanban_nudge_priority_help": "ترتيب الفرز عند اختيار الدفعة التالية من البطاقات المتوقفة. 'priority_first' يختار الأولوية الأعلى قبل الأقدم؛ 'age_first' يختار الأقدم بغض النظر عن الأولوية.",
         "kanban_nudge_statuses_help": "حالات البطاقة التي تؤدي إلى nudges. الافتراضي هو todo + in_progress + review + blocked. استبعاد 'blocked' شائع عندما تنتظر البطاقات المحجوبة الآخرين فعلاً.",
+
+        "chat_outbox_queued_n": "{n} في الانتظار",
+        "chat_outbox_retrying_n": "{n} قيد إعادة المحاولة",
+        "chat_outbox_cancel_confirm": "إلغاء هذه الرسالة في الانتظار؟",
+        "chat_outbox_failed_retry_q": "إعادة محاولة إرسال هذه الرسالة؟",
+        "chat_outbox_failed_delete_q": "حذف هذه الرسالة الفاشلة؟",
 }
 
 

--- a/backend/tests/jest/outbox-ui.test.js
+++ b/backend/tests/jest/outbox-ui.test.js
@@ -1,0 +1,381 @@
+/**
+ * Outbox UI helpers — banner + bubble state classes + tap handlers.
+ *
+ * Card: card_751775f0435f3a17e669d12a.
+ * Spec: docs/offline-delivery-queue-spec.md (acceptance #4 + #5).
+ *
+ * jest.config.js uses testEnvironment:'node' with no jsdom, so we hand-roll a
+ * minimal DOM stub that covers the surface outbox-ui.js touches: classList,
+ * setAttribute, querySelector('[data-outbox-key=...]'), appendChild,
+ * removeChild, addEventListener('click', ...), .hidden, .textContent. The
+ * stub is deliberately small — enough to drive the helpers, not a general
+ * DOM emulator. If outbox-ui.js grows to need more APIs, extend the stub
+ * before reaching for the real jsdom dep.
+ */
+'use strict';
+
+const path = require('path');
+
+// ── Minimal DOM stub ──────────────────────────────────────────────────────
+function makeStub() {
+    const allElements = [];
+
+    function ClassList(el) {
+        this._el = el;
+    }
+    ClassList.prototype.contains = function (c) {
+        const cn = this._el.className || '';
+        return cn.split(/\s+/).indexOf(c) !== -1;
+    };
+    ClassList.prototype.add = function (c) {
+        const set = new Set((this._el.className || '').split(/\s+/).filter(Boolean));
+        set.add(c);
+        this._el.className = Array.from(set).join(' ');
+    };
+    ClassList.prototype.remove = function (c) {
+        const set = new Set((this._el.className || '').split(/\s+/).filter(Boolean));
+        set.delete(c);
+        this._el.className = Array.from(set).join(' ');
+    };
+
+    function Element(tag) {
+        this.tagName = String(tag || '').toUpperCase();
+        this.children = [];
+        this.parentNode = null;
+        this.attrs = {};
+        this.className = '';
+        this.hidden = false;
+        this.textContent = '';
+        this._listeners = {};
+        this.classList = new ClassList(this);
+        this.ownerDocument = doc;
+        allElements.push(this);
+    }
+    Element.prototype.appendChild = function (child) {
+        child.parentNode = this;
+        this.children.push(child);
+        return child;
+    };
+    Element.prototype.removeChild = function (child) {
+        const idx = this.children.indexOf(child);
+        if (idx >= 0) {
+            this.children.splice(idx, 1);
+            child.parentNode = null;
+        }
+        return child;
+    };
+    Element.prototype.setAttribute = function (k, v) {
+        this.attrs[k] = String(v);
+    };
+    Element.prototype.getAttribute = function (k) {
+        return Object.prototype.hasOwnProperty.call(this.attrs, k) ? this.attrs[k] : null;
+    };
+    Element.prototype.addEventListener = function (evt, cb) {
+        if (!this._listeners[evt]) this._listeners[evt] = [];
+        this._listeners[evt].push(cb);
+    };
+    Element.prototype.removeEventListener = function (evt, cb) {
+        const arr = this._listeners[evt] || [];
+        const idx = arr.indexOf(cb);
+        if (idx >= 0) arr.splice(idx, 1);
+    };
+    Element.prototype.dispatchEvent = function (evt) {
+        const arr = this._listeners[evt.type] || [];
+        for (const cb of arr.slice()) cb(evt);
+    };
+    Element.prototype.querySelector = function (selector) {
+        // Only [data-outbox-key="..."] is exercised by outbox-ui.js.
+        const m = selector.match(/^\[data-outbox-key="([^"]+)"\]$/);
+        if (!m) return null;
+        const key = m[1].replace(/\\(.)/g, '$1');
+        // Walk every element we have created and check attr (depth-first via allElements is fine).
+        for (const el of allElements) {
+            if (el.attrs && el.attrs['data-outbox-key'] === key) return el;
+        }
+        return null;
+    };
+
+    const doc = {
+        createElement: function (tag) { return new Element(tag); },
+    };
+    return { doc, Element };
+}
+
+// ── Load outbox-ui.js fresh per test ──────────────────────────────────────
+function loadOutboxUI() {
+    const p = path.join(__dirname, '..', '..', 'public', 'portal', 'shared', 'outbox-ui.js');
+    delete require.cache[require.resolve(p)];
+    return require(p);
+}
+
+describe('outbox-ui — banner visibility', () => {
+    let ui, doc;
+    beforeEach(() => {
+        ui = loadOutboxUI();
+        ({ doc } = makeStub());
+    });
+
+    test('hidden + empty text when 0 queued + 0 retrying', () => {
+        const banner = doc.createElement('div');
+        const text = doc.createElement('span');
+        banner.hidden = false;
+        text.textContent = 'stale';
+        ui.updateBanner(banner, text, { by: { queued: 0, retrying: 0, sent: 5, failed: 1 } });
+        expect(banner.hidden).toBe(true);
+        expect(text.textContent).toBe('');
+    });
+
+    test('shown with "N queued" when only queued > 0', () => {
+        const banner = doc.createElement('div');
+        const text = doc.createElement('span');
+        banner.hidden = true;
+        ui.updateBanner(banner, text, { by: { queued: 3, retrying: 0 } });
+        expect(banner.hidden).toBe(false);
+        expect(text.textContent).toBe('3 queued');
+    });
+
+    test('shown with both segments joined by · when both > 0', () => {
+        const banner = doc.createElement('div');
+        const text = doc.createElement('span');
+        ui.updateBanner(banner, text, { by: { queued: 2, retrying: 1 } });
+        expect(banner.hidden).toBe(false);
+        expect(text.textContent).toBe('2 queued · 1 retrying');
+    });
+
+    test('falls through to i18n callback when provided', () => {
+        const banner = doc.createElement('div');
+        const text = doc.createElement('span');
+        const t = (key) => {
+            if (key === 'chat_outbox_queued_n') return '{n} 排隊中';
+            if (key === 'chat_outbox_retrying_n') return '{n} 重試中';
+            return key;
+        };
+        ui.updateBanner(banner, text, { by: { queued: 4, retrying: 2 } }, t);
+        expect(text.textContent).toBe('4 排隊中 · 2 重試中');
+    });
+
+    test('null banner is a no-op (does not throw)', () => {
+        expect(() => ui.updateBanner(null, null, { by: { queued: 1, retrying: 0 } })).not.toThrow();
+    });
+});
+
+describe('outbox-ui — bubble lifecycle + state classes', () => {
+    let ui, doc, container;
+    beforeEach(() => {
+        ui = loadOutboxUI();
+        ({ doc } = makeStub());
+        container = doc.createElement('div');
+    });
+
+    test('renderQueuedBubble appends bubble with queued class + data-outbox-key + text', () => {
+        const el = ui.renderQueuedBubble(container, { idempotencyKey: 'k-1', text: 'hello' });
+        expect(el).not.toBeNull();
+        expect(container.children).toContain(el);
+        expect(el.getAttribute('data-outbox-key')).toBe('k-1');
+        expect(el.classList.contains('msg-outbox')).toBe(true);
+        expect(el.classList.contains('msg-outbox-queued')).toBe(true);
+        // bubble child + spinner + warn (3 children)
+        expect(el.children.length).toBe(3);
+        expect(el.children[0].className).toBe('chat-bubble');
+        expect(el.children[0].textContent).toBe('hello');
+    });
+
+    test('renderQueuedBubble is idempotent — second call with same key does not double-append', () => {
+        const first = ui.renderQueuedBubble(container, { idempotencyKey: 'k-2', text: 'x' });
+        const second = ui.renderQueuedBubble(container, { idempotencyKey: 'k-2', text: 'x' });
+        expect(second).toBe(first);
+        expect(container.children.length).toBe(1);
+    });
+
+    test('setBubbleState flips queued → retrying → failed (4-state transition)', () => {
+        ui.renderQueuedBubble(container, { idempotencyKey: 'k-3', text: 't' });
+        ui.setBubbleState(container, 'k-3', 'retrying');
+        const el = ui.findBubble(container, 'k-3');
+        expect(el.classList.contains('msg-outbox-queued')).toBe(false);
+        expect(el.classList.contains('msg-outbox-retrying')).toBe(true);
+
+        ui.setBubbleState(container, 'k-3', 'failed');
+        expect(el.classList.contains('msg-outbox-retrying')).toBe(false);
+        expect(el.classList.contains('msg-outbox-failed')).toBe(true);
+
+        ui.setBubbleState(container, 'k-3', 'sent');
+        expect(el.classList.contains('msg-outbox-failed')).toBe(false);
+        expect(el.classList.contains('msg-outbox-sent')).toBe(true);
+    });
+
+    test('setBubbleState ignores unknown state', () => {
+        ui.renderQueuedBubble(container, { idempotencyKey: 'k-4', text: 't' });
+        ui.setBubbleState(container, 'k-4', 'nonsense');
+        const el = ui.findBubble(container, 'k-4');
+        expect(el.classList.contains('msg-outbox-queued')).toBe(true);
+        expect(el.classList.contains('msg-outbox-nonsense')).toBe(false);
+    });
+
+    test('removeBubble drops the element from the container', () => {
+        ui.renderQueuedBubble(container, { idempotencyKey: 'k-5', text: 't' });
+        expect(container.children.length).toBe(1);
+        const ok = ui.removeBubble(container, 'k-5');
+        expect(ok).toBe(true);
+        expect(container.children.length).toBe(0);
+    });
+
+    test('removeBubble returns false when key not found', () => {
+        expect(ui.removeBubble(container, 'no-such-key')).toBe(false);
+    });
+});
+
+describe('outbox-ui — tap handlers', () => {
+    let ui, doc, container;
+    beforeEach(() => {
+        ui = loadOutboxUI();
+        ({ doc } = makeStub());
+        container = doc.createElement('div');
+    });
+
+    function fireClick(target) {
+        let prevented = false, stopped = false;
+        const evt = {
+            type: 'click',
+            target,
+            preventDefault() { prevented = true; },
+            stopPropagation() { stopped = true; },
+        };
+        container.dispatchEvent(evt);
+        return { prevented, stopped };
+    }
+
+    test('clicking queued bubble triggers onCancel with the idempotencyKey', () => {
+        const onCancel = jest.fn();
+        const onFailedMenu = jest.fn();
+        ui.attachTapHandlers(container, { onCancel, onFailedMenu });
+        const el = ui.renderQueuedBubble(container, { idempotencyKey: 'kq', text: 'q' });
+        fireClick(el);
+        expect(onCancel).toHaveBeenCalledWith('kq', el);
+        expect(onFailedMenu).not.toHaveBeenCalled();
+    });
+
+    test('clicking retrying bubble triggers onCancel', () => {
+        const onCancel = jest.fn();
+        const onFailedMenu = jest.fn();
+        ui.attachTapHandlers(container, { onCancel, onFailedMenu });
+        ui.renderQueuedBubble(container, { idempotencyKey: 'kr', text: 'r' });
+        ui.setBubbleState(container, 'kr', 'retrying');
+        const el = ui.findBubble(container, 'kr');
+        fireClick(el);
+        expect(onCancel).toHaveBeenCalledWith('kr', el);
+    });
+
+    test('clicking failed bubble triggers onFailedMenu, not onCancel', () => {
+        const onCancel = jest.fn();
+        const onFailedMenu = jest.fn();
+        ui.attachTapHandlers(container, { onCancel, onFailedMenu });
+        ui.renderQueuedBubble(container, { idempotencyKey: 'kf', text: 'f' });
+        ui.setBubbleState(container, 'kf', 'failed');
+        const el = ui.findBubble(container, 'kf');
+        fireClick(el);
+        expect(onFailedMenu).toHaveBeenCalledWith('kf', el);
+        expect(onCancel).not.toHaveBeenCalled();
+    });
+
+    test('clicking sent bubble triggers neither handler', () => {
+        const onCancel = jest.fn();
+        const onFailedMenu = jest.fn();
+        ui.attachTapHandlers(container, { onCancel, onFailedMenu });
+        ui.renderQueuedBubble(container, { idempotencyKey: 'ks', text: 's' });
+        ui.setBubbleState(container, 'ks', 'sent');
+        const el = ui.findBubble(container, 'ks');
+        fireClick(el);
+        expect(onCancel).not.toHaveBeenCalled();
+        expect(onFailedMenu).not.toHaveBeenCalled();
+    });
+
+    test('clicking a child of the bubble walks up to the outbox container', () => {
+        const onCancel = jest.fn();
+        ui.attachTapHandlers(container, { onCancel });
+        const el = ui.renderQueuedBubble(container, { idempotencyKey: 'kc', text: 'c' });
+        // Click the inner chat-bubble — handler must walk up to outbox parent.
+        fireClick(el.children[0]);
+        expect(onCancel).toHaveBeenCalledWith('kc', el);
+    });
+
+    test('detach function unbinds the click listener', () => {
+        const onCancel = jest.fn();
+        const detach = ui.attachTapHandlers(container, { onCancel });
+        const el = ui.renderQueuedBubble(container, { idempotencyKey: 'kd', text: 'd' });
+        detach();
+        fireClick(el);
+        expect(onCancel).not.toHaveBeenCalled();
+    });
+});
+
+describe('outbox-ui — chat.html integration contract', () => {
+    // The bubble lifecycle is wired into chat.html at the enqueue/markRetrying
+    // /markSent/markFailed call sites. Lock the surface so a future drift
+    // (someone removes the UI calls but keeps the outbox.js calls) leaves a
+    // regression fingerprint.
+    const fs = require('fs');
+    const chatHtml = fs.readFileSync(
+        path.join(__dirname, '..', '..', 'public', 'portal', 'chat.html'),
+        'utf8'
+    );
+
+    test('outbox-ui.js is loaded as a portal script', () => {
+        expect(chatHtml).toMatch(/<script src="shared\/outbox-ui\.js"><\/script>/);
+    });
+
+    test('outbox banner element + text span are present', () => {
+        expect(chatHtml).toMatch(/id="outboxBanner"/);
+        expect(chatHtml).toMatch(/id="outboxBannerText"/);
+    });
+
+    test('enqueue path calls renderQueuedBubble + setBubbleState retrying', () => {
+        expect(chatHtml).toMatch(/EclawOutboxUI\.renderQueuedBubble\(/);
+        expect(chatHtml).toMatch(/EclawOutboxUI\.setBubbleState\([^,]+,\s*__idempotencyKey,\s*['"]retrying['"]\)/);
+    });
+
+    test('success path removes the inline bubble', () => {
+        expect(chatHtml).toMatch(/EclawOutboxUI\.removeBubble\([^,]+,\s*__idempotencyKey\)/);
+    });
+
+    test('failure path flips bubble to failed', () => {
+        expect(chatHtml).toMatch(/EclawOutboxUI\.setBubbleState\([^,]+,\s*__idempotencyKey,\s*['"]failed['"]\)/);
+    });
+
+    test('tap handlers are attached on init', () => {
+        expect(chatHtml).toMatch(/EclawOutboxUI\.attachTapHandlers\(\s*c\s*,\s*\{\s*onCancel:\s*_onOutboxCancel\s*,\s*onFailedMenu:\s*_onOutboxFailedMenu\s*\}\)/);
+    });
+
+    test('banner updater uses EclawOutboxUI.updateBanner with i18n callback', () => {
+        expect(chatHtml).toMatch(/EclawOutboxUI\.updateBanner\(/);
+        expect(chatHtml).toMatch(/i18n\.t\(k\)/);
+    });
+
+    test('cancel handler removes outbox entry + bubble + refreshes banner', () => {
+        expect(chatHtml).toMatch(/EclawOutbox\.remove\(key\)/);
+        expect(chatHtml).toMatch(/EclawOutboxUI\.removeBubble\(c,\s*key\)/);
+        expect(chatHtml).toMatch(/_updateOutboxBanner\(\)/);
+    });
+
+    test('failed retry path re-enqueues with fresh idempotencyKey (snapshot lookup)', () => {
+        expect(chatHtml).toMatch(/EclawOutbox\.snapshot\(\)/);
+        expect(chatHtml).toMatch(/EclawOutbox\.enqueue\(entry\.payload\)/);
+    });
+});
+
+describe('outbox-ui — i18n keys exist in EN locale', () => {
+    const fs = require('fs');
+    const i18nJs = fs.readFileSync(
+        path.join(__dirname, '..', '..', 'public', 'shared', 'i18n.js'),
+        'utf8'
+    );
+    const NEEDED = [
+        'chat_outbox_queued_n',
+        'chat_outbox_retrying_n',
+        'chat_outbox_cancel_confirm',
+        'chat_outbox_failed_retry_q',
+        'chat_outbox_failed_delete_q',
+    ];
+    test.each(NEEDED)('%s is declared in i18n.js', (key) => {
+        expect(i18nJs).toMatch(new RegExp('"' + key + '":'));
+    });
+});


### PR DESCRIPTION
## Summary

Completes spec acceptance **#4 (bubble states)** and **#5 (queue-count banner)** from `docs/offline-delivery-queue-spec.md`. PR #3270 wired `window.EclawOutbox.{enqueue, markRetrying, markSent, markFailed}` into chat.html, but the user saw no visual feedback — this PR adds:

1. **Banner** at top of `#chatMessages`: hidden when queued+retrying=0, otherwise shows `📤 N queued · M retrying`. Updates on outbox state change + every 5s; data source `EclawOutbox.summary()`.
2. **Bubble state classes**: `queued` = light-gray + spinner / `retrying` = yellow-tinted + spinner / `sent` = removed (replaced by real server message via `loadMessages()`) / `failed` = red-bordered + ⚠️.
3. **Tap handlers**: `queued`/`retrying` bubble → confirm cancel (drops outbox entry + bubble). `failed` bubble → retry (re-enqueue same payload with fresh idempotencyKey) or delete.

Card: **`card_751775f0435f3a17e669d12a`**

## Changes

- `backend/public/portal/shared/outbox-ui.js` (new, 160 LOC): pure DOM helpers — `updateBanner` / `renderQueuedBubble` / `setBubbleState` / `removeBubble` / `attachTapHandlers`. Keeps chat.html slim and the helpers unit-testable without booting the page.
- `backend/public/portal/chat.html`: loads outbox-ui.js, replaces inline banner updater with module call, renders inline bubble at enqueue, flips state class on markRetrying / markSent / markFailed, attaches delegated click handler. New CSS for the 4 bubble states + dark mode parity.
- `backend/public/shared/i18n.js`: **5 new keys** (`chat_outbox_queued_n`, `chat_outbox_retrying_n`, `chat_outbox_cancel_confirm`, `chat_outbox_failed_retry_q`, `chat_outbox_failed_delete_q`) inserted via AST tool into **all 16 locales** (en is meaning source; 15 other locales translated).
- `backend/tests/jest/outbox-ui.test.js` (new): 31 cases covering banner visibility matrix, 4-state bubble class transitions, idempotent re-render, tap handler routing (queued/retrying → onCancel, failed → onFailedMenu, sent → no-op), bubble-walk-up from child clicks, detach unbinding; plus chat.html integration contract regex tests + i18n key declaration checks.

## Verification

- **Jest**: `npm test` → 269/269 suites + 3724/3724 tests green
- **ESLint**: `npm run lint` → 0 new warnings (4 pre-existing)
- **i18n strict**: `node scripts/i18n-check.js` → all referenced keys resolve in EN

E2E via Playwright `route.abort()` + screenshot diff is left for #2 review stage (U101 has no MCP authorization — bridge keyboard authorization is documented as broken).

## Test plan

- [x] Jest unit tests for outbox-ui.js helpers (banner / bubble class transitions / tap handlers)
- [x] Static contract tests pin the chat.html wire points
- [x] Static i18n key declaration tests
- [ ] Manual E2E in browser: offline + send → queued bubble + banner appears; reconnect → bubble removed + banner clears; force fail → failed bubble + tap → retry/delete menu (reviewer to verify)

🤖 Generated with [Claude Code](https://claude.com/claude-code)