### PR TITLE
feat(portal): optimistic UI + undo toast (kanban move/archive + chat sending) — 情緒價值 #2

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -92,7 +92,12 @@
         body.dark .msg-outbox-retrying .chat-bubble { background: #3a3220; color: #e8d488; }
         .msg-outbox-failed .chat-bubble { border: 1.5px solid #d94f4f; background: #fdecec; color: #5a1a1a; }
         body.dark .msg-outbox-failed .chat-bubble { background: #3a1e1e; color: #ffb4b4; border-color: #b34141; }
+        /* sending = online optimistic state (情緒價值 #2): keep the normal sent
+           bubble look, just dim it + spin until the POST resolves. */
+        .msg-outbox-sending { cursor: default; }
+        .msg-outbox-sending .chat-bubble { opacity: 0.7; }
         .msg-outbox-queued .msg-outbox-spinner,
+        .msg-outbox-sending .msg-outbox-spinner,
         .msg-outbox-retrying .msg-outbox-spinner {
             display: inline-block;
             width: 10px; height: 10px;
@@ -6563,8 +6568,12 @@
                                 }
                                 if (__outboxEntry) {
                                     window.EclawOutbox.markRetrying(__idempotencyKey);
+                                    // Visual state is 'sending' (online optimistic, 情緒價值 #2),
+                                    // not 'retrying' — this is the first in-flight attempt. The
+                                    // queue bookkeeping above still tracks it for offline flush.
                                     if (__chatContainer && window.EclawOutboxUI) {
-                                        window.EclawOutboxUI.setBubbleState(__chatContainer, __idempotencyKey, 'retrying');
+                                        const __sendingEl = window.EclawOutboxUI.setBubbleState(__chatContainer, __idempotencyKey, 'sending');
+                                        if (__sendingEl) __sendingEl.setAttribute('aria-label', i18n.t('chat_sending') || 'Sending…');
                                     }
                                 }
                                 _updateOutboxBanner();

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -363,8 +363,10 @@
 
         /* ══════════════ Toast ══════════════ */
         .kb-toast { position:fixed; bottom:24px; right:24px; background:#4ade80; color:#000; padding:10px 20px; border-radius:var(--radius-sm); font-size:13px; font-weight:600; z-index:200; display:none; backdrop-filter:blur(8px); -webkit-backdrop-filter:blur(8px); }
-        .kb-toast.show { display:block; }
+        .kb-toast.show { display:flex; align-items:center; gap:4px; }
         .kb-toast.error { background:#ef4444; color:#fff; }
+        .kb-toast-undo { margin-left:10px; background:rgba(0,0,0,0.15); border:none; color:inherit; font-weight:700; padding:4px 12px; border-radius:6px; cursor:pointer; font-size:13px; font-family:inherit; }
+        .kb-toast-undo:hover { background:rgba(0,0,0,0.28); }
 
         /* ══════════════ Automation Collapse Section ══════════════ */
         .kb-automation { margin-bottom:16px; background:var(--card); border:1px solid var(--card-border); border-radius:var(--radius); }
@@ -1076,7 +1078,7 @@
     </div>
 
     <!-- Toast -->
-    <div class="kb-toast" id="kbToast"></div>
+    <div class="kb-toast" id="kbToast" role="status" aria-live="polite"></div>
 
     <!-- Message Preview Modal -->
     <div class="kb-message-modal" id="messageModal" style="display: none;">
@@ -1515,6 +1517,44 @@
                 deviceId: currentUser.deviceId, deviceSecret: currentUser.deviceSecret,
                 newStatus, assignedBots
             });
+        }
+
+        // ── Optimistic move + undo (情緒價值 #2, card_c575aacae639721dbc8cfaa3) ──
+        // Flip the local model and re-render BEFORE the server confirms, so the
+        // card visually lands in the target column immediately. Server failure
+        // (e.g. done-gate rejection) reverts the flip and surfaces the error.
+        async function optimisticMove(cardId, newStatus) {
+            const card = findCard(cardId);
+            if (!card) return;
+            const prevStatus = card.status;
+            card.status = newStatus;
+            renderBoard(true);
+            try {
+                await apiMoveCard(cardId, newStatus, card.assignedBots || []);
+                showUndoToast(
+                    t('kb_toast_moved', 'Moved to {col}').replace('{col}', STATUS_LABELS[newStatus] || newStatus),
+                    () => undoMove(cardId, prevStatus)
+                );
+                await loadCards();
+                if (openCardId === cardId) openDetail(cardId);
+            } catch (err) {
+                card.status = prevStatus;
+                renderBoard(true);
+                showToast(t('kb_err_move', 'Move failed') + ': ' + (err.message || err), true);
+            }
+        }
+
+        async function undoMove(cardId, prevStatus) {
+            const card = findCard(cardId);
+            if (card) { card.status = prevStatus; renderBoard(true); }
+            try {
+                await apiMoveCard(cardId, prevStatus, (card && card.assignedBots) || []);
+                await loadCards(); // re-fetch = server-state consistency check
+                showToast(t('kb_undo_done', 'Undone'));
+            } catch (err) {
+                await loadCards();
+                showToast(t('kb_undo_failed', 'Undo failed') + ': ' + (err.message || err), true);
+            }
         }
 
         async function apiReopenCard(cardId, body) {
@@ -2254,12 +2294,9 @@
                     if (!card || card.status === newStatus) { dragCard = null; return; }
                     if (card.isAutomation) { showToast('自動化母卡無法手動移動', true); dragCard = null; return; }
                     if (card.status === 'done') { showToast('Cannot move Done cards', true); dragCard = null; return; }
-                    try {
-                        await apiMoveCard(dragCard, newStatus, card.assignedBots || []);
-                        showToast('Moved to ' + STATUS_LABELS[newStatus]);
-                        await loadCards();
-                    } catch(err) { showToast('Move failed: ' + (err.message||err), true); }
+                    const moving = dragCard;
                     dragCard = null;
+                    await optimisticMove(moving, newStatus);
                 });
             });
         }
