### PR TITLE
fix(achievements): notes_authored counts real per-entity notes (was 0)

### DIFF
--- a/backend/entity-status.js
+++ b/backend/entity-status.js
@@ -631,19 +631,31 @@ async function getAchievements(deviceId, entityId) {
                 count = Number(r.rows[0]?.c || 0);
                 lastEventAt = r.rows[0]?.ts || null;
             } else if (axis === 'notes_authored') {
-                // mission_notes has no entity_id column; per-entity attribution
-                // is via created_by = 'entity_<N>' (see mindmap-graph-projection.js
-                // parseNumericCreatedBy). Prior query referenced a non-existent
-                // column and was swallowed by the per-axis catch — visible in
-                // Railway prod log as `column "entity_id" does not exist` spam.
+                // Notes do NOT live in the legacy `mission_notes` table — that
+                // table is never written to (no INSERT/UPDATE/CREATE anywhere in
+                // the backend). The real source is the `notes` JSONB column on
+                // mission_dashboard, where GET /api/mission/notes, /note/add and
+                // friends read/write. Per-entity attribution is the JSON field
+                // `createdBy = 'entity_<N>'` (set in mission.js note/add etc.).
+                // Prior queries (against mission_notes.entity_id then
+                // mission_notes.created_by) both hit a table with 0 rows and
+                // returned 0 — the disconnect Hank saw: GET /api/mission/notes
+                // shows the device's notes but achievements said 0.
+                // We expand the JSONB array and count this entity's notes.
+                // createdAt is a JS epoch-ms number in the JSON; convert for ts.
                 const r = await pool.query(
-                    `SELECT COUNT(*)::int AS c, MAX(created_at) AS ts
-                       FROM mission_notes
-                      WHERE device_id = $1 AND created_by = $2`,
+                    `SELECT COUNT(*)::int AS c,
+                            MAX((n->>'createdAt')::bigint) AS ts_ms
+                       FROM mission_dashboard md
+                       CROSS JOIN LATERAL jsonb_array_elements(
+                            COALESCE(md.notes, '[]'::jsonb)) AS n
+                      WHERE md.device_id = $1
+                        AND n->>'createdBy' = $2`,
                     [deviceId, `entity_${eid}`]
                 );
                 count = Number(r.rows[0]?.c || 0);
-                lastEventAt = r.rows[0]?.ts || null;
+                const tsMs = r.rows[0]?.ts_ms;
+                lastEventAt = tsMs != null ? new Date(Number(tsMs)) : null;
             } else if (axis === 'prs_merged') {
                 // v2 (card_13405b3448d89931665c1670): the only on-device PR
                 // signal is GitHub PR URLs that bots paste into kanban evidence
@@ -769,15 +781,23 @@ async function getAchievementEvents(deviceId, entityId, axis, limit) {
             }));
         }
         if (axis === 'notes_authored') {
+            // Mirror the count source: mission_dashboard.notes JSONB filtered by
+            // createdBy = 'entity_<N>'. createdAt is JS epoch-ms in the JSON.
             const r = await pool.query(
-                `SELECT id, title, created_at
-                   FROM mission_notes
-                  WHERE device_id = $1 AND entity_id = $2
-                  ORDER BY created_at DESC LIMIT $3`,
-                [deviceId, eid, lim]
+                `SELECT n->>'id'    AS id,
+                        n->>'title' AS title,
+                        (n->>'createdAt')::bigint AS created_ms
+                   FROM mission_dashboard md
+                   CROSS JOIN LATERAL jsonb_array_elements(
+                        COALESCE(md.notes, '[]'::jsonb)) AS n
+                  WHERE md.device_id = $1
+                    AND n->>'createdBy' = $2
+                  ORDER BY (n->>'createdAt')::bigint DESC NULLS LAST
+                  LIMIT $3`,
+                [deviceId, `entity_${eid}`, lim]
             );
             return r.rows.map(row => ({
-                ts: row.created_at ? row.created_at.toISOString() : null,
+                ts: row.created_ms != null ? new Date(Number(row.created_ms)).toISOString() : null,
                 chip: { kind: 'note', noteId: row.id, label: row.title },
             }));
         }

--- a/backend/tests/jest/entity-status-achievements.test.js
+++ b/backend/tests/jest/entity-status-achievements.test.js
@@ -104,6 +104,72 @@ describe('Achievements backend slice', () => {
         expect(items.find(x => x.axis === 'cards_reviewed').count).toBe(11);
     });
 
