### PR TITLE
feat(arena): bind interview score to entity, display on namecard + plaza (card_ad4)

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -2175,7 +2175,32 @@ async function setEntityPublic(deviceId, entityId, isPublic) {
     }
 }
 
-async function searchPublicCards({ q, tag, capability, limit = 20, offset = 0, sort = 'newest' }) {
+// Extract Arena interview fields from the entity's identity JSONB blob.
+// Returns nulls when no interview has been recorded — UI uses these to
+// render the "尚未面試 / No interview yet" placeholder + ? icon UX.
+function extractArenaFieldsFromIdentity(identity) {
+    if (!identity || typeof identity !== 'object') {
+        return { arenaScore: null, arenaMaxScore: null, arenaNormalized: null, arenaPassed: null, lastInterviewAt: null };
+    }
+    const ic = identity.interviewCapabilities;
+    if (!ic || typeof ic !== 'object') {
+        return { arenaScore: null, arenaMaxScore: null, arenaNormalized: null, arenaPassed: null, lastInterviewAt: identity.lastInterviewAt || null };
+    }
+    const score = Number.isFinite(Number(ic.score)) ? Number(ic.score) : null;
+    const max = Number.isFinite(Number(ic.maxScore)) ? Number(ic.maxScore) : null;
+    const normalized = Number.isFinite(Number(ic.normalized)) ? Number(ic.normalized) : null;
+    const passed = typeof ic.passed === 'boolean' ? ic.passed : null;
+    const completedAt = Number.isFinite(Number(ic.completedAt)) ? Number(ic.completedAt) : null;
+    return {
+        arenaScore: score,
+        arenaMaxScore: max,
+        arenaNormalized: normalized,
+        arenaPassed: passed,
+        lastInterviewAt: completedAt || identity.lastInterviewAt || null,
+    };
+}
+
+async function searchPublicCards({ q, tag, capability, minArenaScore, limit = 20, offset = 0, sort = 'newest' }) {
     try {
         const conditions = [`e.is_public = true`, `e.bot_secret IS NOT NULL`];
         const params = [];
@@ -2196,8 +2221,26 @@ async function searchPublicCards({ q, tag, capability, limit = 20, offset = 0, s
             params.push(`%${capability}%`);
             paramIdx++;
         }
+        // minArenaScore: 0–100 normalized percentage. Read from
+        // identity.interviewCapabilities.normalized. Filters out
+        // entities with no recorded interview.
+        const minScoreNum = parseInt(minArenaScore, 10);
+        if (Number.isFinite(minScoreNum) && minScoreNum > 0 && minScoreNum <= 100) {
+            conditions.push(`((e.identity->'interviewCapabilities'->>'normalized')::int >= $${paramIdx})`);
+            params.push(minScoreNum);
+            paramIdx++;
+        }
 
-        const orderBy = sort === 'rating' ? 'e.avg_rating DESC, e.rating_count DESC' : 'e.published_at DESC NULLS LAST';
+        let orderBy;
+        if (sort === 'rating') {
+            orderBy = 'e.avg_rating DESC, e.rating_count DESC';
+        } else if (sort === 'arena_score') {
+            // Sort highest-scoring entities first; entities with no recorded
+            // interview (NULL normalized) sort last via NULLS LAST.
+            orderBy = `(e.identity->'interviewCapabilities'->>'normalized')::int DESC NULLS LAST, e.published_at DESC NULLS LAST`;
+        } else {
+            orderBy = 'e.published_at DESC NULLS LAST';
+        }
         const safeLimit = Math.min(Math.max(parseInt(limit) || 20, 1), 50);
         const safeOffset = Math.max(parseInt(offset) || 0, 0);
 
@@ -2207,7 +2250,7 @@ async function searchPublicCards({ q, tag, capability, limit = 20, offset = 0, s
         // plaza shows e.avatar — the static emoji/upload set on first
         // bind — even after the owner picked a sprite companion.
         const sql = `
-            SELECT e.public_code, e.name, e.character, e.avatar, e.agent_card,
+            SELECT e.public_code, e.name, e.character, e.avatar, e.agent_card, e.identity,
                    e.avg_rating, e.rating_count, e.community_message_count,
                    e.published_at, e.level, e.xp,
                    petdx.avatar_url AS petdx_avatar_url
@@ -2227,22 +2270,26 @@ async function searchPublicCards({ q, tag, capability, limit = 20, offset = 0, s
         `;
 
         const result = await pool.query(sql, params);
-        return result.rows.map(r => ({
-            publicCode: r.public_code,
-            name: r.name,
-            character: r.character,
-            avatar: r.avatar,
-            petdxAvatarUrl: r.petdx_avatar_url || null,
-            description: r.agent_card?.description || null,
-            capabilities: r.agent_card?.capabilities || [],
-            tags: r.agent_card?.tags || [],
-            avgRating: parseFloat(r.avg_rating) || 0,
-            ratingCount: parseInt(r.rating_count) || 0,
-            messageCount: parseInt(r.community_message_count) || 0,
-            publishedAt: r.published_at,
-            level: r.level || 1,
-            xp: r.xp || 0
-        }));
+        return result.rows.map(r => {
+            const arena = extractArenaFieldsFromIdentity(r.identity);
+            return {
+                publicCode: r.public_code,
+                name: r.name,
+                character: r.character,
+                avatar: r.avatar,
+                petdxAvatarUrl: r.petdx_avatar_url || null,
+                description: r.agent_card?.description || null,
+                capabilities: r.agent_card?.capabilities || [],
+                tags: r.agent_card?.tags || [],
+                avgRating: parseFloat(r.avg_rating) || 0,
+                ratingCount: parseInt(r.rating_count) || 0,
+                messageCount: parseInt(r.community_message_count) || 0,
+                publishedAt: r.published_at,
+                level: r.level || 1,
+                xp: r.xp || 0,
+                ...arena,
+            };
+        });
     } catch (err) {
         console.error('[DB] searchPublicCards error:', err.message);
         return [];
@@ -2252,7 +2299,7 @@ async function searchPublicCards({ q, tag, capability, limit = 20, offset = 0, s
 async function getPublicCardDetail(publicCode) {
     try {
         const result = await pool.query(
-            `SELECT e.public_code, e.name, e.character, e.avatar, e.agent_card,
+            `SELECT e.public_code, e.name, e.character, e.avatar, e.agent_card, e.identity,
                     e.avg_rating, e.rating_count, e.community_message_count,
                     e.published_at, e.level, e.xp, e.state,
                     petdx.avatar_url AS petdx_avatar_url
@@ -2271,6 +2318,7 @@ async function getPublicCardDetail(publicCode) {
         );
         if (result.rows.length === 0) return null;
         const r = result.rows[0];
+        const arena = extractArenaFieldsFromIdentity(r.identity);
         return {
             publicCode: r.public_code,
             name: r.name,
@@ -2284,7 +2332,8 @@ async function getPublicCardDetail(publicCode) {
             publishedAt: r.published_at,
             level: r.level || 1,
             xp: r.xp || 0,
-            state: r.state || 'IDLE'
+            state: r.state || 'IDLE',
+            ...arena,
         };
     } catch (err) {
         console.error('[DB] getPublicCardDetail error:', err.message);
@@ -2590,6 +2639,7 @@ module.exports = {
     setEntityPublic,
     searchPublicCards,
     getPublicCardDetail,
+    extractArenaFieldsFromIdentity,
     getCommunityMessages,
     addCommunityMessage,
     upsertCommunityRating,

--- a/backend/index.js
+++ b/backend/index.js
@@ -3680,7 +3680,7 @@ if (process.env.NODE_ENV !== 'test') setTimeout(() => inviteModule.initInviteDat
 // ============================================
 // INTERVIEW ARENA — public bot capability testing
 // ============================================
-const arenaModule = require('./interview-arena')({ serverLog, io, devices });
+const arenaModule = require('./interview-arena')({ serverLog, io, devices, saveDeviceData: db.saveDeviceData });
 app.use('/api/arena', arenaModule.router);
 // Serve arena public pages (no-cache to prevent CDN stale versions)
 app.get(['/arena', '/arena/index.html'], (_req, res) => { res.set('Cache-Control', 'no-cache'); res.sendFile(path.join(__dirname, 'public/arena/index.html')); });
@@ -8014,6 +8014,11 @@ app.get('/api/entities', async (req, res) => {
                     isPublic: !!entity.isPublic,
                     rental_status: entity.rental_status || null,  // 'leased_in', 'leased_out', or null
                     rental_contract_id: entity.rental_contract_id || null,
+                    // Arena interview binding (card_ad404375) — owner can see
+                    // the verified score on their namecard editor. Identity-
+                    // scoped only; never includes other secrets.
+                    interviewCapabilities: (entity.identity && entity.identity.interviewCapabilities) || null,
+                    lastInterviewAt: (entity.identity && entity.identity.lastInterviewAt) || null,
                     messageQueue: (entity.messageQueue || []).map(m => ({
                         text: m.text,
                         from: m.from,
@@ -13068,10 +13073,10 @@ app.get('/api/community/publish', async (req, res) => {
  * Query: ?q=keyword&tag=ecommerce&capability=translation&limit=20&offset=0&sort=newest|rating
  */
 app.get('/api/community/search', async (req, res) => {
-    const { q, tag, capability, limit, offset, sort } = req.query;
+    const { q, tag, capability, minArenaScore, limit, offset, sort } = req.query;
 
     const results = await db.searchPublicCards({
-        q, tag, capability,
+        q, tag, capability, minArenaScore,
         limit: parseInt(limit) || 20,
         offset: parseInt(offset) || 0,
         sort: sort || 'newest'
@@ -13089,9 +13094,9 @@ app.get('/api/community/search', async (req, res) => {
  * No auth required. Same query contract as /search.
  */
 app.get('/api/community/list', async (req, res) => {
-    const { q, tag, capability, limit, offset, sort } = req.query;
+    const { q, tag, capability, minArenaScore, limit, offset, sort } = req.query;
     const results = await db.searchPublicCards({
-        q, tag, capability,
+        q, tag, capability, minArenaScore,
         limit: parseInt(limit) || 20,
         offset: parseInt(offset) || 0,
         sort: sort || 'newest'

--- a/backend/interview-arena.js
+++ b/backend/interview-arena.js
@@ -1082,6 +1082,53 @@ function mapArenaResultToCapabilities(report) {
     };
 }
 
+/**
+ * Build the entity.identity patch that records a verified Arena
+ * interview result on the bot's namecard (card_ad404375 — Arena/Feature/P1).
+ *
+ * Pure function — no I/O. Caller merges the returned object into
+ * `entity.identity` and persists via db.saveDeviceData.
+ *
+ * Latest-wins: callers should overwrite any prior interviewCapabilities
+ * block with this patch (latest interview defines the verified score).
+ *
+ * @param {object} exam — { id, model, total_score, max_score, completed_at }
+ * @param {object} mapped — output of mapArenaResultToCapabilities()
+ * @param {number} [nowMs] — clock injection for tests
+ * @returns {{interviewCapabilities:object,lastInterviewAt:number}|null}
+ */
+function buildInterviewIdentityPatch(exam, mapped, nowMs) {
+    if (!exam || !mapped || typeof mapped !== 'object') return null;
+
+    const totalScore = Number(exam.total_score);
+    const maxScore = Number(exam.max_score);
+    if (!Number.isFinite(totalScore) || !Number.isFinite(maxScore) || maxScore <= 0) {
+        return null;
+    }
+    // Clamp + guard against out-of-range / negative server-side rows
+    const score = Math.max(0, Math.min(maxScore, Math.round(totalScore)));
+    const max = Math.max(1, Math.round(maxScore));
+    const normalized = Math.round((score / max) * 100);
+    const passed = !!mapped.passed;
+    const completedAtMs = exam.completed_at
+        ? new Date(exam.completed_at).getTime()
+        : (typeof nowMs === 'number' ? nowMs : Date.now());
+
+    return {
+        interviewCapabilities: {
+            score,
+            maxScore: max,
+            normalized,
+            passed,
+            model: exam.model || null,
+            examId: exam.id || null,
+            completedAt: completedAtMs,
+            source: 'arena',
+        },
+        lastInterviewAt: typeof nowMs === 'number' ? nowMs : Date.now(),
+    };
+}
+
 // ============================================
 // Answer-leak prevention: decoy + strip
 // ============================================
@@ -1230,10 +1277,12 @@ function stripSecretsForBot(testType, config) {
 // Express factory
 // ============================================
 
-module.exports = function arenaFactory({ serverLog, io, devices } = {}) {
+module.exports = function arenaFactory({ serverLog, io, devices, saveDeviceData } = {}) {
     const router = express.Router();
     const audit = serverLog || (() => {});
     const deviceRegistry = devices || {};
+    // Used to verify entity botSecret on the /leaderboard binding path.
+    const safeEqual = require('./safe-equal');
 
     // Per-IP cooldown: 1 exam per 5 minutes
     const examCooldownMap = new Map(); // ip → last exam timestamp
@@ -1730,9 +1779,19 @@ module.exports = function arenaFactory({ serverLog, io, devices } = {}) {
     });
 
     // POST /api/arena/leaderboard — submit to leaderboard
+    //
+    // Anonymous path (back-compat): { examId, name } only — writes a
+    // leaderboard row tagged with the typed display name.
+    //
+    // Entity-bound path (card_ad404375 — namecard score binding):
+    // { examId, name, deviceId, entityId, botSecret } — if the credentials
+    // verify, the verified score is also written back to
+    // entity.identity.interviewCapabilities so the bot's namecard + plaza
+    // tile show the verified score. Anonymous path keeps working when no
+    // botSecret is supplied or credentials fail.
     router.post('/leaderboard', async (req, res) => {
         try {
-            const { examId, name } = req.body || {};
+            const { examId, name, deviceId, entityId, botSecret } = req.body || {};
             if (!examId || !name || typeof name !== 'string' || name.trim().length === 0) {
                 return res.status(400).json({ success: false, error: 'examId_and_name_required' });
             }
@@ -1763,7 +1822,51 @@ module.exports = function arenaFactory({ serverLog, io, devices } = {}) {
                  JSON.stringify(report)]
             );
             const leaderboardId = lbRes.rows[0] ? lbRes.rows[0].id : null;
-            res.json({ success: true, leaderboardId });
+
+            // Optional entity binding — write the verified score back to the
+            // bot's identity if botSecret authenticates. Failures here MUST
+            // NOT fail the public LB submit (back-compat with anonymous flow).
+            let entityBinding = null;
+            try {
+                if (deviceId && botSecret) {
+                    const eId = parseInt(entityId, 10);
+                    const device = deviceRegistry[deviceId];
+                    const entity = (device && Number.isInteger(eId)) ? device.entities?.[eId] : null;
+                    const credsOk = !!(entity && entity.isBound && entity.botSecret && safeEqual(entity.botSecret, botSecret));
+                    if (credsOk) {
+                        const mapped = mapArenaResultToCapabilities(report);
+                        const patch = buildInterviewIdentityPatch(exam, mapped);
+                        if (patch) {
+                            if (!entity.identity) entity.identity = {};
+                            // Latest-wins: overwrite any prior interviewCapabilities block.
+                            entity.identity.interviewCapabilities = patch.interviewCapabilities;
+                            entity.identity.lastInterviewAt = patch.lastInterviewAt;
+                            entity.lastUpdated = Date.now();
+                            if (saveDeviceData) {
+                                // Fire-and-forget persistence — log failures but
+                                // don't fail the LB submit. Same pattern as
+                                // identity PATCH (index.js:13598).
+                                Promise.resolve(saveDeviceData(deviceId, device))
+                                    .catch(err => audit('warn', 'arena', `entity binding save failed: ${err.message}`));
+                            }
+                            entityBinding = {
+                                entityId: eId,
+                                score: patch.interviewCapabilities.score,
+                                maxScore: patch.interviewCapabilities.maxScore,
+                                normalized: patch.interviewCapabilities.normalized,
+                                passed: patch.interviewCapabilities.passed,
+                            };
+                            audit('info', 'arena', `entity ${deviceId}:${eId} bound to exam ${exam.id} score=${entityBinding.normalized}%`);
+                        }
+                    } else if (entityId !== undefined) {
+                        audit('warn', 'arena', `entity binding rejected for device=${deviceId} entity=${entityId}: invalid credentials`);
+                    }
+                }
+            } catch (bindErr) {
+                console.warn('[Arena] entity binding error (non-blocking):', bindErr.message);
+            }
+
+            res.json({ success: true, leaderboardId, entityBinding });
         } catch (err) {
             res.status(500).json({ success: false, error: 'internal_error' });
         }
@@ -1893,7 +1996,8 @@ module.exports = function arenaFactory({ serverLog, io, devices } = {}) {
     // Path 1 unchanged. Paths 2–3 let ops admin without a separate env —
     // possession of deviceSecret / botSecret is already proof of ownership.
     // When multi-tenant launches, gate 2–3 on a specific ADMIN_DEVICE_ID env.
-    const safeEqual = require('./safe-equal');
+    // (safeEqual already required at the top of arenaFactory for the
+    // /leaderboard entity binding path; reuse the same import.)
 
     function checkAdminAuth(req) {
         const body = req.body || {};
@@ -2027,6 +2131,7 @@ module.exports = function arenaFactory({ serverLog, io, devices } = {}) {
 module.exports.TEST_TYPES = TEST_TYPES;
 module.exports.MAX_TOTAL_SCORE = MAX_TOTAL_SCORE;
 module.exports.mapArenaResultToCapabilities = mapArenaResultToCapabilities;
+module.exports.buildInterviewIdentityPatch = buildInterviewIdentityPatch;
 module.exports.ARENA_PASS_THRESHOLD = ARENA_PASS_THRESHOLD;
 module.exports.ARENA_TO_CAPABILITY_MAP = ARENA_TO_CAPABILITY_MAP;
 module.exports.SCORING_ENGINES = SCORING_ENGINES;

--- a/backend/public/arena/exam.html
+++ b/backend/public/arena/exam.html
@@ -930,7 +930,27 @@
             const btn = document.getElementById('nameSubmitBtn'); btn.disabled = true;
             try {
                 await fetch(`${API}/api/arena/exam/${EXAM_ID}/finalize`, { method: 'POST' });
-                const r = await (await fetch(`${API}/api/arena/leaderboard`, { method: 'POST', headers: {'Content-Type':'application/json'}, body: JSON.stringify({ examId: EXAM_ID, name }) })).json();
+                // Entity binding (card_ad404375) — if this browser has a
+                // bound entity in localStorage, attach botSecret so the
+                // backend records the verified score on the bot's identity
+                // (namecard + plaza chip). Falls back to anonymous submit
+                // if any credential is missing.
+                let binding = {};
+                try {
+                    const dId = localStorage.getItem('deviceId');
+                    const dSec = localStorage.getItem('deviceSecret');
+                    if (dId && dSec) {
+                        const er = await fetch(`${API}/api/entities?deviceId=${encodeURIComponent(dId)}&deviceSecret=${encodeURIComponent(dSec)}`);
+                        if (er.ok) {
+                            const ed = await er.json();
+                            const bound = (ed.entities || []).find(e => e && e.isBound && e.botSecret);
+                            if (bound && Number.isFinite(Number(bound.entityId))) {
+                                binding = { deviceId: dId, entityId: Number(bound.entityId), botSecret: bound.botSecret };
+                            }
+                        }
+                    }
+                } catch (_) { /* private browsing or quota — leave anon */ }
+                const r = await (await fetch(`${API}/api/arena/leaderboard`, { method: 'POST', headers: {'Content-Type':'application/json'}, body: JSON.stringify(Object.assign({ examId: EXAM_ID, name }, binding)) })).json();
                 if (r.leaderboardId) myLeaderboardId = r.leaderboardId;
                 // Hide floating prompt
                 dismissModal();

--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -1228,6 +1228,14 @@
                     caps: (r.capabilities || []).map(c => c.name || c.id || c),
                     stars: r.avgRating || 0, reviews: r.messageCount || 0,
                     level: r.level || 1, xp: r.xp || 0,
+                    // Arena verified score (card_ad404375). Number fields only —
+                    // server enrichment never lets these leak strings/HTML, so
+                    // they're safe to interpolate directly in number contexts.
+                    arenaScore: (typeof r.arenaScore === 'number') ? r.arenaScore : null,
+                    arenaMaxScore: (typeof r.arenaMaxScore === 'number') ? r.arenaMaxScore : null,
+                    arenaNormalized: (typeof r.arenaNormalized === 'number') ? r.arenaNormalized : null,
+                    arenaPassed: (typeof r.arenaPassed === 'boolean') ? r.arenaPassed : null,
+                    lastInterviewAt: (typeof r.lastInterviewAt === 'number') ? r.lastInterviewAt : null,
                     isRental: false
                 }));
             }
@@ -1301,13 +1309,30 @@
         grid.innerHTML = bots.map(bot => bot.isRental ? renderRentalCard(bot) : renderCommunityCard(bot)).join('');
     }
     function renderCommunityCard(bot) {
+        // Arena verified score chip (card_ad404375). Number-only fields, so
+        // safe to interpolate. Color tier: pass=green, attempt=amber.
+        let arenaChip = '';
+        if (typeof bot.arenaScore === 'number' && typeof bot.arenaMaxScore === 'number' && bot.arenaMaxScore > 0) {
+            const pct = (typeof bot.arenaNormalized === 'number') ? bot.arenaNormalized : Math.round((bot.arenaScore / bot.arenaMaxScore) * 100);
+            const pass = bot.arenaPassed === true;
+            const bg = pass ? 'rgba(16,185,129,0.15)' : 'rgba(245,158,11,0.12)';
+            const fg = pass ? '#10b981' : '#f59e0b';
+            const bd = pass ? 'rgba(16,185,129,0.3)' : 'rgba(245,158,11,0.3)';
+            const ariaLabel = (pass ? 'Arena verified passed' : 'Arena verified attempt')
+                + ' ' + bot.arenaScore + ' of ' + bot.arenaMaxScore + ', ' + pct + ' percent';
+            arenaChip = `<span class="bot-card-arena-chip" aria-label="${ariaLabel}" `
+                + `style="display:inline-flex;align-items:center;gap:4px;padding:2px 8px;border-radius:10px;`
+                + `background:${bg};color:${fg};border:1px solid ${bd};font-size:10px;font-weight:600;margin-left:6px;">`
+                + (pass ? '✓ ' : '• ') + 'Arena ' + bot.arenaScore + '/' + bot.arenaMaxScore + ' (' + pct + '%)'
+                + `</span>`;
+        }
         return `<div class="bot-card" onclick="openDetail('${bot.publicCode}')">
             <span class="bot-card-level ${lvClass(bot.level)}">Lv.${bot.level}</span>
             <div class="bot-card-header">
                 <div class="bot-card-avatar">
                     ${botAvatarHtml(bot.avatar, 56)}
                 </div>
-                <div class="bot-card-info"><div class="bot-card-name">${esc(bot.name)}</div></div>
+                <div class="bot-card-info"><div class="bot-card-name">${esc(bot.name)}${arenaChip}</div></div>
             </div>
             <div class="bot-card-desc">${esc(bot.desc)}</div>
             <div class="bot-card-footer">
@@ -1393,6 +1418,35 @@
             const tags = bot.agentCard?.tags || [];
             const desc = bot.agentCard?.description || '';
 
+            // Arena verified score line (card_ad404375). Falls back to a
+            // ? icon empty state so plaza viewers can see how the score is
+            // earned (Globe-user setup-clarity rule).
+            const hasArena = typeof bot.arenaScore === 'number'
+                && typeof bot.arenaMaxScore === 'number' && bot.arenaMaxScore > 0;
+            let arenaLine;
+            if (hasArena) {
+                const pct = (typeof bot.arenaNormalized === 'number') ? bot.arenaNormalized : Math.round((bot.arenaScore / bot.arenaMaxScore) * 100);
+                const pass = bot.arenaPassed === true;
+                const tone = pass ? '#10b981' : '#f59e0b';
+                let when = '';
+                if (typeof bot.lastInterviewAt === 'number') {
+                    try { when = ' • ' + new Date(bot.lastInterviewAt).toISOString().slice(0, 10); } catch (_) {}
+                }
+                arenaLine = `<div class="detail-arena" role="status" aria-label="Arena verified score ${bot.arenaScore} of ${bot.arenaMaxScore}, ${pct} percent"
+                    style="margin:8px auto 0;padding:6px 12px;border-radius:14px;background:rgba(16,185,129,0.10);color:${tone};border:1px solid ${tone}33;font-size:13px;font-weight:600;display:inline-flex;gap:6px;">
+                    ${pass ? '✓' : '•'} Arena ${bot.arenaScore}/${bot.arenaMaxScore} (${pct}%)<span style="font-weight:400;color:var(--text-secondary);">${when}</span>
+                </div>`;
+            } else {
+                arenaLine = `<div class="detail-arena-empty" style="margin:8px auto 0;font-size:12px;color:var(--text-secondary);">
+                    尚未面試 / No Arena interview yet
+                    <span class="detail-arena-help" tabindex="0" role="button"
+                        aria-label="How a verified Arena score works"
+                        onclick="event.stopPropagation();window.__plazaArenaHelp(this)"
+                        onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();event.stopPropagation();window.__plazaArenaHelp(this);}"
+                        style="cursor:help;display:inline-block;border:1px solid var(--card-border);border-radius:50%;width:16px;height:16px;line-height:14px;text-align:center;margin-left:4px;font-size:10px;">?</span>
+                </div>`;
+            }
+
             content.innerHTML = `
                 <button class="modal-close" onclick="closeDetail()">✕</button>
                 <div class="detail-header">
@@ -1400,6 +1454,7 @@
                     <div class="detail-name">${esc(bot.name)}</div>
                     <div class="detail-code" onclick="navigator.clipboard.writeText('${bot.publicCode}')" title="Copy">${bot.publicCode}</div>
                     <div class="detail-desc">${esc(desc)}</div>
+                    ${arenaLine}
                     <div class="detail-level-xp">
                         <span>🏆 Lv.${bot.level||1}</span>
                         <span>⚡ ${(bot.xp||0).toLocaleString()} XP</span>
@@ -1694,6 +1749,49 @@
     /* ══════ Utilities ══════ */
     function esc(s) { const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
     function lvClass(lv) { return lv >= 15 ? 'lv-legend' : lv >= 10 ? 'lv-elite' : lv >= 7 ? 'lv-high' : lv >= 4 ? 'lv-mid' : 'lv-low'; }
+
+    // Arena ? icon help popover for the plaza detail's empty state
+    // (card_ad404375). Tells viewers HOW a verified score is earned.
+    // Keyboard-dismissible (Escape) + click-outside-dismissible — same UX
+    // as the namecard editor's popover.
+    window.__plazaArenaHelp = function(anchor) {
+        const msg = 'The verified score is recorded after the bot completes an Arena interview.\n\nHow it appears here:\n1. Owner runs an Arena interview from their dashboard\n2. Bot runs 12 challenges (≤3 min)\n3. Score binds to the bot identity and shows on this plaza tile';
+        try {
+            const existing = document.querySelector('.plaza-arena-help-popover');
+            if (existing) existing.remove();
+            const pop = document.createElement('div');
+            pop.className = 'plaza-arena-help-popover';
+            pop.setAttribute('role', 'tooltip');
+            pop.style.cssText = 'position:absolute;z-index:99999;max-width:280px;background:var(--card-bg,#1e1e2e);color:var(--text-primary,#fff);border:1px solid var(--card-border,#333);padding:10px 12px;border-radius:8px;font-size:12px;line-height:1.5;white-space:pre-line;box-shadow:0 4px 12px rgba(0,0,0,0.3);';
+            pop.textContent = msg;
+            const r = anchor.getBoundingClientRect();
+            pop.style.left = (window.scrollX + r.left) + 'px';
+            pop.style.top = (window.scrollY + r.bottom + 6) + 'px';
+            document.body.appendChild(pop);
+            const cleanup = function() {
+                if (pop.parentNode) pop.remove();
+                document.removeEventListener('click', dismiss, true);
+                document.removeEventListener('keydown', onKey, true);
+                try { if (anchor && typeof anchor.focus === 'function') anchor.focus(); } catch (_) {}
+            };
+            const dismiss = function(ev) {
+                if (ev && pop.contains(ev.target)) return;
+                cleanup();
+            };
+            const onKey = function(ev) {
+                if (ev.key === 'Escape' || ev.key === 'Esc') {
+                    ev.preventDefault();
+                    cleanup();
+                }
+            };
+            setTimeout(function() {
+                document.addEventListener('click', dismiss, true);
+                document.addEventListener('keydown', onKey, true);
+            }, 0);
+        } catch (e) {
+            alert(msg);
+        }
+    };
 
     /* ══════ Init ══════ */
     let _st;

--- a/backend/public/portal/shared/agent-card-editor.js
+++ b/backend/public/portal/shared/agent-card-editor.js
@@ -69,7 +69,25 @@ window.AgentCardEditor = (function() {
             || ac.interviewCapabilities
             || (ac.capabilities && !Array.isArray(ac.capabilities) ? ac.capabilities : null);
 
+        // Arena verified-score binding (card_ad404375). interviewCapabilities
+        // here is the IDENTITY-level numeric score block written by the
+        // /api/arena/leaderboard POST entity-binding path — distinct from
+        // arenaCaps (which is the per-capability supported/unsupported map).
+        // Falls back to identity.lastInterviewAt when score is unset.
+        var arenaScore = (this.identity && this.identity.interviewCapabilities
+            && typeof this.identity.interviewCapabilities.score === 'number')
+            ? this.identity.interviewCapabilities
+            : null;
+
         container.innerHTML =
+            // ── Arena verified score (card_ad404375) ──
+            '<div class="ace-field" data-arena-score-section="1">' +
+                '<label>' + t('dash_arena_score', 'Arena Verified Score') +
+                ' <span class="ace-help-tip" data-arena-help="1" tabindex="0" role="button" aria-label="' +
+                    esc(t('dash_arena_score_help_aria', 'How to get a verified Arena score')) + '" ' +
+                    'style="cursor:help;font-size:11px;color:var(--text-secondary);border:1px solid var(--card-border);border-radius:50%;padding:0 5px;margin-left:4px;">?</span></label>' +
+                '<div class="ace-arena-score" id="aceArenaScore' + uid + '" aria-live="polite"></div>' +
+            '</div>' +
             // ── Capabilities (read-only Arena badges) ──
             '<div class="ace-field">' +
                 '<label>' + t('dash_capabilities', 'Capabilities') +
@@ -117,6 +135,21 @@ window.AgentCardEditor = (function() {
             '</div>';
 
         this._uid = uid;
+
+        // Render Arena verified score badge (card_ad404375)
+        this._renderArenaScore(arenaScore);
+
+        // Wire ? icon help tooltip — click/hover/focus reveals what + needs +
+        // concrete next step (Globe-user setup-conditions UX rule).
+        var helpTip = container.querySelector('.ace-help-tip[data-arena-help="1"]');
+        if (helpTip) {
+            var self2 = this;
+            var helpToggle = function() { self2._showArenaScoreHelp(helpTip); };
+            helpTip.addEventListener('click', helpToggle);
+            helpTip.addEventListener('keydown', function(e) {
+                if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); helpToggle(); }
+            });
+        }
 
         // Render Arena capability badges
         this._renderCaps(arenaCaps);
@@ -168,6 +201,111 @@ window.AgentCardEditor = (function() {
             badge.textContent = (supported ? '✅ ' : '❌ ') + key + pctStr;
             container.appendChild(badge);
         });
+    };
+
+    /**
+     * Render the Arena verified numeric score on the namecard.
+     * Empty state shows a "尚未面試 / No interview yet" placeholder with
+     * a `?` icon explaining how to get a score (Globe-user setup UX rule).
+     */
+    AgentCardEditor.prototype._renderArenaScore = function(score) {
+        var container = document.getElementById('aceArenaScore' + this._uid);
+        if (!container) return;
+        container.innerHTML = '';
+        if (!score || typeof score.score !== 'number' || typeof score.maxScore !== 'number' || score.maxScore <= 0) {
+            // Empty state — no interview recorded yet.
+            var empty = document.createElement('div');
+            empty.style.cssText = 'font-size:12px;color:var(--text-secondary);padding:8px 0;';
+            empty.textContent = t('dash_arena_score_empty', '尚未面試 — 點擊「Run Interview」開始驗證 / No interview yet — click Run Interview to start');
+            container.appendChild(empty);
+            return;
+        }
+        var pct = (typeof score.normalized === 'number')
+            ? score.normalized
+            : Math.round((score.score / score.maxScore) * 100);
+        var passed = !!score.passed;
+        var badge = document.createElement('div');
+        badge.style.cssText = 'display:inline-flex;align-items:center;gap:8px;padding:6px 12px;border-radius:14px;font-size:13px;font-weight:600;' +
+            (passed
+                ? 'background:rgba(16,185,129,0.15);color:#10b981;border:1px solid rgba(16,185,129,0.3);'
+                : 'background:rgba(245,158,11,0.12);color:#f59e0b;border:1px solid rgba(245,158,11,0.3);');
+        // Use textContent to keep score data XSS-safe. Owner-controlled strings
+        // (model) are escaped via esc() before going into HTML; numeric fields
+        // come from server enrichment and are always Number-coerced upstream.
+        badge.setAttribute('aria-label',
+            (passed ? t('dash_arena_score_passed_aria', 'Arena verified: passed') : t('dash_arena_score_attempt_aria', 'Arena verified: attempt')) +
+            ' ' + score.score + ' / ' + score.maxScore + ' (' + pct + '%)');
+        badge.textContent = (passed ? '✓ ' : '• ') +
+            t('dash_arena_score_label', 'Arena') + ' ' +
+            score.score + '/' + score.maxScore + ' (' + pct + '%)';
+        container.appendChild(badge);
+
+        // Sub-line: model + completedAt
+        if (score.completedAt) {
+            var date = new Date(score.completedAt);
+            var sub = document.createElement('div');
+            sub.style.cssText = 'font-size:11px;color:var(--text-secondary);margin-top:4px;';
+            var dateStr;
+            try { dateStr = date.toISOString().slice(0, 10); } catch (e) { dateStr = ''; }
+            var modelPart = score.model ? (' • ' + esc(String(score.model).slice(0, 32))) : '';
+            sub.innerHTML = (passed
+                ? t('dash_arena_score_passed', 'Passed')
+                : t('dash_arena_score_attempt', 'Attempt')) +
+                ' ' + dateStr + modelPart;
+            container.appendChild(sub);
+        }
+    };
+
+    /**
+     * Show the ? icon help — fires inline popover or alert as fallback.
+     * Spec content: what (verified score) + needs (run an Arena exam) +
+     * concrete next step (click Run Interview). Globe-user copy.
+     */
+    AgentCardEditor.prototype._showArenaScoreHelp = function(anchor) {
+        var msg = t('dash_arena_score_help_body',
+            'The verified score is recorded after your bot completes an Arena interview.\n\nTo get a score:\n1. Click "Run Interview" above\n2. Your bot runs 12 challenges (≤3 min)\n3. Score binds to this namecard and appears on the plaza');
+        // Lightweight popover: append a tooltip div next to the anchor that
+        // auto-dismisses on outside click. Falls back to alert() if DOM is
+        // weird (e.g. anchor detached).
+        try {
+            var existing = document.querySelector('.ace-help-popover');
+            if (existing) existing.remove();
+            var pop = document.createElement('div');
+            pop.className = 'ace-help-popover';
+            pop.setAttribute('role', 'tooltip');
+            pop.style.cssText = 'position:absolute;z-index:9999;max-width:280px;background:var(--card-bg,#1e1e2e);color:var(--text-primary,#fff);border:1px solid var(--card-border,#333);padding:10px 12px;border-radius:8px;font-size:12px;line-height:1.5;white-space:pre-line;box-shadow:0 4px 12px rgba(0,0,0,0.3);';
+            pop.textContent = msg;
+            // Position relative to anchor
+            var r = anchor.getBoundingClientRect();
+            pop.style.left = (window.scrollX + r.left) + 'px';
+            pop.style.top = (window.scrollY + r.bottom + 6) + 'px';
+            document.body.appendChild(pop);
+            var cleanup = function() {
+                if (pop && pop.parentNode) pop.remove();
+                document.removeEventListener('click', dismiss, true);
+                document.removeEventListener('keydown', onKey, true);
+                // Restore focus to the trigger so keyboard users don't lose place.
+                try { if (anchor && typeof anchor.focus === 'function') anchor.focus(); } catch (_) {}
+            };
+            var dismiss = function(ev) {
+                if (ev && pop.contains(ev.target)) return;
+                cleanup();
+            };
+            // Escape-key dismiss for keyboard-only users (a11y).
+            var onKey = function(ev) {
+                if (ev.key === 'Escape' || ev.key === 'Esc') {
+                    ev.preventDefault();
+                    cleanup();
+                }
+            };
+            // Defer so the click that opened the tip doesn't close it
+            setTimeout(function() {
+                document.addEventListener('click', dismiss, true);
+                document.addEventListener('keydown', onKey, true);
+            }, 0);
+        } catch (e) {
+            alert(msg);
+        }
     };
 
     AgentCardEditor.prototype._renderTags = function(containerId, tags) {

--- a/backend/tests/jest/arena-entity-binding.test.js
+++ b/backend/tests/jest/arena-entity-binding.test.js
@@ -1,0 +1,177 @@
+/**
+ * Arena → entity binding (card_ad404375).
+ *
+ * Pure-function tests for buildInterviewIdentityPatch +
+ * extractArenaFieldsFromIdentity. The route-level glue itself is
+ * exercised indirectly here (these are the only branches that touch
+ * persistence-shaped data).
+ *
+ * Why pure-function only: the existing interview-arena.test.js exercises
+ * the full pg-mock harness for the exam lifecycle — duplicating it for
+ * the binding leg adds noise without strengthening the contract. The
+ * binding behavior reduces cleanly to "given an exam + mapped result,
+ * what writes back to identity?", which is a pure function.
+ */
+
+// db.js eagerly creates a pg Pool at require-time. Stub it out so the
+// test file doesn't try to open a connection.
+jest.mock('pg', () => ({ Pool: jest.fn(() => ({ query: jest.fn(), connect: jest.fn() })) }));
+
+const { buildInterviewIdentityPatch } = require('../../interview-arena');
+const { extractArenaFieldsFromIdentity } = require('../../db');
+
+describe('buildInterviewIdentityPatch', () => {
+    const validExam = {
+        id: 'exam-abc',
+        model: 'claude-opus-4',
+        total_score: 91,
+        max_score: 147,
+        completed_at: new Date('2026-06-13T12:00:00Z'),
+    };
+    const validMapped = { passed: true, normalizedScore: 62 };
+
+    test('returns null for missing exam', () => {
+        expect(buildInterviewIdentityPatch(null, validMapped)).toBeNull();
+    });
+
+    test('returns null for missing mapped result', () => {
+        expect(buildInterviewIdentityPatch(validExam, null)).toBeNull();
+    });
+
+    test('writes verified score for happy-path exam', () => {
+        const patch = buildInterviewIdentityPatch(validExam, validMapped, 1700000000000);
+        expect(patch).not.toBeNull();
+        expect(patch.interviewCapabilities).toMatchObject({
+            score: 91,
+            maxScore: 147,
+            passed: true,
+            model: 'claude-opus-4',
+            examId: 'exam-abc',
+            source: 'arena',
+        });
+        // normalized = round(91 / 147 * 100) = 62
+        expect(patch.interviewCapabilities.normalized).toBe(62);
+        expect(patch.lastInterviewAt).toBe(1700000000000);
+    });
+
+    test('clamps negative server-side total_score to 0', () => {
+        const patch = buildInterviewIdentityPatch({ ...validExam, total_score: -5 }, validMapped);
+        expect(patch.interviewCapabilities.score).toBe(0);
+        expect(patch.interviewCapabilities.normalized).toBe(0);
+    });
+
+    test('clamps total_score > max_score down to max_score', () => {
+        const patch = buildInterviewIdentityPatch({ ...validExam, total_score: 999 }, validMapped);
+        expect(patch.interviewCapabilities.score).toBe(147);
+        expect(patch.interviewCapabilities.normalized).toBe(100);
+    });
+
+    test('rejects non-numeric total_score', () => {
+        expect(buildInterviewIdentityPatch({ ...validExam, total_score: 'NaN' }, validMapped)).toBeNull();
+    });
+
+    test('rejects zero or negative max_score', () => {
+        expect(buildInterviewIdentityPatch({ ...validExam, max_score: 0 }, validMapped)).toBeNull();
+        expect(buildInterviewIdentityPatch({ ...validExam, max_score: -10 }, validMapped)).toBeNull();
+    });
+
+    test('passed flag follows mapped.passed (not the score itself)', () => {
+        const failed = buildInterviewIdentityPatch(validExam, { passed: false });
+        expect(failed.interviewCapabilities.passed).toBe(false);
+    });
+
+    test('falls back to nowMs when completed_at missing', () => {
+        const patch = buildInterviewIdentityPatch({ ...validExam, completed_at: null }, validMapped, 1234567);
+        expect(patch.interviewCapabilities.completedAt).toBe(1234567);
+        expect(patch.lastInterviewAt).toBe(1234567);
+    });
+
+    test('latest-wins: rerunning yields a fresh patch (overwrites prior)', () => {
+        const first = buildInterviewIdentityPatch(validExam, validMapped, 1000);
+        const second = buildInterviewIdentityPatch(
+            { ...validExam, total_score: 120, completed_at: new Date('2026-06-14T12:00:00Z') },
+            { passed: true },
+            2000
+        );
+        expect(second.interviewCapabilities.score).toBe(120);
+        expect(second.lastInterviewAt).toBeGreaterThan(first.lastInterviewAt);
+    });
+
+    test('model is optional — null when missing', () => {
+        const patch = buildInterviewIdentityPatch({ ...validExam, model: undefined }, validMapped);
+        expect(patch.interviewCapabilities.model).toBeNull();
+    });
+});
+
+describe('extractArenaFieldsFromIdentity', () => {
+    test('returns null fields when identity is null/undefined', () => {
+        expect(extractArenaFieldsFromIdentity(null)).toEqual({
+            arenaScore: null, arenaMaxScore: null, arenaNormalized: null,
+            arenaPassed: null, lastInterviewAt: null,
+        });
+        expect(extractArenaFieldsFromIdentity(undefined).arenaScore).toBeNull();
+    });
+
+    test('returns null fields when identity has no interviewCapabilities', () => {
+        const out = extractArenaFieldsFromIdentity({ public: { description: 'hi' } });
+        expect(out.arenaScore).toBeNull();
+        expect(out.arenaPassed).toBeNull();
+    });
+
+    test('preserves lastInterviewAt even when interviewCapabilities missing', () => {
+        const out = extractArenaFieldsFromIdentity({ lastInterviewAt: 1700000000000 });
+        expect(out.lastInterviewAt).toBe(1700000000000);
+        expect(out.arenaScore).toBeNull();
+    });
+
+    test('extracts full happy-path block', () => {
+        const out = extractArenaFieldsFromIdentity({
+            interviewCapabilities: {
+                score: 91, maxScore: 147, normalized: 62, passed: true,
+                completedAt: 1700000000000,
+            },
+            lastInterviewAt: 1700000000000,
+        });
+        expect(out).toEqual({
+            arenaScore: 91, arenaMaxScore: 147, arenaNormalized: 62,
+            arenaPassed: true, lastInterviewAt: 1700000000000,
+        });
+    });
+
+    test('drops non-numeric score (defense-in-depth)', () => {
+        const out = extractArenaFieldsFromIdentity({
+            interviewCapabilities: { score: 'not a number', maxScore: 147 },
+        });
+        expect(out.arenaScore).toBeNull();
+        expect(out.arenaMaxScore).toBe(147);
+    });
+
+    test('passed must be strict boolean — string "true" rejected', () => {
+        const out = extractArenaFieldsFromIdentity({
+            interviewCapabilities: { score: 91, maxScore: 147, passed: 'true' },
+        });
+        expect(out.arenaPassed).toBeNull();
+    });
+
+    test('falls back to identity.lastInterviewAt when ic.completedAt missing', () => {
+        const out = extractArenaFieldsFromIdentity({
+            interviewCapabilities: { score: 91, maxScore: 147 },
+            lastInterviewAt: 1700000999999,
+        });
+        expect(out.lastInterviewAt).toBe(1700000999999);
+    });
+});
+
+describe('binding integrity: identity patch never leaks secrets', () => {
+    test('patch keys are score-shaped only — no botSecret/deviceSecret/identity-internal', () => {
+        const patch = buildInterviewIdentityPatch(
+            { id: 'e', model: 'm', total_score: 50, max_score: 100, completed_at: new Date() },
+            { passed: true }
+        );
+        const allowedTop = ['interviewCapabilities', 'lastInterviewAt'];
+        expect(Object.keys(patch).sort()).toEqual(allowedTop.sort());
+        const ic = patch.interviewCapabilities;
+        const allowedIc = ['score', 'maxScore', 'normalized', 'passed', 'model', 'examId', 'completedAt', 'source'].sort();
+        expect(Object.keys(ic).sort()).toEqual(allowedIc);
+    });
+});


### PR DESCRIPTION
## Summary
- POST `/api/arena/leaderboard` now optionally accepts `{deviceId, entityId, botSecret}` and writes the verified score to `entity.identity.interviewCapabilities` + `lastInterviewAt`. Anonymous submissions still work.
- Plaza (`/api/community/search`, `/list`, `/card/:code`) surfaces `arenaScore/arenaMaxScore/arenaNormalized/arenaPassed/lastInterviewAt`, with a new `minArenaScore` filter and `sort=arena_score` option.
- Namecard editor + plaza grid + bot-detail modal render the score, with a ? icon empty-state popover that explains how to earn one (Globe-user setup-conditions UX rule).

## Why
`backend/public/portal/info.html:3576` documented the gap: 'Integration with EClawbot's entity system (via botSecret) is planned for verified scores'. Arena LB was IP-tracked anonymous — bots' namecards never reflected their verified score. `agent-card-editor.js:68` had already pre-wired the `this.identity.interviewCapabilities` read-point; the server side was the missing half.

## Implementation
- **Pure helpers (testable)** — `buildInterviewIdentityPatch(exam, mapped)` in `interview-arena.js` and `extractArenaFieldsFromIdentity(identity)` in `db.js`. Both exported for unit tests.
- **Route glue** — POST `/leaderboard` looks up the entity by `(deviceId, entityId, botSecret)` via `safeEqual`. On match it writes through the patch and fire-and-forget calls `db.saveDeviceData` (same pattern as identity PATCH). Failures here log a warning but never fail the public LB submit (anonymous flow stays alive).
- **DB enrichment** — `searchPublicCards` + `getPublicCardDetail` now SELECT `e.identity` and map a fixed allow-list of arena fields. `is_public = true` predicate unchanged, so no privacy regression.
- **UI** — namecard editor renders a verified-score badge above the existing capability badges; community grid puts a `[score/total]` chip next to the bot name; bot-detail modal shows the score + completedAt date. Empty state in both surfaces gets a `?` icon popover with keyboard dismiss.
- **Arena exam page** — `submitName()` auto-attaches binding params when a bound entity is found via `/api/entities`. Anonymous flow unchanged.

## Tests
- **New (`backend/tests/jest/arena-entity-binding.test.js`)** — 19 pure-function tests covering happy path, clamps (negative / overshoot), NaN/zero-max rejection, passed-boolean integrity, latest-wins on rerun, identity-internal leak guard. All passing.
- **Full Jest suite** — 319 suites, **4409 passed**, 17 skipped, **0 regressions**.
- **ESLint** — 0 errors, only pre-existing unrelated warnings.

## Sub-Agent adversarial review
Spawned a general-purpose sub-agent to review privacy/exfil, identity-bleed, race, schema, plaza pagination, XSS, a11y, and mobile 390x844. Result: **no privacy/exfil/identity-bleed/XSS/schema concerns**. Two a11y findings flagged and fixed in this same PR:
1. Namecard ? popover lacked Escape-key dismiss → added with focus-restore.
2. Plaza `?` icon advertised `role=button` without an activation handler → wired to a real click/keydown popover (`window.__plazaArenaHelp`).

## Globe-user
Works for every entity worldwide. No tenant carveouts. Score is locale-independent (numeric ratio); copy goes through the existing `i18n.t()` pipeline. Anonymous Arena submissions still work for users without an EClaw entity.

## Setup conditions
To populate the verified score, the bot owner must (1) have a bound entity on a registered device, (2) run an Arena exam from the dashboard, (3) submit the leaderboard form while their session has `deviceId` + `deviceSecret` in localStorage (the default state for portal users). Anonymous Arena submissions just don't bind to a namecard.

## Empty-state ? icon UX
Both the namecard editor and the plaza detail show a `尚未面試 / No Arena interview yet` placeholder + a `?` icon. Click/keyboard-enter reveals a popover that spells out **what** (verified score) + **needs** (run an Arena exam) + **concrete next step** (click Run Interview). Escape or click-outside dismisses; focus returns to the trigger.

## Out of scope
- Card retest countdown (card_959b58d0)
- Leaderboard avatar swap (card_718b23dc)
- Leaderboard mobile layout (card_b97f6afa)
- Namecard publish toggle UX (card_36ae7465)

## Test plan
- [x] Pure-function unit tests pass (19/19)
- [x] Full Jest suite pass (4409/4409)
- [x] ESLint clean
- [x] Adversarial sub-agent review applied
- [ ] Post-merge: production E2E — submit exam as bound entity → name appears on leaderboard with bot's name → reload dashboard → verified score visible on namecard → visit `/portal/community.html` → chip visible on bot tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)