### PR TITLE
feat(android): settings-manifest Stage 2 — consume /api/settings-manifest (native vs webFallback routing + version gating)

### DIFF
--- a/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
@@ -49,6 +49,8 @@ import com.facebook.login.LoginManager
 import com.facebook.login.LoginResult
 import com.hank.clawlive.settings.NotificationPreferenceCatalog
 import com.hank.clawlive.settings.NotificationPreferenceCategory
+import com.hank.clawlive.settings.DynamicSettingsRow
+import com.hank.clawlive.settings.SettingsManifestSync
 import com.hank.clawlive.ui.AiChatFabHelper
 import com.hank.clawlive.ui.BottomNavHelper
 import com.hank.clawlive.ui.EntityChipHelper
@@ -179,6 +181,7 @@ class SettingsActivity : AppCompatActivity() {
         setupRemoteControlCollapsible()
         setupLangCollapsible()
         setupChannelApiCollapsible()
+        loadSettingsManifest()
     }
 
     private fun setupEdgeToEdgeInsets() {
@@ -1012,6 +1015,137 @@ class SettingsActivity : AppCompatActivity() {
         } catch (e: Exception) {
             e.printStackTrace()
         }
+    }
+
+    // ============================================
+    // SETTINGS AUTO-SYNC (manifest Stage 2)
+    // ============================================
+
+    /**
+     * Fetch GET /api/settings-manifest at launch and surface any settings feature
+     * that this binary does NOT already render natively — opening its web fallback in
+     * a WebView. This is the zero-rebuild auto-sync seam (docs/specs/settings-manifest-spec.md):
+     * a NEW web-only settings feature appears here on day one; a native feature gated
+     * out by the running app version shows a "?" help row pointing at the web.
+     *
+     * Graceful degradation: any failure (offline / 5xx / parse) is logged and the
+     * static settings screen is left exactly as-is — never crash, never blank.
+     */
+    private fun loadSettingsManifest() {
+        val appVersion = runCatching {
+            packageManager.getPackageInfo(packageName, 0).versionName
+        }.getOrNull()
+
+        lifecycleScope.launch {
+            val resp = runCatching {
+                NetworkModule.api.getSettingsManifest(appVersion = appVersion, platform = "android")
+            }.getOrElse { e ->
+                Timber.w(e, "[SettingsManifest] fetch failed — keeping static settings screen")
+                return@launch
+            }
+
+            if (!resp.success || resp.manifest == null) {
+                Timber.w("[SettingsManifest] non-success response (error=${resp.error}) — keeping static screen")
+                return@launch
+            }
+
+            val rows = runCatching {
+                SettingsManifestSync.planDynamicRows(resp.manifest, appVersion)
+            }.getOrElse { e ->
+                Timber.w(e, "[SettingsManifest] plan failed — keeping static screen")
+                return@launch
+            }
+
+            renderManifestExtraRows(rows)
+        }
+    }
+
+    private fun renderManifestExtraRows(rows: List<DynamicSettingsRow>) {
+        val container = findViewById<LinearLayout>(R.id.settingsManifestExtraContainer)
+        container.removeAllViews()
+        if (rows.isEmpty()) {
+            container.visibility = View.GONE
+            return
+        }
+        container.visibility = View.VISIBLE
+
+        // Section header so the synced rows are visually grouped.
+        container.addView(TextView(this).apply {
+            text = getString(R.string.settings_more_section_title)
+            setTextColor(getColor(R.color.text_white_50))
+            textSize = 13f
+            val vpad = dpToPx(8)
+            setPadding(0, vpad * 2, 0, vpad)
+        })
+
+        rows.forEach { row -> container.addView(buildManifestRow(row)) }
+        TelemetryHelper.trackAction("settings_manifest_extra_rows_${rows.size}")
+    }
+
+    /** Build one tappable row for a manifest feature that opens its web fallback. */
+    private fun buildManifestRow(row: DynamicSettingsRow): View {
+        val rowLayout = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = android.view.Gravity.CENTER_VERTICAL
+            val vpad = dpToPx(12)
+            setPadding(0, vpad, 0, vpad)
+            isClickable = true
+            setOnClickListener { openManifestWebFallback(row) }
+        }
+
+        val label = TextView(this).apply {
+            text = row.name
+            setTextColor(getColor(android.R.color.white))
+            textSize = 16f
+            layoutParams = LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f)
+        }
+        rowLayout.addView(label)
+
+        if (row.gated) {
+            // Gated state: badge + "?" help (what / needs / next step), per spec §4.
+            label.append("  ⓘ")
+            val badge = TextView(this).apply {
+                text = getString(R.string.settings_feature_gated_badge)
+                setTextColor(getColor(R.color.text_white_50))
+                textSize = 11f
+                setPadding(dpToPx(8), 0, dpToPx(8), 0)
+            }
+            rowLayout.addView(badge)
+        }
+
+        val help = ImageView(this).apply {
+            setImageResource(android.R.drawable.ic_menu_help)
+            setColorFilter(getColor(R.color.text_white_50))
+            val sz = dpToPx(20)
+            layoutParams = LinearLayout.LayoutParams(sz, sz).apply {
+                marginStart = dpToPx(8)
+            }
+            isClickable = true
+            setOnClickListener { showManifestRowHelp(row) }
+        }
+        rowLayout.addView(help)
+
+        return rowLayout
+    }
+
+    /** "?" affordance: what this setting is, what it needs, and the next step. */
+    private fun showManifestRowHelp(row: DynamicSettingsRow) {
+        val msg = if (row.gated) {
+            getString(R.string.settings_feature_gated_help)
+        } else {
+            getString(R.string.settings_feature_web_help)
+        }
+        AlertDialog.Builder(this)
+            .setTitle(getString(R.string.settings_feature_help_title))
+            .setMessage(msg)
+            .setPositiveButton(R.string.settings_open_on_web) { _, _ -> openManifestWebFallback(row) }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun openManifestWebFallback(row: DynamicSettingsRow) {
+        TelemetryHelper.trackAction("settings_manifest_web_${row.key}")
+        WebViewActivity.launch(this, row.webFallback, row.name)
     }
 
     // ============================================

--- a/app/src/main/java/com/hank/clawlive/settings/SettingsManifestSync.kt
+++ b/app/src/main/java/com/hank/clawlive/settings/SettingsManifestSync.kt
@@ -1,0 +1,141 @@
+package com.hank.clawlive.settings
+
+/**
+ * Stage-2 auto-sync planner: turns the resolved manifest into the *extra* settings
+ * rows the running binary doesn't already render natively.
+ *
+ * The existing [com.hank.clawlive.SettingsActivity] is a hand-built static screen:
+ * features such as Subscription / Language / Notifications already have native rows
+ * wired by hand. The manifest's value is the AUTO-SYNC seam — when a NEW
+ * settings feature ships web-only (`native:false`) or a native feature is gated out
+ * by the running app version, the app must surface it WITHOUT a rebuild by opening
+ * the web fallback. This planner computes exactly that delta:
+ *
+ *   - A feature that the running app already renders natively (its `key` is in
+ *     [nativeRowKeys]) and the manifest agrees is native -> no extra row (the static
+ *     screen already covers it).
+ *   - A feature the manifest routes to the web ([FeatureSurface.WEB] /
+ *     [FeatureSurface.NATIVE_PLUS_WEB]) that has NO native static row -> emit a
+ *     dynamic row that opens the web fallback. This is how a brand-new web-only
+ *     feature appears on day one with zero rebuild.
+ *   - A feature the running app DOES render natively but the manifest has gated to
+ *     the web (declared native, but the running app predates `minAppVersion`) ->
+ *     emit a [DynamicSettingsRow] flagged [DynamicSettingsRow.gated] so the UI can
+ *     show the spec §4 "?"-help (what / needs / next step) instead of a stale
+ *     native control the binary can't honor.
+ *
+ * This file is pure Kotlin (no Android deps) so the delta logic is unit-testable.
+ */
+
+/** A settings row the manifest asks the app to surface beyond its static screen. */
+data class DynamicSettingsRow(
+    val key: String,
+    val name: String,
+    val webFallback: String,
+    /**
+     * True when this feature DECLARES native support but the running app version is
+     * below its `minAppVersion` — i.e. it was downgraded to the web fallback by the
+     * version gate. The UI shows the "?" gated-help affordance (update app / open on
+     * web) rather than presenting it as a plain web-only feature.
+     */
+    val gated: Boolean
+)
+
+object SettingsManifestSync {
+
+    /**
+     * Manifest feature keys that this binary already renders as native settings rows
+     * (hand-wired in SettingsActivity's static layout). Keep in sync with the static
+     * screen — a key here means "the static screen covers it, don't add a dynamic
+     * row when the manifest also says native".
+     *
+     * Note: `kanban_nudge` is intentionally NOT here even though a static row exists,
+     * because that static row itself opens the web fallback — it is already the
+     * web-surface, so re-emitting it would duplicate. Web-surfaced static rows are
+     * tracked in [webBackedStaticRowKeys] instead.
+     */
+    val nativeRowKeys: Set<String> = setOf(
+        "subscription",
+        "invite",
+        "language",
+        "display",
+        "chat_prefs",
+        "notifications",
+        "developer_broadcast",
+        "wallet",
+        "my_rentals",
+        "files",
+        "companion_petdx",
+        "feedback",
+        "account_identity",
+        "channel_api",
+        "logout"
+    )
+
+    /**
+     * Manifest feature keys the static screen already surfaces via its OWN web link
+     * (a hand-wired row that opens the portal). The manifest agrees these are web,
+     * so the static row is correct — no dynamic duplicate needed.
+     */
+    val webBackedStaticRowKeys: Set<String> = setOf(
+        "kanban_nudge"
+    )
+
+    private val staticallyCoveredKeys: Set<String> = nativeRowKeys + webBackedStaticRowKeys
+
+    /**
+     * Decide whether a feature DECLARES native support yet was gated to the web by
+     * the running app version (vs being plain web-only). Used to flag rows so the UI
+     * shows the "update app / open on web" help instead of a generic web row.
+     */
+    fun isVersionGated(feature: SettingsManifestFeature, appVersion: String?): Boolean {
+        val declared = SettingsManifestResolver.nativeSupport(feature.native)
+        if (declared == NativeSupport.NONE) return false // genuinely web-only, not gated
+        if (appVersion.isNullOrBlank()) return false     // no version sent -> declared trusted
+        return SettingsManifestResolver.compareVersions(appVersion, feature.minAppVersion) < 0
+    }
+
+    /**
+     * Plan the dynamic rows to append to the static settings screen.
+     *
+     * @param manifest   the manifest envelope (null/failed fetch -> no extra rows;
+     *                   the caller keeps its static screen as graceful degradation).
+     * @param appVersion the running app versionName, for the client-side version gate.
+     */
+    fun planDynamicRows(manifest: SettingsManifest?, appVersion: String?): List<DynamicSettingsRow> {
+        if (manifest == null) return emptyList()
+        val resolved = SettingsManifestResolver.resolve(manifest, appVersion)
+        val byKey = manifest.features.associateBy { it.key }
+
+        return resolved.mapNotNull { r ->
+            // Feature renders natively this binary already covers -> nothing to add.
+            if (r.surface == FeatureSurface.NATIVE && r.key in nativeRowKeys) return@mapNotNull null
+            // NATIVE_PLUS_WEB / WEB that the static screen already covers via its own
+            // row (native row OR web-backed row) -> the static screen is enough.
+            if (r.key in staticallyCoveredKeys && r.surface != FeatureSurface.WEB) {
+                // partial native already rendered statically; no separate web row.
+                return@mapNotNull null
+            }
+            // A WEB-surfaced feature the static screen already covers (e.g. a native
+            // row that the manifest gated out, or a web-backed static row that is
+            // already the web surface) -> only add a row if it is NOT statically
+            // covered at all. Statically-covered web rows are left to the static UI.
+            if (r.surface == FeatureSurface.WEB && r.key in staticallyCoveredKeys) {
+                val feat = byKey[r.key]
+                val gated = feat != null && isVersionGated(feat, appVersion)
+                // If the static native row exists but the manifest gated it out, the
+                // static row would present a control the binary can't fully honor;
+                // surface a gated help row so the user can reach the web version.
+                if (gated && r.key in nativeRowKeys) {
+                    return@mapNotNull DynamicSettingsRow(r.key, r.name, r.webFallback, gated = true)
+                }
+                return@mapNotNull null
+            }
+            // Everything else: a feature with no native static row that the manifest
+            // routes to the web -> THIS is the zero-rebuild auto-sync payoff.
+            val feat = byKey[r.key]
+            val gated = feat != null && isVersionGated(feat, appVersion)
+            DynamicSettingsRow(r.key, r.name, r.webFallback, gated = gated)
+        }
+    }
+}

--- a/app/src/main/res/layout/activity_settings.xml
+++ b/app/src/main/res/layout/activity_settings.xml
@@ -1338,6 +1338,16 @@
                 </LinearLayout>
             </com.google.android.material.card.MaterialCardView>
 
+            <!-- Settings auto-sync extra rows (manifest Stage 2): web-fallback /
+                 version-gated features with no native static row are appended here
+                 at launch. Empty + GONE until the manifest fetch succeeds. -->
+            <LinearLayout
+                android:id="@+id/settingsManifestExtraContainer"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:visibility="gone"/>
+
             <!-- App Version -->
             <TextView
                 android:id="@+id/tvAppVersion"

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -847,6 +847,13 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="ecoin_unit">e币</string>
     <string name="org_chart_sheet_title">组织图</string>
     <string name="settings_delete_account">删除账户</string>
+    <!-- 设置自动同步（manifest 第二阶段） -->
+    <string name="settings_more_section_title">更多设置</string>
+    <string name="settings_open_on_web">在网页打开</string>
+    <string name="settings_feature_help_title">关于此设置</string>
+    <string name="settings_feature_web_help">此设置会在网页视图中打开，因为此 App 版本尚未内置原生界面。更新 App 即可获得原生界面，或现在直接在网页中使用。</string>
+    <string name="settings_feature_gated_help">此设置的原生版本需要较新的 App 版本。更新 App 即可获得原生界面，或现在直接在网页中打开。</string>
+    <string name="settings_feature_gated_badge">更新 App 以使用原生版</string>
     <string name="settings_invite">邀请好友</string>
     <string name="settings_my_rentals">我的租借</string>
     <string name="settings_wallet">钱包</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -692,6 +692,13 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="settings_my_rentals">我的租借</string>
     <string name="settings_invite">邀請好友</string>
     <string name="settings_delete_account">刪除帳戶</string>
+    <!-- 設定自動同步（manifest 第二階段） -->
+    <string name="settings_more_section_title">更多設定</string>
+    <string name="settings_open_on_web">在網頁開啟</string>
+    <string name="settings_feature_help_title">關於此設定</string>
+    <string name="settings_feature_web_help">此設定會在網頁檢視中開啟，因為此 App 版本尚未內建原生畫面。更新 App 即可取得原生畫面，或現在直接在網頁中使用。</string>
+    <string name="settings_feature_gated_help">此設定的原生版本需要較新的 App 版本。更新 App 即可取得原生畫面，或現在直接在網頁中開啟。</string>
+    <string name="settings_feature_gated_badge">更新 App 以使用原生版</string>
     <string name="show_label">顯示</string>
     <string name="sign_in_facebook">使用 Facebook 登入</string>
     <string name="sign_in_google">使用 Google 登入</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -46,6 +46,13 @@
     <string name="settings_my_rentals">My Rentals</string>
     <string name="settings_invite">Invite Friends</string>
     <string name="settings_delete_account">Delete Account</string>
+    <!-- Settings auto-sync (manifest Stage 2) -->
+    <string name="settings_more_section_title">More Settings</string>
+    <string name="settings_open_on_web">Open on web</string>
+    <string name="settings_feature_help_title">About this setting</string>
+    <string name="settings_feature_web_help">This setting opens in a web view because a native screen isn\'t in this app version yet. Update the app to get the native screen, or use it on the web now.</string>
+    <string name="settings_feature_gated_help">A native version of this setting needs a newer app version. Update the app to get the native screen, or open it on the web now.</string>
+    <string name="settings_feature_gated_badge">Update app for native</string>
     <string name="usage_title">Today\'s Usage</string>
     <string name="premium_badge">PREMIUM</string>
     <string name="sends_today">sends today</string>

--- a/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
+++ b/app/src/test/java/com/hank/clawlive/UnitTestSuite.kt
@@ -3,6 +3,7 @@ package com.hank.clawlive
 import com.hank.clawlive.fcm.FcmChannelCreationTest
 import com.hank.clawlive.settings.NotificationPreferenceCatalogTest
 import com.hank.clawlive.settings.SettingsManifestResolverTest
+import com.hank.clawlive.settings.SettingsManifestSyncTest
 import org.junit.runner.RunWith
 import org.junit.runners.Suite
 
@@ -22,6 +23,7 @@ import org.junit.runners.Suite
     CompanionDescriptorAnimationTest::class,
     NotificationPreferenceCatalogTest::class,
     SettingsManifestResolverTest::class,
+    SettingsManifestSyncTest::class,
     FcmChannelCreationTest::class
 )
 class UnitTestSuite

