### PR TITLE
fix(grpc): validate GRPC_PORT env, fall back to PORT+1 on out-of-range

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -22686,7 +22686,12 @@ if (require.main === module) {
         // Start gRPC server on PORT+1
         try {
             const grpcModule = require('./grpc-server')(devices, { serverLog });
-            const grpcPort = parseInt(process.env.GRPC_PORT || (port + 1));
+            const fallbackPort = port + 1;
+            let grpcPort = parseInt(process.env.GRPC_PORT || fallbackPort, 10);
+            if (!Number.isInteger(grpcPort) || grpcPort < 0 || grpcPort >= 65536) {
+                console.warn(`[gRPC] Invalid GRPC_PORT="${process.env.GRPC_PORT}" (out of 0-65535) — falling back to PORT+1=${fallbackPort}`);
+                grpcPort = fallbackPort;
+            }
             grpcModule.startGrpcServer(grpcPort);
         } catch (err) {
             console.error('[gRPC] Failed to initialize:', err.message);

--- a/backend/tests/jest/grpc-port-validation.test.js
+++ b/backend/tests/jest/grpc-port-validation.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const indexSrc = fs.readFileSync(path.join(__dirname, '..', '..', 'index.js'), 'utf8');
+
+describe('gRPC port validation — guard against bad GRPC_PORT env (card_e0a7e1ca)', () => {
+    test('grpcPort fallback variable is computed once as port+1', () => {
+        expect(indexSrc).toMatch(/const fallbackPort = port \+ 1;/);
+    });
+
+    test('parseInt receives explicit radix 10 (defensive against leading-zero / octal)', () => {
+        expect(indexSrc).toMatch(/parseInt\(process\.env\.GRPC_PORT \|\| fallbackPort,\s*10\)/);
+    });
+
+    test('out-of-range guard rejects values >= 65536, < 0, or non-integers', () => {
+        expect(indexSrc).toMatch(/!Number\.isInteger\(grpcPort\)\s*\|\|\s*grpcPort < 0\s*\|\|\s*grpcPort >= 65536/);
+    });
+
+    test('on bad value, warns + falls back to PORT+1 (does not throw / crash gRPC init)', () => {
+        expect(indexSrc).toMatch(/\[gRPC\] Invalid GRPC_PORT[\s\S]*?falling back to PORT\+1[\s\S]*?grpcPort = fallbackPort/);
+    });
+
+    test('grpcPort is let (reassignable) not const (so fallback reassign compiles)', () => {
+        expect(indexSrc).toMatch(/let grpcPort = parseInt\(process\.env\.GRPC_PORT/);
+    });
+});
+
+// Pure unit test of the validation logic in isolation (no module load)
+describe('gRPC port validation — boundary contract', () => {
+    function validatePort(envVal, fallback) {
+        let p = parseInt(envVal || fallback, 10);
+        if (!Number.isInteger(p) || p < 0 || p >= 65536) return fallback;
+        return p;
+    }
+
+    test('80801 (the prod incident value) → fallback', () => {
+        expect(validatePort('80801', 8081)).toBe(8081);
+    });
+
+    test('65535 (max valid) → accepted', () => {
+        expect(validatePort('65535', 8081)).toBe(65535);
+    });
+
+    test('65536 (off-by-one over max) → fallback', () => {
+        expect(validatePort('65536', 8081)).toBe(8081);
+    });
+
+    test('0 (valid lower bound) → accepted', () => {
+        expect(validatePort('0', 8081)).toBe(0);
+    });
+
+    test('-1 (below min) → fallback', () => {
+        expect(validatePort('-1', 8081)).toBe(8081);
+    });
+
+    test('empty string → fallback (parseInt of fallback)', () => {
+        expect(validatePort('', 8081)).toBe(8081);
+    });
+
+    test('non-numeric "abc" → fallback (NaN rejected)', () => {
+        expect(validatePort('abc', 8081)).toBe(8081);
+    });
+
+    test('typical 8081 → accepted', () => {
+        expect(validatePort('8081', 8081)).toBe(8081);
+    });
+
+    test('undefined env → fallback', () => {
+        expect(validatePort(undefined, 8081)).toBe(8081);
+    });
+});


### PR DESCRIPTION
## Summary
- Validate `GRPC_PORT` env var at boot: must be integer in [0, 65535]
- On bad value: warn + fall back to `PORT+1`; gRPC server still starts
- Added explicit `parseInt(..., 10)` radix for safety

## Why
Prod Railway env has `GRPC_PORT=80801` (typo for 8080/8081). Currently:
```
[gRPC] Failed to start server: options.port should be >= 0 and < 65536. Received type number (80801).
```
gRPC server is down at boot every deploy until env var is corrected. Code-side guard means env-misconfig users get a working gRPC on the default fallback port.

Source: card_e0a7e1ca (Card B Railway log monitor first-run finding).

## Tests
- `backend/tests/jest/grpc-port-validation.test.js` — 14 tests
  - 5 source-grep assertions (radix-10, boundary expr, fallback reassign, warn message, `let` not `const`)
  - 9 boundary contract tests (80801, 65535, 65536, 0, -1, '', 'abc', 8081, undefined)
- 14/14 pass locally

## Test plan
- [x] Jest unit tests pass
- [ ] After merge + Railway redeploy: prod boot log should show `[gRPC] Invalid GRPC_PORT="80801" — falling back to PORT+1=8081` + then `[gRPC] Server running on port 8081` (instead of crash)
- [ ] Separate followup: fix Railway env var `GRPC_PORT=80801` → `8081` (user action; this PR makes that fix non-blocking)

## Out of scope
- Not changing the Railway env var itself (no admin access from this card; user/oncall to fix)
- Not migrating other env-parsed numeric ports (one card = one fix per [[feedback_pr_workflow]])

🤖 Generated with [Claude Code](https://claude.com/claude-code)