### PR TITLE
feat(chat): returning-user greeting + new-user starter chips — 情緒價值 #1

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -288,6 +288,23 @@
 
         body.density-comfortable .chat-messages { padding: 20px; padding-right: 36px; gap: 18px; }
         body.density-comfortable .chat-bubble { padding: 12px 18px; font-size: 15px; line-height: 1.5; }
+
+        /* ── 情緒價值 #1: greeting banner (card_f8167ec5) ── */
+        .greet-banner {
+            margin: 8px 14px 4px; padding: 10px 14px; border-radius: 14px;
+            background: var(--bg-card, #f4f6fb); border: 1px solid var(--border-color, #dfe3ec);
+            font-size: 14px; line-height: 1.5; display: flex; flex-direction: column; gap: 8px;
+        }
+        body.dark .greet-banner { background: #23262f; border-color: #3a3f4d; }
+        .greet-banner-text { display: flex; align-items: flex-start; gap: 6px; }
+        .greet-chips { display: flex; flex-wrap: wrap; gap: 6px; }
+        .greet-chip {
+            border: 1px solid var(--primary, #5b6cff); color: var(--primary, #5b6cff);
+            background: transparent; border-radius: 16px; padding: 5px 14px;
+            font-size: 13px; cursor: pointer; min-height: 32px;
+        }
+        .greet-chip:hover { background: rgba(91,108,255,0.1); }
+        .greet-chip.greet-chip-dismiss { border-color: var(--border-color, #c8cdd9); color: var(--text-secondary, #8a8f9c); }
         body.density-comfortable .chat-msg { max-width: 75%; }
         body.density-comfortable .chat-source { font-size: 12px; margin-bottom: 4px; }
 
@@ -2996,6 +3013,7 @@
 
             <!-- Messages Area -->
             <div class="chat-messages-wrapper">
+                <div class="greet-banner" id="greetBanner" style="display:none" role="status"></div>
                 <div class="chat-messages" id="chatMessages">
                     <div class="chat-loading" id="chatLoading">
                         <div class="spinner"></div>
@@ -4636,6 +4654,7 @@
                     _sourceParseCache.clear();
                     renderFilterChips();
                     renderMessages(prevCount < allMessages.length);
+                    try { EclawGreeting.maybeShow(); } catch (_) { /* greeting must never break chat */ }
                     if (!isFirstLoad && getChatMessageDeepLinkId()) {
                         await handleChatMessageDeepLink({ showMissingToast: false, scroll: false });
                     }
@@ -6327,6 +6346,76 @@
         }
 
         // ── Send Message ──
+        // ── 情緒價值 #1: 回訪個人化問候 + 新手 starter chips (card_f8167ec5) ──
+        // Banner lives OUTSIDE #chatMessages so renderMessages() re-renders
+        // can never wipe it. Shown at most once per device per day.
+        const EclawGreeting = {
+            _shown: false,
+            _guardKey() {
+                const d = new Date();
+                const day = d.getFullYear() + '-' + String(d.getMonth() + 1).padStart(2, '0') + '-' + String(d.getDate()).padStart(2, '0');
+                return 'eclaw_greet_' + day;
+            },
+            maybeShow() {
+                if (this._shown) return;
+                this._shown = true; // single evaluation per page load
+                let guarded = false;
+                try { guarded = !!localStorage.getItem(this._guardKey()); } catch (_) {}
+                if (guarded) return;
+                const banner = document.getElementById('greetBanner');
+                if (!banner) return;
+                const t = (k, fb) => (window.i18n && i18n.t) ? i18n.t(k, fb) : fb;
+                const esc = (x) => (typeof escapeHtml === 'function') ? escapeHtml(x) : x;
+                const botMsgs = (allMessages || []).filter(m => m.is_from_bot && (m.text || '').trim());
+                let html;
+                if (botMsgs.length > 0) {
+                    // Returning user: topic = last bot message, stripped to 40 chars.
+                    // (Vector recall has no portal client route today — this is the
+                    // card-sanctioned fallback and needs zero extra API calls.)
+                    const last = botMsgs[botMsgs.length - 1];
+                    const topic = (typeof stripReplyQuotePrefix === 'function' ? stripReplyQuotePrefix(last.text) : last.text)
+                        .replace(/\s+/g, ' ').trim().slice(0, 40);
+                    const tpl = t('greet_returning_template', '上次我們聊到「{topic}」，要接著聊嗎？');
+                    html = '<div class="greet-banner-text">👋 ' + esc(tpl).replace('{topic}', '<b>' + esc(topic) + '</b>') + '</div>' +
+                        '<div class="greet-chips">' +
+                        '<button class="greet-chip" onclick="EclawGreeting.continueTopic()">' + esc(t('greet_continue', '繼續上次話題')) + '</button>' +
+                        '<button class="greet-chip greet-chip-dismiss" onclick="EclawGreeting.dismiss()">' + esc(t('greet_change_topic', '換個話題')) + '</button>' +
+                        '</div>';
+                } else {
+                    // Brand-new entity: welcome + 3 starter prompts (activation moment).
+                    const starters = [
+                        t('greet_starter_1', '你可以幫我做什麼？'),
+                        t('greet_starter_2', '幫我規劃今天的待辦事項'),
+                        t('greet_starter_3', '用三句話介紹一下你自己')
+                    ];
+                    html = '<div class="greet-banner-text">🎉 ' + esc(t('greet_welcome_new', '歡迎！我是你的 AI 夥伴，點一個問題開始吧：')) + '</div>' +
+                        '<div class="greet-chips">' +
+                        starters.map(st => '<button class="greet-chip" onclick="EclawGreeting.sendStarter(this)">' + esc(st) + '</button>').join('') +
+                        '<button class="greet-chip greet-chip-dismiss" onclick="EclawGreeting.dismiss()">✕</button>' +
+                        '</div>';
+                }
+                banner.innerHTML = html;
+                banner.style.display = '';
+                try { localStorage.setItem(this._guardKey(), '1'); } catch (_) {}
+            },
+            continueTopic() {
+                const t = (k, fb) => (window.i18n && i18n.t) ? i18n.t(k, fb) : fb;
+                const input = document.getElementById('messageInput');
+                if (input) { input.value = t('greet_continue_send_text', '我們繼續上次的話題吧'); sendMessage(); }
+                this.dismiss();
+            },
+            sendStarter(btn) {
+                const input = document.getElementById('messageInput');
+                if (input) { input.value = btn.textContent.trim(); sendMessage(); }
+                this.dismiss();
+            },
+            dismiss() {
+                const banner = document.getElementById('greetBanner');
+                if (banner) banner.style.display = 'none';
+            }
+        };
+        window.EclawGreeting = EclawGreeting;
+
         async function sendMessage() {
             const input = document.getElementById('messageInput');
             const text = input.value.trim();

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650135,6 +650135,15 @@ const TRANSLATIONS = {
 
         "session_expired_relogin": "Session expired — please log in again",
         "session_invalid_relogin": "Please log in to continue",
+
+        "greet_returning_template": "Last time we talked about \"{topic}\" — pick up where we left off?",
+        "greet_continue": "Continue last topic",
+        "greet_change_topic": "New topic",
+        "greet_continue_send_text": "Let's continue our last topic",
+        "greet_welcome_new": "Welcome! I'm your AI companion — tap a question to get started:",
+        "greet_starter_1": "What can you help me with?",
+        "greet_starter_2": "Help me plan today's to-dos",
+        "greet_starter_3": "Introduce yourself in three sentences",
 },
 
 
@@ -1234737,6 +1234746,15 @@ const TRANSLATIONS = {
 
         "session_expired_relogin": "会话已过期，请重新登录",
         "session_invalid_relogin": "请登录后继续",
+
+        "greet_returning_template": "上次我们聊到「{topic}」，要接着聊吗？",
+        "greet_continue": "继续上次话题",
+        "greet_change_topic": "换个话题",
+        "greet_continue_send_text": "我们继续上次的话题吧",
+        "greet_welcome_new": "欢迎！我是你的 AI 伙伴，点一个问题开始吧：",
+        "greet_starter_1": "你可以帮我做什么？",
+        "greet_starter_2": "帮我规划今天的待办事项",
+        "greet_starter_3": "用三句话介绍一下你自己",
 },
 
 
@@ -2411942,6 +2411960,15 @@ const TRANSLATIONS = {
 
         "session_expired_relogin": "セッションの有効期限が切れました。再度ログインしてください",
         "session_invalid_relogin": "続行するにはログインしてください",
+
+        "greet_returning_template": "前回は「{topic}」について話しましたね。続きを話しますか？",
+        "greet_continue": "前回の続きを話す",
+        "greet_change_topic": "別の話題にする",
+        "greet_continue_send_text": "前回の話題の続きをしましょう",
+        "greet_welcome_new": "ようこそ！あなたのAIパートナーです。質問をタップして始めましょう：",
+        "greet_starter_1": "何を手伝ってくれますか？",
+        "greet_starter_2": "今日のタスクを計画して",
+        "greet_starter_3": "3文で自己紹介して",
 },
 
 
@@ -2942159,6 +2942186,15 @@ const TRANSLATIONS = {
 
         "session_expired_relogin": "세션이 만료되었습니다. 다시 로그인해 주세요",
         "session_invalid_relogin": "계속하려면 로그인해 주세요",
+
+        "greet_returning_template": "지난번에 \"{topic}\"에 대해 이야기했죠. 이어서 할까요?",
+        "greet_continue": "지난 대화 이어가기",
+        "greet_change_topic": "다른 주제로",
+        "greet_continue_send_text": "지난 주제를 이어서 이야기해요",
+        "greet_welcome_new": "환영합니다! 저는 당신의 AI 파트너예요. 질문을 눌러 시작하세요:",
+        "greet_starter_1": "무엇을 도와줄 수 있나요?",
+        "greet_starter_2": "오늘 할 일을 계획해 줘",
+        "greet_starter_3": "세 문장으로 자기소개해 줘",
 },
 
 
@@ -2943748,6 +2943784,15 @@ const TRANSLATIONS = {
 
         "session_expired_relogin": "登入已過期，請重新登入",
         "session_invalid_relogin": "請登入後繼續",
+
+        "greet_returning_template": "上次我們聊到「{topic}」，要接著聊嗎？",
+        "greet_continue": "繼續上次話題",
+        "greet_change_topic": "換個話題",
+        "greet_continue_send_text": "我們繼續上次的話題吧",
+        "greet_welcome_new": "歡迎！我是你的 AI 夥伴，點一個問題開始吧：",
+        "greet_starter_1": "你可以幫我做什麼？",
+        "greet_starter_2": "幫我規劃今天的待辦事項",
+        "greet_starter_3": "用三句話介紹一下你自己",
 },
 
 
@@ -3997301,6 +3997346,15 @@ const TRANSLATIONS = {
 
         "session_expired_relogin": "Phiên đã hết hạn — vui lòng đăng nhập lại",
         "session_invalid_relogin": "Vui lòng đăng nhập để tiếp tục",
+
+        "greet_returning_template": "Lần trước chúng ta đã nói về \"{topic}\" — tiếp tục nhé?",
+        "greet_continue": "Tiếp tục chủ đề trước",
+        "greet_change_topic": "Chủ đề khác",
+        "greet_continue_send_text": "Chúng ta tiếp tục chủ đề lần trước nhé",
+        "greet_welcome_new": "Chào mừng! Tôi là người bạn AI của bạn — chạm vào một câu hỏi để bắt đầu:",
+        "greet_starter_1": "Bạn có thể giúp tôi những gì?",
+        "greet_starter_2": "Giúp tôi lên kế hoạch việc cần làm hôm nay",
+        "greet_starter_3": "Giới thiệu bản thân trong ba câu",
 },
 
 
@@ -4523701,6 +4523755,15 @@ const TRANSLATIONS = {
 
         "session_expired_relogin": "Sesi berakhir — silakan masuk lagi",
         "session_invalid_relogin": "Silakan masuk untuk melanjutkan",
+
+        "greet_returning_template": "Terakhir kali kita membahas \"{topic}\" — lanjutkan?",
+        "greet_continue": "Lanjutkan topik terakhir",
+        "greet_change_topic": "Topik lain",
+        "greet_continue_send_text": "Mari lanjutkan topik terakhir kita",
+        "greet_welcome_new": "Selamat datang! Saya teman AI Anda — ketuk pertanyaan untuk memulai:",
+        "greet_starter_1": "Apa yang bisa kamu bantu?",
+        "greet_starter_2": "Bantu saya merencanakan tugas hari ini",
+        "greet_starter_3": "Perkenalkan dirimu dalam tiga kalimat",
 },
 
 
@@ -5566401,6 +5566464,15 @@ const TRANSLATIONS = {
 
         "session_expired_relogin": "La sesión ha expirado: vuelve a iniciar sesión",
         "session_invalid_relogin": "Inicia sesión para continuar",
+
+        "greet_returning_template": "La última vez hablamos de \"{topic}\". ¿Seguimos donde lo dejamos?",
+        "greet_continue": "Continuar el último tema",
+        "greet_change_topic": "Otro tema",
+        "greet_continue_send_text": "Sigamos con nuestro último tema",
+        "greet_welcome_new": "¡Bienvenido! Soy tu compañero de IA. Toca una pregunta para empezar:",
+        "greet_starter_1": "¿En qué puedes ayudarme?",
+        "greet_starter_2": "Ayúdame a planificar mis tareas de hoy",
+        "greet_starter_3": "Preséntate en tres frases",
 },
 
 


### PR DESCRIPTION
## Card
card_f8167ec58c306b7ab8cde796 — [Feature/P1] 情緒價值 #1 (#6 rank 🥇)

## What
- **Returning users**: banner 「上次我們聊到「topic」，要接著聊嗎？」 (topic = last bot msg, 40 chars, card-sanctioned fallback — zero extra API calls) + 繼續/換話題 chips. 繼續 sends through the normal sendMessage pipeline.
- **New entities**: welcome + 3 starter prompt chips (activation moment).
- **Day guard**: localStorage date key — once per device per day.
- Banner is a sibling of #chatMessages (immune to re-render wipes), try-guarded hook so greeting can never break chat load.
- i18n 8 keys × 8 locales (AST tool).

## Tests
i18n + portal-smoke-static + chat jest suites green. Post-merge: prod Playwright E2E (returning greeting on E2E Bot history / new-user starters / day-guard reload) + mobile+desktop screenshots to card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)