### PR TITLE
[codex] fix chat embedding vector dimensions

### DIFF
--- a/backend/chat-embedding.js
+++ b/backend/chat-embedding.js
@@ -10,6 +10,42 @@ const { generateEmbedding, toPgVectorLiteral, DEFAULT_DIM } = require('./embeddi
 
 let vectorEnabled = false;  // set true after successful schema init
 let poolRef = null;
+const EXPECTED_VECTOR_TYPE = `vector(${DEFAULT_DIM})`;
+
+function vectorDim(vec) {
+    return Array.isArray(vec) ? vec.length : null;
+}
+
+function hasExpectedDim(vec) {
+    return vectorDim(vec) === DEFAULT_DIM;
+}
+
+async function normalizeEmbeddingColumn(pool) {
+    const result = await pool.query(`
+        SELECT pg_catalog.format_type(a.atttypid, a.atttypmod) AS column_type
+        FROM pg_catalog.pg_attribute a
+        WHERE a.attrelid = 'chat_messages'::regclass
+          AND a.attname = 'embedding'
+          AND NOT a.attisdropped
+        LIMIT 1
+    `);
+    const columnType = result.rows?.[0]?.column_type;
+    if (!columnType || columnType === EXPECTED_VECTOR_TYPE) return;
+
+    console.warn(`[ChatEmbedding] normalizing embedding column ${columnType} -> ${EXPECTED_VECTOR_TYPE}`);
+    await pool.query('DROP INDEX IF EXISTS idx_chat_embedding_hnsw');
+    await pool.query(`
+        UPDATE chat_messages
+        SET embedding = NULL, embedded_at = NULL
+        WHERE embedding IS NOT NULL
+          AND vector_dims(embedding) <> ${DEFAULT_DIM}
+    `);
+    await pool.query(`
+        ALTER TABLE chat_messages
+        ALTER COLUMN embedding TYPE vector(${DEFAULT_DIM})
+        USING embedding::vector(${DEFAULT_DIM})
+    `);
+}
 
 async function initSchema(pool) {
     poolRef = pool;
@@ -29,6 +65,7 @@ async function initSchema(pool) {
     try {
         await pool.query(`ALTER TABLE chat_messages ADD COLUMN IF NOT EXISTS embedding vector(${DEFAULT_DIM})`);
         await pool.query(`ALTER TABLE chat_messages ADD COLUMN IF NOT EXISTS embedded_at TIMESTAMP WITH TIME ZONE`);
+        await normalizeEmbeddingColumn(pool);
     } catch (err) {
         console.warn('[ChatEmbedding] embedding column migration failed:', err.message);
         vectorEnabled = false;
@@ -59,6 +96,10 @@ function embedMessageAsync(messageId, text, opts = {}) {
         try {
             const vec = await generateEmbedding(text, opts);
             if (!vec) return;
+            if (!hasExpectedDim(vec)) {
+                console.warn(`[ChatEmbedding] skip embedding write for ${messageId}: dim=${vectorDim(vec)} expected=${DEFAULT_DIM}`);
+                return;
+            }
             const literal = toPgVectorLiteral(vec);
             if (!literal) return;
             await poolRef.query(
@@ -80,6 +121,10 @@ function embedMessageAsync(messageId, text, opts = {}) {
  */
 async function searchBySemantic(deviceId, queryEmbedding, opts = {}) {
     if (!vectorEnabled || !queryEmbedding) return [];
+    if (!hasExpectedDim(queryEmbedding)) {
+        console.warn(`[ChatEmbedding] skip semantic search: query dim=${vectorDim(queryEmbedding)} expected=${DEFAULT_DIM}`);
+        return [];
+    }
     const literal = toPgVectorLiteral(queryEmbedding);
     if (!literal) return [];
     const limit = Math.min(Math.max(parseInt(opts.limit, 10) || 5, 1), 50);

--- a/backend/scripts/backfill-embeddings.js
+++ b/backend/scripts/backfill-embeddings.js
@@ -12,8 +12,9 @@
  *   --device all devices
  *   --dry-run skip UPDATE, just print what would change
  *
- * Safe to re-run: only touches rows where embedding IS NULL. Rate-limited via
- * the OpenAI API server-side; if you hit rate limits, lower --batch.
+ * Safe to re-run: first ensures the pgvector schema matches DEFAULT_DIM, then
+ * only touches rows where embedding IS NULL. Rate-limited via the OpenAI API
+ * server-side; if you hit rate limits, lower --batch.
  *
  * The script exits with a non-zero code only on fatal errors (db connect
  * failure, missing env). Individual embedding failures are skipped with a
@@ -23,6 +24,7 @@
 require('dotenv').config();
 const { Pool } = require('pg');
 const embeddingClient = require('../embedding-client');
+const chatEmbedding = require('../chat-embedding');
 const { DEFAULT_DIM } = embeddingClient;
 
 function parseArgs(argv) {
@@ -53,14 +55,19 @@ async function main() {
         ssl: process.env.PG_SSL === 'false' ? false : { rejectUnauthorized: false }
     });
 
-    console.log(`[backfill] provider=${embeddingClient.pickProvider()} batch=${opts.batch} max=${opts.max} device=${opts.device || 'ALL'} dryRun=${opts.dryRun}`);
+    console.log(`[backfill] provider=${embeddingClient.pickProvider()} expectedDim=${DEFAULT_DIM} batch=${opts.batch} max=${opts.max} device=${opts.device || 'ALL'} dryRun=${opts.dryRun}`);
 
-    // Ensure the column exists before we try to query it; if pgvector is not
-    // installed this will fail loudly, which is the right thing here.
+    // Ensure the runtime schema exists and matches the selected default
+    // dimension before querying rows. This also resets incompatible legacy
+    // vectors to NULL so the loop below can recompute them.
     try {
+        const schemaReady = await chatEmbedding.initSchema(pool);
+        if (!schemaReady) {
+            throw new Error('chat embedding schema init returned false');
+        }
         await pool.query(`SELECT embedding FROM chat_messages WHERE embedding IS NULL LIMIT 0`);
     } catch (err) {
-        console.error('[backfill] chat_messages.embedding column not available — run the server once to trigger the migration, or install pgvector extension:', err.message);
+        console.error('[backfill] chat_messages.embedding column not available — install pgvector extension and ensure chat_messages exists:', err.message);
         await pool.end();
         process.exit(2);
     }

--- a/backend/tests/jest/chat-embedding-unit.test.js
+++ b/backend/tests/jest/chat-embedding-unit.test.js
@@ -1,0 +1,113 @@
+'use strict';
+
+function createPool(columnType = 'vector(1536)') {
+    const pool = {
+        queries: [],
+        async query(sql) {
+            const text = String(sql);
+            pool.queries.push(text);
+            if (text.includes('pg_catalog.format_type')) {
+                return { rows: [{ column_type: columnType }] };
+            }
+            return { rows: [] };
+        },
+    };
+    return pool;
+}
+
+function queryIndex(pool, needle) {
+    return pool.queries.findIndex((sql) => sql.includes(needle));
+}
+
+describe('chat-embedding schema normalization', () => {
+    let warnSpy;
+
+    beforeEach(() => {
+        jest.resetModules();
+        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+        jest.dontMock('../../embedding-client');
+    });
+
+    it('repairs a legacy unbounded pgvector column before creating the HNSW index', async () => {
+        const chatEmbedding = require('../../chat-embedding');
+        const pool = createPool('vector');
+
+        await chatEmbedding.initSchema(pool);
+
+        expect(queryIndex(pool, 'DROP INDEX IF EXISTS idx_chat_embedding_hnsw')).toBeGreaterThan(-1);
+        expect(queryIndex(pool, 'vector_dims(embedding) <> 1536')).toBeGreaterThan(-1);
+        expect(queryIndex(pool, 'ALTER COLUMN embedding TYPE vector(1536)')).toBeGreaterThan(-1);
+        expect(queryIndex(pool, 'ALTER COLUMN embedding TYPE vector(1536)'))
+            .toBeLessThan(queryIndex(pool, 'CREATE INDEX IF NOT EXISTS idx_chat_embedding_hnsw'));
+    });
+
+    it('repairs a legacy fixed-dimension vector column before creating the HNSW index', async () => {
+        const chatEmbedding = require('../../chat-embedding');
+        const pool = createPool('vector(384)');
+
+        await chatEmbedding.initSchema(pool);
+
+        expect(queryIndex(pool, 'DROP INDEX IF EXISTS idx_chat_embedding_hnsw')).toBeGreaterThan(-1);
+        expect(queryIndex(pool, 'vector_dims(embedding) <> 1536')).toBeGreaterThan(-1);
+        expect(queryIndex(pool, 'ALTER COLUMN embedding TYPE vector(1536)')).toBeGreaterThan(-1);
+        expect(queryIndex(pool, 'CREATE INDEX IF NOT EXISTS idx_chat_embedding_hnsw')).toBeGreaterThan(-1);
+    });
+
+    it('does not rewrite an already dimensioned vector(1536) column', async () => {
+        const chatEmbedding = require('../../chat-embedding');
+        const pool = createPool('vector(1536)');
+
+        await chatEmbedding.initSchema(pool);
+
+        expect(queryIndex(pool, 'DROP INDEX IF EXISTS idx_chat_embedding_hnsw')).toBe(-1);
+        expect(queryIndex(pool, 'ALTER COLUMN embedding TYPE vector(1536)')).toBe(-1);
+        expect(queryIndex(pool, 'CREATE INDEX IF NOT EXISTS idx_chat_embedding_hnsw')).toBeGreaterThan(-1);
+    });
+});
+
+describe('chat-embedding dimension guards', () => {
+    let warnSpy;
+
+    beforeEach(() => {
+        jest.resetModules();
+        warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+        jest.dontMock('../../embedding-client');
+    });
+
+    it('skips semantic search when the query vector has the wrong dimension', async () => {
+        const chatEmbedding = require('../../chat-embedding');
+        const pool = createPool();
+        await chatEmbedding.initSchema(pool);
+        const queryCount = pool.queries.length;
+
+        const rows = await chatEmbedding.searchBySemantic('device-a', Array(1024).fill(0.1));
+
+        expect(rows).toEqual([]);
+        expect(pool.queries).toHaveLength(queryCount);
+    });
+
+    it('skips embedding writes when the generated vector has the wrong dimension', async () => {
+        jest.doMock('../../embedding-client', () => ({
+            DEFAULT_DIM: 1536,
+            generateEmbedding: jest.fn().mockResolvedValue(Array(1024).fill(0.1)),
+            toPgVectorLiteral: jest.fn(() => '[0.100000]'),
+        }));
+        const chatEmbedding = require('../../chat-embedding');
+        const pool = createPool();
+        await chatEmbedding.initSchema(pool);
+        const queryCount = pool.queries.length;
+
+        chatEmbedding.embedMessageAsync('message-1', 'hello');
+        await new Promise((resolve) => setImmediate(resolve));
+
+        expect(pool.queries).toHaveLength(queryCount);
+    });
+});


### PR DESCRIPTION
## Summary
- Normalize `chat_messages.embedding` to the checked-in `DEFAULT_DIM` (`vector(1536)`) before creating `idx_chat_embedding_hnsw`.
- Drop/recreate the HNSW index when repairing a legacy unbounded or wrong-dimension vector column, and clear incompatible generated vectors so they can be recomputed.
- Guard semantic search and async embedding writes so 1024-dimension provider output cannot poison the fixed-dimension pgvector schema.
- Make `backend/scripts/backfill-embeddings.js` run the same schema repair before recomputing `embedding IS NULL` rows.

## Root Cause / Decision
- Source inspection found no checked-in `backend/migrations` DDL for `chat_messages.embedding`; the live DDL is the runtime migration in `backend/chat-embedding.js`.
- `backend/embedding-client.js` (from commit `e523b29f`) defines the intended default as OpenAI `text-embedding-3-small` with `DEFAULT_DIM = 1536`.
- The only checked-in 1024 path is `CHAT_EMBEDDING_PROVIDER=voyage`, whose output is incompatible with the current fixed `vector(1536)` schema. Product/docs also describe OpenAI 1536 as the default.
- Therefore this PR treats 1024 output as the accidental/misconfigured path for the current schema, not as an intentional migration target. If EClaw later wants Voyage 1024 as the primary model, that needs a separate explicit schema/backfill plan.
- The prod `expected 384 got 1024` HNSW failure is consistent with an existing legacy/unbounded or wrong-dimension column/index plus newer 1024 vectors; `ADD COLUMN IF NOT EXISTS` could not repair that existing shape.

## Production Repair Path
1. Deploy this PR so startup normalizes the column/index and rejects wrong-dimension vectors.
2. Ensure the production embedding provider is the intended OpenAI 1536 path, not Voyage 1024, unless a new 1024 schema migration is intentionally planned.
3. Run `node backend/scripts/backfill-embeddings.js --max=0` with the production DB/API key context to recompute rows whose incompatible vectors were cleared to `NULL`.

Reviewer requested by EClaw card `card_563f12c86a8d6e7107747bf6`: #2 / LOBSTER.

## Validation
- `node -c backend/chat-embedding.js`
- `node -c backend/scripts/backfill-embeddings.js`
- `node -c backend/tests/jest/chat-embedding-unit.test.js`
- `npx jest tests/jest/chat-embedding-unit.test.js tests/jest/chat-search.test.js --runInBand`
