### PR TITLE
feat(wallpaper): T1 random wander engine + Settings toggle (card_bf8fd536)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
@@ -102,6 +102,8 @@ class SettingsActivity : AppCompatActivity() {
     private lateinit var chipLangTh: Chip
     private lateinit var chipLangVi: Chip
     private lateinit var chipLangId: Chip
+    private lateinit var switchWallpaperWalking: MaterialSwitch
+    private lateinit var btnWallpaperWalkingHelp: TextView
     private lateinit var btnSetWallpaper: MaterialButton
     private lateinit var btnDebugEntityLimit: MaterialButton
     private lateinit var topBar: LinearLayout
@@ -142,6 +144,7 @@ class SettingsActivity : AppCompatActivity() {
     private var isChannelApiExpanded = false
     private var channelApiSecretVisible = false
     private var cachedChannelSecret: String? = null
+    private var syncingWallpaperWalkingSwitch = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -207,6 +210,7 @@ class SettingsActivity : AppCompatActivity() {
         updateEntityCount()
         loadAccountStatus()
         updateCrashLogBadge()
+        updateWallpaperWalkingSwitch()
     }
 
     override fun onPause() {
@@ -234,6 +238,9 @@ class SettingsActivity : AppCompatActivity() {
         chipLangTh = findViewById(R.id.chipLangTh)
         chipLangVi = findViewById(R.id.chipLangVi)
         chipLangId = findViewById(R.id.chipLangId)
+        switchWallpaperWalking = findViewById(R.id.switchWallpaperWalking)
+        btnWallpaperWalkingHelp = findViewById(R.id.btnWallpaperWalkingHelp)
+        switchWallpaperWalking.isChecked = layoutPrefs.wallpaperWalkingEnabled
         topBar = findViewById(R.id.topBar)
         btnSetWallpaper = findViewById(R.id.btnSetWallpaper)
         tvEntityCount = findViewById(R.id.tvEntityCount)
@@ -329,6 +336,24 @@ class SettingsActivity : AppCompatActivity() {
 
         btnSetWallpaper.setOnClickListener {
             startActivity(Intent(this, WallpaperPreviewActivity::class.java))
+        }
+
+        switchWallpaperWalking.setOnCheckedChangeListener { _, isChecked ->
+            if (syncingWallpaperWalkingSwitch) return@setOnCheckedChangeListener
+            layoutPrefs.wallpaperWalkingEnabled = isChecked
+            Toast.makeText(
+                this,
+                getString(if (isChecked) R.string.wallpaper_walking_enabled else R.string.wallpaper_walking_disabled),
+                Toast.LENGTH_SHORT
+            ).show()
+        }
+
+        btnWallpaperWalkingHelp.setOnClickListener {
+            AlertDialog.Builder(this)
+                .setTitle(R.string.wallpaper_walking_title)
+                .setMessage(R.string.wallpaper_walking_help)
+                .setPositiveButton(android.R.string.ok, null)
+                .show()
         }
 
         findViewById<MaterialButton>(R.id.btnBrowseCompanions).setOnClickListener {
@@ -530,6 +555,14 @@ class SettingsActivity : AppCompatActivity() {
     private fun updateDebugEntityLimitButton() {
         val limit = layoutPrefs.debugEntityLimit
         btnDebugEntityLimit.text = "[DEBUG] Entity Limit: $limit"
+    }
+
+    private fun updateWallpaperWalkingSwitch() {
+        if (::switchWallpaperWalking.isInitialized) {
+            syncingWallpaperWalkingSwitch = true
+            switchWallpaperWalking.isChecked = layoutPrefs.wallpaperWalkingEnabled
+            syncingWallpaperWalkingSwitch = false
+        }
     }
 
     private fun updateEntityCount() {

--- a/app/src/main/java/com/hank/clawlive/WallpaperPreviewActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/WallpaperPreviewActivity.kt
@@ -18,6 +18,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.button.MaterialButton
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.materialswitch.MaterialSwitch
 import com.hank.clawlive.data.local.DeviceManager
 import com.hank.clawlive.data.local.LayoutPreferences
@@ -41,6 +42,8 @@ class WallpaperPreviewActivity : AppCompatActivity() {
     private lateinit var previewView: WallpaperPreviewView
     private lateinit var switchCustomLayout: MaterialSwitch
     private lateinit var switchBackground: MaterialSwitch
+    private lateinit var switchWalking: MaterialSwitch
+    private lateinit var btnWalkingHelp: TextView
     private lateinit var switchUsageOverlay: MaterialSwitch
     private lateinit var checkUsageClaude: CheckBox
     private lateinit var checkUsageCodex: CheckBox
@@ -133,6 +136,8 @@ class WallpaperPreviewActivity : AppCompatActivity() {
         previewView = findViewById(R.id.wallpaperPreviewView)
         switchCustomLayout = findViewById(R.id.switchCustomLayout)
         switchBackground = findViewById(R.id.switchBackground)
+        switchWalking = findViewById(R.id.switchWalking)
+        btnWalkingHelp = findViewById(R.id.btnWalkingHelp)
         switchUsageOverlay = findViewById(R.id.switchUsageOverlay)
         checkUsageClaude = findViewById(R.id.checkUsageClaude)
         checkUsageCodex = findViewById(R.id.checkUsageCodex)
@@ -159,6 +164,7 @@ class WallpaperPreviewActivity : AppCompatActivity() {
         }
         switchCustomLayout.isChecked = layoutPrefs.useCustomLayout
         switchBackground.isChecked = layoutPrefs.useBackgroundImage
+        switchWalking.isChecked = layoutPrefs.wallpaperWalkingEnabled
         switchUsageOverlay.isChecked = layoutPrefs.usageOverlayEnabled
         checkUsageClaude.isChecked = layoutPrefs.usageOverlayShowClaude
         checkUsageCodex.isChecked = layoutPrefs.usageOverlayShowCodex
@@ -247,6 +253,23 @@ class WallpaperPreviewActivity : AppCompatActivity() {
             if (!isChecked) {
                 Toast.makeText(this, getString(R.string.background_disabled), Toast.LENGTH_SHORT).show()
             }
+        }
+
+        switchWalking.setOnCheckedChangeListener { _, isChecked ->
+            previewView.setWalkingEnabled(isChecked)
+            val message = getString(
+                if (isChecked) R.string.wallpaper_walking_enabled
+                else R.string.wallpaper_walking_disabled
+            )
+            Toast.makeText(this, message, Toast.LENGTH_SHORT).show()
+        }
+
+        btnWalkingHelp.setOnClickListener {
+            MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.wallpaper_walking_title)
+                .setMessage(R.string.wallpaper_walking_help)
+                .setPositiveButton(android.R.string.ok, null)
+                .show()
         }
 
         switchUsageOverlay.setOnCheckedChangeListener { _, isChecked ->

--- a/app/src/main/java/com/hank/clawlive/data/local/LayoutPreferences.kt
+++ b/app/src/main/java/com/hank/clawlive/data/local/LayoutPreferences.kt
@@ -2,6 +2,7 @@ package com.hank.clawlive.data.local
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.provider.Settings
 
 /**
  * Entity Layout Types for wallpaper positioning
@@ -29,6 +30,7 @@ enum class UsageOverlayPosition {
  */
 class LayoutPreferences private constructor(context: Context) {
 
+    private val appContext: Context = context.applicationContext
     private val prefs: SharedPreferences = context.getSharedPreferences(
         PREFS_NAME, Context.MODE_PRIVATE
     )
@@ -293,7 +295,7 @@ class LayoutPreferences private constructor(context: Context) {
      * or entity settings for other devices.
      */
     var wallpaperWalkingEnabled: Boolean
-        get() = prefs.getBoolean(KEY_WALLPAPER_WALKING_ENABLED, false)
+        get() = prefs.getBoolean(KEY_WALLPAPER_WALKING_ENABLED, true) && !isAnimatorDurationDisabled()
         set(value) {
             prefs.edit().putBoolean(KEY_WALLPAPER_WALKING_ENABLED, value).apply()
         }
@@ -428,6 +430,18 @@ class LayoutPreferences private constructor(context: Context) {
             showFiveHour -> RESET_WINDOW_5H
             showWeekly -> RESET_WINDOW_WEEKLY
             else -> RESET_WINDOW_OFF
+        }
+    }
+
+    private fun isAnimatorDurationDisabled(): Boolean {
+        return try {
+            Settings.Global.getFloat(
+                appContext.contentResolver,
+                Settings.Global.ANIMATOR_DURATION_SCALE,
+                1f
+            ) == 0f
+        } catch (e: Exception) {
+            false
         }
     }
 

--- a/app/src/main/java/com/hank/clawlive/data/local/LayoutPreferences.kt
+++ b/app/src/main/java/com/hank/clawlive/data/local/LayoutPreferences.kt
@@ -286,6 +286,18 @@ class LayoutPreferences private constructor(context: Context) {
             prefs.edit().putInt(KEY_SERVER_ENTITY_LIMIT, value.coerceIn(4, 8)).apply()
         }
 
+    /**
+     * Device-level wallpaper walking toggle. This intentionally lives in the
+     * wallpaper/layout preference file rather than per-entity state: one device
+     * can choose whether its wallpaper entities wander without changing server
+     * or entity settings for other devices.
+     */
+    var wallpaperWalkingEnabled: Boolean
+        get() = prefs.getBoolean(KEY_WALLPAPER_WALKING_ENABLED, false)
+        set(value) {
+            prefs.edit().putBoolean(KEY_WALLPAPER_WALKING_ENABLED, value).apply()
+        }
+
     var usageOverlayEnabled: Boolean
         get() = prefs.getBoolean(KEY_USAGE_OVERLAY_ENABLED, true)
         set(value) {
@@ -433,6 +445,7 @@ class LayoutPreferences private constructor(context: Context) {
         private const val KEY_BACKGROUND_URI = "background_image_uri"
         private const val KEY_DEBUG_ENTITY_LIMIT = "debug_entity_limit"
         private const val KEY_SERVER_ENTITY_LIMIT = "server_entity_limit"
+        private const val KEY_WALLPAPER_WALKING_ENABLED = "wallpaper_walking_enabled"
         private const val KEY_USAGE_OVERLAY_ENABLED = "usage_overlay_enabled"
         private const val KEY_USAGE_OVERLAY_POSITION = "usage_overlay_position"
         private const val KEY_USAGE_OVERLAY_CENTER = "usage_overlay_center"

--- a/app/src/main/java/com/hank/clawlive/data/model/CompanionDescriptor.kt
+++ b/app/src/main/java/com/hank/clawlive/data/model/CompanionDescriptor.kt
@@ -74,8 +74,49 @@ data class CompanionDetail(
             loop = obj.get("loop")?.asBoolean ?: true,
             fps = obj.get("fps")?.asInt ?: 4,
             row = obj.get("row")?.asInt ?: 0,
-            frames = obj.get("frames")?.asInt ?: 1
+            frames = obj.get("frames")?.asInt ?: 1,
+            animation = obj.get("animation")?.asString
         )
+    }
+
+    fun spritesheetAnimation(state: String): SpriteAnimationHint? {
+        val stateHint = stateAsset(state) ?: return null
+        val animationName = stateHint.animation
+        val fallbackRow = defaultSpritesheetRow(state, stateHint)
+        if (animationName.isNullOrBlank()) {
+            val frameDurationMs = (1000 / stateHint.fps.coerceAtLeast(1)).coerceAtLeast(1)
+            return SpriteAnimationHint(
+                row = fallbackRow,
+                frameDurationsMs = List(stateHint.frames.coerceAtLeast(1)) { frameDurationMs }
+            )
+        }
+
+        val asset = descriptor?.getAsJsonObject("asset") ?: return null
+        val animations = asset.getAsJsonObject("animations") ?: return null
+        val anim = animations.getAsJsonObject(animationName)
+            ?: animations.getAsJsonObject("idle")
+            ?: return null
+
+        val row = anim.get("row")?.asInt ?: fallbackRow
+        val durations = when {
+            anim.has("frames") && anim.get("frames").isJsonArray -> {
+                anim.getAsJsonArray("frames").mapNotNull { it.asInt.takeIf { v -> v > 0 } }
+            }
+            else -> {
+                val count = anim.get("count")?.asInt ?: stateHint.frames
+                val dur = anim.get("dur")?.asInt ?: (1000 / stateHint.fps.coerceAtLeast(1))
+                val last = anim.get("last")?.asInt
+                List(count.coerceAtLeast(1)) { index ->
+                    if (last != null && index == count - 1) last.coerceAtLeast(1) else dur.coerceAtLeast(1)
+                }
+            }
+        }
+
+        return SpriteAnimationHint(row = row, frameDurationsMs = durations.ifEmpty { listOf(250) })
+    }
+
+    private fun defaultSpritesheetRow(state: String, stateHint: StateAssetHint): Int {
+        return if (stateHint.row > 0) stateHint.row else supportedStates.indexOf(state).coerceAtLeast(0)
     }
 
     /** Dimensions of one frame in the spritesheet. Defaults to 128×128 if unspecified. */
@@ -89,7 +130,9 @@ data class CompanionDetail(
     /** Direct URL of the spritesheet image (overrides top-level assetUrl). */
     fun spritesheetUrl(): String? {
         val asset = descriptor?.getAsJsonObject("asset") ?: return assetUrl
-        return asset.get("sheetUrl")?.asString ?: assetUrl
+        return asset.get("sheetUrl")?.asString
+            ?: asset.get("url")?.asString
+            ?: assetUrl
     }
 
     /**
@@ -106,5 +149,11 @@ data class StateAssetHint(
     val loop: Boolean = true,
     val fps: Int = 4,
     val row: Int = 0,
-    val frames: Int = 1
+    val frames: Int = 1,
+    val animation: String? = null
+)
+
+data class SpriteAnimationHint(
+    val row: Int = 0,
+    val frameDurationsMs: List<Int> = listOf(250)
 )

--- a/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
@@ -31,6 +31,7 @@ class ClawRenderer(
     private val layoutPrefs = LayoutPreferences.getInstance(context)
     private val spritesheetDrawer = companionRepository?.let { SpritesheetCompanionDrawer(it) }
     private val usageOverlayRenderer = UsageOverlayRenderer(context, layoutPrefs)
+    private val wanderController = WallpaperWanderController()
 
     // Background image cache
     private var cachedBackgroundBitmap: Bitmap? = null
@@ -470,7 +471,15 @@ class ClawRenderer(
             return
         }
 
-        val positions = calculateEntityPositions(width, height, entities.size, entities)
+        val basePositions = calculateEntityPositions(width, height, entities.size, entities)
+        val walkingEnabled = layoutPrefs.wallpaperWalkingEnabled
+        val positions = wanderController.positionsFor(
+            basePositions = basePositions,
+            entities = entities,
+            width = width,
+            height = height,
+            enabled = walkingEnabled
+        )
         val baseScale = getScaleFactor(entities.size)
 
         entities.forEachIndexed { index, entity ->
@@ -479,7 +488,10 @@ class ClawRenderer(
                 // Apply per-entity scale multiplier on top of base scale
                 val entityScale = layoutPrefs.getEntityScale(entity.entityId)
                 val finalScale = baseScale * entityScale
-                drawSingleEntityAt(canvas, entity, cx, cy, finalScale, width)
+                val motionStateOverride = if (wanderController.isWalking(entity.entityId)) {
+                    WallpaperWanderController.WALKING_STATE_ASSET
+                } else null
+                drawSingleEntityAt(canvas, entity, cx, cy, finalScale, width, motionStateOverride)
             }
         }
 
@@ -495,7 +507,8 @@ class ClawRenderer(
         centerX: Float,
         centerY: Float,
         scale: Float,
-        screenWidth: Float
+        screenWidth: Float,
+        motionStateOverride: String? = null
     ) {
         // Calculate Animation (Bobbing)
         val time = System.currentTimeMillis() - startTime
@@ -528,7 +541,13 @@ class ClawRenderer(
         val companion = companionRepository?.cached(entity.entityId)
         val drawResult = if (companion != null && companion.assetType == "spritesheet") {
             spritesheetDrawer?.draw(
-                canvas, companion, entity.entityId, entity.state.toString(), centerX, charY, scale
+                canvas,
+                companion,
+                entity.entityId,
+                motionStateOverride ?: entity.state.toString(),
+                centerX,
+                charY,
+                scale
             ) ?: SpritesheetCompanionDrawer.DrawResult.UNSUPPORTED
         } else SpritesheetCompanionDrawer.DrawResult.UNSUPPORTED
 

--- a/app/src/main/java/com/hank/clawlive/engine/SpritesheetCompanionDrawer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/SpritesheetCompanionDrawer.kt
@@ -66,11 +66,13 @@ class SpritesheetCompanionDrawer(
         val supported = companion.supportedStates
         val effectiveState = if (currentState in supported) currentState else "IDLE"
         val hint = companion.stateAsset(effectiveState) ?: return DrawResult.UNSUPPORTED
+        val animation = companion.spritesheetAnimation(effectiveState)
 
         // Row defaults to position in supportedStates if descriptor doesn't pin one.
-        val row = if (hint.row > 0) hint.row else supported.indexOf(effectiveState).coerceAtLeast(0)
-        val frames = hint.frames.coerceAtLeast(1)
-        val fps = hint.fps.coerceAtLeast(1)
+        val row = animation?.row ?: if (hint.row > 0) hint.row else supported.indexOf(effectiveState).coerceAtLeast(0)
+        val frameDurations = animation?.frameDurationsMs?.takeIf { it.isNotEmpty() }
+            ?: List(hint.frames.coerceAtLeast(1)) { (1000 / hint.fps.coerceAtLeast(1)).coerceAtLeast(1) }
+        val frames = frameDurations.size
 
         // Reset frame timing on state change so non-looping animations replay.
         val now = System.currentTimeMillis()
@@ -80,8 +82,7 @@ class SpritesheetCompanionDrawer(
         }
 
         val elapsed = now - stateStart
-        val rawIndex = (elapsed * fps / 1000L).toInt()
-        val frameIndex = if (hint.loop) rawIndex % frames else rawIndex.coerceAtMost(frames - 1)
+        val frameIndex = computeFrameIndex(elapsed, frameDurations, hint.loop)
 
         val srcX = (frameIndex * frameW).coerceAtMost(sheet.width - frameW).coerceAtLeast(0)
         val srcY = (row * frameH).coerceAtMost(sheet.height - frameH).coerceAtLeast(0)
@@ -102,6 +103,22 @@ class SpritesheetCompanionDrawer(
         )
         canvas.drawBitmap(sheet, src, dst, paint)
         return DrawResult.DRAWN
+    }
+
+    private fun computeFrameIndex(elapsedMs: Long, frameDurationsMs: List<Int>, loop: Boolean): Int {
+        val total = frameDurationsMs.sum().coerceAtLeast(1)
+        val t = if (loop) {
+            ((elapsedMs % total) + total) % total
+        } else {
+            elapsedMs.coerceAtMost(total.toLong())
+        }.toInt()
+
+        var acc = 0
+        for (i in frameDurationsMs.indices) {
+            acc += frameDurationsMs[i].coerceAtLeast(1)
+            if (t < acc) return i
+        }
+        return frameDurationsMs.lastIndex.coerceAtLeast(0)
     }
 }
 

--- a/app/src/main/java/com/hank/clawlive/engine/WallpaperWanderController.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/WallpaperWanderController.kt
@@ -1,32 +1,53 @@
 package com.hank.clawlive.engine
 
+import android.graphics.PointF
 import com.hank.clawlive.data.model.CharacterState
 import com.hank.clawlive.data.model.EntityStatus
 import kotlin.math.hypot
+import kotlin.math.min
 import kotlin.random.Random
+
+interface MotionController {
+    fun position(entityId: Int): PointF
+    fun motionState(entityId: Int): MotionState
+    fun setTarget(entityId: Int, xPct: Float, yPct: Float, onArrive: (() -> Unit)? = null)
+    fun stop(entityId: Int)
+    fun clearStop(entityId: Int)
+    fun resumeWander(entityId: Int)
+}
+
+enum class MotionState {
+    WANDERING,
+    MOVING_TO_TARGET,
+    STOPPED,
+    SLEEPING
+}
 
 /**
  * Lightweight per-device wallpaper wander engine.
  *
- * The controller keeps only in-memory pixel positions/targets; the persisted
+ * The controller keeps only in-memory screen-percent positions/targets; the persisted
  * switch lives in LayoutPreferences so the feature remains device-level, not
  * per-entity. It is deterministic enough for tests via injectable time/random,
  * but cheap enough for the wallpaper draw loop (O(entityCount), no allocations
  * beyond the returned position list).
  */
 class WallpaperWanderController(
-    private val speedPxPerSecond: Float = DEFAULT_SPEED_PX_PER_SECOND,
+    private val wanderSpeedPctPerSecond: Float = DEFAULT_WANDER_SPEED_PCT_PER_SECOND,
+    private val targetSpeedPctPerSecond: Float = DEFAULT_TARGET_SPEED_PCT_PER_SECOND,
     private val random: Random = Random.Default
-) {
+) : MotionController {
     private data class WanderState(
-        var x: Float,
-        var y: Float,
-        var targetX: Float,
-        var targetY: Float,
+        var xPct: Float,
+        var yPct: Float,
+        var targetXPct: Float,
+        var targetYPct: Float,
         var lastUpdateMs: Long,
         var idleUntilMs: Long,
         var retargetAtMs: Long,
-        var moving: Boolean
+        var moving: Boolean,
+        var motionState: MotionState,
+        var onArrive: (() -> Unit)? = null
     )
 
     private val states = mutableMapOf<Int, WanderState>()
@@ -36,6 +57,47 @@ class WallpaperWanderController(
     }
 
     fun isWalking(entityId: Int): Boolean = states[entityId]?.moving == true
+
+    override fun position(entityId: Int): PointF {
+        val state = states[entityId] ?: return PointF(0.5f, 0.5f)
+        return PointF(state.xPct, state.yPct)
+    }
+
+    override fun motionState(entityId: Int): MotionState {
+        return states[entityId]?.motionState ?: MotionState.STOPPED
+    }
+
+    override fun setTarget(entityId: Int, xPct: Float, yPct: Float, onArrive: (() -> Unit)?) {
+        val state = commandState(entityId)
+        state.targetXPct = xPct.coerceIn(MIN_X_PCT, MAX_X_PCT)
+        state.targetYPct = yPct.coerceIn(MIN_Y_PCT, MAX_Y_PCT)
+        state.motionState = MotionState.MOVING_TO_TARGET
+        state.moving = false
+        state.onArrive = onArrive
+    }
+
+    override fun stop(entityId: Int) {
+        val state = commandState(entityId)
+        state.motionState = MotionState.STOPPED
+        state.moving = false
+        state.onArrive = null
+    }
+
+    override fun clearStop(entityId: Int) {
+        val state = states[entityId] ?: return
+        if (state.motionState == MotionState.STOPPED) {
+            state.motionState = MotionState.WANDERING
+            state.idleUntilMs = 0L
+        }
+    }
+
+    override fun resumeWander(entityId: Int) {
+        val state = commandState(entityId)
+        state.motionState = MotionState.WANDERING
+        state.moving = false
+        state.idleUntilMs = 0L
+        state.onArrive = null
+    }
 
     fun positionsFor(
         basePositions: List<Pair<Float, Float>>,
@@ -57,8 +119,9 @@ class WallpaperWanderController(
             val base = basePositions.getOrNull(index) ?: (width / 2f to height / 2f)
             if (entity.state == CharacterState.SLEEPING) {
                 val state = stateFor(entity.entityId, base, width, height, nowMs)
+                state.motionState = MotionState.SLEEPING
                 state.moving = false
-                state.x to state.y
+                state.xPct * width to state.yPct * height
             } else {
                 advance(entity.entityId, base, width, height, nowMs)
             }
@@ -73,38 +136,50 @@ class WallpaperWanderController(
         nowMs: Long
     ): Pair<Float, Float> {
         val state = stateFor(entityId, base, width, height, nowMs)
+        if (state.motionState == MotionState.SLEEPING) {
+            state.motionState = MotionState.WANDERING
+            state.idleUntilMs = 0L
+        }
+
         val dtSeconds = ((nowMs - state.lastUpdateMs).coerceIn(0L, 1000L)) / 1000f
         state.lastUpdateMs = nowMs
 
+        when (state.motionState) {
+            MotionState.STOPPED,
+            MotionState.SLEEPING -> {
+                state.moving = false
+                return state.xPct * width to state.yPct * height
+            }
+            MotionState.MOVING_TO_TARGET -> {
+                val arrived = moveTowardTarget(state, width, height, targetSpeedPctPerSecond, dtSeconds)
+                if (arrived) {
+                    state.motionState = MotionState.STOPPED
+                    val callback = state.onArrive
+                    state.onArrive = null
+                    callback?.invoke()
+                }
+                return state.xPct * width to state.yPct * height
+            }
+            MotionState.WANDERING -> Unit
+        }
+
         if (nowMs < state.idleUntilMs) {
             state.moving = false
-            return state.x to state.y
+            return state.xPct * width to state.yPct * height
         }
 
         if (nowMs >= state.retargetAtMs) {
-            retarget(state, width, height, nowMs)
+            retarget(state, nowMs)
         }
 
-        val dx = state.targetX - state.x
-        val dy = state.targetY - state.y
-        val distance = hypot(dx, dy)
-        val step = speedPxPerSecond * dtSeconds
-
-        if (distance <= step || distance < ARRIVAL_EPSILON_PX) {
-            state.x = state.targetX
-            state.y = state.targetY
+        if (moveTowardTarget(state, width, height, wanderSpeedPctPerSecond, dtSeconds)) {
             state.moving = false
             state.idleUntilMs = nowMs + randomLong(0L, MAX_IDLE_MS)
-            retarget(state, width, height, state.idleUntilMs)
-        } else if (step > 0f) {
-            state.x += dx / distance * step
-            state.y += dy / distance * step
-            state.moving = true
+            retarget(state, state.idleUntilMs)
         }
 
-        state.x = state.x.coerceIn(minX(width), maxX(width))
-        state.y = state.y.coerceIn(minY(height), maxY(height))
-        return state.x to state.y
+        coerceToSafeBounds(state)
+        return state.xPct * width to state.yPct * height
     }
 
     private fun stateFor(
@@ -114,32 +189,80 @@ class WallpaperWanderController(
         height: Float,
         nowMs: Long
     ): WanderState {
-        return states.getOrPut(entityId) {
-            val x = base.first.coerceIn(minX(width), maxX(width))
-            val y = base.second.coerceIn(minY(height), maxY(height))
-            val target = randomTarget(width, height)
+        val state = states.getOrPut(entityId) {
+            val x = (base.first / width).coerceIn(MIN_X_PCT, MAX_X_PCT)
+            val y = (base.second / height).coerceIn(MIN_Y_PCT, MAX_Y_PCT)
+            val target = randomTarget()
             WanderState(
-                x = x,
-                y = y,
-                targetX = target.first,
-                targetY = target.second,
+                xPct = x,
+                yPct = y,
+                targetXPct = target.first,
+                targetYPct = target.second,
                 lastUpdateMs = nowMs,
                 idleUntilMs = nowMs + randomLong(0L, MAX_IDLE_MS),
                 retargetAtMs = nowMs + randomLong(MIN_RETARGET_MS, MAX_RETARGET_MS),
-                moving = false
+                moving = false,
+                motionState = MotionState.WANDERING
+            )
+        }
+        coerceToSafeBounds(state)
+        return state
+    }
+
+    private fun commandState(entityId: Int): WanderState {
+        return states.getOrPut(entityId) {
+            WanderState(
+                xPct = 0.5f,
+                yPct = 0.5f,
+                targetXPct = 0.5f,
+                targetYPct = 0.5f,
+                lastUpdateMs = 0L,
+                idleUntilMs = 0L,
+                retargetAtMs = 0L,
+                moving = false,
+                motionState = MotionState.STOPPED
             )
         }
     }
 
-    private fun retarget(state: WanderState, width: Float, height: Float, fromMs: Long) {
-        val target = randomTarget(width, height)
-        state.targetX = target.first
-        state.targetY = target.second
+    private fun moveTowardTarget(
+        state: WanderState,
+        width: Float,
+        height: Float,
+        speedPctPerSecond: Float,
+        dtSeconds: Float
+    ): Boolean {
+        val dxPx = (state.targetXPct - state.xPct) * width
+        val dyPx = (state.targetYPct - state.yPct) * height
+        val distancePx = hypot(dxPx, dyPx)
+        val stepPx = speedPctPerSecond * min(width, height) * dtSeconds
+
+        if (distancePx <= stepPx || distancePx < ARRIVAL_EPSILON_PX) {
+            state.xPct = state.targetXPct
+            state.yPct = state.targetYPct
+            state.moving = false
+            return true
+        }
+
+        if (stepPx > 0f) {
+            val fraction = (stepPx / distancePx).coerceAtMost(1f)
+            state.xPct += (state.targetXPct - state.xPct) * fraction
+            state.yPct += (state.targetYPct - state.yPct) * fraction
+            state.moving = true
+        }
+        coerceToSafeBounds(state)
+        return false
+    }
+
+    private fun retarget(state: WanderState, fromMs: Long) {
+        val target = randomTarget()
+        state.targetXPct = target.first
+        state.targetYPct = target.second
         state.retargetAtMs = fromMs + randomLong(MIN_RETARGET_MS, MAX_RETARGET_MS)
     }
 
-    private fun randomTarget(width: Float, height: Float): Pair<Float, Float> {
-        return randomFloat(minX(width), maxX(width)) to randomFloat(minY(height), maxY(height))
+    private fun randomTarget(): Pair<Float, Float> {
+        return randomFloat(MIN_X_PCT, MAX_X_PCT) to randomFloat(MIN_Y_PCT, MAX_Y_PCT)
     }
 
     private fun randomFloat(min: Float, max: Float): Float {
@@ -152,17 +275,22 @@ class WallpaperWanderController(
         return min + random.nextLong(max - min + 1)
     }
 
-    private fun minX(width: Float): Float = width * 0.08f
-    private fun maxX(width: Float): Float = width * 0.92f
-    private fun minY(height: Float): Float = height * 0.12f
-    private fun maxY(height: Float): Float = height * 0.82f
+    private fun coerceToSafeBounds(state: WanderState) {
+        state.xPct = state.xPct.coerceIn(MIN_X_PCT, MAX_X_PCT)
+        state.yPct = state.yPct.coerceIn(MIN_Y_PCT, MAX_Y_PCT)
+    }
 
     companion object {
-        const val DEFAULT_SPEED_PX_PER_SECOND = 10f
+        const val DEFAULT_WANDER_SPEED_PCT_PER_SECOND = 0.04f
+        const val DEFAULT_TARGET_SPEED_PCT_PER_SECOND = 0.12f
         private const val ARRIVAL_EPSILON_PX = 1f
         private const val MAX_IDLE_MS = 3000L
         private const val MIN_RETARGET_MS = 3000L
         private const val MAX_RETARGET_MS = 8000L
+        private const val MIN_X_PCT = 0.08f
+        private const val MAX_X_PCT = 0.92f
+        private const val MIN_Y_PCT = 0.12f
+        private const val MAX_Y_PCT = 0.82f
         const val WALKING_STATE_ASSET = "WALKING"
     }
 }

--- a/app/src/main/java/com/hank/clawlive/engine/WallpaperWanderController.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/WallpaperWanderController.kt
@@ -1,0 +1,168 @@
+package com.hank.clawlive.engine
+
+import com.hank.clawlive.data.model.CharacterState
+import com.hank.clawlive.data.model.EntityStatus
+import kotlin.math.hypot
+import kotlin.random.Random
+
+/**
+ * Lightweight per-device wallpaper wander engine.
+ *
+ * The controller keeps only in-memory pixel positions/targets; the persisted
+ * switch lives in LayoutPreferences so the feature remains device-level, not
+ * per-entity. It is deterministic enough for tests via injectable time/random,
+ * but cheap enough for the wallpaper draw loop (O(entityCount), no allocations
+ * beyond the returned position list).
+ */
+class WallpaperWanderController(
+    private val speedPxPerSecond: Float = DEFAULT_SPEED_PX_PER_SECOND,
+    private val random: Random = Random.Default
+) {
+    private data class WanderState(
+        var x: Float,
+        var y: Float,
+        var targetX: Float,
+        var targetY: Float,
+        var lastUpdateMs: Long,
+        var idleUntilMs: Long,
+        var retargetAtMs: Long,
+        var moving: Boolean
+    )
+
+    private val states = mutableMapOf<Int, WanderState>()
+
+    fun reset() {
+        states.clear()
+    }
+
+    fun isWalking(entityId: Int): Boolean = states[entityId]?.moving == true
+
+    fun positionsFor(
+        basePositions: List<Pair<Float, Float>>,
+        entities: List<EntityStatus>,
+        width: Float,
+        height: Float,
+        enabled: Boolean,
+        nowMs: Long = System.currentTimeMillis()
+    ): List<Pair<Float, Float>> {
+        if (!enabled || width <= 0f || height <= 0f) {
+            states.clear()
+            return basePositions
+        }
+
+        val activeIds = entities.map { it.entityId }.toSet()
+        states.keys.toList().forEach { id -> if (id !in activeIds) states.remove(id) }
+
+        return entities.mapIndexed { index, entity ->
+            val base = basePositions.getOrNull(index) ?: (width / 2f to height / 2f)
+            if (entity.state == CharacterState.SLEEPING) {
+                val state = stateFor(entity.entityId, base, width, height, nowMs)
+                state.moving = false
+                state.x to state.y
+            } else {
+                advance(entity.entityId, base, width, height, nowMs)
+            }
+        }
+    }
+
+    private fun advance(
+        entityId: Int,
+        base: Pair<Float, Float>,
+        width: Float,
+        height: Float,
+        nowMs: Long
+    ): Pair<Float, Float> {
+        val state = stateFor(entityId, base, width, height, nowMs)
+        val dtSeconds = ((nowMs - state.lastUpdateMs).coerceIn(0L, 1000L)) / 1000f
+        state.lastUpdateMs = nowMs
+
+        if (nowMs < state.idleUntilMs) {
+            state.moving = false
+            return state.x to state.y
+        }
+
+        if (nowMs >= state.retargetAtMs) {
+            retarget(state, width, height, nowMs)
+        }
+
+        val dx = state.targetX - state.x
+        val dy = state.targetY - state.y
+        val distance = hypot(dx, dy)
+        val step = speedPxPerSecond * dtSeconds
+
+        if (distance <= step || distance < ARRIVAL_EPSILON_PX) {
+            state.x = state.targetX
+            state.y = state.targetY
+            state.moving = false
+            state.idleUntilMs = nowMs + randomLong(0L, MAX_IDLE_MS)
+            retarget(state, width, height, state.idleUntilMs)
+        } else if (step > 0f) {
+            state.x += dx / distance * step
+            state.y += dy / distance * step
+            state.moving = true
+        }
+
+        state.x = state.x.coerceIn(minX(width), maxX(width))
+        state.y = state.y.coerceIn(minY(height), maxY(height))
+        return state.x to state.y
+    }
+
+    private fun stateFor(
+        entityId: Int,
+        base: Pair<Float, Float>,
+        width: Float,
+        height: Float,
+        nowMs: Long
+    ): WanderState {
+        return states.getOrPut(entityId) {
+            val x = base.first.coerceIn(minX(width), maxX(width))
+            val y = base.second.coerceIn(minY(height), maxY(height))
+            val target = randomTarget(width, height)
+            WanderState(
+                x = x,
+                y = y,
+                targetX = target.first,
+                targetY = target.second,
+                lastUpdateMs = nowMs,
+                idleUntilMs = nowMs + randomLong(0L, MAX_IDLE_MS),
+                retargetAtMs = nowMs + randomLong(MIN_RETARGET_MS, MAX_RETARGET_MS),
+                moving = false
+            )
+        }
+    }
+
+    private fun retarget(state: WanderState, width: Float, height: Float, fromMs: Long) {
+        val target = randomTarget(width, height)
+        state.targetX = target.first
+        state.targetY = target.second
+        state.retargetAtMs = fromMs + randomLong(MIN_RETARGET_MS, MAX_RETARGET_MS)
+    }
+
+    private fun randomTarget(width: Float, height: Float): Pair<Float, Float> {
+        return randomFloat(minX(width), maxX(width)) to randomFloat(minY(height), maxY(height))
+    }
+
+    private fun randomFloat(min: Float, max: Float): Float {
+        if (max <= min) return min
+        return min + random.nextFloat() * (max - min)
+    }
+
+    private fun randomLong(min: Long, max: Long): Long {
+        if (max <= min) return min
+        return min + random.nextLong(max - min + 1)
+    }
+
+    private fun minX(width: Float): Float = width * 0.08f
+    private fun maxX(width: Float): Float = width * 0.92f
+    private fun minY(height: Float): Float = height * 0.12f
+    private fun maxY(height: Float): Float = height * 0.82f
+
+    companion object {
+        const val DEFAULT_SPEED_PX_PER_SECOND = 10f
+        private const val ARRIVAL_EPSILON_PX = 1f
+        private const val MAX_IDLE_MS = 3000L
+        private const val MIN_RETARGET_MS = 3000L
+        private const val MAX_RETARGET_MS = 8000L
+        const val WALKING_STATE_ASSET = "WALKING"
+    }
+}

--- a/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
@@ -8,6 +8,8 @@ import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.RectF
 import android.net.Uri
+import android.os.Handler
+import android.os.Looper
 import android.util.AttributeSet
 import android.view.MotionEvent
 import android.view.View
@@ -19,6 +21,7 @@ import com.hank.clawlive.data.model.UsageSnapshotLatest
 import com.hank.clawlive.engine.ProceduralCreatureDrawer
 import com.hank.clawlive.engine.SpritesheetCompanionDrawer
 import com.hank.clawlive.engine.UsageOverlayRenderer
+import com.hank.clawlive.engine.WallpaperWanderController
 import com.hank.clawlive.data.repository.CompanionRepository
 import kotlin.math.ceil
 import kotlin.math.sqrt
@@ -41,6 +44,16 @@ class WallpaperPreviewView @JvmOverloads constructor(
 
     private val layoutPrefs = LayoutPreferences.getInstance(context)
     private val usageOverlayRenderer = UsageOverlayRenderer(context, layoutPrefs)
+    private val wanderController = WallpaperWanderController()
+    private val animationHandler = Handler(Looper.getMainLooper())
+    private val animationRunnable = object : Runnable {
+        override fun run() {
+            if (layoutPrefs.wallpaperWalkingEnabled && isAttachedToWindow) {
+                invalidate()
+                animationHandler.postDelayed(this, WALKING_PREVIEW_FRAME_MS)
+            }
+        }
+    }
     private var companionRepository: CompanionRepository? = null
     private var spritesheetDrawer: SpritesheetCompanionDrawer? = null
 
@@ -117,6 +130,27 @@ class WallpaperPreviewView @JvmOverloads constructor(
     
     init {
         setWillNotDraw(false)
+    }
+
+    override fun onAttachedToWindow() {
+        super.onAttachedToWindow()
+        updateWalkingAnimationLoop()
+    }
+
+    fun setWalkingEnabled(enabled: Boolean) {
+        layoutPrefs.wallpaperWalkingEnabled = enabled
+        if (!enabled) {
+            wanderController.reset()
+        }
+        invalidate()
+        updateWalkingAnimationLoop()
+    }
+
+    private fun updateWalkingAnimationLoop() {
+        animationHandler.removeCallbacks(animationRunnable)
+        if (layoutPrefs.wallpaperWalkingEnabled && isAttachedToWindow) {
+            animationHandler.postDelayed(animationRunnable, WALKING_PREVIEW_FRAME_MS)
+        }
     }
 
     /**
@@ -241,11 +275,21 @@ class WallpaperPreviewView @JvmOverloads constructor(
         // Draw grid lines for reference
         drawGridLines(canvas)
 
+        val basePositions = entities.map { entity ->
+            val pos = entityPositions[entity.entityId] ?: Pair(0.5f, 0.5f)
+            pos.first * width to pos.second * height
+        }
+        val renderPositions = wanderController.positionsFor(
+            basePositions = basePositions,
+            entities = entities,
+            width = width.toFloat(),
+            height = height.toFloat(),
+            enabled = layoutPrefs.wallpaperWalkingEnabled
+        )
+
         // Draw each entity with per-entity scale
         entities.forEachIndexed { index, entity ->
-            val pos = entityPositions[entity.entityId] ?: Pair(0.5f, 0.5f)
-            val x = pos.first * width
-            val y = pos.second * height
+            val (x, y) = renderPositions.getOrNull(index) ?: basePositions.getOrNull(index) ?: (width / 2f to height / 2f)
             
             // Get per-entity scale
             val entityScale = entityScales[entity.entityId] ?: 1.0f
@@ -274,7 +318,14 @@ class WallpaperPreviewView @JvmOverloads constructor(
             canvas.drawCircle(x, y, indicatorRadius, indicatorPaint)
 
             // Draw entity preview with per-entity scale
-            drawEntityPreview(canvas, entity, x, y, entityScale)
+            drawEntityPreview(
+                canvas,
+                entity,
+                x,
+                y,
+                entityScale,
+                walking = wanderController.isWalking(entity.entityId)
+            )
 
             // Draw entity name label
             labelPaint.textSize = 32f * entityScale.coerceAtLeast(0.7f)
@@ -457,14 +508,21 @@ class WallpaperPreviewView @JvmOverloads constructor(
     /**
      * Draw entity preview (simplified lobster shape)
      */
-    private fun drawEntityPreview(canvas: Canvas, entity: EntityStatus, cx: Float, cy: Float, scale: Float) {
+    private fun drawEntityPreview(
+        canvas: Canvas,
+        entity: EntityStatus,
+        cx: Float,
+        cy: Float,
+        scale: Float,
+        walking: Boolean = false
+    ) {
         val companion = companionRepository?.cached(entity.entityId) ?: companionsByEntity[entity.entityId]
         if (companion?.assetType == "spritesheet") {
             val result = spritesheetDrawer?.draw(
                 canvas,
                 companion,
                 entity.entityId,
-                entity.state.toString(),
+                if (walking) WallpaperWanderController.WALKING_STATE_ASSET else entity.state.toString(),
                 cx,
                 cy,
                 scale * 1.2f
@@ -894,8 +952,13 @@ class WallpaperPreviewView @JvmOverloads constructor(
     }
 
     override fun onDetachedFromWindow() {
+        animationHandler.removeCallbacks(animationRunnable)
         super.onDetachedFromWindow()
         cachedBackgroundBitmap?.recycle()
         cachedBackgroundBitmap = null
+    }
+
+    companion object {
+        private const val WALKING_PREVIEW_FRAME_MS = 100L
     }
 }

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1008,6 +1008,77 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
+            <!-- Wallpaper walking toggle -->
+            <com.google.android.material.card.MaterialCardView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="8dp"
+                app:cardCornerRadius="12dp"
+                app:cardElevation="0dp"
+                app:cardBackgroundColor="@color/surface_input"
+                app:strokeColor="@color/text_dark"
+                app:strokeWidth="1dp">
+
+                <LinearLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="horizontal"
+                    android:gravity="center_vertical"
+                    android:paddingHorizontal="16dp"
+                    android:paddingVertical="12dp">
+
+                    <ImageView
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
+                        android:src="@drawable/ic_wallpaper"
+                        android:contentDescription="@string/nav_wallpaper"
+                        app:tint="@color/text_white_80"/>
+
+                    <LinearLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:layout_marginStart="16dp"
+                        android:orientation="vertical">
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:text="@string/wallpaper_walking_title"
+                            android:textSize="14sp"
+                            android:textColor="@color/text_white_80"/>
+
+                        <TextView
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:layout_marginTop="2dp"
+                            android:text="@string/wallpaper_walking_settings_desc"
+                            android:textSize="12sp"
+                            android:textColor="@color/text_white_60"/>
+                    </LinearLayout>
+
+                    <TextView
+                        android:id="@+id/btnWallpaperWalkingHelp"
+                        android:layout_width="40dp"
+                        android:layout_height="40dp"
+                        android:layout_marginEnd="8dp"
+                        android:background="?attr/selectableItemBackgroundBorderless"
+                        android:contentDescription="@string/wallpaper_walking_help_button"
+                        android:gravity="center"
+                        android:minWidth="40dp"
+                        android:minHeight="40dp"
+                        android:text="?"
+                        android:textColor="@color/text_white_80"
+                        android:textSize="18sp"
+                        android:textStyle="bold"/>
+
+                    <com.google.android.material.materialswitch.MaterialSwitch
+                        android:id="@+id/switchWallpaperWalking"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"/>
+                </LinearLayout>
+            </com.google.android.material.card.MaterialCardView>
+
             <!-- Set Wallpaper Button -->
             <com.google.android.material.button.MaterialButton
                 android:id="@+id/btnSetWallpaper"

--- a/app/src/main/res/layout/activity_wallpaper_preview.xml
+++ b/app/src/main/res/layout/activity_wallpaper_preview.xml
@@ -139,6 +139,44 @@
 
         </LinearLayout>
 
+        <!-- Walking Toggle -->
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginBottom="12dp">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/wallpaper_walking_title"
+                android:textColor="@android:color/white"
+                android:textSize="16sp" />
+
+            <TextView
+                android:id="@+id/btnWalkingHelp"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_marginEnd="8dp"
+                android:background="?attr/selectableItemBackgroundBorderless"
+                android:contentDescription="@string/wallpaper_walking_help_button"
+                android:gravity="center"
+                android:minWidth="40dp"
+                android:minHeight="40dp"
+                android:text="?"
+                android:textColor="@android:color/white"
+                android:textSize="18sp"
+                android:textStyle="bold" />
+
+            <com.google.android.material.materialswitch.MaterialSwitch
+                android:id="@+id/switchWalking"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content" />
+
+        </LinearLayout>
+
         <LinearLayout
             android:id="@+id/usageOverlayPanel"
             android:layout_width="match_parent"

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -768,6 +768,12 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="wallpaper_usage_engine_claude">Claude</string>
     <string name="wallpaper_usage_engine_codex">Codex</string>
     <string name="wallpaper_usage_items">显示项目</string>
+    <string name="wallpaper_walking_title">行走功能</string>
+    <string name="wallpaper_walking_settings_desc">让壁纸实体慢慢随机走动</string>
+    <string name="wallpaper_walking_help_button">关于壁纸行走功能</string>
+    <string name="wallpaper_walking_help">说明：壁纸上的实体会像宠物一样四处慢慢走动。后续消息互动阶段会让你或其他实体发消息时，它们跑到对方旁边。\n\n需要：已开启基本壁纸、至少一个已绑定的实体、行走动画已下载。\n\n测试：开启此功能后，按下方壁纸预览并停留 30 秒，观察所有实体走一轮。</string>
+    <string name="wallpaper_walking_enabled">行走功能已开启</string>
+    <string name="wallpaper_walking_disabled">行走功能已关闭</string>
     <string name="wallpaper_usage_overlay">用量显示</string>
     <string name="wallpaper_usage_overlay_syncing">用量同步中...</string>
     <string name="wallpaper_usage_overlay_title">用量</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -780,6 +780,12 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="wallpaper_usage_engine_claude">Claude</string>
     <string name="wallpaper_usage_engine_codex">Codex</string>
     <string name="wallpaper_usage_items">顯示項目</string>
+    <string name="wallpaper_walking_title">行走功能</string>
+    <string name="wallpaper_walking_settings_desc">讓桌布實體慢慢隨機走動</string>
+    <string name="wallpaper_walking_help_button">關於桌布行走功能</string>
+    <string name="wallpaper_walking_help">說明：桌布上的實體會像寵物一樣四處慢慢走動。後續訊息互動階段會讓你或其他實體傳訊息時，他們跑到對方旁邊。\n\n需要：已開啟基本桌布、至少一個已綁定的實體、行走動畫已下載。\n\n測試：開啟此功能後，按下方桌布預覽並停留 30 秒，觀察所有實體走一輪。</string>
+    <string name="wallpaper_walking_enabled">行走功能已開啟</string>
+    <string name="wallpaper_walking_disabled">行走功能已關閉</string>
     <string name="wallpaper_usage_overlay">用量顯示</string>
     <string name="wallpaper_usage_overlay_syncing">用量同步中...</string>
     <string name="wallpaper_usage_overlay_title">用量</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -85,6 +85,12 @@
     <string name="browse_companions">Browse Companions</string>
     <string name="drag_to_position">Drag entities to position them</string>
     <string name="pinch_to_resize">Drag to move; pinch entities or usage to resize</string>
+    <string name="wallpaper_walking_title">Walking Feature</string>
+    <string name="wallpaper_walking_settings_desc">Slow random wander for wallpaper entities</string>
+    <string name="wallpaper_walking_help_button">About wallpaper walking</string>
+    <string name="wallpaper_walking_help">What: wallpaper entities slowly wander like pets. Later message-aware phases will make them move toward each other when you or another entity sends a message.\n\nNeeds: basic wallpaper enabled, at least one bound entity, and the walking animation downloaded.\n\nTest: turn this on, open the wallpaper preview below, and leave it open for 30 seconds to watch every entity walk.</string>
+    <string name="wallpaper_walking_enabled">Walking feature enabled</string>
+    <string name="wallpaper_walking_disabled">Walking feature disabled</string>
     <string name="wallpaper_usage_overlay">Usage Overlay</string>
     <string name="wallpaper_usage_overlay_title">Usage</string>
     <string name="wallpaper_usage_overlay_syncing">Usage syncing...</string>

--- a/app/src/test/java/com/hank/clawlive/CompanionDescriptorAnimationTest.kt
+++ b/app/src/test/java/com/hank/clawlive/CompanionDescriptorAnimationTest.kt
@@ -1,0 +1,78 @@
+package com.hank.clawlive
+
+import com.google.gson.JsonParser
+import com.hank.clawlive.data.model.CompanionDetail
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class CompanionDescriptorAnimationTest {
+    @Test
+    fun walkingStateUsesPetdxRunningRightAnimation() {
+        val descriptor = JsonParser.parseString(
+            """
+            {
+              "asset": {
+                "url": "https://example.test/sprite.webp",
+                "frameWidth": 192,
+                "frameHeight": 208,
+                "animations": {
+                  "idle": { "row": 0, "frames": [280, 110] },
+                  "running-right": { "row": 1, "count": 8, "dur": 120, "last": 220 }
+                }
+              },
+              "stateAssets": {
+                "IDLE": { "animation": "idle", "loop": true },
+                "WALKING": { "animation": "running-right", "loop": true }
+              }
+            }
+            """.trimIndent()
+        ).asJsonObject
+
+        val companion = CompanionDetail(
+            id = "petdex-test",
+            name = "Petdex Test",
+            assetType = "spritesheet",
+            assetUrl = "https://fallback.test/sprite.webp",
+            supportedStates = listOf("IDLE", "WALKING"),
+            descriptor = descriptor
+        )
+
+        val animation = companion.spritesheetAnimation("WALKING")
+
+        assertEquals("https://example.test/sprite.webp", companion.spritesheetUrl())
+        assertEquals(1, animation?.row)
+        assertEquals(8, animation?.frameDurationsMs?.size)
+        assertEquals(120, animation?.frameDurationsMs?.first())
+        assertEquals(220, animation?.frameDurationsMs?.last())
+        assertTrue(companion.stateAsset("WALKING")?.loop == true)
+    }
+
+    @Test
+    fun legacySpritesheetStateWithoutNamedAnimationKeepsSupportedStateRowFallback() {
+        val descriptor = JsonParser.parseString(
+            """
+            {
+              "stateAssets": {
+                "IDLE": { "frames": 2, "fps": 4 },
+                "BUSY": { "frames": 3, "fps": 6 }
+              }
+            }
+            """.trimIndent()
+        ).asJsonObject
+
+        val companion = CompanionDetail(
+            id = "legacy-sheet",
+            name = "Legacy Sheet",
+            assetType = "spritesheet",
+            supportedStates = listOf("IDLE", "BUSY"),
+            descriptor = descriptor
+        )
+
+        val animation = companion.spritesheetAnimation("BUSY")
+
+        assertEquals(1, animation?.row)
+        assertEquals(3, animation?.frameDurationsMs?.size)
+        assertEquals(166, animation?.frameDurationsMs?.first())
+    }
+}

--- a/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
+++ b/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
@@ -16,6 +16,8 @@ import org.junit.runners.Suite
 @Suite.SuiteClasses(
     MessageRequestFormatTest::class,
     ChatEchoSuppressionTest::class,
+    WallpaperWanderControllerTest::class,
+    CompanionDescriptorAnimationTest::class,
     NotificationPreferenceCatalogTest::class
 )
 class UnitTestSuite

--- a/app/src/test/java/com/hank/clawlive/WallpaperWanderControllerTest.kt
+++ b/app/src/test/java/com/hank/clawlive/WallpaperWanderControllerTest.kt
@@ -1,0 +1,72 @@
+package com.hank.clawlive
+
+import com.hank.clawlive.data.model.CharacterState
+import com.hank.clawlive.data.model.EntityStatus
+import com.hank.clawlive.engine.WallpaperWanderController
+import kotlin.random.Random
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WallpaperWanderControllerTest {
+    @Test
+    fun enabledWanderMovesEntityAtSlowSpeed() {
+        val controller = WallpaperWanderController(random = Random(7))
+        val entity = EntityStatus(entityId = 1, state = CharacterState.IDLE)
+        val base = listOf(500f to 500f)
+
+        controller.positionsFor(base, listOf(entity), 1000f, 1000f, enabled = true, nowMs = 0L)
+        val after = controller.positionsFor(base, listOf(entity), 1000f, 1000f, enabled = true, nowMs = 4000L)
+
+        assertNotEquals("walking should update x", base[0].first, after[0].first)
+        assertNotEquals("walking should update y", base[0].second, after[0].second)
+        assertTrue("controller reports walking while moving", controller.isWalking(1))
+    }
+
+    @Test
+    fun disabledWanderReturnsBasePositionAndDoesNotWalk() {
+        val controller = WallpaperWanderController(random = Random(3))
+        val entity = EntityStatus(entityId = 2, state = CharacterState.IDLE)
+        val base = listOf(250f to 300f)
+
+        controller.positionsFor(base, listOf(entity), 1000f, 1000f, enabled = true, nowMs = 0L)
+        val positions = controller.positionsFor(base, listOf(entity), 1000f, 1000f, enabled = false, nowMs = 5000L)
+
+        assertEquals(base, positions)
+        assertFalse(controller.isWalking(2))
+    }
+
+    @Test
+    fun sleepingEntityDoesNotMoveEvenWhenEnabled() {
+        val controller = WallpaperWanderController(random = Random(11))
+        val entity = EntityStatus(entityId = 3, state = CharacterState.SLEEPING)
+        val base = listOf(600f to 650f)
+
+        val first = controller.positionsFor(base, listOf(entity), 1000f, 1000f, enabled = true, nowMs = 0L)
+        val after = controller.positionsFor(base, listOf(entity), 1000f, 1000f, enabled = true, nowMs = 9000L)
+
+        assertEquals(first, after)
+        assertFalse(controller.isWalking(3))
+    }
+
+    @Test
+    fun wanderStaysInsideSafeWallpaperBounds() {
+        val controller = WallpaperWanderController(random = Random(23))
+        val entity = EntityStatus(entityId = 4, state = CharacterState.IDLE)
+        var positions = listOf(1f to 1f)
+
+        repeat(20) { step ->
+            positions = controller.positionsFor(positions, listOf(entity), 1000f, 1000f, enabled = true, nowMs = step * 1000L)
+            val (x, y) = positions[0]
+            assertTrue("x in safe bounds: $x", x in 80f..920f)
+            assertTrue("y in safe bounds: $y", y in 120f..820f)
+        }
+    }
+
+    @Test
+    fun walkingStateConstantMatchesPetdxDescriptorStateName() {
+        assertEquals("WALKING", WallpaperWanderController.WALKING_STATE_ASSET)
+    }
+}

--- a/app/src/test/java/com/hank/clawlive/WallpaperWanderControllerTest.kt
+++ b/app/src/test/java/com/hank/clawlive/WallpaperWanderControllerTest.kt
@@ -2,6 +2,7 @@ package com.hank.clawlive
 
 import com.hank.clawlive.data.model.CharacterState
 import com.hank.clawlive.data.model.EntityStatus
+import com.hank.clawlive.engine.MotionState
 import com.hank.clawlive.engine.WallpaperWanderController
 import kotlin.random.Random
 import org.junit.Assert.assertEquals
@@ -68,5 +69,50 @@ class WallpaperWanderControllerTest {
     @Test
     fun walkingStateConstantMatchesPetdxDescriptorStateName() {
         assertEquals("WALKING", WallpaperWanderController.WALKING_STATE_ASSET)
+    }
+
+    @Test
+    fun motionControllerTargetMovesInScreenPercentAndStopsOnArrival() {
+        val controller = WallpaperWanderController(random = Random(31))
+        val entity = EntityStatus(entityId = 5, state = CharacterState.IDLE)
+        val base = listOf(500f to 500f)
+        var arrived = false
+
+        controller.positionsFor(base, listOf(entity), 1000f, 1000f, enabled = true, nowMs = 0L)
+        controller.setTarget(5, 0.8f, 0.5f) { arrived = true }
+
+        var positions = base
+        repeat(4) { step ->
+            positions = controller.positionsFor(
+                base,
+                listOf(entity),
+                1000f,
+                1000f,
+                enabled = true,
+                nowMs = (step + 1) * 1000L
+            )
+        }
+
+        assertTrue(arrived)
+        assertEquals(MotionState.STOPPED, controller.motionState(5))
+        assertEquals(800f, positions[0].first, 0.001f)
+        assertEquals(500f, positions[0].second, 0.001f)
+    }
+
+    @Test
+    fun stopAndResumeExposeMotionStateForFollowOnCards() {
+        val controller = WallpaperWanderController(random = Random(37))
+        val entity = EntityStatus(entityId = 6, state = CharacterState.IDLE)
+        val base = listOf(500f to 500f)
+
+        controller.positionsFor(base, listOf(entity), 1000f, 1000f, enabled = true, nowMs = 0L)
+        controller.stop(6)
+
+        assertEquals(MotionState.STOPPED, controller.motionState(6))
+        assertFalse(controller.isWalking(6))
+
+        controller.resumeWander(6)
+
+        assertEquals(MotionState.WANDERING, controller.motionState(6))
     }
 }


### PR DESCRIPTION
## Summary

Walking System T1 foundation for `card_bf8fd53614762c04b8df6a25`.

- Adds `MotionController` / `MotionState` and implements them in `WallpaperWanderController` so T2-T5 can consume `position`, `setTarget`, `stop`, `clearStop`, and `resumeWander` instead of re-inventing motion state.
- Stores entity motion as screen-percent coordinates, then converts to pixels at render time. Random wander uses percent-per-second speed and safe bounds; target movement uses a faster purposeful speed.
- Defaults the device-level `LayoutPreferences.wallpaperWalkingEnabled` toggle ON, while honoring Android reduce-motion by treating `Settings.Global.ANIMATOR_DURATION_SCALE == 0` as disabled.
- Adds Settings and Wallpaper Preview toggles/help text, with EN + zh-rTW + zh-rCN strings.
- Wires `ClawRenderer` and `WallpaperPreviewView` to use animated positions and switch spritesheet rendering to `WALKING` while an entity is moving.
- Extends companion descriptor spritesheet parsing for named animation blocks while preserving legacy `frames`/`fps` and supported-state row fallback.
- Keeps sleeping entities frozen for T1; T5 owns the full sleep/speakTo edge cases.

## Out of scope

- Speech bubble anchoring: T2
- speakTo movement: T3
- Broadcast halo: T4
- Full sleep behavior: T5

## Validation

- `./gradlew :app:testDebugUnitTest --tests com.hank.clawlive.WallpaperWanderControllerTest --tests com.hank.clawlive.CompanionDescriptorAnimationTest`
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:lintDebug`

Card ref: `card_bf8fd53614762c04b8df6a25`
Parent SPEC: `card_8765101e1479be4d664ec163`
