### PR TITLE
fix(rental): JS-side listing id (belt-and-suspenders for P0 #card_68242d88)

### DIFF
--- a/backend/rental.js
+++ b/backend/rental.js
@@ -384,14 +384,21 @@ async function createListing({
 
     // Avatar is passed from the route handler where _interviewDeps is in scope
 
+    // card_68242d883b51c3b6ceda09cb: don't depend on the DB-side DEFAULT for id.
+    // Prod's bot_listings.id lost its DEFAULT in an old migration and the
+    // startup ALTER (above) doesn't always reach the live table (e.g. when the
+    // app DB user lacks ALTER privilege). Generate the id in JS — same shape
+    // as the schema DEFAULT — so INSERT always supplies a value.
+    const listingId = 'listing_' + crypto.randomBytes(12).toString('hex');
+
     const res = await pool.query(
         `INSERT INTO bot_listings
-            (owner_user_id, owner_device_id, owner_entity_id, title, description,
+            (id, owner_user_id, owner_device_id, owner_entity_id, title, description,
              rate_mli_per_ktoken, min_rental_minutes, max_rental_minutes, avatar_url, status,
              bound_rebind_count)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, 'draft', $10)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, 'draft', $11)
          RETURNING id, status, created_at, bound_rebind_count`,
-        [ownerUserId, ownerDeviceId, ownerEntityId, title, description,
+        [listingId, ownerUserId, ownerDeviceId, ownerEntityId, title, description,
          rateMliPerKtoken, minRentalMinutes, maxRentalMinutes, avatarUrl || null,
          Number.isInteger(boundRebindCount) && boundRebindCount >= 0 ? boundRebindCount : 0]
     );

--- a/backend/tests/jest/rental-listing.test.js
+++ b/backend/tests/jest/rental-listing.test.js
@@ -41,10 +41,13 @@ jest.mock('pg', () => {
 
         // INSERT new listing
         if (/^INSERT INTO bot_listings/i.test(norm)) {
-            const [ownerUserId, ownerDeviceId, ownerEntityId, title, description,
+            // card_68242d883b51c3b6ceda09cb: id now generated in JS and passed
+            // explicitly as $1; prod DB's lost-DEFAULT failure mode was the
+            // original root cause of the 執行面試 P0.
+            const [id, ownerUserId, ownerDeviceId, ownerEntityId, title, description,
                    rate, minMin, maxMin, avatarUrl, boundRebindCount /* 'draft' status is literal */] = params;
             const row = {
-                id: genId(),
+                id: id || genId(),
                 owner_user_id: ownerUserId,
                 owner_device_id: ownerDeviceId,
                 owner_entity_id: ownerEntityId,
@@ -322,7 +325,8 @@ describe('rental: createListing', () => {
             title: 'My Bot',
             rateMliPerKtoken: 5000, // ignored — always 0 at creation
         });
-        expect(listing.id).toMatch(/^listing-/);
+        // card_68242d883b51c3b6ceda09cb: id is now JS-generated as 'listing_<hex>'
+        expect(listing.id).toMatch(/^listing_[0-9a-f]{24}$/);
         expect(listing.status).toBe('draft');
         const row = globalThis.__rentalFakeState.listings.find(l => l.id === listing.id);
         expect(row.rate_mli_per_ktoken).toBe(0);


### PR DESCRIPTION
## Summary
- PR #3351 added a startup ALTER to restore the lost DEFAULT on `bot_listings.id`, but post-deploy `POST /api/rental/listing` *still* 500'd with the same 23502 — the ALTER swallow-caught silently (almost certainly the prod DB user lacks ALTER privilege on this table).
- Generate the id directly in `createListing` as `'listing_' + crypto.randomBytes(12).toString('hex')` — same shape as the schema DEFAULT — and pass it as `$1` in the INSERT. The INSERT no longer depends on the DB-side DEFAULT being present.
- Startup ALTER from #3351 stays as a soft self-heal (if a DBA later grants ALTER, the DEFAULT comes back without code change). Audit logging from #3350 stays — every future rental 500 stays visible in /api/logs.

## Linked
- card_68242d883b51c3b6ceda09cb (P0/UI)
- PR #3350 (diagnostic audit logging — stays)
- PR #3351 (startup ALTER — stays as soft self-heal)

## Test plan
- [x] `rental-listing.test.js` 38/38 passes with updated fake-pg mock (id now at $1)
- [x] `rental-init-id-defaults.test.js` 3/3 still passes (startup ALTER guard stays)
- [ ] Merge → Railway redeploy → re-fire `POST /api/rental/listing` entity 3 → expect 200 with `{listing.id: "listing_<24hex>"}`
- [ ] Click 執行面試 on Mac_E in dashboard → expect ✅ "Evaluation opened in new tab"

🤖 Generated with [Claude Code](https://claude.com/claude-code)