### PR TITLE
fix(kanban): autoReviewOnTransform infers aboutCardId from card_<hex> in message

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -3867,6 +3867,25 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             // (e.g. a bot reporting completion of task X while only task Y was
             // eligible for auto-close on its board would close Y by mistake).
             // See card_393752f8 / card_819d50f1 RCA for a real instance.
+            //
+            // Defensive inference: if the bot explicitly typed `card_<hex>` in the
+            // transform message and exactly one unique id is mentioned, treat it as
+            // an implicit aboutCardId. This is safer than the legacy fallback
+            // because the id comes from the bot's own text (so it's about THIS
+            // reply), not from a board scan that could match an unrelated card.
+            if (!aboutCardId && typeof transformMessage === 'string' && transformMessage.length > 0) {
+                const matches = transformMessage.match(/\bcard_[a-f0-9]{8,}\b/gi);
+                if (matches && matches.length > 0) {
+                    const unique = Array.from(new Set(matches.map(m => m.toLowerCase())));
+                    if (unique.length === 1) {
+                        aboutCardId = unique[0];
+                        console.log(`[Kanban] autoReviewOnTransform inferred aboutCardId=${aboutCardId} from entity ${entityId} message text`);
+                    } else {
+                        console.warn(`[Kanban] autoReviewOnTransform skipped: entity ${entityId} mentioned ${unique.length} distinct card_ids in message but no explicit aboutCardId — pass {aboutCardId:"card_..."} to disambiguate`);
+                        return;
+                    }
+                }
+            }
             if (!aboutCardId) {
                 console.warn(`[Kanban] autoReviewOnTransform skipped: no aboutCardId provided by entity ${entityId} — pass {aboutCardId:"card_..."} in transform body to auto-close a specific card`);
                 return;

--- a/backend/tests/jest/kanban-autoreview-cardid-infer.test.js
+++ b/backend/tests/jest/kanban-autoreview-cardid-infer.test.js
@@ -1,0 +1,95 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..', '..');
+const kanbanSrc = fs.readFileSync(path.join(ROOT, 'kanban.js'), 'utf8');
+
+function extractFunctionBody(src, signature) {
+    const start = src.indexOf(signature);
+    if (start === -1) throw new Error(`function not found: ${signature}`);
+    const open = src.indexOf('{', start);
+    let depth = 0;
+    for (let i = open; i < src.length; i++) {
+        const ch = src[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') { depth--; if (depth === 0) return src.slice(open, i + 1); }
+    }
+    throw new Error(`unterminated function: ${signature}`);
+}
+
+describe('autoReviewOnTransform — aboutCardId inference from transformMessage text', () => {
+    const sig = 'async function autoReviewOnTransform(deviceId, entityId, transformMessage, aboutCardId)';
+    const body = extractFunctionBody(kanbanSrc, sig);
+
+    test('regex literal `\\bcard_[a-f0-9]{8,}\\b` is present', () => {
+        expect(body).toMatch(/\/\\bcard_\[a-f0-9\]\{8,\}\\b\/gi/);
+    });
+
+    test('inference happens BEFORE the "no aboutCardId provided" skip', () => {
+        const inferIdx = body.indexOf('inferred aboutCardId');
+        const skipIdx = body.indexOf('no aboutCardId provided');
+        expect(inferIdx).toBeGreaterThan(-1);
+        expect(skipIdx).toBeGreaterThan(-1);
+        expect(inferIdx).toBeLessThan(skipIdx);
+    });
+
+    test('inference is gated on aboutCardId being falsy AND transformMessage being a non-empty string', () => {
+        expect(body).toMatch(/!aboutCardId\s*&&\s*typeof transformMessage === 'string'\s*&&\s*transformMessage\.length > 0/);
+    });
+
+    test('multiple distinct card_ids in message → skip (ambiguous), do not pick first', () => {
+        expect(body).toMatch(/unique\.length === 1/);
+        expect(body).toMatch(/distinct card_ids in message but no explicit aboutCardId/);
+    });
+
+    test('inference dedupes via Set + lowercases for case-insensitive identity', () => {
+        expect(body).toMatch(/new Set\(matches\.map\(m => m\.toLowerCase\(\)\)\)/);
+    });
+
+    test('legacy "skip when nothing extractable" guard still runs as the second gate', () => {
+        // After inference attempt, if aboutCardId still undefined → skip
+        expect(body).toMatch(/if\s*\(\s*!\s*aboutCardId\s*\)\s*{\s*console\.warn\([^)]*no aboutCardId provided[\s\S]*?return\s*;?\s*}/);
+    });
+});
+
+describe('autoReviewOnTransform — regex behavior contract', () => {
+    // Pure unit test of the regex pattern (no DB / no module load)
+    const PATTERN = /\bcard_[a-f0-9]{8,}\b/gi;
+
+    test('matches 8-char hex card id', () => {
+        const m = 'closed card_cc7a3f0c per SOP'.match(PATTERN);
+        expect(m).toEqual(['card_cc7a3f0c']);
+    });
+
+    test('matches longer hex card id (24-char as commonly returned by /api/mission/card)', () => {
+        const m = 'see card_cc7a3f0c4e2a8b1d9f1234ab for context'.match(PATTERN);
+        expect(m).toEqual(['card_cc7a3f0c4e2a8b1d9f1234ab']);
+    });
+
+    test('does NOT match too-short card id (under 8 chars)', () => {
+        const m = 'card_abc123 is too short'.match(PATTERN);
+        expect(m).toBeNull();
+    });
+
+    test('does NOT match card_id with non-hex chars', () => {
+        const m = 'card_zzzzzzzz has non-hex'.match(PATTERN);
+        expect(m).toBeNull();
+    });
+
+    test('case-insensitive: uppercase hex matches too', () => {
+        const m = 'CARD_AABBCCDD11'.match(PATTERN);
+        expect(m).toEqual(['CARD_AABBCCDD11']);
+    });
+
+    test('multi-mention preserves duplicates; dedup is caller responsibility', () => {
+        const m = 'card_cc7a3f0c then card_cc7a3f0c again'.match(PATTERN);
+        expect(m).toEqual(['card_cc7a3f0c', 'card_cc7a3f0c']);
+    });
+
+    test('two distinct ids surface both', () => {
+        const m = 'about card_aaaaaaaa and card_bbbbbbbb'.match(PATTERN);
+        expect(m).toEqual(['card_aaaaaaaa', 'card_bbbbbbbb']);
+    });
+});


### PR DESCRIPTION
## Summary
- POST /api/transform without explicit `aboutCardId` now infers it when the bot's message text contains exactly one `card_<hex>` mention (>=8 hex chars, case-insensitive)
- Multiple distinct ids in same message → skip with ambiguity warn (no silent first-pick)
- Existing skip path (no extractable + no explicit) preserved — emits the original "pass aboutCardId in body" guidance

## Why
15× `[Kanban] autoReviewOnTransform skipped: no aboutCardId provided` warnings in eclaw service prod logs (past 6h, card_cc7a3f0c). Commander/Hermes regularly reply to kanban-triggered transforms with the card id quoted in text but without the explicit body field → backend defaults to skip, requiring manual /move calls.

This is the (b) defensive backend angle from card_cc7a3f0c. (a) dispatch template hygiene is being captured separately in commander memory.

## Safety vs. legacy fallback
The previous "exactly one eligible card on board" fallback was removed (card_393752f8 / card_819d50f1 RCA) because it closed unrelated cards. This new inference is stricter:
- Card id must appear in the bot's OWN message text (not a board scan)
- Existing query (`WHERE c.id = $1 AND assigned_bots @> entityId`) still applies — inferred id must still pass the same eligibility filter
- Multi-mention → skip; never silently pick

## Tests
- New: `kanban-autoreview-cardid-infer.test.js` — 13 tests covering inference position, regex contract (8-char min, hex-only, case-insensitive, dedup), multi-mention skip
- Existing: `kanban-autoreview-cardid-guard.test.js` — all 10 tests still pass (skip-when-missing guard preserved; legacy untargeted branch still absent)

23/23 pass locally.

## Test plan
- [x] Jest unit tests pass
- [ ] Prod: 6h after merge, Card B Railway log cron should show 0 `autoReviewOnTransform skipped` warnings for commander/Hermes when they quote card_id in replies

🤖 Generated with [Claude Code](https://claude.com/claude-code)