### PR TITLE
fix(plaza): crop petdx sprite avatars to frame 0 (P0 mismatched avatar)

### DIFF
--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -1113,7 +1113,26 @@
         }
         return row.avatar || '\u{1F916}';
     }
+    // PETDX spritesheets are an 8×9 grid (192×208 per frame). A raw <img src=sprite.webp>
+    // shrinks the WHOLE sheet into the avatar box → all poses visible at once (the P0
+    // "大頭貼 mismatched" bug). Crop to frame 0 (idle, top-left) via background-size:
+    // 800% 900% (8 cols × 9 rows → one frame == box) + position 0 0. Interim render fix;
+    // the data-layer fix (store single-frame avatar.webp on companion create, Plan 3) is
+    // tracked separately on card_3144 / the store-on-create chain.
+    function isPetdxSprite(u) {
+        return typeof u === 'string' && /\/api\/petdx\/[^/]+\/sprite\.(webp|png)(\?|$)/i.test(u);
+    }
+    function petdxFrame0Html(url, size) {
+        const s = size || 48;
+        return '<div role="img" aria-label="bot avatar" style="width:' + s + 'px;height:' + s +
+            'px;border-radius:50%;background-image:url(' + esc(url) +
+            ');background-repeat:no-repeat;background-size:800% 900%;background-position:0 0;"></div>';
+    }
     function botAvatarHtml(avatar, size) {
+        // Single-frame crop for PETDX spritesheet URLs (covers petdxAvatarUrl = sprite.webp).
+        if (isPetdxSprite(avatar)) {
+            return petdxFrame0Html(avatar, size || 48);
+        }
         if (typeof renderAvatarHtml === 'function') {
             return renderAvatarHtml(avatar, size || 48);
         }


### PR DESCRIPTION
## P0 — card_3144
Plaza bot avatars showed the WHOLE petdx sprite sheet (8×9 grid, 192×208/frame) shrunk into a 40px box → all poses at once = 'mismatched'. Confirmed on prod: img src=/api/petdx/<slug>/sprite.webp, naturalWidth/Height 1536×1872.

## Fix (interim render-layer, per Hank '先上前端 crop')
botAvatarHtml detects petdx sprite URLs and crops to frame 0 (idle, top-left) via background-size:800% 900% + position 0 0 — shows the same idle frame AvatarPetdx renders. 1-file frontend change.

## Data-layer fix (Plan 3, separate)
store-on-create single-frame avatar.webp — tracked on card_3144 / the store-on-create chain. This interim ships the visible fix now.

## Test
jest community-plaza-avatar-petdx: 8/8 pass.
Prod-verify (Playwright re-check single-frame render) after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)