### PR TITLE
fix(portal): label publisher visibility toggles

### DIFF
--- a/backend/public/portal/publisher-setup.html
+++ b/backend/public/portal/publisher-setup.html
@@ -146,7 +146,11 @@
                         <label for="xConsumerKey">Consumer Key / 消費者金鑰</label>
                         <div class="pw-row">
                             <input type="password" id="xConsumerKey" autocomplete="off" spellcheck="false">
-                            <button type="button" class="pw-toggle" onclick="togglePw('xConsumerKey', this)">👁</button>
+                            <button type="button" class="pw-toggle"
+                                data-visibility-label="consumer key"
+                                aria-label="Show consumer key"
+                                title="Show consumer key"
+                                onclick="togglePw('xConsumerKey', this)">👁</button>
                         </div>
                         <div class="field-hint">From X Developer Portal → App → Keys and tokens → API Key.</div>
                     </div>
@@ -155,7 +159,11 @@
                         <label for="xConsumerSecret">Consumer Secret / 消費者密鑰</label>
                         <div class="pw-row">
                             <input type="password" id="xConsumerSecret" autocomplete="off" spellcheck="false">
-                            <button type="button" class="pw-toggle" onclick="togglePw('xConsumerSecret', this)">👁</button>
+                            <button type="button" class="pw-toggle"
+                                data-visibility-label="consumer secret"
+                                aria-label="Show consumer secret"
+                                title="Show consumer secret"
+                                onclick="togglePw('xConsumerSecret', this)">👁</button>
                         </div>
                         <div class="field-hint">Paired with the Consumer Key. AKA "API Key Secret".</div>
                     </div>
@@ -164,7 +172,11 @@
                         <label for="xAccessToken">Access Token / 存取權杖</label>
                         <div class="pw-row">
                             <input type="password" id="xAccessToken" autocomplete="off" spellcheck="false">
-                            <button type="button" class="pw-toggle" onclick="togglePw('xAccessToken', this)">👁</button>
+                            <button type="button" class="pw-toggle"
+                                data-visibility-label="access token"
+                                aria-label="Show access token"
+                                title="Show access token"
+                                onclick="togglePw('xAccessToken', this)">👁</button>
                         </div>
                         <div class="field-hint">Generated in X Developer Portal under your App → Keys and tokens → Access Token.</div>
                     </div>
@@ -173,7 +185,11 @@
                         <label for="xAccessTokenSecret">Access Token Secret / 存取權杖密鑰</label>
                         <div class="pw-row">
                             <input type="password" id="xAccessTokenSecret" autocomplete="off" spellcheck="false">
-                            <button type="button" class="pw-toggle" onclick="togglePw('xAccessTokenSecret', this)">👁</button>
+                            <button type="button" class="pw-toggle"
+                                data-visibility-label="access token secret"
+                                aria-label="Show access token secret"
+                                title="Show access token secret"
+                                onclick="togglePw('xAccessTokenSecret', this)">👁</button>
                         </div>
                         <div class="field-hint">Paired with the Access Token.</div>
                     </div>
@@ -218,7 +234,12 @@
             const el = document.getElementById(id);
             if (!el) return;
             el.type = el.type === 'password' ? 'text' : 'password';
+            const subject = btn.dataset.visibilityLabel || 'secret value';
+            const action = el.type === 'password' ? 'Show' : 'Hide';
+            const label = `${action} ${subject}`;
             btn.textContent = el.type === 'password' ? '👁' : '🙈';
