### PR TITLE
fix(parity): restore missing cross-platform endpoints (GH#3286)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -20764,12 +20764,17 @@ app.get('/sw.js', (req, res) => {
     res.sendFile(path.join(__dirname, 'public/sw.js'));
 });
 
-app.get('/api/push/vapid-public-key', (req, res) => {
+function handleVapidPublicKey(req, res) {
     if (!process.env.VAPID_PUBLIC_KEY) {
         return res.status(503).json({ success: false, error: 'Web Push not configured' });
     }
     res.json({ success: true, publicKey: process.env.VAPID_PUBLIC_KEY });
-});
+}
+app.get('/api/push/vapid-public-key', handleVapidPublicKey);
+// Cross-platform parity alias (GH#3286): mobile/web audit clients probe the
+// notifications-namespaced path. Forward to the same handler so any client
+// path resolves identically.
+app.get('/api/notifications/vapid-key', handleVapidPublicKey);
 
 app.post('/api/push/subscribe', async (req, res) => {
     const deviceId = authDevice(req);
@@ -21957,7 +21962,7 @@ app.post('/api/portal/beacons', express.json({ limit: '64kb' }), beaconLimiter, 
 });
 
 // GET /api/device-telemetry — Read telemetry for debugging
-app.get('/api/device-telemetry', async (req, res) => {
+async function handleDeviceTelemetryRead(req, res) {
     const { deviceId, deviceSecret, type, page, action, since, until, limit } = req.query;
     if (!deviceId || !deviceSecret) {
         return res.status(400).json({ success: false, error: 'deviceId and deviceSecret required' });
@@ -21968,7 +21973,11 @@ app.get('/api/device-telemetry', async (req, res) => {
     }
     const entries = await telemetry.getEntries(chatPool, deviceId, { type, page, action, since, until, limit });
     res.json({ success: true, count: entries.length, entries });
-});
+}
+app.get('/api/device-telemetry', handleDeviceTelemetryRead);
+// Cross-platform parity alias (GH#3286): audit clients probe the short
+// `/api/telemetry` path. Forward to the same device-scoped handler.
+app.get('/api/telemetry', handleDeviceTelemetryRead);
 
 // GET /api/device-telemetry/summary — Quick overview of a device's buffer
 app.get('/api/device-telemetry/summary', async (req, res) => {

--- a/backend/tests/jest/parity-aliases-3286.test.js
+++ b/backend/tests/jest/parity-aliases-3286.test.js
@@ -1,0 +1,130 @@
+/**
+ * Cross-platform parity endpoint aliases (GH#3286)
+ *
+ * The bot audit (entity #3) reported three endpoints as "missing" but they
+ * existed under different canonical paths. This suite locks in the additive
+ * path aliases added to backend/index.js so a client probing either the
+ * canonical OR the audit-expected path resolves to identical behavior:
+ *
+ *   /api/notifications/vapid-key  -> same handler as /api/push/vapid-public-key
+ *   /api/telemetry                -> same handler as /api/device-telemetry
+ *
+ * These tests mirror the exact handler functions and dual-path registration
+ * used in index.js (the monolith is too heavy to boot under jest), proving
+ * the alias contract: same status + same body shape on both paths.
+ */
+
+const express = require('express');
+const request = require('supertest');
+
+// ---- shims that mirror index.js dependencies for these two handlers ----
+function safeEqual(a, b) {
+    if (typeof a !== 'string' || typeof b !== 'string') return false;
+    if (a.length !== b.length) return false;
+    let diff = 0;
+    for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+    return diff === 0;
+}
+
+const deviceId = 'dev-1';
+const deviceSecret = 'sec-1';
+const devices = { [deviceId]: { deviceSecret } };
+
+const telemetry = {
+    getEntries: jest.fn().mockResolvedValue([{ ts: 1, type: 'api', action: 'GET /x' }]),
+};
+const chatPool = {};
+
+// ---- handlers copied 1:1 from index.js (the code under test) ----
+function handleVapidPublicKey(req, res) {
+    if (!process.env.VAPID_PUBLIC_KEY) {
+        return res.status(503).json({ success: false, error: 'Web Push not configured' });
+    }
+    res.json({ success: true, publicKey: process.env.VAPID_PUBLIC_KEY });
+}
+
+async function handleDeviceTelemetryRead(req, res) {
+    const { deviceId: did, deviceSecret: dsec, type, page, action, since, until, limit } = req.query;
+    if (!did || !dsec) {
+        return res.status(400).json({ success: false, error: 'deviceId and deviceSecret required' });
+    }
+    const device = devices[did];
+    if (!device || !safeEqual(device.deviceSecret, dsec)) {
+        return res.status(401).json({ success: false, error: 'Invalid credentials' });
+    }
+    const entries = await telemetry.getEntries(chatPool, did, { type, page, action, since, until, limit });
+    res.json({ success: true, count: entries.length, entries });
+}
+
+function buildApp() {
+    const app = express();
+    app.use(express.json());
+    // dual registration, exactly as index.js wires it
+    app.get('/api/push/vapid-public-key', handleVapidPublicKey);
+    app.get('/api/notifications/vapid-key', handleVapidPublicKey);
+    app.get('/api/device-telemetry', handleDeviceTelemetryRead);
+    app.get('/api/telemetry', handleDeviceTelemetryRead);
+    return app;
+}
+
+describe('GH#3286 VAPID key alias', () => {
+    const OLD_ENV = process.env.VAPID_PUBLIC_KEY;
+    afterAll(() => { process.env.VAPID_PUBLIC_KEY = OLD_ENV; });
+
+    it('canonical and alias both return the key when configured', async () => {
+        process.env.VAPID_PUBLIC_KEY = 'BTestKey123';
+        const app = buildApp();
+        const canonical = await request(app).get('/api/push/vapid-public-key');
+        const alias = await request(app).get('/api/notifications/vapid-key');
+        expect(canonical.status).toBe(200);
+        expect(alias.status).toBe(200);
+        expect(alias.body).toEqual(canonical.body);
+        expect(alias.body).toEqual({ success: true, publicKey: 'BTestKey123' });
+    });
+
+    it('canonical and alias both 503 when not configured', async () => {
+        delete process.env.VAPID_PUBLIC_KEY;
+        const app = buildApp();
+        const canonical = await request(app).get('/api/push/vapid-public-key');
+        const alias = await request(app).get('/api/notifications/vapid-key');
+        expect(canonical.status).toBe(503);
+        expect(alias.status).toBe(503);
+        expect(alias.body).toEqual(canonical.body);
+    });
+});
+
+describe('GH#3286 telemetry alias', () => {
+    afterEach(() => telemetry.getEntries.mockClear());
+
+    it('400 on both paths without creds', async () => {
+        const app = buildApp();
+        const canonical = await request(app).get('/api/device-telemetry');
+        const alias = await request(app).get('/api/telemetry');
+        expect(canonical.status).toBe(400);
+        expect(alias.status).toBe(400);
+        expect(alias.body).toEqual(canonical.body);
+    });
+
+    it('401 on both paths with bad creds', async () => {
+        const app = buildApp();
+        const q = `?deviceId=${deviceId}&deviceSecret=wrong`;
+        const canonical = await request(app).get('/api/device-telemetry' + q);
+        const alias = await request(app).get('/api/telemetry' + q);
+        expect(canonical.status).toBe(401);
+        expect(alias.status).toBe(401);
+        expect(alias.body).toEqual(canonical.body);
+    });
+
+    it('200 with entries on both paths with valid creds (entity/device-scoped)', async () => {
+        const app = buildApp();
+        const q = `?deviceId=${deviceId}&deviceSecret=${deviceSecret}`;
+        const canonical = await request(app).get('/api/device-telemetry' + q);
+        const alias = await request(app).get('/api/telemetry' + q);
+        expect(canonical.status).toBe(200);
+        expect(alias.status).toBe(200);
+        expect(alias.body).toEqual(canonical.body);
+        expect(alias.body).toMatchObject({ success: true, count: 1 });
+        // scoped to the authenticated device, never global
+        expect(telemetry.getEntries).toHaveBeenLastCalledWith(chatPool, deviceId, expect.any(Object));
+    });
+});


### PR DESCRIPTION
Closes the actionable parts of #3286.

## Per-endpoint current-status verdict
All endpoints in #3286 were re-probed against `https://eclawbot.com` (Chrome UA, device creds from the card's AVAILABLE TOOLS block). The audit's reported statuses were partly stale and partly used the wrong path/creds.

| Endpoint (as reported in #3286) | Reported | Actual current | Verdict | Action |
|---|---|---|---|---|
| `/api/chat/history` | 404 | **200** | Already works | none |
| `/api/mission/dashboard` | 401 | **200** | Already works | none |
| `/api/schedules` | 410 | 410 | **Intentional** deprecation (`{deprecated:true, redirect:"kanban"}`) | none — keep |
| `/api/contacts` | 401 | 401 | **Correct auth** — needs `deviceSecret`; audit probed with `botSecret`/`entityId` | none |
| `/api/feedback` | 400 | 400 | **Correct auth** — needs `deviceId`+`deviceSecret`; audit sent none | none |
| `/api/notifications/vapid-key` | 404 | 404 | **Wrong path** — real endpoint is `/api/push/vapid-public-key` (200) | **alias added** |
| `/api/telemetry` | 404 | 404 | **Wrong path** — real endpoint is `/api/device-telemetry` (400 w/o creds) | **alias added** |

## What was restored / changed
No endpoints were genuinely missing — the two true gaps were path-naming mismatches between what cross-platform audit/mobile clients probe and the canonical server paths. Fixed with additive GET aliases that forward to the **same** handlers (no logic fork):

- `GET /api/notifications/vapid-key` -> `handleVapidPublicKey` (same as `/api/push/vapid-public-key`)
- `GET /api/telemetry` -> `handleDeviceTelemetryRead` (same as `/api/device-telemetry`)

Both handlers remain device-scoped: VAPID key gate on `VAPID_PUBLIC_KEY` env; telemetry requires `deviceId`+`deviceSecret` auth and queries only the authenticated device's rows (multi-tenant safe — no global read).

Targeted Edits to `backend/index.js` only; no wholesale rewrite. The handlers were extracted to named functions and registered on both paths.

## Tests
`backend/tests/jest/parity-aliases-3286.test.js` — 5 cases, all green:
- VAPID: canonical + alias both 200 (configured) and both 503 (unconfigured), identical bodies
- Telemetry: canonical + alias both 400 (no creds), 401 (bad creds), 200 (valid creds), identical bodies + device-scoped query assertion

```
PASS tests/jest/parity-aliases-3286.test.js
Tests: 5 passed, 5 total
```

`node --check backend/index.js` passes.

## Remaining / not in scope
- `/api/schedules` 410 is by design (kanban replacement) — no change, matches existing intent.
- `/api/contacts` 401 and `/api/feedback` 400 are correct auth behavior; the audit (entity #3) should probe them with `deviceSecret`, not `botSecret`/`entityId`. Recommend updating the bot-audit harness to use canonical paths + device creds to stop emitting false parity gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)