### PR TITLE
[codex] Fix Android App Links domain verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -435,6 +435,7 @@ EClaw/
    |-----|----------|---------|--------|
    | Interview start fails with owner_device_not_found | `GET /api/rental/debug/interview-start-fail?deviceId=X&deviceSecret=Y` | 2026-04-12 | Active |
 | Rental contract start returns internal_error during rent/borrow E2E (#2283) | `GET /api/rental/debug/contract-start-fail?deviceId=X&deviceSecret=Y&listingId=Y&renterDeviceId=Z&durationMinutes=30` | 2026-05-01 | Active |
+   | Android App Links domain verification fails for eclawbot.com | `GET /api/debug/android-app-links?deviceId=X&deviceSecret=Y` | 2026-06-19 | Active |
    | Chat first render delayed by cross-device label resolution | `GET /api/debug/chat-render-load-order?deviceId=X&deviceSecret=Y` | 2026-05-01 | Active |
    | Kanban nudges ignored by Codex channel bridge | `GET /api/mission/debug/kanban-codex-nudge?deviceId=X&deviceSecret=Y` | 2026-05-01 | Active |
    | Info public pages: roadmap redirects unauthenticated visitors + release notes show raw Markdown links | `GET /api/debug/info-public-pages?deviceId=X&deviceSecret=Y` | 2026-05-04 | Active |

--- a/backend/redirect-router.js
+++ b/backend/redirect-router.js
@@ -208,17 +208,28 @@ setTimeout(function () {
 }
 
 // ── Android App Links verification (Phase B) ─────────────────────────────
-// Digital Asset Links statement for com.hank.clawlive. Fingerprints come from
-// ASSETLINKS_FINGERPRINTS (comma-separated SHA-256 cert digests) so the Play
-// App Signing certificate can be added without a deploy-time code change; the
-// committed default is the local release-key (upload) certificate.
+// Digital Asset Links statement for com.hank.clawlive. Defaults include both
+// certificates visible on Play Console's app-signing page: the Play App Signing
+// key (what Google Play installs) and the upload key (local release builds).
+// ASSETLINKS_FINGERPRINTS appends any future rotation fingerprints.
 const ANDROID_PACKAGE = 'com.hank.clawlive';
+const ANDROID_APP_LINK_HOST = 'eclawbot.com';
+const ANDROID_APP_LINK_PATH_PREFIX = '/r/';
+const PLAY_APP_SIGNING_CERT_SHA256 = 'A2:EB:6D:55:DD:DF:1C:9D:68:2E:B5:67:1C:1A:E5:8C:01:06:CB:A2:A2:93:5D:DB:CE:D2:AB:E2:E6:F7:76:DB';
 const UPLOAD_CERT_SHA256 = '0D:F0:18:33:A4:41:C4:02:74:9C:CF:4A:5A:59:F2:0C:62:00:3D:59:91:86:36:98:17:D5:89:50:47:DB:E8:10';
+const DEFAULT_ASSETLINKS_FINGERPRINTS = [PLAY_APP_SIGNING_CERT_SHA256, UPLOAD_CERT_SHA256];
+const CERT_FINGERPRINT_RE = /^([0-9A-F]{2}:){31}[0-9A-F]{2}$/;
 
 function assetlinksFingerprints() {
-    const fromEnv = String(process.env.ASSETLINKS_FINGERPRINTS || '')
-        .split(',').map(s => s.trim()).filter(Boolean);
-    return fromEnv.length ? fromEnv : [UPLOAD_CERT_SHA256];
+    const seen = new Set();
+    return DEFAULT_ASSETLINKS_FINGERPRINTS
+        .concat(String(process.env.ASSETLINKS_FINGERPRINTS || '').split(','))
+        .map(s => String(s || '').trim().toUpperCase())
+        .filter(fp => {
+            if (!CERT_FINGERPRINT_RE.test(fp) || seen.has(fp)) return false;
+            seen.add(fp);
+            return true;
+        });
 }
 
 router.get('/.well-known/assetlinks.json', (req, res) => {
@@ -231,6 +242,33 @@ router.get('/.well-known/assetlinks.json', (req, res) => {
             sha256_cert_fingerprints: assetlinksFingerprints(),
         },
     }]);
+});
+
+router.get('/api/debug/android-app-links', (req, res) => {
+    const auth = authDeviceOrBot(req);
+    if (!auth) return res.status(403).json({ success: false, error: 'Invalid credentials' });
+
+    const fingerprints = assetlinksFingerprints();
+    return res.json({
+        success: true,
+        bug: 'android-app-links',
+        diagnostics: {
+            packageName: ANDROID_PACKAGE,
+            host: ANDROID_APP_LINK_HOST,
+            scheme: 'https',
+            pathPrefix: ANDROID_APP_LINK_PATH_PREFIX,
+            assetlinksUrl: `https://${ANDROID_APP_LINK_HOST}/.well-known/assetlinks.json`,
+            relation: 'delegate_permission/common.handle_all_urls',
+            fingerprintCount: fingerprints.length,
+            fingerprints,
+            playAppSigningCertFingerprint: PLAY_APP_SIGNING_CERT_SHA256,
+            uploadCertFingerprint: UPLOAD_CERT_SHA256,
+            hasAdditionalFingerprints: fingerprints.length > 1,
+            envVariable: 'ASSETLINKS_FINGERPRINTS',
+            expectedPlayConsoleSource: 'Google Play Console > Protect with Play > Play Store safeguards > Manage Play app signing > App signing key certificate > SHA-256 certificate fingerprint',
+        },
+        timestamp: new Date().toISOString(),
+    });
 });
 
 // ── iOS Universal Links AASA (Phase C) ───────────────────────────────────

