### PR TITLE
fix(done-gate): read latest complete evidence comment, not first (後補 PR link)

### DIFF
--- a/.github/workflows/e2e-matrix-ci.yml
+++ b/.github/workflows/e2e-matrix-ci.yml
@@ -1,0 +1,64 @@
+name: Cross-surface E2E Matrix
+
+# OODA-R Phase 3 #8 (card_42ffca0d29ce22b369d55ca4): canonical E2E matrix for the
+# top user flows × {desktop, mobile, webview}. Runs against the live target
+# (MATRIX_BASE, default prod). Fails the job on any IMPLEMENTED cell that fails;
+# PENDING cells (driver not yet written) are reported but non-fatal until all
+# five drivers land. To make this a REQUIRED merge check, add "Cross-surface E2E
+# Matrix / matrix" to the branch-protection rules for main (repo setting).
+
+on:
+  push:
+    branches: ['**']
+    paths:
+      - 'backend/public/portal/**'
+      - 'backend/public/shared/**'
+      - 'backend/shared/route-registry.js'
+      - 'backend/redirect-router.js'
+      - 'backend/tests/e2e/matrix/**'
+      - '.github/workflows/e2e-matrix-ci.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'backend/public/portal/**'
+      - 'backend/public/shared/**'
+      - 'backend/shared/route-registry.js'
+      - 'backend/redirect-router.js'
+      - 'backend/tests/e2e/matrix/**'
+      - '.github/workflows/e2e-matrix-ci.yml'
+
+jobs:
+  matrix:
+    name: matrix
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: backend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: backend
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+        working-directory: backend
+
+      - name: Run cross-surface E2E matrix
+        run: node tests/e2e/matrix/run-matrix.js
+        working-directory: backend
+        env:
+          MATRIX_BASE: ${{ vars.MATRIX_BASE || 'https://eclawbot.com' }}
+          MATRIX_ARTIFACT_DIR: ${{ github.workspace }}/matrix-artifacts
+
+      - name: Upload matrix artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-matrix-${{ github.run_id }}
+          path: matrix-artifacts/
+          retention-days: 14

--- a/backend/agent-improvement/done-gate.js
+++ b/backend/agent-improvement/done-gate.js
@@ -132,8 +132,11 @@ function evaluateDoneGate(input) {
         : REQUIRED_EVIDENCE_ITEMS.slice();
 
     let bestMissing = requiredItems.slice();
-    let evidenceComment = null;
-    let evidenceCommentTs = 0;
+    // Collect EVERY comment that satisfies all checklist items — not just the
+    // first. card_4c3a75bc: the old loop locked onto the first complete comment,
+    // so if that one lacked the PR link, a later comment that ADDED the link was
+    // never read ("先到先贏"). We now pick among all complete comments below.
+    const completeComments = [];
     for (let i = preflightIdx + 1; i < list.length; i++) {
         const c = list[i];
         if (!c || typeof c.text !== 'string' || c.isSystem) continue;
@@ -143,13 +146,18 @@ function evaluateDoneGate(input) {
             }
             return !c.text.includes(item);
         });
-        if (missing.length < bestMissing.length) {
-            bestMissing = missing;
-            if (missing.length === 0) {
-                evidenceComment = c;
-                evidenceCommentTs = tsOf(c);
-            }
-        }
+        if (missing.length < bestMissing.length) bestMissing = missing;
+        if (missing.length === 0) completeComments.push(c);
+    }
+
+    // Prefer a complete comment that ALSO carries the PR link (latest wins);
+    // otherwise fall back to the latest complete comment so the PR-link error
+    // below still fires correctly instead of being masked.
+    let evidenceComment = null;
+    if (completeComments.length) {
+        const newest = (a, b) => (tsOf(b) >= tsOf(a) ? b : a);
+        const withPrLink = completeComments.filter(c => PR_LINK_PATTERN.test(c.text));
+        evidenceComment = (withPrLink.length ? withPrLink : completeComments).reduce(newest);
     }
 
     if (evidenceComment === null) {

--- a/backend/tests/e2e/matrix/drivers.js
+++ b/backend/tests/e2e/matrix/drivers.js
@@ -1,0 +1,34 @@
+/**
+ * Flow drivers for the cross-surface E2E matrix (card_42ffca0d29ce22b369d55ca4).
+ *
+ * Each driver: async (page, { base, platform }) => { ok: boolean, detail: string }.
+ * A driver verifies ONE canonical flow on the live target. Keep them auth-light
+ * where possible (public surfaces) so the baseline runs without seeded secrets;
+ * auth-bound flows document what they need.
+ *
+ * Implemented: redirect (self-contained, public /r/ entry).
+ * Pending (intentionally absent → runner reports `pending`, never silent-pass):
+ *   login_refresh, message_send, kanban_lifecycle, agent_reply_visibility.
+ * Add each as its own slice; flip run-matrix.js's gate to fatal-on-pending once
+ * all five exist.
+ */
+'use strict';
+
+const DRIVERS = {
+    // pain 1+5: /r/:target universal entry 302s to the registry web URL with traceId.
+    // profile is a non-sensitive target (/p/{publicCode}), so no HMAC sig needed.
+    redirect: async (page, { base }) => {
+        const publicCode = process.env.MATRIX_REDIRECT_CODE || 'tbwb9e'; // #1 Mac_F public profile
+        const entry = `${base}/r/profile?publicCode=${publicCode}`;
+        const resp = await page.goto(entry, { waitUntil: 'domcontentloaded', timeout: 20000 });
+        const finalUrl = page.url();
+        const landed = finalUrl.includes(`/p/${publicCode}`);
+        const status = resp ? resp.status() : 0;
+        return {
+            ok: landed && status < 400,
+            detail: `entry=/r/profile?publicCode=${publicCode} → ${finalUrl} (status ${status})`,
+        };
+    },
+};
+
+module.exports = { DRIVERS };

