### PR TITLE
chore(safety): extract safeUpdatedAtToISO helper + global unhandledRejection guard + CI ban (06/16 RCA)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -42,6 +42,31 @@ jobs:
         run: npm run lint
         working-directory: backend
 
+      - name: Ban unguarded new Date(row.updated_at).toISOString() (06-16 incident class)
+        # 2026-06-16 RCA: PR #3422 → PR #3424 hotfix → PR #3427 carry-forward →
+        # PR #3432 second hotfix. Three PRs, two prod incidents, same line of
+        # code. Permanent fix is centralized helper backend/safe-date.js + this
+        # gate so the unguarded pattern literally cannot be merged again.
+        # See: https://github.com/HankHuang0516/EClaw/pull/3424
+        # See: https://github.com/HankHuang0516/EClaw/pull/3432
+        run: |
+          set -e
+          HITS=$(grep -rn --include='*.js' --exclude-dir=node_modules \
+            -E 'new Date\([^)]*updated_at[^)]*\)\.toISOString' \
+            backend/ \
+            | grep -v 'safe-date.js' \
+            | grep -vE '^[^:]+:[0-9]+:[[:space:]]*(//|\*)' \
+            || true)
+          if [ -n "$HITS" ]; then
+            echo "::error::Unguarded new Date(row.updated_at).toISOString() detected."
+            echo "::error::Use the safeUpdatedAtToISO(row) helper from backend/safe-date.js instead."
+            echo "::error::Background: this pattern caused 2 prod incidents on 2026-06-16 (PRs #3422->#3424, #3427->#3432)."
+            echo ""
+            echo "$HITS"
+            exit 1
+          fi
+          echo "OK - no unguarded new Date(...updated_at...).toISOString() outside safe-date.js."
+
   # ── i18n validation (fast, no npm ci needed) ────────────────────────────────
   i18n:
     name: i18n syntax check

--- a/backend/index.js
+++ b/backend/index.js
@@ -38,6 +38,7 @@ const sanitizeHtml = require('sanitize-html');
 const compression = require('compression');
 
 const safeEqual = require('./safe-equal');
+const { safeUpdatedAtToISO } = require('./safe-date');
 const { createHermesHealthMonitor } = require('./hermes-health-check');
 const { createSettingsHelpInvariantCron } = require('./settings-help-invariant-cron');
 
@@ -20968,19 +20969,41 @@ process.on('uncaughtException', async (err) => {
     process.exit(1);
 });
 