--- a/backend/tests/jest/redirect-phase-b.test.js
+++ b/backend/tests/jest/redirect-phase-b.test.js
@@ -1,7 +1,7 @@
 /**
  * Redirect state machine Phase B — Android App Links (card_8df2a4cbd972d19d7e3d38d2).
  * Spec: docs/redirect-state-machine-spec.md §3/§4/§7.
- * Covers: /.well-known/assetlinks.json statement shape + env override, and the
+ * Covers: /.well-known/assetlinks.json statement shape + env append, and the
  * 400 ms APP_ATTEMPT interstitial branch (Android mobile UA only).
  */
 'use strict';
@@ -22,6 +22,8 @@ const DEVICES = {
 const ANDROID_UA = 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Mobile Safari/537.36';
 const IPHONE_UA = 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) Mobile/15E148 Safari/604.1';
 const FP_RE = /^([0-9A-F]{2}:){31}[0-9A-F]{2}$/;
+const PLAY_APP_SIGNING_CERT_SHA256 = 'A2:EB:6D:55:DD:DF:1C:9D:68:2E:B5:67:1C:1A:E5:8C:01:06:CB:A2:A2:93:5D:DB:CE:D2:AB:E2:E6:F7:76:DB';
+const UPLOAD_CERT_SHA256 = '0D:F0:18:33:A4:41:C4:02:74:9C:CF:4A:5A:59:F2:0C:62:00:3D:59:91:86:36:98:17:D5:89:50:47:DB:E8:10';
 
 function makeApp() {
     redirect.init({ chatPool: null, devices: DEVICES, jwtSecret: 'test-signing-secret' });
@@ -44,15 +46,60 @@ describe('GET /.well-known/assetlinks.json', () => {
         expect(stmt.target.package_name).toBe('com.hank.clawlive');
         expect(stmt.target.sha256_cert_fingerprints.length).toBeGreaterThan(0);
         for (const fp of stmt.target.sha256_cert_fingerprints) expect(fp).toMatch(FP_RE);
+        expect(stmt.target.sha256_cert_fingerprints).toContain(PLAY_APP_SIGNING_CERT_SHA256);
+        expect(stmt.target.sha256_cert_fingerprints).toContain(UPLOAD_CERT_SHA256);
     });
 
-    test('ASSETLINKS_FINGERPRINTS env overrides the committed default (Play App Signing cert path)', async () => {
-        const playCert = 'AA:' + Array(31).fill('BB').join(':');
-        process.env.ASSETLINKS_FINGERPRINTS = ` ${playCert} , ${'CC:' + Array(31).fill('DD').join(':')} `;
+    test('ASSETLINKS_FINGERPRINTS env appends rotation certs without dropping Play or upload certs', async () => {
+        const rotationCert = 'AA:' + Array(31).fill('BB').join(':');
+        process.env.ASSETLINKS_FINGERPRINTS = ` ${rotationCert} , ${'CC:' + Array(31).fill('DD').join(':')} `;
         const res = await request(makeApp()).get('/.well-known/assetlinks.json');
         const fps = res.body[0].target.sha256_cert_fingerprints;
-        expect(fps).toHaveLength(2);
-        expect(fps[0]).toBe(playCert);
+        expect(fps).toHaveLength(4);
+        expect(fps[0]).toBe(PLAY_APP_SIGNING_CERT_SHA256);
+        expect(fps).toContain(UPLOAD_CERT_SHA256);
+        expect(fps).toContain(rotationCert);
+    });
+
+    test('ignores invalid and duplicate ASSETLINKS_FINGERPRINTS entries', async () => {
+        const rotationCert = 'AA:' + Array(31).fill('BB').join(':');
+        process.env.ASSETLINKS_FINGERPRINTS = `not-a-fingerprint, ${rotationCert.toLowerCase()}, ${rotationCert}, ${UPLOAD_CERT_SHA256}`;
+        const res = await request(makeApp()).get('/.well-known/assetlinks.json');
+        const fps = res.body[0].target.sha256_cert_fingerprints;
+        expect(fps).toHaveLength(3);
+        expect(fps).toContain(rotationCert);
+        expect(fps.filter(fp => fp === UPLOAD_CERT_SHA256)).toHaveLength(1);
+    });
+});
+
+describe('GET /api/debug/android-app-links', () => {
+    afterEach(() => { delete process.env.ASSETLINKS_FINGERPRINTS; });
+
+    test('requires device authentication', async () => {
+        const res = await request(makeApp()).get('/api/debug/android-app-links');
+        expect(res.status).toBe(403);
+    });
+
+    test('returns Android App Links diagnostics without exposing secrets', async () => {
+        const playCert = 'AA:' + Array(31).fill('BB').join(':');
+        process.env.ASSETLINKS_FINGERPRINTS = playCert;
+        const res = await request(makeApp())
+            .get('/api/debug/android-app-links')
+            .query({ deviceId: DEVICE, deviceSecret: DEVICES[DEVICE].deviceSecret });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.bug).toBe('android-app-links');
+        expect(res.body.diagnostics.packageName).toBe('com.hank.clawlive');
+        expect(res.body.diagnostics.host).toBe('eclawbot.com');
+        expect(res.body.diagnostics.pathPrefix).toBe('/r/');
+        expect(res.body.diagnostics.assetlinksUrl).toBe('https://eclawbot.com/.well-known/assetlinks.json');
+        expect(res.body.diagnostics.hasAdditionalFingerprints).toBe(true);
+        expect(res.body.diagnostics.playAppSigningCertFingerprint).toBe(PLAY_APP_SIGNING_CERT_SHA256);
+        expect(res.body.diagnostics.uploadCertFingerprint).toBe(UPLOAD_CERT_SHA256);
+        expect(res.body.diagnostics.fingerprints).toContain(PLAY_APP_SIGNING_CERT_SHA256);
+        expect(res.body.diagnostics.fingerprints).toContain(playCert);
+        expect(JSON.stringify(res.body)).not.toContain(DEVICES[DEVICE].deviceSecret);
     });
 });
 


