### PR TITLE
feat(android): settings-manifest Stage 2 follow-up — BuildConfig.VERSION_NAME for version gate + UI fallback test

### DIFF
--- a/app/src/androidTest/java/com/hank/clawlive/SettingsActivityUiTest.kt
+++ b/app/src/androidTest/java/com/hank/clawlive/SettingsActivityUiTest.kt
@@ -67,6 +67,32 @@ class SettingsActivityUiTest {
         }
     }
 
+    /**
+     * Stage-2 manifest auto-sync: the settings screen must inflate and stay usable
+     * regardless of the manifest fetch. The dynamic-rows container exists and — until
+     * the async fetch populates it — is hidden (View.GONE). This is the graceful
+     * failure-fallback contract: an offline / failed / empty manifest leaves the static
+     * settings screen exactly as-is (container hidden), never blank, never crashing.
+     */
+    @Test
+    fun testManifestExtraContainerExistsAndDefaultsHidden() {
+        ActivityScenario.launch(SettingsActivity::class.java).use { scenario ->
+            scenario.onActivity { activity ->
+                val container = activity.findViewById<View>(R.id.settingsManifestExtraContainer)
+                assertNotNull("Manifest extra-rows container should exist in the layout", container)
+                // Before any rows are rendered (no network in instrumentation), the
+                // container is GONE so the static screen is unchanged.
+                assertEquals(
+                    "Manifest extra container should be hidden until rows are planned",
+                    View.GONE,
+                    container.visibility
+                )
+                // The static screen itself must still be present and functional.
+                assertNotNull("Subscription card should still render", activity.findViewById<View>(R.id.cardSubscription))
+            }
+        }
+    }
+
     @Test
     fun testSafeInsetsAppliedCorrectly() {
         ActivityScenario.launch(SettingsActivity::class.java).use { scenario ->

--- a/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/SettingsActivity.kt
@@ -1032,9 +1032,11 @@ class SettingsActivity : AppCompatActivity() {
      * static settings screen is left exactly as-is — never crash, never blank.
      */
     private fun loadSettingsManifest() {
-        val appVersion = runCatching {
-            packageManager.getPackageInfo(packageName, 0).versionName
-        }.getOrNull()
+        // Spec §4 / Stage-2 requirement: send the REAL installed version so the
+        // backend's minAppVersion gate is correct. BuildConfig.VERSION_NAME is the
+        // compile-time-pinned gradle versionName and is always present; it can't throw
+        // the way packageManager.getPackageInfo can on edge devices.
+        val appVersion = BuildConfig.VERSION_NAME.takeIf { it.isNotBlank() }
 
         lifecycleScope.launch {
             val resp = runCatching {


### PR DESCRIPTION
## Context / important finding

The assigned task was to **implement settings-manifest Stage 2 (Android)**. On investigation, **Stage 2 was already implemented and merged** on `main`:

- PR #3575 (`dc31bb52`) — `SettingsManifest.kt` model + `SettingsManifestResolver` version-gate resolver.
- PR #3585 (`6981c468`, **MERGED** on branch `feat/settings-manifest-stage2-android`) — wired the manifest into `SettingsActivity` (`loadSettingsManifest()` → `SettingsManifestSync.planDynamicRows()` → web-fallback rows + gated `?`-help), `getSettingsManifest()` Retrofit method, layout container, string resources, and pure-logic unit tests.

So rather than re-implementing, this PR is a **small, surgical follow-up** that closes the one remaining gap against the task's explicit requirement #4 and adds a UI-level fallback test.

## Scope

1. **`SettingsActivity.loadSettingsManifest()`** — source `appVersion` from `BuildConfig.VERSION_NAME` instead of `packageManager.getPackageInfo(packageName, 0).versionName`. Spec §4 requires the app send the *real installed version* so the backend `minAppVersion` gate is correct. `BuildConfig.VERSION_NAME` is the compile-pinned gradle `versionName` (`1.0.94`), is always present, can't throw on edge devices, and matches the existing `BuildConfig.DEBUG` usage already in this Activity. Behavior is otherwise identical (same value, still wrapped so blank → null → "declared" view).
2. **`SettingsActivityUiTest`** — new `testManifestExtraContainerExistsAndDefaultsHidden` covering the **graceful failure-fallback** contract (spec §2 / task req #3): the manifest extra-rows container exists and stays `View.GONE` until rows are planned, so an offline/failed/empty manifest leaves the static settings screen intact and the subscription card still renders. Follows the existing `ActivityScenario` pattern in this file.

## Spec section refs
- §2 seam + graceful degradation; §2.1 endpoint contract (`appVersion`+`platform=android`); §3 version gating; §4 "send appVersion" + `?`-icon UX.

## Test results (exact commands, run in worktree)
- `./gradlew :app:testDebugUnitTest --tests "com.hank.clawlive.settings.*"` → **BUILD SUCCESSFUL**. Resolver 11/11, Sync 9/9, NotificationCatalog 3/3, all green.
- `./gradlew :app:testDebugUnitTest` (full) → **BUILD SUCCESSFUL**, **147 tests, 0 failures, 0 errors** across 15 suites.
- `./gradlew :app:compileDebugAndroidTestKotlin` → **BUILD SUCCESSFUL** (new androidTest compiles).
- Did NOT run the emulator/instrumented suite per instructions; the new androidTest will run in CI on a device.
- Env notes: worktree needed `local.properties` (sdk.dir) + `app/google-services.json` copied from the main checkout (both gitignored, not committed).

## Spec ambiguities resolved
- None new. The merged resolver already handles the `native` enum (`true`/`"partial"`/`false`), blank-appVersion → trust-declared, and suffix-tolerant version compare per spec §3.

## Not done (per instructions)
- No `versionCode`/`versionName` bump (release handled separately).
- Not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt7jNhQxvz1FkErAbyHneC