-process.on('unhandledRejection', async (reason) => {
+// 2026-06-16 RCA change:
+// The original handler called process.exit(1) on every unhandled rejection.
+// PR #3422's unguarded `new Date(row.updated_at).toISOString()` threw
+// RangeError per-request → this handler crashed the server → Railway respawn
+// → next request crashed it again → 7 minute restart loop until hotfix
+// PR #3432 shipped. A single bad row or pathological request shouldn't take
+// down the whole server.
+//
+// New policy: log + audit to DB, but DO NOT exit. The catch sites that needed
+// the crash (genuine fatal data corruption) should call process.exit
+// themselves; everything else survives so other in-flight requests aren't
+// killed as collateral damage.
+process.on('unhandledRejection', async (reason, promise) => {
     const msg = reason instanceof Error ? reason.message : String(reason);
     const stack = reason instanceof Error ? reason.stack : undefined;
-    console.error('[FATAL] Unhandled rejection:', reason);
+    const name = reason instanceof Error ? reason.name : typeof reason;
+    console.error('[FATAL] Unhandled rejection survived (would have crashed pre-2026-06-16 incident):',
+        name, msg);
+    if (stack) console.error(stack);
     try {
         await chatPool.query(
             `INSERT INTO server_logs (level, category, message, metadata)
              VALUES ($1, $2, $3, $4)`,
-            ['error', 'crash', `Unhandled rejection: ${msg}`,
-             JSON.stringify({ stack: stack?.substring(0, 2000) })]
+            ['error', 'crash', `Unhandled rejection (survived): ${msg}`,
+             JSON.stringify({
+                 name,
+                 stack: stack?.substring(0, 2000),
+                 // Promise stringifies to "[object Promise]" but presence
+                 // confirms we got the rejection event vs. a synthesized call.
+                 hasPromise: !!promise,
+                 rcaRef: '2026-06-16-restart-loop',
+             })]
         );
-    } catch (_) { /* DB write failed, nothing we can do */ }
-    process.exit(1);
+    } catch (_) { /* DB write failed; console.error above is the durable record */ }
+    // Intentionally NO process.exit — survive the bad request, keep serving.
 });
 
 // Fire-and-forget handshake failure recorder
@@ -21072,17 +21095,12 @@ app.post('/api/device-vars', async (req, res) => {
                 ? existingRow.var_keys.length
                 : 0;
             // Defensive: row.updated_at may be Date, string, or unexpected shape
-            // depending on pg driver state. `new Date(invalidShape).toISOString()`
-            // throws RangeError "Invalid time value" → unhandled rejection → crash
-            // → restart loop (incident 2026-06-16 14:15:45Z; same pattern as PR #3424
-            // hotfixed in GET handler). Wrap defensively + fall back to null.
-            let existingUpdatedAt = null;
-            try {
-                if (existingRow && existingRow.updated_at) {
-                    const d = new Date(existingRow.updated_at);
-                    if (!Number.isNaN(d.getTime())) existingUpdatedAt = d.toISOString();
-                }
-            } catch (_) { existingUpdatedAt = null; }
+            // depending on pg driver state. Unguarded `new Date(x).toISOString()`
+            // threw RangeError "Invalid time value" → unhandled rejection → crash
+            // → restart loop (incident 2026-06-16 14:15:45Z, hotfix PR #3432).
+            // Permanent fix: centralized helper enforced by CI grep ban — see
+            // backend/safe-date.js.
+            const existingUpdatedAt = safeUpdatedAtToISO(existingRow);
             if (existingKeyCount > 0) {
                 const _srcLabel = (source === 'web' || source === 'app') ? source : 'legacy';
                 console.warn(`[Vars] POST without expectedUpdatedAt against non-empty row (deviceId=${deviceId} source=${_srcLabel} keys=${existingKeyCount} strictMode=${strictMode})`);
@@ -21108,14 +21126,9 @@ app.post('/api/device-vars', async (req, res) => {
         }
     } else {
         const currentRow = await loadExistingRowOnce();
-        // Defensive: see comment on existingUpdatedAt above (incident 2026-06-16 14:15:45Z).
-        let currentUpdatedAt = null;
-        try {
-            if (currentRow && currentRow.updated_at) {
-                const d = new Date(currentRow.updated_at);
-                if (!Number.isNaN(d.getTime())) currentUpdatedAt = d.toISOString();
-            }
-        } catch (_) { currentUpdatedAt = null; }
+        // Defensive: see comment on existingUpdatedAt above (incident 2026-06-16
+        // 14:15:45Z). Centralized helper — see backend/safe-date.js.
+        const currentUpdatedAt = safeUpdatedAtToISO(currentRow);
         if (currentUpdatedAt && currentUpdatedAt !== expectedUpdatedAt) {
             const _srcLabel = (source === 'web' || source === 'app') ? source : 'legacy';
             db.logDeviceVarsAudit({
@@ -21296,7 +21309,9 @@ app.post('/api/device-vars', async (req, res) => {
         let newUpdatedAt = null;
         try {
             const postRow = await db.getDeviceVars(deviceId);
-            if (postRow && postRow.updated_at) newUpdatedAt = new Date(postRow.updated_at).toISOString();
+            // Defensive: centralized helper guards against malformed updated_at
+            // shape from pg driver (06-16 incident class). See backend/safe-date.js.
+            newUpdatedAt = safeUpdatedAtToISO(postRow);
         } catch (e) { /* fall through; client can refetch via GET */ }
 
         const response = { success: true, count: varKeys.length, updatedAt: newUpdatedAt };
@@ -21372,26 +21387,12 @@ app.get('/api/device-vars', async (req, res) => {
         // last-write-wins data loss when multiple web/app clients have stale
         // vault snapshots.
         // Defensive: row.updated_at may be a Date, string, or unexpected shape
-        // depending on pg driver state. `new Date(invalidShape).toISOString()`
-        // throws RangeError "Invalid time value", which the outer catch then
-        // logged as "Decrypt failed" — a false 500 that masked perfectly healthy
-        // vault data (incident 2026-06-16 ~12:36 TW; clients kept rendering
-        // from var_keys metadata + localStorage cache while owner-auth GET
-        // 500'd for ~30min). Wrap defensively + fall back to null.
-        try {
-            if (row.updated_at) {
-                const d = new Date(row.updated_at);
-                if (!Number.isNaN(d.getTime())) {
-                    out.updatedAt = d.toISOString();
-                } else {
-                    out.updatedAt = null;
-                }
-            } else {
-                out.updatedAt = null;
-            }
-        } catch (_) {
-            out.updatedAt = null;
-        }
+        // depending on pg driver state. Unguarded `new Date(x).toISOString()`
+        // threw RangeError "Invalid time value" → false 500 "Decrypt failed"
+        // (incident 2026-06-16 ~12:36 TW, hotfix PR #3424).
+        // Permanent fix: centralized helper enforced by CI grep ban — see
+        // backend/safe-date.js.
+        out.updatedAt = safeUpdatedAtToISO(row);
         if (authMode === 'owner') {
             out.sources = row.var_sources || {};
             out.locked = !!row.is_locked;

--- a/backend/mindmap-graph-projection.js
+++ b/backend/mindmap-graph-projection.js
@@ -22,6 +22,8 @@
 
 'use strict';
 
+const { safeUpdatedAtToISO } = require('./safe-date');
+
 const SCHEMA_VERSION = 2;
 const LABEL_MAX = 80;
 const TITLE_MAX = 200;
@@ -93,7 +95,7 @@ function buildTaskNode(card, commentCount, noteCount) {
         summary: clip((card.description || '').replace(/\s+/g, ' ').trim(), SUMMARY_MAX),
         commentCount: Number.isFinite(commentCount) ? commentCount : 0,
         noteCount: Number.isFinite(noteCount) ? noteCount : 0,
-        updatedAt: card.updated_at ? new Date(card.updated_at).toISOString() : null,
+        updatedAt: safeUpdatedAtToISO(card),
         url: `/portal/kanban.html?card=${encodeURIComponent(card.id)}`,
         colorKey: `status:${card.status || 'todo'}`,
         val: taskVal(card.priority, card.is_automation, card.status),
@@ -111,7 +113,7 @@ function buildNoteNode(note) {
         category: note.category || 'general',
         ownerEntityId,
         summary: clip((note.content || '').replace(/\s+/g, ' ').trim(), SUMMARY_MAX),
-        updatedAt: note.updated_at ? new Date(note.updated_at).toISOString() : null,
+        updatedAt: safeUpdatedAtToISO(note),
         url: `/portal/mission.html?note=${encodeURIComponent(note.id)}`,
         colorKey: `note:${note.category || 'general'}`,
         val: 4,

--- a/backend/safe-date.js
+++ b/backend/safe-date.js
@@ -1,0 +1,38 @@
+'use strict';
+
+/**
+ * Safe row.updated_at → ISO-8601 string conversion.
+ *
+ * Background (2026-06-16 incident chain):
+ * - PR #3422 introduced `new Date(row.updated_at).toISOString()` in the vault
+ *   GET handler. When `row.updated_at` was an unexpected shape (pg-driver
+ *   returned a string, null, or already-Date in a malformed state), the
+ *   construction produced an Invalid Date and `.toISOString()` threw
+ *   `RangeError: Invalid time value` (incident ~12:36 TW, hotfix PR #3424).
+ * - PR #3427 copy-pasted the same unguarded pattern into the POST handler's
+ *   strict-mode no-etag guard at index.js:21075. At 14:15:45Z prod hit the
+ *   path, RangeError bubbled to the existing unhandledRejection handler
+ *   which called process.exit(1) → restart loop until hotfix PR #3432.
+ *
+ * Permanent fix (this module, 06-16 RCA PR):
+ * - Single defensive helper used at every call site.
+ * - CI grep ban in `.github/workflows/backend-ci.yml` forbids
+ *   `new Date(...updated_at...).toISOString()` outside this file so the
+ *   pattern can't be reintroduced.
+ *
+ * Returns the ISO-8601 string for `row.updated_at`, or `null` when the row
+ * is missing, the field is missing/null/undefined, or the value cannot be
+ * coerced to a valid Date. Never throws.
+ */
+function safeUpdatedAtToISO(row) {
+    if (!row || row.updated_at === null || row.updated_at === undefined) return null;
+    try {
+        const d = new Date(row.updated_at);
+        if (Number.isNaN(d.getTime())) return null;
+        return d.toISOString();
+    } catch (_) {
+        return null;
+    }
+}
+
+module.exports = { safeUpdatedAtToISO };

--- a/backend/tests/jest/safe-date.test.js
+++ b/backend/tests/jest/safe-date.test.js
@@ -1,0 +1,112 @@
+/**
+ * safeUpdatedAtToISO unit tests
+ *
+ * Locks down the permanent fix for the 2026-06-16 RangeError "Invalid time value"
+ * incident class. PRs #3422→#3424 (GET handler hotfix), PR #3427→#3432 (POST
+ * handler hotfix). See backend/safe-date.js for full RCA.
+ *
+ * The helper MUST:
+ * - return null for any missing/null/undefined/malformed input (never throw)
+ * - return an ISO-8601 string for any valid Date-coercible input
+ *
+ * If this file regresses, the gating CI grep ban (.github/workflows/backend-ci.yml
+ * "Ban unguarded new Date..." step) becomes the next line of defense.
+ */
+
+const { safeUpdatedAtToISO } = require('../../safe-date');
+
+describe('safeUpdatedAtToISO', () => {
+    describe('returns null for missing/null/undefined input', () => {
+        test('null row', () => {
+            expect(safeUpdatedAtToISO(null)).toBeNull();
+        });
+
+        test('undefined row', () => {
+            expect(safeUpdatedAtToISO(undefined)).toBeNull();
+        });
+
+        test('empty object (no updated_at)', () => {
+            expect(safeUpdatedAtToISO({})).toBeNull();
+        });
+
+        test('updated_at: null', () => {
+            expect(safeUpdatedAtToISO({ updated_at: null })).toBeNull();
+        });
+
+        test('updated_at: undefined (explicit)', () => {
+            expect(safeUpdatedAtToISO({ updated_at: undefined })).toBeNull();
+        });
+    });
+
+    describe('returns null for malformed values (never throws)', () => {
+        test('updated_at: arbitrary non-date string', () => {
+            expect(safeUpdatedAtToISO({ updated_at: 'invalid' })).toBeNull();
+        });
+
+        test('updated_at: new Date("invalid") (already-Invalid Date)', () => {
+            expect(safeUpdatedAtToISO({ updated_at: new Date('invalid') })).toBeNull();
+        });
+
+        test('updated_at: new Date(NaN)', () => {
+            expect(safeUpdatedAtToISO({ updated_at: new Date(NaN) })).toBeNull();
+        });
+
+        test('updated_at: "banana"', () => {
+            expect(safeUpdatedAtToISO({ updated_at: 'banana' })).toBeNull();
+        });
+
+        test('updated_at: empty string', () => {
+            expect(safeUpdatedAtToISO({ updated_at: '' })).toBeNull();
+        });
+
+        test('updated_at: object that throws when coerced (Symbol)', () => {
+            // Date(Symbol) throws TypeError; helper must catch and return null.
+            expect(safeUpdatedAtToISO({ updated_at: Symbol('x') })).toBeNull();
+        });
+    });
+
+    describe('returns ISO string for valid inputs', () => {
+        test('updated_at: valid Date object', () => {
+            const d = new Date('2026-06-16T14:00:00Z');
+            expect(safeUpdatedAtToISO({ updated_at: d })).toBe('2026-06-16T14:00:00.000Z');
+        });
+
+        test('updated_at: epoch ms (number)', () => {
+            // 1750000000000 → 2025-06-15T16:53:20.000Z (sanity-check is a valid ISO)
+            const out = safeUpdatedAtToISO({ updated_at: 1750000000000 });
+            expect(out).toBe(new Date(1750000000000).toISOString());
+            expect(out).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+        });
+
+        test('updated_at: ISO-8601 string', () => {
+            expect(safeUpdatedAtToISO({ updated_at: '2026-06-16T14:00:00Z' }))
+                .toBe('2026-06-16T14:00:00.000Z');
+        });
+
+        test('updated_at: ISO-8601 string with timezone offset', () => {
+            // 2026-06-16T22:00:00+08:00 == 2026-06-16T14:00:00Z
+            expect(safeUpdatedAtToISO({ updated_at: '2026-06-16T22:00:00+08:00' }))
+                .toBe('2026-06-16T14:00:00.000Z');
+        });
+    });
+
+    describe('incident-class regression coverage', () => {
+        // These mirror the actual shapes the pg driver was returning when the
+        // 06-16 incidents fired. If any of these throw, the server is back in
+        // restart-loop territory.
+
+        test('does NOT throw on pg-driver Invalid Date (06-16 ~12:36 TW symptom)', () => {
+            const malformedRow = { updated_at: new Date('not-a-date') };
+            expect(() => safeUpdatedAtToISO(malformedRow)).not.toThrow();
+            expect(safeUpdatedAtToISO(malformedRow)).toBeNull();
+        });
+
+        test('does NOT throw on missing row (06-16 14:15Z symptom — POST etag check)', () => {
+            // The crash happened on the strict-mode no-etag guard when the row
+            // existed but updated_at was unexpectedly shaped. Confirm the
+            // "no row at all" boundary also doesn't throw.
+            expect(() => safeUpdatedAtToISO(undefined)).not.toThrow();
+            expect(() => safeUpdatedAtToISO(null)).not.toThrow();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Permanent fix for the 2026-06-16 RangeError "Invalid time value" incident class. Three PRs, two prod incidents, same line of code — this PR makes the pattern impossible to reintroduce.

## Incident chain (RCA)

| When | PR | Action | Result |
|---|---|---|---|
| 06/16 11:00 TW | #3422 | Added `new Date(row.updated_at).toISOString()` to GET vault | Bad pg-driver shape → RangeError → 500 "Decrypt failed" |
| 06/16 12:36 TW | #3424 | Hotfix: inline guard + try/catch in GET handler ONLY | Symptom gone, root pattern remains |
| 06/16 12:50 TW | #3427 | NEW unguarded site in POST strict-mode no-etag guard (copy-paste carry-forward) | Hazard reintroduced |
| 06/16 14:15:45Z | — | Prod hit the new path → RangeError → existing `unhandledRejection` handler called `process.exit(1)` → Railway respawn → next request → restart loop |
| 06/16 14:22 TW | #3432 | Hotfix: inline guard at 2 POST sites | Symptom gone, root pattern STILL remains, restart-loop hazard STILL remains |

The class of bug carried forward through 3 PRs because:
1. No shared helper — each fix was inline try/catch, easy to skip on the next call site.
2. No CI gate — the unguarded pattern could merge again.
3. The global `unhandledRejection` handler was a guillotine (`process.exit(1)`), not a safety net — one bad request killed the entire process.

## The 5 changes

### 1. `backend/safe-date.js` (new)
Single defensive helper:
```js
function safeUpdatedAtToISO(row) {
    if (!row || row.updated_at === null || row.updated_at === undefined) return null;
    try {
        const d = new Date(row.updated_at);
        if (Number.isNaN(d.getTime())) return null;
        return d.toISOString();
    } catch (_) { return null; }
}
```
Modeled on the `backend/safe-equal.js` precedent.

### 2. `backend/index.js` — replace ALL unguarded sites
- POST `/api/device-vars` strict-mode no-etag guard (ex-PR #3432)
- POST `/api/device-vars` etag-present branch (ex-PR #3432)
- POST `/api/device-vars` re-read after upsert (was inside outer try/catch — didn't crash but same hazard waiting to fire on future refactor)
- GET `/api/device-vars` (ex-PR #3424)

Also `backend/mindmap-graph-projection.js` — two existing unguarded ternary sites swept into the helper to keep CI ban green and pre-empt the same class of bug on `/api/mindmap/graph` responses.

### 3. Global `unhandledRejection` handler — survive instead of exit
The pre-existing handler called `process.exit(1)` on every rejection. THIS WAS THE RESTART LOOP. New policy:
- Log + audit to DB with `rcaRef: '2026-06-16-restart-loop'` and `reason.name` so future incidents surface clearly in the `server_logs.crash` query.
- Do NOT exit. Per-handler try/catch still owns genuine fatal exit decisions; the global handler is now a safety net, not a guillotine.
- Trade-off: server keeps running with potentially-bad state. Mitigation: enhanced logging (name + stack + promise presence) so we can debug what survived.

### 4. CI grep ban in `.github/workflows/backend-ci.yml`
New step in the `lint` job greps `backend/**.js` for `new Date(...updated_at...).toISOString()` outside `safe-date.js` and outside comments. Fails the build with a pointer to the helper.

**Locally verified**:
```
$ # baseline: clean
OK - no unguarded new Date(...updated_at...).toISOString() outside safe-date.js.

$ # canary: inject the pattern in _ci_ban_canary.js
GREP BAN TRIGGERED (expected):
backend/_ci_ban_canary.js:3:    return new Date(row.updated_at).toISOString();

$ # remove canary -> clean again
Confirmed clean post-canary-removal.
```

### 5. `backend/tests/jest/safe-date.test.js` (new)
17 tests covering:
- null / undefined / missing-field input → null
- malformed values: string "invalid", Invalid Date, NaN, Symbol, empty string → null
- valid inputs: Date object, epoch ms (number), ISO string, ISO string + timezone offset → ISO-8601
- incident-class regressions: explicit "does NOT throw" assertions for both the 12:36 TW and 14:15Z shapes

## Test plan

- [x] `npm test` — 317 suites, **4356 passed**, 17 skipped, 0 failed
- [x] `safe-date.test.js` — 17/17 pass
- [x] `device-vars.test.js` — 57/57 pass (call sites still work)
- [x] `mindmap-graph.test.js` — 26/26 pass (other helper users still work)
- [x] `npm run lint` — clean (4 pre-existing warnings unchanged)
- [x] CI grep ban triggers on injected canary, clears on removal

## Why each change is needed

| Change | Without it… |
|---|---|
| Helper | Next call site = next incident. PR #3432 already proved inline fixes don't propagate. |
| Replace all sites | Hotfixed sites are safe; unhotfixed sites (re-read after upsert + mindmap projections) still carry the hazard. |
| Survive-not-exit unhandledRejection | One bad request takes down the whole server again → restart loop again. |
| CI ban | Helper alone doesn't prevent a future PR from inlining the pattern again. |
| Tests | Without coverage, a future refactor of the helper itself silently regresses. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)