### PR DESCRIPTION
## Summary

Fixes the Android App Links verification failure for `https://eclawbot.com/r/*` by publishing the Play App Signing certificate fingerprint in `/.well-known/assetlinks.json`.

## Root Cause

Google Play Console showed the `/r/` App Link for `com.hank.clawlive.MainActivity` failing domain verification. The Android manifest path was already scoped correctly to `https://eclawbot.com/r/`, but the live Digital Asset Links file only listed the upload-key SHA-256 fingerprint. Play-distributed installs are signed with the Play App Signing key, so Play Console expects that certificate fingerprint in the asset links statement.

## Changes

- Adds the Play App Signing SHA-256 fingerprint as a default `assetlinks.json` fingerprint while retaining the upload-key fingerprint.
- Keeps `ASSETLINKS_FINGERPRINTS` as an append-only rotation path with validation and deduplication.
- Adds `GET /api/debug/android-app-links` with device/bot auth for production diagnostics without exposing secrets.
- Expands regression coverage for default fingerprints, env append behavior, duplicate/invalid filtering, and the debug endpoint.
- Registers the active Android App Links debug endpoint in `AGENTS.md`.

## Validation

- `npm test -- --runTestsByPath tests/jest/redirect-phase-b.test.js`
- `git diff --check AGENTS.md backend/redirect-router.js backend/tests/jest/redirect-phase-b.test.js`

## Deployment Note

The live `https://eclawbot.com/.well-known/assetlinks.json` will remain unchanged until this PR is merged and deployed. After deployment, recheck the Play Console Deep Links page for versionCode 100 and the live asset links response.