### PR TITLE
fix(db): bootstrap pgcrypto extension on boot (fixes gen_random_bytes errors)

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -91,6 +91,23 @@ async function createTables() {
     try {
         const client = await pool.connect();
 
+        // pgcrypto provides gen_random_bytes(int) which is used as the DEFAULT for
+        // every id column in kanban / mission / rental / arena schemas (e.g.
+        // `card_' || encode(gen_random_bytes(12), 'hex')`). On some PG installs
+        // the extension is not enabled by default; bootstrap-time CREATE EXTENSION
+        // IF NOT EXISTS makes the missing-function error self-healing.
+        // Card source: card_c2612cb2 (Railway log monitor 06-16 17:35 TW fire —
+        // `[Kanban] Error: function gen_random_bytes(integer) does not exist`).
+        // Mirrors the pgvector pattern in chat-embedding.js: soft-fail since
+        // EXTENSION may be privileged-only on hosted PG; the row inserts that
+        // depend on it will then fail loudly with their own error rather than
+        // silently breaking the whole table create.
+        try {
+            await client.query('CREATE EXTENSION IF NOT EXISTS pgcrypto');
+        } catch (err) {
+            console.warn('[DB] pgcrypto CREATE EXTENSION failed (id DEFAULTs that use gen_random_bytes will fail until enabled by DB admin):', err.message);
+        }
+
         // Create devices table
         await client.query(`
             CREATE TABLE IF NOT EXISTS devices (

--- a/backend/tests/jest/db-pgcrypto-bootstrap.test.js
+++ b/backend/tests/jest/db-pgcrypto-bootstrap.test.js
@@ -1,0 +1,50 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const dbSrc = fs.readFileSync(path.join(__dirname, '..', '..', 'db.js'), 'utf8');
+
+describe('db.js bootstrap — pgcrypto extension auto-enable (card_c2612cb2)', () => {
+    test('createTables() issues CREATE EXTENSION IF NOT EXISTS pgcrypto', () => {
+        expect(dbSrc).toMatch(/CREATE EXTENSION IF NOT EXISTS pgcrypto/);
+    });
+
+    test('pgcrypto bootstrap fires BEFORE the devices table create (so id DEFAULTs work on first run)', () => {
+        const pgcryptoIdx = dbSrc.indexOf('CREATE EXTENSION IF NOT EXISTS pgcrypto');
+        const devicesIdx = dbSrc.indexOf('CREATE TABLE IF NOT EXISTS devices');
+        expect(pgcryptoIdx).toBeGreaterThan(-1);
+        expect(devicesIdx).toBeGreaterThan(-1);
+        expect(pgcryptoIdx).toBeLessThan(devicesIdx);
+    });
+
+    test('pgcrypto failure is soft-handled with warn (matches pgvector pattern)', () => {
+        // Mirror chat-embedding.js: CREATE EXTENSION may be privileged-only on
+        // hosted PG; we warn and continue rather than crash boot
+        expect(dbSrc).toMatch(/try\s*{\s*await client\.query\('CREATE EXTENSION IF NOT EXISTS pgcrypto'\);[\s\S]*?catch\s*\(err\)\s*{[\s\S]*?console\.warn\(/);
+    });
+
+    test('warn message names the consequence (gen_random_bytes DEFAULTs will fail) so DB admins know what to do', () => {
+        expect(dbSrc).toMatch(/gen_random_bytes/);
+        expect(dbSrc).toMatch(/pgcrypto CREATE EXTENSION failed/);
+    });
+
+    test('comment references card_c2612cb2 source of the bug', () => {
+        expect(dbSrc).toMatch(/card_c2612cb2/);
+    });
+
+    test('does NOT use top-level await (would break Node ≤16) — extension call is inside async function', () => {
+        // The CREATE EXTENSION must be inside the existing createTables() async fn,
+        // not a new top-level await. Verify by checking it's not the first line of
+        // a non-async block.
+        const lines = dbSrc.split('\n');
+        const pgcryptoLineIdx = lines.findIndex(l => l.includes("'CREATE EXTENSION IF NOT EXISTS pgcrypto'"));
+        expect(pgcryptoLineIdx).toBeGreaterThan(-1);
+        // Walk up to find the nearest async function — should find one
+        let foundAsync = false;
+        for (let i = pgcryptoLineIdx; i >= 0; i--) {
+            if (/async\s+function\s+\w+/.test(lines[i])) { foundAsync = true; break; }
+        }
+        expect(foundAsync).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- `createTables()` now issues `CREATE EXTENSION IF NOT EXISTS pgcrypto` before any table create
- Soft-fail with a clear warn if EXTENSION is privileged-only on the host (matches pgvector pattern in `chat-embedding.js`)

## Why
Prod log (Card B Railway log monitor 06-16 17:35 TW, 6× at boot):
```
[Kanban] Error: function gen_random_bytes(integer) does not exist
```

Every kanban / mission / rental / arena id column DEFAULTs to:
```sql
DEFAULT ('card_' || encode(gen_random_bytes(12), 'hex'))
```
…which silently fails until pgcrypto is enabled. Source: card_c2612cb2.

## Pattern parity
`backend/chat-embedding.js:20` already bootstraps pgvector this way:
```js
await pool.query('CREATE EXTENSION IF NOT EXISTS vector');
```
This PR mirrors that — runs once at boot, idempotent, harmless if already enabled.

## Tests
- `backend/tests/jest/db-pgcrypto-bootstrap.test.js` — 6 tests
  - CREATE EXTENSION statement present
  - Fires before devices table create (id DEFAULTs work on first boot)
  - Wrapped in try/catch with warn (matches pgvector soft-fail pattern)
  - Warn message names the consequence (`gen_random_bytes DEFAULTs will fail`)
  - Cites card_c2612cb2
  - Not top-level await (safe for Node ≤16)
- 6/6 pass locally

## Test plan
- [x] Jest unit tests pass
- [ ] After merge + Railway deploy: prod boot log should show no more `function gen_random_bytes(integer) does not exist` errors
- [ ] Card B's next 6h cron tick (24:00 TW) should report 0 ERROR-low (pgcrypto entry should vanish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)