### PR TITLE
feat(android): Stage 2 settings-manifest consume + version-gate resolver (card_9ca1b7c2)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
+++ b/app/src/main/java/com/hank/clawlive/data/remote/ClawApiService.kt
@@ -11,6 +11,7 @@ import com.hank.clawlive.data.model.CrossSpeakResponse
 import com.hank.clawlive.data.model.ScheduleListResponse
 import com.hank.clawlive.data.model.ScheduleCreateResponse
 import com.hank.clawlive.data.model.ScheduleDeleteResponse
+import com.hank.clawlive.settings.SettingsManifestResponse
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
 import retrofit2.http.*
@@ -30,6 +31,17 @@ interface ClawApiService {
         @Query("entityId") entityId: Int = 0,
         @Query("appVersion") appVersion: String? = null
     ): AgentStatus
+
+    // Settings auto-sync seam (Stage 2): fetched at launch so the app surfaces
+    // each enabled settings feature natively or via WebView per `native`.
+    // Public GET — no auth (pure capability descriptor). Sending appVersion +
+    // platform lets the backend apply the minAppVersion version gate.
+    // See backend/lib/settings-manifest.js + docs/specs/settings-manifest-spec.md.
+    @GET("api/settings-manifest")
+    suspend fun getSettingsManifest(
+        @Query("appVersion") appVersion: String? = null,
+        @Query("platform") platform: String = "android"
+    ): SettingsManifestResponse
 
     // Device registration - get binding code
     @POST("api/device/register")

