### PR TITLE
feat(wallpaper): T4 broadcast formation (card_005d4bd7)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/engine/BroadcastFormationController.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/BroadcastFormationController.kt
@@ -1,0 +1,162 @@
+package com.hank.clawlive.engine
+
+import kotlin.math.PI
+import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.hypot
+import kotlin.math.max
+import kotlin.math.sin
+
+/**
+ * Child T4 — Broadcast formation geometry.
+ *
+ * On a broadcast event (speakTo all / @all) the **sender** does an accelerated walk to
+ * screen center (0.5, 0.5) and every non-sleeping **bystander** moves toward the sender
+ * and forms an evenly-distributed halo ring around it. The halo holds until the next
+ * state change (a new broadcast/speakTo cancels it, or [haloDwellSeconds] elapses).
+ *
+ * This is pure, side-effect-free geometry: it computes screen-percent targets and steps
+ * entities toward them. The wallpaper service wires the output into
+ * [WallpaperWanderController.setTarget] for the sender and each bystander so the existing
+ * draw-loop animation handles the actual walk. Keeping it pure makes the §6 spec testable
+ * without an Android surface.
+ *
+ * Coordinate contract (matches T1 + spec §3/§4):
+ *  - All positions are screen-fraction floats in [0,1]; x is corrected by aspect ratio so
+ *    the halo looks visually circular on portrait phones.
+ *  - 1 entity-unit = sprite_width * [ENTITY_UNIT_SPRITE_MULTIPLIER] (spec §3, default 1.5).
+ *    Halo radius keeps every bystander >= 1 entity-unit from each other and the sender.
+ *
+ * @see docs/specs/wallpaper-walking-system-architecture.md §6
+ */
+class BroadcastFormationController(
+    /** Halo persistence after the broadcast is received (spec §6.4, O-6). */
+    private val haloDwellSeconds: Float = DEFAULT_HALO_DWELL_SECONDS
+) {
+    /** A computed screen-percent target plus the participant it belongs to. */
+    data class Slot(
+        val entityId: Int,
+        val xPct: Float,
+        val yPct: Float
+    )
+
+    /**
+     * Result of planning a broadcast formation: where the sender goes and where each
+     * non-sleeping bystander goes. [haloDismissAtMs] is when the formation should release
+     * back to wander (spec §6.4).
+     */
+    data class Formation(
+        val senderSlot: Slot,
+        val bystanderSlots: List<Slot>,
+        val radiusPct: Float,
+        val haloDismissAtMs: Long
+    )
+
+    /**
+     * Position of one participant in screen-fraction coordinates. [sleeping] participants
+     * are excluded from halo recruitment per spec §7.1 (not counted in `n`, no slot).
+     */
+    data class Participant(
+        val entityId: Int,
+        val xPct: Float,
+        val yPct: Float,
+        val sleeping: Boolean = false
+    )
+
+    /**
+     * Plan the formation for a broadcast originating from [senderId].
+     *
+     * @param senderId the entity that broadcast.
+     * @param participants current positions of all entities (including the sender).
+     * @param senderSpriteWidthPx sender sprite width in device px (focal point for entity-unit; spec §3.2).
+     * @param screenWidthPx surface width in px (for entity-unit -> percent + aspect correction).
+     * @param screenHeightPx surface height in px (for aspect correction).
+     * @param broadcastReceivedAtMs timestamp the broadcast arrived (drives [Formation.haloDismissAtMs]).
+     */
+    fun plan(
+        senderId: Int,
+        participants: List<Participant>,
+        senderSpriteWidthPx: Float,
+        screenWidthPx: Float,
+        screenHeightPx: Float,
+        broadcastReceivedAtMs: Long
+    ): Formation {
+        require(screenWidthPx > 0f && screenHeightPx > 0f) { "screen dimensions must be positive" }
+
+        val senderSlot = Slot(senderId, CENTER_X, CENTER_Y)
+        val dismissAt = broadcastReceivedAtMs + (haloDwellSeconds * 1000f).toLong()
+
+        // Non-sleeping bystanders only (spec §6 step 2/3, §7.1).
+        val bystanders = participants.filter { it.entityId != senderId && !it.sleeping }
+        val n = bystanders.size
+        if (n == 0) {
+            // Spec O-4 / X-3: sender still walks to center, halo timer still ticks.
+            return Formation(senderSlot, emptyList(), 0f, dismissAt)
+        }
+
+        val radiusPct = haloRadiusPct(n, senderSpriteWidthPx, screenWidthPx)
+        val aspect = screenHeightPx / screenWidthPx // §6.2 x-correction so the ring is visually circular
+
+        // §6.3 assignment: order bystanders by the angle from screen-center to their current
+        // position, then drop them onto evenly-spaced ring slots starting at 12 o'clock,
+        // clockwise. This minimizes total walking distance and avoids the X-crossing tangle.
+        val ordered = bystanders.sortedBy { angleFromCenter(it) }
+
+        val slots = ordered.mapIndexed { i, b ->
+            val theta = THETA_OFFSET + 2.0 * PI * i / n
+            val x = (CENTER_X + radiusPct * cos(theta).toFloat() * aspect)
+                .coerceIn(MIN_PCT, MAX_PCT)
+            val y = (CENTER_Y + radiusPct * sin(theta).toFloat())
+                .coerceIn(MIN_PCT, MAX_PCT)
+            Slot(b.entityId, x, y)
+        }
+
+        return Formation(senderSlot, slots, radiusPct, dismissAt)
+    }
+
+    /**
+     * Halo radius in screen-percent (spec §6.1).
+     *
+     *   radius = max(1.5 * entityUnitPct, 0.18 + 0.012 * n)  capped at 0.42
+     *
+     * The count-scaled floor prevents many bystanders from crushing together; the cap keeps
+     * the halo on-screen on small phones.
+     */
+    fun haloRadiusPct(n: Int, senderSpriteWidthPx: Float, screenWidthPx: Float): Float {
+        val entityUnitPct = (senderSpriteWidthPx * ENTITY_UNIT_SPRITE_MULTIPLIER) / screenWidthPx
+        val countScaledFloor = COUNT_FLOOR_BASE + COUNT_FLOOR_PER_ENTITY * n
+        return max(SPRITE_RADIUS_FACTOR * entityUnitPct, countScaledFloor).coerceAtMost(MAX_RADIUS_PCT)
+    }
+
+    /**
+     * True once the halo dwell window has elapsed; the service should then
+     * [WallpaperWanderController.resumeWander] every participant (spec §6.4).
+     */
+    fun shouldDismiss(formation: Formation, nowMs: Long): Boolean = nowMs >= formation.haloDismissAtMs
+
+    private fun angleFromCenter(p: Participant): Float =
+        atan2((p.yPct - CENTER_Y).toDouble(), (p.xPct - CENTER_X).toDouble()).toFloat()
+
+    companion object {
+        const val CENTER_X = 0.5f
+        const val CENTER_Y = 0.5f
+
+        /** Spec §3: 1 entity-unit = sprite_width * 1.5. */
+        const val ENTITY_UNIT_SPRITE_MULTIPLIER = 1.5f
+
+        /** Spec §6.1 radius terms. */
+        const val SPRITE_RADIUS_FACTOR = 1.5f
+        const val COUNT_FLOOR_BASE = 0.18f
+        const val COUNT_FLOOR_PER_ENTITY = 0.012f
+        const val MAX_RADIUS_PCT = 0.42f
+
+        /** Spec §6.2: first bystander at 12 o'clock (above sender). */
+        const val THETA_OFFSET = -PI / 2.0
+
+        const val DEFAULT_HALO_DWELL_SECONDS = 6.0f
+
+        // Keep ring slots inside the visible surface (mirrors T1 safe-bound intent).
+        private const val MIN_PCT = 0.05f
+        private const val MAX_PCT = 0.95f
+    }
+}

