### PR TITLE
fix(ci): ESLint window global + deeplink test qMeta param + sitemap dates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,7 +178,7 @@ EClaw/
 │   │   └── docs/
 │   │       └── webhook-troubleshooting.md
 │   ├── tests/                # Regression + integration tests (59 files)
-│   ├── tests/jest/           # Jest unit tests (268 files, CI-run via `npm test`)
+│   ├── tests/jest/           # Jest unit tests (285 files, CI-run via `npm test`)
 │   └── scripts/              # Setup scripts
 ├── app/                      # Android app (Kotlin)
 │   └── src/main/java/com/hank/clawlive/
@@ -1162,7 +1162,7 @@ curl "https://eclawbot.com/api/device-telemetry?deviceId=ID&deviceSecret=SECRET&
 
 ## Test Coverage Summary
 
-**~475 total API routes** across all modules (425 excluding Article Publisher), **~85% covered** by Jest + integration tests (~3747 test cases across 270 Jest files + 79 integration tests).
+**~475 total API routes** across all modules (425 excluding Article Publisher), **~85% covered** by Jest + integration tests (~3969 test cases across 285 Jest files + 79 integration tests).
 
 | Module | Coverage | Notes |
 |--------|----------|-------|
@@ -1255,7 +1255,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 | R2 Quota Rich Card | `node backend/tests/test-r2-quota-rich-card.js` | Device ID + Secret | R2 quota exceeded rich card E2E |
 | Subscription Plans Live | `node backend/tests/test-subscription-plans-live.js` | Device ID + Secret | Subscription plans + wallet live verification |
 
-### Jest Unit Tests (CI-run, `npm test`, 268 files)
+### Jest Unit Tests (CI-run, `npm test`, 285 files)
 
 | Test | File | Description |
 |------|------|-------------|
@@ -1338,7 +1338,7 @@ All test files are in `backend/tests/`. Run with `node backend/tests/<file>`.
 ### Running All Tests
 ```bash
 node backend/run_all_tests.js          # Run all tests sequentially
-cd backend && npm test                  # Jest unit tests (268 files)
+cd backend && npm test                  # Jest unit tests (285 files)
 cd backend && npm run lint              # ESLint
 ```
 

--- a/backend/public/sitemap.xml
+++ b/backend/public/sitemap.xml
@@ -2,67 +2,67 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://eclawbot.com/</loc>
-    <lastmod>2026-06-12</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/portal/</loc>
-    <lastmod>2026-06-12</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/api/docs</loc>
-    <lastmod>2026-06-12</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.7</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/.well-known/agent.json</loc>
-    <lastmod>2026-06-12</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/enterprise</loc>
-    <lastmod>2026-06-12</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/privacy-policy.html</loc>
-    <lastmod>2026-06-12</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/llms.txt</loc>
-    <lastmod>2026-06-12</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/arena/</loc>
-    <lastmod>2026-06-12</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/portal/community.html</loc>
-    <lastmod>2026-06-12</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/promo.html</loc>
-    <lastmod>2026-06-12</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://eclawbot.com/promo-meta.html</loc>
-    <lastmod>2026-06-12</lastmod>
+    <lastmod>2026-06-13</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/backend/shared/route-registry.js
+++ b/backend/shared/route-registry.js
@@ -1,3 +1,4 @@
+/* global window */
 /**
  * Canonical route registry — docs/redirect-state-machine-spec.md §2.
  * Card: card_14571f26914b9c1eae148362 (OODA-R Phase 2 #7, Phase A).

--- a/backend/tests/jest/chat-kanban-message-deeplink-static.test.js
+++ b/backend/tests/jest/chat-kanban-message-deeplink-static.test.js
@@ -41,7 +41,7 @@ describe('chat message deep-link plumbing', () => {
         expect(chatHtml).not.toContain('prefillInput, messageId, meta, ts } = JSON.parse(pq)');
         expect(chatHtml).toContain('await openChatMessageDeepLink(messageId, { showMissingToast: true, scroll: true });');
         expect(chatHtml).toContain('const msgId = intent.messageId || quote.messageId');
-        expect(chatHtml).toContain("quoteToChat(quote.source || '引用', quote.title || '', quote.excerpt || '');");
+        expect(chatHtml).toContain("quoteToChat(quote.source || '引用', quote.title || '', quote.excerpt || '', qMeta);");
     });
 
     test('native WebView fallback uses canonical messageId query', () => {


### PR DESCRIPTION
## Summary
- Fix ESLint `no-undef: window` in `route-registry.js` (UMD dual-env file needs `/* global window */`)
- Fix `chat-kanban-message-deeplink-static.test.js` — `quoteToChat()` now takes 4th param `qMeta`
- Update CLAUDE.md test counts: 285 suites / 3969 tests
- Sitemap `lastmod` → 2026-06-13

## Test plan
- [x] `npm run lint` — 0 errors (3 pre-existing warnings)
- [x] `npm test` — 285 suites, 3969 tests pass
- [x] `node scripts/i18n-check.js` — all keys resolve

## Code Review Checklist
✅ Logic trace: ESLint global declaration + test string alignment
✅ Test coverage: deeplink test updated
✅ Return shape: N/A (no API changes)
✅ What this does NOT fix: pre-existing warnings in companion-api.js, index.js, kanban.js
✅ Security: no security implications
⚠️ NO-OP /api/help update
⚠️ NO-OP related docs
⚠️ NO-OP i18n audit (no UI changes)
⚠️ NO-OP info page
⚠️ NO-OP debug endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)