### PR TITLE
fix(push): wire kanban-done notification to device web-push/FCM (card_caa6307)

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -21251,9 +21251,21 @@ app.delete('/api/push/unsubscribe', async (req, res) => {
 
 // Send Web Push to all subscriptions for a device
 async function sendWebPush(deviceId, notif) {
-    if (!process.env.VAPID_PUBLIC_KEY) return;
+    if (!process.env.VAPID_PUBLIC_KEY) {
+        serverLog('warn', 'web_push', 'skip: VAPID not configured', { deviceId, metadata: { category: notif?.category } });
+        return;
+    }
     try {
         const subs = await notifModule.getPushSubscriptions(deviceId);
+        // A device with zero subscriptions silently produced no push and no
+        // log — the exact failure mode behind "手機通知沒收到". Record it so
+        // the owner can be told their phone never registered a subscription.
+        if (!subs.length) {
+            serverLog('warn', 'web_push', 'skip: no push subscriptions for device', { deviceId, metadata: { category: notif?.category } });
+            return;
+        }
+        let sent = 0;
+        let removed = 0;
         for (const sub of subs) {
             try {
                 await webpush.sendNotification(
@@ -21265,14 +21277,20 @@ async function sendWebPush(deviceId, notif) {
                         category: notif.category
                     })
                 );
+                sent++;
             } catch (e) {
                 if (e.statusCode === 410 || e.statusCode === 404) {
                     await notifModule.removePushSubscription(sub.endpoint);
+                    removed++;
+                } else {
+                    serverLog('error', 'web_push', `send failed: ${e.message}`, { deviceId, metadata: { category: notif?.category, statusCode: e.statusCode } });
                 }
             }
         }
+        serverLog('info', 'web_push', 'dispatch complete', { deviceId, metadata: { category: notif?.category, subs: subs.length, sent, removedStale: removed } });
     } catch (err) {
         console.warn('[WebPush] Send failed:', err.message);
+        serverLog('error', 'web_push', `dispatch error: ${err.message}`, { deviceId, metadata: { category: notif?.category } });
     }
 }
 
@@ -21348,9 +21366,16 @@ try {
             credential: firebaseAdmin.credential.cert(JSON.parse(process.env.FIREBASE_SERVICE_ACCOUNT))
         });
         serverLog('info', 'fcm_init', 'Firebase Admin initialized');
+        // Mirror to stdout so boot-log inspection (Railway) can confirm FCM is
+        // live. serverLog only writes to the server_logs DB table, so its
+        // absence from stdout was misread as "FCM never initialized".
+        console.log('[FCM] Firebase Admin initialized');
+    } else {
+        console.log('[FCM] FIREBASE_SERVICE_ACCOUNT not set — Android push disabled');
     }
 } catch (e) {
     serverLog('warn', 'fcm_init', `Firebase Admin init skipped: ${e.message}`);
+    console.warn('[FCM] Firebase Admin init FAILED:', e.message);
 }
 
 async function sendFcm(deviceId, notif) {

--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -2292,14 +2292,23 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
             // chatty cron/auto-generated children without losing manual closures.
             if (newStatus === 'done' && typeof notifyDevice === 'function') {
                 const isAuto = !!card.is_auto_generated;
+                const doneCategory = isAuto ? 'kanban_done_auto' : 'kanban_done';
+                // Stdout breadcrumb so "手機通知沒收到" can be diagnosed from
+                // Railway logs: confirms the device-push dispatch path was
+                // entered for this owner device + category. The downstream
+                // sendWebPush/sendFcm outcomes log to server_logs (DB), so this
+                // line is the only stdout evidence that the chain even fired.
+                console.log(`[Kanban] move→done device-push dispatch: device=${deviceId} card=${cardId} category=${doneCategory}`);
                 notifyDevice(deviceId, {
                     type: 'kanban',
-                    category: isAuto ? 'kanban_done_auto' : 'kanban_done',
+                    category: doneCategory,
                     title: isAuto ? '✅ 自動任務完成' : '✅ 任務完成',
                     body: card.title,
                     link: `/portal/kanban.html?card=${cardId}`,
                     metadata: { cardId, isAuto, fromStatus: oldStatus }
-                }).catch(() => {});
+                }).catch((e) => {
+                    console.error(`[Kanban] move→done device-push dispatch failed: device=${deviceId} card=${cardId}:`, e.message);
+                });
             }
 
             // If this is an auto-generated child card moving to Done → update parent
