### PR TITLE
perf(dashboard): downsample usage timeline polylines to ≤600 points

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -6137,11 +6137,18 @@
                 if (!res.ok) throw new Error('http ' + res.status);
                 const data = await res.json();
                 if (!data.success) throw new Error(data.error || 'timeline failed');
-                return (data.points || []).map(p => ({
+                let pts = (data.points || []).map(p => ({
                     t: new Date(p.captured_at),
                     c5: p.claude_5h_pct, x5: p.codex_5h_pct,
                     c7: p.claude_7d_pct, x7: p.codex_7d_pct,
                 }));
+                // #3291 returns every 5-min row (30d ≈ 8.6k) — downsample to
+                // ≤600 points so the weekly polyline stays light on mobile.
+                if (pts.length > 600) {
+                    const step = Math.ceil(pts.length / 600);
+                    pts = pts.filter((_, i) => i % step === 0 || i === pts.length - 1);
+                }
+                return pts;
             };
             const fill = (blockSel, points, fields, colors, labels) => {
                 const block = overlay.querySelector(blockSel);


### PR DESCRIPTION
E2E found the weekly chart polyline carrying ~14.8k points (30d × 5-min snapshots; the #3291 backend route has no LIMIT). Client-side downsample in `fetchPts` to ≤600 points (every Nth + always the last point) keeps the SVG light on mobile without visual change. Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)