--- a/app/src/test/java/com/hank/clawlive/settings/SettingsManifestSyncTest.kt
+++ b/app/src/test/java/com/hank/clawlive/settings/SettingsManifestSyncTest.kt
@@ -1,0 +1,176 @@
+package com.hank.clawlive.settings
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Pure-logic tests for the Stage-2 auto-sync row planner ([SettingsManifestSync]).
+ *
+ * The planner computes the DELTA between what the static SettingsActivity already
+ * renders and what the manifest declares: only web-fallback / version-gated features
+ * with no native static row become dynamic rows. No Android deps.
+ */
+class SettingsManifestSyncTest {
+
+    private fun feature(
+        key: String,
+        native: Any?,
+        enabled: Boolean = true,
+        minVer: String = "0.0.0",
+        webFallback: String = "https://eclawbot.com/portal/settings.html?focus=$key"
+    ) = SettingsManifestFeature(
+        key = key,
+        name = key.replaceFirstChar { it.uppercase() },
+        enabled = enabled,
+        native = native,
+        webFallback = webFallback,
+        minAppVersion = minVer
+    )
+
+    private fun manifest(vararg features: SettingsManifestFeature) = SettingsManifest(
+        platform = "android",
+        appVersion = "1.0.0",
+        stage = 1,
+        features = features.toList()
+    )
+
+    // ── new web-only feature with no native row → appears (the auto-sync payoff) ──
+
+    @Test
+    fun planDynamicRows_newWebOnlyFeature_emitsWebRow() {
+        // rotate_secret / switch_device: native:false, no static row.
+        val rows = SettingsManifestSync.planDynamicRows(
+            manifest(feature("rotate_secret", native = false)),
+            "1.0.94"
+        )
+        assertEquals(1, rows.size)
+        assertEquals("rotate_secret", rows[0].key)
+        assertFalse("plain web-only feature is not version-gated", rows[0].gated)
+        assertEquals(
+            "https://eclawbot.com/portal/settings.html?focus=rotate_secret",
+            rows[0].webFallback
+        )
+    }
+
+    // ── feature the static screen already renders natively → no dynamic row ──
+
+    @Test
+    fun planDynamicRows_nativeFeatureWithStaticRow_isSkipped() {
+        val rows = SettingsManifestSync.planDynamicRows(
+            manifest(
+                feature("subscription", native = true, minVer = "1.0.0"),
+                feature("language", native = true, minVer = "1.0.0"),
+                feature("notifications", native = true, minVer = "1.0.0")
+            ),
+            "1.0.94"
+        )
+        assertTrue("static native rows produce no extra rows", rows.isEmpty())
+    }
+
+    // ── web-backed static row (kanban_nudge opens web itself) → no duplicate ──
+
+    @Test
+    fun planDynamicRows_webBackedStaticRow_isNotDuplicated() {
+        val rows = SettingsManifestSync.planDynamicRows(
+            manifest(feature("kanban_nudge", native = false)),
+            "1.0.94"
+        )
+        assertTrue("kanban_nudge has its own static web row — no dynamic duplicate", rows.isEmpty())
+    }
+
+    // ── disabled feature is dropped before planning ──
+
+    @Test
+    fun planDynamicRows_disabledFeature_isDropped() {
+        val rows = SettingsManifestSync.planDynamicRows(
+            manifest(feature("agent_policy", native = false, enabled = false)),
+            "1.0.94"
+        )
+        assertTrue(rows.isEmpty())
+    }
+
+    // ── version-gated NATIVE feature with a static row → gated help row ──
+
+    @Test
+    fun planDynamicRows_nativeFeatureGatedByVersion_emitsGatedRow() {
+        // subscription declares native at minVer 2.5.0, but the running app is 1.0.0,
+        // so the static native row can't be honored → surface a gated help row.
+        val rows = SettingsManifestSync.planDynamicRows(
+            manifest(feature("subscription", native = true, minVer = "2.5.0")),
+            "1.0.0"
+        )
+        assertEquals(1, rows.size)
+        assertEquals("subscription", rows[0].key)
+        assertTrue("downgraded native feature is flagged gated", rows[0].gated)
+    }
+
+    // ── a NEW native-declared feature gated out, no static row → gated web row ──
+
+    @Test
+    fun planDynamicRows_newNativeFeatureGated_emitsGatedRow() {
+        val rows = SettingsManifestSync.planDynamicRows(
+            manifest(feature("companion_v2", native = true, minVer = "3.0.0")),
+            "1.0.0"
+        )
+        assertEquals(1, rows.size)
+        assertEquals("companion_v2", rows[0].key)
+        assertTrue(rows[0].gated)
+    }
+
+    // ── isVersionGated distinguishes gated vs plain web-only ──
+
+    @Test
+    fun isVersionGated_distinguishesGatedFromWebOnly() {
+        // declared native but app too old → gated
+        assertTrue(
+            SettingsManifestSync.isVersionGated(feature("x", native = true, minVer = "2.0.0"), "1.0.0")
+        )
+        // declared native and app new enough → not gated
+        assertFalse(
+            SettingsManifestSync.isVersionGated(feature("x", native = true, minVer = "1.0.0"), "1.0.0")
+        )
+        // genuinely web-only → not "gated" (it never declared native)
+        assertFalse(
+            SettingsManifestSync.isVersionGated(feature("x", native = false, minVer = "0.0.0"), "1.0.0")
+        )
+        // no appVersion sent → declared native trusted, not gated
+        assertFalse(
+            SettingsManifestSync.isVersionGated(feature("x", native = true, minVer = "2.0.0"), null)
+        )
+    }
+
+    // ── graceful fallback: null manifest → no rows (caller keeps static screen) ──
+
+    @Test
+    fun planDynamicRows_nullManifest_isEmpty() {
+        assertEquals(emptyList<DynamicSettingsRow>(), SettingsManifestSync.planDynamicRows(null, "1.0.0"))
+    }
+
+    // ── realistic live manifest shape → only the expected extras surface ──
+
+    @Test
+    fun planDynamicRows_liveLikeManifest_surfacesOnlyMissingFeatures() {
+        val rows = SettingsManifestSync.planDynamicRows(
+            manifest(
+                feature("account_identity", native = true, minVer = "1.0.0"),
+                feature("channel_api", native = "partial", minVer = "1.0.0"),
+                feature("subscription", native = true, minVer = "1.0.0"),
+                feature("notifications", native = true, minVer = "1.0.0"),
+                feature("kanban_nudge", native = false),          // web-backed static row
+                feature("rental_management", native = false),      // NEW web-only → row
+                feature("agent_policy", native = false),           // NEW web-only → row
+                feature("passive_health", native = false),         // NEW web-only → row
+                feature("rotate_secret", native = false),          // NEW web-only → row
+                feature("switch_device", native = false)           // NEW web-only → row
+            ),
+            "1.0.94"
+        )
+        assertEquals(
+            listOf("rental_management", "agent_policy", "passive_health", "rotate_secret", "switch_device"),
+            rows.map { it.key }
+        )
+        assertTrue("all are plain web-only, none gated", rows.none { it.gated })
+    }
+}


