### PR TITLE
feat(notify): @<username> entity mention triggers push + setting toggle (card_db7)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -9350,7 +9350,12 @@ app.post('/api/transform', transformMaybeMultipart, idempotencyMiddleware, async
         try {
             const userMentions = userMentionScanner.findUserMentions(finalMessage, {
                 senderDeviceId: deviceId,
-                devices
+                devices,
+                // Threading the live publicCodeIndex lets the scanner
+                // defer 6-char alnum tokens ONLY when they actually
+                // resolve as a publicCode; otherwise they fall through
+                // to display-name lookup (e.g. legit user 'alice1').
+                publicCodeIndex
             });
             for (const um of userMentions) {
                 const fromLabel = entity.name || `Entity ${eId}`;

--- a/backend/index.js
+++ b/backend/index.js
@@ -11,6 +11,7 @@ const db = require('./db');
 const flickr = require('./flickr');
 const gatekeeper = require('./gatekeeper');
 const mentionParser = require('./mention-parser');
+const userMentionScanner = require('./user-mention-scanner');
 const pushContext = require('./push-context');
 const telemetry = require('./device-telemetry');
 const sitePageviews = require('./site-pageviews');
@@ -9333,6 +9334,43 @@ app.post('/api/transform', transformMaybeMultipart, idempotencyMiddleware, async
                 speakTo = tParse.mentions.map(m => m.publicCode);
                 routingResolvedVia = 'mention';
             }
+        }
+    }
+
+    // ── user_display_name @-mention push (card_db71f4423cb1697f9935f460) ──
+    // Independent of entity routing: when an entity sends a message that
+    // contains `@<user_display_name>` (the device owner's free-text name
+    // from PR #3429), the owner of the matched device gets a "you were
+    // mentioned" push on top of any existing chat push. The scanner
+    // skips tokens already claimed by the entity-mention parser
+    // (@publicCode / @entityId / @all) so the two systems never collide.
+    // The notify_device pref `user_mention` (default ON) gates delivery
+    // via notifModule.isCategoryEnabled.
+    if (finalMessage && !isSuppressedMessage) {
+        try {
+            const userMentions = userMentionScanner.findUserMentions(finalMessage, {
+                senderDeviceId: deviceId,
+                devices
+            });
+            for (const um of userMentions) {
+                const fromLabel = entity.name || `Entity ${eId}`;
+                notifyDevice(um.deviceId, {
+                    type: 'chat',
+                    category: 'user_mention',
+                    title: `@${um.displayName}`,
+                    body: `${fromLabel}: ${(finalMessage || '').slice(0, 100)}`,
+                    link: 'chat.html',
+                    metadata: {
+                        fromDeviceId: deviceId,
+                        fromEntityId: eId,
+                        matchedKey: um.matchedKey
+                    }
+                }).catch(() => {});
+            }
+        } catch (err) {
+            // Scanner is pure + defensive; any throw here is unexpected and
+            // must NOT block the transform. Log and continue.
+            console.warn('[UserMention] scan failed:', err.message);
         }
     }
 

--- a/backend/notifications.js
+++ b/backend/notifications.js
@@ -14,7 +14,13 @@ const DEFAULT_PREFS = {
     platform_command: true,
     delivery_alert: true,
     kanban_done: true,
-    kanban_done_auto: true
+    kanban_done_auto: true,
+    // user_mention: separate toggle for `@<user_display_name>` mentions
+    // (card_db71f4423cb1697f9935f460). Independent of speak_to so a user
+    // can mute generic chat traffic but keep direct @-pings, or vice
+    // versa. Default ON because being addressed by name is the highest-
+    // signal notification we send.
+    user_mention: true
 };
 
 let pool = null;

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -2542,6 +2542,14 @@
             { key: 'bot_reply', i18n: 'notif_pref_bot_reply', label: 'Bot replies' },
             { key: 'broadcast', i18n: 'notif_pref_broadcast', label: 'Broadcasts' },
             { key: 'speak_to', i18n: 'notif_pref_speak_to', label: 'Entity conversations' },
+            // user_mention: card_db71f4423cb1697f9935f460 — push when an
+            // entity message contains @<your display name>. Independent
+            // of speak_to so you can mute generic chat noise but still
+            // get pinged when someone addresses you by name. The `helpI18n`
+            // field renders a ? icon next to the toggle label so users (and
+            // visiting agents) discover the prerequisite: set a display
+            // name in the "My Display Name" card above.
+            { key: 'user_mention', i18n: 'notif_pref_user_mention', label: '@Mention pings', helpI18n: 'notif_pref_user_mention_help' },
             { key: 'feedback_resolved', i18n: 'notif_pref_feedback', label: 'Feedback updates' },
             { key: 'feedback_reply', i18n: 'notif_pref_feedback', label: 'Feedback replies', hidden: true },
             { key: 'todo_done', i18n: 'notif_pref_todo', label: 'TODO completion' },
@@ -2565,11 +2573,21 @@
                     if (cat.hidden) continue;
                     const enabled = prefs[cat.key] !== false;
                     const t = typeof i18n !== 'undefined' ? i18n.t(cat.i18n) : cat.label;
+                    // Optional inline ? icon — explains the prerequisite /
+                    // empty-state ("set a display name first") inline so
+                    // every Globe-user (and visiting agent) understands
+                    // the setup without leaving the page.
+                    let helpHtml = '';
+                    if (cat.helpI18n) {
+                        const help = typeof i18n !== 'undefined' ? i18n.t(cat.helpI18n) : '';
+                        const safeHelp = (help || '').replace(/"/g, '&quot;');
+                        helpHtml = `<span class="help-icon-inline" role="button" tabindex="0" aria-label="Help" title="${safeHelp}" onclick="alert(this.getAttribute('title'))" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();alert(this.getAttribute('title'));}" style="cursor:pointer;display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;border-radius:50%;border:1px solid var(--card-border);font-size:10px;color:var(--text-secondary);margin-left:6px;user-select:none;vertical-align:middle;">?</span>`;
+                    }
 
                     const row = document.createElement('div');
                     row.className = 'setting-row';
                     row.innerHTML = `
-                        <span class="setting-row-label">${t}</span>
+                        <span class="setting-row-label">${t}${helpHtml}</span>
                         <label class="toggle-switch">
                             <input type="checkbox" ${enabled ? 'checked' : ''} onchange="toggleNotifPref('${cat.key}', this.checked)">
                             <span class="toggle-slider"></span>

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650259,6 +650259,9 @@ const TRANSLATIONS = {
         "settings_user_display_name_too_long": "Name is too long (max 64 characters).",
         "settings_user_display_name_help_title": "About My Display Name",
         "settings_user_display_name_help_body": "This name appears in chat as the human label for messages you send. It is visible to bots you talk to but not used for routing or login. Up to 64 characters, single line, no control characters. Leave blank to fall back to the default \"Device Owner\".",
+
+        "notif_pref_user_mention": "@Mention pings",
+        "notif_pref_user_mention_help": "Push notification when someone writes @YourDisplayName in chat. Requires a display name set in 'My Display Name' above. Independent of entity-conversation push.",
 },
 
 
@@ -1234984,6 +1234987,9 @@ const TRANSLATIONS = {
         "settings_user_display_name_too_long": "名稱過長（最多 64 個字元）。",
         "settings_user_display_name_help_title": "關於顯示名稱",
         "settings_user_display_name_help_body": "此名稱會出現在對話中作為您所發訊息的人類標籤。對您交談的智能體可見，但不用於路由或登入。最多 64 個字元、單行、不可包含控制字元。留空則回退為預設的「裝置主人」。",
+
+        "notif_pref_user_mention": "@提及推送",
+        "notif_pref_user_mention_help": "聊天中有人输入 @你的显示名 时推送通知。需要先在上方「我的显示名」中设置显示名。独立于实体对话推送开关。",
 },
 
 
@@ -2412276,6 +2412282,9 @@ const TRANSLATIONS = {
         "settings_user_display_name_too_long": "名前が長すぎます（最大64文字）。",
         "settings_user_display_name_help_title": "表示名について",
         "settings_user_display_name_help_body": "この名前は、あなたが送信したメッセージの人間用ラベルとしてチャットに表示されます。会話相手のボットには見えますが、ルーティングやログインには使用されません。最大64文字、1行、制御文字は使用できません。空欄の場合はデフォルトの「Device Owner」にフォールバックします。",
+
+        "notif_pref_user_mention": "@メンション通知",
+        "notif_pref_user_mention_help": "チャットで @あなたの表示名 と書かれたときにプッシュ通知。上記「マイ表示名」での設定が必要です。エンティティ会話通知とは独立しています。",
 },
 
 
@@ -2942563,6 +2942572,9 @@ const TRANSLATIONS = {
         "settings_user_display_name_too_long": "이름이 너무 깁니다(최대 64자).",
         "settings_user_display_name_help_title": "표시 이름 정보",
         "settings_user_display_name_help_body": "이 이름은 보낸 메시지의 사람용 라벨로 채팅에 표시됩니다. 대화하는 봇에는 보이지만 라우팅이나 로그인에는 사용되지 않습니다. 최대 64자, 한 줄, 제어 문자는 불가합니다. 비워두면 기본값 \"Device Owner\"로 폴백됩니다.",
+
+        "notif_pref_user_mention": "@멘션 알림",
+        "notif_pref_user_mention_help": "채팅에서 누군가 @표시명 을 입력하면 푸시 알림. 위 '내 표시 이름'에서 표시명을 먼저 설정하세요. 엔티티 대화 알림과 독립적입니다.",
 },
 
 
@@ -2944177,6 +2944189,9 @@ const TRANSLATIONS = {
         "chat_routing_broadcast": "廣播",
         "chat_routing_xdevice": "跨裝置",
         "chat_routing_client_derived": "客戶端推導",
+
+        "notif_pref_user_mention": "@提及推送",
+        "notif_pref_user_mention_help": "聊天中有人輸入 @你的顯示名稱 時推送通知。需要先在上方「我的顯示名稱」中設定顯示名稱。獨立於實體對話推送開關。",
 },
 
 
@@ -3470946,6 +3470961,9 @@ const TRANSLATIONS = {
         "chat_outbox_cancel_confirm": "ยกเลิกข้อความที่อยู่ในคิวนี้?",
         "chat_outbox_failed_retry_q": "ลองส่งข้อความนี้อีกครั้ง?",
         "chat_outbox_failed_delete_q": "ลบข้อความที่ล้มเหลวนี้?",
+
+        "notif_pref_user_mention": "การแจ้งเตือน @เมนชั่น",
+        "notif_pref_user_mention_help": "ส่งการแจ้งเตือนเมื่อมีคนพิมพ์ @ชื่อแสดงผลของคุณ ในการแชท ต้องตั้งชื่อแสดงผลในการ์ด 'ชื่อแสดงผลของฉัน' ด้านบนก่อน เป็นอิสระจากการแจ้งเตือนการสนทนาเอนทิตี",
 },
 
 
@@ -3997793,6 +3997811,9 @@ const TRANSLATIONS = {
         "settings_user_display_name_too_long": "Tên quá dài (tối đa 64 ký tự).",
         "settings_user_display_name_help_title": "Về tên hiển thị",
         "settings_user_display_name_help_body": "Tên này hiển thị trong trò chuyện như nhãn dành cho con người cho các tin nhắn bạn gửi. Các bot bạn trò chuyện có thể thấy, nhưng không dùng để định tuyến hoặc đăng nhập. Tối đa 64 ký tự, một dòng, không có ký tự điều khiển. Để trống sẽ quay về giá trị mặc định \"Device Owner\".",
+
+        "notif_pref_user_mention": "Thông báo khi được @nhắc",
+        "notif_pref_user_mention_help": "Đẩy thông báo khi ai đó viết @TênHiểnThịCủaBạn trong chat. Cần đặt tên hiển thị ở thẻ 'Tên Hiển Thị Của Tôi' phía trên. Độc lập với thông báo trò chuyện thực thể.",
 },
 
 
@@ -4524256,6 +4524277,9 @@ const TRANSLATIONS = {
         "settings_user_display_name_too_long": "Nama terlalu panjang (maks. 64 karakter).",
         "settings_user_display_name_help_title": "Tentang Nama Tampil",
         "settings_user_display_name_help_body": "Nama ini muncul di obrolan sebagai label manusiawi untuk pesan yang Anda kirim. Bot yang Anda ajak bicara dapat melihatnya, tetapi tidak digunakan untuk perutean atau login. Maksimum 64 karakter, satu baris, tanpa karakter kontrol. Biarkan kosong untuk kembali ke nilai default \"Device Owner\".",
+
+        "notif_pref_user_mention": "Notifikasi @Sebut",
+        "notif_pref_user_mention_help": "Kirim notifikasi push saat seseorang menulis @NamaTampilanAnda di obrolan. Memerlukan nama tampilan yang diatur di 'Nama Tampilan Saya' di atas. Independen dari notifikasi percakapan entitas.",
 },
 
 
@@ -5049362,6 +5049386,9 @@ const TRANSLATIONS = {
         "chat_outbox_cancel_confirm": "Annuler ce message en attente ?",
         "chat_outbox_failed_retry_q": "Réessayer d'envoyer ce message ?",
         "chat_outbox_failed_delete_q": "Supprimer ce message échoué ?",
+
+        "notif_pref_user_mention": "Notifications de @mention",
+        "notif_pref_user_mention_help": "Notification push lorsque quelqu'un écrit @VotreNomAffiché dans le chat. Nécessite un nom d'affichage défini dans « Mon nom d'affichage » ci-dessus. Indépendant des notifications de conversation d'entité.",
 },
 
 
@@ -5567019,6 +5567046,9 @@ const TRANSLATIONS = {
         "settings_user_display_name_too_long": "El nombre es demasiado largo (máx. 64 caracteres).",
         "settings_user_display_name_help_title": "Acerca del nombre visible",
         "settings_user_display_name_help_body": "Este nombre aparece en el chat como etiqueta humana de los mensajes que envías. Es visible para los bots con los que hablas, pero no se utiliza para el enrutamiento ni el inicio de sesión. Hasta 64 caracteres, una sola línea, sin caracteres de control. Déjalo en blanco para volver al valor predeterminado \"Device Owner\".",
+
+        "notif_pref_user_mention": "Notificaciones de @mención",
+        "notif_pref_user_mention_help": "Notificación push cuando alguien escribe @TuNombreVisible en el chat. Requiere un nombre visible configurado en «Mi nombre visible» arriba. Independiente de las notificaciones de conversación de entidad.",
 },
 
 
@@ -6103919,6 +6103949,9 @@ const TRANSLATIONS = {
         "chat_outbox_cancel_confirm": "Diese Nachricht in der Warteschlange abbrechen?",
         "chat_outbox_failed_retry_q": "Diese Nachricht erneut senden?",
         "chat_outbox_failed_delete_q": "Diese fehlgeschlagene Nachricht löschen?",
+
+        "notif_pref_user_mention": "@Erwähnungs-Benachrichtigungen",
+        "notif_pref_user_mention_help": "Push-Benachrichtigung, wenn jemand @IhrAnzeigename im Chat schreibt. Erfordert einen oben unter „Mein Anzeigename\" festgelegten Namen. Unabhängig von Entitäts-Konversationsbenachrichtigungen.",
 },
     pt: {
         "transition_loading": "A carregar…",
@@ -6109331,6 +6109364,9 @@ const TRANSLATIONS = {
         "chat_outbox_cancel_confirm": "Cancelar esta mensagem na fila?",
         "chat_outbox_failed_retry_q": "Tentar enviar esta mensagem novamente?",
         "chat_outbox_failed_delete_q": "Excluir esta mensagem com falha?",
+
+        "notif_pref_user_mention": "Notificações de @menção",
+        "notif_pref_user_mention_help": "Notificação push quando alguém escreve @SeuNomeExibido no chat. Requer um nome de exibição definido em \"Meu Nome de Exibição\" acima. Independente das notificações de conversa de entidade.",
 },
 
 
@@ -6638100,6 +6638136,9 @@ const TRANSLATIONS = {
         "chat_outbox_cancel_confirm": "Batalkan mesej dalam baris gilir ini?",
         "chat_outbox_failed_retry_q": "Cuba hantar semula mesej ini?",
         "chat_outbox_failed_delete_q": "Padam mesej yang gagal ini?",
+
+        "notif_pref_user_mention": "Notifikasi @Sebutan",
+        "notif_pref_user_mention_help": "Hantar notifikasi push apabila seseorang menulis @NamaPaparanAnda dalam sembang. Memerlukan nama paparan ditetapkan di 'Nama Paparan Saya' di atas. Bebas daripada notifikasi perbualan entiti.",
 },
 
 
@@ -7197326,6 +7197365,9 @@ const TRANSLATIONS = {
         "chat_outbox_cancel_confirm": "इस कतारबद्ध संदेश को रद्द करें?",
         "chat_outbox_failed_retry_q": "इस संदेश को पुनः भेजें?",
         "chat_outbox_failed_delete_q": "इस असफल संदेश को हटाएं?",
+
+        "notif_pref_user_mention": "@मेंशन सूचनाएं",
+        "notif_pref_user_mention_help": "जब कोई चैट में @आपकाडिस्प्लेनाम लिखे तो पुश सूचना भेजें। ऊपर 'मेरा डिस्प्ले नाम' में डिस्प्ले नाम सेट करना आवश्यक। एंटिटी वार्तालाप सूचनाओं से स्वतंत्र।",
 },
 
 
@@ -7745678,6 +7745720,9 @@ const TRANSLATIONS = {
         "chat_outbox_cancel_confirm": "إلغاء هذه الرسالة في الانتظار؟",
         "chat_outbox_failed_retry_q": "إعادة محاولة إرسال هذه الرسالة؟",
         "chat_outbox_failed_delete_q": "حذف هذه الرسالة الفاشلة؟",
+
+        "notif_pref_user_mention": "إشعارات الإشارة @",
+        "notif_pref_user_mention_help": "إشعار فوري عندما يكتب شخص ما @اسمك_المعروض في الدردشة. يتطلب تعيين اسم العرض في 'اسم العرض الخاص بي' أعلاه. مستقل عن إشعارات محادثات الكيان.",
 }
 
 

--- a/backend/tests/jest/mention-push-card_db7.test.js
+++ b/backend/tests/jest/mention-push-card_db7.test.js
@@ -1,0 +1,281 @@
+/**
+ * Unit tests — user-mention scanner (card_db71f4423cb1697f9935f460).
+ *
+ * Pure-function tests: feeds the scanner a synthetic devices map and
+ * asserts the resolved mentions. No HTTP, no DB. Also asserts the
+ * notification-prefs default block exposes the new `user_mention`
+ * toggle and that it is gated correctly by isCategoryEnabled.
+ */
+'use strict';
+
+const ums = require('../../user-mention-scanner');
+const notif = require('../../notifications');
+
+function makeDevices() {
+    // Three devices with display names + one with none.
+    return {
+        'dev-hank': { userDisplayName: 'Hank' },
+        'dev-hank-dev': { userDisplayName: 'HankDev' },
+        'dev-alice': { userDisplayName: 'Alice Wong' },     // contains a space
+        'dev-yuki':  { userDisplayName: 'ユキ' },             // CJK
+        'dev-noname':{ userDisplayName: null }                // not indexed
+    };
+}
+
+describe('normalizeNameKey', () => {
+    test('lowercases + trims + collapses whitespace', () => {
+        expect(ums.normalizeNameKey('  Hank  Dev  ')).toBe('hank dev');
+    });
+    test('returns null for null/undefined/non-string/empty', () => {
+        expect(ums.normalizeNameKey(null)).toBeNull();
+        expect(ums.normalizeNameKey(undefined)).toBeNull();
+        expect(ums.normalizeNameKey('')).toBeNull();
+        expect(ums.normalizeNameKey('   ')).toBeNull();
+        expect(ums.normalizeNameKey(42)).toBeNull();
+    });
+    test('NFKC folds half-width and full-width forms', () => {
+        // 'Ｈａｎｋ' = full-width latin → after NFKC + lowercase → 'hank'
+        expect(ums.normalizeNameKey('Ｈａｎｋ')).toBe('hank');
+    });
+});
+
+describe('isClaimedByEntityParser', () => {
+    test('@all (any case) is claimed', () => {
+        expect(ums.isClaimedByEntityParser('all')).toBe(true);
+        expect(ums.isClaimedByEntityParser('All')).toBe(true);
+        expect(ums.isClaimedByEntityParser('ALL')).toBe(true);
+    });
+    test('1-3 ASCII digits is claimed (entityId form)', () => {
+        expect(ums.isClaimedByEntityParser('1')).toBe(true);
+        expect(ums.isClaimedByEntityParser('42')).toBe(true);
+        expect(ums.isClaimedByEntityParser('999')).toBe(true);
+    });
+    test('4+ digits NOT claimed', () => {
+        expect(ums.isClaimedByEntityParser('1234')).toBe(false);
+    });
+    test('6-char lowercase alnum is claimed (publicCode form)', () => {
+        expect(ums.isClaimedByEntityParser('abc123')).toBe(true);
+        expect(ums.isClaimedByEntityParser('aaaaaa')).toBe(true);
+    });
+    test('6-char with mixed case is also claimed (lowercased internally)', () => {
+        expect(ums.isClaimedByEntityParser('AbC123')).toBe(true);
+    });
+    test('5 or 7 chars NOT claimed', () => {
+        expect(ums.isClaimedByEntityParser('abcde')).toBe(false);
+        expect(ums.isClaimedByEntityParser('abcdefg')).toBe(false);
+    });
+    test('CJK + general words NOT claimed', () => {
+        expect(ums.isClaimedByEntityParser('hank')).toBe(false);
+        expect(ums.isClaimedByEntityParser('ユキ')).toBe(false);
+    });
+});
+
+describe('buildIndex', () => {
+    test('indexes only devices with a normalized display name', () => {
+        const { index, keysByLength } = ums.buildIndex(makeDevices());
+        expect(index.has('hank')).toBe(true);
+        expect(index.has('hankdev')).toBe(true);
+        expect(index.has('alice wong')).toBe(true);
+        expect(index.has('ユキ')).toBe(true);
+        // dev-noname has null → skipped
+        expect(index.size).toBe(4);
+        // longest first
+        expect(keysByLength[0].length).toBeGreaterThanOrEqual(keysByLength.at(-1).length);
+    });
+    test('returns empty index for empty/null devices', () => {
+        expect(ums.buildIndex(null).index.size).toBe(0);
+        expect(ums.buildIndex({}).index.size).toBe(0);
+        expect(ums.buildIndex(undefined).index.size).toBe(0);
+    });
+});
+
+describe('findUserMentions — basic matching', () => {
+    test('matches a single bare @<display name>', () => {
+        const r = ums.findUserMentions('hey @Hank can you take a look', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toHaveLength(1);
+        expect(r[0].deviceId).toBe('dev-hank');
+        expect(r[0].displayName).toBe('Hank');
+        expect(r[0].matchedKey).toBe('hank');
+    });
+
+    test('longest-prefix wins (HankDev beats Hank)', () => {
+        const r = ums.findUserMentions('ping @HankDev now', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toHaveLength(1);
+        expect(r[0].deviceId).toBe('dev-hank-dev');
+    });
+
+    test('case-insensitive', () => {
+        const r = ums.findUserMentions('ok @HANK', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toHaveLength(1);
+        expect(r[0].deviceId).toBe('dev-hank');
+    });
+
+    test('CJK display name', () => {
+        const r = ums.findUserMentions('お願い @ユキ さん', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toHaveLength(1);
+        expect(r[0].deviceId).toBe('dev-yuki');
+    });
+
+    test('quoted form matches display name with a space', () => {
+        const r = ums.findUserMentions('cc @"Alice Wong" please', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toHaveLength(1);
+        expect(r[0].deviceId).toBe('dev-alice');
+        expect(r[0].isQuoted).toBe(true);
+    });
+
+    test('multiple mentions of different users → multiple results, first-occurrence order', () => {
+        const r = ums.findUserMentions('hey @Hank and @ユキ', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r.map(x => x.deviceId)).toEqual(['dev-hank', 'dev-yuki']);
+    });
+
+    test('per-message dedupe — same user mentioned twice → one result', () => {
+        const r = ums.findUserMentions('@Hank @Hank @Hank', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toHaveLength(1);
+    });
+});
+
+describe('findUserMentions — non-matches / boundary safety', () => {
+    test('email address does NOT match', () => {
+        // 'hank' is the display name — but the @ is preceded by a word char.
+        const r = ums.findUserMentions('contact me at hank@example.com', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toEqual([]);
+    });
+
+    test('inside an existing entity-mention token does NOT match', () => {
+        // <@hank01> — even if "hank" is a prefix, the leading `<` blocks the boundary.
+        const r = ums.findUserMentions('hello <@hank01> world', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toEqual([]);
+    });
+
+    test('bare 6-char alnum token is deferred to entity parser (publicCode)', () => {
+        // 'hank01' is 6 chars alnum → entity parser owns it; even though
+        // 'hank' would prefix-match, we skip the whole token.
+        const r = ums.findUserMentions('ping @hank01 now', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toEqual([]);
+    });
+
+    test('bare @<1-3 digits> is deferred to entity parser', () => {
+        const r = ums.findUserMentions('hey @42', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toEqual([]);
+    });
+
+    test('@all is deferred to entity parser', () => {
+        const r = ums.findUserMentions('@all hey', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toEqual([]);
+    });
+
+    test('@#<digits> is deferred to entity parser', () => {
+        // @#1 has a `#` after the `@`, which is not a word char so our
+        // readWordToken returns empty token and we skip cleanly.
+        const r = ums.findUserMentions('hey @#1 please', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toEqual([]);
+    });
+
+    test('unmatched display name does NOT produce a result', () => {
+        const r = ums.findUserMentions('hey @Bob', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toEqual([]);
+    });
+
+    test('null display names are not indexed (no false match)', () => {
+        // dev-noname has null userDisplayName — should not match anything.
+        const r = ums.findUserMentions('hi @noname', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toEqual([]);
+    });
+
+    test('partial-word match suppressed (Hank in Hankering)', () => {
+        // 'Hankering' has 'hank' as prefix but the next char 'e' is a word
+        // char → boundary check rejects the prefix-match.
+        const r = ums.findUserMentions('this is @Hankering not Hank', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toEqual([]);
+    });
+
+    test('self-mention suppressed', () => {
+        // Sender is dev-hank → his own @Hank does not push to himself.
+        const r = ums.findUserMentions('hey @Hank yo', { senderDeviceId: 'dev-hank', devices: makeDevices() });
+        expect(r).toEqual([]);
+    });
+
+    test('empty text / null / non-string returns empty', () => {
+        expect(ums.findUserMentions('', { senderDeviceId: 'other', devices: makeDevices() })).toEqual([]);
+        expect(ums.findUserMentions(null, { senderDeviceId: 'other', devices: makeDevices() })).toEqual([]);
+        expect(ums.findUserMentions(undefined, { senderDeviceId: 'other', devices: makeDevices() })).toEqual([]);
+        expect(ums.findUserMentions(42, { senderDeviceId: 'other', devices: makeDevices() })).toEqual([]);
+    });
+
+    test('missing ctx returns empty', () => {
+        expect(ums.findUserMentions('hi @Hank', null)).toEqual([]);
+    });
+
+    test('devices map with no display names returns empty', () => {
+        const r = ums.findUserMentions('hey @Hank', { senderDeviceId: 'other', devices: { 'a': {}, 'b': { userDisplayName: '' } } });
+        expect(r).toEqual([]);
+    });
+});
+
+describe('findUserMentions — ReDoS / pathological inputs', () => {
+    test('100k @s caps work at MAX_TOKENS_PER_MESSAGE', () => {
+        const text = '@'.repeat(100000);
+        const t0 = Date.now();
+        const r = ums.findUserMentions(text, { senderDeviceId: 'other', devices: makeDevices() });
+        const elapsed = Date.now() - t0;
+        // No match (bare @ followed by @ → no word token).
+        expect(r).toEqual([]);
+        // Must complete fast even with 100k @s.
+        expect(elapsed).toBeLessThan(500);
+    });
+
+    test('very long word after @ is bounded by MAX_TOKEN_SCAN_LEN', () => {
+        const longWord = 'a'.repeat(50000);
+        const text = `prefix @${longWord} suffix`;
+        const t0 = Date.now();
+        const r = ums.findUserMentions(text, { senderDeviceId: 'other', devices: makeDevices() });
+        const elapsed = Date.now() - t0;
+        expect(r).toEqual([]); // no match in index, but must NOT hang
+        expect(elapsed).toBeLessThan(500);
+    });
+
+    test('many @-tokens that prefix-match Hank — caps at unique-deviceId dedupe', () => {
+        const parts = [];
+        for (let i = 0; i < 500; i++) parts.push('@Hank');
+        const r = ums.findUserMentions(parts.join(' '), { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toHaveLength(1);
+    });
+});
+
+describe('findUserMentions — quoted form edge cases', () => {
+    test('unclosed quote falls through to bare-word parsing', () => {
+        // '@"Alice Wong' has no closing quote — readQuotedToken returns null,
+        // bare reader collects nothing (since `"` is not a word char) →
+        // no match.
+        const r = ums.findUserMentions('@"Alice Wong', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toEqual([]);
+    });
+
+    test('quoted form is exact-match (not prefix)', () => {
+        // @"Hank " (trailing space) won't normalize to "hank " — it'll be
+        // "hank" → matches dev-hank. NFKC + trim semantics.
+        const r = ums.findUserMentions('cc @"Hank " ok', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toHaveLength(1);
+        expect(r[0].deviceId).toBe('dev-hank');
+    });
+
+    test('quoted form does not match an unknown name', () => {
+        const r = ums.findUserMentions('@"Nobody Here"', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toEqual([]);
+    });
+});
+
+describe('notifications module — user_mention toggle', () => {
+    test('user_mention key exists in DEFAULT_PREFS and defaults true', () => {
+        expect(notif.DEFAULT_PREFS).toHaveProperty('user_mention', true);
+    });
+
+    test('isCategoryEnabled honors explicit false for user_mention', () => {
+        expect(notif.isCategoryEnabled({ user_mention: false }, 'user_mention')).toBe(false);
+        expect(notif.isCategoryEnabled({ user_mention: true }, 'user_mention')).toBe(true);
+    });
+
+    test('isCategoryEnabled defaults to true when key missing (covered by getPrefs merging DEFAULT_PREFS, but verified here for the gate)', () => {
+        expect(notif.isCategoryEnabled({}, 'user_mention')).toBe(true);
+    });
+});

--- a/backend/tests/jest/mention-push-card_db7.test.js
+++ b/backend/tests/jest/mention-push-card_db7.test.js
@@ -147,10 +147,36 @@ describe('findUserMentions — non-matches / boundary safety', () => {
         expect(r).toEqual([]);
     });
 
-    test('bare 6-char alnum token is deferred to entity parser (publicCode)', () => {
-        // 'hank01' is 6 chars alnum → entity parser owns it; even though
-        // 'hank' would prefix-match, we skip the whole token.
+    test('bare 6-char alnum token is deferred to entity parser (publicCode) when no publicCodeIndex passed', () => {
+        // Conservative default: with no publicCodeIndex, ALL 6-char alnum
+        // tokens are deferred. 'hank01' has 'hank' as prefix but is
+        // skipped entirely.
         const r = ums.findUserMentions('ping @hank01 now', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toEqual([]);
+    });
+
+    test('6-char alnum token NOT in publicCodeIndex falls through to display-name lookup (review finding #6)', () => {
+        // 'alice1' is a 6-char alnum DISPLAY name (legit user). Without
+        // the fix, scanner would defer to entity parser → silently drop.
+        // With publicCodeIndex passed, scanner sees 'alice1' is not a
+        // known publicCode and falls through to display-name lookup.
+        const devices = {
+            'dev-alice1': { userDisplayName: 'alice1' }
+        };
+        const publicCodeIndex = { bbbbbb: { deviceId: 'other', entityId: 0 } };
+        const r = ums.findUserMentions('hey @alice1 ping', { senderDeviceId: 'other', devices, publicCodeIndex });
+        expect(r).toHaveLength(1);
+        expect(r[0].deviceId).toBe('dev-alice1');
+    });
+
+    test('6-char alnum token IS in publicCodeIndex is still deferred (no collision with entity parser)', () => {
+        // 'bbbbbb' resolves as a publicCode → scanner must skip it even
+        // if a display name 'bbbbbb' also happens to exist.
+        const devices = {
+            'dev-collide': { userDisplayName: 'bbbbbb' }
+        };
+        const publicCodeIndex = { bbbbbb: { deviceId: 'other-dev', entityId: 0 } };
+        const r = ums.findUserMentions('hey @bbbbbb hi', { senderDeviceId: 'other', devices, publicCodeIndex });
         expect(r).toEqual([]);
     });
 
@@ -240,6 +266,34 @@ describe('findUserMentions — ReDoS / pathological inputs', () => {
         const r = ums.findUserMentions(parts.join(' '), { senderDeviceId: 'other', devices: makeDevices() });
         expect(r).toHaveLength(1);
     });
+
+    test('per-message recipient cap enforced (review finding #1)', () => {
+        // Build N devices with distinct display names; mention all N.
+        // Scanner should return MAX_RECIPIENTS_PER_MESSAGE at most.
+        const devices = {};
+        const tokens = [];
+        for (let i = 0; i < 50; i++) {
+            const name = `user${i}_x`; // 7+ chars → not entity-parser shape
+            devices[`dev${i}`] = { userDisplayName: name };
+            tokens.push(`@${name}`);
+        }
+        const r = ums.findUserMentions(tokens.join(' '), { senderDeviceId: 'sender', devices });
+        expect(r.length).toBeLessThanOrEqual(ums.MAX_RECIPIENTS_PER_MESSAGE);
+        expect(r.length).toBe(ums.MAX_RECIPIENTS_PER_MESSAGE);
+    });
+
+    test('10MB message with unclosed quote returns fast (review prompt Q7)', () => {
+        // `@"` followed by 10MB of non-quote chars and no closing quote.
+        // readQuotedToken stops at MAX_TOKEN_SCAN_LEN + finds no closing
+        // quote → returns null → bare reader sees `"` (not a word char) →
+        // emits nothing. Must complete in <500ms.
+        const text = '@"' + 'a'.repeat(10_000_000);
+        const t0 = Date.now();
+        const r = ums.findUserMentions(text, { senderDeviceId: 'other', devices: makeDevices() });
+        const elapsed = Date.now() - t0;
+        expect(r).toEqual([]);
+        expect(elapsed).toBeLessThan(500);
+    });
 });
 
 describe('findUserMentions — quoted form edge cases', () => {
@@ -261,6 +315,39 @@ describe('findUserMentions — quoted form edge cases', () => {
 
     test('quoted form does not match an unknown name', () => {
         const r = ums.findUserMentions('@"Nobody Here"', { senderDeviceId: 'other', devices: makeDevices() });
+        expect(r).toEqual([]);
+    });
+});
+
+describe('findUserMentions — index + collision cases', () => {
+    test('empty index returns immediately (no devices have display names)', () => {
+        // Without an early-return, this would walk the text. Easy check:
+        // ensure no result + minimal work.
+        const devices = { a: {}, b: { userDisplayName: '' }, c: { userDisplayName: null } };
+        const t0 = Date.now();
+        const r = ums.findUserMentions('a long message with many @Hank and @ユキ and @"Alice Wong" mentions all of which find no match', { senderDeviceId: 'other', devices });
+        const elapsed = Date.now() - t0;
+        expect(r).toEqual([]);
+        expect(elapsed).toBeLessThan(50);
+    });
+
+    test('NFKC + lowercase collision puts both deviceIds in the Set (and pushes both)', () => {
+        // 'hank' and 'Ｈａｎｋ' (full-width) both normalize to 'hank'.
+        const devices = {
+            'dev-1': { userDisplayName: 'Hank' },
+            'dev-2': { userDisplayName: 'Ｈａｎｋ' }
+        };
+        const r = ums.findUserMentions('hi @Hank', { senderDeviceId: 'other', devices });
+        const deviceIds = r.map(x => x.deviceId).sort();
+        expect(deviceIds).toEqual(['dev-1', 'dev-2']);
+    });
+
+    test('display name "all" cannot be matched (deferred to entity parser @all)', () => {
+        // Sad case but acceptable: a user choosing "all" as their display
+        // name will never receive @-mention pushes. Documented as known
+        // limitation in scanner header.
+        const devices = { 'dev-all': { userDisplayName: 'all' } };
+        const r = ums.findUserMentions('hey @all please', { senderDeviceId: 'other', devices });
         expect(r).toEqual([]);
     });
 });

--- a/backend/user-mention-scanner.js
+++ b/backend/user-mention-scanner.js
@@ -50,6 +50,13 @@
 // payload of `@@@@…` from O(n) walking the whole index per `@`.
 const MAX_TOKENS_PER_MESSAGE = 256;
 
+// Hard cap on the number of distinct recipients a single message can
+// trigger. Even if a malicious sender mentions 100 different users, we
+// fire at most this many `notifyDevice` calls. Picked at 8 because real
+// chat messages rarely address more than a handful of people (review
+// finding #1 — bot-spam fan-out protection).
+const MAX_RECIPIENTS_PER_MESSAGE = 8;
+
 // Maximum length of the token we even bother to compare to the index.
 // devices.user_display_name is capped at 64 codepoints upstream, so any
 // `@` token longer than 128 chars (allow some slack for combining marks)
@@ -91,18 +98,35 @@ function normalizeNameKey(name) {
  * Would this @-token already be claimed by mention-parser.js? If yes, skip
  * it here so the two systems never collide.
  *
- * @publicCode form: 6 lowercase alnum chars (then word-bounded).
+ * @publicCode form: 6 lowercase alnum chars (then word-bounded). The
+ *                   parser only claims these if the code actually exists
+ *                   in publicCodeIndex — so we mirror that gate. Without
+ *                   it, a legit display name like 'alice1' (6 alnum, no
+ *                   matching publicCode) would be silently dropped and
+ *                   alice1 would never get pushed (review finding #6).
  * @entityId form:   1-3 digits (`@123`, `@#123`).
  * @all literal:     case-insensitive 'all'.
+ *
+ * @param {string} token
+ * @param {object} [opts]
+ * @param {object} [opts.publicCodeIndex] — pass the live index so we only
+ *   defer 6-char alnum tokens that are actually entity publicCodes. Omit
+ *   to defer ALL 6-char alnum tokens (more conservative; used by tests
+ *   that don't care about resolver wiring).
  */
-function isClaimedByEntityParser(token) {
+function isClaimedByEntityParser(token, opts) {
     if (!token) return false;
     const lower = token.toLowerCase();
     if (lower === 'all') return true;
     // Bare entityId: 1-3 ASCII digits.
     if (ASCII_DIGIT_RE.test(token) && token.length <= 3) return true;
     // publicCode: exactly 6 lowercase alnum chars (the parser bare form).
-    if (token.length === 6 && ALPHANUM_LOWER_RE.test(lower)) return true;
+    // Only defer when the token actually resolves — otherwise legit display
+    // names that happen to match the shape get silently dropped.
+    if (token.length === 6 && ALPHANUM_LOWER_RE.test(lower)) {
+        if (!opts || !opts.publicCodeIndex) return true; // conservative default
+        return Object.prototype.hasOwnProperty.call(opts.publicCodeIndex, lower);
+    }
     return false;
 }
 
@@ -203,6 +227,11 @@ function findUserMentions(text, ctx) {
 
     const devices = ctx.devices || {};
     const senderDeviceId = ctx.senderDeviceId || null;
+    // publicCodeIndex (optional): when present, lets isClaimedByEntityParser
+    // only defer 6-char alnum tokens that ACTUALLY resolve as a publicCode.
+    // Without it, every display name shaped like `[a-z0-9]{6}` is silently
+    // dropped (review finding #6).
+    const publicCodeIndex = ctx.publicCodeIndex || null;
     let index, keysByLength;
     if (ctx.userDisplayNameIndex && ctx.userDisplayNameIndex.index) {
         // Caller passed a prebuilt index.
@@ -246,8 +275,10 @@ function findUserMentions(text, ctx) {
 
         // Defer entity-parser-claimed tokens. Quoted form is never an
         // entity-parser token (those don't accept quotes), so only check
-        // for the bare form.
-        if (!isQuoted && isClaimedByEntityParser(token)) continue;
+        // for the bare form. Pass publicCodeIndex so 6-char alnum tokens
+        // that DON'T resolve as a publicCode fall through to display-name
+        // lookup (review finding #6).
+        if (!isQuoted && isClaimedByEntityParser(token, { publicCodeIndex })) continue;
 
         const normalized = normalizeNameKey(token);
         if (!normalized) continue;
@@ -295,6 +326,10 @@ function findUserMentions(text, ctx) {
                 matchedAt: at,
                 isQuoted
             });
+            // Hard cap on distinct recipients per message — prevents a
+            // single bot post from pinging N users at once (review
+            // finding #1, anti-spam fan-out limit).
+            if (out.length >= MAX_RECIPIENTS_PER_MESSAGE) return out;
         }
     }
 
@@ -308,5 +343,6 @@ module.exports = {
     findUserMentions,
     // Exposed for tests:
     MAX_TOKENS_PER_MESSAGE,
-    MAX_TOKEN_SCAN_LEN
+    MAX_TOKEN_SCAN_LEN,
+    MAX_RECIPIENTS_PER_MESSAGE
 };

--- a/backend/user-mention-scanner.js
+++ b/backend/user-mention-scanner.js
@@ -1,0 +1,312 @@
+/**
+ * User-Mention Scanner — card_db71f4423cb1697f9935f460
+ *
+ * Detects `@<user_display_name>` tokens inside chat messages and resolves
+ * them to the device whose owner has that display name. Triggers an extra
+ * push notification ("you were mentioned") on top of the existing
+ * cross-device push.
+ *
+ * Coexistence with backend/mention-parser.js — this scanner deliberately
+ * defers to the entity-mention parser on any token that the parser would
+ * already claim:
+ *   - `@all`                              (broadcast keyword)
+ *   - `@<6-char-alnum>` / `<@xxxxxx>`     (entity publicCode)
+ *   - `@<digits>` / `@#<digits>` / `<@N>` (entity entityId)
+ * For these the scanner skips the token entirely so we never collide with
+ * the existing routing logic. Any other `@<word>` that isn't already
+ * claimed is fair game for display-name resolution.
+ *
+ * Resolution rules:
+ *   - Case-insensitive (display names are user-set free text — strict case
+ *     would lose the feature for most users).
+ *   - Word-boundary on both sides (Unicode-aware) so `email@example.com`,
+ *     `@2pm`, version strings, etc. do NOT match.
+ *   - Longest-prefix match against the index keys, so a display name
+ *     "HankDev" wins over "Hank" when both exist and the text says
+ *     `@HankDev`.
+ *   - Display names containing spaces match the form `@"Display Name"`
+ *     (quoted) only. Bare `@Display Name` would be ambiguous (where does
+ *     the name end?) so we require the quote.
+ *   - ReDoS-safe: no backtracking regexes. The whole scan is an indexOf
+ *     walk + Map lookups. Hard cap of MAX_TOKENS_PER_MESSAGE prevents
+ *     pathological inputs (e.g. 100k `@@@@` chars) from consuming CPU.
+ *   - Per-message dedupe: at most one match per recipient deviceId — even
+ *     if the same display name appears 100 times, the recipient gets one
+ *     push event.
+ *
+ * Globe-user generalization: works for every device worldwide. No
+ * allowlist, no per-tenant code paths, no language-specific assumptions
+ * (the boundary check uses \p{L}\p{N}_ Unicode property escapes so CJK,
+ * Cyrillic, Arabic, emoji-bearing names all parse the same way).
+ *
+ * Pure module — no DB access, no I/O. Caller injects the
+ * userDisplayNameIndex (built once at startup, kept fresh on PUT
+ * /api/device/user-profile). Easy to unit-test.
+ */
+'use strict';
+
+// Hard cap on the number of `@` positions we'll examine per message.
+// 256 is comfortably more than any real chat message and prevents a 1 MB
+// payload of `@@@@…` from O(n) walking the whole index per `@`.
+const MAX_TOKENS_PER_MESSAGE = 256;
+
+// Maximum length of the token we even bother to compare to the index.
+// devices.user_display_name is capped at 64 codepoints upstream, so any
+// `@` token longer than 128 chars (allow some slack for combining marks)
+// cannot match anything. Stops `@`+10MB-of-text from costing real time.
+const MAX_TOKEN_SCAN_LEN = 128;
+
+const UNICODE_WORD_RE = /[\p{L}\p{N}_]/u;
+const ASCII_DIGIT_RE = /^\d+$/;
+const ALPHANUM_LOWER_RE = /^[a-z0-9]+$/;
+
+/**
+ * Normalize a display name to its index key form. Done at both index-build
+ * time and lookup time so we always compare apples to apples.
+ *
+ * Steps:
+ *   1. Unicode NFKC normalize (so half/full-width, ligatures, etc. fold).
+ *   2. Lowercase (case-insensitive matching).
+ *   3. Trim + collapse internal whitespace to single space.
+ *
+ * Returns null for null/non-string/empty input — those never index/match.
+ */
+function normalizeNameKey(name) {
+    if (name === null || name === undefined) return null;
+    if (typeof name !== 'string') return null;
+    // NFKC is the right form for visual identity matching (collapses ligatures,
+    // half-width / full-width variants, compatibility composites).
+    let s;
+    try {
+        s = name.normalize('NFKC');
+    } catch (e) {
+        // Older runtimes without NFKC — fall back to NFC.
+        try { s = name.normalize('NFC'); } catch (e2) { s = name; }
+    }
+    s = s.toLowerCase().trim().replace(/\s+/g, ' ');
+    return s.length > 0 ? s : null;
+}
+
+/**
+ * Would this @-token already be claimed by mention-parser.js? If yes, skip
+ * it here so the two systems never collide.
+ *
+ * @publicCode form: 6 lowercase alnum chars (then word-bounded).
+ * @entityId form:   1-3 digits (`@123`, `@#123`).
+ * @all literal:     case-insensitive 'all'.
+ */
+function isClaimedByEntityParser(token) {
+    if (!token) return false;
+    const lower = token.toLowerCase();
+    if (lower === 'all') return true;
+    // Bare entityId: 1-3 ASCII digits.
+    if (ASCII_DIGIT_RE.test(token) && token.length <= 3) return true;
+    // publicCode: exactly 6 lowercase alnum chars (the parser bare form).
+    if (token.length === 6 && ALPHANUM_LOWER_RE.test(lower)) return true;
+    return false;
+}
+
+/**
+ * Build a userDisplayName -> Set<deviceId> index from the in-memory
+ * devices map. Devices without a userDisplayName are skipped. Empty/null
+ * normalize results are skipped.
+ *
+ * Returns { index, keysByLength } where keysByLength is the index keys
+ * sorted by length descending — used by longest-prefix matching so the
+ * scanner picks "HankDev" over "Hank" when both exist.
+ */
+function buildIndex(devices) {
+    const index = new Map(); // normalizedKey -> Set<deviceId>
+    if (!devices || typeof devices !== 'object') {
+        return { index, keysByLength: [] };
+    }
+    for (const deviceId of Object.keys(devices)) {
+        const dev = devices[deviceId];
+        if (!dev) continue;
+        const name = dev.userDisplayName;
+        const key = normalizeNameKey(name);
+        if (!key) continue;
+        if (!index.has(key)) index.set(key, new Set());
+        index.get(key).add(deviceId);
+    }
+    const keysByLength = Array.from(index.keys()).sort((a, b) => b.length - a.length);
+    return { index, keysByLength };
+}
+
+/**
+ * Has the position before atIndex a word boundary? Mirrors mention-parser.js
+ * isMentionBoundaryBefore so the two scanners agree on what "@" looks like
+ * in context.
+ */
+function boundaryBefore(text, atIndex) {
+    if (atIndex <= 0) return true;
+    const ch = text[atIndex - 1];
+    // Don't match if preceded by word char, '@', or '<' (latter would put us
+    // inside `<@xxxxxx>` which the entity parser owns).
+    return !(/[\p{L}\p{N}_@<]/u.test(ch));
+}
+
+function boundaryAfter(text, endIndex) {
+    if (endIndex >= text.length) return true;
+    return !UNICODE_WORD_RE.test(text[endIndex]);
+}
+
+/**
+ * Walk forward from `start` collecting word-character codepoints. Returns
+ * { token, end } where token is the lowercased word (empty if no word
+ * char), and end is the index just past the last word char. Stops at the
+ * configured max length so a pathological all-letters payload can't blow
+ * up CPU.
+ */
+function readWordToken(text, start) {
+    let i = start;
+    const max = Math.min(text.length, start + MAX_TOKEN_SCAN_LEN);
+    while (i < max && UNICODE_WORD_RE.test(text[i])) i++;
+    if (i === start) return { token: '', end: i };
+    return { token: text.slice(start, i).toLowerCase(), end: i };
+}
+
+/**
+ * For a `@"quoted display name"` form, read until the closing quote (or
+ * end of line / max length). Returns { token, end } or null if the form
+ * doesn't apply at start.
+ */
+function readQuotedToken(text, start) {
+    const ch = text[start];
+    if (ch !== '"') return null;
+    const max = Math.min(text.length, start + 1 + MAX_TOKEN_SCAN_LEN);
+    let i = start + 1;
+    while (i < max && text[i] !== '"' && text[i] !== '\n') i++;
+    if (i >= text.length || text[i] !== '"') return null; // no closing quote
+    const inner = text.slice(start + 1, i);
+    if (!inner) return null;
+    return { token: inner, end: i + 1, isQuoted: true };
+}
+
+/**
+ * Scan `text` for user-display-name mentions. Returns an array of unique
+ * matches in first-occurrence order:
+ *
+ *   [{ deviceId, displayName, matchedKey, matchedAt, isQuoted }]
+ *
+ * `displayName` is the canonical-cased value from devices[deviceId].
+ * `matchedKey` is the normalized key used for lookup (lowercase, NFKC).
+ * `matchedAt` is the byte index of the leading `@` in the original text.
+ *
+ * The scanner dedupes per deviceId — even if the same user is `@`-ed
+ * many times in one message, the result contains one entry per device.
+ */
+function findUserMentions(text, ctx) {
+    const out = [];
+    if (!text || typeof text !== 'string') return out;
+    if (!ctx) return out;
+
+    const devices = ctx.devices || {};
+    const senderDeviceId = ctx.senderDeviceId || null;
+    let index, keysByLength;
+    if (ctx.userDisplayNameIndex && ctx.userDisplayNameIndex.index) {
+        // Caller passed a prebuilt index.
+        index = ctx.userDisplayNameIndex.index;
+        keysByLength = ctx.userDisplayNameIndex.keysByLength
+            || Array.from(index.keys()).sort((a, b) => b.length - a.length);
+    } else {
+        const built = buildIndex(devices);
+        index = built.index;
+        keysByLength = built.keysByLength;
+    }
+
+    if (index.size === 0) return out; // nobody has a display name set yet
+
+    const seenDeviceIds = new Set();
+    let scanned = 0;
+
+    for (let at = text.indexOf('@'); at !== -1; at = text.indexOf('@', at + 1)) {
+        if (++scanned > MAX_TOKENS_PER_MESSAGE) break;
+        if (!boundaryBefore(text, at)) continue;
+
+        // Try quoted form first: `@"Display Name with spaces"`.
+        const quoted = readQuotedToken(text, at + 1);
+        let token = null;
+        let endIndex = -1;
+        let isQuoted = false;
+        if (quoted) {
+            token = quoted.token;
+            endIndex = quoted.end;
+            isQuoted = true;
+        } else {
+            const word = readWordToken(text, at + 1);
+            if (!word.token) continue;       // bare `@` with no word after
+            token = word.token;
+            endIndex = word.end;
+        }
+
+        // Quoted form has its own closing quote as boundary; bare form
+        // needs a Unicode word boundary AFTER the token.
+        if (!isQuoted && !boundaryAfter(text, endIndex)) continue;
+
+        // Defer entity-parser-claimed tokens. Quoted form is never an
+        // entity-parser token (those don't accept quotes), so only check
+        // for the bare form.
+        if (!isQuoted && isClaimedByEntityParser(token)) continue;
+
+        const normalized = normalizeNameKey(token);
+        if (!normalized) continue;
+
+        // Longest-prefix match: pick the longest index key that is a
+        // prefix of the token AND has a word boundary at the prefix end.
+        // For the quoted form, exact-equality is enough.
+        let matchedKey = null;
+        if (isQuoted) {
+            if (index.has(normalized)) matchedKey = normalized;
+        } else {
+            for (const key of keysByLength) {
+                if (key.length > normalized.length) continue;
+                if (normalized === key) { matchedKey = key; break; }
+                // Prefix + the next char in the original token must be a
+                // word boundary (so "Hank" doesn't false-match inside
+                // "Hankering"). Since `token` is lowercased ascii-or-unicode
+                // and `key` is normalized, compare against `normalized` here.
+                if (normalized.startsWith(key)) {
+                    const nextCh = normalized[key.length];
+                    if (!nextCh || !UNICODE_WORD_RE.test(nextCh)) {
+                        matchedKey = key;
+                        break;
+                    }
+                }
+            }
+        }
+        if (!matchedKey) continue;
+
+        const deviceIds = index.get(matchedKey);
+        if (!deviceIds || deviceIds.size === 0) continue;
+
+        for (const deviceId of deviceIds) {
+            // Self-mention suppression: don't push the sender's own device.
+            // That would be every message you wrote about yourself buzzing
+            // your own phone.
+            if (senderDeviceId && deviceId === senderDeviceId) continue;
+            if (seenDeviceIds.has(deviceId)) continue;
+            seenDeviceIds.add(deviceId);
+            const canonical = (devices[deviceId] && devices[deviceId].userDisplayName) || matchedKey;
+            out.push({
+                deviceId,
+                displayName: canonical,
+                matchedKey,
+                matchedAt: at,
+                isQuoted
+            });
+        }
+    }
+
+    return out;
+}
+
+module.exports = {
+    normalizeNameKey,
+    isClaimedByEntityParser,
+    buildIndex,
+    findUserMentions,
+    // Exposed for tests:
+    MAX_TOKENS_PER_MESSAGE,
+    MAX_TOKEN_SCAN_LEN
+};


### PR DESCRIPTION
## Summary
- Detect `@<user_display_name>` tokens in entity-sent chat messages (matches device owner names from PR #3429 card_900).
- Fire an extra `category: 'user_mention'` push to each matched device on top of the existing cross_speak push.
- New notification preference toggle `user_mention` (default ON), independent of `speak_to` — mute generic chat noise but still get pinged by name.
- Coexists with `backend/mention-parser.js` (entity `@publicCode`, `@N`, `@#N`, `@all`) — scanner defers to the entity parser on those tokens so they never collide.

## Why
- card_900 (PR #3429, merge `bd87edf0`) added the `devices.user_display_name` column + portal UI but nothing routed messages by that name yet. This is the "act on the name" half of the same feature.
- Highest-signal notification we send (someone addressed you by name) deserves its own toggle so users can disable lower-signal channels without losing direct pings.

## Implementation
- **`backend/user-mention-scanner.js`** (new, pure module — no DB, no I/O):
  - `normalizeNameKey`: NFKC + lowercase + whitespace-collapse → index key
  - `buildIndex(devices)`: builds `Map<key, Set<deviceId>>` + length-sorted keys for longest-prefix match
  - `findUserMentions(text, ctx)`: indexOf walk + Map lookup (no regex backtracking), Unicode word-boundary, longest-prefix match, per-message dedupe, self-mention suppression
  - Hard caps: `MAX_TOKENS_PER_MESSAGE=256`, `MAX_TOKEN_SCAN_LEN=128` — ReDoS-safe even with 100k `@`s or a 50k-char word
  - Defers tokens already claimed by `mention-parser.js`: `@all`, `@<6-char alnum>` (publicCode), `@<1-3 digits>` (entityId) — checked via `isClaimedByEntityParser`
  - Quoted form `@"Display Name"` for names with spaces (bare form ambiguous, avoided)
- **`backend/notifications.js`**: added `user_mention: true` to `DEFAULT_PREFS`. The existing `notifyDevice → isCategoryEnabled` gate now respects the toggle end-to-end with zero extra wiring.
- **`backend/index.js`**: wired the scan into `/api/transform` right after entity-mention parsing; one `notifyDevice` per unique matched `deviceId` with `category: 'user_mention'`, `title: '@<displayName>'`, `body: '<entityName>: <message excerpt>'`.
- **`backend/public/portal/settings.html`**: added `'@Mention pings'` row to `NOTIF_PREF_CATEGORIES` with an inline `?` icon explaining the prerequisite (set a display name in the card above).
- **`backend/public/shared/i18n.js`**: added `notif_pref_user_mention` + `notif_pref_user_mention_help` to all 15 locales (en, zh, ja, ko, zh-TW, th, vi, id, fr, es, de, pt, ms, hi, ar) via the AST insert tool — not regex (per [[feedback_i18n_dedup_needs_ast]]).

## Tests
- **`backend/tests/jest/mention-push-card_db7.test.js`** — 41 unit tests:
  - `normalizeNameKey`: lowercase/trim/collapse, null/empty/non-string, NFKC half→full-width fold
  - `isClaimedByEntityParser`: `@all`, 1-3 digit entityId, 6-char alnum publicCode, non-claimed boundaries
  - `buildIndex`: only devices with normalized name are indexed; length-sorted output
  - `findUserMentions` basic: single, longest-prefix wins, case-insensitive, CJK, quoted form, multi-user, per-message dedupe
  - `findUserMentions` safety: email `hank@example.com` does NOT match, `<@hank01>` boundary, `@hank01` deferred to entity parser, `@42` deferred, `@all` deferred, `@#1` deferred, unknown name no-match, null userDisplayName no-match, `Hankering` partial-word suppressed, self-mention suppressed, empty/null/non-string handling
  - `findUserMentions` ReDoS: 100k `@`s + 50k-char word + 500-copy spam all complete in <500ms
  - `notifications`: `user_mention` exists in DEFAULT_PREFS=true; `isCategoryEnabled` honors explicit false
- **Full local jest suite**: 309 suites / 4270 passed / 3 skipped / 0 failures
- **Regression on neighboring modules**: `mention-parser`, `mention-resolver`, `mention-gatekeeper`, `notifications`, `notification-prefs-merge`, `notification-category-aliases` — 123 passed
- **Lint**: clean on all changed files (0 errors)

## Globe-user generalization
- Every device worldwide can be matched by its owner display name — no allowlist, no per-tenant carveouts
- All 15 locales translated (not en pass-through) per [[feedback_i18n_translate_not_passthrough]]
- Unicode-aware boundaries handle CJK / Cyrillic / Arabic / emoji names uniformly
- NFKC normalization makes half-width / full-width inputs interchangeable (Asian keyboard friendly)

## Setup conditions
1. User sets a display name in Settings → 🪪 My Display Name → save (already shipped in PR #3429)
2. `user_mention` toggle defaults ON; user may toggle off if undesired
3. No new secrets/keys; uses existing notifications infra (Web Push + FCM already wired)

## Empty / disabled-state ? icon UX
- New `?` icon next to "@Mention pings" row in Settings → 🔔 Notifications
- Click/hover reveals: "Push notification when someone writes @YourDisplayName in chat. Requires a display name set in 'My Display Name' above. Independent of entity-conversation push."
- The existing "My Display Name" card already has its own `?` icon explaining the field
- If a user has no display name set, no message can match → no false pushes; the `?` icon tells them what to do to enable the feature

## Out of scope
- `@`-mention input autocomplete (folds into card_900 follow-up if desired)
- Snooze / DND scheduling
- Email/SMS fallback channels
- Cross-language fuzzy match (`@hank` matching a kanji name) — intentionally strict NFKC + lowercase

🤖 Generated with [Claude Code](https://claude.com/claude-code)