### PR TITLE
fix(tts): Bug#161 手機 TTS 沒聲音

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -20720,6 +20720,19 @@ app.post('/api/device/tts', async (req, res) => {
         metadata: { lang: ttsLang, speed: ttsSpeed, pitch: ttsPitch, textLen: text.length }
     });
 
+    // Bug #161 (GH #2862): TTS was fire-and-forget — it emitted to the
+    // Socket.IO room and called sendFcm() without ever checking whether
+    // EITHER channel could actually reach the device, yet always returned
+    // success:true. When the device was offline AND had no fcmToken
+    // (log: "fcm_send: skip: no fcmToken for device"), the audio silently
+    // vanished but the bot was told it succeeded and told the user
+    // "語音已發送!". Make delivery observable so the caller knows the truth.
+    let socketsOnline = 0;
+    try {
+        const sockets = await io.in(`device:${deviceId}`).fetchSockets();
+        socketsOnline = sockets.length;
+    } catch (_) { /* fetchSockets unavailable (e.g. tests) → treat as offline */ }
+
     // Emit via Socket.IO to the device
     io.to(`device:${deviceId}`).emit('device:tts', {
         text,
@@ -20731,16 +20744,47 @@ app.post('/api/device/tts', async (req, res) => {
     });
 
     // Also send FCM data message as fallback (in case Socket.IO is disconnected)
+    let fcmDelivered = false;
     if (typeof sendFcm === 'function') {
-        sendFcm(deviceId, {
-            title: entityName,
-            body: text,
-            category: 'tts',
-            link: ''
-        }).catch(() => {});
+        try {
+            fcmDelivered = await sendFcm(deviceId, {
+                title: entityName,
+                body: text,
+                category: 'tts',
+                link: ''
+            });
+        } catch (_) { fcmDelivered = false; }
     }
 
-    res.json({ success: true, message: `TTS command sent to device`, lang: ttsLang, speed: ttsSpeed, pitch: ttsPitch });
+    const channels = [];
+    if (socketsOnline > 0) channels.push('socket');
+    if (fcmDelivered) channels.push('fcm');
+    const delivered = channels.length > 0;
+
+    if (!delivered) {
+        // No viable delivery channel — surface it instead of a false success
+        // so the bot does not tell the user the voice was sent.
+        serverLog('warn', 'tts', 'no delivery channel: device offline and no FCM fallback', {
+            deviceId, entityId: eId,
+            metadata: { socketsOnline, fcmDelivered, hasFcmToken: !!device.fcmToken }
+        });
+        return res.json({
+            success: true,
+            delivered: false,
+            via: channels,
+            warning: 'tts_not_delivered',
+            message: 'TTS command accepted but the device is offline and has no push fallback — no audio will play. Open the EClaw app on the device.',
+            lang: ttsLang, speed: ttsSpeed, pitch: ttsPitch
+        });
+    }
+
+    res.json({
+        success: true,
+        delivered: true,
+        via: channels,
+        message: `TTS command sent to device`,
+        lang: ttsLang, speed: ttsSpeed, pitch: ttsPitch
+    });
 });
 
 // Prune old notifications daily
