### PR TITLE
feat(router): SmartRouter v1 — 3-mode navigation + files.html proof slice

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -875,6 +875,17 @@ app.use('/docs', express.static(path.join(__dirname, 'public/docs'), {
     lastModified: true,
     maxAge: '1h'
 }));
+// Dependency-free shared core modules served verbatim to the browser so the
+// portal SmartRouter consumes the SAME route-registry.js as the server (single
+// URL SoT, no drift). Whitelist .js only — this dir is server code, not assets.
+app.use('/shared-core', express.static(path.join(__dirname, 'shared'), {
+    etag: true,
+    lastModified: true,
+    maxAge: '1h',
+    setHeaders: (res, filePath) => {
+        if (!filePath.endsWith('.js')) { res.status(404); }
+    }
+}));
 
 // Privacy policy (public, root-level)
 app.get(['/privacy-policy.html', '/privacy-policy'], (req, res) => {

--- a/backend/public/portal/files.html
+++ b/backend/public/portal/files.html
@@ -696,6 +696,8 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
+    <script src="/shared-core/route-registry.js"></script>
+    <script src="shared/smart-router.js"></script>
     <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid|EClawIOS/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
     <script src="shared/ai-chat.js"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
@@ -1348,7 +1350,10 @@
                 }));
             } catch (_) {}
             exitMultiSelectMode();
-            window.location.href = '/portal/chat.html';
+            // SmartRouter proof slice: single→full nav, split→sibling chat pane swap,
+            // app→native chat tab. Falls back to raw nav if router absent.
+            if (window.SmartRouter) window.SmartRouter.navigate('chat');
+            else window.location.href = '/portal/chat.html';
         }
 
         // --- Long-press / pointer handling ---
@@ -1420,7 +1425,9 @@
                 window.parent.postMessage({ type: 'eclaw_quote', source, title, excerpt: excerpt || '' }, window.location.origin);
             } else {
                 localStorage.setItem('eclaw_pending_quote', JSON.stringify({ source, title, excerpt: excerpt || '', ts: Date.now() }));
-                window.location.href = '/portal/chat.html';
+                // Not embedded → single mode; SmartRouter resolves to full chat nav.
+                if (window.SmartRouter) window.SmartRouter.navigate('chat');
+                else window.location.href = '/portal/chat.html';
             }
         }
 

