### PR TITLE
feat(animation): 健檢中 health-checking avatar animation (backend state + Web)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -7921,6 +7921,11 @@ app.get('/api/entities', async (req, res) => {
                     lastUpdated: entity.lastUpdated,
                     isBound: true,  // Always true since we only return bound entities
                     avatar: entity.avatar || null,
+                    // Transient passive-health flag (in-memory). Lets polling
+                    // clients (Android live wallpaper / widget / iOS) render the
+                    // 健檢中 (health-checking) animation. Backward-compatible add.
+                    healthChecking: !!entity.healthChecking,
+                    healthCheckingAt: entity.healthCheckingAt || null,
                     petdxCompanionId: petdx.petdxCompanionId || null,
                     petdxAvatarUrl: petdx.petdxAvatarUrl || null,
                     xp: entity.xp || 0,
@@ -8129,6 +8134,11 @@ app.get('/api/status', (req, res) => {
         // widget, iOS) keep entity avatars in sync with the dashboard.
         // See backend/openapi.yaml `/api/status` and Entity schema.
         avatar: entity.avatar || null,
+        // Transient passive-health flag (in-memory). Lets polling clients
+        // (Android live wallpaper / widget / iOS) render the 健檢中
+        // (health-checking) animation. Backward-compatible add.
+        healthChecking: !!entity.healthChecking,
+        healthCheckingAt: entity.healthCheckingAt || null,
         rental_status: entity.rental_status || null,  // 'leased_in', 'leased_out', or null
         rental_contract_id: entity.rental_contract_id || null,
         versionInfo: getVersionInfo(appVersion || entity.appVersion)
@@ -19184,6 +19194,29 @@ passiveHealth.init({
     getChannelAccountById: db.getChannelAccountById,
     isReady: () => persistenceReady,
     selfBaseUrl: `http://localhost:${port}`,
+    // Live-push the transient healthChecking flag so portal clients flip the
+    // 健檢中 (health-checking) animation on/off in real time. Reuses the same
+    // 'entity:update' Socket.IO room-per-device pattern as Discord/bot register.
+    emitEntityUpdate: (deviceId, entityId) => {
+        try {
+            const entity = devices[deviceId] && devices[deviceId].entities
+                ? devices[deviceId].entities[entityId]
+                : null;
+            if (!entity) return;
+            io.to(`device:${deviceId}`).emit('entity:update', {
+                deviceId,
+                entityId,
+                name: entity.name,
+                character: entity.character,
+                state: entity.state,
+                message: entity.message,
+                healthChecking: !!entity.healthChecking,
+                healthCheckingAt: entity.healthCheckingAt || null,
+            });
+        } catch (err) {
+            console.error(`[PassiveHealth] emitEntityUpdate broadcast failed: ${err.message}`);
+        }
+    },
 });
 passiveHealth.startScheduler(3_600_000); // hourly tick; per-device intervalHours gates actual runs
 

--- a/backend/passive-health.js
+++ b/backend/passive-health.js
@@ -44,6 +44,10 @@ let deriveProvider = null;  // index.js deriveChannelProvider(callbackUrl)
 let getChannelAccount = null; // db.getChannelAccountById(id)
 let isReady = () => false;  // () => persistenceReady
 let selfBaseUrl = 'http://localhost:3000'; // base URL for internal self-repair call
+// Optional broadcaster (injected): emitEntityUpdate(deviceId, entityId) pushes a
+// live Socket.IO entity-update to portal clients so the 健檢中 (health-checking)
+// animation flips on/off in real time. No-op if not wired.
+let emitEntityUpdate = null;
 
 // ── Settings defaults (stored under prefs.passiveHealth) ──────────────────────
 const SETTINGS_DEFAULTS = {
@@ -75,6 +79,18 @@ function init(opts) {
     getChannelAccount = opts.getChannelAccountById || null;
     if (typeof opts.isReady === 'function') isReady = opts.isReady;
     if (opts.selfBaseUrl) selfBaseUrl = opts.selfBaseUrl;
+    if (typeof opts.emitEntityUpdate === 'function') emitEntityUpdate = opts.emitEntityUpdate;
+}
+
+// Best-effort live push of the in-memory healthChecking flag. Never throws —
+// a broadcast failure must not abort a health sweep.
+function notifyEntityUpdate(deviceId, entityId) {
+    if (!emitEntityUpdate) return;
+    try {
+        emitEntityUpdate(deviceId, entityId);
+    } catch (err) {
+        console.error('[PassiveHealth] emitEntityUpdate error:', err.message);
+    }
 }
 
 // ── Settings read/write (prefs.passiveHealth JSONB merge) ─────────────────────
@@ -377,52 +393,71 @@ async function fileBugIssue(deviceId, deviceSecret, entityId, provider, failingS
  * 60s cooldown), then file a bug if still unhealthy. Returns a summary.
  */
 async function runEntity(deviceId, deviceSecret, entityId, settings) {
-    const health = await computePassiveHealth(deviceId, entityId);
-    if (!health.eligible) {
-        return { entityId, eligible: false, reason: health.reason };
+    // Mark the entity as "health-checking" for the whole check+repair span so
+    // the Web Portal (and polling clients) can show the 健檢中 animation. The
+    // flag is in-memory only and is guaranteed cleared by the finally guard
+    // below, even if the check/repair throws.
+    const entity = getEntity(deviceId, entityId);
+    if (entity) {
+        entity.healthChecking = true;
+        entity.healthCheckingAt = Date.now();
+        notifyEntityUpdate(deviceId, entityId);
     }
 
-    await logEvent(deviceId, entityId, 'passive_health',
-        health.healthy ? 'Passive health: healthy' : `Passive health: unhealthy (${health.failingSignals.join(', ')})`,
-        { healthy: health.healthy, failingSignals: health.failingSignals, provider: health.provider, signals: health.signals });
+    try {
+        const health = await computePassiveHealth(deviceId, entityId);
+        if (!health.eligible) {
+            return { entityId, eligible: false, reason: health.reason };
+        }
 
-    if (health.healthy || !settings.autoRepair) {
-        return { entityId, eligible: true, healthy: health.healthy, repaired: false, failingSignals: health.failingSignals };
-    }
+        await logEvent(deviceId, entityId, 'passive_health',
+            health.healthy ? 'Passive health: healthy' : `Passive health: unhealthy (${health.failingSignals.join(', ')})`,
+            { healthy: health.healthy, failingSignals: health.failingSignals, provider: health.provider, signals: health.signals });
 
-    // Unhealthy + autoRepair → up to 3 repair attempts, spaced past the cooldown.
-    let recovered = false;
-    for (let attempt = 1; attempt <= MAX_REPAIR_ATTEMPTS; attempt++) {
-        const repair = await attemptSelfRepair(deviceId, deviceSecret, entityId);
+        if (health.healthy || !settings.autoRepair) {
+            return { entityId, eligible: true, healthy: health.healthy, repaired: false, failingSignals: health.failingSignals };
+        }
+
+        // Unhealthy + autoRepair → up to 3 repair attempts, spaced past the cooldown.
+        let recovered = false;
+        for (let attempt = 1; attempt <= MAX_REPAIR_ATTEMPTS; attempt++) {
+            const repair = await attemptSelfRepair(deviceId, deviceSecret, entityId);
+            await logEvent(deviceId, entityId, 'self_repair',
+                `Self-repair attempt ${attempt}/${MAX_REPAIR_ATTEMPTS}: ${repair.ok ? 'triggered' : 'failed'} (http ${repair.status})`,
+                { attempt, ok: repair.ok, httpStatus: repair.status, mode: repair.data && repair.data.mode });
+
+            // Re-check health after the attempt.
+            const recheck = await computePassiveHealth(deviceId, entityId);
+            if (recheck.eligible && recheck.healthy) {
+                recovered = true;
+                await logEvent(deviceId, entityId, 'passive_health',
+                    `Recovered after self-repair attempt ${attempt}`,
+                    { healthy: true, afterAttempt: attempt });
+                break;
+            }
+            if (attempt < MAX_REPAIR_ATTEMPTS) {
+                await sleep(REPAIR_SPACING_MS); // respect the 60s self-repair cooldown
+            }
+        }
+
+        if (recovered) {
+            return { entityId, eligible: true, healthy: false, repaired: true, failingSignals: health.failingSignals };
+        }
+
+        // Still unhealthy after all attempts → file a bug.
+        const bug = await fileBugIssue(deviceId, deviceSecret, entityId, health.provider, health.failingSignals);
         await logEvent(deviceId, entityId, 'self_repair',
-            `Self-repair attempt ${attempt}/${MAX_REPAIR_ATTEMPTS}: ${repair.ok ? 'triggered' : 'failed'} (http ${repair.status})`,
-            { attempt, ok: repair.ok, httpStatus: repair.status, mode: repair.data && repair.data.mode });
+            bug.filed ? `Bug filed after ${MAX_REPAIR_ATTEMPTS} failed repairs (feedback #${bug.feedbackId})` : `Bug filing failed: ${bug.reason}`,
+            { filed: bug.filed, feedbackId: bug.feedbackId, issueUrl: bug.issueUrl, failingSignals: health.failingSignals });
 
-        // Re-check health after the attempt.
-        const recheck = await computePassiveHealth(deviceId, entityId);
-        if (recheck.eligible && recheck.healthy) {
-            recovered = true;
-            await logEvent(deviceId, entityId, 'passive_health',
-                `Recovered after self-repair attempt ${attempt}`,
-                { healthy: true, afterAttempt: attempt });
-            break;
-        }
-        if (attempt < MAX_REPAIR_ATTEMPTS) {
-            await sleep(REPAIR_SPACING_MS); // respect the 60s self-repair cooldown
+        return { entityId, eligible: true, healthy: false, repaired: false, bugFiled: bug.filed, feedbackId: bug.feedbackId, failingSignals: health.failingSignals };
+    } finally {
+        // Always clear the transient flag + push the cleared state, even on error.
+        if (entity) {
+            entity.healthChecking = false;
+            notifyEntityUpdate(deviceId, entityId);
         }
     }
-
-    if (recovered) {
-        return { entityId, eligible: true, healthy: false, repaired: true, failingSignals: health.failingSignals };
-    }
-
-    // Still unhealthy after all attempts → file a bug.
-    const bug = await fileBugIssue(deviceId, deviceSecret, entityId, health.provider, health.failingSignals);
-    await logEvent(deviceId, entityId, 'self_repair',
-        bug.filed ? `Bug filed after ${MAX_REPAIR_ATTEMPTS} failed repairs (feedback #${bug.feedbackId})` : `Bug filing failed: ${bug.reason}`,
-        { filed: bug.filed, feedbackId: bug.feedbackId, issueUrl: bug.issueUrl, failingSignals: health.failingSignals });
-
-    return { entityId, eligible: true, healthy: false, repaired: false, bugFiled: bug.filed, feedbackId: bug.feedbackId, failingSignals: health.failingSignals };
 }
 
 /**

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -4076,6 +4076,12 @@
                 } else {
                     hideTypingIndicator();
                 }
+                // Passive-health 健檢中: toggle a ring + badge on the target-bar
+                // entity label without re-rendering the whole bar. Keeps the
+                // in-memory boundEntities flag in sync for subsequent re-renders.
+                if ('healthChecking' in data && entityId != null) {
+                    applyHealthCheckingToTargetBar(entityId, !!data.healthChecking);
+                }
             };
 
             // Poll every 5 seconds (fallback when socket disconnected)
@@ -4085,6 +4091,29 @@
                 }
             }, 5000);
         });
+
+        // Toggle the 健檢中 (health-checking) ring + badge on a target-bar entity
+        // label. Patches boundEntities so a later full re-render keeps the state,
+        // and mutates the DOM label in place for an instant visual update.
+        function applyHealthCheckingToTargetBar(entityId, on) {
+            const ent = (boundEntities || []).find(e => e.entityId === entityId);
+            if (ent) ent.healthChecking = on;
+            const label = document.querySelector('.target-entity-check[data-entity-id="' + entityId + '"]');
+            if (!label) return;
+            const main = label.querySelector('.target-label-main');
+            if (!main) return;
+            main.classList.toggle('health-checking-inline', on);
+            let badge = main.querySelector('.health-checking-badge-inline');
+            if (on && !badge) {
+                badge = document.createElement('span');
+                badge.className = 'health-checking-badge health-checking-badge-inline';
+                badge.setAttribute('data-i18n', 'health_checking');
+                badge.textContent = (typeof i18n !== 'undefined' && i18n.t) ? i18n.t('health_checking') : 'Health-checking';
+                main.appendChild(badge);
+            } else if (!on && badge) {
+                badge.remove();
+            }
+        }
 
         // ── Usage Badge ──
         // Daily message limit was removed — badge always shows "Unlimited".

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -2979,6 +2979,20 @@
             loadEntities().then(() => onOrgChartEntityChange());
         }
 
+        // Live entity:update push (e.g. passive-health 健檢中 flag toggling on/off).
+        // Patch the in-memory entity + re-render the card so the avatar ring
+        // animation flips without a full reload. Skip during edit mode to
+        // preserve drag state (parity with loadEntities).
+        function onSocketEntityUpdate(data) {
+            if (!data || data.entityId == null) return;
+            if (isEditMode) return;
+            const ent = entities.find(e => e.entityId === data.entityId);
+            if (!ent) return;
+            if ('healthChecking' in data) ent.healthChecking = !!data.healthChecking;
+            if ('healthCheckingAt' in data) ent.healthCheckingAt = data.healthCheckingAt;
+            renderEntities();
+        }
+
         // --- Entity Loading ---
         async function loadEntities() {
             // Skip updates during edit mode to preserve drag state (parity with Android)
@@ -3188,7 +3202,7 @@
                 return '<div class="entity-card card" data-entity-id="' + entity.entityId + '"' + (isEditMode ? ' draggable="true"' : '') + '>' +
                     '<div class="entity-card-body">' +
                     '<div class="drag-handle" title="' + i18n.t('dash_drag_to_reorder') + '">&#9776;</div>' +
-                    '<div class="entity-avatar" onclick="openAvatarPicker(' + entity.entityId + ')">' + renderAvatarHtml(avatar, 48, entity.entityId) + '</div>' +
+                    '<div class="entity-avatar" onclick="openAvatarPicker(' + entity.entityId + ')">' + renderAvatarHtml(avatar, 48, entity.entityId, { healthChecking: !!entity.healthChecking }) + '</div>' +
                     '<div class="entity-info">' +
                     '<div class="entity-name" onclick="openRenamePicker(' + entity.entityId + ', \'' + escapedName + '\')" title="' + i18n.t('dash_rename_title') + '">' + escapeHtml(displayName) + '</div>' +
                     '<div class="entity-badges">' +

--- a/backend/public/portal/shared/entity-utils.js
+++ b/backend/public/portal/shared/entity-utils.js
@@ -185,28 +185,57 @@ function _petdxCanRenderCanvas(entityId) {
     const sheetUrl = (node.asset && node.asset.url) || node.assetUrl;
     return typeof sheetUrl === 'string' && sheetUrl.length > 0;
 }
-function renderAvatarHtml(avatar, size, entityId) {
+function _healthCheckingBadgeHtml() {
+    // Small 「健檢中」label rendered next to a health-checking avatar. Uses
+    // i18n.t() when available (data-i18n keeps it live-translatable), else
+    // falls back to the English string so it never renders a raw key.
+    var label = (typeof i18n !== 'undefined' && typeof i18n.t === 'function')
+        ? i18n.t('health_checking')
+        : 'Health-checking';
+    return '<span class="health-checking-badge" data-i18n="health_checking">' + label + '</span>';
+}
+
+/**
+ * Render an avatar as HTML.
+ *
+ * @param {string} avatar - emoji string or image URL
+ * @param {number} [size=48] - size in px (for image avatars)
+ * @param {number} [entityId] - optional entityId to consider for petdx render
+ * @param {object} [opts] - optional flags. opts.healthChecking=true wraps the
+ *        avatar in a `.health-checking` ring animation + a 「健檢中」badge.
+ */
+function renderAvatarHtml(avatar, size, entityId, opts) {
     size = size || 48;
     const eidAttr = entityId != null ? ' data-entity-id="' + Number(entityId) + '"' : '';
+    let inner;
     if (entityId != null && _petdxCanRenderCanvas(entityId)) {
         // imageRendering keeps the spritesheet pixel-art crisp at small sizes;
         // matches PetdxRenderer's ctx.imageSmoothingEnabled = false.
-        return '<canvas class="entity-avatar-canvas"' + eidAttr
+        inner = '<canvas class="entity-avatar-canvas"' + eidAttr
             + ' data-petdx-entity-id="' + Number(entityId) + '"'
             + ' width="' + size + '" height="' + size + '"'
             + ' style="width:' + size + 'px;height:' + size + 'px;'
             + 'image-rendering:pixelated;border-radius:50%;vertical-align:middle;"'
             + ' aria-label="entity avatar"></canvas>';
-    }
-    if (isAvatarUrl(avatar)) {
-        return '<img src="' + avatar + '" class="entity-avatar-img"' + eidAttr +
+    } else if (isAvatarUrl(avatar)) {
+        inner = '<img src="' + avatar + '" class="entity-avatar-img"' + eidAttr +
             ' style="width:' + size + 'px;height:' + size + 'px;" alt="avatar" loading="lazy">';
+    } else if (entityId != null) {
+        // Emoji fallback — wrap in a span so the click delegate can resolve entityId.
+        inner = '<span class="entity-avatar-emoji"' + eidAttr + '>' + (avatar || '\u{1F99E}') + '</span>';
+    } else {
+        inner = avatar || '\u{1F99E}';
     }
-    // Emoji fallback — wrap in a span so the click delegate can resolve entityId.
-    if (entityId != null) {
-        return '<span class="entity-avatar-emoji"' + eidAttr + '>' + (avatar || '\u{1F99E}') + '</span>';
+
+    // Health-checking: wrap in a pulsing/glowing ring + 「健檢中」badge. The
+    // wrapper keeps the original markup intact so existing click delegates that
+    // resolve data-entity-id still work.
+    if (opts && opts.healthChecking) {
+        return '<span class="avatar-health-wrap health-checking" '
+            + 'style="width:' + size + 'px;height:' + size + 'px;">'
+            + inner + _healthCheckingBadgeHtml() + '</span>';
     }
-    return avatar || '\u{1F99E}';
+    return inner;
 }
 
 /**

--- a/backend/public/portal/shared/style.css
+++ b/backend/public/portal/shared/style.css
@@ -585,6 +585,81 @@ a:hover { text-decoration: underline; }
     object-fit: cover;
 }
 
+/* ── Passive-health "健檢中" (health-checking) animation ─────────────────────
+   When an entity is being checked/repaired by the passive-health subsystem,
+   renderAvatarHtml() wraps its avatar in .avatar-health-wrap.health-checking.
+   A pulsing/glowing ring + a small badge signal the in-progress state. */
+.avatar-health-wrap {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    vertical-align: middle;
+}
+.avatar-health-wrap.health-checking::before {
+    content: "";
+    position: absolute;
+    inset: -4px;
+    border-radius: 50%;
+    border: 2px solid var(--accent-cyan, #4fc3f7);
+    box-shadow: 0 0 8px 2px rgba(79, 195, 247, 0.6);
+    pointer-events: none;
+    animation: healthCheckPulse 1.4s ease-in-out infinite;
+}
+@keyframes healthCheckPulse {
+    0%   { transform: scale(0.92); opacity: 0.55; }
+    50%  { transform: scale(1.08); opacity: 1; }
+    100% { transform: scale(0.92); opacity: 0.55; }
+}
+.health-checking-badge {
+    position: absolute;
+    bottom: -8px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--accent-cyan, #4fc3f7);
+    color: #06283d;
+    font-size: 9px;
+    font-weight: 600;
+    line-height: 1;
+    padding: 2px 5px;
+    border-radius: 8px;
+    white-space: nowrap;
+    pointer-events: none;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+/* Inline variant for the chat target bar: the label is a compact flex row, so
+   render the badge inline (not absolutely positioned) and give the row a subtle
+   pulsing glow instead of a ring. */
+.health-checking-badge-inline {
+    position: static;
+    transform: none;
+    bottom: auto;
+    left: auto;
+    margin-left: 4px;
+}
+.target-label-main.health-checking-inline {
+    animation: healthCheckGlow 1.4s ease-in-out infinite;
+    border-radius: 6px;
+}
+@keyframes healthCheckGlow {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(79, 195, 247, 0); }
+    50%      { box-shadow: 0 0 6px 1px rgba(79, 195, 247, 0.7); }
+}
+
+/* Respect users who prefer reduced motion: keep the ring + badge visible as a
+   static indicator, but drop the pulsing animation. */
+@media (prefers-reduced-motion: reduce) {
+    .avatar-health-wrap.health-checking::before {
+        animation: none;
+        opacity: 0.9;
+    }
+    .target-label-main.health-checking-inline {
+        animation: none;
+        box-shadow: 0 0 4px 1px rgba(79, 195, 247, 0.6);
+    }
+}
+
 .avatar-upload-area {
     position: relative;
     width: 100%;

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -241032,7 +241032,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "Code",
+        "dash_public_code": "Code", "health_checking": "Health-checking",
 
 
 
@@ -880739,7 +880739,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "代碼",
+        "dash_public_code": "代碼", "health_checking": "健檢中",
 
 
 
@@ -1330810,7 +1330810,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "代碼",
+        "dash_public_code": "代碼", "health_checking": "健检中",
 
 
 
@@ -2057366,7 +2057366,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "コード",
+        "dash_public_code": "コード", "health_checking": "ヘルスチェック中",
 
 
 
@@ -2620566,7 +2620566,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "코드",
+        "dash_public_code": "코드", "health_checking": "상태 점검 중",
 
 
 
@@ -3153474,7 +3153474,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "โค้ด",
+        "dash_public_code": "โค้ด", "health_checking": "กำลังตรวจสุขภาพ",
 
 
 
@@ -3682676,7 +3682676,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "Mã",
+        "dash_public_code": "Mã", "health_checking": "Đang kiểm tra tình trạng",
 
 
 
@@ -4209379,7 +4209379,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "Kode",
+        "dash_public_code": "Kode", "health_checking": "Memeriksa kesehatan",
 
 
 
@@ -4735826,7 +4735826,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "Code",
+        "dash_public_code": "Code", "health_checking": "Vérification de l’état",
 
 
 
@@ -5259388,7 +5259388,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "Código...",
+        "dash_public_code": "Código...", "health_checking": "Comprobando estado",
 
 
 
@@ -5778060,7 +5778060,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "Code",
+        "dash_public_code": "Code", "health_checking": "Zustandsprüfung läuft",
 
 
 
@@ -6105604,7 +6105604,7 @@ const TRANSLATIONS = {
         "dash_avatar_remove": "Remove photo",
         "dash_avatar_removed": "Photo removed",
         "dash_code_copied": "Command copied to clipboard!",
-        "dash_public_code": "Code",
+        "dash_public_code": "Code", "health_checking": "Verificando integridade",
         "dash_copy_code": "Click to copy public code",
         "dash_public_code_copied": "Public code copied!",
         "dash_code_generated": "Binding code generated!",
@@ -6315096,7 +6315096,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "Kod",
+        "dash_public_code": "Kod", "health_checking": "Menyemak kesihatan",
 
 
 
@@ -6780118,7 +6780118,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "कोड",
+        "dash_public_code": "कोड", "health_checking": "स्वास्थ्य जाँच जारी",
 
 
 
@@ -7403099,7 +7403099,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "الكود",
+        "dash_public_code": "الكود", "health_checking": "جارٍ فحص الحالة",
 
 
 


### PR DESCRIPTION
Adds the 健檢中 (health-checking) animation: while passive-health checks/repairs an entity, its avatar animates + shows a 健檢中 badge in the Web Portal, and the state is exposed for Android/iOS (those clients are a follow-up).
- backend/passive-health.js runEntity: set in-memory entity.healthChecking true for the whole check+repair span, cleared in finally; best-effort Socket.IO broadcast via injected emitEntityUpdate.
- backend/index.js: wire emitEntityUpdate -> io.to(device:ID).emit('entity:update', {...healthChecking}); expose healthChecking + healthCheckingAt in /api/status & /api/entities (additive).
- Web: entity-utils renderAvatarHtml health-checking ring + badge; dashboard + chat target bar live-toggle on entity:update; style.css pulse/glow + prefers-reduced-motion fallback.
- i18n: health_checking added to all 15 locales (no hardcoded text).
Verify: i18n-syntax jest pass, i18n-check.js pass, passive-health jest 19 pass, node --check OK.