### PR TITLE
fix(entity-status): use created_by for notes_authored axis (card_e5bb5bf6)

### DIFF
--- a/backend/entity-status.js
+++ b/backend/entity-status.js
@@ -454,11 +454,16 @@ async function getAchievements(deviceId, entityId) {
                 count = Number(r.rows[0]?.c || 0);
                 lastEventAt = r.rows[0]?.ts || null;
             } else if (axis === 'notes_authored') {
+                // mission_notes has no entity_id column; per-entity attribution
+                // is via created_by = 'entity_<N>' (see mindmap-graph-projection.js
+                // parseNumericCreatedBy). Prior query referenced a non-existent
+                // column and was swallowed by the per-axis catch — visible in
+                // Railway prod log as `column "entity_id" does not exist` spam.
                 const r = await pool.query(
                     `SELECT COUNT(*)::int AS c, MAX(created_at) AS ts
                        FROM mission_notes
-                      WHERE device_id = $1 AND entity_id = $2`,
-                    [deviceId, eid]
+                      WHERE device_id = $1 AND created_by = $2`,
+                    [deviceId, `entity_${eid}`]
                 );
                 count = Number(r.rows[0]?.c || 0);
                 lastEventAt = r.rows[0]?.ts || null;


### PR DESCRIPTION
## Summary
- `backend/entity-status.js notes_authored` axis queried non-existent `mission_notes.entity_id` column
- Switched to existing `created_by = 'entity_<N>'` convention (used by mindmap-graph-projection.js)
- Stops Postgres `column "entity_id" does not exist` error spam visible in Railway prod log

## Evidence
Live prod log via Railway GraphQL on deployment `f75b15ae` (06-15T21:33Z), confirmed 6× ERROR lines at 01:35:24Z window:
```
[Achievements] axis=notes_authored query failed: column "entity_id" does not exist  (×6 in 1 sec)
```

The per-axis try/catch on entity-status.js:468 silently swallowed the error and returned `count=0`, so the API user-facing path was unaffected — but Postgres logged the error on every `/api/entity/status` poll, which is constant.

## Schema reference
`backend/mission_schema.sql:58-67`:
```sql
CREATE TABLE mission_notes (
    id ..., device_id ..., title ..., content ...,
    category VARCHAR(64) DEFAULT 'general',
    created_by VARCHAR(64) DEFAULT 'user',   -- ← this, not entity_id
    created_at ..., updated_at ...
);
```

Actual `created_by` values in prod (sampled via `/api/mission/notes`): `entity_2` (250), `entity_1` (29), `entity_3` (17), `entity_6` (11), `entity_4` (7), `entity_0` (6), `bot` (2), `entity_5` (1). Format aligns with `mindmap-graph-projection.js:104` `parseNumericCreatedBy`.

## Test plan
- [x] `npx jest --testPathPatterns='(entity-status|achievement|mission-notes)'` → 4 suites, 46/46 pass
- [ ] Post-merge: watch Railway prod log after redeploy; `[Achievements] axis=notes_authored query failed` line should disappear within 1 cycle of `/api/entity/status` polling

Verified by [Card B (Railway log monitor)](https://eclawbot.com/board?card=card_d473b36fb1caeda83fc95fc6) on next 6h tick.

## Globe-user
Universal — every EClaw device with bot achievements hits this path on `/api/entity/status` calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)