### PR TITLE
fix(voice): Bug#160 語音訊息發送失敗

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -22645,14 +22645,28 @@ const mediaUpload = multer({
     limits: { fileSize: 100 * 1024 * 1024 }, // 100MB max
     fileFilter: (req, file, cb) => {
         const imageTypes = ['image/jpeg', 'image/png', 'image/webp', 'image/gif'];
-        const audioTypes = ['audio/webm', 'audio/ogg', 'audio/mp4', 'audio/aac', 'audio/mpeg'];
+        // Bug #160 (GH#2861): browser/WebView MediaRecorder tags the blob with a
+        // codec-suffixed mime (e.g. "audio/webm;codecs=opus", "audio/ogg;codecs=opus")
+        // and Android MediaRecorder can emit audio/3gpp / audio/amr / audio/x-m4a.
+        // The old list only had bare base types, so codec-suffixed/Android voices
+        // were rejected by multer -> the error escaped to Express's default HTML
+        // 500 handler (no JSON), and the app showed an opaque "語音訊息發送失敗".
+        // Normalize by stripping codec/charset params before comparing, and widen
+        // the accepted audio set to cover real Android + WebView recorders.
+        const audioTypes = [
+            'audio/webm', 'audio/ogg', 'audio/mp4', 'audio/aac', 'audio/mpeg',
+            'audio/wav', 'audio/x-wav', 'audio/opus', 'audio/3gpp', 'audio/3gpp2',
+            'audio/amr', 'audio/x-m4a', 'audio/mp4a-latm', 'audio/flac',
+        ];
         const videoTypes = ['video/mp4', 'video/webm', 'video/quicktime', 'video/x-matroska'];
         const mediaType = (req.body && req.body.mediaType) || '';
-        if (mediaType === 'photo' && !imageTypes.includes(file.mimetype)) {
+        // "audio/webm;codecs=opus" -> "audio/webm"
+        const baseMime = String(file.mimetype || '').split(';')[0].trim().toLowerCase();
+        if (mediaType === 'photo' && !imageTypes.includes(baseMime)) {
             cb(new Error('Unsupported image type: ' + file.mimetype));
-        } else if (mediaType === 'voice' && !audioTypes.includes(file.mimetype)) {
+        } else if (mediaType === 'voice' && !audioTypes.includes(baseMime)) {
             cb(new Error('Unsupported audio type: ' + file.mimetype));
-        } else if (mediaType === 'video' && !videoTypes.includes(file.mimetype)) {
+        } else if (mediaType === 'video' && !videoTypes.includes(baseMime)) {
             cb(new Error('Unsupported video type: ' + file.mimetype));
         } else {
             cb(null, true); // "file" type accepts anything
@@ -22878,7 +22892,28 @@ app.get('/api/chat/file/:id', async (req, res) => {
  * Body (multipart): file, deviceId, deviceSecret, mediaType ("photo" | "voice" | "file")
  * Max file size: 100MB
  */
-app.post('/api/chat/upload-media', mediaUpload.single('file'), async (req, res) => {
+// Bug #160 (GH#2861): wrap multer so a fileFilter rejection or size-limit error
+// returns a clean { success:false } JSON body (+ diagnostic server log) instead of
+// escaping to Express's default HTML 500 handler. The Android app parses the JSON
+// body to surface the failure reason; a non-JSON 500 became an opaque "發送失敗"
+// with no diagnostic on the server side (matching the issue's empty error logs).
+function mediaUploadSingle(req, res, next) {
+    mediaUpload.single('file')(req, res, (err) => {
+        if (!err) return next();
+        const isMulterErr = err instanceof multer.MulterError;
+        const mediaType = (req.body && req.body.mediaType) || 'unknown';
+        const status = (isMulterErr && err.code === 'LIMIT_FILE_SIZE') ? 413 : 400;
+        console.error(`[Upload] Rejected ${mediaType} upload: ${err.code || ''} ${err.message}`);
+        return res.status(status).json({
+            success: false,
+            error: 'upload_rejected',
+            code: isMulterErr ? err.code : 'UNSUPPORTED_MEDIA',
+            message: err.message,
+        });
+    });
+}
+
+app.post('/api/chat/upload-media', mediaUploadSingle, async (req, res) => {
     const { deviceId, deviceSecret, mediaType } = req.body;
 
     if (!deviceId || !deviceSecret) {

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -8016,6 +8016,7 @@
         // ── Voice Recording ──
         let mediaRecorder = null;
         let audioChunks = [];
+        let recordedMimeType = ''; // Bug #160: actual MediaRecorder mime (may be mp4/ogg, not webm)
         let recordingStartTime = 0;
         let recordingTimer = null;
         const MAX_RECORD_SECONDS = 180;
@@ -8072,6 +8073,11 @@
 
                 mediaRecorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
                 audioChunks = [];
+                // Bug #160: remember the mime the recorder actually used. On Android
+                // WebView audio/webm is often unsupported and it falls back to
+                // audio/mp4 / audio/ogg. The old code hardcoded audio/webm on the
+                // upload blob, mislabeling the bytes; upload then failed.
+                recordedMimeType = mediaRecorder.mimeType || mimeType || 'audio/webm';
 
                 mediaRecorder.ondataavailable = (e) => {
                     if (e.data.size > 0) audioChunks.push(e.data);
@@ -8173,7 +8179,10 @@
 
             mediaRecorder.onstop = async () => {
                 mediaRecorder.stream.getTracks().forEach(t => t.stop());
-                const audioBlob = new Blob(audioChunks, { type: 'audio/webm' });
+                // Bug #160: use the recorder's real mime so the blob bytes and the
+                // Content-Type the browser sends to /api/chat/upload-media agree.
+                const blobType = recordedMimeType || mediaRecorder.mimeType || 'audio/webm';
+                const audioBlob = new Blob(audioChunks, { type: blobType });
                 mediaRecorder = null;
                 await uploadVoice(audioBlob, durationSec);
             };
@@ -8192,18 +8201,37 @@
             btn.disabled = true;
 
             try {
+                // Bug #160: derive the filename extension from the actual blob mime
+                // so the uploaded file isn't always mislabeled "voice.webm".
+                const mimeBase = String(blob.type || '').split(';')[0].trim().toLowerCase();
+                const extByMime = {
+                    'audio/webm': 'webm', 'audio/ogg': 'ogg', 'audio/mp4': 'm4a',
+                    'audio/aac': 'aac', 'audio/mpeg': 'mp3', 'audio/wav': 'wav',
+                    'audio/3gpp': '3gp', 'audio/amr': 'amr',
+                };
+                const voiceName = 'voice.' + (extByMime[mimeBase] || 'webm');
+
                 const formData = new FormData();
-                formData.append('file', blob, 'voice.webm');
+                // multer reads req.body.mediaType inside fileFilter, so send the text
+                // fields BEFORE the file part to guarantee mediaType is parsed first.
                 formData.append('deviceId', currentUser.deviceId);
                 formData.append('deviceSecret', currentUser.deviceSecret);
                 formData.append('mediaType', 'voice');
+                formData.append('file', blob, voiceName);
 
                 const uploadRes = await fetch(API_BASE + '/api/chat/upload-media', {
                     method: 'POST',
                     body: formData
                 });
-                const uploadData = await uploadRes.json();
-                if (!uploadData.success) throw new Error(uploadData.error || 'Upload failed');
+                // Bug #160: tolerate a non-JSON body (e.g. proxy/gateway HTML error)
+                // so the user gets a real status code instead of an opaque parse crash.
+                let uploadData;
+                try {
+                    uploadData = await uploadRes.json();
+                } catch {
+                    throw new Error('HTTP ' + uploadRes.status + ' (invalid response)');
+                }
+                if (!uploadData.success) throw new Error(uploadData.message || uploadData.error || ('HTTP ' + uploadRes.status));
 
                 // ── Local broadcast ──
                 if (targets.local.length > 0) {

--- a/backend/tests/jest/voice-upload.test.js
+++ b/backend/tests/jest/voice-upload.test.js
@@ -1,0 +1,224 @@
+/**
+ * Jest test: Voice / audio upload via POST /api/chat/upload-media
+ *
+ * Regression coverage for Bug #160 (GH#2861) "語音訊息發送失敗".
+ *
+ * Root cause: the multer fileFilter only accepted a short list of *bare* audio
+ * mimes (audio/webm, audio/ogg, ...). Real recorders tag the blob with a
+ * codec-suffixed mime ("audio/webm;codecs=opus", "audio/ogg;codecs=opus") and
+ * Android MediaRecorder can emit audio/3gpp / audio/x-m4a, all of which were
+ * rejected. The rejection Error escaped multer and hit Express's default HTML
+ * 500 handler, so the app received a non-JSON body -> opaque "send failed" with
+ * no diagnostic on the server side.
+ *
+ * Fixes asserted here:
+ *  1. codec-suffixed audio mimes are accepted (base-type normalization),
+ *  2. a genuinely unsupported audio mime is rejected with a clean JSON body
+ *     (success:false) rather than an HTML 500 — i.e. no silent drop.
+ */
+
+// ── Same mocks as avatar-upload.test.js ──
+jest.mock('pg', () => ({
+    Pool: jest.fn().mockImplementation(() => ({
+        query: jest.fn().mockResolvedValue({ rows: [{ id: 'fake-uuid' }], rowCount: 1 }),
+        connect: jest.fn().mockResolvedValue({
+            query: jest.fn().mockResolvedValue({ rows: [] }),
+            release: jest.fn(),
+        }),
+        end: jest.fn().mockResolvedValue(undefined),
+    })),
+}));
+
+jest.mock('../../db', () => ({
+    initDatabase: jest.fn().mockResolvedValue(true),
+    saveDeviceData: jest.fn().mockResolvedValue(true),
+    saveAllDevices: jest.fn().mockResolvedValue(true),
+    loadAllDevices: jest.fn().mockResolvedValue({}),
+    deleteDevice: jest.fn().mockResolvedValue(true),
+    getStats: jest.fn().mockResolvedValue({}),
+    closeDatabase: jest.fn().mockResolvedValue(undefined),
+    saveOfficialBot: jest.fn().mockResolvedValue(true),
+    loadOfficialBots: jest.fn().mockResolvedValue({}),
+    deleteOfficialBot: jest.fn().mockResolvedValue(true),
+    saveOfficialBinding: jest.fn().mockResolvedValue(true),
+    removeOfficialBinding: jest.fn().mockResolvedValue(true),
+    getOfficialBinding: jest.fn().mockResolvedValue(null),
+    getDeviceOfficialBindings: jest.fn().mockResolvedValue([]),
+    updateSubscriptionVerified: jest.fn().mockResolvedValue(true),
+    loadAllOfficialBindings: jest.fn().mockResolvedValue([]),
+    getExpiredPersonalBindings: jest.fn().mockResolvedValue([]),
+    getPaidBorrowSlots: jest.fn().mockResolvedValue(0),
+    incrementPaidBorrowSlots: jest.fn().mockResolvedValue(true),
+    saveFeedback: jest.fn().mockResolvedValue({ id: 1 }),
+}));
+
+jest.mock('../../flickr', () => ({
+    initFlickr: jest.fn(),
+    uploadPhoto: jest.fn().mockResolvedValue({ success: true, url: 'https://x/y.jpg', photoId: '1' }),
+    isAvailable: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock('../../scheduler', () => ({
+    init: jest.fn(),
+    createSchedule: jest.fn().mockResolvedValue({ id: 1 }),
+    updateSchedule: jest.fn().mockResolvedValue(true),
+    deleteSchedule: jest.fn().mockResolvedValue(true),
+    getSchedules: jest.fn().mockResolvedValue([]),
+    getSchedule: jest.fn().mockResolvedValue(null),
+    getSchedulesForBot: jest.fn().mockResolvedValue([]),
+}));
+
+jest.mock('../../device-telemetry', () => ({
+    initTelemetryTable: jest.fn().mockResolvedValue(undefined),
+    appendEntries: jest.fn().mockResolvedValue(undefined),
+    captureApiCall: jest.fn().mockResolvedValue(undefined),
+    getEntries: jest.fn().mockResolvedValue([]),
+    getSummary: jest.fn().mockResolvedValue({}),
+    clearEntries: jest.fn().mockResolvedValue(undefined),
+    createMiddleware: jest.fn().mockReturnValue((_req, _res, next) => next()),
+    sanitize: jest.fn().mockImplementation((v) => v),
+    MAX_BUFFER_BYTES: 1024 * 1024,
+    MAX_ENTRIES: 500,
+}));
+
+jest.mock('../../device-feedback', () => ({
+    initFeedbackTable: jest.fn().mockResolvedValue(undefined),
+    initFeedbackPhotosTable: jest.fn().mockResolvedValue(undefined),
+    captureLogSnapshot: jest.fn().mockResolvedValue([]),
+    captureDeviceState: jest.fn().mockResolvedValue({}),
+    autoTriage: jest.fn().mockResolvedValue('low'),
+    generateAiPrompt: jest.fn().mockReturnValue(''),
+    saveFeedback: jest.fn().mockResolvedValue({ id: 1 }),
+    getFeedbackList: jest.fn().mockResolvedValue([]),
+    getFeedbackById: jest.fn().mockResolvedValue(null),
+    updateFeedback: jest.fn().mockResolvedValue(true),
+    createGithubIssue: jest.fn().mockResolvedValue(null),
+    getPendingDebugFeedback: jest.fn().mockResolvedValue([]),
+    saveDebugResult: jest.fn().mockResolvedValue(true),
+    setMark: jest.fn().mockResolvedValue(undefined),
+    getMark: jest.fn().mockResolvedValue(null),
+    clearMark: jest.fn().mockResolvedValue(undefined),
+    LOG_WINDOW_MS: 60000,
+    MAX_PHOTOS_PER_FEEDBACK: 10,
+    MAX_PHOTO_SIZE: 5 * 1024 * 1024,
+    saveFeedbackPhoto: jest.fn().mockResolvedValue({ id: 1 }),
+    getFeedbackPhotos: jest.fn().mockResolvedValue([]),
+    getFeedbackPhoto: jest.fn().mockResolvedValue(null),
+    deleteFeedbackPhotos: jest.fn().mockResolvedValue(undefined),
+    cleanupResolvedFeedbackPhotos: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../gatekeeper', () => ({
+    detectMaliciousMessage: jest.fn().mockReturnValue({ isMalicious: false }),
+    detectAndMaskLeaks: jest.fn().mockImplementation((text) => text),
+    initGatekeeperTable: jest.fn().mockResolvedValue(undefined),
+    loadBlockedDevices: jest.fn().mockResolvedValue(undefined),
+    recordViolation: jest.fn().mockResolvedValue(undefined),
+    isDeviceBlocked: jest.fn().mockReturnValue(false),
+    getStrikeInfo: jest.fn().mockResolvedValue({ strikes: 0, blocked: false }),
+    getFreeBotTOS: jest.fn().mockResolvedValue(null),
+    hasAgreedToTOS: jest.fn().mockResolvedValue(false),
+    recordTOSAgreement: jest.fn().mockResolvedValue(undefined),
+    setServerLog: jest.fn(),
+    MAX_STRIKES: 3,
+    FREE_BOT_TOS_VERSION: '1.0',
+}));
+
+jest.mock('../../notifications', () => {
+    const express = jest.requireActual('express');
+    const actual = jest.requireActual('../../notifications');
+    return {
+        init: jest.fn(),
+        router: express.Router(),
+        initNotificationTables: jest.fn().mockResolvedValue(undefined),
+        truncateUtf8: actual.truncateUtf8,
+        isRichCardQuestion: actual.isRichCardQuestion,
+        buildRichCardNotification: actual.buildRichCardNotification,
+        createRichCardNotifLimiter: actual.createRichCardNotifLimiter,
+    };
+});
+
+jest.mock('../../chat-integrity', () => ({
+    init: jest.fn().mockReturnValue({
+        verify: jest.fn().mockReturnValue({ valid: true }),
+        sign: jest.fn().mockReturnValue('sig'),
+    }),
+    initIntegrityTable: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../device-preferences', () => ({
+    init: jest.fn(),
+    initTable: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('../../org-chart', () => ({
+    initTable: jest.fn().mockResolvedValue(undefined),
+    getOrgChart: jest.fn().mockResolvedValue({ hierarchy: {}, options: { kanbanReviewer: false, taskForward: false, allForward: false } }),
+    updateOrgChart: jest.fn().mockResolvedValue({ success: true, orgChart: { hierarchy: {}, options: {} } }),
+    getSuperior: jest.fn().mockReturnValue(null),
+    getSubordinates: jest.fn().mockReturnValue([]),
+    buildDefault: jest.fn().mockReturnValue({ USER: [] }),
+    pruneHierarchy: jest.fn().mockImplementation((h) => h),
+    validateHierarchy: jest.fn().mockReturnValue({ valid: true }),
+    validateOptions: jest.fn().mockImplementation((o) => o),
+    onEntityDeleted: jest.fn().mockResolvedValue(undefined),
+    invalidateCache: jest.fn(),
+    DEFAULT_OPTIONS: { kanbanReviewer: false, taskForward: false, allForward: false },
+}));
+
+const request = require('supertest');
+const app = require('../../index');
+
+const AUDIO = Buffer.from('fake-audio-bytes');
+
+describe('POST /api/chat/upload-media — voice (Bug #160)', () => {
+    test('rejects missing credentials with JSON body (not HTML)', async () => {
+        const res = await request(app)
+            .post('/api/chat/upload-media')
+            .field('mediaType', 'voice')
+            .attach('file', AUDIO, { filename: 'voice.webm', contentType: 'audio/webm' });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+    });
+
+    // Core regression: codec-suffixed mimes from real recorders must be ACCEPTED
+    // by the fileFilter (i.e. they must pass validation and reach auth/handler,
+    // which returns 401 for the unknown device — NOT a 400 "unsupported" reject).
+    const acceptedMimes = [
+        ['audio/webm;codecs=opus', 'voice.webm'],
+        ['audio/ogg;codecs=opus', 'voice.ogg'],
+        ['audio/mp4', 'voice.m4a'],
+        ['audio/3gpp', 'voice.3gp'],
+        ['audio/x-m4a', 'voice.m4a'],
+    ];
+    test.each(acceptedMimes)('accepts real-recorder mime %s past the fileFilter', async (mime, name) => {
+        const res = await request(app)
+            .post('/api/chat/upload-media')
+            // text fields BEFORE the file so req.body.mediaType is parsed first
+            .field('deviceId', 'nonexistent-device')
+            .field('deviceSecret', 'wrong')
+            .field('mediaType', 'voice')
+            .attach('file', AUDIO, { filename: name, contentType: mime });
+        // Passed the filter -> failed auth (unknown device) = 401. The bug would
+        // have produced a 400/500 "Unsupported audio type" instead.
+        expect(res.status).toBe(401);
+        expect(res.body.success).toBe(false);
+    });
+
+    // No silent drop: a genuinely unsupported audio mime is rejected with a
+    // clean JSON body (success:false), never an HTML 500 from Express default.
+    test('rejects unsupported audio mime with clean JSON (no silent drop)', async () => {
+        const res = await request(app)
+            .post('/api/chat/upload-media')
+            .field('deviceId', 'nonexistent-device')
+            .field('deviceSecret', 'wrong')
+            .field('mediaType', 'voice')
+            .attach('file', AUDIO, { filename: 'voice.txt', contentType: 'text/plain' });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+        expect(res.body.error).toBe('upload_rejected');
+        expect(typeof res.body.message).toBe('string');
+        // Response must be JSON, not an HTML error page.
+        expect(res.headers['content-type']).toMatch(/application\/json/);
+    });
+});


### PR DESCRIPTION
Fixes GH#2861 (Bug #160, Android app 1.0.84). Kanban card `card_ffb60469be9dd11e79e5495c`.

## Root cause
Voice send goes through the web chat (Android WebView) → `POST /api/chat/upload-media` with `mediaType=voice`.

1. The multer `fileFilter` for `voice` only accepted **bare** audio mimes: `audio/webm`, `audio/ogg`, `audio/mp4`, `audio/aac`, `audio/mpeg`. But:
   - Browser/WebView `MediaRecorder` tags the blob with a **codec-suffixed** mime — `audio/webm;codecs=opus`, `audio/ogg;codecs=opus` — which is `!== 'audio/webm'`, so it was rejected.
   - Android `MediaRecorder` can emit `audio/3gpp` / `audio/x-m4a`, also rejected.
2. The web client hardcoded the upload blob as `audio/webm` (`new Blob(chunks, { type: 'audio/webm' })`) even when the recorder actually fell back to mp4/ogg — mislabeling the bytes.
3. When `fileFilter` calls `cb(new Error(...))`, the error **escaped multer to Express's default error handler** (the global handler at index.js:19594 only covers JSON-syntax / 413 and `next()`s everything else; the route is registered after it). Result: a generic **HTML 500**, not the `{success:false}` JSON the app parses → opaque "語音訊息發送失敗" with no server-side error (matches the issue's empty error logs / "No obvious errors detected").

## Fix
**Backend (`backend/index.js`)**
- Normalize `file.mimetype` to its base type (strip `;codecs=...`) before the fileFilter comparison; widen the accepted audio set (`3gpp`, `3gpp2`, `amr`, `x-m4a`, `mp4a-latm`, `wav`, `x-wav`, `opus`, `flac`).
- New `mediaUploadSingle` wrapper: a fileFilter / `LIMIT_FILE_SIZE` error now returns a clean `{ success:false, error:'upload_rejected', code, message }` (400, or 413 for size) **plus a `[Upload] Rejected …` diagnostic log** — no silent drop, no HTML 500.

**Web client (`backend/public/portal/chat.html`)**
- Preserve the recorder's real mime (`mediaRecorder.mimeType`) on the upload blob so bytes and Content-Type agree; derive the filename extension from it.
- Send text fields (incl. `mediaType`) **before** the file part so multer parses `mediaType` first.
- Tolerate a non-JSON upload response instead of crashing on `.json()`.

No new i18n keys (reused existing `chat_voice_upload_failed`).

## Test
`backend/tests/jest/voice-upload.test.js` — 7 cases:
- codec-suffixed + Android mimes (`audio/webm;codecs=opus`, `audio/ogg;codecs=opus`, `audio/mp4`, `audio/3gpp`, `audio/x-m4a`) pass the filter (reach auth → 401, not a 400/500 "unsupported"),
- an unsupported mime (`text/plain`) is rejected with a **JSON** `success:false` body (`content-type: application/json`) — asserts no silent drop.

```
PASS tests/jest/voice-upload.test.js (7 passed)
PASS tests/jest/avatar-upload.test.js (11 passed, no regression on shared mediaUpload)
Test Suites: 2 passed · Tests: 18 passed
```

## Out of scope / remaining
- Native Android recorder (`NativeAudioRecorder.kt`) already emits `audio/mp4` (valid) — unchanged; no APK rebuild required for the WebView fix.
- Could not E2E on a physical Android device; verified via jest + code path. Recommend a quick prod E2E voice send from the Android app post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)