### PR TITLE
feat(settings): 被動健檢 passive-health UI wired to /api/passive-health + manifest

### DIFF
--- a/backend/lib/settings-manifest.js
+++ b/backend/lib/settings-manifest.js
@@ -158,6 +158,16 @@ const FEATURES = [
         minAppVersion: { android: '0.0.0', ios: '0.0.0' },
     },
     {
+        key: 'passive_health',
+        name: 'Passive Health-Check',
+        enabled: true,
+        // Web-only today: settings.html section wired to /api/passive-health.
+        // native:false → app surfaces it via WebView focus=passive_health until a
+        // native screen ships (card_a346b317920f6daf017c83e7).
+        native: { android: false, ios: false },
+        minAppVersion: { android: '0.0.0', ios: '0.0.0' },
+    },
+    {
         key: 'wallet',
         name: 'Wallet',
         enabled: true,

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -1432,6 +1432,65 @@
             </div>
         </div>
 
+        <!-- Passive Health-Check Card (card_a346b317920f6daf017c83e7) -->
+        <div class="card" id="passive-health-card">
+            <div class="notif-header" role="button" tabindex="0" aria-expanded="false"
+                 aria-controls="passiveHealthContent" id="passiveHealthHeader"
+                 onclick="togglePassiveHealthSection()"
+                 onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();togglePassiveHealthSection();}">
+                <div class="card-title" style="margin-bottom:0;display:flex;align-items:center;gap:8px;">
+                    <span>🩺 <span data-i18n="passive_health_title">Passive Health-Check</span></span>
+                    <span class="help-icon" data-help-content-key="passive_health_section_help"></span>
+                </div>
+                <span class="expand-arrow" id="passiveHealthArrow">&#9662;</span>
+            </div>
+
+            <div class="notif-content" id="passiveHealthContent">
+            <p class="section-desc" data-i18n="passive_health_desc">Passive health-check periodically inspects your agents' health on the interval you set, with optional auto-repair; off by default.</p>
+
+            <!-- HELP-KEY: passive_health_enable_help -->
+            <div class="setting-row" style="margin-top:8px;">
+                <span class="setting-row-label">
+                    <span data-i18n="passive_health_enable_label">Enable passive health-check</span>
+                    <span class="help-icon" data-help-content-key="passive_health_enable_help"></span>
+                </span>
+                <label class="toggle-switch">
+                    <input type="checkbox" id="togglePassiveHealth" aria-label="Enable passive health-check"
+                           onchange="onPassiveHealthEnabledChange(this.checked)">
+                    <span class="toggle-slider" aria-hidden="true"></span>
+                </label>
+            </div>
+
+            <!-- HELP-KEY: passive_health_interval_help -->
+            <div class="setting-row" id="passiveHealthIntervalRow" style="flex-direction:column;align-items:stretch;gap:6px;">
+                <span class="setting-row-label" style="display:flex;justify-content:space-between;align-items:center;">
+                    <span>
+                        <span data-i18n="passive_health_interval_label">Check interval (hours)</span>
+                        <span class="help-icon" data-help-content-key="passive_health_interval_help"></span>
+                    </span>
+                    <span id="passiveHealthIntervalValue" style="font-variant-numeric:tabular-nums;color:var(--text-secondary);">6h</span>
+                </span>
+                <input type="range" id="passiveHealthIntervalSlider" aria-label="Passive health-check interval in hours" min="1" max="168" step="1" value="6"
+                       oninput="onPassiveHealthIntervalInput(this.value)"
+                       onchange="savePassiveHealthSettings()"
+                       style="width:100%;">
+            </div>
+
+            <!-- HELP-KEY: passive_health_auto_repair_help -->
+            <div class="setting-row" id="passiveHealthAutoRepairRow">
+                <span class="setting-row-label">
+                    <span data-i18n="passive_health_auto_repair_label">Auto-repair</span>
+                    <span class="help-icon" data-help-content-key="passive_health_auto_repair_help"></span>
+                </span>
+                <label class="toggle-switch">
+                    <input type="checkbox" id="togglePassiveHealthAutoRepair" aria-label="Enable auto-repair"
+                           onchange="savePassiveHealthSettings()">
+                    <span class="toggle-slider" aria-hidden="true"></span>
+                </label>
+            </div>
+            </div><!-- /.notif-content #passiveHealthContent -->
+        </div>
+
         <!-- Wallet Card -->
         <div class="card" style="cursor:pointer;" onclick="(window.SmartRouter&&window.SmartRouter.navigate('wallet'))||(window.location.href='wallet.html')">
             <div class="card-title">
