### PR TITLE
fix(portal-vault): save race-loss + delete button UX (card_3a46)

### DIFF
--- a/backend/public/portal/env-vars.html
+++ b/backend/public/portal/env-vars.html
@@ -182,7 +182,7 @@
             align-items: center;
             justify-content: center;
             transition: all 0.15s;
-            opacity: 0.5;
+            opacity: 0.8;
         }
 
         .var-row:hover .var-action-btn { opacity: 1; }
@@ -192,9 +192,37 @@
             color: var(--text);
         }
 
+        .var-action-btn.delete {
+            color: var(--danger, #f44336);
+            opacity: 0.85;
+        }
+
         .var-action-btn.delete:hover {
             background: var(--danger, #f44336);
             color: #fff;
+            opacity: 1;
+        }
+
+        /* Mobile: no hover state, so keep actions visible at full opacity. */
+        @media (hover: none) {
+            .var-action-btn { opacity: 1; }
+        }
+
+        /* Empty-state setup hint */
+        .env-empty-hint {
+            text-align: center;
+            padding: 28px 16px;
+            color: var(--text-muted);
+        }
+        .env-empty-hint .env-empty-icon {
+            font-size: 32px;
+            margin-bottom: 8px;
+        }
+        .env-empty-hint .env-empty-text {
+            font-size: 13px;
+            line-height: 1.6;
+            max-width: 420px;
+            margin: 0 auto;
         }
 
         .vars-add-row {
@@ -408,7 +436,10 @@
             const vars = loadLocalVars();
             const keys = Object.keys(vars).sort();
             if (!keys.length) {
-                el.innerHTML = '<div class="mc-empty">' + i18n.t('env_no_vars') + '</div>';
+                el.innerHTML = `<div class="env-empty-hint">
+                    <div class="env-empty-icon">🔑</div>
+                    <div class="env-empty-text" data-i18n="env_empty_setup_hint">${esc(i18n.t('env_empty_setup_hint'))}</div>
+                </div>`;
                 return;
             }
             el.innerHTML = keys.map(k => `
@@ -417,9 +448,9 @@
                     <div class="var-row-val" id="varVal_${esc(k)}">••••••••</div>
                     <div class="var-row-actions">
                         <button class="var-action-btn" onclick="copyVarRef(this,'${esc(k)}')" title="Copy {{${esc(k)}}} reference">📎</button>
-                        <button class="var-action-btn" onclick="toggleVarVal('${esc(k)}')" title="${i18n.t('common_toggle_visibility')}">👁</button>
-                        <button class="var-action-btn" onclick="showVarDialog('${esc(k)}')" title="${i18n.t('common_edit')}">✏️</button>
-                        <button class="var-action-btn delete" onclick="deleteVar('${esc(k)}')" title="${i18n.t('common_delete')}">×</button>
+                        <button class="var-action-btn" onclick="toggleVarVal('${esc(k)}')" title="${esc(i18n.t('common_toggle_visibility'))}">👁</button>
+                        <button class="var-action-btn" onclick="showVarDialog('${esc(k)}')" title="${esc(i18n.t('common_edit'))}">✏️</button>
+                        <button class="var-action-btn delete" onclick="deleteVar('${esc(k)}')" title="${esc(i18n.t('common_delete'))}" aria-label="${esc(i18n.t('common_delete'))} ${esc(k)}">🗑</button>
                     </div>
                 </div>`).join('');
         }
@@ -451,17 +482,49 @@
         }
 
         // ── CRUD ──
-        function saveLocalVars(vars) {
+        // Save flow: localStorage first (so render is instant), then await server commit.
+        // Returns { ok: bool, error?: string } so the dialog can show pending state and
+        // only close after the server confirms — fixes the save race-loss where a refresh
+        // before the (fire-and-forget) POST landed would re-hydrate stale server state
+        // and wipe the just-added key from localStorage.
+        async function saveLocalVars(vars) {
             localStorage.setItem(varsKey(), JSON.stringify(vars));
             renderVars();
-            syncVarsToServer();
+            return await syncVarsToServer();
         }
 
         async function deleteVar(key) {
-            if (!await showConfirm({ message: i18n.t('env_confirm_delete').replace('{key}', key), danger: true })) return;
-            const vars = loadLocalVars();
-            delete vars[key];
-            saveLocalVars(vars);
+            const confirmed = await showConfirm({
+                message: i18n.t('env_confirm_delete').replace('{key}', key),
+                danger: true,
+                itemName: key,
+                confirmText: i18n.t('common_delete')
+            });
+            if (!confirmed) return;
+
+            // Use the dedicated DELETE endpoint so deleting the LAST key still works.
+            // (Going via the merge-POST would send {vars:{},source:'web'} which the
+            // server's empty-merge guard refuses with refuse_empty_merge_wipe.)
+            try {
+                const res = await apiCall('DELETE', '/api/device-vars/' + encodeURIComponent(key), {
+                    deviceId: currentUser.deviceId,
+                    deviceSecret: currentUser.deviceSecret
+                });
+                if (!res || res.success === false) {
+                    throw new Error((res && res.error) || 'delete_failed');
+                }
+                const vars = loadLocalVars();
+                delete vars[key];
+                localStorage.setItem(varsKey(), JSON.stringify(vars));
+                renderVars();
+                if (typeof showToast === 'function') {
+                    showToast(i18n.t('env_key_deleted').replace('{key}', key), 'success');
+                }
+            } catch (e) {
+                if (typeof showToast === 'function') {
+                    showToast(i18n.t('env_delete_failed').replace('{error}', e.message || 'unknown'), 'error');
+                }
+            }
         }
 
         function showVarDialog(editKey) {
@@ -492,15 +555,37 @@
                     </div>
                 </div>
             </div>`;
-            document.getElementById('dlgVarSaveBtn').onclick = () => {
+            document.getElementById('dlgVarSaveBtn').onclick = async () => {
+                const btn = document.getElementById('dlgVarSaveBtn');
+                const cancelBtn = btn.parentElement.querySelector('.btn-outline');
                 const key = document.getElementById('dlg_var_key').value.trim();
                 const val = document.getElementById('dlg_var_value').value;
-                if (!key) return;
+                if (!key || btn.disabled) return;
                 const updated = loadLocalVars();
                 if (isEdit && editKey !== key) delete updated[editKey]; // handle key rename
                 updated[key] = val;
-                saveLocalVars(updated);
-                closeDialog();
+
+                // Pending state — keep the dialog open and the button disabled until the
+                // server confirms. Closing before confirm caused the race-loss bug where
+                // a refresh re-hydrated stale server state and dropped the new key.
+                const origText = btn.textContent;
+                btn.disabled = true;
+                if (cancelBtn) cancelBtn.disabled = true;
+                btn.textContent = i18n.t('env_saving');
+
+                const result = await saveLocalVars(updated);
+
+                if (result && result.ok) {
+                    if (typeof showToast === 'function') showToast(i18n.t('env_saved'), 'success');
+                    closeDialog();
+                } else {
+                    btn.disabled = false;
+                    if (cancelBtn) cancelBtn.disabled = false;
+                    btn.textContent = origText;
+                    if (typeof showToast === 'function') {
+                        showToast(i18n.t('env_save_failed').replace('{error}', (result && result.error) || 'unknown'), 'error');
+                    }
+                }
             };
             setTimeout(() => {
                 const f = isEdit
@@ -523,11 +608,14 @@
         }
 
         // ── Server sync ──
+        // Returns { ok: bool, skipped?: bool, error?: string } so the Save dialog can
+        // gate its close + show toast based on the server commit, not on the optimistic
+        // localStorage write. Callers that don't care can ignore the return.
         async function syncVarsToServer() {
-            if (!currentUser) return;
+            if (!currentUser) return { ok: true, skipped: true };
             const locked = isLocked();
             const vars = loadLocalVars();
-            if (Object.keys(vars).length === 0) return;
+            if (Object.keys(vars).length === 0) return { ok: true, skipped: true };
             try {
                 const result = await apiCall('POST', '/api/device-vars', {
                     deviceId: currentUser.deviceId,
@@ -541,8 +629,9 @@
                     localStorage.setItem(varsKey(), JSON.stringify(result.mergedVars));
                     renderAll();
                 }
+                return { ok: true };
             } catch (e) {
-                // silent — non-critical background sync
+                return { ok: false, error: e.message || 'sync_failed' };
             }
         }
 

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650217,6 +650217,12 @@ const TRANSLATIONS = {
         "petdx_switch_failed": "Switch failed: {error}",
         "petdx_network_error": "Network error: {error}",
         "petdx_favorite_failed": "Save to favorites failed: {error}",
+        "env_saving": "Saving...",
+        "env_saved": "Saved",
+        "env_save_failed": "Save failed: {error}",
+        "env_key_deleted": "Deleted \"{key}\"",
+        "env_delete_failed": "Delete failed: {error}",
+        "env_empty_setup_hint": "No keys yet. Click \"+ Add\" to store credentials your bots can read via the secrets API.",
 },
 
 
@@ -1234901,6 +1234907,12 @@ const TRANSLATIONS = {
         "petdx_switch_failed": "切換失敗：{error}",
         "petdx_network_error": "網路錯誤：{error}",
         "petdx_favorite_failed": "收藏失敗：{error}",
+        "env_saving": "儲存中...",
+        "env_saved": "已儲存",
+        "env_save_failed": "儲存失敗：{error}",
+        "env_key_deleted": "已刪除「{key}」",
+        "env_delete_failed": "刪除失敗：{error}",
+        "env_empty_setup_hint": "尚未設定金鑰。點擊「+ 新增」來儲存 Bot 可透過 secrets API 讀取的憑證。",
 },
 
 


### PR DESCRIPTION
> Replaces #3389 — rebased onto latest main to pick up `f0ca344e` (portal-smoke `/shared-core` mount fix). Same code change as #3389.

## Summary

- **Save race-loss**: vault Save dialog now awaits the server POST before closing. Was fire-and-forget — a refresh before the POST landed would re-hydrate stale server state and drop the just-added key.
- **Last-key delete**: delete now routes through `DELETE /api/device-vars/:key` instead of merge-POSTing the new (now empty) vars map. The merge-POST path silently failed on last-key delete because the server's empty-merge guard refuses `{vars:{},source:'web'}` with `refuse_empty_merge_wipe`.
- **Delete affordance**: 🗑 icon (was `×`), danger-colored, full opacity on touch (no hover state), `aria-label` for screen readers.
- **Empty state**: 🔑 icon + `env_empty_setup_hint` so new users see what to do.
- **i18n**: 6 new keys (`env_saving` / `env_saved` / `env_save_failed` / `env_key_deleted` / `env_delete_failed` / `env_empty_setup_hint`) added to `en` + `zh` blocks.

Card: `card_3a461db1a70670bc542880d5`. Hank's original ask: 金鑰庫的UX不太順暢 — 儲存了新的key 重新整理有時會遺失，刪除key需要有對應的UX.

## Test plan

- [x] `node backend/scripts/i18n-check.js` — green
- [x] `npx jest --testPathPattern=i18n-syntax` — pass
- [x] `npx jest --testPathPattern=device-vars` — pass
- [x] `npx jest --testPathPattern=portal-smoke` — pass (60 total tests)
- [ ] Prod: add key, refresh — key persists
- [ ] Prod: delete last key — key gone, no `refuse_empty_merge_wipe` error
- [ ] Prod: zero console errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)