+            btn.setAttribute('aria-label', label);
+            btn.setAttribute('title', label);
         }
 
         function clearForm() {

--- a/backend/public/portal/publisher.html
+++ b/backend/public/portal/publisher.html
@@ -203,7 +203,11 @@
                     <input type="password" id="apiKeyInput"
                         data-i18n-placeholder="pub_apikey_placeholder"
                         placeholder="X-Publisher-Key (from device-vars: PUBLISHER_API_KEY)">
-                    <button class="btn btn-sm btn-outline" onclick="togglePasswordVisibility('apiKeyInput', this)">👁</button>
+                    <button type="button" class="btn btn-sm btn-outline"
+                        data-visibility-label="publisher API key"
+                        aria-label="Show publisher API key"
+                        title="Show publisher API key"
+                        onclick="togglePasswordVisibility('apiKeyInput', this)">👁</button>
                     <button class="btn btn-sm btn-primary" onclick="saveApiKey()" data-i18n="pub_apikey_save">Save</button>
                     <span id="apiKeyStatus" class="key-status unset" data-i18n="pub_apikey_unset">not set</span>
                 </div>
@@ -266,7 +270,12 @@
         function togglePasswordVisibility(inputId, btn) {
             const el = document.getElementById(inputId);
             el.type = el.type === 'password' ? 'text' : 'password';
+            const subject = btn.dataset.visibilityLabel || 'secret value';
+            const action = el.type === 'password' ? 'Show' : 'Hide';
+            const label = `${action} ${subject}`;
             btn.textContent = el.type === 'password' ? '👁' : '🙈';
+            btn.setAttribute('aria-label', label);
+            btn.setAttribute('title', label);
         }
 
         // ─── Init ───

--- a/backend/tests/jest/portal-static-ids.test.js
+++ b/backend/tests/jest/portal-static-ids.test.js
@@ -69,4 +69,29 @@ describe('portal static HTML IDs', () => {
     expect(settings.match(/class="roster-action" aria-label="\$\{rosterT\('settings_roster_col_action','Action'\)\}"/g)).toHaveLength(2);
   });
 
+  test('publisher secret visibility toggles expose accessible names and tooltips', () => {
+    const publisherPath = path.join(__dirname, '../../public/portal/publisher.html');
+    const publisher = fs.readFileSync(publisherPath, 'utf8');
+    expect(publisher).toContain('data-visibility-label="publisher API key"');
+    expect(publisher).toContain('aria-label="Show publisher API key"');
+    expect(publisher).toContain('title="Show publisher API key"');
+    expect(publisher).toContain("btn.setAttribute('aria-label', label)");
+    expect(publisher).toContain("btn.setAttribute('title', label)");
+
+    const setupPath = path.join(__dirname, '../../public/portal/publisher-setup.html');
+    const setup = fs.readFileSync(setupPath, 'utf8');
+    [
+      'consumer key',
+      'consumer secret',
+      'access token',
+      'access token secret',
+    ].forEach((label) => {
+      expect(setup).toContain(`data-visibility-label="${label}"`);
+      expect(setup).toContain(`aria-label="Show ${label}"`);
+      expect(setup).toContain(`title="Show ${label}"`);
+    });
+    expect(setup).toContain("btn.setAttribute('aria-label', label)");
+    expect(setup).toContain("btn.setAttribute('title', label)");
+  });
+
 });


### PR DESCRIPTION
## Summary
- Adds accessible names and titles to Publisher secret visibility toggle buttons.
- Keeps the visual eye/mask behavior unchanged while updating the Show/Hide accessible state.
- Adds Jest coverage so Publisher visibility toggles cannot regress to unlabeled icon-only buttons.

Fixes #3408

## QA / UIUX Evidence
- `npm run smoke:portal` PASS
- Portal Jest suites PASS: 4 suites, 12 tests
- Playwright portal UIUX smoke PASS: 39 portal pages x desktop/mobile = 78 checks, 0 failures, 1602 visible controls audited/trial-clicked
- Interaction smoke PASS for desktop Kanban/telemetry, mobile nav, Kanban filter/new-card editor, Publisher API-key toggle, and Publisher setup credential toggle

Kanban evidence is attached to `card_40cc2103de36351a6415f6c4`: report JSON, logs, patch, and screenshots.

## User POV
A user tabbing or using assistive tech on Publisher pages now hears the same Show/Hide intent that sighted users infer from the icon, including state changes after toggling.

## Review
Requested for Entity #2 code review via the linked kanban card.