### PR TITLE
feat(msg-lifecycle): Phase 2 — transition engine + dual-write + backfill + debug endpoint + divergence detector

### DIFF
--- a/backend/delivery-receipts.js
+++ b/backend/delivery-receipts.js
@@ -3,6 +3,18 @@
 const DEFAULT_FAILURE_ALERT_THRESHOLD = 3;
 const deliveryFailureStreaks = new Map();
 
+// MessageLifecycle dual-write (spec §7, card_1b1c1322). Lazily required so this
+// leaf module has no hard dependency / require cycle. Best-effort: lifecycle
+// failures never affect the legacy delivery_alert path.
+let _lifecycle = null;
+function lifecycle() {
+    if (_lifecycle === null) {
+        try { _lifecycle = require('./lib/message-lifecycle'); }
+        catch (_) { _lifecycle = false; }
+    }
+    return _lifecycle || null;
+}
+
 function deliveryReceiptKey(deviceId, entityId, channel = 'channel_callback') {
     return `${deviceId || 'unknown_device'}:${entityId ?? 'unknown_entity'}:${channel}`;
 }
@@ -20,7 +32,8 @@ function recordDeliveryReceipt({
     success,
     reason,
     metadata = {},
-    threshold = DEFAULT_FAILURE_ALERT_THRESHOLD
+    threshold = DEFAULT_FAILURE_ALERT_THRESHOLD,
+    messageId = null
 }) {
     const key = deliveryReceiptKey(deviceId, entityId, channel);
     const receiptMetadata = {
@@ -37,6 +50,20 @@ function recordDeliveryReceipt({
                 entityId,
                 metadata: receiptMetadata
             });
+        }
+        // Dual-write (spec §7): a confirmed delivery receipt advances the
+        // lifecycle to push_delivered. Only when a real message_id is threaded
+        // through — push_delivered is NEVER derived/synthesized (constraint #2).
+        if (messageId) {
+            const lc = lifecycle();
+            if (lc) {
+                Promise.resolve(lc.transition({
+                    messageId,
+                    targetState: 'push_delivered',
+                    eventAt: new Date(),
+                    source: 'channel_callback',
+                })).catch(() => {});
+            }
         }
         return { consecutiveFailures: 0, alerted: false };
     }
@@ -68,6 +95,26 @@ function recordDeliveryReceipt({
                 entityId,
                 metadata: failureMetadata
             });
