### PR TITLE
fix(portal): keep hover toolbar compact

### DIFF
--- a/backend/public/shared/hover-click-toolbar.css
+++ b/backend/public/shared/hover-click-toolbar.css
@@ -1,8 +1,8 @@
 /* hover-click-toolbar.css — IDE-style floating toolbar + dom-select rings
  * Spec: docs/specs/a-hover-click-dom-interaction.md §3
  *
- * Mobile: bottom-sheet variant (slides up from bottom edge, ~50% viewport).
- * Desktop: dropdown popover anchored under the selected element (max 480px).
+ * Mobile: bottom-sheet variant with compact action grid.
+ * Desktop: docked toolbar at viewport top-right (max 480px).
  * Reduced motion respected on both.
  */
 
@@ -79,6 +79,7 @@
    anchoring under the picked element, so it never blocks the visible
    target. Mobile keeps the bottom-sheet variant (handled in @media). */
 .eclaw-hover-click-toolbar {
+  box-sizing: border-box;
   position: fixed;
   top: 16px;
   right: 16px;
@@ -88,7 +89,7 @@
   border-radius: 12px;
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
   padding: 8px;
-  max-width: min(620px, calc(100vw - 32px));
+  max-width: min(480px, calc(100vw - 32px));
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
   font-size: 14px;
   color: var(--text, #18181b);
@@ -160,7 +161,7 @@
   display: flex;
   align-items: center;
   gap: 4px;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
 }
 
 .eclaw-hover-click-toolbar__chip {
@@ -194,8 +195,8 @@
 .eclaw-hover-click-toolbar__chip-icon { font-size: 16px; line-height: 1; }
 .eclaw-hover-click-toolbar__chip-label { font-size: 13px; }
 
-/* Tight pack so the docked top-right toolbar fits 10 chips on one row
-   at typical desktop widths without wrap. Falls back to wrap below 620px. */
+/* Tight pack so the docked top-right toolbar keeps the expanded action set
+   compact while still wrapping inside the 480px cap. */
 @media (min-width: 721px) {
   .eclaw-hover-click-toolbar__chip { padding: 4px 8px; gap: 3px; }
   .eclaw-hover-click-toolbar__chip-label { font-size: 12px; }
@@ -339,6 +340,8 @@
     top: auto !important;
     width: 100%;
     max-width: 100%;
+    max-height: min(70vh, 560px);
+    overflow-y: auto;
     border-radius: 16px 16px 0 0;
     padding: 12px 12px 24px;
     transform: translateY(100%);
@@ -348,20 +351,31 @@
     transform: translateY(0);
   }
   .eclaw-hover-click-toolbar__row {
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
     align-items: stretch;
-    gap: 2px;
+    gap: 8px;
+  }
+  .eclaw-hover-click-toolbar__target-label {
+    grid-column: 1 / -1;
+    max-width: none;
+    margin: 0 0 2px;
+    padding: 0 2px;
+  }
+  .eclaw-hover-click-toolbar__divider {
+    display: none;
   }
   .eclaw-hover-click-toolbar__chip {
-    justify-content: flex-start;
+    justify-content: center;
     min-height: 44px;
-    padding: 10px 14px;
+    padding: 10px 8px;
   }
   .eclaw-hover-click-toolbar__close {
-    margin-top: 8px;
+    grid-column: 1 / -1;
+    margin-top: 2px;
     margin-left: 0;
     align-self: center;
-    width: 50%;
+    width: 100%;
   }
   .eclaw-hover-click-toolbar__drag-handle {
     display: none;

--- a/backend/public/shared/hover-click-toolbar.js
+++ b/backend/public/shared/hover-click-toolbar.js
@@ -2,11 +2,11 @@
  * hover-click-toolbar.js — IDE-style floating toolbar primitive
  * Spec: docs/specs/a-hover-click-dom-interaction.md §3
  *
- * Anchors to the selected DOM element. Desktop = popover under the bbox,
- * mobile = bottom sheet (per filter-summary primitive convention).
+ * Desktop = docked toolbar near the viewport top-right, mobile = bottom
+ * sheet (per filter-summary primitive convention).
  *
- * Action chips (canonical order): Move / Resize / Style / Duplicate /
- * Delete / Inspect / Info. First chip auto-focuses (per #6 review Q1).
+ * Action chips group by purpose: history, transform, structure, inspect,
+ * reset/share. Move auto-focuses on open because history is initially empty.
  *
  * Dependencies (loaded by host page):
  *   - shared/i18n.js (window.i18n.t)
@@ -137,7 +137,6 @@
     row.appendChild(labelEl);
 
     const chipEls = {};
-    let firstChipFocused = false;
     CHIP_DEFS.forEach((def, idx) => {
       if (def.divider) {
         const div = document.createElement('span');
@@ -150,8 +149,7 @@
       b.type = 'button';
       b.className = 'eclaw-hover-click-toolbar__chip';
       b.setAttribute('data-chip', def.id);
-      b.setAttribute('tabindex', firstChipFocused ? '-1' : '0');
-      firstChipFocused = true;
+      b.setAttribute('tabindex', '0');
       const labelTxt = t(def.i18n, def.fallback);
       b.innerHTML = `<span class="eclaw-hover-click-toolbar__chip-icon" aria-hidden="true">${def.icon}</span><span class="eclaw-hover-click-toolbar__chip-label">${labelTxt}</span>`;
       b.addEventListener('click', () => activateChip(def.id));
@@ -338,9 +336,11 @@
       // Reset chip can revert to it.
       initialOuterHTML = el.outerHTML;
       openFlag = true;
-      // First chip focused per #6 review Q1.
+      updateHistoryButtons();
+      // Primary action focused per #6 review Q1; history chips are disabled
+      // until a mutation exists, so they should not be the initial stop.
       requestAnimationFrame(() => {
-        const focusTarget = chipEls.undo || chipEls.move;
+        const focusTarget = chipEls.move || Array.from(shell.querySelectorAll('button:not([disabled])'))[0];
         if (focusTarget) focusTarget.focus();
       });
     }
@@ -408,6 +408,18 @@
     //     beforeHTML, afterHTML }  // for diff-format spec §6 outerHTML diff
     const history = [];
     let historyCursor = 0; // points one past the last applied entry
+    function updateHistoryButtons() {
+      const states = {
+        undo: historyCursor > 0,
+        redo: historyCursor < history.length,
+      };
+      Object.entries(states).forEach(([id, enabled]) => {
+        const chip = chipEls[id];
+        if (!chip) return;
+        chip.disabled = !enabled;
+        chip.setAttribute('aria-disabled', String(!enabled));
+      });
+    }
     function recordMutation(mut, undoFn, redoFn) {
       // Drop redo tail if we recorded a new mutation after some undos.
       if (historyCursor < history.length) history.length = historyCursor;
@@ -423,6 +435,7 @@
       history.push(entry);
       historyCursor = history.length;
       mutations.push(mut);
+      updateHistoryButtons();
       if (onMutation) onMutation(mut);
     }
     function snapshotBefore(el) {
@@ -433,12 +446,14 @@
       const entry = history[historyCursor - 1];
       if (entry.undo) entry.undo();
       historyCursor -= 1;
+      updateHistoryButtons();
     }
     function doRedo() {
       if (historyCursor >= history.length) return;
       const entry = history[historyCursor];
       if (entry.redo) entry.redo();
       historyCursor += 1;
+      updateHistoryButtons();
     }
 
     let dragging = null;

--- a/backend/tests/e2e/hover-click-dom.spec.js
+++ b/backend/tests/e2e/hover-click-dom.spec.js
@@ -189,12 +189,19 @@ async function testToolbarStyleDuplicateDelete(page) {
     await cta.click();
     await expectToolbarVisible(page);
 
-    page.once('dialog', dialog => dialog.accept('rebeccapurple'));
     await page.locator('[data-chip="style"]').click();
+    const colorInput = page.locator('.eclaw-hover-click-toolbar__subpanel [data-style-key="color"]');
+    await colorInput.waitFor({ state: 'visible', timeout: 2000 });
+    await colorInput.evaluate((el) => {
+        el.value = '#663399';
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+    });
     await page.waitForFunction(() => document.getElementById('summary').textContent.includes('button#primaryAction (color)'));
     const color = await cta.evaluate(el => getComputedStyle(el).color);
-    assert(color === 'rgb(102, 51, 153)', `Style chip should apply rebeccapurple, got ${color}`);
-    assert((await page.locator('#log').textContent()).includes('rebeccapurple'), 'style mutation should render unified diff text');
+    assert(color === 'rgb(102, 51, 153)', `Style chip should apply #663399, got ${color}`);
+    const diffText = await page.locator('#log').textContent();
+    assert(/color|663399|102,\s*51,\s*153/i.test(diffText), `style mutation should render unified diff text, got: ${diffText}`);
 
     await page.locator('[data-chip="duplicate"]').click();
     await page.waitForFunction(() => document.querySelectorAll('#primaryCard #primaryAction').length === 2);
@@ -263,8 +270,14 @@ async function testPortalImportDomSelectFlow(page) {
     await importedButton.click();
     await expectToolbarVisible(page);
 
-    page.once('dialog', dialog => dialog.accept('#123456'));
     await page.locator('.eclaw-hover-click-toolbar').last().locator('[data-chip="style"]').click();
+    const colorInput = page.locator('.eclaw-hover-click-toolbar').last().locator('.eclaw-hover-click-toolbar__subpanel [data-style-key="color"]');
+    await colorInput.waitFor({ state: 'visible', timeout: 2000 });
+    await colorInput.evaluate((el) => {
+        el.value = '#123456';
+        el.dispatchEvent(new Event('input', { bubbles: true }));
+        el.dispatchEvent(new Event('change', { bubbles: true }));
+    });
     await page.waitForFunction(() => window.__importE2E.lastDiff && window.__importE2E.lastDiff.unified.includes('/portal/import-fixture.html'));
     assert(await importedButton.evaluate(el => getComputedStyle(el).color === 'rgb(18, 52, 86)'), 'imported DOM target should accept toolbar style mutation');
 

--- a/backend/tests/e2e/hover-click-toolbar.spec.js
+++ b/backend/tests/e2e/hover-click-toolbar.spec.js
@@ -5,8 +5,8 @@
  * - Hover any DOM element shows preview ring; click commits selection
  *   and opens the toolbar.
  * - Esc / outside-click dismisses; ring + toolbar gone.
- * - Mobile viewport: bottom-sheet variant slides up; vertical chip list.
- * - Desktop viewport: popover variant anchored under the element.
+ * - Mobile viewport: bottom-sheet variant slides up; two-column chip grid.
+ * - Desktop viewport: docked top-right toolbar stays capped and wrapped.
  *
  * Card: card_af967715a0ab1724da98dcc2 (Test/P2) — slice 2/4.
  *
@@ -149,14 +149,19 @@ async function runTests() {
         const toolbarVisible = await pageD.evaluate(() => !document.querySelector('.eclaw-hover-click-toolbar').hidden);
         check('click → toolbar visible (not hidden)', toolbarVisible);
 
-        // 4. Toolbar has all 7 chips
+        // 4. Toolbar has the expanded 11-chip action set
         const chipCount = await pageD.evaluate(() =>
             document.querySelectorAll('.eclaw-hover-click-toolbar__chip').length);
-        check('toolbar has 7 action chips', chipCount === 7, `got ${chipCount}`);
+        check('toolbar has 11 action chips', chipCount === 11, `got ${chipCount}`);
 
-        // 5. First chip (Move) auto-focused per #6 Q1
+        // 5. Move auto-focused per #6 Q1; Undo/Redo are disabled until history exists
         const focusedChip = await pageD.evaluate(() => document.activeElement && document.activeElement.getAttribute('data-chip'));
         check('first chip (Move) auto-focused per #6 Q1', focusedChip === 'move', `got "${focusedChip}"`);
+        const historyDisabled = await pageD.evaluate(() => ({
+            undo: document.querySelector('[data-chip="undo"]').disabled,
+            redo: document.querySelector('[data-chip="redo"]').disabled,
+        }));
+        check('empty history disables Undo/Redo', historyDisabled.undo && historyDisabled.redo);
 
         // 6. Esc dismisses
         await pageD.keyboard.press('Escape');
@@ -219,14 +224,14 @@ async function runTests() {
         check('mobile: fixed bottom anchoring',
             sheetState.position === 'fixed' && sheetState.bottom === '0px');
 
-        // Vertical chip layout (per #6 Q6) — first chip's offsetTop differs from second
+        // Compact grid layout — first two chips share a row, third wraps below.
         const chipOffsets = await pageM.evaluate(() => {
             const chips = Array.from(document.querySelectorAll('.eclaw-hover-click-toolbar__chip'));
             return chips.map((c) => ({ id: c.dataset.chip, top: c.offsetTop }));
         });
-        const vertical = chipOffsets[0].top !== chipOffsets[1].top;
-        check('mobile: chips stack vertically per #6 Q6',
-            vertical, `offsets ${JSON.stringify(chipOffsets.slice(0, 3))}`);
+        const grid = chipOffsets[0].top === chipOffsets[1].top && chipOffsets[2].top > chipOffsets[1].top;
+        check('mobile: chips use two-column grid',
+            grid, `offsets ${JSON.stringify(chipOffsets.slice(0, 4))}`);
 
         await ctxM.close();
     } finally {

--- a/backend/tests/visual/hover-click-toolbar.baseline.js
+++ b/backend/tests/visual/hover-click-toolbar.baseline.js
@@ -1,10 +1,10 @@
 /**
  * Layout baseline for the hover-click toolbar (slice 3/4).
  *
- * Captured 2026-06-03 from `node backend/tests/visual/hover-click-toolbar.spec.js`
- * against the merged impl (PR #3107 + #3109 + #3110). If a future change
- * shifts these numbers, the spec test will fail loudly — pick: update
- * baseline + add a comment explaining the intent, or revert the change.
+ * Captured 2026-06-20 from `node backend/tests/visual/hover-click-toolbar.spec.js`
+ * after the toolbar expanded to 11 chips. If a future change shifts these
+ * numbers, the spec test will fail loudly — pick: update baseline + add a
+ * comment explaining the intent, or revert the change.
  *
  * Values use a small tolerance (3-4px) for desktop horizontal/vertical
  * positions to absorb sub-pixel rounding in Chromium across runs. Mobile
@@ -15,24 +15,18 @@
 
 module.exports = {
     desktop: {
-        chipCount: 7,
-        // max-width is 480px per spec §3.1; default box-sizing is content-box
-        // so padding (8+8) and border (1+1) add ~18px → outer width up to
-        // ~498. Locked here so a future box-sizing/padding change is
-        // visible. If we switch to box-sizing: border-box, tighten this.
-        toolbarWidth: { min: 360, max: 510 },
-        // Toolbar should anchor close under the bounding box (spec §3.3
-        // "directly below the selected element's bounding box"). 8px is
-        // the gap in code; allow ±4px for layout differences.
-        toolbarTopVsButton: { min: 4, max: 16 },
+        chipCount: 11,
+        // Desktop is intentionally docked near the viewport top-right so it
+        // does not cover the selected element. The shell uses border-box
+        // sizing and a 480px cap.
+        toolbarWidth: { min: 430, max: 490 },
+        toolbarTop: { min: 12, max: 20 },
+        toolbarRightGap: { min: 12, max: 20 },
     },
     mobile: {
-        // Full-viewport width on bottom-sheet variant. Same content-box
-        // padding-overflow issue → outer width = viewport + padding + border.
-        // Viewport 390 + (12+12) padding + ~2px border ≈ 416.
-        width: { min: 410, max: 422 },
-        // Vertical span of the chip list — last chip's offsetTop. With
-        // 7 chips × ~46px spacing observed in baseline (move=12, last≈288).
-        chipsVerticalSpan: { min: 240, max: 360 },
+        // Full-viewport width on bottom-sheet variant with border-box sizing.
+        width: { min: 386, max: 394 },
+        // Two-column grid keeps the expanded 11-chip set compact.
+        chipsVerticalSpan: { min: 220, max: 360 },
     },
 };

--- a/backend/tests/visual/hover-click-toolbar.spec.js
+++ b/backend/tests/visual/hover-click-toolbar.spec.js
@@ -10,12 +10,12 @@
  * regression-locks the QUANTITATIVE LAYOUT INVARIANTS the screenshots
  * in PR #3107 captured:
  *
- *   - desktop popover anchors under the selected element, within the
- *     viewport
+ *   - desktop toolbar docks at the viewport top-right without covering the
+ *     selected element
  *   - desktop toolbar width is capped per spec §3.1 (max 480px)
  *   - mobile bottom-sheet pins to viewport bottom (top edge in
  *     bottom half of screen)
- *   - mobile chip-list height grows linearly with chip count
+ *   - mobile chip grid stays compact as the action set grows
  *   - selected element gets the ring class
  *
  * A future PR can add full pixelmatch-baseline regression on top of
@@ -112,7 +112,8 @@ async function runTests() {
                 ringSelected: btn.classList.contains('eclaw-dom-select__ring-selected'),
                 toolbarVisible: !tb.hidden,
                 toolbarWidth: Math.round(tbR.width),
-                toolbarTopVsButton: Math.round(tbR.top - btnR.bottom),
+                toolbarTop: Math.round(tbR.top),
+                toolbarRightGap: Math.round(1280 - tbR.right),
                 toolbarLeftInViewport: tbR.left >= 0 && tbR.right <= 1280,
                 chipCount: tb.querySelectorAll('.eclaw-hover-click-toolbar__chip').length,
             };
@@ -123,8 +124,10 @@ async function runTests() {
         check('desktop: chip count', desktop.chipCount, BASELINE.desktop.chipCount, results);
         check('desktop: toolbar width ≤ spec cap',
             desktop.toolbarWidth, BASELINE.desktop.toolbarWidth, results);
-        check('desktop: toolbar anchors under button',
-            desktop.toolbarTopVsButton, BASELINE.desktop.toolbarTopVsButton, results);
+        check('desktop: toolbar docks at viewport top',
+            desktop.toolbarTop, BASELINE.desktop.toolbarTop, results);
+        check('desktop: toolbar docks at viewport right',
+            desktop.toolbarRightGap, BASELINE.desktop.toolbarRightGap, results);
         check('desktop: toolbar within viewport horizontally',
             desktop.toolbarLeftInViewport ? 1 : 0, 1, results);
 
@@ -164,7 +167,7 @@ async function runTests() {
         check('mobile: full-viewport width', mobile.width, BASELINE.mobile.width, results);
         check('mobile: top edge in bottom half of viewport',
             mobile.topInBottomHalf ? 1 : 0, 1, results);
-        check('mobile: chips span vertically (offsetTop grows)',
+        check('mobile: chips stay compact in grid',
             mobile.chipsVerticalSpan, BASELINE.mobile.chipsVerticalSpan, results);
 
         await ctxM.close();


### PR DESCRIPTION
## Summary
- Fixes the expanded hover-click toolbar so the 11-chip action set stays capped and wrapped on desktop.
- Changes the mobile bottom sheet to a compact two-column action grid with a scroll-safe max height.
- Disables Undo/Redo while history is empty and restores Move as the initial keyboard focus target.
- Updates focused e2e/visual toolbar tests to cover the current 11-chip subpanel UX.

Closes #3600

## Test Plan
- npm run lint
- npm run smoke:portal
- node tests/test-ux-static-audit.js
- node tests/test-ui-text-contrast.js
- node tests/test-portal-duplicate-vars.js
- node tests/test-ux-parity.js
- node tests/test-ux-live-validation.js
- npx jest --runInBand --runTestsByPath tests/jest/portal-smoke-static.test.js tests/jest/portal-static-ids.test.js tests/jest/portal-script-order.test.js tests/jest/portal-page-api-map.test.js tests/jest/info-guide-mobile-layout.test.js tests/jest/portal-auth-forms.test.js tests/jest/portal-auth-race.test.js tests/jest/kanban-dispatch-mode-ux.test.js tests/jest/invite-qr-generator-ui-state.test.js tests/jest/ios-bottom-nav.test.js tests/jest/ios-webview-chrome.test.js tests/jest/chat-render-load-order.test.js tests/jest/chat-scroll-anchor-lock.test.js tests/jest/chat-targets-static.test.js tests/jest/mention-ux-static.test.js tests/jest/outbox-ui.test.js tests/jest/portal-legacy-redirects.test.js tests/jest/portal-retest-countdown.test.js tests/jest/dashboard-usage-timeline-modal.test.js tests/jest/dashboard-usage-widget-rate-limits.test.js tests/jest/dashboard-agent-policy-card.test.js tests/jest/entity-status-achievements-ui.test.js
- PORTAL_BASE=http://127.0.0.1:3100 UIUX_ARTIFACT_DIR=/tmp/eclaw-qa-uiux-20260620-2300-artifacts/portal-smoke-after-fix node tests/e2e/portal-uiux-smoke.spec.js
- node tests/e2e/help-popover.spec.js
- node tests/e2e/hover-click-toolbar.spec.js
- node tests/e2e/hover-click-dom.spec.js
- node tests/visual/hover-click-toolbar.spec.js

## QA Notes
- The full portal smoke passed after the fix: 39 pages x 2 viewports, 0 failures.
- Lint exits 0 with 7 pre-existing warnings.
- Authenticated live validation smoke was skipped by the existing harness because BROADCAST_TEST_DEVICE_ID and BROADCAST_TEST_DEVICE_SECRET were not set.