### PR TITLE
feat(plaza): petdx avatar.webp R2 route (Plan-3 Phase 4)

### DIFF
--- a/backend/petdex-route.js
+++ b/backend/petdex-route.js
@@ -1,10 +1,12 @@
 /**
- * Petdex public sprite proxy — serves `/api/petdx/:slug/sprite.webp` directly
- * from R2 without requiring deviceId/botSecret. Petdex sprites are MIT-licensed
- * public gallery assets; no auth needed.
+ * Petdex public asset proxy — serves `/api/petdx/:slug/sprite.webp` (full sprite
+ * sheet) and `/api/petdx/:slug/avatar.webp` (single-frame avatar) directly from
+ * R2 without requiring deviceId/botSecret. Petdex sprites are MIT-licensed public
+ * gallery assets; no auth needed.
  *
  * Spec: docs/specs/petdx-uiux-spec-amendment-2026-06-05-phase2-r2-pipeline.md §3.2
- * Phase 2 PR: #3176 (spec)
+ *       docs/specs/companion-avatar-url-store-on-create.md §2.3 (avatar.webp key)
+ * Phase 2 PR: #3176 (spec) · Plaza Plan-3 Phase 4 (avatar route)
  *
  * #1 sign-off guardrails:
  *   - Slug whitelist (no directory traversal, no R2 object listing surface).
@@ -31,12 +33,15 @@ function createRouter({ r2, bucket, log } = {}) {
     const bucketName = bucket || process.env.R2_BUCKET_NAME || 'eclaw-files';
     const logger = typeof log === 'function' ? log : () => {};
 
-    router.get('/:slug/sprite.webp', async (req, res) => {
+    // Shared streamer for the immutable public webp assets under
+    // petdx-sprites/{slug}/. `filename` is the object basename (sprite.webp /
+    // avatar.webp). 404 on bad slug or missing key, 502 on upstream error.
+    async function streamPetdxWebp(req, res, filename) {
         const { slug } = req.params;
         if (!slug || !SLUG_PATTERN.test(slug)) {
             return res.status(404).type('text/plain').send('not found');
         }
-        const key = `petdx-sprites/${slug}/sprite.webp`;
+        const key = `petdx-sprites/${slug}/${filename}`;
         try {
             const out = await client.send(new GetObjectCommand({ Bucket: bucketName, Key: key }));
             res.setHeader('Content-Type', 'image/webp');
@@ -45,7 +50,7 @@ function createRouter({ r2, bucket, log } = {}) {
             if (out.ETag) res.setHeader('ETag', out.ETag);
             out.Body.pipe(res);
             out.Body.on('error', (err) => {
-                logger('warn', 'petdex-route', `[petdx] stream ${slug} failed: ${err.message}`);
+                logger('warn', 'petdex-route', `[petdx] stream ${slug}/${filename} failed: ${err.message}`);
                 if (!res.headersSent) res.status(502).end();
                 else res.end();
             });
@@ -55,10 +60,14 @@ function createRouter({ r2, bucket, log } = {}) {
             if (code === 'NoSuchKey' || code === 'NotFound' || status === 404) {
                 return res.status(404).type('text/plain').send('not found');
             }
-            logger('error', 'petdex-route', `[petdx] R2 GET ${slug} failed: ${code || status || err.message}`);
+            logger('error', 'petdex-route', `[petdx] R2 GET ${slug}/${filename} failed: ${code || status || err.message}`);
             return res.status(502).type('text/plain').send('upstream error');
         }
-    });
+    }
+
+    router.get('/:slug/sprite.webp', (req, res) => streamPetdxWebp(req, res, 'sprite.webp'));
+    // Plaza Plan-3 Phase 4: single-frame avatar (derived frame 0, ≤512×512).
+    router.get('/:slug/avatar.webp', (req, res) => streamPetdxWebp(req, res, 'avatar.webp'));
 
     return router;
 }

--- a/backend/tests/jest/petdex-route-avatar.test.js
+++ b/backend/tests/jest/petdex-route-avatar.test.js
@@ -1,0 +1,72 @@
+/**
+ * petdex-route — /api/petdx/:slug/avatar.webp (Plaza Plan-3 Phase 4)
+ *
+ * Pure route test: inject a fake R2 (S3) client via createRouter({ r2 }), so no
+ * network/AWS. Asserts the avatar.webp route mirrors sprite.webp: 200 + webp
+ * when the key exists, 404 on missing key, 404 on bad slug (whitelist guard).
+ */
+
+const express = require('express');
+const request = require('supertest');
+const { Readable } = require('stream');
+const { createRouter } = require('../../petdex-route');
+
+// Fake R2: resolves a webp Body for keys we "have", throws NoSuchKey otherwise.
+function makeFakeR2(presentKeys) {
+    return {
+        send(cmd) {
+            const key = cmd.input.Key;
+            if (presentKeys.has(key)) {
+                const bytes = Buffer.from('RIFF....WEBPfake'); // stand-in payload
+                return Promise.resolve({
+                    Body: Readable.from([bytes]),
+                    ContentLength: bytes.length,
+                    ETag: '"deadbeef"',
+                });
+            }
+            const err = new Error('not found');
+            err.name = 'NoSuchKey';
+            err.$metadata = { httpStatusCode: 404 };
+            return Promise.reject(err);
+        },
+    };
+}
+
+function appWith(presentKeys) {
+    const app = express();
+    app.use('/api/petdx', createRouter({ r2: makeFakeR2(presentKeys), bucket: 'test-bucket' }));
+    return app;
+}
+
+describe('GET /api/petdx/:slug/avatar.webp', () => {
+    it('200 + image/webp when the avatar key exists in R2', async () => {
+        const app = appWith(new Set(['petdx-sprites/zoro/avatar.webp']));
+        const res = await request(app).get('/api/petdx/zoro/avatar.webp');
+        expect(res.status).toBe(200);
+        expect(res.headers['content-type']).toBe('image/webp');
+        expect(res.headers['cache-control']).toBe('public, max-age=31536000, immutable');
+        expect(res.body.length).toBeGreaterThan(0);
+    });
+
+    it('404 when the avatar key is missing (NoSuchKey)', async () => {
+        const app = appWith(new Set()); // nothing in R2
+        const res = await request(app).get('/api/petdx/zoro/avatar.webp');
+        expect(res.status).toBe(404);
+    });
+
+    it('404 on an invalid slug (whitelist guard, no traversal)', async () => {
+        const app = appWith(new Set(['petdx-sprites/zoro/avatar.webp']));
+        // uppercase + dot-segment must be rejected before any R2 lookup
+        const res = await request(app).get('/api/petdx/..%2Fsecret/avatar.webp');
+        expect(res.status).toBe(404);
+        const res2 = await request(app).get('/api/petdx/ZORO/avatar.webp');
+        expect(res2.status).toBe(404);
+    });
+
+    it('avatar.webp and sprite.webp are independent keys', async () => {
+        // Only the sprite exists → avatar 404s, sprite 200s (no cross-serving).
+        const app = appWith(new Set(['petdx-sprites/luffy/sprite.webp']));
+        expect((await request(app).get('/api/petdx/luffy/avatar.webp')).status).toBe(404);
+        expect((await request(app).get('/api/petdx/luffy/sprite.webp')).status).toBe(200);
+    });
+});


### PR DESCRIPTION
## Scope
**Plaza Plan-3 Phase 4** (`card_884f6f2c`) — serve the derived single-frame avatar from R2 at stable public URL `/api/petdx/:slug/avatar.webp` (key `petdx-sprites/{slug}/avatar.webp`). Spec §2.3.

## Changes
- `backend/petdex-route.js`: factored R2 stream+guard into `streamPetdxWebp(req,res,filename)` (DRY); registered both `sprite.webp` and new `avatar.webp`. avatar reuses the exact sprite contract — slug whitelist (no traversal/listing), stream-through (no 302), `Cache-Control: immutable`, 404 bad-slug/missing-key, 502 upstream.
- `backend/tests/jest/petdex-route-avatar.test.js`: 4 tests via injected fake R2 (`createRouter({r2})`, no network) — 200+webp present, 404 NoSuchKey, 404 invalid slug (uppercase + `%2F` traversal), avatar/sprite independent keys.

## Test plan
`npx jest petdex-route-avatar` → 4/4 green locally. Phase 5 migration populates the keys; Phase 8 does the prod hit (`/api/petdx/zoro/avatar.webp` → 256² webp). Backend CI + Jest is the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)