### PR TITLE
fix(split): 在看板中開啟 targets existing kanban pane in split mode (no dup task pane / no chat redirect)

### DIFF
--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -3532,6 +3532,10 @@
     </div>
 
     <script src="shared/api.js"></script>
+    <!-- SmartRouter: split-mode "在看板中開啟" must route into the existing kanban
+         pane, not window.open a 2nd pane / redirect chat (card_2d5fbe88). -->
+    <script src="/shared-core/route-registry.js"></script>
+    <script src="shared/smart-router.js"></script>
     <script src="shared/nav.js"></script>
     <script src="shared/auth.js"></script>
     <!-- Phase 2 #5 offline delivery queue: load before sendMessage runs. -->
@@ -9054,8 +9058,30 @@
 
         function openKanbanCard(cardId, event) {
             if (event && typeof event.preventDefault === 'function') event.preventDefault();
-            if (eclawNavigateMissionCard(cardId)) return;
-            const url = getKanbanCardUrl(cardId);
+            const id = String(cardId || '').trim();
+            if (!id) return;
+
+            // SmartRouter (route-registry + smart-router.js) resolves the right
+            // target per nav mode (card_2d5fbe88):
+            //   • split → posts split_navigate to the workspace host, which loads
+            //     the card into the EXISTING kanban pane (no 2nd pane, chat pane
+            //     untouched). Degrades to single full-page only if the host never acks.
+            //   • app   → native tab bridge (targetTab:'mission').
+            //   • single→ full-page navigate to kanban.html?card=…#… in this tab.
+            const SR = window.SmartRouter;
+            if (SR && typeof SR.navigate === 'function' && SR.mode && SR.mode !== 'single') {
+                if (SR.navigate('card', { cardId: id }) !== false) return;
+            }
+
+            // Native bridge fallback (older WebViews without SmartRouter app mode).
+            if (eclawNavigateMissionCard(id)) return;
+
+            // Single / standalone page: SmartRouter same-tab navigate when present,
+            // else the legacy new-tab open so standalone users keep that affordance.
+            if (SR && typeof SR.navigate === 'function' && SR.mode === 'single') {
+                if (SR.navigate('card', { cardId: id }) !== false) return;
+            }
+            const url = getKanbanCardUrl(id);
             const opened = window.open(url, '_blank', 'noopener');
             if (!opened) window.location.href = url;
         }
@@ -9089,7 +9115,7 @@
             const kanbanUrl = getKanbanCardUrl(c.id || cardId);
 
             let html = `<div class="entity-card-actions">
-                <a class="entity-open-kanban" href="${escapeHtml(kanbanUrl)}" target="_blank" rel="noopener" onclick="openKanbanCard('${escapeJs(c.id || cardId)}', event)">📋 ${escapeHtml(openKanbanLabel)}</a>
+                <a class="entity-open-kanban" href="${escapeHtml(kanbanUrl)}" rel="noopener" onclick="openKanbanCard('${escapeJs(c.id || cardId)}', event)">📋 ${escapeHtml(openKanbanLabel)}</a>
             </div>`;
 
             html += `<div class="entity-meta">

--- a/backend/public/portal/shared/autolink-chip-preview.js
+++ b/backend/public/portal/shared/autolink-chip-preview.js
@@ -196,7 +196,7 @@
                 ${comments}
             </div>
             <div class="chip-popover-footer">
-                <a href="${escapeHtml(fullUrl)}" class="chip-popover-open">${escapeHtml(openFullLabel)}</a>
+                <a href="${escapeHtml(fullUrl)}" class="chip-popover-open" data-action="open-full" data-card-id="${escapeHtml(hashId)}">${escapeHtml(openFullLabel)}</a>
             </div>
         `;
     }
@@ -228,6 +228,20 @@
                 return;
             }
             if (action === 'requote') { insertRequoteToken(pop._data, pop._refType, pop._refId, pop._anchorEl || rootAnchor); closeAll(); return; }