--- a/app/src/main/java/com/hank/clawlive/settings/SettingsManifest.kt
+++ b/app/src/main/java/com/hank/clawlive/settings/SettingsManifest.kt
@@ -1,0 +1,159 @@
+package com.hank.clawlive.settings
+
+/**
+ * Client-side model + resolver for the settings auto-sync seam (Stage 2).
+ *
+ * The backend ships `GET /api/settings-manifest?appVersion=&platform=` (Stage 1,
+ * see backend/lib/settings-manifest.js + docs/specs/settings-manifest-spec.md).
+ * Each enabled feature carries a `native` capability flag and a `webFallback`
+ * URL. The app must, per feature, decide how to surface it:
+ *
+ *   native == true       -> render the native screen for that feature
+ *   native == "partial"  -> render native UI + a "more on web" link -> webFallback
+ *   native == false      -> open webFallback in a WebView
+ *
+ * The backend already applies the `minAppVersion` version gate when the app sends
+ * `appVersion`. This client resolver mirrors that gate locally so the decision is
+ * correct EVEN IF the app failed to send `appVersion` (e.g. the manifest was
+ * cached, or fetched without the query param). A native flag the running binary
+ * cannot honor is therefore never trusted blindly: if the running app version is
+ * below the feature's `minAppVersion`, the feature is downgraded to the web
+ * fallback. This is a pure function — no Android deps — so it is unit-testable.
+ */
+
+/** One feature row as returned by GET /api/settings-manifest. */
+data class SettingsManifestFeature(
+    val key: String = "",
+    val name: String = "",
+    val enabled: Boolean = false,
+    // Gson decodes the JSON `native` field (true | "partial" | false) into Any?.
+    // Use [nativeSupport] to normalise it; never read this raw field directly.
+    val native: Any? = false,
+    val webFallback: String = "",
+    val minAppVersion: String = "0.0.0"
+)
+
+/** Top-level manifest envelope: GET /api/settings-manifest. */
+data class SettingsManifest(
+    val platform: String = "android",
+    val appVersion: String? = null,
+    val generatedAt: String? = null,
+    val stage: Int = 0,
+    val features: List<SettingsManifestFeature> = emptyList()
+)
+
+/** Retrofit response wrapper: { success, manifest }. */
+data class SettingsManifestResponse(
+    val success: Boolean = false,
+    val manifest: SettingsManifest? = null,
+    val error: String? = null
+)
+
+/** Normalised native-support level for one feature on this platform. */
+enum class NativeSupport { FULL, PARTIAL, NONE }
+
+/**
+ * How the app should surface one resolved feature.
+ *
+ * - [NATIVE]        : render the native screen ([NativeSupport.FULL]).
+ * - [NATIVE_PLUS_WEB]: render native UI + a "more on web" link to [webFallback]
+ *                      ([NativeSupport.PARTIAL]).
+ * - [WEB]           : open [webFallback] in a WebView ([NativeSupport.NONE], or a
+ *                      higher level downgraded by the version gate).
+ */
+enum class FeatureSurface { NATIVE, NATIVE_PLUS_WEB, WEB }
+
+/** A feature after the client version gate has been applied. */
+data class ResolvedFeature(
+    val key: String,
+    val name: String,
+    val surface: FeatureSurface,
+    val webFallback: String
+)
+
+object SettingsManifestResolver {
+
+    /** Parse the raw `native` JSON value (true | "partial" | false) into an enum. */
+    fun nativeSupport(raw: Any?): NativeSupport = when (raw) {
+        true -> NativeSupport.FULL
+        is String -> if (raw.equals("partial", ignoreCase = true)) {
+            NativeSupport.PARTIAL
+        } else {
+            // Any non-"partial" string (incl. "false", "true", "") is treated as
+            // "not natively renderable" — fail safe to the web fallback.
+            if (raw.equals("true", ignoreCase = true)) NativeSupport.FULL else NativeSupport.NONE
+        }
+        else -> NativeSupport.NONE
+    }
+
+    /**
+     * Compare two dotted version strings. Returns -1 / 0 / 1. Mirrors
+     * backend/lib/settings-manifest.js `compareVersions` (non-numeric or missing
+     * segments are treated as 0). Tolerant of suffixes like "1.2.3-debug".
+     */
+    fun compareVersions(v1: String, v2: String): Int {
+        val a = splitVersion(v1)
+        val b = splitVersion(v2)
+        val n = maxOf(a.size, b.size)
+        for (i in 0 until n) {
+            val p1 = a.getOrElse(i) { 0 }
+            val p2 = b.getOrElse(i) { 0 }
+            if (p1 < p2) return -1
+            if (p1 > p2) return 1
+        }
+        return 0
+    }
+
+    private fun splitVersion(v: String): List<Int> =
+        v.split('.').map { seg ->
+            // Take the leading run of digits ("3-debug" -> 3), default 0.
+            seg.takeWhile { it.isDigit() }.toIntOrNull() ?: 0
+        }
+
+    /**
+     * Resolve one feature against the running app version, applying the
+     * minAppVersion gate. A FULL/PARTIAL native flag is downgraded to the web
+     * surface when the running app is older than the feature's minAppVersion.
+     *
+     * @param appVersion the running app's versionName. When null/blank, the
+     *   declared native level is trusted (the backend reports it as declared
+     *   when no appVersion is sent).
+     */
+    fun resolveFeature(feature: SettingsManifestFeature, appVersion: String?): ResolvedFeature {
+        val declared = nativeSupport(feature.native)
+        val gated = if (declared == NativeSupport.NONE) {
+            NativeSupport.NONE
+        } else if (appVersion.isNullOrBlank()) {
+            declared
+        } else if (compareVersions(appVersion, feature.minAppVersion) < 0) {
+            // Running app predates native support for this feature -> web fallback.
+            NativeSupport.NONE
+        } else {
+            declared
+        }
+
+        val surface = when (gated) {
+            NativeSupport.FULL -> FeatureSurface.NATIVE
+            NativeSupport.PARTIAL -> FeatureSurface.NATIVE_PLUS_WEB
+            NativeSupport.NONE -> FeatureSurface.WEB
+        }
+
+        return ResolvedFeature(
+            key = feature.key,
+            name = feature.name,
+            surface = surface,
+            webFallback = feature.webFallback
+        )
+    }
+
+    /**
+     * Resolve every ENABLED feature in the manifest into a render plan. Disabled
+     * features are dropped (the app surfaces nothing for them).
+     */
+    fun resolve(manifest: SettingsManifest?, appVersion: String?): List<ResolvedFeature> {
+        if (manifest == null) return emptyList()
+        return manifest.features
+            .filter { it.enabled }
+            .map { resolveFeature(it, appVersion) }
+    }
+}

--- a/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
+++ b/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
@@ -1,6 +1,7 @@
 package com.hank.clawlive
 
 import com.hank.clawlive.settings.NotificationPreferenceCatalogTest
+import com.hank.clawlive.settings.SettingsManifestResolverTest
 import org.junit.runner.RunWith
 import org.junit.runners.Suite
 
@@ -18,6 +19,7 @@ import org.junit.runners.Suite
     ChatEchoSuppressionTest::class,
     WallpaperWanderControllerTest::class,
     CompanionDescriptorAnimationTest::class,
-    NotificationPreferenceCatalogTest::class
+    NotificationPreferenceCatalogTest::class,
+    SettingsManifestResolverTest::class
 )
 class UnitTestSuite

