### PR TITLE
feat(embedding): zero-key local ONNX provider (multilingual-e5-small, 384d)

### DIFF
--- a/backend/chat-embedding.js
+++ b/backend/chat-embedding.js
@@ -94,7 +94,9 @@ function embedMessageAsync(messageId, text, opts = {}) {
     if (!vectorEnabled || !messageId || !text) return;
     setImmediate(async () => {
         try {
-            const vec = await generateEmbedding(text, opts);
+            // Stored chat messages are "passages" for asymmetric (e5-style) local
+            // models; the role hint is ignored by symmetric providers (openai/voyage).
+            const vec = await generateEmbedding(text, { ...opts, role: 'passage' });
             if (!vec) return;
             if (!hasExpectedDim(vec)) {
                 console.warn(`[ChatEmbedding] skip embedding write for ${messageId}: dim=${vectorDim(vec)} expected=${DEFAULT_DIM}`);

--- a/backend/embedding-client.js
+++ b/backend/embedding-client.js
@@ -1,23 +1,68 @@
 /**
- * Embedding client — thin wrapper around OpenAI / Voyage embedding APIs.
+ * Embedding client — thin wrapper around OpenAI / Voyage / local embedding backends.
  *
  * Design goals:
  *   1. Fail gracefully when no API key is configured — caller handles null return
  *   2. Support BYO (bring-your-own) key via device-vars (same pattern as Track 4
  *      Claude channel binding); fall back to server env var
- *   3. Provider-agnostic: OpenAI text-embedding-3-small (1536 dim) is the default;
- *      Voyage-3 (1024 dim) is selectable via CHAT_EMBEDDING_PROVIDER env var, but
- *      the chat_messages.embedding column is fixed at vector(1536) so Voyage
- *      requires schema re-provisioning — handled by failing loudly at embed time.
+ *   3. Provider-agnostic via CHAT_EMBEDDING_PROVIDER:
+ *        - 'openai' (default): text-embedding-3-small, 1536 dim — needs OPENAI_API_KEY
+ *        - 'voyage': voyage-3, 1024 dim — needs VOYAGE_API_KEY
+ *        - 'local': @xenova/transformers ONNX, multilingual-e5-small, 384 dim —
+ *          ZERO API key, runs in-process. Model weights auto-download once then
+ *          run offline. Picked for keyless multilingual (Globe-user) deployments.
+ *      The chat_messages.embedding column is provisioned to vector(DEFAULT_DIM);
+ *      chat-embedding.js#normalizeEmbeddingColumn auto-migrates + rebuilds the HNSW
+ *      index + clears mismatched vectors when the active provider's dim changes.
  */
 
-const DEFAULT_MODEL = 'text-embedding-3-small';
-const DEFAULT_DIM = 1536;
-
+// ---- provider + dimension resolution (read once at module load; env is set at boot)
 function pickProvider() {
     const p = String(process.env.CHAT_EMBEDDING_PROVIDER || 'openai').toLowerCase();
+    if (p === 'local') return 'local';
     if (p === 'voyage') return 'voyage';
     return 'openai';
+}
+
+// Local model is configurable but defaults to the lightweight multilingual e5.
+const LOCAL_MODEL = process.env.LOCAL_EMBEDDING_MODEL || 'Xenova/multilingual-e5-small';
+const LOCAL_DIM = parseInt(process.env.LOCAL_EMBEDDING_DIM, 10) || 384;
+
+const DIM_BY_PROVIDER = { openai: 1536, voyage: 1024, local: LOCAL_DIM };
+
+const DEFAULT_MODEL = 'text-embedding-3-small';
+// DEFAULT_DIM tracks the ACTIVE provider so the schema/guards in chat-embedding.js
+// provision the matching vector(N) column. Changing CHAT_EMBEDDING_PROVIDER and
+// rebooting triggers an automatic column migration + HNSW rebuild + backfill.
+const DEFAULT_DIM = DIM_BY_PROVIDER[pickProvider()] || 1536;
+
+// ---- local ONNX backend (lazy: pipeline + weights load only on first embed) ----
+let _localPipelinePromise = null;
+function getLocalPipeline() {
+    if (!_localPipelinePromise) {
+        _localPipelinePromise = (async () => {
+            // dynamic import: @xenova/transformers is ESM-only
+            const { pipeline, env } = await import('@xenova/transformers');
+            // Allow remote weight download (first run) + on-disk cache for reuse.
+            env.allowRemoteModels = true;
+            return pipeline('feature-extraction', LOCAL_MODEL);
+        })().catch((err) => {
+            // Reset so a transient failure (e.g. download hiccup) can retry next call.
+            _localPipelinePromise = null;
+            throw err;
+        });
+    }
+    return _localPipelinePromise;
+}
+
+async function embedLocal(text, role) {
+    const pipe = await getLocalPipeline();
+    // e5 family expects an asymmetric "query: " / "passage: " prefix. Stored
+    // messages are passages; search inputs are queries. Default to query.
+    const prefix = role === 'passage' ? 'passage: ' : 'query: ';
+    const input = /^(query|passage):\s/.test(text) ? text : prefix + text;
+    const output = await pipe(input, { pooling: 'mean', normalize: true });
+    return Array.from(output.data);
 }
 
 async function resolveApiKey(deviceId, provider, getDeviceVar) {
@@ -79,6 +124,15 @@ async function generateEmbedding(text, opts = {}) {
     if (!text || typeof text !== 'string' || text.trim().length === 0) return null;
     const clipped = text.length > 8000 ? text.slice(0, 8000) : text;
     const provider = pickProvider();
+    // Local backend needs no API key — runs the ONNX model in-process.
+    if (provider === 'local') {
+        try {
+            return await embedLocal(clipped, opts.role);
+        } catch (err) {
+            console.warn('[Embedding] local generateEmbedding failed:', err.message);
+            return null;
+        }
+    }
     const apiKey = await resolveApiKey(opts.deviceId, provider, opts.getDeviceVar);
     if (!apiKey) return null;
     try {
@@ -102,6 +156,7 @@ function toPgVectorLiteral(vec) {
 
 function isConfigured() {
     const provider = pickProvider();
+    if (provider === 'local') return true; // no key required — model runs in-process
     return !!(provider === 'voyage' ? process.env.VOYAGE_API_KEY : process.env.OPENAI_API_KEY);
 }
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -29,6 +29,7 @@
     "@aws-sdk/s3-request-presigner": "^3.1028.0",
     "@grpc/grpc-js": "^1.14.3",
     "@grpc/proto-loader": "^0.8.0",
+    "@xenova/transformers": "^2.17.2",
     "bcrypt": "^6.0.0",
     "compression": "^1.8.1",
     "cookie-parser": "^1.4.7",

--- a/backend/tests/jest/chat-embedding-unit.test.js
+++ b/backend/tests/jest/chat-embedding-unit.test.js
@@ -1,6 +1,14 @@
 'use strict';
 
-function createPool(columnType = 'vector(1536)') {
+// DEFAULT_DIM is provider-driven (openai=1536, voyage=1024, local=384). The
+// schema-normalization assertions derive the expected dimension from the module
+// rather than hard-coding 1536, so the suite stays correct under any provider.
+const { DEFAULT_DIM } = require('../../embedding-client');
+const EXPECTED_TYPE = `vector(${DEFAULT_DIM})`;
+const LEGACY_DIM = DEFAULT_DIM + 1; // any dim that differs from the active one
+const WRONG_DIM = DEFAULT_DIM === 1024 ? 1536 : 1024; // a dim != DEFAULT_DIM
+
+function createPool(columnType = EXPECTED_TYPE) {
     const pool = {
         queries: [],
         async query(sql) {
@@ -39,32 +47,32 @@ describe('chat-embedding schema normalization', () => {
         await chatEmbedding.initSchema(pool);
 
         expect(queryIndex(pool, 'DROP INDEX IF EXISTS idx_chat_embedding_hnsw')).toBeGreaterThan(-1);
-        expect(queryIndex(pool, 'vector_dims(embedding) <> 1536')).toBeGreaterThan(-1);
-        expect(queryIndex(pool, 'ALTER COLUMN embedding TYPE vector(1536)')).toBeGreaterThan(-1);
-        expect(queryIndex(pool, 'ALTER COLUMN embedding TYPE vector(1536)'))
+        expect(queryIndex(pool, `vector_dims(embedding) <> ${DEFAULT_DIM}`)).toBeGreaterThan(-1);
+        expect(queryIndex(pool, `ALTER COLUMN embedding TYPE ${EXPECTED_TYPE}`)).toBeGreaterThan(-1);
+        expect(queryIndex(pool, `ALTER COLUMN embedding TYPE ${EXPECTED_TYPE}`))
             .toBeLessThan(queryIndex(pool, 'CREATE INDEX IF NOT EXISTS idx_chat_embedding_hnsw'));
     });
 
     it('repairs a legacy fixed-dimension vector column before creating the HNSW index', async () => {
         const chatEmbedding = require('../../chat-embedding');
-        const pool = createPool('vector(384)');
+        const pool = createPool(`vector(${LEGACY_DIM})`);
 
         await chatEmbedding.initSchema(pool);
 
         expect(queryIndex(pool, 'DROP INDEX IF EXISTS idx_chat_embedding_hnsw')).toBeGreaterThan(-1);
-        expect(queryIndex(pool, 'vector_dims(embedding) <> 1536')).toBeGreaterThan(-1);
-        expect(queryIndex(pool, 'ALTER COLUMN embedding TYPE vector(1536)')).toBeGreaterThan(-1);
+        expect(queryIndex(pool, `vector_dims(embedding) <> ${DEFAULT_DIM}`)).toBeGreaterThan(-1);
+        expect(queryIndex(pool, `ALTER COLUMN embedding TYPE ${EXPECTED_TYPE}`)).toBeGreaterThan(-1);
         expect(queryIndex(pool, 'CREATE INDEX IF NOT EXISTS idx_chat_embedding_hnsw')).toBeGreaterThan(-1);
     });
 
-    it('does not rewrite an already dimensioned vector(1536) column', async () => {
+    it('does not rewrite an already correctly dimensioned vector column', async () => {
         const chatEmbedding = require('../../chat-embedding');
-        const pool = createPool('vector(1536)');
+        const pool = createPool(EXPECTED_TYPE);
 
         await chatEmbedding.initSchema(pool);
 
         expect(queryIndex(pool, 'DROP INDEX IF EXISTS idx_chat_embedding_hnsw')).toBe(-1);
-        expect(queryIndex(pool, 'ALTER COLUMN embedding TYPE vector(1536)')).toBe(-1);
+        expect(queryIndex(pool, `ALTER COLUMN embedding TYPE ${EXPECTED_TYPE}`)).toBe(-1);
         expect(queryIndex(pool, 'CREATE INDEX IF NOT EXISTS idx_chat_embedding_hnsw')).toBeGreaterThan(-1);
     });
 });
@@ -88,7 +96,7 @@ describe('chat-embedding dimension guards', () => {
         await chatEmbedding.initSchema(pool);
         const queryCount = pool.queries.length;
 
-        const rows = await chatEmbedding.searchBySemantic('device-a', Array(1024).fill(0.1));
+        const rows = await chatEmbedding.searchBySemantic('device-a', Array(WRONG_DIM).fill(0.1));
 
         expect(rows).toEqual([]);
         expect(pool.queries).toHaveLength(queryCount);
@@ -96,8 +104,8 @@ describe('chat-embedding dimension guards', () => {
 
     it('skips embedding writes when the generated vector has the wrong dimension', async () => {
         jest.doMock('../../embedding-client', () => ({
-            DEFAULT_DIM: 1536,
-            generateEmbedding: jest.fn().mockResolvedValue(Array(1024).fill(0.1)),
+            DEFAULT_DIM,
+            generateEmbedding: jest.fn().mockResolvedValue(Array(WRONG_DIM).fill(0.1)),
             toPgVectorLiteral: jest.fn(() => '[0.100000]'),
         }));
         const chatEmbedding = require('../../chat-embedding');


### PR DESCRIPTION
## Why
Hank's deployment has **no OpenAI API key**, so vector search — the flagship cross-session memory feature — was dead (embeddings returned null, search silently fell back to keyword). This adds a **keyless** embedding backend.

## What
New `local` provider in `embedding-client.js` running **`Xenova/multilingual-e5-small`** (384-dim) in-process via `@xenova/transformers`. Zero API key, no Python — model weights auto-download once then run offline. Multilingual (zh/en/全球 Globe-user).

- **embedding-client.js**: `local` provider; **lazy-loaded** pipeline (weights load only on first embed → never blocks boot); e5 `query:`/`passage:` prefixing; `DEFAULT_DIM` now provider-driven (local=384, voyage=1024, openai=1536); `isConfigured()`=true for local
- **chat-embedding.js**: stored messages embed with `role:'passage'`
- existing `normalizeEmbeddingColumn()` auto-migrates column → `vector(384)` + rebuilds HNSW + clears mismatched vectors on next boot; `backfill-embeddings.js` recomputes
- **tests**: derive expected dim from `DEFAULT_DIM` (no longer hard-code 1536); pass under both providers

## Activate
Set `CHAT_EMBEDDING_PROVIDER=local` on Railway. (Optional: `LOCAL_EMBEDDING_MODEL`, `LOCAL_EMBEDDING_DIM`.)

## Test plan & evidence
- 5/5 jest unit tests pass under **both** openai(1536) and local(384) providers
- Local smoke test: model loads, emits **384-dim** vectors, **zh** semantic ordering correct (related 0.898 > unrelated 0.802), zero API key. First-embed 26.6s = one-time model load; subsequent fast.

## Risk
Railway memory: first embed loads the ONNX model (~quantized 100MB-class). Lazy-load means boot is unaffected; if the instance RAM is <512MB this could be tight — monitor first-embed after deploy, fall back to a smaller model via `LOCAL_EMBEDDING_MODEL` if needed.

## Out of scope
Provider auto-detection; embedding cache warming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)