### PR TITLE
feat(hermes): structured JSON logging + shape test

### DIFF
--- a/backend/hermes-health-check.js
+++ b/backend/hermes-health-check.js
@@ -27,12 +27,49 @@ function sanitizeForLog(value) {
         .replace(/(https?:\/\/)[^@\s]+@/gi, '$1[redacted]@')
         .replace(/\b(?:ghp|gho|ghu|ghs|ghr)_[A-Za-z0-9_]{20,}\b/g, '[redacted]')
         .replace(/\bgithub_pat_[A-Za-z0-9_]{20,}\b/g, '[redacted]')
-        .replace(/\bx-access-token:[^@\s]+@/gi, 'x-access-token:[redacted]@');
+        .replace(/\bx-access-token:[^@\s]+@/gi, 'x-access-token:[redacted]@')
+        // Connection strings (e.g. DATABASE_URL): scheme://user:pass@host -> scheme://[redacted]@host
+        .replace(/\b([a-z][a-z0-9+.-]*:\/\/)[^@\s/]+:[^@\s/]+@/gi, '$1[redacted]@')
+        // key=value style secrets (botSecret/token/secret/password/api_key/database_url)
+        .replace(/\b(bot_?secret|device_?secret|secret|token|password|passwd|api[_-]?key|database_?url)\s*[=:]\s*['"]?[^\s'"&]+/gi, '$1=[redacted]');
 }
 
 function clip(value, max = MAX_ERROR_CHARS) {
     const s = sanitizeForLog(value).replace(/\s+/g, ' ').trim();
     return s.length > max ? s.slice(0, max - 3) + '...' : s;
+}
+
+const HERMES_LOG_LEVELS = new Set(['debug', 'info', 'warn', 'error']);
+
+// Build a single structured log record. Pure (testable) — no I/O, no clock unless
+// caller omits `now`. Always returns the canonical field set so Railway log-drain →
+// Loki can rely on a stable schema. Secrets are stripped from `event`/`error`.
+function formatHermesLog(level, event, fields = {}, now = () => Date.now()) {
+    const { duration_ms, error, ...rest } = fields || {};
+    const record = {
+        timestamp: new Date(now()).toISOString(),
+        level: HERMES_LOG_LEVELS.has(level) ? level : 'info',
+        service: 'hermes',
+        event: clip(event || 'unknown', 120),
+        duration_ms: Number.isFinite(duration_ms) ? Math.round(duration_ms) : null,
+        error: error == null ? null : clip(error, MAX_ERROR_CHARS),
+    };
+    // Merge any extra structured metadata, sanitizing string values; never let a
+    // caller-supplied field clobber the canonical ones above.
+    for (const [k, v] of Object.entries(rest)) {
+        if (k in record) continue;
+        record[k] = typeof v === 'string' ? clip(v, MAX_ERROR_CHARS) : v;
+    }
+    return record;
+}
+
+// Emit one JSON object per line on stdout (warn/error → stderr) for Railway drain.
+function hermesLog(level, event, fields = {}, { now, out = process.stdout, err = process.stderr } = {}) {
+    const record = formatHermesLog(level, event, fields, now);
+    const line = JSON.stringify(record) + '\n';
+    const sink = (record.level === 'warn' || record.level === 'error') ? err : out;
+    sink.write(line);
+    return record;
 }
 
 function loadConfig(env = process.env) {
@@ -174,6 +211,9 @@ function createHermesHealthMonitor({
     execFile = defaultExecFile,
     notifyDevice = null,
     audit = () => {},
+    // Structured JSON sink (stdout) consumed by Railway log-drain → Loki.
+    // Injectable for tests; defaults to the real stdout/stderr emitter.
+    jsonLog = (level, event, fields) => hermesLog(level, event, fields, { now }),
     now = () => Date.now(),
 } = {}) {
     const state = initialState();
@@ -262,6 +302,9 @@ function createHermesHealthMonitor({
                 result: 'skipped',
                 metadata: { reason, skipReason: config.skipReason },
             });
+            jsonLog('info', 'hermes_health_check', {
+                result: 'skipped', reason, skip_reason: config.skipReason, duration_ms: 0,
+            });
             return { ok: null, skipped: true, reason: config.skipReason };
         }
 
@@ -282,6 +325,9 @@ function createHermesHealthMonitor({
                 action: 'hermes_health_check',
                 result: 'ok',
                 metadata: { reason, durationMs: probe.durationMs, branch: probe.branch, remote: probe.remote },
+            });
+            jsonLog('info', 'hermes_health_check', {
+                result: 'ok', reason, duration_ms: probe.durationMs, branch: probe.branch, remote: probe.remote,
             });
             return { ...probe, skipped: false };
         } catch (err) {
@@ -304,6 +350,11 @@ function createHermesHealthMonitor({
                     durationMs: state.lastDurationMs,
                 },
             });
+            jsonLog('error', 'hermes_health_check', {
+                result: 'failed', reason, error,
+                duration_ms: state.lastDurationMs,
+                consecutive_failures: state.consecutiveFailures,
+            });
 
             let alert = null;
             if (state.consecutiveFailures >= ALERT_FAILURE_THRESHOLD
@@ -324,11 +375,11 @@ function createHermesHealthMonitor({
     function startCron({ nodeCron } = {}) {
         const config = loadConfig(env);
         if (!config.enabled) {
-            console.log('[HermesHealth] disabled via HERMES_HEALTHCHECK_ENABLED=0');
+            hermesLog('info', 'hermes_health_cron_disabled', { reason: 'HERMES_HEALTHCHECK_ENABLED=0' });
             return () => {};
         }
         if (!config.configured) {
-            console.log(`[HermesHealth] cron not scheduled: ${config.skipReason}`);
+            hermesLog('info', 'hermes_health_cron_not_scheduled', { reason: config.skipReason });
             return () => {};
         }
         if (!nodeCron || typeof nodeCron.schedule !== 'function') {
@@ -337,7 +388,7 @@ function createHermesHealthMonitor({
 
         const task = nodeCron.schedule(config.cron, () => {
             runOnce('cron').catch(err => {
-                console.error('[HermesHealth] cron tick error:', err && err.message);
+                hermesLog('error', 'hermes_health_cron_tick_error', { error: err && err.message });
             });
         }, { timezone: config.timezone });
         audit('info', 'hermes_health', `[HermesHealth] scheduled ${config.cron} ${config.timezone}`, {
@@ -364,6 +415,8 @@ module.exports = {
     loadConfig,
     sanitizeForLog,
     computeSla,
+    formatHermesLog,
+    hermesLog,
     ALERT_FAILURE_THRESHOLD,
     DEFAULT_CRON,
     DEFAULT_TIMEOUT_MS,

--- a/backend/index.js
+++ b/backend/index.js
@@ -39,7 +39,7 @@ const compression = require('compression');
 
 const safeEqual = require('./safe-equal');
 const { safeUpdatedAtToISO } = require('./safe-date');
-const { createHermesHealthMonitor } = require('./hermes-health-check');
+const { createHermesHealthMonitor, hermesLog } = require('./hermes-health-check');
 const { createSettingsHelpInvariantCron } = require('./settings-help-invariant-cron');
 
 // ============================================
@@ -21170,7 +21170,7 @@ if (process.env.NODE_ENV !== 'test') {
     try {
         hermesHealthMonitor.startCron({ nodeCron });
     } catch (err) {
-        console.error('[HermesHealth] failed to schedule cron:', err && err.message);
+        hermesLog('error', 'hermes_health_cron_schedule_failed', { error: err && err.message });
         serverLog('error', 'hermes_health', `[HermesHealth] failed to schedule cron: ${err && err.message}`, {
             action: 'hermes_health_check',
             result: 'schedule_failed',

--- a/backend/tests/jest/hermes-json-log.test.js
+++ b/backend/tests/jest/hermes-json-log.test.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const {
+    createHermesHealthMonitor,
+    formatHermesLog,
+    hermesLog,
+} = require('../../hermes-health-check');
+
+const REQUIRED_FIELDS = ['timestamp', 'level', 'service', 'event', 'duration_ms', 'error'];
+
+function execResponder(handler) {
+    return jest.fn((file, args, options, cb) => {
+        try {
+            const result = handler({ file, args, options });
+            if (result instanceof Error) {
+                cb(result, result.stdout || '', result.stderr || result.message);
+                return;
+            }
+            cb(null, result?.stdout || '', result?.stderr || '');
+        } catch (err) {
+            cb(err, err.stdout || '', err.stderr || err.message);
+        }
+    });
+}
+
+function failingGit(message) {
+    const err = new Error(message);
+    err.code = 128;
+    err.stderr = message;
+    return err;
+}
+
+describe('Hermes structured JSON logging (H2 t6)', () => {
+    const FIXED_NOW = () => Date.parse('2026-06-17T00:00:00.000Z');
+
+    test('formatHermesLog emits the canonical field set as a JSON-serializable object', () => {
+        const record = formatHermesLog('info', 'probe_ok', { duration_ms: 1234.7 }, FIXED_NOW);
+
+        // valid JSON round-trip
+        const parsed = JSON.parse(JSON.stringify(record));
+        for (const field of REQUIRED_FIELDS) {
+            expect(parsed).toHaveProperty(field);
+        }
+        expect(parsed.timestamp).toBe('2026-06-17T00:00:00.000Z');
+        expect(parsed.level).toBe('info');
+        expect(parsed.service).toBe('hermes');
+        expect(parsed.event).toBe('probe_ok');
+        expect(parsed.duration_ms).toBe(1235); // rounded
+        expect(parsed.error).toBeNull();
+    });
+
+    test('unknown levels fall back to info; non-finite duration becomes null', () => {
+        const a = formatHermesLog('LOUD', 'x', {}, FIXED_NOW);
+        expect(a.level).toBe('info');
+        expect(a.duration_ms).toBeNull();
+        const b = formatHermesLog('warn', 'y', { duration_ms: NaN }, FIXED_NOW);
+        expect(b.level).toBe('warn');
+        expect(b.duration_ms).toBeNull();
+    });
+
+    test('extra metadata is merged but cannot clobber canonical fields', () => {
+        const record = formatHermesLog('info', 'evt', {
+            reason: 'cron',
+            service: 'attacker',     // must not override
+            timestamp: 'fake',       // must not override
+            consecutive_failures: 2,
+        }, FIXED_NOW);
+        expect(record.service).toBe('hermes');
+        expect(record.timestamp).toBe('2026-06-17T00:00:00.000Z');
+        expect(record.reason).toBe('cron');
+        expect(record.consecutive_failures).toBe(2);
+    });
+
+    test('secrets are redacted from event and error fields', () => {
+        const record = formatHermesLog('error', 'push_failed', {
+            error: 'fatal: auth failed for https://x-access-token:ghp_abcdefghijklmnopqrstuvwxyz@github.com/acme/repo.git '
+                + 'botSecret=c4f39efb2c46346e00da5c394efc3e97 token=supersecretvalue '
+                + 'DATABASE_URL=postgres://user:p4ssw0rd@db.internal:5432/eclaw',
+        }, FIXED_NOW);
+        const serialized = JSON.stringify(record);
+        expect(serialized).not.toContain('ghp_abcdefghijklmnopqrstuvwxyz');
+        expect(serialized).not.toContain('c4f39efb2c46346e00da5c394efc3e97');
+        expect(serialized).not.toContain('supersecretvalue');
+        expect(serialized).not.toContain('p4ssw0rd');
+        expect(serialized).toContain('[redacted]');
+    });
+
+    test('hermesLog writes exactly one valid JSON line; warn/error go to stderr', () => {
+        const out = { writes: [], write(s) { this.writes.push(s); } };
+        const err = { writes: [], write(s) { this.writes.push(s); } };
+
+        hermesLog('info', 'info_event', { duration_ms: 10 }, { now: FIXED_NOW, out, err });
+        hermesLog('error', 'err_event', { error: 'boom' }, { now: FIXED_NOW, out, err });
+
+        expect(out.writes).toHaveLength(1);
+        expect(err.writes).toHaveLength(1);
+
+        // each write is a single newline-terminated line (no plain-text leakage)
+        for (const line of [...out.writes, ...err.writes]) {
+            expect(line.endsWith('\n')).toBe(true);
+            expect(line.trimEnd().split('\n')).toHaveLength(1);
+            const parsed = JSON.parse(line); // throws if not valid JSON => plain text leak
+            for (const field of REQUIRED_FIELDS) {
+                expect(parsed).toHaveProperty(field);
+            }
+        }
+    });
+
+    test('every monitor lifecycle emission is structured JSON with required fields', async () => {
+        const lines = [];
+        const sink = { write(s) { lines.push(s); } };
+        let fail = true;
+        const execFile = execResponder(({ args }) => {
+            if (args.includes('push') && fail) return failingGit('network unavailable');
+            return { stdout: args.includes('--abbrev-ref') ? 'main\n' : 'true\n' };
+        });
+        const monitor = createHermesHealthMonitor({
+            env: {
+                HERMES_HEALTHCHECK_REPO_DIR: '/repo/hermes',
+                HERMES_HEALTHCHECK_BRANCH: 'main',
+            },
+            execFile,
+            // route the default jsonLog stdout into our capture sink
+            jsonLog: (level, event, fields) =>
+                hermesLog(level, event, fields, { now: FIXED_NOW, out: sink, err: sink }),
+        });
+
+        await monitor.runOnce('test'); // failure path
+        fail = false;
+        await monitor.runOnce('test'); // ok path
+
+        // skipped path on an unconfigured monitor
+        const skipMonitor = createHermesHealthMonitor({
+            env: {},
+            execFile: jest.fn(),
+            jsonLog: (level, event, fields) =>
+                hermesLog(level, event, fields, { now: FIXED_NOW, out: sink, err: sink }),
+        });
+        await skipMonitor.runOnce('test');
+
+        expect(lines.length).toBe(3);
+        const records = lines.map((l) => {
+            expect(l.endsWith('\n')).toBe(true);
+            return JSON.parse(l); // asserts no plain-text leakage
+        });
+        for (const r of records) {
+            for (const field of REQUIRED_FIELDS) expect(r).toHaveProperty(field);
+            expect(r.event).toBe('hermes_health_check');
+            expect(r.service).toBe('hermes');
+        }
+        expect(records.map(r => r.result).sort()).toEqual(['failed', 'ok', 'skipped']);
+        const failed = records.find(r => r.result === 'failed');
+        expect(failed.level).toBe('error');
+        expect(failed).toHaveProperty('consecutive_failures', 1);
+    });
+});


### PR DESCRIPTION
## Card
card_d3983f06c023dbaf4e5fb75f — [Hermes/P2] H2 t6: Structured JSON log → Railway drain → Grafana dashboard. This PR ships the **code/log-format part only** (per dispatch); infra is noted as a follow-up below (no blocking).

## Scope
Convert Hermes-side `console.*` output to single-line **structured JSON** on stdout/stderr so Railway log-drain → Grafana Loki can parse a stable schema.

### Canonical log schema
```json
{"timestamp":"<ISO-8601>","level":"info|warn|error|debug","service":"hermes","event":"<snake_case>","duration_ms":<int|null>,"error":"<sanitized|null>"}
```
Plus optional sanitized metadata (`result`, `reason`, `branch`, `remote`, `consecutive_failures`, …) merged in — caller fields can never clobber the canonical ones.

### Files
- **`backend/hermes-health-check.js`**
  - `formatHermesLog(level, event, fields, now)` — pure, testable record builder (normalizes level, rounds/normalizes `duration_ms`, always emits the canonical field set).
  - `hermesLog(level, event, fields, {now,out,err})` — emits one JSON line; `warn`/`error` → stderr, else stdout. Sinks injectable for tests.
  - Hardened `sanitizeForLog` to also redact `botSecret`/`deviceSecret`/`token`/`password`/`api_key`/`DATABASE_URL` `key=value` forms **and** generic `scheme://user:pass@host` connection strings (on top of the existing GH-token / `user:pass@` URL redaction).
  - Monitor now takes an injectable `jsonLog` sink (defaults to real stdout emitter) and emits **ok / failed / skipped** probe outcomes as JSON; the 3 raw `console.*` in `startCron` now route through `hermesLog`.
- **`backend/index.js`** — the hermes cron-schedule-failed `console.error` now routes through `hermesLog` (`hermes_health_cron_schedule_failed`). (DB `serverLog` audit row kept unchanged.)
- **`backend/tests/jest/hermes-json-log.test.js`** — new shape test.

## jest
`backend/tests/jest/hermes-json-log.test.js` + existing `hermes-health-check.test.js` — **12/12 pass**. New suite asserts:
- valid JSON round-trip + all required fields present (no plain-text leakage)
- unknown level → `info`; non-finite `duration_ms` → `null`
- extra metadata merged but **cannot** clobber canonical fields
- secrets (GH token / botSecret / token / `user:pass@` DATABASE_URL) redacted from `event`/`error`
- `hermesLog` writes exactly one newline-terminated JSON line; warn/error → stderr
- full monitor lifecycle (failed/ok/skipped) emits structured JSON with required fields

## Secret safety
Per constraint: no secrets in logs. All `event`/`error`/string-metadata values pass through `sanitizeForLog` before serialization; test asserts botSecret/token/GH-PAT/DATABASE_URL never appear.

## Infra follow-up (NOT in this PR — needs decision, do not block)
The Railway log-drain → Grafana Loki dashboard piece is INFRA:
- **Consult Hermes (publicCode `00vt9i`)**: does the current Railway plan include a log drain, or do we need an upgrade?
- Per the no-new-API-keys constraint, target **Grafana Cloud free tier** (no new key) or self-hosted Loki — pick cheapest given the answer above.
- Remaining dashboard panels (from card acceptance): P50/P95/P99 webhook→PR latency, error rate by event type, active session count, P95 < 30s SLO panel (matches `SLA_TARGET_PCT=99`), and a read-only embed at `/portal/dashboard`.

The JSON schema in this PR already carries the fields those panels need (`event`, `duration_ms`, `level`, `result`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)