### PR TITLE
fix(split-filter): entity chip row scrolls/wraps in narrow pane (no clip)

### DIFF
--- a/backend/public/shared/filter-summary.css
+++ b/backend/public/shared/filter-summary.css
@@ -131,6 +131,47 @@
   margin-top: 10px;
 }
 
+/* ── Entity chip row inside the filter panel — split-view clip fix ──
+ * card_f66d3265b16bf8f95349e1cf: in workspace.html split panes chat.html is
+ * loaded in a narrow iframe. The host page's `.chip-group` desktop branch
+ * (overflow:hidden; max-height:34px + JS toggle) wraps overflowing entity chips
+ * to a hidden second row, and the toggle that reveals them is unreliable inside
+ * the popover/iframe — so entities beyond row 1 (Hermes / PetDX / 我的訊息 …)
+ * became unreachable.
+ *
+ * Inside this panel we don't need the collapse-to-one-row affordance (the panel
+ * is purpose-built for filtering), so make the entity row a single horizontal
+ * momentum-scroll strip with NO height clip. Every entity is reachable by scroll
+ * regardless of pane width / viewport media-query. Scoped to the panel so the
+ * host page's standalone (non-split) chat header keeps its wrap+toggle behavior. */
+.eclaw-filter-summary__panel .chip-group {
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  overflow-y: hidden;
+  max-height: none;
+  -webkit-overflow-scrolling: touch;   /* momentum scroll on iOS WebView */
+  scrollbar-width: thin;               /* Firefox: keep a slim scroll affordance */
+  padding-bottom: 2px;
+}
+
+/* The host JS expand/collapse toggle is meaningless once the row scrolls. */
+.eclaw-filter-summary__panel .filter-chip-toggle {
+  display: none !important;
+}
+
+/* Chips must not shrink — keep them tappable while the row scrolls. */
+.eclaw-filter-summary__panel .filter-chip {
+  flex-shrink: 0;
+}
+
+/* Keep the popover itself within the split pane so it can never be clipped by
+ * the iframe edge: cap its width to the viewport (pane) and let it scroll if a
+ * narrow pane can't fit the default min-width. */
+.eclaw-filter-summary__panel:not(.is-mobile) {
+  max-width: min(480px, calc(100vw - 24px));
+  overflow: auto;
+}
+
 /* Respect reduced motion: no slide-in animation. (Default has none; this is a
  * future guard if we add one.) */
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
## Scope
Fixes `card_f66d3265b16bf8f95349e1cf`: in workspace.html split panes, the 篩選條件 entity selector clipped overflowing entity chips in the narrow split-pane width — entities beyond the visible row (Hermes / Codex_Bot / PetDX / Voyager / 我的訊息 …) were unreachable (no scroll, hidden second row).

## Root cause
chat.html loads in a narrow iframe inside workspace.html. Its legacy filter bar is moved into the shared `createFilterSummary()` popover panel at boot. The host page's `.chip-group` desktop branch uses `overflow:hidden; max-height:34px; flex-wrap:wrap` + a JS expand toggle. Inside the popover/iframe the overflowing chips wrap to a **hidden second row**, and the toggle that would reveal them relies on `offsetTop`/`resize` detection that is unreliable in the iframe popover — so the extra entities became unreachable.

## Fix (filter-summary.css only)
Scoped to `.eclaw-filter-summary__panel`:
- Entity `.chip-group` → single horizontal momentum-scroll strip (`flex-wrap:nowrap; overflow-x:auto; max-height:none; -webkit-overflow-scrolling:touch`). Every entity reachable by scroll regardless of pane width / media-query.
- Hide the now-meaningless expand toggle inside the panel.
- `.filter-chip { flex-shrink:0 }` so chips stay tappable while scrolling.
- Cap desktop popover width to the pane (`min(480px, 100vw-24px)`) so it can never be clipped by the iframe edge.

Standalone (non-split) chat header is unaffected outside the panel; behavior is consistent and strictly improves reachability.

## Verification
- BEFORE: narrow pane shows only 全部/Lobster/Mac_F/Mac_Cl/Mac_E/Eclaw_Office; remaining 5 entities clipped on a hidden row.
- AFTER (desktop 1280x800 split + mobile 390x844): entity row scrolls; all entities (incl. 我的訊息) reachable. Filter-type chips (對話/看板/排程/系統/健康) unchanged.
- browser_console_messages: 0 errors.
- jest: 338 suites / 4716 passed / 17 skipped / 0 failed.
- `git diff --stat`: 1 file, +41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)