### PR TITLE
feat(message-lifecycle): Phase 2 Step 2 — Redis deadline wheel + sweeper + cold-start scan (card_545c)

### DIFF
--- a/backend/lib/message-lifecycle/cold-start.js
+++ b/backend/lib/message-lifecycle/cold-start.js
@@ -1,0 +1,169 @@
+/**
+ * MessageLifecycle cold-start scan (spec §4.4 + §9.9).
+ *
+ * Card: card_545ce5986b9c1332315ba303 (Phase 2 Step 2 — cold-start).
+ * Spec: docs/specs/message-lifecycle-spec.md §4.4 Redis-lost failure mode,
+ *       §9.9 acceptance scenario.
+ *
+ * On boot (or whenever Redis is detected empty), scan message_lifecycle for
+ * every row whose state is NOT 'user_seen' and whose pivot timestamp is
+ * within timeout reach, then ZADD each one back into the deadline wheel.
+ *
+ * Pagination: the scan is keyset-paginated by (inbound_seen_at, message_id)
+ * with LIMIT pageSize per query. This is required for the globe-user
+ * generalization called out in card_545c: very large devices may accumulate
+ * >10k stale lifecycle rows, and a single unbounded scan would block the
+ * event loop and the PG pool.
+ *
+ * Per spec §4 preamble: Redis is cache, DB is source of truth — so this
+ * function NEVER mutates message_lifecycle. It only reads.
+ */
+
+/**
+ * Per-state timeout cap (ms). Used by the cold-start scan to compute each
+ * row's deadline = state_changed_at + timeout_for(state).
+ *
+ * Values match spec §2.2 defaults; the dual-write Step 3 will make these
+ * per-entity-class configurable. For Step 2 we use the conservative ceiling
+ * (paid bot timeout) so the wheel never under-schedules — a row that is
+ * actually under a smaller per-entity cap will simply fire its alert sooner
+ * via Step 3's transition() path that schedules with the entity-specific
+ * deadline.
+ */
+const DEFAULT_STATE_TIMEOUTS_MS = {
+    inbound_seen: 180_000,   // 180s — paid bot ceiling per spec §2.2
+    bot_acked: 60_000,       // 60s — channel ceiling
+    push_delivered: 86_400_000, // 24h — best-effort engagement window
+};
+
+const COLD_START_PAGE_SIZE = 1000;
+// Backstop so a malformed page-cursor or unbounded growth can never block
+// boot indefinitely. 1M rows × 1000 pageSize = 1000 pages — well above any
+// realistic load and small enough to abort cleanly.
+const MAX_PAGES = 1000;
+
+/**
+ * Run the cold-start scan and repopulate the wheel.
+ *
+ * @param {object} options
+ * @param {object} options.wheel   Deadline wheel (createWheel result).
+ * @param {object} options.pool    pg.Pool — provides .query().
+ * @param {object} [options.stateTimeouts] Override per-state timeout caps.
+ * @param {number} [options.pageSize=1000] Rows per scan query.
+ * @param {number} [options.maxPages=1000] Backstop on total pages scanned.
+ * @param {()=>number} [options.now] Injected clock.
+ * @param {(msg:string,...args:any[])=>void} [options.log] Log sink.
+ * @returns {Promise<{scanned:number, scheduled:number, pages:number}>}
+ */
+async function runColdStart(options) {
+    if (!options || !options.wheel || !options.pool) {
+        throw new TypeError('runColdStart: { wheel, pool } are required');
+    }
+    const {
+        wheel,
+        pool,
+        stateTimeouts = DEFAULT_STATE_TIMEOUTS_MS,
+        pageSize = COLD_START_PAGE_SIZE,
+        maxPages = MAX_PAGES,
+        now = Date.now,
+        log = (...args) => console.log(...args),
+    } = options;
+
+    if (!wheel.enabled) {
+        log('[lifecycle-cold-start] wheel disabled (no Redis) — skipping cold-start scan');
+        return { scanned: 0, scheduled: 0, pages: 0 };
+    }
+
+    const startNow = now();
+    let scanned = 0;
+    let scheduled = 0;
+    let pages = 0;
+
+    // Keyset cursor: (last_seen_at, last_message_id). Sorting by
+    // inbound_seen_at + message_id gives a deterministic total order that
+    // does not require an offset (which would degrade as the table grows).
+    let cursorTs = null;
+    let cursorId = null;
+
+    while (pages < maxPages) {
+        const params = [pageSize];
+        let where = `state IN ('inbound_seen', 'bot_acked', 'push_delivered')`;
+        if (cursorTs !== null) {
+            params.push(cursorTs, cursorId);
+            where += ` AND (inbound_seen_at, message_id) > ($2, $3)`;
+        }
+        const sql = `
+            SELECT message_id,
+                   state,
+                   inbound_seen_at,
+                   bot_acked_at,
+                   push_delivered_at
+              FROM message_lifecycle
+             WHERE ${where}
+             ORDER BY inbound_seen_at ASC, message_id ASC
+             LIMIT $1
+        `;
+        let rows;
+        try {
+            const result = await pool.query(sql, params);
+            rows = result.rows || [];
+        } catch (err) {
+            log('[lifecycle-cold-start] page query failed', err);
+            return { scanned, scheduled, pages, error: err.message };
+        }
+        if (rows.length === 0) break;
+        pages++;
+        for (const row of rows) {
+            scanned++;
+            const pivot = pivotForState(row);
+            if (pivot === null) {
+                // Should not happen: NOT NULL on inbound_seen_at and the
+                // per-state column is set whenever that state is reached.
+                // Log + skip.
+                log(`[lifecycle-cold-start] row ${row.message_id} missing pivot for state=${row.state} — skipped`);
+                continue;
+            }
+            const timeoutMs = stateTimeouts[row.state] ?? DEFAULT_STATE_TIMEOUTS_MS[row.state] ?? 0;
+            const deadlineMs = pivot.getTime() + timeoutMs;
+            // Re-arm even if already past due — the sweeper's first post-restart
+            // tick will fire the alert. This is the explicit §9.9 contract:
+            // "any alerts that would have fired during the outage emit on the
+            // first post-cold-start sweep cycle."
+            try {
+                await wheel.schedule(row.message_id, deadlineMs);
+                scheduled++;
+            } catch (err) {
+                log(`[lifecycle-cold-start] wheel.schedule failed for ${row.message_id}`, err);
+            }
+        }
+        const last = rows[rows.length - 1];
+        cursorTs = last.inbound_seen_at;
+        cursorId = last.message_id;
+        if (rows.length < pageSize) break;
+    }
+
+    const elapsedMs = now() - startNow;
+    log(`[lifecycle-cold-start] repopulated wheel: scanned=${scanned} scheduled=${scheduled} pages=${pages} elapsedMs=${elapsedMs}`);
+    return { scanned, scheduled, pages };
+}
+
+function pivotForState(row) {
+    switch (row.state) {
+        case 'inbound_seen':
+            return row.inbound_seen_at instanceof Date ? row.inbound_seen_at : null;
+        case 'bot_acked':
+            return row.bot_acked_at instanceof Date ? row.bot_acked_at : null;
+        case 'push_delivered':
+            return row.push_delivered_at instanceof Date ? row.push_delivered_at : null;
+        default:
+            return null;
+    }
+}
+
+module.exports = {
+    runColdStart,
+    DEFAULT_STATE_TIMEOUTS_MS,
+    COLD_START_PAGE_SIZE,
+    // Exported for tests.
+    _pivotForState: pivotForState,
+};

