### PR TITLE
feat(rental): emit OODA-R Episode on rentalRoute 500 [SI stream C]

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -3529,6 +3529,9 @@ const rentalModule = require('./rental')({
     adminMiddleware: authModule.adminMiddleware,
     walletModule,
     serverLog,
+    // card_7fc8e7abc3cb546e89721a26 (SI stream C): wire OODA-R episode
+    // emit so rentalRoute 500s self-file an Episode for downstream mining.
+    agentImprovementModule: agentImprovement,
 });
 app.use('/api/rental', rentalModule.router);
 

--- a/backend/rental.js
+++ b/backend/rental.js
@@ -1757,7 +1757,7 @@ function createDefaultRentalEntity(entityId) {
 // Express factory
 // ============================================
 
-module.exports = function rentalFactory({ authMiddleware, softAuthMiddleware, adminMiddleware, walletModule, serverLog } = {}) {
+module.exports = function rentalFactory({ authMiddleware, softAuthMiddleware, adminMiddleware, walletModule, serverLog, agentImprovementModule } = {}) {
     if (typeof authMiddleware !== 'function') {
         throw new Error('rental: authMiddleware is required');
     }
@@ -1766,6 +1766,35 @@ module.exports = function rentalFactory({ authMiddleware, softAuthMiddleware, ad
     }
     const router = express.Router();
     const audit = serverLog || (() => {});
+
+    // card_7fc8e7abc3cb546e89721a26 (SI stream C): emit an OODA-R Episode on
+    // every rentalRoute 500 so the self-improvement framework can mine the
+    // failure class — closes the gap Hank flagged on card_68242d88
+    // ("internal_error 會回傳API 到內部進行 self improvement?").
+    // Anchored to the SI parent card; fire-and-forget so episode failures
+    // never affect the user-visible response.
+    const EPISODE_ANCHOR_CARD = 'card_7fc8e7abc3cb546e89721a26';
+    async function emitRentalEpisode({ req, err, pool }) {
+        if (!agentImprovementModule?.ingestEpisode || !pool) return;
+        try {
+            const route = `${req.method} ${(req.originalUrl || req.path || '').split('?')[0]}`;
+            await agentImprovementModule.ingestEpisode({
+                _deviceId: req.user?.deviceId || 'unknown',
+                cardId: EPISODE_ANCHOR_CARD,
+                entityId: 0,
+                taskType: 'rental_handler_500',
+                painTags: ['delivery_reliability', 'test_coverage'],
+                deliverable: `rental endpoint ${route}`,
+                userVisibleResult: 'internal_error',
+                evidence: [
+                    { kind: 'log', ref: `audit:rental:${route}`, note: 'rentalRoute catch audit row' },
+                ],
+                missedChecks: ['schema-drift-sentinel', 'integration-test-real-db'],
+                severity: 'P0',
+                occurredAt: new Date().toISOString(),
+            }, pool);
+        } catch (_) { /* fire-and-forget — never let SI emit affect the response */ }
+    }
     const optionalAuthMiddleware = typeof softAuthMiddleware === 'function'
         ? softAuthMiddleware
         : (_req, _res, next) => next();
@@ -1822,6 +1851,10 @@ module.exports = function rentalFactory({ authMiddleware, softAuthMiddleware, ad
                         },
                     });
                 } catch (_) { /* never let audit failure cascade */ }
+                // SI stream C: fire-and-forget OODA-R episode emit. Awaiting
+                // would tie the user response to SI store availability — we
+                // explicitly don't want that.
+                emitRentalEpisode({ req, err, pool });
                 res.status(500).json({ success: false, error: 'internal_error' });
             }
         };

