### PR TITLE
fix(ui): friendly interview error + reference code [SI stream D]

### DIFF
--- a/backend/public/portal/shared/agent-card-editor.js
+++ b/backend/public/portal/shared/agent-card-editor.js
@@ -292,13 +292,37 @@ window.AgentCardEditor = (function() {
                     ' <a href="' + examUrl + '?returnUrl=' + returnUrl + '" target="_blank" style="color:var(--primary);">' +
                     t('dash_interview_view_results', 'View Results →') + '</a></span>';
             } else {
-                if (statusEl) { statusEl.textContent = ''; var _sp2 = document.createElement('span'); _sp2.style.color = '#ef4444'; _sp2.textContent = '\u274c ' + (examRes.error || 'Failed to create exam'); statusEl.appendChild(_sp2); }
+                // SI stream D card_7fc8e7ab: friendly message + error_id for
+                // support reference instead of leaking the raw server token.
+                this._renderInterviewError(statusEl, examRes.error || null);
             }
         } catch (err) {
             btn.disabled = false;
             btn.textContent = '🧪 ' + t('dash_run_interview', 'Run Interview');
-            if (statusEl) { statusEl.textContent = ''; var _sp = document.createElement('span'); _sp.style.color = '#ef4444'; _sp.textContent = '\u274c ' + (err.message || 'Error'); statusEl.appendChild(_sp); }
+            this._renderInterviewError(statusEl, err && err.message);
         }
