### PR TITLE
feat(kanban): detail-modal maximize + splitter + side linked-card chips (card_3651ed7a)

### DIFF
--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -162,7 +162,22 @@
         /* ══════════════ Detail Modal ══════════════ */
         .kb-modal-overlay { position:fixed; inset:0; background:rgba(0,0,0,0.6); backdrop-filter:blur(4px); -webkit-backdrop-filter:blur(4px); display:none; align-items:flex-start; justify-content:center; z-index:100; padding:40px 16px; overflow-y:auto; }
         .kb-modal-overlay.show { display:flex; }
-        .kb-modal { background:var(--card); border:1px solid var(--card-border); border-radius:var(--radius); width:100%; max-width:640px; max-height:85vh; display:flex; flex-direction:column; overflow:hidden; }
+        .kb-modal { background:var(--card); border:1px solid var(--card-border); border-radius:var(--radius); width:100%; max-width:640px; max-height:85vh; display:flex; flex-direction:column; overflow:hidden; position:relative; --kb-meta-h:min(32vh, 260px); }
+        /* ── Modal 3 增強 (card_3651ed7ad8e676d3a4f6a9dc) ── */
+        .kb-modal.kb-modal-max { max-width:95vw; width:95vw; height:95vh; max-height:95vh; }
+        .kb-modal-maximize { background:none; border:none; color:var(--text-secondary); cursor:pointer; font-size:17px; padding:2px 8px; border-radius:6px; line-height:1; flex:0 0 auto; }
+        .kb-modal-maximize:hover, .kb-modal-maximize[aria-pressed="true"] { color:var(--text-primary,#fff); background:rgba(255,255,255,0.08); }
+        .kb-modal-splitter { flex:0 0 4px; height:4px; cursor:ns-resize; background:var(--card-border); opacity:0.6; transition:opacity 0.15s, background 0.15s; touch-action:none; }
+        .kb-modal-splitter:hover, .kb-modal-splitter.dragging { opacity:1; background:var(--primary,#6c63ff); }
+        .kb-modal-splitter:focus { outline:2px solid var(--primary,#6c63ff); outline-offset:-1px; }
+        .kb-modal-side-chip { position:absolute; top:50%; transform:translateY(-50%); z-index:5;
+            width:34px; height:34px; border-radius:50%; border:1px solid var(--card-border);
+            background:rgba(20,20,32,0.82); color:var(--text-primary,#fff); font-size:13px; cursor:pointer;
+            display:flex; align-items:center; justify-content:center; backdrop-filter:blur(4px);
+            box-shadow:0 2px 10px rgba(0,0,0,0.4); transition:background 0.15s, transform 0.15s; }
+        .kb-modal-side-chip:hover { background:var(--primary,#6c63ff); transform:translateY(-50%) scale(1.12); }
+        .kb-modal-side-prev { left:6px; }
+        .kb-modal-side-next { right:6px; }
         .kb-modal.kb-modal-comments-active { height:min(85dvh, 760px); }
         .kb-modal.kb-modal-comments-active .kb-modal-meta { max-height:none; overflow:visible; overscroll-behavior:contain; }
         .kb-modal.kb-modal-comments-active .kb-detail-desc,
@@ -174,7 +189,7 @@
         .kb-modal-close { background:none; border:none; color:var(--text-muted); font-size:20px; cursor:pointer; padding:4px; }
         .kb-btn-quote-chat { background:none; border:1px solid var(--primary,#3b82f6); color:var(--primary,#3b82f6); border-radius:6px; font-size:12px; padding:4px 10px; cursor:pointer; white-space:nowrap; }
         .kb-btn-quote-chat:hover { background:var(--primary,#3b82f6); color:#fff; }
-        .kb-modal-meta { padding:12px 24px; display:flex; gap:12px; flex-wrap:wrap; font-size:12px; color:var(--text-secondary); border-bottom:1px solid var(--card-border); flex:0 0 auto; max-height:min(32vh, 260px); overflow-y:auto; overscroll-behavior:contain; }
+        .kb-modal-meta { padding:12px 24px; display:flex; gap:12px; flex-wrap:wrap; font-size:12px; color:var(--text-secondary); border-bottom:1px solid var(--card-border); flex:0 0 auto; max-height:var(--kb-meta-h); overflow-y:auto; overscroll-behavior:contain; }
         .kb-modal-meta .meta-item { display:flex; align-items:center; gap:4px; }
         .kb-detail-desc { width:100%; font-size:13px; color:var(--text-secondary); margin-top:8px; white-space:pre-wrap; word-break:break-word; max-height:30vh; overflow-y:auto; overscroll-behavior:contain; padding-right:4px; }
         .kb-detail-link-chip-row { display:flex; flex-wrap:wrap; gap:6px; margin-top:8px; width:100%; }
@@ -896,9 +911,14 @@
             <div class="kb-modal-header">
                 <h3 id="detailTitle"></h3>
                 <button class="kb-btn-quote-chat" onclick="quoteKanbanCardToChat()" title="引用到聊天視窗">📌 引用</button>
+                <button class="kb-modal-maximize" id="kbModalMaxBtn" onclick="toggleModalMaximize()" aria-label="Maximize" aria-pressed="false">⛶</button>
                 <button class="kb-modal-close" onclick="closeDetail()" aria-label="Close">&times;</button>
             </div>
+            <button class="kb-modal-side-chip kb-modal-side-prev" id="kbSidePrev" style="display:none" aria-label="Previous linked card">◀</button>
+            <button class="kb-modal-side-chip kb-modal-side-next" id="kbSideNext" style="display:none" aria-label="Next linked card">▶</button>
             <div class="kb-modal-meta" id="detailMeta"></div>
+            <div class="kb-modal-splitter" id="kbModalSplitter" role="separator" aria-orientation="horizontal"
+                 aria-label="Drag to resize description area" tabindex="0"></div>
             <div class="kb-modal-tabs">
                 <button class="kb-modal-tab active" data-i18n="kb_tab_comments" onclick="switchDetailTab('comments',this)">💬 Comments</button>
                 <button class="kb-modal-tab" data-i18n="kb_tab_notes" onclick="switchDetailTab('notes',this)">📝 Notes</button>
@@ -2692,6 +2712,7 @@
             refreshDetailTags(cardId);
             loadCardLinksForDetail(cardId);
             refreshTaskRelationBanner(card);
+            updateModalSideChips(card);
 
             // Move bar — primary action + secondary chips + overflow admin UI
             const moveBar = document.getElementById('moveBar');
@@ -3150,6 +3171,98 @@
         document.addEventListener('keydown', (e) => {
             if (e.key === 'Escape' && document.getElementById('detailModal').classList.contains('show')) closeDetail();
         });
+
+        // ── Modal 3 增強 (card_3651ed7ad8e676d3a4f6a9dc) ──
+        // 1) maximize toggle, persisted; 2) draggable meta/tabs splitter,
+        // persisted px height; 3) side prev/next chips populated in openDetail.
+        function toggleModalMaximize() {
+            const modal = document.querySelector('#detailModal .kb-modal');
+            const btn = document.getElementById('kbModalMaxBtn');
+            if (!modal || !btn) return;
+            const on = !modal.classList.contains('kb-modal-max');
+            modal.classList.toggle('kb-modal-max', on);
+            btn.setAttribute('aria-pressed', String(on));
+            btn.title = on ? t('kb_modal_restore', 'Restore size') : t('kb_modal_maximize', 'Maximize');
+            try { localStorage.setItem('kb_modal_max', on ? '1' : '0'); } catch (_) {}
+        }
+
+        function applyModalPrefs() {
+            const modal = document.querySelector('#detailModal .kb-modal');
+            const btn = document.getElementById('kbModalMaxBtn');
+            try {
+                if (localStorage.getItem('kb_modal_max') === '1' && modal && btn) {
+                    modal.classList.add('kb-modal-max');
+                    btn.setAttribute('aria-pressed', 'true');
+                }
+                const savedH = parseInt(localStorage.getItem('kb_modal_split_px') || '', 10);
+                if (modal && Number.isFinite(savedH) && savedH >= 80) {
+                    modal.style.setProperty('--kb-meta-h', savedH + 'px');
+                }
+            } catch (_) {}
+            if (btn && !btn.title) btn.title = t('kb_modal_maximize', 'Maximize');
+            const splitter = document.getElementById('kbModalSplitter');
+            if (splitter) splitter.setAttribute('aria-label', t('kb_modal_splitter_aria', 'Drag to resize description area'));
+        }
+
+        function initModalSplitter() {
+            const splitter = document.getElementById('kbModalSplitter');
+            const modal = document.querySelector('#detailModal .kb-modal');
+            const meta = document.getElementById('detailMeta');
+            if (!splitter || !modal || !meta) return;
+            let startY = 0, startH = 0, dragging = false;
+            const clampH = (h) => Math.max(80, Math.min(h, Math.round(modal.clientHeight * 0.8)));
+            const onMove = (clientY) => {
+                if (!dragging) return;
+                const h = clampH(startH + (clientY - startY));
+                modal.style.setProperty('--kb-meta-h', h + 'px');
+            };
+            const stop = () => {
+                if (!dragging) return;
+                dragging = false;
+                splitter.classList.remove('dragging');
+                const h = parseInt(getComputedStyle(meta).height, 10);
+                try { localStorage.setItem('kb_modal_split_px', String(h)); } catch (_) {}
+            };
+            splitter.addEventListener('mousedown', (e) => {
+                dragging = true; startY = e.clientY; startH = meta.getBoundingClientRect().height;
+                splitter.classList.add('dragging'); e.preventDefault();
+            });
+            document.addEventListener('mousemove', (e) => onMove(e.clientY));
+            document.addEventListener('mouseup', stop);
+            splitter.addEventListener('touchstart', (e) => {
+                dragging = true; startY = e.touches[0].clientY; startH = meta.getBoundingClientRect().height;
+                splitter.classList.add('dragging');
+            }, { passive: true });
+            document.addEventListener('touchmove', (e) => { if (dragging) onMove(e.touches[0].clientY); }, { passive: true });
+            document.addEventListener('touchend', stop);
+            // keyboard a11y: arrows nudge the split by 24px
+            splitter.addEventListener('keydown', (e) => {
+                if (e.key !== 'ArrowUp' && e.key !== 'ArrowDown') return;
+                e.preventDefault();
+                const cur = meta.getBoundingClientRect().height;
+                const h = clampH(cur + (e.key === 'ArrowDown' ? 24 : -24));
+                modal.style.setProperty('--kb-meta-h', h + 'px');
+                try { localStorage.setItem('kb_modal_split_px', String(h)); } catch (_) {}
+            });
+        }
+
+        function updateModalSideChips(card) {
+            const sp = document.getElementById('kbSidePrev');
+            const sn = document.getElementById('kbSideNext');
+            const wire = (btn, linkedId, label) => {
+                if (!btn) return;
+                if (!linkedId) { btn.style.display = 'none'; btn.onclick = null; return; }
+                const linked = findCard(linkedId);
+                btn.style.display = 'flex';
+                btn.title = (linked && linked.title) ? linked.title : linkedId;
+                btn.setAttribute('aria-label', label + ': ' + btn.title);
+                btn.onclick = (e) => { e.stopPropagation(); openDetail(linkedId); };
+            };
+            wire(sp, card.linkedPrevCardId, t('kb_modal_prev_card', 'Previous linked card'));
+            wire(sn, card.linkedNextCardId, t('kb_modal_next_card', 'Next linked card'));
+        }
+        applyModalPrefs();
+        initModalSplitter();
 
         function eclawShowFloatToast(msg) {
             const tip = document.createElement('div');

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650168,6 +650168,12 @@ const TRANSLATIONS = {
         "entity_status_achievement_cards_reviewed": "Cards reviewed",
         "entity_status_achievement_notes_authored": "Notes authored",
         "entity_status_achievement_no_events": "No events yet.",
+
+        "kb_modal_maximize": "Maximize",
+        "kb_modal_restore": "Restore size",
+        "kb_modal_splitter_aria": "Drag to resize description area",
+        "kb_modal_prev_card": "Previous linked card",
+        "kb_modal_next_card": "Next linked card",
 },
 
 
@@ -1234803,6 +1234809,12 @@ const TRANSLATIONS = {
         "entity_status_achievement_cards_reviewed": "评审参与数",
         "entity_status_achievement_notes_authored": "撰写的笔记数",
         "entity_status_achievement_no_events": "暂无事件。",
+
+        "kb_modal_maximize": "最大化",
+        "kb_modal_restore": "还原大小",
+        "kb_modal_splitter_aria": "拖拉调整描述区高度",
+        "kb_modal_prev_card": "上一张链接任务卡",
+        "kb_modal_next_card": "下一张链接任务卡",
 },
 
 
@@ -2412041,6 +2412053,12 @@ const TRANSLATIONS = {
         "entity_status_achievement_cards_reviewed": "レビュー参加数",
         "entity_status_achievement_notes_authored": "作成したノート数",
         "entity_status_achievement_no_events": "イベントはまだありません。",
+
+        "kb_modal_maximize": "最大化",
+        "kb_modal_restore": "元のサイズに戻す",
+        "kb_modal_splitter_aria": "ドラッグして説明エリアの高さを調整",
+        "kb_modal_prev_card": "前のリンクカード",
+        "kb_modal_next_card": "次のリンクカード",
 },
 
 
@@ -2942291,6 +2942309,12 @@ const TRANSLATIONS = {
         "entity_status_achievement_cards_reviewed": "리뷰 참여 수",
         "entity_status_achievement_notes_authored": "작성한 노트 수",
         "entity_status_achievement_no_events": "아직 이벤트가 없습니다.",
+
+        "kb_modal_maximize": "최대화",
+        "kb_modal_restore": "크기 복원",
+        "kb_modal_splitter_aria": "드래그하여 설명 영역 크기 조절",
+        "kb_modal_prev_card": "이전 연결 카드",
+        "kb_modal_next_card": "다음 연결 카드",
 },
 
 
@@ -2943913,6 +2943937,12 @@ const TRANSLATIONS = {
         "entity_status_achievement_cards_reviewed": "評審參與數",
         "entity_status_achievement_notes_authored": "撰寫的筆記數",
         "entity_status_achievement_no_events": "尚無事件。",
+
+        "kb_modal_maximize": "最大化",
+        "kb_modal_restore": "還原大小",
+        "kb_modal_splitter_aria": "拖拉調整描述區高度",
+        "kb_modal_prev_card": "上一張鏈結任務卡",
+        "kb_modal_next_card": "下一張鏈結任務卡",
 },
 
 
@@ -3997499,6 +3997529,12 @@ const TRANSLATIONS = {
         "entity_status_achievement_cards_reviewed": "Số thẻ đã đánh giá",
         "entity_status_achievement_notes_authored": "Số ghi chú đã viết",
         "entity_status_achievement_no_events": "Chưa có sự kiện nào.",
+
+        "kb_modal_maximize": "Phóng to",
+        "kb_modal_restore": "Khôi phục kích thước",
+        "kb_modal_splitter_aria": "Kéo để điều chỉnh vùng mô tả",
+        "kb_modal_prev_card": "Thẻ liên kết trước",
+        "kb_modal_next_card": "Thẻ liên kết tiếp theo",
 },
 
 
@@ -4523932,6 +4523968,12 @@ const TRANSLATIONS = {
         "entity_status_achievement_cards_reviewed": "Kartu direviu",
         "entity_status_achievement_notes_authored": "Catatan dibuat",
         "entity_status_achievement_no_events": "Belum ada acara.",
+
+        "kb_modal_maximize": "Maksimalkan",
+        "kb_modal_restore": "Kembalikan ukuran",
+        "kb_modal_splitter_aria": "Seret untuk mengubah tinggi area deskripsi",
+        "kb_modal_prev_card": "Kartu tertaut sebelumnya",
+        "kb_modal_next_card": "Kartu tertaut berikutnya",
 },
 
 
@@ -5566665,6 +5566707,12 @@ const TRANSLATIONS = {
         "entity_status_achievement_cards_reviewed": "Tarjetas revisadas",
         "entity_status_achievement_notes_authored": "Notas creadas",
         "entity_status_achievement_no_events": "Aún no hay eventos.",
+
+        "kb_modal_maximize": "Maximizar",
+        "kb_modal_restore": "Restaurar tamaño",
+        "kb_modal_splitter_aria": "Arrastra para redimensionar la descripción",
+        "kb_modal_prev_card": "Tarjeta enlazada anterior",
+        "kb_modal_next_card": "Tarjeta enlazada siguiente",
 },
 
 

--- a/backend/tests/jest/kanban-modal-enhancements.test.js
+++ b/backend/tests/jest/kanban-modal-enhancements.test.js
@@ -1,0 +1,77 @@
+/**
+ * Kanban detail-modal 3 enhancements — card_3651ed7ad8e676d3a4f6a9dc.
+ * Contract tests over kanban.html source (maximize / splitter / side chips);
+ * interactive behavior is covered by the prod Playwright E2E on the card.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const src = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'portal', 'kanban.html'),
+    'utf8'
+);
+const i18nSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'shared', 'i18n.js'),
+    'utf8'
+);
+
+describe('kanban modal — maximize', () => {
+    test('maximize button sits in the modal header with aria-pressed', () => {
+        expect(src).toMatch(/<button class="kb-modal-maximize" id="kbModalMaxBtn" onclick="toggleModalMaximize\(\)"[^>]*aria-pressed="false"/);
+    });
+    test('kb-modal-max class expands to ~95vw/95vh', () => {
+        expect(src).toMatch(/\.kb-modal\.kb-modal-max \{ max-width:95vw; width:95vw; height:95vh; max-height:95vh; \}/);
+    });
+    test('toggle persists to localStorage kb_modal_max and applyModalPrefs restores it', () => {
+        expect(src).toMatch(/localStorage\.setItem\('kb_modal_max'/);
+        expect(src).toMatch(/localStorage\.getItem\('kb_modal_max'\) === '1'/);
+    });
+});
+
+describe('kanban modal — splitter', () => {
+    test('splitter element has separator role + ns-resize cursor styling', () => {
+        expect(src).toMatch(/id="kbModalSplitter" role="separator" aria-orientation="horizontal"/);
+        expect(src).toMatch(/\.kb-modal-splitter \{[^}]*cursor:ns-resize/);
+    });
+    test('meta height is driven by the --kb-meta-h CSS var', () => {
+        expect(src).toMatch(/--kb-meta-h:min\(32vh, 260px\)/);
+        expect(src).toMatch(/\.kb-modal-meta \{[^}]*max-height:var\(--kb-meta-h\)/);
+    });
+    test('drag persists px height to kb_modal_split_px with a floor of 80px', () => {
+        expect(src).toMatch(/localStorage\.setItem\('kb_modal_split_px'/);
+        expect(src).toMatch(/Math\.max\(80, Math\.min\(h, Math\.round\(modal\.clientHeight \* 0\.8\)\)\)/);
+    });
+    test('keyboard arrows nudge the split (a11y)', () => {
+        expect(src).toMatch(/e\.key !== 'ArrowUp' && e\.key !== 'ArrowDown'/);
+    });
+});
+
+describe('kanban modal — side prev/next chips', () => {
+    test('both side chips exist, hidden by default', () => {
+        expect(src).toMatch(/id="kbSidePrev" style="display:none"/);
+        expect(src).toMatch(/id="kbSideNext" style="display:none"/);
+    });
+    test('openDetail wires chips via updateModalSideChips(card)', () => {
+        expect(src).toMatch(/updateModalSideChips\(card\);/);
+        expect(src).toMatch(/wire\(sp, card\.linkedPrevCardId/);
+        expect(src).toMatch(/wire\(sn, card\.linkedNextCardId/);
+    });
+    test('chip without a linked id stays display:none (no spacing leak)', () => {
+        expect(src).toMatch(/if \(!linkedId\) \{ btn\.style\.display = 'none'; btn\.onclick = null; return; \}/);
+    });
+    test('chip click switches card via openDetail(linkedId)', () => {
+        expect(src).toMatch(/btn\.onclick = \(e\) => \{ e\.stopPropagation\(\); openDetail\(linkedId\); \};/);
+    });
+});
+
+describe('kanban modal — i18n keys', () => {
+    const NEEDED = [
+        'kb_modal_maximize', 'kb_modal_restore', 'kb_modal_splitter_aria',
+        'kb_modal_prev_card', 'kb_modal_next_card',
+    ];
+    test.each(NEEDED)('%s is declared in i18n.js', (key) => {
+        expect(i18nSrc).toMatch(new RegExp('"' + key + '":'));
+    });
+});


### PR DESCRIPTION
## Scope (card_3651ed7ad8e676d3a4f6a9dc — Hank 06-10 annotated screenshot)

1. **Maximize** — ⛶ button beside ✕; toggles `.kb-modal-max` (95vw × 95vh), persisted in `localStorage.kb_modal_max`, restored on next open; `aria-pressed` reflects state.
2. **Draggable splitter** — 4px `ns-resize` bar between the description area and the 留言/筆記/檔案 tab bar; drag (mouse + touch) adjusts `--kb-meta-h` live; ArrowUp/Down nudges ±24px for keyboard users; persisted as px (`kb_modal_split_px`), clamped [80px, 80% of modal].
3. **Side ◀/▶ linked-card chips** — circular buttons vertically centered on the modal's left/right edges; rendered ONLY when `linkedPrevCardId`/`linkedNextCardId` exists (zero footprint otherwise); click switches to that card via `openDetail`; tooltip + aria-label carry the linked card title. Existing inline prev/next chips in the chip row untouched (side chips are the quick-switch affordance Hank circled).

No backend changes. i18n: 5 keys ×8 locales via AST insert.

## Tests
- Jest: 16 new contract tests; **full suite 273 suites / 3797 passed**
- Post-deploy prod E2E: maximize toggle + persist, splitter drag + persist, side-chip nav on a linked chain, no-link absence; desktop/mobile screenshots to card /file (requiresScreenshotReview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)