### PR TITLE
chore(petdx): PR-C — one-time vault cleanup for residual PETDX_* keys

### DIFF
--- a/backend/scripts/petdx-vault-cleanup.js
+++ b/backend/scripts/petdx-vault-cleanup.js
@@ -1,0 +1,294 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Petdx PR-C — one-time device-vars vault cleanup.
+ *
+ * PR-A + PR-B moved AvatarPetdx companion selection entirely onto
+ * companion_select_log (the source of truth). The per-entity
+ * PETDX_CURRENT_<id> / PETDX_AVATAR_<id> / PETDX_SOURCE_<id> vault keys are no
+ * longer read or written by any code path. This script removes the residual
+ * keys that older binds left behind.
+ *
+ * Safety:
+ *   - Default mode is --dry-run; nothing is written without --commit.
+ *   - Scope to a single device with --device=<id> for the pilot soak.
+ *   - Only keys matching ^PETDX_(CURRENT|AVATAR|SOURCE)_<digits>$ are touched;
+ *     every other vault entry (including unrelated PETDX_* names) is preserved.
+ *   - Each removal is recorded in device_vars_audit (action='delete_one',
+ *     source='petdx-phase0-prc-cleanup'); values are never logged.
+ *
+ * Rollout (per the chained kanban card):
+ *   1. node petdx-vault-cleanup.js --device=<hank> --commit   (pilot)
+ *   2. 24h soak — confirm dashboards/avatars still resolve from the log SoT
+ *   3. node petdx-vault-cleanup.js --commit                   (fleet-wide)
+ *
+ * Required env: DATABASE_URL, SEAL_KEY (64 hex chars).
+ */
+
+const crypto = require('crypto');
+const { Pool } = require('pg');
+
+const CLEANUP_SOURCE = 'petdx-phase0-prc-cleanup';
+const PETDX_VAULT_KEY_RE = /^PETDX_(CURRENT|AVATAR|SOURCE)_\d+$/;
+
+function parseArgs(argv = process.argv) {
+    const opts = {
+        commit: false,
+        deviceId: process.env.DEVICE_ID || null,
+        json: false,
+    };
+    for (const arg of argv.slice(2)) {
+        if (arg === '--commit' || arg === '--apply') opts.commit = true;
+        else if (arg === '--dry-run') opts.commit = false;
+        else if (arg === '--json') opts.json = true;
+        else if (arg.startsWith('--device=')) opts.deviceId = arg.slice('--device='.length);
+        else if (arg === '--help' || arg === '-h') opts.help = true;
+        else throw new Error(`Unknown argument: ${arg}`);
+    }
+    return opts;
+}
+
+function usage() {
+    return [
+        'Usage: node backend/scripts/petdx-vault-cleanup.js [--dry-run] [--commit] [--device=<deviceId>] [--json]',
+        '',
+        'Removes residual PETDX_CURRENT/AVATAR/SOURCE_<entityId> vault keys (PR-C).',
+        'Default mode is --dry-run. --commit re-encrypts each device vault without the keys.',
+        'Required env: DATABASE_URL, SEAL_KEY (64 hex chars).',
+    ].join('\n');
+}
+
+function isProductionRuntime() {
+    return process.env.NODE_ENV === 'production' || Boolean(process.env.RAILWAY_ENVIRONMENT);
+}
+
+function shouldUseSsl(connectionString) {
+    const sslMode = (process.env.PGSSLMODE || '').toLowerCase();
+    if (sslMode === 'disable') return false;
+    if (sslMode === 'require' || sslMode === 'verify-ca' || sslMode === 'verify-full') {
+        return { rejectUnauthorized: sslMode !== 'require' };
+    }
+    try {
+        const host = new URL(connectionString).hostname;
+        if (host === 'localhost' || host === '127.0.0.1' || host.endsWith('.railway.internal')) {
+            return false;
+        }
+    } catch (_) {
+        // Fall through to production default.
+    }
+    return isProductionRuntime() ? { rejectUnauthorized: false } : false;
+}
+
+function assertSealKey(sealKey) {
+    if (!sealKey || !/^[0-9a-fA-F]{64}$/.test(sealKey)) {
+        throw new Error('SEAL_KEY must be exactly 64 hex characters');
+    }
+}
+
+function encryptVars(varsObj, sealKey) {
+    assertSealKey(sealKey);
+    const key = Buffer.from(sealKey, 'hex');
+    const iv = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv('aes-256-gcm', key, iv);
+    let encrypted = cipher.update(JSON.stringify(varsObj), 'utf8', 'base64');
+    encrypted += cipher.final('base64');
+    const authTag = cipher.getAuthTag();
+    return {
+        encrypted,
+        iv: iv.toString('hex'),
+        authTag: authTag.toString('hex'),
+    };
+}
+
+function decryptVars(encrypted, ivHex, authTagHex, sealKey) {
+    assertSealKey(sealKey);
+    const key = Buffer.from(sealKey, 'hex');
+    const iv = Buffer.from(ivHex, 'hex');
+    const authTag = Buffer.from(authTagHex, 'hex');
+    const decipher = crypto.createDecipheriv('aes-256-gcm', key, iv);
+    decipher.setAuthTag(authTag);
+    let decrypted = decipher.update(encrypted, 'base64', 'utf8');
+    decrypted += decipher.final('utf8');
+    return JSON.parse(decrypted);
+}
+
+function normalizeJson(value, fallback) {
+    if (!value) return fallback;
+    if (typeof value === 'string') {
+        try { return JSON.parse(value); } catch (_) { return fallback; }
+    }
+    return value;
+}
+
+// Pure: the residual PETDX_* keys present on a decrypted vars object.
+function planCleanup(vars) {
+    if (!vars || typeof vars !== 'object') return [];
+    return Object.keys(vars).filter(k => PETDX_VAULT_KEY_RE.test(k));
+}
+
+async function loadDeviceIds(pool, deviceId = null) {
+    if (deviceId) return [deviceId];
+    const res = await pool.query('SELECT device_id FROM device_vars ORDER BY device_id');
+    return res.rows.map(r => r.device_id);
+}
+
+async function loadVault(pool, sealKey, deviceId) {
+    const res = await pool.query(
+        'SELECT encrypted_vars, iv, auth_tag, var_sources, is_locked FROM device_vars WHERE device_id = $1',
+        [deviceId]
+    );
+    if (!res.rows || res.rows.length === 0) return null;
+    const row = res.rows[0];
+    return {
+        vars: decryptVars(row.encrypted_vars, row.iv, row.auth_tag, sealKey) || {},
+        sources: normalizeJson(row.var_sources, {}) || {},
+        locked: !!row.is_locked,
+    };
+}
+
+async function saveVault(pool, sealKey, deviceId, vault) {
+    const { encrypted, iv, authTag } = encryptVars(vault.vars, sealKey);
+    await pool.query(
+        `INSERT INTO device_vars (device_id, encrypted_vars, iv, auth_tag, var_keys, var_sources, is_locked, updated_at)
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+         ON CONFLICT (device_id)
+         DO UPDATE SET encrypted_vars = $2,
+                       iv = $3,
+                       auth_tag = $4,
+                       var_keys = $5,
+                       var_sources = $6,
+                       is_locked = $7,
+                       updated_at = $8`,
+        [
+            deviceId,
+            encrypted,
+            iv,
+            authTag,
+            Object.keys(vault.vars),
+            JSON.stringify(vault.sources || {}),
+            !!vault.locked,
+            Date.now(),
+        ]
+    );
+}
+
+async function appendAudit(pool, { deviceId, keyName, beforeCount, afterCount }) {
+    await pool.query(
+        `INSERT INTO device_vars_audit
+            (device_id, action, key_name, source, before_count, after_count)
+         VALUES ($1, 'delete_one', $2, $3, $4, $5)`,
+        [deviceId, keyName, CLEANUP_SOURCE, beforeCount, afterCount]
+    );
+}
+
+async function cleanupDevice(pool, sealKey, deviceId, commit) {
+    const vault = await loadVault(pool, sealKey, deviceId);
+    if (!vault) return { deviceId, removed: [], status: 'no-vault' };
+
+    const removed = planCleanup(vault.vars);
+    if (removed.length === 0) return { deviceId, removed: [], status: 'clean' };
+
+    if (!commit) return { deviceId, removed, status: 'dry-run' };
+
+    const beforeCount = Object.keys(vault.vars).length;
+    for (const k of removed) {
+        delete vault.vars[k];
+        delete vault.sources[k];
+    }
+    const afterCount = Object.keys(vault.vars).length;
+    await saveVault(pool, sealKey, deviceId, vault);
+    for (const k of removed) {
+        await appendAudit(pool, { deviceId, keyName: k, beforeCount, afterCount });
+    }
+    return { deviceId, removed, status: 'cleaned' };
+}
+
+function summarize(results) {
+    const summary = { devicesScanned: results.length, devicesModified: 0, keysRemoved: 0 };
+    for (const r of results) {
+        if (r.removed.length > 0) {
+            summary.keysRemoved += r.removed.length;
+            if (r.status === 'cleaned' || r.status === 'dry-run') summary.devicesModified++;
+        }
+    }
+    return summary;
+}
+
+async function runCleanup({ pool, sealKey, commit = false, deviceId = null, logger = console } = {}) {
+    if (!pool) throw new Error('pool required');
+    assertSealKey(sealKey);
+    const deviceIds = await loadDeviceIds(pool, deviceId);
+    const results = [];
+    for (const id of deviceIds) {
+        let result;
+        try {
+            result = await cleanupDevice(pool, sealKey, id, commit);
+        } catch (err) {
+            result = { deviceId: id, removed: [], status: 'error', error: err.message };
+        }
+        results.push(result);
+        if (!logger.json) {
+            const prefix = commit ? '[COMMIT]' : '[DRY]';
+            logger.log(`${prefix} ${result.status} device=${id} keys=${result.removed.length}${result.error ? ` error=${result.error}` : ''}`);
+        }
+    }
+
+    const summary = summarize(results);
+    if (!logger.json) {
+        logger.log(`[petdx-vault-cleanup] done mode=${commit ? 'commit' : 'dry-run'} scanned=${summary.devicesScanned} modified=${summary.devicesModified} keysRemoved=${summary.keysRemoved}`);
+    }
+    return { summary, results };
+}
+
+async function main(argv = process.argv, env = process.env) {
+    const opts = parseArgs(argv);
+    if (opts.help) {
+        console.log(usage());
+        return { summary: null, results: [] };
+    }
+    const connectionString = env.DATABASE_URL;
+    if (!connectionString) throw new Error('DATABASE_URL is required');
+    const pool = new Pool({
+        connectionString,
+        ssl: shouldUseSsl(connectionString),
+    });
+    try {
+        const result = await runCleanup({
+            pool,
+            sealKey: env.SEAL_KEY,
+            commit: opts.commit,
+            deviceId: opts.deviceId,
+            logger: opts.json ? { json: true, log() {} } : console,
+        });
+        if (opts.json) console.log(JSON.stringify(result.summary));
+        return result;
+    } finally {
+        await pool.end();
+    }
+}
+
+module.exports = {
+    CLEANUP_SOURCE,
+    PETDX_VAULT_KEY_RE,
+    parseArgs,
+    encryptVars,
+    decryptVars,
+    planCleanup,
+    loadDeviceIds,
+    loadVault,
+    saveVault,
+    appendAudit,
+    cleanupDevice,
+    summarize,
+    runCleanup,
+    main,
+    shouldUseSsl,
+};
+
+if (require.main === module) {
+    main().catch((err) => {
+        console.error('[petdx-vault-cleanup] fatal:', err.message);
+        process.exit(1);
+    });
+}

