### PR TITLE
fix(routing): supervisor #2 no longer 搶答 messages addressed to #1 — escalate only on timeout

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -19,6 +19,7 @@ const feedbackModule = require('./device-feedback');
 const chatIntegrity = require('./chat-integrity');
 const communitySsr = require('./community-ssr');
 const { isLowSignalFwd } = require('./org-fwd-filter');
+const orgFwdEscalation = require('./org-fwd-escalation');
 const { buildOrgEntitySessionKey, isOrgEntitySessionKey } = require('./session-scope');
 const { assignDefaultCompanionIfMissing } = require('./petdx-phase0-hook');
 // JWT secret: fail-safe random per process if env var is missing (tokens signed in one process won't verify in another)
@@ -9999,9 +10000,13 @@ app.post('/api/transform', transformMaybeMultipart, idempotencyMiddleware, async
                     viaChannel
                 });
 
-                // Org chart: auto-forward incoming speakTo message to superior (same-device only, fire-and-forget)
+                // Org chart: escalate incoming speakTo message to superior only if
+                // the target stays silent past the threshold (same-device only,
+                // fire-and-forget). inbound:true gates this as a "緊迫盯人"
+                // escalation so the superior never 搶答 a message addressed to the
+                // target (card_184f2a25c1f1a13ebae5ec3e).
                 if (!isCrossDevice && toEntity.isBound) {
-                    orgChartForward(toEntity, target.deviceId, deliveryText, { fromEntityId: eId }).catch(() => {});
+                    orgChartForward(toEntity, target.deviceId, deliveryText, { fromEntityId: eId, inbound: true, inboundAt: Date.now() }).catch(() => {});
                 }
 
                 // Notify both devices
@@ -12363,9 +12368,12 @@ app.post('/api/entity/speak-to', async (req, res) => {
         }
     }
 