--- a/app/src/test/java/com/hank/clawlive/settings/SettingsManifestResolverTest.kt
+++ b/app/src/test/java/com/hank/clawlive/settings/SettingsManifestResolverTest.kt
@@ -1,0 +1,132 @@
+package com.hank.clawlive.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * Pure-logic tests for the Stage-2 client manifest resolver. Mirrors the
+ * backend contract in backend/lib/settings-manifest.js + the worked version-gate
+ * example in docs/specs/settings-manifest-spec.md §3. No Android deps.
+ */
+class SettingsManifestResolverTest {
+
+    // ── native flag normalisation ────────────────────────────────────────────
+
+    @Test
+    fun nativeSupport_normalisesTruePartialFalse() {
+        assertEquals(NativeSupport.FULL, SettingsManifestResolver.nativeSupport(true))
+        assertEquals(NativeSupport.PARTIAL, SettingsManifestResolver.nativeSupport("partial"))
+        assertEquals(NativeSupport.PARTIAL, SettingsManifestResolver.nativeSupport("PARTIAL"))
+        assertEquals(NativeSupport.NONE, SettingsManifestResolver.nativeSupport(false))
+        assertEquals(NativeSupport.NONE, SettingsManifestResolver.nativeSupport(null))
+        // "true" as a JSON string still means natively renderable.
+        assertEquals(NativeSupport.FULL, SettingsManifestResolver.nativeSupport("true"))
+        // Any unknown string fails safe to web.
+        assertEquals(NativeSupport.NONE, SettingsManifestResolver.nativeSupport("maybe"))
+    }
+
+    // ── compareVersions parity with backend ──────────────────────────────────
+
+    @Test
+    fun compareVersions_matchesBackendSemantics() {
+        assertEquals(-1, SettingsManifestResolver.compareVersions("1.0.0", "2.5.0"))
+        assertEquals(0, SettingsManifestResolver.compareVersions("2.5.0", "2.5.0"))
+        assertEquals(1, SettingsManifestResolver.compareVersions("3.0.0", "2.5.0"))
+        // Missing segments treated as 0.
+        assertEquals(0, SettingsManifestResolver.compareVersions("1.0", "1.0.0"))
+        assertEquals(1, SettingsManifestResolver.compareVersions("1.0.1", "1.0"))
+        // Suffixed build names tolerated (leading digits only).
+        assertEquals(0, SettingsManifestResolver.compareVersions("2.5.0-debug", "2.5.0"))
+    }
+
+    // ── version gating (spec §3 worked example: companion_petdx) ──────────────
+
+    private fun feature(native: Any?, minVer: String) = SettingsManifestFeature(
+        key = "companion_petdx",
+        name = "Companion (PetDX)",
+        enabled = true,
+        native = native,
+        webFallback = "https://eclawbot.com/portal/settings.html?focus=companion_petdx",
+        minAppVersion = minVer
+    )
+
+    @Test
+    fun resolve_oldAppBelowMinVersion_downgradesToWeb() {
+        val r = SettingsManifestResolver.resolveFeature(feature(true, "2.5.0"), "1.0.0")
+        assertEquals(FeatureSurface.WEB, r.surface)
+        assertEquals("https://eclawbot.com/portal/settings.html?focus=companion_petdx", r.webFallback)
+    }
+
+    @Test
+    fun resolve_appAtMinVersion_getsNative() {
+        val r = SettingsManifestResolver.resolveFeature(feature(true, "2.5.0"), "2.5.0")
+        assertEquals(FeatureSurface.NATIVE, r.surface)
+    }
+
+    @Test
+    fun resolve_appAboveMinVersion_getsNative() {
+        val r = SettingsManifestResolver.resolveFeature(feature(true, "2.5.0"), "3.0.0")
+        assertEquals(FeatureSurface.NATIVE, r.surface)
+    }
+
+    @Test
+    fun resolve_partialFeatureAboveGate_getsNativePlusWeb() {
+        val r = SettingsManifestResolver.resolveFeature(feature("partial", "1.0.0"), "1.0.0")
+        assertEquals(FeatureSurface.NATIVE_PLUS_WEB, r.surface)
+    }
+
+    @Test
+    fun resolve_partialFeatureBelowGate_downgradesToWeb() {
+        val r = SettingsManifestResolver.resolveFeature(feature("partial", "2.0.0"), "1.0.0")
+        assertEquals(FeatureSurface.WEB, r.surface)
+    }
+
+    @Test
+    fun resolve_nativeFalseFeature_alwaysWeb_evenOnNewApp() {
+        // rotate_secret / switch_device today: native:false on both platforms.
+        val r = SettingsManifestResolver.resolveFeature(feature(false, "0.0.0"), "99.0.0")
+        assertEquals(FeatureSurface.WEB, r.surface)
+    }
+
+    @Test
+    fun resolve_missingAppVersion_trustsDeclaredNative() {
+        // Backend reports native as declared when appVersion is absent; the client
+        // resolver mirrors that (no downgrade) so cached/param-less fetches agree.
+        val r = SettingsManifestResolver.resolveFeature(feature(true, "2.5.0"), null)
+        assertEquals(FeatureSurface.NATIVE, r.surface)
+        val rBlank = SettingsManifestResolver.resolveFeature(feature(true, "2.5.0"), "")
+        assertEquals(FeatureSurface.NATIVE, rBlank.surface)
+    }
+
+    // ── manifest-level resolve ───────────────────────────────────────────────
+
+    @Test
+    fun resolveManifest_dropsDisabled_andGatesEach() {
+        val manifest = SettingsManifest(
+            platform = "android",
+            appVersion = "1.0.0",
+            stage = 1,
+            features = listOf(
+                SettingsManifestFeature("account_identity", "Account & Identity", true, true, "wf_a", "1.0.0"),
+                SettingsManifestFeature("rotate_secret", "Rotate Secret", true, false, "wf_r", "0.0.0"),
+                SettingsManifestFeature("companion_petdx", "Companion", true, true, "wf_c", "2.5.0"),
+                SettingsManifestFeature("hidden_feature", "Hidden", false, true, "wf_h", "1.0.0")
+            )
+        )
+        val resolved = SettingsManifestResolver.resolve(manifest, "1.0.0")
+
+        // disabled feature dropped
+        assertEquals(listOf("account_identity", "rotate_secret", "companion_petdx"), resolved.map { it.key })
+        // account: native at min 1.0.0 on a 1.0.0 app
+        assertEquals(FeatureSurface.NATIVE, resolved[0].surface)
+        // rotate_secret: native:false -> web
+        assertEquals(FeatureSurface.WEB, resolved[1].surface)
+        // companion: gated out (1.0.0 < 2.5.0) -> web
+        assertEquals(FeatureSurface.WEB, resolved[2].surface)
+    }
+
+    @Test
+    fun resolveManifest_nullManifest_isEmpty() {
+        assertEquals(emptyList<ResolvedFeature>(), SettingsManifestResolver.resolve(null, "1.0.0"))
+    }
+}