### PR DESCRIPTION
## What this builds

Completes the **device-build half of Stage 2** of settings→APP auto-sync (parent spec `docs/specs/settings-manifest-spec.md`). PR #3575 already shipped the pure consume/resolve seam (`ClawApiService.getSettingsManifest`, `SettingsManifest` Gson models, `SettingsManifestResolver`) but its own description explicitly deferred *"wiring the resolved plan into SettingsActivity row rendering + WebView open"* as the remaining device step. **This PR is that wiring.**

`SettingsActivity` is a ~1.4k-line hand-built static screen that already renders native rows for the features it covers. Per the no-wholesale-rewrite rule, this does **not** convert it into a manifest-driven RecyclerView. Instead it adds a thin **auto-sync delta layer**:

- **`settings/SettingsManifestSync.kt`** (pure, unit-tested) — given the manifest + running `appVersion`, computes only the *extra* rows the binary does not already render: web-only features with no native static row, plus native features the running app version gates out. A `nativeRowKeys` set records what the static screen already covers so nothing is duplicated.
- **`SettingsActivity.loadSettingsManifest()`** (called from `onCreate`) — fetches `GET /api/settings-manifest` with `appVersion` (`BuildConfig` versionName) + `platform=android` so the backend `minAppVersion` gate applies, then appends the planned rows into a new `settingsManifestExtraContainer`.

