### PR TITLE
feat(redirect): Phase B — Android App Links (assetlinks + autoVerify + app /r/ handler + 400ms APP_ATTEMPT)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -51,10 +51,23 @@
 
         <activity
             android:name=".MainActivity"
-            android:exported="true">
+            android:exported="true"
+            android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <!-- Android App Links: /r/ universal entry (redirect-state-machine-spec §3).
+                 Verification requires /.well-known/assetlinks.json to list the
+                 Play App Signing certificate fingerprint. -->
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="eclawbot.com"
+                    android:pathPrefix="/r/" />
             </intent-filter>
         </activity>
 

--- a/app/src/main/java/com/hank/clawlive/MainActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/MainActivity.kt
@@ -262,9 +262,24 @@ class MainActivity : AppCompatActivity() {
         // devices[] map so dashboard.html's /api/auth/device-login can succeed.
         val deviceId = deviceManager.deviceId
         val deviceSecret = deviceManager.deviceSecret
-        val baseUrl = "https://eclawbot.com/portal/dashboard.html"
-        val url = "$baseUrl?embed=1&deviceId=$deviceId&deviceSecret=$deviceSecret"
+        // App Links (/r/ universal entry, spec §3) land here — route the
+        // WebView to the deep-link target; plain launches keep the dashboard.
+        val url = com.hank.clawlive.util.RedirectLinkParser
+            .buildPortalUrl(intent?.data, deviceId, deviceSecret)
         wv.loadUrl(com.hank.clawlive.util.PortalUrlHelper.withAppLang(this, url))
+    }
+
+    // singleTask relaunch from a verified App Link while already running.
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        val data = intent.data ?: return
+        if (!com.hank.clawlive.util.RedirectLinkParser.isRedirectLink(data)) return
+        val deviceId = deviceManager.deviceId ?: return
+        val deviceSecret = deviceManager.deviceSecret ?: return
+        val url = com.hank.clawlive.util.RedirectLinkParser
+            .buildPortalUrl(data, deviceId, deviceSecret)
+        webView?.loadUrl(com.hank.clawlive.util.PortalUrlHelper.withAppLang(this, url))
     }
 
     private fun injectCredentials(webView: WebView?) {

--- a/app/src/main/java/com/hank/clawlive/util/RedirectLinkParser.kt
+++ b/app/src/main/java/com/hank/clawlive/util/RedirectLinkParser.kt
@@ -1,0 +1,76 @@
+package com.hank.clawlive.util
+
+import android.net.Uri
+
+/**
+ * App-side mirror of backend/shared/route-registry.js for the /r/ universal
+ * entry (docs/redirect-state-machine-spec.md §2/§3, Phase B).
+ *
+ * Maps a verified App Link `https://eclawbot.com/r/<target>?…` to the portal
+ * page path the in-app WebView should load. Unknown or malformed targets fall
+ * back to the dashboard so a deep link is never a dead end (spec §3).
+ */
+object RedirectLinkParser {
+
+    private const val HOST = "eclawbot.com"
+    private const val PREFIX = "/r/"
+
+    private val PARAM_RE = mapOf(
+        "cardId" to Regex("^card_[a-zA-Z0-9]{6,32}$"),
+        "noteId" to Regex("^[a-zA-Z0-9_-]{1,64}$"),
+        "publicCode" to Regex("^[a-z0-9]{6}$"),
+    )
+    private val TRACE_RE = Regex("^rt_[a-f0-9]{12}$")
+
+    private const val DASHBOARD = "/portal/dashboard.html"
+
+    /** True when the Uri is an /r/ universal link this app should consume. */
+    fun isRedirectLink(uri: Uri?): Boolean =
+        uri != null && uri.host.equals(HOST, ignoreCase = true) &&
+            (uri.path ?: "").startsWith(PREFIX)
+
+    /**
+     * Portal path (+query/hash) for the target, or the dashboard fallback.
+     * The traceId query param is preserved so the target page's telemetry
+     * beacon reports TARGET_RENDERED under the original trace (spec §5).
+     */
+    fun toPortalPath(uri: Uri?): String {
+        if (!isRedirectLink(uri)) return DASHBOARD
+        val target = (uri!!.path ?: "").removePrefix(PREFIX).trimEnd('/')
+        val trace = uri.getQueryParameter("traceId")
+            ?.takeIf { TRACE_RE.matches(it) }
+        val path = when (target) {
+            "dashboard" -> DASHBOARD
+            "settings" -> "/portal/settings.html"
+            "chat" -> param(uri, "publicCode")?.let { "/portal/chat.html?contact=$it" }
+            "card" -> param(uri, "cardId")?.let { "/portal/kanban.html?card=$it#$it" }
+            "note" -> param(uri, "noteId")?.let { "/portal/mission.html?note=$it" }
+            "profile" -> param(uri, "publicCode")?.let { "/p/$it" }
+            else -> null
+        } ?: DASHBOARD
+        return if (trace != null) appendQuery(path, "traceId=$trace") else path
+    }
+
+    /**
+     * Full WebView URL: portal path + embed/credential params, with any hash
+     * fragment kept at the end (kanban's `#cardId` handler relies on it).
+     */
+    fun buildPortalUrl(uri: Uri?, deviceId: String, deviceSecret: String): String {
+        val path = toPortalPath(uri)
+        return "https://" + HOST + appendQuery(
+            path,
+            "embed=1&deviceId=$deviceId&deviceSecret=$deviceSecret"
+        )
+    }
+
+    private fun param(uri: Uri, name: String): String? =
+        uri.getQueryParameter(name)?.takeIf { PARAM_RE[name]?.matches(it) == true }
+
+    private fun appendQuery(path: String, query: String): String {
+        val hashIdx = path.indexOf('#')
+        val base = if (hashIdx == -1) path else path.substring(0, hashIdx)
+        val hash = if (hashIdx == -1) "" else path.substring(hashIdx)
+        val sep = if (base.contains('?')) "&" else "?"
+        return base + sep + query + hash
+    }
+}

--- a/backend/redirect-router.js
+++ b/backend/redirect-router.js
@@ -22,7 +22,7 @@ const registry = require('./shared/route-registry');
 const SIG_TTL_DEFAULT_S = 7 * 24 * 3600;   // minted links live a week unless overridden
 const RETENTION_DAYS = 30;                  // approved open-point 2
 const TRACE_RE = /^rt_[a-f0-9]{12}$/;
-const STATES = ['RECEIVED', 'SIG_REJECTED', 'WEB_DIRECT', 'WEB_FALLBACK', 'APP_OPENED', 'LOGIN_REDIRECT', 'TARGET_RENDERED'];
+const STATES = ['RECEIVED', 'SIG_REJECTED', 'WEB_DIRECT', 'WEB_FALLBACK', 'APP_ATTEMPT', 'APP_OPENED', 'LOGIN_REDIRECT', 'TARGET_RENDERED'];
 
 let pool = null;
 let devicesRef = null;
@@ -167,16 +167,70 @@ router.get('/r/:target', async (req, res) => {
         return res.redirect(302, '/portal/dashboard.html?redirectError=expired');
     }
 
-    // Phase A (approved open-point 1): straight to web on every platform.
-    // APP_ATTEMPT activates with Phase B App Links.
     const dest = registry.buildWebUrl(target, params);
     const sep = dest.includes('?') ? '&' : '?';
     const hashIdx = dest.indexOf('#');
     const withTrace = hashIdx === -1
         ? dest + sep + 'traceId=' + traceId
         : dest.slice(0, hashIdx) + sep + 'traceId=' + traceId + dest.slice(hashIdx);
+
+    // Phase B: Android mobile browsers get the 400 ms APP_ATTEMPT interstitial
+    // (spec §4). Installed+verified apps never reach here — the OS routes the
+    // link natively — so this covers app-not-installed / unverified, falling
+    // back to the web target. Other platforms keep the Phase A straight 302.
+    if (platform === 'mobile_web' && /Android/i.test(String(req.headers['user-agent'] || ''))) {
+        await logEvent(traceId, 'APP_ATTEMPT', target, platform);
+        return res.status(200).type('html').send(appAttemptInterstitial(withTrace, traceId, target));
+    }
     await logEvent(traceId, 'WEB_DIRECT', target, platform);
     return res.redirect(302, withTrace);
+});
+
+// 400 ms app-attempt window (spec §3/§4, approved open-point 1 — activates
+// with Phase B). Logs WEB_FALLBACK via the telemetry beacon when the timer
+// fires, then JS-redirects to the web destination.
+function appAttemptInterstitial(destUrl, traceId, target) {
+    const dest = JSON.stringify(destUrl);
+    const body = JSON.stringify({ traceId, state: 'WEB_FALLBACK', target, platform: 'mobile_web', fallbackReason: 'app_attempt_timeout' });
+    return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"><meta name="robots" content="noindex">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>EClaw</title></head>
+<body style="background:#0D0D1A;margin:0">
+<script>
+setTimeout(function () {
+    try { navigator.sendBeacon('/api/redirect/telemetry', new Blob([${JSON.stringify(body)}], { type: 'application/json' })); } catch (e) {}
+    location.replace(${dest});
+}, 400);
+</script>
+<noscript><meta http-equiv="refresh" content="0;url=${destUrl.replace(/"/g, '&quot;')}"></noscript>
+</body></html>`;
+}
+
+// ── Android App Links verification (Phase B) ─────────────────────────────
+// Digital Asset Links statement for com.hank.clawlive. Fingerprints come from
+// ASSETLINKS_FINGERPRINTS (comma-separated SHA-256 cert digests) so the Play
+// App Signing certificate can be added without a deploy-time code change; the
+// committed default is the local release-key (upload) certificate.
+const ANDROID_PACKAGE = 'com.hank.clawlive';
+const UPLOAD_CERT_SHA256 = '0D:F0:18:33:A4:41:C4:02:74:9C:CF:4A:5A:59:F2:0C:62:00:3D:59:91:86:36:98:17:D5:89:50:47:DB:E8:10';
+
+function assetlinksFingerprints() {
+    const fromEnv = String(process.env.ASSETLINKS_FINGERPRINTS || '')
+        .split(',').map(s => s.trim()).filter(Boolean);
+    return fromEnv.length ? fromEnv : [UPLOAD_CERT_SHA256];
+}
+
+router.get('/.well-known/assetlinks.json', (req, res) => {
+    res.set('Cache-Control', 'public, max-age=3600');
+    return res.json([{
+        relation: ['delegate_permission/common.handle_all_urls'],
+        target: {
+            namespace: 'android_app',
+            package_name: ANDROID_PACKAGE,
+            sha256_cert_fingerprints: assetlinksFingerprints(),
+        },
+    }]);
 });
 
 // ── server-side mint (#6 amendment 2) ───────────────────────────────────

--- a/backend/tests/jest/redirect-phase-b.test.js
+++ b/backend/tests/jest/redirect-phase-b.test.js
@@ -1,0 +1,110 @@
+/**
+ * Redirect state machine Phase B — Android App Links (card_8df2a4cbd972d19d7e3d38d2).
+ * Spec: docs/redirect-state-machine-spec.md §3/§4/§7.
+ * Covers: /.well-known/assetlinks.json statement shape + env override, and the
+ * 400 ms APP_ATTEMPT interstitial branch (Android mobile UA only).
+ */
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+
+const redirect = require('../../redirect-router');
+
+const DEVICE = 'dev-redirect-test';
+const DEVICES = {
+    [DEVICE]: {
+        deviceSecret: 'ds-secret',
+        entities: { 2: { isBound: true, botSecret: 'bs-secret' } },
+    },
+};
+
+const ANDROID_UA = 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Mobile Safari/537.36';
+const IPHONE_UA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile/15E148 Safari/604.1';
+const FP_RE = /^([0-9A-F]{2}:){31}[0-9A-F]{2}$/;
+
+function makeApp() {
+    redirect.init({ chatPool: null, devices: DEVICES, jwtSecret: 'test-signing-secret' });
+    const app = express();
+    app.use(redirect.router);
+    return app;
+}
+
+describe('GET /.well-known/assetlinks.json', () => {
+    afterEach(() => { delete process.env.ASSETLINKS_FINGERPRINTS; });
+
+    test('serves a handle_all_urls statement for com.hank.clawlive', async () => {
+        const res = await request(makeApp()).get('/.well-known/assetlinks.json');
+        expect(res.status).toBe(200);
+        expect(res.headers['content-type']).toMatch(/application\/json/);
+        expect(Array.isArray(res.body)).toBe(true);
+        const stmt = res.body[0];
+        expect(stmt.relation).toEqual(['delegate_permission/common.handle_all_urls']);
+        expect(stmt.target.namespace).toBe('android_app');
+        expect(stmt.target.package_name).toBe('com.hank.clawlive');
+        expect(stmt.target.sha256_cert_fingerprints.length).toBeGreaterThan(0);
+        for (const fp of stmt.target.sha256_cert_fingerprints) expect(fp).toMatch(FP_RE);
+    });
+
+    test('ASSETLINKS_FINGERPRINTS env overrides the committed default (Play App Signing cert path)', async () => {
+        const playCert = 'AA:' + Array(31).fill('BB').join(':');
+        process.env.ASSETLINKS_FINGERPRINTS = ` ${playCert} , ${'CC:' + Array(31).fill('DD').join(':')} `;
+        const res = await request(makeApp()).get('/.well-known/assetlinks.json');
+        const fps = res.body[0].target.sha256_cert_fingerprints;
+        expect(fps).toHaveLength(2);
+        expect(fps[0]).toBe(playCert);
+    });
+});
+
+describe('GET /r/:target — APP_ATTEMPT interstitial (Phase B)', () => {
+    let app;
+    beforeEach(() => { app = makeApp(); });
+
+    test('Android mobile UA gets the 400 ms interstitial, not a 302', async () => {
+        const res = await request(app)
+            .get('/r/chat?publicCode=3xa3h4')
+            .set('User-Agent', ANDROID_UA);
+        expect(res.status).toBe(200);
+        expect(res.headers['content-type']).toMatch(/text\/html/);
+        expect(res.text).toContain('setTimeout');
+        expect(res.text).toContain('400');
+        // destination carries the traceId and is JSON-escaped into the script
+        expect(res.text).toMatch(/location\.replace\("\/portal\/chat\.html\?contact=3xa3h4&traceId=rt_[a-f0-9]{12}"\)/);
+        // fallback beacon reports the spec §4 timeout transition
+        expect(res.text).toContain('WEB_FALLBACK');
+        expect(res.text).toContain('app_attempt_timeout');
+        // noscript users still reach the target
+        expect(res.text).toContain('http-equiv="refresh"');
+    });
+
+    test('iPhone UA keeps the straight 302 (iOS activates in Phase C)', async () => {
+        const res = await request(app)
+            .get('/r/chat?publicCode=3xa3h4')
+            .set('User-Agent', IPHONE_UA);
+        expect(res.status).toBe(302);
+    });
+
+    test('desktop UA keeps the straight 302', async () => {
+        const res = await request(app).get('/r/chat?publicCode=3xa3h4');
+        expect(res.status).toBe(302);
+    });
+
+    test('app WebView UA (EClawAndroid) bypasses the interstitial', async () => {
+        const res = await request(app)
+            .get('/r/chat?publicCode=3xa3h4')
+            .set('User-Agent', ANDROID_UA + ' EClawAndroid');
+        expect(res.status).toBe(302);
+    });
+
+    test('sig-rejected sensitive target never reaches the interstitial', async () => {
+        const res = await request(app)
+            .get('/r/card?cardId=card_abc123def456')
+            .set('User-Agent', ANDROID_UA);
+        expect(res.status).toBe(302);
+        expect(res.headers.location).toBe('/portal/dashboard.html?redirectError=expired');
+    });
+
+    test('APP_ATTEMPT is an accepted telemetry beacon state', () => {
+        expect(redirect._internal.STATES).toContain('APP_ATTEMPT');
+    });
+});


### PR DESCRIPTION
## Scope
Phase B of the unified redirect state machine — **spec `docs/redirect-state-machine-spec.md` §3/§4/§7**, card `card_8df2a4cbd972d19d7e3d38d2` (parent card_14571f26914b9c1eae148362, Phase A = PR #3322).

### Backend
- `GET /.well-known/assetlinks.json` — Digital Asset Links statement for `com.hank.clawlive`. Fingerprints read from `ASSETLINKS_FINGERPRINTS` (comma-separated env); committed default = local upload-key cert.
- `/r/:target`: Android mobile browsers now get the **400 ms APP_ATTEMPT interstitial** (spec §4, approved open-point 1 'activates with Phase B') — logs `APP_ATTEMPT`, beacons `WEB_FALLBACK/app_attempt_timeout`, JS-redirects to the web target, `<noscript>` refresh fallback. Desktop / iOS / `EClawAndroid` WebView UAs keep the Phase A straight 302.
- `APP_ATTEMPT` added to telemetry `STATES`.

### Android app
- `MainActivity`: `autoVerify` intent-filter for `https://eclawbot.com/r/*` + `launchMode=singleTask`; initial WebView load and `onNewIntent` route through the new parser.
- `RedirectLinkParser` (new util): app-side mirror of `route-registry.js` — param-validated target→portal mapping, traceId passthrough, dashboard fallback (never dead-ends), hash-safe embed/credential assembly.

## ⚠️ Release-blocking follow-up (documented, not in this PR)
AAB uploads use **Play App Signing**, so the device-visible cert is Google's, not the committed upload cert. Before App Links verification turns green in prod, the Play Console → App signing SHA-256 must be added via `ASSETLINKS_FINGERPRINTS` on Railway (zero code change). Until then `/r/` links keep working via the web fallback — no user-facing regression.

## Test plan
- `npx jest tests/jest/redirect-phase-b.test.js tests/jest/redirect-router.test.js` → 36/36 green (8 new).
- Full backend jest suite run before merge.
- App slice needs the next release build (vc98+) — per build/test autopush flow; E2E: `adb shell am start -a android.intent.action.VIEW -d 'https://eclawbot.com/r/card?...'` + assetlinks verify via `adb shell pm get-app-links`.

## Out of scope
- iOS AASA (Phase C card), legacy hop migration (Phase D card), Play Console fingerprint retrieval (blocked on console access — tracked on card).

🤖 Generated with [Claude Code](https://claude.com/claude-code)