@@ -20902,13 +20946,13 @@ try {
 async function sendFcm(deviceId, notif) {
     if (!firebaseAdmin) {
         serverLog('warn', 'fcm_send', 'skip: firebaseAdmin not initialized', { deviceId, metadata: { category: notif?.category } });
-        return;
+        return false;
     }
     const device = devices[deviceId];
     const token = device?.fcmToken;
     if (!token) {
         serverLog('warn', 'fcm_send', 'skip: no fcmToken for device', { deviceId, metadata: { deviceExists: !!device, category: notif?.category } });
-        return;
+        return false;
     }
     const tokenPrefix = token.slice(0, 12);
     // Silent categories handled by the app's FCM service (start TtsService,
@@ -20931,12 +20975,14 @@ async function sendFcm(deviceId, notif) {
     try {
         const resp = await firebaseAdmin.messaging().send(fcmMessage);
         serverLog('info', 'fcm_send', 'sent OK', { deviceId, metadata: { tokenPrefix, category: notif?.category, messageId: resp } });
+        return true;
     } catch (e) {
         if (e.code === 'messaging/registration-token-not-registered') {
             delete devices[deviceId]?.fcmToken;
             chatPool.query('UPDATE devices SET fcm_token = NULL WHERE device_id = $1', [deviceId]).catch(() => {});
         }
         serverLog('error', 'fcm_send', `send failed: ${e.message}`, { deviceId, metadata: { tokenPrefix, code: e.code } });
+        return false;
     }
 }
 

--- a/backend/public/portal/info.html
+++ b/backend/public/portal/info.html
@@ -1968,6 +1968,8 @@ async function replyWithVoice(message, deviceId, entityId, botSecret) {
 
                         <div class="note" data-i18n="guide_voice_note">💡 <strong>提示：</strong>TTS 目前僅支援 Android 裝置。iOS 支援規劃中。文字長度上限 500 字，超過請分段呼叫。</div>
 
+                        <div class="note" data-i18n="[html]guide_voice_delivery_note">🔇 <strong>沒聽到聲音？</strong>TTS 需要裝置上線（EClaw App 開啟、登入並連上 Socket.IO），或已註冊推播（FCM）作為斷線備援。若兩者皆無，伺服器會回傳 <code>delivered:false</code> 與 <code>warning:"tts_not_delivered"</code>，代表指令已接收但沒有任何聲音播出 —— 請在裝置上開啟 EClaw App 後再試一次。</div>
+
                         <div class="cta-links">
                             <h3 data-i18n="guide_voice_cta_title">立即試用</h3>
                             <p class="cta-item" data-i18n="[html]guide_voice_cta_api">API 文件：<a href="https://eclawbot.com/api/skill-doc" target="_blank" rel="noopener">完整 API Skill Doc</a></p>

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650308,6 +650308,8 @@ const TRANSLATIONS = {
         "card_retest_tier_red": "Urgent",
         "card_retest_tier_green": "Lifting",
         "card_retest_tier_ready": "Ready",
+
+        "guide_voice_delivery_note": "🔇 <strong>No sound?</strong> TTS requires the device to be online (EClaw App open, signed in, and connected via Socket.IO), or to have push (FCM) registered as an offline fallback. If neither is available, the server returns <code>delivered:false</code> with <code>warning:\"tts_not_delivered\"</code>, meaning the command was accepted but no audio will play — open the EClaw App on the device and try again.",
 },
 
 
@@ -1235082,6 +1235084,8 @@ const TRANSLATIONS = {
         "card_retest_tier_red": "緊急",
         "card_retest_tier_green": "即將解鎖",
         "card_retest_tier_ready": "可重測",
+
+        "guide_voice_delivery_note": "🔇 <strong>沒聽到聲音？</strong>TTS 需要裝置上線（EClaw App 開啟、登入並連上 Socket.IO），或已註冊推播（FCM）作為斷線備援。若兩者皆無，伺服器會回傳 <code>delivered:false</code> 與 <code>warning:\"tts_not_delivered\"</code>，代表指令已接收但沒有任何聲音播出 —— 請在裝置上開啟 EClaw App 後再試一次。",
 },
 
 

--- a/backend/tests/jest/device-tts-delivery.test.js
+++ b/backend/tests/jest/device-tts-delivery.test.js
@@ -1,0 +1,133 @@
+/**
+ * POST /api/device/tts — delivery-awareness tests (Jest + Supertest)
+ *
+ * Regression coverage for Bug #161 / GH #2862
+ * ("tts 語音發送失敗 手機裝置沒聽到聲音"):
+ *
+ * The endpoint used to emit a Socket.IO event + fire sendFcm() without ever
+ * checking whether EITHER channel could reach the device, yet always returned
+ * success:true. When the device was offline AND had no fcmToken
+ * (log: "fcm_send: skip: no fcmToken for device") the audio silently vanished
+ * but the bot was told it succeeded.
+ *
+ * These tests pin the response *shape* so a regression to silent
+ * fire-and-forget is caught:
+ *   - validation / auth still behaves
+ *   - offline + no FCM  -> success:true BUT delivered:false +
+ *                          warning:"tts_not_delivered" + via:[] + message present
+ *   - lang/speed/pitch echoed back and clamped to defaults
+ */
+
+require('./helpers/mock-setup');
+
+const request = require('supertest');
+let app;
+
+const post = (path) => request(app).post(path).set('Host', 'localhost');
+
+async function registerDevice(id) {
+    const secret = `secret-${id}`;
+    await post('/api/device/register')
+        .send({ deviceId: id, deviceSecret: secret, entityId: 0 });
+    return secret;
+}
+
+beforeAll(() => {
+    app = require('../../index');
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+    jest.resetModules();
+});
+
+describe('POST /api/device/tts — validation & auth', () => {
+    it('400 when deviceId missing', async () => {
+        const res = await post('/api/device/tts').send({ text: 'hi' });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+    });
+
+    it('400 when text missing', async () => {
+        const res = await post('/api/device/tts').send({ deviceId: 'tts-d1' });
+        expect(res.status).toBe(400);
+        expect(res.body.success).toBe(false);
+    });
+
+    it('400 when text exceeds 500 chars', async () => {
+        const deviceId = 'tts-long';
+        const secret = await registerDevice(deviceId);
+        const res = await post('/api/device/tts')
+            .send({ deviceId, deviceSecret: secret, entityId: 0, text: 'x'.repeat(501) });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/500 characters/i);
+    });
+
+    it('404 for unknown device', async () => {
+        const res = await post('/api/device/tts')
+            .send({ deviceId: 'tts-nope', deviceSecret: 'sec', text: 'hi' });
+        expect(res.status).toBe(404);
+        expect(res.body.error).toMatch(/not found/i);
+    });
+
+    it('400 for negative entityId', async () => {
+        const deviceId = 'tts-neg';
+        const secret = await registerDevice(deviceId);
+        const res = await post('/api/device/tts')
+            .send({ deviceId, deviceSecret: secret, entityId: -1, text: 'hi' });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toMatch(/invalid entityId/i);
+    });
+
+    it('403/400 for wrong botSecret on unbound entity', async () => {
+        const deviceId = 'tts-auth';
+        await registerDevice(deviceId);
+        const res = await post('/api/device/tts')
+            .send({ deviceId, botSecret: 'wrong', entityId: 0, text: 'hi' });
+        expect([400, 403]).toContain(res.status);
+        expect(res.body.success).toBe(false);
+    });
+});
+
+describe('POST /api/device/tts — Bug #161 delivery awareness', () => {
+    it('offline device with no FCM token reports delivered:false + tts_not_delivered', async () => {
+        const deviceId = 'tts-offline';
+        const secret = await registerDevice(deviceId);
+
+        const res = await post('/api/device/tts')
+            .send({ deviceId, deviceSecret: secret, entityId: 0, text: '您好' });
+
+        // Request itself is valid (200/success:true) but delivery is honestly false
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.delivered).toBe(false);
+        expect(res.body.warning).toBe('tts_not_delivered');
+        expect(Array.isArray(res.body.via)).toBe(true);
+        expect(res.body.via).toHaveLength(0);
+        // Non-empty, actionable message so a bot does not falsely claim success
+        expect(typeof res.body.message).toBe('string');
+        expect(res.body.message.length).toBeGreaterThan(0);
+    });
+
+    it('response always carries the delivered flag (never silent fire-and-forget)', async () => {
+        const deviceId = 'tts-shape';
+        const secret = await registerDevice(deviceId);
+        const res = await post('/api/device/tts')
+            .send({ deviceId, deviceSecret: secret, entityId: 0, text: 'hello' });
+        expect(res.body).toHaveProperty('delivered');
+        expect(res.body).toHaveProperty('via');
+    });
+
+    it('echoes & clamps lang/speed/pitch to defaults for out-of-range input', async () => {
+        const deviceId = 'tts-params';
+        const secret = await registerDevice(deviceId);
+        const res = await post('/api/device/tts')
+            .send({ deviceId, deviceSecret: secret, entityId: 0, text: 'hi',
+                    lang: 'en-US', speed: 99, pitch: 0.01 });
+        expect(res.status).toBe(200);
+        expect(res.body.lang).toBe('en-US');
+        expect(res.body.speed).toBe(1.0); // 99 out of [0.5,2.0] -> default
+        expect(res.body.pitch).toBe(1.0); // 0.01 out of range -> default
+    });
+});


### PR DESCRIPTION
## Scope
Fix GH #2862 / Bug #161「tts 語音發送失敗 手機裝置沒聽到聲音」(Android 1.0.84). Kanban card_5a22ccfdf6d295ba963b48b1.

## Root cause
`POST /api/device/tts` was fire-and-forget. It emitted a `device:tts` Socket.IO event **without checking room membership**, then called `sendFcm()` as a "fallback" — but `sendFcm()` silently returns when the device has no `fcmToken` (issue log: `[WARN] fcm_send: skip: no fcmToken for device`). The endpoint then **always returned `success:true`** regardless of whether either channel actually reached the device.

Result for the reporting device (offline socket + no FCM token): the TTS command silently vanished, the bot was told it succeeded, and the bot told the user「語音已再次發送！」— but no audio ever played. The existing voice guide even advertised "FCM 備援" as if delivery were guaranteed.

## Fix (targeted, no rewrite)
- `sendFcm()` now returns a boolean (`true` sent / `false` skipped-or-failed).
- `/api/device/tts`:
  - checks Socket.IO room membership via `io.in(...).fetchSockets()` (wrapped in try/catch → offline if unavailable),
  - awaits `sendFcm()` to learn if the push fallback actually fired,
  - returns `delivered` + `via[]` (`socket` / `fcm`),
  - on **no viable channel**: returns `success:true, delivered:false, via:[], warning:"tts_not_delivered"` + an actionable message, and emits a `warn` serverLog. The bot can now read `delivered`/`warning` and avoid falsely claiming success.
- `info.html` voice guide: added a「沒聽到聲音？」? icon UX note documenting the online/FCM requirement + the `delivered:false` response shape (Globe-user setup condition). i18n keys `guide_voice_delivery_note` added for **EN + ZH** via `backend/scripts/i18n-insert-locale-keys.js` (other locales fall back to en by design).

## Test
`backend/tests/jest/device-tts-delivery.test.js` (new, 9 cases) pins the response shape so a regression to silent fire-and-forget is caught: validation/auth, offline+no-FCM → `delivered:false`+`tts_not_delivered`+empty `via`+non-empty message, `delivered` flag always present, lang/speed/pitch echo+clamp.

```
$ npx jest tests/jest/device-tts-delivery.test.js tests/jest/screen-control.test.js
Test Suites: 2 passed, 2 total
Tests:       45 passed, 45 total
```
i18n parity/lint/syntax suites also pass (4 suites / 42 tests; dup-key + syntax green).

## Out of scope
- Android-side TtsService/foreground-service behavior (client). This PR makes the **server** delivery state observable; if delivery never had a channel the client never had a chance. A follow-up could surface `delivered:false` in the bot's reply text directly.

## User POV
A bot that calls TTS to an offline device now gets `delivered:false` instead of a false success, and the portal voice guide tells the user exactly what's needed (open the app / register push) when there's no sound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)