@@ -1731,6 +1790,8 @@
             loadPromptPolicy(user);
             initKanbanNudgeCollapse();
             initUsageWarningCollapse();
+            initPassiveHealthCollapse();
+            loadPassiveHealthSettings();
             updatePushToggle();
 
             document.getElementById('pageContent').style.display = '';
@@ -2805,6 +2866,146 @@
                 // /api/usage/snapshot may 401 on app webview without device-login —
                 // treat as "unknown" and stay hidden rather than false-alarming.
                 notice.style.display = 'none';
+            }
+        }
+
+        // ============================================
+        // PASSIVE HEALTH-CHECK (card_a346b317920f6daf017c83e7)
+        // Wired to the existing /api/passive-health/settings GET/PUT.
+        // Auth = deviceId + deviceSecret query params (authDevice on the API),
+        // not the cookie auth that apiCall uses — so we fetch directly with the
+        // current user's device credentials (same pattern as AvatarPetdx).
+        // ============================================
+        const PASSIVE_HEALTH_DEFAULTS = { enabled: false, intervalHours: 6, autoRepair: true };
+        // Snapshot of the last-known full settings so a partial PUT never
+        // clobbers a sibling field (the API does a partial patch, but sending
+        // the full current object is the simplest partial-safe contract).
+        let _passiveHealthSettings = { ...PASSIVE_HEALTH_DEFAULTS };
+
+        const PASSIVE_HEALTH_COLLAPSE_KEY = 'settings_passive_health_collapsed';
+        function togglePassiveHealthSection() {
+            const content = document.getElementById('passiveHealthContent');
+            const arrow = document.getElementById('passiveHealthArrow');
+            const header = document.getElementById('passiveHealthHeader');
+            const expanded = !content.classList.contains('visible');
+            content.classList.toggle('visible', expanded);
+            arrow.classList.toggle('expanded', expanded);
+            if (header) header.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+            try { localStorage.setItem(PASSIVE_HEALTH_COLLAPSE_KEY, expanded ? '0' : '1'); } catch (_) { }
+        }
+        function initPassiveHealthCollapse() {
+            // Default collapsed. Only expand if user explicitly opened it before.
+            let collapsed = '1';
+            try { collapsed = localStorage.getItem(PASSIVE_HEALTH_COLLAPSE_KEY) || '1'; } catch (_) { }
+            if (collapsed === '0') {
+                document.getElementById('passiveHealthContent').classList.add('visible');
+                document.getElementById('passiveHealthArrow').classList.add('expanded');
+                const header = document.getElementById('passiveHealthHeader');
+                if (header) header.setAttribute('aria-expanded', 'true');
+            }
+        }
+
+        function passiveHealthAuthQuery() {
+            const u = (typeof currentUser !== 'undefined' && currentUser) ? currentUser : {};
+            const deviceId = u.deviceId || '';
+            const deviceSecret = u.deviceSecret || '';
+            return 'deviceId=' + encodeURIComponent(deviceId) + '&deviceSecret=' + encodeURIComponent(deviceSecret);
+        }
+
+        // Grey out / disable the interval + auto-repair controls when the
+        // feature is OFF, so it's clear they have no effect until enabled.
+        function applyPassiveHealthEnabledUI(enabled) {
+            const slider = document.getElementById('passiveHealthIntervalSlider');
+            const autoRepair = document.getElementById('togglePassiveHealthAutoRepair');
+            const intervalRow = document.getElementById('passiveHealthIntervalRow');
+            const autoRow = document.getElementById('passiveHealthAutoRepairRow');
+            if (slider) slider.disabled = !enabled;
+            if (autoRepair) autoRepair.disabled = !enabled;
+            [intervalRow, autoRow].forEach((row) => {
+                if (row) row.style.opacity = enabled ? '1' : '0.5';
+            });
+        }
+
+        function applyPassiveHealthSettings(s) {
+            const settings = { ...PASSIVE_HEALTH_DEFAULTS, ...(s || {}) };
+            _passiveHealthSettings = {
+                enabled: settings.enabled !== false ? !!settings.enabled : false,
+                intervalHours: Math.max(1, Math.min(168, Math.round(Number(settings.intervalHours)) || PASSIVE_HEALTH_DEFAULTS.intervalHours)),
+                autoRepair: settings.autoRepair !== false,
+            };
+            const toggle = document.getElementById('togglePassiveHealth');
+            const slider = document.getElementById('passiveHealthIntervalSlider');
+            const value = document.getElementById('passiveHealthIntervalValue');
+            const autoRepair = document.getElementById('togglePassiveHealthAutoRepair');
+            if (toggle) toggle.checked = _passiveHealthSettings.enabled;
+            if (slider) slider.value = _passiveHealthSettings.intervalHours;
+            if (value) value.textContent = _passiveHealthSettings.intervalHours + 'h';
+            if (autoRepair) autoRepair.checked = _passiveHealthSettings.autoRepair;
+            applyPassiveHealthEnabledUI(_passiveHealthSettings.enabled);
+        }
+
+        async function loadPassiveHealthSettings() {
+            try {
+                const resp = await fetch(API_BASE + '/api/passive-health/settings?' + passiveHealthAuthQuery(), {
+                    method: 'GET',
+                    credentials: 'include',
+                });
+                const data = await resp.json().catch(() => ({}));
+                if (resp.ok && data && data.success && data.settings) {
+                    applyPassiveHealthSettings(data.settings);
+                } else {
+                    applyPassiveHealthSettings(PASSIVE_HEALTH_DEFAULTS);
+                }
+            } catch (e) {
+                // Non-fatal: show defaults so the controls still render.
+                applyPassiveHealthSettings(PASSIVE_HEALTH_DEFAULTS);
+            }
+        }
+
+        function getPassiveHealthSettingsFromUI() {
+            const enabled = document.getElementById('togglePassiveHealth')?.checked === true;
+            const iv = parseInt(document.getElementById('passiveHealthIntervalSlider')?.value, 10);
+            const autoRepair = document.getElementById('togglePassiveHealthAutoRepair')?.checked === true;
+            return {
+                enabled,
+                intervalHours: Number.isFinite(iv) ? Math.max(1, Math.min(168, iv)) : _passiveHealthSettings.intervalHours,
+                autoRepair,
+            };
+        }
+
+        function onPassiveHealthIntervalInput(value) {
+            const el = document.getElementById('passiveHealthIntervalValue');
+            if (el) el.textContent = value + 'h';
+        }
+
+        async function onPassiveHealthEnabledChange(checked) {
+            // Reflect the disabled-state of dependent controls immediately, then persist.
+            applyPassiveHealthEnabledUI(checked);
+            await savePassiveHealthSettings();
+        }
+
+        async function savePassiveHealthSettings() {
+            // Send the FULL current {enabled,intervalHours,autoRepair} so a change
+            // to one control never clobbers the siblings (partial-safe).
+            const body = getPassiveHealthSettingsFromUI();
+            try {
+                const resp = await fetch(API_BASE + '/api/passive-health/settings?' + passiveHealthAuthQuery(), {
+                    method: 'PUT',
+                    credentials: 'include',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify(body),
+                });
+                const data = await resp.json().catch(() => ({}));
+                if (resp.ok && data && data.success && data.settings) {
+                    applyPassiveHealthSettings(data.settings);
+                    if (typeof showToast === 'function') showToast(i18n.t('common_saved') || 'Saved', 'success');
+                } else {
+                    throw new Error((data && data.error) || ('HTTP ' + resp.status));
+                }
+            } catch (e) {
+                if (typeof showToast === 'function') showToast(i18n.t('toast_preference_update_failed') || 'Update failed', 'error');
+                // Re-sync UI back to the last-known-good settings on failure.
+                applyPassiveHealthSettings(_passiveHealthSettings);
             }
         }
 

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650343,6 +650343,16 @@ const TRANSLATIONS = {
 
         "org_options_title": "Hierarchy behavior",
         "org_routing_escalation_help": "In the org hierarchy, a message addressed to a subordinate entity is NOT answered immediately by the supervisor. Only if the subordinate stays silent past a timeout (default ~30 min) does it escalate to the superior to take over. Broadcasts or messages that @-mention the supervisor directly are exempt.",
+
+        "passive_health_title": "Passive Health-Check",
+        "passive_health_desc": "Passive health-check periodically inspects your agents' health on the interval you set, with optional auto-repair; off by default.",
+        "passive_health_section_help": "Passive health-check periodically inspects your agents' health on the interval you set, with optional auto-repair; off by default.",
+        "passive_health_enable_label": "Enable passive health-check",
+        "passive_health_enable_help": "When on, the backend inspects each channel-bound agent's health on your chosen interval using signals it already has — no chat message is sent and no model turn is used.",
+        "passive_health_interval_label": "Check interval (hours)",
+        "passive_health_interval_help": "How often the passive sweep runs, in hours (1–168). Only takes effect when passive health-check is enabled.",
+        "passive_health_auto_repair_label": "Auto-repair",
+        "passive_health_auto_repair_help": "When an agent is found unhealthy, automatically run the existing self-repair flow (up to 3 attempts) before filing a bug. Only takes effect when passive health-check is enabled.",
 },
 
 
