### PR TITLE
feat(wallpaper): T5 sleep state stops walking (card_805bf4f8)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/engine/SleepGateController.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/SleepGateController.kt
@@ -1,0 +1,108 @@
+package com.hank.clawlive.engine
+
+import android.graphics.PointF
+import com.hank.clawlive.data.model.CharacterState
+import com.hank.clawlive.data.model.EntityStatus
+
+/**
+ * Walking child T5 — sleep gate (spec §7).
+ *
+ * Pure-Kotlin, testable wrapper around T1's [MotionController] / [WallpaperWanderController].
+ * It does not own positions; the underlying wander engine remains the single source of
+ * coordinate truth (screen-percent, 0.0..1.0). The gate only decides, per server-reported
+ * [CharacterState], whether motion ticks and motion commands are allowed to reach the engine.
+ *
+ * Rules enforced (spec §7.1):
+ *  - A `SLEEPING` entity is excluded from the wander engine: its position freezes at the last
+ *    known coordinate and it does not move across ticks.
+ *  - On wake (`CharacterState` flips away from `SLEEPING`) the entity re-enters wander
+ *    immediately (spec §7.2 step 1; the wake animation in §7.2 step 3 is a renderer concern).
+ *  - speakTo asymmetry (spec §7.1 row "SpeakTo receiver-pause"): a sleeping *receiver* does NOT
+ *    halt or take a target — it stays put. A non-sleeping *sender* still approaches and stops at
+ *    the sleeping entity's position, "dropping off" the message.
+ *
+ * The gate never writes back to [EntityStatus.state]; motion is a client-side overlay
+ * (spec §2.2 implementer rule).
+ */
+class SleepGateController(
+    private val delegate: WallpaperWanderController = WallpaperWanderController()
+) {
+    /** Last sleep snapshot, keyed by entityId. Used to detect wake edges and gate commands. */
+    private val sleeping = mutableMapOf<Int, Boolean>()
+
+    fun reset() {
+        sleeping.clear()
+        delegate.reset()
+    }
+
+    /** True iff the entity is currently gated as sleeping. */
+    fun isSleeping(entityId: Int): Boolean = sleeping[entityId] == true
+
+    /**
+     * Advance the wander engine for one draw tick while applying the sleep gate.
+     *
+     * Sleeping entities have their position frozen (the underlying engine already pins a
+     * `SLEEPING` entity to its last position; the gate additionally records the sleep edge so
+     * command routing — [requestApproach] / [requestReceiverPause] — can honor the asymmetry).
+     *
+     * @return per-entity device-pixel positions, index-aligned with [entities] (same contract as
+     *   [WallpaperWanderController.positionsFor]).
+     */
+    fun tick(
+        basePositions: List<Pair<Float, Float>>,
+        entities: List<EntityStatus>,
+        width: Float,
+        height: Float,
+        enabled: Boolean,
+        nowMs: Long = System.currentTimeMillis()
+    ): List<Pair<Float, Float>> {
+        val activeIds = entities.map { it.entityId }.toSet()
+        sleeping.keys.toList().forEach { id -> if (id !in activeIds) sleeping.remove(id) }
+        entities.forEach { sleeping[it.entityId] = it.state == CharacterState.SLEEPING }
+        return delegate.positionsFor(basePositions, entities, width, height, enabled, nowMs)
+    }
+
+    /** Current motion state for the entity (delegates to the wander engine). */
+    fun motionState(entityId: Int): MotionState = delegate.motionState(entityId)
+
+    /** Current screen-percent position for the entity (delegates to the wander engine). */
+    fun position(entityId: Int): PointF = delegate.position(entityId)
+
+    fun isWalking(entityId: Int): Boolean = delegate.isWalking(entityId)
+
+    /**
+     * Sender side of a speakTo (spec §7.1): the sender approaches [receiver] and stops on arrival.
+     * Honored even when the receiver is sleeping — the message is still "delivered" visually.
+     *
+     * A *sleeping* sender cannot approach; the request is dropped (gate).
+     *
+     * @return true if the approach target was set, false if the sender was gated by sleep.
+     */
+    fun requestApproach(
+        senderId: Int,
+        receiver: EntityStatus,
+        receiverXPct: Float,
+        receiverYPct: Float,
+        onArrive: (() -> Unit)? = null
+    ): Boolean {
+        if (isSleeping(senderId)) return false
+        // Walk to the receiver regardless of whether the receiver is awake.
+        delegate.setTarget(senderId, receiverXPct, receiverYPct, onArrive)
+        return true
+    }
+
+    /**
+     * Receiver side of a speakTo (spec §2.4 / §7.1): an awake receiver halts in place to listen.
+     * A sleeping receiver does NOT react — it stays put (no STOPPED transition, no target).
+     *
+     * @return true if the receiver was halted, false if it was sleeping and stayed put.
+     */
+    fun requestReceiverPause(receiver: EntityStatus): Boolean {
+        if (receiver.state == CharacterState.SLEEPING) {
+            sleeping[receiver.entityId] = true
+            return false
+        }
+        delegate.stop(receiver.entityId)
+        return true
+    }
+}

