### PR TITLE
fix(kanban): severity-gate stall escalation — skip auto-block for P0, skip L2 for P3 backlog (card_22ab8c3b path #2)

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -3025,7 +3025,15 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
      * #1701: Three escalation levels:
      *   1. Nudge (>staleThreshold, default 3h) — system comment + notification
      *   2. Escalate (>6h) — auto-upgrade priority (P2→P1) + notify reviewer
+     *      Severity gate (card_22ab8c3b path #2, follow-up to PR #3564): a P3
+     *      card in `backlog` is a design-first draft awaiting launch — do NOT
+     *      auto-upgrade it to P2 just because it has been sitting. Returns
+     *      false so the card falls through to the L1 nudge path instead.
      *   3. Block (>12h) — move to blocked status + system comment
+     *      Severity gate (same card): a P0 card means "fix now, supervisor's
+     *      attention" — silently moving it to `blocked` hides it from the
+     *      active board. Instead fire a heightened L1 nudge with a P0-stalled
+     *      prefix + supervisor notification; state stays in_progress.
      * Also checks for orphaned rental bot assignments.
      */
     // Sort stale cards by user-chosen priority mode (see device_preferences.kanban_nudge_priority_mode).
@@ -3380,6 +3388,28 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
     async function fireBlockEscalation(card, recipientIds = null) {
         const elapsedHrs = Math.round((Date.now() - new Date(card.status_changed_at).getTime()) / 3600000 * 10) / 10;
         const recipients = Array.isArray(recipientIds) ? recipientIds : buildEscalationRecipients(card);
+        // Severity gate (card_22ab8c3b path #2, sibling of PR #3564):
+        // P0 cards are "fix now, supervisor's attention". Auto-moving them to
+        // `blocked` hides them from the active board and clears the in_progress
+        // queue, which is the opposite of what a P0 stall calls for. Instead
+        // fire a heightened L1 nudge with a P0-stalled prefix and notify the
+        // recipient set (including the supervisor reviewer). State is NOT
+        // changed; the card stays in its current column so it remains visible.
+        if (card.priority === 'P0') {
+            await addSystemComment(card.id, card.device_id,
+                `🚨 P0 stalled — 卡片已停滯 ${elapsedHrs} 小時，主管請介入（未自動 blocked，保留 in_progress 可視性）`);
+            await pool.query(
+                `UPDATE kanban_cards SET last_stale_nudge_at = NOW(), updated_at = NOW() WHERE id = $1`,
+                [card.id]
+            );
+            if (recipients.length > 0) {
+                notifyEntities(card.device_id, recipients,
+                    `🚨 P0 stalled 卡片「${card.title}」停滯 ${elapsedHrs}h，主管請介入`,
+                    { cardId: card.id });
+            }
+            if (serverLog) serverLog('warn', 'kanban', `[Stale] P0 card ${card.id} stalled ${elapsedHrs}h — heightened L1 (no auto-block)`, { deviceId: card.device_id });
+            return;
+        }
         await pool.query(
             `UPDATE kanban_cards SET status = 'blocked', status_changed_at = NOW(), last_stale_nudge_at = NOW(), updated_at = NOW() WHERE id = $1`,
             [card.id]
@@ -3397,6 +3427,11 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
     async function fireLevelTwoEscalation(card, recipientIds = null) {
         const elapsedHrs = Math.round((Date.now() - new Date(card.status_changed_at).getTime()) / 3600000 * 10) / 10;
         const recipients = Array.isArray(recipientIds) ? recipientIds : buildEscalationRecipients(card);
+        // Severity gate (card_22ab8c3b path #2): P3 cards in `backlog` are
+        // design-first drafts awaiting launch — they sit there on purpose and
+        // must NOT be silently bumped to P2 by clock alone. Skip L2; the L1
+        // nudge cadence still applies if the device opts backlog into nudges.
+        if (card.priority === 'P3' && card.status === 'backlog') return false;
         const PRIORITY_UPGRADE = { P3: 'P2', P2: 'P1', P1: 'P0', P0: 'P0' };
         const newPriority = PRIORITY_UPGRADE[card.priority] || card.priority;
         if (newPriority === card.priority) return false;

--- a/backend/tests/jest/kanban-stall-severity-gate.test.js
+++ b/backend/tests/jest/kanban-stall-severity-gate.test.js
@@ -1,0 +1,276 @@
+'use strict';
+
+/**
+ * Regression test — stall-escalation severity gate on backend/kanban.js
+ * (card_22ab8c3b80ae01b923ce73f7 path #2; sibling of PR #3564 which fixed
+ * backend/agent-improvement/heartbeat.js path #1).
+ *
+ * Two gates pinned here:
+ *   A. fireBlockEscalation — P0 cards must NOT be auto-moved to `blocked`.
+ *      Auto-blocking a P0 hides the highest-severity item from the active
+ *      board; instead we fire a heightened L1 nudge + supervisor notify and
+ *      leave status untouched.
+ *   B. fireLevelTwoEscalation — P3 + status='backlog' cards must NOT be
+ *      auto-upgraded to P2. These are design-first drafts awaiting launch;
+ *      a clock-based bump corrupts triage.
+ *
+ * Pre-existing PRIORITY_UPGRADE P0→P0 no-op stays intact.
+ *
+ * Mix of source-grep invariants (same style as kanban-stale-dep-gating /
+ * kanban-stale-skip-recurring) plus a Function-constructor behavioural
+ * smoke that exercises the gate branches end-to-end with a mock pool.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const kanbanSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'kanban.js'),
+    'utf8'
+);
+
+function extractFunctionBody(src, signature) {
+    const start = src.indexOf(signature);
+    if (start === -1) throw new Error(`function not found: ${signature}`);
+    const open = src.indexOf('{', start);
+    let depth = 0;
+    for (let i = open; i < src.length; i++) {
+        const ch = src[i];
+        if (ch === '{') depth++;
+        else if (ch === '}') {
+            depth--;
+            if (depth === 0) return src.slice(open, i + 1);
+        }
+    }
+    throw new Error(`unterminated function: ${signature}`);
+}
+
+describe('fireBlockEscalation — P0 severity gate (no auto-block)', () => {
+    const body = extractFunctionBody(
+        kanbanSrc,
+        'async function fireBlockEscalation(card, recipientIds = null)'
+    );
+
+    test('gate triggers on card.priority === \'P0\'', () => {
+        expect(body).toMatch(/card\.priority\s*===\s*'P0'/);
+    });
+
+    test('P0 branch does NOT issue UPDATE ... status = \'blocked\'', () => {
+        // The gate runs BEFORE the legacy UPDATE that flips status to 'blocked'.
+        const gateIdx = body.indexOf("card.priority === 'P0'");
+        const blockUpdateIdx = body.indexOf("status = 'blocked'");
+        expect(gateIdx).toBeGreaterThan(-1);
+        expect(blockUpdateIdx).toBeGreaterThan(-1);
+        expect(gateIdx).toBeLessThan(blockUpdateIdx);
+        // P0 branch returns before reaching the block-update.
+        const p0Slice = body.slice(gateIdx, blockUpdateIdx);
+        expect(p0Slice).toMatch(/return\s*;/);
+    });
+
+    test('P0 branch still records last_stale_nudge_at (so cadence dedupe works)', () => {
+        // Without this the heightened nudge would re-fire on every cron tick.
+        const gateIdx = body.indexOf("card.priority === 'P0'");
+        const returnIdx = body.indexOf('return;', gateIdx);
+        const p0Slice = body.slice(gateIdx, returnIdx);
+        expect(p0Slice).toMatch(/last_stale_nudge_at\s*=\s*NOW\(\)/);
+    });
+
+    test('P0 branch surfaces a \'P0 stalled\' system comment + notify', () => {
+        const gateIdx = body.indexOf("card.priority === 'P0'");
+        const returnIdx = body.indexOf('return;', gateIdx);
+        const p0Slice = body.slice(gateIdx, returnIdx);
+        expect(p0Slice).toMatch(/P0 stalled/);
+        expect(p0Slice).toMatch(/addSystemComment/);
+        expect(p0Slice).toMatch(/notifyEntities/);
+    });
+
+    test('non-P0 path preserved: still updates status to \'blocked\'', () => {
+        // Defense-in-depth — make sure the refactor didn't accidentally kill
+        // the original P1/P2/P3 auto-block behavior.
+        expect(body).toMatch(/UPDATE kanban_cards SET status = 'blocked'/);
+    });
+});
+
+describe('fireLevelTwoEscalation — P3 backlog gate (no auto-bump)', () => {
+    const body = extractFunctionBody(
+        kanbanSrc,
+        'async function fireLevelTwoEscalation(card, recipientIds = null)'
+    );
+
+    test('gate triggers on priority === \'P3\' && status === \'backlog\'', () => {
+        expect(body).toMatch(
+            /card\.priority\s*===\s*'P3'\s*&&\s*card\.status\s*===\s*'backlog'\s*\)\s*return\s+false/
+        );
+    });
+
+    test('gate runs BEFORE PRIORITY_UPGRADE lookup', () => {
+        const gateIdx = body.indexOf("card.priority === 'P3'");
+        const upgradeIdx = body.indexOf('PRIORITY_UPGRADE');
+        expect(gateIdx).toBeGreaterThan(-1);
+        expect(upgradeIdx).toBeGreaterThan(-1);
+        expect(gateIdx).toBeLessThan(upgradeIdx);
+    });
+
+    test('existing P0→P0 no-op still present (PRIORITY_UPGRADE table unchanged)', () => {
+        expect(body).toMatch(/PRIORITY_UPGRADE\s*=\s*\{[^}]*P0:\s*'P0'/);
+        expect(body).toMatch(/if \(newPriority === card\.priority\) return false/);
+    });
+});
+
+describe('fireBlockEscalation + fireLevelTwoEscalation — behavioural smoke', () => {
+    // Reconstruct the functions in isolation by capturing their bodies and
+    // wiring synthetic pool/addSystemComment/notifyEntities/serverLog stubs.
+    const blockSrc = extractFunctionBody(
+        kanbanSrc,
+        'async function fireBlockEscalation(card, recipientIds = null)'
+    );
+    const l2Src = extractFunctionBody(
+        kanbanSrc,
+        'async function fireLevelTwoEscalation(card, recipientIds = null)'
+    );
+
+    const makeBlock = (deps) =>
+        // eslint-disable-next-line no-new-func
+        new Function(
+            'pool', 'addSystemComment', 'notifyEntities', 'serverLog', 'buildEscalationRecipients',
+            `return async function fireBlockEscalation(card, recipientIds = null) ${blockSrc}`
+        )(deps.pool, deps.addSystemComment, deps.notifyEntities, deps.serverLog, deps.buildEscalationRecipients);
+
+    const makeL2 = (deps) =>
+        // eslint-disable-next-line no-new-func
+        new Function(
+            'pool', 'addSystemComment', 'notifyEntities', 'serverLog', 'buildEscalationRecipients', 'require',
+            `return async function fireLevelTwoEscalation(card, recipientIds = null) ${l2Src}`
+        )(deps.pool, deps.addSystemComment, deps.notifyEntities, deps.serverLog, deps.buildEscalationRecipients,
+          () => ({ incrementCounter: () => {} }));
+
+    function makeDeps() {
+        const queries = [];
+        const comments = [];
+        const notifies = [];
+        return {
+            queries, comments, notifies,
+            pool: { query: async (sql, params) => { queries.push({ sql, params }); return { rows: [] }; } },
+            addSystemComment: async (cardId, deviceId, text) => { comments.push({ cardId, deviceId, text }); },
+            notifyEntities: (deviceId, recipients, msg, extra) => { notifies.push({ deviceId, recipients, msg, extra }); },
+            serverLog: () => {},
+            buildEscalationRecipients: () => [],
+        };
+    }
+
+    function makeCard(overrides) {
+        const thirteenHoursAgo = new Date(Date.now() - 13 * 3600 * 1000).toISOString();
+        return {
+            id: 'card_test_x',
+            device_id: 'dev1',
+            title: 'test card',
+            priority: 'P2',
+            status: 'in_progress',
+            status_changed_at: thirteenHoursAgo,
+            ...overrides,
+        };
+    }
+
+    test('P0 in_progress 13h elapsed → no auto-block, heightened L1 fires (recipients notified)', async () => {
+        const deps = makeDeps();
+        const fn = makeBlock(deps);
+        const card = makeCard({ priority: 'P0' });
+        await fn(card, [1, 2]);
+        // No status='blocked' UPDATE.
+        const blockUpdates = deps.queries.filter(q => /status = 'blocked'/.test(q.sql));
+        expect(blockUpdates.length).toBe(0);
+        // last_stale_nudge_at is recorded (cadence dedupe).
+        const nudgeUpdates = deps.queries.filter(q => /last_stale_nudge_at\s*=\s*NOW\(\)/.test(q.sql));
+        expect(nudgeUpdates.length).toBe(1);
+        // System comment carries the P0-stalled prefix.
+        expect(deps.comments.length).toBe(1);
+        expect(deps.comments[0].text).toMatch(/P0 stalled/);
+        // Supervisor / assignees notified.
+        expect(deps.notifies.length).toBe(1);
+        expect(deps.notifies[0].recipients).toEqual([1, 2]);
+    });
+
+    test('P2 in_progress 13h elapsed → auto-block fires (no regression)', async () => {
+        const deps = makeDeps();
+        const fn = makeBlock(deps);
+        const card = makeCard({ priority: 'P2' });
+        await fn(card, [3]);
+        const blockUpdates = deps.queries.filter(q => /status = 'blocked'/.test(q.sql));
+        expect(blockUpdates.length).toBe(1);
+        expect(deps.comments[0].text).toMatch(/自動封鎖/);
+    });
+
+    test('P1 in_progress 13h elapsed → auto-block fires (no regression)', async () => {
+        const deps = makeDeps();
+        const fn = makeBlock(deps);
+        const card = makeCard({ priority: 'P1' });
+        await fn(card, [4]);
+        const blockUpdates = deps.queries.filter(q => /status = 'blocked'/.test(q.sql));
+        expect(blockUpdates.length).toBe(1);
+    });
+
+    test('P3 backlog 7h elapsed → fireLevelTwoEscalation returns false (no priority change)', async () => {
+        const deps = makeDeps();
+        const fn = makeL2(deps);
+        const sevenHoursAgo = new Date(Date.now() - 7 * 3600 * 1000).toISOString();
+        const card = makeCard({
+            priority: 'P3',
+            status: 'backlog',
+            status_changed_at: sevenHoursAgo,
+        });
+        const fired = await fn(card, [5]);
+        expect(fired).toBe(false);
+        // No UPDATE on kanban_cards.
+        expect(deps.queries.length).toBe(0);
+        // No system comment, no notify.
+        expect(deps.comments.length).toBe(0);
+        expect(deps.notifies.length).toBe(0);
+    });
+
+    test('P3 in_progress 7h elapsed → P3→P2 upgrade still fires (gate is backlog-only)', async () => {
+        const deps = makeDeps();
+        const fn = makeL2(deps);
+        const sevenHoursAgo = new Date(Date.now() - 7 * 3600 * 1000).toISOString();
+        const card = makeCard({
+            priority: 'P3',
+            status: 'in_progress',
+            status_changed_at: sevenHoursAgo,
+        });
+        const fired = await fn(card, [6]);
+        expect(fired).toBe(true);
+        const upgradeUpdates = deps.queries.filter(q => /SET priority =/.test(q.sql));
+        expect(upgradeUpdates.length).toBe(1);
+        expect(upgradeUpdates[0].params[0]).toBe('P2');
+    });
+
+    test('P2 in_progress 7h elapsed → P2→P1 upgrade still fires (no regression)', async () => {
+        const deps = makeDeps();
+        const fn = makeL2(deps);
+        const sevenHoursAgo = new Date(Date.now() - 7 * 3600 * 1000).toISOString();
+        const card = makeCard({
+            priority: 'P2',
+            status: 'in_progress',
+            status_changed_at: sevenHoursAgo,
+        });
+        const fired = await fn(card, [7]);
+        expect(fired).toBe(true);
+        const upgradeUpdates = deps.queries.filter(q => /SET priority =/.test(q.sql));
+        expect(upgradeUpdates[0].params[0]).toBe('P1');
+    });
+
+    test('P0 at L2 → still no-op (existing PRIORITY_UPGRADE P0→P0 preserved)', async () => {
+        const deps = makeDeps();
+        const fn = makeL2(deps);
+        const sevenHoursAgo = new Date(Date.now() - 7 * 3600 * 1000).toISOString();
+        const card = makeCard({
+            priority: 'P0',
+            status: 'in_progress',
+            status_changed_at: sevenHoursAgo,
+        });
+        const fired = await fn(card, [8]);
+        expect(fired).toBe(false);
+        // No UPDATE on kanban_cards.
+        const upgradeUpdates = deps.queries.filter(q => /SET priority =/.test(q.sql));
+        expect(upgradeUpdates.length).toBe(0);
+    });
+});


### PR DESCRIPTION
## Summary
- Sibling of [#3564](https://github.com/HankHuang0516/EClaw/pull/3564) — completes severity-gating for the second stall-escalation path that card `card_22ab8c3b80ae01b923ce73f7` flagged.
- `backend/kanban.js` `fireBlockEscalation` no longer auto-moves **P0** stalls to `blocked`; instead it fires a heightened L1 nudge (`🚨 P0 stalled` prefix) and notifies the supervisor recipient set. State stays `in_progress` so the card remains visible on the active board.
- `backend/kanban.js` `fireLevelTwoEscalation` skips when `priority === 'P3' && status === 'backlog'`. Design-first backlog drafts must not be clock-bumped to P2.
- Existing P0→P0 `PRIORITY_UPGRADE` no-op preserved; non-P0 auto-block path and P1/P2/P3 (non-backlog) L2 upgrade path unchanged.

## Card
`card_22ab8c3b80ae01b923ce73f7` — [Bug/Infra/P2] Stall-escalation cron lacks severity gate. PR #3564 fixed path #1 (`backend/agent-improvement/heartbeat.js`). This PR fixes path #2 (`backend/kanban.js:3217-3236` and the two fire fns at L3380/L3397). Both paths now severity-aware.

## Changes
1. `backend/kanban.js`
   - `fireBlockEscalation`: P0 early-return branch (heightened L1 + supervisor notify + `last_stale_nudge_at = NOW()` for cadence dedupe).
   - `fireLevelTwoEscalation`: P3-backlog early-return with `return false` (so call site treats it as not-fired, lets the L1 path take over).
   - Doc comment block ("Three escalation levels") updated to call out both gates.
2. `backend/tests/jest/kanban-stall-severity-gate.test.js` (new)
   - 15 tests: 9 source-grep invariants + 7 behavioural smokes via `new Function` capture of the two fns with a stub pool/comment/notify layer.

## Diff size
- `backend/kanban.js`: +35 / -0 (well under the 120-line cap)
- new test file: +276 lines

## Test plan
- [x] `npx jest --runTestsByPath backend/tests/jest/kanban-stall-severity-gate.test.js` → **15/15 pass**
- [x] `npx jest --runTestsByPath backend/tests/jest/kanban-stale-dep-gating.test.js backend/tests/jest/kanban-stale-skip-recurring.test.js backend/tests/jest/kanban-nudge-stop-mode.test.js backend/tests/jest/kanban-ooda-r-done-gate-v2.test.js` → **58/58 pass** (no regression)
- [x] `git grep -l 'fireBlockEscalation\|fireLevelTwoEscalation' backend/tests/` — all 3 hits covered above
- [ ] GitHub Actions full CI (ESLint / Jest / i18n / Railway preview)
- [ ] Admin-squash-merge after green

## Behaviour matrix
| priority × status × elapsed | before this PR | after this PR |
|---|---|---|
| P0 × in_progress × >12h | auto-`blocked` (hidden) | stays `in_progress` + 🚨 P0 stalled nudge + supervisor notify |
| P1/P2 × in_progress × >12h | auto-`blocked` | auto-`blocked` (unchanged) |
| P3 × backlog × >6h | auto-bump P3→P2 | stays P3 (no L2 fired; L1 still applies) |
| P3 × in_progress × >6h | auto-bump P3→P2 | auto-bump P3→P2 (unchanged) |
| P0 × any × >6h | L2 no-op (P0→P0) | L2 no-op (unchanged) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt7jNhQxvz1FkErAbyHneC