### PR TITLE
feat(infra): hourly auto-process cron + terminal GC for kanban sub-cards (card_2a7b)

### DIFF
--- a/backend/scripts/hourly-auto-process-cards.sh
+++ b/backend/scripts/hourly-auto-process-cards.sh
@@ -1,0 +1,139 @@
+#!/bin/bash
+#
+# hourly-auto-process-cards.sh
+#
+# Hourly cron that auto-claims stale TODO kanban sub-cards for entity #2
+# (the commander). For each eligible card, spawn a `bridge-auth U##` terminal
+# via ~/.claude/bin/unit.py and dispatch the card's work-package so the
+# sub-card moves itself to in_progress and works on its own.
+#
+# Card filter: status=todo AND assignedBots∋ENTITY_ID AND age > 1h
+# Dispatch limit: MAX_CARDS (default 2)
+# Mode: DRY_RUN=1 prints the plan without spawning
+#
+# Env:
+#   DEVICE_ID            Owner device (default 480def4c-2183-4d8e-afd0-b131ae89adcc)
+#   BOT_SECRET           Owner bot secret (read from backend/.env if unset)
+#   ENTITY_ID            Commander entity id (default 2)
+#   ENDPOINT             API base (default https://eclawbot.com)
+#   MAX_CARDS            Max cards to dispatch per run (default 2)
+#   MIN_AGE_SECONDS      Minimum card age (default 3600 = 1h)
+#   DRY_RUN              1 = log only, no spawn (default 0)
+#   LOG_FILE             Log path (default /tmp/hourly-auto-process.log)
+#
+# Exit:
+#   0  success (may have dispatched 0 cards)
+#   1  configuration error (missing creds)
+#   2  API error (cards fetch failed)
+
+set -euo pipefail
+
+# ── Config ───────────────────────────────────────────────────────────────
+DEVICE_ID="${DEVICE_ID:-480def4c-2183-4d8e-afd0-b131ae89adcc}"
+ENTITY_ID="${ENTITY_ID:-2}"
+ENDPOINT="${ENDPOINT:-https://eclawbot.com}"
+MAX_CARDS="${MAX_CARDS:-2}"
+MIN_AGE_SECONDS="${MIN_AGE_SECONDS:-3600}"
+DRY_RUN="${DRY_RUN:-0}"
+LOG_FILE="${LOG_FILE:-/tmp/hourly-auto-process.log}"
+UNIT_PY="${UNIT_PY:-$HOME/.claude/bin/unit.py}"
+
+# Fall back to backend/.env for BOT_SECRET when not provided
+if [ -z "${BOT_SECRET:-}" ]; then
+  ENV_FILE="$(cd "$(dirname "$0")/.." && pwd)/.env"
+  if [ -f "$ENV_FILE" ]; then
+    BOT_SECRET="$(grep -E '^(BROADCAST_TEST_DEVICE_SECRET|BOT_SECRET)=' "$ENV_FILE" | head -1 | cut -d= -f2- | tr -d '"' || true)"
+  fi
+fi
+
+log() {
+  printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" | tee -a "$LOG_FILE" >&2
+}
+
+if [ -z "${BOT_SECRET:-}" ]; then
+  log "ERROR: BOT_SECRET unset and not found in backend/.env"
+  exit 1
+fi
+
+log "── hourly-auto-process start (DRY_RUN=$DRY_RUN MAX=$MAX_CARDS MIN_AGE=${MIN_AGE_SECONDS}s)"
+
+# ── Fetch + filter cards ────────────────────────────────────────────────
+URL="${ENDPOINT}/api/mission/cards?deviceId=${DEVICE_ID}&botSecret=${BOT_SECRET}&entityId=${ENTITY_ID}&status=todo&limit=100"
+CARDS_JSON="$(curl -sS --max-time 30 "$URL")" || {
+  log "ERROR: cards fetch failed"
+  exit 2
+}
+
+# Pick top-N eligible cards: assignedBots∋ENTITY_ID and age > MIN_AGE_SECONDS.
+# Output: id<TAB>title (newline-separated)
+ELIGIBLE="$(printf '%s' "$CARDS_JSON" | python3 -c '
+import json, sys, time
+data = json.load(sys.stdin)
+entity_id  = int(sys.argv[1])
+min_age_ms = int(sys.argv[2]) * 1000
+max_cards  = int(sys.argv[3])
+now_ms = int(time.time() * 1000)
+cards = data.get("cards", []) or []
+out = []
+for c in cards:
+    if c.get("status") != "todo":
+        continue
+    if entity_id not in (c.get("assignedBots") or []):
+        continue
+    age = now_ms - int(c.get("statusChangedAt") or c.get("createdAt") or 0)
+    if age < min_age_ms:
+        continue
+    out.append((age, c["id"], (c.get("title") or "").replace("\t"," ").replace("\n"," ")))
+out.sort(key=lambda r: -r[0])
+for _, cid, title in out[:max_cards]:
+    print(f"{cid}\t{title}")
+' "$ENTITY_ID" "$MIN_AGE_SECONDS" "$MAX_CARDS")"
+
+COUNT="$(printf '%s\n' "$ELIGIBLE" | grep -c . || true)"
+log "eligible cards: $COUNT"
+
+if [ "$COUNT" -eq 0 ]; then
+  log "nothing to dispatch"
+  exit 0
+fi
+
+# ── Dispatch each eligible card ──────────────────────────────────────────
+DISPATCHED=0
+while IFS=$'\t' read -r CID TITLE; do
+  [ -z "$CID" ] && continue
+  log "→ card=$CID  title=${TITLE:0:80}"
+
+  if [ "$DRY_RUN" = "1" ]; then
+    log "  [DRY_RUN] would spawn bridge-auth + dispatch $CID"
+    DISPATCHED=$((DISPATCHED + 1))
+    continue
+  fi
+
+  if [ ! -x "$UNIT_PY" ]; then
+    log "  ERROR: unit.py not executable at $UNIT_PY — skipping spawn"
+    continue
+  fi
+
+  # Spawn a fresh worker window (bridge-auth handshake).
+  SHORT="${CID#card_}"
+  SHORT="${SHORT:0:8}"
+  ROLE="auto-$SHORT"
+  SPAWN_OUT="$("$UNIT_PY" spawn "$ROLE" 2>&1 || true)"
+  UID_TAG="$(printf '%s' "$SPAWN_OUT" | awk 'NR==1 {print $1}')"
+  if [ -z "$UID_TAG" ] || ! printf '%s' "$UID_TAG" | grep -qE '^U[0-9]+$'; then
+    log "  ERROR: spawn failed: $SPAWN_OUT"
+    continue
+  fi
+
+  # Dispatch the bridge-auth command; the worker reads the card itself.
+  DISPATCH_CMD="bridge-auth $UID_TAG $CID"
+  "$UNIT_PY" dispatch "$UID_TAG" "$DISPATCH_CMD" >/dev/null 2>&1 || {
+    log "  ERROR: dispatch failed for $UID_TAG → $CID"
+    continue
+  }
+  log "  spawned $UID_TAG ← $DISPATCH_CMD"
+  DISPATCHED=$((DISPATCHED + 1))
+done <<< "$ELIGIBLE"
+
+log "── done. dispatched=$DISPATCHED"
+exit 0