@@ -1235147,6 +1235157,16 @@ const TRANSLATIONS = {
 
         "org_options_title": "层级行为",
         "org_routing_escalation_help": "组织阶层中,发给子实体的讯息,主管不会即时抢答;只有子实体逾时静默(预设约 30 分钟)未回应时,才会升级给上层主管接手。broadcast 或直接 @主管 的讯息不受此限。",
+
+        "passive_health_title": "被動健檢",
+        "passive_health_desc": "被動健檢會依設定週期自動檢查智能體健康狀態,可選擇自動修復;預設關閉。",
+        "passive_health_section_help": "被動健檢會依設定週期自動檢查智能體健康狀態,可選擇自動修復;預設關閉。",
+        "passive_health_enable_label": "啟用被動健檢",
+        "passive_health_enable_help": "開啟後,後端會依你設定的週期,用既有的訊號檢查每個頻道綁定智能體的健康狀態 — 不會送出聊天訊息,也不會消耗模型回合。",
+        "passive_health_interval_label": "健檢週期(小時)",
+        "passive_health_interval_help": "被動健檢執行的頻率,以小時計(1–168)。僅在啟用被動健檢後才會生效。",
+        "passive_health_auto_repair_label": "自動修復",
+        "passive_health_auto_repair_help": "當偵測到智能體不健康時,自動執行既有的自我修復流程(最多 3 次),仍失敗才回報問題。僅在啟用被動健檢後才會生效。",
 },
 
 

