### PR TITLE
feat(entity-status): Achievements UI — section + drill-down chips + i18n (card_8ca0b6ac)

### DIFF
--- a/backend/public/portal/shared/entity-status-panel.js
+++ b/backend/public/portal/shared/entity-status-panel.js
@@ -33,6 +33,25 @@
         kanban_nudge_no_reply: 'Task nudges not acted on',
         system_msg_no_reply:   'System msgs not acked',
     };
+    // Achievements (card_8ca0b6acb1fb3d7a0b650dfd). Shared i18n.js carries the
+    // same strings under entity_status_achievement_* for pages that load i18n;
+    // these local dicts are the fallback for pages that don't.
+    const ACHIEVEMENT_LABELS_ZH = {
+        tasks_done:     '完成任務數',
+        chat_upvotes:   '聊天泡泡 👍',
+        chat_downvotes: '聊天泡泡 👎',
+        prs_merged:     '合併的 PR 數',
+        cards_reviewed: '評審參與數',
+        notes_authored: '撰寫的筆記數',
+    };
+    const ACHIEVEMENT_LABELS_EN = {
+        tasks_done:     'Tasks completed',
+        chat_upvotes:   'Chat bubble 👍',
+        chat_downvotes: 'Chat bubble 👎',
+        prs_merged:     'PRs merged',
+        cards_reviewed: 'Cards reviewed',
+        notes_authored: 'Notes authored',
+    };
 
     let rootEl = null;
     let currentEid = null;
@@ -74,6 +93,22 @@
         const lang = (document.documentElement.getAttribute('lang') || 'en').toLowerCase();
         const isZh = lang.startsWith('zh') || lang === 'tw' || lang === 'cn';
         const dict = isZh ? COUNTER_LABELS_ZH : COUNTER_LABELS_EN;
+        return dict[axis] || axis;
+    }
+
+    function pickAchievementLabel(axis) {
+        // Prefer the shared i18n dictionary when the host page loaded it —
+        // covers all 8 locales; the local zh/en dicts are the fallback.
+        const key = 'entity_status_achievement_' + axis;
+        try {
+            if (window.i18n && typeof window.i18n.t === 'function') {
+                const v = window.i18n.t(key);
+                if (v && v !== key) return v;
+            }
+        } catch (_) { /* fall through */ }
+        const lang = (document.documentElement.getAttribute('lang') || 'en').toLowerCase();
+        const isZh = lang.startsWith('zh') || lang === 'tw' || lang === 'cn';
+        const dict = isZh ? ACHIEVEMENT_LABELS_ZH : ACHIEVEMENT_LABELS_EN;
         return dict[axis] || axis;
     }
 
