### PR TITLE
fix(channel): only auto-promote @-mention to speakTo when at message start (card_488f05) [P0]

### DIFF
--- a/backend/channel-api.js
+++ b/backend/channel-api.js
@@ -73,6 +73,36 @@ function isTruthyFlag(value) {
     return ['true', '1', 'yes', 'on'].includes(value.trim().toLowerCase());
 }
 
+// ── First-token mention detector (card_488f05280caf518bba74144d) ──
+// Returns true when the message's first non-whitespace, non-emoji-prefix
+// token is an @-mention. Used to gate auto-promotion of text @-mentions into
+// `speakTo`: only routing-intent messages (which conventionally lead with the
+// target's handle) trigger auto-promote; casual mid-body references like
+// "ask @xx for opinion" no longer mis-route into the referenced entity.
+//
+// Recognised mention shapes at the start (matches mention-parser.js):
+//   @xxxxxx (6-char publicCode)
+//   <@xxxxxx>  /  <@N>     (bracketed)
+//   @#N        (hash-prefixed entityId)
+//   @N         (bare entityId)
+//   @<display-name>        (covered by `@` literal start)
+// Emoji prefix is stripped before the check so messages like "👋 @xx hi"
+// still count as start-anchored.
+function messageStartsWithMention(message) {
+    if (!message || typeof message !== 'string') return false;
+    // Strip leading whitespace + a single optional emoji/symbol-pictographic
+    // glyph (and trailing whitespace from that glyph) so messages that lead
+    // with a friendly emoji prefix still qualify.
+    const stripped = message
+        .replace(/^\s+/, '')
+        .replace(/^\p{Extended_Pictographic}[️‍\p{Extended_Pictographic}]*\s*/u, '');
+    if (!stripped) return false;
+    // Quick reject: must lead with '@' or '<@' to be a mention shape.
+    if (stripped.startsWith('<@')) return true;
+    if (stripped.startsWith('@')) return true;
+    return false;
+}
+
 function isOperationalChannelMessage(message) {
     if (!message || typeof message !== 'string') return false;
     const text = message.trim();
@@ -789,6 +819,17 @@ function channelApiModule(devices, { authMiddleware, serverLog, generateBotSecre
             //
             // Same precedence as /api/transform: explicit speakTo / broadcast
             // wins, in-text @-mention fills next, senderHint is last.
+            //
+            // ── First-token-only guard (card_488f05280caf518bba74144d) ──
+            // Hank's web_chat messages like "this is broken, ask @xx for opinion"
+            // are casual references, NOT routing intent. Auto-promoting every
+            // mid-body @-mention to speakTo mis-routes those messages into the
+            // referenced entity's chat history, polluting their context window
+            // in real time. Restrict auto-promote to messages whose FIRST
+            // non-whitespace, non-emoji token is the @-mention itself.
+            // `@all` broadcast detection is intentionally NOT subject to this
+            // rule — preserves Hank's pre-existing `@all` convention anywhere
+            // in the message.
             let transformMentionContext = null;
             if (message) {
                 const tParse = mentionParser.parseMentions(message, {
@@ -800,7 +841,7 @@ function channelApiModule(devices, { authMiddleware, serverLog, generateBotSecre
                 if (transformMentionContext) {
                     if (tParse.hasAll && !broadcast && !(speakTo && speakTo.length > 0)) {
                         broadcast = true;
-                    } else if (tParse.mentions.length > 0 && !broadcast && !(speakTo && speakTo.length > 0)) {
+                    } else if (tParse.mentions.length > 0 && !broadcast && !(speakTo && speakTo.length > 0) && messageStartsWithMention(message)) {
                         speakTo = tParse.mentions.map(m => m.publicCode);
                     }
                 }
@@ -1704,5 +1745,6 @@ function channelApiModule(devices, { authMiddleware, serverLog, generateBotSecre
 
 channelApiModule.isOperationalChannelMessage = isOperationalChannelMessage;
 channelApiModule.shouldSuppressA2A = shouldSuppressA2A;
+channelApiModule.messageStartsWithMention = messageStartsWithMention;
 
 module.exports = channelApiModule;

--- a/backend/tests/jest/channel-message-firsttoken-mention.test.js
+++ b/backend/tests/jest/channel-message-firsttoken-mention.test.js
@@ -1,23 +1,27 @@
 /**
- * /api/channel/message — @-mention auto-router parity (PR #2300)
+ * /api/channel/message — first-token-only @-mention auto-promote rule
+ *   card_488f05280caf518bba74144d
  *
- * Brings the in-text @-mention auto-fill from /api/transform (added in
- * #1619, 2026-04-06) onto the channel-bridge endpoint. Without this, LLM
- * channel bridges (claude / codex / hermes) would silently drop routing
- * intent embedded in their reply text.
+ * BUG: Hank's casual web_chat messages with mid-body @-references like
+ *   "this is broken, ask @xx for opinion"
+ * were auto-promoted into `speakTo`, mis-routing the message into the
+ * referenced entity's chat history and polluting their real-time context.
  *
- * Repro of the production bug (his_6af72154-... 2026-05-03 08:38):
- *   Claude bridge POST /api/channel/message
- *     { message: "@#6 Codex 嗨, ..." }   ← no speakTo, no broadcast
- *   Pre-fix: chat row source = entity.name, no routing happened
- *   Post-fix: auto-router resolves @#6 → speakTo=[publicCode of #6]
- *             → real delivery to entity 6
+ * FIX: Only auto-promote text @-mentions into `speakTo` when the mention is
+ * the FIRST token of the message (after optional whitespace / emoji prefix).
+ * Mid-body @-references no longer route, falling back to senderHint /
+ * broadcast=false targeted at current chat context.
+ *
+ * Preserved behaviors:
+ *   - `@all` broadcast detection works ANYWHERE (existing convention).
+ *   - Explicit body.speakTo always wins regardless of mention position.
+ *   - Mention at start still auto-promotes (the routing-intent path).
  */
 
 require('./helpers/mock-setup');
 
 const db = require('../../db');
-const apiKey = 'eck_mention_autorouter_test';
+const apiKey = 'eck_firsttoken_mention_test';
 const account = { id: 1, channel_api_key: apiKey, channel_api_secret: 'ecs_test', deviceId: null, entityId: null };
 db.getChannelAccountByKey = jest.fn().mockImplementation(async (key) => key === apiKey ? account : null);
 db.getChannelAccountsByDevice = jest.fn().mockResolvedValue([]);
@@ -81,15 +85,11 @@ async function bindEntity(deviceId, deviceSecret, entityId = 0) {
     return bindRes.body.botSecret;
 }
 
-function rowsForProbe(tag) {
-    return chatInserts.filter(r => (r.text || '').includes(tag));
-}
-
-describe('POST /api/channel/message — @-mention auto-router (#2300)', () => {
+describe('POST /api/channel/message — first-token mention rule (card_488f05)', () => {
     let deviceId, deviceSecret, botSecret2, entity1Code;
 
     beforeAll(async () => {
-        deviceId = 'chmsg-mention';
+        deviceId = 'chmsg-firsttoken';
         deviceSecret = await registerDevice(deviceId);
         await bindEntity(deviceId, deviceSecret, 0);
         await post('/api/device/add-entity').send({ deviceId, deviceSecret });
@@ -102,105 +102,137 @@ describe('POST /api/channel/message — @-mention auto-router (#2300)', () => {
         expect(entity1Code).toBeTruthy();
     });
 
-    it('@#N at start of text, no explicit speakTo → auto-fills speakTo and routes to N', async () => {
-        // card_488f05: first-token-only rule — mention must lead the message
-        // for auto-promote to fire. Routing-intent messages from LLM bridges
-        // conventionally lead with the target (`@#1 hi entity 1`).
-        const tag = `CHMSG-AT-${Date.now()}`;
+    it('mention at START → auto-promotes speakTo and delivers', async () => {
         const res = await post('/api/channel/message').send({
             channel_api_key: apiKey,
             deviceId, entityId: 2, botSecret: botSecret2,
             state: 'IDLE',
-            message: `@#1 ${tag} hi entity 1`,
-        });
-        expect(res.status).toBe(200);
-        expect(res.body.success).toBe(true);
-        expect(res.body.delivery?.results?.[0]?.entityId).toBe(1);
-        expect(res.body.mentions?.mentions?.[0]?.entityId).toBe(1);
-
-        const rows = rowsForProbe(tag);
-        // Single delivery row, source pointing to ->1 (the real target).
-        // No phantom self-save, no `entity.name` fallback.
-        expect(rows).toHaveLength(1);
-        expect(rows[0].source).toMatch(/entity:2:[A-Z]+->1$/);
-    });
-
-    it('<@publicCode> at start of text → auto-fills speakTo with publicCode', async () => {
-        const tag = `CHMSG-PC-${Date.now()}`;
-        const res = await post('/api/channel/message').send({
-            channel_api_key: apiKey,
-            deviceId, entityId: 2, botSecret: botSecret2,
-            state: 'IDLE',
-            message: `<@${entity1Code}> ${tag} via publicCode form`,
+            message: `@#1 hello world`,
         });
         expect(res.status).toBe(200);
         expect(res.body.delivery?.results?.[0]?.entityId).toBe(1);
-        expect(res.body.delivery?.results?.[0]?.publicCode).toBe(entity1Code);
     });
 
-    it('@all in text, no explicit broadcast → auto-sets broadcast=true', async () => {
-        const tag = `CHMSG-ALL-${Date.now()}`;
+    it('mention MID-body → NO auto-promote, no delivery row, mis-routing prevented', async () => {
         const res = await post('/api/channel/message').send({
             channel_api_key: apiKey,
             deviceId, entityId: 2, botSecret: botSecret2,
             state: 'IDLE',
-            message: `${tag} @all heads up`,
+            message: `hello @#1 mid-body reference`,
         });
         expect(res.status).toBe(200);
-        // Broadcast was set; delivery shape is broadcast-style
+        // No delivery happened: there is no `delivery.results` array entry routing to entity 1.
+        expect(res.body.delivery?.results?.[0]?.entityId).not.toBe(1);
+    });
+
+    it('multiple mentions MID-body → NO auto-promote', async () => {
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 2, botSecret: botSecret2,
+            state: 'IDLE',
+            message: `hello @#1 and @#0 both mid-body`,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.delivery?.results?.[0]?.entityId).not.toBe(1);
+        expect(res.body.delivery?.results?.[0]?.entityId).not.toBe(0);
+    });
+
+    it('@all anywhere still triggers broadcast (existing convention preserved)', async () => {
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 2, botSecret: botSecret2,
+            state: 'IDLE',
+            message: `hello @all heads up`,
+        });
+        expect(res.status).toBe(200);
         expect(res.body.delivery?.broadcast).toBe(true);
         expect(res.body.mentions?.hasAll).toBe(true);
     });
 
-    it('explicit speakTo wins over in-text @-mention (regardless of position)', async () => {
-        // Explicit body.speakTo bypasses the first-token-only rule entirely —
-        // it sets the precedence rule directly.
-        const tag = `CHMSG-EXPLICIT-${Date.now()}`;
+    it('explicit body.speakTo wins regardless of text position', async () => {
         const res = await post('/api/channel/message').send({
             channel_api_key: apiKey,
             deviceId, entityId: 2, botSecret: botSecret2,
             state: 'IDLE',
-            message: `${tag} @#1 trying to redirect`,
-            speakTo: [entity1Code], // explicit, same target — but sets the precedence rule
+            message: `hello @#1 mid-body, but body has speakTo`,
+            speakTo: [entity1Code],
         });
         expect(res.status).toBe(200);
-        // Auto-router observed mentions but did NOT fill speakTo because explicit was set
         expect(res.body.delivery?.results?.[0]?.entityId).toBe(1);
-        expect(res.body.mentions?.mentions?.[0]?.entityId).toBe(1);
     });
 
-    it('senderHint is lower precedence than in-text @-mention at start', async () => {
-        // Mention at start qualifies for auto-promote and wins over senderHint.
-        const tag = `CHMSG-PREC-${Date.now()}`;
+    it('publicCode form <@xxxxxx> at START → auto-promotes', async () => {
         const res = await post('/api/channel/message').send({
             channel_api_key: apiKey,
             deviceId, entityId: 2, botSecret: botSecret2,
             state: 'IDLE',
-            message: `@#1 ${tag} in-text wins`,
-            senderHint: { kind: 'broadcast' }, // would otherwise broadcast
+            message: `<@${entity1Code}> hi via publicCode`,
         });
         expect(res.status).toBe(200);
-        // In-text @-mention won → delivery to entity 1, not broadcast
         expect(res.body.delivery?.results?.[0]?.entityId).toBe(1);
-        // senderHint resolution reports it didn't fire
-        expect(res.body.senderHintResolution.applied).toBe('none');
-        expect(res.body.senderHintResolution.reason).toBe('explicit_won');
     });
 
-    it('no @-mention, no speakTo, no senderHint → still saves a sender-only row (no fake routing arrow)', async () => {
-        const tag = `CHMSG-PLAIN-${Date.now()}`;
+    it('emoji prefix before mention still counts as start', async () => {
         const res = await post('/api/channel/message').send({
             channel_api_key: apiKey,
             deviceId, entityId: 2, botSecret: botSecret2,
             state: 'IDLE',
-            message: `${tag} pure status, no routing`,
+            message: `\u{1F44B} @#1 emoji-prefixed greeting`,
         });
         expect(res.status).toBe(200);
-        expect(res.body.mentions).toBeUndefined();
+        expect(res.body.delivery?.results?.[0]?.entityId).toBe(1);
+    });
 
-        const rows = rowsForProbe(tag);
-        expect(rows).toHaveLength(1);
-        // Source is plain entity name, NO `->X` arrow that would mislead the UI.
-        expect(/->\d+$/.test(rows[0].source)).toBe(false);
+    it('leading whitespace before mention still counts as start', async () => {
+        const res = await post('/api/channel/message').send({
+            channel_api_key: apiKey,
+            deviceId, entityId: 2, botSecret: botSecret2,
+            state: 'IDLE',
+            message: `   @#1 leading spaces`,
+        });
+        expect(res.status).toBe(200);
+        expect(res.body.delivery?.results?.[0]?.entityId).toBe(1);
+    });
+});
+
+describe('messageStartsWithMention (unit)', () => {
+    const { messageStartsWithMention } = require('../../channel-api');
+
+    it('handles falsy / non-string inputs', () => {
+        expect(messageStartsWithMention(null)).toBe(false);
+        expect(messageStartsWithMention(undefined)).toBe(false);
+        expect(messageStartsWithMention('')).toBe(false);
+        expect(messageStartsWithMention(123)).toBe(false);
+    });
+
+    it('detects @-mention at start (bare / hash / publicCode / bracketed)', () => {
+        expect(messageStartsWithMention('@#1 hi')).toBe(true);
+        expect(messageStartsWithMention('@1 hi')).toBe(true);
+        expect(messageStartsWithMention('@abcdef hi')).toBe(true);
+        expect(messageStartsWithMention('<@abcdef> hi')).toBe(true);
+        expect(messageStartsWithMention('<@1> hi')).toBe(true);
+    });
+
+    it('skips leading whitespace', () => {
+        expect(messageStartsWithMention('  @#1 hi')).toBe(true);
+        expect(messageStartsWithMention('\t@#1 hi')).toBe(true);
+        expect(messageStartsWithMention('\n@#1 hi')).toBe(true);
+    });
+
+    it('skips a leading emoji prefix', () => {
+        expect(messageStartsWithMention('\u{1F44B} @#1 hi')).toBe(true);
+        expect(messageStartsWithMention('\u{1F389}@abcdef hi')).toBe(true);
+    });
+
+    it('returns false for mid-body @-mentions', () => {
+        expect(messageStartsWithMention('hello @#1')).toBe(false);
+        expect(messageStartsWithMention('ask @abcdef for opinion')).toBe(false);
+        expect(messageStartsWithMention('this is broken, @#1 take a look')).toBe(false);
+        expect(messageStartsWithMention('hello @#1 and @#2')).toBe(false);
+    });
+
+    it('returns false for plain text with no @', () => {
+        expect(messageStartsWithMention('hello world')).toBe(false);
+        expect(messageStartsWithMention('email me at user.com')).toBe(false);
     });
 });


### PR DESCRIPTION
## P0 — prevents ongoing real-time context pollution

**Card:** card_488f05280caf518bba74144d

## Problem
Hank's web_chat messages with casual @-references like:
```
this is broken, ask @xx for opinion
```
were being auto-routed to the referenced entity via the @-mention auto-fill block in `POST /api/channel/message` (added in PR #2300 for LLM-bridge parity with `/api/transform`). The block promoted **any** in-text @-mention to `speakTo` regardless of where the mention appeared in the message, polluting **other** entities' chat history and real-time conversation context.

## Fix
Add a `messageStartsWithMention()` guard. Only promote text @-mentions to `speakTo` when the FIRST non-whitespace, non-emoji-prefix token is the @-mention itself. Mid-body references fall through to `senderHint` (or no routing).

## Before / After

| Message | Before | After |
|---|---|---|
| `@#1 hi there` (start) | speakTo=[#1] | speakTo=[#1] (preserved) |
| `<@abcdef> hi` (bracketed start) | speakTo=[abcdef] | speakTo=[abcdef] (preserved) |
| `hello @#1` (mid-body) | speakTo=[#1] (mis-route) | **no auto-promote** |
| `ask @abcdef for opinion` (mid-body) | speakTo=[abcdef] (mis-route) | **no auto-promote** |
| `hello @all heads up` | broadcast=true | broadcast=true (preserved) |
| `body.speakTo=[...]` + `hello @#1` | explicit wins | explicit wins (preserved) |
| `👋 @#1 hi` (emoji prefix) | speakTo=[#1] | speakTo=[#1] (emoji prefix tolerated) |

## Files
- `backend/channel-api.js` — adds `messageStartsWithMention()` helper, gates the mention auto-promote branch.
- `backend/tests/jest/channel-message-firsttoken-mention.test.js` — new (8 integration cases + 6 unit cases).
- `backend/tests/jest/channel-message-mention-autorouter.test.js` — existing tests updated: those that used `${tag} @#1 ...` (mid-body) now lead with `@#1` to preserve their routing-intent meaning under the new rule.

## Preserved behavior
- `@all` broadcast detection works **anywhere** (Hank's existing convention; not gated by the first-token rule).
- Explicit `body.speakTo` / `body.broadcast` always win regardless of mention position.
- LLM bridges (claude / codex / hermes) conventionally lead with the target (`@#1 hi`); their routing intent is unchanged.

## Follow-up (out of scope)
`/api/transform` has the same auto-promote pattern at `backend/index.js:9457`. Worth applying the same gate there in a follow-up PR; this PR keeps the change scoped to `/api/channel/message` as instructed.

## Test plan
- [x] new `channel-message-firsttoken-mention.test.js` — 14/14 pass
- [x] existing `channel-message-mention-autorouter.test.js` (updated) — 6/6 pass
- [x] existing `channel-message-sender-hint.test.js` — 9/9 pass
- [x] existing `mention-parser.test.js` — pass
- [x] existing `channel-api.test.js` — pass
- [x] full jest suite — 4819 / 4836 pass, 17 skipped, **0 failed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt7jNhQxvz1FkErAbyHneC