--- a/backend/tests/jest/petdx-vault-cleanup.test.js
+++ b/backend/tests/jest/petdx-vault-cleanup.test.js
@@ -1,0 +1,140 @@
+'use strict';
+
+/**
+ * Petdx PR-C — one-time vault cleanup script.
+ *
+ * Covers the pure planner (which keys get removed) and the device-level
+ * cleanup loop against an in-memory vault, including dry-run vs commit,
+ * sibling-key preservation, and audit emission.
+ */
+
+const cleanup = require('../../scripts/petdx-vault-cleanup');
+
+const SEAL_KEY = 'a'.repeat(64);
+
+describe('petdx-vault-cleanup — planCleanup', () => {
+    test('selects only PETDX_CURRENT/AVATAR/SOURCE_<digits> keys', () => {
+        const vars = {
+            PETDX_CURRENT_7: 'petdx-lobster-default',
+            PETDX_AVATAR_7: '/static/companions/petdx-lobster-default/avatar.png',
+            PETDX_SOURCE_7: 'phase0-auto',
+            PETDX_CURRENT_12: 'petdx-zoro',
+            OPENAI_API_KEY: 'sk-xxx',
+            PETDX_FEATURE_FLAG: 'on',       // PETDX_ prefix but not a per-entity key
+            PETDX_CURRENT_ABC: 'not-numeric',
+        };
+        expect(cleanup.planCleanup(vars).sort()).toEqual([
+            'PETDX_AVATAR_7',
+            'PETDX_CURRENT_12',
+            'PETDX_CURRENT_7',
+            'PETDX_SOURCE_7',
+        ]);
+    });
+
+    test('returns empty for clean / non-object inputs', () => {
+        expect(cleanup.planCleanup({ OPENAI_API_KEY: 'x' })).toEqual([]);
+        expect(cleanup.planCleanup(null)).toEqual([]);
+        expect(cleanup.planCleanup(undefined)).toEqual([]);
+    });
+});
+
+describe('petdx-vault-cleanup — cleanupDevice', () => {
+    function makePool(vault) {
+        const audits = [];
+        const saved = [];
+        const pool = {
+            audits,
+            saved,
+            async query(sql, params) {
+                if (/SELECT .* FROM device_vars WHERE device_id/i.test(sql)) {
+                    if (!vault) return { rows: [] };
+                    const { encrypted, iv, authTag } = cleanup.encryptVars(vault.vars, SEAL_KEY);
+                    return {
+                        rows: [{
+                            encrypted_vars: encrypted, iv, auth_tag: authTag,
+                            var_sources: JSON.stringify(vault.sources || {}),
+                            is_locked: !!vault.locked,
+                        }],
+                    };
+                }
+                if (/INSERT INTO device_vars /i.test(sql)) {
+                    // params: [deviceId, encrypted, iv, authTag, varKeys, varSources, locked, ts]
+                    const decoded = cleanup.decryptVars(params[1], params[2], params[3], SEAL_KEY);
+                    saved.push({ deviceId: params[0], vars: decoded, varKeys: params[4] });
+                    return { rows: [] };
+                }
+                if (/INSERT INTO device_vars_audit/i.test(sql)) {
+                    audits.push({ deviceId: params[0], keyName: params[1], source: params[2] });
+                    return { rows: [] };
+                }
+                return { rows: [] };
+            },
+        };
+        return pool;
+    }
+
+    test('dry-run reports keys but does not write or audit', async () => {
+        const pool = makePool({
+            vars: { PETDX_CURRENT_7: 'petdx-lobster-default', OPENAI_API_KEY: 'sk-x' },
+            sources: { PETDX_CURRENT_7: 'petdx-phase0', OPENAI_API_KEY: 'user' },
+        });
+        const res = await cleanup.cleanupDevice(pool, SEAL_KEY, 'D1', false);
+        expect(res).toMatchObject({ deviceId: 'D1', status: 'dry-run' });
+        expect(res.removed).toEqual(['PETDX_CURRENT_7']);
+        expect(pool.saved).toHaveLength(0);
+        expect(pool.audits).toHaveLength(0);
+    });
+
+    test('commit removes only PETDX keys, preserves siblings, emits one audit per key', async () => {
+        const pool = makePool({
+            vars: {
+                PETDX_CURRENT_7: 'petdx-lobster-default',
+                PETDX_AVATAR_7: '/static/companions/petdx-lobster-default/avatar.png',
+                OPENAI_API_KEY: 'sk-x',
+            },
+            sources: { PETDX_CURRENT_7: 'petdx-phase0', PETDX_AVATAR_7: 'petdx-phase0', OPENAI_API_KEY: 'user' },
+        });
+        const res = await cleanup.cleanupDevice(pool, SEAL_KEY, 'D1', true);
+        expect(res.status).toBe('cleaned');
+        expect(res.removed.sort()).toEqual(['PETDX_AVATAR_7', 'PETDX_CURRENT_7']);
+
+        expect(pool.saved).toHaveLength(1);
+        expect(pool.saved[0].vars).toEqual({ OPENAI_API_KEY: 'sk-x' });
+
+        expect(pool.audits).toHaveLength(2);
+        expect(pool.audits.every(a => a.source === 'petdx-phase0-prc-cleanup')).toBe(true);
+        expect(pool.audits.map(a => a.keyName).sort()).toEqual(['PETDX_AVATAR_7', 'PETDX_CURRENT_7']);
+    });
+
+    test('a vault with no PETDX keys is left untouched (status=clean)', async () => {
+        const pool = makePool({ vars: { OPENAI_API_KEY: 'sk-x' }, sources: {} });
+        const res = await cleanup.cleanupDevice(pool, SEAL_KEY, 'D1', true);
+        expect(res.status).toBe('clean');
+        expect(res.removed).toEqual([]);
+        expect(pool.saved).toHaveLength(0);
+        expect(pool.audits).toHaveLength(0);
+    });
+
+    test('a device with no vault row returns status=no-vault', async () => {
+        const pool = makePool(null);
+        const res = await cleanup.cleanupDevice(pool, SEAL_KEY, 'D1', true);
+        expect(res.status).toBe('no-vault');
+        expect(res.removed).toEqual([]);
+    });
+});
+
+describe('petdx-vault-cleanup — runCleanup summary', () => {
+    test('summarize counts scanned / modified / keys', () => {
+        const results = [
+            { deviceId: 'A', removed: ['PETDX_CURRENT_1', 'PETDX_AVATAR_1'], status: 'cleaned' },
+            { deviceId: 'B', removed: [], status: 'clean' },
+            { deviceId: 'C', removed: ['PETDX_SOURCE_2'], status: 'dry-run' },
+            { deviceId: 'D', removed: [], status: 'no-vault' },
+        ];
+        expect(cleanup.summarize(results)).toEqual({
+            devicesScanned: 4,
+            devicesModified: 2,
+            keysRemoved: 3,
+        });
+    });
+});


