### PR TITLE
feat(redirect): Phase A — /r/ universal entry + registry + mint + telemetry (OODA-R #7)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -2275,6 +2275,14 @@ entityStatus.bindJwtSecret(JWT_SECRET_FALLBACK);
 app.use('/api/entity-status', entityStatus.router);
 
 // ============================================
+// REDIRECT STATE MACHINE — universal /r/:target entry + mint/telemetry/stats.
+// Phase A (web slice) of docs/redirect-state-machine-spec.md (OODA-R #7).
+// Pool wired below alongside the other initTable calls.
+// ============================================
+const redirectRouter = require('./redirect-router');
+app.use(redirectRouter.router);
+
+// ============================================
 // AGENT IMPROVEMENT — OODA-R episode store (Phase 0 #2a, card_2024e5eebe...).
 // Ingests user-visible feedback signals into the episode store defined by
 // Phase 0 #1's schema; Phase 1 #3 preflight lint will read from this table.
@@ -18988,6 +18996,7 @@ devicePrefs.initTable(chatPool);
 entityStatus.initTable(chatPool)
     .then(() => entityStatus.startSweeper(60_000))
     .catch(err => console.error('[EntityStatus] initTable error:', err.message));
+redirectRouter.init({ chatPool, devices, jwtSecret: JWT_SECRET_FALLBACK });
 agentImprovement.initTable(chatPool)
     .catch(err => console.error('[AgentImprovement] initTable error:', err.message));
 

--- a/backend/public/portal/index.html
+++ b/backend/public/portal/index.html
@@ -452,6 +452,16 @@
                 window.location.href = 'invite.html?redeem=' + encodeURIComponent(pendingCode);
                 return;
             }
+            // LOGIN_REDIRECT return_to round-trip (redirect spec §4): honor the
+            // interrupted destination only if it's a same-origin portal page or
+            // the /r/ entry — mirrors route-registry.isSafeReturnTo so a crafted
+            // link can't turn login into an open redirect.
+            const returnTo = new URLSearchParams(window.location.search).get('return_to');
+            if (returnTo && !returnTo.startsWith('//')
+                && /^\/(r\/|portal\/(dashboard|chat|kanban|mission|settings)\.html)/.test(returnTo)) {
+                window.location.href = returnTo;
+                return;
+            }
             window.location.href = 'dashboard.html';
         }
 

--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -45,7 +45,15 @@ async function apiCall(method, path, body = null, opts = {}) {
                 ? t('session_expired_relogin', 'Session expired — please log in again')
                 : t('session_invalid_relogin', 'Please log in to continue');
             try { showToast(msg, 'warning'); } catch (_) { /* toast not ready pre-DOM */ }
-            setTimeout(() => { window.location.href = 'index.html?authReason=' + encodeURIComponent(reason); }, 1200);
+            // Carry the interrupted destination so login can round-trip back
+            // (redirect spec §4 LOGIN_REDIRECT; index.html validates against
+            // its portal-page allowlist before honoring it).
+            const returnTo = (window.location.pathname || '')
+                + (window.location.search || '') + (window.location.hash || '');
+            setTimeout(() => {
+                window.location.href = 'index.html?authReason=' + encodeURIComponent(reason)
+                    + '&return_to=' + encodeURIComponent(returnTo);
+            }, 1200);
         }
         const authErr = new Error(data.error || 'Not authenticated');
         authErr.status = 401;