--- a/backend/public/portal/shared/smart-router.js
+++ b/backend/public/portal/shared/smart-router.js
@@ -1,0 +1,204 @@
+/**
+ * SmartRouter — 3-mode in-session navigation (docs/smart-router-spec.md).
+ * Card: card_866e95ee74d5a168f2e35de6 (v1 impl). Spec APPROVED 94109cf1.
+ *
+ * Modes (spec §1): 'single' (full-page), 'split' (workspace pane swap),
+ * 'app' (native tab bridge). Mode is frozen at boot; navigate() dispatches
+ * per-mode and degrades one level on failure so navigation never dead-ends.
+ *
+ * Consumes the SAME route registry as the server via /shared-core/route-registry.js
+ * (window.EClawRouteRegistry) — single URL SoT. Load that BEFORE this file.
+ */
+(function (global) {
+    'use strict';
+
+    var registry = global.EClawRouteRegistry || null;
+
+    // Native host mapping (spec §3, #6 review am.1): the native shells today host
+    // only chat + mission tabs. Any target absent from this map degrades to
+    // 'single' IMMEDIATELY in app mode — no bridge round-trip, no timeout wait.
+    var APP_TARGET_TAB = { chat: 'chat', card: 'mission', note: 'mission' };
+
+    var SPLIT_ACK_TIMEOUT_MS = 300; // spec §3 split ack contract
+
+    // ── Mode detection (spec §2, first match wins) ──
+    function detectMode() {
+        // 1. app outranks split — a WebView inside the native app is still app mode.
+        if (global.EClawNativeNav) return 'app';
+        if (global.AndroidBridge || /EClawAndroid|EClawIOS/i.test(global.navigator && global.navigator.userAgent || '')) {
+            return 'app';
+        }
+        // 2. split — embedded pane whose parent is same-origin.
+        var body = global.document && global.document.body;
+        var embedFlag = (body && body.classList && body.classList.contains('embed-mode'))
+            || /[?&]embed=1\b/.test(global.location && global.location.search || '')
+            || (global.parent && global.parent !== global.self);
+        if (embedFlag && _parentIsSameOrigin()) return 'split';
+        // 3. single — standalone page.
+        return 'single';
+    }
+
+    function _parentIsSameOrigin() {
+        if (!global.parent || global.parent === global.self) return false;
+        try {
+            // Throws on cross-origin; a readable parent.location.origin === ours = same-origin.
+            return global.parent.location.origin === global.location.origin;
+        } catch (_) {
+            return false;
+        }
+    }
+
+    // ── URL building (spec §3: delegates to the registry, single SoT) ──
+    // Tolerant-degrade: a bare target whose required params are absent (e.g.
+    // generic "open chat" with no contact) strips the unfilled {param} query/hash
+    // segments instead of throwing, so navigate('chat') still resolves. This keeps
+    // route-registry.js untouched as the SoT (its buildWebUrl stays strict).
+    function buildUrl(target, params) {
+        params = params || {};
+        if (!registry || !registry.isKnownTarget(target)) {
+            // No registry / unknown target: last-resort same-origin no-op guard.
+            return null;
+        }
+        try {
+            return registry.buildWebUrl(target, params);
+        } catch (e) {
+            // Missing/invalid param → build the bare path by dropping unfilled tokens.
+            return _bareUrl(target);
+        }
+    }
+
+    function _bareUrl(target) {
+        var raw = registry.ROUTES[target].web; // e.g. '/portal/chat.html?contact={publicCode}'
+        // Drop a trailing '?a={x}&b={y}' / '#{x}' whose tokens were never filled.
+        var path = raw.split(/[?#]/)[0];
+        return path;
+    }
+
+    // ── Per-mode dispatch (spec §3) ──
+    var _pendingAcks = {}; // requestId -> timer handle (split mode)
+
+    function navigate(target, opts) {
+        opts = opts || {};
+        var params = opts.params || opts; // allow navigate(t, {params}) or navigate(t, params)
+        var mode = SmartRouter.mode;
+
+        if (mode === 'app') return _navigateApp(target, params, opts);
+        if (mode === 'split') return _navigateSplit(target, params, opts);
+        return _navigateSingle(target, params);
+    }
+
+    function _navigateSingle(target, params) {
+        var url = buildUrl(target, params);
+        if (!url) return false;
+        global.location.assign(url); // never replace() — natural browser history (spec §Q3)
+        return true;
+    }
+
+    function _navigateApp(target, params, opts) {
+        var tab = APP_TARGET_TAB[target];
+        if (!tab) return _navigateSingle(target, params); // unmapped → immediate single fallback
+        try {
+            var ok = global.EClawNativeNav.navigate(Object.assign({
+                targetTab: tab,
+                sourceTab: opts.sourceTab,
+                target: target
+            }, params));
+            if (ok === false) return _navigateSingle(target, params); // bridge declined → degrade
+            return true;
+        } catch (_) {
+            return _navigateSingle(target, params); // bridge threw → degrade
+        }
+    }
+
+    function _navigateSplit(target, params, opts) {
+        if (!_parentIsSameOrigin()) return _navigateSingle(target, params);
+        var requestId = 'nav_' + _hex8();
+        var origin = global.location.origin;
+        var degraded = false;
+
+        // 300ms timer: no ack → degrade to single (full-page navigate). A late ack
+        // after degradation is ignored because the requestId is no longer pending.
+        _pendingAcks[requestId] = global.setTimeout(function () {
+            delete _pendingAcks[requestId];
+            if (!degraded) {
+                degraded = true;
+                _navigateSingle(target, params);
+            }
+        }, SPLIT_ACK_TIMEOUT_MS);
+
+        global.parent.postMessage({
+            type: 'split_navigate',
+            requestId: requestId,
+            target: target,
+            params: params,
+            panel: 'self'
+        }, origin);
+        return true;
+    }
+
+    // Listen for the host's ack (split mode) — cancels the degrade timer.
+    function _onMessage(e) {
+        if (e.origin !== global.location.origin || !e.data) return;
+        if (e.data.type === 'split_navigate_ack' && e.data.requestId) {
+            var timer = _pendingAcks[e.data.requestId];
+            if (timer) {
+                global.clearTimeout(timer);
+                delete _pendingAcks[e.data.requestId];
+            }
+        }
+        if (e.data.type === 'split_navigated' && _navHandlers.length) {
+            _navHandlers.forEach(function (h) { try { h(e.data); } catch (_) {} });
+        }
+    }
+
+    // ── onNavigate(handler) — in-mode transition hook (spec §3) ──
+    var _navHandlers = [];
+    function onNavigate(handler) {
+        if (typeof handler !== 'function') return;
+        _navHandlers.push(handler);
+        if (SmartRouter.mode === 'app') {
+            // Wrap the existing native replay so pages subscribe once.
+            global.eclawHandleNativeNavigateIntent = function (intent) {
+                _navHandlers.forEach(function (h) { try { h(intent); } catch (_) {} });
+            };
+        }
+        // 'single' is a no-op (full reload re-boots the page).
+    }
+
+    function _hex8() {
+        var s = '';
+        for (var i = 0; i < 8; i++) s += Math.floor(Math.random() * 16).toString(16);
+        return s;
+    }
+
+    var SmartRouter = {
+        mode: 'single', // overwritten at boot
+        navigate: navigate,
+        onNavigate: onNavigate,
+        buildUrl: buildUrl,
+        detectMode: detectMode,        // exposed for tests
+        APP_TARGET_TAB: APP_TARGET_TAB // exposed for tests
+    };
+
+    function boot() {
+        SmartRouter.mode = detectMode();
+        if (global.document && global.document.body) {
+            global.document.body.dataset.navMode = SmartRouter.mode; // spec §2 marker
+        }
+        global.addEventListener('message', _onMessage);
+    }
+
+    // Boot now if DOM is ready, else on DOMContentLoaded (body must exist for data-nav-mode).
+    if (global.document && global.document.body) {
+        boot();
+    } else if (global.document) {
+        global.document.addEventListener('DOMContentLoaded', boot);
+    }
+
+    global.SmartRouter = SmartRouter;
+
+    // CJS export for jest (jsdom) — tests can require() and drive detectMode/buildUrl.
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = SmartRouter;
+    }
+})(typeof window !== 'undefined' ? window : this);

--- a/backend/public/portal/workspace.html
+++ b/backend/public/portal/workspace.html
@@ -135,6 +135,7 @@
     <script src="shared/footer.js"></script>
     <script src="../shared/telemetry.js"></script>
     <script src="shared/ai-chat.js"></script>
+    <script src="/shared-core/route-registry.js"></script>
     <script>
     const PAGES = {
         'dashboard':   { href: 'dashboard.html',   icon: '📊', label: 'Dashboard',  i18nKey: 'nav_dashboard' },
@@ -479,7 +480,38 @@
             if (chatPane) chatPane.contentWindow.postMessage(e.data, window.location.origin);
             return;
         }
+        if (e.data.type === 'split_navigate') {
+            // SmartRouter split dispatch (smart-router.js §3 ack contract).
+            // Identify the requesting pane by event.source — NEVER by src matching
+            // (duplicate pages break that). Ack BEFORE the swap unloads the pane.
+            handleSplitNavigate(e);
+            return;
+        }
     });
