### PR TITLE
fix(modal): scroll-lock v2 (position:fixed blocks programmatic scroll)

### DIFF
--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -113,17 +113,27 @@ function _tFb(k, fb) {
 let _eclawDialogId = 0;
 
 // Body scroll-lock for modal dialogs (showConfirm / showPrompt). Without it the
-// page behind a destructive confirm still scrolls on wheel/touch, so the user can
-// lose the dialog out of view or mis-tap a moved control. Ref-counted so stacked
-// dialogs don't unlock prematurely; restores the prior inline overflow on the last
-// close. Inline style (not a CSS class) keeps it self-contained — no stylesheet dep.
+// page behind a destructive confirm still scrolls (wheel/touch AND programmatic),
+// so the user can lose the dialog out of view or mis-tap a moved control.
+//
+// `overflow:hidden` alone only blocks USER wheel/touch — programmatic scrollTo
+// still moves the page. The robust mobile lock is position:fixed on body with
+// top:-scrollY: the document collapses to the viewport so it cannot scroll at all,
+// and the visual position is preserved. Restored (incl. scroll position) on the
+// last close. Ref-counted so stacked dialogs don't unlock prematurely.
 let _eclawScrollLockCount = 0;
-let _eclawPrevBodyOverflow = '';
+let _eclawPrevBody = null;     // saved inline styles to restore
+let _eclawLockedScrollY = 0;   // scroll position captured at first lock
 function _eclawLockBodyScroll() {
     if (typeof document === 'undefined' || !document.body) return;
     if (_eclawScrollLockCount === 0) {
-        _eclawPrevBodyOverflow = document.body.style.overflow;
-        document.body.style.overflow = 'hidden';
+        const b = document.body.style;
+        _eclawPrevBody = { overflow: b.overflow, position: b.position, top: b.top, width: b.width };
+        _eclawLockedScrollY = window.scrollY || window.pageYOffset || 0;
+        b.overflow = 'hidden';
+        b.position = 'fixed';
+        b.top = `-${_eclawLockedScrollY}px`;
+        b.width = '100%';
     }
     _eclawScrollLockCount++;
 }
@@ -131,8 +141,14 @@ function _eclawUnlockBodyScroll() {
     if (typeof document === 'undefined' || !document.body) return;
     if (_eclawScrollLockCount === 0) return;
     _eclawScrollLockCount--;
-    if (_eclawScrollLockCount === 0) {
-        document.body.style.overflow = _eclawPrevBodyOverflow;
+    if (_eclawScrollLockCount === 0 && _eclawPrevBody) {
+        const b = document.body.style;
+        b.overflow = _eclawPrevBody.overflow;
+        b.position = _eclawPrevBody.position;
+        b.top = _eclawPrevBody.top;
+        b.width = _eclawPrevBody.width;
+        _eclawPrevBody = null;
+        window.scrollTo(0, _eclawLockedScrollY); // restore the pre-lock scroll position
     }
 }
 const _ECLAW_DIALOG_SHADOW_STYLE = 'style="box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);"';

--- a/backend/tests/jest/showConfirm-scroll-lock.test.js
+++ b/backend/tests/jest/showConfirm-scroll-lock.test.js
@@ -20,16 +20,21 @@ const apiJs = fs.readFileSync(
 );
 
 describe('modal body scroll-lock (showConfirm / showPrompt)', () => {
-    test('defines a ref-counted lock helper that sets body overflow hidden', () => {
+    test('lock helper uses position:fixed + top:-scrollY (blocks programmatic scroll too)', () => {
         expect(apiJs).toMatch(/function\s+_eclawLockBodyScroll\s*\(/);
-        expect(apiJs).toMatch(/document\.body\.style\.overflow\s*=\s*['"]hidden['"]/);
+        expect(apiJs).toMatch(/\.overflow\s*=\s*['"]hidden['"]/);
+        expect(apiJs).toMatch(/\.position\s*=\s*['"]fixed['"]/);
+        expect(apiJs).toMatch(/\.top\s*=\s*[`'"]-\$\{?_eclawLockedScrollY/);
+        expect(apiJs).toMatch(/_eclawLockedScrollY\s*=\s*window\.scrollY/);
         // ref count so stacked dialogs don't unlock prematurely
         expect(apiJs).toMatch(/_eclawScrollLockCount\s*\+\+/);
     });
 
-    test('defines an unlock helper that restores the prior overflow on the last close', () => {
+    test('unlock helper restores saved inline styles AND the pre-lock scroll position', () => {
         expect(apiJs).toMatch(/function\s+_eclawUnlockBodyScroll\s*\(/);
-        expect(apiJs).toMatch(/document\.body\.style\.overflow\s*=\s*_eclawPrevBodyOverflow/);
+        expect(apiJs).toMatch(/b\.overflow\s*=\s*_eclawPrevBody\.overflow/);
+        expect(apiJs).toMatch(/b\.position\s*=\s*_eclawPrevBody\.position/);
+        expect(apiJs).toMatch(/window\.scrollTo\(0,\s*_eclawLockedScrollY\)/);
         expect(apiJs).toMatch(/_eclawScrollLockCount\s*--/);
     });
 


### PR DESCRIPTION
Follow-up to #3334 (card_ba264f85). prod E2E showed overflow:hidden only blocks user wheel/touch; window.scrollTo still scrolled. v2 uses position:fixed + top:-scrollY so the document can't scroll at all (programmatic or user), restoring styles + scroll position on the last close. Ref-counted, both showConfirm + showPrompt. Tests 9/9. 🤖 Generated with [Claude Code](https://claude.com/claude-code)