### PR TITLE
fix(portal): expand small clickable targets

### DIFF
--- a/backend/public/portal/about-founder.html
+++ b/backend/public/portal/about-founder.html
@@ -119,7 +119,9 @@
         }
         .share-btn:hover { opacity: 0.8; }
         .nav-back {
-            display: inline-block;
+            display: inline-flex;
+            align-items: center;
+            min-height: 28px;
             margin-bottom: 24px;
             font-size: 14px;
             color: var(--text-secondary);

--- a/backend/public/portal/analytics.html
+++ b/backend/public/portal/analytics.html
@@ -34,6 +34,10 @@
         }
         .ana-controls input[type=text] { min-width: 180px; }
         .ana-refresh-btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 28px;
             margin-left: auto;
             background: var(--primary);
             color: #fff;

--- a/backend/public/portal/chat.html
+++ b/backend/public/portal/chat.html
@@ -331,6 +331,8 @@
             border: 1px solid var(--card-border);
         }
         .density-switcher button {
+            min-width: 28px;
+            min-height: 28px;
             background: transparent;
             border: 0;
             color: var(--text-muted);
@@ -813,6 +815,10 @@
             flex-shrink: 0;
         }
         .btn-add-contact {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 28px;
             font-size: 13px;
             padding: 2px 8px;
             border-radius: 12px;

--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -470,6 +470,8 @@
             padding: 2px;
         }
         .plaza-view-btn {
+            display: inline-flex; align-items: center; justify-content: center;
+            min-width: 28px; min-height: 28px;
             background: none; border: none; color: var(--text-muted); cursor: pointer;
             padding: 4px 8px; border-radius: 4px; font-size: 14px; transition: all 0.2s;
         }