--- a/backend/scripts/terminal-gc.sh
+++ b/backend/scripts/terminal-gc.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+#
+# terminal-gc.sh
+#
+# Hourly memory janitor. When free memory is low, walk the U## bridge
+# registry in ~/.claude/bin/units.json and close terminals whose bound
+# kanban card is already `done` (or whose window has gone dead).
+#
+# Algorithm:
+#   1. Read vm_stat → free MB
+#   2. If free MB >= FREE_MB_THRESHOLD AND not FORCE=1, exit (no work)
+#   3. List registered units via unit.py list
+#   4. For each U## whose role looks like "auto-<8hex>":
+#      - resolve card_<full> from the EClaw API (status check)
+#      - if card.status in (done, archived) OR window is dead → kill U##
+#   5. Log summary to LOG_FILE
+#
+# Env:
+#   FREE_MB_THRESHOLD  Aggressive-close threshold in MB (default 200)
+#   DEVICE_ID          Owner device (default 480def4c-...)
+#   BOT_SECRET         Owner bot secret (read from backend/.env if unset)
+#   ENTITY_ID          Commander entity id (default 2)
+#   ENDPOINT           API base (default https://eclawbot.com)
+#   DRY_RUN            1 = log only, no kill (default 0)
+#   FORCE              1 = ignore memory threshold and scan anyway
+#   LOG_FILE           Log path (default /tmp/terminal-gc.log)
+#
+# Exit:
+#   0  success (may have closed 0 terminals)
+#   1  configuration error
+
+set -euo pipefail
+
+FREE_MB_THRESHOLD="${FREE_MB_THRESHOLD:-200}"
+DEVICE_ID="${DEVICE_ID:-480def4c-2183-4d8e-afd0-b131ae89adcc}"
+ENTITY_ID="${ENTITY_ID:-2}"
+ENDPOINT="${ENDPOINT:-https://eclawbot.com}"
+DRY_RUN="${DRY_RUN:-0}"
+FORCE="${FORCE:-0}"
+LOG_FILE="${LOG_FILE:-/tmp/terminal-gc.log}"
+UNIT_PY="${UNIT_PY:-$HOME/.claude/bin/unit.py}"
+
+if [ -z "${BOT_SECRET:-}" ]; then
+  ENV_FILE="$(cd "$(dirname "$0")/.." && pwd)/.env"
+  if [ -f "$ENV_FILE" ]; then
+    BOT_SECRET="$(grep -E '^(BROADCAST_TEST_DEVICE_SECRET|BOT_SECRET)=' "$ENV_FILE" | head -1 | cut -d= -f2- | tr -d '"' || true)"
+  fi
+fi
+
+log() {
+  printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*" | tee -a "$LOG_FILE" >&2
+}
+
+# ── free-memory probe ────────────────────────────────────────────────────
+FREE_MB="$(vm_stat | awk '
+  /page size of/  {gsub(/[^0-9]/, "", $0); ps=$0+0}
+  /Pages free/    {gsub(/[^0-9]/, "", $3); pf=$3+0}
+  END {if (ps==0) ps=16384; printf "%d", (pf*ps)/1048576}
+')"
+log "── terminal-gc start (free=${FREE_MB}MB threshold=${FREE_MB_THRESHOLD}MB DRY_RUN=$DRY_RUN FORCE=$FORCE)"
+
+if [ "$FORCE" != "1" ] && [ "$FREE_MB" -ge "$FREE_MB_THRESHOLD" ]; then
+  log "memory ok — skipping aggressive sweep"
+  exit 0
+fi
+
+if [ ! -x "$UNIT_PY" ]; then
+  log "ERROR: unit.py not executable at $UNIT_PY"
+  exit 1
+fi
+
+# ── enumerate units ──────────────────────────────────────────────────────
+# unit.py list format:
+#   ID    winId  alive  status    role
+#   U07     1234  yes    done      auto-2a7b0d69
+UNIT_LIST="$("$UNIT_PY" list 2>/dev/null || true)"
+if [ -z "$UNIT_LIST" ] || ! printf '%s' "$UNIT_LIST" | grep -qE '^U[0-9]+'; then
+  log "no units registered"
+  exit 0
+fi
+
+# Each row: U##<SP>winId<SP>alive<SP>status<SP>role
+ROWS="$(printf '%s\n' "$UNIT_LIST" | awk '/^U[0-9]+/ {print $1"\t"$3"\t"$5}')"
+CLOSED=0
+SCANNED=0
+
+while IFS=$'\t' read -r UID_TAG ALIVE ROLE; do
+  [ -z "$UID_TAG" ] && continue
+  SCANNED=$((SCANNED + 1))
+
+  # Dead window → prune the registry entry.
+  if [ "$ALIVE" != "yes" ]; then
+    log "→ $UID_TAG  window dead — pruning"
+    if [ "$DRY_RUN" != "1" ]; then
+      "$UNIT_PY" kill "$UID_TAG" >/dev/null 2>&1 || true
+      CLOSED=$((CLOSED + 1))
+    fi
+    continue
+  fi
+
+  # Only manage auto-spawned bridges (role prefix "auto-").
+  if ! printf '%s' "$ROLE" | grep -qE '^auto-[0-9a-f]+'; then
+    log "→ $UID_TAG  role=$ROLE — not auto-managed, skipping"
+    continue
+  fi
+
+  PREFIX="${ROLE#auto-}"
+  if [ -z "${BOT_SECRET:-}" ]; then
+    log "→ $UID_TAG  BOT_SECRET unset — cannot check card status, skipping"
+    continue
+  fi
+
+  # Look up the card whose id starts with card_<PREFIX>. The shell uses
+  # role=auto-<first-8-hex>, so we list all cards (any status) and match.
+  CARDS_URL="${ENDPOINT}/api/mission/cards?deviceId=${DEVICE_ID}&botSecret=${BOT_SECRET}&entityId=${ENTITY_ID}&includeArchived=true&limit=200"
+  CARD_STATUS="$(curl -sS --max-time 20 "$CARDS_URL" \
+    | python3 -c "
+import json, sys
+prefix='card_$PREFIX'
+data=json.load(sys.stdin)
+for c in (data.get('cards') or []):
+    if (c.get('id') or '').startswith(prefix):
+        print(c.get('status') or '')
+        sys.exit()
+print('')
+" 2>/dev/null || echo "")"
+
+  log "→ $UID_TAG  role=$ROLE  card_status=${CARD_STATUS:-unknown}"
+
+  case "$CARD_STATUS" in
+    done|archived|"")
+      if [ "$DRY_RUN" = "1" ]; then
+        log "  [DRY_RUN] would close $UID_TAG"
+      else
+        "$UNIT_PY" kill "$UID_TAG" >/dev/null 2>&1 \
+          && log "  closed $UID_TAG" \
+          || log "  ERROR closing $UID_TAG"
+        CLOSED=$((CLOSED + 1))
+      fi
+      ;;
+    *)
+      log "  keep — card still active"
+      ;;
+  esac
+done <<< "$ROWS"
+
+# Final free-memory probe for the log line.
+FREE_MB_AFTER="$(vm_stat | awk '
+  /page size of/  {gsub(/[^0-9]/, "", $0); ps=$0+0}
+  /Pages free/    {gsub(/[^0-9]/, "", $3); pf=$3+0}
+  END {if (ps==0) ps=16384; printf "%d", (pf*ps)/1048576}
+')"
+log "── done. scanned=$SCANNED closed=$CLOSED free_before=${FREE_MB}MB free_after=${FREE_MB_AFTER}MB"
+exit 0

