### PR TITLE
fix(entity-status): tasks_done JSONB containment — was silently 0

### DIFF
--- a/backend/entity-status.js
+++ b/backend/entity-status.js
@@ -417,11 +417,15 @@ async function getAchievements(deviceId, entityId) {
         let lastEventAt = null;
         try {
             if (axis === 'tasks_done') {
+                // assigned_bots is JSONB (not int[]) — `= ANY()` throws and the
+                // per-axis catch silently zeroed this axis. jsonb containment
+                // ('[2,6]' @> '2') is the correct predicate. Found via prod
+                // probe: board had 215 done cards for #2, API said 0.
                 const r = await pool.query(
                     `SELECT COUNT(*)::int AS c, MAX(updated_at) AS ts
                        FROM kanban_cards
                       WHERE device_id = $1 AND status = 'done'
-                        AND $2 = ANY(assigned_bots)`,
+                        AND assigned_bots @> to_jsonb($2::int)`,
                     [deviceId, eid]
                 );
                 count = Number(r.rows[0]?.c || 0);
@@ -487,7 +491,7 @@ async function getAchievementEvents(deviceId, entityId, axis, limit) {
                 `SELECT id, title, updated_at
                    FROM kanban_cards
                   WHERE device_id = $1 AND status = 'done'
-                    AND $2 = ANY(assigned_bots)
+                    AND assigned_bots @> to_jsonb($2::int)
                   ORDER BY updated_at DESC LIMIT $3`,
                 [deviceId, eid, lim]
             );

--- a/backend/tests/jest/entity-status-achievements.test.js
+++ b/backend/tests/jest/entity-status-achievements.test.js
@@ -49,11 +49,11 @@ describe('Achievements backend slice', () => {
         });
     });
 
-    test('getAchievements aggregates tasks_done by status=done AND $entity=ANY(assigned_bots)', async () => {
+    test('getAchievements aggregates tasks_done by status=done AND jsonb containment on assigned_bots', async () => {
         const lastTs = new Date('2026-06-10T12:00:00Z');
         const pool = makePool([
             {
-                match: (s) => s.includes('FROM kanban_cards') && s.includes('status = \'done\'') && s.includes('ANY(assigned_bots)'),
+                match: (s) => s.includes('FROM kanban_cards') && s.includes('status = \'done\'') && s.includes('assigned_bots @> to_jsonb($2::int)'),
                 rows: (p) => {
                     expect(p[0]).toBe(DEVICE);
                     expect(p[1]).toBe(ENTITY);
@@ -113,7 +113,7 @@ describe('Achievements backend slice', () => {
     test('getAchievementEvents for tasks_done returns card chips', async () => {
         const pool = makePool([
             {
-                match: (s) => s.includes('FROM kanban_cards') && s.includes('ANY(assigned_bots)') && s.includes('ORDER BY updated_at DESC'),
+                match: (s) => s.includes('FROM kanban_cards') && s.includes('assigned_bots @> to_jsonb($2::int)') && s.includes('ORDER BY updated_at DESC'),
                 rows: () => [
                     { id: 'card_a', title: 'Ship X', updated_at: new Date('2026-06-10T08:00:00Z') },
                     { id: 'card_b', title: 'Ship Y', updated_at: new Date('2026-06-09T08:00:00Z') },
@@ -150,7 +150,7 @@ describe('Achievements backend slice', () => {
         let capturedLimit = null;
         const pool = makePool([
             {
-                match: (s) => s.includes('FROM kanban_cards') && s.includes('ANY(assigned_bots)'),
+                match: (s) => s.includes('FROM kanban_cards') && s.includes('assigned_bots @> to_jsonb($2::int)'),
                 rows: (p) => { capturedLimit = p[2]; return []; },
             },
         ]);


### PR DESCRIPTION
Prod probe during the card_8ca0b6ac UI E2E found `tasks_done: 0` while the kanban API shows **215** done cards with `assignedBots=[2]`. Root cause: `assigned_bots` is JSONB, so `$2 = ANY(assigned_bots)` (PR #3290) throws `op ANY/ALL (array) requires array` on every call — and the per-axis try/catch (designed for missing tables) swallowed it into a 0.

Fix: jsonb containment `assigned_bots @> to_jsonb($2::int)` in both the count and the events query (matches the `@>` pattern index.js already uses for assigned_bots). SQL-shape jest assertions updated; 11/11 + full suite 3781 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)