### PR TITLE
feat(portal): petdx-browser 60-per-page prev/next pagination replacing load-more

### DIFF
--- a/backend/public/portal/petdx-browser.html
+++ b/backend/public/portal/petdx-browser.html
@@ -114,12 +114,21 @@
         padding: 8px 16px; border-radius: 6px; cursor: pointer;
         font: inherit;
     }
-    .load-more-btn {
-        background: var(--accent); border: none; color: #fff;
-        padding: 6px 16px; border-radius: 6px; cursor: pointer;
-        font: inherit; font-size: 13px;
+    .pager {
+        display: inline-flex; align-items: center; gap: 8px;
     }
-    .load-more-btn:hover { opacity: 0.9; }
+    .pager-btn {
+        background: var(--panel); border: 1px solid var(--border); color: var(--text);
+        padding: 4px 10px; border-radius: 6px; cursor: pointer;
+        font: inherit; font-size: 12px;
+    }
+    .pager-btn:hover:not(:disabled) { border-color: var(--accent); color: var(--accent); }
+    .pager-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+    .pager-info { color: var(--muted); font-size: 12px; }
+    .pager-controls {
+        max-width: 1280px; margin: 16px auto 0;
+        display: flex; justify-content: center;
+    }
     .login-warn {
         padding: 12px; margin-bottom: 12px;
         background: #5a3000; color: #ffb04a;
@@ -203,9 +212,10 @@
     </div>
     <div id="grid" class="grid"></div>
     <div id="empty" class="empty" style="display: none;">
-        <div>沒有符合條件的伙伴 / No companions match your filter.</div>
-        <button onclick="resetFilters()">清除篩選 / Reset</button>
+        <div id="empty-msg">沒有符合條件的伙伴 / No companions match your filter.</div>
+        <button id="empty-reset" onclick="resetFilters()">清除篩選 / Reset</button>
     </div>
+    <div class="pager-controls" id="pager-controls"></div>
 </main>
 
 <div id="modal" class="modal-bg" role="dialog" aria-modal="true">
@@ -299,14 +309,29 @@
     ];
     const filterState = { scope: '', category: '', sort: 'popular' };
     let searchTerm = '';
-    // Pagination state (Hank 2026-06-12: browser capped at first 60, no paging).
-    // /api/companion/list already supports page/limit/total; we page client-side.
+    // Pagination state (Hank 2026-06-14): 60-per-page prev/next, no accumulation.
+    // Each page-flip *replaces* grid content so DOM nodes from the previous page
+    // are released to GC — prevents memory bloat on long browsing sessions.
     const PAGE_SIZE = 60;
     let currentPage = 1;
-    let loadedCount = 0;
     let totalCount = 0;
-    let loadingMore = false;
+    let totalPages = 1;
+    let isLoading = false;
     let searchTimer = 0;
+
+    // Sync ?page=N back into the URL bar without reloading. Preserves all other
+    // query params (deviceId/deviceSecret/entityId/botSecret/…) so a deep link
+    // copied off the address bar keeps the user logged in on the right page.
+    function syncUrlPage() {
+        try {
+            const params = new URLSearchParams(location.search);
+            if (currentPage > 1) params.set('page', String(currentPage));
+            else params.delete('page');
+            const qs = params.toString();
+            const newUrl = location.pathname + (qs ? '?' + qs : '') + location.hash;
+            history.replaceState(null, '', newUrl);
+        } catch (_) { /* history API failure is non-fatal */ }
+    }
 
     // ── Renderer pool ─────────────────────────────────────────────
     // One PetdxRenderer controller per visible card. We tear down on
@@ -336,6 +361,7 @@
                 c.textContent = opt.t;
                 c.addEventListener('click', () => {
                     filterState[group.key] = opt.v;
+                    currentPage = 1;
                     renderFilters();
                     loadList();
                 });
@@ -348,18 +374,22 @@
     window.resetFilters = function () {
         Object.keys(filterState).forEach(k => filterState[k] = (k === 'sort' ? 'popular' : ''));
         searchTerm = '';
+        currentPage = 1;
         document.getElementById('search').value = '';
         renderFilters();
         loadList();
     };
 
     // ── List loader ───────────────────────────────────────────────
-    // loadList(false) = fresh load (page 1, clears grid); loadList(true) = append next page.
-    async function loadList(append = false) {
+    // loadList(): always loads the page in `currentPage`, replacing grid
+    // content (no append). Filter/search/entity changes reset currentPage=1
+    // *before* calling this; prev/next set currentPage explicitly.
+    async function loadList() {
         const status = document.getElementById('status');
         const grid = document.getElementById('grid');
         const empty = document.getElementById('empty');
-        const pagination = document.getElementById('pagination');
+        const emptyMsg = document.getElementById('empty-msg');
+        const emptyReset = document.getElementById('empty-reset');
 
         const creds = getCreds();
         if (!creds.deviceId || (!creds.deviceSecret && !creds.botSecret)) {
@@ -368,19 +398,15 @@
             return;
         }
 
-        if (append) {
-            if (loadingMore || loadedCount >= totalCount) return;
-            loadingMore = true;
-            currentPage += 1;
-        } else {
-            currentPage = 1;
-            loadedCount = 0;
-            totalCount = 0;
-            empty.style.display = 'none';
-            tearDownRenderers();
-            grid.innerHTML = '';
-        }
-        status.textContent = append ? '載入更多…' : '載入中…';
+        if (isLoading) return;
+        isLoading = true;
+
+        // Tear down current page renderers + clear grid BEFORE the fetch so
+        // the old DOM nodes can be GC'd while we wait. Critical for memory.
+        empty.style.display = 'none';
+        tearDownRenderers();
+        grid.innerHTML = '';
+        status.textContent = '載入中…';
 
         const q = authQuery();
         if (filterState.scope)    q.set('scope', filterState.scope);
@@ -396,25 +422,45 @@
             data = await r.json();
             if (!data.success) {
                 status.textContent = '載入失敗：' + (data.error || r.status);
-                if (append) { currentPage -= 1; }
                 return;
             }
         } catch (err) {
             status.textContent = '網路錯誤：' + err.message;
-            if (append) { currentPage -= 1; }
             return;
         } finally {
-            loadingMore = false;
+            isLoading = false;
         }
 
         const items = data.companions || [];
         totalCount = data.total || 0;
-        loadedCount += items.length;
+        totalPages = Math.max(1, Math.ceil(totalCount / PAGE_SIZE));
+
+        // Clamp currentPage if the active filter shrank the result set so much
+        // that the saved page no longer exists (e.g. user on page 5, then
+        // applies a filter that has only 2 pages).
+        if (currentPage > totalPages) {
+            currentPage = totalPages;
+            isLoading = false;
+            syncUrlPage();
+            return loadList();
+        }
+
         status.textContent = '共 ' + totalCount + ' 個伙伴';
 
-        if (!loadedCount) {
+        if (totalCount === 0) {
+            // Distinguish "no companions exist at all" from "no match for current
+            // filter" — first is a system-wide empty state, second is filter UX.
+            const filtered = !!(searchTerm || filterState.scope || filterState.category);
+            if (filtered) {
+                emptyMsg.textContent = '沒有符合條件的伙伴 / No companions match your filter.';
+                emptyReset.style.display = '';
+            } else {
+                emptyMsg.textContent = '尚無夥伴 / No partners yet.';
+                emptyReset.style.display = 'none';
+            }
             empty.style.display = 'block';
             renderPagination();
+            syncUrlPage();
             return;
         }
 
@@ -423,27 +469,58 @@
             grid.appendChild(node);
         });
         renderPagination();
+        syncUrlPage();
     }
 