--- a/docs/infra/hourly-cron.md
+++ b/docs/infra/hourly-cron.md
@@ -1,0 +1,104 @@
+# Hourly Auto-Process Cron + Terminal GC
+
+> **Scope** Single Mac (Hank's workstation). Macros use `osascript` + `launchd`, so this is **not portable** to Linux/Railway. The card-filter API call itself (`GET /api/mission/cards`) is standard EClaw and portable; only the bridge-spawn mechanism is Mac-specific.
+
+## What it does
+
+Every hour at minute 0 the LaunchAgent runs two shell scripts back-to-back:
+
+1. **`backend/scripts/hourly-auto-process-cards.sh`** — fetches `GET /api/mission/cards?status=todo`, filters cards assigned to entity #2 (commander) that have been stuck in `todo` for more than 1 hour, then spawns up to `MAX_CARDS` (default 2) bridge-auth terminals via `~/.claude/bin/unit.py spawn` + `dispatch`. Each spawned terminal claims the card and works it.
+2. **`backend/scripts/terminal-gc.sh`** — reads `vm_stat`. If free memory is below `FREE_MB_THRESHOLD` MB (default 200), walks `~/.claude/bin/units.json`, looks up each `auto-<prefix>` unit's card status, and closes terminals whose card is already `done`/`archived` (or whose window is dead).
+
+Both scripts log to `/tmp/`. Both honor `DRY_RUN=1`.
+
+## Files
+
+| Path | Purpose |
+|------|---------|
+| `backend/scripts/hourly-auto-process-cards.sh` | Card scanner + bridge spawner |
+| `backend/scripts/terminal-gc.sh` | Memory janitor for `U##` worker windows |
+| `infra/launchd/com.eclaw.hourly-auto-process.plist` | LaunchAgent template |
+| `docs/infra/hourly-cron.md` | This guide |
+
+## Enable on a fresh Mac
+
+```bash
+# 1. Copy the template
+cp infra/launchd/com.eclaw.hourly-auto-process.plist ~/Library/LaunchAgents/
+
+# 2. Edit the four REPLACE_ME values
+#    - REPLACE_ME_REPO_PATH    → /Users/<you>/Desktop/Project/EClaw  (no trailing slash)
+#    - REPLACE_ME_DEVICE_ID    → your owner deviceId (UUID)
+#    - REPLACE_ME_BOT_SECRET   → the matching botSecret for entity #2
+#    (ENTITY_ID defaults to 2; change only if your commander is a different slot)
+vim ~/Library/LaunchAgents/com.eclaw.hourly-auto-process.plist
+
+# 3. Load it
+launchctl load ~/Library/LaunchAgents/com.eclaw.hourly-auto-process.plist
+
+# 4. Verify
+launchctl list | grep eclaw
+#   →  -    0    com.eclaw.hourly-auto-process
+```
+
+The first fire happens at the next top-of-hour. Force a one-shot run with:
+
+```bash
+launchctl start com.eclaw.hourly-auto-process
+```
+
+## Disable / pause
+
+```bash
+# Stop the schedule (keeps the plist)
+launchctl unload ~/Library/LaunchAgents/com.eclaw.hourly-auto-process.plist
+
+# Permanently remove
+rm ~/Library/LaunchAgents/com.eclaw.hourly-auto-process.plist
+```
+
+## Check last-run log
+
+```bash
+tail -50 /tmp/hourly-auto-process.log
+tail -50 /tmp/terminal-gc.log
+
+# launchd stdout/stderr (rarely needed)
+tail -50 /tmp/eclaw-hourly.launchd.out.log
+tail -50 /tmp/eclaw-hourly.launchd.err.log
+```
+
+A healthy fire ends with `── done. dispatched=<N>` and `── done. scanned=<N> closed=<M> ...`.
+
+## Manual smoke test
+
+```bash
+# Dry-run (no terminals spawned, no kills)
+DRY_RUN=1 BOT_SECRET=… backend/scripts/hourly-auto-process-cards.sh
+DRY_RUN=1 FORCE=1 BOT_SECRET=… backend/scripts/terminal-gc.sh
+```
+
+`DRY_RUN=1` prints the plan to `/tmp/hourly-auto-process.log` and `/tmp/terminal-gc.log` without touching Terminal.app. `FORCE=1` on the GC bypasses the free-memory threshold so the scan still runs.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| `launchctl list \| grep eclaw` shows nothing | Plist not loaded, or filename mismatch | `launchctl load …` again; check `~/Library/LaunchAgents/com.eclaw.hourly-auto-process.plist` exists |
+| Logs say `ERROR: BOT_SECRET unset` | `BOT_SECRET` env var not baked into the plist | Edit the `<key>BOT_SECRET</key>` value in the plist, then `launchctl unload && load` |
+| Logs say `ERROR: cards fetch failed` | API endpoint unreachable or wrong `DEVICE_ID` | `curl` the URL by hand; check Railway is up; verify deviceId+botSecret pair via `/api/auth/me` |
+| Logs say `ERROR: unit.py not executable` | `~/.claude/bin/unit.py` missing | Re-clone the Claude harness, or `chmod +x ~/.claude/bin/unit.py` |
+| `dispatched=0` every hour, but cards are stuck | Cards younger than `MIN_AGE_SECONDS` (default 3600), or not assigned to entity #2 | Lower `MIN_AGE_SECONDS` in the plist; double-check the assigned entity on the card |
+| GC closes nothing even with low memory | Cards still `todo`/`in_progress`, or role name isn't `auto-<hex>` | Only `auto-`-spawned units are managed. Manual `unit.py spawn` terminals are left alone by design |
+| Plist runs but no terminals appear | `osascript` lacks Automation permission for the launchd process | macOS → System Settings → Privacy & Security → Automation → allow the shell helper to control Terminal |
+| Terminals stack up overnight | `MAX_CARDS` too high, or GC `FREE_MB_THRESHOLD` too low | Tune the two env vars in the plist and `launchctl unload && load` |
+
+## Globe-user generalization
+
+The `GET /api/mission/cards` filter is portable EClaw API — any client (Linux cron + Python, Windows Task Scheduler + PowerShell, Railway worker) can fetch the same eligible-card list. What is **not** portable:
+
+- `osascript` Terminal.app driver → would need a tmux/screen replacement (`tmux new-window`, `tmux send-keys`)
+- `~/.claude/bin/unit.py` registry → would need a session-id store for the chosen multiplexer
+- `launchd` schedule → swap for `cron`, `systemd-timer`, or a managed scheduler
+
+The two shell scripts in `backend/scripts/` are written so the API-call path is independent of the spawn path; a port can replace the spawn block (`"$UNIT_PY" spawn` / `dispatch`) without rewriting the filter loop.

--- a/infra/launchd/com.eclaw.hourly-auto-process.plist
+++ b/infra/launchd/com.eclaw.hourly-auto-process.plist
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.eclaw.hourly-auto-process.plist
+
+  Hourly LaunchAgent that:
+    1. Dispatches stale TODO sub-cards (backend/scripts/hourly-auto-process-cards.sh)
+    2. Closes idle worker terminals when memory is tight (backend/scripts/terminal-gc.sh)
+
+  Install:
+    cp infra/launchd/com.eclaw.hourly-auto-process.plist ~/Library/LaunchAgents/
+    launchctl load ~/Library/LaunchAgents/com.eclaw.hourly-auto-process.plist
+
+  Edit the four <string>REPLACE_ME_*</string> values below before loading.
+  See docs/infra/hourly-cron.md for the full guide.
+-->
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.eclaw.hourly-auto-process</string>
+
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/zsh</string>
+    <string>-lc</string>
+    <string>REPO=REPLACE_ME_REPO_PATH; "$REPO/backend/scripts/hourly-auto-process-cards.sh" &amp;&amp; "$REPO/backend/scripts/terminal-gc.sh"</string>
+  </array>
+
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Minute</key>
+    <integer>0</integer>
+  </dict>
+
+  <key>RunAtLoad</key>
+  <false/>
+
+  <key>StandardOutPath</key>
+  <string>/tmp/eclaw-hourly.launchd.out.log</string>
+  <key>StandardErrorPath</key>
+  <string>/tmp/eclaw-hourly.launchd.err.log</string>
+
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+    <key>DEVICE_ID</key>
+    <string>REPLACE_ME_DEVICE_ID</string>
+    <key>BOT_SECRET</key>
+    <string>REPLACE_ME_BOT_SECRET</string>
+    <key>ENTITY_ID</key>
+    <string>2</string>
+    <key>ENDPOINT</key>
+    <string>https://eclawbot.com</string>
+    <key>MAX_CARDS</key>
+    <string>2</string>
+    <key>FREE_MB_THRESHOLD</key>
+    <string>200</string>
+  </dict>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- `backend/scripts/hourly-auto-process-cards.sh` — hourly GET `/api/mission/cards` filter for stale TODO sub-cards assigned to entity #2, spawns up to `MAX_CARDS` bridge-auth workers via `~/.claude/bin/unit.py`.
- `backend/scripts/terminal-gc.sh` — reads `vm_stat`, walks `units.json`, closes `auto-*` U## windows whose bound card is `done`/`archived` once free memory drops below `FREE_MB_THRESHOLD` (default 200MB).
- `infra/launchd/com.eclaw.hourly-auto-process.plist` — `StartCalendarInterval Minute=0` LaunchAgent that runs both scripts back-to-back.
- `docs/infra/hourly-cron.md` — enable, disable, log paths, smoke-test, troubleshooting matrix, globe-user portability note.

Card: `card_2a7b0d6955ee781a823c5087`

## Test plan
- [x] `bash -n` syntax check both scripts → OK
- [x] `DRY_RUN=1 BOT_SECRET=… backend/scripts/hourly-auto-process-cards.sh` → eligible cards: 2, dispatched=2
- [x] `DRY_RUN=1 FORCE=1 BOT_SECRET=… backend/scripts/terminal-gc.sh` → clean exit, no units registered
- [ ] After merge: copy plist to `~/Library/LaunchAgents/`, fill DEVICE_ID/BOT_SECRET/REPO, `launchctl load`

## Self-review
- **Security**: plist ships with REPLACE_ME placeholders; `BOT_SECRET` is gitignored.
- **i18n**: N/A (backend infra, no UI strings).
- **Debug**: scripts log to `/tmp/hourly-auto-process.log` and `/tmp/terminal-gc.log`.
- **Out-of-scope**: actual `launchctl load` is a one-time-per-Mac manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)