### PR TITLE
fix(dashboard): usage-timeline modal ✕ button was dead (IIFE scope)

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -6165,6 +6165,12 @@
             }
         }
 
+        // This whole block lives inside the usage-widget IIFE (line ~5631) —
+        // expose the modal pair on window so the overlay's inline onclick and
+        // other surfaces can reach them (same pattern as refreshUsageWidget).
+        window.openUsageTimelineModal = openUsageTimelineModal;
+        window.closeUsageTimelineModal = closeUsageTimelineModal;
+
         // Whole-widget click opens the timeline (Hank: 「點擊儀表板的用量視窗」);
         // inner buttons (Refresh etc.) keep their own behavior.
         (function () {

--- a/backend/tests/jest/dashboard-usage-timeline-modal.test.js
+++ b/backend/tests/jest/dashboard-usage-timeline-modal.test.js
@@ -40,6 +40,10 @@ describe('usage timeline modal — wiring contract', () => {
     test('empty data falls back to the no-data i18n string', () => {
         expect(src).toMatch(/dashboard_usage_chart_no_data/);
     });
+    test('modal pair exposed on window (block lives inside the widget IIFE; inline ✕ onclick needs the global)', () => {
+        expect(src).toMatch(/window\.openUsageTimelineModal = openUsageTimelineModal;/);
+        expect(src).toMatch(/window\.closeUsageTimelineModal = closeUsageTimelineModal;/);
+    });
     test('usage widget gets pointer cursor, refresh button keeps refreshUsageWidget', () => {
         expect(src).toMatch(/\.usage-widget \{ cursor: pointer; \}/);
         expect(src).toMatch(/onclick="refreshUsageWidget\(\)"/);


### PR DESCRIPTION
Prod E2E for card_fb8a5a39 hit `ReferenceError: closeUsageTimelineModal is not defined`: the modal functions are declared inside the usage-widget IIFE, so the overlay's inline `onclick="closeUsageTimelineModal()"` (which resolves on window) could never work — the ✕ button was dead for real users (scrim + Esc still worked). Exposed `open`/`closeUsageTimelineModal` on window, matching the existing `refreshUsageWidget` pattern. +1 contract test locks the exposure; full suite 3814 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)