### PR TITLE
fix(heartbeat): severity-gate auto-block to P0/P1 stale in_progress cards

### DIFF
--- a/backend/agent-improvement/heartbeat.js
+++ b/backend/agent-improvement/heartbeat.js
@@ -3,7 +3,7 @@
 //
 // Detects cards that are silently stuck:
 //   - in_progress > 2h with no new comment      → post a "what's next?" prompt
-//   - in_progress > 24h with no new comment     → move to blocked + system note
+//   - P0/P1 in_progress > 24h with no new comment → move to blocked + system note
 //
 // Pure-function selectors + a single startSweeper() that wires the interval.
 // The selectors are the unit-testable seam; the action layer below them is
@@ -14,6 +14,7 @@
 const PROMPT_AFTER_MS = 2 * 60 * 60 * 1000;       // 2h
 const ESCALATE_AFTER_MS = 24 * 60 * 60 * 1000;    // 24h
 const SWEEP_INTERVAL_MS = 5 * 60 * 1000;          // 5min
+const ESCALATE_SEVERITIES = new Set(['P0', 'P1']);
 
 /**
  * @typedef {Object} CardActivity
@@ -21,6 +22,8 @@ const SWEEP_INTERVAL_MS = 5 * 60 * 1000;          // 5min
  * @property {string} deviceId
  * @property {string} title
  * @property {string} status              expect 'in_progress'
+ * @property {string} [priority]          Kanban severity: P0/P1/P2/P3
+ * @property {string} [severity]          Alias accepted by tests/callers
  * @property {string|number|Date} statusChangedAt
  * @property {string|number|Date|null} lastNonSystemCommentAt   null if none
  * @property {string|number|Date|null} lastHeartbeatPromptAt    null if never
@@ -32,6 +35,15 @@ function tsOf(v) {
     if (typeof v === 'number') return v;
     if (v instanceof Date) return v.getTime();
     return Date.parse(v) || 0;
+}
+
+function severityOf(card) {
+    const raw = card && (card.severity || card.priority);
+    return ((raw || 'P2') + '').trim().toUpperCase();
+}
+
+function allowsEscalation(card) {
+    return ESCALATE_SEVERITIES.has(severityOf(card));
 }
 
 /**
@@ -49,7 +61,7 @@ function classifyCard(card, nowMs) {
     if (lastActivityTs === 0) return 'idle';
 
     const age = nowMs - lastActivityTs;
-    if (age >= ESCALATE_AFTER_MS) {
+    if (age >= ESCALATE_AFTER_MS && allowsEscalation(card)) {
         // Dedupe: don't escalate twice (most recent escalate within 12h → already handled).
         const lastEsc = tsOf(card.lastEscalateAt);
         if (lastEsc > 0 && (nowMs - lastEsc) < (12 * 60 * 60 * 1000)) return 'idle';
@@ -104,6 +116,7 @@ function startSweeper({ pool, addSystemComment, moveCard, getNow }, intervalMs =
                     c.device_id AS "deviceId",
                     c.title AS "title",
                     c.status AS "status",
+                    c.priority AS "priority",
                     c.status_changed_at AS "statusChangedAt",
                     (SELECT MAX(created_at)
                        FROM kanban_comments

--- a/backend/index.js
+++ b/backend/index.js
@@ -20117,7 +20117,7 @@ agentImprovement.initTable(chatPool)
 
 // OODA-R Phase 1 #4 — anti-laziness heartbeat sweeper.
 // in_progress >2h with no new comment → post a "what's next?" prompt;
-// in_progress >24h → move to blocked. Dedupes so it doesn't spam.
+// P0/P1 in_progress >24h → move to blocked. Dedupes so it doesn't spam.
 const heartbeat = require('./agent-improvement/heartbeat');
 heartbeat.startSweeper({
     pool: chatPool,

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -11785,9 +11785,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/backend/tests/jest/kanban-ooda-r-done-gate-v2.test.js
+++ b/backend/tests/jest/kanban-ooda-r-done-gate-v2.test.js
@@ -300,6 +300,7 @@ describe('heartbeat — classifyCard', () => {
     test('escalate_due at >24h', () => {
         const v = classifyCard({
             status: 'in_progress',
+            priority: 'P1',
             statusChangedAt: new Date(now - 25 * 60 * 60 * 1000).toISOString(),
             lastNonSystemCommentAt: null,
             lastEscalateAt: null,
@@ -307,9 +308,22 @@ describe('heartbeat — classifyCard', () => {
         expect(v).toBe('escalate_due');
     });
 
+    test('escalation severity gate keeps P2 stale cards in prompt path', () => {
+        const v = classifyCard({
+            status: 'in_progress',
+            priority: 'P2',
+            statusChangedAt: new Date(now - 25 * 60 * 60 * 1000).toISOString(),
+            lastNonSystemCommentAt: null,
+            lastHeartbeatPromptAt: null,
+            lastEscalateAt: null,
+        }, now);
+        expect(v).toBe('prompt_due');
+    });
+
     test('escalate suppressed if already escalated within 12h', () => {
         const v = classifyCard({
             status: 'in_progress',
+            priority: 'P1',
             statusChangedAt: new Date(now - 25 * 60 * 60 * 1000).toISOString(),
             lastNonSystemCommentAt: null,
             lastEscalateAt: new Date(now - 6 * 60 * 60 * 1000).toISOString(),
@@ -340,7 +354,7 @@ describe('heartbeat — classifyBatch', () => {
             { status: 'todo' },
             { status: 'in_progress', statusChangedAt: new Date(now - 30 * 60 * 1000).toISOString() }, // fresh
             { status: 'in_progress', statusChangedAt: new Date(now - 3 * 60 * 60 * 1000).toISOString() }, // prompt
-            { status: 'in_progress', statusChangedAt: new Date(now - 26 * 60 * 60 * 1000).toISOString() }, // escalate
+            { status: 'in_progress', priority: 'P1', statusChangedAt: new Date(now - 26 * 60 * 60 * 1000).toISOString() }, // escalate
         ];
         const { prompt, escalate } = classifyBatch(cards, now);
         expect(prompt.length).toBe(1);


### PR DESCRIPTION
## Summary
- Severity-gate heartbeat auto-block: only `P0`/`P1` stale `in_progress >24h` cards auto-move to blocked.
- `P2`/`P3` cards stay on the `>2h prompt` path — they still get nudged, but won't lose queue position from sparse comments alone.
- Implementation by Codex (entity #6); reviewed + merged by entity #2 commander.

## Card
`card_22ab8c3b80ae01b923ce73f7` — [Bug/Infra/P2] Stall-escalation cron lacks severity gate — P0 wrongly auto-blocked, P3 design-first wrongly escalated.

Note: My filed card flagged TWO files (`backend/agent-improvement/heartbeat.js` AND `backend/kanban.js:3217` 6h/12h gating). This PR fixes the heartbeat.js sweep path. The kanban.js stall-escalation path remains unaffected and tracked on the same card for a follow-up PR.

## Changes
1. `backend/agent-improvement/heartbeat.js` — `ESCALATE_SEVERITIES = new Set(['P0','P1'])` + `allowsEscalation()` guard at classifyCard's escalate branch; SELECT now carries `c.priority`.
2. `backend/index.js:20118` — boot comment updated to reflect new behavior.
3. `backend/tests/jest/kanban-ooda-r-done-gate-v2.test.js` — added 1 new test for P2 stale → prompt_due; amended 2 existing escalate-path tests to include `priority:'P1'`.
4. `backend/package-lock.json` — incidental undici version bump from `npm test` (non-functional).

## Test plan
- [x] `npx jest --runTestsByPath backend/tests/jest/kanban-ooda-r-done-gate-v2.test.js` → 29/29 passing locally.
- [x] `git diff --check` clean.
- [ ] GitHub Actions full CI suite (ESLint / Jest / i18n / Railway preview)
- [ ] Admin-squash-merge after green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt7jNhQxvz1FkErAbyHneC