### PR TITLE
fix(chat): exclusive quote-receiver auto-select — stop reply mis-route to #1

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3908,7 +3908,7 @@
                     const { source, title, excerpt, messageId, meta, ts } = JSON.parse(pq);
                     if (Date.now() - ts < 120000) { // within 2 minutes
                         await openChatMessageDeepLink(messageId, { showMissingToast: true, scroll: true });
-                        quoteToChat(source, title, excerpt || '', meta);
+                        quoteToChat(source, title, excerpt || '', meta || receiverMetaFromMessageId(messageId));
                     }
                 }
             } catch(e) {}
@@ -3948,7 +3948,7 @@
                 if (!e.data || e.data.type !== 'eclaw_quote') return;
                 const { source, title, excerpt, messageId, meta } = e.data;
                 await openChatMessageDeepLink(messageId, { showMissingToast: true, scroll: true });
-                quoteToChat(source, title, excerpt || '', meta);
+                quoteToChat(source, title, excerpt || '', meta || receiverMetaFromMessageId(messageId));
             });
 
             // Mount @mention autocomplete on the message input.
@@ -4851,6 +4851,20 @@
             return Array.isArray(allMessages)
                 ? allMessages.find(m => normalizeChatMessageId(m && m.id) === id) || null
                 : null;
+        }
+
+        // Derive the smart-receiver auto-select meta from a quoted chat message.
+        // Quote entry points that don't carry an explicit `meta` (native/canvas
+        // nav-intent, cross-page deep-link) can resolve the sender entity from the
+        // already-loaded message so the reply still auto-routes to its sender.
+        function receiverMetaFromMessageId(messageId) {
+            const m = messageId ? findChatMessageById(messageId) : null;
+            if (m && m.is_from_bot === true &&
+                m.entity_id !== null && m.entity_id !== undefined &&
+                Number.isFinite(Number(m.entity_id))) {
+                return { kind: 'chat-entity', entityId: Number(m.entity_id) };
+            }
+            return {};
         }
 
         function getRenderedMessageIds(msg) {
@@ -6301,11 +6315,33 @@
             } else {
                 return;
             }
