### PR TITLE
feat(kanban): auto-inject Self-improvement section on POST /card

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -242,6 +242,20 @@ const PRIORITY_COLORS = { P0: '🔴', P1: '🟠', P2: '🔵', P3: '⚪' };
 // should ask a supervisor/reviewer/creator to reopen rather than drag Done cards.
 const REOPEN_SUPERVISOR_ENTITY_IDS = new Set([1, 2]);
 
+// Self-improvement (OODA-R) section auto-appended on every parent card created
+// via POST /card. Per Hank 2026-06-12 audit: every parent kanban automation card
+// must carry a retro slot so the loop closes. Skipped when description already
+// contains "Self-improvement" (idempotent + lets callers opt to write their own).
+const SI_TEMPLATE_SECTION = `
+
+## Self-improvement (OODA-R)
+- **Episode trigger**: <event that writes an episode — usually move-to-done or done-evidence>
+- **Pain taxonomy axis**: <axis from pain taxonomy / episode schema>
+- **Feedback ingest**: <signal flowing back into this card — cron output / child retro / chat upvote/downvote / kanban refire>
+- **Done-retro slot**: <one question to answer at close-out — "what guard/gate/template change would prevent recurrence?">
+- **Rule promotion candidate**: <if learning generalizes, name the meta-PR / lint rule / template diff>
+`;
+
 // ── Schema init ──
 async function initKanbanDatabase() {
     try {
@@ -916,6 +930,15 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             });
         }
 
