### PR TITLE
feat(plaza): companion avatar backfill migration (Plan-3 Phase 5)

### DIFF
--- a/backend/scripts/backfill-companion-avatar-url.js
+++ b/backend/scripts/backfill-companion-avatar-url.js
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * Plaza Plan-3 Phase 5 — backfill companion single-frame avatars.
+ *
+ * For every companion still pointing avatar_url at a PETDX sprite sheet, derive
+ * frame 0 (via companion-avatar-util.extractFrameZero), upload it to R2 at
+ * petdx-sprites/{slug}/avatar.webp (the Phase 4 route key), and repoint
+ * avatar_url to /api/petdx/{slug}/avatar.webp.
+ *
+ * Spec: docs/specs/companion-avatar-url-store-on-create.md §2.2/§2.3/§5
+ *
+ * Usage:
+ *   node backend/scripts/backfill-companion-avatar-url.js --dry-run   # plan only
+ *   node backend/scripts/backfill-companion-avatar-url.js --commit    # apply
+ *
+ * Idempotent: the SELECT only matches rows whose avatar_url still references a
+ * sprite sheet, so re-running after a successful pass is a no-op.
+ */
+
+const { extractFrameZero } = require('../companion-avatar-util');
+
+// Rows still on a sprite-sheet avatar. (Already-migrated rows point at
+// avatar.webp and are excluded, making the script idempotent.)
+const SELECT_SQL =
+    "SELECT id, descriptor, asset_url, avatar_url FROM companions " +
+    "WHERE asset_type = 'spritesheet' AND avatar_url LIKE '%sprite.webp%'";
+
+// Pull the slug out of an EClaw petdx proxy URL: /api/petdx/<slug>/sprite.webp
+function slugFromUrl(url) {
+    if (typeof url !== 'string') return null;
+    const m = url.match(/\/api\/petdx\/([a-z0-9][a-z0-9-]{0,128})\/sprite\.webp/i);
+    return m ? m[1] : null;
+}
+
+async function bodyToBuffer(body) {
+    // AWS SDK v3 stream: prefer transformToByteArray, fall back to async iter.
+    if (body && typeof body.transformToByteArray === 'function') {
+        return Buffer.from(await body.transformToByteArray());
+    }
+    const chunks = [];
+    for await (const c of body) chunks.push(Buffer.isBuffer(c) ? c : Buffer.from(c));
+    return Buffer.concat(chunks);
+}
+
+/**
+ * Core backfill. Dependencies are injected so this is unit-testable without a
+ * real DB/R2.
+ *   deps.pool   — pg Pool (query)
+ *   deps.r2     — S3 client (send)
+ *   deps.GetObjectCommand / deps.PutObjectCommand — @aws-sdk commands
+ *   deps.bucket — R2 bucket name
+ *   deps.dryRun — when true, plan only (no R2 writes, no UPDATE)
+ *   deps.logger — (level, msg) => void
+ */
+async function runBackfill(deps) {
+    const { pool, r2, GetObjectCommand, PutObjectCommand, bucket } = deps;
+    const dryRun = !!deps.dryRun;
+    const log = deps.logger || (() => {});
+
+    const summary = { scanned: 0, migrated: 0, skipped: 0, failed: 0, dryRun, rows: [] };
+    const { rows } = await pool.query(SELECT_SQL);
+    summary.scanned = rows.length;
+
+    for (const row of rows) {
+        const slug = slugFromUrl(row.avatar_url) || slugFromUrl(row.asset_url);
+        if (!slug) {
+            summary.skipped++;
+            summary.rows.push({ id: row.id, action: 'skip', reason: 'no-slug-in-url' });
+            log('warn', `skip ${row.id}: cannot derive slug from ${row.avatar_url}`);
+            continue;
+        }
+        const newAvatarUrl = `/api/petdx/${slug}/avatar.webp`;
+        const spriteKey = `petdx-sprites/${slug}/sprite.webp`;
+        const avatarKey = `petdx-sprites/${slug}/avatar.webp`;
+
+        if (dryRun) {
+            summary.migrated++; // counted as "would migrate"
+            summary.rows.push({ id: row.id, action: 'would-migrate', slug, newAvatarUrl });
+            log('info', `[dry-run] ${row.id} → ${newAvatarUrl} (derive ${spriteKey} → ${avatarKey})`);
+            continue;
+        }
+
+        try {
+            const obj = await r2.send(new GetObjectCommand({ Bucket: bucket, Key: spriteKey }));
+            const spriteBuf = await bodyToBuffer(obj.Body);
+            const descriptor = typeof row.descriptor === 'string'
+                ? JSON.parse(row.descriptor) : (row.descriptor || {});
+            const { buffer: avatarBuf } = await extractFrameZero(spriteBuf, descriptor);
+
+            await r2.send(new PutObjectCommand({
+                Bucket: bucket,
+                Key: avatarKey,
+                Body: avatarBuf,
+                ContentType: 'image/webp',
+                CacheControl: 'public, max-age=31536000, immutable',
+            }));
+            await pool.query('UPDATE companions SET avatar_url = $1 WHERE id = $2', [newAvatarUrl, row.id]);
+
+            summary.migrated++;
+            summary.rows.push({ id: row.id, action: 'migrated', slug, newAvatarUrl, bytes: avatarBuf.length });
+            log('info', `migrated ${row.id} → ${newAvatarUrl} (${avatarBuf.length}b webp)`);
+        } catch (err) {
+            summary.failed++;
+            summary.rows.push({ id: row.id, action: 'failed', slug, error: err.message });
+            log('error', `FAILED ${row.id} (${slug}): ${err.message}`);
+        }
+    }
+    return summary;
+}
+
+async function main() {
+    const args = process.argv.slice(2);
+    const dryRun = !args.includes('--commit'); // default safe: dry-run unless --commit
+    const asJson = args.includes('--json');
+
+    const { Pool } = require('pg');
+    const { S3Client, GetObjectCommand, PutObjectCommand } = require('@aws-sdk/client-s3');
+    const cs = process.env.DATABASE_URL;
+    const pool = new Pool({
+        connectionString: cs,
+        ssl: cs && !/localhost|127\.0\.0\.1/.test(cs) ? { rejectUnauthorized: false } : false,
+    });
+    const r2 = new S3Client({
+        region: 'auto',
+        endpoint: `https://${process.env.R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
+        credentials: {
+            accessKeyId: process.env.R2_ACCESS_KEY_ID || '',
+            secretAccessKey: process.env.R2_SECRET_ACCESS_KEY || '',
+        },
+    });
+    const bucket = process.env.R2_BUCKET_NAME || 'eclaw-files';
+
+    const logger = (level, msg) => console.log(`[${level}] ${msg}`);
+    console.log(`[backfill-avatar] mode=${dryRun ? 'DRY-RUN' : 'COMMIT'} bucket=${bucket}`);
+    try {
+        const summary = await runBackfill({ pool, r2, GetObjectCommand, PutObjectCommand, bucket, dryRun, logger });
+        if (asJson) console.log(JSON.stringify(summary, null, 2));
+        console.log(`[backfill-avatar] done: scanned=${summary.scanned} migrated=${summary.migrated} skipped=${summary.skipped} failed=${summary.failed} (dryRun=${summary.dryRun})`);
+        process.exitCode = summary.failed > 0 ? 1 : 0;
+    } finally {
+        await pool.end().catch(() => {});
+    }
+}
+
+if (require.main === module) {
+    main().catch((e) => { console.error(e); process.exit(1); });
+}
+
+module.exports = { runBackfill, slugFromUrl, bodyToBuffer, SELECT_SQL };

--- a/backend/tests/jest/backfill-companion-avatar-url.test.js
+++ b/backend/tests/jest/backfill-companion-avatar-url.test.js
@@ -1,0 +1,135 @@
+/**
+ * backfill-companion-avatar-url — Plaza Plan-3 Phase 5
+ *
+ * Unit test with injected fake pg pool + fake R2 (no network/DB). A real
+ * sharp-built sprite sheet feeds the real extractFrameZero, so the derive path
+ * is exercised end-to-end in-memory.
+ */
+
+const sharp = require('sharp');
+const {
+    runBackfill, slugFromUrl, SELECT_SQL,
+} = require('../../scripts/backfill-companion-avatar-url');
+
+// Fake @aws-sdk command classes (tagged so the fake client can route).
+class GetObjectCommand { constructor(input) { this.input = input; this.__t = 'get'; } }
+class PutObjectCommand { constructor(input) { this.input = input; this.__t = 'put'; } }
+
+async function makeSprite() {
+    // 8×9 grid, 64px frames; frame 0 RED on BLUE rest (matches petdx layout shape).
+    const fw = 64, fh = 64, cols = 8, rows = 9;
+    const base = sharp({ create: { width: fw * cols, height: fh * rows, channels: 3, background: { r: 220, g: 30, b: 30 } } });
+    // whole sheet red so any crop is red — we only assert the avatar is a valid webp here
+    return base.webp().toBuffer();
+}
+
+function makeFakePool(rows) {
+    const updates = [];
+    return {
+        updates,
+        async query(sql, params) {
+            if (/^SELECT/i.test(sql)) return { rows };
+            if (/^UPDATE/i.test(sql)) { updates.push({ sql, params }); return { rowCount: 1 }; }
+            return { rows: [] };
+        },
+    };
+}
+
+function makeFakeR2(spriteBuf) {
+    const puts = [];
+    return {
+        puts,
+        async send(cmd) {
+            if (cmd.__t === 'get') {
+                return { Body: { transformToByteArray: async () => spriteBuf } };
+            }
+            if (cmd.__t === 'put') { puts.push(cmd.input); return {}; }
+            throw new Error('unknown command');
+        },
+    };
+}
+
+const DESC = { asset: { frameWidth: 64, frameHeight: 64, cols: 8, rows: 9 } };
+
+describe('slugFromUrl', () => {
+    it('extracts slug from a petdx sprite proxy URL', () => {
+        expect(slugFromUrl('/api/petdx/zoro/sprite.webp')).toBe('zoro');
+        expect(slugFromUrl('https://eclawbot.com/api/petdx/tomori-2/sprite.webp')).toBe('tomori-2');
+    });
+    it('returns null for non-matching / junk', () => {
+        expect(slugFromUrl('/api/petdx/zoro/avatar.webp')).toBeNull();
+        expect(slugFromUrl('whatever')).toBeNull();
+        expect(slugFromUrl(null)).toBeNull();
+    });
+});
+
+describe('SELECT_SQL is idempotent by construction', () => {
+    it('only targets spritesheet rows whose avatar_url still references a sprite sheet', () => {
+        expect(SELECT_SQL).toMatch(/asset_type\s*=\s*'spritesheet'/);
+        expect(SELECT_SQL).toMatch(/avatar_url LIKE '%sprite\.webp%'/);
+    });
+});
+
+describe('runBackfill', () => {
+    const baseDeps = () => ({ GetObjectCommand, PutObjectCommand, bucket: 'test-bucket', logger: () => {} });
+
+    it('dry-run plans without any R2 put or DB update', async () => {
+        const pool = makeFakePool([
+            { id: 'petdx-zoro', descriptor: DESC, asset_url: '/api/petdx/zoro/sprite.webp', avatar_url: '/api/petdx/zoro/sprite.webp' },
+        ]);
+        const r2 = makeFakeR2(await makeSprite());
+        const s = await runBackfill({ ...baseDeps(), pool, r2, dryRun: true });
+        expect(s.scanned).toBe(1);
+        expect(s.migrated).toBe(1); // "would migrate"
+        expect(r2.puts).toHaveLength(0);
+        expect(pool.updates).toHaveLength(0);
+        expect(s.rows[0]).toMatchObject({ action: 'would-migrate', slug: 'zoro', newAvatarUrl: '/api/petdx/zoro/avatar.webp' });
+    });
+
+    it('commit derives frame 0, uploads avatar.webp, and repoints avatar_url', async () => {
+        const pool = makeFakePool([
+            { id: 'petdx-zoro', descriptor: DESC, asset_url: '/api/petdx/zoro/sprite.webp', avatar_url: '/api/petdx/zoro/sprite.webp' },
+        ]);
+        const r2 = makeFakeR2(await makeSprite());
+        const s = await runBackfill({ ...baseDeps(), pool, r2, dryRun: false });
+
+        expect(s.migrated).toBe(1);
+        expect(s.failed).toBe(0);
+        // uploaded to the avatar key with webp content-type + immutable cache
+        expect(r2.puts).toHaveLength(1);
+        expect(r2.puts[0].Key).toBe('petdx-sprites/zoro/avatar.webp');
+        expect(r2.puts[0].ContentType).toBe('image/webp');
+        expect(r2.puts[0].CacheControl).toMatch(/immutable/);
+        expect(Buffer.isBuffer(r2.puts[0].Body)).toBe(true);
+        // and it's a real webp (sharp can read it back as 256×256)
+        const meta = await sharp(r2.puts[0].Body).metadata();
+        expect(meta.format).toBe('webp');
+        expect(meta.width).toBe(256);
+        // avatar_url repointed
+        expect(pool.updates).toHaveLength(1);
+        expect(pool.updates[0].params).toEqual(['/api/petdx/zoro/avatar.webp', 'petdx-zoro']);
+    });
+
+    it('skips a row whose URL has no derivable slug (no write, counted skipped)', async () => {
+        const pool = makeFakePool([
+            { id: 'weird', descriptor: DESC, asset_url: 'sprite.webp', avatar_url: 'sprite.webp' },
+        ]);
+        const r2 = makeFakeR2(await makeSprite());
+        const s = await runBackfill({ ...baseDeps(), pool, r2, dryRun: false });
+        expect(s.skipped).toBe(1);
+        expect(s.migrated).toBe(0);
+        expect(r2.puts).toHaveLength(0);
+        expect(pool.updates).toHaveLength(0);
+    });
+
+    it('records a failure (and continues) when R2 get throws, without updating the row', async () => {
+        const pool = makeFakePool([
+            { id: 'petdx-zoro', descriptor: DESC, asset_url: '/api/petdx/zoro/sprite.webp', avatar_url: '/api/petdx/zoro/sprite.webp' },
+        ]);
+        const r2 = { puts: [], async send() { throw new Error('NoSuchKey'); } };
+        const s = await runBackfill({ ...baseDeps(), pool, r2, dryRun: false });
+        expect(s.failed).toBe(1);
+        expect(s.migrated).toBe(0);
+        expect(pool.updates).toHaveLength(0);
+    });
+});


### PR DESCRIPTION
## Scope
**Plaza Plan-3 Phase 5** (`card_fa860952`) — one-shot migration backfilling existing companions whose `avatar_url` is still a PETDX sprite sheet. Spec §2.2/§2.3/§5.

## Script `backend/scripts/backfill-companion-avatar-url.js`
- SELECT `asset_type='spritesheet' AND avatar_url LIKE '%sprite.webp%'` → idempotent (migrated rows excluded).
- Per row: R2 Get `petdx-sprites/{slug}/sprite.webp` → `extractFrameZero` (Phase 3) → R2 Put `petdx-sprites/{slug}/avatar.webp` (image/webp, immutable) → `UPDATE avatar_url='/api/petdx/{slug}/avatar.webp'` (Phase 4 route).
- **`--dry-run` is the default**; `--commit` to write; `--json` for the audit artifact. Per-row failures isolated (logged/counted, no UPDATE). `runBackfill()` takes injected pool/r2 → unit-testable.

## Tests (7, green locally)
fake pool + fake R2 + real sharp sprite: dry-run writes nothing; commit uploads a real 256² webp to the avatar key + repoints avatar_url; bad-slug skipped; R2 error isolated; slug parse + idempotent-SQL asserts.

## Test plan / run
`npx jest backfill-companion-avatar-url` → 7/7. Prod `--commit` run happens post-deploy with DB+R2 creds; Phase 8 prod-verifies (`COUNT(spritesheet w/ sprite.webp avatar)=0`). Backend CI + Jest is the merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)