### PR TITLE
feat(wallpaper): T2 speech bubble anchored to entity (card_4e95ad36)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/engine/SpeechBubbleController.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/SpeechBubbleController.kt
@@ -1,0 +1,178 @@
+package com.hank.clawlive.engine
+
+/**
+ * Pure-Kotlin state machine + coordinate math for Walking System child T2:
+ * speech bubbles anchored to an entity sprite (see
+ * docs/specs/wallpaper-walking-system-architecture.md §5).
+ *
+ * Design goals (mirrors [WallpaperWanderController]):
+ *  - All positions are screen-percent floats in [0..1] so bubbles survive
+ *    orientation change / surface re-creation. Pixel coords are derived on-render
+ *    by the (thin) drawing hook, never stored here.
+ *  - The bubble RE-ANCHORS every frame while visible: [placementFor] reads the
+ *    entity's *current* wander position each call, so the bubble trails a walking
+ *    sprite. It never snapshots the anchor at show-time.
+ *  - Fade is a deterministic timer driven by an injectable `nowMs`, so the whole
+ *    lifecycle is unit-testable without Android / a Choreographer.
+ *
+ * Rendering stays thin: a drawer asks [placementFor] for the percent anchor +
+ * alpha, multiplies by the surface width/height, and blits the bubble. This class
+ * owns no Bitmap/Canvas/Paint.
+ */
+class SpeechBubbleController(
+    private val defaultTtlMs: Long = DEFAULT_TTL_MS,
+    private val fadeOutMs: Long = DEFAULT_FADE_OUT_MS,
+    /** Gap between the sprite top and the bubble tail, as a fraction of screen height. */
+    private val gapPctOfHeight: Float = DEFAULT_GAP_PCT_OF_HEIGHT
+) {
+    /** A live bubble's immutable spec. Position is resolved per-frame, not stored here. */
+    private data class Bubble(
+        val text: String,
+        val shownAtMs: Long,
+        val expiresAtMs: Long
+    )
+
+    private val bubbles = mutableMapOf<Int, Bubble>()
+
+    /**
+     * Anchor + visibility result for one entity's bubble, in screen-percent.
+     *
+     * @param anchorXPct horizontal center of the bubble tail, [0..1]
+     * @param anchorYPct vertical position of the bubble tail, [0..1]
+     * @param flippedBelow true when the entity is too near the top edge, so the
+     *        bubble is rendered *below* the sprite (tail points up) per §5.4
+     * @param alpha fade alpha in [0..1]; 1 while live, ramping to 0 over [fadeOutMs]
+     */
+    data class BubblePlacement(
+        val text: String,
+        val anchorXPct: Float,
+        val anchorYPct: Float,
+        val flippedBelow: Boolean,
+        val alpha: Float
+    )
+
+    /** True if this entity currently has a (not-yet-expired) bubble. */
+    fun isVisible(entityId: Int, nowMs: Long): Boolean {
+        val bubble = bubbles[entityId] ?: return false
+        if (nowMs >= bubble.expiresAtMs) {
+            bubbles.remove(entityId)
+            return false
+        }
+        return true
+    }
+
+    /** Number of live bubbles (after pruning expired ones). */
+    fun activeCount(nowMs: Long): Int {
+        prune(nowMs)
+        return bubbles.size
+    }
+
+    fun reset() = bubbles.clear()
+
+    /**
+     * Show (or refresh) a bubble for [entityId]. TTL scales with message length
+     * per §5.3: max(2s, 0.06s * chars) capped at 8s, unless [ttlMsOverride] is given.
+     * A new message resets the TTL (rapid-fire chat, open question O-7).
+     * Blank text clears any existing bubble.
+     */
+    fun show(
+        entityId: Int,
+        text: String,
+        nowMs: Long,
+        ttlMsOverride: Long? = null
+    ) {
+        if (text.isBlank()) {
+            bubbles.remove(entityId)
+            return
+        }
+        val ttl = ttlMsOverride ?: ttlForText(text)
+        bubbles[entityId] = Bubble(
+            text = text,
+            shownAtMs = nowMs,
+            expiresAtMs = nowMs + ttl
+        )
+    }
+
+    /** Explicitly clear a bubble (e.g. conversation ended). */
+    fun clear(entityId: Int) {
+        bubbles.remove(entityId)
+    }
+
+    /**
+     * Resolve the bubble placement for [entityId] at the entity's *current*
+     * position (re-anchored every frame so the bubble follows a walking sprite).
+     *
+     * Position is supplied as screen-percent so this works identically whether the
+     * entity is WANDERING (T1 animated position) or STOPPED / reduce-motion
+     * (static base position) — both anchor through the same formula.
+     *
+     * @param entityXPct sprite center X in screen-percent [0..1]
+     * @param entityYPct sprite center Y in screen-percent [0..1]
+     * @param spriteHeightPct sprite bounding-box height as a fraction of screen height
+     * @return placement, or null when no live bubble exists
+     */
+    fun placementFor(
+        entityId: Int,
+        entityXPct: Float,
+        entityYPct: Float,
+        spriteHeightPct: Float,
+        nowMs: Long
+    ): BubblePlacement? {
+        val bubble = bubbles[entityId] ?: return null
+        if (nowMs >= bubble.expiresAtMs) {
+            bubbles.remove(entityId)
+            return null
+        }
+
+        val halfSprite = spriteHeightPct * 0.5f
+        // §5.1 anchor: above the sprite top by `gap`. §5.4: flip below if too near top.
+        val topAnchorY = entityYPct - halfSprite - gapPctOfHeight
+        val flippedBelow = topAnchorY < gapPctOfHeight
+        val anchorY = if (flippedBelow) {
+            entityYPct + halfSprite + gapPctOfHeight
+        } else {
+            topAnchorY
+        }
+
+        val anchorX = entityXPct.coerceIn(0f, 1f)
+        val anchorYClamped = anchorY.coerceIn(0f, 1f)
+
+        return BubblePlacement(
+            text = bubble.text,
+            anchorXPct = anchorX,
+            anchorYPct = anchorYClamped,
+            flippedBelow = flippedBelow,
+            alpha = alphaFor(bubble, nowMs)
+        )
+    }
+
+    private fun alphaFor(bubble: Bubble, nowMs: Long): Float {
+        val remaining = bubble.expiresAtMs - nowMs
+        if (remaining <= 0L) return 0f
+        if (fadeOutMs <= 0L || remaining >= fadeOutMs) return 1f
+        return (remaining.toFloat() / fadeOutMs.toFloat()).coerceIn(0f, 1f)
+    }
+
+    private fun ttlForText(text: String): Long {
+        val scaled = (PER_CHAR_MS * text.length)
+        return scaled.coerceIn(MIN_TTL_MS, defaultTtlMs)
+    }
+
+    private fun prune(nowMs: Long) {
+        val expired = bubbles.filterValues { nowMs >= it.expiresAtMs }.keys.toList()
+        expired.forEach { bubbles.remove(it) }
+    }
+
+    companion object {
+        /** Default / max TTL cap (§5.3). */
+        const val DEFAULT_TTL_MS = 8_000L
+        /** Floor for any message bubble (§5.3). */
+        const val MIN_TTL_MS = 2_000L
+        /** Per-character contribution to TTL (§5.3: 0.06s/char). */
+        const val PER_CHAR_MS = 60L
+        /** Fade-out ramp window at the end of life. */
+        const val DEFAULT_FADE_OUT_MS = 600L
+        /** Gap above the sprite, ~ default 8dp expressed as a small fraction of height. */
+        const val DEFAULT_GAP_PCT_OF_HEIGHT = 0.02f
+    }
+}

