### PR TITLE
feat(git-author): Tier 1 per-entity git author identity + spec + prs_merged author-source

### DIFF
--- a/backend/entity-status.js
+++ b/backend/entity-status.js
@@ -13,6 +13,7 @@
 
 const express = require('express');
 const safeEqual = require('./safe-equal');
+const { entityGitEmail } = require('./scripts/entity-git-author');
 
 const CANONICAL_AXES = [
     'chat_no_reply',
@@ -535,6 +536,54 @@ function normalizePrKey(raw) {
     return num ? `#${num[0]}` : null;
 }
 
+// Per-entity git author identity → prs_merged author-source (Tier 1).
+// Spec: docs/specs/per-entity-git-author-spec.md (§6). The author-source counts
+// distinct PRs whose commits are authored/co-authored by entity-<N>@bots.eclaw,
+// UNION'd + deduped with the kanban-evidence path. Production wires this to a
+// read-only GitHub query using the EXISTING GITHUB_TOKEN; tests inject a mock.
+// Default is null (no author-source) so DB-only environments degrade silently to
+// the evidence path. Set via setPrAuthorSource().
+let _prAuthorSource = null;
+
+// resolver: async (entityEmail, { deviceId, entityId }) => Array<{ prKey?, owner?, repo?, number?, lastEventAt? }>
+// Each item must yield a normalized `owner/repo#N` (or `#N`) key — same key space
+// as extractPrKeys/normalizePrKey so cross-source duplicates collapse.
+function setPrAuthorSource(resolver) {
+    _prAuthorSource = (typeof resolver === 'function') ? resolver : null;
+}
+
+// Best-effort: never throws. Returns [] on ANY failure (no resolver injected,
+// GITHUB_TOKEN absent, GH unreachable/non-200, malformed payload, exception).
+// Items are normalized to { key, lastEventAt }.
+async function fetchAuthoredPrKeys(deviceId, entityId) {
+    if (!_prAuthorSource) return [];
+    try {
+        const email = entityGitEmail(entityId);
+        if (!email) return [];
+        const raw = await _prAuthorSource(email, { deviceId, entityId: Number(entityId) });
+        if (!Array.isArray(raw)) return [];
+        const out = [];
+        for (const item of raw) {
+            if (!item) continue;
+            let key = null;
+            if (item.prKey) {
+                key = String(item.prKey).toLowerCase();
+            } else if (item.owner && item.repo && item.number != null) {
+                key = `${String(item.owner).toLowerCase()}/${String(item.repo).toLowerCase()}#${item.number}`;
+            } else if (item.number != null) {
+                key = normalizePrKey(item.number);
+            }
+            if (key) out.push({ key, lastEventAt: item.lastEventAt || null });
+        }
+        return out;
+    } catch (err) {
+        // Graceful degrade — author-source contributes nothing, evidence path stands.
+        console.warn('[Achievements] prs_merged author-source failed (degrading to evidence path):',
+            err && err.message);
+        return [];
+    }
+}
+
 async function getAchievements(deviceId, entityId) {
     if (!pool) return [];
     const eid = Number(entityId);
@@ -643,6 +692,14 @@ async function getAchievements(deviceId, entityId) {
                 for (const row of rw.rows) {
                     const k = normalizePrKey(row.pr);
                     if (k) { seen.add(k); noteLast(row.updated_at); }
+                }
+                // 3) Author-source (Tier 1, spec §6): distinct PRs authored/co-
+                //    authored by entity-<N>@bots.eclaw. Best-effort — degrades to
+                //    [] on any failure, so the evidence path above always stands.
+                const authored = await fetchAuthoredPrKeys(deviceId, eid);
+                for (const a of authored) {
+                    seen.add(a.key);
+                    noteLast(a.lastEventAt);
                 }
                 count = seen.size;
                 lastEventAt = last;
@@ -1105,4 +1162,5 @@ module.exports = {
     CANONICAL_ACHIEVEMENTS,
     getAchievements,
     getAchievementEvents,
+    setPrAuthorSource,
 };

--- a/backend/scripts/entity-git-author.js
+++ b/backend/scripts/entity-git-author.js
@@ -1,0 +1,111 @@
+'use strict';
+
+/**
+ * Per-entity git author identity — Tier 1.
+ * Spec: docs/specs/per-entity-git-author-spec.md
+ * Card: card_35009109c256040aa91200bd
+ *
+ * Pure, dependency-light. Given a global entity id (and optionally the entity's
+ * display name) it derives the git author identity used to attribute commits /
+ * PRs to the real EClaw entity instead of only the shared merging account.
+ *
+ *   Email :  entity-<globalEntityId>@bots.eclaw   (always derivable from id alone)
+ *   Name  :  EClaw #<N> <displayName>             (displayName resolved per §4)
+ *   Author:  EClaw #<N> <displayName> <entity-<N>@bots.eclaw>
+ *
+ * Globe-user: no hardcoded entity/device — everything derives from the id +
+ * (optional) name passed in. Works for any entity on any device worldwide.
+ *
+ * CLI:  node entity-git-author.js <entityId>   → prints the author string.
+ */
+
+// Reserved, non-routable attribution domain (see spec §3). Not a real TLD; used
+// only as a stable join key for the prs_merged metric, never for mail.
+const EMAIL_DOMAIN = 'bots.eclaw';
+
+/**
+ * Normalize a global entity id to a non-negative integer, or null if invalid.
+ */
+function normalizeEntityId(entityId) {
+    // Reject null/undefined/'' up front — Number() coerces these to 0/NaN in
+    // ways that would silently mint a wrong identity.
+    if (entityId == null) return null;
+    if (typeof entityId === 'string' && entityId.trim() === '') return null;
+    const n = Number(entityId);
+    if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) return null;
+    return n;
+}
+
+/**
+ * Stable attribution email for an entity. Derivable from the id alone so the
+ * metric (§6) always has a join key even when no display name is on record.
+ * Returns null only for an invalid id.
+ */
+function entityGitEmail(entityId) {
+    const n = normalizeEntityId(entityId);
+    if (n === null) return null;
+    return `entity-${n}@${EMAIL_DOMAIN}`;
+}
+
+/**
+ * Resolve the display name for an entity (spec §4): explicit name → fallback
+ * `Entity <N>`. Caller passes whatever it already has (e.g. entity.name from
+ * the in-memory device record, or a codename); we never reach into a DB here so
+ * the function stays pure and dependency-light.
+ */
+function resolveDisplayName(entityId, name) {
+    const n = normalizeEntityId(entityId);
+    if (name != null) {
+        const trimmed = String(name).trim();
+        if (trimmed) return trimmed;
+    }
+    return `Entity ${n === null ? entityId : n}`;
+}
+
+/**
+ * Build the per-entity git author identity.
+ *
+ * @param {number|string} entityId  global entity id
+ * @param {{name?: string}} [opts]  optional display name (entity.name / codename)
+ * @returns {{name: string, email: string, authorString: string}}
+ * @throws {TypeError} if entityId is not a non-negative integer
+ */
+function entityGitAuthor(entityId, opts) {
+    const n = normalizeEntityId(entityId);
+    if (n === null) {
+        throw new TypeError(
+            `entityGitAuthor: entityId must be a non-negative integer, got ${JSON.stringify(entityId)}`
+        );
+    }
+    const displayName = resolveDisplayName(n, opts && opts.name);
+    const name = `EClaw #${n} ${displayName}`;
+    const email = `entity-${n}@${EMAIL_DOMAIN}`;
+    const authorString = `${name} <${email}>`;
+    return { name, email, authorString };
+}
+
+module.exports = {
+    EMAIL_DOMAIN,
+    entityGitAuthor,
+    entityGitEmail,
+    resolveDisplayName,
+    normalizeEntityId,
+};
+
+// ── CLI ───────────────────────────────────────────────────────────────────────
+// node entity-git-author.js <entityId> [displayName]
+// Prints the author string (e.g. for `git commit --author="$(...)"`).
+if (require.main === module) {
+    const [, , idArg, nameArg] = process.argv;
+    if (idArg == null) {
+        process.stderr.write('usage: node entity-git-author.js <entityId> [displayName]\n');
+        process.exit(2);
+    }
+    try {
+        const { authorString } = entityGitAuthor(idArg, nameArg != null ? { name: nameArg } : undefined);
+        process.stdout.write(authorString + '\n');
+    } catch (err) {
+        process.stderr.write(String((err && err.message) || err) + '\n');
+        process.exit(1);
+    }
+}

--- a/backend/tests/jest/entity-git-author.test.js
+++ b/backend/tests/jest/entity-git-author.test.js
@@ -1,0 +1,91 @@
+'use strict';
+
+/**
+ * Tests for the per-entity git author identity helper (Tier 1).
+ * Spec: docs/specs/per-entity-git-author-spec.md
+ * Card: card_35009109c256040aa91200bd
+ */
+
+const { execFileSync } = require('child_process');
+const path = require('path');
+const {
+    entityGitAuthor,
+    entityGitEmail,
+    resolveDisplayName,
+    normalizeEntityId,
+    EMAIL_DOMAIN,
+} = require('../../scripts/entity-git-author');
+
+const SCRIPT = path.join(__dirname, '..', '..', 'scripts', 'entity-git-author.js');
+
+describe('entity-git-author helper', () => {
+    test('email scheme is entity-<N>@bots.eclaw, derived from id alone', () => {
+        expect(EMAIL_DOMAIN).toBe('bots.eclaw');
+        expect(entityGitEmail(2)).toBe('entity-2@bots.eclaw');
+        expect(entityGitEmail(42)).toBe('entity-42@bots.eclaw');
+        expect(entityGitEmail('5')).toBe('entity-5@bots.eclaw');
+        // email derivable even with no name
+        expect(entityGitAuthor(7).email).toBe('entity-7@bots.eclaw');
+    });
+
+    test('author string for #2 matches the spec sample', () => {
+        const a = entityGitAuthor(2, { name: 'Mac_ClaudeAce主管' });
+        expect(a.name).toBe('EClaw #2 Mac_ClaudeAce主管');
+        expect(a.email).toBe('entity-2@bots.eclaw');
+        expect(a.authorString).toBe('EClaw #2 Mac_ClaudeAce主管 <entity-2@bots.eclaw>');
+    });
+
+    test('name format is EClaw #<N> <displayName>', () => {
+        expect(entityGitAuthor(5, { name: 'Hermes' }).name).toBe('EClaw #5 Hermes');
+        expect(entityGitAuthor(5, { name: 'Hermes' }).authorString)
+            .toBe('EClaw #5 Hermes <entity-5@bots.eclaw>');
+    });
+
+    test('falls back to "Entity <N>" when no name provided', () => {
+        const a = entityGitAuthor(42);
+        expect(a.name).toBe('EClaw #42 Entity 42');
+        expect(a.authorString).toBe('EClaw #42 Entity 42 <entity-42@bots.eclaw>');
+    });
+
+    test('blank / whitespace name falls back to "Entity <N>"', () => {
+        expect(entityGitAuthor(3, { name: '   ' }).name).toBe('EClaw #3 Entity 3');
+        expect(entityGitAuthor(3, { name: '' }).name).toBe('EClaw #3 Entity 3');
+        expect(resolveDisplayName(3, null)).toBe('Entity 3');
+        expect(resolveDisplayName(3, 'Mac_E')).toBe('Mac_E');
+    });
+
+    test('accepts numeric-string entity ids', () => {
+        expect(entityGitAuthor('2', { name: 'X' }).email).toBe('entity-2@bots.eclaw');
+    });
+
+    test('entity 0 is valid (non-negative)', () => {
+        expect(entityGitAuthor(0).authorString).toBe('EClaw #0 Entity 0 <entity-0@bots.eclaw>');
+    });
+
+    test('globe-user: no hardcoded entity — arbitrary high id works', () => {
+        const a = entityGitAuthor(99999, { name: 'Future Bot' });
+        expect(a.authorString).toBe('EClaw #99999 Future Bot <entity-99999@bots.eclaw>');
+    });
+
+    test.each([null, undefined, -1, 1.5, NaN, 'abc', {}])(
+        'throws TypeError on invalid id %p', (bad) => {
+            expect(() => entityGitAuthor(bad)).toThrow(TypeError);
+        }
+    );
+
+    test('normalizeEntityId / entityGitEmail return null on invalid id', () => {
+        expect(normalizeEntityId('abc')).toBeNull();
+        expect(normalizeEntityId(-1)).toBeNull();
+        expect(entityGitEmail('abc')).toBeNull();
+    });
+
+    test('CLI prints the author string for an entity id', () => {
+        const out = execFileSync('node', [SCRIPT, '2', 'Mac_ClaudeAce主管'], { encoding: 'utf8' });
+        expect(out.trim()).toBe('EClaw #2 Mac_ClaudeAce主管 <entity-2@bots.eclaw>');
+    });
+
+    test('CLI without a name falls back to Entity <N>', () => {
+        const out = execFileSync('node', [SCRIPT, '8'], { encoding: 'utf8' });
+        expect(out.trim()).toBe('EClaw #8 Entity 8 <entity-8@bots.eclaw>');
+    });
+});

--- a/backend/tests/jest/entity-status-prs-author-source.test.js
+++ b/backend/tests/jest/entity-status-prs-author-source.test.js
@@ -1,0 +1,111 @@
+'use strict';
+
+/**
+ * Tests for the prs_merged author-source (Tier 1 per-entity git author).
+ * Spec: docs/specs/per-entity-git-author-spec.md (§6)
+ * Card: card_35009109c256040aa91200bd
+ *
+ * Verifies the new git-author-grounded source UNIONs + dedupes with the existing
+ * kanban-evidence-comment path, and that it degrades gracefully (never errors).
+ */
+
+const entityStatus = require('../../entity-status');
+
+const DEVICE = 'd1';
+const ENTITY = 2;
+
+function makePool(matchers) {
+    return {
+        async query(sql, params) {
+            const s = sql.replace(/\s+/g, ' ').trim();
+            for (const m of matchers) {
+                if (m.match(s, params)) return { rows: m.rows(params) };
+            }
+            return { rows: [] };
+        },
+    };
+}
+
+// Evidence-comment rows referencing PR #200 (the existing path).
+const evidenceMatcher = {
+    match: (s) => s.includes('FROM kanban_comments') && s.includes('github'),
+    rows: () => [
+        { text: 'merged https://github.com/HankHuang0516/EClaw/pull/200', created_at: new Date('2026-06-05T00:00:00Z') },
+    ],
+};
+
+afterEach(() => {
+    // Always clear the injected source so a leak can't poison other suites.
+    entityStatus.setPrAuthorSource(null);
+});
+
+describe('prs_merged author-source', () => {
+    test('UNIONs author-source PRs with the evidence path', async () => {
+        entityStatus.initTable(makePool([evidenceMatcher]));
+        // Author-source contributes a DIFFERENT pr (#201).
+        entityStatus.setPrAuthorSource(async (email, ctx) => {
+            expect(email).toBe('entity-2@bots.eclaw');
+            expect(ctx).toEqual({ deviceId: DEVICE, entityId: ENTITY });
+            return [
+                { owner: 'HankHuang0516', repo: 'EClaw', number: 201, lastEventAt: new Date('2026-06-08T00:00:00Z') },
+            ];
+        });
+        const items = await entityStatus.getAchievements(DEVICE, ENTITY);
+        const pr = items.find(x => x.axis === 'prs_merged');
+        expect(pr.count).toBe(2); // #200 (evidence) + #201 (author)
+        expect(pr.lastEventAt).toBe(new Date('2026-06-08T00:00:00Z').toISOString());
+    });
+
+    test('dedupes a PR that appears in BOTH the evidence path and the author-source', async () => {
+        entityStatus.initTable(makePool([evidenceMatcher]));
+        // Author-source re-reports the SAME pr #200 (via prKey form).
+        entityStatus.setPrAuthorSource(async () => [
+            { prKey: 'hankhuang0516/eclaw#200', lastEventAt: new Date('2026-06-09T00:00:00Z') },
+        ]);
+        const items = await entityStatus.getAchievements(DEVICE, ENTITY);
+        const pr = items.find(x => x.axis === 'prs_merged');
+        expect(pr.count).toBe(1); // collapsed, not double-counted
+    });
+
+    test('author-source can be the ONLY source (no evidence comments)', async () => {
+        entityStatus.initTable(makePool([])); // empty DB
+        entityStatus.setPrAuthorSource(async () => [
+            { owner: 'HankHuang0516', repo: 'EClaw', number: 300 },
+            { owner: 'HankHuang0516', repo: 'EClaw', number: 301 },
+        ]);
+        const items = await entityStatus.getAchievements(DEVICE, ENTITY);
+        expect(items.find(x => x.axis === 'prs_merged').count).toBe(2);
+    });
+
+    test('graceful degrade: no source injected → evidence-path count only', async () => {
+        entityStatus.initTable(makePool([evidenceMatcher]));
+        entityStatus.setPrAuthorSource(null);
+        const items = await entityStatus.getAchievements(DEVICE, ENTITY);
+        expect(items.find(x => x.axis === 'prs_merged').count).toBe(1); // just #200
+    });
+
+    test('graceful degrade: a THROWING source never errors, falls back to evidence path', async () => {
+        entityStatus.initTable(makePool([evidenceMatcher]));
+        entityStatus.setPrAuthorSource(async () => { throw new Error('GH 503 unreachable'); });
+        const items = await entityStatus.getAchievements(DEVICE, ENTITY);
+        const pr = items.find(x => x.axis === 'prs_merged');
+        expect(pr.count).toBe(1); // evidence path stands
+        // and the other five axes are unaffected
+        expect(items).toHaveLength(6);
+    });
+
+    test('graceful degrade: malformed (non-array) source contributes nothing', async () => {
+        entityStatus.initTable(makePool([evidenceMatcher]));
+        entityStatus.setPrAuthorSource(async () => ({ not: 'an array' }));
+        const items = await entityStatus.getAchievements(DEVICE, ENTITY);
+        expect(items.find(x => x.axis === 'prs_merged').count).toBe(1);
+    });
+
+    test('author-source bare number is normalized into the shared #N key space', async () => {
+        entityStatus.initTable(makePool([])); // no evidence
+        entityStatus.setPrAuthorSource(async () => [{ number: '402' }, { number: 402 }]);
+        const items = await entityStatus.getAchievements(DEVICE, ENTITY);
+        // both normalize to #402 → 1 distinct
+        expect(items.find(x => x.axis === 'prs_merged').count).toBe(1);
+    });
+});

--- a/docs/specs/per-entity-git-author-spec.md
+++ b/docs/specs/per-entity-git-author-spec.md
@@ -1,0 +1,181 @@
+# Per-Entity Git Author Identity — Spec (Tier 1)
+
+Card: card_35009109c256040aa91200bd
+Status: Tier 1 (this spec + helper + metric author-source). Tier 2 deferred (see §7).
+Approval: Hank approved Tier 1 (no new external accounts/keys).
+
+## 1. Problem
+
+Every EClaw PR is merged through the **shared `HankHuang0516` GitHub account**, so
+`git log` / `git blame` and the GitHub commit-author column attribute *all* work to one
+human account. Which EClaw **entity** (entity #1 Planner, #2 Mac_ClaudeAce主管, #3 Mac_E,
+#4 Eclaw_Office, #5 Hermes, …, and any future device-bound entity) actually did the work
+is invisible in version-control history.
+
+The merged-PR achievement metric (`backend/entity-status.js` `prs_merged`,
+card_13405b3448d89931665c1670) works around this today by **parsing GitHub PR URLs out of
+kanban evidence comments** that bots paste. That is fragile (depends on a bot remembering to
+paste the URL into the right card) and is not grounded in git history.
+
+Tier 1 establishes a **per-entity git author identity** so attribution is *real* (lands in
+commit metadata), and gives `prs_merged` a second, history-grounded source.
+
+## 2. Globe-user requirements
+
+This scheme MUST work for **any** device and **any** entity worldwide — no hardcoded entity,
+no single-tenant carve-out (platform-rule compliance gate).
+
+- Identity is derived purely from the **global entity id** + the entity's display name as
+  stored in entity records. Nothing is hardcoded per entity or per device.
+- A fresh device that binds entity N gets a correct author identity for N with zero config.
+
+### Setup conditions
+
+- **Required:** the global entity id (`globalEntityId`). For the author *name* the entity's
+  display name is resolved best-effort; if unavailable it degrades (see §4) — name resolution
+  is never a hard requirement, the email is always derivable from the id alone.
+- **Optional (metric author-source, §6):** read-only GitHub access via the **existing**
+  `GITHUB_TOKEN` env (already wired for other GH reads in this repo). No new key. If absent,
+  the metric simply degrades to the existing evidence-comment path.
+
+### ? icon / empty-state UX
+
+Where a UI surfaces "PRs merged" attribution and the author-source is unavailable
+(`GITHUB_TOKEN` absent, or GH unreachable), the panel shows the count from the evidence path
+only, plus a `?` hint:
+
+> **What:** PRs attributed to this entity by git commit author.
+> **Needs:** commits authored as `EClaw #<N> … <entity-<N>@bots.eclaw>` (Tier 1) **or** a
+> GitHub PR URL pasted into a kanban evidence comment.
+> **Next step:** commit via the per-entity author identity (§5) so future PRs attribute
+> automatically; or paste the merged PR URL into the card's evidence comment.
+
+## 3. Email scheme
+
+```
+entity-<globalEntityId>@bots.eclaw
+```
+
+- `<globalEntityId>` is the **global** entity id (not the device-local sparse key when those
+  diverge). Examples: `entity-1@bots.eclaw`, `entity-2@bots.eclaw`, `entity-42@bots.eclaw`.
+- `bots.eclaw` is a **non-routable reserved-style domain** used only as a stable attribution
+  key — Tier 1 does **not** register or send mail to it. (`.eclaw` is not a real TLD; this is
+  intentional so the address can never collide with a real inbox.)
+- The email is the **stable join key** for the metric (§6): all of an entity's commits share
+  one email regardless of display-name changes.
+
+## 4. Author name format
+
+```
+EClaw #<N> <displayName>
+```
+
+`displayName` is resolved in this order (first non-empty wins):
+
+1. an explicitly-passed `name` (caller already has the entity record loaded — e.g. the
+   `entity.name` field used throughout `backend/index.js`);
+2. the entity's display name / codename from entity records;
+3. fallback literal `Entity <N>`.
+
+Examples:
+
+- `EClaw #2 Mac_ClaudeAce主管`
+- `EClaw #5 Hermes`
+- `EClaw #42 Entity 42` (no name on record → fallback)
+
+The combined **author string** (git `--author` / trailer form) is:
+
+```
+EClaw #<N> <displayName> <entity-<N>@bots.eclaw>
+```
+
+e.g. `EClaw #2 Mac_ClaudeAce主管 <entity-2@bots.eclaw>`.
+
+## 5. Commit convention
+
+Agents / automated processes attribute a commit to their entity using **one** of:
+
+**(a) Author override** — when the entity itself is doing the commit:
+
+```sh
+git -c user.name="EClaw #2 Mac_ClaudeAce主管" \
+    -c user.email="entity-2@bots.eclaw" \
+    commit -m "..."
+# or, keeping local config intact:
+git commit --author="EClaw #2 Mac_ClaudeAce主管 <entity-2@bots.eclaw>" -m "..."
+```
+
+The helper `backend/scripts/entity-git-author.js` (§ below) produces exactly the
+`name` / `email` / `authorString` needed:
+
+```sh
+node backend/scripts/entity-git-author.js 2
+# → EClaw #2 Mac_ClaudeAce主管 <entity-2@bots.eclaw>
+```
+
+**(b) `Co-Authored-By:` trailer** — when the **top-level author must stay the merging account**
+(e.g. an admin squash-merge through `HankHuang0516`), the entity is still credited via a
+trailer in the commit body:
+
+```
+<subject>
+
+<body>
+
+Co-Authored-By: EClaw #2 Mac_ClaudeAce主管 <entity-2@bots.eclaw>
+```
+
+GitHub recognizes `Co-Authored-By:` and shows multiple authors on the commit; the metric
+(§6) parses the **same email** out of either the top-level author or a trailer.
+
+### How this makes attribution real
+
+- `git log --author="entity-2@bots.eclaw"` and `git blame` now resolve to the entity.
+- GitHub's commit **Author** column (and "co-authored-by" badge) shows the entity instead of
+  only the shared human account.
+- The achievement metric can count merged PRs **by author email** (§6) — grounded in git
+  history, not just pasted URLs.
+
+## 6. Metric upgrade — `prs_merged` author-source
+
+`backend/entity-status.js` `getAchievements()` axis `prs_merged` gains a **second source**,
+UNION'd + deduped with the existing kanban-evidence-comment path (key space
+`owner/repo#N` / `#N`, unchanged):
+
+- **Existing path (unchanged):** PR URLs in this entity's evidence comments + `rework_pr_number`
+  union. Still authoritative; never removed.
+- **New author-source (best-effort):** distinct PRs whose commits are authored (or
+  co-authored) by `entity-<N>@bots.eclaw`. The data is provided to `getAchievements` via an
+  injectable async resolver (`prAuthorSource`) so the DB-only unit tests stay hermetic and so
+  production can wire it to a read-only GH query using the existing `GITHUB_TOKEN`. Each
+  returned PR contributes its `owner/repo#N` key into the same `Set`, so duplicates across the
+  two sources collapse automatically.
+
+### Graceful degradation (never error)
+
+The author-source is wrapped so that **any** failure — no resolver injected, `GITHUB_TOKEN`
+absent, GH unreachable / rate-limited / non-200, malformed payload, thrown exception — is
+caught and treated as "contributes nothing". The metric then returns exactly the
+evidence-path count. The axis-level `try/catch` already present means even a thrown resolver
+can never abort the other five achievement axes.
+
+This honors [[feedback_no_new_api_keys]] (reuse `GITHUB_TOKEN` only) and the read-only
+constraint.
+
+## 7. Tier 2 (deferred — needs Hank approval)
+
+Tier 1 attribution is **commit-metadata only**: `bots.eclaw` addresses are unverified, so the
+GitHub **Contributors** tab and per-entity avatars will not light up (GitHub only credits the
+Contributors graph / avatar to commits whose author email maps to a real GitHub account).
+
+Tier 2 would create **real GitHub machine-user accounts** per entity (each with the matching
+verified email + avatar) so the Contributors tab and avatar columns reflect entities. That
+requires **external account creation** and is therefore **out of scope for Tier 1** and
+**deferred pending Hank's explicit approval** (external accounts/keys gate).
+
+## 8. Out of scope (Tier 1)
+
+- Real/verified email delivery to `bots.eclaw`.
+- Real GitHub accounts / Contributors-tab / avatar attribution (Tier 2).
+- Auto-rewriting existing history.
+- New i18n strings (none required; helper + metric are non-UI).


### PR DESCRIPTION
## Scope (card_35009109c256040aa91200bd)

Tier 1 of per-entity git author identity (Hank approved; NO new external accounts/keys). Makes merged-PR/commit attribution real instead of all-to-shared-HankHuang0516.

### Deliverables
1. **Spec** `docs/specs/per-entity-git-author-spec.md`
   - Email: `entity-<globalEntityId>@bots.eclaw` (derived from global id, no hardcoding; reserved non-routable domain — attribution key only).
   - Name: `EClaw #<N> <displayName>` (displayName: passed name → entity record → `Entity N`).
   - Commit convention: `git -c user.name/email` / `--author=`, or `Co-Authored-By:` trailer when top-level author must stay the merging account.
   - How attribution becomes real (git log/blame + GitHub author column) and how prs_merged counts by author email.
   - Tier 2 (real GH machine-user accounts → Contributors tab/avatars) deferred, needs Hank approval.
2. **Helper** `backend/scripts/entity-git-author.js`: pure `entityGitAuthor(id,{name}) → {name,email,authorString}` + `entityGitEmail` + CLI (`node entity-git-author.js <id>` prints authorString). Dependency-light, globe-user.
3. **Metric** `backend/entity-status.js` `prs_merged`: injectable best-effort author-source counting distinct PRs authored by `entity-<N>@bots.eclaw`, UNION+dedupe with the existing evidence-comment path (same `owner/repo#N` key space). Degrades gracefully (no resolver / no GITHUB_TOKEN / GH down / malformed / throws → evidence path only, never errors).

### Acceptance
- `node entity-git-author.js 2 Mac_ClaudeAce主管` → `EClaw #2 Mac_ClaudeAce主管 <entity-2@bots.eclaw>`
- prs_merged UNIONs author-source + evidence, dedupes overlap, never regresses existing path.

### Test plan / Evidence
- Jest: `entity-git-author.test.js` (helper, 22) + `entity-status-prs-author-source.test.js` (author-source, 7) + existing `entity-status-achievements.test.js` (unchanged, passing) → 40/40. Full backend suite: 338 suites / 4716 passing.

### Out of scope
Real email delivery, Tier 2 GH accounts/Contributors/avatars, history rewrite, i18n (none needed).

### User POV
git history + GitHub author column now show which entity did the work; the achievement "PRs merged" count becomes grounded in git authorship, not just pasted URLs.

Card: card_35009109c256040aa91200bd

🤖 Generated with [Claude Code](https://claude.com/claude-code)