### PR TITLE
fix(agent-card): thread deviceSecret into AgentCardEditor.save() — name-card save 400

### DIFF
--- a/backend/public/portal/card-holder.html
+++ b/backend/public/portal/card-holder.html
@@ -1146,6 +1146,7 @@
                 var chEditor = new AgentCardEditor('aceEditorCH', {
                     entityId: card.entityId,
                     deviceId: currentUser?.deviceId || currentUser?.device_id || '',
+                    deviceSecret: currentUser?.deviceSecret,
                     publicCode: card.publicCode,
                     identity: card.identity || {},
                     agentCard: ac,

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -3699,6 +3699,7 @@
                     var editor = new AgentCardEditor('aceEditor' + entityId, {
                         entityId: entityId,
                         deviceId: currentUser?.deviceId || currentUser?.device_id || '',
+                        deviceSecret: currentUser?.deviceSecret,
                         publicCode: thisEntity.publicCode || '',
                         identity: identity,
                         agentCard: pub,

--- a/backend/public/portal/shared/agent-card-editor.js
+++ b/backend/public/portal/shared/agent-card-editor.js
@@ -10,7 +10,7 @@
  *
  * Usage:
  *   const editor = new AgentCardEditor(containerId, {
- *       entityId, deviceId, publicCode, identity, agentCard, isOwner
+ *       entityId, deviceId, deviceSecret, publicCode, identity, agentCard, isOwner
  *   });
  *   editor.render();
  *   editor.save();  // called by save button
@@ -38,6 +38,8 @@ window.AgentCardEditor = (function() {
      * @param {Object} opts
      * @param {number} opts.entityId
      * @param {string} opts.deviceId
+     * @param {string} opts.deviceSecret — owner auth for PUT /api/entity/agent-card
+     * @param {string} [opts.botSecret] — alternative auth (bot self-edit)
      * @param {string} opts.publicCode
      * @param {Object} opts.identity — full identity JSONB (may have interviewCapabilities)
      * @param {Object} opts.agentCard — identity.public or agentCard object
@@ -48,6 +50,8 @@ window.AgentCardEditor = (function() {
         this.containerId = containerId;
         this.entityId = opts.entityId;
         this.deviceId = opts.deviceId;
+        this.deviceSecret = opts.deviceSecret;
+        this.botSecret = opts.botSecret;
         this.publicCode = opts.publicCode;
         this.identity = opts.identity || {};
         this.ac = opts.agentCard || {};
@@ -441,11 +445,17 @@ window.AgentCardEditor = (function() {
     AgentCardEditor.prototype.save = async function() {
         var data = this.collect();
         try {
-            var res = await apiCall('PUT', '/api/entity/agent-card', {
+            var body = {
                 deviceId: this.deviceId,
                 entityId: this.entityId,
                 agentCard: data,
-            });
+            };
+            // Auth: backend requires deviceSecret (owner) or botSecret.
+            // Without one, PUT /api/entity/agent-card 400s with
+            // "deviceSecret or botSecret required" (name-card save bug).
+            if (this.deviceSecret) body.deviceSecret = this.deviceSecret;
+            if (this.botSecret) body.botSecret = this.botSecret;
+            var res = await apiCall('PUT', '/api/entity/agent-card', body);
             if (res && res.success) {
                 if (typeof showToast === 'function') showToast(t('dash_id_saved', 'Saved'), 'success');
                 this.onSave(data);

--- a/backend/tests/jest/agent-card-editor-save-auth.test.js
+++ b/backend/tests/jest/agent-card-editor-save-auth.test.js
@@ -1,0 +1,101 @@
+/**
+ * card_2e65c220dc43fde62a1957e9 — name-card (card-holder) save 400 bug.
+ *
+ * Repro: AgentCardEditor.save() PUT /api/entity/agent-card omitted
+ * deviceSecret → backend (index.js PUT handler) returned
+ * 400 "deviceSecret or botSecret required".
+ *
+ * Fix: constructor threads opts.deviceSecret/opts.botSecret, save() puts
+ * them into the request body. Call sites (card-holder.html, dashboard.html)
+ * pass currentUser.deviceSecret.
+ *
+ * This suite asserts:
+ *  1. save() includes deviceSecret in the PUT body when provided.
+ *  2. save() falls back to botSecret when only that is provided.
+ *  3. both editor call sites pass deviceSecret into the constructor.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const vm = require('vm');
+
+const PORTAL = path.join(__dirname, '..', '..', 'public', 'portal');
+const EDITOR_SRC = path.join(PORTAL, 'shared', 'agent-card-editor.js');
+
+function loadEditor(apiCallStub) {
+    const src = fs.readFileSync(EDITOR_SRC, 'utf8');
+    const ctx = {
+        window: { AgentCardEditor: null },
+        document: {
+            createElement: () => ({ style: {}, textContent: '', innerHTML: '', appendChild() {} }),
+            getElementById: () => null,
+        },
+        apiCall: apiCallStub,
+        showToast: () => {},
+        console: { error: () => {}, log: () => {}, warn: () => {} },
+        Math, Date, JSON, encodeURIComponent, decodeURIComponent,
+    };
+    vm.createContext(ctx);
+    vm.runInContext(src, ctx, { filename: 'agent-card-editor.js' });
+    return ctx.window.AgentCardEditor;
+}
+
+describe('AgentCardEditor.save() auth (card_2e65c220)', () => {
+    function makeEditor(opts, captured) {
+        const AgentCardEditor = loadEditor(async (method, url, body) => {
+            captured.method = method;
+            captured.url = url;
+            captured.body = body;
+            return { success: true, agentCard: body.agentCard };
+        });
+        const ed = new AgentCardEditor('container', opts);
+        // Bypass DOM-dependent collect() with a deterministic payload.
+        ed.collect = () => ({ description: 'd', protocols: [], tags: [], version: '1.0.0', website: '', contactEmail: '' });
+        return ed;
+    }
+
+    test('includes deviceSecret in PUT body', async () => {
+        const captured = {};
+        const ed = makeEditor({ entityId: 2, deviceId: 'dev-1', deviceSecret: 'SECRET_DS' }, captured);
+        await ed.save();
+        expect(captured.method).toBe('PUT');
+        expect(captured.url).toBe('/api/entity/agent-card');
+        expect(captured.body.deviceSecret).toBe('SECRET_DS');
+        expect(captured.body.deviceId).toBe('dev-1');
+        expect(captured.body.entityId).toBe(2);
+    });
+
+    test('falls back to botSecret when only botSecret provided', async () => {
+        const captured = {};
+        const ed = makeEditor({ entityId: 2, deviceId: 'dev-1', botSecret: 'SECRET_BS' }, captured);
+        await ed.save();
+        expect(captured.body.botSecret).toBe('SECRET_BS');
+        expect(captured.body.deviceSecret).toBeUndefined();
+    });
+
+    test('REGRESSION: no auth → body would 400 (neither secret present)', async () => {
+        // Documents the original bug shape: with no secret the body carries
+        // neither field, which the backend rejects with
+        // "deviceSecret or botSecret required".
+        const captured = {};
+        const ed = makeEditor({ entityId: 2, deviceId: 'dev-1' }, captured);
+        await ed.save();
+        expect(captured.body.deviceSecret).toBeUndefined();
+        expect(captured.body.botSecret).toBeUndefined();
+    });
+});
+
+describe('AgentCardEditor call sites pass deviceSecret', () => {
+    const PAGES = ['card-holder.html', 'dashboard.html'];
+    for (const page of PAGES) {
+        test(`${page} passes deviceSecret into new AgentCardEditor`, () => {
+            const content = fs.readFileSync(path.join(PORTAL, page), 'utf8');
+            const idx = content.indexOf('new AgentCardEditor');
+            expect(idx).toBeGreaterThan(-1);
+            // Inspect the constructor opts object literal (next ~400 chars).
+            const slice = content.slice(idx, idx + 600);
+            expect(slice).toMatch(/deviceSecret:\s*currentUser/);
+        });
+    }
+});


### PR DESCRIPTION
## Problem
Editing a bot's agent-card (name-card / card-holder) fields and saving failed with **400 "deviceSecret or botSecret required"**.

The shared component `backend/public/portal/shared/agent-card-editor.js` received `deviceId` + `publicCode` but **not** `deviceSecret`. Its `save()` did `PUT /api/entity/agent-card` without any auth secret, so the backend handler (`index.js`, `if (!deviceSecret && !botSecret) → 400`) rejected it. The card-holder.html *fallback* `saveAgentCard()` passed `deviceSecret`, but the primary path `window._chEditor.save()` (the shared editor) did not. `dashboard.html`'s identity editor had the same latent bug.

## Fix
- `shared/agent-card-editor.js`: constructor accepts `opts.deviceSecret` (+ `opts.botSecret` as alternative); `save()` includes whichever is present in the PUT body.
- `card-holder.html` (~L1146): pass `deviceSecret: currentUser?.deviceSecret` into `new AgentCardEditor(...)`.
- `dashboard.html` (~L3699): same fix for the identity editor.
- No backend change needed — the PUT already accepts `deviceSecret`.

## Tests
- New `backend/tests/jest/agent-card-editor-save-auth.test.js`:
  - `save()` includes `deviceSecret` in PUT body
  - falls back to `botSecret` when only that is provided
  - regression doc: no-auth body (original bug shape)
  - both call sites pass `deviceSecret` into the constructor
- Full `tests/jest` suite green: **336 suites, 4688 passed, 17 skipped, 0 failed**.

## Verification
Harness loading the **real fixed editor** + a faithful mock of the backend auth gate, driven via Playwright at 1280x800 + 390x844:
- **BEFORE** (no deviceSecret): `PUT … deviceSecret present: false → 400 "deviceSecret or botSecret required"` (error toast) — reproduced.
- **AFTER** (deviceSecret threaded): `PUT … deviceSecret present: true → 200 success` (success toast) — fixed.
- Console errors on the editor page: **0**.

card_2e65c220dc43fde62a1957e9

🤖 Generated with [Claude Code](https://claude.com/claude-code)