### PR TITLE
fix(chat): routing pointer never renders bare 「？」 — resolve org-parent for auto-upward routes (card_ecda7243)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -9574,7 +9574,13 @@ app.post('/api/transform', transformMaybeMultipart, idempotencyMiddleware, async
         // Skip saving to owner's chat when entity is leased_out — rental mirror handles renter's copy
         const isLeasedOut = entity.rental_status === 'leased_out';
         if (!hasDelivery && !isLeasedOut) {
-            await saveChatMessage(deviceId, eId, finalMessage, chatSource, false, true, null, null, null, null, null, null, validatedCard, validatedAttachments, viaChannel);
+            // card_ecda7243: resolve a real routing_meta for this self-reply so
+            // the chat UI never renders a bare 「？」 routing pointer. The target
+            // is the org-chart parent when this reply auto-forwards upward, else
+            // the device owner (User). Falls back to null on hard error (client
+            // still renders a ?-free degraded chip).
+            const selfReplyRoutingMeta = await resolveSelfReplyRoutingMeta(entity, deviceId, eId, finalMessage);
+            await saveChatMessage(deviceId, eId, finalMessage, chatSource, false, true, null, null, null, null, null, null, validatedCard, validatedAttachments, viaChannel, selfReplyRoutingMeta);
         }
         if (!isLeasedOut) markMessagesAsRead(deviceId, eId);
         if (pendingA2A) {
@@ -19094,6 +19100,89 @@ async function orgChartForward(entity, deviceId, message, opts = {}) {
         }
     } catch (err) {
         console.error('[OrgChart] orgChartForward error:', err.message);
+    }
+}
+
+/**
+ * Resolve the routing_meta for a bot's self-reply to the user (no speakTo /
+ * broadcast). card_ecda7243: such a reply row used to be saved with
+ * routing_meta=null, so the chat UI's renderRoutingChip fell through to a
+ * degraded "#N → ?" chip — a bare 「？」 routing pointer.
+ *
+ * Mirrors the orgChartForward() decision so the pointer reflects what actually
+ * happens to the message:
+ *   - If org auto-forward (allForward OR taskForward-with-tasks) WILL forward
+ *     this reply upward to the entity's superior → target = that PARENT entity
+ *     (mode 'org_upward'). This is the card's repro: subordinate → User no
+ *     speakTo → auto-routes to org upper-level.
+ *   - Otherwise the reply is a true direct-to-user message → target = USER
+ *     (mode 'toUser', to_entity_id null but to_name a clear "User" label).
+ *
+ * Globe-user: derives the parent purely from the device's org-chart hierarchy
+ * (getSuperior), never a hardcoded entity id. Returns null only on hard error,
+ * in which case the caller saves with routing_meta=null and the client falls
+ * back to its (now ?-free) degraded chip.
+ */
+async function resolveSelfReplyRoutingMeta(entity, deviceId, eId, message) {
+    try {
+        const orgData = await orgChartModule.getOrgChart(deviceId);
+        const hierarchy = orgData && orgData.hierarchy;
+        const options = (orgData && orgData.options) || {};
+        const device = devices[deviceId];
+
+        if (hierarchy && device) {
+            const superiorId = orgChartModule.getSuperior(hierarchy, eId);
+            // A real entity superior (not USER, not orphan) AND auto-forward
+            // configured means the reply genuinely routes upward.
+            if (superiorId != null && superiorId !== 'USER') {
+                const superiorEntity = device.entities?.[superiorId];
+                if (superiorEntity && superiorEntity.isBound) {
+                    let willForward = !!options.allForward;
+                    if (!willForward && options.taskForward && chatPool) {
+                        try {
+                            const taskCheck = await chatPool.query(
+                                `SELECT 1 FROM kanban_cards WHERE device_id = $1 AND assigned_bots @> $2::jsonb AND status IN ('todo', 'in_progress') LIMIT 1`,
+                                [deviceId, JSON.stringify([eId])]
+                            );
+                            willForward = taskCheck.rows.length > 0;
+                        } catch (_) { /* fall through to toUser */ }
+                    }
+                    // Suppress low-signal fwds the same way orgChartForward does,
+                    // so the pointer doesn't claim an upward route that never fires.
+                    if (willForward && typeof isLowSignalFwd === 'function' && isLowSignalFwd(message)) {
+                        willForward = false;
+                    }
+                    if (willForward) {
+                        return buildRoutingMeta({
+                            mode: 'org_upward',
+                            fromEntity: entity, fromId: eId,
+                            toEntity: superiorEntity, toId: superiorId,
+                            status: 'sent'
+                        });
+                    }
+                }
+            }
+        }
+
+        // True direct-to-user reply: resolved target is the device owner (USER),
+        // never a bare '?'. to_entity_id stays null (USER is not an entity) but
+        // to_name carries an explicit "User" so the client renders "#N → User".
+        const meta = buildRoutingMeta({
+            mode: 'toUser',
+            fromEntity: entity, fromId: eId,
+            toEntity: null, toId: null,
+            status: 'sent'
+        });
+        meta.to_name = 'User';
+        meta.to_is_user = true;
+        // USER is the device owner, not a levelled entity — drop to_lv so the
+        // client's Number.isFinite(to_lv) gate hides the LV badge (null coerces
+        // to 0 via Number(), which would wrongly render "LV0").
+        delete meta.to_lv;
+        return meta;
+    } catch (err) {
+        console.error('[OrgChart] resolveSelfReplyRoutingMeta error:', err.message);
+        return null;
     }
 }
 

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -6103,11 +6103,20 @@
                 // card_1f8 fallback: source unparseable but row is a bot reply with a
                 // known sender — render a degraded sender-only chip so the user at
                 // least sees who said it (instead of an empty meta row).
