### PR TITLE
feat(desktop): P1-A Tauri 2 scaffold + command layer

### DIFF
--- a/eclaw-desktop/.gitignore
+++ b/eclaw-desktop/.gitignore
@@ -1,0 +1,7 @@
+node_modules/
+dist/
+src-tauri/target/
+src-tauri/gen/
+*.log
+.DS_Store
+Thumbs.db

--- a/eclaw-desktop/index.html
+++ b/eclaw-desktop/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="zh-TW">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' https://eclawbot.com https://eclaw.up.railway.app"
+    />
+    <title>EClaw Desktop</title>
+  </head>
+  <body>
+    <div id="app">
+      <h1>EClaw Desktop</h1>
+      <p>載入中...</p>
+    </div>
+    <script type="module" src="./src/main.ts"></script>
+  </body>
+</html>

--- a/eclaw-desktop/package.json
+++ b/eclaw-desktop/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "eclaw-desktop",
+  "version": "0.1.0",
+  "private": true,
+  "description": "EClaw Desktop - One-click agent binding in 30 seconds",
+  "scripts": {
+    "dev": "tauri dev",
+    "build": "tauri build",
+    "build:debug": "tauri build --debug",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@tauri-apps/api": "^2.0.0"
+  },
+  "devDependencies": {
+    "@tauri-apps/cli": "^2.0.0",
+    "@types/node": "^20.0.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/eclaw-desktop/src-tauri/Cargo.toml
+++ b/eclaw-desktop/src-tauri/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "eclaw-desktop"
+version = "0.1.0"
+edition = "2021"
+
+[build-dependencies]
+tauri-build = { version = "2", features = [] }
+
+[dependencies]
+tauri = { version = "2", features = [] }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+rustc-version = "0.4"
+
+[profile.release]
+strip = true
+lto = true
+codegen-units = 1
+panic = "abort"

--- a/eclaw-desktop/src-tauri/build.rs
+++ b/eclaw-desktop/src-tauri/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    tauri_build::build()
+}

--- a/eclaw-desktop/src-tauri/capabilities/default.json
+++ b/eclaw-desktop/src-tauri/capabilities/default.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "../gen/schemas/desktop-schema.json",
+  "identifier": "default",
+  "description": "Default capability for EClaw Desktop",
+  "windows": ["main"],
+  "permissions": [
+    "core:default",
+    "core:window:allow-close",
+    "core:window:allow-minimize",
+    "core:window:allow-toggle-maximize",
+    "core:window:allow-set-title",
+    "shell:allow-open"
+  ]
+}

