### PR TITLE
fix(portal): UX/i18n/a11y audit batch (GH#2954)

### DIFF
--- a/backend/public/portal/card-holder.html
+++ b/backend/public/portal/card-holder.html
@@ -701,7 +701,7 @@
         <div class="modal-card share-modal-content">
             <h3>&#x1F517; <span data-i18n="sc_share_chat_link">Share Chat Link</span></h3>
             <div class="share-url-row">
-                <input type="text" id="shareUrl" readonly>
+                <input type="text" id="shareUrl" readonly aria-label="Share chat link">
                 <button onclick="copyShareUrl()" data-i18n="sc_copy">Copy</button>
             </div>
             <div class="share-qr-wrap">

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3299,7 +3299,7 @@
                 <div class="target-bar-row" id="targetBarRow">
                     <span class="target-label" data-i18n="chat_send_to">Send to:</span>
                     <label class="target-check" id="targetAll" style="display:none;">
-                        <input type="checkbox" checked onchange="toggleTargetAll(this)">
+                        <input type="checkbox" checked onchange="toggleTargetAll(this)" aria-label="Send to all">
                         <span data-i18n="chat_filter_all">All</span>
                     </label>
                 </div>
@@ -3374,7 +3374,7 @@
             <div class="r2-modal-footer">
                 <label class="r2-upload-label">
                     &#x2B06; 上傳到檔案庫
-                    <input type="file" id="r2UploadInput" style="display:none" multiple onchange="uploadToR2(this)">
+                    <input type="file" id="r2UploadInput" style="display:none" multiple onchange="uploadToR2(this)" aria-label="Upload files to library">
                 </label>
                 <button class="btn btn-outline" onclick="closeR2FilesPanel()" style="padding:8px 16px;font-size:14px;">關閉</button>
             </div>

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -2203,28 +2203,28 @@
                 <!-- Behavior Options (single-select) -->
                 <div class="org-options">
                     <label class="org-option-card">
-                        <input type="radio" name="orgMode" value="none" onchange="saveOrgOptions()">
+                        <input type="radio" name="orgMode" value="none" onchange="saveOrgOptions()" aria-label="Org mode: None">
                         <div class="org-opt-text">
                             <strong data-i18n="org_opt_none_title">None</strong>
                             <span data-i18n="org_opt_none_desc">No hierarchy behavior enabled</span>
                         </div>
                     </label>
                     <label class="org-option-card">
-                        <input type="radio" name="orgMode" value="low" onchange="saveOrgOptions()">
+                        <input type="radio" name="orgMode" value="low" onchange="saveOrgOptions()" aria-label="Org mode: Low Interference">
                         <div class="org-opt-text">
                             <strong data-i18n="org_opt1_title">Low Interference</strong>
                             <span data-i18n="org_opt1_desc">Superior becomes default kanban task reviewer</span>
                         </div>
                     </label>
                     <label class="org-option-card">
-                        <input type="radio" name="orgMode" value="recommended" onchange="saveOrgOptions()">
+                        <input type="radio" name="orgMode" value="recommended" onchange="saveOrgOptions()" aria-label="Org mode: Recommended">
                         <div class="org-opt-text">
                             <strong data-i18n="org_opt2_title">Recommended</strong>
                             <span data-i18n="org_opt2_desc">Auto-route messages to superior when kanban tasks incomplete</span>
                         </div>
                     </label>
                     <label class="org-option-card">
-                        <input type="radio" name="orgMode" value="strict" onchange="saveOrgOptions()">
+                        <input type="radio" name="orgMode" value="strict" onchange="saveOrgOptions()" aria-label="Org mode: Close Supervision">
                         <div class="org-opt-text">
                             <strong data-i18n="org_opt3_title">Close Supervision</strong>
                             <span data-i18n="org_opt3_desc">Superior becomes kanban reviewer + all messages auto-routed to superior</span>

--- a/backend/public/portal/feedback.html
+++ b/backend/public/portal/feedback.html
@@ -706,7 +706,7 @@
             <div class="photo-section">
                 <div class="photo-label" data-i18n="feedback_photo_label">Attach Photos (Optional)</div>
                 <div class="photo-hint" data-i18n="feedback_photo_hint">Add up to 5 photos to help illustrate the issue</div>
-                <input type="file" id="photoInput" accept="image/jpeg,image/png,image/webp,image/gif" multiple style="display:none" onchange="onPhotosSelected(event)">
+                <input type="file" id="photoInput" accept="image/jpeg,image/png,image/webp,image/gif" multiple style="display:none" onchange="onPhotosSelected(event)" aria-label="Attach photos">
                 <button type="button" class="photo-add-btn" id="photoAddBtn" onclick="document.getElementById('photoInput').click()">
                     📷 <span data-i18n="feedback_photo_add">Add Photos</span>
                 </button>

--- a/backend/public/portal/interactive-dev.html
+++ b/backend/public/portal/interactive-dev.html
@@ -112,17 +112,17 @@
                 <p class="id-import-lede" data-i18n="interactive_dev_import_lede">Pick what the toolbar edits.</p>
                 <fieldset class="id-import-fieldset">
                     <label class="id-import-option">
-                        <input type="radio" name="kind" value="this-page" checked>
+                        <input type="radio" name="kind" value="this-page" checked aria-label="Import source: this page (sandbox)">
                         <span><strong data-i18n="interactive_dev_import_this_page">This page (sandbox)</strong><br>
                         <small data-i18n="interactive_dev_import_this_page_hint">Default. Edit the existing Point-and-Edit testbed below.</small></span>
                     </label>
                     <label class="id-import-option">
-                        <input type="radio" name="kind" value="selector">
+                        <input type="radio" name="kind" value="selector" aria-label="Import source: specific element">
                         <span><strong data-i18n="interactive_dev_import_selector">Specific element</strong><br>
                         <input type="text" name="selector" placeholder="CSS selector, e.g. .my-card" class="id-import-input"></span>
                     </label>
                     <label class="id-import-option">
-                        <input type="radio" name="kind" value="url">
+                        <input type="radio" name="kind" value="url" aria-label="Import source: URL">
                         <span><strong data-i18n="interactive_dev_import_url">URL</strong><br>
                         <input type="url" name="url" placeholder="https://eclawbot.com/portal/info.html" class="id-import-input">
                         <small data-i18n="interactive_dev_import_url_hint">Deny-on-miss allowlist. eclawbot.com domains + example.com allowed in v1.</small></span>

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -774,15 +774,15 @@
             <div class="kb-search-scope" id="kbSearchScope" style="display:flex; gap:4px; align-items:center;">
                 <span style="font-size:12px; color:#888;" data-i18n="kb_search_scope_label">Scope:</span>
                 <label class="kb-scope-chip active" data-scope="title">
-                    <input type="checkbox" value="title" checked onchange="onSearchScopeChange()">
+                    <input type="checkbox" value="title" checked onchange="onSearchScopeChange()" aria-label="Search scope: title">
                     <span data-i18n="kb_search_scope_title">Title</span>
                 </label>
                 <label class="kb-scope-chip" data-scope="comments">
-                    <input type="checkbox" value="comments" onchange="onSearchScopeChange()">
+                    <input type="checkbox" value="comments" onchange="onSearchScopeChange()" aria-label="Search scope: comments">
                     <span data-i18n="kb_search_scope_comments">Comments</span>
                 </label>
                 <label class="kb-scope-chip" data-scope="subcards">
-                    <input type="checkbox" value="subcards" onchange="onSearchScopeChange()">
+                    <input type="checkbox" value="subcards" onchange="onSearchScopeChange()" aria-label="Search scope: sub-cards">
                     <span data-i18n="kb_search_scope_subcards">Sub-cards</span>
                 </label>
             </div>
@@ -808,11 +808,11 @@
                    oninput="onFunnelChange()" style="padding:6px 10px; border:1px solid #ccc; border-radius:6px; min-width:120px;" data-i18n-aria-label="a11y_kanban_filter_tag" aria-label="Filter by tag">
             <label style="font-size:13px; color:#666;">
                 <span data-i18n="kb_funnel_since">Since</span>:
-                <input type="date" id="funnelSince" onchange="onFunnelChange()" style="padding:4px 6px; border:1px solid #ccc; border-radius:6px;">
+                <input type="date" id="funnelSince" onchange="onFunnelChange()" style="padding:4px 6px; border:1px solid #ccc; border-radius:6px;" aria-label="Filter since date">
             </label>
             <label style="font-size:13px; color:#666;">
                 <span data-i18n="kb_funnel_until">Until</span>:
-                <input type="date" id="funnelUntil" onchange="onFunnelChange()" style="padding:4px 6px; border:1px solid #ccc; border-radius:6px;">
+                <input type="date" id="funnelUntil" onchange="onFunnelChange()" style="padding:4px 6px; border:1px solid #ccc; border-radius:6px;" aria-label="Filter until date">
             </label>
             <button class="btn btn-ghost" onclick="resetFunnel()" data-i18n="kb_funnel_reset" style="font-size:13px;">Reset</button>
         </div>
@@ -979,19 +979,19 @@
             </div>
             <div class="kb-form-group">
                 <div class="kb-auto-toggle-row">
-                    <label class="kb-auto-toggle-label"><input type="checkbox" id="newRequiresScreenshot" checked> 📸 <span data-i18n="kb_label_requires_screenshot">需截圖審查（完成時附截圖才可推進 review/done）</span></label>
+                    <label class="kb-auto-toggle-label"><input type="checkbox" id="newRequiresScreenshot" checked aria-label="Requires screenshot review"> 📸 <span data-i18n="kb_label_requires_screenshot">需截圖審查（完成時附截圖才可推進 review/done）</span></label>
                 </div>
             </div>
             <div class="kb-form-group">
                 <div class="kb-auto-toggle-row">
-                    <label class="kb-auto-toggle-label"><input type="checkbox" id="newGated" onchange="document.getElementById('newGateReason').style.display=this.checked?'block':'none'"> 🔒 <span data-i18n="kb_label_gated">Launch-gate（暫停 L1/L2/L3 自動升級；移出 backlog 時自動關閉）</span></label>
+                    <label class="kb-auto-toggle-label"><input type="checkbox" id="newGated" onchange="document.getElementById('newGateReason').style.display=this.checked?'block':'none'" aria-label="Launch-gate this card"> 🔒 <span data-i18n="kb_label_gated">Launch-gate（暫停 L1/L2/L3 自動升級；移出 backlog 時自動關閉）</span></label>
                 </div>
                 <input type="text" id="newGateReason" class="kb-form-input" placeholder="原因（選填，例：等發版）" maxlength="255" style="display:none;margin-top:6px;" aria-label="Gate reason">
                 <div class="kb-gate-hint" data-i18n="kb_gate_backlog_only_hint" style="display:none;font-size:11px;color:#9ca3af;margin-top:4px;">Launch-gate 只在 backlog 卡可用</div>
             </div>
             <div class="kb-form-group">
                 <div class="kb-auto-toggle-row">
-                    <label class="kb-auto-toggle-label"><input type="checkbox" id="newIsAutomation" onchange="toggleAutoFields()"> ⚡ <span data-i18n="kb_label_automation">Set as Automation</span></label>
+                    <label class="kb-auto-toggle-label"><input type="checkbox" id="newIsAutomation" onchange="toggleAutoFields()" aria-label="Set as automation"> ⚡ <span data-i18n="kb_label_automation">Set as Automation</span></label>
                 </div>
                 <div class="kb-auto-fields" id="autoFields">
                     <label class="kb-form-label" data-i18n="kb_label_schedule">Schedule</label>
@@ -1031,18 +1031,18 @@
             </div>
             <div class="kb-form-group">
                 <div class="kb-auto-toggle-row">
-                    <label class="kb-auto-toggle-label"><input type="checkbox" id="editRequiresScreenshot"> 📸 <span data-i18n="kb_label_requires_screenshot">需截圖審查（完成時附截圖才可推進 review/done）</span></label>
+                    <label class="kb-auto-toggle-label"><input type="checkbox" id="editRequiresScreenshot" aria-label="Requires screenshot review"> 📸 <span data-i18n="kb_label_requires_screenshot">需截圖審查（完成時附截圖才可推進 review/done）</span></label>
                 </div>
             </div>
             <div class="kb-form-group">
                 <div class="kb-auto-toggle-row">
-                    <label class="kb-auto-toggle-label"><input type="checkbox" id="editGated"> 🔒 <span data-i18n="kb_label_gated">Launch-gate（暫停 L1/L2/L3 自動升級；移出 backlog 時自動關閉）</span></label>
+                    <label class="kb-auto-toggle-label"><input type="checkbox" id="editGated" aria-label="Launch-gate this card"> 🔒 <span data-i18n="kb_label_gated">Launch-gate（暫停 L1/L2/L3 自動升級；移出 backlog 時自動關閉）</span></label>
                 </div>
                 <input type="text" id="editGateReason" class="kb-form-input" placeholder="原因（選填，例：等發版）" maxlength="255" style="margin-top:6px;" aria-label="Gate reason">
             </div>
             <div class="kb-form-group" id="editReworkGroup" style="display:none">
                 <div class="kb-auto-toggle-row">
-                    <label class="kb-auto-toggle-label"><input type="checkbox" id="editRequiresPrRework"> 🔁 Requires PR rework before Done</label>
+                    <label class="kb-auto-toggle-label"><input type="checkbox" id="editRequiresPrRework" aria-label="Requires PR rework before done"> 🔁 Requires PR rework before Done</label>
                 </div>
                 <input class="kb-form-input" id="editReworkPrNumber" placeholder="New PR number or URL" aria-label="PR number or URL">
                 <div style="font-size:12px;color:var(--text-secondary);margin-top:6px">Reopened PR-linked cards cannot return to Done until a follow-up PR number is recorded.</div>

--- a/backend/public/portal/mindmap.html
+++ b/backend/public/portal/mindmap.html
@@ -113,19 +113,19 @@
                         </select>
                     </label>
                     <label>
-                        <input type="checkbox" id="mmIncludeArchived">
+                        <input type="checkbox" id="mmIncludeArchived" aria-label="Include archived">
                         <span data-i18n="mm_filter_archived">Archived</span>
                     </label>
                     <label>
-                        <input type="checkbox" id="mmIncludeDone">
+                        <input type="checkbox" id="mmIncludeDone" aria-label="Include done">
                         <span data-i18n="mm_filter_done">Done</span>
                     </label>
                     <label>
-                        <input type="checkbox" id="mmIncludeNotes" checked>
+                        <input type="checkbox" id="mmIncludeNotes" checked aria-label="Include notes">
                         <span data-i18n="mm_filter_notes">Notes</span>
                     </label>
                     <label>
-                        <input type="checkbox" id="mmIncludeOwners" checked>
+                        <input type="checkbox" id="mmIncludeOwners" checked aria-label="Include owners">
                         <span data-i18n="mm_filter_owners">Owners</span>
                     </label>
                 </div>

--- a/backend/public/portal/onboarding.html
+++ b/backend/public/portal/onboarding.html
@@ -542,7 +542,7 @@
             <div class="ob-footer">
                 <a class="ob-wizard-link" href="/portal/onboarding/wizard.html" data-i18n="onboarding_wizard_link">Not sure? Take the 3-question wizard →</a>
                 <label class="ob-skip-row">
-                    <input type="checkbox" id="ob-dont-show">
+                    <input type="checkbox" id="ob-dont-show" aria-label="Don't show this again">
                     <span data-i18n="onboarding_dont_show_again">Don't show this again</span>
                 </label>
                 <button type="button" class="ob-skip-btn" id="ob-skip-btn" data-i18n="onboarding_skip_btn">Just explore for now</button>

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1027,7 +1027,7 @@
                     <div class="setting-row">
                         <span class="setting-row-label" data-i18n="broadcast_pref_recipient_info">Show recipient list in broadcasts</span>
                         <label class="toggle-switch">
-                            <input type="checkbox" id="toggleBroadcastRecipientInfo" onchange="toggleDevicePref('broadcast_recipient_info', this.checked)">
+                            <input type="checkbox" id="toggleBroadcastRecipientInfo" aria-label="Include recipient info in broadcasts" onchange="toggleDevicePref('broadcast_recipient_info', this.checked)">
                             <span class="toggle-slider"></span>
                         </label>
                     </div>
@@ -1058,12 +1058,12 @@
                                     <span data-i18n="prompt_policy_entity_label">Entity #</span>
                                     <span class="help-icon" data-help-content-key="prompt_policy_entity_help"></span>
                                 </span>
-                                <input type="number" id="promptPolicyEntityId" min="0" step="1" value="0" class="policy-input" onchange="onPromptPolicyEntityChange()">
+                                <input type="number" id="promptPolicyEntityId" aria-label="Prompt policy entity ID" min="0" step="1" value="0" class="policy-input" onchange="onPromptPolicyEntityChange()">
                             </label>
                         </div>
 
                         <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;">
-                            <input type="checkbox" id="promptPolicyEnabled">
+                            <input type="checkbox" id="promptPolicyEnabled" aria-label="Enable device prompt policy">
                             <!-- HELP-KEY: prompt_policy_enabled_help -->
                             <span id="promptPolicyEnabledLabel" data-i18n="prompt_policy_enabled_label">Enable device prompt policy</span>
                             <span class="help-icon" data-help-content-key="prompt_policy_enabled_help"></span>
@@ -1080,13 +1080,13 @@
 
                         <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:10px;">
                             <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;">
-                                <input type="checkbox" id="promptPolicyRequirePlan">
+                                <input type="checkbox" id="promptPolicyRequirePlan" aria-label="Require test plan">
                                 <!-- HELP-KEY: prompt_policy_require_plan_help -->
                                 <span data-i18n="prompt_policy_require_plan_label">Require test plan</span>
                                 <span class="help-icon" data-help-content-key="prompt_policy_require_plan_help"></span>
                             </label>
                             <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;">
-                                <input type="checkbox" id="promptPolicyRequireMilestones">
+                                <input type="checkbox" id="promptPolicyRequireMilestones" aria-label="Require milestone updates">
                                 <!-- HELP-KEY: prompt_policy_require_milestones_help -->
                                 <span data-i18n="prompt_policy_require_milestones_label">Require milestone updates</span>
                                 <span class="help-icon" data-help-content-key="prompt_policy_require_milestones_help"></span>
@@ -1095,7 +1095,7 @@
                                 <!-- HELP-KEY: prompt_policy_heartbeat_help -->
                                 <span data-i18n="prompt_policy_heartbeat_label">Heartbeat min</span>
                                 <span class="help-icon" data-help-content-key="prompt_policy_heartbeat_help"></span>
-                                <input type="number" id="promptPolicyHeartbeatMinutes" min="1" max="30" step="1"
+                                <input type="number" id="promptPolicyHeartbeatMinutes" aria-label="Prompt policy heartbeat minutes" min="1" max="30" step="1"
                                        style="width:70px;padding:6px 8px;border:1px solid var(--card-border);border-radius:6px;background:var(--bg);color:var(--text);text-align:right;">
                             </label>
                         </div>
@@ -1132,7 +1132,7 @@
                             <button class="btn btn-outline btn-sm" onclick="loadPromptPolicy()" data-i18n="common_refresh">Refresh</button>
                             <span style="display:flex;align-items:center;gap:6px;font-size:13px;color:var(--text-secondary);">
                                 Preview entity #
-                                <input type="number" id="promptPolicyPreviewEntity" min="0" step="1" value="0" class="policy-input" style="width:64px;text-align:right;">
+                                <input type="number" id="promptPolicyPreviewEntity" aria-label="Prompt policy preview entity" min="0" step="1" value="0" class="policy-input" style="width:64px;text-align:right;">
                             </span>
                             <select id="promptPolicyPreviewChannel" class="policy-select" style="width:auto;">
                                 <option value="codex">codex</option>
@@ -1168,7 +1168,7 @@
                         <span data-i18n="kanban_nudge_batch_label">Cards per cycle</span>
                         <span class="help-icon" data-help-content-key="kanban_nudge_batch_help"></span>
                     </span>
-                    <input type="number" id="kanbanNudgeBatchSize" min="1" max="20" step="1"
+                    <input type="number" id="kanbanNudgeBatchSize" aria-label="Kanban nudge batch size" min="1" max="20" step="1"
                            style="width:72px;padding:6px 8px;border:1px solid var(--card-border);border-radius:6px;background:var(--bg);color:var(--text);text-align:right;"
                            onchange="saveKanbanNudgePref('kanban_nudge_batch_size', Math.max(1, Math.min(20, parseInt(this.value)||1)))">
                 </div>
@@ -1180,15 +1180,15 @@
                         <span class="help-icon" data-help-content-key="kanban_nudge_priority_help"></span>
                     </span>
                     <label style="display:flex;align-items:center;gap:8px;padding:4px 0;font-size:13px;cursor:pointer;">
-                        <input type="radio" name="kanbanNudgePriorityMode" value="priority_first" onchange="saveKanbanNudgePref('kanban_nudge_priority_mode', this.value)">
+                        <input type="radio" name="kanbanNudgePriorityMode" value="priority_first" aria-label="Nudge order: level-first" onchange="saveKanbanNudgePref('kanban_nudge_priority_mode', this.value)">
                         <span data-i18n="kanban_nudge_priority_mode_level">Level-first (P0 &gt; P1 &gt; P2)</span>
                     </label>
                     <label style="display:flex;align-items:center;gap:8px;padding:4px 0;font-size:13px;cursor:pointer;">
-                        <input type="radio" name="kanbanNudgePriorityMode" value="column_first" onchange="saveKanbanNudgePref('kanban_nudge_priority_mode', this.value)">
+                        <input type="radio" name="kanbanNudgePriorityMode" value="column_first" aria-label="Nudge order: column-first" onchange="saveKanbanNudgePref('kanban_nudge_priority_mode', this.value)">
                         <span data-i18n="kanban_nudge_priority_mode_column">Column-first (Review &gt; In Progress &gt; Todo)</span>
                     </label>
                     <label style="display:flex;align-items:center;gap:8px;padding:4px 0;font-size:13px;cursor:pointer;">
-                        <input type="radio" name="kanbanNudgePriorityMode" value="column_level" onchange="saveKanbanNudgePref('kanban_nudge_priority_mode', this.value)">
+                        <input type="radio" name="kanbanNudgePriorityMode" value="column_level" aria-label="Nudge order: column plus level" onchange="saveKanbanNudgePref('kanban_nudge_priority_mode', this.value)">
                         <span data-i18n="kanban_nudge_priority_mode_both">Column + level (Review P2 &gt; In Progress P1 &gt; Todo P0)</span>
                     </label>
                 </div>
@@ -1210,10 +1210,10 @@
                         Per Hank 2026-06-01 16:57 TW directive.
                     -->
                     <div style="display:flex;flex-wrap:wrap;gap:8px;">
-                        <label class="nudge-status-chip"><input type="checkbox" value="backlog" onchange="saveKanbanNudgeStatuses()"><span data-i18n="kanban_status_backlog">Backlog</span></label>
-                        <label class="nudge-status-chip"><input type="checkbox" value="todo" onchange="saveKanbanNudgeStatuses()"><span data-i18n="kanban_status_todo">Todo</span></label>
-                        <label class="nudge-status-chip"><input type="checkbox" value="in_progress" onchange="saveKanbanNudgeStatuses()"><span data-i18n="kanban_status_in_progress">In Progress</span></label>
-                        <label class="nudge-status-chip"><input type="checkbox" value="review" onchange="saveKanbanNudgeStatuses()"><span data-i18n="kanban_status_review">Review</span></label>
+                        <label class="nudge-status-chip"><input type="checkbox" value="backlog" onchange="saveKanbanNudgeStatuses()" aria-label="Notify status: backlog"><span data-i18n="kanban_status_backlog">Backlog</span></label>
+                        <label class="nudge-status-chip"><input type="checkbox" value="todo" onchange="saveKanbanNudgeStatuses()" aria-label="Notify status: todo"><span data-i18n="kanban_status_todo">Todo</span></label>
+                        <label class="nudge-status-chip"><input type="checkbox" value="in_progress" onchange="saveKanbanNudgeStatuses()" aria-label="Notify status: in progress"><span data-i18n="kanban_status_in_progress">In Progress</span></label>
+                        <label class="nudge-status-chip"><input type="checkbox" value="review" onchange="saveKanbanNudgeStatuses()" aria-label="Notify status: review"><span data-i18n="kanban_status_review">Review</span></label>
                     </div>
                 </div>
 
@@ -1224,11 +1224,11 @@
                         <span class="help-icon" data-help-content-key="kanban_nudge_interval_help"></span>
                     </span>
                     <span style="display:flex;align-items:center;gap:4px;">
-                        <input type="number" id="kanbanNudgeIntervalHours" min="0" max="24" step="1"
+                        <input type="number" id="kanbanNudgeIntervalHours" aria-label="Nudge interval hours" min="0" max="24" step="1"
                                style="width:56px;padding:6px 8px;border:1px solid var(--card-border);border-radius:6px;background:var(--bg);color:var(--text);text-align:right;"
                                onchange="saveKanbanNudgeInterval()">
                         <span style="font-size:13px;" data-i18n="kanban_nudge_interval_hour">h</span>
-                        <input type="number" id="kanbanNudgeIntervalMinutes" min="0" max="59" step="1"
+                        <input type="number" id="kanbanNudgeIntervalMinutes" aria-label="Nudge interval minutes" min="0" max="59" step="1"
                                style="width:56px;padding:6px 8px;border:1px solid var(--card-border);border-radius:6px;background:var(--bg);color:var(--text);text-align:right;"
                                onchange="saveKanbanNudgeInterval()">
                         <span style="font-size:13px;" data-i18n="kanban_nudge_interval_min">m</span>
@@ -1243,14 +1243,14 @@
                     </span>
                     <p class="section-desc" style="margin:0 0 6px 0;font-size:12px;" data-i18n="kanban_nudge_advanced_desc">🅰️ stale-card nudge vs 🅱️ cron-schedule trigger — separate switches.</p>
                     <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;">
-                        <input type="checkbox" id="kanbanNudgePerEntityThrottle"
+                        <input type="checkbox" id="kanbanNudgePerEntityThrottle" aria-label="Per-entity nudge throttle"
                                onchange="saveKanbanNudgePref('kanban_nudge_per_entity_throttle', this.checked)">
                         <!-- HELP-KEY: kanban_nudge_per_entity_throttle_help -->
                         <span data-i18n="kanban_nudge_per_entity_throttle_label">🅰️ Stale-card: cap each entity at 1 nudge per interval</span>
                         <span class="help-icon" data-help-content-key="kanban_nudge_per_entity_throttle_help"></span>
                     </label>
                     <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;">
-                        <input type="checkbox" id="kanbanCronRecurringNotify"
+                        <input type="checkbox" id="kanbanCronRecurringNotify" aria-label="Recurring cron notify"
                                onchange="saveKanbanNudgePref('kanban_cron_recurring_notify', this.checked)">
                         <!-- HELP-KEY: kanban_cron_recurring_notify_help -->
                         <span data-i18n="kanban_cron_recurring_notify_label">🅱️ Cron母卡 self-recurring (no child): notify on each fire</span>
@@ -1287,7 +1287,7 @@
                         </p>
 
                         <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;padding:6px 8px;border:1px solid rgba(251,191,36,0.35);border-radius:8px;background:rgba(251,191,36,0.08);">
-                            <input type="checkbox" id="kanbanNudgeEntStopMode"
+                            <input type="checkbox" id="kanbanNudgeEntStopMode" aria-label="Entity nudge stop mode"
                                    onchange="onKanbanNudgeEntityOverrideToggle('kanban_nudge_stop_mode', this.checked)">
                             <!-- HELP-KEY: kanban_nudge_per_entity_stop_mode_help -->
                             <span data-i18n="kanban_nudge_per_entity_stop_mode">Stop-mode: pause stale-card reminders for this entity</span>
@@ -1297,18 +1297,18 @@
                         <!-- Override row: interval -->
                         <div style="display:flex;flex-direction:column;gap:6px;">
                             <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;">
-                                <input type="checkbox" id="kanbanNudgeEntOverrideInterval"
+                                <input type="checkbox" id="kanbanNudgeEntOverrideInterval" aria-label="Override entity nudge interval"
                                        onchange="onKanbanNudgeEntityOverrideToggle('kanban_nudge_interval_minutes', this.checked)">
                                 <!-- HELP-KEY: kanban_nudge_per_entity_override_interval_help -->
                                 <span data-i18n="kanban_nudge_per_entity_override_interval">Override interval</span>
                                 <span class="help-icon" data-help-content-key="kanban_nudge_per_entity_override_interval_help"></span>
                             </label>
                             <span style="display:flex;align-items:center;gap:4px;padding-left:24px;">
-                                <input type="number" id="kanbanNudgeEntIntervalHours" min="0" max="24" step="1" disabled
+                                <input type="number" id="kanbanNudgeEntIntervalHours" aria-label="Entity nudge interval hours" min="0" max="24" step="1" disabled
                                        style="width:56px;padding:6px 8px;border:1px solid var(--card-border);border-radius:6px;background:var(--bg);color:var(--text);text-align:right;"
                                        onchange="saveKanbanNudgeEntityInterval()">
                                 <span style="font-size:13px;" data-i18n="kanban_nudge_interval_hour">h</span>
-                                <input type="number" id="kanbanNudgeEntIntervalMinutes" min="0" max="59" step="1" disabled
+                                <input type="number" id="kanbanNudgeEntIntervalMinutes" aria-label="Entity nudge interval minutes" min="0" max="59" step="1" disabled
                                        style="width:56px;padding:6px 8px;border:1px solid var(--card-border);border-radius:6px;background:var(--bg);color:var(--text);text-align:right;"
                                        onchange="saveKanbanNudgeEntityInterval()">
                                 <span style="font-size:13px;" data-i18n="kanban_nudge_interval_min">m</span>
@@ -1318,7 +1318,7 @@
                         <!-- Override row: statuses -->
                         <div style="display:flex;flex-direction:column;gap:6px;">
                             <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;">
-                                <input type="checkbox" id="kanbanNudgeEntOverrideStatuses"
+                                <input type="checkbox" id="kanbanNudgeEntOverrideStatuses" aria-label="Override entity nudge statuses"
                                        onchange="onKanbanNudgeEntityOverrideToggle('kanban_nudge_statuses', this.checked)">
                                 <!-- HELP-KEY: kanban_nudge_per_entity_override_statuses_help -->
                                 <span data-i18n="kanban_nudge_per_entity_override_statuses">Override columns</span>
@@ -1326,24 +1326,24 @@
                             </label>
                             <!-- 'blocked' omitted; see device-wide chip block above. -->
                             <div id="kanbanNudgeEntStatusChips" style="display:flex;flex-wrap:wrap;gap:8px;padding-left:24px;opacity:0.5;">
-                                <label class="nudge-status-chip"><input type="checkbox" value="backlog" data-ent-status onchange="saveKanbanNudgeEntityStatuses()"><span data-i18n="kanban_status_backlog">Backlog</span></label>
-                                <label class="nudge-status-chip"><input type="checkbox" value="todo" data-ent-status onchange="saveKanbanNudgeEntityStatuses()"><span data-i18n="kanban_status_todo">Todo</span></label>
-                                <label class="nudge-status-chip"><input type="checkbox" value="in_progress" data-ent-status onchange="saveKanbanNudgeEntityStatuses()"><span data-i18n="kanban_status_in_progress">In Progress</span></label>
-                                <label class="nudge-status-chip"><input type="checkbox" value="review" data-ent-status onchange="saveKanbanNudgeEntityStatuses()"><span data-i18n="kanban_status_review">Review</span></label>
+                                <label class="nudge-status-chip"><input type="checkbox" value="backlog" data-ent-status aria-label="Entity notify status: backlog" onchange="saveKanbanNudgeEntityStatuses()"><span data-i18n="kanban_status_backlog">Backlog</span></label>
+                                <label class="nudge-status-chip"><input type="checkbox" value="todo" data-ent-status aria-label="Entity notify status: todo" onchange="saveKanbanNudgeEntityStatuses()"><span data-i18n="kanban_status_todo">Todo</span></label>
+                                <label class="nudge-status-chip"><input type="checkbox" value="in_progress" data-ent-status aria-label="Entity notify status: in progress" onchange="saveKanbanNudgeEntityStatuses()"><span data-i18n="kanban_status_in_progress">In Progress</span></label>
+                                <label class="nudge-status-chip"><input type="checkbox" value="review" data-ent-status aria-label="Entity notify status: review" onchange="saveKanbanNudgeEntityStatuses()"><span data-i18n="kanban_status_review">Review</span></label>
                             </div>
                         </div>
 
                         <!-- Override row: throttle -->
                         <div style="display:flex;flex-direction:column;gap:6px;">
                             <label style="display:flex;align-items:center;gap:8px;font-size:13px;cursor:pointer;">
-                                <input type="checkbox" id="kanbanNudgeEntOverrideThrottle"
+                                <input type="checkbox" id="kanbanNudgeEntOverrideThrottle" aria-label="Override entity nudge throttle"
                                        onchange="onKanbanNudgeEntityOverrideToggle('kanban_nudge_per_entity_throttle', this.checked)">
                                 <!-- HELP-KEY: kanban_nudge_per_entity_override_throttle_help -->
                                 <span data-i18n="kanban_nudge_per_entity_override_throttle">Override throttle</span>
                                 <span class="help-icon" data-help-content-key="kanban_nudge_per_entity_override_throttle_help"></span>
                             </label>
                             <label style="display:flex;align-items:center;gap:8px;font-size:13px;padding-left:24px;cursor:pointer;">
-                                <input type="checkbox" id="kanbanNudgeEntThrottleVal" disabled
+                                <input type="checkbox" id="kanbanNudgeEntThrottleVal" aria-label="Entity nudge throttle value" disabled
                                        onchange="saveKanbanNudgeEntityThrottle()">
                                 <!-- HELP-KEY: kanban_nudge_per_entity_throttle_short_help -->
                                 <span data-i18n="kanban_nudge_per_entity_throttle_short">Cap this entity at 1 nudge per interval</span>
@@ -1377,7 +1377,7 @@
                     <span class="help-icon" data-help-content-key="usage_warning_enable_help"></span>
                 </span>
                 <label class="switch" style="position:relative;display:inline-block;width:44px;height:24px;">
-                    <input type="checkbox" id="toggleUsageWarning"
+                    <input type="checkbox" id="toggleUsageWarning" aria-label="Enable usage warnings"
                            onchange="onUsageWarningEnabledChange(this.checked)"
                            style="opacity:0;width:0;height:0;">
                     <span aria-hidden="true"
@@ -1394,7 +1394,7 @@
                     </span>
                     <span id="usageWarning5hValue" style="font-variant-numeric:tabular-nums;color:var(--text-secondary);">15%</span>
                 </span>
-                <input type="range" id="usageWarning5hSlider" min="0" max="100" step="1" value="15"
+                <input type="range" id="usageWarning5hSlider" aria-label="5-hour usage warning threshold" min="0" max="100" step="1" value="15"
                        oninput="onUsageWarningSliderInput('5h', this.value)"
                        onchange="saveUsageWarningConfig()"
                        style="width:100%;">
@@ -1409,7 +1409,7 @@
                     </span>
                     <span id="usageWarning7dValue" style="font-variant-numeric:tabular-nums;color:var(--text-secondary);">5%</span>
                 </span>
-                <input type="range" id="usageWarning7dSlider" min="0" max="100" step="1" value="5"
+                <input type="range" id="usageWarning7dSlider" aria-label="7-day usage warning threshold" min="0" max="100" step="1" value="5"
                        oninput="onUsageWarningSliderInput('7d', this.value)"
                        onchange="saveUsageWarningConfig()"
                        style="width:100%;">
@@ -1656,7 +1656,7 @@
                     <span data-i18n="feedback_photo_label">Attach Photos (Optional)</span>
                     <span class="help-icon" data-help-content-key="feedback_photo_help"></span>
                 </div>
-                <input type="file" id="fbPhotoInput" accept="image/jpeg,image/png,image/webp,image/gif" multiple style="display:none" onchange="onFeedbackPhotosSelected(event)">
+                <input type="file" id="fbPhotoInput" aria-label="Attach photos" accept="image/jpeg,image/png,image/webp,image/gif" multiple style="display:none" onchange="onFeedbackPhotosSelected(event)">
                 <button type="button" class="fb-photo-btn" id="fbPhotoAddBtn" onclick="document.getElementById('fbPhotoInput').click()">
                     📷 <span data-i18n="feedback_photo_add">Add Photos</span>
                 </button>


### PR DESCRIPTION
## Summary
First coherent batch against the portal static UX audit backlog (GH#2954). This PR closes **all 9 accessibility findings** — unlabeled inputs that had no accessible name (no `<label for=>`, placeholder, or aria-label).

The audit only credits `<label for="id">` (not wrapping `<label>`), so checkbox/radio/date/number/range/file inputs that were visually labeled via a sibling `<span data-i18n>` still failed. Each now gets a descriptive `aria-label`.

## Audit count: before → after
`node backend/tests/test-ux-static-audit.js`
- **Before:** Total checks 349 | Passed 283 | **Failed 66**
- **After:** Total checks 349 | Passed 292 | **Failed 57**
- All 9 `[*] accessibility` checks now pass (0 remaining).

## Findings fixed (9 pages, 61 inputs)
| Page | Inputs labeled |
|---|---|
| settings.html | 34 (nudge/prompt-policy toggles, sliders, file) |
| kanban.html | 11 (search scope, funnel dates, card automation toggles) |
| dashboard.html | 4 (org-mode radios) |
| mindmap.html | 4 (filter checkboxes) |
| interactive-dev.html | 3 (import-source radios) |
| chat.html | 2 (send-to-all, R2 upload) |
| card-holder.html | 1 (share URL) |
| feedback.html | 1 (photo upload) |
| onboarding.html | 1 (don't-show-again) |

## Remaining (not in this PR — future batches)
- **i18n coverage gaps** (admin, dashboard, chat, kanban, community, roadmap, files, mission, several demo pages) — requires AST locale insertion via `i18n-insert-locale-keys.js`; large, deferred to a dedicated i18n batch.
- **auth-guard findings** (community, compare, marketplace, workspace, plaza, etc.) — these are mostly **public discovery pages**; adding a hard `checkAuth()` redirect would regress public browsing. Per the issue, these need public/authenticated triage + audit-harness exclusions, which the issue explicitly scopes to the **QA-harness-refresh track**, separate from this product backlog.
- **empty/loading-state findings** (index, plaza, petdx-preview, invite-qr-generator, roadmap) — verified to be **false positives**: the flagged `.map/.forEach` iterate static config arrays / `querySelectorAll`, not API-fetched lists. Belongs to the harness-exclusion track.
- **telemetry / API-error-handling findings** — deferred.

## Scope / safety
- Targeted in-place Edits only — no wholesale HTML rewrite. Diff is 61 lines changed across 9 files (1:1 line edits).
- Pure additive `aria-label` attributes; no behavior, layout, or JS changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)