### PR TITLE
fix(transform): quiet default entityId zero correction

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -9179,7 +9179,7 @@ app.post('/api/transform', transformMaybeMultipart, idempotencyMiddleware, async
 
     // Resolve entityId and verify auth
     let eId;
-    let entityIdCorrected = false;
+    let entityIdCorrectionWarning = null;
     if (channelAuthResult) {
         // Channel key path: entityId already validated and entity confirmed in ACL
         eId = parseInt(entityId);
@@ -9211,7 +9211,8 @@ app.post('/api/transform', transformMaybeMultipart, idempotencyMiddleware, async
                 return res.status(403).json({ success: false, message: "Invalid botSecret — no matching entity found" });
             }
         } else {
-            const requestedId = parseInt(entityId) || 0;
+            const rawRequestedEntityId = entityId;
+            const requestedId = parseInt(rawRequestedEntityId, 10) || 0;
             const requestedEntity = device.entities[requestedId];
             if (requestedEntity && requestedEntity.isBound && requestedEntity.botSecret && safeEqual(requestedEntity.botSecret, botSecret)) {
                 eId = requestedId;
@@ -9222,8 +9223,15 @@ app.post('/api/transform', transformMaybeMultipart, idempotencyMiddleware, async
                     return res.status(403).json({ success: false, message: "Invalid botSecret" });
                 }
                 eId = correctId;
-                entityIdCorrected = true;
-                console.warn(`[Transform] Device ${deviceId}: entityId=${requestedId} doesn't match botSecret, auto-corrected to ${correctId}`);
+
+                // `entityId: "0"` is a common legacy/default transform caller value.
+                // Treat it like omitted entityId: auto-detect from botSecret without
+                // emitting the high-signal mismatch warning used for genuine wrong IDs.
+                const isDefaultEntityIdFallback = String(rawRequestedEntityId).trim() === '0';
+                if (!isDefaultEntityIdFallback) {
+                    entityIdCorrectionWarning = `entityId mismatch: you provided ${requestedId} but your botSecret belongs to entity ${correctId}. Auto-corrected to ${correctId}.`;
+                    console.warn(`[Transform] Device ${deviceId}: entityId=${requestedId} doesn't match botSecret, auto-corrected to ${correctId}`);
+                }
             }
         }
     }
@@ -9814,9 +9822,7 @@ app.post('/api/transform', transformMaybeMultipart, idempotencyMiddleware, async
     }
 
     // ── speakTo / broadcast delivery ──
-    const warnings = entityIdCorrected
-        ? [`entityId mismatch: you provided ${parseInt(entityId) || 0} but your botSecret belongs to entity ${eId}. Auto-corrected to ${eId}.`]
-        : [];
+    const warnings = entityIdCorrectionWarning ? [entityIdCorrectionWarning] : [];
     let deliveryResults = null;
     // Tracks whether the delivery path actually persisted a chat row. If
     // hasDelivery was true but every target fell through (all speakTo codes

--- a/backend/tests/jest/transform-delivery.test.js
+++ b/backend/tests/jest/transform-delivery.test.js
@@ -359,10 +359,11 @@ describe('Transform entityId auto-detect', () => {
     const deviceId = 'transform-autoid-test';
     const deviceSecret = `secret-${deviceId}`;
     let botSecret0;
+    let botSecret1;
 
     beforeAll(async () => {
         botSecret0 = await bindEntity(deviceId, deviceSecret, 0);
-        await bindEntity(deviceId, deviceSecret, 1);
+        botSecret1 = await bindEntity(deviceId, deviceSecret, 1);
     });
 
     it('works without entityId (auto-detect from botSecret)', async () => {
@@ -392,6 +393,29 @@ describe('Transform entityId auto-detect', () => {
         expect(res.body.entityId).toBe(0); // corrected
         expect(res.body.warnings).toBeDefined();
         expect(res.body.warnings.some(w => w.includes('Auto-corrected'))).toBe(true);
+    });
+
+    it('silently auto-corrects legacy entityId zero default', async () => {
+        const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+        try {
+            const res = await post('/api/transform')
+                .send({
+                    deviceId,
+                    entityId: '0',  // legacy/default caller value — botSecret belongs to entity 1
+                    botSecret: botSecret1,
+                    message: 'Legacy zero default test',
+                    state: 'IDLE'
+                });
+            expect(res.status).toBe(200);
+            expect(res.body.success).toBe(true);
+            expect(res.body.entityId).toBe(1); // corrected from botSecret
+            expect(res.body.warnings || []).not.toEqual(expect.arrayContaining([
+                expect.stringContaining('entityId mismatch')
+            ]));
+            expect(warnSpy.mock.calls.some(args => String(args[0]).includes('[Transform] Device'))).toBe(false);
+        } finally {
+            warnSpy.mockRestore();
+        }
     });
 
     it('rejects invalid botSecret', async () => {


### PR DESCRIPTION
## Summary
- Treat legacy/default `entityId: "0"` transform calls like omitted entityId: resolve the entity from botSecret without emitting the high-signal mismatch warn.
- Preserve warning + response warning for genuine mismatches where a non-zero entityId does not own the supplied botSecret.
- Add regression coverage for silent correction of `entityId: "0"` with an entity-1 botSecret.

## Verification
- `node --check backend/index.js`
- `node --check backend/tests/jest/transform-delivery.test.js`
- `git diff --check`
- Targeted Jest was attempted but local sandbox cannot bind Supertest ephemeral ports (`listen EPERM 0.0.0.0`); escalation was rejected, so CI should be the dynamic verifier.

## Card
- Advances `card_4c2e0cf209e3c57359809017` / Transform entityId=0 ErrLog.
