### PR TITLE
fix(invite): stats query references non-existent column balance_delta (card_b2fc0e2d follow-up)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -6657,7 +6657,7 @@ app.get('/api/invite/stats', async (req, res) => {
             pg.query('SELECT bonus_messages, total_invited, milestones_claimed FROM invite_rewards WHERE device_id = $1', [deviceId]),
             pg.query('SELECT message_count FROM usage_tracking WHERE device_id = $1 AND date = CURRENT_DATE', [deviceId]),
             pg.query(
-                `SELECT COALESCE(SUM(balance_delta), 0) as total_earned_mli
+                `SELECT COALESCE(SUM(delta_mli), 0) as total_earned_mli
                  FROM wallet_ledger wl
                  JOIN user_accounts ua ON ua.id = wl.user_id
                  WHERE ua.device_id = $1


### PR DESCRIPTION
## Scope
Prod error (Railway, eclaw): `[Invite] stats error: column balance_delta does not exist`.

## Root cause
`/api/invite/stats` runs `SELECT COALESCE(SUM(balance_delta),0) … FROM wallet_ledger`, but `wallet_ledger` has no `balance_delta` column. Per schema, the signed-amount column is **`delta_mli`** (`delta_mli BIGINT NOT NULL -- signed: + credit, - debit`).

## Fix
`SUM(balance_delta)` → `SUM(delta_mli)` (alias `total_earned_mli` unchanged). One-line, column-name correction verified against the wallet_ledger CREATE TABLE.

## Verification
- `node -c` clean.
- Column confirmed from schema (migrations) + cross-checked vs other wallet_ledger usage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)