### PR TITLE
feat(channel): wire dashboard 重新綁定 to version-aware channel self-repair API

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -16460,6 +16460,112 @@ app.post('/api/entity/refresh', async (req, res) => {
 });
 
 // ============================================
+// CHANNEL SELF-REPAIR (version-aware repair + re-bind sync-verify)
+// ============================================
+// Wired to the dashboard 重新綁定 button. Triggers the bound channel's
+// POST {callback_url -> /self-repair} webhook — a repo-bound, version-aware repair
+// program that detects+installs the latest repair version, repairs, health-checks,
+// then idempotently re-binds via /api/channel/bind. Falls back to the legacy /restart
+// for channels whose /self-repair endpoint is not yet deployed. Mirrors the channel
+// restart auth path in /api/entity/refresh (X-API-Key: channel_api_key).
+app.post('/api/channel/self-repair', async (req, res) => {
+    const { deviceId, deviceSecret, entityId } = req.body;
+
+    if (!deviceId || !deviceSecret) {
+        return res.status(400).json({ success: false, error: 'deviceId and deviceSecret required' });
+    }
+    const eId = parseInt(entityId);
+    if (isNaN(eId) || eId < 0) {
+        return res.status(400).json({ success: false, error: 'Invalid entityId' });
+    }
+    const device = devices[deviceId];
+    if (!device || !safeEqual(device.deviceSecret, deviceSecret)) {
+        return res.status(403).json({ success: false, error: 'Invalid device credentials' });
+    }
+    if (!isValidEntityId(device, eId)) {
+        return res.status(400).json({ success: false, error: 'Invalid entityId' });
+    }
+    const entity = device.entities[eId];
+    if (!entity || !entity.isBound) {
+        return res.status(400).json({ success: false, error: 'Entity is not bound' });
+    }
+    if (entity.bindingType !== 'channel' || !entity.channelAccountId) {
+        return res.status(400).json({ success: false, error: 'Entity is not a channel binding' });
+    }
+
+    // Cooldown: reuse refresh cooldown map (1 minute)
+    const cooldownKey = `${deviceId}:${eId}`;
+    const lastRun = refreshCooldowns[cooldownKey] || 0;
+    const elapsed = Date.now() - lastRun;
+    const COOLDOWN_MS = 60000;
+    if (elapsed < COOLDOWN_MS) {
+        const remaining = Math.ceil((COOLDOWN_MS - elapsed) / 1000);
+        return res.status(429).json({ success: false, error: `請等待 ${remaining} 秒後再試`, cooldown_remaining: remaining });
+    }
+
+    let account;
+    try {
+        account = await db.getChannelAccountById(entity.channelAccountId);
+    } catch { /* ignore */ }
+    if (!account || !account.callback_url) {
+        return res.json({ success: false, error: 'Channel callback URL not set', hint: 'Re-register the channel callback first.' });
+    }
+
+    const headers = { 'Content-Type': 'application/json', 'X-API-Key': account.channel_api_key };
+    refreshCooldowns[cooldownKey] = Date.now();
+
+    // 1) Try the version-aware self-repair endpoint first.
+    const selfRepairUrl = account.callback_url.replace(/\/eclaw-webhook\/?$/, '/self-repair');
+    try {
+        const resp = await fetch(selfRepairUrl, {
+            method: 'POST', headers, body: JSON.stringify({ deviceId, entityId: eId }),
+            signal: AbortSignal.timeout(160000) // version-check + restart + bind can take a while
+        });
+        if (resp.status !== 404) {
+            const data = await resp.json().catch(() => ({}));
+            if (resp.ok && data.ok) {
+                entity.lastUpdated = Date.now();
+                await saveData();
+                console.log(`[SelfRepair] OK device ${deviceId} entity ${eId} v${data.localVersion}->${data.latestVersion} updated=${data.updated} bindOk=${data.bindOk}`);
+                return res.json({
+                    success: true, mode: 'self-repair', repairTriggered: true,
+                    localVersion: data.localVersion, latestVersion: data.latestVersion,
+                    updated: !!data.updated, bindOk: !!data.bindOk,
+                    message: data.message || '自我修復完成'
+                });
+            }
+            return res.json({
+                success: false, mode: 'self-repair', repairTriggered: true,
+                bindOk: !!(data && data.bindOk),
+                error: (data && (data.message || data.error)) || '自我修復失敗'
+            });
+        }
+        // 404 -> channel has no /self-repair yet; fall through to /restart.
+    } catch (err) {
+        console.warn(`[SelfRepair] /self-repair failed device ${deviceId} entity ${eId}: ${err.message}; trying /restart`);
+        // fall through to restart fallback
+    }
+
+    // 2) Fallback: legacy /restart (no version-check / bind-verify, but better than a dead button).
+    try {
+        const restartUrl = account.callback_url.replace(/\/eclaw-webhook\/?$/, '/restart');
+        const resp = await fetch(restartUrl, {
+            method: 'POST', headers, body: JSON.stringify({ mode: '--smart', deviceId, entityId: eId }),
+            signal: AbortSignal.timeout(95000)
+        });
+        const data = await resp.json().catch(() => ({}));
+        if (resp.ok && data.ok) {
+            entity.lastUpdated = Date.now();
+            await saveData();
+            return res.json({ success: true, mode: 'restart-fallback', repairTriggered: true, message: data.message || '通道已重啟（此通道尚未部署自我修復）' });
+        }
+        return res.json({ success: false, mode: 'restart-fallback', repairTriggered: true, error: (data && (data.message || data.error)) || '通道修復失敗' });
+    } catch (err2) {
+        return res.json({ success: false, webhookBroken: true, error: `通道修復失敗: ${err2.message}`, hint: 'Channel bridge unreachable.' });
+    }
+});
+
+// ============================================
 // BOT WEBHOOK REGISTRATION (Push Mode)
 // ============================================
 

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -3858,7 +3858,7 @@
                 '</p>' +
                 '<div class="dialog-actions">' +
                 '<button class="btn btn-outline" onclick="this.closest(\'.confirm-overlay\').remove()">' + i18n.t('mc_dlg_cancel') + '</button>' +
