### PR TITLE
fix(chat): routing-detail sender resolves from from_entity_id on null routing_meta — kill Unspecified→Unspecified/undefined (card_e53b0908)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -6094,10 +6094,20 @@
                 const json = escapeHtml(JSON.stringify(payload || {}));
                 return ` data-routing-kind="${kind}" data-routing-meta="${json}" role="button" tabindex="0" data-i18n-aria-label="chat_routing_chip_aria" aria-label="${escapeHtml(tt('chat_routing_chip_aria','Click to see routing rule + org structure'))}" onclick="openRoutingChipDetail(this);event.stopPropagation();" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();openRoutingChipDetail(this);}" style="cursor:pointer"`;
             };
+            // card_e53b09082f4d66b8125cccca: the SENDER of a chat row is ALWAYS
+            // knowable from the row's own entity_id — even when routing_meta is
+            // null/degraded. Resolve a sender floor (id + real display name) once
+            // here so EVERY stub/payload below carries it; the detail modal must
+            // never degrade the from-side to 「Unspecified」/undefined.
+            const senderFloorId = (msg && msg.entity_id != null && Number.isFinite(Number(msg.entity_id)))
+                ? Number(msg.entity_id) : null;
+            const senderFloorName = senderFloorId != null
+                ? (typeof getEntityDisplayName === 'function' ? getEntityDisplayName(senderFloorId) : null)
+                : null;
             if (!rm || typeof rm !== 'object') {
                 const routed = parseEntitySource(msg && msg.source);
                 if (routed && (msg.is_from_bot || routed.crossDevice)) {
-                    const stub = { status: 'unconfirmed', mode: routed.crossDevice ? 'xdevice' : 'speakTo', from_entity_id: routed.fromEntityId || null, to_entity_id: (routed.targets && routed.targets[0]) || null };
+                    const stub = { status: 'unconfirmed', mode: routed.crossDevice ? 'xdevice' : 'speakTo', from_entity_id: (routed.fromEntityId != null ? routed.fromEntityId : senderFloorId), from_name: senderFloorName, from_public_code: routed.crossDevice ? (routed.fromPublicCode || null) : null, to_entity_id: (routed.targets && routed.targets[0]) || null };
                     return `<span class="routing-chip rc-unconfirmed"${chipClickAttrs('unconfirmed', stub)} title="${escapeHtml(tt('chat_routing_unconfirmed','路由未確認'))}">⚑ ${escapeHtml(tt('chat_routing_unconfirmed','路由未確認'))}</span>`;
                 }
                 // card_1f8 fallback: source unparseable but row is a bot reply with a
@@ -6115,7 +6125,7 @@
                         ? ('#' + orgChartCommanderId)
                         : (tt('chat_routing_to_user', 'User'));
                     const title = `${tt('chat_routing_label','路由')}: ${senderLabel} → ${targetLabel} · ${tt('chat_routing_client_derived','client-derived')}`;
-                    const stub = { status: 'degraded', from_entity_id: msg.entity_id, to_entity_id: (orgChartCommanderId != null && orgChartCommanderId !== Number(msg.entity_id)) ? orgChartCommanderId : null, to_is_user: !(orgChartCommanderId != null && orgChartCommanderId !== Number(msg.entity_id)) };
+                    const stub = { status: 'degraded', from_entity_id: msg.entity_id, from_name: senderFloorName, to_entity_id: (orgChartCommanderId != null && orgChartCommanderId !== Number(msg.entity_id)) ? orgChartCommanderId : null, to_is_user: !(orgChartCommanderId != null && orgChartCommanderId !== Number(msg.entity_id)) };
                     return `<span class="routing-chip rc-degraded"${chipClickAttrs('degraded-client', stub)} title="${escapeHtml(title)}"><span class="rc-route">${escapeHtml(senderLabel)} → ${escapeHtml(targetLabel)}</span></span>`;
                 }
                 return '';
@@ -6125,7 +6135,14 @@
                 const isFail = rm.status === 'failed';
                 const cls = isFail ? 'rc-failed' : 'rc-degraded';
                 const lbl = isFail ? tt('chat_routing_failed','路由失敗') : tt('chat_routing_degraded','路由降級');
-                return `<span class="routing-chip ${cls}"${chipClickAttrs(isFail ? 'failed' : 'degraded', rm)} title="${escapeHtml(lbl)}">⚠ ${escapeHtml(lbl)}</span>`;
+                // card_e53b0908: a backend degraded/failed meta may omit the sender;
+                // floor it from the row's own entity_id so the detail modal resolves
+                // a real sender instead of 「Unspecified」.
+                const degradedPayload = Object.assign({}, rm, {
+                    from_entity_id: (rm.from_entity_id != null ? rm.from_entity_id : senderFloorId),
+                    from_name: (rm.from_name != null ? rm.from_name : senderFloorName),
+                });
+                return `<span class="routing-chip ${cls}"${chipClickAttrs(isFail ? 'failed' : 'degraded', degradedPayload)} title="${escapeHtml(lbl)}">⚠ ${escapeHtml(lbl)}</span>`;
             }
             // Positive: from → to · LV{to_lv}, optional mode prefix.
             // Globe-user rule (card_29eed229d389e53bfae7d954): never render