--- a/backend/redirect-router.js
+++ b/backend/redirect-router.js
@@ -1,0 +1,241 @@
+/**
+ * Unified redirect entry + telemetry — docs/redirect-state-machine-spec.md
+ * (APPROVED 2026-06-12, #6 review). Card: card_14571f26914b9c1eae148362
+ * Phase A (web slice).
+ *
+ * Routes (mounted at app root):
+ *   GET  /r/:target               — universal entry: sig check → telemetry → 302
+ *   POST /api/redirect/mint       — server-side signed-link minting (#6 am. 2)
+ *   POST /api/redirect/telemetry  — client beacon for page-side transitions
+ *   GET  /api/redirect/stats      — success rate per target/platform
+ *
+ * Per the approved open-point 1: Phase A goes straight to web (no app-attempt
+ * window) — the 400 ms attempt activates with Phase B (App Links).
+ */
+'use strict';
+
+const express = require('express');
+const crypto = require('crypto');
+const safeEqual = require('./safe-equal');
+const registry = require('./shared/route-registry');
+
+const SIG_TTL_DEFAULT_S = 7 * 24 * 3600;   // minted links live a week unless overridden
+const RETENTION_DAYS = 30;                  // approved open-point 2
+const TRACE_RE = /^rt_[a-f0-9]{12}$/;
+const STATES = ['RECEIVED', 'SIG_REJECTED', 'WEB_DIRECT', 'WEB_FALLBACK', 'APP_OPENED', 'LOGIN_REDIRECT', 'TARGET_RENDERED'];
+
+let pool = null;
+let devicesRef = null;
+let signingSecret = null;
+let purgeTimer = null;
+
+function init({ chatPool, devices, jwtSecret }) {
+    pool = chatPool || null;
+    devicesRef = devices || null;
+    // Reuses JWT_SECRET per spec §3 (no-new-keys); server-side only (#6 am. 2).
+    signingSecret = jwtSecret || process.env.JWT_SECRET || null;
+    ensureSchema().catch(err => console.warn('[Redirect] schema init failed:', err.message));
+    if (!purgeTimer) {
+        purgeTimer = setInterval(() => purgeOldEvents().catch(() => {}), 24 * 3600 * 1000);
+        if (purgeTimer.unref) purgeTimer.unref();
+    }
+}
+
+async function ensureSchema() {
+    if (!pool) return;
+    await pool.query(`
+        CREATE TABLE IF NOT EXISTS redirect_events (
+            id              BIGSERIAL PRIMARY KEY,
+            trace_id        TEXT        NOT NULL,
+            state           TEXT        NOT NULL,
+            target          TEXT        NOT NULL,
+            platform        TEXT        NULL,
+            fallback_reason TEXT        NULL,
+            created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        )
+    `);
+    await pool.query(`CREATE INDEX IF NOT EXISTS redirect_events_trace_idx
+        ON redirect_events (trace_id, created_at)`);
+    await pool.query(`CREATE INDEX IF NOT EXISTS redirect_events_created_idx
+        ON redirect_events (created_at DESC)`);
+    await purgeOldEvents();
+}
+
+async function purgeOldEvents() {
+    if (!pool) return;
+    await pool.query(
+        `DELETE FROM redirect_events WHERE created_at < NOW() - ($1 || ' days')::interval`,
+        [RETENTION_DAYS]
+    );
+}
+
+function mintTraceId() {
+    return 'rt_' + crypto.randomBytes(6).toString('hex');
+}
+
+// HMAC over `target|sortedParams|exp` — spec §3.
+function computeSig(target, params, exp) {
+    const route = registry.ROUTES[target];
+    const canonical = (route ? route.params : []).slice().sort()
+        .map(k => k + '=' + String(params[k] ?? '')).join('&');
+    return crypto.createHmac('sha256', String(signingSecret))
+        .update(target + '|' + canonical + '|' + exp)
+        .digest('hex').slice(0, 32);
+}
+
+function verifySig(target, params, exp, sig) {
+    if (!signingSecret) return false;
+    const expNum = Number(exp);
+    if (!Number.isFinite(expNum) || expNum * 1000 < Date.now()) return false;
+    if (typeof sig !== 'string' || sig.length !== 32) return false;
+    return safeEqual(computeSig(target, params, expNum), sig);
+}
+
+function detectPlatform(req) {
+    const ua = String(req.headers['user-agent'] || '');
+    if (/EClawAndroid|EClawIOS/i.test(ua)) return 'app_webview';
+    if (/Android|iPhone|iPad|Mobile/i.test(ua)) return 'mobile_web';
+    if (/bot|crawler|spider|curl|wget/i.test(ua)) return 'bot';
+    return 'desktop_web';
+}
+
+async function logEvent(traceId, state, target, platform, fallbackReason) {
+    if (!pool) return;
+    try {
+        await pool.query(
+            `INSERT INTO redirect_events (trace_id, state, target, platform, fallback_reason)
+             VALUES ($1, $2, $3, $4, $5)`,
+            [traceId, state, target, platform || null, fallbackReason || null]
+        );
+    } catch (err) {
+        console.warn('[Redirect] logEvent failed:', err.message);
+    }
+}
+
+// Same auth contract as entity-status's authDeviceOrBot, trimmed to what the
+// mint/stats endpoints need (no cookie path — these are bot/owner APIs).
+function authDeviceOrBot(req) {
+    const src = Object.assign({}, req.query, req.body || {});
+    const deviceId = src.deviceId;
+    if (!deviceId || !devicesRef || !devicesRef[deviceId]) return null;
+    const device = devicesRef[deviceId];
+    if (src.deviceSecret && safeEqual(device.deviceSecret, src.deviceSecret)) {
+        return { deviceId };
+    }
+    if (src.botSecret) {
+        const ents = device.entities || {};
+        const eid = parseInt(src.entityId) || 0;
+        if (eid > 0) {
+            const e = ents[eid];
+            if (e && e.isBound && e.botSecret && safeEqual(e.botSecret, src.botSecret)) return { deviceId, entityId: eid };
+        } else {
+            const match = Object.entries(ents).find(([, e]) =>
+                e && e.isBound && e.botSecret && safeEqual(e.botSecret, src.botSecret));
+            if (match) return { deviceId, entityId: Number(match[0]) };
+        }
+    }
+    return null;
+}
+
+const router = express.Router();
+
+// ── universal entry ──────────────────────────────────────────────────────
+router.get('/r/:target', async (req, res) => {
+    const target = String(req.params.target || '');
+    const traceId = TRACE_RE.test(String(req.query.traceId || '')) ? req.query.traceId : mintTraceId();
+    const platform = detectPlatform(req);
+
+    if (!registry.isKnownTarget(target)) {
+        await logEvent(traceId, 'SIG_REJECTED', target.slice(0, 64), platform, 'unknown_target');
+        return res.redirect(302, '/portal/dashboard.html?redirectError=unknown');
+    }
+    await logEvent(traceId, 'RECEIVED', target, platform);
+
+    const route = registry.ROUTES[target];
+    const params = {};
+    for (const name of route.params) params[name] = req.query[name];
+
+    const paramCheck = registry.validateParams(target, params);
+    if (!paramCheck.ok) {
+        await logEvent(traceId, 'SIG_REJECTED', target, platform, paramCheck.error);
+        return res.redirect(302, '/portal/dashboard.html?redirectError=invalid');
+    }
+
+    if (route.sensitive && !verifySig(target, params, req.query.exp, req.query.sig)) {
+        // never a dead end — spec §3
+        await logEvent(traceId, 'SIG_REJECTED', target, platform, 'bad_or_expired_sig');
+        return res.redirect(302, '/portal/dashboard.html?redirectError=expired');
+    }
+
+    // Phase A (approved open-point 1): straight to web on every platform.
+    // APP_ATTEMPT activates with Phase B App Links.
+    const dest = registry.buildWebUrl(target, params);
+    const sep = dest.includes('?') ? '&' : '?';
+    const hashIdx = dest.indexOf('#');
+    const withTrace = hashIdx === -1
+        ? dest + sep + 'traceId=' + traceId
+        : dest.slice(0, hashIdx) + sep + 'traceId=' + traceId + dest.slice(hashIdx);
+    await logEvent(traceId, 'WEB_DIRECT', target, platform);
+    return res.redirect(302, withTrace);
+});
+
+// ── server-side mint (#6 amendment 2) ───────────────────────────────────
+router.post('/api/redirect/mint', express.json(), async (req, res) => {
+    const auth = authDeviceOrBot(req);
+    if (!auth) return res.status(403).json({ success: false, error: 'Invalid credentials' });
+    const { target, params } = req.body || {};
+    const check = registry.validateParams(String(target || ''), params || {});
+    if (!check.ok) return res.status(400).json({ success: false, error: check.error });
+    const traceId = mintTraceId();
+    let url = registry.buildUniversalUrl(target, params, traceId);
+    if (registry.ROUTES[target].sensitive) {
+        if (!signingSecret) return res.status(500).json({ success: false, error: 'signing_unavailable' });
+        const ttl = Math.min(Number(req.body.ttlSeconds) || SIG_TTL_DEFAULT_S, 30 * 24 * 3600);
+        const exp = Math.floor(Date.now() / 1000) + ttl;
+        const sig = computeSig(target, params, exp);
+        url += '&exp=' + exp + '&sig=' + sig;
+    }
+    return res.json({ success: true, url, traceId });
+});
+
+// ── client beacon for page-side transitions (TARGET_RENDERED etc.) ──────
+router.post('/api/redirect/telemetry', express.json(), async (req, res) => {
+    const { traceId, state, target } = req.body || {};
+    if (!TRACE_RE.test(String(traceId || '')) || !STATES.includes(state) || !registry.isKnownTarget(String(target || ''))) {
+        return res.status(400).json({ success: false, error: 'invalid_event' });
+    }
+    await logEvent(traceId, state, target, detectPlatform(req),
+        typeof req.body.fallbackReason === 'string' ? req.body.fallbackReason.slice(0, 128) : null);
+    return res.json({ success: true });
+});
+
+// ── stats: success rate per target/platform (spec §5) ───────────────────
+router.get('/api/redirect/stats', async (req, res) => {
+    const auth = authDeviceOrBot(req);
+    if (!auth) return res.status(403).json({ success: false, error: 'Invalid credentials' });
+    if (!pool) return res.json({ success: true, window: null, rows: [] });
+    const days = Math.min(Math.max(parseInt(req.query.days) || 7, 1), RETENTION_DAYS);
+    try {
+        const r = await pool.query(`
+            SELECT target, platform,
+                   COUNT(*) FILTER (WHERE state = 'RECEIVED')::int                          AS received,
+                   COUNT(DISTINCT trace_id) FILTER (WHERE state IN ('TARGET_RENDERED','APP_OPENED'))::int AS landed,
+                   COUNT(*) FILTER (WHERE state = 'SIG_REJECTED')::int                      AS rejected
+              FROM redirect_events
+             WHERE created_at > NOW() - ($1 || ' days')::interval
+             GROUP BY target, platform
+             ORDER BY target, platform`,
+            [days]
+        );
+        return res.json({ success: true, windowDays: days, rows: r.rows });
+    } catch (err) {
+        console.error('[Redirect] stats error:', err.message);
+        return res.status(500).json({ success: false, error: 'internal' });
+    }
+});
+
+module.exports = {
+    router,
+    init,
+    _internal: { computeSig, verifySig, detectPlatform, mintTraceId, authDeviceOrBot, STATES, TRACE_RE },
+};

