### PR TITLE
release: 1.0.94 (vc 102) — FCM kanban-done notification fix

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 101
-        versionName = "1.0.93"
+        versionCode = 102
+        versionName = "1.0.94"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
Version bump 1.0.93→1.0.94 (versionCode 101→102) to ship the mobile-push fix to users.

## Ships
- **PR #3581** — Android: create notification channels in `ClawApplication.onCreate` so FCM cold-starts display kanban-done notifications (root cause: channel only created in MainActivity, which FCM cold-start never runs → Android O+ silently drops). Emulator-verified on Pixel_9a.
- **PR #3580** — backend push observability (stdout breadcrumbs + server_logs fcm_send/web_push results) + 9 regression tests.

Closes the user-facing half of card_caa6307 (手機通知不工作). Backend FCM send already confirmed working in prod (`fcm_send: sent OK`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)