### PR TITLE
feat(portal): destructive confirm modal entrance animation + reduced-motion gate (card_e5c460fb)

### DIFF
--- a/backend/public/portal/shared/api.js
+++ b/backend/public/portal/shared/api.js
@@ -188,6 +188,35 @@ function _eclawUnlockBodyScroll() {
     }
 }
 const _ECLAW_DIALOG_SHADOW_STYLE = 'style="box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);"';
+
+// ─── Entrance animation (card_e5c460fb) ───
+// Inject a one-time <style> that gives the shared destructive-confirm modal a
+// subtle mount entrance: a backdrop fade on `.eclaw-confirm-overlay` and an
+// opacity+scale rise on `.eclaw-confirm-dialog`. Scoped to the eclaw-confirm-*
+// classes so the shared base `.dialog` (used by other modals) is untouched.
+//
+// Both animations are gated behind `@media (prefers-reduced-motion: reduce)`
+// → `animation: none` so users who opt out get the prior instant render with
+// zero motion. The keyframes start at opacity:1 / scale:1 only as a no-op
+// fallback; the `animation` shorthand drives the 0→1 / 0.96→1 transition.
+const _ECLAW_DIALOG_ANIM_STYLE_ID = 'eclaw-confirm-anim-style';
+function _eclawEnsureDialogAnimStyle() {
+    if (typeof document === 'undefined' || !document.head) return;
+    if (document.getElementById(_ECLAW_DIALOG_ANIM_STYLE_ID)) return;
+    const style = document.createElement('style');
+    style.id = _ECLAW_DIALOG_ANIM_STYLE_ID;
+    style.textContent = `
+@keyframes eclawConfirmOverlayIn { from { opacity: 0; } to { opacity: 1; } }
+@keyframes eclawConfirmDialogIn { from { opacity: 0; transform: scale(0.96); } to { opacity: 1; transform: scale(1); } }
+.eclaw-confirm-overlay { animation: eclawConfirmOverlayIn 160ms ease-out both; }
+.eclaw-confirm-dialog { animation: eclawConfirmDialogIn 160ms ease-out both; }
+@media (prefers-reduced-motion: reduce) {
+    .eclaw-confirm-overlay,
+    .eclaw-confirm-dialog { animation: none; }
+}`;
+    document.head.appendChild(style);
+}
+
 function showConfirm({ message, title, confirmText, cancelText, danger, itemName } = {}) {
     // Dev-time hint: destructive confirms should name the item so a fast-clicking user can
     // verify what's about to be destroyed. Localhost / dev hosts only; silent in production.
@@ -228,6 +257,7 @@ function showConfirm({ message, title, confirmText, cancelText, danger, itemName
                 <button type="button" class="btn ${danger ? 'btn-danger' : 'btn-primary'} eclaw-confirm-ok"${danger && !confirmText ? ` aria-label="${_escAttr(t('dialog_confirm_destructive', 'Confirm destructive action'))}"` : ''}>${danger ? '<span class="eclaw-confirm-danger-glyph" aria-hidden="true">⚠ </span>' : ''}${_escHtml(confirmText || (danger ? t('dialog_confirm', 'Confirm') : t('dialog_ok', 'OK')))}</button>
             </div>
         </div>`;
+        _eclawEnsureDialogAnimStyle();
         document.body.appendChild(overlay);
         _eclawLockBodyScroll();
         const cleanup = (result) => { document.removeEventListener('keydown', _keyHandler, true); overlay.remove(); _eclawUnlockBodyScroll(); resolve(result); };
@@ -306,6 +336,7 @@ function showPrompt({ message, title, defaultValue, placeholder, confirmText, ca
                 <button type="button" class="btn btn-primary eclaw-confirm-ok">${_escHtml(confirmText || t('dialog_ok', 'OK'))}</button>
             </div>
         </div>`;
+        _eclawEnsureDialogAnimStyle();
         document.body.appendChild(overlay);
         _eclawLockBodyScroll();
         const input = overlay.querySelector('.eclaw-prompt-input');

--- a/backend/tests/jest/showConfirm-entrance-anim.test.js
+++ b/backend/tests/jest/showConfirm-entrance-anim.test.js
@@ -1,0 +1,89 @@
+/**
+ * Static invariant test for the destructive-confirm modal entrance animation.
+ *
+ * Card: card_e5c460fbe8cb77d711d4523b (P3) — pure-CSS mount entrance for the
+ * shared `showConfirm` / `showPrompt` modal: a backdrop fade on
+ * `.eclaw-confirm-overlay` + an opacity/scale rise on `.eclaw-confirm-dialog`,
+ * BOTH gated behind `@media (prefers-reduced-motion: reduce)` → no animation.
+ *
+ * jest.config.js uses testEnvironment: 'node', so (matching the sibling
+ * showConfirm-*.test.js files) these assertions grep the injected CSS in the
+ * source rather than running a JSDOM render. A future edit that drops the
+ * keyframes, the animation property, or the reduced-motion gate fails here.
+ *
+ * The two acceptance behaviours map to two source facts:
+ *   1. animation present (≤200ms fade+scale)  → keyframes + `animation:` shorthand
+ *   2. prefers-reduced-motion:reduce → instant → `@media (...) { animation: none }`
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const apiJs = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'public', 'portal', 'shared', 'api.js'),
+    'utf8'
+);
+
+// Isolate the injected <style> string so the reduced-motion assertions can't be
+// satisfied by unrelated CSS elsewhere in the file.
+const styleBlockMatch = apiJs.match(/_eclawEnsureDialogAnimStyle[\s\S]*?document\.head\.appendChild\(style\)/);
+
+describe('showConfirm — entrance animation (card_e5c460fb)', () => {
+    test('a one-time animation <style> injector exists and is idempotent', () => {
+        // Guarded by a stable id so re-opening the modal does not append a 2nd
+        // <style>; injector is a no-op when the node already exists.
+        expect(apiJs).toMatch(/function\s+_eclawEnsureDialogAnimStyle\s*\(/);
+        expect(apiJs).toMatch(/getElementById\(_ECLAW_DIALOG_ANIM_STYLE_ID\)/);
+        expect(apiJs).toMatch(/_ECLAW_DIALOG_ANIM_STYLE_ID\s*=\s*['"]eclaw-confirm-anim-style['"]/);
+    });
+
+    test('injector is invoked before the overlay is mounted (both modals)', () => {
+        // showConfirm + showPrompt both share .eclaw-confirm-* classes; the
+        // call must precede appendChild so the keyframe runs on mount. Two
+        // render sites → injector referenced at least twice.
+        const calls = apiJs.match(/_eclawEnsureDialogAnimStyle\(\);\s*\n\s*document\.body\.appendChild\(overlay\)/g) || [];
+        expect(calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    test('keyframes define a backdrop fade and an opacity+scale dialog rise', () => {
+        expect(styleBlockMatch).not.toBeNull();
+        const css = styleBlockMatch[0];
+        // Overlay backdrop opacity fade.
+        expect(css).toMatch(/@keyframes\s+eclawConfirmOverlayIn\s*\{[^}]*opacity:\s*0[^}]*\}/);
+        // Dialog: opacity 0→1 AND transform scale(0.96)→1.
+        expect(css).toMatch(/@keyframes\s+eclawConfirmDialogIn\s*\{[\s\S]*?opacity:\s*0;\s*transform:\s*scale\(0\.96\)/);
+        expect(css).toMatch(/transform:\s*scale\(1\)/);
+    });
+
+    test('animation property is wired to the eclaw-confirm-* classes (≤200ms)', () => {
+        const css = styleBlockMatch[0];
+        // Overlay + dialog each get the keyframe via the `animation` shorthand.
+        expect(css).toMatch(/\.eclaw-confirm-overlay\s*\{\s*animation:\s*eclawConfirmOverlayIn\s+160ms\s+ease-out/);
+        expect(css).toMatch(/\.eclaw-confirm-dialog\s*\{\s*animation:\s*eclawConfirmDialogIn\s+160ms\s+ease-out/);
+        // Duration must satisfy acceptance #1 (entrance ≤200ms).
+        const durs = [...css.matchAll(/animation:[^;]*?(\d+)ms/g)].map((m) => Number(m[1]));
+        expect(durs.length).toBeGreaterThanOrEqual(2);
+        durs.forEach((d) => expect(d).toBeLessThanOrEqual(200));
+    });
+
+    test('prefers-reduced-motion:reduce disables BOTH animations (instant)', () => {
+        // Acceptance #2: opt-out users get animation:none on overlay AND dialog.
+        const css = styleBlockMatch[0];
+        const rmMatch = css.match(/@media\s*\(\s*prefers-reduced-motion:\s*reduce\s*\)\s*\{([\s\S]*?)\}/);
+        expect(rmMatch).not.toBeNull();
+        const rmBody = rmMatch[1];
+        expect(rmBody).toMatch(/\.eclaw-confirm-overlay/);
+        expect(rmBody).toMatch(/\.eclaw-confirm-dialog/);
+        expect(rmBody).toMatch(/animation:\s*none/);
+    });
+
+    test('a11y + dismiss contract untouched (no regression)', () => {
+        // Cheap guard so this CSS-only card cannot have quietly dropped the
+        // verified-good behaviours while editing the same function.
+        expect(apiJs).toMatch(/role="alertdialog"/);
+        expect(apiJs).toMatch(/aria-modal="true"/);
+        expect(apiJs).toMatch(/if\s*\(\s*e\.key\s*===\s*['"]Escape['"]\s*\)\s*cleanup\(\s*false\s*\)/);
+        expect(apiJs).toMatch(/btn-danger/);
+    });
+});


### PR DESCRIPTION
## Card
card_e5c460fbe8cb77d711d4523b (P3) — entrance animation for the shared destructive confirm modal.

## What
Pure-CSS mount entrance for the shared `showConfirm` / `showPrompt` modal (`backend/public/portal/shared/api.js`). No JS behavior change.

A one-time scoped `<style>` (`_eclawEnsureDialogAnimStyle`, id-guarded, idempotent) is injected on first modal open:

\`\`\`css
@keyframes eclawConfirmOverlayIn { from { opacity: 0; } to { opacity: 1; } }
@keyframes eclawConfirmDialogIn  { from { opacity: 0; transform: scale(0.96); } to { opacity: 1; transform: scale(1); } }
.eclaw-confirm-overlay { animation: eclawConfirmOverlayIn 160ms ease-out both; }
.eclaw-confirm-dialog  { animation: eclawConfirmDialogIn  160ms ease-out both; }
@media (prefers-reduced-motion: reduce) {
    .eclaw-confirm-overlay,
    .eclaw-confirm-dialog { animation: none; }
}
\`\`\`

- Backdrop opacity fade on `.eclaw-confirm-overlay`
- Dialog opacity 0→1 + transform scale(0.96)→1, 160ms ease-out (≤200ms)
- BOTH gated behind `@media (prefers-reduced-motion: reduce)` → `animation: none` (instant for opt-out users)
- Scoped to `.eclaw-confirm-*` so the shared base `.dialog` (used by other modals) is untouched

## Acceptance
1. ✅ Destructive `showConfirm` shows a 160ms fade+scale entrance (Playwright: `animationName=eclawConfirmDialogIn`, `animationDuration=0.16s`)
2. ✅ `prefers-reduced-motion: reduce` → CSSOM media rule resolves `animation-name: none` for both selectors
3. ✅ No console-error delta (only a harness favicon 404, unrelated)
4. ✅ Dialog fully in viewport at mobile 390x844 and desktop 1280x800
5. ✅ a11y unchanged: `role=alertdialog`, `aria-modal`, default focus on Cancel, Tab focus-trap, Esc dismiss, backdrop-no-dismiss, `btn-danger` on OK — all intact
6. ✅ Test added: `backend/tests/jest/showConfirm-entrance-anim.test.js` (source-grep style, matching sibling `showConfirm-*.test.js`)

## Tests
\`\`\`
npx jest showConfirm-entrance-anim showConfirm-a11y-attrs showConfirm-danger-default-focus showConfirm-scroll-lock
Test Suites: 4 passed, 4 total
Tests:       22 passed, 22 total
\`\`\`
Plus a live Playwright render of the real `api.js` confirming computed `animationName`/duration present (no reduced-motion) and the reduced-motion `@media` rule present in CSSOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt7jNhQxvz1FkErAbyHneC