### PR TITLE
feat(health): surface no-callback as not-ready (entity can't reply despite live process)

### DIFF
--- a/backend/passive-health.js
+++ b/backend/passive-health.js
@@ -237,13 +237,22 @@ function collectHeartbeatSignal(entity, nowMs) {
 }
 
 async function resolveChannel(entity) {
-    const out = { provider: null, callbackHealthy: null };
+    // callbackActive distinguishes "this entity literally cannot be reached/reply"
+    // (no callback_url registered on its channel account) from "callback is set but
+    // unhealthy" (callbackHealthy:false). A live daemon with no callback registered
+    // is the #6-Codex failure mode: the process is up so liveness looks green, yet
+    // EClaw has nowhere to push a message, so the entity can never receive/reply.
+    // null = unknown (no account record / lookup failed); we don't assert either way.
+    const out = { provider: null, callbackHealthy: null, callbackActive: null };
     if (!entity || !entity.channelAccountId || !getChannelAccount) return out;
     let account = null;
     try {
         account = await getChannelAccount(entity.channelAccountId);
     } catch { /* ignore — treat as unknown */ }
-    if (!account || !account.callback_url) return out;
+    if (!account) return out; // no account record → unknown, leave callbackActive null
+    // Account record exists → we CAN assert callback registration state.
+    out.callbackActive = !!account.callback_url;
+    if (!account.callback_url) return out; // registered=false; no provider, no probe
     out.provider = deriveProvider ? deriveProvider(account.callback_url) : null;
     // Optional cheap GET to the callback host's /health. Best-effort: a failure
     // here is one signal among several, never the sole verdict.
@@ -292,10 +301,36 @@ async function computePassiveHealth(deviceId, entityId) {
         failing.push('callback_unhealthy');
     }
 
+    // No callback registered = the entity CANNOT receive a push or reply, even
+    // though its daemon process may be perfectly alive. This is a hard not-ready
+    // condition (distinct from a transient unhealthy signal): a self-repair won't
+    // fix it — the callback must be re-bound. Surface it as its own failing signal
+    // AND a top-level callbackActive flag so the UI can render "無法回覆" / amber
+    // instead of a misleading green "healthy".
+    const noCallback = channel.callbackActive === false;
+    if (noCallback) {
+        failing.push('no_callback');
+    }
+
+    const healthy = failing.length === 0;
+    // readiness is the user-facing verdict the dashboard light keys off:
+    //   'no_callback'  → live process but unreachable (can't reply) → amber 無法回覆
+    //   'unhealthy'    → has a callback but failing other signals    → red
+    //   'healthy'      → reachable + no failing signals              → green
+    let readiness;
+    if (noCallback) readiness = 'no_callback';
+    else if (!healthy) readiness = 'unhealthy';
+    else readiness = 'healthy';
+
     return {
         eligible: true,
         entityId,
-        healthy: failing.length === 0,
+        healthy,
+        // canReply is false whenever there is no registered callback — the single
+        // boolean a caller needs to decide "is this entity actually answerable?".
+        canReply: !noCallback,
+        callbackActive: channel.callbackActive,
+        readiness,
         failingSignals: failing,
         provider: channel.provider,
         signals: {
@@ -306,6 +341,7 @@ async function computePassiveHealth(deviceId, entityId) {
             heartbeatKnown: heartbeat.heartbeatKnown,
             heartbeatStale: heartbeat.heartbeatStale,
             callbackHealthy: channel.callbackHealthy,
+            callbackActive: channel.callbackActive,
         },
         checkedAt: new Date(nowMs).toISOString(),
     };
@@ -414,12 +450,26 @@ async function runEntity(deviceId, deviceSecret, entityId, settings) {
             return { entityId, eligible: false, reason: health.reason };
         }
 
+        const noCallback = health.callbackActive === false;
         await logEvent(deviceId, entityId, 'passive_health',
-            health.healthy ? 'Passive health: healthy' : `Passive health: unhealthy (${health.failingSignals.join(', ')})`,
-            { healthy: health.healthy, failingSignals: health.failingSignals, provider: health.provider, signals: health.signals });
+            health.healthy ? 'Passive health: healthy'
+                : noCallback ? 'Passive health: no callback registered — entity cannot reply (re-bind required)'
+                : `Passive health: unhealthy (${health.failingSignals.join(', ')})`,
+            { healthy: health.healthy, readiness: health.readiness, canReply: health.canReply, callbackActive: health.callbackActive, failingSignals: health.failingSignals, provider: health.provider, signals: health.signals });
 
         if (health.healthy || !settings.autoRepair) {
-            return { entityId, eligible: true, healthy: health.healthy, repaired: false, failingSignals: health.failingSignals };
+            return { entityId, eligible: true, healthy: health.healthy, readiness: health.readiness, canReply: health.canReply, callbackActive: health.callbackActive, repaired: false, failingSignals: health.failingSignals };
+        }
+
+        // No callback registered is NOT self-repairable — the callback must be
+        // re-bound at the container/channel-account level. Skip the (futile) repair
+        // attempts and file a bug directly so a human gets the re-bind signal.
+        if (noCallback) {
+            const bug = await fileBugIssue(deviceId, deviceSecret, entityId, health.provider, health.failingSignals);
+            await logEvent(deviceId, entityId, 'self_repair',
+                bug.filed ? `No-callback bug filed (feedback #${bug.feedbackId}) — re-bind required, not self-repairable` : `No-callback bug filing failed: ${bug.reason}`,
+                { filed: bug.filed, feedbackId: bug.feedbackId, issueUrl: bug.issueUrl, reason: 'no_callback', failingSignals: health.failingSignals });
+            return { entityId, eligible: true, healthy: false, readiness: health.readiness, canReply: false, callbackActive: false, repaired: false, bugFiled: bug.filed, feedbackId: bug.feedbackId, failingSignals: health.failingSignals };
         }
 
         // Unhealthy + autoRepair → up to 3 repair attempts, spaced past the cooldown.

--- a/backend/tests/jest/passive-health.test.js
+++ b/backend/tests/jest/passive-health.test.js
@@ -271,6 +271,83 @@ describe('heartbeat signal (channel-push entities have no daemon lastSeen)', () 
     });
 });
 