@@ -4080,6 +4089,7 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                 // Always classified as kanban_done_auto since this branch only
                 // runs for bot-reported IDLE auto-completions.
                 if (typeof notifyDevice === 'function') {
+                    console.log(`[Kanban] auto-done device-push dispatch: device=${deviceId} card=${card.id} category=kanban_done_auto closedBy=${entityId}`);
                     notifyDevice(deviceId, {
                         type: 'kanban',
                         category: 'kanban_done_auto',
@@ -4087,7 +4097,9 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
                         body: card.title,
                         link: `/portal/kanban.html?card=${card.id}`,
                         metadata: { cardId: card.id, isAuto: true, autoClosedBy: entityId }
-                    }).catch(() => {});
+                    }).catch((e) => {
+                        console.error(`[Kanban] auto-done device-push dispatch failed: device=${deviceId} card=${card.id}:`, e.message);
+                    });
                 }
 
                 // Award XP for completing task

--- a/backend/tests/jest/kanban-done-device-push-wiring.test.js
+++ b/backend/tests/jest/kanban-done-device-push-wiring.test.js
@@ -1,0 +1,116 @@
+'use strict';
+
+/**
+ * Regression: kanban card-done → owner device web-push / FCM dispatch wiring.
+ *
+ * card_caa6307361d8e8196bbdeb5a — "[Bug/Mobile/P1] 手機通知最近不工作 — 尤其
+ * 任務完成通知 (kanban done push)".
+ *
+ * Investigation outcome: the device-push chain is intact end-to-end
+ * (move→done and auto-close→done both call notifyDevice → sendWebPush +
+ * sendFcm). The danger is a SILENT regression — a future refactor dropping
+ * the notifyDevice() call from either done path, or wiring an unregistered
+ * notification category, would re-introduce "phone never gets task-done
+ * push" with zero test coverage (the only prior test,
+ * kanban-done-push-categories.test.js, asserts the prefs key exists but NOT
+ * that the move handler actually dispatches).
+ *
+ * Style: static source-grep, matching kanban-smart-notify-queue.test.js
+ * (the kanban module requires a live pg pool, so behavioral mocking is not
+ * the convention for this module). These tests pin the structural
+ * invariants so the wiring cannot silently rot.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const kanbanSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'kanban.js'),
+    'utf8'
+);
+const indexSrc = fs.readFileSync(
+    path.join(__dirname, '..', '..', 'index.js'),
+    'utf8'
+);
+const { DEFAULT_PREFS } = require('../../notifications');
+
+describe('kanban done → device push wiring (manual /move)', () => {
+    test('createKanbanModule accepts notifyDevice dependency', () => {
+        expect(kanbanSrc).toMatch(/function createKanbanModule\([^)]*notifyDevice[^)]*\)/);
+    });
+
+    test('index.js passes notifyDevice into the kanban module', () => {
+        // require('./kanban')(devices, { ... notifyDevice ... })
+        expect(indexSrc).toMatch(/require\(['"]\.\/kanban['"]\)\(devices,\s*\{[\s\S]*?notifyDevice[\s\S]*?\}\)/);
+    });
+
+    test("move→done dispatches device push via notifyDevice with kanban_done/kanban_done_auto", () => {
+        // The newStatus === 'done' branch must call notifyDevice with the
+        // owner deviceId and a kanban_done* category.
+        expect(kanbanSrc).toMatch(/newStatus === 'done' && typeof notifyDevice === 'function'/);
+        const doneBlock = kanbanSrc.slice(
+            kanbanSrc.indexOf("newStatus === 'done' && typeof notifyDevice === 'function'")
+        ).slice(0, 800);
+        expect(doneBlock).toMatch(/notifyDevice\(deviceId,/);
+        expect(doneBlock).toMatch(/'kanban_done_auto'/);
+        expect(doneBlock).toMatch(/'kanban_done'/);
+    });
+
+    test('move→done logs a stdout breadcrumb for diagnosability', () => {
+        // serverLog (fcm/web_push) only hits the server_logs DB table, so a
+        // stdout breadcrumb is the single Railway-log signal that the dispatch
+        // path fired. Without it "手機沒收到推播" is undiagnosable from logs.
+        expect(kanbanSrc).toMatch(/move→done device-push dispatch/);
+    });
+});
+
+describe('kanban auto-close (autoReviewOnTransform) → device push wiring', () => {
+    test('auto-done path dispatches device push via notifyDevice', () => {
+        const idx = kanbanSrc.indexOf('async function autoReviewOnTransform');
+        expect(idx).toBeGreaterThan(-1);
+        const fnBody = kanbanSrc.slice(idx, idx + 9000);
+        // Bot-reported IDLE auto-completion must still reach the owner device.
+        expect(fnBody).toMatch(/notifyDevice\(deviceId,/);
+        expect(fnBody).toMatch(/'kanban_done_auto'/);
+        expect(fnBody).toMatch(/auto-done device-push dispatch/);
+    });
+});
+
+describe('device-push category prefs are registered (no silent drop)', () => {
+    test('kanban_done and kanban_done_auto exist and default ON', () => {
+        // notifyDevice() returns early if isCategoryEnabled() is false; an
+        // unregistered category would fall through DEFAULT_PREFS. These keys
+        // must stay registered + default true or done-push silently dies.
+        expect(DEFAULT_PREFS.kanban_done).toBe(true);
+        expect(DEFAULT_PREFS.kanban_done_auto).toBe(true);
+    });
+});
+
+describe('sendWebPush / sendFcm dispatch is reachable from notifyDevice', () => {
+    test('notifyDevice fans out to sendWebPush and sendFcm', () => {
+        const idx = indexSrc.indexOf('async function notifyDevice(deviceId, notification)');
+        expect(idx).toBeGreaterThan(-1);
+        const fnBody = indexSrc.slice(idx, idx + 2400);
+        expect(fnBody).toMatch(/sendWebPush\(deviceId, notif\)/);
+        expect(fnBody).toMatch(/sendFcm\(deviceId, notif\)/);
+        // The category gate must precede the fan-out.
+        expect(fnBody).toMatch(/isCategoryEnabled\(prefs, notification\.category\)/);
+    });
+
+    test('sendWebPush logs the empty-subscription case (key diagnostic)', () => {
+        // The prod symptom is "no push, no log". A device with zero
+        // subscriptions must now leave a server_logs breadcrumb instead of a
+        // silent no-op.
+        const idx = indexSrc.indexOf('async function sendWebPush(deviceId, notif)');
+        expect(idx).toBeGreaterThan(-1);
+        const fnBody = indexSrc.slice(idx, idx + 1800);
+        expect(fnBody).toMatch(/no push subscriptions for device/);
+    });
+
+    test('FCM init mirrors a stdout breadcrumb (Railway boot-log visibility)', () => {
+        // The investigation was misled because serverLog('fcm_init') never
+        // reaches stdout. Pin the stdout mirror so boot-log inspection can
+        // confirm Android push is live.
+        expect(indexSrc).toMatch(/\[FCM\] Firebase Admin initialized/);
+    });
+});


### PR DESCRIPTION
## Card
card_caa6307361d8e8196bbdeb5a — [Bug/Mobile/P1] 手機通知最近不工作 — 尤其任務完成通知 (kanban done push)

## Definitive root cause (investigation REFUTED the original hypothesis)
The hypothesis was: the kanban done path writes to chat_history + does an in-app Socket.IO "channel push to entity" but **never** calls `notifyDevice()`/`sendWebPush()`/`sendFcm()`. **This is false at the code level.** Both done paths already dispatch device push:

- `POST /card/:id/move` with `newStatus === 'done'` → `notifyDevice(deviceId, { category: 'kanban_done' | 'kanban_done_auto' })` — `backend/kanban.js:2293`
- `autoReviewOnTransform` (bot IDLE auto-close, bypasses /move) → `notifyDevice(...)` — `backend/kanban.js:4082`

`notifyDevice` (`backend/index.js:20387`) checks the category pref, saves, emits Socket.IO, then fans out to `sendWebPush(deviceId, notif)` (`index.js:21253`) **and** `sendFcm(deviceId, notif)` (`index.js:21356`). Category `kanban_done` / `kanban_done_auto` is registered and defaults `true` (`backend/notifications.js:16-17`); `isCategoryEnabled` fails open. `firebase-admin` is a dependency (`backend/package.json:41`) and inits from `FIREBASE_SERVICE_ACCOUNT` (`index.js:21343`); `buildFcmNotificationData` exists (`notifications.js:498`). The architectural worry "deviceId is the bot's device, not the owner's" is also false: entities live under `devices[deviceId].entities[entityId]`, so a bot authenticates with the **owner's** `deviceId` + its own `botSecret` — `notifyDevice(deviceId)` correctly targets the owner device.

### The actual blocker = observability, and the prod evidence was a red herring
`serverLog()` (`index.js:21614`) writes **only to the `server_logs` Postgres table — never stdout**. Therefore:
- `serverLog('info','fcm_init','Firebase Admin initialized')` never appears in Railway stdout → the "boot log has no `[FCM]` line" observation does **not** mean FCM failed to init.
- `fcm_send` skip/error/sent all go to the DB table, not stdout → "ZERO web-push/FCM sends, ZERO errors" in stdout is **expected** whether or not pushes fire.
- `sendWebPush` had **no** success log, was silent on per-sub 410/404, and a device with **zero** subscriptions was a completely silent no-op → the prime real-world failure ("phone never registered a subscription") left no trace at all.

So the stdout evidence cannot confirm or refute device-push delivery. The real-world causes are data-side (owner device has no `push_subscriptions` row / no `fcm_token`, or a stale `registration-token-not-registered`) and must be read from the `server_logs` table / `GET /api/device/fcm-status`, not stdout.

## The fix (surgical — no wholesale rewrites)
- **`backend/kanban.js`** — stdout breadcrumb + error log at **both** done-path `notifyDevice` calls (`move→done` and `auto-done`), so a fired dispatch is visible in Railway logs.
- **`backend/index.js` `sendWebPush`** — log VAPID-missing, **empty-subscription** (the prime "phone never registered" case), per-sub send errors, and a `dispatch complete` summary (`subs / sent / removedStale`) to `server_logs`.
- **`backend/index.js` FCM init** — mirror init success / missing-env / failure to **stdout** so boot-log inspection can finally confirm Android push is live.

## Test coverage
New `backend/tests/jest/kanban-done-device-push-wiring.test.js` (9 tests) pins both done paths call notifyDevice with kanban_done*, the module wiring, the sendWebPush+sendFcm fan-out behind the category gate, registered categories, and the new diagnostics. Closes the gap left by `kanban-done-push-categories.test.js` (prefs-only).

### Test results
7 suites / 92 tests all green (kanban-done-device-push-wiring, kanban-done-push-categories, push-notifications, notification-category-aliases, notifications, notification-prefs-merge, push-context). No package.json change.

## Follow-up for prod triage (data-side, not code)
After deploy, query `server_logs WHERE category IN ('fcm_init','fcm_send','web_push')` post card→done, and `GET /api/device/fcm-status` for the owner device. Expect `skip: no push subscriptions` / `skip: no fcmToken` / `registration-token-not-registered` — pinpointing the per-device registration gap the silent code was hiding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)