### PR TITLE
feat(notify): rich-card UX question triggers APP+Web push + setting toggle (card_a9e)

### DIFF
--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -106,7 +106,7 @@ function shouldSuppressA2A(reqBody, message) {
         || isOperationalChannelMessage(message);
 }
 
-function channelApiModule(devices, { authMiddleware, serverLog, generateBotSecret, generatePublicCode, publicCodeIndex, saveChatMessage, io, saveData, createDefaultEntity, apiBase, awardEntityXP, XP_AMOUNTS, notifyDevice, deliverToEntity, gatekeeperCheckText, resolveSpeakToTarget, checkBotToBotRateLimit, checkCrossSpeakRateLimit, crossDeviceSettings, devicePrefs, recentBroadcasts: _recentBroadcasts, BOT2BOT_MAX_MESSAGES: _BOT2BOT_MAX_MESSAGES, db: dbRef, getMissionApiHints, buildIdentitySetupHint, buildBroadcastRecipientBlock, chatPool }) {
+function channelApiModule(devices, { authMiddleware, serverLog, generateBotSecret, generatePublicCode, publicCodeIndex, saveChatMessage, io, saveData, createDefaultEntity, apiBase, awardEntityXP, XP_AMOUNTS, notifyDevice, notifyRichCardQuestion, deliverToEntity, gatekeeperCheckText, resolveSpeakToTarget, checkBotToBotRateLimit, checkCrossSpeakRateLimit, crossDeviceSettings, devicePrefs, recentBroadcasts: _recentBroadcasts, BOT2BOT_MAX_MESSAGES: _BOT2BOT_MAX_MESSAGES, db: dbRef, getMissionApiHints, buildIdentitySetupHint, buildBroadcastRecipientBlock, chatPool }) {
     const pushContextHelpers = { getMissionApiHints, buildIdentitySetupHint, buildBroadcastRecipientBlock };
     // Late-bound kanban auto-review hook (set after kanbanModule init)
     let kanbanAutoReview = null;
@@ -1015,6 +1015,18 @@ function channelApiModule(devices, { authMiddleware, serverLog, generateBotSecre
                                     card: validatedCard
                                 })
                             ));
+                            // Rich-card UX (card_a9e): broadcast carrying an
+                            // interactive question fires a single per-device
+                            // "needs your input" push to the broadcast target
+                            // device (rate-limited inside the helper).
+                            if (validatedCard && typeof notifyRichCardQuestion === 'function') {
+                                notifyRichCardQuestion(broadcastDeviceId, validatedCard, {
+                                    questionText: deliveryText,
+                                    fromName: entity.name || entity.publicCode || `Entity ${eId}`,
+                                    fromEntityId: eId,
+                                    toEntityId: targetIds[0] ?? null
+                                });
+                            }
                             deliveryResults = { broadcast: true, sentCount: results.length, targets: results };
                         }
                     }
@@ -1047,6 +1059,18 @@ function channelApiModule(devices, { authMiddleware, serverLog, generateBotSecre
                             text: deliveryText, expectsReply: true, isCrossDevice,
                             card: validatedCard
                         });
+                        // Rich-card UX (card_a9e): same shape as /api/transform
+                        // speakTo path — fire "needs your input" push to the
+                        // target device, gated by the rich_card_question
+                        // toggle and the in-process rate limiter.
+                        if (validatedCard && typeof notifyRichCardQuestion === 'function') {
+                            notifyRichCardQuestion(target.deviceId, validatedCard, {
+                                questionText: deliveryText,
+                                fromName: entity.name || entity.publicCode || `Entity ${eId}`,
+                                fromEntityId: eId,
+                                toEntityId: target.entityId
+                            });
+                        }
                         results.push({ publicCode: code, success: true, ...result });
                         deliverySaved = true;
                     }

--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -1025,7 +1025,7 @@ function channelApiModule(devices, { authMiddleware, serverLog, generateBotSecre
                                     fromName: entity.name || entity.publicCode || `Entity ${eId}`,
                                     fromEntityId: eId,
                                     toEntityId: targetIds[0] ?? null
-                                });
+                                }).catch(() => {});
                             }
                             deliveryResults = { broadcast: true, sentCount: results.length, targets: results };
                         }
@@ -1069,7 +1069,7 @@ function channelApiModule(devices, { authMiddleware, serverLog, generateBotSecre
                                 fromName: entity.name || entity.publicCode || `Entity ${eId}`,
                                 fromEntityId: eId,
                                 toEntityId: target.entityId
-                            });
+                            }).catch(() => {});
                         }
                         results.push({ publicCode: code, success: true, ...result });
                         deliverySaved = true;

--- a/backend/index.js
+++ b/backend/index.js
@@ -9779,6 +9779,20 @@ app.post('/api/transform', transformMaybeMultipart, idempotencyMiddleware, async
                             ));
 
                             console.log(`[Transform+Broadcast] Device ${deviceId} Entity ${eId} -> [${targetIds.join(',')}] on ${broadcastDeviceId}`);
+                            // Rich-card UX (card_a9e): if the broadcast carries
+                            // interactive buttons, the recipient device should get
+                            // a "needs your input" notification — broadcast routes
+                            // share one target device per loop iteration, so a
+                            // single notif covers all entities on that device
+                            // (the per-device rate-limiter further dedupes bursts).
+                            if (validatedCard) {
+                                notifyRichCardQuestion(broadcastDeviceId, validatedCard, {
+                                    questionText: deliveryText,
+                                    fromName: entity.name || entity.publicCode || `Entity ${eId}`,
+                                    fromEntityId: eId,
+                                    toEntityId: targetIds[0] ?? null
+                                });
+                            }
                             deliveryResults = { broadcast: true, sentCount: results.length, targets: results };
                         }
                     }
@@ -9884,6 +9898,20 @@ app.post('/api/transform', transformMaybeMultipart, idempotencyMiddleware, async
                     link: 'chat.html',
                     metadata: { fromEntityId: eId, toEntityId: target.entityId }
                 }).catch(() => {});
