### PR TITLE
fix(grpc): coerce PORT to int so gRPC server starts in prod (real fix, not log-downgrade)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -23622,7 +23622,10 @@ if (require.main === module) {
         // Start gRPC server on PORT+1
         try {
             const grpcModule = require('./grpc-server')(devices, { serverLog });
-            const fallbackPort = port + 1;
+            // `port` is `process.env.PORT || 3000` — a STRING in prod (Railway), so
+            // `port + 1` would string-concat ("8080"+1="80801" > 65535) and crash
+            // gRPC bind with "options.port should be >= 0 and < 65536". Coerce first.
+            const fallbackPort = parseInt(port, 10) + 1;
             let grpcPort = parseInt(process.env.GRPC_PORT || fallbackPort, 10);
             if (!Number.isInteger(grpcPort) || grpcPort < 0 || grpcPort >= 65536) {
                 console.warn(`[gRPC] Invalid GRPC_PORT="${process.env.GRPC_PORT}" (out of 0-65535) — falling back to PORT+1=${fallbackPort}`);

--- a/backend/tests/jest/grpc-port-validation.test.js
+++ b/backend/tests/jest/grpc-port-validation.test.js
@@ -6,8 +6,10 @@ const path = require('path');
 const indexSrc = fs.readFileSync(path.join(__dirname, '..', '..', 'index.js'), 'utf8');
 
 describe('gRPC port validation — guard against bad GRPC_PORT env (card_e0a7e1ca)', () => {
-    test('grpcPort fallback variable is computed once as port+1', () => {
-        expect(indexSrc).toMatch(/const fallbackPort = port \+ 1;/);
+    test('grpcPort fallback is port+1 with PORT coerced to int (prod sends PORT as string)', () => {
+        // Must parseInt(port) before +1, else "8080"+1 string-concats to "80801" (>65535)
+        // and crashes gRPC bind. See fix/grpc-port-string-coercion.
+        expect(indexSrc).toMatch(/const fallbackPort = parseInt\(port, 10\) \+ 1;/);
     });
 
     test('parseInt receives explicit radix 10 (defensive against leading-zero / octal)', () => {


### PR DESCRIPTION
## Context
Follow-up to Hank's principle: *an error must mean a real problem — no 'benign errors'.* Auditing the Railway error log under that lens, the recurring `[gRPC] Failed to start server: options.port should be >= 0 and < 65536` is **not noise — gRPC is genuinely down in prod.**

## Root cause
`const port = process.env.PORT || 3000` is a **string** in prod (Railway). `const fallbackPort = port + 1` string-concatenates → `"8080"+1 = "80801"` (> 65535). The out-of-range guard trips, logs `Invalid GRPC_PORT`, and reassigns `grpcPort = fallbackPort` — still the bad `"80801"` string — so `bindAsync` gets an invalid port and gRPC never starts.

## Fix
`const fallbackPort = parseInt(port, 10) + 1;`. Verified: string `PORT='8080'` → fallback `8081` (int), guard passes, binds `0.0.0.0:8081`. Local default (3000 number) unaffected. The `Invalid GRPC_PORT` warn also becomes honest (only fires on a genuinely bad user-set value).

## Test
`grpc-port-validation.test.js` updated to assert the int-coerced form → 14/14 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)