### PR TITLE
feat(dashboard): level-up celebration overlay — 情緒價值 #3

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -1960,6 +1960,37 @@
             .uw-bar-label { font-size: 12px; }
             .uw-bar-pct { font-size: 13px; }
         }
+
+        /* ── Level-up celebration (情緒價值 #3, card_91c97a12a385cac144ad223e) ── */
+        .lvlup-overlay {
+            position: fixed; inset: 0; z-index: 10050;
+            display: flex; align-items: center; justify-content: center;
+            background: rgba(0,0,0,0.45); pointer-events: none; overflow: hidden;
+        }
+        .lvlup-card {
+            background: var(--card, #1b1b2f); border: 1px solid var(--card-border, #333);
+            border-radius: 18px; padding: 28px 44px; text-align: center;
+            box-shadow: 0 18px 60px rgba(108,99,255,0.35);
+            animation: lvlup-pop 0.45s cubic-bezier(0.18, 1.4, 0.4, 1);
+        }
+        .lvlup-badge { font-size: 44px; animation: lvlup-spin 1.2s ease-in-out; }
+        .lvlup-title { font-size: 26px; font-weight: 800; color: #fbbf24; margin-top: 6px; }
+        .lvlup-name { font-size: 14px; color: var(--text-secondary, #aaa); margin-top: 4px; }
+        .lvlup-praise { font-size: 15px; font-weight: 600; color: var(--text-primary, #fff); margin-top: 10px; }
+        .lvlup-confetti {
+            position: absolute; top: -12px; width: 10px; height: 14px; border-radius: 2px;
+            animation: lvlup-fall 1.5s linear forwards;
+        }
+        @keyframes lvlup-pop { 0% { transform: scale(0.4); opacity: 0; } 100% { transform: scale(1); opacity: 1; } }
+        @keyframes lvlup-spin { 0% { transform: rotate(-25deg) scale(0.3); } 60% { transform: rotate(12deg) scale(1.25); } 100% { transform: rotate(0) scale(1); } }
+        @keyframes lvlup-fall { 0% { transform: translateY(0) rotate(0); opacity: 1; } 100% { transform: translateY(105vh) rotate(540deg); opacity: 0.6; } }
+        /* reduced-motion → static banner, no confetti / pop / spin */
+        .lvlup-overlay.lvlup-reduced .lvlup-card,
+        .lvlup-overlay.lvlup-reduced .lvlup-badge { animation: none; }
+        @media (prefers-reduced-motion: reduce) {
+            .lvlup-card, .lvlup-badge { animation: none !important; }
+            .lvlup-confetti { display: none; }
+        }
     </style>
     <link rel="canonical" href="https://eclawbot.com/portal/dashboard.html">
 </head>
@@ -2557,6 +2588,7 @@
     <script src="shared/nav.js"></script>
     <script src="shared/auth.js"></script>
     <script src="shared/entity-utils.js"></script>
+    <script src="shared/levelup.js"></script>
     <script src="../shared/petdx-renderer.js"></script>
     <script src="../shared/avatar-petdx.js"></script>
     <script src="../shared/telemetry.js"></script>
@@ -2939,6 +2971,14 @@
 
                 entities = newEntities;
                 updateEntityMaps(entities);
+
+                // 情緒價值 #3: celebrate level-ups detected across poll cycles.
+                // First poll only primes the baseline; failures never block the dashboard.
+                try {
+                    if (window.EclawLevelUp) {
+                        EclawLevelUp.onEntitiesUpdated(entities, { t: (k) => i18n.t(k) });
+                    }
+                } catch (_e) { /* celebration is best-effort */ }
 
                 if (window.AvatarPetdx && currentUser && currentUser.deviceSecret) {
                     const entityIds = entities.map(e => e.entityId).filter(Boolean);

--- a/backend/public/portal/shared/levelup.js
+++ b/backend/public/portal/shared/levelup.js
@@ -1,0 +1,166 @@
+/**
+ * Level-up celebration — 情緒價值 #3 (card_91c97a12a385cac144ad223e).
+ *
+ * Watches the entity list the dashboard already polls (10s interval) and
+ * fires a 1.5s full-screen celebration when an entity's level increases
+ * during the session. Pure logic (diff + guards) is separated from the DOM
+ * bits so Jest can drive it without a browser:
+ *
+ *   check(entities, storage)  — returns [{entityId, name, level}] to celebrate
+ *   celebrate(hit, opts)      — renders the overlay (auto-removes ~1.5s)
+ *
+ * Guards:
+ *   - first sighting of an entity in a session only primes the baseline
+ *     (no celebration on page load)
+ *   - localStorage `eclaw_lvlup_<entityId>` keeps the highest celebrated
+ *     level so the same level never celebrates twice across reloads
+ *   - prefers-reduced-motion → static banner, no confetti / scale
+ *
+ * First-achievement celebrations (tasks_done 0→1) intentionally NOT here —
+ * they wait on card_8ca's achievements API per the card's dependency note.
+ */
+(function (global) {
+    'use strict';
+
+    var PRAISE_KEYS = [
+        'levelup_praise_1', 'levelup_praise_2', 'levelup_praise_3',
+        'levelup_praise_4', 'levelup_praise_5'
+    ];
+    var GUARD_PREFIX = 'eclaw_lvlup_';
+
+    // session baseline: entityId -> last seen level
+    var _seen = {};
+
+    function _guardKey(entityId) { return GUARD_PREFIX + String(entityId); }
+
+    function _celebratedLevel(storage, entityId) {
+        try {
+            var v = storage.getItem(_guardKey(entityId));
+            return v === null ? 0 : (parseInt(v, 10) || 0);
+        } catch (_e) { return 0; }
+    }
+
+    function _markCelebrated(storage, entityId, level) {
+        try { storage.setItem(_guardKey(entityId), String(level)); } catch (_e) { /* quota */ }
+    }
+
+    /**
+     * Diff the fresh entity list against the session baseline.
+     * Returns the entities whose level rose AND that haven't celebrated
+     * this level before (localStorage guard). Always advances the baseline.
+     */
+    function check(entities, storage) {
+        storage = storage || global.localStorage;
+        var hits = [];
+        (entities || []).forEach(function (e) {
+            if (!e || e.entityId === undefined || e.entityId === null) return;
+            var id = e.entityId;
+            var level = e.level || 1;
+            var prev = _seen[id];
+            _seen[id] = level;
+            if (prev === undefined) return;            // baseline priming, not a level-up
+            if (level <= prev) return;                 // no increase
+            if (level <= _celebratedLevel(storage, id)) return; // already celebrated
+            _markCelebrated(storage, id, level);
+            hits.push({ entityId: id, name: e.name || ('#' + id), level: level });
+        });
+        return hits;
+    }
+
+    /** Test hook: reset the session baseline. */
+    function _resetSession() { _seen = {}; }
+
+    function _prefersReducedMotion() {
+        try {
+            return global.matchMedia && global.matchMedia('(prefers-reduced-motion: reduce)').matches;
+        } catch (_e) { return false; }
+    }
+
+    function _pickPraise(t) {
+        var key = PRAISE_KEYS[Math.floor(Math.random() * PRAISE_KEYS.length)];
+        var v = (typeof t === 'function') ? t(key) : null;
+        return (v && v !== key) ? v : 'Great work!';
+    }
+
+    /**
+     * Render the celebration overlay. opts: { t (i18n fn), doc, duration }.
+     * Returns the overlay element (mostly for tests).
+     */
+    function celebrate(hit, opts) {
+        opts = opts || {};
+        var doc = opts.doc || global.document;
+        var t = opts.t;
+        var duration = opts.duration || 1500;
+        var reduced = _prefersReducedMotion();
+
+        var prev = doc.getElementById('lvlupOverlay');
+        if (prev && prev.parentNode) prev.parentNode.removeChild(prev);
+
+        var overlay = doc.createElement('div');
+        overlay.id = 'lvlupOverlay';
+        overlay.className = 'lvlup-overlay' + (reduced ? ' lvlup-reduced' : '');
+        overlay.setAttribute('role', 'status');
+        overlay.setAttribute('aria-live', 'polite');
+
+        var titleTpl = (typeof t === 'function' && t('levelup_title') !== 'levelup_title' && t('levelup_title'))
+            ? t('levelup_title') : 'Level {n}!';
+        var card = doc.createElement('div');
+        card.className = 'lvlup-card';
+        var badge = doc.createElement('div');
+        badge.className = 'lvlup-badge';
+        badge.textContent = '⭐';
+        var title = doc.createElement('div');
+        title.className = 'lvlup-title';
+        title.textContent = titleTpl.replace('{n}', String(hit.level));
+        var who = doc.createElement('div');
+        who.className = 'lvlup-name';
+        who.textContent = hit.name;
+        var praise = doc.createElement('div');
+        praise.className = 'lvlup-praise';
+        praise.textContent = _pickPraise(t);
+        card.appendChild(badge); card.appendChild(title);
+        card.appendChild(who); card.appendChild(praise);
+        overlay.appendChild(card);
+
+        if (!reduced) {
+            for (var i = 0; i < 24; i++) {
+                var c = doc.createElement('span');
+                c.className = 'lvlup-confetti';
+                c.style.left = (Math.random() * 100) + '%';
+                c.style.animationDelay = (Math.random() * 0.4) + 's';
+                c.style.background = ['#6c63ff', '#4ade80', '#fbbf24', '#f472b6', '#38bdf8'][i % 5];
+                overlay.appendChild(c);
+            }
+        }
+
+        doc.body.appendChild(overlay);
+        setTimeout(function () {
+            if (overlay.parentNode) overlay.parentNode.removeChild(overlay);
+        }, duration);
+        return overlay;
+    }
+
+    /** Convenience: diff + celebrate each hit (stagger if multiple). */
+    function onEntitiesUpdated(entities, opts) {
+        opts = opts || {};
+        var hits = check(entities, opts.storage);
+        hits.forEach(function (hit, idx) {
+            setTimeout(function () { celebrate(hit, opts); }, idx * 1700);
+        });
+        return hits;
+    }
+
+    var api = {
+        check: check,
+        celebrate: celebrate,
+        onEntitiesUpdated: onEntitiesUpdated,
+        _resetSession: _resetSession,
+        PRAISE_KEYS: PRAISE_KEYS,
+    };
+
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = api;
+    } else if (global) {
+        global.EclawLevelUp = api;
+    }
+})(typeof window !== 'undefined' ? window : (typeof global !== 'undefined' ? global : this));

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650152,6 +650152,13 @@ const TRANSLATIONS = {
         "kb_undo_failed": "Undo failed",
         "kb_err_move": "Move failed",
         "chat_sending": "Sending…",
+
+        "levelup_title": "Level {n}!",
+        "levelup_praise_1": "Amazing progress — keep it up!",
+        "levelup_praise_2": "Your agent is getting stronger!",
+        "levelup_praise_3": "Hard work pays off!",
+        "levelup_praise_4": "A new milestone unlocked!",
+        "levelup_praise_5": "Onward and upward!",
 },
 
 
@@ -1234771,6 +1234778,13 @@ const TRANSLATIONS = {
         "kb_undo_failed": "撤销失败",
         "kb_err_move": "移动失败",
         "chat_sending": "发送中…",
+
+        "levelup_title": "升到 Lv.{n}！",
+        "levelup_praise_1": "进步神速，继续保持！",
+        "levelup_praise_2": "你的智能体越来越强了！",
+        "levelup_praise_3": "努力没有白费！",
+        "levelup_praise_4": "解锁新的里程碑！",
+        "levelup_praise_5": "更上一层楼！",
 },
 
 
@@ -2411993,6 +2412007,13 @@ const TRANSLATIONS = {
         "kb_undo_failed": "元に戻せませんでした",
         "kb_err_move": "移動に失敗しました",
         "chat_sending": "送信中…",
+
+        "levelup_title": "Lv.{n} にアップ！",
+        "levelup_praise_1": "すごい成長です — この調子！",
+        "levelup_praise_2": "エージェントがどんどん強くなっています！",
+        "levelup_praise_3": "努力が実りました！",
+        "levelup_praise_4": "新しいマイルストーン達成！",
+        "levelup_praise_5": "さらなる高みへ！",
 },
 
 
@@ -2942227,6 +2942248,13 @@ const TRANSLATIONS = {
         "kb_undo_failed": "실행 취소 실패",
         "kb_err_move": "이동 실패",
         "chat_sending": "전송 중…",
+
+        "levelup_title": "Lv.{n} 달성!",
+        "levelup_praise_1": "놀라운 성장이에요 — 계속 화이팅!",
+        "levelup_praise_2": "에이전트가 점점 강해지고 있어요!",
+        "levelup_praise_3": "노력이 결실을 맺었어요!",
+        "levelup_praise_4": "새로운 이정표 달성!",
+        "levelup_praise_5": "더 높은 곳으로!",
 },
 
 
@@ -2943833,6 +2943861,13 @@ const TRANSLATIONS = {
         "kb_undo_failed": "復原失敗",
         "kb_err_move": "移動失敗",
         "chat_sending": "傳送中…",
+
+        "levelup_title": "升到 Lv.{n}！",
+        "levelup_praise_1": "進步神速，繼續保持！",
+        "levelup_praise_2": "你的智能體越來越強了！",
+        "levelup_praise_3": "努力沒有白費！",
+        "levelup_praise_4": "解鎖新的里程碑！",
+        "levelup_praise_5": "更上一層樓！",
 },
 
 
@@ -3997403,6 +3997438,13 @@ const TRANSLATIONS = {
         "kb_undo_failed": "Hoàn tác thất bại",
         "kb_err_move": "Di chuyển thất bại",
         "chat_sending": "Đang gửi…",
+
+        "levelup_title": "Lên cấp {n}!",
+        "levelup_praise_1": "Tiến bộ tuyệt vời — cố lên!",
+        "levelup_praise_2": "Agent của bạn ngày càng mạnh hơn!",
+        "levelup_praise_3": "Nỗ lực đã được đền đáp!",
+        "levelup_praise_4": "Mở khóa cột mốc mới!",
+        "levelup_praise_5": "Tiến lên phía trước!",
 },
 
 
@@ -4523820,6 +4523862,13 @@ const TRANSLATIONS = {
         "kb_undo_failed": "Gagal mengurungkan",
         "kb_err_move": "Gagal memindahkan",
         "chat_sending": "Mengirim…",
+
+        "levelup_title": "Naik ke Lv.{n}!",
+        "levelup_praise_1": "Kemajuan luar biasa — pertahankan!",
+        "levelup_praise_2": "Agenmu semakin kuat!",
+        "levelup_praise_3": "Kerja keras membuahkan hasil!",
+        "levelup_praise_4": "Tonggak baru terbuka!",
+        "levelup_praise_5": "Terus melangkah maju!",
 },
 
 
@@ -5566537,6 +5566586,13 @@ const TRANSLATIONS = {
         "kb_undo_failed": "No se pudo deshacer",
         "kb_err_move": "Error al mover",
         "chat_sending": "Enviando…",
+
+        "levelup_title": "¡Nivel {n}!",
+        "levelup_praise_1": "¡Progreso increíble — sigue así!",
+        "levelup_praise_2": "¡Tu agente es cada vez más fuerte!",
+        "levelup_praise_3": "¡El esfuerzo da sus frutos!",
+        "levelup_praise_4": "¡Nuevo hito desbloqueado!",
+        "levelup_praise_5": "¡Siempre hacia arriba!",
 },
 
 

--- a/backend/tests/jest/levelup.test.js
+++ b/backend/tests/jest/levelup.test.js
@@ -1,0 +1,118 @@
+/**
+ * Level-up celebration logic — 情緒價值 #3 (card_91c97a12a385cac144ad223e).
+ *
+ * Drives shared/levelup.js check() (session diff + localStorage guard) under
+ * node without a DOM. celebrate()'s DOM work is covered by the prod
+ * Playwright E2E; here we lock the pure logic that decides WHEN to fire.
+ */
+'use strict';
+
+const path = require('path');
+
+function loadLevelUp() {
+    const p = path.join(__dirname, '..', '..', 'public', 'portal', 'shared', 'levelup.js');
+    delete require.cache[require.resolve(p)];
+    return require(p);
+}
+
+function makeStorage(initial) {
+    const map = new Map(Object.entries(initial || {}));
+    return {
+        getItem: (k) => (map.has(k) ? map.get(k) : null),
+        setItem: (k, v) => map.set(k, String(v)),
+        _dump: () => Object.fromEntries(map),
+    };
+}
+
+describe('levelup — check() session diff', () => {
+    let lvl, storage;
+    beforeEach(() => {
+        lvl = loadLevelUp();
+        lvl._resetSession();
+        storage = makeStorage();
+    });
+
+    test('first sighting primes baseline, never celebrates', () => {
+        const hits = lvl.check([{ entityId: 2, name: 'LOBSTER', level: 7 }], storage);
+        expect(hits).toEqual([]);
+    });
+
+    test('level increase after baseline celebrates once with entity info', () => {
+        lvl.check([{ entityId: 2, name: 'LOBSTER', level: 7 }], storage);
+        const hits = lvl.check([{ entityId: 2, name: 'LOBSTER', level: 8 }], storage);
+        expect(hits).toEqual([{ entityId: 2, name: 'LOBSTER', level: 8 }]);
+    });
+
+    test('same level on next poll does not re-celebrate', () => {
+        lvl.check([{ entityId: 2, level: 7 }], storage);
+        lvl.check([{ entityId: 2, level: 8 }], storage);
+        expect(lvl.check([{ entityId: 2, level: 8 }], storage)).toEqual([]);
+    });
+
+    test('level decrease never celebrates', () => {
+        lvl.check([{ entityId: 2, level: 7 }], storage);
+        expect(lvl.check([{ entityId: 2, level: 6 }], storage)).toEqual([]);
+    });
+
+    test('localStorage guard survives session reset (reload simulation)', () => {
+        lvl.check([{ entityId: 2, level: 7 }], storage);
+        lvl.check([{ entityId: 2, level: 8 }], storage); // celebrated, guard=8
+        lvl._resetSession();                              // simulate reload
+        lvl.check([{ entityId: 2, level: 7 }], storage);  // stale baseline first
+        // poll catches up to 8 again — guard must block the duplicate
+        expect(lvl.check([{ entityId: 2, level: 8 }], storage)).toEqual([]);
+        // but a genuinely new level still fires
+        expect(lvl.check([{ entityId: 2, level: 9 }], storage)).toEqual([
+            { entityId: 2, name: '#2', level: 9 },
+        ]);
+    });
+
+    test('multiple entities level up in one poll → multiple hits', () => {
+        lvl.check([{ entityId: 1, level: 3 }, { entityId: 2, level: 5 }], storage);
+        const hits = lvl.check([{ entityId: 1, level: 4 }, { entityId: 2, level: 6 }], storage);
+        expect(hits.map(h => h.entityId).sort()).toEqual([1, 2]);
+    });
+
+    test('missing level defaults to 1, null entity rows are skipped', () => {
+        expect(() => lvl.check([null, { entityId: 3 }], storage)).not.toThrow();
+        const hits = lvl.check([{ entityId: 3, level: 2 }], storage);
+        expect(hits).toEqual([{ entityId: 3, name: '#3', level: 2 }]);
+    });
+});
+
+describe('levelup — dashboard integration contract', () => {
+    const fs = require('fs');
+    const dashHtml = fs.readFileSync(
+        path.join(__dirname, '..', '..', 'public', 'portal', 'dashboard.html'),
+        'utf8'
+    );
+
+    test('levelup.js is loaded as a portal script', () => {
+        expect(dashHtml).toMatch(/<script src="shared\/levelup\.js"><\/script>/);
+    });
+
+    test('loadEntities hooks onEntitiesUpdated inside a try guard', () => {
+        expect(dashHtml).toMatch(/EclawLevelUp\.onEntitiesUpdated\(entities/);
+    });
+
+    test('reduced-motion CSS disables confetti + animations', () => {
+        expect(dashHtml).toMatch(/prefers-reduced-motion:\s*reduce/);
+        expect(dashHtml).toMatch(/\.lvlup-confetti\s*\{\s*display:\s*none;\s*\}/);
+    });
+});
+
+describe('levelup — i18n keys exist', () => {
+    const fs = require('fs');
+    const i18nJs = fs.readFileSync(
+        path.join(__dirname, '..', '..', 'public', 'shared', 'i18n.js'),
+        'utf8'
+    );
+    const NEEDED = [
+        'levelup_title',
+        'levelup_praise_1', 'levelup_praise_2', 'levelup_praise_3',
+        'levelup_praise_4', 'levelup_praise_5',
+    ];
+    test.each(NEEDED)('%s is declared in i18n.js', (key) => {
+        expect(i18nJs).toMatch(new RegExp('"' + key + '":'));
+    });
+});


### PR DESCRIPTION
## Scope (card_91c97a12a385cac144ad223e, parent 情緒價值盤點 #6-rank 🥉)

Entity level-up celebration on the dashboard (level data already polled every 10s):
- `shared/levelup.js` — `check()` diffs levels across poll cycles (first sighting only primes the baseline → no celebration on page load); localStorage `eclaw_lvlup_<entityId>` guards each level to one celebration across reloads; `celebrate()` renders a 1.5s auto-dismiss overlay: ⭐ badge, 「升到 Lv.N！」, entity name, random praise from a 5-message pool.
- `prefers-reduced-motion: reduce` → static banner (no confetti / pop / spin), per acceptance.
- Multiple simultaneous level-ups stagger 1.7s apart.
- Overlay is `pointer-events:none` + `role=status aria-live=polite` — never blocks the dashboard.

## Out of scope (per card)
First-achievement (tasks_done 0→1) waits on card_8ca's achievements API.

## Tests
- Jest: 16 new (baseline priming, single-fire, decrease ignore, reload-guard, multi-entity, integration contract, i18n key presence) — **full suite 271 suites / 3759 passed**
- Post-deploy prod E2E with mocked level-up + reduced-motion run + screenshots to card /file before close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)