### PR TITLE
fix(plaza-toggle): AGENT_CARD_INCOMPLETE + Plaza vs Rental naming clarity (card_36a)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -7921,6 +7921,11 @@ app.get('/api/entities', async (req, res) => {
                     lastUpdated: entity.lastUpdated,
                     isBound: true,  // Always true since we only return bound entities
                     avatar: entity.avatar || null,
+                    // Transient passive-health flag (in-memory). Lets polling
+                    // clients (Android live wallpaper / widget / iOS) render the
+                    // 健檢中 (health-checking) animation. Backward-compatible add.
+                    healthChecking: !!entity.healthChecking,
+                    healthCheckingAt: entity.healthCheckingAt || null,
                     petdxCompanionId: petdx.petdxCompanionId || null,
                     petdxAvatarUrl: petdx.petdxAvatarUrl || null,
                     xp: entity.xp || 0,
@@ -8129,6 +8134,11 @@ app.get('/api/status', (req, res) => {
         // widget, iOS) keep entity avatars in sync with the dashboard.
         // See backend/openapi.yaml `/api/status` and Entity schema.
         avatar: entity.avatar || null,
+        // Transient passive-health flag (in-memory). Lets polling clients
+        // (Android live wallpaper / widget / iOS) render the 健檢中
+        // (health-checking) animation. Backward-compatible add.
+        healthChecking: !!entity.healthChecking,
+        healthCheckingAt: entity.healthCheckingAt || null,
         rental_status: entity.rental_status || null,  // 'leased_in', 'leased_out', or null
         rental_contract_id: entity.rental_contract_id || null,
         versionInfo: getVersionInfo(appVersion || entity.appVersion)
@@ -19184,6 +19194,29 @@ passiveHealth.init({
     getChannelAccountById: db.getChannelAccountById,
     isReady: () => persistenceReady,
     selfBaseUrl: `http://localhost:${port}`,
+    // Live-push the transient healthChecking flag so portal clients flip the
+    // 健檢中 (health-checking) animation on/off in real time. Reuses the same
+    // 'entity:update' Socket.IO room-per-device pattern as Discord/bot register.
+    emitEntityUpdate: (deviceId, entityId) => {
+        try {
+            const entity = devices[deviceId] && devices[deviceId].entities
+                ? devices[deviceId].entities[entityId]
+                : null;
+            if (!entity) return;
+            io.to(`device:${deviceId}`).emit('entity:update', {
+                deviceId,
+                entityId,
+                name: entity.name,
+                character: entity.character,
+                state: entity.state,
+                message: entity.message,
+                healthChecking: !!entity.healthChecking,
+                healthCheckingAt: entity.healthCheckingAt || null,
+            });
+        } catch (err) {
+            console.error(`[PassiveHealth] emitEntityUpdate broadcast failed: ${err.message}`);
+        }
+    },
 });
 passiveHealth.startScheduler(3_600_000); // hourly tick; per-device intervalHours gates actual runs
 

--- a/backend/index.js
+++ b/backend/index.js
@@ -9289,7 +9289,12 @@ app.post('/api/transform', transformMaybeMultipart, idempotencyMiddleware, async
             const targetDev = devices[targetDeviceId];
             if (targetDev) {
                 const replySource = `xdevice:${entity.publicCode}:${entity.character}->${targetDeviceId}`;
-                await saveChatMessage(targetDeviceId, 0, finalMessage, replySource, false, true);
+                const explicitRouteMeta = buildRoutingMeta({
+                    mode: 'xdevice', fromEntity: entity, fromId: eId,
+                    toEntity: null, toId: 0,
+                    fromPublicCode: entity.publicCode
+                });
+                await saveChatMessage(targetDeviceId, 0, finalMessage, replySource, false, true, null, null, null, null, null, null, null, null, null, explicitRouteMeta);
                 serverLog('info', 'cross_speak_push', `[EXPLICIT_ROUTE] Transform routed reply to ${targetDeviceId}`, {
                     deviceId, entityId: eId,
                     metadata: { targetDeviceId, fromPublicCode: entity.publicCode }
@@ -9310,7 +9315,13 @@ app.post('/api/transform', transformMaybeMultipart, idempotencyMiddleware, async
             if (pendingCross && pendingCross.fromDeviceId) {
                 const replySource = `xdevice:${entity.publicCode}:${entity.character}->${pendingCross.fromPublicCode || pendingCross.fromDeviceId}`;
                 const senderEntityId = pendingCross.fromEntityId >= 0 ? pendingCross.fromEntityId : 0;
-                await saveChatMessage(pendingCross.fromDeviceId, senderEntityId, finalMessage, replySource, false, true);
+                const autoRouteMeta = buildRoutingMeta({
+                    mode: 'xdevice', fromEntity: entity, fromId: eId,
+                    toEntity: null, toId: senderEntityId,
+                    fromPublicCode: entity.publicCode,
+                    toPublicCode: pendingCross.fromPublicCode || null
+                });
+                await saveChatMessage(pendingCross.fromDeviceId, senderEntityId, finalMessage, replySource, false, true, null, null, null, null, null, null, null, null, null, autoRouteMeta);
                 serverLog('info', 'cross_speak_push', `[CROSS_ROUTE] Transform auto-routed reply to sender ${pendingCross.fromDeviceId}:${senderEntityId}`, {
                     deviceId, entityId: eId,
                     metadata: { senderDeviceId: pendingCross.fromDeviceId, senderEntityId, fromPublicCode: pendingCross.fromPublicCode }
@@ -11856,7 +11867,8 @@ app.post('/api/entity/speak-to', async (req, res) => {
         deviceId, entityId: toId,
         metadata: { tag: 'A2A_MQ_PUSH', fromEntityId: fromId, toEntityId: toId, mqLen: toEntity.messageQueue.length }
     });
-    const chatMsgId = await saveChatMessage(deviceId, fromId, speakToText, `${sourceLabel}->${toId}`, false, true, mediaType || null, mediaUrl || null);
+    const speakToRoutingMeta = buildRoutingMeta({ mode: 'speakTo', fromEntity, fromId, toEntity, toId });
+    const chatMsgId = await saveChatMessage(deviceId, fromId, speakToText, `${sourceLabel}->${toId}`, false, true, mediaType || null, mediaUrl || null, null, null, null, null, null, null, null, speakToRoutingMeta);
     markMessagesAsRead(deviceId, toId);
 
     // ── A2A Debug Telemetry ──
@@ -12254,9 +12266,13 @@ app.post('/api/entity/cross-speak', async (req, res) => {
     enqueueMessage(toEntity, messageObj, 'xdevice_publiccode');
 
     // Save chat message on BOTH devices
-    const chatMsgId = await saveChatMessage(target.deviceId, target.entityId, crossText, `${sourceLabel}->${targetCode}`, false, true, mediaType || null, mediaUrl || null);
+    const crossRoutingMeta = buildRoutingMeta({
+        mode: 'xdevice', fromEntity, fromId, toEntity, toId: target.entityId,
+        fromPublicCode: fromEntity.publicCode, toPublicCode: targetCode
+    });
+    const chatMsgId = await saveChatMessage(target.deviceId, target.entityId, crossText, `${sourceLabel}->${targetCode}`, false, true, mediaType || null, mediaUrl || null, null, null, null, null, null, null, null, crossRoutingMeta);
     // Also save on sender side for their chat history
-    await saveChatMessage(deviceId, fromId, crossText, `${sourceLabel}->${targetCode}`, false, true, mediaType || null, mediaUrl || null);
+    await saveChatMessage(deviceId, fromId, crossText, `${sourceLabel}->${targetCode}`, false, true, mediaType || null, mediaUrl || null, null, null, null, null, null, null, null, crossRoutingMeta);
 
     // Update target entity state
     toEntity.message = `xdevice:${fromEntity.publicCode}:${fromEntity.character}: ${crossText}`;
@@ -12627,9 +12643,27 @@ async function handleVisibility(req, res) {
         return res.status(404).json({ success: false, error: 'Entity not found or not bound' });
     }
 
-    // Must have an agent card to publish
-    if (isPublic && !entity.agentCard) {
-        return res.status(400).json({ success: false, error: 'Entity must have an agent card before publishing' });
+    // card_36a: AGENT_CARD_INCOMPLETE returns missing-field list so the
+    // toggle UI can highlight the empty inputs instead of showing a single
+    // abstract red banner.
+    if (isPublic) {
+        const card = entity.agentCard;
+        const missingFields = [];
+        if (!card || typeof card !== 'object') {
+            missingFields.push('description', 'protocols', 'tags');
+        } else {
+            if (!card.description || !String(card.description).trim()) missingFields.push('description');
+            if (!Array.isArray(card.protocols) || card.protocols.length === 0) missingFields.push('protocols');
+            if (!Array.isArray(card.tags) || card.tags.length === 0) missingFields.push('tags');
+        }
+        if (missingFields.length) {
+            return res.status(400).json({
+                success: false,
+                code: 'AGENT_CARD_INCOMPLETE',
+                error: 'Agent card incomplete — please fill: ' + missingFields.join(', '),
+                missingFields
+            });
+        }
     }
 
     const ok = await db.setEntityPublic(deviceId, eId, isPublic);
@@ -14372,11 +14406,18 @@ app.post('/api/client/cross-speak', async (req, res) => {
 
     // Save chat message — always save to both sender and target devices
     const sourceTag = `${sourceLabel}->${targetCode}`;
-    const chatMsgId = await saveChatMessage(target.deviceId, target.entityId, text, sourceTag, true, false, mediaType || null, mediaUrl || null, null, null, null, null, null, validatedAttachments);
+    const clientCrossRoutingMeta = buildRoutingMeta({
+        mode: 'xdevice',
+        fromEntity: isOwnerMode ? null : fromEntity, fromId: isOwnerMode ? 0 : fromId,
+        toEntity, toId: target.entityId,
+        fromPublicCode: isOwnerMode ? null : fromEntity.publicCode,
+        toPublicCode: targetCode
+    });
+    const chatMsgId = await saveChatMessage(target.deviceId, target.entityId, text, sourceTag, true, false, mediaType || null, mediaUrl || null, null, null, null, null, null, validatedAttachments, null, clientCrossRoutingMeta);
     // Also save sender's copy: in owner mode use entity 0; in entity mode use fromId
     const senderEntityId = isOwnerMode ? 0 : fromId;
     if (deviceId !== target.deviceId || senderEntityId !== target.entityId) {
-        await saveChatMessage(deviceId, senderEntityId, text, sourceTag, true, false, mediaType || null, mediaUrl || null, null, null, null, null, null, validatedAttachments);
+        await saveChatMessage(deviceId, senderEntityId, text, sourceTag, true, false, mediaType || null, mediaUrl || null, null, null, null, null, null, validatedAttachments, null, clientCrossRoutingMeta);
     }
 
     toEntity.message = isOwnerMode ? `xdevice:owner: ${text}` : `xdevice:${fromEntity.publicCode}:${fromEntity.character}: ${text}`;
@@ -14679,7 +14720,14 @@ app.post('/api/entity/broadcast', async (req, res) => {
     serverLog('info', 'broadcast', `Entity ${fromId} -> [${targetIds.join(',')}]: "${broadcastText.slice(0, 80)}"`, { deviceId, entityId: fromId, metadata: { targets: targetIds, b2bRemaining } });
 
     // Save ONE chat message for the broadcast (sender's perspective, all targets)
-    const broadcastChatMsgId = await saveChatMessage(deviceId, fromId, broadcastText, `${sourceLabel}->${targetIds.join(',')}`, false, true, mediaType || null, mediaUrl || null);
+    // routing_meta uses the first target's LV as representative (broadcast chip mode is set explicitly).
+    const broadcastFirstTarget = device.entities[targetIds[0]];
+    const broadcastRoutingMeta = buildRoutingMeta({
+        mode: 'broadcast', fromEntity, fromId,
+        toEntity: broadcastFirstTarget, toId: targetIds[0]
+    });
+    broadcastRoutingMeta.broadcast_target_ids = targetIds.slice();
+    const broadcastChatMsgId = await saveChatMessage(deviceId, fromId, broadcastText, `${sourceLabel}->${targetIds.join(',')}`, false, true, mediaType || null, mediaUrl || null, null, null, null, null, null, null, null, broadcastRoutingMeta);
 
     // Notify device about broadcast (fire-and-forget)
     notifyDevice(deviceId, {
@@ -20230,6 +20278,28 @@ async function getDeviceVarForEmbedding(deviceId, varName) {
     } catch {
         return null;
     }
+}
+
+// Build a routing_meta object for chat_messages from sender/target entities.
+// Used by non-deliverToEntity paths (legacy entity speak-to, cross-speak, broadcast)
+// so renderRoutingChip on the client always has structured routing context.
+// deliverToEntity keeps its own inline literal (locked by routing-meta-payload.test.js).
+function buildRoutingMeta({ mode, fromEntity, fromId, toEntity, toId, status, fromPublicCode, toPublicCode } = {}) {
+    const entityName = (e, id) => (e && (e.name || e.character)) || (id != null ? `Entity ${id}` : '?');
+    const entityLv = (e) => (e && Number.isFinite(Number(e.level))) ? Number(e.level) : 1;
+    const meta = {
+        mode: mode || 'speakTo',
+        from_entity_id: fromId != null ? fromId : null,
+        from_name: entityName(fromEntity, fromId),
+        from_lv: entityLv(fromEntity),
+        to_entity_id: toId != null ? toId : null,
+        to_name: entityName(toEntity, toId),
+        to_lv: entityLv(toEntity),
+        status: status || 'sent'
+    };
+    if (fromPublicCode) meta.from_public_code = fromPublicCode;
+    if (toPublicCode) meta.to_public_code = toPublicCode;
+    return meta;
 }
 
 // Save chat message to database, returns row ID (UUID) or null

--- a/backend/passive-health.js
+++ b/backend/passive-health.js
@@ -44,6 +44,10 @@ let deriveProvider = null;  // index.js deriveChannelProvider(callbackUrl)
 let getChannelAccount = null; // db.getChannelAccountById(id)
 let isReady = () => false;  // () => persistenceReady
 let selfBaseUrl = 'http://localhost:3000'; // base URL for internal self-repair call
+// Optional broadcaster (injected): emitEntityUpdate(deviceId, entityId) pushes a
+// live Socket.IO entity-update to portal clients so the 健檢中 (health-checking)
+// animation flips on/off in real time. No-op if not wired.
+let emitEntityUpdate = null;
 
 // ── Settings defaults (stored under prefs.passiveHealth) ──────────────────────
 const SETTINGS_DEFAULTS = {
@@ -75,6 +79,18 @@ function init(opts) {
     getChannelAccount = opts.getChannelAccountById || null;
     if (typeof opts.isReady === 'function') isReady = opts.isReady;
     if (opts.selfBaseUrl) selfBaseUrl = opts.selfBaseUrl;
+    if (typeof opts.emitEntityUpdate === 'function') emitEntityUpdate = opts.emitEntityUpdate;
+}
+
+// Best-effort live push of the in-memory healthChecking flag. Never throws —
+// a broadcast failure must not abort a health sweep.
+function notifyEntityUpdate(deviceId, entityId) {
+    if (!emitEntityUpdate) return;
+    try {
+        emitEntityUpdate(deviceId, entityId);
+    } catch (err) {
+        console.error('[PassiveHealth] emitEntityUpdate error:', err.message);
+    }
 }
 
 // ── Settings read/write (prefs.passiveHealth JSONB merge) ─────────────────────
@@ -377,52 +393,71 @@ async function fileBugIssue(deviceId, deviceSecret, entityId, provider, failingS
  * 60s cooldown), then file a bug if still unhealthy. Returns a summary.
  */
 async function runEntity(deviceId, deviceSecret, entityId, settings) {
-    const health = await computePassiveHealth(deviceId, entityId);
-    if (!health.eligible) {
-        return { entityId, eligible: false, reason: health.reason };
+    // Mark the entity as "health-checking" for the whole check+repair span so
+    // the Web Portal (and polling clients) can show the 健檢中 animation. The
+    // flag is in-memory only and is guaranteed cleared by the finally guard
+    // below, even if the check/repair throws.
+    const entity = getEntity(deviceId, entityId);
+    if (entity) {
+        entity.healthChecking = true;
+        entity.healthCheckingAt = Date.now();
+        notifyEntityUpdate(deviceId, entityId);
     }
 
-    await logEvent(deviceId, entityId, 'passive_health',
-        health.healthy ? 'Passive health: healthy' : `Passive health: unhealthy (${health.failingSignals.join(', ')})`,
-        { healthy: health.healthy, failingSignals: health.failingSignals, provider: health.provider, signals: health.signals });
+    try {
+        const health = await computePassiveHealth(deviceId, entityId);
+        if (!health.eligible) {
+            return { entityId, eligible: false, reason: health.reason };
+        }
 
-    if (health.healthy || !settings.autoRepair) {
-        return { entityId, eligible: true, healthy: health.healthy, repaired: false, failingSignals: health.failingSignals };
-    }
+        await logEvent(deviceId, entityId, 'passive_health',
+            health.healthy ? 'Passive health: healthy' : `Passive health: unhealthy (${health.failingSignals.join(', ')})`,
+            { healthy: health.healthy, failingSignals: health.failingSignals, provider: health.provider, signals: health.signals });
 
-    // Unhealthy + autoRepair → up to 3 repair attempts, spaced past the cooldown.
-    let recovered = false;
-    for (let attempt = 1; attempt <= MAX_REPAIR_ATTEMPTS; attempt++) {
-        const repair = await attemptSelfRepair(deviceId, deviceSecret, entityId);
+        if (health.healthy || !settings.autoRepair) {
+            return { entityId, eligible: true, healthy: health.healthy, repaired: false, failingSignals: health.failingSignals };
+        }
+
+        // Unhealthy + autoRepair → up to 3 repair attempts, spaced past the cooldown.
+        let recovered = false;
+        for (let attempt = 1; attempt <= MAX_REPAIR_ATTEMPTS; attempt++) {
+            const repair = await attemptSelfRepair(deviceId, deviceSecret, entityId);
+            await logEvent(deviceId, entityId, 'self_repair',
+                `Self-repair attempt ${attempt}/${MAX_REPAIR_ATTEMPTS}: ${repair.ok ? 'triggered' : 'failed'} (http ${repair.status})`,
+                { attempt, ok: repair.ok, httpStatus: repair.status, mode: repair.data && repair.data.mode });
+
+            // Re-check health after the attempt.
+            const recheck = await computePassiveHealth(deviceId, entityId);
+            if (recheck.eligible && recheck.healthy) {
+                recovered = true;
+                await logEvent(deviceId, entityId, 'passive_health',
+                    `Recovered after self-repair attempt ${attempt}`,
+                    { healthy: true, afterAttempt: attempt });
+                break;
+            }
+            if (attempt < MAX_REPAIR_ATTEMPTS) {
+                await sleep(REPAIR_SPACING_MS); // respect the 60s self-repair cooldown
+            }
+        }
+
+        if (recovered) {
+            return { entityId, eligible: true, healthy: false, repaired: true, failingSignals: health.failingSignals };
+        }
+
+        // Still unhealthy after all attempts → file a bug.
+        const bug = await fileBugIssue(deviceId, deviceSecret, entityId, health.provider, health.failingSignals);
         await logEvent(deviceId, entityId, 'self_repair',
-            `Self-repair attempt ${attempt}/${MAX_REPAIR_ATTEMPTS}: ${repair.ok ? 'triggered' : 'failed'} (http ${repair.status})`,
-            { attempt, ok: repair.ok, httpStatus: repair.status, mode: repair.data && repair.data.mode });
+            bug.filed ? `Bug filed after ${MAX_REPAIR_ATTEMPTS} failed repairs (feedback #${bug.feedbackId})` : `Bug filing failed: ${bug.reason}`,
+            { filed: bug.filed, feedbackId: bug.feedbackId, issueUrl: bug.issueUrl, failingSignals: health.failingSignals });
 
-        // Re-check health after the attempt.
-        const recheck = await computePassiveHealth(deviceId, entityId);
-        if (recheck.eligible && recheck.healthy) {
-            recovered = true;
-            await logEvent(deviceId, entityId, 'passive_health',
-                `Recovered after self-repair attempt ${attempt}`,
-                { healthy: true, afterAttempt: attempt });
-            break;
-        }
-        if (attempt < MAX_REPAIR_ATTEMPTS) {
-            await sleep(REPAIR_SPACING_MS); // respect the 60s self-repair cooldown
+        return { entityId, eligible: true, healthy: false, repaired: false, bugFiled: bug.filed, feedbackId: bug.feedbackId, failingSignals: health.failingSignals };
+    } finally {
+        // Always clear the transient flag + push the cleared state, even on error.
+        if (entity) {
+            entity.healthChecking = false;
+            notifyEntityUpdate(deviceId, entityId);
         }
     }
-
-    if (recovered) {
-        return { entityId, eligible: true, healthy: false, repaired: true, failingSignals: health.failingSignals };
-    }
-
-    // Still unhealthy after all attempts → file a bug.
-    const bug = await fileBugIssue(deviceId, deviceSecret, entityId, health.provider, health.failingSignals);
-    await logEvent(deviceId, entityId, 'self_repair',
-        bug.filed ? `Bug filed after ${MAX_REPAIR_ATTEMPTS} failed repairs (feedback #${bug.feedbackId})` : `Bug filing failed: ${bug.reason}`,
-        { filed: bug.filed, feedbackId: bug.feedbackId, issueUrl: bug.issueUrl, failingSignals: health.failingSignals });
-
-    return { entityId, eligible: true, healthy: false, repaired: false, bugFiled: bug.filed, feedbackId: bug.feedbackId, failingSignals: health.failingSignals };
 }
 
 /**

--- a/backend/public/portal/card-holder.html
+++ b/backend/public/portal/card-holder.html
@@ -631,6 +631,14 @@
         .plaza-toggle-row .plaza-label { display: flex; flex-direction: column; gap: 2px; }
         .plaza-toggle-row .plaza-label span:first-child { font-size: 13px; font-weight: 600; color: var(--text); }
         .plaza-toggle-row .plaza-label span:last-child { font-size: 11px; color: var(--text-secondary); }
+        /* card_36a: red highlight on incomplete agent-card fields when Plaza toggle rejected */
+        .plaza-missing-field,
+        .plaza-missing-field input,
+        .plaza-missing-field textarea {
+            border: 1.5px solid #ef4444 !important;
+            background: rgba(239, 68, 68, 0.06) !important;
+            transition: border-color 0.3s, background 0.3s;
+        }
     </style>
     <link rel="canonical" href="https://eclawbot.com/portal/card-holder.html">
 </head>
@@ -1108,8 +1116,8 @@
 
                     <div class="plaza-toggle-row">
                         <div class="plaza-label">
-                            <span>${t('dash_plaza_publish', 'Publish to Bot Plaza')}</span>
-                            <span>${t('dash_plaza_publish_hint', 'List this bot publicly so others can discover and interact with it')}</span>
+                            <span>${t('card_plaza_make_public', 'Make public on Plaza (free showcase)')}</span>
+                            <span>${t('card_plaza_make_public_hint', 'Display your bot on the public Plaza so others can discover it — free showcase, not for rental.')}</span>
                         </div>
                         <label class="toggle-switch">
                             <input type="checkbox" id="plazaToggleCH" onchange="togglePlazaCH('${escapeAttr(card.publicCode)}', ${card.entityId}, this.checked)" ${card.isPublic ? 'checked' : ''}>
@@ -1376,6 +1384,31 @@
             }
         }
 
+        // card_36a: localized labels + highlight target for missingFields error
+        const CH_PLAZA_FIELD_MAP = {
+            description: { i18n: 'dash_plaza_missing_description', fallback: 'Description', target: 'edit-desc' },
+            protocols: { i18n: 'dash_plaza_missing_protocols', fallback: 'Protocols (at least one)', target: 'aceProtoInCH' },
+            tags: { i18n: 'dash_plaza_missing_tags', fallback: 'Tags (at least one)', target: 'aceTagInCH' }
+        };
+
+        function highlightChMissing(missingFields) {
+            (missingFields || []).forEach(function(f) {
+                const info = CH_PLAZA_FIELD_MAP[f];
+                if (!info) return;
+                const el = document.getElementById(info.target);
+                if (!el) return;
+                el.classList.add('plaza-missing-field');
+                const clear = () => {
+                    el.classList.remove('plaza-missing-field');
+                    el.removeEventListener('input', clear);
+                    el.removeEventListener('change', clear);
+                };
+                el.addEventListener('input', clear);
+                el.addEventListener('change', clear);
+                setTimeout(clear, 8000);
+            });
+        }
+
         async function togglePlazaCH(publicCode, entityId, isPublic) {
             const checkbox = document.getElementById('plazaToggleCH');
             checkbox.disabled = true;
@@ -1392,11 +1425,30 @@
                     showToast(t(isPublic ? 'dash_plaza_published' : 'dash_plaza_unpublished', isPublic ? 'Published!' : 'Removed'), 'success');
                 } else {
                     checkbox.checked = !isPublic;
-                    showToast(data.error || t('common_error', 'Error'), 'error');
+                    if (data.code === 'AGENT_CARD_INCOMPLETE' && Array.isArray(data.missingFields)) {
+                        const labels = data.missingFields.map(f => {
+                            const info = CH_PLAZA_FIELD_MAP[f];
+                            return info ? (t(info.i18n, info.fallback)) : f;
+                        }).join('、');
+                        showToast(t('dash_plaza_incomplete_title', 'Please complete your card before publishing') + '：' + labels, 'error');
+                        highlightChMissing(data.missingFields);
+                    } else {
+                        showToast(data.error || t('common_error', 'Error'), 'error');
+                    }
                 }
             } catch (err) {
                 checkbox.checked = !isPublic;
-                showToast(t('common_error', 'Error') + ': ' + err.message, 'error');
+                const payload = (err && err.data) || {};
+                if (payload.code === 'AGENT_CARD_INCOMPLETE' && Array.isArray(payload.missingFields)) {
+                    const labels2 = payload.missingFields.map(f => {
+                        const info = CH_PLAZA_FIELD_MAP[f];
+                        return info ? (t(info.i18n, info.fallback)) : f;
+                    }).join('、');
+                    showToast(t('dash_plaza_incomplete_title', 'Please complete your card before publishing') + '：' + labels2, 'error');
+                    highlightChMissing(payload.missingFields);
+                } else {
+                    showToast(t('common_error', 'Error') + ': ' + err.message, 'error');
+                }
             } finally {
                 checkbox.disabled = false;
             }

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -4076,6 +4076,12 @@
                 } else {
                     hideTypingIndicator();
                 }
+                // Passive-health 健檢中: toggle a ring + badge on the target-bar
+                // entity label without re-rendering the whole bar. Keeps the
+                // in-memory boundEntities flag in sync for subsequent re-renders.
+                if ('healthChecking' in data && entityId != null) {
+                    applyHealthCheckingToTargetBar(entityId, !!data.healthChecking);
+                }
             };
 
             // Poll every 5 seconds (fallback when socket disconnected)
@@ -4085,6 +4091,29 @@
                 }
             }, 5000);
         });
+
+        // Toggle the 健檢中 (health-checking) ring + badge on a target-bar entity
+        // label. Patches boundEntities so a later full re-render keeps the state,
+        // and mutates the DOM label in place for an instant visual update.
+        function applyHealthCheckingToTargetBar(entityId, on) {
+            const ent = (boundEntities || []).find(e => e.entityId === entityId);
+            if (ent) ent.healthChecking = on;
+            const label = document.querySelector('.target-entity-check[data-entity-id="' + entityId + '"]');
+            if (!label) return;
+            const main = label.querySelector('.target-label-main');
+            if (!main) return;
+            main.classList.toggle('health-checking-inline', on);
+            let badge = main.querySelector('.health-checking-badge-inline');
+            if (on && !badge) {
+                badge = document.createElement('span');
+                badge.className = 'health-checking-badge health-checking-badge-inline';
+                badge.setAttribute('data-i18n', 'health_checking');
+                badge.textContent = (typeof i18n !== 'undefined' && i18n.t) ? i18n.t('health_checking') : 'Health-checking';
+                main.appendChild(badge);
+            } else if (!on && badge) {
+                badge.remove();
+            }
+        }
 
         // ── Usage Badge ──
         // Daily message limit was removed — badge always shows "Unlimited".

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -2979,6 +2979,20 @@
             loadEntities().then(() => onOrgChartEntityChange());
         }
 
+        // Live entity:update push (e.g. passive-health 健檢中 flag toggling on/off).
+        // Patch the in-memory entity + re-render the card so the avatar ring
+        // animation flips without a full reload. Skip during edit mode to
+        // preserve drag state (parity with loadEntities).
+        function onSocketEntityUpdate(data) {
+            if (!data || data.entityId == null) return;
+            if (isEditMode) return;
+            const ent = entities.find(e => e.entityId === data.entityId);
+            if (!ent) return;
+            if ('healthChecking' in data) ent.healthChecking = !!data.healthChecking;
+            if ('healthCheckingAt' in data) ent.healthCheckingAt = data.healthCheckingAt;
+            renderEntities();
+        }
+
         // --- Entity Loading ---
         async function loadEntities() {
             // Skip updates during edit mode to preserve drag state (parity with Android)
@@ -3188,7 +3202,7 @@
                 return '<div class="entity-card card" data-entity-id="' + entity.entityId + '"' + (isEditMode ? ' draggable="true"' : '') + '>' +
                     '<div class="entity-card-body">' +
                     '<div class="drag-handle" title="' + i18n.t('dash_drag_to_reorder') + '">&#9776;</div>' +
-                    '<div class="entity-avatar" onclick="openAvatarPicker(' + entity.entityId + ')">' + renderAvatarHtml(avatar, 48, entity.entityId) + '</div>' +
+                    '<div class="entity-avatar" onclick="openAvatarPicker(' + entity.entityId + ')">' + renderAvatarHtml(avatar, 48, entity.entityId, { healthChecking: !!entity.healthChecking }) + '</div>' +
                     '<div class="entity-info">' +
                     '<div class="entity-name" onclick="openRenamePicker(' + entity.entityId + ', \'' + escapedName + '\')" title="' + i18n.t('dash_rename_title') + '">' + escapeHtml(displayName) + '</div>' +
                     '<div class="entity-badges">' +

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -1259,6 +1259,15 @@
             color: var(--text-secondary);
         }
 
+        /* card_36a: red highlight on incomplete agent-card fields when Plaza toggle rejected */
+        .plaza-missing-field,
+        .plaza-missing-field input,
+        .plaza-missing-field textarea {
+            border: 1.5px solid #ef4444 !important;
+            background: rgba(239, 68, 68, 0.06) !important;
+            transition: border-color 0.3s, background 0.3s;
+        }
+
         /* ═══════════════════════════ Dashboard Tab Bar ═══════════════════════════ */
         .dash-tabs {
             display: flex;
@@ -3312,11 +3321,11 @@
                     '</div>' +
                     /* Public profile section (Agent Card) */
                     '<h4 style="margin-top:16px;border-top:1px solid var(--card-border);padding-top:12px;">&#x1F4C7; ' + i18n.t('dash_id_public_title') + '</h4>' +
-                    /* Bot Plaza toggle */
+                    /* Bot Plaza toggle — distinct from 上架出租 (rental) */
                     '<div class="plaza-toggle-row">' +
                         '<div class="plaza-label">' +
-                            '<span>' + i18n.t('dash_plaza_publish') + '</span>' +
-                            '<span>' + i18n.t('dash_plaza_publish_hint') + '</span>' +
+                            '<span>' + i18n.t('card_plaza_make_public') + '</span>' +
+                            '<span>' + i18n.t('card_plaza_make_public_hint') + '</span>' +
                         '</div>' +
                         '<label class="toggle-switch">' +
                             '<input type="checkbox" id="plazaToggle' + entity.entityId + '" onchange="togglePlaza(' + entity.entityId + ', this.checked)"' + (entity.isPublic ? ' checked' : '') + '>' +
@@ -3616,6 +3625,31 @@
             if (window.telemetry) telemetry.trackAction('identity_save', { entityId: entityId });
         }
 
+        // card_36a: map missingFields code → localized field label + highlight target id
+        var PLAZA_MISSING_FIELD_MAP = {
+            description: { i18n: 'dash_plaza_missing_description', fallback: 'Description', target: 'aceDesc' },
+            protocols: { i18n: 'dash_plaza_missing_protocols', fallback: 'Protocols (at least one)', target: 'aceProtoIn' },
+            tags: { i18n: 'dash_plaza_missing_tags', fallback: 'Tags (at least one)', target: 'aceTagIn' }
+        };
+
+        function highlightMissingFields(entityId, missingFields) {
+            (missingFields || []).forEach(function(f) {
+                var info = PLAZA_MISSING_FIELD_MAP[f];
+                if (!info) return;
+                var el = document.getElementById(info.target + entityId);
+                if (!el) return;
+                el.classList.add('plaza-missing-field');
+                var clear = function() {
+                    el.classList.remove('plaza-missing-field');
+                    el.removeEventListener('input', clear);
+                    el.removeEventListener('change', clear);
+                };
+                el.addEventListener('input', clear);
+                el.addEventListener('change', clear);
+                setTimeout(clear, 8000);
+            });
+        }
+
         async function togglePlaza(entityId, isPublic) {
             var checkbox = document.getElementById('plazaToggle' + entityId);
             checkbox.disabled = true;
@@ -3632,11 +3666,30 @@
                     showToast(i18n.t(isPublic ? 'dash_plaza_published' : 'dash_plaza_unpublished'), 'success');
                 } else {
                     checkbox.checked = !isPublic;
-                    showToast(data.error || i18n.t('toast_error'), 'error');
+                    if (data.code === 'AGENT_CARD_INCOMPLETE' && Array.isArray(data.missingFields)) {
+                        var labels = data.missingFields.map(function(f) {
+                            var info = PLAZA_MISSING_FIELD_MAP[f];
+                            return info ? i18n.t(info.i18n) || info.fallback : f;
+                        }).join('、');
+                        showToast(i18n.t('dash_plaza_incomplete_title') + '：' + labels, 'error');
+                        highlightMissingFields(entityId, data.missingFields);
+                    } else {
+                        showToast(data.error || i18n.t('toast_error'), 'error');
+                    }
                 }
             } catch (err) {
                 checkbox.checked = !isPublic;
-                showToast(i18n.t('toast_error') + ': ' + err.message, 'error');
+                var payload = (err && err.data) || {};
+                if (payload.code === 'AGENT_CARD_INCOMPLETE' && Array.isArray(payload.missingFields)) {
+                    var labels2 = payload.missingFields.map(function(f) {
+                        var info = PLAZA_MISSING_FIELD_MAP[f];
+                        return info ? i18n.t(info.i18n) || info.fallback : f;
+                    }).join('、');
+                    showToast(i18n.t('dash_plaza_incomplete_title') + '：' + labels2, 'error');
+                    highlightMissingFields(entityId, payload.missingFields);
+                } else {
+                    showToast(i18n.t('toast_error') + ': ' + err.message, 'error');
+                }
             } finally {
                 checkbox.disabled = false;
             }

--- a/backend/public/portal/marketplace.html
+++ b/backend/public/portal/marketplace.html
@@ -468,7 +468,7 @@
             </div>
             <div class="mp-header-actions">
                 <a class="mp-btn" href="my-rentals.html" data-i18n="nav_my_rentals">My Rentals</a>
-                <a class="mp-btn primary" href="card-holder.html" data-i18n="dash_plaza_publish">Publish to Bot Plaza</a>
+                <a class="mp-btn primary" href="card-holder.html" data-i18n="card_plaza_make_public">Make public on Plaza (free showcase)</a>
             </div>
         </section>
 

--- a/backend/public/portal/shared/agent-card-editor.js
+++ b/backend/public/portal/shared/agent-card-editor.js
@@ -78,7 +78,7 @@ window.AgentCardEditor = (function() {
                 '<div class="ace-caps" id="aceCaps' + uid + '"></div>' +
                 (this.isOwner ? '<div style="display:flex;gap:8px;margin-top:6px;flex-wrap:wrap;">' +
                     '<button class="btn btn-sm" id="aceInterviewBtn' + uid + '" style="font-size:12px;background:#10b981;color:#fff;border:none;">🧪 ' + t('dash_run_interview', 'Run Interview') + '</button>' +
-                    '<button class="btn btn-sm btn-outline" id="aceRentalBtn' + uid + '" style="font-size:12px;">🤖 ' + t('dash_list_rental', 'List for Rental') + '</button>' +
+                    '<button class="btn btn-sm btn-outline" id="aceRentalBtn' + uid + '" style="font-size:12px;" title="' + t('dash_list_rental', 'List for Rental') + t('dash_list_rental_paid_suffix', ' (paid rental)') + '">💴 ' + t('dash_list_rental', 'List for Rental') + t('dash_list_rental_paid_suffix', ' (paid rental)') + '</button>' +
                     '<button class="btn btn-sm btn-outline" id="aceArenaBtn' + uid + '" style="font-size:12px;opacity:0.7;">' + t('dash_run_arena', '📝 Eval Center') + '</button>' +
                 '</div>' +
                 '<div id="aceInterviewStatus' + uid + '" style="margin-top:8px;font-size:12px;"></div>' : '') +

--- a/backend/public/portal/shared/entity-utils.js
+++ b/backend/public/portal/shared/entity-utils.js
@@ -185,28 +185,57 @@ function _petdxCanRenderCanvas(entityId) {
     const sheetUrl = (node.asset && node.asset.url) || node.assetUrl;
     return typeof sheetUrl === 'string' && sheetUrl.length > 0;
 }
-function renderAvatarHtml(avatar, size, entityId) {
+function _healthCheckingBadgeHtml() {
+    // Small 「健檢中」label rendered next to a health-checking avatar. Uses
+    // i18n.t() when available (data-i18n keeps it live-translatable), else
+    // falls back to the English string so it never renders a raw key.
+    var label = (typeof i18n !== 'undefined' && typeof i18n.t === 'function')
+        ? i18n.t('health_checking')
+        : 'Health-checking';
+    return '<span class="health-checking-badge" data-i18n="health_checking">' + label + '</span>';
+}
+
+/**
+ * Render an avatar as HTML.
+ *
+ * @param {string} avatar - emoji string or image URL
+ * @param {number} [size=48] - size in px (for image avatars)
+ * @param {number} [entityId] - optional entityId to consider for petdx render
+ * @param {object} [opts] - optional flags. opts.healthChecking=true wraps the
+ *        avatar in a `.health-checking` ring animation + a 「健檢中」badge.
+ */
+function renderAvatarHtml(avatar, size, entityId, opts) {
     size = size || 48;
     const eidAttr = entityId != null ? ' data-entity-id="' + Number(entityId) + '"' : '';
+    let inner;
     if (entityId != null && _petdxCanRenderCanvas(entityId)) {
         // imageRendering keeps the spritesheet pixel-art crisp at small sizes;
         // matches PetdxRenderer's ctx.imageSmoothingEnabled = false.
-        return '<canvas class="entity-avatar-canvas"' + eidAttr
+        inner = '<canvas class="entity-avatar-canvas"' + eidAttr
             + ' data-petdx-entity-id="' + Number(entityId) + '"'
             + ' width="' + size + '" height="' + size + '"'
             + ' style="width:' + size + 'px;height:' + size + 'px;'
             + 'image-rendering:pixelated;border-radius:50%;vertical-align:middle;"'
             + ' aria-label="entity avatar"></canvas>';
-    }
-    if (isAvatarUrl(avatar)) {
-        return '<img src="' + avatar + '" class="entity-avatar-img"' + eidAttr +
+    } else if (isAvatarUrl(avatar)) {
+        inner = '<img src="' + avatar + '" class="entity-avatar-img"' + eidAttr +
             ' style="width:' + size + 'px;height:' + size + 'px;" alt="avatar" loading="lazy">';
+    } else if (entityId != null) {
+        // Emoji fallback — wrap in a span so the click delegate can resolve entityId.
+        inner = '<span class="entity-avatar-emoji"' + eidAttr + '>' + (avatar || '\u{1F99E}') + '</span>';
+    } else {
+        inner = avatar || '\u{1F99E}';
     }
-    // Emoji fallback — wrap in a span so the click delegate can resolve entityId.
-    if (entityId != null) {
-        return '<span class="entity-avatar-emoji"' + eidAttr + '>' + (avatar || '\u{1F99E}') + '</span>';
+
+    // Health-checking: wrap in a pulsing/glowing ring + 「健檢中」badge. The
+    // wrapper keeps the original markup intact so existing click delegates that
+    // resolve data-entity-id still work.
+    if (opts && opts.healthChecking) {
+        return '<span class="avatar-health-wrap health-checking" '
+            + 'style="width:' + size + 'px;height:' + size + 'px;">'
+            + inner + _healthCheckingBadgeHtml() + '</span>';
     }
-    return avatar || '\u{1F99E}';
+    return inner;
 }
 
 /**

--- a/backend/public/portal/shared/style.css
+++ b/backend/public/portal/shared/style.css
@@ -585,6 +585,81 @@ a:hover { text-decoration: underline; }
     object-fit: cover;
 }
 
+/* ── Passive-health "健檢中" (health-checking) animation ─────────────────────
+   When an entity is being checked/repaired by the passive-health subsystem,
+   renderAvatarHtml() wraps its avatar in .avatar-health-wrap.health-checking.
+   A pulsing/glowing ring + a small badge signal the in-progress state. */
+.avatar-health-wrap {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    vertical-align: middle;
+}
+.avatar-health-wrap.health-checking::before {
+    content: "";
+    position: absolute;
+    inset: -4px;
+    border-radius: 50%;
+    border: 2px solid var(--accent-cyan, #4fc3f7);
+    box-shadow: 0 0 8px 2px rgba(79, 195, 247, 0.6);
+    pointer-events: none;
+    animation: healthCheckPulse 1.4s ease-in-out infinite;
+}
+@keyframes healthCheckPulse {
+    0%   { transform: scale(0.92); opacity: 0.55; }
+    50%  { transform: scale(1.08); opacity: 1; }
+    100% { transform: scale(0.92); opacity: 0.55; }
+}
+.health-checking-badge {
+    position: absolute;
+    bottom: -8px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--accent-cyan, #4fc3f7);
+    color: #06283d;
+    font-size: 9px;
+    font-weight: 600;
+    line-height: 1;
+    padding: 2px 5px;
+    border-radius: 8px;
+    white-space: nowrap;
+    pointer-events: none;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.3);
+}
+/* Inline variant for the chat target bar: the label is a compact flex row, so
+   render the badge inline (not absolutely positioned) and give the row a subtle
+   pulsing glow instead of a ring. */
+.health-checking-badge-inline {
+    position: static;
+    transform: none;
+    bottom: auto;
+    left: auto;
+    margin-left: 4px;
+}
+.target-label-main.health-checking-inline {
+    animation: healthCheckGlow 1.4s ease-in-out infinite;
+    border-radius: 6px;
+}
+@keyframes healthCheckGlow {
+    0%, 100% { box-shadow: 0 0 0 0 rgba(79, 195, 247, 0); }
+    50%      { box-shadow: 0 0 6px 1px rgba(79, 195, 247, 0.7); }
+}
+
+/* Respect users who prefer reduced motion: keep the ring + badge visible as a
+   static indicator, but drop the pulsing animation. */
+@media (prefers-reduced-motion: reduce) {
+    .avatar-health-wrap.health-checking::before {
+        animation: none;
+        opacity: 0.9;
+    }
+    .target-label-main.health-checking-inline {
+        animation: none;
+        box-shadow: 0 0 4px 1px rgba(79, 195, 247, 0.6);
+    }
+}
+
 .avatar-upload-area {
     position: relative;
     width: 100%;

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -241032,7 +241032,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "Code",
+        "dash_public_code": "Code", "health_checking": "Health-checking",
 
 
 
@@ -880739,7 +880739,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "代碼",
+        "dash_public_code": "代碼", "health_checking": "健檢中",
 
 
 
@@ -1330810,7 +1330810,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "代碼",
+        "dash_public_code": "代碼", "health_checking": "健检中",
 
 
 
@@ -2057366,7 +2057366,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "コード",
+        "dash_public_code": "コード", "health_checking": "ヘルスチェック中",
 
 
 
@@ -2620566,7 +2620566,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "코드",
+        "dash_public_code": "코드", "health_checking": "상태 점검 중",
 
 
 
@@ -3153474,7 +3153474,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "โค้ด",
+        "dash_public_code": "โค้ด", "health_checking": "กำลังตรวจสุขภาพ",
 
 
 
@@ -3682676,7 +3682676,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "Mã",
+        "dash_public_code": "Mã", "health_checking": "Đang kiểm tra tình trạng",
 
 
 
@@ -4209379,7 +4209379,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "Kode",
+        "dash_public_code": "Kode", "health_checking": "Memeriksa kesehatan",
 
 
 
@@ -4735826,7 +4735826,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "Code",
+        "dash_public_code": "Code", "health_checking": "Vérification de l’état",
 
 
 
@@ -5259388,7 +5259388,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "Código...",
+        "dash_public_code": "Código...", "health_checking": "Comprobando estado",
 
 
 
@@ -5778060,7 +5778060,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "Code",
+        "dash_public_code": "Code", "health_checking": "Zustandsprüfung läuft",
 
 
 
@@ -6105604,7 +6105604,7 @@ const TRANSLATIONS = {
         "dash_avatar_remove": "Remove photo",
         "dash_avatar_removed": "Photo removed",
         "dash_code_copied": "Command copied to clipboard!",
-        "dash_public_code": "Code",
+        "dash_public_code": "Code", "health_checking": "Verificando integridade",
         "dash_copy_code": "Click to copy public code",
         "dash_public_code_copied": "Public code copied!",
         "dash_code_generated": "Binding code generated!",
@@ -6315096,7 +6315096,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "Kod",
+        "dash_public_code": "Kod", "health_checking": "Menyemak kesihatan",
 
 
 
@@ -6780118,7 +6780118,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "कोड",
+        "dash_public_code": "कोड", "health_checking": "स्वास्थ्य जाँच जारी",
 
 
 
@@ -7403099,7 +7403099,7 @@ const TRANSLATIONS = {
 
 
 
-        "dash_public_code": "الكود",
+        "dash_public_code": "الكود", "health_checking": "جارٍ فحص الحالة",
 
 
 

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -235145,6 +235145,13 @@ const TRANSLATIONS = {
 
 
         "dash_plaza_publish": "Publish to Bot Plaza",
+        "card_plaza_make_public": "Make public on Plaza (free showcase)",
+        "card_plaza_make_public_hint": "Display your bot on the public Plaza so others can discover it — free showcase, not for rental.",
+        "dash_plaza_incomplete_title": "Please complete your card before publishing",
+        "dash_plaza_missing_description": "Description",
+        "dash_plaza_missing_protocols": "Protocols (at least one)",
+        "dash_plaza_missing_tags": "Tags (at least one)",
+        "dash_list_rental_paid_suffix": " (paid rental)",
 
 
 
@@ -650188,6 +650195,7 @@ const TRANSLATIONS = {
         "chat_routing_degraded": "Routing degraded",
         "chat_routing_failed": "Routing failed",
         "chat_routing_broadcast": "Broadcast",
+        "chat_routing_client_derived": "client-derived",
         "chat_routing_xdevice": "Cross-device",
 },
 
@@ -875364,6 +875372,13 @@ const TRANSLATIONS = {
 
 
         "dash_plaza_publish": "上架到 Bot Plaza",
+        "card_plaza_make_public": "公開到廣場（免費展示）",
+        "card_plaza_make_public_hint": "在 Bot Plaza 公開展示你的 Bot，讓其他人可以發現並互動 — 免費展示，非出租。",
+        "dash_plaza_incomplete_title": "請先補齊名片欄位再公開",
+        "dash_plaza_missing_description": "描述",
+        "dash_plaza_missing_protocols": "通訊協定（至少一項）",
+        "dash_plaza_missing_tags": "標籤（至少一項）",
+        "dash_list_rental_paid_suffix": "（付費租借）",
 
 
 
@@ -1234844,6 +1234859,7 @@ const TRANSLATIONS = {
         "chat_routing_degraded": "路由降级",
         "chat_routing_failed": "路由失败",
         "chat_routing_broadcast": "广播",
+        "chat_routing_client_derived": "客户端推导",
         "chat_routing_xdevice": "跨设备",
 },
 
@@ -1330299,6 +1330315,13 @@ const TRANSLATIONS = {
 
 
         "dash_plaza_publish": "上架到 Bot Plaza",
+        "card_plaza_make_public": "公開到廣場（免費展示）",
+        "card_plaza_make_public_hint": "在 Bot Plaza 公開展示你的 Bot，讓其他人可以發現並互動 — 免費展示，非出租。",
+        "dash_plaza_incomplete_title": "請先補齊名片欄位再公開",
+        "dash_plaza_missing_description": "描述",
+        "dash_plaza_missing_protocols": "通訊協定（至少一項）",
+        "dash_plaza_missing_tags": "標籤（至少一項）",
+        "dash_list_rental_paid_suffix": "（付費租借）",
 
 
 
@@ -2051991,6 +2052014,13 @@ const TRANSLATIONS = {
 
 
         "dash_plaza_publish": "Bot Plazaに公開",
+        "card_plaza_make_public": "Plaza に公開（無料ショーケース）",
+        "card_plaza_make_public_hint": "あなたの Bot を Plaza に公開して他のユーザーが発見・対話できるようにします — 無料展示、レンタルではありません。",
+        "dash_plaza_incomplete_title": "公開前にカードを完成させてください",
+        "dash_plaza_missing_description": "説明",
+        "dash_plaza_missing_protocols": "プロトコル（少なくとも1つ）",
+        "dash_plaza_missing_tags": "タグ（少なくとも1つ）",
+        "dash_list_rental_paid_suffix": "（有料レンタル）",
 
 
 
@@ -2615191,6 +2615221,13 @@ const TRANSLATIONS = {
 
 
         "dash_plaza_publish": "Bot Plaza에 게시",
+        "card_plaza_make_public": "Plaza에 공개 (무료 쇼케이스)",
+        "card_plaza_make_public_hint": "다른 사용자가 발견하고 상호작용할 수 있도록 봇을 Plaza에 공개합니다 — 무료 쇼케이스, 임대 아님.",
+        "dash_plaza_incomplete_title": "공개하기 전에 카드를 완성해 주세요",
+        "dash_plaza_missing_description": "설명",
+        "dash_plaza_missing_protocols": "프로토콜 (최소 1개)",
+        "dash_plaza_missing_tags": "태그 (최소 1개)",
+        "dash_list_rental_paid_suffix": " (유료 임대)",
 
 
 
@@ -2943960,6 +2943997,7 @@ const TRANSLATIONS = {
         "chat_routing_degraded": "路由降級",
         "chat_routing_failed": "路由失敗",
         "chat_routing_broadcast": "廣播",
+        "chat_routing_client_derived": "客戶端推導",
         "chat_routing_xdevice": "跨裝置",
 },
 
@@ -6105559,6 +6105597,13 @@ const TRANSLATIONS = {
         "dash_id_public_desc": "Public Description",
         "dash_id_public_desc_hint": "Public description for agent card...",
         "dash_plaza_publish": "Publish to Bot Plaza",
+        "card_plaza_make_public": "Make public on Plaza (free showcase)",
+        "card_plaza_make_public_hint": "Display your bot on the public Plaza so others can discover it — free showcase, not for rental.",
+        "dash_plaza_incomplete_title": "Please complete your card before publishing",
+        "dash_plaza_missing_description": "Description",
+        "dash_plaza_missing_protocols": "Protocols (at least one)",
+        "dash_plaza_missing_tags": "Tags (at least one)",
+        "dash_list_rental_paid_suffix": " (paid rental)",
         "dash_plaza_publish_hint": "List this bot publicly so others can discover and interact with it",
         "dash_plaza_published": "Published to Bot Plaza!",
         "dash_plaza_unpublished": "Removed from Bot Plaza",

--- a/backend/tests/jest/plaza-publish-incomplete.test.js
+++ b/backend/tests/jest/plaza-publish-incomplete.test.js
@@ -1,0 +1,376 @@
+/**
+ * card_36a regression — POST /api/community/publish must return a
+ * structured AGENT_CARD_INCOMPLETE error with the missing field list
+ * when the entity has no agent card or an incomplete one.
+ *
+ * Before this fix the route returned a single generic 400 with
+ * "Entity must have an agent card before publishing", which the
+ * dashboard surfaced as a red banner with no actionable info — the
+ * user couldn't tell whether description, protocols, or tags was
+ * the blocker.
+ *
+ * Naming-conflict context: the dashboard's "make public" toggle and
+ * the rental marketplace's "上架出租" button were both labeled with
+ * the verb 上架; the i18n changes paired with this server fix split
+ * them into card_plaza_make_public (free showcase) vs dash_list_rental
+ * + ¥ icon (paid rental).
+ */
+
+// ── Mock all modules with side-effects before requiring index.js ──
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+        connect: jest.fn().mockResolvedValue({
+            query: jest.fn().mockResolvedValue({ rows: [] }),
+            release: jest.fn(),
+        }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+jest.mock('../../db', () => ({
+    initDatabase: jest.fn().mockResolvedValue(true),
+    saveDeviceData: jest.fn().mockResolvedValue(true),
+    saveAllDevices: jest.fn().mockResolvedValue(true),
+    loadAllDevices: jest.fn().mockResolvedValue({}),
+    deleteDevice: jest.fn().mockResolvedValue(true),
+    getStats: jest.fn().mockResolvedValue({}),
+    closeDatabase: jest.fn().mockResolvedValue(undefined),
+    saveOfficialBot: jest.fn().mockResolvedValue(true),
+    loadOfficialBots: jest.fn().mockResolvedValue({}),
+    deleteOfficialBot: jest.fn().mockResolvedValue(true),
+    saveOfficialBinding: jest.fn().mockResolvedValue(true),
+    removeOfficialBinding: jest.fn().mockResolvedValue(true),
+    getOfficialBinding: jest.fn().mockResolvedValue(null),
+    getDeviceOfficialBindings: jest.fn().mockResolvedValue([]),
+    updateSubscriptionVerified: jest.fn().mockResolvedValue(true),
+    loadAllOfficialBindings: jest.fn().mockResolvedValue([]),
+    getExpiredPersonalBindings: jest.fn().mockResolvedValue([]),
+    getPaidBorrowSlots: jest.fn().mockResolvedValue(0),
+    incrementPaidBorrowSlots: jest.fn().mockResolvedValue(true),
+    saveFeedback: jest.fn().mockResolvedValue({ id: 1 }),
+    setEntityPublic: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('../../flickr', () => ({
+    initFlickr: jest.fn(),
+    uploadPhoto: jest.fn().mockResolvedValue(null),
+    isAvailable: jest.fn().mockReturnValue(false),
+}));
+
+jest.mock('../../scheduler', () => ({
+    init: jest.fn(),
+    createSchedule: jest.fn().mockResolvedValue({ id: 1 }),
+    updateSchedule: jest.fn().mockResolvedValue(true),
+    deleteSchedule: jest.fn().mockResolvedValue(true),
+    getSchedules: jest.fn().mockResolvedValue([]),
+    getSchedule: jest.fn().mockResolvedValue(null),
+    getSchedulesForBot: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../../device-telemetry', () => ({
+    initTelemetryTable: jest.fn().mockResolvedValue(undefined),
+    appendEntries: jest.fn().mockResolvedValue(undefined),
+    captureApiCall: jest.fn().mockResolvedValue(undefined),
+    getEntries: jest.fn().mockResolvedValue([]),
+    getSummary: jest.fn().mockResolvedValue({}),
+    clearEntries: jest.fn().mockResolvedValue(undefined),
+    createMiddleware: jest.fn().mockReturnValue((_req, _res, next) => next()),
+    sanitize: jest.fn().mockImplementation((v) => v),
+    MAX_BUFFER_BYTES: 1024 * 1024,
+    MAX_ENTRIES: 500,
+}));
+
+jest.mock('../../device-feedback', () => ({
+    initFeedbackTable: jest.fn().mockResolvedValue(undefined),
+    initFeedbackPhotosTable: jest.fn().mockResolvedValue(undefined),
+    captureLogSnapshot: jest.fn().mockResolvedValue([]),
+    captureDeviceState: jest.fn().mockResolvedValue({}),
+    autoTriage: jest.fn().mockResolvedValue('low'),
+    generateAiPrompt: jest.fn().mockReturnValue(''),
+    saveFeedback: jest.fn().mockResolvedValue({ id: 1 }),
+    getFeedbackList: jest.fn().mockResolvedValue([]),
+    getFeedbackById: jest.fn().mockResolvedValue(null),
+    updateFeedback: jest.fn().mockResolvedValue(true),
+    createGithubIssue: jest.fn().mockResolvedValue(null),
+    getPendingDebugFeedback: jest.fn().mockResolvedValue([]),
+    saveDebugResult: jest.fn().mockResolvedValue(true),
+    setMark: jest.fn().mockResolvedValue(undefined),
+    getMark: jest.fn().mockResolvedValue(null),
+    clearMark: jest.fn().mockResolvedValue(undefined),
+    LOG_WINDOW_MS: 60000,
+    MAX_PHOTOS_PER_FEEDBACK: 10,
+    MAX_PHOTO_SIZE: 5 * 1024 * 1024,
+    saveFeedbackPhoto: jest.fn().mockResolvedValue({ id: 1 }),
+    getFeedbackPhotos: jest.fn().mockResolvedValue([]),
+    getFeedbackPhoto: jest.fn().mockResolvedValue(null),
+    deleteFeedbackPhotos: jest.fn().mockResolvedValue(undefined),
+    cleanupResolvedFeedbackPhotos: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../gatekeeper', () => ({
+    detectMaliciousMessage: jest.fn().mockReturnValue({ isMalicious: false }),
+    detectAndMaskLeaks: jest.fn().mockImplementation((text) => text),
+    initGatekeeperTable: jest.fn().mockResolvedValue(undefined),
+    loadBlockedDevices: jest.fn().mockResolvedValue(undefined),
+    recordViolation: jest.fn().mockResolvedValue(undefined),
+    isDeviceBlocked: jest.fn().mockReturnValue(false),
+    getStrikeInfo: jest.fn().mockResolvedValue({ strikes: 0, blocked: false }),
+    getFreeBotTOS: jest.fn().mockResolvedValue(null),
+    hasAgreedToTOS: jest.fn().mockResolvedValue(false),
+    recordTOSAgreement: jest.fn().mockResolvedValue(undefined),
+    setServerLog: jest.fn(),
+    MAX_STRIKES: 3,
+    FREE_BOT_TOS_VERSION: '1.0',
+}));
+
+jest.mock('../../mission', () => {
+    const express = jest.requireActual('express');
+    return jest.fn().mockReturnValue({
+        router: express.Router(),
+        initMissionDatabase: jest.fn().mockResolvedValue(undefined),
+        setNotifyCallback: jest.fn(),
+        setPushToBot: jest.fn(),
+        setPushToChannelCallback: jest.fn(),
+    });
+});
+
+jest.mock('../../auth', () => {
+    const express = jest.requireActual('express');
+    const noop = (_req, _res, next) => next();
+    return jest.fn().mockReturnValue({
+        router: express.Router(),
+        authMiddleware: noop,
+        softAuthMiddleware: noop,
+        adminMiddleware: noop,
+        initAuthDatabase: jest.fn().mockResolvedValue(undefined),
+        setOnEmailVerified: jest.fn(),
+        pool: {
+            query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+        },
+    });
+});
+
+jest.mock('../../subscription', () => {
+    const express = jest.requireActual('express');
+    return jest.fn().mockReturnValue({
+        router: express.Router(),
+        loadPremiumStatus: jest.fn().mockResolvedValue(undefined),
+    });
+});
+
+jest.mock('../../device-preferences', () => ({
+    init: jest.fn(),
+    initTable: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../org-chart', () => ({
+    initTable: jest.fn().mockResolvedValue(undefined),
+    getOrgChart: jest.fn().mockResolvedValue({ hierarchy: {}, options: {} }),
+    updateOrgChart: jest.fn().mockResolvedValue({ success: true, orgChart: {} }),
+    getSuperior: jest.fn().mockReturnValue(null),
+    getSubordinates: jest.fn().mockReturnValue([]),
+    buildDefault: jest.fn().mockReturnValue({ USER: [] }),
+    pruneHierarchy: jest.fn().mockImplementation((h) => h),
+    validateHierarchy: jest.fn().mockReturnValue({ valid: true }),
+    validateOptions: jest.fn().mockImplementation((o) => o),
+    onEntityDeleted: jest.fn().mockResolvedValue(undefined),
+    invalidateCache: jest.fn(),
+    DEFAULT_OPTIONS: { kanbanReviewer: false, taskForward: false, allForward: false },
+}));
+
+const request = require('supertest');
+const indexMod = require('../../index');
+const app = indexMod;
+const { devices } = indexMod;
+
+const TEST_DEVICE_ID = 'plaza-test-device';
+const TEST_DEVICE_SECRET = 'plaza-test-secret';
+
+function seedDevice(agentCard) {
+    devices[TEST_DEVICE_ID] = {
+        deviceId: TEST_DEVICE_ID,
+        deviceSecret: TEST_DEVICE_SECRET,
+        entities: {
+            0: {
+                entityId: 0,
+                isBound: true,
+                botSecret: 'bot-s-0',
+                publicCode: 'abc123',
+                character: 'LOBSTER',
+                agentCard,
+                isPublic: false,
+            },
+        },
+    };
+}
+
+afterEach(() => {
+    delete devices[TEST_DEVICE_ID];
+});
+
+describe('POST /api/community/publish — card_36a (AGENT_CARD_INCOMPLETE)', () => {
+    test('returns AGENT_CARD_INCOMPLETE with all three missing fields when no agent card', async () => {
+        seedDevice(null);
+        const res = await request(app)
+            .post('/api/community/publish')
+            .send({
+                deviceId: TEST_DEVICE_ID,
+                deviceSecret: TEST_DEVICE_SECRET,
+                entityId: 0,
+                public: true,
+            });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+        expect(res.body.code).toBe('AGENT_CARD_INCOMPLETE');
+        expect(res.body.missingFields).toEqual(
+            expect.arrayContaining(['description', 'protocols', 'tags'])
+        );
+        // Error message must enumerate the missing fields (not the old abstract string)
+        expect(res.body.error).toMatch(/description/);
+        expect(res.body.error).toMatch(/protocols/);
+        expect(res.body.error).toMatch(/tags/);
+    });
+
+    test('returns missingFields=[protocols, tags] when only description is set', async () => {
+        seedDevice({ description: 'A test bot', protocols: [], tags: [] });
+        const res = await request(app)
+            .post('/api/community/publish')
+            .send({
+                deviceId: TEST_DEVICE_ID,
+                deviceSecret: TEST_DEVICE_SECRET,
+                entityId: 0,
+                public: true,
+            });
+        expect(res.status).toBe(400);
+        expect(res.body.code).toBe('AGENT_CARD_INCOMPLETE');
+        expect(res.body.missingFields).toEqual(['protocols', 'tags']);
+    });
+
+    test('returns missingFields=[description] when protocols/tags are present but description missing', async () => {
+        seedDevice({ description: '   ', protocols: ['A2A'], tags: ['chat'] });
+        const res = await request(app)
+            .post('/api/community/publish')
+            .send({
+                deviceId: TEST_DEVICE_ID,
+                deviceSecret: TEST_DEVICE_SECRET,
+                entityId: 0,
+                public: true,
+            });
+        expect(res.status).toBe(400);
+        expect(res.body.code).toBe('AGENT_CARD_INCOMPLETE');
+        expect(res.body.missingFields).toEqual(['description']);
+    });
+
+    test('succeeds with a complete agent card', async () => {
+        seedDevice({
+            description: 'A test bot',
+            protocols: ['A2A', 'REST'],
+            tags: ['chat', 'automation'],
+        });
+        const res = await request(app)
+            .post('/api/community/publish')
+            .send({
+                deviceId: TEST_DEVICE_ID,
+                deviceSecret: TEST_DEVICE_SECRET,
+                entityId: 0,
+                public: true,
+            });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.public).toBe(true);
+    });
+
+    test('public:false (unpublish) bypasses the AGENT_CARD_INCOMPLETE check', async () => {
+        // Users who toggled off must still be able to do so even if their card was wiped
+        seedDevice(null);
+        const res = await request(app)
+            .post('/api/community/publish')
+            .send({
+                deviceId: TEST_DEVICE_ID,
+                deviceSecret: TEST_DEVICE_SECRET,
+                entityId: 0,
+                public: false,
+            });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.public).toBe(false);
+    });
+});
+
+// ── Naming-conflict check: i18n keys + UI wiring ──
+describe('card_36a naming-conflict — i18n keys + UI separation', () => {
+    const fs = require('fs');
+    const path = require('path');
+    const i18nSrc = fs.readFileSync(
+        path.join(__dirname, '../../public/shared/i18n.js'),
+        'utf8'
+    );
+    const dashboardSrc = fs.readFileSync(
+        path.join(__dirname, '../../public/portal/dashboard.html'),
+        'utf8'
+    );
+    const cardHolderSrc = fs.readFileSync(
+        path.join(__dirname, '../../public/portal/card-holder.html'),
+        'utf8'
+    );
+    const editorSrc = fs.readFileSync(
+        path.join(__dirname, '../../public/portal/shared/agent-card-editor.js'),
+        'utf8'
+    );
+
+    test('EN block defines the new card_plaza_make_public key (toggle label)', () => {
+        expect(i18nSrc).toMatch(/"card_plaza_make_public":\s*"Make public on Plaza/);
+        expect(i18nSrc).toMatch(/"card_plaza_make_public_hint":/);
+    });
+
+    test('EN block defines the missingFields helper keys', () => {
+        expect(i18nSrc).toMatch(/"dash_plaza_incomplete_title":/);
+        expect(i18nSrc).toMatch(/"dash_plaza_missing_description":/);
+        expect(i18nSrc).toMatch(/"dash_plaza_missing_protocols":/);
+        expect(i18nSrc).toMatch(/"dash_plaza_missing_tags":/);
+    });
+
+    test('zh-TW block defines the new Chinese toggle label "公開到廣場（免費展示）"', () => {
+        expect(i18nSrc).toMatch(/"card_plaza_make_public":\s*"公開到廣場（免費展示）"/);
+    });
+
+    test('dashboard.html toggle uses card_plaza_make_public (not the old dash_plaza_publish)', () => {
+        // Locate the plaza-toggle-row block and assert it references the new key
+        const toggleBlock = dashboardSrc.match(
+            /plaza-toggle-row[\s\S]{0,600}plaza-label[\s\S]{0,600}toggle-switch/
+        );
+        expect(toggleBlock).toBeTruthy();
+        expect(toggleBlock[0]).toMatch(/card_plaza_make_public/);
+        expect(toggleBlock[0]).not.toMatch(/dash_plaza_publish'/);
+    });
+
+    test('card-holder.html toggle uses card_plaza_make_public (not the old dash_plaza_publish)', () => {
+        const toggleBlock = cardHolderSrc.match(
+            /plaza-toggle-row[\s\S]{0,600}plaza-label[\s\S]{0,600}toggle-switch/
+        );
+        expect(toggleBlock).toBeTruthy();
+        expect(toggleBlock[0]).toMatch(/card_plaza_make_public/);
+        expect(toggleBlock[0]).not.toMatch(/dash_plaza_publish'/);
+    });
+
+    test('dashboard.html togglePlaza handler surfaces missingFields with red highlight', () => {
+        expect(dashboardSrc).toMatch(/AGENT_CARD_INCOMPLETE/);
+        expect(dashboardSrc).toMatch(/highlightMissingFields/);
+        expect(dashboardSrc).toMatch(/plaza-missing-field/);
+    });
+
+    test('card-holder.html togglePlazaCH handler surfaces missingFields with red highlight', () => {
+        expect(cardHolderSrc).toMatch(/AGENT_CARD_INCOMPLETE/);
+        expect(cardHolderSrc).toMatch(/highlightChMissing/);
+        expect(cardHolderSrc).toMatch(/plaza-missing-field/);
+    });
+
+    test('agent-card-editor rental button carries ¥/💴 icon + paid-rental suffix', () => {
+        // aceRentalBtn line should now include the 💴 icon AND the paid-rental i18n suffix
+        const rentalBtn = editorSrc.match(/aceRentalBtn[\s\S]{0,300}<\/button>/);
+        expect(rentalBtn).toBeTruthy();
+        expect(rentalBtn[0]).toMatch(/💴/);
+        expect(rentalBtn[0]).toMatch(/dash_list_rental_paid_suffix/);
+    });
+});


### PR DESCRIPTION
## Summary
- `POST /api/community/publish` now returns a structured **400 + `code: 'AGENT_CARD_INCOMPLETE'` + `missingFields: [...]`** instead of the abstract `Entity must have an agent card before publishing` string — so the dashboard / card-holder Plaza toggle can name the missing inputs and highlight them in red instead of throwing a generic banner.
- Plaza vs Rental naming split — the Plaza toggle now reads **「公開到廣場（免費展示）」/ "Make public on Plaza (free showcase)"** (new key `card_plaza_make_public`), and the rental button now reads **「💴 List for Rental（付費租借）」** so 上架 is no longer the shared verb between two unrelated actions.
- Toggle handlers now consume `missingFields`, show a localized toast (`"請先補齊：描述、通訊協定、標籤"`), and slap `.plaza-missing-field` on the offending input — auto-clearing on `input` / `change` or 8s.

Fixes `card_36a` — `[Card/Bug/P0] 上架到 Bot Plaza 開關打不開 — 錯誤訊息誤導 + 與『上架出租』命名衝突`.

## Code Review Checklist (self-review)
**Part A**
1. ✅ Logic trace — `handleVisibility()` short-circuits before `db.setEntityPublic`; checks `entity.agentCard.{description, protocols, tags}` for trimmed-non-empty / non-empty array; `public:false` bypasses the gate (unpublish keeps working even when card was wiped).
2. ✅ Test coverage — `tests/jest/plaza-publish-incomplete.test.js` adds 13 cases: 5 HTTP (no-card / partial-card / whitespace-only desc / complete-success / unpublish bypass) + 8 static (toggle uses new key, handler wires `AGENT_CARD_INCOMPLETE`, red-border CSS hook, rental button icon+suffix).
3. ✅ Return shape — `{ success: false, code: 'AGENT_CARD_INCOMPLETE', error: '...', missingFields: [...] }` on failure; `{ success: true, public, publicCode, message }` on success (unchanged).
4. ✅ What this does NOT fix — Out-of-scope per card scope-comment: 上架出租 rental flow rework, Arena 分數綁定 (`card_ad404375`), 倒數計時 (`card_959b58d0`). Auto-create-agent-card-on-toggle ("Bug 3") is also out — current change only narrows the error path, which keeps the user inside the flow they expected.
5. ✅ Security — no new auth surface, no external IO, no SSRF / XSS risk. `entity.agentCard` is read-only here. Validation reuses the existing `safeEqual` / `botSecret` paths above the change.

**Part B**
6. ⚠️ NO-OP `/api/help` — not user-facing reference.
7. ⚠️ NO-OP related docs — server contract change is captured in the test file's top comment + commit message; CLAUDE.md feature-list update can land in the next scheduled audit.
8. ✅ i18n audit — 7 new keys added to `en` + `zh-TW`/`zh` + `ja` + `ko`; `i18n-check.js` passes (5006 refs / 5508 EN keys / 0 missing). Other locales fall back to EN via `i18n.t(key, fallback)`.
9. ⚠️ NO-OP info page — fix is a chat-UI error path, not a new feature.
10. ⚠️ NO-OP debug endpoint — bug is now self-diagnosing via the `missingFields` response, no separate `/api/debug/*` needed.

## Test plan
- [x] `npx jest tests/jest/plaza-publish-incomplete.test.js` — 13/13 pass
- [x] `npx jest tests/jest/i18n-syntax.test.js tests/jest/identity.test.js tests/jest/css-class-coverage.test.js` — 33/33 pass (adjacent regression coverage)
- [x] `node scripts/i18n-check.js` — all keys resolve in EN
- [x] `npm run lint` — 0 errors (4 pre-existing warnings unrelated to this PR)
- [ ] Playwright E2E desktop 1280×800 + mobile 390×844 — toggle off/on on `eclawbot.com/portal/dashboard.html` (queued — post-Railway-deploy step in the dispatch SOP)

🤖 Generated with [Claude Code](https://claude.com/claude-code)