### PR TITLE
fix(workspace): wire Bot 市集 top-nav in split mode

### DIFF
--- a/backend/public/portal/workspace.html
+++ b/backend/public/portal/workspace.html
@@ -144,6 +144,7 @@
         'kanban':      { href: 'kanban.html',       icon: '📋', label: 'Kanban',     i18nKey: 'nav_kanban' },
         'card-holder': { href: 'card-holder.html',  icon: '🗂️', label: 'Cards',     i18nKey: 'nav_card_holder' },
         'community':   { href: 'community.html',    icon: '🏪', label: 'Community',  i18nKey: 'nav_community' },
+        'marketplace': { href: 'marketplace.html',  icon: '🤝', label: 'Marketplace', i18nKey: 'nav_marketplace' },
         'settings':    { href: 'settings.html',     icon: '⚙️', label: 'Settings',  i18nKey: 'nav_settings' },
         'info':        { href: 'info.html',         icon: '📖', label: 'Info',       i18nKey: 'nav_info' },
         'admin':       { href: 'admin.html',        icon: '🔒', label: 'Admin',      i18nKey: 'nav_admin' }


### PR DESCRIPTION
## Card
card_afb70726724bb169b8494abd

## Root cause (Part 1)
Split-view shell `backend/public/portal/workspace.html` intercepts top-nav clicks (`document.querySelectorAll('.nav-link')` → `handleNavClick(pageIdFromHref(href))`). `handleNavClick` early-returns on `if (!PAGES[pageId]) return;`.

`nav.js` renders a **"Bot 市集" (marketplace → marketplace.html)** link, but the workspace-local `PAGES` table had **no `marketplace` entry** (it had `community` but not `marketplace`). So `pageIdFromHref('marketplace.html')` → `'marketplace'` → `PAGES['marketplace']` undefined → `handleNavClick` returns immediately → **silent no-op**, unlike Chat / Kanban / Community.

## Fix
Add the missing `marketplace` entry to the `PAGES` table (1 line):
```js
'marketplace': { href: 'marketplace.html', icon: '🤝', label: 'Marketplace', i18nKey: 'nav_marketplace' },
```
- `nav_marketplace` i18n key ("Bot 市集") already exists in all 7 locales — no new strings.
- Clicking Bot 市集 in split mode now opens a marketplace pane, consistent with other top-nav items and the PR #3459 pattern (resolve target pane, no dup pane, sibling panes preserved).

## E2E (reproduce-before/after)
| | panes after clicking Bot 市集 | marketplace pane |
|---|---|---|
| BEFORE (origin/main) | 2 (unchanged) | ❌ false — no-op bug |
| AFTER desktop | 3 | ✅ opened |
| AFTER mobile | active pane | ✅ opened |

App console errors attributable to the change: **0** (the only 404 is `/shared-core/route-registry.js`, a harness-only absolute path absent from the static test server; present in production).

jest: **336 suites / 4689 tests pass** (17 skipped, 0 failed).

## Scope
`git diff --stat`: `backend/public/portal/workspace.html | 1 +` (1 file, 1 insertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)