### PR TITLE
fix(push): log gateway timeout/abort at warn, not error (no benign error)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -19082,10 +19082,6 @@ async function pushToBot(entity, deviceId, eventType, payload, opts = {}) {
             return { pushed: false, reason: `http_${response.status}`, error: errorText, debug: { url, tokenLength: token.length, status: response.status, hint: debugHint.trim() } };
         }
     } catch (err) {
-        console.error(`[Push] ✗ Device ${deviceId} Entity ${entity.entityId}: Push error:`, err.message);
-        console.error(`[Push] Full error:`, err);
-        serverLog('error', 'push_error', `Entity ${entity.entityId} push exception: ${err.message}`, { deviceId, entityId: entity.entityId });
-
         // AbortError / TimeoutError: gateway didn't ack within 15s but the bot may
         // still be processing and reply async via /api/transform. Don't pollute
         // entity.message with diagnostic text (push_status carries the signal).
@@ -19094,6 +19090,19 @@ async function pushToBot(entity, deviceId, eventType, payload, opts = {}) {
         // transform overwrites → user/client polling between the two sees noise.
         const isAbort = err.name === 'AbortError' || err.name === 'TimeoutError'
             || /aborted|timeout/i.test(err.message || '');
+
+        // Log severity must match reality (no "benign error"): a gateway timeout is a
+        // known async-uncertain state (bot may still reply via /api/transform), so it is
+        // a WARN, not an ERROR. Reserve console.error + serverLog('error') for hard
+        // failures (ENOTFOUND / ECONNREFUSED / TLS / non-2xx). This stops benign
+        // push-timeout noise (esp. to offline/test devices) from paging as ERROR.
+        if (isAbort) {
+            console.warn(`[Push] ⏳ Device ${deviceId} Entity ${entity.entityId}: push gateway timeout (no 15s ack) — bot may reply async via /api/transform: ${err.message}`);
+        } else {
+            console.error(`[Push] ✗ Device ${deviceId} Entity ${entity.entityId}: Push error:`, err.message);
+            console.error(`[Push] Full error:`, err);
+            serverLog('error', 'push_error', `Entity ${entity.entityId} push exception: ${err.message}`, { deviceId, entityId: entity.entityId });
+        }
 
         if (!isAbort) {
             // Hard connection failure (ENOTFOUND / ECONNREFUSED / TLS / etc.) — surface to UI.


### PR DESCRIPTION
## Problem
`pushToBot`'s `catch` block logged **every** exception via `console.error` + `serverLog('error')` — including `AbortError`/`TimeoutError`. But the surrounding code already treats a gateway timeout as a **benign async-uncertain state** (15s no-ack; the bot may still reply via `/api/transform`, and the code deliberately does NOT set `WEBHOOK_ERROR` for it).

Logging that as ERROR violates the "error = real problem, no benign error" principle and generates `[ErrLog/ERROR]` P0 cards. The sampled occurrences are benign push timeouts to offline/test devices (e.g. `2a0ad04d` = BROADCAST_TEST_DEVICE, hit by health/E2E crons).

## Fix
Hoist the `isAbort` check above logging; log timeouts/aborts at `console.warn`, and reserve `console.error` + `serverLog('error')` for hard failures (ENOTFOUND/ECONNREFUSED/TLS/non-2xx). **No behavior change** to `entity.message` / `push_status` — only log severity now matches reality.

## Test
- `node --check` passes; existing `push-notifications.test.js` + full jest run in CI.
- Manual trace: timeout path → warn (no serverLog error); hard-fail path → unchanged error + WEBHOOK_ERROR.

## Refs
Resolves the ErrLog P0 group: `[Push] ... operation aborted due to timeout` / `DOMException [TimeoutError]` / `push_timeout`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)