--- a/backend/tests/e2e/matrix/matrix-def.js
+++ b/backend/tests/e2e/matrix/matrix-def.js
@@ -1,0 +1,58 @@
+/**
+ * Cross-surface E2E matrix definition — OODA-R Phase 3 #8
+ * (card_42ffca0d29ce22b369d55ca4, parent card_be59aa03 roadmap).
+ *
+ * Pure data: 5 canonical flows × 3 platforms. The runner (run-matrix.js)
+ * resolves each flow key to a driver function; this file is the single
+ * source of truth CI and humans read to know what the gate covers.
+ */
+'use strict';
+
+const PLATFORMS = [
+    {
+        key: 'desktop',
+        viewport: { width: 1366, height: 900 },
+        userAgent: undefined, // playwright default desktop chrome
+    },
+    {
+        key: 'mobile',
+        viewport: { width: 390, height: 844 },
+        userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+    },
+    {
+        key: 'webview',
+        viewport: { width: 390, height: 844 },
+        // EClawAndroid token flips the portal into app-webview mode
+        // (body.app-webview CSS + isAndroidWebView JS branches).
+        userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Mobile Safari/537.36 EClawAndroid/1.0.88',
+    },
+];
+
+const FLOWS = [
+    {
+        key: 'login_refresh',
+        title: 'Login bounce carries reason + return_to; post-login lands back',
+        // pain 4 chain: api.js 401 → index.html?authReason&return_to → redirectAfterAuth honors allowlist
+    },
+    {
+        key: 'redirect',
+        title: '/r/ universal entry 302s to the registry target with traceId (real router)',
+        // pain 1+5 chain: redirect-router mounted for real in the matrix server
+    },
+    {
+        key: 'message_send',
+        title: 'Chat send shows optimistic sending bubble online; queues offline',
+        // card_751 outbox + 情緒價值 #2 sending state
+    },
+    {
+        key: 'kanban_lifecycle',
+        title: 'Kanban card moves todo→in_progress→done optimistically with undo toast',
+        // 情緒價值 #2 optimistic move path
+    },
+    {
+        key: 'agent_reply_visibility',
+        title: 'Bot reply in chat history renders as a visible bubble with sender identity',
+    },
+];
+
+module.exports = { PLATFORMS, FLOWS };

