### PR TITLE
fix(usage-warning): cooldown + user-facing-only gate (card_a69e8ffa)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -9356,12 +9356,18 @@ app.post('/api/transform', transformMaybeMultipart, idempotencyMiddleware, async
         broadcast = false;
         routingResolvedVia = null;
     }
-    // Usage warning prefix (card_9cd84ee7d830b2f76c595f6c).
+    // Usage warning prefix (card_9cd84ee7d830b2f76c595f6c; card_a69e8ffa refinement).
     // When the device opted in and the latest usage_snapshots row shows
     // Claude 5h/7d remaining ≤ thresholds, prepend a system warning so the
-    // dialog partner knows quota is tight. Best-effort: any failure here
-    // (no snapshot / stale / DB hiccup) silently skips — never blocks delivery.
-    if (typeof finalMessage === 'string' && finalMessage && !isSuppressedMessage) {
+    // user knows quota is tight. Best-effort: any failure here (no snapshot /
+    // stale / DB hiccup) silently skips — never blocks delivery.
+    // Gate to USER-FACING pushes only: skip bot-to-bot directed messages
+    // (speakTo targets another entity). Riding bot-to-bot acks made the warning
+    // surface via org-chart-forward as a standalone conversational line to the
+    // user (card_a69e8ffa). The per-device cooldown in usage-warning.js further
+    // ensures it piggybacks at most once per window rather than on every message.
+    const _isBotToBot = Array.isArray(speakTo) && speakTo.length > 0;
+    if (typeof finalMessage === 'string' && finalMessage && !isSuppressedMessage && !_isBotToBot) {
         try {
             const _prefs = await devicePrefs.getPrefs(deviceId);
             const _cfg = _prefs && _prefs.usage_warning_config;

--- a/backend/lib/usage-warning.js
+++ b/backend/lib/usage-warning.js
@@ -10,9 +10,19 @@
  *
  * Trigger:  (5h_remaining ≤ threshold_5h_pct) OR (7d_remaining ≤ threshold_7d_pct)
  * Stale:    captured_at older than 6h → skip (no false-positive warnings)
+ * Cooldown: once attached, suppress re-attachment for COOLDOWN window per device
+ *           (card_a69e8ffa — without this the prefix rode EVERY message ≤ threshold,
+ *           so it read as a repeated standalone conversational line rather than a
+ *           one-off piggyback on a content push).
  */
 
 const STALE_THRESHOLD_MS = 6 * 60 * 60 * 1000;  // 6 hours
+const DEFAULT_COOLDOWN_MS = 30 * 60 * 1000;     // 30 min — one warning per device per window
+
+// Per-device last-attached timestamp (ms epoch). In-memory is sufficient: a missed
+// cooldown across a process restart at most lets one extra warning through, which is
+// harmless. Keyed by deviceId.
+const _lastWarnedAt = new Map();
 
 const WARNING_TEMPLATES = {
     'zh': '⚠️ 系統訊息：本 Agent 5h 剩餘 {five}% / 7d 剩餘 {seven}%。已達警戒閾值。',
@@ -101,9 +111,31 @@ function formatWarningText(lang, fiveRem, sevenRem) {
 }
 
 /**
+ * Pure cooldown check. Returns true when a prior warning at `lastMs` is still
+ * inside the `cooldownMs` window relative to `nowMs` (so a new one should be
+ * suppressed). lastMs == null/undefined → never warned → not within cooldown.
+ */
+function withinCooldown(lastMs, nowMs, cooldownMs = DEFAULT_COOLDOWN_MS) {
+    if (lastMs == null || !Number.isFinite(lastMs)) return false;
+    return (nowMs - lastMs) < cooldownMs;
+}
+
+/**
+ * Resolve the per-device cooldown window from config (cooldown_min minutes),
+ * falling back to the 30-min default. 0/negative disables the cooldown.
+ */
+function resolveCooldownMs(config) {
+    const m = config && config.cooldown_min;
+    if (Number.isFinite(m)) return Math.max(0, m * 60 * 1000);
+    return DEFAULT_COOLDOWN_MS;
+}
+
+/**
  * Convenience wrapper: query the latest snapshot, decide, format.
  * Returns the warning prefix string, or null if no warning should be attached.
- * Never throws — quota warnings must not break the message-send path.
+ * Applies a per-device cooldown so the prefix piggybacks at most once per window
+ * instead of riding every message (card_a69e8ffa). Never throws — quota warnings
+ * must not break the message-send path.
  */
 async function getWarningPrefix(pool, deviceId, config, lang, nowMs = Date.now()) {
     if (!pool || !deviceId) return null;
@@ -125,6 +157,12 @@ async function getWarningPrefix(pool, deviceId, config, lang, nowMs = Date.now()
         } : null;
         const decision = shouldWarnNow(snapshot, config, nowMs);
         if (!decision.warn) return null;
+        // Cooldown: suppress if we already attached a warning for this device
+        // inside the window — keeps it a one-off piggyback, not a per-message echo.
+        if (withinCooldown(_lastWarnedAt.get(deviceId), nowMs, resolveCooldownMs(config))) {
+            return null;
+        }
+        _lastWarnedAt.set(deviceId, nowMs);
         return formatWarningText(lang, decision.five_hour_remaining_pct, decision.seven_day_remaining_pct);
     } catch (err) {
         // Quota warnings are advisory — swallow errors so we never block delivery.
@@ -137,9 +175,14 @@ async function getWarningPrefix(pool, deviceId, config, lang, nowMs = Date.now()
 
 module.exports = {
     STALE_THRESHOLD_MS,
+    DEFAULT_COOLDOWN_MS,
     WARNING_TEMPLATES,
     pickClaudeLivePct,
     shouldWarnNow,
     formatWarningText,
+    withinCooldown,
+    resolveCooldownMs,
     getWarningPrefix,
+    // Test/ops hook: clear the in-memory per-device cooldown state.
+    _resetCooldownState: () => _lastWarnedAt.clear(),
 };

--- a/backend/tests/jest/usage-warning.test.js
+++ b/backend/tests/jest/usage-warning.test.js
@@ -12,9 +12,12 @@
 
 const {
     STALE_THRESHOLD_MS,
+    DEFAULT_COOLDOWN_MS,
     shouldWarnNow,
     formatWarningText,
     pickClaudeLivePct,
+    withinCooldown,
+    resolveCooldownMs,
 } = require('../../lib/usage-warning');
 
 const DEFAULT_CFG = { enabled: true, threshold_5h_pct: 15, threshold_7d_pct: 5 };
@@ -128,6 +131,31 @@ describe('shouldWarnNow — custom thresholds', () => {
         // 7d_remaining=10, threshold=5 → 10 ≤ 5 false → no breach either
         const out = shouldWarnNow(mkSnap({ five: 90, seven: 90 }), cfg, NOW);
         expect(out.warn).toBe(false);
+    });
+});
+
+describe('withinCooldown / resolveCooldownMs (card_a69e8ffa)', () => {
+    test('never-warned (null last) → not within cooldown', () => {
+        expect(withinCooldown(null, NOW)).toBe(false);
+        expect(withinCooldown(undefined, NOW)).toBe(false);
+    });
+    test('inside the window → within cooldown (suppress)', () => {
+        expect(withinCooldown(NOW - 5 * 60 * 1000, NOW, DEFAULT_COOLDOWN_MS)).toBe(true);
+    });
+    test('past the window → not within cooldown (allow)', () => {
+        expect(withinCooldown(NOW - 31 * 60 * 1000, NOW, DEFAULT_COOLDOWN_MS)).toBe(false);
+    });
+    test('exactly at the boundary → not within cooldown (allow)', () => {
+        expect(withinCooldown(NOW - DEFAULT_COOLDOWN_MS, NOW, DEFAULT_COOLDOWN_MS)).toBe(false);
+    });
+    test('resolveCooldownMs reads config.cooldown_min (minutes → ms)', () => {
+        expect(resolveCooldownMs({ cooldown_min: 10 })).toBe(10 * 60 * 1000);
+        expect(resolveCooldownMs({ cooldown_min: 0 })).toBe(0);     // disables cooldown
+        expect(resolveCooldownMs({})).toBe(DEFAULT_COOLDOWN_MS);    // default
+        expect(resolveCooldownMs(null)).toBe(DEFAULT_COOLDOWN_MS);
+    });
+    test('cooldown_min: 0 → every breach allowed (no suppression)', () => {
+        expect(withinCooldown(NOW - 1, NOW, resolveCooldownMs({ cooldown_min: 0 }))).toBe(false);
     });
 });
 


### PR DESCRIPTION
## Problem
Hank: the 5h/7d usage warning read as a standalone conversational line, not a one-off piggyback.

## Root cause
The prepend itself is correct (`index.js`: `prefix + '\n\n' + finalMessage`). Two gaps:
1. **No cooldown** → every message ≤ threshold got the prefix (repeated → conversational).
2. **No recipient gate** → bot-to-bot messages got it too, then org-chart-forward surfaced it to the user as a floating system line.

## Fix
- `usage-warning.js`: per-device cooldown (default 30 min, `config.cooldown_min` override; 0 disables). In-memory Map keyed by deviceId.
- `index.js`: gate the prepend to user-facing pushes only (skip when `speakTo` targets another entity).

## Tests
`usage-warning.test.js` +6 cooldown/resolveCooldownMs cases (27 total); device-preferences-usage-warning unaffected. **29/29 pass.**

## Deploy
EClaw backend (Railway). Needs deploy to take effect on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)