## How render decisions map to manifest fields

| manifest `native` / gate | surface |
|---|---|
| `true` + feature already has a native static row | nothing added (static screen covers it) |
| `false` / new web-only feature (no static row) | dynamic row → opens `webFallback` in the existing `WebViewActivity` (reuses its deviceId/deviceSecret injection) |
| declared native but running app `< minAppVersion` | **gated** row: "Update app for native" badge + a `?` help dialog (what / needs / next step, spec §4) whose primary action opens the web fallback |

Day-one zero-rebuild payoff: `rotate_secret`, `switch_device`, `rental_management`, `agent_policy`, `passive_health` (all `native:false` with no static row) now surface automatically. `kanban_nudge` — a static row that already opens the web — is tracked separately and never duplicated.

## Version gating + fallback behavior

- Client re-applies the `minAppVersion` gate locally (mirrors the backend) so a native flag the running binary can't honor is still downgraded — correct even on a cached/param-less fetch.
- **Graceful degradation:** any fetch / parse / plan failure is logged via Timber and the static settings screen is left exactly as-is — never crash, never blank.

## Test coverage

`SettingsManifestSyncTest` (9 cases, registered in `UnitTestSuite`): new-web-only emits a row, native+static skipped, web-backed static row not duplicated, disabled dropped, native gated by version → gated row, `isVersionGated` gated-vs-web distinction, null manifest empty, live-shape manifest surfaces only the missing features. Existing `SettingsManifestResolverTest` still green.

`./gradlew :app:compileDebugKotlin :app:testDebugUnitTest` → **BUILD SUCCESSFUL**, all green.

i18n: EN + zh-TW + zh-CN strings for the section header, "Open on web", and the `?`-help / gated-badge text.

## Scope

**iOS half is a separate follow-up.** This PR is Android only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)