--- a/backend/tests/jest/rental-ooda-r-episode-emit.test.js
+++ b/backend/tests/jest/rental-ooda-r-episode-emit.test.js
@@ -1,0 +1,136 @@
+/**
+ * rental → OODA-R episode emit on 500 — card_7fc8e7ab (SI stream C).
+ *
+ * Verifies that when rentalRoute's catch fires (synthesized via a forced
+ * pool error), the wired agentImprovementModule.ingestEpisode is called
+ * with a well-formed Episode payload pinned to the SI anchor card.
+ */
+'use strict';
+
+jest.mock('pg', () => {
+    class FakePool {
+        async connect() {
+            return {
+                query: async () => { throw new Error('forced fake-pg failure'); },
+                release: () => {},
+            };
+        }
+        async query() { throw new Error('forced fake-pg failure'); }
+    }
+    return { Pool: jest.fn().mockImplementation(() => new FakePool()) };
+});
+
+jest.mock('fs', () => {
+    const real = jest.requireActual('fs');
+    return {
+        ...real,
+        readFileSync: jest.fn((p, enc) => {
+            if (typeof p === 'string' && p.endsWith('rental_schema.sql')) return '';
+            return real.readFileSync(p, enc);
+        }),
+    };
+});
+
+const rental = require('../../rental');
+
+const stubAuth = (req, _res, next) => {
+    req.user = { userId: 'u-test', deviceId: 'dev-test' };
+    next();
+};
+const stubWallet = {
+    withTransaction: async () => { throw new Error('not_used'); },
+    LEDGER_TYPES: {},
+};
+
+describe('rentalRoute 500 path emits an OODA-R Episode (card_7fc8e7ab — SI stream C)', () => {
+    test('ingestEpisode called with episode anchored to the SI card on 500', async () => {
+        const ingestCalls = [];
+        const agentImprovementModule = {
+            ingestEpisode: async (episode /*, pool*/) => {
+                ingestCalls.push(episode);
+                return { id: 1 };
+            },
+        };
+        const api = rental({
+            authMiddleware: stubAuth,
+            walletModule: stubWallet,
+            agentImprovementModule,
+        });
+
+        // Pull the registered POST /listing route handler directly so we don't
+        // need a full Express harness — the rentalRoute wrapper is the
+        // subject under test.
+        const routeLayer = api.router.stack.find(l =>
+            l.route && l.route.path === '/listing' && l.route.methods.post
+        );
+        expect(routeLayer).toBeTruthy();
+        // Stack: [authMiddleware, rentalRoute(...handler...)]. The wrapper is
+        // the LAST entry on the layer.
+        const rentalRouteHandler = routeLayer.route.stack[routeLayer.route.stack.length - 1].handle;
+
+        const req = {
+            user: { userId: 'u-test', deviceId: 'dev-test' },
+            method: 'POST',
+            originalUrl: '/api/rental/listing',
+            path: '/listing',
+            body: {
+                ownerDeviceId: 'd', ownerEntityId: 0, title: 'x', rateMliPerKtoken: 5000,
+            },
+        };
+        let captured;
+        const res = {
+            status(code) { captured = { code }; return this; },
+            json(body) { captured.body = body; return this; },
+        };
+
+        await rentalRouteHandler(req, res);
+
+        // Response shape — surface contract unchanged.
+        expect(captured.code).toBe(500);
+        expect(captured.body).toEqual({ success: false, error: 'internal_error' });
+
+        // The fire-and-forget emit is awaited as a microtask — flush.
+        await new Promise(r => setImmediate(r));
+
+        expect(ingestCalls.length).toBe(1);
+        const ep = ingestCalls[0];
+        expect(ep.cardId).toBe('card_7fc8e7abc3cb546e89721a26');
+        expect(ep.taskType).toBe('rental_handler_500');
+        expect(ep.severity).toBe('P0');
+        expect(ep.userVisibleResult).toBe('internal_error');
+        expect(ep.painTags).toEqual(expect.arrayContaining(['delivery_reliability', 'test_coverage']));
+        expect(ep.missedChecks).toEqual(expect.arrayContaining(['schema-drift-sentinel']));
+        expect(typeof ep.occurredAt).toBe('string');
+        // ISO-8601 parseable
+        expect(Number.isNaN(Date.parse(ep.occurredAt))).toBe(false);
+    });
+
+    test('no episode emit when agentImprovementModule is not wired (back-compat)', async () => {
+        const api = rental({
+            authMiddleware: stubAuth,
+            walletModule: stubWallet,
+            // No agentImprovementModule — exactly how old call sites looked.
+        });
+        const routeLayer = api.router.stack.find(l =>
+            l.route && l.route.path === '/listing' && l.route.methods.post
+        );
+        const handler = routeLayer.route.stack[routeLayer.route.stack.length - 1].handle;
+
+        const req = {
+            user: { userId: 'u-test' },
+            method: 'POST',
+            originalUrl: '/api/rental/listing',
+            body: { ownerDeviceId: 'd', ownerEntityId: 0, title: 'x', rateMliPerKtoken: 5000 },
+        };
+        let captured;
+        const res = {
+            status(code) { captured = { code }; return this; },
+            json(body) { captured.body = body; return this; },
+        };
+
+        // Must not throw even though episode emit path is absent.
+        await expect(handler(req, res)).resolves.toBeUndefined();
+        expect(captured.code).toBe(500);
+        expect(captured.body).toEqual({ success: false, error: 'internal_error' });
+    });
+});


### PR DESCRIPTION
## Summary
- **SI card_7fc8e7ab — stream C** (OODA-R episode emit on 500). Closes the gap Hank flagged on card_68242d88: "internal_error 會回傳API 到內部進行 self improvement?"
- Before: rentalRoute catch wrote an audit row (PR #3350). Paper trail for support but not a signal the SI framework can mine — entire schema-drift class stayed invisible to OODA-R Phase 0 #1.
- After: rentalRoute also fires-and-forgets `agentImprovementModule.ingestEpisode()` with a well-formed Episode payload anchored to the SI parent card. `painTags=['delivery_reliability','test_coverage']`, `missedChecks=['schema-drift-sentinel','integration-test-real-db']`. Episode failures never affect the response shape.
- Wires `agentImprovementModule` into the rentalFactory in index.js; optional param so existing callers (tests) keep working.

## Linked
- card_7fc8e7abc3cb546e89721a26 (SI/P1)
- Streams A ✅ #3354, B ✅ #3355. D (friendly UX) still to come.

## Test plan
- [x] new `rental-ooda-r-episode-emit.test.js` 2/2 pass — episode emitted with correct anchor / taskType / painTags / severity AND old call sites without the dep keep working
- [x] all existing rental tests still green: 62/62 (listing 38, contract 18, init-id-defaults 3, schema-drift-sentinel 3 unit + 2 skipped)
- [ ] Post-merge prod verification: trigger any rental 500 (or wait for natural one), confirm `/api/agent-improvement/episodes?painTag=delivery_reliability` shows the new row

🤖 Generated with [Claude Code](https://claude.com/claude-code)