@@ -838,6 +840,8 @@
             text-transform: uppercase; letter-spacing: 0.5px; margin-right: 4px;
         }
         .cap-filter-chip {
+            display: inline-flex; align-items: center; justify-content: center;
+            min-height: 28px;
             padding: 4px 12px; border-radius: var(--radius-pill);
             background: var(--input-bg); border: 1px solid var(--card-border);
             color: var(--text-secondary); font-size: 12px; font-weight: 500;

--- a/backend/public/portal/compare.html
+++ b/backend/public/portal/compare.html
@@ -61,7 +61,7 @@
         .compare-container { max-width: 900px; margin: 0 auto; padding: 20px 16px; }
 
         /* Back link */
-        .back-link { display: inline-flex; align-items: center; gap: 6px; font-size: 13px; color: var(--text-muted); margin-bottom: 16px; text-decoration: none; }
+        .back-link { display: inline-flex; align-items: center; min-height: 28px; gap: 6px; font-size: 13px; color: var(--text-muted); margin-bottom: 16px; text-decoration: none; }
         .back-link:hover { color: var(--primary); text-decoration: none; }
 
         /* Compare styles */

--- a/backend/public/portal/env-vars.html
+++ b/backend/public/portal/env-vars.html
@@ -74,7 +74,9 @@
         .lock-btn {
             display: inline-flex;
             align-items: center;
+            justify-content: center;
             gap: 6px;
+            min-height: 28px;
             padding: 6px 14px;
             border-radius: var(--radius-pill);
             font-size: 13px;

--- a/backend/public/portal/feedback.html
+++ b/backend/public/portal/feedback.html
@@ -612,6 +612,7 @@
             display: flex;
             align-items: center;
             gap: 4px;
+            min-height: 28px;
         }
 
         .back-link:hover {

--- a/backend/public/portal/index.html
+++ b/backend/public/portal/index.html
@@ -296,7 +296,7 @@
             <button type="submit" class="btn btn-primary btn-block" id="loginBtn" style="margin-top:16px"
                 data-i18n="login_btn_login">Login</button>
             <p style="text-align:center;margin-top:16px;font-size:13px;">
-                <a href="#" onclick="showTab('forgot');return false;" data-i18n="login_link_forgot">Forgot password?</a>
+                <a href="#" onclick="showTab('forgot');return false;" style="display:inline-flex;align-items:center;min-height:28px;" data-i18n="login_link_forgot">Forgot password?</a>
             </p>
             <div style="display:flex;align-items:center;gap:12px;margin:20px 0 12px;">
                 <div style="flex:1;height:1px;background:var(--card-border)"></div>

--- a/backend/public/portal/interactive-dev.html
+++ b/backend/public/portal/interactive-dev.html
@@ -21,7 +21,7 @@
         .id-page-heading { margin: 0 0 8px; font-size: 22px; display: flex; align-items: center; gap: 12px; }
         .id-page-lede { margin: 0 0 20px; color: var(--text-secondary); font-size: 14px; line-height: 1.5; max-width: 720px; }
         /* v1.2c Import button + modal */
-        .id-import-btn { font-size: 13px; padding: 5px 12px; border: 1px solid var(--card-border, rgba(0,0,0,0.12)); background: var(--bg, #fff); color: var(--text, #18181b); border-radius: 8px; cursor: pointer; font-weight: 500; }
+        .id-import-btn { display: inline-flex; align-items: center; justify-content: center; min-height: 28px; font-size: 13px; padding: 5px 12px; border: 1px solid var(--card-border, rgba(0,0,0,0.12)); background: var(--bg, #fff); color: var(--text, #18181b); border-radius: 8px; cursor: pointer; font-weight: 500; }
         .id-import-btn:hover { background: rgba(99,102,241,0.08); }
         .id-import-dialog { border: none; border-radius: 12px; padding: 0; max-width: 520px; width: calc(100vw - 32px); background: var(--bg, #fff); color: var(--text, #18181b); box-shadow: 0 20px 50px rgba(0,0,0,0.3); }
         .id-import-dialog::backdrop { background: rgba(0,0,0,0.45); }

--- a/backend/public/portal/invite-qr-generator.html
+++ b/backend/public/portal/invite-qr-generator.html
@@ -36,7 +36,7 @@
         .qrg-btn-secondary:hover { border-color: var(--primary); }
         .qrg-btn:disabled { opacity: 0.5; cursor: not-allowed; }
 
-        .qrg-back { display: inline-block; margin-bottom: 12px; font-size: 13px; color: var(--text-secondary); text-decoration: none; }
+        .qrg-back { display: inline-flex; align-items: center; min-height: 28px; margin-bottom: 12px; font-size: 13px; color: var(--text-secondary); text-decoration: none; }
         .qrg-back:hover { color: var(--primary); }
     </style>
 </head>

--- a/backend/public/portal/mindmap.html
+++ b/backend/public/portal/mindmap.html
@@ -33,7 +33,7 @@
         .mm-toolbar-group { display: flex; gap: 6px; align-items: center; flex-wrap: wrap; }
         .mm-toolbar select { background: var(--input-bg); border: 1px solid var(--card-border); border-radius: var(--radius-sm, 6px); color: var(--text); font-size: 12px; padding: 5px 8px; cursor: pointer; }
         .mm-toolbar label { font-size: 12px; color: var(--text-secondary, #888); cursor: pointer; display: inline-flex; gap: 4px; align-items: center; }
-        .mm-toolbar button { background: var(--input-bg); border: 1px solid var(--card-border); border-radius: var(--radius-sm, 6px); padding: 5px 10px; font-size: 12px; color: var(--text); cursor: pointer; transition: border-color 0.15s; white-space: nowrap; }
+        .mm-toolbar button { display: inline-flex; align-items: center; justify-content: center; min-height: 28px; background: var(--input-bg); border: 1px solid var(--card-border); border-radius: var(--radius-sm, 6px); padding: 5px 10px; font-size: 12px; color: var(--text); cursor: pointer; transition: border-color 0.15s; white-space: nowrap; }
         .mm-toolbar button:hover { border-color: var(--primary, #6c63ff); }
         .mm-toolbar button.mm-btn-primary { background: var(--primary, #6c63ff); border-color: var(--primary, #6c63ff); color: #fff; }
         .mm-spacer { flex: 1; }

--- a/backend/public/portal/mission.html
+++ b/backend/public/portal/mission.html
@@ -559,7 +559,9 @@
         .add-cat-btn {
             display: inline-flex;
             align-items: center;
+            justify-content: center;
             gap: 4px;
+            min-height: 28px;
             font-size: 11px;
             color: var(--text-muted);
             background: none;

--- a/backend/public/portal/petdx-browser.html
+++ b/backend/public/portal/petdx-browser.html
@@ -58,6 +58,8 @@
         display: flex; flex-wrap: wrap; gap: 6px; padding-top: 8px;
     }
     .chip {
+        display: inline-flex; align-items: center; justify-content: center;
+        min-height: 28px;
         background: var(--panel); border: 1px solid var(--border);
         color: var(--text); padding: 4px 10px; border-radius: 999px;
         font-size: 12px; cursor: pointer;
@@ -67,6 +69,7 @@
     .chip.active { background: var(--accent-soft); border-color: var(--accent); color: var(--accent); }
     .chip-group { display: inline-flex; flex-wrap: wrap; gap: 4px; align-items: center; }
     .chip-label { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.05em; padding: 0 4px; }
+    .login-warn a { display: inline-flex; align-items: center; min-height: 28px; }
     main {
         max-width: 1280px; margin: 0 auto; padding: 16px;
     }

--- a/backend/public/portal/settings.html
+++ b/backend/public/portal/settings.html
@@ -423,7 +423,9 @@
         }
 
         .feedback-history-link {
-            display: inline-block;
+            display: inline-flex;
+            align-items: center;
+            min-height: 28px;
             font-size: 13px;
             color: var(--warning);
             text-decoration: underline;
@@ -432,7 +434,9 @@
         .btn-ask-ai {
             display: inline-flex;
             align-items: center;
+            justify-content: center;
             gap: 4px;
+            min-height: 28px;
             padding: 5px 12px;
             border-radius: 8px;
             border: 1px solid var(--primary);
@@ -675,6 +679,7 @@
         .roster-status.archived, .roster-status.terminated, .roster-status.down { color:#ef4444; background:rgba(239,68,68,.13); }
         .roster-action { max-width:190px; padding:7px 9px; border:1px solid var(--card-border); border-radius:8px; background:var(--bg); color:var(--text); font-size:13px; }
         .roster-empty { padding:18px 12px; color:var(--text-secondary); font-size:13px; text-align:center; }
+        .roster-empty-cta { display:inline-flex; align-items:center; min-height:28px; }
         .roster-note { margin-top:8px; color:var(--text-muted); font-size:12px; line-height:1.45; }
         @media (max-width:640px) {
             .roster-table-wrap { border:none; background:transparent; }
@@ -1349,7 +1354,7 @@
                     <button type="button" id="usageWarningHelpBtn"
                             onclick="event.stopPropagation();showUsageWarningHelp()"
                             aria-label="Usage warning help"
-                            style="background:transparent;border:1px solid var(--card-border);color:var(--text-secondary);width:24px;height:24px;border-radius:50%;font-size:13px;cursor:pointer;padding:0;line-height:1;">?</button>
+                            style="background:transparent;border:1px solid var(--card-border);color:var(--text-secondary);width:28px;height:28px;border-radius:50%;font-size:13px;cursor:pointer;padding:0;line-height:1;">?</button>
                 </div>
                 <span class="expand-arrow" id="usageWarningArrow">&#9662;</span>
             </div>
@@ -1559,9 +1564,9 @@
         <!-- Logout -->
         <div class="actions-section">
             <button class="logout-btn" onclick="doLogout()" data-i18n="nav_logout">Logout</button>
-            <a href="delete-account.html" style="display:block;text-align:center;margin-top:12px;font-size:13px;color:var(--danger);opacity:0.7;text-decoration:none;" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.7'" data-i18n="delete_account_title">Delete Account</a>
+            <a href="delete-account.html" style="display:flex;align-items:center;justify-content:center;min-height:28px;text-align:center;margin-top:12px;font-size:13px;color:var(--danger);opacity:0.7;text-decoration:none;" onmouseover="this.style.opacity='1'" onmouseout="this.style.opacity='0.7'" data-i18n="delete_account_title">Delete Account</a>
             <div class="meta-section">
-                <a href="#" onclick="showPrivacyPolicy()"
+                <a href="#" onclick="showPrivacyPolicy()" style="display:inline-flex;align-items:center;min-height:28px;"
                     data-i18n="settings_privacy_link">Privacy Policy</a>
                 <div class="meta-version">
                     <span data-i18n="settings_version">Version</span> <span id="appVersion">1.2.0</span>

--- a/backend/public/portal/share-chat.html
+++ b/backend/public/portal/share-chat.html
@@ -116,7 +116,7 @@
         .debug-panel .debug-entry.error { color: #ef4444; }
         .debug-panel .debug-entry.warn { color: #f59e0b; }
         .debug-panel .debug-entry.info { color: #60a5fa; }
-        .debug-toggle { position: fixed; bottom: 8px; right: 8px; z-index: 201; background: #111827; color: #10b981; border: 1px solid #10b981; border-radius: 4px; padding: 4px 8px; font-size: 10px; cursor: pointer; font-family: monospace; }
+        .debug-toggle { position: fixed; bottom: 8px; right: 8px; z-index: 201; min-height: 28px; background: #111827; color: #10b981; border: 1px solid #10b981; border-radius: 4px; padding: 4px 8px; font-size: 10px; cursor: pointer; font-family: monospace; }
 
         /* ── Toast ── */
         .toast { position: fixed; top: 16px; left: 50%; transform: translateX(-50%); padding: 8px 20px; border-radius: 8px; font-size: 13px; font-weight: 600; z-index: 300; animation: fadeInOut 3s ease; pointer-events: none; }

--- a/backend/public/portal/shared/info.css
+++ b/backend/public/portal/shared/info.css
@@ -827,7 +827,9 @@
     border: 0;
 }
 .qs-promo-link {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    min-height: 28px;
     margin-top: 12px;
     font-size: 0.9rem;
     color: var(--text-secondary);
@@ -1740,6 +1742,11 @@
     gap: 6px;
 }
 .ped-agent-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 28px;
+    min-height: 28px;
     background: rgba(124, 58, 237, 0.18);
     border: 1px solid rgba(124, 58, 237, 0.4);
     color: #ddd6fe;
@@ -1772,6 +1779,10 @@
     font-weight: 600;
 }
 .ped-clear {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 28px;
     background: transparent;
     color: #94a3b8;
     border: 1px solid rgba(148, 163, 184, 0.3);

--- a/backend/public/portal/shared/style.css
+++ b/backend/public/portal/shared/style.css
@@ -881,6 +881,9 @@ a:hover { text-decoration: underline; }
 }
 
 .chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     padding: 6px 14px;
     min-height: 28px;
     border-radius: 20px;
@@ -1308,10 +1311,13 @@ a:hover { text-decoration: underline; }
 }
 
 .footer-link {
-    display: block;
+    display: inline-flex;
+    align-items: center;
     font-size: 13px;
     color: var(--text-muted);
-    padding: 3px 0;
+    min-width: 28px;
+    min-height: 28px;
+    padding: 4px 0;
     transition: color 0.2s;
     text-decoration: none;
 }

--- a/backend/public/portal/telemetry.html
+++ b/backend/public/portal/telemetry.html
@@ -34,6 +34,10 @@
         }
         .tel-actions { margin-left: auto; display: flex; gap: 8px; }
         .tel-btn {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-height: 28px;
             background: var(--primary);
             color: #fff;
             border: none;

--- a/backend/tests/jest/portal-static-ids.test.js
+++ b/backend/tests/jest/portal-static-ids.test.js
@@ -86,10 +86,15 @@ describe('portal static HTML IDs', () => {
     const dashboard = fs.readFileSync(path.join(__dirname, '../../public/portal/dashboard.html'), 'utf8');
     const settings = fs.readFileSync(path.join(__dirname, '../../public/portal/settings.html'), 'utf8');
     const sharedStyle = fs.readFileSync(path.join(__dirname, '../../public/portal/shared/style.css'), 'utf8');
+    const infoStyle = fs.readFileSync(path.join(__dirname, '../../public/portal/shared/info.css'), 'utf8');
     const refsStyle = fs.readFileSync(path.join(__dirname, '../../public/shared/refs-popover.css'), 'utf8');
     const kanban = fs.readFileSync(path.join(__dirname, '../../public/portal/kanban.html'), 'utf8');
     const community = fs.readFileSync(path.join(__dirname, '../../public/portal/community.html'), 'utf8');
     const envVars = fs.readFileSync(path.join(__dirname, '../../public/portal/env-vars.html'), 'utf8');
+    const chat = fs.readFileSync(path.join(__dirname, '../../public/portal/chat.html'), 'utf8');
+    const mission = fs.readFileSync(path.join(__dirname, '../../public/portal/mission.html'), 'utf8');
+    const petdxBrowser = fs.readFileSync(path.join(__dirname, '../../public/portal/petdx-browser.html'), 'utf8');
+    const telemetry = fs.readFileSync(path.join(__dirname, '../../public/portal/telemetry.html'), 'utf8');
     // The k-Value Tracker widget originally lived on dashboard.html but moved
     // to invite.html (card_8ff516c15600aa1b55c7cabe) — it is invite-funnel
     // analytics, not an entity-binding metric. Lock the deviceSecret auth
@@ -107,11 +112,24 @@ describe('portal static HTML IDs', () => {
     expect(sharedStyle).toMatch(/\.ecoin-badge\s*\{[\s\S]*min-height:\s*28px/);
     expect(sharedStyle).toMatch(/\.btn-sm\s*\{[^}]*min-height:\s*28px/);
     expect(sharedStyle).toMatch(/\.chip\s*\{[\s\S]*min-height:\s*28px/);
+    expect(sharedStyle).toMatch(/\.footer-link\s*\{[\s\S]*min-width:\s*28px;[\s\S]*min-height:\s*28px/);
     expect(sharedStyle).toMatch(/\.help-icon\s*\{[\s\S]*width:\s*28px;[\s\S]*height:\s*28px/);
+    expect(infoStyle).toMatch(/\.qs-promo-link\s*\{[\s\S]*min-height:\s*28px/);
+    expect(infoStyle).toMatch(/\.ped-agent-action\s*\{[\s\S]*min-width:\s*28px;[\s\S]*min-height:\s*28px/);
     expect(refsStyle).toMatch(/\.eclaw-refs-icon\s*\{[\s\S]*width:\s*28px;[\s\S]*height:\s*28px/);
     expect(kanban).toMatch(/\.kb-chip\s*\{[^}]*min-height:28px/);
+    expect(chat).toMatch(/\.density-switcher button\s*\{[\s\S]*min-width:\s*28px;[\s\S]*min-height:\s*28px/);
+    expect(chat).toMatch(/\.btn-add-contact\s*\{[\s\S]*min-height:\s*28px/);
     expect(community).toMatch(/\.invite-cta-copy-btn\s*\{[\s\S]*min-width:\s*28px;[\s\S]*min-height:\s*28px/);
+    expect(community).toMatch(/\.plaza-view-btn\s*\{[\s\S]*min-width:\s*28px;[\s\S]*min-height:\s*28px/);
+    expect(community).toMatch(/\.cap-filter-chip\s*\{[\s\S]*min-height:\s*28px/);
+    expect(mission).toMatch(/\.add-cat-btn\s*\{[\s\S]*min-height:\s*28px/);
     expect(envVars).toMatch(/id="btnRevealCurlId"[\s\S]*min-width:28px;min-height:28px/);
+    expect(envVars).toMatch(/\.lock-btn\s*\{[\s\S]*min-height:\s*28px/);
+    expect(settings).toMatch(/\.feedback-history-link\s*\{[\s\S]*min-height:\s*28px/);
+    expect(settings).toMatch(/\.btn-ask-ai\s*\{[\s\S]*min-height:\s*28px/);
+    expect(petdxBrowser).toMatch(/\.login-warn a\s*\{[\s\S]*min-height:\s*28px/);
+    expect(telemetry).toMatch(/\.tel-btn\s*\{[\s\S]*min-height:\s*28px/);
   });
 
   test('publisher secret visibility toggles expose accessible names and tooltips', () => {


### PR DESCRIPTION
## Summary
- Expand small clickable/tappable portal targets to at least 28px on shared footer links and page-level action controls.
- Cover Bot Plaza filters/view toggles, chat density/contact controls, mission/env-var utilities, telemetry/analytics actions, settings feedback/account links, and shared info/petdx controls.
- Add static regression guards so the small-target fixes stay locked.

Fixes #3557

## QA / Validation
- `npm run smoke:portal` PASS
- `node tests/test-portal-duplicate-vars.js` PASS
- `npx jest --runTestsByPath tests/jest/portal-smoke-static.test.js tests/jest/portal-static-ids.test.js tests/jest/portal-page-api-map.test.js tests/jest/qa-uiux-20260606-regressions.test.js --runInBand` PASS (4 suites / 17 tests)
- `UIUX_ARTIFACT_DIR=/tmp/eclaw-qa-uiux-20260619-2302-artifacts/browser-smoke-final PORTAL_BASE=http://127.0.0.1:3101 node tests/e2e/portal-uiux-smoke.spec.js` PASS (39 pages x 2 viewports, 1614 controls, 0 failures)
- Target detail audit reduced visible tiny targets from 512 to 30; remaining entries are content/document links on Nagoya atlas, Roadmap, and share-chat footer, not primary action controls.
- `node tests/test-ux-static-audit.js` still reports the known 56 static backlog failures tracked by #2954; no new issue filed for that existing backlog.

## Evidence
Kanban card `card_4493446ed9d55968bf47ee41` has attached final browser smoke log, Jest log, tiny-target detail log, and mobile PNG screenshot.

## Reviewer
#2 code review requested per QA/UIUX automation SOP.
