### PR TITLE
diag(rental): audit-log Pg error details in rentalRoute catch [P0/UI]

### DIFF
--- a/backend/rental.js
+++ b/backend/rental.js
@@ -1783,6 +1783,27 @@ module.exports = function rentalFactory({ authMiddleware, softAuthMiddleware, ad
                     return res.status(code).json(body);
                 }
                 console.error('[Rental] handler error:', err);
+                // P0 card_68242d883b51c3b6ceda09cb: surface Pg-level details to
+                // audit log so internal_error responses can be diagnosed from
+                // /api/logs?category=rental&level=error without Railway stdout.
+                try {
+                    audit('error', 'rental', `handler error ${req.method} ${req.originalUrl || req.path}: ${err.message || 'unknown'}`, {
+                        userId: req.user?.userId,
+                        action: 'handler_error',
+                        resource: req.originalUrl || req.path,
+                        result: 'failure',
+                        metadata: {
+                            errMessage: err.message || null,
+                            errCode: err.code || null,
+                            errConstraint: err.constraint || null,
+                            errDetail: err.detail || null,
+                            errTable: err.table || null,
+                            errColumn: err.column || null,
+                            errRoutine: err.routine || null,
+                            errStackHead: (err.stack || '').split('\n').slice(0, 3).join(' | '),
+                        },
+                    });
+                } catch (_) { /* never let audit failure cascade */ }
                 res.status(500).json({ success: false, error: 'internal_error' });
             }
         };


### PR DESCRIPTION
## Summary
- P0 card_68242d883b51c3b6ceda09cb: 執行面試 (`POST /api/rental/listing`) returns 500 `internal_error` for every entity except the legacy Mac_F row from April. Wrapper at rental.js:1786 swallowed the Pg error into `console.error` only.
- This patch teaches the catch to also write `err.message / err.code / err.constraint / err.detail / err.table / err.column / err.routine / err.stack` head into `audit('error', 'rental', ...)` so the underlying failure is visible from `/api/logs?category=rental&level=error` after redeploy.
- Once root cause is identified, the audit logging stays as a permanent diagnostic surface for future rental 500s (RAILWAY_ECLAW API token is currently broken so /api/logs is the only path).

## Test plan
- [ ] Merge + Railway redeploys (~2 min)
- [ ] Re-hit `POST /api/rental/listing` for `ownerEntityId=3` via Playwright on prod
- [ ] Confirm response body unchanged: `{success:false, error:'internal_error'}` HTTP 500
- [ ] Confirm `/api/logs?deviceId=...&deviceSecret=...&category=rental&level=error&limit=20` now shows the captured row with metadata.errCode / errConstraint / errMessage
- [ ] Open follow-up card with the real root cause from that log row

🤖 Generated with [Claude Code](https://claude.com/claude-code)