-                '<button class="btn btn-primary" onclick="this.closest(\'.confirm-overlay\').remove(); scrollToRebind(' + entityId + ')">' + i18n.t('dash_refresh_broken_rebind') + '</button>' +
+                '<button class="btn btn-primary" onclick="this.closest(\'.confirm-overlay\').remove(); rebindSelfRepair(' + entityId + ', this)">' + i18n.t('dash_refresh_broken_rebind') + '</button>' +
                 '</div>' +
                 '</div>';
             document.body.appendChild(overlay);
@@ -3869,6 +3869,43 @@
             if (!isAddExpanded) toggleAddEntity();
             selectSlot(entityId);
             document.getElementById('addEntityCard').scrollIntoView({ behavior: 'smooth' });
+        }
+
+        // Smart re-bind: trigger the bound channel's version-aware self-repair program
+        // (detect+install latest repair version -> repair -> health -> /api/channel/bind re-bind).
+        // Falls back to the manual rebind scroll if the channel bridge is unreachable.
+        async function rebindSelfRepair(entityId, btnEl) {
+            var originalText = btnEl ? btnEl.textContent : '';
+            if (btnEl) { btnEl.disabled = true; btnEl.textContent = i18n.t('dash_refreshing'); }
+            if (window.telemetry) telemetry.trackAction('channel_self_repair', { entityId: entityId });
+            try {
+                var result = await apiCall('POST', '/api/channel/self-repair', {
+                    deviceId: currentUser.deviceId,
+                    deviceSecret: currentUser.deviceSecret,
+                    entityId: entityId
+                });
+                if (result.success) {
+                    var detail = result.localVersion ? (' v' + result.localVersion + (result.updated ? '\u2192latest' : '')) : '';
+                    showToast(i18n.t('dash_restart_success') + detail, 'success');
+                    setTimeout(function() { loadEntities(); }, 2000);
+                } else if (result.webhookBroken) {
+                    // Channel bridge unreachable — fall back to manual rebind
+                    showToast(result.error || i18n.t('dash_restart_failed'), 'error');
+                    scrollToRebind(entityId);
+                } else {
+                    showToast(i18n.t('dash_restart_failed') + (result.error ? ': ' + result.error : ''), 'error');
+                }
+            } catch (e) {
+                if (e.status === 429) {
+                    var remaining = (e.data && e.data.cooldown_remaining) || 60;
+                    showToast(i18n.t('dash_refresh_cooldown', { s: remaining }), 'error');
+                } else {
+                    if (window.telemetry) telemetry.trackError(e, { action: 'channel_self_repair' });
+                    showToast(e.message || i18n.t('dash_restart_failed'), 'error');
+                }
+            } finally {
+                if (btnEl) { btnEl.disabled = false; btnEl.textContent = originalText; }
+            }
         }
 
         // --- Avatar Emoji Picker ---

