### PR TITLE
chore(roadmap): drop Desktop Phase 4 + mark H3-t1 done + OODA-R kickoff→shipped

### DIFF
--- a/backend/public/portal/roadmap.html
+++ b/backend/public/portal/roadmap.html
@@ -445,7 +445,7 @@
             </p>
 
             <p style="font-size:12px;color:var(--text-secondary);margin-top:14px;padding-top:10px;border-top:1px dashed var(--card-border);">
-                Status: 🟡 kickoff (2026-06-07). #1/#6 reviews integrated. Next: split into 9 implementation cards, ship Phase 0+1 within the week. Live progress on <code>card_be59aa034883fe36d3645a27</code>.
+                Status: ✅ shipped (Phase 1–4 complete). All 9 implementation cards landed; live progress on <code>card_be59aa034883fe36d3645a27</code> and per-card status under <code>/api/mission/roadmap-status</code>.
             </p>
         </div>
 
@@ -761,7 +761,7 @@
                 <h3>Phase H3 — <span data-i18n="rm_h3_name">Private Repo Support</span> <span class="rm-status-badge partial" data-i18n="rm_in_progress">In Progress</span></h3>
                 <div class="rm-phase-desc" data-i18n="rm_h3_desc">Hermes can operate on private repositories. Aligned with <a href="info.html#guide/card_f531861e" style="color:var(--primary);">card_f531861e</a> (claude-cli-proxy vault integration). Target: Hermes can clone/push to any EClaw org private repo without anonymous fallback.</div>
                 <ul class="rm-tasks">
-                    <li class="partial" data-i18n="rm_h3_t1">claude-cli-proxy reads GIT_HUB2 from vault (card_f531861e) — Hermes git operations use authenticated context instead of anonymous fallback</li>
+                    <li class="done" data-i18n="rm_h3_t1">claude-cli-proxy reads GIT_HUB2 from vault (card_f531861e ✅ done; backend/hermes-org-token.js shipped) — Hermes git operations use authenticated context instead of anonymous fallback</li>
                     <li class="todo" data-i18n="rm_h3_t2">Per-org credential scope: Hermes receives org-specific token; cannot access repos outside assigned orgs</li>
                     <li class="partial" data-i18n="rm_h3_t3">Hermes tested against a private test repo — clone, branch, commit, push, PR all succeed</li>
                 </ul>
@@ -911,18 +911,8 @@
                 </ul>
             </div>
 
-            <div class="rm-phase todo">
-                <h3>Phase 4 — <span data-i18n="rm_d4_name">企業級功能</span> <span class="rm-status-badge todo" data-i18n="rm_todo">Todo</span></h3>
-                <div class="rm-phase-desc" data-i18n="rm_d4_desc">2-3 週：批量部署、安全強化、合規報告</div>
-                <ul class="rm-tasks">
-                    <li class="todo">企業配置模板</li>
-                    <li class="todo">靜默安裝選項</li>
-                    <li class="todo">集中管理介面</li>
-                    <li class="todo">企業憑證整合</li>
-                    <li class="todo">審計日誌</li>
-                    <li class="todo">合規報告生成</li>
-                </ul>
-            </div>
+            <!-- Phase 4 (Enterprise Features) intentionally removed 2026-06-18: Hank scoped this initiative
+                 down to Phases 1–3 only. Out-of-scope items kept in kanban backlog if revived. -->
 
             <!-- Key Technical Challenges -->
             <div style="background:rgba(239,68,68,0.08);border:1px solid rgba(239,68,68,0.25);border-radius:var(--radius-sm);padding:14px 16px;margin-top:16px;">


### PR DESCRIPTION
## Summary
- Drop Desktop App Phase 4 (enterprise features) per Hank 2026-06-18 scope decision
- Mark Hermes Phase H3-t1 done (card_f531861e closed; backend/hermes-org-token.js shipped)
- Fix OODA-R banner stale "kickoff" → "shipped" (live /api/mission/roadmap-status shows 9/9 shipped)

## Test plan
- [ ] roadmap.html still renders without layout regression
- [ ] No console errors on /portal/roadmap.html load
- [ ] Phase H4 (Showcase Ready) section directly follows H3, no gap from removed Phase 4
- [ ] OODA-R section reads "✅ shipped" with 9/9 reference link working

## Out-of-scope
- Orphan i18n keys (rm_d4_name / rm_d4_desc) intentionally left in shared/i18n.js to avoid risky regex-based multi-locale delete; cleanup deferred per [[feedback_i18n_dedup_needs_ast]]
- Top-up System ② Stub status note (separate follow-up — code already shipped but production GOOGLE_PLAY_SERVICE_ACCOUNT not configured)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TNyVYteNS318xV1RwdQ1Gr