### PR TITLE
Make wallpaper walking purposeful

### DIFF
--- a/app/src/androidTest/java/com/hank/clawlive/WallpaperMoreSettingsUiTest.kt
+++ b/app/src/androidTest/java/com/hank/clawlive/WallpaperMoreSettingsUiTest.kt
@@ -19,6 +19,7 @@ class WallpaperMoreSettingsUiTest {
             scenario.onActivity { activity ->
                 val prefs = LayoutPreferences.getInstance(activity)
                 assertTrue(prefs.wallpaperSpeechBubblesEnabled)
+                assertTrue(prefs.wallpaperPurposefulWalkingEnabled)
                 assertTrue(prefs.wallpaperBubblePulseEnabled)
                 assertTrue(prefs.wallpaperBubbleOverlayAvoidanceEnabled)
                 assertTrue(prefs.wallpaperStateAuraEnabled)
@@ -37,13 +38,17 @@ class WallpaperMoreSettingsUiTest {
                     }
                 }
                 collect(root)
-                assertTrue("Expected advanced wallpaper switches", switches.size >= 7)
+                assertTrue("Expected advanced wallpaper switches", switches.size >= 8)
                 switches.forEach { assertTrue("Default-on switch should start checked", it.isChecked) }
                 assertTrue("Expected bubble duration slider", sliders.isNotEmpty())
 
                 switches.first().isChecked = false
                 assertFalse(prefs.wallpaperSpeechBubblesEnabled)
                 prefs.wallpaperSpeechBubblesEnabled = true
+
+                switches[1].isChecked = false
+                assertFalse(prefs.wallpaperPurposefulWalkingEnabled)
+                prefs.wallpaperPurposefulWalkingEnabled = true
 
                 sliders.first().value = 18f
                 assertEquals(18, prefs.wallpaperBubbleDurationSeconds)

--- a/app/src/main/java/com/hank/clawlive/WallpaperMoreSettingsActivity.kt
+++ b/app/src/main/java/com/hank/clawlive/WallpaperMoreSettingsActivity.kt
@@ -66,6 +66,12 @@ class WallpaperMoreSettingsActivity : AppCompatActivity() {
         addDurationSlider(content)
         addSwitch(
             content,
+            title = getString(R.string.wallpaper_setting_purposeful_walking),
+            description = getString(R.string.wallpaper_setting_purposeful_walking_desc),
+            checked = layoutPrefs.wallpaperPurposefulWalkingEnabled
+        ) { layoutPrefs.wallpaperPurposefulWalkingEnabled = it }
+        addSwitch(
+            content,
             title = getString(R.string.wallpaper_setting_bubble_pulse),
             description = getString(R.string.wallpaper_setting_bubble_pulse_desc),
             checked = layoutPrefs.wallpaperBubblePulseEnabled

--- a/app/src/main/java/com/hank/clawlive/data/local/LayoutPreferences.kt
+++ b/app/src/main/java/com/hank/clawlive/data/local/LayoutPreferences.kt
@@ -300,6 +300,12 @@ class LayoutPreferences private constructor(context: Context) {
             prefs.edit().putBoolean(KEY_WALLPAPER_WALKING_ENABLED, value).apply()
         }
 
+    var wallpaperPurposefulWalkingEnabled: Boolean
+        get() = prefs.getBoolean(KEY_WALLPAPER_PURPOSEFUL_WALKING_ENABLED, true)
+        set(value) {
+            prefs.edit().putBoolean(KEY_WALLPAPER_PURPOSEFUL_WALKING_ENABLED, value).apply()
+        }
+
     var wallpaperSpeechBubblesEnabled: Boolean
         get() = prefs.getBoolean(KEY_WALLPAPER_SPEECH_BUBBLES_ENABLED, true)
         set(value) {
@@ -523,6 +529,7 @@ class LayoutPreferences private constructor(context: Context) {
         private const val KEY_DEBUG_ENTITY_LIMIT = "debug_entity_limit"
         private const val KEY_SERVER_ENTITY_LIMIT = "server_entity_limit"
         private const val KEY_WALLPAPER_WALKING_ENABLED = "wallpaper_walking_enabled"
+        private const val KEY_WALLPAPER_PURPOSEFUL_WALKING_ENABLED = "wallpaper_purposeful_walking_enabled"
         private const val KEY_WALLPAPER_SPEECH_BUBBLES_ENABLED = "wallpaper_speech_bubbles_enabled"
         private const val KEY_WALLPAPER_BUBBLE_DURATION_SECONDS = "wallpaper_bubble_duration_seconds"
         private const val KEY_WALLPAPER_BUBBLE_PULSE_ENABLED = "wallpaper_bubble_pulse_enabled"

--- a/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/ClawRenderer.kt
@@ -501,7 +501,8 @@ class ClawRenderer(
             entities = entities,
             width = width,
             height = height,
-            enabled = walkingEnabled
+            enabled = walkingEnabled,
+            purposeful = layoutPrefs.wallpaperPurposefulWalkingEnabled
         )
         val baseScale = getScaleFactor(entities.size)
         val nowMs = System.currentTimeMillis()

--- a/app/src/main/java/com/hank/clawlive/engine/SleepGateController.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/SleepGateController.kt
@@ -54,12 +54,21 @@ class SleepGateController(
         width: Float,
         height: Float,
         enabled: Boolean,
+        purposeful: Boolean = true,
         nowMs: Long = System.currentTimeMillis()
     ): List<Pair<Float, Float>> {
         val activeIds = entities.map { it.entityId }.toSet()
         sleeping.keys.toList().forEach { id -> if (id !in activeIds) sleeping.remove(id) }
         entities.forEach { sleeping[it.entityId] = it.state == CharacterState.SLEEPING }
-        return delegate.positionsFor(basePositions, entities, width, height, enabled, nowMs)
+        return delegate.positionsFor(
+            basePositions = basePositions,
+            entities = entities,
+            width = width,
+            height = height,
+            enabled = enabled,
+            purposeful = purposeful,
+            nowMs = nowMs
+        )
     }
 
     /** Current motion state for the entity (delegates to the wander engine). */

--- a/app/src/main/java/com/hank/clawlive/engine/WallpaperWanderController.kt
+++ b/app/src/main/java/com/hank/clawlive/engine/WallpaperWanderController.kt
@@ -23,6 +23,13 @@ enum class MotionState {
     SLEEPING
 }
 
+enum class AmbientWanderGoal {
+    RANDOM,
+    VISIT_COMPANION,
+    PATROL,
+    RETURN_HOME
+}
+
 /**
  * Lightweight per-device wallpaper wander engine.
  *
@@ -40,6 +47,8 @@ class WallpaperWanderController(
     private data class WanderState(
         var xPct: Float,
         var yPct: Float,
+        var homeXPct: Float,
+        var homeYPct: Float,
         var targetXPct: Float,
         var targetYPct: Float,
         var lastUpdateMs: Long,
@@ -47,7 +56,15 @@ class WallpaperWanderController(
         var retargetAtMs: Long,
         var moving: Boolean,
         var motionState: MotionState,
+        var ambientGoal: AmbientWanderGoal,
+        var ambientStep: Int,
         var onArrive: (() -> Unit)? = null
+    )
+
+    private data class AmbientPeer(
+        val entityId: Int,
+        val xPct: Float,
+        val yPct: Float
     )
 
     private val states = mutableMapOf<Int, WanderState>()
@@ -57,6 +74,10 @@ class WallpaperWanderController(
     }
 
     fun isWalking(entityId: Int): Boolean = states[entityId]?.moving == true
+
+    fun ambientGoal(entityId: Int): AmbientWanderGoal {
+        return states[entityId]?.ambientGoal ?: AmbientWanderGoal.RANDOM
+    }
 
     override fun position(entityId: Int): PointF {
         val state = states[entityId] ?: return PointF(0.5f, 0.5f)
@@ -105,6 +126,7 @@ class WallpaperWanderController(
         width: Float,
         height: Float,
         enabled: Boolean,
+        purposeful: Boolean = true,
         nowMs: Long = System.currentTimeMillis()
     ): List<Pair<Float, Float>> {
         if (!enabled || width <= 0f || height <= 0f) {
@@ -114,6 +136,18 @@ class WallpaperWanderController(
 
         val activeIds = entities.map { it.entityId }.toSet()
         states.keys.toList().forEach { id -> if (id !in activeIds) states.remove(id) }
+        val ambientPeers = entities.mapIndexedNotNull { index, entity ->
+            if (entity.state == CharacterState.SLEEPING) return@mapIndexedNotNull null
+            val base = basePositions.getOrNull(index) ?: (width / 2f to height / 2f)
+            val baseX = (base.first / width).coerceIn(MIN_X_PCT, MAX_X_PCT)
+            val baseY = (base.second / height).coerceIn(MIN_Y_PCT, MAX_Y_PCT)
+            val state = states[entity.entityId]
+            AmbientPeer(
+                entityId = entity.entityId,
+                xPct = state?.xPct ?: baseX,
+                yPct = state?.yPct ?: baseY
+            )
+        }
 
         return entities.mapIndexed { index, entity ->
             val base = basePositions.getOrNull(index) ?: (width / 2f to height / 2f)
@@ -123,19 +157,24 @@ class WallpaperWanderController(
                 state.moving = false
                 state.xPct * width to state.yPct * height
             } else {
-                advance(entity.entityId, base, width, height, nowMs)
+                advance(entity, base, width, height, nowMs, purposeful, ambientPeers)
             }
         }
     }
 
     private fun advance(
-        entityId: Int,
+        entity: EntityStatus,
         base: Pair<Float, Float>,
         width: Float,
         height: Float,
-        nowMs: Long
+        nowMs: Long,
+        purposeful: Boolean,
+        ambientPeers: List<AmbientPeer>
     ): Pair<Float, Float> {
+        val entityId = entity.entityId
         val state = stateFor(entityId, base, width, height, nowMs)
+        state.homeXPct = (base.first / width).coerceIn(MIN_X_PCT, MAX_X_PCT)
+        state.homeYPct = (base.second / height).coerceIn(MIN_Y_PCT, MAX_Y_PCT)
         if (state.motionState == MotionState.SLEEPING) {
             state.motionState = MotionState.WANDERING
             state.idleUntilMs = 0L
@@ -169,13 +208,13 @@ class WallpaperWanderController(
         }
 
         if (nowMs >= state.retargetAtMs) {
-            retarget(state, nowMs)
+            retarget(state, nowMs, entity, purposeful, ambientPeers)
         }
 
         if (moveTowardTarget(state, width, height, wanderSpeedPctPerSecond, dtSeconds)) {
             state.moving = false
             state.idleUntilMs = nowMs + randomLong(0L, MAX_IDLE_MS)
-            retarget(state, state.idleUntilMs)
+            retarget(state, state.idleUntilMs, entity, purposeful, ambientPeers)
         }
 
         coerceToSafeBounds(state)
@@ -196,13 +235,17 @@ class WallpaperWanderController(
             WanderState(
                 xPct = x,
                 yPct = y,
+                homeXPct = x,
+                homeYPct = y,
                 targetXPct = target.first,
                 targetYPct = target.second,
                 lastUpdateMs = nowMs,
                 idleUntilMs = nowMs + randomLong(0L, MAX_IDLE_MS),
                 retargetAtMs = nowMs + randomLong(MIN_RETARGET_MS, MAX_RETARGET_MS),
                 moving = false,
-                motionState = MotionState.WANDERING
+                motionState = MotionState.WANDERING,
+                ambientGoal = AmbientWanderGoal.RANDOM,
+                ambientStep = 0
             )
         }
         coerceToSafeBounds(state)
@@ -214,13 +257,17 @@ class WallpaperWanderController(
             WanderState(
                 xPct = 0.5f,
                 yPct = 0.5f,
+                homeXPct = 0.5f,
+                homeYPct = 0.5f,
                 targetXPct = 0.5f,
                 targetYPct = 0.5f,
                 lastUpdateMs = 0L,
                 idleUntilMs = 0L,
                 retargetAtMs = 0L,
                 moving = false,
-                motionState = MotionState.STOPPED
+                motionState = MotionState.STOPPED,
+                ambientGoal = AmbientWanderGoal.RANDOM,
+                ambientStep = 0
             )
         }
     }
@@ -254,11 +301,82 @@ class WallpaperWanderController(
         return false
     }
 
-    private fun retarget(state: WanderState, fromMs: Long) {
-        val target = randomTarget()
+    private fun retarget(
+        state: WanderState,
+        fromMs: Long,
+        entity: EntityStatus,
+        purposeful: Boolean,
+        ambientPeers: List<AmbientPeer>
+    ) {
+        val target = if (purposeful) {
+            purposefulTarget(state, entity, ambientPeers)
+        } else {
+            state.ambientGoal = AmbientWanderGoal.RANDOM
+            randomTarget()
+        }
         state.targetXPct = target.first
         state.targetYPct = target.second
         state.retargetAtMs = fromMs + randomLong(MIN_RETARGET_MS, MAX_RETARGET_MS)
+    }
+
+    private fun purposefulTarget(
+        state: WanderState,
+        entity: EntityStatus,
+        ambientPeers: List<AmbientPeer>
+    ): Pair<Float, Float> {
+        val peers = ambientPeers.filter { it.entityId != entity.entityId }
+        val step = state.ambientStep++
+        val goal = when {
+            peers.isNotEmpty() && entity.state == CharacterState.EXCITED -> AmbientWanderGoal.VISIT_COMPANION
+            entity.state == CharacterState.BUSY -> if (step % 2 == 0) AmbientWanderGoal.PATROL else AmbientWanderGoal.RETURN_HOME
+            peers.isNotEmpty() && step % 3 == 0 -> AmbientWanderGoal.VISIT_COMPANION
+            step % 3 == 1 -> AmbientWanderGoal.PATROL
+            else -> AmbientWanderGoal.RETURN_HOME
+        }
+        state.ambientGoal = goal
+
+        return when (goal) {
+            AmbientWanderGoal.VISIT_COMPANION -> companionVisitTarget(entity.entityId, peers)
+            AmbientWanderGoal.PATROL -> patrolTarget(state, step)
+            AmbientWanderGoal.RETURN_HOME -> nearHomeTarget(state)
+            AmbientWanderGoal.RANDOM -> randomTarget()
+        }
+    }
+
+    private fun companionVisitTarget(entityId: Int, peers: List<AmbientPeer>): Pair<Float, Float> {
+        val peer = peers.random(random)
+        val side = if ((entityId + peer.entityId) % 2 == 0) 1f else -1f
+        val x = peer.xPct + side * randomFloat(SOCIAL_MIN_OFFSET_PCT, SOCIAL_MAX_OFFSET_PCT)
+        val y = peer.yPct + randomFloat(-SOCIAL_Y_OFFSET_PCT, SOCIAL_Y_OFFSET_PCT)
+        return safeTarget(x, y)
+    }
+
+    private fun patrolTarget(state: WanderState, step: Int): Pair<Float, Float> {
+        val phase = step % 4
+        val x = state.homeXPct + when (phase) {
+            0 -> -PATROL_RADIUS_X_PCT
+            1 -> PATROL_RADIUS_X_PCT
+            2 -> PATROL_RADIUS_X_PCT * 0.5f
+            else -> -PATROL_RADIUS_X_PCT * 0.5f
+        }
+        val y = state.homeYPct + when (phase) {
+            0 -> -PATROL_RADIUS_Y_PCT
+            1 -> -PATROL_RADIUS_Y_PCT * 0.4f
+            2 -> PATROL_RADIUS_Y_PCT
+            else -> PATROL_RADIUS_Y_PCT * 0.4f
+        }
+        return safeTarget(x, y)
+    }
+
+    private fun nearHomeTarget(state: WanderState): Pair<Float, Float> {
+        return safeTarget(
+            state.homeXPct + randomFloat(-HOME_RADIUS_PCT, HOME_RADIUS_PCT),
+            state.homeYPct + randomFloat(-HOME_RADIUS_PCT, HOME_RADIUS_PCT)
+        )
+    }
+
+    private fun safeTarget(xPct: Float, yPct: Float): Pair<Float, Float> {
+        return xPct.coerceIn(MIN_X_PCT, MAX_X_PCT) to yPct.coerceIn(MIN_Y_PCT, MAX_Y_PCT)
     }
 
     private fun randomTarget(): Pair<Float, Float> {
@@ -291,6 +409,12 @@ class WallpaperWanderController(
         private const val MAX_X_PCT = 0.92f
         private const val MIN_Y_PCT = 0.12f
         private const val MAX_Y_PCT = 0.82f
+        private const val SOCIAL_MIN_OFFSET_PCT = 0.06f
+        private const val SOCIAL_MAX_OFFSET_PCT = 0.12f
+        private const val SOCIAL_Y_OFFSET_PCT = 0.05f
+        private const val PATROL_RADIUS_X_PCT = 0.16f
+        private const val PATROL_RADIUS_Y_PCT = 0.08f
+        private const val HOME_RADIUS_PCT = 0.05f
         const val WALKING_STATE_ASSET = "WALKING"
     }
 }

--- a/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
+++ b/app/src/main/java/com/hank/clawlive/ui/WallpaperPreviewView.kt
@@ -286,7 +286,8 @@ class WallpaperPreviewView @JvmOverloads constructor(
             entities = entities,
             width = width.toFloat(),
             height = height.toFloat(),
-            enabled = layoutPrefs.wallpaperWalkingEnabled
+            enabled = layoutPrefs.wallpaperWalkingEnabled,
+            purposeful = layoutPrefs.wallpaperPurposefulWalkingEnabled
         )
 
         // Draw each entity with per-entity scale

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -769,9 +769,9 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="wallpaper_usage_engine_codex">Codex</string>
     <string name="wallpaper_usage_items">显示项目</string>
     <string name="wallpaper_walking_title">行走功能</string>
-    <string name="wallpaper_walking_settings_desc">让壁纸实体慢慢随机走动</string>
+    <string name="wallpaper_walking_settings_desc">让壁纸实体慢慢依目标移动</string>
     <string name="wallpaper_walking_help_button">关于壁纸行走功能</string>
-    <string name="wallpaper_walking_help">说明：壁纸上的实体会像宠物一样四处慢慢走动。后续消息互动阶段会让你或其他实体发消息时，它们跑到对方旁边。\n\n需要：已开启基本壁纸、至少一个已绑定的实体、行走动画已下载。\n\n测试：开启此功能后，按下方壁纸预览并停留 30 秒，观察所有实体走一轮。</string>
+    <string name="wallpaper_walking_help">说明：壁纸上的实体会像宠物一样慢慢移动。开启“有目的的行走”时，待机伙伴会选择拜访同伴、巡逻、回到自己活动区等环境目标。消息互动仍会让你或其他实体发消息时，它们跑到对方旁边。\n\n需要：已开启基本壁纸、至少一个已绑定的实体、行走动画已下载。\n\n测试：开启此功能后，按下方壁纸预览并停留 30 秒，观察所有实体走一轮。</string>
     <string name="wallpaper_walking_enabled">行走功能已开启</string>
     <string name="wallpaper_walking_disabled">行走功能已关闭</string>
     <string name="wallpaper_usage_overlay">用量显示</string>
@@ -910,6 +910,8 @@ GPS：仅按需获取，不会后台追踪，服务器重启后数据消失。
     <string name="wallpaper_setting_bubble_duration">消息气泡停留时间</string>
     <string name="wallpaper_setting_bubble_duration_desc">调整壁纸气泡存在时间；长消息会自动延长，但最多 30 秒。</string>
     <string name="wallpaper_setting_bubble_duration_value">%1$d 秒</string>
+    <string name="wallpaper_setting_purposeful_walking">有目的的行走</string>
+    <string name="wallpaper_setting_purposeful_walking_desc">让待机伙伴会拜访同伴、巡逻、回到自己的活动区。</string>
     <string name="wallpaper_setting_bubble_pulse">气泡脉冲</string>
     <string name="wallpaper_setting_bubble_pulse_desc">气泡内容更新时短暂高亮伙伴。</string>
     <string name="wallpaper_setting_bubble_avoidance">智能气泡避让</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -788,9 +788,9 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="wallpaper_usage_engine_codex">Codex</string>
     <string name="wallpaper_usage_items">顯示項目</string>
     <string name="wallpaper_walking_title">行走功能</string>
-    <string name="wallpaper_walking_settings_desc">讓桌布實體慢慢隨機走動</string>
+    <string name="wallpaper_walking_settings_desc">讓桌布實體慢慢依目標走動</string>
     <string name="wallpaper_walking_help_button">關於桌布行走功能</string>
-    <string name="wallpaper_walking_help">說明：桌布上的實體會像寵物一樣四處慢慢走動。後續訊息互動階段會讓你或其他實體傳訊息時，他們跑到對方旁邊。\n\n需要：已開啟基本桌布、至少一個已綁定的實體、行走動畫已下載。\n\n測試：開啟此功能後，按下方桌布預覽並停留 30 秒，觀察所有實體走一輪。</string>
+    <string name="wallpaper_walking_help">說明：桌布上的實體會像寵物一樣慢慢走動。開啟「有目的的走路」時，待機夥伴會選擇拜訪同伴、巡邏、回到自己活動區等環境目標。訊息互動仍會讓你或其他實體傳訊息時，他們跑到對方旁邊。\n\n需要：已開啟基本桌布、至少一個已綁定的實體、行走動畫已下載。\n\n測試：開啟此功能後，按下方桌布預覽並停留 30 秒，觀察所有實體走一輪。</string>
     <string name="wallpaper_walking_enabled">行走功能已開啟</string>
     <string name="wallpaper_walking_disabled">行走功能已關閉</string>
     <string name="wallpaper_usage_overlay">用量顯示</string>
@@ -824,6 +824,8 @@ GPS：僅按需取得，不會背景追蹤，伺服器重啟後資料消失。
     <string name="wallpaper_setting_bubble_duration">訊息泡泡停留時間</string>
     <string name="wallpaper_setting_bubble_duration_desc">調整桌布泡泡存在時間；長訊息會自動延長，但最多 30 秒。</string>
     <string name="wallpaper_setting_bubble_duration_value">%1$d 秒</string>
+    <string name="wallpaper_setting_purposeful_walking">有目的的走路</string>
+    <string name="wallpaper_setting_purposeful_walking_desc">讓待機夥伴會拜訪同伴、巡邏、回到自己的活動區。</string>
     <string name="wallpaper_setting_bubble_pulse">泡泡脈衝</string>
     <string name="wallpaper_setting_bubble_pulse_desc">泡泡內容更新時短暫高亮夥伴。</string>
     <string name="wallpaper_setting_bubble_avoidance">智慧泡泡避讓</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -93,9 +93,9 @@
     <string name="drag_to_position">Drag entities to position them</string>
     <string name="pinch_to_resize">Drag to move; pinch entities or usage to resize</string>
     <string name="wallpaper_walking_title">Walking Feature</string>
-    <string name="wallpaper_walking_settings_desc">Slow random wander for wallpaper entities</string>
+    <string name="wallpaper_walking_settings_desc">Slow goal-based movement for wallpaper entities</string>
     <string name="wallpaper_walking_help_button">About wallpaper walking</string>
-    <string name="wallpaper_walking_help">What: wallpaper entities slowly wander like pets. Later message-aware phases will make them move toward each other when you or another entity sends a message.\n\nNeeds: basic wallpaper enabled, at least one bound entity, and the walking animation downloaded.\n\nTest: turn this on, open the wallpaper preview below, and leave it open for 30 seconds to watch every entity walk.</string>
+    <string name="wallpaper_walking_help">What: wallpaper entities slowly move like pets. When Purposeful walking is enabled, idle companions choose ambient goals such as visiting peers, patrolling, and returning to their home area. Message-aware movement still makes them move toward each other when you or another entity sends a message.\n\nNeeds: basic wallpaper enabled, at least one bound entity, and the walking animation downloaded.\n\nTest: turn this on, open the wallpaper preview below, and leave it open for 30 seconds to watch every entity walk.</string>
     <string name="wallpaper_walking_enabled">Walking feature enabled</string>
     <string name="wallpaper_walking_disabled">Walking feature disabled</string>
     <string name="wallpaper_usage_overlay">Usage Overlay</string>
@@ -132,6 +132,8 @@
     <string name="wallpaper_setting_bubble_duration">Message bubble duration</string>
     <string name="wallpaper_setting_bubble_duration_desc">Controls how long wallpaper bubbles stay visible; long messages automatically get more time.</string>
     <string name="wallpaper_setting_bubble_duration_value">%1$d sec</string>
+    <string name="wallpaper_setting_purposeful_walking">Purposeful walking</string>
+    <string name="wallpaper_setting_purposeful_walking_desc">Give idle companions goals like visiting peers, patrolling, and returning home.</string>
     <string name="wallpaper_setting_bubble_pulse">Bubble pulse</string>
     <string name="wallpaper_setting_bubble_pulse_desc">Briefly highlight a companion when its bubble changes.</string>
     <string name="wallpaper_setting_bubble_avoidance">Smart bubble avoidance</string>

--- a/app/src/test/java/com/hank/clawlive/WallpaperWanderControllerTest.kt
+++ b/app/src/test/java/com/hank/clawlive/WallpaperWanderControllerTest.kt
@@ -2,6 +2,7 @@ package com.hank.clawlive
 
 import com.hank.clawlive.data.model.CharacterState
 import com.hank.clawlive.data.model.EntityStatus
+import com.hank.clawlive.engine.AmbientWanderGoal
 import com.hank.clawlive.engine.MotionState
 import com.hank.clawlive.engine.WallpaperWanderController
 import kotlin.random.Random
@@ -24,6 +25,35 @@ class WallpaperWanderControllerTest {
         assertNotEquals("walking should update x", base[0].first, after[0].first)
         assertNotEquals("walking should update y", base[0].second, after[0].second)
         assertTrue("controller reports walking while moving", controller.isWalking(1))
+    }
+
+    @Test
+    fun purposefulWanderFirstRetargetMovesTowardCompanion() {
+        val controller = WallpaperWanderController(random = Random(41))
+        val left = EntityStatus(entityId = 1, state = CharacterState.IDLE)
+        val right = EntityStatus(entityId = 2, state = CharacterState.IDLE)
+        val entities = listOf(left, right)
+        val base = listOf(200f to 500f, 800f to 500f)
+
+        controller.positionsFor(base, entities, 1000f, 1000f, enabled = true, purposeful = true, nowMs = 0L)
+        val after = controller.positionsFor(base, entities, 1000f, 1000f, enabled = true, purposeful = true, nowMs = 9000L)
+
+        assertEquals(AmbientWanderGoal.VISIT_COMPANION, controller.ambientGoal(1))
+        assertTrue("left companion should head toward the right companion", after[0].first > base[0].first)
+    }
+
+    @Test
+    fun purposefulWanderCanBeDisabledForClassicRandomMode() {
+        val controller = WallpaperWanderController(random = Random(43))
+        val left = EntityStatus(entityId = 1, state = CharacterState.IDLE)
+        val right = EntityStatus(entityId = 2, state = CharacterState.IDLE)
+        val entities = listOf(left, right)
+        val base = listOf(200f to 500f, 800f to 500f)
+
+        controller.positionsFor(base, entities, 1000f, 1000f, enabled = true, purposeful = false, nowMs = 0L)
+        controller.positionsFor(base, entities, 1000f, 1000f, enabled = true, purposeful = false, nowMs = 9000L)
+
+        assertEquals(AmbientWanderGoal.RANDOM, controller.ambientGoal(1))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Adds a default-on `Purposeful walking` switch in More wallpaper settings so users can return to classic random wandering when needed.
- Makes ambient wallpaper movement goal-based: idle companions can visit peers, patrol around their home area, or return home instead of only wandering randomly.
- Applies the same behavior to live wallpaper and wallpaper preview, and updates EN / zh-TW / zh-CN copy.

## Risk / compatibility
- Existing `Walking Feature` remains the main entry point from Set Wallpaper / wallpaper preview.
- Explicit message-aware movement (`speakTo` / broadcast targets) is unchanged.
- New behavior is behind `wallpaper_purposeful_walking_enabled`, default `true`.

## Validation
- `ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :app:testDebugUnitTest --tests com.hank.clawlive.WallpaperWanderControllerTest --tests com.hank.clawlive.SleepGateControllerTest` — pass
- `ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :app:testDebugUnitTest --tests com.hank.clawlive.WallpaperWanderControllerTest --tests com.hank.clawlive.SleepGateControllerTest :app:assembleDebug :app:assembleDebugAndroidTest :app:lintDebug` — pass
- `ANDROID_HOME="$HOME/Library/Android/sdk" ./gradlew :app:connectedDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class='com.hank.clawlive.WallpaperMoreSettingsUiTest,com.hank.clawlive.WallpaperPreviewUiTest#testMoreWallpaperSettingsButtonIsClickable,com.hank.clawlive.WallpaperPreviewUiTest#testEntityTapUsesRenderedWalkingPositionForHitTarget'` — pass on Pixel_9a API 16 emulator
- `AdminAccountLoginProbeTest` via `adb shell am instrument` with admin account `bbb880008@gmail.com` — pass

## Manual emulator evidence
- Admin account verified on Settings: `app/build/visual-checks/purposeful-walking/admin-settings.png`
- More wallpaper settings shows `Purposeful walking`: `app/build/visual-checks/purposeful-walking/more-settings-purposeful-walking.png`

## Notes
- Unrelated backend line-ending noise existed in the worktree and was left unstaged.
- No production deploy or merge was performed by Codex.
