### PR TITLE
fix(avatars): petdx companion avatars on community/share-chat/card-holder (audit P3)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -12758,7 +12758,7 @@ app.post('/api/entity/cross-speak', async (req, res) => {
  * Look up entity info by public code (non-sensitive data only).
  * Query: ?code=abc123  (also accepts ?publicCode=abc123)
  */
-app.get('/api/entity/lookup', (req, res) => {
+app.get('/api/entity/lookup', async (req, res) => {
     const code = req.query.code || req.query.publicCode;
     if (!code) {
         return res.status(400).json({ success: false, message: "code query parameter required" });
@@ -12797,6 +12797,23 @@ app.get('/api/entity/lookup', (req, res) => {
         };
     }
 
+    // Petdx 夥伴 avatar enrichment (audit P3, card_8512e936d13662c0dc1495bf).
+    // share-chat.html is a PUBLIC cross-device page: the viewer looks up
+    // someone else's bot by public code, so the client-side AvatarPetdx
+    // descriptor cache (keyed on the VIEWER's own device entities) can't
+    // resolve this entity's companion — passing its entityId would mis-render
+    // against the viewer's own slot. Instead surface the OWNER's currently
+    // selected companion avatar URL (the same device-safe image path the
+    // plaza/marketplace use via petdxAvatarUrl), so the canonical 夥伴
+    // appearance shows. Falls back to entity.avatar (emoji/upload) when the
+    // owner has no companion selected — never a yellow box.
+    let petdxAvatarUrl = null;
+    try {
+        const petdxMap = await getPetdxEntityEnrichmentMap(target.deviceId);
+        const enr = petdxMap.get(Number(target.entityId));
+        if (enr && enr.petdxAvatarUrl) petdxAvatarUrl = enr.petdxAvatarUrl;
+    } catch (_) { /* graceful: keep emoji/upload fallback */ }
+
     res.json({
         success: true,
         entity: {
@@ -12805,6 +12822,7 @@ app.get('/api/entity/lookup', (req, res) => {
             character: entity.character,
             state: entity.state,
             avatar: entity.avatar,
+            petdxAvatarUrl,
             level: entity.level,
             agentCard: entity.agentCard || null,
             capabilitiesStatus,
@@ -14098,6 +14116,47 @@ function enrichCardHolderEntry(c) {
     return { ...c, online: false };
 }
 
+/**
+ * Async batch variant of enrichCardHolderEntry — also surfaces each owner's
+ * currently selected petdx 夥伴 companion avatar URL (audit P3,
+ * card_8512e936d13662c0dc1495bf). card-holder.html lists contacts that mostly
+ * belong to OTHER devices, so the client-side AvatarPetdx canvas can't resolve
+ * them (descriptor cache is keyed on the viewer's own device entities). Mirror
+ * the plaza/marketplace approach: enrich the row with petdxAvatarUrl — the
+ * device-safe image of the owner's selected companion — so the card-holder
+ * renders the canonical 夥伴 appearance instead of the static emoji. Own-device
+ * cards keep their entityId and still mount the animated chibi canvas.
+ *
+ * Batches one petdx lookup per distinct owner device, so a 50-row mixed list
+ * costs at most a handful of queries. Falls back to emoji/upload on any miss.
+ */
+async function enrichCardHolderEntriesWithPetdx(list) {
+    const arr = (list || []).map(enrichCardHolderEntry);
+    // Group live entries by owner device so we run getPetdxEntityEnrichmentMap
+    // once per device rather than once per row.
+    const deviceMaps = new Map();   // deviceId -> Map<entityId, {petdxAvatarUrl}>
+    const deviceIds = new Set();
+    for (const c of arr) {
+        const live = publicCodeIndex[c.publicCode];
+        if (live && live.deviceId) deviceIds.add(live.deviceId);
+    }
+    await Promise.all(Array.from(deviceIds).map(async (did) => {
+        try {
+            deviceMaps.set(did, await getPetdxEntityEnrichmentMap(did));
+        } catch (_) { /* graceful: leave emoji/upload fallback for this device */ }
+    }));
+    return arr.map((c) => {
+        const live = publicCodeIndex[c.publicCode];
+        if (!live) return c;
+        const m = deviceMaps.get(live.deviceId);
+        const enr = m && m.get(Number(live.entityId));
+        if (enr && enr.petdxAvatarUrl) {
+            return { ...c, petdxAvatarUrl: enr.petdxAvatarUrl };
+        }
+        return c;
+    });
+}
+
 /** Helper: resolve owner/session auth for card-holder read APIs */
 function resolveCardHolderReadAuth(req) {
     let deviceId = req.query.deviceId;
@@ -14134,7 +14193,7 @@ app.get('/api/contacts', async (req, res) => {
     if (req.query.offset) opts.offset = parseInt(req.query.offset) || 0;
 
     const cards = await db.getCardHolder(deviceId, opts);
-    const enriched = cards.map(enrichCardHolderEntry);
+    const enriched = await enrichCardHolderEntriesWithPetdx(cards);
     res.json({ success: true, contacts: enriched });
 });
 
@@ -14268,7 +14327,7 @@ app.get('/api/contacts/recent', async (req, res) => {
 
     const limit = Math.min(parseInt(req.query.limit) || 20, 100);
     const cards = await db.getRecentInteractions(deviceId, limit);
-    const enriched = cards.map(enrichCardHolderEntry);
+    const enriched = await enrichCardHolderEntriesWithPetdx(cards);
     res.json({ success: true, contacts: enriched });
 });
 
@@ -14287,7 +14346,7 @@ app.get('/api/contacts/search', async (req, res) => {
     if (q.length > 100) return res.status(400).json({ success: false, error: 'Query too long' });
 
     const cards = await db.searchCards(deviceId, q);
-    const enriched = cards.map(enrichCardHolderEntry);
+    const enriched = await enrichCardHolderEntriesWithPetdx(cards);
 
     // If query looks like a publicCode (3-8 alphanumeric), also search externally
     let external = [];
@@ -14301,11 +14360,22 @@ app.get('/api/contacts/search', async (req, res) => {
                 const dev = devices[live.deviceId];
                 const ent = dev?.entities?.[live.entityId];
                 if (ent && ent.isBound) {
+                    // Surface the owner's selected petdx companion avatar (audit
+                    // P3) so the external search hit shows the 夥伴 appearance,
+                    // matching saved/recent rows. Cross-device → URL image, not
+                    // a client canvas. Falls back to ent.avatar on no companion.
+                    let petdxAvatarUrl = null;
+                    try {
+                        const m = await getPetdxEntityEnrichmentMap(live.deviceId);
+                        const enr = m.get(Number(live.entityId));
+                        if (enr && enr.petdxAvatarUrl) petdxAvatarUrl = enr.petdxAvatarUrl;
+                    } catch (_) { /* graceful */ }
                     external.push({
                         publicCode: code,
                         name: ent.name || null,
                         character: ent.character || null,
                         avatar: ent.avatar || null,
+                        petdxAvatarUrl,
                         agentCard: ent.agentCard || null,
                         online: true
                     });
@@ -14361,14 +14431,30 @@ app.get('/api/contacts/friend-requests', async (req, res) => {
     const status = req.query.status || null;
     const requests = await db.getFriendRequests(deviceId, direction, status);
 
-    // Enrich with live entity data
+    // Enrich with live entity data + petdx 夥伴 companion avatar (audit P3).
+    // Cross-device requesters → surface the owner's companion avatar URL so the
+    // request card shows the 夥伴 appearance, not the static emoji. Batched one
+    // petdx lookup per distinct owner device.
+    const reqDeviceIds = new Set();
+    for (const r of requests) {
+        const code = direction === 'received' ? r.fromPublicCode : r.toPublicCode;
+        const live = publicCodeIndex[code];
+        if (live && live.deviceId) reqDeviceIds.add(live.deviceId);
+    }
+    const reqPetdxMaps = new Map();
+    await Promise.all(Array.from(reqDeviceIds).map(async (did) => {
+        try { reqPetdxMaps.set(did, await getPetdxEntityEnrichmentMap(did)); }
+        catch (_) { /* graceful */ }
+    }));
     const enriched = requests.map(r => {
         const code = direction === 'received' ? r.fromPublicCode : r.toPublicCode;
         const live = publicCodeIndex[code];
         if (live) {
             const dev = devices[live.deviceId];
             const ent = dev?.entities?.[live.entityId];
-            return { ...r, name: ent?.name || null, character: ent?.character || null, avatar: ent?.avatar || null, online: true };
+            const m = reqPetdxMaps.get(live.deviceId);
+            const enr = m && m.get(Number(live.entityId));
+            return { ...r, name: ent?.name || null, character: ent?.character || null, avatar: ent?.avatar || null, petdxAvatarUrl: (enr && enr.petdxAvatarUrl) || null, online: true };
         }
         return { ...r, name: null, character: null, avatar: null, online: false };
     });
@@ -14395,7 +14481,7 @@ app.get('/api/contacts/friends', async (req, res) => {
     }
 
     const friends = await db.getFriends(deviceId);
-    const enriched = friends.map(enrichCardHolderEntry);
+    const enriched = await enrichCardHolderEntriesWithPetdx(friends);
     res.json({ success: true, friends: enriched });
 });
 

--- a/backend/public/portal/card-holder.html
+++ b/backend/public/portal/card-holder.html
@@ -928,6 +928,22 @@
             container.innerHTML = html;
         }
 
+        // Petdx 夥伴 avatar resolution for CROSS-DEVICE contact rows (audit P3,
+        // card_8512e936d13662c0dc1495bf). Recent/Collected/Search/Friend rows
+        // belong to OTHER devices, so the client AvatarPetdx descriptor cache
+        // (keyed on the viewer's OWN entities) can't resolve them — passing
+        // their entityId would mis-render against the viewer's own slot. The
+        // server enriches each row with petdxAvatarUrl (the owner's selected
+        // companion avatar image); prefer it over the static emoji/upload so
+        // the 夥伴 appearance shows. Falls back to emoji — never a yellow box.
+        // (My-cards stay on the entityId canvas path — own device, animatable.)
+        function chCrossDeviceAvatar(row) {
+            if (row && typeof row.petdxAvatarUrl === 'string' && row.petdxAvatarUrl) {
+                return row.petdxAvatarUrl;
+            }
+            return null;
+        }
+
         // ── My Card rendering ──
         function renderMyCardHtml(c) {
             const avatar = c.avatar || '\u{1F99E}';
@@ -958,7 +974,7 @@
 
         // ── Friend request rendering ──
         function renderFriendRequestHtml(r) {
-            const avatar = r.avatar || '\u{1F99E}';
+            const avatar = chCrossDeviceAvatar(r) || r.avatar || '\u{1F99E}';
             return `<div class="friend-req-card">
                 <div class="card-row">
                     <span class="agent-avatar">${renderAvatarHtml(avatar, 42)}</span>
@@ -978,7 +994,7 @@
 
         // ── Recent rendering ──
         function renderRecentHtml(c) {
-            const avatar = c.avatar || (c.character === 'PIG' ? '\u{1F437}' : '\u{1F99E}');
+            const avatar = chCrossDeviceAvatar(c) || c.avatar || (c.character === 'PIG' ? '\u{1F437}' : '\u{1F99E}');
             const snap = c.cardSnapshot || {};
             const friendLabel = c.isFriend ? `<span class="friend-badge">${t('cardholder_friend', 'Friend')}</span>` : '';
             let html = `<div class="card-item" onclick="openDetail('${escapeAttr(c.publicCode)}')">
@@ -1005,7 +1021,7 @@
 
         // ── Collected rendering ──
         function renderCollectedHtml(c) {
-            const avatar = c.avatar || (c.character === 'PIG' ? '\u{1F437}' : '\u{1F99E}');
+            const avatar = chCrossDeviceAvatar(c) || c.avatar || (c.character === 'PIG' ? '\u{1F437}' : '\u{1F99E}');
             const snap = c.cardSnapshot || {};
             const friendLabel = c.isFriend ? `<span class="friend-badge">${t('cardholder_friend', 'Friend')}</span>` : '';
             let html = `<div class="card-item ${c.pinned ? 'pinned' : ''} ${c.blocked ? 'blocked' : ''}" onclick="openDetail('${escapeAttr(c.publicCode)}')">
@@ -1065,7 +1081,7 @@
             if (searchExternal.length > 0) {
                 html += `<div class="search-results-title">${t('cardholder_search_external', 'Online Agents')}</div>`;
                 html += searchExternal.map(c => {
-                    const avatar = c.avatar || '\u{1F99E}';
+                    const avatar = chCrossDeviceAvatar(c) || c.avatar || '\u{1F99E}';
                     const snap = c.agentCard || {};
                     return `<div class="card-item">
                         <div class="card-row">
@@ -1200,7 +1216,7 @@
             if (!card) return;
 
             const snap = card.cardSnapshot || {};
-            const avatar = card.avatar || (card.character === 'PIG' ? '\u{1F437}' : '\u{1F99E}');
+            const avatar = chCrossDeviceAvatar(card) || card.avatar || (card.character === 'PIG' ? '\u{1F437}' : '\u{1F99E}');
             const caps = snap.capabilities || [];
             const tags = snap.tags || [];
             const protocols = snap.protocols || [];

--- a/backend/public/portal/share-chat.html
+++ b/backend/public/portal/share-chat.html
@@ -486,7 +486,7 @@
                 'offers':{'@type':'Offer','price':'0','priceCurrency':'USD'},
                 'author':{'@type':'Person','name':targetEntity.name||targetCode},
                 'url':'https://eclawbot.com/c/'+targetCode,
-                'image':targetEntity.avatar&&targetEntity.avatar.startsWith('http')?targetEntity.avatar:undefined,
+                'image':(function(){var p=targetEntity.petdxAvatarUrl;var a=targetEntity.avatar;var abs=function(u){if(typeof u!=='string')return null;if(/^https?:\/\//.test(u))return u;if(u.charAt(0)==='/')return 'https://eclawbot.com'+u;return null;};return abs(p)||abs(a)||undefined;})(),
                 'keywords':ac.tags?ac.tags.join(', '):undefined,
               };
               jsonldEl.textContent=JSON.stringify(jsonld);
@@ -518,14 +518,27 @@
 
     function renderEntityHeader(e) {
         const avatarEl = document.getElementById('entityAvatar');
-        if (e.avatar && e.avatar.startsWith('http')) {
+        // Canonical petdx 夥伴 avatar (audit P3, card_8512e936d13662c0dc1495bf).
+        // This is a PUBLIC cross-device share page: the viewer looks up someone
+        // else's bot by public code, so the client AvatarPetdx canvas can't
+        // resolve this entity (descriptor cache is keyed on the viewer's OWN
+        // device entities). The lookup API surfaces petdxAvatarUrl — the owner's
+        // selected companion avatar IMAGE — which is the device-safe way to show
+        // the 夥伴 appearance. Prefer it over the static emoji/upload, then route
+        // through renderAvatarHtml for consistent markup (no entityId → image /
+        // emoji ladder, never a yellow box).
+        const petdx = (typeof e.petdxAvatarUrl === 'string' && e.petdxAvatarUrl) ? e.petdxAvatarUrl : null;
+        const avatar = petdx || e.avatar || (e.character === 'PIG' ? '\u{1F437}' : '\u{1F99E}');
+        if (typeof renderAvatarHtml === 'function') {
+            avatarEl.innerHTML = renderAvatarHtml(avatar, 48);
+        } else if (typeof avatar === 'string' && avatar.startsWith('http')) {
             const img = document.createElement('img');
-            img.src = e.avatar;
+            img.src = avatar;
             img.alt = 'avatar';
             avatarEl.textContent = '';
             avatarEl.appendChild(img);
         } else {
-            avatarEl.textContent = e.avatar || (e.character === 'PIG' ? '\u{1F437}' : '\u{1F99E}');
+            avatarEl.textContent = avatar;
         }
         document.getElementById('entityName').textContent = e.name || e.publicCode;
         document.getElementById('entityCode').textContent = e.publicCode;

--- a/backend/tests/jest/entities-binding-discovery.test.js
+++ b/backend/tests/jest/entities-binding-discovery.test.js
@@ -100,7 +100,10 @@ describe('/api/entities response shape', () => {
 });
 
 describe('/api/entity/lookup response shape (public)', () => {
-    const handler = slice("app.get('/api/entity/lookup'", 2500);
+    // Widened span: the lookup handler now also computes the petdx 夥伴 avatar
+    // enrichment (audit P3, card_8512e936d13662c0dc1495bf) before the response,
+    // which pushes the response-shape fields further down the function body.
+    const handler = slice("app.get('/api/entity/lookup'", 4200);
 
     it('exposes bindingType (coarse binding class)', () => {
         expect(handler).toMatch(/bindingType:\s*entity\.bindingType/);


### PR DESCRIPTION
## Scope
Audit `acd92496` / `card_8512e936d13662c0dc1495bf` follow-up. After marketplace (PR #3471), three more surfaces lacked the canonical petdx 夥伴 appearance: **community.html**, **share-chat.html**, **card-holder.html**.

## Key architectural finding
The client-side `AvatarPetdx` `<canvas>` (animated chibi) only resolves for the **viewer's OWN device entities** — `descriptorByEntityId` is keyed on bare `entityId` (0-3) with **no device scoping** (`backend/public/shared/avatar-petdx.js`). All three surfaces list bots from **other devices**, so passing a cross-device `entityId` to `renderAvatarHtml` would mis-render against the viewer's own slot (e.g. plaza bot `entityId=0` → viewer's own entity-0 companion).

The device-safe way to show the 夥伴 appearance on cross-device/public surfaces is the **owner's selected companion avatar URL** (`petdxAvatarUrl`, server-enriched image) — exactly the pattern `community.html` + `marketplace` already use. Fallback ladder stays companion-image → static avatar/upload → emoji; **never a yellow box**.

## Changes
- **share-chat.html** (public cross-device): `/api/entity/lookup` now surfaces `petdxAvatarUrl` (owner's companion, via `getPetdxEntityEnrichmentMap`); `renderEntityHeader` prefers it and routes through `renderAvatarHtml`; OG/JSON-LD `image` prefers it (absolute-URL resolved).
- **card-holder.html**: recent / collected / search / friend-request / detail rows are cross-device → backend enriches each with `petdxAvatarUrl` (batched one petdx lookup per owner device) and the 5 flagged render sites (964/986/1013/1072/1210) now prefer it via `chCrossDeviceAvatar()`. My-cards keep the **own-device** `entityId` canvas path (already correct, lines 937/1106).
- **community.html**: already correct (`resolveBotAvatar` → `petdxAvatarUrl` image). No change — cross-device entityId canvas intentionally avoided.
- Widened `entities-binding-discovery.test.js` lookup-handler slice span (the new enrichment pushed `bindingType` past the old 2500-char window).

## Surfaces: petdx vs fallback
| Surface | Result |
|---|---|
| card-holder **my-cards** (own device) | animated petdx **canvas** chibi (entityId path) |
| card-holder recent/collected/search/friend/detail (cross-device) | petdx companion **image** (owner's selected avatar) |
| share-chat (public, cross-device) | petdx companion **image** |
| community plaza (cross-device) | petdx companion **image** (already shipped) |

Cross-device caveat (per #3471): canvas chibi never resolves for other-device entities — image fallback is by design.

## Phase-1 verification
Spot-checked community live: plaza cards already render petdx companion **images** (2 imgs, 0 raw emoji, 0 canvas) — correct cross-device behavior. Own-device canvas autoMount confirmed wired on card-holder my-cards (preload + autoMount at L791/799).

## Test plan
`npm test` (full jest): **336 suites / 4691 passed / 0 failed / 17 skipped**.

## Out of scope
Device-scoping the AvatarPetdx descriptor cache (would let cross-device canvases animate) — separate larger refactor.

## User POV
Users now see each bot's actual chosen 夥伴 companion avatar across the card holder, public share-chat link, and (already) the plaza — instead of a stale static emoji.

Card: `card_8512e936d13662c0dc1495bf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)