--- a/backend/tests/jest/settings-manifest.test.js
+++ b/backend/tests/jest/settings-manifest.test.js
@@ -50,9 +50,9 @@ describe('buildSettingsManifest() — structure', () => {
         const expected = [
             'account_identity', 'channel_api', 'subscription', 'invite', 'language',
             'display', 'chat_prefs', 'rental_management', 'notifications',
-            'developer_broadcast', 'agent_policy', 'kanban_nudge', 'wallet',
-            'my_rentals', 'files', 'companion_petdx', 'feedback', 'rotate_secret',
-            'switch_device', 'logout',
+            'developer_broadcast', 'agent_policy', 'kanban_nudge', 'passive_health',
+            'wallet', 'my_rentals', 'files', 'companion_petdx', 'feedback',
+            'rotate_secret', 'switch_device', 'logout',
         ];
         for (const k of expected) expect(keys).toContain(k);
         expect(keys.length).toBe(expected.length);
@@ -97,7 +97,7 @@ describe('buildSettingsManifest() — platform handling', () => {
 
 describe('drift list — HIGH/MED features are web-only on both platforms', () => {
     for (const platform of SUPPORTED_PLATFORMS) {
-        for (const key of ['rotate_secret', 'switch_device', 'rental_management', 'agent_policy', 'kanban_nudge']) {
+        for (const key of ['rotate_secret', 'switch_device', 'rental_management', 'agent_policy', 'kanban_nudge', 'passive_health']) {
             it(`${key} is native:false on ${platform}`, () => {
                 const f = buildSettingsManifest('1.0.0', platform).features.find((x) => x.key === key);
                 expect(f.native).toBe(false);


### PR DESCRIPTION
## Scope
Adds a collapsible **被動健檢 / Passive Health-Check** section to the portal Settings page, wired to the **existing** backend `GET/PUT /api/passive-health/settings`. No backend API change. Card `card_a346b317920f6daf017c83e7`.

## Controls (settings.html)
- **啟用被動健檢** — `.toggle-switch` → `enabled`
- **健檢週期 (小時)** — range slider 1–168 with live `Nh` value label, clamped → `intervalHours`
- **自動修復** — `.toggle-switch` → `autoRepair`
- canonical `.help-icon` (`data-help-content-key`) on the section header + each control
- Collapsible (default collapsed, localStorage persisted) matching the 用量警告 pattern (PR #3470)

## Behaviour
- **Load**: `GET /api/passive-health/settings?deviceId&deviceSecret` (creds from `currentUser`, since the API uses `authDevice` query-param auth, not cookie `apiCall`) → reflects `enabled / intervalHours / autoRepair`.
- **Change**: PUTs the **full current** `{enabled,intervalHours,autoRepair}` so a single-control change never clobbers siblings (partial-safe; mirrors the backend partial-patch contract). Saved toast on success; UI re-syncs to last-known-good on failure.
- Interval + auto-repair controls are **greyed + disabled** while `enabled` is off.

## i18n
9 new keys × EN + ZH (zh = Traditional) inserted via the **AST** script `i18n-insert-locale-keys.js` (never regex). **zh-TW intentionally NOT added** → falls back to zh, keeping the fallback-chain test <100.
Keys: `passive_health_title`, `passive_health_desc`, `passive_health_section_help`, `passive_health_enable_label`, `passive_health_enable_help`, `passive_health_interval_label`, `passive_health_interval_help`, `passive_health_auto_repair_label`, `passive_health_auto_repair_help`.

## Manifest
New `passive_health` feature in `lib/settings-manifest.js` (`native:false` both platforms, `enabled:true`, `webFallback=…?focus=passive_health`) so the app auto-surfaces it via WebView per the PR #3464 contract. Manifest jest updated for the new key + count + drift-list coverage.

## Test plan / Evidence
- `settings-manifest`, `i18n-fallback-chain`, `i18n-syntax`, `i18n-lint-dup-keys`, `kanban-i18n-zh-tw-alias` → **69 passed** (log attached to card).
- E2E render (mock-served worktree build, desktop 1280x800 + mobile 390x844): section expanded showing all controls + help icons, **load reflecting backend values** (enabled, 12h, auto-repair on). **0 JS console errors** (only 2 environment 404s for socket.io / route-registry not served by the mock).

## Out of scope
Native app screens (Stage 2), settings-deep-link FOCUS_MAP entry (full-page fallback already works).

## User POV
Users can now turn on periodic passive health-checking of their agents, set how often it runs, and opt into auto-repair — directly from Settings, with a ? explaining what it does and that it's off by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)