### PR TITLE
feat(settings): user_display_name column + portal UI (card_900)

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -266,6 +266,14 @@ async function createTables() {
             ALTER TABLE devices ADD COLUMN IF NOT EXISTS prompt_policy JSONB
         `);
 
+        // User display name (card_900db3bf): owner-set human name shown in chat/UI
+        // headers in place of generic "Device Owner" / "裝置主人". Plain TEXT (nullable);
+        // backend caps length to 64 chars at write time (matches devicePrefs validation
+        // pattern). No backfill — existing devices stay NULL until owner sets a value.
+        await client.query(`
+            ALTER TABLE devices ADD COLUMN IF NOT EXISTS user_display_name TEXT
+        `);
+
         // Dynamic entity system: per-device counter for unique entity ID assignment
         await client.query(`
             ALTER TABLE devices ADD COLUMN IF NOT EXISTS next_entity_id INTEGER DEFAULT 1
@@ -853,6 +861,7 @@ async function loadAllDevices() {
                 promptPolicy: row.prompt_policy
                     ? (typeof row.prompt_policy === 'string' ? JSON.parse(row.prompt_policy) : row.prompt_policy)
                     : null,
+                userDisplayName: row.user_display_name || null,
                 fcmToken: row.fcm_token || null,
                 apnsToken: row.apns_token || null,
                 entities: {}

--- a/backend/index.js
+++ b/backend/index.js
@@ -19894,6 +19894,14 @@ function normalizeUserDisplayName(input) {
     // a single-line UI label, so newlines/NUL/etc. would render as gibberish
     // or break layout. UTF-8 multibyte chars and emoji pass through fine.
     if (/[\x00-\x1f\x7f]/.test(trimmed)) return undefined;
+    // Reject Unicode bidi-override + zero-width chars: they enable spoofing
+    // (RTL-override "Admin" lookalikes) and invisible layout breakage in a
+    // user-facing label. Block:
+    //   ​-‏ (zero-width space / joiner / non-joiner / LRM / RLM)
+    //   ‪-‮ (bidi embedding/override controls)
+    //   ⁦-⁩ (bidi isolate controls)
+    //   ﻿       (zero-width no-break space / BOM)
+    if (/[​-‏‪-‮⁦-⁩﻿]/.test(trimmed)) return undefined;
     return trimmed;
 }
 
@@ -19949,12 +19957,17 @@ app.put('/api/device/user-profile', async (req, res) => {
     }
     try {
         const pool = db._getPool && db._getPool();
-        if (pool) {
-            await pool.query(
-                `UPDATE devices SET user_display_name = $1, updated_at = $2 WHERE device_id = $3`,
-                [normalized, Date.now(), deviceId]
-            );
+        if (!pool) {
+            // No DB pool means we cannot persist. Return 500 instead of
+            // succeeding-into-RAM-only — silent loss on next process restart
+            // is worse than a visible error the client can retry.
+            console.error('[UserProfile] PUT failed: db pool unavailable');
+            return res.status(500).json({ success: false, error: 'Database unavailable' });
         }
+        await pool.query(
+            `UPDATE devices SET user_display_name = $1, updated_at = $2 WHERE device_id = $3`,
+            [normalized, Date.now(), deviceId]
+        );
         // Update in-memory cache so subsequent GET (and any downstream consumers
         // that read devices[deviceId]) see the new value without a restart.
         if (devices[deviceId]) {

--- a/backend/index.js
+++ b/backend/index.js
@@ -19869,6 +19869,114 @@ app.put('/api/device-preferences', async (req, res) => {
 });
 
 // ============================================
+// DEVICE USER PROFILE — user_display_name (card_900db3bf)
+// ============================================
+// Owner-set human name shown in chat / UI in place of "Device Owner".
+// Persisted in devices.user_display_name (added by db.js migration).
+// Auth: device owner only (deviceSecret OR JWT cookie via authDevice helper).
+//
+// Globe-user generalization: every device worldwide can set its own display
+// name; no allowlist, no per-tenant carveouts. Trimmed + length-capped at
+// write time so 1-byte and 60-byte UTF-8 inputs round-trip safely.
+
+const USER_DISPLAY_NAME_MAX_LEN = 64;
+
+function normalizeUserDisplayName(input) {
+    if (input === null || input === undefined) return null;
+    if (typeof input !== 'string') return undefined; // sentinel: invalid type
+    const trimmed = input.trim();
+    if (trimmed.length === 0) return null;          // empty → clear
+    // Length cap via Array.from to count Unicode code points, not UTF-16 units,
+    // so a single emoji counts as 1 char (matches user-visible length).
+    const codePoints = Array.from(trimmed);
+    if (codePoints.length > USER_DISPLAY_NAME_MAX_LEN) return undefined; // too long
+    // Reject ASCII control chars (\x00-\x1f and \x7f DEL): the field is
+    // a single-line UI label, so newlines/NUL/etc. would render as gibberish
+    // or break layout. UTF-8 multibyte chars and emoji pass through fine.
+    if (/[\x00-\x1f\x7f]/.test(trimmed)) return undefined;
+    return trimmed;
+}
+
+app.get('/api/device/user-profile', async (req, res) => {
+    const deviceId = authDevice(req);
+    if (!deviceId) return res.status(401).json({ success: false, error: 'Unauthorized' });
+    try {
+        // Prefer in-memory cache (loaded by loadAllDevices); fall back to DB read
+        // so the endpoint still works for devices created in this process before
+        // a restart hydrates the cache.
+        let userDisplayName = null;
+        const memDevice = devices[deviceId];
+        if (memDevice && Object.prototype.hasOwnProperty.call(memDevice, 'userDisplayName')) {
+            userDisplayName = memDevice.userDisplayName || null;
+        } else {
+            const pool = db._getPool && db._getPool();
+            if (pool) {
+                const result = await pool.query(
+                    'SELECT user_display_name FROM devices WHERE device_id = $1',
+                    [deviceId]
+                );
+                userDisplayName = result.rows[0]?.user_display_name || null;
+            }
+        }
+        return res.json({
+            success: true,
+            profile: {
+                userDisplayName,
+                maxLength: USER_DISPLAY_NAME_MAX_LEN
+            }
+        });
+    } catch (err) {
+        console.error('[UserProfile] GET failed:', err.message);
+        return res.status(500).json({ success: false, error: 'Internal error' });
+    }
+});
+
+app.put('/api/device/user-profile', async (req, res) => {
+    const deviceId = authDevice(req);
+    if (!deviceId) return res.status(401).json({ success: false, error: 'Unauthorized' });
+    const body = req.body || {};
+    // Only handle the field if the caller actually sent it — lets future fields
+    // be added without breaking partial PUTs.
+    if (!Object.prototype.hasOwnProperty.call(body, 'userDisplayName')) {
+        return res.status(400).json({ success: false, error: 'userDisplayName field required' });
+    }
+    const normalized = normalizeUserDisplayName(body.userDisplayName);
+    if (normalized === undefined) {
+        return res.status(400).json({
+            success: false,
+            error: `Invalid userDisplayName (must be string, ≤${USER_DISPLAY_NAME_MAX_LEN} chars, no control characters)`
+        });
+    }
+    try {
+        const pool = db._getPool && db._getPool();
+        if (pool) {
+            await pool.query(
+                `UPDATE devices SET user_display_name = $1, updated_at = $2 WHERE device_id = $3`,
+                [normalized, Date.now(), deviceId]
+            );
+        }
+        // Update in-memory cache so subsequent GET (and any downstream consumers
+        // that read devices[deviceId]) see the new value without a restart.
+        if (devices[deviceId]) {
+            devices[deviceId].userDisplayName = normalized;
+        }
+        // Notify connected portal/app sockets in the device room so other open
+        // tabs reflect the change immediately.
+        try { io.to(deviceId).emit('device:user-profile', { deviceId, profile: { userDisplayName: normalized } }); } catch (e) {}
+        return res.json({
+            success: true,
+            profile: {
+                userDisplayName: normalized,
+                maxLength: USER_DISPLAY_NAME_MAX_LEN
+            }
+        });
+    } catch (err) {
+        console.error('[UserProfile] PUT failed:', err.message);
+        return res.status(500).json({ success: false, error: 'Internal error' });
+    }
+});
+
+// ============================================
 // ORGANIZATION HIERARCHY CHART
 // ============================================
 

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -788,6 +788,47 @@
             </div>
         </div>
 
+        <!-- User Display Name Card (card_900db3bf) -->
+        <div class="card" id="userProfileCard">
+            <div class="card-title" style="display:flex;align-items:center;gap:6px;">
+                <span>🪪 <span data-i18n="settings_user_display_name_title">My Display Name</span></span>
+                <span class="help-icon-inline"
+                      title="Click for help"
+                      role="button"
+                      tabindex="0"
+                      aria-label="Help"
+                      onclick="showUserDisplayNameHelp()"
+                      onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();showUserDisplayNameHelp();}"
+                      style="cursor:pointer;display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:50%;border:1px solid var(--card-border);font-size:11px;color:var(--text-secondary);user-select:none;">?</span>
+            </div>
+            <p class="section-desc" data-i18n="settings_user_display_name_desc">The name shown in chat headers in place of "Device Owner". Leave blank to use the default.</p>
+            <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-top:8px;">
+                <input type="text"
+                       id="userDisplayNameInput"
+                       maxlength="64"
+                       data-i18n-placeholder="settings_user_display_name_placeholder"
+                       placeholder="e.g. Hank"
+                       style="flex:1;min-width:160px;padding:8px 10px;border:1px solid var(--card-border);border-radius:6px;background:var(--bg);color:var(--text);font-size:14px;">
+                <button class="btn btn-primary btn-sm"
+                        onclick="saveUserDisplayName()"
+                        id="userDisplayNameSaveBtn"
+                        data-i18n="common_save">Save</button>
+            </div>
+            <p id="userDisplayNameStatus" class="section-desc" style="margin:8px 0 0;min-height:18px;"></p>
+            <!-- Empty / disabled-state help dialog (hidden by default) -->
+            <div id="userDisplayNameHelpDialog"
+                 onclick="if(event.target===this)closeUserDisplayNameHelp()"
+                 style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.55);z-index:9999;align-items:center;justify-content:center;padding:16px;">
+                <div style="background:var(--bg);color:var(--text);max-width:480px;width:100%;border-radius:10px;padding:18px 20px;border:1px solid var(--card-border);">
+                    <h3 style="margin:0 0 8px;font-size:16px;" data-i18n="settings_user_display_name_help_title">About My Display Name</h3>
+                    <p style="margin:0 0 8px;font-size:13px;line-height:1.5;" data-i18n="settings_user_display_name_help_body">This name appears in chat as the human label for messages you send. It is visible to bots you talk to but not used for routing or login. Up to 64 characters, single line, no control characters. Leave blank to fall back to the default "Device Owner".</p>
+                    <div style="display:flex;justify-content:flex-end;margin-top:12px;">
+                        <button class="btn btn-sm btn-outline" onclick="closeUserDisplayNameHelp()" data-i18n="common_close">Close</button>
+                    </div>
+                </div>
+            </div>
+        </div>
+
         <!-- Channel API Card -->
         <div class="card" id="channelApiCard">
             <div class="card-title" style="display:flex;align-items:center;justify-content:space-between;">
@@ -1690,6 +1731,7 @@
             loadViewModePreference();
             loadNotifPreferences();
             loadDevicePreferences();
+            loadUserDisplayName();
             populateKanbanNudgeEntityPicker();
             loadOwnerRoster(user).catch(e => console.warn('[Roster] initial load failed:', e));
             loadPromptPolicy(user);
@@ -2550,6 +2592,68 @@
                 showToast(i18n.t('toast_preference_update_failed'), 'error');
             }
         }
+
+        // ============================================
+        // USER DISPLAY NAME (card_900db3bf)
+        // ============================================
+        async function loadUserDisplayName() {
+            const input = document.getElementById('userDisplayNameInput');
+            const status = document.getElementById('userDisplayNameStatus');
+            if (!input) return;
+            try {
+                const data = await apiCall('GET', '/api/device/user-profile');
+                const name = data && data.profile && data.profile.userDisplayName;
+                input.value = name || '';
+                if (status) status.textContent = '';
+            } catch (e) {
+                if (status) status.textContent = i18n.t('settings_user_display_name_load_failed') || 'Failed to load name';
+            }
+        }
+
+        async function saveUserDisplayName() {
+            const input = document.getElementById('userDisplayNameInput');
+            const status = document.getElementById('userDisplayNameStatus');
+            const btn = document.getElementById('userDisplayNameSaveBtn');
+            if (!input) return;
+            const raw = input.value || '';
+            // Client-side length cap (UI hint only — server is the gate).
+            const codePoints = Array.from(raw.trim());
+            if (codePoints.length > 64) {
+                if (status) status.textContent = i18n.t('settings_user_display_name_too_long') || 'Name is too long (max 64).';
+                return;
+            }
+            if (btn) btn.disabled = true;
+            try {
+                const data = await apiCall('PUT', '/api/device/user-profile', { userDisplayName: raw });
+                const name = data && data.profile && data.profile.userDisplayName;
+                input.value = name || '';
+                if (status) status.textContent = '';
+                if (typeof showToast === 'function') {
+                    showToast(i18n.t('settings_user_display_name_saved') || 'Display name saved', 'success');
+                }
+            } catch (e) {
+                if (status) status.textContent = (e && e.message) || i18n.t('settings_user_display_name_save_failed') || 'Save failed';
+            } finally {
+                if (btn) btn.disabled = false;
+            }
+        }
+
+        function showUserDisplayNameHelp() {
+            const dlg = document.getElementById('userDisplayNameHelpDialog');
+            if (dlg) dlg.style.display = 'flex';
+        }
+        function closeUserDisplayNameHelp() {
+            const dlg = document.getElementById('userDisplayNameHelpDialog');
+            if (dlg) dlg.style.display = 'none';
+        }
+
+        window.onSocketUserProfile = function(data) {
+            if (!data || !data.profile) return;
+            const input = document.getElementById('userDisplayNameInput');
+            if (input && document.activeElement !== input) {
+                input.value = data.profile.userDisplayName || '';
+            }
+        };
 
         // ============================================
         // DEVICE PREFERENCES (broadcast settings)

--- a/backend/public/portal/shared/socket.js
+++ b/backend/public/portal/shared/socket.js
@@ -58,6 +58,10 @@ function initPortalSocket() {
         if (typeof onSocketDevicePreferences === 'function') onSocketDevicePreferences(data);
     });
 
+    portalSocket.on('device:user-profile', (data) => {
+        if (typeof onSocketUserProfile === 'function') onSocketUserProfile(data);
+    });
+
     portalSocket.on('disconnect', () => {
         console.log('[Socket] Disconnected');
     });

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650249,6 +650249,16 @@ const TRANSLATIONS = {
         "env_key_deleted": "Deleted \"{key}\"",
         "env_delete_failed": "Delete failed: {error}",
         "env_empty_setup_hint": "No keys yet. Click \"+ Add\" to store credentials your bots can read via the secrets API.",
+
+        "settings_user_display_name_title": "My Display Name",
+        "settings_user_display_name_desc": "The name shown in chat headers in place of \"Device Owner\". Leave blank to use the default.",
+        "settings_user_display_name_placeholder": "e.g. Hank",
+        "settings_user_display_name_saved": "Display name saved",
+        "settings_user_display_name_save_failed": "Save failed",
+        "settings_user_display_name_load_failed": "Failed to load name",
+        "settings_user_display_name_too_long": "Name is too long (max 64 characters).",
+        "settings_user_display_name_help_title": "About My Display Name",
+        "settings_user_display_name_help_body": "This name appears in chat as the human label for messages you send. It is visible to bots you talk to but not used for routing or login. Up to 64 characters, single line, no control characters. Leave blank to fall back to the default \"Device Owner\".",
 },
 
 
@@ -1234964,6 +1234974,16 @@ const TRANSLATIONS = {
         "env_key_deleted": "已刪除「{key}」",
         "env_delete_failed": "刪除失敗：{error}",
         "env_empty_setup_hint": "尚未設定金鑰。點擊「+ 新增」來儲存 Bot 可透過 secrets API 讀取的憑證。",
+
+        "settings_user_display_name_title": "我的顯示名稱",
+        "settings_user_display_name_desc": "在對話標題顯示的名稱，取代「裝置主人」。留空則使用預設值。",
+        "settings_user_display_name_placeholder": "例如：Hank",
+        "settings_user_display_name_saved": "已儲存顯示名稱",
+        "settings_user_display_name_save_failed": "儲存失敗",
+        "settings_user_display_name_load_failed": "載入名稱失敗",
+        "settings_user_display_name_too_long": "名稱過長（最多 64 個字元）。",
+        "settings_user_display_name_help_title": "關於顯示名稱",
+        "settings_user_display_name_help_body": "此名稱會出現在對話中作為您所發訊息的人類標籤。對您交談的智能體可見，但不用於路由或登入。最多 64 個字元、單行、不可包含控制字元。留空則回退為預設的「裝置主人」。",
 },
 
 
@@ -2412246,6 +2412266,16 @@ const TRANSLATIONS = {
         "petdx_switch_failed": "切り替えに失敗しました：{error}",
         "petdx_network_error": "ネットワークエラー：{error}",
         "petdx_favorite_failed": "お気に入りの保存に失敗しました：{error}",
+
+        "settings_user_display_name_title": "表示名",
+        "settings_user_display_name_desc": "「Device Owner」の代わりにチャットヘッダーに表示される名前です。空欄の場合はデフォルト値が使われます。",
+        "settings_user_display_name_placeholder": "例: Hank",
+        "settings_user_display_name_saved": "表示名を保存しました",
+        "settings_user_display_name_save_failed": "保存に失敗しました",
+        "settings_user_display_name_load_failed": "名前の読み込みに失敗しました",
+        "settings_user_display_name_too_long": "名前が長すぎます（最大64文字）。",
+        "settings_user_display_name_help_title": "表示名について",
+        "settings_user_display_name_help_body": "この名前は、あなたが送信したメッセージの人間用ラベルとしてチャットに表示されます。会話相手のボットには見えますが、ルーティングやログインには使用されません。最大64文字、1行、制御文字は使用できません。空欄の場合はデフォルトの「Device Owner」にフォールバックします。",
 },
 
 
@@ -2942523,6 +2942553,16 @@ const TRANSLATIONS = {
         "petdx_switch_failed": "전환 실패: {error}",
         "petdx_network_error": "네트워크 오류: {error}",
         "petdx_favorite_failed": "즐겨찾기 저장 실패: {error}",
+
+        "settings_user_display_name_title": "표시 이름",
+        "settings_user_display_name_desc": "채팅 헤더에서 \"Device Owner\" 대신 표시되는 이름입니다. 비워두면 기본값이 사용됩니다.",
+        "settings_user_display_name_placeholder": "예: Hank",
+        "settings_user_display_name_saved": "표시 이름이 저장되었습니다",
+        "settings_user_display_name_save_failed": "저장 실패",
+        "settings_user_display_name_load_failed": "이름 로드 실패",
+        "settings_user_display_name_too_long": "이름이 너무 깁니다(최대 64자).",
+        "settings_user_display_name_help_title": "표시 이름 정보",
+        "settings_user_display_name_help_body": "이 이름은 보낸 메시지의 사람용 라벨로 채팅에 표시됩니다. 대화하는 봇에는 보이지만 라우팅이나 로그인에는 사용되지 않습니다. 최대 64자, 한 줄, 제어 문자는 불가합니다. 비워두면 기본값 \"Device Owner\"로 폴백됩니다.",
 },
 
 
@@ -3997743,6 +3997783,16 @@ const TRANSLATIONS = {
         "petdx_switch_failed": "Chuyển đổi thất bại: {error}",
         "petdx_network_error": "Lỗi mạng: {error}",
         "petdx_favorite_failed": "Lưu vào yêu thích thất bại: {error}",
+
+        "settings_user_display_name_title": "Tên hiển thị của tôi",
+        "settings_user_display_name_desc": "Tên hiển thị trong tiêu đề trò chuyện thay cho \"Device Owner\". Để trống để dùng giá trị mặc định.",
+        "settings_user_display_name_placeholder": "ví dụ: Hank",
+        "settings_user_display_name_saved": "Đã lưu tên hiển thị",
+        "settings_user_display_name_save_failed": "Lưu thất bại",
+        "settings_user_display_name_load_failed": "Không tải được tên",
+        "settings_user_display_name_too_long": "Tên quá dài (tối đa 64 ký tự).",
+        "settings_user_display_name_help_title": "Về tên hiển thị",
+        "settings_user_display_name_help_body": "Tên này hiển thị trong trò chuyện như nhãn dành cho con người cho các tin nhắn bạn gửi. Các bot bạn trò chuyện có thể thấy, nhưng không dùng để định tuyến hoặc đăng nhập. Tối đa 64 ký tự, một dòng, không có ký tự điều khiển. Để trống sẽ quay về giá trị mặc định \"Device Owner\".",
 },
 
 
@@ -4524196,6 +4524246,16 @@ const TRANSLATIONS = {
         "petdx_switch_failed": "Pergantian gagal: {error}",
         "petdx_network_error": "Kesalahan jaringan: {error}",
         "petdx_favorite_failed": "Gagal menyimpan ke favorit: {error}",
+
+        "settings_user_display_name_title": "Nama Tampil Saya",
+        "settings_user_display_name_desc": "Nama yang ditampilkan di header obrolan menggantikan \"Device Owner\". Biarkan kosong untuk memakai nilai default.",
+        "settings_user_display_name_placeholder": "mis. Hank",
+        "settings_user_display_name_saved": "Nama tampil disimpan",
+        "settings_user_display_name_save_failed": "Gagal menyimpan",
+        "settings_user_display_name_load_failed": "Gagal memuat nama",
+        "settings_user_display_name_too_long": "Nama terlalu panjang (maks. 64 karakter).",
+        "settings_user_display_name_help_title": "Tentang Nama Tampil",
+        "settings_user_display_name_help_body": "Nama ini muncul di obrolan sebagai label manusiawi untuk pesan yang Anda kirim. Bot yang Anda ajak bicara dapat melihatnya, tetapi tidak digunakan untuk perutean atau login. Maksimum 64 karakter, satu baris, tanpa karakter kontrol. Biarkan kosong untuk kembali ke nilai default \"Device Owner\".",
 },
 
 
@@ -5566949,6 +5567009,16 @@ const TRANSLATIONS = {
         "petdx_switch_failed": "Cambio fallido: {error}",
         "petdx_network_error": "Error de red: {error}",
         "petdx_favorite_failed": "Error al guardar en favoritos: {error}",
+
+        "settings_user_display_name_title": "Mi nombre visible",
+        "settings_user_display_name_desc": "El nombre que aparece en los encabezados del chat en lugar de \"Device Owner\". Déjalo en blanco para usar el valor predeterminado.",
+        "settings_user_display_name_placeholder": "p. ej. Hank",
+        "settings_user_display_name_saved": "Nombre guardado",
+        "settings_user_display_name_save_failed": "Error al guardar",
+        "settings_user_display_name_load_failed": "Error al cargar el nombre",
+        "settings_user_display_name_too_long": "El nombre es demasiado largo (máx. 64 caracteres).",
+        "settings_user_display_name_help_title": "Acerca del nombre visible",
+        "settings_user_display_name_help_body": "Este nombre aparece en el chat como etiqueta humana de los mensajes que envías. Es visible para los bots con los que hablas, pero no se utiliza para el enrutamiento ni el inicio de sesión. Hasta 64 caracteres, una sola línea, sin caracteres de control. Déjalo en blanco para volver al valor predeterminado \"Device Owner\".",
 },
 
 

--- a/backend/tests/jest/device-profile-user-display-name.test.js
+++ b/backend/tests/jest/device-profile-user-display-name.test.js
@@ -242,12 +242,62 @@ describe('PUT /api/device/user-profile', () => {
         });
         expect(res.status).toBe(200);
         expect(res.body.profile.userDisplayName).toBe(evil);
-        // Confirm UPDATE was invoked via parameterized query with `$1`
+        // Confirm UPDATE was invoked via parameterized query, NOT string-
+        // interpolated. Three assertions stacked:
+        //   1. The SQL string uses placeholder $1 (proves parameterization).
+        //   2. The raw `evil` string never appears in the SQL itself.
+        //   3. The full evil payload was passed as the bound parameter.
         const updateCalls = db._mockPool.query.mock.calls.filter(c => /UPDATE devices/i.test(c[0]));
         expect(updateCalls.length).toBeGreaterThanOrEqual(1);
         const [sql, params] = updateCalls[updateCalls.length - 1];
         expect(sql).toMatch(/\$1/);
+        expect(sql).not.toContain('DROP TABLE');
+        expect(sql).not.toContain(evil);
         expect(params[0]).toBe(evil);
+    });
+
+    it('rejects names containing Unicode bidi-override (RTL/LRO) chars', async () => {
+        const devId = `ud-put-bidi-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        // U+202E = RIGHT-TO-LEFT OVERRIDE — used in "Admin" spoofs
+        const res = await put('/api/device/user-profile').send({
+            deviceId: devId, deviceSecret: secret, userDisplayName: 'A‮nimdA',
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/Invalid userDisplayName/i);
+    });
+
+    it('rejects names containing zero-width chars (ZWSP / ZWJ / ZWNJ)', async () => {
+        const devId = `ud-put-zwsp-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        // U+200B = ZERO WIDTH SPACE
+        const res = await put('/api/device/user-profile').send({
+            deviceId: devId, deviceSecret: secret, userDisplayName: 'Hank​Fake',
+        });
+        expect(res.status).toBe(400);
+    });
+
+    it('rejects names with embedded BOM / zero-width no-break space (U+FEFF)', async () => {
+        const devId = `ud-put-bom-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        // BOM in the middle (leading/trailing BOM is harmlessly stripped by trim())
+        const res = await put('/api/device/user-profile').send({
+            deviceId: devId, deviceSecret: secret, userDisplayName: 'Han﻿k',
+        });
+        expect(res.status).toBe(400);
+    });
+
+    it('rejects array and object payloads (only string accepted)', async () => {
+        const devId = `ud-put-arr-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        const r1 = await put('/api/device/user-profile').send({
+            deviceId: devId, deviceSecret: secret, userDisplayName: ['Hank'],
+        });
+        expect(r1.status).toBe(400);
+        const r2 = await put('/api/device/user-profile').send({
+            deviceId: devId, deviceSecret: secret, userDisplayName: { name: 'Hank' },
+        });
+        expect(r2.status).toBe(400);
     });
 
     it('persists the value into the in-memory devices cache for next GET', async () => {

--- a/backend/tests/jest/device-profile-user-display-name.test.js
+++ b/backend/tests/jest/device-profile-user-display-name.test.js
@@ -1,0 +1,282 @@
+/**
+ * Device User Profile — user_display_name endpoint tests
+ *
+ * Coverage:
+ *   - GET /api/device/user-profile (owner-auth gate + cache + DB fallback)
+ *   - PUT /api/device/user-profile (owner-auth gate, validation, trim,
+ *     null/empty clear, length cap, control-char rejection, persistence)
+ *
+ * Card: card_900db3bf28ba004813d97ce9
+ */
+
+require('./helpers/mock-setup');
+const request = require('supertest');
+let app;
+let db;
+const get = (path) => request(app).get(path).set('Host', 'localhost');
+const put = (path) => request(app).put(path).set('Host', 'localhost');
+const post = (path) => request(app).post(path).set('Host', 'localhost');
+
+async function registerDevice(id) {
+    const secret = `secret-${id}`;
+    await post('/api/device/register').send({ deviceId: id, deviceSecret: secret, entityId: 0 });
+    return secret;
+}
+
+beforeAll(() => {
+    process.env.SEAL_KEY = '0'.repeat(64);
+    app = require('../../index');
+    db = require('../../db');
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+});
+
+beforeEach(() => {
+    // Reset the shared mock pool so each test sees a clean query log
+    if (db && db._mockPool && db._mockPool.query) {
+        db._mockPool.query.mockReset();
+        db._mockPool.query.mockResolvedValue({ rows: [], rowCount: 0 });
+    }
+});
+
+// ════════════════════════════════════════════════════════════════
+// GET /api/device/user-profile — owner auth required
+// ════════════════════════════════════════════════════════════════
+describe('GET /api/device/user-profile', () => {
+    it('returns 401 when no credentials provided', async () => {
+        const res = await get('/api/device/user-profile');
+        expect(res.status).toBe(401);
+        expect(res.body.success).toBe(false);
+    });
+
+    it('returns 401 when only deviceId is provided', async () => {
+        const res = await get('/api/device/user-profile?deviceId=dev-noauth');
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 401 when deviceSecret is wrong', async () => {
+        const devId = `ud-get-wrong-${Date.now()}`;
+        await registerDevice(devId);
+        const res = await get(`/api/device/user-profile?deviceId=${devId}&deviceSecret=wrong-secret`);
+        expect(res.status).toBe(401);
+    });
+
+    it('returns profile with null userDisplayName for a freshly registered device', async () => {
+        const devId = `ud-get-ok-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        const res = await get(`/api/device/user-profile?deviceId=${devId}&deviceSecret=${secret}`);
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.profile).toBeDefined();
+        expect(res.body.profile.userDisplayName).toBeNull();
+        expect(res.body.profile.maxLength).toBe(64);
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// PUT /api/device/user-profile — set and clear
+// ════════════════════════════════════════════════════════════════
+describe('PUT /api/device/user-profile', () => {
+    it('returns 401 without credentials', async () => {
+        const res = await put('/api/device/user-profile').send({ userDisplayName: 'Hank' });
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 401 with wrong deviceSecret', async () => {
+        const devId = `ud-put-wrong-${Date.now()}`;
+        await registerDevice(devId);
+        const res = await put('/api/device/user-profile').send({
+            deviceId: devId,
+            deviceSecret: 'wrong',
+            userDisplayName: 'Hank',
+        });
+        expect(res.status).toBe(401);
+    });
+
+    it('returns 400 when body has no userDisplayName field', async () => {
+        const devId = `ud-put-missing-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        const res = await put('/api/device/user-profile').send({
+            deviceId: devId,
+            deviceSecret: secret,
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/userDisplayName/i);
+    });
+
+    it('accepts a valid string and echoes it back', async () => {
+        const devId = `ud-put-ok-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        const res = await put('/api/device/user-profile').send({
+            deviceId: devId,
+            deviceSecret: secret,
+            userDisplayName: 'Hank',
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.profile.userDisplayName).toBe('Hank');
+    });
+
+    it('trims surrounding whitespace', async () => {
+        const devId = `ud-put-trim-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        const res = await put('/api/device/user-profile').send({
+            deviceId: devId,
+            deviceSecret: secret,
+            userDisplayName: '  Hank  ',
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.profile.userDisplayName).toBe('Hank');
+    });
+
+    it('treats empty string as clear (returns null)', async () => {
+        const devId = `ud-put-empty-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        // First set a value
+        await put('/api/device/user-profile').send({
+            deviceId: devId, deviceSecret: secret, userDisplayName: 'TempName',
+        });
+        // Then clear
+        const res = await put('/api/device/user-profile').send({
+            deviceId: devId, deviceSecret: secret, userDisplayName: '   ',
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.profile.userDisplayName).toBeNull();
+    });
+
+    it('treats explicit null as clear', async () => {
+        const devId = `ud-put-null-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        const res = await put('/api/device/user-profile').send({
+            deviceId: devId, deviceSecret: secret, userDisplayName: null,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.profile.userDisplayName).toBeNull();
+    });
+
+    it('rejects non-string types (number)', async () => {
+        const devId = `ud-put-type-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        const res = await put('/api/device/user-profile').send({
+            deviceId: devId, deviceSecret: secret, userDisplayName: 12345,
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/Invalid userDisplayName/i);
+    });
+
+    it('rejects names exceeding 64 code points', async () => {
+        const devId = `ud-put-toolong-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        // 65 ASCII chars
+        const tooLong = 'a'.repeat(65);
+        const res = await put('/api/device/user-profile').send({
+            deviceId: devId, deviceSecret: secret, userDisplayName: tooLong,
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/Invalid userDisplayName/i);
+    });
+
+    it('accepts names exactly at the 64-codepoint cap', async () => {
+        const devId = `ud-put-exact-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        const exact = 'a'.repeat(64);
+        const res = await put('/api/device/user-profile').send({
+            deviceId: devId, deviceSecret: secret, userDisplayName: exact,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.profile.userDisplayName).toBe(exact);
+    });
+
+    it('counts emoji as one code point, not multiple UTF-16 units', async () => {
+        const devId = `ud-put-emoji-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        // 32 emoji = 32 code points (well under 64) but 64 UTF-16 units
+        const emoji = '🚀'.repeat(32);
+        const res = await put('/api/device/user-profile').send({
+            deviceId: devId, deviceSecret: secret, userDisplayName: emoji,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.profile.userDisplayName).toBe(emoji);
+    });
+
+    it('accepts CJK characters', async () => {
+        const devId = `ud-put-cjk-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        const res = await put('/api/device/user-profile').send({
+            deviceId: devId, deviceSecret: secret, userDisplayName: '小明',
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.profile.userDisplayName).toBe('小明');
+    });
+
+    it('rejects names containing newline (control char)', async () => {
+        const devId = `ud-put-nl-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        const res = await put('/api/device/user-profile').send({
+            deviceId: devId, deviceSecret: secret, userDisplayName: 'Line1\nLine2',
+        });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/Invalid userDisplayName/i);
+    });
+
+    it('rejects names containing NUL byte', async () => {
+        const devId = `ud-put-nul-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        const res = await put('/api/device/user-profile').send({
+            deviceId: devId, deviceSecret: secret, userDisplayName: 'a b',
+        });
+        expect(res.status).toBe(400);
+    });
+
+    it('does not write SQL injection literally into a string column', async () => {
+        // The endpoint uses parameterized SQL via pg, so the raw string ends
+        // up stored verbatim — proving the input never breaks query parsing.
+        const devId = `ud-put-sql-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        const evil = "Robert'); DROP TABLE devices;--";
+        const res = await put('/api/device/user-profile').send({
+            deviceId: devId, deviceSecret: secret, userDisplayName: evil,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.profile.userDisplayName).toBe(evil);
+        // Confirm UPDATE was invoked via parameterized query with `$1`
+        const updateCalls = db._mockPool.query.mock.calls.filter(c => /UPDATE devices/i.test(c[0]));
+        expect(updateCalls.length).toBeGreaterThanOrEqual(1);
+        const [sql, params] = updateCalls[updateCalls.length - 1];
+        expect(sql).toMatch(/\$1/);
+        expect(params[0]).toBe(evil);
+    });
+
+    it('persists the value into the in-memory devices cache for next GET', async () => {
+        const devId = `ud-put-roundtrip-${Date.now()}`;
+        const secret = await registerDevice(devId);
+        await put('/api/device/user-profile').send({
+            deviceId: devId, deviceSecret: secret, userDisplayName: 'Persistent',
+        });
+        const res = await get(`/api/device/user-profile?deviceId=${devId}&deviceSecret=${secret}`);
+        expect(res.status).toBe(200);
+        expect(res.body.profile.userDisplayName).toBe('Persistent');
+    });
+});
+
+// ════════════════════════════════════════════════════════════════
+// Schema migration smoke — db.js createTables() idempotent ALTER
+// ════════════════════════════════════════════════════════════════
+describe('devices.user_display_name migration', () => {
+    it('db.js source contains the idempotent ALTER TABLE', () => {
+        const fs = require('fs');
+        const path = require('path');
+        const dbSrc = fs.readFileSync(path.join(__dirname, '..', '..', 'db.js'), 'utf8');
+        expect(dbSrc).toMatch(/ALTER TABLE devices ADD COLUMN IF NOT EXISTS user_display_name TEXT/);
+    });
+
+    it('loadAllDevices maps row.user_display_name → userDisplayName in cache', () => {
+        const fs = require('fs');
+        const path = require('path');
+        const dbSrc = fs.readFileSync(path.join(__dirname, '..', '..', 'db.js'), 'utf8');
+        expect(dbSrc).toMatch(/userDisplayName:\s*row\.user_display_name/);
+    });
+});


### PR DESCRIPTION
## Summary
Adds an owner-set human display name to every device so chat headers can render `Hank` instead of the generic `Device Owner` / `裝置主人` label.

Focused PR per 1 PR = 1 feature ([[feedback_pr_workflow]]). The follow-on `@handle` + mention-parser extension lives in `card_db71f4423` and depends on this column.

Card: `card_900db3bf28ba004813d97ce9`

## Why
- Title and description on the card explicitly list `devices.user_display_name` as the first deliverable.
- `mention-parser.js` does not have an `@username` route today, and the `display_name` column on the codebase is the admin-bot label (`official_bots.display_name`), not a device-level user identity. There was no API for the owner to set the human label they want bots to address them by.
- Per `[[feedback_spec_globe_user_setup_clarity]]`, the spec includes a globe-user generalization (any device worldwide can set its own name; no allow-listing) and a `?` icon dialog that explains what the field does, where it shows up, and what happens when blank.

## What changed
**Schema** (`backend/db.js`)
- Idempotent `ALTER TABLE devices ADD COLUMN IF NOT EXISTS user_display_name TEXT` inside the existing `createTables` migration block.
- `loadAllDevices()` maps `row.user_display_name` → cached `userDisplayName`.

**API** (`backend/index.js`)
- `GET  /api/device/user-profile` — owner-auth via existing `authDevice(req)` helper (deviceSecret query/body **or** JWT cookie).
- `PUT  /api/device/user-profile` — same auth, body `{ userDisplayName }`.
- Validation in `normalizeUserDisplayName()`:
  - string only (other types → 400)
  - trim surrounding whitespace
  - empty / null → clear (stores `NULL`)
  - cap at 64 Unicode code points (emoji counts as 1, not 2 UTF-16 units)
  - reject ASCII control chars (`\x00-\x1f`, `\x7f`) so it stays a single-line label
- Emits Socket.IO `device:user-profile` event to the `deviceId` room so other open tabs/clients refresh without polling.

**UI** (`backend/public/portal/settings.html`, `backend/public/portal/shared/socket.js`)
- New `🪪 My Display Name` card directly under the Account info card, containing:
  - text input (maxlength=64), Save button, status line
  - inline `?` icon → modal dialog explaining what the field is, who sees it (bots you chat with — not used for routing/login), the 64-char cap, and the fall-back behaviour when blank
- Wired into the existing settings init alongside `loadDevicePreferences()`.
- Socket layer forwards `device:user-profile` to `onSocketUserProfile` so the input reflects remote saves (without clobbering a focused input).

**i18n** (`backend/public/shared/i18n.js`)
- 9 new keys × 7 locales (en/zh/ja/ko/es/vi/id) inserted via the AST tool `backend/scripts/i18n-insert-locale-keys.js` per `[[reference_i18n_insert_via_ast]]`.
- No regex/sed/Python depth-walker (the patterns that broke PR #3253).

## Test plan
- [x] Jest unit + integration suite for the new endpoint
  - `backend/tests/jest/device-profile-user-display-name.test.js` — 22 tests, all green:
    - 401 when no creds / wrong secret / only deviceId
    - 400 when body has no `userDisplayName` field
    - 400 on non-string, > 64 code points, newline, NUL byte
    - 200 on plain string, with surrounding whitespace trimmed
    - 200 on explicit null / whitespace-only string → returns `null`
    - 200 on emoji (32 × 🚀 = 32 code points but 64 UTF-16 units — proves we count the user-visible length)
    - 200 on CJK characters
    - 200 on exact 64-char input
    - Parameterized-SQL anti-injection: `Robert'); DROP TABLE devices;--` is stored verbatim, asserted via the `$1` placeholder in the captured query
    - Round-trip: PUT then GET returns the new value
  - Schema migration smoke: source assertions that the ALTER and the `userDisplayName` mapping both exist
- [x] Adjacent suites still green — ran `device-preferences`, `device-vars`, `auth`, `i18n-fallback-chain` together: 98 passed, 0 failed
- [x] Full jest run (excluding `socket-io`, `integration`, `e2e`, `tests/api/`, `cron-task-monitor`): **307 suites, 4215 tests passed, 0 failed**
- [x] ESLint: zero new errors (4 pre-existing warnings on unrelated files)
- [x] `check-settings-help-invariant.js --all` clean (this card uses `_title` + `_desc` keys + a `?` dialog, not the `_label`/`_help` registry pattern, so no registry entry needed)

## Out of scope (separate cards)
- `@handle` column + uniqueness + 30-day cooldown (`card_db71f4423`)
- `mention-parser.js` `@handle` route + push notification (`card_db71f4423`)
- Cross-device privacy toggle for handle lookup (`card_db71f4423`)

## Risk notes
- Migration is `ADD COLUMN IF NOT EXISTS … TEXT` (nullable, no default) — safe on a populated `devices` table at any size; no backfill needed.
- All writes go through pg `$1` placeholders; the new column never sees string-interpolated SQL.
- The new endpoint is owner-only — there's no public-read surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)