### PR TITLE
feat(oodar): rule promotion engine + roadmap live tracker

### DIFF
--- a/backend/agent-improvement/roadmap-manifest.js
+++ b/backend/agent-improvement/roadmap-manifest.js
@@ -1,0 +1,115 @@
+// OODA-R Phase 4 #9 — public roadmap manifest.
+// Card: card_5ac74610cbf1f89440427809
+//
+// Maps the 9 self-improvement roadmap items to their kanban card IDs so the
+// public /portal/roadmap.html tracker can pull LIVE status (todo / in_progress
+// / shipped) instead of the hard-coded badges that were there before.
+//
+// Why a manifest module rather than reading the roadmap from the DB directly:
+//   - The roadmap is a curated narrative (9 items, 4 phases) that does NOT map
+//     1:1 to every kanban card; the manifest is the editorial source of truth
+//     for WHICH cards are public and in WHAT order.
+//   - It carries no secrets — only public card IDs + display labels + PR links
+//     that already appear on the public roadmap page today.
+//   - The route layer joins this manifest against kanban_cards.status so the
+//     public page never needs a botSecret (the old /cards endpoint requires one).
+//
+// Each item's `cardId` is looked up in kanban_cards at request time; the live
+// `status` overrides the manifest's `fallbackStatus` when the card is found.
+// fallbackStatus exists so the page degrades gracefully if a card was archived
+// or the device board is unavailable.
+
+'use strict';
+
+/**
+ * Kanban status → public tracker status. The public page only speaks three
+ * words; internal statuses collapse into them. Single source of truth so the
+ * endpoint and any test agree.
+ * @type {Readonly<Record<string,string>>}
+ */
+const KANBAN_TO_PUBLIC = Object.freeze({
+    backlog: 'todo',
+    todo: 'todo',
+    in_progress: 'in_progress',
+    review: 'in_progress',
+    done: 'shipped',
+    blocked: 'todo', // blocked is still "not shipped" from a user's POV
+});
+
+/** @type {readonly string[]} */
+const PUBLIC_STATUSES = Object.freeze(['todo', 'in_progress', 'shipped']);
+
+/**
+ * @param {string} kanbanStatus
+ * @returns {string} one of PUBLIC_STATUSES
+ */
+function toPublicStatus(kanbanStatus) {
+    return KANBAN_TO_PUBLIC[kanbanStatus] || 'todo';
+}
+
+/**
+ * @typedef {Object} RoadmapItem
+ * @property {string} id            stable slug used as the i18n / DOM anchor
+ * @property {number} phase         0..4
+ * @property {number} num           1..9 (the roadmap's item number)
+ * @property {string} cardId        kanban card backing this item
+ * @property {string} title         English display title (i18n key = `rm_oodar_${id}`)
+ * @property {string} fallbackStatus  public status used when the card is missing
+ * @property {string} [pr]          PR URL to surface as the "ship proof" link
+ */
+
+/**
+ * The 9-item OODA-R roadmap. cardIds are the real Phase 0–4 subcards under
+ * parent card_be59aa034883fe36d3645a27 (see fixtures/episodes.js + roadmap.html
+ * narrative). PRs are the ones already cited on the public page.
+ * @type {readonly RoadmapItem[]}
+ */
+const ROADMAP_ITEMS = Object.freeze([
+    { id: 'p0-1-taxonomy', phase: 0, num: 1, cardId: 'card_e9de7607cd9a838462148328', title: 'Pain taxonomy + episode schema', fallbackStatus: 'shipped', pr: 'https://github.com/HankHuang0516/EClaw/pull/3226' },
+    { id: 'p0-2-ingest',   phase: 0, num: 2, cardId: 'card_af7d8bb1c7c74',            title: 'Feedback ingestion bridge',       fallbackStatus: 'shipped', pr: 'https://github.com/HankHuang0516/EClaw/pull/3227' },
+    { id: 'p1-3-preflight', phase: 1, num: 3, cardId: 'card_50dccd356888b22d6654e85a', title: 'Task-start preflight lint',       fallbackStatus: 'shipped', pr: 'https://github.com/HankHuang0516/EClaw/pull/3228' },
+    { id: 'p1-4-done-gate', phase: 1, num: 4, cardId: 'card_337040389de34bcb65cf0cb0', title: 'Done-evidence gate + anti-laziness guard', fallbackStatus: 'shipped', pr: 'https://github.com/HankHuang0516/EClaw/pull/3230' },
+    { id: 'p2-5-offline',  phase: 2, num: 5, cardId: 'card_47ed9a0c21dd507d3b726136', title: 'Offline delivery queue + reconnect replay', fallbackStatus: 'todo' },
+    { id: 'p2-6-auth',     phase: 2, num: 6, cardId: 'card_214d48e395e812b3e909e5ca', title: 'Auth/session persistence + refresh diagnostics', fallbackStatus: 'todo' },
+    { id: 'p2-7-redirect', phase: 2, num: 7, cardId: 'card_14571f26914b9c1eae148362', title: 'Unified App/Web redirect state machine', fallbackStatus: 'todo' },
+    { id: 'p3-8-e2e',      phase: 3, num: 8, cardId: 'card_42ffca0d29ce22b369d55ca4', title: 'Cross-surface E2E matrix for top workflows', fallbackStatus: 'todo' },
+    { id: 'p4-9-promote',  phase: 4, num: 9, cardId: 'card_5ac74610cbf1f89440427809', title: 'Rule promotion engine + public roadmap tracker', fallbackStatus: 'in_progress' },
+]);
+
+/**
+ * Build the public tracker payload by joining the manifest against a map of
+ * cardId → { status, updatedAt }. Pure — the route layer supplies the map from
+ * a single SQL query. Items whose card is absent fall back to fallbackStatus.
+ *
+ * @param {Record<string,{status?:string, updatedAt?:string|Date}>} cardStatusById
+ * @returns {{items:Array, generatedAt:string}}
+ */
+function buildTrackerPayload(cardStatusById = {}) {
+    const items = ROADMAP_ITEMS.map((it) => {
+        const row = cardStatusById[it.cardId];
+        const live = row && row.status ? toPublicStatus(row.status) : null;
+        const updatedAt = row && row.updatedAt
+            ? (row.updatedAt instanceof Date ? row.updatedAt.toISOString() : String(row.updatedAt))
+            : null;
+        return {
+            id: it.id,
+            phase: it.phase,
+            num: it.num,
+            cardId: it.cardId,
+            title: it.title,
+            status: live || it.fallbackStatus,
+            live: !!live,
+            updatedAt,
+            pr: it.pr || null,
+        };
+    });
+    return { items, generatedAt: new Date().toISOString() };
+}
+
+module.exports = {
+    KANBAN_TO_PUBLIC,
+    PUBLIC_STATUSES,
+    toPublicStatus,
+    ROADMAP_ITEMS,
+    buildTrackerPayload,
+};

