### PR TITLE
fix(rental/bind): clearer 502 error + retry hint + Jest (GH#3001, card_3367)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -15844,11 +15844,14 @@ app.post('/api/official-borrow/bind-free', async (req, res) => {
     const handshake = await handshakeWithBot(freeBot.webhook_url, freeBot.token, preferredKey, deviceId, eId, 'free', freeBotAuthOpts);
 
     if (!handshake.success) {
-        return res.status(502).json({
-            success: false,
-            error: `無法與免費版機器人建立連線。${handshake.error || ''}`,
-            hint: 'Bot gateway may not have active sessions. Check bot configuration.'
+        const failurePayload = buildBindFailurePayload(handshake, {
+            botKind: 'free',
+            botId: freeBot.bot_id,
+            botName: freeBot.display_name || freeBot.bot_id,
+            webhookUrl: freeBot.webhook_url,
         });
+        failurePayload.error = `無法與免費版機器人建立連線 (${failurePayload.code}). ${handshake.error || ''}`.trim();
+        return res.status(502).json(failurePayload);
     }
 
     const sessionKey = handshake.sessionKey;
@@ -16023,11 +16026,14 @@ app.post('/api/official-borrow/bind-personal', async (req, res) => {
     const handshake = await handshakeWithBot(personalBot.webhook_url, personalBot.token, preferredKey, deviceId, eId, 'personal', personalBotAuthOpts);
 
     if (!handshake.success) {
-        return res.status(502).json({
-            success: false,
-            error: `無法與月租版機器人建立連線。${handshake.error || ''}`,
-            hint: 'Bot gateway may not have active sessions. Check bot configuration.'
+        const failurePayload = buildBindFailurePayload(handshake, {
+            botKind: 'personal',
+            botId: personalBot.bot_id,
+            botName: personalBot.display_name || personalBot.bot_id,
+            webhookUrl: personalBot.webhook_url,
         });
+        failurePayload.error = `無法與月租版機器人建立連線 (${failurePayload.code}). ${handshake.error || ''}`.trim();
+        return res.status(502).json(failurePayload);
     }
 
     const sessionKey = handshake.sessionKey;
@@ -16373,12 +16379,16 @@ app.post('/api/entity/refresh', async (req, res) => {
         if (!handshake.success) {
             // Set cooldown even on failure to prevent spamming
             refreshCooldowns[cooldownKey] = Date.now();
-            return res.json({
-                success: false,
-                webhookBroken: true,
-                error: `無法與機器人建立連線。${handshake.error || ''}`,
-                hint: 'Bot gateway may not have active sessions. A full rebind may be required.'
+            const failurePayload = buildBindFailurePayload(handshake, {
+                botKind: bot.bot_type,
+                botId: bot.bot_id,
+                botName: bot.display_name || bot.bot_id,
+                webhookUrl: bot.webhook_url,
             });
+            failurePayload.webhookBroken = true;
+            failurePayload.error = `無法與機器人建立連線 (${failurePayload.code}). ${handshake.error || ''}`.trim();
+            failurePayload.hint = (failurePayload.hint || '') + ' A full rebind may be required.';
+            return res.json(failurePayload);
         }
 
         const newSessionKey = handshake.sessionKey;
@@ -17870,7 +17880,78 @@ async function handshakeWithBot(url, token, preferredSessionKey, deviceId, entit
     console.error(`[Handshake] ✗ All session attempts failed (type=${finalErrorType}): ${result.error}`);
     serverLog('error', 'handshake', `All session attempts failed for Entity ${entityId} (${finalErrorType})`, { deviceId, entityId, metadata: { url, errorType: finalErrorType } });
     logHandshakeFailure({ deviceId, entityId, webhookUrl: url, errorType: finalErrorType, errorMessage: result.error || 'No working session found on gateway', source: 'bind_handshake' });
-    return { success: false, error: result.error || 'No working session found on gateway' };
+    return {
+        success: false,
+        error: result.error || 'No working session found on gateway',
+        errorType: finalErrorType,
+        httpStatus: result.httpStatus || null,
+    };
+}
+
+/**
+ * Helper: Build a structured 502 payload for bind failures.
+ * Caller maps errorType (timeout|no_sessions|http_NNN|connection_failed) into a
+ * stable `code` so debugging tools and the user-facing UI know whether the bot
+ * box is offline, the gateway is up but has no sessions, or the upstream LLM
+ * timed out.
+ */
+function buildBindFailurePayload(handshake, { botKind, botId, botName, webhookUrl }) {
+    const errorType = handshake?.errorType || 'connection_failed';
+    const httpStatus = handshake?.httpStatus || null;
+    // Map errorType → stable code + hint + retryable flag
+    let code;
+    let hint;
+    let retryable;
+    let retryAfterMs;
+    if (errorType === 'timeout') {
+        code = 'UPSTREAM_TIMEOUT';
+        hint = 'Bot took longer than 60s to reply. Cold-start or LLM provider slow — retry usually succeeds.';
+        retryable = true;
+        retryAfterMs = 5000;
+    } else if (errorType === 'no_sessions') {
+        code = 'BOT_NO_SESSIONS';
+        hint = 'Gateway responded but has no active sessions for this bot. Check bot is running and connected to its gateway.';
+        retryable = false;
+        retryAfterMs = null;
+    } else if (errorType === 'connection_failed') {
+        // No HTTP response at all — host unreachable, DNS fail, tunnel down
+        // (most common cause: Mac local bot box offline / ngrok tunnel dropped).
+        code = 'BOT_UNREACHABLE';
+        hint = 'Could not reach the bot webhook. The bot host may be offline (e.g. local tunnel dropped). Verify the bot box is up.';
+        retryable = true;
+        retryAfterMs = 30000;
+    } else if (errorType.startsWith('http_')) {
+        const status = httpStatus || parseInt(errorType.slice(5), 10) || 502;
+        code = status === 502 ? 'UPSTREAM_502' : `UPSTREAM_HTTP_${status}`;
+        hint = `Bot webhook returned HTTP ${status}. Upstream gateway or LLM provider failed — retry after a short delay.`;
+        retryable = status >= 500;
+        retryAfterMs = retryable ? 10000 : null;
+    } else {
+        code = 'BIND_FAILED';
+        hint = 'Bot gateway may not have active sessions. Check bot configuration.';
+        retryable = false;
+        retryAfterMs = null;
+    }
+    const payload = {
+        success: false,
+        code,
+        errorType,
+        upstream: 'bot_webhook',
+        error: handshake?.error || 'Bind handshake failed',
+        hint,
+        retryable,
+        botKind: botKind || null,
+        botId: botId || null,
+        botName: botName || null,
+        webhookHost: webhookUrl ? safeHostname(webhookUrl) : null,
+    };
+    if (retryAfterMs != null) payload.retry_after_ms = retryAfterMs;
+    if (httpStatus != null) payload.upstream_http_status = httpStatus;
+    return payload;
+}
+
+function safeHostname(urlStr) {
+    try { return new URL(urlStr).hostname; } catch { return null; }
 }
 
 /**
@@ -22658,4 +22739,5 @@ module.exports._officialBorrowTest = {
     getOfficialBindingReuseStatus,
     OFFICIAL_FREE_BINDING_REUSE_TTL_MS,
 };
+module.exports._buildBindFailurePayload = buildBindFailurePayload;
 module.exports._getSilentTransformSuppressionReason = getSilentTransformSuppressionReason;

--- a/backend/tests/jest/official-borrow-bind-502-structured.test.js
+++ b/backend/tests/jest/official-borrow-bind-502-structured.test.js
@@ -1,0 +1,246 @@
+/**
+ * Structured 502 on free/personal bot bind failure (GH#3001 / card_3367).
+ *
+ * Before this change, every handshake failure surfaced as a generic 502 with
+ * "無法與免費版機器人建立連線" — the caller had no way to distinguish:
+ *
+ *   - bot host unreachable (Mac local box offline, tunnel dropped)
+ *   - gateway up but no sessions
+ *   - upstream LLM timed out
+ *   - gateway returned HTTP 5xx
+ *
+ * `buildBindFailurePayload` maps the handshake `errorType` to a stable `code`
+ * plus a `retryable` flag + `retry_after_ms` hint so health-cron and the
+ * Android/iOS UI can show a useful next step instead of "try again later".
+ *
+ * Coverage:
+ *   1. Unit: every errorType → expected code + retryable
+ *   2. Endpoint: bind-free returns structured 502 when handshake fails
+ *      (validates the new fields are wired into the actual response).
+ */
+
+require('./helpers/mock-setup');
+
+const request = require('supertest');
+const db = require('../../db');
+const gatekeeper = require('../../gatekeeper');
+
+let app;
+
+const post = (path) => request(app).post(path).set('Host', 'localhost').set('Accept-Encoding', 'identity');
+
+beforeAll(() => {
+    app = require('../../index');
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+    jest.resetModules();
+});
+
+function clearMap(map) {
+    for (const key of Object.keys(map)) delete map[key];
+}
+
+beforeEach(() => {
+    clearMap(app.devices);
+    clearMap(app._publicCodeIndex);
+    clearMap(app._officialBorrowTest.officialBots);
+    clearMap(app._officialBorrowTest.officialBindingsCache);
+    gatekeeper.isDeviceBlocked.mockReturnValue(false);
+    gatekeeper.hasAgreedToTOS.mockReturnValue(true);
+    db.getOfficialBinding.mockResolvedValue(null);
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 1. Unit: buildBindFailurePayload mapping
+// ════════════════════════════════════════════════════════════════════════════
+describe('buildBindFailurePayload (unit)', () => {
+    const ctx = {
+        botKind: 'free',
+        botId: 'mac_local_minimax_2_5',
+        botName: 'Mac本地版_MiniMax2.5',
+        webhookUrl: 'https://mac-tunnel.example.com/mcp',
+    };
+
+    it('maps connection_failed → BOT_UNREACHABLE (the Mac-box-offline case from GH#3001)', () => {
+        const p = app._buildBindFailurePayload(
+            { success: false, error: 'fetch failed', errorType: 'connection_failed' },
+            ctx,
+        );
+        expect(p.success).toBe(false);
+        expect(p.code).toBe('BOT_UNREACHABLE');
+        expect(p.errorType).toBe('connection_failed');
+        expect(p.upstream).toBe('bot_webhook');
+        expect(p.retryable).toBe(true);
+        expect(p.retry_after_ms).toBeGreaterThan(0);
+        expect(p.botId).toBe('mac_local_minimax_2_5');
+        expect(p.botName).toBe('Mac本地版_MiniMax2.5');
+        expect(p.webhookHost).toBe('mac-tunnel.example.com');
+        expect(p.hint).toMatch(/offline|unreachable/i);
+    });
+
+    it('maps timeout → UPSTREAM_TIMEOUT (retryable)', () => {
+        const p = app._buildBindFailurePayload(
+            { success: false, error: 'aborted', errorType: 'timeout' },
+            ctx,
+        );
+        expect(p.code).toBe('UPSTREAM_TIMEOUT');
+        expect(p.retryable).toBe(true);
+        expect(p.retry_after_ms).toBeGreaterThan(0);
+    });
+
+    it('maps no_sessions → BOT_NO_SESSIONS (NOT retryable — needs operator action)', () => {
+        const p = app._buildBindFailurePayload(
+            { success: false, error: 'No session found', errorType: 'no_sessions' },
+            ctx,
+        );
+        expect(p.code).toBe('BOT_NO_SESSIONS');
+        expect(p.retryable).toBe(false);
+        expect(p.retry_after_ms).toBeUndefined();
+    });
+
+    it('maps http_502 → UPSTREAM_502 with httpStatus preserved', () => {
+        const p = app._buildBindFailurePayload(
+            { success: false, error: 'HTTP 502: Bad Gateway', errorType: 'http_502', httpStatus: 502 },
+            ctx,
+        );
+        expect(p.code).toBe('UPSTREAM_502');
+        expect(p.upstream_http_status).toBe(502);
+        expect(p.retryable).toBe(true);
+    });
+
+    it('maps http_403 → UPSTREAM_HTTP_403 (not retryable, 4xx is not transient)', () => {
+        const p = app._buildBindFailurePayload(
+            { success: false, error: 'HTTP 403', errorType: 'http_403', httpStatus: 403 },
+            ctx,
+        );
+        expect(p.code).toBe('UPSTREAM_HTTP_403');
+        expect(p.retryable).toBe(false);
+    });
+
+    it('falls back gracefully on missing/unknown errorType', () => {
+        const p = app._buildBindFailurePayload(
+            { success: false, error: 'mystery' },
+            ctx,
+        );
+        // Default mapping when errorType missing: treat as connection_failed.
+        expect(p.code).toBe('BOT_UNREACHABLE');
+        expect(p.botId).toBe('mac_local_minimax_2_5');
+    });
+
+    it('passes through nulls when bot metadata is absent', () => {
+        const p = app._buildBindFailurePayload(
+            { success: false, errorType: 'timeout' },
+            {},
+        );
+        expect(p.botKind).toBeNull();
+        expect(p.botId).toBeNull();
+        expect(p.botName).toBeNull();
+        expect(p.webhookHost).toBeNull();
+    });
+});
+
+// ════════════════════════════════════════════════════════════════════════════
+// 2. Endpoint: POST /api/official-borrow/bind-free returns structured 502
+// ════════════════════════════════════════════════════════════════════════════
+describe('POST /api/official-borrow/bind-free — structured 502 on handshake failure', () => {
+    function seedDeviceAndFreeBot() {
+        const deviceId = 'gh3001-device';
+        const deviceSecret = 'gh3001-secret';
+        const botId = 'mac_local_minimax_2_5';
+        const now = Date.now();
+
+        // Device with one empty entity slot.
+        app.devices[deviceId] = {
+            deviceId,
+            deviceSecret,
+            createdAt: now,
+            nextEntityId: 1,
+            entities: {
+                0: {
+                    ...app._createDefaultEntity(0),
+                    entityId: 0,
+                    isBound: false,
+                },
+            },
+        };
+
+        // Free bot pointing at a webhook we'll force-fail.
+        app._officialBorrowTest.officialBots[botId] = {
+            bot_id: botId,
+            display_name: 'Mac本地版_MiniMax2.5',
+            bot_type: 'free',
+            // Use a URL that hits the global.fetch mock below, NOT a private IP
+            // (DNS-rebinding protection rejects private IPs before fetch).
+            // example.com resolves to a public IP, satisfying the DNS-rebinding
+            // guard; fetch itself is mocked so we never actually hit the network.
+            webhook_url: 'https://example.com/mcp',
+            token: 'fake-token',
+            status: 'active',
+            session_key_template: 'default',
+        };
+
+        return { deviceId, deviceSecret, botId };
+    }
+
+    it('returns 502 with code=BOT_UNREACHABLE when webhook host fails to connect', async () => {
+        const { deviceId, deviceSecret, botId } = seedDeviceAndFreeBot();
+
+        // Force every fetch attempt (handshake + session discovery) to fail
+        // with a network error — same shape as a dropped tunnel.
+        const origFetch = global.fetch;
+        global.fetch = jest.fn().mockImplementation(async () => {
+            const err = new Error('fetch failed: ECONNREFUSED');
+            err.name = 'TypeError';
+            throw err;
+        });
+
+        try {
+            const res = await post('/api/official-borrow/bind-free')
+                .send({ deviceId, deviceSecret, entityId: 0, botId });
+
+            expect(res.status).toBe(502);
+            // Structured fields the SOP / health-cron / Android UI rely on:
+            expect(res.body.success).toBe(false);
+            expect(res.body.code).toBe('BOT_UNREACHABLE');
+            expect(res.body.upstream).toBe('bot_webhook');
+            expect(res.body.errorType).toBe('connection_failed');
+            expect(res.body.retryable).toBe(true);
+            expect(res.body.retry_after_ms).toBeGreaterThan(0);
+            expect(res.body.botId).toBe(botId);
+            expect(res.body.botName).toBe('Mac本地版_MiniMax2.5');
+            expect(res.body.botKind).toBe('free');
+            expect(res.body.webhookHost).toBe('example.com');
+            // The human-readable error still names the kind for backward compat.
+            expect(res.body.error).toMatch(/免費版|BOT_UNREACHABLE/);
+        } finally {
+            global.fetch = origFetch;
+        }
+    });
+
+    it('returns 502 with code=UPSTREAM_502 when webhook returns HTTP 502', async () => {
+        const { deviceId, deviceSecret, botId } = seedDeviceAndFreeBot();
+
+        const origFetch = global.fetch;
+        global.fetch = jest.fn().mockResolvedValue({
+            ok: false,
+            status: 502,
+            text: async () => 'Bad Gateway',
+        });
+
+        try {
+            const res = await post('/api/official-borrow/bind-free')
+                .send({ deviceId, deviceSecret, entityId: 0, botId });
+
+            expect(res.status).toBe(502);
+            expect(res.body.code).toBe('UPSTREAM_502');
+            expect(res.body.errorType).toBe('http_502');
+            expect(res.body.upstream_http_status).toBe(502);
+            expect(res.body.retryable).toBe(true);
+        } finally {
+            global.fetch = origFetch;
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- Make `handshakeWithBot` propagate the computed `errorType` (timeout / no_sessions / http_NNN / connection_failed) and `httpStatus` back to callers instead of swallowing them.
- Add `buildBindFailurePayload(handshake, ctx)` that maps each errorType → stable `code` (BOT_UNREACHABLE / UPSTREAM_TIMEOUT / BOT_NO_SESSIONS / UPSTREAM_502 / UPSTREAM_HTTP_NNN), `hint`, `retryable`, `retry_after_ms`, plus `botId`/`botName`/`botKind`/`webhookHost` so callers know which bot failed and what to do.
- Wire the payload into `bind-free`, `bind-personal`, and the session-refresh path.

## Why (GH#3001)
2026-05-28 18:00 TW health cron: 2/3 free bots returned HTTP 502 on `/api/official-borrow/bind-free`. Both were Mac local bots whose webhook tunnels were down — but the response only said `無法與免費版機器人建立連線` with hint `Bot gateway may not have active sessions`, which is wrong for the *box-offline* mode and gave the on-call no signal on retry vs operator action.

After this PR the same failure returns a structured payload (sample below) so the next health-cron and the Android/iOS UI know exactly what to surface.

```json
{
  "success": false,
  "code": "BOT_UNREACHABLE",
  "errorType": "connection_failed",
  "upstream": "bot_webhook",
  "retryable": true,
  "retry_after_ms": 30000,
  "botId": "mac_local_minimax_2_5",
  "botName": "Mac本地版_MiniMax2.5",
  "botKind": "free",
  "webhookHost": "mac-tunnel.example.com",
  "hint": "Could not reach the bot webhook. The bot host may be offline..."
}
```

## Test plan
- [x] `node --check backend/index.js`
- [x] `cd backend && npx jest tests/jest/official-borrow.test.js tests/jest/official-borrow-binding-reuse.test.js tests/jest/official-borrow-bind-502-structured.test.js --runInBand` → **38/38 pass**
- [x] New test `official-borrow-bind-502-structured.test.js` covers: every errorType → expected code/retryable (unit), and the wire path for `bind-free` returning the structured payload on `connection_failed` and on `HTTP 502` (integration via `supertest` + mocked global.fetch).

## What this does NOT fix
- The Mac local bot box still has to be up. This PR makes the failure mode legible to operators and to the UI; it does not repair an offline tunnel.
- `bind-personal` and `sync-binding` now return the structured payload in the same shape but were not explicitly covered by the new Jest test (they share the same helper so unit coverage transfers; runtime parity is mechanical).

## Refs
- GH#3001
- card_33679aa1113405512825c854

## Self-review (CLAUDE.md 10-item checklist)
- [x] Logic trace: handshake → errorType propagates → buildBindFailurePayload → 502 JSON
- [x] Test coverage: 9 new cases (7 unit + 2 supertest); both error shapes exercised
- [x] Return shape: backward compatible (kept `success:false`, `error`, `hint`; added new fields alongside)
- [x] What this does NOT fix: documented above
- [x] Security: no new auth surfaces, error messages do not leak secrets
- [x] /api/help: not affected (no new public endpoints)
- [x] Related docs: behavior described in PR body; no doc files need editing
- [x] i18n: no new user-facing strings — error remains zh; new fields are machine-readable codes
- [x] Info page: N/A
- [x] Debug endpoint: N/A — error response itself is the diagnostic