### PR TITLE
feat(dashboard): first-achievement toast (card_d3556164 — EV3 deferred slice)

### DIFF
--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -2013,6 +2013,18 @@
             .lvlup-card, .lvlup-badge { animation: none !important; }
             .lvlup-confetti { display: none; }
         }
+        /* first-achievement toast (card_d3556164) — small, non-fullscreen */
+        .firstach-toast {
+            position: fixed; bottom: 28px; left: 50%; transform: translateX(-50%);
+            z-index: 10060; background: var(--card, #1b1b2f); color: var(--text-primary, #fff);
+            border: 1px solid rgba(251,191,36,0.5); border-radius: 999px;
+            padding: 10px 22px; font-size: 14px; font-weight: 700;
+            box-shadow: 0 8px 30px rgba(251,191,36,0.25);
+            animation: firstach-pop 0.4s cubic-bezier(0.18, 1.4, 0.4, 1);
+        }
+        @keyframes firstach-pop { 0% { transform: translateX(-50%) scale(0.6); opacity: 0; } 100% { transform: translateX(-50%) scale(1); opacity: 1; } }
+        .firstach-toast.firstach-reduced { animation: none; }
+        @media (prefers-reduced-motion: reduce) { .firstach-toast { animation: none !important; } }
     </style>
     <link rel="canonical" href="https://eclawbot.com/portal/dashboard.html">
 </head>
@@ -2999,6 +3011,12 @@
                 try {
                     if (window.EclawLevelUp) {
                         EclawLevelUp.onEntitiesUpdated(entities, { t: (k) => i18n.t(k) });
+                        // First-achievement toast (card_d3556164): throttled to
+                        // ~60s inside pollFirstAchievements; same best-effort rule.
+                        EclawLevelUp.pollFirstAchievements(entities, {
+                            t: (k) => i18n.t(k),
+                            fetcher: (eid) => fetch(`/api/entity-status/${eid}/achievements?deviceId=${encodeURIComponent(currentUser.deviceId)}&deviceSecret=${encodeURIComponent(currentUser.deviceSecret)}`, { credentials: 'same-origin' }).then(r => r.json()),
+                        });
                     }
                 } catch (_e) { /* celebration is best-effort */ }
 

--- a/backend/public/portal/shared/levelup.js
+++ b/backend/public/portal/shared/levelup.js
@@ -140,6 +140,103 @@
         return overlay;
     }
 