@@ -2400,12 +2437,28 @@
             const card = findCard(cardId);
             if (!card) return;
             if (!await showConfirm({ message: t('kb_archive_confirm', 'Archive this card?'), itemName: card.title || card.id, danger: true })) return;
+            // Optimistic: drop the card from the board right away; revert on
+            // server failure. Undo path uses the existing /restore endpoint.
+            const idx = allCards.findIndex(c => c.id === cardId);
+            const snapshot = idx >= 0 ? allCards[idx] : null;
+            if (idx >= 0) { allCards.splice(idx, 1); renderBoard(true); }
+            closeDetail();
             try {
                 await apiCall('DELETE', `/api/mission/card/${cardId}?deviceId=${encodeURIComponent(currentUser.deviceId)}&deviceSecret=${encodeURIComponent(currentUser.deviceSecret)}`);
-                showToast('Archived');
-                closeDetail();
+                showUndoToast(t('kb_toast_archived', 'Archived'), async () => {
+                    try {
+                        await apiCall('POST', `/api/mission/card/${cardId}/restore`, {
+                            deviceId: currentUser.deviceId, deviceSecret: currentUser.deviceSecret
+                        });
+                        await loadCards();
+                        showToast(t('kb_undo_done', 'Undone'));
+                    } catch (err) {
+                        showToast(t('kb_undo_failed', 'Undo failed') + ': ' + (err.message || err), true);
+                    }
+                });
                 await loadCards();
             } catch (err) {
+                if (snapshot) { allCards.splice(idx, 0, snapshot); renderBoard(true); }
                 showToast('Archive failed: ' + (err.message || err), true);
             }
         }
@@ -3710,12 +3763,7 @@
             if (!card || card.status === newStatus) return;
             if (card.isAutomation) { showToast('自動化母卡由排程管理，無法手動移動', true); return; }
             if (card.status === 'done') { showToast('Cannot move Done cards; use Reopen', true); return; }
-            try {
-                await apiMoveCard(cardId, newStatus, card.assignedBots || []);
-                showToast('Moved to ' + STATUS_LABELS[newStatus]);
-                await loadCards();
-                if (openCardId === cardId) openDetail(cardId);
-            } catch(e) { showToast('Move failed', true); }
+            await optimisticMove(cardId, newStatus);
         }
 
         function closeReopenDialog() {
@@ -4384,11 +4432,33 @@
         }
 
         // ── Utils ──