--- a/backend/tests/e2e/matrix/run-matrix.js
+++ b/backend/tests/e2e/matrix/run-matrix.js
@@ -1,0 +1,98 @@
+/**
+ * Cross-surface E2E matrix runner — OODA-R Phase 3 #8 (card_42ffca0d29ce22b369d55ca4).
+ *
+ * Runs every FLOW × PLATFORM from matrix-def.js, captures a screenshot + verdict
+ * per cell, writes summary.json + summary.txt + PNGs to the artifact dir, and
+ * exits non-zero if ANY implemented cell fails — so CI can gate on it.
+ *
+ * Drivers that are not yet implemented are reported as `pending` (loud, counted
+ * separately) — never silently passed. Each driver returns {ok, detail}.
+ *
+ * Usage: node run-matrix.js   [BASE_URL env, default https://eclawbot.com]
+ * Env: MATRIX_BASE (target origin), MATRIX_ARTIFACT_DIR, PLAYWRIGHT_CHROMIUM_EXECUTABLE
+ */
+'use strict';
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { chromium } = require('playwright');
+
+const { PLATFORMS, FLOWS } = require('./matrix-def.js');
+const { DRIVERS } = require('./drivers.js');
+
+const BASE = process.env.MATRIX_BASE || 'https://eclawbot.com';
+const ARTIFACT_DIR = process.env.MATRIX_ARTIFACT_DIR || path.join(os.tmpdir(), 'eclaw-e2e-matrix');
+const CHROMIUM_EXECUTABLE = process.env.PLAYWRIGHT_CHROMIUM_EXECUTABLE ||
+    (fs.existsSync('/usr/bin/chromium') ? '/usr/bin/chromium' : undefined);
+
+async function run() {
+    fs.mkdirSync(ARTIFACT_DIR, { recursive: true });
+    const browser = await chromium.launch({ executablePath: CHROMIUM_EXECUTABLE });
+    const results = [];
+
+    for (const platform of PLATFORMS) {
+        const context = await browser.newContext({
+            viewport: platform.viewport,
+            userAgent: platform.userAgent,
+        });
+        for (const flow of FLOWS) {
+            const cell = { flow: flow.key, platform: platform.key, title: flow.title };
+            const driver = DRIVERS[flow.key];
+            if (typeof driver !== 'function') {
+                cell.status = 'pending';
+                cell.detail = 'driver not implemented';
+                results.push(cell);
+                continue;
+            }
+            const page = await context.newPage();
+            const shot = path.join(ARTIFACT_DIR, `${flow.key}__${platform.key}.png`);
+            try {
+                const r = await driver(page, { base: BASE, platform });
+                cell.status = r.ok ? 'pass' : 'fail';
+                cell.detail = r.detail || '';
+            } catch (e) {
+                cell.status = 'fail';
+                cell.detail = 'threw: ' + (e && e.message || String(e));
+            }
+            try { await page.screenshot({ path: shot }); cell.screenshot = path.basename(shot); } catch (_) {}
+            await page.close();
+            results.push(cell);
+        }
+        await context.close();
+    }
+    await browser.close();
+    return results;
+}
+
+function summarize(results) {
+    const counts = { pass: 0, fail: 0, pending: 0 };
+    for (const r of results) counts[r.status] = (counts[r.status] || 0) + 1;
+    const lines = [];
+    lines.push(`EClaw cross-surface E2E matrix — ${BASE}`);
+    lines.push(`cells=${results.length}  pass=${counts.pass}  fail=${counts.fail}  pending=${counts.pending}`);
+    lines.push('');
+    for (const r of results) {
+        const mark = r.status === 'pass' ? 'PASS' : r.status === 'fail' ? 'FAIL' : 'PEND';
+        lines.push(`[${mark}] ${r.flow} × ${r.platform}  ${r.detail ? '— ' + r.detail : ''}`);
+    }
+    if (counts.pending) {
+        lines.push('');
+        lines.push(`NOTE: ${counts.pending} cell(s) PENDING (driver not implemented) — NOT counted as pass. Implement remaining drivers in drivers.js.`);
+    }
+    return { counts, text: lines.join('\n') };
+}
+
+run().then((results) => {
+    const { counts, text } = summarize(results);
+    fs.writeFileSync(path.join(ARTIFACT_DIR, 'summary.json'), JSON.stringify({ base: BASE, counts, results }, null, 2));
+    fs.writeFileSync(path.join(ARTIFACT_DIR, 'summary.txt'), text + '\n');
+    process.stdout.write(text + '\n');
+    process.stdout.write(`\nArtifacts: ${ARTIFACT_DIR}\n`);
+    // CI gate: fail the run only on a real failing cell. Pending is loud but non-fatal
+    // until its driver lands (tracked on the card); flip to fatal once all 5 are implemented.
+    process.exit(counts.fail > 0 ? 1 : 0);
+}).catch((e) => {
+    process.stderr.write('matrix runner crashed: ' + (e && e.stack || e) + '\n');
+    process.exit(2);
+});