+    };
+
+    /**
+     * SI stream D - card_7fc8e7ab: replace raw server error codes with a
+     * localized friendly message plus an error_id the user can quote to
+     * support. Raw code is logged via console.error so technical users can
+     * still find it in DevTools - only the user-visible surface is sanitized.
+     */
+    AgentCardEditor.prototype._renderInterviewError = function(statusEl, rawError) {
+        if (!statusEl) return;
+        var errorId = (Math.random().toString(16).slice(2, 6) + Math.random().toString(16).slice(2, 6));
+        var friendly = t('dash_interview_failed_retry',
+            'Interview could not start - please try again. Reference code: %s');
+        var withCode = friendly.indexOf('%s') >= 0
+            ? friendly.replace('%s', errorId)
+            : (friendly + ' (' + errorId + ')');
+        statusEl.textContent = '';
+        var sp = document.createElement('span');
+        sp.style.color = '#ef4444';
+        sp.textContent = '\u274c ' + withCode;
+        statusEl.appendChild(sp);
+        try { console.error('[interview] error_id=' + errorId + ' raw=' + (rawError || 'unknown')); } catch (_) {}
     };
 
     AgentCardEditor.prototype._openArena = async function() {

--- a/backend/tests/jest/agent-card-editor-friendly-error.test.js
+++ b/backend/tests/jest/agent-card-editor-friendly-error.test.js
@@ -1,0 +1,90 @@
+/**
+ * SI stream D — agent-card-editor _renderInterviewError unit test.
+ * card_7fc8e7abc3cb546e89721a26.
+ *
+ * Verifies that the friendly error renderer:
+ *  - shows a localized message + reference code instead of raw server tokens
+ *  - logs the raw token to console.error so DevTools still has it
+ *  - tolerates missing statusEl (no-op, no throw)
+ *
+ * Uses jsdom-style stubs — no real DOM needed for this scoped test.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+function loadEditor() {
+    const src = fs.readFileSync(
+        path.join(__dirname, '..', '..', 'public', 'portal', 'shared', 'agent-card-editor.js'),
+        'utf8'
+    );
+    // Minimal DOM-ish surface for the renderer to write into.
+    const fakeEl = (tag) => ({
+        tag, style: {}, textContent: '', children: [],
+        appendChild(c) { this.children.push(c); },
+    });
+    const ctx = {
+        window: {
+            AgentCardEditor: null,
+        },
+        document: {
+            createElement: (tag) => fakeEl(tag),
+            getElementById: () => null,
+        },
+        // i18n fallback wrapper used by the editor.
+        t: (_k, fallback) => fallback,
+        // apiCall stub — not exercised in this test.
+        apiCall: async () => ({}),
+        showToast: () => {},
+        console: {
+            calls: [],
+            error: function(msg) { this.calls.push(['error', msg]); },
+            log: () => {},
+            warn: () => {},
+        },
+        Math, Date, JSON, encodeURIComponent, decodeURIComponent,
+    };
+    ctx.window.console = ctx.console;
+    vm.createContext(ctx);
+    vm.runInContext(src, ctx, { filename: 'agent-card-editor.js' });
+    return ctx;
+}
+
+describe('AgentCardEditor._renderInterviewError (card_7fc8e7ab — SI stream D)', () => {
+    const ctx = loadEditor();
+    const AgentCardEditor = ctx.window.AgentCardEditor;
+
+    test('module loaded and renderer exists on prototype', () => {
+        expect(typeof AgentCardEditor).toBe('function');
+        expect(typeof AgentCardEditor.prototype._renderInterviewError).toBe('function');
+    });
+
+    test('renders friendly message + reference code, swallows raw server token', () => {
+        const statusEl = ctx.document.createElement('span');
+        // Renderer is invoked as a prototype method but only touches `statusEl`.
+        AgentCardEditor.prototype._renderInterviewError.call({}, statusEl, 'internal_error');
+        const written = statusEl.children[0]?.textContent || '';
+        // No raw server token surfaced.
+        expect(written.includes('internal_error')).toBe(false);
+        // Friendly fallback text from the t() stub.
+        expect(written).toMatch(/Interview could not start/);
+        // A reference code was substituted into the %s slot.
+        expect(written).toMatch(/[0-9a-f]{8}/);
+    });
+
+    test('raw error is preserved in console.error for DevTools traceability', () => {
+        ctx.console.calls.length = 0;
+        const statusEl = ctx.document.createElement('span');
+        AgentCardEditor.prototype._renderInterviewError.call({}, statusEl, 'duplicate_listing');
+        const logged = ctx.console.calls.map(c => c.join(' ')).join('\n');
+        expect(logged).toMatch(/\[interview\] error_id=[0-9a-f]+ raw=duplicate_listing/);
+    });
+
+    test('no statusEl → no-op, no throw', () => {
+        expect(() =>
+            AgentCardEditor.prototype._renderInterviewError.call({}, null, 'x')
+        ).not.toThrow();
+    });
+});


### PR DESCRIPTION
## Summary
- **SI card_7fc8e7ab — stream D** (Friendly UX). Closes the second half of Hank's concern on card_68242d88: 「internal_error 錯誤訊息這麼隨便 用戶信心度會下降的」.
- Before: agent-card-editor.js:295 dumped the raw server token (`internal_error`, `duplicate_listing`, etc.) into the on-screen status.
- After: new `_renderInterviewError()` on the editor renders a localized message with an 8-hex reference code (e.g. `❌ Interview could not start - please try again. Reference code: a3f29b8c`) and emits the raw token through `console.error` so technical users can still find it in DevTools.
- Both the `examRes.error` branch and the `catch(err)` branch share the same renderer.

## i18n
- New key: `dash_interview_failed_retry`. JS-side fallback (English) ships in this PR so the surface works immediately.
- 7-locale dictionary entries are **out-of-scope** and tracked as a follow-up i18n dispatch per the i18n-delegation rule.

## Linked
- card_7fc8e7abc3cb546e89721a26 (SI/P1)
- Streams A ✅ #3354, B ✅ #3355, C ✅ #3356. With D merged, the SI card closes.

## Test plan
- [x] 4/4 `agent-card-editor-friendly-error.test.js` pass — VM-sandbox loads the editor without a real DOM, verifies the renderer hides the raw token, surfaces the reference code, preserves the raw token for DevTools, and is a no-op when statusEl is absent
- [ ] Post-merge: in dashboard.html click 執行面試 on an entity whose backend fails (or temporarily revert PR #3352 to repro) — confirm friendly message + reference code appears instead of raw `internal_error`

🤖 Generated with [Claude Code](https://claude.com/claude-code)