### PR TITLE
fix(kanban): downgrade autoReviewOnTransform-skipped warn → debug (log hygiene)

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -3974,13 +3974,13 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                         aboutCardId = unique[0];
                         console.log(`[Kanban] autoReviewOnTransform inferred aboutCardId=${aboutCardId} from entity ${entityId} message text`);
                     } else {
-                        console.warn(`[Kanban] autoReviewOnTransform skipped: entity ${entityId} mentioned ${unique.length} distinct card_ids in message but no explicit aboutCardId — pass {aboutCardId:"card_..."} to disambiguate`);
+                        console.debug(`[Kanban] autoReviewOnTransform skipped: entity ${entityId} mentioned ${unique.length} distinct card_ids in message but no explicit aboutCardId — pass {aboutCardId:"card_..."} to disambiguate`);
                         return;
                     }
                 }
             }
             if (!aboutCardId) {
-                console.warn(`[Kanban] autoReviewOnTransform skipped: no aboutCardId provided by entity ${entityId} — pass {aboutCardId:"card_..."} in transform body to auto-close a specific card`);
+                console.debug(`[Kanban] autoReviewOnTransform skipped: no aboutCardId provided by entity ${entityId} — pass {aboutCardId:"card_..."} in transform body to auto-close a specific card`);
                 return;
             }
             // Find active card assigned to this entity that is in todo/in_progress.


### PR DESCRIPTION
## Why
The two `[Kanban] autoReviewOnTransform skipped` `console.warn` lines fire on **every** normal transform/IDLE message lacking an `aboutCardId` (most bot-to-bot traffic). They're benign advisories (skip is correct by-design), not errors — but at warn-level they dominate prod log volume and trip the 6h Railway log classifier into **false ERROR-high → false P1** cards every cycle (surfaced 06-18: entity2×10 + entity5×5).

## What
Downgrade both to `console.debug` (off by default). Log-level only — **zero behavior change**. Defense-in-depth alongside #5's classifier IGN3 exclusion (option a).

## Test plan
`node -c backend/kanban.js` passes. No logic touched.

## Card
card_8673e224 (mother card_b2fc0e2d). Related: archived card_daf61fd7 (same benign warn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)