### PR TITLE
hotfix(vault): defensive new Date() in POST /api/device-vars (restart loop 06/16 14:15Z)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -21071,9 +21071,18 @@ app.post('/api/device-vars', async (req, res) => {
             const existingKeyCount = existingRow && existingRow.var_keys && Array.isArray(existingRow.var_keys)
                 ? existingRow.var_keys.length
                 : 0;
-            const existingUpdatedAt = existingRow && existingRow.updated_at
-                ? new Date(existingRow.updated_at).toISOString()
-                : null;
+            // Defensive: row.updated_at may be Date, string, or unexpected shape
+            // depending on pg driver state. `new Date(invalidShape).toISOString()`
+            // throws RangeError "Invalid time value" → unhandled rejection → crash
+            // → restart loop (incident 2026-06-16 14:15:45Z; same pattern as PR #3424
+            // hotfixed in GET handler). Wrap defensively + fall back to null.
+            let existingUpdatedAt = null;
+            try {
+                if (existingRow && existingRow.updated_at) {
+                    const d = new Date(existingRow.updated_at);
+                    if (!Number.isNaN(d.getTime())) existingUpdatedAt = d.toISOString();
+                }
+            } catch (_) { existingUpdatedAt = null; }
             if (existingKeyCount > 0) {
                 const _srcLabel = (source === 'web' || source === 'app') ? source : 'legacy';
                 console.warn(`[Vars] POST without expectedUpdatedAt against non-empty row (deviceId=${deviceId} source=${_srcLabel} keys=${existingKeyCount} strictMode=${strictMode})`);
@@ -21099,9 +21108,14 @@ app.post('/api/device-vars', async (req, res) => {
         }
     } else {
         const currentRow = await loadExistingRowOnce();
-        const currentUpdatedAt = currentRow && currentRow.updated_at
-            ? new Date(currentRow.updated_at).toISOString()
-            : null;
+        // Defensive: see comment on existingUpdatedAt above (incident 2026-06-16 14:15:45Z).
+        let currentUpdatedAt = null;
+        try {
+            if (currentRow && currentRow.updated_at) {
+                const d = new Date(currentRow.updated_at);
+                if (!Number.isNaN(d.getTime())) currentUpdatedAt = d.toISOString();
+            }
+        } catch (_) { currentUpdatedAt = null; }
         if (currentUpdatedAt && currentUpdatedAt !== expectedUpdatedAt) {
             const _srcLabel = (source === 'web' || source === 'app') ? source : 'legacy';
             db.logDeviceVarsAudit({


### PR DESCRIPTION
## URGENT: prod restart loop

**Incident**: 2026-06-16 14:15:45Z FATAL Unhandled rejection: RangeError: Invalid time value at index.js:21075 Date.toISOString(). Backend in restart loop; mobile app shows '載入聊天記錄失敗'; /api/chat/history returns 503 'Server starting up'.

**Root cause**: PR #3427's vault strict-mode no-etag guard + the expectedUpdatedAt etag check both call `new Date(row.updated_at).toISOString()` without the defensive Number.isNaN guard that PR #3424 added to the GET handler. When pg driver returns an unexpected updated_at shape, this throws RangeError → unhandled rejection → crash.

**Fix**: Mirror PR #3424's pattern — try/catch + Number.isNaN(d.getTime()) guard + null fallback at both POST call sites (existingUpdatedAt for strict-mode guard, currentUpdatedAt for etag check).

**Verification post-merge**: chat/history should return 200 within ~60s of Railway redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)