### PR TITLE
fix(chat-embedding): HNSW dim mismatch — normalize column to vector(1536)=DEFAULT_DIM + guards (card_563f12c8)

### DIFF
--- a/backend/chat-embedding.js
+++ b/backend/chat-embedding.js
@@ -10,6 +10,42 @@ const { generateEmbedding, toPgVectorLiteral, DEFAULT_DIM } = require('./embeddi
 
 let vectorEnabled = false;  // set true after successful schema init
 let poolRef = null;
+const EXPECTED_VECTOR_TYPE = `vector(${DEFAULT_DIM})`;
+
+function vectorDim(vec) {
+    return Array.isArray(vec) ? vec.length : null;
+}
+
+function hasExpectedDim(vec) {
+    return vectorDim(vec) === DEFAULT_DIM;
+}
+
+async function normalizeEmbeddingColumn(pool) {
+    const typeResult = await pool.query(`
+        SELECT pg_catalog.format_type(a.atttypid, a.atttypmod) AS column_type
+        FROM pg_catalog.pg_attribute a
+        WHERE a.attrelid = 'chat_messages'::regclass
+          AND a.attname = 'embedding'
+          AND NOT a.attisdropped
+        LIMIT 1
+    `);
+    const columnType = typeResult.rows?.[0]?.column_type;
+    if (!columnType || columnType === EXPECTED_VECTOR_TYPE) return;
+
+    console.warn(`[ChatEmbedding] normalizing embedding column ${columnType} -> ${EXPECTED_VECTOR_TYPE}`);
+    await pool.query('DROP INDEX IF EXISTS idx_chat_embedding_hnsw');
+    await pool.query(`
+        UPDATE chat_messages
+        SET embedding = NULL, embedded_at = NULL
+        WHERE embedding IS NOT NULL
+          AND vector_dims(embedding) <> ${DEFAULT_DIM}
+    `);
+    await pool.query(`
+        ALTER TABLE chat_messages
+        ALTER COLUMN embedding TYPE vector(${DEFAULT_DIM})
+        USING embedding::vector(${DEFAULT_DIM})
+    `);
+}
 
 async function initSchema(pool) {
     poolRef = pool;
@@ -29,6 +65,7 @@ async function initSchema(pool) {
     try {
         await pool.query(`ALTER TABLE chat_messages ADD COLUMN IF NOT EXISTS embedding vector(${DEFAULT_DIM})`);
         await pool.query(`ALTER TABLE chat_messages ADD COLUMN IF NOT EXISTS embedded_at TIMESTAMP WITH TIME ZONE`);
+        await normalizeEmbeddingColumn(pool);
     } catch (err) {
         console.warn('[ChatEmbedding] embedding column migration failed:', err.message);
         vectorEnabled = false;
@@ -59,6 +96,10 @@ function embedMessageAsync(messageId, text, opts = {}) {
         try {
             const vec = await generateEmbedding(text, opts);
             if (!vec) return;
+            if (!hasExpectedDim(vec)) {
+                console.warn(`[ChatEmbedding] skip embedding write for ${messageId}: dim=${vectorDim(vec)} expected=${DEFAULT_DIM}`);
+                return;
+            }
             const literal = toPgVectorLiteral(vec);
             if (!literal) return;
             await poolRef.query(
@@ -80,6 +121,10 @@ function embedMessageAsync(messageId, text, opts = {}) {
  */
 async function searchBySemantic(deviceId, queryEmbedding, opts = {}) {
     if (!vectorEnabled || !queryEmbedding) return [];
+    if (!hasExpectedDim(queryEmbedding)) {
+        console.warn(`[ChatEmbedding] skip semantic search: query dim=${vectorDim(queryEmbedding)} expected=${DEFAULT_DIM}`);
+        return [];
+    }
     const literal = toPgVectorLiteral(queryEmbedding);
     if (!literal) return [];
     const limit = Math.min(Math.max(parseInt(opts.limit, 10) || 5, 1), 50);

--- a/backend/tests/jest/chat-embedding-unit.test.js
+++ b/backend/tests/jest/chat-embedding-unit.test.js
@@ -1,0 +1,99 @@
+function createPool(columnType = 'vector(1536)') {
+    const pool = {
+        queries: [],
+        async query(sql) {
+            const text = String(sql);
+            pool.queries.push(text);
+            if (text.includes('pg_catalog.format_type')) {
+                return { rows: [{ column_type: columnType }] };
+            }
+            return { rows: [] };
+        }
+    };
+    return pool;
+}
+
+function queryIndex(pool, needle) {
+    return pool.queries.findIndex((sql) => sql.includes(needle));
+}
+
+describe('chat-embedding schema normalization', () => {
+    let warnSpy;
+
+    beforeEach(() => {
+        jest.resetModules();
+        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+        jest.dontMock('../../embedding-client');
+    });
+
+    it('repairs a legacy unbounded pgvector column before creating HNSW index', async () => {
+        const chatEmbedding = require('../../chat-embedding');
+        const pool = createPool('vector');
+
+        await chatEmbedding.initSchema(pool);
+
+        expect(queryIndex(pool, 'DROP INDEX IF EXISTS idx_chat_embedding_hnsw')).toBeGreaterThan(-1);
+        expect(queryIndex(pool, 'vector_dims(embedding) <> 1536')).toBeGreaterThan(-1);
+        expect(queryIndex(pool, 'ALTER COLUMN embedding TYPE vector(1536)')).toBeGreaterThan(-1);
+        expect(queryIndex(pool, 'ALTER COLUMN embedding TYPE vector(1536)'))
+            .toBeLessThan(queryIndex(pool, 'CREATE INDEX IF NOT EXISTS idx_chat_embedding_hnsw'));
+    });
+
+    it('does not rewrite an already dimensioned vector(1536) column', async () => {
+        const chatEmbedding = require('../../chat-embedding');
+        const pool = createPool('vector(1536)');
+
+        await chatEmbedding.initSchema(pool);
+
+        expect(queryIndex(pool, 'DROP INDEX IF EXISTS idx_chat_embedding_hnsw')).toBe(-1);
+        expect(queryIndex(pool, 'ALTER COLUMN embedding TYPE vector(1536)')).toBe(-1);
+        expect(queryIndex(pool, 'CREATE INDEX IF NOT EXISTS idx_chat_embedding_hnsw')).toBeGreaterThan(-1);
+    });
+});
+
+describe('chat-embedding dimension guards', () => {
+    let warnSpy;
+
+    beforeEach(() => {
+        jest.resetModules();
+        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+        jest.dontMock('../../embedding-client');
+    });
+
+    it('skips semantic search when the query vector has the wrong dimension', async () => {
+        const chatEmbedding = require('../../chat-embedding');
+        const pool = createPool();
+        await chatEmbedding.initSchema(pool);
+        const queryCount = pool.queries.length;
+
+        const rows = await chatEmbedding.searchBySemantic('device-a', [0.1, 0.2, 0.3]);
+
+        expect(rows).toEqual([]);
+        expect(pool.queries).toHaveLength(queryCount);
+    });
+
+    it('skips embedding writes when the generated vector has the wrong dimension', async () => {
+        jest.doMock('../../embedding-client', () => ({
+            DEFAULT_DIM: 1536,
+            generateEmbedding: jest.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+            toPgVectorLiteral: jest.fn(() => '[0.100000,0.200000,0.300000]')
+        }));
+        const chatEmbedding = require('../../chat-embedding');
+        const pool = createPool();
+        await chatEmbedding.initSchema(pool);
+        const queryCount = pool.queries.length;
+
+        chatEmbedding.embedMessageAsync('message-1', 'hello');
+        await new Promise((resolve) => setImmediate(resolve));
+
+        expect(pool.queries).toHaveLength(queryCount);
+    });
+});


### PR DESCRIPTION
## Scope
Prod error: `[ChatEmbedding] HNSW index creation failed: incorrect index dimensions: expected 384 got 1024` — vector search (flagship feature) broken.

## Root cause
`chat_messages.embedding` column drifted (legacy unbounded / 384-dim + stray 1024-dim Voyage vectors). Canonical model is OpenAI `text-embedding-3-small` → `DEFAULT_DIM=1536`; `embedding-client.js` documents the column as **fixed at vector(1536)**.

## Fix (authored by #6/Codex, reviewed + dimension-verified by #2)
- `normalizeEmbeddingColumn()` on startup: detect legacy column, DROP stale HNSW index, NULL embeddings whose `vector_dims <> DEFAULT_DIM`, ALTER column → `vector(DEFAULT_DIM)`, rebuild HNSW.
- Dim guards before write + before semantic search (wrong-dim vector can't crash DB again).
- Keyed to the `DEFAULT_DIM` constant (1536), not magic numbers.
- New unit test `chat-embedding-unit.test.js`.

## Verification
- Dimension confirmed 1536 against `embedding-client.DEFAULT_DIM` + the documented fixed-1536 column (the 1024 in the error = stray Voyage vectors, which the guard now clears).
- Patch applies clean on origin/main; `node -c` clean on both files.
- #6 ran `chat-embedding-unit` + `chat-search` jest green; local npx-jest env quirk so **CI is the gate**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)