### PR TITLE
fix(security): enforce deviceSecret on /api/client/speak

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -11241,6 +11241,16 @@ app.post('/api/client/speak', idempotencyMiddleware, clientSpeakDedupeMiddleware
         return res.status(404).json({ success: false, message: "Device not found" });
     }
 
+    // deviceId alone is NOT a credential — it appears in URLs, screenshots and
+    // logs. Without this gate anyone holding a deviceId could impersonate the
+    // device owner and push commands to its bots (card_b0fbccf25252518e7044c47c).
+    if (!deviceSecret) {
+        return res.status(401).json({ success: false, message: "deviceSecret required" });
+    }
+    if (!safeEqual(device.deviceSecret, deviceSecret)) {
+        return res.status(403).json({ success: false, message: "Invalid deviceSecret for this device" });
+    }
+
     // Developer exemption: admin-owned devices with valid deviceSecret skip Gatekeeper First Lock
     const isDeveloper = deviceSecret && safeEqual(device.deviceSecret, deviceSecret) && developerDeviceIds.has(deviceId);
     if (deviceSecret) {


### PR DESCRIPTION
## Card
card_b0fbccf25252518e7044c47c — [Security/P0] /api/client/speak 無 deviceSecret 驗證

## Vulnerability (prod-verified tonight)
`POST /api/client/speak` with **no** deviceSecret — or a **wrong** one — returned `200 {"success":true,"message":"Sent to 1 entity(s)"}` and actually pushed the message to the device's bots. deviceId is not a secret (URLs, screenshots, logs), so anyone holding one could impersonate the device owner and issue commands to its bots. Found by the multi-tenant E2E rows 5-6 work (card_25021d74): binding entities to the BROADCAST_TEST device flipped the auth-missing path from fast-4xx (no entities) to full delivery.

## Fix
Mandatory gate right after device lookup: missing → 401, mismatch → 403 (timing-safe `safeEqual`, same pattern as `/api/device/status`). Brings the user-side path to parity with `/api/transform` which already enforces botSecret.

## Caller audit (no breakage)
- Android `MessageActivity`: sends `deviceManager.deviceSecret` ✓
- Portal `chat.html` (3 call sites + outbox replay): apiCall payloads include deviceSecret ✓
- `info.html`: documentation curl example only, already shows deviceSecret ✓

## Tests
- jest client-speak-payload-dedupe 11/11, cross-speak ×3 suites 38/38, `node --check` clean
- Post-deploy: curl ×3 (missing→401, wrong→403, correct→200) + existing multi-tenant-e2e row-6 auth test flips green — will verify and attach to card before close

🤖 Generated with [Claude Code](https://claude.com/claude-code)