+                // card_ecda7243: NEVER render a bare 「？」 on the target side. Backend
+                // now stamps a real routing_meta on self-replies, so this branch only
+                // fires for legacy/null-meta rows. Resolve the target the same way the
+                // positive branch does — org-chart commander (the upper-level entity)
+                // when known, else label it clearly as the User (the only other place a
+                // no-speakTo bot reply can land). No '?' in any case.
                 if (msg && msg.is_from_bot && msg.entity_id != null) {
                     const senderLabel = '#' + msg.entity_id;
-                    const title = `${tt('chat_routing_label','路由')}: ${senderLabel} → ? · ${tt('chat_routing_client_derived','client-derived')}`;
-                    const stub = { status: 'degraded', from_entity_id: msg.entity_id, to_entity_id: null };
-                    return `<span class="routing-chip rc-degraded"${chipClickAttrs('degraded-client', stub)} title="${escapeHtml(title)}"><span class="rc-route">${escapeHtml(senderLabel)} → ?</span></span>`;
+                    const targetLabel = (orgChartCommanderId != null && orgChartCommanderId !== Number(msg.entity_id))
+                        ? ('#' + orgChartCommanderId)
+                        : (tt('chat_routing_to_user', 'User'));
+                    const title = `${tt('chat_routing_label','路由')}: ${senderLabel} → ${targetLabel} · ${tt('chat_routing_client_derived','client-derived')}`;
+                    const stub = { status: 'degraded', from_entity_id: msg.entity_id, to_entity_id: (orgChartCommanderId != null && orgChartCommanderId !== Number(msg.entity_id)) ? orgChartCommanderId : null, to_is_user: !(orgChartCommanderId != null && orgChartCommanderId !== Number(msg.entity_id)) };
+                    return `<span class="routing-chip rc-degraded"${chipClickAttrs('degraded-client', stub)} title="${escapeHtml(title)}"><span class="rc-route">${escapeHtml(senderLabel)} → ${escapeHtml(targetLabel)}</span></span>`;
                 }
                 return '';
             }
@@ -6126,13 +6135,19 @@
             const seg = routingLvSegment(rm.to_lv);
             const fallback = (orgChartCommanderId != null) ? ('#' + orgChartCommanderId) : null;
             const from = rm.from_name || (rm.from_entity_id != null ? '#' + rm.from_entity_id : fallback);