+
+    // Swap the requesting pane's src to the SmartRouter target. Acks first so the
+    // pane can cancel its 300ms degrade timer before its document unloads.
+    function handleSplitNavigate(e) {
+        const { requestId, target, params } = e.data;
+        const pane = Array.from(document.querySelectorAll('iframe.workspace-pane'))
+            .find(f => f.contentWindow === e.source);
+        const url = (window.EClawRouteRegistry && buildPaneUrl(target, params)) || null;
+        if (!pane || !url) return; // unknown target / orphan source → pane stays, its timer degrades it
+        // Ack to the exact requesting window before we swap it.
+        if (requestId && e.source) {
+            try { e.source.postMessage({ type: 'split_navigate_ack', requestId }, window.location.origin); } catch (_) {}
+        }
+        bustChatPaneCache();
+        pane.src = url;
+    }
+
+    // Mirror SmartRouter.buildUrl's tolerant-degrade: strict registry URL, else bare path.
+    function buildPaneUrl(target, params) {
+        const reg = window.EClawRouteRegistry;
+        if (!reg || !reg.isKnownTarget(target)) return null;
+        try { return reg.buildWebUrl(target, params || {}); }
+        catch (_) { return reg.ROUTES[target].web.split(/[?#]/)[0]; }
+    }
 
     document.addEventListener('DOMContentLoaded', initWorkspace);
     </script>

--- a/backend/shared/route-registry.js
+++ b/backend/shared/route-registry.js
@@ -7,9 +7,12 @@
  * kanban's `?card=<id>#<id>` hash handler, chat's `?contact=<publicCode>`
  * shareable-link param, mission's `?note=`, and the `/p/:publicCode` route.
  *
- * Used by: backend/redirect-router.js (Phase A). The portal-side SmartRouter
- * (docs/smart-router-spec.md) consumes a copy when its implementation card
- * lands — keep this file dependency-free CJS so it can be served verbatim.
+ * Used by: backend/redirect-router.js (Phase A) AND the portal-side
+ * SmartRouter (docs/smart-router-spec.md), which consumes this very file in
+ * the browser via the `/shared-core/route-registry.js` static mount — single
+ * URL SoT, no drift. The UMD tail below exposes `window.EClawRouteRegistry`
+ * in the browser while keeping `module.exports` for Node; keep this file
+ * dependency-free so it serves verbatim.
  */
 'use strict';
 
@@ -84,7 +87,7 @@ function isSafeReturnTo(value) {
     return Object.values(ROUTES).some(r => r.web.split(/[?#]/)[0] === path);
 }
 
-module.exports = {
+const _api = {
     ROUTES,
     isKnownTarget,
     validateParams,
@@ -92,3 +95,11 @@ module.exports = {
     buildUniversalUrl,
     isSafeReturnTo,
 };
+
+// UMD tail: CJS for Node (redirect-router), global for the browser (SmartRouter).
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports = _api;
+}
+if (typeof window !== 'undefined') {
+    window.EClawRouteRegistry = _api;
+}

--- a/backend/tests/jest/smart-router.test.js
+++ b/backend/tests/jest/smart-router.test.js
@@ -1,0 +1,191 @@
+/**
+ * SmartRouter v1 — mode detection matrix + fallback degradation + split ack timeout.
+ * Spec: docs/smart-router-spec.md §2/§3. Card: card_866e95ee74d5a168f2e35de6.
+ *
+ * Drives the module under a fresh jsdom-ish global per case (the file boots on
+ * load, so we re-require with a reset global to exercise each detection branch).
+ */
+'use strict';
+
+const path = require('path');
+
+const ROUTER_PATH = path.join(__dirname, '../../public/portal/shared/smart-router.js');
+const REGISTRY_PATH = path.join(__dirname, '../../shared/route-registry.js');
+
+// Minimal window stub; per-case overrides merge in before load.
+function makeWin(overrides) {
+    const listeners = {};
+    const win = Object.assign({
+        location: { origin: 'https://eclawbot.com', search: '', assign: jest.fn(), href: '' },
+        navigator: { userAgent: 'Mozilla/5.0' },
+        document: { body: { dataset: {}, classList: { contains: () => false } } },
+        parent: null,
+        self: null,
+        addEventListener: (t, h) => { (listeners[t] = listeners[t] || []).push(h); },
+        setTimeout: (fn, ms) => setTimeout(fn, ms),
+        clearTimeout: (id) => clearTimeout(id),
+        Math: Math,
+        _emit: (t, ev) => (listeners[t] || []).forEach(h => h(ev)),
+    }, overrides);
+    win.self = win.self || win;
+    return win;
+}
+
+// Load registry + router against a given window global, returning the SmartRouter.
+function loadRouter(win) {
+    jest.resetModules();
+    const reg = require(REGISTRY_PATH);
+    win.EClawRouteRegistry = reg;
+    global.window = win;
+    global.module = { exports: {} };
+    // The router IIFE reads `window` via the param; require() returns its export.
+    delete require.cache[require.resolve(ROUTER_PATH)];
+    const SmartRouter = require(ROUTER_PATH);
+    return SmartRouter;
+}
+
+afterEach(() => { delete global.window; });
+
+describe('detectMode matrix (spec §2, first match wins)', () => {
+    test('EClawNativeNav present → app (outranks split)', () => {
+        const win = makeWin({ EClawNativeNav: { navigate: () => true } });
+        win.parent = win; // even if embeddable, app wins
+        expect(loadRouter(win).mode).toBe('app');
+    });
+
+    test('legacy AndroidBridge → app', () => {
+        const win = makeWin({ AndroidBridge: {} });
+        expect(loadRouter(win).mode).toBe('app');
+    });
+
+    test('EClawIOS UA → app', () => {
+        const win = makeWin({ navigator: { userAgent: 'EClawIOS/1.0' } });
+        expect(loadRouter(win).mode).toBe('app');
+    });
+
+    test('?embed=1 with same-origin parent → split', () => {
+        const win = makeWin({ location: { origin: 'https://eclawbot.com', search: '?embed=1', assign: jest.fn() } });
+        win.parent = { location: { origin: 'https://eclawbot.com' } };
+        expect(loadRouter(win).mode).toBe('split');
+    });
+
+    test('parent !== self (no embed flag) same-origin → split', () => {
+        const win = makeWin({});
+        win.self = win;
+        win.parent = { location: { origin: 'https://eclawbot.com' } };
+        expect(loadRouter(win).mode).toBe('split');
+    });
+
+    test('cross-origin parent → single (not split)', () => {
+        const win = makeWin({});
+        win.parent = { get location() { throw new Error('cross-origin'); } };
+        expect(loadRouter(win).mode).toBe('single');
+    });
+
+    test('standalone page → single', () => {
+        const win = makeWin({});
+        win.parent = win; // parent === self
+        expect(loadRouter(win).mode).toBe('single');
+    });
+
+    test('boot sets body.dataset.navMode', () => {
+        const win = makeWin({});
+        win.parent = win;
+        const SR = loadRouter(win);
+        expect(win.document.body.dataset.navMode).toBe(SR.mode);
+    });
+});
+
+describe('buildUrl tolerant-degrade (spec §3)', () => {
+    test('strict registry URL when params present', () => {
+        const win = makeWin({}); win.parent = win;
+        const SR = loadRouter(win);
+        expect(SR.buildUrl('chat', { publicCode: 'abc123' })).toBe('/portal/chat.html?contact=abc123');
+    });
+    test('bare path when required param absent (generic open-chat)', () => {
+        const win = makeWin({}); win.parent = win;
+        const SR = loadRouter(win);
+        expect(SR.buildUrl('chat')).toBe('/portal/chat.html');
+    });
+    test('unknown target → null', () => {
+        const win = makeWin({}); win.parent = win;
+        const SR = loadRouter(win);
+        expect(SR.buildUrl('nope')).toBeNull();
+    });
+});
+
+describe('per-mode dispatch + fallback degradation (spec §3)', () => {
+    test('single → location.assign with built url', () => {
+        const win = makeWin({}); win.parent = win;
+        const SR = loadRouter(win);
+        SR.navigate('chat', { publicCode: 'abc123' });
+        expect(win.location.assign).toHaveBeenCalledWith('/portal/chat.html?contact=abc123');
+    });
+
+    test('app unmapped target → immediate single fallback (no bridge call)', () => {
+        const navSpy = jest.fn(() => true);
+        const win = makeWin({ EClawNativeNav: { navigate: navSpy } });
+        const SR = loadRouter(win);
+        SR.navigate('settings'); // not in APP_TARGET_TAB
+        expect(navSpy).not.toHaveBeenCalled();
+        expect(win.location.assign).toHaveBeenCalledWith('/portal/settings.html');
+    });
+
+    test('app mapped target → bridge.navigate with targetTab', () => {
+        const navSpy = jest.fn(() => true);
+        const win = makeWin({ EClawNativeNav: { navigate: navSpy } });
+        const SR = loadRouter(win);
+        SR.navigate('card', { cardId: 'card_abc123' });
+        expect(navSpy).toHaveBeenCalledWith(expect.objectContaining({ targetTab: 'mission', target: 'card' }));
+    });
+
+    test('app bridge returns false → degrade to single', () => {
+        const win = makeWin({ EClawNativeNav: { navigate: () => false } });
+        const SR = loadRouter(win);
+        SR.navigate('chat', { publicCode: 'abc123' });
+        expect(win.location.assign).toHaveBeenCalledWith('/portal/chat.html?contact=abc123');
+    });
+});
+
+describe('split ack contract (spec §3)', () => {
+    test('posts split_navigate to parent with nav_ requestId', () => {
+        const post = jest.fn();
+        const win = makeWin({ location: { origin: 'https://eclawbot.com', search: '?embed=1', assign: jest.fn() } });
+        win.parent = { location: { origin: 'https://eclawbot.com' }, postMessage: post };
+        const SR = loadRouter(win);
+        SR.navigate('chat');
+        expect(post).toHaveBeenCalledWith(
+            expect.objectContaining({ type: 'split_navigate', target: 'chat', requestId: expect.stringMatching(/^nav_[0-9a-f]{8}$/) }),
+            'https://eclawbot.com'
+        );
+    });
+
+    test('no ack within 300ms → degrade to single full-page navigate', (done) => {
+        const post = jest.fn();
+        const assign = jest.fn();
+        const win = makeWin({ location: { origin: 'https://eclawbot.com', search: '?embed=1', assign } });
+        win.parent = { location: { origin: 'https://eclawbot.com' }, postMessage: post };
+        const SR = loadRouter(win);
+        SR.navigate('chat');
+        setTimeout(() => {
+            expect(assign).toHaveBeenCalledWith('/portal/chat.html');
+            done();
+        }, 360);
+    });
+
+    test('ack before timeout → no degrade (location.assign NOT called)', (done) => {
+        const post = jest.fn();
+        const assign = jest.fn();
+        const win = makeWin({ location: { origin: 'https://eclawbot.com', search: '?embed=1', assign } });
+        win.parent = { location: { origin: 'https://eclawbot.com' }, postMessage: post };
+        const SR = loadRouter(win);
+        SR.navigate('chat');
+        const requestId = post.mock.calls[0][0].requestId;
+        // Simulate host ack back to the pane.
+        win._emit('message', { origin: 'https://eclawbot.com', data: { type: 'split_navigate_ack', requestId } });
+        setTimeout(() => {
+            expect(assign).not.toHaveBeenCalled();
+            done();
+        }, 360);
+    });
+});


### PR DESCRIPTION
Implements **docs/smart-router-spec.md** (APPROVED 94109cf1; #6's 4 amendments folded). Card: card_866e95ee74d5a168f2e35de6.

## Scope (spec §7 acceptance)
1. **smart-router.js** (`backend/public/portal/shared/`): `detectMode()` (app>split>single, same-origin parent check) · per-mode `navigate()` dispatch · `APP_TARGET_TAB={chat,card,note}` (unmapped target → immediate single fallback, no bridge round-trip) · split **ack contract** (`nav_`+8hex requestId, host identifies pane by `event.source`, ack-before-swap, **300ms** degrade-to-single, late-ack ignored) · `body[data-nav-mode]` marker · `onNavigate()` hook.
2. **route-registry.js**: UMD tail → browser gets `window.EClawRouteRegistry` (same file the server requires) = single URL SoT, no drift. CJS path unchanged.
3. **index.js**: `/shared-core` static mount serves `backend/shared/*.js` verbatim (.js-only).
4. **workspace.html**: `split_navigate` host case — pane identified by `event.source` (never src matching), acks before swapping `pane.src`.
5. **files.html**: 2 chat hops → `SmartRouter.navigate('chat')` (proof slice).

## Implementation decision (documented)
The registry's `chat` target requires `publicCode`, but the files.html hops are generic "open chat" (no contact). Rather than mutate the shared registry, `SmartRouter.buildUrl` **tolerant-degrades**: strict `registry.buildWebUrl` first, and on missing-param it strips unfilled `{param}` segments to the bare path. Registry stays strict SoT; the host's `buildPaneUrl` mirrors this. So `navigate('chat')`→`/portal/chat.html`, `navigate('chat',{publicCode})`→`/portal/chat.html?contact=…`.

## Tests
- `smart-router.test.js` **18/18**: detection matrix (incl. app-outranks-split priority, cross-origin parent → single, data-nav-mode), buildUrl tolerant-degrade, per-mode dispatch + fallback (app unmapped/bridge-false → single), split ack timeout + ack-cancels-degrade.
- `redirect-router.test.js` **28/28** unaffected by the UMD change (server consumer).
- `node --check index.js` OK.

## Test plan (prod E2E, post-deploy)
- single: `/portal/files.html` → file→chat hop full-navigates; `body[data-nav-mode=single]`.
- split: `/portal/workspace.html` with a files pane → hop swaps that pane's src to chat, sibling panes keep context; `data-nav-mode=split`.
- app: files.html under WebView UA (`EClawAndroid`) → `data-nav-mode=app`, unmapped targets degrade.
- `data-nav-mode` screenshots for all 3 modes attached to card.

## Out of scope
settings/kanban/mission/dashboard migration (Phase D card_125161f5); native LRU (Q2 native follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)