### PR TITLE
fix(channel): audit log for speakTo routing decisions (card_488f05)

### DIFF
--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -669,6 +669,11 @@ function channelApiModule(devices, { authMiddleware, serverLog, generateBotSecre
         try {
             const { channel_api_key, deviceId, entityId, botSecret, message, state, mediaType, mediaUrl, targetDeviceId, card, senderHint, aboutCardId } = req.body;
             let { speakTo, broadcast } = req.body;
+            // Snapshot original request routing values BEFORE @-mention / senderHint
+            // auto-fill mutates speakTo/broadcast. Used by the [Routing] audit log
+            // below to disambiguate chosenPath (card_488f05 — speakTo routing audit).
+            const _origSpeakTo = Array.isArray(speakTo) ? speakTo.slice() : (speakTo || null);
+            const _origBroadcast = !!broadcast;
             const suppressA2AForward = shouldSuppressA2A(req.body || {}, message);
 
             if (process.env.DEBUG === 'true') serverLog('info', 'client_push', `[PUSH] /channel/message called, state=${state}, hasMsg=${!!message}`, { deviceId, entityId: entityId !== undefined ? parseInt(entityId) : 'auto' });
@@ -977,6 +982,27 @@ function channelApiModule(devices, { authMiddleware, serverLog, generateBotSecre
                 if (speakTo && broadcast) {
                     warnings.push('Both speakTo and broadcast provided — broadcast takes priority, speakTo ignored.');
                 }
+
+                // ── [Routing] audit log (card_488f05) ──
+                // Single structured line per /channel/message delivery so we can grep
+                // production logs to reproduce the speakTo mis-routing bug. Captures
+                // the precedence branch that won (explicit body → text @-mention →
+                // senderHint fallback → broadcast). DO NOT add to inner per-target loops.
+                const _hadOrigSpeakTo = Array.isArray(_origSpeakTo) && _origSpeakTo.length > 0;
+                const _textMentionCount = transformMentionContext
+                    ? ((transformMentionContext.mentions && transformMentionContext.mentions.length) || 0) + (transformMentionContext.hasAll ? 1 : 0)
+                    : 0;
+                let _chosenPath;
+                if (_hadOrigSpeakTo) _chosenPath = 'explicit-speakTo';
+                else if (_origBroadcast) _chosenPath = 'broadcast';
+                else if (_textMentionCount > 0 && (broadcast || (Array.isArray(speakTo) && speakTo.length > 0))) _chosenPath = 'text-mention';
+                else if (senderHintResolution && (senderHintResolution.applied === 'speakTo' || senderHintResolution.applied === 'broadcast')) _chosenPath = 'senderHint-fallback';
+                else _chosenPath = broadcast ? 'broadcast' : 'explicit-speakTo';
+                const _finalRecipients = broadcast
+                    ? 'broadcast'
+                    : (Array.isArray(speakTo) ? speakTo.join(',') : String(speakTo || ''));
+                const _senderHintKind = senderHint && senderHint.kind ? senderHint.kind : 'none';
+                console.log(`[Routing] device=${String(deviceId || '').slice(0, 8)} entity=${eId} req.speakTo=${JSON.stringify(_origSpeakTo)} req.broadcast=${_origBroadcast} textMentions=${_textMentionCount} senderHint=${_senderHintKind} chosenPath=${_chosenPath} finalRecipients=${_finalRecipients}`);
 
                 const gkResult = gatekeeperCheckText ? gatekeeperCheckText(deviceId, eId, message, entity.botSecret) : { text: message };
                 const deliveryText = gkResult.text;

--- a/backend/tests/jest/channel-message-routing-audit-log.test.js
+++ b/backend/tests/jest/channel-message-routing-audit-log.test.js
@@ -1,0 +1,164 @@
+/**
+ * /api/channel/message — [Routing] audit log (card_488f05)
+ *
+ * Verifies the structured audit log emitted at the speakTo/broadcast delivery
+ * point in backend/channel-api.js. This log lets us reproduce the speakTo
+ * mis-routing bug (filed as card_488f05280caf518bba74144d) by grepping
+ * production logs for the chosenPath that won for each /channel/message call.
+ *
+ * Scope: observability ONLY. This PR does NOT change routing precedence;
+ * the existing test files (channel-message-mention-autorouter.test.js +
+ * channel-message-sender-hint.test.js) still own the precedence contract.
+ */
+
+require('./helpers/mock-setup');
+
+const db = require('../../db');
+const apiKey = 'eck_routing_audit_log_test';
+const account = { id: 1, channel_api_key: apiKey, channel_api_secret: 'ecs_test', deviceId: null, entityId: null };
+db.getChannelAccountByKey = jest.fn().mockImplementation(async (key) => key === apiKey ? account : null);
+db.getChannelAccountsByDevice = jest.fn().mockResolvedValue([]);
+db.createChannelAccount = jest.fn().mockResolvedValue(account);
+db.getChannelAccountById = jest.fn().mockResolvedValue(null);
+db.deleteChannelAccount = jest.fn().mockResolvedValue(true);
+db.updateChannelCallback = jest.fn().mockResolvedValue(true);
+db.updateChannelE2eeCapable = jest.fn().mockResolvedValue(true);
+db.clearChannelCallback = jest.fn().mockResolvedValue(true);
+db.getChannelAccountByDevice = jest.fn().mockResolvedValue(null);
+
+const request = require('supertest');
+let app;
+
+const post = (path) => request(app).post(path).set('Host', 'localhost');
+
+async function registerDevice(id) {
+    const secret = `secret-${id}`;
+    await post('/api/device/register').send({ deviceId: id, deviceSecret: secret, entityId: 0 });
+    return secret;
+}
+
+async function bindEntity(deviceId, deviceSecret, entityId = 0) {
+    const regRes = await post('/api/device/register').send({ deviceId, deviceSecret, entityId });
+    const code = regRes.body.bindingCode;
+    if (!code) return undefined;
+    const bindRes = await post('/api/bind').send({ code });
+    return bindRes.body.botSecret;
+}
+
+beforeAll(() => {
+    app = require('../../index');
+});
+
+afterAll(async () => {
+    const { httpServer } = require('../../index');
+    await new Promise(resolve => httpServer.close(resolve));
+});
+
+function captureRoutingLogs(spy) {
+    return spy.mock.calls
+        .map(args => (args && args[0]) || '')
+        .filter(s => typeof s === 'string' && s.startsWith('[Routing] '));
+}
+
+describe('POST /api/channel/message — [Routing] audit log (card_488f05)', () => {
+    let deviceId, deviceSecret, botSecret2, entity0Code, entity1Code;
+    let logSpy;
+
+    beforeAll(async () => {
+        // Long deviceId so we can verify the 8-char privacy mask
+        deviceId = 'audit-routing-device-xyz-very-long';
+        deviceSecret = await registerDevice(deviceId);
+        await bindEntity(deviceId, deviceSecret, 0);
+        await post('/api/device/add-entity').send({ deviceId, deviceSecret });
+        await bindEntity(deviceId, deviceSecret, 1);
+        await post('/api/device/add-entity').send({ deviceId, deviceSecret });
+        botSecret2 = await bindEntity(deviceId, deviceSecret, 2);
+
+        const { devices } = require('../../index');
+        entity0Code = devices[deviceId].entities[0].publicCode;
+        entity1Code = devices[deviceId].entities[1].publicCode;
+        expect(entity0Code).toBeTruthy();
+        expect(entity1Code).toBeTruthy();
+    });
+
+    beforeEach(() => {
+        logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        logSpy.mockRestore();
+    });
+
+    it('chosenPath=explicit-speakTo when body provides speakTo', async () => {
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 2, botSecret: botSecret2,
+            state: 'IDLE',
+            message: 'hello entity 1 via explicit speakTo',
+            speakTo: [entity1Code],
+        });
+        expect(res.status).toBe(200);
+
+        const logs = captureRoutingLogs(logSpy);
+        expect(logs).toHaveLength(1);
+        expect(logs[0]).toContain('chosenPath=explicit-speakTo');
+        expect(logs[0]).toContain(`entity=2`);
+        expect(logs[0]).toContain(`finalRecipients=${entity1Code}`);
+        // Privacy mask: only first 8 chars of deviceId leak
+        expect(logs[0]).toContain(`device=${deviceId.slice(0, 8)} `);
+        expect(logs[0]).not.toContain(deviceId);
+    });
+
+    it('chosenPath=text-mention when @#N fills speakTo (no explicit body)', async () => {
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 2, botSecret: botSecret2,
+            state: 'IDLE',
+            message: '@#1 hi from text mention',
+        });
+        expect(res.status).toBe(200);
+
+        const logs = captureRoutingLogs(logSpy);
+        expect(logs).toHaveLength(1);
+        expect(logs[0]).toContain('chosenPath=text-mention');
+        expect(logs[0]).toContain('textMentions=1');
+        expect(logs[0]).toContain('req.speakTo=null');
+        expect(logs[0]).toContain('req.broadcast=false');
+        expect(logs[0]).toContain(`finalRecipients=${entity1Code}`);
+    });
+
+    it('chosenPath=broadcast when body provides broadcast=true', async () => {
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 2, botSecret: botSecret2,
+            state: 'IDLE',
+            message: 'broadcast to everyone',
+            broadcast: true,
+        });
+        expect(res.status).toBe(200);
+
+        const logs = captureRoutingLogs(logSpy);
+        expect(logs).toHaveLength(1);
+        expect(logs[0]).toContain('chosenPath=broadcast');
+        expect(logs[0]).toContain('req.broadcast=true');
+        expect(logs[0]).toContain('finalRecipients=broadcast');
+    });
+
+    it('chosenPath=senderHint-fallback when only senderHint resolves the target', async () => {
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 2, botSecret: botSecret2,
+            state: 'IDLE',
+            message: 'reply with no @ or speakTo, senderHint only',
+            senderHint: { kind: 'entity', entityId: 0, publicCode: entity0Code },
+        });
+        expect(res.status).toBe(200);
+
+        const logs = captureRoutingLogs(logSpy);
+        expect(logs).toHaveLength(1);
+        expect(logs[0]).toContain('chosenPath=senderHint-fallback');
+        expect(logs[0]).toContain('senderHint=entity');
+        expect(logs[0]).toContain('textMentions=0');
+        expect(logs[0]).toContain(`finalRecipients=${entity0Code}`);
+    });
+});


