### PR TITLE
feat(settings-manifest): /api/settings-manifest auto-sync seam + spec (Stage 1 backend)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -7025,6 +7025,23 @@ app.get('/api/version', (req, res) => {
     res.json(response);
 });
 
+// Settings auto-sync seam (Stage 1). Pure capability descriptor — no user data,
+// so no auth needed (mirrors /api/version's public-GET access pattern). Apps
+// query this at launch and surface each enabled Settings feature natively (if
+// their version qualifies) or via the webFallback WebView. See
+// docs/specs/settings-manifest-spec.md and backend/lib/settings-manifest.js.
+const { buildSettingsManifest } = require('./lib/settings-manifest');
+app.get('/api/settings-manifest', (req, res) => {
+    try {
+        const { appVersion, platform } = req.query;
+        const manifest = buildSettingsManifest(appVersion, platform);
+        res.json({ success: true, manifest });
+    } catch (err) {
+        console.error('[settings-manifest] build failed:', err);
+        res.status(500).json({ success: false, error: 'manifest_build_failed' });
+    }
+});
+
 // ============================================
 // LINK PREVIEW (Open Graph metadata extraction)
 // ============================================

--- a/backend/lib/settings-manifest.js
+++ b/backend/lib/settings-manifest.js
@@ -1,0 +1,302 @@
+/**
+ * settings-manifest.js — Auto-sync seam between the EClaw web Settings page and
+ * the native mobile apps (Android / iOS).
+ *
+ * The EClaw mobile app is HYBRID: some Settings features are implemented
+ * natively, others are WebView-embedded portal pages. Today there is NO
+ * machine-readable description of "which settings features exist and how each
+ * app should surface them", so the native half drifts from the web half
+ * whenever a new web-only feature ships.
+ *
+ * This module is the Stage-1 backend seam. `buildSettingsManifest(appVersion,
+ * platform)` returns a pure, device-/locale-agnostic (Globe-user) descriptor of
+ * every Settings feature. An app queries GET /api/settings-manifest at launch
+ * and, for each enabled feature, surfaces an entry:
+ *   - native: true   → app renders its native screen for that feature
+ *   - native: false  → app opens `webFallback` in a WebView
+ *   - native:"partial" → app renders native UI but links out to `webFallback`
+ *                        for the missing sub-features
+ * The decision is gated by `minAppVersion`: if the running app is OLDER than the
+ * version that shipped native support, the manifest downgrades that feature to
+ * native:false + webFallback so an old binary still surfaces the feature
+ * (via WebView) with ZERO rebuild.
+ *
+ * CONTRACT: a NEW settings feature only needs (a) a section in the web
+ * settings.html + (b) one entry in FEATURES below. The app then surfaces it
+ * automatically (native if its version qualifies, else WebView fallback) with
+ * no app store release.
+ *
+ * Stage 2 (apps consume this manifest — needs a build) and Stage 3 (full
+ * dynamic schema registry incl. field-level declarations) are follow-ups.
+ *
+ * Pure function: no I/O, no globals, no device/entity/locale hardcoding.
+ */
+
+'use strict';
+
+const PORTAL_SETTINGS_BASE = 'https://eclawbot.com/portal/settings.html';
+
+// Build the focus-deep-link form of the web Settings page. `?focus=<key>` tells
+// the portal to scroll to / highlight that feature's section.
+function portalFocus(key) {
+    return `${PORTAL_SETTINGS_BASE}?focus=${encodeURIComponent(key)}`;
+}
+
+/**
+ * Canonical declaration of every Settings feature.
+ *
+ * Per-platform native support is expressed as:
+ *   native: { android: <support>, ios: <support> }
+ * where <support> is one of:
+ *   - true        : implemented natively
+ *   - "partial"   : partial native UI, rest via webFallback
+ *   - false       : no native UI, always WebView
+ * `minAppVersion.android` / `.ios` is the FIRST app version that ships the
+ * declared native support. If the running app is older, the feature is
+ * downgraded to native:false + webFallback at resolve time.
+ *
+ * Support levels (native: false) that have no per-version gate use
+ * minAppVersion "0.0.0" (always "below" any real app version's native, i.e.
+ * never natively available — they live on the web).
+ *
+ * Drift list (from the 2026-06 settings audit) is reflected here:
+ *   HIGH: rotate_secret, switch_device — missing from BOTH apps → native:false
+ *   MED : rental_management (full UI web-only), agent_policy (web-only),
+ *         channel_api (Android read-only → "partial"), notifications
+ *         (iOS fewer categories → "partial").
+ */
+const FEATURES = [
+    {
+        key: 'account_identity',
+        name: 'Account & Identity',
+        enabled: true,
+        native: { android: true, ios: true },
+        minAppVersion: { android: '1.0.0', ios: '1.0.0' },
+    },
+    {
+        key: 'channel_api',
+        name: 'Channel API',
+        enabled: true,
+        // Android settings screen is read-only for channel API (MED drift);
+        // iOS has the full native editor.
+        native: { android: 'partial', ios: true },
+        minAppVersion: { android: '1.0.0', ios: '1.0.0' },
+    },
+    {
+        key: 'subscription',
+        name: 'Subscription',
+        enabled: true,
+        native: { android: true, ios: true },
+        minAppVersion: { android: '1.0.0', ios: '1.0.0' },
+    },
+    {
+        key: 'invite',
+        name: 'Invite & Rewards',
+        enabled: true,
+        native: { android: true, ios: true },
+        minAppVersion: { android: '1.0.0', ios: '1.0.0' },
+    },
+    {
+        key: 'language',
+        name: 'Language',
+        enabled: true,
+        native: { android: true, ios: true },
+        minAppVersion: { android: '1.0.0', ios: '1.0.0' },
+    },
+    {
+        key: 'display',
+        name: 'Display',
+        enabled: true,
+        native: { android: true, ios: true },
+        minAppVersion: { android: '1.0.0', ios: '1.0.0' },
+    },
+    {
+        key: 'chat_prefs',
+        name: 'Chat Preferences',
+        enabled: true,
+        native: { android: true, ios: true },
+        minAppVersion: { android: '1.0.0', ios: '1.0.0' },
+    },
+    {
+        key: 'rental_management',
+        name: 'Rental Management',
+        enabled: true,
+        // Full rental-management UI is web-only on both apps (MED drift).
+        native: { android: false, ios: false },
+        minAppVersion: { android: '0.0.0', ios: '0.0.0' },
+    },
+    {
+        key: 'notifications',
+        name: 'Notifications',
+        enabled: true,
+        // iOS exposes fewer notification categories natively (MED drift) →
+        // "partial"; Android has the full set.
+        native: { android: true, ios: 'partial' },
+        minAppVersion: { android: '1.0.0', ios: '1.0.0' },
+    },
+    {
+        key: 'developer_broadcast',
+        name: 'Developer Broadcast',
+        enabled: true,
+        native: { android: true, ios: true },
+        minAppVersion: { android: '1.0.0', ios: '1.0.0' },
+    },
+    {
+        key: 'agent_policy',
+        name: 'Agent Policy',
+        enabled: true,
+        // Agent policy editor is web-only on both apps (MED drift).
+        native: { android: false, ios: false },
+        minAppVersion: { android: '0.0.0', ios: '0.0.0' },
+    },
+    {
+        key: 'kanban_nudge',
+        name: 'Kanban Nudge',
+        enabled: true,
+        // Web-only configuration surface today.
+        native: { android: false, ios: false },
+        minAppVersion: { android: '0.0.0', ios: '0.0.0' },
+    },
+    {
+        key: 'wallet',
+        name: 'Wallet',
+        enabled: true,
+        native: { android: true, ios: true },
+        minAppVersion: { android: '1.0.0', ios: '1.0.0' },
+    },
+    {
+        key: 'my_rentals',
+        name: 'My Rentals',
+        enabled: true,
+        native: { android: true, ios: true },
+        minAppVersion: { android: '1.0.0', ios: '1.0.0' },
+    },
+    {
+        key: 'files',
+        name: 'Files',
+        enabled: true,
+        native: { android: true, ios: true },
+        minAppVersion: { android: '1.0.0', ios: '1.0.0' },
+    },
+    {
+        key: 'companion_petdx',
+        name: 'Companion (PetDX)',
+        enabled: true,
+        native: { android: true, ios: true },
+        minAppVersion: { android: '1.0.0', ios: '1.0.0' },
+    },
+    {
+        key: 'feedback',
+        name: 'Feedback & Support',
+        enabled: true,
+        native: { android: true, ios: true },
+        minAppVersion: { android: '1.0.0', ios: '1.0.0' },
+    },
+    {
+        key: 'rotate_secret',
+        name: 'Rotate Secret',
+        enabled: true,
+        // HIGH drift: missing from BOTH native apps → web fallback only.
+        native: { android: false, ios: false },
+        minAppVersion: { android: '0.0.0', ios: '0.0.0' },
+    },
+    {
+        key: 'switch_device',
+        name: 'Switch Device',
+        enabled: true,
+        // HIGH drift: missing from BOTH native apps → web fallback only.
+        native: { android: false, ios: false },
+        minAppVersion: { android: '0.0.0', ios: '0.0.0' },
+    },
+    {
+        key: 'logout',
+        name: 'Logout',
+        enabled: true,
+        native: { android: true, ios: true },
+        minAppVersion: { android: '1.0.0', ios: '1.0.0' },
+    },
+];
+
+const SUPPORTED_PLATFORMS = ['android', 'ios'];
+
+// Self-contained semver-ish comparison (mirrors index.js compareVersions but
+// keeps this module dependency-free and pure). Returns -1 / 0 / 1.
+function compareVersions(v1, v2) {
+    const a = String(v1).split('.').map((n) => parseInt(n, 10) || 0);
+    const b = String(v2).split('.').map((n) => parseInt(n, 10) || 0);
+    for (let i = 0; i < Math.max(a.length, b.length); i++) {
+        const p1 = a[i] || 0;
+        const p2 = b[i] || 0;
+        if (p1 < p2) return -1;
+        if (p1 > p2) return 1;
+    }
+    return 0;
+}
+
+/**
+ * Resolve the per-platform native support for one feature against the running
+ * app version, applying the minAppVersion gate.
+ *
+ * @returns {true|"partial"|false}
+ */
+function resolveNative(feature, appVersion, platform) {
+    const declared = feature.native[platform];
+    if (declared === false || declared === undefined) return false;
+
+    const minVer = (feature.minAppVersion && feature.minAppVersion[platform]) || '0.0.0';
+    // If no version supplied, assume the latest-capable app (show native as
+    // declared). Manifest consumers always send appVersion in practice.
+    if (!appVersion) return declared;
+
+    // Older than the version that shipped this native support → downgrade to
+    // web fallback so the old binary still surfaces the feature.
+    if (compareVersions(appVersion, minVer) < 0) return false;
+    return declared;
+}
+
+/**
+ * Build the settings manifest for a given app version + platform.
+ *
+ * @param {string} [appVersion] e.g. "1.0.0". Optional; when omitted, native
+ *   support is reported as declared (no version downgrade).
+ * @param {string} [platform]   "android" | "ios" (case-insensitive). Defaults
+ *   to "android". Unknown platforms fall back to "android".
+ * @returns {{platform:string, appVersion:(string|null), generatedAt:string,
+ *   stage:number, features:Array}} Pure manifest object.
+ */
+function buildSettingsManifest(appVersion, platform) {
+    const plat = SUPPORTED_PLATFORMS.includes(String(platform).toLowerCase())
+        ? String(platform).toLowerCase()
+        : 'android';
+
+    const features = FEATURES.map((f) => {
+        const native = resolveNative(f, appVersion, plat);
+        return {
+            key: f.key,
+            name: f.name,
+            enabled: f.enabled,
+            native, // true | "partial" | false
+            // webFallback is ALWAYS present so the app can open it whenever
+            // native is false/"partial" or the version gate downgrades it.
+            webFallback: portalFocus(f.key),
+            minAppVersion: (f.minAppVersion && f.minAppVersion[plat]) || '0.0.0',
+        };
+    });
+
+    return {
+        platform: plat,
+        appVersion: appVersion || null,
+        generatedAt: new Date().toISOString(),
+        stage: 1,
+        features,
+    };
+}
+
+module.exports = {
+    buildSettingsManifest,
+    // exported for tests / Stage-2 reuse
+    FEATURES,
+    SUPPORTED_PLATFORMS,
+    compareVersions,
+    portalFocus,
+};

