### PR TITLE
fix(release): drop @semantic-release/git + @semantic-release/changelog (#6 ruling Path A — GH Release/tag only)

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -1,7 +1,11 @@
 name: Semantic Release
 
-# Automatically analyzes commits on main, bumps version, generates
-# CHANGELOG.md, and creates a GitHub Release.
+# Automatically analyzes commits on main, bumps version, and creates
+# a GitHub Release (tag + release notes). Per #6 ruling Path A
+# (2026-06-14), this workflow no longer pushes a release commit back
+# to main — branch protection blocks @semantic-release/git, and
+# GitHub Releases are the system of record. CHANGELOG.md is not
+# regenerated; release notes live on the Releases page.
 #
 # Commit message convention (Angular preset):
 #   feat: add feature          → minor bump (1.x.0)
@@ -33,7 +37,7 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
 
     permissions:
-      contents: write      # push tags + update CHANGELOG.md
+      contents: write      # create tags + GitHub Releases
       issues: write        # close issues referenced in commits
       pull-requests: write # comment on PRs
 
@@ -64,8 +68,6 @@ jobs:
             semantic-release@24 \
             @semantic-release/commit-analyzer@13 \
             @semantic-release/release-notes-generator@14 \
-            @semantic-release/changelog@6 \
-            @semantic-release/git@10 \
             @semantic-release/github@10
 
       - name: Run semantic-release

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -35,19 +35,6 @@
       }
     ],
     [
-      "@semantic-release/changelog",
-      {
-        "changelogFile": "CHANGELOG.md"
-      }
-    ],
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "backend/package.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ],
-    [
       "@semantic-release/github",
       {
         "successComment": false,


### PR DESCRIPTION
## Summary

Fix card_baf1fc4f7c0ed016360f95b9 — Semantic Release on `main` has been failing on every push because `@semantic-release/git` tries to push a release commit back to `main`, and branch protection rejects it with GH006 (`Changes must be made through a pull request`).

Per #6 ruling Path A (2026-06-14), drop **both** `@semantic-release/git` **and** `@semantic-release/changelog` from the pipeline. The workflow now does only: commit-analyze → release notes → GitHub Release / tag. GitHub Releases become the system of record for release notes.

## Changes

- `.releaserc.json` — remove both plugin entries from the `plugins` array. Remaining plugins: `commit-analyzer`, `release-notes-generator`, `github`.
- `.github/workflows/semantic-release.yml` — drop `@semantic-release/changelog@6` and `@semantic-release/git@10` from the `npm install --no-save` step. Refresh header / permissions comments.
- Historical `CHANGELOG.md` left untouched in the repo (just stop appending to it).
- No `package.json` change — the plugins were installed inline by the workflow (`--no-save`), not pinned in devDependencies.

## Why Path A (verbatim from #6)

> 走 A，而且要同時移除 @semantic-release/changelog + @semantic-release/git，讓 workflow 只做 commit analyze、release notes、GitHub Release/tag。

Independently verified by #6 against `.releaserc.json` + `semantic-release.yml` + origin/main + branch protection API + last 8 failed runs + latest GH Release `v1.1194.0` (2026-05-31).

## Test plan

- [x] `.releaserc.json` re-validates as JSON; plugins array no longer contains `@semantic-release/changelog` or `@semantic-release/git`.
- [x] Workflow YAML still parses; install step shrinks by exactly 2 lines.
- [ ] After merge: next push to `main` triggers `Semantic Release` workflow → run conclusion = `success` → new GitHub Release created with tag > `v1.1194.0`.

## What this does NOT fix

- Does not retroactively re-run the 8 prior failed runs.
- Does not regenerate or delete the historical `CHANGELOG.md` — it just stops appending.
- Does not change branch protection rules on `main` (they remain as-is; we route around them instead).

## Refs

- Card: `card_baf1fc4f7c0ed016360f95b9`
- Ruling: #6 (2026-06-14)
- Last green release: `v1.1194.0` (2026-05-31)

🤖 Generated with [Claude Code](https://claude.com/claude-code)