+    // ── First-achievement toast (card_d355616434834b0737d6380f) ──
+    // Watches the card_8ca achievements API for any axis count crossing
+    // 0 → ≥1 during the session. Small toast, NOT the full-screen level-up
+    // overlay. Same guard philosophy: first sighting primes the baseline,
+    // localStorage keeps each (entity, axis) to a single celebration ever.
+    var FIRSTACH_PREFIX = 'eclaw_firstach_';
+    var _achSeen = {};          // 'eid:axis' -> last seen count
+    var _achLastPollMs = 0;
+    var ACH_POLL_MIN_MS = 60000; // piggyback on the 10s entity poll, act every ~60s
+
+    function _achGuarded(storage, eid, axis) {
+        try { return storage.getItem(FIRSTACH_PREFIX + eid + '_' + axis) === '1'; }
+        catch (_e) { return false; }
+    }
+    function _achMarc(storage, eid, axis) {
+        try { storage.setItem(FIRSTACH_PREFIX + eid + '_' + axis, '1'); } catch (_e) { /* quota */ }
+    }
+
+    /** Pure diff: returns [{entityId, axis}] crossing 0→≥1, baseline-primed + guarded. */
+    function checkFirstAchievements(entityId, achievements, storage) {
+        storage = storage || global.localStorage;
+        var hits = [];
+        (achievements || []).forEach(function (a) {
+            if (!a || !a.axis) return;
+            var key = entityId + ':' + a.axis;
+            var count = Number(a.count) || 0;
+            var prev = _achSeen[key];
+            _achSeen[key] = count;
+            if (prev === undefined) return;        // baseline priming
+            if (!(prev === 0 && count >= 1)) return;
+            if (_achGuarded(storage, entityId, a.axis)) return;
+            _achMarc(storage, entityId, a.axis);
+            hits.push({ entityId: entityId, axis: a.axis });
+        });
+        return hits;
+    }
+
+    /** Test hook. */
+    function _resetAchSession() { _achSeen = {}; _achLastPollMs = 0; }
+
+    function _axisLabel(axis, t) {
+        var key = 'entity_status_achievement_' + axis;
+        var v = (typeof t === 'function') ? t(key) : null;
+        return (v && v !== key) ? v : axis;
+    }
+
+    /** Small toast — distinct from the full-screen level-up overlay. */
+    function celebrateFirstAchievement(hit, opts) {
+        opts = opts || {};
+        var doc = opts.doc || global.document;
+        var t = opts.t;
+        var duration = opts.duration || 2500;
+        var reduced = _prefersReducedMotion();
+        var prev = doc.getElementById('firstachToast');
+        if (prev && prev.parentNode) prev.parentNode.removeChild(prev);
+        var el = doc.createElement('div');
+        el.id = 'firstachToast';
+        el.className = 'firstach-toast' + (reduced ? ' firstach-reduced' : '');
+        el.setAttribute('role', 'status');
+        el.setAttribute('aria-live', 'polite');
+        var tpl = (typeof t === 'function' && t('firstach_title') !== 'firstach_title' && t('firstach_title'))
+            ? t('firstach_title') : 'First achievement: {label}!';
+        el.textContent = '🏅 ' + tpl.replace('{label}', _axisLabel(hit.axis, t));
+        doc.body.appendChild(el);
+        setTimeout(function () {
+            if (el.parentNode) el.parentNode.removeChild(el);
+        }, duration);
+        return el;
+    }
+
+    /**
+     * Throttled poll driver — call from the dashboard's entity-poll hook.
+     * opts.fetcher(entityId) must resolve to the /achievements payload
+     * ({achievements:[...]}) and is injected so tests need no network.
+     */
+    function pollFirstAchievements(entities, opts) {
+        opts = opts || {};
+        var nowMs = (typeof opts.nowMs === 'number') ? opts.nowMs : Date.now();
+        if (nowMs - _achLastPollMs < ACH_POLL_MIN_MS) return Promise.resolve([]);
+        _achLastPollMs = nowMs;
+        var fetcher = opts.fetcher;
+        if (typeof fetcher !== 'function') return Promise.resolve([]);
+        var ids = (entities || []).map(function (e) { return e && e.entityId; })
+            .filter(function (id) { return id !== undefined && id !== null; });
+        return Promise.all(ids.map(function (eid) {
+            return Promise.resolve(fetcher(eid)).then(function (data) {
+                return checkFirstAchievements(eid, (data && data.achievements) || [], opts.storage);
+            }).catch(function () { return []; });
+        })).then(function (lists) {
+            var hits = [].concat.apply([], lists);
+            hits.forEach(function (hit, idx) {
+                setTimeout(function () { celebrateFirstAchievement(hit, opts); }, idx * 2700);
+            });
+            return hits;
+        });
+    }
+
     /** Convenience: diff + celebrate each hit (stagger if multiple). */
     function onEntitiesUpdated(entities, opts) {
         opts = opts || {};
@@ -154,7 +251,11 @@
         check: check,
         celebrate: celebrate,
         onEntitiesUpdated: onEntitiesUpdated,
+        checkFirstAchievements: checkFirstAchievements,
+        celebrateFirstAchievement: celebrateFirstAchievement,
+        pollFirstAchievements: pollFirstAchievements,
         _resetSession: _resetSession,
+        _resetAchSession: _resetAchSession,
         PRAISE_KEYS: PRAISE_KEYS,
     };
 

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650180,6 +650180,8 @@ const TRANSLATIONS = {
         "dashboard_usage_chart_weekly_label": "Weekly % (last 30d)",
         "dashboard_usage_chart_loading": "Loading…",
         "dashboard_usage_chart_no_data": "No data yet",
+
+        "firstach_title": "First achievement: {label}!",
 },
 
 
@@ -1234827,6 +1234829,8 @@ const TRANSLATIONS = {
         "dashboard_usage_chart_weekly_label": "每週用量 %（近 30 天）",
         "dashboard_usage_chart_loading": "載入中…",
         "dashboard_usage_chart_no_data": "尚無資料",
+
+        "firstach_title": "首個成就：{label}！",
 },
 
 
