### PR TITLE
chore(release): bump to vc103 / 1.0.95 for scheduled Play release

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,8 +20,8 @@ android {
         applicationId = "com.hank.clawlive"
         minSdk = 24
         targetSdk = 35
-        versionCode = 102
-        versionName = "1.0.94"
+        versionCode = 103
+        versionName = "1.0.95"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 


### PR DESCRIPTION
Prep for the scheduled 2026-06-21 10:00 TW Play production release. Bumps versionCode 102→103, versionName 1.0.94→1.0.95. Content: FCM fix (#3580/#3581) + settings-manifest Stage 2 Android (#3575/#3585/#3593). One-line gradle change. 🤖 Generated with [Claude Code](https://claude.com/claude-code)