### PR TITLE
feat(info): Day 158 daily highlight embed — 一夜 14 個更新

### DIFF
--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -105,26 +105,26 @@
                 <a class="qs-promo-link" href="/promo.html" target="_blank" rel="noopener" data-i18n="qs_promo_full_page_link">📺 開啟完整影片頁</a>
             </section>
 
-            <!-- Daily highlight: Day 151 — Petdx 自有化, 少一個外部 SPOF (6/05) -->
-            <section class="qs-promo-section qs-daily-highlight" aria-labelledby="qs-day151-heading"
+            <!-- Daily highlight: Day 158 — 一夜 14 個更新：你的智能體學會慶祝了 (6/12) -->
+            <section class="qs-promo-section qs-daily-highlight" aria-labelledby="qs-day158-heading"
                 style="margin-top: 12px; padding-top: 8px; border-top: 1px dashed rgba(124,58,237,0.25);">
-                <h2 id="qs-day151-heading" class="qs-promo-title" style="font-size: 1.05em; color: #42d4f4;">
-                    🦞 Day 151 — Petdx 自有化, 少一個外部 SPOF
+                <h2 id="qs-day158-heading" class="qs-promo-title" style="font-size: 1.05em; color: #42d4f4;">
+                    🦞 Day 158 — 一夜 14 個更新：你的智能體學會慶祝了
                 </h2>
                 <p class="qs-promo-lede" style="font-size: 0.92em; opacity: 0.85;">
-                    6/05 出貨：六實體大頭照從外部 CDN 403 → R2 self-host 全恢復。Phase 2 R2 pipeline (#3175) · Phase 2.5 orphan recovery (#3179) · Phase C settings 入口 (#3180)。59s · 9:16 · silent · 真實 EClaw UI。
+                    6/12 週四 changelog 高光：一夜 14 個更新落地。打開聊天室它記得你 · 拖卡片不再等伺服器 · 升級的瞬間有人為它慶祝 · 點開頭像進度都看得到。85s · 16:9 · zh-TW BGM-only · 真實 EClaw UI。
                 </p>
-                <div class="qs-promo-frame" style="max-width: 360px; aspect-ratio: 9 / 16;">
+                <div class="qs-promo-frame" style="max-width: 480px; aspect-ratio: 16 / 9;">
                     <iframe
-                        src="https://www.youtube.com/embed/6hD9OTwc4jo"
-                        title="Day 151 — Petdx 自有化, 少一個外部 SPOF"
+                        src="https://www.youtube.com/embed/CAvRd9PyQlg"
+                        title="Day 158 — 一夜 14 個更新：你的智能體學會慶祝了"
                         loading="lazy"
                         allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
                         referrerpolicy="strict-origin-when-cross-origin"
                         allowfullscreen
                         style="width:100%; height:100%; border:0; border-radius: 12px; background: #000;"></iframe>
                 </div>
-                <a class="qs-promo-link" href="https://youtube.com/shorts/6hD9OTwc4jo" target="_blank" rel="noopener" style="font-size: 0.85em;">📺 在 YouTube Shorts 開啟</a>
+                <a class="qs-promo-link" href="https://www.youtube.com/watch?v=CAvRd9PyQlg" target="_blank" rel="noopener" style="font-size: 0.85em;">📺 在 YouTube 開啟</a>
             </section>
 
             <!-- Hero: 你想做什麼？ -->


### PR DESCRIPTION
## Scope
Rotate the `info.html` daily-highlight section from Day 151 (6/05) to **Day 158 (6/12)**.
- iframe src → `https://www.youtube.com/embed/CAvRd9PyQlg`
- title/heading/lede → Day 158 — 一夜 14 個更新：你的智能體學會慶祝了
- aspect-ratio 9/16 → **16/9** (Day 158 is 1920×1080 landscape, not a vertical Short), max-width 360→480px
- link → regular watch URL (not /shorts/)
- Only `backend/public/portal/info.html` touched.

## Acceptance
- info.html renders Day 158 iframe; video plays on prod desktop + mobile
- YouTube video verified playable pre-merge: `playabilityStatus.status = OK`, oEmbed 200
- Copyright check: claim detected but owner permits YouTube use → global playback, not blocked (avoids the 06/05 UNPLAYABLE regression)

## Test plan
- Post-deploy prod URL: https://eclawbot.com/portal/info.html — screenshot desktop 1280×800 + mobile 390×844 showing the Day 158 section + iframe rendered/playable

## Out of scope
- promo.html / promo-meta.html evergreen embeds (policy: evergreen only, untouched)
- i18n dict: section uses inline zh text matching the existing Day 151 pattern; no new data-i18n keys introduced

## Evidence
- Card card_f1428e06ef7417fa18de23ee (Daily Eclaw 06/12)
- Prod screenshots attached to card post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)