@@ -2412077,6 +2412081,8 @@ const TRANSLATIONS = {
         "dashboard_usage_chart_weekly_label": "週間使用率 %（過去30日）",
         "dashboard_usage_chart_loading": "読み込み中…",
         "dashboard_usage_chart_no_data": "データはまだありません",
+
+        "firstach_title": "初めての実績：{label}！",
 },
 
 
@@ -2942339,6 +2942345,8 @@ const TRANSLATIONS = {
         "dashboard_usage_chart_weekly_label": "주간 사용률 %(최근 30일)",
         "dashboard_usage_chart_loading": "불러오는 중…",
         "dashboard_usage_chart_no_data": "아직 데이터가 없습니다",
+
+        "firstach_title": "첫 업적: {label}!",
 },
 
 
@@ -3997530,6 +3997538,8 @@ const TRANSLATIONS = {
         "dashboard_usage_chart_weekly_label": "% hàng tuần (30 ngày qua)",
         "dashboard_usage_chart_loading": "Đang tải…",
         "dashboard_usage_chart_no_data": "Chưa có dữ liệu",
+
+        "firstach_title": "Thành tích đầu tiên: {label}!",
 },
 
 
@@ -4523975,6 +4523985,8 @@ const TRANSLATIONS = {
         "dashboard_usage_chart_weekly_label": "% mingguan (30 hari terakhir)",
         "dashboard_usage_chart_loading": "Memuat…",
         "dashboard_usage_chart_no_data": "Belum ada data",
+
+        "firstach_title": "Pencapaian pertama: {label}!",
 },
 
 
@@ -5566720,6 +5566732,8 @@ const TRANSLATIONS = {
         "dashboard_usage_chart_weekly_label": "% semanal (últimos 30 días)",
         "dashboard_usage_chart_loading": "Cargando…",
         "dashboard_usage_chart_no_data": "Aún no hay datos",
+
+        "firstach_title": "¡Primer logro: {label}!",
 },
 
 

--- a/backend/tests/jest/levelup.test.js
+++ b/backend/tests/jest/levelup.test.js
@@ -116,3 +116,82 @@ describe('levelup — i18n keys exist', () => {
         expect(i18nJs).toMatch(new RegExp('"' + key + '":'));
     });
 });