-            const hintLabel = (i18n && typeof i18n.t === 'function' && i18n.t('chat_receiver_hint_auto')) || 'auto';
+            // Only the quoted sender(s) that actually have a target checkbox can be
+            // auto-selected. If none are bound here (e.g. a cross-device sender),
+            // leave the existing selection untouched rather than wiping it blank.
+            const wanted = new Set();
             entityIds.forEach(eid => {
+                if (document.querySelector('.target-entity-check input[type="checkbox"][data-entity="' + eid + '"]')) {
+                    wanted.add(eid);
+                }
+            });
+            if (wanted.size === 0) return;
+            // EXCLUSIVE auto-select: a quote of #6 must route to #6 ONLY. The old
+            // additive toggle left the prior/default recipient set checked, so
+            // replies leaked to whoever was already selected — typically #1, the
+            // first bound entity (card_3462117951fa588df9ff8a95 "誤路由到 #1").
+            // Clear every entity + contact checkbox first, then check exactly the
+            // quoted sender(s). The user can still re-add recipients manually
+            // afterwards (a manual toggle revokes that entry's auto hint).
+            document.querySelectorAll('.target-entity-check input[type="checkbox"]').forEach(cb => {
+                cb.checked = wanted.has(Number(cb.dataset.entity));
+            });
+            document.querySelectorAll('.target-contact-check input[type="checkbox"]').forEach(cb => {
+                cb.checked = false;
+            });
+            const hintLabel = (i18n && typeof i18n.t === 'function' && i18n.t('chat_receiver_hint_auto')) || 'auto';
+            wanted.forEach(eid => {
                 const cb = document.querySelector('.target-entity-check input[type="checkbox"][data-entity="' + eid + '"]');
                 if (!cb) return;
-                if (!cb.checked) cb.checked = true;
                 const label = cb.closest('.target-entity-check');
                 if (label && !label.querySelector('.receiver-hint-auto')) {
                     const badge = document.createElement('span');
@@ -8300,7 +8336,11 @@
                     handled = await openChatMessageDeepLink(msgId, { showMissingToast: true, scroll: true });
                 }
                 if (quote && (quote.title || quote.excerpt)) {
-                    quoteToChat(quote.source || '引用', quote.title || '', quote.excerpt || '');
+                    // Carry the sender so the reply auto-routes to it. Native nav
+                    // intents don't pass `meta`, so derive it from the deep-linked
+                    // message (card_3462... — canvas quote dropped the receiver).
+                    const qMeta = quote.meta || receiverMetaFromMessageId(msgId);
+                    quoteToChat(quote.source || '引用', quote.title || '', quote.excerpt || '', qMeta);
                     handled = true;
                 }
                 if (handled) return true;

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -1015,6 +1015,8 @@
     <script src="/socket.io/socket.io.js"></script>
     <script src="shared/socket.js"></script>
     <script src="shared/footer.js"></script>
+    <script src="/shared-core/route-registry.js"></script>
+    <script src="shared/smart-router.js"></script>
     <script>if (typeof AndroidBridge !== 'undefined' || /EClawAndroid|EClawIOS/i.test(navigator.userAgent)) window.__blockAiChatWidget = true;</script>
     <script src="shared/ai-chat.js"></script>
     <script>if(typeof renderAvatarHtml==='undefined'){window.renderAvatarHtml=function(a){return a||'\u{1F99E}'};window.isAvatarUrl=function(){return false}}</script>
@@ -1510,7 +1512,8 @@
                 }).catch(() => {});
                 updateNotifiedSnapshot();
                 closeDialog();
-                window.location.href = 'chat.html';
+                if (window.SmartRouter) window.SmartRouter.navigate('chat');
+                else window.location.href = 'chat.html';
             };
         }
 
@@ -2141,7 +2144,8 @@
                 window.parent.postMessage({ type: 'eclaw_quote', source, title, excerpt: excerpt || '', prefillInput }, window.location.origin);
             } else {
                 localStorage.setItem('eclaw_pending_quote', JSON.stringify({ source, title, excerpt: excerpt || '', prefillInput, ts: Date.now() }));
-                window.location.href = '/portal/chat.html';
+                if (window.SmartRouter) window.SmartRouter.navigate('chat');
+                else window.location.href = '/portal/chat.html';
             }
         }
 

--- a/backend/public/portal/petdx-browser.html
+++ b/backend/public/portal/petdx-browser.html
@@ -114,6 +114,12 @@
         padding: 8px 16px; border-radius: 6px; cursor: pointer;
         font: inherit;
     }
+    .load-more-btn {
+        background: var(--accent); border: none; color: #fff;
+        padding: 6px 16px; border-radius: 6px; cursor: pointer;
+        font: inherit; font-size: 13px;
+    }
+    .load-more-btn:hover { opacity: 0.9; }
     .login-warn {
         padding: 12px; margin-bottom: 12px;
         background: #5a3000; color: #ffb04a;
@@ -275,6 +281,13 @@
     ];
     const filterState = { scope: '', category: '', sort: 'popular' };
     let searchTerm = '';
+    // Pagination state (Hank 2026-06-12: browser capped at first 60, no paging).
+    // /api/companion/list already supports page/limit/total; we page client-side.
+    const PAGE_SIZE = 60;
+    let currentPage = 1;
+    let loadedCount = 0;
+    let totalCount = 0;
+    let loadingMore = false;
     let searchTimer = 0;
 
     // ── Renderer pool ─────────────────────────────────────────────
@@ -323,7 +336,8 @@
     };
 
     // ── List loader ───────────────────────────────────────────────