+        let _toastTimer = null;
         function showToast(msg, isError) {
-            const t = document.getElementById('kbToast');
-            t.textContent = msg;
-            t.className = 'kb-toast show' + (isError ? ' error' : '');
-            setTimeout(() => t.classList.remove('show'), 2500);
+            const el = document.getElementById('kbToast');
+            el.textContent = msg;
+            el.className = 'kb-toast show' + (isError ? ' error' : '');
+            clearTimeout(_toastTimer);
+            _toastTimer = setTimeout(() => el.classList.remove('show'), 2500);
+        }
+        // Toast with an inline undo action. Stays up longer than the plain
+        // toast (default 5s) so the user has time to hit 復原. Card: 情緒價值 #2
+        // (card_c575aacae639721dbc8cfaa3).
+        function showUndoToast(msg, onUndo, duration = 5000) {
+            const el = document.getElementById('kbToast');
+            el.textContent = msg;
+            const btn = document.createElement('button');
+            btn.className = 'kb-toast-undo';
+            btn.id = 'kbToastUndo';
+            btn.textContent = t('kb_undo', 'Undo');
+            btn.onclick = () => {
+                clearTimeout(_toastTimer);
+                el.classList.remove('show');
+                try { onUndo(); } catch (e) { console.error('[Kanban] undo failed:', e); }
+            };
+            el.appendChild(btn);
+            el.className = 'kb-toast show';
+            clearTimeout(_toastTimer);
+            _toastTimer = setTimeout(() => el.classList.remove('show'), duration);
         }
     </script>
 </body>