--- a/backend/lib/message-lifecycle/deadline-wheel.js
+++ b/backend/lib/message-lifecycle/deadline-wheel.js
@@ -1,0 +1,257 @@
+/**
+ * MessageLifecycle deadline wheel (spec §4.2).
+ *
+ * Card: card_545ce5986b9c1332315ba303 (Phase 2 Step 2 — Redis deadline wheel).
+ * Spec: docs/specs/message-lifecycle-spec.md §4 (Redis schema + wheel API).
+ *
+ * Purpose: a Redis-sorted-set-backed deadline queue. Each message_id is stored
+ * with a score equal to its next "stuck" deadline in epoch ms. The sweeper
+ * (see ./sweeper.js) pops every entry whose score is <= now and either advances
+ * its lifecycle row or fires a stuck alert.
+ *
+ * Redis is cache + deadline wheel, NOT source of truth (spec §4 preamble).
+ * If the Redis instance is lost, cold-start (./cold-start.js) repopulates the
+ * wheel from the message_lifecycle table on the next boot.
+ *
+ * Client interface contract
+ * -------------------------
+ * createWheel({ redisClient }) accepts ANY object with these async methods:
+ *
+ *   zadd(key, score, member)            -> add or update a member's score
+ *   zrem(key, ...members)               -> remove members; returns removed count
+ *   zrangebyscore(key, min, max, opts?) -> returns members with min <= score <= max
+ *                                          opts = { limit: { offset, count } }
+ *   zremrangebyscore(key, min, max)     -> removes members in score range
+ *
+ * Names are lowercase to match ioredis. The redis@v4 package uses camelCase
+ * (zAdd/zRangeByScore) — callers using v4 should wrap their client first
+ * (helper not provided in Step 2 to avoid pulling in a hard dependency).
+ *
+ * If redisClient is null/undefined, createWheel returns a disabled wheel:
+ * every method resolves to a no-op (popDue returns []). A single warning is
+ * logged at construction time so operators see exactly one line per boot
+ * instead of one per request.
+ */
+
+const DEFAULT_KEY_PREFIX = 'ml';
+const DEFAULT_MAX_BATCH = 500;
+
+function deadlinesKey(prefix) {
+    return `${prefix}:deadlines`;
+}
+
+function makeDisabledWheel(reason) {
+    if (reason) {
+        console.warn(`[WARN] LIFECYCLE: ${reason} — deadline wheel disabled, timeouts will not auto-advance. Set REDIS_URL env var.`);
+    }
+    return {
+        enabled: false,
+        async schedule() {},
+        async cancel() { return 0; },
+        async popDue() { return []; },
+        async requeue() {},
+        async size() { return 0; },
+    };
+}
+
+/**
+ * Create a deadline wheel.
+ *
+ * @param {object} [options]
+ * @param {object} [options.redisClient] Redis client implementing the interface
+ *   above. If omitted, returns a disabled wheel with all ops as no-ops.
+ * @param {string} [options.keyPrefix='ml'] Key namespace, e.g. 'ml' yields
+ *   'ml:deadlines'.
+ * @param {number} [options.maxBatch=500] Default batch cap for popDue.
+ * @returns {object} wheel with schedule/cancel/popDue/requeue methods.
+ */
+function createWheel(options = {}) {
+    const {
+        redisClient = null,
+        keyPrefix = DEFAULT_KEY_PREFIX,
+        maxBatch: defaultMaxBatch = DEFAULT_MAX_BATCH,
+    } = options;
+
+    if (!redisClient) {
+        return makeDisabledWheel('REDIS_URL not set');
+    }
+
+    const key = deadlinesKey(keyPrefix);
+
+    return {
+        enabled: true,
+
+        /**
+         * Insert or refresh a deadline (spec §4.2 wheel.schedule).
+         * ZADD ml:deadlines <deadline> <message_id>
+         */
+        async schedule(messageId, deadlineMs) {
+            assertMessageId(messageId);
+            assertDeadline(deadlineMs);
+            await redisClient.zadd(key, Number(deadlineMs), String(messageId));
+        },
+
+        /**
+         * Remove a deadline (spec §4.2 wheel.cancel).
+         * ZREM ml:deadlines <message_id>
+         * Returns the count of members removed (0 if the wheel did not have it).
+         */
+        async cancel(messageId) {
+            assertMessageId(messageId);
+            const removed = await redisClient.zrem(key, String(messageId));
+            return Number(removed) || 0;
+        },
+
+        /**
+         * Pop all deadlines whose score is <= now (spec §4.2 wheel.popDue).
+         * The ZRANGEBYSCORE + ZREMRANGEBYSCORE pair is the at-least-once
+         * dispatch primitive — duplicates are absorbed by the sweeper's
+         * alert dedup (spec §4.3).
+         *
+         * @param {number} nowMs Epoch ms cutoff.
+         * @param {number} [maxBatch] Override the construction-time cap.
+         * @returns {Promise<string[]>} message_ids that were due.
+         */
+        async popDue(nowMs, maxBatch) {
+            assertDeadline(nowMs);
+            const count = Number.isInteger(maxBatch) && maxBatch > 0 ? maxBatch : defaultMaxBatch;
+            const dueIds = await redisClient.zrangebyscore(
+                key,
+                '-inf',
+                Number(nowMs),
+                { limit: { offset: 0, count } }
+            );
+            if (!Array.isArray(dueIds) || dueIds.length === 0) {
+                return [];
+            }
+            // Remove exactly the ids we returned. Using ZREM (not ZREMRANGEBYSCORE)
+            // because between the ZRANGEBYSCORE and a hypothetical ZREMRANGEBYSCORE
+            // a new id could land in the same score window and be deleted without
+            // ever being returned. Per-id ZREM is the at-least-once contract that
+            // the spec §4.2 popDue requires.
+            await redisClient.zrem(key, ...dueIds);
+            return dueIds.map(String);
+        },
+
+        /**
+         * Refresh a deadline to a later time (spec §4.2 wheel.requeue).
+         * Used by the sweeper after firing a stuck alert to schedule the next
+         * re-alert past the cooldown window.
+         */
+        async requeue(messageId, newDeadlineMs) {
+            assertMessageId(messageId);
+            assertDeadline(newDeadlineMs);
+            await redisClient.zadd(key, Number(newDeadlineMs), String(messageId));
+        },
+
+        /**
+         * Current wheel population — for /api/debug/message-lifecycle health
+         * surfaces (Step 5) and for tests. Not in the spec but cheap.
+         */
+        async size() {
+            if (typeof redisClient.zcard === 'function') {
+                const n = await redisClient.zcard(key);
+                return Number(n) || 0;
+            }
+            return null;
+        },
+    };
+}
+
+function assertMessageId(messageId) {
+    if (messageId === null || messageId === undefined || messageId === '') {
+        throw new TypeError('deadline-wheel: messageId is required');
+    }
+}
+
+function assertDeadline(ms) {
+    if (!Number.isFinite(Number(ms))) {
+        throw new TypeError('deadline-wheel: deadline must be a finite number (epoch ms)');
+    }
+}
+
+/**
+ * In-memory Redis-ZSET stub satisfying the wheel's client contract.
+ *
+ * Exposed because:
+ *   - Jest tests need it to exercise the wheel without a live Redis.
+ *   - Step 3 dual-write tests can use it to assert wheel state transitions.
+ *   - It documents the exact client contract by being a working reference.
+ *
+ * NOT for production use. Single-process, no persistence, no atomicity.
+ */
+function createInMemoryClient() {
+    const stores = new Map(); // key -> Map<member, score>
+
+    function getOrCreate(key) {
+        if (!stores.has(key)) stores.set(key, new Map());
+        return stores.get(key);
+    }
+
+    return {
+        async zadd(key, score, member) {
+            const z = getOrCreate(key);
+            const isNew = !z.has(member);
+            z.set(member, Number(score));
+            return isNew ? 1 : 0;
+        },
+        async zrem(key, ...members) {
+            const z = stores.get(key);
+            if (!z) return 0;
+            let removed = 0;
+            for (const m of members) {
+                if (z.delete(m)) removed++;
+            }
+            return removed;
+        },
+        async zrangebyscore(key, min, max, opts = {}) {
+            const z = stores.get(key);
+            if (!z) return [];
+            const lo = min === '-inf' ? -Infinity : Number(min);
+            const hi = max === '+inf' ? Infinity : Number(max);
+            const out = [];
+            for (const [member, score] of z.entries()) {
+                if (score >= lo && score <= hi) out.push([member, score]);
+            }
+            // ZRANGEBYSCORE returns members in ascending score order;
+            // ties broken lexicographically by member.
+            out.sort((a, b) => (a[1] - b[1]) || (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+            const offset = opts?.limit?.offset || 0;
+            const count = opts?.limit?.count;
+            const sliced = Number.isInteger(count)
+                ? out.slice(offset, offset + count)
+                : out.slice(offset);
+            return sliced.map(([m]) => m);
+        },
+        async zremrangebyscore(key, min, max) {
+            const z = stores.get(key);
+            if (!z) return 0;
+            const lo = min === '-inf' ? -Infinity : Number(min);
+            const hi = max === '+inf' ? Infinity : Number(max);
+            let removed = 0;
+            for (const [member, score] of [...z.entries()]) {
+                if (score >= lo && score <= hi) {
+                    z.delete(member);
+                    removed++;
+                }
+            }
+            return removed;
+        },
+        async zcard(key) {
+            const z = stores.get(key);
+            return z ? z.size : 0;
+        },
+        _flushall() {
+            stores.clear();
+        },
+    };
+}
+
+module.exports = {
+    createWheel,
+    createInMemoryClient,
+    // Exposed for tests + downstream modules (e.g. cold-start.js needs to
+    // share the same prefix when it repopulates the wheel).
+    DEFAULT_KEY_PREFIX,
+    deadlinesKey,
+};

--- a/backend/lib/message-lifecycle/index.js
+++ b/backend/lib/message-lifecycle/index.js
@@ -1,0 +1,27 @@
+/**
+ * MessageLifecycle public API — Phase 2 Step 2 surface.
+ *
+ * Card: card_545ce5986b9c1332315ba303.
+ * Spec: docs/specs/message-lifecycle-spec.md §4.
+ *
+ * Step 2 ships the wheel + sweeper + cold-start primitives. Wiring them
+ * into the boot path of `backend/index.js` is Step 3's job (dual-write).
+ * This index file is here so Step 3 can `require('./lib/message-lifecycle')`
+ * and pick what it needs without reaching into individual files.
+ */
+
+const { createWheel, createInMemoryClient, deadlinesKey, DEFAULT_KEY_PREFIX } = require('./deadline-wheel');
+const { createSweeper, DEFAULT_INTERVAL_MS } = require('./sweeper');
+const { runColdStart, DEFAULT_STATE_TIMEOUTS_MS, COLD_START_PAGE_SIZE } = require('./cold-start');
+
+module.exports = {
+    createWheel,
+    createInMemoryClient,
+    createSweeper,
+    runColdStart,
+    deadlinesKey,
+    DEFAULT_KEY_PREFIX,
+    DEFAULT_INTERVAL_MS,
+    DEFAULT_STATE_TIMEOUTS_MS,
+    COLD_START_PAGE_SIZE,
+};

--- a/backend/lib/message-lifecycle/sweeper.js
+++ b/backend/lib/message-lifecycle/sweeper.js
@@ -1,0 +1,128 @@
+/**
+ * MessageLifecycle sweeper loop (spec §4.3).
+ *
+ * Card: card_545ce5986b9c1332315ba303 (Phase 2 Step 2 — sweeper).
+ * Spec: docs/specs/message-lifecycle-spec.md §4.3.
+ *
+ * The sweeper polls the deadline wheel every N ms (default 5000 — env
+ * LIFECYCLE_SWEEP_INTERVAL_MS) and hands every popped message_id to a
+ * caller-supplied handler. The handler decides whether to emit a stuck
+ * alert, advance the lifecycle row, or requeue.
+ *
+ * This module is intentionally thin: it owns the timer + concurrency
+ * discipline + cancellation, but NOT the policy decision (alert? requeue?
+ * advance?). Policy lives in Step 3 (dual-write) and Step 6 (divergence
+ * detector). Decoupling them lets Step 2 ship a verifiable loop without
+ * the SLO formula choices.
+ *
+ * Concurrency: at most one onDue invocation per tick. If onDue is slow, the
+ * next tick is delayed until the previous one completes. This is the spec
+ * §4.3 contract — "at-least-once duplication is absorbed by alert dedup".
+ */
+
+const DEFAULT_INTERVAL_MS = 5000;
+
+function parseInterval(envValue) {
+    const n = Number(envValue);
+    if (Number.isFinite(n) && n >= 100) return Math.floor(n);
+    return DEFAULT_INTERVAL_MS;
+}
+
+/**
+ * Create a sweeper.
+ *
+ * @param {object} options
+ * @param {object} options.wheel  A deadline-wheel created via createWheel().
+ * @param {(id:string)=>Promise<void>} options.onDue
+ *   Handler invoked with each due message_id. Errors are swallowed and
+ *   logged so one bad row never wedges the loop.
+ * @param {number} [options.intervalMs] Tick interval. Defaults to
+ *   process.env.LIFECYCLE_SWEEP_INTERVAL_MS or 5000.
+ * @param {number} [options.maxBatch=500] Per-tick popDue cap.
+ * @param {()=>number} [options.now] Injected clock — used by tests to make
+ *   "due" deterministic. Production passes Date.now.
+ * @param {(msg:string,err?:Error)=>void} [options.logError] Error logger.
+ */
+function createSweeper(options) {
+    if (!options || typeof options.onDue !== 'function') {
+        throw new TypeError('createSweeper: onDue handler is required');
+    }
+    if (!options.wheel || typeof options.wheel.popDue !== 'function') {
+        throw new TypeError('createSweeper: wheel with popDue is required');
+    }
+
+    const {
+        wheel,
+        onDue,
+        intervalMs = parseInterval(process.env.LIFECYCLE_SWEEP_INTERVAL_MS),
+        maxBatch = 500,
+        now = Date.now,
+        logError = (msg, err) => console.error(msg, err),
+    } = options;
+
+    let timer = null;
+    let running = false;
+    let stopped = false;
+    let tickInFlight = null;
+
+    async function tick() {
+        if (stopped) return;
+        try {
+            const dueIds = await wheel.popDue(now(), maxBatch);
+            for (const id of dueIds) {
+                if (stopped) break;
+                try {
+                    await onDue(id);
+                } catch (err) {
+                    logError(`[lifecycle-sweeper] onDue handler failed for ${id}`, err);
+                }
+            }
+        } catch (err) {
+            logError('[lifecycle-sweeper] popDue failed', err);
+        }
+    }
+
+    function scheduleNext() {
+        if (stopped) return;
+        timer = setTimeout(async () => {
+            tickInFlight = tick();
+            await tickInFlight;
+            tickInFlight = null;
+            scheduleNext();
+        }, intervalMs);
+        if (typeof timer.unref === 'function') timer.unref();
+    }
+
+    return {
+        start() {
+            if (running || stopped) return;
+            running = true;
+            scheduleNext();
+        },
+        async stop() {
+            stopped = true;
+            running = false;
+            if (timer) {
+                clearTimeout(timer);
+                timer = null;
+            }
+            if (tickInFlight) {
+                try { await tickInFlight; } catch { /* swallow */ }
+            }
+        },
+        /**
+         * Force a single tick synchronously (used by tests to avoid timer
+         * flakiness). Not for production.
+         */
+        async _tickOnce() {
+            await tick();
+        },
+        get intervalMs() { return intervalMs; },
+        get isRunning() { return running && !stopped; },
+    };
+}
+
+module.exports = {
+    createSweeper,
+    DEFAULT_INTERVAL_MS,
+};

--- a/backend/tests/jest/message-lifecycle/deadline-wheel.test.js
+++ b/backend/tests/jest/message-lifecycle/deadline-wheel.test.js
@@ -1,0 +1,382 @@
+/**
+ * Tests for the MessageLifecycle Phase 2 Step 2 deliverables:
+ *   - backend/lib/message-lifecycle/deadline-wheel.js
+ *   - backend/lib/message-lifecycle/sweeper.js
+ *   - backend/lib/message-lifecycle/cold-start.js
+ *
+ * Card: card_545ce5986b9c1332315ba303.
+ * Spec: docs/specs/message-lifecycle-spec.md §4 + §9.9.
+ *
+ * The wheel runs against an in-memory ZSET stub (see createInMemoryClient in
+ * deadline-wheel.js). The stub is the same shape ioredis exposes, so the
+ * suite locks the contract that production Redis must honor.
+ */
+
+const {
+    createWheel,
+    createInMemoryClient,
+    createSweeper,
+    runColdStart,
+    deadlinesKey,
+    DEFAULT_KEY_PREFIX,
+} = require('../../../lib/message-lifecycle');
+
+describe('deadline-wheel.createWheel', () => {
+    let client;
+    let wheel;
+
+    beforeEach(() => {
+        client = createInMemoryClient();
+        wheel = createWheel({ redisClient: client });
+    });
+
+    test('schedule + popDue returns due ids in FIFO-by-deadline order', async () => {
+        // Three deadlines, intentionally scheduled out of chronological order.
+        await wheel.schedule('m_third', 3000);
+        await wheel.schedule('m_first', 1000);
+        await wheel.schedule('m_second', 2000);
+
+        // now=2500ms should pop the two earliest, leaving m_third.
+        const due = await wheel.popDue(2500);
+        expect(due).toEqual(['m_first', 'm_second']);
+
+        // Subsequent popDue at the same cutoff returns empty — the same id
+        // is never popped twice (at-least-once contract; the spec §4.3
+        // dedup is upstream of the wheel).
+        const again = await wheel.popDue(2500);
+        expect(again).toEqual([]);
+
+        // m_third still in the wheel until its score is in range.
+        expect(await wheel.size()).toBe(1);
+        const final = await wheel.popDue(5000);
+        expect(final).toEqual(['m_third']);
+        expect(await wheel.size()).toBe(0);
+    });
+
+    test('cancel removes a message from the wheel', async () => {
+        await wheel.schedule('m_a', 1000);
+        await wheel.schedule('m_b', 2000);
+        expect(await wheel.size()).toBe(2);
+
+        const removed = await wheel.cancel('m_a');
+        expect(removed).toBe(1);
+        expect(await wheel.size()).toBe(1);
+
+        // popDue past both original deadlines should only return m_b.
+        const due = await wheel.popDue(5000);
+        expect(due).toEqual(['m_b']);
+    });
+
+    test('cancel of unknown id is a no-op (returns 0)', async () => {
+        const removed = await wheel.cancel('never_scheduled');
+        expect(removed).toBe(0);
+    });
+
+    test('requeue updates an existing deadline to a later score', async () => {
+        await wheel.schedule('m_x', 1000);
+        // popDue at 1500 would normally pop m_x; requeue first to 5000.
+        await wheel.requeue('m_x', 5000);
+
+        const tooEarly = await wheel.popDue(1500);
+        expect(tooEarly).toEqual([]);
+
+        const later = await wheel.popDue(5500);
+        expect(later).toEqual(['m_x']);
+    });
+
+    test('requeue updates an existing deadline to an earlier score', async () => {
+        await wheel.schedule('m_y', 9999);
+        await wheel.requeue('m_y', 100);
+        const due = await wheel.popDue(200);
+        expect(due).toEqual(['m_y']);
+    });
+
+    test('popDue honors maxBatch cap', async () => {
+        for (let i = 0; i < 10; i++) {
+            await wheel.schedule(`m_${i}`, i + 1);
+        }
+        const first = await wheel.popDue(100, 3);
+        expect(first).toHaveLength(3);
+        expect(first).toEqual(['m_0', 'm_1', 'm_2']);
+        const rest = await wheel.popDue(100, 100);
+        expect(rest).toHaveLength(7);
+    });
+
+    test('schedule rejects null / undefined / empty message ids', async () => {
+        await expect(wheel.schedule(null, 1)).rejects.toThrow(/messageId/);
+        await expect(wheel.schedule(undefined, 1)).rejects.toThrow(/messageId/);
+        await expect(wheel.schedule('', 1)).rejects.toThrow(/messageId/);
+    });
+
+    test('schedule rejects non-finite deadlines', async () => {
+        await expect(wheel.schedule('m', NaN)).rejects.toThrow(/deadline/);
+        await expect(wheel.schedule('m', Infinity)).rejects.toThrow(/deadline/);
+        await expect(wheel.schedule('m', 'soon')).rejects.toThrow(/deadline/);
+    });
+
+    test('disabled wheel (no Redis) logs once + becomes no-op', async () => {
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const off = createWheel({});
+        expect(off.enabled).toBe(false);
+        await off.schedule('m', 1);
+        await off.requeue('m', 2);
+        expect(await off.popDue(99)).toEqual([]);
+        expect(await off.cancel('m')).toBe(0);
+        expect(warn).toHaveBeenCalledTimes(1);
+        expect(warn.mock.calls[0][0]).toMatch(/REDIS_URL not set/);
+        warn.mockRestore();
+    });
+
+    test('integration smoke: 3 deadlines, time advances, popDue returns in order', async () => {
+        // Spec acceptance per dispatch — verifies the wheel's promise that
+        // it pops earliest-first as wall time moves forward.
+        const ids = ['alpha', 'beta', 'gamma'];
+        const deadlines = [1000, 2000, 3000];
+        await Promise.all(ids.map((id, i) => wheel.schedule(id, deadlines[i])));
+
+        expect(await wheel.popDue(500)).toEqual([]);
+        expect(await wheel.popDue(1500)).toEqual(['alpha']);
+        expect(await wheel.popDue(2500)).toEqual(['beta']);
+        expect(await wheel.popDue(3500)).toEqual(['gamma']);
+        expect(await wheel.size()).toBe(0);
+    });
+
+    test('deadlinesKey + DEFAULT_KEY_PREFIX are exported for downstream wiring', () => {
+        // Step 3 dual-write needs the same key prefix to reach the same ZSET.
+        expect(DEFAULT_KEY_PREFIX).toBe('ml');
+        expect(deadlinesKey('ml')).toBe('ml:deadlines');
+        expect(deadlinesKey('custom')).toBe('custom:deadlines');
+    });
+});
+
+describe('sweeper.createSweeper', () => {
+    let client;
+    let wheel;
+
+    beforeEach(() => {
+        client = createInMemoryClient();
+        wheel = createWheel({ redisClient: client });
+    });
+
+    test('_tickOnce hands each due id to the onDue handler', async () => {
+        await wheel.schedule('m_a', 100);
+        await wheel.schedule('m_b', 200);
+        await wheel.schedule('m_z', 9999);
+
+        const seen = [];
+        const sweeper = createSweeper({
+            wheel,
+            onDue: async (id) => { seen.push(id); },
+            now: () => 500,
+        });
+        await sweeper._tickOnce();
+        expect(seen).toEqual(['m_a', 'm_b']);
+
+        // m_z still in the wheel.
+        expect(await wheel.size()).toBe(1);
+    });
+
+    test('onDue handler error does not wedge the loop', async () => {
+        await wheel.schedule('m_bad', 100);
+        await wheel.schedule('m_good', 200);
+
+        const seen = [];
+        const errors = [];
+        const sweeper = createSweeper({
+            wheel,
+            now: () => 1000,
+            onDue: async (id) => {
+                seen.push(id);
+                if (id === 'm_bad') throw new Error('boom');
+            },
+            logError: (msg, err) => errors.push({ msg, err: err && err.message }),
+        });
+        await sweeper._tickOnce();
+        expect(seen).toEqual(['m_bad', 'm_good']);
+        expect(errors).toHaveLength(1);
+        expect(errors[0].err).toBe('boom');
+    });
+
+    test('LIFECYCLE_SWEEP_INTERVAL_MS env override', () => {
+        const prev = process.env.LIFECYCLE_SWEEP_INTERVAL_MS;
+        try {
+            process.env.LIFECYCLE_SWEEP_INTERVAL_MS = '2500';
+            const s = createSweeper({ wheel, onDue: async () => {} });
+            expect(s.intervalMs).toBe(2500);
+        } finally {
+            if (prev === undefined) delete process.env.LIFECYCLE_SWEEP_INTERVAL_MS;
+            else process.env.LIFECYCLE_SWEEP_INTERVAL_MS = prev;
+        }
+    });
+
+    test('invalid env falls back to default 5000', () => {
+        const prev = process.env.LIFECYCLE_SWEEP_INTERVAL_MS;
+        try {
+            process.env.LIFECYCLE_SWEEP_INTERVAL_MS = 'banana';
+            const s = createSweeper({ wheel, onDue: async () => {} });
+            expect(s.intervalMs).toBe(5000);
+        } finally {
+            if (prev === undefined) delete process.env.LIFECYCLE_SWEEP_INTERVAL_MS;
+            else process.env.LIFECYCLE_SWEEP_INTERVAL_MS = prev;
+        }
+    });
+
+    test('createSweeper validates required options', () => {
+        expect(() => createSweeper(null)).toThrow();
+        expect(() => createSweeper({ wheel })).toThrow(/onDue/);
+        expect(() => createSweeper({ onDue: () => {} })).toThrow(/wheel/);
+    });
+
+    test('start / stop lifecycle', async () => {
+        const sweeper = createSweeper({ wheel, onDue: async () => {}, intervalMs: 60_000 });
+        sweeper.start();
+        expect(sweeper.isRunning).toBe(true);
+        await sweeper.stop();
+        expect(sweeper.isRunning).toBe(false);
+    });
+});
+
+describe('cold-start.runColdStart (spec §9.9 — Redis lost → restart)', () => {
+    function makeFakePool(rowsByCursor) {
+        return {
+            calls: [],
+            async query(sql, params) {
+                this.calls.push({ sql, params: [...params] });
+                const cursor = params[1] !== undefined
+                    ? `${params[1].toISOString()}|${params[2]}`
+                    : '__head__';
+                const rows = rowsByCursor[cursor] || [];
+                // Honor LIMIT (params[0]).
+                return { rows: rows.slice(0, params[0]) };
+            },
+        };
+    }
+
+    test('§9.9: simulate Redis lost → restart → wheel restored from DB', async () => {
+        // Two rows would have been in the wheel before Redis was flushed.
+        const rows = [
+            {
+                message_id: 'msg_inbound_old',
+                state: 'inbound_seen',
+                inbound_seen_at: new Date('2026-01-01T00:00:00Z'),
+                bot_acked_at: null,
+                push_delivered_at: null,
+            },
+            {
+                message_id: 'msg_bot_acked_old',
+                state: 'bot_acked',
+                inbound_seen_at: new Date('2026-01-01T00:00:30Z'),
+                bot_acked_at: new Date('2026-01-01T00:00:45Z'),
+                push_delivered_at: null,
+            },
+        ];
+        const pool = makeFakePool({ __head__: rows });
+
+        const client = createInMemoryClient();
+        const wheel = createWheel({ redisClient: client });
+        expect(await wheel.size()).toBe(0); // Redis was flushed
+
+        const result = await runColdStart({
+            wheel,
+            pool,
+            now: () => new Date('2026-01-01T00:30:00Z').getTime(),
+            log: () => {},
+        });
+
+        expect(result.scanned).toBe(2);
+        expect(result.scheduled).toBe(2);
+        // Wheel now has both stale rows re-armed.
+        expect(await wheel.size()).toBe(2);
+
+        // popDue at "now" pops every re-armed row whose deadline is in the
+        // past — verifying the §9.9 contract that alerts which would have
+        // fired during the outage emit on the first post-restart sweep.
+        const due = await wheel.popDue(new Date('2026-01-01T00:30:00Z').getTime());
+        expect(due.sort()).toEqual(['msg_bot_acked_old', 'msg_inbound_old']);
+    });
+
+    test('paginates beyond a single page (globe-user generalization)', async () => {
+        // Three pages: 2 + 2 + 1 rows. Page size = 2 forces real keyset
+        // pagination via the cursor params.
+        const page1 = [
+            mkRow('m1', 'inbound_seen', '2026-01-01T00:00:00Z'),
+            mkRow('m2', 'inbound_seen', '2026-01-01T00:00:01Z'),
+        ];
+        const page2 = [
+            mkRow('m3', 'bot_acked', '2026-01-01T00:00:02Z'),
+            mkRow('m4', 'push_delivered', '2026-01-01T00:00:03Z'),
+        ];
+        const page3 = [
+            mkRow('m5', 'inbound_seen', '2026-01-01T00:00:04Z'),
+        ];
+
+        const rowsByCursor = {
+            __head__: page1,
+            [`${page1[1].inbound_seen_at.toISOString()}|m2`]: page2,
+            [`${page2[1].inbound_seen_at.toISOString()}|m4`]: page3,
+        };
+        const pool = makeFakePool(rowsByCursor);
+
+        const wheel = createWheel({ redisClient: createInMemoryClient() });
+        const result = await runColdStart({
+            wheel,
+            pool,
+            pageSize: 2,
+            now: () => Date.parse('2026-01-01T01:00:00Z'),
+            log: () => {},
+        });
+
+        expect(result.pages).toBe(3);
+        expect(result.scanned).toBe(5);
+        expect(result.scheduled).toBe(5);
+        expect(await wheel.size()).toBe(5);
+        // First page query has no cursor params (pageSize only).
+        expect(pool.calls[0].params).toHaveLength(1);
+        // Subsequent pages have keyset (pageSize, cursorTs, cursorId).
+        expect(pool.calls[1].params).toHaveLength(3);
+        expect(pool.calls[1].params[2]).toBe('m2');
+        expect(pool.calls[2].params[2]).toBe('m4');
+    });
+
+    test('skips user_seen rows via the SQL WHERE clause', async () => {
+        const pool = makeFakePool({ __head__: [] });
+        const wheel = createWheel({ redisClient: createInMemoryClient() });
+        const result = await runColdStart({ wheel, pool, log: () => {} });
+        // Verify the WHERE excludes user_seen + lists the three live states.
+        expect(pool.calls[0].sql).toMatch(/state IN \('inbound_seen', 'bot_acked', 'push_delivered'\)/);
+        expect(pool.calls[0].sql).not.toMatch(/user_seen/);
+        expect(result.scanned).toBe(0);
+    });
+
+    test('returns early when wheel is disabled (no Redis)', async () => {
+        const pool = {
+            calls: [],
+            async query(sql, params) {
+                this.calls.push({ sql, params });
+                return { rows: [] };
+            },
+        };
+        const warn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        const wheel = createWheel({});
+        const result = await runColdStart({ wheel, pool, log: () => {} });
+        expect(result).toEqual({ scanned: 0, scheduled: 0, pages: 0 });
+        expect(pool.calls).toHaveLength(0); // never hit PG
+        warn.mockRestore();
+    });
+
+    test('runColdStart validates required args', async () => {
+        await expect(runColdStart()).rejects.toThrow(/wheel.*pool|pool.*wheel/);
+        await expect(runColdStart({ wheel: {} })).rejects.toThrow();
+        await expect(runColdStart({ pool: {} })).rejects.toThrow();
+    });
+});
+
+function mkRow(id, state, isoTs) {
+    return {
+        message_id: id,
+        state,
+        inbound_seen_at: new Date(isoTs),
+        bot_acked_at: state === 'bot_acked' || state === 'push_delivered' ? new Date(isoTs) : null,
+        push_delivered_at: state === 'push_delivered' ? new Date(isoTs) : null,
+    };
+}


### PR DESCRIPTION
## Summary

Lands the Redis-sorted-set deadline wheel + 5s sweeper loop + DB-scan cold-start that the `message_lifecycle` table (Step 1 #3385) needs to actually drive alerts.

- Spec: `docs/specs/message-lifecycle-spec.md` §4 (Redis schema + wheel API), §4.3 (sweeper), §4.4 (Redis-lost failure mode), §9.9 (cold-start acceptance scenario).
- Card: `card_545ce5986b9c1332315ba303` (Phase 2 Step 2 of 6; parent `card_1b1c` stays `in_progress` until all six steps ship).

## What ships

| New file | Purpose |
|---|---|
| `backend/lib/message-lifecycle/deadline-wheel.js` | `createWheel({ redisClient })` — `schedule` / `cancel` / `popDue` / `requeue` per spec §4.2. `popDue` uses `ZRANGEBYSCORE` + per-id `ZREM` (not `ZREMRANGEBYSCORE`) so an id that lands in the same score window between range fetch and delete cannot be silently dropped. Also exports `createInMemoryClient()` — an ioredis-shaped ZSET stub the tests use. |
| `backend/lib/message-lifecycle/sweeper.js` | `createSweeper({ wheel, onDue, intervalMs })` — periodic tick that pops every due id and hands it to the caller's handler. Errors in `onDue` are swallowed + logged so one bad row never wedges the loop. `LIFECYCLE_SWEEP_INTERVAL_MS` env override (default `5000`). Policy (alert vs requeue) is intentionally not in this module — that's Step 3 dual-write. |
| `backend/lib/message-lifecycle/cold-start.js` | `runColdStart({ wheel, pool })` — keyset-paginated scan of `message_lifecycle WHERE state IN ('inbound_seen','bot_acked','push_delivered')` ordered by `(inbound_seen_at, message_id)`. Repopulates the wheel with `deadline = pivot_at + per_state_timeout`. Pagination is the globe-user generalization from the dispatch (keyset cursors, not OFFSET) so the scan stays bounded past 10k stale rows. |
| `backend/lib/message-lifecycle/index.js` | Re-exports the public surface so Step 3 can `require('./lib/message-lifecycle')`. |
| `backend/tests/jest/message-lifecycle/deadline-wheel.test.js` | 22 cases, all green (see below). |

## Setup conditions

No `REDIS_URL` env / no Redis client injected → wheel is disabled: every op is a no-op, `popDue` returns `[]`, and a single line is logged at construction time:

```
[WARN] LIFECYCLE: REDIS_URL not set — deadline wheel disabled, timeouts will not auto-advance. Set REDIS_URL env var.
```

Matches the dispatch "setup conditions (? icon UX)" verbatim.

## Test plan

- [x] `npx jest tests/jest/message-lifecycle/` → **22/22 green**
  - schedule/popDue FIFO-by-deadline ordering (3 deadlines, out-of-order schedule)
  - cancel removes / cancel-of-unknown-id no-ops
  - requeue to later AND earlier scores
  - popDue `maxBatch` cap
  - schedule input validation (null/empty id, NaN/Infinity/string deadline)
  - disabled-wheel branch — single warn, all ops no-op
  - integration smoke: 3 deadlines, time advances, popDue returns in order
  - sweeper `_tickOnce` / onDue-error tolerance / env interval override / invalid-env fallback / start+stop lifecycle / arg validation
  - cold-start spec §9.9: simulate Redis lost → restart → wheel restored from DB (alerts that would have fired during the outage emit on the first post-restart sweep)
  - cold-start multi-page keyset pagination (3 pages × 2 = 5 rows)
  - cold-start `WHERE` excludes `user_seen` / early-returns when wheel disabled
  - cold-start arg validation
- [x] `npx jest tests/jest` (full suite) → **301 suites, 4148 tests passed, 17 skipped, 0 failed** — no regressions.
- [x] `npm run lint` → 0 errors (4 pre-existing warnings unchanged).
- [x] `node scripts/i18n-check.js` → no new key references; no HTML/i18n.js touched.

## What this does NOT change

- **No new npm dependency.** The wheel accepts any client implementing `{zadd, zrem, zrangebyscore, zremrangebyscore}` (ioredis-style). A real Redis client (`ioredis` or `redis@v4`) gets wired in when Step 3 dual-write lands.
- **`backend/index.js` is untouched.** The sweeper is NOT started on boot here. Step 3 owns the boot wiring and the dual-write call sites that `schedule()` deadlines on every transition.
- **No schema changes.** Step 1 (#3385) owns `message_lifecycle` + `lifecycle_event_log`.

## Out of scope (per spec §8 + dispatch)

- Step 3 dual-write across `chat_no_reply` / `delivery_alert` sites
- Step 4 lazy-on-read backfill resolver
- Step 5 `GET /api/debug/message-lifecycle/:messageId`
- Step 6 Phase 3 cutover divergence detector

🤖 Generated with [Claude Code](https://claude.com/claude-code)