-    async function loadList() {
+    // loadList(false) = fresh load (page 1, clears grid); loadList(true) = append next page.
+    async function loadList(append = false) {
         const status = document.getElementById('status');
         const grid = document.getElementById('grid');
         const empty = document.getElementById('empty');
@@ -336,17 +350,27 @@
             return;
         }
 
-        status.textContent = '載入中…';
-        empty.style.display = 'none';
-        tearDownRenderers();
-        grid.innerHTML = '';
+        if (append) {
+            if (loadingMore || loadedCount >= totalCount) return;
+            loadingMore = true;
+            currentPage += 1;
+        } else {
+            currentPage = 1;
+            loadedCount = 0;
+            totalCount = 0;
+            empty.style.display = 'none';
+            tearDownRenderers();
+            grid.innerHTML = '';
+        }
+        status.textContent = append ? '載入更多…' : '載入中…';
 
         const q = authQuery();
         if (filterState.scope)    q.set('scope', filterState.scope);
         if (filterState.category) q.set('category', filterState.category);
         if (filterState.sort)     q.set('sort', filterState.sort);
         if (searchTerm)           q.set('q', searchTerm);
-        q.set('limit', '60');
+        q.set('limit', String(PAGE_SIZE));
+        q.set('page', String(currentPage));
 
         let data;
         try {
@@ -354,21 +378,25 @@
             data = await r.json();
             if (!data.success) {
                 status.textContent = '載入失敗：' + (data.error || r.status);
+                if (append) { currentPage -= 1; }
                 return;
             }
         } catch (err) {
             status.textContent = '網路錯誤：' + err.message;
+            if (append) { currentPage -= 1; }
             return;
+        } finally {
+            loadingMore = false;
         }
 
         const items = data.companions || [];
-        status.textContent = '共 ' + (data.total || 0) + ' 個伙伴';
-        pagination.textContent = items.length === data.total
-            ? ''
-            : '顯示前 ' + items.length + ' 個';
+        totalCount = data.total || 0;
+        loadedCount += items.length;
+        status.textContent = '共 ' + totalCount + ' 個伙伴';
 
-        if (!items.length) {
+        if (!loadedCount) {
             empty.style.display = 'block';
+            renderPagination();
             return;
         }
 
@@ -376,6 +404,28 @@
             const node = renderCardNode(card);
             grid.appendChild(node);
         });
+        renderPagination();
+    }
+
+    // Render the load-more control in the #pagination slot. Shows a button while
+    // more remain; a "all shown" note once everything is loaded.
+    function renderPagination() {
+        const pagination = document.getElementById('pagination');
+        if (!pagination) return;
+        pagination.innerHTML = '';
+        if (loadedCount >= totalCount) {
+            if (totalCount > PAGE_SIZE) {
+                pagination.textContent = '已顯示全部 ' + totalCount + ' 個';
+            }
+            return;
+        }
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.id = 'load-more-btn';
+        btn.className = 'load-more-btn';
+        btn.textContent = `載入更多（${loadedCount}/${totalCount}）`;
+        btn.addEventListener('click', () => loadList(true));
+        pagination.appendChild(btn);
     }
 
     // ── Card node ─────────────────────────────────────────────────

