### PR TITLE
feat(android): enrich wallpaper companion animation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,8 +20,8 @@ These overrides are mandatory for Codex in this repo:
 - **Repository**: `HankHuang0516/realbot` (GitHub repo ID: `1150444936`)
 - **Production URL**: `https://eclawbot.com`
 - **Package name**: `realbot-backend` (historical name; brand is "EClaw")
-- **Current version**: 1.1121.x+ (via semantic-release; `package.json` stays 1.0.0 placeholder)
-- **Android app version**: 1.0.79 (versionCode 85); `LATEST_APP_VERSION` constant in `backend/index.js`
+- **Current version**: 1.1185.x+ (via semantic-release; `package.json` stays 1.0.0 placeholder)
+- **Android app version**: 1.0.93 (versionCode 101); `LATEST_APP_VERSION` constant in `backend/index.js`
 - **Brand name**: "EClawbot" (rebranded from "EClaw" in v1.105.0; domain `eclawbot.com`)
 
 ---
@@ -381,6 +381,7 @@ EClaw/
 - Real-time: Socket.IO via `SocketManager.kt`
 - Push: Firebase Cloud Messaging (`ClawFcmService.kt`)
 - Live Wallpaper: Custom `ClawRenderer` engine
+- Live Wallpaper companion animation: `WallpaperWanderController` owns walking positions/state, `SpeechBubbleController` owns message bubble TTL/anchor/fade math, and `WallpaperRenderDiagnostics` owns in-memory render self-adjustment counters. Keep these pure/testable and do not store message text, secrets, device IDs, or asset URLs in diagnostics.
 - Billing: Google Play Billing (`BillingManager.kt`)
 - AI Chat: `AiChatViewModel.kt` manages state (fixes message loss, typing race condition)
 - Bottom nav: FILES tab renamed to CARDS (Card Holder); Files link moved to Settings
@@ -557,10 +558,23 @@ EClaw/
 
 ## Git Workflow
 
-- **PR then merge**: When work is complete, push the feature branch, create a PR via GitHub API, then merge it to `main` yourself (squash merge). After merging, check that the CI actions on `main` have not failed.
-- **Workflow**: develop on feature branch → push → create PR → merge PR → **check CI status on main** → **verify production**
-- 工作完成後 push feature branch、建立 PR、自行 merge 到 main，然後確認 main 的 CI actions 沒有 failed。
+- **PR then review**: When work is complete, push the feature branch and create a PR via GitHub API. Codex must not merge to `main` unless the user explicitly authorizes that exact merge in the current thread.
+- **Workflow**: develop on feature branch → push → create PR → **wait for PR CI to pass** → #2/user review → approved merge → **check CI status on main** → **verify production**
+- 工作完成後 push feature branch、建立 PR，交由使用者或 #2 review/merge；Codex 不可自行 merge 到 main，除非本 thread 明確要求。
 - Codex 會在 git push 之前審查你的代碼
+
+### ⚠️ Merge Gate — CI Must Pass Before Merge (MANDATORY)
+
+**任務未結束，直到以下三步全部完成，或清楚回報目前停在 review / merge / deploy 的哪一階段：**
+
+1. **PR CI 全綠** — 用 GitHub check runs 確認所有 check runs 的 `conclusion` 都是 `success`（或 `skipped`）。若有失敗立即修復，不可繞過。
+2. **Approved merge 進 main** — 只有使用者或 #2 明確核准後才可 merge。Draft PR 必須先轉 ready；Codex 不可自行 merge，除非使用者在目前 thread 明確要求。
+3. **確認 main CI 也綠** — merge 後確認最新一次 main workflow run 沒有 failure，並完成 production verification。
+
+**絕對不可以：**
+- 在 CI 還在跑（`in_progress` / `queued`）時就 merge
+- 留著 draft PR 不說明 review/merge 狀態就結束任務
+- 把舊的同類 PR 堆積不關閉 — 同一功能只能有 1 個 open PR，建新 PR 前先關閉舊的
 
 ### ⚠️ Code Review Checklist (MANDATORY — applies to every PR)
 