--- a/backend/agent-improvement/rule-promotion.js
+++ b/backend/agent-improvement/rule-promotion.js
@@ -1,0 +1,304 @@
+// OODA-R Phase 4 #9 — rule promotion engine.
+// Card: card_5ac74610cbf1f89440427809
+// Parent: card_be59aa034883fe36d3645a27
+//
+// This is the "Reinforce" step of the OODA-R loop (see roadmap.html
+// #ai-agent-self-improvement). When the SAME pain taxonomy keeps re-firing
+// across episodes, a one-off lesson on a single card is not enough — the
+// learning must be *promoted* into an enforced rule (a new SOP entry, a CI
+// check, a lint rule, or a required checklist item) so the next agent cannot
+// re-ship the same class of failure.
+//
+// Design seam (mirrors preflight.js / done-gate.js): this module is PURE.
+// It takes an already-loaded list of episodes (validateEpisode-compatible
+// shape) and returns deterministic suggestion objects + a meta-PR draft body.
+// It NEVER touches the DB, the network, or the GitHub API — the route/cron
+// layer is responsible for fetching episodes and actually opening the PR.
+// That keeps the promotion logic unit-testable with fixed input → fixed
+// output, which is exactly what the acceptance criteria asks for.
+//
+// "N consecutive warnings" semantics: episodes are sorted by occurredAt ASC;
+// for each painTag we find the longest *trailing* run of episodes carrying
+// that tag (most recent N in a row). A run of length >= threshold for a tag
+// triggers a promotion suggestion. "Consecutive" is evaluated per-tag over
+// the chronologically-ordered episode stream so an unrelated episode in the
+// middle breaks the run (the same failure must keep recurring, not merely
+// have happened N times ever).
+
+'use strict';
+
+const { PAIN_TAXONOMY_SET } = require('./episode-schema');
+
+/**
+ * Default promotion threshold. Hank's done-retro slot on this card asks
+ * "rule 提升閾值 N=? 是否需要按 pain axis 分級?" — answered here: the base
+ * threshold is 3 (three consecutive same-axis warnings = systemic, not noise),
+ * but severity-bearing axes promote faster via SEVERITY_THRESHOLD_OVERRIDE so
+ * a P0 class doesn't have to re-hurt the user three times before it is gated.
+ * @type {number}
+ */
+const DEFAULT_THRESHOLD = 3;
+
+/**
+ * Per-severity threshold override. The MINIMUM (most aggressive) threshold
+ * among the episodes in a run wins — a single P0 in the run pulls the whole
+ * run's bar down to 2. Tunable so the engine can re-tune itself later (this
+ * card is self-recursive: if N is miscalibrated, a later episode promotes a
+ * change to these numbers).
+ * @type {Readonly<Record<string, number>>}
+ */
+const SEVERITY_THRESHOLD_OVERRIDE = Object.freeze({
+    P0: 2,
+    P1: 3,
+    P2: 3,
+    P3: 4,
+});
+
+/**
+ * The four enforcement vehicles a lesson can be promoted into. The engine
+ * picks one per pain axis via PAIN_AXIS_TO_VEHICLE so the meta-PR has a
+ * concrete, actionable target instead of a vague "add a rule".
+ * @type {readonly string[]}
+ */
+const RULE_VEHICLES = Object.freeze(['sop', 'ci_check', 'lint', 'checklist']);
+
+/**
+ * Map each pain axis to the enforcement vehicle that best fits its failure
+ * mode. Code-shaped pains (test coverage, redirect) get machine-enforced
+ * vehicles (CI / lint); process-shaped pains (ownership, task context) get
+ * human-enforced vehicles (SOP / checklist). Deterministic — same axis always
+ * yields the same vehicle, which keeps the suggestion shape stable for tests.
+ * @type {Readonly<Record<string, {vehicle:string, target:string}>>}
+ */
+const PAIN_AXIS_TO_VEHICLE = Object.freeze({
+    delivery_reliability: { vehicle: 'ci_check', target: 'CI: offline-queue replay + delivery-state E2E must pass before merge' },
+    auth_session:         { vehicle: 'ci_check', target: 'CI: session-persistence + refresh-mutex E2E must pass before merge' },
+    redirect_deeplink:    { vehicle: 'lint',     target: 'Lint: deep-link / redirect changes must carry a traceId + canonical-route assertion' },
+    ux_feedback:          { vehicle: 'checklist', target: 'Required checklist: every UI card cites a before/after screenshot showing the visible delta' },
+    agent_ownership:      { vehicle: 'sop',      target: 'SOP: explicit owner + heartbeat cadence declared on card before in_progress' },
+    task_context:         { vehicle: 'sop',      target: 'SOP: Task Contract (scope/acceptance/test/evidence) published at preflight' },
+    test_coverage:        { vehicle: 'ci_check', target: 'CI: cross-surface E2E matrix gate blocks merge on failure' },
+    scope_completeness:   { vehicle: 'checklist', target: 'Required checklist: done-gate evidence comment with all 6 items + artifacts' },
+});
+
+/**
+ * Stable ISO timestamp parse → epoch ms, with a deterministic tiebreaker so
+ * episodes that share an occurredAt keep a stable order (by cardId) instead of
+ * relying on input order. NaN dates sort to the front (treated as oldest).
+ * @param {object} ep
+ * @returns {number}
+ */
+function epMs(ep) {
+    const t = Date.parse(ep && ep.occurredAt);
+    return Number.isNaN(t) ? 0 : t;
+}
+
+/**
+ * Sort episodes chronologically ASC, deterministically. Pure — returns a new
+ * array, does not mutate the input.
+ * @param {object[]} episodes
+ * @returns {object[]}
+ */
+function sortChronological(episodes) {
+    return episodes
+        .slice()
+        .sort((a, b) => (epMs(a) - epMs(b)) || String(a.cardId || '').localeCompare(String(b.cardId || '')));
+}
+
+/**
+ * For one pain axis, find the longest TRAILING consecutive run of episodes
+ * carrying that tag in the chronologically-sorted stream. "Trailing" = the run
+ * must include the most recent episode that has the tag, AND not be interrupted
+ * by a later episode that lacks it. We walk the sorted stream and reset the run
+ * whenever an episode without the tag appears, so the returned run is the
+ * current unbroken streak ending at the latest tagged episode.
+ *
+ * @param {string} tag
+ * @param {object[]} sorted   chronological ASC
+ * @returns {object[]}        the trailing run (may be empty)
+ */
+function trailingRunForTag(tag, sorted) {
+    let run = [];
+    for (const ep of sorted) {
+        const tags = Array.isArray(ep.painTags) ? ep.painTags : [];
+        if (tags.includes(tag)) {
+            run.push(ep);
+        } else {
+            run = [];
+        }
+    }
+    return run;
+}
+
+/**
+ * The most aggressive (lowest) threshold implied by a run's severities.
+ * @param {object[]} run
+ * @returns {number}
+ */
+function effectiveThreshold(run) {
+    let best = DEFAULT_THRESHOLD;
+    for (const ep of run) {
+        const sev = ep && ep.severity;
+        const override = SEVERITY_THRESHOLD_OVERRIDE[sev];
+        if (typeof override === 'number' && override < best) best = override;
+    }
+    return best;
+}
+
+/**
+ * @typedef {Object} PromotionSuggestion
+ * @property {string} painTag            the axis that keeps re-firing
+ * @property {string} vehicle            one of RULE_VEHICLES
+ * @property {string} ruleTarget         concrete rule text to enforce
+ * @property {number} consecutiveCount   length of the trailing run
+ * @property {number} threshold          the threshold this run cleared
+ * @property {('P0'|'P1'|'P2'|'P3')} highestSeverity   most severe in the run
+ * @property {string[]} supportingCardIds episodes (cardIds) backing the suggestion
+ * @property {object[]} supportingEpisodes the actual episode objects (chrono ASC)
+ * @property {string} suggestionId       deterministic id: `promote:<tag>:<lastCardId>`
+ */
+
+const SEVERITY_RANK = Object.freeze({ P0: 0, P1: 1, P2: 2, P3: 3 });
+
+function highestSeverity(run) {
+    let best = 'P3';
+    for (const ep of run) {
+        const sev = ep && ep.severity;
+        if (sev in SEVERITY_RANK && SEVERITY_RANK[sev] < SEVERITY_RANK[best]) best = sev;
+    }
+    return best;
+}
+
+/**
+ * Evaluate a set of episodes and return one promotion suggestion per pain axis
+ * whose trailing consecutive run meets its threshold. Deterministic: same input
+ * episodes → identical suggestions array (sorted by severity then painTag).
+ *
+ * @param {object[]} episodes               validateEpisode-compatible objects
+ * @param {object} [opts]
+ * @param {number} [opts.threshold]         override DEFAULT_THRESHOLD globally
+ * @param {Record<string,number>} [opts.severityOverride]  override per-severity bars
+ * @returns {PromotionSuggestion[]}
+ */
+function evaluatePromotions(episodes, opts = {}) {
+    if (!Array.isArray(episodes) || episodes.length === 0) return [];
+    const sorted = sortChronological(episodes);
+
+    // Collect every painTag actually present in the stream (closed-set guarded).
+    const tagsPresent = new Set();
+    for (const ep of sorted) {
+        const tags = Array.isArray(ep.painTags) ? ep.painTags : [];
+        for (const t of tags) if (PAIN_TAXONOMY_SET.has(t)) tagsPresent.add(t);
+    }
+
+    const suggestions = [];
+    for (const tag of tagsPresent) {
+        const run = trailingRunForTag(tag, sorted);
+        if (run.length === 0) continue;
+
+        let bar = typeof opts.threshold === 'number' ? opts.threshold : effectiveThreshold(run);
+        if (opts.severityOverride) {
+            // Recompute bar against caller-supplied overrides.
+            let best = typeof opts.threshold === 'number' ? opts.threshold : DEFAULT_THRESHOLD;
+            for (const ep of run) {
+                const o = opts.severityOverride[ep && ep.severity];
+                if (typeof o === 'number' && o < best) best = o;
+            }
+            bar = best;
+        }
+
+        if (run.length < bar) continue;
+
+        const veh = PAIN_AXIS_TO_VEHICLE[tag] || { vehicle: 'sop', target: `SOP: codify a guard for repeated ${tag} failures` };
+        const lastCardId = run[run.length - 1].cardId || 'unknown';
+        suggestions.push({
+            painTag: tag,
+            vehicle: veh.vehicle,
+            ruleTarget: veh.target,
+            consecutiveCount: run.length,
+            threshold: bar,
+            highestSeverity: highestSeverity(run),
+            supportingCardIds: run.map(e => e.cardId).filter(Boolean),
+            supportingEpisodes: run,
+            suggestionId: `promote:${tag}:${lastCardId}`,
+        });
+    }
+
+    suggestions.sort((a, b) =>
+        (SEVERITY_RANK[a.highestSeverity] - SEVERITY_RANK[b.highestSeverity]) ||
+        a.painTag.localeCompare(b.painTag));
+    return suggestions;
+}
+
+/**
+ * Render the markdown body for the meta-PR that proposes a single rule
+ * promotion. Includes the N supporting episodes (cardId · severity · the
+ * lesson / missedCheck) so a reviewer can audit the basis. Deterministic
+ * string output — secrets never appear because we only echo cardId / severity /
+ * missedChecks (the episode schema already forbids secret-shaped substrings,
+ * and assertNoSecrets is the upstream guard at ingest time).
+ *
+ * @param {PromotionSuggestion} s
+ * @returns {string}
+ */
+function renderMetaPrBody(s) {
+    if (!s || typeof s !== 'object') return '';
+    const lines = [];
+    lines.push('## OODA-R rule promotion (auto-suggested)');
+    lines.push('');
+    lines.push(`The \`${s.painTag}\` pain axis fired **${s.consecutiveCount} consecutive** warnings ` +
+        `(threshold ${s.threshold}, highest severity ${s.highestSeverity}). Promoting the lesson into an enforced rule.`);
+    lines.push('');
+    lines.push('### Proposed rule');
+    lines.push(`- **Vehicle**: \`${s.vehicle}\``);
+    lines.push(`- **Enforce**: ${s.ruleTarget}`);
+    lines.push('');
+    lines.push(`### Supporting episodes (${s.supportingEpisodes.length})`);
+    for (const ep of s.supportingEpisodes) {
+        const lesson = (Array.isArray(ep.missedChecks) && ep.missedChecks[0])
+            || ep.userFeedback
+            || ep.userVisibleResult
+            || ep.deliverable
+            || '(no lesson recorded)';
+        lines.push(`- [${ep.cardId || 'unknown'} · ${ep.severity || '?'}] ${lesson}`);
+    }
+    lines.push('');
+    lines.push('### Reinforce checklist');
+    lines.push(`- [ ] Implement the ${s.vehicle} above`);
+    lines.push('- [ ] Add/extend a test that fails when the rule is violated');
+    lines.push('- [ ] Cross-link this PR back to the supporting episode cards');
+    lines.push('- [ ] Write a promotion episode (regressed-axis / supporting count / proposed rule)');
+    lines.push('');
+    lines.push(`<!-- suggestionId: ${s.suggestionId} -->`);
+    return lines.join('\n');
+}
+
+/**
+ * Convenience: produce a "draft" object the route/cron layer can hand to the
+ * GitHub API (it constructs title + body + a stable branch name). Still pure —
+ * does not call GitHub.
+ * @param {PromotionSuggestion} s
+ * @returns {{title:string, body:string, branch:string, suggestionId:string}}
+ */
+function buildMetaPrDraft(s) {
+    return {
+        title: `chore(oodar): promote ${s.painTag} lesson to ${s.vehicle} rule`,
+        body: renderMetaPrBody(s),
+        branch: `oodar/promote-${s.painTag.replace(/_/g, '-')}`,
+        suggestionId: s.suggestionId,
+    };
+}
+
+module.exports = {
+    DEFAULT_THRESHOLD,
+    SEVERITY_THRESHOLD_OVERRIDE,
+    RULE_VEHICLES,
+    PAIN_AXIS_TO_VEHICLE,
+    sortChronological,
+    trailingRunForTag,
+    effectiveThreshold,
+    highestSeverity,
+    evaluatePromotions,
+    renderMetaPrBody,
+    buildMetaPrDraft,
+};

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -233,6 +233,8 @@ async function mapCardFileRow(r) {
 // Valid statuses + labels — imported from public/shared/kanban-status.js so
 // server, kanban UI, settings UI, chat smart-chip, and nudge all share one enum.
 const KanbanStatus = require('./public/shared/kanban-status.js');
+// OODA-R Phase 4 #9: public roadmap tracker manifest + payload builder.
+const { ROADMAP_ITEMS, buildTrackerPayload } = require('./agent-improvement/roadmap-manifest.js');
 const STATUSES = KanbanStatus.STATUSES;
 const STATUS_LABELS = KanbanStatus.STATUS_LABELS_EN;
 const PRIORITIES = ['P0', 'P1', 'P2', 'P3'];
@@ -999,6 +1001,46 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
         } catch (err) {
             console.error('[Kanban] Create card error:', err);
             res.status(500).json({ success: false, error: err.message });
+        }
+    });
+
+    // ============================================
+    // GET /roadmap-status — PUBLIC OODA-R roadmap tracker (no auth, no secrets)
+    // ============================================
+    // OODA-R Phase 4 #9 (card_5ac74610cbf1f89440427809). Powers the LIVE status
+    // badges on /portal/roadmap.html. The old badges were hard-coded; this
+    // endpoint joins the editorial manifest (agent-improvement/roadmap-manifest)
+    // against kanban_cards.status so the public page reflects real progress.
+    //
+    // Public by design: it exposes ONLY the curated 9 OODA-R item card IDs +
+    // their status + updated_at + the PR links that already appear on the page.
+    // No botSecret/deviceSecret required (the page is public). The canonical
+    // board is the first ADMIN_DEVICE_IDS entry — the platform team's own board.
+    router.get('/roadmap-status', async (req, res) => {
+        try {
+            const adminDeviceId = (process.env.ADMIN_DEVICE_IDS || '')
+                .split(',').map(s => s.trim()).filter(Boolean)[0];
+            const cardStatusById = {};
+            if (adminDeviceId) {
+                const ids = ROADMAP_ITEMS.map(it => it.cardId);
+                const result = await pool.query(
+                    `SELECT id, status, updated_at FROM kanban_cards
+                     WHERE device_id = $1 AND id = ANY($2::text[])`,
+                    [adminDeviceId, ids]
+                );
+                for (const row of result.rows) {
+                    cardStatusById[row.id] = { status: row.status, updatedAt: row.updated_at };
+                }
+            }
+            const payload = buildTrackerPayload(cardStatusById);
+            // Short cache: the page polls at load; 60s is plenty and shields the DB.
+            res.set('Cache-Control', 'public, max-age=60');
+            res.json({ success: true, ...payload });
+        } catch (err) {
+            console.error('[Kanban] roadmap-status error:', err);
+            // Degrade gracefully — return manifest fallbacks so the page renders.
+            const payload = buildTrackerPayload({});
+            res.json({ success: true, degraded: true, ...payload });
         }
     });
 

