### PR TITLE
fix(ci): portal-smoke resolves /shared-core mount (Phase D follow-up)

### DIFF
--- a/backend/scripts/portal-smoke-check.js
+++ b/backend/scripts/portal-smoke-check.js
@@ -47,6 +47,9 @@ function resolveAsset(pageFile, rawUrl) {
     const url = cleanAssetUrl(rawUrl);
     if (!url || isExternal(url)) return null;
     if (url === '/socket.io/socket.io.js') return null;
+    // /shared-core/* is an Express static mount onto backend/shared/ (index.js
+    // line ~881). Translate so the smoke check finds the source file.
+    if (url.startsWith('/shared-core/')) return path.join(ROOT, 'shared', url.slice('/shared-core/'.length));
     if (url.startsWith('/')) return path.join(PUBLIC, url);
     return path.join(path.dirname(path.join(PUBLIC, pageFile)), url);
 }


### PR DESCRIPTION
## Summary
Follow-up fix for PR #3373. Phase D added `<script src="/shared-core/route-registry.js">` to dashboard.html + kanban.html, but `/shared-core/` is an Express static mount onto `backend/shared/`, not a public/-relative path, so the portal smoke check broke main CI:
```
- portal/dashboard.html: missing asset /shared-core/route-registry.js
- portal/kanban.html: missing asset /shared-core/route-registry.js
```

Teaches `resolveAsset()` in `backend/scripts/portal-smoke-check.js` to translate `/shared-core/*` → `backend/shared/*` so the smoke check finds the source. Verified locally: `node scripts/portal-smoke-check.js` → exit 0.

## Test plan
- [x] `node backend/scripts/portal-smoke-check.js` → "Portal smoke check passed"
- [x] No code logic change — CI-resolver patch only

🤖 Generated with [Claude Code](https://claude.com/claude-code)