### PR TITLE
fix(notifications): define missing buildFcmNotificationData — Android push silently dead (P1)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -20387,13 +20387,21 @@ async function notifyDevice(deviceId, notification) {
         });
 
         // Web Push (Phase 3 — enabled when VAPID keys are configured)
+        // Log dispatch failures instead of swallowing them — a silent
+        // .catch(()=>{}) here previously hid a hard TypeError (missing
+        // buildFcmNotificationData) so FCM died silently. Every push surfaces
+        // its own error now.
         if (typeof sendWebPush === 'function') {
-            sendWebPush(deviceId, notif).catch(() => {});
+            sendWebPush(deviceId, notif).catch((e) => {
+                serverLog('error', 'web_push', `dispatch failed: ${e.message}`, { deviceId, metadata: { category: notif?.category } });
+            });
         }
 
         // FCM (Phase 5 — enabled when firebase-admin is configured)
         if (typeof sendFcm === 'function') {
-            sendFcm(deviceId, notif).catch(() => {});
+            sendFcm(deviceId, notif).catch((e) => {
+                serverLog('error', 'fcm_dispatch', `dispatch failed: ${e.message}`, { deviceId, metadata: { category: notif?.category } });
+            });
         }
     } catch (err) {
         console.warn('[Notify] Failed:', err.message);

--- a/backend/notifications.js
+++ b/backend/notifications.js
@@ -491,6 +491,27 @@ async function getPushSubscriptions(deviceId) {
     }
 }
 
+// Build the FCM `data` payload from a saved notification row.
+// FCM requires every `data` value to be a string, so coerce all fields and
+// JSON-encode the metadata object. The Android app reads these to route/display
+// the notification (e.g. navigate to `link`).
+function buildFcmNotificationData(notif) {
+    const data = {
+        title: String(notif.title || ''),
+        body: String(notif.body || ''),
+        category: String(notif.category || ''),
+        type: String(notif.type || ''),
+        link: String(notif.link || '')
+    };
+    if (notif.id != null) data.notifId = String(notif.id);
+    if (notif.metadata != null) {
+        data.metadata = typeof notif.metadata === 'string'
+            ? notif.metadata
+            : JSON.stringify(notif.metadata);
+    }
+    return data;
+}
+
 module.exports = {
     DEFAULT_PREFS,
     initNotificationTables,
@@ -513,5 +534,6 @@ module.exports = {
     truncateUtf8,
     createRichCardNotifLimiter,
     isRichCardQuestion,
-    buildRichCardNotification
+    buildRichCardNotification,
+    buildFcmNotificationData
 };

--- a/backend/tests/jest/helpers/mock-setup.js
+++ b/backend/tests/jest/helpers/mock-setup.js
@@ -186,6 +186,8 @@ jest.mock('../../../notifications', () => {
         isRichCardQuestion: actual.isRichCardQuestion,
         buildRichCardNotification: actual.buildRichCardNotification,
         createRichCardNotifLimiter: actual.createRichCardNotifLimiter,
+        // FCM data builder — pure, mirrors prod so sendFcm() resolves it in tests.
+        buildFcmNotificationData: actual.buildFcmNotificationData,
         // Save/save-misc no-ops so notifyDevice() doesn't blow up if reached.
         saveNotification: jest.fn().mockResolvedValue(null),
         getNotifications: jest.fn().mockResolvedValue([]),

--- a/backend/tests/jest/push-notifications.test.js
+++ b/backend/tests/jest/push-notifications.test.js
@@ -182,3 +182,54 @@ describe('GET /api/device/fcm-status', () => {
         expect(typeof res.body.firebaseAdminInitialized).toBe('boolean');
     });
 });
+
+// ════════════════════════════════════════════════════════════════
+// buildFcmNotificationData — FCM `data` payload builder
+// Regression guard: sendFcm() calls notifModule.buildFcmNotificationData(notif)
+// on EVERY Android push. It was called but never defined/exported, so every
+// FCM send threw a TypeError that a silent .catch(()=>{}) swallowed — Android
+// "task done" notifications died silently for weeks. These tests fail loudly if
+// the export is ever dropped again or returns a non-string value (FCM rejects
+// non-string data fields).
+// ════════════════════════════════════════════════════════════════
+describe('buildFcmNotificationData', () => {
+    const notifications = require('../../notifications');
+
+    it('is exported as a function', () => {
+        expect(typeof notifications.buildFcmNotificationData).toBe('function');
+    });
+
+    it('maps a kanban_done notification to an all-string FCM data payload', () => {
+        const data = notifications.buildFcmNotificationData({
+            id: 42,
+            type: 'kanban',
+            category: 'kanban_done',
+            title: '✅ 任務完成',
+            body: 'Ship the thing',
+            link: '/portal/kanban.html?card=abc',
+            metadata: { cardId: 'abc', isAuto: false }
+        });
+        // FCM requires every data value to be a string
+        for (const [k, v] of Object.entries(data)) {
+            expect(typeof v).toBe('string');
+        }
+        expect(data.category).toBe('kanban_done');
+        expect(data.title).toBe('✅ 任務完成');
+        expect(data.link).toBe('/portal/kanban.html?card=abc');
+        expect(data.notifId).toBe('42');
+        expect(JSON.parse(data.metadata)).toEqual({ cardId: 'abc', isAuto: false });
+    });
+
+    it('never throws on missing/empty fields (returns empty strings)', () => {
+        const data = notifications.buildFcmNotificationData({});
+        expect(typeof data.title).toBe('string');
+        expect(data.title).toBe('');
+        expect(data.body).toBe('');
+        expect(data.category).toBe('');
+    });
+
+    it('passes through an already-stringified metadata unchanged', () => {
+        const data = notifications.buildFcmNotificationData({ metadata: '{"x":1}' });
+        expect(data.metadata).toBe('{"x":1}');
+    });
+});


### PR DESCRIPTION
## Root cause (P1 — mobile notifications not working, esp. task-done)
`sendFcm()` calls `notifModule.buildFcmNotificationData(notif)` on **every** Android push (`backend/index.js:21345`), but that function was **never defined or exported** from `notifications.js` — a dangling call introduced in commit `e523b29f` (2026-06-14). Every FCM send threw `TypeError: buildFcmNotificationData is not a function`, swallowed by `notifyDevice`'s `sendFcm(...).catch(()=>{})`. So `kanban_done` and all FCM notifications silently never reached Android for weeks. Web Push survived (builds payload inline).

Verified: `git grep buildFcmNotificationData` → 1 call site, 0 definitions, not in any export.

## Fix
- **`notifications.js`**: define + export `buildFcmNotificationData(notif)` → FCM `data` payload, all values coerced to **string** (FCM rejects non-string `data`), metadata JSON-encoded, `notifId` when present.
- **`index.js` `notifyDevice`**: the silent `.catch(()=>{})` on sendWebPush/sendFcm → `serverLog('error', …)` so dispatch failures surface (this masking is what hid the bug for weeks).
- **`push-notifications.test.js`**: regression block — export exists, all-string output, metadata JSON-encoded, empty input safe. Prior tests only checked preference gating, never the FCM data path → couldn't catch this.

## Test plan / merge gate
Local: `node --check` on all 3 files + inline function verification (all-string payload, empty-case safe). Touches `index.js` → **merge only on green Backend CI + Jest** (no admin-bypass).

## Remaining (needs Hank)
On-device "move card done → phone notification pops" screenshot needs a real Android device with an FCM token (Hank reported it from his phone). After this deploys to prod, the prod log `fcm_send: sent OK` + Hank's device confirms end-to-end; happy to coordinate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)