+
+describe('first-achievement — checkFirstAchievements() diff + guard (card_d3556164)', () => {
+    let lvl, storage;
+    beforeEach(() => {
+        lvl = loadLevelUp();
+        lvl._resetAchSession();
+        storage = makeStorage();
+    });
+
+    const ach = (axis, count) => ({ axis, count });
+
+    test('first sighting primes baseline, never celebrates (even count≥1)', () => {
+        expect(lvl.checkFirstAchievements(2, [ach('tasks_done', 5)], storage)).toEqual([]);
+        expect(lvl.checkFirstAchievements(2, [ach('tasks_done', 6)], storage)).toEqual([]);
+    });
+
+    test('0→1 transition after baseline celebrates once with entity+axis', () => {
+        lvl.checkFirstAchievements(2, [ach('chat_upvotes', 0)], storage);
+        expect(lvl.checkFirstAchievements(2, [ach('chat_upvotes', 1)], storage))
+            .toEqual([{ entityId: 2, axis: 'chat_upvotes' }]);
+        // and never again, even if it dips and rises (server-side anomaly)
+        lvl.checkFirstAchievements(2, [ach('chat_upvotes', 0)], storage);
+        expect(lvl.checkFirstAchievements(2, [ach('chat_upvotes', 3)], storage)).toEqual([]);
+    });
+
+    test('localStorage guard survives session reset', () => {
+        lvl.checkFirstAchievements(2, [ach('notes_authored', 0)], storage);
+        lvl.checkFirstAchievements(2, [ach('notes_authored', 1)], storage); // celebrated
+        lvl._resetAchSession();
+        lvl.checkFirstAchievements(2, [ach('notes_authored', 0)], storage); // stale baseline
+        expect(lvl.checkFirstAchievements(2, [ach('notes_authored', 1)], storage)).toEqual([]);
+    });
+
+    test('axes are independent per entity', () => {
+        lvl.checkFirstAchievements(1, [ach('tasks_done', 0)], storage);
+        lvl.checkFirstAchievements(2, [ach('tasks_done', 0)], storage);
+        expect(lvl.checkFirstAchievements(1, [ach('tasks_done', 1)], storage))
+            .toEqual([{ entityId: 1, axis: 'tasks_done' }]);
+        // entity 2 still eligible independently
+        expect(lvl.checkFirstAchievements(2, [ach('tasks_done', 2)], storage))
+            .toEqual([{ entityId: 2, axis: 'tasks_done' }]);
+    });
+
+    test('pollFirstAchievements throttles to one pass per 60s window', async () => {
+        const fetcher = jest.fn().mockResolvedValue({ achievements: [ach('tasks_done', 0)] });
+        await lvl.pollFirstAchievements([{ entityId: 2 }], { fetcher, storage, nowMs: 1000000 });
+        await lvl.pollFirstAchievements([{ entityId: 2 }], { fetcher, storage, nowMs: 1030000 }); // +30s → skipped
+        expect(fetcher).toHaveBeenCalledTimes(1);
+        await lvl.pollFirstAchievements([{ entityId: 2 }], { fetcher, storage, nowMs: 1070000 }); // +70s → runs
+        expect(fetcher).toHaveBeenCalledTimes(2);
+    });
+
+    test('fetcher failure for one entity never throws or blocks others', async () => {
+        const fetcher = jest.fn()
+            .mockImplementation((eid) => eid === 1 ? Promise.reject(new Error('boom')) : Promise.resolve({ achievements: [] }));
+        await expect(lvl.pollFirstAchievements([{ entityId: 1 }, { entityId: 2 }], { fetcher, storage, nowMs: 5000000 }))
+            .resolves.toEqual([]);
+    });
+});
+
+describe('first-achievement — dashboard integration + i18n', () => {
+    const fs = require('fs');
+    const dashHtml = fs.readFileSync(
+        path.join(__dirname, '..', '..', 'public', 'portal', 'dashboard.html'), 'utf8');
+    const i18nJs = fs.readFileSync(
+        path.join(__dirname, '..', '..', 'public', 'shared', 'i18n.js'), 'utf8');
+
+    test('dashboard hooks pollFirstAchievements with an injected fetcher', () => {
+        expect(dashHtml).toMatch(/EclawLevelUp\.pollFirstAchievements\(entities/);
+        expect(dashHtml).toMatch(/\/api\/entity-status\/\$\{eid\}\/achievements/);
+    });
+    test('toast CSS exists with reduced-motion fallback', () => {
+        expect(dashHtml).toMatch(/\.firstach-toast \{/);
+        expect(dashHtml).toMatch(/\.firstach-toast \{ animation: none !important; \}/);
+    });
+    test('firstach_title declared in i18n.js', () => {
+        expect(i18nJs).toMatch(/"firstach_title":/);
+    });
+});


### PR DESCRIPTION
## Scope (card_d355616434834b0737d6380f, parent 情緒價值 #3)

The 情緒價值 #3 card deferred first-achievement celebration until card_8ca's achievements API shipped — it did (PR #3310-#3312), so this connects it:

- `pollFirstAchievements(entities, {fetcher})` piggybacks the dashboard's 10s entity poll but acts at most every 60s; per-entity fetch failures are isolated.
- `checkFirstAchievements` celebrates an axis crossing **0 → ≥1** once ever per (entity, axis): session baseline priming (no celebration on page load) + `eclaw_firstach_<eid>_<axis>` localStorage guard (dip-and-rise anomalies stay silent).
- Toast: small bottom-center pill 「🏅 首個成就：<axis label>！」 — deliberately NOT the full-screen level-up overlay; 2.5s auto-dismiss; `prefers-reduced-motion` removes the pop animation; `role=status aria-live=polite`. Multiple hits stagger 2.7s.
- i18n: `firstach_title` ×7 locales (Traditional→zh, zh-TW untouched per the #3316 canonical rule); axis labels reuse `entity_status_achievement_*`.

## Tests
Jest 9 new (0→1 single-fire, reload guard, per-entity independence, 60s throttle, failure isolation, dashboard/i18n contracts) — **full suite green, merge gated on jest exit code**.

Post-deploy prod E2E (mock 0→1 via fetch intercept + reduced-motion + screenshots) before card close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)