### PR TITLE
fix(ci): desktop-build uses dtolnay/rust-toolchain

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -64,7 +64,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           version: ${{ env.RUST_VERSION }}
 
@@ -153,7 +153,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup Rust
-        uses: dtolnay/rust-action@stable
+        uses: dtolnay/rust-toolchain@stable
         with:
           version: ${{ env.RUST_VERSION }}
 


### PR DESCRIPTION
desktop-build.yml (P1-G) referenced nonexistent dtolnay/rust-action@stable → both jobs failed at Set up job. Fixed to dtolnay/rust-toolchain@stable (the standard Rust setup action). Found by #5 CI monitoring.

CI-only YAML, 2-line fix.

Generated with Claude Code