--- a/app/src/test/java/com/hank/clawlive/SleepGateControllerTest.kt
+++ b/app/src/test/java/com/hank/clawlive/SleepGateControllerTest.kt
@@ -1,0 +1,146 @@
+package com.hank.clawlive
+
+import com.hank.clawlive.data.model.CharacterState
+import com.hank.clawlive.data.model.EntityStatus
+import com.hank.clawlive.engine.MotionState
+import com.hank.clawlive.engine.SleepGateController
+import com.hank.clawlive.engine.WallpaperWanderController
+import kotlin.random.Random
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Walking child T5 — sleep gate unit tests (spec §7).
+ * Pure JVM tests; no Android instrumentation required.
+ */
+class SleepGateControllerTest {
+
+    private fun controller(seed: Int) =
+        SleepGateController(WallpaperWanderController(random = Random(seed)))
+
+    @Test
+    fun sleepingEntityDoesNotMoveOnWanderTick() {
+        val gate = controller(7)
+        val entity = EntityStatus(entityId = 1, state = CharacterState.SLEEPING)
+        val base = listOf(600f to 650f)
+
+        val first = gate.tick(base, listOf(entity), 1000f, 1000f, enabled = true, nowMs = 0L)
+        val after = gate.tick(base, listOf(entity), 1000f, 1000f, enabled = true, nowMs = 8000L)
+
+        assertEquals("sleeping entity stays frozen across ticks", first, after)
+        assertFalse(gate.isWalking(1))
+        assertTrue(gate.isSleeping(1))
+        assertEquals(MotionState.SLEEPING, gate.motionState(1))
+    }
+
+    @Test
+    fun positionFrozenAcrossManyTicksWhileSleeping() {
+        val gate = controller(13)
+        val entity = EntityStatus(entityId = 2, state = CharacterState.SLEEPING)
+        val base = listOf(420f to 380f)
+
+        var positions = gate.tick(base, listOf(entity), 1000f, 1000f, enabled = true, nowMs = 0L)
+        val frozen = positions[0]
+        repeat(10) { step ->
+            positions = gate.tick(base, listOf(entity), 1000f, 1000f, enabled = true, nowMs = (step + 1) * 1000L)
+            assertEquals("x frozen at tick $step", frozen.first, positions[0].first)
+            assertEquals("y frozen at tick $step", frozen.second, positions[0].second)
+        }
+    }
+
+    @Test
+    fun wakeResumesMovement() {
+        val gate = controller(23)
+        val sleepingEntity = EntityStatus(entityId = 3, state = CharacterState.SLEEPING)
+        val base = listOf(500f to 500f)
+
+        // Asleep: frozen.
+        val asleepA = gate.tick(base, listOf(sleepingEntity), 1000f, 1000f, enabled = true, nowMs = 0L)
+        val asleepB = gate.tick(base, listOf(sleepingEntity), 1000f, 1000f, enabled = true, nowMs = 3000L)
+        assertEquals(asleepA, asleepB)
+        assertTrue(gate.isSleeping(3))
+
+        // Wake: same entityId now IDLE. Should re-enter wander and move.
+        val awakeEntity = EntityStatus(entityId = 3, state = CharacterState.IDLE)
+        gate.tick(base, listOf(awakeEntity), 1000f, 1000f, enabled = true, nowMs = 4000L)
+        val moved = gate.tick(base, listOf(awakeEntity), 1000f, 1000f, enabled = true, nowMs = 8000L)
+
+        assertFalse(gate.isSleeping(3))
+        val movedFromFrozen =
+            moved[0].first != asleepB[0].first || moved[0].second != asleepB[0].second
+        assertTrue("woke entity resumes wander movement", movedFromFrozen)
+    }
+
+    @Test
+    fun speakToToSleepingReceiver_receiverStaysPut_senderApproaches() {
+        val gate = controller(31)
+        val sender = EntityStatus(entityId = 10, state = CharacterState.IDLE)
+        val sleepingReceiver = EntityStatus(entityId = 11, state = CharacterState.SLEEPING)
+        val base = listOf(200f to 500f, 800f to 500f) // sender left, receiver right
+
+        // Seed both entities into the engine.
+        val seeded = gate.tick(base, listOf(sender, sleepingReceiver), 1000f, 1000f, enabled = true, nowMs = 0L)
+        val receiverFrozen = seeded[1]
+
+        // Receiver is sleeping → pause request must NOT halt it (returns false, stays put).
+        val receiverPaused = gate.requestReceiverPause(sleepingReceiver)
+        assertFalse("sleeping receiver does not react to speakTo", receiverPaused)
+
+        // Sender (awake) approaches receiver's screen-% position.
+        val approachSet = gate.requestApproach(sender.entityId, sleepingReceiver, 0.8f, 0.5f)
+        assertTrue("awake sender takes an approach target", approachSet)
+        assertEquals(MotionState.MOVING_TO_TARGET, gate.motionState(sender.entityId))
+
+        // Advance several ticks.
+        var positions = seeded
+        repeat(6) { step ->
+            positions = gate.tick(
+                base,
+                listOf(sender, sleepingReceiver),
+                1000f, 1000f,
+                enabled = true,
+                nowMs = (step + 1) * 1000L
+            )
+        }
+
+        // Receiver stayed frozen the entire time.
+        assertEquals("sleeping receiver x stayed put", receiverFrozen.first, positions[1].first)
+        assertEquals("sleeping receiver y stayed put", receiverFrozen.second, positions[1].second)
+        assertEquals(MotionState.SLEEPING, gate.motionState(sleepingReceiver.entityId))
+
+        // Sender moved from its origin toward the receiver.
+        assertNotEquals("sender moved toward receiver", seeded[0].first, positions[0].first)
+        assertTrue("sender advanced rightward toward receiver", positions[0].first > seeded[0].first)
+    }
+
+    @Test
+    fun sleepingSenderCannotApproach() {
+        val gate = controller(41)
+        val sleepingSender = EntityStatus(entityId = 20, state = CharacterState.SLEEPING)
+        val receiver = EntityStatus(entityId = 21, state = CharacterState.IDLE)
+        val base = listOf(300f to 300f, 700f to 300f)
+
+        gate.tick(base, listOf(sleepingSender, receiver), 1000f, 1000f, enabled = true, nowMs = 0L)
+
+        val approachSet = gate.requestApproach(sleepingSender.entityId, receiver, 0.7f, 0.3f)
+        assertFalse("sleeping sender cannot approach", approachSet)
+        assertEquals(MotionState.SLEEPING, gate.motionState(sleepingSender.entityId))
+    }
+
+    @Test
+    fun awakeReceiverHaltsToListen() {
+        val gate = controller(53)
+        val receiver = EntityStatus(entityId = 30, state = CharacterState.IDLE)
+        val base = listOf(500f to 500f)
+
+        gate.tick(base, listOf(receiver), 1000f, 1000f, enabled = true, nowMs = 0L)
+        val halted = gate.requestReceiverPause(receiver)
+
+        assertTrue("awake receiver halts in place", halted)
+        assertEquals(MotionState.STOPPED, gate.motionState(30))
+        assertFalse(gate.isWalking(30))
+    }
+}