--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -113,17 +113,27 @@ function _tFb(k, fb) {
 let _eclawDialogId = 0;
 
 // Body scroll-lock for modal dialogs (showConfirm / showPrompt). Without it the
-// page behind a destructive confirm still scrolls on wheel/touch, so the user can
-// lose the dialog out of view or mis-tap a moved control. Ref-counted so stacked
-// dialogs don't unlock prematurely; restores the prior inline overflow on the last
-// close. Inline style (not a CSS class) keeps it self-contained — no stylesheet dep.
+// page behind a destructive confirm still scrolls (wheel/touch AND programmatic),
+// so the user can lose the dialog out of view or mis-tap a moved control.
+//
+// `overflow:hidden` alone only blocks USER wheel/touch — programmatic scrollTo
+// still moves the page. The robust mobile lock is position:fixed on body with
+// top:-scrollY: the document collapses to the viewport so it cannot scroll at all,
+// and the visual position is preserved. Restored (incl. scroll position) on the
+// last close. Ref-counted so stacked dialogs don't unlock prematurely.
 let _eclawScrollLockCount = 0;
-let _eclawPrevBodyOverflow = '';
+let _eclawPrevBody = null;     // saved inline styles to restore
+let _eclawLockedScrollY = 0;   // scroll position captured at first lock
 function _eclawLockBodyScroll() {
     if (typeof document === 'undefined' || !document.body) return;
     if (_eclawScrollLockCount === 0) {
-        _eclawPrevBodyOverflow = document.body.style.overflow;
-        document.body.style.overflow = 'hidden';
+        const b = document.body.style;
+        _eclawPrevBody = { overflow: b.overflow, position: b.position, top: b.top, width: b.width };
+        _eclawLockedScrollY = window.scrollY || window.pageYOffset || 0;
+        b.overflow = 'hidden';
+        b.position = 'fixed';
+        b.top = `-${_eclawLockedScrollY}px`;
+        b.width = '100%';
     }
     _eclawScrollLockCount++;
 }
@@ -131,8 +141,14 @@ function _eclawUnlockBodyScroll() {
     if (typeof document === 'undefined' || !document.body) return;
     if (_eclawScrollLockCount === 0) return;
     _eclawScrollLockCount--;
-    if (_eclawScrollLockCount === 0) {
-        document.body.style.overflow = _eclawPrevBodyOverflow;
+    if (_eclawScrollLockCount === 0 && _eclawPrevBody) {
+        const b = document.body.style;
+        b.overflow = _eclawPrevBody.overflow;
+        b.position = _eclawPrevBody.position;
+        b.top = _eclawPrevBody.top;
+        b.width = _eclawPrevBody.width;
+        _eclawPrevBody = null;
+        window.scrollTo(0, _eclawLockedScrollY); // restore the pre-lock scroll position
     }
 }
 const _ECLAW_DIALOG_SHADOW_STYLE = 'style="box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);"';

--- a/backend/tests/e2e/matrix/drivers.js
+++ b/backend/tests/e2e/matrix/drivers.js
@@ -118,7 +118,7 @@ const DRIVERS = {
                 ok: rendered,
                 detail: `card ${cardId} lifecycle ${seen.join('→')}; rendered_in_kanban=${rendered}`,
             };
-        } finally {
+        } finally { // eslint-disable-line no-unsafe-finally
             // self-clean: archive the marker card. Cleanup failure throws → cell fails.
             if (cardId) {
                 const del = await api('DELETE', `/api/mission/card/${cardId}`, auth);
@@ -128,6 +128,68 @@ const DRIVERS = {
                 }
             }
         }
+    },
+
+    // A bot reply in chat history renders as a visible bubble WITH sender identity.
+    // READ-ONLY (#6 ruling: stable existing fixture on BROADCAST_TEST). No writes,
+    // no cleanup. Finds an existing is_from_bot reply via API, then asserts chat.html
+    // renders a received bubble (.chat-bubble) carrying a non-empty sender label
+    // (.chat-source) for a bot message.
+    agent_reply_visibility: async (page, { base }) => {
+        const { deviceId, deviceSecret, entityId } = testCreds();
+        const STUBS = [
+            'Hi! I am online and ready to chat~',
+            '你好！我已上線，準備好聊天囉~',
+        ];
+        // 1. confirm a real bot reply exists (fixture)
+        const histResp = await page.request.fetch(
+            `${base}/api/chat/history?deviceId=${encodeURIComponent(deviceId)}&deviceSecret=${encodeURIComponent(deviceSecret)}&entityId=${entityId}&limit=50`,
+            { timeout: 45000 }
+        );
+        let hist = null; try { hist = await histResp.json(); } catch (_) {}
+        const msgs = (hist && (hist.messages || hist)) || [];
+        const botReply = Array.isArray(msgs) ? msgs.find(m =>
+            (m.is_from_bot === true || m.isFromBot === true) &&
+            (m.text || '').trim().length >= 5 &&
+            !STUBS.includes((m.text || '').trim())
+        ) : null;
+        if (!botReply) {
+            return { ok: false, detail: 'no stable bot-reply fixture in chat history (need a prior bot reply on the test device)' };
+        }
+
+        // 2. render check: inject creds, load chat.html, assert a received bubble
+        //    with a non-empty sender label (.chat-source) exists for a bot message.
+        await page.addInitScript(([d, sec]) => {
+            try { localStorage.setItem('deviceId', d); localStorage.setItem('deviceSecret', sec); } catch (_) {}
+        }, [deviceId, deviceSecret]);
+        await page.goto(`${base}/portal/chat.html`, { waitUntil: 'domcontentloaded', timeout: 45000 });
+
+        let verdict = { ok: false };
+        try {
+            verdict = await page.waitForFunction(() => {
+                const msgs = Array.from(document.querySelectorAll('.chat-msg'));
+                for (const m of msgs) {
+                    if (m.classList.contains('sent')) continue;       // skip our own
+                    const src = m.querySelector('.chat-source');
+                    const bubble = m.querySelector('.chat-bubble');
+                    const senderLabel = src && (src.textContent || '').trim();
+                    const bodyText = bubble && (bubble.textContent || '').trim();
+                    if (senderLabel && bodyText) {
+                        return { ok: true, sender: senderLabel.slice(0, 40), textLen: bodyText.length };
+                    }
+                }
+                return false; // keep waiting
+            }, null, { timeout: 15000 }).then(h => h.jsonValue());
+        } catch (_) {
+            verdict = { ok: false };
+        }
+
+        return {
+            ok: !!verdict.ok,
+            detail: verdict.ok
+                ? `bot reply renders with sender="${verdict.sender}" (${verdict.textLen} chars)`
+                : `bot reply found in API but no received .chat-msg with .chat-source + .chat-bubble rendered`,
+        };
     },
 };
 

