### PR TITLE
feat(audit): weekly compliance + multi-tenant audit system

### DIFF
--- a/backend/agent-improvement/audit-rules.js
+++ b/backend/agent-improvement/audit-rules.js
@@ -1,0 +1,222 @@
+// Weekly platform-compliance + multi-tenant audit rules.
+// Card: card_923709f59ecb0c1cd66bc786
+//
+// Two dimensions, per Hank 2026-06-07 20:32 TW:
+//   A. 用戶平台規範遵循 — feedback_platform_user_rule_compliance: every
+//      repo/feature/script/template/doc must work for ALL worldwide users;
+//      no single-tenant designs, no carveouts.
+//   B. 多用戶 / 多實體角度 — features must reason about N>1 users per
+//      device and N>1 entities per user (the test device has 2 entities but
+//      production accounts vary; UI / API / DB queries that assume N=1 leak).
+//
+// Each rule is a pure JSON object so the auditor walks them deterministically.
+// New rules: add to the array; bump `id` (kebab-case slug, unique).
+
+'use strict';
+
+/**
+ * @typedef {Object} AuditRule
+ * @property {string} id                kebab-case unique slug
+ * @property {('compliance'|'multi_tenant')} dimension
+ * @property {('P0'|'P1'|'P2'|'P3')} severity
+ * @property {string} title             one-liner
+ * @property {string} rationale         why this is a violation
+ * @property {RegExp} pattern           matches the offending text
+ * @property {(filePath: string, match: string) => boolean} [filePathFilter]
+ *           optional: skip files that don't match. Returns true to KEEP.
+ * @property {string[]} [allowFiles]    substrings — file paths containing any
+ *                                       of these are ALWAYS exempt (tests, etc.)
+ */
+
+const TEST_PATH_HINTS = Object.freeze([
+    '/tests/', '/test/', '__tests__', '.test.js', '.spec.js',
+    '/fixtures/', '/migrations/', // migrations may legitimately reference example IDs
+]);
+const HANK_HEX_DEVICE = '480def4c-2183-4d8e-afd0-b131ae89adcc';
+const HANK_HEX_REGEX = new RegExp(HANK_HEX_DEVICE, 'g');
+
+/** @type {AuditRule[]} */
+const RULES = [
+    // ── Dimension A: platform compliance ───────────────────────────────
+    {
+        id: 'hardcoded-hank-device-id',
+        dimension: 'compliance',
+        severity: 'P0',
+        title: 'Hank\'s deviceId UUID hardcoded in source',
+        rationale: 'EClawbot must work for any user. Hardcoding the test device UUID into shipped code makes the feature single-tenant.',
+        pattern: HANK_HEX_REGEX,
+        allowFiles: TEST_PATH_HINTS.slice(),
+    },
+    {
+        id: 'hardcoded-users-hank-path',
+        dimension: 'compliance',
+        severity: 'P1',
+        title: 'Absolute path under /Users/hank/ in shipped code',
+        rationale: 'Paths under one developer\'s home directory will not resolve on production or another contributor\'s laptop.',
+        pattern: /\/Users\/hank\//,
+        allowFiles: ['/scripts/dev', '/.local/', '/docs/'],
+    },
+    {
+        id: 'hardcoded-entity-id-comparison',
+        dimension: 'compliance',
+        severity: 'P1',
+        title: 'Equality check against hardcoded entityId 1-5',
+        rationale: 'EClawbot entity slots are user-configurable. `entityId === 2` (etc.) outside a routing seam single-tenants the feature.',
+        pattern: /\bentityId\s*===\s*[1-5]\b/,
+        allowFiles: TEST_PATH_HINTS.concat(['/agent-improvement/', '/eclaw-bridge/']),
+    },
+    {
+        id: 'hardcoded-public-code-literal',
+        dimension: 'compliance',
+        severity: 'P2',
+        title: '6-char publicCode literal hardcoded',
+        rationale: 'publicCodes are assigned per user; literals like `tbwb9e` or `3xa3h4` in shipped code identify specific user bots.',
+        // EXACTLY 6 lowercase a-z/0-9 between quote delimiters, requiring BOTH a
+        // letter and a digit — that is the publicCode shape (e.g. tbwb9e, 3xa3h4).
+        // Lookaheads keep us from false-firing on '401', '256kb', plain words, or
+        // long hashes (the earlier `[a-z0-9]*\d[a-z0-9]*` matched all of those).
+        pattern: /['"`](?=[a-z0-9]{6}['"`])(?=[a-z0-9]*[a-z])(?=[a-z0-9]*\d)[a-z0-9]{6}['"`]/,
+        filePathFilter: (p) => /\.(js|ts)$/.test(p) && !/\.test\./.test(p),
+        allowFiles: TEST_PATH_HINTS.concat(['/migrations/', '/api-docs', 'api_refs']),
+    },
+    {
+        id: 'hank-specific-conditional',
+        dimension: 'compliance',
+        severity: 'P0',
+        title: 'Conditional gated on Hank\'s specific deviceId or email',
+        rationale: 'Features that fork on `if (deviceId === HANK_*)` are explicitly single-tenant.',
+        pattern: /if\s*\(\s*deviceId\s*===?\s*['"`][a-f0-9-]{8,}/,
+        allowFiles: TEST_PATH_HINTS.slice(),
+    },
+    {
+        id: 'migration-without-if-not-exists',
+        dimension: 'compliance',
+        severity: 'P2',
+        title: 'Migration ADD COLUMN without IF NOT EXISTS',
+        rationale: 'Re-running a migration on a fresh prod database should be safe. ADD COLUMN without IF NOT EXISTS crashes on replay.',
+        pattern: /ALTER\s+TABLE\s+\w+\s+ADD\s+COLUMN\s+(?!IF\s+NOT\s+EXISTS)/i,
+        filePathFilter: (p) => p.endsWith('.up.sql'),
+    },
+    {
+        id: 'zh-only-string-no-i18n-key',
+        dimension: 'compliance',
+        severity: 'P3',
+        title: 'Chinese-only literal in alert() / confirm() / throw',
+        rationale: 'Worldwide-user platform: every user-visible string must be either i18n-keyed or English. zh-only strings in alerts strand non-CJK users.',
+        pattern: /(alert|confirm|throw\s+new\s+Error)\s*\(\s*['"`][一-鿿]/,
+        filePathFilter: (p) => /\.(js|html)$/.test(p),
+        allowFiles: TEST_PATH_HINTS.concat(['/i18n', '/docs/', 'memory/']),
+    },
+
+    // ── Dimension B: multi-tenant perspective ──────────────────────────
+    {
+        id: 'db-query-missing-entity-id-filter',
+        dimension: 'multi_tenant',
+        severity: 'P2',
+        title: 'DB SELECT/UPDATE on entity-scoped table missing entity_id filter',
+        rationale: 'Tables with entity_id columns (counters, episodes, drawer state) need WHERE filters on both device_id AND entity_id; otherwise rows from one entity leak into another\'s view.',
+        pattern: /WHERE\s+device_id\s*=\s*\$\d+\s*$/im,
+        filePathFilter: (p) => /\.(js|sql)$/.test(p),
+        allowFiles: TEST_PATH_HINTS.concat(['/devices', '/auth', '/migrations/']),
+    },
+    {
+        id: 'broadcast-without-recipient-list',
+        dimension: 'multi_tenant',
+        severity: 'P1',
+        title: 'speakTo:[] without senderHint or explicit broadcast flag',
+        rationale: 'Empty speakTo arrays + missing broadcast flag silently fan out to all entities on the device. PR #2960 / U64 incident.',
+        pattern: /speakTo:\s*\[\s*\]/,
+        filePathFilter: (p) => /\.(js)$/.test(p) && !/\.test\./.test(p),
+        allowFiles: TEST_PATH_HINTS.slice(),
+    },
+    {
+        id: 'cron-once-per-device-assumption',
+        dimension: 'multi_tenant',
+        severity: 'P2',
+        title: 'Cron job iterates devices via SELECT DISTINCT but does not iterate entities',
+        rationale: 'A cron that runs once per device but skips per-entity work treats N=2 entities as a single agent. Counter/episode/drawer crons must iterate entities.',
+        pattern: /SELECT\s+DISTINCT\s+device_id\s+FROM/i,
+        filePathFilter: (p) => /(cron|sweeper|background)/.test(p),
+    },
+    {
+        id: 'ui-assumes-two-bot-slots',
+        dimension: 'multi_tenant',
+        severity: 'P2',
+        title: 'UI hardcodes 2 / 5 bot slots',
+        rationale: 'Test device has 2 slots, prod accounts have up to 5. Loops with `i < 2` / array literals `[#1, #2]` strand bot 3-5.',
+        pattern: /for\s*\(\s*(?:let|const|var)?\s*\w+\s*=\s*[01]\s*;\s*\w+\s*<\s*[25]\s*;.*botSlots?/,
+        filePathFilter: (p) => /\.(js|html)$/.test(p),
+        allowFiles: TEST_PATH_HINTS.slice(),
+    },
+    {
+        id: 'counter-increment-not-per-entity',
+        dimension: 'multi_tenant',
+        severity: 'P1',
+        title: 'incrementCounter / addCounter call without entityId argument',
+        rationale: 'Per-entity counters (no_reply axes, error counters) need entityId; calls without it bucket into entity_id=0 and the dashboard collapses entities into one row.',
+        pattern: /incrementCounter\s*\(\s*[a-zA-Z_$][^,)]*\)/,
+        filePathFilter: (p) => /\.(js)$/.test(p) && !/\.test\./.test(p),
+        allowFiles: TEST_PATH_HINTS.slice(),
+    },
+];
+
+const DIMENSIONS = Object.freeze(['compliance', 'multi_tenant']);
+const SEVERITIES = Object.freeze(['P0', 'P1', 'P2', 'P3']);
+
+function isFileExempt(filePath, rule) {
+    if (!filePath) return false;
+    // Normalize a leading slash so `/tests/` style hints match repo-relative
+    // paths that START with `tests/` (the runner emits paths without a leading
+    // slash). Without this, `tests/foo.js` slips past every `/tests/` hint.
+    const norm = filePath.startsWith('/') ? filePath : '/' + filePath;
+    const allow = rule.allowFiles || [];
+    for (const hint of allow) {
+        if (norm.includes(hint)) return true;
+    }
+    if (typeof rule.filePathFilter === 'function') {
+        if (!rule.filePathFilter(filePath, '')) return true;
+    }
+    return false;
+}
+
+/**
+ * Scan one chunk of text against all rules; returns flat findings list.
+ * @param {string} filePath
+ * @param {string} text
+ * @returns {{ruleId:string, dimension:string, severity:string, title:string, rationale:string, lineNo:number, excerpt:string}[]}
+ */
+function scanText(filePath, text) {
+    if (typeof text !== 'string' || text.length === 0) return [];
+    const lines = text.split('\n');
+    const findings = [];
+    for (const rule of RULES) {
+        if (isFileExempt(filePath, rule)) continue;
+        const re = new RegExp(rule.pattern.source, rule.pattern.flags.includes('g') ? rule.pattern.flags : rule.pattern.flags + 'g');
+        for (let lineNo = 0; lineNo < lines.length; lineNo++) {
+            const line = lines[lineNo];
+            re.lastIndex = 0;
+            const m = re.exec(line);
+            if (m) {
+                findings.push({
+                    ruleId: rule.id,
+                    dimension: rule.dimension,
+                    severity: rule.severity,
+                    title: rule.title,
+                    rationale: rule.rationale,
+                    filePath,
+                    lineNo: lineNo + 1,
+                    excerpt: line.trim().slice(0, 160),
+                });
+            }
+        }
+    }
+    return findings;
+}
+
+module.exports = {
+    RULES,
+    DIMENSIONS,
+    SEVERITIES,
+    isFileExempt,
+    scanText,
+};

--- a/backend/agent-improvement/audit-run.js
+++ b/backend/agent-improvement/audit-run.js
@@ -1,0 +1,111 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Weekly compliance + multi-tenant audit runner.
+ * Card: card_923709f59ecb0c1cd66bc786 (Hank 2026-06-07 20:32 TW).
+ *
+ * Walks the shipped source tree, applies the pure-data rules in
+ * audit-rules.js, and emits findings grouped by (ruleId, file). Designed to
+ * run from the weekly cron card (`0 9 * * 1` Asia/Taipei): the cron dispatch
+ * runs `node audit-run.js --json`, then files one kanban subcard per distinct
+ * (ruleId) group at the rule's severity.
+ *
+ * Globe-user safe (per feedback_platform_user_rule_compliance): no hardcoded
+ * device/owner — it audits the repo, takes the repo root as argv or cwd.
+ *
+ * Usage:
+ *   node audit-run.js                 # human summary to stdout
+ *   node audit-run.js --json          # machine JSON ({findings, groups, stats})
+ *   node audit-run.js --root <dir>    # override scan root (default: repo backend/)
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { scanText, RULES } = require('./audit-rules');
+
+// Directories we never walk — vendored code, build output, the audit's own
+// rule definitions (which contain the offending patterns as data), and VCS.
+const SKIP_DIRS = new Set([
+    'node_modules', '.git', 'dist', 'build', 'coverage', '.next',
+    'vendor', 'assets', '.worktrees', 'tmp',
+]);
+// The rules file legitimately contains every pattern as data; auditing it
+// produces only self-references. Same for the runner and its tests.
+const SELF_FILES = new Set(['audit-rules.js', 'audit-run.js', 'audit-rules.test.js']);
+const SCAN_EXT = new Set(['.js', '.ts', '.html', '.sql']);
+const MAX_FILE_BYTES = 2 * 1024 * 1024; // skip giant generated bundles (i18n.js etc.)
+
+function* walk(dir) {
+    let entries;
+    try { entries = fs.readdirSync(dir, { withFileTypes: true }); }
+    catch { return; }
+    for (const e of entries) {
+        if (e.name.startsWith('.') && e.name !== '.') continue;
+        const full = path.join(dir, e.name);
+        if (e.isDirectory()) {
+            if (SKIP_DIRS.has(e.name)) continue;
+            yield* walk(full);
+        } else if (e.isFile()) {
+            if (SELF_FILES.has(e.name)) continue;
+            if (!SCAN_EXT.has(path.extname(e.name))) continue;
+            yield full;
+        }
+    }
+}
+
+function runAudit(root) {
+    const findings = [];
+    let filesScanned = 0;
+    for (const file of walk(root)) {
+        let stat;
+        try { stat = fs.statSync(file); } catch { continue; }
+        if (stat.size > MAX_FILE_BYTES) continue;
+        let text;
+        try { text = fs.readFileSync(file, 'utf8'); } catch { continue; }
+        filesScanned++;
+        // Use a repo-relative path so findings are portable / not owner-specific.
+        const rel = path.relative(root, file);
+        for (const f of scanText(rel, text)) findings.push(f);
+    }
+    // Group by ruleId so the cron files one subcard per rule class, not per line.
+    const groups = {};
+    for (const f of findings) {
+        (groups[f.ruleId] ||= {
+            ruleId: f.ruleId, dimension: f.dimension, severity: f.severity,
+            title: f.title, rationale: f.rationale, hits: [],
+        }).hits.push({ filePath: f.filePath, lineNo: f.lineNo, excerpt: f.excerpt });
+    }
+    const groupList = Object.values(groups).sort((a, b) =>
+        ['P0', 'P1', 'P2', 'P3'].indexOf(a.severity) - ['P0', 'P1', 'P2', 'P3'].indexOf(b.severity));
+    return {
+        stats: { filesScanned, findings: findings.length, ruleGroups: groupList.length, rulesTotal: RULES.length },
+        groups: groupList,
+        findings,
+    };
+}
+
+function main() {
+    const argv = process.argv.slice(2);
+    const rootIdx = argv.indexOf('--root');
+    const root = rootIdx !== -1 ? argv[rootIdx + 1]
+        : path.resolve(__dirname, '..'); // default: backend/
+    const result = runAudit(root);
+    if (argv.includes('--json')) {
+        process.stdout.write(JSON.stringify(result, null, 2) + '\n');
+        return;
+    }
+    const { stats, groups } = result;
+    console.log(`Audit: ${stats.filesScanned} files, ${stats.findings} findings across ${stats.ruleGroups}/${stats.rulesTotal} rules\n`);
+    for (const g of groups) {
+        console.log(`[${g.severity}] ${g.dimension} :: ${g.ruleId} — ${g.hits.length} hit(s)`);
+        console.log(`   ${g.title}`);
+        for (const h of g.hits.slice(0, 5)) console.log(`     ${h.filePath}:${h.lineNo}  ${h.excerpt}`);
+        if (g.hits.length > 5) console.log(`     … and ${g.hits.length - 5} more`);
+        console.log('');
+    }
+}
+
+if (require.main === module) main();
+
+module.exports = { runAudit, walk };

--- a/backend/tests/jest/audit-rules.test.js
+++ b/backend/tests/jest/audit-rules.test.js
@@ -1,0 +1,98 @@
+'use strict';
+
+/**
+ * Rule-matcher determinism tests for the weekly compliance + multi-tenant
+ * audit. Card: card_923709f59ecb0c1cd66bc786 (Hank 2026-06-07 20:32 TW).
+ *
+ * Each case feeds a deterministic text snippet to scanText() and asserts the
+ * exact finding shape (ruleId / dimension / severity / lineNo). This is the
+ * contract the weekly runner depends on; a regex regression that widens or
+ * narrows a rule will flip one of these.
+ */
+
+const audit = require('../../agent-improvement/audit-rules');
+
+describe('audit-rules — rule catalog shape', () => {
+    test('every rule has the required pure-data fields + unique id', () => {
+        const ids = new Set();
+        for (const r of audit.RULES) {
+            expect(typeof r.id).toBe('string');
+            expect(r.id).toMatch(/^[a-z0-9-]+$/);
+            expect(ids.has(r.id)).toBe(false);
+            ids.add(r.id);
+            expect(audit.DIMENSIONS).toContain(r.dimension);
+            expect(audit.SEVERITIES).toContain(r.severity);
+            expect(r.pattern).toBeInstanceOf(RegExp);
+            expect(typeof r.title).toBe('string');
+            expect(typeof r.rationale).toBe('string');
+        }
+    });
+});
+
+describe('audit-rules — scanText matcher (deterministic input → finding shape)', () => {
+    test('hardcoded Hank device UUID flagged P0 compliance with correct line', () => {
+        const text = [
+            'const x = 1;',
+            "const dev = '480def4c-2183-4d8e-afd0-b131ae89adcc';",
+        ].join('\n');
+        const f = audit.scanText('backend/foo.js', text);
+        const hit = f.find(r => r.ruleId === 'hardcoded-hank-device-id');
+        expect(hit).toBeTruthy();
+        expect(hit.dimension).toBe('compliance');
+        expect(hit.severity).toBe('P0');
+        expect(hit.lineNo).toBe(2);
+        expect(hit.filePath).toBe('backend/foo.js');
+    });
+
+    test('/Users/hank/ absolute path flagged P1', () => {
+        const f = audit.scanText('backend/svc.js', "require('/Users/hank/secret.js');");
+        expect(f.some(r => r.ruleId === 'hardcoded-users-hank-path' && r.severity === 'P1')).toBe(true);
+    });
+
+    test('entityId === N equality flagged in normal source', () => {
+        const f = audit.scanText('backend/handler.js', 'if (entityId === 2) { doThing(); }');
+        expect(f.some(r => r.ruleId === 'hardcoded-entity-id-comparison')).toBe(true);
+    });
+
+    test('migration ADD COLUMN without IF NOT EXISTS flagged only in .up.sql', () => {
+        const sql = 'ALTER TABLE bots ADD COLUMN nickname TEXT;';
+        expect(audit.scanText('m/20260101_x.up.sql', sql)
+            .some(r => r.ruleId === 'migration-without-if-not-exists')).toBe(true);
+        // filePathFilter restricts to .up.sql — a .js file with the same text is exempt
+        expect(audit.scanText('backend/notsql.js', sql)
+            .some(r => r.ruleId === 'migration-without-if-not-exists')).toBe(false);
+    });
+
+    test('empty speakTo:[] flagged P1 multi_tenant', () => {
+        const f = audit.scanText('backend/route.js', 'send({ speakTo: [] , message });');
+        const hit = f.find(r => r.ruleId === 'broadcast-without-recipient-list');
+        expect(hit).toBeTruthy();
+        expect(hit.dimension).toBe('multi_tenant');
+        expect(hit.severity).toBe('P1');
+    });
+
+    test('IF NOT EXISTS migration is NOT flagged (no false positive)', () => {
+        const sql = 'ALTER TABLE bots ADD COLUMN IF NOT EXISTS nickname TEXT;';
+        expect(audit.scanText('m/20260101_x.up.sql', sql)
+            .some(r => r.ruleId === 'migration-without-if-not-exists')).toBe(false);
+    });
+});
+
+describe('audit-rules — file exemptions', () => {
+    test('test paths exempt the Hank-UUID rule', () => {
+        const text = "const d = '480def4c-2183-4d8e-afd0-b131ae89adcc';";
+        expect(audit.scanText('backend/tests/jest/foo.test.js', text)
+            .some(r => r.ruleId === 'hardcoded-hank-device-id')).toBe(false);
+    });
+
+    test('isFileExempt honors allowFiles substrings and filePathFilter', () => {
+        const ruleUuid = audit.RULES.find(r => r.id === 'hardcoded-hank-device-id');
+        expect(audit.isFileExempt('a/__tests__/b.js', ruleUuid)).toBe(true);
+        expect(audit.isFileExempt('backend/real.js', ruleUuid)).toBe(false);
+    });
+
+    test('empty / non-string text returns no findings', () => {
+        expect(audit.scanText('x.js', '')).toEqual([]);
+        expect(audit.scanText('x.js', null)).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Scope
Ships the buildable half of **card_923709f59ecb0c1cd66bc786** (Hank 2026-06-07 20:32 TW — weekly self-review for single-tenant / N=1-user / N=1-entity assumptions).

## What ships
- `backend/agent-improvement/audit-rules.js` — 12 pure-data rules × 2 dimensions (compliance, multi_tenant) + deterministic `scanText()` matcher
- `backend/agent-improvement/audit-run.js` — repo walker, groups findings by ruleId, `--json` for the weekly cron to file one subcard per rule class. Globe-user safe (no hardcoded owner; `--root` arg).
- `backend/tests/jest/audit-rules.test.js` — 10 determinism tests (input → finding shape)

## Self-noise fixes on first real run
- `hardcoded-public-code-literal`: matched any quoted token with a digit ('401','256kb') → now exactly-6 alnum requiring both a letter and a digit (491→40 hits)
- `isFileExempt`: normalize leading slash so '/tests/' hints match repo-relative paths starting 'tests/'

## First run
642 files, 100 findings across 6 rule classes — feeds dogfood subcards. Auto-fixing is out of scope (audit only opens cards).

## Test plan
- `npx jest tests/jest/audit-rules.test.js` → 10/10 pass
- `node agent-improvement/audit-run.js` → human summary; `--json` → machine output
- Full suite green (only 3 new files, no existing code touched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)