### PR TITLE
fix(usage): timeline endpoint reads nested rate_limits (Claude chart line was blank)

### DIFF
--- a/backend/tests/jest/usage-api-claude-live-pct.test.js
+++ b/backend/tests/jest/usage-api-claude-live-pct.test.js
@@ -1,0 +1,67 @@
+/**
+ * Backend usage-api pickClaudeLivePct helper — card_555a7d5f99fd5c6f1a28a169.
+ *
+ * The Claude statusLine hook writes nested
+ * `live.rate_limits.{five_hour,seven_day}.used_percentage`. Earlier code
+ * paths (live widget legacy + a few callers) also pass a flat
+ * `live.{five_hour,seven_day}_pct`. The timeline endpoint previously only
+ * read the flat form, so every Claude line in the SVG chart was empty
+ * whenever statusLine was the only producer. The helper now tolerates both
+ * shapes; these tests pin that contract.
+ */
+'use strict';
+
+const usageApi = require('../../usage-api');
+
+const { pickClaudeLivePct } = usageApi({}).router && usageApi({})._internal
+    ? usageApi({})._internal
+    : require('../../usage-api')({})._internal;
+
+describe('pickClaudeLivePct — read both nested and flat shapes', () => {
+    test('returns null for null / undefined / non-dict input', () => {
+        expect(pickClaudeLivePct(null, 'five_hour')).toBeNull();
+        expect(pickClaudeLivePct(undefined, 'five_hour')).toBeNull();
+        expect(pickClaudeLivePct({}, 'five_hour')).toBeNull();
+    });
+
+    test('flat shape — live.five_hour_pct is read directly', () => {
+        const live = { five_hour_pct: 42, seven_day_pct: 73 };
+        expect(pickClaudeLivePct(live, 'five_hour')).toBe(42);
+        expect(pickClaudeLivePct(live, 'seven_day')).toBe(73);
+    });
+
+    test('nested shape — statusLine hook output (used_percentage) is read', () => {
+        const live = {
+            rate_limits: {
+                five_hour: { used_percentage: 4, resets_at: 1781295000 },
+                seven_day: { used_percentage: 48, resets_at: 1781704800 },
+            },
+        };
+        expect(pickClaudeLivePct(live, 'five_hour')).toBe(4);
+        expect(pickClaudeLivePct(live, 'seven_day')).toBe(48);
+    });
+
+    test('flat wins over nested when both present (legacy producer + new producer overlap)', () => {
+        const live = {
+            five_hour_pct: 12,
+            rate_limits: { five_hour: { used_percentage: 99 } },
+        };
+        expect(pickClaudeLivePct(live, 'five_hour')).toBe(12);
+    });
+
+    test('rejects non-number values gracefully', () => {
+        expect(pickClaudeLivePct({ five_hour_pct: 'oops' }, 'five_hour')).toBeNull();
+        expect(pickClaudeLivePct({ five_hour_pct: null }, 'five_hour')).toBeNull();
+        expect(pickClaudeLivePct({
+            rate_limits: { five_hour: { used_percentage: 'oops' } },
+        }, 'five_hour')).toBeNull();
+        expect(pickClaudeLivePct({ rate_limits: { five_hour: {} } }, 'five_hour')).toBeNull();
+    });
+
+    test('accepts zero (truthy-trap regression guard)', () => {
+        expect(pickClaudeLivePct({ five_hour_pct: 0 }, 'five_hour')).toBe(0);
+        expect(pickClaudeLivePct({
+            rate_limits: { five_hour: { used_percentage: 0 } },
+        }, 'five_hour')).toBe(0);
+    });
+});

--- a/backend/usage-api.js
+++ b/backend/usage-api.js
@@ -108,6 +108,28 @@ function authenticate(devices, { deviceId, deviceSecret, entityId, botSecret }) 
  * We surface a unified `sum_input_tokens` / `sum_output_tokens` / `sum_cost_usd`
  * regardless of which engine is being aggregated.
  */
