### PR TITLE
fix(chat): greet banner white-on-dark — phantom CSS variables (card_079ea943)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -297,7 +297,11 @@
         /* ── 情緒價值 #1: greeting banner (card_f8167ec5) ── */
         .greet-banner {
             margin: 8px 14px 4px; padding: 10px 14px; border-radius: 14px;
-            background: var(--bg-card, #f4f6fb); border: 1px solid var(--border-color, #dfe3ec);
+            /* real theme tokens only — the originals referenced two variables
+               that exist nowhere in style.css, so their light fallbacks painted
+               a white box on the dark portal (Hank 06/12 08:25, card_079ea943) */
+            background: var(--card, #1A1A2E); border: 1px solid var(--card-border, #333355);
+            color: var(--text, #ffffff);
             font-size: 14px; line-height: 1.5; display: flex; flex-direction: column; gap: 8px;
         }
         body.dark .greet-banner { background: #23262f; border-color: #3a3f4d; }
@@ -309,7 +313,7 @@
             font-size: 13px; cursor: pointer; min-height: 32px;
         }
         .greet-chip:hover { background: rgba(91,108,255,0.1); }
-        .greet-chip.greet-chip-dismiss { border-color: var(--border-color, #c8cdd9); color: var(--text-secondary, #8a8f9c); }
+        .greet-chip.greet-chip-dismiss { border-color: var(--card-border, #333355); color: var(--text-secondary, #AAAAAA); }
         body.density-comfortable .chat-msg { max-width: 75%; }
         body.density-comfortable .chat-source { font-size: 12px; margin-bottom: 4px; }
 

--- a/backend/tests/jest/chat-greeting.test.js
+++ b/backend/tests/jest/chat-greeting.test.js
@@ -1,0 +1,21 @@
+
+describe('greet banner — theme-token regression guard (card_079ea943)', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(path.join(__dirname, '..', '..', 'public', 'portal', 'chat.html'), 'utf8');
+    const tokens = fs.readFileSync(path.join(__dirname, '..', '..', 'public', 'portal', 'shared', 'style.css'), 'utf8');
+
+    test('banner uses REAL tokens (--card/--card-border/--text), not phantom --bg-card', () => {
+        const block = src.slice(src.indexOf('.greet-banner {'), src.indexOf('.greet-banner-text'));
+        expect(block).toMatch(/background: var\(--card, #1A1A2E\)/);
+        expect(block).toMatch(/color: var\(--text, #ffffff\)/);
+        expect(block).not.toMatch(/--bg-card/);
+    });
+    test('every var() token referenced by the greet block is defined in style.css :root', () => {
+        const block = src.slice(src.indexOf('.greet-banner {'), src.indexOf('.density-switcher'));
+        const used = [...new Set([...block.matchAll(/var\((--[a-z-]+)/g)].map(m => m[1]))];
+        for (const t of used) {
+            expect(tokens).toMatch(new RegExp(t.replace(/[-]/g, '\\-') + '\\s*:'));
+        }
+    });
+});


### PR DESCRIPTION
Hank's 08:25 screenshot shows the returning-user greeting banner as a white box with unreadable text on the dark portal. Root cause: the banner CSS referenced `--bg-card`/`--border-color` — neither exists in style.css — so the LIGHT fallbacks painted white on dark; the `body.dark` override is dead code (the portal is dark via :root tokens, no body class).

Fix: real tokens `--card`/`--card-border` + explicit `color: var(--text)`; dismiss-chip border/color same treatment.

**Same-class sweep (per Hank's 找出類似問題):** grepped every `var(--*, <light fallback>)` across portal pages + tonight's components (lvlup, firstach, utl, kb-toast, side chips, achievements rows) — all other hits either use tokens that exist (fallback dead) or are light *text* fallbacks on dark (correct color either way). This banner was the only background-class instance. New regression test asserts every token used by the greet block is defined in :root, so a future phantom token fails CI.

Suite 276/3853 green (merge gated on jest exit). Post-deploy prod screenshot to card before close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)