@@ -8690,12 +8707,30 @@
             const fromSum = (detail && detail.fromEntity) || (payload.from_entity_id != null ? summariesById.get(payload.from_entity_id) : null);
             const toSum = (detail && detail.toEntity) || (payload.to_entity_id != null ? summariesById.get(payload.to_entity_id) : null);
 
-            const renderPill = (which, sum, fallbackId, fallbackName) => {
+            // card_e53b0908: a chat row ALWAYS knows its sender (entity_id), so
+            // the from-pill must never degrade to 「Unspecified」/undefined. Build
+            // the from-side fallback chain from the payload's sender floor
+            // (id / name / publicCode), only landing on a neutral label as the
+            // last resort — and a sender-specific one ("Sender") so we never
+            // emit the same generic "Unspecified" on BOTH sides.
+            const renderPill = (which, sum, fallbackId, fallbackName, fallbackCode) => {
                 // card_ecda7243: never fall through to a bare '?'. When neither a
                 // summary nor an explicit name/id resolve, show a clearly-labeled
-                // "unspecified" state instead of a naked question mark.
-                const label = (sum && (sum.name || sum.character)) || fallbackName || (fallbackId != null ? '#' + fallbackId : tt('chat_routing_unspecified', 'Unspecified'));
-                const code = sum && sum.publicCode ? '#' + sum.publicCode : '';
+                // state instead of a naked question mark or a literal "undefined".
+                // Guard: a `undefined`/null fallbackName must NOT be stringified
+                // into the template — coalesce through the whole chain first.
+                const safeFallbackName = (fallbackName != null && String(fallbackName).trim() !== '' && String(fallbackName) !== 'undefined')
+                    ? fallbackName : null;
+                const neutral = which === 'from'
+                    ? tt('chat_routing_sender', 'Sender')
+                    : tt('chat_routing_unspecified', 'Unspecified');
+                const label = (sum && (sum.name || sum.character))
+                    || safeFallbackName
+                    || (fallbackId != null ? '#' + fallbackId : null)
+                    || (fallbackCode ? '#' + fallbackCode : null)
+                    || neutral;
+                const code = sum && sum.publicCode ? '#' + sum.publicCode
+                    : (!sum && fallbackCode ? '#' + fallbackCode : '');
                 const lv = sum && sum.level != null ? `LV${sum.level}` : '';
                 const initials = String(label).slice(0, 2);
                 const avatar = sum && sum.avatar
@@ -8733,11 +8768,11 @@
             let html = '<div class="rd-section">';
             html += `<div class="rd-section-title">${esc(tt('chat_routing_detail_section_route', 'This message route'))}</div>`;
             html += '<div class="rd-route-line">';
-            html += renderPill('from', fromSum, payload.from_entity_id, payload.from_name);
+            html += renderPill('from', fromSum, payload.from_entity_id, payload.from_name, payload.from_public_code);
             html += '<span class="rd-arrow">→</span>';
             // card_ecda7243: a self-reply to the device owner targets USER (to_is_user),
             // not an entity — show the localized "User" label instead of a bare '?'.
-            html += renderPill('to', toSum, payload.to_entity_id, payload.to_is_user ? tt('chat_routing_to_user', 'User') : payload.to_name);
+            html += renderPill('to', toSum, payload.to_entity_id, payload.to_is_user ? tt('chat_routing_to_user', 'User') : payload.to_name, payload.to_public_code);
             if (modeLabel) html += `<span class="rd-mode-pill">${esc(modeLabel)}</span>`;
             html += `<span class="rd-status-pill rd-status-${esc(statusKey)}">${esc(statusLabel)}</span>`;
             html += '</div>';

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650328,6 +650328,8 @@ const TRANSLATIONS = {
         "chat_routing_org_upward": "Escalated",
 
         "chat_routing_unspecified": "Unspecified",
+
+        "chat_routing_sender": "Sender",
 },
 
 
@@ -1235117,6 +1235119,8 @@ const TRANSLATIONS = {
         "pubpage_invite_cta_title": "想要自己的 bot？",
         "pubpage_invite_cta_desc": "到 EClawbot 打造你的專屬 bot，雙方各得 500 e幣。",
         "pubpage_invite_cta_button": "立即開始 · 領 500 e幣",
+
+        "chat_routing_sender": "發送者",
 },
 
 
@@ -1849270,6 +1849274,8 @@ const TRANSLATIONS = {
         "chat_routing_org_upward": "上报",
 
         "chat_routing_unspecified": "未指定",
+
+        "chat_routing_sender": "发送者",
 },
 
 

--- a/backend/tests/jest/routing-chip-detail.test.js
+++ b/backend/tests/jest/routing-chip-detail.test.js
@@ -108,7 +108,11 @@ describe('routing chip click affordance (chat.html)', () => {
         // positive. The helper interpolates onclick=openRoutingChipDetail.
         const fnStart = chatSrc.indexOf('function renderRoutingChip(msg)');
         expect(fnStart).toBeGreaterThan(-1);
-        const body = chatSrc.slice(fnStart, fnStart + 7000);
+        // card_e53b0908: window must cover the full function (it grew with the
+        // sender-floor resolution) so the 4th (positive-branch) call site is
+        // still in range. Slice to the next top-level function declaration.
+        const fnEnd = chatSrc.indexOf('function isIncomingCrossDevice', fnStart);
+        const body = chatSrc.slice(fnStart, fnEnd > fnStart ? fnEnd : fnStart + 9000);
         // The declaration line uses `chipClickAttrs = (` (with a space before
         // the paren), so `chipClickAttrs\(` only matches the 4 call sites.
         const callSites = (body.match(/chipClickAttrs\(/g) || []).length;
@@ -224,6 +228,74 @@ describe('routing-detail modal i18n', () => {
         const occurrences = (i18nSrc.match(new RegExp(`"${key}"\\s*:`, 'g')) || []).length;
         // At least EN + ZH (zh-TW + zh-CN both count, so threshold = 3 covers
         // PR pre-flight gate "EN+ZH same PR").
+        expect(occurrences).toBeGreaterThanOrEqual(3);
+    });
+});
+
+// ── 5. Sender always resolves on null/degraded routing_meta ───────────────
+// card_e53b09082f4d66b8125cccca — legacy null routing_meta rows rendered the
+// routing-detail modal as 「Unspecified → Unspecified」/undefined on BOTH sides.
+// The SENDER is always knowable from the chat row's own entity_id, so every
+// chip stub must carry a sender floor (from_entity_id + resolved from_name) and
+// the modal's from-pill must never degrade to the generic "Unspecified" label
+// nor stringify a JS `undefined`.
+describe('sender-floor resolution (chat.html) — never Unspecified/undefined on from-side', () => {
+    const chipFn = (() => {
+        const i = chatSrc.indexOf('function renderRoutingChip(msg)');
+        const j = chatSrc.indexOf('function isIncomingCrossDevice', i);
+        return chatSrc.slice(i, j > i ? j : i + 9000);
+    })();
+    const detailFn = (() => {
+        const i = chatSrc.indexOf('function renderRoutingChipDetailBody(bodyEl, payload');
+        return chatSrc.slice(i, i + 9000);
+    })();
+
+    test('renderRoutingChip computes a sender floor from msg.entity_id', () => {
+        expect(chipFn).toMatch(/senderFloorId\s*=/);
+        expect(chipFn).toMatch(/msg\.entity_id/);
+        expect(chipFn).toMatch(/getEntityDisplayName/);
+    });
+
+    test('unconfirmed stub carries from_entity_id floor + from_name (cross-device too)', () => {
+        // The unconfirmed branch must fall back to the row sender when the parsed
+        // source has no fromEntityId (e.g. cross-device publicCode-only), and
+        // carry from_name + from_public_code so the modal can label it.
+        expect(chipFn).toMatch(/from_entity_id:\s*\(routed\.fromEntityId\s*!=\s*null\s*\?\s*routed\.fromEntityId\s*:\s*senderFloorId\)/);
+        expect(chipFn).toMatch(/from_name:\s*senderFloorName/);
+        expect(chipFn).toMatch(/from_public_code/);
+    });
+
+    test('degraded-client stub carries from_name', () => {
+        const degraded = chipFn.split('msg.is_from_bot && msg.entity_id != null').pop() || '';
+        expect(degraded).toMatch(/from_name:\s*senderFloorName/);
+    });
+
+    test('backend degraded/failed meta is floored with the row sender', () => {
+        expect(chipFn).toMatch(/degradedPayload\s*=\s*Object\.assign\(\{\},\s*rm,/);
+        expect(chipFn).toMatch(/from_entity_id:\s*\(rm\.from_entity_id\s*!=\s*null\s*\?\s*rm\.from_entity_id\s*:\s*senderFloorId\)/);
+    });
+
+    test('renderPill guards against a literal "undefined" fallbackName', () => {
+        expect(detailFn).toMatch(/String\(fallbackName\)\s*!==\s*'undefined'/);
+        expect(detailFn).toMatch(/safeFallbackName/);
+    });
+
+    test('from-pill uses a sender-specific neutral label, not the shared Unspecified', () => {
+        // The from-side must land on chat_routing_sender, never chat_routing_unspecified.
+        expect(detailFn).toMatch(/which\s*===\s*'from'/);
+        expect(detailFn).toMatch(/chat_routing_sender/);
+    });
+
+    test('renderPill accepts a publicCode fallback and both call sites pass it', () => {
+        expect(detailFn).toMatch(/renderPill\s*=\s*\(which,\s*sum,\s*fallbackId,\s*fallbackName,\s*fallbackCode\)/);
+        expect(detailFn).toMatch(/renderPill\('from',\s*fromSum,\s*payload\.from_entity_id,\s*payload\.from_name,\s*payload\.from_public_code\)/);
+        expect(detailFn).toMatch(/renderPill\('to',\s*toSum,[\s\S]*?payload\.to_public_code\)/);
+    });
+
+    test('chat_routing_sender key ships in EN + ZH (>=3 locales)', () => {
+        const i18nPath = path.join(backendDir, 'public', 'shared', 'i18n.js');
+        const i18nSrc = fs.readFileSync(i18nPath, 'utf8');
+        const occurrences = (i18nSrc.match(/"chat_routing_sender"\s*:/g) || []).length;
         expect(occurrences).toBeGreaterThanOrEqual(3);
     });
 });


### PR DESCRIPTION
## Bug (Hank, real user, 2026-06-17 + screenshot)
The 路由詳情 (routing-detail) modal, for an OLD message whose DB `routing_meta` is null, rendered the chip as 「Un Unspecified → Un Unspecified」 with rule source 「未知（無 routing_meta）」. Both sides degraded to "Unspecified", and a JS `undefined` could be stringified into the label. The org tree showed the message's real sender entity (#10) — the SENDER side must always resolve to the real entity, never "Unspecified"/undefined. #3455 fixed the bare "?" but left this degraded-branch sender gap.

## Root cause
`backend/public/portal/chat.html`
- `renderRoutingChip`: the `unconfirmed` stub set `from_entity_id: routed.fromEntityId || null` (null for cross-device / unparseable sources), and the backend degraded/failed branch passed raw `rm` through. When the meta carried no sender, the modal's `renderPill` fell to the shared `chat_routing_unspecified` label on BOTH sides.
- `renderRoutingChipDetailBody.renderPill`: a null/`undefined` `fallbackName` could be stringified, and the from-side reused the same generic "Unspecified" fallback.

## Fix
1. **Sender floor** — a chat row always knows its sender via `msg.entity_id`. Compute a sender floor (id + `getEntityDisplayName`) once in `renderRoutingChip` and carry it into EVERY stub/payload (`unconfirmed`, `degraded-client`, backend `degraded`/`failed`). Cross-device also carries `from_public_code`.
2. **renderPill** — `which`-aware fallback chain (summary name → safe fallbackName → id → publicCode → neutral). The from-side neutral is a sender-specific `chat_routing_sender` label, never the shared "Unspecified". A literal `"undefined"`/blank `fallbackName` is guarded out before stringification.
3. **Target** keeps #3455's org-parent / User resolution; genuinely unresolvable → clear neutral label (never `undefined`, never double-Unspecified).
4. **i18n** — new `chat_routing_sender` in en (`Sender`) + zh (`發送者`, Traditional canonical) + zh-CN (`发送者`) via `i18n-insert-locale-keys.js`; zh-TW falls back to zh (kept thin per the fallback-chain gate).

## Before / After
Synthetic null-meta + `from_entity_id:10` fixture rendered through the ACTUAL fixed `renderRoutingChipDetailBody`:
- BEFORE: `Unspecified → Unspecified`, rule source `Unknown (no routing_meta)`
- AFTER: `Lobster → Unspecified` (sender resolved from #10; no literal "undefined")

Desktop 1280x800 + mobile 390x844 screenshots attached in commander report. Console clean.

## Tests
`routing-chip-detail.test.js` gains a sender-floor `describe` block (8 cases) locking: sender floor computed from `msg.entity_id`; every stub carries `from_entity_id` + `from_name`; backend degraded meta floored; renderPill guards literal `"undefined"`; from-side uses `chat_routing_sender` not the shared Unspecified; publicCode fallback wired at both call sites; key parity ≥3 locales. The chip-click-affordance window was widened to the full (now-longer) function.

9 suites / 138 tests pass: i18n-syntax, i18n-lint-dup-keys, i18n-fallback-chain, routing-chip-detail, chat-routing-chip, routing-self-reply-card-ecda7243, chat-routing-chip-commander-fallback, routing-meta-card-1f8, routing-meta-payload.

card_e53b09082f4d66b8125cccca (follow-up to #3455 / #3456)

🤖 Generated with [Claude Code](https://claude.com/claude-code)