### PR TITLE
[codex] Add Play Integrity standard bridge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -308,6 +308,7 @@ EClaw/
 | `/api/schedules` | _(deprecated, returns 410)_ | Legacy task scheduling (removed) |
 | `/api/notifications/*` | notifications.js | Push notification management |
 | `/api/device-telemetry` | device-telemetry.js | AI debug buffer |
+| `/api/play-integrity/*` | play-integrity.js | Google Play Integrity bridge (standard requestHash + classic nonce + verifier configuration diagnostics; full verdict decode gated on service-account config) |
 | `/api/device-vars` | index.js | Environment variable management (POST merge/replace, DELETE wipe w/ `confirm:"YES_DELETE_ALL_VAULT"`, DELETE single key) |
 | `/api/device-vars/audit` | index.js | Owner-auth audit trail: every POST/DELETE leaves a row; never stores values, only key names + caller IP/UA + before/after counts |
 | `/api/logs` | index.js | Server log querying |

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -86,6 +86,7 @@ dependencies {
 
     // Google Play Billing for subscriptions
     implementation(libs.billing)
+    implementation(libs.play.integrity)
 
     // Room Database for chat history
     implementation(libs.room.runtime)

--- a/app/src/main/java/com/hank/clawlive/ClawApplication.kt
+++ b/app/src/main/java/com/hank/clawlive/ClawApplication.kt
@@ -8,6 +8,7 @@ import com.hank.clawlive.data.remote.NetworkModule
 import com.hank.clawlive.data.remote.TelemetryHelper
 import com.hank.clawlive.debug.CrashLogManager
 import com.hank.clawlive.debug.FileTimberTree
+import com.hank.clawlive.integrity.PlayIntegrityReporter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -60,7 +61,21 @@ class ClawApplication : Application() {
         // and POSTing it unconditionally fixes that class of silent failures.
         refreshAndRegisterFcmToken()
 
+        // 7. Report a Play Integrity startup signal in release builds so Play
+        // Console can monitor genuine installs without adding user-visible work.
+        reportPlayIntegrityStartup()
+
         Timber.i("ClawApplication initialized")
+    }
+
+    private fun reportPlayIntegrityStartup() {
+        if (BuildConfig.DEBUG) {
+            Timber.d("[PlayIntegrity] Skipping startup report in debug build")
+            return
+        }
+        CoroutineScope(Dispatchers.IO).launch {
+            PlayIntegrityReporter.getInstance(this@ClawApplication).reportStartup()
+        }
     }
 
     private fun refreshAndRegisterFcmToken() {

--- a/app/src/main/java/com/hank/clawlive/data/model/PlayIntegrityModels.kt
+++ b/app/src/main/java/com/hank/clawlive/data/model/PlayIntegrityModels.kt
@@ -1,0 +1,27 @@
+package com.hank.clawlive.data.model
+
+import com.google.gson.annotations.SerializedName
+
+data class PlayIntegrityNonceResponse(
+    @SerializedName("success") val success: Boolean = false,
+    @SerializedName("nonce") val nonce: String? = null,
+    @SerializedName("requestHash") val requestHash: String? = null,
+    @SerializedName("requestMode") val requestMode: String? = null,
+    @SerializedName("cloudProjectNumber") val cloudProjectNumber: String? = null,
+    @SerializedName("action") val action: String? = null,
+    @SerializedName("ttlSeconds") val ttlSeconds: Int = 0,
+    @SerializedName("packageName") val packageName: String? = null,
+    @SerializedName("verificationConfigured") val verificationConfigured: Boolean = false,
+    @SerializedName("standardRequestConfigured") val standardRequestConfigured: Boolean = false,
+    @SerializedName("error") val error: String? = null
+)
+
+data class PlayIntegrityVerdictResponse(
+    @SerializedName("success") val success: Boolean = false,
+    @SerializedName("status") val status: String? = null,
+    @SerializedName("verificationConfigured") val verificationConfigured: Boolean = false,
+    @SerializedName("packageName") val packageName: String? = null,
+    @SerializedName("action") val action: String? = null,
+    @SerializedName("requestMode") val requestMode: String? = null,
+    @SerializedName("error") val error: String? = null
+)

--- a/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
@@ -35,6 +35,12 @@ interface ClawApiService {
     @POST("api/device/register")
     suspend fun registerDevice(@Body request: RegisterRequest): RegisterResponse
 
+    @POST("api/play-integrity/nonce")
+    suspend fun createPlayIntegrityNonce(@Body body: Map<String, String>): PlayIntegrityNonceResponse
+
+    @POST("api/play-integrity/verdict")
+    suspend fun submitPlayIntegrityVerdict(@Body body: Map<String, String>): PlayIntegrityVerdictResponse
+
     // Device status - using deviceId + secret
     @POST("api/device/status")
     suspend fun getDeviceStatus(@Body request: DeviceStatusRequest): AgentStatus

--- a/app/src/main/java/com/hank/clawlive/integrity/PlayIntegrityReporter.kt
+++ b/app/src/main/java/com/hank/clawlive/integrity/PlayIntegrityReporter.kt
@@ -1,0 +1,197 @@
+package com.hank.clawlive.integrity
+
+import android.content.Context
+import com.google.android.play.core.integrity.IntegrityManagerFactory
+import com.google.android.play.core.integrity.IntegrityTokenRequest
+import com.google.android.play.core.integrity.IntegrityTokenResponse
+import com.google.android.play.core.integrity.StandardIntegrityManager
+import com.google.android.play.core.integrity.StandardIntegrityManager.PrepareIntegrityTokenRequest
+import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityToken
+import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityTokenProvider
+import com.google.android.play.core.integrity.StandardIntegrityManager.StandardIntegrityTokenRequest
+import com.hank.clawlive.data.local.DeviceManager
+import com.hank.clawlive.data.model.PlayIntegrityNonceResponse
+import com.hank.clawlive.data.remote.NetworkModule
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlinx.coroutines.suspendCancellableCoroutine
+import timber.log.Timber
+
+/**
+ * Best-effort Google Play Integrity bridge.
+ *
+ * The client requests a server-scoped nonce, asks Google Play for an integrity
+ * token, then submits the token to the backend. The backend decides whether
+ * full Google server-side decode is configured; this class never logs tokens.
+ */
+class PlayIntegrityReporter private constructor(context: Context) {
+
+    private val appContext = context.applicationContext
+    private val deviceManager = DeviceManager.getInstance(appContext)
+    private val classicIntegrityManager = IntegrityManagerFactory.create(appContext)
+    private val standardIntegrityManager: StandardIntegrityManager =
+        IntegrityManagerFactory.createStandard(appContext)
+
+    @Volatile
+    private var standardTokenProvider: StandardIntegrityTokenProvider? = null
+
+    @Volatile
+    private var preparedCloudProjectNumber: Long? = null
+
+    suspend fun reportStartup() {
+        reportAction(ACTION_STARTUP)
+    }
+
+    suspend fun reportAction(action: String) {
+        val deviceId = deviceManager.deviceId
+        val deviceSecret = deviceManager.deviceSecret
+        if (deviceId.isBlank() || deviceSecret.isBlank()) return
+
+        try {
+            val nonceResponse = NetworkModule.api.createPlayIntegrityNonce(
+                mapOf(
+                    "deviceId" to deviceId,
+                    "deviceSecret" to deviceSecret,
+                    "action" to action,
+                    "appVersion" to deviceManager.appVersion
+                )
+            )
+            val nonce = nonceResponse.nonce
+            if (!nonceResponse.success || nonce.isNullOrBlank()) {
+                Timber.tag(TAG).w("Nonce request failed for action=%s error=%s", action, nonceResponse.error)
+                return
+            }
+
+            val tokenResult = requestBestIntegrityToken(nonceResponse)
+            val verdict = NetworkModule.api.submitPlayIntegrityVerdict(
+                mutableMapOf(
+                    "deviceId" to deviceId,
+                    "deviceSecret" to deviceSecret,
+                    "action" to action,
+                    "nonce" to nonce,
+                    "requestMode" to tokenResult.requestMode,
+                    "integrityToken" to tokenResult.token,
+                    "appVersion" to deviceManager.appVersion
+                ).apply {
+                    if (tokenResult.requestHash.isNotBlank()) put("requestHash", tokenResult.requestHash)
+                }
+            )
+            Timber.tag(TAG).i(
+                "Integrity report action=%s mode=%s status=%s verificationConfigured=%s",
+                action,
+                tokenResult.requestMode,
+                verdict.status,
+                verdict.verificationConfigured
+            )
+        } catch (e: Exception) {
+            Timber.tag(TAG).w(e, "Integrity report failed for action=%s", action)
+        }
+    }
+
+    private suspend fun requestBestIntegrityToken(nonceResponse: PlayIntegrityNonceResponse): IntegrityTokenResult {
+        val nonce = nonceResponse.nonce.orEmpty()
+        val requestHash = nonceResponse.requestHash.orEmpty()
+        val cloudProjectNumber = nonceResponse.cloudProjectNumber?.toLongOrNull()
+        val shouldUseStandard =
+            nonceResponse.requestMode == MODE_STANDARD &&
+                nonceResponse.standardRequestConfigured &&
+                cloudProjectNumber != null &&
+                requestHash.isNotBlank()
+
+        if (shouldUseStandard) {
+            try {
+                val token = requestStandardIntegrityToken(cloudProjectNumber, requestHash).token()
+                return IntegrityTokenResult(
+                    token = token,
+                    requestMode = MODE_STANDARD,
+                    requestHash = requestHash
+                )
+            } catch (e: Exception) {
+                Timber.tag(TAG).w(e, "Standard integrity request failed; falling back to classic")
+            }
+        }
+
+        return IntegrityTokenResult(
+            token = requestClassicIntegrityToken(nonce).token(),
+            requestMode = MODE_CLASSIC,
+            requestHash = ""
+        )
+    }
+
+    private suspend fun requestStandardIntegrityToken(
+        cloudProjectNumber: Long,
+        requestHash: String
+    ): StandardIntegrityToken {
+        val provider = getStandardTokenProvider(cloudProjectNumber)
+        return suspendCancellableCoroutine { cont ->
+            val task = provider.request(
+                StandardIntegrityTokenRequest.builder()
+                    .setRequestHash(requestHash)
+                    .build()
+            )
+            task.addOnSuccessListener { response ->
+                if (cont.isActive) cont.resume(response)
+            }
+            task.addOnFailureListener { error ->
+                if (cont.isActive) cont.resumeWithException(error)
+            }
+        }
+    }
+
+    private suspend fun getStandardTokenProvider(cloudProjectNumber: Long): StandardIntegrityTokenProvider {
+        val current = standardTokenProvider
+        if (current != null && preparedCloudProjectNumber == cloudProjectNumber) return current
+
+        return suspendCancellableCoroutine { cont ->
+            val task = standardIntegrityManager.prepareIntegrityToken(
+                PrepareIntegrityTokenRequest.builder()
+                    .setCloudProjectNumber(cloudProjectNumber)
+                    .build()
+            )
+            task.addOnSuccessListener { provider ->
+                preparedCloudProjectNumber = cloudProjectNumber
+                standardTokenProvider = provider
+                if (cont.isActive) cont.resume(provider)
+            }
+            task.addOnFailureListener { error ->
+                if (cont.isActive) cont.resumeWithException(error)
+            }
+        }
+    }
+
+    private suspend fun requestClassicIntegrityToken(nonce: String): IntegrityTokenResponse =
+        suspendCancellableCoroutine { cont ->
+            val task = classicIntegrityManager.requestIntegrityToken(
+                IntegrityTokenRequest.builder()
+                    .setNonce(nonce)
+                    .build()
+            )
+            task.addOnSuccessListener { response ->
+                if (cont.isActive) cont.resume(response)
+            }
+            task.addOnFailureListener { error ->
+                if (cont.isActive) cont.resumeWithException(error)
+            }
+        }
+
+    companion object {
+        private const val TAG = "PlayIntegrity"
+        private const val ACTION_STARTUP = "startup"
+        private const val MODE_CLASSIC = "classic"
+        private const val MODE_STANDARD = "standard"
+
+        @Volatile
+        private var instance: PlayIntegrityReporter? = null
+
+        fun getInstance(context: Context): PlayIntegrityReporter =
+            instance ?: synchronized(this) {
+                instance ?: PlayIntegrityReporter(context.applicationContext).also { instance = it }
+            }
+    }
+
+    private data class IntegrityTokenResult(
+        val token: String,
+        val requestMode: String,
+        val requestHash: String
+    )
+}

--- a/backend/index.js
+++ b/backend/index.js
@@ -2438,7 +2438,7 @@ app.use('/api/bot', botTools.router);
 // server-side decode is gated on service-account configuration.
 // ============================================
 const playIntegrity = require('./play-integrity');
-app.use('/api/play-integrity', playIntegrity.createRouter({ devices }));
+app.use('/api/play-integrity', playIntegrity.createRouter({ devices, audit: serverLog }));
 
 // ============================================
 // COMPANION (Petdx 伙伴瀏覽器 / 社群伙伴貢獻系統)

--- a/backend/index.js
+++ b/backend/index.js
@@ -2433,6 +2433,14 @@ const botTools = require('./bot-tools');
 app.use('/api/bot', botTools.router);
 
 // ============================================
+// GOOGLE PLAY INTEGRITY — Android anti-abuse signal bridge.
+// Client can request a signed nonce and submit an Integrity token. Full Google
+// server-side decode is gated on service-account configuration.
+// ============================================
+const playIntegrity = require('./play-integrity');
+app.use('/api/play-integrity', playIntegrity.createRouter({ devices }));
+
+// ============================================
 // COMPANION (Petdx 伙伴瀏覽器 / 社群伙伴貢獻系統)
 // ============================================
 const companionModule = require('./companion-api')({

--- a/backend/play-integrity.js
+++ b/backend/play-integrity.js
@@ -1,0 +1,377 @@
+'use strict';
+
+const crypto = require('crypto');
+const express = require('express');
+const { GoogleAuth } = require('google-auth-library');
+const safeEqual = require('./safe-equal');
+
+const PACKAGE_NAME = 'com.hank.clawlive';
+const NONCE_TTL_MS = 10 * 60 * 1000;
+const VERDICT_FRESHNESS_MS = 10 * 60 * 1000;
+const ACTION_RE = /^[a-z][a-z0-9_-]{2,63}$/;
+const TOKEN_MIN_LENGTH = 50;
+const TOKEN_MAX_LENGTH = 20000;
+const PROCESS_LOCAL_NONCE_SECRET = crypto.randomBytes(32).toString('hex');
+const PLAY_INTEGRITY_SCOPE = 'https://www.googleapis.com/auth/playintegrity';
+const PLAY_INTEGRITY_DECODE_URL = `https://playintegrity.googleapis.com/v1/${PACKAGE_NAME}:decodeIntegrityToken`;
+const REQUEST_MODES = new Set(['classic', 'standard']);
+
+let cachedAuthClient = null;
+const usedNonceHashes = new Map();
+
+function base64UrlEncode(input) {
+    return Buffer.from(input).toString('base64')
+        .replace(/\+/g, '-')
+        .replace(/\//g, '_')
+        .replace(/=+$/g, '');
+}
+
+function base64UrlDecode(input) {
+    const normalized = String(input || '').replace(/-/g, '+').replace(/_/g, '/');
+    const padding = '='.repeat((4 - (normalized.length % 4)) % 4);
+    return Buffer.from(normalized + padding, 'base64').toString('utf8');
+}
+
+function signingSecret() {
+    return process.env.PLAY_INTEGRITY_NONCE_SECRET
+        || process.env.JWT_SECRET
+        || PROCESS_LOCAL_NONCE_SECRET;
+}
+
+function signPayload(payload) {
+    return crypto.createHmac('sha256', signingSecret())
+        .update(JSON.stringify(payload))
+        .digest('hex')
+        .slice(0, 32);
+}
+
+function makeNonce({ deviceId, action, now = Date.now() }) {
+    const payload = {
+        v: 1,
+        d: String(deviceId),
+        a: String(action),
+        t: now,
+        r: crypto.randomBytes(16).toString('hex'),
+    };
+    payload.s = signPayload(payload);
+    return base64UrlEncode(JSON.stringify(payload));
+}
+
+function makeRequestHash(nonce) {
+    return base64UrlEncode(crypto.createHash('sha256').update(String(nonce)).digest());
+}
+
+function verifyNonce(nonce, { deviceId, action, now = Date.now() } = {}) {
+    try {
+        const payload = JSON.parse(base64UrlDecode(nonce));
+        const sig = payload.s;
+        const unsigned = { ...payload };
+        delete unsigned.s;
+        if (!sig || !safeEqual(sig, signPayload(unsigned))) return { ok: false, error: 'bad_signature' };
+        if (payload.v !== 1) return { ok: false, error: 'bad_version' };
+        if (deviceId && payload.d !== deviceId) return { ok: false, error: 'device_mismatch' };
+        if (action && payload.a !== action) return { ok: false, error: 'action_mismatch' };
+        if (!Number.isFinite(payload.t) || now - payload.t > NONCE_TTL_MS || payload.t - now > 60_000) {
+            return { ok: false, error: 'expired' };
+        }
+        return { ok: true, payload };
+    } catch (_err) {
+        return { ok: false, error: 'malformed' };
+    }
+}
+
+function purgeUsedNonces(now = Date.now()) {
+    for (const [hash, expiresAt] of usedNonceHashes.entries()) {
+        if (expiresAt <= now) usedNonceHashes.delete(hash);
+    }
+}
+
+function claimNonce(nonce, now = Date.now()) {
+    purgeUsedNonces(now);
+    const hash = crypto.createHash('sha256').update(String(nonce)).digest('hex');
+    if (usedNonceHashes.has(hash)) return false;
+    usedNonceHashes.set(hash, now + NONCE_TTL_MS);
+    return true;
+}
+
+function verificationConfigured() {
+    return Boolean(
+        process.env.PLAY_INTEGRITY_SERVICE_ACCOUNT_JSON
+        || process.env.GOOGLE_APPLICATION_CREDENTIALS
+        || process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON
+    );
+}
+
+function standardIntegrityCloudProjectNumber() {
+    const raw = String(process.env.PLAY_INTEGRITY_CLOUD_PROJECT_NUMBER || '').trim();
+    if (!/^[1-9][0-9]{4,20}$/.test(raw)) return null;
+    const parsed = Number(raw);
+    return Number.isSafeInteger(parsed) ? raw : null;
+}
+
+function serviceAccountCredentials() {
+    const raw = process.env.PLAY_INTEGRITY_SERVICE_ACCOUNT_JSON
+        || process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON
+        || '';
+    if (!raw) return null;
+    try {
+        return JSON.parse(raw);
+    } catch (err) {
+        err.code = 'BAD_SERVICE_ACCOUNT_JSON';
+        throw err;
+    }
+}
+
+async function getAccessToken() {
+    if (!cachedAuthClient) {
+        const credentials = serviceAccountCredentials();
+        const options = { scopes: [PLAY_INTEGRITY_SCOPE] };
+        if (credentials) options.credentials = credentials;
+        if (!credentials && process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+            options.keyFile = process.env.GOOGLE_APPLICATION_CREDENTIALS;
+        }
+        cachedAuthClient = await new GoogleAuth(options).getClient();
+    }
+    const token = await cachedAuthClient.getAccessToken();
+    return typeof token === 'string' ? token : token?.token;
+}
+
+async function decodeIntegrityTokenWithGoogle(integrityToken) {
+    const accessToken = await getAccessToken();
+    if (!accessToken) {
+        const err = new Error('missing Google access token');
+        err.code = 'MISSING_ACCESS_TOKEN';
+        throw err;
+    }
+    const response = await fetch(PLAY_INTEGRITY_DECODE_URL, {
+        method: 'POST',
+        headers: {
+            Authorization: `Bearer ${accessToken}`,
+            'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ integrity_token: integrityToken }),
+    });
+    if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        const err = new Error(`Play Integrity decode failed: HTTP ${response.status}`);
+        err.code = 'GOOGLE_DECODE_FAILED';
+        err.status = response.status;
+        err.body = body.slice(0, 300);
+        throw err;
+    }
+    return response.json();
+}
+
+function extractPayload(decoded) {
+    return decoded?.tokenPayloadExternal || decoded?.payload || decoded || {};
+}
+
+function evaluatePayload(decoded, {
+    nonce,
+    requestHash,
+    requestMode = 'classic',
+    now = Date.now(),
+}) {
+    const payload = extractPayload(decoded);
+    const requestDetails = payload.requestDetails || {};
+    const requestPackageName = requestDetails.requestPackageName;
+    const tokenNonce = requestDetails.nonce;
+    const tokenRequestHash = requestDetails.requestHash;
+    const timestampMillis = Number(requestDetails.timestampMillis);
+    const appIntegrity = payload.appIntegrity || {};
+    const deviceIntegrity = payload.deviceIntegrity || {};
+    const accountDetails = payload.accountDetails || {};
+    const environmentDetails = payload.environmentDetails || {};
+    const recentDeviceActivity = payload.recentDeviceActivity || null;
+    const appRecognitionVerdict = appIntegrity.appRecognitionVerdict || 'UNKNOWN';
+    const deviceRecognitionVerdict = Array.isArray(deviceIntegrity.deviceRecognitionVerdict)
+        ? deviceIntegrity.deviceRecognitionVerdict
+        : [];
+    const nonceMatches = requestMode === 'classic' && tokenNonce === nonce;
+    const requestHashMatches = requestMode === 'standard' && tokenRequestHash === requestHash;
+
+    const checks = {
+        packageNameMatches: requestPackageName === PACKAGE_NAME,
+        nonceMatches,
+        requestHashMatches,
+        bindingMatches: requestMode === 'standard' ? requestHashMatches : nonceMatches,
+        fresh: Number.isFinite(timestampMillis) && Math.abs(now - timestampMillis) <= VERDICT_FRESHNESS_MS,
+        appRecognized: appRecognitionVerdict === 'PLAY_RECOGNIZED',
+        deviceMeetsIntegrity: deviceRecognitionVerdict.includes('MEETS_DEVICE_INTEGRITY'),
+    };
+    const verified = checks.packageNameMatches
+        && checks.bindingMatches
+        && checks.fresh
+        && checks.appRecognized
+        && checks.deviceMeetsIntegrity;
+    return {
+        verified,
+        requestMode,
+        checks,
+        verdict: {
+            appRecognitionVerdict,
+            deviceRecognitionVerdict,
+            appLicensingVerdict: accountDetails.appLicensingVerdict || null,
+            appAccessRiskVerdict: environmentDetails.appAccessRiskVerdict || null,
+            playProtectVerdict: environmentDetails.playProtectVerdict || null,
+            recentDeviceActivity,
+            packageName: appIntegrity.packageName || null,
+            versionCode: appIntegrity.versionCode || null,
+        },
+    };
+}
+
+function authenticateDevice(devices, req) {
+    const src = Object.assign({}, req.query || {}, req.body || {});
+    const deviceId = src.deviceId;
+    const deviceSecret = src.deviceSecret;
+    if (!deviceId || !deviceSecret || !devices || !devices[deviceId]) return null;
+    const device = devices[deviceId];
+    if (!device.deviceSecret || !safeEqual(device.deviceSecret, deviceSecret)) return null;
+    return { deviceId };
+}
+
+function createRouter({ devices, decodeIntegrityToken = decodeIntegrityTokenWithGoogle } = {}) {
+    const router = express.Router();
+    router.use(express.json({ limit: '32kb' }));
+
+    router.post('/nonce', (req, res) => {
+        const auth = authenticateDevice(devices, req);
+        if (!auth) return res.status(403).json({ success: false, error: 'Invalid credentials' });
+
+        const action = String(req.body?.action || 'startup');
+        if (!ACTION_RE.test(action)) {
+            return res.status(400).json({ success: false, error: 'invalid_action' });
+        }
+
+        const nonce = makeNonce({ deviceId: auth.deviceId, action });
+        const cloudProjectNumber = standardIntegrityCloudProjectNumber();
+        const requestMode = cloudProjectNumber ? 'standard' : 'classic';
+        return res.json({
+            success: true,
+            nonce,
+            requestHash: makeRequestHash(nonce),
+            requestMode,
+            cloudProjectNumber,
+            action,
+            ttlSeconds: Math.floor(NONCE_TTL_MS / 1000),
+            packageName: PACKAGE_NAME,
+            verificationConfigured: verificationConfigured(),
+            standardRequestConfigured: Boolean(cloudProjectNumber),
+        });
+    });
+
+    router.post('/verdict', async (req, res) => {
+        const auth = authenticateDevice(devices, req);
+        if (!auth) return res.status(403).json({ success: false, error: 'Invalid credentials' });
+
+        const action = String(req.body?.action || 'startup');
+        const nonce = String(req.body?.nonce || '');
+        const requestHash = String(req.body?.requestHash || '');
+        const requestMode = String(req.body?.requestMode || (requestHash ? 'standard' : 'classic'));
+        const integrityToken = String(req.body?.integrityToken || '');
+        if (!ACTION_RE.test(action)) {
+            return res.status(400).json({ success: false, error: 'invalid_action' });
+        }
+        if (!REQUEST_MODES.has(requestMode)) {
+            return res.status(400).json({ success: false, error: 'invalid_request_mode' });
+        }
+        if (integrityToken.length < TOKEN_MIN_LENGTH || integrityToken.length > TOKEN_MAX_LENGTH) {
+            return res.status(400).json({ success: false, error: 'invalid_integrity_token' });
+        }
+
+        const nonceCheck = verifyNonce(nonce, { deviceId: auth.deviceId, action });
+        if (!nonceCheck.ok) {
+            return res.status(400).json({ success: false, error: 'invalid_nonce', reason: nonceCheck.error });
+        }
+        if (requestMode === 'standard' && requestHash !== makeRequestHash(nonce)) {
+            return res.status(400).json({ success: false, error: 'invalid_request_hash' });
+        }
+        if (!claimNonce(nonce)) {
+            return res.status(409).json({ success: false, error: 'nonce_replay' });
+        }
+
+        if (verificationConfigured()) {
+            try {
+                const decoded = await decodeIntegrityToken(integrityToken);
+                const evaluation = evaluatePayload(decoded, { nonce, requestHash, requestMode });
+                return res.json({
+                    success: true,
+                    status: evaluation.verified ? 'verified' : 'verification_failed',
+                    verificationConfigured: true,
+                    packageName: PACKAGE_NAME,
+                    action,
+                    requestMode,
+                    integrity: evaluation,
+                });
+            } catch (err) {
+                console.warn('[PlayIntegrity] decode failed:', err.code || err.message, err.status || '');
+                return res.status(502).json({
+                    success: false,
+                    error: 'play_integrity_decode_failed',
+                    code: err.code || 'DECODE_FAILED',
+                    verificationConfigured: true,
+                });
+            }
+        }
+
+        return res.json({
+            success: true,
+            status: 'received_unverified',
+            verificationConfigured: false,
+            packageName: PACKAGE_NAME,
+            action,
+            requestMode,
+            // Intentionally do not echo or log the token. Server-side Google
+            // decode/verify is only active once service credentials are wired.
+        });
+    });
+
+    router.get('/debug', (req, res) => {
+        const auth = authenticateDevice(devices, req);
+        if (!auth) return res.status(403).json({ success: false, error: 'Invalid credentials' });
+        return res.json({
+            success: true,
+            feature: 'play-integrity',
+            diagnostics: {
+                packageName: PACKAGE_NAME,
+                nonceTtlSeconds: Math.floor(NONCE_TTL_MS / 1000),
+                verificationConfigured: verificationConfigured(),
+                standardRequestConfigured: Boolean(standardIntegrityCloudProjectNumber()),
+                cloudProjectNumberConfigured: Boolean(standardIntegrityCloudProjectNumber()),
+                verifierCredentialSources: {
+                    playIntegrityServiceAccountJson: Boolean(process.env.PLAY_INTEGRITY_SERVICE_ACCOUNT_JSON),
+                    googleApplicationCredentials: Boolean(process.env.GOOGLE_APPLICATION_CREDENTIALS),
+                    googleApplicationCredentialsJson: Boolean(process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON),
+                },
+                requestModes: ['standard', 'classic'],
+                actions: ['startup', 'billing_topup', 'borrow_subscription'],
+            },
+            timestamp: new Date().toISOString(),
+        });
+    });
+
+    return router;
+}
+
+module.exports = {
+    createRouter,
+    _internal: {
+        makeNonce,
+        makeRequestHash,
+        verifyNonce,
+        claimNonce,
+        purgeUsedNonces,
+        evaluatePayload,
+        verificationConfigured,
+        standardIntegrityCloudProjectNumber,
+        decodeIntegrityTokenWithGoogle,
+        _resetForTests: () => {
+            usedNonceHashes.clear();
+            cachedAuthClient = null;
+        },
+        PACKAGE_NAME,
+        NONCE_TTL_MS,
+        VERDICT_FRESHNESS_MS,
+    },
+};

--- a/backend/play-integrity.js
+++ b/backend/play-integrity.js
@@ -15,9 +15,11 @@ const PROCESS_LOCAL_NONCE_SECRET = crypto.randomBytes(32).toString('hex');
 const PLAY_INTEGRITY_SCOPE = 'https://www.googleapis.com/auth/playintegrity';
 const PLAY_INTEGRITY_DECODE_URL = `https://playintegrity.googleapis.com/v1/${PACKAGE_NAME}:decodeIntegrityToken`;
 const REQUEST_MODES = new Set(['classic', 'standard']);
+const LAST_VERDICT_DEVICE_LIMIT = 500;
 
 let cachedAuthClient = null;
 const usedNonceHashes = new Map();
+const lastVerdictSummariesByDevice = new Map();
 
 function base64UrlEncode(input) {
     return Buffer.from(input).toString('base64')
@@ -166,6 +168,96 @@ function extractPayload(decoded) {
     return decoded?.tokenPayloadExternal || decoded?.payload || decoded || {};
 }
 
+function appAccessRiskApps(appAccessRiskVerdict) {
+    return Array.isArray(appAccessRiskVerdict?.appsDetected)
+        ? appAccessRiskVerdict.appsDetected
+        : [];
+}
+
+function summarizeConsoleSignals(verdict) {
+    const appAccessApps = appAccessRiskApps(verdict.appAccessRiskVerdict);
+    const deviceLabels = Array.isArray(verdict.deviceRecognitionVerdict)
+        ? verdict.deviceRecognitionVerdict
+        : [];
+    const recentDeviceActivityLevel = verdict.recentDeviceActivity?.deviceActivityLevel || null;
+    return {
+        playLicensing: {
+            observed: Boolean(verdict.appLicensingVerdict),
+            value: verdict.appLicensingVerdict || null,
+        },
+        appIntegrity: {
+            observed: Boolean(verdict.appRecognitionVerdict && verdict.appRecognitionVerdict !== 'UNKNOWN'),
+            value: verdict.appRecognitionVerdict || null,
+            packageName: verdict.packageName || null,
+            versionCode: verdict.versionCode || null,
+        },
+        deviceIntegrity: {
+            observed: deviceLabels.length > 0,
+            values: deviceLabels,
+        },
+        virtualIntegrity: {
+            observed: deviceLabels.includes('MEETS_VIRTUAL_INTEGRITY'),
+            values: deviceLabels.filter(v => v === 'MEETS_VIRTUAL_INTEGRITY'),
+        },
+        recentDeviceActivity: {
+            observed: Boolean(verdict.recentDeviceActivity),
+            value: recentDeviceActivityLevel,
+        },
+        playProtect: {
+            observed: Boolean(verdict.playProtectVerdict),
+            value: verdict.playProtectVerdict || null,
+        },
+        appAccessRisk: {
+            observed: Boolean(verdict.appAccessRiskVerdict),
+            values: appAccessApps,
+            hasCaptureOrControlRisk: appAccessApps.some(v => /CAPTURING|CONTROLLING|OVERLAYS/.test(v)),
+        },
+    };
+}
+
+function rememberVerdictSummary(deviceId, summary, audit = () => {}) {
+    const safeSummary = {
+        checkedAt: new Date().toISOString(),
+        packageName: PACKAGE_NAME,
+        action: summary.action,
+        status: summary.status,
+        requestMode: summary.requestMode,
+        verificationConfigured: Boolean(summary.verificationConfigured),
+        checks: summary.checks || null,
+        consoleSignals: summary.verdict ? summarizeConsoleSignals(summary.verdict) : null,
+        decodeErrorCode: summary.decodeErrorCode || null,
+    };
+    lastVerdictSummariesByDevice.delete(deviceId);
+    lastVerdictSummariesByDevice.set(deviceId, safeSummary);
+    while (lastVerdictSummariesByDevice.size > LAST_VERDICT_DEVICE_LIMIT) {
+        const oldest = lastVerdictSummariesByDevice.keys().next().value;
+        lastVerdictSummariesByDevice.delete(oldest);
+    }
+    try {
+        audit(
+            safeSummary.status === 'verified' ? 'info' : 'warn',
+            'play_integrity',
+            `Play Integrity verdict ${safeSummary.status} action=${safeSummary.action}`,
+            {
+                deviceId,
+                action: 'play_integrity_verdict',
+                resource: PACKAGE_NAME,
+                result: safeSummary.status,
+                metadata: {
+                    requestMode: safeSummary.requestMode,
+                    verificationConfigured: safeSummary.verificationConfigured,
+                    checks: safeSummary.checks,
+                    consoleSignals: safeSummary.consoleSignals,
+                    decodeErrorCode: safeSummary.decodeErrorCode,
+                },
+            }
+        );
+    } catch (_err) {
+        // Audit logging must never affect the user-facing verdict flow.
+    }
+    return safeSummary;
+}
+
 function evaluatePayload(decoded, {
     nonce,
     requestHash,
@@ -182,7 +274,7 @@ function evaluatePayload(decoded, {
     const deviceIntegrity = payload.deviceIntegrity || {};
     const accountDetails = payload.accountDetails || {};
     const environmentDetails = payload.environmentDetails || {};
-    const recentDeviceActivity = payload.recentDeviceActivity || null;
+    const recentDeviceActivity = deviceIntegrity.recentDeviceActivity || payload.recentDeviceActivity || null;
     const appRecognitionVerdict = appIntegrity.appRecognitionVerdict || 'UNKNOWN';
     const deviceRecognitionVerdict = Array.isArray(deviceIntegrity.deviceRecognitionVerdict)
         ? deviceIntegrity.deviceRecognitionVerdict
@@ -231,7 +323,7 @@ function authenticateDevice(devices, req) {
     return { deviceId };
 }
 
-function createRouter({ devices, decodeIntegrityToken = decodeIntegrityTokenWithGoogle } = {}) {
+function createRouter({ devices, decodeIntegrityToken = decodeIntegrityTokenWithGoogle, audit = () => {} } = {}) {
     const router = express.Router();
     router.use(express.json({ limit: '32kb' }));
 
@@ -295,9 +387,18 @@ function createRouter({ devices, decodeIntegrityToken = decodeIntegrityTokenWith
             try {
                 const decoded = await decodeIntegrityToken(integrityToken);
                 const evaluation = evaluatePayload(decoded, { nonce, requestHash, requestMode });
+                const status = evaluation.verified ? 'verified' : 'verification_failed';
+                rememberVerdictSummary(auth.deviceId, {
+                    action,
+                    status,
+                    requestMode,
+                    verificationConfigured: true,
+                    checks: evaluation.checks,
+                    verdict: evaluation.verdict,
+                }, audit);
                 return res.json({
                     success: true,
-                    status: evaluation.verified ? 'verified' : 'verification_failed',
+                    status,
                     verificationConfigured: true,
                     packageName: PACKAGE_NAME,
                     action,
@@ -306,6 +407,13 @@ function createRouter({ devices, decodeIntegrityToken = decodeIntegrityTokenWith
                 });
             } catch (err) {
                 console.warn('[PlayIntegrity] decode failed:', err.code || err.message, err.status || '');
+                rememberVerdictSummary(auth.deviceId, {
+                    action,
+                    status: 'decode_failed',
+                    requestMode,
+                    verificationConfigured: true,
+                    decodeErrorCode: err.code || 'DECODE_FAILED',
+                }, audit);
                 return res.status(502).json({
                     success: false,
                     error: 'play_integrity_decode_failed',
@@ -315,6 +423,12 @@ function createRouter({ devices, decodeIntegrityToken = decodeIntegrityTokenWith
             }
         }
 
+        rememberVerdictSummary(auth.deviceId, {
+            action,
+            status: 'received_unverified',
+            requestMode,
+            verificationConfigured: false,
+        }, audit);
         return res.json({
             success: true,
             status: 'received_unverified',
@@ -346,6 +460,7 @@ function createRouter({ devices, decodeIntegrityToken = decodeIntegrityTokenWith
                 },
                 requestModes: ['standard', 'classic'],
                 actions: ['startup', 'billing_topup', 'borrow_subscription'],
+                lastVerdict: lastVerdictSummariesByDevice.get(auth.deviceId) || null,
             },
             timestamp: new Date().toISOString(),
         });
@@ -366,8 +481,11 @@ module.exports = {
         verificationConfigured,
         standardIntegrityCloudProjectNumber,
         decodeIntegrityTokenWithGoogle,
+        rememberVerdictSummary,
+        summarizeConsoleSignals,
         _resetForTests: () => {
             usedNonceHashes.clear();
+            lastVerdictSummariesByDevice.clear();
             cachedAuthClient = null;
         },
         PACKAGE_NAME,

--- a/backend/tests/jest/play-integrity.test.js
+++ b/backend/tests/jest/play-integrity.test.js
@@ -1,0 +1,374 @@
+'use strict';
+
+const express = require('express');
+const request = require('supertest');
+const playIntegrity = require('../../play-integrity');
+
+const DEVICE_ID = 'device-play-integrity';
+const DEVICE_SECRET = 'secret-play-integrity';
+const devices = {
+    [DEVICE_ID]: { deviceSecret: DEVICE_SECRET, entities: {} },
+};
+
+function makeApp(options = {}) {
+    const app = express();
+    app.use('/api/play-integrity', playIntegrity.createRouter({ devices, ...options }));
+    return app;
+}
+
+describe('Play Integrity bridge', () => {
+    afterEach(() => {
+        delete process.env.PLAY_INTEGRITY_SERVICE_ACCOUNT_JSON;
+        delete process.env.GOOGLE_APPLICATION_CREDENTIALS;
+        delete process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON;
+        delete process.env.PLAY_INTEGRITY_CLOUD_PROJECT_NUMBER;
+        playIntegrity._internal._resetForTests();
+        jest.restoreAllMocks();
+    });
+
+    test('nonce endpoint requires device auth', async () => {
+        const res = await request(makeApp())
+            .post('/api/play-integrity/nonce')
+            .send({ deviceId: DEVICE_ID, action: 'startup' });
+        expect(res.status).toBe(403);
+    });
+
+    test('issues a signed nonce scoped to device and action', async () => {
+        const res = await request(makeApp())
+            .post('/api/play-integrity/nonce')
+            .send({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET, action: 'startup' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.packageName).toBe('com.hank.clawlive');
+        expect(res.body.verificationConfigured).toBe(false);
+        expect(res.body.requestMode).toBe('classic');
+        expect(res.body.requestHash).toBe(playIntegrity._internal.makeRequestHash(res.body.nonce));
+
+        const check = playIntegrity._internal.verifyNonce(res.body.nonce, {
+            deviceId: DEVICE_ID,
+            action: 'startup',
+        });
+        expect(check.ok).toBe(true);
+        expect(check.payload.d).toBe(DEVICE_ID);
+        expect(check.payload.a).toBe('startup');
+    });
+
+    test('nonce endpoint switches to standard challenge when Cloud project number is configured', async () => {
+        process.env.PLAY_INTEGRITY_CLOUD_PROJECT_NUMBER = '123456789012';
+        const res = await request(makeApp())
+            .post('/api/play-integrity/nonce')
+            .send({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET, action: 'startup' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.requestMode).toBe('standard');
+        expect(res.body.cloudProjectNumber).toBe('123456789012');
+        expect(res.body.standardRequestConfigured).toBe(true);
+        expect(res.body.requestHash).toBe(playIntegrity._internal.makeRequestHash(res.body.nonce));
+    });
+
+    test('rejects tampered or mismatched nonces', async () => {
+        const nonce = playIntegrity._internal.makeNonce({ deviceId: DEVICE_ID, action: 'startup' });
+        expect(playIntegrity._internal.verifyNonce(nonce + 'x', { deviceId: DEVICE_ID, action: 'startup' }).ok).toBe(false);
+        expect(playIntegrity._internal.verifyNonce(nonce, { deviceId: DEVICE_ID, action: 'billing_topup' })).toEqual({
+            ok: false,
+            error: 'action_mismatch',
+        });
+    });
+
+    test('verdict endpoint accepts token shape but does not claim verification without credentials', async () => {
+        const nonce = playIntegrity._internal.makeNonce({ deviceId: DEVICE_ID, action: 'startup' });
+        const token = 'a'.repeat(100);
+        const res = await request(makeApp())
+            .post('/api/play-integrity/verdict')
+            .send({
+                deviceId: DEVICE_ID,
+                deviceSecret: DEVICE_SECRET,
+                action: 'startup',
+                nonce,
+                integrityToken: token,
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.status).toBe('received_unverified');
+        expect(res.body.verificationConfigured).toBe(false);
+        expect(res.body.requestMode).toBe('classic');
+        expect(JSON.stringify(res.body)).not.toContain(token);
+    });
+
+    test('verdict endpoint accepts standard requestHash challenge without credentials', async () => {
+        const nonce = playIntegrity._internal.makeNonce({ deviceId: DEVICE_ID, action: 'startup' });
+        const requestHash = playIntegrity._internal.makeRequestHash(nonce);
+        const token = 's'.repeat(100);
+        const res = await request(makeApp())
+            .post('/api/play-integrity/verdict')
+            .send({
+                deviceId: DEVICE_ID,
+                deviceSecret: DEVICE_SECRET,
+                action: 'startup',
+                nonce,
+                requestHash,
+                requestMode: 'standard',
+                integrityToken: token,
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body.status).toBe('received_unverified');
+        expect(res.body.requestMode).toBe('standard');
+        expect(JSON.stringify(res.body)).not.toContain(token);
+    });
+
+    test('verdict endpoint rejects a mismatched standard requestHash before claiming nonce', async () => {
+        const nonce = playIntegrity._internal.makeNonce({ deviceId: DEVICE_ID, action: 'startup' });
+        const body = {
+            deviceId: DEVICE_ID,
+            deviceSecret: DEVICE_SECRET,
+            action: 'startup',
+            nonce,
+            requestHash: 'wrong-hash',
+            requestMode: 'standard',
+            integrityToken: 'h'.repeat(100),
+        };
+
+        const first = await request(makeApp())
+            .post('/api/play-integrity/verdict')
+            .send(body);
+        const second = await request(makeApp())
+            .post('/api/play-integrity/verdict')
+            .send({ ...body, requestHash: playIntegrity._internal.makeRequestHash(nonce) });
+
+        expect(first.status).toBe(400);
+        expect(first.body.error).toBe('invalid_request_hash');
+        expect(second.status).toBe(200);
+        expect(second.body.status).toBe('received_unverified');
+    });
+
+    test('verdict endpoint rejects nonce replay', async () => {
+        const nonce = playIntegrity._internal.makeNonce({ deviceId: DEVICE_ID, action: 'startup' });
+        const body = {
+            deviceId: DEVICE_ID,
+            deviceSecret: DEVICE_SECRET,
+            action: 'startup',
+            nonce,
+            integrityToken: 'r'.repeat(100),
+        };
+
+        const first = await request(makeApp())
+            .post('/api/play-integrity/verdict')
+            .send(body);
+        const replay = await request(makeApp())
+            .post('/api/play-integrity/verdict')
+            .send(body);
+
+        expect(first.status).toBe(200);
+        expect(first.body.status).toBe('received_unverified');
+        expect(replay.status).toBe(409);
+        expect(replay.body.error).toBe('nonce_replay');
+    });
+
+    test('debug endpoint reports verifier configuration without exposing secrets', async () => {
+        process.env.PLAY_INTEGRITY_SERVICE_ACCOUNT_JSON = '{"type":"service_account"}';
+        const res = await request(makeApp())
+            .get('/api/play-integrity/debug')
+            .query({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET });
+
+        expect(res.status).toBe(200);
+        expect(res.body.success).toBe(true);
+        expect(res.body.diagnostics.verificationConfigured).toBe(true);
+        expect(res.body.diagnostics.standardRequestConfigured).toBe(false);
+        expect(res.body.diagnostics.verifierCredentialSources.playIntegrityServiceAccountJson).toBe(true);
+        expect(res.body.diagnostics.requestModes).toEqual(['standard', 'classic']);
+        expect(JSON.stringify(res.body)).not.toContain('service_account');
+        expect(JSON.stringify(res.body)).not.toContain(DEVICE_SECRET);
+    });
+
+    test('debug endpoint reports standard request configuration without exposing project value', async () => {
+        process.env.PLAY_INTEGRITY_CLOUD_PROJECT_NUMBER = '123456789012';
+        const res = await request(makeApp())
+            .get('/api/play-integrity/debug')
+            .query({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET });
+
+        expect(res.status).toBe(200);
+        expect(res.body.diagnostics.standardRequestConfigured).toBe(true);
+        expect(res.body.diagnostics.cloudProjectNumberConfigured).toBe(true);
+        expect(JSON.stringify(res.body)).not.toContain('123456789012');
+    });
+
+    test('verdict endpoint decodes and evaluates Google payload when credentials are configured', async () => {
+        process.env.PLAY_INTEGRITY_SERVICE_ACCOUNT_JSON = '{"type":"service_account"}';
+        const nonce = playIntegrity._internal.makeNonce({ deviceId: DEVICE_ID, action: 'startup' });
+        const token = 'b'.repeat(100);
+        const decodeIntegrityToken = jest.fn(async () => ({
+            tokenPayloadExternal: {
+                requestDetails: {
+                    requestPackageName: 'com.hank.clawlive',
+                    nonce,
+                    timestampMillis: String(Date.now()),
+                },
+                appIntegrity: {
+                    appRecognitionVerdict: 'PLAY_RECOGNIZED',
+                    packageName: 'com.hank.clawlive',
+                    versionCode: '100',
+                },
+                deviceIntegrity: {
+                    deviceRecognitionVerdict: ['MEETS_DEVICE_INTEGRITY'],
+                },
+                accountDetails: {
+                    appLicensingVerdict: 'LICENSED',
+                },
+            },
+        }));
+
+        const res = await request(makeApp({ decodeIntegrityToken }))
+            .post('/api/play-integrity/verdict')
+            .send({
+                deviceId: DEVICE_ID,
+                deviceSecret: DEVICE_SECRET,
+                action: 'startup',
+                nonce,
+                integrityToken: token,
+            });
+
+        expect(res.status).toBe(200);
+        expect(decodeIntegrityToken).toHaveBeenCalledWith(token);
+        expect(res.body.status).toBe('verified');
+        expect(res.body.integrity.verified).toBe(true);
+        expect(res.body.integrity.checks).toEqual({
+            packageNameMatches: true,
+            nonceMatches: true,
+            requestHashMatches: false,
+            bindingMatches: true,
+            fresh: true,
+            appRecognized: true,
+            deviceMeetsIntegrity: true,
+        });
+        expect(res.body.integrity.verdict.appRecognitionVerdict).toBe('PLAY_RECOGNIZED');
+        expect(JSON.stringify(res.body)).not.toContain(token);
+    });
+
+    test('verdict endpoint decodes and evaluates standard requestHash payload', async () => {
+        process.env.PLAY_INTEGRITY_SERVICE_ACCOUNT_JSON = '{"type":"service_account"}';
+        const nonce = playIntegrity._internal.makeNonce({ deviceId: DEVICE_ID, action: 'startup' });
+        const requestHash = playIntegrity._internal.makeRequestHash(nonce);
+        const token = 'e'.repeat(100);
+        const decodeIntegrityToken = jest.fn(async () => ({
+            tokenPayloadExternal: {
+                requestDetails: {
+                    requestPackageName: 'com.hank.clawlive',
+                    requestHash,
+                    timestampMillis: String(Date.now()),
+                },
+                appIntegrity: {
+                    appRecognitionVerdict: 'PLAY_RECOGNIZED',
+                    packageName: 'com.hank.clawlive',
+                    versionCode: '100',
+                },
+                deviceIntegrity: {
+                    deviceRecognitionVerdict: ['MEETS_DEVICE_INTEGRITY'],
+                },
+                accountDetails: {
+                    appLicensingVerdict: 'LICENSED',
+                },
+                environmentDetails: {
+                    appAccessRiskVerdict: { appsDetected: ['KNOWN_INSTALLED'] },
+                    playProtectVerdict: 'NO_ISSUES',
+                },
+                recentDeviceActivity: {
+                    deviceActivityLevel: 'LEVEL_1',
+                },
+            },
+        }));
+
+        const res = await request(makeApp({ decodeIntegrityToken }))
+            .post('/api/play-integrity/verdict')
+            .send({
+                deviceId: DEVICE_ID,
+                deviceSecret: DEVICE_SECRET,
+                action: 'startup',
+                nonce,
+                requestHash,
+                requestMode: 'standard',
+                integrityToken: token,
+            });
+
+        expect(res.status).toBe(200);
+        expect(decodeIntegrityToken).toHaveBeenCalledWith(token);
+        expect(res.body.status).toBe('verified');
+        expect(res.body.requestMode).toBe('standard');
+        expect(res.body.integrity.requestMode).toBe('standard');
+        expect(res.body.integrity.checks).toEqual({
+            packageNameMatches: true,
+            nonceMatches: false,
+            requestHashMatches: true,
+            bindingMatches: true,
+            fresh: true,
+            appRecognized: true,
+            deviceMeetsIntegrity: true,
+        });
+        expect(res.body.integrity.verdict.appAccessRiskVerdict).toEqual({ appsDetected: ['KNOWN_INSTALLED'] });
+        expect(res.body.integrity.verdict.playProtectVerdict).toBe('NO_ISSUES');
+        expect(res.body.integrity.verdict.recentDeviceActivity).toEqual({ deviceActivityLevel: 'LEVEL_1' });
+        expect(JSON.stringify(res.body)).not.toContain(token);
+    });
+
+    test('verdict endpoint surfaces failed integrity checks without accepting the action', async () => {
+        process.env.PLAY_INTEGRITY_SERVICE_ACCOUNT_JSON = '{"type":"service_account"}';
+        const nonce = playIntegrity._internal.makeNonce({ deviceId: DEVICE_ID, action: 'startup' });
+        const decodeIntegrityToken = jest.fn(async () => ({
+            tokenPayloadExternal: {
+                requestDetails: {
+                    requestPackageName: 'com.hank.clawlive',
+                    nonce: 'wrong-nonce',
+                    timestampMillis: String(Date.now()),
+                },
+                appIntegrity: { appRecognitionVerdict: 'UNRECOGNIZED_VERSION' },
+                deviceIntegrity: { deviceRecognitionVerdict: [] },
+            },
+        }));
+
+        const res = await request(makeApp({ decodeIntegrityToken }))
+            .post('/api/play-integrity/verdict')
+            .send({
+                deviceId: DEVICE_ID,
+                deviceSecret: DEVICE_SECRET,
+                action: 'startup',
+                nonce,
+                integrityToken: 'c'.repeat(100),
+            });
+
+        expect(res.status).toBe(200);
+        expect(res.body.status).toBe('verification_failed');
+        expect(res.body.integrity.verified).toBe(false);
+        expect(res.body.integrity.checks.nonceMatches).toBe(false);
+        expect(res.body.integrity.checks.bindingMatches).toBe(false);
+        expect(res.body.integrity.checks.appRecognized).toBe(false);
+        expect(res.body.integrity.checks.deviceMeetsIntegrity).toBe(false);
+    });
+
+    test('verdict endpoint returns 502 when Google decode fails after credentials are configured', async () => {
+        jest.spyOn(console, 'warn').mockImplementation(() => {});
+        process.env.PLAY_INTEGRITY_SERVICE_ACCOUNT_JSON = '{"type":"service_account"}';
+        const nonce = playIntegrity._internal.makeNonce({ deviceId: DEVICE_ID, action: 'startup' });
+        const decodeIntegrityToken = jest.fn(async () => {
+            const err = new Error('upstream failed');
+            err.code = 'GOOGLE_DECODE_FAILED';
+            throw err;
+        });
+
+        const res = await request(makeApp({ decodeIntegrityToken }))
+            .post('/api/play-integrity/verdict')
+            .send({
+                deviceId: DEVICE_ID,
+                deviceSecret: DEVICE_SECRET,
+                action: 'startup',
+                nonce,
+                integrityToken: 'd'.repeat(100),
+            });
+
+        expect(res.status).toBe(502);
+        expect(res.body.success).toBe(false);
+        expect(res.body.error).toBe('play_integrity_decode_failed');
+        expect(res.body.verificationConfigured).toBe(true);
+    });
+});

--- a/backend/tests/jest/play-integrity.test.js
+++ b/backend/tests/jest/play-integrity.test.js
@@ -97,6 +97,42 @@ describe('Play Integrity bridge', () => {
         expect(JSON.stringify(res.body)).not.toContain(token);
     });
 
+    test('debug endpoint reports last unverified verdict without token or nonce material', async () => {
+        const nonce = playIntegrity._internal.makeNonce({ deviceId: DEVICE_ID, action: 'startup' });
+        const token = 'u'.repeat(100);
+        const app = makeApp();
+        const verdict = await request(app)
+            .post('/api/play-integrity/verdict')
+            .send({
+                deviceId: DEVICE_ID,
+                deviceSecret: DEVICE_SECRET,
+                action: 'startup',
+                nonce,
+                integrityToken: token,
+            });
+        const debug = await request(app)
+            .get('/api/play-integrity/debug')
+            .query({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET });
+
+        expect(verdict.status).toBe(200);
+        expect(debug.status).toBe(200);
+        expect(debug.body.diagnostics.lastVerdict).toMatchObject({
+            packageName: 'com.hank.clawlive',
+            action: 'startup',
+            status: 'received_unverified',
+            requestMode: 'classic',
+            verificationConfigured: false,
+            checks: null,
+            consoleSignals: null,
+            decodeErrorCode: null,
+        });
+        expect(debug.body.diagnostics.lastVerdict.checkedAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+        const debugJson = JSON.stringify(debug.body);
+        expect(debugJson).not.toContain(token);
+        expect(debugJson).not.toContain(nonce);
+        expect(debugJson).not.toContain(DEVICE_SECRET);
+    });
+
     test('verdict endpoint accepts standard requestHash challenge without credentials', async () => {
         const nonce = playIntegrity._internal.makeNonce({ deviceId: DEVICE_ID, action: 'startup' });
         const requestHash = playIntegrity._internal.makeRequestHash(nonce);
@@ -220,7 +256,8 @@ describe('Play Integrity bridge', () => {
             },
         }));
 
-        const res = await request(makeApp({ decodeIntegrityToken }))
+        const app = makeApp({ decodeIntegrityToken });
+        const res = await request(app)
             .post('/api/play-integrity/verdict')
             .send({
                 deviceId: DEVICE_ID,
@@ -266,6 +303,9 @@ describe('Play Integrity bridge', () => {
                 },
                 deviceIntegrity: {
                     deviceRecognitionVerdict: ['MEETS_DEVICE_INTEGRITY'],
+                    recentDeviceActivity: {
+                        deviceActivityLevel: 'LEVEL_1',
+                    },
                 },
                 accountDetails: {
                     appLicensingVerdict: 'LICENSED',
@@ -274,13 +314,11 @@ describe('Play Integrity bridge', () => {
                     appAccessRiskVerdict: { appsDetected: ['KNOWN_INSTALLED'] },
                     playProtectVerdict: 'NO_ISSUES',
                 },
-                recentDeviceActivity: {
-                    deviceActivityLevel: 'LEVEL_1',
-                },
             },
         }));
 
-        const res = await request(makeApp({ decodeIntegrityToken }))
+        const app = makeApp({ decodeIntegrityToken });
+        const res = await request(app)
             .post('/api/play-integrity/verdict')
             .send({
                 deviceId: DEVICE_ID,
@@ -309,6 +347,47 @@ describe('Play Integrity bridge', () => {
         expect(res.body.integrity.verdict.appAccessRiskVerdict).toEqual({ appsDetected: ['KNOWN_INSTALLED'] });
         expect(res.body.integrity.verdict.playProtectVerdict).toBe('NO_ISSUES');
         expect(res.body.integrity.verdict.recentDeviceActivity).toEqual({ deviceActivityLevel: 'LEVEL_1' });
+        const debug = await request(app)
+            .get('/api/play-integrity/debug')
+            .query({ deviceId: DEVICE_ID, deviceSecret: DEVICE_SECRET });
+        expect(debug.status).toBe(200);
+        expect(debug.body.diagnostics.lastVerdict).toMatchObject({
+            action: 'startup',
+            status: 'verified',
+            requestMode: 'standard',
+            verificationConfigured: true,
+            checks: {
+                packageNameMatches: true,
+                requestHashMatches: true,
+                bindingMatches: true,
+                fresh: true,
+                appRecognized: true,
+                deviceMeetsIntegrity: true,
+            },
+            consoleSignals: {
+                playLicensing: { observed: true, value: 'LICENSED' },
+                appIntegrity: {
+                    observed: true,
+                    value: 'PLAY_RECOGNIZED',
+                    packageName: 'com.hank.clawlive',
+                    versionCode: '100',
+                },
+                deviceIntegrity: { observed: true, values: ['MEETS_DEVICE_INTEGRITY'] },
+                virtualIntegrity: { observed: false, values: [] },
+                recentDeviceActivity: { observed: true, value: 'LEVEL_1' },
+                playProtect: { observed: true, value: 'NO_ISSUES' },
+                appAccessRisk: {
+                    observed: true,
+                    values: ['KNOWN_INSTALLED'],
+                    hasCaptureOrControlRisk: false,
+                },
+            },
+        });
+        const debugJson = JSON.stringify(debug.body);
+        expect(debugJson).not.toContain(token);
+        expect(debugJson).not.toContain(nonce);
+        expect(debugJson).not.toContain(requestHash);
+        expect(debugJson).not.toContain(DEVICE_SECRET);
         expect(JSON.stringify(res.body)).not.toContain(token);
     });
 

--- a/docs/ops/google-play-console-coverage-2026-06-19.md
+++ b/docs/ops/google-play-console-coverage-2026-06-19.md
@@ -1,0 +1,152 @@
+# Google Play Console Coverage Runbook - 2026-06-19
+
+This runbook captures the live Google Play Console gaps for `EClawbot (OpenClaw)`
+package `com.hank.clawlive` and the exact completion path. Do not paste secrets
+into this file, PR comments, logs, or issue comments.
+
+## Live State
+
+Observed in Google Play Console on 2026-06-19 10:12 CST:
+
+| Surface | Current state | Remaining blocker |
+| --- | --- | --- |
+| Deep links, version `100 (1.0.92)` | `/r/` on `eclawbot.com` shows `未通過網域檢查` | Production `/.well-known/assetlinks.json` still publishes only the upload certificate. PR #3545 must be reviewed, merged, and deployed so the Play App Signing certificate is served. |
+| Protect with Play: Auto protection | `1/1` enabled | None. |
+| Protect with Play: Play Integrity API | `0/7` enabled, `尚未整合 Play Integrity API` | PR #3546 must be reviewed, merged, deployed, configured with Google credentials, and shipped in a new Android release. |
+| Protect with Play: Play Store safeguards | `6/7` enabled | `商店資訊檢查功能` is off for `禁止在高風險裝置上安裝應用程式`; this is a Play Console setting reached via `管理商店顯示設定`. |
+| Protect with Play: Play Billing safeguards | `4/4` enabled | None. |
+
+## Required PR Order
+
+1. Review and merge PR #3545: Android App Links domain verification.
+2. Let Railway production deploy `main`.
+3. Verify production serves both Android App Links fingerprints:
+   - Play App Signing certificate fingerprint.
+   - Upload certificate fingerprint.
+4. Re-check Play Console deep links for version `100 (1.0.92)` and confirm `/r/`
+   on `eclawbot.com` no longer reports `未通過網域檢查`.
+5. Review and merge PR #3546: Play Integrity standard bridge.
+6. Let Railway production deploy `main`.
+7. Configure Play Integrity server verification in Railway and Google Play
+   Console.
+8. Build and upload a new Android release containing the Play Integrity client
+   integration.
+
+Do not merge to `main` or trigger production deploy from an automation thread
+unless the user explicitly asks for that exact action.
+
+## Deep Link Verification
+
+Before PR #3545 deploys, production currently returns only the upload
+certificate:
+
+```sh
+curl -fsSL https://eclawbot.com/.well-known/assetlinks.json \
+  | jq -r '.[0].target.sha256_cert_fingerprints[]'
+```
+
+After PR #3545 deploys, this command must include both the Play App Signing
+certificate and the upload certificate. If Play Console still shows the domain
+as failed after production is correct, wait for Play revalidation and then
+reopen:
+
+`Google Play Console -> EClawbot (OpenClaw) -> 開發更多使用者 -> 深層連結`
+
+Expected state:
+
+- Version selector: `100 (1.0.92)` or the latest shipped Android version.
+- Domain: `eclawbot.com`.
+- Path prefix: `/r/`.
+- Status no longer says `未通過網域檢查`.
+
+## Play Integrity Activation
+
+PR #3546 adds:
+
+- Android dependency on Google Play Integrity.
+- Release-build startup reporting through `PlayIntegrityReporter`.
+- Server nonce and verdict endpoints under `/api/play-integrity/*`.
+- Standard API `requestHash` support when `PLAY_INTEGRITY_CLOUD_PROJECT_NUMBER`
+  is configured.
+- Classic nonce fallback when standard requests are not configured.
+- Device-auth debug endpoint at `GET /api/play-integrity/debug`.
+
+Set configuration through the production secret manager only:
+
+| Variable | Purpose |
+| --- | --- |
+| `PLAY_INTEGRITY_CLOUD_PROJECT_NUMBER` | Enables Standard Integrity API requests from Android. |
+| `PLAY_INTEGRITY_SERVICE_ACCOUNT_JSON` | Enables backend decode through the Play Integrity API. |
+| `GOOGLE_APPLICATION_CREDENTIALS_JSON` or `GOOGLE_APPLICATION_CREDENTIALS` | Alternate credential sources for backend decode. |
+| `PLAY_INTEGRITY_NONCE_SECRET` | Optional dedicated nonce signing secret; defaults to `JWT_SECRET` if unset. |
+
+Never print or commit the values. Only report whether each variable is present.
+
+After deploy, verify configuration with a device-authenticated request:
+
+```sh
+curl -fsS 'https://eclawbot.com/api/play-integrity/debug?deviceId=...&deviceSecret=...'
+```
+
+The response should show:
+
+- `verificationConfigured: true`
+- `standardRequestConfigured: true`
+- `cloudProjectNumberConfigured: true`
+
+Then upload a new Android release so Play Console can observe real integrity
+traffic from the Play-distributed build.
+
+## Play Integrity Signals
+
+The Protect with Play page currently lists these seven disabled Play Integrity
+services:
+
+| Console label | Signal surfaced by PR #3546 |
+| --- | --- |
+| `Play 授權檢查功能` | `accountDetails.appLicensingVerdict` |
+| `應用程式完整性檢查功能` | `appIntegrity.appRecognitionVerdict`, `packageName`, `versionCode` |
+| `裝置完整性檢查功能` | `deviceIntegrity.deviceRecognitionVerdict` |
+| `虛擬完整性檢查功能` | `deviceIntegrity.deviceRecognitionVerdict` values returned by Google |
+| `近期裝置活動功能` | `recentDeviceActivity` |
+| `Play 安全防護狀態` | `environmentDetails.playProtectVerdict` |
+| `應用程式存取風險功能` | `environmentDetails.appAccessRiskVerdict` |
+
+Expected backend behavior after server credentials are configured:
+
+- Valid package, binding, freshness, app recognition, and device integrity
+  return `status: "verified"`.
+- Failed checks return `status: "verification_failed"` and include the failed
+  check booleans.
+- Tokens are never echoed in responses or logs.
+
+## Store Safeguard Manual Setting
+
+The remaining `Play 商店防護措施` item is not a repository change.
+
+Manual path:
+
+1. Open `Google Play Console -> EClawbot (OpenClaw) -> 由 Google Play 保護`.
+2. Expand `Play 商店防護措施`.
+3. On `禁止在高風險裝置上安裝應用程式`, click `管理商店顯示設定`.
+4. Enable `商店資訊檢查功能` if the business decision is to block high-risk
+   device installs through the store listing check.
+5. Return to `由 Google Play 保護` and verify `Play 商店防護措施` is `7/7`.
+
+This setting changes Google Play distribution behavior, so do it only after the
+user explicitly approves that Console-side change.
+
+## Completion Evidence
+
+Do not call the Android/Play Console coverage work complete until all of the
+following are true:
+
+- Play Console deep links show no `未通過網域檢查` issue for `eclawbot.com` `/r/`.
+- `Protect with Play -> Auto protection` is `1/1`.
+- `Protect with Play -> Play Integrity API` is `7/7`.
+- `Protect with Play -> Play Store safeguards` is `7/7`.
+- `Protect with Play -> Play Billing safeguards` is `4/4`.
+- Production `/api/play-integrity/debug` reports verifier and standard request
+  configuration present without exposing any secret values.
+- A Play-distributed Android build containing PR #3546 has sent at least one
+  Play Integrity verdict to production.

--- a/docs/ops/google-play-console-coverage-2026-06-19.md
+++ b/docs/ops/google-play-console-coverage-2026-06-19.md
@@ -93,6 +93,10 @@ The response should show:
 - `verificationConfigured: true`
 - `standardRequestConfigured: true`
 - `cloudProjectNumberConfigured: true`
+- `lastVerdict` remains `null` until a Play-distributed Android build submits
+  a verdict. After the first release-build report, `lastVerdict` must show the
+  latest action/status/checks and `consoleSignals` without echoing a token,
+  nonce, request hash, device secret, or service-account value.
 
 Then upload a new Android release so Play Console can observe real integrity
 traffic from the Play-distributed build.
@@ -118,6 +122,9 @@ Expected backend behavior after server credentials are configured:
   return `status: "verified"`.
 - Failed checks return `status: "verification_failed"` and include the failed
   check booleans.
+- `GET /api/play-integrity/debug` returns the latest safe `lastVerdict`
+  summary for that device so release verification does not depend only on
+  external Play Console refresh timing.
 - Tokens are never echoed in responses or logs.
 
 ## Store Safeguard Manual Setting
@@ -149,4 +156,5 @@ following are true:
 - Production `/api/play-integrity/debug` reports verifier and standard request
   configuration present without exposing any secret values.
 - A Play-distributed Android build containing PR #3546 has sent at least one
-  Play Integrity verdict to production.
+  Play Integrity verdict to production, and `/api/play-integrity/debug`
+  reports a `lastVerdict.status` of `verified` for that device.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ credentialManager = "1.5.0-beta01"
 googleId = "1.1.1"
 facebookSdk = "17.0.0"
 playServicesLocation = "21.3.0"
+playIntegrity = "1.6.0"
 
 [libraries]
 billing = { group = "com.android.billingclient", name = "billing-ktx", version.ref = "billing" }
@@ -71,6 +72,9 @@ facebook-login = { group = "com.facebook.android", name = "facebook-login", vers
 
 # Google Play Services Location
 play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "playServicesLocation" }
+
+# Google Play Integrity
+play-integrity = { group = "com.google.android.play", name = "integrity", version.ref = "playIntegrity" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

Adds an Android + backend Play Integrity bridge so EClawbot can start covering the Play Console "Play Integrity API" services that currently show as not integrated.

## What Changed

- Adds the Play Integrity Android library (`com.google.android.play:integrity:1.6.0`).
- Adds a release-build startup reporter that requests a server challenge, requests a Play Integrity token, and submits it back to the backend without logging tokens.
- Uses Standard Integrity requests first when `PLAY_INTEGRITY_CLOUD_PROJECT_NUMBER` is configured, binding the token to a server-generated `requestHash`.
- Falls back to Classic Integrity nonce requests if standard setup is unavailable or the standard request fails.
- Adds `/api/play-integrity/nonce`, `/api/play-integrity/verdict`, and `/api/play-integrity/debug` backend routes.
- Adds server-side Google decode support gated on service-account configuration via `PLAY_INTEGRITY_SERVICE_ACCOUNT_JSON`, `GOOGLE_APPLICATION_CREDENTIALS`, or `GOOGLE_APPLICATION_CREDENTIALS_JSON`.
- Verifies package name, request binding, timestamp freshness, app recognition, and device integrity before returning `verified`.
- Surfaces optional Play Integrity payload signals such as app access risk, Play Protect, licensing, and recent device activity when Google returns them.

## Why

Play Console's "Protected with Play" page showed Play Integrity API as `0/7` services enabled and "not integrated". Official Android docs recommend Standard API requests for most integrations, with `requestHash` binding and backend decode/verification. App access risk in Standard requests requires Play Integrity library 1.4.0 or higher, so this uses 1.6.0.

## Validation

- `npm test -- --runTestsByPath tests/jest/play-integrity.test.js`
- `./gradlew :app:compileDebugKotlin :app:compileReleaseKotlin`
- `node -c backend/play-integrity.js`
- `npx eslint play-integrity.js tests/jest/play-integrity.test.js` (0 errors; Jest file is ignored by existing ESLint config with a warning)
- `git diff --check AGENTS.md app/build.gradle.kts gradle/libs.versions.toml app/src/main/java/com/hank/clawlive/ClawApplication.kt app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt app/src/main/java/com/hank/clawlive/data/model/PlayIntegrityModels.kt app/src/main/java/com/hank/clawlive/integrity/PlayIntegrityReporter.kt backend/index.js backend/play-integrity.js backend/tests/jest/play-integrity.test.js`

## Deployment / Console Notes

This code path becomes fully verified only after production backend credentials and Play Console/Cloud setup are completed:

- Link a Google Cloud project in Play Console: Protected with Play -> Play Integrity API -> Get started -> Link Cloud project.
- Set `PLAY_INTEGRITY_CLOUD_PROJECT_NUMBER` on the backend to enable Standard Integrity requests.
- Configure one backend verifier credential source for Google server-side decode.
- Merge/deploy backend and release an Android build containing the client reporter before expecting Play Console to move from "not integrated".