### PR TITLE
fix(openclaw-channel): preserve EClaw reply targets (rebased #3135)

### DIFF
--- a/openclaw-channel-eclaw/README.md
+++ b/openclaw-channel-eclaw/README.md
@@ -189,6 +189,35 @@ docker compose up -d --no-deps openclaw-f
 docker exec openclaw-project-f openclaw --version
 ```
 
+Known-good recovery for project E / entity #3 after version drift:
+
+```bash
+cd /Users/hank/Desktop/Project/openclaw-docker
+# project E intentionally reuses the same verified runtime image as project F;
+# its MiniMax default model remains controlled by project-e's mounted config.
+docker compose up -d --no-deps --force-recreate openclaw-e
+docker exec openclaw-project-e openclaw --version
+docker exec openclaw-project-e openclaw plugins list --json
+```
+
+Expected post-upgrade state for #3:
+
+- `openclaw --version` reports `OpenClaw 2026.6.1`.
+- The loaded `openclaw-channel` plugin reports version `1.3.1` and is sourced
+  from `/home/node/.openclaw/npm/projects/.../@eclaw/openclaw-channel`.
+- `session.reset` is set to an idle reset window so six-hour fleet monitors do
+  not reuse a stale, task-heavy MiniMax conversation indefinitely.
+- API ACK, model-backed reply-path, and browser UI ACK all pass for entity #3.
+
+If #3 has an older untracked side-loaded extension, `openclaw plugins update`
+will report no install record. Install the tracked npm package instead:
+
+```bash
+docker exec openclaw-project-e \
+  openclaw plugins install @eclaw/openclaw-channel@1.3.1
+docker restart openclaw-project-e
+```
+
 After the recreate, verify startup logs show the intended runtime model, for
 example `agent model: openai-codex/gpt-5.5 (thinking=xhigh, ...)`, then test
 the E-Claw browser chat UI with a fresh nonce. For #1/#3, keep
@@ -196,6 +225,13 @@ the E-Claw browser chat UI with a fresh nonce. For #1/#3, keep
 does not starve the interactive reply path while kanban cards still reach the
 model and can be executed. Use `ECLAW_SUPPRESS_KANBAN_NOTIFICATIONS=1` only for
 agents where kanban is deliberately notification-only.
+
+API `/api/client/speak` health probes may set `from` to a source label such as
+`targeted-model-health`; the channel must not treat that label as the
+message-tool reply target. Current channel builds route replies through the
+stable E-Claw conversation id (`deviceId:entityId`) and declare an E-Claw target
+resolver so OpenClaw's `message` tool can send the reply instead of failing with
+`Unknown target`.
 
 For #1 model-health failures where the runtime eventually replies after the
 monitor has already timed out, inspect `openclaw-project-f` logs for

--- a/openclaw-channel-eclaw/src/channel.ts
+++ b/openclaw-channel-eclaw/src/channel.ts
@@ -3,6 +3,14 @@ import { sendText, sendMedia } from './outbound.js';
 import { startAccount } from './gateway.js';
 import { eclawOnboardingAdapter } from './onboarding.js';
 
+function normalizeEClawMessagingTarget(target: string): string {
+  return target.trim();
+}
+
+function looksLikeEClawTargetId(target: string): boolean {
+  return target.trim().length > 0;
+}
+
 /**
  * E-Claw ChannelPlugin definition.
  *
@@ -35,6 +43,22 @@ export const eclawChannel = {
   config: {
     listAccountIds,
     resolveAccount,
+  },
+
+  messaging: {
+    targetPrefixes: ['eclaw'],
+    normalizeTarget: normalizeEClawMessagingTarget,
+    inferTargetChatType: () => 'direct',
+    targetResolver: {
+      looksLikeId: looksLikeEClawTargetId,
+      hint: '<conversationId|publicCode|source>',
+    },
+  },
+
+  agentPrompt: {
+    messageToolHints: () => [
+      '- E-Claw targeting: omit `target` to reply to the current entity conversation. Explicit targets may be the E-Claw conversation id, public code, or source label resolved by the channel.',
+    ],
   },
 
   outbound: {

--- a/openclaw-channel-eclaw/src/webhook-handler.ts
+++ b/openclaw-channel-eclaw/src/webhook-handler.ts
@@ -81,6 +81,7 @@ export function createWebhookHandler(
       const rt = getPluginRuntime();
       const client = getClient(accountId);
       const conversationId = msg.conversationId || `${msg.deviceId}:${msg.entityId}`;
+      const replyTarget = conversationId || msg.from || accountId;
 
       const directAck = String(msg.text || '').match(/^ECLAW_HEALTHCHECK\s+([A-Za-z0-9_-]+)(?=\s|$)/m);
       if (directAck) {
@@ -176,9 +177,10 @@ export function createWebhookHandler(
         Provider: 'eclaw',
         OriginatingChannel: 'eclaw',
         AccountId: accountId,
-        From: msg.from,
-        To: conversationId,
-        OriginatingTo: msg.from,
+        From: replyTarget,
+        To: replyTarget,
+        OriginatingTo: replyTarget,
+        SenderName: msg.from,
         SessionKey: conversationId,
         Body: body,
         RawBody: body,

--- a/openclaw-channel-eclaw/test/webhook-handler.test.ts
+++ b/openclaw-channel-eclaw/test/webhook-handler.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createWebhookHandler } from '../src/webhook-handler.js';
+import { eclawChannel } from '../src/channel.js';
 import { setPluginRuntime } from '../src/runtime.js';
 import { setClient } from '../src/outbound.js';
 
@@ -173,6 +174,56 @@ describe('createWebhookHandler', () => {
     expect(res.end).toHaveBeenCalledWith(JSON.stringify({ ok: true }));
     expect(finalizeInboundContext).toHaveBeenCalled();
     expect(dispatchReplyWithBufferedBlockDispatcher).toHaveBeenCalled();
+  });
+
+  it('uses a stable E-Claw conversation id as the reply target instead of the webhook source label', async () => {
+    const dispatchReplyWithBufferedBlockDispatcher = vi.fn().mockResolvedValue(undefined);
+    const finalizeInboundContext = vi.fn((ctx) => ctx);
+    setPluginRuntime({
+      channel: {
+        reply: {
+          finalizeInboundContext,
+          dispatchReplyWithBufferedBlockDispatcher,
+        },
+      },
+    });
+
+    const client = {
+      sendMessage: vi.fn().mockResolvedValue({ success: true }),
+    };
+    setClient('default', client as any);
+
+    const handler = createWebhookHandler('token', 'default', {});
+    const res = {
+      writeHead: vi.fn(),
+      end: vi.fn(),
+    };
+
+    await handler({
+      method: 'POST',
+      body: {
+        deviceId: 'device-1',
+        entityId: 1,
+        event: 'message',
+        from: 'targeted-doctor-model-health-1',
+        text: 'hello',
+      },
+    }, res);
+
+    expect(finalizeInboundContext).toHaveBeenCalled();
+    expect(finalizeInboundContext.mock.calls[0]?.[0]).toMatchObject({
+      From: 'device-1:1',
+      To: 'device-1:1',
+      OriginatingTo: 'device-1:1',
+      SenderName: 'targeted-doctor-model-health-1',
+      SessionKey: 'device-1:1',
+    });
+  });
+
+  it('declares an E-Claw target resolver for source labels and conversation ids', () => {
+    expect(eclawChannel.messaging.targetResolver.looksLikeId('targeted-doctor-model-health-1')).toBe(true);
+    expect(eclawChannel.messaging.targetResolver.looksLikeId('device-1:1')).toBe(true);
+    expect(eclawChannel.messaging.normalizeTarget('  device-1:1  ')).toBe('device-1:1');
   });
 
   it('continues dispatching kanban notifications when suppression is disabled', async () => {


### PR DESCRIPTION
Rebased+conflict-resolved replacement for #3135 (whose branch had a stale, no-merge-base history and was unmergeable).

## What
- Route replies through the stable EClaw conversation id (`deviceId:entityId`) instead of the webhook source label.
- Declare an EClaw `messaging.targetResolver` + `normalizeTarget` so OpenClaw's `message` tool can resolve the target instead of failing with `Unknown target`.
- Carry the original source label as `SenderName`.

## Why
`/api/client/speak` health probes set `from` to a source label (e.g. `targeted-model-health`); treating that as the reply target broke the message-tool reply path. This is the openclaw-channel side of the reply-routing fix.

## Verification
- `tsc --noEmit` clean.
- `vitest run`: 9/9 pass, including 2 new reply-target tests.
- Only 4 openclaw-channel-eclaw files touched; rebased onto current main (no stale-base reversions).

Closes #3135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt7jNhQxvz1FkErAbyHneC