### PR TITLE
[codex] sync Android notification settings with Web

### DIFF
--- a/RELEASE_HISTORY.md
+++ b/RELEASE_HISTORY.md
@@ -5,6 +5,8 @@ Track git commits for each release to enable changelog generation via `git diff`
 ---
 
 ## Latest
+v1.0.93 | pending | 2026-06-19 | versionCode 101 | Release candidate 🚧 | **Push notification settings parity**: Android native Settings now exposes the Web/backend notification categories for `@mention` pings and rich-card questions, keeps the same category order as the portal, and mirrors the portal Feedback toggle by updating both `feedback_resolved` and `feedback_reply`. Adds a unit regression test for the Android notification preference catalog so future Web/App push-setting drift is caught before release.
+
 v1.0.92 | f9851ca4 | 2026-06-14 | versionCode 100 | Production ✅ (Play API `completed`, uploaded 2026-06-14 20:43 TW) | **Health-checking animation parity + portal/backend reliability rollup**: Android wallpaper/entity cards and iOS entity cards now render the backend `healthChecking` state with visible animation; passive health/self-repair and message-lifecycle backend flow is included; Petdx pagination, entity PR widgets, roadmap live kanban status, chat routing fallback, env-var vault save/delete fixes, avatar Petdx rendering, portal accessibility/parity, rental bind/retirement, redirect/i18n/API error, Plaza, chat, arena, and release/CI reliability fixes are bundled.
 
 v1.0.91 | fc3b1477 | 2026-06-13 | versionCode 99 | Production ✅ (Play API `completed`, live on 2026-06-14 check) | **Play review compliance hotfix**: removed broad Android media/storage permissions (`READ_MEDIA_IMAGES`, `READ_EXTERNAL_STORAGE`, related legacy storage declarations), added manifest permission regression coverage, fixed release lintVital manifest resource issues, and cleared the prior Google Play photo/video permission blocker.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 100
-        versionName = "1.0.92"
+        versionCode = 101
+        versionName = "1.0.93"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
@@ -47,6 +47,8 @@ import com.facebook.FacebookCallback
 import com.facebook.FacebookException
 import com.facebook.login.LoginManager
 import com.facebook.login.LoginResult
+import com.hank.clawlive.settings.NotificationPreferenceCatalog
+import com.hank.clawlive.settings.NotificationPreferenceCategory
 import com.hank.clawlive.ui.AiChatFabHelper
 import com.hank.clawlive.ui.BottomNavHelper
 import com.hank.clawlive.ui.EntityChipHelper
@@ -1027,22 +1029,6 @@ class SettingsActivity : AppCompatActivity() {
         }
     }
 