--- a/eclaw-desktop/src-tauri/src/lib.rs
+++ b/eclaw-desktop/src-tauri/src/lib.rs
@@ -1,0 +1,78 @@
+//! EClaw Desktop — P1-A: Tauri 2 scaffold + command layer framework
+//! All business logic stubs (OAuth, Credential, Agent Probe) return errors
+//! pointing to their respective implementation cards.
+
+use serde::{Deserialize, Serialize};
+use tauri::command;
+
+/// P1-A: Health check — verifies the Rust backend is reachable.
+#[command]
+pub fn health_check() -> HealthStatus {
+    HealthStatus {
+        app_version: env!("CARGO_PKG_VERSION").to_string(),
+        platform: std::env::consts::OS.to_string(),
+        rust_version: rust_version::VERSION.to_string(),
+    }
+}
+
+/// P1-B stub: OAuth flow will be implemented in P1-B.
+/// Currently returns an error so the renderer knows it is not yet implemented.
+#[command]
+pub async fn oauth_start() -> Result<String, String> {
+    Err("P1-B not implemented: OAuth flow is handled by card_dd7e7e3a9d3056df71f1aca3".to_string())
+}
+
+/// P1-C stub: Credential store will be implemented in P1-C.
+/// Returns None to indicate no stored credential exists yet.
+#[command]
+pub async fn credential_get() -> Result<Option<serde_json::Value>, String> {
+    Err("P1-C not implemented: OS Credential Store is handled by card_7c15a7d095db68e27fee54d3".to_string())
+}
+
+/// P1-C stub: Store credential envelope in OS Credential Store.
+/// Currently returns an error.
+#[command]
+pub async fn credential_store(
+    _refresh_token: String,
+    _id_token: String,
+    _expires_at: i64,
+) -> Result<(), String> {
+    Err("P1-C not implemented: OS Credential Store is handled by card_7c15a7d095db68e27fee54d3".to_string())
+}
+
+/// P1-E stub: Agent probe will be implemented in P1-E.
+/// Currently returns an empty list.
+#[command]
+pub async fn agent_probe() -> Result<Vec<AgentInfo>, String> {
+    Err("P1-E not implemented: Agent probe is handled by card_630f5575ed11a8bc35a04e0f".to_string())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthStatus {
+    pub app_version: String,
+    pub platform: String,
+    pub rust_version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AgentInfo {
+    pub agent_type: String,
+    pub name: String,
+    pub version: Option<String>,
+    pub endpoint: Option<String>,
+    pub health: Option<String>,
+}
+
+#[cfg_attr(mobile, tauri::mobile_entry_point)]
+pub fn run() {
+    tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![
+            health_check,
+            oauth_start,
+            credential_get,
+            credential_store,
+            agent_probe,
+        ])
+        .run(tauri::generate_context!())
+        .expect("error while running tauri application");
+}

--- a/eclaw-desktop/src-tauri/src/main.rs
+++ b/eclaw-desktop/src-tauri/src/main.rs
@@ -1,0 +1,6 @@
+// P1-A: main.rs — Tauri entry point, delegates to lib::run()
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
+fn main() {
+    eclaw_desktop_lib::run();
+}

--- a/eclaw-desktop/src-tauri/tauri.conf.json
+++ b/eclaw-desktop/src-tauri/tauri.conf.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "../node_modules/@tauri-apps/cli/schema.json",
+  "productName": "EClaw Desktop",
+  "version": "0.1.0",
+  "identifier": "com.eclaw.desktop",
+  "build": {
+    "devtools": true,
+    "beforeBuildCommand": "",
+    "beforeDevCommand": ""
+  },
+  "app": {
+    "withGlobalTauri": false,
+    "security": {
+      "assetProtocol": {
+        "enable": false
+      }
+    },
+    "windows": [
+      {
+        "title": "EClaw Desktop",
+        "label": "main",
+        "width": 480,
+        "height": 640,
+        "minWidth": 400,
+        "minHeight": 500,
+        "center": true,
+        "resizable": true,
+        "fullscreen": false,
+        "decorations": true,
+        "transparent": false
+      }
+    ]
+  },
+  "bundle": {
+    "active": true,
+    "targets": "all",
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ]
+  }
+}

--- a/eclaw-desktop/src/main.ts
+++ b/eclaw-desktop/src/main.ts
@@ -1,0 +1,79 @@
+import "./styles.css";
+
+interface HealthStatus {
+  app_version: string;
+  platform: string;
+  rust_version: string;
+}
+
+interface TauriError {
+  message: string;
+}
+
+async function init(): Promise<void> {
+  const app = document.getElementById("app")!;
+
+  try {
+    const status = await window.__TAURI__.core.invoke<HealthStatus>("health_check");
+
+    app.innerHTML = `
+      <header class="header">
+        <h1>EClaw Desktop</h1>
+      </header>
+      <main class="main">
+        <div class="version-info">
+          <span>v${status.app_version}</span>
+          <span>${status.platform}</span>
+          <span>Rust ${status.rust_version}</span>
+        </div>
+        <div class="status-badge">
+          <span class="dot"></span>
+          就緒
+        </div>
+        <div class="actions">
+          <button id="btn-setup" class="btn-primary">開始設定</button>
+        </div>
+        <div id="oauth-placeholder" class="oauth-placeholder" style="display:none">
+          <p>連接中，請在瀏覽器完成驗證...</p>
+        </div>
+      </main>
+      <footer class="footer">
+        <p>您的認證資料只存在本機，不会上传到服务器</p>
+      </footer>
+    `;
+
+    const btnSetup = document.getElementById("btn-setup");
+    btnSetup?.addEventListener("click", async () => {
+      const oauthPlaceholder = document.getElementById("oauth-placeholder");
+      if (oauthPlaceholder) {
+        oauthPlaceholder.style.display = "block";
+      }
+      try {
+        const result = await window.__TAURI__.core.invoke<string>("oauth_start");
+        console.log("oauth_start:", result);
+      } catch (e) {
+        const err = e as TauriError;
+        if (err.message?.includes("P1-B not implemented")) {
+          oauthPlaceholder!.innerHTML =
+            "<p>設定功能即將推出，請稍候。</p>";
+        }
+      }
+    });
+  } catch (e) {
+    const err = e as TauriError;
+    app.innerHTML = `
+      <h1>EClaw Desktop</h1>
+      <p class="error">連接失敗：${err.message ?? e}</p>
+      <p>請確認 EClaw Desktop 已正確啟動。</p>
+    `;
+  }
+}
+
+// Augment Window to include Tauri global
+declare global {
+  interface Window {
+    __TAURI__: typeof import("@tauri-apps/api").Tauri;
+  }
+}
+
+init();

