### PR TITLE
feat(message-lifecycle): Phase 2 Step 1 — DB schema migration + lifecycle_event_log (card_1b1c)

### DIFF
--- a/backend/migrations/20260614_message_lifecycle.down.sql
+++ b/backend/migrations/20260614_message_lifecycle.down.sql
@@ -1,0 +1,10 @@
+-- Down: 20260614_message_lifecycle
+-- Drop the lifecycle schema in reverse order.
+
+DROP INDEX IF EXISTS idx_lel_message;
+DROP TABLE IF EXISTS lifecycle_event_log;
+
+DROP INDEX IF EXISTS idx_ml_reply_chain;
+DROP INDEX IF EXISTS idx_ml_stuck_lookup;
+DROP INDEX IF EXISTS idx_ml_device_entity_state;
+DROP TABLE IF EXISTS message_lifecycle;

--- a/backend/migrations/20260614_message_lifecycle.up.sql
+++ b/backend/migrations/20260614_message_lifecycle.up.sql
@@ -1,0 +1,120 @@
+-- Migration: 20260614_message_lifecycle
+-- Card: card_1b1c13225f10e8a803cef532 (MessageLifecycle Phase 2 Step 1 — DB only)
+-- Spec: docs/specs/message-lifecycle-spec.md §3 (Option B), §3.3, §11
+--
+-- Phase 2 Step 1 of 6: ships ONLY the DB layer for the unified message
+-- lifecycle state machine. Steps 2-6 (Redis wheel, dual-write, backfill,
+-- debug endpoint, divergence detector) land in follow-up PRs.
+--
+-- Option choice: B (companion message_lifecycle table) per spec §3.4 trade-off:
+--   - Lower migration risk: no ALTER TABLE on the hot chat_messages path.
+--   - Cleaner separation: chat_messages callers are unchanged; only the new
+--     lifecycle code touches message_lifecycle.
+--   - Outbound rows live as their own row (direction='outbound') instead of
+--     leaving lifecycle columns NULL on every outbound chat_messages row.
+--   - Backfill is INSERT into a separate table (cold path) instead of UPDATE
+--     on chat_messages (hot path) — safer for Railway PG.
+--
+-- Naming note: the spec text uses `chat_history` as the abstract noun for the
+-- chat-message corpus. The actual table in this codebase is `chat_messages`
+-- (backend/auth_schema.sql:72) with a UUID primary key. We therefore key the
+-- lifecycle row by `message_id TEXT` (matches spec §3.2 + §3.3 verbatim) and
+-- do NOT add a FK — this keeps schema flexibility and matches spec §3.3 which
+-- also uses TEXT without a FK.
+--
+-- Constraint #1 (§11): no UPDATE/DELETE path rolls back a state field.
+--   - Encoded structurally at the app layer (lifecycle.transition() rejects
+--     late events into lifecycle_event_log with applied='rejected_late').
+--   - A CHECK on `state` restricts values to the enum domain. PG does not
+--     have a clean way to forbid an UPDATE that lowers a state index, so the
+--     monotonicity invariant is enforced in code (see spec §2.3 rule 2). The
+--     audit table preserves every attempt regardless of acceptance.
+--
+-- Constraint #2 (§11): unknown/null/timeout NEVER inflate user_seen success.
+--   - push_delivered_at and user_seen_at are NULLABLE and are NEVER derived
+--     by the backfill resolver (spec §5.1). The schema does not COALESCE them
+--     anywhere; SLO query authors must keep `user_seen_at IS NOT NULL` in the
+--     numerator of real_user_seen_rate (spec §6.2).
+
+CREATE TABLE IF NOT EXISTS message_lifecycle (
+    message_id          TEXT PRIMARY KEY,
+    tenant_id           TEXT NOT NULL,
+    device_id           VARCHAR(64) NOT NULL,
+    entity_id           INTEGER NOT NULL,
+    direction           TEXT NOT NULL CHECK (direction IN ('inbound', 'outbound')),
+    reply_to_message_id TEXT,
+
+    state               TEXT NOT NULL CHECK (state IN ('inbound_seen', 'bot_acked', 'push_delivered', 'user_seen')),
+    inbound_seen_at     TIMESTAMPTZ NOT NULL,
+    bot_acked_at        TIMESTAMPTZ,
+    push_delivered_at   TIMESTAMPTZ,
+    user_seen_at        TIMESTAMPTZ,
+
+    -- Spec §2.3 rule 3: out-of-order events advance to the highest observed
+    -- state; the skipped intermediate states are recorded here (e.g. ['bot_acked']
+    -- if we jumped inbound_seen → push_delivered).
+    skipped_states      TEXT[] NOT NULL DEFAULT '{}',
+
+    last_error          TEXT,
+    alerted_at          TIMESTAMPTZ,
+    source              TEXT NOT NULL DEFAULT 'live'
+                        CHECK (source IN ('live', 'backfill', 'backfill+link', 'backfill+heuristic', 'inferred')),
+
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Per-entity state lookup (dashboard panels, per-entity stuck counts).
+CREATE INDEX IF NOT EXISTS idx_ml_device_entity_state
+    ON message_lifecycle (device_id, entity_id, state);
+
+-- Sweeper hot path: find rows past their per-state deadline. The COALESCE
+-- here is a pivot for "timestamp of current state" (spec §6.3) and is
+-- correct because each state's *_at is populated as that state is reached.
+-- This does NOT violate constraint #2: COALESCE in an INDEX is only used to
+-- locate stuck rows, never to inflate user_seen success in an SLO numerator.
+CREATE INDEX IF NOT EXISTS idx_ml_stuck_lookup
+    ON message_lifecycle (state, COALESCE(push_delivered_at, bot_acked_at, inbound_seen_at))
+    WHERE state <> 'user_seen';
+
+-- Reply-chain joins: given an inbound message_id, find its outbound replies.
+CREATE INDEX IF NOT EXISTS idx_ml_reply_chain
+    ON message_lifecycle (reply_to_message_id)
+    WHERE reply_to_message_id IS NOT NULL;
+
+COMMENT ON TABLE message_lifecycle IS
+    'Unified message lifecycle state machine (spec docs/specs/message-lifecycle-spec.md §2). '
+    'Replaces legacy chat_no_reply (entity-status.js) and delivery_alert (hermes) counters. '
+    'Phase 2 Step 1 ships the schema only — dual-write, Redis wheel, backfill resolver, '
+    'and debug endpoint follow in Steps 2-5. Spec §11 constraint #1: no UPDATE path '
+    'rolls back a state field (enforced at app layer in lifecycle.transition()). Spec §11 '
+    'constraint #2: push_delivered_at and user_seen_at are NEVER derived — SLO queries MUST '
+    'keep user_seen_at IS NOT NULL in real_user_seen_rate numerator.';
+
+-- ============================================
+-- lifecycle_event_log: audit trail of every transition attempt
+-- Spec §2.4 + §3.3
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS lifecycle_event_log (
+    id              BIGSERIAL PRIMARY KEY,
+    message_id      TEXT NOT NULL,
+    attempted_state TEXT NOT NULL
+                    CHECK (attempted_state IN ('inbound_seen', 'bot_acked', 'push_delivered', 'user_seen')),
+    event_at        TIMESTAMPTZ NOT NULL,
+    transition_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    applied         TEXT NOT NULL
+                    CHECK (applied IN ('accepted', 'idempotent_noop', 'rejected_late', 'rejected_unknown_message')),
+    reason          TEXT,
+    source          TEXT NOT NULL
+);
+
+-- Per-message audit timeline (debug endpoint hot path, spec §9.1/9.2 acceptance).
+CREATE INDEX IF NOT EXISTS idx_lel_message
+    ON lifecycle_event_log (message_id, transition_at DESC);
+
+COMMENT ON TABLE lifecycle_event_log IS
+    'Append-only audit of every lifecycle transition attempt — accepted, idempotent_noop, '
+    'rejected_late, or rejected_unknown_message (spec §2.4). NEVER mutated after insert; '
+    'this is the structural enforcement of constraint #1 (no rollback). Read by the debug '
+    'endpoint GET /api/debug/message-lifecycle/:messageId (Step 5) for the per-message timeline.';

--- a/backend/tests/jest/message-lifecycle-migration.test.js
+++ b/backend/tests/jest/message-lifecycle-migration.test.js
@@ -1,0 +1,195 @@
+'use strict';
+
+// Migration smoke test for 20260614_message_lifecycle.
+//
+// Card: card_1b1c13225f10e8a803cef532 (MessageLifecycle Phase 2 Step 1).
+// Spec: docs/specs/message-lifecycle-spec.md §3 (Option B), §3.3.
+//
+// This is a static-shape test (no live PG harness required). It loads the
+// up + down SQL and asserts the schema contract that Steps 2-6 depend on:
+//   - message_lifecycle table exists with the expected columns + CHECK
+//     constraints (state enum, direction enum, source enum).
+//   - The three indexes the sweeper hot path needs are present.
+//   - lifecycle_event_log table exists with the expected applied-state CHECK
+//     and the per-message timeline index.
+//   - down.sql drops every object created by up.sql (round-trip safety).
+//   - Spec §11 constraints are encoded structurally — push_delivered_at and
+//     user_seen_at are NULLABLE (NEVER derived), and lifecycle_event_log has
+//     no DELETE/UPDATE statements that would let it roll back state.
+
+const fs = require('fs');
+const path = require('path');
+
+const MIGRATIONS_DIR = path.join(__dirname, '..', '..', 'migrations');
+const UP_FILE = path.join(MIGRATIONS_DIR, '20260614_message_lifecycle.up.sql');
+const DOWN_FILE = path.join(MIGRATIONS_DIR, '20260614_message_lifecycle.down.sql');
+
+function readSql(file) {
+    return fs.readFileSync(file, 'utf8');
+}
+
+describe('20260614_message_lifecycle migration', () => {
+    const up = readSql(UP_FILE);
+    const down = readSql(DOWN_FILE);
+
+    describe('message_lifecycle table (spec §3.2)', () => {
+        test('creates message_lifecycle table', () => {
+            expect(up).toMatch(/CREATE TABLE IF NOT EXISTS message_lifecycle/);
+        });
+
+        test('keys lifecycle by message_id TEXT PRIMARY KEY (spec §3.2)', () => {
+            expect(up).toMatch(/message_id\s+TEXT PRIMARY KEY/);
+        });
+
+        test('requires tenant_id, device_id, entity_id, direction, state, inbound_seen_at', () => {
+            for (const col of [
+                /tenant_id\s+TEXT NOT NULL/,
+                /device_id\s+VARCHAR\(64\) NOT NULL/,
+                /entity_id\s+INTEGER NOT NULL/,
+                /direction\s+TEXT NOT NULL/,
+                /state\s+TEXT NOT NULL/,
+                /inbound_seen_at\s+TIMESTAMPTZ NOT NULL/,
+            ]) {
+                expect(up).toMatch(col);
+            }
+        });
+
+        test('bot_acked_at / push_delivered_at / user_seen_at are NULLABLE (constraint #2 §11)', () => {
+            // None of these may be NOT NULL — they are NEVER derived during backfill
+            // (spec §5.1), and a NOT NULL would force inflation of user_seen success.
+            expect(up).not.toMatch(/bot_acked_at\s+TIMESTAMPTZ NOT NULL/);
+            expect(up).not.toMatch(/push_delivered_at\s+TIMESTAMPTZ NOT NULL/);
+            expect(up).not.toMatch(/user_seen_at\s+TIMESTAMPTZ NOT NULL/);
+            // They must still be declared as TIMESTAMPTZ columns.
+            expect(up).toMatch(/bot_acked_at\s+TIMESTAMPTZ/);
+            expect(up).toMatch(/push_delivered_at\s+TIMESTAMPTZ/);
+            expect(up).toMatch(/user_seen_at\s+TIMESTAMPTZ/);
+        });
+
+        test('state CHECK restricts to the 4 spec §2 states', () => {
+            // The actual constraint clause; quoting matters because PG is permissive
+            // about CHECK position but we want to lock the 4-state enum domain.
+            for (const literal of [
+                "'inbound_seen'",
+                "'bot_acked'",
+                "'push_delivered'",
+                "'user_seen'",
+            ]) {
+                expect(up).toContain(literal);
+            }
+            expect(up).toMatch(/CHECK \(state IN \('inbound_seen', 'bot_acked', 'push_delivered', 'user_seen'\)\)/);
+        });
+
+        test('direction CHECK restricts to inbound|outbound (spec §3.2)', () => {
+            expect(up).toMatch(/CHECK \(direction IN \('inbound', 'outbound'\)\)/);
+        });
+
+        test('source CHECK includes the backfill provenance values (spec §5.4)', () => {
+            for (const literal of ["'live'", "'backfill+link'", "'backfill+heuristic'", "'inferred'"]) {
+                expect(up).toContain(literal);
+            }
+        });
+
+        test('skipped_states is a TEXT[] default empty (spec §2.3 rule 3)', () => {
+            expect(up).toMatch(/skipped_states\s+TEXT\[\]\s+NOT NULL\s+DEFAULT\s+'\{\}'/);
+        });
+
+        test('declares all three sweeper-hot-path indexes', () => {
+            expect(up).toMatch(/CREATE INDEX IF NOT EXISTS idx_ml_device_entity_state/);
+            expect(up).toMatch(/CREATE INDEX IF NOT EXISTS idx_ml_stuck_lookup/);
+            expect(up).toMatch(/CREATE INDEX IF NOT EXISTS idx_ml_reply_chain/);
+        });
+
+        test('stuck-lookup index is partial WHERE state <> user_seen (spec §6.3)', () => {
+            // The partial predicate is what makes the sweeper scan cheap — must not
+            // be dropped in future edits, so we lock it here.
+            expect(up).toMatch(/idx_ml_stuck_lookup[\s\S]+?WHERE state <> 'user_seen'/);
+        });
+
+        test('reply-chain index is partial WHERE reply_to_message_id IS NOT NULL', () => {
+            expect(up).toMatch(/idx_ml_reply_chain[\s\S]+?WHERE reply_to_message_id IS NOT NULL/);
+        });
+    });
+
+    describe('lifecycle_event_log table (spec §2.4 + §3.3)', () => {
+        test('creates lifecycle_event_log table', () => {
+            expect(up).toMatch(/CREATE TABLE IF NOT EXISTS lifecycle_event_log/);
+        });
+
+        test('id is BIGSERIAL PRIMARY KEY', () => {
+            expect(up).toMatch(/id\s+BIGSERIAL PRIMARY KEY/);
+        });
+
+        test('message_id is TEXT NOT NULL (matches message_lifecycle PK type)', () => {
+            // Spec §3.3 uses TEXT, not BIGINT FK to chat_messages — the actual
+            // chat_messages PK is UUID, and lifecycle_event_log stays decoupled
+            // so it can audit messages whose chat_messages row never landed.
+            expect(up).toMatch(/lifecycle_event_log[\s\S]+?message_id\s+TEXT NOT NULL/);
+        });
+
+        test('attempted_state CHECK matches the 4-state enum', () => {
+            expect(up).toMatch(/CHECK \(attempted_state IN \('inbound_seen', 'bot_acked', 'push_delivered', 'user_seen'\)\)/);
+        });
+
+        test('applied CHECK matches the 4 outcomes from spec §2.4', () => {
+            expect(up).toMatch(/CHECK \(applied IN \('accepted', 'idempotent_noop', 'rejected_late', 'rejected_unknown_message'\)\)/);
+        });
+
+        test('event_at + transition_at are both required (audit timeline integrity)', () => {
+            expect(up).toMatch(/event_at\s+TIMESTAMPTZ NOT NULL/);
+            expect(up).toMatch(/transition_at\s+TIMESTAMPTZ NOT NULL DEFAULT NOW\(\)/);
+        });
+
+        test('declares idx_lel_message for per-message timeline lookup', () => {
+            expect(up).toMatch(/CREATE INDEX IF NOT EXISTS idx_lel_message[\s\S]+?\(message_id, transition_at DESC\)/);
+        });
+
+        test('append-only: no UPDATE or DELETE statements in up.sql', () => {
+            // Structural enforcement of constraint #1 (§11): the migration itself
+            // never writes a path that mutates or removes audit rows.
+            expect(up).not.toMatch(/\bUPDATE\s+lifecycle_event_log/i);
+            expect(up).not.toMatch(/\bDELETE\s+FROM\s+lifecycle_event_log/i);
+        });
+    });
+
+    describe('rollback (down.sql)', () => {
+        test('drops both tables', () => {
+            expect(down).toMatch(/DROP TABLE IF EXISTS lifecycle_event_log/);
+            expect(down).toMatch(/DROP TABLE IF EXISTS message_lifecycle/);
+        });
+
+        test('drops every index created by up.sql', () => {
+            const upIndexes = [...up.matchAll(/CREATE INDEX IF NOT EXISTS (\w+)/g)].map((m) => m[1]);
+            expect(upIndexes.length).toBeGreaterThan(0);
+            for (const ix of upIndexes) {
+                expect(down).toContain(`DROP INDEX IF EXISTS ${ix}`);
+            }
+        });
+
+        test('uses IF EXISTS to be idempotent on a clean DB', () => {
+            // Counting: 2 tables + however many indexes are in up.sql.
+            const dropTables = (down.match(/DROP TABLE IF EXISTS/g) || []).length;
+            const dropIndexes = (down.match(/DROP INDEX IF EXISTS/g) || []).length;
+            expect(dropTables).toBe(2);
+            expect(dropIndexes).toBeGreaterThanOrEqual(3);
+        });
+    });
+
+    describe('spec §11 constraints encoded structurally', () => {
+        test('constraint #1: no rollback path in either file', () => {
+            // up.sql may reset state via app logic only — never via SQL that
+            // unconditionally lowers a state field.
+            expect(up).not.toMatch(/UPDATE\s+message_lifecycle\s+SET\s+state\s*=/i);
+        });
+
+        test('constraint #2: schema does not COALESCE user_seen_at into a default', () => {
+            // user_seen_at is bare NULLABLE — no DEFAULT, no COALESCE, no trigger
+            // path can synthesize a value. This is the structural side of
+            // "fallbacks are never folded into user_seen success."
+            const userSeenLine = up.match(/user_seen_at[^,\n]*/);
+            expect(userSeenLine).not.toBeNull();
+            expect(userSeenLine[0]).not.toMatch(/DEFAULT/i);
+            expect(userSeenLine[0]).not.toMatch(/COALESCE/i);
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Ships Step 1 of MessageLifecycle Phase 2 — DB layer only. Subsequent PRs land the Redis deadline wheel, dual-write, backfill resolver, debug endpoint, and divergence detector.

- **Card**: `card_1b1c13225f10e8a803cef532` (parent stays `in_progress` until all 6 steps ship)
- **Spec**: `docs/specs/message-lifecycle-spec.md` (Phase 1 merged in #3371)
- **Diff**: 3 new files, 325 insertions — `migrations/20260614_message_lifecycle.{up,down}.sql` + a Jest smoke test. No edits to existing code.

## Decision: Option A vs B → **Option B** (companion `message_lifecycle` table)

Per spec §3.4 trade-off matrix:

| Reason | Why B wins for Phase 2 |
|---|---|
| Migration risk | No `ALTER TABLE` on the hot `chat_messages` path — no lock concern on Railway PG |
| Backfill blast radius | Backfill = `INSERT` into a cold table, not `UPDATE` on a hot table |
| Outbound rows | Direction='outbound' rows are first-class instead of leaving 6 columns NULL on every `chat_messages` row |
| Existing code touchpoints | Every `chat_messages` SELECT/INSERT is unchanged; only new lifecycle code touches `message_lifecycle` |
| Rollback | `DROP TABLE` cleanup is identical cost to `DROP COLUMN`; B has no edge here |

Spec §3.4 itself recommends B unless `chat_messages` is already denormalized enough that A is a strict win — it isn't. Option A's only advantage (no JOIN for chat+state views) is a Phase 3 dashboard concern that we can resolve with a view.

> **Naming note**: spec text uses `chat_history` as the abstract noun; the actual table in this codebase is `chat_messages` (`backend/auth_schema.sql:72`) with a UUID PK. We key the lifecycle row by `message_id TEXT` per spec §3.2/§3.3 verbatim and intentionally skip a FK, keeping schema flexibility for messages whose chat row never landed.

## Schema changes

### `message_lifecycle` (spec §3.2)
- PK `message_id TEXT`, plus `tenant_id`, `device_id`, `entity_id`, `direction` ∈ {inbound, outbound}
- State column with CHECK enum: `inbound_seen` → `bot_acked` → `push_delivered` → `user_seen`
- Per-state timestamps; `bot_acked_at` / `push_delivered_at` / `user_seen_at` are **NULLABLE** (§11 #2)
- `skipped_states TEXT[]` for out-of-order events (§2.3 rule 3)
- `source` CHECK includes `live | backfill | backfill+link | backfill+heuristic | inferred` (§5.4)
- Three indexes match the sweeper hot paths (§4 / §6.3):
  - `idx_ml_device_entity_state` — dashboard per-entity panels
  - `idx_ml_stuck_lookup` — partial `WHERE state <> 'user_seen'`
  - `idx_ml_reply_chain` — partial `WHERE reply_to_message_id IS NOT NULL`

### `lifecycle_event_log` (spec §2.4 + §3.3)
- Append-only audit; one row per transition attempt
- `applied` CHECK: `accepted | idempotent_noop | rejected_late | rejected_unknown_message`
- Index `idx_lel_message (message_id, transition_at DESC)` for the per-message debug timeline

## §11 #6 sign-off constraints honored

| Constraint | Encoding |
|---|---|
| **#1: idempotent + monotonic, no rollback** | `lifecycle_event_log` is append-only; up.sql has no `UPDATE`/`DELETE` against it. Late events go here with `applied='rejected_late'` (enforced at app layer in Step 2's `lifecycle.transition()`). Smoke test locks this with two negative-match assertions. |
| **#2: unknown/null/timeout NEVER inflate user_seen** | `push_delivered_at` and `user_seen_at` are NULLABLE with no DEFAULT, no COALESCE, no trigger that could synthesize them. Backfill resolver (Step 4) will never set them per spec §5.1. SLO numerator in Step 6 must keep `user_seen_at IS NOT NULL`. Smoke test locks the NULLABLE invariant + the absence of DEFAULT/COALESCE on `user_seen_at`. |

## Test plan

- [x] `cd backend && npx jest tests/jest/message-lifecycle-migration.test.js` — **24 / 24 passing** (0.4s)
- [x] Migration up.sql parses cleanly (no syntax errors); all 3 indexes + 2 CHECK enums present
- [x] Migration down.sql drops every object up.sql creates (round-trip parity asserted)
- [x] No edits to existing files — pure addition, zero risk to in-flight code
- [ ] Live DB apply — happens via Railway deploy after merge; the existing migrations directory pattern (see `20260609_idempotency_keys.up.sql`) is loaded by app boot

## Out of scope (follow-up PRs)

- **Step 2**: Redis deadline wheel (`wheel.schedule / cancel / popDue / requeue` + sweeper loop, spec §4)
- **Step 3**: dual-write protocol — every site that increments `chat_no_reply` / `delivery_alert` also calls `lifecycle.transition(...)` (spec §7)
- **Step 4**: lazy-on-read backfill resolver (`backfill_lifecycle(message_id)`, spec §5)
- **Step 5**: `GET /api/debug/message-lifecycle/:messageId` endpoint (debug timeline)
- **Step 6**: Phase 3 cutover divergence detector (spec §6.5 / §9.10)
- The 10 Jest scenarios from spec §9 land with Step 3 once dual-write exists

Closes `card_1b1c13225f10e8a803cef532` Step 1 only; parent card stays `in_progress`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)