### PR TITLE
feat(mindmap): center node uses entity display name + avatar (replace codename/yellow square)

### DIFF
--- a/backend/mindmap-graph-projection.js
+++ b/backend/mindmap-graph-projection.js
@@ -120,8 +120,35 @@ function buildNoteNode(note) {
     };
 }
 
+// Resolve an entity's human display name. Mirrors entity-utils.js
+// getEntityDisplayName priority: server-set display `name` first, then a
+// title-cased `character` codename (LOBSTER -> Lobster), then a numeric
+// fallback. Keeps the owner/center node label off the raw codename so the
+// mind-map center matches the rest of the surfaces (kanban/arena avatars).
+function ownerDisplayName(entityId, entityRecord) {
+    const name = entityRecord && entityRecord.name;
+    if (name && String(name).trim()) return String(name).trim();
+    const character = entityRecord && entityRecord.character;
+    if (character && String(character).trim()) {
+        const c = String(character).trim();
+        return c.charAt(0) + c.slice(1).toLowerCase();
+    }
+    return `Entity ${entityId}`;
+}
+
+// Resolve the avatar to paint for an owner node. Prefer a real image (the
+// live petdx companion sprite URL) over the emoji avatar so the center node
+// shows an actual headshot; fall back to the emoji, then null (frontend then
+// draws a deterministic initial badge — never a bare yellow square).
+function ownerAvatar(entityRecord) {
+    if (!entityRecord) return null;
+    const petdx = entityRecord.petdxAvatarUrl;
+    if (petdx && String(petdx).trim()) return String(petdx).trim();
+    return entityRecord.avatar || null;
+}
+
 function buildOwnerNode(entityId, entityRecord) {
-    const label = (entityRecord && (entityRecord.character || entityRecord.name)) || `Entity ${entityId}`;
+    const label = ownerDisplayName(entityId, entityRecord);
     return {
         id: `owner:${entityId}`,
         sourceId: String(entityId),
@@ -129,7 +156,15 @@ function buildOwnerNode(entityId, entityRecord) {
         fullTitle: clip(label, TITLE_MAX),
         type: 'owner',
         ownerEntityId: entityId,
-        avatar: (entityRecord && entityRecord.avatar) || null,
+        // Avatar rides along so the canvas renderer can paint a real headshot
+        // (大頭貼) in place of the yellow square. Prefer the live petdx sprite
+        // URL (a real image) over the emoji avatar, matching the entity-utils
+        // resolution chain; the frontend draws URLs as a clipped image and
+        // emoji as a glyph, falling back to a deterministic initial badge.
+        avatar: ownerAvatar(entityRecord),
+        // emoji avatar kept as a secondary fast-paint / fallback hint.
+        avatarEmoji: (entityRecord && entityRecord.avatar) || null,
+        character: (entityRecord && entityRecord.character) || null,
         colorKey: 'owner',
         val: 6,
     };

--- a/backend/mindmap.js
+++ b/backend/mindmap.js
@@ -1037,6 +1037,40 @@ function createMindmapModule(devices) {
             // Sort cards before projection so cap-truncation prefers active P0 work.
             graphProjection.sortCardsForCap(cards);
 
+            // Enrich the entity map with the live petdx companion sprite URL so
+            // owner/center nodes paint a real avatar (大頭貼) headshot instead of
+            // the bare yellow-square placeholder. Mirrors the /api/entities
+            // enrichment (latest companion_select_log row per entity JOIN
+            // companions); falls back silently to the emoji avatar on any error.
+            const baseEntities = (devices && devices[deviceId] && devices[deviceId].entities) || {};
+            let entityMap = baseEntities;
+            try {
+                const petdxRes = await pool.query(
+                    `SELECT DISTINCT ON (l.entity_id)
+                            l.entity_id, l.companion_id, l.origin, c.avatar_url
+                       FROM companion_select_log l
+                       LEFT JOIN companions c ON c.id = l.companion_id
+                      WHERE l.device_id = $1 AND l.entity_id IS NOT NULL
+                      ORDER BY l.entity_id, l.selected_at DESC, l.id DESC`,
+                    [deviceId]
+                );
+                if (petdxRes.rows.length) {
+                    entityMap = {};
+                    for (const [k, v] of Object.entries(baseEntities)) entityMap[k] = { ...v };
+                    for (const r of petdxRes.rows) {
+                        if (r.origin === 'unbind-cleared') continue;
+                        const eid = Number(r.entity_id);
+                        if (!Number.isFinite(eid) || !r.companion_id) continue;
+                        const url = (typeof r.avatar_url === 'string' && r.avatar_url.trim())
+                            ? r.avatar_url
+                            : `/static/companions/${r.companion_id}/avatar.png`;
+                        entityMap[eid] = { ...(entityMap[eid] || {}), petdxAvatarUrl: url };
+                    }
+                }
+            } catch (petdxErr) {
+                console.warn('[Mindmap] petdx avatar enrichment failed:', petdxErr.message);
+            }
+
             const projection = graphProjection.projectGraph({
                 cards,
                 initialCardIds,
@@ -1048,7 +1082,7 @@ function createMindmapModule(devices) {
                 noteCounts: noteCounts.rows,
                 notes,
                 anchorRows: anchorsResult.rows,
-                entityMap: (devices && devices[deviceId] && devices[deviceId].entities) || {},
+                entityMap,
                 options,
             });
 

--- a/backend/public/portal/mindmap.html
+++ b/backend/public/portal/mindmap.html
@@ -250,6 +250,38 @@
         const OWNER_COLOR = '#fbbf24';
         const CHAT_COLOR = '#34d399';
 
+        // ── Owner avatar cache ───────────────────────────────────────────────
+        // Owner/center nodes paint the entity's avatar (大頭貼) instead of the
+        // plain yellow square. node.avatar is resolved server-side via the
+        // entity record (entity-utils chain: explicit URL/emoji → petdx → …).
+        // URL avatars are loaded once into an Image and drawn clipped to a
+        // circle; emoji avatars are drawn as a glyph; missing avatars fall back
+        // to a deterministic initial badge — never a bare yellow square.
+        const _ownerImgCache = new Map(); // url -> { img, loaded }
+        function _ownerAvatarImg(url) {
+            let entry = _ownerImgCache.get(url);
+            if (entry) return entry;
+            entry = { img: new Image(), loaded: false };
+            entry.img.crossOrigin = 'anonymous';
+            entry.img.onload = () => {
+                entry.loaded = true;
+                // Repaint so the freshly-decoded avatar shows without a click.
+                try { if (fg) fg.refresh && fg.refresh(); } catch (_) {}
+            };
+            entry.img.onerror = () => { entry.failed = true; };
+            entry.img.src = url;
+            _ownerImgCache.set(url, entry);
+            return entry;
+        }
+        function _isAvatarUrl(v) {
+            return typeof v === 'string' && /^(https?:\/\/|\/)/.test(v);
+        }
+        function _ownerInitial(node) {
+            const s = node.label || node.character || '';
+            const ch = String(s).trim().charAt(0);
+            return ch ? ch.toUpperCase() : '#';
+        }
+
         const EDGE_COLOR = {
             parent: 'rgba(160, 174, 192, 0.55)',
             blocks: 'rgba(248, 113, 113, 0.75)',
@@ -598,14 +630,74 @@
             return '#888';
         }
 
+        // Owner/center node: paint the entity avatar inside a circle.
+        // Replaces the legacy yellow-square placeholder so the center node
+        // shows the bound entity's 大頭貼 + real display name.
+        function drawOwnerNode(node, ctx, r, isSel, scale) {
+            const cx = node.x, cy = node.y;
+            const av = node.avatar;
+            ctx.save();
+            // Clip to a circle so URL/emoji avatars sit in a round headshot.
+            ctx.beginPath();
+            ctx.arc(cx, cy, r, 0, Math.PI * 2, false);
+            ctx.closePath();
+            let painted = false;
+            if (_isAvatarUrl(av)) {
+                const entry = _ownerAvatarImg(av);
+                if (entry.loaded && !entry.failed) {
+                    ctx.save();
+                    ctx.clip();
+                    try {
+                        ctx.drawImage(entry.img, cx - r, cy - r, r * 2, r * 2);
+                        painted = true;
+                    } catch (_) {}
+                    ctx.restore();
+                }
+            }
+            if (!painted) {
+                // Backdrop disc (entity owner accent) for emoji / initial fallback.
+                ctx.fillStyle = OWNER_COLOR;
+                ctx.globalAlpha = node.archived ? 0.45 : 1;
+                ctx.fill();
+                ctx.globalAlpha = 1;
+                if (typeof av === 'string' && av && !_isAvatarUrl(av)) {
+                    // Emoji avatar glyph.
+                    ctx.fillStyle = '#1a1a1a';
+                    ctx.font = (r * 1.3) + 'px sans-serif';
+                    ctx.textAlign = 'center';
+                    ctx.textBaseline = 'middle';
+                    ctx.fillText(av, cx, cy + r * 0.04);
+                } else {
+                    // Deterministic initial badge (no avatar at all).
+                    ctx.fillStyle = '#1a1a1a';
+                    ctx.font = '600 ' + (r * 1.1) + 'px sans-serif';
+                    ctx.textAlign = 'center';
+                    ctx.textBaseline = 'middle';
+                    ctx.fillText(_ownerInitial(node), cx, cy + r * 0.04);
+                }
+            }
+            // Ring: selection highlight, else a subtle owner-accent border so the
+            // avatar reads as the center/owner node.
+            ctx.beginPath();
+            ctx.arc(cx, cy, r, 0, Math.PI * 2, false);
+            ctx.strokeStyle = isSel ? '#fff' : OWNER_COLOR;
+            ctx.lineWidth = (isSel ? 2 : 1.4) / scale;
+            ctx.stroke();
+            ctx.restore();
+        }
+
         function drawNode(node, ctx, scale) {
             const r = Math.max(3, Math.sqrt(Number(node.val) || 4) * 2.2);
             const isSel = node.id === selectedId;
-            ctx.beginPath();
             if (node.type === 'owner') {
-                // Owner: square
-                ctx.rect(node.x - r, node.y - r, r * 2, r * 2);
-            } else if (node.type === 'chat') {
+                // Owner: avatar headshot (大頭貼) in a circle.
+                drawOwnerNode(node, ctx, r, isSel, scale);
+                // Label still painted by the shared label block below.
+                drawNodeLabel(node, ctx, scale, r);
+                return;
+            }
+            ctx.beginPath();
+            if (node.type === 'chat') {
                 // Chat: diamond
                 ctx.moveTo(node.x, node.y - r);
                 ctx.lineTo(node.x + r, node.y);
@@ -639,19 +731,27 @@
             }
             ctx.globalAlpha = 1;
 
-            // Label only when zoomed in enough.
-            // Large graphs (>250 nodes): require deeper zoom so text-shaping
-            // doesn't dominate the frame budget on WebView-class GPUs.
-            const labelGate = GRAPH.nodes.length > LABEL_LARGE_GRAPH_THRESHOLD
-                ? LABEL_ZOOM_GATE_LARGE : LABEL_ZOOM_GATE_SMALL;
-            if (scale > labelGate && node.label) {
-                ctx.font = (11 / scale) + 'px sans-serif';
-                ctx.fillStyle = 'rgba(255,255,255,0.85)';
-                ctx.textAlign = 'center';
-                ctx.textBaseline = 'top';
-                const label = node.label.length > 28 ? node.label.slice(0, 27) + '…' : node.label;
-                ctx.fillText(label, node.x, node.y + r + 2);
+            drawNodeLabel(node, ctx, scale, r);
+        }
+
+        // Shared label painter. Owner/center nodes always show their name (it's
+        // the identity of the map); other nodes gate the label behind a zoom
+        // threshold so text-shaping doesn't dominate the frame budget on large
+        // graphs / WebView-class GPUs.
+        function drawNodeLabel(node, ctx, scale, r) {
+            if (!node.label) return;
+            if (node.type !== 'owner') {
+                const labelGate = GRAPH.nodes.length > LABEL_LARGE_GRAPH_THRESHOLD
+                    ? LABEL_ZOOM_GATE_LARGE : LABEL_ZOOM_GATE_SMALL;
+                if (scale <= labelGate) return;
             }
+            const isOwner = node.type === 'owner';
+            ctx.font = (isOwner ? '600 ' : '') + ((isOwner ? 12 : 11) / scale) + 'px sans-serif';
+            ctx.fillStyle = isOwner ? '#fff' : 'rgba(255,255,255,0.85)';
+            ctx.textAlign = 'center';
+            ctx.textBaseline = 'top';
+            const label = node.label.length > 28 ? node.label.slice(0, 27) + '…' : node.label;
+            ctx.fillText(label, node.x, node.y + r + 2);
         }
 
         // ── Click → preview ──────────────────────────────────────────────────

--- a/backend/tests/jest/mindmap-graph.test.js
+++ b/backend/tests/jest/mindmap-graph.test.js
@@ -118,14 +118,24 @@ describe('mindmap-graph-projection — pure helpers', () => {
         expect(stringOwner.ownerEntityId).toBeNull();
     });
 
-    test('buildOwnerNode uses entity record character name when available', () => {
-        const node = projection.buildOwnerNode(2, { character: 'LOBSTER', avatar: 'http://a.png' });
-        expect(node.id).toBe('owner:2');
-        expect(node.label).toBe('LOBSTER');
-        expect(node.avatar).toBe('http://a.png');
-        expect(node.type).toBe('owner');
+    test('buildOwnerNode prefers display name over codename, carries avatar + character', () => {
+        // Server display name wins over the raw codename character.
+        const named = projection.buildOwnerNode(2, { name: 'Lobster Boss', character: 'LOBSTER', avatar: 'http://a.png' });
+        expect(named.id).toBe('owner:2');
+        expect(named.label).toBe('Lobster Boss');
+        expect(named.avatar).toBe('http://a.png');
+        expect(named.character).toBe('LOBSTER');
+        expect(named.type).toBe('owner');
+
+        // No display name → title-cased codename (LOBSTER → Lobster), never raw.
+        const codenameOnly = projection.buildOwnerNode(2, { character: 'LOBSTER', avatar: 'http://a.png' });
+        expect(codenameOnly.label).toBe('Lobster');
+        expect(codenameOnly.character).toBe('LOBSTER');
+
+        // No record at all → numeric fallback.
         const fallback = projection.buildOwnerNode(99, undefined);
         expect(fallback.label).toBe('Entity 99');
+        expect(fallback.avatar).toBeNull();
     });
 
     test('buildChatNode produces chat:<id> with deep link', () => {


### PR DESCRIPTION
## Why
Hank (2026-06-17 12:50 TW, web_chat + screenshot): the mind-map (心智圖) **center/owner node** rendered the raw codename **"LOBSTER"** on a plain **yellow-square** placeholder. Hank wants (1) the real entity display name and (2) the actual avatar (大頭貼).

Card: `card_3bbd321594dfb1a684133071`

## Root cause
- `backend/mindmap-graph-projection.js` `buildOwnerNode`: `label = character || name` → the codename ("LOBSTER") always beat the real display name; only the emoji avatar was passed and the canvas ignored it.
- `backend/public/portal/mindmap.html` `drawNode`: owner nodes were painted as a flat `OWNER_COLOR` (`#fbbf24`) `ctx.rect` — the yellow square — never the avatar.

## What changed
- **`mindmap-graph-projection.js`**: `ownerDisplayName()` resolves name-first (server `name` > title-cased codename > `Entity N`), mirroring `entity-utils.getEntityDisplayName`. `ownerAvatar()` prefers the live petdx companion sprite URL over the emoji avatar. Node now carries `avatar` + `character`.
- **`mindmap.js`**: enriches the `entityMap` with the live petdx sprite URL (`companion_select_log` JOIN `companions`, latest per entity), mirroring the `/api/entities` enrichment; silent emoji fallback on error.
- **`mindmap.html`**: `drawOwnerNode()` paints the avatar clipped to a circle — URL → cached `Image`, emoji → glyph, none → deterministic initial badge — with an owner-accent / selection ring. **Never a bare yellow square.** Owner label always shows (it's the map's identity); shared `drawNodeLabel()` keeps the zoom-gate for other nodes.

## Avatar-resolver reuse
Follows the established `entity-utils.js` convention (server name > codename for the label; explicit avatar → petdx → emoji for the image) used by the kanban/arena avatar surfaces.

## Globe-user
Resolved from the device owner's own entity records — no hardcoded entityId / name / avatar. Works for any user's mind-map center.

## Verification
- `jest tests/jest/mindmap-graph.test.js` → **26/26 pass** (updated owner-node test: name-first + avatar + character).
- Offline render harness driven by **real prod graph data** (`/api/mindmap/graph` for the reporter's device):
  - **BEFORE** (desktop): yellow square + "LOBSTER" codename.
  - **AFTER** (desktop + mobile): circular petdx avatar headshot + **"Mac_ClaudeAce主管"** real display name; emoji-avatar fallback (owner #3 🐱) and initial-badge fallback confirmed.
  - **Console clean** (0 errors / 0 warnings) — no SVG NaN / canvas errors.

Screenshots attached in the card / channel (before desktop, after desktop, after mobile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)