### PR TITLE
fix(portal-a11y): add accessible labels to visible form controls (GH#2967, card_ddd9)

### DIFF
--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -968,10 +968,10 @@
         <div class="plaza-toolbar">
             <div class="plaza-search">
                 <span class="search-icon">🔍</span>
-                <input type="text" id="searchInput" data-i18n="community_search_placeholder" placeholder="搜尋 Bot 名稱、描述、標籤..." maxlength="100" aria-label="Search">
-                <button class="search-clear" id="searchClear" onclick="clearSearch()" aria-label="Clear search">✕</button>
+                <input type="text" id="searchInput" data-i18n="community_search_placeholder" placeholder="搜尋 Bot 名稱、描述、標籤..." maxlength="100" data-i18n-aria-label="a11y_community_search_bots" aria-label="Search bots">
+                <button class="search-clear" id="searchClear" onclick="clearSearch()" data-i18n-aria-label="a11y_community_clear_search" aria-label="Clear search">✕</button>
             </div>
-            <select class="plaza-sort" id="sortSelect" onchange="handleSort()" aria-label="Sort bots">
+            <select class="plaza-sort" id="sortSelect" onchange="handleSort()" data-i18n-aria-label="a11y_community_sort_bots" aria-label="Sort bots">
                 <option value="popular" data-i18n="community_sort_popular">🔥 熱門</option>
                 <option value="newest" data-i18n="community_sort_newest">🆕 最新</option>
                 <option value="rating" data-i18n="community_sort_rating">⭐ 評分</option>
@@ -1008,8 +1008,8 @@
         <div class="rate-slider-row" id="rateSliderRow">
             <span class="rate-slider-label" data-i18n="mp_rate_range_label">Rate</span>
             <div class="rate-slider-track">
-                <input type="range" id="rateMin" min="1" max="50" value="1" step="1" oninput="onRateSliderChange()" aria-label="Minimum rate">
-                <input type="range" id="rateMax" min="1" max="50" value="50" step="1" oninput="onRateSliderChange()" aria-label="Maximum rate">
+                <input type="range" id="rateMin" min="1" max="50" value="1" step="1" oninput="onRateSliderChange()" data-i18n-aria-label="a11y_community_rate_min" aria-label="Minimum rate">
+                <input type="range" id="rateMax" min="1" max="50" value="50" step="1" oninput="onRateSliderChange()" data-i18n-aria-label="a11y_community_rate_max" aria-label="Maximum rate">
             </div>
             <span class="rate-slider-value" id="rateSliderValue">1 – 50 e&#24163;/1K</span>
         </div>
@@ -1417,7 +1417,7 @@
                 <div class="detail-comments">
                     <div class="detail-comments-title">💬 留言板 <span style="color:var(--text-muted);font-weight:400;">(${currentDetailMessages.length})</span></div>
                     <div class="comment-input-row">
-                        <input class="comment-input" id="commentInput" type="text" placeholder="留下你的評價..." maxlength="500" onkeydown="if(event.key==='Enter')sendComment()" aria-label="Comment">
+                        <input class="comment-input" id="commentInput" type="text" placeholder="留下你的評價..." maxlength="500" onkeydown="if(event.key==='Enter')sendComment()" data-i18n-aria-label="a11y_community_comment" aria-label="Comment">
                         <button class="comment-send" onclick="sendComment()">送出</button>
                     </div>
                     <div class="comment-list" id="commentList">${renderComments(currentDetailMessages)}</div>

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -751,7 +751,7 @@
                     <button class="kb-chip active" data-filter="all" data-i18n="kb_filter_all" onclick="filterCards('all')">All</button>
                     <button class="kb-chip" data-filter="mine" data-i18n="kb_filter_mine" onclick="filterCards('mine')">My Cards</button>
                 </div>
-                <select class="kb-sort-select" onchange="sortCards(this.value)" aria-label="Sort kanban cards">
+                <select class="kb-sort-select" onchange="sortCards(this.value)" data-i18n-aria-label="a11y_kanban_sort_cards" aria-label="Sort kanban cards">
                     <option value="updated_desc" data-i18n="kb_sort_recently_updated">Recently Updated</option>
                     <option value="updated_asc" data-i18n="kb_sort_oldest_updated">Oldest Updated</option>
                     <option value="default" data-i18n="kb_sort_default">Default Order</option>
@@ -770,7 +770,7 @@
         <!-- Funnel (collapsible) -->
         <div class="kb-funnel" id="kbFunnel" style="display:none; padding:8px 0 4px 0; gap:8px; flex-wrap:wrap;">
             <input type="text" id="funnelSearch" placeholder="Search…" data-i18n-placeholder="kb_funnel_search"
-                   oninput="onFunnelChange()" style="padding:6px 10px; border:1px solid #ccc; border-radius:6px; min-width:180px;" aria-label="Search cards">
+                   oninput="onFunnelChange()" style="padding:6px 10px; border:1px solid #ccc; border-radius:6px; min-width:180px;" data-i18n-aria-label="a11y_kanban_search_cards" aria-label="Search cards">
             <div class="kb-search-scope" id="kbSearchScope" style="display:flex; gap:4px; align-items:center;">
                 <span style="font-size:12px; color:#888;" data-i18n="kb_search_scope_label">Scope:</span>
                 <label class="kb-scope-chip active" data-scope="title">
@@ -786,7 +786,7 @@
                     <span data-i18n="kb_search_scope_subcards">Sub-cards</span>
                 </label>
             </div>
-            <select id="funnelStatus" onchange="onFunnelChange()" style="padding:6px 10px; border:1px solid #ccc; border-radius:6px;" aria-label="Filter by status">
+            <select id="funnelStatus" onchange="onFunnelChange()" style="padding:6px 10px; border:1px solid #ccc; border-radius:6px;" data-i18n-aria-label="a11y_kanban_filter_status" aria-label="Filter by status">
                 <option value="" data-i18n="kb_funnel_status_all">All statuses</option>
                 <option value="backlog" data-i18n="kb_col_backlog">Backlog</option>
                 <option value="todo" data-i18n="kb_col_todo">TODO</option>
@@ -794,18 +794,18 @@
                 <option value="review" data-i18n="kb_col_review">Review</option>
                 <option value="done" data-i18n="kb_col_done">Done</option>
             </select>
-            <select id="funnelPriority" onchange="onFunnelChange()" style="padding:6px 10px; border:1px solid #ccc; border-radius:6px;" aria-label="Filter by priority">
+            <select id="funnelPriority" onchange="onFunnelChange()" style="padding:6px 10px; border:1px solid #ccc; border-radius:6px;" data-i18n-aria-label="a11y_kanban_filter_priority" aria-label="Filter by priority">
                 <option value="" data-i18n="kb_funnel_priority_all">All priorities</option>
                 <option value="P0">P0</option>
                 <option value="P1">P1</option>
                 <option value="P2">P2</option>
                 <option value="P3">P3</option>
             </select>
-            <select id="funnelEntity" onchange="onFunnelChange()" style="padding:6px 10px; border:1px solid #ccc; border-radius:6px;" aria-label="Filter by entity">
+            <select id="funnelEntity" onchange="onFunnelChange()" style="padding:6px 10px; border:1px solid #ccc; border-radius:6px;" data-i18n-aria-label="a11y_kanban_filter_entity" aria-label="Filter by entity">
                 <option value="" data-i18n="kb_funnel_entity_all">All entities</option>
             </select>
             <input type="text" id="funnelTag" placeholder="Tag…" data-i18n-placeholder="kb_funnel_tag"
-                   oninput="onFunnelChange()" style="padding:6px 10px; border:1px solid #ccc; border-radius:6px; min-width:120px;" aria-label="Filter by tag">
+                   oninput="onFunnelChange()" style="padding:6px 10px; border:1px solid #ccc; border-radius:6px; min-width:120px;" data-i18n-aria-label="a11y_kanban_filter_tag" aria-label="Filter by tag">
             <label style="font-size:13px; color:#666;">
                 <span data-i18n="kb_funnel_since">Since</span>:
                 <input type="date" id="funnelSince" onchange="onFunnelChange()" style="padding:4px 6px; border:1px solid #ccc; border-radius:6px;">
@@ -844,7 +844,7 @@
                 <div class="kb-auto-filter" id="autoFilter">
                     <input type="search" class="kb-auto-filter-search" id="autoFilterSearch"
                         placeholder="Search title / description…" data-i18n-placeholder="kb_auto_filter_search_ph"
-                        autocomplete="off" aria-label="Search automations">
+                        autocomplete="off" data-i18n-aria-label="a11y_kanban_search_automations" aria-label="Search automations">
                     <div class="kb-auto-filter-group" id="autoFilterEntities">
                         <span class="kb-auto-filter-group-label" data-i18n="kb_auto_filter_entity">Entity</span>
                     </div>

--- a/backend/public/portal/screen-control.html
+++ b/backend/public/portal/screen-control.html
@@ -275,15 +275,15 @@
                         </select>
                     </div>
                     <div id="paramsGroup">
-                        <label data-i18n="screen_ctrl_label_node_id">Node ID (from tree above, e.g. n3)</label>
+                        <label for="paramNodeId" data-i18n="screen_ctrl_label_node_id">Node ID (from tree above, e.g. n3)</label>
                         <input type="text" id="paramNodeId" placeholder="n0">
                     </div>
                     <div id="textGroup" style="display:none;">
-                        <label data-i18n="screen_ctrl_label_text">Text to type</label>
+                        <label for="paramText" data-i18n="screen_ctrl_label_text">Text to type</label>
                         <input type="text" id="paramText" data-i18n-placeholder="screen_ctrl_placeholder_text" placeholder="Enter text...">
                     </div>
                     <div id="scrollDirGroup" style="display:none;">
-                        <label data-i18n="screen_ctrl_label_scroll_dir">Scroll direction</label>
+                        <label for="paramScrollDir" data-i18n="screen_ctrl_label_scroll_dir">Scroll direction</label>
                         <select id="paramScrollDir">
                             <option value="down" data-i18n="screen_ctrl_opt_down">down</option>
                             <option value="up" data-i18n="screen_ctrl_opt_up">up</option>

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -128,6 +128,20 @@ const TRANSLATIONS = {
 
     en: {
         "transition_loading": "Loading…",
+        "a11y_community_search_bots": "Search bots",
+        "a11y_community_clear_search": "Clear search",
+        "a11y_community_sort_bots": "Sort bots",
+        "a11y_community_rate_min": "Minimum rate",
+        "a11y_community_rate_max": "Maximum rate",
+        "a11y_community_comment": "Comment",
+        "a11y_kanban_sort_cards": "Sort kanban cards",
+        "a11y_kanban_search_cards": "Search cards",
+        "a11y_kanban_filter_status": "Filter by status",
+        "a11y_kanban_filter_priority": "Filter by priority",
+        "a11y_kanban_filter_entity": "Filter by entity",
+        "a11y_kanban_filter_tag": "Filter by tag",
+        "a11y_kanban_search_automations": "Search automations",
+
         "dashboard_usage_widget_title": "Claude Code / Codex usage",
         "dashboard_usage_widget_refresh": "Refresh",
         "dashboard_usage_widget_loading": "Loading usage data...",
@@ -650461,6 +650475,20 @@ const TRANSLATIONS = {
 
     zh: {
         "transition_loading": "載入中…",
+        "a11y_community_search_bots": "搜尋機器人",
+        "a11y_community_clear_search": "清除搜尋",
+        "a11y_community_sort_bots": "排序機器人",
+        "a11y_community_rate_min": "最低費率",
+        "a11y_community_rate_max": "最高費率",
+        "a11y_community_comment": "留言",
+        "a11y_kanban_sort_cards": "排序看板卡片",
+        "a11y_kanban_search_cards": "搜尋卡片",
+        "a11y_kanban_filter_status": "依狀態篩選",
+        "a11y_kanban_filter_priority": "依優先級篩選",
+        "a11y_kanban_filter_entity": "依實體篩選",
+        "a11y_kanban_filter_tag": "依標籤篩選",
+        "a11y_kanban_search_automations": "搜尋自動化",
+
         "dashboard_usage_widget_title": "Claude Code / Codex 用量",
         "dashboard_usage_widget_refresh": "重新整理",
         "dashboard_usage_widget_loading": "正在載入用量資料...",
@@ -7764294,6 +7764322,16 @@ class I18n {
 
 
 
+        // Translate aria-label attributes (does NOT set title — keeps tooltip-less labelling for inputs/selects)
+        document.querySelectorAll('[data-i18n-aria-label]').forEach(el => {
+            const key = el.getAttribute('data-i18n-aria-label');
+            if (key) {
+                const translated = this.t(key);
+                if (translated !== key) {
+                    el.setAttribute('aria-label', translated);
+                }
+            }
+        });
         // Update html lang attribute
 
 

--- a/backend/scripts/portal-smoke-check.js
+++ b/backend/scripts/portal-smoke-check.js
@@ -47,6 +47,9 @@ function resolveAsset(pageFile, rawUrl) {
     const url = cleanAssetUrl(rawUrl);
     if (!url || isExternal(url)) return null;
     if (url === '/socket.io/socket.io.js') return null;
+    // /shared-core/* is an Express static mount onto backend/shared/ (index.js
+    // line ~881). Translate so the smoke check finds the source file.
+    if (url.startsWith('/shared-core/')) return path.join(ROOT, 'shared', url.slice('/shared-core/'.length));
     if (url.startsWith('/')) return path.join(PUBLIC, url);
     return path.join(path.dirname(path.join(PUBLIC, pageFile)), url);
 }

--- a/backend/tests/jest/portal-static-ids.test.js
+++ b/backend/tests/jest/portal-static-ids.test.js
@@ -48,18 +48,21 @@ describe('portal static HTML IDs', () => {
   test('visible portal controls expose accessible names', () => {
     const communityPath = path.join(__dirname, '../../public/portal/community.html');
     const community = fs.readFileSync(communityPath, 'utf8');
-    expect(community).toContain('id="sortSelect" onchange="handleSort()" aria-label="Sort bots"');
-    expect(community).toContain('id="rateMin" min="1" max="50" value="1" step="1" oninput="onRateSliderChange()" aria-label="Minimum rate"');
-    expect(community).toContain('id="rateMax" min="1" max="50" value="50" step="1" oninput="onRateSliderChange()" aria-label="Maximum rate"');
-    expect(community).toContain('id="searchClear" onclick="clearSearch()" aria-label="Clear search"');
+    expect(community).toContain('id="sortSelect" onchange="handleSort()" data-i18n-aria-label="a11y_community_sort_bots" aria-label="Sort bots"');
+    expect(community).toContain('id="rateMin" min="1" max="50" value="1" step="1" oninput="onRateSliderChange()" data-i18n-aria-label="a11y_community_rate_min" aria-label="Minimum rate"');
+    expect(community).toContain('id="rateMax" min="1" max="50" value="50" step="1" oninput="onRateSliderChange()" data-i18n-aria-label="a11y_community_rate_max" aria-label="Maximum rate"');
+    expect(community).toContain('id="searchClear" onclick="clearSearch()" data-i18n-aria-label="a11y_community_clear_search" aria-label="Clear search"');
 
     const kanbanPath = path.join(__dirname, '../../public/portal/kanban.html');
     const kanban = fs.readFileSync(kanbanPath, 'utf8');
-    expect(kanban).toContain('class="kb-sort-select" onchange="sortCards(this.value)" aria-label="Sort kanban cards"');
+    expect(kanban).toContain('class="kb-sort-select" onchange="sortCards(this.value)" data-i18n-aria-label="a11y_kanban_sort_cards" aria-label="Sort kanban cards"');
 
     const screenControlPath = path.join(__dirname, '../../public/portal/screen-control.html');
     const screenControl = fs.readFileSync(screenControlPath, 'utf8');
     expect(screenControl).toContain('<label for="commandType" data-i18n="screen_ctrl_label_command">Command</label>');
+    expect(screenControl).toContain('<label for="paramNodeId" data-i18n="screen_ctrl_label_node_id">');
+    expect(screenControl).toContain('<label for="paramText" data-i18n="screen_ctrl_label_text">');
+    expect(screenControl).toContain('<label for="paramScrollDir" data-i18n="screen_ctrl_label_scroll_dir">');
 
     const settingsPath = path.join(__dirname, '../../public/portal/settings.html');
     const settings = fs.readFileSync(settingsPath, 'utf8');


### PR DESCRIPTION
## Summary

QA/UIUX audit (2026-05-26) found visible portal controls without programmatic labels. Fix the audit-mentioned controls and i18n-key the user-facing aria-label strings.

Closes #2967
Closes card_ddd9abd876bdf6c2c76e4f12

## Affected

| File | Control | Fix |
|---|---|---|
| `community.html` | `#searchInput` | `data-i18n-aria-label="a11y_community_search_bots"` |
| `community.html` | `#searchClear` | `data-i18n-aria-label="a11y_community_clear_search"` |
| `community.html` | `#sortSelect` (Bot Plaza sort) | `data-i18n-aria-label="a11y_community_sort_bots"` |
| `community.html` | `#rateMin` (rate slider) | `data-i18n-aria-label="a11y_community_rate_min"` |
| `community.html` | `#rateMax` (rate slider) | `data-i18n-aria-label="a11y_community_rate_max"` |
| `community.html` | `#commentInput` | `data-i18n-aria-label="a11y_community_comment"` |
| `kanban.html` | board sort `<select>` | `data-i18n-aria-label="a11y_kanban_sort_cards"` |
| `kanban.html` | `#funnelSearch` | `data-i18n-aria-label="a11y_kanban_search_cards"` |
| `kanban.html` | `#funnelStatus` | `data-i18n-aria-label="a11y_kanban_filter_status"` |
| `kanban.html` | `#funnelPriority` | `data-i18n-aria-label="a11y_kanban_filter_priority"` |
| `kanban.html` | `#funnelEntity` | `data-i18n-aria-label="a11y_kanban_filter_entity"` |
| `kanban.html` | `#funnelTag` | `data-i18n-aria-label="a11y_kanban_filter_tag"` |
| `kanban.html` | `#autoFilterSearch` | `data-i18n-aria-label="a11y_kanban_search_automations"` |
| `screen-control.html` | `<label>` for `#paramNodeId` | add `for="paramNodeId"` |
| `screen-control.html` | `<label>` for `#paramText` | add `for="paramText"` |
| `screen-control.html` | `<label>` for `#paramScrollDir` | add `for="paramScrollDir"` |
| `shared/i18n.js` | apply loop | add `data-i18n-aria-label` handler (sets aria-label only, no title) |

## i18n

13 new keys × 2 locales (EN + ZH). Other locales fall back to EN per `[[feedback_i18n_inline_vs_dict]]`.

Keys: `a11y_community_search_bots`, `a11y_community_clear_search`, `a11y_community_sort_bots`, `a11y_community_rate_min`, `a11y_community_rate_max`, `a11y_community_comment`, `a11y_kanban_sort_cards`, `a11y_kanban_search_cards`, `a11y_kanban_filter_status`, `a11y_kanban_filter_priority`, `a11y_kanban_filter_entity`, `a11y_kanban_filter_tag`, `a11y_kanban_search_automations`.

The hardcoded `aria-label="..."` attributes are kept as fallbacks; the i18n.js handler overwrites them once translations apply (mirrors the existing `data-i18n-title` pattern).

**Note on settings.html roster-action selects**: already i18n-keyed via `rosterT('settings_roster_col_action','Action')` since the audit-baseline fix — no change needed.

**Note on schedule.html**: file is a redirect stub to `kanban.html` — no controls present.

## Test plan

- [x] `node backend/scripts/i18n-check.js` — all referenced keys resolve in EN (0 missing)
- [x] `cd backend && npx jest tests/jest/i18n-syntax` — 12/12 passes
- [ ] Post-deploy: open `/portal/community.html`, `/portal/kanban.html`, `/portal/screen-control.html` at 390x844 + 1280x800; DevTools Accessibility tab confirms every touched control has populated `name`
- [ ] Screenshots uploaded to card_ddd9abd876bdf6c2c76e4f12 via `/file`

## Globe-user

All aria-label values are i18n-keyed via `data-i18n-aria-label` (per `[[feedback_platform_user_rule_compliance]]`). Non-English users now hear localized control names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)