### PR TITLE
fix(portal): gate owner-scope API calls on real user account → stop 401 console errors (card_01417648)

### DIFF
--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -1623,7 +1623,13 @@
                 (l.owner_device_id && l.owner_device_id === (meData.user.deviceId || meData.user.device_id))
             ));
             _rentalWalletBalance = null;
-            if (meData?.user && !isSelfOwned) {
+            // meData.user.id is null for a device-only / globe-user session (no
+            // email account). /api/wallet/balance is account-scoped (walletRoute
+            // → 401 without a userId), so only fetch the balance estimate when a
+            // real account is signed in — otherwise the rental-detail modal logs
+            // a 401. The estimate just stays unset, which is the correct UX for a
+            // not-signed-in viewer. card_01417648.
+            if (meData?.user && meData.user.id && !isSelfOwned) {
                 apiFetch('/api/wallet/balance?deviceId=' + encodeURIComponent(meData.user.deviceId || meData.user.device_id))
                     .then(wb => { const w = wb.wallet || wb; _rentalWalletBalance = parseInt(w.balance_mli, 10) || 0; updateRentalEstimate(rateMli, depositEcoin); })
                     .catch(() => {});

--- a/backend/public/portal/my-rentals.html
+++ b/backend/public/portal/my-rentals.html
@@ -214,6 +214,20 @@
 
         async function loadTab() {
             const wrap = document.getElementById('mrContent');
+            // Device-only / globe-user sessions (bound device, no email account)
+            // resolve to a truthy currentUser whose `id` is null. Rental endpoints
+            // (my-listings / my-contracts / my-disputes) are account-scoped and
+            // 401 ('unauthenticated') without a userId — calling them just spams
+            // the console. Show a no-account empty-state instead. card_01417648.
+            if (!window.currentUser || !window.currentUser.id) {
+                const hint = tt('mr_no_account', 'Sign in with an email account to manage rentals.');
+                const help = tt('mr_no_account_help', 'Rental listings and contracts are tied to a user account. A device-only session has none yet — sign in or create an account from Settings to get started.');
+                wrap.innerHTML = `<div class="mr-empty">${esc(hint)} `
+                    + `<span tabindex="0" role="button" title="${esc(help)}" aria-label="${esc(help)}" `
+                    + `style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;margin-left:6px;`
+                    + `border-radius:50%;background:var(--bg-tertiary,rgba(127,127,127,0.2));font-size:12px;cursor:help;vertical-align:middle;">?</span></div>`;
+                return;
+            }
             wrap.innerHTML = `<div class="mr-empty">${tt('mr_loading', 'Loading...')}</div>`;
             try {
                 if (currentTab === 'disputes') {

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -3205,6 +3205,20 @@
 
         async function loadOwnerRoster(user = currentUser) {
             const note = document.getElementById('rosterStatusNote');
+
+            // Device-only / globe-user sessions (bound device, no email account)
+            // resolve to a truthy currentUser whose `id` is null. The rental
+            // endpoints below are account-scoped and 401 ('unauthenticated')
+            // without a userId — calling them just floods the console. Render the
+            // existing roster empty-state (which carries the ? help-icon) and
+            // skip the calls entirely. card_01417648.
+            if (!user || !user.id) {
+                ownerRosterState = { mock: false, listings: [], rentals: [], history: [] };
+                if (note) note.textContent = rosterT('settings_roster_no_account', 'Sign in with an email account to manage rentals.');
+                renderOwnerRoster();
+                return;
+            }
+
             if (note) note.textContent = rosterT('settings_roster_loading', 'Loading roster…');
 
             // Real rental data sources (same endpoints my-rentals.html uses):

--- a/backend/public/portal/shared/agent-card-editor.js
+++ b/backend/public/portal/shared/agent-card-editor.js
@@ -224,6 +224,13 @@ window.AgentCardEditor = (function() {
         // Owner-only: see comment block above.
         if (!this.isOwner) return;
         if (typeof apiCall !== 'function') return;
+        // Account-scoped: /api/rental/my-listings is gated by rentalRoute, which
+        // 401s ('unauthenticated') unless the session carries a userId. Entity
+        // ownership (isOwner) is NOT the same as having a user account — a
+        // device-only / globe-user session owns its entities but has
+        // currentUser.id === null. Skip the fetch to avoid a 401 console error
+        // per card render. card_01417648.
+        if (typeof window === 'undefined' || !window.currentUser || !window.currentUser.id) return;
 
         function mount(deadlineMs) {
             if (!Number.isFinite(deadlineMs)) return;

--- a/backend/public/portal/shared/nav.js
+++ b/backend/public/portal/shared/nav.js
@@ -134,11 +134,14 @@ function doLogout() { logout(); }
 // (e.g. user has no wallet yet).
 async function _loadNavEcoinBadge() {
     try {
-        // Guard: only fetch the wallet balance when authenticated. On public /
-        // unauthenticated pages window.currentUser is unset (auth.js populates it
-        // after /me succeeds); skipping here avoids a 401 console error on every
-        // public page view. See issue #3513.
-        if (!window.currentUser) return;
+        // Guard: only fetch the wallet balance when there is a real user
+        // ACCOUNT. auth.js populates window.currentUser after /me succeeds, but a
+        // device-only session (bound device, no email account) still resolves to
+        // a truthy currentUser with `id: null`. /api/wallet/balance requires a
+        // userId (walletRoute → 401 'unauthenticated' when absent), so gating on
+        // currentUser alone still 401s for device-only / globe-user sessions.
+        // Require currentUser.id to avoid a 401 console error. See #3513 + card_01417648.
+        if (!window.currentUser || !window.currentUser.id) return;
         const badge = document.getElementById('ecoinBadge');
         const amountEl = document.getElementById('ecoinAmount');
         if (!badge || !amountEl) return;

--- a/backend/public/portal/wallet.html
+++ b/backend/public/portal/wallet.html
@@ -340,6 +340,25 @@
             }
         }
 
+        // No-account empty-state: a device-only / globe-user session has no
+        // e-coin wallet (wallet is keyed by user account). Render a neutral
+        // empty-state instead of firing account-scoped calls that would 401.
+        // The (?) explains what is needed + the concrete next step. card_01417648.
+        function renderWalletNoAccount() {
+            const dash = '—';
+            ['balanceEcoin', 'balanceUsd', 'heldEcoin', 'lifetimeEarned', 'lifetimeSpent']
+                .forEach(id => { const el = document.getElementById(id); if (el) el.textContent = dash; });
+            const wrap = document.getElementById('ledgerWrap');
+            if (wrap) {
+                const hint = tt('wallet_no_account', 'Sign in with an email account to use your e-coin wallet.');
+                const help = tt('wallet_no_account_help', 'The e-coin wallet (balance, top-up, history) is tied to a user account. A device-only session has no wallet yet — sign in or create an account from Settings to enable it.');
+                wrap.innerHTML = `<div class="empty-state">${escapeHtml(hint)} `
+                    + `<span tabindex="0" role="button" title="${escapeHtml(help)}" aria-label="${escapeHtml(help)}" `
+                    + `style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;margin-left:6px;`
+                    + `border-radius:50%;background:rgba(255,255,255,0.15);font-size:12px;cursor:help;vertical-align:middle;">?</span></div>`;
+            }
+        }
+
         async function loadTiers() {
             try {
                 const data = await apiCall('GET', '/api/wallet/topup/tiers', null, { skip401Redirect: true });
@@ -472,6 +491,19 @@
             const user = await checkAuth();
             if (!user) return;
             initPortalSocket();
+
+            // Device-only / globe-user sessions (a bound device with no email
+            // account) resolve to a truthy user whose `id` is null. The e-coin
+            // wallet is account-scoped: /api/wallet/balance + /history require a
+            // userId (walletRoute → 401 'unauthenticated'), so calling them here
+            // just floods the console with 401s. Show the no-account empty-state
+            // and load only the public top-up catalog. card_01417648.
+            if (!user.id) {
+                renderWalletNoAccount();
+                loadTiers();
+                initTourTrack2Step4();
+                return;
+            }
 
             await Promise.all([loadBalance(), loadTiers(), loadHistory()]);
             initTourTrack2Step4();

--- a/backend/public/shared/i18n.js
+++ b/backend/public/shared/i18n.js
@@ -650373,6 +650373,11 @@ const TRANSLATIONS = {
         "passive_health_interval_help": "How often the passive sweep runs, in hours (1–168). Only takes effect when passive health-check is enabled.",
         "passive_health_auto_repair_label": "Auto-repair",
         "passive_health_auto_repair_help": "When an agent is found unhealthy, automatically run the existing self-repair flow (up to 3 attempts) before filing a bug. Only takes effect when passive health-check is enabled.",
+
+        "wallet_no_account": "Sign in with an email account to use your e-coin wallet.",
+        "wallet_no_account_help": "The e-coin wallet (balance, top-up, history) is tied to a user account. A device-only session has no wallet yet — sign in or create an account from Settings to enable it.",
+        "mr_no_account": "Sign in with an email account to manage rentals.",
+        "mr_no_account_help": "Rental listings and contracts are tied to a user account. A device-only session has none yet — sign in or create an account from Settings to get started.",
 },
 
 
@@ -1235207,6 +1235212,11 @@ const TRANSLATIONS = {
         "passive_health_interval_help": "被動健檢執行的頻率,以小時計(1–168)。僅在啟用被動健檢後才會生效。",
         "passive_health_auto_repair_label": "自動修復",
         "passive_health_auto_repair_help": "當偵測到智能體不健康時,自動執行既有的自我修復流程(最多 3 次),仍失敗才回報問題。僅在啟用被動健檢後才會生效。",
+
+        "wallet_no_account": "登入 email 帳號後即可使用 e-coin 錢包。",
+        "wallet_no_account_help": "e-coin 錢包（餘額、儲值、紀錄）綁定於使用者帳號。僅綁定裝置的工作階段尚無錢包 — 請至設定登入或建立帳號以啟用。",
+        "mr_no_account": "登入 email 帳號後即可管理租賃。",
+        "mr_no_account_help": "租賃刊登與合約綁定於使用者帳號。僅綁定裝置的工作階段尚無帳號 — 請至設定登入或建立帳號以開始使用。",
 },
 
 
@@ -1849382,6 +1849392,11 @@ const TRANSLATIONS = {
         "chat_routing_unspecified": "未指定",
 
         "chat_routing_sender": "发送者",
+
+        "wallet_no_account": "登录 email 账号后即可使用 e-coin 钱包。",
+        "wallet_no_account_help": "e-coin 钱包（余额、充值、记录）绑定于用户账号。仅绑定设备的会话尚无钱包 — 请至设置登录或创建账号以启用。",
+        "mr_no_account": "登录 email 账号后即可管理租赁。",
+        "mr_no_account_help": "租赁刊登与合约绑定于用户账号。仅绑定设备的会话尚无账号 — 请至设置登录或创建账号以开始使用。",
 },
 
 
@@ -2944615,6 +2944630,11 @@ const TRANSLATIONS = {
         "chat_routing_org_upward": "上報",
 
         "chat_routing_unspecified": "未指定",
+
+        "wallet_no_account": "登入 email 帳號後即可使用 e-coin 錢包。",
+        "wallet_no_account_help": "e-coin 錢包（餘額、儲值、紀錄）綁定於使用者帳號。僅綁定裝置的工作階段尚無錢包 — 請至設定登入或建立帳號以啟用。",
+        "mr_no_account": "登入 email 帳號後即可管理租賃。",
+        "mr_no_account_help": "租賃刊登與合約綁定於使用者帳號。僅綁定裝置的工作階段尚無帳號 — 請至設定登入或建立帳號以開始使用。",
 },
 
 


### PR DESCRIPTION
## Problem
A device-only / **globe-user** session (a bound device with **no email account**) resolves to a truthy `window.currentUser` whose **`id` is `null`**. The e-coin wallet and rental endpoints are account-scoped — `walletRoute` / `rentalRoute` return **401 `unauthenticated`** whenever the JWT carries no `userId`.

Pages gated these fetches on `currentUser` (truthy) — or not at all — so on a freshly-bound globe-user device:
- **every page** fired `/api/wallet/balance` (nav badge) → 401
- **settings** additionally fired `/api/rental/my-listings` + `/api/rental/my-contracts` (renter|owner) → 3× 401

→ 4 red console errors on `settings`, 1 on every other page. Repro'd 6/6 by the destructive-modals daily E2E (card_e2eb9d81).

## Why gating, not catching
A 401 logged by the browser **cannot be suppressed by JS** — `.catch()` / `skip401Redirect` only stop the auth *redirect*, not the native console log. The only correct fix is to **gate the call on a real account (`currentUser.id`)**.

## Changes
| File | Change |
|------|--------|
| `shared/nav.js` | Tighten the #3513 badge guard `!currentUser` → `!currentUser.id` (device-only sessions still 401'd the every-page badge) |
| `wallet.html` | Skip balance+history for no-account sessions; no-account empty-state with **(?)** explaining what's needed + next step; still load the public top-up catalog |
| `my-rentals.html` | Gate `loadTab`; no-account empty-state with **(?)** |
| `settings.html` | Gate `loadOwnerRoster`; reuse existing `rosterEmptyState` (already has the **?** help-icon) |
| `shared/agent-card-editor.js` | Entity ownership (`isOwner`) ≠ user account → add account check before the retest-countdown `my-listings` fetch |
| `community.html` | Only fetch the rental-detail wallet estimate when a real account is signed in |

`chat.html` `fetchContractData` intentionally left untouched — it is **click-triggered** (opens a preview modal) and contract chips only exist for account holders, so it is not part of the page-load console spam.

## Test plan
- [ ] Prod E2E (Playwright, after Railway deploy): unbound/globe-user device opens `settings`, `wallet`, `my-rentals`, a public page → **0 × 401** in console (incognito + console capture). Screenshot evidence on card.
- [ ] Account-holder regression: signed-in user still sees real wallet balance + rental roster.
- Backend CI (i18n-syntax + i18n-check + jest) green.

## Globe-user / Setup / ? icon (per spec rule)
- **Globe-user**: this PR *is* the globe-user generalization — no-account sessions now degrade gracefully on every owner-scope surface.
- **Setup condition**: features become live once the user signs in / creates an email account (wallet + rentals are account-scoped by design).
- **? icon**: wallet + my-rentals empty-states carry a (?) that explains *what* (wallet/rentals are account-scoped), *why empty* (device-only session has no account), and the *next step* (sign in / create account from Settings); settings reuses the existing roster help-icon.

---
## Self-review checklist (docs/code-review-checklist.md)
**Part A**
1. **Logic trace** ✅ — root cause traced to `walletRoute`/`rentalRoute` `!req.user.userId` 401 + `/me` device-only `user.id:null`; gate matches the JWT auth model.
2. **Test coverage** ✅ — prod E2E console-capture plan (unbound) + account-holder regression; no backend logic changed.
3. **Return shape** ✅ — no API contract change; frontend-only gating + empty-states.
4. **What this does NOT fix** ⚠️ — does not change backend 401 semantics (intentional: wallet/rental ARE account-scoped, 401 is correct for a genuinely accountless request — we just stop *calling*); `chat.html` contract-chip click path not gated (account-holder-only artifact).
5. **Security** ✅ — no auth weakening; purely skips calls that would 401 anyway; empty-state strings are static + escaped.

**Part B**
6. **/api/help** ⚠️ NO-OP — no API surface change.
7. **Related docs** ⚠️ NO-OP — no doc impact.
8. **i18n audit** ⚠️ — new empty-state strings use `tt()`/`rosterT()` JS **fallbacks** (English), so no `data-i18n`/`i18n.t()` keys are introduced and `i18n-check` stays green; full zh/locale translation of the 5 new key names (`wallet_no_account[_help]`, `mr_no_account[_help]`, `settings_roster_no_account`) is a delegable i18n follow-up.
9. **Info page** ⚠️ NO-OP.
10. **Debug endpoint** ⚠️ NO-OP — pure frontend console-hygiene fix; reproducible via Playwright console capture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)