### PR TITLE
feat(plaza): 公開頁邀請 CTA + SEO 邀請段落

### DIFF
--- a/backend/community-ssr.js
+++ b/backend/community-ssr.js
@@ -133,6 +133,10 @@ ${card.ratingCount > 0 ? `<span>★ ${escapeHtml(card.avgRating.toFixed(1))} (${
 ${capabilities.length ? `<section class="section"><h2>Capabilities</h2><ul class="chips">${capChips}</ul></section>` : ''}
 ${tags.length ? `<section class="section"><h2>Tags</h2><ul class="chips">${tagChips}</ul></section>` : ''}
 ${protocols.length ? `<section class="section"><h2>Protocols</h2><ul class="chips">${protoChips}</ul></section>` : ''}
+<section class="section invite-section">
+<h2>Invite friends, earn e-coin</h2>
+<p class="desc">EClawbot is free to join. When a friend signs up with your invite link, they get 100 e-coin and you get 500 — and a 500 e-coin bonus lands on their first top-up. Bring your team to ${escapeHtml(card.name)} and the rest of the Bot Plaza, and your e-coin grows as they work. <a href="/r/invite" rel="nofollow">Open your invite page &rarr;</a></p>
+</section>
 <div class="cta">
 <a class="btn" href="${escapeHtml(liveUrl)}" rel="canonical-app">Open in Plaza</a>
 </div>

--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -953,6 +953,20 @@
             </div>
         </div>
 
+        <!-- ── Guest Invite CTA (visible to logged-out visitors; long-line growth) ── -->
+        <div id="inviteCtaGuest" class="invite-cta-banner invite-cta-guest" aria-label="Invite incentive">
+            <div class="invite-cta-inner">
+                <div class="invite-cta-icon">🎁</div>
+                <div class="invite-cta-body">
+                    <div class="invite-cta-title" data-i18n="community_invite_guest_title">Invited by a friend? Sign up and you both earn e-coin</div>
+                    <div class="invite-cta-desc" data-i18n="community_invite_guest_desc">New members get 100 e-coin, and your inviter gets 500 — plus a 500 e-coin bonus on your first top-up.</div>
+                </div>
+                <div class="invite-cta-actions">
+                    <a class="invite-cta-share-btn" href="/r/invite" onclick="if (typeof beaconCta === 'function') beaconCta('plaza-guest-invite-cta');" data-i18n="community_invite_guest_btn">Claim your bonus</a>
+                </div>
+            </div>
+        </div>
+
         <!-- Featured this week — rotates weekly from featured-bot/rotation.json -->
         <section class="featured-week" id="featuredWeek" hidden>
             <div class="featured-week-head">
@@ -1127,16 +1141,24 @@
     let _inviteCode = null;
 
     async function loadInviteCode() {
+        const guestCta = document.getElementById('inviteCtaGuest');
         try {
             const data = await apiFetch('/api/invite/my-code');
-            if (!data || !data.success || !data.code) return;
+            if (!data || !data.success || !data.code) {
+                // Authenticated check failed gracefully → treat as guest.
+                if (guestCta) guestCta.classList.add('visible');
+                return;
+            }
             _inviteCode = data.code;
             document.getElementById('inviteCtaCode').textContent = data.code;
             const banner = document.getElementById('inviteCtaBanner');
             if (banner) banner.classList.add('visible');
+            // Authenticated owner sees the personal-code banner, not the guest CTA.
+            if (guestCta) guestCta.classList.remove('visible');
         } catch (e) {
-            // 401 or network error — hide banner silently (user not logged in)
+            // 401 or network error — user is logged out: show the guest invite CTA.
             _inviteCode = null;
+            if (guestCta) guestCta.classList.add('visible');
         }
     }
 

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650310,6 +650310,9 @@ const TRANSLATIONS = {
         "card_retest_tier_ready": "Ready",
 
         "guide_voice_delivery_note": "🔇 <strong>No sound?</strong> TTS requires the device to be online (EClaw App open, signed in, and connected via Socket.IO), or to have push (FCM) registered as an offline fallback. If neither is available, the server returns <code>delivered:false</code> with <code>warning:\"tts_not_delivered\"</code>, meaning the command was accepted but no audio will play — open the EClaw App on the device and try again.",
+        "community_invite_guest_title": "Invited by a friend? Sign up and you both earn e-coin",
+        "community_invite_guest_desc": "New members get 100 e-coin, and your inviter gets 500 — plus a 500 e-coin bonus on your first top-up.",
+        "community_invite_guest_btn": "Claim your bonus",
 },
 
 
@@ -1235086,6 +1235089,9 @@ const TRANSLATIONS = {
         "card_retest_tier_ready": "可重測",
 
         "guide_voice_delivery_note": "🔇 <strong>沒聽到聲音？</strong>TTS 需要裝置上線（EClaw App 開啟、登入並連上 Socket.IO），或已註冊推播（FCM）作為斷線備援。若兩者皆無，伺服器會回傳 <code>delivered:false</code> 與 <code>warning:\"tts_not_delivered\"</code>，代表指令已接收但沒有任何聲音播出 —— 請在裝置上開啟 EClaw App 後再試一次。",
+        "community_invite_guest_title": "朋友邀請你來的嗎？註冊後雙方都能領 e幣",
+        "community_invite_guest_desc": "新成員可獲得 100 e幣，邀請你的人可獲得 500 e幣，首次儲值再加贈 500 e幣。",
+        "community_invite_guest_btn": "領取你的獎勵",
 },
 
 


### PR DESCRIPTION
## Scope
card_6285164360cae4c7b7873beb (#6 裁定 a, Growth/P2, 長線 — 不期待短期漏斗效果)

Two growth touchpoints on the public Bot Plaza surface:

1. **Logged-out guest invite CTA** on the Plaza public bot-list page (`community.html`, which `/portal/plaza.html` redirects to). Shown only to unauthenticated visitors; the existing authenticated owner-code banner takes over once logged in (mutually exclusive). Links to the canonical `/r/invite` deeplink (route-registry `invite` target).
2. **Invite-incentive paragraph** appended to the per-bot **SEO article template** (`community-ssr.js`, the crawler-indexed `/community/<code>` pages). New "Invite friends, earn e-coin" section above the CTA, `/r/invite` link with `rel="nofollow"`.

## Files changed
- `backend/public/portal/community.html` — guest CTA block (`#inviteCtaGuest`, reuses existing `.invite-cta-banner` styles) + `loadInviteCode()` now toggles guest vs owner CTA.
- `backend/community-ssr.js` — invite-incentive `<section>` in `renderBotPageHtml`.
- `backend/public/shared/i18n.js` — EN + ZH keys via `i18n-insert-locale-keys.js` (AST tool, no regex).

## i18n keys added (EN + ZH)
- `community_invite_guest_title`
- `community_invite_guest_desc`
- `community_invite_guest_btn`

(SSR article page is server-rendered crawler-facing English, matching its existing `lang="en"` English-only convention; the client guest CTA carries the localized keys.)

## Invite deeplink convention
Uses `/r/invite` — the universal redirect entry mapped in `shared/route-registry.js` (`invite` target → `/portal/invite.html`, non-sensitive, no params), matching existing repo convention.

## Render verified
- SSR template render asserted (node + curl): `invite-section`, `href="/r/invite"`, `rel="nofollow"` all present.
- jest: `community-ssr.test.js` (15), `community-bot-focus`, `share-chat-ssr-og`, `i18n-syntax.test.js`, `i18n-lint-dup-keys.test.js` — all pass; `node --check` clean on both edited JS files.
- Screenshot note: SSR invite section captured via Playwright fullpage; community.html guest-CTA path is plain DOM toggle on `apiFetch('/api/invite/my-code')` 401 (logged-out), no API dependency to render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)