--- a/app/src/test/java/com/hank/clawlive/SpeechBubbleControllerTest.kt
+++ b/app/src/test/java/com/hank/clawlive/SpeechBubbleControllerTest.kt
@@ -1,0 +1,149 @@
+package com.hank.clawlive
+
+import com.hank.clawlive.engine.SpeechBubbleController
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class SpeechBubbleControllerTest {
+
+    /** T2-1 (STOPPED) — bubble anchors above a static sprite at the entity coords. */
+    @Test
+    fun bubbleAnchorsAboveEntityCoords() {
+        val controller = SpeechBubbleController()
+        controller.show(entityId = 1, text = "hi", nowMs = 0L)
+
+        val placement = controller.placementFor(
+            entityId = 1,
+            entityXPct = 0.5f,
+            entityYPct = 0.5f,
+            spriteHeightPct = 0.10f,
+            nowMs = 0L
+        )
+
+        assertNotNull(placement)
+        // anchored at the sprite center X, and ABOVE the sprite center (smaller Y).
+        assertEquals(0.5f, placement!!.anchorXPct, 0.0001f)
+        assertTrue("bubble should sit above the sprite", placement.anchorYPct < 0.5f)
+        assertFalse(placement.flippedBelow)
+        assertEquals("hi", placement.text)
+    }
+
+    /** T2-2 — bubble follows the entity when the sprite walks (re-anchored each frame). */
+    @Test
+    fun bubblePositionUpdatesWhenEntityMoves() {
+        val controller = SpeechBubbleController()
+        controller.show(entityId = 2, text = "walking", nowMs = 0L)
+
+        val before = controller.placementFor(2, 0.2f, 0.5f, 0.10f, nowMs = 100L)!!
+        // entity walks to the right and up
+        val after = controller.placementFor(2, 0.7f, 0.3f, 0.10f, nowMs = 200L)!!
+
+        assertEquals(0.2f, before.anchorXPct, 0.0001f)
+        assertEquals(0.7f, after.anchorXPct, 0.0001f)
+        assertTrue("bubble X follows sprite X", after.anchorXPct > before.anchorXPct)
+        assertTrue("bubble Y follows sprite Y", after.anchorYPct < before.anchorYPct)
+    }
+
+    /** T2-1 lifecycle — bubble expires and is gone after its TTL. */
+    @Test
+    fun bubbleExpiresAfterTimeout() {
+        val controller = SpeechBubbleController(defaultTtlMs = 4_000L)
+        controller.show(entityId = 3, text = "x", nowMs = 0L)
+
+        // floor TTL is 2s for a short message; still visible just before.
+        assertTrue(controller.isVisible(3, nowMs = 1_999L))
+        assertNotNull(controller.placementFor(3, 0.5f, 0.5f, 0.1f, nowMs = 1_999L))
+
+        // after TTL: gone.
+        assertFalse(controller.isVisible(3, nowMs = 2_001L))
+        assertNull(controller.placementFor(3, 0.5f, 0.5f, 0.1f, nowMs = 2_001L))
+        assertEquals(0, controller.activeCount(nowMs = 2_001L))
+    }
+
+    /** Reduce-motion / disabled-walk: a static (non-walking) entity still anchors. */
+    @Test
+    fun staticEntityStillAnchorsWhenWalkDisabled() {
+        val controller = SpeechBubbleController()
+        controller.show(entityId = 4, text = "still", nowMs = 0L)
+
+        // Same coords across frames (no wander) — bubble must still resolve.
+        val first = controller.placementFor(4, 0.4f, 0.6f, 0.10f, nowMs = 0L)!!
+        val later = controller.placementFor(4, 0.4f, 0.6f, 0.10f, nowMs = 500L)!!
+
+        assertEquals(first.anchorXPct, later.anchorXPct, 0.0001f)
+        assertEquals(first.anchorYPct, later.anchorYPct, 0.0001f)
+        assertEquals(0.4f, first.anchorXPct, 0.0001f)
+    }
+
+    /** §5.4 — near the top edge the bubble flips below the sprite (tail points up). */
+    @Test
+    fun bubbleFlipsBelowWhenNearTopEdge() {
+        val controller = SpeechBubbleController()
+        controller.show(entityId = 5, text = "top", nowMs = 0L)
+
+        val placement = controller.placementFor(
+            entityId = 5,
+            entityXPct = 0.5f,
+            entityYPct = 0.02f, // sprite hugging the top
+            spriteHeightPct = 0.10f,
+            nowMs = 0L
+        )!!
+
+        assertTrue("should flip below near top", placement.flippedBelow)
+        assertTrue("flipped bubble sits below the sprite center", placement.anchorYPct > 0.02f)
+    }
+
+    /** §5.3 — TTL scales with message length, capped at the default max. */
+    @Test
+    fun ttlScalesWithMessageLengthAndCaps() {
+        val controller = SpeechBubbleController(defaultTtlMs = 8_000L)
+
+        // 600-char message → would be 36s, capped to 8s (T2-4).
+        val long = "a".repeat(600)
+        controller.show(entityId = 6, text = long, nowMs = 0L)
+        assertTrue(controller.isVisible(6, nowMs = 7_999L))
+        assertFalse(controller.isVisible(6, nowMs = 8_001L))
+    }
+
+    /** §5.3 / O-7 — a new message resets the TTL rather than letting the old one expire. */
+    @Test
+    fun newMessageResetsTtl() {
+        val controller = SpeechBubbleController()
+        controller.show(entityId = 7, text = "first", nowMs = 0L)
+        // refresh near end of life
+        controller.show(entityId = 7, text = "second", nowMs = 1_500L)
+
+        // original would have expired at 2_000L; refreshed one lives to 3_500L.
+        assertTrue(controller.isVisible(7, nowMs = 3_000L))
+        val placement = controller.placementFor(7, 0.5f, 0.5f, 0.1f, nowMs = 3_000L)!!
+        assertEquals("second", placement.text)
+    }
+
+    /** Fade alpha ramps from 1.0 to 0.0 across the fade-out window. */
+    @Test
+    fun alphaRampsDownDuringFadeOut() {
+        val controller = SpeechBubbleController(defaultTtlMs = 4_000L, fadeOutMs = 1_000L)
+        controller.show(entityId = 8, text = "fade", nowMs = 0L, ttlMsOverride = 4_000L)
+
+        val full = controller.placementFor(8, 0.5f, 0.5f, 0.1f, nowMs = 1_000L)!!
+        val mid = controller.placementFor(8, 0.5f, 0.5f, 0.1f, nowMs = 3_500L)!!
+
+        assertEquals("fully opaque while not fading", 1.0f, full.alpha, 0.0001f)
+        assertTrue("alpha is ramping down", mid.alpha < 1.0f && mid.alpha > 0.0f)
+    }
+
+    /** Blank text clears any existing bubble (no empty bubbles render). */
+    @Test
+    fun blankTextClearsBubble() {
+        val controller = SpeechBubbleController()
+        controller.show(entityId = 9, text = "hello", nowMs = 0L)
+        assertTrue(controller.isVisible(9, nowMs = 0L))
+
+        controller.show(entityId = 9, text = "   ", nowMs = 100L)
+        assertFalse(controller.isVisible(9, nowMs = 100L))
+    }
+}


