### PR TITLE
test(petdx): lock in avatar.webp 404 invariant — sprite-crop is canonical (card_8aabe541)

### DIFF
--- a/backend/tests/jest/community-plaza-avatar-petdx.test.js
+++ b/backend/tests/jest/community-plaza-avatar-petdx.test.js
@@ -13,6 +13,22 @@ const RENTAL_JS = fs.readFileSync(
     path.join(__dirname, '../../rental.js'),
     'utf8',
 );
+const ENTITY_UTILS_JS = fs.readFileSync(
+    path.join(__dirname, '../../public/portal/shared/entity-utils.js'),
+    'utf8',
+);
+const PETDEX_BRIDGE_JS = fs.readFileSync(
+    path.join(__dirname, '../../petdex-bridge.js'),
+    'utf8',
+);
+const COMPANION_API_JS = fs.readFileSync(
+    path.join(__dirname, '../../companion-api.js'),
+    'utf8',
+);
+const BACKFILL_AVATAR_JS = fs.readFileSync(
+    path.join(__dirname, '../../scripts/backfill-companion-avatar-url.js'),
+    'utf8',
+);
 
 describe('community.html — bot plaza must surface PETDX companion avatar', () => {
     test('loads entity-utils.js + avatar-petdx.js shared modules', () => {
@@ -81,5 +97,81 @@ describe('rental.js — marketplace + listing detail expose petdx_avatar_url', (
         expect(body).toMatch(/bl\.avatar_url/);
         expect(body).toMatch(/companion_select_log/);
         expect(body).toMatch(/petdx_avatar_url/);
+    });
+});
+
+// ─────────────────────────────────────────────────────────────────────────
+// avatar.webp 404 invariant — card_8aabe54193a4eefa21dced81 (P3)
+//
+// GET /api/petdx/<slug>/avatar.webp 404s on prod for bridge-synced companions
+// (e.g. zoro) because the avatar.webp R2 key is never populated by the catalog
+// bridge. That is NON-BLOCKING and BY DESIGN: the canonical avatar source is the
+// shared renderAvatarHtml() CSS sprite-crop path (PR #3539), and every emitted
+// petdx_avatar_url points at sprite.webp — which the crop path renders correctly.
+//
+// The avatar.webp single-frame URL is a Phase 4/5 optimization that is ONLY ever
+// emitted AFTER its bytes are written to R2 (deriveSpriteAvatarUrl on submit, and
+// the backfill cron, both PUT before repointing avatar_url). These tests lock in
+// that invariant so no future change can emit an avatar.webp URL that 404s.
+// ─────────────────────────────────────────────────────────────────────────
+describe('avatar.webp 404 invariant — sprite-crop is the canonical avatar source', () => {
+    test('shared renderAvatarHtml crops petdx sprite.webp (background-size 800% 900%)', () => {
+        // The crop branch is the canonical avatar render for petdx sprite URLs.
+        expect(ENTITY_UTILS_JS).toMatch(/function\s+isPetdxSprite\s*\(/);
+        // isPetdxSprite matches sprite.webp / sprite.png — NOT avatar.webp.
+        expect(ENTITY_UTILS_JS).toMatch(/sprite\\\.\(webp\|png\)/);
+        expect(ENTITY_UTILS_JS).not.toMatch(/isPetdxSprite[\s\S]{0,200}avatar\\\.webp/);
+        // The crop branch frame-0 CSS — the source of correct rendering.
+        expect(ENTITY_UTILS_JS).toMatch(/background-size:\s*800%\s*900%/);
+    });
+
+    test('catalog bridge stores sprite.webp as avatar_url (never avatar.webp)', () => {
+        // spriteProxyUrl — the value the bridge writes to companions.avatar_url —
+        // must end in sprite.webp so bridge-synced companions render via the crop
+        // path and never reference an unpopulated avatar.webp key.
+        const fn = PETDEX_BRIDGE_JS.split('function spriteProxyUrl')[1] || '';
+        const body = fn.split(/\nfunction /)[0];
+        expect(body).toMatch(/sprite\.webp/);
+        expect(body).not.toMatch(/avatar\.webp/);
+    });
+
+    test('deriveSpriteAvatarUrl PUTs avatar.webp to R2 BEFORE returning the avatar.webp URL', () => {
+        // The submit-path derive must upload the cropped frame to R2 and only then
+        // return the /api/petdx/<slug>/avatar.webp proxy URL — so a returned
+        // avatar.webp URL always has bytes behind it (no 404 emitted).
+        const fn = COMPANION_API_JS.split('async function deriveSpriteAvatarUrl')[1] || '';
+        const body = fn.split(/\n(?:async )?function /)[0];
+        const putIdx = body.indexOf('PutObjectCommand');
+        const urlIdx = body.search(/return\s+`[^`]*avatar\.webp/);
+        expect(putIdx).toBeGreaterThan(-1);
+        expect(urlIdx).toBeGreaterThan(-1);
+        // The PUT must precede the avatar.webp return.
+        expect(putIdx).toBeLessThan(urlIdx);
+    });
+
+    test('backfill cron PUTs avatar.webp to R2 BEFORE repointing avatar_url', () => {
+        // The Phase-5 backfill must upload the avatar.webp object and only then
+        // UPDATE companions.avatar_url to the avatar.webp URL — same no-404
+        // invariant for the batch path.
+        const fn = BACKFILL_AVATAR_JS.split('async function runBackfill')[1] || '';
+        const body = fn.split(/\n(?:async )?function /)[0];
+        const putIdx = body.indexOf('PutObjectCommand');
+        const updateIdx = body.search(/UPDATE companions SET avatar_url/);
+        expect(putIdx).toBeGreaterThan(-1);
+        expect(updateIdx).toBeGreaterThan(-1);
+        expect(putIdx).toBeLessThan(updateIdx);
+    });
+
+    test('petdx_avatar_url consumers route through the crop-aware renderAvatarHtml', () => {
+        // marketplace.html + community.html feed petdx_avatar_url into
+        // renderAvatarHtml / resolveBotAvatar — the crop path — never a raw <img>
+        // that would 404 on a missing avatar.webp.
+        const MARKETPLACE_HTML = fs.readFileSync(
+            path.join(__dirname, '../../public/portal/marketplace.html'),
+            'utf8',
+        );
+        expect(MARKETPLACE_HTML).toMatch(/petdx_avatar_url/);
+        expect(MARKETPLACE_HTML).toMatch(/renderAvatarHtml\(/);
+        expect(COMMUNITY_HTML).toMatch(/resolveBotAvatar\(\s*\{\s*petdxAvatarUrl:\s*l\.petdx_avatar_url/);
     });
 });


### PR DESCRIPTION
## Card
card_8aabe54193a4eefa21dced81 (P3) — `GET /api/petdx/<companion>/avatar.webp` → 404 on prod (e.g. `zoro`); `petdx_avatar_url` in `/api/rental/marketplace` still points to `sprite.webp`.

## Decision: DATA state, not a code defect → add a regression test (no code fix)

Investigated both hypotheses (avatar.webp dead/superseded vs. route mis-deployed). The system is **already self-consistent** — the 404 is a benign data state, not a bug:

| Concern | Evidence |
|---|---|
| Where is `avatar_url` (→ `petdx_avatar_url`) set? | `petdex-bridge.js:186-187,237-238` — the catalog bridge writes **`sprite.webp`** as `avatar_url` for synced companions like `zoro`. |
| Who consumes `petdx_avatar_url`? | `marketplace.html:858`, `community.html:1350,1702` → all feed it into shared `renderAvatarHtml()` / `resolveBotAvatar()`. |
| Does the crop path render sprite.webp correctly? | `entity-utils.js:230-239` (PR #3539) — `isPetdxSprite` matches `sprite.webp` and CSS-crops frame 0 (`background-size:800% 900%`). Renders correctly. |
| Does anything emit `avatar.webp` as a URL that could 404? | No. `companion-api.js` `deriveSpriteAvatarUrl` (submit path) and `scripts/backfill-companion-avatar-url.js` (cron) both **PUT** `avatar.webp` to R2 **before** returning/repointing the `avatar.webp` URL. So an `avatar.webp` URL is only ever emitted after its bytes exist. |

The `GET .../avatar.webp` route (`petdex-route.js:70`) is correct code. `zoro/avatar.webp` 404s only because (a) the backfill cron hasn't run for that slug, so `avatar_url` is still `sprite.webp` (renders fine via crop), and (b) nothing emits `avatar.webp` for `zoro` — a direct hit to that URL is the only way to see the 404.

**`avatar.webp` is a Phase 4/5 single-frame optimization, NOT superseded — it's a no-404 lazy path.** The CSS sprite-crop (PR #3539) is the canonical render today; `avatar.webp` repointing is an optional speedup once the backfill populates R2.

## Change
Adds a `describe('avatar.webp 404 invariant ...')` block to `community-plaza-avatar-petdx.test.js` (source-grep style, matching the existing convention) locking in:
1. Shared `renderAvatarHtml` crops `sprite.webp` (`background-size:800% 900%`); `isPetdxSprite` matches sprite.webp, not avatar.webp.
2. The bridge stores `sprite.webp` (never `avatar.webp`).
3. `deriveSpriteAvatarUrl` PUTs avatar.webp to R2 **before** returning the avatar.webp URL.
4. The backfill cron PUTs avatar.webp **before** repointing `avatar_url`.
5. `petdx_avatar_url` consumers route through the crop-aware `renderAvatarHtml`.

This prevents any future regression where the bridge/derive emits an `avatar.webp` URL before its bytes exist.

## Recommended ops follow-up (no code needed)
To eliminate the prod 404 for synced slugs, run the existing backfill once per env: `node backend/scripts/backfill-companion-avatar-url.js --commit` (default dry-run; `--commit` derives + PUTs `avatar.webp` and repoints `avatar_url`). Until then, rendering is fully correct via the crop path.

## Tests
- This suite: **13/13** pass (8 existing + 5 new).
- Related suites (`petdex-route-avatar`, `backfill-companion-avatar-url`, `petdex-bridge`, `companion-api`, this): **116/116** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt7jNhQxvz1FkErAbyHneC