### PR TITLE
fix(plaza): surface PETDX companion avatar on community.html (card_314)

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -2156,11 +2156,25 @@ async function searchPublicCards({ q, tag, capability, limit = 20, offset = 0, s
         const safeOffset = Math.max(parseInt(offset) || 0, 0);
 
         params.push(safeLimit, safeOffset);
+        // LEFT JOIN LATERAL surfaces the owner's currently selected
+        // companion avatar (PETDX dressing system). Without it, the
+        // plaza shows e.avatar — the static emoji/upload set on first
+        // bind — even after the owner picked a sprite companion.
         const sql = `
             SELECT e.public_code, e.name, e.character, e.avatar, e.agent_card,
                    e.avg_rating, e.rating_count, e.community_message_count,
-                   e.published_at, e.level, e.xp
+                   e.published_at, e.level, e.xp,
+                   petdx.avatar_url AS petdx_avatar_url
             FROM entities e
+            LEFT JOIN LATERAL (
+                SELECT c.avatar_url
+                FROM companion_select_log s
+                LEFT JOIN companions c ON c.id = s.companion_id
+                WHERE s.device_id = e.device_id
+                  AND s.entity_id IS NOT DISTINCT FROM e.entity_id
+                ORDER BY s.selected_at DESC
+                LIMIT 1
+            ) petdx ON true
             WHERE ${conditions.join(' AND ')}
             ORDER BY ${orderBy}
             LIMIT $${paramIdx} OFFSET $${paramIdx + 1}
@@ -2172,6 +2186,7 @@ async function searchPublicCards({ q, tag, capability, limit = 20, offset = 0, s
             name: r.name,
             character: r.character,
             avatar: r.avatar,
+            petdxAvatarUrl: r.petdx_avatar_url || null,
             description: r.agent_card?.description || null,
             capabilities: r.agent_card?.capabilities || [],
             tags: r.agent_card?.tags || [],
@@ -2193,8 +2208,18 @@ async function getPublicCardDetail(publicCode) {
         const result = await pool.query(
             `SELECT e.public_code, e.name, e.character, e.avatar, e.agent_card,
                     e.avg_rating, e.rating_count, e.community_message_count,
-                    e.published_at, e.level, e.xp, e.state
+                    e.published_at, e.level, e.xp, e.state,
+                    petdx.avatar_url AS petdx_avatar_url
              FROM entities e
+             LEFT JOIN LATERAL (
+                 SELECT c.avatar_url
+                 FROM companion_select_log s
+                 LEFT JOIN companions c ON c.id = s.companion_id
+                 WHERE s.device_id = e.device_id
+                   AND s.entity_id IS NOT DISTINCT FROM e.entity_id
+                 ORDER BY s.selected_at DESC
+                 LIMIT 1
+             ) petdx ON true
              WHERE e.public_code = $1 AND e.is_public = true`,
             [publicCode]
         );
@@ -2205,6 +2230,7 @@ async function getPublicCardDetail(publicCode) {
             name: r.name,
             character: r.character,
             avatar: r.avatar,
+            petdxAvatarUrl: r.petdx_avatar_url || null,
             agentCard: r.agent_card || null,
             avgRating: parseFloat(r.avg_rating) || 0,
             ratingCount: parseInt(r.rating_count) || 0,

--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -1065,6 +1065,8 @@
     <script src="shared/footer.js"></script>
     <script src="shared/product-tour.js"></script>
     <script src="../shared/telemetry.js"></script>
+    <script src="shared/entity-utils.js"></script>
+    <script src="../shared/avatar-petdx.js"></script>
     <script>
     /* ══════════════════════════════════════
        Real API Integration
@@ -1083,6 +1085,30 @@
     let rateMax = 50;
     let _rateDebounce = null;
     let loadBotsRequestSeq = 0;
+
+    /* ══════ Avatar resolution ══════ */
+    // Plaza bots belong to OTHER users, so we can't rely on the per-entity
+    // AvatarPetdx descriptor cache (keyed on the current user's deviceId).
+    // Instead, the server enriches each row with petdxAvatarUrl — the bot
+    // owner's currently selected companion's avatar URL — and we prefer it
+    // over the legacy entities.avatar emoji/upload.
+    function resolveBotAvatar(row) {
+        if (!row) return '\u{1F916}';
+        if (typeof row.petdxAvatarUrl === 'string' && row.petdxAvatarUrl) {
+            return row.petdxAvatarUrl;
+        }
+        return row.avatar || '\u{1F916}';
+    }
+    function botAvatarHtml(avatar, size) {
+        if (typeof renderAvatarHtml === 'function') {
+            return renderAvatarHtml(avatar, size || 48);
+        }
+        // Fallback if entity-utils.js failed to load (CDN miss, etc.)
+        if (typeof avatar === 'string' && /^(https?:\/\/|\/)/.test(avatar)) {
+            return '<img src="' + esc(avatar) + '" style="width:' + (size || 48) + 'px;height:' + (size || 48) + 'px;border-radius:50%;object-fit:cover;" alt="">';
+        }
+        return avatar || '\u{1F916}';
+    }
 
     /* ══════ API ══════ */
     async function apiFetch(path) {
@@ -1196,7 +1222,8 @@
                 if (isCommunityFilter) p.set('tag', currentFilter);
                 const data = await apiFetch('/api/community/search?' + p);
                 communityBots = (data.results || []).map(r => ({
-                    publicCode: r.publicCode, name: r.name || 'Unnamed', avatar: r.avatar || '🤖',
+                    publicCode: r.publicCode, name: r.name || 'Unnamed',
+                    avatar: resolveBotAvatar(r),
                     desc: r.description || '', tags: r.tags || [],
                     caps: (r.capabilities || []).map(c => c.name || c.id || c),
                     stars: r.avgRating || 0, reviews: r.messageCount || 0,
@@ -1219,7 +1246,8 @@
                     rentalBots = (data.listings || []).map(l => {
                         const caps = l.capabilities ? Object.keys(l.capabilities).filter(k => l.capabilities[k]?.supported) : [];
                         return {
-                            publicCode: l.owner_public_code || null, name: l.title || 'Rental Bot', avatar: l.avatar_url || '🤖',
+                            publicCode: l.owner_public_code || null, name: l.title || 'Rental Bot',
+                            avatar: resolveBotAvatar({ petdxAvatarUrl: l.petdx_avatar_url, avatar: l.avatar_url }),
                             desc: l.description || (l.model_detected || ''),
                             tags: caps, caps: caps, _capsObj: l.capabilities || {},
                             stars: l.avg_rating || 0, reviews: l.total_rentals || 0,
@@ -1277,7 +1305,7 @@
             <span class="bot-card-level ${lvClass(bot.level)}">Lv.${bot.level}</span>
             <div class="bot-card-header">
                 <div class="bot-card-avatar">
-                    ${(bot.avatar||'').startsWith('http') ? `<img src="${esc(bot.avatar)}" alt="">` : (bot.avatar||'🤖')}
+                    ${botAvatarHtml(bot.avatar, 56)}
                 </div>
                 <div class="bot-card-info"><div class="bot-card-name">${esc(bot.name)}</div></div>
             </div>
@@ -1310,7 +1338,7 @@
         return `<div class="${isRented ? 'bot-card rented' : 'bot-card'}" onclick="${isRented ? '' : "openRentalDetail('" + bot.listingId + "')"}" style="border-left:3px solid ${borderColor};">
             <span class="bot-card-level" style="background:${borderColor};color:#fff;">${isRented ? tt('mp_status_rented','\u5df2\u51fa\u79df') : tt('community_filter_rental','\u51fa\u79df')}</span>
             <div class="bot-card-header">
-                <div class="bot-card-avatar">${bot.avatar && bot.avatar.startsWith('http') ? '<img src="' + esc(bot.avatar) + '" style="width:40px;height:40px;border-radius:50%;object-fit:cover;">' : (bot.avatar || '\ud83e\udd16')}</div>
+                <div class="bot-card-avatar">${botAvatarHtml(bot.avatar, 40)}</div>
                 <div class="bot-card-info">
                     <div class="bot-card-name">${esc(bot.name)}</div>
                     ${bot.modelDetected ? `<div style="font-size:11px;color:var(--text-secondary);">\ud83e\udd16 ${esc(bot.modelDetected)}</div>` : ''}
@@ -1368,7 +1396,7 @@
             content.innerHTML = `
                 <button class="modal-close" onclick="closeDetail()">✕</button>
                 <div class="detail-header">
-                    <div class="detail-avatar">${(bot.avatar||'🤖').startsWith('http') ? `<img src="${esc(bot.avatar)}" alt="">` : (bot.avatar||'🤖')}</div>
+                    <div class="detail-avatar">${botAvatarHtml(resolveBotAvatar(bot), 72)}</div>
                     <div class="detail-name">${esc(bot.name)}</div>
                     <div class="detail-code" onclick="navigator.clipboard.writeText('${bot.publicCode}')" title="Copy">${bot.publicCode}</div>
                     <div class="detail-desc">${esc(desc)}</div>
@@ -1516,7 +1544,7 @@
             content.innerHTML = `
                 <button class="modal-close" onclick="closeDetail()">\u2715</button>
                 <div class="detail-header">
-                    <div class="detail-avatar">${l.avatar_url && l.avatar_url.startsWith('http') ? '<img src="' + esc(l.avatar_url) + '" style="width:60px;height:60px;border-radius:50%;object-fit:cover;">' : (l.avatar_url || '\ud83e\udd16')}</div>
+                    <div class="detail-avatar">${botAvatarHtml(resolveBotAvatar({ petdxAvatarUrl: l.petdx_avatar_url, avatar: l.avatar_url }), 72)}</div>
                     <div class="detail-name">${esc(l.title)}</div>
                     ${l.model_detected ? `<div style="font-size:12px;color:var(--text-secondary);margin-top:2px;">\ud83e\udd16 ${esc(l.model_detected)}</div>` : ''}
                     <div class="detail-level-xp"><span style="color:#f59e0b;">${stars} (${l.total_rentals || 0} ${ttt('mp_d_rentals','rentals')})</span></div>

--- a/backend/rental.js
+++ b/backend/rental.js
@@ -755,14 +755,26 @@ async function terminateActiveContractsOnRebind(deviceId, entityId, walletApi) {
 
 async function getListing(listingId) {
     const res = await pool.query(
-        `SELECT id, owner_user_id, owner_device_id, owner_entity_id,
-                title, description, rate_mli_per_ktoken,
-                min_rental_minutes, max_rental_minutes, availability_windows,
-                model_detected, capabilities, benchmark_score, interview_passed,
-                last_interview_at, avg_rating, total_rentals, uptime_pct, status,
-                soft_pause_until, soft_pause_reason,
-                created_at, updated_at
-         FROM bot_listings WHERE id = $1`,
+        `SELECT bl.id, bl.owner_user_id, bl.owner_device_id, bl.owner_entity_id,
+                bl.title, bl.description, bl.rate_mli_per_ktoken,
+                bl.min_rental_minutes, bl.max_rental_minutes, bl.availability_windows,
+                bl.model_detected, bl.capabilities, bl.benchmark_score, bl.interview_passed,
+                bl.last_interview_at, bl.avg_rating, bl.total_rentals, bl.uptime_pct, bl.status,
+                bl.soft_pause_until, bl.soft_pause_reason,
+                bl.avatar_url,
+                petdx.avatar_url AS petdx_avatar_url,
+                bl.created_at, bl.updated_at
+         FROM bot_listings bl
+         LEFT JOIN LATERAL (
+             SELECT c.avatar_url
+             FROM companion_select_log s
+             LEFT JOIN companions c ON c.id = s.companion_id
+             WHERE s.device_id = bl.owner_device_id
+               AND s.entity_id IS NOT DISTINCT FROM bl.owner_entity_id
+             ORDER BY s.selected_at DESC
+             LIMIT 1
+         ) petdx ON true
+         WHERE bl.id = $1`,
         [listingId]
     );
     return serializeSoftPauseFields(res.rows[0] || null);
@@ -913,6 +925,7 @@ async function searchMarketplace({
                 bl.avg_rating, bl.total_rentals, bl.uptime_pct,
                 bl.owner_device_id, bl.owner_entity_id,
                 bl.avatar_url,
+                petdx.avatar_url AS petdx_avatar_url,
                 bl.bound_rebind_count,
                 bl.soft_pause_until, bl.soft_pause_reason,
                 bl.created_at AS bl_created_at,
@@ -924,6 +937,15 @@ async function searchMarketplace({
                       AND ac.status IN ('reserved', 'active', 'suspended_insufficient_funds')
                 ) AS has_active_contract
             FROM bot_listings bl
+            LEFT JOIN LATERAL (
+                SELECT c.avatar_url
+                FROM companion_select_log s
+                LEFT JOIN companions c ON c.id = s.companion_id
+                WHERE s.device_id = bl.owner_device_id
+                  AND s.entity_id IS NOT DISTINCT FROM bl.owner_entity_id
+                ORDER BY s.selected_at DESC
+                LIMIT 1
+            ) petdx ON true
             WHERE ${where.join(' AND ')}
             ORDER BY bl.owner_device_id, bl.owner_entity_id, bl.created_at DESC
          ) deduped

--- a/backend/tests/jest/community-plaza-avatar-petdx.test.js
+++ b/backend/tests/jest/community-plaza-avatar-petdx.test.js
@@ -1,0 +1,85 @@
+const fs = require('fs');
+const path = require('path');
+
+const COMMUNITY_HTML = fs.readFileSync(
+    path.join(__dirname, '../../public/portal/community.html'),
+    'utf8',
+);
+const DB_JS = fs.readFileSync(
+    path.join(__dirname, '../../db.js'),
+    'utf8',
+);
+const RENTAL_JS = fs.readFileSync(
+    path.join(__dirname, '../../rental.js'),
+    'utf8',
+);
+
+describe('community.html — bot plaza must surface PETDX companion avatar', () => {
+    test('loads entity-utils.js + avatar-petdx.js shared modules', () => {
+        expect(COMMUNITY_HTML).toMatch(/<script[^>]*src=["']shared\/entity-utils\.js["']/);
+        expect(COMMUNITY_HTML).toMatch(/<script[^>]*src=["']\.\.\/shared\/avatar-petdx\.js["']/);
+    });
+
+    test('defines resolveBotAvatar() preferring petdxAvatarUrl over avatar', () => {
+        expect(COMMUNITY_HTML).toMatch(/function\s+resolveBotAvatar\s*\(/);
+        expect(COMMUNITY_HTML).toMatch(/row\.petdxAvatarUrl/);
+    });
+
+    test('routes plaza listings through resolveBotAvatar + botAvatarHtml — no raw inline (avatar||).startsWith branch left', () => {
+        // The old inline emoji/URL ternary used (bot.avatar||'').startsWith('http').
+        // Catch any regression where the same antipattern reappears against a bot
+        // record, since that path silently skips the petdxAvatarUrl enrichment.
+        const inlineMatches = COMMUNITY_HTML.match(/\(bot\.avatar\|\|['"][^'"]*['"]\)\.startsWith/g);
+        expect(inlineMatches).toBeNull();
+        const inlineRentalMatches = COMMUNITY_HTML.match(/l\.avatar_url\s*&&\s*l\.avatar_url\.startsWith\(/g);
+        expect(inlineRentalMatches).toBeNull();
+    });
+
+    test('community + rental listing rows flow through resolveBotAvatar', () => {
+        // Community search row mapping uses resolveBotAvatar(r)
+        expect(COMMUNITY_HTML).toMatch(/avatar:\s*resolveBotAvatar\(r\)/);
+        // Rental marketplace row mapping forwards petdx_avatar_url alongside avatar_url
+        expect(COMMUNITY_HTML).toMatch(/resolveBotAvatar\(\s*\{\s*petdxAvatarUrl:\s*l\.petdx_avatar_url/);
+    });
+});
+
+describe('searchPublicCards — surfaces petdx_avatar_url for plaza enrichment', () => {
+    test('SQL joins companion_select_log + companions and selects avatar_url', () => {
+        // Search query must LEFT JOIN LATERAL the companion select log →
+        // companions to surface each owner's current companion avatar.
+        const fn = DB_JS.split('async function searchPublicCards')[1] || '';
+        const body = fn.split(/\nasync function /)[0];
+        expect(body).toMatch(/companion_select_log/);
+        expect(body).toMatch(/LEFT JOIN companions/);
+        expect(body).toMatch(/petdx\.avatar_url\s+AS\s+petdx_avatar_url/i);
+        expect(body).toMatch(/petdxAvatarUrl:\s*r\.petdx_avatar_url/);
+    });
+
+    test('getPublicCardDetail also surfaces petdxAvatarUrl', () => {
+        const fn = DB_JS.split('async function getPublicCardDetail')[1] || '';
+        const body = fn.split(/\nasync function /)[0];
+        expect(body).toMatch(/companion_select_log/);
+        expect(body).toMatch(/petdxAvatarUrl:\s*r\.petdx_avatar_url/);
+    });
+});
+
+describe('rental.js — marketplace + listing detail expose petdx_avatar_url', () => {
+    test('searchMarketplace SQL joins companion_select_log', () => {
+        // Find the marketplace listing query — identified by DISTINCT ON
+        // (bl.owner_device_id, bl.owner_entity_id), the dedup key.
+        const block = RENTAL_JS.match(/DISTINCT ON \(bl\.owner_device_id[\s\S]+?ORDER BY \$\{orderBy\}/);
+        expect(block).not.toBeNull();
+        expect(block[0]).toMatch(/companion_select_log/);
+        expect(block[0]).toMatch(/petdx\.avatar_url\s+AS\s+petdx_avatar_url/i);
+    });
+
+    test('getListing SQL joins companion_select_log + selects avatar_url', () => {
+        const fn = RENTAL_JS.split('async function getListing')[1] || '';
+        const body = fn.split(/\nasync function /)[0];
+        // The single-listing detail query previously didn't even select
+        // avatar_url — locking in the fix here.
+        expect(body).toMatch(/bl\.avatar_url/);
+        expect(body).toMatch(/companion_select_log/);
+        expect(body).toMatch(/petdx_avatar_url/);
+    });
+});

--- a/backend/tests/jest/rental-interview.test.js
+++ b/backend/tests/jest/rental-interview.test.js
@@ -44,10 +44,11 @@ jest.mock('pg', () => {
             return { rows: [{ id: row.id, status: row.status, created_at: row.created_at }], rowCount: 1 };
         }
 
-        // SELECT listing by id
-        if (/^SELECT .* FROM bot_listings WHERE id = \$1$/i.test(norm)) {
+        // SELECT listing by id — accept both legacy and `bl.`-aliased shape
+        // (introduced when getListing picked up a petdx_avatar_url JOIN).
+        if (/^SELECT .* FROM bot_listings(?:\s+bl)?.* WHERE (?:bl\.)?id = \$1$/i.test(norm)) {
             const row = state.listings.find(l => l.id === params[0]);
-            return { rows: row ? [{ ...row }] : [], rowCount: row ? 1 : 0 };
+            return { rows: row ? [{ ...row, petdx_avatar_url: null }] : [], rowCount: row ? 1 : 0 };
         }
 
         // COUNT recent interviews (rate limit)

--- a/backend/tests/jest/rental-listing.test.js
+++ b/backend/tests/jest/rental-listing.test.js
@@ -169,11 +169,13 @@ jest.mock('pg', () => {
             return { rows: [{ id: row.id, status: row.status, updated_at: row.updated_at }], rowCount: 1 };
         }
 
-        // GET single listing
-        if (/^SELECT id, owner_user_id.*title.*description.*rate_mli_per_ktoken/i.test(norm)) {
+        // GET single listing — accept both legacy unaliased and the
+        // `bl.`-aliased shape introduced when getListing picked up a
+        // LEFT JOIN LATERAL on companion_select_log for petdx avatar.
+        if (/^SELECT (?:bl\.)?id, (?:bl\.)?owner_user_id.*(?:bl\.)?title.*(?:bl\.)?description.*(?:bl\.)?rate_mli_per_ktoken/i.test(norm)) {
             const row = state.listings.find(l => l.id === params[0]);
             if (!row) return { rows: [], rowCount: 0 };
-            return { rows: [{ ...row }], rowCount: 1 };
+            return { rows: [{ ...row, petdx_avatar_url: null }], rowCount: 1 };
         }
 
         // List my listings

--- a/backend/tests/jest/rental-soft-pause.test.js
+++ b/backend/tests/jest/rental-soft-pause.test.js
@@ -75,9 +75,9 @@ jest.mock('pg', () => {
             return rows([{ id: l.id, status: l.status, soft_pause_until: null, soft_pause_reason: null }]);
         }
 
-        if (/^SELECT id, owner_user_id, owner_device_id, owner_entity_id,.*soft_pause_until, soft_pause_reason,.*FROM bot_listings WHERE id = \$1$/i.test(norm)) {
+        if (/^SELECT (?:bl\.)?id, (?:bl\.)?owner_user_id, (?:bl\.)?owner_device_id, (?:bl\.)?owner_entity_id,.*soft_pause_until, (?:bl\.)?soft_pause_reason,.*FROM bot_listings/i.test(norm)) {
             const l = getListing(params[0]);
-            return l ? rows([{ ...l }]) : rows([]);
+            return l ? rows([{ ...l, petdx_avatar_url: null }]) : rows([]);
         }
         if (/^SELECT id FROM rental_contracts WHERE listing_id = \$1 AND status LIKE 'active%' LIMIT 1$/i.test(norm)) {
             return rows(state.contracts.filter((c) => c.listing_id === params[0] && String(c.status).startsWith('active')).slice(0, 1).map((c) => ({ id: c.id })));
@@ -93,7 +93,7 @@ jest.mock('pg', () => {
             })));
         }
 
-        if (/FROM bot_listings bl\s+WHERE/i.test(norm) && /bl.status = 'listed'/i.test(norm)) {
+        if (/FROM bot_listings bl\b/i.test(norm) && /bl.status = 'listed'/i.test(norm)) {
             const now = Date.now();
             const limit = params[params.length - 2] || 20;
             const offset = params[params.length - 1] || 0;
@@ -103,7 +103,8 @@ jest.mock('pg', () => {
                 min_rental_minutes: l.min_rental_minutes, max_rental_minutes: l.max_rental_minutes,
                 model_detected: l.model_detected, capabilities: l.capabilities, benchmark_score: l.benchmark_score,
                 avg_rating: l.avg_rating, total_rentals: l.total_rentals, uptime_pct: l.uptime_pct,
-                owner_device_id: l.owner_device_id, owner_entity_id: l.owner_entity_id, avatar_url: l.avatar_url,
+                owner_device_id: l.owner_device_id, owner_entity_id: l.owner_entity_id,
+                avatar_url: l.avatar_url, petdx_avatar_url: null,
                 bound_rebind_count: l.bound_rebind_count, soft_pause_until: l.soft_pause_until, soft_pause_reason: l.soft_pause_reason,
                 has_active_contract: activeContracts(l.id).length > 0,
             })));


### PR DESCRIPTION
## Summary
- Plaza listings (community.html) now surface the bot owner's currently selected AvatarPetdx companion avatar instead of the static `entities.avatar` emoji/upload. Root cause: `searchPublicCards` / `searchMarketplace` / `getListing` never consulted `companion_select_log`, so the plaza was blind to companion swaps made through the dressing system.
- Backend (`db.js`, `rental.js`): four SQL queries gain a `LEFT JOIN LATERAL` against the latest `companion_select_log` row → `companions.avatar_url`, surfaced as `petdx_avatar_url` / `petdxAvatarUrl`. `getListing` additionally now actually selects `bl.avatar_url` (it never did, so the rental detail modal had no avatar source at all).
- Frontend (`community.html`): loads `shared/entity-utils.js` + `shared/avatar-petdx.js`, defines `resolveBotAvatar()` (prefers `petdxAvatarUrl` over legacy `avatar`) + `botAvatarHtml()` (delegates to `renderAvatarHtml` with a no-helper fallback), and replaces every inline `(avatar||).startsWith('http') ? <img> : emoji` ternary across community cards, rental cards, and the two detail modals.

## Test plan
- [x] `npx jest tests/jest/community-plaza-avatar-petdx.test.js` — new static-audit suite (8 tests, all green) locking in the resolver pipeline + both SQL JOINs.
- [x] `npm test` — 295 suites / 4022 tests pass / 0 failed (full Jest sweep).
- [x] `npm run lint` — 0 errors (only 4 pre-existing warnings, none from this change).
- [x] `node scripts/i18n-check.js` — all referenced keys resolve in EN; no UI strings added by this change.
- [ ] Production E2E (post-merge): browse https://eclawbot.com/portal/community.html after Railway deploy and verify a published bot whose owner has selected a sprite companion shows the sprite avatar (not the emoji).

## Self-review (`docs/code-review-checklist.md`)
Part A
- [x] Logic trace: data flow walked from SQL → API JSON → community.html render in 6 spots (community + rental, list + detail). No remaining direct-`avatar` reads on bot rows.
- [x] Test coverage: new static-audit suite + matcher updates in 3 rental Jest suites for the `bl.`-aliased / petdx-augmented row shape.
- [x] Return shape: `petdxAvatarUrl: null` is preserved when no companion is selected so callers without the new field do not change behavior.
- [x] What this does NOT fix: the rental `bot_listings.avatar_url` snapshot taken at listing-creation time stays as-is — by design (it's a marketing snapshot). The plaza now layers the live companion avatar on top of that snapshot, but the snapshot itself is unchanged.
- [x] Security: no new auth surface, no new input. SQL is parameterized; the new JOIN keys on existing indexed columns (`device_id, entity_id, selected_at`).
Part B
- [x] `/api/help`: no shape change to public response (added field is opt-in for clients).
- [x] Related docs: none required — `petdxAvatarUrl` matches the existing field name already in `/api/entities` enrichment.
- [x] i18n audit: ⚠️ NO-OP — no user-visible strings added/changed.
- [x] Info page: ⚠️ NO-OP — bug fix, no new feature surface.
- [x] Debug endpoint: ⚠️ NO-OP per CLAUDE.md §5a (no bug report ticket attached; this is a forward-fix dispatched as card_314 with self-contained verification steps in the Test plan above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)