### PR TITLE
fix(db): ensure fcm_token + apns_token columns at startup migration (card_caa6307)

### DIFF
--- a/backend/db.js
+++ b/backend/db.js
@@ -290,6 +290,21 @@ async function createTables() {
         `);
         console.log('[DynamicEntity] DB migration: next_entity_id column ensured on devices table');
 
+        // Push tokens (card_caa6307 follow-up): fcm_token (Android) + apns_token (iOS).
+        // Previously these were created lazily at runtime in index.js only when the FIRST
+        // token of each platform was registered (ALTER ... ADD COLUMN IF NOT EXISTS with a
+        // swallowed .catch). On a fresh DB (e.g. the 2026-04 pgvector migration) any query
+        // referencing apns_token before an iOS device ever registered errored with
+        // "column apns_token does not exist". Ensure both columns exist at startup so the
+        // schema never drifts regardless of registration traffic.
+        await client.query(`
+            ALTER TABLE devices ADD COLUMN IF NOT EXISTS fcm_token TEXT
+        `);
+        await client.query(`
+            ALTER TABLE devices ADD COLUMN IF NOT EXISTS apns_token TEXT
+        `);
+        console.log('[Push] DB migration: fcm_token + apns_token columns ensured on devices table');
+
         // Official bot bindings (free bot multi-device tracking)
         await client.query(`
             CREATE TABLE IF NOT EXISTS official_bot_bindings (


### PR DESCRIPTION
## Problem
`devices.fcm_token` and `devices.apns_token` were created **lazily** in `index.js` only when the first token of each platform was registered (`ALTER ... ADD COLUMN IF NOT EXISTS` with a swallowed `.catch(()=>{})`). On a fresh DB — e.g. the 2026-04 migration to `postgres-pgvector` — any query referencing `apns_token` before an iOS device ever registered errored with `column "apns_token" does not exist`.

Surfaced by #5's Railway PG log monitor; live schema diff confirmed `apns_token` was the only missing `devices` column on pgvector (`paid_borrow_slots`/`next_entity_id`/`prompt_policy`/`user_display_name`/`fcm_token` all present → no paid-feature impact).

## Fix
Move `ADD COLUMN IF NOT EXISTS` for both push-token columns into the `devices` startup-migration block in `db.js`, so the schema is guaranteed at boot regardless of push-registration traffic. Idempotent; no backfill needed.

Part of the card_caa6307 mobile-push cleanup (umbrella card_cff46d3). Low-impact (no iOS users yet) but removes recurring schema-drift errors per the no-benign-error principle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)