+        }
+        // Dual-write divergence guard (spec §6.5 / §9.10): the legacy
+        // delivery_alert just fired. If we have a message_id but no lifecycle
+        // row stuck at bot_acked/push_delivered, dual-write was skipped on the
+        // delivery path — record it for the Phase 3 cutover gate.
+        if (messageId) {
+            const lc = lifecycle();
+            if (lc) {
+                Promise.resolve((async () => {
+                    const row = await lc.getLifecycle(messageId).catch(() => null);
+                    if (!row || row.state === 'inbound_seen') {
+                        await lc.recordDivergence({
+                            messageId, deviceId, entityId,
+                            legacyCounter: 'delivery_alert',
+                            direction: 'lifecycle_skipped',
+                            reason: 'delivery_alert fired but lifecycle not at/after bot_acked',
+                        });
+                    }
+                })()).catch(() => {});
+            }
         }
         if (notifyDevice) {
             Promise.resolve(notifyDevice(deviceId, {

--- a/backend/entity-status.js
+++ b/backend/entity-status.js
@@ -36,6 +36,28 @@ const CANONICAL_ACHIEVEMENTS = [
 
 let pool = null;
 let devicesRef = null;
+// MessageLifecycle dual-write (spec §7, card_1b1c1322). Lazily required to
+// avoid a require cycle at module-load. Every legacy counter site below ALSO
+// calls into this so the new state machine runs in parallel. Lifecycle writes
+// are best-effort: a failure here NEVER blocks the legacy counter path (legacy
+// stays authoritative for reads during parallel run).
+let _lifecycle = null;
+function lifecycle() {
+    if (_lifecycle === null) {
+        try { _lifecycle = require('./lib/message-lifecycle'); }
+        catch (_) { _lifecycle = false; }
+    }
+    return _lifecycle || null;
+}
+// Synthesize a stable lifecycle message_id from the legacy tracking tuple when
+// the real chat message_id is not threaded through this path. Deterministic so
+// trackOutbound + markReplyReceived + the sweeper converge on the SAME row.
+function synthMessageId(deviceId, recipientEntityId, axis, dispatchedAtMs) {
+    // Round dispatched time to the second so the inbound + its bot_acked +
+    // its stuck-tick all resolve to one lifecycle row.
+    const bucket = Math.floor((dispatchedAtMs || Date.now()) / 1000);
+    return `lc:${deviceId}:${recipientEntityId}:${axis}:${bucket}`;
+}
 // Shared with index.js so we verify cookies against the same secret. Set via
 // bindJwtSecret() at bootstrap. Falling back to process.env.JWT_SECRET works
 // only when that env var is present (i.e. when the secret survives restarts);
@@ -143,6 +165,29 @@ async function trackOutbound(deviceId, senderEntityId, recipientEntityId, eventT
     } catch (err) {
         console.error('[EntityStatus] trackOutbound error:', err.message);
     }
+
+    // Dual-write (spec §7): a message was routed to recipientEntityId who now
+    // owes a reply — that is the inbound_seen of the recipient's lifecycle. We
+    // only dual-write the chat axis (chat_no_reply replacement, spec §6.5); the
+    // a2a / system axes get their own lifecycle direction in a later phase.
+    if (axis === 'chat_no_reply') {
+        const lc = lifecycle();
+        if (lc) {
+            const messageId = synthMessageId(deviceId, recipientEntityId, axis, Date.now());
+            Promise.resolve(lc.transition({
+                messageId,
+                targetState: 'inbound_seen',
+                eventAt: new Date(),
+                source: 'trackOutbound',
+                create: {
+                    deviceId,
+                    entityId: Number(recipientEntityId),
+                    tenantId: String(deviceId),
+                    direction: 'inbound',
+                },
+            })).catch(err => console.error('[lifecycle] trackOutbound dual-write failed:', err.message));
+        }
+    }
 }
 
 // Called when an incoming transform/speak from `senderEntityId` arrives. Match
@@ -169,9 +214,30 @@ async function markReplyReceived(deviceId, replyFromEntityId, eventType) {
                    ${extra}
                  ORDER BY dispatched_at ASC
                  LIMIT 1
-              )`,
+              )
+              RETURNING recipient_entity_id, axis, dispatched_at`,
             params
         );
+
+        // Dual-write (spec §7): the recipient produced a reply → bot_acked for
+        // the inbound it answered. Reconstruct the same synthesized message_id
+        // trackOutbound used so the transition lands on the right row. Only the
+        // chat axis is dual-written (chat_no_reply replacement, spec §6.5).
+        const matched = result.rows && result.rows[0];
+        if (matched && matched.axis === 'chat_no_reply') {
+            const lc = lifecycle();
+            if (lc) {
+                const dispatchedMs = matched.dispatched_at
+                    ? new Date(matched.dispatched_at).getTime() : Date.now();
+                const messageId = synthMessageId(deviceId, matched.recipient_entity_id, matched.axis, dispatchedMs);
+                Promise.resolve(lc.transition({
+                    messageId,
+                    targetState: 'bot_acked',
+                    eventAt: new Date(),
+                    source: 'markReplyReceived',
+                })).catch(err => console.error('[lifecycle] markReplyReceived dual-write failed:', err.message));
+            }
+        }
         return result.rowCount || 0;
     } catch (err) {
         console.error('[EntityStatus] markReplyReceived error:', err.message);
@@ -203,6 +269,42 @@ async function sweepExpired() {
                         last_event_at = NOW(),
                         updated_at = NOW()
                 `, [row.device_id, row.recipient_entity_id, row.axis]);
+
+                // Dual-write divergence guard (spec §6.5 / §9.10): the legacy
+                // chat_no_reply counter just ticked because the bot stayed
+                // silent past its grace window. The matching lifecycle row
+                // should still be at inbound_seen (never advanced to bot_acked).
+                // If there is NO lifecycle row at all, dual-write was skipped on
+                // the inbound path — record a divergence so the Phase 3 cutover
+                // gate surfaces it rather than silently passing.
+                if (row.axis === 'chat_no_reply') {
+                    const lc = lifecycle();
+                    if (lc) {
+                        Promise.resolve((async () => {
+                            // We cannot reconstruct the exact dispatched-second
+                            // bucket here (the pending row is being deleted), so
+                            // we check for ANY recent inbound_seen lifecycle row
+                            // for this (device, entity) that is still stuck.
+                            const probe = await pool.query(
+                                `SELECT message_id FROM message_lifecycle
+                                  WHERE device_id = $1 AND entity_id = $2
+                                    AND state = 'inbound_seen'
+                                    AND inbound_seen_at > NOW() - INTERVAL '1 hour'
+                                  LIMIT 1`,
+                                [row.device_id, row.recipient_entity_id]
+                            ).catch(() => ({ rows: [] }));
+                            if (!probe.rows.length) {
+                                await lc.recordDivergence({
+                                    deviceId: row.device_id,
+                                    entityId: row.recipient_entity_id,
+                                    legacyCounter: 'chat_no_reply',
+                                    direction: 'lifecycle_skipped',
+                                    reason: 'legacy counter ticked but no stuck inbound_seen lifecycle row found',
+                                });
+                            }
+                        })()).catch(() => {});
+                    }
+                }
             } catch (err) {
                 console.error('[EntityStatus] sweepExpired upsert error:', err.message);
             }

--- a/backend/index.js
+++ b/backend/index.js
@@ -2296,6 +2296,34 @@ const hermesOrgToken = require('./hermes-org-token');
 hermesOrgToken.bindDevicesRef(devices);
 app.use('/api/hermes', hermesOrgToken.router);
 
+// MessageLifecycle debug endpoint (spec §9 acceptance B5, card_1b1c1322).
+// GET /api/debug/message-lifecycle/:messageId → the materialized lifecycle row
+// + the last 20 lifecycle_event_log audit entries. Read-only; no auth beyond
+// the same surface the other /api/debug/* routes use (these are diagnostic).
+app.get('/api/debug/message-lifecycle/:messageId', async (req, res) => {
+    try {
+        const ml = require('./lib/message-lifecycle');
+        const messageId = req.params.messageId;
+        const row = await ml.getLifecycle(messageId);
+        const eventLog = await ml.getEventLog(messageId, 20);
+        if (!row && (!eventLog || eventLog.length === 0)) {
+            return res.status(404).json({
+                success: false,
+                message: 'no lifecycle row or audit entries for this message_id',
+                messageId,
+            });
+        }
+        return res.json({
+            success: true,
+            messageId,
+            lifecycle: row || null,
+            eventLog: eventLog || [],
+        });
+    } catch (err) {
+        return res.status(500).json({ success: false, message: err.message });
+    }
+});
+
 // ENTITY GH-STATS — merged-PR count + smart-link widget on entity cards
 // (card_8a25cadcc9fc88f153fa1316). Endpoint is registered later (~line 8067)
 // next to /api/entities so it sits alongside its peers; the module itself is
@@ -19731,6 +19759,50 @@ entityStatus.initTable(chatPool)
     .catch(err => console.error('[EntityStatus] initTable error:', err.message));
 hermesOrgToken.initTable(chatPool)
     .catch(err => console.error('[HermesOrgToken] initTable error:', err.message));
+
+// MessageLifecycle Phase 2 Step 3 (card_1b1c1322) — DB store + deadline wheel
+// + sweeper boot. Runs in parallel with the legacy entity-status counters
+// (dual-write, spec §7). Redis is optional: without REDIS_URL the wheel is a
+// disabled no-op and transitions still persist to PG (the source of truth);
+// stuck-alert auto-arming is then deferred to the cold-start scan on next boot.
+const messageLifecycle = require('./lib/message-lifecycle');
+messageLifecycle.initTable(chatPool)
+    .then(() => {
+        const lcWheel = messageLifecycle.createWheel({
+            redisClient: (typeof globalThis.__eclawRedisClient === 'object' && globalThis.__eclawRedisClient) || null,
+        });
+        messageLifecycle.setWheel(lcWheel);
+        if (lcWheel.enabled) {
+            // Re-arm the deadline wheel from the DB on boot (spec §4.4 / §9.9).
+            messageLifecycle.runColdStart({ wheel: lcWheel, pool: chatPool })
+                .catch(err => console.error('[lifecycle] cold-start error:', err.message));
+            const lcSweeper = messageLifecycle.createSweeper({
+                wheel: lcWheel,
+                onDue: async (messageId) => {
+                    // Stuck-alert policy: re-check DB, alert if still stuck past
+                    // cooldown, then requeue past the cooldown (spec §4.3 / §9.6).
+                    const row = await messageLifecycle.getLifecycle(messageId).catch(() => null);
+                    if (!row || row.state === 'user_seen') return;
+                    const cooldownMs = 60_000;
+                    const now = Date.now();
+                    const alertedAt = row.alerted_at ? new Date(row.alerted_at).getTime() : 0;
+                    if (!alertedAt || (now - alertedAt) > cooldownMs) {
+                        // push_delivered never pages on its own (spec §6.4).
+                        if (row.state !== 'push_delivered') {
+                            console.warn(`[lifecycle][stuck] message=${messageId} state=${row.state} device=${row.device_id} entity=${row.entity_id} replaces_legacy=${row.state === 'inbound_seen' || row.state === 'bot_acked' ? 'chat_no_reply' : 'delivery_alert'}`);
+                        }
+                        await chatPool.query(
+                            `UPDATE message_lifecycle SET alerted_at = NOW() WHERE message_id = $1`,
+                            [messageId]
+                        ).catch(() => {});
+                    }
+                    await lcWheel.requeue(messageId, now + cooldownMs).catch(() => {});
+                },
+            });
+            lcSweeper.start();
+        }
+    })
+    .catch(err => console.error('[lifecycle] initTable error:', err.message));
 redirectRouter.init({ chatPool, devices, jwtSecret: JWT_SECRET_FALLBACK });
 agentImprovement.initTable(chatPool)
     .catch(err => console.error('[AgentImprovement] initTable error:', err.message));

--- a/backend/lib/message-lifecycle/engine.js
+++ b/backend/lib/message-lifecycle/engine.js
@@ -1,0 +1,157 @@
+/**
+ * MessageLifecycle transition engine — pure state-machine logic (spec §2).
+ *
+ * Card: card_1b1c13225f10e8a803cef532 (Phase 2 Step 3 — dual-write engine).
+ * Spec: docs/specs/message-lifecycle-spec.md §2 (state machine), §11 (#6 constraints).
+ *
+ * This module is intentionally DB-free and Redis-free. It encodes ONLY the
+ * decision: given the current materialized row and an incoming transition
+ * attempt, what is the new row + what audit verdict applies. The store
+ * (./store.js) owns persistence; this owns correctness.
+ *
+ * Why split: the two #6 sign-off constraints (idempotent + monotonic; never
+ * inflate user_seen) are pure logic. Encoding them here, with exhaustive unit
+ * tests, means the persistence layer cannot accidentally roll back a state —
+ * it can only apply the verdict this engine returns.
+ */
+'use strict';
+
+// Canonical state ordering. Index = monotonic rank. Spec §2.1.
+const STATES = ['inbound_seen', 'bot_acked', 'push_delivered', 'user_seen'];
+
+// Map state -> the *_at column that records when it was reached.
+const STATE_AT_FIELD = {
+    inbound_seen: 'inbound_seen_at',
+    bot_acked: 'bot_acked_at',
+    push_delivered: 'push_delivered_at',
+    user_seen: 'user_seen_at',
+};
+
+// Audit verdicts (spec §2.4 — lifecycle_event_log.applied domain).
+const APPLIED = {
+    ACCEPTED: 'accepted',
+    IDEMPOTENT_NOOP: 'idempotent_noop',
+    REJECTED_LATE: 'rejected_late',
+    REJECTED_UNKNOWN_MESSAGE: 'rejected_unknown_message',
+};
+
+function stateIndex(state) {
+    const i = STATES.indexOf(state);
+    return i; // -1 if unknown
+}
+
+function isValidState(state) {
+    return stateIndex(state) >= 0;
+}
+
+/**
+ * Decide the outcome of a transition attempt.
+ *
+ * @param {object|null} row  Current materialized lifecycle row, or null if the
+ *   message has no lifecycle row yet (caller decides whether to create one).
+ * @param {string} targetState  State the event is trying to advance to.
+ * @param {Date|number|string} eventAt  When the upstream event actually happened.
+ * @returns {{
+ *   applied: string,          // one of APPLIED.*
+ *   nextState?: string,       // resulting row.state if accepted
+ *   setField?: string,        // the *_at column to set (accepted only)
+ *   setValue?: Date,          // value for that column (accepted only)
+ *   skippedStates?: string[], // intermediate states jumped over (spec §2.3 rule 3)
+ *   reason?: string,          // human-readable diagnostic for the audit row
+ * }}
+ *
+ * Contract (spec §2.3):
+ *   1. Idempotent — re-applying the same target at the current state where the
+ *      *_at is already set returns IDEMPOTENT_NOOP (no mutation).
+ *   2. Monotonic — a target whose rank is <= the current state's rank, and
+ *      whose *_at is NOT already settable as a forward advance, is REJECTED_LATE.
+ *   3. No rollback — never returns a nextState with lower rank than row.state.
+ *   4. Skip-forward — advancing past intermediate states records them in
+ *      skippedStates and leaves their *_at NULL (spec §9.3). Their *_at is
+ *      NEVER backfilled later (constraint #2 + §9.3).
+ */
+function decideTransition(row, targetState, eventAt) {
+    if (!isValidState(targetState)) {
+        return {
+            applied: APPLIED.REJECTED_UNKNOWN_MESSAGE,
+            reason: `unknown target state '${targetState}'`,
+        };
+    }
+
+    const at = coerceDate(eventAt);
+    const targetIdx = stateIndex(targetState);
+
+    // No existing row: the store decides creation. For inbound_seen this is a
+    // fresh-row create; for any later state with no row it is "unknown message"
+    // (we never fabricate an inbound_seen we did not observe).
+    if (!row) {
+        if (targetState === 'inbound_seen') {
+            return {
+                applied: APPLIED.ACCEPTED,
+                nextState: 'inbound_seen',
+                setField: 'inbound_seen_at',
+                setValue: at,
+                skippedStates: [],
+                reason: 'created',
+            };
+        }
+        return {
+            applied: APPLIED.REJECTED_UNKNOWN_MESSAGE,
+            reason: `no lifecycle row for target '${targetState}'`,
+        };
+    }
+
+    const currentIdx = stateIndex(row.state);
+
+    // Idempotent: the *_at for this exact target is already populated.
+    // Re-applying the same advance is a no-op. Spec §2.3 rule 1 + §9.1.
+    const targetAtField = STATE_AT_FIELD[targetState];
+    if (row[targetAtField] != null) {
+        return {
+            applied: APPLIED.IDEMPOTENT_NOOP,
+            reason: `${targetState} already recorded`,
+        };
+    }
+
+    // Monotonic guard: a target at or below the current rank, whose *_at is
+    // NULL, means a late/out-of-order event for a state we already advanced
+    // past (or skipped). It is recorded in the audit log but NEVER mutates the
+    // row. Spec §2.3 rule 2 + §9.2 + §9.3 (late bot_acked after skip).
+    if (targetIdx <= currentIdx) {
+        return {
+            applied: APPLIED.REJECTED_LATE,
+            reason: `target '${targetState}' (rank ${targetIdx}) <= current '${row.state}' (rank ${currentIdx})`,
+        };
+    }
+
+    // Forward advance — possibly skipping intermediate states (spec §2.3 rule 3).
+    const skipped = [];
+    for (let i = currentIdx + 1; i < targetIdx; i++) {
+        skipped.push(STATES[i]);
+    }
+
+    return {
+        applied: APPLIED.ACCEPTED,
+        nextState: targetState,
+        setField: targetAtField,
+        setValue: at,
+        skippedStates: skipped,
+        reason: skipped.length ? `advanced, skipped [${skipped.join(',')}]` : 'advanced',
+    };
+}
+
+function coerceDate(v) {
+    if (v instanceof Date) return v;
+    if (typeof v === 'number') return new Date(v);
+    if (typeof v === 'string') return new Date(v);
+    return new Date();
+}
+
+module.exports = {
+    STATES,
+    STATE_AT_FIELD,
+    APPLIED,
+    stateIndex,
+    isValidState,
+    decideTransition,
+};

--- a/backend/lib/message-lifecycle/index.js
+++ b/backend/lib/message-lifecycle/index.js
@@ -4,17 +4,20 @@
  * Card: card_545ce5986b9c1332315ba303.
  * Spec: docs/specs/message-lifecycle-spec.md §4.
  *
- * Step 2 ships the wheel + sweeper + cold-start primitives. Wiring them
- * into the boot path of `backend/index.js` is Step 3's job (dual-write).
- * This index file is here so Step 3 can `require('./lib/message-lifecycle')`
- * and pick what it needs without reaching into individual files.
+ * Step 2 shipped the wheel + sweeper + cold-start primitives.
+ * Step 3 (this card, card_1b1c1322) adds the transition engine + DB store +
+ * backfill resolver + divergence detector. Callers `require('./lib/message-lifecycle')`
+ * and pick what they need without reaching into individual files.
  */
 
 const { createWheel, createInMemoryClient, deadlinesKey, DEFAULT_KEY_PREFIX } = require('./deadline-wheel');
 const { createSweeper, DEFAULT_INTERVAL_MS } = require('./sweeper');
 const { runColdStart, DEFAULT_STATE_TIMEOUTS_MS, COLD_START_PAGE_SIZE } = require('./cold-start');
+const engine = require('./engine');
+const store = require('./store');
 
 module.exports = {
+    // Step 2 — Redis deadline wheel
     createWheel,
     createInMemoryClient,
     createSweeper,
@@ -24,4 +27,21 @@ module.exports = {
     DEFAULT_INTERVAL_MS,
     DEFAULT_STATE_TIMEOUTS_MS,
     COLD_START_PAGE_SIZE,
+
+    // Step 3 — transition engine (pure) + DB store + backfill + divergence
+    engine,
+    STATES: engine.STATES,
+    APPLIED: engine.APPLIED,
+    decideTransition: engine.decideTransition,
+    store,
+    // store convenience re-exports (the common dual-write surface)
+    initTable: store.initTable,
+    setPool: store.setPool,
+    setWheel: store.setWheel,
+    transition: store.transition,
+    backfillLifecycle: store.backfillLifecycle,
+    recordDivergence: store.recordDivergence,
+    divergenceSummary: store.divergenceSummary,
+    getLifecycle: store.getLifecycle,
+    getEventLog: store.getEventLog,
 };

--- a/backend/lib/message-lifecycle/store.js
+++ b/backend/lib/message-lifecycle/store.js
@@ -1,0 +1,441 @@
+/**
+ * MessageLifecycle store — DB persistence + transition application (spec §3,§5,§7).
+ *
+ * Card: card_1b1c13225f10e8a803cef532 (Phase 2 Step 3 — dual-write store).
+ * Spec: docs/specs/message-lifecycle-spec.md §3 (Option B schema), §5 (backfill),
+ *       §7 (dual-write protocol), §11 (#6 constraints).
+ *
+ * Schema option: B (companion `message_lifecycle` table) — choice carried from
+ * Step 1 (backend/migrations/20260614_message_lifecycle.up.sql). Rationale in
+ * that file's header + spec §3.4.
+ *
+ * Dual-write discipline (spec §7):
+ *   - Every method is best-effort and NEVER throws on the hot path. A lifecycle
+ *     write failure must not break the legacy counter path (legacy stays
+ *     authoritative for reads during parallel run).
+ *   - Persistence applies ONLY the verdict the pure engine returns. The engine
+ *     guarantees idempotency + monotonicity; the store never writes a SQL
+ *     UPDATE that lowers a state rank or backfills a skipped *_at.
+ *
+ * Source of truth = PG. Redis (the deadline wheel) is an optional cache passed
+ * in via setWheel(); if absent, transitions still persist, they just won't
+ * auto-arm stuck alerts (the cold-start scan can re-arm on next boot).
+ */
+'use strict';
+
+const { decideTransition, APPLIED, STATE_AT_FIELD, stateIndex, isValidState } = require('./engine');
+
+let pool = null;
+let wheel = null; // optional deadline wheel (createWheel result)
+
+// Per-state stuck timeout (ms). Spec §2.2 defaults; tunable per entity class.
+// These are the conservative ceilings used to arm the deadline wheel. The
+// sweeper re-checks the DB row before alerting, so over-scheduling is harmless.
+const STATE_TIMEOUTS_MS = {
+    inbound_seen: 90_000,        // 90s free-bot bot_acked deadline (spec §2.2)
+    bot_acked: 60_000,           // 60s channel push deadline
+    push_delivered: 86_400_000,  // 24h best-effort (never paged — spec §6.4)
+};
+
+function setPool(p) { pool = p; }
+function setWheel(w) { wheel = w; }
+function getStateTimeoutMs(state) { return STATE_TIMEOUTS_MS[state] ?? 0; }
+
+/**
+ * Replayable DDL. The repo applies schema via initTable() at boot (not a SQL
+ * migration runner); this mirrors backend/migrations/20260614_message_lifecycle.up.sql
+ * verbatim so the two never drift. IF NOT EXISTS everywhere — safe to re-run.
+ */
+async function initTable(chatPool) {
+    pool = chatPool;
+    if (!pool) return;
+    await pool.query(`
+        CREATE TABLE IF NOT EXISTS message_lifecycle (
+            message_id          TEXT PRIMARY KEY,
+            tenant_id           TEXT NOT NULL,
+            device_id           VARCHAR(64) NOT NULL,
+            entity_id           INTEGER NOT NULL,
+            direction           TEXT NOT NULL CHECK (direction IN ('inbound', 'outbound')),
+            reply_to_message_id TEXT,
+            state               TEXT NOT NULL CHECK (state IN ('inbound_seen','bot_acked','push_delivered','user_seen')),
+            inbound_seen_at     TIMESTAMPTZ NOT NULL,
+            bot_acked_at        TIMESTAMPTZ,
+            push_delivered_at   TIMESTAMPTZ,
+            user_seen_at        TIMESTAMPTZ,
+            skipped_states      TEXT[] NOT NULL DEFAULT '{}',
+            last_error          TEXT,
+            alerted_at          TIMESTAMPTZ,
+            source              TEXT NOT NULL DEFAULT 'live'
+                                CHECK (source IN ('live','backfill','backfill+link','backfill+heuristic','inferred')),
+            created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        CREATE INDEX IF NOT EXISTS idx_ml_device_entity_state
+            ON message_lifecycle (device_id, entity_id, state);
+        CREATE INDEX IF NOT EXISTS idx_ml_stuck_lookup
+            ON message_lifecycle (state, COALESCE(push_delivered_at, bot_acked_at, inbound_seen_at))
+            WHERE state <> 'user_seen';
+        CREATE INDEX IF NOT EXISTS idx_ml_reply_chain
+            ON message_lifecycle (reply_to_message_id)
+            WHERE reply_to_message_id IS NOT NULL;
+
+        CREATE TABLE IF NOT EXISTS lifecycle_event_log (
+            id              BIGSERIAL PRIMARY KEY,
+            message_id      TEXT NOT NULL,
+            attempted_state TEXT NOT NULL
+                            CHECK (attempted_state IN ('inbound_seen','bot_acked','push_delivered','user_seen')),
+            event_at        TIMESTAMPTZ NOT NULL,
+            transition_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+            applied         TEXT NOT NULL
+                            CHECK (applied IN ('accepted','idempotent_noop','rejected_late','rejected_unknown_message')),
+            reason          TEXT,
+            source          TEXT NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_lel_message
+            ON lifecycle_event_log (message_id, transition_at DESC);
+
+        -- Divergence detector (spec §6.5 / §9.10): every dual-write site that
+        -- fails to also bump its legacy counter records here so the Phase 3
+        -- cutover gate can surface it instead of silently passing.
+        CREATE TABLE IF NOT EXISTS lifecycle_divergence_log (
+            id                BIGSERIAL PRIMARY KEY,
+            message_id        TEXT,
+            device_id         VARCHAR(64),
+            entity_id         INTEGER,
+            legacy_counter    TEXT NOT NULL,   -- 'chat_no_reply' | 'delivery_alert' | ...
+            direction         TEXT NOT NULL,   -- 'legacy_skipped' | 'lifecycle_skipped'
+            reason            TEXT,
+            occurred_at       TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        CREATE INDEX IF NOT EXISTS idx_ldl_window
+            ON lifecycle_divergence_log (occurred_at DESC);
+    `);
+}
+
+async function fetchRow(messageId) {
+    if (!pool) return null;
+    const r = await pool.query(
+        `SELECT * FROM message_lifecycle WHERE message_id = $1`,
+        [String(messageId)]
+    );
+    return r.rows[0] || null;
+}
+
+async function writeAudit(client, messageId, attemptedState, eventAt, applied, reason, source) {
+    const exec = client || pool;
+    if (!exec) return;
+    await exec.query(
+        `INSERT INTO lifecycle_event_log (message_id, attempted_state, event_at, applied, reason, source)
+         VALUES ($1, $2, $3, $4, $5, $6)`,
+        [String(messageId), attemptedState, toTs(eventAt), applied, reason || null, source || 'unknown']
+    );
+}
+
+/**
+ * Apply a transition (spec §2.3, §7). Best-effort: returns a verdict object,
+ * never throws on the hot path.
+ *
+ * @param {object} opts
+ * @param {string} opts.messageId
+ * @param {string} opts.targetState  'inbound_seen'|'bot_acked'|'push_delivered'|'user_seen'
+ * @param {Date|number|string} [opts.eventAt]  upstream event time (default now)
+ * @param {string} [opts.source]  audit source ('transform'|'enqueue'|'chat_read'|...)
+ * @param {object} [opts.create]  fields used only when creating the inbound_seen
+ *        row: { deviceId, entityId, direction, replyToMessageId, tenantId }
+ * @param {string} [opts.rowSource]  message_lifecycle.source override (backfill etc.)
+ * @returns {Promise<{applied:string, state?:string, reason?:string}>}
+ */
+async function transition(opts) {
+    const {
+        messageId,
+        targetState,
+        eventAt = new Date(),
+        source = 'unknown',
+        create = {},
+        rowSource = null,
+    } = opts || {};
+
+    if (!pool || !messageId || !targetState) {
+        return { applied: 'skipped', reason: 'store not ready or missing args' };
+    }
+
+    let client;
+    try {
+        client = await pool.connect();
+    } catch (err) {
+        console.error('[lifecycle] transition: pool.connect failed', err.message);
+        return { applied: 'skipped', reason: 'no db connection' };
+    }
+
+    try {
+        await client.query('BEGIN');
+        // Lock the row for the duration so concurrent transitions serialize
+        // (idempotency + monotonicity must hold under parallel events).
+        const sel = await client.query(
+            `SELECT * FROM message_lifecycle WHERE message_id = $1 FOR UPDATE`,
+            [String(messageId)]
+        );
+        const row = sel.rows[0] || null;
+
+        const verdict = decideTransition(row, targetState, eventAt);
+
+        if (verdict.applied === APPLIED.IDEMPOTENT_NOOP
+            || verdict.applied === APPLIED.REJECTED_LATE
+            || verdict.applied === APPLIED.REJECTED_UNKNOWN_MESSAGE) {
+            await writeAudit(client, messageId, targetState, eventAt, verdict.applied, verdict.reason, source);
+            await client.query('COMMIT');
+            return { applied: verdict.applied, state: row ? row.state : null, reason: verdict.reason };
+        }
+
+        // ACCEPTED
+        if (!row) {
+            // Create the inbound_seen row. We only ever create on inbound_seen
+            // (engine guarantees this; later states with no row are rejected).
+            const deviceId = String(create.deviceId || 'unknown').slice(0, 64);
+            const entityId = Number(create.entityId) || 0;
+            const direction = create.direction === 'outbound' ? 'outbound' : 'inbound';
+            const tenantId = String(create.tenantId || create.deviceId || 'unknown');
+            const replyTo = create.replyToMessageId ? String(create.replyToMessageId) : null;
+            await client.query(
+                `INSERT INTO message_lifecycle
+                    (message_id, tenant_id, device_id, entity_id, direction, reply_to_message_id,
+                     state, inbound_seen_at, source)
+                 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+                 ON CONFLICT (message_id) DO NOTHING`,
+                [String(messageId), tenantId, deviceId, entityId, direction, replyTo,
+                 'inbound_seen', toTs(verdict.setValue), rowSource || 'live']
+            );
+        } else {
+            // Forward advance on an existing row. Build a dynamic SET that only
+            // touches: state, the new *_at column, skipped_states, alerted_at
+            // reset, updated_at. NEVER touches a lower *_at (engine guarantees
+            // setField is strictly forward) — this is the structural no-rollback.
+            const sets = [`state = $2`, `${verdict.setField} = $3`, `updated_at = NOW()`];
+            const params = [String(messageId), verdict.nextState, toTs(verdict.setValue)];
+            // Reset alert state so the new state's timeout starts fresh (spec §9.6).
+            sets.push(`alerted_at = NULL`);
+            // last_error cleared on successful advance (spec §1 last_error def).
+            sets.push(`last_error = NULL`);
+            if (verdict.skippedStates && verdict.skippedStates.length) {
+                // Read-modify-write the array within the locked txn (avoids a
+                // hard dependency on array_cat and is safe under FOR UPDATE).
+                const existingSkips = Array.isArray(row.skipped_states) ? row.skipped_states : [];
+                const merged = Array.from(new Set([...existingSkips, ...verdict.skippedStates]));
+                params.push(merged);
+                sets.push(`skipped_states = $${params.length}::text[]`);
+            }
+            if (rowSource) {
+                params.push(rowSource);
+                sets.push(`source = $${params.length}`);
+            }
+            await client.query(
+                `UPDATE message_lifecycle SET ${sets.join(', ')} WHERE message_id = $1`,
+                params
+            );
+        }
+
+        await writeAudit(client, messageId, targetState, eventAt, APPLIED.ACCEPTED, verdict.reason, source);
+        await client.query('COMMIT');
+
+        // Arm / cancel the deadline wheel (best-effort; outside the txn).
+        await syncWheel(messageId, verdict.nextState, verdict.setValue).catch(() => {});
+
+        return { applied: APPLIED.ACCEPTED, state: verdict.nextState, reason: verdict.reason };
+    } catch (err) {
+        try { await client.query('ROLLBACK'); } catch { /* swallow */ }
+        console.error('[lifecycle] transition failed', err.message);
+        return { applied: 'error', reason: err.message };
+    } finally {
+        client.release();
+    }
+}
+
+/**
+ * Arm or cancel the deadline wheel for a row that just advanced (spec §4.2).
+ * user_seen is terminal → cancel. Other states → schedule next stuck deadline.
+ */
+async function syncWheel(messageId, state, stateAt) {
+    if (!wheel || !wheel.enabled) return;
+    if (state === 'user_seen') {
+        await wheel.cancel(messageId);
+        return;
+    }
+    const timeout = getStateTimeoutMs(state);
+    if (!timeout) return;
+    const pivot = stateAt instanceof Date ? stateAt.getTime() : Date.now();
+    await wheel.schedule(messageId, pivot + timeout);
+}
+
+/**
+ * Backfill resolver (spec §5) — lazy on read, per message.
+ *
+ * Derives inbound_seen (+ bot_acked from explicit reply link or time-proximity
+ * heuristic). NEVER derives push_delivered_at or user_seen_at (constraint #2).
+ *
+ * @param {string} messageId
+ * @param {object} opts
+ * @param {function} opts.fetchInbound  async (messageId) => { device_id, entity_id, created_at, is_from_user } | null
+ * @param {function} opts.findReply     async (messageId) => { created_at } | null  (explicit reply_to link)
+ * @param {function} opts.findNearestOutbound  async ({device_id, entity_id, after, withinSeconds}) => { created_at } | null
+ * @returns {Promise<object|null>} the materialized row, or null if not an inbound message.
+ */
+async function backfillLifecycle(messageId, opts = {}) {
+    if (!pool || !messageId) return null;
+    const { fetchInbound, findReply, findNearestOutbound } = opts;
+
+    // Already materialized? Return it (idempotent backfill).
+    const existing = await fetchRow(messageId).catch(() => null);
+    if (existing) return existing;
+
+    if (typeof fetchInbound !== 'function') return null;
+    const inbound = await fetchInbound(messageId);
+    if (!inbound || inbound.is_from_user === false) return null; // not an inbound user message
+
+    // Always derivable: inbound_seen.
+    await transition({
+        messageId,
+        targetState: 'inbound_seen',
+        eventAt: inbound.created_at,
+        source: 'backfill',
+        rowSource: 'backfill',
+        create: {
+            deviceId: inbound.device_id,
+            entityId: inbound.entity_id,
+            tenantId: inbound.device_id,
+            direction: 'inbound',
+        },
+    });
+
+    // Try bot_acked from explicit reply link first (high confidence).
+    let reply = null;
+    if (typeof findReply === 'function') {
+        reply = await findReply(messageId).catch(() => null);
+    }
+    if (reply && reply.created_at) {
+        await transition({
+            messageId,
+            targetState: 'bot_acked',
+            eventAt: reply.created_at,
+            source: 'backfill',
+            rowSource: 'backfill+link',
+        });
+    } else if (typeof findNearestOutbound === 'function') {
+        // Heuristic fallback: nearest outbound within 5min (spec §5.2 / §9.5).
+        const candidate = await findNearestOutbound({
+            device_id: inbound.device_id,
+            entity_id: inbound.entity_id,
+            after: inbound.created_at,
+            withinSeconds: 300,
+        }).catch(() => null);
+        if (candidate && candidate.created_at) {
+            await transition({
+                messageId,
+                targetState: 'bot_acked',
+                eventAt: candidate.created_at,
+                source: 'backfill',
+                rowSource: 'backfill+heuristic',
+            });
+            // Flag heuristic-derived rows (spec §5.4) — non-null last_error.
+            await pool.query(
+                `UPDATE message_lifecycle
+                    SET last_error = $2
+                  WHERE message_id = $1 AND source = 'backfill+heuristic'`,
+                [String(messageId),
+                 'derived from time-proximity heuristic; not a confirmed reply']
+            ).catch(() => {});
+        }
+    }
+
+    // push_delivered_at and user_seen_at are NEVER derived (spec §5.1 + §11 #2).
+    return fetchRow(messageId);
+}
+
+/** Record a dual-write divergence (spec §6.5 / §9.10). Best-effort. */
+async function recordDivergence({ messageId, deviceId, entityId, legacyCounter, direction = 'legacy_skipped', reason }) {
+    if (!pool || !legacyCounter) return;
+    try {
+        await pool.query(
+            `INSERT INTO lifecycle_divergence_log
+                (message_id, device_id, entity_id, legacy_counter, direction, reason)
+             VALUES ($1,$2,$3,$4,$5,$6)`,
+            [messageId ? String(messageId) : null,
+             deviceId ? String(deviceId).slice(0, 64) : null,
+             entityId != null ? Number(entityId) : null,
+             String(legacyCounter), String(direction), reason ? String(reason).slice(0, 500) : null]
+        );
+    } catch (err) {
+        console.error('[lifecycle] recordDivergence failed', err.message);
+    }
+}
+
+/**
+ * Divergence summary for the Phase 3 cutover gate (spec §6.5). Compares new
+ * alert volume vs legacy alert volume over a window and flags >±10% drift.
+ *
+ * @param {object} opts
+ * @param {number} [opts.windowHours=168]  parallel-run window (default 7d)
+ * @param {number} [opts.newAlertVolume]   count of new (lifecycle) stuck alerts in window
+ * @param {number} [opts.legacyAlertVolume] sum of legacy counter increments in window
+ */
+async function divergenceSummary(opts = {}) {
+    const windowHours = Number(opts.windowHours) || 168;
+    let skippedCount = 0;
+    if (pool) {
+        const r = await pool.query(
+            `SELECT COUNT(*)::int AS n FROM lifecycle_divergence_log
+              WHERE occurred_at > NOW() - ($1 || ' hours')::interval`,
+            [String(windowHours)]
+        ).catch(() => ({ rows: [{ n: 0 }] }));
+        skippedCount = r.rows[0] ? r.rows[0].n : 0;
+    }
+    const newVol = Number(opts.newAlertVolume);
+    const legacyVol = Number(opts.legacyAlertVolume);
+    let ratio = null;
+    let withinGate = null;
+    if (Number.isFinite(newVol) && Number.isFinite(legacyVol) && legacyVol > 0) {
+        ratio = newVol / legacyVol;
+        withinGate = ratio >= 0.9 && ratio <= 1.1; // ±10% gate (spec §6.5)
+    }
+    return { windowHours, divergenceEvents: skippedCount, ratio, withinGate };
+}
+
+async function getLifecycle(messageId) {
+    return fetchRow(messageId);
+}
+
+async function getEventLog(messageId, limit = 20) {
+    if (!pool || !messageId) return [];
+    const r = await pool.query(
+        `SELECT message_id, attempted_state, event_at, transition_at, applied, reason, source
+           FROM lifecycle_event_log
+          WHERE message_id = $1
+          ORDER BY transition_at DESC, id DESC
+          LIMIT $2`,
+        [String(messageId), Math.min(Number(limit) || 20, 100)]
+    );
+    return r.rows;
+}
+
+function toTs(v) {
+    if (v instanceof Date) return v.toISOString();
+    if (typeof v === 'number') return new Date(v).toISOString();
+    if (typeof v === 'string') return v;
+    return new Date().toISOString();
+}
+
+module.exports = {
+    setPool,
+    setWheel,
+    initTable,
+    transition,
+    backfillLifecycle,
+    recordDivergence,
+    divergenceSummary,
+    getLifecycle,
+    getEventLog,
+    getStateTimeoutMs,
+    STATE_TIMEOUTS_MS,
+    // exposed for tests / wiring
+    syncWheel,
+    fetchRow,
+};

--- a/backend/migrations/20260614_message_lifecycle.down.sql
+++ b/backend/migrations/20260614_message_lifecycle.down.sql
@@ -1,6 +1,9 @@
 -- Down: 20260614_message_lifecycle
 -- Drop the lifecycle schema in reverse order.
 
+DROP INDEX IF EXISTS idx_ldl_window;
+DROP TABLE IF EXISTS lifecycle_divergence_log;
+
 DROP INDEX IF EXISTS idx_lel_message;
 DROP TABLE IF EXISTS lifecycle_event_log;
 

--- a/backend/migrations/20260614_message_lifecycle.up.sql
+++ b/backend/migrations/20260614_message_lifecycle.up.sql
@@ -118,3 +118,30 @@ COMMENT ON TABLE lifecycle_event_log IS
     'rejected_late, or rejected_unknown_message (spec §2.4). NEVER mutated after insert; '
     'this is the structural enforcement of constraint #1 (no rollback). Read by the debug '
     'endpoint GET /api/debug/message-lifecycle/:messageId (Step 5) for the per-message timeline.';
+
+-- ============================================
+-- lifecycle_divergence_log: dual-write divergence detector (Phase 2 Step 6)
+-- Spec §6.5 (Phase 3 cutover gate) + §9.10 acceptance.
+-- Added in Step 3 (card_1b1c1322) alongside the dual-write paths.
+-- ============================================
+
+CREATE TABLE IF NOT EXISTS lifecycle_divergence_log (
+    id              BIGSERIAL PRIMARY KEY,
+    message_id      TEXT,
+    device_id       VARCHAR(64),
+    entity_id       INTEGER,
+    legacy_counter  TEXT NOT NULL,   -- 'chat_no_reply' | 'delivery_alert' | 'system_msg_no_reply'
+    direction       TEXT NOT NULL,   -- 'legacy_skipped' | 'lifecycle_skipped'
+    reason          TEXT,
+    occurred_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ldl_window
+    ON lifecycle_divergence_log (occurred_at DESC);
+
+COMMENT ON TABLE lifecycle_divergence_log IS
+    'Dual-write divergence detector (spec §6.5 / §9.10). When a legacy counter '
+    'site increments but its paired lifecycle.transition() was skipped (or vice '
+    'versa), one row is recorded here. The Phase 3 cutover gate (new_alert_volume '
+    '/ legacy_alert_volume within +-10%) reads this so divergence surfaces rather '
+    'than silently passing.';

--- a/backend/tests/jest/message-lifecycle-migration.test.js
+++ b/backend/tests/jest/message-lifecycle-migration.test.js
@@ -153,7 +153,8 @@ describe('20260614_message_lifecycle migration', () => {
     });
 
     describe('rollback (down.sql)', () => {
-        test('drops both tables', () => {
+        test('drops all lifecycle tables', () => {
+            expect(down).toMatch(/DROP TABLE IF EXISTS lifecycle_divergence_log/);
             expect(down).toMatch(/DROP TABLE IF EXISTS lifecycle_event_log/);
             expect(down).toMatch(/DROP TABLE IF EXISTS message_lifecycle/);
         });
@@ -167,11 +168,12 @@ describe('20260614_message_lifecycle migration', () => {
         });
 
         test('uses IF EXISTS to be idempotent on a clean DB', () => {
-            // Counting: 2 tables + however many indexes are in up.sql.
+            // Counting: 3 tables (message_lifecycle, lifecycle_event_log,
+            // lifecycle_divergence_log) + however many indexes are in up.sql.
             const dropTables = (down.match(/DROP TABLE IF EXISTS/g) || []).length;
             const dropIndexes = (down.match(/DROP INDEX IF EXISTS/g) || []).length;
-            expect(dropTables).toBe(2);
-            expect(dropIndexes).toBeGreaterThanOrEqual(3);
+            expect(dropTables).toBe(3);
+            expect(dropIndexes).toBeGreaterThanOrEqual(4);
         });
     });
 

--- a/backend/tests/jest/message-lifecycle/engine.test.js
+++ b/backend/tests/jest/message-lifecycle/engine.test.js
@@ -1,0 +1,117 @@
+'use strict';
+
+// Pure transition-engine tests (spec §2.3, §11 constraint #1).
+//
+// Card: card_1b1c13225f10e8a803cef532 (Phase 2 Step 3).
+// Spec: docs/specs/message-lifecycle-spec.md §2.3 (idempotent/monotonic/no-rollback),
+//       §9.1-§9.3 acceptance scenarios at the pure-logic layer.
+//
+// The engine is DB-free, so these tests lock the decision contract without any
+// harness. The store tests (./store.test.js) then verify the same contract end
+// to end against an in-memory Postgres (pg-mem).
+
+const { decideTransition, APPLIED, STATES, stateIndex } = require('../../../lib/message-lifecycle/engine');
+
+const T0 = new Date('2026-06-16T00:00:00Z');
+const T1 = new Date('2026-06-16T00:01:00Z');
+
+function rowAt(state, fields = {}) {
+    return {
+        message_id: 'm',
+        state,
+        inbound_seen_at: T0,
+        bot_acked_at: null,
+        push_delivered_at: null,
+        user_seen_at: null,
+        ...fields,
+    };
+}
+
+describe('engine: state ordering', () => {
+    test('canonical order is inbound_seen < bot_acked < push_delivered < user_seen', () => {
+        expect(STATES).toEqual(['inbound_seen', 'bot_acked', 'push_delivered', 'user_seen']);
+        expect(stateIndex('inbound_seen')).toBeLessThan(stateIndex('bot_acked'));
+        expect(stateIndex('push_delivered')).toBeLessThan(stateIndex('user_seen'));
+        expect(stateIndex('nope')).toBe(-1);
+    });
+});
+
+describe('engine: row creation', () => {
+    test('no row + inbound_seen → ACCEPTED create', () => {
+        const v = decideTransition(null, 'inbound_seen', T0);
+        expect(v.applied).toBe(APPLIED.ACCEPTED);
+        expect(v.nextState).toBe('inbound_seen');
+        expect(v.setField).toBe('inbound_seen_at');
+    });
+
+    test('no row + later state → rejected_unknown_message (never fabricate inbound)', () => {
+        const v = decideTransition(null, 'bot_acked', T0);
+        expect(v.applied).toBe(APPLIED.REJECTED_UNKNOWN_MESSAGE);
+    });
+
+    test('unknown target state → rejected_unknown_message', () => {
+        const v = decideTransition(rowAt('inbound_seen'), 'garbage', T0);
+        expect(v.applied).toBe(APPLIED.REJECTED_UNKNOWN_MESSAGE);
+    });
+});
+
+describe('engine: §9.1 idempotent', () => {
+    test('re-applying an already-recorded state is a no-op', () => {
+        const row = rowAt('bot_acked', { bot_acked_at: T0 });
+        const v = decideTransition(row, 'bot_acked', T1);
+        expect(v.applied).toBe(APPLIED.IDEMPOTENT_NOOP);
+        expect(v.setField).toBeUndefined();
+    });
+});
+
+describe('engine: §9.2 monotonic — late event rejected', () => {
+    test('bot_acked arriving after push_delivered (bot_acked_at NULL) is rejected_late', () => {
+        const row = rowAt('push_delivered', { push_delivered_at: T1 });
+        const v = decideTransition(row, 'bot_acked', T0);
+        expect(v.applied).toBe(APPLIED.REJECTED_LATE);
+        expect(v.setField).toBeUndefined();
+    });
+
+    test('a strictly-lower state with its *_at NULL is rejected_late (no rollback)', () => {
+        const row = rowAt('user_seen', { user_seen_at: T1 });
+        const v = decideTransition(row, 'inbound_seen', T0);
+        // inbound_seen_at is set (NOT NULL) so this is idempotent, not late:
+        expect([APPLIED.IDEMPOTENT_NOOP, APPLIED.REJECTED_LATE]).toContain(v.applied);
+        expect(v.nextState).toBeUndefined();
+    });
+});
+
+describe('engine: §9.3 out-of-order skip', () => {
+    test('inbound_seen → user_seen records skipped [bot_acked, push_delivered]', () => {
+        const row = rowAt('inbound_seen', { inbound_seen_at: T0 });
+        const v = decideTransition(row, 'user_seen', T1);
+        expect(v.applied).toBe(APPLIED.ACCEPTED);
+        expect(v.nextState).toBe('user_seen');
+        expect(v.setField).toBe('user_seen_at');
+        expect(v.skippedStates).toEqual(['bot_acked', 'push_delivered']);
+    });
+
+    test('after a skip to user_seen, a late bot_acked is rejected_late (never backfills)', () => {
+        // Simulate the post-skip row: state=user_seen, bot_acked_at still NULL.
+        const row = rowAt('user_seen', { user_seen_at: T1, bot_acked_at: null });
+        const v = decideTransition(row, 'bot_acked', T0);
+        expect(v.applied).toBe(APPLIED.REJECTED_LATE);
+        expect(v.setField).toBeUndefined();
+    });
+});
+
+describe('engine: forward advance', () => {
+    test('inbound_seen → bot_acked sets bot_acked_at, no skips', () => {
+        const v = decideTransition(rowAt('inbound_seen'), 'bot_acked', T1);
+        expect(v.applied).toBe(APPLIED.ACCEPTED);
+        expect(v.setField).toBe('bot_acked_at');
+        expect(v.skippedStates).toEqual([]);
+    });
+
+    test('bot_acked → push_delivered → user_seen advances stepwise', () => {
+        let v = decideTransition(rowAt('bot_acked', { bot_acked_at: T0 }), 'push_delivered', T1);
+        expect(v.nextState).toBe('push_delivered');
+        v = decideTransition(rowAt('push_delivered', { bot_acked_at: T0, push_delivered_at: T1 }), 'user_seen', T1);
+        expect(v.nextState).toBe('user_seen');
+    });
+});

--- a/backend/tests/jest/message-lifecycle/store.test.js
+++ b/backend/tests/jest/message-lifecycle/store.test.js
@@ -1,0 +1,309 @@
+'use strict';
+
+// DB-backed lifecycle store tests against an in-memory Postgres (pg-mem).
+//
+// Card: card_1b1c13225f10e8a803cef532 (Phase 2 Step 3 — dual-write store).
+// Spec: docs/specs/message-lifecycle-spec.md §9 acceptance scenarios.
+//
+// Coverage of the spec §9 scenarios:
+//   9.1  Idempotent transition                 — here (idempotent_noop audit)
+//   9.2  Monotonic — late event rejected        — here (rejected_late audit)
+//   9.3  Out-of-order — skip intermediate state — here (skipped_states + late reject)
+//   9.4  Unknown stays unknown — backfilled row  — here (backfill+link, SLO numerator)
+//   9.5  Heuristic backfill flagged             — here (backfill+heuristic last_error)
+//   9.6  Stuck alert + cooldown                  — sweeper-policy test (here, via store + wheel)
+//   9.7  Timeout NEVER folds into user_seen      — here (real_user_seen_rate SQL)
+//   9.8  Reply-chain link integrity             — here (outbound row + inbound advance)
+//   9.9  Redis lost — cold start                 — deadline-wheel.test.js (Step 2)
+//   9.10 Dual-write divergence detector          — here (recordDivergence + summary)
+
+const { newDb } = require('pg-mem');
+
+function makePool() {
+    const db = newDb();
+    const { Pool } = db.adapters.createPg();
+    return new Pool();
+}
+
+// Fresh store module + pool per test so module-level `pool` never leaks.
+function freshStore() {
+    jest.resetModules();
+    const store = require('../../../lib/message-lifecycle/store');
+    const pool = makePool();
+    return { store, pool };
+}
+
+const ISO = (s) => new Date(s);
+
+describe('lifecycle store (pg-mem)', () => {
+    let store, pool;
+
+    beforeEach(async () => {
+        ({ store, pool } = freshStore());
+        await store.initTable(pool);
+    });
+
+    async function seedInbound(messageId, opts = {}) {
+        return store.transition({
+            messageId,
+            targetState: 'inbound_seen',
+            eventAt: opts.eventAt || ISO('2026-06-16T00:00:00Z'),
+            source: opts.source || 'trackOutbound',
+            create: {
+                deviceId: opts.deviceId || 'd1',
+                entityId: opts.entityId ?? 2,
+                tenantId: opts.deviceId || 'd1',
+                direction: 'inbound',
+            },
+            rowSource: opts.rowSource,
+        });
+    }
+
+    test('§9.1 idempotent transition — second apply is idempotent_noop', async () => {
+        await seedInbound('m1');
+        const a = await store.transition({ messageId: 'm1', targetState: 'bot_acked', eventAt: ISO('2026-06-16T00:00:30Z'), source: 'markReplyReceived' });
+        const b = await store.transition({ messageId: 'm1', targetState: 'bot_acked', eventAt: ISO('2026-06-16T00:00:30Z'), source: 'markReplyReceived' });
+        expect(a.applied).toBe('accepted');
+        expect(b.applied).toBe('idempotent_noop');
+
+        const row = await store.getLifecycle('m1');
+        expect(row.state).toBe('bot_acked');
+        expect(row.bot_acked_at).toBeTruthy();
+
+        const log = await store.getEventLog('m1');
+        const acked = log.filter(e => e.attempted_state === 'bot_acked');
+        expect(acked.map(e => e.applied).sort()).toEqual(['accepted', 'idempotent_noop']);
+    });
+
+    test('§9.2 monotonic — late bot_acked after the row advanced past it is rejected_late, *_at not overwritten', async () => {
+        // Spec §9.2: the row is at push_delivered; a bot_acked event arrives
+        // late. Per §2.3 rule 3 the row reached push_delivered by SKIPPING
+        // bot_acked (push delivered before the bot_acked signal landed), so
+        // bot_acked_at is NULL and the late event must be rejected, NOT
+        // backfilled. (If bot_acked_at were already set the correct verdict is
+        // idempotent_noop — covered in §9.1.)
+        await seedInbound('m2');
+        await store.transition({ messageId: 'm2', targetState: 'push_delivered', eventAt: ISO('2026-06-16T00:01:00Z'), source: 's' });
+
+        const before = await store.getLifecycle('m2');
+        expect(before.state).toBe('push_delivered');
+        expect(before.bot_acked_at).toBeNull(); // skipped
+
+        const late = await store.transition({ messageId: 'm2', targetState: 'bot_acked', eventAt: ISO('2026-06-16T00:02:00Z'), source: 's' });
+        const after = await store.getLifecycle('m2');
+
+        expect(late.applied).toBe('rejected_late');
+        expect(after.state).toBe('push_delivered');
+        expect(after.bot_acked_at).toBeNull(); // NEVER backfilled
+
+        const log = await store.getEventLog('m2');
+        const lateRows = log.filter(e => e.attempted_state === 'bot_acked' && e.applied === 'rejected_late');
+        expect(lateRows).toHaveLength(1);
+    });
+
+    test('§9.3 out-of-order — inbound_seen → user_seen skips, intermediate *_at stay NULL, later bot_acked rejected', async () => {
+        await seedInbound('m3');
+        const jump = await store.transition({ messageId: 'm3', targetState: 'user_seen', eventAt: ISO('2026-06-16T00:00:10Z'), source: 'chat_read' });
+        expect(jump.applied).toBe('accepted');
+
+        const row = await store.getLifecycle('m3');
+        expect(row.state).toBe('user_seen');
+        expect(row.skipped_states.sort()).toEqual(['bot_acked', 'push_delivered']);
+        expect(row.bot_acked_at).toBeNull();
+        expect(row.push_delivered_at).toBeNull();
+        expect(row.user_seen_at).toBeTruthy();
+
+        const late = await store.transition({ messageId: 'm3', targetState: 'bot_acked', eventAt: ISO('2026-06-16T00:01:00Z'), source: 's' });
+        expect(late.applied).toBe('rejected_late');
+        const after = await store.getLifecycle('m3');
+        expect(after.bot_acked_at).toBeNull(); // NEVER backfilled
+    });
+
+    test('§9.4 backfill+link — bot_acked set, push/user NULL, counts in denominator not numerator', async () => {
+        const fetchInbound = async () => ({ device_id: 'd1', entity_id: 2, created_at: ISO('2026-06-16T00:00:00Z'), is_from_user: true });
+        const findReply = async () => ({ created_at: ISO('2026-06-16T00:00:20Z') });
+        const row = await store.backfillLifecycle('m4', { fetchInbound, findReply });
+
+        expect(row.state).toBe('bot_acked');
+        expect(row.bot_acked_at).toBeTruthy();
+        expect(row.push_delivered_at).toBeNull();
+        expect(row.user_seen_at).toBeNull();
+        expect(row.source).toBe('backfill+link');
+
+        // SLO: real_user_seen_rate numerator requires user_seen_at IS NOT NULL.
+        // COUNT(col) counts only non-null values — the standard-SQL spelling of
+        // the §6.2 numerator (no COALESCE permitted, constraint #2).
+        const r = await pool.query(`
+            SELECT COUNT(user_seen_at)::int AS num, COUNT(*)::int AS den
+            FROM message_lifecycle WHERE message_id = 'm4'`);
+        expect(r.rows[0].num).toBe(0); // counted as a miss
+        expect(r.rows[0].den).toBe(1);
+    });
+
+    test('§9.5 heuristic backfill — source flagged + non-null last_error', async () => {
+        const fetchInbound = async () => ({ device_id: 'd1', entity_id: 2, created_at: ISO('2026-06-16T00:00:00Z'), is_from_user: true });
+        const findReply = async () => null; // no explicit link
+        const findNearestOutbound = async () => ({ created_at: ISO('2026-06-16T00:01:30Z') }); // 90s later
+        const row = await store.backfillLifecycle('m5', { fetchInbound, findReply, findNearestOutbound });
+
+        expect(row.state).toBe('bot_acked');
+        expect(row.source).toBe('backfill+heuristic');
+        expect(row.last_error).toBeTruthy();
+        expect(row.push_delivered_at).toBeNull();
+        expect(row.user_seen_at).toBeNull();
+    });
+
+    test('§9.5b backfill of a non-inbound message returns null (never fabricates)', async () => {
+        const fetchInbound = async () => ({ device_id: 'd1', entity_id: 2, created_at: ISO('2026-06-16T00:00:00Z'), is_from_user: false });
+        const row = await store.backfillLifecycle('m5b', { fetchInbound });
+        expect(row).toBeNull();
+    });
+
+    test('§9.7 timeout NEVER folds into user_seen success — 50/30/20 split → rate = 0.5', async () => {
+        // 50 user_seen, 30 stuck at push_delivered, 20 stuck at bot_acked.
+        let n = 0;
+        for (let i = 0; i < 50; i++) {
+            const id = `seen_${i}`; n++;
+            await seedInbound(id, { eventAt: ISO('2026-06-16T00:00:00Z') });
+            await store.transition({ messageId: id, targetState: 'bot_acked', eventAt: ISO('2026-06-16T00:00:10Z'), source: 's' });
+            await store.transition({ messageId: id, targetState: 'push_delivered', eventAt: ISO('2026-06-16T00:00:20Z'), source: 's' });
+            await store.transition({ messageId: id, targetState: 'user_seen', eventAt: ISO('2026-06-16T00:00:30Z'), source: 's' });
+        }
+        for (let i = 0; i < 30; i++) {
+            const id = `pd_${i}`;
+            await seedInbound(id, { eventAt: ISO('2026-06-16T00:00:00Z') });
+            await store.transition({ messageId: id, targetState: 'bot_acked', eventAt: ISO('2026-06-16T00:00:10Z'), source: 's' });
+            await store.transition({ messageId: id, targetState: 'push_delivered', eventAt: ISO('2026-06-16T00:00:20Z'), source: 's' });
+        }
+        for (let i = 0; i < 20; i++) {
+            const id = `ba_${i}`;
+            await seedInbound(id, { eventAt: ISO('2026-06-16T00:00:00Z') });
+            await store.transition({ messageId: id, targetState: 'bot_acked', eventAt: ISO('2026-06-16T00:00:10Z'), source: 's' });
+        }
+
+        const r = await pool.query(`
+            SELECT COUNT(user_seen_at)::int AS num, COUNT(*)::int AS den
+            FROM message_lifecycle`);
+        const rate = r.rows[0].num / r.rows[0].den;
+        expect(r.rows[0].den).toBe(100);
+        expect(r.rows[0].num).toBe(50);
+        expect(rate).toBe(0.5);
+    });
+
+    test('§9.8 reply-chain — outbound row created with reply_to; inbound advances to bot_acked', async () => {
+        await seedInbound('m7_in');
+        // Outbound reply recorded as its own lifecycle row (direction=outbound).
+        await store.transition({
+            messageId: 'm7_out',
+            targetState: 'inbound_seen', // an outbound row also starts at its own creation
+            eventAt: ISO('2026-06-16T00:00:40Z'),
+            source: 'transform',
+            create: { deviceId: 'd1', entityId: 2, tenantId: 'd1', direction: 'outbound', replyToMessageId: 'm7_in' },
+        });
+        // The inbound advances to bot_acked at the outbound's creation time.
+        await store.transition({ messageId: 'm7_in', targetState: 'bot_acked', eventAt: ISO('2026-06-16T00:00:40Z'), source: 'transform' });
+
+        const inbound = await store.getLifecycle('m7_in');
+        const outbound = await store.getLifecycle('m7_out');
+        expect(inbound.state).toBe('bot_acked');
+        expect(outbound.direction).toBe('outbound');
+        expect(outbound.reply_to_message_id).toBe('m7_in');
+    });
+
+    test('§9.10 dual-write divergence — recorded + surfaced by summary gate', async () => {
+        await store.recordDivergence({
+            messageId: 'm8', deviceId: 'd1', entityId: 2,
+            legacyCounter: 'chat_no_reply', direction: 'lifecycle_skipped',
+            reason: 'legacy ticked, lifecycle missing',
+        });
+        const summary = await store.divergenceSummary({ windowHours: 168, newAlertVolume: 80, legacyAlertVolume: 100 });
+        expect(summary.divergenceEvents).toBe(1);
+        expect(summary.ratio).toBeCloseTo(0.8, 5);
+        expect(summary.withinGate).toBe(false); // 0.8 is outside ±10%
+
+        const ok = await store.divergenceSummary({ windowHours: 168, newAlertVolume: 95, legacyAlertVolume: 100 });
+        expect(ok.withinGate).toBe(true); // 0.95 within ±10%
+    });
+
+    test('rejected_unknown_message — later state with no row never fabricates inbound', async () => {
+        const v = await store.transition({ messageId: 'ghost', targetState: 'push_delivered', source: 's' });
+        expect(v.applied).toBe('rejected_unknown_message');
+        const row = await store.getLifecycle('ghost');
+        expect(row).toBeNull();
+    });
+});
+
+describe('§9.6 stuck alert + cooldown (sweeper policy over store + wheel)', () => {
+    const { createWheel, createInMemoryClient } = require('../../../lib/message-lifecycle/deadline-wheel');
+
+    let store, pool, wheel;
+
+    beforeEach(async () => {
+        ({ store, pool } = freshStore());
+        await store.initTable(pool);
+        wheel = createWheel({ redisClient: createInMemoryClient() });
+        store.setWheel(wheel);
+    });
+
+    // Reproduce the boot onDue policy (index.js) against the store + wheel so
+    // the cooldown contract in spec §9.6 is verified without a live server.
+    function makeOnDue(nowRef) {
+        return async (messageId) => {
+            const row = await store.getLifecycle(messageId);
+            if (!row || row.state === 'user_seen') return;
+            const cooldownMs = 60_000;
+            const now = nowRef.now;
+            const alertedAt = row.alerted_at ? new Date(row.alerted_at).getTime() : 0;
+            let alerted = false;
+            if (!alertedAt || (now - alertedAt) > cooldownMs) {
+                if (row.state !== 'push_delivered') {
+                    alerted = true;
+                    await pool.query(
+                        `UPDATE message_lifecycle SET alerted_at = $2 WHERE message_id = $1`,
+                        [messageId, new Date(now).toISOString()]
+                    );
+                }
+            }
+            await wheel.requeue(messageId, now + cooldownMs);
+            return alerted;
+        };
+    }
+
+    test('alert fires, suppressed within cooldown, re-fires after cooldown, resets on advance', async () => {
+        const nowRef = { now: ISO('2026-06-16T00:03:20Z').getTime() }; // 200s after inbound
+        await store.transition({
+            messageId: 'm6', targetState: 'inbound_seen', eventAt: ISO('2026-06-16T00:00:00Z'),
+            source: 'trackOutbound', create: { deviceId: 'd1', entityId: 2, tenantId: 'd1', direction: 'inbound' },
+        });
+        await store.transition({ messageId: 'm6', targetState: 'bot_acked', eventAt: ISO('2026-06-16T00:00:00Z'), source: 's' });
+
+        const onDue = makeOnDue(nowRef);
+
+        // First sweep: bot_acked stuck → alert.
+        const a1 = await onDue('m6');
+        expect(a1).toBe(true);
+        let row = await store.getLifecycle('m6');
+        expect(row.alerted_at).toBeTruthy();
+
+        // 30s later (< 60s cooldown): no re-alert.
+        nowRef.now += 30_000;
+        const a2 = await onDue('m6');
+        expect(a2).toBe(false);
+
+        // 90s after first alert (> cooldown): re-alert.
+        nowRef.now += 60_000; // total +90s
+        const a3 = await onDue('m6');
+        expect(a3).toBe(true);
+
+        // push_delivered arrives → advance, alerted_at reset, deadline cancel+rearm.
+        await store.transition({ messageId: 'm6', targetState: 'push_delivered', eventAt: new Date(nowRef.now), source: 'channel_callback' });
+        row = await store.getLifecycle('m6');
+        expect(row.state).toBe('push_delivered');
+        expect(row.alerted_at).toBeNull();
+
+        // Now stuck at push_delivered → never pages (spec §6.4).
+        nowRef.now += 1000;
+        const a4 = await onDue('m6');
+        expect(a4).toBe(false);
+    });
+});


### PR DESCRIPTION
## Scope (card_1b1c13225f10e8a803cef532 — MessageLifecycle Phase 2)

Phase 2 Step 1 (schema, PR #3385) and Step 2 (Redis deadline wheel + sweeper + cold-start, PR #3388) are already merged. **This PR ships the remaining Phase 2 work** — Steps 3–6 of the card scope — as one coherent, fully-tested increment.

Spec: `docs/specs/message-lifecycle-spec.md` §2, §3, §5, §6.5, §7, §9, §11.

### Schema option
**Option B (companion `message_lifecycle` table)** — choice carried from Step 1 (no `chat_messages` lock; backfill is INSERT into a cold-path table; outbound rows are their own row). Rationale in `backend/migrations/20260614_message_lifecycle.up.sql` header + spec §3.4.

### What this PR adds

1. **Transition engine** (`backend/lib/message-lifecycle/engine.js`) — pure, DB-free idempotent + monotonic state machine. Encodes #6 constraint #1 structurally: late/out-of-order events return `rejected_late`, skipped intermediate states are tracked, and no path rolls back or backfills a `*_at` field.
2. **DB store** (`backend/lib/message-lifecycle/store.js`) — `transition()` (FOR UPDATE row lock serializes concurrent events), `backfillLifecycle()` (lazy-on-read, §5 — **NEVER derives** `push_delivered_at`/`user_seen_at`, constraint #2), `getLifecycle()`, `getEventLog()`, `recordDivergence()`, `divergenceSummary()`. Best-effort: never throws on the hot path. Replayable `initTable()` DDL mirrors the migration (the repo creates tables via `initTable`, not a SQL runner).
3. **Dual-write** (spec §7) — every legacy counter site also calls `lifecycle.transition(...)`; legacy stays authoritative for reads:
   - `entity-status.trackOutbound` → `inbound_seen`
   - `entity-status.markReplyReceived` → `bot_acked`
   - `entity-status.sweepExpired` (chat_no_reply tick) → divergence guard
   - `delivery-receipts` success → `push_delivered`; alert → divergence guard
4. **Debug endpoint** — `GET /api/debug/message-lifecycle/:messageId` returns the row + last 20 `lifecycle_event_log` entries (acceptance B5).
5. **Divergence detector** (spec §6.5 / §9.10) — new `lifecycle_divergence_log` table + `divergenceSummary()` ±10% cutover gate for Phase 3.
6. **Boot wiring** — `initTable` + deadline wheel + sweeper. Redis is optional: with no `REDIS_URL` the wheel is a disabled no-op, transitions still persist to PG (source of truth), and stuck-alert arming is deferred to the cold-start scan on next boot.

### Constraints (hard, from #6)
- **Idempotent + monotonic** — no UPDATE/DELETE rolls back a state field; late events → `lifecycle_event_log` with `applied='rejected_late'`. Verified in engine + store tests.
- **unknown/null/timeout NEVER inflate user_seen** — SLO numerator uses `COUNT(user_seen_at)` (non-null only), no COALESCE; backfill never derives `push_delivered_at`/`user_seen_at`. Verified in §9.4/§9.5/§9.7 tests.

### §9 acceptance scenarios — 10/10 covered, all green
- 9.1 idempotent · 9.2 monotonic late-reject · 9.3 out-of-order skip · 9.4 backfill+link unknown-stays-unknown · 9.5 heuristic backfill flagged · 9.6 stuck alert + cooldown · 9.7 timeout never folds into user_seen (50/30/20 → 0.5) · 9.8 reply-chain link integrity · **9.9 Redis-lost cold start** (covered by Step 2's `deadline-wheel.test.js`) · 9.10 dual-write divergence detector.

New tests: `tests/jest/message-lifecycle/engine.test.js` + `store.test.js` (pg-mem in-memory Postgres — real SQL/CHECK/transactions). **Full suite: 323 suites / 4502 passing / 0 failing.**

### Remaining for follow-up (Phase 3, out of scope per card)
- Dashboard / alert / cron cutover to the new SLO + legacy-counter removal.
- Wiring real `message_id` through the channel-delivery path (currently `delivery-receipts` dual-writes `push_delivered` only when a `messageId` is supplied; the synthesized-id seam covers `inbound_seen`/`bot_acked`). The `user_seen` transition source (`chat:read` socket event) is also a Phase 3 wire-up.
- A2A / system-message axes get their own outbound lifecycle direction in a later phase (today only the `chat_no_reply` axis is dual-written).

🤖 Generated with [Claude Code](https://claude.com/claude-code)