-            const to = rm.to_name || (rm.to_entity_id != null ? '#' + rm.to_entity_id : fallback);
+            // card_ecda7243: a self-reply to the device owner carries to_is_user
+            // (mode 'toUser') with to_entity_id null — render the localized "User"
+            // label, never the raw to_name or a '?' fallback.
+            const to = rm.to_is_user
+                ? tt('chat_routing_to_user', 'User')
+                : (rm.to_name || (rm.to_entity_id != null ? '#' + rm.to_entity_id : fallback));
             if (!from || !to) return '';
             const lvNum = Number(rm.to_lv);
             const hasLv = Number.isFinite(lvNum);
             let modeTag = '';
             if (rm.mode === 'broadcast') modeTag = `<span class="rc-mode">${escapeHtml(tt('chat_routing_broadcast','廣播'))}</span>`;
             else if (rm.mode === 'xdevice') modeTag = `<span class="rc-mode">${escapeHtml(tt('chat_routing_xdevice','跨裝置'))}</span>`;
+            else if (rm.mode === 'org_upward') modeTag = `<span class="rc-mode">${escapeHtml(tt('chat_routing_org_upward','上報'))}</span>`;
             const lvHtml = hasLv ? `<span class="rc-lv">LV${lvNum}</span>` : '';
             const lvTitle = hasLv ? ` · LV${lvNum}` : '';
             const title = `${tt('chat_routing_label','路由')}: ${from} → ${to}${lvTitle}`;