### PR DESCRIPTION
## Card
card_9ca1b7c2d2d5fa378c5d248b — Stage 2 of settings→APP auto-sync (parent card_6dbb98223cadc793a96f4246, spec `docs/specs/settings-manifest-spec.md`).

## Scope
Android client seam to **consume** `GET /api/settings-manifest` (Stage 1, already shipped: `backend/lib/settings-manifest.js` + endpoint in `backend/index.js`) and decide, per enabled feature, whether to render the native screen or open the web fallback in a WebView.

- **`ClawApiService.getSettingsManifest(appVersion, platform="android")`** — public GET wired to the Stage-1 endpoint; sends `appVersion`+`platform` so the backend `minAppVersion` gate applies (spec §2.1).
- **`settings/SettingsManifest.kt`** — Gson models + pure-logic `SettingsManifestResolver` that mirrors backend `resolveNative` / `compareVersions`. Resolves each enabled feature to `NATIVE` / `NATIVE_PLUS_WEB` / `WEB`, **re-applying the version gate client-side** so a native flag the running binary can't honor is downgraded to the web fallback even on a cached / param-less fetch.
- **`SettingsManifestResolverTest`** — 11 pure-logic tests (native-flag normalisation true/"partial"/false, `compareVersions` parity with backend, spec §3 `companion_petdx` version-gate worked example, disabled-feature drop, null-manifest). Registered in `UnitTestSuite`.

## Test plan / Evidence
`./gradlew :app:testDebugUnitTest` — full unit suite green: SettingsManifestResolverTest **11/11**, plus all pre-existing (ChatEchoSuppression 15, WallpaperWanderController 7, MessageRequestFormat 5, NotificationPreferenceCatalog 3, CompanionDescriptorAnimation 2) — 0 failures / 0 errors. My code compiles clean (only pre-existing warnings in unrelated files).

## Out of scope (remaining for this stage — needs a device build to verify)
Wiring the resolved render plan into `SettingsActivity` row rendering + WebView open (UI, needs on-device E2E). This PR ships the testable consume/resolve core so the device-build step is a thin, verified-logic integration.

## User POV / Globe-user
Pure capability descriptor, no device/entity/locale hardcoding — the resolver behaves identically for every user worldwide; gating keyed only on the running app's `versionName`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt7jNhQxvz1FkErAbyHneC