--- a/backend/tests/jest/settings-manifest.test.js
+++ b/backend/tests/jest/settings-manifest.test.js
@@ -1,0 +1,181 @@
+/**
+ * Unit tests for lib/settings-manifest.js — the Stage-1 settings auto-sync seam.
+ *
+ * Pure logic, no DB / HTTP. Asserts manifest structure, required keys on every
+ * feature, minAppVersion version gating (old app → native:false + webFallback),
+ * and that webFallback URLs are well-formed.
+ */
+
+const {
+    buildSettingsManifest,
+    FEATURES,
+    SUPPORTED_PLATFORMS,
+    compareVersions,
+} = require('../../lib/settings-manifest');
+
+const REQUIRED_KEYS = ['key', 'name', 'enabled', 'native', 'webFallback', 'minAppVersion'];
+
+describe('buildSettingsManifest() — structure', () => {
+    it('returns the manifest envelope with expected top-level fields', () => {
+        const m = buildSettingsManifest('1.0.0', 'android');
+        expect(m).toMatchObject({
+            platform: 'android',
+            appVersion: '1.0.0',
+            stage: 1,
+        });
+        expect(typeof m.generatedAt).toBe('string');
+        expect(Number.isNaN(Date.parse(m.generatedAt))).toBe(false);
+        expect(Array.isArray(m.features)).toBe(true);
+        expect(m.features.length).toBe(FEATURES.length);
+    });
+
+    it('every feature has all required keys with valid types', () => {
+        const m = buildSettingsManifest('1.0.0', 'ios');
+        for (const f of m.features) {
+            for (const k of REQUIRED_KEYS) {
+                expect(f).toHaveProperty(k);
+            }
+            expect(typeof f.key).toBe('string');
+            expect(f.key.length).toBeGreaterThan(0);
+            expect(typeof f.name).toBe('string');
+            expect(typeof f.enabled).toBe('boolean');
+            expect([true, false, 'partial']).toContain(f.native);
+            expect(typeof f.webFallback).toBe('string');
+            expect(typeof f.minAppVersion).toBe('string');
+        }
+    });
+
+    it('declares all real settings feature keys (no drift in the canonical set)', () => {
+        const keys = buildSettingsManifest('1.0.0', 'android').features.map((f) => f.key);
+        const expected = [
+            'account_identity', 'channel_api', 'subscription', 'invite', 'language',
+            'display', 'chat_prefs', 'rental_management', 'notifications',
+            'developer_broadcast', 'agent_policy', 'kanban_nudge', 'wallet',
+            'my_rentals', 'files', 'companion_petdx', 'feedback', 'rotate_secret',
+            'switch_device', 'logout',
+        ];
+        for (const k of expected) expect(keys).toContain(k);
+        expect(keys.length).toBe(expected.length);
+    });
+
+    it('feature keys are unique', () => {
+        const keys = buildSettingsManifest('1.0.0', 'android').features.map((f) => f.key);
+        expect(new Set(keys).size).toBe(keys.length);
+    });
+});
+
+describe('buildSettingsManifest() — platform handling', () => {
+    it('supports android and ios', () => {
+        expect(buildSettingsManifest('1.0.0', 'android').platform).toBe('android');
+        expect(buildSettingsManifest('1.0.0', 'ios').platform).toBe('ios');
+    });
+
+    it('is case-insensitive on platform', () => {
+        expect(buildSettingsManifest('1.0.0', 'iOS').platform).toBe('ios');
+        expect(buildSettingsManifest('1.0.0', 'ANDROID').platform).toBe('android');
+    });
+
+    it('falls back to android for unknown / missing platform', () => {
+        expect(buildSettingsManifest('1.0.0', 'windows').platform).toBe('android');
+        expect(buildSettingsManifest('1.0.0').platform).toBe('android');
+    });
+
+    it('reflects per-platform native drift (channel_api Android partial, iOS true)', () => {
+        const a = buildSettingsManifest('1.0.0', 'android').features.find((f) => f.key === 'channel_api');
+        const i = buildSettingsManifest('1.0.0', 'ios').features.find((f) => f.key === 'channel_api');
+        expect(a.native).toBe('partial');
+        expect(i.native).toBe(true);
+    });
+
+    it('reflects iOS notifications partial drift', () => {
+        const a = buildSettingsManifest('1.0.0', 'android').features.find((f) => f.key === 'notifications');
+        const i = buildSettingsManifest('1.0.0', 'ios').features.find((f) => f.key === 'notifications');
+        expect(a.native).toBe(true);
+        expect(i.native).toBe('partial');
+    });
+});
+
+describe('drift list — HIGH/MED features are web-only on both platforms', () => {
+    for (const platform of SUPPORTED_PLATFORMS) {
+        for (const key of ['rotate_secret', 'switch_device', 'rental_management', 'agent_policy', 'kanban_nudge']) {
+            it(`${key} is native:false on ${platform}`, () => {
+                const f = buildSettingsManifest('1.0.0', platform).features.find((x) => x.key === key);
+                expect(f.native).toBe(false);
+                expect(f.webFallback).toContain(`focus=${key}`);
+            });
+        }
+    }
+});
+
+describe('minAppVersion gating', () => {
+    // Synthetic gate: temporarily lift a feature's native floor so we can prove
+    // an old app gets downgraded. We do this by mutating the exported FEATURES
+    // entry and restoring it (table-driven, deterministic).
+    const target = FEATURES.find((f) => f.key === 'companion_petdx');
+    const origNative = JSON.parse(JSON.stringify(target.native));
+    const origMin = JSON.parse(JSON.stringify(target.minAppVersion));
+
+    afterEach(() => {
+        target.native = JSON.parse(JSON.stringify(origNative));
+        target.minAppVersion = JSON.parse(JSON.stringify(origMin));
+    });
+
+    it('an app OLDER than minAppVersion sees native:false + webFallback', () => {
+        target.native = { android: true, ios: true };
+        target.minAppVersion = { android: '2.5.0', ios: '2.5.0' };
+
+        const oldApp = buildSettingsManifest('1.0.0', 'android').features.find((f) => f.key === 'companion_petdx');
+        expect(oldApp.native).toBe(false);
+        expect(oldApp.webFallback).toContain('focus=companion_petdx');
+        expect(oldApp.minAppVersion).toBe('2.5.0');
+    });
+
+    it('an app AT or ABOVE minAppVersion keeps native support', () => {
+        target.native = { android: true, ios: true };
+        target.minAppVersion = { android: '2.5.0', ios: '2.5.0' };
+
+        const atVer = buildSettingsManifest('2.5.0', 'android').features.find((f) => f.key === 'companion_petdx');
+        const above = buildSettingsManifest('3.0.0', 'android').features.find((f) => f.key === 'companion_petdx');
+        expect(atVer.native).toBe(true);
+        expect(above.native).toBe(true);
+    });
+
+    it('partial native is also downgraded for an old app', () => {
+        target.native = { android: 'partial', ios: 'partial' };
+        target.minAppVersion = { android: '2.5.0', ios: '2.5.0' };
+
+        const oldApp = buildSettingsManifest('1.0.0', 'android').features.find((f) => f.key === 'companion_petdx');
+        expect(oldApp.native).toBe(false);
+    });
+
+    it('omitting appVersion reports native as declared (no downgrade)', () => {
+        target.native = { android: true, ios: true };
+        target.minAppVersion = { android: '2.5.0', ios: '2.5.0' };
+
+        const noVer = buildSettingsManifest(undefined, 'android').features.find((f) => f.key === 'companion_petdx');
+        expect(noVer.native).toBe(true);
+        expect(noVer.appVersion).toBeUndefined(); // it's a feature, no appVersion field
+    });
+});
+
+describe('webFallback URLs are well-formed', () => {
+    it('every webFallback is an https eclawbot.com portal URL with a focus param', () => {
+        const m = buildSettingsManifest('1.0.0', 'android');
+        for (const f of m.features) {
+            const u = new URL(f.webFallback);
+            expect(u.protocol).toBe('https:');
+            expect(u.hostname).toBe('eclawbot.com');
+            expect(u.pathname).toBe('/portal/settings.html');
+            expect(u.searchParams.get('focus')).toBe(f.key);
+        }
+    });
+});
+
+describe('compareVersions()', () => {
+    it('orders versions correctly', () => {
+        expect(compareVersions('1.0.0', '1.0.1')).toBe(-1);
+        expect(compareVersions('1.2.0', '1.1.9')).toBe(1);
+        expect(compareVersions('2.0.0', '2.0.0')).toBe(0);
+        expect(compareVersions('1.0', '1.0.0')).toBe(0);
+    });
+});

