### PR TITLE
feat(dashboard): usage-widget click → 5h/weekly timeline chart modal (card_fb8a5a39)

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -1961,6 +1961,28 @@
             .uw-bar-pct { font-size: 13px; }
         }
 
+        /* ── Usage timeline modal (card_fb8a5a39ebe67581a66c6061) ── */
+        .usage-widget { cursor: pointer; }
+        .utl-overlay { position:fixed; inset:0; z-index:10010; background:rgba(0,0,0,0.55);
+            display:flex; align-items:center; justify-content:center; padding:18px;
+            backdrop-filter:blur(4px); -webkit-backdrop-filter:blur(4px); }
+        .utl-panel { width:min(720px, 96vw); max-height:92vh; overflow-y:auto; }
+        .utl-head { display:flex; align-items:center; justify-content:space-between; margin-bottom:12px; }
+        .utl-title { font-size:16px; font-weight:700; }
+        .utl-close { background:none; border:none; color:var(--text-secondary,#aaa); cursor:pointer;
+            font-size:18px; padding:4px 10px; border-radius:6px; }
+        .utl-close:hover { color:var(--text-primary,#fff); background:rgba(255,255,255,0.07); }
+        .utl-chart-block { margin-bottom:18px; }
+        .utl-chart-label { font-size:13px; font-weight:600; color:var(--text-secondary,#aaa); margin-bottom:6px; }
+        .utl-svg { width:100%; height:160px; background:rgba(255,255,255,0.03);
+            border:1px solid var(--card-border,#333); border-radius:10px; touch-action:none; }
+        .utl-legend { display:flex; gap:16px; font-size:12px; color:var(--text-secondary,#aaa); margin-top:6px; }
+        .utl-legend-dot { display:inline-block; width:10px; height:10px; border-radius:50%; margin-right:5px; vertical-align:-1px; }
+        .utl-caption { font-size:12px; color:var(--text-secondary,#aaa); min-height:16px;
+            margin-top:4px; font-variant-numeric:tabular-nums; }
+        .utl-empty { font-size:13px; color:var(--text-muted,#888); font-style:italic;
+            text-align:center; padding:28px 0; }
+
         /* ── Level-up celebration (情緒價值 #3, card_91c97a12a385cac144ad223e) ── */
         .lvlup-overlay {
             position: fixed; inset: 0; z-index: 10050;
@@ -6017,6 +6039,142 @@
         }
 
         window.refreshUsageWidget = function () { loadUsageWidget(); };
+
+        // ── Usage timeline modal (card_fb8a5a39ebe67581a66c6061) ──
+        // Click the usage widget (not its buttons) → modal with two vanilla-SVG
+        // line charts driven by GET /api/usage/timeline (PR #3291 backend):
+        // 5h-session %s over the last 24h, weekly %s over the last 30d.
+        const UTL_SERIES = [
+            { key: 'claude', color5h: '#ff8a5c', colorWk: '#ffc857', label: 'Claude' },
+            { key: 'codex',  color5h: '#5cdfff', colorWk: '#3aa6ff', label: 'Codex' },
+        ];
+
+        function closeUsageTimelineModal() {
+            const el = document.getElementById('utlOverlay');
+            if (el) el.remove();
+            document.removeEventListener('keydown', _utlEsc);
+        }
+        function _utlEsc(e) { if (e.key === 'Escape') closeUsageTimelineModal(); }
+
+        function _utlChartSvg(points, fields, colors) {
+            // points: [{t:Date, a:claudePct|null, b:codexPct|null}]
+            const W = 680, H = 160, PX = 34, PY = 12;
+            const usable = points.filter(p => p[fields[0]] !== null || p[fields[1]] !== null);
+            if (usable.length < 2) return null;
+            const t0 = usable[0].t.getTime(), t1 = usable[usable.length - 1].t.getTime();
+            const xOf = (t) => t1 === t0 ? PX : PX + (W - 2 * PX) * (t - t0) / (t1 - t0);
+            const yOf = (pct) => PY + (H - 2 * PY) * (1 - Math.max(0, Math.min(100, pct)) / 100);
+            const line = (field, color) => {
+                const pts = usable.filter(p => p[field] !== null)
+                    .map(p => xOf(p.t.getTime()).toFixed(1) + ',' + yOf(p[field]).toFixed(1));
+                if (pts.length < 2) return '';
+                return `<polyline fill="none" stroke="${color}" stroke-width="2" stroke-linejoin="round" points="${pts.join(' ')}"/>`;
+            };
+            const grid = [0, 25, 50, 75, 100].map(v =>
+                `<line x1="${PX}" y1="${yOf(v)}" x2="${W - PX}" y2="${yOf(v)}" stroke="rgba(255,255,255,0.07)" stroke-width="1"/>` +
+                `<text x="${PX - 6}" y="${yOf(v) + 3.5}" text-anchor="end" font-size="9" fill="rgba(255,255,255,0.4)">${v}</text>`
+            ).join('');
+            return `<svg class="utl-svg" viewBox="0 0 ${W} ${H}" preserveAspectRatio="none" role="img">${grid}${line(fields[0], colors[0])}${line(fields[1], colors[1])}</svg>`;
+        }
+
+        function _utlAttachHover(block, points, fields, labels) {
+            const svg = block.querySelector('svg');
+            const caption = block.querySelector('.utl-caption');
+            if (!svg || !caption) return;
+            const usable = points.filter(p => p[fields[0]] !== null || p[fields[1]] !== null);
+            if (!usable.length) return;
+            const show = (clientX) => {
+                const r = svg.getBoundingClientRect();
+                const frac = Math.max(0, Math.min(1, (clientX - r.left) / r.width));
+                const idx = Math.round(frac * (usable.length - 1));
+                const p = usable[idx];
+                const ts = p.t.toLocaleString(undefined, { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', hour12: false });
+                const fmt = (v) => v === null ? '--' : v.toFixed(0) + '%';
+                caption.textContent = `${ts} · ${labels[0]} ${fmt(p[fields[0]])} · ${labels[1]} ${fmt(p[fields[1]])}`;
+            };
+            svg.addEventListener('pointermove', (e) => show(e.clientX));
+            svg.addEventListener('pointerdown', (e) => show(e.clientX));
+        }
+
+        async function openUsageTimelineModal() {
+            closeUsageTimelineModal();
+            const user = window.currentUser;
+            if (!user || !user.deviceId || !user.deviceSecret) return;
+            const overlay = document.createElement('div');
+            overlay.className = 'utl-overlay';
+            overlay.id = 'utlOverlay';
+            overlay.addEventListener('click', (e) => { if (e.target === overlay) closeUsageTimelineModal(); });
+            overlay.innerHTML = `
+                <div class="card utl-panel" role="dialog" aria-modal="true" aria-label="${i18n.t('dashboard_usage_chart_modal_title') || 'Usage timeline'}">
+                    <div class="utl-head">
+                        <div class="utl-title">📈 ${i18n.t('dashboard_usage_chart_modal_title') || 'Usage timeline'}</div>
+                        <button type="button" class="utl-close" onclick="closeUsageTimelineModal()" aria-label="Close">✕</button>
+                    </div>
+                    <div class="utl-chart-block" data-block="5h">
+                        <div class="utl-chart-label">${i18n.t('dashboard_usage_chart_5h_label') || '5h session % (last 24h)'}</div>
+                        <div class="utl-empty">${i18n.t('dashboard_usage_chart_loading') || 'Loading…'}</div>
+                        <div class="utl-caption"></div>
+                    </div>
+                    <div class="utl-chart-block" data-block="wk">
+                        <div class="utl-chart-label">${i18n.t('dashboard_usage_chart_weekly_label') || 'Weekly % (last 30d)'}</div>
+                        <div class="utl-empty">${i18n.t('dashboard_usage_chart_loading') || 'Loading…'}</div>
+                        <div class="utl-caption"></div>
+                    </div>
+                    <div class="utl-legend">
+                        <span><span class="utl-legend-dot" style="background:#ff8a5c"></span>Claude 5h</span>
+                        <span><span class="utl-legend-dot" style="background:#ffc857"></span>Claude weekly</span>
+                        <span><span class="utl-legend-dot" style="background:#5cdfff"></span>Codex 5h</span>
+                        <span><span class="utl-legend-dot" style="background:#3aa6ff"></span>Codex weekly</span>
+                    </div>
+                </div>`;
+            document.body.appendChild(overlay);
+            document.addEventListener('keydown', _utlEsc);
+
+            const qs = 'deviceId=' + encodeURIComponent(user.deviceId)
+                + '&deviceSecret=' + encodeURIComponent(user.deviceSecret);
+            const fetchPts = async (hours) => {
+                const res = await fetch('/api/usage/timeline?hours=' + hours + '&' + qs, { credentials: 'same-origin' });
+                if (!res.ok) throw new Error('http ' + res.status);
+                const data = await res.json();
+                if (!data.success) throw new Error(data.error || 'timeline failed');
+                return (data.points || []).map(p => ({
+                    t: new Date(p.captured_at),
+                    c5: p.claude_5h_pct, x5: p.codex_5h_pct,
+                    c7: p.claude_7d_pct, x7: p.codex_7d_pct,
+                }));
+            };
+            const fill = (blockSel, points, fields, colors, labels) => {
+                const block = overlay.querySelector(blockSel);
+                if (!block) return;
+                const empty = block.querySelector('.utl-empty');
+                const svgHtml = _utlChartSvg(points, fields, colors);
+                if (!svgHtml) {
+                    if (empty) empty.textContent = i18n.t('dashboard_usage_chart_no_data') || 'No data yet';
+                    return;
+                }
+                if (empty) empty.remove();
+                block.querySelector('.utl-caption').insertAdjacentHTML('beforebegin', svgHtml);
+                _utlAttachHover(block, points, fields, labels);
+            };
+            try {
+                const [day, month] = await Promise.all([fetchPts(24), fetchPts(720)]);
+                fill('[data-block="5h"]', day, ['c5', 'x5'], ['#ff8a5c', '#5cdfff'], ['Claude', 'Codex']);
+                fill('[data-block="wk"]', month, ['c7', 'x7'], ['#ffc857', '#3aa6ff'], ['Claude', 'Codex']);
+            } catch (err) {
+                overlay.querySelectorAll('.utl-empty').forEach(el => { el.textContent = 'Failed: ' + (err.message || err); });
+            }
+        }
+
+        // Whole-widget click opens the timeline (Hank: 「點擊儀表板的用量視窗」);
+        // inner buttons (Refresh etc.) keep their own behavior.
+        (function () {
+            const w = document.getElementById('usageWidget');
+            if (!w) return;
+            w.addEventListener('click', (e) => {
+                if (e.target.closest('button, a')) return;
+                openUsageTimelineModal();
+            });
+        })();
 
         /* ── K-Value Tracker (§7 k-Value Metric) ── */
         // Reads GET /api/growth/daily?date=YYYY-MM-DD with device credentials.

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650174,6 +650174,12 @@ const TRANSLATIONS = {
         "kb_modal_splitter_aria": "Drag to resize description area",
         "kb_modal_prev_card": "Previous linked card",
         "kb_modal_next_card": "Next linked card",
+
+        "dashboard_usage_chart_modal_title": "Usage timeline",
+        "dashboard_usage_chart_5h_label": "5h session % (last 24h)",
+        "dashboard_usage_chart_weekly_label": "Weekly % (last 30d)",
+        "dashboard_usage_chart_loading": "Loading…",
+        "dashboard_usage_chart_no_data": "No data yet",
 },
 
 
@@ -1234815,6 +1234821,12 @@ const TRANSLATIONS = {
         "kb_modal_splitter_aria": "拖拉调整描述区高度",
         "kb_modal_prev_card": "上一张链接任务卡",
         "kb_modal_next_card": "下一张链接任务卡",
+
+        "dashboard_usage_chart_modal_title": "用量波形图",
+        "dashboard_usage_chart_5h_label": "5 小时用量 %（近 24 小时）",
+        "dashboard_usage_chart_weekly_label": "每周用量 %（近 30 天）",
+        "dashboard_usage_chart_loading": "载入中…",
+        "dashboard_usage_chart_no_data": "暂无数据",
 },
 
 
@@ -2412059,6 +2412071,12 @@ const TRANSLATIONS = {
         "kb_modal_splitter_aria": "ドラッグして説明エリアの高さを調整",
         "kb_modal_prev_card": "前のリンクカード",
         "kb_modal_next_card": "次のリンクカード",
+
+        "dashboard_usage_chart_modal_title": "使用量タイムライン",
+        "dashboard_usage_chart_5h_label": "5時間使用率 %（過去24時間）",
+        "dashboard_usage_chart_weekly_label": "週間使用率 %（過去30日）",
+        "dashboard_usage_chart_loading": "読み込み中…",
+        "dashboard_usage_chart_no_data": "データはまだありません",
 },
 
 
@@ -2942315,6 +2942333,12 @@ const TRANSLATIONS = {
         "kb_modal_splitter_aria": "드래그하여 설명 영역 크기 조절",
         "kb_modal_prev_card": "이전 연결 카드",
         "kb_modal_next_card": "다음 연결 카드",
+
+        "dashboard_usage_chart_modal_title": "사용량 타임라인",
+        "dashboard_usage_chart_5h_label": "5시간 사용률 %(최근 24시간)",
+        "dashboard_usage_chart_weekly_label": "주간 사용률 %(최근 30일)",
+        "dashboard_usage_chart_loading": "불러오는 중…",
+        "dashboard_usage_chart_no_data": "아직 데이터가 없습니다",
 },
 
 
@@ -2943943,6 +2943967,12 @@ const TRANSLATIONS = {
         "kb_modal_splitter_aria": "拖拉調整描述區高度",
         "kb_modal_prev_card": "上一張鏈結任務卡",
         "kb_modal_next_card": "下一張鏈結任務卡",
+
+        "dashboard_usage_chart_modal_title": "用量波形圖",
+        "dashboard_usage_chart_5h_label": "5 小時用量 %（近 24 小時）",
+        "dashboard_usage_chart_weekly_label": "每週用量 %（近 30 天）",
+        "dashboard_usage_chart_loading": "載入中…",
+        "dashboard_usage_chart_no_data": "尚無資料",
 },
 
 
@@ -3997535,6 +3997565,12 @@ const TRANSLATIONS = {
         "kb_modal_splitter_aria": "Kéo để điều chỉnh vùng mô tả",
         "kb_modal_prev_card": "Thẻ liên kết trước",
         "kb_modal_next_card": "Thẻ liên kết tiếp theo",
+
+        "dashboard_usage_chart_modal_title": "Dòng thời gian sử dụng",
+        "dashboard_usage_chart_5h_label": "% phiên 5 giờ (24 giờ qua)",
+        "dashboard_usage_chart_weekly_label": "% hàng tuần (30 ngày qua)",
+        "dashboard_usage_chart_loading": "Đang tải…",
+        "dashboard_usage_chart_no_data": "Chưa có dữ liệu",
 },
 
 
@@ -4523974,6 +4524010,12 @@ const TRANSLATIONS = {
         "kb_modal_splitter_aria": "Seret untuk mengubah tinggi area deskripsi",
         "kb_modal_prev_card": "Kartu tertaut sebelumnya",
         "kb_modal_next_card": "Kartu tertaut berikutnya",
+
+        "dashboard_usage_chart_modal_title": "Linimasa penggunaan",
+        "dashboard_usage_chart_5h_label": "% sesi 5 jam (24 jam terakhir)",
+        "dashboard_usage_chart_weekly_label": "% mingguan (30 hari terakhir)",
+        "dashboard_usage_chart_loading": "Memuat…",
+        "dashboard_usage_chart_no_data": "Belum ada data",
 },
 
 
@@ -5566713,6 +5566755,12 @@ const TRANSLATIONS = {
         "kb_modal_splitter_aria": "Arrastra para redimensionar la descripción",
         "kb_modal_prev_card": "Tarjeta enlazada anterior",
         "kb_modal_next_card": "Tarjeta enlazada siguiente",
+
+        "dashboard_usage_chart_modal_title": "Cronología de uso",
+        "dashboard_usage_chart_5h_label": "% de sesión 5h (últimas 24h)",
+        "dashboard_usage_chart_weekly_label": "% semanal (últimos 30 días)",
+        "dashboard_usage_chart_loading": "Cargando…",
+        "dashboard_usage_chart_no_data": "Aún no hay datos",
 },
 
 

--- a/backend/tests/jest/dashboard-usage-timeline-modal.test.js
+++ b/backend/tests/jest/dashboard-usage-timeline-modal.test.js
@@ -1,0 +1,102 @@
+/**
+ * Usage timeline modal — card_fb8a5a39ebe67581a66c6061.
+ * Backend GET /timeline shipped in PR #3291 (5h/7d pct fields); this slice is
+ * the dashboard modal. Contract tests over dashboard.html source + the chart
+ * geometry helper executed in a VM; interaction covered by prod Playwright E2E.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const src = fs.readFileSync(
+    path.resolve(__dirname, '../../public/portal/dashboard.html'),
+    'utf8'
+);
+const i18nSrc = fs.readFileSync(
+    path.resolve(__dirname, '../../public/shared/i18n.js'),
+    'utf8'
+);
+
+describe('usage timeline modal — wiring contract', () => {
+    test('whole-widget click opens the modal, buttons excluded', () => {
+        expect(src).toMatch(/w\.addEventListener\('click', \(e\) => \{\s*if \(e\.target\.closest\('button, a'\)\) return;\s*openUsageTimelineModal\(\);/);
+    });
+    test('modal fetches both windows: 24h and 720h (30d)', () => {
+        expect(src).toMatch(/Promise\.all\(\[fetchPts\(24\), fetchPts\(720\)\]\)/);
+        expect(src).toMatch(/\/api\/usage\/timeline\?hours=/);
+    });
+    test('reads the #3291 pct fields', () => {
+        for (const f of ['claude_5h_pct', 'codex_5h_pct', 'claude_7d_pct', 'codex_7d_pct']) {
+            expect(src).toContain(f);
+        }
+    });
+    test('uses the existing uw color tokens (no palette drift)', () => {
+        for (const c of ['#ff8a5c', '#ffc857', '#5cdfff', '#3aa6ff']) {
+            expect(src).toContain(c);
+        }
+    });
+    test('empty data falls back to the no-data i18n string', () => {
+        expect(src).toMatch(/dashboard_usage_chart_no_data/);
+    });
+    test('usage widget gets pointer cursor, refresh button keeps refreshUsageWidget', () => {
+        expect(src).toMatch(/\.usage-widget \{ cursor: pointer; \}/);
+        expect(src).toMatch(/onclick="refreshUsageWidget\(\)"/);
+    });
+});
+
+describe('usage timeline modal — chart geometry (_utlChartSvg in VM)', () => {
+    const match = src.match(/function _utlChartSvg[\s\S]*?\n        \}/);
+    expect(match).toBeTruthy();
+    const ctx = {};
+    vm.createContext(ctx);
+    vm.runInContext(match[0] + '; this._fn = _utlChartSvg;', ctx);
+    const fn = ctx._fn;
+
+    const mk = (n, base) => Array.from({ length: n }, (_, i) => ({
+        t: new Date(Date.UTC(2026, 5, 11, 0, i * 10)),
+        a: base + i, b: null,
+    }));
+
+    test('returns null for <2 usable points (graceful empty state)', () => {
+        expect(fn([], ['a', 'b'], ['#fff', '#000'])).toBeNull();
+        expect(fn(mk(1, 10), ['a', 'b'], ['#fff', '#000'])).toBeNull();
+    });
+
+    test('renders a polyline for a populated series and skips the all-null one', () => {
+        const svg = fn(mk(5, 10), ['a', 'b'], ['#abc111', '#def222']);
+        expect(svg).toContain('<polyline');
+        expect(svg).toContain('#abc111');
+        expect(svg).not.toContain('#def222'); // series b is all null → no line
+    });
+
+    test('clamps out-of-range percentages into the 0-100 band', () => {
+        const pts = [
+            { t: new Date(Date.UTC(2026, 5, 11, 0, 0)), a: -20, b: null },
+            { t: new Date(Date.UTC(2026, 5, 11, 1, 0)), a: 250, b: null },
+        ];
+        const svg = fn(pts, ['a', 'b'], ['#aaa', '#bbb']);
+        // y for 0% is H-PY=148, y for 100% is PY=12 — both endpoints clamp there
+        expect(svg).toContain('148.0');
+        expect(svg).toContain('12.0');
+    });
+
+    test('draws the 0/25/50/75/100 gridline labels', () => {
+        const svg = fn(mk(3, 50), ['a', 'b'], ['#aaa', '#bbb']);
+        for (const v of ['>0<', '>25<', '>50<', '>75<', '>100<']) expect(svg).toContain(v);
+    });
+});
+
+describe('usage timeline modal — i18n keys', () => {
+    const NEEDED = [
+        'dashboard_usage_chart_modal_title',
+        'dashboard_usage_chart_5h_label',
+        'dashboard_usage_chart_weekly_label',
+        'dashboard_usage_chart_loading',
+        'dashboard_usage_chart_no_data',
+    ];
+    test.each(NEEDED)('%s is declared in i18n.js', (key) => {
+        expect(i18nSrc).toMatch(new RegExp('"' + key + '":'));
+    });
+});


### PR DESCRIPTION
## Scope (card_fb8a5a39ebe67581a66c6061)

Hank 06-10: click the dashboard usage widget → modal with 5h/weekly %-vs-time curves, style-matched.

- **Trigger**: whole `#usageWidget` click (inner buttons/links excluded — Refresh keeps working); widget gets `cursor:pointer`.
- **Modal**: standard `.card` shell + overlay; two stacked vanilla-SVG line charts (no new deps): 5h session % from `/api/usage/timeline?hours=24`, weekly % from `hours=720` (route + pct fields shipped in #3291, cap 720h).
- **Style parity**: lines use the widget's exact color tokens (Claude `#ff8a5c`/`#ffc857`, Codex `#5cdfff`/`#3aa6ff`), 0/25/50/75/100 gridlines, shared legend.
- **Tooltip**: pointermove/tap shows `MM/DD HH:mm · Claude N% · Codex N%` caption under each chart.
- States: loading → chart / 'No data yet' / fetch error; Esc + scrim close.

## Tests
- Jest: 15 new (wiring contract + VM-executed `_utlChartSvg` geometry: <2-point null, all-null series skip, % clamping, gridlines, i18n keys) — full suite green
- Post-deploy prod E2E + desktop/mobile screenshots to card /file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)