### PR TITLE
feat(compliance): weekly multi-tenant + platform-rule audit

### DIFF
--- a/backend/agent-improvement/audit-rules.js
+++ b/backend/agent-improvement/audit-rules.js
@@ -26,6 +26,11 @@
  *           optional: skip files that don't match. Returns true to KEEP.
  * @property {string[]} [allowFiles]    substrings — file paths containing any
  *                                       of these are ALWAYS exempt (tests, etc.)
+ * @property {string[]} [falseHits]     lowercased literals that match `pattern`
+ *                                       by shape but are known non-violations
+ *                                       (e.g. 'base64' for the publicCode rule);
+ *                                       a line whose match equals one of these
+ *                                       is suppressed.
  */
 
 const TEST_PATH_HINTS = Object.freeze([
@@ -77,6 +82,11 @@ const RULES = [
         // long hashes (the earlier `[a-z0-9]*\d[a-z0-9]*` matched all of those).
         pattern: /['"`](?=[a-z0-9]{6}['"`])(?=[a-z0-9]*[a-z])(?=[a-z0-9]*\d)[a-z0-9]{6}['"`]/,
         filePathFilter: (p) => /\.(js|ts)$/.test(p) && !/\.test\./.test(p),
+        // Words with the publicCode shape (6 alnum, letter+digit) that are NOT
+        // publicCodes — encodings, hash algos, mime fragments. Without this
+        // blocklist, `base64`/`sha256` flooded the report with 42 false hits and
+        // ~0 true positives on the live tree (see PR scope notes).
+        falseHits: Object.freeze(['base64', 'sha256', 'sha224', 'sha384', 'sha512', 'md5sum', 'ripemd', 'crc32c']),
         allowFiles: TEST_PATH_HINTS.concat(['/migrations/', '/api-docs', 'api_refs']),
     },
     {
@@ -106,6 +116,17 @@ const RULES = [
         pattern: /(alert|confirm|throw\s+new\s+Error)\s*\(\s*['"`][一-鿿]/,
         filePathFilter: (p) => /\.(js|html)$/.test(p),
         allowFiles: TEST_PATH_HINTS.concat(['/i18n', '/docs/', 'memory/']),
+    },
+    {
+        id: 'owner-only-user-query-assumption',
+        dimension: 'compliance',
+        severity: 'P1',
+        title: 'API query assumes the owner is the only user (LIMIT 1 / first row)',
+        rationale: 'An endpoint that fetches "the device row" with no user/entity key and then `rows[0]` / `LIMIT 1` assumes a single account per device. On a multi-user device it silently serves the wrong user. Scope the query by the caller, not "the first row".',
+        // SELECT ... FROM <table> WHERE device_id = $n   LIMIT 1   (no entity/user key)
+        pattern: /FROM\s+\w+\s+WHERE\s+device_id\s*=\s*\$\d+\s+LIMIT\s+1\b/i,
+        filePathFilter: (p) => /\.(js|sql)$/.test(p) && !/\.test\./.test(p),
+        allowFiles: TEST_PATH_HINTS.concat(['/devices', '/auth', '/migrations/']),
     },
 
     // ── Dimension B: multi-tenant perspective ──────────────────────────
@@ -158,6 +179,53 @@ const RULES = [
         filePathFilter: (p) => /\.(js)$/.test(p) && !/\.test\./.test(p),
         allowFiles: TEST_PATH_HINTS.slice(),
     },
+    {
+        id: 'entity-id-from-body-unverified',
+        dimension: 'multi_tenant',
+        severity: 'P0',
+        title: 'entityId read from request body without a caller check',
+        rationale: 'Trusting `req.body.entityId` to scope a query lets any caller act AS another entity on the same device (IDOR). The handler must validate it against the authenticated caller (callerEntityId / session) before using it in a WHERE.',
+        // `const entityId = req.body.entityId`  /  `req.body.entityId`  /  `body.entityId`
+        // The matcher line-context heuristic below would over-fire; keep the pattern
+        // tight to the body-read assignment shape.
+        pattern: /\b(?:const|let|var)\s+entityId\s*=\s*(?:req\.)?body\.entityId\b/,
+        filePathFilter: (p) => /\.(js)$/.test(p) && !/\.test\./.test(p),
+        allowFiles: TEST_PATH_HINTS.slice(),
+    },
+    {
+        id: 'cross-entity-read-modify-write-race',
+        dimension: 'multi_tenant',
+        severity: 'P1',
+        title: 'Non-atomic read-modify-write on a shared counter/column',
+        rationale: 'Two entities acting on the same card/message/counter in parallel can lost-update when the code does `SELECT ... ; <compute> ; UPDATE ... SET col = <newValue>`. Use an atomic `SET col = col + 1` / `ON CONFLICT` / row lock instead of a JS round-trip.',
+        // SET <col> = <number literal> on a counter-shaped column name — the tell of
+        // "I computed the new value in JS and wrote it back" rather than `col = col + N`.
+        pattern: /\bSET\s+(?:\w+_)?(?:count|counter|total|seq|version|balance)\s*=\s*\$?\d/i,
+        filePathFilter: (p) => /\.(js|sql)$/.test(p) && !/\.test\./.test(p),
+        allowFiles: TEST_PATH_HINTS.concat(['/migrations/']),
+    },
+    {
+        id: 'push-fanout-without-dedupe',
+        dimension: 'multi_tenant',
+        severity: 'P2',
+        title: 'Push fan-out loops tokens without a per-recipient dedupe set',
+        rationale: 'When multiple entities share a device, the same push token can appear more than once in the recipient list; sending in a bare `for (token of tokens)` loop double-notifies. Dedupe tokens (new Set(...)) before fan-out.',
+        // for (... of tokens) / forEach over a *tokens variable, used as the send loop.
+        pattern: /for\s*\(\s*(?:const|let|var)\s+\w+\s+of\s+\w*[Tt]okens\s*\)/,
+        filePathFilter: (p) => /\.(js)$/.test(p) && !/\.test\./.test(p),
+        allowFiles: TEST_PATH_HINTS.slice(),
+    },
+    {
+        id: 'upload-path-collides-across-users',
+        dimension: 'multi_tenant',
+        severity: 'P1',
+        title: 'R2 / file upload key built from filename without a per-user namespace',
+        rationale: 'An object key like `uploads/${filename}` or `${req.file.originalname}` collides when two users upload the same filename — one overwrites the other. Namespace the key by deviceId/entityId/uuid.',
+        // putObject/upload Key built directly from a *name var with no id segment.
+        pattern: /[Kk]ey:\s*[`'"](?:uploads?\/|files?\/)?\$\{(?:filename|originalname|req\.file\.originalname|name)\}/,
+        filePathFilter: (p) => /\.(js)$/.test(p) && !/\.test\./.test(p),
+        allowFiles: TEST_PATH_HINTS.slice(),
+    },
 ];
 
 const DIMENSIONS = Object.freeze(['compliance', 'multi_tenant']);
@@ -197,6 +265,13 @@ function scanText(filePath, text) {
             re.lastIndex = 0;
             const m = re.exec(line);
             if (m) {
+                // Suppress known false positives that match by shape (e.g. the
+                // publicCode rule firing on 'base64'). Compare the matched text
+                // stripped of surrounding quotes, case-insensitively.
+                if (rule.falseHits && rule.falseHits.length) {
+                    const matched = m[0].replace(/^['"`]|['"`]$/g, '').toLowerCase();
+                    if (rule.falseHits.includes(matched)) continue;
+                }
                 findings.push({
                     ruleId: rule.id,
                     dimension: rule.dimension,

--- a/backend/tests/jest/audit-rules.test.js
+++ b/backend/tests/jest/audit-rules.test.js
@@ -78,6 +78,62 @@ describe('audit-rules — scanText matcher (deterministic input → finding shap
     });
 });
 
+describe('audit-rules — extended catalog (card rule list A/B coverage)', () => {
+    test('owner-only LIMIT 1 device query flagged P1 compliance', () => {
+        const f = audit.scanText('backend/api_profile.js',
+            'const r = await db.query("SELECT name FROM profiles WHERE device_id = $1 LIMIT 1", [d]);');
+        const hit = f.find(r => r.ruleId === 'owner-only-user-query-assumption');
+        expect(hit).toBeTruthy();
+        expect(hit.dimension).toBe('compliance');
+        expect(hit.severity).toBe('P1');
+    });
+
+    test('entityId read from req.body without caller check flagged P0 multi_tenant', () => {
+        const f = audit.scanText('backend/api_handler.js', 'const entityId = req.body.entityId;');
+        const hit = f.find(r => r.ruleId === 'entity-id-from-body-unverified');
+        expect(hit).toBeTruthy();
+        expect(hit.dimension).toBe('multi_tenant');
+        expect(hit.severity).toBe('P0');
+    });
+
+    test('non-atomic counter write-back flagged (cross-entity race)', () => {
+        const f = audit.scanText('backend/api_card.js',
+            'await db.query("UPDATE cards SET comment_count = $2 WHERE id = $1", [id, n]);');
+        expect(f.some(r => r.ruleId === 'cross-entity-read-modify-write-race')).toBe(true);
+    });
+
+    test('atomic increment (col = col + 1) is NOT flagged (no false positive)', () => {
+        const f = audit.scanText('backend/api_card.js',
+            'await db.query("UPDATE cards SET comment_count = comment_count + 1 WHERE id = $1", [id]);');
+        expect(f.some(r => r.ruleId === 'cross-entity-read-modify-write-race')).toBe(false);
+    });
+
+    test('bare token fan-out loop flagged (no dedupe)', () => {
+        const f = audit.scanText('backend/push.js', 'for (const tok of pushTokens) { send(tok); }');
+        expect(f.some(r => r.ruleId === 'push-fanout-without-dedupe')).toBe(true);
+    });
+
+    test('upload key built from filename without namespace flagged P1', () => {
+        const f = audit.scanText('backend/upload.js', 'await r2.put({ Key: `uploads/${filename}`, Body: buf });');
+        const hit = f.find(r => r.ruleId === 'upload-path-collides-across-users');
+        expect(hit).toBeTruthy();
+        expect(hit.severity).toBe('P1');
+    });
+});
+
+describe('audit-rules — falseHits suppression', () => {
+    test("publicCode rule does NOT flag 'base64' / 'sha256'", () => {
+        const text = "const enc = 'base64'; const algo = 'sha256';";
+        const f = audit.scanText('backend/crypto.js', text);
+        expect(f.some(r => r.ruleId === 'hardcoded-public-code-literal')).toBe(false);
+    });
+
+    test('publicCode rule STILL flags a real code-shaped literal', () => {
+        const f = audit.scanText('backend/routing.js', "const code = 'tbwb9e';");
+        expect(f.some(r => r.ruleId === 'hardcoded-public-code-literal')).toBe(true);
+    });
+});
+
 describe('audit-rules — file exemptions', () => {
     test('test paths exempt the Hank-UUID rule', () => {
         const text = "const d = '480def4c-2183-4d8e-afd0-b131ae89adcc';";


### PR DESCRIPTION
## Scope
Card `card_923709f59ecb0c1cd66bc786` (Hank P0). The weekly compliance + multi-tenant audit **system** (pure-data rules + tree-walking runner + jest) already shipped in **PR #3325** (`backend/agent-improvement/audit-rules.js`, `audit-run.js`, `backend/tests/jest/audit-rules.test.js`). Per the "extend, don't duplicate" rule, this PR **extends the canonical catalog** with the rule classes from the card that were not yet implemented, and removes one high-noise false-positive class. No new scanner files.

## Rules added

### Dimension A — platform-rule compliance
| id | sev | catches |
|---|---|---|
| `owner-only-user-query-assumption` | P1 | `... WHERE device_id = $n LIMIT 1` with no user/entity key — assumes one account per device, serves the wrong user on a multi-user device |

(already present from #3325: hardcoded Hank deviceId, `/Users/hank/` paths, `entityId === N`, publicCode literal, `if (deviceId === HANK_*)` gate, non-replayable `ADD COLUMN`, zh-only alert/throw)

### Dimension B — multi-tenant correctness
| id | sev | catches |
|---|---|---|
| `entity-id-from-body-unverified` | P0 | `const entityId = req.body.entityId` used to scope a query without a caller check (IDOR-shaped) |
| `cross-entity-read-modify-write-race` | P1 | `SET <counter> = $n` write-back instead of atomic `col = col + N` / `ON CONFLICT` — lost update when two entities act on the same row |
| `push-fanout-without-dedupe` | P2 | `for (tok of *tokens)` send loop with no `Set` dedupe — double-notifies a token shared across entities |
| `upload-path-collides-across-users` | P1 | R2/file `Key: \`uploads/${filename}\`` with no per-user namespace — one user overwrites another |

(already present from #3325: `WHERE device_id` missing entity_id, empty `speakTo:[]`, `SELECT DISTINCT device_id` cron, UI 2/5 bot-slot loop, `incrementCounter()` without entityId)

### Precision fix
`hardcoded-public-code-literal` now carries a `falseHits` blocklist (`base64`, `sha256`, `sha384`, ...) wired into the matcher. The 6-char letter+digit shape was firing on encoding/hash literals. **Public-code false hits 42 → 13** on the live tree.

## jest
`backend/tests/jest/audit-rules.test.js`: **10 → 18 cases, all pass** (added 6 new-rule cases incl. two no-false-positive negatives, + 2 falseHits cases).
```
Test Suites: 1 passed, 1 total
Tests:       18 passed, 18 total
```

## Live-tree run (`node backend/agent-improvement/audit-run.js`)
704 files, **97 → 79 findings**, **12 → 17 rules**. New rules immediately surfaced real signal:
- **5× P0** `entity-id-from-body-unverified` (index.js, interview-arena.js, mission.js)
- **4× P1** `cross-entity-read-modify-write-race` (companion-api.js, gatekeeper.js)
- **2× P1** `owner-only-user-query-assumption` (index.js, kanban.js — `SELECT language ... LIMIT 1`)

Per the card these are **audit-only** → the weekly cron files them as subcards; fixing each is a separate ship.

## Weekly cron enable command (for commander — do NOT run from this PR)
Enable on the mom card `card_923709f59ecb0c1cd66bc786` (schedule `0 9 * * 1` Asia/Taipei):
```bash
curl -s -X PUT "https://eclawbot.com/api/mission/card/card_923709f59ecb0c1cd66bc786" \
  -H "Content-Type: application/json" \
  -H "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0 Safari/537.36" \
  -d '{
    "deviceId":"480def4c-2183-4d8e-afd0-b131ae89adcc",
    "botSecret":"<self botSecret>",
    "entityId":2,
    "cronSchedule":"0 9 * * 1",
    "cronTimezone":"Asia/Taipei",
    "cronCommand":"node backend/agent-improvement/audit-run.js --json",
    "cronEnabled":true
  }'
```
The cron runs `audit-run.js --json`, then files one subcard per rule group at the rule's severity (OODA-R dogfood). Confirm the exact `cronSchedule`/`cronCommand` field names against the kanban mom-card schema before enabling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
