### PR TITLE
test(kanban): accept console.debug in autoReview skip-guard assertion (follow #3499)

### DIFF
--- a/backend/tests/jest/kanban-autoreview-cardid-infer.test.js
+++ b/backend/tests/jest/kanban-autoreview-cardid-infer.test.js
@@ -49,8 +49,10 @@ describe('autoReviewOnTransform — aboutCardId inference from transformMessage 
     });
 
     test('legacy "skip when nothing extractable" guard still runs as the second gate', () => {
-        // After inference attempt, if aboutCardId still undefined → skip
-        expect(body).toMatch(/if\s*\(\s*!\s*aboutCardId\s*\)\s*{\s*console\.warn\([^)]*no aboutCardId provided[\s\S]*?return\s*;?\s*}/);
+        // After inference attempt, if aboutCardId still undefined → skip.
+        // Log level is warn|debug (PR #3499 downgraded to debug for log hygiene);
+        // the gate's behavior — advise + return — is what matters here.
+        expect(body).toMatch(/if\s*\(\s*!\s*aboutCardId\s*\)\s*{\s*console\.(?:warn|debug)\([^)]*no aboutCardId provided[\s\S]*?return\s*;?\s*}/);
     });
 });
 


### PR DESCRIPTION
## Why
#3499 downgraded the `autoReviewOnTransform … no aboutCardId` `console.warn`→`console.debug` (log hygiene). This source-pattern test in `kanban-autoreview-cardid-infer.test.js` hard-matched `console\.warn`, so **main Jest went red** after #3499 merged.

## What
Widen the regex to `console\.(?:warn|debug)`. The test's intent is that the skip-guard *advises + returns*, not the specific log level.

## Test plan
`npx jest tests/jest/kanban-autoreview-cardid-infer.test.js` → 13/13 pass against current `kanban.js` (debug). 

My miss for admin-merging #3499 without running the full suite first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)