### PR TITLE
fix(portal): gate owner-scope API calls on real user account (rebased #3552)

### DIFF
--- a/backend/public/portal/community.html
+++ b/backend/public/portal/community.html
@@ -1677,7 +1677,13 @@
                 (l.owner_device_id && l.owner_device_id === (meData.user.deviceId || meData.user.device_id))
             ));
             _rentalWalletBalance = null;
-            if (meData?.user && !isSelfOwned) {
+            // meData.user.id is null for a device-only / globe-user session (no
+            // email account). /api/wallet/balance is account-scoped (walletRoute
+            // → 401 without a userId), so only fetch the balance estimate when a
+            // real account is signed in — otherwise the rental-detail modal logs
+            // a 401. The estimate just stays unset, which is the correct UX for a
+            // not-signed-in viewer. card_01417648.
+            if (meData?.user && meData.user.id && !isSelfOwned) {
                 apiFetch('/api/wallet/balance?deviceId=' + encodeURIComponent(meData.user.deviceId || meData.user.device_id))
                     .then(wb => { const w = wb.wallet || wb; _rentalWalletBalance = parseInt(w.balance_mli, 10) || 0; updateRentalEstimate(rateMli, depositEcoin); })
                     .catch(() => {});

--- a/backend/public/portal/my-rentals.html
+++ b/backend/public/portal/my-rentals.html
@@ -214,6 +214,20 @@
 
         async function loadTab() {
             const wrap = document.getElementById('mrContent');
+            // Device-only / globe-user sessions (bound device, no email account)
+            // resolve to a truthy currentUser whose `id` is null. Rental endpoints
+            // (my-listings / my-contracts / my-disputes) are account-scoped and
+            // 401 ('unauthenticated') without a userId — calling them just spams
+            // the console. Show a no-account empty-state instead. card_01417648.
+            if (!window.currentUser || !window.currentUser.id) {
+                const hint = tt('mr_no_account', 'Sign in with an email account to manage rentals.');
+                const help = tt('mr_no_account_help', 'Rental listings and contracts are tied to a user account. A device-only session has none yet — sign in or create an account from Settings to get started.');
+                wrap.innerHTML = `<div class="mr-empty">${esc(hint)} `
+                    + `<span tabindex="0" role="button" title="${esc(help)}" aria-label="${esc(help)}" `
+                    + `style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;margin-left:6px;`
+                    + `border-radius:50%;background:var(--bg-tertiary,rgba(127,127,127,0.2));font-size:12px;cursor:help;vertical-align:middle;">?</span></div>`;
+                return;
+            }
             wrap.innerHTML = `<div class="mr-empty">${tt('mr_loading', 'Loading...')}</div>`;
             try {
                 if (currentTab === 'disputes') {

--- a/backend/public/portal/shared/nav.js
+++ b/backend/public/portal/shared/nav.js
@@ -134,11 +134,14 @@ function doLogout() { logout(); }
 // (e.g. user has no wallet yet).
 async function _loadNavEcoinBadge() {
     try {
-        // Guard: only fetch the wallet balance when authenticated. On public /
-        // unauthenticated pages window.currentUser is unset (auth.js populates it
-        // after /me succeeds); skipping here avoids a 401 console error on every
-        // public page view. See issue #3513.
-        if (!window.currentUser) return;
+        // Guard: only fetch the wallet balance when there is a real user
+        // ACCOUNT. auth.js populates window.currentUser after /me succeeds, but a
+        // device-only session (bound device, no email account) still resolves to
+        // a truthy currentUser with `id: null`. /api/wallet/balance requires a
+        // userId (walletRoute → 401 'unauthenticated' when absent), so gating on
+        // currentUser alone still 401s for device-only / globe-user sessions.
+        // Require currentUser.id to avoid a 401 console error. See #3513 + card_01417648.
+        if (!window.currentUser || !window.currentUser.id) return;
         const badge = document.getElementById('ecoinBadge');
         const amountEl = document.getElementById('ecoinAmount');
         if (!badge || !amountEl) return;

--- a/backend/public/portal/wallet.html
+++ b/backend/public/portal/wallet.html
@@ -340,6 +340,25 @@
             }
         }
 
+        // No-account empty-state: a device-only / globe-user session has no
+        // e-coin wallet (wallet is keyed by user account). Render a neutral
+        // empty-state instead of firing account-scoped calls that would 401.
+        // The (?) explains what is needed + the concrete next step. card_01417648.
+        function renderWalletNoAccount() {
+            const dash = '—';
+            ['balanceEcoin', 'balanceUsd', 'heldEcoin', 'lifetimeEarned', 'lifetimeSpent']
+                .forEach(id => { const el = document.getElementById(id); if (el) el.textContent = dash; });
+            const wrap = document.getElementById('ledgerWrap');
+            if (wrap) {
+                const hint = tt('wallet_no_account', 'Sign in with an email account to use your e-coin wallet.');
+                const help = tt('wallet_no_account_help', 'The e-coin wallet (balance, top-up, history) is tied to a user account. A device-only session has no wallet yet — sign in or create an account from Settings to enable it.');
+                wrap.innerHTML = `<div class="empty-state">${escapeHtml(hint)} `
+                    + `<span tabindex="0" role="button" title="${escapeHtml(help)}" aria-label="${escapeHtml(help)}" `
+                    + `style="display:inline-flex;align-items:center;justify-content:center;width:18px;height:18px;margin-left:6px;`
+                    + `border-radius:50%;background:rgba(255,255,255,0.15);font-size:12px;cursor:help;vertical-align:middle;">?</span></div>`;
+            }
+        }
+
         async function loadTiers() {
             try {
                 const data = await apiCall('GET', '/api/wallet/topup/tiers', null, { skip401Redirect: true });
@@ -472,6 +491,19 @@
             const user = await checkAuth();
             if (!user) return;
             initPortalSocket();
+
+            // Device-only / globe-user sessions (a bound device with no email
+            // account) resolve to a truthy user whose `id` is null. The e-coin
+            // wallet is account-scoped: /api/wallet/balance + /history require a
+            // userId (walletRoute → 401 'unauthenticated'), so calling them here
+            // just floods the console with 401s. Show the no-account empty-state
+            // and load only the public top-up catalog. card_01417648.
+            if (!user.id) {
+                renderWalletNoAccount();
+                loadTiers();
+                initTourTrack2Step4();
+                return;
+            }
 
             await Promise.all([loadBalance(), loadTiers(), loadHistory()]);
             initTourTrack2Step4();


### PR DESCRIPTION
Rebased+conflict-resolved replacement for #3552 (whose branch was CONFLICTING against current main).

## What
Device-only / globe-user sessions resolve to a truthy `currentUser` with `id: null`. Account-scoped endpoints (`/api/wallet/balance`, rental routes) return 401 'unauthenticated' without a userId, flooding the browser console. This gates those calls on `currentUser.id` and renders no-account empty-states instead.

Covers: nav.js (wallet balance), wallet.html, my-rentals.html, community.html.

## Scope note
The settings.html / agent-card-editor.js gating and all `*_no_account` i18n keys this PR originally proposed are **already present in current main** (a superior version landed via another commit). This rebased branch therefore carries only the still-missing 4-file portion — no duplicate i18n keys, no AST-unsafe edits to the shared i18n.js hot-file (i18n.js is untouched here).

## Verification
- i18n.js untouched (`node --check` of main's version passes; keys already present).
- 4 files, +61/-6, rebased onto current main (no stale-base reversions).

Closes #3552. card_01417648.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mt7jNhQxvz1FkErAbyHneC