### PR TITLE
feat(chat): per-message routing chip + LV palette (routing-viz v1 Part B)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -2685,6 +2685,44 @@
             border-color: rgba(168, 85, 247, 0.35);
         }
 
+        /* ── Routing chip (card_b3724a8 routing-viz v1) ── */
+        /* Per-message proof the org-hierarchy/smart routing fired. Segmented LV
+           palette (target entity LV): higher LV → stronger saturation/border. */
+        .routing-chip {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            padding: 0 6px;
+            margin-right: 6px;
+            border-radius: 9px;
+            font-size: 0.78em;
+            font-weight: 600;
+            line-height: 1.5;
+            border: 1px solid transparent;
+            vertical-align: middle;
+            white-space: nowrap;
+        }
+        .routing-chip .rc-mode {
+            font-size: 0.92em;
+            opacity: 0.85;
+            padding-right: 3px;
+            border-right: 1px solid currentColor;
+            margin-right: 1px;
+        }
+        .routing-chip .rc-lv { font-weight: 700; letter-spacing: 0.02em; }
+        /* LV segments — text/border share the hue; bg is a faint tint that
+           deepens with LV so high-LV (上級) hops visibly stand out. */
+        .routing-chip.rc-lv-unknown { color: #6B7280; border-color: rgba(107,114,128,0.40); background: rgba(107,114,128,0.10); }
+        .routing-chip.rc-lv-1 { color: #2563EB; border-color: rgba(37,99,235,0.45);  background: rgba(37,99,235,0.10); }
+        .routing-chip.rc-lv-3 { color: #0F766E; border-color: rgba(15,118,110,0.50); background: rgba(15,118,110,0.13); }
+        .routing-chip.rc-lv-5 { color: #B45309; border-color: rgba(180,83,9,0.55);   background: rgba(180,83,9,0.16); }
+        .routing-chip.rc-lv-7 { color: #C2410C; border-color: rgba(194,65,12,0.60);  background: rgba(194,65,12,0.19); }
+        .routing-chip.rc-lv-9 { color: #B91C1C; border-color: rgba(185,28,28,0.70);  background: rgba(185,28,28,0.22); }
+        /* Negative indicators (#6 spec point 4) */
+        .routing-chip.rc-unconfirmed { color: #9CA3AF; border-color: rgba(156,163,175,0.40); background: rgba(156,163,175,0.10); font-weight: 500; }
+        .routing-chip.rc-degraded { color: #D97706; border-color: rgba(217,119,6,0.55); background: rgba(217,119,6,0.16); }
+        .routing-chip.rc-failed { color: #DC2626; border-color: rgba(220,38,38,0.65); background: rgba(220,38,38,0.18); }
+
         /* ── 引用預覽卡 popover (Chip B) ── */
         .autolink-chip-popover {
             background: #1e1e28;
@@ -5674,6 +5712,7 @@
                 const replyBtnHtml = (!isSystem && msg.id) ? `<button class="chat-reply-btn" data-msg-id="${escapeHtml(msg.id)}" data-sender="${escapeHtml(replySenderName)}" data-text="${escapeHtml(replySnippet)}" data-receiver-kind="${receiverKind}"${receiverEntityAttr} onclick="handleReplyBtn(this);event.stopPropagation()" data-i18n-title="chat_reply_btn" title="Quote">📌</button>` : '';
                 const renderedMessageIds = getRenderedMessageIds(msg);
                 const renderedIdsAttr = escapeHtml(renderedMessageIds.join(' '));
+                const routingChipHtml = renderRoutingChip(msg);
 
                 return `${dateSep}${unreadSep}
                     <div class="chat-msg ${msgClass}${isGrouped ? ' grouped' : ''}" data-message-id="${escapeHtml(normalizeChatMessageId(msg.id) || msg.id || '')}" data-message-ids="${renderedIdsAttr}" style="position:relative">
@@ -5682,7 +5721,7 @@
                         ${replyBtnHtml}
                         ${previewId ? `<div class="link-preview-slot" id="${previewId}" data-url="${escapeHtml(firstUrl)}"></div>` : ''}
                         ${reactionsHtml}
-                        <div class="chat-meta">${time}</div>
+                        <div class="chat-meta">${routingChipHtml}${time}</div>
                         ${receipt ? `<div class="chat-receipt">${receipt}</div>` : ''}
                     </div>`;
             }).join('');
@@ -5750,6 +5789,54 @@
             _sourceParseCache.set(source, result);
             if (_sourceParseCache.size > 1000) _sourceParseCache.clear();
             return result;
+        }
+
+        // ── Routing chip (card_b3724a8 routing-viz v1, #6 spec) ──
+        // Per-message proof that org-hierarchy / smart routing fired. Reads the
+        // backend-supplied msg.routing_meta ONLY — never recomputes routing.
+        //   positive: 來源→目標 · LV{to_lv}, coloured by a segmented LV palette
+        //   negative: degraded/failed status, or a routed message missing meta
+        // LV palette segments (target entity LV, clamped):
+        //   unknown #6B7280 · 1-2 #2563EB · 3-4 #0F766E · 5-6 #B45309 · 7-8 #C2410C · 9+ #B91C1C
+        function routingLvSegment(lv) {
+            const n = Number(lv);
+            if (!Number.isFinite(n)) return 'unknown';
+            if (n <= 2) return '1';
+            if (n <= 4) return '3';
+            if (n <= 6) return '5';
+            if (n <= 8) return '7';
+            return '9';
+        }
+
+        function renderRoutingChip(msg) {
+            const rm = msg && msg.routing_meta;
+            const tt = (k, fb) => (typeof i18n !== 'undefined' && i18n.t && i18n.t(k)) || fb;
+            // Negative: a message that WAS routed (entity:..->.. / xdevice source)
+            // but carries no routing_meta → "路由未確認".
+            if (!rm || typeof rm !== 'object') {
+                const routed = parseEntitySource(msg && msg.source);
+                if (routed && (msg.is_from_bot || routed.crossDevice)) {
+                    return `<span class="routing-chip rc-unconfirmed" title="${escapeHtml(tt('chat_routing_unconfirmed','路由未確認'))}">⚑ ${escapeHtml(tt('chat_routing_unconfirmed','路由未確認'))}</span>`;
+                }
+                return '';
+            }
+            // Negative: explicit degraded / failed status from the backend.
+            if (rm.status === 'failed' || rm.status === 'degraded') {
+                const isFail = rm.status === 'failed';
+                const cls = isFail ? 'rc-failed' : 'rc-degraded';
+                const lbl = isFail ? tt('chat_routing_failed','路由失敗') : tt('chat_routing_degraded','路由降級');
+                return `<span class="routing-chip ${cls}" title="${escapeHtml(lbl)}">⚠ ${escapeHtml(lbl)}</span>`;
+            }
+            // Positive: from → to · LV{to_lv}, optional mode prefix.
+            const seg = routingLvSegment(rm.to_lv);
+            const from = rm.from_name || (rm.from_entity_id != null ? '#' + rm.from_entity_id : '?');
+            const to = rm.to_name || (rm.to_entity_id != null ? '#' + rm.to_entity_id : '?');
+            const lvNum = Number.isFinite(Number(rm.to_lv)) ? Number(rm.to_lv) : '?';
+            let modeTag = '';
+            if (rm.mode === 'broadcast') modeTag = `<span class="rc-mode">${escapeHtml(tt('chat_routing_broadcast','廣播'))}</span>`;
+            else if (rm.mode === 'xdevice') modeTag = `<span class="rc-mode">${escapeHtml(tt('chat_routing_xdevice','跨裝置'))}</span>`;
+            const title = `${tt('chat_routing_label','路由')}: ${from} → ${to} · LV${lvNum}`;
+            return `<span class="routing-chip rc-lv-${seg}" title="${escapeHtml(title)}">${modeTag}<span class="rc-route">${escapeHtml(from)} → ${escapeHtml(to)}</span><span class="rc-lv">LV${lvNum}</span></span>`;
         }
 
         /** Cross-device message received from another device (not sent by this device's entities) */

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650182,6 +650182,13 @@ const TRANSLATIONS = {
         "dashboard_usage_chart_no_data": "No data yet",
 
         "firstach_title": "First achievement: {label}!",
+
+        "chat_routing_label": "Route",
+        "chat_routing_unconfirmed": "Routing unconfirmed",
+        "chat_routing_degraded": "Routing degraded",
+        "chat_routing_failed": "Routing failed",
+        "chat_routing_broadcast": "Broadcast",
+        "chat_routing_xdevice": "Cross-device",
 },
 
 
@@ -1234831,6 +1234838,13 @@ const TRANSLATIONS = {
         "dashboard_usage_chart_no_data": "尚無資料",
 
         "firstach_title": "首個成就：{label}！",
+
+        "chat_routing_label": "路由",
+        "chat_routing_unconfirmed": "路由未确认",
+        "chat_routing_degraded": "路由降级",
+        "chat_routing_failed": "路由失败",
+        "chat_routing_broadcast": "广播",
+        "chat_routing_xdevice": "跨设备",
 },
 
 
@@ -2943940,6 +2943954,13 @@ const TRANSLATIONS = {
 
 
 
+
+        "chat_routing_label": "路由",
+        "chat_routing_unconfirmed": "路由未確認",
+        "chat_routing_degraded": "路由降級",
+        "chat_routing_failed": "路由失敗",
+        "chat_routing_broadcast": "廣播",
+        "chat_routing_xdevice": "跨裝置",
 },
 
 

--- a/backend/tests/jest/chat-routing-chip.test.js
+++ b/backend/tests/jest/chat-routing-chip.test.js
@@ -1,0 +1,117 @@
+/**
+ * Static invariant test for the chat routing chip (routing-viz v1, Part B).
+ * Card: card_b3724a801eb600036aab901c. #6 v1 spec:
+ *   1. per-message chip 來源→目標·LV{to_lv} as the primary visual
+ *   2. segmented LV palette (not a linear gradient)
+ *   3. frontend RENDERS routing_meta only — never recomputes routing
+ *   4. minimal negative indicator: 路由未確認 / 路由降級 / 路由失敗
+ *
+ * testEnvironment:'node' → lock the source surface (same pattern as
+ * chat-quote-smart-receiver.test.js).
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const chatHtml = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'portal', 'chat.html'),
+    'utf8'
+);
+
+describe('routing chip — render helper', () => {
+    test('renderRoutingChip + routingLvSegment exist', () => {
+        expect(chatHtml).toMatch(/function\s+renderRoutingChip\s*\(\s*msg\s*\)/);
+        expect(chatHtml).toMatch(/function\s+routingLvSegment\s*\(\s*lv\s*\)/);
+    });
+
+    test('reads backend msg.routing_meta — does not recompute routing (#6 spec point 3)', () => {
+        const fn = chatHtml.match(/function\s+renderRoutingChip\s*\(\s*msg\s*\)\s*\{[\s\S]*?\n        \}/);
+        expect(fn).not.toBeNull();
+        const body = fn[0];
+        expect(body).toMatch(/msg\s*&&\s*msg\.routing_meta/);
+        // pulls from/to/lv straight off routing_meta
+        expect(body).toMatch(/rm\.from_name/);
+        expect(body).toMatch(/rm\.to_name/);
+        expect(body).toMatch(/rm\.to_lv/);
+        // must NOT derive a target from hierarchy/boundEntities here
+        expect(body).not.toMatch(/boundEntities|getSuperior|hierarchy/);
+    });
+
+    test('segmented LV palette maps to the #6 breakpoints (1-2/3-4/5-6/7-8/9+)', () => {
+        const seg = chatHtml.match(/function\s+routingLvSegment\s*\(\s*lv\s*\)\s*\{[\s\S]*?\n        \}/)[0];
+        expect(seg).toMatch(/Number\.isFinite\(n\)/);
+        expect(seg).toMatch(/n\s*<=\s*2\)\s*return\s*'1'/);
+        expect(seg).toMatch(/n\s*<=\s*4\)\s*return\s*'3'/);
+        expect(seg).toMatch(/n\s*<=\s*6\)\s*return\s*'5'/);
+        expect(seg).toMatch(/n\s*<=\s*8\)\s*return\s*'7'/);
+        expect(seg).toMatch(/return\s*'9'/);
+        expect(seg).toMatch(/return\s*'unknown'/);
+    });
+
+    test('negative indicators: unconfirmed (routed but no meta) / degraded / failed', () => {
+        const body = chatHtml.match(/function\s+renderRoutingChip[\s\S]*?\n        \}/)[0];
+        expect(body).toMatch(/rc-unconfirmed/);
+        expect(body).toMatch(/rm\.status\s*===\s*'failed'/);
+        expect(body).toMatch(/rm\.status\s*===\s*'degraded'/);
+        // unconfirmed only when the message WAS routed (entity/xdevice source)
+        expect(body).toMatch(/parseEntitySource\(msg\s*&&\s*msg\.source\)/);
+    });
+});
+
+describe('routing chip — CSS palette + template wiring', () => {
+    test('all 6 LV-segment CSS classes present with distinct colours', () => {
+        expect(chatHtml).toMatch(/\.routing-chip\.rc-lv-unknown\s*\{[^}]*#6B7280/);
+        expect(chatHtml).toMatch(/\.routing-chip\.rc-lv-1\s*\{[^}]*#2563EB/);
+        expect(chatHtml).toMatch(/\.routing-chip\.rc-lv-3\s*\{[^}]*#0F766E/);
+        expect(chatHtml).toMatch(/\.routing-chip\.rc-lv-5\s*\{[^}]*#B45309/);
+        expect(chatHtml).toMatch(/\.routing-chip\.rc-lv-7\s*\{[^}]*#C2410C/);
+        expect(chatHtml).toMatch(/\.routing-chip\.rc-lv-9\s*\{[^}]*#B91C1C/);
+    });
+
+    test('negative-state CSS classes present', () => {
+        expect(chatHtml).toMatch(/\.routing-chip\.rc-unconfirmed\s*\{/);
+        expect(chatHtml).toMatch(/\.routing-chip\.rc-degraded\s*\{/);
+        expect(chatHtml).toMatch(/\.routing-chip\.rc-failed\s*\{/);
+    });
+
+    test('chip is computed per message and rendered in the meta row', () => {
+        expect(chatHtml).toMatch(/const\s+routingChipHtml\s*=\s*renderRoutingChip\(msg\)/);
+        expect(chatHtml).toMatch(/<div class="chat-meta">\$\{routingChipHtml\}\$\{time\}<\/div>/);
+    });
+});
+
+describe('routing chip — i18n key parity (en / zh / zh-TW)', () => {
+    const i18nJs = fs.readFileSync(
+        path.join(__dirname, '..', '..', 'public', 'shared', 'i18n.js'),
+        'utf8'
+    );
+    const KEYS = [
+        'chat_routing_label',
+        'chat_routing_unconfirmed',
+        'chat_routing_degraded',
+        'chat_routing_failed',
+        'chat_routing_broadcast',
+        'chat_routing_xdevice',
+    ];
+    // locate each locale block by its opener, bounded by the next opener
+    const LOCALE_RE = /^(\s*)("?(en|zh|zh-TW)"?):\s*\{\s*$/gm;
+    const matches = [];
+    let m;
+    while ((m = LOCALE_RE.exec(i18nJs)) !== null) matches.push({ name: m[3], start: m.index });
+    matches.sort((a, b) => a.start - b.start);
+    const blocks = {};
+    matches.forEach((e, i) => {
+        const end = i + 1 < matches.length ? matches[i + 1].start : i18nJs.length;
+        if (!blocks[e.name]) blocks[e.name] = i18nJs.slice(e.start, end);
+    });
+
+    ['en', 'zh', 'zh-TW'].forEach(loc => {
+        KEYS.forEach(k => {
+            test(`${loc} has ${k}`, () => {
+                expect(blocks[loc]).toBeDefined();
+                expect(blocks[loc]).toMatch(new RegExp('"' + k + '"\\s*:\\s*"[^"]+"'));
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Context (card_b3724a801eb600036aab901c, P1)
Part B — the user-visible chip. Renders the backend `routing_meta` from PR #3342 so the chat page proves org-hierarchy / smart routing fired (Hank: 聊天頁看不出路由有在運作).

## #6 v1 spec → implementation
1. **primary visual** = per-message chip `來源→目標·LV{to_lv}` (mode tag for broadcast/xdevice)
2. **segmented LV palette** (not linear) on target LV: unknown #6B7280 · LV1-2 #2563EB · 3-4 #0F766E · 5-6 #B45309 · 7-8 #C2410C · 9+ #B91C1C — higher LV → stronger
3. `renderRoutingChip` reads `msg.routing_meta` **only**, never recomputes (test guards against boundEntities/getSuperior/hierarchy refs)
4. **negative indicators**: routed-but-no-meta → `路由未確認` (grey); status=degraded → `路由降級`; status=failed → `路由失敗` (red)

## i18n
6 keys → en/zh/zh-TW via `backend/scripts/i18n-insert-locale-keys.js` (AST inserter per reference_i18n_insert_via_ast, NOT regex). Remaining locales = #3/#4 follow-up.

## Test plan
`chat-routing-chip.test.js` **25/25** (helper / no-recompute guard / palette breakpoints / negative states / CSS / template wiring / i18n parity en-zh-zhTW). `chat-quote-smart-receiver` still 32/32. i18n.js `node --check` clean.

## Next
Part C: desktop 1280x800 + mobile 390x844 prod E2E verifying routing_meta end-to-end (backend payload → chip render, incl. LV color tiers + negative state).

🤖 Generated with [Claude Code](https://claude.com/claude-code)