+/**
+ * Read Claude rate-limit %s out of the `claude.live` blob the daemon stored.
+ *
+ * The Claude statusLine hook (~/.claude/usage-statusline.py) emits the
+ * **nested** shape — `live.rate_limits.{five_hour,seven_day}.used_percentage`
+ * — but earlier callers (including the live dashboard widget) used to also
+ * accept a **flat** `live.{five_hour,seven_day}_pct`. The widget already
+ * tolerates both; this helper keeps the timeline endpoint in lockstep so
+ * the SVG line chart isn't silently empty whenever the only available shape
+ * is nested. Returns null if neither shape carries a number.
+ *
+ * card_555a7d5f99fd5c6f1a28a169
+ */
+function pickClaudeLivePct(live, key) {
+    if (!live) return null;
+    const flatKey = key + '_pct';
+    if (typeof live[flatKey] === 'number') return live[flatKey];
+    const nested = live.rate_limits && live.rate_limits[key];
+    if (nested && typeof nested.used_percentage === 'number') return nested.used_percentage;
+    return null;
+}
+
 function sumEngineSessions(engineJson) {
     const sessions = Array.isArray(engineJson?.sessions) ? engineJson.sessions : [];
     let inputTokens = 0;
@@ -329,8 +351,8 @@ module.exports = function(devices) {
                     codex_total_tokens:  x.sum_input_tokens + x.sum_output_tokens,
                     claude_total_cost_usd: c.sum_cost_usd,
                     codex_total_cost_usd:  x.sum_cost_usd,
-                    claude_5h_pct: typeof claudeLive.five_hour_pct === 'number' ? claudeLive.five_hour_pct : null,
-                    claude_7d_pct: typeof claudeLive.seven_day_pct === 'number' ? claudeLive.seven_day_pct : null,
+                    claude_5h_pct: pickClaudeLivePct(claudeLive, 'five_hour'),
+                    claude_7d_pct: pickClaudeLivePct(claudeLive, 'seven_day'),
                     codex_5h_pct: typeof codexLimits.five_hour_pct === 'number' ? codexLimits.five_hour_pct : null,
                     codex_7d_pct: typeof codexLimits.seven_day_pct === 'number' ? codexLimits.seven_day_pct : null,
                 };
@@ -351,6 +373,6 @@ module.exports = function(devices) {
 
     return {
         router,
-        _internal: { authenticate, sumEngineSessions, aggregateOverRange, MAX_TIMELINE_HOURS, SNAPSHOT_BODY_LIMIT }
+        _internal: { authenticate, sumEngineSessions, aggregateOverRange, pickClaudeLivePct, MAX_TIMELINE_HOURS, SNAPSHOT_BODY_LIMIT }
     };
 };


### PR DESCRIPTION
## Summary
- `/api/usage/timeline` only read flat `live.{five_hour,seven_day}_pct` but `~/.claude/usage-statusline.py` emits the **nested** shape `live.rate_limits.{five_hour,seven_day}.used_percentage`. Result: production returned `claude_5h_pct=null/claude_7d_pct=null` on **1190/1190 points in the last 24h**, so the dashboard timeline modal's Claude SVG line never rendered.
- Codex %s populated normally because `codex_loader.py` emits flat keys directly.
- The live widget (`renderClaudeBars`) already tolerated both shapes — this brings the timeline endpoint into the same contract via a new `pickClaudeLivePct` helper.

## Why
Hank 2026-06-13 01:20 TW: 「Claude 用量波形圖沒顯示出來」. Confirmed via `curl /api/usage/timeline?hours=24` showing 0/1190 Claude points populated vs 1190/1190 for Codex. Read/write asymmetry — schema drift between two producers (statusLine hook + legacy flat path) where only one read path tolerated both.

card_555a7d5f99fd5c6f1a28a169

## Test plan
- [x] `npx jest backend/tests/jest/usage-api-claude-live-pct.test.js` — **6 pass** covering: null/undefined/empty input → null; flat shape; nested statusLine shape; flat-wins-over-nested precedence; non-number rejection; zero-accepted (truthy-trap guard).
- [x] `node -c backend/usage-api.js` — parse OK
- [x] Production verification deferred to post-merge Railway deploy: \`curl /api/usage/timeline?hours=24\` should return non-null \`claude_5h_pct\` on the most recent rows (statusLine hook fresh as of 01:23 TW writing \`used_percentage: 4\` for five_hour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)