@@ -8676,7 +8691,10 @@
             const toSum = (detail && detail.toEntity) || (payload.to_entity_id != null ? summariesById.get(payload.to_entity_id) : null);
 
             const renderPill = (which, sum, fallbackId, fallbackName) => {
-                const label = (sum && (sum.name || sum.character)) || fallbackName || (fallbackId != null ? '#' + fallbackId : '?');
+                // card_ecda7243: never fall through to a bare '?'. When neither a
+                // summary nor an explicit name/id resolve, show a clearly-labeled
+                // "unspecified" state instead of a naked question mark.
+                const label = (sum && (sum.name || sum.character)) || fallbackName || (fallbackId != null ? '#' + fallbackId : tt('chat_routing_unspecified', 'Unspecified'));
                 const code = sum && sum.publicCode ? '#' + sum.publicCode : '';
                 const lv = sum && sum.level != null ? `LV${sum.level}` : '';
                 const initials = String(label).slice(0, 2);
@@ -8690,9 +8708,11 @@
                 ? tt('chat_routing_broadcast', '廣播')
                 : payload.mode === 'xdevice'
                     ? tt('chat_routing_xdevice', '跨裝置')
-                    : payload.mode === 'speakTo' || payload.mode === 'speakto'
-                        ? tt('chat_routing_speakto', 'speakTo')
-                        : null;
+                    : payload.mode === 'org_upward'
+                        ? tt('chat_routing_org_upward', '上報')
+                        : payload.mode === 'speakTo' || payload.mode === 'speakto'
+                            ? tt('chat_routing_speakto', 'speakTo')
+                            : null;
             const statusKey = payload.status || (kind === 'unconfirmed' ? 'unconfirmed' : kind === 'failed' ? 'failed' : kind === 'degraded' ? 'degraded' : 'sent');
             const statusLabel = ({
                 sent: tt('chat_routing_status_sent', 'Sent'),
@@ -8715,7 +8735,9 @@
             html += '<div class="rd-route-line">';
             html += renderPill('from', fromSum, payload.from_entity_id, payload.from_name);
             html += '<span class="rd-arrow">→</span>';
-            html += renderPill('to', toSum, payload.to_entity_id, payload.to_name);
+            // card_ecda7243: a self-reply to the device owner targets USER (to_is_user),
+            // not an entity — show the localized "User" label instead of a bare '?'.
+            html += renderPill('to', toSum, payload.to_entity_id, payload.to_is_user ? tt('chat_routing_to_user', 'User') : payload.to_name);
             if (modeLabel) html += `<span class="rd-mode-pill">${esc(modeLabel)}</span>`;
             html += `<span class="rd-status-pill rd-status-${esc(statusKey)}">${esc(statusLabel)}</span>`;
             html += '</div>';

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650323,6 +650323,11 @@ const TRANSLATIONS = {
         "pubpage_invite_cta_title": "Want your own AI bot?",
         "pubpage_invite_cta_desc": "Create yours on EClawbot and you both earn 500 e-coins.",
         "pubpage_invite_cta_button": "Get started — claim 500 e-coins",
+
+        "chat_routing_to_user": "User",
+        "chat_routing_org_upward": "Escalated",
+
+        "chat_routing_unspecified": "Unspecified",
 },
 
 
@@ -1849260,6 +1849265,11 @@ const TRANSLATIONS = {
         "card_retest_tier_red": "紧急",
         "card_retest_tier_green": "即将解锁",
         "card_retest_tier_ready": "可重测",
+
+        "chat_routing_to_user": "用户",
+        "chat_routing_org_upward": "上报",
+
+        "chat_routing_unspecified": "未指定",
 },
 
 
@@ -2944462,6 +2944472,11 @@ const TRANSLATIONS = {
         "pubpage_invite_cta_title": "想要自己的 bot？",
         "pubpage_invite_cta_desc": "到 EClawbot 打造你的專屬 bot，雙方各得 500 e幣。",
         "pubpage_invite_cta_button": "立即開始 · 領 500 e幣",
+
+        "chat_routing_to_user": "用戶",
+        "chat_routing_org_upward": "上報",
+
+        "chat_routing_unspecified": "未指定",
 },
 
 

--- a/backend/tests/jest/chat-routing-chip-commander-fallback.test.js
+++ b/backend/tests/jest/chat-routing-chip-commander-fallback.test.js
@@ -30,9 +30,9 @@ const chatHtml = fs.readFileSync(
 const chipFn = chatHtml.match(/function\s+renderRoutingChip\s*\(\s*msg\s*\)\s*\{[\s\S]*?\n        \}/);
 const chipBody = chipFn ? chipFn[0] : '';
 
-// Out-of-scope by card spec: the `card_1f8 fallback` branch (degraded chip
-// for bot replies with unparseable source) intentionally retains "→ ?".
-// Scope the positive-branch invariants below to the post-"// Positive:" tail.
+// The positive-branch invariants below are scoped to the post-"// Positive:"
+// tail. (card_ecda7243 later extended the no-bare-'?' rule to the degraded
+// fallback branch too — that is locked in routing-meta-card-1f8.test.js.)
 const positiveBranch = chipBody.split('// Positive:').pop() || '';
 
 describe('routing chip — commander fallback (card_29eed229d389e53bfae7d954)', () => {

--- a/backend/tests/jest/routing-meta-card-1f8.test.js
+++ b/backend/tests/jest/routing-meta-card-1f8.test.js
@@ -117,6 +117,23 @@ describe('card_1f8 — frontend: sender-fallback chip when source unparseable', 
         expect(body).toMatch(/rc-unconfirmed/);
     });
 
+    // card_ecda7243: the degraded branch no longer emits a bare 「？」 target.
+    // It resolves the org-chart commander (upper-level entity) when known,
+    // else labels the target as the User — never '?'.
+    test('degraded branch resolves a real target — never a bare "→ ?"', () => {
+        // Scope to the null/unparseable-meta fallback block (before "// Positive:").
+        const head = (fn ? fn[0] : '').split('// Positive:')[0] || '';
+        // No literal "→ ?" anywhere in the fallback block.
+        expect(head).not.toMatch(/→\s*\?/);
+        expect(head).not.toMatch(/to_entity_id\s*:\s*null\s*\}.*→ \?/);
+        // The degraded chip consults the cached org-chart commander as the
+        // upper-level fallback target.
+        const degradedBlock = head.split('msg.is_from_bot && msg.entity_id != null').pop() || '';
+        expect(degradedBlock).toMatch(/orgChartCommanderId/);
+        // and falls back to a localized User label, not '?'.
+        expect(degradedBlock).toMatch(/chat_routing_to_user/);
+    });
+
     test('i18n key chat_routing_client_derived defined in en + zh + zh-TW', () => {
         // sanity: same loose match the i18n-check script uses for parity
         expect(i18nJs.match(/"chat_routing_client_derived"\s*:\s*"[^"]+"/g) || []).toHaveLength(3);

--- a/backend/tests/jest/routing-self-reply-card-ecda7243.test.js
+++ b/backend/tests/jest/routing-self-reply-card-ecda7243.test.js
@@ -1,0 +1,198 @@
+/**
+ * card_ecda7243bf03720a4bbecb2d — routing pointer must NEVER render a bare 「？」.
+ *
+ * Repro (Hank, real user): an entity UNDER the org hierarchy replies to the
+ * User WITHOUT speakTo. The reply row used to be saved with routing_meta=null,
+ * so chat.html#renderRoutingChip fell through to a degraded "#N → ?" chip.
+ *
+ * Two-layer fix locked here:
+ *   1. backend resolveSelfReplyRoutingMeta(): for a no-speakTo self-reply,
+ *      resolve a real routing_meta target —
+ *        • org auto-forward configured + bound superior → mode 'org_upward',
+ *          to = that PARENT entity (the org upper-level).
+ *        • otherwise → mode 'toUser', to_is_user true, to_name 'User'.
+ *      Never produces a '?' target.
+ *   2. backend self-save threads that routing_meta into saveChatMessage.
+ *   3. frontend degraded fallback + positive branch never emit "→ ?".
+ *
+ * We functionally eval the two cooperating module-scope helpers (buildRoutingMeta
+ * + resolveSelfReplyRoutingMeta) with injected deps, plus a static-surface lock
+ * on the self-save wiring + the new i18n keys (same node testEnvironment as the
+ * sibling routing tests).
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const indexJs = fs.readFileSync(path.join(__dirname, '..', '..', 'index.js'), 'utf8');
+const chatHtml = fs.readFileSync(path.join(__dirname, '..', '..', 'public', 'portal', 'chat.html'), 'utf8');
+const i18nJs = fs.readFileSync(path.join(__dirname, '..', '..', 'public', 'shared', 'i18n.js'), 'utf8');
+
+// ── Build a runnable resolveSelfReplyRoutingMeta over injected module deps ──
+function makeResolver({ hierarchy, options, entities, hasOpenTask = false, lowSignal = false }) {
+    const buildRoutingMetaSrc = indexJs.match(/function buildRoutingMeta\([\s\S]*?\n\}/)[0];
+    const resolverSrc = indexJs.match(/async function resolveSelfReplyRoutingMeta\([\s\S]*?\n\}/)[0];
+
+    const orgChartModule = {
+        getOrgChart: async () => ({ hierarchy, options }),
+        getSuperior: (h, id) => {
+            const eid = Number(id);
+            for (const [parentKey, kids] of Object.entries(h || {})) {
+                if (Array.isArray(kids) && kids.includes(eid)) {
+                    return parentKey === 'USER' ? 'USER' : Number(parentKey);
+                }
+            }
+            return null;
+        },
+    };
+    const devices = { dev1: { entities } };
+    const chatPool = { query: async () => ({ rows: hasOpenTask ? [{ '?column?': 1 }] : [] }) };
+    const isLowSignalFwd = () => lowSignal;
+    const console2 = { error: () => {}, log: () => {} };
+
+    // eslint-disable-next-line no-eval
+    return eval(`(function (orgChartModule, devices, chatPool, isLowSignalFwd, console) {
+        ${buildRoutingMetaSrc}
+        ${resolverSrc}
+        return resolveSelfReplyRoutingMeta;
+    })`)(orgChartModule, devices, chatPool, isLowSignalFwd, console2);
+}
+
+describe('resolveSelfReplyRoutingMeta — org-parent vs user, never "?"', () => {
+    const parent = { name: 'Boss', level: 5, isBound: true };
+    const child = { name: 'Worker', level: 2, isBound: true };
+
+    test('subordinate → User, allForward ON → mode org_upward, to = PARENT (not "?")', async () => {
+        const resolve = makeResolver({
+            hierarchy: { USER: [9], 9: [3] },
+            options: { allForward: true },
+            entities: { 3: child, 9: parent },
+        });
+        const meta = await resolve(child, 'dev1', 3, 'real status update');
+        expect(meta.mode).toBe('org_upward');
+        expect(meta.to_entity_id).toBe(9);
+        expect(meta.to_name).toBe('Boss');
+        expect(meta.from_entity_id).toBe(3);
+        expect(meta.to_name).not.toBe('?');
+    });
+
+    test('subordinate → User, taskForward ON + open task → org_upward to PARENT', async () => {
+        const resolve = makeResolver({
+            hierarchy: { USER: [9], 9: [3] },
+            options: { taskForward: true },
+            entities: { 3: child, 9: parent },
+            hasOpenTask: true,
+        });
+        const meta = await resolve(child, 'dev1', 3, 'progress');
+        expect(meta.mode).toBe('org_upward');
+        expect(meta.to_entity_id).toBe(9);
+    });
+
+    test('taskForward ON but NO open task → falls back to toUser (not parent, not "?")', async () => {
+        const resolve = makeResolver({
+            hierarchy: { USER: [9], 9: [3] },
+            options: { taskForward: true },
+            entities: { 3: child, 9: parent },
+            hasOpenTask: false,
+        });
+        const meta = await resolve(child, 'dev1', 3, 'chit chat');
+        expect(meta.mode).toBe('toUser');
+        expect(meta.to_is_user).toBe(true);
+        expect(meta.to_name).toBe('User');
+    });
+
+    test('no org forwarding configured → mode toUser, to_name "User" (never "?")', async () => {
+        const resolve = makeResolver({
+            hierarchy: { USER: [3] },
+            options: {},
+            entities: { 3: child },
+        });
+        const meta = await resolve(child, 'dev1', 3, 'hi');
+        expect(meta.mode).toBe('toUser');
+        expect(meta.to_is_user).toBe(true);
+        expect(meta.to_name).toBe('User');
+        expect(meta.to_entity_id).toBeNull();
+    });
+
+    test('entity directly under USER → toUser even with allForward (superior IS user)', async () => {
+        const resolve = makeResolver({
+            hierarchy: { USER: [3] },
+            options: { allForward: true },
+            entities: { 3: child },
+        });
+        const meta = await resolve(child, 'dev1', 3, 'hi');
+        expect(meta.mode).toBe('toUser');
+    });
+
+    test('superior unbound → toUser (no upward route possible), never "?"', async () => {
+        const resolve = makeResolver({
+            hierarchy: { USER: [9], 9: [3] },
+            options: { allForward: true },
+            entities: { 3: child, 9: { name: 'Boss', isBound: false } },
+        });
+        const meta = await resolve(child, 'dev1', 3, 'hi');
+        expect(meta.mode).toBe('toUser');
+    });
+
+    test('low-signal fwd suppressed → toUser (pointer must not claim a route that never fires)', async () => {
+        const resolve = makeResolver({
+            hierarchy: { USER: [9], 9: [3] },
+            options: { allForward: true },
+            entities: { 3: child, 9: parent },
+            lowSignal: true,
+        });
+        const meta = await resolve(child, 'dev1', 3, 'ok');
+        expect(meta.mode).toBe('toUser');
+    });
+});
+
+describe('backend self-save wiring (static surface)', () => {
+    test('self-reply save resolves + threads routing_meta', () => {
+        expect(indexJs).toMatch(/const selfReplyRoutingMeta = await resolveSelfReplyRoutingMeta\(entity, deviceId, eId, finalMessage\)/);
+        expect(indexJs).toMatch(/saveChatMessage\(deviceId, eId, finalMessage, chatSource, false, true,[^;]*selfReplyRoutingMeta\)/);
+    });
+
+    test('resolver helper is defined with org_upward + toUser modes', () => {
+        const src = indexJs.match(/async function resolveSelfReplyRoutingMeta\([\s\S]*?\n\}/)[0];
+        expect(src).toMatch(/mode: 'org_upward'/);
+        expect(src).toMatch(/mode: 'toUser'/);
+        expect(src).toMatch(/to_is_user = true/);
+        expect(src).not.toMatch(/to_name:\s*'\?'/);
+    });
+});
+
+describe('frontend chip never renders bare "?" (static surface)', () => {
+    const chipFn = chatHtml.match(/function\s+renderRoutingChip\s*\(\s*msg\s*\)\s*\{[\s\S]*?\n        \}/);
+    const chipBody = chipFn ? chipFn[0] : '';
+
+    test('renderRoutingChip parsed', () => {
+        expect(chipFn).not.toBeNull();
+    });
+
+    test('no literal "→ ?" anywhere in the chip', () => {
+        expect(chipBody).not.toMatch(/→\s*\?/);
+    });
+
+    test('degraded fallback uses org commander or localized User label', () => {
+        const head = chipBody.split('// Positive:')[0];
+        const degraded = head.split('msg.is_from_bot && msg.entity_id != null').pop() || '';
+        expect(degraded).toMatch(/orgChartCommanderId/);
+        expect(degraded).toMatch(/chat_routing_to_user/);
+    });
+
+    test('positive branch localizes to_is_user as "User", not raw to_name', () => {
+        const positive = chipBody.split('// Positive:').pop() || '';
+        expect(positive).toMatch(/rm\.to_is_user/);
+        expect(positive).toMatch(/chat_routing_to_user/);
+    });
+});
+
+describe('i18n keys present (en + zh-CN + zh-TW parity)', () => {
+    test('chat_routing_to_user defined in 3 locales', () => {
+        expect((i18nJs.match(/"chat_routing_to_user"\s*:\s*"[^"]+"/g) || [])).toHaveLength(3);
+    });
+    test('chat_routing_org_upward defined in 3 locales', () => {
+        expect((i18nJs.match(/"chat_routing_org_upward"\s*:\s*"[^"]+"/g) || [])).toHaveLength(3);
+    });
+});


### PR DESCRIPTION
## Bug (Hank, real user, 2026-06-17 — card_ecda7243bf03720a4bbecb2d)
In the chat UI, a message's 路由指向 (routing pointer) sometimes rendered a bare 「？」. Repro: an entity UNDER the org hierarchy replies to the User WITHOUT speakTo; the reply auto-routes upward to the org parent — yet the pointer showed 「？」 instead of the upper-level entity.

## Root cause
`backend/index.js` ~L9576: a bot self-reply with no speakTo/broadcast (`hasDelivery=false`) called `saveChatMessage(...)` WITHOUT a `routingMeta` arg → the row's `routing_meta` was `null`.
`backend/public/portal/chat.html` `renderRoutingChip()` ~L6110: with `routing_meta=null` and an unparseable source, the degraded-client fallback branch hardcoded the literal **`#N → ?`** — the reported bare 「？」.
(The existing card_29eed229 commander-fallback fix only covered the *positive* branch; the degraded branch was explicitly left emitting `→ ?`.)

## Fix
**Backend** — new `resolveSelfReplyRoutingMeta()` mirrors `orgChartForward()`'s decision and stamps a real `routing_meta` on the no-speakTo self-reply:
- org auto-forward configured (allForward, or taskForward with an open task) + bound superior → `mode:'org_upward'`, `to` = the entity's org-chart **PARENT** (the upper-level entity). Low-signal fwds suppressed (matches orgChartForward) so the pointer never claims a route that won't fire.
- otherwise → `mode:'toUser'`, `to_is_user:true`, localized "User" label, `to_lv` dropped (no LV badge for the device owner).
- Globe-user: parent derived purely from `getSuperior()` over the device org-chart — no hardcoded entity/device ids.

**Frontend** (`chat.html`) — defense-in-depth so a bare 「？」 can never appear:
- degraded-client fallback now resolves `orgChartCommanderId` (upper-level) or a localized User label instead of `→ ?`.
- positive branch localizes `to_is_user` as "User" and adds the `org_upward` mode tag.
- routing-detail modal `renderPill` no longer falls through to a naked `'?'` (uses `chat_routing_unspecified`).

**i18n** EN + ZH-CN + ZH-TW (via `backend/scripts/i18n-insert-locale-keys.js`): `chat_routing_to_user`, `chat_routing_org_upward`, `chat_routing_unspecified`.

## Tests
- New `routing-self-reply-card-ecda7243.test.js`: functionally evals `resolveSelfReplyRoutingMeta` (7 deterministic cases — org_upward→parent / taskForward / no-forward→toUser / under-USER / unbound-superior / low-signal) + static locks for self-save wiring + frontend no-`?` + i18n parity.
- Updated `routing-meta-card-1f8.test.js` + `chat-routing-chip-commander-fallback.test.js` to lock the degraded branch's no-bare-`?` behavior.
- **412 chat/routing/i18n jest pass.**

## Evidence (before/after, console clean)
Same subordinate→User no-speakTo message rendered by OLD vs NEW renderRoutingChip:
- BEFORE: `#7 → ?` (the bug)
- AFTER A (org_upward): `上報 ｜ Worker → Boss LV5` (the upper-level parent)
- AFTER B (toUser): `Worker → 用戶`
- AFTER C (legacy null-meta): `#7 → #3` (commander fallback)

Screenshots desktop 1280x800 + mobile 390x844 in the channel repo; browser console clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)