### PR TITLE
fix(mindmap): ignore non-UUID chat_anchor placeholders (no bogus chat hub node) (card_1356eaf3)

### DIFF
--- a/backend/kanban.js
+++ b/backend/kanban.js
@@ -958,8 +958,18 @@ function createKanbanModule(devices, { awardEntityXP, serverLog, pushToEntity, p
         // Chat-anchor: pin originating chat message + mind-map coord (Phase 1 — persist
         // only; UI picker + validator enforcement land in follow-up PRs). Auto-cards leave
         // both NULL so the UI renders N/A.
-        const anchorMsgId = (typeof chatAnchorMessageId === 'string' && chatAnchorMessageId.trim())
-            ? chatAnchorMessageId.trim().slice(0, 128)
+        //
+        // The anchor MUST be a real chat_messages UUID (or NULL). Automated card
+        // creators (ErrLog/cron, loop-directive, phase4, speakto, …) previously
+        // POSTed literal placeholder strings such as "cron-auto" / "cron-auto-generated"
+        // here; the mind-map graph projection then grouped every card sharing that
+        // value into one bogus "chat #cron-auto" hub node and non-UUID values raised
+        // "invalid input syntax for type uuid" on chat joins. Reject non-UUID anchors
+        // at the write boundary (store NULL) so the placeholder pollution can't recur.
+        const CHAT_ANCHOR_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+        const anchorMsgId = (typeof chatAnchorMessageId === 'string'
+            && CHAT_ANCHOR_UUID_RE.test(chatAnchorMessageId.trim()))
+            ? chatAnchorMessageId.trim()
             : null;
         let anchorCoord = null;
         if (chatAnchorCoord && typeof chatAnchorCoord === 'object') {

--- a/backend/mindmap-graph-projection.js
+++ b/backend/mindmap-graph-projection.js
@@ -41,6 +41,21 @@ function clip(s, max) {
     return str.length > max ? str.slice(0, max) : str;
 }
 
+// Chat-anchor pollution guard. The automated ErrLog/cron card creator (and a
+// handful of loop-directive / phase4 / speakto card creators) historically wrote
+// literal placeholder strings — "cron-auto", "cron-auto-generated", "his_...",
+// "phase4-read-followup", "speakto-routing-investigation", etc. — into
+// kanban_cards.chat_anchor_message_id instead of a real chat_messages UUID (or
+// NULL). The graph projection then grouped every card sharing such a value into
+// one synthetic chat node (e.g. the bogus green "chat #cron-auto" hub), and the
+// stray 1-card placeholders also triggered "invalid input syntax for type uuid"
+// when joined as UUIDs. Only treat a value as a real chat anchor when it is a
+// canonical UUID; anything else is ignored (no chat node, no chat_anchor edge).
+const CHAT_ANCHOR_UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+function isValidChatAnchorId(v) {
+    return typeof v === 'string' && CHAT_ANCHOR_UUID_RE.test(v);
+}
+
 function parseBoolFlag(raw, def) {
     if (raw === undefined || raw === null || raw === '') return def;
     const s = String(raw).toLowerCase();
@@ -389,7 +404,9 @@ function projectGraph({
     //           note↔chat or card↔chat anchors).
     const chatMsgIds = new Set();
     for (const c of cards) {
-        if (c.chat_anchor_message_id) chatMsgIds.add(c.chat_anchor_message_id);
+        // Ignore non-UUID placeholder anchors (see isValidChatAnchorId) so a bogus
+        // shared value like "cron-auto" never collapses into one synthetic chat hub.
+        if (isValidChatAnchorId(c.chat_anchor_message_id)) chatMsgIds.add(c.chat_anchor_message_id);
     }
     for (const [, anchors] of anchorsByNode) {
         const chatAnchors = anchors.filter(a => a.anchor_type === 'chat_message');
@@ -399,7 +416,9 @@ function projectGraph({
             (a.anchor_type === 'note' && noteIds.has(a.anchor_ref))
         );
         if (!hasIncluded) continue;
-        for (const ca of chatAnchors) chatMsgIds.add(ca.anchor_ref);
+        for (const ca of chatAnchors) {
+            if (isValidChatAnchorId(ca.anchor_ref)) chatMsgIds.add(ca.anchor_ref);
+        }
     }
     for (const msgId of chatMsgIds) {
         const id = `chat:${msgId}`;
@@ -578,7 +597,7 @@ function projectGraph({
     //    6a) kanban_cards.chat_anchor_message_id direct field
     for (const c of cards) {
         const mid = c.chat_anchor_message_id;
-        if (!mid || !nodeIdSet.has(`chat:${mid}`)) continue;
+        if (!isValidChatAnchorId(mid) || !nodeIdSet.has(`chat:${mid}`)) continue;
         links.push(buildLink({
             id: `chat_anchor:task:${c.id}:${mid}`,
             source: `task:${c.id}`,

--- a/backend/tests/jest/kanban-card.test.js
+++ b/backend/tests/jest/kanban-card.test.js
@@ -82,7 +82,7 @@ describe('POST /card — assignedBots validation', () => {
         });
 
         const res = await post('/api/mission/card')
-            .send({ ...AUTH, title: 'Test card', assignedBots: [0], chatAnchorMessageId: 'msg-test-anchor' });
+            .send({ ...AUTH, title: 'Test card', assignedBots: [0], chatAnchorMessageId: 'aaaaaaaa-1111-2222-3333-444444444444' });
         expect(res.status).not.toBe(400);
     });
 
@@ -91,6 +91,38 @@ describe('POST /card — assignedBots validation', () => {
             .send({ ...AUTH, title: 'No anchor', assignedBots: [0] });
         expect(res.status).toBe(400);
         expect(res.body.errorKey).toBe('kb_anchor_required');
+    });
+
+    // card_1356eaf3: non-UUID chat_anchor placeholders (e.g. the ErrLog/cron
+    // creator's "cron-auto") must be treated as "no anchor" at the write boundary
+    // so they never reach the DB and pollute the mind-map chat-hub projection.
+    it('rejects USER-filed card with a non-UUID chatAnchorMessageId placeholder (card_1356eaf3)', async () => {
+        const res = await post('/api/mission/card')
+            .send({ ...AUTH, title: 'cron card', assignedBots: [0], chatAnchorMessageId: 'cron-auto' });
+        expect(res.status).toBe(400);
+        expect(res.body.errorKey).toBe('kb_anchor_required');
+    });
+
+    // A bot/cron-filed card (entityId > 0) with a placeholder anchor is accepted,
+    // but the placeholder is dropped to NULL rather than persisted verbatim.
+    it('drops non-UUID chatAnchorMessageId to NULL for bot-filed cards (card_1356eaf3)', async () => {
+        mockQuery.mockResolvedValueOnce({
+            rows: [{
+                id: 'cron-1', device_id: 'test-dev', title: 'cron card',
+                description: '', priority: 'P2', status: 'backlog',
+                assigned_bots: [0], created_by: 1, chat_anchor_message_id: null,
+                created_at: new Date(), updated_at: new Date(),
+                status_changed_at: new Date(), archived: false,
+            }],
+        });
+        const res = await post('/api/mission/card')
+            .send({ ...AUTH, title: 'cron card', assignedBots: [0], entityId: 1, chatAnchorMessageId: 'cron-auto' });
+        expect(res.status).not.toBe(400);
+        const insertCall = mockQuery.mock.calls.find(c => /INSERT INTO kanban_cards/.test(c[0]));
+        expect(insertCall).toBeTruthy();
+        // chat_anchor_message_id is the 3rd-from-last INSERT param (… anchor, coord, dispatch_mode).
+        const params = insertCall[1];
+        expect(params[params.length - 3]).toBe(null);
     });
 
     it('allows bot-filed card (entityId > 0) without chatAnchorMessageId', async () => {
@@ -116,7 +148,7 @@ describe('POST /card — assignedBots validation', () => {
                 id: 3, device_id: 'test-dev', title: 'From mindmap',
                 description: '', priority: 'P2', status: 'backlog',
                 assigned_bots: [0], created_by: 0,
-                chat_anchor_message_id: 'msg-test-anchor',
+                chat_anchor_message_id: 'aaaaaaaa-1111-2222-3333-444444444444',
                 chat_anchor_coord: { x: 142.5, y: -87.3 },
                 created_at: new Date(), updated_at: new Date(),
                 status_changed_at: new Date(), archived: false,
@@ -124,7 +156,7 @@ describe('POST /card — assignedBots validation', () => {
         });
         const res = await post('/api/mission/card').send({
             ...AUTH, title: 'From mindmap', assignedBots: [0],
-            chatAnchorMessageId: 'msg-test-anchor',
+            chatAnchorMessageId: 'aaaaaaaa-1111-2222-3333-444444444444',
             chatAnchorCoord: { x: 142.5, y: -87.3 },
         });
         expect(res.status).not.toBe(400);
@@ -210,7 +242,7 @@ describe('POST /card — assignedBots validation', () => {
                 id: 4, device_id: 'test-dev', title: 'Bad coord',
                 description: '', priority: 'P2', status: 'backlog',
                 assigned_bots: [0], created_by: 0,
-                chat_anchor_message_id: 'msg-test-anchor',
+                chat_anchor_message_id: 'aaaaaaaa-1111-2222-3333-444444444444',
                 chat_anchor_coord: null,
                 created_at: new Date(), updated_at: new Date(),
                 status_changed_at: new Date(), archived: false,
@@ -218,7 +250,7 @@ describe('POST /card — assignedBots validation', () => {
         });
         const res = await post('/api/mission/card').send({
             ...AUTH, title: 'Bad coord', assignedBots: [0],
-            chatAnchorMessageId: 'msg-test-anchor',
+            chatAnchorMessageId: 'aaaaaaaa-1111-2222-3333-444444444444',
             chatAnchorCoord: { x: 'not-a-number', y: null },
         });
         expect(res.status).not.toBe(400);
@@ -372,7 +404,7 @@ describe('POST /card — inline automation + schedule', () => {
             ...AUTH, title: 'Auto task', assignedBots: [0],
             isAutomation: true,
             schedule: { type: 'recurring', cron: '0 */4 * * *' },
-            chatAnchorMessageId: 'msg-test-anchor',
+            chatAnchorMessageId: 'aaaaaaaa-1111-2222-3333-444444444444',
         });
 
         expect(res.status).toBe(200);
@@ -392,7 +424,7 @@ describe('POST /card — inline automation + schedule', () => {
         const res = await post('/api/mission/card').send({
             ...AUTH, title: 'Auto task', assignedBots: [0],
             schedule: { type: 'recurring', cron: '0 9 * * *' },
-            chatAnchorMessageId: 'msg-test-anchor',
+            chatAnchorMessageId: 'aaaaaaaa-1111-2222-3333-444444444444',
         });
 
         expect(res.status).toBe(200);

--- a/backend/tests/jest/kanban-chat-card-ref.test.js
+++ b/backend/tests/jest/kanban-chat-card-ref.test.js
@@ -76,7 +76,7 @@ describe('notifyEntities → saveChatMessage kanban_ref card arg', () => {
 
         const res = await request(app).post('/api/mission/card').send({
             ...AUTH, title: 'Hello', assignedBots: [0], status: 'todo',
-            chatAnchorMessageId: 'msg-test-anchor',
+            chatAnchorMessageId: 'aaaaaaaa-1111-2222-3333-444444444444',
         });
 
         expect(res.status).toBe(200);

--- a/backend/tests/jest/mindmap-graph.test.js
+++ b/backend/tests/jest/mindmap-graph.test.js
@@ -345,8 +345,11 @@ describe('mindmap-graph-projection — pure helpers', () => {
     });
 
     test('projectGraph emits chat_anchor edges (amendment A)', () => {
+        // Real chat anchors are canonical UUIDs (chat_messages.id).
+        const MSG_PINNED = '11111111-1111-1111-1111-111111111111';
+        const MSG_MIRROR = '22222222-2222-2222-2222-222222222222';
         const cards = [
-            { id: 'card_a', title: 'pinned to chat', description: '', priority: 'P1', status: 'todo', parent_card_id: null, is_automation: false, assigned_bots: [2], created_by: 1, reviewer_entity_id: null, chat_anchor_message_id: 'msg-pinned', archived: false, updated_at: null },
+            { id: 'card_a', title: 'pinned to chat', description: '', priority: 'P1', status: 'todo', parent_card_id: null, is_automation: false, assigned_bots: [2], created_by: 1, reviewer_entity_id: null, chat_anchor_message_id: MSG_PINNED, archived: false, updated_at: null },
         ];
         const result = projection.projectGraph({
             cards,
@@ -358,9 +361,9 @@ describe('mindmap-graph-projection — pure helpers', () => {
                 { id: 'note_a', title: 'cross-linked note', content: '', category: 'general', created_by: '2', updated_at: null },
             ],
             anchorRows: [
-                // mindmap_node that bridges note_a + chat msg-mirror + card_a
+                // mindmap_node that bridges note_a + chat MSG_MIRROR + card_a
                 { node_id: 'mm-1', anchor_type: 'note',          anchor_ref: 'note_a',     display_label: null },
-                { node_id: 'mm-1', anchor_type: 'chat_message', anchor_ref: 'msg-mirror', display_label: null },
+                { node_id: 'mm-1', anchor_type: 'chat_message', anchor_ref: MSG_MIRROR,   display_label: null },
                 { node_id: 'mm-1', anchor_type: 'kanban_card',  anchor_ref: 'card_a',     display_label: null },
             ],
             entityMap: { 2: { character: 'LOBSTER' }, 1: { character: 'Mac_F' } },
@@ -371,16 +374,16 @@ describe('mindmap-graph-projection — pure helpers', () => {
         });
 
         const chatNodes = result.nodes.filter(n => n.type === 'chat').map(n => n.id).sort();
-        expect(chatNodes).toEqual(['chat:msg-mirror', 'chat:msg-pinned']);
+        expect(chatNodes).toEqual([`chat:${MSG_MIRROR}`, `chat:${MSG_PINNED}`].sort());
 
         const chatEdges = result.links.filter(l => l.type === 'chat_anchor');
-        // Expect: task:card_a → chat:msg-pinned (direct field)
-        //          task:card_a → chat:msg-mirror (anchor cross-correlation)
-        //          note:note_a → chat:msg-mirror (anchor cross-correlation)
+        // Expect: task:card_a → chat:MSG_PINNED (direct field)
+        //          task:card_a → chat:MSG_MIRROR (anchor cross-correlation)
+        //          note:note_a → chat:MSG_MIRROR (anchor cross-correlation)
         const pairs = new Set(chatEdges.map(e => `${e.source}->${e.target}`));
-        expect(pairs.has('task:card_a->chat:msg-pinned')).toBe(true);
-        expect(pairs.has('task:card_a->chat:msg-mirror')).toBe(true);
-        expect(pairs.has('note:note_a->chat:msg-mirror')).toBe(true);
+        expect(pairs.has(`task:card_a->chat:${MSG_PINNED}`)).toBe(true);
+        expect(pairs.has(`task:card_a->chat:${MSG_MIRROR}`)).toBe(true);
+        expect(pairs.has(`note:note_a->chat:${MSG_MIRROR}`)).toBe(true);
         expect(result.stats.edgeCounts.chat_anchor).toBe(3);
 
         // And the mindmap_node also bridges note_a ↔ card_a — note_on_card edge.
@@ -388,6 +391,53 @@ describe('mindmap-graph-projection — pure helpers', () => {
         expect(noteOnCard).toBeTruthy();
         expect(noteOnCard.source).toBe('note:note_a');
         expect(noteOnCard.target).toBe('task:card_a');
+    });
+
+    test('projectGraph ignores non-UUID chat_anchor placeholders (no bogus chat hub node) — card_1356eaf3', () => {
+        // Regression: the automated ErrLog/cron card creator wrote literal placeholder
+        // strings into chat_anchor_message_id. Several cards shared "cron-auto", which
+        // the projection used to collapse into one synthetic green "chat #cron-auto" hub.
+        // A valid UUID anchor must still produce exactly one chat node + edge.
+        const VALID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+        const cards = [
+            // Two cards sharing a literal "cron-auto" placeholder → MUST NOT cluster.
+            { id: 'card_x', title: 'cron x', description: '', priority: 'P2', status: 'todo', parent_card_id: null, is_automation: true, assigned_bots: [], created_by: 0, reviewer_entity_id: null, chat_anchor_message_id: 'cron-auto', archived: false, updated_at: null },
+            { id: 'card_y', title: 'cron y', description: '', priority: 'P2', status: 'todo', parent_card_id: null, is_automation: true, assigned_bots: [], created_by: 0, reviewer_entity_id: null, chat_anchor_message_id: 'cron-auto', archived: false, updated_at: null },
+            // Other historical non-UUID placeholders also seen in prod.
+            { id: 'card_z', title: 'phase4', description: '', priority: 'P2', status: 'todo', parent_card_id: null, is_automation: false, assigned_bots: [], created_by: 1, reviewer_entity_id: null, chat_anchor_message_id: 'phase4-read-followup', archived: false, updated_at: null },
+            { id: 'card_w', title: 'speakto', description: '', priority: 'P2', status: 'todo', parent_card_id: null, is_automation: false, assigned_bots: [], created_by: 1, reviewer_entity_id: null, chat_anchor_message_id: 'speakto-routing-investigation', archived: false, updated_at: null },
+            // A real chat-anchored card → still produces its chat node + edge.
+            { id: 'card_ok', title: 'real anchor', description: '', priority: 'P1', status: 'todo', parent_card_id: null, is_automation: false, assigned_bots: [2], created_by: 1, reviewer_entity_id: null, chat_anchor_message_id: VALID, archived: false, updated_at: null },
+        ];
+        const result = projection.projectGraph({
+            cards,
+            initialCardIds: new Set(['card_x', 'card_y', 'card_z', 'card_w', 'card_ok']),
+            depRows: [],
+            commentCounts: [],
+            noteCounts: [],
+            notes: [],
+            anchorRows: [],
+            entityMap: { 2: { character: 'LOBSTER' }, 1: { character: 'Mac_F' } },
+            options: projection.parseGraphOptions({}, { isDeviceAuth: true, callerEntityId: null }),
+        });
+
+        // Only the valid UUID becomes a chat node — no "chat:cron-auto" hub, no strays.
+        const chatNodes = result.nodes.filter(n => n.type === 'chat').map(n => n.id);
+        expect(chatNodes).toEqual([`chat:${VALID}`]);
+        expect(chatNodes).not.toContain('chat:cron-auto');
+
+        // Exactly one chat_anchor edge — from the real card to the real chat node.
+        const chatEdges = result.links.filter(l => l.type === 'chat_anchor');
+        expect(chatEdges).toHaveLength(1);
+        expect(chatEdges[0].source).toBe('task:card_ok');
+        expect(chatEdges[0].target).toBe(`chat:${VALID}`);
+        expect(result.stats.edgeCounts.chat_anchor).toBe(1);
+
+        // And no chat node/edge references any of the placeholder values.
+        for (const ph of ['cron-auto', 'phase4-read-followup', 'speakto-routing-investigation']) {
+            expect(result.nodes.some(n => n.id === `chat:${ph}`)).toBe(false);
+            expect(result.links.some(l => l.target === `chat:${ph}`)).toBe(false);
+        }
     });
 
     test('projectGraph respects limitNodes by dropping trailing nodes + orphans', () => {
@@ -551,6 +601,7 @@ describe('GET /api/mindmap/graph — HTTP', () => {
     });
 
     test('chat_anchor edge surfaces when card has chat_anchor_message_id', async () => {
+        const MSG = '33333333-4444-5555-6666-777777777777'; // real chat_messages UUID
         mockQuery.mockReset();
         mockQuery
             .mockResolvedValueOnce({
@@ -558,7 +609,7 @@ describe('GET /api/mindmap/graph — HTTP', () => {
                     id: 'card_a', title: 'pinned', description: '', priority: 'P1', status: 'todo',
                     parent_card_id: null, is_automation: false,
                     assigned_bots: [], created_by: 0, reviewer_entity_id: null,
-                    chat_anchor_message_id: 'msg-xyz', archived: false, updated_at: null,
+                    chat_anchor_message_id: MSG, archived: false, updated_at: null,
                 }],
             })
             .mockResolvedValueOnce({ rows: [] }) // deps
@@ -571,13 +622,39 @@ describe('GET /api/mindmap/graph — HTTP', () => {
 
         const res = await request(app).get('/api/mindmap/graph' + AUTH);
         expect(res.status).toBe(200);
-        const chatNode = res.body.graph.nodes.find(n => n.id === 'chat:msg-xyz');
+        const chatNode = res.body.graph.nodes.find(n => n.id === `chat:${MSG}`);
         expect(chatNode).toBeTruthy();
         const chatEdge = res.body.graph.links.find(l => l.type === 'chat_anchor');
         expect(chatEdge).toBeTruthy();
         expect(chatEdge.source).toBe('task:card_a');
-        expect(chatEdge.target).toBe('chat:msg-xyz');
+        expect(chatEdge.target).toBe(`chat:${MSG}`);
         expect(chatEdge.evidence).toBe('kanban_cards.chat_anchor_message_id');
+    });
+
+    test('non-UUID chat_anchor placeholder produces NO chat node/edge over HTTP — card_1356eaf3', async () => {
+        mockQuery.mockReset();
+        mockQuery
+            .mockResolvedValueOnce({
+                rows: [{
+                    id: 'card_cron', title: '[Auto] cron card', description: '', priority: 'P2', status: 'todo',
+                    parent_card_id: null, is_automation: true,
+                    assigned_bots: [], created_by: 0, reviewer_entity_id: null,
+                    chat_anchor_message_id: 'cron-auto', archived: false, updated_at: null,
+                }],
+            })
+            .mockResolvedValueOnce({ rows: [] }) // deps
+            .mockResolvedValueOnce({ rows: [] }) // explicit card links
+            .mockResolvedValueOnce({ rows: [] }) // comment counts
+            .mockResolvedValueOnce({ rows: [] }) // note counts
+            .mockResolvedValueOnce({ rows: [] }) // mission notes
+            .mockResolvedValueOnce({ rows: [] }) // explicit note/card links
+            .mockResolvedValueOnce({ rows: [] }); // anchors
+
+        const res = await request(app).get('/api/mindmap/graph' + AUTH);
+        expect(res.status).toBe(200);
+        expect(res.body.graph.nodes.some(n => n.type === 'chat')).toBe(false);
+        expect(res.body.graph.nodes.some(n => n.id === 'chat:cron-auto')).toBe(false);
+        expect(res.body.graph.links.some(l => l.type === 'chat_anchor')).toBe(false);
     });
 
     test('explicit card links are projected into force-graph edges', async () => {


### PR DESCRIPTION
## Root cause (card_1356eaf3)

The mind-map showed a bogus green **"chat #cron-auto"** hub node. The automated ErrLog/cron card creator (plus a few loop-directive / phase4 / speakto creators) wrote **literal placeholder strings** into `kanban_cards.chat_anchor_message_id` instead of a real `chat_messages` UUID (or NULL):

- `"cron-auto"`, `"cron-auto-generated"` (52 cards — already cleaned to NULL in prod DB)
- 7 other strays: `"his_..."`, `"loop-directive-2026-04-28-infra-l2l3-notify"`, `"loop-directive-2026-04-28-infra-screenshot-default"`, `"msg_cron_hermes_001"`, `"phase4-read-followup"`, `"phase4-write-followup"`, `"speakto-routing-investigation"`

The graph projection groups every card sharing a `chat_anchor_message_id` into one synthetic chat node, so all `"cron-auto"` cards collapsed into one bogus hub; the stray values produced 1-card chat nodes and `invalid input syntax for type uuid` when joined as UUIDs.

## Fix — two layers

**1. Source — `backend/kanban.js` `POST /card` (~L961)**
The only code path that persists a caller-supplied `chat_anchor_message_id` (external automated clients POSTed the placeholders here). It now requires the value to be a canonical UUID; non-UUID anchors are stored as `NULL`. All internal cron-spawn child `INSERT`s already leave the column `NULL` (`kanban.js` L3703/L3905) and the settings-help / idle-dispatch crons never write it. Human-filed cards passing a non-UUID now correctly fail the existing `kb_anchor_required` guard.

**2. Projection guard — `backend/mindmap-graph-projection.js`**
Added `isValidChatAnchorId()` (regex `^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$`) and applied it where chat nodes/edges are built from both `kanban_cards.chat_anchor_message_id` and `mindmap_node_anchors` cross-correlation. Non-UUID values no longer synthesize a chat node or edge — defends against future pollution and cleans the 7 remaining strays **without a data migration**. (`mindmap.js` only fetches rows and delegates all node/edge building to `projectGraph()`, so this is the single projection chokepoint.)

## Writers corrected
- `backend/kanban.js:961` — `POST /card` anchor handling (the placeholder entry point). All other `INSERT INTO kanban_cards` sites already wrote NULL.

## Test coverage
- `tests/jest/mindmap-graph.test.js` — new pure-projection + HTTP regression tests: a non-UUID anchor (incl. `"cron-auto"` shared by 2 cards) produces NO chat node/edge, while a valid UUID still does; existing chat_anchor fixtures migrated to real UUIDs.
- `tests/jest/kanban-card.test.js` — new tests: USER-filed non-UUID anchor → 400 `kb_anchor_required`; bot-filed non-UUID anchor → stored as NULL; existing fixtures migrated to real UUIDs.
- `tests/jest/kanban-chat-card-ref.test.js` — anchor fixture migrated to a real UUID.

## Verify
- `npx jest tests/jest/mindmap-graph tests/jest/kanban-mindmap` → **36/36 pass**
- `npx jest tests/jest/kanban tests/jest/mindmap` → **354/354 pass**

🤖 Generated with [Claude Code](https://claude.com/claude-code)