### PR TITLE
test(rental): shift remaining bot_listings INSERT mocks [P0 #card_68242d88 tail]

### DIFF
--- a/backend/tests/jest/rental-interview.test.js
+++ b/backend/tests/jest/rental-interview.test.js
@@ -25,10 +25,11 @@ jest.mock('pg', () => {
 
         // INSERT new listing
         if (/^INSERT INTO bot_listings/i.test(norm)) {
-            const [ownerUserId, ownerDeviceId, ownerEntityId, title, description,
+            // card_68242d88: id is now passed explicitly as $1 — shift the rest.
+            const [explicitId, ownerUserId, ownerDeviceId, ownerEntityId, title, description,
                    rate, minMin, maxMin] = params;
             const row = {
-                id: genId(), owner_user_id: ownerUserId,
+                id: explicitId || genId(), owner_user_id: ownerUserId,
                 owner_device_id: ownerDeviceId, owner_entity_id: ownerEntityId,
                 title, description, rate_mli_per_ktoken: rate,
                 min_rental_minutes: minMin, max_rental_minutes: maxMin,

--- a/backend/tests/jest/rental-wallet-integration.test.js
+++ b/backend/tests/jest/rental-wallet-integration.test.js
@@ -43,13 +43,15 @@ jest.mock('pg', () => {
         if (/^INSERT INTO rental_cooldowns/i.test(norm))
             return { rows: [], rowCount: 1 };
         if (/^INSERT INTO bot_listings/i.test(norm)) {
-            const id = `listing-${state.nextListingId++}`;
+            // card_68242d88: id is now passed explicitly as $1 — all
+            // subsequent params shift by 1.
+            const id = params[0] || `listing-${state.nextListingId++}`;
             state.listings.push({
-                id, owner_user_id: params[0], owner_device_id: params[1],
-                owner_entity_id: params[2], title: params[3],
-                rate_mli_per_ktoken: params[5], status: 'listed',
-                interview_passed: true, min_rental_minutes: params[6],
-                max_rental_minutes: params[7],
+                id, owner_user_id: params[1], owner_device_id: params[2],
+                owner_entity_id: params[3], title: params[4],
+                rate_mli_per_ktoken: params[6], status: 'listed',
+                interview_passed: true, min_rental_minutes: params[7],
+                max_rental_minutes: params[8],
                 created_at: new Date(), updated_at: new Date(),
             });
             return { rows: [{ id, status: 'listed', created_at: new Date() }], rowCount: 1 };


### PR DESCRIPTION
## Summary
- Backend CI on main went red after PR #3352. The id-shift was patched in `rental-listing.test.js` (PR #3352) and `rental-contract.test.js` (PR #3353), but **two more test files** had their own fake-pg simulators reading the old offsets:
  - `rental-interview.test.js`
  - `rental-wallet-integration.test.js`
- Both now read id at params[0] (with the `listing-N` fallback so call sites that genuinely don't pass an id still work).
- 18/18 in those two suites pass; full rental fleet 80/80 green.

## Why it slipped past PR #3352 / #3353
I ran `rental-listing.test.js` + `rental-contract.test.js` locally — the only two that exercise INSERT mocks I was thinking about. The other two never tripped until CI ran the whole rental test fleet. Lesson: when shifting any SQL-mock shape, run the whole `tests/jest/rental-*.test.js` glob, not just the immediate-callsite files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)