### PR TITLE
fix(kanban): jsonb assigned_bots cast error in workload/busy checks (card_c2f1eff2)

### DIFF
--- a/backend/idle_dispatch_handler.js
+++ b/backend/idle_dispatch_handler.js
@@ -17,7 +17,7 @@ async function isBotBusy(deviceId, botEntityId) {
         SELECT COUNT(*) as active_count
         FROM kanban_cards
         WHERE device_id = $1
-        AND $2 = ANY(assigned_bots)
+        AND assigned_bots @> to_jsonb($2::int)
         AND status IN ('todo', 'in_progress')
         AND archived = FALSE
     `, [deviceId, botEntityId]);
@@ -65,7 +65,7 @@ async function smartDispatch(deviceId, cardId, assignedBots) {
                 SELECT COUNT(*) as queued_count
                 FROM kanban_cards
                 WHERE device_id = $1
-                AND $2 = ANY(assigned_bots)
+                AND assigned_bots @> to_jsonb($2::int)
                 AND pending_dispatch = TRUE
                 AND archived = FALSE
             `, [deviceId, primaryBot]);
@@ -115,7 +115,7 @@ async function drainBotQueue(deviceId, botEntityId) {
             SELECT id, title, assigned_bots
             FROM kanban_cards
             WHERE device_id = $1
-            AND $2 = ANY(assigned_bots)
+            AND assigned_bots @> to_jsonb($2::int)
             AND pending_dispatch = TRUE
             AND archived = FALSE
             ORDER BY created_at ASC

--- a/backend/index.js
+++ b/backend/index.js
@@ -13957,7 +13957,7 @@ app.get('/api/entity/:entityId/workload', async (req, res) => {
                 COUNT(*) as count
             FROM kanban_cards
             WHERE device_id = $1
-              AND $2 = ANY(assigned_bots::integer[])
+              AND assigned_bots @> to_jsonb($2::int)
               AND archived = false
               AND status IN ('scheduled', 'todo', 'in_progress', 'review')
             GROUP BY status

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -3572,7 +3572,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                                     SELECT COUNT(*) as active_count
                                     FROM kanban_cards
                                     WHERE device_id = $1
-                                      AND $2 = ANY(assigned_bots::integer[])
+                                      AND assigned_bots @> to_jsonb($2::int)
                                       AND archived = false
                                       AND status IN ('scheduled', 'todo', 'in_progress', 'review')
                                 `, [card.device_id, botId]);
@@ -3805,7 +3805,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                             SELECT COUNT(*) as active_count
                             FROM kanban_cards
                             WHERE device_id = $1
-                              AND $2 = ANY(assigned_bots::integer[])
+                              AND assigned_bots @> to_jsonb($2::int)
                               AND archived = false
                               AND status IN ('scheduled', 'todo', 'in_progress', 'review')
                         `, [card.device_id, botId]);


### PR DESCRIPTION
## Scope
Prod error (Railway deploy 215b2e6f, recurring 2026-06-17T16:04Z): `cannot cast type jsonb to integer[]` from the kanban workload check.

`assigned_bots` is a **jsonb** column (insert/update use `::jsonb`; `botActiveWorkload` uses `@> $2::jsonb`). 6 workload/busy/idle-dispatch queries wrongly treated it as `int[]`:
- `backend/kanban.js` ×2 — smart-queue active-entity checks
- `backend/index.js` ×1 — entity active-task status count
- `backend/idle_dispatch_handler.js` ×3 — `isBotBusy` / queued-count / `drainBotQueue` (`= ANY(assigned_bots)`, also invalid on jsonb)

## Fix
All 6 → `assigned_bots @> to_jsonb($2::int)` (matches proven `botActiveWorkload` pattern). Harden-on-first-fix: whole error class, not just the one logged path.

## Acceptance
- 0 remaining `assigned_bots::integer[]` / `= ANY(assigned_bots)` in backend/.
- `node -c` passes on all 3 files.
- Semantics: `'[2,5]'::jsonb @> '2'::jsonb` → true (array-contains-scalar).

🤖 Generated with [Claude Code](https://claude.com/claude-code)