### PR TITLE
[codex] Fix Android Play media permissions

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 98
-        versionName = "1.0.90"
+        versionCode = 99
+        versionName = "1.0.91"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,9 +11,7 @@
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
-    <!-- Photo picker for custom wallpaper background -->
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <!-- Media selection uses Android picker contracts, which grant access to selected URIs. -->
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.CAMERA" />
     <!-- Push notifications (required for Android 13+ / API 33+) -->

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -956,7 +956,6 @@ GPS: عند الطلب فقط، بلا تتبع في الخلفية، تُفقد
     <string name="channel_api_manage_all">إدارة جميع المفاتيح →</string>
     <string name="facebook_app_id">772387505935344</string>
     <string name="facebook_client_token">139b350cf525d7785d370b1813e77838</string>
-    <string name="fb_login_protocol_scheme">fb772387505935344</string>
     <string name="google_server_client_id">857252321032-3e8ajfc30up4957l8lqns562dee7ll72.apps.googleusercontent.com</string>
 
     <string name="tool_status_analyzing">جاري تشغيل التحليل…</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -955,7 +955,6 @@ Bei Fragen kontaktieren Sie uns über unsere offizielle E-Mail.
     <string name="channel_api_manage_all">Alle Schlüssel verwalten →</string>
     <string name="facebook_app_id">772387505935344</string>
     <string name="facebook_client_token">139b350cf525d7785d370b1813e77838</string>
