### PR TITLE
fix(embedding): build HNSW index single-threaded to avoid /dev/shm exhaustion

### DIFF
--- a/backend/chat-embedding.js
+++ b/backend/chat-embedding.js
@@ -73,8 +73,20 @@ async function initSchema(pool) {
     }
     try {
         // HNSW is fast; falls back to sequential scan if index not present. Safe either way.
-        await pool.query(`CREATE INDEX IF NOT EXISTS idx_chat_embedding_hnsw
-            ON chat_messages USING hnsw (embedding vector_cosine_ops)`);
+        // Build single-threaded: a parallel index build (max_parallel_maintenance_workers>0)
+        // allocates a ~60MB dynamic-shared-memory segment in the container's /dev/shm, which is
+        // too small on hosted PG (Railway ~64MB) and fails with "could not resize shared memory
+        // segment ... No space left on device". Pinning the setting to 0 on the build connection
+        // avoids /dev/shm entirely so the index actually builds (was perpetually falling back to
+        // seq-scan). Use a dedicated client so the SET applies to the same session as the build.
+        const idxClient = await pool.connect();
+        try {
+            await idxClient.query('SET max_parallel_maintenance_workers = 0');
+            await idxClient.query(`CREATE INDEX IF NOT EXISTS idx_chat_embedding_hnsw
+                ON chat_messages USING hnsw (embedding vector_cosine_ops)`);
+        } finally {
+            idxClient.release();
+        }
     } catch (err) {
         console.warn('[ChatEmbedding] HNSW index creation failed (search still works, just slower):', err.message);
     }

--- a/backend/tests/jest/chat-embedding-unit.test.js
+++ b/backend/tests/jest/chat-embedding-unit.test.js
@@ -19,6 +19,15 @@ function createPool(columnType = EXPECTED_TYPE) {
             }
             return { rows: [] };
         },
+        // HNSW index build runs on a dedicated client (SET max_parallel_maintenance_workers=0
+        // applies to the same session). Route the client's queries into the same recorder so
+        // ordering assertions still see the CREATE INDEX.
+        async connect() {
+            return {
+                query: (sql) => pool.query(sql),
+                release: () => {},
+            };
+        },
     };
     return pool;
 }
@@ -74,6 +83,23 @@ describe('chat-embedding schema normalization', () => {
         expect(queryIndex(pool, 'DROP INDEX IF EXISTS idx_chat_embedding_hnsw')).toBe(-1);
         expect(queryIndex(pool, `ALTER COLUMN embedding TYPE ${EXPECTED_TYPE}`)).toBe(-1);
         expect(queryIndex(pool, 'CREATE INDEX IF NOT EXISTS idx_chat_embedding_hnsw')).toBeGreaterThan(-1);
+    });
+
+    it('builds the HNSW index single-threaded to avoid /dev/shm exhaustion', async () => {
+        // Parallel index build allocates a ~60MB DSM segment in the container's /dev/shm,
+        // which fails on hosted PG (Railway ~64MB): "could not resize shared memory segment
+        // ... No space left on device". The build must SET max_parallel_maintenance_workers=0
+        // on the same connection BEFORE CREATE INDEX. (card_cff46d3 HNSW fix)
+        const chatEmbedding = require('../../chat-embedding');
+        const pool = createPool(EXPECTED_TYPE);
+
+        await chatEmbedding.initSchema(pool);
+
+        const setIdx = queryIndex(pool, 'SET max_parallel_maintenance_workers = 0');
+        const createIdx = queryIndex(pool, 'CREATE INDEX IF NOT EXISTS idx_chat_embedding_hnsw');
+        expect(setIdx).toBeGreaterThan(-1);
+        expect(createIdx).toBeGreaterThan(-1);
+        expect(setIdx).toBeLessThan(createIdx);
     });
 });
 


### PR DESCRIPTION
## Root cause (diagnosed live, not a guess)
The recurring `[ChatEmbedding] HNSW index creation failed ... could not resize shared memory segment to ~61MB: No space left on device` is **not** a RAM-tier / dashboard limit. Queried the live pgvector DB (PG 17.9) via Railway API:
- shared_buffers=128MB, maintenance_work_mem=64MB, **max_parallel_maintenance_workers=2**

A **parallel** HNSW build allocates a ~60MB dynamic-shared-memory segment in the container's **/dev/shm**, which is too small on hosted PG (Railway ~64MB) → build fails → search perpetually falls back to seq-scan.

## Fix
`backend/chat-embedding.js`: acquire a dedicated client and `SET max_parallel_maintenance_workers = 0` before `CREATE INDEX ... USING hnsw` so the build runs single-threaded and never touches /dev/shm. Slower build, but it actually succeeds. No infra/plan change.

## Tests
`chat-embedding-unit.test.js`: added `connect()` to the mock pool (build now runs on a dedicated client) + new case asserting `SET max_parallel_maintenance_workers=0` precedes `CREATE INDEX`. 6/6 pass locally.

Converts the HNSW 'known limitation' (umbrella card_cff46d3 / card_fdc0d7ee) into a real fix — once deployed, the index builds and semantic search uses HNSW instead of seq-scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)