+describe('callback-active gate (no callback registered → cannot reply)', () => {
+    // Build an app where getChannelAccountById returns a controllable account so we
+    // can simulate (a) callback registered and (b) callback NULL for the same entity.
+    function buildAppWithAccount(account) {
+        mockPool = makeMockPool();
+        logCalls = [];
+        passiveHealth.init({
+            pool: mockPool,
+            devices: freshDevices(),
+            entityStatus: {
+                logOperation: (...args) => { logCalls.push(args); return Promise.resolve(); },
+            },
+            feedbackModule: {
+                saveFeedback: jest.fn().mockResolvedValue({ id: 'fb-1' }),
+                getFeedbackById: jest.fn().mockResolvedValue(null),
+                createGithubIssue: jest.fn().mockResolvedValue(null),
+            },
+            deriveChannelProvider: () => 'openclaw',
+            getChannelAccountById: jest.fn().mockResolvedValue(account),
+            isReady: () => true,
+            selfBaseUrl: 'http://localhost:3999',
+        });
+        const a = express();
+        a.use('/api/channel/passive-health', passiveHealth.channelRouter);
+        return a;
+    }
+
+    it('entity with callback_url=null → readiness:no_callback, canReply:false, callbackActive:false, NOT healthy', async () => {
+        const a = buildAppWithAccount({ id: 10, callback_url: null });
+        const res = await request(a)
+            .get('/api/channel/passive-health/2')
+            .query({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET });
+        expect(res.status).toBe(200);
+        expect(res.body.eligible).toBe(true);
+        expect(res.body.healthy).toBe(false);          // no longer a misleading green
+        expect(res.body.canReply).toBe(false);
+        expect(res.body.callbackActive).toBe(false);
+        expect(res.body.readiness).toBe('no_callback');
+        expect(res.body.failingSignals).toContain('no_callback');
+        expect(res.body.signals.callbackActive).toBe(false);
+    });
+
+    it('entity with callback_url set → unaffected (healthy, canReply:true, readiness:healthy)', async () => {
+        // No /health probe fetch in this path would resolve to callbackHealthy:false;
+        // stub global fetch to a 200 so the callback probe does not flip the verdict.
+        const origFetch = global.fetch;
+        global.fetch = jest.fn().mockResolvedValue({ ok: true });
+        try {
+            const a = buildAppWithAccount({ id: 10, callback_url: 'https://cb.example.com/hook' });
+            const res = await request(a)
+                .get('/api/channel/passive-health/2')
+                .query({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET });
+            expect(res.status).toBe(200);
+            expect(res.body.eligible).toBe(true);
+            expect(res.body.healthy).toBe(true);
+            expect(res.body.canReply).toBe(true);
+            expect(res.body.callbackActive).toBe(true);
+            expect(res.body.readiness).toBe('healthy');
+            expect(res.body.failingSignals).not.toContain('no_callback');
+        } finally {
+            global.fetch = origFetch;
+        }
+    });
+
+    it('no account record → callbackActive stays null (unknown), does not falsely fail', async () => {
+        const a = buildAppWithAccount(null);
+        const res = await request(a)
+            .get('/api/channel/passive-health/2')
+            .query({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET });
+        expect(res.status).toBe(200);
+        expect(res.body.callbackActive).toBeNull();
+        expect(res.body.canReply).toBe(true);           // unknown ≠ cannot-reply
+        expect(res.body.readiness).toBe('healthy');     // no failing signals
+        expect(res.body.failingSignals).not.toContain('no_callback');
+    });
+});
+
 describe('exports surface', () => {
     it('exposes scheduler + compute functions', () => {
         expect(typeof passiveHealth.startScheduler).toBe('function');


### PR DESCRIPTION
## Part B of card_5450fb11942c9339931df0a6

Makes EClaw passive-health surface **"no callback registered"** as a distinct not-ready state, so an entity like #6 Codex never shows a misleading green "healthy" while it actually cannot receive or reply (its channel callback isn't registered).

### Root cause
`resolveChannel()` already fetched the channel account's `callback_url`, but when it was `null` it returned `{callbackHealthy:null}` and **did not flag it** — so a live daemon with no callback registered still computed `healthy:true`. The process is up (green liveness) but EClaw has nowhere to push a message → it can never reply.

### Changes (backend, targeted)
- `backend/passive-health.js`:
  - `resolveChannel()` now distinguishes **no callback registered** (`callbackActive:false`) from **callback set but unhealthy** (`callbackHealthy:false`) from **unknown / no account record** (`callbackActive:null`).
  - `computePassiveHealth()` returns `callbackActive`, `canReply`, and `readiness` (`'healthy' | 'unhealthy' | 'no_callback'`); `'no_callback'` is added to `failingSignals` so `healthy:false`.
  - `runEntity()` short-circuits the futile self-repair loop for `no_callback` and files a bug directly — a missing callback must be re-bound at the container level, it is not self-repairable.
- `backend/tests/jest/passive-health.test.js`: 3 new cases — `callback_url:null` → `no_callback`/`canReply:false`/`callbackActive:false`/not healthy; `callback_url` set → unaffected (healthy); no account record → `callbackActive:null` (unknown ≠ cannot-reply).

### Not in this PR
- **UI status light**: rendering `readiness:no_callback` as amber 無法回覆 belongs to the entity-status surface (being edited under a parallel card). This PR exposes `callbackActive`/`readiness`/`canReply` in the health API response for that follow-up. No new i18n strings added.
- **Part A** (re-bind #6's callback) needs container access and stays with Hank.

### Tests
```
Tests: 22 passed, 22 total (3 new)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)