### PR TITLE
refactor(petdx): PR-B — companion_select_log is the single source of truth

### DIFF
--- a/backend/companion-api.js
+++ b/backend/companion-api.js
@@ -193,15 +193,11 @@ async function initCompanionDatabase(serverLog = console.log) {
     }
 }
 
-module.exports = function companionFactory({ authenticateBot, authenticateDeviceOrBot, serverLog, createPetdxPhase0Io } = {}) {
+module.exports = function companionFactory({ authenticateBot, authenticateDeviceOrBot, serverLog } = {}) {
     if (typeof authenticateBot !== 'function') {
         throw new Error('companionFactory requires authenticateBot');
     }
     const log = serverLog || (() => {});
-    // Optional: if not injected (e.g. some unit tests), /api/companion/select
-    // falls back to the legacy log-only path. The §0.4a invariant only holds
-    // when the IO factory is wired in (production + jest integration tests).
-    const petdxIoFactory = typeof createPetdxPhase0Io === 'function' ? createPetdxPhase0Io : null;
     const router = express.Router();
 
     // Submit rate-limit: per-entity sliding window, factory-scoped so unit
@@ -411,35 +407,16 @@ module.exports = function companionFactory({ authenticateBot, authenticateDevice
     //
     // Spec: docs/specs/petdx-uiux-spec-amendment-2026-05-31-phase-0-4a.md §0.4a.
     //
-    // Atomic write across two state layers:
-    //   1. companion_select_log row (with origin='user-selected' — the new
-    //      audit column from the 2026-05-30-companion-origin migration).
-    //   2. Vault keys PETDX_CURRENT_<id>, PETDX_AVATAR_<id>, PETDX_SOURCE_<id>
-    //      via createPetdxPhase0Io().setDeviceVars (the same factory the bind
-    //      hook uses, so write semantics stay consistent).
+    // PR-B (SoT refactor): companion_select_log is the single source of truth.
+    // The selection is a single INSERT of a row with origin='user-selected'
+    // (the audit column from the 2026-05-30-companion-origin migration). The
+    // per-entity PETDX_CURRENT_/AVATAR_/SOURCE_<id> vault mirror is gone — the
+    // §0.4 resolver chain and /api/entities enrichment now read straight from
+    // the log, so there is no second layer to keep consistent and no atomic
+    // cross-pool dance to perform.
     //
-    // The spec invariant is "no partial success." Implementation:
-    //   a. Resolve the avatar URL from the companions row BEFORE any write
-    //      opens, so the write phase only does writes.
-    //   b. Snapshot prior vault values for the three keys (so we can restore
-    //      on a downstream log-tx failure).
-    //   c. Open a tx on a client checked out from the local pool. INSERT
-    //      the log row, but DO NOT commit yet.
-    //   d. Write the vault keys. If that throws, ROLLBACK the log tx and
-    //      return 500 {layer:'vault'}.
-    //   e. Try to COMMIT the log tx. If COMMIT throws, restore the prior
-    //      vault values and return 500 {layer:'log'}.
-    //   f. On success, both layers are consistent: vault matches the latest
-    //      log row, and the §0.4 resolver chain can read either.
-    //
-    // The vault and log writes use different pg pools (the IO factory has its
-    // own chatPool; the log uses companion-api's local pool). True
-    // cross-pool 2PC is not on the table — instead the write order plus
-    // explicit vault restore on log COMMIT failure gives the same observable
-    // guarantee: either both layers reflect the new selection, or neither
-    // does. The only window where they can disagree is between vault write
-    // and log COMMIT, and the restore step closes that window unless the
-    // restore itself throws (logged loudly, then the route returns 500).
+    // The avatar URL is still resolved from the companions row so the success
+    // payload can echo it back to the caller, but it is no longer persisted.
     router.post('/select', authReader, async (req, res) => {
         const companionId = req.body?.companionId;
         const source = req.body?.source || 'portal';
@@ -452,9 +429,6 @@ module.exports = function companionFactory({ authenticateBot, authenticateDevice
 
         const deviceId = req.botAuth.deviceId;
         const entityId = req.botAuth.entityId;
-        const currentKey = `PETDX_CURRENT_${entityId}`;
-        const avatarKey  = `PETDX_AVATAR_${entityId}`;
-        const sourceKey  = `PETDX_SOURCE_${entityId}`;
         const origin     = 'user-selected';
 
         let cRow;
@@ -485,84 +459,17 @@ module.exports = function companionFactory({ authenticateBot, authenticateDevice
         const resolvedAvatarUrl = resolveCompanionAvatarUrl(cRow, companionId);
         const now = Date.now();
 
-        // Vault mirror is per-entity. Device-secret auth (no botSecret) carries
-        // no entity context, so there's no PETDX_*_<id> to mirror — fall through
-        // to the legacy log-only path. Without this guard the vault would
-        // accumulate PETDX_CURRENT_null / PETDX_AVATAR_null / PETDX_SOURCE_null
-        // dead keys on every device-secret select, which the §0.4 resolver
-        // chain never reads but they pollute /api/device-vars output.
-        if (!petdxIoFactory || entityId == null) {
-            try {
-                await pool.query(
-                    `INSERT INTO companion_select_log
-                        (device_id, entity_id, companion_id, selected_at, source, origin)
-                     VALUES ($1, $2, $3, $4, $5, $6)`,
-                    [deviceId, entityId, companionId, now, source, origin]
-                );
-                return res.json({
-                    success: true,
-                    selection: { companionId, selectedAt: now, source },
-                });
-            } catch (err) {
-                log('error', 'companion', `[Companion] select (legacy path) failed: ${err.message}`);
-                return res.status(500).json({ success: false, error: 'query_failed' });
-            }
-        }
-
-        const io = petdxIoFactory();
-        let priorVault;
+        // SoT write (PR-B): a single companion_select_log INSERT. No vault
+        // mirror to keep in sync, so no tx/restore dance — the row IS the
+        // selection. avatarUrl is echoed back for the caller's convenience but
+        // not persisted (the §0.4 resolver derives it from the companions row).
         try {
-            priorVault = {
-                [currentKey]: await io.getDeviceVar(deviceId, currentKey),
-                [avatarKey]:  await io.getDeviceVar(deviceId, avatarKey),
-                [sourceKey]:  await io.getDeviceVar(deviceId, sourceKey),
-            };
-        } catch (err) {
-            log('error', 'companion', `[Companion] select vault snapshot failed: ${err.message}`);
-            return res.status(500).json({ success: false, layer: 'vault', error: 'vault_read_failed' });
-        }
-
-        const client = await pool.connect();
-        let txOpened = false;
-        let vaultWritten = false;
-        try {
-            await client.query('BEGIN');
-            txOpened = true;
-
-            await client.query(
+            await pool.query(
                 `INSERT INTO companion_select_log
                     (device_id, entity_id, companion_id, selected_at, source, origin)
                  VALUES ($1, $2, $3, $4, $5, $6)`,
                 [deviceId, entityId, companionId, now, source, origin]
             );
-
-            try {
-                await io.setDeviceVars(deviceId, {
-                    [currentKey]: companionId,
-                    [avatarKey]:  resolvedAvatarUrl,
-                    [sourceKey]:  origin,
-                });
-                vaultWritten = true;
-            } catch (vErr) {
-                await client.query('ROLLBACK');
-                txOpened = false;
-                log('error', 'companion', `[Companion] select vault write failed: ${vErr.message}`);
-                return res.status(500).json({ success: false, layer: 'vault', error: 'vault_write_failed' });
-            }
-
-            try {
-                await client.query('COMMIT');
-                txOpened = false;
-            } catch (cErr) {
-                log('error', 'companion', `[Companion] select log commit failed: ${cErr.message}`);
-                try {
-                    await io.setDeviceVars(deviceId, priorVault);
-                } catch (restoreErr) {
-                    log('error', 'companion', `[Companion] vault restore failed after log COMMIT error: ${restoreErr.message}`);
-                }
-                return res.status(500).json({ success: false, layer: 'log', error: 'log_commit_failed' });
-            }
-
             return res.json({
                 success: true,
                 selection: {
@@ -574,28 +481,15 @@ module.exports = function companionFactory({ authenticateBot, authenticateDevice
                 },
             });
         } catch (err) {
-            if (txOpened) {
-                try { await client.query('ROLLBACK'); } catch (_) { /* ignore */ }
-            }
-            if (vaultWritten) {
-                try { await io.setDeviceVars(deviceId, priorVault); }
-                catch (restoreErr) {
-                    log('error', 'companion', `[Companion] vault restore failed after late error: ${restoreErr.message}`);
-                }
-            }
             log('error', 'companion', `[Companion] select failed: ${err.message}`);
-            return res.status(500).json({ success: false, layer: 'log', error: 'query_failed' });
-        } finally {
-            client.release();
+            return res.status(500).json({ success: false, error: 'query_failed' });
         }
     });
 
-    // Resolve the avatar URL for the vault write. Preference order matches
-    // the §0.4 frontend resolver: explicit avatar_url column wins; otherwise
-    // try descriptor.avatar.url (set by marketplace submit), then fall back
-    // to the Phase 0 static-path convention. This is the value that the
-    // dashboard's fast-paint mirror will read until AvatarPetdx.preload()
-    // resolves on the next page load.
+    // Resolve the avatar URL echoed back in the select response. Preference
+    // order matches the §0.4 frontend resolver: explicit avatar_url column
+    // wins; otherwise try descriptor.avatar.url (set by marketplace submit),
+    // then fall back to the Phase 0 static-path convention.
     function resolveCompanionAvatarUrl(row, companionId) {
         if (row && typeof row.avatar_url === 'string' && row.avatar_url.trim()) {
             return row.avatar_url.trim();

--- a/backend/index.js
+++ b/backend/index.js
@@ -7144,6 +7144,37 @@ function createPetdxPhase0Io() {
  */
 async function clearPetdxVaultForEntity(deviceId, entityId, callContext = 'unbind') {
     if (!deviceId || entityId === undefined || entityId === null) return 0;
+
+    // PR-B: write an unbind tombstone into companion_select_log (the source of
+    // truth) so getLatestSelection() and the /api/entities enrichment treat the
+    // slot as having no live companion — mirroring the old vault-cleared-on-
+    // unbind behaviour and letting a rebind re-assign a default. Copies the last
+    // real selection's companion_id (companion_id is NOT NULL) and tags
+    // origin='unbind-cleared'. Skipped when there is no prior selection or the
+    // latest row is already a tombstone. Best-effort: never breaks the unbind.
+    try {
+        const latest = await chatPool.query(
+            `SELECT companion_id, origin FROM companion_select_log
+              WHERE device_id = $1 AND entity_id = $2
+              ORDER BY selected_at DESC, id DESC LIMIT 1`,
+            [deviceId, entityId]
+        );
+        if (latest.rowCount > 0 && latest.rows[0].origin !== PETDX_TOMBSTONE_ORIGIN) {
+            await chatPool.query(
+                `INSERT INTO companion_select_log
+                    (device_id, entity_id, companion_id, selected_at, source, origin)
+                 VALUES ($1, $2, $3, $4, 'api', $5)`,
+                [deviceId, entityId, latest.rows[0].companion_id, Date.now(), PETDX_TOMBSTONE_ORIGIN]
+            );
+            serverLog('info', 'petdx_vault_clear',
+                `[Petdx tombstone] device ${deviceId} entity ${entityId} tombstoned (${callContext})`,
+                { deviceId, entityId, metadata: { callContext, companionId: latest.rows[0].companion_id } });
+        }
+    } catch (e) {
+        console.warn(`[Petdx tombstone] failed for ${deviceId}:${entityId}: ${e.message}`);
+    }
+
+    // Legacy vault-key cleanup (transitional — PR-C does the one-time fleet wipe).
     if (!SEAL_KEY_HEX) return 0;
     try {
         const row = await db.getDeviceVars(deviceId);
@@ -7197,29 +7228,38 @@ async function clearPetdxVaultForEntity(deviceId, entityId, callContext = 'unbin
     }
 }
 
+// PR-B: read the per-entity companion enrichment straight from the DB source of
+// truth (companion_select_log latest row per entity, JOIN companions for the
+// live avatar) instead of the retired PETDX_CURRENT_/PETDX_AVATAR_ vault mirror.
+// Output shape is unchanged: Map<entityId, {petdxCompanionId, petdxAvatarUrl}>.
+// petdxAvatarUrl prefers the live companions.avatar_url and falls back to the
+// /static/companions/<id>/avatar.png shape the vault used to cache. Tombstoned
+// (origin='unbind-cleared') entities are excluded so a freshly-unbound slot
+// shows no stale companion.
 async function getPetdxEntityEnrichmentMap(deviceId) {
     const out = new Map();
-    if (!deviceId || !SEAL_KEY_HEX) return out;
+    if (!deviceId) return out;
 
     try {
-        const row = await db.getDeviceVars(deviceId);
-        if (!row) return out;
-
-        const vars = decryptVars(row.encrypted_vars, row.iv, row.auth_tag) || {};
-        for (const [key, rawValue] of Object.entries(vars)) {
-            const m = /^PETDX_(CURRENT|AVATAR)_(\d+)$/.exec(key);
-            if (!m) continue;
-
-            const entityId = Number(m[2]);
+        const res = await chatPool.query(
+            `SELECT DISTINCT ON (l.entity_id)
+                    l.entity_id, l.companion_id, l.origin, c.avatar_url
+               FROM companion_select_log l
+               LEFT JOIN companions c ON c.id = l.companion_id
+              WHERE l.device_id = $1 AND l.entity_id IS NOT NULL
+              ORDER BY l.entity_id, l.selected_at DESC, l.id DESC`,
+            [deviceId]
+        );
+        for (const r of res.rows) {
+            if (r.origin === PETDX_TOMBSTONE_ORIGIN) continue;
+            const entityId = Number(r.entity_id);
             if (!Number.isFinite(entityId)) continue;
-
-            const value = typeof rawValue === 'string' && rawValue.trim() ? rawValue : null;
-            if (!value) continue;
-
-            const item = out.get(entityId) || {};
-            if (m[1] === 'CURRENT') item.petdxCompanionId = value;
-            if (m[1] === 'AVATAR') item.petdxAvatarUrl = value;
-            out.set(entityId, item);
+            const companionId = r.companion_id;
+            if (!companionId) continue;
+            const avatarUrl = (typeof r.avatar_url === 'string' && r.avatar_url.trim())
+                ? r.avatar_url
+                : `/static/companions/${companionId}/avatar.png`;
+            out.set(entityId, { petdxCompanionId: companionId, petdxAvatarUrl: avatarUrl });
         }
     } catch (err) {
         console.warn(`[/api/entities] petdx enrichment failed: ${err.message}`);
@@ -7326,8 +7366,6 @@ app.post('/api/admin/petdx-phase0/backfill', async (req, res) => {
                 : await (async () => {
                     const dryIo = {
                         ...io,
-                        setDeviceVars: async () => {},
-                        setDeviceVar: async () => {},
                         appendCompanionSelectLog: async () => {},
                     };
                     return assignDefaultCompanionIfMissing(deviceId, entityForHook, ctxBase, dryIo);

--- a/backend/petdx-phase0-hook.js
+++ b/backend/petdx-phase0-hook.js
@@ -175,19 +175,16 @@ function pickNewSource(ctx) {
  *
  *   io = {
  *     getLatestSelection(deviceId, entityId)  → Promise<{companionId, source}|null>
- *     getDeviceVar(deviceId, key)             → Promise<string|null>
- *     setDeviceVar(deviceId, key, value)      → Promise<void>
- *     setDeviceVars(deviceId, entries)        → Promise<void>      (optional batch write)
- *     appendCompanionSelectLog({...})         → Promise<void>
- *     log(level, tag, message, meta)          → void          (non-fatal logging)
+ *     getDeviceVar(deviceId, key)             → Promise<string|null>   (legacy read fallback only)
+ *     appendCompanionSelectLog({...})         → Promise<void>          (the SoT write)
+ *     log(level, tag, message, meta)          → void                   (non-fatal logging)
  *   }
  *
- * PR-A (PETDX SoT swap): idempotency reads come from `getLatestSelection`
+ * PETDX SoT swap: idempotency reads come from `getLatestSelection`
  * (companion_select_log = source of truth), not the PETDX_CURRENT_/PETDX_SOURCE_
- * vault mirror. The vault is still written (dual-write) for one validation
- * round; PR-B removes the vault writes. Because the DB is now SoT, the
- * companion_select_log append is FATAL — if it fails the hook reports a skip
- * rather than silently leaving the SoT un-updated.
+ * vault mirror. PR-B removed the vault writes entirely — the single
+ * companion_select_log append IS the write, and it is FATAL: if it fails the
+ * hook reports a skip rather than silently leaving the SoT un-updated.
  *
  * Returns `{ assigned, avatarUrl, source }` on a successful write, or
  * `{ skipped: <reason>, source? }` on an intentional no-op. Throws only on
@@ -207,7 +204,6 @@ async function assignDefaultCompanionIfMissing(deviceId, entity, ctx, io) {
 
     const eid = entity.entityId;
     const currentKey = `PETDX_CURRENT_${eid}`;
-    const avatarKey  = `PETDX_AVATAR_${eid}`;
     const sourceKey  = `PETDX_SOURCE_${eid}`;
 
     let existingCompanion = null;
@@ -244,30 +240,10 @@ async function assignDefaultCompanionIfMissing(deviceId, entity, ctx, io) {
     const avatarUrl   = avatarUrlFor(companionId);
     const newSource   = pickNewSource(ctx);
 
-    try {
-        const updates = {
-            [currentKey]: companionId,
-            [avatarKey]: avatarUrl,
-            [sourceKey]: newSource,
-        };
-        if (io.setDeviceVars) {
-            await io.setDeviceVars(deviceId, updates);
-        } else {
-            await io.setDeviceVar(deviceId, currentKey, companionId);
-            await io.setDeviceVar(deviceId, avatarKey,  avatarUrl);
-            await io.setDeviceVar(deviceId, sourceKey,  newSource);
-        }
-    } catch (err) {
-        io.log && io.log('error', '[petdx-phase0]', 'vault write failed', {
-            deviceId, entityId: eid, ctxMode: ctx.mode, ctxSource: ctx.source || null, error: err && err.message,
-        });
-        return { skipped: 'vault_write_failed' };
-    }
-
-    // companion_select_log is the source of truth (PR-A), so this append is
-    // FATAL: a failure here means the SoT was not updated, so report a skip
-    // (the vault mirror may be ahead, but getLatestSelection won't see the
-    // selection and the next hook run re-attempts — SoT stays authoritative).
+    // companion_select_log is the single source of truth (PR-B: the vault
+    // mirror writes are gone). This append IS the write and is therefore
+    // FATAL — a failure means the SoT was not updated, so report a skip and
+    // let the next hook run re-attempt rather than claiming a phantom assign.
     try {
         if (io.appendCompanionSelectLog) {
             await io.appendCompanionSelectLog({

--- a/backend/scripts/petdx-phase0-backfill.js
+++ b/backend/scripts/petdx-phase0-backfill.js
@@ -1,16 +1,15 @@
 #!/usr/bin/env node
 'use strict';
 
-const crypto = require('crypto');
 const { Pool } = require('pg');
 const {
-    avatarUrlFor,
     isCharacterDefaultAvatar,
     pickDefaultCompanion,
 } = require('../petdx-phase0-hook');
 
 const PHASE0_SOURCES = new Set(['phase0-auto', 'phase0-backfill']);
 const SOURCE = 'phase0-backfill';
+const TOMBSTONE_ORIGIN = 'unbind-cleared';
 
 function parseArgs(argv = process.argv) {
     const opts = {
@@ -33,8 +32,9 @@ function usage() {
     return [
         'Usage: node backend/scripts/petdx-phase0-backfill.js [--dry-run] [--commit] [--device=<deviceId>] [--json]',
         '',
-        'Default mode is --dry-run. --commit writes PETDX_CURRENT/PETDX_AVATAR/PETDX_SOURCE and audit rows.',
-        'Required env: DATABASE_URL. Required for decrypt/write: SEAL_KEY (64 hex chars).',
+        'Default mode is --dry-run. --commit appends companion_select_log rows (origin=phase0-backfill).',
+        'companion_select_log is the source of truth; no device-vars vault is read or written.',
+        'Required env: DATABASE_URL.',
     ].join('\n');
 }
 
@@ -57,39 +57,6 @@ function shouldUseSsl(connectionString) {
         // Fall through to production default.
     }
     return isProductionRuntime() ? { rejectUnauthorized: false } : false;
-}
-
-function assertSealKey(sealKey) {
-    if (!sealKey || !/^[0-9a-fA-F]{64}$/.test(sealKey)) {
-        throw new Error('SEAL_KEY must be exactly 64 hex characters');
-    }
-}
-
-function encryptVars(varsObj, sealKey) {
-    assertSealKey(sealKey);
-    const key = Buffer.from(sealKey, 'hex');
-    const iv = crypto.randomBytes(12);
-    const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
-    let encrypted = cipher.update(JSON.stringify(varsObj), 'utf8', 'base64');
-    encrypted += cipher.final('base64');
-    const authTag = cipher.getAuthTag();
-    return {
-        encrypted,
-        iv: iv.toString('hex'),
-        authTag: authTag.toString('hex'),
-    };
-}
-
-function decryptVars(encrypted, ivHex, authTagHex, sealKey) {
-    assertSealKey(sealKey);
-    const key = Buffer.from(sealKey, 'hex');
-    const iv = Buffer.from(ivHex, 'hex');
-    const authTag = Buffer.from(authTagHex, 'hex');
-    const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
-    decipher.setAuthTag(authTag);
-    let decrypted = decipher.update(encrypted, 'base64', 'utf8');
-    decrypted += decipher.final('utf8');
-    return JSON.parse(decrypted);
 }
 
 function normalizeJson(value, fallback) {
@@ -131,46 +98,29 @@ async function loadBoundEntities(pool, deviceId = null) {
     }));
 }
 
-async function loadVault(pool, sealKey, deviceId) {
+// Source of truth read: the latest companion_select_log row per entity. A
+// tombstone (origin='unbind-cleared') means the selection was cleared, so it
+// resolves to "no current selection" (null) and the entity is eligible for a
+// fresh backfill assignment.
+async function loadLatestSelections(pool, deviceId) {
     const result = await pool.query(
-        'SELECT encrypted_vars, iv, auth_tag, var_sources, is_locked FROM device_vars WHERE device_id = $1',
+        `SELECT DISTINCT ON (entity_id) entity_id, companion_id, origin
+           FROM companion_select_log
+          WHERE device_id = $1 AND entity_id IS NOT NULL
+          ORDER BY entity_id, selected_at DESC, id DESC`,
         [deviceId]
     );
-    if (!result.rows || result.rows.length === 0) {
-        return { vars: {}, sources: {}, locked: false };
+    const map = new Map();
+    for (const row of result.rows) {
+        const entityId = Number(row.entity_id);
+        if (!Number.isFinite(entityId)) continue;
+        if (row.origin === TOMBSTONE_ORIGIN) {
+            map.set(entityId, null);
+            continue;
+        }
+        map.set(entityId, { companionId: row.companion_id || null, source: row.origin || null });
     }
-    const row = result.rows[0];
-    return {
-        vars: decryptVars(row.encrypted_vars, row.iv, row.auth_tag, sealKey) || {},
-        sources: normalizeJson(row.var_sources, {}) || {},
-        locked: !!row.is_locked,
-    };
-}
-
-async function saveVault(pool, sealKey, deviceId, vault) {
-    const { encrypted, iv, authTag } = encryptVars(vault.vars, sealKey);
-    await pool.query(
-        `INSERT INTO device_vars (device_id, encrypted_vars, iv, auth_tag, var_keys, var_sources, is_locked, updated_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
-         ON CONFLICT (device_id)
-         DO UPDATE SET encrypted_vars = $2,
-                       iv = $3,
-                       auth_tag = $4,
-                       var_keys = $5,
-                       var_sources = $6,
-                       is_locked = $7,
-                       updated_at = $8`,
-        [
-            deviceId,
-            encrypted,
-            iv,
-            authTag,
-            Object.keys(vault.vars),
-            JSON.stringify(vault.sources || {}),
-            !!vault.locked,
-            Date.now(),
-        ]
-    );
+    return map;
 }
 
 async function appendAudit(pool, entry) {
@@ -182,55 +132,38 @@ async function appendAudit(pool, entry) {
     );
 }
 
-function petdxKeys(entityId) {
-    return {
-        currentKey: `PETDX_CURRENT_${entityId}`,
-        avatarKey: `PETDX_AVATAR_${entityId}`,
-        sourceKey: `PETDX_SOURCE_${entityId}`,
-    };
-}
-
-function planBackfillForEntity(entity, vars) {
-    const keys = petdxKeys(entity.entityId);
-    const current = vars[keys.currentKey] || null;
-    const source = vars[keys.sourceKey] || null;
+// `latest` is the entity's current companion_select_log selection
+// ({ companionId, source } | null), as returned by loadLatestSelections.
+function planBackfillForEntity(entity, latest) {
+    const current = latest ? (latest.companionId || null) : null;
+    const source = latest ? (latest.source || null) : null;
 
     if (entity.rental_status === 'leased_in') {
-        return { outcome: 'skipped', reason: 'rental-leased-in', entity, keys };
+        return { outcome: 'skipped', reason: 'rental-leased-in', entity };
     }
     if (!isCharacterDefaultAvatar(entity.avatar)) {
-        return { outcome: 'skipped', reason: 'user-custom-avatar', entity, keys };
+        return { outcome: 'skipped', reason: 'user-custom-avatar', entity };
     }
     if (source && !PHASE0_SOURCES.has(source)) {
-        return { outcome: 'preserves_existing_source', source, companionId: current, entity, keys };
+        return { outcome: 'preserves_existing_source', source, companionId: current, entity };
     }
     if (current && !source) {
         return {
             outcome: 'stamped-existing',
             companionId: current,
             entity,
-            keys,
-            updates: { [keys.sourceKey]: SOURCE },
             audit: { deviceId: entity.deviceId, entityId: entity.entityId, companionId: current },
         };
     }
     if (current) {
-        return { outcome: 'skipped', reason: 'already_assigned', source, companionId: current, entity, keys };
+        return { outcome: 'skipped', reason: 'already_assigned', source, companionId: current, entity };
     }
 
     const companionId = pickDefaultCompanion(entity);
-    const avatarUrl = avatarUrlFor(companionId);
     return {
         outcome: 'assigned',
         companionId,
-        avatarUrl,
         entity,
-        keys,
-        updates: {
-            [keys.currentKey]: companionId,
-            [keys.avatarKey]: avatarUrl,
-            [keys.sourceKey]: SOURCE,
-        },
         audit: { deviceId: entity.deviceId, entityId: entity.entityId, companionId },
     };
 }
@@ -262,7 +195,7 @@ function summarize(decisions) {
     return summary;
 }
 
-async function runBackfill({ pool, sealKey, commit = false, deviceId = null, logger = console } = {}) {
+async function runBackfill({ pool, commit = false, deviceId = null, logger = console } = {}) {
     if (!pool) throw new Error('pool required');
     const entities = await loadBoundEntities(pool, deviceId);
     const byDevice = new Map();
@@ -273,26 +206,17 @@ async function runBackfill({ pool, sealKey, commit = false, deviceId = null, log
 
     const decisions = [];
     for (const [devId, deviceEntities] of byDevice.entries()) {
-        const vault = await loadVault(pool, sealKey, devId);
-        let dirty = false;
+        const latestByEntity = await loadLatestSelections(pool, devId);
         const audits = [];
 
         for (const entity of deviceEntities) {
-            const decision = planBackfillForEntity(entity, vault.vars);
+            const decision = planBackfillForEntity(entity, latestByEntity.get(entity.entityId) || null);
             decisions.push(decision);
             if (!logger.json) logger.log(formatDecision(decision, commit));
-            if (decision.updates) {
-                Object.assign(vault.vars, decision.updates);
-                for (const key of Object.keys(decision.updates)) {
-                    vault.sources[key] = 'petdx-phase0';
-                }
-                dirty = true;
-            }
             if (decision.audit) audits.push(decision.audit);
         }
 
-        if (commit && dirty) {
-            await saveVault(pool, sealKey, devId, vault);
+        if (commit && audits.length) {
             for (const audit of audits) await appendAudit(pool, audit);
         }
     }
@@ -319,7 +243,6 @@ async function main(argv = process.argv, env = process.env) {
     try {
         const result = await runBackfill({
             pool,
-            sealKey: env.SEAL_KEY,
             commit: opts.commit,
             deviceId: opts.deviceId,
             logger: opts.json ? { json: true, log() {} } : console,
@@ -334,14 +257,11 @@ async function main(argv = process.argv, env = process.env) {
 module.exports = {
     SOURCE,
     PHASE0_SOURCES,
+    TOMBSTONE_ORIGIN,
     parseArgs,
-    encryptVars,
-    decryptVars,
     loadBoundEntities,
-    loadVault,
-    saveVault,
+    loadLatestSelections,
     appendAudit,
-    petdxKeys,
     planBackfillForEntity,
     summarize,
     runBackfill,

--- a/backend/tests/jest/admin-petdx-phase0-backfill.test.js
+++ b/backend/tests/jest/admin-petdx-phase0-backfill.test.js
@@ -32,10 +32,8 @@ describe('POST /api/admin/petdx-phase0/backfill', () => {
         expect(body).toMatch(/source:\s*['"]backfill-script['"]/);
         expect(body).toMatch(/assignDefaultCompanionIfMissing/);
     });
-    test('honors dry-run by stubbing the IO writes', () => {
+    test('honors dry-run by stubbing the companion_select_log write', () => {
         const body = handlerBody();
-        expect(body).toMatch(/setDeviceVars:\s*async \(\) => \{\}/);
-        expect(body).toMatch(/setDeviceVar:\s*async \(\) => \{\}/);
         expect(body).toMatch(/appendCompanionSelectLog:\s*async \(\) => \{\}/);
     });
     test('returns committed flag + per-entity results buckets', () => {

--- a/backend/tests/jest/companion-select-vault-sync.test.js
+++ b/backend/tests/jest/companion-select-vault-sync.test.js
@@ -1,26 +1,23 @@
 'use strict';
 
 /**
- * Companion API — POST /api/companion/select atomic vault-sync tests.
+ * Companion API — POST /api/companion/select source-of-truth tests.
  *
  * Spec: docs/specs/petdx-uiux-spec-amendment-2026-05-31-phase-0-4a.md §0.4a.
  *
- * The §0.4a invariant is "no partial success". This file covers the four
- * spec-mandated cases:
+ * PR-B (SoT refactor): companion_select_log is the single source of truth.
+ * /api/companion/select is now a single INSERT (origin='user-selected') with
+ * no per-entity PETDX_*_<id> vault mirror and no cross-pool tx. These tests
+ * cover:
  *
- *   1. Happy path — both the companion_select_log row (with
- *      origin='user-selected') AND the three PETDX_*_<id> vault keys are
- *      written. The response echoes the resolved avatarUrl.
- *   2. Vault write throws — the log tx ROLLBACKs and no log row lands;
- *      response is 500 {layer:'vault'}.
- *   3. Log COMMIT throws — the prior vault values are restored; response
- *      is 500 {layer:'log'}.
- *   4. Descriptor URL resolution — the avatar URL written into the vault
- *      comes from companions.avatar_url first, then descriptor.avatar.url,
- *      then the static-path fallback.
- *
- * The pg mock here is richer than the one in companion-api.test.js because
- * the §0.4a path uses pool.connect() + tx semantics.
+ *   1. Happy path — one companion_select_log INSERT; the response echoes the
+ *      resolved avatarUrl + origin. No vault writes happen.
+ *   2. INSERT failure — response is 500 {error:'query_failed'}.
+ *   3. Avatar URL resolution — the avatarUrl echoed in the response comes from
+ *      companions.avatar_url first, then descriptor.avatar.url, then the
+ *      static-path fallback.
+ *   4. device-secret auth (entityId=null) — the log row carries a null
+ *      entity_id and the same single-INSERT path is used.
  */
 
 jest.mock('pg', () => {
@@ -45,34 +42,14 @@ jest.mock('pg', () => {
 
 const express = require('express');
 const request = require('supertest');
-const { __mockQuery, __mockClientQuery, __mockRelease } = require('pg');
+const { __mockQuery, __mockClientQuery } = require('pg');
 const companionFactory = require('../../companion-api');
 
 const DEVICE = 'dev-vault-test';
 const ENTITY = 7;
 const SECRET = 'good-secret';
 
-function makeIoMock(initialVars = {}) {
-    const vars = { ...initialVars };
-    const writes = [];
-    return {
-        vars,
-        writes,
-        instance: {
-            async getDeviceVar(_deviceId, key) {
-                return Object.prototype.hasOwnProperty.call(vars, key) ? vars[key] : null;
-            },
-            async setDeviceVars(_deviceId, entries) {
-                writes.push({ ...entries });
-                for (const [k, v] of Object.entries(entries)) vars[k] = v;
-            },
-            log: () => {},
-            appendCompanionSelectLog: async () => {},
-        },
-    };
-}
-
-function makeApp({ ioMock, ioFactoryFails = false } = {}) {
+function makeApp() {
     const app = express();
     app.use(express.json());
     const authBot = (d, e, s) => d === DEVICE && e === ENTITY && s === SECRET;
@@ -81,9 +58,6 @@ function makeApp({ ioMock, ioFactoryFails = false } = {}) {
     const mod = companionFactory({
         authenticateBot: authBot,
         authenticateDeviceOrBot: authDevOrBot,
-        createPetdxPhase0Io: ioFactoryFails
-            ? () => { throw new Error('factory boom'); }
-            : () => ioMock.instance,
     });
     app.use('/api/companion', mod.router);
     return app;
@@ -99,19 +73,15 @@ const COMPANION_ROW_PUBLISHED = {
 beforeEach(() => {
     __mockQuery.mockReset();
     __mockClientQuery.mockReset();
-    __mockRelease.mockReset();
 });
 
-describe('POST /api/companion/select — §0.4a atomic vault sync', () => {
-    test('happy path: log row + 3 vault keys written; response echoes avatarUrl + origin', async () => {
-        const ioMock = makeIoMock();
-        __mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [COMPANION_ROW_PUBLISHED] }); // companion lookup
-        __mockClientQuery
-            .mockResolvedValueOnce({})  // BEGIN
-            .mockResolvedValueOnce({})  // INSERT
-            .mockResolvedValueOnce({}); // COMMIT
+describe('POST /api/companion/select — §0.4a companion_select_log SoT', () => {
+    test('happy path: single log INSERT; response echoes avatarUrl + origin; no vault', async () => {
+        __mockQuery
+            .mockResolvedValueOnce({ rowCount: 1, rows: [COMPANION_ROW_PUBLISHED] }) // companion lookup
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] });                       // INSERT
 
-        const res = await request(makeApp({ ioMock }))
+        const res = await request(makeApp())
             .post('/api/companion/select')
             .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
             .send({ companionId: 'petdx-zoro', source: 'app' });
@@ -123,170 +93,99 @@ describe('POST /api/companion/select — §0.4a atomic vault sync', () => {
         expect(res.body.selection.origin).toBe('user-selected');
         expect(res.body.selection.avatarUrl).toBe('https://r2.example/zoro/avatar.png');
 
-        // tx ordering: BEGIN, INSERT, COMMIT
-        expect(__mockClientQuery.mock.calls[0][0]).toBe('BEGIN');
-        expect(__mockClientQuery.mock.calls[1][0]).toMatch(/INSERT INTO companion_select_log/);
-        expect(__mockClientQuery.mock.calls[1][0]).toMatch(/origin/);
-        expect(__mockClientQuery.mock.calls[1][1]).toEqual([
+        // Single INSERT via pool.query — no tx, no pool.connect.
+        const insert = __mockQuery.mock.calls[1];
+        expect(insert[0]).toMatch(/INSERT INTO companion_select_log/);
+        expect(insert[0]).toMatch(/origin/);
+        expect(insert[1]).toEqual([
             DEVICE, ENTITY, 'petdx-zoro', expect.any(Number), 'app', 'user-selected',
         ]);
-        expect(__mockClientQuery.mock.calls[2][0]).toBe('COMMIT');
-
-        // vault: one batched setDeviceVars with the three keys
-        expect(ioMock.writes).toHaveLength(1);
-        expect(ioMock.writes[0]).toEqual({
-            [`PETDX_CURRENT_${ENTITY}`]: 'petdx-zoro',
-            [`PETDX_AVATAR_${ENTITY}`]:  'https://r2.example/zoro/avatar.png',
-            [`PETDX_SOURCE_${ENTITY}`]:  'user-selected',
-        });
-        // client released exactly once
-        expect(__mockRelease).toHaveBeenCalledTimes(1);
+        expect(__mockClientQuery).not.toHaveBeenCalled();
     });
 
-    test('vault write throws → ROLLBACK log tx, response 500 {layer:vault}', async () => {
-        const ioMock = makeIoMock({
-            [`PETDX_CURRENT_${ENTITY}`]: 'petdx-lobster-default',
-            [`PETDX_AVATAR_${ENTITY}`]: '/static/companions/petdx-lobster-default/avatar.png',
-            [`PETDX_SOURCE_${ENTITY}`]: 'phase0-backfill',
-        });
-        // Override setDeviceVars to throw on the FIRST call only (so restore
-        // path doesn't run — there's nothing to restore yet).
-        let writeCount = 0;
-        ioMock.instance.setDeviceVars = async () => {
-            writeCount++;
-            throw new Error('vault disk full');
-        };
+    test('INSERT failure → response 500 {error:query_failed}', async () => {
+        __mockQuery
+            .mockResolvedValueOnce({ rowCount: 1, rows: [COMPANION_ROW_PUBLISHED] })
+            .mockRejectedValueOnce(new Error('insert disk full'));
 
-        __mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [COMPANION_ROW_PUBLISHED] });
-        __mockClientQuery
-            .mockResolvedValueOnce({})  // BEGIN
-            .mockResolvedValueOnce({})  // INSERT
-            .mockResolvedValueOnce({}); // ROLLBACK
-
-        const res = await request(makeApp({ ioMock }))
+        const res = await request(makeApp())
             .post('/api/companion/select')
             .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
             .send({ companionId: 'petdx-zoro', source: 'app' });
 
         expect(res.status).toBe(500);
         expect(res.body.success).toBe(false);
-        expect(res.body.layer).toBe('vault');
-
-        // Last client query MUST be ROLLBACK
-        const last = __mockClientQuery.mock.calls[__mockClientQuery.mock.calls.length - 1];
-        expect(last[0]).toBe('ROLLBACK');
-        // Never COMMITted
-        expect(__mockClientQuery.mock.calls.every(c => c[0] !== 'COMMIT')).toBe(true);
-        expect(writeCount).toBe(1);
-        expect(__mockRelease).toHaveBeenCalledTimes(1);
-    });
-
-    test('log COMMIT throws → prior vault values restored, response 500 {layer:log}', async () => {
-        const PRIOR = {
-            [`PETDX_CURRENT_${ENTITY}`]: 'petdx-lobster-default',
-            [`PETDX_AVATAR_${ENTITY}`]: '/static/companions/petdx-lobster-default/avatar.png',
-            [`PETDX_SOURCE_${ENTITY}`]: 'phase0-backfill',
-        };
-        const ioMock = makeIoMock(PRIOR);
-
-        __mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [COMPANION_ROW_PUBLISHED] });
-        __mockClientQuery
-            .mockResolvedValueOnce({})                                          // BEGIN
-            .mockResolvedValueOnce({})                                          // INSERT
-            .mockRejectedValueOnce(new Error('connection lost during commit')); // COMMIT throws
-
-        const res = await request(makeApp({ ioMock }))
-            .post('/api/companion/select')
-            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
-            .send({ companionId: 'petdx-zoro', source: 'app' });
-
-        expect(res.status).toBe(500);
-        expect(res.body.layer).toBe('log');
-
-        // Vault: two writes — the forward write, then the restore back to prior.
-        expect(ioMock.writes).toHaveLength(2);
-        expect(ioMock.writes[1]).toEqual(PRIOR);
-        // And the in-memory vault state is back at prior values:
-        expect(ioMock.vars).toEqual(PRIOR);
-        expect(__mockRelease).toHaveBeenCalledTimes(1);
+        expect(res.body.error).toBe('query_failed');
+        expect(__mockClientQuery).not.toHaveBeenCalled();
     });
 
     test('avatar URL preference: avatar_url column wins over descriptor.avatar.url', async () => {
-        const ioMock = makeIoMock();
-        __mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{
-            id: 'petdx-x', status: 'published', scope: 'system',
-            device_id: null, author_entity_id: null,
-            avatar_url: '/explicit/avatar.png',
-            descriptor: { avatar: { url: '/from/descriptor.png' } },
-        }] });
-        __mockClientQuery
-            .mockResolvedValueOnce({})  // BEGIN
-            .mockResolvedValueOnce({})  // INSERT
-            .mockResolvedValueOnce({}); // COMMIT
+        __mockQuery
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{
+                id: 'petdx-x', status: 'published', scope: 'system',
+                device_id: null, author_entity_id: null,
+                avatar_url: '/explicit/avatar.png',
+                descriptor: { avatar: { url: '/from/descriptor.png' } },
+            }] })
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] });
 
-        const res = await request(makeApp({ ioMock }))
+        const res = await request(makeApp())
             .post('/api/companion/select')
             .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
             .send({ companionId: 'petdx-x', source: 'app' });
 
         expect(res.status).toBe(200);
-        expect(ioMock.vars[`PETDX_AVATAR_${ENTITY}`]).toBe('/explicit/avatar.png');
+        expect(res.body.selection.avatarUrl).toBe('/explicit/avatar.png');
     });
 
     test('avatar URL preference: descriptor.avatar.url wins when avatar_url column is null', async () => {
-        const ioMock = makeIoMock();
-        __mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{
-            id: 'petdx-x', status: 'published', scope: 'system',
-            device_id: null, author_entity_id: null,
-            avatar_url: null,
-            descriptor: { avatar: { url: '/from/descriptor.png' } },
-        }] });
-        __mockClientQuery
-            .mockResolvedValueOnce({}).mockResolvedValueOnce({}).mockResolvedValueOnce({});
+        __mockQuery
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{
+                id: 'petdx-x', status: 'published', scope: 'system',
+                device_id: null, author_entity_id: null,
+                avatar_url: null,
+                descriptor: { avatar: { url: '/from/descriptor.png' } },
+            }] })
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] });
 
-        await request(makeApp({ ioMock }))
+        const res = await request(makeApp())
             .post('/api/companion/select')
             .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
             .send({ companionId: 'petdx-x', source: 'app' });
 
-        expect(ioMock.vars[`PETDX_AVATAR_${ENTITY}`]).toBe('/from/descriptor.png');
+        expect(res.body.selection.avatarUrl).toBe('/from/descriptor.png');
     });
 
     test('avatar URL preference: static-path fallback when both are missing', async () => {
-        const ioMock = makeIoMock();
-        __mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{
-            id: 'petdx-lobster-default', status: 'published', scope: 'system',
-            device_id: null, author_entity_id: null,
-            avatar_url: null,
-            descriptor: { description: 'procedural-only, no avatar shape' },
-        }] });
-        __mockClientQuery
-            .mockResolvedValueOnce({}).mockResolvedValueOnce({}).mockResolvedValueOnce({});
+        __mockQuery
+            .mockResolvedValueOnce({ rowCount: 1, rows: [{
+                id: 'petdx-lobster-default', status: 'published', scope: 'system',
+                device_id: null, author_entity_id: null,
+                avatar_url: null,
+                descriptor: { description: 'procedural-only, no avatar shape' },
+            }] })
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] });
 
-        await request(makeApp({ ioMock }))
+        const res = await request(makeApp())
             .post('/api/companion/select')
             .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
             .send({ companionId: 'petdx-lobster-default', source: 'app' });
 
-        expect(ioMock.vars[`PETDX_AVATAR_${ENTITY}`])
+        expect(res.body.selection.avatarUrl)
             .toBe('/static/companions/petdx-lobster-default/avatar.png');
     });
 
-    test('device-secret auth (entityId=null) skips vault write but still fills log + origin', async () => {
-        const ioMock = makeIoMock();
-        // No __mockClientQuery responses — should never be called.
+    test('device-secret auth (entityId=null) writes a log row with null entity_id', async () => {
         __mockQuery
             .mockResolvedValueOnce({ rowCount: 1, rows: [COMPANION_ROW_PUBLISHED] })
-            .mockResolvedValueOnce({ rowCount: 1, rows: [] }); // legacy INSERT via pool.query
+            .mockResolvedValueOnce({ rowCount: 1, rows: [] });
 
-        // Override the auth predicate so deviceSecret-only succeeds with entityId=null.
         const app = express();
         app.use(express.json());
         const mod = companionFactory({
             authenticateBot: (d, e, s) => false,
             authenticateDeviceOrBot: ({ deviceId, deviceSecret }) =>
                 deviceId === DEVICE && deviceSecret === 'dev-secret',
-            createPetdxPhase0Io: () => ioMock.instance,
         });
         app.use('/api/companion', mod.router);
 
@@ -297,51 +196,11 @@ describe('POST /api/companion/select — §0.4a atomic vault sync', () => {
 
         expect(res.status).toBe(200);
         expect(res.body.selection.companionId).toBe('petdx-zoro');
-        // Vault must NOT be touched.
-        expect(ioMock.writes).toHaveLength(0);
-        // Log INSERT used the legacy pool.query path.
-        expect(__mockClientQuery).not.toHaveBeenCalled();
         const insert = __mockQuery.mock.calls[1];
         expect(insert[0]).toMatch(/INSERT INTO companion_select_log/);
-        // entityId column gets null since none was provided.
         expect(insert[1]).toEqual([
             DEVICE, null, 'petdx-zoro', expect.any(Number), 'app', 'user-selected',
         ]);
-    });
-
-    test('factory-not-injected fallback: legacy log-only INSERT (origin still written, no vault writes)', async () => {
-        // No createPetdxPhase0Io passed → legacy code path.
-        const app = (() => {
-            const a = express();
-            a.use(express.json());
-            const mod = companionFactory({
-                authenticateBot: (d, e, s) => d === DEVICE && e === ENTITY && s === SECRET,
-                authenticateDeviceOrBot: ({ deviceId, botSecret, entityId }) =>
-                    deviceId === DEVICE && botSecret === SECRET && entityId === ENTITY,
-            });
-            a.use('/api/companion', mod.router);
-            return a;
-        })();
-
-        __mockQuery
-            .mockResolvedValueOnce({ rowCount: 1, rows: [COMPANION_ROW_PUBLISHED] })
-            .mockResolvedValueOnce({ rowCount: 1, rows: [] });
-
-        const res = await request(app)
-            .post('/api/companion/select')
-            .query({ deviceId: DEVICE, botSecret: SECRET, entityId: ENTITY })
-            .send({ companionId: 'petdx-zoro', source: 'app' });
-
-        expect(res.status).toBe(200);
-        // Legacy path uses pool.query, NOT pool.connect; the second
-        // pool.query call is the INSERT (origin column included).
-        const insert = __mockQuery.mock.calls[1];
-        expect(insert[0]).toMatch(/INSERT INTO companion_select_log/);
-        expect(insert[0]).toMatch(/origin/);
-        expect(insert[1]).toEqual([
-            DEVICE, ENTITY, 'petdx-zoro', expect.any(Number), 'app', 'user-selected',
-        ]);
-        // No client.connect calls in legacy path.
         expect(__mockClientQuery).not.toHaveBeenCalled();
     });
 });

--- a/backend/tests/jest/entities-petdx-enrichment.test.js
+++ b/backend/tests/jest/entities-petdx-enrichment.test.js
@@ -1,7 +1,9 @@
 /**
- * Phase 0 regression: /api/entities is the canonical transport for
- * PETDX_CURRENT_<entityId> and PETDX_AVATAR_<entityId>. The portal resolver
- * must not read broad device-vars directly just to render kanban avatars.
+ * PR-B regression: /api/entities enrichment reads companion selections from
+ * the companion_select_log source of truth (joined to companions for the live
+ * avatar_url), NOT the retired PETDX_CURRENT_/PETDX_AVATAR_<id> device-vars
+ * vault mirror. The portal resolver still receives petdxCompanionId +
+ * petdxAvatarUrl on each entity payload.
  */
 
 const fs = require('fs');
@@ -18,16 +20,24 @@ describe('/api/entities petdx enrichment', () => {
     const helper = slice('async function getPetdxEntityEnrichmentMap', 2500);
     const handler = slice("app.get('/api/entities',", 8000);
 
-    it('decrypts device_vars once server-side and projects only PETDX_CURRENT/PETDX_AVATAR keys', () => {
-        expect(helper).toMatch(/db\.getDeviceVars\(deviceId\)/);
-        expect(helper).toMatch(/decryptVars\(row\.encrypted_vars,\s*row\.iv,\s*row\.auth_tag\)/);
-        expect(helper).toMatch(/PETDX_\(CURRENT\|AVATAR\)_/);
-        expect(helper).toMatch(/item\.petdxCompanionId\s*=\s*value/);
-        expect(helper).toMatch(/item\.petdxAvatarUrl\s*=\s*value/);
+    it('reads the latest selection per entity from companion_select_log joined to companions', () => {
+        expect(helper).toMatch(/chatPool\.query/);
+        expect(helper).toMatch(/DISTINCT ON \(l\.entity_id\)/);
+        expect(helper).toMatch(/FROM companion_select_log l/);
+        expect(helper).toMatch(/LEFT JOIN companions c ON c\.id = l\.companion_id/);
+        // No vault decrypt path remains.
+        expect(helper).not.toMatch(/decryptVars/);
+        expect(helper).not.toMatch(/db\.getDeviceVars/);
     });
 
-    it('does not break /api/entities when vault enrichment is unavailable', () => {
-        expect(helper).toMatch(/if \(!deviceId \|\| !SEAL_KEY_HEX\) return out/);
+    it('skips tombstoned selections and falls back to the static avatar path', () => {
+        expect(helper).toMatch(/if \(r\.origin === PETDX_TOMBSTONE_ORIGIN\) continue/);
+        expect(helper).toMatch(/\/static\/companions\/\$\{companionId\}\/avatar\.png/);
+        expect(helper).toMatch(/petdxCompanionId: companionId, petdxAvatarUrl: avatarUrl/);
+    });
+
+    it('does not break /api/entities when enrichment query fails', () => {
+        expect(helper).toMatch(/if \(!deviceId\) return out/);
         expect(helper).toMatch(/catch \(err\)/);
         expect(helper).toMatch(/return out/);
     });

--- a/backend/tests/jest/petdx-phase0-backfill.test.js
+++ b/backend/tests/jest/petdx-phase0-backfill.test.js
@@ -1,7 +1,6 @@
 const backfill = require('../../scripts/petdx-phase0-backfill');
 
 const LOBSTER_COMPANION = 'petdx-lobster-default';
-const LOBSTER_AVATAR_URL = '/static/companions/petdx-lobster-default/avatar.png';
 
 function entity(overrides = {}) {
     return {
@@ -16,16 +15,11 @@ function entity(overrides = {}) {
 }
 
 describe('petdx-phase0-backfill decision planner', () => {
-    test('fresh default-avatar entity receives current/avatar/source updates', () => {
-        const decision = backfill.planBackfillForEntity(entity(), {});
+    test('fresh default-avatar entity (no log selection) is assigned + audited', () => {
+        const decision = backfill.planBackfillForEntity(entity(), null);
         expect(decision.outcome).toBe('assigned');
         expect(decision.companionId).toBe(LOBSTER_COMPANION);
-        expect(decision.avatarUrl).toBe(LOBSTER_AVATAR_URL);
-        expect(decision.updates).toEqual({
-            PETDX_CURRENT_7: LOBSTER_COMPANION,
-            PETDX_AVATAR_7: LOBSTER_AVATAR_URL,
-            PETDX_SOURCE_7: 'phase0-backfill',
-        });
+        expect(decision.updates).toBeUndefined();
         expect(decision.audit).toMatchObject({
             deviceId: 'D1',
             entityId: 7,
@@ -33,52 +27,53 @@ describe('petdx-phase0-backfill decision planner', () => {
         });
     });
 
-    test('existing current without source stamps source only', () => {
+    test('existing selection without source stamps a phase0 audit row', () => {
         const decision = backfill.planBackfillForEntity(entity(), {
-            PETDX_CURRENT_7: 'petdx-legacy',
-            PETDX_AVATAR_7: '/static/companions/petdx-legacy/avatar.png',
+            companionId: 'petdx-legacy',
+            source: null,
         });
         expect(decision.outcome).toBe('stamped-existing');
-        expect(decision.updates).toEqual({ PETDX_SOURCE_7: 'phase0-backfill' });
+        expect(decision.updates).toBeUndefined();
         expect(decision.audit.companionId).toBe('petdx-legacy');
     });
 
     test('user-selected source is preserved untouched', () => {
         const decision = backfill.planBackfillForEntity(entity(), {
-            PETDX_CURRENT_7: 'petdx-custom',
-            PETDX_SOURCE_7: 'user-selected',
+            companionId: 'petdx-custom',
+            source: 'user-selected',
         });
         expect(decision).toMatchObject({
             outcome: 'preserves_existing_source',
             source: 'user-selected',
             companionId: 'petdx-custom',
         });
-        expect(decision.updates).toBeUndefined();
+        expect(decision.audit).toBeUndefined();
     });
 
-    test('non-phase0 source tag is preserved even when current is missing', () => {
+    test('non-phase0 source tag is preserved even when companion is missing', () => {
         const decision = backfill.planBackfillForEntity(entity(), {
-            PETDX_SOURCE_7: 'rental-inherited',
+            companionId: null,
+            source: 'rental-inherited',
         });
         expect(decision).toMatchObject({
             outcome: 'preserves_existing_source',
             source: 'rental-inherited',
             companionId: null,
         });
-        expect(decision.updates).toBeUndefined();
+        expect(decision.audit).toBeUndefined();
     });
 
     test('leased-in rental and custom avatar are skipped', () => {
-        expect(backfill.planBackfillForEntity(entity({ rental_status: 'leased_in' }), {}))
+        expect(backfill.planBackfillForEntity(entity({ rental_status: 'leased_in' }), null))
             .toMatchObject({ outcome: 'skipped', reason: 'rental-leased-in' });
-        expect(backfill.planBackfillForEntity(entity({ avatar: 'https://example.com/me.png' }), {}))
+        expect(backfill.planBackfillForEntity(entity({ avatar: 'https://example.com/me.png' }), null))
             .toMatchObject({ outcome: 'skipped', reason: 'user-custom-avatar' });
     });
 
-    test('phase0 current is idempotent', () => {
+    test('phase0 selection is idempotent', () => {
         const decision = backfill.planBackfillForEntity(entity(), {
-            PETDX_CURRENT_7: LOBSTER_COMPANION,
-            PETDX_SOURCE_7: 'phase0-auto',
+            companionId: LOBSTER_COMPANION,
+            source: 'phase0-auto',
         });
         expect(decision).toMatchObject({
             outcome: 'skipped',

--- a/backend/tests/jest/petdx-phase0-hook.test.js
+++ b/backend/tests/jest/petdx-phase0-hook.test.js
@@ -88,7 +88,7 @@ describe('petdx-phase0-hook — pure helpers', () => {
 });
 
 describe('petdx-phase0-hook — assignDefaultCompanionIfMissing', () => {
-    test('first-time bind writes all 3 vault keys + audit log', async () => {
+    test('first-time bind appends the companion_select_log row (PR-B: no vault write)', async () => {
         const io = makeIo();
         const result = await hook.assignDefaultCompanionIfMissing(
             'D1',
@@ -101,9 +101,10 @@ describe('petdx-phase0-hook — assignDefaultCompanionIfMissing', () => {
             avatarUrl: LOBSTER_AVATAR_URL,
             source: 'phase0-auto',
         });
-        expect(io.vars.PETDX_CURRENT_7).toBe(LOBSTER_COMPANION);
-        expect(io.vars.PETDX_AVATAR_7).toBe(LOBSTER_AVATAR_URL);
-        expect(io.vars.PETDX_SOURCE_7).toBe('phase0-auto');
+        // PR-B: the vault mirror is gone — the single SoT write is the audit log.
+        expect(io.vars.PETDX_CURRENT_7).toBeUndefined();
+        expect(io.vars.PETDX_AVATAR_7).toBeUndefined();
+        expect(io.vars.PETDX_SOURCE_7).toBeUndefined();
         expect(io.auditCalls).toHaveLength(1);
         expect(io.auditCalls[0]).toMatchObject({
             entityId: 7,
@@ -113,27 +114,6 @@ describe('petdx-phase0-hook — assignDefaultCompanionIfMissing', () => {
             ctxMode: 'bind',
             ctxSource: 'bind-endpoint',
         });
-    });
-
-    test('first-time bind uses batch vault write when IO supports it', async () => {
-        const io = makeIo();
-        io.setDeviceVars = jest.fn(async (_deviceId, entries) => {
-            Object.assign(io.vars, entries);
-        });
-        io.setDeviceVar = jest.fn();
-        const result = await hook.assignDefaultCompanionIfMissing(
-            'D1',
-            { entityId: 7, character: 'LOBSTER', avatar: null },
-            { mode: 'bind', source: 'bind-endpoint' },
-            io,
-        );
-        expect(result.assigned).toBe(LOBSTER_COMPANION);
-        expect(io.setDeviceVars).toHaveBeenCalledWith('D1', {
-            PETDX_CURRENT_7: LOBSTER_COMPANION,
-            PETDX_AVATAR_7: LOBSTER_AVATAR_URL,
-            PETDX_SOURCE_7: 'phase0-auto',
-        });
-        expect(io.setDeviceVar).not.toHaveBeenCalled();
     });
 
     test('second bind is a no-op when phase0-auto already set', async () => {
@@ -321,7 +301,6 @@ describe('petdx-phase0-hook — assignDefaultCompanionIfMissing', () => {
             io,
         );
         expect(result.source).toBe('phase0-backfill');
-        expect(io.vars.PETDX_SOURCE_7).toBe('phase0-backfill');
         expect(io.auditCalls[0].origin).toBe('phase0-backfill');
         expect(io.auditCalls[0].ctxSource).toBe('backfill-script');
     });
@@ -349,20 +328,7 @@ describe('petdx-phase0-hook — assignDefaultCompanionIfMissing', () => {
         expect(io.vars.PETDX_CURRENT_7).toBeUndefined();
     });
 
-    test('vault write failure is reported, no audit', async () => {
-        const io = makeIo();
-        io.setDeviceVar = async () => { throw new Error('boom'); };
-        const result = await hook.assignDefaultCompanionIfMissing(
-            'D1',
-            { entityId: 7, character: 'LOBSTER', avatar: null },
-            { mode: 'bind' },
-            io,
-        );
-        expect(result.skipped).toBe('vault_write_failed');
-        expect(io.auditCalls).toHaveLength(0);
-    });
-
-    test('companion_select_log write failure is FATAL (PR-A: log is SoT)', async () => {
+    test('companion_select_log write failure is FATAL (log is the only SoT write)', async () => {
         const io = makeIo();
         io.appendCompanionSelectLog = async () => { throw new Error('log boom'); };
         const result = await hook.assignDefaultCompanionIfMissing(
@@ -372,8 +338,9 @@ describe('petdx-phase0-hook — assignDefaultCompanionIfMissing', () => {
             io,
         );
         expect(result).toEqual({ skipped: 'log_write_failed' });
-        // Vault mirror was written before the (now-fatal) SoT append.
-        expect(io.vars.PETDX_SOURCE_7).toBe('phase0-auto');
+        // PR-B: no vault mirror is written at all.
+        expect(io.vars.PETDX_CURRENT_7).toBeUndefined();
+        expect(io.vars.PETDX_SOURCE_7).toBeUndefined();
     });
 });
 

--- a/backend/tests/jest/petdx-vault-clear-on-unbind.test.js
+++ b/backend/tests/jest/petdx-vault-clear-on-unbind.test.js
@@ -66,6 +66,28 @@ describe('clearPetdxVaultForEntity — static invariants', () => {
         }
     });
 
+    it('PR-B: writes an unbind tombstone into companion_select_log before the legacy wipe', () => {
+        const fs = require('fs');
+        const src = fs.readFileSync(require.resolve('../../index'), 'utf8');
+        const i = src.indexOf('async function clearPetdxVaultForEntity');
+        expect(i).toBeGreaterThan(-1);
+        const body = src.slice(i, i + 2600);
+        // Looks up the latest selection, then inserts a tombstone row tagged
+        // origin=PETDX_TOMBSTONE_ORIGIN, skipping when already tombstoned.
+        expect(body).toMatch(/FROM companion_select_log/);
+        expect(body).toMatch(/INSERT INTO companion_select_log/);
+        expect(body).toMatch(/latest\.rows\[0\]\.origin !== PETDX_TOMBSTONE_ORIGIN/);
+        expect(body).toMatch(/PETDX_TOMBSTONE_ORIGIN/);
+        // The tombstone write is best-effort and must not break the unbind.
+        expect(body).toMatch(/\[Petdx tombstone\] failed/);
+    });
+
+    it('PR-B: PETDX_TOMBSTONE_ORIGIN is the unbind-cleared sentinel origin', () => {
+        const fs = require('fs');
+        const src = fs.readFileSync(require.resolve('../../index'), 'utf8');
+        expect(src).toMatch(/PETDX_TOMBSTONE_ORIGIN\s*=\s*['"]unbind-cleared['"]/);
+    });
+
     it('helper signature: (deviceId, entityId, callContext) — null/undefined inputs short-circuit', () => {
         // Documents the early-exit contract: if deviceId or entityId is missing,
         // the helper returns 0 without throwing or hitting the DB.


### PR DESCRIPTION
## Summary

PR-B of the 3-PR AvatarPetdx SoT refactor. Retires the per-entity
`PETDX_CURRENT_/AVATAR_/SOURCE_<entityId>` device-vars vault mirror; the
`companion_select_log` DB table is now the **single source of truth** for
companion selection. (PR-A landed the SoT read + dual-write in #3410.)

### Changes
- **petdx-phase0-hook.js** — removed the vault write block; the single fatal
  `appendCompanionSelectLog` is the only SoT write. Reads stay on
  `getLatestSelection` (with legacy `getDeviceVar` fallback).
- **index.js `getPetdxEntityEnrichmentMap`** — reads the latest selection per
  entity from `companion_select_log` JOIN `companions` (live `avatar_url`,
  `/static/companions/<id>/avatar.png` fallback) instead of decrypting the
  vault. Tombstoned slots are excluded.
- **index.js `clearPetdxVaultForEntity`** — writes an unbind tombstone
  (`origin='unbind-cleared'`) into the log so a rebound slot re-assigns a
  default. The legacy vault-key wipe is kept transitional; **PR-C** does the
  one-time fleet wipe.
- **index.js admin backfill** — dry-run io stub drops the now-dead
  `setDeviceVars`/`setDeviceVar`.
- **companion-api `/api/companion/select`** — single log INSERT
  (`origin='user-selected'`); removed the cross-pool tx + vault dual-write +
  restore machinery.
- **scripts/petdx-phase0-backfill.js** — idempotency now reads the log
  (`loadLatestSelections`), append-only; removed vault read/write + the
  `SEAL_KEY`/crypto dependency.
- **tests** — updated hook/backfill/admin/select/enrichment/unbind suites for
  the log-only behavior; added unbind-tombstone + enrichment-JOIN coverage.

### Verification
- `npx eslint` on all 4 changed source files: 0 errors (2 pre-existing warnings).
- Full backend jest: **306 suites, 4178 passed, 17 skipped, 0 failures**.

## Self-review checklist (docs/code-review-checklist.md)
1. **Scope** — only the vault-mirror retirement; no unrelated changes.
2. **Tests** — all affected suites updated + new tombstone/JOIN coverage; full suite green.
3. **Security** — no new inputs; parameterized SQL; companionId regex unchanged; no secrets logged.
4. **Error handling** — log append stays fatal (skip, not phantom assign); tombstone write best-effort; enrichment query failure returns empty map (non-fatal poll).
5. **i18n** — no user-facing strings changed.
6. **Backwards-compat** — `getLatestSelection` keeps the `getDeviceVar` read fallback; the legacy vault wipe remains until PR-C; `user-selected`/`rental-inherited` semantics preserved.
7. **Performance** — enrichment is one DISTINCT ON query per device (was one decrypt); select drops a pool.connect + 3 vault round-trips.
8. **Data integrity** — tombstone copies the last real `companion_id` (NOT NULL), skips when already tombstoned; idempotency unchanged.
9. **Observability** — tombstone + enrichment-failure serverLog lines retained.
10. **Migration/rollout** — no schema change (uses PR-A's `origin` column); chained after PR-A; PR-C handles the residual-key fleet wipe.

Reviewer: Entity 2. Chained after #3410 (PR-A, merged). PR-C follows.
