### PR TITLE
fix(a11y): non-color ⚠ glyph on destructive confirm OK button

### DIFF
--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -189,7 +189,7 @@ function showConfirm({ message, title, confirmText, cancelText, danger, itemName
             <div class="dialog-body"><p id="${messageId}" style="margin:0;line-height:1.6;color:var(--text-secondary)">${_escHtml(message)}</p>${itemStrip}</div>
             <div class="dialog-actions">
                 <button type="button" class="btn btn-outline eclaw-confirm-cancel"${danger && !cancelText ? ` aria-label="${_escAttr(t('dialog_cancel_aria', 'Cancel, keep current state'))}"` : ''}>${_escHtml(cancelText || t('dialog_cancel', 'Cancel'))}</button>
-                <button type="button" class="btn ${danger ? 'btn-danger' : 'btn-primary'} eclaw-confirm-ok"${danger && !confirmText ? ` aria-label="${_escAttr(t('dialog_confirm_destructive', 'Confirm destructive action'))}"` : ''}>${_escHtml(confirmText || (danger ? t('dialog_confirm', 'Confirm') : t('dialog_ok', 'OK')))}</button>
+                <button type="button" class="btn ${danger ? 'btn-danger' : 'btn-primary'} eclaw-confirm-ok"${danger && !confirmText ? ` aria-label="${_escAttr(t('dialog_confirm_destructive', 'Confirm destructive action'))}"` : ''}>${danger ? '<span class="eclaw-confirm-danger-glyph" aria-hidden="true">⚠ </span>' : ''}${_escHtml(confirmText || (danger ? t('dialog_confirm', 'Confirm') : t('dialog_ok', 'OK')))}</button>
             </div>
         </div>`;
         document.body.appendChild(overlay);


### PR DESCRIPTION
## Why
destructive-modals daily E2E Phase 2 (card_441a7b5d): the `showConfirm({danger:true})` OK button conveyed destructiveness via **red color alone** (`btn-danger`). Fails colorblind users + Apple HIG / Material guidance (destructive confirms shouldn't rely on a single channel). Per Hank's no-color-only-signal principle.

## What
Prepend an `aria-hidden` ⚠ glyph to the danger OK label → cue is now **icon + color** (two channels), generic across any destructive action. Screen readers unaffected (existing `aria-label="Confirm destructive action"` conveys intent; glyph is decorative). Non-danger buttons unchanged.

## Test plan
16/16 existing `showConfirm-*` jest tests pass (danger-default-focus, a11y-attrs, scroll-lock). `node -c` clean.

Card: card_441a7b5d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)