### PR TITLE
feat(plaza): frame-extract util — sprite → single-frame WebP (Plan-3 Phase 3)

### DIFF
--- a/backend/companion-avatar-util.js
+++ b/backend/companion-avatar-util.js
@@ -1,0 +1,58 @@
+// Companion avatar derivation utilities (Plaza Plan-3 Phase 3).
+//
+// Pure, dependency-light helpers for turning a PETDX-style sprite sheet into a
+// single-frame avatar image. No DB, no network — callers pass in the sheet
+// bytes and the descriptor; this module only does the pixel work via sharp.
+//
+// Contract: docs/specs/companion-avatar-url-store-on-create.md §2.2
+//   spritesheet → crop frame 0 (top-left cell) → encode WebP ≤ 512×512.
+
+const sharp = require('sharp');
+
+// Output avatar dimensions (square, ≤512 per the spec). 256 keeps avatars
+// crisp on retina without bloating R2.
+const OUTPUT_SIZE = 256;
+// Fallback frame size when the descriptor omits frame dimensions.
+const DEFAULT_FRAME = 256;
+
+// A descriptor may arrive either as the raw descriptor (`{ asset: {...} }`) or
+// wrapped one level deeper (`{ descriptor: { asset: {...} } }`) depending on the
+// call site — mirror the unwrap pattern used elsewhere for petdx descriptors.
+function unwrapAsset(descriptor) {
+    if (!descriptor || typeof descriptor !== 'object') return {};
+    if (descriptor.descriptor && descriptor.descriptor.asset) return descriptor.descriptor.asset;
+    if (descriptor.asset && typeof descriptor.asset === 'object') return descriptor.asset;
+    return {};
+}
+
+function positiveIntOr(value, fallback) {
+    const n = Math.floor(Number(value));
+    return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+// Crop frame 0 (top-left cell of the grid) out of a sprite sheet and return a
+// square WebP avatar. Returns { buffer, mime, width, height }.
+async function extractFrameZero(spritesheetBuffer, descriptor = {}) {
+    if (!Buffer.isBuffer(spritesheetBuffer)) {
+        throw new TypeError('extractFrameZero: spritesheetBuffer must be a Buffer');
+    }
+    const asset = unwrapAsset(descriptor);
+    const frameWidth = positiveIntOr(asset.frameWidth, DEFAULT_FRAME);
+    const frameHeight = positiveIntOr(asset.frameHeight, DEFAULT_FRAME);
+
+    // Clamp the extract window to the actual image so a mis-stated frame size
+    // (or a single-frame image) can never throw sharp's "extract_area" error.
+    const meta = await sharp(spritesheetBuffer).metadata();
+    const width = Math.min(frameWidth, meta.width || frameWidth);
+    const height = Math.min(frameHeight, meta.height || frameHeight);
+
+    const buffer = await sharp(spritesheetBuffer)
+        .extract({ left: 0, top: 0, width, height })
+        .resize(OUTPUT_SIZE, OUTPUT_SIZE, { fit: 'cover' })
+        .webp({ quality: 90 })
+        .toBuffer();
+
+    return { buffer, mime: 'image/webp', width: OUTPUT_SIZE, height: OUTPUT_SIZE };
+}
+
+module.exports = { extractFrameZero, unwrapAsset, OUTPUT_SIZE, DEFAULT_FRAME };

--- a/backend/tests/jest/companion-avatar-util.test.js
+++ b/backend/tests/jest/companion-avatar-util.test.js
@@ -1,0 +1,106 @@
+/**
+ * companion-avatar-util — extractFrameZero (Plaza Plan-3 Phase 3)
+ *
+ * Pure image util; uses real sharp (no mock-setup). Builds synthetic sprite
+ * sheets so the crop math is verifiable: frame 0 is one colour, every other
+ * frame is a different colour, so a correct frame-0 crop is uniformly the
+ * frame-0 colour and a wrong/over-wide crop bleeds the neighbour colour in.
+ */
+
+const sharp = require('sharp');
+const { extractFrameZero, unwrapAsset } = require('../../companion-avatar-util');
+
+const RED = { r: 220, g: 30, b: 30 };
+const BLUE = { r: 30, g: 30, b: 220 };
+
+// Build a cols×rows sheet where frame 0 (top-left fw×fh) is RED and the rest BLUE.
+async function buildSheet(fw, fh, cols, rows) {
+    const W = fw * cols;
+    const H = fh * rows;
+    const base = sharp({ create: { width: W, height: H, channels: 3, background: BLUE } });
+    const frame0 = await sharp({ create: { width: fw, height: fh, channels: 3, background: RED } })
+        .png().toBuffer();
+    return base.composite([{ input: frame0, left: 0, top: 0 }]).png().toBuffer();
+}
+
+// Mean RGB of a (decoded) image buffer.
+async function meanRgb(buf) {
+    const { data } = await sharp(buf).removeAlpha().raw().toBuffer({ resolveWithObject: true });
+    let r = 0, g = 0, b = 0;
+    const px = data.length / 3;
+    for (let i = 0; i < data.length; i += 3) { r += data[i]; g += data[i + 1]; b += data[i + 2]; }
+    return { r: r / px, g: g / px, b: b / px };
+}
+
+describe('extractFrameZero', () => {
+    it('crops frame 0 to a 256×256 WebP (8×8 grid, 64px frames)', async () => {
+        const sheet = await buildSheet(64, 64, 8, 8); // 512×512
+        const out = await extractFrameZero(sheet, { asset: { frameWidth: 64, frameHeight: 64 } });
+
+        expect(out.mime).toBe('image/webp');
+        expect(out.width).toBe(256);
+        expect(out.height).toBe(256);
+
+        const meta = await sharp(out.buffer).metadata();
+        expect(meta.format).toBe('webp');
+        expect(meta.width).toBe(256);
+        expect(meta.height).toBe(256);
+
+        // Must be the frame-0 colour (RED-dominant), with no BLUE neighbour bleed.
+        const m = await meanRgb(out.buffer);
+        expect(m.r).toBeGreaterThan(150);
+        expect(m.b).toBeLessThan(90);
+    });
+
+    it('works with 256px frames too', async () => {
+        const sheet = await buildSheet(256, 256, 8, 9); // canonical PETDX-ish grid
+        const out = await extractFrameZero(sheet, { asset: { frameWidth: 256, frameHeight: 256 } });
+        const m = await meanRgb(out.buffer);
+        expect(m.r).toBeGreaterThan(150);
+        expect(m.b).toBeLessThan(90);
+    });
+
+    it('unwraps a nested descriptor.descriptor.asset', async () => {
+        const sheet = await buildSheet(64, 64, 8, 8);
+        const out = await extractFrameZero(sheet, { descriptor: { asset: { frameWidth: 64, frameHeight: 64 } } });
+        const m = await meanRgb(out.buffer);
+        expect(m.r).toBeGreaterThan(150);
+        expect(m.b).toBeLessThan(90);
+    });
+
+    it('falls back to the default frame size when descriptor omits dims', async () => {
+        // Sheet whose frame 0 is exactly the 256 default; rest BLUE.
+        const sheet = await buildSheet(256, 256, 2, 2); // 512×512
+        const out = await extractFrameZero(sheet, {}); // no asset → DEFAULT_FRAME (256)
+        const m = await meanRgb(out.buffer);
+        expect(m.r).toBeGreaterThan(150);
+        expect(m.b).toBeLessThan(90);
+    });
+
+    it('clamps the extract window to the image (mis-stated frame size never throws)', async () => {
+        const sheet = await buildSheet(64, 64, 1, 1); // single 64×64 RED frame
+        // Descriptor claims 999px frames — must clamp, not throw extract_area.
+        const out = await extractFrameZero(sheet, { asset: { frameWidth: 999, frameHeight: 999 } });
+        expect(out.width).toBe(256);
+        const m = await meanRgb(out.buffer);
+        expect(m.r).toBeGreaterThan(150);
+    });
+
+    it('throws a clear error on non-Buffer input', async () => {
+        await expect(extractFrameZero('not-a-buffer', {})).rejects.toThrow(/Buffer/);
+    });
+});
+
+describe('unwrapAsset', () => {
+    it('returns top-level asset', () => {
+        expect(unwrapAsset({ asset: { frameWidth: 64 } })).toEqual({ frameWidth: 64 });
+    });
+    it('returns nested descriptor.asset', () => {
+        expect(unwrapAsset({ descriptor: { asset: { frameWidth: 32 } } })).toEqual({ frameWidth: 32 });
+    });
+    it('returns {} for junk input', () => {
+        expect(unwrapAsset(null)).toEqual({});
+        expect(unwrapAsset(42)).toEqual({});
+        expect(unwrapAsset({})).toEqual({});
+    });
+});


### PR DESCRIPTION
## Scope
**Plaza Plan-3 Phase 3** (`card_34a616c7`) — pure image helper that Phases 4-6 call to derive a single-frame avatar from a PETDX sprite sheet. Contract: `docs/specs/companion-avatar-url-store-on-create.md` §2.2.

## Changes (additive — 2 new files)
- `backend/companion-avatar-util.js` — `extractFrameZero(buf, descriptor)` → `{buffer, mime, width, height}`: crop frame 0 → resize 256² cover → WebP q90; `unwrapAsset()` handles top-level + nested `descriptor.descriptor.asset`; frame dims from `asset.frameWidth/frameHeight` (256 default); extract window clamped to the image (mis-stated size can't throw). Pure, no DB/network.
- `backend/tests/jest/companion-avatar-util.test.js` — 9 tests: RED-frame-0-on-BLUE synthetic sheets prove the crop is exactly frame 0 (no neighbour bleed) at 64px & 256px; nested unwrap; default fallback; oversize clamp; non-Buffer error; unwrapAsset edges.

## Test plan
`npx jest companion-avatar-util` → 9/9 green locally. Uses real sharp (merged in Phase 2 #3529). No package.json change. Backend CI + Jest is the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)