### PR TITLE
fix(nav): guard ecoin badge wallet fetch behind auth (#3513)

### DIFF
--- a/backend/public/portal/shared/nav.js
+++ b/backend/public/portal/shared/nav.js
@@ -134,6 +134,11 @@ function doLogout() { logout(); }
 // (e.g. user has no wallet yet).
 async function _loadNavEcoinBadge() {
     try {
+        // Guard: only fetch the wallet balance when authenticated. On public /
+        // unauthenticated pages window.currentUser is unset (auth.js populates it
+        // after /me succeeds); skipping here avoids a 401 console error on every
+        // public page view. See issue #3513.
+        if (!window.currentUser) return;
         const badge = document.getElementById('ecoinBadge');
         const amountEl = document.getElementById('ecoinAmount');
         if (!badge || !amountEl) return;


### PR DESCRIPTION
Fixes #3513.

## Problem
`_loadNavEcoinBadge()` (shared nav.js) auto-fired via setTimeout on every portal page including public/unauthenticated ones, calling `GET /api/wallet/balance` → **401 console error** on roadmap.html, info.html, etc.

## Fix
Added `if (!window.currentUser) return;` guard — `window.currentUser` is set by auth.js `checkAuth()` after /me succeeds, so the wallet call now only runs for authenticated users.

## Test
- Before: console shows `Failed to load resource: 401 @ /api/wallet/balance` on roadmap.html + info.html (verified via Playwright).
- After deploy: re-run console sweep, expect 0 errors.
- node --check syntax OK.

Found by daily QA/UIUX regression sweep (card_0cb56b2662732d8749daa171).

🤖 Generated with [Claude Code](https://claude.com/claude-code)