### PR TITLE
fix(portal): address authenticated QA/UIUX sweep regressions

### DIFF
--- a/backend/growth.js
+++ b/backend/growth.js
@@ -7,7 +7,8 @@
  *   GET /daily — today's aggregate growth metrics
  *
  * Auth chain (all must pass):
- *   1. botSecret matches devices[deviceId].entities[entityId].botSecret
+ *   1. deviceSecret matches devices[deviceId].deviceSecret, OR
+ *      botSecret matches devices[deviceId].entities[entityId].botSecret
  *   2. user_accounts.is_admin = TRUE for the user owning that deviceId
  *   3. Per-bot rate limit: 60 requests / hour
  *
@@ -46,6 +47,29 @@ function findEntity(devices, deviceId, entityId, botSecret) {
     const entity = (device.entities || {})[entityId];
     if (!entity || !safeEqual(entity.botSecret, botSecret)) return null;
     return entity;
+}
+
+function authenticateMetrics(devices, { deviceId, deviceSecret, botSecret, entityId }) {
+    if (!deviceId) {
+        return { ok: false, status: 400, error: 'Missing deviceId' };
+    }
+    const device = devices[deviceId];
+    if (!device) {
+        return { ok: false, status: 401, error: 'Invalid credentials' };
+    }
+    if (deviceSecret && device.deviceSecret && safeEqual(device.deviceSecret, deviceSecret)) {
+        return { ok: true, rateKey: `device:${deviceId}`, entityId: null };
+    }
+    if (botSecret && entityId !== undefined && entityId !== null && entityId !== '') {
+        const parsedEntityId = parseInt(entityId, 10);
+        if (findEntity(devices, deviceId, parsedEntityId, botSecret)) {
+            return { ok: true, rateKey: `bot:${botSecret}`, entityId: parsedEntityId };
+        }
+    }
+    if (!deviceSecret && (!botSecret || entityId === undefined || entityId === null || entityId === '')) {
+        return { ok: false, status: 400, error: 'Missing deviceSecret or botSecret + entityId' };
+    }
+    return { ok: false, status: 401, error: 'Invalid credentials' };
 }
 
 async function isOwnerAdmin(deviceId) {
@@ -229,14 +253,15 @@ async function fetchPortalFunnel(since, until) {
     // Aggregate into: { action -> { total, by_source: [{source, channel, count}] }
     const funnel = {};
     for (const row of r.rows) {
+        const count = Number(row.event_count) || 0;
         if (!funnel[row.action]) {
             funnel[row.action] = { total: 0, by_source: [] };
         }
-        funnel[row.action].total += row.event_count;
+        funnel[row.action].total += count;
         funnel[row.action].by_source.push({
             source: row.source,
             channel: row.channel,
-            count: row.event_count
+            count
         });
     }
     return funnel;
@@ -247,11 +272,7 @@ module.exports = function(devices) {
     const router = express.Router();
 
     router.get('/daily', async (req, res) => {
-        const { deviceId, botSecret, entityId, date } = req.query;
-
-        if (!deviceId || !botSecret || !entityId) {
-            return res.status(400).json({ success: false, error: 'Missing deviceId, botSecret, or entityId' });
-        }
+        const { deviceId, deviceSecret, botSecret, entityId, date } = req.query;
 
         let anchorDate;
         if (date === undefined || date === '') {
@@ -262,12 +283,12 @@ module.exports = function(devices) {
             return res.status(400).json({ success: false, error: 'Invalid date — expected YYYY-MM-DD' });
         }
 
-        const entity = findEntity(devices, deviceId, parseInt(entityId), botSecret);
-        if (!entity) {
-            return res.status(401).json({ success: false, error: 'Invalid credentials' });
+        const auth = authenticateMetrics(devices, { deviceId, deviceSecret, botSecret, entityId });
+        if (!auth.ok) {
+            return res.status(auth.status).json({ success: false, error: auth.error });
         }
 
-        if (!checkRate(botSecret)) {
+        if (!checkRate(auth.rateKey)) {
             return res.status(429).json({ success: false, error: 'Rate limit exceeded (60/hour)' });
         }
 
@@ -311,11 +332,7 @@ module.exports = function(devices) {
 
     // GET /api/growth/funnel — portal beacon funnel counts by action × source × channel
     router.get('/funnel', async (req, res) => {
-        const { deviceId, botSecret, entityId, since, until } = req.query;
-
-        if (!deviceId || !botSecret || !entityId) {
-            return res.status(400).json({ success: false, error: 'Missing deviceId, botSecret, or entityId' });
-        }
+        const { deviceId, deviceSecret, botSecret, entityId, since, until } = req.query;
         if (!since || !until) {
             return res.status(400).json({ success: false, error: 'since and until (YYYY-MM-DD) are required' });
         }
@@ -323,12 +340,23 @@ module.exports = function(devices) {
             return res.status(400).json({ success: false, error: 'Invalid date — expected YYYY-MM-DD' });
         }
 
-        const entity = findEntity(devices, deviceId, parseInt(entityId), botSecret);
-        if (!entity) {
-            return res.status(401).json({ success: false, error: 'Invalid credentials' });
+        const auth = authenticateMetrics(devices, { deviceId, deviceSecret, botSecret, entityId });
+        if (!auth.ok) {
+            return res.status(auth.status).json({ success: false, error: auth.error });
         }
-        if (!checkRate(botSecret)) {
+        if (!checkRate(auth.rateKey)) {
             return res.status(429).json({ success: false, error: 'Rate limit exceeded (60/hour)' });
+        }
+
+        let admin;
+        try {
+            admin = await isOwnerAdmin(deviceId);
+        } catch (err) {
+            console.error('[Growth] funnel admin check error:', err);
+            return res.status(500).json({ success: false, error: 'Internal error' });
+        }
+        if (!admin) {
+            return res.status(403).json({ success: false, error: 'Owner is not admin' });
         }
 
         try {
@@ -342,6 +370,6 @@ module.exports = function(devices) {
 
     return {
         router,
-        _internal: { checkRate, findEntity, isOwnerAdmin, fetchSignupsForDate, fetchSignupSourceForDate, fetchRetention7dForDate, fetchPlazaNewListedForDate, fetchInviteConversion, fetchInviteClicksForDate, fetchInviteKForDate, fetchPortalFunnel, isValidDateStr, taipeiTodayISO, rateBuckets }
+        _internal: { checkRate, findEntity, authenticateMetrics, isOwnerAdmin, fetchSignupsForDate, fetchSignupSourceForDate, fetchRetention7dForDate, fetchPlazaNewListedForDate, fetchInviteConversion, fetchInviteClicksForDate, fetchInviteKForDate, fetchPortalFunnel, isValidDateStr, taipeiTodayISO, rateBuckets }
     };
 };

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -183,6 +183,7 @@
 
         .filter-chip {
             padding: 5px 14px;
+            min-height: 28px;
             border-radius: 20px;
             font-size: 12px;
             cursor: pointer;
@@ -207,6 +208,7 @@
 
         .filter-chip-toggle {
             padding: 5px 10px;
+            min-height: 28px;
             border-radius: 20px;
             font-size: 12px;
             cursor: pointer;
@@ -487,10 +489,14 @@
             text-transform: lowercase;
         }
         .code-copy-btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 28px;
             background: none;
             border: 1px solid rgba(255,255,255,0.12);
             color: var(--text-muted, #8b949e);
-            padding: 2px 8px;
+            padding: 4px 8px;
             border-radius: 4px;
             font-size: 11px;
             cursor: pointer;

--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -177,12 +177,17 @@
             font-family: monospace;
         }
         .invite-cta-copy-btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 28px;
+            min-height: 28px;
             background: none;
             border: none;
             color: var(--text-muted);
             cursor: pointer;
             font-size: 14px;
-            padding: 2px 4px;
+            padding: 0;
             border-radius: 4px;
             transition: color 0.2s;
         }

--- a/backend/public/portal/dashboard.html
+++ b/backend/public/portal/dashboard.html
@@ -6506,7 +6506,7 @@
         })();
 
         /* ── K-Value Tracker (§7 k-Value Metric) ── */
-        // Reads GET /api/growth/daily?date=YYYY-MM-DD with device credentials.
+        // Reads GET /api/growth/daily?date=YYYY-MM-DD with owner device credentials.
         // Renders invite_k: shares/clicks/redeemed/activated + k_observed + k_model.
         // Requires owner/admin credentials.
         async function loadKValue(dateStr) {
@@ -6531,11 +6531,9 @@
             error.style.display = 'none';
 
             try {
-                const entityId = parseInt(new URLSearchParams(window.location.search).get('entity') || '0', 10);
                 const params = new URLSearchParams({
                     deviceId: user.deviceId,
-                    botSecret: user.deviceSecret,
-                    entityId: entityId,
+                    deviceSecret: user.deviceSecret,
                     date: dateStr
                 });
                 const r = await fetch('/api/growth/daily?' + params.toString(), { credentials: 'include' });

--- a/backend/public/portal/env-vars.html
+++ b/backend/public/portal/env-vars.html
@@ -356,7 +356,7 @@
                         載入中...
                     </div>
                     <button id="btnRevealCurlId" onclick="toggleCurlHintReveal()"
-                        style="position:absolute;top:4px;right:6px;background:none;border:none;cursor:pointer;font-size:13px;padding:2px;opacity:0.55;"
+                        style="position:absolute;top:4px;right:6px;background:none;border:none;cursor:pointer;font-size:13px;padding:0;opacity:0.68;min-width:28px;min-height:28px;display:inline-flex;align-items:center;justify-content:center;border-radius:6px;"
                         data-i18n-title="env_toggle_device_id" title="Show/Hide Device ID">👁</button>
                 </div>
             </div>

--- a/backend/public/portal/kanban.html
+++ b/backend/public/portal/kanban.html
@@ -25,7 +25,7 @@
         .kb-toolbar-actions .btn { white-space:nowrap; flex-shrink:0; }
         .kb-filter-chips { display:flex; gap:6px; flex-wrap:wrap; flex-shrink:0; }
         .kb-chip { white-space:nowrap; }
-        .kb-chip { padding:4px 12px; border-radius:var(--radius-pill); font-size:12px; font-weight:500; cursor:pointer; border:1px solid var(--card-border); background:none; color:var(--text-secondary); transition:all 0.2s; }
+        .kb-chip { padding:5px 12px; min-height:28px; border-radius:var(--radius-pill); font-size:12px; font-weight:500; cursor:pointer; border:1px solid var(--card-border); background:none; color:var(--text-secondary); transition:all 0.2s; }
         .kb-chip.active { background:var(--primary); color:#fff; border-color:var(--primary); }
         .kb-chip:hover:not(.active) { border-color:var(--text-muted); color:var(--text); }
         .kb-sort-select { background:var(--input-bg); border:1px solid var(--card-border); border-radius:var(--radius-sm); color:var(--text); font-size:12px; padding:6px 8px; cursor:pointer; transition:border-color 0.2s; min-width:140px; margin-left:8px; }

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -54,6 +54,27 @@
             min-width: 0;
             justify-content: flex-end;
         }
+        .settings-icon-btn {
+            min-width: 28px;
+            min-height: 28px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            background: none;
+            border: none;
+            cursor: pointer;
+            font-size: 14px;
+            padding: 0;
+            opacity: 0.68;
+            line-height: 1;
+            flex-shrink: 0;
+            border-radius: 6px;
+        }
+        .settings-icon-btn:hover,
+        .settings-icon-btn:focus-visible {
+            opacity: 1;
+            background: var(--input-bg);
+        }
 
         /* ── Subscription ── */
         .subscription-header {
@@ -745,8 +766,7 @@
                 <span class="info-label" data-i18n="settings_device_id">Device ID</span>
                 <span class="info-value-mono-group">
                     <span class="info-value mono" id="accountDeviceId">--</span>
-                    <button onclick="copyDeviceId()"
-                        style="background:none;border:none;cursor:pointer;font-size:14px;padding:0 2px;opacity:0.6;line-height:1;flex-shrink:0;"
+                    <button class="settings-icon-btn" onclick="copyDeviceId()"
                         data-i18n-title="common_copy" title="複製">📋</button>
                 </span>
             </div>
@@ -754,8 +774,7 @@
                 <span class="info-label" data-i18n="settings_device_secret">Device Secret</span>
                 <span class="info-value-mono-group">
                     <span class="info-value mono" id="accountDeviceSecret">--</span>
-                    <button onclick="copyDeviceSecret()"
-                        style="background:none;border:none;cursor:pointer;font-size:14px;padding:0 2px;opacity:0.6;line-height:1;flex-shrink:0;"
+                    <button class="settings-icon-btn" onclick="copyDeviceSecret()"
                         data-i18n-title="common_copy" title="複製">📋</button>
                 </span>
             </div>
@@ -2771,9 +2790,14 @@
             // Skip when not authenticated: /api/usage/snapshot needs a session, so
             // calling it pre-login returns a misleading 400 (missing-creds) in the
             // console for no benefit — the stale notice is irrelevant when logged out.
-            if (typeof currentUser === 'undefined' || !currentUser) { notice.style.display = 'none'; return; }
+            const user = (typeof window !== 'undefined' && window.currentUser) || (typeof currentUser !== 'undefined' ? currentUser : null);
+            if (!user || !user.deviceId || !user.deviceSecret) { notice.style.display = 'none'; return; }
             try {
-                const data = await apiCall('GET', '/api/usage/snapshot');
+                const qs = new URLSearchParams({
+                    deviceId: user.deviceId,
+                    deviceSecret: user.deviceSecret
+                });
+                const data = await apiCall('GET', '/api/usage/snapshot?' + qs.toString());
                 const cap = data && data.latest && data.latest.captured_at;
                 const t = cap ? Date.parse(cap) : NaN;
                 const STALE_MS = 6 * 60 * 60 * 1000;

--- a/backend/public/portal/shared/style.css
+++ b/backend/public/portal/shared/style.css
@@ -235,6 +235,7 @@ a:hover { text-decoration: underline; }
     align-items: center;
     gap: 5px;
     padding: 4px 10px 4px 6px;
+    min-height: 28px;
     border-radius: 16px;
     background: linear-gradient(135deg, rgba(109, 40, 217, 0.2), rgba(16, 185, 129, 0.15));
     border: 1px solid rgba(109, 40, 217, 0.3);
@@ -461,7 +462,7 @@ a:hover { text-decoration: underline; }
     color: var(--text);
 }
 .btn-ghost:hover { background: var(--card-border); color: var(--text); }
-.btn-sm { padding: 6px 12px; font-size: 12px; }
+.btn-sm { padding: 6px 12px; font-size: 12px; min-height: 28px; }
 .btn-block { width: 100%; justify-content: center; }
 .btn:disabled { opacity: 0.5; cursor: not-allowed; pointer-events: none; background: var(--card-border); }
 .btn:focus-visible { outline: 2px solid var(--primary); outline-offset: 2px; }
@@ -881,6 +882,7 @@ a:hover { text-decoration: underline; }
 
 .chip {
     padding: 6px 14px;
+    min-height: 28px;
     border-radius: 20px;
     font-size: 12px;
     cursor: pointer;
@@ -1243,7 +1245,7 @@ a:hover { text-decoration: underline; }
 
 @media (max-width: 480px) {
     .nav-logo-text { display: none; }
-    .chip { padding: 4px 10px; font-size: 11px; }
+    .chip { padding: 5px 10px; font-size: 11px; min-height: 28px; }
     .entity-grid { grid-template-columns: 1fr; }
 }
 
@@ -1590,8 +1592,8 @@ a:hover { text-decoration: underline; }
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 16px;
-    height: 16px;
+    width: 28px;
+    height: 28px;
     border-radius: 50%;
     background: rgba(108,99,255,0.15);
     color: var(--primary, #6c63ff);
@@ -1605,13 +1607,12 @@ a:hover { text-decoration: underline; }
     font-size: 0; /* hide text */
     position: relative; /* anchor the ::after tap-target expansion */
 }
-/* Invisible expanded hit area — bumps the effective tap target from 16x16
-   to 36x36 (Apple HIG 44pt / Material 48dp minimum). Click/tap bubbles
-   from ::after to .help-icon so the popover toggler still fires. */
+/* Invisible expanded hit area — keeps the compact icon easier to tap without
+   shifting surrounding labels. Click/tap bubbles from ::after to .help-icon. */
 .help-icon::after {
     content: '';
     position: absolute;
-    inset: -10px;
+    inset: -4px;
 }
 .help-icon:hover {
     background: rgba(108,99,255,0.3);

--- a/backend/public/shared/refs-popover.css
+++ b/backend/public/shared/refs-popover.css
@@ -12,8 +12,8 @@
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 18px;
-    height: 18px;
+    width: 28px;
+    height: 28px;
     margin-left: 4px;
     padding: 0;
     border: 0;

--- a/backend/tests/jest/growth.test.js
+++ b/backend/tests/jest/growth.test.js
@@ -60,6 +60,7 @@ beforeEach(() => {
 });
 
 const get = (qs) => request(app).get('/api/growth/daily' + qs);
+const getFunnel = (qs) => request(app).get('/api/growth/funnel' + qs);
 
 function setupAdminQueries({
     signups = 5, cohort = 10, active = 4, plaza = 2,
@@ -81,6 +82,15 @@ function setupAdminQueries({
         .mockResolvedValueOnce({ rows: finalInviteClicksRows })
         .mockResolvedValueOnce({ rows: finalSourceRows })
         .mockResolvedValueOnce({ rows: [finalInviteKRow] });
+}
+
+function setupFunnelQueries({
+    isAdmin = true,
+    rows = [{ action: 'signup_started', source: 'web_portal', channel: 'portal', event_count: '3' }],
+} = {}) {
+    mockQuery
+        .mockResolvedValueOnce({ rows: [{ is_admin: isAdmin }] })
+        .mockResolvedValueOnce({ rows });
 }
 
 describe('Growth /daily auth', () => {
@@ -109,6 +119,14 @@ describe('Growth /daily auth', () => {
         mockQuery.mockResolvedValueOnce({ rows: [] });
         const res = await get('?deviceId=unknown-dev&botSecret=orphan-bot-sec&entityId=2');
         expect(res.status).toBe(403);
+    });
+
+    it('accepts owner deviceSecret without requiring an entity botSecret', async () => {
+        setupAdminQueries({ signups: 4 });
+        const res = await get('?deviceId=admin-dev&deviceSecret=sec');
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.today_signups).toBe(4);
     });
 });
 
@@ -301,6 +319,34 @@ describe('Growth /daily rate limit', () => {
         const res = await get('?deviceId=user-dev&botSecret=user-bot-sec&entityId=2');
         expect(res.status).toBe(200);
     }, 30000);
+});
+
+describe('Growth /funnel auth', () => {
+    const range = '&since=2026-06-01&until=2026-06-19';
+
+    it('accepts owner deviceSecret only for admin owners', async () => {
+        setupFunnelQueries();
+        const res = await getFunnel('?deviceId=admin-dev&deviceSecret=sec' + range);
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.funnel.signup_started).toEqual({
+            total: 3,
+            by_source: [{ source: 'web_portal', channel: 'portal', count: 3 }],
+        });
+    });
+
+    it('rejects non-admin owners after metric auth', async () => {
+        setupFunnelQueries({ isAdmin: false });
+        const res = await getFunnel('?deviceId=user-dev&deviceSecret=sec2' + range);
+        expect(res.status).toBe(403);
+        expect(res.body.error).toMatch(/admin/i);
+    });
+
+    it('returns 500 on db error in funnel admin check', async () => {
+        mockQuery.mockRejectedValueOnce(new Error('funnel admin check failed'));
+        const res = await getFunnel('?deviceId=admin-dev&deviceSecret=sec' + range);
+        expect(res.status).toBe(500);
+    });
 });
 
 describe('Growth signup_source schema contract', () => {

--- a/backend/tests/jest/portal-static-ids.test.js
+++ b/backend/tests/jest/portal-static-ids.test.js
@@ -82,6 +82,32 @@ describe('portal static HTML IDs', () => {
     expect(settings.match(/class="roster-action" aria-label="\$\{rosterT\('settings_roster_col_action','Action'\)\}"/g)).toHaveLength(2);
   });
 
+  test('authenticated QA/UIUX sweep regressions stay fixed', () => {
+    const dashboard = fs.readFileSync(path.join(__dirname, '../../public/portal/dashboard.html'), 'utf8');
+    const settings = fs.readFileSync(path.join(__dirname, '../../public/portal/settings.html'), 'utf8');
+    const sharedStyle = fs.readFileSync(path.join(__dirname, '../../public/portal/shared/style.css'), 'utf8');
+    const refsStyle = fs.readFileSync(path.join(__dirname, '../../public/shared/refs-popover.css'), 'utf8');
+    const kanban = fs.readFileSync(path.join(__dirname, '../../public/portal/kanban.html'), 'utf8');
+    const community = fs.readFileSync(path.join(__dirname, '../../public/portal/community.html'), 'utf8');
+    const envVars = fs.readFileSync(path.join(__dirname, '../../public/portal/env-vars.html'), 'utf8');
+
+    expect(dashboard).toContain("deviceSecret: user.deviceSecret");
+    expect(dashboard).not.toContain("botSecret: user.deviceSecret");
+
+    expect(settings).toContain("const qs = new URLSearchParams({");
+    expect(settings).toContain("deviceSecret: user.deviceSecret");
+    expect(settings).toContain("'/api/usage/snapshot?' + qs.toString()");
+
+    expect(sharedStyle).toMatch(/\.ecoin-badge\s*\{[\s\S]*min-height:\s*28px/);
+    expect(sharedStyle).toMatch(/\.btn-sm\s*\{[^}]*min-height:\s*28px/);
+    expect(sharedStyle).toMatch(/\.chip\s*\{[\s\S]*min-height:\s*28px/);
+    expect(sharedStyle).toMatch(/\.help-icon\s*\{[\s\S]*width:\s*28px;[\s\S]*height:\s*28px/);
+    expect(refsStyle).toMatch(/\.eclaw-refs-icon\s*\{[\s\S]*width:\s*28px;[\s\S]*height:\s*28px/);
+    expect(kanban).toMatch(/\.kb-chip\s*\{[^}]*min-height:28px/);
+    expect(community).toMatch(/\.invite-cta-copy-btn\s*\{[\s\S]*min-width:\s*28px;[\s\S]*min-height:\s*28px/);
+    expect(envVars).toMatch(/id="btnRevealCurlId"[\s\S]*min-width:28px;min-height:28px/);
+  });
+
   test('publisher secret visibility toggles expose accessible names and tooltips', () => {
     const publisherPath = path.join(__dirname, '../../public/portal/publisher.html');
     const publisher = fs.readFileSync(publisherPath, 'utf8');


### PR DESCRIPTION
## Summary
- Fix dashboard k-value widget auth so `/api/growth/daily` uses owner `deviceSecret` instead of sending it as `botSecret`.
- Fix settings usage snapshot stale-check so `/api/usage/snapshot` receives device credentials and no longer logs a missing-creds 400 on load.
- Bring the authenticated sweep's tiny portal controls up to at least 28px hit targets across dashboard/settings/kanban/chat/community/env-vars shared controls.

Fixes #3540
Fixes #3541
Fixes #3542

## Test Plan
- `npm test -- --runTestsByPath tests/jest/growth.test.js tests/jest/portal-static-ids.test.js`
- `npm test -- --runTestsByPath tests/jest/portal-static-ids.test.js`
- `node scripts/portal-smoke-check.js`
- Focused local Playwright sweep against patched static portal at desktop 1280x800 and mobile 390x844 for dashboard/settings/kanban/chat/community/env-vars; report saved locally under `/tmp/eclaw-auth-uiux-sweep-20260619-patched/focused-report.json`.

## Notes
- Live production pre-fix sweep covered 11 authenticated portal pages on desktop/mobile and produced the three linked issues. Production also emitted some 429s from live rate limits/link previews; those are treated as environment noise, not fixed in this PR.