+    // card_c712d141e288fb1f9ebd38d3 — notes_authored was counting the legacy
+    // `mission_notes` table (never written to → always 0). Real notes live in
+    // mission_dashboard.notes JSONB, attributed per-entity via createdBy.
+    test('getAchievements notes_authored counts mission_dashboard.notes JSONB by createdBy = entity_<N>', async () => {
+        let captured = null;
+        const pool = makePool([
+            {
+                match: (s, p) => s.includes('FROM mission_dashboard')
+                    && s.includes('jsonb_array_elements')
+                    && s.includes("n->>'createdBy' = $2"),
+                rows: (p) => {
+                    captured = p;
+                    expect(p[0]).toBe(DEVICE);
+                    expect(p[1]).toBe('entity_2');
+                    // 251 notes authored by entity_2; latest createdAt as epoch-ms.
+                    return [{ c: 251, ts_ms: '1750000000000' }];
+                },
+            },
+        ]);
+        entityStatus.initTable(pool);
+        const items = await entityStatus.getAchievements(DEVICE, ENTITY);
+        const na = items.find(x => x.axis === 'notes_authored');
+        expect(na.count).toBe(251);
+        expect(na.lastEventAt).toBe(new Date(1750000000000).toISOString());
+        // Must NOT query the dead legacy table.
+        expect(captured).not.toBeNull();
+    });
+
+    test('getAchievements notes_authored is 0 when entity has no notes (empty JSONB)', async () => {
+        const pool = makePool([
+            {
+                match: (s) => s.includes('FROM mission_dashboard') && s.includes('jsonb_array_elements'),
+                rows: () => [{ c: 0, ts_ms: null }],
+            },
+        ]);
+        entityStatus.initTable(pool);
+        const items = await entityStatus.getAchievements(DEVICE, ENTITY);
+        const na = items.find(x => x.axis === 'notes_authored');
+        expect(na.count).toBe(0);
+        expect(na.lastEventAt).toBeNull();
+    });
+
+    test('getAchievementEvents for notes_authored returns note chips from JSONB newest-first', async () => {
+        const pool = makePool([
+            {
+                match: (s, p) => s.includes('FROM mission_dashboard')
+                    && s.includes('jsonb_array_elements')
+                    && s.includes("n->>'createdBy' = $2")
+                    && s.includes('ORDER BY'),
+                rows: (p) => {
+                    expect(p[1]).toBe('entity_2');
+                    return [
+                        { id: 'note_a', title: 'Roadmap', created_ms: '1750000200000' },
+                        { id: 'note_b', title: 'Spec notes', created_ms: '1750000100000' },
+                    ];
+                },
+            },
+        ]);
+        entityStatus.initTable(pool);
+        const items = await entityStatus.getAchievementEvents(DEVICE, ENTITY, 'notes_authored', 10);
+        expect(items).toHaveLength(2);
+        expect(items[0].chip).toEqual({ kind: 'note', noteId: 'note_a', label: 'Roadmap' });
+        expect(items[0].ts).toBe(new Date(1750000200000).toISOString());
+        expect(items[1].chip.noteId).toBe('note_b');
+    });
+
     // card_13405b3448d89931665c1670 — prs_merged is now derived from on-device
     // GitHub PR URLs in kanban evidence comments (+ rework_pr_number union),
     // replacing the hardcoded-0 stub.


### PR DESCRIPTION
## Problem
Achievements panel `撰寫的筆記數` (notes_authored) showed **0** for entity #2 despite the entity having notes. `GET /api/mission/notes` returns 325 device notes; achievements said 0.

card_c712d141e288fb1f9ebd38d3

## Root cause
`notes_authored` queried the legacy `mission_notes` table — which is **never written to** anywhere in the backend (no INSERT/UPDATE/CREATE). Real notes live in the **`mission_dashboard.notes` JSONB column** (what `/api/mission/notes`, `/note/add`, `/note/update` read/write). #3476 had tweaked the column to `created_by` but it was still pointed at the dead table → still 0.

## Notes are per-entity
Each note object carries `createdBy: "entity_<N>"` (set in mission.js note/add etc.). So "撰寫的筆記數 per entity" is well-defined. For entity #2: 251 of the device's 325 notes are `createdBy=entity_2`.

## Fix
- `getAchievements` notes_authored: `COUNT` over `jsonb_array_elements(mission_dashboard.notes)` filtered on `createdBy = 'entity_<N>'`; `lastEventAt` from max `createdAt` (JS epoch-ms in JSON).
- `getAchievementEvents` notes_authored: same source, returns note chips (`{kind:'note', noteId, label}`) newest-first.
- Mirrors the prs_merged author-source alignment (#3462/#3476). No other axis touched. No new i18n strings (label exists).

## Verify
- BEFORE (live prod curl): notes_authored count 0, lastEventAt null.
- AFTER (jest fixture + render harness): 251 with note events.
- jest `entity-status` suites: 52/52 green (3 new notes_authored tests).
- Render harness (real entity-status-panel.js, mocked fetch): BEFORE 0, AFTER 251 + expanded note chips, 0 console errors, desktop + mobile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)