+        // Auto-inject Self-improvement template if description doesn't already include it.
+        // Per Hank 2026-06-12: every parent kanban automation card must carry an OODA-R
+        // retro slot. POST /card only creates parent cards (cron-instance children INSERT
+        // directly without this path), so unconditional injection is safe.
+        const rawDesc = description || '';
+        const finalDescription = rawDesc.includes('Self-improvement')
+            ? rawDesc
+            : (rawDesc.trimEnd() + SI_TEMPLATE_SECTION);
+
         try {
             const result = await pool.query(
                 `INSERT INTO kanban_cards (id, device_id, title, description, priority, status, assigned_bots, created_by, reviewer_entity_id, status_changed_at,
@@ -925,7 +948,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                     $10, $11, $12, $13, $14, $15, $16, $17,
                     $18, $19::jsonb, $20)
                  RETURNING *`,
-                [newCardId(), deviceId, title.trim(), description || '', cardPriority, cardStatus, JSON.stringify(bots), createdBy, reviewer,
+                [newCardId(), deviceId, title.trim(), finalDescription, cardPriority, cardStatus, JSON.stringify(bots), createdBy, reviewer,
                     finalAutomation, schedEnabled, schedType, schedCron, schedRunAt, schedTz, schedNextRunAt, finalRequiresScreenshot,
                     anchorMsgId, anchorCoord ? JSON.stringify(anchorCoord) : null, finalDispatchMode]
             );

--- a/backend/tests/jest/kanban-card.test.js
+++ b/backend/tests/jest/kanban-card.test.js
@@ -136,6 +136,74 @@ describe('POST /card — assignedBots validation', () => {
         expect(JSON.parse(coordParam)).toEqual({ x: 142.5, y: -87.3 });
     });
 
+    // Self-improvement template auto-inject (Hank 2026-06-12 audit follow-up)
+    // — every parent card description gets a "## Self-improvement (OODA-R)" slot
+    // appended when missing; idempotent when caller already wrote one.
+    it('appends ## Self-improvement section to bot-filed card with empty description', async () => {
+        mockQuery.mockResolvedValueOnce({
+            rows: [{
+                id: 'si-1', device_id: 'test-dev', title: 'Bot card',
+                description: '', priority: 'P2', status: 'backlog',
+                assigned_bots: [0], created_by: 1,
+                created_at: new Date(), updated_at: new Date(),
+                status_changed_at: new Date(), archived: false,
+            }],
+        });
+        const res = await post('/api/mission/card')
+            .send({ ...AUTH, title: 'Bot card', assignedBots: [0], entityId: 1 });
+        expect(res.status).not.toBe(400);
+        const insertCall = mockQuery.mock.calls.find(c => /INSERT INTO kanban_cards/.test(c[0]));
+        expect(insertCall).toBeTruthy();
+        const descParam = insertCall[1][3];
+        expect(descParam).toMatch(/## Self-improvement \(OODA-R\)/);
+        expect(descParam).toMatch(/Episode trigger/);
+        expect(descParam).toMatch(/Rule promotion candidate/);
+    });
+
+    it('appends ## Self-improvement section while preserving caller description', async () => {
+        mockQuery.mockResolvedValueOnce({
+            rows: [{
+                id: 'si-2', device_id: 'test-dev', title: 'Has scope',
+                description: '## Scope\nDo the thing', priority: 'P2', status: 'backlog',
+                assigned_bots: [0], created_by: 1,
+                created_at: new Date(), updated_at: new Date(),
+                status_changed_at: new Date(), archived: false,
+            }],
+        });
+        const res = await post('/api/mission/card').send({
+            ...AUTH, title: 'Has scope', assignedBots: [0], entityId: 1,
+            description: '## Scope\nDo the thing',
+        });
+        expect(res.status).not.toBe(400);
+        const insertCall = mockQuery.mock.calls.find(c => /INSERT INTO kanban_cards/.test(c[0]));
+        const descParam = insertCall[1][3];
+        expect(descParam).toMatch(/^## Scope\nDo the thing/);
+        expect(descParam).toMatch(/## Self-improvement \(OODA-R\)/);
+    });
+
+    it('is idempotent — does not re-append when description already has Self-improvement', async () => {
+        const callerDesc = '## Scope\nFoo\n\n## Self-improvement\n- Episode trigger: custom one';
+        mockQuery.mockResolvedValueOnce({
+            rows: [{
+                id: 'si-3', device_id: 'test-dev', title: 'Has SI',
+                description: callerDesc, priority: 'P2', status: 'backlog',
+                assigned_bots: [0], created_by: 1,
+                created_at: new Date(), updated_at: new Date(),
+                status_changed_at: new Date(), archived: false,
+            }],
+        });
+        const res = await post('/api/mission/card').send({
+            ...AUTH, title: 'Has SI', assignedBots: [0], entityId: 1,
+            description: callerDesc,
+        });
+        expect(res.status).not.toBe(400);
+        const insertCall = mockQuery.mock.calls.find(c => /INSERT INTO kanban_cards/.test(c[0]));
+        const descParam = insertCall[1][3];
+        expect(descParam).toBe(callerDesc);
+        // ensure the template's distinctive "(OODA-R)" qualifier was NOT appended
+        expect(descParam).not.toMatch(/## Self-improvement \(OODA-R\)/);
+    });
+
     it('ignores malformed chatAnchorCoord (NaN coords stored as null)', async () => {
         mockQuery.mockResolvedValueOnce({
             rows: [{


### PR DESCRIPTION
## Summary
- Wire missing **parent-card description layer** of the OODA-R Self-improvement framework. Transition-level hooks (preflight on in_progress / done-evidence on done) already live, but parent card descriptions were missing the explicit retro contract — audit found 45/59 (76%) parent kanban-automation cards had no SI section.
- POST `/card` now appends a canonical `## Self-improvement (OODA-R)` template when the caller's description doesn't already contain `Self-improvement`. Idempotent — caller-written SI sections pass through untouched.
- Only triggers on `POST /card` (parent creation); cron-instance children INSERT directly without this path so `[Auto]` noise is excluded by construction.

## Why
Hank 2026-06-12 22:21 TW audit: 「目前看板自動化每張母卡都要導入 Self-improvement 的概念 有做到嗎？」 — closes the "every parent card carries a retro slot" requirement so each card's OODA loop has a defined Reflect step at scoping time, not just an after-the-fact evidence dump.

Audit board: active in_progress parents that were missing SI before this PR (Phase D / OODA-R Phase 3 #8 / Phase 4 #9 / MessageLifecycle / UniversalAuth) — backfilled inline ahead of this PR on `card_125161f56080b...` / `card_42ffca0d29ce2...` / `card_5ac74610cbf1f...` / `card_438801589b275...` / `card_9a3649b0df8ab...`. Audit-driver card: `card_908d46799db38944263bd167`.

## Test plan
- [x] `npx jest backend/tests/jest/kanban-card.test.js` — **49 passed** including 3 new SI auto-inject cases:
  - appends SI section to bot-filed card with empty description
  - appends SI section while preserving caller-provided scope text
  - idempotent — does not re-append when description already has Self-improvement
- [x] `node -c backend/kanban.js` — parse OK
- [x] Manual: 5 active in_progress parent cards backfilled via `PUT /api/mission/card/:id` (description); spot-checked via kanban nudge re-fire showing SI block in re-delivered task description

🤖 Generated with [Claude Code](https://claude.com/claude-code)