--- a/docs/specs/settings-manifest-spec.md
+++ b/docs/specs/settings-manifest-spec.md
@@ -1,0 +1,171 @@
+# Settings Manifest / APP Auto-Sync Seam Spec
+
+> Source of truth for how a NEW Settings feature reaches the mobile apps with
+> ZERO app rebuild.
+> Logic:    [`backend/lib/settings-manifest.js`](../../backend/lib/settings-manifest.js) (`buildSettingsManifest`)
+> Endpoint: `GET /api/settings-manifest` in [`backend/index.js`](../../backend/index.js) (next to `/api/version`)
+> Web UI:   [`backend/public/portal/settings.html`](../../backend/public/portal/settings.html)
+> Tests:    [`backend/tests/jest/settings-manifest.test.js`](../../backend/tests/jest/settings-manifest.test.js)
+
+## 動機 / Why this spec exists
+
+Hank's request: 「設計一種方法讓設定內的新功能自主同步到 APP 中」 — design a way for
+new Settings features to auto-sync into the app.
+
+The EClaw mobile app is **HYBRID**:
+- Android `SettingsActivity.kt` is **native** for some Settings features and
+  **WebView-embeds** `backend/public/portal/settings.html` for others.
+- iOS is the same shape.
+
+Today there is **no settings manifest/schema**. The native half is hand-maintained,
+so it **drifts** from the web half every time a web-only Settings feature ships.
+Adding a feature to the web does not surface it in the app until someone hand-edits
+the native code and ships a store release.
+
+`/api/version` (`backend/index.js`, near the `/api/version` handler) carries
+**hardcoded per-platform feature lists** — a parallel, stale source of truth that
+makes the drift worse, not better.
+
+### Drift list (2026-06 settings audit)
+
+| Severity | Feature | Drift |
+|----------|---------|-------|
+| HIGH | `rotate_secret` (Rotate Secret) | missing from BOTH Android and iOS native |
+| HIGH | `switch_device` (Switch Device) | missing from BOTH Android and iOS native |
+| MED  | `rental_management` (出租管理) | full UI is web-only on both apps |
+| MED  | `agent_policy` (Agent Policy) | web-only on both apps |
+| MED  | `channel_api` (Channel API) | Android settings is **read-only** (partial) |
+| MED  | `notifications` | iOS exposes **fewer** notification categories (partial) |
+
+---
+
+## 1. 名詞 / Vocabulary
+
+- **Settings feature** — One row in the Settings page (e.g. *Subscription*,
+  *Rotate Secret*). Identified by a stable `key`.
+- **native support** — How well the running app implements a feature in native code:
+  - `true` — fully native screen.
+  - `"partial"` — native UI exists but is incomplete; the rest lives on the web.
+  - `false` — no native UI; the app must open the web fallback.
+- **webFallback** — A portal URL the app opens in a WebView when native support is
+  `false` or `"partial"`, or when the version gate downgrades the feature.
+- **minAppVersion** — The FIRST app version that ships the declared native support
+  for a platform. An older app is downgraded to `native:false` + `webFallback`.
+
+---
+
+## 2. The seam
+
+```
+                     GET /api/settings-manifest?appVersion=&platform=
+  App launch ───────────────────────────────────────────────►  backend
+       ▲                                                            │
+       │   { success:true, manifest:{ platform, appVersion,         │
+       │       stage:1, features:[ {key,name,enabled,native,        │
+       │       webFallback,minAppVersion}, ... ] } }                │
+       └────────────────────────────────────────────────────────────┘
+
+  For each enabled feature the app surfaces an entry:
+    native === true       → render the native screen
+    native === "partial"  → render native UI + a "more on web" link → webFallback
+    native === false      → open webFallback in a WebView
+```
+
+The manifest is a **pure capability descriptor**: it contains no user data, so the
+endpoint needs **no auth** — it mirrors `/api/version`'s public-GET access pattern.
+The function `buildSettingsManifest(appVersion, platform)` is pure,
+device-/entity-/locale-agnostic (**Globe-user**): the same inputs always produce the
+same manifest for any user worldwide.
+
+### 2.1 Endpoint contract
+
+`GET /api/settings-manifest?appVersion=<semver>&platform=<android|ios>`
+
+- `appVersion` — optional. When omitted, native support is reported as declared
+  (no version downgrade).
+- `platform` — optional, case-insensitive. Unknown / missing → defaults to `android`.
+- Response: `{ "success": true, "manifest": { ...see §2 } }`.
+- On internal error: `500 { "success": false, "error": "manifest_build_failed" }`.
+
+### 2.2 Feature entry shape
+
+```jsonc
+{
+  "key": "rotate_secret",            // stable identifier
+  "name": "Rotate Secret",           // display label (apps may localize)
+  "enabled": true,                   // feature is live at all
+  "native": false,                   // true | "partial" | false  (post-gate)
+  "webFallback": "https://eclawbot.com/portal/settings.html?focus=rotate_secret",
+  "minAppVersion": "0.0.0"           // floor for native support on this platform
+}
+```
+
+`webFallback` is **always present** so the app can open it whenever it needs to,
+regardless of `native`. URLs point at
+`https://eclawbot.com/portal/settings.html?focus=<key>` (the `?focus=<key>` param
+tells the portal to scroll to / highlight that section), or the relevant portal page.
+
+---
+
+## 3. The auto-sync contract (the answer to Hank's request)
+
+A **NEW** Settings feature reaches the app with **ZERO app rebuild** by doing only:
+
+1. Add the feature's section to the web `backend/public/portal/settings.html`.
+2. Add ONE entry to `FEATURES` in `backend/lib/settings-manifest.js`.
+
+Then, the next time any app launches and calls `GET /api/settings-manifest`:
+
+- If the feature is declared `native:false` (the default for a brand-new web-only
+  feature), every app immediately surfaces an entry that opens the web fallback in a
+  WebView. No store release. The feature is live on day one.
+- Later, when a platform ships native support, bump that feature's `native` and
+  `minAppVersion` for the platform. Apps at/above the floor get the native screen;
+  older binaries keep the web fallback automatically.
+
+This removes the drift class entirely: the web settings page + the manifest are the
+single source of truth, and the manifest is what the app reads.
+
+### Version gating (worked example)
+
+Feature `companion_petdx` declared `native:{android:true}`, `minAppVersion:{android:"2.5.0"}`:
+
+| Running app | `native` returned | Surface |
+|-------------|-------------------|---------|
+| `1.0.0` (old) | `false` | WebView → `webFallback` |
+| `2.5.0` | `true` | native screen |
+| `3.0.0` | `true` | native screen |
+
+---
+
+## 4. Globe-user / setup conditions / ? icon UX
+
+- **Globe-user**: no device, entity, or locale is hardcoded. The manifest is
+  identical for every user worldwide; `name` strings are English defaults that apps
+  localize via their existing i18n. No single-tenant carveouts.
+- **Setup conditions**: none for Stage 1 — the endpoint is public and stateless.
+  Apps must send `appVersion` + `platform` on launch to get correct gating; if they
+  don't, they get the "declared" (latest-capable) view, which is safe (it may show a
+  native flag the binary can't honor — Stage 2 apps must send `appVersion`).
+- **? icon UX (empty / disabled state)**: when a feature shows the web-fallback
+  variant, the app's `?` affordance should reveal: *what* (this setting opens in the
+  web view because the native screen isn't in this app version yet), *needs* (update
+  the app to get the native screen, or use it on the web now), and the *next step*
+  (a tappable "Open on web" / "Update app" button).
+
+---
+
+## 5. Stages / follow-ups
+
+- **Stage 1 (this spec — backend only, NO app code):** `buildSettingsManifest` +
+  `GET /api/settings-manifest` + tests + this spec. Ships independently; no build.
+- **Stage 2 (needs an app build):** Android `SettingsActivity.kt` and the iOS
+  settings screen **consume** `/api/settings-manifest` at launch and render entries
+  from it (native vs WebView per `native`). Tracked as a follow-up card.
+- **Stage 3 (needs a build):** Native implementation of the HIGH-drift features
+  `rotate_secret` + `switch_device`, plus a **full dynamic schema registry**
+  (field-level declarations, so even the contents of a native screen are
+  manifest-driven). Tracked as a follow-up card.
+
+`/api/version`'s hardcoded feature lists should eventually be derived from this
+manifest (out of scope for Stage 1).


