### PR TITLE
feat(hermes): per-org credential scope + entity_org_grants

### DIFF
--- a/backend/hermes-org-token.js
+++ b/backend/hermes-org-token.js
@@ -1,0 +1,263 @@
+'use strict';
+
+/**
+ * hermes-org-token.js — Per-org credential scope for Hermes.
+ * Card: card_1242aaa56221c42a1fe5ef87 ([Hermes/P2] H3 t2)
+ * Roadmap: 🤖 Hermes Channel — H3 Private Repo Support (roadmap.html line 682)
+ *
+ * Problem today: Hermes uses ONE vault PAT (GIT_HUB2) with whatever scope it was
+ * issued for, so a Hermes session bound to entity-A can clone/push to ANY repo
+ * the PAT can reach — including orgs that entity was never assigned to.
+ *
+ * This module tightens that to per-org scope:
+ *   - entity_org_grants maps (entity_id, org_login) → an org that entity may use.
+ *   - GET /api/hermes/org-token?orgLogin=X reads the authenticated entity from
+ *     the request, checks entity_org_grants, and (when issuance infra is wired)
+ *     returns a SCOPED GitHub App installation token for that org — NEVER the
+ *     master PAT.
+ *   - Orgs not granted to the entity → 403 + an entity_org_token_audit row.
+ *
+ * SECURITY: this module never returns or logs the master PAT. The only token it
+ * can ever return is a per-org GitHub App installation token from
+ * issueInstallationToken(). Until that infra exists, issuance is stubbed behind
+ * a clear interface and the route returns 501 — but the grant-check + 403 path
+ * is fully implemented and tested so cross-org access is denied from day one.
+ *
+ * Auth shape mirrors /api/entity-status: deviceId+deviceSecret OR
+ * deviceId+botSecret(+entityId). The resolved entityId is what the grant-check
+ * runs against — a caller can only ever ask for tokens as the entity it
+ * authenticated as.
+ */
+
+const express = require('express');
+const safeEqual = require('./safe-equal');
+
+let pool = null;
+let devicesRef = null;
+
+function bindDevicesRef(devices) {
+    devicesRef = devices;
+}
+
+function initTable(chatPool) {
+    pool = chatPool;
+    // Mirror the migration so a fresh boot has the table even before the
+    // migration runner executes (same self-heal pattern as entity-status).
+    return pool.query(`
+        CREATE TABLE IF NOT EXISTS entity_org_grants (
+            id BIGSERIAL PRIMARY KEY,
+            entity_id INTEGER NOT NULL,
+            device_id VARCHAR(64),
+            org_login VARCHAR(255) NOT NULL,
+            installation_id BIGINT,
+            granted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            granted_by VARCHAR(64) NOT NULL DEFAULT 'admin',
+            revoked_at TIMESTAMPTZ
+        );
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_entity_org_grants
+            ON entity_org_grants(entity_id, COALESCE(device_id, ''), LOWER(org_login));
+        CREATE INDEX IF NOT EXISTS idx_entity_org_grants_lookup
+            ON entity_org_grants(entity_id, LOWER(org_login))
+            WHERE revoked_at IS NULL;
+
+        CREATE TABLE IF NOT EXISTS entity_org_token_audit (
+            id BIGSERIAL PRIMARY KEY,
+            entity_id INTEGER NOT NULL,
+            device_id VARCHAR(64),
+            org_login VARCHAR(255) NOT NULL,
+            outcome VARCHAR(32) NOT NULL,
+            detail TEXT,
+            requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        CREATE INDEX IF NOT EXISTS idx_entity_org_token_audit_lookup
+            ON entity_org_token_audit(entity_id, requested_at DESC);
+    `);
+}
+
+// ---------------------------------------------------------------------------
+// Auth — resolve the calling entity from the request (same shape as
+// /api/entity-status authDeviceOrBot, minus the JWT cookie path which the proxy
+// does not use; proxy calls carry deviceId+botSecret+entityId).
+// ---------------------------------------------------------------------------
+function authEntity(req) {
+    const deviceId = req.query.deviceId || req.body?.deviceId;
+    const deviceSecret = req.query.deviceSecret || req.body?.deviceSecret;
+    const botSecret = req.query.botSecret || req.body?.botSecret;
+    const callerEntityId = parseInt(req.query.entityId || req.body?.entityId, 10) || 0;
+
+    if (!deviceId || !devicesRef || !devicesRef[deviceId]) return null;
+    const device = devicesRef[deviceId];
+
+    // Device-secret auth must still name which entity it is acting as — per-org
+    // scope is meaningless without an entity to scope it to.
+    if (deviceSecret && safeEqual(device.deviceSecret, deviceSecret)) {
+        if (callerEntityId > 0) return { deviceId, entityId: callerEntityId };
+        return null;
+    }
+    if (botSecret) {
+        const ents = device.entities || {};
+        if (callerEntityId > 0) {
+            const e = ents[callerEntityId];
+            if (e && e.isBound && e.botSecret && safeEqual(e.botSecret, botSecret)) {
+                return { deviceId, entityId: callerEntityId };
+            }
+        } else {
+            const match = Object.entries(ents).find(([, e]) =>
+                e && e.isBound && e.botSecret && safeEqual(e.botSecret, botSecret));
+            if (match) return { deviceId, entityId: Number(match[0]) };
+        }
+    }
+    return null;
+}
+
+// ---------------------------------------------------------------------------
+// Grant-check — does (entity_id, org_login) have an active grant?
+// Case-insensitive on org_login. Device-scoped grants (device_id set) match
+// only that device; any-device grants (device_id NULL) match every device.
+// ---------------------------------------------------------------------------
+async function hasOrgGrant(entityId, deviceId, orgLogin) {
+    if (!pool) throw new Error('pool not initialized');
+    const result = await pool.query(
+        `SELECT installation_id
+           FROM entity_org_grants
+          WHERE entity_id = $1
+            AND LOWER(org_login) = LOWER($2)
+            AND revoked_at IS NULL
+            AND (device_id IS NULL OR device_id = $3)
+          ORDER BY device_id NULLS LAST
+          LIMIT 1`,
+        [entityId, orgLogin, deviceId || null]
+    );
+    if (result.rows.length === 0) return null;
+    return { installationId: result.rows[0].installation_id };
+}
+
+async function writeAudit(entityId, deviceId, orgLogin, outcome, detail) {
+    if (!pool) return;
+    try {
+        await pool.query(
+            `INSERT INTO entity_org_token_audit
+                (entity_id, device_id, org_login, outcome, detail)
+             VALUES ($1, $2, $3, $4, $5)`,
+            [entityId, deviceId || null, orgLogin, outcome, detail ? String(detail).slice(0, 500) : null]
+        );
+    } catch (err) {
+        console.error('[hermes-org-token] audit write failed:', err.message);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Token issuance interface (STUB).
+//
+// This is the only place a token is ever produced. It must issue a GitHub App
+// INSTALLATION token scoped to the single org's installation — never the master
+// PAT. Wire-up (Phase, tracked separately): create a GitHub App, install it per
+// org (HankHuang0516 is already connected — extend that pattern), store the
+// installation_id on the grant row, then exchange App JWT → installation token
+// via POST /app/installations/:installation_id/access_tokens.
+//
+// Until that infra exists this returns { available:false } and the route
+// answers 501. The grant-check + 403 path above does NOT depend on this.
+//
+// Returns: { available, token?, expiresAt?, reason? }
+// ---------------------------------------------------------------------------
+async function issueInstallationToken({ orgLogin, installationId }) {
+    // TODO(card_1242aaa5 follow-up): implement GitHub App installation-token
+    // exchange. Requires GITHUB_APP_ID + GITHUB_APP_PRIVATE_KEY env + a per-org
+    // installation_id. Must scope the token to this installation only.
+    void orgLogin;
+    void installationId;
+    return {
+        available: false,
+        reason: 'github_app_installation_token_issuance_not_configured',
+    };
+}
+
+const router = express.Router();
+
+/**
+ * GET /api/hermes/org-token?orgLogin=X
+ * Auth: deviceId+deviceSecret+entityId OR deviceId+botSecret(+entityId)
+ *
+ * Flow:
+ *   1. Resolve calling entity from creds (403 if not authed).
+ *   2. Require orgLogin (400 if missing).
+ *   3. Grant-check (entity, org). No active grant → 403 + audit. THIS IS THE
+ *      multi-tenant boundary: an entity can never get a token for an org it was
+ *      not granted.
+ *   4. Issue a SCOPED installation token via issueInstallationToken(). If the
+ *      issuance infra is not wired → 501 + audit (NOT 403 — the grant exists,
+ *      we just can't mint yet). Never returns the master PAT.
+ */
+router.get('/org-token', async (req, res) => {
+    const auth = authEntity(req);
+    if (!auth) {
+        return res.status(403).json({ success: false, error: 'Invalid credentials' });
+    }
+    const orgLogin = String(req.query.orgLogin || '').trim();
+    if (!orgLogin) {
+        return res.status(400).json({ success: false, error: 'orgLogin required' });
+    }
+    if (!pool) {
+        return res.status(500).json({ success: false, error: 'pool not initialized' });
+    }
+
+    try {
+        const grant = await hasOrgGrant(auth.entityId, auth.deviceId, orgLogin);
+        if (!grant) {
+            await writeAudit(auth.entityId, auth.deviceId, orgLogin, 'denied_no_grant',
+                'entity has no active grant for this org');
+            // Deliberately generic message — do not leak whether the org exists.
+            return res.status(403).json({
+                success: false,
+                error: 'org_not_granted',
+                message: 'This entity is not granted access to the requested org.',
+            });
+        }
+
+        const issued = await issueInstallationToken({
+            orgLogin,
+            installationId: grant.installationId,
+        });
+
+        if (!issued.available) {
+            await writeAudit(auth.entityId, auth.deviceId, orgLogin, 'issuance_unavailable',
+                issued.reason || 'issuance stub');
+            return res.status(501).json({
+                success: false,
+                error: 'token_issuance_not_implemented',
+                reason: issued.reason || 'github_app_installation_token_issuance_not_configured',
+                message: 'Org grant verified, but scoped GitHub App installation-token '
+                    + 'issuance is not yet wired. See hermes-org-token.js issueInstallationToken().',
+                granted: true,
+                orgLogin,
+            });
+        }
+
+        await writeAudit(auth.entityId, auth.deviceId, orgLogin, 'granted', null);
+        // SECURITY: only the per-org installation token is returned here.
+        return res.json({
+            success: true,
+            orgLogin,
+            token: issued.token,
+            expiresAt: issued.expiresAt || null,
+            scope: 'installation',
+        });
+    } catch (err) {
+        console.error('[hermes-org-token] org-token error:', err.message);
+        return res.status(500).json({ success: false, error: 'internal' });
+    }
+});
+
+module.exports = {
+    router,
+    bindDevicesRef,
+    initTable,
+    // exported for tests + future grant-management routes
+    authEntity,
+    hasOrgGrant,
+    writeAudit,
+    issueInstallationToken,
+    _setPoolForTest(p) { pool = p; },
+    _setDevicesForTest(d) { devicesRef = d; },
+};

--- a/backend/index.js
+++ b/backend/index.js
@@ -2287,6 +2287,15 @@ entityStatus.bindDevicesRef(devices);
 entityStatus.bindJwtSecret(JWT_SECRET_FALLBACK);
 app.use('/api/entity-status', entityStatus.router);
 
+// HERMES ORG-TOKEN — per-org credential scope (card_1242aaa56221c42a1fe5ef87).
+// GET /api/hermes/org-token?orgLogin=X — grant-checks entity_org_grants and
+// returns a SCOPED GitHub App installation token (never the master PAT); orgs
+// not granted to the calling entity → 403 + audit log. Pool wired below with
+// the other initTable calls.
+const hermesOrgToken = require('./hermes-org-token');
+hermesOrgToken.bindDevicesRef(devices);
+app.use('/api/hermes', hermesOrgToken.router);
+
 // ENTITY GH-STATS — merged-PR count + smart-link widget on entity cards
 // (card_8a25cadcc9fc88f153fa1316). Endpoint is registered later (~line 8067)
 // next to /api/entities so it sits alongside its peers; the module itself is
@@ -19720,6 +19729,8 @@ devicePrefs.initTable(chatPool);
 entityStatus.initTable(chatPool)
     .then(() => entityStatus.startSweeper(60_000))
     .catch(err => console.error('[EntityStatus] initTable error:', err.message));
+hermesOrgToken.initTable(chatPool)
+    .catch(err => console.error('[HermesOrgToken] initTable error:', err.message));
 redirectRouter.init({ chatPool, devices, jwtSecret: JWT_SECRET_FALLBACK });
 agentImprovement.initTable(chatPool)
     .catch(err => console.error('[AgentImprovement] initTable error:', err.message));

--- a/backend/migrations/20260617_entity_org_grants.down.sql
+++ b/backend/migrations/20260617_entity_org_grants.down.sql
@@ -1,0 +1,9 @@
+-- Down migration for 20260617_entity_org_grants
+-- Round-trip safety: drop every object created by the up migration.
+
+DROP INDEX IF EXISTS idx_entity_org_token_audit_lookup;
+DROP TABLE IF EXISTS entity_org_token_audit;
+
+DROP INDEX IF EXISTS idx_entity_org_grants_lookup;
+DROP INDEX IF EXISTS uq_entity_org_grants;
+DROP TABLE IF EXISTS entity_org_grants;

--- a/backend/migrations/20260617_entity_org_grants.up.sql
+++ b/backend/migrations/20260617_entity_org_grants.up.sql
@@ -1,0 +1,69 @@
+-- Migration: 20260617_entity_org_grants
+-- Card: card_1242aaa56221c42a1fe5ef87 ([Hermes/P2] H3 t2 — Per-org credential scope)
+-- Roadmap: 🤖 Hermes Channel — H3 Private Repo Support (roadmap.html line 682)
+--
+-- Per-org credential scope for Hermes. Each entity-bound Hermes session may only
+-- obtain a scoped GitHub App installation token for orgs explicitly granted here.
+-- Orgs NOT present for an entity are refused (403 + audit log) at the
+-- /api/hermes/org-token route — the master PAT is never returned.
+--
+-- Replayable: IF NOT EXISTS on every object so re-running the migration (or the
+-- module's initTable() bootstrap) is a no-op.
+
+CREATE TABLE IF NOT EXISTS entity_org_grants (
+    id BIGSERIAL PRIMARY KEY,
+    -- The EClaw entity (bot) the grant is bound to. Matches entities[].entityId.
+    entity_id INTEGER NOT NULL,
+    -- Optional device scope. NULL = grant applies to the entity on any device it
+    -- is bound to; a value pins the grant to one device's binding of the entity.
+    device_id VARCHAR(64),
+    -- GitHub org login (case-insensitive compare done in app layer via LOWER()).
+    org_login VARCHAR(255) NOT NULL,
+    -- The GitHub App installation id for this org, if known. The token-issuance
+    -- layer maps org_login -> installation_id; carrying it here lets the route
+    -- issue a scoped installation token without a second lookup. Nullable while
+    -- App-installation infra is still being wired (token issuance stubbed → 501).
+    installation_id BIGINT,
+    granted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- Who/what created the grant (audit aid): 'admin' | 'self-service' | 'seed'.
+    granted_by VARCHAR(64) NOT NULL DEFAULT 'admin',
+    -- Soft-revoke without losing the audit trail of the original grant.
+    revoked_at TIMESTAMPTZ
+);
+
+-- One active grant row per (entity, device, org). device_id participates so an
+-- entity can be granted org-X on device A but not device B. COALESCE keeps the
+-- NULL (any-device) rows unique too.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_entity_org_grants
+    ON entity_org_grants(entity_id, COALESCE(device_id, ''), LOWER(org_login));
+
+-- Hot path: grant-check by (entity, org) ignoring revoked rows.
+CREATE INDEX IF NOT EXISTS idx_entity_org_grants_lookup
+    ON entity_org_grants(entity_id, LOWER(org_login))
+    WHERE revoked_at IS NULL;
+
+COMMENT ON TABLE entity_org_grants IS
+    'Per-org credential scope for Hermes (card_1242aaa5). Maps an EClaw entity to '
+    'the GitHub orgs it may obtain a scoped installation token for. Orgs absent '
+    'here are refused at /api/hermes/org-token (403 + audit log). The master PAT '
+    'is NEVER returned by that route — only per-org GitHub App installation tokens.';
+
+-- Audit log of every org-token request (granted or refused). Security-critical:
+-- this is the trail that proves cross-org access was denied. NEVER stores a token.
+CREATE TABLE IF NOT EXISTS entity_org_token_audit (
+    id BIGSERIAL PRIMARY KEY,
+    entity_id INTEGER NOT NULL,
+    device_id VARCHAR(64),
+    org_login VARCHAR(255) NOT NULL,
+    -- 'granted' | 'denied_no_grant' | 'denied_auth' | 'issuance_unavailable'
+    outcome VARCHAR(32) NOT NULL,
+    detail TEXT,
+    requested_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_entity_org_token_audit_lookup
+    ON entity_org_token_audit(entity_id, requested_at DESC);
+
+COMMENT ON TABLE entity_org_token_audit IS
+    'Append-only audit of org-token requests (card_1242aaa5). One row per call to '
+    '/api/hermes/org-token. Records outcome + org but NEVER the token value or PAT.';

--- a/backend/tests/jest/hermes-org-token.test.js
+++ b/backend/tests/jest/hermes-org-token.test.js
@@ -1,0 +1,226 @@
+'use strict';
+
+/**
+ * hermes-org-token — card_1242aaa56221c42a1fe5ef87 ([Hermes/P2] H3 t2).
+ *
+ * Pins the per-org credential-scope contract:
+ *   - entity-A granted org-X is allowed (issuance stubbed → 501, granted:true).
+ *   - entity-A NOT granted org-Y is blocked → 403 + audit row (denied_no_grant).
+ *   - Cross-org boundary: grant for org-X never leaks a token for org-Y.
+ *   - Auth: bad/missing creds → 403; missing orgLogin → 400.
+ *   - SECURITY: the route never returns the master PAT — only an installation
+ *     token, which the stub does not produce yet (501).
+ *   - Migration SQL ships entity_org_grants + audit table, replayable, with a
+ *     matching down migration.
+ *
+ * Pool is a hermetic in-memory mock; no live PG harness required.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const express = require('express');
+const request = require('supertest');
+
+const mod = require('../../hermes-org-token');
+
+// --- in-memory pool mock ---------------------------------------------------
+// Stores grants + audit rows and answers the two queries the module runs:
+//   - SELECT ... FROM entity_org_grants WHERE entity_id=$1 AND LOWER(org_login)=LOWER($2) ...
+//   - INSERT INTO entity_org_token_audit ...
+function makePool(grants) {
+    const audit = [];
+    const pool = {
+        audit,
+        async query(sql, params) {
+            if (/FROM entity_org_grants/.test(sql)) {
+                const [entityId, orgLogin, deviceId] = params;
+                const row = grants.find(g =>
+                    g.entity_id === entityId &&
+                    g.org_login.toLowerCase() === String(orgLogin).toLowerCase() &&
+                    !g.revoked_at &&
+                    (g.device_id == null || g.device_id === deviceId));
+                return { rows: row ? [{ installation_id: row.installation_id ?? null }] : [] };
+            }
+            if (/INSERT INTO entity_org_token_audit/.test(sql)) {
+                const [entity_id, device_id, org_login, outcome, detail] = params;
+                audit.push({ entity_id, device_id, org_login, outcome, detail });
+                return { rows: [] };
+            }
+            return { rows: [] };
+        },
+    };
+    return pool;
+}
+
+const DEVICE_ID = 'dev-1';
+const DEVICE_SECRET = 'dsecret';
+const BOT_SECRET = 'bsecret-A';
+const ENTITY_A = 7;
+
+function makeDevices() {
+    return {
+        [DEVICE_ID]: {
+            deviceSecret: DEVICE_SECRET,
+            entities: {
+                [ENTITY_A]: { isBound: true, botSecret: BOT_SECRET },
+            },
+        },
+    };
+}
+
+function makeApp(pool, devices) {
+    mod._setPoolForTest(pool);
+    mod._setDevicesForTest(devices);
+    const app = express();
+    app.use(express.json());
+    app.use('/api/hermes', mod.router);
+    return app;
+}
+
+describe('hermes-org-token — per-org credential scope', () => {
+    test('entity-A granted org-X is allowed (issuance stubbed → 501, granted:true)', async () => {
+        const pool = makePool([
+            { entity_id: ENTITY_A, device_id: null, org_login: 'org-X', installation_id: 111 },
+        ]);
+        const app = makeApp(pool, makeDevices());
+
+        const res = await request(app)
+            .get('/api/hermes/org-token')
+            .query({ deviceId: DEVICE_ID, botSecret: BOT_SECRET, entityId: ENTITY_A, orgLogin: 'org-X' });
+
+        expect(res.status).toBe(501);
+        expect(res.body.granted).toBe(true);
+        expect(res.body.error).toBe('token_issuance_not_implemented');
+        // SECURITY: no token (and certainly no PAT) is returned.
+        expect(res.body.token).toBeUndefined();
+        const granted = pool.audit.find(a => a.outcome === 'issuance_unavailable');
+        expect(granted).toBeTruthy();
+        expect(granted.org_login).toBe('org-X');
+    });
+
+    test('entity-A blocked in org-Y → 403 + audit denied_no_grant', async () => {
+        const pool = makePool([
+            { entity_id: ENTITY_A, device_id: null, org_login: 'org-X', installation_id: 111 },
+        ]);
+        const app = makeApp(pool, makeDevices());
+
+        const res = await request(app)
+            .get('/api/hermes/org-token')
+            .query({ deviceId: DEVICE_ID, botSecret: BOT_SECRET, entityId: ENTITY_A, orgLogin: 'org-Y' });
+
+        expect(res.status).toBe(403);
+        expect(res.body.error).toBe('org_not_granted');
+        expect(res.body.token).toBeUndefined();
+        const denied = pool.audit.find(a => a.outcome === 'denied_no_grant');
+        expect(denied).toBeTruthy();
+        expect(denied.org_login).toBe('org-Y');
+        expect(denied.entity_id).toBe(ENTITY_A);
+    });
+
+    test('org match is case-insensitive', async () => {
+        const pool = makePool([
+            { entity_id: ENTITY_A, device_id: null, org_login: 'Org-X', installation_id: 1 },
+        ]);
+        const app = makeApp(pool, makeDevices());
+        const res = await request(app)
+            .get('/api/hermes/org-token')
+            .query({ deviceId: DEVICE_ID, botSecret: BOT_SECRET, entityId: ENTITY_A, orgLogin: 'ORG-x' });
+        // grant found → not a 403; issuance stub → 501
+        expect(res.status).toBe(501);
+        expect(res.body.granted).toBe(true);
+    });
+
+    test('bad botSecret → 403 invalid credentials (no audit, no grant-check)', async () => {
+        const pool = makePool([
+            { entity_id: ENTITY_A, device_id: null, org_login: 'org-X', installation_id: 1 },
+        ]);
+        const app = makeApp(pool, makeDevices());
+        const res = await request(app)
+            .get('/api/hermes/org-token')
+            .query({ deviceId: DEVICE_ID, botSecret: 'WRONG', entityId: ENTITY_A, orgLogin: 'org-X' });
+        expect(res.status).toBe(403);
+        expect(res.body.error).toBe('Invalid credentials');
+        expect(pool.audit.length).toBe(0);
+    });
+
+    test('deviceSecret auth without entityId → 403 (scope needs an entity)', async () => {
+        const pool = makePool([]);
+        const app = makeApp(pool, makeDevices());
+        const res = await request(app)
+            .get('/api/hermes/org-token')
+            .query({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET, orgLogin: 'org-X' });
+        expect(res.status).toBe(403);
+    });
+
+    test('missing orgLogin → 400', async () => {
+        const pool = makePool([]);
+        const app = makeApp(pool, makeDevices());
+        const res = await request(app)
+            .get('/api/hermes/org-token')
+            .query({ deviceId: DEVICE_ID, botSecret: BOT_SECRET, entityId: ENTITY_A });
+        expect(res.status).toBe(400);
+        expect(res.body.error).toBe('orgLogin required');
+    });
+
+    test('device-scoped grant only matches its own device', async () => {
+        // grant pinned to a DIFFERENT device → entity on DEVICE_ID is blocked.
+        const pool = makePool([
+            { entity_id: ENTITY_A, device_id: 'other-device', org_login: 'org-X', installation_id: 1 },
+        ]);
+        const app = makeApp(pool, makeDevices());
+        const res = await request(app)
+            .get('/api/hermes/org-token')
+            .query({ deviceId: DEVICE_ID, botSecret: BOT_SECRET, entityId: ENTITY_A, orgLogin: 'org-X' });
+        expect(res.status).toBe(403);
+    });
+
+    test('hasOrgGrant returns null for ungranted, installation for granted', async () => {
+        const pool = makePool([
+            { entity_id: ENTITY_A, device_id: null, org_login: 'org-X', installation_id: 222 },
+        ]);
+        mod._setPoolForTest(pool);
+        expect(await mod.hasOrgGrant(ENTITY_A, DEVICE_ID, 'org-Y')).toBeNull();
+        const g = await mod.hasOrgGrant(ENTITY_A, DEVICE_ID, 'org-X');
+        expect(g).toEqual({ installationId: 222 });
+    });
+
+    test('issueInstallationToken stub reports unavailable (never the PAT)', async () => {
+        const out = await mod.issueInstallationToken({ orgLogin: 'org-X', installationId: 1 });
+        expect(out.available).toBe(false);
+        expect(out.token).toBeUndefined();
+        expect(out.reason).toMatch(/not_configured/);
+    });
+});
+
+describe('20260617_entity_org_grants migration', () => {
+    const dir = path.join(__dirname, '..', '..', 'migrations');
+    const up = fs.readFileSync(path.join(dir, '20260617_entity_org_grants.up.sql'), 'utf8');
+    const down = fs.readFileSync(path.join(dir, '20260617_entity_org_grants.down.sql'), 'utf8');
+
+    test('creates entity_org_grants with entity_id, org_login, granted_at (replayable)', () => {
+        expect(up).toMatch(/CREATE TABLE IF NOT EXISTS entity_org_grants/);
+        expect(up).toMatch(/entity_id\s+INTEGER NOT NULL/);
+        expect(up).toMatch(/org_login\s+VARCHAR\(255\) NOT NULL/);
+        expect(up).toMatch(/granted_at\s+TIMESTAMPTZ NOT NULL DEFAULT NOW\(\)/);
+    });
+
+    test('ships the audit table and is replayable (IF NOT EXISTS everywhere)', () => {
+        expect(up).toMatch(/CREATE TABLE IF NOT EXISTS entity_org_token_audit/);
+        // every CREATE TABLE / INDEX is guarded
+        const creates = up.match(/CREATE (?:TABLE|UNIQUE INDEX|INDEX)/g) || [];
+        const guarded = up.match(/CREATE (?:TABLE|UNIQUE INDEX|INDEX) IF NOT EXISTS/g) || [];
+        expect(guarded.length).toBe(creates.length);
+        expect(creates.length).toBeGreaterThan(0);
+    });
+
+    test('down migration drops every object', () => {
+        expect(down).toMatch(/DROP TABLE IF EXISTS entity_org_grants/);
+        expect(down).toMatch(/DROP TABLE IF EXISTS entity_org_token_audit/);
+    });
+
+    test('migration never stores a token (security invariant)', () => {
+        // no column named anything like token/pat in the grants/audit tables
+        expect(up).not.toMatch(/token\s+(VARCHAR|TEXT)/i);
+        expect(up).not.toMatch(/\bpat\b\s+(VARCHAR|TEXT)/i);
+    });
+});


### PR DESCRIPTION
## Card
card_1242aaa56221c42a1fe5ef87 — [Hermes/P2] H3 t2: Per-org credential scope for Hermes (PAT cannot reach non-assigned repos)
Roadmap: 🤖 Hermes Channel — H3 Private Repo Support (roadmap.html line 682)

## Problem
Today Hermes uses one vault PAT (GIT_HUB2) with whatever broad scope it was issued for, so a Hermes session bound to entity-A can clone/push to **any** repo the PAT reaches — including orgs that entity was never assigned. This is the multi-tenant hole H3 closes.

## Scope (EClaw backend side)
Each entity-bound Hermes session must read a **per-org-scoped** token derived from EClaw's entity→org mapping; cross-org access is denied at the EClaw route (proxy enforces by calling it).

## DONE (fully implemented + tested)
- **Migration** `20260617_entity_org_grants` (up+down): `entity_org_grants(entity_id, org_login, granted_at` + `device_id`, `installation_id`, `granted_by`, `revoked_at)` and an append-only `entity_org_token_audit` table. Replayable (`IF NOT EXISTS` on every object); down drops everything.
- **Route** `GET /api/hermes/org-token?orgLogin=X` (new module `hermes-org-token.js`): resolves the calling entity from creds (`deviceId+deviceSecret+entityId` or `+botSecret`), grant-checks `entity_org_grants` (case-insensitive org, device-scoped + any-device grants), audits every call.
- **403 on non-granted org** + audit row (`denied_no_grant`). This is the multi-tenant boundary — an entity can never get a token for an org it wasn't granted. Auth failures → 403 (no audit/grant-check); missing `orgLogin` → 400.
- Targeted registration in `index.js` (require + `app.use('/api/hermes', ...)` + `initTable`) — **no wholesale rewrite**.

## STUBBED (clear interface + 501)
- `issueInstallationToken({orgLogin, installationId})` — the GitHub App installation-token exchange (App JWT → `POST /app/installations/:id/access_tokens`) is **not yet wired** (needs `GITHUB_APP_ID` + private key + per-org `installation_id`; HankHuang0516 already connected — extend that pattern). Until then a **verified grant** returns **501** with `granted:true` + a `reason`, behind a documented `TODO`. The grant-check/403 path does **not** depend on issuance.

## SECURITY
The route **never** returns or logs the master PAT. The only token it can ever emit is a per-org GitHub App installation token from `issueInstallationToken()` — which the stub does not produce yet. A jest invariant asserts the migration stores no token/PAT column.

## jest
`tests/jest/hermes-org-token.test.js` — **13/13 pass**, incl. the acceptance case **entity-A allowed in org-X but blocked in org-Y** (403 + audit), case-insensitive match, device-scoped isolation, 501 issuance stub, and migration shape/round-trip/security-invariant.

## Consult (per card "Consult-first")
speakTo Hermes (00vt9i) sent: *is per-installation token issuance already shipped on the proxy side?* If yes, leave `issueInstallationToken()` as-is (proxy mints) or have proxy call this route's 501 as the grant-gate; if no, this route is the contract. **Not blocking** — grant-check/403 shipped now; awaiting Hermes reply on the issuance half.

## Out of scope (per card)
GitHub App marketplace listing; org-admin self-service grant UI (Phase 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)