### PR TITLE
fix(rental): restore bot_listings.id DEFAULT on startup [P0/UI]

### DIFF
--- a/backend/rental.js
+++ b/backend/rental.js
@@ -317,6 +317,17 @@ async function initRentalDatabase() {
         } catch (err) {
             console.warn('[Rental] Schema warning: rental_contracts.id default:', err.message);
         }
+        // P0 card_68242d883b51c3b6ceda09cb: live bot_listings.id lost its DEFAULT
+        // during an earlier schema migration. CREATE TABLE IF NOT EXISTS at the
+        // top of this file does nothing on existing tables, so the VARCHAR(48)
+        // DEFAULT in the schema definition never reached prod. INSERT without
+        // explicit id then hits 23502 not_null_violation. Mirror the
+        // rental_contracts fix above so every startup re-asserts the DEFAULT.
+        try {
+            await pool.query(`ALTER TABLE bot_listings ALTER COLUMN id SET DEFAULT ('listing_' || encode(gen_random_bytes(12), 'hex'))`);
+        } catch (err) {
+            console.warn('[Rental] Schema warning: bot_listings.id default:', err.message);
+        }
 
         // Startup cleanup: revert any listings stuck in 'interview' (server crashed mid-run)
         await pool.query(

--- a/backend/tests/jest/rental-init-id-defaults.test.js
+++ b/backend/tests/jest/rental-init-id-defaults.test.js
@@ -1,0 +1,85 @@
+/**
+ * Regression: initRentalDatabase must re-assert the id-column DEFAULT on
+ * bot_listings AND rental_contracts every startup. CREATE TABLE IF NOT EXISTS
+ * is a no-op when the table already exists, so any prior migration that lost
+ * the DEFAULT silently breaks every subsequent INSERT with
+ *   23502 null value in column "id" of relation "bot_listings"
+ *
+ * Origin: card_68242d883b51c3b6ceda09cb — production POST /api/rental/listing
+ * 500'd on every entity because the live bot_listings.id had no DEFAULT.
+ * Mac_F's April listing succeeded under the old UUID DEFAULT, then a schema
+ * change to VARCHAR(48) DEFAULT ('listing_' || ...) never reached prod.
+ */
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+
+const issued = [];
+
+jest.mock('pg', () => {
+    class FakePool {
+        async connect() {
+            return {
+                query: async (sql) => { issued.push(String(sql).trim()); return { rows: [], rowCount: 0 }; },
+                release: () => {},
+            };
+        }
+        async query(sql) { issued.push(String(sql).trim()); return { rows: [], rowCount: 0 }; }
+    }
+    return { Pool: jest.fn().mockImplementation(() => new FakePool()) };
+});
+
+jest.mock('fs', () => {
+    const real = jest.requireActual('fs');
+    return {
+        ...real,
+        readFileSync: jest.fn((p, enc) => {
+            if (typeof p === 'string' && p.endsWith('rental_schema.sql')) return '';
+            return real.readFileSync(p, enc);
+        }),
+    };
+});
+
+const rental = require('../../rental');
+
+const noopAuth = (_req, _res, next) => next();
+const stubWallet = {
+    withTransaction: async () => { throw new Error('not_used_in_init_tests'); },
+    LEDGER_TYPES: {},
+};
+const api = rental({ authMiddleware: noopAuth, walletModule: stubWallet });
+
+describe('rental: initRentalDatabase re-asserts id-column DEFAULTs (card_68242d88)', () => {
+    beforeEach(() => { issued.length = 0; });
+
+    test('emits ALTER TABLE bot_listings ALTER COLUMN id SET DEFAULT listing_...', async () => {
+        await api.initRentalDatabase();
+        const match = issued.find(q =>
+            /ALTER TABLE\s+bot_listings\s+ALTER COLUMN\s+id\s+SET DEFAULT/i.test(q)
+            && /'listing_'\s*\|\|\s*encode\(gen_random_bytes\(12\),\s*'hex'\)/i.test(q)
+        );
+        expect(match).toBeTruthy();
+    });
+
+    test('emits ALTER TABLE rental_contracts ALTER COLUMN id SET DEFAULT contract_... (parallel guard)', async () => {
+        await api.initRentalDatabase();
+        const match = issued.find(q =>
+            /ALTER TABLE\s+rental_contracts\s+ALTER COLUMN\s+id\s+SET DEFAULT/i.test(q)
+            && /'contract_'\s*\|\|\s*encode\(gen_random_bytes\(12\),\s*'hex'\)/i.test(q)
+        );
+        expect(match).toBeTruthy();
+    });
+});
+
+describe('rental.js source-level regression (card_68242d88)', () => {
+    test('rental.js literally contains the bot_listings.id SET DEFAULT statement', () => {
+        const src = fs.readFileSync.getMockImplementation()
+            ? require('fs').readFileSync(path.join(__dirname, '..', '..', 'rental.js'), 'utf8')
+            : '';
+        // Sanity: read the real file via the un-mocked real fs
+        const real = jest.requireActual('fs');
+        const text = real.readFileSync(path.join(__dirname, '..', '..', 'rental.js'), 'utf8');
+        expect(text).toMatch(/ALTER TABLE bot_listings ALTER COLUMN id SET DEFAULT \('listing_' \|\| encode\(gen_random_bytes\(12\), 'hex'\)\)/);
+    });
+});


### PR DESCRIPTION
## Summary
- **P0 root cause** (confirmed via PR #3350 diagnostic):
  ```
  null value in column "id" of relation "bot_listings" violates not-null constraint
  errCode 23502, errTable bot_listings, errColumn id
  ```
- The schema says `id VARCHAR(48) PRIMARY KEY DEFAULT ('listing_' || encode(gen_random_bytes(12), 'hex'))`, but `CREATE TABLE IF NOT EXISTS` is a no-op on existing tables. The April-era live table kept its old UUID-style id (Mac_F's listing has a UUID, not the `listing_` prefix) and lost the DEFAULT expression in a prior migration. Every new INSERT writes NULL into id → 23502 → 500 → ❌ internal_error.
- Mirror the `rental_contracts.id` re-assert pattern one block above so every startup pins the bot_listings.id DEFAULT. Same idempotent ALTER, same console.warn fallback.

## Linked
- card_68242d883b51c3b6ceda09cb (P0/UI)
- PR #3350 (diagnostic — stays merged; provides permanent /api/logs trail for future rental 500s)

## Test plan
- [x] Jest `rental-init-id-defaults.test.js` passes (3/3): asserts bot_listings + rental_contracts ALTER statements are emitted at startup AND that the source literally contains the bot_listings ALTER (catches regression by source edit too).
- [x] Existing `rental-listing.test.js` still passes (38/38).
- [ ] Merge → Railway redeploy → re-fire `POST /api/rental/listing` for entityId=3 → expect HTTP 200 with `{success:true, listing:{id:"listing_..."}}` instead of 500.
- [ ] Click 執行面試 on Mac_E in dashboard → expect ✅ "Evaluation opened in new tab" instead of ❌ internal_error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)