### PR TITLE
[codex] Add wallpaper bubble duration control

### DIFF
--- a/app/src/androidTest/java/com/hank/clawlive/WallpaperMoreSettingsUiTest.kt
+++ b/app/src/androidTest/java/com/hank/clawlive/WallpaperMoreSettingsUiTest.kt
@@ -3,7 +3,9 @@ package com.hank.clawlive
 import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.android.material.materialswitch.MaterialSwitch
+import com.google.android.material.slider.Slider
 import com.hank.clawlive.data.local.LayoutPreferences
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -26,8 +28,10 @@ class WallpaperMoreSettingsUiTest {
 
                 val root = activity.window.decorView
                 val switches = mutableListOf<MaterialSwitch>()
+                val sliders = mutableListOf<Slider>()
                 fun collect(view: android.view.View) {
                     if (view is MaterialSwitch) switches.add(view)
+                    if (view is Slider) sliders.add(view)
                     if (view is android.view.ViewGroup) {
                         for (i in 0 until view.childCount) collect(view.getChildAt(i))
                     }
@@ -35,10 +39,15 @@ class WallpaperMoreSettingsUiTest {
                 collect(root)
                 assertTrue("Expected advanced wallpaper switches", switches.size >= 7)
                 switches.forEach { assertTrue("Default-on switch should start checked", it.isChecked) }
+                assertTrue("Expected bubble duration slider", sliders.isNotEmpty())
 
                 switches.first().isChecked = false
                 assertFalse(prefs.wallpaperSpeechBubblesEnabled)
                 prefs.wallpaperSpeechBubblesEnabled = true
+
+                sliders.first().value = 18f
+                assertEquals(18, prefs.wallpaperBubbleDurationSeconds)
+                prefs.wallpaperBubbleDurationSeconds = LayoutPreferences.WALLPAPER_BUBBLE_DURATION_DEFAULT_SECONDS
             }
         }
     }

--- a/app/src/main/java/com/hank/clawlive/WallpaperMoreSettingsActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/WallpaperMoreSettingsActivity.kt
@@ -6,9 +6,15 @@ import android.widget.LinearLayout
 import android.widget.ScrollView
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import com.google.android.material.appbar.MaterialToolbar
 import com.google.android.material.materialswitch.MaterialSwitch
+import com.google.android.material.slider.Slider
 import com.hank.clawlive.data.local.LayoutPreferences