-    <string name="fb_login_protocol_scheme">fb772387505935344</string>
     <string name="google_server_client_id">857252321032-3e8ajfc30up4957l8lqns562dee7ll72.apps.googleusercontent.com</string>
 
     <string name="tool_status_analyzing">Analyse wird ausgeführt…</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -878,7 +878,6 @@ Tu suscripción permanece activa y puedes reenlazar en cualquier momento (sujeto
     <string name="channel_api_manage_all">Administrar todas las claves →</string>
     <string name="facebook_app_id">772387505935344</string>
     <string name="facebook_client_token">139b350cf525d7785d370b1813e77838</string>
-    <string name="fb_login_protocol_scheme">fb772387505935344</string>
     <string name="google_server_client_id">857252321032-3e8ajfc30up4957l8lqns562dee7ll72.apps.googleusercontent.com</string>
 
     <string name="tool_status_analyzing">Ejecutando análisis…</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -955,7 +955,6 @@ Si vous avez des questions, contactez-nous via notre e-mail officiel.
     <string name="channel_api_manage_all">Gérer toutes les clés →</string>
     <string name="facebook_app_id">772387505935344</string>
     <string name="facebook_client_token">139b350cf525d7785d370b1813e77838</string>
-    <string name="fb_login_protocol_scheme">fb772387505935344</string>
     <string name="google_server_client_id">857252321032-3e8ajfc30up4957l8lqns562dee7ll72.apps.googleusercontent.com</string>
 
     <string name="tool_status_analyzing">Analyse en cours…</string>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -963,7 +963,6 @@ GPS: केवल अनुरोध पर, कोई बैकग्राउ�
     <string name="channel_api_manage_all">सभी कुंजी प्रबंधित करें →</string>
     <string name="facebook_app_id">772387505935344</string>
     <string name="facebook_client_token">139b350cf525d7785d370b1813e77838</string>
-    <string name="fb_login_protocol_scheme">fb772387505935344</string>
     <string name="google_server_client_id">857252321032-3e8ajfc30up4957l8lqns562dee7ll72.apps.googleusercontent.com</string>
 
     <string name="tool_status_analyzing">विश्लेषण चल रहा है…</string>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -302,7 +302,6 @@
     <string name="facebook_client_token">139b350cf525d7785d370b1813e77838</string>
     <string name="failed_add_slot">Gagal menambahkan slot</string>
     <string name="failed_format">Gagal: %s</string>
-    <string name="fb_login_protocol_scheme">fb772387505935344</string>
     <string name="fcm_channel_chat_desc">Pesan dari entitas Anda</string>
     <string name="fcm_channel_chat_name">Pesan obrolan</string>
     <string name="fcm_channel_feedback_desc">Pembaruan status masukan</string>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -858,7 +858,6 @@ Jika ada pertanyaan, silakan hubungi kami melalui email resmi kami.
     <string name="channel_api_manage_all">Kelola Semua Kunci →</string>
     <string name="facebook_app_id">772387505935344</string>
     <string name="facebook_client_token">139b350cf525d7785d370b1813e77838</string>
-    <string name="fb_login_protocol_scheme">fb772387505935344</string>
     <string name="google_server_client_id">857252321032-3e8ajfc30up4957l8lqns562dee7ll72.apps.googleusercontent.com</string>
 
     <string name="tool_status_analyzing">Menjalankan analisis…</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -480,7 +480,6 @@
     <string name="connected_accounts">Conti collegati</string>
     <string name="facebook_app_id">772387505935344</string>
     <string name="facebook_client_token">139b350cf525d7785d370b1813e77838</string>
-    <string name="fb_login_protocol_scheme">fb772387505935344</string>
     <string name="google_server_client_id">857252321032-3e8ajfc30up4957l8lqns562dee7ll72.apps.googleusercontent.com</string>
     <string name="account_login">Accesso all\'account</string>
     <string name="account_login_hint">Accedi con l\'e-mail associata per ripristinare i dati del dispositivo dopo la reinstallazione.</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -851,7 +851,6 @@ GPS：オンデマンドのみ、バックグラウンド追跡なし、サー�
     <string name="channel_api_manage_all">すべてのキーを管理 →</string>
     <string name="facebook_app_id">772387505935344</string>
     <string name="facebook_client_token">139b350cf525d7785d370b1813e77838</string>
-    <string name="fb_login_protocol_scheme">fb772387505935344</string>
     <string name="google_server_client_id">857252321032-3e8ajfc30up4957l8lqns562dee7ll72.apps.googleusercontent.com</string>
 
     <string name="tool_status_analyzing">分析を実行中…</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -851,7 +851,6 @@ GPS: 온디맨드만, 백그라운드 추적 없음, 서버 재시작 시 데이
     <string name="channel_api_manage_all">모든 키 관리 →</string>
     <string name="facebook_app_id">772387505935344</string>
     <string name="facebook_client_token">139b350cf525d7785d370b1813e77838</string>
-    <string name="fb_login_protocol_scheme">fb772387505935344</string>
     <string name="google_server_client_id">857252321032-3e8ajfc30up4957l8lqns562dee7ll72.apps.googleusercontent.com</string>
 
     <string name="tool_status_analyzing">분석 실행 중…</string>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -963,7 +963,6 @@ Jika anda mempunyai sebarang soalan, sila hubungi kami melalui e-mel rasmi kami.
     <string name="channel_api_manage_all">Urus Semua Kunci →</string>
     <string name="facebook_app_id">772387505935344</string>
     <string name="facebook_client_token">139b350cf525d7785d370b1813e77838</string>
-    <string name="fb_login_protocol_scheme">fb772387505935344</string>
     <string name="google_server_client_id">857252321032-3e8ajfc30up4957l8lqns562dee7ll72.apps.googleusercontent.com</string>
 
     <string name="tool_status_analyzing">Menjalankan analisis…</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -480,7 +480,6 @@
     <string name="connected_accounts">Contas conectadas</string>
     <string name="facebook_app_id">772387505935344</string>
     <string name="facebook_client_token">139b350cf525d7785d370b1813e77838</string>
-    <string name="fb_login_protocol_scheme">fb772387505935344</string>
     <string name="google_server_client_id">857252321032-3e8ajfc30up4957l8lqns562dee7ll72.apps.googleusercontent.com</string>
     <string name="account_login">Login da conta</string>
     <string name="account_login_hint">Faça login com seu e-mail vinculado para restaurar os dados do dispositivo após a reinstalação.</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -480,7 +480,6 @@
     <string name="connected_accounts">Подключенные аккаунты</string>
     <string name="facebook_app_id">772387505935344</string>
     <string name="facebook_client_token">139b350cf525d7785d370b1813e77838</string>
-    <string name="fb_login_protocol_scheme">fb772387505935344</string>
     <string name="google_server_client_id">857252321032-3e8ajfc30up4957l8lqns562dee7ll72.apps.googleusercontent.com</string>
     <string name="account_login">Вход в аккаунт</string>
     <string name="account_login_hint">Войдите в систему, используя привязанный адрес электронной почты, чтобы восстановить данные устройства после переустановки.</string>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -850,7 +850,6 @@ GPS：รับตามความต้องการเท่านั้�
     <string name="channel_api_manage_all">จัดการคีย์ทั้งหมด →</string>
     <string name="facebook_app_id">772387505935344</string>
     <string name="facebook_client_token">139b350cf525d7785d370b1813e77838</string>
-    <string name="fb_login_protocol_scheme">fb772387505935344</string>
     <string name="google_server_client_id">857252321032-3e8ajfc30up4957l8lqns562dee7ll72.apps.googleusercontent.com</string>
 
     <string name="tool_status_analyzing">กำลังวิเคราะห์…</string>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -850,7 +850,6 @@ Nếu có bất kỳ câu hỏi nào, vui lòng liên hệ với chúng tôi qua
     <string name="channel_api_manage_all">Quản lý tất cả khóa →</string>
     <string name="facebook_app_id">772387505935344</string>
     <string name="facebook_client_token">139b350cf525d7785d370b1813e77838</string>
-    <string name="fb_login_protocol_scheme">fb772387505935344</string>
     <string name="google_server_client_id">857252321032-3e8ajfc30up4957l8lqns562dee7ll72.apps.googleusercontent.com</string>
 
     <string name="tool_status_analyzing">Đang phân tích…</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -853,7 +853,6 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="channel_api_manage_all">管理所有密钥 →</string>
     <string name="facebook_app_id">772387505935344</string>
     <string name="facebook_client_token">139b350cf525d7785d370b1813e77838</string>
-    <string name="fb_login_protocol_scheme">fb772387505935344</string>
     <string name="google_server_client_id">857252321032-3e8ajfc30up4957l8lqns562dee7ll72.apps.googleusercontent.com</string>
 
     <string name="tool_status_analyzing">正在运行分析…</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -863,7 +863,6 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="close">關閉</string>    <string name="channel_api_manage_all">管理所有金鑰 →</string>
     <string name="facebook_app_id">772387505935344</string>
     <string name="facebook_client_token">139b350cf525d7785d370b1813e77838</string>
-    <string name="fb_login_protocol_scheme">fb772387505935344</string>
     <string name="google_server_client_id">857252321032-3e8ajfc30up4957l8lqns562dee7ll72.apps.googleusercontent.com</string>
 
     <string name="tool_status_analyzing">正在執行分析…</string>

--- a/app/src/test/java/com/hank/clawlive/AndroidManifestMediaPermissionTest.kt
+++ b/app/src/test/java/com/hank/clawlive/AndroidManifestMediaPermissionTest.kt
@@ -1,0 +1,59 @@
+package com.hank.clawlive
+
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.w3c.dom.Element
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+class AndroidManifestMediaPermissionTest {
+
+    @Test
+    fun manifestDoesNotRequestBroadPhotoOrVideoLibraryAccess() {
+        val declaredPermissions = readManifestPermissions()
+        val disallowedPermissions = setOf(
+            "android.permission.READ_MEDIA_IMAGES",
+            "android.permission.READ_MEDIA_VIDEO",
+            "android.permission.READ_EXTERNAL_STORAGE",
+            "android.permission.WRITE_EXTERNAL_STORAGE"
+        )
+
+        val declaredDisallowedPermissions = declaredPermissions.intersect(disallowedPermissions)
+        assertTrue(
+            "Use Android picker URI grants instead of broad media/storage permissions: $declaredDisallowedPermissions",
+            declaredDisallowedPermissions.isEmpty()
+        )
+    }
+
+    private fun readManifestPermissions(): Set<String> {
+        val manifest = locateManifest()
+        val documentBuilderFactory = DocumentBuilderFactory.newInstance().apply {
+            isNamespaceAware = true
+        }
+        val document = documentBuilderFactory.newDocumentBuilder().parse(manifest)
+        val nodes = document.getElementsByTagName("uses-permission")
+
+        return (0 until nodes.length)
+            .mapNotNull { index ->
+                val element = nodes.item(index) as? Element ?: return@mapNotNull null
+                element.getAttributeNS(ANDROID_NAMESPACE, "name")
+                    .takeIf { it.isNotBlank() }
+                    ?: element.getAttribute("android:name").takeIf { it.isNotBlank() }
+            }
+            .toSet()
+    }
+
+    private fun locateManifest(): File {
+        val candidates = listOf(
+            File("src/main/AndroidManifest.xml"),
+            File("app/src/main/AndroidManifest.xml")
+        )
+
+        return candidates.firstOrNull { it.isFile }
+            ?: error("Could not locate AndroidManifest.xml from ${File(".").absolutePath}")
+    }
+
+    private companion object {
+        private const val ANDROID_NAMESPACE = "http://schemas.android.com/apk/res/android"
+    }
+}


### PR DESCRIPTION
## Summary
- remove broad Android media/storage permissions that block Google Play review for the production release
- bump Android app to versionCode 99 / versionName 1.0.91 so a fixed AAB can replace the pending 1.0.90 artifact
- add a unit test that prevents READ_MEDIA_IMAGES, READ_MEDIA_VIDEO, READ_EXTERNAL_STORAGE, and WRITE_EXTERNAL_STORAGE from returning to the manifest
- remove localized Facebook protocol-scheme overrides so release lint no longer reports ManifestResource for the manifest data scheme

## Why
Google Play Console blocks the current production pending change with an improper photo/video permissions issue. The app already uses Android picker contracts for user-selected media, so it does not need broad media library access.

## Validation
- ./gradlew :app:testDebugUnitTest --tests com.hank.clawlive.AndroidManifestMediaPermissionTest :app:lintDebug :app:bundleRelease --no-daemon
- checked release merged/packaged manifests for absence of broad media/storage permissions
- built signed release AAB at app/build/outputs/bundle/release/app-release.aab
