### PR TITLE
feat(animation): 健檢中 health-checking parity (Android wallpaper + iOS) + visible-hold

### DIFF
--- a/app/src/main/java/com/hank/clawlive/data/model/AgentStatus.kt
+++ b/app/src/main/java/com/hank/clawlive/data/model/AgentStatus.kt
@@ -10,7 +10,9 @@ data class AgentStatus(
     val isBound: Boolean = false,
     val usage: UsageInfo? = null,
     val messageQueue: List<MessageQueueItem>? = null,
-    val botSecret: String? = null
+    val botSecret: String? = null,
+    val healthChecking: Boolean = false,  // true while passive health-check/repair runs (held visible >=4.5s)
+    val healthCheckingAt: Long? = null  // epoch ms the health-check flag was set (server-provided)
 ) {
     // All characters are now LOBSTER type (PIG removed)
     val baseShape: CharacterType

--- a/app/src/main/java/com/hank/clawlive/data/model/EntityStatus.kt
+++ b/app/src/main/java/com/hank/clawlive/data/model/EntityStatus.kt
@@ -21,7 +21,9 @@ data class EntityStatus(
     val level: Int = 1,
     val publicCode: String? = null,  // Cross-device messaging code
     val bindingType: String? = null,  // "channel" = OpenClaw channel plugin, null = direct binding
-    val encryptionStatus: String? = null  // "e2ee" | "transport" | null (Issue #212)
+    val encryptionStatus: String? = null,  // "e2ee" | "transport" | null (Issue #212)
+    val healthChecking: Boolean = false,  // true while passive health-check/repair runs (held visible >=4.5s)
+    val healthCheckingAt: Long? = null  // epoch ms the health-check flag was set (server-provided)
 ) {
     // All characters are now LOBSTER type (PIG removed)
     val baseShape: CharacterType
@@ -39,7 +41,9 @@ data class EntityStatus(
         lastUpdated = lastUpdated,
         usage = usage,
         messageQueue = messageQueue,
-        botSecret = botSecret
+        botSecret = botSecret,
+        healthChecking = healthChecking,
+        healthCheckingAt = healthCheckingAt
     )
 
     companion object {
@@ -57,7 +61,9 @@ data class EntityStatus(
             isBound = agentStatus.isBound,
             usage = agentStatus.usage,
             messageQueue = agentStatus.messageQueue,
-            botSecret = agentStatus.botSecret
+            botSecret = agentStatus.botSecret,
+            healthChecking = agentStatus.healthChecking,
+            healthCheckingAt = agentStatus.healthCheckingAt
         )
     }
 }

--- a/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
@@ -89,6 +89,22 @@ class ClawRenderer(
         isAntiAlias = true
     }
 
+    // Health-checking pulsing ring paint (parity with Web .health-checking ring)
+    private val healthRingPaint = Paint().apply {
+        style = Paint.Style.STROKE
+        color = Color.parseColor("#22D3EE") // cyan, matches Web health ring accent
+        isAntiAlias = true
+        strokeCap = Paint.Cap.ROUND
+    }
+
+    // Health-checking 「健檢中」label paint
+    private val healthLabelPaint = TextPaint().apply {
+        color = Color.parseColor("#22D3EE")
+        textAlign = Paint.Align.CENTER
+        isAntiAlias = true
+        isFakeBoldText = true
+    }
+
     // Animation state
     private var startTime = System.currentTimeMillis()
 
@@ -493,6 +509,14 @@ class ClawRenderer(
         val charY = centerY + bobOffset
         val radius = 150f * scale
 
+        // Health-checking: pulsing/glowing ring around the creature while the
+        // passive health-check/repair runs (parity with Web .health-checking
+        // avatar ring). Time-based sine pulse reuses the per-frame redraw loop
+        // (33ms) already driving the bobbing animation.
+        if (entity.healthChecking && !isAmbient) {
+            drawHealthCheckingRing(canvas, centerX, charY, radius, scale, time)
+        }
+
         // Petdx companion routing — if the entity has a current companion and
         // it's a spritesheet asset, render that. Procedural assets and missing
         // descriptors go to the legacy lobster drawer with optional body-color
@@ -562,6 +586,20 @@ class ClawRenderer(
             stateTextPaint.textAlign = Paint.Align.LEFT
             canvas.drawText(statusText, groupStartX + badgeDiameter + spacing, statusY, stateTextPaint)
             stateTextPaint.textAlign = Paint.Align.CENTER // Restore default
+
+            // 「健檢中」label below the status bar while health-checking. Pulses
+            // its alpha in sync with the ring so the two read as one effect.
+            if (entity.healthChecking) {
+                val pulse = (sin(time * 0.006f) * 0.5f + 0.5f) // 0..1
+                healthLabelPaint.textSize = (24f * scale).coerceAtLeast(16f)
+                healthLabelPaint.alpha = (140 + 115 * pulse).toInt().coerceIn(0, 255)
+                canvas.drawText(
+                    context.getString(R.string.health_checking),
+                    centerX,
+                    statusY + lineHeight,
+                    healthLabelPaint
+                )
+            }
         }
 
         // Draw "Zzz" if sleeping (Overlay on body/head, maybe slightly adjusted)
@@ -570,6 +608,39 @@ class ClawRenderer(
             // Moving Zzz slightly up so it doesn't overlap too much with the center face features
             canvas.drawText("Zzz...", centerX + radius * 0.7f, charY - radius * 0.8f, textPaint)
         }
+    }
+
+    /**
+     * Draw a pulsing/glowing ring around a health-checking entity.
+     *
+     * Uses a time-based sine pulse so the ring radius + opacity breathe in sync
+     * with the wallpaper's 33ms redraw loop (parity with the Web avatar
+     * `.health-checking` ring). Two concentric strokes give a soft glow.
+     */
+    private fun drawHealthCheckingRing(
+        canvas: Canvas,
+        cx: Float,
+        cy: Float,
+        radius: Float,
+        scale: Float,
+        time: Long
+    ) {
+        val pulse = (sin(time * 0.006f) * 0.5f + 0.5f) // 0..1 breathing factor
+        val baseRingRadius = radius * 0.95f
+        val ringRadius = baseRingRadius + (12f * scale * pulse)
+
+        // Outer glow (wider stroke, lower alpha)
+        healthRingPaint.strokeWidth = 10f * scale
+        healthRingPaint.alpha = (50 + 60 * pulse).toInt().coerceIn(0, 255)
+        canvas.drawCircle(cx, cy, ringRadius + (6f * scale), healthRingPaint)
+
+        // Inner crisp ring (thinner stroke, higher alpha)
+        healthRingPaint.strokeWidth = 5f * scale
+        healthRingPaint.alpha = (140 + 115 * pulse).toInt().coerceIn(0, 255)
+        canvas.drawCircle(cx, cy, ringRadius, healthRingPaint)
+
+        // Restore full alpha so the shared paint doesn't leak state into reuse
+        healthRingPaint.alpha = 255
     }
 
     /**

--- a/app/src/main/java/com/hank/clawlive/ui/EntityCardAdapter.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/EntityCardAdapter.kt
@@ -89,12 +89,19 @@ class EntityCardAdapter(
         holder.bind(entity)
     }
 
+    override fun onViewRecycled(holder: ViewHolder) {
+        super.onViewRecycled(holder)
+        // Stop any running health-checking pulse so recycled rows don't animate
+        holder.stopHealthChecking()
+    }
+
     inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         private val tvEntityIcon: TextView = itemView.findViewById(R.id.tvEntityIcon)
         private val tvEntityName: TextView = itemView.findViewById(R.id.tvEntityName)
         private val tvEntityId: TextView = itemView.findViewById(R.id.tvEntityId)
         private val tvStateBadge: TextView = itemView.findViewById(R.id.tvStateBadge)
         private val tvChannelBadge: TextView = itemView.findViewById(R.id.tvChannelBadge)
+        private val tvHealthCheckingBadge: TextView = itemView.findViewById(R.id.tvHealthCheckingBadge)
         private val tvE2eeBadge: TextView = itemView.findViewById(R.id.tvE2eeBadge)
         private val publicCodeRow: LinearLayout = itemView.findViewById(R.id.publicCodeRow)
         private val tvPublicCode: TextView = itemView.findViewById(R.id.tvPublicCode)
@@ -148,6 +155,10 @@ class EntityCardAdapter(
 
             // E2EE Badge
             tvE2eeBadge.visibility = if (entity.encryptionStatus == "e2ee") View.VISIBLE else View.GONE
+
+            // Health-checking: 健檢中 badge + subtle avatar pulse while the
+            // passive health-check/repair runs (parity with Web avatar ring).
+            applyHealthChecking(entity.healthChecking)
 
             // Message
             tvLastMessage.text = entity.message
@@ -214,6 +225,44 @@ class EntityCardAdapter(
                 }
                 popup.show()
             }
+        }
+
+        /** Running avatar pulse animator while health-checking; null when idle. */
+        private var healthPulseAnimator: android.animation.ObjectAnimator? = null
+
+        /**
+         * Toggle the 健檢中 badge + a subtle breathing alpha pulse on the avatar.
+         * Mirrors the Web `.health-checking` avatar ring animation. The pulse is
+         * cancelled (and alpha restored) whenever health-checking ends so recycled
+         * rows never keep a stale animation.
+         */
+        private fun applyHealthChecking(healthChecking: Boolean) {
+            tvHealthCheckingBadge.visibility = if (healthChecking) View.VISIBLE else View.GONE
+
+            if (healthChecking) {
+                if (healthPulseAnimator?.isRunning != true) {
+                    healthPulseAnimator = android.animation.ObjectAnimator.ofFloat(
+                        avatarContainer, View.ALPHA, 1f, 0.45f
+                    ).apply {
+                        duration = 750
+                        repeatCount = android.animation.ObjectAnimator.INFINITE
+                        repeatMode = android.animation.ObjectAnimator.REVERSE
+                        interpolator = android.view.animation.AccelerateDecelerateInterpolator()
+                        start()
+                    }
+                }
+            } else {
+                healthPulseAnimator?.cancel()
+                healthPulseAnimator = null
+                avatarContainer.alpha = 1f
+            }
+        }
+
+        /** Cancel the avatar pulse + restore alpha (called on view recycle). */
+        fun stopHealthChecking() {
+            healthPulseAnimator?.cancel()
+            healthPulseAnimator = null
+            avatarContainer.alpha = 1f
         }
 
         private fun getStateBadgeColor(state: CharacterState): Int {

--- a/app/src/main/res/layout/item_agent_card.xml
+++ b/app/src/main/res/layout/item_agent_card.xml
@@ -114,6 +114,20 @@
                 android:background="@drawable/badge_channel_background"
                 android:visibility="gone" />
 
+            <!-- Health-checking Badge (visible only while passive health-check runs) -->
+            <TextView
+                android:id="@+id/tvHealthCheckingBadge"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="6dp"
+                android:paddingHorizontal="10dp"
+                android:paddingVertical="4dp"
+                android:text="@string/health_checking"
+                android:textColor="#22D3EE"
+                android:textSize="11sp"
+                android:background="@drawable/badge_background"
+                android:visibility="gone" />
+
             <!-- E2EE Badge (visible only for E2EE-capable channel entities) -->
             <TextView
                 android:id="@+id/tvE2eeBadge"

--- a/app/src/main/res/values-ar/strings.xml
+++ b/app/src/main/res/values-ar/strings.xml
@@ -991,4 +991,6 @@ GPS: عند الطلب فقط، بلا تتبع في الخلفية، تُفقد
     <string name="wallpaper_settings_expand_action">توسيع لوحة الإعدادات</string>
     <string name="wallpaper_settings_collapse_action">طي لوحة الإعدادات</string>
     <string name="wallpaper_settings_collapse_caret_up">▲</string>
+    <!-- Health-checking status shown on entity avatar while passive health-check runs -->
+    <string name="health_checking">جارٍ الفحص الصحي</string>
 </resources>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -990,4 +990,6 @@ Bei Fragen kontaktieren Sie uns über unsere offizielle E-Mail.
     <string name="wallpaper_settings_expand_action">Einstellungspanel erweitern</string>
     <string name="wallpaper_settings_collapse_action">Einstellungspanel einklappen</string>
     <string name="wallpaper_settings_collapse_caret_up">▲</string>
+    <!-- Health-checking status shown on entity avatar while passive health-check runs -->
+    <string name="health_checking">Gesundheitsprüfung</string>
 </resources>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -913,4 +913,6 @@ Tu suscripción permanece activa y puedes reenlazar en cualquier momento (sujeto
     <string name="wallpaper_settings_expand_action">Expandir panel de configuración</string>
     <string name="wallpaper_settings_collapse_action">Contraer panel de configuración</string>
     <string name="wallpaper_settings_collapse_caret_up">▲</string>
+    <!-- Health-checking status shown on entity avatar while passive health-check runs -->
+    <string name="health_checking">Comprobando estado</string>
 </resources>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -990,4 +990,6 @@ Si vous avez des questions, contactez-nous via notre e-mail officiel.
     <string name="wallpaper_settings_expand_action">Développer le panneau de paramètres</string>
     <string name="wallpaper_settings_collapse_action">Réduire le panneau de paramètres</string>
     <string name="wallpaper_settings_collapse_caret_up">▲</string>
+    <!-- Health-checking status shown on entity avatar while passive health-check runs -->
+    <string name="health_checking">Vérification de santé</string>
 </resources>

--- a/app/src/main/res/values-hi/strings.xml
+++ b/app/src/main/res/values-hi/strings.xml
@@ -990,4 +990,6 @@ GPS: केवल अनुरोध पर, कोई बैकग्राउ�
     <string name="wallpaper_settings_collapse_caret_up">▲</string>
     <string name="ai_chat_status_processing_result">परिणाम प्रोसेस हो रहा है</string>
     <string name="ai_chat_status_analyzing">विश्लेषण हो रहा है</string>
+    <!-- Health-checking status shown on entity avatar while passive health-check runs -->
+    <string name="health_checking">स्वास्थ्य जांच</string>
 </resources>

--- a/app/src/main/res/values-id/strings.xml
+++ b/app/src/main/res/values-id/strings.xml
@@ -855,4 +855,6 @@
     <string name="wallpaper_settings_expand_action">Perluas panel pengaturan</string>
     <string name="wallpaper_settings_collapse_action">Ciutkan panel pengaturan</string>
     <string name="wallpaper_settings_collapse_caret_up">▲</string>
+    <!-- Health-checking status shown on entity avatar while passive health-check runs -->
+    <string name="health_checking">Memeriksa kesehatan</string>
 </resources>

--- a/app/src/main/res/values-in/strings.xml
+++ b/app/src/main/res/values-in/strings.xml
@@ -885,4 +885,6 @@ Jika ada pertanyaan, silakan hubungi kami melalui email resmi kami.
     <string name="wallpaper_settings_collapse_caret_up">▲</string>
     <string name="ai_chat_status_processing_result">Memproses hasil</string>
     <string name="ai_chat_status_analyzing">Menganalisis</string>
+    <!-- Health-checking status shown on entity avatar while passive health-check runs -->
+    <string name="health_checking">Memeriksa kesehatan</string>
 </resources>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -852,4 +852,6 @@
     <string name="tool_status_writing">Scrittura del file...</string>
     <string name="custom_layout_enabled">Layout personalizzato abilitato</string>
     <string name="custom_layout_using_preset">Utilizzando il layout preimpostato</string>
+    <!-- Health-checking status shown on entity avatar while passive health-check runs -->
+    <string name="health_checking">Controllo integrità</string>
 </resources>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -886,4 +886,6 @@ GPS：オンデマンドのみ、バックグラウンド追跡なし、サー�
     <string name="wallpaper_settings_expand_action">設定パネルを展開</string>
     <string name="wallpaper_settings_collapse_action">設定パネルを折りたたむ</string>
     <string name="wallpaper_settings_collapse_caret_up">▲</string>
+    <!-- Health-checking status shown on entity avatar while passive health-check runs -->
+    <string name="health_checking">ヘルスチェック中</string>
 </resources>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -886,4 +886,6 @@ GPS: 온디맨드만, 백그라운드 추적 없음, 서버 재시작 시 데이
     <string name="wallpaper_settings_expand_action">설정 패널 펼치기</string>
     <string name="wallpaper_settings_collapse_action">설정 패널 접기</string>
     <string name="wallpaper_settings_collapse_caret_up">▲</string>
+    <!-- Health-checking status shown on entity avatar while passive health-check runs -->
+    <string name="health_checking">상태 확인 중</string>
 </resources>

--- a/app/src/main/res/values-ms/strings.xml
+++ b/app/src/main/res/values-ms/strings.xml
@@ -990,4 +990,6 @@ Jika anda mempunyai sebarang soalan, sila hubungi kami melalui e-mel rasmi kami.
     <string name="wallpaper_settings_collapse_caret_up">▲</string>
     <string name="ai_chat_status_processing_result">Memproses hasil</string>
     <string name="ai_chat_status_analyzing">Menganalisis</string>
+    <!-- Health-checking status shown on entity avatar while passive health-check runs -->
+    <string name="health_checking">Menyemak kesihatan</string>
 </resources>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -852,4 +852,6 @@
     <string name="tool_status_writing">Gravando arquivo…</string>
     <string name="custom_layout_enabled">Layout personalizado ativado</string>
     <string name="custom_layout_using_preset">Usando layout predefinido</string>
+    <!-- Health-checking status shown on entity avatar while passive health-check runs -->
+    <string name="health_checking">Verificando integridade</string>
 </resources>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -852,4 +852,6 @@
     <string name="tool_status_writing">Запись файла…</string>
     <string name="custom_layout_enabled">Пользовательский макет включен</string>
     <string name="custom_layout_using_preset">Использование предустановленного макета</string>
+    <!-- Health-checking status shown on entity avatar while passive health-check runs -->
+    <string name="health_checking">Проверка состояния</string>
 </resources>

--- a/app/src/main/res/values-th/strings.xml
+++ b/app/src/main/res/values-th/strings.xml
@@ -885,4 +885,6 @@ GPS：รับตามความต้องการเท่านั้�
     <string name="wallpaper_settings_expand_action">ขยายแผงการตั้งค่า</string>
     <string name="wallpaper_settings_collapse_action">ยุบแผงการตั้งค่า</string>
     <string name="wallpaper_settings_collapse_caret_up">▲</string>
+    <!-- Health-checking status shown on entity avatar while passive health-check runs -->
+    <string name="health_checking">กำลังตรวจสุขภาพ</string>
 </resources>

--- a/app/src/main/res/values-vi/strings.xml
+++ b/app/src/main/res/values-vi/strings.xml
@@ -885,4 +885,6 @@ Nếu có bất kỳ câu hỏi nào, vui lòng liên hệ với chúng tôi qua
     <string name="wallpaper_settings_expand_action">Mở rộng bảng cài đặt</string>
     <string name="wallpaper_settings_collapse_action">Thu gọn bảng cài đặt</string>
     <string name="wallpaper_settings_collapse_caret_up">▲</string>
+    <!-- Health-checking status shown on entity avatar while passive health-check runs -->
+    <string name="health_checking">Đang kiểm tra</string>
 </resources>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -888,4 +888,6 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="wallpaper_settings_expand_action">展开设置面板</string>
     <string name="wallpaper_settings_collapse_action">收起设置面板</string>
     <string name="wallpaper_settings_collapse_caret_up">▲</string>
+    <!-- Health-checking status shown on entity avatar while passive health-check runs -->
+    <string name="health_checking">健检中</string>
 </resources>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -886,4 +886,6 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="ai_chat_tool_status_default">處理中</string>
     <string name="msg_no_entities_connected">沒有已連接的實體。請先綁定實體。</string>
     <string name="webview_title_eclawbot_portal">EClawbot 入口網站</string>
+    <!-- Health-checking status shown on entity avatar while passive health-check runs -->
+    <string name="health_checking">健檢中</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1002,4 +1002,6 @@ If you have any questions, please contact us via our official email.
     <string name="tool_status_writing">Writing file…</string>
     <string name="custom_layout_enabled">Custom layout enabled</string>
     <string name="custom_layout_using_preset">Using preset layout</string>
+    <!-- Health-checking status shown on entity avatar while passive health-check runs -->
+    <string name="health_checking">Health-checking</string>
 </resources>

--- a/backend/passive-health.js
+++ b/backend/passive-health.js
@@ -62,6 +62,10 @@ const MAX_INTERVAL_HOURS = 168; // one week
 const MAX_REPAIR_ATTEMPTS = 3;
 const REPAIR_COOLDOWN_MS = 60_000; // self-repair endpoint enforces a 60s cooldown
 const REPAIR_SPACING_MS = REPAIR_COOLDOWN_MS + 5_000; // space attempts past the cooldown
+// Minimum time the in-memory `healthChecking` flag stays on so the 健檢中 avatar/
+// wallpaper animation is perceptible even on a fast healthy check (which can finish
+// in <1s). The clear is scheduled non-blocking (does not slow the sweep).
+const HEALTH_CHECKING_MIN_VISIBLE_MS = 4500;
 // An entity is "unhealthy" if any error axis has accrued at least this many
 // recent (still-open) failures, or its daemon heartbeat is stale, or the
 // callback host /health probe fails.
@@ -452,10 +456,25 @@ async function runEntity(deviceId, deviceSecret, entityId, settings) {
 
         return { entityId, eligible: true, healthy: false, repaired: false, bugFiled: bug.filed, feedbackId: bug.feedbackId, failingSignals: health.failingSignals };
     } finally {
-        // Always clear the transient flag + push the cleared state, even on error.
+        // Clear the transient flag + push the cleared state, but hold it visible for a
+        // minimum duration so the 健檢中 animation is perceptible even on a fast healthy
+        // check. Non-blocking (scheduled, does not slow the sweep) and guarded so a newer
+        // check on the same entity (different healthCheckingAt) is never cleared early.
         if (entity) {
-            entity.healthChecking = false;
-            notifyEntityUpdate(deviceId, entityId);
+            const startedAt = entity.healthCheckingAt;
+            const clearFlag = () => {
+                if (entity.healthCheckingAt === startedAt) {
+                    entity.healthChecking = false;
+                    notifyEntityUpdate(deviceId, entityId);
+                }
+            };
+            const remaining = HEALTH_CHECKING_MIN_VISIBLE_MS - (Date.now() - (startedAt || Date.now()));
+            if (remaining > 0) {
+                const t = setTimeout(clearFlag, remaining);
+                if (t.unref) t.unref();
+            } else {
+                clearFlag();
+            }
         }
     }
 }

--- a/ios-app/components/EntityCard.tsx
+++ b/ios-app/components/EntityCard.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { View, StyleSheet, TouchableOpacity } from 'react-native';
+import React, { useEffect, useRef } from 'react';
+import { View, StyleSheet, TouchableOpacity, Animated, Easing } from 'react-native';
 import { Card, Text, Avatar, IconButton, useTheme } from 'react-native-paper';
 import { useTranslation } from 'react-i18next';
 import { Entity } from '../store/entityStore';
@@ -56,6 +56,36 @@ export default function EntityCard({ entity, editMode, onLongPress, onAvatarPres
   const xpNext = entity.xpForNextLevel ?? 100;
   const xpProgress = xpNext > 0 ? Math.min(xp / xpNext, 1) : 0;
 
+  // Health-checking: breathing avatar pulse + 健檢中 label while the backend
+  // passive health-check/repair runs (parity with the Web avatar ring).
+  const healthChecking = !!entity.healthChecking;
+  const pulse = useRef(new Animated.Value(1)).current;
+  useEffect(() => {
+    if (!healthChecking) {
+      pulse.stopAnimation();
+      pulse.setValue(1);
+      return;
+    }
+    const loop = Animated.loop(
+      Animated.sequence([
+        Animated.timing(pulse, {
+          toValue: 0.45,
+          duration: 750,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+        Animated.timing(pulse, {
+          toValue: 1,
+          duration: 750,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+      ])
+    );
+    loop.start();
+    return () => loop.stop();
+  }, [healthChecking, pulse]);
+
   return (
     <Card
       style={[styles.card, { backgroundColor: theme.colors.surfaceVariant }]}
@@ -69,7 +99,13 @@ export default function EntityCard({ entity, editMode, onLongPress, onAvatarPres
           delayLongPress={500}
           activeOpacity={0.7}
         >
-          <View style={styles.avatarContainer}>
+          <Animated.View
+            style={[
+              styles.avatarContainer,
+              healthChecking && styles.avatarHealthRing,
+              healthChecking && { opacity: pulse },
+            ]}
+          >
             {entity.avatarUrl ? (
               <Avatar.Image size={48} source={{ uri: entity.avatarUrl }} />
             ) : (
@@ -79,7 +115,7 @@ export default function EntityCard({ entity, editMode, onLongPress, onAvatarPres
                 style={{ backgroundColor: CHARACTER_COLORS[entity.character] || '#7C3AED' }}
               />
             )}
-          </View>
+          </Animated.View>
         </TouchableOpacity>
 
         {/* Info section */}
@@ -114,8 +150,8 @@ export default function EntityCard({ entity, editMode, onLongPress, onAvatarPres
             ) : null}
           </View>
 
-          {/* Badges row: Channel + E2EE */}
-          {(entity.channelBound || entity.encryptionStatus === 'e2ee') && (
+          {/* Badges row: Channel + E2EE + Health-checking */}
+          {(entity.channelBound || entity.encryptionStatus === 'e2ee' || healthChecking) && (
             <View style={styles.badgeRow}>
               {entity.channelBound && (
                 <View style={[styles.badge, { backgroundColor: '#4CAF5022' }]}>
@@ -126,6 +162,13 @@ export default function EntityCard({ entity, editMode, onLongPress, onAvatarPres
                 <View style={[styles.badge, { backgroundColor: '#60A5FA22' }]}>
                   <Text style={[styles.badgeText, { color: '#60A5FA' }]}>🔒 E2EE</Text>
                 </View>
+              )}
+              {healthChecking && (
+                <Animated.View style={[styles.badge, { backgroundColor: '#22D3EE22', opacity: pulse }]}>
+                  <Text style={[styles.badgeText, { color: '#22D3EE' }]}>
+                    {t('home.health_checking', 'Health-checking')}
+                  </Text>
+                </Animated.View>
               )}
             </View>
           )}
@@ -179,6 +222,12 @@ const styles = StyleSheet.create({
   },
   avatarContainer: {
     marginTop: 2,
+  },
+  avatarHealthRing: {
+    borderRadius: 28,
+    borderWidth: 2,
+    borderColor: '#22D3EE',
+    padding: 2,
   },
   info: {
     flex: 1,

--- a/ios-app/i18n/de.json
+++ b/ios-app/i18n/de.json
@@ -103,7 +103,8 @@
     "unbind_success": "Entität entbunden",
     "edit_mode": "Bearbeiten",
     "edit_mode_on": "Fertig",
-    "org_chart": "Organigramm"
+    "org_chart": "Organigramm",
+    "health_checking": "Gesundheitsprüfung"
   },
   "chat": {
     "title": "Chat",

--- a/ios-app/i18n/en.json
+++ b/ios-app/i18n/en.json
@@ -103,7 +103,8 @@
     "entity_idle": "Idle",
     "unbind_title": "Unbind Entity",
     "unbind_message": "Are you sure you want to unbind {{name}}?",
-    "unbind_success": "Entity unbound"
+    "unbind_success": "Entity unbound",
+    "health_checking": "Health-checking"
   },
   "chat": {
     "title": "Chat",

--- a/ios-app/i18n/es.json
+++ b/ios-app/i18n/es.json
@@ -103,7 +103,8 @@
     "channel_ai_agent_hint": "🤖 Se recomienda encarecidamente usar Claude Code u otros agentes de IA para la instalación asistida.",
     "edit_mode": "Editar",
     "edit_mode_on": "Hecho",
-    "org_chart": "Organigrama"
+    "org_chart": "Organigrama",
+    "health_checking": "Comprobando estado"
   },
   "chat": {
     "title": "Chat",

--- a/ios-app/i18n/fr.json
+++ b/ios-app/i18n/fr.json
@@ -103,7 +103,8 @@
     "unbind_success": "Entité déliée",
     "edit_mode": "Modifier",
     "edit_mode_on": "Terminé",
-    "org_chart": "Organigramme"
+    "org_chart": "Organigramme",
+    "health_checking": "Vérification de santé"
   },
   "chat": {
     "title": "Discussion",

--- a/ios-app/i18n/id.json
+++ b/ios-app/i18n/id.json
@@ -103,7 +103,8 @@
     "unbind_success": "Ikatan entitas dilepas",
     "edit_mode": "Sunting",
     "edit_mode_on": "Selesai",
-    "org_chart": "Bagan Organisasi"
+    "org_chart": "Bagan Organisasi",
+    "health_checking": "Memeriksa kesehatan"
   },
   "chat": {
     "title": "Obrolan",

--- a/ios-app/i18n/it.json
+++ b/ios-app/i18n/it.json
@@ -102,7 +102,8 @@
     "unbind_success": "Entità dissociata",
     "edit_mode": "Modifica",
     "edit_mode_on": "Fatto",
-    "org_chart": "Organigramma"
+    "org_chart": "Organigramma",
+    "health_checking": "Controllo integrità"
   },
   "chat": {
     "title": "Chat",

--- a/ios-app/i18n/ja.json
+++ b/ios-app/i18n/ja.json
@@ -103,7 +103,8 @@
     "unbind_success": "エンティティのバインドを解除しました",
     "edit_mode": "編集",
     "edit_mode_on": "完了",
-    "org_chart": "組織図"
+    "org_chart": "組織図",
+    "health_checking": "ヘルスチェック中"
   },
   "chat": {
     "title": "チャット",

--- a/ios-app/i18n/ko.json
+++ b/ios-app/i18n/ko.json
@@ -103,7 +103,8 @@
     "unbind_success": "엔티티 바인딩이 해제되었습니다",
     "edit_mode": "편집",
     "edit_mode_on": "완료",
-    "org_chart": "조직도"
+    "org_chart": "조직도",
+    "health_checking": "상태 확인 중"
   },
   "chat": {
     "title": "채팅",

--- a/ios-app/i18n/nl.json
+++ b/ios-app/i18n/nl.json
@@ -102,7 +102,8 @@
     "unbind_success": "Entiteit ontbonden",
     "edit_mode": "Bewerken",
     "edit_mode_on": "Klaar",
-    "org_chart": "Organigram"
+    "org_chart": "Organigram",
+    "health_checking": "Gezondheidscontrole"
   },
   "chat": {
     "title": "Chat",

--- a/ios-app/i18n/pl.json
+++ b/ios-app/i18n/pl.json
@@ -102,7 +102,8 @@
     "unbind_success": "Encja odwiązana",
     "edit_mode": "Edytuj",
     "edit_mode_on": "Gotowe",
-    "org_chart": "Schemat organizacyjny"
+    "org_chart": "Schemat organizacyjny",
+    "health_checking": "Sprawdzanie stanu"
   },
   "chat": {
     "title": "Czat",

--- a/ios-app/i18n/pt.json
+++ b/ios-app/i18n/pt.json
@@ -102,7 +102,8 @@
     "unbind_success": "Entidade desvinculada",
     "edit_mode": "Editar",
     "edit_mode_on": "Concluído",
-    "org_chart": "Organograma"
+    "org_chart": "Organograma",
+    "health_checking": "Verificando integridade"
   },
   "chat": {
     "title": "Chat",

--- a/ios-app/i18n/ru.json
+++ b/ios-app/i18n/ru.json
@@ -102,7 +102,8 @@
     "unbind_success": "Сущность отвязана",
     "edit_mode": "Изменить",
     "edit_mode_on": "Готово",
-    "org_chart": "Оргсхема"
+    "org_chart": "Оргсхема",
+    "health_checking": "Проверка состояния"
   },
   "chat": {
     "title": "Чат",

--- a/ios-app/i18n/th.json
+++ b/ios-app/i18n/th.json
@@ -103,7 +103,8 @@
     "unbind_success": "ยกเลิกการผูกเอนทิตีแล้ว",
     "edit_mode": "แก้ไข",
     "edit_mode_on": "เสร็จ",
-    "org_chart": "แผนผังองค์กร"
+    "org_chart": "แผนผังองค์กร",
+    "health_checking": "กำลังตรวจสุขภาพ"
   },
   "chat": {
     "title": "แชท",

--- a/ios-app/i18n/vi.json
+++ b/ios-app/i18n/vi.json
@@ -103,7 +103,8 @@
     "unbind_success": "Đã hủy liên kết thực thể",
     "edit_mode": "Sửa",
     "edit_mode_on": "Xong",
-    "org_chart": "Sơ đồ tổ chức"
+    "org_chart": "Sơ đồ tổ chức",
+    "health_checking": "Đang kiểm tra"
   },
   "chat": {
     "title": "Trò chuyện",

--- a/ios-app/i18n/zh-CN.json
+++ b/ios-app/i18n/zh-CN.json
@@ -103,7 +103,8 @@
     "unbind_success": "实体已解除绑定",
     "edit_mode": "编辑",
     "edit_mode_on": "完成",
-    "org_chart": "组织图"
+    "org_chart": "组织图",
+    "health_checking": "健检中"
   },
   "chat": {
     "title": "聊天",

--- a/ios-app/i18n/zh-TW.json
+++ b/ios-app/i18n/zh-TW.json
@@ -103,7 +103,8 @@
     "unbind_success": "實體已解除綁定",
     "edit_mode": "編輯",
     "edit_mode_on": "完成",
-    "org_chart": "組織圖"
+    "org_chart": "組織圖",
+    "health_checking": "健檢中"
   },
   "chat": {
     "title": "聊天",

--- a/ios-app/services/socketService.ts
+++ b/ios-app/services/socketService.ts
@@ -28,6 +28,9 @@ export interface EntityUpdate {
   character?: string;
   state?: string;
   message?: string;
+  // Passive health-check flag toggling on/off (drives avatar pulse + 健檢中 label).
+  healthChecking?: boolean;
+  healthCheckingAt?: number;
 }
 
 type EventCallback<T = unknown> = (data: T) => void;

--- a/ios-app/store/entityStore.ts
+++ b/ios-app/store/entityStore.ts
@@ -18,6 +18,10 @@ export interface Entity {
   xpForNextLevel?: number;
   channelBound?: boolean;
   messageTime?: number; // timestamp ms of last message
+  // True while the backend passive health-check/repair runs for this entity
+  // (held visible >=4.5s). Drives the avatar pulse + 健檢中 label (Web parity).
+  healthChecking?: boolean;
+  healthCheckingAt?: number; // epoch ms the health-check flag was set (server-provided)
 }
 
 interface EntityState {


### PR DESCRIPTION
Aligns the 健檢中 (health-checking) animation across all surfaces and makes it perceptible.

- backend/passive-health.js: hold the in-memory healthChecking flag visible >=4.5s (non-blocking, guarded scheduled clear) so the avatar/wallpaper animation is seen even on a fast healthy check (the check finishes <1s). Does not slow the sweep.
- Android: healthChecking parsed into EntityStatus/AgentStatus; ClawRenderer LIVE WALLPAPER draws a time-based sine pulsing cyan ring + 健檢中 label around a checking entity; entity card badge + breathing avatar pulse; i18n in all 18 strings.xml.
- iOS: healthChecking on the Entity type + socket payload; EntityCard.tsx Animated avatar pulse + ring + 健檢中 badge; i18n in all 16 locales.
Web animation already shipped (#3364); this completes parity. No hardcoded labels.

Verify: backend node --check OK; iOS tsc --noEmit clean for changed files; Android compile validated by CI (local SDK android-35 missing).