### PR TITLE
hotfix(vault): defensive new Date() in GET — fixes false 500 (incident 06/16 ~12:36 TW)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -21134,14 +21134,36 @@ app.get('/api/device-vars', async (req, res) => {
         // 409 if it doesn't match the current row — prevents cross-device
         // last-write-wins data loss when multiple web/app clients have stale
         // vault snapshots.
-        out.updatedAt = row.updated_at ? new Date(row.updated_at).toISOString() : null;
+        // Defensive: row.updated_at may be a Date, string, or unexpected shape
+        // depending on pg driver state. `new Date(invalidShape).toISOString()`
+        // throws RangeError "Invalid time value", which the outer catch then
+        // logged as "Decrypt failed" — a false 500 that masked perfectly healthy
+        // vault data (incident 2026-06-16 ~12:36 TW; clients kept rendering
+        // from var_keys metadata + localStorage cache while owner-auth GET
+        // 500'd for ~30min). Wrap defensively + fall back to null.
+        try {
+            if (row.updated_at) {
+                const d = new Date(row.updated_at);
+                if (!Number.isNaN(d.getTime())) {
+                    out.updatedAt = d.toISOString();
+                } else {
+                    out.updatedAt = null;
+                }
+            } else {
+                out.updatedAt = null;
+            }
+        } catch (_) {
+            out.updatedAt = null;
+        }
         if (authMode === 'owner') {
             out.sources = row.var_sources || {};
             out.locked = !!row.is_locked;
         }
         return res.json(out);
     } catch (err) {
-        console.error(`[Vars] Decrypt failed for ${deviceId}:`, err.message);
+        // Log the real exception type so future incidents don't get mis-labelled
+        // as "decryption" when it's actually a serialization bug.
+        console.error(`[Vars] GET handler failed for ${deviceId}: ${err && err.name}: ${err && err.message}`);
         return res.status(500).json({ success: false, error: 'Decryption failed' });
     }
 });


### PR DESCRIPTION
## Summary
- PR #3422 added `new Date(row.updated_at).toISOString()` to GET response — threw `RangeError: Invalid time value` on edge-case row shape
- Outer try/catch caught it but mis-logged as "Decrypt failed" → false 500 for ~30 min
- Fix: defensive wrap + null fallback; rename catch log to surface real err.name

## Incident timeline (TW)
- 12:36 — Hank adds RAILWAY_ECLAE_0616 via web (PR #3422+#3423 work — addition stuck)
- 12:37 — commander GET probe → 500 "Decryption failed" → commander panics
- 13:01 — Hank confirms client shows correct state including the new key (data intact)
- 13:21 — commander pulls Railway prod log via Card B path, sees real error `Invalid time value`
- 13:25 — root cause located in PR #3422 line, this hotfix authored

## Why client kept rendering
`var_keys` is a separate plain TEXT[] column the GET path doesn't touch when the JSON-serialization throws. Client reads cached localStorage + var_keys metadata from chat envelope, so user-facing UI was unaffected. Only the commander (curl-based) saw the 500.

## Test plan
- [x] backend/tests/jest/device-vars.test.js → 47/47 pass
- [ ] Post-deploy: GET /api/device-vars returns 200 with updatedAt (or null) instead of 500

## Linked
- Predecessor PR: #3422 (introduced the bug)
- Predecessor PR: #3423 (client-side, unaffected — writes still work)
- Card: card_946cfefe81be5f7f5f449563

🤖 Generated with [Claude Code](https://claude.com/claude-code)