--- a/app/src/androidTest/java/com/hank/clawlive/WallpaperAnimationVisualProbeTest.kt
+++ b/app/src/androidTest/java/com/hank/clawlive/WallpaperAnimationVisualProbeTest.kt
@@ -1,0 +1,157 @@
+package com.hank.clawlive
+
+import android.content.ContentValues
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.os.Build
+import android.os.Environment
+import android.provider.MediaStore
+import android.view.MotionEvent
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.hank.clawlive.data.local.LayoutPreferences
+import com.hank.clawlive.data.model.CharacterState
+import com.hank.clawlive.data.model.EntityStatus
+import com.hank.clawlive.engine.ClawRenderer
+import com.hank.clawlive.ui.WallpaperPreviewView
+import java.io.File
+import java.io.FileOutputStream
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class WallpaperAnimationVisualProbeTest {
+    @Test
+    fun captureRendererBubbleAuraShadowProbe() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val prefs = LayoutPreferences.getInstance(context)
+        prefs.clearAllCustomPositions()
+        prefs.clearAllEntityScales()
+        prefs.useCustomLayout = true
+        prefs.wallpaperWalkingEnabled = true
+        prefs.usageOverlayEnabled = true
+        prefs.clearUsageOverlayTransform()
+        prefs.setEntityScale(0, 0.72f)
+        prefs.setEntityScale(1, 0.72f)
+        prefs.setCustomPosition(0, 0.28f, 0.05f)
+        prefs.setCustomPosition(1, 0.52f, 0.68f)
+
+        val bitmap = Bitmap.createBitmap(1080, 1920, Bitmap.Config.ARGB_8888)
+        val canvas = Canvas(bitmap)
+        val renderer = ClawRenderer(context)
+        renderer.drawMultiEntity(
+            canvas,
+            listOf(
+                EntityStatus(
+                    entityId = 0,
+                    name = "Top flip",
+                    state = CharacterState.EXCITED,
+                    message = "Near top: bubble flips below",
+                    isBound = true
+                ),
+                EntityStatus(
+                    entityId = 1,
+                    name = "Busy walk",
+                    state = CharacterState.BUSY,
+                    message = "Walking anchor + aura",
+                    isBound = true
+                )
+            ),
+            loading = false
+        )
+
+        val file = saveBitmap("renderer-bubble-aura-shadow.png", bitmap)
+        assertTrue(file.length() > 0)
+    }
+
+    @Test
+    fun capturePreviewRenderedHitTargetProbe() {
+        val instrumentation = InstrumentationRegistry.getInstrumentation()
+        val targetContext = instrumentation.targetContext
+        val prefs = LayoutPreferences.getInstance(targetContext)
+        prefs.clearAllCustomPositions()
+        prefs.clearAllEntityScales()
+        prefs.useCustomLayout = true
+        prefs.wallpaperWalkingEnabled = true
+        prefs.setCustomPosition(0, 0.72f, 0.46f)
+
+        ActivityScenario.launch(WallpaperPreviewActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val preview = activity.findViewById<WallpaperPreviewView>(R.id.wallpaperPreviewView)
+                preview.setEntities(
+                    listOf(
+                        EntityStatus(entityId = 0, name = "Walker", isBound = true)
+                    )
+                )
+                preview.dispatchTouchEvent(
+                    MotionEvent.obtain(
+                        0L,
+                        32L,
+                        MotionEvent.ACTION_DOWN,
+                        preview.width * 0.72f,
+                        preview.height * 0.46f,
+                        0
+                    )
+                )
+                preview.dispatchTouchEvent(
+                    MotionEvent.obtain(
+                        0L,
+                        64L,
+                        MotionEvent.ACTION_UP,
+                        preview.width * 0.72f,
+                        preview.height * 0.46f,
+                        0
+                    )
+                )
+                val bitmap = Bitmap.createBitmap(preview.width, preview.height, Bitmap.Config.ARGB_8888)
+                preview.draw(Canvas(bitmap))
+                val file = saveBitmap("preview-rendered-hit-target.png", bitmap)
+                assertTrue(file.length() > 0)
+            }
+            instrumentation.waitForIdleSync()
+        }
+    }
+
+    private fun saveBitmap(name: String, bitmap: Bitmap): File {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val dir = File(context.getExternalFilesDir(null), "wallpaper-animation-visual-probes")
+        dir.mkdirs()
+        val file = File(dir, name)
+        FileOutputStream(file).use { out ->
+            bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+        }
+        savePublicDownloadBitmap(name, bitmap)
+        return file
+    }
+
+    private fun savePublicDownloadBitmap(name: String, bitmap: Bitmap) {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            val values = ContentValues().apply {
+                put(MediaStore.Downloads.DISPLAY_NAME, name)
+                put(MediaStore.Downloads.MIME_TYPE, "image/png")
+                put(MediaStore.Downloads.RELATIVE_PATH, "Download/eclaw-wallpaper-visual-probes")
+                put(MediaStore.Downloads.IS_PENDING, 1)
+            }
+            val uri = context.contentResolver.insert(MediaStore.Downloads.EXTERNAL_CONTENT_URI, values)
+                ?: error("Unable to create visual probe download: $name")
+            context.contentResolver.openOutputStream(uri)?.use { out ->
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+            } ?: error("Unable to open visual probe download: $name")
+            values.clear()
+            values.put(MediaStore.Downloads.IS_PENDING, 0)
+            context.contentResolver.update(uri, values, null, null)
+        } else {
+            val dir = File(
+                Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS),
+                "eclaw-wallpaper-visual-probes"
+            )
+            dir.mkdirs()
+            FileOutputStream(File(dir, name)).use { out ->
+                bitmap.compress(Bitmap.CompressFormat.PNG, 100, out)
+            }
+        }
+    }
+}

--- a/app/src/androidTest/java/com/hank/clawlive/WallpaperPreviewUiTest.kt
+++ b/app/src/androidTest/java/com/hank/clawlive/WallpaperPreviewUiTest.kt
@@ -372,6 +372,32 @@ class WallpaperPreviewUiTest {
     }
 
     @Test