### PR DESCRIPTION
## Summary

PR-C (final) of the AvatarPetdx SoT refactor. After PR-A (#3410) and PR-B
(#3411) made `companion_select_log` the single source of truth, the per-entity
`PETDX_CURRENT_/AVATAR_/SOURCE_<entityId>` device-vars vault keys are no longer
read or written by any code path. This adds a one-time cleanup script to remove
the residual keys.

### Changes
- **scripts/petdx-vault-cleanup.js** — scans `device_vars`, decrypts each
  vault, removes **only** keys matching `^PETDX_(CURRENT|AVATAR|SOURCE)_<digits>$`,
  re-encrypts, and records each removal in `device_vars_audit`
  (`action='delete_one'`, `source='petdx-phase0-prc-cleanup'`; values never
  logged). Flags: default `--dry-run`, `--device=<id>` (pilot scope),
  `--commit` (apply), `--json` (automation).
- **tests** — pure `planCleanup` selector + per-device cleanup loop (dry-run vs
  commit, sibling-key preservation, audit emission, no-vault/clean cases) +
  summary counts. 7 tests, all green.

### Rollout (operational — not run in CI)
1. `node backend/scripts/petdx-vault-cleanup.js --device=<hank> --commit` (pilot)
2. 24h soak — confirm dashboards/avatars still resolve from the log SoT
3. `node backend/scripts/petdx-vault-cleanup.js --commit` (fleet-wide)

Requires `DATABASE_URL` + `SEAL_KEY`.

### Verification
- `npx eslint scripts/petdx-vault-cleanup.js`: 0 errors.
- `npx jest petdx-vault-cleanup`: 7 passed.

## Self-review checklist (docs/code-review-checklist.md)
1. **Scope** — adds a standalone script + test only; no runtime code paths change.
2. **Tests** — planner + cleanup loop + summary covered; dry-run/commit both asserted.
3. **Security** — only PETDX per-entity keys are touched (anchored regex); all other vault entries preserved; values never logged; parameterized SQL; SEAL_KEY validated (64 hex).
4. **Error handling** — per-device errors are caught and reported (status='error'), the run continues; no-vault/clean cases handled.
5. **i18n** — no user-facing strings.
6. **Backwards-compat** — idempotent (re-running on a clean vault is a no-op); chained after PR-B; safe to run repeatedly.
7. **Performance** — one decrypt + at most one re-encrypt/upsert per device; default dry-run does zero writes.
8. **Data integrity** — sibling keys + var_sources preserved; before/after counts recorded in the audit row.
9. **Observability** — per-device log line + final summary (scanned/modified/keysRemoved); device_vars_audit trail for every delete.
10. **Migration/rollout** — no schema change; staged pilot → soak → fleet documented above.

Reviewer: Entity 2. Chained after #3411 (PR-B, merged).