--- a/backend/tests/jest/channel-self-repair.test.js
+++ b/backend/tests/jest/channel-self-repair.test.js
@@ -1,0 +1,71 @@
+/**
+ * Channel self-repair endpoint validation tests (Jest + Supertest)
+ *
+ * Tests: POST /api/channel/self-repair — the dashboard 重新綁定 trigger that invokes a
+ * bound channel's version-aware self-repair program (with /restart fallback).
+ * Covers the auth + binding validation gates (no live channel webhook required).
+ */
+
+require('./helpers/mock-setup');
+
+const db = require('../../db');
+db.getChannelAccountById = jest.fn().mockResolvedValue(null);
+
+const request = require('supertest');
+let app;
+
+const post = (path) => request(app).post(path).set('Host', 'localhost');
+
+async function registerDevice(id) {
+    const secret = `secret-${id}`;
+    await post('/api/device/register').send({ deviceId: id, deviceSecret: secret, entityId: 0 });
+    return secret;
+}
+
+beforeAll(() => {
+    app = require('../../index');
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+});
+
+describe('POST /api/channel/self-repair', () => {
+    it('returns 400 when deviceId is missing', async () => {
+        const res = await post('/api/channel/self-repair').send({ deviceSecret: 'x', entityId: 1 });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+    });
+
+    it('returns 400 when deviceSecret is missing', async () => {
+        const res = await post('/api/channel/self-repair').send({ deviceId: 'sr-dev', entityId: 1 });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+    });
+
+    it('returns 400 on invalid entityId', async () => {
+        const secret = await registerDevice('sr-dev-1');
+        const res = await post('/api/channel/self-repair')
+            .send({ deviceId: 'sr-dev-1', deviceSecret: secret, entityId: -5 });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+    });
+
+    it('returns 403 on invalid device credentials', async () => {
+        await registerDevice('sr-dev-2');
+        const res = await post('/api/channel/self-repair')
+            .send({ deviceId: 'sr-dev-2', deviceSecret: 'wrong-secret', entityId: 0 });
+        expect(res.status).toBe(403);
+        expect(res.body.success).toBe(false);
+    });
+
+    it('returns 400 when the entity is not a channel binding', async () => {
+        const secret = await registerDevice('sr-dev-3');
+        // entity 0 is the default (non-channel) entity → must be rejected before any webhook call
+        const res = await post('/api/channel/self-repair')
+            .send({ deviceId: 'sr-dev-3', deviceSecret: secret, entityId: 0 });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary
- Adds `POST /api/channel/self-repair` — resolves the entity's bound channel account and triggers the channel's `{callback_url}/self-repair` webhook (a repo-bound, version-aware repair program: self-detect + install latest repair version -> repair -> health-check -> idempotent `/api/channel/bind` re-bind sync-verify). Falls back to the legacy `/restart` for channels whose `/self-repair` is not yet deployed. Mirrors the `X-API-Key` channel auth path of `/api/entity/refresh`.
- Rewires the dashboard 重新綁定 button (webhook-broken dialog) to call this endpoint via `rebindSelfRepair()` (reuses existing i18n keys; graceful fallback to manual rebind scroll if the bridge is unreachable).
- Adds `tests/jest/channel-self-repair.test.js` (auth/binding validation gates).

## Test plan
- [x] `npx jest tests/jest/channel-self-repair.test.js` — 5/5 pass
- [x] `node scripts/i18n-check.js` — all referenced keys resolve in EN (no new keys)
- [x] `npx jest --testPathPattern=i18n-syntax` — 12/12 pass
- [x] `npx eslint index.js` — 0 errors
- [ ] Post-merge: verify Railway deploy + smoke-test 重新綁定 on #2

Generated with Claude Code