+            if (action === 'open-full') {
+                // card_2d5fbe88 sibling: in split mode the "打開完整頁面 →" link
+                // must route into the EXISTING kanban pane, not navigate the
+                // current (chat) pane. SmartRouter posts split_navigate; the
+                // workspace host loads the card into the kanban pane.
+                const SR = window.SmartRouter;
+                const cardId = btn.getAttribute('data-card-id') || '';
+                if (SR && SR.mode === 'split' && typeof SR.navigate === 'function' && cardId) {
+                    e.preventDefault();
+                    if (SR.navigate('card', { cardId }) !== false) { closeAll(); return; }
+                }
+                // Single/app or no router: fall through to the native <a> navigation.
+                return;
+            }
         });
     }
 

--- a/backend/public/portal/workspace.html
+++ b/backend/public/portal/workspace.html
@@ -489,20 +489,115 @@
         }
     });
 
-    // Swap the requesting pane's src to the SmartRouter target. Acks first so the
-    // pane can cancel its 300ms degrade timer before its document unloads.
+    // SmartRouter target → workspace page-id of the pane that should own it.
+    // Cross-pane targets (a chat card → kanban) must land in the EXISTING
+    // sibling pane, NOT swap the requester's own pane (card_2d5fbe88: split
+    // "在看板中開啟" was spawning a 2nd task pane + redirecting chat).
+    const TARGET_PANE = { card: 'kanban', note: 'mission' };
+
+    // Drive an already-loaded pane to focus the target IN PLACE (no src reload,
+    // no flash) by replaying the native-navigate intent that kanban/mission both
+    // implement. Returns true if the pane accepted the intent.
+    function _focusPaneInPlace(pane, target, params) {
+        try {
+            const win = pane && pane.contentWindow;
+            const fn = win && win.eclawHandleNativeNavigateIntent;
+            if (typeof fn !== 'function') return false;
+            const pageId = TARGET_PANE[target];
+            const targetTab = pageId === 'kanban' || pageId === 'mission' ? 'mission' : pageId;
+            const intent = Object.assign({ targetTab: targetTab, target: target }, params || {});
+            const r = fn(intent);
+            // Handler may be async (returns a Promise) — treat a truthy/Promise
+            // return as accepted; only an explicit synchronous `false` is a reject.
+            return r !== false;
+        } catch (_) { return false; }
+    }
+
+    function _findPaneByPageId(pageId) {
+        const info = PAGES[pageId];
+        if (!info) return null;
+        return Array.from(document.querySelectorAll('iframe.workspace-pane'))
+            .find(f => f.src && f.src.includes(info.href)) || null;
+    }
+
+    // Route a SmartRouter split dispatch. Cross-pane targets go to the sibling
+    // pane (open it if absent); same-pane targets swap the requester in place.
+    // Acks the requester FIRST so its 300ms degrade timer is cancelled and it
+    // never falls back to a full-page navigate (which redirected the chat pane).
     function handleSplitNavigate(e) {
         const { requestId, target, params } = e.data;
-        const pane = Array.from(document.querySelectorAll('iframe.workspace-pane'))
+        const requester = Array.from(document.querySelectorAll('iframe.workspace-pane'))
             .find(f => f.contentWindow === e.source);
         const url = (window.EClawRouteRegistry && buildPaneUrl(target, params)) || null;
-        if (!pane || !url) return; // unknown target / orphan source → pane stays, its timer degrades it
-        // Ack to the exact requesting window before we swap it.
-        if (requestId && e.source) {
-            try { e.source.postMessage({ type: 'split_navigate_ack', requestId }, window.location.origin); } catch (_) {}
+        if (!requester || !url) return; // unknown target / orphan source → requester's timer degrades it
+
+        const ack = () => {
+            if (requestId && e.source) {
+                try { e.source.postMessage({ type: 'split_navigate_ack', requestId }, window.location.origin); } catch (_) {}
+            }
+        };
+
+        const destPageId = TARGET_PANE[target];
+        const requesterIsDest = destPageId && PAGES[destPageId] && requester.src
+            && requester.src.includes(PAGES[destPageId].href);
+
+        // Cross-pane: target belongs in a sibling pane (e.g. chat card → kanban).
+        if (destPageId && !requesterIsDest) {
+            ack(); // requester keeps its own page; cancel its degrade timer now.
+            let destPane = _findPaneByPageId(destPageId);
+            if (destPane) {
+                // Pane already open — focus the card in place (no reload, no flash).
+                if (_focusPaneInPlace(destPane, target, params)) {
+                    bustChatPaneCache();
+                    return;
+                }
+                // Handler unavailable (pane mid-load) → set src so its boot deep-links.
+                destPane.src = url;
+                bustChatPaneCache();
+                return;
+            }
+            // Sibling pane not open — add it, pre-pointed at the target URL.
+            _openPaneWithUrl(destPageId, url);
+            bustChatPaneCache();
+            return;
         }
+
+        // Same-pane (or non-cross-pane) target: swap the requester in place.
+        ack();
         bustChatPaneCache();
-        pane.src = url;
+        requester.src = url;
+    }
+
+    // Inject embed=1 into the QUERY (before any #hash) so panes boot in embed mode
+    // without corrupting a deep-link fragment like kanban.html?card=X#X.
+    function _withEmbed(url) {
+        const hashAt = url.indexOf('#');
+        const base = hashAt >= 0 ? url.slice(0, hashAt) : url;
+        const frag = hashAt >= 0 ? url.slice(hashAt) : '';
+        const sep = base.indexOf('?') >= 0 ? '&' : '?';
+        return base + sep + 'embed=1' + frag;
+    }
+
+    // Add a new pane for pageId and point its iframe at an explicit URL (carrying
+    // ?card=… deep-link), rather than the default PAGES[pageId].href.
+    function _openPaneWithUrl(pageId, url) {
+        if (!PAGES[pageId]) return;
+        if (panes.findIndex(p => p.id === pageId) >= 0) {
+            // Already a pane for this page (src mismatch) — re-point + focus it.
+            render();
+            const pane = _findPaneByPageId(pageId);
+            if (pane) pane.src = _withEmbed(url);
+            return;
+        }
+        panes.push({ id: pageId, width: 0 });
+        activePaneIdx = panes.length - 1;
+        normalizeWidths();
+        clampActivePaneIdx();
+        render();
+        // After render the iframe exists with the default href; re-point to the
+        // deep-link URL so the card opens on first boot.
+        const pane = _findPaneByPageId(pageId);
+        if (pane) pane.src = _withEmbed(url);
     }
 
     // Mirror SmartRouter.buildUrl's tolerant-degrade: strict registry URL, else bare path.

--- a/backend/tests/jest/smart-router.test.js
+++ b/backend/tests/jest/smart-router.test.js
@@ -337,6 +337,51 @@ describe('split ack contract (spec §3)', () => {
         }, 360);
     });
 