@@ -126,6 +161,25 @@
         const qs = _credQs();
         qs.set('limit', '50');
         const res = await fetch(`/api/entity-status/${eid}/counter/${encodeURIComponent(axis)}/events?${qs.toString()}`, {
+            credentials: 'include',
+        });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        return res.json();
+    }
+
+    async function fetchAchievements(eid) {
+        const qs = _credQs();
+        const res = await fetch(`/api/entity-status/${eid}/achievements?${qs.toString()}`, {
+            credentials: 'include',
+        });
+        if (!res.ok) throw new Error('HTTP ' + res.status);
+        return res.json();
+    }
+
+    async function fetchAchievementEvents(eid, axis) {
+        const qs = _credQs();
+        qs.set('limit', '50');
+        const res = await fetch(`/api/entity-status/${eid}/achievement/${encodeURIComponent(axis)}/events?${qs.toString()}`, {
             credentials: 'include',
         });
         if (!res.ok) throw new Error('HTTP ' + res.status);
@@ -350,11 +404,18 @@
                 </header>
                 <div class="${ROOT_CLASS}__help-popover" data-role="help-popover" hidden>
                     <p><strong>Counters</strong> — each row counts open events the entity hasn&#39;t acted on. Number is live: it drops as the entity replies. Click a counter to see <em>which</em> events.</p>
+                    <p><strong>Achievements</strong> — cumulative wins: tasks completed, chat 👍/👎, reviews, notes. Click a row to see the contributing cards / messages as chips.</p>
                     <p><strong>Operation log</strong> — recent kanban / message / system events for this entity, newest first. Card chips open the card&#39;s popover; ${ICON_QUOTE} quotes the row into your chat composer.</p>
                 </div>
                 <section class="${ROOT_CLASS}__section" data-section="counters">
                     <h3 class="${ROOT_CLASS}__section-title">累計錯誤次數 / Error counters</h3>
                     <ul class="${ROOT_CLASS}__counter-list" data-role="counter-list">
+                        <li class="${ROOT_CLASS}__counter-row" data-state="loading">Loading…</li>
+                    </ul>
+                </section>
+                <section class="${ROOT_CLASS}__section" data-section="achievements">
+                    <h3 class="${ROOT_CLASS}__section-title">成就 / Achievements</h3>
+                    <ul class="${ROOT_CLASS}__counter-list" data-role="achievement-list">
                         <li class="${ROOT_CLASS}__counter-row" data-state="loading">Loading…</li>
                     </ul>
                 </section>
@@ -395,7 +456,14 @@
             const counterRow = e.target.closest && e.target.closest(`.${ROOT_CLASS}__counter-row[data-axis]`);
             if (counterRow && !e.target.closest(`.${ROOT_CLASS}__counter-events`)) {
                 const axis = counterRow.dataset.axis;
-                if (axis) toggleCounterDrilldown(root, eid, axis, counterRow);
+                // Achievement rows reuse the counter row class for identical
+                // styling; data-kind distinguishes which drill-down endpoint
+                // the click hits.
+                if (axis && counterRow.dataset.kind === 'achievement') {
+                    toggleAchievementDrilldown(root, eid, axis, counterRow);
+                } else if (axis) {
+                    toggleCounterDrilldown(root, eid, axis, counterRow);
+                }
                 e.stopPropagation();
                 return;
             }
@@ -485,6 +553,100 @@
                 <span class="${ROOT_CLASS}__counter-event-chip">${chipHtml}</span>
             </li>`;
         }).join('');
+    }
+
+    function renderAchievements(root, items) {
+        const list = root.querySelector('[data-role="achievement-list"]');
+        if (!list) return;
+        if (!items || items.length === 0) {
+            const empty = pickAchievementLabel('no_events') !== 'no_events'
+                ? pickAchievementLabel('no_events') : 'No achievements yet.';
+            list.innerHTML = `<li class="${ROOT_CLASS}__counter-row" data-state="empty">${escapeHtml(empty)}</li>`;
+            return;
+        }
+        list.innerHTML = items.map(a => `
+            <li class="${ROOT_CLASS}__counter-row" data-axis="${escapeHtml(a.axis)}" data-kind="achievement"
+                role="button" tabindex="0"
+                aria-expanded="false"
+                aria-label="${escapeHtml(pickAchievementLabel(a.axis))}: ${Number(a.count) || 0}. Click to see contributing events.">
+                ${SVG_CHEVRON}
+                <span class="${ROOT_CLASS}__counter-label">${escapeHtml(pickAchievementLabel(a.axis))}</span>
+                <span class="${ROOT_CLASS}__counter-value">${Number(a.count) || 0}</span>
+            </li>`).join('');
+    }
+
+    // Achievement drill-down rows: (timestamp, chip). Backend chip shapes:
+    //   {kind:'card', cardId, label} → src://kanban/card/<bare> preview chip
+    //   {kind:'chat', messageId, excerpt} → message-coord chip
+    //   {kind:'note', noteId, label} → plain chip (no preview route for notes)
+    function renderAchievementEvents(items) {
+        if (!items || items.length === 0) {
+            const empty = (function () {
+                try {
+                    if (window.i18n && typeof window.i18n.t === 'function') {
+                        const v = window.i18n.t('entity_status_achievement_no_events');
+                        if (v && v !== 'entity_status_achievement_no_events') return v;
+                    }
+                } catch (_) { /* fall through */ }
+                return 'No events yet.';
+            })();
+            return `<li class="${ROOT_CLASS}__counter-event-row" data-state="empty">${escapeHtml(empty)}</li>`;
+        }
+        return items.map(it => {
+            const ts = formatTs(it.ts);
+            const chip = it.chip || {};
+            let chipHtml = '';
+            if (chip.kind === 'card' && chip.cardId) {
+                const cardId = String(chip.cardId);
+                const bareId = cardId.replace(/^card_/, '');
+                const srcRef = 'src://kanban/card/' + bareId;
+                const color = STATUS_COLOR.done; // contributing cards are done/reviewed
+                const label = chip.label ? String(chip.label).slice(0, 26) : cardId.slice(0, 12);
+                chipHtml = `<span class="autolink-chip ${ROOT_CLASS}__chip" `
+                    + `data-ref-type="src" data-ref-id="${escapeHtml(srcRef)}" `
+                    + `data-card-id="${escapeHtml(cardId)}" `
+                    + `style="background:${color}22;border-color:${color};color:${color};" `
+                    + `title="${escapeHtml(chip.label || cardId)}">${escapeHtml(label)}</span>`;
+            } else if (chip.kind === 'chat' && chip.messageId) {
+                const label = chip.excerpt ? String(chip.excerpt).slice(0, 26) : ('msg ' + String(chip.messageId).slice(-6));
+                chipHtml = `<span class="autolink-chip ${ROOT_CLASS}__chip" `
+                    + `data-ref-type="message" data-ref-id="${escapeHtml(chip.messageId)}" `
+                    + `title="${escapeHtml(chip.excerpt || chip.messageId)}">${escapeHtml(label)}</span>`;
+            } else {
+                const label = chip.label ? String(chip.label).slice(0, 26) : (chip.kind || 'event');
+                chipHtml = `<span class="${ROOT_CLASS}__chip" title="${escapeHtml(chip.label || '')}">${escapeHtml(label)}</span>`;
+            }
+            return `<li class="${ROOT_CLASS}__counter-event-row">
+                <time class="${ROOT_CLASS}__counter-event-time">${escapeHtml(ts)}</time>
+                <span class="${ROOT_CLASS}__counter-event-chip">${chipHtml}</span>
+            </li>`;
+        }).join('');
+    }
+
+    async function toggleAchievementDrilldown(root, eid, axis, row) {
+        if (!row) return;
+        const existing = row.nextElementSibling
+            && row.nextElementSibling.matches(`.${ROOT_CLASS}__counter-events[data-axis="${axis}"]`)
+            ? row.nextElementSibling : null;
+        if (existing) {
+            existing.remove();
+            row.setAttribute('aria-expanded', 'false');
+            row.classList.remove(`${ROOT_CLASS}__counter-row--expanded`);
+            return;
+        }
+        const list = document.createElement('ul');
+        list.className = `${ROOT_CLASS}__counter-events`;
+        list.dataset.axis = axis;
+        list.innerHTML = `<li class="${ROOT_CLASS}__counter-event-row" data-state="loading">Loading…</li>`;
+        row.insertAdjacentElement('afterend', list);
+        row.setAttribute('aria-expanded', 'true');
+        row.classList.add(`${ROOT_CLASS}__counter-row--expanded`);
+        try {
+            const data = await fetchAchievementEvents(eid, axis);
+            list.innerHTML = renderAchievementEvents(data.items || []);
+        } catch (err) {
+            list.innerHTML = `<li class="${ROOT_CLASS}__counter-event-row" data-state="error">Failed to load: ${escapeHtml(err.message)}</li>`;
+        }
     }
 
     async function toggleCounterDrilldown(root, eid, axis, counterRow) {
@@ -616,15 +778,27 @@
         // ESC closes.
         document.addEventListener('keydown', _onEsc);
 
-        try {
-            const data = await fetchStatus(targetEid);
-            renderCounters(rootEl, data.counters);
-        } catch (err) {
-            const list = rootEl.querySelector('[data-role="counter-list"]');
-            if (list) {
-                list.innerHTML = `<li class="${ROOT_CLASS}__counter-row" data-state="error">Failed to load: ${err.message}</li>`;
+        // Counters + achievements fetch concurrently; either failing leaves
+        // its own section in an error state without blocking the other.
+        const statusP = fetchStatus(targetEid).then(
+            (data) => renderCounters(rootEl, data.counters),
+            (err) => {
+                const list = rootEl && rootEl.querySelector('[data-role="counter-list"]');
+                if (list) {
+                    list.innerHTML = `<li class="${ROOT_CLASS}__counter-row" data-state="error">Failed to load: ${escapeHtml(err.message)}</li>`;
+                }
             }
-        }
+        );
+        const achP = fetchAchievements(targetEid).then(
+            (data) => renderAchievements(rootEl, data.achievements),
+            (err) => {
+                const list = rootEl && rootEl.querySelector('[data-role="achievement-list"]');
+                if (list) {
+                    list.innerHTML = `<li class="${ROOT_CLASS}__counter-row" data-state="error">Failed to load: ${escapeHtml(err.message)}</li>`;
+                }
+            }
+        );
+        await Promise.all([statusP, achP]);
 
         // Initial log fetch + infinite scroll setup.
         logCursor = null;
@@ -667,7 +841,11 @@
             const active = document.activeElement;
             if (active && active.classList && active.classList.contains(ROOT_CLASS + '__counter-row') && active.dataset.axis) {
                 e.preventDefault();
-                toggleCounterDrilldown(rootEl, currentEid, active.dataset.axis, active);
+                if (active.dataset.kind === 'achievement') {
+                    toggleAchievementDrilldown(rootEl, currentEid, active.dataset.axis, active);
+                } else {
+                    toggleCounterDrilldown(rootEl, currentEid, active.dataset.axis, active);
+                }
             }
         }
     }

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650159,6 +650159,15 @@ const TRANSLATIONS = {
         "levelup_praise_3": "Hard work pays off!",
         "levelup_praise_4": "A new milestone unlocked!",
         "levelup_praise_5": "Onward and upward!",
+
+        "entity_status_achievements_section_title": "Achievements",
+        "entity_status_achievement_tasks_done": "Tasks completed",
+        "entity_status_achievement_chat_upvotes": "Chat bubble 👍",
+        "entity_status_achievement_chat_downvotes": "Chat bubble 👎",
+        "entity_status_achievement_prs_merged": "PRs merged",
+        "entity_status_achievement_cards_reviewed": "Cards reviewed",
+        "entity_status_achievement_notes_authored": "Notes authored",
+        "entity_status_achievement_no_events": "No events yet.",
 },
 
 
@@ -1234785,6 +1234794,15 @@ const TRANSLATIONS = {
         "levelup_praise_3": "努力没有白费！",
         "levelup_praise_4": "解锁新的里程碑！",
         "levelup_praise_5": "更上一层楼！",
+
+        "entity_status_achievements_section_title": "成就",
+        "entity_status_achievement_tasks_done": "完成任务数",
+        "entity_status_achievement_chat_upvotes": "聊天泡泡 👍",
+        "entity_status_achievement_chat_downvotes": "聊天泡泡 👎",
+        "entity_status_achievement_prs_merged": "合并的 PR 数",
+        "entity_status_achievement_cards_reviewed": "评审参与数",
+        "entity_status_achievement_notes_authored": "撰写的笔记数",
+        "entity_status_achievement_no_events": "暂无事件。",
 },
 
 
@@ -2412014,6 +2412032,15 @@ const TRANSLATIONS = {
         "levelup_praise_3": "努力が実りました！",
         "levelup_praise_4": "新しいマイルストーン達成！",
         "levelup_praise_5": "さらなる高みへ！",
+
+        "entity_status_achievements_section_title": "実績",
+        "entity_status_achievement_tasks_done": "完了したタスク数",
+        "entity_status_achievement_chat_upvotes": "チャットの👍",
+        "entity_status_achievement_chat_downvotes": "チャットの👎",
+        "entity_status_achievement_prs_merged": "マージされたPR数",
+        "entity_status_achievement_cards_reviewed": "レビュー参加数",
+        "entity_status_achievement_notes_authored": "作成したノート数",
+        "entity_status_achievement_no_events": "イベントはまだありません。",
 },
 
 
@@ -2942255,6 +2942282,15 @@ const TRANSLATIONS = {
         "levelup_praise_3": "노력이 결실을 맺었어요!",
         "levelup_praise_4": "새로운 이정표 달성!",
         "levelup_praise_5": "더 높은 곳으로!",
+
+        "entity_status_achievements_section_title": "업적",
+        "entity_status_achievement_tasks_done": "완료한 작업 수",
+        "entity_status_achievement_chat_upvotes": "채팅 말풍선 👍",
+        "entity_status_achievement_chat_downvotes": "채팅 말풍선 👎",
+        "entity_status_achievement_prs_merged": "병합된 PR 수",
+        "entity_status_achievement_cards_reviewed": "리뷰 참여 수",
+        "entity_status_achievement_notes_authored": "작성한 노트 수",
+        "entity_status_achievement_no_events": "아직 이벤트가 없습니다.",
 },
 
 
@@ -2943868,6 +2943904,15 @@ const TRANSLATIONS = {
         "levelup_praise_3": "努力沒有白費！",
         "levelup_praise_4": "解鎖新的里程碑！",
         "levelup_praise_5": "更上一層樓！",
+
+        "entity_status_achievements_section_title": "成就",
+        "entity_status_achievement_tasks_done": "完成任務數",
+        "entity_status_achievement_chat_upvotes": "聊天泡泡 👍",
+        "entity_status_achievement_chat_downvotes": "聊天泡泡 👎",
+        "entity_status_achievement_prs_merged": "合併的 PR 數",
+        "entity_status_achievement_cards_reviewed": "評審參與數",
+        "entity_status_achievement_notes_authored": "撰寫的筆記數",
+        "entity_status_achievement_no_events": "尚無事件。",
 },
 
 
@@ -3997445,6 +3997490,15 @@ const TRANSLATIONS = {
         "levelup_praise_3": "Nỗ lực đã được đền đáp!",
         "levelup_praise_4": "Mở khóa cột mốc mới!",
         "levelup_praise_5": "Tiến lên phía trước!",
+
+        "entity_status_achievements_section_title": "Thành tích",
+        "entity_status_achievement_tasks_done": "Số nhiệm vụ hoàn thành",
+        "entity_status_achievement_chat_upvotes": "Bong bóng chat 👍",
+        "entity_status_achievement_chat_downvotes": "Bong bóng chat 👎",
+        "entity_status_achievement_prs_merged": "Số PR đã hợp nhất",
+        "entity_status_achievement_cards_reviewed": "Số thẻ đã đánh giá",
+        "entity_status_achievement_notes_authored": "Số ghi chú đã viết",
+        "entity_status_achievement_no_events": "Chưa có sự kiện nào.",
 },
 
 
@@ -4523869,6 +4523923,15 @@ const TRANSLATIONS = {
         "levelup_praise_3": "Kerja keras membuahkan hasil!",
         "levelup_praise_4": "Tonggak baru terbuka!",
         "levelup_praise_5": "Terus melangkah maju!",
+
+        "entity_status_achievements_section_title": "Pencapaian",
+        "entity_status_achievement_tasks_done": "Tugas selesai",
+        "entity_status_achievement_chat_upvotes": "Gelembung chat 👍",
+        "entity_status_achievement_chat_downvotes": "Gelembung chat 👎",
+        "entity_status_achievement_prs_merged": "PR digabungkan",
+        "entity_status_achievement_cards_reviewed": "Kartu direviu",
+        "entity_status_achievement_notes_authored": "Catatan dibuat",
+        "entity_status_achievement_no_events": "Belum ada acara.",
 },
 
 
@@ -5566593,6 +5566656,15 @@ const TRANSLATIONS = {
         "levelup_praise_3": "¡El esfuerzo da sus frutos!",
         "levelup_praise_4": "¡Nuevo hito desbloqueado!",
         "levelup_praise_5": "¡Siempre hacia arriba!",
+
+        "entity_status_achievements_section_title": "Logros",
+        "entity_status_achievement_tasks_done": "Tareas completadas",
+        "entity_status_achievement_chat_upvotes": "Burbujas de chat 👍",
+        "entity_status_achievement_chat_downvotes": "Burbujas de chat 👎",
+        "entity_status_achievement_prs_merged": "PRs fusionados",
+        "entity_status_achievement_cards_reviewed": "Tarjetas revisadas",
+        "entity_status_achievement_notes_authored": "Notas creadas",
+        "entity_status_achievement_no_events": "Aún no hay eventos.",
 },
 
 

--- a/backend/tests/jest/entity-status-achievements-ui.test.js
+++ b/backend/tests/jest/entity-status-achievements-ui.test.js
@@ -1,0 +1,93 @@
+/**
+ * Achievements UI slice — card_8ca0b6acb1fb3d7a0b650dfd (frontend follow-up
+ * to the PR #3290 backend slice). Contract tests over entity-status-panel.js
+ * source + i18n key presence; DOM behavior is covered by the prod Playwright
+ * E2E attached to the card.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const panelSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'portal', 'shared', 'entity-status-panel.js'),
+    'utf8'
+);
+const i18nSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'shared', 'i18n.js'),
+    'utf8'
+);
+
+const AXES = ['tasks_done', 'chat_upvotes', 'chat_downvotes', 'prs_merged', 'cards_reviewed', 'notes_authored'];
+
+describe('entity-status-panel — achievements section contract', () => {
+    test('achievements section markup is present between counters and log', () => {
+        const counters = panelSrc.indexOf('data-section="counters"');
+        const achievements = panelSrc.indexOf('data-section="achievements"');
+        const log = panelSrc.indexOf('data-section="log"');
+        expect(counters).toBeGreaterThan(-1);
+        expect(achievements).toBeGreaterThan(counters);
+        expect(log).toBeGreaterThan(achievements);
+    });
+
+    test('fetches hit the backend achievement routes', () => {
+        expect(panelSrc).toMatch(/\/achievements\?\$\{qs\.toString\(\)\}/);
+        expect(panelSrc).toMatch(/\/achievement\/\$\{encodeURIComponent\(axis\)\}\/events/);
+    });
+
+    test('renderAchievements rows reuse the counter row shape (style parity)', () => {
+        expect(panelSrc).toMatch(/function renderAchievements\(/);
+        // same class as counter rows + role/tabindex/aria-expanded + chevron
+        const block = panelSrc.slice(panelSrc.indexOf('function renderAchievements'));
+        expect(block).toMatch(/__counter-row" data-axis="\$\{escapeHtml\(a\.axis\)\}" data-kind="achievement"/);
+        expect(block).toMatch(/role="button" tabindex="0"/);
+        expect(block).toMatch(/aria-expanded="false"/);
+        expect(block).toMatch(/SVG_CHEVRON/);
+    });
+
+    test('click handler branches achievement rows to the achievement drill-down', () => {
+        expect(panelSrc).toMatch(/dataset\.kind === 'achievement'/);
+        expect(panelSrc).toMatch(/toggleAchievementDrilldown\(root, eid, axis, counterRow\)/);
+    });
+
+    test('keyboard Enter/Space also branches on data-kind', () => {
+        expect(panelSrc).toMatch(/active\.dataset\.kind === 'achievement'/);
+    });
+
+    test('card chips use the src://kanban/card/<bare> preview format', () => {
+        const block = panelSrc.slice(panelSrc.indexOf('function renderAchievementEvents'));
+        expect(block).toMatch(/src:\/\/kanban\/card\/' \+ bareId/);
+        expect(block).toMatch(/data-ref-type="src"/);
+    });
+
+    test('chat chips carry data-ref-type="message" with the message id', () => {
+        const block = panelSrc.slice(panelSrc.indexOf('function renderAchievementEvents'));
+        expect(block).toMatch(/data-ref-type="message" data-ref-id="\$\{escapeHtml\(chip\.messageId\)\}"/);
+    });
+
+    test('open() fetches counters and achievements concurrently', () => {
+        expect(panelSrc).toMatch(/Promise\.all\(\[statusP, achP\]\)/);
+    });
+
+    test.each(AXES)('local label fallback covers axis %s in zh + en', (axis) => {
+        const zh = panelSrc.indexOf('ACHIEVEMENT_LABELS_ZH');
+        const en = panelSrc.indexOf('ACHIEVEMENT_LABELS_EN');
+        expect(zh).toBeGreaterThan(-1);
+        expect(en).toBeGreaterThan(-1);
+        const zhBlock = panelSrc.slice(zh, en);
+        const enBlock = panelSrc.slice(en, panelSrc.indexOf('};', en));
+        expect(zhBlock).toContain(axis + ':');
+        expect(enBlock).toContain(axis + ':');
+    });
+});
+
+describe('entity-status-panel — achievement i18n keys exist in i18n.js', () => {
+    const NEEDED = [
+        'entity_status_achievements_section_title',
+        ...AXES.map(a => 'entity_status_achievement_' + a),
+        'entity_status_achievement_no_events',
+    ];
+    test.each(NEEDED)('%s is declared', (key) => {
+        expect(i18nSrc).toMatch(new RegExp('"' + key + '":'));
+    });
+});


### PR DESCRIPTION
## Scope (card_8ca0b6acb1fb3d7a0b650dfd — frontend slice; backend shipped in #3290)

Hank 06-10: 「實體狀態內增加一個成就list … 與錯誤計數器風格一致 … 可點開查看歷史訊息的座標chip」

- **Achievements section** in the Entity Status drawer, directly below Error Counters, above Operation Log. Rows are visually identical to counter rows (same `__counter-row` class, chevron, pill badge); `data-kind=achievement` routes interaction to the achievement endpoints.
- **Drill-down**: click / Enter / Space expands inline chips per contributing event — kanban cards as `src://kanban/card/<bare>` AutolinkChipPreview chips (title as label), chat 👍/👎 as message-coord chips (excerpt label), notes as plain labelled chips.
- **Fetching**: `/api/entity-status/:eId/achievements` + `/achievement/:axis/events` (whitelisted backend routes from #3290); counters and achievements load concurrently with independent error states.
- **i18n**: 8 keys ×8 locales via espree AST insert; panel prefers shared i18n, falls back to built-in zh/en dicts on pages that don't load i18n.js.
- prs_merged renders as 0 (backend v2 note) — row kept for axis-set stability.

## Tests
- Jest: 21 new UI contract tests + existing 12 backend achievement tests green; **full suite 272 suites / 3781 passed**
- Post-deploy prod E2E (panel open → section visible → drill-down chips → popover) + mobile/desktop screenshots to card /file before close (requiresScreenshotReview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)