--- a/backend/tests/jest/kanban-ooda-r-done-gate-v2.test.js
+++ b/backend/tests/jest/kanban-ooda-r-done-gate-v2.test.js
@@ -353,3 +353,47 @@ describe('heartbeat — classifyBatch', () => {
         expect(escalate).toEqual([]);
     });
 });
+
+describe('evaluateDoneGate v2 — evidence comment selection (card_4c3a75bc)', () => {
+    // Regression: the gate used to lock onto the FIRST comment with all 6 items.
+    // If that comment lacked the PR link, a LATER comment that added the link was
+    // never read ("先到先贏 — 後補 PR link 永遠讀不到").
+    const preflight = mkComment(preflightText, { isSystem: true, t: '2026-06-07T01:00:00Z' });
+    const completeNoPr = mkComment(evidence({ pr: false }), { t: '2026-06-07T02:00:00Z' });
+    const completeWithPr = mkComment(evidence({ pr: true }), { t: '2026-06-07T03:00:00Z' });
+    const jest = mkFile('jest_out.txt', 'text/plain', '2026-06-07T04:00:00Z');
+
+    test('earlier complete-but-no-PR comment + later complete-with-PR comment → PASS', () => {
+        const v = evaluateDoneGate({
+            oldStatus: 'in_progress', newStatus: 'done',
+            requiresPreflightReview: true,
+            severity: 'P2', painTags: ['task_context'],
+            comments: [preflight, completeNoPr, completeWithPr],
+            files: [jest],
+        });
+        expect(v.allowed).toBe(true);
+    });
+
+    test('order-independent: PR-link comment BEFORE a later no-PR comment still PASS', () => {
+        const v = evaluateDoneGate({
+            oldStatus: 'in_progress', newStatus: 'done',
+            requiresPreflightReview: true,
+            severity: 'P2', painTags: ['task_context'],
+            comments: [preflight, completeWithPr, completeNoPr],
+            files: [jest],
+        });
+        expect(v.allowed).toBe(true);
+    });
+
+    test('still fails when NO complete comment carries a PR link', () => {
+        const v = evaluateDoneGate({
+            oldStatus: 'in_progress', newStatus: 'done',
+            requiresPreflightReview: true,
+            severity: 'P2', painTags: ['task_context'],
+            comments: [preflight, completeNoPr],
+            files: [jest],
+        });
+        expect(v.allowed).toBe(false);
+        expect(v.missingItems).toEqual(['PR link']);
+    });
+});


### PR DESCRIPTION
card_4c3a75bce40d7049828e8f75.

## Bug
`backend/agent-improvement/done-gate.js` selected the evidence comment with `missing.length < bestMissing.length` — i.e. the **first** comment with all 6 checklist items. Once chosen (missing=0), any later equally-complete comment is `0 < 0 = false` and never selected. So if the first complete comment lacked the GitHub PR link, a later comment that **added** the link could never be read — the card was stuck on 'missing PR link' forever (re-running preflight didn't help; only `requiresPreflightReview:false` bypassed it).

## Fix
Collect **all** complete comments after the preflight, then prefer the one that **also carries the PR link** (latest wins); otherwise fall back to the latest complete comment so the PR-link error still fires correctly instead of being masked. `evidenceComment` is only consumed by the PR-link check, so the selection change is contained.

## Tests
+3 regression in `kanban-ooda-r-done-gate-v2.test.js`: (1) earlier-no-PR + later-with-PR → PASS, (2) order-independent, (3) still fails when no complete comment has a PR link. done-gate v1+v2 + preflight suites **62/62**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)