### PR DESCRIPTION
Implements Walking System child **T2 — speech bubble anchored to entity** (parent SPEC `card_8765101e1479be4d664ec163`, architecture doc §5).

## What
Pure-Kotlin, testable speech-bubble state machine + coordinate math. Rendering hooks stay thin (no Bitmap/Canvas/Paint in this class).

- **Anchor (§5.1):** bubble sits above the sprite top, centered on the sprite X, all in screen-percent `[0..1]` (orientation-safe, matches T1 `WallpaperWanderController`).
- **Follow during walk (§5.2):** `placementFor(...)` re-reads the entity's *current* percent position every call, so the bubble trails a wandering sprite. Never snapshots anchor at show-time.
- **Fade timer (§5.3):** TTL scales with message length `max(2s, 0.06s*chars)` capped at 8s; configurable default. Alpha ramps 1→0 across a fade-out window. New message resets TTL (O-7).
- **Edge flip (§5.4):** near the top edge the bubble flips below the sprite (tail up).
- **Reduce-motion / disabled-walk:** a static (non-wandering) entity anchors through the same formula — verified by test.

## Files
- `app/src/main/java/com/hank/clawlive/engine/SpeechBubbleController.kt` (new, controller + `BubblePlacement`)
- `app/src/test/java/com/hank/clawlive/SpeechBubbleControllerTest.kt` (new, 9 unit tests)

## Tests
`./gradlew :app:testDebugUnitTest --tests SpeechBubbleControllerTest` → **BUILD SUCCESSFUL, 9/9 passing** (anchors at coords / follows on move / expires after timeout / static-anchor when walk disabled / top-edge flip / TTL length-scaling+cap / TTL reset / alpha ramp / blank clears).

CI gate to verify. Does not touch main; no unrelated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)