### PR DESCRIPTION
Implements Walking child **T5 — sleep state stops walking** (spec `docs/specs/wallpaper-walking-system-architecture.md` §7).

## Approach
Pure-Kotlin, testable `SleepGateController` that wraps T1's `WallpaperWanderController` (`MotionController`). The wander engine stays the single source of coordinate truth (screen-percent, 0.0..1.0); the gate only decides whether motion ticks/commands reach the engine, keyed on server-reported `CharacterState`.

## Rules enforced (spec §7.1 / §7.2)
- Sleeping entity excluded from wander ticks; position frozen at last known screen-% coord, held across ticks.
- Wake (`CharacterState` flips away from `SLEEPING`) re-enters wander immediately.
- speakTo asymmetry: a sleeping **receiver** stays put (no halt, no LISTENING), while an awake **sender** still approaches and stops at the sleeping entity's position (drops off the message).
- Sleeping **sender** is gated and cannot approach.
- Never writes back to `EntityStatus.state` (motion is a client-side overlay, §2.2).

## Files changed (2)
- `app/src/main/java/com/hank/clawlive/engine/SleepGateController.kt` (new)
- `app/src/test/java/com/hank/clawlive/SleepGateControllerTest.kt` (new, 6 JUnit tests)

## Tests
`./gradlew :app:testDebugUnitTest --tests com.hank.clawlive.SleepGateControllerTest` → **BUILD SUCCESSFUL**, 6/6 green:
- sleeping entity does not move on wander tick
- position frozen across many ticks
- wake resumes movement
- speakTo to sleeping receiver: receiver stays put, sender approaches
- sleeping sender cannot approach
- awake receiver halts to listen

Does not touch main. No unrelated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt7jNhQxvz1FkErAbyHneC