### PR TITLE
fix(plaza): crop petdx sprites in shared renderAvatarHtml — fixes marketplace/arena/share-chat avatars (P0)

### DIFF
--- a/backend/public/portal/shared/entity-utils.js
+++ b/backend/public/portal/shared/entity-utils.js
@@ -137,6 +137,16 @@ function isAvatarUrl(avatar) {
     return avatar && typeof avatar === 'string' && /^(https?:\/\/|\/)/.test(avatar);
 }
 
+// A PETDX sprite-sheet proxy URL (/api/petdx/<slug>/sprite.webp). Cross-device
+// plaza/marketplace/arena bots arrive with this as their avatar_url and have no
+// cached AvatarPetdx descriptor (the canvas path), so a raw <img src> would
+// shrink the whole 8×9 sheet into the avatar box — the "大頭貼 mismatched" P0.
+// renderAvatarHtml crops frame 0 instead. (community.html had its own copy of
+// this; this is the shared fix so every surface is covered.)
+function isPetdxSprite(u) {
+    return typeof u === 'string' && /\/api\/petdx\/[^/]+\/sprite\.(webp|png)(\?|$)/i.test(u);
+}
+
 /**
  * Render an avatar as HTML. Returns an <img> tag for URLs, or emoji text for emoji avatars.
  *
@@ -217,6 +227,16 @@ function renderAvatarHtml(avatar, size, entityId, opts) {
             + ' style="width:' + size + 'px;height:' + size + 'px;'
             + 'image-rendering:pixelated;border-radius:50%;vertical-align:middle;"'
             + ' aria-label="entity avatar"></canvas>';
+    } else if (isPetdxSprite(avatar)) {
+        // Cross-device petdx bot with no cached descriptor: crop frame 0 (top-left
+        // cell of the 8×9 grid) via background-size 800% 900% instead of rendering
+        // the raw sheet. Fixes marketplace/arena/share-chat (community.html already
+        // had this). One day the Phase-5 backfill repoints avatar_url → avatar.webp
+        // and this branch stops matching, falling through to the plain <img> below.
+        inner = '<div role="img" aria-label="avatar" class="entity-avatar-img"' + eidAttr
+            + ' style="width:' + size + 'px;height:' + size + 'px;border-radius:50%;'
+            + 'background-image:url(' + _escAttr(avatar) + ');background-repeat:no-repeat;'
+            + 'background-size:800% 900%;background-position:0 0;"></div>';
     } else if (isAvatarUrl(avatar)) {
         inner = '<img src="' + avatar + '" class="entity-avatar-img"' + eidAttr +
             ' style="width:' + size + 'px;height:' + size + 'px;" alt="avatar" loading="lazy">';

--- a/backend/tests/jest/portal-entity-avatar-canvas-guard.test.js
+++ b/backend/tests/jest/portal-entity-avatar-canvas-guard.test.js
@@ -125,3 +125,59 @@ describe('renderAvatarHtml — canvas-vs-URL guard (Phase 0 dashboard bug fix)',
         expect(html).toContain('data-petdx-entity-id="1"');
     });
 });
+
+// Regression: cross-device petdx bots (marketplace / arena / share-chat) arrive
+// with avatar_url = /api/petdx/<slug>/sprite.webp and NO cached descriptor, so the
+// canvas path is skipped. Before this fix renderAvatarHtml emitted a raw <img src=
+// sprite.webp> → the whole 8×9 sheet shrank into the box (the "大頭貼 mismatched" P0,
+// previously only fixed in community.html). Now it crops frame 0 at the shared layer.
+describe('renderAvatarHtml — petdx sprite frame-0 crop (cross-device, no descriptor)', () => {
+    const SPRITE = '/api/petdx/zoro/sprite.webp';
+
+    test('isPetdxSprite matches sprite proxy URLs only', () => {
+        const ctx = loadResolver();
+        expect(ctx.isPetdxSprite('/api/petdx/zoro/sprite.webp')).toBe(true);
+        expect(ctx.isPetdxSprite('https://eclawbot.com/api/petdx/a-b/sprite.png')).toBe(true);
+        expect(ctx.isPetdxSprite('/api/petdx/zoro/avatar.webp')).toBe(false); // derived single frame
+        expect(ctx.isPetdxSprite('/static/x.png')).toBe(false);
+        expect(ctx.isPetdxSprite(null)).toBeFalsy();
+    });
+
+    test('sprite URL with no AvatarPetdx → frame-0 crop div, NOT raw sheet img', () => {
+        const ctx = loadResolver();
+        const html = ctx.renderAvatarHtml(SPRITE, 48, 7);
+        expect(html).toContain('background-size:800% 900%');
+        expect(html).toContain('background-position:0 0');
+        expect(html).toContain('url(' + SPRITE + ')');
+        expect(html).toContain('data-entity-id="7"');
+        expect(html).not.toContain('<img'); // never the raw shrunk sheet
+        expect(html).not.toContain('<canvas');
+    });
+
+    test('sprite URL when descriptor cache lacks this entity → still cropped', () => {
+        const ctx = loadResolver();
+        ctx.window.AvatarPetdx = { hasDescriptor: () => false, getDescriptor: () => null };
+        const html = ctx.renderAvatarHtml(SPRITE, 56);
+        expect(html).toContain('background-size:800% 900%');
+        expect(html).not.toContain('<img');
+    });
+
+    test('derived avatar.webp (post-backfill) renders as plain img, NOT cropped', () => {
+        const ctx = loadResolver();
+        const html = ctx.renderAvatarHtml('/api/petdx/zoro/avatar.webp', 48, 7);
+        expect(html).toContain('<img src="/api/petdx/zoro/avatar.webp"');
+        expect(html).not.toContain('background-size:800% 900%');
+    });
+
+    test('own-device animated canvas still wins over crop when descriptor present', () => {
+        const ctx = loadResolver();
+        ctx.window.AvatarPetdx = {
+            hasDescriptor: (id) => id === 3,
+            getDescriptor: () => ({ assetType: 'spritesheet', descriptor: { assetType: 'spritesheet', asset: { url: SPRITE } } }),
+            descriptorAvatarUrl: () => SPRITE,
+        };
+        const html = ctx.renderAvatarHtml(SPRITE, 48, 3);
+        expect(html).toContain('<canvas');
+        expect(html).not.toContain('background-size:800% 900%');
+    });
+});


### PR DESCRIPTION
## Scope (card_a0a5041b)
**Harden-on-first-fix gap:** #3527's frame-0 crop only patched `community.html`. Every other surface (marketplace / arena / share-chat) renders avatars via the **shared** `renderAvatarHtml` in `portal/shared/entity-utils.js`, which had no sprite-crop branch → a cross-device petdx bot (`avatar_url = /api/petdx/<slug>/sprite.webp`, no cached descriptor) fell through to a raw `<img src=sprite.webp>` = the whole 8×9 sheet shrunk into the box = the same "大頭貼 mismatched" P0, **still live** on those surfaces.

## Prod-verified before fixing
DOM eval on `https://eclawbot.com/portal/marketplace.html`: bot `zoro` rendered as `<img src=/api/petdx/zoro/sprite.webp>` at 48×48 (all poses crushed together). Code-verified: `renderAvatarHtml` had no `isPetdxSprite`/crop path.

## Fix
Add `isPetdxSprite()` + a frame-0 crop `<div>` (`background-size:800% 900%; position:0 0`) **between** the canvas branch and the raw-`<img>` branch:
- own-device **animated canvas** still wins when a descriptor is cached;
- cross-device **sprite URLs crop to frame 0** on all surfaces;
- derived **`avatar.webp`** (post Phase-5 backfill) falls through to a plain `<img>` (branch stops matching).

Defense-in-depth: fixes all surfaces **now**, independent of the Phase-5 backfill / Phase-6 (#3535) store-on-create timeline.

## Test plan
- +5 regression tests in `portal-entity-avatar-canvas-guard.test.js` (sprite→crop, no-descriptor→crop, avatar.webp→plain img, canvas-still-wins, `isPetdxSprite` matching).
- `npx jest portal-entity-avatar-* community-plaza-avatar-petdx kanban-avatar-parity-static` → **42 passed**.
- ESLint: `public/` browser files are ignored by config (unchanged).

## User POV
Bot avatars on marketplace, arena, and share-chat now show the clean single idle frame instead of a garbled multi-pose thumbnail — matching community.html.

🤖 Generated with [Claude Code](https://claude.com/claude-code)