-    private data class NotifPrefCategory(
-        val key: String,
-        val labelResId: Int
-    )
-
-    private val notifCategories = listOf(
-        NotifPrefCategory("bot_reply", R.string.notif_pref_bot_reply),
-        NotifPrefCategory("broadcast", R.string.notif_pref_broadcast),
-        NotifPrefCategory("speak_to", R.string.notif_pref_speak_to),
-        NotifPrefCategory("feedback_resolved", R.string.notif_pref_feedback),
-        NotifPrefCategory("todo_done", R.string.notif_pref_todo),
-        NotifPrefCategory("kanban_done", R.string.notif_pref_kanban_done),
-        NotifPrefCategory("kanban_done_auto", R.string.notif_pref_kanban_done_auto),
-        NotifPrefCategory("scheduled", R.string.notif_pref_scheduled)
-    )
-
     private fun loadNotificationPreferences() {
         // Show loading state
         notifPrefsContainer.removeAllViews()
@@ -1074,7 +1060,7 @@ class SettingsActivity : AppCompatActivity() {
     private fun buildNotifPrefToggles(prefs: Map<String, Boolean>) {
         notifPrefsContainer.removeAllViews()
 
-        for (category in notifCategories) {
+        for (category in NotificationPreferenceCatalog.categories) {
             val enabled = prefs[category.key] ?: true
 
             val row = LinearLayout(this).apply {
@@ -1099,7 +1085,7 @@ class SettingsActivity : AppCompatActivity() {
             val toggle = MaterialSwitch(this).apply {
                 isChecked = enabled
                 setOnCheckedChangeListener { _, isChecked ->
-                    updateNotifPref(category.key, isChecked)
+                    updateNotifPref(category, isChecked)
                 }
             }
 
@@ -1109,13 +1095,13 @@ class SettingsActivity : AppCompatActivity() {
         }
     }
 
-    private fun updateNotifPref(category: String, enabled: Boolean) {
+    private fun updateNotifPref(category: NotificationPreferenceCategory, enabled: Boolean) {
         lifecycleScope.launch {
             try {
                 val body = mapOf<String, Any>(
                     "deviceId" to deviceManager.deviceId,
                     "deviceSecret" to deviceManager.deviceSecret,
-                    "prefs" to mapOf(category to enabled)
+                    "prefs" to category.updatePayload(enabled)
                 )
                 val response = NetworkModule.api.updateNotificationPreferences(body)
                 if (!response.success) {
@@ -1123,7 +1109,7 @@ class SettingsActivity : AppCompatActivity() {
                 }
             } catch (e: Exception) {
                 Timber.e(e, "Failed to update notification preference")
-                TelemetryHelper.trackError(e, mapOf("action" to "update_notif_pref", "category" to category))
+                TelemetryHelper.trackError(e, mapOf("action" to "update_notif_pref", "category" to category.key))
             }
         }
     }

--- a/app/src/main/java/com/hank/clawlive/settings/NotificationPreferenceCatalog.kt
+++ b/app/src/main/java/com/hank/clawlive/settings/NotificationPreferenceCatalog.kt
@@ -1,0 +1,30 @@
+package com.hank.clawlive.settings
+
+import com.hank.clawlive.R
+
+data class NotificationPreferenceCategory(
+    val key: String,
+    val labelResId: Int,
+    val writeAliases: List<String> = emptyList()
+) {
+    fun updatePayload(enabled: Boolean): Map<String, Boolean> {
+        return (listOf(key) + writeAliases).associateWith { enabled }
+    }
+}
+
+object NotificationPreferenceCatalog {
+    val categories: List<NotificationPreferenceCategory> = listOf(
+        NotificationPreferenceCategory("bot_reply", R.string.notif_pref_bot_reply),
+        NotificationPreferenceCategory("broadcast", R.string.notif_pref_broadcast),
+        NotificationPreferenceCategory("speak_to", R.string.notif_pref_speak_to),
+        NotificationPreferenceCategory("user_mention", R.string.notif_pref_user_mention),
+        NotificationPreferenceCategory("feedback_resolved", R.string.notif_pref_feedback, listOf("feedback_reply")),
+        NotificationPreferenceCategory("todo_done", R.string.notif_pref_todo),
+        NotificationPreferenceCategory("scheduled", R.string.notif_pref_scheduled),
+        NotificationPreferenceCategory("kanban_done", R.string.notif_pref_kanban_done),
+        NotificationPreferenceCategory("kanban_done_auto", R.string.notif_pref_kanban_done_auto),
+        NotificationPreferenceCategory("rich_card_question", R.string.notif_pref_rich_card)
+    )
+
+    val visibleKeys: List<String> = categories.map { it.key }
+}

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -487,10 +487,12 @@
     <string name="notif_pref_bot_reply">机器人回复</string>
     <string name="notif_pref_broadcast">广播消息</string>
     <string name="notif_pref_feedback">用户反馈</string>
+    <string name="notif_pref_rich_card">互动卡片提问</string>
     <string name="notif_pref_scheduled">定时任务</string>
     <string name="notif_pref_speak_to">私聊消息</string>
     <string name="notif_pref_title">通知设置</string>
     <string name="notif_pref_todo">待办提醒</string>
+    <string name="notif_pref_user_mention">@提及提醒</string>
     <string name="notif_prefs_error">加载失败</string>
     <string name="notif_prefs_loading">正在加载…</string>
     <string name="notification_sent">通知已发送</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -497,10 +497,12 @@
     <string name="notif_pref_feedback">使用者回饋</string>
     <string name="notif_pref_kanban_done">看板任務完成</string>
     <string name="notif_pref_kanban_done_auto">看板自動化任務完成</string>
+    <string name="notif_pref_rich_card">互動卡片提問</string>
     <string name="notif_pref_scheduled">定時任務</string>
     <string name="notif_pref_speak_to">私聊訊息</string>
     <string name="notif_pref_title">通知設定</string>
     <string name="notif_pref_todo">待辦提醒</string>
+    <string name="notif_pref_user_mention">@提及提醒</string>
     <string name="notif_prefs_error">載入失敗</string>
     <string name="notif_prefs_loading">正在載入…</string>
     <string name="notification_sent">通知已發送</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -715,10 +715,12 @@ If you have any questions, please contact us via our official email.
     <string name="notif_pref_bot_reply">Bot Replies</string>
     <string name="notif_pref_broadcast">Broadcasts</string>
     <string name="notif_pref_speak_to">Entity Messages</string>
+    <string name="notif_pref_user_mention">@Mention Pings</string>
     <string name="notif_pref_feedback">Feedback Updates</string>
     <string name="notif_pref_todo">TODO Completed</string>
     <string name="notif_pref_kanban_done">Kanban Card Completed</string>
     <string name="notif_pref_kanban_done_auto">Kanban Automation Completed</string>
+    <string name="notif_pref_rich_card">Rich-card Questions</string>
     <string name="notif_pref_scheduled">Scheduled Messages</string>
     <string name="notif_prefs_loading">Loading preferences…</string>
     <string name="notif_prefs_error">Failed to load notification preferences</string>

--- a/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
+++ b/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
@@ -1,5 +1,6 @@
 package com.hank.clawlive
 
+import com.hank.clawlive.settings.NotificationPreferenceCatalogTest
 import org.junit.runner.RunWith
 import org.junit.runners.Suite
 
@@ -14,6 +15,7 @@ import org.junit.runners.Suite
 @RunWith(Suite::class)
 @Suite.SuiteClasses(
     MessageRequestFormatTest::class,
-    ChatEchoSuppressionTest::class
+    ChatEchoSuppressionTest::class,
+    NotificationPreferenceCatalogTest::class
 )
 class UnitTestSuite

--- a/app/src/test/java/com/hank/clawlive/settings/NotificationPreferenceCatalogTest.kt
+++ b/app/src/test/java/com/hank/clawlive/settings/NotificationPreferenceCatalogTest.kt
@@ -1,0 +1,48 @@
+package com.hank.clawlive.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class NotificationPreferenceCatalogTest {
+
+    @Test
+    fun visibleKeysMatchWebNotificationSettings() {
+        assertEquals(
+            listOf(
+                "bot_reply",
+                "broadcast",
+                "speak_to",
+                "user_mention",
+                "feedback_resolved",
+                "todo_done",
+                "scheduled",
+                "kanban_done",
+                "kanban_done_auto",
+                "rich_card_question"
+            ),
+            NotificationPreferenceCatalog.visibleKeys
+        )
+    }
+
+    @Test
+    fun feedbackToggleAlsoUpdatesFeedbackReplyAlias() {
+        val feedback = NotificationPreferenceCatalog.categories.single { it.key == "feedback_resolved" }
+
+        assertEquals(
+            mapOf(
+                "feedback_resolved" to false,
+                "feedback_reply" to false
+            ),
+            feedback.updatePayload(false)
+        )
+    }
+
+    @Test
+    fun newHighSignalPushCategoriesAreExposed() {
+        val keys = NotificationPreferenceCatalog.visibleKeys
+
+        assertTrue(keys.contains("user_mention"))
+        assertTrue(keys.contains("rich_card_question"))
+    }
+}

--- a/backend/index.js
+++ b/backend/index.js
@@ -1129,7 +1129,7 @@ function ensureOneEmptySlot(device) {
 
 // Latest app version - update this with each release
 // Bot will warn users if their app version is older than this
-const LATEST_APP_VERSION = "1.0.92";
+const LATEST_APP_VERSION = "1.0.93";
 const FORCE_UPDATE_BELOW = null; // Set to version string (e.g. "1.0.30") to force-update anything below
 const APP_RELEASE_NOTES = process.env.APP_RELEASE_NOTES || null;
 


### PR DESCRIPTION
## Summary
- expose the Web/backend notification categories `user_mention` and `rich_card_question` in Android native Settings
- mirror Web feedback behavior by writing both `feedback_resolved` and `feedback_reply` from the native Feedback toggle
- bump Android to `1.0.93` / `versionCode 101` and sync `LATEST_APP_VERSION`
- add a JVM regression test for the Android notification preference catalog

## Why
Android `1.0.92` only exposed the older native notification preference list, while the portal/backend had added newer push-setting controls. Per the release-tracking policy, Web/App notification parity gaps should trigger an Android update path.

## Validation
- `ANDROID_HOME=/Users/hank/Library/Android/sdk ANDROID_SDK_ROOT=/Users/hank/Library/Android/sdk ./gradlew :app:testDebugUnitTest --tests 'com.hank.clawlive.settings.NotificationPreferenceCatalogTest'`\n- `ANDROID_HOME=/Users/hank/Library/Android/sdk ANDROID_SDK_ROOT=/Users/hank/Library/Android/sdk ./gradlew :app:testDebugUnitTest`\n- `ANDROID_HOME=/Users/hank/Library/Android/sdk ANDROID_SDK_ROOT=/Users/hank/Library/Android/sdk ./gradlew :app:lintDebug`\n- `ANDROID_HOME=/Users/hank/Library/Android/sdk ANDROID_SDK_ROOT=/Users/hank/Library/Android/sdk ./gradlew :app:bundleRelease --no-daemon`\n- `npm test -- --runTestsByPath tests/jest/notifications.test.js tests/jest/notification-prefs-merge.test.js tests/jest/mention-push-card_db7.test.js tests/jest/rich-card-notification.test.js tests/jest/notification-category-aliases.test.js`\n\n## Release gate blocker\n`cd backend && node run_all_tests.js` was started and stopped after repeated pre-existing live production release-gate failures. Early failures included missing legacy debug endpoints (`/api/debug/devices`, `/api/debug/reset`), `/api/entities` / `/api/status` contract failures, and `deviceSecret required` failures in messaging/webhook tests. Do not merge/upload until the backend release gate is repaired or explicitly accepted as pre-existing.\n\n## Local release artifact\nA signed local AAB was built at `app/build/outputs/bundle/release/app-release.aab` with SHA-256 `d5a078d598174984de6db9134f2cda29b959eaedc156b657ec674b8406752b31`. This PR does not upload it; production upload remains gated on PR/CI/backend release checks.