### PR TITLE
feat(auth): sliding session refresh + 401 reason codes — OODA-R Phase 2 #6

### DIFF
--- a/backend/auth.js
+++ b/backend/auth.js
@@ -150,12 +150,37 @@ module.exports = function(devices, getOrCreateDevice, serverLog) {
         );
     }
 
-    function verifyToken(token) {
+    // 30s clock tolerance: device clocks (esp. mobile) drift; without this a
+    // slightly-fast client gets 401 token_expired moments before real expiry.
+    const JWT_CLOCK_TOLERANCE_S = 30;
+
+    // Detailed verify: callers that surface 401s need to tell an expired
+    // session (user-fixable: re-login / refresh) from a tampered token.
+    function verifyTokenDetailed(token) {
         try {
-            return jwt.verify(token, JWT_SECRET, { algorithms: ['HS256'] });
-        } catch {
-            return null;
+            const decoded = jwt.verify(token, JWT_SECRET, {
+                algorithms: ['HS256'],
+                clockTolerance: JWT_CLOCK_TOLERANCE_S,
+            });
+            return { decoded, reason: null };
+        } catch (err) {
+            const reason = err && err.name === 'TokenExpiredError' ? 'token_expired' : 'token_invalid';
+            return { decoded: null, reason };
         }
+    }
+
+    function verifyToken(token) {
+        return verifyTokenDetailed(token).decoded;
+    }
+
+    function setSessionCookie(res, token) {
+        res.cookie('eclaw_session', token, {
+            httpOnly: true,
+            secure: process.env.NODE_ENV === 'production',
+            sameSite: 'lax',
+            maxAge: 7 * 24 * 60 * 60 * 1000,
+            path: '/'
+        });
     }
 
     // Extract bearer token from Authorization header (mobile clients can't carry httpOnly cookies)
@@ -166,15 +191,19 @@ module.exports = function(devices, getOrCreateDevice, serverLog) {
         return m ? m[1] : null;
     }
 
-    // Middleware: extract user from cookie OR Authorization: Bearer header
+    // Middleware: extract user from cookie OR Authorization: Bearer header.
+    // 401 responses carry a machine-readable `reason` (no_token /
+    // token_expired / token_invalid) so clients can show "session expired,
+    // please log in again" instead of a silent kick (pain 4).
     function authMiddleware(req, res, next) {
         const token = (req.cookies && req.cookies.eclaw_session) || extractBearer(req);
         if (!token) {
-            return res.status(401).json({ success: false, error: 'Not authenticated' });
+            return res.status(401).json({ success: false, error: 'Not authenticated', reason: 'no_token' });
         }
-        const decoded = verifyToken(token);
+        const { decoded, reason } = verifyTokenDetailed(token);
         if (!decoded) {
-            return res.status(401).json({ success: false, error: 'Invalid or expired session' });
+            const message = reason === 'token_expired' ? 'Session expired' : 'Invalid session';
+            return res.status(401).json({ success: false, error: message, reason });
         }
         // Enrich with deviceSecret from in-memory devices map (no longer stored in JWT)
         if (decoded.deviceId && devices[decoded.deviceId]) {
@@ -527,6 +556,32 @@ module.exports = function(devices, getOrCreateDevice, serverLog) {
     });
 
     // ============================================
+    // POST /refresh — sliding-session renewal (OODA-R Phase 2 #6, pain 4)
+    // Requires a CURRENTLY-VALID token (cookie or bearer); mints a fresh
+    // 7-day JWT and re-sets the cookie. An expired token cannot refresh
+    // itself — that 401 carries reason:token_expired so the client shows a
+    // re-login prompt instead of silently kicking. Clients are expected to
+    // call this proactively before expiry (portal: session-keeper in
+    // auth.js with a single-flight mutex against thundering herd).
+    // ============================================
+    router.post('/refresh', authMiddleware, (req, res) => {
+        const fresh = signToken({ id: req.user.userId, device_id: req.user.deviceId });
+        setSessionCookie(res, fresh);
+        const decoded = jwt.decode(fresh);
+        audit('info', 'auth', 'Session refreshed', {
+            userId: req.user.userId, deviceId: req.user.deviceId, ipAddress: req.ip,
+            action: 'refresh', resource: 'session', result: 'success'
+        });
+        res.json({
+            success: true,
+            // Bearer clients (mobile) can't read the httpOnly cookie — return
+            // the token in-body for them; browser clients just use the cookie.
+            token: fresh,
+            expiresAt: decoded && decoded.exp ? decoded.exp * 1000 : null
+        });
+    });
+
+    // ============================================
     // GET /verify-email?token=xxx — serves a page that auto-POSTs token
     // (CWE-598 mitigation: token consumed via POST, not GET)
     // ============================================
@@ -812,6 +867,7 @@ module.exports = function(devices, getOrCreateDevice, serverLog) {
 
                 return res.json({
                     success: true,
+                    session: { expiresAt: req.user.exp ? req.user.exp * 1000 : null },
                     user: {
                         id: null,
                         email: null,
@@ -896,6 +952,7 @@ module.exports = function(devices, getOrCreateDevice, serverLog) {
 
             res.json({
                 success: true,
+                session: { expiresAt: req.user.exp ? req.user.exp * 1000 : null },
                 user: {
                     id: user.id,
                     email: user.email,

--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -36,9 +36,21 @@ async function apiCall(method, path, body = null, opts = {}) {
             && !window.location.pathname.includes('index.html')
             && !window.location.pathname.endsWith('/portal/')
             && !window.location.pathname.includes('info.html')) {
-            window.location.href = 'index.html';
+            // Pain 4 fix: tell the user WHY they are being sent to login
+            // instead of a silent kick. `reason` comes from authMiddleware
+            // (no_token / token_expired / token_invalid).
+            const reason = data.reason || 'no_token';
+            const t = (k, fb) => (window.i18n && window.i18n.t) ? window.i18n.t(k, fb) : fb;
+            const msg = reason === 'token_expired'
+                ? t('session_expired_relogin', 'Session expired — please log in again')
+                : t('session_invalid_relogin', 'Please log in to continue');
+            try { showToast(msg, 'warning'); } catch (_) { /* toast not ready pre-DOM */ }
+            setTimeout(() => { window.location.href = 'index.html?authReason=' + encodeURIComponent(reason); }, 1200);
         }
-        throw new Error(data.error || 'Not authenticated');
+        const authErr = new Error(data.error || 'Not authenticated');
+        authErr.status = 401;
+        authErr.reason = data.reason || null;
+        throw authErr;
     }
 
     if (!response.ok) {

--- a/backend/public/portal/shared/auth.js
+++ b/backend/public/portal/shared/auth.js
@@ -3,6 +3,38 @@
 
 let currentUser = null;
 
+// ── Session keeper (OODA-R Phase 2 #6, pain 4) ──
+// Single-flight refresh: many tabs / many callers collapse onto one
+// in-flight POST /api/auth/refresh (mutex against thundering herd on
+// expiry). Refresh fires 10 minutes before expiresAt (floor 30s).
+let _refreshTimer = null;
+let _refreshInflight = null;
+
+function _refreshSession() {
+    if (_refreshInflight) return _refreshInflight;
+    _refreshInflight = apiCall('POST', '/api/auth/refresh', {}, { skip401Redirect: true })
+        .then((resp) => {
+            if (resp && resp.expiresAt) _scheduleSessionRefresh(resp.expiresAt);
+            return resp;
+        })
+        .catch((err) => {
+            // Refresh with an already-expired/invalid token: let the next
+            // regular apiCall surface the reason-coded 401 prompt.
+            console.warn('[Auth] session refresh failed:', err && err.message);
+            return null;
+        })
+        .finally(() => { _refreshInflight = null; });
+    return _refreshInflight;
+}
+
+function _scheduleSessionRefresh(expiresAtMs) {
+    if (_refreshTimer) clearTimeout(_refreshTimer);
+    const lead = 10 * 60 * 1000;
+    const delay = Math.max(expiresAtMs - Date.now() - lead, 30 * 1000);
+    _refreshTimer = setTimeout(_refreshSession, delay);
+    _refreshTimer && _refreshTimer.unref && _refreshTimer.unref();
+}
+
 async function checkAuth() {
     // If WebView host passed an authToken in the URL (iOS shell), stash it as a cookie
     // so apiCall's default credentials include it on /me. Also mirror to localStorage
@@ -37,6 +69,13 @@ async function checkAuth() {
         const data = await apiCall('GET', '/api/auth/me', null, { skip401Redirect: true });
         currentUser = data.user;
         window.currentUser = currentUser;
+
+        // Pain 4 fix: proactive sliding-session renewal. /me now returns
+        // session.expiresAt; refresh shortly before expiry so a long-lived
+        // tab never hits a hard token_expired 401.
+        if (data.session && data.session.expiresAt) {
+            _scheduleSessionRefresh(data.session.expiresAt);
+        }
 
         // WebView stale-session guard: if the host passed deviceId+deviceSecret
         // in the URL but /me returned a DIFFERENT device (e.g. leftover session

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650132,6 +650132,9 @@ const TRANSLATIONS = {
         "dialog_ok": "OK",
         "dialog_cancel_aria": "Cancel, keep current state",
         "dialog_confirm_destructive": "Confirm destructive action",
+
+        "session_expired_relogin": "Session expired — please log in again",
+        "session_invalid_relogin": "Please log in to continue",
 },
 
 
@@ -1234731,6 +1234734,9 @@ const TRANSLATIONS = {
         "dialog_ok": "好",
         "dialog_cancel_aria": "取消，保持当前状态",
         "dialog_confirm_destructive": "确认破坏性操作",
+
+        "session_expired_relogin": "会话已过期，请重新登录",
+        "session_invalid_relogin": "请登录后继续",
 },
 
 
@@ -2411933,6 +2411939,9 @@ const TRANSLATIONS = {
         "dialog_ok": "OK",
         "dialog_cancel_aria": "キャンセルして現在の状態を保持",
         "dialog_confirm_destructive": "破壊的な操作を確認",
+
+        "session_expired_relogin": "セッションの有効期限が切れました。再度ログインしてください",
+        "session_invalid_relogin": "続行するにはログインしてください",
 },
 
 
@@ -2942147,6 +2942156,9 @@ const TRANSLATIONS = {
         "dialog_ok": "확인",
         "dialog_cancel_aria": "취소하고 현재 상태 유지",
         "dialog_confirm_destructive": "위험한 작업 확인",
+
+        "session_expired_relogin": "세션이 만료되었습니다. 다시 로그인해 주세요",
+        "session_invalid_relogin": "계속하려면 로그인해 주세요",
 },
 
 
@@ -2943733,6 +2943745,9 @@ const TRANSLATIONS = {
         "dialog_ok": "好",
         "dialog_cancel_aria": "取消，保持目前狀態",
         "dialog_confirm_destructive": "確認破壞性操作",
+
+        "session_expired_relogin": "登入已過期，請重新登入",
+        "session_invalid_relogin": "請登入後繼續",
 },
 
 
@@ -3997283,6 +3997298,9 @@ const TRANSLATIONS = {
         "dialog_ok": "OK",
         "dialog_cancel_aria": "Hủy, giữ nguyên trạng thái hiện tại",
         "dialog_confirm_destructive": "Xác nhận hành động phá hủy",
+
+        "session_expired_relogin": "Phiên đã hết hạn — vui lòng đăng nhập lại",
+        "session_invalid_relogin": "Vui lòng đăng nhập để tiếp tục",
 },
 
 
@@ -4523680,6 +4523698,9 @@ const TRANSLATIONS = {
         "dialog_ok": "OK",
         "dialog_cancel_aria": "Batal, pertahankan status saat ini",
         "dialog_confirm_destructive": "Konfirmasi tindakan destruktif",
+
+        "session_expired_relogin": "Sesi berakhir — silakan masuk lagi",
+        "session_invalid_relogin": "Silakan masuk untuk melanjutkan",
 },
 
 
@@ -5566377,6 +5566398,9 @@ const TRANSLATIONS = {
         "dialog_ok": "Aceptar",
         "dialog_cancel_aria": "Cancelar y mantener el estado actual",
         "dialog_confirm_destructive": "Confirmar acción destructiva",
+
+        "session_expired_relogin": "La sesión ha expirado: vuelve a iniciar sesión",
+        "session_invalid_relogin": "Inicia sesión para continuar",
 },
 
 

--- a/backend/tests/jest/auth-session-refresh.test.js
+++ b/backend/tests/jest/auth-session-refresh.test.js
@@ -1,0 +1,104 @@
+'use strict';
+
+/**
+ * OODA-R Phase 2 #6 — auth/session persistence + refresh diagnostics.
+ * Card: card_214d48e395e812b3e909e5ca. Addresses pain 4 (帳號莫名要重新登入).
+ *
+ * Exercises the auth router in isolation with a stub express app — no DB
+ * needed for the token paths under test (refresh + middleware reasons).
+ */
+
+const express = require('express');
+const cookieParser = require('cookie-parser');
+const jwt = require('jsonwebtoken');
+const request = require('supertest');
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'test-secret-for-jest';
+const JWT_SECRET = process.env.JWT_SECRET;
+
+const devices = {
+    'dev-1': { deviceSecret: 'sec-1' },
+};
+
+const authFactory = require('../../auth');
+
+function buildApp() {
+    const app = express();
+    app.use(express.json());
+    app.use(cookieParser());
+    const mod = authFactory(devices, () => devices['dev-1'], () => {});
+    app.use('/api/auth', mod.router);
+    // Tiny protected probe using the same middleware
+    app.get('/probe', mod.authMiddleware, (req, res) => res.json({ ok: true, user: req.user }));
+    return app;
+}
+
+function tokenFor({ deviceId = 'dev-1', userId = null, expiresIn = '7d' } = {}) {
+    return jwt.sign({ userId, deviceId }, JWT_SECRET, { expiresIn });
+}
+
+describe('401 reason codes (pain 4: no silent kick)', () => {
+    const app = buildApp();
+
+    test('no token → reason no_token', async () => {
+        const res = await request(app).get('/probe');
+        expect(res.status).toBe(401);
+        expect(res.body.reason).toBe('no_token');
+    });
+
+    test('expired token → reason token_expired', async () => {
+        // expired well beyond the 30s clock tolerance
+        const expired = tokenFor({ expiresIn: '-120s' });
+        const res = await request(app).get('/probe').set('Authorization', `Bearer ${expired}`);
+        expect(res.status).toBe(401);
+        expect(res.body.reason).toBe('token_expired');
+        expect(res.body.error).toMatch(/expired/i);
+    });
+
+    test('garbage token → reason token_invalid', async () => {
+        const res = await request(app).get('/probe').set('Authorization', 'Bearer not.a.jwt');
+        expect(res.status).toBe(401);
+        expect(res.body.reason).toBe('token_invalid');
+    });
+
+    test('clock-skew guard: token expired <30s ago still accepted', async () => {
+        const justExpired = tokenFor({ expiresIn: '-5s' });
+        const res = await request(app).get('/probe').set('Authorization', `Bearer ${justExpired}`);
+        expect(res.status).toBe(200);
+    });
+});
+
+describe('POST /api/auth/refresh (sliding session)', () => {
+    const app = buildApp();
+
+    test('valid token → fresh token + new cookie + expiresAt', async () => {
+        const valid = tokenFor();
+        const res = await request(app)
+            .post('/api/auth/refresh')
+            .set('Authorization', `Bearer ${valid}`);
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(typeof res.body.token).toBe('string');
+        expect(res.body.expiresAt).toBeGreaterThan(Date.now());
+        const setCookie = res.headers['set-cookie'] || [];
+        expect(setCookie.some(c => c.startsWith('eclaw_session='))).toBe(true);
+        // fresh token decodes to same identity
+        const decoded = jwt.verify(res.body.token, JWT_SECRET);
+        expect(decoded.deviceId).toBe('dev-1');
+    });
+
+    test('expired token cannot refresh itself → 401 token_expired', async () => {
+        const expired = tokenFor({ expiresIn: '-120s' });
+        const res = await request(app)
+            .post('/api/auth/refresh')
+            .set('Authorization', `Bearer ${expired}`);
+        expect(res.status).toBe(401);
+        expect(res.body.reason).toBe('token_expired');
+    });
+
+    test('no token cannot refresh → 401 no_token', async () => {
+        const res = await request(app).post('/api/auth/refresh');
+        expect(res.status).toBe(401);
+        expect(res.body.reason).toBe('no_token');
+    });
+});

--- a/backend/tests/jest/portal-auth-race.test.js
+++ b/backend/tests/jest/portal-auth-race.test.js
@@ -76,7 +76,9 @@ describe('apiCall 401 behavior', () => {
         loadApiJs(sandbox);
 
         await expect(sandbox.apiCall('GET', '/api/auth/me')).rejects.toThrow(/Not authenticated/);
-        expect(hrefSetter).toHaveBeenCalledWith('index.html');
+        // Pain-4 contract (OODA-R Phase 2 #6): redirect now carries the
+        // machine-readable reason so index.html can explain the kick.
+        expect(hrefSetter).toHaveBeenCalledWith('index.html?authReason=no_token');
     });
 
     test('401 with skip401Redirect=true does NOT navigate', async () => {


### PR DESCRIPTION
## Card
card_214d48e395e812b3e909e5ca — [OODA-R/P1] Phase 2 #6 (pain 4: 帳號莫名要重新登入)

## Root cause (recon on card)
`JWT_EXPIRY=7d`, **no refresh endpoint anywhere** → hard 401 on day 7; portal api.js silently redirected to index.html. User experience: unexplained logout.

## What
- **POST /api/auth/refresh**: sliding renewal — valid cookie/bearer token mints a fresh 7d JWT + re-sets the httpOnly cookie (token also in-body for mobile bearer clients). Expired tokens canNOT self-refresh (401 token_expired). Audit line on every refresh.
- **Reason codes**: authMiddleware 401s now carry `reason: no_token | token_expired | token_invalid`; 30s `clockTolerance` so mobile clock drift stops causing premature expiry.
- **/me** exposes `session.expiresAt` (both auth branches).
- **Portal session keeper** (shared/auth.js): proactive refresh 10min before expiry, single-flight promise mutex (thundering-herd guard), reschedules from each response.
- **Visible kick** (shared/api.js): localized toast + `index.html?authReason=<reason>` after 1.2s replaces the silent redirect.
- **i18n**: 2 new keys × 8 locales (AST tool).

## Tests
- NEW `auth-session-refresh.test.js`: 7/7 (3 reason codes, clock-skew accept window, refresh happy/expired/missing) — supertest against the real auth router, no DB needed.
- `portal-auth-race.test.js` updated to the new redirect contract: 8/8.
- Sweep (auth|session|i18n-syntax|portal-smoke, 270 suites): all green after contract update.

## Post-merge verification plan
Prod curl: expired-token 401 carries reason; /refresh round-trip; /me has session.expiresAt. UX smoke per card acceptance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)