### PR TITLE
feat(admin): add self-improvement hub loop

### DIFF
--- a/backend/public/portal/admin/index.html
+++ b/backend/public/portal/admin/index.html
@@ -20,6 +20,17 @@
         .ah-card-title { font-size: 15px; font-weight: 700; display: flex; align-items: center; gap: 8px; }
         .ah-card-desc { font-size: 12px; color: var(--text-secondary); }
         .ah-card-soon { font-size: 10px; color: #f59e0b; text-transform: uppercase; letter-spacing: 1px; margin-top: 4px; }
+        .ah-card-actions { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 8px; }
+        .ah-action { border: 1px solid var(--card-border); background: var(--input-bg); color: var(--text); border-radius: var(--radius-sm); padding: 7px 10px; font-size: 12px; text-decoration: none; cursor: pointer; }
+        .ah-action:hover { border-color: var(--primary); }
+        .ah-action.primary { background: var(--primary); border-color: var(--primary); color: #fff; }
+        .ah-self-card { border-color: rgba(108, 99, 255, 0.45); }
+        .ah-help-btn { margin-left: auto; width: 22px; height: 22px; border-radius: 999px; border: 1px solid var(--card-border); background: var(--input-bg); color: var(--text-secondary); cursor: pointer; font-size: 12px; font-weight: 700; }
+        .ah-help-btn:hover { color: var(--primary); border-color: var(--primary); }
+        .ah-help-panel { display: none; margin-top: 10px; border: 1px dashed var(--card-border); border-radius: var(--radius-sm); padding: 10px 12px; font-size: 12px; color: var(--text-secondary); line-height: 1.55; background: rgba(108, 99, 255, 0.06); }
+        .ah-help-panel.open { display: block; }
+        .ah-mini-list { margin: 6px 0 0 18px; padding: 0; }
+        .ah-status-note { font-size: 11px; color: var(--text-secondary); min-height: 16px; margin-top: 6px; }
 
         .ah-section-title { font-size: 13px; font-weight: 700; color: var(--text-secondary); text-transform: uppercase; letter-spacing: 0.5px; margin: 18px 0 10px 0; }
         .ah-footnote { font-size: 11px; color: var(--text-secondary); margin-top: 24px; text-align: center; opacity: 0.7; }
@@ -42,6 +53,36 @@
                 <div class="ah-card-title">🩺 <span data-i18n="admin_hub_card_rental_monitor">Rental Health Monitor</span></div>
                 <div class="ah-card-desc" data-i18n="admin_hub_card_rental_monitor_desc">DB latency, tombstone growth, publisher integration status, fleet counts.</div>
             </a>
+        </div>
+
+        <h3 class="ah-section-title" data-i18n="admin_hub_section_self_improvement">Self improvement</h3>
+        <div class="ah-grid">
+            <div class="ah-card ah-self-card" id="adminSelfImprovementCard">
+                <div class="ah-card-title">
+                    🧭 <span data-i18n="admin_hub_card_self_improvement">Admin self-improvement loop</span>
+                    <button class="ah-help-btn" type="button" aria-expanded="false" aria-controls="adminSelfHelp" onclick="toggleAdminSelfHelp(this)">?</button>
+                </div>
+                <div class="ah-card-desc" data-i18n="admin_hub_card_self_improvement_desc">Capture admin-page friction, empty states, and failed actions into an OODA-R brief that can become a card or note.</div>
+                <div class="ah-card-actions">
+                    <a class="ah-action primary" href="/portal/kanban.html?q=admin%20self%20improvement" data-i18n="admin_hub_self_open_kanban">Open Kanban</a>
+                    <a class="ah-action" href="/portal/feedback.html" data-i18n="admin_hub_self_open_feedback">Feedback history</a>
+                    <button class="ah-action" type="button" onclick="copyAdminSelfImprovementBrief()" data-i18n="admin_hub_self_copy_brief">Copy OODA-R brief</button>
+                </div>
+                <div id="adminSelfHelp" class="ah-help-panel" aria-live="polite">
+                    <strong data-i18n="admin_hub_self_help_what_label">What:</strong>
+                    <span data-i18n="admin_hub_self_help_what">Use this when an admin page is confusing, empty, blocked, or repeatedly needs manual follow-up.</span><br>
+                    <strong data-i18n="admin_hub_self_help_needs_label">Needs:</strong>
+                    <span data-i18n="admin_hub_self_help_needs">Admin access plus an actionable observation; no secrets, tokens, or private device credentials.</span><br>
+                    <strong data-i18n="admin_hub_self_help_next_label">Next step:</strong>
+                    <span data-i18n="admin_hub_self_help_next">Open Kanban or copy the brief, then attach screenshots and the smallest reproducible admin-page path.</span>
+                    <ul class="ah-mini-list">
+                        <li data-i18n="admin_hub_self_help_globe">Globe-user: describe the user/device capability, not a single local account.</li>
+                        <li data-i18n="admin_hub_self_help_setup">Setup: name required permissions, API availability, and graceful degradation.</li>
+                        <li data-i18n="admin_hub_self_help_empty">Empty state: include what it means, what is needed, and the next action.</li>
+                    </ul>
+                </div>
+                <div id="adminSelfStatus" class="ah-status-note" aria-live="polite"></div>
+            </div>
         </div>
 
         <h3 class="ah-section-title" data-i18n="admin_hub_section_future">Planned</h3>
@@ -85,6 +126,59 @@
 
     <script>
         function tt(k, fb) { return (typeof i18n !== 'undefined' ? i18n.t(k) : null) || fb; }
+
+        function setAdminSelfStatus(messageKey, fallback) {
+            const el = document.getElementById('adminSelfStatus');
+            if (el) el.textContent = tt(messageKey, fallback);
+        }
+
+        function toggleAdminSelfHelp(btn) {
+            const panel = document.getElementById('adminSelfHelp');
+            if (!panel) return;
+            const open = !panel.classList.contains('open');
+            panel.classList.toggle('open', open);
+            if (btn) btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+            setAdminSelfStatus(
+                open ? 'admin_hub_self_status_help_open' : 'admin_hub_self_status_help_closed',
+                open ? 'Help opened — capture What, Needs, Next step.' : ''
+            );
+        }
+
+        function buildAdminSelfImprovementBrief() {
+            const path = window.location.pathname || '/portal/admin/';
+            return [
+                '[Admin Self-improvement OODA-R]',
+                'Page: ' + path,
+                'Observation: <describe the admin-page friction, empty state, or failed action>',
+                'Globe-user: <which role/capability is affected globally; no hardcoded device/entity/user>',
+                'Setup: <required admin permission/API/runtime condition; graceful degradation if missing>',
+                '? icon UX: <What this state means / Needs / Next step>',
+                'Evidence: <attach screenshot or reproducible path>',
+                'Next card/note: <smallest shippable improvement>'
+            ].join('\n');
+        }
+
+        async function copyAdminSelfImprovementBrief() {
+            const brief = buildAdminSelfImprovementBrief();
+            try {
+                if (navigator.clipboard && navigator.clipboard.writeText) {
+                    await navigator.clipboard.writeText(brief);
+                } else {
+                    const ta = document.createElement('textarea');
+                    ta.value = brief;
+                    ta.setAttribute('readonly', '');
+                    ta.style.position = 'fixed';
+                    ta.style.left = '-9999px';
+                    document.body.appendChild(ta);
+                    ta.select();
+                    document.execCommand('copy');
+                    ta.remove();
+                }
+                setAdminSelfStatus('admin_hub_self_status_copied', 'OODA-R brief copied. Paste it into a Kanban card or mission note.');
+            } catch (err) {
+                setAdminSelfStatus('admin_hub_self_status_copy_failed', 'Copy failed — open Kanban and paste the brief manually.');
+            }
+        }
 
         function getAuthQuery() {
             const u = window.currentUser || {};

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -579190,6 +579190,26 @@ const TRANSLATIONS = {
 
 
         "admin_hub_section_monitoring": "Monitoring",
+        "admin_hub_section_self_improvement": "Self improvement",
+        "admin_hub_card_self_improvement": "Admin self-improvement loop",
+        "admin_hub_card_self_improvement_desc": "Capture admin-page friction, empty states, and failed actions into an OODA-R brief that can become a card or note.",
+        "admin_hub_self_open_kanban": "Open Kanban",
+        "admin_hub_self_open_feedback": "Feedback history",
+        "admin_hub_self_copy_brief": "Copy OODA-R brief",
+        "admin_hub_self_help_what_label": "What:",
+        "admin_hub_self_help_what": "Use this when an admin page is confusing, empty, blocked, or repeatedly needs manual follow-up.",
+        "admin_hub_self_help_needs_label": "Needs:",
+        "admin_hub_self_help_needs": "Admin access plus an actionable observation; no secrets, tokens, or private device credentials.",
+        "admin_hub_self_help_next_label": "Next step:",
+        "admin_hub_self_help_next": "Open Kanban or copy the brief, then attach screenshots and the smallest reproducible admin-page path.",
+        "admin_hub_self_help_globe": "Globe-user: describe the user/device capability, not a single local account.",
+        "admin_hub_self_help_setup": "Setup: name required permissions, API availability, and graceful degradation.",
+        "admin_hub_self_help_empty": "Empty state: include what it means, what is needed, and the next action.",
+        "admin_hub_self_status_help_open": "Help opened — capture What, Needs, Next step.",
+        "admin_hub_self_status_help_closed": "",
+        "admin_hub_self_status_copied": "OODA-R brief copied. Paste it into a Kanban card or mission note.",
+        "admin_hub_self_status_copy_failed": "Copy failed — open Kanban and paste the brief manually.",
+
 
 
 
@@ -1187263,6 +1187283,26 @@ const TRANSLATIONS = {
 
 
         "admin_hub_section_monitoring": "監控",
+        "admin_hub_section_self_improvement": "自我改善",
+        "admin_hub_card_self_improvement": "管理頁面自我改善迴路",
+        "admin_hub_card_self_improvement_desc": "把管理頁面的痛點、空狀態與失敗操作整理成 OODA-R 摘要，可貼到卡片或 note。",
+        "admin_hub_self_open_kanban": "開啟 Kanban",
+        "admin_hub_self_open_feedback": "Feedback 歷史",
+        "admin_hub_self_copy_brief": "複製 OODA-R 摘要",
+        "admin_hub_self_help_what_label": "What：",
+        "admin_hub_self_help_what": "當管理頁面讓人困惑、空白、被阻擋，或反覆需要人工追蹤時使用。",
+        "admin_hub_self_help_needs_label": "Needs：",
+        "admin_hub_self_help_needs": "需要管理員權限與可行觀察；不要放入 secret、token 或私人裝置憑證。",
+        "admin_hub_self_help_next_label": "Next step：",
+        "admin_hub_self_help_next": "開啟 Kanban 或複製摘要，並附上截圖與最小可重現的管理頁路徑。",
+        "admin_hub_self_help_globe": "Globe-user：描述全域角色/裝置能力，不要綁定單一本機帳號。",
+        "admin_hub_self_help_setup": "Setup：列出所需權限、API 可用性與降級行為。",
+        "admin_hub_self_help_empty": "Empty state：包含它代表什麼、需要什麼、下一步動作。",
+        "admin_hub_self_status_help_open": "已開啟說明 — 請整理 What、Needs、Next step。",
+        "admin_hub_self_status_help_closed": "",
+        "admin_hub_self_status_copied": "已複製 OODA-R 摘要，可貼到 Kanban 卡片或 mission note。",
+        "admin_hub_self_status_copy_failed": "複製失敗 — 請開啟 Kanban 後手動貼上摘要。",
+
 
 
 
@@ -1246562,6 +1246602,26 @@ const TRANSLATIONS = {
 
 
         "admin_hub_section_monitoring": "監控",
+        "admin_hub_section_self_improvement": "自我改善",
+        "admin_hub_card_self_improvement": "管理页面自我改善回路",
+        "admin_hub_card_self_improvement_desc": "把管理页面的痛点、空状态与失败操作整理成 OODA-R 摘要，可贴到卡片或 note。",
+        "admin_hub_self_open_kanban": "开启 Kanban",
+        "admin_hub_self_open_feedback": "Feedback 历史",
+        "admin_hub_self_copy_brief": "复制 OODA-R 摘要",
+        "admin_hub_self_help_what_label": "What：",
+        "admin_hub_self_help_what": "当管理页面让人困惑、空白、被阻挡，或反复需要人工追踪时使用。",
+        "admin_hub_self_help_needs_label": "Needs：",
+        "admin_hub_self_help_needs": "需要管理员权限与可行观察；不要放入 secret、token 或私人设备凭证。",
+        "admin_hub_self_help_next_label": "Next step：",
+        "admin_hub_self_help_next": "开启 Kanban 或复制摘要，并附上截图与最小可重现的管理页路径。",
+        "admin_hub_self_help_globe": "Globe-user：描述全域角色/设备能力，不要绑定单一本机账号。",
+        "admin_hub_self_help_setup": "Setup：列出所需权限、API 可用性与降级行为。",
+        "admin_hub_self_help_empty": "Empty state：包含它代表什么、需要什么、下一步动作。",
+        "admin_hub_self_status_help_open": "已开启说明 — 请整理 What、Needs、Next step。",
+        "admin_hub_self_status_help_closed": "",
+        "admin_hub_self_status_copied": "已复制 OODA-R 摘要，可贴到 Kanban 卡片或 mission note。",
+        "admin_hub_self_status_copy_failed": "复制失败 — 请开启 Kanban 后手动贴上摘要。",
+
 
 
 

--- a/backend/tests/jest/admin-hub-self-improvement.test.js
+++ b/backend/tests/jest/admin-hub-self-improvement.test.js
@@ -1,0 +1,77 @@
+/**
+ * Admin hub self-improvement surface — card_84d5811099ae2660fdf8a2c8.
+ *
+ * Static contract tests keep this page-level slice small: visible entry,
+ * actionable fallback paths, ? help UX, Globe-user/setup/empty-state copy, and
+ * EN+ZH i18n keys.
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const adminHubSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'portal', 'admin', 'index.html'),
+    'utf8'
+);
+const i18nSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'shared', 'i18n.js'),
+    'utf8'
+);
+
+describe('admin hub self-improvement surface', () => {
+    test('renders a visible self-improvement card with three action paths', () => {
+        expect(adminHubSrc).toContain('id="adminSelfImprovementCard"');
+        expect(adminHubSrc).toContain('admin_hub_section_self_improvement');
+        expect(adminHubSrc).toContain('href="/portal/kanban.html?q=admin%20self%20improvement"');
+        expect(adminHubSrc).toContain('href="/portal/feedback.html"');
+        expect(adminHubSrc).toContain('copyAdminSelfImprovementBrief()');
+    });
+
+    test('has ? help UX with What / Needs / Next step and accessible toggle state', () => {
+        expect(adminHubSrc).toMatch(/class="ah-help-btn"[^>]+aria-expanded="false"[^>]+aria-controls="adminSelfHelp"/);
+        expect(adminHubSrc).toContain('admin_hub_self_help_what_label');
+        expect(adminHubSrc).toContain('admin_hub_self_help_needs_label');
+        expect(adminHubSrc).toContain('admin_hub_self_help_next_label');
+        expect(adminHubSrc).toContain('toggleAdminSelfHelp');
+    });
+
+    test('copy brief template carries Globe-user, Setup, and empty-state prompts without secrets', () => {
+        expect(adminHubSrc).toContain('Globe-user: <which role/capability is affected globally; no hardcoded device/entity/user>');
+        expect(adminHubSrc).toContain('Setup: <required admin permission/API/runtime condition; graceful degradation if missing>');
+        expect(adminHubSrc).toContain('? icon UX: <What this state means / Needs / Next step>');
+        const selfImprovementSlice = adminHubSrc.slice(
+            adminHubSrc.indexOf('id="adminSelfImprovementCard"'),
+            adminHubSrc.indexOf('function getAuthQuery')
+        );
+        expect(selfImprovementSlice).not.toMatch(/botSecret|deviceSecret|DATABASE_URL|CLOUDFLARE_API_TOKEN/);
+    });
+});
+
+describe('admin hub self-improvement i18n', () => {
+    const keys = [
+        'admin_hub_section_self_improvement',
+        'admin_hub_card_self_improvement',
+        'admin_hub_card_self_improvement_desc',
+        'admin_hub_self_open_kanban',
+        'admin_hub_self_open_feedback',
+        'admin_hub_self_copy_brief',
+        'admin_hub_self_help_what_label',
+        'admin_hub_self_help_what',
+        'admin_hub_self_help_needs_label',
+        'admin_hub_self_help_needs',
+        'admin_hub_self_help_next_label',
+        'admin_hub_self_help_next',
+        'admin_hub_self_help_globe',
+        'admin_hub_self_help_setup',
+        'admin_hub_self_help_empty',
+        'admin_hub_self_status_copied',
+        'admin_hub_self_status_copy_failed',
+    ];
+
+    test.each(keys)('%s exists in EN + ZH locales', (key) => {
+        const matches = i18nSrc.match(new RegExp('"' + key + '":', 'g')) || [];
+        // EN + Traditional ZH + Simplified ZH.
+        expect(matches.length).toBeGreaterThanOrEqual(3);
+    });
+});


### PR DESCRIPTION
## Summary
- Add an Admin Hub self-improvement loop card on `/portal/admin/index.html`.
- Provide three action paths: open Kanban with an admin self-improvement query, open feedback history, and copy an OODA-R brief template.
- Add `?` help UX covering What / Needs / Next step plus Globe-user / Setup / Empty-state prompts.
- Add EN + ZH i18n keys and a static Jest contract test for the new page-level surface.

## Verification
- `npx jest tests/jest/admin-hub-self-improvement.test.js --runInBand --forceExit`
- `node scripts/portal-smoke-check.js`
- `git diff --check -- backend/public/portal/admin/index.html backend/public/shared/i18n.js backend/tests/jest/admin-hub-self-improvement.test.js`
- Custom static check confirmed each new i18n key exists in EN + Traditional ZH + Simplified ZH.

## Evidence / blocker
- Screenshot evidence is still pending: Browser plugin reported no available in-app browser, local Playwright Chromium hit macOS MachPort permission denial, and the unsandboxed screenshot run was not approved.
- This PR is therefore ready for code review but still needs screenshot evidence before the kanban card can auto-close.

## Card
- card_84d5811099ae2660fdf8a2c8
