### PR TITLE
fix(vault): strict-mode no-etag guard prevents zombification by legacy clients

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -20874,7 +20874,53 @@ app.post('/api/device-vars', async (req, res) => {
     // check (legacy behavior). Same-source merge logic below still drops
     // unknown-to-client keys without this check — that's the failure mode
     // PR #3392 left unaddressed (web+app+other multi-device race).
-    if (expectedUpdatedAt) {
+    // Strict-mode no-etag guard (card_908a34a9, follow-up to card_946cfefe):
+    // when expectedUpdatedAt is absent AND the server row exists with at least
+    // one key, the client is replaying an old snapshot it loaded before the
+    // expectedUpdatedAt protocol shipped (typical: Android app or stale tab
+    // that opened before PR #3422/3423). Without the etag we can't tell if
+    // they read latest, so the same multi-device last-write-wins race that
+    // PR #3422 was meant to fix can still happen — observed 06-16 17:35 TW
+    // when RAILWAY_ECLAE_0616 was zombified back to the pre-rotation value.
+    //
+    // VAULT_STRICT_NO_ETAG env (default "warn"): "warn" logs + lets through
+    // for a grace window so Android can ship its own etag-aware client; flip
+    // to "reject" via Railway env once mobile catches up. "off" disables the
+    // guard entirely (escape hatch).
+    if (!expectedUpdatedAt) {
+        const strictMode = (process.env.VAULT_STRICT_NO_ETAG || 'warn').toLowerCase();
+        if (strictMode === 'warn' || strictMode === 'reject') {
+            const existingRow = await db.getDeviceVars(deviceId);
+            const existingKeyCount = existingRow && existingRow.var_keys && Array.isArray(existingRow.var_keys)
+                ? existingRow.var_keys.length
+                : 0;
+            const existingUpdatedAt = existingRow && existingRow.updated_at
+                ? new Date(existingRow.updated_at).toISOString()
+                : null;
+            if (existingKeyCount > 0) {
+                const _srcLabel = (source === 'web' || source === 'app') ? source : 'legacy';
+                console.warn(`[Vars] POST without expectedUpdatedAt against non-empty row (deviceId=${deviceId} source=${_srcLabel} keys=${existingKeyCount} strictMode=${strictMode})`);
+                db.logDeviceVarsAudit({
+                    deviceId,
+                    action: strictMode === 'reject' ? 'refuse_no_etag' : 'warn_no_etag',
+                    source: _srcLabel,
+                    callerIp: _auditCtx.ip,
+                    callerUa: _auditCtx.ua,
+                    beforeCount: _beforeCount,
+                    afterCount: _beforeCount,
+                });
+                if (strictMode === 'reject') {
+                    return res.status(400).json({
+                        success: false,
+                        error: 'stale_write_no_etag',
+                        message: 'POST is missing expectedUpdatedAt and a server vault already exists. Refetch via GET to obtain updatedAt, then retry POST with it.',
+                        serverUpdatedAt: existingUpdatedAt,
+                    });
+                }
+                // strictMode === 'warn': fall through (grace window for Android catch-up)
+            }
+        }
+    } else {
         const currentRow = await db.getDeviceVars(deviceId);
         const currentUpdatedAt = currentRow && currentRow.updated_at
             ? new Date(currentRow.updated_at).toISOString()

--- a/backend/index.js
+++ b/backend/index.js
@@ -20865,6 +20865,19 @@ app.post('/api/device-vars', async (req, res) => {
     const _auditCtx = { ip: req.ip, ua: req.get('user-agent') };
     const _metaBefore = await db.getDeviceVarsMeta(deviceId);
     const _beforeCount = _metaBefore && Array.isArray(_metaBefore.var_keys) ? _metaBefore.var_keys.length : 0;
+    // Cache for db.getDeviceVars: strict-guard, etag-check, and downstream
+    // empty-wipe / merge branches all want the same row. Read once, reuse —
+    // (1) keeps tests using mockResolvedValueOnce passing (single getDeviceVars
+    // consumption per request), (2) shaves a redundant DB round-trip.
+    let cachedExistingRow = null;
+    let cachedExistingRowLoaded = false;
+    const loadExistingRowOnce = async () => {
+        if (!cachedExistingRowLoaded) {
+            cachedExistingRow = await db.getDeviceVars(deviceId);
+            cachedExistingRowLoaded = true;
+        }
+        return cachedExistingRow;
+    };
 
     // Optimistic concurrency (card_946cfefe): if client sent the snapshot it
     // based its edit on via `expectedUpdatedAt`, refuse the write when the
@@ -20890,7 +20903,7 @@ app.post('/api/device-vars', async (req, res) => {
     if (!expectedUpdatedAt) {
         const strictMode = (process.env.VAULT_STRICT_NO_ETAG || 'warn').toLowerCase();
         if (strictMode === 'warn' || strictMode === 'reject') {
-            const existingRow = await db.getDeviceVars(deviceId);
+            const existingRow = await loadExistingRowOnce();
             const existingKeyCount = existingRow && existingRow.var_keys && Array.isArray(existingRow.var_keys)
                 ? existingRow.var_keys.length
                 : 0;
@@ -20921,7 +20934,7 @@ app.post('/api/device-vars', async (req, res) => {
             }
         }
     } else {
-        const currentRow = await db.getDeviceVars(deviceId);
+        const currentRow = await loadExistingRowOnce();
         const currentUpdatedAt = currentRow && currentRow.updated_at
             ? new Date(currentRow.updated_at).toISOString()
             : null;
@@ -20974,7 +20987,7 @@ app.post('/api/device-vars', async (req, res) => {
 
         // If source is provided, do merge instead of replace
         if (src) {
-            const existing = await db.getDeviceVars(deviceId);
+            const existing = await loadExistingRowOnce();
             let existingVars = {};
             let existingSources = {};
 
@@ -21074,7 +21087,7 @@ app.post('/api/device-vars', async (req, res) => {
             // confirm flag for empty replacements on a non-empty vault so
             // accidental curls / buggy scripts can't silently zero it out.
             if (Object.keys(incoming).length === 0) {
-                const existing = await db.getDeviceVars(deviceId);
+                const existing = await loadExistingRowOnce();
                 const hadKeys = existing && Array.isArray(existing.var_keys) && existing.var_keys.length > 0;
                 if (hadKeys && confirm !== 'REPLACE_ALL_EMPTY') {
                     serverLog('warn', 'device_vars', `[Vars] refused legacy empty wipe for ${deviceId}: ${existing.var_keys.length} keys present, no confirm`, { deviceId, metadata: { existingKeyCount: existing.var_keys.length } });

--- a/backend/tests/jest/device-vars-strict-no-etag.test.js
+++ b/backend/tests/jest/device-vars-strict-no-etag.test.js
@@ -1,0 +1,62 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const indexSrc = fs.readFileSync(path.join(__dirname, '..', '..', 'index.js'), 'utf8');
+
+describe('POST /api/device-vars — strict no-etag guard (card_908a34a9 / vault zombification re-occurrence)', () => {
+    test('strictMode env flag read from VAULT_STRICT_NO_ETAG with "warn" default', () => {
+        expect(indexSrc).toMatch(/process\.env\.VAULT_STRICT_NO_ETAG\s*\|\|\s*['"]warn['"]/);
+    });
+
+    test('guard fires only when expectedUpdatedAt is absent', () => {
+        expect(indexSrc).toMatch(/if\s*\(\s*!expectedUpdatedAt\s*\)\s*{[\s\S]*?VAULT_STRICT_NO_ETAG/);
+    });
+
+    test('guard skips entirely when strictMode is "off"', () => {
+        // The block only enters the gate when strictMode is 'warn' OR 'reject'
+        expect(indexSrc).toMatch(/strictMode === ['"]warn['"]\s*\|\|\s*strictMode === ['"]reject['"]/);
+    });
+
+    test('guard requires existing row with at least one key (existingKeyCount > 0)', () => {
+        expect(indexSrc).toMatch(/existingKeyCount\s*>\s*0/);
+        expect(indexSrc).toMatch(/var_keys\s*&&\s*Array\.isArray\(existingRow\.var_keys\)/);
+    });
+
+    test('reject mode returns 400 with stale_write_no_etag and serverUpdatedAt', () => {
+        expect(indexSrc).toMatch(/error:\s*['"]stale_write_no_etag['"]/);
+        expect(indexSrc).toMatch(/POST is missing expectedUpdatedAt and a server vault already exists/);
+        expect(indexSrc).toMatch(/return res\.status\(400\)\.json\(\s*{[\s\S]*?serverUpdatedAt:\s*existingUpdatedAt/);
+    });
+
+    test('warn mode logs + falls through (does NOT return 400)', () => {
+        // Audit row written with action refuse_no_etag (reject) or warn_no_etag (warn)
+        expect(indexSrc).toMatch(/action:\s*strictMode === ['"]reject['"]\s*\?\s*['"]refuse_no_etag['"]\s*:\s*['"]warn_no_etag['"]/);
+        // console.warn fires either way
+        expect(indexSrc).toMatch(/\[Vars\] POST without expectedUpdatedAt against non-empty row/);
+    });
+
+    test('guard does not fire when existing row is empty (existingKeyCount = 0)', () => {
+        // First-time POST (no existing keys) must succeed — strict mode only protects
+        // against overwriting an existing non-empty vault with a stale snapshot
+        const block = indexSrc.match(/if\s*\(\s*!expectedUpdatedAt\s*\)\s*{[\s\S]*?else\s*{[\s\S]*?const currentRow = await db\.getDeviceVars/);
+        expect(block).toBeTruthy();
+        // The early-return path (400) is inside the existingKeyCount > 0 branch
+        expect(block[0]).toMatch(/if\s*\(\s*existingKeyCount\s*>\s*0\s*\)\s*{[\s\S]*?return res\.status\(400\)/);
+    });
+
+    test('audit row records source label (web/app/legacy) for forensic trace', () => {
+        expect(indexSrc).toMatch(/const _srcLabel = \(source === ['"]web['"]\s*\|\|\s*source === ['"]app['"]\)\s*\?\s*source\s*:\s*['"]legacy['"]/);
+    });
+
+    test('coexists with existing expectedUpdatedAt path (else branch preserved)', () => {
+        // The original 409 stale_write logic (when expectedUpdatedAt is sent but mismatched)
+        // must remain intact in the else branch
+        expect(indexSrc).toMatch(/else\s*{[\s\S]*?const currentRow = await db\.getDeviceVars[\s\S]*?currentUpdatedAt !== expectedUpdatedAt[\s\S]*?error:\s*['"]stale_write['"]/);
+    });
+
+    test('comment cites card_908a34a9 (follow-up) and card_946cfefe (origin)', () => {
+        expect(indexSrc).toMatch(/card_908a34a9[\s\S]*?card_946cfefe/);
+    });
+});

--- a/backend/tests/jest/device-vars-strict-no-etag.test.js
+++ b/backend/tests/jest/device-vars-strict-no-etag.test.js
@@ -39,8 +39,11 @@ describe('POST /api/device-vars — strict no-etag guard (card_908a34a9 / vault 
 
     test('guard does not fire when existing row is empty (existingKeyCount = 0)', () => {
         // First-time POST (no existing keys) must succeed — strict mode only protects
-        // against overwriting an existing non-empty vault with a stale snapshot
-        const block = indexSrc.match(/if\s*\(\s*!expectedUpdatedAt\s*\)\s*{[\s\S]*?else\s*{[\s\S]*?const currentRow = await db\.getDeviceVars/);
+        // against overwriting an existing non-empty vault with a stale snapshot.
+        // (Row loader was refactored to a cached helper to avoid double DB reads
+        // and keep mockResolvedValueOnce-style tests passing; accept either the
+        // direct `await db.getDeviceVars` form or the `await loadExistingRowOnce` form.)
+        const block = indexSrc.match(/if\s*\(\s*!expectedUpdatedAt\s*\)\s*{[\s\S]*?else\s*{[\s\S]*?const currentRow = await (?:db\.getDeviceVars|loadExistingRowOnce)/);
         expect(block).toBeTruthy();
         // The early-return path (400) is inside the existingKeyCount > 0 branch
         expect(block[0]).toMatch(/if\s*\(\s*existingKeyCount\s*>\s*0\s*\)\s*{[\s\S]*?return res\.status\(400\)/);
@@ -52,8 +55,9 @@ describe('POST /api/device-vars — strict no-etag guard (card_908a34a9 / vault 
 
     test('coexists with existing expectedUpdatedAt path (else branch preserved)', () => {
         // The original 409 stale_write logic (when expectedUpdatedAt is sent but mismatched)
-        // must remain intact in the else branch
-        expect(indexSrc).toMatch(/else\s*{[\s\S]*?const currentRow = await db\.getDeviceVars[\s\S]*?currentUpdatedAt !== expectedUpdatedAt[\s\S]*?error:\s*['"]stale_write['"]/);
+        // must remain intact in the else branch.
+        // (Row read may go through the cached loadExistingRowOnce helper — accept either form.)
+        expect(indexSrc).toMatch(/else\s*{[\s\S]*?const currentRow = await (?:db\.getDeviceVars|loadExistingRowOnce)[\s\S]*?currentUpdatedAt !== expectedUpdatedAt[\s\S]*?error:\s*['"]stale_write['"]/);
     });
 
     test('comment cites card_908a34a9 (follow-up) and card_946cfefe (origin)', () => {


### PR DESCRIPTION
## Summary
- POST /api/device-vars now logs (warn mode, default) or rejects (reject mode) when `expectedUpdatedAt` is absent AND the server row already has at least one key
- Staged rollout via `VAULT_STRICT_NO_ETAG` env: `warn` (default) → `reject` (once Android catches up) → `off` (escape hatch)
- 400 `stale_write_no_etag` response includes `serverUpdatedAt` so clients can refetch + retry

## Why
**Re-occurrence evidence** (card_908a34a9 — follow-up to card_946cfefe / PR #3422 + #3423):
- 06-16 17:35 TW: Card B Railway log monitor cron found vault `RAILWAY_ECLAE_0616 = c6a49300...` (the OLD broken token Hank rotated out 4h+ ago to `c3817705...`)
- Within minutes of Hank re-adding the new token via web client (which uses expectedUpdatedAt per PR #3423), it got overwritten back to the zombie value by another client (Android app / legacy tab) that POSTed a stale snapshot without the etag
- Server backward-compat path accepted the no-etag POST → silent zombification → 6h cron broke vault auth

## Staged rollout
1. **This PR (warn default)**: server logs every no-etag-against-non-empty POST as `[Vars] POST without expectedUpdatedAt against non-empty row` + audits as `warn_no_etag`. Behavior unchanged for clients. Buys time.
2. **Follow-up: Android client PR**: mirror PR #3423 logic (GET captures updatedAt → POST sends expectedUpdatedAt → handle 409 retry). Card to be filed once warn-mode log shows acceptable migration progress.
3. **Flip env to `reject`**: Railway env `VAULT_STRICT_NO_ETAG=reject`. Any unmigrated client gets 400 + actionable error. Web client already handles 409 via PR #3423; same logic works for 400.
4. **Escape hatch**: `VAULT_STRICT_NO_ETAG=off` disables guard entirely if rollout causes incident.

## Safety
- Empty-vault POSTs (first-time setup, `existingKeyCount === 0`) **never** hit the guard — gated on `existingKeyCount > 0`
- Existing expectedUpdatedAt 409 stale_write path is preserved verbatim in the `else` branch
- No client-visible behavior change in default warn mode

## Tests
- `backend/tests/jest/device-vars-strict-no-etag.test.js` — 10 tests
  - Default env value (`warn`)
  - Guard scope (only when `!expectedUpdatedAt` AND `existingKeyCount > 0`)
  - Strict mode "off" / "warn" / "reject" all distinct
  - 400 response shape (error code, serverUpdatedAt, message)
  - Audit action labels (`warn_no_etag` vs `refuse_no_etag`)
  - Source label sanitization (web/app/legacy)
  - Coexistence with existing 409 path
- 10/10 pass locally

## Test plan
- [x] Jest unit tests pass
- [ ] After merge + Railway deploy: prod log should show `[Vars] POST without expectedUpdatedAt against non-empty row` for each Android tick; no client breakage
- [ ] Monitor warn count for 24h before flipping env to `reject`
- [ ] Once flipped: re-run vault zombification reproduction (re-add RAILWAY_ECLAE_0616 via web, observe no revert from idle Android tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)