--- a/backend/public/portal/shared/outbox-ui.js
+++ b/backend/public/portal/shared/outbox-ui.js
@@ -13,7 +13,9 @@
 (function (global) {
     'use strict';
 
-    var STATES = ['queued', 'retrying', 'sent', 'failed'];
+    // 'sending' = online optimistic first attempt (情緒價值 #2). It is NOT
+    // tap-cancellable like queued/retrying — the POST is already in flight.
+    var STATES = ['queued', 'sending', 'retrying', 'sent', 'failed'];
 
     function tt(t, key, fallback) {
         if (typeof t === 'function') {

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650144,6 +650144,14 @@ const TRANSLATIONS = {
         "greet_starter_1": "What can you help me with?",
         "greet_starter_2": "Help me plan today's to-dos",
         "greet_starter_3": "Introduce yourself in three sentences",
+
+        "kb_toast_moved": "Moved to {col}",
+        "kb_toast_archived": "Archived",
+        "kb_undo": "Undo",
+        "kb_undo_done": "Undone",
+        "kb_undo_failed": "Undo failed",
+        "kb_err_move": "Move failed",
+        "chat_sending": "Sending…",
 },
 
 
@@ -1234755,6 +1234763,14 @@ const TRANSLATIONS = {
         "greet_starter_1": "你可以帮我做什么？",
         "greet_starter_2": "帮我规划今天的待办事项",
         "greet_starter_3": "用三句话介绍一下你自己",
+
+        "kb_toast_moved": "已移到 {col}",
+        "kb_toast_archived": "已封存",
+        "kb_undo": "撤销",
+        "kb_undo_done": "已撤销",
+        "kb_undo_failed": "撤销失败",
+        "kb_err_move": "移动失败",
+        "chat_sending": "发送中…",
 },
 
 
@@ -2411969,6 +2411985,14 @@ const TRANSLATIONS = {
         "greet_starter_1": "何を手伝ってくれますか？",
         "greet_starter_2": "今日のタスクを計画して",
         "greet_starter_3": "3文で自己紹介して",
+
+        "kb_toast_moved": "{col} に移動しました",
+        "kb_toast_archived": "アーカイブしました",
+        "kb_undo": "元に戻す",
+        "kb_undo_done": "元に戻しました",
+        "kb_undo_failed": "元に戻せませんでした",
+        "kb_err_move": "移動に失敗しました",
+        "chat_sending": "送信中…",
 },
 
 
@@ -2942195,6 +2942219,14 @@ const TRANSLATIONS = {
         "greet_starter_1": "무엇을 도와줄 수 있나요?",
         "greet_starter_2": "오늘 할 일을 계획해 줘",
         "greet_starter_3": "세 문장으로 자기소개해 줘",
+
+        "kb_toast_moved": "{col}(으)로 이동했습니다",
+        "kb_toast_archived": "보관했습니다",
+        "kb_undo": "실행 취소",
+        "kb_undo_done": "실행 취소됨",
+        "kb_undo_failed": "실행 취소 실패",
+        "kb_err_move": "이동 실패",
+        "chat_sending": "전송 중…",
 },
 
 
@@ -2943793,6 +2943825,14 @@ const TRANSLATIONS = {
         "greet_starter_1": "你可以幫我做什麼？",
         "greet_starter_2": "幫我規劃今天的待辦事項",
         "greet_starter_3": "用三句話介紹一下你自己",
+
+        "kb_toast_moved": "已移到 {col}",
+        "kb_toast_archived": "已封存",
+        "kb_undo": "復原",
+        "kb_undo_done": "已復原",
+        "kb_undo_failed": "復原失敗",
+        "kb_err_move": "移動失敗",
+        "chat_sending": "傳送中…",
 },
 
 
@@ -3997355,6 +3997395,14 @@ const TRANSLATIONS = {
         "greet_starter_1": "Bạn có thể giúp tôi những gì?",
         "greet_starter_2": "Giúp tôi lên kế hoạch việc cần làm hôm nay",
         "greet_starter_3": "Giới thiệu bản thân trong ba câu",
+
+        "kb_toast_moved": "Đã chuyển đến {col}",
+        "kb_toast_archived": "Đã lưu trữ",
+        "kb_undo": "Hoàn tác",
+        "kb_undo_done": "Đã hoàn tác",
+        "kb_undo_failed": "Hoàn tác thất bại",
+        "kb_err_move": "Di chuyển thất bại",
+        "chat_sending": "Đang gửi…",
 },
 
 
@@ -4523764,6 +4523812,14 @@ const TRANSLATIONS = {
         "greet_starter_1": "Apa yang bisa kamu bantu?",
         "greet_starter_2": "Bantu saya merencanakan tugas hari ini",
         "greet_starter_3": "Perkenalkan dirimu dalam tiga kalimat",
+
+        "kb_toast_moved": "Dipindahkan ke {col}",
+        "kb_toast_archived": "Diarsipkan",
+        "kb_undo": "Urungkan",
+        "kb_undo_done": "Telah diurungkan",
+        "kb_undo_failed": "Gagal mengurungkan",
+        "kb_err_move": "Gagal memindahkan",
+        "chat_sending": "Mengirim…",
 },
 
 
@@ -5566473,6 +5566529,14 @@ const TRANSLATIONS = {
         "greet_starter_1": "¿En qué puedes ayudarme?",
         "greet_starter_2": "Ayúdame a planificar mis tareas de hoy",
         "greet_starter_3": "Preséntate en tres frases",
+
+        "kb_toast_moved": "Movido a {col}",
+        "kb_toast_archived": "Archivado",
+        "kb_undo": "Deshacer",
+        "kb_undo_done": "Deshecho",
+        "kb_undo_failed": "No se pudo deshacer",
+        "kb_err_move": "Error al mover",
+        "chat_sending": "Enviando…",
 },
 
 

--- a/backend/tests/jest/outbox-ui.test.js
+++ b/backend/tests/jest/outbox-ui.test.js
@@ -203,6 +203,18 @@ describe('outbox-ui — bubble lifecycle + state classes', () => {
         expect(el.classList.contains('msg-outbox-sent')).toBe(true);
     });
 
+    test('setBubbleState supports sending state (online optimistic)', () => {
+        ui.renderQueuedBubble(container, { idempotencyKey: 'k-snd', text: 't' });
+        ui.setBubbleState(container, 'k-snd', 'sending');
+        const el = ui.findBubble(container, 'k-snd');
+        expect(el.classList.contains('msg-outbox-queued')).toBe(false);
+        expect(el.classList.contains('msg-outbox-sending')).toBe(true);
+        // first-attempt failure path: sending → failed
+        ui.setBubbleState(container, 'k-snd', 'failed');
+        expect(el.classList.contains('msg-outbox-sending')).toBe(false);
+        expect(el.classList.contains('msg-outbox-failed')).toBe(true);
+    });
+
     test('setBubbleState ignores unknown state', () => {
         ui.renderQueuedBubble(container, { idempotencyKey: 'k-4', text: 't' });
         ui.setBubbleState(container, 'k-4', 'nonsense');
@@ -277,6 +289,18 @@ describe('outbox-ui — tap handlers', () => {
         expect(onCancel).not.toHaveBeenCalled();
     });
 
+    test('clicking sending bubble triggers neither handler (POST already in flight)', () => {
+        const onCancel = jest.fn();
+        const onFailedMenu = jest.fn();
+        ui.attachTapHandlers(container, { onCancel, onFailedMenu });
+        ui.renderQueuedBubble(container, { idempotencyKey: 'ksnd2', text: 's' });
+        ui.setBubbleState(container, 'ksnd2', 'sending');
+        const el = ui.findBubble(container, 'ksnd2');
+        fireClick(el);
+        expect(onCancel).not.toHaveBeenCalled();
+        expect(onFailedMenu).not.toHaveBeenCalled();
+    });
+
     test('clicking sent bubble triggers neither handler', () => {
         const onCancel = jest.fn();
         const onFailedMenu = jest.fn();
@@ -328,9 +352,13 @@ describe('outbox-ui — chat.html integration contract', () => {
         expect(chatHtml).toMatch(/id="outboxBannerText"/);
     });
 
-    test('enqueue path calls renderQueuedBubble + setBubbleState retrying', () => {
+    test('enqueue path calls renderQueuedBubble + setBubbleState sending (online optimistic, 情緒價值 #2)', () => {
         expect(chatHtml).toMatch(/EclawOutboxUI\.renderQueuedBubble\(/);
-        expect(chatHtml).toMatch(/EclawOutboxUI\.setBubbleState\([^,]+,\s*__idempotencyKey,\s*['"]retrying['"]\)/);
+        expect(chatHtml).toMatch(/EclawOutboxUI\.setBubbleState\([^,]+,\s*__idempotencyKey,\s*['"]sending['"]\)/);
+    });
+
+    test('sending bubble carries a localized aria-label', () => {
+        expect(chatHtml).toMatch(/setAttribute\('aria-label',\s*i18n\.t\('chat_sending'\)/);
     });
 
     test('success path removes the inline bubble', () => {
@@ -374,6 +402,14 @@ describe('outbox-ui — i18n keys exist in EN locale', () => {
         'chat_outbox_cancel_confirm',
         'chat_outbox_failed_retry_q',
         'chat_outbox_failed_delete_q',
+        // 情緒價值 #2 (card_c575aacae639721dbc8cfaa3)
+        'chat_sending',
+        'kb_toast_moved',
+        'kb_toast_archived',
+        'kb_undo',
+        'kb_undo_done',
+        'kb_undo_failed',
+        'kb_err_move',
     ];
     test.each(NEEDED)('%s is declared in i18n.js', (key) => {
         expect(i18nJs).toMatch(new RegExp('"' + key + '":'));


### PR DESCRIPTION
## Scope (card_c575aacae639721dbc8cfaa3, parent 情緒價值盤點 #6-rank 🥈)

1. **Kanban move** (drag-drop + overflow menu): card visually moves immediately; server confirm in background; failure (e.g. done-gate) reverts + error toast; success shows「已移到 <欄> — 復原」undo toast (5s). Undo moves back and re-fetches board (server-state consistency).
2. **Kanban archive**: card disappears immediately after the existing danger-confirm; toast「已封存 — 復原」; undo calls existing `POST /card/:id/restore`; server failure reverts the local removal.
3. **Chat send**: first online attempt renders the card_751 outbox bubble in a new `sending` state (normal bubble look, dimmed + spinner, localized `aria-label`) instead of `retrying`; offline queue semantics untouched (no scope overlap with card_751 — queue bookkeeping still markRetrying).

## Implementation
- `showUndoToast(msg, onUndo, 5000)` + `optimisticMove`/`undoMove` in kanban.html; `#kbToast` now `role=status aria-live=polite`
- `outbox-ui.js` STATES + `sending` (not tap-cancellable; classifyClick branches unchanged)
- i18n: `kb_toast_moved/kb_toast_archived/kb_undo/kb_undo_done/kb_undo_failed/kb_err_move/chat_sending` ×8 locales via `backend/scripts/i18n-insert-locale-keys.js` (espree AST)

## Tests
- Jest: outbox-ui suite 41/41 (new: sending-state transitions, sending-click no-op, contract regex updated to 'sending', 7 i18n key presence checks); **full suite 270 suites / 3743 passed**
- Post-deploy prod E2E (Playwright): move/undo, archive/undo, chat sending — screenshots to card /file (follow-up on this card before close)

🤖 Generated with [Claude Code](https://claude.com/claude-code)