### PR DESCRIPTION
## Stage 1: Settings → APP auto-sync seam (backend + spec)

Card: `card_6dbb98223cadc793a96f4246`

Implements Hank's request 「設計一種方法讓設定內的新功能自主同步到 APP 中」 — Stage 1 (backend + spec only; NO app/native code).

### What this does
The EClaw mobile app is HYBRID (native + WebView-embedded portal settings). There was no settings manifest, so the native half drifts from the web. This adds the **auto-sync seam**:

`GET /api/settings-manifest?appVersion=&platform=` → `{success, manifest}`. Each settings feature is declared with `{key, name, enabled, native: true|"partial"|false, webFallback, minAppVersion}`.

**Contract:** a NEW settings feature only needs (a) added to web `settings.html` + (b) a manifest entry → the app surfaces it automatically (native if its version qualifies, else opens the `webFallback` WebView) with ZERO app rebuild.

### Files (4)
- `backend/lib/settings-manifest.js` — pure `buildSettingsManifest(appVersion, platform)`, 20 features, version gating, Globe-user.
- `backend/index.js` — `GET /api/settings-manifest` (public GET, mirrors `/api/version`).
- `docs/specs/settings-manifest-spec.md` — contract, drift list, Stage 2/3 follow-ups, ? icon UX.
- `backend/tests/jest/settings-manifest.test.js` — 25 tests (green).

### Drift reflected
HIGH: `rotate_secret`, `switch_device` → native:false. MED: `rental_management`/`agent_policy`/`kanban_nudge` web-only; `channel_api` Android partial; `notifications` iOS partial.

### Tests
```
Test Suites: 1 passed, 1 total
Tests:       25 passed, 25 total
```

### Follow-ups (need app builds → separate cards)
- Stage 2: Android+iOS consume `/api/settings-manifest`.
- Stage 3: native Rotate Secret + Switch Device + dynamic schema registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)