+    // card_2d5fbe88: split "在看板中開啟" — chat pane must dispatch the card
+    // target to the host (which routes it into the existing kanban pane), NOT
+    // window.open a 2nd pane or full-page navigate (which redirected chat).
+    test('card target in split mode posts split_navigate with cardId (no full-page assign)', () => {
+        const post = jest.fn();
+        const assign = jest.fn();
+        const win = makeWin({ location: { origin: 'https://eclawbot.com', search: '?embed=1', assign } });
+        win.parent = { location: { origin: 'https://eclawbot.com' }, postMessage: post };
+        const SR = loadRouter(win);
+        expect(SR.mode).toBe('split');
+        SR.navigate('card', { cardId: 'card_2d5fbe88efdd98e90b0cae28' });
+        expect(post).toHaveBeenCalledWith(
+            expect.objectContaining({
+                type: 'split_navigate',
+                target: 'card',
+                params: { cardId: 'card_2d5fbe88efdd98e90b0cae28' },
+                requestId: expect.stringMatching(/^nav_[0-9a-f]{8}$/),
+            }),
+            'https://eclawbot.com'
+        );
+        // No synchronous full-page redirect — the host owns the pane swap.
+        expect(assign).not.toHaveBeenCalled();
+    });
+
+    test('card target ack from host cancels degrade — chat pane never full-page navigates', (done) => {
+        const post = jest.fn();
+        const assign = jest.fn();
+        const win = makeWin({ location: { origin: 'https://eclawbot.com', search: '?embed=1', assign } });
+        win.parent = { location: { origin: 'https://eclawbot.com' }, postMessage: post };
+        const SR = loadRouter(win);
+        SR.navigate('card', { cardId: 'card_2d5fbe88efdd98e90b0cae28' });
+        const requestId = post.mock.calls[0][0].requestId;
+        win._emit('message', { origin: 'https://eclawbot.com', data: { type: 'split_navigate_ack', requestId } });
+        setTimeout(() => {
+            expect(assign).not.toHaveBeenCalled();
+            done();
+        }, 360);
+    });
+
+    test('card target builds the kanban deep-link URL (host buildPaneUrl SoT)', () => {
+        const registry = require('../../shared/route-registry.js');
+        expect(registry.buildWebUrl('card', { cardId: 'card_2d5fbe88efdd98e90b0cae28' }))
+            .toBe('/portal/kanban.html?card=card_2d5fbe88efdd98e90b0cae28#card_2d5fbe88efdd98e90b0cae28');
+    });
+
     test('ack before timeout → no degrade (location.assign NOT called)', (done) => {
         const post = jest.fn();
         const assign = jest.fn();


### PR DESCRIPTION
**Card:** card_2d5fbe88efdd98e90b0cae28

## Bug (real user, web_chat 2026-06-17)
In Web 分割版 (split workspace), a task card in the CHAT pane has an **在看板中開啟** (Open in Kanban) action. Clicking it (1) opened a **NEW** task window/pane AND (2) **redirected the chat pane** to the task page → split view ended up showing **TWO** task panes.

## Root cause (file:line)
- `backend/public/portal/chat.html` `openKanbanCard()` bypassed SmartRouter entirely: tried the native bridge, then `window.open(url, '_blank')` (= new window/pane); the `<a>` also carried `target="_blank"`. No split-mode check.
- `backend/public/portal/workspace.html` `handleSplitNavigate()` **always swapped the requesting pane's `src`** — so a cross-pane `card` target would redirect the chat pane itself.

## Fix (targeted, no wholesale rewrite)
- **chat.html**: load `route-registry.js` + `smart-router.js`; `openKanbanCard()` routes via `SmartRouter`:
  - split → posts `split_navigate`; host loads the card into the **existing kanban pane**.
  - app → native tab bridge (`targetTab:'mission'`).
  - single → same-tab navigate; legacy `_blank` open kept only as the no-router standalone fallback.
  - removed `target="_blank"` from the action `<a>`.
- **workspace.html**: `handleSplitNavigate()` resolves cross-pane targets (`TARGET_PANE`: `card→kanban`, `note→mission`) into the **existing sibling pane** — focuses the card **in place** via `eclawHandleNativeNavigateIntent` (no reload/flash), opens the pane only if absent, and **acks the requester first** so its 300 ms degrade timer never full-page-navigates the chat pane. `_withEmbed()` injects `embed=1` before any `#hash`.

## Cross-pane audit (same class)
| Surface | Status |
|---|---|
| chat.html `openKanbanCard` (在看板中開啟) | **FIXED** (primary) |
| autolink-chip-preview.js "打開完整頁面 →" | **FIXED** — split routes via SmartRouter to kanban pane instead of navigating chat pane |
| autolink-chip.js `onChipClick` deep-link fallback | only fires when preview handler absent; preview path now pane-aware → user-facing path covered |
| mindmap.html "Open in Kanban" `target=_top` | by design (escapes its own embed); mindmap is not a workspace pane → out of scope, noted |

## Tests
- Backend jest green: **331 suites / 4615 passed**.
- `backend/tests/jest/smart-router.test.js` **+3**: card target posts `split_navigate` w/ cardId (no full-page `assign`); host ack cancels degrade; card builds the kanban deep-link URL.

## E2E (real workspace.html)
Playwright drove the **real** `workspace.html` split view (chat + kanban panes). Fired the actual `split_navigate target=card` → result:
- kanban pane received the intent **in place** (`{targetTab:'mission', target:'card', cardId:'card_2d5...'}`)
- panes **2→2** (NO duplicate pane)
- chat pane `src` **unchanged** (not redirected)
- ack sent → chat SmartRouter cancels degrade timer

Screenshot: `split_open_in_kanban_FIXED_desktop_1280x800.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)