### PR TITLE
fix(passive-health): heartbeat_stale false-positive for channel-push entities

### DIFF
--- a/backend/passive-health.js
+++ b/backend/passive-health.js
@@ -202,9 +202,16 @@ function collectHeartbeatSignal(entity, nowMs) {
         if (typeof raw === 'number' && Number.isFinite(raw)) lastSeenMs = raw;
         else { const ms = Date.parse(raw); if (Number.isFinite(ms)) lastSeenMs = ms; }
     }
-    const stale = lastSeenMs === null || (nowMs - lastSeenMs) > HEARTBEAT_STALE_MS;
+    // Only flag stale when a heartbeat is actually KNOWN and old. Channel-push
+    // entities (claude-code, openclaw channel, etc.) legitimately never report a
+    // daemon lastSeen — treating "no heartbeat" as stale would falsely mark every
+    // healthy channel entity unhealthy and trigger needless repairs. For those,
+    // liveness is judged by the callback /health probe + stuck-message signals.
+    const heartbeatKnown = lastSeenMs !== null;
+    const stale = heartbeatKnown && (nowMs - lastSeenMs) > HEARTBEAT_STALE_MS;
     return {
-        lastSeen: lastSeenMs === null ? null : new Date(lastSeenMs).toISOString(),
+        lastSeen: heartbeatKnown ? new Date(lastSeenMs).toISOString() : null,
+        heartbeatKnown,
         heartbeatStale: stale,
     };
 }
@@ -276,6 +283,7 @@ async function computePassiveHealth(deviceId, entityId) {
             stuckPending: errorSignals.stuckPending,
             counters: errorSignals.counters,
             lastSeen: heartbeat.lastSeen,
+            heartbeatKnown: heartbeat.heartbeatKnown,
             heartbeatStale: heartbeat.heartbeatStale,
             callbackHealthy: channel.callbackHealthy,
         },

--- a/backend/tests/jest/passive-health.test.js
+++ b/backend/tests/jest/passive-health.test.js
@@ -234,6 +234,30 @@ describe('disabled-device no-op', () => {
     });
 });
 
+describe('heartbeat signal (channel-push entities have no daemon lastSeen)', () => {
+    const { collectHeartbeatSignal } = passiveHealth._internal;
+    const now = Date.now();
+
+    it('does NOT flag stale when no heartbeat is known (channel-push entity)', () => {
+        const sig = collectHeartbeatSignal({ isBound: true, bindingType: 'channel' }, now);
+        expect(sig.heartbeatKnown).toBe(false);
+        expect(sig.heartbeatStale).toBe(false);
+        expect(sig.lastSeen).toBeNull();
+    });
+
+    it('flags stale only when a known heartbeat is old', () => {
+        const old = collectHeartbeatSignal({ lastSeen: now - 10 * 60 * 1000 }, now);
+        expect(old.heartbeatKnown).toBe(true);
+        expect(old.heartbeatStale).toBe(true);
+    });
+
+    it('does not flag a fresh known heartbeat', () => {
+        const fresh = collectHeartbeatSignal({ lastSeen: now - 1000 }, now);
+        expect(fresh.heartbeatKnown).toBe(true);
+        expect(fresh.heartbeatStale).toBe(false);
+    });
+});
+
 describe('exports surface', () => {
     it('exposes scheduler + compute functions', () => {
         expect(typeof passiveHealth.startScheduler).toBe('function');


### PR DESCRIPTION
Fixes a false-positive found during live verification of PR #3360: channel-push entities (claude-code/#2, openclaw channel) never report a daemon lastSeen, so the passive verdict wrongly flagged healthy channel entities as heartbeat_stale (would trigger needless self-repair when enabled). Now heartbeat_stale fires only when a heartbeat is KNOWN and old; channel liveness relies on the callback /health probe + stuck-message signals. Adds heartbeatKnown diagnostic + 3 unit tests (18/18 pass). Still DEFAULT OFF. No schema changes.