--- a/eclaw-desktop/src/styles.css
+++ b/eclaw-desktop/src/styles.css
@@ -1,0 +1,139 @@
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+:root {
+  --primary: #2563eb;
+  --primary-hover: #1d4ed8;
+  --bg: #f7f7f7;
+  --surface: #ffffff;
+  --text: #222222;
+  --text-muted: #666666;
+  --border: #e5e5e5;
+  --radius: 12px;
+  --radius-sm: 8px;
+}
+
+body {
+  font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI",
+    "PingFang TC", "Microsoft JhengHei", sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  line-height: 1.5;
+}
+
+#app {
+  background: var(--surface);
+  border-radius: var(--radius);
+  box-shadow: 0 2px 16px rgba(0, 0, 0, 0.1);
+  width: 100%;
+  max-width: 400px;
+  padding: 2rem;
+  text-align: center;
+}
+
+.header {
+  margin-bottom: 1.5rem;
+}
+
+h1 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.main {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.version-info {
+  display: flex;
+  gap: 0.5rem;
+  justify-content: center;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.version-info span {
+  background: var(--bg);
+  padding: 0.125rem 0.5rem;
+  border-radius: 999px;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  background: #ecfdf5;
+  color: #059669;
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  align-self: center;
+}
+
+.dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #059669;
+}
+
+.actions {
+  margin-top: 0.5rem;
+}
+
+.btn-primary {
+  background: var(--primary);
+  color: white;
+  border: none;
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--radius-sm);
+  font-size: 1rem;
+  font-weight: 500;
+  cursor: pointer;
+  width: 100%;
+  transition: background 0.15s;
+}
+
+.btn-primary:hover {
+  background: var(--primary-hover);
+}
+
+.oauth-placeholder {
+  background: #eff6ff;
+  border: 1px solid #bfdbfe;
+  border-radius: var(--radius-sm);
+  padding: 0.75rem;
+  font-size: 0.875rem;
+  color: #1e40af;
+}
+
+.footer {
+  margin-top: 1.5rem;
+  border-top: 1px solid var(--border);
+  padding-top: 1rem;
+}
+
+.footer p {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.error {
+  color: #dc2626;
+  background: #fef2f2;
+  padding: 0.5rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.875rem;
+  margin-bottom: 0.5rem;
+}

--- a/eclaw-desktop/tsconfig.json
+++ b/eclaw-desktop/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "module": "ESNext",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
P1-A implementation (card_384e86ee07b38cca3d29c6a9). #4 authored, rebased clean by #2 — only eclaw-desktop/ cherry-picked (the original branch reverted nav.js #3514 and deleted the merged P1-A spec; both excluded).

## Contents (12 files, isolated new dir)
Tauri 2 scaffold: window config, capabilities (scoped shell:allow-open), 4 placeholder commands (health_check / oauth_start / credential_get+store / agent_probe), frontend shell (index.html + main.ts + styles.css) with CSP meta tag.

## Verification
- Isolated new dir — does not import into or affect existing backend/jest/CI.
- node --check N/A (TS/Rust). Tauri build (tauri dev/build + CSP enforcement per spec acceptance) NOT run locally — no Rust toolchain in this env; deferred to implementer/CI before P1-A close.

## Follow-up nit
tauri.conf.json sets assetProtocol.enable:false but no explicit app.security.csp — CSP currently only via index.html meta. Implementer should also set conf-level csp per spec §3.

Generated with Claude Code