### PR TITLE
fix(settings): skip /api/usage/snapshot stale-check when not authenticated

### DIFF
--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -2768,6 +2768,10 @@
         async function refreshUsageWarningStaleNotice() {
             const notice = document.getElementById('usageWarningStaleNotice');
             if (!notice) return;
+            // Skip when not authenticated: /api/usage/snapshot needs a session, so
+            // calling it pre-login returns a misleading 400 (missing-creds) in the
+            // console for no benefit — the stale notice is irrelevant when logged out.
+            if (typeof currentUser === 'undefined' || !currentUser) { notice.style.display = 'none'; return; }
             try {
                 const data = await apiCall('GET', '/api/usage/snapshot');
                 const cap = data && data.latest && data.latest.captured_at;


### PR DESCRIPTION
## Why
P0 console-QA (2026-06-18) found `GET /api/usage/snapshot` returning **400** (not 401) on `settings.html` load. `refreshUsageWarningStaleNotice()` fires it unconditionally; the endpoint needs a session and returns `400 'deviceId and deviceSecret required, or valid session cookie'` when called pre-login. Already caught+ignored, but per Hank's *no-benign-errors* principle it shouldn't appear.

## Fix
Guard on `currentUser` (the same auth signal `passiveHealthAuthQuery` uses) — skip the call and hide the notice when logged out. Zero change for authenticated users (cookie auth still works).

## Test plan
Portal Smoke CI. Manual: unauthenticated settings load → no `/api/usage/snapshot` request in network/console; authenticated load → stale-check runs as before.

Card: card_2322e8c6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)