+import kotlin.math.roundToInt
 
 class WallpaperMoreSettingsActivity : AppCompatActivity() {
     private val layoutPrefs by lazy { LayoutPreferences.getInstance(this) }
@@ -16,6 +22,7 @@ class WallpaperMoreSettingsActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         title = getString(R.string.wallpaper_more_settings)
+        WindowCompat.setDecorFitsSystemWindows(window, false)
 
         val density = resources.displayMetrics.density
         fun dp(value: Int): Int = (value * density).toInt()
@@ -32,6 +39,17 @@ class WallpaperMoreSettingsActivity : AppCompatActivity() {
             setNavigationOnClickListener { finish() }
         }
         root.addView(toolbar, LinearLayout.LayoutParams.MATCH_PARENT, dp(56))
+        ViewCompat.setOnApplyWindowInsetsListener(root) { _, insets ->
+            val systemBars = insets.getInsets(
+                WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout()
+            )
+            toolbar.updatePadding(top = systemBars.top)
+            toolbar.layoutParams = toolbar.layoutParams.apply {
+                height = dp(56) + systemBars.top
+            }
+            root.updatePadding(bottom = systemBars.bottom)
+            insets
+        }
 
         val content = LinearLayout(this).apply {
             orientation = LinearLayout.VERTICAL
@@ -45,6 +63,7 @@ class WallpaperMoreSettingsActivity : AppCompatActivity() {
             description = getString(R.string.wallpaper_setting_speech_bubbles_desc),
             checked = layoutPrefs.wallpaperSpeechBubblesEnabled
         ) { layoutPrefs.wallpaperSpeechBubblesEnabled = it }
+        addDurationSlider(content)
         addSwitch(
             content,
             title = getString(R.string.wallpaper_setting_bubble_pulse),
@@ -95,6 +114,57 @@ class WallpaperMoreSettingsActivity : AppCompatActivity() {
             setTextColor(0xB3FFFFFF.toInt())
             textSize = 14f
         })
+    }
+
+    private fun addDurationSlider(parent: LinearLayout) {
+        val density = resources.displayMetrics.density
+        fun dp(value: Int): Int = (value * density).toInt()
+
+        val container = LinearLayout(this).apply {
+            orientation = LinearLayout.VERTICAL
+            setPadding(0, dp(10), 0, dp(14))
+        }
+        val header = LinearLayout(this).apply {
+            orientation = LinearLayout.HORIZONTAL
+            gravity = Gravity.CENTER_VERTICAL
+        }
+        header.addView(TextView(this).apply {
+            text = getString(R.string.wallpaper_setting_bubble_duration)
+            setTextColor(0xFFFFFFFF.toInt())
+            textSize = 16f
+        }, LinearLayout.LayoutParams(0, LinearLayout.LayoutParams.WRAP_CONTENT, 1f))
+
+        val valueLabel = TextView(this).apply {
+            text = bubbleDurationLabel(layoutPrefs.wallpaperBubbleDurationSeconds)
+            setTextColor(0xB3FFFFFF.toInt())
+            textSize = 14f
+            gravity = Gravity.END
+        }
+        header.addView(valueLabel)
+        container.addView(header)
+        container.addView(TextView(this).apply {
+            text = getString(R.string.wallpaper_setting_bubble_duration_desc)
+            setTextColor(0x99FFFFFF.toInt())
+            textSize = 12f
+            setPadding(0, dp(4), 0, dp(6))
+        })
+        container.addView(Slider(this).apply {
+            valueFrom = LayoutPreferences.WALLPAPER_BUBBLE_DURATION_MIN_SECONDS.toFloat()
+            valueTo = LayoutPreferences.WALLPAPER_BUBBLE_DURATION_MAX_SECONDS.toFloat()
+            stepSize = 1f
+            value = layoutPrefs.wallpaperBubbleDurationSeconds.toFloat()
+            contentDescription = getString(R.string.wallpaper_setting_bubble_duration)
+            addOnChangeListener { _, sliderValue, _ ->
+                val seconds = sliderValue.roundToInt()
+                layoutPrefs.wallpaperBubbleDurationSeconds = seconds
+                valueLabel.text = bubbleDurationLabel(seconds)
+            }
+        })
+        parent.addView(container)
+    }
+
+    private fun bubbleDurationLabel(seconds: Int): String {
+        return getString(R.string.wallpaper_setting_bubble_duration_value, seconds)
     }
 
     private fun addSwitch(

--- a/app/src/main/java/com/hank/clawlive/data/local/LayoutPreferences.kt
+++ b/app/src/main/java/com/hank/clawlive/data/local/LayoutPreferences.kt
@@ -306,6 +306,27 @@ class LayoutPreferences private constructor(context: Context) {
             prefs.edit().putBoolean(KEY_WALLPAPER_SPEECH_BUBBLES_ENABLED, value).apply()
         }
 
+    var wallpaperBubbleDurationSeconds: Int
+        get() = prefs.getInt(
+            KEY_WALLPAPER_BUBBLE_DURATION_SECONDS,
+            WALLPAPER_BUBBLE_DURATION_DEFAULT_SECONDS
+        ).coerceIn(
+            WALLPAPER_BUBBLE_DURATION_MIN_SECONDS,
+            WALLPAPER_BUBBLE_DURATION_MAX_SECONDS
+        )
+        set(value) {
+            prefs.edit().putInt(
+                KEY_WALLPAPER_BUBBLE_DURATION_SECONDS,
+                value.coerceIn(
+                    WALLPAPER_BUBBLE_DURATION_MIN_SECONDS,
+                    WALLPAPER_BUBBLE_DURATION_MAX_SECONDS
+                )
+            ).apply()
+        }
+
+    val wallpaperBubbleDurationMs: Long
+        get() = wallpaperBubbleDurationSeconds * 1_000L
+
     var wallpaperBubblePulseEnabled: Boolean
         get() = prefs.getBoolean(KEY_WALLPAPER_BUBBLE_PULSE_ENABLED, true)
         set(value) {
@@ -503,6 +524,7 @@ class LayoutPreferences private constructor(context: Context) {
         private const val KEY_SERVER_ENTITY_LIMIT = "server_entity_limit"
         private const val KEY_WALLPAPER_WALKING_ENABLED = "wallpaper_walking_enabled"
         private const val KEY_WALLPAPER_SPEECH_BUBBLES_ENABLED = "wallpaper_speech_bubbles_enabled"
+        private const val KEY_WALLPAPER_BUBBLE_DURATION_SECONDS = "wallpaper_bubble_duration_seconds"
         private const val KEY_WALLPAPER_BUBBLE_PULSE_ENABLED = "wallpaper_bubble_pulse_enabled"
         private const val KEY_WALLPAPER_BUBBLE_OVERLAY_AVOIDANCE_ENABLED = "wallpaper_bubble_overlay_avoidance_enabled"
         private const val KEY_WALLPAPER_STATE_AURA_ENABLED = "wallpaper_state_aura_enabled"
@@ -525,6 +547,10 @@ class LayoutPreferences private constructor(context: Context) {
         const val RESET_WINDOW_5H = "5h"
         const val RESET_WINDOW_WEEKLY = "weekly"
         const val RESET_WINDOW_5H_WEEKLY = "5h_weekly"
+
+        const val WALLPAPER_BUBBLE_DURATION_MIN_SECONDS = 3
+        const val WALLPAPER_BUBBLE_DURATION_MAX_SECONDS = 30
+        const val WALLPAPER_BUBBLE_DURATION_DEFAULT_SECONDS = 12
 
         // Display mode constants
         const val MODE_SINGLE = 1

--- a/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
@@ -36,6 +36,7 @@ class ClawRenderer(
     private val speechBubbleController = SpeechBubbleController()
     private val renderDiagnostics = WallpaperRenderDiagnostics()
     private val lastBubbleMessageByEntity = mutableMapOf<Int, String>()
+    private val lastBubbleDurationByEntity = mutableMapOf<Int, Long>()
     private val bubblePulseStartedByEntity = mutableMapOf<Int, Long>()
 
     // Background image cache
@@ -556,21 +557,34 @@ class ClawRenderer(
         val staleEntityIds = lastBubbleMessageByEntity.keys - liveEntityIds
         staleEntityIds.forEach { speechBubbleController.clear(it) }
         lastBubbleMessageByEntity.keys.retainAll(liveEntityIds)
+        lastBubbleDurationByEntity.keys.retainAll(liveEntityIds)
         bubblePulseStartedByEntity.keys.retainAll(liveEntityIds)
+        val preferredTtlMs = layoutPrefs.wallpaperBubbleDurationMs
 
         entities.forEach { entity ->
             val displayText = if (isAmbient) getStateEmoji(entity.state) else entity.message.trim()
             if (displayText.isBlank()) {
                 lastBubbleMessageByEntity.remove(entity.entityId)
+                lastBubbleDurationByEntity.remove(entity.entityId)
                 bubblePulseStartedByEntity.remove(entity.entityId)
                 speechBubbleController.clear(entity.entityId)
                 return@forEach
             }
 
-            if (lastBubbleMessageByEntity[entity.entityId] != displayText) {
-                speechBubbleController.show(entity.entityId, displayText, nowMs)
+            val messageChanged = lastBubbleMessageByEntity[entity.entityId] != displayText
+            val durationChanged = lastBubbleDurationByEntity[entity.entityId] != preferredTtlMs
+            if (messageChanged || durationChanged) {
+                speechBubbleController.show(
+                    entity.entityId,
+                    displayText,
+                    nowMs,
+                    preferredTtlMs = preferredTtlMs
+                )
                 lastBubbleMessageByEntity[entity.entityId] = displayText
-                bubblePulseStartedByEntity[entity.entityId] = nowMs
+                lastBubbleDurationByEntity[entity.entityId] = preferredTtlMs
+                if (messageChanged) {
+                    bubblePulseStartedByEntity[entity.entityId] = nowMs
+                }
             }
         }
     }
@@ -578,6 +592,7 @@ class ClawRenderer(
     private fun clearSpeechBubbles() {
         lastBubbleMessageByEntity.keys.toList().forEach { speechBubbleController.clear(it) }
         lastBubbleMessageByEntity.clear()
+        lastBubbleDurationByEntity.clear()
         bubblePulseStartedByEntity.clear()
     }
 

--- a/app/src/main/java/com/hank/clawlive/engine/SpeechBubbleController.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/SpeechBubbleController.kt
@@ -70,8 +70,9 @@ class SpeechBubbleController(
     fun reset() = bubbles.clear()
 
     /**
-     * Show (or refresh) a bubble for [entityId]. TTL scales with message length
-     * per §5.3: max(2s, 0.06s * chars) capped at 8s, unless [ttlMsOverride] is given.
+     * Show (or refresh) a bubble for [entityId]. TTL starts from the preferred
+     * user duration, then extends for long text at 0.06s/char and caps at 30s.
+     * [ttlMsOverride] remains an exact escape hatch for deterministic tests.
      * A new message resets the TTL (rapid-fire chat, open question O-7).
      * Blank text clears any existing bubble.
      */
@@ -79,13 +80,14 @@ class SpeechBubbleController(
         entityId: Int,
         text: String,
         nowMs: Long,
-        ttlMsOverride: Long? = null
+        ttlMsOverride: Long? = null,
+        preferredTtlMs: Long? = null
     ) {
         if (text.isBlank()) {
             bubbles.remove(entityId)
             return
         }
-        val ttl = ttlMsOverride ?: ttlForText(text)
+        val ttl = ttlMsOverride ?: ttlForText(text, preferredTtlMs ?: defaultTtlMs)
         bubbles[entityId] = Bubble(
             text = text,
             shownAtMs = nowMs,
@@ -153,9 +155,10 @@ class SpeechBubbleController(
         return (remaining.toFloat() / fadeOutMs.toFloat()).coerceIn(0f, 1f)
     }
 
-    private fun ttlForText(text: String): Long {
-        val scaled = (PER_CHAR_MS * text.length)
-        return scaled.coerceIn(MIN_TTL_MS, defaultTtlMs)
+    private fun ttlForText(text: String, preferredTtlMs: Long): Long {
+        val preferred = preferredTtlMs.coerceIn(MIN_TTL_MS, MAX_TTL_MS)
+        val scaled = (PER_CHAR_MS * text.length).coerceAtLeast(MIN_TTL_MS)
+        return maxOf(preferred, scaled).coerceAtMost(MAX_TTL_MS)
     }
 
     private fun prune(nowMs: Long) {
@@ -164,10 +167,12 @@ class SpeechBubbleController(
     }
 
     companion object {
-        /** Default / max TTL cap (§5.3). */
-        const val DEFAULT_TTL_MS = 8_000L
+        /** Default preferred TTL for short wallpaper bubbles. */
+        const val DEFAULT_TTL_MS = 12_000L
         /** Floor for any message bubble (§5.3). */
-        const val MIN_TTL_MS = 2_000L
+        const val MIN_TTL_MS = 3_000L
+        /** Smart cap for long messages, regardless of text length. */
+        const val MAX_TTL_MS = 30_000L
         /** Per-character contribution to TTL (§5.3: 0.06s/char). */
         const val PER_CHAR_MS = 60L
         /** Fade-out ramp window at the end of life. */

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -907,6 +907,9 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="wallpaper_more_settings_desc">进阶壁纸动画与断网行为。新的增强功能默认全部启用。</string>
     <string name="wallpaper_setting_speech_bubbles">消息气泡</string>
     <string name="wallpaper_setting_speech_bubbles_desc">在伙伴旁显示实体状态与最近消息。</string>
+    <string name="wallpaper_setting_bubble_duration">消息气泡停留时间</string>
+    <string name="wallpaper_setting_bubble_duration_desc">调整壁纸气泡存在时间；长消息会自动延长，但最多 30 秒。</string>
+    <string name="wallpaper_setting_bubble_duration_value">%1$d 秒</string>
     <string name="wallpaper_setting_bubble_pulse">气泡脉冲</string>
     <string name="wallpaper_setting_bubble_pulse_desc">气泡内容更新时短暂高亮伙伴。</string>
     <string name="wallpaper_setting_bubble_avoidance">智能气泡避让</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -821,6 +821,9 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="wallpaper_more_settings_desc">進階桌布動畫與斷線行為。新的加強功能預設全部啟用。</string>
     <string name="wallpaper_setting_speech_bubbles">訊息泡泡</string>
     <string name="wallpaper_setting_speech_bubbles_desc">在夥伴旁顯示實體狀態與最近訊息。</string>
+    <string name="wallpaper_setting_bubble_duration">訊息泡泡停留時間</string>
+    <string name="wallpaper_setting_bubble_duration_desc">調整桌布泡泡存在時間；長訊息會自動延長，但最多 30 秒。</string>
+    <string name="wallpaper_setting_bubble_duration_value">%1$d 秒</string>
     <string name="wallpaper_setting_bubble_pulse">泡泡脈衝</string>
     <string name="wallpaper_setting_bubble_pulse_desc">泡泡內容更新時短暫高亮夥伴。</string>
     <string name="wallpaper_setting_bubble_avoidance">智慧泡泡避讓</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -129,6 +129,9 @@
     <string name="wallpaper_more_settings_desc">Advanced wallpaper animation and offline behavior. New enhancements are enabled by default.</string>
     <string name="wallpaper_setting_speech_bubbles">Message bubbles</string>
     <string name="wallpaper_setting_speech_bubbles_desc">Show entity status and recent messages near each companion.</string>
+    <string name="wallpaper_setting_bubble_duration">Message bubble duration</string>
+    <string name="wallpaper_setting_bubble_duration_desc">Controls how long wallpaper bubbles stay visible; long messages automatically get more time.</string>
+    <string name="wallpaper_setting_bubble_duration_value">%1$d sec</string>
     <string name="wallpaper_setting_bubble_pulse">Bubble pulse</string>
     <string name="wallpaper_setting_bubble_pulse_desc">Briefly highlight a companion when its bubble changes.</string>
     <string name="wallpaper_setting_bubble_avoidance">Smart bubble avoidance</string>

--- a/app/src/test/java/com/hank/clawlive/SpeechBubbleControllerTest.kt
+++ b/app/src/test/java/com/hank/clawlive/SpeechBubbleControllerTest.kt
@@ -54,14 +54,14 @@ class SpeechBubbleControllerTest {
         val controller = SpeechBubbleController(defaultTtlMs = 4_000L)
         controller.show(entityId = 3, text = "x", nowMs = 0L)
 
-        // floor TTL is 2s for a short message; still visible just before.
-        assertTrue(controller.isVisible(3, nowMs = 1_999L))
-        assertNotNull(controller.placementFor(3, 0.5f, 0.5f, 0.1f, nowMs = 1_999L))
+        // Short messages use the preferred/default TTL; still visible just before.
+        assertTrue(controller.isVisible(3, nowMs = 3_999L))
+        assertNotNull(controller.placementFor(3, 0.5f, 0.5f, 0.1f, nowMs = 3_999L))
 
         // after TTL: gone.
-        assertFalse(controller.isVisible(3, nowMs = 2_001L))
-        assertNull(controller.placementFor(3, 0.5f, 0.5f, 0.1f, nowMs = 2_001L))
-        assertEquals(0, controller.activeCount(nowMs = 2_001L))
+        assertFalse(controller.isVisible(3, nowMs = 4_001L))
+        assertNull(controller.placementFor(3, 0.5f, 0.5f, 0.1f, nowMs = 4_001L))
+        assertEquals(0, controller.activeCount(nowMs = 4_001L))
     }
 
     /** Reduce-motion / disabled-walk: a static (non-walking) entity still anchors. */
@@ -114,29 +114,33 @@ class SpeechBubbleControllerTest {
         assertTrue(placement.anchorYPct > 0.14f)
     }
 
-    /** §5.3 — TTL scales with message length, capped at the default max. */
+    /** §5.3 — TTL uses the user preference and scales long messages up to a smart cap. */
     @Test
-    fun ttlScalesWithMessageLengthAndCaps() {
+    fun ttlUsesPreferenceAndScalesWithMessageLengthAndCaps() {
         val controller = SpeechBubbleController(defaultTtlMs = 8_000L)
 
-        // 600-char message → would be 36s, capped to 8s (T2-4).
+        controller.show(entityId = 16, text = "short", nowMs = 0L, preferredTtlMs = 15_000L)
+        assertTrue(controller.isVisible(16, nowMs = 14_999L))
+        assertFalse(controller.isVisible(16, nowMs = 15_001L))
+
+        // 600-char message -> would be 36s, capped to the smart 30s max.
         val long = "a".repeat(600)
         controller.show(entityId = 6, text = long, nowMs = 0L)
-        assertTrue(controller.isVisible(6, nowMs = 7_999L))
-        assertFalse(controller.isVisible(6, nowMs = 8_001L))
+        assertTrue(controller.isVisible(6, nowMs = 29_999L))
+        assertFalse(controller.isVisible(6, nowMs = 30_001L))
     }
 
     /** §5.3 / O-7 — a new message resets the TTL rather than letting the old one expire. */
     @Test
     fun newMessageResetsTtl() {
-        val controller = SpeechBubbleController()
+        val controller = SpeechBubbleController(defaultTtlMs = 4_000L)
         controller.show(entityId = 7, text = "first", nowMs = 0L)
         // refresh near end of life
-        controller.show(entityId = 7, text = "second", nowMs = 1_500L)
+        controller.show(entityId = 7, text = "second", nowMs = 3_500L)
 
-        // original would have expired at 2_000L; refreshed one lives to 3_500L.
-        assertTrue(controller.isVisible(7, nowMs = 3_000L))
-        val placement = controller.placementFor(7, 0.5f, 0.5f, 0.1f, nowMs = 3_000L)!!
+        // original would have expired at 4_000L; refreshed one lives to 7_500L.
+        assertTrue(controller.isVisible(7, nowMs = 7_000L))
+        val placement = controller.placementFor(7, 0.5f, 0.5f, 0.1f, nowMs = 7_000L)!!
         assertEquals("second", placement.text)
     }
 


### PR DESCRIPTION
## Summary
- Add a 3-30 second Message bubble duration slider in More wallpaper settings.
- Apply the setting in the live wallpaper renderer so existing bubbles refresh when the duration changes.
- Make bubble TTL smart: user duration is the base, long messages automatically get more time up to 30 seconds.
- Keep the More wallpaper settings toolbar clear of the status bar/cutout area.

## Verification
- ANDROID_HOME="/Users/hank/Library/Android/sdk" ./gradlew :app:testDebugUnitTest --tests com.hank.clawlive.SpeechBubbleControllerTest :app:assembleDebug :app:assembleDebugAndroidTest :app:lintDebug
- ANDROID_HOME="/Users/hank/Library/Android/sdk" ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class='com.hank.clawlive.WallpaperMoreSettingsUiTest,com.hank.clawlive.SettingsActivityUiTest#testWallpaperEntryIsSingleSettingsSurface,com.hank.clawlive.WallpaperPreviewUiTest#testMoreWallpaperSettingsButtonIsClickable'
- Manual Pixel_9a emulator check with admin account bbb880008@gmail.com: Settings -> Set Wallpaper -> More wallpaper settings shows the Message bubble duration slider.