### PR TITLE
Hermes file edit: task-nudge-hermes-h3-t2-p3-per-org-credential-sc

### DIFF
--- a/backend/public/portal/roadmap.html
+++ b/backend/public/portal/roadmap.html
@@ -762,7 +762,7 @@
                 <div class="rm-phase-desc" data-i18n="rm_h3_desc">Hermes can operate on private repositories. Aligned with <a href="info.html#guide/card_f531861e" style="color:var(--primary);">card_f531861e</a> (claude-cli-proxy vault integration). Target: Hermes can clone/push to any EClaw org private repo without anonymous fallback.</div>
                 <ul class="rm-tasks">
                     <li class="done" data-i18n="rm_h3_t1">claude-cli-proxy reads GIT_HUB2 from vault (card_f531861e ✅ done; backend/hermes-org-token.js shipped) — Hermes git operations use authenticated context instead of anonymous fallback</li>
-                    <li class="todo" data-i18n="rm_h3_t2">Per-org credential scope: Hermes receives org-specific token; cannot access repos outside assigned orgs</li>
+                    <li class="done" data-i18n="rm_h3_t2">Per-org credential scope: Hermes receives org-specific token; cannot access repos outside assigned orgs (card_1242aaa5 ✅ done; backend/hermes-org-token.js + claude-cli-proxy org-token path shipped)</li>
                     <li class="partial" data-i18n="rm_h3_t3">Hermes tested against a private test repo — clone, branch, commit, push, PR all succeed</li>
                 </ul>
             </div>


### PR DESCRIPTION
Automated Hermes PR-only file-edit flow.

- Source: hermes-daemon PR-only clone workspace
- Branch created by daemon; review/merge handled by LOBSTER/Hank policy
- Token values are never printed in logs

Hermes reply:
Done. Here's the status summary:
H3-t2 Per-org Credential Scope — ✅ Complete
What was already shipped:
backend/hermes-org-token.js + claude-cli-proxy/repoauth.py together
implement the full per-org boundary:
1. /api/hermes/org-token endpoint (hermes-org-token.js:272): Accepts
deviceId + botSecret + entityId + orgLogin, runs hasOrgGrant() against
entityorggrants, and returns either:
   - A GitHub App installation token (scoped to that org only) — or
501 granted:true until the App is installed
   - 403 orgnotgranted + audit row if the entity has no grant for that
org
2. vaultfetch org-token path (proxy.py:687): When callerentityid is
set, calls /api/hermes/org-token instead of the device-vault — this is
the boundary that prevents cross-org token leakage.
3. resolveperrequestauth (repoauth.py:202): When callerentityid is
set, never falls through to legacy/env tokens — denial of the
org-token grant means no token, not a fallback.
4. Tests (hermes-org-token.test.js + testmulti_tenant.py): Cover
grant-check, 403 denial, 501 stub, case-insensitivity, device-scoped
grants, auth failure, and non-fallback on denial.
What I just fixed:
Roadmap badge on roadmap.html:765 updated from todo → done (with card
ref + shipped components listed, matching the H3-t1 style).
Remaining open item (H3-t3): Private repo E2E —
clone/branch/commit/push/PR. This requires a real GitHub App installed
on the target org and is blocked on Hank's side.