### PR TITLE
fix(passive-health): partial settings PUT must not clobber omitted fields

### DIFF
--- a/backend/passive-health.js
+++ b/backend/passive-health.js
@@ -551,11 +551,14 @@ router.put('/settings', express.json(), async (req, res) => {
         }
     }
     try {
-        const settings = await updateSettings(auth.deviceId, {
-            enabled: body.enabled,
-            intervalHours: body.intervalHours,
-            autoRepair: body.autoRepair,
-        });
+        // Partial update: only patch keys actually present in the body. (Passing
+        // undefined for an omitted key would make coerceSettings clobber it — e.g.
+        // a PUT of just {autoRepair:false} must NOT silently disable `enabled`.)
+        const patch = {};
+        if ('enabled' in body) patch.enabled = body.enabled;
+        if ('intervalHours' in body) patch.intervalHours = body.intervalHours;
+        if ('autoRepair' in body) patch.autoRepair = body.autoRepair;
+        const settings = await updateSettings(auth.deviceId, patch);
         return res.json({ success: true, deviceId: auth.deviceId, settings });
     } catch (err) {
         console.error('[PassiveHealth] put settings error:', err.message);

--- a/backend/tests/jest/passive-health.test.js
+++ b/backend/tests/jest/passive-health.test.js
@@ -234,6 +234,19 @@ describe('disabled-device no-op', () => {
     });
 });
 
+describe('partial settings PUT preserves omitted fields', () => {
+    it('PUT {autoRepair:false} alone does NOT disable enabled', async () => {
+        await request(app).put('/api/passive-health/settings')
+            .send({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET, enabled: true, autoRepair: true, intervalHours: 6 });
+        const res = await request(app).put('/api/passive-health/settings')
+            .send({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET, autoRepair: false });
+        expect(res.statusCode).toBe(200);
+        expect(res.body.settings.enabled).toBe(true);      // preserved
+        expect(res.body.settings.intervalHours).toBe(6);   // preserved
+        expect(res.body.settings.autoRepair).toBe(false);  // changed
+    });
+});
+
 describe('heartbeat signal (channel-push entities have no daemon lastSeen)', () => {
     const { collectHeartbeatSignal } = passiveHealth._internal;
     const now = Date.now();


### PR DESCRIPTION
Found during live verification of the passive-health subsystem: a partial PUT to /api/passive-health/settings (e.g. {autoRepair:false}) silently reset enabled to false, because the handler always forwarded enabled/intervalHours/autoRepair as undefined and coerceSettings treats key-presence as intent. Now only keys actually present in the body are patched; omitted fields are preserved. Regression test added (19/19). DEFAULT OFF unchanged; no schema changes.