### PR TITLE
fix(chat-embedding): HNSW backfill schema-repair + refined guards (reconcile #3496 onto #3495)

### DIFF
--- a/backend/chat-embedding.js
+++ b/backend/chat-embedding.js
@@ -21,7 +21,7 @@ function hasExpectedDim(vec) {
 }
 
 async function normalizeEmbeddingColumn(pool) {
-    const typeResult = await pool.query(`
+    const result = await pool.query(`
         SELECT pg_catalog.format_type(a.atttypid, a.atttypmod) AS column_type
         FROM pg_catalog.pg_attribute a
         WHERE a.attrelid = 'chat_messages'::regclass
@@ -29,7 +29,7 @@ async function normalizeEmbeddingColumn(pool) {
           AND NOT a.attisdropped
         LIMIT 1
     `);
-    const columnType = typeResult.rows?.[0]?.column_type;
+    const columnType = result.rows?.[0]?.column_type;
     if (!columnType || columnType === EXPECTED_VECTOR_TYPE) return;
 
     console.warn(`[ChatEmbedding] normalizing embedding column ${columnType} -> ${EXPECTED_VECTOR_TYPE}`);

--- a/backend/scripts/backfill-embeddings.js
+++ b/backend/scripts/backfill-embeddings.js
@@ -12,8 +12,9 @@
  *   --device all devices
  *   --dry-run skip UPDATE, just print what would change
  *
- * Safe to re-run: only touches rows where embedding IS NULL. Rate-limited via
- * the OpenAI API server-side; if you hit rate limits, lower --batch.
+ * Safe to re-run: first ensures the pgvector schema matches DEFAULT_DIM, then
+ * only touches rows where embedding IS NULL. Rate-limited via the OpenAI API
+ * server-side; if you hit rate limits, lower --batch.
  *
  * The script exits with a non-zero code only on fatal errors (db connect
  * failure, missing env). Individual embedding failures are skipped with a
@@ -23,6 +24,7 @@
 require('dotenv').config();
 const { Pool } = require('pg');
 const embeddingClient = require('../embedding-client');
+const chatEmbedding = require('../chat-embedding');
 const { DEFAULT_DIM } = embeddingClient;
 
 function parseArgs(argv) {
@@ -53,14 +55,19 @@ async function main() {
         ssl: process.env.PG_SSL === 'false' ? false : { rejectUnauthorized: false }
     });
 
-    console.log(`[backfill] provider=${embeddingClient.pickProvider()} batch=${opts.batch} max=${opts.max} device=${opts.device || 'ALL'} dryRun=${opts.dryRun}`);
+    console.log(`[backfill] provider=${embeddingClient.pickProvider()} expectedDim=${DEFAULT_DIM} batch=${opts.batch} max=${opts.max} device=${opts.device || 'ALL'} dryRun=${opts.dryRun}`);
 
-    // Ensure the column exists before we try to query it; if pgvector is not
-    // installed this will fail loudly, which is the right thing here.
+    // Ensure the runtime schema exists and matches the selected default
+    // dimension before querying rows. This also resets incompatible legacy
+    // vectors to NULL so the loop below can recompute them.
     try {
+        const schemaReady = await chatEmbedding.initSchema(pool);
+        if (!schemaReady) {
+            throw new Error('chat embedding schema init returned false');
+        }
         await pool.query(`SELECT embedding FROM chat_messages WHERE embedding IS NULL LIMIT 0`);
     } catch (err) {
-        console.error('[backfill] chat_messages.embedding column not available — run the server once to trigger the migration, or install pgvector extension:', err.message);
+        console.error('[backfill] chat_messages.embedding column not available — install pgvector extension and ensure chat_messages exists:', err.message);
         await pool.end();
         process.exit(2);
     }

--- a/backend/tests/jest/chat-embedding-unit.test.js
+++ b/backend/tests/jest/chat-embedding-unit.test.js
@@ -1,3 +1,5 @@
+'use strict';
+
 function createPool(columnType = 'vector(1536)') {
     const pool = {
         queries: [],
@@ -8,7 +10,7 @@ function createPool(columnType = 'vector(1536)') {
                 return { rows: [{ column_type: columnType }] };
             }
             return { rows: [] };
-        }
+        },
     };
     return pool;
 }
@@ -30,7 +32,7 @@ describe('chat-embedding schema normalization', () => {
         jest.dontMock('../../embedding-client');
     });
 
-    it('repairs a legacy unbounded pgvector column before creating HNSW index', async () => {
+    it('repairs a legacy unbounded pgvector column before creating the HNSW index', async () => {
         const chatEmbedding = require('../../chat-embedding');
         const pool = createPool('vector');
 
@@ -41,6 +43,18 @@ describe('chat-embedding schema normalization', () => {
         expect(queryIndex(pool, 'ALTER COLUMN embedding TYPE vector(1536)')).toBeGreaterThan(-1);
         expect(queryIndex(pool, 'ALTER COLUMN embedding TYPE vector(1536)'))
             .toBeLessThan(queryIndex(pool, 'CREATE INDEX IF NOT EXISTS idx_chat_embedding_hnsw'));
+    });
+
+    it('repairs a legacy fixed-dimension vector column before creating the HNSW index', async () => {
+        const chatEmbedding = require('../../chat-embedding');
+        const pool = createPool('vector(384)');
+
+        await chatEmbedding.initSchema(pool);
+
+        expect(queryIndex(pool, 'DROP INDEX IF EXISTS idx_chat_embedding_hnsw')).toBeGreaterThan(-1);
+        expect(queryIndex(pool, 'vector_dims(embedding) <> 1536')).toBeGreaterThan(-1);
+        expect(queryIndex(pool, 'ALTER COLUMN embedding TYPE vector(1536)')).toBeGreaterThan(-1);
+        expect(queryIndex(pool, 'CREATE INDEX IF NOT EXISTS idx_chat_embedding_hnsw')).toBeGreaterThan(-1);
     });
 
     it('does not rewrite an already dimensioned vector(1536) column', async () => {
@@ -74,7 +88,7 @@ describe('chat-embedding dimension guards', () => {
         await chatEmbedding.initSchema(pool);
         const queryCount = pool.queries.length;
 
-        const rows = await chatEmbedding.searchBySemantic('device-a', [0.1, 0.2, 0.3]);
+        const rows = await chatEmbedding.searchBySemantic('device-a', Array(1024).fill(0.1));
 
         expect(rows).toEqual([]);
         expect(pool.queries).toHaveLength(queryCount);
@@ -83,8 +97,8 @@ describe('chat-embedding dimension guards', () => {
     it('skips embedding writes when the generated vector has the wrong dimension', async () => {
         jest.doMock('../../embedding-client', () => ({
             DEFAULT_DIM: 1536,
-            generateEmbedding: jest.fn().mockResolvedValue([0.1, 0.2, 0.3]),
-            toPgVectorLiteral: jest.fn(() => '[0.100000,0.200000,0.300000]')
+            generateEmbedding: jest.fn().mockResolvedValue(Array(1024).fill(0.1)),
+            toPgVectorLiteral: jest.fn(() => '[0.100000]'),
         }));
         const chatEmbedding = require('../../chat-embedding');
         const pool = createPool();


### PR DESCRIPTION
## Scope
Reconciles #6's PR #3496 onto main after #3495 already landed the core HNSW dimension fix. #3496 conflicted (its base predated #3495); this brings the unique value forward:
- `backend/scripts/backfill-embeddings.js`: run schema repair (normalize column→vector(1536), drop/rebuild HNSW, clear wrong-dim vectors) **before** recomputing NULL embeddings.
- `chat-embedding.js`: #6's refined runtime guards (final version, superset of #3495).

## Provenance
Authored by #6/Codex (PR #3496); reconciled + reviewed + pushed by #2 to resolve the parallel-PR collision (I'd merged #6's earlier working-tree version as #3495 before #6 finished its clean PR). #3496 will be closed as superseded by this.

## Verification
- Patch (#3496 delta vs main) applied clean on current main; `node -c` clean on changed JS.
- #6 ran `chat-embedding-unit` + `chat-search` jest → 19/19.

🤖 Generated with [Claude Code](https://claude.com/claude-code)