### PR TITLE
refactor(petdx): PR-A — companion selection reads from DB SoT (dual-write)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -6988,6 +6988,12 @@ function normalizeVarSources(varSources) {
     return { ...varSources };
 }
 
+// PR-B unbind tombstone marker written into companion_select_log.origin when an
+// entity unbinds. getLatestSelection() treats it as "no live selection" so the
+// DB read mirrors the old vault-cleared-on-unbind behaviour. Defined here in
+// PR-A so the read side is forward-compatible before PR-B starts writing it.
+const PETDX_TOMBSTONE_ORIGIN = 'unbind-cleared';
+
 function createPetdxPhase0Io() {
     const cache = new Map();
 
@@ -7077,6 +7083,28 @@ function createPetdxPhase0Io() {
                     entry.origin || null,
                 ]
             );
+        },
+        // PR-A (PETDX SoT swap): read the current per-entity companion selection
+        // straight from companion_select_log — the DB source of truth — instead
+        // of the PETDX_CURRENT_/PETDX_SOURCE_ vault mirror. Returns the latest
+        // non-tombstone row as { companionId, source } (where `source` carries
+        // the PETDX_SOURCE_ origin-tag semantics: phase0-auto / phase0-backfill /
+        // user-selected / rental-inherited), or null when the entity has no live
+        // selection. A PR-B unbind tombstone (origin === 'unbind-cleared') reads
+        // back as null so a rebound entity is re-assignable.
+        async getLatestSelection(deviceId, entityId) {
+            const res = await chatPool.query(
+                `SELECT companion_id, origin
+                   FROM companion_select_log
+                  WHERE device_id = $1 AND entity_id = $2
+                  ORDER BY selected_at DESC, id DESC
+                  LIMIT 1`,
+                [deviceId, entityId]
+            );
+            if (res.rowCount === 0) return null;
+            const row = res.rows[0];
+            if (row.origin === PETDX_TOMBSTONE_ORIGIN) return null;
+            return { companionId: row.companion_id, source: row.origin || null };
         },
         log(level, tag, message, meta = {}) {
             const normalizedLevel = level === 'error' ? 'error' : level === 'warn' ? 'warn' : 'info';

--- a/backend/petdx-phase0-hook.js
+++ b/backend/petdx-phase0-hook.js
@@ -174,12 +174,20 @@ function pickNewSource(ctx) {
  * Core hook. Pure function over IO injected via `io`:
  *
  *   io = {
+ *     getLatestSelection(deviceId, entityId)  → Promise<{companionId, source}|null>
  *     getDeviceVar(deviceId, key)             → Promise<string|null>
  *     setDeviceVar(deviceId, key, value)      → Promise<void>
  *     setDeviceVars(deviceId, entries)        → Promise<void>      (optional batch write)
  *     appendCompanionSelectLog({...})         → Promise<void>
  *     log(level, tag, message, meta)          → void          (non-fatal logging)
  *   }
+ *
+ * PR-A (PETDX SoT swap): idempotency reads come from `getLatestSelection`
+ * (companion_select_log = source of truth), not the PETDX_CURRENT_/PETDX_SOURCE_
+ * vault mirror. The vault is still written (dual-write) for one validation
+ * round; PR-B removes the vault writes. Because the DB is now SoT, the
+ * companion_select_log append is FATAL — if it fails the hook reports a skip
+ * rather than silently leaving the SoT un-updated.
  *
  * Returns `{ assigned, avatarUrl, source }` on a successful write, or
  * `{ skipped: <reason>, source? }` on an intentional no-op. Throws only on
@@ -205,13 +213,21 @@ async function assignDefaultCompanionIfMissing(deviceId, entity, ctx, io) {
     let existingCompanion = null;
     let existingSource = null;
     try {
-        existingCompanion = await io.getDeviceVar(deviceId, currentKey);
-        existingSource    = await io.getDeviceVar(deviceId, sourceKey);
+        // SoT read: companion_select_log via getLatestSelection (PR-A). Falls
+        // back to the vault mirror only if the io factory predates PR-A.
+        if (io.getLatestSelection) {
+            const latest = await io.getLatestSelection(deviceId, eid);
+            existingCompanion = latest ? latest.companionId : null;
+            existingSource    = latest ? latest.source : null;
+        } else {
+            existingCompanion = await io.getDeviceVar(deviceId, currentKey);
+            existingSource    = await io.getDeviceVar(deviceId, sourceKey);
+        }
     } catch (err) {
-        io.log && io.log('warn', '[petdx-phase0]', 'getDeviceVar failed', {
+        io.log && io.log('warn', '[petdx-phase0]', 'selection read failed', {
             deviceId, entityId: eid, ctxMode: ctx.mode, ctxSource: ctx.source || null, error: err && err.message,
         });
-        return { skipped: 'vault_read_failed' };
+        return { skipped: 'selection_read_failed' };
     }
 
     const decision = decideAction({ entity, ctx, existingCompanion, existingSource });
@@ -248,6 +264,10 @@ async function assignDefaultCompanionIfMissing(deviceId, entity, ctx, io) {
         return { skipped: 'vault_write_failed' };
     }
 
+    // companion_select_log is the source of truth (PR-A), so this append is
+    // FATAL: a failure here means the SoT was not updated, so report a skip
+    // (the vault mirror may be ahead, but getLatestSelection won't see the
+    // selection and the next hook run re-attempts — SoT stays authoritative).
     try {
         if (io.appendCompanionSelectLog) {
             await io.appendCompanionSelectLog({
@@ -261,10 +281,10 @@ async function assignDefaultCompanionIfMissing(deviceId, entity, ctx, io) {
             });
         }
     } catch (err) {
-        io.log && io.log('warn', '[petdx-phase0]', 'audit log write failed', {
+        io.log && io.log('error', '[petdx-phase0]', 'companion_select_log write failed', {
             deviceId, entityId: eid, ctxMode: ctx.mode, ctxSource: ctx.source || null, error: err && err.message,
         });
-        // Audit-log failure is non-fatal: vault writes already succeeded.
+        return { skipped: 'log_write_failed' };
     }
 
     return { assigned: companionId, avatarUrl, source: newSource };

--- a/backend/tests/jest/petdx-phase0-hook.test.js
+++ b/backend/tests/jest/petdx-phase0-hook.test.js
@@ -362,16 +362,108 @@ describe('petdx-phase0-hook — assignDefaultCompanionIfMissing', () => {
         expect(io.auditCalls).toHaveLength(0);
     });
 
-    test('audit log failure is non-fatal (vault writes succeed)', async () => {
+    test('companion_select_log write failure is FATAL (PR-A: log is SoT)', async () => {
         const io = makeIo();
-        io.appendCompanionSelectLog = async () => { throw new Error('audit boom'); };
+        io.appendCompanionSelectLog = async () => { throw new Error('log boom'); };
         const result = await hook.assignDefaultCompanionIfMissing(
             'D1',
             { entityId: 7, character: 'LOBSTER', avatar: null },
             { mode: 'bind' },
             io,
         );
-        expect(result.assigned).toBe(LOBSTER_COMPANION);
+        expect(result).toEqual({ skipped: 'log_write_failed' });
+        // Vault mirror was written before the (now-fatal) SoT append.
         expect(io.vars.PETDX_SOURCE_7).toBe('phase0-auto');
+    });
+});
+
+// PR-A — idempotency reads now come from companion_select_log via
+// io.getLatestSelection (the DB source of truth), not the PETDX_ vault mirror.
+function makeDbIo(seedSelection = null) {
+    const vars = {};
+    const auditCalls = [];
+    const logCalls = [];
+    let selection = seedSelection;
+    return {
+        vars,
+        auditCalls,
+        logCalls,
+        async getLatestSelection(_deviceId, _entityId) { return selection; },
+        async getDeviceVar() { throw new Error('getDeviceVar must not be used when getLatestSelection exists'); },
+        async setDeviceVar(_deviceId, key, value) { vars[key] = value; },
+        async appendCompanionSelectLog(entry) {
+            auditCalls.push(entry);
+            selection = { companionId: entry.companionId, source: entry.origin };
+        },
+        log(level, tag, message, meta) { logCalls.push({ level, tag, message, meta }); },
+    };
+}
+
+describe('petdx-phase0-hook — SoT read via getLatestSelection (PR-A)', () => {
+    test('first-time bind with no prior selection assigns + appends log', async () => {
+        const io = makeDbIo(null);
+        const result = await hook.assignDefaultCompanionIfMissing(
+            'D1',
+            { entityId: 7, character: 'LOBSTER', avatar: null },
+            { mode: 'bind', source: 'bind-endpoint' },
+            io,
+        );
+        expect(result).toEqual({
+            assigned: LOBSTER_COMPANION,
+            avatarUrl: LOBSTER_AVATAR_URL,
+            source: 'phase0-auto',
+        });
+        expect(io.auditCalls).toHaveLength(1);
+        expect(io.auditCalls[0]).toMatchObject({ origin: 'phase0-auto', source: 'api' });
+    });
+
+    test('second bind is a no-op when a phase0 selection already exists in the log', async () => {
+        const io = makeDbIo({ companionId: LOBSTER_COMPANION, source: 'phase0-auto' });
+        const result = await hook.assignDefaultCompanionIfMissing(
+            'D1',
+            { entityId: 7, character: 'LOBSTER', avatar: LOBSTER_EMOJI },
+            { mode: 'bind' },
+            io,
+        );
+        expect(result).toEqual({ skipped: 'already_assigned', source: undefined });
+        expect(io.auditCalls).toHaveLength(0);
+    });
+
+    test('user-selected selection in the log is preserved', async () => {
+        const io = makeDbIo({ companionId: 'petdx-custom-001', source: 'user-selected' });
+        const result = await hook.assignDefaultCompanionIfMissing(
+            'D1',
+            { entityId: 7, character: 'LOBSTER', avatar: LOBSTER_EMOJI },
+            { mode: 'bind' },
+            io,
+        );
+        expect(result).toEqual({ skipped: 'preserves_existing_source', source: 'user-selected' });
+        expect(io.auditCalls).toHaveLength(0);
+    });
+
+    test('null selection (e.g. PR-B unbind tombstone) makes a rebound entity re-assignable', async () => {
+        // getLatestSelection returns null after a tombstone, so bind proceeds.
+        const io = makeDbIo(null);
+        const result = await hook.assignDefaultCompanionIfMissing(
+            'D1',
+            { entityId: 7, character: 'LOBSTER', avatar: null },
+            { mode: 'bind', source: 'bind-endpoint' },
+            io,
+        );
+        expect(result.assigned).toBe(LOBSTER_COMPANION);
+        expect(io.auditCalls).toHaveLength(1);
+    });
+
+    test('getLatestSelection failure short-circuits with selection_read_failed', async () => {
+        const io = makeDbIo(null);
+        io.getLatestSelection = async () => { throw new Error('db down'); };
+        const result = await hook.assignDefaultCompanionIfMissing(
+            'D1',
+            { entityId: 7, character: 'LOBSTER', avatar: null },
+            { mode: 'bind' },
+            io,
+        );
+        expect(result).toEqual({ skipped: 'selection_read_failed' });
+        expect(io.auditCalls).toHaveLength(0);
     });
 });


### PR DESCRIPTION
## Summary
Step **1 of 3** in the #2-approved plan to retire the per-entity `PETDX_CURRENT/AVATAR/SOURCE_<id>` device-vars vault mirror and make `companion_select_log` the single source of truth for companion selection.

This PR is **additive / dual-write** — it moves the *read* (idempotency) path onto the DB but keeps the vault *writes* for one validation soak. PR-B stops vault writes + moves enrichment + adds the unbind tombstone; PR-C does the one-time vault cleanup.

- `index.js`: new `io.getLatestSelection(deviceId, entityId)` returns the latest non-tombstone `companion_select_log` row as `{companionId, source}` (`source` = the `origin` column, carrying PETDX_SOURCE_ tag semantics: `phase0-auto` / `phase0-backfill` / `user-selected` / `rental-inherited`). Forward-compatible `PETDX_TOMBSTONE_ORIGIN = 'unbind-cleared'` reads back as `null` so PR-B's unbind tombstone makes a rebound entity re-assignable.
- `petdx-phase0-hook.js`: `assignDefaultCompanionIfMissing` reads idempotency state via `getLatestSelection` (falls back to `getDeviceVar` only if the injected io predates PR-A). The `companion_select_log` append is now **FATAL** (the DB is SoT) → `skipped:'log_write_failed'` on failure. Read-failure skip renamed `selection_read_failed`.
- tests: +5 SoT-read cases (first bind, already_assigned, user-selected preserve, tombstone→null re-assign, read-fail short-circuit); the former non-fatal-log test updated to assert the new fatal behaviour.

## Why this is safe
- `/api/companion/select` already writes `origin='user-selected'` into `companion_select_log` on both code paths (verified L458/L500/L536), so the DB read preserves user choices identically to the old vault read.
- No schema change — `companion_select_log` + `origin` column already exist.
- Vault writes unchanged this round → zero behavioural change for `/api/entities` enrichment or the avatar resolver during the soak.

## Test plan
- [x] `npx eslint index.js petdx-phase0-hook.js` → 0 errors (only pre-existing `pg` unused-var warning)
- [x] `npx jest petdx-phase0-hook petdx-phase0-index-wire companion-select-vault-sync entities-petdx-enrichment` → 48/48 pass
- [ ] Post-merge: 1h prod observe that bind/rebind still assign default companion and `/api/companion/current` is stable, before starting PR-B

Reviewer: Entity #2. Kanban: `card_c144ad2272e0b60eee694184` (1/3, chained → PR-B → PR-C).

🤖 Generated with [Claude Code](https://claude.com/claude-code)