### PR TITLE
fix(parity): close 5 W22 cross-platform gaps (GH#2973, card_4161)

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -27,6 +27,7 @@ data/*.json
 !data/skill-templates.json
 !data/soul-templates.json
 !data/rule-templates.json
+!data/portal-page-api-map.json
 
 # Test files
 test-entity-info.json

--- a/backend/data/portal-page-api-map.json
+++ b/backend/data/portal-page-api-map.json
@@ -1,0 +1,158 @@
+{
+  "_comment": "Source of truth for parity audits: maps backend API paths to the portal page(s) that implement their UI. Used by the weekly parity audit cron card (entity #2) to avoid false-positive 'missing portal page' gaps when the page exists under a different name. Add new entries when introducing portal pages for existing APIs.",
+  "_updated": "2026-06-14",
+  "_format": {
+    "api": "Backend API path prefix (e.g. '/api/contacts')",
+    "page": "Portal page filename under backend/public/portal/, or an array if multiple pages",
+    "kind": "primary | secondary | embedded — primary is the canonical UI; embedded means it's a section/widget inside another page",
+    "notes": "Optional human note about the mapping"
+  },
+  "mappings": [
+    {
+      "api": "/api/contacts",
+      "page": "card-holder.html",
+      "kind": "primary",
+      "notes": "Card Holder / 名片夾 — list, search, pin, block, refresh agent cards"
+    },
+    {
+      "api": "/api/entity/agent-card",
+      "page": "dashboard.html",
+      "kind": "embedded",
+      "notes": "Agent card editor is loaded via shared/agent-card-editor.js inside dashboard.html (per-entity card)"
+    },
+    {
+      "api": "/api/entities",
+      "page": "dashboard.html",
+      "kind": "embedded",
+      "notes": "Entity CRUD (add/delete/rename/reorder) is the central panel of dashboard.html; raw /api/entities is bot-scoped (botSecret + entityId), not user-scoped"
+    },
+    {
+      "api": "/api/device/add-entity",
+      "page": "dashboard.html",
+      "kind": "embedded"
+    },
+    {
+      "api": "/api/device/entity/:entityId/permanent",
+      "page": "dashboard.html",
+      "kind": "embedded"
+    },
+    {
+      "api": "/api/device-telemetry",
+      "page": "telemetry.html",
+      "kind": "primary",
+      "notes": "Read-only telemetry viewer for the current device — added 2026-06-14 to close W22 parity gap"
+    },
+    {
+      "api": "/api/publisher/platforms",
+      "page": ["publisher.html", "publisher-setup.html"],
+      "kind": "primary",
+      "notes": "publisher.html is the composer; publisher-setup.html is the platform-credentials wizard. Not linked in main nav by design (entry via Wallet / Info hub)."
+    },
+    {
+      "api": "/api/mission/card",
+      "page": ["kanban.html", "mission.html"],
+      "kind": "primary"
+    },
+    {
+      "api": "/api/mindmap",
+      "page": "mission.html",
+      "kind": "embedded",
+      "notes": "Mind map is embedded inside mission.html since v1.1114 (standalone mindmap.html was removed)"
+    },
+    {
+      "api": "/api/chat",
+      "page": "chat.html",
+      "kind": "primary"
+    },
+    {
+      "api": "/api/files",
+      "page": "files.html",
+      "kind": "primary"
+    },
+    {
+      "api": "/api/device-vars",
+      "page": "env-vars.html",
+      "kind": "primary"
+    },
+    {
+      "api": "/api/feedback",
+      "page": "feedback.html",
+      "kind": "primary"
+    },
+    {
+      "api": "/api/notifications",
+      "page": "settings.html",
+      "kind": "embedded",
+      "notes": "Notification subscription is part of Settings page; vapid-key path is /api/notifications/vapid (audit's /vapid-key was wrong)"
+    },
+    {
+      "api": "/api/auth",
+      "page": ["index.html", "delete-account.html", "settings.html"],
+      "kind": "primary"
+    },
+    {
+      "api": "/api/analytics",
+      "page": "analytics.html",
+      "kind": "primary"
+    },
+    {
+      "api": "/api/wallet",
+      "page": "wallet.html",
+      "kind": "primary"
+    },
+    {
+      "api": "/api/rental",
+      "page": ["plaza.html", "marketplace.html", "my-rentals.html"],
+      "kind": "primary"
+    },
+    {
+      "api": "/api/invite",
+      "page": ["invite.html", "invite-qr-generator.html"],
+      "kind": "primary"
+    },
+    {
+      "api": "/api/community",
+      "page": "community.html",
+      "kind": "primary"
+    },
+    {
+      "api": "/api/oauth",
+      "page": null,
+      "kind": "none",
+      "notes": "OAuth 2.0 server endpoints — programmatic only, no portal UI by design"
+    },
+    {
+      "api": "/api/a2a",
+      "page": null,
+      "kind": "none",
+      "notes": "A2A protocol — bot-to-bot only, no portal UI by design"
+    },
+    {
+      "api": "/api/grpc",
+      "page": null,
+      "kind": "none"
+    },
+    {
+      "api": "/api/discord",
+      "page": null,
+      "kind": "none",
+      "notes": "Discord native slash commands — no portal UI"
+    },
+    {
+      "api": "/api/health",
+      "page": null,
+      "kind": "none"
+    },
+    {
+      "api": "/api/version",
+      "page": null,
+      "kind": "none"
+    },
+    {
+      "api": "/api/schedules",
+      "page": null,
+      "kind": "deprecated",
+      "notes": "Legacy bare schedules API returns 410 GONE since v1.362. Scheduling lives on /api/mission/card/:id/schedule and is surfaced via kanban.html"
+    }
+  ]
+}

--- a/backend/public/portal/telemetry.html
+++ b/backend/public/portal/telemetry.html
@@ -1,0 +1,379 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex, nofollow">
+    <title data-i18n="[html]telemetry_title">EClawbot - Device Telemetry</title>
+    <meta name="description" content="Per-device telemetry buffer viewer for debugging API calls, page views, and client-side errors.">
+    <link rel="icon" type="image/png" href="assets/favicon-32.png">
+    <link rel="stylesheet" href="shared/style.css">
+    <style>
+        .tel-controls {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            align-items: center;
+            margin-bottom: 18px;
+        }
+        .tel-controls label {
+            font-size: 13px;
+            color: var(--text-secondary);
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+        .tel-controls select, .tel-controls input {
+            background: var(--input-bg);
+            color: var(--text);
+            border: 1px solid var(--card-border);
+            border-radius: var(--radius-sm);
+            padding: 6px 10px;
+            font-size: 13px;
+        }
+        .tel-actions { margin-left: auto; display: flex; gap: 8px; }
+        .tel-btn {
+            background: var(--primary);
+            color: #fff;
+            border: none;
+            border-radius: var(--radius-sm);
+            padding: 6px 14px;
+            font-size: 13px;
+            cursor: pointer;
+        }
+        .tel-btn.secondary {
+            background: transparent;
+            color: var(--text);
+            border: 1px solid var(--card-border);
+        }
+        .tel-btn.danger { background: #c0392b; }
+        .tel-btn:hover { opacity: 0.85; }
+
+        .tel-summary {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+            gap: 12px;
+            margin-bottom: 20px;
+        }
+        .tel-stat-card {
+            background: var(--input-bg);
+            border: 1px solid var(--card-border);
+            border-radius: var(--radius-sm);
+            padding: 14px 16px;
+        }
+        .tel-stat-label {
+            font-size: 12px;
+            color: var(--text-secondary);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+            margin-bottom: 6px;
+        }
+        .tel-stat-value {
+            font-size: 24px;
+            font-weight: 700;
+            color: var(--text);
+            font-variant-numeric: tabular-nums;
+        }
+        .tel-section {
+            background: var(--card-bg);
+            border: 1px solid var(--card-border);
+            border-radius: var(--radius-sm);
+            padding: 16px;
+            margin-bottom: 18px;
+        }
+        .tel-section h2 {
+            font-size: 15px;
+            font-weight: 600;
+            margin: 0 0 12px 0;
+            color: var(--text);
+        }
+        table.tel-table {
+            width: 100%;
+            border-collapse: collapse;
+            font-size: 12px;
+            font-family: monospace;
+        }
+        table.tel-table th, table.tel-table td {
+            text-align: left;
+            padding: 6px 8px;
+            border-bottom: 1px solid var(--card-border);
+            vertical-align: top;
+        }
+        table.tel-table th {
+            color: var(--text-secondary);
+            font-weight: 600;
+            font-size: 11px;
+            text-transform: uppercase;
+            letter-spacing: 0.4px;
+        }
+        table.tel-table td.col-time { white-space: nowrap; color: var(--text-secondary); }
+        table.tel-table td.col-type {
+            font-weight: 600;
+            color: var(--primary);
+            white-space: nowrap;
+        }
+        table.tel-table td.col-detail { word-break: break-all; }
+        .tel-empty {
+            color: var(--text-secondary);
+            font-size: 13px;
+            padding: 14px 4px;
+            text-align: center;
+        }
+        .tel-error {
+            color: #f44;
+            background: rgba(255, 68, 68, 0.08);
+            border: 1px solid rgba(255, 68, 68, 0.3);
+            border-radius: var(--radius-sm);
+            padding: 10px 12px;
+            margin-bottom: 16px;
+            font-size: 13px;
+        }
+        .tel-loading { color: var(--text-secondary); text-align: center; padding: 40px 20px; }
+        .tel-note { color: var(--text-secondary); font-size: 12px; margin-top: 6px; }
+        @media (max-width: 720px) {
+            .tel-actions { margin-left: 0; width: 100%; }
+        }
+    </style>
+</head>
+
+<body>
+    <div id="navContainer"></div>
+
+    <main class="page">
+        <div class="page-header">
+            <h1 data-i18n="[html]telemetry_heading">Device Telemetry</h1>
+        </div>
+        <p class="tel-note" data-i18n="[html]telemetry_subtitle">
+            Per-device debug buffer: API calls, page views, actions, errors. Auth-gated to this device only. Buffer auto-trims at ~1 MB.
+        </p>
+
+        <div id="loadingState" class="tel-loading" data-i18n="common_loading">Loading...</div>
+
+        <div id="telemetryContent" style="display: none;">
+            <div class="tel-controls">
+                <label>
+                    <span data-i18n="[html]telemetry_type_label">Type</span>
+                    <select id="typeSel">
+                        <option value="" data-i18n="[html]telemetry_type_all">All</option>
+                        <option value="api_req">api_req</option>
+                        <option value="page_view">page_view</option>
+                        <option value="action">action</option>
+                        <option value="error">error</option>
+                    </select>
+                </label>
+                <label>
+                    <span data-i18n="[html]telemetry_limit_label">Limit</span>
+                    <select id="limitSel">
+                        <option value="50">50</option>
+                        <option value="100" selected>100</option>
+                        <option value="250">250</option>
+                        <option value="500">500</option>
+                    </select>
+                </label>
+                <div class="tel-actions">
+                    <button id="refreshBtn" class="tel-btn" data-i18n="common_refresh">Refresh</button>
+                    <button id="clearBtn" class="tel-btn danger" data-i18n="[html]telemetry_clear">Clear buffer</button>
+                </div>
+            </div>
+
+            <div id="errorBanner" class="tel-error" style="display: none;"></div>
+
+            <div class="tel-summary" id="summaryGrid"></div>
+
+            <div class="tel-section">
+                <h2 data-i18n="[html]telemetry_entries">Recent entries</h2>
+                <div style="overflow-x:auto;">
+                    <table class="tel-table">
+                        <thead>
+                            <tr>
+                                <th data-i18n="[html]telemetry_col_time">Time</th>
+                                <th data-i18n="[html]telemetry_col_type">Type</th>
+                                <th data-i18n="[html]telemetry_col_detail">Detail</th>
+                            </tr>
+                        </thead>
+                        <tbody id="entriesBody"></tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <script src="shared/api.js"></script>
+    <script src="shared/nav.js"></script>
+    <script src="shared/auth.js"></script>
+    <script src="../shared/telemetry.js"></script>
+    <script src="../shared/i18n.js"></script>
+    <script src="../shared/transition-overlay.js"></script>
+    <script src="shared/footer.js"></script>
+    <script>
+        let refreshTimer = null;
+
+        function showError(msg) {
+            const el = document.getElementById('errorBanner');
+            if (!msg) { el.style.display = 'none'; el.textContent = ''; return; }
+            el.style.display = '';
+            el.textContent = msg;
+        }
+
+        function fmtNumber(n) {
+            if (typeof n !== 'number' || !isFinite(n)) return '—';
+            return n.toLocaleString();
+        }
+
+        function fmtTime(ts) {
+            if (!ts) return '—';
+            const d = new Date(ts);
+            if (isNaN(d.getTime())) return String(ts);
+            const pad = (n) => String(n).padStart(2, '0');
+            return `${pad(d.getMonth()+1)}/${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}:${pad(d.getSeconds())}`;
+        }
+
+        function escapeHtml(s) {
+            return String(s == null ? '' : s)
+                .replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;').replace(/'/g, '&#39;');
+        }
+
+        function renderSummary(s) {
+            const grid = document.getElementById('summaryGrid');
+            grid.innerHTML = '';
+            const totalLabel = (typeof i18n !== 'undefined' && i18n.t) ? i18n.t('[html]telemetry_total_label', 'Total entries') : 'Total entries';
+            const cards = [
+                { label: totalLabel, value: fmtNumber(s.total || 0) }
+            ];
+            const byType = s.byType || {};
+            Object.keys(byType).sort().forEach(k => {
+                cards.push({ label: k, value: fmtNumber(byType[k]) });
+            });
+            cards.forEach(c => {
+                const div = document.createElement('div');
+                div.className = 'tel-stat-card';
+                div.innerHTML = `<div class="tel-stat-label">${escapeHtml(c.label)}</div><div class="tel-stat-value">${escapeHtml(c.value)}</div>`;
+                grid.appendChild(div);
+            });
+        }
+
+        function summarizeEntry(e) {
+            if (!e || typeof e !== 'object') return '';
+            if (e.endpoint) {
+                const status = e.status ? ` [${e.status}]` : '';
+                const dur = e.durationMs != null ? ` ${e.durationMs}ms` : '';
+                return `${e.method || ''} ${e.endpoint}${status}${dur}`.trim();
+            }
+            if (e.page) return e.page;
+            if (e.action) return e.action + (e.detail ? ' — ' + (typeof e.detail === 'string' ? e.detail : JSON.stringify(e.detail)) : '');
+            if (e.message) return e.message;
+            return JSON.stringify(e).slice(0, 240);
+        }
+
+        function renderEntries(entries) {
+            const tbody = document.getElementById('entriesBody');
+            tbody.innerHTML = '';
+            if (!entries || entries.length === 0) {
+                const tr = document.createElement('tr');
+                const td = document.createElement('td');
+                td.colSpan = 3;
+                td.className = 'tel-empty';
+                td.setAttribute('data-i18n', '[html]telemetry_no_entries');
+                td.textContent = (typeof i18n !== 'undefined' && i18n.t) ? i18n.t('[html]telemetry_no_entries', 'No telemetry entries in buffer.') : 'No telemetry entries in buffer.';
+                tr.appendChild(td); tbody.appendChild(tr);
+                return;
+            }
+            entries.forEach(e => {
+                const tr = document.createElement('tr');
+                const tdT = document.createElement('td');
+                tdT.className = 'col-time';
+                tdT.textContent = fmtTime(e.ts || e.timestamp || e.time);
+                const tdY = document.createElement('td');
+                tdY.className = 'col-type';
+                tdY.textContent = e.type || '—';
+                const tdD = document.createElement('td');
+                tdD.className = 'col-detail';
+                tdD.textContent = summarizeEntry(e);
+                tr.appendChild(tdT); tr.appendChild(tdY); tr.appendChild(tdD);
+                tbody.appendChild(tr);
+            });
+        }
+
+        async function fetchTelemetry() {
+            const user = window.currentUser;
+            if (!user || !user.deviceId || !user.deviceSecret) {
+                showError('Not signed in or missing device credentials.');
+                return;
+            }
+            const type = document.getElementById('typeSel').value;
+            const limit = document.getElementById('limitSel').value;
+
+            const qs = new URLSearchParams({
+                deviceId: user.deviceId,
+                deviceSecret: user.deviceSecret,
+                limit
+            });
+            if (type) qs.set('type', type);
+
+            try {
+                showError('');
+                const summary = await apiCall('GET', `/api/device-telemetry/summary?deviceId=${encodeURIComponent(user.deviceId)}&deviceSecret=${encodeURIComponent(user.deviceSecret)}`);
+                renderSummary(summary || {});
+
+                const data = await apiCall('GET', `/api/device-telemetry?${qs.toString()}`);
+                renderEntries((data && data.entries) || []);
+            } catch (e) {
+                console.error('[Telemetry] Fetch failed:', e);
+                showError('Failed to load telemetry: ' + (e.message || e));
+            }
+        }
+
+        async function clearBuffer() {
+            const user = window.currentUser;
+            if (!user || !user.deviceId || !user.deviceSecret) return;
+            const proceed = window.confirm((typeof i18n !== 'undefined' && i18n.t) ? i18n.t('[html]telemetry_clear_confirm', 'Clear the entire telemetry buffer for this device?') : 'Clear the entire telemetry buffer for this device?');
+            if (!proceed) return;
+            try {
+                await apiCall('DELETE', '/api/device-telemetry', {
+                    deviceId: user.deviceId,
+                    deviceSecret: user.deviceSecret
+                });
+                await fetchTelemetry();
+            } catch (e) {
+                console.error('[Telemetry] Clear failed:', e);
+                showError('Failed to clear: ' + (e.message || e));
+            }
+        }
+
+        window.addEventListener('DOMContentLoaded', async () => {
+            try {
+                renderNav('telemetry');
+                if (typeof renderFooter === 'function') renderFooter();
+                const user = await checkAuth();
+                if (!user) return;
+
+                document.getElementById('loadingState').style.display = 'none';
+                document.getElementById('telemetryContent').style.display = '';
+
+                document.getElementById('typeSel').addEventListener('change', fetchTelemetry);
+                document.getElementById('limitSel').addEventListener('change', fetchTelemetry);
+                document.getElementById('refreshBtn').addEventListener('click', fetchTelemetry);
+                document.getElementById('clearBtn').addEventListener('click', clearBuffer);
+
+                await fetchTelemetry();
+
+                refreshTimer = setInterval(() => {
+                    if (document.hidden) return;
+                    fetchTelemetry();
+                }, 30000);
+            } catch (initErr) {
+                console.error('[Telemetry] Init error:', initErr);
+                const el = document.getElementById('loadingState');
+                if (el) {
+                    const p = document.createElement('p');
+                    p.style.cssText = 'color:#f44;padding:20px;';
+                    p.textContent = 'Telemetry init error: ' + initErr.message;
+                    el.innerHTML = ''; el.appendChild(p);
+                }
+            }
+        });
+    </script>
+</body>
+</html>

--- a/backend/tests/jest/portal-page-api-map.test.js
+++ b/backend/tests/jest/portal-page-api-map.test.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const MAP_FILE = path.resolve(__dirname, '..', '..', 'data', 'portal-page-api-map.json');
+const PORTAL_DIR = path.resolve(__dirname, '..', '..', 'public', 'portal');
+
+describe('portal-page-api-map.json — source of truth for parity audits', () => {
+    let doc;
+
+    beforeAll(() => {
+        const raw = fs.readFileSync(MAP_FILE, 'utf8');
+        doc = JSON.parse(raw);
+    });
+
+    test('is valid JSON with required top-level fields', () => {
+        expect(doc).toBeDefined();
+        expect(Array.isArray(doc.mappings)).toBe(true);
+        expect(doc.mappings.length).toBeGreaterThan(0);
+    });
+
+    test('every entry has an api path and a kind', () => {
+        for (const entry of doc.mappings) {
+            expect(typeof entry.api).toBe('string');
+            expect(entry.api.startsWith('/api/')).toBe(true);
+            expect(typeof entry.kind).toBe('string');
+            expect(['primary', 'secondary', 'embedded', 'none', 'deprecated']).toContain(entry.kind);
+        }
+    });
+
+    test('every page filename referenced exists under backend/public/portal/', () => {
+        const missing = [];
+        for (const entry of doc.mappings) {
+            if (entry.page == null) continue;
+            const pages = Array.isArray(entry.page) ? entry.page : [entry.page];
+            for (const p of pages) {
+                const fp = path.join(PORTAL_DIR, p);
+                if (!fs.existsSync(fp)) {
+                    missing.push({ api: entry.api, page: p });
+                }
+            }
+        }
+        if (missing.length > 0) {
+            const lines = missing.map(m => `  ${m.api} -> ${m.page}`).join('\n');
+            throw new Error(`portal-page-api-map.json references missing portal pages:\n${lines}`);
+        }
+    });
+
+    test('api paths are unique (no duplicate mappings)', () => {
+        const seen = new Set();
+        const dupes = [];
+        for (const entry of doc.mappings) {
+            if (seen.has(entry.api)) dupes.push(entry.api);
+            seen.add(entry.api);
+        }
+        expect(dupes).toEqual([]);
+    });
+
+    test('W22 audit false-positive APIs are mapped to existing pages', () => {
+        // Locks the parity gaps from GH#2973 (W22, 2026-05-27):
+        // contacts, /api/entities, agent-card — all marked "missing" by the
+        // audit but actually have portal coverage. Telemetry is the only
+        // real gap and is covered by the new telemetry.html.
+        const required = [
+            '/api/contacts',
+            '/api/entity/agent-card',
+            '/api/entities',
+            '/api/device-telemetry',
+            '/api/publisher/platforms'
+        ];
+        for (const api of required) {
+            const entry = doc.mappings.find(e => e.api === api);
+            expect(entry).toBeDefined();
+            expect(entry.page).not.toBeNull();
+        }
+    });
+});


### PR DESCRIPTION
## Summary

Closes #2973. Triage + fix for the 5 cross-platform parity gaps flagged by entity #2 in the 2026-05-27 (W22) audit.

**4 of 5 gaps are false positives** — the audit cron's heuristic looked for portal pages by URL convention (`/portal/<feature>.html`) and missed pages that exist under a different name (e.g. `card-holder.html` is the `/api/contacts` UI). **1 is a real gap** (`/api/device-telemetry` had no portal page).

| # | Gap | Verdict | Fix |
|---|-----|---------|-----|
| 1 | Publisher portal page | false positive | `portal/publisher.html` already exists |
| 2 | Telemetry portal page | **real** | added `portal/telemetry.html` (read-only viewer) |
| 3 | Contacts portal page | false positive | `portal/card-holder.html` IS the `/api/contacts` UI |
| 4 | Entity CRUD raw page | false positive | `dashboard.html` handles `/api/device/add-entity` + `.../permanent`. Bare `/api/entities` returning 403 is correct — it is bot-scoped (botSecret+entityId), not user-scoped. |
| 5 | Agent Card admin page | false positive | `dashboard.html` loads `shared/agent-card-editor.js` for per-entity card editing |

## How future W23+ audits stay honest

Added `backend/data/portal-page-api-map.json` as the single source of truth that maps every API path prefix to the portal page(s) that implement it (or marks the API `kind: "none"` if it is bot/admin-only by design). The new Jest test locks four invariants:

- Every entry has a valid `kind` (`primary | secondary | embedded | none | deprecated`)
- Every referenced `page` filename exists on disk under `backend/public/portal/`
- No duplicate `api` keys
- All 5 W22 false-positive APIs (contacts, agent-card, entities, device-telemetry, publisher/platforms) resolve to a real page

## Files

```
+ backend/public/portal/telemetry.html              (read-only telemetry viewer)
+ backend/data/portal-page-api-map.json             (API -> portal page SoT)
+ backend/tests/jest/portal-page-api-map.test.js    (5 cases, all passing)
~ backend/.gitignore                                (allow new data file)
```

## Test plan

- [x] `npx jest tests/jest/portal-page-api-map.test.js` — 5/5 pass
- [x] `npx jest tests/jest/i18n-syntax.test.js` — 12/12 pass (new HTML uses `[html]` i18n-fallback prefix, no `data-i18n` key insertions needed)
- [x] `node scripts/i18n-check.js` — green, "All referenced keys resolve in EN"
- [x] `npx jest tests/jest/css-class-coverage.test.js` — 2/2 pass
- [ ] After merge: open `/portal/telemetry.html` while signed in, verify summary + entries render

Note: `portal-smoke-static.test.js` has a pre-existing failure on `dashboard.html` / `kanban.html` complaining about a missing `/shared-core/route-registry.js` asset — verified by re-running on `main` before any of this PR's changes. Unrelated.

## Out of scope

- Setting up the parity audit infrastructure itself (per dispatch).
- Fixing the audit cron card's known recommendation-section bugs (chat history POST, scheduler 410 confirm-and-remove). Those live on the production cron card spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)