--- a/backend/tests/jest/chat-quote-smart-receiver.test.js
+++ b/backend/tests/jest/chat-quote-smart-receiver.test.js
@@ -88,7 +88,9 @@ describe('chat quote-reply smart receiver — chat.html surface', () => {
         expect(chatHtml).toMatch(
             /const\s*\{\s*source,\s*title,\s*excerpt,\s*messageId,\s*meta,\s*ts\s*\}\s*=\s*JSON\.parse\(pq\)/
         );
-        expect(chatHtml).toMatch(/quoteToChat\(\s*source,\s*title,\s*excerpt\s*\|\|\s*['"]['"]\s*,\s*meta\s*\)/);
+        // meta is forwarded; when the producer omits it we derive the sender
+        // from the deep-linked message (card_3462... fix).
+        expect(chatHtml).toMatch(/quoteToChat\(\s*source,\s*title,\s*excerpt\s*\|\|\s*['"]['"]\s*,\s*meta\s*\|\|\s*receiverMetaFromMessageId\(messageId\)\s*\)/);
         // workspace.html postMessage relay — same intentional drop
         expect(chatHtml).toMatch(
             /const\s*\{\s*source,\s*title,\s*excerpt,\s*messageId,\s*meta\s*\}\s*=\s*e\.data/
@@ -96,6 +98,33 @@ describe('chat quote-reply smart receiver — chat.html surface', () => {
         // Regression guard: prefillInput must NOT reappear in either destructure
         expect(chatHtml).not.toMatch(/prefillInput,\s*messageId,\s*meta,\s*ts\s*\}\s*=\s*JSON\.parse\(pq\)/);
         expect(chatHtml).not.toMatch(/prefillInput,\s*messageId,\s*meta\s*\}\s*=\s*e\.data/);
+    });
+
+    // card_3462117951fa588df9ff8a95 — the canvas/native nav-intent quote path
+    // dropped the receiver meta, so a quote of #6 fell back to the residual
+    // selection (#1). It must now derive the sender from the deep-linked msg.
+    test('native nav-intent quote derives receiver meta from the deep-linked message', () => {
+        // helper resolves a bot sender → { kind:'chat-entity', entityId }
+        expect(chatHtml).toMatch(/function\s+receiverMetaFromMessageId\s*\(\s*messageId\s*\)/);
+        expect(chatHtml).toMatch(/m\.is_from_bot\s*===\s*true/);
+        expect(chatHtml).toMatch(/return\s*\{\s*kind:\s*['"]chat-entity['"]\s*,\s*entityId:\s*Number\(m\.entity_id\)\s*\}/);
+        // eclawHandleNativeNavigateIntent wires it in (was bare quoteToChat w/o meta)
+        expect(chatHtml).toMatch(/const\s+qMeta\s*=\s*quote\.meta\s*\|\|\s*receiverMetaFromMessageId\(msgId\)/);
+        expect(chatHtml).toMatch(/quoteToChat\(\s*quote\.source\s*\|\|\s*['"]引用['"]\s*,\s*quote\.title\s*\|\|\s*['"]['"]\s*,\s*quote\.excerpt\s*\|\|\s*['"]['"]\s*,\s*qMeta\s*\)/);
+    });
+
+    // The auto-select must be EXCLUSIVE — clearing the residual/default
+    // selection — otherwise a quote of #6 still leaks to whoever was already
+    // checked (#1). This is the load-bearing assertion for card_3462...
+    test('applyAutoToggleReceivers clears every entity + contact checkbox before checking the sender', () => {
+        const fn = chatHtml.match(/function\s+applyAutoToggleReceivers\s*\(\s*meta\s*\)\s*\{[\s\S]*?\n        \}/);
+        expect(fn).not.toBeNull();
+        const body = fn[0];
+        // resets all entity checkboxes to (wanted.has) and all contacts to false
+        expect(body).toMatch(/\.target-entity-check input\[type="checkbox"\][\s\S]*?cb\.checked\s*=\s*wanted\.has\(Number\(cb\.dataset\.entity\)\)/);
+        expect(body).toMatch(/\.target-contact-check input\[type="checkbox"\][\s\S]*?cb\.checked\s*=\s*false/);
+        // bails out (leaves selection untouched) when no quoted sender is bound here
+        expect(body).toMatch(/if\s*\(\s*wanted\.size\s*===\s*0\s*\)\s*return/);
     });
 
     test('manual uncheck revokes the hint via updateTargetAll', () => {
@@ -364,6 +393,30 @@ describe('applyAutoToggleReceivers — behaviour against a hand-rolled DOM stub'
         expect(sandbox.document.querySelector('[data-entity="7"]').checked).toBe(false);
         const badges = sandbox.document.querySelectorAll('.receiver-hint-auto');
         expect(badges.length).toBe(1);
+    });
+
+    // card_3462... regression: a residual/default recipient (#1) must be
+    // UNCHECKED when a quote of #5 auto-selects, so the reply routes to #5 only.
+    test('chat-entity source clears a pre-checked residual recipient (#1 → off)', () => {
+        const { sandbox, api } = makeSandbox([1, 5, 7]);
+        // simulate the default "all checked" / last-sent residual state
+        sandbox.document.querySelector('[data-entity="1"]').checked = true;
+        sandbox.document.querySelector('[data-entity="7"]').checked = true;
+        api.applyAutoToggleReceivers({ kind: 'chat-entity', entityId: 5 });
+        expect(sandbox.document.querySelector('[data-entity="1"]').checked).toBe(false);
+        expect(sandbox.document.querySelector('[data-entity="5"]').checked).toBe(true);
+        expect(sandbox.document.querySelector('[data-entity="7"]').checked).toBe(false);
+        expect(sandbox.document.querySelectorAll('.receiver-hint-auto').length).toBe(1);
+    });
+
+    // If the quoted sender isn't a bound target here, leave the selection
+    // untouched rather than wiping the bar blank (no recipient = unsendable).
+    test('unbound sender → existing selection preserved (no exclusive wipe)', () => {
+        const { sandbox, api } = makeSandbox([1, 2]);
+        sandbox.document.querySelector('[data-entity="1"]').checked = true;
+        api.applyAutoToggleReceivers({ kind: 'chat-entity', entityId: 9 }); // 9 not bound
+        expect(sandbox.document.querySelector('[data-entity="1"]').checked).toBe(true);
+        expect(sandbox.document.querySelectorAll('.receiver-hint-auto').length).toBe(0);
     });
 
     test('chat-system source → no toggle, no badge', () => {

--- a/backend/tests/jest/petdx-browser-pagination.test.js
+++ b/backend/tests/jest/petdx-browser-pagination.test.js
@@ -1,0 +1,49 @@
+/**
+ * Static invariant test for petdx-browser pagination (load-more).
+ * Card: card_6e21220bbf406675e7992790 (Hank 2026-06-12 — browser showed only the
+ * first 60 companions with no paging).
+ *
+ * jest.config.js uses testEnvironment: 'node' (matching the portal static tests),
+ * so we lock the SOURCE surface. Runtime behaviour (append + reset) is covered by
+ * the prod E2E. /api/companion/list already supports page/limit/total — this is a
+ * pure front-end consumer fix.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const html = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'portal', 'petdx-browser.html'),
+    'utf8'
+);
+
+describe('petdx-browser pagination (load-more)', () => {
+    test('sends the page param to /api/companion/list', () => {
+        expect(html).toMatch(/q\.set\(\s*['"]page['"]\s*,\s*String\(currentPage\)\s*\)/);
+    });
+
+    test('loadList supports an append mode (page 1 reset vs next-page append)', () => {
+        expect(html).toMatch(/async function loadList\(\s*append\s*=\s*false\s*\)/);
+        // append path advances the page; reset path returns to 1
+        expect(html).toMatch(/currentPage\s*\+=\s*1/);
+        expect(html).toMatch(/currentPage\s*=\s*1/);
+    });
+
+    test('tracks loaded vs total and stops appending when exhausted', () => {
+        expect(html).toMatch(/loadedCount\s*\+=\s*items\.length/);
+        expect(html).toMatch(/totalCount\s*=\s*data\.total/);
+        expect(html).toMatch(/loadedCount\s*>=\s*totalCount/);
+    });
+
+    test('renders a load-more button wired to append, hidden when all shown', () => {
+        expect(html).toMatch(/className\s*=\s*['"]load-more-btn['"]/);
+        expect(html).toMatch(/\.load-more-btn\s*\{/); // CSS rule present
+        expect(html).toMatch(/addEventListener\(\s*['"]click['"]\s*,\s*\(\)\s*=>\s*loadList\(true\)\s*\)/);
+        expect(html).toMatch(/已顯示全部/);
+    });
+
+    test('guards against double-trigger while a load-more is in flight', () => {
+        expect(html).toMatch(/if\s*\(\s*loadingMore\s*\|\|\s*loadedCount\s*>=\s*totalCount\s*\)\s*return/);
+    });
+});

--- a/backend/tests/jest/showConfirm-scroll-lock.test.js
+++ b/backend/tests/jest/showConfirm-scroll-lock.test.js
@@ -20,16 +20,21 @@ const apiJs = fs.readFileSync(
 );
 
 describe('modal body scroll-lock (showConfirm / showPrompt)', () => {
-    test('defines a ref-counted lock helper that sets body overflow hidden', () => {
+    test('lock helper uses position:fixed + top:-scrollY (blocks programmatic scroll too)', () => {
         expect(apiJs).toMatch(/function\s+_eclawLockBodyScroll\s*\(/);
-        expect(apiJs).toMatch(/document\.body\.style\.overflow\s*=\s*['"]hidden['"]/);
+        expect(apiJs).toMatch(/\.overflow\s*=\s*['"]hidden['"]/);
+        expect(apiJs).toMatch(/\.position\s*=\s*['"]fixed['"]/);
+        expect(apiJs).toMatch(/\.top\s*=\s*[`'"]-\$\{?_eclawLockedScrollY/);
+        expect(apiJs).toMatch(/_eclawLockedScrollY\s*=\s*window\.scrollY/);
         // ref count so stacked dialogs don't unlock prematurely
         expect(apiJs).toMatch(/_eclawScrollLockCount\s*\+\+/);
     });
 
-    test('defines an unlock helper that restores the prior overflow on the last close', () => {
+    test('unlock helper restores saved inline styles AND the pre-lock scroll position', () => {
         expect(apiJs).toMatch(/function\s+_eclawUnlockBodyScroll\s*\(/);
-        expect(apiJs).toMatch(/document\.body\.style\.overflow\s*=\s*_eclawPrevBodyOverflow/);
+        expect(apiJs).toMatch(/b\.overflow\s*=\s*_eclawPrevBody\.overflow/);
+        expect(apiJs).toMatch(/b\.position\s*=\s*_eclawPrevBody\.position/);
+        expect(apiJs).toMatch(/window\.scrollTo\(0,\s*_eclawLockedScrollY\)/);
         expect(apiJs).toMatch(/_eclawScrollLockCount\s*--/);
     });
 


### PR DESCRIPTION
## Problem (card_3462117951fa588df9ff8a95, P0)
Hank 06/12: 用智慧引用（↩ canvas 引用）回覆 #6 訊息時，自動勾選傳送者沒作用，連續多則誤送給 #1。

## Root cause
Two defects in chat.html quote-receiver auto-select:
1. **Additive, not exclusive.** `applyAutoToggleReceivers` only *checked* the quoted sender's checkbox; it never cleared the residual/default set. The target bar defaults to **all entities checked** (`isChecked … : true`), and #1 is the first bound entity — so a quote of #6 left #1 still checked and the reply leaked to #1.
2. **Native/canvas path dropped meta entirely.** `eclawHandleNativeNavigateIntent` called `quoteToChat(source,title,excerpt)` with **no 4th `meta` arg** → `applyAutoToggleReceivers(undefined)` bailed → nothing auto-selected, recipient = residual #1.

Regression origin: smart-quote inline preview (card_d999b966) added the canvas quote path without carrying the sender.

## Fix
- `applyAutoToggleReceivers` is now **exclusive**: clears every entity + contact checkbox, then checks only the quoted sender(s). If no quoted sender is bound on this device it **bails without wiping** (never leaves an unsendable blank bar).
- New `receiverMetaFromMessageId(messageId)` derives `{kind:'chat-entity',entityId}` from the already-loaded deep-linked message. Wired into the native nav-intent path **and** as a fallback for the localStorage / postMessage pickups when a producer omits `meta`.

## Test plan
`backend/tests/jest/chat-quote-smart-receiver.test.js` — **32/32 pass** (+4 new):
- residual #1 cleared when quoting #5
- unbound sender → existing selection preserved
- native nav-intent derives meta contract
- exclusive entity+contact clear contract

Broader chat suites (targets-static, quote-photo) green: 38/38.

## Evidence
prod screenshots (desktop 1280x800 + mobile 390x844) to follow post-deploy on the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)