--- a/backend/shared/route-registry.js
+++ b/backend/shared/route-registry.js
@@ -1,0 +1,94 @@
+/**
+ * Canonical route registry — docs/redirect-state-machine-spec.md §2.
+ * Card: card_14571f26914b9c1eae148362 (OODA-R Phase 2 #7, Phase A).
+ *
+ * The single source of truth for every logical navigation target. URL shapes
+ * intentionally match the CURRENT page consumers (per #6 review amendment 1):
+ * kanban's `?card=<id>#<id>` hash handler, chat's `?contact=<publicCode>`
+ * shareable-link param, mission's `?note=`, and the `/p/:publicCode` route.
+ *
+ * Used by: backend/redirect-router.js (Phase A). The portal-side SmartRouter
+ * (docs/smart-router-spec.md) consumes a copy when its implementation card
+ * lands — keep this file dependency-free CJS so it can be served verbatim.
+ */
+'use strict';
+
+// sensitive: deep link pre-selects private context → requires HMAC sig (spec §3)
+const ROUTES = {
+    dashboard: { web: '/portal/dashboard.html',                     params: [],             sensitive: false },
+    chat:      { web: '/portal/chat.html?contact={publicCode}',     params: ['publicCode'], sensitive: false },
+    card:      { web: '/portal/kanban.html?card={cardId}#{cardId}', params: ['cardId'],     sensitive: true },
+    note:      { web: '/portal/mission.html?note={noteId}',         params: ['noteId'],     sensitive: true },
+    profile:   { web: '/p/{publicCode}',                            params: ['publicCode'], sensitive: false },
+    settings:  { web: '/portal/settings.html',                      params: [],             sensitive: false },
+};
+
+const PARAM_RE = {
+    cardId:     /^card_[a-zA-Z0-9]{6,32}$/,
+    noteId:     /^[a-zA-Z0-9_-]{1,64}$/,
+    publicCode: /^[a-z0-9]{6}$/,
+};
+
+function isKnownTarget(target) {
+    return Object.prototype.hasOwnProperty.call(ROUTES, target);
+}
+
+/** Validate params against the target's declared list + per-param regex. */
+function validateParams(target, params) {
+    if (!isKnownTarget(target)) return { ok: false, error: 'unknown_target' };
+    const route = ROUTES[target];
+    params = params || {};
+    for (const name of route.params) {
+        const v = params[name];
+        if (v === undefined || v === null || v === '') return { ok: false, error: 'missing_param:' + name };
+        if (PARAM_RE[name] && !PARAM_RE[name].test(String(v))) return { ok: false, error: 'invalid_param:' + name };
+    }
+    return { ok: true };
+}
+
+/** Build the web URL (path + query/hash) for a target. Throws on invalid input. */
+function buildWebUrl(target, params) {
+    const check = validateParams(target, params);
+    if (!check.ok) throw new Error('buildWebUrl: ' + check.error);
+    let url = ROUTES[target].web;
+    for (const name of ROUTES[target].params) {
+        url = url.split('{' + name + '}').join(encodeURIComponent(String(params[name])));
+    }
+    return url;
+}
+
+/**
+ * Build the universal /r/ entry URL (spec §3). Unsigned form — the caller
+ * (redirect-router's mint endpoint) appends sig/exp for sensitive targets.
+ */
+function buildUniversalUrl(target, params, traceId) {
+    const check = validateParams(target, params);
+    if (!check.ok) throw new Error('buildUniversalUrl: ' + check.error);
+    const qs = new URLSearchParams();
+    for (const name of ROUTES[target].params) qs.set(name, String(params[name]));
+    if (traceId) qs.set('traceId', traceId);
+    const q = qs.toString();
+    return '/r/' + encodeURIComponent(target) + (q ? '?' + q : '');
+}
+
+/**
+ * Validate a return_to value against the registry (spec §4): must be a
+ * same-origin relative URL whose path is either a registered web path or
+ * the /r/ entry. Never an open redirect.
+ */
+function isSafeReturnTo(value) {
+    if (typeof value !== 'string' || !value.startsWith('/')) return false;
+    if (value.startsWith('//')) return false; // protocol-relative escape
+    const path = value.split(/[?#]/)[0];
+    if (path === '/r' || path.startsWith('/r/')) return true;
+    return Object.values(ROUTES).some(r => r.web.split(/[?#]/)[0] === path);
+}
+
+module.exports = {
+    ROUTES,
+    isKnownTarget,
+    validateParams,
+    buildWebUrl,
+    buildUniversalUrl,
+    isSafeReturnTo,
+};

--- a/backend/tests/jest/portal-auth-race.test.js
+++ b/backend/tests/jest/portal-auth-race.test.js
@@ -76,9 +76,11 @@ describe('apiCall 401 behavior', () => {
         loadApiJs(sandbox);
 
         await expect(sandbox.apiCall('GET', '/api/auth/me')).rejects.toThrow(/Not authenticated/);
-        // Pain-4 contract (OODA-R Phase 2 #6): redirect now carries the
-        // machine-readable reason so index.html can explain the kick.
-        expect(hrefSetter).toHaveBeenCalledWith('index.html?authReason=no_token');
+        // Pain-4 contract (OODA-R Phase 2 #6): redirect carries the
+        // machine-readable reason; Phase 2 #7 adds return_to so login can
+        // round-trip back to the interrupted page (redirect spec §4).
+        expect(hrefSetter).toHaveBeenCalledWith(
+            'index.html?authReason=no_token&return_to=' + encodeURIComponent('/portal/dashboard.html'));
     });
 
     test('401 with skip401Redirect=true does NOT navigate', async () => {

--- a/backend/tests/jest/redirect-router.test.js
+++ b/backend/tests/jest/redirect-router.test.js
@@ -1,0 +1,183 @@
+/**
+ * Redirect state machine Phase A — card_14571f26914b9c1eae148362.
+ * Spec: docs/redirect-state-machine-spec.md (APPROVED, #6 review folded).
+ * Covers: route registry shapes/validation, HMAC sig roundtrip, /r/ entry
+ * states, server-side mint auth, telemetry beacon validation, return_to guard.
+ */
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+
+const registry = require('../../shared/route-registry');
+const redirect = require('../../redirect-router');
+
+const DEVICE = 'dev-redirect-test';
+const DEVICES = {
+    [DEVICE]: {
+        deviceSecret: 'ds-secret',
+        entities: { 2: { isBound: true, botSecret: 'bs-secret' } },
+    },
+};
+
+function makeApp() {
+    redirect.init({ chatPool: null, devices: DEVICES, jwtSecret: 'test-signing-secret' });
+    const app = express();
+    app.use(redirect.router);
+    return app;
+}
+
+describe('route registry — URL shapes match current consumers (#6 amendment 1)', () => {
+    test('card → kanban ?card=<id>#<id>', () => {
+        expect(registry.buildWebUrl('card', { cardId: 'card_abc123def456' }))
+            .toBe('/portal/kanban.html?card=card_abc123def456#card_abc123def456');
+    });
+    test('chat → ?contact=<publicCode>', () => {
+        expect(registry.buildWebUrl('chat', { publicCode: '3xa3h4' }))
+            .toBe('/portal/chat.html?contact=3xa3h4');
+    });
+    test('note → mission ?note=', () => {
+        expect(registry.buildWebUrl('note', { noteId: 'n-42' }))
+            .toBe('/portal/mission.html?note=n-42');
+    });
+    test('profile → /p/:publicCode (not /portal/bot/)', () => {
+        expect(registry.buildWebUrl('profile', { publicCode: 'tbwb9e' })).toBe('/p/tbwb9e');
+    });
+    test('param regexes reject malformed input', () => {
+        expect(registry.validateParams('card', { cardId: 'not-a-card' }).ok).toBe(false);
+        expect(registry.validateParams('chat', { publicCode: 'UPPER!' }).ok).toBe(false);
+        expect(registry.validateParams('card', {}).ok).toBe(false);
+        expect(registry.validateParams('nope', {}).error).toBe('unknown_target');
+    });
+    test('sensitive flags: card/note signed, chat/profile public (approved open-point 3)', () => {
+        expect(registry.ROUTES.card.sensitive).toBe(true);
+        expect(registry.ROUTES.note.sensitive).toBe(true);
+        expect(registry.ROUTES.chat.sensitive).toBe(false);
+        expect(registry.ROUTES.profile.sensitive).toBe(false);
+    });
+});
+
+describe('route registry — isSafeReturnTo (no open redirect)', () => {
+    test.each([
+        ['/portal/chat.html?contact=abc123', true],
+        ['/r/card?cardId=card_abc123def456', true],
+        ['/portal/dashboard.html', true],
+        ['https://evil.example/portal/chat.html', false],
+        ['//evil.example/phish', false],
+        ['/portal/unknown-page.html', false],
+        ['javascript:alert(1)', false],
+    ])('%s → %s', (value, ok) => {
+        expect(registry.isSafeReturnTo(value)).toBe(ok);
+    });
+});
+
+describe('sig — HMAC roundtrip', () => {
+    beforeAll(() => redirect.init({ chatPool: null, devices: DEVICES, jwtSecret: 'test-signing-secret' }));
+    const { computeSig, verifySig } = redirect._internal;
+    const params = { cardId: 'card_abc123def456' };
+
+    test('valid sig within exp verifies', () => {
+        const exp = Math.floor(Date.now() / 1000) + 60;
+        expect(verifySig('card', params, exp, computeSig('card', params, exp))).toBe(true);
+    });
+    test('expired sig rejected', () => {
+        const exp = Math.floor(Date.now() / 1000) - 1;
+        expect(verifySig('card', params, exp, computeSig('card', params, exp))).toBe(false);
+    });
+    test('tampered param rejected', () => {
+        const exp = Math.floor(Date.now() / 1000) + 60;
+        const sig = computeSig('card', params, exp);
+        expect(verifySig('card', { cardId: 'card_fff000fff000' }, exp, sig)).toBe(false);
+    });
+});
+
+describe('GET /r/:target', () => {
+    let app;
+    beforeEach(() => { app = makeApp(); });
+
+    test('public target 302s to the registry web URL with traceId appended', async () => {
+        const res = await request(app).get('/r/chat?publicCode=3xa3h4');
+        expect(res.status).toBe(302);
+        expect(res.headers.location).toMatch(/^\/portal\/chat\.html\?contact=3xa3h4&traceId=rt_[a-f0-9]{12}$/);
+    });
+    test('traceId lands BEFORE the hash for card targets', async () => {
+        const exp = Math.floor(Date.now() / 1000) + 60;
+        const sig = redirect._internal.computeSig('card', { cardId: 'card_abc123def456' }, exp);
+        const res = await request(app).get(`/r/card?cardId=card_abc123def456&exp=${exp}&sig=${sig}`);
+        expect(res.status).toBe(302);
+        expect(res.headers.location).toMatch(/^\/portal\/kanban\.html\?card=card_abc123def456&traceId=rt_[a-f0-9]{12}#card_abc123def456$/);
+    });
+    test('sensitive target without sig → dashboard with redirectError (never dead-ends)', async () => {
+        const res = await request(app).get('/r/card?cardId=card_abc123def456');
+        expect(res.status).toBe(302);
+        expect(res.headers.location).toBe('/portal/dashboard.html?redirectError=expired');
+    });
+    test('unknown target → dashboard with redirectError=unknown', async () => {
+        const res = await request(app).get('/r/etcpasswd');
+        expect(res.status).toBe(302);
+        expect(res.headers.location).toBe('/portal/dashboard.html?redirectError=unknown');
+    });
+    test('malformed param → redirectError=invalid', async () => {
+        const res = await request(app).get('/r/chat?publicCode=NOPE');
+        expect(res.status).toBe(302);
+        expect(res.headers.location).toBe('/portal/dashboard.html?redirectError=invalid');
+    });
+});
+
+describe('POST /api/redirect/mint', () => {
+    let app;
+    beforeEach(() => { app = makeApp(); });
+
+    test('403 without credentials', async () => {
+        const res = await request(app).post('/api/redirect/mint')
+            .send({ target: 'card', params: { cardId: 'card_abc123def456' } });
+        expect(res.status).toBe(403);
+    });
+    test('mints signed URL for sensitive target with botSecret auth', async () => {
+        const res = await request(app).post('/api/redirect/mint')
+            .send({ deviceId: DEVICE, botSecret: 'bs-secret', entityId: 2,
+                target: 'card', params: { cardId: 'card_abc123def456' } });
+        expect(res.status).toBe(200);
+        expect(res.body.url).toMatch(/^\/r\/card\?cardId=card_abc123def456&traceId=rt_[a-f0-9]{12}&exp=\d+&sig=[a-f0-9]{32}$/);
+    });
+    test('minted URL round-trips through /r/ to the kanban deep link', async () => {
+        const mint = await request(app).post('/api/redirect/mint')
+            .send({ deviceId: DEVICE, deviceSecret: 'ds-secret',
+                target: 'card', params: { cardId: 'card_abc123def456' } });
+        const res = await request(app).get(mint.body.url);
+        expect(res.status).toBe(302);
+        expect(res.headers.location).toContain('/portal/kanban.html?card=card_abc123def456');
+    });
+    test('public target mints unsigned URL', async () => {
+        const res = await request(app).post('/api/redirect/mint')
+            .send({ deviceId: DEVICE, deviceSecret: 'ds-secret',
+                target: 'profile', params: { publicCode: 'tbwb9e' } });
+        expect(res.body.url).toMatch(/^\/r\/profile\?publicCode=tbwb9e&traceId=rt_[a-f0-9]{12}$/);
+    });
+    test('400 on unknown target / bad params', async () => {
+        const res = await request(app).post('/api/redirect/mint')
+            .send({ deviceId: DEVICE, deviceSecret: 'ds-secret', target: 'card', params: { cardId: 'bad' } });
+        expect(res.status).toBe(400);
+    });
+});
+
+describe('POST /api/redirect/telemetry', () => {
+    let app;
+    beforeEach(() => { app = makeApp(); });
+
+    test('accepts a valid TARGET_RENDERED beacon', async () => {
+        const res = await request(app).post('/api/redirect/telemetry')
+            .send({ traceId: 'rt_0123456789ab', state: 'TARGET_RENDERED', target: 'chat' });
+        expect(res.status).toBe(200);
+    });
+    test('rejects bad traceId / unknown state / unknown target', async () => {
+        for (const body of [
+            { traceId: 'nope', state: 'TARGET_RENDERED', target: 'chat' },
+            { traceId: 'rt_0123456789ab', state: 'HACK', target: 'chat' },
+            { traceId: 'rt_0123456789ab', state: 'TARGET_RENDERED', target: 'nope' },
+        ]) {
+            const res = await request(app).post('/api/redirect/telemetry').send(body);
+            expect(res.status).toBe(400);
+        }
+    });
+});


### PR DESCRIPTION
Implements the web slice of `docs/redirect-state-machine-spec.md` (APPROVED by #6 with 3 amendments, all folded):

- **`backend/shared/route-registry.js`** — single SoT for 6 targets with consumer-exact URL shapes (kanban `?card=<id>#<id>`, chat `?contact=`, mission `?note=`, `/p/:publicCode`), per-param regex validation, `isSafeReturnTo`.
- **`backend/redirect-router.js`** — `GET /r/:target`: traceId minting, HMAC sig check for sensitive targets (card/note), platform detect, `redirect_events` logging, 302 to web (straight-to-web per approved open-point 1; the 400 ms app-attempt activates with Phase B App Links). Failure paths always land on dashboard with `?redirectError=` — never a dead end. `POST /api/redirect/mint` (botSecret/deviceSecret-authed, server-only signing per #6 amendment 2), `POST /api/redirect/telemetry` beacon (validated traceId/state/target), `GET /api/redirect/stats` (success rate per target/platform). 30-day retention purge (approved open-point 2).
- **return_to round-trip** — api.js 401 bounce carries the interrupted destination; index.html honors it post-login behind an allowlist regex mirroring `isSafeReturnTo` (open-redirect-proof: rejects `//`, absolute URLs, unknown paths).

## Tests
28 new jest (registry shapes incl. all #6 amendment assertions, HMAC roundtrip/expiry/tamper, /r/ 302 matrix incl. traceId-before-hash, mint auth 403/400/200 + mint→/r/ roundtrip, telemetry validation, isSafeReturnTo table) + auth-race contract updated. **Full suite 275 suites / 3851 green, merge gated on jest exit.**

Post-deploy prod E2E: /r/ 302 matrix via curl + browser return_to round-trip + stats endpoint, before card close. Phase B (Android manifest/assetlinks) and C (AASA) are separate cards per spec §7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)