-    // Org chart: auto-forward incoming message to superior for target entity with incomplete tasks (fire-and-forget)
+    // Org chart: escalate incoming message to superior only if the target stays
+    // silent past the threshold (fire-and-forget). inbound:true gates this as a
+    // "緊迫盯人" escalation so the superior never 搶答 a message addressed to the
+    // target (card_184f2a25c1f1a13ebae5ec3e).
     if (toEntity && toEntity.isBound) {
-        orgChartForward(toEntity, deviceId, speakToText, { fromEntityId: fromId }).catch(() => {});
+        orgChartForward(toEntity, deviceId, speakToText, { fromEntityId: fromId, inbound: true, inboundAt: Date.now() }).catch(() => {});
     }
 
     const speakToResponse = {
@@ -19045,6 +19053,44 @@ async function orgChartForward(entity, deviceId, message, opts = {}) {
     if (!message || message.startsWith(ORG_TASK_FWD_PREFIX) || message.startsWith(ORG_FWD_PREFIX)) return;
     if (isLowSignalFwd(message)) {
         serverLog('info', 'org_forward_skip', `#${entity.entityId} suppressed low-signal fwd: "${String(message).trim().slice(0, 60)}"`, { deviceId, entityId: entity.entityId });
+        return;
+    }
+
+    // ── "緊迫盯人" supervisor escalation gate (card_184f2a25c1f1a13ebae5ec3e) ──
+    // opts.inbound = true means `message` is an INBOUND message addressed to
+    // `entity` (the target/subordinate), NOT the entity's own response. Relaying
+    // an inbound-to-#1 message to its superior #2 *immediately* makes #2 "搶答"
+    // a message that was addressed to #1 while #1 is still handling it. Inbound
+    // forwarding is an ESCALATION — defer it past a silence window and only fire
+    // if the target stays silent (never produces a response). The legitimate
+    // response-forward path (a bot's own output → superior) is unaffected.
+    if (opts.inbound) {
+        const inboundAt = Number.isFinite(opts.inboundAt) ? opts.inboundAt : Date.now();
+        const silenceMs = orgFwdEscalation.DEFAULT_ESCALATE_SILENCE_MS;
+        const targetEntityId = entity.entityId;
+        const escalateTimer = setTimeout(() => {
+            try {
+                const dev = devices[deviceId];
+                const liveTarget = dev && dev.entities ? dev.entities[targetEntityId] : null;
+                if (!liveTarget) return;
+                const decision = orgFwdEscalation.shouldEscalateInbound({
+                    targetLastReplyAt: liveTarget.lastUpdated,
+                    inboundAt,
+                    silenceMs,
+                });
+                if (!decision.escalate) {
+                    serverLog('info', 'org_escalate_skip', `#${targetEntityId} inbound not escalated: ${decision.reason}`, { deviceId, entityId: targetEntityId });
+                    return;
+                }
+                serverLog('info', 'org_escalate', `#${targetEntityId} silent past ${Math.round(silenceMs / 60000)}min — escalating inbound to superior`, { deviceId, entityId: targetEntityId });
+                // Re-enter with inbound cleared so the standard forward path runs.
+                orgChartForward(liveTarget, deviceId, message, { fromEntityId: opts.fromEntityId }).catch(() => {});
+            } catch (err) {
+                console.error('[OrgChart] inbound escalation tick error:', err.message);
+            }
+        }, silenceMs);
+        // Don't let the pending escalation timer keep the process alive.
+        if (typeof escalateTimer.unref === 'function') escalateTimer.unref();
         return;
     }
 

--- a/backend/org-fwd-escalation.js
+++ b/backend/org-fwd-escalation.js
@@ -1,0 +1,75 @@
+/**
+ * Org-chart inbound escalation timing ("緊迫盯人" supervisor escalation).
+ *
+ * Root cause (card_184f2a25c1f1a13ebae5ec3e): a channel message addressed to a
+ * target entity (e.g. #1 Mac_F) was being relayed to that entity's superior
+ * (#2 Mac_ClaudeAce 主管) IMMEDIATELY by orgChartForward() at the two inbound
+ * call sites (speakTo / cross-speak delivery). The superior's channel then
+ * treats the relayed message as an actionable prompt and "搶答" — answers a
+ * message that was addressed to the subordinate, while the subordinate was
+ * still actively handling it. Hank caught this in the web UI: he ticked
+ * 「傳送給 ☑ Mac_F (#1)」 yet #2 replied to 「聽到請回答」.
+ *
+ * The fix: inbound forwarding to a superior is an ESCALATION, not a mirror.
+ * The supervisor should only be pulled in when the target has gone SILENT past
+ * a threshold (default ~30 min, mirroring Hank's chat-reply escalation norm and
+ * the kanban L1/L2/L3 grace-window style). If the target replied (produced a
+ * response) since it last received an inbound message, there is nothing to
+ * escalate — the subordinate is doing its job.
+ *
+ * This module is a pure decision function (no I/O) so it can be unit-tested in
+ * isolation, the same way org-fwd-filter.js is.
+ */
+
+// Default silence window before an unanswered inbound to the target escalates
+// to its superior. ~30 min per Hank's chat-reply escalation norm. Overridable
+// via ECLAW_ORG_ESCALATE_SILENCE_MIN for ops tuning.
+const DEFAULT_ESCALATE_SILENCE_MS = (() => {
+    const raw = parseInt(process.env.ECLAW_ORG_ESCALATE_SILENCE_MIN || '30', 10);
+    const min = Number.isFinite(raw) && raw > 0 ? raw : 30;
+    return min * 60 * 1000;
+})();
+
+/**
+ * Decide whether an INBOUND message addressed to `target` should be escalated
+ * to its superior right now.
+ *
+ * @param {object} args
+ * @param {number} [args.targetLastReplyAt] - epoch ms when the target entity
+ *        last produced a response (entity.lastUpdated). Undefined/null = the
+ *        target has never replied.
+ * @param {number} args.inboundAt - epoch ms when this inbound message arrived
+ *        (typically Date.now() at the call site).
+ * @param {number} [args.silenceMs] - silence threshold; defaults to
+ *        DEFAULT_ESCALATE_SILENCE_MS.
+ * @param {number} [args.now] - current epoch ms; defaults to Date.now().
+ * @returns {{ escalate: boolean, reason: string }}
+ */
+function shouldEscalateInbound({ targetLastReplyAt, inboundAt, silenceMs, now } = {}) {
+    const threshold = Number.isFinite(silenceMs) && silenceMs > 0
+        ? silenceMs
+        : DEFAULT_ESCALATE_SILENCE_MS;
+    const nowMs = Number.isFinite(now) ? now : Date.now();
+    const arrivedAt = Number.isFinite(inboundAt) ? inboundAt : nowMs;
+
+    // If the target has replied AT OR AFTER this inbound arrived, the
+    // subordinate is actively handling it — never escalate (this is the
+    // 搶答 case the card is about).
+    if (Number.isFinite(targetLastReplyAt) && targetLastReplyAt >= arrivedAt) {
+        return { escalate: false, reason: 'target_replied_after_inbound' };
+    }
+
+    // Otherwise, escalate only once the target has stayed silent past the
+    // threshold since this inbound arrived. Immediate forwarding (now within
+    // the grace window) is suppressed — the subordinate gets first crack.
+    if (nowMs - arrivedAt < threshold) {
+        return { escalate: false, reason: 'within_grace_window' };
+    }
+
+    return { escalate: true, reason: 'target_silent_past_threshold' };
+}
+
+module.exports = {
+    shouldEscalateInbound,
+    DEFAULT_ESCALATE_SILENCE_MS,
+};

--- a/backend/tests/jest/org-fwd-escalation.test.js
+++ b/backend/tests/jest/org-fwd-escalation.test.js
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for org-fwd-escalation — the "緊迫盯人" supervisor escalation gate.
+ *
+ * Card: card_184f2a25c1f1a13ebae5ec3e
+ * Bug: a message addressed to target #1 (Mac_F) was relayed to its superior #2
+ * (Mac_ClaudeAce 主管) immediately, so #2 "搶答" the message. The gate must:
+ *   - NOT escalate an inbound message while it is within the grace window
+ *     (subordinate gets first crack)
+ *   - NOT escalate if the target replied at/after the inbound arrived
+ *   - escalate only once the target stays silent past the threshold
+ */
+
+const { shouldEscalateInbound, DEFAULT_ESCALATE_SILENCE_MS } = require('../../org-fwd-escalation');
+
+const MIN = 60 * 1000;
+
+describe('shouldEscalateInbound()', () => {
+    describe('the 搶答 case — message addressed to #1 must NOT reach #2 immediately', () => {
+        it('does NOT escalate immediately after an inbound to a never-replied target', () => {
+            const inboundAt = 1_000_000;
+            const decision = shouldEscalateInbound({
+                targetLastReplyAt: undefined, // #1 has not replied yet
+                inboundAt,
+                silenceMs: 30 * MIN,
+                now: inboundAt + 1, // ~immediate, the original bug trigger
+            });
+            expect(decision.escalate).toBe(false);
+            expect(decision.reason).toBe('within_grace_window');
+        });
+
+        it('does NOT escalate if the target replied AT or AFTER the inbound arrived', () => {
+            const inboundAt = 1_000_000;
+            const decision = shouldEscalateInbound({
+                targetLastReplyAt: inboundAt + 5 * MIN, // #1 actively handled it
+                inboundAt,
+                silenceMs: 30 * MIN,
+                now: inboundAt + 40 * MIN, // even long after, #1 replied → no escalation
+            });
+            expect(decision.escalate).toBe(false);
+            expect(decision.reason).toBe('target_replied_after_inbound');
+        });
+
+        it('does NOT escalate while still inside the grace window even with no reply', () => {
+            const inboundAt = 1_000_000;
+            const decision = shouldEscalateInbound({
+                targetLastReplyAt: inboundAt - 10 * MIN, // last reply was BEFORE this inbound
+                inboundAt,
+                silenceMs: 30 * MIN,
+                now: inboundAt + 29 * MIN, // just under threshold
+            });
+            expect(decision.escalate).toBe(false);
+            expect(decision.reason).toBe('within_grace_window');
+        });
+    });
+
+    describe('timeout escalation — #1 silent past threshold DOES reach #2', () => {
+        it('escalates once the target stays silent past the threshold (never replied)', () => {
+            const inboundAt = 1_000_000;
+            const decision = shouldEscalateInbound({
+                targetLastReplyAt: undefined,
+                inboundAt,
+                silenceMs: 30 * MIN,
+                now: inboundAt + 31 * MIN,
+            });
+            expect(decision.escalate).toBe(true);
+            expect(decision.reason).toBe('target_silent_past_threshold');
+        });
+
+        it('escalates if the only reply predates this inbound and grace has elapsed', () => {
+            const inboundAt = 1_000_000;
+            const decision = shouldEscalateInbound({
+                targetLastReplyAt: inboundAt - 1, // stale reply, before the inbound
+                inboundAt,
+                silenceMs: 30 * MIN,
+                now: inboundAt + 30 * MIN, // exactly at threshold counts as past grace
+            });
+            expect(decision.escalate).toBe(true);
+            expect(decision.reason).toBe('target_silent_past_threshold');
+        });
+
+        it('a reply exactly at the inbound timestamp suppresses escalation', () => {
+            const inboundAt = 1_000_000;
+            const decision = shouldEscalateInbound({
+                targetLastReplyAt: inboundAt, // tie → treated as "replied"
+                inboundAt,
+                silenceMs: 30 * MIN,
+                now: inboundAt + 60 * MIN,
+            });
+            expect(decision.escalate).toBe(false);
+            expect(decision.reason).toBe('target_replied_after_inbound');
+        });
+    });
+
+    describe('defaults & guards', () => {
+        it('defaults to ~30 min silence threshold', () => {
+            expect(DEFAULT_ESCALATE_SILENCE_MS).toBe(30 * MIN);
+        });
+
+        it('falls back to the default threshold when silenceMs is invalid', () => {
+            const inboundAt = 1_000_000;
+            // 20 min after inbound with default 30 min → still within grace
+            const decision = shouldEscalateInbound({
+                targetLastReplyAt: undefined,
+                inboundAt,
+                silenceMs: 0, // invalid → default
+                now: inboundAt + 20 * MIN,
+            });
+            expect(decision.escalate).toBe(false);
+            expect(decision.reason).toBe('within_grace_window');
+        });
+
+        it('treats a missing inboundAt as "now" (no immediate escalation)', () => {
+            const now = 5_000_000;
+            const decision = shouldEscalateInbound({
+                targetLastReplyAt: undefined,
+                inboundAt: undefined,
+                silenceMs: 30 * MIN,
+                now,
+            });
+            expect(decision.escalate).toBe(false);
+            expect(decision.reason).toBe('within_grace_window');
+        });
+    });
+});


### PR DESCRIPTION
## Card
card_184f2a25c1f1a13ebae5ec3e

## Root cause (file:line)
`backend/index.js` — `orgChartForward()` was invoked at the two **inbound** call sites with no timing gate:
- `/api/transform` speakTo delivery (index.js:10005)
- `/api/entity/speak-to` (index.js:12369)

Both relayed an inbound message **addressed to a target entity (#1 Mac_F)** to that entity's superior (#2 主管) **immediately** via `unifiedPush(...'org_forward')`. The superior's channel bridge then treats the relayed text as an actionable prompt and **搶答** — answers a message addressed to the subordinate while the subordinate is still handling it. Hank reproduced it: web UI 「傳送給 ☑ Mac_F (#1)」 yet #2 replied to 「聽到請回答」.

The user→entity `/api/client/speak` path already does NOT forward (index.js comment ~11733). The legitimate **response-forward** path (a bot's own output → superior, index.js:9806) is correct and is left unchanged.

## Fix (correct layer = EClaw backend)
Inbound forwarding to a superior is an **ESCALATION ("緊迫盯人"), not a mirror**:
- Both inbound call sites now pass `inbound: true, inboundAt: Date.now()`.
- `orgChartForward()` defers the inbound relay past a silence window (default ~30 min, `ECLAW_ORG_ESCALATE_SILENCE_MIN`, mirroring Hank's chat-reply escalation norm + kanban grace-window style) and only escalates if the target stayed silent — i.e. never produced a response (`entity.lastUpdated >= inboundAt`) since the inbound arrived. Timer is `.unref()`'d.
- New pure decision module `backend/org-fwd-escalation.js` (`shouldEscalateInbound`) — same testable shape as `org-fwd-filter.js`.

Broadcast / @-mention / messages genuinely targeted at #2 are unaffected.

## Before / after routing behavior
- BEFORE: message→#1 → immediately relayed to #2 → #2 答 (搶答).
- AFTER: message→#1 → #2 sees nothing until #1 is silent past ~30 min; if #1 replies, #2 never gets it.

## Tests
`backend/tests/jest/org-fwd-escalation.test.js` — 9 cases (搶答 suppression, target-replied suppression, grace-window, timeout escalation, defaults/guards). `npx jest tests/jest/org-fwd-escalation.test.js tests/jest/org-fwd-filter.test.js tests/jest/org-chart.test.js` → **77 passed, 3 suites**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)