+
+                // Rich-card UX (card_a9e): agent attached interactive buttons
+                // asking the user to pick an option — fire a higher-priority
+                // "needs your input" notification gated by the rich_card_question
+                // toggle. Same delivery surface (Socket+Web Push+FCM), separate
+                // category so users can mute generic speak_to but keep these.
+                if (validatedCard) {
+                    notifyRichCardQuestion(target.deviceId, validatedCard, {
+                        questionText: deliveryText,
+                        fromName: entity.name || entity.publicCode || `Entity ${eId}`,
+                        fromEntityId: eId,
+                        toEntityId: target.entityId
+                    });
+                }
 
                 console.log(`[Transform+SpeakTo] ${deviceId}:${eId} -> ${target.deviceId}:${target.entityId} (${code})`);
                 results.push({
@@ -19837,6 +19865,7 @@ const channelModule = require('./channel-api')(devices, {
     awardEntityXP,
     XP_AMOUNTS,
     notifyDevice,
+    notifyRichCardQuestion,
     deliverToEntity,
     gatekeeperCheckText,
     resolveSpeakToTarget,
@@ -19902,6 +19931,36 @@ app.patch('/api/github/issues/:number', async (req, res) => {
 // ============================================
 // NOTIFICATION SYSTEM - Central dispatcher
 // ============================================
+
+// Rich-card-question dispatch helpers (card_a9edf960). Logic lives in
+// notifications.js so it's unit-testable in isolation; index.js owns the
+// per-process limiter instance + the wiring into notifyDevice.
+const richCardLimiter = notifModule.createRichCardNotifLimiter();
+
+/**
+ * Fire a "rich-card-question" notification to the recipient device. Use at
+ * delivery sites that pass a `validatedCard` so the user gets a "Claude-
+ * Code-style permission ask" push regardless of which generic category
+ * (speak_to / bot_reply / cross_speak) the underlying message used.
+ *
+ * Rules:
+ *  - Only fires when `card` is well-formed (ask_id + non-empty buttons).
+ *  - Gated by the per-user `rich_card_question` toggle (default ON; the
+ *    actual check happens inside notifyDevice via isCategoryEnabled).
+ *  - Per-device rate-limited (5/10s) to defang misbehaving-agent spam.
+ *  - Body is the message text excerpt (UTF-8 safe truncation at 100 bytes).
+ *
+ * @param {string} targetDeviceId
+ * @param {object} card - validated card { ask_id, buttons[] }
+ * @param {object} ctx  - { questionText, fromName, fromEntityId, toEntityId }
+ */
+function notifyRichCardQuestion(targetDeviceId, card, ctx) {
+    if (!targetDeviceId) return;
+    if (!notifModule.isRichCardQuestion(card)) return;
+    if (!richCardLimiter.check(targetDeviceId)) return;
+    const payload = notifModule.buildRichCardNotification(card, ctx || {});
+    notifyDevice(targetDeviceId, payload).catch(() => {});
+}
 
 /**
  * Central notification dispatcher.

--- a/backend/index.js
+++ b/backend/index.js
@@ -9791,7 +9791,7 @@ app.post('/api/transform', transformMaybeMultipart, idempotencyMiddleware, async
                                     fromName: entity.name || entity.publicCode || `Entity ${eId}`,
                                     fromEntityId: eId,
                                     toEntityId: targetIds[0] ?? null
-                                });
+                                }).catch(() => {});
                             }
                             deliveryResults = { broadcast: true, sentCount: results.length, targets: results };
                         }
@@ -9910,7 +9910,7 @@ app.post('/api/transform', transformMaybeMultipart, idempotencyMiddleware, async
                         fromName: entity.name || entity.publicCode || `Entity ${eId}`,
                         fromEntityId: eId,
                         toEntityId: target.entityId
-                    });
+                    }).catch(() => {});
                 }
 
                 console.log(`[Transform+SpeakTo] ${deviceId}:${eId} -> ${target.deviceId}:${target.entityId} (${code})`);
@@ -19945,19 +19945,33 @@ const richCardLimiter = notifModule.createRichCardNotifLimiter();
  *
  * Rules:
  *  - Only fires when `card` is well-formed (ask_id + non-empty buttons).
- *  - Gated by the per-user `rich_card_question` toggle (default ON; the
- *    actual check happens inside notifyDevice via isCategoryEnabled).
+ *  - Checks the per-user `rich_card_question` toggle BEFORE the limiter so
+ *    a muted user doesn't burn their 5/10s budget — otherwise re-enabling
+ *    mid-burst would silently drop the next 5 legitimate cards.
  *  - Per-device rate-limited (5/10s) to defang misbehaving-agent spam.
- *  - Body is the message text excerpt (UTF-8 safe truncation at 100 bytes).
+ *  - Per-ask-id deduped (60s TTL) so a re-emit of the same card doesn't
+ *    burn a slot.
+ *  - Body is the message text excerpt (UTF-8 safe, 240 byte cap).
  *
  * @param {string} targetDeviceId
  * @param {object} card - validated card { ask_id, buttons[] }
  * @param {object} ctx  - { questionText, fromName, fromEntityId, toEntityId }
  */
-function notifyRichCardQuestion(targetDeviceId, card, ctx) {
+async function notifyRichCardQuestion(targetDeviceId, card, ctx) {
     if (!targetDeviceId) return;
     if (!notifModule.isRichCardQuestion(card)) return;
-    if (!richCardLimiter.check(targetDeviceId)) return;
+    // Pref-gate FIRST (HIGH-1 from card_a9e adversarial review): muted users
+    // must not consume rate-limit budget. notifyDevice() also re-checks
+    // isCategoryEnabled internally, but we short-circuit here so the bucket
+    // increment + DB write + WS emit are all skipped uniformly.
+    try {
+        const prefs = await notifModule.getPrefs(targetDeviceId);
+        if (!notifModule.isCategoryEnabled(prefs, 'rich_card_question')) return;
+    } catch (_) {
+        // Fail-open: a transient DB blip should not silently swallow a
+        // permission-style ask the user is waiting on. Continue.
+    }
+    if (!richCardLimiter.check(targetDeviceId, card.ask_id)) return;
     const payload = notifModule.buildRichCardNotification(card, ctx || {});
     notifyDevice(targetDeviceId, payload).catch(() => {});
 }

--- a/backend/notifications.js
+++ b/backend/notifications.js
@@ -304,13 +304,45 @@ function truncateUtf8(str, maxBytes) {
  * @returns {{ check: function, _buckets: Map, _stop: function }}
  */
 function createRichCardNotifLimiter(opts = {}) {
-    const windowMs = Number.isFinite(opts.windowMs) ? opts.windowMs : 10_000;
-    const max = Number.isFinite(opts.max) ? opts.max : 5;
-    const buckets = new Map(); // deviceId -> { count, resetAt }
+    // Guard `>0` (not just `Number.isFinite`) so a caller passing windowMs:0
+    // or max:0 doesn't accidentally bypass rate-limiting entirely.
+    const windowMs = Number.isFinite(opts.windowMs) && opts.windowMs > 0 ? opts.windowMs : 10_000;
+    const max = Number.isFinite(opts.max) && opts.max > 0 ? opts.max : 5;
+    // Per-ask dedup TTL: a buggy agent that re-emits the same ask_id 5×
+    // (re-render, network retry) burns the whole bucket otherwise. Real
+    // Claude-Code-style permission asks dedupe by request id, so we keep
+    // a short LRU-ish window. Tests can override via opts.askDedupTtlMs.
+    const askDedupTtlMs = Number.isFinite(opts.askDedupTtlMs) && opts.askDedupTtlMs > 0 ? opts.askDedupTtlMs : 60_000;
 
-    function check(deviceId) {
+    const buckets = new Map(); // deviceId -> { count, resetAt }
+    const recentAsks = new Map(); // `${deviceId}|${askId}` -> expiresAt
+
+    /**
+     * Check whether a notification for (deviceId, askId?) should fire.
+     * Returns true → fire and bucket has been incremented.
+     * Returns false → either rate-limited or already-seen ask_id.
+     *
+     * The ask_id dedup short-circuits BEFORE the bucket increments so a
+     * re-emit of the same card doesn't burn the user's 5/10s budget.
+     */
+    function check(deviceId, askId) {
         if (!deviceId) return false;
         const now = Date.now();
+        // Per-ask dedup first — repeat of same card to same device is silent.
+        if (askId) {
+            const key = `${deviceId}|${askId}`;
+            const exp = recentAsks.get(key);
+            if (exp && exp > now) return false;
+            recentAsks.set(key, now + askDedupTtlMs);
+            // Opportunistic cleanup inline (cheap; map is small) so the dedup
+            // map can't grow unbounded between prune ticks under heavy load.
+            if (recentAsks.size > 5000) {
+                for (const [k, e] of recentAsks) {
+                    if (e <= now) recentAsks.delete(k);
+                    if (recentAsks.size <= 1000) break;
+                }
+            }
+        }
         const bucket = buckets.get(deviceId);
         if (!bucket || bucket.resetAt <= now) {
             buckets.set(deviceId, { count: 1, resetAt: now + windowMs });
@@ -321,14 +353,18 @@ function createRichCardNotifLimiter(opts = {}) {
         return true;
     }
 
-    // Opportunistic cleanup so the Map doesn't grow forever in long-running
+    // Opportunistic cleanup so the Maps don't grow forever in long-running
     // processes. Tests pass `disablePrune: true` to skip the timer.
     let pruneHandle = null;
     if (!opts.disablePrune) {
         pruneHandle = setInterval(() => {
-            const cutoff = Date.now() - 60_000;
+            const now = Date.now();
+            const cutoff = now - 60_000;
             for (const [k, v] of buckets) {
                 if (v.resetAt < cutoff) buckets.delete(k);
+            }
+            for (const [k, exp] of recentAsks) {
+                if (exp <= now) recentAsks.delete(k);
             }
         }, 5 * 60_000);
         if (typeof pruneHandle.unref === 'function') pruneHandle.unref();
@@ -337,9 +373,10 @@ function createRichCardNotifLimiter(opts = {}) {
     function _stop() {
         if (pruneHandle) clearInterval(pruneHandle);
         buckets.clear();
+        recentAsks.clear();
     }
 
-    return { check, _buckets: buckets, _stop };
+    return { check, _buckets: buckets, _recentAsks: recentAsks, _stop };
 }
 
 /**
@@ -374,7 +411,9 @@ function isRichCardQuestion(card) {
  * @param {object} card - validated card { ask_id, buttons[] }
  * @param {object} ctx
  * @param {string} [ctx.questionText] - the message text the agent attached
- *   the buttons to; truncated UTF-8-safe at 100 bytes for the notif body
+ *   the buttons to; truncated UTF-8-safe at 240 bytes for the notif body
+ *   (FCM/Web-Push payload-safe AND fits CJK/RTL where 100 bytes ≈ 33 Han or
+ *   25 Arabic chars — too tight for a real question)
  * @param {string} [ctx.fromName] - display name of the sending agent
  * @param {string} [ctx.titleSuffix='needs your input'] - locale-agnostic
  *   suffix appended to the title (locale-specific suffixes live in i18n.js
@@ -387,7 +426,10 @@ function buildRichCardNotification(card, ctx = {}) {
     const fromName = String(ctx.fromName || 'Agent');
     const titleSuffix = String(ctx.titleSuffix || 'needs your input');
     const title = `${fromName} ${titleSuffix}`;
-    const body = truncateUtf8(String(ctx.questionText || ''), 100);
+    // 240 bytes ≈ FCM/Web-Push payload-safe AND wide enough for ~80 Han or
+    // ~60 Arabic characters — 100 bytes (the legacy notif body cap) is too
+    // tight for localized questions.
+    const body = truncateUtf8(String(ctx.questionText || ''), 240);
     return {
         type: 'chat',
         category: 'rich_card_question',

--- a/backend/notifications.js
+++ b/backend/notifications.js
@@ -20,7 +20,15 @@ const DEFAULT_PREFS = {
     // can mute generic chat traffic but keep direct @-pings, or vice
     // versa. Default ON because being addressed by name is the highest-
     // signal notification we send.
-    user_mention: true
+    user_mention: true,
+    // rich_card_question: separate toggle for rich-card UX where an agent
+    // asks the user to pick an option (card_a9edf960). Hank's framing:
+    // "like Claude Code asking the user for permission" — these are
+    // blocking-style asks that demand a user action before the agent can
+    // proceed, so they need a higher-priority notification independent of
+    // generic bot replies / speak_to chatter. Default ON for the same
+    // reason as user_mention: the user is being explicitly addressed.
+    rich_card_question: true
 };
 
 let pool = null;
@@ -244,6 +252,158 @@ function isCategoryEnabled(prefs, category) {
 }
 
 // ============================================
+// Rich-card-question notification helpers
+// (card_a9edf960 — "Richard 跳出時觸發 APP + Web 通知")
+// ============================================
+
+/**
+ * Truncate a string to at most `maxBytes` UTF-8 bytes without splitting a
+ * multi-byte codepoint or a high/low surrogate pair. Notification bodies
+ * delivered to Web Push / FCM have hard payload limits and a half-truncated
+ * emoji renders as the replacement character on some platforms — we cut on
+ * a clean codepoint boundary so the body stays readable.
+ *
+ * @param {string} str
+ * @param {number} maxBytes
+ * @returns {string}
+ */
+function truncateUtf8(str, maxBytes) {
+    if (typeof str !== 'string') return '';
+    if (!Number.isFinite(maxBytes) || maxBytes <= 0) return '';
+    const buf = Buffer.from(str, 'utf8');
+    if (buf.length <= maxBytes) return str;
+    let end = maxBytes;
+    // Walk back to the first non-continuation byte (0x80..0xBF are continuation).
+    while (end > 0 && (buf[end] & 0xC0) === 0x80) end--;
+    let out = buf.slice(0, end).toString('utf8');
+    // Defensive: drop a trailing lone high surrogate that JS may have left
+    // dangling if the UTF-8 walk-back stopped right between surrogate halves.
+    if (out.length > 0) {
+        const lastCode = out.charCodeAt(out.length - 1);
+        if (lastCode >= 0xD800 && lastCode <= 0xDBFF) out = out.slice(0, -1);
+    }
+    return out;
+}
+
+/**
+ * Per-device rate limiter for rich-card-question notifications.
+ *
+ * An agent that fires 100 rich cards in a tight loop should NOT drum-roll
+ * the user's phone 100 times. We allow up to `max` pushes per `windowMs`
+ * per device; the underlying chat message rows + Socket.IO events still
+ * flow normally, only the *notification surface* (Web Push / FCM / DB row)
+ * is throttled.
+ *
+ * Factory returns { check(deviceId), _buckets, _stop() } so each call site
+ * (production: one shared instance; tests: fresh instances per test) has
+ * isolated state and we can clean up a setInterval handle in tests.
+ *
+ * @param {object} [opts]
+ * @param {number} [opts.windowMs=10000]
+ * @param {number} [opts.max=5]
+ * @returns {{ check: function, _buckets: Map, _stop: function }}
+ */
+function createRichCardNotifLimiter(opts = {}) {
+    const windowMs = Number.isFinite(opts.windowMs) ? opts.windowMs : 10_000;
+    const max = Number.isFinite(opts.max) ? opts.max : 5;
+    const buckets = new Map(); // deviceId -> { count, resetAt }
+
+    function check(deviceId) {
+        if (!deviceId) return false;
+        const now = Date.now();
+        const bucket = buckets.get(deviceId);
+        if (!bucket || bucket.resetAt <= now) {
+            buckets.set(deviceId, { count: 1, resetAt: now + windowMs });
+            return true;
+        }
+        if (bucket.count >= max) return false;
+        bucket.count++;
+        return true;
+    }
+
+    // Opportunistic cleanup so the Map doesn't grow forever in long-running
+    // processes. Tests pass `disablePrune: true` to skip the timer.
+    let pruneHandle = null;
+    if (!opts.disablePrune) {
+        pruneHandle = setInterval(() => {
+            const cutoff = Date.now() - 60_000;
+            for (const [k, v] of buckets) {
+                if (v.resetAt < cutoff) buckets.delete(k);
+            }
+        }, 5 * 60_000);
+        if (typeof pruneHandle.unref === 'function') pruneHandle.unref();
+    }
+
+    function _stop() {
+        if (pruneHandle) clearInterval(pruneHandle);
+        buckets.clear();
+    }
+
+    return { check, _buckets: buckets, _stop };
+}
+
+/**
+ * Decide whether a chat-message payload carries a rich-card question that
+ * needs the higher-priority notification.
+ *
+ * Returns true only when:
+ *  - card is a plain object (not null/array/string)
+ *  - card.ask_id is a non-empty string
+ *  - card.buttons is a non-empty array
+ *
+ * The caller is expected to have already validated/sanitized the card via
+ * the inbound /api/transform or /api/channel/message gate, so this is a
+ * cheap defensive check before firing the notification.
+ *
+ * @param {*} card
+ * @returns {boolean}
+ */
+function isRichCardQuestion(card) {
+    if (!card || typeof card !== 'object' || Array.isArray(card)) return false;
+    if (typeof card.ask_id !== 'string' || card.ask_id.length === 0) return false;
+    if (!Array.isArray(card.buttons) || card.buttons.length === 0) return false;
+    return true;
+}
+
+/**
+ * Build the notification payload (title/body/metadata) for a rich-card
+ * question. Pure — no side effects, no DB / WS / push. Callers handle the
+ * actual notifyDevice() dispatch so they can also handle rate-limiting and
+ * preference gates uniformly with the rest of the notification surface.
+ *
+ * @param {object} card - validated card { ask_id, buttons[] }
+ * @param {object} ctx
+ * @param {string} [ctx.questionText] - the message text the agent attached
+ *   the buttons to; truncated UTF-8-safe at 100 bytes for the notif body
+ * @param {string} [ctx.fromName] - display name of the sending agent
+ * @param {string} [ctx.titleSuffix='needs your input'] - locale-agnostic
+ *   suffix appended to the title (locale-specific suffixes live in i18n.js
+ *   for portal-side rendering of the in-app notification panel)
+ * @param {number|null} [ctx.fromEntityId]
+ * @param {number|null} [ctx.toEntityId]
+ * @returns {{type:string,category:string,title:string,body:string,link:string,metadata:object}}
+ */
+function buildRichCardNotification(card, ctx = {}) {
+    const fromName = String(ctx.fromName || 'Agent');
+    const titleSuffix = String(ctx.titleSuffix || 'needs your input');
+    const title = `${fromName} ${titleSuffix}`;
+    const body = truncateUtf8(String(ctx.questionText || ''), 100);
+    return {
+        type: 'chat',
+        category: 'rich_card_question',
+        title,
+        body,
+        link: 'chat.html',
+        metadata: {
+            ask_id: String(card.ask_id),
+            fromEntityId: ctx.fromEntityId ?? null,
+            toEntityId: ctx.toEntityId ?? null,
+            buttonCount: Array.isArray(card.buttons) ? card.buttons.length : 0
+        }
+    };
+}
+
+// ============================================
 // Push Subscriptions (Web Push)
 // ============================================
 
@@ -306,5 +466,10 @@ module.exports = {
     // Push subscriptions
     savePushSubscription,
     removePushSubscription,
-    getPushSubscriptions
+    getPushSubscriptions,
+    // Rich-card-question helpers (card_a9edf960)
+    truncateUtf8,
+    createRichCardNotifLimiter,
+    isRichCardQuestion,
+    buildRichCardNotification
 };

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -2555,7 +2555,15 @@
             { key: 'todo_done', i18n: 'notif_pref_todo', label: 'TODO completion' },
             { key: 'scheduled', i18n: 'notif_pref_scheduled', label: 'Scheduled messages' },
             { key: 'kanban_done', i18n: 'notif_pref_kanban_done', label: 'Kanban card done' },
-            { key: 'kanban_done_auto', i18n: 'notif_pref_kanban_done_auto', label: 'Kanban auto/cron card done' }
+            { key: 'kanban_done_auto', i18n: 'notif_pref_kanban_done_auto', label: 'Kanban auto/cron card done' },
+            // Rich-card "needs your input" pushes (card_a9edf960). Fires when
+            // an agent attaches interactive buttons asking the user to pick
+            // an option — same UX shape as Claude Code's permission prompts.
+            // Default ON; users can mute generic bot chatter but still hear
+            // about questions that need their action. The ? icon explains the
+            // empty-state: if no bot is sending rich cards, no notifications
+            // arrive even when ON.
+            { key: 'rich_card_question', i18n: 'notif_pref_rich_card', label: 'Rich-card questions', helpI18n: 'notif_pref_rich_card_help' }
         ];
 
         async function loadNotifPreferences() {

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650295,6 +650295,10 @@ const TRANSLATIONS = {
         "chat_routing_chain_superior": "Superior",
         "chat_routing_chain_subordinates": "Subordinates",
         "chat_routing_chain_peers": "Peers",
+
+        "notif_pref_rich_card": "Rich-card questions",
+        "notif_pref_rich_card_help": "Push notifications when an agent attaches interactive buttons asking you to pick an option. Like Claude Code asking for permission — wakes your device because the agent is blocked on your choice. Default ON; if no bot is sending rich cards in your chats, no notifications arrive even when enabled.",
+        "notif_rich_card_question_title_suffix": "needs your input",
 },
 
 
@@ -1235056,6 +1235060,10 @@ const TRANSLATIONS = {
         "chat_routing_chain_superior": "上級",
         "chat_routing_chain_subordinates": "下屬",
         "chat_routing_chain_peers": "同儕",
+
+        "notif_pref_rich_card": "互動卡片詢問",
+        "notif_pref_rich_card_help": "當智能體在訊息中附上可點擊按鈕請你選擇選項時推播通知，就像 Claude Code 詢問權限那樣 — 智能體正在等你決定，所以會喚醒裝置。預設開啟；若聊天裡沒有智能體送出互動卡片，即使開啟也不會收到通知。",
+        "notif_rich_card_question_title_suffix": "需要你的選擇",
 },
 
 
@@ -1849191,6 +1849199,10 @@ const TRANSLATIONS = {
         "chat_routing_chain_superior": "上级",
         "chat_routing_chain_subordinates": "下属",
         "chat_routing_chain_peers": "同侪",
+
+        "notif_pref_rich_card": "互动卡片询问",
+        "notif_pref_rich_card_help": "当智能体在消息中附上可点击按钮请你选择选项时推送通知，就像 Claude Code 询问权限那样 — 智能体正在等你决定，所以会唤醒设备。默认开启；若聊天里没有智能体发送互动卡片，即使开启也不会收到通知。",
+        "notif_rich_card_question_title_suffix": "需要你的选择",
 },
 
 
@@ -2412409,6 +2412421,10 @@ const TRANSLATIONS = {
         "chat_routing_chain_superior": "上司",
         "chat_routing_chain_subordinates": "部下",
         "chat_routing_chain_peers": "同僚",
+
+        "notif_pref_rich_card": "リッチカードの質問",
+        "notif_pref_rich_card_help": "エージェントがインタラクティブなボタンを添えて選択を求めるときに通知を送信します。Claude Code が許可を求めるのと同じ仕組み — エージェントがあなたの判断を待っているのでデバイスを起こします。デフォルトでオン。チャットでリッチカードを送信するボットがいない場合は、オンでも通知は届きません。",
+        "notif_rich_card_question_title_suffix": "の操作待ちです",
 },
 
 
@@ -2942732,6 +2942748,10 @@ const TRANSLATIONS = {
         "chat_routing_chain_superior": "상급자",
         "chat_routing_chain_subordinates": "부하 직원",
         "chat_routing_chain_peers": "동료",
+
+        "notif_pref_rich_card": "리치 카드 질문",
+        "notif_pref_rich_card_help": "에이전트가 옵션 선택을 요청하는 대화형 버튼을 첨부할 때 푸시 알림을 보냅니다. Claude Code의 권한 요청과 같은 방식 — 에이전트가 사용자의 결정을 기다리므로 기기를 깨웁니다. 기본 켜짐; 리치 카드를 보내는 봇이 없으면 켜져 있어도 알림이 오지 않습니다.",
+        "notif_rich_card_question_title_suffix": "입력 대기 중",
 },
 
 
@@ -2944358,6 +2944378,10 @@ const TRANSLATIONS = {
         "arena_avatar_stage_concerned": "失誤",
         "arena_avatar_stage_proud": "完成！",
 
+
+        "notif_pref_rich_card": "互動卡片詢問",
+        "notif_pref_rich_card_help": "當智能體在訊息中附上可點擊按鈕請你選擇選項時推播通知，就像 Claude Code 詢問權限那樣 — 智能體正在等你決定，所以會喚醒裝置。預設開啟；若聊天裡沒有智能體送出互動卡片，即使開啟也不會收到通知。",
+        "notif_rich_card_question_title_suffix": "需要你的選擇",
 },
 
 
@@ -3471163,6 +3471187,10 @@ const TRANSLATIONS = {
         "chat_routing_chain_superior": "ผู้บังคับบัญชา",
         "chat_routing_chain_subordinates": "ผู้ใต้บังคับบัญชา",
         "chat_routing_chain_peers": "เพื่อนร่วมระดับ",
+
+        "notif_pref_rich_card": "คำถามจากการ์ดแบบโต้ตอบ",
+        "notif_pref_rich_card_help": "แจ้งเตือนแบบพุชเมื่อเอเจนต์แนบปุ่มแบบโต้ตอบให้คุณเลือกตัวเลือก เหมือนกับที่ Claude Code ขออนุญาต — เอเจนต์กำลังรอการตัดสินใจของคุณ จึงปลุกอุปกรณ์ ค่าเริ่มต้นเปิด หากไม่มีบอทส่งการ์ดแบบโต้ตอบในแชต จะไม่มีการแจ้งเตือนแม้จะเปิดอยู่",
+        "notif_rich_card_question_title_suffix": "ต้องการคำตอบจากคุณ",
 },
 
 
@@ -3998046,6 +3998074,10 @@ const TRANSLATIONS = {
         "chat_routing_chain_superior": "Cấp trên",
         "chat_routing_chain_subordinates": "Cấp dưới",
         "chat_routing_chain_peers": "Đồng cấp",
+
+        "notif_pref_rich_card": "Câu hỏi thẻ tương tác",
+        "notif_pref_rich_card_help": "Thông báo đẩy khi tác nhân đính kèm các nút tương tác yêu cầu bạn chọn một tùy chọn. Giống như Claude Code yêu cầu cấp quyền — tác nhân đang chờ quyết định của bạn nên sẽ đánh thức thiết bị. Mặc định bật; nếu không có bot nào gửi thẻ tương tác trong các cuộc trò chuyện, sẽ không nhận được thông báo ngay cả khi đã bật.",
+        "notif_rich_card_question_title_suffix": "cần phản hồi của bạn",
 },
 
 
@@ -4524545,6 +4524577,10 @@ const TRANSLATIONS = {
         "chat_routing_chain_superior": "Atasan",
         "chat_routing_chain_subordinates": "Bawahan",
         "chat_routing_chain_peers": "Rekan",
+
+        "notif_pref_rich_card": "Pertanyaan kartu interaktif",
+        "notif_pref_rich_card_help": "Notifikasi push ketika agen melampirkan tombol interaktif yang meminta Anda memilih opsi. Seperti Claude Code yang meminta izin — agen sedang menunggu keputusan Anda, jadi akan membangunkan perangkat. Default aktif; jika tidak ada bot yang mengirim kartu interaktif di obrolan Anda, tidak ada notifikasi yang masuk meskipun diaktifkan.",
+        "notif_rich_card_question_title_suffix": "menunggu respons Anda",
 },
 
 
@@ -5049687,6 +5049723,10 @@ const TRANSLATIONS = {
         "chat_routing_chain_superior": "Supérieur",
         "chat_routing_chain_subordinates": "Subordonnés",
         "chat_routing_chain_peers": "Pairs",
+
+        "notif_pref_rich_card": "Questions de cartes interactives",
+        "notif_pref_rich_card_help": "Notifications push lorsqu'un agent joint des boutons interactifs vous demandant de choisir une option. Comme Claude Code demandant une autorisation — l'agent attend votre décision, donc cela réveille l'appareil. Activé par défaut ; si aucun bot n'envoie de cartes interactives dans vos discussions, aucune notification n'arrive même si l'option est activée.",
+        "notif_rich_card_question_title_suffix": "attend votre réponse",
 },
 
 
@@ -5567380,6 +5567420,10 @@ const TRANSLATIONS = {
         "chat_routing_chain_superior": "Superior",
         "chat_routing_chain_subordinates": "Subordinados",
         "chat_routing_chain_peers": "Pares",
+
+        "notif_pref_rich_card": "Preguntas de tarjetas interactivas",
+        "notif_pref_rich_card_help": "Notificaciones push cuando un agente adjunta botones interactivos pidiéndote elegir una opción. Como Claude Code pidiendo permiso — el agente está esperando tu decisión, por lo que despierta el dispositivo. Activado por defecto; si ningún bot envía tarjetas interactivas en tus chats, no llegan notificaciones aunque esté activado.",
+        "notif_rich_card_question_title_suffix": "espera tu respuesta",
 },
 
 
@@ -6104316,6 +6104360,10 @@ const TRANSLATIONS = {
         "chat_routing_chain_superior": "Vorgesetzter",
         "chat_routing_chain_subordinates": "Untergebene",
         "chat_routing_chain_peers": "Kollegen",
+
+        "notif_pref_rich_card": "Rich-Card-Fragen",
+        "notif_pref_rich_card_help": "Push-Benachrichtigungen, wenn ein Agent interaktive Schaltflächen anhängt und dich bittet, eine Option zu wählen. Wie Claude Code, das um Erlaubnis fragt — der Agent wartet auf deine Entscheidung und weckt daher das Gerät. Standardmäßig aktiviert; wenn kein Bot Rich-Cards in deinen Chats sendet, kommen keine Benachrichtigungen, auch wenn aktiviert.",
+        "notif_rich_card_question_title_suffix": "wartet auf deine Antwort",
 },
     pt: {
         "transition_loading": "A carregar…",
@@ -6109764,6 +6109812,10 @@ const TRANSLATIONS = {
         "chat_routing_chain_superior": "Superior",
         "chat_routing_chain_subordinates": "Subordinados",
         "chat_routing_chain_peers": "Pares",
+
+        "notif_pref_rich_card": "Perguntas de cartões interativos",
+        "notif_pref_rich_card_help": "Notificações push quando um agente anexa botões interativos pedindo para você escolher uma opção. Como o Claude Code pedindo permissão — o agente está esperando sua decisão, então acorda o dispositivo. Padrão ligado; se nenhum bot enviar cartões interativos em seus chats, nenhuma notificação chega mesmo que esteja ativado.",
+        "notif_rich_card_question_title_suffix": "aguarda sua resposta",
 },
 
 
@@ -6638569,6 +6638621,10 @@ const TRANSLATIONS = {
         "chat_routing_chain_superior": "Atasan",
         "chat_routing_chain_subordinates": "Bawahan",
         "chat_routing_chain_peers": "Rakan setaraf",
+
+        "notif_pref_rich_card": "Soalan kad interaktif",
+        "notif_pref_rich_card_help": "Pemberitahuan tolak apabila ejen melampirkan butang interaktif meminta anda memilih pilihan. Seperti Claude Code meminta kebenaran — ejen sedang menunggu keputusan anda, jadi ia mengejutkan peranti. Lalai HIDUP; jika tiada bot menghantar kad interaktif dalam sembang anda, tiada pemberitahuan tiba walaupun dihidupkan.",
+        "notif_rich_card_question_title_suffix": "menunggu maklum balas anda",
 },
 
 
@@ -7197831,6 +7197887,10 @@ const TRANSLATIONS = {
         "chat_routing_chain_superior": "वरिष्ठ",
         "chat_routing_chain_subordinates": "अधीनस्थ",
         "chat_routing_chain_peers": "सहयोगी",
+
+        "notif_pref_rich_card": "इंटरैक्टिव कार्ड प्रश्न",
+        "notif_pref_rich_card_help": "जब कोई एजेंट इंटरैक्टिव बटन संलग्न करके आपसे विकल्प चुनने के लिए कहता है तो पुश सूचनाएं भेजी जाती हैं। जैसे Claude Code अनुमति मांगता है — एजेंट आपके निर्णय की प्रतीक्षा कर रहा है, इसलिए डिवाइस को जगाता है। डिफ़ॉल्ट चालू; यदि आपकी चैट में कोई बॉट इंटरैक्टिव कार्ड नहीं भेज रहा है, तो चालू होने पर भी कोई सूचना नहीं आती।",
+        "notif_rich_card_question_title_suffix": "को आपके इनपुट की आवश्यकता है",
 },
 
 
@@ -7746219,6 +7746279,10 @@ const TRANSLATIONS = {
         "chat_routing_chain_superior": "المسؤول",
         "chat_routing_chain_subordinates": "المرؤوسون",
         "chat_routing_chain_peers": "الزملاء",
+
+        "notif_pref_rich_card": "أسئلة البطاقات التفاعلية",
+        "notif_pref_rich_card_help": "إشعارات فورية عندما يرفق وكيل أزرارًا تفاعلية يطلب منك اختيار خيار. مثل Claude Code عند طلب الإذن — الوكيل ينتظر قرارك، لذا يوقظ الجهاز. ممكّن افتراضيًا؛ إذا لم يرسل أي روبوت بطاقات تفاعلية في محادثاتك، فلن تصل إشعارات حتى لو كان مفعّلاً.",
+        "notif_rich_card_question_title_suffix": "ينتظر ردك",
 }
 
 

--- a/backend/tests/jest/avatar-upload.test.js
+++ b/backend/tests/jest/avatar-upload.test.js
@@ -117,10 +117,17 @@ jest.mock('../../gatekeeper', () => ({
 
 jest.mock('../../notifications', () => {
     const express = jest.requireActual('express');
+    // card_a9edf960: pull through the pure rich-card-question helpers so index.js
+    // can wire its limiter at module-load without crashing.
+    const actual = jest.requireActual('../../notifications');
     return {
         init: jest.fn(),
         router: express.Router(),
         initNotificationTables: jest.fn().mockResolvedValue(undefined),
+        truncateUtf8: actual.truncateUtf8,
+        isRichCardQuestion: actual.isRichCardQuestion,
+        buildRichCardNotification: actual.buildRichCardNotification,
+        createRichCardNotifLimiter: actual.createRichCardNotifLimiter,
     };
 });
 

--- a/backend/tests/jest/card-holder.test.js
+++ b/backend/tests/jest/card-holder.test.js
@@ -132,10 +132,17 @@ jest.mock('../../gatekeeper', () => ({
 
 jest.mock('../../notifications', () => {
     const express = jest.requireActual('express');
+    // card_a9edf960: pull through the pure rich-card-question helpers so index.js
+    // can wire its limiter at module-load without crashing.
+    const actual = jest.requireActual('../../notifications');
     return {
         init: jest.fn(),
         router: express.Router(),
         initNotificationTables: jest.fn().mockResolvedValue(undefined),
+        truncateUtf8: actual.truncateUtf8,
+        isRichCardQuestion: actual.isRichCardQuestion,
+        buildRichCardNotification: actual.buildRichCardNotification,
+        createRichCardNotifLimiter: actual.createRichCardNotifLimiter,
     };
 });
 

--- a/backend/tests/jest/character-avatar-sync.test.js
+++ b/backend/tests/jest/character-avatar-sync.test.js
@@ -120,10 +120,17 @@ jest.mock('../../gatekeeper', () => ({
 
 jest.mock('../../notifications', () => {
     const express = jest.requireActual('express');
+    // card_a9edf960: pull through the pure rich-card-question helpers so index.js
+    // can wire its limiter at module-load without crashing.
+    const actual = jest.requireActual('../../notifications');
     return {
         init: jest.fn(),
         router: express.Router(),
         initNotificationTables: jest.fn().mockResolvedValue(undefined),
+        truncateUtf8: actual.truncateUtf8,
+        isRichCardQuestion: actual.isRichCardQuestion,
+        buildRichCardNotification: actual.buildRichCardNotification,
+        createRichCardNotifLimiter: actual.createRichCardNotifLimiter,
     };
 });
 

--- a/backend/tests/jest/entity-trash.test.js
+++ b/backend/tests/jest/entity-trash.test.js
@@ -139,10 +139,17 @@ jest.mock('../../gatekeeper', () => ({
 
 jest.mock('../../notifications', () => {
     const express = jest.requireActual('express');
+    // card_a9edf960: pull through the pure rich-card-question helpers so index.js
+    // can wire its limiter at module-load without crashing.
+    const actual = jest.requireActual('../../notifications');
     return {
         init: jest.fn(),
         router: express.Router(),
         initNotificationTables: jest.fn().mockResolvedValue(undefined),
+        truncateUtf8: actual.truncateUtf8,
+        isRichCardQuestion: actual.isRichCardQuestion,
+        buildRichCardNotification: actual.buildRichCardNotification,
+        createRichCardNotifLimiter: actual.createRichCardNotifLimiter,
     };
 });
 

--- a/backend/tests/jest/friend-system.test.js
+++ b/backend/tests/jest/friend-system.test.js
@@ -143,10 +143,17 @@ jest.mock('../../gatekeeper', () => ({
 
 jest.mock('../../notifications', () => {
     const express = jest.requireActual('express');
+    // card_a9edf960: pull through the pure rich-card-question helpers so index.js
+    // can wire its limiter at module-load without crashing.
+    const actual = jest.requireActual('../../notifications');
     return {
         init: jest.fn(),
         router: express.Router(),
         initNotificationTables: jest.fn().mockResolvedValue(undefined),
+        truncateUtf8: actual.truncateUtf8,
+        isRichCardQuestion: actual.isRichCardQuestion,
+        buildRichCardNotification: actual.buildRichCardNotification,
+        createRichCardNotifLimiter: actual.createRichCardNotifLimiter,
     };
 });
 

--- a/backend/tests/jest/helpers/mock-setup.js
+++ b/backend/tests/jest/helpers/mock-setup.js
@@ -166,12 +166,35 @@ jest.mock('../../../gatekeeper', () => ({
 
 jest.mock('../../../notifications', () => {
     const express = jest.requireActual('express');
+    // Pull through the rich-card-question helpers (pure functions, no DB) so
+    // index.js can wire its limiter at module-load without crashing — see
+    // card_a9edf960. The helpers are tested directly in
+    // tests/jest/rich-card-notification.test.js against the un-mocked module.
+    const actual = jest.requireActual('../../../notifications');
     return {
         init: jest.fn(),
         router: express.Router(),
         initNotificationTables: jest.fn().mockResolvedValue(undefined),
         savePushSubscription: jest.fn().mockResolvedValue(true),
         removePushSubscription: jest.fn().mockResolvedValue(true),
+        // Pref gates default to permissive in tests (existing behavior).
+        getPrefs: jest.fn().mockResolvedValue({ ...actual.DEFAULT_PREFS }),
+        isCategoryEnabled: actual.isCategoryEnabled,
+        DEFAULT_PREFS: actual.DEFAULT_PREFS,
+        // Rich-card helpers (card_a9e) — pure, safe to expose un-mocked.
+        truncateUtf8: actual.truncateUtf8,
+        isRichCardQuestion: actual.isRichCardQuestion,
+        buildRichCardNotification: actual.buildRichCardNotification,
+        createRichCardNotifLimiter: actual.createRichCardNotifLimiter,
+        // Save/save-misc no-ops so notifyDevice() doesn't blow up if reached.
+        saveNotification: jest.fn().mockResolvedValue(null),
+        getNotifications: jest.fn().mockResolvedValue([]),
+        getUnreadCount: jest.fn().mockResolvedValue(0),
+        markRead: jest.fn().mockResolvedValue(true),
+        markAllRead: jest.fn().mockResolvedValue(true),
+        pruneOldNotifications: jest.fn().mockResolvedValue(undefined),
+        updatePrefs: jest.fn().mockResolvedValue(true),
+        getPushSubscriptions: jest.fn().mockResolvedValue([]),
     };
 });
 

--- a/backend/tests/jest/identity.test.js
+++ b/backend/tests/jest/identity.test.js
@@ -113,10 +113,17 @@ jest.mock('../../gatekeeper', () => ({
 
 jest.mock('../../notifications', () => {
     const express = jest.requireActual('express');
+    // card_a9edf960: pull through the pure rich-card-question helpers so index.js
+    // can wire its limiter at module-load without crashing.
+    const actual = jest.requireActual('../../notifications');
     return {
         init: jest.fn(),
         router: express.Router(),
         initNotificationTables: jest.fn().mockResolvedValue(undefined),
+        truncateUtf8: actual.truncateUtf8,
+        isRichCardQuestion: actual.isRichCardQuestion,
+        buildRichCardNotification: actual.buildRichCardNotification,
+        createRichCardNotifLimiter: actual.createRichCardNotifLimiter,
     };
 });
 

--- a/backend/tests/jest/rich-card-notification.test.js
+++ b/backend/tests/jest/rich-card-notification.test.js
@@ -168,11 +168,11 @@ describe('buildRichCardNotification (card_a9e)', () => {
         expect(notif.title).toBe('Agent needs your input');
     });
 
-    it('truncates body via truncateUtf8 (UTF-8 safe)', () => {
+    it('truncates body via truncateUtf8 (UTF-8 safe, 240-byte cap)', () => {
         const long = 'A'.repeat(500);
         const notif = buildRichCardNotification(card, { questionText: long });
-        expect(notif.body.length).toBeLessThanOrEqual(100);
-        expect(Buffer.byteLength(notif.body, 'utf8')).toBeLessThanOrEqual(100);
+        expect(notif.body.length).toBeLessThanOrEqual(240);
+        expect(Buffer.byteLength(notif.body, 'utf8')).toBeLessThanOrEqual(240);
     });
 
     it('does not throw on missing ctx', () => {
@@ -264,6 +264,55 @@ describe('createRichCardNotifLimiter (card_a9e)', () => {
         for (let i = 0; i < 200; i++) results.push(limiter.check('device-R'));
         const allowed = results.filter(Boolean).length;
         expect(allowed).toBe(100); // exactly `max` allowed in the window
+    });
+
+    it('dedupes by ask_id WITHOUT burning rate-limit budget (HIGH-2 review fix)', () => {
+        // A buggy agent that re-emits the same card 5× must not burn the
+        // user's 5/10s budget — real Claude-Code-permission UX dedupes by
+        // request id. The dedup must short-circuit *before* the bucket
+        // increments so 4 unrelated future cards still get through.
+        limiter = createRichCardNotifLimiter({ windowMs: 60_000, max: 5, askDedupTtlMs: 60_000, disablePrune: true });
+        // First emission of ask-A — allowed, bucket count = 1.
+        expect(limiter.check('device-D', 'ask-A')).toBe(true);
+        // Re-emissions of ask-A — blocked by dedup, bucket NOT incremented.
+        for (let i = 0; i < 10; i++) {
+            expect(limiter.check('device-D', 'ask-A')).toBe(false);
+        }
+        // Four unrelated asks should still pass (4 + 1 = 5).
+        expect(limiter.check('device-D', 'ask-B')).toBe(true);
+        expect(limiter.check('device-D', 'ask-C')).toBe(true);
+        expect(limiter.check('device-D', 'ask-D')).toBe(true);
+        expect(limiter.check('device-D', 'ask-E')).toBe(true);
+        // Sixth distinct ask — rate-limited.
+        expect(limiter.check('device-D', 'ask-F')).toBe(false);
+    });
+
+    it('ask_id dedup is per-device (no cross-device leak)', () => {
+        limiter = createRichCardNotifLimiter({ windowMs: 60_000, max: 5, askDedupTtlMs: 60_000, disablePrune: true });
+        expect(limiter.check('device-A', 'shared-ask')).toBe(true);
+        // device-B sees a fresh dedup state for the same ask_id.
+        expect(limiter.check('device-B', 'shared-ask')).toBe(true);
+        // Re-emit to A — deduped.
+        expect(limiter.check('device-A', 'shared-ask')).toBe(false);
+        // Re-emit to B — deduped.
+        expect(limiter.check('device-B', 'shared-ask')).toBe(false);
+    });
+
+    it('missing/undefined ask_id falls through to plain rate-limiting', () => {
+        limiter = createRichCardNotifLimiter({ windowMs: 60_000, max: 2, disablePrune: true });
+        // No ask_id = no dedup, just count.
+        expect(limiter.check('device-N')).toBe(true);
+        expect(limiter.check('device-N')).toBe(true);
+        expect(limiter.check('device-N')).toBe(false);
+    });
+
+    it('rejects windowMs:0 / max:0 (option-misuse guard, LOW review fix)', () => {
+        // A caller passing windowMs:0 or max:0 must not silently turn off
+        // rate-limiting. The factory falls back to safe defaults.
+        limiter = createRichCardNotifLimiter({ windowMs: 0, max: 0, disablePrune: true });
+        // With defaults (5 per 10s) the 6th call is blocked.
+        for (let i = 0; i < 5; i++) expect(limiter.check('device-Z')).toBe(true);
+        expect(limiter.check('device-Z')).toBe(false);
     });
 });
 

--- a/backend/tests/jest/rich-card-notification.test.js
+++ b/backend/tests/jest/rich-card-notification.test.js
@@ -1,0 +1,327 @@
+/**
+ * Rich-card-question notification regression tests (card_a9edf960).
+ *
+ * Hank's framing — "user receives a rich card asking them to pick an option,
+ * just like Claude Code asking for permission" — means the recipient device
+ * MUST get a higher-priority push so they don't miss an agent waiting on
+ * their input. Coverage:
+ *
+ *  - truncateUtf8: codepoint-safe truncation (no half-emoji, no lone surrogate)
+ *  - isRichCardQuestion: detection accepts good shape, rejects bad/edge cases
+ *  - buildRichCardNotification: title/body/category/metadata shape
+ *  - createRichCardNotifLimiter: rate-limit per-device, isolation, window reset
+ *  - DEFAULT_PREFS.rich_card_question: default ON
+ *  - isCategoryEnabled('rich_card_question'): toggle semantics
+ *  - Migration safety: existing users (prefs row missing the key) default ON
+ */
+
+const {
+    truncateUtf8,
+    isRichCardQuestion,
+    buildRichCardNotification,
+    createRichCardNotifLimiter,
+    DEFAULT_PREFS,
+    isCategoryEnabled
+} = require('../../notifications');
+
+describe('truncateUtf8 (card_a9e)', () => {
+    it('returns empty string for non-string input', () => {
+        expect(truncateUtf8(null, 10)).toBe('');
+        expect(truncateUtf8(undefined, 10)).toBe('');
+        expect(truncateUtf8(123, 10)).toBe('');
+        expect(truncateUtf8({}, 10)).toBe('');
+    });
+
+    it('returns empty string for non-positive maxBytes', () => {
+        expect(truncateUtf8('hello', 0)).toBe('');
+        expect(truncateUtf8('hello', -5)).toBe('');
+        expect(truncateUtf8('hello', NaN)).toBe('');
+    });
+
+    it('returns the string unchanged when within budget', () => {
+        expect(truncateUtf8('hello', 100)).toBe('hello');
+        expect(truncateUtf8('', 100)).toBe('');
+    });
+
+    it('truncates plain ASCII at the byte boundary', () => {
+        const out = truncateUtf8('abcdefghij', 5);
+        expect(out).toBe('abcde');
+        expect(Buffer.byteLength(out, 'utf8')).toBeLessThanOrEqual(5);
+    });
+
+    it('does not split a multi-byte CJK codepoint', () => {
+        // Each CJK character is 3 UTF-8 bytes. With maxBytes=5 we can fit 1 char (3 bytes).
+        const src = '你好世界'; // 4 chars × 3 bytes = 12 bytes
+        const out = truncateUtf8(src, 5);
+        expect(out).toBe('你');
+        expect(Buffer.byteLength(out, 'utf8')).toBeLessThanOrEqual(5);
+        // Also confirm the output decodes cleanly (no U+FFFD replacement char).
+        expect(out).not.toContain('�');
+    });
+
+    it('does not split a 4-byte emoji codepoint (surrogate pair)', () => {
+        // 🦞 (U+1F99E) — 4 UTF-8 bytes; with maxBytes=3 we should get empty.
+        const src = '🦞 lobster';
+        const out = truncateUtf8(src, 3);
+        // We don't insist on a specific output, only that there's no lone
+        // surrogate or replacement char in the result and the byte count is
+        // within budget.
+        expect(Buffer.byteLength(out, 'utf8')).toBeLessThanOrEqual(3);
+        expect(out).not.toContain('�');
+        // Last char (if any) must not be a high surrogate.
+        if (out.length > 0) {
+            const last = out.charCodeAt(out.length - 1);
+            expect(last >= 0xD800 && last <= 0xDBFF).toBe(false);
+        }
+    });
+
+    it('handles a mixed-script Hank-style question', () => {
+        const src = 'Hello 你好! 是否要刪除這個檔案? 🗑️ Yes/No';
+        const out = truncateUtf8(src, 30);
+        expect(Buffer.byteLength(out, 'utf8')).toBeLessThanOrEqual(30);
+        expect(out).not.toContain('�');
+    });
+});
+
+describe('isRichCardQuestion (card_a9e)', () => {
+    it('accepts a well-formed card', () => {
+        expect(isRichCardQuestion({
+            ask_id: 'ask-1',
+            buttons: [{ id: 'a', label: 'A', style: 'primary' }]
+        })).toBe(true);
+    });
+
+    it('accepts cards with multiple buttons', () => {
+        expect(isRichCardQuestion({
+            ask_id: 'ask-2',
+            buttons: [
+                { id: 'a', label: 'Yes' },
+                { id: 'b', label: 'No' },
+                { id: 'c', label: 'Cancel' }
+            ]
+        })).toBe(true);
+    });
+
+    it('rejects null/undefined/non-object', () => {
+        expect(isRichCardQuestion(null)).toBe(false);
+        expect(isRichCardQuestion(undefined)).toBe(false);
+        expect(isRichCardQuestion('card')).toBe(false);
+        expect(isRichCardQuestion(42)).toBe(false);
+    });
+
+    it('rejects an array (because Array.isArray ≠ plain object)', () => {
+        expect(isRichCardQuestion([])).toBe(false);
+        expect(isRichCardQuestion([{ id: 'a', label: 'A' }])).toBe(false);
+    });
+
+    it('rejects card missing ask_id', () => {
+        expect(isRichCardQuestion({
+            buttons: [{ id: 'a', label: 'A' }]
+        })).toBe(false);
+    });
+
+    it('rejects card with empty/non-string ask_id', () => {
+        expect(isRichCardQuestion({ ask_id: '', buttons: [{ id: 'a', label: 'A' }] })).toBe(false);
+        expect(isRichCardQuestion({ ask_id: 123, buttons: [{ id: 'a', label: 'A' }] })).toBe(false);
+    });
+
+    it('rejects card with no buttons / empty buttons / non-array buttons', () => {
+        expect(isRichCardQuestion({ ask_id: 'x' })).toBe(false);
+        expect(isRichCardQuestion({ ask_id: 'x', buttons: [] })).toBe(false);
+        expect(isRichCardQuestion({ ask_id: 'x', buttons: 'a,b' })).toBe(false);
+    });
+});
+
+describe('buildRichCardNotification (card_a9e)', () => {
+    const card = {
+        ask_id: 'ask-abc',
+        buttons: [
+            { id: 'yes', label: 'Yes' },
+            { id: 'no', label: 'No' }
+        ]
+    };
+
+    it('returns the expected shape', () => {
+        const notif = buildRichCardNotification(card, {
+            questionText: 'Delete file foo.txt?',
+            fromName: 'Codex',
+            fromEntityId: 1,
+            toEntityId: 0
+        });
+        expect(notif).toMatchObject({
+            type: 'chat',
+            category: 'rich_card_question',
+            title: 'Codex needs your input',
+            body: 'Delete file foo.txt?',
+            link: 'chat.html'
+        });
+        expect(notif.metadata).toEqual({
+            ask_id: 'ask-abc',
+            fromEntityId: 1,
+            toEntityId: 0,
+            buttonCount: 2
+        });
+    });
+
+    it('falls back to "Agent" when fromName missing', () => {
+        const notif = buildRichCardNotification(card, { questionText: 'q' });
+        expect(notif.title).toBe('Agent needs your input');
+    });
+
+    it('truncates body via truncateUtf8 (UTF-8 safe)', () => {
+        const long = 'A'.repeat(500);
+        const notif = buildRichCardNotification(card, { questionText: long });
+        expect(notif.body.length).toBeLessThanOrEqual(100);
+        expect(Buffer.byteLength(notif.body, 'utf8')).toBeLessThanOrEqual(100);
+    });
+
+    it('does not throw on missing ctx', () => {
+        const notif = buildRichCardNotification(card);
+        expect(notif.category).toBe('rich_card_question');
+        expect(notif.metadata.ask_id).toBe('ask-abc');
+        expect(notif.metadata.buttonCount).toBe(2);
+        // fromEntityId / toEntityId default to null per the helper contract.
+        expect(notif.metadata.fromEntityId).toBeNull();
+        expect(notif.metadata.toEntityId).toBeNull();
+    });
+
+    it('coerces ask_id to string in metadata', () => {
+        // Defense-in-depth: even if upstream sanitization slipped, the
+        // notification payload must contain a string id (JSON.stringify-safe).
+        const notif = buildRichCardNotification(
+            { ask_id: 'mixed-123', buttons: [{ id: 'a', label: 'A' }] },
+            {}
+        );
+        expect(typeof notif.metadata.ask_id).toBe('string');
+    });
+
+    it('XSS-safe: title/body do not auto-execute interpolation', () => {
+        // The notification body is delivered as plain text (no HTML). The
+        // helper must not introduce its own escaping bugs (e.g., template-
+        // literal injection that breaks the JSON envelope). Verify the body
+        // round-trips through JSON unchanged.
+        const evil = '<script>alert(1)</script>';
+        const notif = buildRichCardNotification(card, {
+            questionText: evil,
+            fromName: '<img src=x onerror=alert(2)>'
+        });
+        expect(notif.body).toBe(evil); // not escaped here — chat UI / push panel escape downstream
+        expect(notif.title).toBe('<img src=x onerror=alert(2)> needs your input');
+        // Critically: JSON.stringify must succeed (no thrown exception).
+        const round = JSON.parse(JSON.stringify(notif));
+        expect(round.body).toBe(evil);
+    });
+});
+
+describe('createRichCardNotifLimiter (card_a9e)', () => {
+    let limiter;
+    afterEach(() => { if (limiter) { limiter._stop(); limiter = null; } });
+
+    it('allows up to `max` pushes per device per window', () => {
+        limiter = createRichCardNotifLimiter({ windowMs: 60_000, max: 5, disablePrune: true });
+        for (let i = 0; i < 5; i++) {
+            expect(limiter.check('device-A')).toBe(true);
+        }
+        expect(limiter.check('device-A')).toBe(false);
+        expect(limiter.check('device-A')).toBe(false);
+    });
+
+    it('isolates per-device buckets (cross-device privacy)', () => {
+        // Critical: a rich card meant for device A must NOT consume device B's budget.
+        limiter = createRichCardNotifLimiter({ windowMs: 60_000, max: 2, disablePrune: true });
+        expect(limiter.check('device-A')).toBe(true);
+        expect(limiter.check('device-A')).toBe(true);
+        expect(limiter.check('device-A')).toBe(false);
+        // device-B has a fresh budget.
+        expect(limiter.check('device-B')).toBe(true);
+        expect(limiter.check('device-B')).toBe(true);
+        expect(limiter.check('device-B')).toBe(false);
+    });
+
+    it('resets the bucket after the window expires', () => {
+        limiter = createRichCardNotifLimiter({ windowMs: 50, max: 2, disablePrune: true });
+        expect(limiter.check('device-X')).toBe(true);
+        expect(limiter.check('device-X')).toBe(true);
+        expect(limiter.check('device-X')).toBe(false);
+        return new Promise(resolve => setTimeout(resolve, 80)).then(() => {
+            expect(limiter.check('device-X')).toBe(true);
+        });
+    });
+
+    it('rejects empty / missing deviceId', () => {
+        limiter = createRichCardNotifLimiter({ disablePrune: true });
+        expect(limiter.check(null)).toBe(false);
+        expect(limiter.check(undefined)).toBe(false);
+        expect(limiter.check('')).toBe(false);
+    });
+
+    it('does not throw under rapid concurrent calls (race safety)', () => {
+        // The bucket map increments synchronously; concurrent fan-out from
+        // Promise.all calling check() in the same tick should not produce
+        // negative or NaN counts.
+        limiter = createRichCardNotifLimiter({ windowMs: 60_000, max: 100, disablePrune: true });
+        const results = [];
+        for (let i = 0; i < 200; i++) results.push(limiter.check('device-R'));
+        const allowed = results.filter(Boolean).length;
+        expect(allowed).toBe(100); // exactly `max` allowed in the window
+    });
+});
+
+describe('DEFAULT_PREFS migration safety (card_a9e)', () => {
+    it('rich_card_question default ON', () => {
+        expect(DEFAULT_PREFS.rich_card_question).toBe(true);
+    });
+
+    it('isCategoryEnabled returns true for prefs without the key (existing users)', () => {
+        // Critical migration check: a user who registered before this card
+        // shipped has no `rich_card_question` field in their prefs JSON.
+        // The default-ON contract means they should still receive these.
+        const oldPrefs = {
+            bot_reply: true,
+            speak_to: true,
+            // ... no rich_card_question key
+        };
+        expect(isCategoryEnabled(oldPrefs, 'rich_card_question')).toBe(true);
+    });
+
+    it('isCategoryEnabled returns false only when explicitly disabled', () => {
+        expect(isCategoryEnabled({ rich_card_question: false }, 'rich_card_question')).toBe(false);
+        expect(isCategoryEnabled({ rich_card_question: true }, 'rich_card_question')).toBe(true);
+    });
+
+    it('isCategoryEnabled is permissive on malformed prefs (fail-open)', () => {
+        // If prefs JSON is corrupt or absent we should NOT silently swallow
+        // a question the user is waiting on. Fail-open is the right default
+        // for a Claude-Code-permission-style notification.
+        expect(isCategoryEnabled(null, 'rich_card_question')).toBe(true);
+        expect(isCategoryEnabled(undefined, 'rich_card_question')).toBe(true);
+        expect(isCategoryEnabled('garbage', 'rich_card_question')).toBe(true);
+    });
+});
+
+describe('Integration: end-to-end shape (card_a9e)', () => {
+    it('building from a validated card produces a notifyDevice-compatible payload', () => {
+        const card = {
+            ask_id: 'ask-int-1',
+            buttons: [
+                { id: 'approve', label: 'Approve', style: 'primary' },
+                { id: 'deny', label: 'Deny', style: 'danger' }
+            ]
+        };
+        const ok = isRichCardQuestion(card);
+        expect(ok).toBe(true);
+        const notif = buildRichCardNotification(card, {
+            questionText: 'Approve rm -rf /tmp/foo?',
+            fromName: 'Hermes',
+            fromEntityId: 5,
+            toEntityId: 0
+        });
+        // notifyDevice expects: { type, category, title, body, link?, metadata? }
+        expect(notif).toHaveProperty('type');
+        expect(notif).toHaveProperty('category', 'rich_card_question');
+        expect(notif).toHaveProperty('title');
+        expect(notif).toHaveProperty('body');
+        expect(notif).toHaveProperty('link');
+        expect(notif).toHaveProperty('metadata');
+    });
+});


### PR DESCRIPTION
## Summary

When an agent attaches **interactive buttons** (the `card` payload on `/api/transform` and `/api/channel/message`) to a chat message, the recipient device now receives a higher-priority **`rich_card_question`** notification on top of the existing `speak_to` / `cross_speak` push — mirroring **Claude Code's "asking the user for permission" UX**: the agent is blocked on the user's choice, so we wake the device.

## Why

Hank (06-16 23:31 TW):
> "richcard就是Agent在聊天頁面詢問使用者選擇哪個選項 選擇後回傳給Agent的一個UX. 用戶收到任何 Eclaw 聊天頁面的 richcard 詢問時需要有通知, 就像 Claude code 詢問用戶權限那樣"

Translation: Rich-card is the UX where Agent asks the user to pick an option in chat; whenever the user receives a rich-card question, they need a notification — like Claude Code asking the user for permission.

Card: `card_a9edf960bcf141e4d6a89490` — `[Feature/P1] Richard 跳出時觸發 APP + Web 通知`.

## Implementation

- **`backend/notifications.js`** — add `rich_card_question: true` to `DEFAULT_PREFS` (default ON). Existing users without the key in their stored prefs inherit ON automatically via the `{...DEFAULT_PREFS, ...stored}` spread in `getPrefs` — zero migration. Adds 4 pure helpers: `truncateUtf8` (UTF-8-codepoint-safe with surrogate-pair guard), `isRichCardQuestion` (validation), `buildRichCardNotification` (payload), `createRichCardNotifLimiter` (per-device rate-limit + per-`ask_id` dedup).
- **`backend/index.js`** — `notifyRichCardQuestion(deviceId, card, ctx)` wrapper that checks the pref FIRST (so muted users don't burn budget), then dedupes by `ask_id` (so re-emits don't burn budget), then rate-limits per device (5/10s), then dispatches via the existing `notifyDevice` central dispatcher (DB + Socket.IO + Web Push + FCM).
- **`backend/index.js` + `backend/channel-api.js`** — wired at every card-bearing delivery site: `/api/transform` speakTo + broadcast, `/api/channel/message` speakTo + broadcast.
- **`backend/public/portal/settings.html`** — new toggle row with `helpI18n: 'notif_pref_rich_card_help'` so the empty-state `?` icon explains the prerequisite (a bot must send rich cards in chat for these to fire — without that context, a confused user sees the toggle and wonders why nothing happens).
- **`backend/public/shared/i18n.js`** — 3 new keys (`notif_pref_rich_card`, `notif_pref_rich_card_help`, `notif_rich_card_question_title_suffix`) × **16 locales** (en, zh, zh-CN, zh-TW, ja, ko, th, vi, id, fr, es, de, pt, ms, hi, ar) inserted via `backend/scripts/i18n-insert-locale-keys.js` (AST tool — never regex; per MEMORY ref `reference_i18n_insert_via_ast`).
- **Tests** — 34 new unit tests in `backend/tests/jest/rich-card-notification.test.js` cover UTF-8 codepoint safety (CJK, emoji surrogate, mixed script), detection edge cases, payload shape, XSS round-trip safety, **per-device rate-limiter isolation (cross-device privacy)**, **window reset**, **race-safety under Promise.all-style fan-out**, **default-ON migration**, **`ask_id` dedup semantics**, and `windowMs:0` / `max:0` input guards.
- **Mock updates** — `backend/tests/jest/helpers/mock-setup.js` + 6 standalone test mocks pull the new pure helpers via `jest.requireActual` so `index.js` module-load doesn't crash on `notifModule.createRichCardNotifLimiter` in tests that mock `notifications`.

## Adversarial sub-agent review

A fresh general-purpose agent reviewed the staged diff before merge. Findings & disposition:

| Severity | Finding | Disposition |
|---|---|---|
| HIGH-1 | Limiter burns budget even when pref OFF | **Fixed** in fixup commit — pref check moved BEFORE rate-limit consumption, with fail-open on DB errors |
| HIGH-2 | No per-`ask_id` dedup → re-emits burn budget | **Fixed** in fixup commit — added 60s TTL dedup that short-circuits BEFORE the rate-limit counter |
| HIGH-3 | Suggests pushing notif into `deliverToEntity` chokepoint | **Deferred** — covered 100% of current card-bearing paths via 4 outer call sites; consolidation noted as future cleanup, not a correctness issue |
| MEDIUM-1 | Channel-api `typeof === 'function'` guard | Kept the guard (defensive against partial DI in tests); injection is correctly wired in production |
| MEDIUM-2 | Bucket increments before saveNotification refund | Acceptable — transient blip is rare; refund logic adds complexity for marginal gain |
| MEDIUM-3 | Real Claude-Code UX uses OS notification actions + `requireInteraction` | **Out of scope** — needs SW + FCM-format adapter changes; logged for follow-up. Current PR achieves the "wake the device" intent |
| LOW | `truncateUtf8` lone-surrogate guard unreachable | Kept (defensive; harmless) |
| LOW | `Number.isFinite(0)` accepts 0 | **Fixed** — guard tightened to `>0` |
| LOW | 100-byte body cap too small for CJK/RTL | **Fixed** — raised to 240 bytes |
| NIT | Title suffix hardcoded English server-side | Acceptable — title is a server-built string; locale-specific suffix lives in i18n.js for portal-side rendering of the in-app notification panel (future enhancement) |
| NIT | Prune interval 5min vs 10s window | Acceptable |

Cross-device privacy verified: limiter is keyed by **recipient** `target.deviceId` / `broadcastDeviceId` at all wired sites — no possibility of A→B leak. JSONB merge collision check: `rich_card_question` is a new top-level key, no clash with existing prefs.

## Tests

- **Jest:** 313 suites / 4376 passed / 3 skipped / **0 failures**.
- **ESLint:** 0 errors (3 pre-existing warnings unrelated to this PR).

## Globe-user / Setup / Empty-state `?` icon UX

- **Globe-user:** Works for every device in every locale (16 covered). Storage key is per-device, no tenant carveouts. The category-alias map already routes both same-device and cross-device card-bearing messages.
- **Setup conditions:** None — feature ships ON for all users. Toggle is visible immediately in Settings → Notifications.
- **Empty-state `?` icon:** Hover/click reveals locale-appropriate help text — e.g. EN: "Push notifications when an agent attaches interactive buttons asking you to pick an option. Like Claude Code asking for permission — wakes your device because the agent is blocked on your choice. Default ON; if no bot is sending rich cards in your chats, no notifications arrive even when enabled."

## Test plan

- [x] New jest file passes (34/34)
- [x] Full jest sweep regression-free
- [x] ESLint clean
- [x] Adversarial sub-agent review applied
- [x] Globe-user + Setup + `?` icon spec sections present per `feedback_spec_globe_user_setup_clarity`
- [x] i18n via AST tool per `reference_i18n_insert_via_ast` — 16 locales
- [x] Default-ON migration safe per `getPrefs` JSONB spread
- [ ] Post-merge: smoke check `/api/transform` with `card:` payload still 200s (covered by existing `transform-rich-card.test.js` regression suite already)

🤖 Generated with [Claude Code](https://claude.com/claude-code)