-    // Render the load-more control in the #pagination slot. Shows a button while
-    // more remain; a "all shown" note once everything is loaded.
+    function goToPage(n) {
+        const clamped = Math.max(1, Math.min(totalPages, n));
+        if (clamped === currentPage) return;
+        currentPage = clamped;
+        loadList();
+        // Scroll back to the top of the grid so the user sees the new page,
+        // not whatever scroll position the previous page left them at.
+        window.scrollTo({ top: 0, behavior: 'smooth' });
+    }
+
+    // Render the prev/next pager beneath the grid + a compact "Page X of Y"
+    // indicator in the top status bar. Both slots stay in sync.
     function renderPagination() {
-        const pagination = document.getElementById('pagination');
-        if (!pagination) return;
-        pagination.innerHTML = '';
-        if (loadedCount >= totalCount) {
-            if (totalCount > PAGE_SIZE) {
-                pagination.textContent = '已顯示全部 ' + totalCount + ' 個';
-            }
-            return;
-        }
-        const btn = document.createElement('button');
-        btn.type = 'button';
-        btn.id = 'load-more-btn';
-        btn.className = 'load-more-btn';
-        btn.textContent = `載入更多（${loadedCount}/${totalCount}）`;
-        btn.addEventListener('click', () => loadList(true));
-        pagination.appendChild(btn);
+        const topSlot = document.getElementById('pagination');
+        const pagerSlot = document.getElementById('pager-controls');
+        if (!topSlot || !pagerSlot) return;
+
+        topSlot.textContent = totalCount > 0
+            ? `第 ${currentPage} / ${totalPages} 頁 · Page ${currentPage} of ${totalPages}`
+            : '';
+
+        pagerSlot.innerHTML = '';
+        if (totalPages <= 1) return;
+
+        const pager = document.createElement('div');
+        pager.className = 'pager';
+
+        const prev = document.createElement('button');
+        prev.type = 'button';
+        prev.className = 'pager-btn';
+        prev.textContent = '‹ 上一頁 / Prev';
+        prev.disabled = currentPage <= 1;
+        prev.addEventListener('click', () => goToPage(currentPage - 1));
+        pager.appendChild(prev);
+
+        const info = document.createElement('span');
+        info.className = 'pager-info';
+        info.textContent = `${currentPage} / ${totalPages}`;
+        pager.appendChild(info);
+
+        const next = document.createElement('button');
+        next.type = 'button';
+        next.className = 'pager-btn';
+        next.textContent = '下一頁 / Next ›';
+        next.disabled = currentPage >= totalPages;
+        next.addEventListener('click', () => goToPage(currentPage + 1));
+        pager.appendChild(next);
+
+        pagerSlot.appendChild(pager);
     }
 
     // ── Card node ─────────────────────────────────────────────────