--- a/app/src/test/java/com/hank/clawlive/BroadcastFormationControllerTest.kt
+++ b/app/src/test/java/com/hank/clawlive/BroadcastFormationControllerTest.kt
@@ -1,0 +1,209 @@
+package com.hank.clawlive
+
+import com.hank.clawlive.engine.BroadcastFormationController
+import com.hank.clawlive.engine.BroadcastFormationController.Participant
+import kotlin.math.atan2
+import kotlin.math.hypot
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Child T4 — broadcast formation geometry tests (spec §8.3 + §6).
+ *
+ * Pure-Kotlin: no Android surface. Screen is a 1080x2400 portrait phone; sprite width 120px
+ * gives 1 entity-unit = 120 * 1.5 = 180px = 0.1667 of width. Spacing checks are done in
+ * *visual* (aspect-corrected px) space, matching how the halo is actually rendered.
+ */
+class BroadcastFormationControllerTest {
+    private val screenW = 1080f
+    private val screenH = 2400f
+    private val spriteW = 120f
+    private val oneEntityUnitPx = spriteW * BroadcastFormationController.ENTITY_UNIT_SPRITE_MULTIPLIER
+
+    private fun controller() = BroadcastFormationController()
+
+    /** Visual pixel distance between two screen-percent slots (x already aspect-corrected at plan time). */
+    private fun pxDistance(
+        ax: Float, ay: Float, bx: Float, by: Float
+    ): Float = hypot((ax - bx) * screenW, (ay - by) * screenH)
+
+    private fun grid(ids: List<Int>): List<Participant> = ids.mapIndexed { i, id ->
+        // spread starting positions around the screen so angular sort is meaningful
+        Participant(id, xPct = 0.2f + 0.1f * i, yPct = 0.2f + 0.08f * i)
+    }
+
+    @Test
+    fun senderTargetsScreenCenter() {
+        val parts = grid(listOf(1, 2, 3, 4))
+        val f = controller().plan(
+            senderId = 1,
+            participants = parts,
+            senderSpriteWidthPx = spriteW,
+            screenWidthPx = screenW,
+            screenHeightPx = screenH,
+            broadcastReceivedAtMs = 0L
+        )
+        assertEquals(1, f.senderSlot.entityId)
+        assertEquals(BroadcastFormationController.CENTER_X, f.senderSlot.xPct, 1e-6f)
+        assertEquals(BroadcastFormationController.CENTER_Y, f.senderSlot.yPct, 1e-6f)
+    }
+
+    @Test
+    fun fourEntitiesGetThreeDistinctNonOverlappingSlots() {
+        val parts = grid(listOf(1, 2, 3, 4))
+        val f = controller().plan(1, parts, spriteW, screenW, screenH, 0L)
+
+        assertEquals("sender excluded, 3 bystanders", 3, f.bystanderSlots.size)
+
+        // distinct slot positions
+        val keys = f.bystanderSlots.map { "${it.xPct},${it.yPct}" }.toSet()
+        assertEquals("all slots distinct", 3, keys.size)
+
+        // every bystander id present exactly once, sender absent
+        val ids = f.bystanderSlots.map { it.entityId }.toSet()
+        assertEquals(setOf(2, 3, 4), ids)
+
+        // >= 1 entity-unit from each other and from the sender (center)
+        assertSpacing(f)
+    }
+
+    @Test
+    fun eightEntitiesHitCountScaledRadiusAndStayApart() {
+        val parts = grid((1..8).toList())
+        val f = controller().plan(1, parts, spriteW, screenW, screenH, 0L)
+
+        assertEquals(7, f.bystanderSlots.size)
+        // spec §6.1 count-scaled floor dominates for large n (0.18 + 0.012*7 = 0.264 > 1.5*eu pct)
+        val euPct = oneEntityUnitPx / screenW
+        assertTrue(
+            "radius should hit count-scaled floor for n=7",
+            f.radiusPct >= 0.18f + 0.012f * 7 - 1e-4f
+        )
+        assertTrue("radius respects sprite floor", f.radiusPct >= 1.5f * euPct - 1e-4f)
+        assertSpacing(f)
+    }
+
+    @Test
+    fun radiusIsCappedForVeryLargeCounts() {
+        val parts = grid((1..40).toList())
+        val f = controller().plan(1, parts, spriteW, screenW, screenH, 0L)
+        assertTrue(
+            "radius capped at ${BroadcastFormationController.MAX_RADIUS_PCT}",
+            f.radiusPct <= BroadcastFormationController.MAX_RADIUS_PCT + 1e-6f
+        )
+    }
+
+    @Test
+    fun firstBystanderSitsAboveSender() {
+        // single bystander -> theta = -pi/2 -> directly above center (12 o'clock), spec §6.2
+        val parts = listOf(
+            Participant(1, 0.3f, 0.3f),
+            Participant(2, 0.8f, 0.8f)
+        )
+        val f = controller().plan(1, parts, spriteW, screenW, screenH, 0L)
+        assertEquals(1, f.bystanderSlots.size)
+        val slot = f.bystanderSlots[0]
+        assertEquals("x at center column", BroadcastFormationController.CENTER_X, slot.xPct, 1e-4f)
+        assertTrue("y above center (smaller y = higher)", slot.yPct < BroadcastFormationController.CENTER_Y)
+    }
+
+    @Test
+    fun sleepingEntityExcludedFromHalo() {
+        // spec §8.3 T4-3: 3 entities, one sleeping -> only 1 bystander at 12 o'clock
+        val parts = listOf(
+            Participant(1, 0.3f, 0.3f),                 // sender
+            Participant(2, 0.7f, 0.7f),                 // awake bystander
+            Participant(3, 0.6f, 0.6f, sleeping = true) // sleeping -> excluded
+        )
+        val f = controller().plan(1, parts, spriteW, screenW, screenH, 0L)
+        assertEquals("sleeping not recruited", 1, f.bystanderSlots.size)
+        assertEquals(2, f.bystanderSlots[0].entityId)
+    }
+
+    @Test
+    fun zeroBystandersSenderStillGoesToCenter() {
+        // spec X-3 / O-4
+        val parts = listOf(Participant(1, 0.3f, 0.3f))
+        val f = controller().plan(1, parts, spriteW, screenW, screenH, 0L)
+        assertEquals(0, f.bystanderSlots.size)
+        assertEquals(BroadcastFormationController.CENTER_X, f.senderSlot.xPct, 1e-6f)
+        assertEquals(BroadcastFormationController.CENTER_Y, f.senderSlot.yPct, 1e-6f)
+    }
+
+    @Test
+    fun formationHoldsForDwellWindowThenDismisses() {
+        // spec §6.4: halo persists until halo_dwell_seconds elapses
+        val ctrl = BroadcastFormationController(haloDwellSeconds = 6.0f)
+        val parts = grid(listOf(1, 2, 3))
+        val received = 10_000L
+        val f = ctrl.plan(1, parts, spriteW, screenW, screenH, received)
+
+        assertEquals(received + 6_000L, f.haloDismissAtMs)
+        assertTrue("holds at t=0", !ctrl.shouldDismiss(f, received))
+        assertTrue("holds mid-window", !ctrl.shouldDismiss(f, received + 5_999L))
+        assertTrue("dismisses at window end", ctrl.shouldDismiss(f, received + 6_000L))
+        assertTrue("dismisses after window", ctrl.shouldDismiss(f, received + 9_000L))
+    }
+
+    @Test
+    fun slotAssignmentPreservesAngularOrderToAvoidCrossing() {
+        // spec §6.3: bystanders are dropped onto ring slots in angular order of their current
+        // position. The anti-crossing invariant is that walking the slot ring clockwise visits
+        // entities in the same cyclic order as their origin angles around the sender.
+        val parts = listOf(
+            Participant(1, 0.5f, 0.5f),  // sender at center
+            Participant(2, 0.9f, 0.6f),  // lower-right
+            Participant(3, 0.1f, 0.6f),  // lower-left
+            Participant(4, 0.9f, 0.4f),  // upper-right
+            Participant(5, 0.1f, 0.4f)   // upper-left
+        )
+        val f = controller().plan(1, parts, spriteW, screenW, screenH, 0L)
+
+        // origin angle around center for each bystander
+        fun originAngle(id: Int): Double {
+            val p = parts.first { it.entityId == id }
+            return atan2((p.yPct - 0.5).toDouble(), (p.xPct - 0.5).toDouble())
+        }
+        // slots are emitted in ring order (clockwise from 12 o'clock). The entity ids in that
+        // emission order must be a rotation of the ids sorted by origin angle.
+        val emissionOrder = f.bystanderSlots.map { it.entityId }
+        val byOriginAngle = emissionOrder.sortedBy { originAngle(it) }
+
+        fun isRotationOf(a: List<Int>, b: List<Int>): Boolean {
+            if (a.size != b.size) return false
+            val doubled = b + b
+            for (start in b.indices) {
+                if (doubled.subList(start, start + a.size) == a) return true
+            }
+            return false
+        }
+        assertTrue(
+            "emission order $emissionOrder must be a rotation of origin-angle order $byOriginAngle",
+            isRotationOf(emissionOrder, byOriginAngle)
+        )
+    }
+
+    /** Asserts every bystander slot is >= 1 entity-unit from each other and from the sender center. */
+    private fun assertSpacing(f: BroadcastFormationController.Formation) {
+        val center = f.senderSlot
+        for (s in f.bystanderSlots) {
+            val dCenter = pxDistance(s.xPct, s.yPct, center.xPct, center.yPct)
+            assertTrue(
+                "slot ${s.entityId} must be >= 1 entity-unit ($oneEntityUnitPx px) from sender; was $dCenter",
+                dCenter >= oneEntityUnitPx - 1f
+            )
+        }
+        for (i in f.bystanderSlots.indices) {
+            for (j in i + 1 until f.bystanderSlots.size) {
+                val a = f.bystanderSlots[i]
+                val b = f.bystanderSlots[j]
+                val d = pxDistance(a.xPct, a.yPct, b.xPct, b.yPct)
+                assertTrue(
+                    "slots ${a.entityId} & ${b.entityId} must be >= 1 entity-unit apart; was $d",
+                    d >= oneEntityUnitPx - 1f
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implements Walking System child **T4 — Broadcast movement: sender→center, others surround** (card_005d4bd7fe65fb05641315f5), per `docs/specs/wallpaper-walking-system-architecture.md` §6.

## Scope
On a broadcast event (`@all` / speakTo all):
- **Sender** targets screen center `(0.5, 0.5)` for an accelerated walk.
- **Non-sleeping bystanders** form an evenly-distributed halo ring around the sender, kept ≥ 1 entity-unit apart from each other and the sender (no overlap).
- Formation **holds** until the dwell window elapses or a new broadcast cancels it (`shouldDismiss`).

Pure-Kotlin, testable geometry (no Android surface dependency); the wallpaper service wires `Formation` slots into T1's `WallpaperWanderController.setTarget` / `resumeWander`.

### Spec conformance
- 1 entity-unit = `sprite_width × 1.5` (§3), documented as `ENTITY_UNIT_SPRITE_MULTIPLIER`.
- Halo radius = `max(1.5·euPct, 0.18 + 0.012·n)` capped at `0.42` (§6.1).
- Even ring at `θ_i = -π/2 + 2π·i/n`, x aspect-corrected so the halo is visually circular on portrait (§6.2).
- Slot assignment in angular order of origin → anti-crossing (§6.3).
- Sleeping entities excluded from `n` and slots (§6 step 3 / §7.1).
- `n == 0` → sender still walks to center, dwell timer still ticks (O-4 / X-3).
- Halo dwell default 6.0s (§6.4 / O-6).

## Files
- `app/src/main/java/com/hank/clawlive/engine/BroadcastFormationController.kt` (new)
- `app/src/test/java/com/hank/clawlive/BroadcastFormationControllerTest.kt` (new)

## Tests — 9 JUnit, all passing
`./gradlew :app:testDebugUnitTest` → **BUILD SUCCESSFUL** (full app unit suite green, no regressions).
Covers: sender→center; 4 entities → 3 distinct non-overlapping ≥1eu slots; 8 entities → count-scaled radius + spacing; radius cap; 12-o'clock first slot; sleeping excluded (T4-3); zero-bystander sender-to-center; formation holds for dwell window then dismisses; angular-order anti-crossing.

Does not touch main / no merge. T1 foundation only; independent of T2/T3/T5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt7jNhQxvz1FkErAbyHneC