### PR TITLE
fix(settings): unify all ? help-icons to the 用量警告 canonical style

### DIFF
--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -792,14 +792,7 @@
         <div class="card" id="userProfileCard">
             <div class="card-title" style="display:flex;align-items:center;gap:6px;">
                 <span>🪪 <span data-i18n="settings_user_display_name_title">My Display Name</span></span>
-                <span class="help-icon-inline"
-                      title="Click for help"
-                      role="button"
-                      tabindex="0"
-                      aria-label="Help"
-                      onclick="showUserDisplayNameHelp()"
-                      onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();showUserDisplayNameHelp();}"
-                      style="cursor:pointer;display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;border-radius:50%;border:1px solid var(--card-border);font-size:11px;color:var(--text-secondary);user-select:none;">?</span>
+                <span class="help-icon" data-help-content-key="settings_user_display_name_help_body"></span>
             </div>
             <p class="section-desc" data-i18n="settings_user_display_name_desc">The name shown in chat headers in place of "Device Owner". Leave blank to use the default.</p>
             <div style="display:flex;gap:8px;align-items:center;flex-wrap:wrap;margin-top:8px;">
@@ -815,18 +808,6 @@
                         data-i18n="common_save">Save</button>
             </div>
             <p id="userDisplayNameStatus" class="section-desc" style="margin:8px 0 0;min-height:18px;"></p>
-            <!-- Empty / disabled-state help dialog (hidden by default) -->
-            <div id="userDisplayNameHelpDialog"
-                 onclick="if(event.target===this)closeUserDisplayNameHelp()"
-                 style="display:none;position:fixed;inset:0;background:rgba(0,0,0,0.55);z-index:9999;align-items:center;justify-content:center;padding:16px;">
-                <div style="background:var(--bg);color:var(--text);max-width:480px;width:100%;border-radius:10px;padding:18px 20px;border:1px solid var(--card-border);">
-                    <h3 style="margin:0 0 8px;font-size:16px;" data-i18n="settings_user_display_name_help_title">About My Display Name</h3>
-                    <p style="margin:0 0 8px;font-size:13px;line-height:1.5;" data-i18n="settings_user_display_name_help_body">This name appears in chat as the human label for messages you send. It is visible to bots you talk to but not used for routing or login. Up to 64 characters, single line, no control characters. Leave blank to fall back to the default "Device Owner".</p>
-                    <div style="display:flex;justify-content:flex-end;margin-top:12px;">
-                        <button class="btn btn-sm btn-outline" onclick="closeUserDisplayNameHelp()" data-i18n="common_close">Close</button>
-                    </div>
-                </div>
-            </div>
         </div>
 
         <!-- Channel API Card -->
@@ -2587,9 +2568,11 @@
                     // the setup without leaving the page.
                     let helpHtml = '';
                     if (cat.helpI18n) {
-                        const help = typeof i18n !== 'undefined' ? i18n.t(cat.helpI18n) : '';
-                        const safeHelp = (help || '').replace(/"/g, '&quot;');
-                        helpHtml = `<span class="help-icon-inline" role="button" tabindex="0" aria-label="Help" title="${safeHelp}" onclick="alert(this.getAttribute('title'))" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();alert(this.getAttribute('title'));}" style="cursor:pointer;display:inline-flex;align-items:center;justify-content:center;width:16px;height:16px;border-radius:50%;border:1px solid var(--card-border);font-size:10px;color:var(--text-secondary);margin-left:6px;user-select:none;vertical-align:middle;">?</span>`;
+                        // Canonical ? icon — same .help-icon style + click-popover
+                        // interaction as the 用量警告 (usage warning) section.
+                        // help-popover.js delegates clicks on .help-icon globally,
+                        // so dynamically-inserted icons work without extra wiring.
+                        helpHtml = ` <span class="help-icon" data-help-content-key="${cat.helpI18n}"></span>`;
                     }
 
                     const row = document.createElement('div');
@@ -2662,15 +2645,6 @@
             } finally {
                 if (btn) btn.disabled = false;
             }
-        }
-
-        function showUserDisplayNameHelp() {
-            const dlg = document.getElementById('userDisplayNameHelpDialog');
-            if (dlg) dlg.style.display = 'flex';
-        }
-        function closeUserDisplayNameHelp() {
-            const dlg = document.getElementById('userDisplayNameHelpDialog');
-            if (dlg) dlg.style.display = 'none';
         }
 
         window.onSocketUserProfile = function(data) {


### PR DESCRIPTION
## Card
card_cf92fd65802d1cb98c1eac2c

## Problem (real-user Hank)
The 通知偏好 (notification preferences) ? help-icon looked **different** from the 用量警告 (usage warning) ? icon. 用量警告 uses the canonical `.help-icon` (purple SVG `?` in a tinted circle, click-to-popover). Two other settings ? icons used a divergent `.help-icon-inline` (plain gray `?` glyph, one-off inline style, `alert()` or bespoke modal).

## Fix — unify to the 用量警告 canonical `.help-icon` (the standard going forward)
- **Notification per-category ? icon** (JS-generated, line ~2592): `.help-icon-inline` + `alert()` → `.help-icon[data-help-content-key]`. `help-popover.js` delegates clicks on `.help-icon` at the document level, so dynamically-inserted icons work with no extra wiring.
- **My Display Name card ? icon** (line ~795): `.help-icon-inline` + custom modal → `.help-icon[data-help-content-key="settings_user_display_name_help_body"]`. Removed the now-unused modal markup + `showUserDisplayNameHelp()` / `closeUserDisplayNameHelp()`.

Tooltip **content preserved** (reuses existing i18n keys) — no new user-facing strings → no i18n change.

## Scope
Single file: `backend/public/portal/settings.html` (+6 / −32). `git diff --stat` shows ONLY settings.html.

## Evidence
- BEFORE (desktop): 用量警告 purple SVG vs 通知偏好/Display-Name gray `?` glyphs — visibly inconsistent.
- AFTER (desktop 1280x800 + mobile 390x844): 通知偏好 + Display Name now render the identical canonical purple SVG icon. OLD divergent styles shown for contrast.
- Console errors: 0 (only a harness favicon 404).
- jest: 103/103 pass (settings-deep-link-focus, settings-prompt-policy-dashboard, onboarding-tour, portal-static-ids) against the changed file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)