### PR TITLE
feat(entity): merged-PR count + smart-link widget on entity cards (card_8a25)

### DIFF
--- a/backend/config/entity-gh-login.json
+++ b/backend/config/entity-gh-login.json
@@ -1,0 +1,8 @@
+{
+  "_comment": "Maps entityId -> GitHub login for the 'merged-PR count' widget on entity cards (card_8a25). Customize for your deployment. byDevice overrides byEntityId. Entries with no mapping render a setup hint instead of a count.",
+  "byEntityId": {
+    "2": "HankHuang0516",
+    "5": "HankHuang0516"
+  },
+  "byDevice": {}
+}

--- a/backend/entity-gh-stats.js
+++ b/backend/entity-gh-stats.js
@@ -1,0 +1,159 @@
+/**
+ * entity-gh-stats.js — merged-PR count + smart-link data source
+ * card_8a25cadcc9fc88f153fa1316
+ *
+ * Resolves `entityId -> GitHub login` from `backend/config/entity-gh-login.json`
+ * and queries the GitHub Search API for merged PRs authored by that login.
+ *
+ * `setup_required` is returned (200, never 4xx) when either the mapping is
+ * empty for this entity or the GITHUB_TOKEN env var is absent — the dashboard
+ * widget surfaces this as a ? icon with the exact remediation hint.
+ *
+ * 5-minute in-memory cache per gh_login keeps us comfortably under the 30 req/min
+ * GitHub Search quota even with many entity cards rendering concurrently.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const CONFIG_PATH = path.join(__dirname, 'config', 'entity-gh-login.json');
+const CACHE_TTL_MS = 5 * 60 * 1000;
+const SEARCH_PER_PAGE = 10;
+
+let configCache = null;
+let configCacheMtime = 0;
+const ghCache = new Map(); // login -> { fetchedAt, data }
+
+function loadConfig() {
+    try {
+        const stat = fs.statSync(CONFIG_PATH);
+        if (configCache && stat.mtimeMs === configCacheMtime) return configCache;
+        const raw = fs.readFileSync(CONFIG_PATH, 'utf8');
+        configCache = JSON.parse(raw);
+        configCacheMtime = stat.mtimeMs;
+        return configCache;
+    } catch (err) {
+        if (err.code !== 'ENOENT') {
+            console.warn('[entity-gh-stats] config load failed:', err.message);
+        }
+        return { byEntityId: {}, byDevice: {} };
+    }
+}
+
+/**
+ * Resolve the GitHub login for a (deviceId, entityId) pair. `byDevice`
+ * overrides `byEntityId` so multi-tenant deployments can scope per device
+ * without colliding on entity ids.
+ */
+function resolveGhLogin(deviceId, entityId) {
+    const cfg = loadConfig();
+    const eid = String(entityId);
+    const byDevice = cfg.byDevice || {};
+    if (deviceId && byDevice[deviceId] && byDevice[deviceId][eid]) {
+        return String(byDevice[deviceId][eid]);
+    }
+    const byEntityId = cfg.byEntityId || {};
+    if (byEntityId[eid]) return String(byEntityId[eid]);
+    return null;
+}
+
+async function fetchMergedPrs(login) {
+    const cached = ghCache.get(login);
+    if (cached && Date.now() - cached.fetchedAt < CACHE_TTL_MS) return cached.data;
+
+    const q = encodeURIComponent(`is:pr is:merged author:${login}`);
+    const url = `https://api.github.com/search/issues?q=${q}&sort=updated&order=desc&per_page=${SEARCH_PER_PAGE}`;
+    const headers = {
+        'Accept': 'application/vnd.github+json',
+        'User-Agent': 'EClawbot-entity-gh-stats',
+        'X-GitHub-Api-Version': '2022-11-28',
+    };
+    if (process.env.GITHUB_TOKEN) headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
+
+    const res = await fetch(url, { headers });
+    if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        const err = new Error(`GitHub ${res.status}: ${body.slice(0, 200)}`);
+        err.status = res.status;
+        throw err;
+    }
+    const json = await res.json();
+    const data = {
+        merged_pr_count: typeof json.total_count === 'number' ? json.total_count : 0,
+        recent_prs: (json.items || []).slice(0, SEARCH_PER_PAGE).map(item => ({
+            number: item.number,
+            title: item.title,
+            html_url: item.html_url,
+            repo: extractRepoFromUrl(item.repository_url),
+            mergedAt: item.closed_at || item.updated_at || null,
+        })),
+    };
+    ghCache.set(login, { fetchedAt: Date.now(), data });
+    return data;
+}
+
+function extractRepoFromUrl(repoUrl) {
+    if (!repoUrl) return null;
+    // https://api.github.com/repos/<owner>/<repo>
+    const m = repoUrl.match(/\/repos\/([^/]+\/[^/]+)$/);
+    return m ? m[1] : null;
+}
+
+/**
+ * Build the response payload for GET /api/entities/:entityId/gh-stats.
+ * Always returns a 200-shaped object — callers decide the HTTP status.
+ */
+async function buildStats(deviceId, entityId) {
+    const gh_login = resolveGhLogin(deviceId, entityId);
+    if (!gh_login) {
+        return {
+            success: true,
+            merged_pr_count: 0,
+            recent_prs: [],
+            gh_login: null,
+            setup_required: true,
+            setup_reason: 'no_login_mapped',
+        };
+    }
+    if (!process.env.GITHUB_TOKEN) {
+        return {
+            success: true,
+            merged_pr_count: 0,
+            recent_prs: [],
+            gh_login,
+            setup_required: true,
+            setup_reason: 'no_github_token',
+        };
+    }
+    try {
+        const data = await fetchMergedPrs(gh_login);
+        return {
+            success: true,
+            merged_pr_count: data.merged_pr_count,
+            recent_prs: data.recent_prs,
+            gh_login,
+            setup_required: false,
+            actions_url: `https://github.com/pulls?q=${encodeURIComponent(`is:pr is:merged author:${gh_login}`)}`,
+        };
+    } catch (err) {
+        return {
+            success: false,
+            error: err.message || 'GitHub fetch failed',
+            status: err.status || 500,
+            gh_login,
+        };
+    }
+}
+
+function _clearCacheForTest() {
+    ghCache.clear();
+    configCache = null;
+    configCacheMtime = 0;
+}
+
+module.exports = {
+    buildStats,
+    resolveGhLogin,
+    loadConfig,
+    _clearCacheForTest,
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -2285,6 +2285,12 @@ entityStatus.bindDevicesRef(devices);
 entityStatus.bindJwtSecret(JWT_SECRET_FALLBACK);
 app.use('/api/entity-status', entityStatus.router);
 
+// ENTITY GH-STATS — merged-PR count + smart-link widget on entity cards
+// (card_8a25cadcc9fc88f153fa1316). Endpoint is registered later (~line 8067)
+// next to /api/entities so it sits alongside its peers; the module itself is
+// stateless so we just require() it here.
+const entityGhStats = require('./entity-gh-stats');
+
 // Passive health-check + auto self-repair subsystem (DEFAULT OFF, opt-in per
 // device). Routers are mounted here; the pool/devices/dependency wiring +
 // scheduler start happen at boot (see passiveHealth.init below) once chatPool
@@ -8064,6 +8070,74 @@ app.get('/api/entities/status', async (req, res) => {
         entities: entityList,
         activeCount: entityList.filter(e => e.isBound).length,
     });
+});
+
+/**
+ * GET /api/entities/:entityId/gh-stats
+ * card_8a25cadcc9fc88f153fa1316 — merged-PR count + smart-link for entity cards.
+ *
+ * Resolves the entity's GitHub login from backend/config/entity-gh-login.json,
+ * queries GitHub Search for merged PRs authored by that login, and returns
+ * { merged_pr_count, recent_prs, gh_login, actions_url, setup_required }.
+ *
+ * Always 200 with `setup_required:true` when the login is unmapped or
+ * GITHUB_TOKEN is absent — the dashboard widget surfaces those as ? hints
+ * rather than treating them as errors.
+ *
+ * Auth: deviceId+deviceSecret OR deviceId+botSecret(+entityId) OR JWT cookie.
+ * Mirrors /api/entities (line 7844) so the dashboard can reuse its session.
+ */
+app.get('/api/entities/:entityId/gh-stats', async (req, res) => {
+    const filterDeviceId = req.query.deviceId;
+    const deviceSecret = req.query.deviceSecret;
+    const botSecret = req.query.botSecret;
+    const queryEntityId = parseInt(req.query.entityId) || 0;
+    const targetEntityId = parseInt(req.params.entityId);
+
+    if (!Number.isFinite(targetEntityId) || targetEntityId < 0) {
+        return res.status(400).json({ success: false, message: 'Invalid entityId' });
+    }
+
+    const jwtDeviceId = req.user && req.user.deviceId;
+    const deviceAuthed = filterDeviceId && deviceSecret && devices[filterDeviceId]
+        && safeEqual(devices[filterDeviceId].deviceSecret, deviceSecret);
+    let botAuthed = false;
+    if (!deviceAuthed && filterDeviceId && botSecret && devices[filterDeviceId]) {
+        const ents = devices[filterDeviceId].entities || {};
+        if (queryEntityId > 0) {
+            const e = ents[queryEntityId];
+            botAuthed = !!(e && e.isBound && e.botSecret && safeEqual(e.botSecret, botSecret));
+        } else {
+            botAuthed = Object.values(ents).some(e => e && e.isBound && e.botSecret && safeEqual(e.botSecret, botSecret));
+        }
+    }
+    const authedDeviceId = deviceAuthed
+        ? filterDeviceId
+        : botAuthed
+            ? filterDeviceId
+            : (jwtDeviceId && (!filterDeviceId || filterDeviceId === jwtDeviceId)) ? jwtDeviceId : null;
+
+    if (!filterDeviceId && !jwtDeviceId) {
+        return res.status(400).json({ success: false, message: 'deviceId required' });
+    }
+    const effectiveDeviceId = filterDeviceId || jwtDeviceId;
+    if (!devices[effectiveDeviceId]) {
+        return res.status(404).json({ success: false, message: 'Device not found' });
+    }
+    if (!authedDeviceId) {
+        return res.status(403).json({ success: false, message: 'Invalid credentials' });
+    }
+
+    const entity = devices[authedDeviceId].entities?.[targetEntityId];
+    if (!entity || !entity.isBound) {
+        return res.status(404).json({ success: false, message: 'Entity not bound' });
+    }
+
+    const stats = await entityGhStats.buildStats(authedDeviceId, targetEntityId);
+    if (stats.success === false) {
+        return res.status(stats.status || 502).json(stats);
+    }
+    res.json(stats);
 });
 
 /**

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -161,6 +161,66 @@
             opacity: 0.6;
         }
 
+        /* card_8a25: merged-PR count + smart-link widget on each entity card */
+        .entity-pr-widget {
+            display: inline-flex;
+            align-items: center;
+            gap: 6px;
+            margin-top: 6px;
+            cursor: pointer;
+            font-size: 12px;
+            color: var(--text-secondary);
+            background: var(--input-bg);
+            padding: 2px 8px;
+            border-radius: 6px;
+            transition: opacity 0.15s, background 0.15s;
+        }
+        .entity-pr-widget:hover { opacity: 0.85; background: var(--card-border, rgba(255,255,255,0.06)); }
+        .entity-pr-widget .pr-label { color: var(--text-muted, #888); font-size: 11px; }
+        .entity-pr-widget .pr-count { font-weight: 700; color: var(--accent-cyan, #4FC3F7); }
+        .entity-pr-widget .pr-link { font-size: 11px; opacity: 0.7; }
+        .entity-pr-widget.setup .pr-count { color: var(--text-muted, #888); font-weight: 500; }
+        .entity-pr-widget.setup .pr-help { color: var(--accent-amber, #FFB300); }
+
+        /* Modal — recent PRs list shown on widget click */
+        .pr-overlay {
+            position: fixed; inset: 0; background: rgba(0,0,0,0.55);
+            display: flex; align-items: center; justify-content: center; z-index: 9000;
+            padding: 16px;
+        }
+        .pr-panel {
+            background: var(--card-bg, #1c1c1e); color: var(--text-primary, #eee);
+            border-radius: 12px; max-width: 560px; width: 100%;
+            max-height: 80vh; overflow: hidden; display: flex; flex-direction: column;
+            box-shadow: 0 16px 48px rgba(0,0,0,0.5);
+        }
+        .pr-panel-head {
+            display: flex; align-items: center; justify-content: space-between;
+            padding: 14px 18px; border-bottom: 1px solid var(--card-border, rgba(255,255,255,0.08));
+        }
+        .pr-panel-title { font-weight: 600; font-size: 15px; }
+        .pr-panel-close {
+            background: transparent; border: none; color: inherit;
+            font-size: 18px; cursor: pointer; padding: 4px 10px; border-radius: 6px;
+        }
+        .pr-panel-close:hover { background: rgba(255,255,255,0.08); }
+        .pr-panel-body { padding: 8px 0; overflow-y: auto; }
+        .pr-row {
+            display: block; padding: 10px 18px; text-decoration: none; color: inherit;
+            border-bottom: 1px solid rgba(255,255,255,0.04);
+        }
+        .pr-row:hover { background: rgba(255,255,255,0.04); }
+        .pr-row:last-child { border-bottom: none; }
+        .pr-row-title { font-size: 13px; line-height: 1.4; }
+        .pr-row-meta { font-size: 11px; color: var(--text-muted, #888); margin-top: 2px; }
+        .pr-panel-foot {
+            padding: 10px 18px; border-top: 1px solid var(--card-border, rgba(255,255,255,0.08));
+            font-size: 12px; color: var(--text-muted, #888);
+        }
+        .pr-panel-foot a { color: var(--accent-cyan, #4FC3F7); text-decoration: none; }
+        .pr-panel-foot a:hover { text-decoration: underline; }
+        .pr-empty { padding: 24px 18px; text-align: center; color: var(--text-muted, #888); font-size: 13px; }
+
         .entity-message {
             font-size: 13px;
             color: var(--text-secondary);
@@ -3234,6 +3294,11 @@
                             '</div>';
                     })() +
                     (entity.publicCode ? '<div class="entity-public-code" onclick="copyPublicCode(\'' + entity.publicCode + '\')" title="' + i18n.t('dash_copy_code') + '"><span class="code-label">' + i18n.t('dash_public_code') + ':</span> <code>' + entity.publicCode + '</code> <span class="copy-hint">&#x1F4CB;</span></div>' : '') +
+                    '<div class="entity-pr-widget" id="prWidget' + entity.entityId + '" data-entity-id="' + entity.entityId + '" onclick="openPrStatsModal(' + entity.entityId + ', event)" title="' + i18n.t('dash_pr_widget_hint') + '">' +
+                        '<span class="pr-label">' + i18n.t('dash_pr_count_label') + ':</span>' +
+                        '<span class="pr-count">…</span>' +
+                        '<span class="pr-link">&#x1F517;</span>' +
+                    '</div>' +
                     '<div class="entity-message">' + escapeHtml(lastMsg) + '</div>' +
                     '</div>' +
                     '</div>' +
@@ -3345,7 +3410,127 @@
                     '</div>';
             }).join('');
             if (isEditMode) setupDragListeners();
+            populatePrWidgets(entities);
         }
+
+        // ── card_8a25: merged-PR count + smart-link widget on entity cards ──
+        // Fetches /api/entities/:entityId/gh-stats for each card and rewrites the
+        // placeholder "…" with the count (or a ? hint when setup is required).
+        // Errors stay silent in the widget so a missing GH token never breaks
+        // entity rendering; the click-through modal surfaces the same error.
+        const _prStatsCache = new Map(); // entityId -> stats
+        async function populatePrWidgets(rendered) {
+            if (!currentUser || !currentUser.deviceId || !currentUser.deviceSecret) return;
+            for (const entity of rendered) {
+                const el = document.getElementById('prWidget' + entity.entityId);
+                if (!el) continue;
+                try {
+                    const qs = 'deviceId=' + encodeURIComponent(currentUser.deviceId)
+                        + '&deviceSecret=' + encodeURIComponent(currentUser.deviceSecret);
+                    const res = await fetch('/api/entities/' + entity.entityId + '/gh-stats?' + qs,
+                        { credentials: 'same-origin' });
+                    if (!res.ok) throw new Error('http ' + res.status);
+                    const data = await res.json();
+                    _prStatsCache.set(entity.entityId, data);
+                    paintPrWidget(el, data);
+                } catch (err) {
+                    paintPrWidget(el, { success: false, error: err.message });
+                }
+            }
+        }
+
+        function paintPrWidget(el, data) {
+            const countEl = el.querySelector('.pr-count');
+            const linkEl = el.querySelector('.pr-link');
+            if (!data || data.success === false) {
+                el.classList.add('setup');
+                el.classList.remove('ready');
+                countEl.textContent = '?';
+                if (linkEl) linkEl.textContent = '⚠️'; // ⚠️
+                el.title = i18n.t('dash_pr_widget_error_hint') + ' ' + ((data && data.error) || '');
+                return;
+            }
+            if (data.setup_required) {
+                el.classList.add('setup');
+                el.classList.remove('ready');
+                countEl.textContent = '?';
+                if (linkEl) linkEl.textContent = '⚙️'; // ⚙️
+                const reason = data.setup_reason === 'no_github_token'
+                    ? i18n.t('dash_pr_setup_no_token')
+                    : i18n.t('dash_pr_setup_no_login');
+                el.title = reason;
+                return;
+            }
+            el.classList.remove('setup');
+            el.classList.add('ready');
+            countEl.textContent = String(data.merged_pr_count || 0);
+            if (linkEl) linkEl.textContent = '\u{1F517}'; // 🔗
+            el.title = i18n.t('dash_pr_widget_open');
+        }
+
+        function closePrStatsModal() {
+            const el = document.getElementById('prStatsOverlay');
+            if (el) el.remove();
+            document.removeEventListener('keydown', _prEsc);
+        }
+        function _prEsc(e) { if (e.key === 'Escape') closePrStatsModal(); }
+
+        window.openPrStatsModal = function (entityId, event) {
+            if (event && event.stopPropagation) event.stopPropagation();
+            closePrStatsModal();
+            const data = _prStatsCache.get(entityId);
+            const overlay = document.createElement('div');
+            overlay.className = 'pr-overlay';
+            overlay.id = 'prStatsOverlay';
+            overlay.addEventListener('click', (e) => { if (e.target === overlay) closePrStatsModal(); });
+
+            const titleLabel = i18n.t('dash_pr_recent_title');
+            const closeLabel = i18n.t('common_close') || 'Close';
+            let body = '';
+            let foot = '';
+
+            if (!data || data.success === false) {
+                body = '<div class="pr-empty">' + (i18n.t('dash_pr_widget_error_hint')
+                    + ' ' + ((data && data.error) || '')) + '</div>';
+            } else if (data.setup_required) {
+                const reason = data.setup_reason === 'no_github_token'
+                    ? i18n.t('dash_pr_setup_no_token')
+                    : i18n.t('dash_pr_setup_no_login');
+                body = '<div class="pr-empty">' + escapeHtml(reason) + '</div>';
+            } else if (!data.recent_prs || data.recent_prs.length === 0) {
+                body = '<div class="pr-empty">' + i18n.t('dash_pr_none') + '</div>';
+                if (data.actions_url) {
+                    foot = '<a href="' + escapeHtml(data.actions_url) + '" target="_blank" rel="noopener noreferrer">'
+                        + escapeHtml('@' + (data.gh_login || '')) + ' · ' + i18n.t('dash_pr_view_all') + ' &#x2197;</a>';
+                }
+            } else {
+                body = data.recent_prs.map(pr => {
+                    const when = pr.mergedAt ? new Date(pr.mergedAt).toLocaleDateString() : '';
+                    const repo = pr.repo ? escapeHtml(pr.repo) : '';
+                    return '<a class="pr-row" href="' + escapeHtml(pr.html_url || '#') + '" target="_blank" rel="noopener noreferrer">'
+                        + '<div class="pr-row-title">' + escapeHtml(pr.title || '(no title)') + '</div>'
+                        + '<div class="pr-row-meta">'
+                        + (repo ? repo + ' #' + pr.number : '#' + pr.number)
+                        + (when ? ' · ' + when : '')
+                        + '</div></a>';
+                }).join('');
+                foot = '<a href="' + escapeHtml(data.actions_url) + '" target="_blank" rel="noopener noreferrer">'
+                    + escapeHtml('@' + data.gh_login) + ' · ' + i18n.t('dash_pr_view_all') + ' &#x2197;</a>';
+            }
+
+            overlay.innerHTML =
+                '<div class="card pr-panel" role="dialog" aria-modal="true" aria-label="' + escapeHtml(titleLabel) + '">'
+                + '<div class="pr-panel-head">'
+                + '<div class="pr-panel-title">&#x1F517; ' + escapeHtml(titleLabel) + '</div>'
+                + '<button type="button" class="pr-panel-close" onclick="closePrStatsModal()" aria-label="' + escapeHtml(closeLabel) + '">&#x2715;</button>'
+                + '</div>'
+                + '<div class="pr-panel-body">' + body + '</div>'
+                + (foot ? '<div class="pr-panel-foot">' + foot + '</div>' : '')
+                + '</div>';
+            document.body.appendChild(overlay);
+            document.addEventListener('keydown', _prEsc);
+        };
+        window.closePrStatsModal = closePrStatsModal;
 
         // --- Edit Mode ---
         function toggleEditMode() {

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -241040,6 +241040,16 @@ const TRANSLATIONS = {
 
 
         "dash_public_code": "Code", "health_checking": "Health-checking",
+        "dash_pr_count_label": "Merged PRs",
+        "dash_pr_recent_title": "Recent merged PRs",
+        "dash_pr_none": "No merged PRs yet",
+        "dash_pr_setup_no_login": "⚠️ This entity has no GitHub login mapped. To enable PR count: add { \"entityId\": \"your-gh-login\" } to backend/config/entity-gh-login.json.",
+        "dash_pr_setup_no_token": "⚠️ GitHub integration not configured. Set GITHUB_TOKEN env var to enable PR stats.",
+        "dash_pr_widget_hint": "Click to see recent merged PRs",
+        "dash_pr_widget_open": "Open recent merged PRs",
+        "dash_pr_widget_error_hint": "Couldn't load PR stats:",
+        "dash_pr_view_all": "View all on GitHub",
+        "common_close": "Close",
 
 
 
@@ -880761,6 +880771,16 @@ const TRANSLATIONS = {
 
 
         "dash_public_code": "代碼", "health_checking": "健檢中",
+        "dash_pr_count_label": "已合併 PR",
+        "dash_pr_recent_title": "最近合併的 PR",
+        "dash_pr_none": "尚無已合併的 PR",
+        "dash_pr_setup_no_login": "⚠️ 這個實體尚未對應 GitHub 帳號。若要啟用 PR 計數，請在 backend/config/entity-gh-login.json 加入 { \"entityId\": \"your-gh-login\" }。",
+        "dash_pr_setup_no_token": "⚠️ 尚未設定 GitHub 整合。請在環境變數設定 GITHUB_TOKEN 以啟用 PR 統計。",
+        "dash_pr_widget_hint": "點擊查看最近合併的 PR",
+        "dash_pr_widget_open": "開啟最近合併的 PR",
+        "dash_pr_widget_error_hint": "無法載入 PR 統計：",
+        "dash_pr_view_all": "在 GitHub 上查看全部",
+        "common_close": "關閉",
 
 
 
@@ -1330846,6 +1330866,16 @@ const TRANSLATIONS = {
 
 
         "dash_public_code": "代碼", "health_checking": "健检中",
+        "dash_pr_count_label": "已合并 PR",
+        "dash_pr_recent_title": "最近合并的 PR",
+        "dash_pr_none": "暂无已合并的 PR",
+        "dash_pr_setup_no_login": "⚠️ 该实体尚未映射 GitHub 账号。若要启用 PR 计数，请在 backend/config/entity-gh-login.json 加入 { \"entityId\": \"your-gh-login\" }。",
+        "dash_pr_setup_no_token": "⚠️ 尚未配置 GitHub 集成。请设置 GITHUB_TOKEN 环境变量以启用 PR 统计。",
+        "dash_pr_widget_hint": "点击查看最近合并的 PR",
+        "dash_pr_widget_open": "打开最近合并的 PR",
+        "dash_pr_widget_error_hint": "无法加载 PR 统计：",
+        "dash_pr_view_all": "在 GitHub 上查看全部",
+        "common_close": "关闭",
 
 
 

--- a/backend/scripts/portal-smoke-check.js
+++ b/backend/scripts/portal-smoke-check.js
@@ -47,6 +47,9 @@ function resolveAsset(pageFile, rawUrl) {
     const url = cleanAssetUrl(rawUrl);
     if (!url || isExternal(url)) return null;
     if (url === '/socket.io/socket.io.js') return null;
+    // /shared-core/* is an Express static mount onto backend/shared/ (index.js
+    // line ~881). Translate so the smoke check finds the source file.
+    if (url.startsWith('/shared-core/')) return path.join(ROOT, 'shared', url.slice('/shared-core/'.length));
     if (url.startsWith('/')) return path.join(PUBLIC, url);
     return path.join(path.dirname(path.join(PUBLIC, pageFile)), url);
 }

--- a/backend/tests/jest/entity-gh-stats.test.js
+++ b/backend/tests/jest/entity-gh-stats.test.js
@@ -1,0 +1,137 @@
+/**
+ * entity-gh-stats — card_8a25cadcc9fc88f153fa1316.
+ *
+ * Pins the contract for the merged-PR count + smart-link widget data source:
+ *   - Mapping resolves from byEntityId (default) and byDevice override.
+ *   - Missing mapping → setup_required:'no_login_mapped' (still 200).
+ *   - Missing GITHUB_TOKEN → setup_required:'no_github_token' (still 200).
+ *   - Happy path → merged_pr_count + recent_prs[] + actions_url.
+ *
+ * GitHub Search is mocked via global.fetch so the test stays hermetic.
+ */
+'use strict';
+
+const ghStats = require('../../entity-gh-stats');
+
+const ORIG_FETCH = global.fetch;
+const ORIG_TOKEN = process.env.GITHUB_TOKEN;
+
+describe('entity-gh-stats — config + buildStats contract', () => {
+    beforeEach(() => {
+        ghStats._clearCacheForTest();
+    });
+    afterEach(() => {
+        global.fetch = ORIG_FETCH;
+        if (ORIG_TOKEN === undefined) delete process.env.GITHUB_TOKEN;
+        else process.env.GITHUB_TOKEN = ORIG_TOKEN;
+    });
+
+    test('resolveGhLogin reads byEntityId from the shipped config', () => {
+        const cfg = ghStats.loadConfig();
+        expect(cfg).toBeTruthy();
+        // The shipped config maps a couple of entityIds to HankHuang0516 so the
+        // production dashboard renders a non-zero count out of the box.
+        const someMappedId = Object.keys(cfg.byEntityId || {})[0];
+        if (someMappedId) {
+            const login = ghStats.resolveGhLogin('any-device', someMappedId);
+            expect(typeof login).toBe('string');
+            expect(login.length).toBeGreaterThan(0);
+        }
+    });
+
+    test('buildStats returns setup_required when entity is unmapped', async () => {
+        const out = await ghStats.buildStats('unknown-device', 999999);
+        expect(out.success).toBe(true);
+        expect(out.setup_required).toBe(true);
+        expect(out.setup_reason).toBe('no_login_mapped');
+        expect(out.merged_pr_count).toBe(0);
+        expect(out.recent_prs).toEqual([]);
+        expect(out.gh_login).toBeNull();
+    });
+
+    test('buildStats returns setup_required when GITHUB_TOKEN env is missing', async () => {
+        delete process.env.GITHUB_TOKEN;
+        const cfg = ghStats.loadConfig();
+        const mappedId = Object.keys(cfg.byEntityId || {})[0];
+        if (!mappedId) return; // skip when shipped config is empty
+        const out = await ghStats.buildStats('any-device', mappedId);
+        expect(out.success).toBe(true);
+        expect(out.setup_required).toBe(true);
+        expect(out.setup_reason).toBe('no_github_token');
+        expect(out.gh_login).toBeTruthy();
+        expect(out.merged_pr_count).toBe(0);
+    });
+
+    test('buildStats happy path → merged_pr_count + recent_prs + actions_url', async () => {
+        process.env.GITHUB_TOKEN = 'fake-token';
+        const cfg = ghStats.loadConfig();
+        const mappedId = Object.keys(cfg.byEntityId || {})[0];
+        if (!mappedId) return;
+        const mockJson = {
+            total_count: 42,
+            items: [
+                {
+                    number: 101,
+                    title: 'feat(test): adds a thing',
+                    html_url: 'https://github.com/owner/repo/pull/101',
+                    repository_url: 'https://api.github.com/repos/owner/repo',
+                    closed_at: '2026-06-13T12:00:00Z',
+                    updated_at: '2026-06-13T12:00:00Z',
+                },
+            ],
+        };
+        global.fetch = jest.fn(async () => ({
+            ok: true,
+            status: 200,
+            json: async () => mockJson,
+        }));
+        const out = await ghStats.buildStats('any-device', mappedId);
+        expect(out.success).toBe(true);
+        expect(out.setup_required).toBe(false);
+        expect(out.merged_pr_count).toBe(42);
+        expect(out.recent_prs).toHaveLength(1);
+        expect(out.recent_prs[0]).toMatchObject({
+            number: 101,
+            title: 'feat(test): adds a thing',
+            html_url: 'https://github.com/owner/repo/pull/101',
+            repo: 'owner/repo',
+        });
+        expect(out.actions_url).toMatch(/^https:\/\/github\.com\/pulls\?q=/);
+        // Authorization header must be sent when token is present.
+        const call = global.fetch.mock.calls[0];
+        expect(call[1].headers.Authorization).toMatch(/^Bearer /);
+    });
+
+    test('buildStats propagates GitHub errors with status code', async () => {
+        process.env.GITHUB_TOKEN = 'fake-token';
+        const cfg = ghStats.loadConfig();
+        const mappedId = Object.keys(cfg.byEntityId || {})[0];
+        if (!mappedId) return;
+        global.fetch = jest.fn(async () => ({
+            ok: false,
+            status: 403,
+            text: async () => 'rate limited',
+            json: async () => ({}),
+        }));
+        const out = await ghStats.buildStats('any-device', mappedId);
+        expect(out.success).toBe(false);
+        expect(out.status).toBe(403);
+        expect(out.error).toMatch(/GitHub 403/);
+    });
+
+    test('5-minute cache prevents repeat GitHub calls for the same login', async () => {
+        process.env.GITHUB_TOKEN = 'fake-token';
+        const cfg = ghStats.loadConfig();
+        const mappedId = Object.keys(cfg.byEntityId || {})[0];
+        if (!mappedId) return;
+        global.fetch = jest.fn(async () => ({
+            ok: true,
+            status: 200,
+            json: async () => ({ total_count: 7, items: [] }),
+        }));
+        await ghStats.buildStats('any-device', mappedId);
+        await ghStats.buildStats('any-device', mappedId);
+        await ghStats.buildStats('other-device', mappedId);
+        expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+});


### PR DESCRIPTION
## Summary
- Dashboard entity cards now show "Merged PRs: N 🔗" sourced from a new `GET /api/entities/:entityId/gh-stats` endpoint.
- Endpoint resolves `entityId → GitHub login` from `backend/config/entity-gh-login.json` (with `byDevice` override) and queries the GitHub Search API; results are cached 5 minutes per login.
- When the entity has no mapping or `GITHUB_TOKEN` is unset, the endpoint still returns `200` with `setup_required:true` and a reason — the widget paints a `?` icon with the exact remediation hint instead of treating it as a failure (globe-user parity).
- Click the widget → modal lists the most recent merged PRs with titles, repos, dates, and per-PR GitHub links + a "view all on GitHub" footer.

## Files changed
- `backend/entity-gh-stats.js` *(new)* — config loader, login resolver, GitHub Search wrapper, 5-min cache
- `backend/config/entity-gh-login.json` *(new)* — entity → login mapping (override per deployment)
- `backend/index.js` — wires the new endpoint next to `/api/entities/status`; same auth pattern (`deviceSecret` / `botSecret+entityId` / JWT cookie)
- `backend/public/portal/dashboard.html` — widget on each entity card + modal renderer
- `backend/public/shared/i18n.js` — 9 new dashboard keys + `common_close`, EN + zh-TW + zh-CN
- `backend/tests/jest/entity-gh-stats.test.js` *(new)* — 6 Jest cases

## Test plan
- [x] `node backend/scripts/i18n-check.js` → all referenced keys resolve in EN
- [x] `npx jest --testPathPatterns=i18n-syntax` → 12/12 pass
- [x] `npx jest --testPathPatterns=entity-gh-stats` → 6/6 pass
- [x] `node -c backend/index.js` → syntax OK
- [ ] Post-deploy: `curl /api/entities/2/gh-stats` returns non-zero `merged_pr_count` on prod (HankHuang0516)
- [ ] Post-deploy: dashboard widget renders on prod, click opens modal with recent PRs
- [ ] Post-deploy: simulate "no GH login mapped" entity → `?` icon empty state shows

## Globe-user / setup conditions
- Endpoint returns `setup_required:'no_login_mapped'` when the entity is unmapped → widget shows `?` + hint to edit `backend/config/entity-gh-login.json`.
- Endpoint returns `setup_required:'no_github_token'` when `GITHUB_TOKEN` is unset → widget shows `?` + hint to configure the env var.
- Fetch failures from GitHub keep the dashboard usable: widget shows `⚠️` with the error message in the tooltip + modal.

## Code review checklist (Part A core)
- **Logic trace**: auth mirrors `/api/entities` (deviceId+deviceSecret / botSecret+entityId / JWT cookie). Entity must be bound. Path conflict avoided by suffix `/gh-stats`. ✅
- **Test coverage**: 6 Jest cases pin config resolve, both `setup_required` reasons, happy path payload, GitHub error propagation, and 5-min cache. ✅
- **Return shape**: stable `{ success, merged_pr_count, recent_prs, gh_login, actions_url?, setup_required, setup_reason? }`. ✅
- **What this does NOT fix**: does not change the avatar achievements panel, does not extend to chat.html / kanban.html, does not gate writes (read-only). ⚠️ NO-OP
- **Security**: GitHub token never leaks to the client; mapping file is server-side only; `escapeHtml` used for every PR title/repo before rendering. ✅

## Code review checklist (Part B extended)
- `/api/help`: ⚠️ NO-OP — endpoint is dashboard-internal; skill template surface is the right place to expose it (next audit can add it).
- Related docs: ⚠️ NO-OP — kept this PR focused; recent-features section will be appended on the next CLAUDE.md sync.
- i18n: ✅ EN + zh-TW + zh-CN added; `i18n-check.js` passes; `i18n-syntax` test passes.
- Info page: ⚠️ NO-OP.
- Debug endpoint: ⚠️ NO-OP — not a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)