@@ -739,7 +816,10 @@
     document.getElementById('search').addEventListener('input', (e) => {
         searchTerm = e.target.value.trim();
         clearTimeout(searchTimer);
-        searchTimer = setTimeout(loadList, 250);
+        searchTimer = setTimeout(() => {
+            currentPage = 1;
+            loadList();
+        }, 250);
     });
 
     // ── Entity selector ──────────────────────────────────────────
@@ -790,6 +870,7 @@
         }
         // mine-scope filtering is tied to entityId — re-apply both list and
         // owner-state so the "✓ 目前選用" badge tracks the new scope.
+        currentPage = 1;
         loadList();
         refreshOwnerState();
     });
@@ -833,6 +914,12 @@
         const c = getCreds();
         const stored = localStorage.getItem(ACTIVE_ENTITY_KEY) || '';
         activeEntityId = c.entityId || stored || '';
+
+        // Restore page from ?page= URL param so a shared deep link lands the
+        // viewer on the same page the linker saw. Clamped to >=1; out-of-range
+        // values are corrected after the first fetch (see loadList clamp).
+        const urlPage = parseInt(new URLSearchParams(location.search).get('page'), 10);
+        if (Number.isFinite(urlPage) && urlPage >= 1) currentPage = urlPage;
 
         renderFilters();
         loadEntities();

