### PR TITLE
enh(settings): make 用量警告 section collapsible (match sibling sections)

### DIFF
--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1345,15 +1345,23 @@
             </div>
         </div>
 
-        <!-- Usage Warning Settings (card_9cd84ee7d830b2f76c595f6c) -->
+        <!-- Usage Warning Settings (card_9cd84ee7d830b2f76c595f6c) — collapsible (card_ae3a7bdc) -->
         <div class="card" id="usage-warning-card">
-            <div class="card-title" style="display:flex;align-items:center;gap:8px;">
-                <span>⚠️ <span data-i18n="usage_warning_title">Usage Warning</span></span>
-                <button type="button" id="usageWarningHelpBtn"
-                        onclick="showUsageWarningHelp()"
-                        aria-label="Usage warning help"
-                        style="background:transparent;border:1px solid var(--card-border);color:var(--text-secondary);width:24px;height:24px;border-radius:50%;font-size:13px;cursor:pointer;padding:0;line-height:1;">?</button>
+            <div class="notif-header" role="button" tabindex="0" aria-expanded="false"
+                 aria-controls="usageWarningContent" id="usageWarningHeader"
+                 onclick="toggleUsageWarningSection()"
+                 onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleUsageWarningSection();}">
+                <div class="card-title" style="margin-bottom:0;display:flex;align-items:center;gap:8px;">
+                    <span>⚠️ <span data-i18n="usage_warning_title">Usage Warning</span></span>
+                    <button type="button" id="usageWarningHelpBtn"
+                            onclick="event.stopPropagation();showUsageWarningHelp()"
+                            aria-label="Usage warning help"
+                            style="background:transparent;border:1px solid var(--card-border);color:var(--text-secondary);width:24px;height:24px;border-radius:50%;font-size:13px;cursor:pointer;padding:0;line-height:1;">?</button>
+                </div>
+                <span class="expand-arrow" id="usageWarningArrow">&#9662;</span>
             </div>
+
+            <div class="notif-content" id="usageWarningContent">
             <p class="section-desc" data-i18n="usage_warning_desc">When triggered, the Agent prepends a system warning to every outgoing message so the recipient knows quota is tight.</p>
 
             <div id="usageWarningStaleNotice"
@@ -1402,6 +1410,7 @@
                        onchange="saveUsageWarningConfig()"
                        style="width:100%;">
             </div>
+            </div><!-- /.notif-content #usageWarningContent -->
         </div>
 
         <!-- Usage Warning Help Modal -->
@@ -1721,6 +1730,7 @@
             loadOwnerRoster(user).catch(e => console.warn('[Roster] initial load failed:', e));
             loadPromptPolicy(user);
             initKanbanNudgeCollapse();
+            initUsageWarningCollapse();
             updatePushToggle();
 
             document.getElementById('pageContent').style.display = '';
@@ -2519,6 +2529,32 @@
                 document.getElementById('kanbanNudgeContent').classList.add('visible');
                 document.getElementById('kanbanNudgeArrow').classList.add('expanded');
                 const header = document.getElementById('kanbanNudgeHeader');
+                if (header) header.setAttribute('aria-expanded', 'true');
+            }
+        }
+
+        // Usage Warning collapsible (card_ae3a7bdc) — reuses the same
+        // notif-header / expand-arrow / notif-content pattern + localStorage
+        // convention as the Kanban Nudge section above.
+        const USAGE_WARNING_COLLAPSE_KEY = 'settings_usage_warning_collapsed';
+        function toggleUsageWarningSection() {
+            const content = document.getElementById('usageWarningContent');
+            const arrow = document.getElementById('usageWarningArrow');
+            const header = document.getElementById('usageWarningHeader');
+            const expanded = !content.classList.contains('visible');
+            content.classList.toggle('visible', expanded);
+            arrow.classList.toggle('expanded', expanded);
+            if (header) header.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+            try { localStorage.setItem(USAGE_WARNING_COLLAPSE_KEY, expanded ? '0' : '1'); } catch (_) { }
+        }
+        function initUsageWarningCollapse() {
+            // Default collapsed. Only expand if user explicitly opened it previously.
+            let collapsed = '1';
+            try { collapsed = localStorage.getItem(USAGE_WARNING_COLLAPSE_KEY) || '1'; } catch (_) { }
+            if (collapsed === '0') {
+                document.getElementById('usageWarningContent').classList.add('visible');
+                document.getElementById('usageWarningArrow').classList.add('expanded');
+                const header = document.getElementById('usageWarningHeader');
                 if (header) header.setAttribute('aria-expanded', 'true');
             }
         }


### PR DESCRIPTION
## Scope
Real-user Hank: 「設定>用量警告也要使用下拉收合UI」. Convert the Usage Warning (用量警告) card in `backend/public/portal/settings.html` from always-expanded to a collapsible dropdown.

Card: card_ae3a7bdc1376ade33ffdf5b3

## Reused pattern (no new collapsible style invented)
Reuses the EXACT same collapsible component as the **Kanban Nudge** sibling section on the same page:
- `notif-header` clickable header (role=button, tabindex, aria-expanded, aria-controls, Enter/Space keyboard support)
- `expand-arrow` chevron (`&#9662;`) that rotates via `.expanded`
- `notif-content` body (visible via `.visible`)
- `localStorage` key `settings_usage_warning_collapsed` (same `settings_*_collapsed` convention), default **collapsed** to match the Kanban Nudge sibling
- `initUsageWarningCollapse()` wired into `DOMContentLoaded` right next to `initKanbanNudgeCollapse()`

The toggle, 5h/7d threshold sliders, stale notice, and `.help-icon`s all move inside the collapsible body. The `?` help button stays in the header with `event.stopPropagation()` so it opens the modal without toggling collapse.

## Acceptance
- Header click / Enter / Space expands & collapses the body
- Chevron rotates; aria-expanded reflects state
- State persists in localStorage across reloads (default collapsed)
- Toggle + both sliders fully functional inside the body
- No new user-facing strings (reuses existing `usage_warning_title`)

## Test plan / Evidence
- jest (i18n-syntax + portal-legacy-redirects): 17 passed — confirms settings.html parses & i18n wiring intact
- Playwright BEFORE/AFTER screenshots (desktop 1280x800 + mobile 390x844) showing the new collapsible header + chevron + expanded body; toggle/sliders verified working inside body; 0 console errors from the change
- `git diff --stat`: only `backend/public/portal/settings.html` (43 insertions, 7 deletions)

## Out of scope
Other settings cards; deep-link focus map (no `usage-warning` focus key exists today).

## User POV
Settings page is less cluttered; 用量警告 now collapses/expands like its sibling sections, with state remembered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)