### PR DESCRIPTION
## Summary
Adds a single structured `[Routing]` audit log line at the speakTo / broadcast delivery point in `POST /api/channel/message` so we can grep prod logs to reproduce the speakTo mis-routing bug filed as **card_488f05280caf518bba74144d**.

The bug: `backend/channel-api.js:794-804` mentionParser auto-resolves `@`-tokens in `text` to `speakTo` when the body has no explicit `speakTo`. This can mis-route messages whose text contains `@`-tokens that weren't intended as routing. Today there is no log line that tells us **which precedence branch fired** for a given /channel/message call, so we can't confirm reproductions from logs alone.

## What the log captures
```
[Routing] device=DEVICE_PFX entity=N req.speakTo=[...]|null req.broadcast=BOOL textMentions=K senderHint=KIND chosenPath=PATH finalRecipients=R
```
- `device`: first 8 chars of deviceId only (privacy mask)
- `req.speakTo` / `req.broadcast`: snapshot of the **original** body values, captured before the mentionParser/senderHint auto-fill blocks mutate `speakTo`/`broadcast`
- `chosenPath` ∈ `{explicit-speakTo, text-mention, senderHint-fallback, broadcast}`
- `finalRecipients`: comma-joined publicCodes, or the literal `broadcast`

## Scope guardrails
- **Observability only.** No change to routing precedence logic. Sister tests `channel-message-mention-autorouter` + `channel-message-sender-hint` still own the precedence contract — both run green unchanged.
- **No frontend / composer changes.** Tracked as separate P2 follow-up.
- **No inner-loop logging.** The log fires once per /channel/message call (same cardinality as the existing per-message `serverLog` calls), not per delivery target.
- **No change to backend/index.js `/api/transform`** — same class of bug there should be a sibling card.

## Test plan
- [x] `npx jest --runTestsByPath backend/tests/jest/channel-message-routing-audit-log.test.js --forceExit` → **4/4 green** (covers all four `chosenPath` branches via `console.log` spy + privacy-mask assertion)
- [x] `npx jest --runTestsByPath backend/tests/jest/channel-message-mention-autorouter.test.js backend/tests/jest/channel-message-sender-hint.test.js` → **15/15 green** (no regression in routing precedence)

## Files changed
- `backend/channel-api.js` — +31 lines (snapshot of orig values + audit log block inside delivery `if`)
- `backend/tests/jest/channel-message-routing-audit-log.test.js` — new, 159 lines

## Related card
card_488f05280caf518bba74144d  `[Bug/Platform/P0] speakTo 路由錯誤重現`

🤖 Generated with [Claude Code](https://claude.com/claude-code)