--- a/backend/tests/jest/companion-api.test.js
+++ b/backend/tests/jest/companion-api.test.js
@@ -167,6 +167,68 @@ describe('companion-api: GET /list auth + validation', () => {
         expect(listCall[0]).toMatch(/device_id = \$\d/);
         expect(listCall[1]).toEqual(expect.arrayContaining([ENTITY, DEVICE]));
     });
+
+    // ── Pagination params (petdx-browser prev/next page-flip contract) ────
+    // The portal pager calls /list with explicit page=N&limit=60. These tests
+    // pin the response shape (page+limit+total) so the frontend can compute
+    // totalPages = ceil(total/limit) and disable prev/next accurately.
+    test('echoes page=N&limit=60 back in response + reflects them in SQL OFFSET/LIMIT', async () => {
+        __mockQuery
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [{ total: 240 }] });
+        const res = await request(makeApp())
+            .get('/api/companion/list')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY, page: '3', limit: '60' });
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({
+            success: true, page: 3, limit: 60, total: 240, companions: [],
+        });
+        // SQL params end with [..., limit, offset]; offset = (3-1)*60 = 120.
+        const listCallParams = __mockQuery.mock.calls[0][1];
+        expect(listCallParams[listCallParams.length - 2]).toBe(60);
+        expect(listCallParams[listCallParams.length - 1]).toBe(120);
+    });
+
+    test('limit is clamped to MAX_LIMIT (100) when caller asks for 9999', async () => {
+        __mockQuery
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [{ total: 0 }] });
+        const res = await request(makeApp())
+            .get('/api/companion/list')
+            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY, limit: '9999' });
+        expect(res.status).toBe(200);
+        expect(res.body.limit).toBe(100);
+    });
+
+    test('bad page/limit input falls back to defaults (page=1, limit=30)', async () => {
+        __mockQuery
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [{ total: 0 }] });
+        const res = await request(makeApp())
+            .get('/api/companion/list')
+            .query({
+                deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY,
+                page: 'abc', limit: '-7',
+            });
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({ page: 1, limit: 30 });
+    });
+
+    test('page=N with no result rows still returns the requested page number (frontend clamps via total)', async () => {
+        // Server doesn't clamp page against total — the frontend does (so the
+        // user gets feedback before a wasted round-trip). Pin that contract.
+        __mockQuery
+            .mockResolvedValueOnce({ rows: [] })
+            .mockResolvedValueOnce({ rows: [{ total: 5 }] });
+        const res = await request(makeApp())
+            .get('/api/companion/list')
+            .query({
+                deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY,
+                page: '99', limit: '60',
+            });
+        expect(res.status).toBe(200);
+        expect(res.body).toMatchObject({ page: 99, limit: 60, total: 5, companions: [] });
+    });
 });
 
 describe('companion-api: deviceSecret auth path (portal pages)', () => {

--- a/backend/tests/jest/petdx-browser-pagination.test.js
+++ b/backend/tests/jest/petdx-browser-pagination.test.js
@@ -1,12 +1,15 @@
 /**
- * Static invariant test for petdx-browser pagination (load-more).
- * Card: card_6e21220bbf406675e7992790 (Hank 2026-06-12 — browser showed only the
- * first 60 companions with no paging).
+ * Static invariant test for petdx-browser pagination.
  *
- * jest.config.js uses testEnvironment: 'node' (matching the portal static tests),
- * so we lock the SOURCE surface. Runtime behaviour (append + reset) is covered by
- * the prod E2E. /api/companion/list already supports page/limit/total — this is a
- * pure front-end consumer fix.
+ * Originally written for the load-more flavour (card_6e21220bbf406675e7992790,
+ * Hank 2026-06-12). Rewritten for the prev/next 60-per-page redesign
+ * (card_ddb8ebfd2112b8cfc89ebc9f, Hank 2026-06-14) — switched away from
+ * load-more so DOM nodes from the previous page get GC'd between flips and
+ * the heap stays flat on long sessions.
+ *
+ * jest.config.js uses testEnvironment: 'node' (matching the portal static
+ * tests), so we lock the SOURCE surface here. Runtime behaviour is covered by
+ * the prod E2E and companion-api.test.js (server response shape).
  */
 'use strict';
 
@@ -18,32 +21,64 @@ const html = fs.readFileSync(
     'utf8'
 );
 
-describe('petdx-browser pagination (load-more)', () => {
-    test('sends the page param to /api/companion/list', () => {
+describe('petdx-browser pagination (prev/next, 60 per page)', () => {
+    test('sends page + 60-card limit to /api/companion/list', () => {
         expect(html).toMatch(/q\.set\(\s*['"]page['"]\s*,\s*String\(currentPage\)\s*\)/);
+        expect(html).toMatch(/const\s+PAGE_SIZE\s*=\s*60/);
+        expect(html).toMatch(/q\.set\(\s*['"]limit['"]\s*,\s*String\(PAGE_SIZE\)\s*\)/);
     });
 
-    test('loadList supports an append mode (page 1 reset vs next-page append)', () => {
-        expect(html).toMatch(/async function loadList\(\s*append\s*=\s*false\s*\)/);
-        // append path advances the page; reset path returns to 1
-        expect(html).toMatch(/currentPage\s*\+=\s*1/);
-        expect(html).toMatch(/currentPage\s*=\s*1/);
+    test('loadList replaces grid each call (no append mode)', () => {
+        // No `append` param on loadList — every call is a fresh page.
+        expect(html).toMatch(/async function loadList\(\s*\)/);
+        // Append-mode primitives from the old design must be gone.
+        expect(html).not.toMatch(/loadedCount/);
+        expect(html).not.toMatch(/loadingMore/);
+        expect(html).not.toMatch(/load-more-btn/);
     });
 
-    test('tracks loaded vs total and stops appending when exhausted', () => {
-        expect(html).toMatch(/loadedCount\s*\+=\s*items\.length/);
-        expect(html).toMatch(/totalCount\s*=\s*data\.total/);
-        expect(html).toMatch(/loadedCount\s*>=\s*totalCount/);
+    test('tears down per-card renderers + clears grid before the next fetch', () => {
+        // tearDownRenderers + grid.innerHTML = '' must happen BEFORE the await
+        // — without this, the old 60 canvases linger through the fetch and
+        // heap usage doubles between page-flips.
+        const loadList = html.match(/async function loadList\(\)\s*\{[\s\S]*?const q = authQuery\(\);/);
+        expect(loadList).not.toBeNull();
+        expect(loadList[0]).toMatch(/tearDownRenderers\(\)/);
+        expect(loadList[0]).toMatch(/grid\.innerHTML\s*=\s*['"]['"]/);
     });
 
-    test('renders a load-more button wired to append, hidden when all shown', () => {
-        expect(html).toMatch(/className\s*=\s*['"]load-more-btn['"]/);
-        expect(html).toMatch(/\.load-more-btn\s*\{/); // CSS rule present
-        expect(html).toMatch(/addEventListener\(\s*['"]click['"]\s*,\s*\(\)\s*=>\s*loadList\(true\)\s*\)/);
-        expect(html).toMatch(/已顯示全部/);
+    test('derives totalPages from total + clamps current page when filter shrinks result set', () => {
+        expect(html).toMatch(/totalPages\s*=\s*Math\.max\(\s*1\s*,\s*Math\.ceil\(\s*totalCount\s*\/\s*PAGE_SIZE\s*\)\s*\)/);
+        // After the count comes back, if currentPage > totalPages we re-fetch
+        // the clamped page rather than showing a confusing empty grid.
+        expect(html).toMatch(/currentPage\s*>\s*totalPages/);
     });
 
-    test('guards against double-trigger while a load-more is in flight', () => {
-        expect(html).toMatch(/if\s*\(\s*loadingMore\s*\|\|\s*loadedCount\s*>=\s*totalCount\s*\)\s*return/);
+    test('renders prev + next buttons disabled at the ends', () => {
+        expect(html).toMatch(/className\s*=\s*['"]pager-btn['"]/);
+        expect(html).toMatch(/prev\.disabled\s*=\s*currentPage\s*<=\s*1/);
+        expect(html).toMatch(/next\.disabled\s*=\s*currentPage\s*>=\s*totalPages/);
+        // A "Page X of Y" indicator must surface somewhere; bilingual string is fine.
+        expect(html).toMatch(/Page \$\{currentPage\} of \$\{totalPages\}/);
+    });
+
+    test('filter / search / entity-selector changes reset to page 1', () => {
+        // resetFilters() + filter chip click + search debounce + selector change
+        // all set currentPage = 1 before re-querying.
+        const resetCount = (html.match(/currentPage\s*=\s*1/g) || []).length;
+        // 5 expected sites: filter chip handler, resetFilters, search debounce,
+        // entity-selector change, and URL-restore guard. Lock the floor.
+        expect(resetCount).toBeGreaterThanOrEqual(4);
+    });
+
+    test('keeps the URL ?page= param in sync via history.replaceState', () => {
+        expect(html).toMatch(/history\.replaceState\(/);
+        expect(html).toMatch(/params\.set\(\s*['"]page['"]\s*,\s*String\(currentPage\)\s*\)/);
+        // Init reads ?page= back so deep links and refresh survive.
+        expect(html).toMatch(/URLSearchParams\(location\.search\)\.get\(\s*['"]page['"]\s*\)/);
+    });
+
+    test('shows a distinct "no partners yet" message when totalCount is 0 with no filter active', () => {
+        expect(html).toMatch(/No partners yet/);
     });
 });


### PR DESCRIPTION
## Summary
- Replaces accumulating `載入更多` button with fixed 60-per-page **prev/next** pager on `/portal/petdx-browser.html` so DOM nodes from the previous page can be GC'd between page-flips — fixes the heap bloat / browser stall Hank reported.
- Each `loadList()` call now tears down `PetdxRenderer` controllers and clears `#grid` *before* the fetch, so the prior 60 cards (and their per-card `<canvas>` + rAF loops) release before the next batch arrives.
- Adds `?page=N` URL sync via `history.replaceState`; deep links / refresh survive. Other query params (deviceId/deviceSecret/entityId/botSecret) are preserved verbatim.
- Filter / search / entity-selector changes reset `currentPage = 1`; pager clamps a stale `currentPage` to `totalPages` when an applied filter shrinks the result set below it.
- Distinguishes `尚無夥伴 / No partners yet` (`totalCount === 0`, no filter active) from the existing `沒有符合條件的伙伴 / No companions match your filter` empty state.

## Backend
None needed — `/api/companion/list` already echoes `{ success, page, limit, total, companions }` and accepts `?page=N&limit=60`. Pinned with new Jest cases covering:
- echo of `page=3&limit=60` + correct SQL `OFFSET 120` binding,
- `limit` clamped to `MAX_LIMIT=100` on 9999,
- bad `page=abc&limit=-7` → falls back to defaults `(1, 30)`,
- `page=99` past `total=5` still returns the requested page number (frontend clamps).

## Test plan
- [x] `cd backend && npx jest tests/jest/companion-api.test.js` — **79 passed** (75 prior + 4 new pagination cases). Log: `/file petdx-jest-companion.log`.
- [x] `cd backend && npx jest --testPathPattern=i18n-syntax` — 12 passed.
- [x] `node backend/scripts/i18n-check.js` — `✅ All referenced keys resolve in EN`.
- [ ] Manual: open `/portal/petdx-browser.html` in Chrome, flip 1→2→3 → prev/next disable correctly, `?page=N` syncs in address bar, refresh keeps the page.
- [ ] Manual memory: Performance tab, flip 10 pages, heap stable (no monotonic growth between Detached HTMLElements).

## Out of scope
- Other portal pages that still have load-more (separate cards if reported).
- Server-side rendering / SSR.
- Infinite-scroll fallback (Hank explicitly asked for prev/next, not load-more).

Closes card `card_ddb8ebfd2112b8cfc89ebc9f`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)