### PR TITLE
test(rental): shift rental-contract.test.js bot_listings mock for P0 #3352

### DIFF
--- a/backend/tests/jest/rental-contract.test.js
+++ b/backend/tests/jest/rental-contract.test.js
@@ -50,17 +50,19 @@ jest.mock('pg', () => {
             return { rows: [], rowCount: 1 };
         }
         if (/^INSERT INTO bot_listings/i.test(norm)) {
-            const id = `listing-${state.nextListingId++}`;
+            // card_68242d883b51c3b6ceda09cb: id is now JS-generated and passed
+            // as $1; all subsequent params shift by 1.
+            const id = params[0] || `listing-${state.nextListingId++}`;
             state.listings.push({
                 id,
-                owner_user_id: params[0],
-                owner_device_id: params[1],
-                owner_entity_id: params[2],
-                title: params[3],
-                description: params[4],
-                rate_mli_per_ktoken: params[5],
-                min_rental_minutes: params[6],
-                max_rental_minutes: params[7],
+                owner_user_id: params[1],
+                owner_device_id: params[2],
+                owner_entity_id: params[3],
+                title: params[4],
+                description: params[5],
+                rate_mli_per_ktoken: params[6],
+                min_rental_minutes: params[7],
+                max_rental_minutes: params[8],
                 availability_windows: [],
                 model_detected: null,
                 capabilities: {},


### PR DESCRIPTION
## Summary
- PR #3352 added id as `$1` to createListing's INSERT, breaking `rental-contract.test.js`'s separate fake-pg simulator (it still read params[0..7] under the old shape — avatar_url got mistaken for max_rental_minutes, every contract test failed with `duration_above_listing_max`).
- Shift the mock's param indices by 1; accept the JS-supplied id with the `listing-N` fallback intact.

## Test plan
- [x] `npx jest tests/jest/rental-contract.test.js` → 18/18 pass
- [x] `npx jest tests/jest/rental-listing.test.js` → 38/38 (unchanged)
- [x] `npx jest tests/jest/rental-init-id-defaults.test.js` → 3/3 (unchanged)
- [ ] CI Backend job green after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)