--- a/backend/public/portal/roadmap.html
+++ b/backend/public/portal/roadmap.html
@@ -365,6 +365,39 @@
                 <li><strong>Feedback bridge</strong>: Hank's chat corrections, kanban comments, review feedback all funnel into the episode store automatically — no more human-cached reminders</li>
             </ol>
 
+            <!-- ───────────────────────────────────────────────────────────
+                 LIVE roadmap tracker (Phase 4 #9, card_5ac74610cbf1f89440427809).
+                 Status is pulled at runtime from /api/mission/roadmap-status
+                 (kanban-backed) — NOT hard-coded. Falls back to manifest status
+                 if the endpoint is unreachable so the page always renders.
+                 ─────────────────────────────────────────────────────────── -->
+            <h3 style="font-size:14px;font-weight:700;margin:18px 0 8px;display:flex;align-items:center;gap:8px;">
+                📡 <span data-i18n="rm_oodar_live_title">Live status tracker</span>
+                <span class="rm-oodar-help" tabindex="0" role="button"
+                      aria-label="How live status works"
+                      data-i18n-title="rm_oodar_live_help"
+                      title="Status, last-update time and PR links are pulled live from the team kanban board via /api/mission/roadmap-status. No login needed; if the board is unreachable the page shows the last known plan status."
+                      style="cursor:help;font-size:12px;color:var(--text-secondary);border:1px solid var(--card-border);border-radius:50%;width:18px;height:18px;display:inline-flex;align-items:center;justify-content:center;">?</span>
+            </h3>
+            <div id="rmOodarLiveMeta" style="font-size:11px;color:var(--text-secondary);margin-bottom:10px;" data-i18n="rm_oodar_live_loading">Loading live status…</div>
+            <div id="rmOodarLive" class="rm-oodar-live" aria-live="polite">
+                <!-- rows injected by JS; static markup below is the no-JS fallback -->
+                <noscript><div style="font-size:12px;color:var(--text-secondary);" data-i18n="rm_oodar_live_nojs">Enable JavaScript to see live kanban-backed status. The static 4-phase plan below is always available.</div></noscript>
+            </div>
+            <style>
+                .rm-oodar-live { display:flex; flex-direction:column; gap:6px; margin-bottom:8px; }
+                .rm-oodar-row { display:flex; align-items:center; gap:10px; padding:8px 10px; border:1px solid var(--card-border); border-radius:var(--radius-sm); background:var(--input-bg); font-size:13px; }
+                .rm-oodar-row .rm-oodar-num { flex:0 0 auto; width:22px; height:22px; border-radius:50%; background:var(--card); border:1px solid var(--card-border); display:inline-flex; align-items:center; justify-content:center; font-size:11px; font-weight:700; }
+                .rm-oodar-row .rm-oodar-title { flex:1 1 auto; min-width:0; }
+                .rm-oodar-row .rm-oodar-when { flex:0 0 auto; font-size:10px; color:var(--text-secondary); }
+                .rm-oodar-badge { flex:0 0 auto; padding:2px 8px; border-radius:10px; font-size:10px; font-weight:700; text-transform:uppercase; letter-spacing:.3px; }
+                .rm-oodar-badge.shipped { background:#10b981; color:#fff; }
+                .rm-oodar-badge.in_progress { background:#f59e0b; color:#000; }
+                .rm-oodar-badge.todo { background:var(--card); color:var(--text-secondary); border:1px solid var(--card-border); }
+                .rm-oodar-row a.rm-oodar-pr { flex:0 0 auto; font-size:11px; color:var(--primary); text-decoration:none; }
+                .rm-oodar-live-dot { display:inline-block; width:6px; height:6px; border-radius:50%; background:#10b981; margin-right:4px; vertical-align:middle; }
+            </style>
+
             <h3 style="font-size:14px;font-weight:700;margin:14px 0 8px;">🗺️ 9-item delivery roadmap (4 phases)</h3>
             <div style="font-size:13px;line-height:1.65;">
                 <div style="margin-bottom:14px;">
@@ -951,7 +984,81 @@
             if (typeof renderFooter === 'function') renderFooter();
             if (typeof i18n !== 'undefined') i18n.apply();
             try { await injectLiveCardStatus(); } catch (e) { console.warn('[roadmap] live status injection failed:', e?.message || e); }
+            try { await loadOodarLiveStatus(); } catch (e) { console.warn('[roadmap] OODA-R live tracker failed:', e?.message || e); }
         });
+
+        // OODA-R Phase 4 #9 (card_5ac74610cbf1f89440427809):
+        // render the LIVE, kanban-backed status of the 9 self-improvement items.
+        // Unlike injectLiveCardStatus() (which needs admin deviceSecret and is a
+        // no-op for public visitors), this hits the PUBLIC /roadmap-status
+        // endpoint so anonymous visitors also see real status, not hard-coded.
+        async function loadOodarLiveStatus() {
+            const host = document.getElementById('rmOodarLive');
+            const meta = document.getElementById('rmOodarLiveMeta');
+            if (!host) return;
+            const STATUS_LABEL = { shipped: 'Shipped', in_progress: 'In Progress', todo: 'Planned' };
+            const tr = (k, fb) => (typeof i18n !== 'undefined' && i18n.t) ? (i18n.t(k) || fb) : fb;
+            const fmtWhen = (iso) => {
+                if (!iso) return '';
+                const d = new Date(iso);
+                return isNaN(d.getTime()) ? '' : d.toISOString().slice(0, 10);
+            };
+            try {
+                const res = await fetch('/api/mission/roadmap-status', { credentials: 'omit' });
+                if (!res.ok) throw new Error('http ' + res.status);
+                const data = await res.json();
+                const items = (data && data.items) || [];
+                if (!items.length) throw new Error('empty');
+                host.innerHTML = '';
+                for (const it of items) {
+                    const row = document.createElement('div');
+                    row.className = 'rm-oodar-row';
+                    const num = document.createElement('span');
+                    num.className = 'rm-oodar-num';
+                    num.textContent = it.num;
+                    const title = document.createElement('span');
+                    title.className = 'rm-oodar-title';
+                    title.textContent = it.title;
+                    const badge = document.createElement('span');
+                    badge.className = 'rm-oodar-badge ' + (it.status || 'todo');
+                    if (it.live) {
+                        const dot = document.createElement('span');
+                        dot.className = 'rm-oodar-live-dot';
+                        dot.title = 'live from kanban';
+                        badge.appendChild(dot);
+                    }
+                    badge.appendChild(document.createTextNode(STATUS_LABEL[it.status] || it.status || ''));
+                    row.appendChild(num);
+                    row.appendChild(title);
+                    if (it.updatedAt) {
+                        const when = document.createElement('span');
+                        when.className = 'rm-oodar-when';
+                        when.textContent = fmtWhen(it.updatedAt);
+                        row.appendChild(when);
+                    }
+                    row.appendChild(badge);
+                    if (it.pr) {
+                        const pr = document.createElement('a');
+                        pr.className = 'rm-oodar-pr';
+                        pr.href = it.pr;
+                        pr.target = '_blank';
+                        pr.rel = 'noopener';
+                        pr.textContent = 'PR ↗';
+                        row.appendChild(pr);
+                    }
+                    host.appendChild(row);
+                }
+                if (meta) {
+                    const liveCount = items.filter(i => i.live).length;
+                    const gen = fmtWhen(data.generatedAt) || new Date().toISOString().slice(0, 10);
+                    meta.textContent = (data.degraded
+                        ? tr('rm_oodar_live_degraded', 'Showing last-known plan status (kanban unreachable).')
+                        : `${liveCount}/${items.length} ${tr('rm_oodar_live_from_kanban', 'items live from kanban')}`) + ' · ' + gen;
+                }
+            } catch (e) {
+                if (meta) meta.textContent = tr('rm_oodar_live_unavailable', 'Live status unavailable — see the 4-phase plan below.');
+            }
+        }
 
         // ── Live status from kanban ───────────────────────────────────────
         // Reads /api/mission/cards, walks every [data-card-id] element, and

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650313,6 +650313,13 @@ const TRANSLATIONS = {
         "community_invite_guest_title": "Invited by a friend? Sign up and you both earn e-coin",
         "community_invite_guest_desc": "New members get 100 e-coin, and your inviter gets 500 — plus a 500 e-coin bonus on your first top-up.",
         "community_invite_guest_btn": "Claim your bonus",
+        "rm_oodar_live_title": "Live status tracker",
+        "rm_oodar_live_help": "Status, last-update time and PR links are pulled live from the team kanban board via /api/mission/roadmap-status. No login needed; if the board is unreachable the page shows the last known plan status.",
+        "rm_oodar_live_loading": "Loading live status…",
+        "rm_oodar_live_nojs": "Enable JavaScript to see live kanban-backed status. The static 4-phase plan below is always available.",
+        "rm_oodar_live_from_kanban": "items live from kanban",
+        "rm_oodar_live_degraded": "Showing last-known plan status (kanban unreachable).",
+        "rm_oodar_live_unavailable": "Live status unavailable — see the 4-phase plan below.",
 },
 
 
@@ -1235092,6 +1235099,13 @@ const TRANSLATIONS = {
         "community_invite_guest_title": "朋友邀請你來的嗎？註冊後雙方都能領 e幣",
         "community_invite_guest_desc": "新成員可獲得 100 e幣，邀請你的人可獲得 500 e幣，首次儲值再加贈 500 e幣。",
         "community_invite_guest_btn": "領取你的獎勵",
+        "rm_oodar_live_title": "即時狀態追蹤",
+        "rm_oodar_live_help": "狀態、最後更新時間與 PR 連結皆透過 /api/mission/roadmap-status 從團隊看板即時拉取，無需登入；若看板暫時無法連線，頁面會顯示最後已知的計畫狀態。",
+        "rm_oodar_live_loading": "正在載入即時狀態…",
+        "rm_oodar_live_nojs": "請啟用 JavaScript 以檢視看板即時狀態；下方的四階段計畫一律可見。",
+        "rm_oodar_live_from_kanban": "個項目為看板即時狀態",
+        "rm_oodar_live_degraded": "顯示最後已知的計畫狀態（看板暫時無法連線）。",
+        "rm_oodar_live_unavailable": "即時狀態暫時無法取得 — 請參考下方四階段計畫。",
 },
 
 

--- a/backend/tests/jest/agent-improvement-roadmap-manifest.test.js
+++ b/backend/tests/jest/agent-improvement-roadmap-manifest.test.js
@@ -1,0 +1,108 @@
+/**
+ * Phase 4 #9 — public roadmap manifest + tracker payload builder.
+ * Card: card_5ac74610cbf1f89440427809
+ */
+'use strict';
+
+const {
+    KANBAN_TO_PUBLIC,
+    PUBLIC_STATUSES,
+    toPublicStatus,
+    ROADMAP_ITEMS,
+    buildTrackerPayload,
+} = require('../../agent-improvement/roadmap-manifest');
+
+describe('toPublicStatus()', () => {
+    test('collapses kanban statuses into the 3 public words', () => {
+        expect(toPublicStatus('backlog')).toBe('todo');
+        expect(toPublicStatus('todo')).toBe('todo');
+        expect(toPublicStatus('in_progress')).toBe('in_progress');
+        expect(toPublicStatus('review')).toBe('in_progress');
+        expect(toPublicStatus('done')).toBe('shipped');
+        expect(toPublicStatus('blocked')).toBe('todo');
+    });
+    test('unknown status defaults to todo', () => {
+        expect(toPublicStatus('weird')).toBe('todo');
+        expect(toPublicStatus(undefined)).toBe('todo');
+    });
+    test('every mapping target is a valid public status', () => {
+        for (const v of Object.values(KANBAN_TO_PUBLIC)) {
+            expect(PUBLIC_STATUSES).toContain(v);
+        }
+    });
+});
+
+describe('ROADMAP_ITEMS', () => {
+    test('has exactly 9 items, one per OODA-R roadmap number', () => {
+        expect(ROADMAP_ITEMS).toHaveLength(9);
+        expect(ROADMAP_ITEMS.map(i => i.num)).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    });
+    test('every item carries a cardId, title, and valid fallbackStatus', () => {
+        for (const it of ROADMAP_ITEMS) {
+            expect(typeof it.cardId).toBe('string');
+            expect(it.cardId.length).toBeGreaterThan(0);
+            expect(typeof it.title).toBe('string');
+            expect(PUBLIC_STATUSES).toContain(it.fallbackStatus);
+        }
+    });
+    test('item ids are unique (DOM/i18n anchors must not collide)', () => {
+        const ids = ROADMAP_ITEMS.map(i => i.id);
+        expect(new Set(ids).size).toBe(ids.length);
+    });
+    test('is frozen so the route layer cannot mutate it', () => {
+        expect(Object.isFrozen(ROADMAP_ITEMS)).toBe(true);
+    });
+});
+
+describe('buildTrackerPayload()', () => {
+    test('uses fallbackStatus and live=false when no card data supplied', () => {
+        const { items, generatedAt } = buildTrackerPayload({});
+        expect(items).toHaveLength(9);
+        for (const it of items) {
+            expect(it.live).toBe(false);
+            expect(it.updatedAt).toBeNull();
+            expect(PUBLIC_STATUSES).toContain(it.status);
+        }
+        expect(() => new Date(generatedAt)).not.toThrow();
+        expect(Number.isNaN(Date.parse(generatedAt))).toBe(false);
+    });
+
+    test('live status overrides fallback when the card is found', () => {
+        const target = ROADMAP_ITEMS.find(i => i.num === 5); // p2 offline, fallback todo
+        const ts = '2026-06-15T00:00:00.000Z';
+        const { items } = buildTrackerPayload({
+            [target.cardId]: { status: 'in_progress', updatedAt: ts },
+        });
+        const got = items.find(i => i.cardId === target.cardId);
+        expect(got.status).toBe('in_progress');
+        expect(got.live).toBe(true);
+        expect(got.updatedAt).toBe(ts);
+    });
+
+    test('Date updatedAt is serialized to ISO', () => {
+        const target = ROADMAP_ITEMS[0];
+        const d = new Date('2026-06-16T12:34:56.000Z');
+        const { items } = buildTrackerPayload({
+            [target.cardId]: { status: 'done', updatedAt: d },
+        });
+        const got = items.find(i => i.cardId === target.cardId);
+        expect(got.status).toBe('shipped');
+        expect(got.updatedAt).toBe('2026-06-16T12:34:56.000Z');
+    });
+
+    test('card present but no status string → falls back', () => {
+        const target = ROADMAP_ITEMS[0];
+        const { items } = buildTrackerPayload({ [target.cardId]: {} });
+        const got = items.find(i => i.cardId === target.cardId);
+        expect(got.live).toBe(false);
+        expect(got.status).toBe(target.fallbackStatus);
+    });
+
+    test('payload carries no secret-shaped fields (only public card data)', () => {
+        const { items } = buildTrackerPayload({});
+        const json = JSON.stringify(items);
+        // no botSecret / deviceSecret / 32-hex token leakage
+        expect(/botSecret|deviceSecret|Bearer\s/i.test(json)).toBe(false);
+        expect(/\b[a-f0-9]{32,}\b/i.test(json)).toBe(false);
+    });
+});

--- a/backend/tests/jest/agent-improvement-rule-promotion.test.js
+++ b/backend/tests/jest/agent-improvement-rule-promotion.test.js
@@ -1,0 +1,281 @@
+/**
+ * Phase 4 #9 — rule promotion engine.
+ * Card: card_5ac74610cbf1f89440427809
+ *
+ * Deterministic input → suggestion shape. No DB / network / GitHub.
+ */
+'use strict';
+
+const {
+    DEFAULT_THRESHOLD,
+    SEVERITY_THRESHOLD_OVERRIDE,
+    RULE_VEHICLES,
+    PAIN_AXIS_TO_VEHICLE,
+    sortChronological,
+    trailingRunForTag,
+    effectiveThreshold,
+    highestSeverity,
+    evaluatePromotions,
+    renderMetaPrBody,
+    buildMetaPrDraft,
+} = require('../../agent-improvement/rule-promotion');
+
+const { PAIN_TAXONOMY } = require('../../agent-improvement/episode-schema');
+
+// Minimal episode factory — only the fields the engine reads.
+function ep(cardId, tag, occurredAt, severity = 'P2', extra = {}) {
+    return {
+        cardId,
+        painTags: Array.isArray(tag) ? tag : [tag],
+        occurredAt,
+        severity,
+        ...extra,
+    };
+}
+
+const T = (n) => `2026-06-1${n}T00:00:00+08:00`; // T(0)..T(9) ascending
+
+describe('constants', () => {
+    test('DEFAULT_THRESHOLD is 3', () => {
+        expect(DEFAULT_THRESHOLD).toBe(3);
+    });
+    test('P0 promotes faster than P2/P3', () => {
+        expect(SEVERITY_THRESHOLD_OVERRIDE.P0).toBeLessThan(SEVERITY_THRESHOLD_OVERRIDE.P2);
+        expect(SEVERITY_THRESHOLD_OVERRIDE.P0).toBe(2);
+    });
+    test('every pain axis maps to a known vehicle', () => {
+        for (const tag of PAIN_TAXONOMY) {
+            const m = PAIN_AXIS_TO_VEHICLE[tag];
+            expect(m).toBeDefined();
+            expect(RULE_VEHICLES).toContain(m.vehicle);
+            expect(typeof m.target).toBe('string');
+            expect(m.target.length).toBeGreaterThan(0);
+        }
+    });
+});
+
+describe('sortChronological()', () => {
+    test('sorts ASC by occurredAt, stable by cardId on ties', () => {
+        const a = ep('b', 'auth_session', T(2));
+        const b = ep('a', 'auth_session', T(2)); // same time, earlier cardId
+        const c = ep('c', 'auth_session', T(1));
+        const out = sortChronological([a, b, c]).map(e => e.cardId);
+        expect(out).toEqual(['c', 'a', 'b']);
+    });
+    test('does not mutate input', () => {
+        const arr = [ep('b', 'auth_session', T(2)), ep('a', 'auth_session', T(1))];
+        const snapshot = arr.map(e => e.cardId);
+        sortChronological(arr);
+        expect(arr.map(e => e.cardId)).toEqual(snapshot);
+    });
+});
+
+describe('trailingRunForTag()', () => {
+    test('returns the unbroken streak ending at the latest tagged episode', () => {
+        const sorted = sortChronological([
+            ep('c1', 'auth_session', T(0)),
+            ep('c2', 'auth_session', T(1)),
+            ep('c3', 'auth_session', T(2)),
+        ]);
+        expect(trailingRunForTag('auth_session', sorted).map(e => e.cardId))
+            .toEqual(['c1', 'c2', 'c3']);
+    });
+    test('an interrupting episode without the tag resets the run', () => {
+        const sorted = sortChronological([
+            ep('c1', 'auth_session', T(0)),
+            ep('c2', 'test_coverage', T(1)), // breaks the auth streak
+            ep('c3', 'auth_session', T(2)),
+            ep('c4', 'auth_session', T(3)),
+        ]);
+        // trailing run is only c3,c4 (c1 is before the break)
+        expect(trailingRunForTag('auth_session', sorted).map(e => e.cardId))
+            .toEqual(['c3', 'c4']);
+    });
+    test('empty when tag never present', () => {
+        const sorted = sortChronological([ep('c1', 'auth_session', T(0))]);
+        expect(trailingRunForTag('ux_feedback', sorted)).toEqual([]);
+    });
+});
+
+describe('effectiveThreshold() / highestSeverity()', () => {
+    test('a single P0 in the run pulls the bar to 2', () => {
+        const run = [ep('c1', 'auth_session', T(0), 'P2'), ep('c2', 'auth_session', T(1), 'P0')];
+        expect(effectiveThreshold(run)).toBe(2);
+    });
+    test('all-P2 run keeps the default bar of 3', () => {
+        const run = [ep('c1', 'auth_session', T(0), 'P2'), ep('c2', 'auth_session', T(1), 'P2')];
+        expect(effectiveThreshold(run)).toBe(3);
+    });
+    test('highestSeverity returns the most severe', () => {
+        expect(highestSeverity([
+            ep('c1', 'auth_session', T(0), 'P3'),
+            ep('c2', 'auth_session', T(1), 'P1'),
+        ])).toBe('P1');
+    });
+});
+
+describe('evaluatePromotions()', () => {
+    test('no suggestion below threshold (2 consecutive P2 < bar 3)', () => {
+        const out = evaluatePromotions([
+            ep('c1', 'task_context', T(0), 'P2'),
+            ep('c2', 'task_context', T(1), 'P2'),
+        ]);
+        expect(out).toEqual([]);
+    });
+
+    test('3 consecutive same-axis P2 warnings → one suggestion', () => {
+        const out = evaluatePromotions([
+            ep('c1', 'task_context', T(0), 'P2'),
+            ep('c2', 'task_context', T(1), 'P2'),
+            ep('c3', 'task_context', T(2), 'P2'),
+        ]);
+        expect(out).toHaveLength(1);
+        const s = out[0];
+        expect(s.painTag).toBe('task_context');
+        expect(s.consecutiveCount).toBe(3);
+        expect(s.threshold).toBe(3);
+        expect(s.vehicle).toBe(PAIN_AXIS_TO_VEHICLE.task_context.vehicle);
+        expect(s.supportingCardIds).toEqual(['c1', 'c2', 'c3']);
+        expect(s.suggestionId).toBe('promote:task_context:c3');
+    });
+
+    test('2 consecutive warnings with a P0 promote early (bar drops to 2)', () => {
+        const out = evaluatePromotions([
+            ep('c1', 'auth_session', T(0), 'P0'),
+            ep('c2', 'auth_session', T(1), 'P2'),
+        ]);
+        expect(out).toHaveLength(1);
+        expect(out[0].consecutiveCount).toBe(2);
+        expect(out[0].threshold).toBe(2);
+        expect(out[0].highestSeverity).toBe('P0');
+    });
+
+    test('an interrupting different-axis episode breaks the streak (no promotion)', () => {
+        const out = evaluatePromotions([
+            ep('c1', 'task_context', T(0), 'P2'),
+            ep('c2', 'task_context', T(1), 'P2'),
+            ep('c3', 'ux_feedback', T(2), 'P2'), // breaks task_context streak
+            ep('c4', 'task_context', T(3), 'P2'),
+        ]);
+        // task_context trailing run is only c4 → below bar
+        const tc = out.find(s => s.painTag === 'task_context');
+        expect(tc).toBeUndefined();
+    });
+
+    test('deterministic ordering: equal severity → alphabetical painTag', () => {
+        // Both axes co-tagged on every episode (neither streak interrupted) and
+        // share the same episode-level severities, so highestSeverity ties at P0;
+        // tiebreak is alphabetical painTag → task_context before test_coverage.
+        const out = evaluatePromotions([
+            ep('a1', ['task_context', 'test_coverage'], T(0), 'P2'),
+            ep('a2', ['task_context', 'test_coverage'], T(1), 'P0'),
+            ep('a3', ['task_context', 'test_coverage'], T(2), 'P2'),
+        ]);
+        expect(out.map(s => s.painTag)).toEqual(['task_context', 'test_coverage']);
+        expect(out.every(s => s.highestSeverity === 'P0')).toBe(true);
+    });
+
+    test('a later different-axis episode resets the prior axis trailing run', () => {
+        // task_context streak of 3, then 2 unrelated test_coverage episodes —
+        // task_context no longer has a TRAILING run (it was interrupted), so it
+        // does not promote; test_coverage (only 2, P0) does via the P0 bar drop.
+        const out = evaluatePromotions([
+            ep('a1', 'task_context', T(0), 'P2'),
+            ep('a2', 'task_context', T(1), 'P2'),
+            ep('a3', 'task_context', T(2), 'P2'),
+            ep('b1', 'test_coverage', T(3), 'P0'),
+            ep('b2', 'test_coverage', T(4), 'P0'),
+        ]);
+        expect(out.map(s => s.painTag)).toEqual(['test_coverage']);
+    });
+
+    test('caller can override the global threshold', () => {
+        const out = evaluatePromotions([
+            ep('c1', 'task_context', T(0), 'P2'),
+            ep('c2', 'task_context', T(1), 'P2'),
+        ], { threshold: 2 });
+        expect(out).toHaveLength(1);
+        expect(out[0].threshold).toBe(2);
+    });
+
+    test('empty / non-array input → empty', () => {
+        expect(evaluatePromotions([])).toEqual([]);
+        expect(evaluatePromotions(null)).toEqual([]);
+        expect(evaluatePromotions(undefined)).toEqual([]);
+    });
+
+    test('ignores tags outside the closed taxonomy', () => {
+        const out = evaluatePromotions([
+            ep('c1', 'not_a_real_tag', T(0), 'P0'),
+            ep('c2', 'not_a_real_tag', T(1), 'P0'),
+        ]);
+        expect(out).toEqual([]);
+    });
+});
+
+describe('renderMetaPrBody()', () => {
+    const suggestion = evaluatePromotions([
+        ep('c1', 'task_context', T(0), 'P2', { missedChecks: ['no Task Contract published'] }),
+        ep('c2', 'task_context', T(1), 'P2', { missedChecks: ['scope drifted mid-card'] }),
+        ep('c3', 'task_context', T(2), 'P2', { userFeedback: '不知道自己該做甚麼' }),
+    ])[0];
+
+    test('includes axis, count, vehicle, and every supporting episode lesson', () => {
+        const md = renderMetaPrBody(suggestion);
+        expect(md).toContain('task_context');
+        expect(md).toContain('3 consecutive');
+        expect(md).toContain(suggestion.vehicle);
+        expect(md).toContain('no Task Contract published');
+        expect(md).toContain('scope drifted mid-card');
+        expect(md).toContain('不知道自己該做甚麼');
+        expect(md).toContain('[c1 · P2]');
+        expect(md).toContain(`suggestionId: ${suggestion.suggestionId}`);
+    });
+
+    test('is deterministic — same suggestion renders identical body', () => {
+        expect(renderMetaPrBody(suggestion)).toBe(renderMetaPrBody(suggestion));
+    });
+
+    test('falls back to deliverable when no lesson fields present', () => {
+        const s = evaluatePromotions([
+            ep('d1', 'task_context', T(0), 'P2', { deliverable: 'thing A' }),
+            ep('d2', 'task_context', T(1), 'P2', { deliverable: 'thing B' }),
+            ep('d3', 'task_context', T(2), 'P2', { deliverable: 'thing C' }),
+        ])[0];
+        const md = renderMetaPrBody(s);
+        expect(md).toContain('thing A');
+    });
+
+    test('empty input → empty string', () => {
+        expect(renderMetaPrBody(null)).toBe('');
+    });
+});
+
+describe('buildMetaPrDraft()', () => {
+    const s = evaluatePromotions([
+        ep('c1', 'test_coverage', T(0), 'P1'),
+        ep('c2', 'test_coverage', T(1), 'P1'),
+        ep('c3', 'test_coverage', T(2), 'P1'),
+    ])[0];
+
+    test('produces title/body/branch/suggestionId', () => {
+        const draft = buildMetaPrDraft(s);
+        expect(draft.title).toContain('test_coverage');
+        expect(draft.title).toContain(s.vehicle);
+        expect(draft.branch).toBe('oodar/promote-test-coverage');
+        expect(draft.body).toBe(renderMetaPrBody(s));
+        expect(draft.suggestionId).toBe(s.suggestionId);
+    });
+});
+
+describe('integration with real fixtures', () => {
+    const FIXTURES = require('../../agent-improvement/__tests__/fixtures/episodes');
+
+    test('runs against the canonical fixture set without throwing', () => {
+        const out = evaluatePromotions(FIXTURES);
+        expect(Array.isArray(out)).toBe(true);
+        // Each fixture has a distinct painTag → no axis reaches a run of 2,
+        // so nothing should promote. Guards against false positives.
+        expect(out).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Scope
OODA-R Phase 4 #9 — capstone (card_5ac74610cbf1f89440427809, parent card_be59aa034883fe36d3645a27). Two coherent increments:

### 1. Rule promotion engine — `backend/agent-improvement/rule-promotion.js`
The "Reinforce" step of the loop. When the SAME pain taxonomy fires **N consecutive** warnings, auto-suggest promoting the lesson into an enforced rule and produce a meta-PR draft with the N supporting episodes.
- **Trailing-run semantics**: per-axis longest unbroken streak ending at the most recent tagged episode; an interrupting different-axis episode resets the streak (the failure must keep *recurring*, not merely have happened N times ever).
- **Threshold N=3** default; **P0-bearing runs drop to N=2** (severity-graded — directly answers the done-retro slot "rule 提升閾值 N=? 是否需要按 pain axis 分級?").
- Each axis maps to a concrete **vehicle** (`sop` / `ci_check` / `lint` / `checklist`) + enforce-target string → deterministic meta-PR `{title, body, branch}` embedding the supporting episodes' cardId · severity · lesson.
- **Pure** (no DB / network / GitHub) — the route/cron layer fetches episodes and opens the PR. Same seam as preflight.js / done-gate.js.

### 2. Public roadmap live tracker
- New **public** endpoint `GET /api/mission/roadmap-status` (kanban.js) — **no auth, no secrets**. Joins an editorial manifest (`agent-improvement/roadmap-manifest.js`) against `kanban_cards.status` for the canonical `ADMIN_DEVICE_IDS` board; 60s cache; graceful manifest-fallback on DB error.
- `/portal/roadmap.html` gains a **"Live status tracker"** section that fetches it and renders per-item status (todo / in_progress / shipped) + last-update date + PR link.
- Why a new endpoint: the existing `injectLiveCardStatus()` (PR #3217) needs an admin `deviceSecret` and is a **no-op for public visitors** (keeps hard-coded badges). This makes the public page status *actually* kanban-backed.
- **? icon UX**: `data-i18n-title` + hard `title` fallback explaining how live status works + that no login is needed.
- **i18n**: 7 new keys × **EN + ZH** inserted via `backend/scripts/i18n-insert-locale-keys.js` (AST, espree).

## Tests
- `agent-improvement-rule-promotion.test.js` — 26 tests (deterministic input → suggestion shape; threshold/severity grading; streak interruption; meta-PR body determinism + fallbacks).
- `agent-improvement-roadmap-manifest.test.js` — 12 tests (status mapping, payload build, live-override, Date→ISO, secret-free assertion).
- **Full backend jest green: 323 suites, 4518 passed, 17 skipped, 0 failed.** New-suite log artifact: `oodar-phase4-jest.log`.

## User POV / Globe-user
- Any anonymous visitor opening `/portal/roadmap.html` (desktop 1280x800 + mobile 390x844) sees the live tracker; works for ALL deployments via `ADMIN_DEVICE_IDS` env (no hardcoded device). Empty/unreachable board degrades to the last-known plan with an explanatory line + ? icon.

## Out of scope (deferred)
- Wiring the engine into a cron that actually *opens* the meta-PR on GitHub (pure module shipped; route/cron is a follow-up).
- Full 12-locale translation of the 7 new keys (EN+ZH shipped per same-PR rule; remaining locales fall back to EN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)