### PR TITLE
fix(workspace/nav): wire 邀請 split-nav + correct swapped 社群/市集 icons

### DIFF
--- a/backend/public/portal/shared/nav.js
+++ b/backend/public/portal/shared/nav.js
@@ -13,8 +13,8 @@ function renderNav(activePage) {
         { id: 'kanban', i18nKey: 'nav_kanban', label: 'Kanban', href: 'kanban.html', icon: '📋' },
         { id: 'card-holder', i18nKey: 'nav_card_holder', label: 'Cards', href: 'card-holder.html', icon: '🗂️' },
         { id: 'invite', i18nKey: 'nav_invite', label: 'Invite Friends', href: 'invite.html', icon: '🎁' },
-        { id: 'community', i18nKey: 'nav_community', label: 'Community', href: 'community.html', icon: '🏪' },
-        { id: 'marketplace', i18nKey: 'nav_marketplace', label: 'Marketplace', href: 'marketplace.html', icon: '🤝' },
+        { id: 'community', i18nKey: 'nav_community', label: 'Community', href: 'community.html', icon: '🤝' },
+        { id: 'marketplace', i18nKey: 'nav_marketplace', label: 'Marketplace', href: 'marketplace.html', icon: '🏪' },
         { id: 'settings', i18nKey: 'nav_settings', label: 'Settings', href: 'settings.html', icon: '⚙️' },
         { id: 'info', i18nKey: 'nav_info', label: 'Info', href: 'info.html', icon: '📖' }
     ];

--- a/backend/public/portal/workspace.html
+++ b/backend/public/portal/workspace.html
@@ -143,6 +143,7 @@
         'mission':     { href: 'mission.html',      icon: '🚀', label: 'Mission',    i18nKey: 'nav_mission' },
         'kanban':      { href: 'kanban.html',       icon: '📋', label: 'Kanban',     i18nKey: 'nav_kanban' },
         'card-holder': { href: 'card-holder.html',  icon: '🗂️', label: 'Cards',     i18nKey: 'nav_card_holder' },
+        'invite':      { href: 'invite.html',       icon: '🎁', label: 'Invite Friends', i18nKey: 'nav_invite' },
         'community':   { href: 'community.html',    icon: '🏪', label: 'Community',  i18nKey: 'nav_community' },
         'marketplace': { href: 'marketplace.html',  icon: '🤝', label: 'Marketplace', i18nKey: 'nav_marketplace' },
         'settings':    { href: 'settings.html',     icon: '⚙️', label: 'Settings',  i18nKey: 'nav_settings' },


### PR DESCRIPTION
## Scope
Two small nav fixes in the EClaw split-view shell. Card: card_5508c545537434c759ab7e23

### FIX 1 — invite split-nav no-op (same root cause as #3473)
`backend/public/portal/workspace.html` intercepts top-nav clicks via `handleNavClick(pageIdFromHref(href))`, which early-returns on `if (!PAGES[pageId]) return;`. nav.js renders an 邀請/Invite link (invite.html) but the workspace-local PAGES table had **no `invite` entry** → clicking 邀請 in split mode was a silent no-op. Added the 1-line PAGES entry (invite.html + existing `nav_invite` i18n key), matching #3473's pattern.

### FIX 2 — swapped nav icons
In `backend/public/portal/shared/nav.js` the 社群 (community) and 市集 (marketplace) icons were semantically reversed: community=🏪 (shop), marketplace=🤝 (handshake). Swapped to community=🤝, marketplace=🏪. Only these two icons touched.

## Evidence
- BEFORE (desktop): PAGES has no invite → `handleNavClick('invite')` early-returns (no-op); community=🏪 / marketplace=🤝.
- AFTER (desktop+mobile): clicking 邀請 opens a 🎁 Invite Friends pane (panes 2→3, real `handleNavClick` exercised); community=🤝 / marketplace=🏪.
- Console: 0 errors from nav.js/workspace.html logic (only static-asset/API 404s from the backend-less local harness, present in BEFORE too).
- Screenshots uploaded to card via /file.

## Test plan
- jest suite run + log attached to card.

## Out of scope
- workspace.html PAGES community/marketplace icons left as-is (FIX 2 scoped to nav.js top-nav per card; PAGES icons only render pane-label tabs, top-nav is the user-visible bar).

## User POV
Users in split-view can now open the Invite Friends pane, and the Community/Marketplace nav icons match their meaning.

card_5508c545537434c759ab7e23

🤖 Generated with [Claude Code](https://claude.com/claude-code)