+    fun testEntityTapUsesRenderedWalkingPositionForHitTarget() {
+        ActivityScenario.launch(WallpaperPreviewActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val prefs = LayoutPreferences.getInstance(activity)
+                prefs.clearAllCustomPositions()
+                prefs.clearAllEntityScales()
+
+                val preview = activity.findViewById<WallpaperPreviewView>(R.id.wallpaperPreviewView)
+                preview.setEntities(
+                    listOf(
+                        EntityStatus(entityId = 0, name = "Walker", isBound = true)
+                    )
+                )
+
+                val renderedX = preview.width * 0.72f
+                val renderedY = preview.height * 0.46f
+                preview.setRenderedEntityCenterForTest(0, renderedX, renderedY)
+
+                dispatchTap(preview, renderedX, renderedY)
+
+                assertEquals("entity:0", preview.getLockedTargetForTest())
+            }
+        }
+    }
+
+    @Test
     fun testSafeInsetsAppliedCorrectly() {
         ActivityScenario.launch(WallpaperPreviewActivity::class.java).use { scenario ->
             scenario.onActivity { activity ->

--- a/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
@@ -19,6 +19,7 @@ import com.hank.clawlive.data.model.EntityStatus
 import com.hank.clawlive.data.model.UsageSnapshotLatest
 import com.hank.clawlive.data.repository.CompanionRepository
 import timber.log.Timber
+import kotlin.math.abs
 import kotlin.math.ceil
 import kotlin.math.sin
 import kotlin.math.sqrt
@@ -32,6 +33,10 @@ class ClawRenderer(
     private val spritesheetDrawer = companionRepository?.let { SpritesheetCompanionDrawer(it) }
     private val usageOverlayRenderer = UsageOverlayRenderer(context, layoutPrefs)
     private val wanderController = WallpaperWanderController()
+    private val speechBubbleController = SpeechBubbleController()
+    private val renderDiagnostics = WallpaperRenderDiagnostics()
+    private val lastBubbleMessageByEntity = mutableMapOf<Int, String>()
+    private val bubblePulseStartedByEntity = mutableMapOf<Int, Long>()
 
     // Background image cache
     private var cachedBackgroundBitmap: Bitmap? = null
@@ -104,6 +109,23 @@ class ClawRenderer(
         textAlign = Paint.Align.CENTER
         isAntiAlias = true
         isFakeBoldText = true
+    }
+
+    private val shadowPaint = Paint().apply {
+        style = Paint.Style.FILL
+        color = Color.BLACK
+        isAntiAlias = true
+    }
+
+    private val stateAuraPaint = Paint().apply {
+        style = Paint.Style.FILL
+        isAntiAlias = true
+    }
+
+    private val bubblePulsePaint = Paint().apply {
+        style = Paint.Style.STROKE
+        isAntiAlias = true
+        strokeCap = Paint.Cap.ROUND
     }
 
     // Animation state
@@ -481,6 +503,17 @@ class ClawRenderer(
             enabled = walkingEnabled
         )
         val baseScale = getScaleFactor(entities.size)
+        val nowMs = System.currentTimeMillis()
+        syncSpeechBubbles(entities, nowMs)
+        renderDiagnostics.recordFrame(
+            walkingEntityCount = entities.count { wanderController.isWalking(it.entityId) },
+            activeBubbleCount = speechBubbleController.activeCount(nowMs)
+        )
+        val bubbleAvoidBounds = usageOverlayRenderer.getBounds(
+            canvas.width,
+            canvas.height,
+            usageSnapshot
+        )
 
         entities.forEachIndexed { index, entity ->
             if (index < positions.size) {
@@ -491,11 +524,45 @@ class ClawRenderer(
                 val motionStateOverride = if (wanderController.isWalking(entity.entityId)) {
                     WallpaperWanderController.WALKING_STATE_ASSET
                 } else null
-                drawSingleEntityAt(canvas, entity, cx, cy, finalScale, width, motionStateOverride)
+                drawSingleEntityAt(
+                    canvas,
+                    entity,
+                    cx,
+                    cy,
+                    finalScale,
+                    width,
+                    motionStateOverride,
+                    nowMs,
+                    bubbleAvoidBounds
+                )
             }
         }
 
         usageOverlayRenderer.draw(canvas, usageSnapshot)
+    }
+
+    private fun syncSpeechBubbles(entities: List<EntityStatus>, nowMs: Long) {
+        val liveEntityIds = entities.map { it.entityId }.toSet()
+        val staleEntityIds = lastBubbleMessageByEntity.keys - liveEntityIds
+        staleEntityIds.forEach { speechBubbleController.clear(it) }
+        lastBubbleMessageByEntity.keys.retainAll(liveEntityIds)
+        bubblePulseStartedByEntity.keys.retainAll(liveEntityIds)
+
+        entities.forEach { entity ->
+            val displayText = if (isAmbient) getStateEmoji(entity.state) else entity.message.trim()
+            if (displayText.isBlank()) {
+                lastBubbleMessageByEntity.remove(entity.entityId)
+                bubblePulseStartedByEntity.remove(entity.entityId)
+                speechBubbleController.clear(entity.entityId)
+                return@forEach
+            }
+
+            if (lastBubbleMessageByEntity[entity.entityId] != displayText) {
+                speechBubbleController.show(entity.entityId, displayText, nowMs)
+                lastBubbleMessageByEntity[entity.entityId] = displayText
+                bubblePulseStartedByEntity[entity.entityId] = nowMs
+            }
+        }
     }
 
     /**
@@ -508,10 +575,12 @@ class ClawRenderer(
         centerY: Float,
         scale: Float,
         screenWidth: Float,
-        motionStateOverride: String? = null
+        motionStateOverride: String? = null,
+        nowMs: Long = System.currentTimeMillis(),
+        bubbleAvoidBounds: RectF? = null
     ) {
         // Calculate Animation (Bobbing)
-        val time = System.currentTimeMillis() - startTime
+        val time = nowMs - startTime
         val bobOffset = if (entity.state == CharacterState.SLEEPING) {
             0f
         } else {
@@ -521,6 +590,12 @@ class ClawRenderer(
 
         val charY = centerY + bobOffset
         val radius = 150f * scale
+        val quietEffects = renderDiagnostics.shouldReduceEffects(entity.entityId)
+
+        drawGroundShadow(canvas, centerX, charY, radius, scale, time)
+        if (!quietEffects) {
+            drawStateAura(canvas, entity, centerX, charY, radius, scale, time)
+        }
 
         // Health-checking: pulsing/glowing ring around the creature while the
         // passive health-check/repair runs (parity with Web .health-checking
@@ -539,7 +614,8 @@ class ClawRenderer(
         // (card_9e52c7b405d0fdd3aad0d2e3). A blank gap for one 33 ms tick is
         // invisible; a wrong-character flash is not.
         val companion = companionRepository?.cached(entity.entityId)
-        val drawResult = if (companion != null && companion.assetType == "spritesheet") {
+        val attemptedSpritesheet = companion != null && companion.assetType == "spritesheet"
+        val drawResult = if (attemptedSpritesheet) {
             spritesheetDrawer?.draw(
                 canvas,
                 companion,
@@ -550,6 +626,9 @@ class ClawRenderer(
                 scale
             ) ?: SpritesheetCompanionDrawer.DrawResult.UNSUPPORTED
         } else SpritesheetCompanionDrawer.DrawResult.UNSUPPORTED
+        if (attemptedSpritesheet) {
+            renderDiagnostics.recordCompanionDraw(entity.entityId, drawResult.toDiagnosticsOutcome())
+        }
 
         when (drawResult) {
             SpritesheetCompanionDrawer.DrawResult.DRAWN,
@@ -559,9 +638,26 @@ class ClawRenderer(
                 drawLobsterAtPosition(canvas, centerX, charY, entity, scale, companion)
         }
 
-        // Draw message bubble (ABOVE the entity)
-        // Anchor point is top of the character + margin
-        drawMessageBubble(canvas, entity, centerX, charY - radius - (20f * scale), scale, screenWidth)
+        val bubblePlacement = speechBubbleController.placementFor(
+            entityId = entity.entityId,
+            entityXPct = (centerX / canvas.width.toFloat()).coerceIn(0f, 1f),
+            entityYPct = (charY / canvas.height.toFloat()).coerceIn(0f, 1f),
+            spriteHeightPct = ((radius * 2f) / canvas.height.toFloat()).coerceIn(0.02f, 0.9f),
+            nowMs = nowMs
+        )
+        if (bubblePlacement != null) {
+            val renderBubblePlacement = if (bubblePlacement.flippedBelow && !isAmbient) {
+                val labelClearancePct = ((88f * scale) / canvas.height.toFloat()).coerceIn(0f, 0.12f)
+                bubblePlacement.copy(
+                    anchorYPct = (bubblePlacement.anchorYPct + labelClearancePct).coerceIn(0f, 1f)
+                )
+            } else {
+                bubblePlacement
+            }
+            val pulseAgeMs = bubblePulseStartedByEntity[entity.entityId]?.let { nowMs - it } ?: Long.MAX_VALUE
+            drawBubblePulse(canvas, entity, centerX, charY, radius, scale, pulseAgeMs, renderBubblePlacement.alpha)
+            drawMessageBubble(canvas, entity, renderBubblePlacement, scale, screenWidth, bubbleAvoidBounds)
+        }
 
         // Draw Name and Status Group BELOW the entity
         if (!isAmbient) {
@@ -627,6 +723,81 @@ class ClawRenderer(
             // Moving Zzz slightly up so it doesn't overlap too much with the center face features
             canvas.drawText("Zzz...", centerX + radius * 0.7f, charY - radius * 0.8f, textPaint)
         }
+    }
+
+    private fun drawGroundShadow(
+        canvas: Canvas,
+        cx: Float,
+        cy: Float,
+        radius: Float,
+        scale: Float,
+        time: Long
+    ) {
+        val walkPulse = (sin(time * 0.008f) * 0.5f + 0.5f).toFloat()
+        val shadowWidth = radius * (0.78f + 0.05f * walkPulse)
+        val shadowHeight = (18f * scale).coerceAtLeast(6f)
+        shadowPaint.alpha = (52 + 18 * walkPulse).toInt().coerceIn(0, 96)
+        canvas.drawOval(
+            RectF(
+                cx - shadowWidth,
+                cy + radius * 0.72f,
+                cx + shadowWidth,
+                cy + radius * 0.72f + shadowHeight
+            ),
+            shadowPaint
+        )
+        shadowPaint.alpha = 255
+    }
+
+    private fun drawStateAura(
+        canvas: Canvas,
+        entity: EntityStatus,
+        cx: Float,
+        cy: Float,
+        radius: Float,
+        scale: Float,
+        time: Long
+    ) {
+        if (isAmbient) return
+        val accent = when (entity.state) {
+            CharacterState.IDLE -> if (wanderController.isWalking(entity.entityId)) Color.rgb(45, 212, 191) else return
+            CharacterState.BUSY -> Color.rgb(59, 130, 246)
+            CharacterState.EATING -> Color.rgb(34, 197, 94)
+            CharacterState.EXCITED -> Color.rgb(245, 158, 11)
+            CharacterState.SLEEPING -> Color.rgb(99, 102, 241)
+        }
+        val pulse = (sin(time * 0.0045f) * 0.5f + 0.5f).toFloat()
+        stateAuraPaint.color = accent
+        stateAuraPaint.alpha = (18 + 30 * pulse).toInt().coerceIn(0, 72)
+        canvas.drawCircle(cx, cy, radius * (1.04f + 0.08f * pulse) + 8f * scale, stateAuraPaint)
+        stateAuraPaint.alpha = 255
+    }
+
+    private fun drawBubblePulse(
+        canvas: Canvas,
+        entity: EntityStatus,
+        cx: Float,
+        cy: Float,
+        radius: Float,
+        scale: Float,
+        ageMs: Long,
+        bubbleAlpha: Float
+    ) {
+        if (isAmbient || ageMs !in 0L..BUBBLE_PULSE_MS) return
+        val progress = ageMs.toFloat() / BUBBLE_PULSE_MS.toFloat()
+        bubblePulsePaint.color = stateAccentColor(entity.state)
+        bubblePulsePaint.strokeWidth = (3f * scale).coerceAtLeast(1.5f)
+        bubblePulsePaint.alpha = ((1f - progress) * bubbleAlpha * 130f).toInt().coerceIn(0, 160)
+        canvas.drawCircle(cx, cy, radius * (0.92f + 0.22f * progress), bubblePulsePaint)
+        bubblePulsePaint.alpha = 255
+    }
+
+    private fun stateAccentColor(state: CharacterState): Int = when (state) {
+        CharacterState.SLEEPING -> Color.rgb(129, 140, 248)
+        CharacterState.EXCITED -> Color.rgb(251, 146, 60)
+        CharacterState.BUSY -> Color.rgb(96, 165, 250)
+        CharacterState.EATING -> Color.rgb(74, 222, 128)
+        CharacterState.IDLE -> Color.rgb(45, 212, 191)
     }
 
     /**
@@ -697,146 +868,126 @@ class ClawRenderer(
         canvas.drawText("#$entityId", x, y + (10f * scale), badgeTextPaint)
     }
 
-    /**
-     * Draw message bubble with semi-transparent background.
-     */
-    /**
-     * Draw message bubble with semi-transparent background.
-     * Positioned ABOVE the anchor point (bottom of bubble -> anchor).
-     */
-    /**
-     * Draw message bubble with semi-transparent background.
-     * Positioned ABOVE the anchor point (bottom of bubble -> anchor).
-     */
-    /**
-     * Draw message bubble with semi-transparent background.
-     * Positioned ABOVE the anchor point (bottom of bubble -> anchor).
-     */
     private fun drawMessageBubble(
         canvas: Canvas,
         entity: EntityStatus,
-        centerX: Float,
-        anchorBottomY: Float,
+        placement: SpeechBubbleController.BubblePlacement,
         scale: Float,
-        screenWidth: Float
+        screenWidth: Float,
+        avoidBounds: RectF? = null
     ) {
-        val message = entity.message ?: ""
-        if (message.isEmpty() && isAmbient) return
+        val displayText = placement.text
+        if (displayText.isBlank()) return
 
-        // 1. Setup Text Paint
         textPaint.textSize = (32f * scale).coerceAtLeast(16f)
         textPaint.color = Color.WHITE
-        // FORCE LEFT ALIGNMENT for bubble text to prevent overflow
+        val alpha = (placement.alpha * 255f).toInt().coerceIn(0, 255)
+        if (alpha <= 0) return
+
         val originalAlign = textPaint.textAlign
+        val originalTextAlpha = textPaint.alpha
+        val originalBubbleAlpha = bubblePaint.alpha
+        val originalStrokeAlpha = bubbleStrokePaint.alpha
         textPaint.textAlign = Paint.Align.LEFT
+        textPaint.alpha = alpha
 
-        val displayText = if (isAmbient) {
-            getStateEmoji(entity.state)
-        } else {
-            message
-        }
-
-        // 2. Define Layout Constraints
         val padH = 16f * scale
         val padV = 16f * scale
         val screenHeight = canvas.height.toFloat()
-        val screenMargin = 40f * scale // Safety margin from top/bottom
-        
-        // Calculate max available height for text
-        // (Screen Height - Margins - Padding)
+        val screenMargin = 40f * scale
+        val tailHeight = 20f * scale
+
         val maxAvailableHeight = screenHeight - (screenMargin * 2) - (padV * 2)
-        
         val maxWidth = (screenWidth * 0.8f).coerceIn(200f, 800f)
         val maxTextWidth = (maxWidth - padH * 2).toInt().coerceAtLeast(1)
-        
-        // Calculate Max Lines to fit in screen
         val lineHeight = textPaint.fontSpacing
         val maxLines = (maxAvailableHeight / lineHeight).toInt().coerceAtLeast(1)
 
-        // 3. Create StaticLayout
         val layoutBuilder = android.text.StaticLayout.Builder.obtain(
             displayText, 0, displayText.length, textPaint, maxTextWidth
         )
-            .setAlignment(android.text.Layout.Alignment.ALIGN_NORMAL) 
+            .setAlignment(android.text.Layout.Alignment.ALIGN_NORMAL)
             .setLineSpacing(4f, 1.0f)
             .setIncludePad(true)
             .setMaxLines(maxLines)
             .setEllipsize(android.text.TextUtils.TruncateAt.END)
-        
+
         val layout = layoutBuilder.build()
 
-        // 4. Calculate Dimensions
         var widestLineWidth = 0f
         for (i in 0 until layout.lineCount) {
-             val lineWidth = layout.getLineWidth(i)
-             if (lineWidth > widestLineWidth) {
-                 widestLineWidth = lineWidth
-             }
+            val lineWidth = layout.getLineWidth(i)
+            if (lineWidth > widestLineWidth) {
+                widestLineWidth = lineWidth
+            }
         }
-        
-        val contentWidth = widestLineWidth
-        // Ensure minimum width for the tail connection
-        val minContentWidth = 40f * scale 
-        val finalContentWidth = contentWidth.coerceAtLeast(minContentWidth)
-        
+
+        val finalContentWidth = widestLineWidth.coerceAtLeast(40f * scale)
         val bubbleWidth = finalContentWidth + padH * 2
         val bubbleHeight = layout.height.toFloat() + padV * 2
-
-        // 5. Calculate Positioning (Smart Constraints)
-        val idealTop = anchorBottomY - bubbleHeight
-        
-        // If idealTop is above the screen margin, shift it down to the margin.
-        // This might cause it to overlap the character, but text legibility is priority.
-        val bubbleTop = if (idealTop < screenMargin) {
-            screenMargin
+        val anchorX = placement.anchorXPct * screenWidth
+        val anchorY = placement.anchorYPct * screenHeight
+        val idealTop = if (placement.flippedBelow) {
+            anchorY + tailHeight
         } else {
-            idealTop
+            anchorY - tailHeight - bubbleHeight
         }
-        
+        val maxTop = (screenHeight - screenMargin - bubbleHeight).coerceAtLeast(screenMargin)
+        var bubbleTop = idealTop.coerceIn(screenMargin, maxTop)
+        val maxLeft = (screenWidth - screenMargin - bubbleWidth).coerceAtLeast(screenMargin)
+        val bubbleLeft = (anchorX - bubbleWidth / 2f).coerceIn(screenMargin, maxLeft)
+        val bubbleRight = bubbleLeft + bubbleWidth
+        avoidBounds?.let { avoid ->
+            val avoidPadding = 10f * scale
+            val paddedAvoid = RectF(avoid).apply {
+                inset(-avoidPadding, -avoidPadding)
+            }
+            val currentRect = RectF(bubbleLeft, bubbleTop, bubbleRight, bubbleTop + bubbleHeight)
+            if (RectF.intersects(currentRect, paddedAvoid)) {
+                val candidates = listOf(
+                    paddedAvoid.bottom + avoidPadding,
+                    paddedAvoid.top - avoidPadding - bubbleHeight,
+                    maxTop,
+                    screenMargin
+                )
+                    .map { it.coerceIn(screenMargin, maxTop) }
+                    .distinct()
+                    .filter { candidateTop ->
+                        !RectF.intersects(
+                            RectF(bubbleLeft, candidateTop, bubbleRight, candidateTop + bubbleHeight),
+                            paddedAvoid
+                        )
+                    }
+                bubbleTop = candidates.minByOrNull { abs(it - idealTop) } ?: bubbleTop
+            }
+        }
         val bubbleBottom = bubbleTop + bubbleHeight
-        val bubbleLeft = centerX - bubbleWidth / 2
-        val bubbleRight = centerX + bubbleWidth / 2
-        
-        // Check if shifted significantly (tail would be disconnected/weird)
-        // If the bubble bottom is significantly below the anchor point, we should hide the tail?
-        // Actually, if bubbleTop != idealTop, it means we shifted.
-        val isShifted = bubbleTop > idealTop + 1f // allowance for float error
+        val isShifted = abs(bubbleTop - idealTop) > tailHeight * 0.6f
 
-        // 6. Draw Bubble Shape (Unified Path)
         val cornerRadius = 24f * scale
-        
-        // Tail geometry
         val tailWidth = 20f * scale
-        val tailHeight = 20f * scale
-        val tailTipX = centerX
-        val tailTipY = bubbleBottom + tailHeight
-        val tailBaseLeft = centerX - (tailWidth / 2) + (5f * scale)
-        val tailBaseRight = centerX + (tailWidth / 2)
-        
+        val tailBaseX = anchorX.coerceIn(bubbleLeft + cornerRadius, bubbleRight - cornerRadius)
         val path = android.graphics.Path()
-        
+
+        path.addRoundRect(
+            RectF(bubbleLeft, bubbleTop, bubbleRight, bubbleBottom),
+            cornerRadius,
+            cornerRadius,
+            android.graphics.Path.Direction.CW
+        )
         if (!isAmbient && !isShifted) {
-             // WITH TAIL
-            path.moveTo(tailBaseRight, bubbleBottom)
-            path.lineTo(bubbleRight - cornerRadius, bubbleBottom)
-            path.arcTo(RectF(bubbleRight - cornerRadius * 2, bubbleBottom - cornerRadius * 2, bubbleRight, bubbleBottom), 90f, -90f)
-            path.lineTo(bubbleRight, bubbleTop + cornerRadius)
-            path.arcTo(RectF(bubbleRight - cornerRadius * 2, bubbleTop, bubbleRight, bubbleTop + cornerRadius * 2), 0f, -90f)
-            path.lineTo(bubbleLeft + cornerRadius, bubbleTop)
-            path.arcTo(RectF(bubbleLeft, bubbleTop, bubbleLeft + cornerRadius * 2, bubbleTop + cornerRadius * 2), 270f, -90f)
-            path.lineTo(bubbleLeft, bubbleBottom - cornerRadius)
-            path.arcTo(RectF(bubbleLeft, bubbleBottom - cornerRadius * 2, bubbleLeft + cornerRadius * 2, bubbleBottom), 180f, -90f)
-            path.lineTo(tailBaseLeft, bubbleBottom)
-            path.quadTo(centerX - (tailWidth * 0.2f), bubbleBottom + (tailHeight * 0.6f), tailTipX, tailTipY)
-            path.quadTo(centerX + (tailWidth * 0.4f), bubbleBottom + (tailHeight * 0.3f), tailBaseRight, bubbleBottom)
-        } else {
-            // NO TAIL (Rounded Rect only) - used when shifted or ambient
-            path.addRoundRect(RectF(bubbleLeft, bubbleTop, bubbleRight, bubbleBottom), cornerRadius, cornerRadius, android.graphics.Path.Direction.CW)
+            if (placement.flippedBelow) {
+                path.moveTo(tailBaseX - tailWidth / 2f, bubbleTop)
+                path.quadTo(tailBaseX - tailWidth * 0.2f, bubbleTop - tailHeight * 0.55f, anchorX, anchorY)
+                path.quadTo(tailBaseX + tailWidth * 0.2f, bubbleTop - tailHeight * 0.55f, tailBaseX + tailWidth / 2f, bubbleTop)
+            } else {
+                path.moveTo(tailBaseX + tailWidth / 2f, bubbleBottom)
+                path.quadTo(tailBaseX + tailWidth * 0.2f, bubbleBottom + tailHeight * 0.55f, anchorX, anchorY)
+                path.quadTo(tailBaseX - tailWidth * 0.2f, bubbleBottom + tailHeight * 0.55f, tailBaseX - tailWidth / 2f, bubbleBottom)
+            }
         }
-        
         path.close()
 
-        // Set Paint Colors
         val bubblesColor = when (entity.state) {
             CharacterState.SLEEPING -> Color.argb(230, 50, 50, 80)
             CharacterState.EXCITED -> Color.argb(230, 255, 100, 50)
@@ -845,24 +996,23 @@ class ClawRenderer(
             else -> Color.argb(230, 40, 40, 40)
         }
         bubblePaint.color = bubblesColor
-        
+        bubblePaint.alpha = (Color.alpha(bubblesColor) * placement.alpha).toInt().coerceIn(0, 255)
         bubbleStrokePaint.strokeWidth = 4f * scale
         bubbleStrokePaint.color = Color.WHITE
+        bubbleStrokePaint.alpha = (210f * placement.alpha).toInt().coerceIn(0, 255)
 
-        // Draw Fill
         canvas.drawPath(path, bubblePaint)
-        
-        // Draw Border
         canvas.drawPath(path, bubbleStrokePaint)
 
-        // 7. Draw Text
         canvas.save()
         canvas.translate(bubbleLeft + padH, bubbleTop + padV)
         layout.draw(canvas)
         canvas.restore()
-        
-        // Restore original alignment (CENTER)
+
         textPaint.textAlign = originalAlign
+        textPaint.alpha = originalTextAlpha
+        bubblePaint.alpha = originalBubbleAlpha
+        bubbleStrokePaint.alpha = originalStrokeAlpha
     }
 
     /**
@@ -1108,6 +1258,19 @@ class ClawRenderer(
         }
     }
 
+    fun diagnosticsSnapshotForTest(): WallpaperRenderDiagnostics.Snapshot {
+        return renderDiagnostics.snapshot()
+    }
+
+    private fun SpritesheetCompanionDrawer.DrawResult.toDiagnosticsOutcome(): WallpaperRenderDiagnostics.CompanionDrawOutcome {
+        return when (this) {
+            SpritesheetCompanionDrawer.DrawResult.DRAWN -> WallpaperRenderDiagnostics.CompanionDrawOutcome.DRAWN
+            SpritesheetCompanionDrawer.DrawResult.LOADING -> WallpaperRenderDiagnostics.CompanionDrawOutcome.LOADING
+            SpritesheetCompanionDrawer.DrawResult.UNSUPPORTED -> WallpaperRenderDiagnostics.CompanionDrawOutcome.UNSUPPORTED
+            SpritesheetCompanionDrawer.DrawResult.ERROR -> WallpaperRenderDiagnostics.CompanionDrawOutcome.ERROR
+        }
+    }
+
     // ============================================
     // BACKWARD COMPATIBLE SINGLE ENTITY
     // ============================================
@@ -1119,5 +1282,9 @@ class ClawRenderer(
         // Convert to EntityStatus and use multi-entity renderer
         val entityStatus = EntityStatus.fromAgentStatus(status, 0)
         drawMultiEntity(canvas, listOf(entityStatus))
+    }
+
+    companion object {
+        private const val BUBBLE_PULSE_MS = 720L
     }
 }

--- a/app/src/main/java/com/hank/clawlive/engine/SpeechBubbleController.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/SpeechBubbleController.kt
@@ -127,7 +127,7 @@ class SpeechBubbleController(
         val halfSprite = spriteHeightPct * 0.5f
         // §5.1 anchor: above the sprite top by `gap`. §5.4: flip below if too near top.
         val topAnchorY = entityYPct - halfSprite - gapPctOfHeight
-        val flippedBelow = topAnchorY < gapPctOfHeight
+        val flippedBelow = topAnchorY < TOP_EDGE_FLIP_THRESHOLD_PCT
         val anchorY = if (flippedBelow) {
             entityYPct + halfSprite + gapPctOfHeight
         } else {
@@ -174,5 +174,7 @@ class SpeechBubbleController(
         const val DEFAULT_FADE_OUT_MS = 600L
         /** Gap above the sprite, ~ default 8dp expressed as a small fraction of height. */
         const val DEFAULT_GAP_PCT_OF_HEIGHT = 0.02f
+        /** Practical top gutter: flip before the bubble gets pinned to the top edge. */
+        const val TOP_EDGE_FLIP_THRESHOLD_PCT = 0.08f
     }
 }

--- a/app/src/main/java/com/hank/clawlive/engine/WallpaperRenderDiagnostics.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/WallpaperRenderDiagnostics.kt
@@ -1,0 +1,79 @@
+package com.hank.clawlive.engine
+
+/**
+ * Lightweight, in-memory feedback loop for the live wallpaper renderer.
+ *
+ * It intentionally records only counts and entity ids. No message text, tokens,
+ * URLs, or device identifiers are stored here.
+ */
+class WallpaperRenderDiagnostics(
+    private val reduceEffectsThreshold: Int = DEFAULT_REDUCE_EFFECTS_THRESHOLD
+) {
+    enum class CompanionDrawOutcome {
+        DRAWN,
+        LOADING,
+        UNSUPPORTED,
+        ERROR
+    }
+
+    data class Snapshot(
+        val framesDrawn: Int,
+        val lastWalkingEntityCount: Int,
+        val lastActiveBubbleCount: Int,
+        val spritesheetUnsupportedByEntity: Map<Int, Int>,
+        val spritesheetErrorsByEntity: Map<Int, Int>,
+        val reducedEffectsEntityIds: Set<Int>
+    )
+
+    private var framesDrawn = 0
+    private var lastWalkingEntityCount = 0
+    private var lastActiveBubbleCount = 0
+    private val unsupportedByEntity = mutableMapOf<Int, Int>()
+    private val errorsByEntity = mutableMapOf<Int, Int>()
+
+    fun recordFrame(walkingEntityCount: Int, activeBubbleCount: Int) {
+        framesDrawn += 1
+        lastWalkingEntityCount = walkingEntityCount.coerceAtLeast(0)
+        lastActiveBubbleCount = activeBubbleCount.coerceAtLeast(0)
+    }
+
+    fun recordCompanionDraw(entityId: Int, outcome: CompanionDrawOutcome) {
+        when (outcome) {
+            CompanionDrawOutcome.DRAWN -> clearEntity(entityId)
+            CompanionDrawOutcome.LOADING -> Unit
+            CompanionDrawOutcome.UNSUPPORTED -> {
+                unsupportedByEntity[entityId] = (unsupportedByEntity[entityId] ?: 0) + 1
+            }
+            CompanionDrawOutcome.ERROR -> {
+                errorsByEntity[entityId] = (errorsByEntity[entityId] ?: 0) + 1
+            }
+        }
+    }
+
+    fun shouldReduceEffects(entityId: Int): Boolean {
+        return ((unsupportedByEntity[entityId] ?: 0) + (errorsByEntity[entityId] ?: 0)) >= reduceEffectsThreshold
+    }
+
+    fun snapshot(): Snapshot {
+        val reduced = (unsupportedByEntity.keys + errorsByEntity.keys)
+            .filter { shouldReduceEffects(it) }
+            .toSet()
+        return Snapshot(
+            framesDrawn = framesDrawn,
+            lastWalkingEntityCount = lastWalkingEntityCount,
+            lastActiveBubbleCount = lastActiveBubbleCount,
+            spritesheetUnsupportedByEntity = unsupportedByEntity.toMap(),
+            spritesheetErrorsByEntity = errorsByEntity.toMap(),
+            reducedEffectsEntityIds = reduced
+        )
+    }
+
+    private fun clearEntity(entityId: Int) {
+        unsupportedByEntity.remove(entityId)
+        errorsByEntity.remove(entityId)
+    }
+
+    companion object {
+        const val DEFAULT_REDUCE_EFFECTS_THRESHOLD = 3
+    }
+}

--- a/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
@@ -70,6 +70,7 @@ class WallpaperPreviewView @JvmOverloads constructor(
 
     // Custom positions (percentage 0.0-1.0)
     private val entityPositions = mutableMapOf<Int, Pair<Float, Float>>()
+    private val lastRenderPositionsByEntity = mutableMapOf<Int, Pair<Float, Float>>()
     
     // Per-entity scales
     private val entityScales = mutableMapOf<Int, Float>()
@@ -260,6 +261,7 @@ class WallpaperPreviewView @JvmOverloads constructor(
 
     override fun onDraw(canvas: Canvas) {
         super.onDraw(canvas)
+        lastRenderPositionsByEntity.clear()
 
         // Draw background (custom image or black)
         drawBackground(canvas)
@@ -290,6 +292,7 @@ class WallpaperPreviewView @JvmOverloads constructor(
         // Draw each entity with per-entity scale
         entities.forEachIndexed { index, entity ->
             val (x, y) = renderPositions.getOrNull(index) ?: basePositions.getOrNull(index) ?: (width / 2f to height / 2f)
+            lastRenderPositionsByEntity[entity.entityId] = x to y
             
             // Get per-entity scale
             val entityScale = entityScales[entity.entityId] ?: 1.0f
@@ -661,8 +664,10 @@ class WallpaperPreviewView @JvmOverloads constructor(
                     lockEntity(draggingEntityIndex)
                     val entity = entities[draggingEntityIndex]
                     val pos = entityPositions[entity.entityId] ?: Pair(0.5f, 0.5f)
-                    dragOffsetX = pos.first * width - x
-                    dragOffsetY = pos.second * height - y
+                    val renderPos = lastRenderPositionsByEntity[entity.entityId]
+                        ?: (pos.first * width to pos.second * height)
+                    dragOffsetX = renderPos.first - x
+                    dragOffsetY = renderPos.second - y
                     invalidate()
                     return true
                 }
@@ -853,9 +858,10 @@ class WallpaperPreviewView @JvmOverloads constructor(
     private fun findEntityAtPosition(touchX: Float, touchY: Float): Int {
         for (index in entities.indices.reversed()) {
             val entity = entities[index]
-            val pos = entityPositions[entity.entityId] ?: continue
-            val entityX = pos.first * width
-            val entityY = pos.second * height
+            val rendered = lastRenderPositionsByEntity[entity.entityId]
+            val pos = entityPositions[entity.entityId]
+            val entityX = rendered?.first ?: pos?.let { it.first * width } ?: continue
+            val entityY = rendered?.second ?: pos?.let { it.second * height } ?: continue
             
             // Scale hit radius with entity scale
             val entityScale = entityScales[entity.entityId] ?: 1.0f
@@ -949,6 +955,15 @@ class WallpaperPreviewView @JvmOverloads constructor(
 
     fun getEntityScaleForTest(entityId: Int): Float {
         return entityScales[entityId] ?: 1.0f
+    }
+
+    fun getEntityCenterForTest(entityId: Int): Pair<Float, Float>? {
+        return lastRenderPositionsByEntity[entityId]
+            ?: entityPositions[entityId]?.let { it.first * width to it.second * height }
+    }
+
+    fun setRenderedEntityCenterForTest(entityId: Int, x: Float, y: Float) {
+        lastRenderPositionsByEntity[entityId] = x to y
     }
 
     override fun onDetachedFromWindow() {

--- a/app/src/test/java/com/hank/clawlive/SpeechBubbleControllerTest.kt
+++ b/app/src/test/java/com/hank/clawlive/SpeechBubbleControllerTest.kt
@@ -97,6 +97,23 @@ class SpeechBubbleControllerTest {
         assertTrue("flipped bubble sits below the sprite center", placement.anchorYPct > 0.02f)
     }
 
+    @Test
+    fun bubbleFlipsBeforeItGetsPinnedToTopGutter() {
+        val controller = SpeechBubbleController()
+        controller.show(entityId = 15, text = "top gutter", nowMs = 0L)
+
+        val placement = controller.placementFor(
+            entityId = 15,
+            entityXPct = 0.35f,
+            entityYPct = 0.14f,
+            spriteHeightPct = 0.10f,
+            nowMs = 0L
+        )!!
+
+        assertTrue("top gutter should flip before layout pins bubble to screen edge", placement.flippedBelow)
+        assertTrue(placement.anchorYPct > 0.14f)
+    }
+
     /** §5.3 — TTL scales with message length, capped at the default max. */
     @Test
     fun ttlScalesWithMessageLengthAndCaps() {

--- a/app/src/test/java/com/hank/clawlive/WallpaperRenderDiagnosticsTest.kt
+++ b/app/src/test/java/com/hank/clawlive/WallpaperRenderDiagnosticsTest.kt
@@ -1,0 +1,40 @@
+package com.hank.clawlive
+
+import com.hank.clawlive.engine.WallpaperRenderDiagnostics
+import com.hank.clawlive.engine.WallpaperRenderDiagnostics.CompanionDrawOutcome
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class WallpaperRenderDiagnosticsTest {
+    @Test
+    fun recordsFrameActivityWithoutMessageContent() {
+        val diagnostics = WallpaperRenderDiagnostics()
+
+        diagnostics.recordFrame(walkingEntityCount = 2, activeBubbleCount = 1)
+
+        val snapshot = diagnostics.snapshot()
+        assertEquals(1, snapshot.framesDrawn)
+        assertEquals(2, snapshot.lastWalkingEntityCount)
+        assertEquals(1, snapshot.lastActiveBubbleCount)
+        assertTrue(snapshot.spritesheetErrorsByEntity.isEmpty())
+        assertTrue(snapshot.spritesheetUnsupportedByEntity.isEmpty())
+    }
+
+    @Test
+    fun repeatedSpritesheetFailuresReduceDecorativeEffectsUntilDrawSucceeds() {
+        val diagnostics = WallpaperRenderDiagnostics(reduceEffectsThreshold = 2)
+
+        diagnostics.recordCompanionDraw(7, CompanionDrawOutcome.ERROR)
+        assertFalse(diagnostics.shouldReduceEffects(7))
+
+        diagnostics.recordCompanionDraw(7, CompanionDrawOutcome.UNSUPPORTED)
+        assertTrue(diagnostics.shouldReduceEffects(7))
+        assertTrue(diagnostics.snapshot().reducedEffectsEntityIds.contains(7))
+
+        diagnostics.recordCompanionDraw(7, CompanionDrawOutcome.DRAWN)
+        assertFalse(diagnostics.shouldReduceEffects(7))
+        assertFalse(diagnostics.snapshot().reducedEffectsEntityIds.contains(7))
+    }
+}


### PR DESCRIPTION
## Summary

第一版 Android APP 桌布 + 夥伴動畫豐富化 / 智慧化 / self-improvement：

- 將 live wallpaper 的舊固定 message bubble 接上 `SpeechBubbleController`，bubble 會跟著 walking position 每幀重新 anchor、TTL/fade、生效時 pulse。
- 新增 bubble top-edge flip guard、usage overlay 避讓，以及 flipped bubble 的 status-label clearance。
- 新增地面 shadow、狀態 aura，讓夥伴在桌布中更有層次。
- 新增 `WallpaperRenderDiagnostics`，只記錄非敏感 count/entity id；連續 spritesheet 失敗時降低裝飾效果，成功 draw 後恢復。
- 修正 Wallpaper Preview：hit-test/drag 起點改用最後一次實際 render position，避免 walking preview 裡點到畫面上的角色卻命中舊座標。
- 補 AGENTS/CLAUDE parity：版本資訊、Codex 不自行 merge main 的 workflow、Android wallpaper animation source-of-truth note。

## Validation

- `./gradlew :app:testDebugUnitTest --tests com.hank.clawlive.SpeechBubbleControllerTest --tests com.hank.clawlive.WallpaperRenderDiagnosticsTest --tests com.hank.clawlive.CompanionDescriptorAnimationTest` ✅
- `./gradlew :app:assembleDebug :app:assembleDebugAndroidTest :app:lintDebug` ✅
- `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.hank.clawlive.WallpaperAnimationVisualProbeTest` ✅ on Pixel_9a emulator
- `./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=com.hank.clawlive.WallpaperPreviewUiTest#testEntityTapUsesRenderedWalkingPositionForHitTarget` ✅ on Pixel_9a emulator
- Vision QA via emulator-generated screenshots pulled to local build artifacts:
  - `app/build/visual-checks/eclaw-wallpaper-visual-probes/renderer-bubble-aura-shadow.png` checked: flipped bubble below near top, usage overlay separate, aura/shadow visible.
  - `app/build/visual-checks/eclaw-wallpaper-visual-probes/preview-rendered-hit-target.png` checked: preview entity visible at rendered position with cyan lock halo.

## Review Notes

- `simplify` skill was required by repo instructions for UI/UX changes, but no `simplify` skill was available under `/Users/hank/.codex/skills` or the plugin cache in this environment. Fallback review used `docs/code-review-checklist.md`, Android lint, JVM tests, emulator instrumentation, and visual QA.
- No backend/API/data schema changes.
- No secrets printed or committed. Local `local.properties`, `app/google-services.json`, and build artifacts are ignored.

## Merge / Deploy

Draft for #2 review. Do not merge until CI is green and reviewer accepts the `simplify` skill unavailability note.
